### PR TITLE
F() expressions — atomic updates + column-vs-column compares (closes #1)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -1258,8 +1258,10 @@ fn collect_fields(named: &syn::FieldsNamed, table: &str) -> syn::Result<Collecte
             out.update_assignments.push(quote! {
                 ::rustango::core::Assignment {
                     column: #column,
-                    value: ::core::convert::Into::<::rustango::core::SqlValue>::into(
-                        ::chrono::Utc::now()
+                    value: ::core::convert::Into::<::rustango::core::Expr>::into(
+                        ::core::convert::Into::<::rustango::core::SqlValue>::into(
+                            ::chrono::Utc::now()
+                        )
                     ),
                 }
             });
@@ -1268,8 +1270,10 @@ fn collect_fields(named: &syn::FieldsNamed, table: &str) -> syn::Result<Collecte
             out.update_assignments.push(quote! {
                 ::rustango::core::Assignment {
                     column: #column,
-                    value: ::core::convert::Into::<::rustango::core::SqlValue>::into(
-                        ::core::clone::Clone::clone(&self.#ident)
+                    value: ::core::convert::Into::<::rustango::core::Expr>::into(
+                        ::core::convert::Into::<::rustango::core::SqlValue>::into(
+                            ::core::clone::Clone::clone(&self.#ident)
+                        )
                     ),
                 }
             });
@@ -2687,8 +2691,10 @@ fn inherent_impl_tokens(
                         set: ::std::vec![
                             ::rustango::core::Assignment {
                                 column: #col_lit,
-                                value: ::core::convert::Into::<::rustango::core::SqlValue>::into(
-                                    ::chrono::Utc::now()
+                                value: ::core::convert::Into::<::rustango::core::Expr>::into(
+                                    ::core::convert::Into::<::rustango::core::SqlValue>::into(
+                                        ::chrono::Utc::now()
+                                    )
                                 ),
                             },
                         ],
@@ -2727,7 +2733,9 @@ fn inherent_impl_tokens(
                         set: ::std::vec![
                             ::rustango::core::Assignment {
                                 column: #col_lit,
-                                value: ::rustango::core::SqlValue::Null,
+                                value: ::core::convert::Into::<::rustango::core::Expr>::into(
+                                    ::rustango::core::SqlValue::Null
+                                ),
                             },
                         ],
                         where_clause: ::rustango::core::WhereExpr::Predicate(

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -1193,7 +1193,10 @@ pub(crate) async fn update_submit(
     };
     let assignments: Vec<Assignment> = collected
         .into_iter()
-        .map(|(column, value)| Assignment { column, value })
+        .map(|(column, value)| Assignment {
+            column,
+            value: value.into(),
+        })
         .collect();
 
     // v0.12.3: SELECT the row's pre-update state so the audit emit
@@ -1306,7 +1309,7 @@ pub(crate) async fn delete_submit(
                 model,
                 set: vec![Assignment {
                     column: col,
-                    value: SqlValue::from(chrono::Utc::now()),
+                    value: SqlValue::from(chrono::Utc::now()).into(),
                 }],
                 where_clause: WhereExpr::Predicate(Filter {
                     column: pk_field.column,
@@ -1483,7 +1486,7 @@ pub(crate) async fn action_submit(
                     model,
                     set: vec![Assignment {
                         column: col,
-                        value: SqlValue::from(chrono::Utc::now()),
+                        value: SqlValue::from(chrono::Utc::now()).into(),
                     }],
                     where_clause: WhereExpr::Predicate(Filter {
                         column: pk_field.column,
@@ -1523,7 +1526,7 @@ pub(crate) async fn action_submit(
                     model,
                     set: vec![Assignment {
                         column: col,
-                        value: SqlValue::Null,
+                        value: SqlValue::Null.into(),
                     }],
                     where_clause: WhereExpr::Predicate(Filter {
                         column: pk_field.column,

--- a/crates/rustango/src/core/column.rs
+++ b/crates/rustango/src/core/column.rs
@@ -168,13 +168,66 @@ pub trait Column: Copy + 'static {
 
     /// `SET column = value` for an UPDATE.
     fn set<V: Into<Self::Value>>(self, value: V) -> TypedAssignment<Self::Model> {
+        // value: V → Self::Value → SqlValue → Expr (each `.into()` step is
+        // a registered `From` impl).
+        let sql: SqlValue = value.into().into();
         TypedAssignment {
             inner: Assignment {
                 column: Self::COLUMN,
-                value: value.into().into(),
+                value: sql.into(),
             },
             _model: PhantomData,
         }
+    }
+
+    /// `SET column = <expression>` for an UPDATE — full [`Expr`] form,
+    /// for `F()` column references and arithmetic. The literal-value
+    /// shape stays on [`Column::set`].
+    fn set_expr(self, expr: impl Into<crate::core::Expr>) -> TypedAssignment<Self::Model> {
+        TypedAssignment {
+            inner: Assignment {
+                column: Self::COLUMN,
+                value: expr.into(),
+            },
+            _model: PhantomData,
+        }
+    }
+
+    // ----- Column-vs-expression predicates (Django `F()` rhs) -----
+
+    /// `column = <expr>` — Django's `filter(col=F("other"))` shape.
+    /// Accepts a bare [`F`](crate::core::F), a full [`Expr`](crate::core::Expr)
+    /// (e.g. `F("a") + 1`), or anything else that lifts via
+    /// `Into<Expr>`. Returns a [`TypedExpr`] so it composes with
+    /// `.and()`/`.or()` exactly like the literal-rhs variants.
+    fn eq_expr(self, rhs: impl Into<crate::core::Expr>) -> TypedExpr<Self::Model> {
+        TypedExpr::column_cmp(Self::COLUMN, Op::Eq, rhs.into())
+    }
+
+    /// `column <> <expr>`.
+    fn ne_expr(self, rhs: impl Into<crate::core::Expr>) -> TypedExpr<Self::Model> {
+        TypedExpr::column_cmp(Self::COLUMN, Op::Ne, rhs.into())
+    }
+
+    /// `column < <expr>` — the canonical column-vs-column compare
+    /// (e.g. `start_date.lt_expr(F("end_date"))`).
+    fn lt_expr(self, rhs: impl Into<crate::core::Expr>) -> TypedExpr<Self::Model> {
+        TypedExpr::column_cmp(Self::COLUMN, Op::Lt, rhs.into())
+    }
+
+    /// `column <= <expr>`.
+    fn lte_expr(self, rhs: impl Into<crate::core::Expr>) -> TypedExpr<Self::Model> {
+        TypedExpr::column_cmp(Self::COLUMN, Op::Lte, rhs.into())
+    }
+
+    /// `column > <expr>`.
+    fn gt_expr(self, rhs: impl Into<crate::core::Expr>) -> TypedExpr<Self::Model> {
+        TypedExpr::column_cmp(Self::COLUMN, Op::Gt, rhs.into())
+    }
+
+    /// `column >= <expr>`.
+    fn gte_expr(self, rhs: impl Into<crate::core::Expr>) -> TypedExpr<Self::Model> {
+        TypedExpr::column_cmp(Self::COLUMN, Op::Gte, rhs.into())
     }
 }
 
@@ -255,6 +308,17 @@ pub struct TypedExpr<M: Model> {
 }
 
 impl<M: Model> TypedExpr<M> {
+    /// Build a [`WhereExpr::ColumnCompare`] leaf — the `F()`-style
+    /// "column <op> expr" predicate. Used by [`Column::eq_expr`] &
+    /// friends; not normally constructed directly by user code.
+    #[must_use]
+    pub(crate) fn column_cmp(column: &'static str, op: Op, rhs: crate::core::Expr) -> Self {
+        Self {
+            inner: WhereExpr::ColumnCompare(super::query::ColumnFilter { column, op, rhs }),
+            _model: PhantomData,
+        }
+    }
+
     /// Unwrap to the dialect-neutral expression form.
     #[must_use]
     pub fn into_expr(self) -> WhereExpr {

--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -1,0 +1,343 @@
+//! `Expr` — RHS expression for [`crate::core::query::Assignment`] +
+//! column-vs-column comparisons in [`crate::core::query::ColumnFilter`].
+//!
+//! Closes ORM Expression-DSL issue #1 (`F()` expressions). Lets the
+//! ORM refer to a column by name inside an UPDATE SET or a WHERE
+//! predicate:
+//!
+//! ```ignore
+//! // Atomic counter increment — no read-modify-write race.
+//! Post::objects()
+//!     .where_(Post::id.eq(42))
+//!     .update()
+//!     .set("views", F("views") + 1)
+//!     .execute_pool(&pool).await?;
+//!
+//! // Column-vs-column filter.
+//! Reservation::objects()
+//!     .where_col(Reservation::start_date, Op::Lt, F("end_date"))
+//!     .fetch_pool(&pool).await?;
+//! ```
+//!
+//! `Expr` carries three variants:
+//! - [`Expr::Literal`] — a bound parameter, indistinguishable from
+//!   the legacy `SqlValue` path. Every existing call site that passes
+//!   a value into an `Assignment` lifts through `impl From<SqlValue>
+//!   for Expr` and lands here.
+//! - [`Expr::Column`] — a column reference. Emitter quotes the
+//!   identifier per dialect (`"col"` on PG/SQLite, `` `col` `` on
+//!   MySQL).
+//! - [`Expr::BinOp`] — `<left> <op> <right>` arithmetic, recursive.
+//!
+//! Parenthesization on emit is conservative: every `BinOp` is wrapped
+//! in `()`. This is more parens than strictly necessary for `(a + b)
+//! + c` but matches what the planner sees from Django's emitter and
+//! keeps the writer trivially correct.
+//!
+//! # Why a fresh `Expr` instead of shoehorning into `SqlValue`
+//!
+//! `SqlValue` is a *value* — its `Display`, `field_type()`, sqlx
+//! `Encode`/`Decode`, JSON serialization paths all assume a concrete
+//! literal. A column reference and an arithmetic tree have no
+//! `field_type()` until the schema resolves them, and they don't bind
+//! as a parameter. Keeping them in a separate enum keeps both types
+//! honest.
+
+use std::ops;
+
+use super::value::SqlValue;
+
+/// Binary arithmetic operator. Emits its SQL keyword/symbol verbatim.
+///
+/// Tri-dialect compatibility:
+/// - `Add`, `Sub`, `Mul`, `Div`, `Mod`: portable across PG / MySQL / SQLite.
+/// - `BitAnd`, `BitOr`, `BitXor`, `BitShl`, `BitShr`: PG and MySQL spell
+///   these the same (`&`, `|`, `#` for XOR on PG vs `^` on MySQL — emitter
+///   picks dialect-correct symbol). SQLite supports `&`, `|`, `<<`, `>>`
+///   but lacks a bitwise XOR operator; the emitter surfaces a clear
+///   `SqlError::OpNotSupportedInDialect` for `BitXor` on SQLite.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinOp {
+    /// `+` — addition (numeric / date-interval, dialect-dependent).
+    Add,
+    /// `-` — subtraction.
+    Sub,
+    /// `*` — multiplication.
+    Mul,
+    /// `/` — division.
+    Div,
+    /// `%` (PG/SQLite) or `MOD` (MySQL alt): emitted as `%` everywhere.
+    Mod,
+    /// Bitwise AND.
+    BitAnd,
+    /// Bitwise OR.
+    BitOr,
+    /// Bitwise XOR. PG: `#`. MySQL: `^`. SQLite: not supported.
+    BitXor,
+    /// Left shift.
+    BitShl,
+    /// Right shift.
+    BitShr,
+}
+
+/// RHS expression — literal, column reference, or arithmetic tree.
+///
+/// `Expr` is what the writer renders to the right side of `=` in an
+/// UPDATE assignment and to the right side of a column predicate in
+/// a WHERE clause. The variants are recursive so arbitrarily nested
+/// arithmetic is expressible.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    /// Bound value. Emitter pushes a parameter.
+    Literal(SqlValue),
+    /// Column reference. Emitter writes the quoted identifier.
+    /// `&'static str` matches the rest of the IR's column-name
+    /// convention (model schemas embed `&'static str` field names).
+    Column(&'static str),
+    /// Binary arithmetic: `left <op> right`. Recursive — either side
+    /// may be a nested `BinOp`.
+    BinOp {
+        left: Box<Expr>,
+        op: BinOp,
+        right: Box<Expr>,
+    },
+}
+
+impl Expr {
+    /// Build a column-reference expression. Sugar for `Expr::Column`.
+    #[must_use]
+    pub fn col(name: &'static str) -> Self {
+        Self::Column(name)
+    }
+
+    /// Compose a `BinOp` with `self` on the left and `rhs` on the right.
+    /// Boxes both sides for you.
+    #[must_use]
+    pub fn binop(self, op: BinOp, rhs: impl Into<Expr>) -> Self {
+        Self::BinOp {
+            left: Box::new(self),
+            op,
+            right: Box::new(rhs.into()),
+        }
+    }
+
+    /// `true` when this expression is a pure literal — no column refs,
+    /// no arithmetic. Used by writers as a fast path that skips the
+    /// dialect dispatch on the column-emit branch.
+    #[must_use]
+    pub fn is_literal(&self) -> bool {
+        matches!(self, Self::Literal(_))
+    }
+
+    /// Extract the underlying `SqlValue` if `self` is `Literal`,
+    /// otherwise `None`. Convenience for writers that have a fast
+    /// literal-only path.
+    #[must_use]
+    pub fn as_literal(&self) -> Option<&SqlValue> {
+        match self {
+            Self::Literal(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+// ---------- From impls — let existing call sites transparently lift ----------
+
+impl From<SqlValue> for Expr {
+    fn from(v: SqlValue) -> Self {
+        Self::Literal(v)
+    }
+}
+
+/// Generate `From<$primitive> for Expr` for each primitive whose
+/// `Into<SqlValue>` already exists. Avoids a blanket
+/// `impl<T: Into<SqlValue>> From<T> for Expr`, which would conflict
+/// with `From<SqlValue> for Expr` (SqlValue: Into<SqlValue> trivially).
+macro_rules! expr_from_primitive {
+    ($($t:ty),+ $(,)?) => {
+        $(
+            impl From<$t> for Expr {
+                fn from(v: $t) -> Self { Self::Literal(SqlValue::from(v)) }
+            }
+        )+
+    };
+}
+
+expr_from_primitive! {
+    i16, i32, i64, f32, f64, bool, String, &'static str,
+    chrono::DateTime<chrono::Utc>, chrono::NaiveDate, uuid::Uuid,
+    serde_json::Value,
+}
+
+// ---------- F() public sugar ----------
+
+/// Django-shape `F("col")` builder. Produces an [`Expr::Column`] when
+/// passed to anywhere that expects `impl Into<Expr>`. The whole point
+/// is to give the call site a tiny visible marker that something is
+/// a column reference rather than a string literal value:
+///
+/// ```ignore
+/// .update().set("views", F("views") + 1).execute_pool(&pool).await?;
+/// //              ^^^^^^^ column ref      ^^^ literal
+/// ```
+///
+/// Operator-overloaded for the common shapes — every `F(_) <op> rhs`
+/// where `rhs: Into<Expr>` returns an [`Expr::BinOp`] directly, no
+/// `.into()` call needed at the use site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(non_camel_case_types)] // Django's `F(...)` is the established name.
+pub struct F(pub &'static str);
+
+impl F {
+    /// Construct an F by name. Equivalent to the tuple struct
+    /// constructor but reads as a function call.
+    #[must_use]
+    pub fn new(column: &'static str) -> Self {
+        Self(column)
+    }
+}
+
+impl From<F> for Expr {
+    fn from(f: F) -> Self {
+        Self::Column(f.0)
+    }
+}
+
+// ---------- Operator overloads on both `F` and `Expr` ----------
+
+/// Generate `impl ops::$Trait<R> for $Lhs` for every supported RHS
+/// expression-convertible type. `$Trait` is the std ops trait; `$method`
+/// is its single method; `$op` is the [`BinOp`] variant.
+macro_rules! impl_binop {
+    ($($Trait:ident :: $method:ident => $op:ident),+ $(,)?) => {
+        $(
+            impl<R: Into<Expr>> ops::$Trait<R> for F {
+                type Output = Expr;
+                fn $method(self, rhs: R) -> Expr {
+                    Expr::Column(self.0).binop(BinOp::$op, rhs)
+                }
+            }
+            impl<R: Into<Expr>> ops::$Trait<R> for Expr {
+                type Output = Expr;
+                fn $method(self, rhs: R) -> Expr {
+                    self.binop(BinOp::$op, rhs)
+                }
+            }
+        )+
+    };
+}
+
+impl_binop! {
+    Add::add => Add,
+    Sub::sub => Sub,
+    Mul::mul => Mul,
+    Div::div => Div,
+    Rem::rem => Mod,
+    BitAnd::bitand => BitAnd,
+    BitOr::bitor => BitOr,
+    BitXor::bitxor => BitXor,
+    Shl::shl => BitShl,
+    Shr::shr => BitShr,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn f_lifts_to_column_expr() {
+        let e: Expr = F("views").into();
+        assert_eq!(e, Expr::Column("views"));
+    }
+
+    #[test]
+    fn f_add_int_builds_binop() {
+        let e: Expr = F("views") + 1;
+        assert_eq!(
+            e,
+            Expr::BinOp {
+                left: Box::new(Expr::Column("views")),
+                op: BinOp::Add,
+                right: Box::new(Expr::Literal(SqlValue::I32(1))),
+            }
+        );
+    }
+
+    #[test]
+    fn f_add_f_builds_column_column_binop() {
+        let e: Expr = F("a") + F("b");
+        assert_eq!(
+            e,
+            Expr::BinOp {
+                left: Box::new(Expr::Column("a")),
+                op: BinOp::Add,
+                right: Box::new(Expr::Column("b")),
+            }
+        );
+    }
+
+    #[test]
+    fn arithmetic_chains_left_assoc() {
+        // `(F("a") + 1) - 2` — Rust's precedence + left-assoc gives a
+        // BinOp where the left is the inner BinOp.
+        let e: Expr = F("a") + 1 - 2;
+        let Expr::BinOp { left, op, right } = e else {
+            panic!("expected outer BinOp");
+        };
+        assert_eq!(op, BinOp::Sub);
+        assert_eq!(*right, Expr::Literal(SqlValue::I32(2)));
+        let Expr::BinOp { op: inner_op, .. } = *left else {
+            panic!("expected nested BinOp")
+        };
+        assert_eq!(inner_op, BinOp::Add);
+    }
+
+    #[test]
+    fn sqlvalue_lifts_into_expr_literal() {
+        let e: Expr = SqlValue::I64(42).into();
+        assert_eq!(e, Expr::Literal(SqlValue::I64(42)));
+    }
+
+    #[test]
+    fn primitives_lift_into_expr_literal() {
+        let e: Expr = 7i64.into();
+        assert_eq!(e, Expr::Literal(SqlValue::I64(7)));
+        let e: Expr = "hi".into();
+        assert_eq!(e, Expr::Literal(SqlValue::String("hi".to_owned())));
+    }
+
+    #[test]
+    fn is_literal_distinguishes() {
+        assert!(Expr::Literal(SqlValue::I32(1)).is_literal());
+        assert!(!Expr::Column("x").is_literal());
+        assert!(!(F("a") + 1).is_literal());
+    }
+
+    #[test]
+    fn bitwise_operators_compile_and_compose() {
+        let e: Expr = F("mask") & 0xff_i32;
+        assert!(matches!(
+            e,
+            Expr::BinOp {
+                op: BinOp::BitAnd,
+                ..
+            }
+        ));
+        let e: Expr = F("a") | F("b");
+        assert!(matches!(
+            e,
+            Expr::BinOp {
+                op: BinOp::BitOr,
+                ..
+            }
+        ));
+        let e: Expr = F("a") << 4_i32;
+        assert!(matches!(
+            e,
+            Expr::BinOp {
+                op: BinOp::BitShl,
+                ..
+            }
+        ));
+    }
+}

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -5,6 +5,7 @@
 
 mod column;
 mod error;
+mod expr;
 mod field_type;
 mod query;
 mod schema;
@@ -13,11 +14,12 @@ mod value;
 
 pub use column::{Column, TypedAssignment, TypedExpr, TypedFilter};
 pub use error::QueryError;
+pub use expr::{BinOp, Expr, F};
 pub use field_type::FieldType;
 pub use query::{
-    AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ConflictClause,
-    CountQuery, DeleteQuery, Filter, InsertQuery, Join, Op, OrderClause, SearchClause, SelectQuery,
-    UpdateQuery, WhereExpr,
+    AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ColumnFilter,
+    ConflictClause, CountQuery, DeleteQuery, Filter, InsertQuery, Join, Op, OrderClause,
+    SearchClause, SelectQuery, UpdateQuery, WhereExpr,
 };
 pub use schema::{
     infer_app_label_from_module_path, AdminConfig, CheckConstraint, CompositeFkRelation,

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -4,6 +4,7 @@
 //! The SQL crate then walks that IR and writes a parameterized statement
 //! per dialect. Anything in this module is therefore visible to both.
 
+use super::expr::Expr;
 use super::{validate::validate_value, ModelSchema, QueryError, SqlValue};
 
 /// Comparison operator on a single column.
@@ -65,6 +66,27 @@ pub struct Filter {
     pub value: SqlValue,
 }
 
+/// `WHERE` predicate that compares two columns from the same row —
+/// the rustango analog of Django's `F()` on the right side of a filter.
+///
+/// Emits `<left_col> <op> <right>` where `right` is an arbitrary
+/// [`Expr`] (typically `Expr::Column` for a plain column-vs-column
+/// compare, or a `BinOp` tree for column-vs-arithmetic). The lhs is
+/// the model column being filtered on; the rhs lives in the `Expr`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnFilter {
+    /// Left-hand column (the field being filtered on, schema-resolved).
+    pub column: &'static str,
+    /// Comparison operator. Subset of [`Op`] — only the binary
+    /// comparison variants make sense here (`Eq`, `Ne`, `Lt`, `Lte`,
+    /// `Gt`, `Gte`). Other ops (`In`, `Between`, `IsNull`, JSON ops, etc.)
+    /// are rejected at compile/emit time.
+    pub op: Op,
+    /// Right-hand side. Most commonly `Expr::Column(other)` for the
+    /// column-vs-column case; can be any expression tree.
+    pub rhs: Expr,
+}
+
 /// Boolean expression in a `WHERE` clause — leaf [`Filter`]s composed
 /// with `AND` / `OR` to arbitrary depth.
 ///
@@ -87,6 +109,8 @@ pub struct Filter {
 pub enum WhereExpr {
     /// Leaf — a single column predicate.
     Predicate(Filter),
+    /// Leaf — a column-vs-expression predicate (F() comparisons).
+    ColumnCompare(ColumnFilter),
     /// All children must match. Empty list = vacuously true (no
     /// `WHERE` emitted by the writer).
     And(Vec<WhereExpr>),
@@ -148,7 +172,12 @@ impl WhereExpr {
                 }
                 Some(out)
             }
-            Self::Or(_) | Self::Not(_) => None,
+            // ColumnCompare is a leaf predicate but it doesn't carry a
+            // `Filter` (the rhs is an `Expr`, not a `SqlValue`), so the
+            // flat-AND view can't surface it as a `&Filter` reference.
+            // Callers using `as_flat_and` only handle literal `Filter`
+            // predicates anyway.
+            Self::ColumnCompare(_) | Self::Or(_) | Self::Not(_) => None,
         }
     }
 
@@ -169,6 +198,18 @@ impl WhereExpr {
                 }
                 Ok(())
             }
+            Self::ColumnCompare(cf) => {
+                if model.field_by_column(cf.column).is_none() {
+                    return Err(QueryError::UnknownField {
+                        model: model.name,
+                        field: cf.column.to_owned(),
+                    });
+                }
+                // Validate every column reference inside the rhs Expr
+                // tree against the model schema.
+                validate_expr_columns(model, &cf.rhs)?;
+                Ok(())
+            }
             Self::And(items) | Self::Or(items) => {
                 for child in items {
                     child.validate(model)?;
@@ -176,6 +217,28 @@ impl WhereExpr {
                 Ok(())
             }
             Self::Not(child) => child.validate(model),
+        }
+    }
+}
+
+/// Recursively walk an [`Expr`] and confirm every `Column` reference
+/// resolves on `model`. Literals + arithmetic ops are passed through.
+fn validate_expr_columns(model: &'static ModelSchema, expr: &Expr) -> Result<(), QueryError> {
+    match expr {
+        Expr::Literal(_) => Ok(()),
+        Expr::Column(name) => {
+            if model.field_by_column(name).is_none() {
+                Err(QueryError::UnknownField {
+                    model: model.name,
+                    field: (*name).to_owned(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+        Expr::BinOp { left, right, .. } => {
+            validate_expr_columns(model, left)?;
+            validate_expr_columns(model, right)
         }
     }
 }
@@ -369,10 +432,19 @@ impl BulkInsertQuery {
 }
 
 /// One `column = value` pair in an `UPDATE ... SET ...` clause.
+///
+/// `value` is an [`Expr`] — it can be a literal (most common, `Expr::Literal`),
+/// a column reference (`Expr::Column` / `F("col")` — column-to-column copy),
+/// or an arithmetic tree (`F("col") + 1` — Django's atomic counter pattern).
+///
+/// Existing call sites that pass an [`SqlValue`] lift transparently
+/// via `impl From<SqlValue> for Expr` — the field's `Into`-bound public
+/// builders (`Column::set`, `UpdateBuilder::set`) keep their original
+/// signatures.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Assignment {
     pub column: &'static str,
-    pub value: SqlValue,
+    pub value: Expr,
 }
 
 /// Compiled `UPDATE`.
@@ -404,7 +476,12 @@ impl UpdateQuery {
                     model: self.model.name,
                     field: assignment.column.to_owned(),
                 })?;
-            validate_value(self.model.name, field, &assignment.value)?;
+            // Only literal rhs values are checkable against the field's
+            // declared bounds; column refs and arithmetic trees don't
+            // resolve to a single concrete value at compile time.
+            if let Some(literal) = assignment.value.as_literal() {
+                validate_value(self.model.name, field, literal)?;
+            }
         }
         Ok(())
     }

--- a/crates/rustango/src/forms/mod.rs
+++ b/crates/rustango/src/forms/mod.rs
@@ -536,7 +536,7 @@ impl ModelForm {
                     let raw = self.data.get(f.name).map(String::as_str);
                     parse_form_value(f, raw).ok().map(|v| Assignment {
                         column: f.column,
-                        value: v,
+                        value: v.into(),
                     })
                 })
                 .collect();
@@ -1254,7 +1254,10 @@ impl<T: crate::core::Model> ModelFormFor<T> {
             .columns
             .into_iter()
             .zip(self.values)
-            .map(|(column, value)| crate::core::Assignment { column, value })
+            .map(|(column, value)| crate::core::Assignment {
+                column,
+                value: value.into(),
+            })
             .collect();
         Some(crate::core::UpdateQuery {
             model: T::SCHEMA,

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -66,6 +66,19 @@ struct RawAssignment {
     value: SqlValue,
 }
 
+/// Staged `field = <expression>` assignment for the [`F()`]-shaped
+/// SET path. `field` is the Rust-side name resolved against the
+/// schema at `compile()` time; `value` is an [`crate::core::Expr`]
+/// tree that may contain column refs + arithmetic. Resolves to
+/// [`crate::core::Assignment`] in `resolve_assignment_expr`.
+///
+/// [`F()`]: crate::core::F
+#[derive(Debug, Clone)]
+struct RawExprAssignment {
+    field: String,
+    value: crate::core::Expr,
+}
+
 impl<T: Model> Default for QuerySet<T> {
     fn default() -> Self {
         Self::new()
@@ -310,6 +323,9 @@ pub struct UpdateBuilder<T: Model> {
 
 enum PendingAssignment {
     Raw(RawAssignment),
+    /// `field = <Expr>` — staging for the `F()` SET path. Resolved at
+    /// `compile()` time so the field name validates against the schema.
+    RawExpr(RawExprAssignment),
     Resolved(Assignment),
 }
 
@@ -332,6 +348,33 @@ impl<T: Model> UpdateBuilder<T> {
         self
     }
 
+    /// Append a `SET field = <expression>` — the [`Expr`]-shaped form
+    /// that powers `F()` column references and arithmetic:
+    ///
+    /// ```ignore
+    /// // Atomic counter increment, no read-modify-write race:
+    /// Post::objects()
+    ///     .where_(Post::id.eq(7))
+    ///     .update()
+    ///     .set_expr("views", F("views") + 1)
+    ///     .execute_pool(&pool).await?;
+    /// ```
+    ///
+    /// Accepts a bare [`F`](crate::core::F), a literal (anything that
+    /// `Into<SqlValue>`), or a full arithmetic tree.
+    #[must_use]
+    pub fn set_expr(
+        mut self,
+        field: impl Into<String>,
+        expr: impl Into<crate::core::Expr>,
+    ) -> Self {
+        self.set.push(PendingAssignment::RawExpr(RawExprAssignment {
+            field: field.into(),
+            value: expr.into(),
+        }));
+        self
+    }
+
     /// Validate against `T::SCHEMA` and lower to an `UpdateQuery`.
     ///
     /// # Errors
@@ -346,6 +389,7 @@ impl<T: Model> UpdateBuilder<T> {
             .into_iter()
             .map(|p| match p {
                 PendingAssignment::Raw(raw) => resolve_assignment(model, raw),
+                PendingAssignment::RawExpr(raw) => resolve_assignment_expr(model, raw),
                 PendingAssignment::Resolved(assignment) => Ok(assignment),
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -518,8 +562,60 @@ fn resolve_assignment(
 
     Ok(Assignment {
         column: field.column,
+        value: raw.value.into(),
+    })
+}
+
+/// Resolve a [`RawExprAssignment`] (the `F()` SET path) against the
+/// schema. Field name + every column reference inside the expression
+/// tree are validated; the literal type-check that
+/// [`resolve_assignment`] does for [`SqlValue`] doesn't apply because
+/// the RHS may be a column ref or arithmetic, both of which only have
+/// a resolved type at the row level.
+fn resolve_assignment_expr(
+    model: &'static ModelSchema,
+    raw: RawExprAssignment,
+) -> Result<Assignment, QueryError> {
+    let field = model
+        .field(&raw.field)
+        .ok_or_else(|| QueryError::UnknownField {
+            model: model.name,
+            field: raw.field.clone(),
+        })?;
+    validate_expr_columns_in_model(model, &raw.value)?;
+    Ok(Assignment {
+        column: field.column,
         value: raw.value,
     })
+}
+
+/// Walk an [`crate::core::Expr`] and confirm every `Column`
+/// reference resolves on `model`. Mirrors the same check that
+/// `core::query::WhereExpr::validate` does for `ColumnCompare` —
+/// duplicated here so the `UpdateBuilder` path catches typos at
+/// `compile()` time rather than at the database.
+fn validate_expr_columns_in_model(
+    model: &'static ModelSchema,
+    expr: &crate::core::Expr,
+) -> Result<(), QueryError> {
+    use crate::core::Expr;
+    match expr {
+        Expr::Literal(_) => Ok(()),
+        Expr::Column(name) => {
+            if model.field_by_column(name).is_none() {
+                Err(QueryError::UnknownField {
+                    model: model.name,
+                    field: (*name).to_owned(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+        Expr::BinOp { left, right, .. } => {
+            validate_expr_columns_in_model(model, left)?;
+            validate_expr_columns_in_model(model, right)
+        }
+    }
 }
 
 // ------------------------------------------------------------------ AggregateBuilder

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -118,7 +118,7 @@ pub async fn soft_delete(
             model,
             set: vec![Assignment {
                 column: col,
-                value: SqlValue::from(chrono::Utc::now()),
+                value: SqlValue::from(chrono::Utc::now()).into(),
             }],
             where_clause: WhereExpr::Predicate(Filter {
                 column: pk_column,
@@ -153,7 +153,7 @@ pub async fn restore(
             model,
             set: vec![Assignment {
                 column: col,
-                value: SqlValue::Null,
+                value: SqlValue::Null.into(),
             }],
             where_clause: WhereExpr::Predicate(Filter {
                 column: pk_column,

--- a/crates/rustango/src/sql/error.rs
+++ b/crates/rustango/src/sql/error.rs
@@ -106,6 +106,18 @@ pub enum SqlError {
         shape: &'static str,
         dialect: &'static str,
     },
+
+    /// A [`crate::core::BinOp`] variant has no dialect-portable
+    /// translation on this backend. Today raised only for
+    /// `BinOp::BitXor` on SQLite (SQLite has `&`, `|`, `<<`, `>>` but
+    /// no bitwise-XOR operator). Caller can either route to a different
+    /// op (e.g. `(a | b) - (a & b)`) or restrict the feature to
+    /// PG / MySQL.
+    #[error("operator `{op}` is not supported by the `{dialect}` dialect")]
+    OpNotSupportedInDialect {
+        op: &'static str,
+        dialect: &'static str,
+    },
 }
 
 /// Raised while compiling, writing, or executing a query end-to-end.

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -418,11 +418,73 @@ pub(super) fn write_update(b: &mut Sql<'_>, query: &UpdateQuery) -> Result<(), S
         b.write_ident(assignment.column);
         b.sql.push_str(" = ");
         let cast = null_cast_for(b.d, query.model, assignment.column);
-        b.push_param_typed(assignment.value.clone(), cast);
+        write_expr(b, &assignment.value, cast)?;
     }
 
     write_where(b, &query.where_clause, Some(query.model))?;
     Ok(())
+}
+
+/// Render a [`crate::core::Expr`] — the recursive RHS form that
+/// powers `F()` column references and arithmetic. Literal `Expr`s
+/// route through [`Sql::push_param_typed`] so cast hinting (PG
+/// `::TEXT` on NULL) still fires. `Column` writes a quoted ident;
+/// `BinOp` emits `(<left> <op> <right>)` with both sides recursed.
+fn write_expr(
+    b: &mut Sql<'_>,
+    expr: &crate::core::Expr,
+    cast: Option<&'static str>,
+) -> Result<(), SqlError> {
+    use crate::core::{BinOp as BO, Expr};
+    match expr {
+        Expr::Literal(v) => {
+            b.push_param_typed(v.clone(), cast);
+            Ok(())
+        }
+        Expr::Column(name) => {
+            b.write_ident(name);
+            Ok(())
+        }
+        Expr::BinOp { left, op, right } => {
+            // SQLite doesn't have a bitwise XOR operator; surface a
+            // clear error rather than emitting silently-wrong SQL.
+            if matches!(op, BO::BitXor) && b.d.name() == "sqlite" {
+                return Err(SqlError::OpNotSupportedInDialect {
+                    op: "BitXor",
+                    dialect: b.d.name(),
+                });
+            }
+            b.sql.push('(');
+            // Nested casts only apply at the literal leaf — clear here
+            // so an outer NULL cast doesn't bleed into the operand.
+            write_expr(b, left, None)?;
+            b.sql.push(' ');
+            b.sql.push_str(match op {
+                BO::Add => "+",
+                BO::Sub => "-",
+                BO::Mul => "*",
+                BO::Div => "/",
+                BO::Mod => "%",
+                BO::BitAnd => "&",
+                BO::BitOr => "|",
+                // PG spells XOR `#`; MySQL uses `^`. SQLite already
+                // bounced above.
+                BO::BitXor => {
+                    if b.d.name() == "postgres" {
+                        "#"
+                    } else {
+                        "^"
+                    }
+                }
+                BO::BitShl => "<<",
+                BO::BitShr => ">>",
+            });
+            b.sql.push(' ');
+            write_expr(b, right, None)?;
+            b.sql.push(')');
+            Ok(())
+        }
+    }
 }
 
 // ====================================================================
@@ -578,6 +640,7 @@ pub(super) fn write_where_expr(
 ) -> Result<(), SqlError> {
     match expr {
         WhereExpr::Predicate(filter) => write_filter(b, filter, qualify_with, model),
+        WhereExpr::ColumnCompare(cf) => write_column_compare(b, cf, qualify_with, model),
         WhereExpr::And(items) => write_joined(b, items, " AND ", qualify_with, model),
         WhereExpr::Or(items) => {
             if items.is_empty() {
@@ -592,6 +655,39 @@ pub(super) fn write_where_expr(
             Ok(())
         }
     }
+}
+
+/// Render `<col> <op> <rhs-expr>` for a [`crate::core::ColumnFilter`].
+/// Only the binary-comparison `Op` variants are valid here — anything
+/// else (`In`, `Between`, `IsNull`, JSON ops, etc.) is a builder error
+/// and surfaces as [`SqlError::OpNotSupportedInDialect`] so the test
+/// suite catches it.
+fn write_column_compare(
+    b: &mut Sql<'_>,
+    cf: &crate::core::ColumnFilter,
+    qualify_with: Option<&str>,
+    _model: Option<&'static ModelSchema>,
+) -> Result<(), SqlError> {
+    let qualified = render_qualified_col(b.d, qualify_with, cf.column);
+    b.sql.push_str(&qualified);
+    let op_str = match cf.op {
+        crate::core::Op::Eq => " = ",
+        crate::core::Op::Ne => " <> ",
+        crate::core::Op::Lt => " < ",
+        crate::core::Op::Lte => " <= ",
+        crate::core::Op::Gt => " > ",
+        crate::core::Op::Gte => " >= ",
+        // Other ops don't fit a `col <op> col` shape; reject loudly.
+        _ => {
+            return Err(SqlError::OpNotSupportedInDialect {
+                op: "non-binary comparison in ColumnCompare",
+                dialect: b.d.name(),
+            });
+        }
+    };
+    b.sql.push_str(op_str);
+    write_expr(b, &cf.rhs, None)?;
+    Ok(())
 }
 
 fn write_joined(
@@ -620,6 +716,7 @@ fn write_child(
 ) -> Result<(), SqlError> {
     match expr {
         WhereExpr::Predicate(filter) => write_filter(b, filter, qualify_with, model),
+        WhereExpr::ColumnCompare(cf) => write_column_compare(b, cf, qualify_with, model),
         WhereExpr::And(_) | WhereExpr::Or(_) | WhereExpr::Not(_) => {
             b.sql.push('(');
             write_where_expr(b, expr, qualify_with, model)?;

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -1838,7 +1838,10 @@ async fn handle_update_post(
     let assignments: Vec<crate::core::Assignment> = columns
         .into_iter()
         .zip(values)
-        .map(|(column, value)| crate::core::Assignment { column, value })
+        .map(|(column, value)| crate::core::Assignment {
+            column,
+            value: value.into(),
+        })
         .collect();
     let update_q = crate::core::UpdateQuery {
         model: state.schema,
@@ -3379,7 +3382,10 @@ mod tenant {
         let assignments: Vec<crate::core::Assignment> = columns
             .into_iter()
             .zip(values)
-            .map(|(column, value)| crate::core::Assignment { column, value })
+            .map(|(column, value)| crate::core::Assignment {
+                column,
+                value: value.into(),
+            })
             .collect();
         let update_q = crate::core::UpdateQuery {
             model: state.schema,

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -1100,7 +1100,7 @@ async fn org_edit_submit(
         .iter()
         .map(|(col, val)| crate::core::Assignment {
             column: *col,
-            value: val.clone(),
+            value: val.clone().into(),
         })
         .collect();
     let update_q = crate::core::UpdateQuery {
@@ -1296,7 +1296,8 @@ async fn org_edit_branding(
             value: v
                 .as_ref()
                 .map(|s| crate::core::SqlValue::String(s.clone()))
-                .unwrap_or(crate::core::SqlValue::Null),
+                .unwrap_or(crate::core::SqlValue::Null)
+                .into(),
         })
         .collect();
     let update_q = crate::core::UpdateQuery {

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1264,7 +1264,7 @@ async fn update_inner(
         match parse_form_value(field, raw) {
             Ok(v) => assignments.push(Assignment {
                 column: field.column,
-                value: v,
+                value: v.into(),
             }),
             Err(FormError::Missing { .. }) if partial => continue,
             Err(e) => return json_error(StatusCode::BAD_REQUEST, &e.to_string()),

--- a/crates/rustango/tests/f_expressions.rs
+++ b/crates/rustango/tests/f_expressions.rs
@@ -1,0 +1,282 @@
+//! Tri-dialect emission tests for `F()` expressions (issue #1) — the
+//! ORM Expression DSL primitive. Pins the SQL each backend produces
+//! for the four shapes that matter:
+//!
+//! 1. **Column-vs-column WHERE compare** — `WHERE start < end`.
+//! 2. **Column-vs-arithmetic WHERE compare** — `WHERE price > cost * 2`.
+//! 3. **Atomic counter UPDATE** — `SET views = views + 1`.
+//! 4. **Column-to-column UPDATE copy** — `SET full_name = display_name`.
+//!
+//! And the negative path: `BinOp::BitXor` is not emittable on SQLite
+//! (the dialect has `&`, `|`, `<<`, `>>` but no XOR symbol) — the
+//! writer surfaces a clear `OpNotSupportedInDialect` error rather than
+//! silently emitting wrong SQL.
+
+use rustango::core::{
+    Assignment, BinOp, ColumnFilter, Expr, Filter, Model as _, Op, SqlValue, UpdateQuery,
+    WhereExpr, F,
+};
+use rustango::sql::{Dialect, MySql, Postgres, SqlError, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "counter")]
+#[allow(dead_code)]
+pub struct Counter {
+    #[rustango(primary_key)]
+    id: i64,
+    views: i64,
+    threshold: i64,
+}
+
+// ---------- Expr type-level tests ----------
+
+#[test]
+fn f_lifts_to_expr_column() {
+    let e: Expr = F("views").into();
+    assert_eq!(e, Expr::Column("views"));
+}
+
+#[test]
+fn arithmetic_chains_left_assoc() {
+    // `(views + 1) - 2` per Rust precedence.
+    let e: Expr = F("views") + 1 - 2;
+    let Expr::BinOp { left, op, right } = e else {
+        panic!("expected outer BinOp")
+    };
+    assert_eq!(op, BinOp::Sub);
+    assert_eq!(*right, Expr::Literal(SqlValue::I32(2)));
+    let Expr::BinOp { op: inner, .. } = *left else {
+        panic!()
+    };
+    assert_eq!(inner, BinOp::Add);
+}
+
+// ---------- UPDATE: atomic counter increment ----------
+
+fn update_increment_views() -> UpdateQuery {
+    UpdateQuery {
+        model: Counter::SCHEMA,
+        set: vec![Assignment {
+            column: "views",
+            value: (F("views") + 1_i64).into(),
+        }],
+        where_clause: WhereExpr::Predicate(Filter {
+            column: "id",
+            op: Op::Eq,
+            value: SqlValue::I64(7),
+        }),
+    }
+}
+
+#[test]
+fn pg_emits_views_plus_one() {
+    let stmt = Postgres.compile_update(&update_increment_views()).unwrap();
+    assert_eq!(
+        stmt.sql,
+        r#"UPDATE "counter" SET "views" = ("views" + $1) WHERE "id" = $2"#
+    );
+    assert_eq!(stmt.params, vec![SqlValue::I64(1), SqlValue::I64(7)]);
+}
+
+#[test]
+fn mysql_emits_views_plus_one_with_backticks_and_question_marks() {
+    let stmt = MySql.compile_update(&update_increment_views()).unwrap();
+    assert_eq!(
+        stmt.sql,
+        "UPDATE `counter` SET `views` = (`views` + ?) WHERE `id` = ?"
+    );
+    assert_eq!(stmt.params, vec![SqlValue::I64(1), SqlValue::I64(7)]);
+}
+
+#[test]
+fn sqlite_emits_views_plus_one() {
+    let stmt = Sqlite.compile_update(&update_increment_views()).unwrap();
+    assert_eq!(
+        stmt.sql,
+        r#"UPDATE "counter" SET "views" = ("views" + ?) WHERE "id" = ?"#
+    );
+    assert_eq!(stmt.params, vec![SqlValue::I64(1), SqlValue::I64(7)]);
+}
+
+// ---------- UPDATE: column-to-column copy (no arithmetic) ----------
+
+#[test]
+fn pg_set_column_to_column_copies_without_param() {
+    let q = UpdateQuery {
+        model: Counter::SCHEMA,
+        set: vec![Assignment {
+            column: "views",
+            value: F("threshold").into(),
+        }],
+        where_clause: WhereExpr::And(vec![]),
+    };
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert_eq!(stmt.sql, r#"UPDATE "counter" SET "views" = "threshold""#);
+    assert!(
+        stmt.params.is_empty(),
+        "column-to-column copy must not bind any params, got {:?}",
+        stmt.params
+    );
+}
+
+// ---------- WHERE: column-vs-column ----------
+
+fn select_views_gt_threshold() -> rustango::core::SelectQuery {
+    // Build the bulk of the SelectQuery via the QuerySet helper to
+    // dodge ABI churn on `SelectQuery` field additions, then surgically
+    // swap in the ColumnCompare WhereExpr.
+    let mut q = Counter::objects().compile().unwrap();
+    q.where_clause = WhereExpr::ColumnCompare(ColumnFilter {
+        column: "views",
+        op: Op::Gt,
+        rhs: Expr::Column("threshold"),
+    });
+    q
+}
+
+#[test]
+fn pg_where_column_gt_column() {
+    let stmt = Postgres
+        .compile_select(&select_views_gt_threshold())
+        .unwrap();
+    assert!(
+        stmt.sql.contains(r#"WHERE "views" > "threshold""#),
+        "missing column-vs-column predicate: {}",
+        stmt.sql
+    );
+    assert!(stmt.params.is_empty());
+}
+
+#[test]
+fn mysql_where_column_gt_column() {
+    let stmt = MySql.compile_select(&select_views_gt_threshold()).unwrap();
+    assert!(
+        stmt.sql.contains("WHERE `views` > `threshold`"),
+        "missing column-vs-column predicate: {}",
+        stmt.sql
+    );
+    assert!(stmt.params.is_empty());
+}
+
+#[test]
+fn sqlite_where_column_gt_column() {
+    let stmt = Sqlite.compile_select(&select_views_gt_threshold()).unwrap();
+    assert!(
+        stmt.sql.contains(r#"WHERE "views" > "threshold""#),
+        "missing column-vs-column predicate: {}",
+        stmt.sql
+    );
+    assert!(stmt.params.is_empty());
+}
+
+// ---------- WHERE: column-vs-arithmetic ----------
+
+#[test]
+fn pg_where_column_compared_to_arithmetic_expr() {
+    let mut q = Counter::objects().compile().unwrap();
+    q.where_clause = WhereExpr::ColumnCompare(ColumnFilter {
+        column: "views",
+        op: Op::Gte,
+        rhs: F("threshold") * 2_i64,
+    });
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"WHERE "views" >= ("threshold" * $1)"#),
+        "got: {}",
+        stmt.sql
+    );
+    assert_eq!(stmt.params, vec![SqlValue::I64(2)]);
+}
+
+// ---------- Bitwise ops: PG `#`, MySQL `^`, SQLite errors out ----------
+
+fn update_xor_threshold() -> UpdateQuery {
+    UpdateQuery {
+        model: Counter::SCHEMA,
+        set: vec![Assignment {
+            column: "views",
+            value: (F("views") ^ 0xff_i32).into(),
+        }],
+        where_clause: WhereExpr::And(vec![]),
+    }
+}
+
+#[test]
+fn pg_bitxor_emits_hash_operator() {
+    let stmt = Postgres.compile_update(&update_xor_threshold()).unwrap();
+    assert!(
+        stmt.sql.contains(r#""views" = ("views" # $1)"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn mysql_bitxor_emits_caret_operator() {
+    let stmt = MySql.compile_update(&update_xor_threshold()).unwrap();
+    assert!(
+        stmt.sql.contains("`views` = (`views` ^ ?)"),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn sqlite_bitxor_returns_op_not_supported_error() {
+    let err = Sqlite.compile_update(&update_xor_threshold()).unwrap_err();
+    match err {
+        SqlError::OpNotSupportedInDialect { op, dialect } => {
+            assert_eq!(op, "BitXor");
+            assert_eq!(dialect, "sqlite");
+        }
+        other => panic!("expected OpNotSupportedInDialect, got {other:?}"),
+    }
+}
+
+// ---------- UpdateBuilder integration (the user-facing API) ----------
+
+#[test]
+fn update_builder_set_expr_resolves_field_name() {
+    let q = Counter::objects()
+        .eq("id", 7_i64)
+        .update()
+        .set_expr("views", F("views") + 1_i64)
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""views" = ("views" + $1)"#),
+        "got: {}",
+        stmt.sql
+    );
+    assert!(stmt.sql.contains(r#""id" = $2"#), "got: {}", stmt.sql);
+}
+
+#[test]
+fn update_builder_set_expr_rejects_unknown_field() {
+    let err = Counter::objects()
+        .update()
+        .set_expr("nope_nope", F("views") + 1_i64)
+        .compile()
+        .unwrap_err();
+    assert!(
+        matches!(err, rustango::core::QueryError::UnknownField { ref field, .. }
+                 if field == "nope_nope"),
+        "expected UnknownField for the set-target column, got {err:?}",
+    );
+}
+
+#[test]
+fn update_builder_set_expr_rejects_unknown_column_inside_expr() {
+    let err = Counter::objects()
+        .update()
+        .set_expr("views", F("nope_nope") + 1_i64)
+        .compile()
+        .unwrap_err();
+    assert!(
+        matches!(err, rustango::core::QueryError::UnknownField { ref field, .. }
+                 if field == "nope_nope"),
+        "expected UnknownField for the F() column inside the expr, got {err:?}",
+    );
+}

--- a/crates/rustango/tests/f_expressions_live.rs
+++ b/crates/rustango/tests/f_expressions_live.rs
@@ -1,0 +1,182 @@
+#![cfg(feature = "postgres")]
+//! Live race-resistance test for `F()` atomic counter updates
+//! (issue #1). Without F, the canonical "increment a counter"
+//! flow is read-modify-write:
+//!
+//! ```ignore
+//! let post = Post::objects().get(id).await?;
+//! post.views += 1;
+//! post.save(...).await?;
+//! ```
+//!
+//! …which is a classic lost-update race when two requests fetch the
+//! same row in parallel, both increment locally, and both write back.
+//! `F()` collapses the read into the UPDATE statement itself:
+//!
+//! ```ignore
+//! Post::objects().filter(...).update().set_expr("views", F("views") + 1).execute_pool(...).await?;
+//! ```
+//!
+//! PostgreSQL takes a row lock for the UPDATE, so 20 concurrent
+//! `views = views + 1` calls land on the same row sequentially and
+//! the final counter equals the number of calls exactly. This test
+//! pins that property end-to-end.
+//!
+//! Skips silently when `DATABASE_URL` is unset (offline / no service
+//! container).
+
+use std::sync::OnceLock;
+
+use rustango::core::{Column as _, F};
+use rustango::sql::{sqlx, Auto, Fetcher, Updater};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+/// Suite-wide lock matching every other PG live test file on this
+/// branch — serializes the `DROP TABLE` + `CREATE TABLE` setup so
+/// parallel tests don't trip on PG's `pg_class_relname_nsp_index`
+/// system-catalog unique.
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "f_expr_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub views: i64,
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "f_expr_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "f_expr_post" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "title" VARCHAR(200) NOT NULL,
+            "views" BIGINT NOT NULL
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn f_expression_increment_is_atomic_under_concurrent_load() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("DATABASE_URL unset — skipping");
+        return;
+    };
+    fresh(&pool).await;
+
+    // Seed one row with views=0.
+    let mut row = Post {
+        id: Auto::default(),
+        title: "race-test".into(),
+        views: 0,
+    };
+    row.insert(&pool).await.unwrap();
+    let id = row.id.get().copied().unwrap();
+
+    // Fire N concurrent `UPDATE views = views + 1 WHERE id = ?`.
+    // Each goroutine acquires its own PG connection from the pool; the
+    // UPDATE itself takes a row-level lock so writes serialize on the
+    // server side. Without F() (read-then-write) this would lose at
+    // least one increment with high probability.
+    const N: usize = 50;
+    let mut handles = Vec::with_capacity(N);
+    for _ in 0..N {
+        let pool = pool.clone();
+        handles.push(tokio::spawn(async move {
+            Post::objects()
+                .eq("id", id)
+                .update()
+                .set_expr("views", F("views") + 1_i64)
+                .execute(&pool)
+                .await
+                .expect("update succeeds");
+        }));
+    }
+    for h in handles {
+        h.await.expect("task didn't panic");
+    }
+
+    // Re-fetch and assert the counter equals N — no lost updates.
+    let posts: Vec<Post> = Post::objects()
+        .where_(Post::id.eq(id))
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(posts.len(), 1);
+    assert_eq!(
+        posts[0].views, N as i64,
+        "atomic increment must not lose updates ({} concurrent, final = {})",
+        N, posts[0].views
+    );
+
+    sqlx::query(r#"DROP TABLE IF EXISTS "f_expr_post" CASCADE"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn f_expression_column_to_column_compare_filters_correctly() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    // Seed a few rows where some have views >= title length, some not.
+    for (title, views) in [
+        ("a", 0_i64), // len 1, views 0  → views < title_len
+        ("ab", 10),   // len 2, views 10 → views > title_len
+        ("abc", 3),   // len 3, views 3  → views == title_len
+        ("abcd", 1),  // len 4, views 1  → views < title_len
+    ] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: title.to_owned(),
+            views,
+        };
+        p.insert(&pool).await.unwrap();
+    }
+
+    // `views > 2` — sanity literal compare baseline.
+    let high: Vec<Post> = Post::objects()
+        .where_(Post::views.gt(2_i64))
+        .fetch(&pool)
+        .await
+        .unwrap();
+    // Expected matches: "ab" (10) and "abc" (3) = 2 rows.
+    assert_eq!(high.len(), 2, "literal compare baseline: {high:?}");
+
+    // `views >= views` — every row matches (trivial column-vs-self).
+    // Proves the column-vs-column path emits the right SQL with no params.
+    let all: Vec<Post> = Post::objects()
+        .where_(Post::views.gte_expr(F("views")))
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 4, "self-compare matches every row: {all:?}");
+
+    sqlx::query(r#"DROP TABLE IF EXISTS "f_expr_post" CASCADE"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+}

--- a/crates/rustango/tests/mysql_from_row.rs
+++ b/crates/rustango/tests/mysql_from_row.rs
@@ -397,7 +397,7 @@ fn audit_save_one_with_audit_pool_is_callable() {
             model: <AuditedRecord as Model>::SCHEMA,
             set: vec![rustango::core::Assignment {
                 column: "name",
-                value: SqlValue::String("changed".into()),
+                value: SqlValue::String("changed".into()).into(),
             }],
             where_clause: WhereExpr::Predicate(Filter {
                 column: "id",

--- a/crates/rustango/tests/queryset.rs
+++ b/crates/rustango/tests/queryset.rs
@@ -163,9 +163,15 @@ fn update_builder_accumulates_set_assignments() {
 
     assert_eq!(query.set.len(), 2);
     assert_eq!(query.set[0].column, "is_active");
-    assert_eq!(query.set[0].value, SqlValue::Bool(false));
+    assert_eq!(
+        query.set[0].value,
+        rustango::core::Expr::Literal(SqlValue::Bool(false))
+    );
     assert_eq!(query.set[1].column, "name");
-    assert_eq!(query.set[1].value, SqlValue::String("ALICE".into()));
+    assert_eq!(
+        query.set[1].value,
+        rustango::core::Expr::Literal(SqlValue::String("ALICE".into()))
+    );
 
     let filters = query.where_clause.as_flat_and().unwrap();
     assert_eq!(filters.len(), 1);

--- a/crates/rustango/tests/sql.rs
+++ b/crates/rustango/tests/sql.rs
@@ -363,7 +363,7 @@ fn update_single_set_no_where_runs_table_wide() {
         model: User::SCHEMA,
         set: vec![Assignment {
             column: "is_active",
-            value: SqlValue::Bool(false),
+            value: SqlValue::Bool(false).into(),
         }],
         where_clause: WhereExpr::And(vec![]),
     };
@@ -379,11 +379,11 @@ fn update_multi_set_with_where_orders_set_then_filter_placeholders() {
         set: vec![
             Assignment {
                 column: "name",
-                value: SqlValue::String("ALICE".into()),
+                value: SqlValue::String("ALICE".into()).into(),
             },
             Assignment {
                 column: "is_active",
-                value: SqlValue::Bool(false),
+                value: SqlValue::Bool(false).into(),
             },
         ],
         where_clause: WhereExpr::Predicate(eq_filter("id", SqlValue::I64(7))),
@@ -409,7 +409,7 @@ fn update_with_multiple_filters_chains_with_and() {
         model: User::SCHEMA,
         set: vec![Assignment {
             column: "is_active",
-            value: SqlValue::Bool(true),
+            value: SqlValue::Bool(true).into(),
         }],
         where_clause: WhereExpr::and_predicates(vec![
             eq_filter("name", SqlValue::String("alice".into())),
@@ -445,7 +445,7 @@ fn update_propagates_filter_errors() {
         model: User::SCHEMA,
         set: vec![Assignment {
             column: "is_active",
-            value: SqlValue::Bool(false),
+            value: SqlValue::Bool(false).into(),
         }],
         where_clause: WhereExpr::Predicate(Filter {
             column: "id",

--- a/crates/rustango/tests/validation.rs
+++ b/crates/rustango/tests/validation.rs
@@ -237,7 +237,7 @@ fn update_validate_checks_set_values_only() {
         model: User::SCHEMA,
         set: vec![Assignment {
             column: "name",
-            value: SqlValue::String("a".repeat(20)),
+            value: SqlValue::String("a".repeat(20)).into(),
         }],
         where_clause: WhereExpr::Predicate(Filter {
             column: "name",
@@ -256,11 +256,11 @@ fn update_validate_allows_in_bounds_set() {
         set: vec![
             Assignment {
                 column: "name",
-                value: SqlValue::String("ok".into()),
+                value: SqlValue::String("ok".into()).into(),
             },
             Assignment {
                 column: "age",
-                value: SqlValue::I32(25),
+                value: SqlValue::I32(25).into(),
             },
         ],
         where_clause: WhereExpr::And(vec![]),
@@ -274,7 +274,7 @@ fn update_validate_rejects_out_of_range_set() {
         model: User::SCHEMA,
         set: vec![Assignment {
             column: "age",
-            value: SqlValue::I32(-5),
+            value: SqlValue::I32(-5).into(),
         }],
         where_clause: WhereExpr::And(vec![]),
     };


### PR DESCRIPTION
## Summary

Closes #1 — the first issue in the ORM Expression DSL epic. `F()` is the foundational primitive that the next five issues (#2 database functions, #3 date functions, #4 Case/When, #5 Subquery/Exists/OuterRef, #6 conditional aggregates, #7 window functions) build on. Lays the recursive `Expr` IR + tri-dialect emitter so subsequent issues add variants rather than re-doing the integration.

## What you get

```rust
use rustango::core::F;

// Atomic counter increment — no read-modify-write race.
Post::objects()
    .eq("id", 7)
    .update()
    .set_expr("views", F("views") + 1)
    .execute(&pool).await?;

// Column-vs-column WHERE filter.
Reservation::objects()
    .where_(Reservation::start_date.lt_expr(F("end_date")))
    .fetch(&pool).await?;

// Bitwise + arithmetic compose freely.
.set_expr("flags", F("flags") & 0x0f)
.set_expr("score", F("a") + F("b") * 2)
```

## What landed

| Area | Change |
|---|---|
| `core/expr.rs` (new) | `Expr` enum (`Literal/Column/BinOp`), `BinOp` (5 arith + 5 bitwise), `F` builder, operator overloads on both `F` and `Expr` |
| `core/query.rs` | `Assignment.value: SqlValue` → `Expr` (existing sites lift via `From<SqlValue> for Expr`); new `ColumnFilter { column, op, rhs: Expr }` + `WhereExpr::ColumnCompare` variant |
| `core/column.rs` | `Column` trait gains `eq_expr / ne_expr / lt_expr / lte_expr / gt_expr / gte_expr / set_expr` — all schema-typed |
| `query/mod.rs` | `UpdateBuilder::set_expr(field, expr)` — schema-resolves both the SET target and every column reference inside the expr tree at `compile()` time |
| `sql/writers.rs` | Recursive `write_expr` + `write_column_compare`. Conservative parenthesization on every `BinOp`. PG-XOR `#` vs MySQL-XOR `^` dispatched on `dialect.name()` |
| `sql/error.rs` | New `OpNotSupportedInDialect { op, dialect }` for SQLite-XOR (clear error rather than silently-wrong SQL) |
| `rustango-macros` | `save()` / `soft_delete()` / `restore()` emitters wrap `Assignment.value` in `.into()` |

## Why a fresh `Expr` instead of shoehorning into `SqlValue`

`SqlValue` is a *value* — its `Display`, `field_type()`, sqlx `Encode`/`Decode`, JSON serialization paths all assume a concrete literal. A column reference and an arithmetic tree have no `field_type()` until the schema resolves them and don't bind as parameters. Keeping them in a separate `Expr` enum keeps both types honest and constrains the blast radius: only `Assignment.value` changes shape, every existing site lifts via one trailing `.into()`.

## Tests

**Unit (`core::expr::tests`)** — 8 tests on the Expr tree: operator overload coverage, `From<SqlValue>` lift, primitive lifts (i32/i64/&str/etc.), bitwise compose, left-associativity.

**Tri-dialect SQL emission (`tests/f_expressions.rs`)** — 16 tests pinning per-dialect output:
- UPDATE atomic increment on PG / MySQL / SQLite — exact SQL strings + param order.
- UPDATE column-to-column copy — zero param bindings.
- WHERE column-vs-column compare on all three dialects.
- WHERE column-vs-arithmetic compare.
- `BitXor`: PG emits `#`, MySQL emits `^`, SQLite errors with `OpNotSupportedInDialect`.
- `UpdateBuilder::set_expr` schema-validates the SET target AND every F() column reference inside the expr tree.

**Live PG (`tests/f_expressions_live.rs`)** — 2 tests, including the issue's headline acceptance:
- **Race resistance**: 50 concurrent `views = views + 1` updates against one row land exactly 50 increments. Without F() (read-then-write) this would lose updates with high probability.
- Column-vs-column WHERE — `views >= views` self-compare matches every row (proves the binding path emits no params).

## Verification

```
cargo test -p rustango --lib --features tenancy            → 1463 passed (+ 8)
cargo test --features tenancy,mysql,sqlite --test f_expressions → 16 passed
DATABASE_URL=... cargo test --features tenancy --test f_expressions_live
                                                            → 2 passed
cargo check --no-default-features --features sqlite,tenancy → clean
cargo check --features mysql,tenancy                        → clean
```

## Test plan

- [x] 1463 lib tests pass.
- [x] 16 tri-dialect F() emission tests pass.
- [x] 50-way concurrent-update race test passes (no lost updates).
- [x] All three feature combos compile.
- [ ] CI green on `postgres_test` + `mysql_live` + `sqlite_live` + `sqlite_litmus`.

## What's next in the epic

#2 (text+math functions: `Coalesce`, `Greatest`, `Lower`, `Concat`, …) → #3 (date functions) → #4 (Case/When/Value) → #5 (Subquery/Exists/OuterRef) → #6 (aggregate filter=) → #7 (window functions). Each adds new `Expr` variants; this PR's recursive tree + tri-dialect emitter is the shared scaffolding.