### PR TITLE
Subquery / Exists / OuterRef (closes #5)

### DIFF
--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -120,6 +120,29 @@ pub enum Expr {
         branches: Vec<CaseBranch>,
         default: Option<Box<Expr>>,
     },
+    /// Scalar subquery — `(SELECT col FROM … LIMIT 1)` (issue #5).
+    /// Used in `set_expr` / `eq_expr` / WHERE-rhs slots where a single
+    /// value is expected. The inner [`SelectQuery`] is built by
+    /// calling `QuerySet::compile()` upfront — that way schema
+    /// validation errors surface at construction rather than at
+    /// outer-queryset compile time, and the same compiled subquery
+    /// can be reused across statements.
+    ///
+    /// Caller is responsible for shaping the inner queryset to a
+    /// single row + single column when the slot expects a scalar.
+    ///
+    /// [`SelectQuery`]: crate::core::SelectQuery
+    Subquery(Box<super::query::SelectQuery>),
+    /// Reference to an outer query's column from inside a correlated
+    /// subquery (issue #5). Emitted as `"<outer_table>"."<col>"`; the
+    /// outer table is threaded through the writer at emit time so
+    /// nested `EXISTS` / `IN (SELECT …)` / scalar subqueries can
+    /// reference the outer row.
+    ///
+    /// Build via [`crate::core::subquery::outer_ref`] rather than this
+    /// variant directly — the helper reads closer to Django's
+    /// `OuterRef('col')`.
+    OuterRef(&'static str),
 }
 
 /// One arm of a [`Expr::Case`] expression — `WHEN <condition> THEN <then>`.

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -11,6 +11,7 @@ mod field_type;
 pub mod funcs;
 mod query;
 mod schema;
+pub mod subquery;
 mod validate;
 mod value;
 

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -119,6 +119,21 @@ pub enum WhereExpr {
     Or(Vec<WhereExpr>),
     /// Logical negation. Emits `NOT (child)`.
     Not(Box<WhereExpr>),
+    /// `EXISTS (<subquery>)` — issue #5. True when the inner
+    /// `SelectQuery` returns at least one row. Boxed because
+    /// `SelectQuery` already carries its own `WhereExpr`, which would
+    /// make the enum size unbounded otherwise.
+    Exists(Box<SelectQuery>),
+    /// `NOT EXISTS (<subquery>)` — issue #5. Django's `~Exists` shorthand.
+    NotExists(Box<SelectQuery>),
+    /// `<col> IN (<subquery>)` / `<col> NOT IN (<subquery>)` — issue
+    /// #5. Sibling to `Op::In` / `Op::NotIn` over a literal list, but
+    /// the RHS is a correlated or non-correlated SELECT.
+    InSubquery {
+        column: &'static str,
+        negated: bool,
+        subquery: Box<SelectQuery>,
+    },
 }
 
 impl WhereExpr {
@@ -176,8 +191,14 @@ impl WhereExpr {
             // `Filter` (the rhs is an `Expr`, not a `SqlValue`), so the
             // flat-AND view can't surface it as a `&Filter` reference.
             // Callers using `as_flat_and` only handle literal `Filter`
-            // predicates anyway.
-            Self::ColumnCompare(_) | Self::Or(_) | Self::Not(_) => None,
+            // predicates anyway. Subquery-shaped predicates (#5) also
+            // fall outside the legacy flat-AND view.
+            Self::ColumnCompare(_)
+            | Self::Or(_)
+            | Self::Not(_)
+            | Self::Exists(_)
+            | Self::NotExists(_)
+            | Self::InSubquery { .. } => None,
         }
     }
 
@@ -217,6 +238,21 @@ impl WhereExpr {
                 Ok(())
             }
             Self::Not(child) => child.validate(model),
+            // Subquery predicates (#5) validate their inner SELECT
+            // against the inner SELECT's own model — that walk runs
+            // when the inner queryset was compiled. From the outer
+            // model's perspective there is nothing to check beyond
+            // the column on the LHS of `InSubquery`.
+            Self::Exists(_) | Self::NotExists(_) => Ok(()),
+            Self::InSubquery { column, .. } => {
+                if model.field_by_column(column).is_none() {
+                    return Err(QueryError::UnknownField {
+                        model: model.name,
+                        field: (*column).to_owned(),
+                    });
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -256,6 +292,13 @@ fn validate_expr_columns(model: &'static ModelSchema, expr: &Expr) -> Result<(),
             }
             Ok(())
         }
+        // Inner subquery validates against its own model when the
+        // user compiles it; nothing to check from the outer model
+        // beyond that. `OuterRef` names a column on the outer
+        // model — and from the perspective of the inner-walk it's
+        // a free name; the outer query's compile() validates it
+        // against the outer schema when it embeds this subquery.
+        Expr::Subquery(_) | Expr::OuterRef(_) => Ok(()),
     }
 }
 
@@ -295,6 +338,37 @@ pub struct SelectQuery {
     pub order_by: Vec<OrderClause>,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
+}
+
+/// PartialEq for `SelectQuery` — needed so [`crate::core::Expr`] (which
+/// embeds `Box<SelectQuery>` for issue #5 subqueries) can keep its
+/// `#[derive(PartialEq)]`. `ModelSchema` doesn't implement `PartialEq`
+/// (its fields are heterogeneous + behind static refs), so the `model`
+/// pointer is compared by identity — two queries against the same
+/// schema register equal, which matches every legitimate use case
+/// since model schemas are singletons.
+impl PartialEq for SelectQuery {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.model, other.model)
+            && self.where_clause == other.where_clause
+            && self.search == other.search
+            && self.joins == other.joins
+            && self.order_by == other.order_by
+            && self.limit == other.limit
+            && self.offset == other.offset
+    }
+}
+
+/// Same ptr-eq treatment for `Join` — it also holds `&'static
+/// ModelSchema` (the join target).
+impl PartialEq for Join {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.target, other.target)
+            && self.on_local == other.on_local
+            && self.on_remote == other.on_remote
+            && self.alias == other.alias
+            && self.project == other.project
+    }
 }
 
 /// Single column in an `ORDER BY` clause. Slice 9.0b.

--- a/crates/rustango/src/core/subquery.rs
+++ b/crates/rustango/src/core/subquery.rs
@@ -1,0 +1,155 @@
+//! Subquery / Exists / OuterRef builders (issue #5).
+//!
+//! The fifth slice of the ORM Expression DSL epic. Three Django-shape
+//! primitives that turn a [`SelectQuery`] into something embeddable
+//! inside a larger queryset.
+//!
+//! [`SelectQuery`]: crate::core::SelectQuery
+//!
+//! ```ignore
+//! use rustango::core::subquery::{exists, not_exists, in_subquery, outer_ref};
+//! use rustango::core::{Column as _, F};
+//!
+//! // EXISTS — "authors who have at least one book".
+//! let with_books = Book::objects()
+//!     .where_(Book::author_id.eq_expr(outer_ref("id")))
+//!     .compile()?;
+//! let authors = Author::objects()
+//!     .where_expr(exists(with_books))
+//!     .fetch(&pool).await?;
+//!
+//! // NOT EXISTS — "authors with no books".
+//! let no_books = Book::objects()
+//!     .where_(Book::author_id.eq_expr(outer_ref("id")))
+//!     .compile()?;
+//! let empty = Author::objects()
+//!     .where_expr(not_exists(no_books))
+//!     .fetch(&pool).await?;
+//!
+//! // IN (SELECT …) — "posts in any of the public categories".
+//! let public_cat_ids = Category::objects()
+//!     .where_(Category::is_public.eq(true))
+//!     .compile()?;
+//! let visible = Post::objects()
+//!     .where_expr(in_subquery("category_id", public_cat_ids))
+//!     .fetch(&pool).await?;
+//! ```
+//!
+//! ## How OuterRef resolves
+//!
+//! [`outer_ref("col")`][outer_ref] returns an [`Expr::OuterRef`] that
+//! the SQL writer resolves against the immediately enclosing query at
+//! emit time. Concretely:
+//!
+//! ```text
+//! SELECT … FROM "author" WHERE EXISTS (
+//!     SELECT … FROM "book" WHERE "book"."author_id" = "author"."id"
+//!                                                       ^^^^^^^^
+//!                                                       OuterRef
+//! )
+//! ```
+//!
+//! The writer threads a scope stack through emission — every `EXISTS`,
+//! `NOT EXISTS`, `IN (SELECT …)`, and scalar [`subquery`] pushes a
+//! frame, and `outer_ref("col")` reads the immediate parent. Multi-
+//! level correlation works the same way (parent of parent of …).
+//!
+//! ## Compile-time validation lives on the inner queryset
+//!
+//! These builders take an already-compiled [`SelectQuery`], so any
+//! column-name typo or schema mismatch surfaces at the inner
+//! `queryset.compile()` call — not when the outer query is finally
+//! executed. Build the subquery first, propagate `?`, then embed.
+
+use super::expr::Expr;
+use super::query::{SelectQuery, WhereExpr};
+
+/// `EXISTS (subquery)` — true when the subquery returns at least one
+/// row. Mirrors Django's [`Exists`] expression and is by far the most
+/// common subquery shape in ORM code.
+///
+/// [`Exists`]: https://docs.djangoproject.com/en/6.0/ref/models/expressions/#django.db.models.Exists
+#[must_use]
+pub fn exists(subquery: SelectQuery) -> WhereExpr {
+    WhereExpr::Exists(Box::new(subquery))
+}
+
+/// `NOT EXISTS (subquery)` — true when the subquery returns no rows.
+/// Django's `~Exists(…)` shorthand. The canonical "find rows in A
+/// with no related row in B" pattern.
+#[must_use]
+pub fn not_exists(subquery: SelectQuery) -> WhereExpr {
+    WhereExpr::NotExists(Box::new(subquery))
+}
+
+/// `<column> IN (subquery)` — the standard subquery-membership shape.
+/// Useful when the inner query needs joins or aggregation that can't
+/// be expressed as a flat [`crate::core::Op::In`] list literal.
+///
+/// `column` is the outer column to compare; `subquery` should select
+/// a single column whose values are checked against `column`.
+#[must_use]
+pub fn in_subquery(column: &'static str, subquery: SelectQuery) -> WhereExpr {
+    WhereExpr::InSubquery {
+        column,
+        negated: false,
+        subquery: Box::new(subquery),
+    }
+}
+
+/// `<column> NOT IN (subquery)` — inverse of [`in_subquery`].
+#[must_use]
+pub fn not_in_subquery(column: &'static str, subquery: SelectQuery) -> WhereExpr {
+    WhereExpr::InSubquery {
+        column,
+        negated: true,
+        subquery: Box::new(subquery),
+    }
+}
+
+/// Scalar subquery — `(SELECT … FROM …)`. Embeddable as an `Expr`
+/// anywhere `set_expr` / `eq_expr` / a CASE THEN slot expects a value.
+/// Caller is responsible for shaping the inner queryset (`.limit(1)`,
+/// projection narrowing, etc.) so the result is one column × one row;
+/// otherwise the database errors at runtime.
+#[must_use]
+pub fn subquery(inner: SelectQuery) -> Expr {
+    Expr::Subquery(Box::new(inner))
+}
+
+/// `OuterRef("col")` — reference a column from the enclosing query
+/// inside a correlated subquery. Equivalent to Django's
+/// [`OuterRef('col')`]. Only resolves correctly when emitted from
+/// inside a subquery wrapper ([`exists`], [`not_exists`],
+/// [`in_subquery`], [`subquery`]); the writer raises
+/// [`crate::sql::SqlError::OuterRefOutsideSubquery`] if it shows up
+/// outside one.
+///
+/// `column` is a column name on the outer model — the writer
+/// qualifies it as `"<outer_table>"."<col>"` at emission time, so the
+/// generated SQL stays unambiguous even with name collisions across
+/// inner and outer tables.
+///
+/// [`OuterRef('col')`]: https://docs.djangoproject.com/en/6.0/ref/models/expressions/#django.db.models.OuterRef
+#[must_use]
+pub fn outer_ref(column: &'static str) -> Expr {
+    Expr::OuterRef(column)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The SelectQuery-shaped builders (`exists`, `not_exists`,
+    // `in_subquery`, `not_in_subquery`, `subquery`) are exercised
+    // end-to-end by `tests/subquery_expressions.rs` and
+    // `tests/subquery_expressions_live.rs` where they can use a real
+    // `Model`-derived schema. The unit suite here covers the only
+    // builder that doesn't need one.
+
+    #[test]
+    fn outer_ref_stores_column_name() {
+        let e = outer_ref("id");
+        assert_eq!(e, Expr::OuterRef("id"));
+    }
+}

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -631,6 +631,12 @@ fn validate_expr_columns_in_model(
             }
             Ok(())
         }
+        // Subqueries validate against their own model at the time
+        // they were compiled via QuerySet::compile(); OuterRef
+        // names an outer column resolved when this Expr is embedded
+        // in the outer queryset (the caller already validated it
+        // there).
+        Expr::Subquery(_) | Expr::OuterRef(_) => Ok(()),
     }
 }
 

--- a/crates/rustango/src/sql/error.rs
+++ b/crates/rustango/src/sql/error.rs
@@ -147,6 +147,18 @@ pub enum SqlError {
     /// error on every backend. Reject it loudly here.
     #[error("CASE WHEN branch condition must not be empty")]
     EmptyCaseWhenCondition,
+
+    /// `Expr::OuterRef("col")` was emitted outside any subquery
+    /// scope (issue #5). `OuterRef` only makes sense inside a
+    /// correlated subquery — the writer needs at least two scope
+    /// frames on the stack (outer + subquery) to resolve the column
+    /// against the enclosing query. Programming error.
+    #[error(
+        "`OuterRef(\"{column}\")` used outside of a subquery — \
+         it can only appear inside Exists / NotExists / InSubquery / \
+         Subquery wrappers that know the enclosing query's table"
+    )]
+    OuterRefOutsideSubquery { column: &'static str },
 }
 
 /// Raised while compiling, writing, or executing a query end-to-end.

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -31,6 +31,14 @@ pub(super) struct Sql<'d> {
     pub d: &'d dyn Dialect,
     pub sql: String,
     pub params: Vec<SqlValue>,
+    /// Stack of active emission scopes (innermost last). Pushed by
+    /// `write_select` / `write_update` / `write_delete` / `write_count`
+    /// on entry, popped on exit. Issue #5 reads from this to resolve
+    /// `Expr::OuterRef` inside a nested subquery — the OuterRef's
+    /// referent is the second-from-top frame (the immediate enclosing
+    /// query), and bare `Column` refs implicitly resolve against the
+    /// top frame.
+    pub scope_stack: Vec<&'static ModelSchema>,
 }
 
 impl<'d> Sql<'d> {
@@ -39,6 +47,7 @@ impl<'d> Sql<'d> {
             d,
             sql: String::new(),
             params: Vec::new(),
+            scope_stack: Vec::new(),
         }
     }
 
@@ -47,6 +56,7 @@ impl<'d> Sql<'d> {
             d,
             sql: String::new(),
             params: Vec::with_capacity(cap),
+            scope_stack: Vec::new(),
         }
     }
 
@@ -103,6 +113,13 @@ pub(super) fn null_cast_for(
 // ====================================================================
 
 pub(super) fn write_select(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlError> {
+    b.scope_stack.push(query.model);
+    let result = write_select_inner(b, query);
+    b.scope_stack.pop();
+    result
+}
+
+fn write_select_inner(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlError> {
     let qualify = !query.joins.is_empty();
 
     b.sql.push_str("SELECT ");
@@ -171,16 +188,21 @@ pub(super) fn write_select(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), S
 // ====================================================================
 
 pub(super) fn write_count(b: &mut Sql<'_>, query: &CountQuery) -> Result<(), SqlError> {
-    b.sql.push_str("SELECT COUNT(*) FROM ");
-    b.write_ident(query.model.table);
-    write_where_with_search(
-        b,
-        &query.where_clause,
-        query.search.as_ref(),
-        None,
-        Some(query.model),
-    )?;
-    Ok(())
+    b.scope_stack.push(query.model);
+    let r = (|| {
+        b.sql.push_str("SELECT COUNT(*) FROM ");
+        b.write_ident(query.model.table);
+        write_where_with_search(
+            b,
+            &query.where_clause,
+            query.search.as_ref(),
+            None,
+            Some(query.model),
+        )?;
+        Ok(())
+    })();
+    b.scope_stack.pop();
+    r
 }
 
 // ====================================================================
@@ -404,25 +426,29 @@ pub(super) fn write_update(b: &mut Sql<'_>, query: &UpdateQuery) -> Result<(), S
     if query.set.is_empty() {
         return Err(SqlError::EmptyUpdateSet);
     }
+    b.scope_stack.push(query.model);
+    let r = (|| {
+        b.sql.push_str("UPDATE ");
+        b.write_ident(query.model.table);
+        b.sql.push_str(" SET ");
 
-    b.sql.push_str("UPDATE ");
-    b.write_ident(query.model.table);
-    b.sql.push_str(" SET ");
-
-    let mut first = true;
-    for assignment in &query.set {
-        if !first {
-            b.sql.push_str(", ");
+        let mut first = true;
+        for assignment in &query.set {
+            if !first {
+                b.sql.push_str(", ");
+            }
+            first = false;
+            b.write_ident(assignment.column);
+            b.sql.push_str(" = ");
+            let cast = null_cast_for(b.d, query.model, assignment.column);
+            write_expr(b, &assignment.value, cast)?;
         }
-        first = false;
-        b.write_ident(assignment.column);
-        b.sql.push_str(" = ");
-        let cast = null_cast_for(b.d, query.model, assignment.column);
-        write_expr(b, &assignment.value, cast)?;
-    }
 
-    write_where(b, &query.where_clause, Some(query.model))?;
-    Ok(())
+        write_where(b, &query.where_clause, Some(query.model))?;
+        Ok(())
+    })();
+    b.scope_stack.pop();
+    r
 }
 
 /// Render a [`crate::core::Expr`] — the recursive RHS form that
@@ -486,6 +512,29 @@ fn write_expr(
         }
         Expr::Function { kind, args } => write_function(b, *kind, args),
         Expr::Case { branches, default } => write_case(b, branches, default.as_deref()),
+        Expr::Subquery(inner) => {
+            // `(SELECT … FROM …)` — write_select pushes/pops its own
+            // scope frame so any nested OuterRef inside `inner` looks
+            // up the right enclosing model.
+            b.sql.push('(');
+            write_select(b, inner)?;
+            b.sql.push(')');
+            Ok(())
+        }
+        Expr::OuterRef(col) => {
+            // Resolve against the immediate enclosing scope. The top
+            // frame is the *current* query (the subquery emitting
+            // this OuterRef); the next-most-recent frame is the outer
+            // the user is referring to.
+            let len = b.scope_stack.len();
+            if len < 2 {
+                return Err(SqlError::OuterRefOutsideSubquery { column: col });
+            }
+            let outer = b.scope_stack[len - 2];
+            let qualified = format!("{}.{}", b.d.quote_ident(outer.table), b.d.quote_ident(col),);
+            b.sql.push_str(&qualified);
+            Ok(())
+        }
     }
 }
 
@@ -977,10 +1026,15 @@ fn write_call_unary(
 // ====================================================================
 
 pub(super) fn write_delete(b: &mut Sql<'_>, query: &DeleteQuery) -> Result<(), SqlError> {
-    b.sql.push_str("DELETE FROM ");
-    b.write_ident(query.model.table);
-    write_where(b, &query.where_clause, Some(query.model))?;
-    Ok(())
+    b.scope_stack.push(query.model);
+    let r = (|| {
+        b.sql.push_str("DELETE FROM ");
+        b.write_ident(query.model.table);
+        write_where(b, &query.where_clause, Some(query.model))?;
+        Ok(())
+    })();
+    b.scope_stack.pop();
+    r
 }
 
 // ====================================================================
@@ -1139,6 +1193,30 @@ pub(super) fn write_where_expr(
             b.sql.push(')');
             Ok(())
         }
+        WhereExpr::Exists(subq) => {
+            b.sql.push_str("EXISTS (");
+            write_select(b, subq)?;
+            b.sql.push(')');
+            Ok(())
+        }
+        WhereExpr::NotExists(subq) => {
+            b.sql.push_str("NOT EXISTS (");
+            write_select(b, subq)?;
+            b.sql.push(')');
+            Ok(())
+        }
+        WhereExpr::InSubquery {
+            column,
+            negated,
+            subquery,
+        } => {
+            let qualified = render_qualified_col(b.d, qualify_with, column);
+            b.sql.push_str(&qualified);
+            b.sql.push_str(if *negated { " NOT IN (" } else { " IN (" });
+            write_select(b, subquery)?;
+            b.sql.push(')');
+            Ok(())
+        }
     }
 }
 
@@ -1202,6 +1280,11 @@ fn write_child(
     match expr {
         WhereExpr::Predicate(filter) => write_filter(b, filter, qualify_with, model),
         WhereExpr::ColumnCompare(cf) => write_column_compare(b, cf, qualify_with, model),
+        // Subquery-shaped leaves emit their own parens (EXISTS(…) /
+        // col IN (…)) so we don't need to add a second layer here.
+        WhereExpr::Exists(_) | WhereExpr::NotExists(_) | WhereExpr::InSubquery { .. } => {
+            write_where_expr(b, expr, qualify_with, model)
+        }
         WhereExpr::And(_) | WhereExpr::Or(_) | WhereExpr::Not(_) => {
             b.sql.push('(');
             write_where_expr(b, expr, qualify_with, model)?;

--- a/crates/rustango/tests/subquery_expressions.rs
+++ b/crates/rustango/tests/subquery_expressions.rs
@@ -1,0 +1,282 @@
+//! Tri-dialect emission tests for `Subquery` / `Exists` / `OuterRef`
+//! (issue #5). Most of the produced SQL is standard SQL-92, identical
+//! across PG / MySQL / SQLite — these tests pin the emitted string and
+//! the placeholder dialect-shape for each.
+
+use rustango::core::subquery::{
+    exists, in_subquery, not_exists, not_in_subquery, outer_ref, subquery,
+};
+use rustango::core::{
+    Assignment, Column as _, Expr, Filter, Model as _, Op, SqlValue, UpdateQuery, WhereExpr,
+};
+use rustango::sql::{Dialect, MySql, Postgres, SqlError, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "sq_author")]
+#[allow(dead_code)]
+pub struct Author {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 100)]
+    name: String,
+    book_count: i64,
+}
+
+#[derive(Model)]
+#[rustango(table = "sq_book")]
+#[allow(dead_code)]
+pub struct Book {
+    #[rustango(primary_key)]
+    id: i64,
+    author_id: i64,
+    #[rustango(max_length = 200)]
+    title: String,
+    #[rustango(max_length = 20)]
+    status: String,
+    pages: i64,
+}
+
+// Shared helper — wraps the outer query in an UPDATE because that's
+// the only fully-Expr-aware writer available pre-#75. Picking UPDATE
+// lets us exercise both WHERE-shaped subqueries (Exists / InSubquery)
+// in the outer query's where_clause AND scalar Expr::Subquery in the
+// assignment RHS.
+fn update_against_author(set_value: Expr, where_clause: WhereExpr) -> UpdateQuery {
+    UpdateQuery {
+        model: Author::SCHEMA,
+        set: vec![Assignment {
+            column: "name",
+            value: set_value,
+        }],
+        where_clause,
+    }
+}
+
+// ---------- EXISTS ----------
+
+#[test]
+fn pg_emits_exists_with_dollar_placeholders_and_double_quotes() {
+    let inner = Book::objects()
+        .where_(Book::author_id.eq_expr(outer_ref("id")))
+        .compile()
+        .unwrap();
+    let q = update_against_author(
+        Expr::Literal(SqlValue::String("changed".into())),
+        exists(inner),
+    );
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(
+            r#"WHERE EXISTS (SELECT "id", "author_id", "title", "status", "pages" FROM "sq_book" WHERE "author_id" = "sq_author"."id")"#
+        ),
+        "PG EXISTS shape: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn mysql_emits_exists_with_question_marks_and_backticks() {
+    let inner = Book::objects()
+        .where_(Book::author_id.eq_expr(outer_ref("id")))
+        .compile()
+        .unwrap();
+    let q = update_against_author(
+        Expr::Literal(SqlValue::String("changed".into())),
+        exists(inner),
+    );
+    let stmt = MySql.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains("EXISTS (SELECT"),
+        "MySQL EXISTS keyword: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains("`sq_author`.`id`"),
+        "MySQL OuterRef qualification: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn sqlite_emits_exists_with_question_marks_and_double_quotes() {
+    let inner = Book::objects()
+        .where_(Book::author_id.eq_expr(outer_ref("id")))
+        .compile()
+        .unwrap();
+    let q = update_against_author(
+        Expr::Literal(SqlValue::String("changed".into())),
+        exists(inner),
+    );
+    let stmt = Sqlite.compile_update(&q).unwrap();
+    assert!(stmt.sql.contains("EXISTS (SELECT"));
+    assert!(stmt.sql.contains(r#""sq_author"."id""#));
+}
+
+// ---------- NOT EXISTS ----------
+
+#[test]
+fn not_exists_emits_with_negation_keyword() {
+    let inner = Book::objects()
+        .where_(Book::author_id.eq_expr(outer_ref("id")))
+        .compile()
+        .unwrap();
+    let q = update_against_author(
+        Expr::Literal(SqlValue::String("orphan".into())),
+        not_exists(inner),
+    );
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(stmt.sql.contains("NOT EXISTS (SELECT"), "got: {}", stmt.sql);
+}
+
+// ---------- IN (subquery) ----------
+
+#[test]
+fn in_subquery_emits_with_outer_column_and_subselect() {
+    let inner = Book::objects()
+        .where_(Book::status.eq("published"))
+        .compile()
+        .unwrap();
+    let q = update_against_author(
+        Expr::Literal(SqlValue::String("touched".into())),
+        in_subquery("id", inner),
+    );
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""id" IN (SELECT"#),
+        "outer col + IN + SELECT: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn not_in_subquery_emits_with_not_keyword() {
+    let inner = Book::objects()
+        .where_(Book::status.eq("draft"))
+        .compile()
+        .unwrap();
+    let q = update_against_author(
+        Expr::Literal(SqlValue::String("touched".into())),
+        not_in_subquery("id", inner),
+    );
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""id" NOT IN (SELECT"#),
+        "outer col + NOT IN + SELECT: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Scalar subquery in set_expr ----------
+
+#[test]
+fn scalar_subquery_in_set_expr_emits_in_parens() {
+    // `UPDATE author SET name = (SELECT title FROM book WHERE author_id = author.id) WHERE …`
+    // — sets each author's name to a derived value from their book row.
+    // The inner queryset projects all of Book's columns today (no
+    // .values()-narrow shipped yet); the database will produce a
+    // single column in practice when limit=1 + only-one-row hit.
+    let inner = Book::objects()
+        .where_(Book::author_id.eq_expr(outer_ref("id")))
+        .compile()
+        .unwrap();
+    let q = update_against_author(
+        subquery(inner),
+        WhereExpr::Predicate(Filter {
+            column: "id",
+            op: Op::Eq,
+            value: SqlValue::I64(1),
+        }),
+    );
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"SET "name" = (SELECT"#),
+        "scalar subquery wraps in parens after SET col = : {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains(r#""sq_author"."id""#),
+        "OuterRef inside set_expr scalar subquery resolves outer: {}",
+        stmt.sql
+    );
+}
+
+// ---------- OuterRef error path ----------
+
+#[test]
+fn outer_ref_without_any_subquery_wrap_is_an_emit_error() {
+    // OuterRef makes no sense as a top-level expression — there is no
+    // "outer" to resolve against. Confirm the writer rejects with the
+    // dedicated error rather than emitting nonsense SQL.
+    let q = update_against_author(
+        outer_ref("id"),
+        WhereExpr::Predicate(Filter {
+            column: "id",
+            op: Op::Eq,
+            value: SqlValue::I64(1),
+        }),
+    );
+    let err = Postgres.compile_update(&q).unwrap_err();
+    assert!(
+        matches!(err, SqlError::OuterRefOutsideSubquery { column } if column == "id"),
+        "expected OuterRefOutsideSubquery, got {err:?}",
+    );
+}
+
+// ---------- Composability: Exists inside an Or ----------
+
+#[test]
+fn exists_inside_or_composes_with_other_predicates() {
+    // WHERE name = 'X' OR EXISTS (SELECT … FROM book WHERE …)
+    let inner = Book::objects()
+        .where_(Book::author_id.eq_expr(outer_ref("id")))
+        .compile()
+        .unwrap();
+    let q = update_against_author(
+        Expr::Literal(SqlValue::String("yes".into())),
+        WhereExpr::Or(vec![Author::name.eq("X").into(), exists(inner)]),
+    );
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains("OR EXISTS ("),
+        "Or composition with EXISTS: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Nested correlation: Exists inside Exists ----------
+
+#[test]
+fn nested_subqueries_resolve_each_outer_ref_to_its_enclosing_scope() {
+    // Outermost: Author
+    //   EXISTS Book WHERE author_id = Author.id  AND
+    //                     EXISTS (SELECT … FROM Book WHERE pages > 100
+    //                             AND author_id = Book.author_id)
+    // The inner-inner OuterRef("author_id") should resolve to the
+    // middle Book, not jump to Author.
+    let inner_inner = Book::objects()
+        .where_(Book::pages.gt(100_i64))
+        .where_(Book::author_id.eq_expr(outer_ref("author_id")))
+        .compile()
+        .unwrap();
+    let middle = Book::objects()
+        .where_(Book::author_id.eq_expr(outer_ref("id")))
+        .where_raw(exists(inner_inner))
+        .compile()
+        .unwrap();
+    let q = update_against_author(
+        Expr::Literal(SqlValue::String("nested".into())),
+        exists(middle),
+    );
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""sq_author"."id""#),
+        "outer OuterRef should resolve to Author: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains(r#""sq_book"."author_id""#),
+        "inner OuterRef should resolve to middle Book: {}",
+        stmt.sql
+    );
+}

--- a/crates/rustango/tests/subquery_expressions_live.rs
+++ b/crates/rustango/tests/subquery_expressions_live.rs
@@ -1,0 +1,256 @@
+#![cfg(feature = "postgres")]
+//! Live PG tests for `Subquery` / `Exists` / `OuterRef` (issue #5).
+//! The emission tests pin the SQL strings; this pins the runtime
+//! semantics — actual rows in / actual rows out against a running
+//! database.
+//!
+//! Skips silently when `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::core::subquery::{exists, not_exists, outer_ref};
+use rustango::core::Column as _;
+use rustango::sql::{sqlx, Auto, Fetcher, Updater};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "sql_author")]
+#[allow(dead_code)]
+pub struct Author {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 100)]
+    pub name: String,
+    pub book_count: i64,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "sql_book")]
+#[allow(dead_code)]
+pub struct Book {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub author_id: i64,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 20)]
+    pub status: String,
+    pub pages: i64,
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "sql_book" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(r#"DROP TABLE IF EXISTS "sql_author" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "sql_author" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "name" VARCHAR(100) NOT NULL,
+            "book_count" BIGINT NOT NULL DEFAULT 0
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "sql_book" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "author_id" BIGINT NOT NULL REFERENCES "sql_author"("id"),
+            "title" VARCHAR(200) NOT NULL,
+            "status" VARCHAR(20) NOT NULL,
+            "pages" BIGINT NOT NULL DEFAULT 0
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // 3 authors: Alice (published book), Bob (draft book), Carol (no book).
+    sqlx::query(
+        r#"INSERT INTO "sql_author" ("id", "name") VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Carol')"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(r#"INSERT INTO "sql_book" ("author_id", "title", "status", "pages") VALUES (1, 'Alpha', 'published', 200), (2, 'Bravo', 'draft', 50)"#)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+/// Issue #4 acceptance: "authors with no books" via NOT EXISTS — the
+/// canonical anti-join shape. Carol is the only row that should match.
+#[tokio::test]
+async fn not_exists_finds_authors_with_no_books() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let inner = Book::objects()
+        .where_(Book::author_id.eq_expr(outer_ref("id")))
+        .compile()
+        .unwrap();
+    // No-op UPDATE that we can prove via post-conditions: tag
+    // authors-with-no-books by setting their book_count to -1.
+    Author::objects()
+        .where_raw(not_exists(inner))
+        .update()
+        .set("book_count", -1_i64)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let rows: Vec<Author> = Author::objects()
+        .order_by(&[("id", false)])
+        .fetch(&pool)
+        .await
+        .unwrap();
+    // Alice + Bob keep 0 (they have books); Carol jumps to -1.
+    assert_eq!(rows[0].book_count, 0, "Alice has a book");
+    assert_eq!(rows[1].book_count, 0, "Bob has a book");
+    assert_eq!(rows[2].book_count, -1, "Carol has no books");
+
+    cleanup(&pool).await;
+}
+
+/// EXISTS — positive form. Tag authors who have at least one
+/// PUBLISHED book.
+#[tokio::test]
+async fn exists_finds_authors_with_published_books() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let inner = Book::objects()
+        .where_(Book::author_id.eq_expr(outer_ref("id")))
+        .where_(Book::status.eq("published"))
+        .compile()
+        .unwrap();
+    Author::objects()
+        .where_raw(exists(inner))
+        .update()
+        .set("book_count", 99_i64)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let rows: Vec<Author> = Author::objects()
+        .order_by(&[("id", false)])
+        .fetch(&pool)
+        .await
+        .unwrap();
+    // Only Alice has a published book.
+    assert_eq!(rows[0].book_count, 99, "Alice has published");
+    assert_eq!(rows[1].book_count, 0, "Bob only has draft");
+    assert_eq!(rows[2].book_count, 0, "Carol has no books");
+
+    cleanup(&pool).await;
+}
+
+/// EXISTS-as-correlated-anti-join, alternate phrasing: tag authors
+/// whose book has > 100 pages. This is the pattern users will reach
+/// for instead of `IN (SELECT …)` until projection-narrowing ships —
+/// EXISTS doesn't care how many columns the inner SELECT projects.
+#[tokio::test]
+async fn exists_filters_by_correlated_inner_predicate() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let inner = Book::objects()
+        .where_(Book::author_id.eq_expr(outer_ref("id")))
+        .where_(Book::pages.gt(100_i64))
+        .compile()
+        .unwrap();
+    Author::objects()
+        .where_raw(exists(inner))
+        .update()
+        .set("book_count", 77_i64)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let rows: Vec<Author> = Author::objects()
+        .order_by(&[("id", false)])
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows[0].book_count, 77, "Alice has a 200-page book");
+    assert_eq!(rows[1].book_count, 0, "Bob's book is 50 pages");
+    assert_eq!(rows[2].book_count, 0, "Carol has no books");
+
+    cleanup(&pool).await;
+}
+
+/// Composition: `EXISTS` inside an OR with another predicate.
+#[tokio::test]
+async fn exists_composes_with_or_in_outer_where() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    // Tag rows where name='Carol' OR EXISTS(any-book-with-pages>100).
+    // Alice matches via EXISTS, Carol matches via name. Bob doesn't.
+    use rustango::core::WhereExpr;
+    let inner = Book::objects()
+        .where_(Book::author_id.eq_expr(outer_ref("id")))
+        .where_(Book::pages.gt(100_i64))
+        .compile()
+        .unwrap();
+    Author::objects()
+        .where_raw(WhereExpr::Or(vec![
+            Author::name.eq("Carol").into(),
+            exists(inner),
+        ]))
+        .update()
+        .set("book_count", 7_i64)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let rows: Vec<Author> = Author::objects()
+        .order_by(&[("id", false)])
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows[0].book_count, 7, "Alice via EXISTS");
+    assert_eq!(rows[1].book_count, 0, "Bob: no published, not Carol");
+    assert_eq!(rows[2].book_count, 7, "Carol via name");
+
+    cleanup(&pool).await;
+}
+
+async fn cleanup(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "sql_book" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(r#"DROP TABLE IF EXISTS "sql_author" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+}

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -371,9 +371,71 @@ Post::objects()
 - **Type unification across branches**: every dialect picks a common type from the `THEN` and `ELSE` values. Mixing types (`THEN 1_i64` + `ELSE "string"`) can throw a runtime cast error or coerce surprisingly. Stick to one type per `CASE`.
 - **Performance**: each row evaluates `WHEN` predicates in order until one matches (first-match-wins, per row). Cost grows with the number of branches and the cost of the predicates. For many fixed-string mappings, a join against a small lookup table can be cheaper and more readable.
 
+### Subqueries — `exists() / not_exists() / in_subquery() / subquery() / outer_ref()`
+
+Issue #5 adds Django-shape subquery primitives on the same `Expr` machinery. Four builders cover the bulk of "embed one query inside another":
+
+| Builder | Shape | Use it for |
+|---|---|---|
+| `exists(qs)` | `EXISTS (SELECT … FROM …)` | "Authors who have at least one book" |
+| `not_exists(qs)` | `NOT EXISTS (SELECT …)` | "Authors with no books" (anti-join) |
+| `in_subquery(col, qs)` | `<col> IN (SELECT …)` | "Posts in any public category" |
+| `not_in_subquery(col, qs)` | `<col> NOT IN (SELECT …)` | Inverse of the above |
+| `subquery(qs)` | `(SELECT …)` as a scalar | Computed default in `set_expr` |
+| `outer_ref(col)` | `"<outer_table>"."<col>"` | Reference outer row from inside any of the above |
+
+```rust
+use rustango::core::subquery::{exists, not_exists, in_subquery, outer_ref};
+use rustango::core::{Column as _, WhereExpr};
+
+// "Authors with no books" — the canonical anti-join. Build the inner
+// queryset first so its compile() catches typos; embed via not_exists.
+let no_books = Book::objects()
+    .where_(Book::author_id.eq_expr(outer_ref("id")))
+    .compile()?;
+let orphans = Author::objects()
+    .where_raw(not_exists(no_books))
+    .fetch(&pool).await?;
+
+// "Authors who have a published book of more than 100 pages" — the
+// inner predicate combines a correlation (outer_ref) with literal
+// filters in the same WHERE.
+let inner = Book::objects()
+    .where_(Book::author_id.eq_expr(outer_ref("id")))
+    .where_(Book::status.eq("published"))
+    .where_(Book::pages.gt(100_i64))
+    .compile()?;
+let long_writers = Author::objects()
+    .where_raw(exists(inner))
+    .fetch(&pool).await?;
+
+// Compose EXISTS with an OR.
+let inner = Book::objects()
+    .where_(Book::author_id.eq_expr(outer_ref("id")))
+    .compile()?;
+let featured = Author::objects()
+    .where_raw(WhereExpr::Or(vec![
+        Author::name.eq("Carol").into(),
+        exists(inner),
+    ]))
+    .fetch(&pool).await?;
+```
+
+**Nested correlation works.** OuterRef inside a doubly-nested subquery resolves to the *immediate* enclosing scope — the writer maintains a scope stack as it descends, so `EXISTS (Book WHERE id = outer.id AND EXISTS (Comment WHERE book_id = outer.id))` resolves the inner `outer.id` to `Book.id`, not to the outermost `Author.id`. Use `outer_ref(...)` twice if you really do need to reach two scopes up.
+
+**Errors:**
+
+- **`OuterRefOutsideSubquery`** — emitting `outer_ref("col")` at the top level (not inside any subquery wrapper) is a programming error. The writer raises this loudly with the column name so the call site is easy to find.
+
+**Caveats:**
+
+- **`IN (SELECT …)` projection narrowing**: PG strictly requires the inner SELECT to project exactly one column for the `<col> IN (…)` form. rustango doesn't ship `.values("col")`-style projection narrowing yet (issue #62), so the inner queryset always projects every model column — which makes `in_subquery` only work today against tables whose model has a single column. For the multi-column case, reach for `exists(inner.where_(<outer col>.eq_expr(outer_ref(...))))` — it has the same semantics and doesn't depend on the projection shape.
+- **Scalar `subquery(...)` requires a one-column-one-row inner**: the SQL emitted is `SET col = (SELECT …)` — if the inner produces more than one row, the database errors at runtime. Constrain via `.limit(1)` and either narrow projection (once it lands) or design the inner around a uniqueness invariant.
+- **Subquery compile-time validation lives on the inner queryset**: column typos surface at the inner `queryset.compile()?` call, not at the outer query's `compile()`. Build the inner first and propagate `?`.
+
 ### When to reach for a raw SQL escape hatch instead
 
-The function set covers the common case. For features outside v1–v2 — `Cast`, full-text search, JSON path operators, hash functions, trig, `Subquery`/`Exists`, window functions — see the [Custom SQL escape hatch](#custom-sql-escape-hatch) section below or wait on issues #5–#7 in the ORM Expression DSL epic, which extend the same `Expr` tree.
+The function set covers the common case. For features outside v1–v5 — `Cast`, full-text search, JSON path operators, hash functions, trig, window functions — see the [Custom SQL escape hatch](#custom-sql-escape-hatch) section below or wait on issues #6–#7 in the ORM Expression DSL epic, which extend the same `Expr` tree.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #5 — the fifth issue in the ORM Expression DSL epic. **Stacked on #78** (issue-4-case-when). Will rebase to main once the #1 → #2 → #3 → #4 → #5 chain merges.

Adds Django-shape `Subquery` / `Exists` / `NotExists` / `OuterRef` on the same `Expr` + `WhereExpr` machinery. The issue body said "half of all non-trivial reports require these" — this PR unlocks the four canonical shapes: `EXISTS`, `NOT EXISTS` (Django's `~Exists`), `IN (SELECT …)`, and scalar `(SELECT …)` in `set_expr`. **Nested correlation works**: the writer maintains a scope stack so an `OuterRef` two levels deep resolves to the immediate enclosing query, not the outermost.

## What you get

```rust
use rustango::core::subquery::{exists, not_exists, in_subquery, outer_ref};
use rustango::core::Column as _;

// Authors with no books — canonical anti-join.
let no_books = Book::objects()
    .where_(Book::author_id.eq_expr(outer_ref("id")))
    .compile()?;
let orphans = Author::objects()
    .where_raw(not_exists(no_books))
    .fetch(&pool).await?;

// Authors with at least one long-form published book — correlated EXISTS.
let inner = Book::objects()
    .where_(Book::author_id.eq_expr(outer_ref("id")))
    .where_(Book::status.eq("published"))
    .where_(Book::pages.gt(100_i64))
    .compile()?;
let long_writers = Author::objects()
    .where_raw(exists(inner))
    .fetch(&pool).await?;
```

## Builder API

| Builder | Shape | Use |
|---|---|---|
| `exists(qs)` | `EXISTS (SELECT … FROM …)` | "Authors who have at least one book" |
| `not_exists(qs)` | `NOT EXISTS (…)` | Anti-join — "authors with no books" |
| `in_subquery(col, qs)` | `<col> IN (SELECT …)` | "Posts in any public category" |
| `not_in_subquery(col, qs)` | `<col> NOT IN (…)` | Inverse |
| `subquery(qs)` | `(SELECT …)` (scalar) | Computed default in `set_expr` |
| `outer_ref(col)` | `"<outer>"."col"` | Reference outer row in any of the above |

`qs` is a compiled `SelectQuery` — call `queryset.compile()?` first so typos surface at the inner queryset's compile, not at the outer query's.

## Tri-dialect emission

`EXISTS` / `NOT EXISTS` / `IN (SELECT …)` / `(SELECT …)` are SQL-92 standard — identical SQL on PG, MySQL, and SQLite. Only the placeholder shape (`$N` vs `?`) and identifier quoting (`"…"` vs backticks) differ.

## What landed

- **`core/expr.rs`** — new `Expr::Subquery(Box<SelectQuery>)` and `Expr::OuterRef(&'static str)` variants on the recursive Expr tree.
- **`core/query.rs`** — new `WhereExpr::Exists` / `WhereExpr::NotExists` / `WhereExpr::InSubquery { column, negated, subquery }` variants. Manual `PartialEq` impls for `SelectQuery` + `Join` (ptr-eq on the `&'static ModelSchema`, struct-eq on the rest) so `Expr` / `WhereExpr` can keep their `#[derive(PartialEq)]`.
- **`core/subquery.rs`** (new) — `exists` / `not_exists` / `in_subquery` / `not_in_subquery` / `subquery` / `outer_ref` builders.
- **`sql/writers.rs`** — scope-stack on `Sql<'d>`. Every top-level writer (`write_select` / `write_update` / `write_delete` / `write_count`) pushes its model on entry and pops on exit. `Expr::OuterRef("col")` reads the second-from-top frame (the immediate enclosing query), so nested correlation resolves to the right scope. New `SqlError::OuterRefOutsideSubquery` for the misuse case.
- **`core/query.rs` + `query/mod.rs`** — validation walks for the new variants. Exists/NotExists/InSubquery don't validate the inner SELECT against the OUTER model (the inner was already validated at its own `.compile()`), but `InSubquery` still checks the LHS column against the outer schema.

## Tests

| Suite | Count |
|---|---|
| `core::subquery::tests` (unit) | 1 |
| `tests/subquery_expressions.rs` (tri-dialect emission) | 10 |
| `tests/subquery_expressions_live.rs` (live PG runtime) | 4 |

The 10 emission tests cover: PG/MySQL/SQLite EXISTS placeholder + ident-quote shapes, NOT EXISTS keyword, `IN (SELECT …)` / `NOT IN (SELECT …)` outer-column + sub-select, scalar `subquery()` wrapped in parens after `SET col =`, the `OuterRefOutsideSubquery` programming-error path, EXISTS-inside-OR composition, and a doubly-nested EXISTS that exercises the scope stack — inner OuterRef resolves to the middle scope, not the outermost.

The 4 live PG tests pin runtime semantics end-to-end: NOT EXISTS finds Carol (no books), EXISTS finds Alice (published book), EXISTS-by-pages selects via correlated predicate, and EXISTS-inside-OR composes with a literal name match.

## Cookbook

New "Subqueries — `exists() / not_exists() / in_subquery() / subquery() / outer_ref()`" subsection in `docs/orm.md`. Three caveats documented:

- **`IN (SELECT …)` needs single-column inner projection on PG** — rustango doesn't ship `.values("col")` narrowing yet (#62), so the realistic shape today is `exists(inner.where_(<col>.eq_expr(outer_ref(...))))`. Same semantics.
- **Scalar `subquery(...)` needs one-row × one-column inner** — caller shapes via `.limit(1)` + a uniqueness invariant.
- **`outer_ref(...)` outside any subquery wrapper** is rejected with `SqlError::OuterRefOutsideSubquery`.

## Verification

```
cargo test -p rustango --lib --features tenancy                  → 1477 passed (+1 outer_ref unit test)
cargo test --features tenancy,mysql,sqlite --test subquery_expressions → 10 passed
DATABASE_URL=... cargo test --features tenancy --test subquery_expressions_live → 4 passed
cargo check --no-default-features --features sqlite,tenancy      → clean
cargo check --features mysql,tenancy                             → clean
```

## Foundation extended

`Expr::Subquery` + `Expr::OuterRef` + `WhereExpr::{Exists, NotExists, InSubquery}` join `Function` and `Case` as the recursive-tree variants. Remaining ORM Expression DSL epic:

- **#6** Aggregate `filter=` / `default=` / StdDev / Variance — now fully unblocked (uses the same `Expr::Case` + scope-stack machinery).
- **#7** Window functions.

Plus a new sibling ticket filed alongside this PR:

- **(coming)** Ad-hoc joins: `.join(OtherModel, on=Q(...))` DSL inspired by SQLAlchemy — a feature Django doesn't have out of the box. Independent from #6/#7 at the IR level (different axis: "merge tables horizontally" vs "embed a query inside another"); will ship as a separate PR.

## Test plan

- [x] 1 unit test passes.
- [x] 10 tri-dialect emission tests pass.
- [x] 4 live PG tests pass — all anti-join + correlated-predicate + composition shapes.
- [x] All three feature combos compile.
- [x] Cookbook section + caveats added.
- [ ] CI green on `postgres_test` + `mysql_live` + `sqlite_live` + `sqlite_litmus`.
- [ ] Rebase to main once #78 merges.
