### PR TITLE
Aggregate filter= / default= / StdDev / Variance (closes #6)

### DIFF
--- a/crates/rustango/src/core/aggregates.rs
+++ b/crates/rustango/src/core/aggregates.rs
@@ -1,0 +1,289 @@
+//! Conditional aggregates + StdDev/Variance builders — issue #6.
+//!
+//! Sixth slice of the ORM Expression DSL epic. Closes the Django gap
+//! around `Count("id", filter=Q(...))` / `Sum("price", default=0)` and
+//! adds the `StdDev` + `Variance` families. Builds directly on the
+//! `Expr::Case` machinery from #4 (the non-PG `FILTER (WHERE …)`
+//! fallback is `CASE WHEN`) and on the `WhereExpr` predicate machinery
+//! end-to-end.
+//!
+//! ```ignore
+//! use rustango::core::aggregates::{count, sum, avg};
+//! use rustango::core::Column as _;
+//!
+//! Post::objects()
+//!     .aggregate("posts_total", count("id"))
+//!     .aggregate("active_posts", count("id").filter(Post::active.eq(true)))
+//!     .aggregate(
+//!         "revenue_or_zero",
+//!         sum("price")
+//!             .filter(Post::status.eq("published"))
+//!             .default(0_i64),
+//!     )
+//!     .compute(&pool).await?;
+//! ```
+//!
+//! ## Build order
+//!
+//! Call `.filter(...)` first, then `.default(...)` — the builder wraps
+//! `Filtered` *inside* `Coalesced` so the emitted SQL is
+//! `COALESCE(SUM(col) FILTER (WHERE pred), default)`. Calling them in
+//! the opposite order on the chain produces the same IR (the builder
+//! stores both fields flat and lowers on `.build()`).
+//!
+//! ## Dialect support matrix
+//!
+//! | Aggregate / wrapper | PG | MySQL | SQLite |
+//! |---|---|---|---|
+//! | `Count` / `Sum` / `Avg` / `Max` / `Min` | ✓ | ✓ | ✓ |
+//! | `CountDistinct` | ✓ | ✓ | ✓ (3.35+) |
+//! | `StdDev` / `StdDevPop` | ✓ | ✓ (8.0+) | ✗ |
+//! | `Variance` / `VariancePop` | ✓ | ✓ (8.0+) | ✗ |
+//! | `Filtered { … }` (`FILTER (WHERE …)`) | ✓ native | ✓ via `CASE WHEN` | ✓ native (3.30+) |
+//! | `Coalesced { …, default }` (`COALESCE`) | ✓ | ✓ | ✓ |
+
+use super::query::{AggregateExpr, WhereExpr};
+use super::SqlValue;
+
+/// Fluent wrapper around an [`AggregateExpr`]. Built via the free
+/// functions in this module ([`count`], [`sum`], …); finalize by
+/// passing into anything that takes `impl Into<AggregateExpr>` (e.g.
+/// `QuerySet::aggregate`).
+#[must_use]
+pub struct AggregateBuilder {
+    kind: AggregateExpr,
+    filter: Option<WhereExpr>,
+    default: Option<SqlValue>,
+}
+
+impl AggregateBuilder {
+    fn new(kind: AggregateExpr) -> Self {
+        Self {
+            kind,
+            filter: None,
+            default: None,
+        }
+    }
+
+    /// Attach a `FILTER (WHERE predicate)` clause to this aggregate.
+    /// The writer emits the SQL-standard `FILTER` form on PG + SQLite
+    /// (3.30+) and rewrites to `<agg>(CASE WHEN predicate THEN <arg>
+    /// END)` on MySQL.
+    ///
+    /// Composes with `.and()` / `.or()` / `WhereExpr` like a regular
+    /// WHERE clause:
+    ///
+    /// ```ignore
+    /// count("id").filter(Post::status.eq("published").and(Post::pages.gt(100)))
+    /// ```
+    pub fn filter(mut self, predicate: impl Into<WhereExpr>) -> Self {
+        self.filter = Some(predicate.into());
+        self
+    }
+
+    /// Attach a `COALESCE(<aggregate>, default)` empty-result fallback.
+    /// On a queryset that returns zero rows, the aggregate would
+    /// otherwise be `NULL`; this rewrites to a typed scalar.
+    ///
+    /// ```ignore
+    /// sum("price").default(0_i64)
+    /// // → COALESCE(SUM("price"), 0)
+    /// ```
+    pub fn default(mut self, value: impl Into<SqlValue>) -> Self {
+        self.default = Some(value.into());
+        self
+    }
+
+    /// Finalize to an [`AggregateExpr`]. Same as `Into<AggregateExpr>`
+    /// — provided as a method when type inference would otherwise
+    /// need help.
+    ///
+    /// Wrap order: `Filtered` is always *inside* `Coalesced` when
+    /// both are set, so the emitted SQL is
+    /// `COALESCE(<agg> FILTER (WHERE …), default)`.
+    #[must_use]
+    pub fn build(self) -> AggregateExpr {
+        let mut out = self.kind;
+        if let Some(f) = self.filter {
+            out = AggregateExpr::Filtered {
+                inner: Box::new(out),
+                filter: f,
+            };
+        }
+        if let Some(d) = self.default {
+            out = AggregateExpr::Coalesced {
+                inner: Box::new(out),
+                default: d,
+            };
+        }
+        out
+    }
+}
+
+impl From<AggregateBuilder> for AggregateExpr {
+    fn from(b: AggregateBuilder) -> Self {
+        b.build()
+    }
+}
+
+/// `COUNT(column)` — counts non-NULL values in `column`. For
+/// `COUNT(*)`, use [`count_all`].
+#[must_use]
+pub fn count(column: &'static str) -> AggregateBuilder {
+    AggregateBuilder::new(AggregateExpr::Count(Some(column)))
+}
+
+/// `COUNT(*)` — counts every row regardless of NULL.
+#[must_use]
+pub fn count_all() -> AggregateBuilder {
+    AggregateBuilder::new(AggregateExpr::Count(None))
+}
+
+/// `COUNT(DISTINCT column)` — counts distinct non-NULL values.
+#[must_use]
+pub fn count_distinct(column: &'static str) -> AggregateBuilder {
+    AggregateBuilder::new(AggregateExpr::CountDistinct(column))
+}
+
+/// `SUM(column)`. Combined with `.default(0)`, produces the
+/// "treat empty-result as zero" Django shape.
+#[must_use]
+pub fn sum(column: &'static str) -> AggregateBuilder {
+    AggregateBuilder::new(AggregateExpr::Sum(column))
+}
+
+/// `AVG(column)`.
+#[must_use]
+pub fn avg(column: &'static str) -> AggregateBuilder {
+    AggregateBuilder::new(AggregateExpr::Avg(column))
+}
+
+/// `MAX(column)`.
+#[must_use]
+pub fn max(column: &'static str) -> AggregateBuilder {
+    AggregateBuilder::new(AggregateExpr::Max(column))
+}
+
+/// `MIN(column)`.
+#[must_use]
+pub fn min(column: &'static str) -> AggregateBuilder {
+    AggregateBuilder::new(AggregateExpr::Min(column))
+}
+
+/// `STDDEV_SAMP(column)` — sample standard deviation. Native on PG
+/// and MySQL 8+; SQLite has no built-in stddev and the writer raises
+/// `SqlError::AggregateNotSupported` (matches Django behavior).
+#[must_use]
+pub fn stddev(column: &'static str) -> AggregateBuilder {
+    AggregateBuilder::new(AggregateExpr::StdDev(column))
+}
+
+/// `STDDEV_POP(column)` — population standard deviation. Same
+/// dialect-support story as [`stddev`].
+#[must_use]
+pub fn stddev_pop(column: &'static str) -> AggregateBuilder {
+    AggregateBuilder::new(AggregateExpr::StdDevPop(column))
+}
+
+/// `VAR_SAMP(column)` — sample variance. Same dialect-support
+/// story as [`stddev`].
+#[must_use]
+pub fn variance(column: &'static str) -> AggregateBuilder {
+    AggregateBuilder::new(AggregateExpr::Variance(column))
+}
+
+/// `VAR_POP(column)` — population variance. Same dialect-support
+/// story as [`stddev`].
+#[must_use]
+pub fn variance_pop(column: &'static str) -> AggregateBuilder {
+    AggregateBuilder::new(AggregateExpr::VariancePop(column))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{Filter, Op};
+
+    fn predicate(col: &'static str) -> WhereExpr {
+        WhereExpr::Predicate(Filter {
+            column: col,
+            op: Op::Eq,
+            value: SqlValue::Bool(true),
+        })
+    }
+
+    #[test]
+    fn bare_count_lowers_to_count_variant() {
+        let e: AggregateExpr = count("id").into();
+        assert!(matches!(e, AggregateExpr::Count(Some("id"))));
+    }
+
+    #[test]
+    fn count_all_emits_count_none() {
+        let e: AggregateExpr = count_all().into();
+        assert!(matches!(e, AggregateExpr::Count(None)));
+    }
+
+    #[test]
+    fn filter_wraps_in_filtered_variant() {
+        let e: AggregateExpr = count("id").filter(predicate("active")).into();
+        assert!(matches!(e, AggregateExpr::Filtered { .. }));
+    }
+
+    #[test]
+    fn default_wraps_in_coalesced_variant() {
+        let e: AggregateExpr = sum("price").default(0_i64).into();
+        assert!(matches!(e, AggregateExpr::Coalesced { .. }));
+    }
+
+    #[test]
+    fn filter_then_default_wraps_coalesced_outside_filtered() {
+        let e: AggregateExpr = sum("price")
+            .filter(predicate("active"))
+            .default(0_i64)
+            .into();
+        match e {
+            AggregateExpr::Coalesced { inner, .. } => match *inner {
+                AggregateExpr::Filtered { inner, .. } => {
+                    assert!(matches!(*inner, AggregateExpr::Sum("price")));
+                }
+                _ => panic!("expected Filtered inside Coalesced"),
+            },
+            _ => panic!("expected Coalesced at the top"),
+        }
+    }
+
+    #[test]
+    fn default_then_filter_still_wraps_coalesced_outside_filtered() {
+        // Builder normalizes regardless of chain order — both fields
+        // are stored flat and lowered on `.build()`.
+        let e: AggregateExpr = sum("price")
+            .default(0_i64)
+            .filter(predicate("active"))
+            .into();
+        match e {
+            AggregateExpr::Coalesced { inner, .. } => match *inner {
+                AggregateExpr::Filtered { .. } => {}
+                _ => panic!("expected Filtered inside Coalesced"),
+            },
+            _ => panic!("expected Coalesced at the top"),
+        }
+    }
+
+    #[test]
+    fn stddev_family_lowers_to_dedicated_variants() {
+        assert!(matches!(stddev("x").build(), AggregateExpr::StdDev("x")));
+        assert!(matches!(
+            stddev_pop("x").build(),
+            AggregateExpr::StdDevPop("x")
+        ));
+        assert!(matches!(
+            variance("x").build(),
+            AggregateExpr::Variance("x")
+        ));
+        assert!(matches!(
+            variance_pop("x").build(),
+            AggregateExpr::VariancePop("x")
+        ));
+    }
+}

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -3,6 +3,7 @@
 //! This crate is dependency-light on purpose: no async, no DB drivers, no proc-macros.
 //! Anything that needs to be referenced by both the macro output and the runtime lives here.
 
+pub mod aggregates;
 pub mod case;
 mod column;
 mod error;

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -665,6 +665,20 @@ pub struct BulkUpdateQuery {
 }
 
 /// One aggregate expression in an [`AggregateQuery`].
+///
+/// The flat variants (`Count`, `Sum`, etc.) emit the standard
+/// `AGG(col)` shape; the two recursive wrappers ([`Filtered`] and
+/// [`Coalesced`], issue #6) compose on top to add a `FILTER (WHERE …)`
+/// predicate or a `COALESCE(…, default)` empty-result fallback.
+///
+/// Build via the higher-level helpers in [`crate::core::aggregates`]
+/// (`count`/`sum`/`avg`/`max`/`min`/`count_distinct`/`stddev`/
+/// `stddev_pop`/`variance`/`variance_pop`) rather than constructing
+/// these variants directly — the builder enforces the right wrap
+/// order (`Coalesced` outside `Filtered`).
+///
+/// [`Filtered`]: AggregateExpr::Filtered
+/// [`Coalesced`]: AggregateExpr::Coalesced
 #[derive(Debug, Clone)]
 pub enum AggregateExpr {
     /// `COUNT(*)` or `COUNT(column)` when `column` is `Some`.
@@ -680,6 +694,36 @@ pub enum AggregateExpr {
     Max(&'static str),
     /// `MIN(column)`.
     Min(&'static str),
+    /// `STDDEV_SAMP(column)` — sample standard deviation. Issue #6.
+    /// Native on PG + MySQL 8+; the writer raises
+    /// [`crate::sql::SqlError::AggregateNotSupported`] on SQLite,
+    /// which has no built-in stddev (matches Django behavior).
+    StdDev(&'static str),
+    /// `STDDEV_POP(column)` — population standard deviation. Issue #6.
+    /// Same dialect-support story as [`StdDev`](AggregateExpr::StdDev).
+    StdDevPop(&'static str),
+    /// `VAR_SAMP(column)` — sample variance. Issue #6.
+    /// Same dialect-support story as [`StdDev`](AggregateExpr::StdDev).
+    Variance(&'static str),
+    /// `VAR_POP(column)` — population variance. Issue #6.
+    /// Same dialect-support story as [`StdDev`](AggregateExpr::StdDev).
+    VariancePop(&'static str),
+    /// `<inner> FILTER (WHERE <filter>)` on PG / SQLite (3.30+);
+    /// `<inner-with-CASE-WHEN-arg>` on MySQL. Issue #6. Wraps any
+    /// base aggregate (Count/Sum/Avg/Max/Min/CountDistinct/StdDev/
+    /// Variance/etc.) — nested `Filtered` is rejected at emit time
+    /// to keep emission unambiguous.
+    Filtered {
+        inner: Box<AggregateExpr>,
+        filter: WhereExpr,
+    },
+    /// `COALESCE(<inner>, <default>)` — empty-result fallback. Issue #6.
+    /// Always outermost when combined with `Filtered` (builder enforces
+    /// the order); nested `Coalesced` is rejected at emit time.
+    Coalesced {
+        inner: Box<AggregateExpr>,
+        default: SqlValue,
+    },
 }
 
 /// A `SELECT … GROUP BY … HAVING …` query. Returned rows are untyped

--- a/crates/rustango/src/sql/error.rs
+++ b/crates/rustango/src/sql/error.rs
@@ -169,6 +169,27 @@ pub enum SqlError {
     #[error("JOIN `on` predicate must not be empty")]
     EmptyJoinOnCondition,
 
+    /// An aggregate function isn't supported by the active dialect
+    /// (issue #6). Today raised only for `StdDev` / `StdDevPop` /
+    /// `Variance` / `VariancePop` on SQLite, which has no built-in
+    /// statistical aggregates. Caller can either switch dialects,
+    /// drop the offending annotation, or compute the variance
+    /// formula in app code.
+    #[error("aggregate `{aggregate}` is not supported by the `{dialect}` dialect")]
+    AggregateNotSupported {
+        aggregate: &'static str,
+        dialect: &'static str,
+    },
+
+    /// An ill-formed `AggregateExpr` tree was passed in (issue #6) —
+    /// e.g. `Coalesced { Coalesced { … } }` or `Filtered { Filtered {
+    /// … } }`. The public [`crate::core::aggregates`] builder never
+    /// produces these, so this is a "hand-rolled IR" programmer
+    /// error. `wrapper` names the offending shape for the error
+    /// message.
+    #[error("nested aggregate wrapper `{wrapper}` is not supported")]
+    NestedAggregateWrapper { wrapper: &'static str },
+
     /// A [`crate::core::JoinKind`] was used on a dialect that doesn't
     /// support it (issue #80). Today: `Right` on SQLite, `Full` on
     /// SQLite + MySQL. Caller can either switch dialects, restructure

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -266,43 +266,7 @@ pub(super) fn write_aggregate(b: &mut Sql<'_>, query: &AggregateQuery) -> Result
         if !query.group_by.is_empty() || i > 0 {
             b.sql.push_str(", ");
         }
-        match expr {
-            AggregateExpr::Count(None) => b.sql.push_str("COUNT(*)"),
-            AggregateExpr::Count(Some(col)) => {
-                b.sql.push_str("COUNT(");
-                b.write_ident(col);
-                b.sql.push(')');
-            }
-            AggregateExpr::CountDistinct(col) => {
-                b.sql.push_str("COUNT(DISTINCT ");
-                b.write_ident(col);
-                b.sql.push(')');
-            }
-            AggregateExpr::Sum(col) => {
-                // Both PG and MySQL widen SUM(int) into a type the
-                // SqlValue aggregate decoder doesn't try (PG NUMERIC,
-                // MySQL DECIMAL). Ask the dialect to cast back to a
-                // known scalar so the i64 decode arm picks it up.
-                let inner = format!("SUM({})", b.d.quote_ident(col));
-                let wrapped = b.d.cast_aggregate_to_int(&inner);
-                b.sql.push_str(&wrapped);
-            }
-            AggregateExpr::Avg(col) => {
-                let inner = format!("AVG({})", b.d.quote_ident(col));
-                let wrapped = b.d.cast_aggregate_to_float(&inner);
-                b.sql.push_str(&wrapped);
-            }
-            AggregateExpr::Max(col) => {
-                b.sql.push_str("MAX(");
-                b.write_ident(col);
-                b.sql.push(')');
-            }
-            AggregateExpr::Min(col) => {
-                b.sql.push_str("MIN(");
-                b.write_ident(col);
-                b.sql.push(')');
-            }
-        }
+        write_aggregate_expr(b, expr, query.model)?;
         b.sql.push_str(" AS ");
         b.write_ident(alias);
     }
@@ -329,6 +293,244 @@ pub(super) fn write_aggregate(b: &mut Sql<'_>, query: &AggregateQuery) -> Result
     write_order_limit_offset(b, &query.order_by, query.limit, query.offset, None);
 
     Ok(())
+}
+
+/// What kind of decoder-side cast a base aggregate needs.
+/// PG widens `SUM(bigint)` to NUMERIC and `AVG/STDDEV/VAR_*(bigint)`
+/// to NUMERIC too; MySQL widens to DECIMAL/DOUBLE. The SqlValue
+/// decoder only tries `i64`/`f64`, so the writer post-wraps the
+/// aggregate call to a target type per dialect.
+#[derive(Debug, Clone, Copy)]
+enum AggCast {
+    Int,
+    Float,
+}
+
+/// Return the cast a flat aggregate variant needs, or `None` for
+/// aggregates whose native return type the decoder already handles
+/// (Count, CountDistinct, Max, Min — return i64 on every dialect).
+fn aggregate_cast_kind(expr: &AggregateExpr) -> Option<AggCast> {
+    match expr {
+        AggregateExpr::Sum(_) => Some(AggCast::Int),
+        AggregateExpr::Avg(_)
+        | AggregateExpr::StdDev(_)
+        | AggregateExpr::StdDevPop(_)
+        | AggregateExpr::Variance(_)
+        | AggregateExpr::VariancePop(_) => Some(AggCast::Float),
+        _ => None,
+    }
+}
+
+/// Apply the dialect's cast helper to an already-emitted aggregate
+/// call (or filtered aggregate call). For PG the form is
+/// `<expr>::bigint` / `<expr>::double precision`; MySQL wraps with
+/// `CAST(... AS SIGNED/DOUBLE)`; SQLite with `CAST(... AS INTEGER/REAL)`.
+fn apply_agg_cast(d: &dyn Dialect, kind: AggCast, inner: &str) -> String {
+    match kind {
+        AggCast::Int => d.cast_aggregate_to_int(inner),
+        AggCast::Float => d.cast_aggregate_to_float(inner),
+    }
+}
+
+/// Format the bare aggregate-call SQL (no decoder-side cast) for one
+/// of the flat variants. Doesn't write to `b.sql` — the caller
+/// composes it (optionally inside a FILTER clause, then post-wraps
+/// with `apply_agg_cast` for cast-needing kinds).
+fn format_bare_aggregate(b: &Sql<'_>, expr: &AggregateExpr) -> Result<String, SqlError> {
+    Ok(match expr {
+        AggregateExpr::Count(None) => "COUNT(*)".into(),
+        AggregateExpr::Count(Some(col)) => format!("COUNT({})", b.d.quote_ident(col)),
+        AggregateExpr::CountDistinct(col) => {
+            format!("COUNT(DISTINCT {})", b.d.quote_ident(col))
+        }
+        AggregateExpr::Sum(col) => format!("SUM({})", b.d.quote_ident(col)),
+        AggregateExpr::Avg(col) => format!("AVG({})", b.d.quote_ident(col)),
+        AggregateExpr::Max(col) => format!("MAX({})", b.d.quote_ident(col)),
+        AggregateExpr::Min(col) => format!("MIN({})", b.d.quote_ident(col)),
+        AggregateExpr::StdDev(col)
+        | AggregateExpr::StdDevPop(col)
+        | AggregateExpr::Variance(col)
+        | AggregateExpr::VariancePop(col) => {
+            if b.d.name() == "sqlite" {
+                return Err(SqlError::AggregateNotSupported {
+                    aggregate: stddev_variance_name(expr),
+                    dialect: b.d.name(),
+                });
+            }
+            format!("{}({})", stddev_variance_name(expr), b.d.quote_ident(col))
+        }
+        AggregateExpr::Filtered { .. } | AggregateExpr::Coalesced { .. } => {
+            // `format_bare_aggregate` is only called with a flat
+            // variant — the wrappers are unwrapped first.
+            return Err(SqlError::NestedAggregateWrapper {
+                wrapper: "wrapper at format_bare_aggregate site",
+            });
+        }
+    })
+}
+
+/// Emit one aggregate expression. Recursive for `Filtered` and
+/// `Coalesced` wrappers (issue #6). Dialect dispatch happens here:
+/// PG + SQLite (3.30+) emit native `FILTER (WHERE …)`; MySQL rewrites
+/// to `<agg>(CASE WHEN … THEN <arg> END)`. `Coalesced` always emits
+/// `COALESCE(<inner>, <default>)` regardless of dialect.
+fn write_aggregate_expr(
+    b: &mut Sql<'_>,
+    expr: &AggregateExpr,
+    model: &'static ModelSchema,
+) -> Result<(), SqlError> {
+    match expr {
+        AggregateExpr::Coalesced { inner, default } => {
+            if matches!(inner.as_ref(), AggregateExpr::Coalesced { .. }) {
+                return Err(SqlError::NestedAggregateWrapper {
+                    wrapper: "Coalesced",
+                });
+            }
+            b.sql.push_str("COALESCE(");
+            write_aggregate_expr(b, inner, model)?;
+            b.sql.push_str(", ");
+            let cast = aggregate_column(inner).and_then(|c| null_cast_for(b.d, model, c));
+            b.push_param_typed(default.clone(), cast);
+            b.sql.push(')');
+            Ok(())
+        }
+        AggregateExpr::Filtered { inner, filter } => {
+            if matches!(inner.as_ref(), AggregateExpr::Filtered { .. }) {
+                return Err(SqlError::NestedAggregateWrapper {
+                    wrapper: "Filtered",
+                });
+            }
+            if matches!(inner.as_ref(), AggregateExpr::Coalesced { .. }) {
+                return Err(SqlError::NestedAggregateWrapper {
+                    wrapper: "Filtered(Coalesced)",
+                });
+            }
+            // MySQL: no FILTER keyword — rewrite via CASE WHEN. The
+            // helper applies the dialect's cast helper post-emit for
+            // Sum/Avg/StdDev/etc.
+            if b.d.name() == "mysql" {
+                return write_aggregate_as_case_when(b, inner, filter);
+            }
+            // PG + SQLite (3.30+): native FILTER. Emit
+            // `<bare> FILTER (WHERE <pred>)` into a slice, then
+            // post-wrap with the dialect's cast helper (the cast can't
+            // sit between `<bare>` and `FILTER` on PG — `SUM(x)::bigint
+            // FILTER (...)` is a parse error — so we apply the cast
+            // around `(<bare> FILTER (...))`).
+            let bare = format_bare_aggregate(b, inner)?;
+            let prior = b.sql.len();
+            b.sql.push_str(&bare);
+            b.sql.push_str(" FILTER (WHERE ");
+            write_where_expr(b, filter, None, Some(model))?;
+            b.sql.push(')');
+            if let Some(kind) = aggregate_cast_kind(inner) {
+                let emitted = b.sql[prior..].to_string();
+                b.sql.truncate(prior);
+                let wrapped = apply_agg_cast(b.d, kind, &format!("({emitted})"));
+                b.sql.push_str(&wrapped);
+            }
+            Ok(())
+        }
+        _ => write_aggregate_kind(b, expr),
+    }
+}
+
+/// Emit one of the flat aggregate variants (no `Filtered` /
+/// `Coalesced` wrappers). Pairs `format_bare_aggregate` with a
+/// dialect-aware cast wrap for the kinds whose native return type
+/// the decoder can't otherwise unwrap.
+fn write_aggregate_kind(b: &mut Sql<'_>, expr: &AggregateExpr) -> Result<(), SqlError> {
+    let bare = format_bare_aggregate(b, expr)?;
+    let out = match aggregate_cast_kind(expr) {
+        Some(kind) => apply_agg_cast(b.d, kind, &bare),
+        None => bare,
+    };
+    b.sql.push_str(&out);
+    Ok(())
+}
+
+/// MySQL fallback for `<inner> FILTER (WHERE predicate)`: rewrite to
+/// `<agg>(CASE WHEN predicate THEN <argument> END)`. The `<argument>`
+/// depends on the aggregate kind: `COUNT(*)` becomes
+/// `COUNT(CASE WHEN p THEN 1 END)`, everything else becomes
+/// `<AGG>(CASE WHEN p THEN <col> END)`.
+fn write_aggregate_as_case_when(
+    b: &mut Sql<'_>,
+    inner: &AggregateExpr,
+    filter: &WhereExpr,
+) -> Result<(), SqlError> {
+    // Pick the aggregate keyword (and CASE-THEN argument) for the
+    // emission. COUNT(*) gets `THEN 1`; everything else gets `THEN
+    // <col>`. CountDistinct prefixes the CASE with `DISTINCT`.
+    let (agg_kw, case_then, distinct_prefix) = match inner {
+        AggregateExpr::Count(None) => ("COUNT", None, ""),
+        AggregateExpr::Count(Some(col)) => ("COUNT", Some(*col), ""),
+        AggregateExpr::CountDistinct(col) => ("COUNT", Some(*col), "DISTINCT "),
+        AggregateExpr::Sum(col) => ("SUM", Some(*col), ""),
+        AggregateExpr::Avg(col) => ("AVG", Some(*col), ""),
+        AggregateExpr::Max(col) => ("MAX", Some(*col), ""),
+        AggregateExpr::Min(col) => ("MIN", Some(*col), ""),
+        AggregateExpr::StdDev(col)
+        | AggregateExpr::StdDevPop(col)
+        | AggregateExpr::Variance(col)
+        | AggregateExpr::VariancePop(col) => (stddev_variance_name(inner), Some(*col), ""),
+        AggregateExpr::Filtered { .. } | AggregateExpr::Coalesced { .. } => {
+            return Err(SqlError::NestedAggregateWrapper {
+                wrapper: "wrapper inside Filtered fallback",
+            });
+        }
+    };
+    let prior = b.sql.len();
+    b.sql.push_str(agg_kw);
+    b.sql.push('(');
+    b.sql.push_str(distinct_prefix);
+    b.sql.push_str("CASE WHEN ");
+    write_where_expr(b, filter, None, None)?;
+    b.sql.push_str(" THEN ");
+    match case_then {
+        Some(col) => b.write_ident(col),
+        None => b.sql.push('1'),
+    }
+    b.sql.push_str(" END)");
+    // Apply the dialect's cast wrap for Sum/Avg/StdDev/Variance —
+    // same shape the flat path uses.
+    if let Some(kind) = aggregate_cast_kind(inner) {
+        let emitted = b.sql[prior..].to_string();
+        b.sql.truncate(prior);
+        let wrapped = apply_agg_cast(b.d, kind, &emitted);
+        b.sql.push_str(&wrapped);
+    }
+    Ok(())
+}
+
+/// Look up the column referenced by a flat aggregate variant (or by
+/// the inner of a wrapper). Returns `None` for `Count(None)` (no column).
+fn aggregate_column(expr: &AggregateExpr) -> Option<&'static str> {
+    match expr {
+        AggregateExpr::Count(c) => *c,
+        AggregateExpr::CountDistinct(c)
+        | AggregateExpr::Sum(c)
+        | AggregateExpr::Avg(c)
+        | AggregateExpr::Max(c)
+        | AggregateExpr::Min(c)
+        | AggregateExpr::StdDev(c)
+        | AggregateExpr::StdDevPop(c)
+        | AggregateExpr::Variance(c)
+        | AggregateExpr::VariancePop(c) => Some(c),
+        AggregateExpr::Filtered { inner, .. } | AggregateExpr::Coalesced { inner, .. } => {
+            aggregate_column(inner)
+        }
+    }
+}
+
+fn stddev_variance_name(expr: &AggregateExpr) -> &'static str {
+    match expr {
+        AggregateExpr::StdDev(_) => "STDDEV_SAMP",
+        AggregateExpr::StdDevPop(_) => "STDDEV_POP",
+        AggregateExpr::Variance(_) => "VAR_SAMP",
+        AggregateExpr::VariancePop(_) => "VAR_POP",
+        _ => "(unknown)", // not reachable from public paths
+    }
 }
 
 // ====================================================================

--- a/crates/rustango/tests/aggregate_filter.rs
+++ b/crates/rustango/tests/aggregate_filter.rs
@@ -1,0 +1,399 @@
+//! Tri-dialect emission tests for filtered aggregates +
+//! StdDev/Variance + COALESCE-on-empty (issue #6). PG + SQLite (3.30+)
+//! use native `FILTER (WHERE …)`; MySQL falls back to
+//! `<agg>(CASE WHEN … THEN <arg> END)`. SQLite rejects
+//! StdDev/Variance — no built-in.
+
+use rustango::core::aggregates::{
+    avg, count, count_all, count_distinct, max, min, stddev, stddev_pop, sum, variance,
+    variance_pop,
+};
+use rustango::core::{
+    AggregateExpr, AggregateQuery, Column as _, Filter, Model as _, Op, SqlValue, WhereExpr,
+};
+use rustango::sql::{Dialect, MySql, Postgres, SqlError, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "af_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 20)]
+    status: String,
+    is_active: bool,
+    price: i64,
+    pages: i64,
+}
+
+fn agg(expr: AggregateExpr) -> AggregateQuery {
+    AggregateQuery {
+        model: Post::SCHEMA,
+        where_clause: WhereExpr::And(vec![]),
+        aggregates: vec![("agg", expr)],
+        group_by: vec![],
+        having: None,
+        order_by: vec![],
+        limit: None,
+        offset: None,
+    }
+}
+
+// ---------- Plain aggregates (regression for the writer refactor) ----------
+
+#[test]
+fn flat_count_unchanged_after_refactor() {
+    let q = agg(count("id").into());
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(stmt.sql.contains(r#"COUNT("id") AS "agg""#));
+}
+
+#[test]
+fn flat_count_all_unchanged_after_refactor() {
+    let q = agg(count_all().into());
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(stmt.sql.contains(r#"COUNT(*) AS "agg""#));
+}
+
+#[test]
+fn flat_count_distinct_unchanged_after_refactor() {
+    let q = agg(count_distinct("status").into());
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(stmt.sql.contains(r#"COUNT(DISTINCT "status") AS "agg""#));
+}
+
+// ---------- FILTER (WHERE …) — PG + SQLite native ----------
+
+#[test]
+fn pg_filtered_count_emits_filter_where_clause() {
+    let q = agg(count_all().filter(Post::is_active.eq(true)).into());
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"COUNT(*) FILTER (WHERE "is_active" = $1)"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn sqlite_filtered_count_uses_native_filter_keyword() {
+    // SQLite ≥3.30 supports FILTER natively — confirm we emit the
+    // SQL-standard form, not the CASE WHEN fallback.
+    let q = agg(count_all().filter(Post::is_active.eq(true)).into());
+    let stmt = Sqlite.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"COUNT(*) FILTER (WHERE "is_active" = ?)"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn pg_filtered_sum_keeps_int_cast_wrap_through_filter() {
+    let q = agg(sum("price").filter(Post::status.eq("published")).into());
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    // The cast must wrap the (agg FILTER (...)) form on PG —
+    // `SUM(x)::bigint FILTER (...)` is a parse error because `::`
+    // binds tightly. Emit the cast around the parenthesized FILTER.
+    assert!(
+        stmt.sql
+            .contains(r#"(SUM("price") FILTER (WHERE "status" = $1))::bigint"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+// ---------- MySQL CASE WHEN fallback ----------
+
+#[test]
+fn mysql_filtered_count_rewrites_to_case_when() {
+    let q = agg(count_all().filter(Post::is_active.eq(true)).into());
+    let stmt = MySql.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql
+            .contains("COUNT(CASE WHEN `is_active` = ? THEN 1 END)"),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn mysql_filtered_count_column_arg_uses_column_in_case_then() {
+    let q = agg(count("id").filter(Post::is_active.eq(true)).into());
+    let stmt = MySql.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql
+            .contains("COUNT(CASE WHEN `is_active` = ? THEN `id` END)"),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn mysql_filtered_sum_keeps_dialect_int_cast() {
+    // The MySQL Sum arm wraps the CASE-WHEN sum with the dialect's
+    // int cast — same way the flat path does. Confirms the
+    // `emit_filtered_with_cast` helper threads the wrapper.
+    let q = agg(sum("price").filter(Post::status.eq("published")).into());
+    let stmt = MySql.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql
+            .contains("SUM(CASE WHEN `status` = ? THEN `price` END)"),
+        "core form: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn mysql_filtered_distinct_count_rewrites_to_case_when() {
+    let q = agg(count_distinct("status")
+        .filter(Post::is_active.eq(true))
+        .into());
+    let stmt = MySql.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql
+            .contains("COUNT(DISTINCT CASE WHEN `is_active` = ? THEN `status` END)"),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn mysql_filtered_max_min_avg_rewrite_uniformly() {
+    for (b_kind, expected_kw) in [("MAX", "MAX"), ("MIN", "MIN"), ("AVG", "AVG")] {
+        let agg_expr: AggregateExpr = match b_kind {
+            "MAX" => max("pages").filter(Post::status.eq("draft")).into(),
+            "MIN" => min("pages").filter(Post::status.eq("draft")).into(),
+            "AVG" => avg("pages").filter(Post::status.eq("draft")).into(),
+            _ => unreachable!(),
+        };
+        let stmt = MySql.compile_aggregate(&agg(agg_expr)).unwrap();
+        let needle = format!("{expected_kw}(CASE WHEN `status` = ? THEN `pages` END)");
+        assert!(
+            stmt.sql.contains(&needle),
+            "{b_kind} fallback shape: {}",
+            stmt.sql
+        );
+    }
+}
+
+// ---------- COALESCE-on-empty (default=) ----------
+
+#[test]
+fn pg_default_wraps_in_coalesce() {
+    let q = agg(sum("price").default(0_i64).into());
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    // The inner `SUM("price")` keeps its `::bigint` cast; COALESCE
+    // wraps the lot.
+    assert!(
+        stmt.sql.contains(r#"COALESCE(SUM("price")::bigint, $1)"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn pg_filter_and_default_compose_coalesce_outside_filter() {
+    let q = agg(sum("price")
+        .filter(Post::status.eq("published"))
+        .default(0_i64)
+        .into());
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    // COALESCE((SUM(price) FILTER (WHERE status = $1))::bigint, $2)
+    assert!(
+        stmt.sql
+            .contains(r#"COALESCE((SUM("price") FILTER (WHERE "status" = $1))::bigint, $2)"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn mysql_filter_and_default_compose_coalesce_outside_case_when() {
+    let q = agg(sum("price")
+        .filter(Post::status.eq("published"))
+        .default(0_i64)
+        .into());
+    let stmt = MySql.compile_aggregate(&q).unwrap();
+    // MySQL wraps SUM with `CAST(... AS SIGNED)` via the dialect's
+    // int-cast helper.
+    assert!(
+        stmt.sql
+            .contains("COALESCE(CAST(SUM(CASE WHEN `status` = ? THEN `price` END) AS SIGNED), ?)"),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+// ---------- StdDev / Variance ----------
+
+#[test]
+fn pg_stddev_family_emits_sql_standard_names() {
+    for (b, expected) in [
+        (stddev("pages").build(), "STDDEV_SAMP"),
+        (stddev_pop("pages").build(), "STDDEV_POP"),
+        (variance("pages").build(), "VAR_SAMP"),
+        (variance_pop("pages").build(), "VAR_POP"),
+    ] {
+        let stmt = Postgres.compile_aggregate(&agg(b)).unwrap();
+        let needle = format!(r#"{expected}("pages")"#);
+        assert!(stmt.sql.contains(&needle), "{expected} shape: {}", stmt.sql);
+    }
+}
+
+#[test]
+fn mysql_stddev_family_emits_sql_standard_names() {
+    let stmt = MySql
+        .compile_aggregate(&agg(stddev("pages").build()))
+        .unwrap();
+    assert!(
+        stmt.sql.contains("STDDEV_SAMP(`pages`)"),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn sqlite_stddev_is_rejected_at_emit_time() {
+    let q = agg(stddev("pages").build());
+    let err = Sqlite.compile_aggregate(&q).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            SqlError::AggregateNotSupported {
+                aggregate: "STDDEV_SAMP",
+                dialect: "sqlite"
+            }
+        ),
+        "expected AggregateNotSupported, got {err:?}",
+    );
+}
+
+#[test]
+fn sqlite_variance_is_rejected_at_emit_time() {
+    let q = agg(variance_pop("pages").build());
+    let err = Sqlite.compile_aggregate(&q).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            SqlError::AggregateNotSupported {
+                aggregate: "VAR_POP",
+                dialect: "sqlite"
+            }
+        ),
+        "got {err:?}",
+    );
+}
+
+#[test]
+fn pg_filtered_stddev_uses_native_filter() {
+    let q = agg(stddev("pages").filter(Post::is_active.eq(true)).into());
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    // STDDEV_SAMP returns NUMERIC on PG for bigint input — the
+    // writer wraps with `::double precision` so the decoder's f64
+    // path picks it up.
+    assert!(
+        stmt.sql.contains(
+            r#"(STDDEV_SAMP("pages") FILTER (WHERE "is_active" = $1))::double precision"#
+        ),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn mysql_filtered_stddev_falls_back_to_case_when() {
+    let q = agg(stddev("pages").filter(Post::is_active.eq(true)).into());
+    let stmt = MySql.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql
+            .contains("STDDEV_SAMP(CASE WHEN `is_active` = ? THEN `pages` END)"),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Predicate composition inside filter= ----------
+
+#[test]
+fn filter_accepts_and_or_typed_expr() {
+    let cond = Post::is_active
+        .eq(true)
+        .and(Post::pages.gt(100_i64))
+        .or(Post::status.eq("featured"));
+    let q = agg(count_all().filter(cond).into());
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(stmt.sql.contains("COUNT(*) FILTER (WHERE"));
+    assert!(stmt.sql.contains(" AND "));
+    assert!(stmt.sql.contains(" OR "));
+}
+
+#[test]
+fn filter_accepts_raw_where_expr() {
+    let predicate = WhereExpr::Predicate(Filter {
+        column: "is_active",
+        op: Op::Eq,
+        value: SqlValue::Bool(true),
+    });
+    let q = agg(count_all().filter(predicate).into());
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(stmt.sql.contains("FILTER (WHERE"));
+}
+
+// ---------- Nested-wrapper rejection (programmer-error safety net) ----------
+
+#[test]
+fn nested_filtered_is_rejected_at_emit_time() {
+    // The builder never produces this — only a hand-rolled IR can.
+    let inner = AggregateExpr::Filtered {
+        inner: Box::new(AggregateExpr::Count(None)),
+        filter: WhereExpr::Predicate(Filter {
+            column: "is_active",
+            op: Op::Eq,
+            value: SqlValue::Bool(true),
+        }),
+    };
+    let outer = AggregateExpr::Filtered {
+        inner: Box::new(inner),
+        filter: WhereExpr::Predicate(Filter {
+            column: "is_active",
+            op: Op::Eq,
+            value: SqlValue::Bool(false),
+        }),
+    };
+    let err = Postgres.compile_aggregate(&agg(outer)).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            SqlError::NestedAggregateWrapper {
+                wrapper: "Filtered"
+            }
+        ),
+        "got {err:?}",
+    );
+}
+
+#[test]
+fn nested_coalesced_is_rejected_at_emit_time() {
+    let inner = AggregateExpr::Coalesced {
+        inner: Box::new(AggregateExpr::Sum("price")),
+        default: SqlValue::I64(0),
+    };
+    let outer = AggregateExpr::Coalesced {
+        inner: Box::new(inner),
+        default: SqlValue::I64(0),
+    };
+    let err = Postgres.compile_aggregate(&agg(outer)).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            SqlError::NestedAggregateWrapper {
+                wrapper: "Coalesced"
+            }
+        ),
+        "got {err:?}",
+    );
+}

--- a/crates/rustango/tests/aggregate_filter_live.rs
+++ b/crates/rustango/tests/aggregate_filter_live.rs
@@ -1,0 +1,210 @@
+#![cfg(feature = "postgres")]
+//! Live PG tests for filtered aggregates + COALESCE-on-empty +
+//! StdDev (issue #6). The emission tests pin the SQL strings; this
+//! confirms the database actually returns the conditional + stat
+//! values we expect.
+//!
+//! Skips silently when `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::core::aggregates::{count, count_all, stddev, sum};
+use rustango::core::{Column as _, SqlValue};
+use rustango::sql::{fetch_aggregate, sqlx, Auto};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "afl_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 20)]
+    pub status: String,
+    pub is_active: bool,
+    pub price: i64,
+    pub pages: i64,
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "afl_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "afl_post" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "status" VARCHAR(20) NOT NULL,
+            "is_active" BOOLEAN NOT NULL,
+            "price" BIGINT NOT NULL,
+            "pages" BIGINT NOT NULL
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"INSERT INTO "afl_post" ("status", "is_active", "price", "pages") VALUES
+            ('published', TRUE,  100, 50),
+            ('published', TRUE,  200, 100),
+            ('published', FALSE, 300, 200),
+            ('draft',     TRUE,  400, 25)"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+fn get_i64(rows: &[std::collections::HashMap<String, SqlValue>], key: &str) -> i64 {
+    let row = rows.first().expect("at least one aggregate row");
+    match row.get(key).unwrap_or(&SqlValue::Null) {
+        SqlValue::I64(n) => *n,
+        other => panic!("expected i64 at `{key}`, got {other:?}"),
+    }
+}
+
+fn get_f64(rows: &[std::collections::HashMap<String, SqlValue>], key: &str) -> f64 {
+    let row = rows.first().expect("at least one aggregate row");
+    match row.get(key).unwrap_or(&SqlValue::Null) {
+        SqlValue::F64(f) => *f,
+        SqlValue::F32(f) => f64::from(*f),
+        other => panic!("expected float at `{key}`, got {other:?}"),
+    }
+}
+
+/// Filtered count: "active published posts" — 2 of 4 rows match.
+#[tokio::test]
+async fn filtered_count_matches_predicate() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Post::objects()
+        .aggregate()
+        .annotate(
+            "active_published",
+            count_all()
+                .filter(Post::is_active.eq(true).and(Post::status.eq("published")))
+                .into(),
+        )
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    assert_eq!(get_i64(&rows, "active_published"), 2);
+
+    cleanup(&pool).await;
+}
+
+/// Filtered SUM with COALESCE default — happy path: 100+200=300 for
+/// active+published. Empty-result path: predicate excludes every
+/// row → inner SUM is NULL → COALESCE substitutes 0.
+#[tokio::test]
+async fn filtered_sum_with_default_falls_back_when_empty() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Post::objects()
+        .aggregate()
+        .annotate(
+            "revenue",
+            sum("price")
+                .filter(Post::is_active.eq(true).and(Post::status.eq("published")))
+                .default(0_i64)
+                .into(),
+        )
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    assert_eq!(get_i64(&rows, "revenue"), 300);
+
+    let q = Post::objects()
+        .aggregate()
+        .annotate(
+            "revenue",
+            sum("price")
+                .filter(Post::status.eq("__never_matches__"))
+                .default(0_i64)
+                .into(),
+        )
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    assert_eq!(
+        get_i64(&rows, "revenue"),
+        0,
+        "empty SUM should COALESCE to the default"
+    );
+
+    cleanup(&pool).await;
+}
+
+/// `COUNT(col) FILTER (WHERE …)` column-arg path — confirms the
+/// non-`COUNT(*)` shape executes end-to-end.
+#[tokio::test]
+async fn filtered_count_column_arg_executes() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Post::objects()
+        .aggregate()
+        .annotate("n", count("price").filter(Post::pages.gt(75_i64)).into())
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    // pages > 75: rows with pages=100, pages=200 → 2.
+    assert_eq!(get_i64(&rows, "n"), 2);
+
+    cleanup(&pool).await;
+}
+
+/// Native PG `STDDEV_SAMP(col)` executes end-to-end. Exact stddev
+/// is brittle to assert; check the result is finite and positive
+/// (the four pages values 25/50/100/200 give a real stddev around 75).
+#[tokio::test]
+async fn stddev_returns_a_finite_positive_number() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Post::objects()
+        .aggregate()
+        .annotate("sd", stddev("pages").into())
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let sd = get_f64(&rows, "sd");
+    assert!(
+        sd.is_finite() && sd > 0.0,
+        "stddev should be a finite positive number: {sd}"
+    );
+
+    cleanup(&pool).await;
+}
+
+async fn cleanup(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "afl_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+}

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -462,6 +462,70 @@ let counts = Author::objects()
 // each Author gets a `post_count` extra field accessible via the annotated row
 ```
 
+### Conditional aggregates — `filter=` + `default=` + StdDev/Variance
+
+Issue #6 adds Django-shape `count("id").filter(...)` / `sum("price").default(0)` / `stddev("pages")` builders on the same `AggregateExpr` machinery. The non-PG fallback for `filter=` reuses the `Expr::Case` infrastructure from the conditional-expression slice.
+
+```rust
+use rustango::core::aggregates::{avg, count, count_all, stddev, sum};
+use rustango::core::Column as _;
+
+let rows = Post::objects()
+    .aggregate()
+    // COUNT(*) FILTER (WHERE is_active AND status = 'published')
+    .annotate(
+        "active_published",
+        count_all()
+            .filter(Post::is_active.eq(true).and(Post::status.eq("published")))
+            .into(),
+    )
+    // COALESCE(SUM(price) FILTER (WHERE status = 'published'), 0)
+    //   — returns 0 instead of NULL when the queryset is empty.
+    .annotate(
+        "revenue_or_zero",
+        sum("price")
+            .filter(Post::status.eq("published"))
+            .default(0_i64)
+            .into(),
+    )
+    .annotate("avg_pages", avg("pages").into())
+    .annotate("page_stddev", stddev("pages").into())
+    .compile()?;
+let result = rustango::sql::fetch_aggregate(&rows, &pool).await?;
+```
+
+**Builders** in `rustango::core::aggregates`:
+
+| Builder | SQL |
+|---|---|
+| `count(col)` | `COUNT(col)` |
+| `count_all()` | `COUNT(*)` |
+| `count_distinct(col)` | `COUNT(DISTINCT col)` |
+| `sum(col)` / `avg(col)` / `max(col)` / `min(col)` | the usual |
+| `stddev(col)` / `stddev_pop(col)` | `STDDEV_SAMP` / `STDDEV_POP` |
+| `variance(col)` / `variance_pop(col)` | `VAR_SAMP` / `VAR_POP` |
+
+Each returns an `AggregateBuilder` with two chainable modifiers:
+
+- `.filter(predicate)` — wrap in `FILTER (WHERE predicate)`. The predicate is any `WhereExpr` (typed `.eq()` / `.and()` / raw `WhereExpr::Or(...)`), so it composes the same way as a normal WHERE.
+- `.default(value)` — wrap in `COALESCE(..., value)` so an empty queryset returns the default instead of `NULL`.
+
+Calling both chains as `Coalesced` outside `Filtered`: `COALESCE(SUM(col) FILTER (WHERE p), 0)`. Chain order doesn't matter — `.filter(p).default(0)` and `.default(0).filter(p)` produce the same IR.
+
+**Tri-dialect emission:**
+
+| Feature | PG | MySQL | SQLite |
+|---|---|---|---|
+| `Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` | ✓ | ✓ | ✓ |
+| `StdDev` / `StdDevPop` / `Variance` / `VariancePop` | ✓ | ✓ (8.0+) | ✗ `SqlError::AggregateNotSupported` |
+| `.filter(...)` — native `FILTER (WHERE …)` | ✓ | ✗ rewritten | ✓ (3.30+) |
+| `.filter(...)` — `CASE WHEN` fallback | — | ✓ `<agg>(CASE WHEN … THEN <arg> END)` | — |
+| `.default(...)` — `COALESCE` | ✓ | ✓ | ✓ |
+
+The writer applies the dialect's int/float cast (`::bigint`, `CAST(... AS SIGNED)`, etc.) around the whole `FILTER` expression — `SUM(col)::bigint FILTER (...)` is a PG parse error, so the emitted form is `(SUM(col) FILTER (...))::bigint`. Same shape for `STDDEV_SAMP` / `VAR_SAMP` (they return NUMERIC on PG for bigint input).
+
+**SQLite + StdDev/Variance:** SQLite has no built-in statistical aggregates, so the writer rejects with `SqlError::AggregateNotSupported { aggregate, dialect: "sqlite" }`. Compute the variance formula in app code if portable stats are needed (same posture Django takes).
+
 ---
 
 ## Joins + select_related


### PR DESCRIPTION
## Summary

Closes #6 — the sixth issue in the ORM Expression DSL epic. **Stacked on #81** (issue-6-adhoc-joins). Will rebase to main once the #1 → #2 → #3 → #4 → #5 → #80 → #6 chain merges.

Closes the Django gap around `Count("id", filter=Q(active=True))` / `Sum("price", default=0)` and adds the SQL-standard `StdDev` / `Variance` aggregates. The non-PG `FILTER (WHERE …)` fallback reuses the `Expr::Case` infrastructure from #4.

## What you get

```rust
use rustango::core::aggregates::{count_all, stddev, sum};
use rustango::core::Column as _;

let q = Post::objects()
    .aggregate()
    // COUNT(*) FILTER (WHERE is_active AND status = 'published')
    .annotate(
        "active_published",
        count_all()
            .filter(Post::is_active.eq(true).and(Post::status.eq("published")))
            .into(),
    )
    // COALESCE((SUM(price) FILTER (WHERE status='published'))::bigint, 0)
    .annotate(
        "revenue_or_zero",
        sum("price").filter(Post::status.eq("published")).default(0_i64).into(),
    )
    .annotate("page_stddev", stddev("pages").into())
    .compile()?;
let rows = rustango::sql::fetch_aggregate(&q, &pool).await?;
```

## Builder API

| Builder | SQL |
|---|---|
| `count(col)` / `count_all()` / `count_distinct(col)` | `COUNT(col)` / `COUNT(*)` / `COUNT(DISTINCT col)` |
| `sum(col)` / `avg(col)` / `max(col)` / `min(col)` | the usual |
| `stddev(col)` / `stddev_pop(col)` | `STDDEV_SAMP` / `STDDEV_POP` |
| `variance(col)` / `variance_pop(col)` | `VAR_SAMP` / `VAR_POP` |

Each returns an `AggregateBuilder` with two chainable modifiers:

- `.filter(predicate)` — wrap in `FILTER (WHERE predicate)`. Predicate is any `WhereExpr` (typed `.eq().and()` / raw `WhereExpr::Or(...)`).
- `.default(value)` — wrap in `COALESCE(..., value)` so an empty queryset returns the default instead of `NULL`.

Builder normalizes chain order — `Coalesced` is always **outside** `Filtered` regardless of whether you call `.filter()` before or after `.default()`.

## Tri-dialect emission matrix

| Feature | PG | MySQL | SQLite |
|---|---|---|---|
| `Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` | ✓ | ✓ | ✓ |
| `StdDev` / `StdDevPop` / `Variance` / `VariancePop` | ✓ | ✓ (8.0+) | ✗ `SqlError::AggregateNotSupported` |
| `.filter(...)` — native `FILTER (WHERE …)` | ✓ | ✗ | ✓ (3.30+) |
| `.filter(...)` — `CASE WHEN` fallback | — | ✓ `<agg>(CASE WHEN … THEN <arg> END)` | — |
| `.default(...)` — `COALESCE` | ✓ | ✓ | ✓ |

The decoder-side int/float cast (`::bigint` on PG, `CAST(... AS SIGNED)` on MySQL, etc.) wraps **around** the `FILTER` form — `SUM(x)::bigint FILTER (...)` is a PG parse error because `::` binds tightly, so the writer emits `(SUM(x) FILTER (...))::bigint`. Same shape for `STDDEV_SAMP` / `VAR_SAMP` (they return NUMERIC on PG for bigint input).

## What landed

- **`core/query.rs`** — `AggregateExpr` gains 4 new variants (`StdDev`, `StdDevPop`, `Variance`, `VariancePop`) + 2 recursive wrappers (`Filtered { inner, filter }`, `Coalesced { inner, default }`) for composable filter= / default=.
- **`core/aggregates.rs`** (new) — public builders + `AggregateBuilder` with `.filter()` / `.default()` chain. Normalizes chain order to `Coalesced` outside `Filtered`.
- **`sql/writers.rs`** — extracted `format_bare_aggregate` + `aggregate_cast_kind` + `apply_agg_cast` helpers; refactored `write_aggregate_kind` to thread the dialect's decoder-side cast through both flat and filtered paths. PG + SQLite (3.30+) emit native `FILTER (WHERE …)`; MySQL rewrites via `write_aggregate_as_case_when`. Cast wrap is applied around the parenthesized FILTER form to avoid the `SUM(x)::bigint FILTER (...)` parse error.
- **`sql/error.rs`** — new `AggregateNotSupported { aggregate, dialect }` for SQLite's missing stddev/variance, and `NestedAggregateWrapper { wrapper }` for ill-shaped hand-rolled IR.

## Tests

| Suite | Count |
|---|---|
| `core::aggregates::tests` (unit) | 7 |
| `tests/aggregate_filter.rs` (tri-dialect emission) | 24 |
| `tests/aggregate_filter_live.rs` (live PG runtime) | 4 |

The 24 emission tests cover: per-aggregate flat emission unchanged after the refactor (regression-pin); PG + SQLite native FILTER; MySQL CASE-WHEN fallback for Count, Count(col), CountDistinct, Sum, Avg, Max, Min, StdDev/Variance; COALESCE composition with FILTER (Coalesced outside Filtered); per-dialect StdDev/Variance emission + SQLite rejection; AND/OR + raw `WhereExpr` predicate composition inside `.filter(...)`; `NestedAggregateWrapper` rejection for both `Filtered { Filtered { ... } }` and `Coalesced { Coalesced { ... } }`.

The 4 live PG tests: filtered count matches predicate (returns 2 of 4 rows); filtered SUM with `.default(0)` falls back to 0 on empty result, returns the real sum on happy path; `COUNT(col)` column-arg path executes; `STDDEV_SAMP` returns a finite positive number.

## Cookbook

New "Conditional aggregates — `filter=` + `default=` + StdDev/Variance" subsection under "Aggregations" in `docs/orm.md`. Documents the builder API, the tri-dialect emission matrix, the cast-wrap-around-FILTER quirk, and the SQLite-no-stddev posture (matches Django).

## Verification

```
cargo test -p rustango --lib --features tenancy                  → 1486 passed (+7 aggregate unit tests)
cargo test --features tenancy,mysql,sqlite --test aggregate_filter → 24 passed
DATABASE_URL=… cargo test --features tenancy --test aggregate_filter_live → 4 passed
cargo check --no-default-features --features sqlite,tenancy      → clean
cargo check --features mysql,tenancy                             → clean
```

No regressions in case (15/15), subquery (10/10), or ad-hoc joins (18/18) emission suites.

## Foundation extended

Remaining in the ORM Expression DSL epic:

- **#7** Window functions — `Window(expression, partition_by, order_by, frame)` + 8 window-function variants (`RowNumber` / `Rank` / `DenseRank` / `Lag` / `Lead` / `FirstValue` / `LastValue` / `Ntile`).

## Test plan

- [x] 7 unit tests pass.
- [x] 24 tri-dialect emission tests pass.
- [x] 4 live PG tests pass.
- [x] All three feature combos compile.
- [x] Cookbook section + caveats added.
- [ ] CI green on `postgres_test` + `mysql_live` + `sqlite_live` + `sqlite_litmus`.
- [ ] Rebase to main once #81 merges.
