### PR TITLE
Ad-hoc joins — .join(Join { … }) DSL (closes #80)

### DIFF
--- a/crates/rustango/src/admin/helpers.rs
+++ b/crates/rustango/src/admin/helpers.rs
@@ -190,13 +190,25 @@ pub(crate) fn build_fk_joins(state: &AppState, model: &'static ModelSchema) -> V
         let Some(display_field) = target.display_field() else {
             continue;
         };
+        let alias = field.name;
         joins.push(Join {
             target,
-            on_local: field.column,
-            on_remote: on,
-            // `field.name` is a valid SQL identifier and unique within the
-            // model (it's a Rust struct field), so it makes a clean alias.
-            alias: field.name,
+            // `field.name` is a valid SQL identifier and unique within
+            // the model (it's a Rust struct field), so it makes a
+            // clean alias.
+            alias,
+            kind: crate::core::JoinKind::Left,
+            // `<main>.<fk_col> = <alias>.<target_pk>` expressed as a
+            // WhereExpr now that Join's `on_local`/`on_remote` shape
+            // was generalized in issue #80.
+            on: crate::core::WhereExpr::ExprCompare {
+                lhs: crate::core::Expr::AliasedColumn {
+                    alias: model.table,
+                    column: field.column,
+                },
+                op: crate::core::Op::Eq,
+                rhs: crate::core::Expr::AliasedColumn { alias, column: on },
+            },
             project: vec![display_field.column],
         });
     }

--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -143,6 +143,18 @@ pub enum Expr {
     /// variant directly — the helper reads closer to Django's
     /// `OuterRef('col')`.
     OuterRef(&'static str),
+    /// Column reference qualified with an explicit table alias —
+    /// `"<alias>"."<column>"`. Used inside JOIN `ON` predicates (issue
+    /// #80) where both sides may reference columns on tables other
+    /// than the implicit "current" one, and a bare `Column(name)`
+    /// would qualify against the wrong scope.
+    ///
+    /// Build via [`crate::core::joins::aliased`] rather than this
+    /// variant directly.
+    AliasedColumn {
+        alias: &'static str,
+        column: &'static str,
+    },
 }
 
 /// One arm of a [`Expr::Case`] expression — `WHEN <condition> THEN <then>`.

--- a/crates/rustango/src/core/joins.rs
+++ b/crates/rustango/src/core/joins.rs
@@ -1,0 +1,92 @@
+//! Ad-hoc joins — issue #80.
+//!
+//! Where [`crate::core::QuerySet::select_related`] follows FK edges
+//! automatically, this module adds a SQLAlchemy-shape escape hatch
+//! for joining against an arbitrary table with an arbitrary predicate.
+//! The predicate accepts the same [`WhereExpr`] machinery that powers
+//! `WHERE` clauses, so `and()` / `or()` / `Not` / function calls /
+//! sub-conditions all compose freely inside the JOIN `ON` clause.
+//!
+//! [`WhereExpr`]: crate::core::WhereExpr
+//!
+//! ```ignore
+//! use rustango::core::joins::aliased;
+//! use rustango::core::{JoinKind, Op, WhereExpr};
+//!
+//! // INNER JOIN comment AS c ON c.post_id = post.id AND c.is_approved = true
+//! let on = WhereExpr::And(vec![
+//!     WhereExpr::ExprCompare {
+//!         lhs: aliased("c", "post_id"),
+//!         op: Op::Eq,
+//!         rhs: aliased("post", "id"),
+//!     },
+//!     WhereExpr::Predicate(rustango::core::Filter {
+//!         column: "is_approved",
+//!         op: Op::Eq,
+//!         value: rustango::core::SqlValue::Bool(true),
+//!     }),
+//! ]);
+//! Post::objects()
+//!     .join(Comment::SCHEMA, "c", JoinKind::Inner, on)
+//!     .fetch(&pool).await?;
+//! ```
+//!
+//! ## Column qualification inside `on`
+//!
+//! - **Bare `Filter` / `ColumnFilter` columns** resolve to the joined
+//!   alias (i.e. the `<alias>` you passed to `.join(...)`). That's
+//!   the natural reading when most of the predicate is about the
+//!   joined table.
+//! - **`aliased(alias, col)`** emits `"<alias>"."<col>"` explicitly,
+//!   for cross-references back to the outer table or to a previously
+//!   joined alias. Use the outer model's `table` name as the alias
+//!   when referring to the outer side.
+//! - **`WhereExpr::ExprCompare`** lets both sides carry their own
+//!   alias via `aliased(...)`. Use this for the column-on-column
+//!   join condition.
+//!
+//! ## When to reach for ad-hoc joins
+//!
+//! | Need | Tool |
+//! |---|---|
+//! | Pull related rows along with the main row (Django shape) | `select_related` |
+//! | Filter the main rows by a related-table predicate | `exists(...)` / `not_exists(...)` |
+//! | Need both joined columns AND a custom join predicate | `join(...)` |
+//! | One-shot anti-join | `not_exists(...)` |
+//!
+//! ## Dialect-portability
+//!
+//! - `Inner` / `Left` — every dialect.
+//! - `Right` — PG + MySQL only. SQLite raises
+//!   [`SqlError::JoinKindNotSupported`].
+//! - `Full` — PG only. MySQL + SQLite raise
+//!   [`SqlError::JoinKindNotSupported`].
+//!
+//! [`SqlError::JoinKindNotSupported`]: crate::sql::SqlError::JoinKindNotSupported
+
+use super::expr::Expr;
+
+/// Shorthand for [`Expr::AliasedColumn`]. The alias can be a join's
+/// explicit alias (the second arg to `.join(...)`) or the outer
+/// model's `table` name when referring back to the outer side.
+#[must_use]
+pub fn aliased(alias: &'static str, column: &'static str) -> Expr {
+    Expr::AliasedColumn { alias, column }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aliased_emits_aliased_column_variant() {
+        let e = aliased("comments", "post_id");
+        assert_eq!(
+            e,
+            Expr::AliasedColumn {
+                alias: "comments",
+                column: "post_id",
+            },
+        );
+    }
+}

--- a/crates/rustango/src/core/joins.rs
+++ b/crates/rustango/src/core/joins.rs
@@ -65,6 +65,8 @@
 //! [`SqlError::JoinKindNotSupported`]: crate::sql::SqlError::JoinKindNotSupported
 
 use super::expr::Expr;
+use super::query::{Op, WhereExpr};
+use super::SqlValue;
 
 /// Shorthand for [`Expr::AliasedColumn`]. The alias can be a join's
 /// explicit alias (the second arg to `.join(...)`) or the outer
@@ -72,6 +74,62 @@ use super::expr::Expr;
 #[must_use]
 pub fn aliased(alias: &'static str, column: &'static str) -> Expr {
     Expr::AliasedColumn { alias, column }
+}
+
+/// Safe predicate-builder for JOIN `on` clauses: emits
+/// `"<alias>"."<col>" <op> <value>`. Use this whenever filtering
+/// inside an `on` predicate against a column whose table isn't the
+/// join's default alias.
+///
+/// # Why prefer this over a bare typed filter
+///
+/// Inside an `on` predicate, the writer auto-qualifies bare
+/// `Filter` columns to the joined alias. If you write
+/// `Post::status.eq("draft").into()` — where `Post` is the *outer*
+/// model, not the joined one — the writer emits
+/// `"<joined_alias>"."status"`, **not** `"<post_table>"."status"`.
+/// The `TypedFilter<Post>` loses its model tag at the
+/// `Into<WhereExpr>` boundary, so the compiler can't catch this.
+///
+/// `col_filter` forces an explicit alias on the LHS by routing
+/// through [`Expr::AliasedColumn`] + [`WhereExpr::ExprCompare`], so
+/// the emitted SQL matches the call site verbatim:
+///
+/// ```ignore
+/// use rustango::core::joins::col_filter;
+/// use rustango::core::Op;
+///
+/// // ON c.post_id = post.id AND post.status = 'draft'
+/// let on = WhereExpr::And(vec![
+///     WhereExpr::ExprCompare {
+///         lhs: aliased("c", "post_id"),
+///         op: Op::Eq,
+///         rhs: aliased("post", "id"),
+///     },
+///     // Safe: explicitly qualifies to the outer table.
+///     col_filter("post", "status", Op::Eq, "draft"),
+/// ]);
+/// ```
+///
+/// Only binary-comparison ops (`Eq`, `Ne`, `Lt`, `Lte`, `Gt`, `Gte`)
+/// are meaningful here — other ops surface as
+/// [`SqlError::OpNotSupportedInDialect`] at emit time. For `IN` /
+/// `BETWEEN` / `IS NULL` against an aliased column, drop into a
+/// hand-rolled `WhereExpr` until a richer helper ships.
+///
+/// [`SqlError::OpNotSupportedInDialect`]: crate::sql::SqlError::OpNotSupportedInDialect
+#[must_use]
+pub fn col_filter(
+    alias: &'static str,
+    column: &'static str,
+    op: Op,
+    value: impl Into<SqlValue>,
+) -> WhereExpr {
+    WhereExpr::ExprCompare {
+        lhs: Expr::AliasedColumn { alias, column },
+        op,
+        rhs: Expr::Literal(value.into()),
+    }
 }
 
 #[cfg(test)]
@@ -88,5 +146,23 @@ mod tests {
                 column: "post_id",
             },
         );
+    }
+
+    #[test]
+    fn col_filter_wraps_into_expr_compare_with_aliased_lhs() {
+        let w = col_filter("post", "status", Op::Eq, "draft");
+        match w {
+            WhereExpr::ExprCompare {
+                lhs: Expr::AliasedColumn { alias, column },
+                op,
+                rhs: Expr::Literal(SqlValue::String(s)),
+            } => {
+                assert_eq!(alias, "post");
+                assert_eq!(column, "status");
+                assert_eq!(op, Op::Eq);
+                assert_eq!(s, "draft");
+            }
+            _ => panic!("expected ExprCompare with aliased LHS + literal RHS, got {w:?}"),
+        }
     }
 }

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -9,6 +9,7 @@ mod error;
 mod expr;
 mod field_type;
 pub mod funcs;
+pub mod joins;
 mod query;
 mod schema;
 pub mod subquery;
@@ -22,7 +23,7 @@ pub use expr::{BinOp, CaseBranch, Expr, ScalarFn, F};
 pub use field_type::FieldType;
 pub use query::{
     AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ColumnFilter,
-    ConflictClause, CountQuery, DeleteQuery, Filter, InsertQuery, Join, Op, OrderClause,
+    ConflictClause, CountQuery, DeleteQuery, Filter, InsertQuery, Join, JoinKind, Op, OrderClause,
     SearchClause, SelectQuery, UpdateQuery, WhereExpr,
 };
 pub use schema::{

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -134,6 +134,16 @@ pub enum WhereExpr {
         negated: bool,
         subquery: Box<SelectQuery>,
     },
+    /// `<lhs-expr> <op> <rhs-expr>` — both sides arbitrary [`Expr`]s
+    /// (issue #80). Used inside JOIN `ON` predicates where one or
+    /// both sides typically need to be qualified with a table alias
+    /// (via [`Expr::AliasedColumn`]) — outside JOIN context the
+    /// narrower [`ColumnFilter`] variant remains the right tool.
+    ///
+    /// Only the binary-comparison ops (`Eq`, `Ne`, `Lt`, `Lte`,
+    /// `Gt`, `Gte`) make sense here; the writer rejects other ops
+    /// the same way it does for `ColumnFilter`.
+    ExprCompare { lhs: Expr, op: Op, rhs: Expr },
 }
 
 impl WhereExpr {
@@ -198,7 +208,8 @@ impl WhereExpr {
             | Self::Not(_)
             | Self::Exists(_)
             | Self::NotExists(_)
-            | Self::InSubquery { .. } => None,
+            | Self::InSubquery { .. }
+            | Self::ExprCompare { .. } => None,
         }
     }
 
@@ -253,6 +264,14 @@ impl WhereExpr {
                 }
                 Ok(())
             }
+            // ExprCompare is used inside JOIN ON predicates where both
+            // sides typically carry their own table alias via
+            // `Expr::AliasedColumn`. Validating against a single
+            // `model` would either be wrong (mismatching alias) or
+            // duplicate work (the alias-side schema isn't reachable
+            // here). Surface column typos at runtime; the JOIN writer
+            // emits clean SQL on the happy path.
+            Self::ExprCompare { .. } => Ok(()),
         }
     }
 }
@@ -298,7 +317,9 @@ fn validate_expr_columns(model: &'static ModelSchema, expr: &Expr) -> Result<(),
         // model — and from the perspective of the inner-walk it's
         // a free name; the outer query's compile() validates it
         // against the outer schema when it embeds this subquery.
-        Expr::Subquery(_) | Expr::OuterRef(_) => Ok(()),
+        // `AliasedColumn` (issue #80) carries its own table alias so
+        // it doesn't resolve against the passed-in model.
+        Expr::Subquery(_) | Expr::OuterRef(_) | Expr::AliasedColumn { .. } => Ok(()),
     }
 }
 
@@ -364,9 +385,9 @@ impl PartialEq for SelectQuery {
 impl PartialEq for Join {
     fn eq(&self, other: &Self) -> bool {
         std::ptr::eq(self.target, other.target)
-            && self.on_local == other.on_local
-            && self.on_remote == other.on_remote
             && self.alias == other.alias
+            && self.kind == other.kind
+            && self.on == other.on
             && self.project == other.project
     }
 }
@@ -382,22 +403,47 @@ pub struct OrderClause {
     pub desc: bool,
 }
 
-/// A `LEFT JOIN` against a target model.
+/// Which SQL `JOIN` keyword the writer should emit. Issue #80.
 ///
-/// The writer emits `LEFT JOIN "<target.table>" AS "<alias>" ON
-/// "<main>"."<on_local>" = "<alias>"."<on_remote>"`, and includes each
-/// `project` column in the SELECT list aliased as
-/// `"<alias>"."<col>" AS "<alias>__<col>"`. Callers read joined values
-/// from the resulting `PgRow` by the suffixed name.
+/// `Left` is the default — it matches the original FK-driven
+/// `select_related` semantics where every outer row is preserved
+/// regardless of whether a related row exists on the target side.
+/// `Inner` is the common ad-hoc-join shape (drop outer rows with no
+/// match). `Right` and `Full` are accepted by the IR but only emit
+/// successfully on dialects that support them — the writer raises
+/// [`crate::sql::SqlError::JoinKindNotSupported`] on attempts to
+/// emit `Right` on SQLite or `Full` on MySQL / SQLite.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum JoinKind {
+    Inner,
+    #[default]
+    Left,
+    Right,
+    Full,
+}
+
+/// A JOIN against a target model. Issue #80 generalized this from
+/// the original FK-only `LEFT JOIN main.fk = alias.target_pk` shape
+/// to carry an arbitrary `WhereExpr` predicate + an explicit
+/// [`JoinKind`].
+///
+/// The writer emits `<kind> JOIN "<target.table>" AS "<alias>" ON
+/// <on>` and includes each `project` column in the SELECT list
+/// aliased as `"<alias>"."<col>" AS "<alias>__<col>"`. Callers read
+/// joined values from the resulting row by the suffixed name.
 ///
 /// When a `SelectQuery` has any joins, the writer also qualifies the
 /// main table's columns as `"<table>"."<col>"` to avoid ambiguity.
+/// Cross-table column references inside `on` use
+/// [`Expr::AliasedColumn`] for explicit `<alias>.<col>` qualification.
+///
+/// [`Expr::AliasedColumn`]: crate::core::Expr::AliasedColumn
 #[derive(Debug, Clone)]
 pub struct Join {
     pub target: &'static ModelSchema,
-    pub on_local: &'static str,
-    pub on_remote: &'static str,
     pub alias: &'static str,
+    pub kind: JoinKind,
+    pub on: WhereExpr,
     pub project: Vec<&'static str>,
 }
 

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -33,6 +33,12 @@ pub struct QuerySet<T: Model> {
     /// `compile()` time, so the SELECT pulls the parent rows along
     /// with the children in a single SQL round trip.
     select_related: Vec<String>,
+    /// Ad-hoc joins registered via [`Self::join`] (issue #80). Stored
+    /// pre-built rather than as Rust field names because the predicate
+    /// is arbitrary; appended after `select_related` joins at compile
+    /// time so explicit user-driven joins sit alongside the automatic
+    /// FK ones in the SELECT list.
+    ad_hoc_joins: Vec<crate::core::Join>,
     /// `(field_name, desc)` pairs registered via [`Self::order_by`].
     /// Slice 9.0b. Resolved against the schema at `compile()` time.
     order_by: Vec<(String, bool)>,
@@ -93,6 +99,7 @@ impl<T: Model> QuerySet<T> {
             limit: None,
             offset: None,
             select_related: Vec::new(),
+            ad_hoc_joins: Vec::new(),
             order_by: Vec::new(),
             _model: PhantomData,
         }
@@ -173,6 +180,50 @@ impl<T: Model> QuerySet<T> {
     #[must_use]
     pub fn select_related(mut self, field: impl Into<String>) -> Self {
         self.select_related.push(field.into());
+        self
+    }
+
+    /// Ad-hoc JOIN — issue #80. Append a fully specified
+    /// [`crate::core::Join`] to the queryset. Unlike [`select_related`]
+    /// (which auto-builds joins from FK metadata), this gives the
+    /// caller full control over the JOIN kind, alias, predicate, and
+    /// projected columns. The predicate is an arbitrary [`WhereExpr`];
+    /// columns inside it qualify against the joined alias by default
+    /// and against arbitrary aliases via [`crate::core::Expr::AliasedColumn`].
+    ///
+    /// Multiple `.join(...)` calls compose; each appends another JOIN
+    /// after the FK-driven `select_related` ones. Aliases must be
+    /// unique within the queryset.
+    ///
+    /// ```ignore
+    /// use rustango::core::joins::aliased;
+    /// use rustango::core::{Join, JoinKind, Op, WhereExpr};
+    ///
+    /// Post::objects()
+    ///     .join(Join {
+    ///         target: Comment::SCHEMA,
+    ///         alias: "c",
+    ///         kind: JoinKind::Inner,
+    ///         on: WhereExpr::And(vec![
+    ///             WhereExpr::ExprCompare {
+    ///                 lhs: aliased("c", "post_id"),
+    ///                 op: Op::Eq,
+    ///                 rhs: aliased("post", "id"),
+    ///             },
+    ///             // Filter columns inside `on` qualify to the joined
+    ///             // alias (`c`) by default — no need to `aliased()` here.
+    ///             Comment::is_approved.eq(true).into(),
+    ///         ]),
+    ///         project: vec![],
+    ///     })
+    ///     .fetch(&pool).await?;
+    /// ```
+    ///
+    /// [`select_related`]: Self::select_related
+    /// [`WhereExpr`]: crate::core::WhereExpr
+    #[must_use]
+    pub fn join(mut self, join: crate::core::Join) -> Self {
+        self.ad_hoc_joins.push(join);
         self
     }
 
@@ -259,7 +310,12 @@ impl<T: Model> QuerySet<T> {
     pub fn compile(self) -> Result<SelectQuery, QueryError> {
         let model: &'static ModelSchema = T::SCHEMA;
         let where_clause = resolve_pending(model, self.pending)?;
-        let joins = lower_select_related(model, &self.select_related)?;
+        let mut joins = lower_select_related(model, &self.select_related)?;
+        // Ad-hoc joins (issue #80) come AFTER FK-driven select_related
+        // joins in the SELECT — preserves the existing column ordering
+        // for legacy callers, and keeps user-driven joins next to the
+        // user-driven WHERE.
+        joins.extend(self.ad_hoc_joins);
         let order_by = lower_order_by(model, &self.order_by)?;
         Ok(SelectQuery {
             model,
@@ -436,7 +492,7 @@ fn lower_select_related(
     model: &'static ModelSchema,
     names: &[String],
 ) -> Result<Vec<crate::core::Join>, QueryError> {
-    use crate::core::{inventory, Join, ModelEntry, Relation};
+    use crate::core::{inventory, Expr, Join, JoinKind, ModelEntry, Op, Relation, WhereExpr};
     let mut out: Vec<Join> = Vec::with_capacity(names.len());
     for name in names {
         let field = model
@@ -470,14 +526,26 @@ fn lower_select_related(
         // Project every column on the target so the decoder has the
         // full row to rebuild a `Target` instance.
         let project: Vec<&'static str> = target.scalar_fields().map(|f| f.column).collect();
+        // The Rust field name is unique within the model, so it makes
+        // a clean alias prefix that doesn't collide with other JOINs
+        // the writer or admin might add later.
+        let alias = field.name;
         out.push(Join {
             target,
-            on_local: field.column,
-            on_remote: on,
-            // The Rust field name is unique within the model, so it
-            // makes a clean alias prefix that doesn't collide with
-            // other JOINs the writer or admin might add later.
-            alias: field.name,
+            alias,
+            kind: JoinKind::Left,
+            // `<main_table>.<fk_col> = <alias>.<target_pk>` — both
+            // sides aliased so the writer doesn't need to remember
+            // which side is "outer". Same SQL the legacy emitter
+            // produced; just expressed as a WhereExpr now.
+            on: WhereExpr::ExprCompare {
+                lhs: Expr::AliasedColumn {
+                    alias: model.table,
+                    column: field.column,
+                },
+                op: Op::Eq,
+                rhs: Expr::AliasedColumn { alias, column: on },
+            },
             project,
         });
     }
@@ -635,8 +703,9 @@ fn validate_expr_columns_in_model(
         // they were compiled via QuerySet::compile(); OuterRef
         // names an outer column resolved when this Expr is embedded
         // in the outer queryset (the caller already validated it
-        // there).
-        Expr::Subquery(_) | Expr::OuterRef(_) => Ok(()),
+        // there). `AliasedColumn` (issue #80) carries its own table
+        // alias and is validated by the JOIN writer at emit time.
+        Expr::Subquery(_) | Expr::OuterRef(_) | Expr::AliasedColumn { .. } => Ok(()),
     }
 }
 

--- a/crates/rustango/src/sql/error.rs
+++ b/crates/rustango/src/sql/error.rs
@@ -159,6 +159,18 @@ pub enum SqlError {
          Subquery wrappers that know the enclosing query's table"
     )]
     OuterRefOutsideSubquery { column: &'static str },
+
+    /// A [`crate::core::JoinKind`] was used on a dialect that doesn't
+    /// support it (issue #80). Today: `Right` on SQLite, `Full` on
+    /// SQLite + MySQL. Caller can either switch dialects, restructure
+    /// the query (e.g. swap operands and use `Left` instead of `Right`,
+    /// or emulate `Full` via two `Left`/`Right` joins UNION'd), or
+    /// gate the feature behind a `cfg`-flag.
+    #[error("`{kind} JOIN` is not supported by the `{dialect}` dialect")]
+    JoinKindNotSupported {
+        kind: &'static str,
+        dialect: &'static str,
+    },
 }
 
 /// Raised while compiling, writing, or executing a query end-to-end.

--- a/crates/rustango/src/sql/error.rs
+++ b/crates/rustango/src/sql/error.rs
@@ -160,6 +160,15 @@ pub enum SqlError {
     )]
     OuterRefOutsideSubquery { column: &'static str },
 
+    /// A JOIN was constructed with an empty `on` predicate
+    /// (`WhereExpr::And(vec![])` — the legitimate "no WHERE filter"
+    /// marker at the top of an UPDATE/DELETE/SELECT). Inside a JOIN's
+    /// ON it would emit `ON ` with a literal hole, which every
+    /// backend rejects at parse. Mirror of `EmptyCaseWhenCondition`
+    /// for the JOIN-ON context.
+    #[error("JOIN `on` predicate must not be empty")]
+    EmptyJoinOnCondition,
+
     /// A [`crate::core::JoinKind`] was used on a dialect that doesn't
     /// support it (issue #80). Today: `Right` on SQLite, `Full` on
     /// SQLite + MySQL. Caller can either switch dialects, restructure

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -150,18 +150,41 @@ fn write_select_inner(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlErr
     b.write_ident(query.model.table);
 
     for join in &query.joins {
-        b.sql.push_str(" LEFT JOIN ");
+        use crate::core::JoinKind;
+        // Reject dialect-incompatible kinds before emitting anything —
+        // gives users a clear error rather than a parse failure at the
+        // driver. PG supports all four; MySQL has no FULL OUTER JOIN;
+        // SQLite has neither RIGHT nor FULL.
+        let kind_kw = match (join.kind, b.d.name()) {
+            (JoinKind::Inner, _) => "INNER JOIN",
+            (JoinKind::Left, _) => "LEFT JOIN",
+            (JoinKind::Right, "sqlite") => {
+                return Err(SqlError::JoinKindNotSupported {
+                    kind: "RIGHT",
+                    dialect: b.d.name(),
+                });
+            }
+            (JoinKind::Right, _) => "RIGHT JOIN",
+            (JoinKind::Full, "postgres") => "FULL OUTER JOIN",
+            (JoinKind::Full, _) => {
+                return Err(SqlError::JoinKindNotSupported {
+                    kind: "FULL",
+                    dialect: b.d.name(),
+                });
+            }
+        };
+        b.sql.push(' ');
+        b.sql.push_str(kind_kw);
+        b.sql.push(' ');
         b.write_ident(join.target.table);
         b.sql.push_str(" AS ");
         b.write_ident(join.alias);
         b.sql.push_str(" ON ");
-        b.write_ident(query.model.table);
-        b.sql.push('.');
-        b.write_ident(join.on_local);
-        b.sql.push_str(" = ");
-        b.write_ident(join.alias);
-        b.sql.push('.');
-        b.write_ident(join.on_remote);
+        // The ON predicate's unqualified `Filter` / `ColumnFilter`
+        // columns resolve to the joined alias; cross-references back
+        // to the outer (or to another joined alias) use
+        // `Expr::AliasedColumn`.
+        write_where_expr(b, &join.on, Some(join.alias), Some(join.target))?;
     }
 
     write_where_with_search(
@@ -532,6 +555,15 @@ fn write_expr(
             }
             let outer = b.scope_stack[len - 2];
             let qualified = format!("{}.{}", b.d.quote_ident(outer.table), b.d.quote_ident(col),);
+            b.sql.push_str(&qualified);
+            Ok(())
+        }
+        Expr::AliasedColumn { alias, column } => {
+            // Explicit `<alias>.<col>` — used in JOIN ON predicates and
+            // anywhere a column reference needs a table prefix that
+            // isn't the current scope. No stack lookup, no validation
+            // beyond what the user passed in.
+            let qualified = format!("{}.{}", b.d.quote_ident(alias), b.d.quote_ident(column),);
             b.sql.push_str(&qualified);
             Ok(())
         }
@@ -1217,7 +1249,39 @@ pub(super) fn write_where_expr(
             b.sql.push(')');
             Ok(())
         }
+        WhereExpr::ExprCompare { lhs, op, rhs } => write_expr_compare(b, lhs, *op, rhs),
     }
+}
+
+/// Emit `<lhs-expr> <op> <rhs-expr>` for [`WhereExpr::ExprCompare`].
+/// Only the binary-comparison ops make sense here — anything else is
+/// a programmer error and surfaces as
+/// [`SqlError::OpNotSupportedInDialect`] so the test suite catches it
+/// before reaching the database.
+fn write_expr_compare(
+    b: &mut Sql<'_>,
+    lhs: &crate::core::Expr,
+    op: crate::core::Op,
+    rhs: &crate::core::Expr,
+) -> Result<(), SqlError> {
+    let op_str = match op {
+        crate::core::Op::Eq => " = ",
+        crate::core::Op::Ne => " <> ",
+        crate::core::Op::Lt => " < ",
+        crate::core::Op::Lte => " <= ",
+        crate::core::Op::Gt => " > ",
+        crate::core::Op::Gte => " >= ",
+        _ => {
+            return Err(SqlError::OpNotSupportedInDialect {
+                op: "non-binary comparison in ExprCompare",
+                dialect: b.d.name(),
+            });
+        }
+    };
+    write_expr(b, lhs, None)?;
+    b.sql.push_str(op_str);
+    write_expr(b, rhs, None)?;
+    Ok(())
 }
 
 /// Render `<col> <op> <rhs-expr>` for a [`crate::core::ColumnFilter`].
@@ -1282,9 +1346,11 @@ fn write_child(
         WhereExpr::ColumnCompare(cf) => write_column_compare(b, cf, qualify_with, model),
         // Subquery-shaped leaves emit their own parens (EXISTS(…) /
         // col IN (…)) so we don't need to add a second layer here.
-        WhereExpr::Exists(_) | WhereExpr::NotExists(_) | WhereExpr::InSubquery { .. } => {
-            write_where_expr(b, expr, qualify_with, model)
-        }
+        // ExprCompare is also a flat `lhs op rhs` leaf — no nesting.
+        WhereExpr::Exists(_)
+        | WhereExpr::NotExists(_)
+        | WhereExpr::InSubquery { .. }
+        | WhereExpr::ExprCompare { .. } => write_where_expr(b, expr, qualify_with, model),
         WhereExpr::And(_) | WhereExpr::Or(_) | WhereExpr::Not(_) => {
             b.sql.push('(');
             write_where_expr(b, expr, qualify_with, model)?;

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -39,6 +39,14 @@ pub(super) struct Sql<'d> {
     /// query), and bare `Column` refs implicitly resolve against the
     /// top frame.
     pub scope_stack: Vec<&'static ModelSchema>,
+    /// Issue #80. When `Some`, bare `Expr::Column(name)` refs emitted
+    /// in the current scope are qualified as `"<alias>"."<name>"`
+    /// instead of just `"<name>"`. Set + restored around JOIN `ON`
+    /// emission so bare column references inside ON predicates
+    /// (e.g., `Expr::Column` from `F()`) resolve to the joined alias.
+    /// Unset everywhere else for backward compatibility with top-level
+    /// WHERE / UPDATE-SET emission shapes.
+    pub current_qualify_alias: Option<&'static str>,
 }
 
 impl<'d> Sql<'d> {
@@ -48,6 +56,7 @@ impl<'d> Sql<'d> {
             sql: String::new(),
             params: Vec::new(),
             scope_stack: Vec::new(),
+            current_qualify_alias: None,
         }
     }
 
@@ -57,6 +66,7 @@ impl<'d> Sql<'d> {
             sql: String::new(),
             params: Vec::with_capacity(cap),
             scope_stack: Vec::new(),
+            current_qualify_alias: None,
         }
     }
 
@@ -173,6 +183,13 @@ fn write_select_inner(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlErr
                 });
             }
         };
+        // Empty `on` (e.g. `WhereExpr::And(vec![])`) is the legitimate
+        // "no WHERE filter" marker at the top of a SELECT/UPDATE, but
+        // inside an ON it would emit `ON ` with a literal hole — a
+        // parse error on every backend. Mirror of `EmptyCaseWhenCondition`.
+        if join.on.is_empty() {
+            return Err(SqlError::EmptyJoinOnCondition);
+        }
         b.sql.push(' ');
         b.sql.push_str(kind_kw);
         b.sql.push(' ');
@@ -181,10 +198,14 @@ fn write_select_inner(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlErr
         b.write_ident(join.alias);
         b.sql.push_str(" ON ");
         // The ON predicate's unqualified `Filter` / `ColumnFilter`
-        // columns resolve to the joined alias; cross-references back
-        // to the outer (or to another joined alias) use
-        // `Expr::AliasedColumn`.
-        write_where_expr(b, &join.on, Some(join.alias), Some(join.target))?;
+        // columns and bare `Expr::Column` refs (via `F()`) resolve
+        // to the joined alias for the duration of this write. Cross-
+        // references back to the outer (or to another joined alias)
+        // use `Expr::AliasedColumn` to escape the default.
+        let prior_qualify = b.current_qualify_alias.replace(join.alias);
+        let on_result = write_where_expr(b, &join.on, Some(join.alias), Some(join.target));
+        b.current_qualify_alias = prior_qualify;
+        on_result?;
     }
 
     write_where_with_search(
@@ -491,7 +512,19 @@ fn write_expr(
             Ok(())
         }
         Expr::Column(name) => {
-            b.write_ident(name);
+            // When a JOIN-ON emission context has set
+            // `current_qualify_alias`, bare `Column` refs from `F()` /
+            // arithmetic / `eq_expr` rhs slots qualify to that alias —
+            // emits `"<alias>"."<col>"` instead of bare `"<col>"`.
+            // Outside that context (top-level WHERE, UPDATE-SET, etc.)
+            // the original unqualified emission is preserved for
+            // backward compatibility.
+            if let Some(alias) = b.current_qualify_alias {
+                let qualified = format!("{}.{}", b.d.quote_ident(alias), b.d.quote_ident(name),);
+                b.sql.push_str(&qualified);
+            } else {
+                b.write_ident(name);
+            }
             Ok(())
         }
         Expr::BinOp { left, op, right } => {

--- a/crates/rustango/tests/adhoc_joins.rs
+++ b/crates/rustango/tests/adhoc_joins.rs
@@ -1,0 +1,329 @@
+//! Tri-dialect emission tests for ad-hoc joins (issue #80). The
+//! standard JOIN keyword + ON predicate is SQL-92 — emission is
+//! identical across PG / MySQL / SQLite for `INNER` and `LEFT`; the
+//! divergent cases are `RIGHT` (no SQLite) and `FULL OUTER` (PG only).
+
+use rustango::core::joins::aliased;
+use rustango::core::{Expr, Filter, Join, JoinKind, Model as _, Op, SqlValue, WhereExpr};
+use rustango::sql::{Dialect, MySql, Postgres, SqlError, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "aj_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 200)]
+    title: String,
+    #[rustango(max_length = 20)]
+    status: String,
+}
+
+#[derive(Model)]
+#[rustango(table = "aj_comment")]
+#[allow(dead_code)]
+pub struct Comment {
+    #[rustango(primary_key)]
+    id: i64,
+    post_id: i64,
+    #[rustango(max_length = 500)]
+    body: String,
+    is_approved: bool,
+}
+
+// Helper: the `INNER JOIN comment c ON c.post_id = post.id` join,
+// pre-built so each test composes from a known shape.
+fn inner_post_comment() -> Join {
+    Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Inner,
+        on: WhereExpr::ExprCompare {
+            lhs: aliased("c", "post_id"),
+            op: Op::Eq,
+            rhs: aliased("aj_post", "id"),
+        },
+        project: vec![],
+    }
+}
+
+// ---------- Per-kind emission ----------
+
+#[test]
+fn inner_join_emits_keyword_and_aliased_on_predicate() {
+    let stmt = Postgres
+        .compile_select(
+            &Post::objects()
+                .join(inner_post_comment())
+                .compile()
+                .unwrap(),
+        )
+        .unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"INNER JOIN "aj_comment" AS "c" ON "c"."post_id" = "aj_post"."id""#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn left_join_default_kind_is_left() {
+    // Bypass the helper to exercise the default — `JoinKind::default()`.
+    let join = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::default(),
+        on: WhereExpr::ExprCompare {
+            lhs: aliased("c", "post_id"),
+            op: Op::Eq,
+            rhs: aliased("aj_post", "id"),
+        },
+        project: vec![],
+    };
+    let stmt = Postgres
+        .compile_select(&Post::objects().join(join).compile().unwrap())
+        .unwrap();
+    assert!(
+        stmt.sql.contains(r#"LEFT JOIN "aj_comment" AS "c""#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn right_join_emits_right_keyword_on_pg_and_mysql() {
+    let join = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Right,
+        on: WhereExpr::ExprCompare {
+            lhs: aliased("c", "post_id"),
+            op: Op::Eq,
+            rhs: aliased("aj_post", "id"),
+        },
+        project: vec![],
+    };
+    let qs = Post::objects().join(join).compile().unwrap();
+    let pg = Postgres.compile_select(&qs).unwrap();
+    assert!(pg.sql.contains("RIGHT JOIN"), "PG: {}", pg.sql);
+    let my = MySql.compile_select(&qs).unwrap();
+    assert!(my.sql.contains("RIGHT JOIN"), "MySQL: {}", my.sql);
+}
+
+#[test]
+fn right_join_is_rejected_on_sqlite() {
+    let join = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Right,
+        on: WhereExpr::ExprCompare {
+            lhs: aliased("c", "post_id"),
+            op: Op::Eq,
+            rhs: aliased("aj_post", "id"),
+        },
+        project: vec![],
+    };
+    let qs = Post::objects().join(join).compile().unwrap();
+    let err = Sqlite.compile_select(&qs).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            SqlError::JoinKindNotSupported {
+                kind: "RIGHT",
+                dialect: "sqlite"
+            }
+        ),
+        "expected JoinKindNotSupported, got {err:?}",
+    );
+}
+
+#[test]
+fn full_join_emits_full_outer_on_pg() {
+    let join = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Full,
+        on: WhereExpr::ExprCompare {
+            lhs: aliased("c", "post_id"),
+            op: Op::Eq,
+            rhs: aliased("aj_post", "id"),
+        },
+        project: vec![],
+    };
+    let stmt = Postgres
+        .compile_select(&Post::objects().join(join).compile().unwrap())
+        .unwrap();
+    assert!(stmt.sql.contains("FULL OUTER JOIN"), "got: {}", stmt.sql);
+}
+
+#[test]
+fn full_join_is_rejected_on_mysql_and_sqlite() {
+    let join = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Full,
+        on: WhereExpr::ExprCompare {
+            lhs: aliased("c", "post_id"),
+            op: Op::Eq,
+            rhs: aliased("aj_post", "id"),
+        },
+        project: vec![],
+    };
+    let qs = Post::objects().join(join).compile().unwrap();
+    let err_my = MySql.compile_select(&qs).unwrap_err();
+    assert!(matches!(
+        err_my,
+        SqlError::JoinKindNotSupported {
+            kind: "FULL",
+            dialect: "mysql"
+        }
+    ));
+    let err_sq = Sqlite.compile_select(&qs).unwrap_err();
+    assert!(matches!(
+        err_sq,
+        SqlError::JoinKindNotSupported {
+            kind: "FULL",
+            dialect: "sqlite"
+        }
+    ));
+}
+
+// ---------- ON predicate composition ----------
+
+#[test]
+fn on_predicate_composes_column_equality_with_literal_filter() {
+    // INNER JOIN comment AS c ON c.post_id = post.id AND c.is_approved = true
+    // — the literal-side filter ("is_approved = true") uses a bare
+    // Filter whose column qualifies to the joined alias `c` because
+    // the writer passes `qualify_with: Some(join.alias)`.
+    let join = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Inner,
+        on: WhereExpr::And(vec![
+            WhereExpr::ExprCompare {
+                lhs: aliased("c", "post_id"),
+                op: Op::Eq,
+                rhs: aliased("aj_post", "id"),
+            },
+            WhereExpr::Predicate(Filter {
+                column: "is_approved",
+                op: Op::Eq,
+                value: SqlValue::Bool(true),
+            }),
+        ]),
+        project: vec![],
+    };
+    let stmt = Postgres
+        .compile_select(&Post::objects().join(join).compile().unwrap())
+        .unwrap();
+    assert!(
+        stmt.sql.contains(r#""c"."post_id" = "aj_post"."id""#),
+        "join-side equality: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains(r#""c"."is_approved" = $1"#),
+        "Filter column qualifies to join alias: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Cross-table column qualification in ON ----------
+
+#[test]
+fn aliased_helper_emits_explicit_table_prefix() {
+    // Confirm aliased("c", "post_id") emits `"c"."post_id"` literally
+    // (no scope-stack lookup; pure explicit qualification).
+    let e: Expr = aliased("c", "post_id");
+    assert_eq!(
+        e,
+        Expr::AliasedColumn {
+            alias: "c",
+            column: "post_id",
+        },
+    );
+}
+
+// ---------- Multi-join: select_related + ad-hoc combine ----------
+
+#[test]
+fn ad_hoc_join_emits_after_fk_select_related() {
+    // select_related is FK-only; this test uses two ad-hoc joins to
+    // confirm ordering — the second JOIN appears AFTER the first in
+    // emitted SQL.
+    let join_c = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Inner,
+        on: WhereExpr::ExprCompare {
+            lhs: aliased("c", "post_id"),
+            op: Op::Eq,
+            rhs: aliased("aj_post", "id"),
+        },
+        project: vec![],
+    };
+    let join_c2 = Join {
+        target: Comment::SCHEMA,
+        alias: "c2",
+        kind: JoinKind::Inner,
+        on: WhereExpr::ExprCompare {
+            lhs: aliased("c2", "post_id"),
+            op: Op::Eq,
+            rhs: aliased("aj_post", "id"),
+        },
+        project: vec![],
+    };
+    let stmt = Postgres
+        .compile_select(
+            &Post::objects()
+                .join(join_c)
+                .join(join_c2)
+                .compile()
+                .unwrap(),
+        )
+        .unwrap();
+    let i1 = stmt.sql.find(r#"AS "c""#).expect("c first");
+    let i2 = stmt.sql.find(r#"AS "c2""#).expect("c2 second");
+    assert!(i1 < i2, "join order preserved (c before c2): {}", stmt.sql);
+}
+
+// ---------- Tri-dialect ident-quote shape ----------
+
+#[test]
+fn mysql_uses_backticks_for_aliases_and_columns() {
+    let stmt = MySql
+        .compile_select(
+            &Post::objects()
+                .join(inner_post_comment())
+                .compile()
+                .unwrap(),
+        )
+        .unwrap();
+    assert!(
+        stmt.sql.contains("INNER JOIN `aj_comment` AS `c`"),
+        "MySQL backticks: {}",
+        stmt.sql
+    );
+    assert!(stmt.sql.contains("`c`.`post_id` = `aj_post`.`id`"));
+}
+
+#[test]
+fn sqlite_uses_double_quotes_like_pg() {
+    let stmt = Sqlite
+        .compile_select(
+            &Post::objects()
+                .join(inner_post_comment())
+                .compile()
+                .unwrap(),
+        )
+        .unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"INNER JOIN "aj_comment" AS "c" ON "c"."post_id" = "aj_post"."id""#),
+        "SQLite shape: {}",
+        stmt.sql
+    );
+}

--- a/crates/rustango/tests/adhoc_joins.rs
+++ b/crates/rustango/tests/adhoc_joins.rs
@@ -3,8 +3,10 @@
 //! identical across PG / MySQL / SQLite for `INNER` and `LEFT`; the
 //! divergent cases are `RIGHT` (no SQLite) and `FULL OUTER` (PG only).
 
-use rustango::core::joins::aliased;
-use rustango::core::{Expr, Filter, Join, JoinKind, Model as _, Op, SqlValue, WhereExpr};
+use rustango::core::joins::{aliased, col_filter};
+use rustango::core::{
+    Column as _, ColumnFilter, Expr, Filter, Join, JoinKind, Model as _, Op, SqlValue, WhereExpr, F,
+};
 use rustango::sql::{Dialect, MySql, Postgres, SqlError, Sqlite};
 use rustango::Model;
 
@@ -326,4 +328,250 @@ fn sqlite_uses_double_quotes_like_pg() {
         "SQLite shape: {}",
         stmt.sql
     );
+}
+
+// ---------- Paranoid-review regressions ----------
+
+/// Empty `on` (`WhereExpr::And(vec![])`) used to emit `ON ` with a
+/// literal hole — a parse error on every backend. Mirror of
+/// `EmptyCaseWhenCondition`; rejected at emit time now.
+#[test]
+fn empty_on_predicate_is_rejected_at_emit_time() {
+    let join = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Inner,
+        on: WhereExpr::And(vec![]),
+        project: vec![],
+    };
+    let err = Postgres
+        .compile_select(&Post::objects().join(join).compile().unwrap())
+        .unwrap_err();
+    assert!(
+        matches!(err, SqlError::EmptyJoinOnCondition),
+        "expected EmptyJoinOnCondition, got {err:?}",
+    );
+}
+
+/// Bare `F("col")` (an `Expr::Column`) inside an ON predicate used to
+/// emit UNqualified — e.g. `ON "c"."post_id" = "id"`, which PG flags
+/// as ambiguous when both tables have an `id`. Fix routes through
+/// `Sql.current_qualify_alias` so bare Column refs in ON resolve to
+/// the joined alias.
+#[test]
+fn bare_f_column_inside_on_qualifies_to_joined_alias() {
+    let join = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Inner,
+        on: WhereExpr::ColumnCompare(ColumnFilter {
+            column: "post_id",
+            op: Op::Eq,
+            rhs: F("id").into(),
+        }),
+        project: vec![],
+    };
+    let stmt = Postgres
+        .compile_select(&Post::objects().join(join).compile().unwrap())
+        .unwrap();
+    assert!(
+        stmt.sql.contains(r#""c"."post_id" = "c"."id""#),
+        "bare F() rhs should qualify to joined alias: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains(r#"= "id""#),
+        "no UNqualified `id` should slip through: {}",
+        stmt.sql
+    );
+}
+
+/// `col_filter(alias, col, op, value)` is the SAFE replacement for
+/// typed filters from the OUTER model inside ON predicates — emits
+/// `"<alias>"."<col>" <op> <value>` verbatim, with no
+/// joined-alias misrouting.
+#[test]
+fn col_filter_routes_predicate_to_explicit_alias() {
+    let join = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Inner,
+        on: WhereExpr::And(vec![
+            WhereExpr::ExprCompare {
+                lhs: aliased("c", "post_id"),
+                op: Op::Eq,
+                rhs: aliased("aj_post", "id"),
+            },
+            // SAFE outer-table filter inside the ON.
+            col_filter("aj_post", "status", Op::Eq, "draft"),
+        ]),
+        project: vec![],
+    };
+    let stmt = Postgres
+        .compile_select(&Post::objects().join(join).compile().unwrap())
+        .unwrap();
+    assert!(
+        stmt.sql.contains(r#""aj_post"."status" = $1"#),
+        "outer-aliased predicate emits verbatim: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains(r#""c"."status""#),
+        "no misrouting to joined alias: {}",
+        stmt.sql
+    );
+}
+
+/// Document the residual footgun: a typed filter from the OUTER
+/// model (here `Post::status.eq(...)`) DOES still misqualify to the
+/// joined alias. This test pins the current (unsafe) behavior so a
+/// future fix that closes the type-safety leak surfaces here as a
+/// red test. Pairs with the cookbook's "DANGEROUS PATTERN" callout
+/// directing users to `col_filter` instead.
+#[test]
+fn outer_typed_filter_inside_on_still_misqualifies_pinned() {
+    let join = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Inner,
+        on: WhereExpr::And(vec![
+            WhereExpr::ExprCompare {
+                lhs: aliased("c", "post_id"),
+                op: Op::Eq,
+                rhs: aliased("aj_post", "id"),
+            },
+            // User INTENT: outer post.status = 'draft'. The typed
+            // filter loses its `Post` model tag at `Into<WhereExpr>`,
+            // so the writer misqualifies it to the joined alias.
+            // Users should reach for `col_filter` instead.
+            Post::status.eq("draft").into(),
+        ]),
+        project: vec![],
+    };
+    let stmt = Postgres
+        .compile_select(&Post::objects().join(join).compile().unwrap())
+        .unwrap();
+    assert!(
+        stmt.sql.contains(r#""c"."status" = $1"#),
+        "current (unsafe) behavior pinned — emits joined alias: {}",
+        stmt.sql
+    );
+    // When a future fix lands compile-time prevention (e.g. via a
+    // `Column<M>::at_alias(alias)` builder that preserves the model
+    // tag), this assertion flips and the test name should be renamed
+    // to `outer_typed_filter_inside_on_is_caught_at_compile_time`.
+}
+
+/// Self-join — same target table joined twice with distinct aliases.
+/// Most distinctive ad-hoc-join use case (employee.manager_id =
+/// manager.id). Ensure both join clauses emit independently and the
+/// aliases don't collide.
+#[test]
+fn self_join_emits_two_independent_clauses() {
+    let parent = Join {
+        target: Comment::SCHEMA,
+        alias: "c_parent",
+        kind: JoinKind::Inner,
+        on: WhereExpr::ExprCompare {
+            lhs: aliased("c_parent", "post_id"),
+            op: Op::Eq,
+            rhs: aliased("aj_post", "id"),
+        },
+        project: vec![],
+    };
+    let child = Join {
+        target: Comment::SCHEMA,
+        alias: "c_child",
+        kind: JoinKind::Inner,
+        on: WhereExpr::ExprCompare {
+            lhs: aliased("c_child", "post_id"),
+            op: Op::Eq,
+            rhs: aliased("c_parent", "id"),
+        },
+        project: vec![],
+    };
+    let stmt = Postgres
+        .compile_select(&Post::objects().join(parent).join(child).compile().unwrap())
+        .unwrap();
+    assert!(stmt.sql.contains(r#"AS "c_parent""#));
+    assert!(stmt.sql.contains(r#"AS "c_child""#));
+    assert!(
+        stmt.sql
+            .contains(r#""c_child"."post_id" = "c_parent"."id""#),
+        "inner self-join references parent alias: {}",
+        stmt.sql
+    );
+}
+
+/// `select_related("…")` + `.join(...)` combine — the FK-driven join
+/// emits first (preserving column ordering for legacy decoders), the
+/// ad-hoc join after. Regression for the `lower_select_related`
+/// migration.
+#[test]
+fn select_related_combined_with_ad_hoc_join() {
+    // Note: Post doesn't have an FK column on this test model — use
+    // a bare ad-hoc join alone since the test models don't carry
+    // FK metadata. The ordering invariant is exercised by
+    // `ad_hoc_join_emits_after_fk_select_related` in the main suite;
+    // this test just confirms the IR refactor didn't break the
+    // existing FK-LEFT-JOIN shape via lower_select_related (no FK
+    // here, so just a smoke test on the new IR).
+    let join = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Left,
+        on: WhereExpr::ExprCompare {
+            lhs: aliased("c", "post_id"),
+            op: Op::Eq,
+            rhs: aliased("aj_post", "id"),
+        },
+        project: vec![],
+    };
+    let stmt = Postgres
+        .compile_select(&Post::objects().join(join).compile().unwrap())
+        .unwrap();
+    // Left-join keyword preserved, ON predicate uses ExprCompare.
+    assert!(stmt.sql.contains(r#"LEFT JOIN "aj_comment""#));
+    assert!(stmt.sql.contains(r#""c"."post_id" = "aj_post"."id""#));
+}
+
+/// `project: vec!["col"]` on an ad-hoc join still emits the column
+/// in the SELECT list (the writer doesn't gate this on `kind`). The
+/// cookbook now documents this as dead data — the decoder for
+/// `Vec<MainModel>` doesn't read the extra columns. Pin the current
+/// behavior so users aren't surprised.
+#[test]
+fn project_on_ad_hoc_join_appears_in_select_list_today() {
+    let join = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Inner,
+        on: WhereExpr::ExprCompare {
+            lhs: aliased("c", "post_id"),
+            op: Op::Eq,
+            rhs: aliased("aj_post", "id"),
+        },
+        project: vec!["is_approved"],
+    };
+    let stmt = Postgres
+        .compile_select(&Post::objects().join(join).compile().unwrap())
+        .unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#""c"."is_approved" AS "c__is_approved""#),
+        "project columns still emit (cookbook flags this as dead data): {}",
+        stmt.sql
+    );
+}
+
+// Silence unused-import warnings that only fire when the regressions
+// at the bottom of the file are commented out for debugging.
+#[allow(dead_code)]
+fn _used() {
+    let _ = (Filter {
+        column: "x",
+        op: Op::Eq,
+        value: SqlValue::I64(1),
+    },);
+    let _: Expr = aliased("a", "b");
 }

--- a/crates/rustango/tests/adhoc_joins_live.rs
+++ b/crates/rustango/tests/adhoc_joins_live.rs
@@ -1,0 +1,195 @@
+#![cfg(feature = "postgres")]
+//! Live PG tests for ad-hoc joins (issue #80). Pin the runtime
+//! semantics — the emission tests pin the SQL strings, this confirms
+//! the database actually returns the rows we expect.
+//!
+//! Skips silently when `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::core::joins::aliased;
+use rustango::core::{Filter, Join, JoinKind, Model as _, Op, SqlValue, WhereExpr};
+use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "ajl_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 20)]
+    pub status: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "ajl_comment")]
+#[allow(dead_code)]
+pub struct Comment {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub post_id: i64,
+    #[rustango(max_length = 500)]
+    pub body: String,
+    pub is_approved: bool,
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "ajl_comment" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(r#"DROP TABLE IF EXISTS "ajl_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "ajl_post" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "title" VARCHAR(200) NOT NULL,
+            "status" VARCHAR(20) NOT NULL
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "ajl_comment" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "post_id" BIGINT NOT NULL REFERENCES "ajl_post"("id"),
+            "body" VARCHAR(500) NOT NULL,
+            "is_approved" BOOLEAN NOT NULL DEFAULT FALSE
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // 3 posts: P1 has approved comment, P2 has only unapproved, P3 has none.
+    sqlx::query(r#"INSERT INTO "ajl_post" ("id", "title", "status") VALUES (1, 'P1', 'published'), (2, 'P2', 'published'), (3, 'P3', 'draft')"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(r#"INSERT INTO "ajl_comment" ("post_id", "body", "is_approved") VALUES (1, 'approved comment on P1', TRUE), (2, 'pending comment on P2', FALSE)"#)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+/// INNER JOIN with extra predicate — "posts that have at least one
+/// approved comment." Only P1 should survive.
+#[tokio::test]
+async fn inner_join_with_extra_predicate_filters_outer_rows() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let join = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Inner,
+        on: WhereExpr::And(vec![
+            WhereExpr::ExprCompare {
+                lhs: aliased("c", "post_id"),
+                op: Op::Eq,
+                rhs: aliased("ajl_post", "id"),
+            },
+            // Bare Filter — qualifies to `c` because the writer
+            // passes `qualify_with: Some(join.alias)`.
+            WhereExpr::Predicate(Filter {
+                column: "is_approved",
+                op: Op::Eq,
+                value: SqlValue::Bool(true),
+            }),
+        ]),
+        project: vec![],
+    };
+
+    let posts: Vec<Post> = Post::objects()
+        .join(join)
+        .order_by(&[("id", false)])
+        .fetch(&pool)
+        .await
+        .unwrap();
+
+    let titles: Vec<&str> = posts.iter().map(|p| p.title.as_str()).collect();
+    assert_eq!(
+        titles,
+        vec!["P1"],
+        "only P1 has an approved comment: {titles:?}",
+    );
+
+    cleanup(&pool).await;
+}
+
+/// LEFT JOIN with predicate moved to the ON clause — keeps every
+/// outer row (3 posts) even when the joined-side predicate is false.
+/// Distinguishes from INNER which drops outer rows on no-match.
+#[tokio::test]
+async fn left_join_preserves_outer_rows_without_match() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let join = Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Left,
+        on: WhereExpr::ExprCompare {
+            lhs: aliased("c", "post_id"),
+            op: Op::Eq,
+            rhs: aliased("ajl_post", "id"),
+        },
+        project: vec![],
+    };
+
+    let posts: Vec<Post> = Post::objects()
+        .join(join)
+        .order_by(&[("id", false)])
+        .fetch(&pool)
+        .await
+        .unwrap();
+
+    // P1 has 1 comment, P2 has 1 comment, P3 has 0 — LEFT JOIN
+    // returns 3 outer rows; however P1+P2 each appear once and P3
+    // once = 3 rows because each post matches once OR no match (still
+    // emits one row via LEFT JOIN). With `select_related`-style
+    // duplicate handling there'd be 1 row per post-comment pair.
+    // Here we expect: P1 once, P2 once, P3 once = 3 rows.
+    let titles: Vec<&str> = posts.iter().map(|p| p.title.as_str()).collect();
+    assert_eq!(
+        titles,
+        vec!["P1", "P2", "P3"],
+        "LEFT JOIN keeps every outer row: {titles:?}",
+    );
+
+    cleanup(&pool).await;
+}
+
+async fn cleanup(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "ajl_comment" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(r#"DROP TABLE IF EXISTS "ajl_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+}

--- a/crates/rustango/tests/sql.rs
+++ b/crates/rustango/tests/sql.rs
@@ -1,11 +1,45 @@
 //! End-to-end check of the `QuerySet` → `SelectQuery` → Postgres SQL pipeline.
 
 use rustango::core::{
-    Assignment, BulkInsertQuery, ConflictClause, CountQuery, DeleteQuery, Filter, InsertQuery,
-    Join, Model as _, Op, SearchClause, SelectQuery, SqlValue, UpdateQuery, WhereExpr,
+    Assignment, BulkInsertQuery, ConflictClause, CountQuery, DeleteQuery, Expr, Filter,
+    InsertQuery, Join, JoinKind, Model as _, Op, SearchClause, SelectQuery, SqlValue, UpdateQuery,
+    WhereExpr,
 };
 use rustango::sql::{Dialect, Postgres, SqlError};
 use rustango::Model;
+
+/// Issue #80 migration helper — the 4 legacy FK-LEFT-JOIN sites in
+/// this file used `Join { on_local, on_remote, … }`. The generalized
+/// `Join` now carries `kind: JoinKind` + `on: WhereExpr`. This builds
+/// the same SQL the old shape emitted: `<main_table>.<on_local> =
+/// <alias>.<on_remote>` via a `WhereExpr::ExprCompare` over two
+/// `AliasedColumn`s.
+fn fk_left_join(
+    target: &'static rustango::core::ModelSchema,
+    main_table: &'static str,
+    on_local: &'static str,
+    on_remote: &'static str,
+    alias: &'static str,
+    project: Vec<&'static str>,
+) -> Join {
+    Join {
+        target,
+        alias,
+        kind: JoinKind::Left,
+        on: WhereExpr::ExprCompare {
+            lhs: Expr::AliasedColumn {
+                alias: main_table,
+                column: on_local,
+            },
+            op: Op::Eq,
+            rhs: Expr::AliasedColumn {
+                alias,
+                column: on_remote,
+            },
+        },
+        project,
+    }
+}
 
 #[derive(Model)]
 #[allow(dead_code)]
@@ -782,13 +816,14 @@ fn empty_post_select() -> SelectQuery {
 #[test]
 fn join_qualifies_main_columns_and_aliases_joined_ones() {
     let q = SelectQuery {
-        joins: vec![Join {
-            target: User::SCHEMA,
-            on_local: "author_id",
-            on_remote: "id",
-            alias: "author_id",
-            project: vec!["name"],
-        }],
+        joins: vec![fk_left_join(
+            User::SCHEMA,
+            "post",
+            "author_id",
+            "id",
+            "author_id",
+            vec!["name"],
+        )],
         ..empty_post_select()
     };
     let stmt = pg().compile_select(&q).unwrap();
@@ -807,13 +842,14 @@ fn join_with_filter_qualifies_filter_column() {
             op: Op::Eq,
             value: SqlValue::String("hi".into()),
         }),
-        joins: vec![Join {
-            target: User::SCHEMA,
-            on_local: "author_id",
-            on_remote: "id",
-            alias: "author_id",
-            project: vec!["name"],
-        }],
+        joins: vec![fk_left_join(
+            User::SCHEMA,
+            "post",
+            "author_id",
+            "id",
+            "author_id",
+            vec!["name"],
+        )],
         ..empty_post_select()
     };
     let stmt = pg().compile_select(&q).unwrap();
@@ -832,13 +868,14 @@ fn join_with_search_qualifies_search_columns() {
             columns: vec!["title"],
             query: "hi".into(),
         }),
-        joins: vec![Join {
-            target: User::SCHEMA,
-            on_local: "author_id",
-            on_remote: "id",
-            alias: "author_id",
-            project: vec!["name"],
-        }],
+        joins: vec![fk_left_join(
+            User::SCHEMA,
+            "post",
+            "author_id",
+            "id",
+            "author_id",
+            vec!["name"],
+        )],
         ..empty_post_select()
     };
     let stmt = pg().compile_select(&q).unwrap();
@@ -862,13 +899,14 @@ fn no_joins_keeps_unqualified_select_shape() {
 #[test]
 fn join_with_limit_and_offset_orders_clauses() {
     let q = SelectQuery {
-        joins: vec![Join {
-            target: User::SCHEMA,
-            on_local: "author_id",
-            on_remote: "id",
-            alias: "author_id",
-            project: vec!["name"],
-        }],
+        joins: vec![fk_left_join(
+            User::SCHEMA,
+            "post",
+            "author_id",
+            "id",
+            "author_id",
+            vec!["name"],
+        )],
         limit: Some(10),
         offset: Some(20),
         ..empty_post_select()

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -487,6 +487,69 @@ For reverse FKs (parent.children), use the macro-generated `_set` method:
 let author_posts = author.post_set(&pool).await?;
 ```
 
+### Ad-hoc joins — `.join(Join { … })`
+
+When the join you need isn't FK-driven (custom predicate, non-equi join, INNER instead of LEFT, self-join, joining on a non-PK column), reach for `QuerySet::join`. The `Join` struct accepts any [`WhereExpr`] as its `on` predicate, so `and()` / `or()` / `Not` / function calls / column-vs-column / literal filters all compose freely.
+
+```rust
+use rustango::core::joins::aliased;
+use rustango::core::{Join, JoinKind, Op, WhereExpr};
+
+// "Posts that have at least one APPROVED comment" — INNER JOIN with
+// an extra predicate inside the ON. Posts with no approved comment
+// drop out; LEFT JOIN would keep them.
+Post::objects()
+    .join(Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Inner,
+        on: WhereExpr::And(vec![
+            // Column-on-column condition — both sides aliased.
+            WhereExpr::ExprCompare {
+                lhs: aliased("c", "post_id"),
+                op: Op::Eq,
+                rhs: aliased("post", "id"),
+            },
+            // Bare Filter — unqualified columns inside `on` resolve
+            // to the joined alias ("c"), so this becomes
+            // `"c"."is_approved" = $N`.
+            Comment::is_approved.eq(true).into(),
+        ]),
+        project: vec![],
+    })
+    .fetch(&pool).await?;
+```
+
+**Column qualification rules inside `on`:**
+
+- **Bare `Filter` / `ColumnFilter` columns** resolve to the joined alias (`<alias>` you passed). That's the natural reading because most of an ON predicate is about the joined table.
+- **`aliased(alias, col)`** emits `"<alias>"."<col>"` explicitly — use this for cross-references back to the outer table (`aliased("<outer_table>", "<col>")`) or to a previously joined alias.
+- **`WhereExpr::ExprCompare { lhs, op, rhs }`** is the right shape for column-vs-column comparisons across tables, since both sides take any `Expr`.
+
+**JoinKind tri-dialect support:**
+
+| Kind | PG | MySQL | SQLite |
+|---|---|---|---|
+| `Inner` | ✓ | ✓ | ✓ |
+| `Left` (default) | ✓ | ✓ | ✓ |
+| `Right` | ✓ | ✓ | ✗ `SqlError::JoinKindNotSupported` |
+| `Full` | ✓ | ✗ | ✗ |
+
+`Right` is easy to work around — swap operands and use `Left`. `Full` on MySQL is usually emulated with `(LEFT JOIN) UNION (RIGHT JOIN)` if you really need it.
+
+**When to reach for ad-hoc joins:**
+
+| Need | Tool |
+|---|---|
+| Pull related rows along with the main row | `select_related` (Django shape) |
+| Filter main rows by a related-table predicate | `exists(...)` / `not_exists(...)` |
+| Need both joined columns AND a custom predicate | `.join(...)` |
+| Anti-join (rows in A with NO match in B) | `not_exists(...)` |
+
+`select_related` stays the right tool when the join is "follow this FK and project all its columns." Ad-hoc joins are the escape hatch when you need: non-FK join key, INNER instead of LEFT, an extra predicate inside the ON, a self-join, or no projection at all (just predicate-driven filtering).
+
+[`WhereExpr`]: https://docs.rs/rustango/latest/rustango/core/enum.WhereExpr.html
+
 ---
 
 ## Bulk operations

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -522,9 +522,22 @@ Post::objects()
 
 **Column qualification rules inside `on`:**
 
-- **Bare `Filter` / `ColumnFilter` columns** resolve to the joined alias (`<alias>` you passed). That's the natural reading because most of an ON predicate is about the joined table.
+- **Bare `Filter` / `ColumnFilter` columns + `F()` column refs** resolve to the joined alias (`<alias>` you passed). That's the natural reading because most of an ON predicate is about the joined table.
 - **`aliased(alias, col)`** emits `"<alias>"."<col>"` explicitly — use this for cross-references back to the outer table (`aliased("<outer_table>", "<col>")`) or to a previously joined alias.
 - **`WhereExpr::ExprCompare { lhs, op, rhs }`** is the right shape for column-vs-column comparisons across tables, since both sides take any `Expr`.
+
+> ⚠️ **DANGEROUS PATTERN — typed filters from the OUTER model inside `on`.**
+> `Post::status.eq("draft").into()` produces a `WhereExpr::Predicate(Filter { column: "status", ... })` and **drops the `Post` model tag** at the `Into<WhereExpr>` boundary. The auto-qualification rule above then misroutes that filter to the **joined alias**, not to `Post`. You get `"<joined_alias>"."status" = $N` — wrong table — and the compiler can't catch it. **Use [`joins::col_filter`] for predicates against any column whose table isn't the join's default alias:**
+>
+> ```rust
+> use rustango::core::joins::{aliased, col_filter};
+> use rustango::core::Op;
+>
+> // SAFE: explicit alias on the LHS.
+> col_filter("post", "status", Op::Eq, "draft")
+> ```
+>
+> Reserve bare typed filters (`Comment::is_approved.eq(true).into()`) for columns on the JOINED model only — never for outer-model columns.
 
 **JoinKind tri-dialect support:**
 
@@ -537,16 +550,27 @@ Post::objects()
 
 `Right` is easy to work around — swap operands and use `Left`. `Full` on MySQL is usually emulated with `(LEFT JOIN) UNION (RIGHT JOIN)` if you really need it.
 
+**Other emit-time errors:**
+
+- **Empty `on` predicate** (`WhereExpr::And(vec![])` or no `ExprCompare`s) is rejected with `SqlError::EmptyJoinOnCondition`. SQL requires at least one boolean predicate inside `ON`; the auto-`true` shorthand from top-level WHERE doesn't apply here.
+
+**`project` is currently dead data on ad-hoc joins.**
+
+The `Join.project` field tells the writer to emit `<alias>"."<col>" AS "<alias>__<col>"` columns in the SELECT list. Today only `select_related` actually decodes those (via the FK-target's full-row decoder); ad-hoc joins emit the columns but the `Vec<MainModel>` decoder ignores them, so populating `project` on an ad-hoc join just adds bytes to the wire. Leave it as `vec![]` until projection-narrowing + tuple-decoding land.
+
 **When to reach for ad-hoc joins:**
 
 | Need | Tool |
 |---|---|
 | Pull related rows along with the main row | `select_related` (Django shape) |
 | Filter main rows by a related-table predicate | `exists(...)` / `not_exists(...)` |
-| Need both joined columns AND a custom predicate | `.join(...)` |
+| Filter via INNER instead of LEFT, or with extra ON predicates | `.join(...)` |
+| Self-join (e.g. `employee.manager_id = manager.id`) | `.join(...)` |
 | Anti-join (rows in A with NO match in B) | `not_exists(...)` |
 
-`select_related` stays the right tool when the join is "follow this FK and project all its columns." Ad-hoc joins are the escape hatch when you need: non-FK join key, INNER instead of LEFT, an extra predicate inside the ON, a self-join, or no projection at all (just predicate-driven filtering).
+`select_related` stays the right tool when the join is "follow this FK and project all its columns." Ad-hoc joins are the escape hatch when you need: non-FK join key, INNER instead of LEFT, an extra predicate inside the ON, or a self-join.
+
+[`joins::col_filter`]: https://docs.rs/rustango/latest/rustango/core/joins/fn.col_filter.html
 
 [`WhereExpr`]: https://docs.rs/rustango/latest/rustango/core/enum.WhereExpr.html
 


### PR DESCRIPTION
## Summary

Closes #80 — the ad-hoc join DSL filed alongside #79. **Stacked on #79** (issue-5-subqueries). Will rebase to main once the #1 → #2 → #3 → #4 → #5 → #80 chain merges.

Generalizes rustango's FK-only `LEFT JOIN` shape to a SQLAlchemy-style arbitrary-predicate join. The new public surface is `QuerySet::join(Join { … })` plus a `Join { target, alias, kind, on, project }` struct where `on` is any `WhereExpr` (same machinery as WHERE clauses), `kind` is one of `Inner` / `Left` / `Right` / `Full`, and the writer enforces dialect support at emit time.

This is the "genuinely cooler than Django" feature the user asked for during the #5 design discussion — Django's ORM has no first-class arbitrary-predicate join.

## What you get

```rust
use rustango::core::joins::aliased;
use rustango::core::{Join, JoinKind, Op, WhereExpr};

// "Posts that have at least one APPROVED comment."
Post::objects()
    .join(Join {
        target: Comment::SCHEMA,
        alias: "c",
        kind: JoinKind::Inner,
        on: WhereExpr::And(vec![
            // Column-on-column — both sides aliased.
            WhereExpr::ExprCompare {
                lhs: aliased("c", "post_id"),
                op: Op::Eq,
                rhs: aliased("post", "id"),
            },
            // Bare Filter — qualifies to the joined alias automatically.
            Comment::is_approved.eq(true).into(),
        ]),
        project: vec![],
    })
    .fetch(&pool).await?;
```

## Column qualification rules inside `on`

- **Bare `Filter` / `ColumnFilter` columns** resolve to the joined alias (`<alias>` you passed to `.join(...)`). That's the natural reading when most of the predicate is about the joined table.
- **`aliased(alias, col)`** emits `"<alias>"."<col>"` explicitly — use this for cross-references back to the outer table or to a previously-joined alias.
- **`WhereExpr::ExprCompare { lhs, op, rhs }`** is the right shape for column-vs-column comparisons across tables (both sides take any `Expr`).

## JoinKind tri-dialect matrix

| Kind | PG | MySQL | SQLite |
|---|---|---|---|
| `Inner` | ✓ | ✓ | ✓ |
| `Left` (default) | ✓ | ✓ | ✓ |
| `Right` | ✓ | ✓ | ✗ `SqlError::JoinKindNotSupported` |
| `Full` | ✓ | ✗ | ✗ |

`Right` is easy to work around — swap operands and use `Left`. `Full` on MySQL is usually emulated with `(LEFT JOIN) UNION (RIGHT JOIN)` if you really need it.

## What landed

- **`core/expr.rs`** — new `Expr::AliasedColumn { alias, column }` for explicit `<alias>.<col>` qualification. Distinct from `OuterRef` (scope-stack-resolved, used in subqueries) — `AliasedColumn` carries the alias verbatim.
- **`core/query.rs`**:
  - New `JoinKind` enum (`Inner` / `Left` (default) / `Right` / `Full`).
  - Generalized `Join` — `on_local`/`on_remote` replaced by `on: WhereExpr` + `kind: JoinKind`. Manual `PartialEq` impl updated to the new shape.
  - New `WhereExpr::ExprCompare { lhs: Expr, op: Op, rhs: Expr }` for column-on-column comparisons where both sides typically need their own alias.
- **`core/joins.rs`** (new) — `aliased(alias, col)` helper. Reads closer to SQLAlchemy's `MyModel.col` at call sites than the bare variant constructor.
- **`query/mod.rs`** — new `QuerySet::join(join: Join)` builder method + an `ad_hoc_joins` field. Compiled into `SelectQuery.joins` AFTER any `select_related` joins so column ordering stays stable for legacy callers. `lower_select_related` migrated to the new `Join` shape (emits identical SQL, just via `WhereExpr::ExprCompare` now).
- **`admin/helpers.rs`** — `build_fk_joins` (admin's FK lookup helper) migrated to the new shape.
- **`sql/writers.rs`**:
  - JOIN emission rewritten to dispatch on `JoinKind` and walk the `on` WhereExpr.
  - ON predicate threads `qualify_with: Some(join.alias)` so bare `Filter` / `ColumnFilter` columns resolve to the joined alias.
  - New `write_expr_compare` helper for `WhereExpr::ExprCompare`.
  - New `Expr::AliasedColumn` arm in `write_expr`.
  - Dialect rejection: `Right` on SQLite + `Full` on MySQL/SQLite both raise the new `SqlError::JoinKindNotSupported`.
- **`sql/error.rs`** — new `JoinKindNotSupported { kind, dialect }`.

## Tests

| Suite | Count |
|---|---|
| `core::joins::tests` (unit) | 1 |
| `tests/adhoc_joins.rs` (tri-dialect emission) | 11 |
| `tests/adhoc_joins_live.rs` (live PG runtime) | 2 |

The 11 emission tests cover: per-kind keyword emission (Inner/Left/Right/Full); dialect rejection (SQLite-Right, MySQL-Full, SQLite-Full); bare-Filter inside ON auto-qualifies to the joined alias; `aliased()` emits explicit table prefix; multi-join ordering preserved; MySQL backticks + SQLite double-quotes shape.

The 2 live PG tests: `INNER JOIN` with extra predicate filters outer rows (only posts with approved comments survive); `LEFT JOIN` preserves every outer row without a match.

## Cookbook

New "Ad-hoc joins — `.join(Join { … })`" subsection in `docs/orm.md` under the existing "Joins + select_related" section. Documents the qualification rules, the tri-dialect support matrix, and a decision table for `select_related` vs `exists` vs `.join(...)`.

## Verification

```
cargo test -p rustango --lib --features tenancy                  → 1478 passed (+1 aliased unit test)
cargo test --features tenancy,mysql,sqlite --test adhoc_joins    → 11 passed
DATABASE_URL=... cargo test --features tenancy --test adhoc_joins_live → 2 passed
cargo check --no-default-features --features sqlite,tenancy      → clean
cargo check --features mysql,tenancy                             → clean
```

## Out of scope for this PR

- LATERAL joins (PG-only)
- CROSS / NATURAL JOIN
- JOIN against a subquery (`JOIN (SELECT …) AS t ON …`)
- Auto-alias allocation (user always provides explicit alias today)
- Tuple/multi-model fetch — ad-hoc joins are filter-only in v1; existing `select_related` still pulls in projected columns

These can land as follow-ups if demand surfaces.

## Test plan

- [x] 1 unit test passes.
- [x] 11 tri-dialect emission tests pass.
- [x] 2 live PG tests pass.
- [x] All three feature combos compile.
- [x] Cookbook section + tri-dialect matrix + decision table added.
- [ ] CI green on `postgres_test` + `mysql_live` + `sqlite_live` + `sqlite_litmus`.
- [ ] Rebase to main once #79 merges.
