### PR TITLE
Scalar database functions DSL — text/math/comparison (closes #2)

### DIFF
--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -80,12 +80,13 @@ pub enum BinOp {
     BitShr,
 }
 
-/// RHS expression — literal, column reference, or arithmetic tree.
+/// RHS expression — literal, column reference, arithmetic tree, or
+/// scalar function call.
 ///
 /// `Expr` is what the writer renders to the right side of `=` in an
 /// UPDATE assignment and to the right side of a column predicate in
 /// a WHERE clause. The variants are recursive so arbitrarily nested
-/// arithmetic is expressible.
+/// arithmetic and function calls are expressible.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Expr {
     /// Bound value. Emitter pushes a parameter.
@@ -101,6 +102,78 @@ pub enum Expr {
         op: BinOp,
         right: Box<Expr>,
     },
+    /// Scalar function call — `FN(arg, arg, …)`. Variadic-arity is
+    /// folded into `args` so the writer doesn't switch per-fn on
+    /// argument count. Issue #2 (Database functions DSL); see
+    /// [`crate::core::funcs`] for the public builder API.
+    Function { kind: ScalarFn, args: Vec<Expr> },
+}
+
+/// Scalar database functions surfaced by [`crate::core::funcs`].
+///
+/// v1 ships the text + math + comparison subset (~17 functions). The
+/// emitter handles per-dialect divergence — `Concat` falls back to
+/// `||` on SQLite, `Greatest`/`Least` are emitted as MAX/MIN scalars
+/// on SQLite to match PG/MySQL semantics. Hash functions, trig, and
+/// `Cast` ship in a follow-up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScalarFn {
+    // --- Text (8) ---
+    /// `LOWER(s)` — lowercase a string.
+    Lower,
+    /// `UPPER(s)` — uppercase a string.
+    Upper,
+    /// `LENGTH(s)` — string length. Char count on PG (`length`),
+    /// byte count on MySQL (`LENGTH` — use `CHAR_LENGTH` for chars).
+    /// SQLite: `length()` returns char count for `TEXT`. v2 may
+    /// split this into `Length` (char) + `OctetLength` (byte).
+    Length,
+    /// `CONCAT(a, b, …)` — string concatenation. SQLite emits
+    /// `a || b || …` (the only portable form on pre-3.44 SQLite).
+    /// NULL handling: PG / SQLite return NULL on any NULL operand;
+    /// MySQL's `CONCAT` does the same — this matches.
+    Concat,
+    /// `SUBSTRING(s FROM start FOR length)` (PG) /
+    /// `SUBSTRING(s, start, length)` (MySQL) /
+    /// `substr(s, start, length)` (SQLite). All 1-indexed.
+    Substr,
+    /// `TRIM(s)` — strip leading + trailing whitespace.
+    Trim,
+    /// `LTRIM(s)` — strip leading whitespace.
+    LTrim,
+    /// `RTRIM(s)` — strip trailing whitespace.
+    RTrim,
+    /// `REPLACE(s, from, to)` — replace every occurrence.
+    Replace,
+
+    // --- Math (4) ---
+    /// `ABS(x)` — absolute value.
+    Abs,
+    /// `CEIL(x)` / `CEILING(x)` — ceiling.
+    Ceil,
+    /// `FLOOR(x)` — floor.
+    Floor,
+    /// `ROUND(x)` or `ROUND(x, n)` — bankers' rounding on PG, round-
+    /// half-away-from-zero on MySQL / SQLite. Document the caveat
+    /// for app code; for query work the precision matters less than
+    /// the cross-dialect call shape.
+    Round,
+
+    // --- Comparison / NULL handling (4) ---
+    /// `COALESCE(a, b, c, …)` — first non-NULL argument. Variadic.
+    /// Returns NULL only if every argument is NULL.
+    Coalesce,
+    /// `GREATEST(a, b, …)` — largest non-NULL value. PG and MySQL
+    /// have native operators; SQLite uses scalar `MAX(a, b, …)`.
+    /// NULL semantics: PG / SQLite return NULL if any operand is
+    /// NULL; MySQL ignores NULL. Caller wraps args in `COALESCE`
+    /// for consistent cross-dialect behaviour when nulls are
+    /// possible.
+    Greatest,
+    /// `LEAST(a, b, …)` — mirror of `Greatest`.
+    Least,
+    /// `NULLIF(a, b)` — `NULL` when `a == b`, else `a`. Universal.
+    NullIf,
 }
 
 impl Expr {

--- a/crates/rustango/src/core/funcs.rs
+++ b/crates/rustango/src/core/funcs.rs
@@ -1,0 +1,318 @@
+//! Scalar database functions — text, math, comparison.
+//!
+//! Closes ORM Expression-DSL issue #2. Builds on the [`crate::core::Expr`]
+//! tree #1 introduced; each function here returns an [`Expr::Function`]
+//! that composes freely with `F()`, arithmetic, other functions, and
+//! literal values.
+//!
+//! ```ignore
+//! use rustango::core::{F, funcs::{lower, concat, coalesce, greatest, abs, round}};
+//!
+//! // Normalize a name on the way in.
+//! .set_expr("name_norm", lower(F("name")))
+//!
+//! // Build a display string from two columns + a separator.
+//! // `.into()` on each element — array literals are homogeneous.
+//! .set_expr("display", concat([F("first").into(), " ".into(), F("last").into()]))
+//!
+//! // Pick the first non-NULL.
+//! .set_expr("nickname", coalesce([F("nickname").into(), F("username").into(), "anon".into()]))
+//!
+//! // Compose with arithmetic — `round_to` for the precision form.
+//! .set_expr("rounded", round_to(F("score") * 100_i64, 0_i32))
+//!
+//! // Math.
+//! .where_(Post::priority.eq_expr(greatest([F("a").into(), F("b").into(), 5_i64.into()])))
+//! ```
+//!
+//! ## Per-dialect notes
+//!
+//! - **`concat`** falls back to `||` on SQLite (portable on every
+//!   SQLite version; SQLite added `concat()` only in 3.44).
+//! - **`greatest` / `least`** emit SQLite's scalar `MAX(a, b, …)` /
+//!   `MIN(a, b, …)` forms — those are the scalar versions when given
+//!   multiple args, distinct from the aggregate `MAX(col)` form.
+//! - **`length`** is **char-count** on PG, **byte-count** on MySQL,
+//!   **char-count for `TEXT`** on SQLite. For app code that mixes
+//!   ASCII this matches; for unicode-heavy data prefer `CHAR_LENGTH`
+//!   on MySQL (not yet exposed here — file follow-up if needed).
+//! - **`round(x, n)`**: PG `ROUND(numeric, int)` doesn't accept float
+//!   without a cast; MySQL / SQLite cast implicitly. Pass an integer
+//!   column or wrap in a cast on PG when precision matters.
+//!
+//! ## Composition with `F()` + arithmetic
+//!
+//! Every builder takes `impl Into<Expr>`, so [`F`], primitives, and
+//! [`SqlValue`] all pass directly:
+//!
+//! ```ignore
+//! upper(concat([F("first"), " ".into(), F("last")]))
+//! //    └─── concat returns Expr ──┘
+//! ```
+//!
+//! [`F`]: crate::core::F
+//! [`SqlValue`]: crate::core::SqlValue
+//! [`Expr::Function`]: crate::core::Expr::Function
+
+use super::expr::{Expr, ScalarFn};
+
+// ---------- Unary functions ----------
+
+/// `LOWER(arg)`.
+#[must_use]
+pub fn lower(arg: impl Into<Expr>) -> Expr {
+    unary(ScalarFn::Lower, arg)
+}
+
+/// `UPPER(arg)`.
+#[must_use]
+pub fn upper(arg: impl Into<Expr>) -> Expr {
+    unary(ScalarFn::Upper, arg)
+}
+
+/// `LENGTH(arg)`. See module docs for char-vs-byte semantics.
+#[must_use]
+pub fn length(arg: impl Into<Expr>) -> Expr {
+    unary(ScalarFn::Length, arg)
+}
+
+/// `TRIM(arg)` — strip leading and trailing whitespace.
+#[must_use]
+pub fn trim(arg: impl Into<Expr>) -> Expr {
+    unary(ScalarFn::Trim, arg)
+}
+
+/// `LTRIM(arg)` — strip leading whitespace.
+#[must_use]
+pub fn ltrim(arg: impl Into<Expr>) -> Expr {
+    unary(ScalarFn::LTrim, arg)
+}
+
+/// `RTRIM(arg)` — strip trailing whitespace.
+#[must_use]
+pub fn rtrim(arg: impl Into<Expr>) -> Expr {
+    unary(ScalarFn::RTrim, arg)
+}
+
+/// `ABS(arg)` — absolute value.
+#[must_use]
+pub fn abs(arg: impl Into<Expr>) -> Expr {
+    unary(ScalarFn::Abs, arg)
+}
+
+/// `CEIL(arg)` — ceiling. Emits `CEIL` (PG/SQLite) / `CEILING` (MySQL
+/// alias of CEIL) — the writer picks the dialect-correct token.
+#[must_use]
+pub fn ceil(arg: impl Into<Expr>) -> Expr {
+    unary(ScalarFn::Ceil, arg)
+}
+
+/// `FLOOR(arg)` — floor.
+#[must_use]
+pub fn floor(arg: impl Into<Expr>) -> Expr {
+    unary(ScalarFn::Floor, arg)
+}
+
+// ---------- Binary / 3-ary ----------
+
+/// `ROUND(x)` — round to integer. See [`round_to`] for precision arg.
+#[must_use]
+pub fn round(arg: impl Into<Expr>) -> Expr {
+    unary(ScalarFn::Round, arg)
+}
+
+/// `ROUND(x, n)` — round to `n` decimal places. `n` is typically an
+/// integer literal; pass `0` for integer rounding.
+#[must_use]
+pub fn round_to(arg: impl Into<Expr>, n: impl Into<Expr>) -> Expr {
+    Expr::Function {
+        kind: ScalarFn::Round,
+        args: vec![arg.into(), n.into()],
+    }
+}
+
+/// `SUBSTRING(s, start, length)` — 1-indexed. PG emits the
+/// `FROM…FOR…` form, MySQL/SQLite the comma form. Both produce
+/// identical results.
+#[must_use]
+pub fn substr(s: impl Into<Expr>, start: impl Into<Expr>, length: impl Into<Expr>) -> Expr {
+    Expr::Function {
+        kind: ScalarFn::Substr,
+        args: vec![s.into(), start.into(), length.into()],
+    }
+}
+
+/// `REPLACE(s, from, to)` — replace every non-overlapping match.
+#[must_use]
+pub fn replace(s: impl Into<Expr>, from: impl Into<Expr>, to: impl Into<Expr>) -> Expr {
+    Expr::Function {
+        kind: ScalarFn::Replace,
+        args: vec![s.into(), from.into(), to.into()],
+    }
+}
+
+/// `NULLIF(a, b)` — `NULL` when `a == b`, else `a`.
+#[must_use]
+pub fn nullif(a: impl Into<Expr>, b: impl Into<Expr>) -> Expr {
+    Expr::Function {
+        kind: ScalarFn::NullIf,
+        args: vec![a.into(), b.into()],
+    }
+}
+
+// ---------- Variadic ----------
+
+/// `CONCAT(a, b, …)` — string concatenation. SQLite emits `||`.
+///
+/// Takes `IntoIterator<Item = Expr>`. Array literals work as long as
+/// every element is already an [`Expr`] — call `.into()` on each
+/// non-Expr argument:
+///
+/// ```ignore
+/// concat([F("first").into(), " ".into(), F("last").into()])
+/// ```
+///
+/// (Rust arrays are homogeneous, so a heterogeneous mix of `F` and
+/// `&str` won't infer to a common type. The `.into()` per element is
+/// the price of variadic-arity at the type level.)
+#[must_use]
+pub fn concat<I>(args: I) -> Expr
+where
+    I: IntoIterator<Item = Expr>,
+{
+    variadic(ScalarFn::Concat, args)
+}
+
+/// `COALESCE(a, b, c, …)` — first non-NULL argument.
+/// See [`concat`] re: passing args as already-lifted `Expr`.
+#[must_use]
+pub fn coalesce<I>(args: I) -> Expr
+where
+    I: IntoIterator<Item = Expr>,
+{
+    variadic(ScalarFn::Coalesce, args)
+}
+
+/// `GREATEST(a, b, …)` (PG/MySQL) / `MAX(a, b, …)` scalar (SQLite).
+#[must_use]
+pub fn greatest<I>(args: I) -> Expr
+where
+    I: IntoIterator<Item = Expr>,
+{
+    variadic(ScalarFn::Greatest, args)
+}
+
+/// `LEAST(a, b, …)` (PG/MySQL) / `MIN(a, b, …)` scalar (SQLite).
+#[must_use]
+pub fn least<I>(args: I) -> Expr
+where
+    I: IntoIterator<Item = Expr>,
+{
+    variadic(ScalarFn::Least, args)
+}
+
+// ---------- Internal helpers ----------
+
+fn unary(kind: ScalarFn, arg: impl Into<Expr>) -> Expr {
+    Expr::Function {
+        kind,
+        args: vec![arg.into()],
+    }
+}
+
+fn variadic<I>(kind: ScalarFn, args: I) -> Expr
+where
+    I: IntoIterator<Item = Expr>,
+{
+    Expr::Function {
+        kind,
+        args: args.into_iter().collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{SqlValue, F};
+
+    #[test]
+    fn unary_builds_function_with_one_arg() {
+        let e = lower(F("name"));
+        let Expr::Function { kind, args } = e else {
+            panic!("expected Function variant")
+        };
+        assert_eq!(kind, ScalarFn::Lower);
+        assert_eq!(args, vec![Expr::Column("name")]);
+    }
+
+    #[test]
+    fn variadic_collects_iter() {
+        let e = concat([F("a").into(), " ".into(), F("b").into()]);
+        let Expr::Function { kind, args } = e else {
+            panic!()
+        };
+        assert_eq!(kind, ScalarFn::Concat);
+        assert_eq!(args.len(), 3);
+        assert_eq!(args[0], Expr::Column("a"));
+        assert_eq!(args[1], Expr::Literal(SqlValue::String(" ".into())));
+        assert_eq!(args[2], Expr::Column("b"));
+    }
+
+    #[test]
+    fn coalesce_variadic_takes_vec() {
+        let args: Vec<Expr> = vec![F("a").into(), F("b").into(), 0_i32.into()];
+        let e = coalesce(args);
+        let Expr::Function { kind, args } = e else {
+            panic!()
+        };
+        assert_eq!(kind, ScalarFn::Coalesce);
+        assert_eq!(args.len(), 3);
+    }
+
+    #[test]
+    fn substr_is_3ary() {
+        let e = substr(F("title"), 1_i64, 10_i64);
+        let Expr::Function { kind, args } = e else {
+            panic!()
+        };
+        assert_eq!(kind, ScalarFn::Substr);
+        assert_eq!(args.len(), 3);
+    }
+
+    #[test]
+    fn round_one_arg_vs_two() {
+        let e = round(F("score"));
+        let Expr::Function { args, .. } = e else {
+            panic!()
+        };
+        assert_eq!(args.len(), 1);
+
+        let e = round_to(F("score"), 2_i32);
+        let Expr::Function { args, .. } = e else {
+            panic!()
+        };
+        assert_eq!(args.len(), 2);
+    }
+
+    #[test]
+    fn functions_compose_via_into_expr() {
+        // upper(concat([first, " ", last]))
+        let e = upper(concat([F("first").into(), " ".into(), F("last").into()]));
+        let Expr::Function {
+            kind: outer_kind,
+            args: outer_args,
+        } = e
+        else {
+            panic!()
+        };
+        assert_eq!(outer_kind, ScalarFn::Upper);
+        assert_eq!(outer_args.len(), 1);
+        let Expr::Function {
+            kind: inner_kind, ..
+        } = &outer_args[0]
+        else {
+            panic!("inner should be a Function")
+        };
+        assert_eq!(*inner_kind, ScalarFn::Concat);
+    }
+}

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -7,6 +7,7 @@ mod column;
 mod error;
 mod expr;
 mod field_type;
+pub mod funcs;
 mod query;
 mod schema;
 mod validate;
@@ -14,7 +15,7 @@ mod value;
 
 pub use column::{Column, TypedAssignment, TypedExpr, TypedFilter};
 pub use error::QueryError;
-pub use expr::{BinOp, Expr, F};
+pub use expr::{BinOp, Expr, ScalarFn, F};
 pub use field_type::FieldType;
 pub use query::{
     AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ColumnFilter,

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -240,6 +240,12 @@ fn validate_expr_columns(model: &'static ModelSchema, expr: &Expr) -> Result<(),
             validate_expr_columns(model, left)?;
             validate_expr_columns(model, right)
         }
+        Expr::Function { args, .. } => {
+            for a in args {
+                validate_expr_columns(model, a)?;
+            }
+            Ok(())
+        }
     }
 }
 

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -615,6 +615,12 @@ fn validate_expr_columns_in_model(
             validate_expr_columns_in_model(model, left)?;
             validate_expr_columns_in_model(model, right)
         }
+        Expr::Function { args, .. } => {
+            for a in args {
+                validate_expr_columns_in_model(model, a)?;
+            }
+            Ok(())
+        }
     }
 }
 

--- a/crates/rustango/src/sql/error.rs
+++ b/crates/rustango/src/sql/error.rs
@@ -118,6 +118,20 @@ pub enum SqlError {
         op: &'static str,
         dialect: &'static str,
     },
+
+    /// A scalar function (issue #2) was built with the wrong number of
+    /// arguments — e.g. `Substr` with 2 args, `NullIf` with 3, or
+    /// `Concat` with 0. The builder-side API constrains arity for
+    /// fixed-arity calls (compile error), but the IR is permissive
+    /// enough that hand-rolled `Expr::Function { args: vec![...] }`
+    /// could trip this — the emitter catches it before reaching the
+    /// database with a confusing parse error.
+    #[error("function `{func}` expects {expected} arg(s), got {got}")]
+    FunctionArityMismatch {
+        func: &'static str,
+        expected: &'static str,
+        got: usize,
+    },
 }
 
 /// Raised while compiling, writing, or executing a query end-to-end.

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -500,13 +500,13 @@ fn write_function(
 ) -> Result<(), SqlError> {
     use crate::core::ScalarFn as F;
     match kind {
-        // -------- text: simple FN(arg) --------
-        F::Lower => write_call(b, "LOWER", args),
-        F::Upper => write_call(b, "UPPER", args),
-        F::Length => write_call(b, "LENGTH", args),
-        F::Trim => write_call(b, "TRIM", args),
-        F::LTrim => write_call(b, "LTRIM", args),
-        F::RTrim => write_call(b, "RTRIM", args),
+        // -------- text: simple FN(arg) — unary, arity-checked --------
+        F::Lower => write_call_unary(b, "LOWER", args),
+        F::Upper => write_call_unary(b, "UPPER", args),
+        F::Length => write_call_unary(b, "LENGTH", args),
+        F::Trim => write_call_unary(b, "TRIM", args),
+        F::LTrim => write_call_unary(b, "LTRIM", args),
+        F::RTrim => write_call_unary(b, "RTRIM", args),
 
         // -------- text: 3-ary FN(s, from, to) --------
         F::Replace => {
@@ -578,14 +578,14 @@ fn write_function(
             }
         }
 
-        // -------- math: simple unary --------
-        F::Abs => write_call(b, "ABS", args),
-        F::Floor => write_call(b, "FLOOR", args),
+        // -------- math: simple unary, arity-checked --------
+        F::Abs => write_call_unary(b, "ABS", args),
+        F::Floor => write_call_unary(b, "FLOOR", args),
         F::Ceil => {
             // MySQL accepts both `CEIL` and `CEILING`; PG / SQLite use
             // `CEIL` (SQLite 3.35+). Emit `CEIL` everywhere for the
             // narrowest portable token.
-            write_call(b, "CEIL", args)
+            write_call_unary(b, "CEIL", args)
         }
         F::Round => {
             // 1- or 2-ary. The shape is identical across PG / MySQL /
@@ -621,8 +621,16 @@ fn write_function(
                 });
             }
             // SQLite has no GREATEST keyword. Its scalar `MAX(a, b, …)`
-            // (distinct from the aggregate `MAX(col)` — disambiguated
-            // by argument count) is the portable equivalent.
+            // form requires 2+ args; with 1 arg SQLite parses `MAX(x)` as
+            // the AGGREGATE form, which is a misuse-of-aggregate error
+            // inside `UPDATE SET` and the wrong semantic in `WHERE`.
+            // Surface a clear error rather than emit silently-wrong SQL.
+            if b.d.name() == "sqlite" && args.len() == 1 {
+                return Err(SqlError::OpNotSupportedInDialect {
+                    op: "GREATEST with 1 argument (SQLite collides with the aggregate MAX)",
+                    dialect: "sqlite",
+                });
+            }
             let name = if b.d.name() == "sqlite" {
                 "MAX"
             } else {
@@ -636,6 +644,13 @@ fn write_function(
                     func: "LEAST",
                     expected: ">= 1",
                     got: 0,
+                });
+            }
+            // See `Greatest` above for the SQLite 1-arg rationale.
+            if b.d.name() == "sqlite" && args.len() == 1 {
+                return Err(SqlError::OpNotSupportedInDialect {
+                    op: "LEAST with 1 argument (SQLite collides with the aggregate MIN)",
+                    dialect: "sqlite",
                 });
             }
             let name = if b.d.name() == "sqlite" {
@@ -673,6 +688,28 @@ fn write_call(b: &mut Sql<'_>, name: &str, args: &[crate::core::Expr]) -> Result
     }
     b.sql.push(')');
     Ok(())
+}
+
+/// `write_call` with an arity-1 assertion. Used for unary functions
+/// (LOWER, UPPER, LENGTH, TRIM, LTRIM, RTRIM, ABS, CEIL, FLOOR) so a
+/// hand-rolled `Expr::Function { args: vec![] }` or `vec![a, b]` fails
+/// at emit-time with a clear error rather than reaching the database
+/// with malformed SQL like `LOWER()` or `LENGTH(a, b)`. The public
+/// builder API is type-locked to a single arg, so this only fires for
+/// callers that construct the IR directly.
+fn write_call_unary(
+    b: &mut Sql<'_>,
+    name: &'static str,
+    args: &[crate::core::Expr],
+) -> Result<(), SqlError> {
+    if args.len() != 1 {
+        return Err(SqlError::FunctionArityMismatch {
+            func: name,
+            expected: "1",
+            got: args.len(),
+        });
+    }
+    write_call(b, name, args)
 }
 
 // ====================================================================

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -484,7 +484,195 @@ fn write_expr(
             b.sql.push(')');
             Ok(())
         }
+        Expr::Function { kind, args } => write_function(b, *kind, args),
     }
+}
+
+/// Emit a scalar function call. Most variants are straight `FN(args…)`
+/// across all three dialects; the divergent ones (`Concat` on SQLite,
+/// `Greatest`/`Least` on SQLite, `Substr` PG `FROM…FOR…` form) get
+/// special-cased.
+#[allow(clippy::too_many_lines)] // Per-fn arms are inherently linear.
+fn write_function(
+    b: &mut Sql<'_>,
+    kind: crate::core::ScalarFn,
+    args: &[crate::core::Expr],
+) -> Result<(), SqlError> {
+    use crate::core::ScalarFn as F;
+    match kind {
+        // -------- text: simple FN(arg) --------
+        F::Lower => write_call(b, "LOWER", args),
+        F::Upper => write_call(b, "UPPER", args),
+        F::Length => write_call(b, "LENGTH", args),
+        F::Trim => write_call(b, "TRIM", args),
+        F::LTrim => write_call(b, "LTRIM", args),
+        F::RTrim => write_call(b, "RTRIM", args),
+
+        // -------- text: 3-ary FN(s, from, to) --------
+        F::Replace => {
+            if args.len() != 3 {
+                return Err(SqlError::FunctionArityMismatch {
+                    func: "REPLACE",
+                    expected: "3",
+                    got: args.len(),
+                });
+            }
+            write_call(b, "REPLACE", args)
+        }
+
+        // -------- CONCAT: PG/MySQL native, SQLite `||` --------
+        F::Concat => {
+            if args.is_empty() {
+                return Err(SqlError::FunctionArityMismatch {
+                    func: "CONCAT",
+                    expected: ">= 1",
+                    got: 0,
+                });
+            }
+            if b.d.name() == "sqlite" {
+                // `||` chain. Parenthesize so precedence is unambiguous
+                // when wrapped in another expression.
+                b.sql.push('(');
+                let mut first = true;
+                for a in args {
+                    if !first {
+                        b.sql.push_str(" || ");
+                    }
+                    first = false;
+                    write_expr(b, a, None)?;
+                }
+                b.sql.push(')');
+                Ok(())
+            } else {
+                write_call(b, "CONCAT", args)
+            }
+        }
+
+        // -------- SUBSTR: PG uses `FROM…FOR…`, MySQL/SQLite use commas --------
+        F::Substr => {
+            if args.len() != 3 {
+                return Err(SqlError::FunctionArityMismatch {
+                    func: "SUBSTRING",
+                    expected: "3",
+                    got: args.len(),
+                });
+            }
+            if b.d.name() == "postgres" {
+                b.sql.push_str("SUBSTRING(");
+                write_expr(b, &args[0], None)?;
+                b.sql.push_str(" FROM ");
+                write_expr(b, &args[1], None)?;
+                b.sql.push_str(" FOR ");
+                write_expr(b, &args[2], None)?;
+                b.sql.push(')');
+                Ok(())
+            } else {
+                // MySQL spells it SUBSTRING; SQLite spells it substr.
+                // Both accept the comma form.
+                let name = if b.d.name() == "mysql" {
+                    "SUBSTRING"
+                } else {
+                    "SUBSTR"
+                };
+                write_call(b, name, args)
+            }
+        }
+
+        // -------- math: simple unary --------
+        F::Abs => write_call(b, "ABS", args),
+        F::Floor => write_call(b, "FLOOR", args),
+        F::Ceil => {
+            // MySQL accepts both `CEIL` and `CEILING`; PG / SQLite use
+            // `CEIL` (SQLite 3.35+). Emit `CEIL` everywhere for the
+            // narrowest portable token.
+            write_call(b, "CEIL", args)
+        }
+        F::Round => {
+            // 1- or 2-ary. The shape is identical across PG / MySQL /
+            // SQLite at the SQL surface; precision-arg type semantics
+            // diverge (PG `numeric` only), documented at the builder.
+            if args.is_empty() || args.len() > 2 {
+                return Err(SqlError::FunctionArityMismatch {
+                    func: "ROUND",
+                    expected: "1 or 2",
+                    got: args.len(),
+                });
+            }
+            write_call(b, "ROUND", args)
+        }
+
+        // -------- comparison / NULL --------
+        F::Coalesce => {
+            if args.is_empty() {
+                return Err(SqlError::FunctionArityMismatch {
+                    func: "COALESCE",
+                    expected: ">= 1",
+                    got: 0,
+                });
+            }
+            write_call(b, "COALESCE", args)
+        }
+        F::Greatest => {
+            if args.is_empty() {
+                return Err(SqlError::FunctionArityMismatch {
+                    func: "GREATEST",
+                    expected: ">= 1",
+                    got: 0,
+                });
+            }
+            // SQLite has no GREATEST keyword. Its scalar `MAX(a, b, …)`
+            // (distinct from the aggregate `MAX(col)` — disambiguated
+            // by argument count) is the portable equivalent.
+            let name = if b.d.name() == "sqlite" {
+                "MAX"
+            } else {
+                "GREATEST"
+            };
+            write_call(b, name, args)
+        }
+        F::Least => {
+            if args.is_empty() {
+                return Err(SqlError::FunctionArityMismatch {
+                    func: "LEAST",
+                    expected: ">= 1",
+                    got: 0,
+                });
+            }
+            let name = if b.d.name() == "sqlite" {
+                "MIN"
+            } else {
+                "LEAST"
+            };
+            write_call(b, name, args)
+        }
+        F::NullIf => {
+            if args.len() != 2 {
+                return Err(SqlError::FunctionArityMismatch {
+                    func: "NULLIF",
+                    expected: "2",
+                    got: args.len(),
+                });
+            }
+            write_call(b, "NULLIF", args)
+        }
+    }
+}
+
+/// Standard `NAME(arg, arg, …)` emit. Used by every function variant
+/// whose dialect emission is identical across PG / MySQL / SQLite.
+fn write_call(b: &mut Sql<'_>, name: &str, args: &[crate::core::Expr]) -> Result<(), SqlError> {
+    b.sql.push_str(name);
+    b.sql.push('(');
+    let mut first = true;
+    for a in args {
+        if !first {
+            b.sql.push_str(", ");
+        }
+        first = false;
+        write_expr(b, a, None)?;
+    }
+    b.sql.push(')');
+    Ok(())
 }
 
 // ====================================================================

--- a/crates/rustango/tests/database_functions.rs
+++ b/crates/rustango/tests/database_functions.rs
@@ -1,0 +1,388 @@
+//! Tri-dialect emission tests for the database functions DSL (issue
+//! #2). Pins the SQL each backend emits for every function in the v1
+//! set and the divergent shapes:
+//!
+//! - `Concat` → `CONCAT(a, b)` on PG/MySQL, `(a || b)` on SQLite.
+//! - `Substr` → `SUBSTRING(s FROM start FOR len)` on PG,
+//!   `SUBSTRING(s, start, len)` on MySQL, `SUBSTR(...)` on SQLite.
+//! - `Greatest` / `Least` → `MAX` / `MIN` scalar on SQLite, native
+//!   keyword on PG / MySQL.
+
+use rustango::core::funcs::{
+    abs, ceil, coalesce, concat, floor, greatest, least, length, lower, ltrim, nullif, replace,
+    round, round_to, rtrim, substr, trim, upper,
+};
+use rustango::core::{
+    Assignment, ColumnFilter, Expr, Filter, Model as _, Op, SqlValue, UpdateQuery, WhereExpr, F,
+};
+use rustango::sql::{Dialect, MySql, Postgres, SqlError, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "fnq")]
+#[allow(dead_code)]
+pub struct Row {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 200)]
+    name: String,
+    score: i64,
+}
+
+// ---------- Helper: assert UPDATE SET emits an expr literally ----------
+
+fn update_set_expr(value: Expr) -> UpdateQuery {
+    UpdateQuery {
+        model: Row::SCHEMA,
+        set: vec![Assignment {
+            column: "name",
+            value,
+        }],
+        where_clause: WhereExpr::Predicate(Filter {
+            column: "id",
+            op: Op::Eq,
+            value: SqlValue::I64(1),
+        }),
+    }
+}
+
+// ---------- Text: simple unary ----------
+
+#[test]
+fn lower_emits_lower_fn_in_all_dialects() {
+    let q = update_set_expr(lower(F("name")));
+    assert!(Postgres
+        .compile_update(&q)
+        .unwrap()
+        .sql
+        .contains(r#"SET "name" = LOWER("name")"#));
+    assert!(MySql
+        .compile_update(&q)
+        .unwrap()
+        .sql
+        .contains("SET `name` = LOWER(`name`)"));
+    assert!(Sqlite
+        .compile_update(&q)
+        .unwrap()
+        .sql
+        .contains(r#"SET "name" = LOWER("name")"#));
+}
+
+#[test]
+fn upper_emits_upper_fn() {
+    let q = update_set_expr(upper(F("name")));
+    assert!(Postgres
+        .compile_update(&q)
+        .unwrap()
+        .sql
+        .contains(r#"= UPPER("name")"#));
+}
+
+#[test]
+fn length_emits_length_fn() {
+    let q = update_set_expr(length(F("name")));
+    assert!(Postgres
+        .compile_update(&q)
+        .unwrap()
+        .sql
+        .contains(r#"= LENGTH("name")"#));
+}
+
+#[test]
+fn trim_variants() {
+    let pg = Postgres;
+    let q1 = update_set_expr(trim(F("name")));
+    let q2 = update_set_expr(ltrim(F("name")));
+    let q3 = update_set_expr(rtrim(F("name")));
+    assert!(pg.compile_update(&q1).unwrap().sql.contains("TRIM("));
+    assert!(pg.compile_update(&q2).unwrap().sql.contains("LTRIM("));
+    assert!(pg.compile_update(&q3).unwrap().sql.contains("RTRIM("));
+}
+
+// ---------- Concat: PG/MySQL CONCAT vs SQLite || ----------
+
+#[test]
+fn pg_concat_emits_native_call() {
+    let q = update_set_expr(concat([F("name").into(), " ".into(), F("name").into()]));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"= CONCAT("name", $1, "name")"#),
+        "got: {}",
+        stmt.sql
+    );
+    assert_eq!(
+        stmt.params,
+        vec![SqlValue::String(" ".into()), SqlValue::I64(1)]
+    );
+}
+
+#[test]
+fn mysql_concat_emits_native_call() {
+    let q = update_set_expr(concat([F("name").into(), " ".into(), F("name").into()]));
+    let stmt = MySql.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains("= CONCAT(`name`, ?, `name`)"),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn sqlite_concat_falls_back_to_double_pipe() {
+    let q = update_set_expr(concat([F("name").into(), " ".into(), F("name").into()]));
+    let stmt = Sqlite.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"= ("name" || ? || "name")"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn empty_concat_returns_arity_error() {
+    let q = update_set_expr(Expr::Function {
+        kind: rustango::core::ScalarFn::Concat,
+        args: vec![],
+    });
+    let err = Postgres.compile_update(&q).unwrap_err();
+    assert!(
+        matches!(err, SqlError::FunctionArityMismatch { func: "CONCAT", .. }),
+        "expected arity error, got {err:?}"
+    );
+}
+
+// ---------- Substr: PG FROM…FOR vs MySQL/SQLite commas ----------
+
+#[test]
+fn pg_substr_emits_from_for_form() {
+    let q = update_set_expr(substr(F("name"), 1_i64, 5_i64));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"= SUBSTRING("name" FROM $1 FOR $2)"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn mysql_substr_emits_comma_form_with_substring() {
+    let q = update_set_expr(substr(F("name"), 1_i64, 5_i64));
+    let stmt = MySql.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains("= SUBSTRING(`name`, ?, ?)"),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn sqlite_substr_emits_comma_form_with_substr() {
+    let q = update_set_expr(substr(F("name"), 1_i64, 5_i64));
+    let stmt = Sqlite.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"= SUBSTR("name", ?, ?)"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Replace ----------
+
+#[test]
+fn replace_emits_3_arg_call() {
+    let q = update_set_expr(replace(F("name"), "foo", "bar"));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"= REPLACE("name", $1, $2)"#),
+        "got: {}",
+        stmt.sql
+    );
+    assert_eq!(
+        stmt.params,
+        vec![
+            SqlValue::String("foo".into()),
+            SqlValue::String("bar".into()),
+            SqlValue::I64(1),
+        ],
+    );
+}
+
+// ---------- Math ----------
+
+#[test]
+fn abs_emits_abs_fn() {
+    let q = update_set_expr(abs(F("score")));
+    assert!(Postgres
+        .compile_update(&q)
+        .unwrap()
+        .sql
+        .contains(r#"= ABS("score")"#));
+}
+
+#[test]
+fn ceil_floor_emit_correct_tokens() {
+    let q1 = update_set_expr(ceil(F("score")));
+    let q2 = update_set_expr(floor(F("score")));
+    assert!(Postgres.compile_update(&q1).unwrap().sql.contains("CEIL("));
+    assert!(Postgres.compile_update(&q2).unwrap().sql.contains("FLOOR("));
+}
+
+#[test]
+fn round_one_arg_works() {
+    let q = update_set_expr(round(F("score")));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"= ROUND("score")"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn round_two_arg_works() {
+    let q = update_set_expr(round_to(F("score"), 2_i32));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"= ROUND("score", $1)"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Coalesce / Greatest / Least / NullIf ----------
+
+#[test]
+fn coalesce_emits_all_args() {
+    let q = update_set_expr(coalesce([F("name").into(), "fallback".into()]));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"= COALESCE("name", $1)"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn greatest_on_pg_mysql_emits_native_keyword() {
+    let q = update_set_expr(greatest([F("score").into(), 5_i64.into(), 10_i64.into()]));
+    assert!(Postgres
+        .compile_update(&q)
+        .unwrap()
+        .sql
+        .contains("GREATEST("));
+    assert!(MySql.compile_update(&q).unwrap().sql.contains("GREATEST("));
+}
+
+#[test]
+fn greatest_on_sqlite_falls_back_to_max_scalar() {
+    let q = update_set_expr(greatest([F("score").into(), 5_i64.into(), 10_i64.into()]));
+    let stmt = Sqlite.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"= MAX("score", ?, ?)"#),
+        "SQLite should use scalar MAX, got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn least_on_sqlite_falls_back_to_min_scalar() {
+    let q = update_set_expr(least([F("score").into(), 5_i64.into()]));
+    let stmt = Sqlite.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"= MIN("score", ?)"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn nullif_emits_2_arg_call() {
+    let q = update_set_expr(nullif(F("name"), ""));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"= NULLIF("name", $1)"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Arity error paths ----------
+
+#[test]
+fn substr_with_wrong_arity_errors() {
+    let q = update_set_expr(Expr::Function {
+        kind: rustango::core::ScalarFn::Substr,
+        args: vec![F("name").into(), 1_i64.into()], // only 2 args
+    });
+    let err = Postgres.compile_update(&q).unwrap_err();
+    assert!(matches!(
+        err,
+        SqlError::FunctionArityMismatch {
+            func: "SUBSTRING",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn nullif_with_wrong_arity_errors() {
+    let q = update_set_expr(Expr::Function {
+        kind: rustango::core::ScalarFn::NullIf,
+        args: vec![F("name").into()], // only 1
+    });
+    let err = Postgres.compile_update(&q).unwrap_err();
+    assert!(matches!(
+        err,
+        SqlError::FunctionArityMismatch { func: "NULLIF", .. }
+    ));
+}
+
+// ---------- Composition ----------
+
+#[test]
+fn functions_compose_with_arithmetic() {
+    // upper(concat([F("name"), " ", F("name")])) + literal score
+    // → wrapped properly with the BinOp parens.
+    let inner = upper(concat([F("name").into(), " ".into(), F("name").into()]));
+    let q = update_set_expr(inner);
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"= UPPER(CONCAT("name", $1, "name"))"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn function_in_where_column_compare() {
+    // Build a SELECT … WHERE name = LOWER("other_col"). Use the
+    // QuerySet helper to get a SelectQuery, swap the where clause.
+    let mut q = Row::objects().compile().unwrap();
+    q.where_clause = WhereExpr::ColumnCompare(ColumnFilter {
+        column: "name",
+        op: Op::Eq,
+        rhs: lower(F("name")),
+    });
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"WHERE "name" = LOWER("name")"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Schema validation: column refs inside function args ----------
+
+#[test]
+fn unknown_column_inside_function_is_caught_at_compile() {
+    let err = Row::objects()
+        .update()
+        .set_expr("name", upper(F("nope_nope")))
+        .compile()
+        .unwrap_err();
+    assert!(
+        matches!(err, rustango::core::QueryError::UnknownField { ref field, .. }
+                 if field == "nope_nope"),
+        "expected UnknownField for F() arg inside function, got: {err:?}"
+    );
+}

--- a/crates/rustango/tests/database_functions.rs
+++ b/crates/rustango/tests/database_functions.rs
@@ -373,6 +373,108 @@ fn function_in_where_column_compare() {
 
 // ---------- Schema validation: column refs inside function args ----------
 
+// ---------- Arity enforcement on unary functions (post-review fix A) ----------
+//
+// The public builder API (`lower(arg)`, `upper(arg)`, …) is type-
+// locked to one argument, but the underlying `Expr::Function` variant
+// is permissive — anyone constructing the IR by hand (proc-macro
+// codegen, future feature combos) could pass 0 or 2+ args. The writer
+// catches that with `FunctionArityMismatch` rather than emitting
+// malformed SQL.
+
+#[test]
+fn unary_function_with_zero_args_errors() {
+    for (name, kind) in [
+        ("LOWER", rustango::core::ScalarFn::Lower),
+        ("UPPER", rustango::core::ScalarFn::Upper),
+        ("LENGTH", rustango::core::ScalarFn::Length),
+        ("TRIM", rustango::core::ScalarFn::Trim),
+        ("LTRIM", rustango::core::ScalarFn::LTrim),
+        ("RTRIM", rustango::core::ScalarFn::RTrim),
+        ("ABS", rustango::core::ScalarFn::Abs),
+        ("CEIL", rustango::core::ScalarFn::Ceil),
+        ("FLOOR", rustango::core::ScalarFn::Floor),
+    ] {
+        let q = update_set_expr(Expr::Function { kind, args: vec![] });
+        let err = Postgres.compile_update(&q).unwrap_err();
+        assert!(
+            matches!(err, SqlError::FunctionArityMismatch { func, expected: "1", got: 0 } if func == name),
+            "expected arity-1 error for {name}, got {err:?}",
+        );
+    }
+}
+
+#[test]
+fn unary_function_with_two_args_errors() {
+    let q = update_set_expr(Expr::Function {
+        kind: rustango::core::ScalarFn::Lower,
+        args: vec![F("name").into(), F("name").into()],
+    });
+    let err = Postgres.compile_update(&q).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            SqlError::FunctionArityMismatch {
+                func: "LOWER",
+                expected: "1",
+                got: 2
+            }
+        ),
+        "expected arity error, got {err:?}",
+    );
+}
+
+// ---------- SQLite Greatest/Least with 1 arg (post-review fix B) ----------
+//
+// SQLite's `MAX`/`MIN` are overloaded: 2+ args is the scalar form
+// (semantically equivalent to PG `GREATEST`/`LEAST`); a single arg
+// switches to the aggregate form, which is wrong in `UPDATE SET` and
+// in non-aggregating `WHERE` predicates. The writer rejects the 1-arg
+// SQLite case rather than emit `MAX(x)` and surprise the user with an
+// aggregate-misuse error at execution time.
+
+#[test]
+fn sqlite_greatest_with_one_arg_returns_op_not_supported() {
+    let q = update_set_expr(greatest([F("score").into()]));
+    let err = Sqlite.compile_update(&q).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            SqlError::OpNotSupportedInDialect {
+                dialect: "sqlite",
+                ..
+            }
+        ),
+        "expected OpNotSupportedInDialect on SQLite, got {err:?}",
+    );
+}
+
+#[test]
+fn sqlite_least_with_one_arg_returns_op_not_supported() {
+    let q = update_set_expr(least([F("score").into()]));
+    let err = Sqlite.compile_update(&q).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            SqlError::OpNotSupportedInDialect {
+                dialect: "sqlite",
+                ..
+            }
+        ),
+        "expected OpNotSupportedInDialect on SQLite, got {err:?}",
+    );
+}
+
+#[test]
+fn pg_mysql_greatest_with_one_arg_still_emits() {
+    // PG/MySQL treat `GREATEST(x)` as a legal no-op returning x. Only
+    // SQLite has the aggregate collision — keep the cross-dialect
+    // behaviour asymmetric only where the underlying engine forces it.
+    let q = update_set_expr(greatest([F("score").into()]));
+    assert!(Postgres.compile_update(&q).is_ok());
+    assert!(MySql.compile_update(&q).is_ok());
+}
+
 #[test]
 fn unknown_column_inside_function_is_caught_at_compile() {
     let err = Row::objects()

--- a/crates/rustango/tests/database_functions_live.rs
+++ b/crates/rustango/tests/database_functions_live.rs
@@ -1,0 +1,233 @@
+#![cfg(feature = "postgres")]
+//! Live test for the database functions DSL (issue #2). Pins that
+//! the SQL each builder emits actually executes against a real PG
+//! database — catches per-function quoting / cast / NULL-handling
+//! bugs the emit-only tests can't.
+//!
+//! Skips silently when `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::core::funcs::{coalesce, concat, length, lower, round_to, upper};
+use rustango::core::F;
+use rustango::sql::{sqlx, Auto, Fetcher, Updater};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "fn_demo")]
+#[allow(dead_code)]
+pub struct FnDemo {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 100)]
+    pub name: String,
+    pub score: f64,
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "fn_demo" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "fn_demo" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "name" VARCHAR(100) NOT NULL,
+            "score" DOUBLE PRECISION NOT NULL
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn lower_upper_length_update_round_trip() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let mut row = FnDemo {
+        id: Auto::default(),
+        name: "Mixed Case Name".into(),
+        score: 0.0,
+    };
+    row.insert(&pool).await.unwrap();
+    let id = row.id.get().copied().unwrap();
+
+    // SET name = LOWER(name)
+    FnDemo::objects()
+        .eq("id", id)
+        .update()
+        .set_expr("name", lower(F("name")))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let after: Vec<FnDemo> = FnDemo::objects().eq("id", id).fetch(&pool).await.unwrap();
+    assert_eq!(after[0].name, "mixed case name");
+
+    sqlx::query(r#"DROP TABLE IF EXISTS "fn_demo" CASCADE"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn concat_with_literal_separator_actually_concatenates() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let mut row = FnDemo {
+        id: Auto::default(),
+        name: "prefix".into(),
+        score: 0.0,
+    };
+    row.insert(&pool).await.unwrap();
+    let id = row.id.get().copied().unwrap();
+
+    // SET name = CONCAT(name, '-suffix')
+    FnDemo::objects()
+        .eq("id", id)
+        .update()
+        .set_expr("name", concat([F("name").into(), "-suffix".into()]))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let after: Vec<FnDemo> = FnDemo::objects().eq("id", id).fetch(&pool).await.unwrap();
+    assert_eq!(after[0].name, "prefix-suffix");
+
+    sqlx::query(r#"DROP TABLE IF EXISTS "fn_demo" CASCADE"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn coalesce_picks_first_non_null() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    // Insert a row where name is the empty string (treat as NULL-ish
+    // by NULLIF, but for coalesce we need a literal NULL — manually).
+    sqlx::query(r#"INSERT INTO "fn_demo" ("name", "score") VALUES ('keep', 1.0)"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // SET name = COALESCE(name, 'fallback')
+    // Since name = 'keep' (non-null), the result should still be 'keep'.
+    FnDemo::objects()
+        .update()
+        .set_expr("name", coalesce([F("name").into(), "fallback".into()]))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let after: Vec<FnDemo> = FnDemo::objects().fetch(&pool).await.unwrap();
+    assert_eq!(after[0].name, "keep");
+
+    sqlx::query(r#"DROP TABLE IF EXISTS "fn_demo" CASCADE"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn round_to_two_places_works_on_double() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    sqlx::query(r#"INSERT INTO "fn_demo" ("name", "score") VALUES ('a', 1.23456)"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // ROUND(score::numeric, 2) — PG demands numeric for the 2-arg form.
+    // For this test we instead round to integer via 1-arg ROUND, which
+    // works portably on `double precision`.
+    use rustango::core::funcs::round;
+    FnDemo::objects()
+        .update()
+        .set_expr("score", round(F("score")))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let after: Vec<FnDemo> = FnDemo::objects().fetch(&pool).await.unwrap();
+    assert_eq!(after[0].score, 1.0); // 1.23456 → 1.0
+
+    // round_to also compiles — we don't execute it on `double` (PG
+    // would reject without a cast); just confirm the IR works.
+    let _e = round_to(F("score"), 2_i32);
+
+    sqlx::query(r#"DROP TABLE IF EXISTS "fn_demo" CASCADE"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn nested_function_call_executes() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    sqlx::query(r#"INSERT INTO "fn_demo" ("name", "score") VALUES ('  Padded  ', 0.0)"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // SET name = UPPER(TRIM(name))
+    use rustango::core::funcs::trim;
+    FnDemo::objects()
+        .update()
+        .set_expr("name", upper(trim(F("name"))))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let after: Vec<FnDemo> = FnDemo::objects().fetch(&pool).await.unwrap();
+    assert_eq!(after[0].name, "PADDED");
+
+    // Bonus: LENGTH after the trim is 6, no padding.
+    let lengths: Vec<(i64, i32)> =
+        sqlx::query_as(r#"SELECT id, LENGTH("name")::int FROM "fn_demo""#)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(lengths[0].1, 6);
+
+    // Use the DSL's length() too as a smoke check.
+    let _smoke = length(F("name"));
+
+    sqlx::query(r#"DROP TABLE IF EXISTS "fn_demo" CASCADE"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+}

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -5,6 +5,7 @@ Patterns for the rustango ORM beyond the basics. Most examples assume you alread
 ## Table of contents
 
 - [Querying](#querying)
+- [F() expressions + database functions](#f-expressions--database-functions)
 - [Aggregations](#aggregations)
 - [Joins + select_related](#joins--select_related)
 - [Bulk operations](#bulk-operations)
@@ -90,6 +91,135 @@ let next = Post::objects()
 ```
 
 For HTTP-side cursor pagination, use `ViewSet::cursor_pagination("id")` instead.
+
+---
+
+## F() expressions + database functions
+
+The ORM Expression DSL — `F()` for column references and the `funcs::*` builders for scalar SQL functions — unlocks three patterns that pure value-based `.set()` / `.where_()` can't express:
+
+### 1. Atomic updates (no read-modify-write race)
+
+The classic counter bug — fetch row → mutate field → save — loses updates under concurrency. `F() + 1` collapses the round-trip into a single `UPDATE` statement so the database takes the row lock:
+
+```rust
+use rustango::core::F;
+
+Post::objects()
+    .eq("id", post_id)
+    .update()
+    .set_expr("view_count", F("view_count") + 1_i64)
+    .execute(&pool).await?;
+```
+
+Tri-dialect: emits `views = ("views" + $1)` on PG, ``views = (`views` + ?)`` on MySQL, identical on SQLite. The arithmetic is parenthesized so nested operations stay unambiguous: `F("a") + F("b") * 2`.
+
+Supported operators: `+ - * / %` plus `& | ^ << >>` (bitwise; XOR on SQLite emits a clear `OpNotSupportedInDialect` since SQLite has no XOR symbol).
+
+### 2. Column-vs-column WHERE filters
+
+`Reservation start_date < end_date` (sanity-check row invariant), `Inventory available > reserved` (find rows with capacity):
+
+```rust
+use rustango::core::Column as _;
+
+// `start_date < end_date` for every selected row.
+let valid = Reservation::objects()
+    .where_(Reservation::start_date.lt_expr(F("end_date")))
+    .fetch(&pool).await?;
+
+// Combine with literal predicates.
+let oversold = Inventory::objects()
+    .where_(Inventory::available.lt_expr(F("reserved")))
+    .where_(Inventory::active.eq(true))
+    .fetch(&pool).await?;
+```
+
+The `*_expr` family — `eq_expr`, `ne_expr`, `lt_expr`, `lte_expr`, `gt_expr`, `gte_expr` — mirrors the literal `eq`, `ne`, … methods but takes any `impl Into<Expr>` on the right side: bare column refs (`F("col")`), arithmetic (`F("price") * 2`), or function results (next section).
+
+### 3. Scalar functions — text, math, NULL handling
+
+`rustango::core::funcs` ships builders for the most-used SQL function set. The 17 v1 functions:
+
+| Group | Builders |
+|---|---|
+| **Text** | `lower`, `upper`, `length`, `trim`, `ltrim`, `rtrim`, `concat`, `substr`, `replace` |
+| **Math** | `abs`, `ceil`, `floor`, `round` (1-arg) / `round_to` (2-arg precision) |
+| **NULL** | `coalesce`, `greatest`, `least`, `nullif` |
+
+```rust
+use rustango::core::funcs::{lower, upper, concat, coalesce, trim, abs, round};
+use rustango::core::F;
+
+// Normalize on write.
+User::objects()
+    .eq("id", id)
+    .update()
+    .set_expr("email", lower(trim(F("email"))))
+    .execute(&pool).await?;
+
+// Build a derived column from two FKs + a literal.
+User::objects()
+    .update()
+    .set_expr(
+        "display_name",
+        concat([F("first").into(), " ".into(), F("last").into()]),
+    )
+    .execute(&pool).await?;
+
+// First non-NULL fallback.
+User::objects()
+    .update()
+    .set_expr(
+        "label",
+        coalesce([F("nickname").into(), F("username").into(), "anonymous".into()]),
+    )
+    .execute(&pool).await?;
+
+// Function on the WHERE rhs.
+User::objects()
+    .where_(User::email_norm.eq_expr(lower(F("email_norm"))))
+    .fetch(&pool).await?;
+
+// Functions compose freely — `abs(round(F("score") * 100))` is one Expr.
+Player::objects()
+    .update()
+    .set_expr("score_int", abs(round(F("score") * 100_f64)))
+    .execute(&pool).await?;
+```
+
+### Tri-dialect behavior
+
+Most functions emit identical SQL across PG / MySQL / SQLite. The divergent shapes are handled per-dialect transparently:
+
+| Builder | PG | MySQL | SQLite |
+|---|---|---|---|
+| `concat([a, b])` | `CONCAT(a, b)` | `CONCAT(a, b)` | `(a \|\| b)` |
+| `substr(s, 1, 3)` | `SUBSTRING(s FROM 1 FOR 3)` | `SUBSTRING(s, 1, 3)` | `SUBSTR(s, 1, 3)` |
+| `greatest([a, b])` | `GREATEST(a, b)` | `GREATEST(a, b)` | `MAX(a, b)` scalar |
+| `least([a, b])` | `LEAST(a, b)` | `LEAST(a, b)` | `MIN(a, b)` scalar |
+
+### Variadic builders take `IntoIterator<Item = Expr>`
+
+Rust arrays are homogeneous, so a heterogeneous mix of `F` + `&str` can't infer a common type. Call `.into()` once per element when passing an array literal:
+
+```rust
+concat([F("first").into(), " ".into(), F("last").into()])
+//          ^^^^^^ each element lifted to Expr
+```
+
+Or build a `Vec<Expr>` and pass it directly — same shape, same result.
+
+### Caveats
+
+- **`length` byte-vs-char**: PG returns chars on `TEXT`/`VARCHAR`, MySQL returns **bytes** (use the framework's future `CharLength` builder or wrap in `CHAR_LENGTH` manually if you need cross-dialect char counts).
+- **`round(x, n)` on PG**: PG's 2-arg form requires `numeric`, not `double`. Either pass an integer column or cast the float first; MySQL and SQLite accept either type.
+- **`greatest([single_arg])` / `least([single_arg])` on SQLite**: not supported — SQLite's `MAX(x)` with one arg is the *aggregate*, not the scalar, form. The writer returns `OpNotSupportedInDialect`. PG and MySQL accept the single-arg form as a no-op returning `x`. Wrap with at least one literal to stay portable.
+- **`substr` with negative start**: PG treats negative as "start from char position N" (effectively clamps to 0); MySQL and SQLite treat negative as "count from end". Avoid negative starts in portable code.
+
+### When to reach for a raw SQL escape hatch instead
+
+The function set covers the common case. For features outside v1 — `Cast`, date arithmetic (`Now`, `ExtractYear`, `TruncDate`), full-text search, JSON path operators, hash functions, trig, `Case/When`, `Subquery`/`Exists` — see the [Custom SQL escape hatch](#custom-sql-escape-hatch) section below or wait on issues #3–#7 in the ORM Expression DSL epic, which extend the same `Expr` tree.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #2 — the second issue in the ORM Expression DSL epic. Builds on #1's `Expr` tree to add scalar database function support, the most-used Django ORM piece after `F()`.

## What you get

```rust
use rustango::core::funcs::{lower, upper, concat, substr, replace,
                            trim, ltrim, rtrim, length,
                            abs, ceil, floor, round, round_to,
                            coalesce, greatest, least, nullif};
use rustango::core::F;

// Normalize on write.
.set_expr("name_norm", lower(F("name")))

// Build a display string. Array literals are homogeneous, so each
// arg is `.into()`'d to Expr.
.set_expr("display", concat([F("first").into(), " ".into(), F("last").into()]))

// First non-NULL fallback chain.
.set_expr("nickname", coalesce([F("nickname").into(), F("username").into(), "anon".into()]))

// Math composed with arithmetic from #1.
.set_expr("score", round_to(abs(F("score")), 2_i32))

// Filter against a function result (column-vs-fn compare via #1).
.where_(Post::title.eq_expr(lower(F("title_norm"))))
```

## v1 function set (17)

| Group | Functions |
|---|---|
| **Text** | Lower, Upper, Length, Concat, Substr, Trim, LTrim, RTrim, Replace |
| **Math** | Abs, Ceil, Floor, Round (+ `round_to` for the 2-arg precision form) |
| **Comparison / NULL** | Coalesce, Greatest, Least, NullIf |

**Out of scope (follow-ups):** `Cast` (special syntax + dialect type names diverge), hash functions (MD5, SHA family), trig, Random, Power. Mod already works via `%` BinOp from #1.

## Tri-dialect emission

Most functions are identical across PG / MySQL / SQLite. The divergent shapes are handled by the writer:

| Function | PG | MySQL | SQLite |
|---|---|---|---|
| `Concat` | `CONCAT(a, b)` | `CONCAT(a, b)` | `(a \|\| b)` |
| `Substr` | `SUBSTRING(s FROM a FOR n)` | `SUBSTRING(s, a, n)` | `SUBSTR(s, a, n)` |
| `Greatest` | `GREATEST(a, b)` | `GREATEST(a, b)` | `MAX(a, b)` scalar |
| `Least` | `LEAST(a, b)` | `LEAST(a, b)` | `MIN(a, b)` scalar |
| Everything else | identical | identical | identical |

Documented per-dialect caveats in the `funcs` module docs (`length` byte-vs-char, `round` precision-arg type on PG, NULL semantics on `Greatest`/`Least`).

## What landed

- **`core/expr.rs`** — new `Expr::Function { kind, args }` variant + `ScalarFn` enum (15 cases — `Round` handles 1- and 2-arg via `args.len()`).
- **`core/funcs.rs`** (new) — 17 public builder functions. Unary fns take `impl Into<Expr>`; variadic fns take `IntoIterator<Item = Expr>` (callers `.into()` per array element — Rust arrays are homogeneous, so heterogeneous `F` + `&str` can't infer to a common type).
- **`sql/writers.rs`** — new `write_function` dispatcher with per-dialect arms for Concat / Substr / Greatest / Least; `write_call` helper for the universal-shape functions.
- **`sql/error.rs`** — new `SqlError::FunctionArityMismatch { func, expected, got }` for hand-rolled IR with bad arg counts.
- **Validation walks** — `validate_expr_columns` and `validate_expr_columns_in_model` recurse into `Function.args` so a typo'd column inside a function call is schema-checked at `compile()` time.

## Tests

- **6 unit** in `core::funcs::tests` — builder arity, variadic collect, composition.
- **31 tri-dialect emission** in `tests/database_functions.rs` — exact SQL output per dialect including divergent shapes + arity-error paths (5 added post-review for the unary-arity + SQLite-1-arg-Greatest/Least guardrails).
- **5 live PG** in `tests/database_functions_live.rs` — emitted SQL actually executes round-trip: `lower(name)` updates a row, `concat` with literal separator, `coalesce` non-null passthrough, `round` on `double`, nested `upper(trim(name))`.

```
cargo test -p rustango --lib --features tenancy                          → 1469 passed (+6 funcs)
cargo test -p rustango --features tenancy,mysql,sqlite --test database_functions
                                                                          → 31 passed
DATABASE_URL=... cargo test -p rustango --features tenancy --test database_functions_live
                                                                          → 5 passed
cargo check --no-default-features --features sqlite,tenancy              → clean
cargo check --features mysql,tenancy                                     → clean
```

## Foundation for #3–#7

Same recursive `Expr` + writer extension model. Issue #3 (date functions: `Now`, `ExtractYear`, `TruncDate`) adds `ScalarFn` variants without touching the dispatch frame. #4 (Case/When), #5 (Subquery), #7 (Window functions) add new `Expr` variants alongside `Function`. The infrastructure is in place.

## Test plan

- [x] 1469 lib tests pass.
- [x] 31 tri-dialect F/SQL emission tests pass.
- [x] 5 live PG round-trip tests pass.
- [x] All three feature combos compile.
- [ ] CI green on `postgres_test` + `mysql_live` + `sqlite_live` + `sqlite_litmus`.
