### PR TITLE
Window functions (closes #7) — completes ORM Expression DSL epic

### DIFF
--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -155,6 +155,17 @@ pub enum Expr {
         alias: &'static str,
         column: &'static str,
     },
+    /// Window function — `<fn>(args) OVER (PARTITION BY … ORDER BY …
+    /// [frame])`. Issue #7. Boxed because [`WindowExpr`] carries a
+    /// `Vec<Expr>` for arguments, which makes the enum size
+    /// unbounded otherwise.
+    ///
+    /// Build via [`crate::core::window`] (`row_number`, `rank`,
+    /// `dense_rank`, `lag`, `lead`, `first_value`, `last_value`,
+    /// `ntile`) rather than this variant directly.
+    ///
+    /// [`WindowExpr`]: crate::core::WindowExpr
+    Window(Box<super::window::WindowExpr>),
 }
 
 /// One arm of a [`Expr::Case`] expression — `WHEN <condition> THEN <then>`.

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -16,6 +16,7 @@ mod schema;
 pub mod subquery;
 mod validate;
 mod value;
+pub mod window;
 
 pub use case::{case, value, CaseBuilder};
 pub use column::{Column, TypedAssignment, TypedExpr, TypedFilter};
@@ -34,6 +35,7 @@ pub use schema::{
 };
 pub use validate::validate_value;
 pub use value::SqlValue;
+pub use window::{FrameBoundary, FrameKind, WindowExpr, WindowFn, WindowFrame};
 
 /// Re-exported so `#[derive(Model)]` output can name `inventory` without
 /// requiring downstream crates to add their own dependency on it.

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -320,6 +320,30 @@ fn validate_expr_columns(model: &'static ModelSchema, expr: &Expr) -> Result<(),
         // `AliasedColumn` (issue #80) carries its own table alias so
         // it doesn't resolve against the passed-in model.
         Expr::Subquery(_) | Expr::OuterRef(_) | Expr::AliasedColumn { .. } => Ok(()),
+        // Window (issue #7) — args / partition_by / order_by all
+        // reference the outer model's columns. Validate them.
+        Expr::Window(w) => {
+            for col in &w.partition_by {
+                if model.field_by_column(col).is_none() {
+                    return Err(QueryError::UnknownField {
+                        model: model.name,
+                        field: (*col).to_owned(),
+                    });
+                }
+            }
+            for o in &w.order_by {
+                if model.field_by_column(o.column).is_none() {
+                    return Err(QueryError::UnknownField {
+                        model: model.name,
+                        field: o.column.to_owned(),
+                    });
+                }
+            }
+            for arg in &w.args {
+                validate_expr_columns(model, arg)?;
+            }
+            Ok(())
+        }
     }
 }
 
@@ -724,6 +748,13 @@ pub enum AggregateExpr {
         inner: Box<AggregateExpr>,
         default: SqlValue,
     },
+    /// Window function — `<fn>(args) OVER (PARTITION BY … ORDER BY …)`.
+    /// Issue #7. Conceptually distinct from an aggregate (operates
+    /// over a frame, not a group), but reuses the `annotate()` slot
+    /// because the projection shape is the same. Use the builders in
+    /// [`crate::core::window`] rather than constructing this variant
+    /// directly.
+    Window(Box<super::window::WindowExpr>),
 }
 
 /// A `SELECT … GROUP BY … HAVING …` query. Returned rows are untyped

--- a/crates/rustango/src/core/window.rs
+++ b/crates/rustango/src/core/window.rs
@@ -1,0 +1,333 @@
+//! Window functions — issue #7.
+//!
+//! Seventh and final slice of the ORM Expression DSL epic. Closes the
+//! Django `Window(expression, partition_by=, order_by=, frame=)` gap
+//! with 8 function variants + ROWS/RANGE frame clauses. Tri-dialect
+//! uniform — every backend rustango supports (PG ≥ 9.0, MySQL ≥ 8.0,
+//! SQLite ≥ 3.25) ships native `OVER (…)` syntax.
+//!
+//! ```ignore
+//! use rustango::core::window::{rank, row_number, lag};
+//! use rustango::core::Column as _;
+//!
+//! // Rank users by score within each tenant.
+//! User::objects()
+//!     .aggregate()
+//!     .annotate(
+//!         "tenant_rank",
+//!         rank().partition_by("tenant_id").order_by(&[("score", true)]),
+//!     )
+//!     .compile()?;
+//!
+//! // Day-over-day change via Lag.
+//! Event::objects()
+//!     .update()
+//!     .set_expr(
+//!         "prev_count",
+//!         lag("count", 1, None).order_by(&[("day", false)]),
+//!     )
+//!     .execute(&pool).await?;
+//! ```
+//!
+//! ## Builder shape
+//!
+//! Each constructor (`row_number`, `rank`, `dense_rank`, `lag`,
+//! `lead`, `first_value`, `last_value`, `ntile`) returns a
+//! [`WindowBuilder`] with three chainable modifiers:
+//!
+//! - `.partition_by(col)` — append a `PARTITION BY` column. Call
+//!   multiple times for multi-column partitioning.
+//! - `.order_by(&[("col", desc)])` — append `ORDER BY` columns.
+//! - `.frame(WindowFrame { … })` — set the optional `ROWS`/`RANGE`
+//!   frame clause.
+//!
+//! The builder lowers via `Into<Expr>` so window functions slot into
+//! `set_expr` (UPDATE) and `eq_expr` (WHERE-rhs); via
+//! `Into<AggregateExpr>` so they compose with `annotate()`.
+//!
+//! ## Tri-dialect emission
+//!
+//! `<fn>(args) OVER (PARTITION BY … ORDER BY … [frame])` is SQL-standard
+//! syntax. Identical SQL across PG / MySQL 8+ / SQLite 3.25+.
+
+use super::expr::Expr;
+use super::query::{AggregateExpr, OrderClause};
+use super::SqlValue;
+
+/// Window function kind. The eight v1 variants from Django's epic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowFn {
+    /// `ROW_NUMBER()` — sequential row index within the partition.
+    RowNumber,
+    /// `RANK()` — rank within partition with gaps on ties.
+    Rank,
+    /// `DENSE_RANK()` — rank within partition without gaps.
+    DenseRank,
+    /// `NTILE(buckets)` — divide partition into `buckets` groups.
+    Ntile,
+    /// `LAG(value, offset, default)` — value from the row `offset`
+    /// rows before the current row in the partition.
+    Lag,
+    /// `LEAD(value, offset, default)` — value from the row `offset`
+    /// rows after the current row in the partition.
+    Lead,
+    /// `FIRST_VALUE(expr)` — value from the first row in the
+    /// partition/frame.
+    FirstValue,
+    /// `LAST_VALUE(expr)` — value from the last row in the
+    /// partition/frame.
+    LastValue,
+}
+
+/// `ROWS` vs `RANGE` frame mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameKind {
+    /// `ROWS BETWEEN …` — physical row offsets.
+    Rows,
+    /// `RANGE BETWEEN …` — logical value ranges relative to the
+    /// current row's ORDER BY key.
+    Range,
+}
+
+/// One end of a frame range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameBoundary {
+    /// `UNBOUNDED PRECEDING`.
+    UnboundedPreceding,
+    /// `<n> PRECEDING`.
+    Preceding(i64),
+    /// `CURRENT ROW`.
+    CurrentRow,
+    /// `<n> FOLLOWING`.
+    Following(i64),
+    /// `UNBOUNDED FOLLOWING`.
+    UnboundedFollowing,
+}
+
+/// Frame specification — `ROWS|RANGE BETWEEN <start> AND <end>`
+/// (when `end` is `Some`) or just `ROWS|RANGE <start>` (when `end`
+/// is `None`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowFrame {
+    pub kind: FrameKind,
+    pub start: FrameBoundary,
+    pub end: Option<FrameBoundary>,
+}
+
+/// Window-expression IR. Carries the function kind, its arguments
+/// (e.g. `LAG`'s expr/offset/default), and the OVER clause.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowExpr {
+    pub kind: WindowFn,
+    pub args: Vec<Expr>,
+    pub partition_by: Vec<&'static str>,
+    pub order_by: Vec<OrderClause>,
+    pub frame: Option<WindowFrame>,
+}
+
+/// Fluent wrapper around a [`WindowExpr`]. Built via the free
+/// functions in this module ([`row_number`], [`rank`], …); finalize
+/// by passing into anything that takes `impl Into<Expr>` or
+/// `impl Into<AggregateExpr>`.
+#[must_use]
+pub struct WindowBuilder {
+    inner: WindowExpr,
+}
+
+impl WindowBuilder {
+    fn new(kind: WindowFn, args: Vec<Expr>) -> Self {
+        Self {
+            inner: WindowExpr {
+                kind,
+                args,
+                partition_by: Vec::new(),
+                order_by: Vec::new(),
+                frame: None,
+            },
+        }
+    }
+
+    /// Append a `PARTITION BY` column. Call multiple times to
+    /// partition by multiple columns (left-to-right precedence).
+    pub fn partition_by(mut self, column: &'static str) -> Self {
+        self.inner.partition_by.push(column);
+        self
+    }
+
+    /// Append `ORDER BY` columns. `desc = true` → `DESC`. Multiple
+    /// calls compose; subsequent ones append after earlier ones.
+    pub fn order_by(mut self, items: &[(&'static str, bool)]) -> Self {
+        for (col, desc) in items {
+            self.inner.order_by.push(OrderClause {
+                column: col,
+                desc: *desc,
+            });
+        }
+        self
+    }
+
+    /// Set the frame clause. Replaces any previous frame.
+    pub fn frame(mut self, frame: WindowFrame) -> Self {
+        self.inner.frame = Some(frame);
+        self
+    }
+
+    /// Finalize to an [`Expr`]. Equivalent to `Into<Expr>::into(b)` —
+    /// provided when type inference needs help.
+    #[must_use]
+    pub fn build(self) -> Expr {
+        Expr::Window(Box::new(self.inner))
+    }
+}
+
+impl From<WindowBuilder> for Expr {
+    fn from(b: WindowBuilder) -> Self {
+        b.build()
+    }
+}
+
+impl From<WindowBuilder> for AggregateExpr {
+    fn from(b: WindowBuilder) -> Self {
+        AggregateExpr::Window(Box::new(b.inner))
+    }
+}
+
+// ---------------------------------------------------------------- builders
+
+/// `ROW_NUMBER() OVER (…)` — sequential 1-based row index within
+/// the partition. Ordering is required for deterministic output.
+#[must_use]
+pub fn row_number() -> WindowBuilder {
+    WindowBuilder::new(WindowFn::RowNumber, vec![])
+}
+
+/// `RANK() OVER (…)` — rank within partition; tied rows share a
+/// rank and the next row's rank skips ahead (e.g., 1, 2, 2, 4).
+#[must_use]
+pub fn rank() -> WindowBuilder {
+    WindowBuilder::new(WindowFn::Rank, vec![])
+}
+
+/// `DENSE_RANK() OVER (…)` — rank within partition; tied rows share
+/// a rank but the next row's rank doesn't skip (e.g., 1, 2, 2, 3).
+#[must_use]
+pub fn dense_rank() -> WindowBuilder {
+    WindowBuilder::new(WindowFn::DenseRank, vec![])
+}
+
+/// `NTILE(buckets) OVER (…)` — divide the partition's rows into
+/// `buckets` approximately-equal groups.
+#[must_use]
+pub fn ntile(buckets: i64) -> WindowBuilder {
+    WindowBuilder::new(WindowFn::Ntile, vec![Expr::Literal(SqlValue::I64(buckets))])
+}
+
+/// `LAG(<column>, <offset>, <default>) OVER (…)` — value from the
+/// row `offset` rows before the current row, with `default`
+/// substituted when out of range.
+///
+/// Pass `offset = 1` for "previous row," `offset = N` for further
+/// back. `default = None` produces `LAG(col, offset)` (omits the
+/// default arg — NULL is returned for out-of-range positions).
+#[must_use]
+pub fn lag(column: &'static str, offset: i64, default: Option<SqlValue>) -> WindowBuilder {
+    let mut args = vec![Expr::Column(column), Expr::Literal(SqlValue::I64(offset))];
+    if let Some(d) = default {
+        args.push(Expr::Literal(d));
+    }
+    WindowBuilder::new(WindowFn::Lag, args)
+}
+
+/// `LEAD(<column>, <offset>, <default>) OVER (…)` — value from the
+/// row `offset` rows after the current row.
+#[must_use]
+pub fn lead(column: &'static str, offset: i64, default: Option<SqlValue>) -> WindowBuilder {
+    let mut args = vec![Expr::Column(column), Expr::Literal(SqlValue::I64(offset))];
+    if let Some(d) = default {
+        args.push(Expr::Literal(d));
+    }
+    WindowBuilder::new(WindowFn::Lead, args)
+}
+
+/// `FIRST_VALUE(<column>) OVER (…)` — value of `column` from the
+/// first row of the partition/frame.
+#[must_use]
+pub fn first_value(column: &'static str) -> WindowBuilder {
+    WindowBuilder::new(WindowFn::FirstValue, vec![Expr::Column(column)])
+}
+
+/// `LAST_VALUE(<column>) OVER (…)` — value of `column` from the
+/// last row of the partition/frame.
+#[must_use]
+pub fn last_value(column: &'static str) -> WindowBuilder {
+    WindowBuilder::new(WindowFn::LastValue, vec![Expr::Column(column)])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn row_number_has_no_args() {
+        let b = row_number();
+        assert!(b.inner.args.is_empty());
+        assert_eq!(b.inner.kind, WindowFn::RowNumber);
+    }
+
+    #[test]
+    fn lag_default_none_omits_default_arg() {
+        let b = lag("price", 1, None);
+        assert_eq!(b.inner.args.len(), 2);
+    }
+
+    #[test]
+    fn lag_default_some_includes_default_arg() {
+        let b = lag("price", 1, Some(SqlValue::I64(0)));
+        assert_eq!(b.inner.args.len(), 3);
+    }
+
+    #[test]
+    fn partition_by_appends() {
+        let b = row_number()
+            .partition_by("tenant_id")
+            .partition_by("region");
+        assert_eq!(b.inner.partition_by, vec!["tenant_id", "region"]);
+    }
+
+    #[test]
+    fn order_by_appends_multiple() {
+        let b = row_number().order_by(&[("score", true), ("id", false)]);
+        assert_eq!(b.inner.order_by.len(), 2);
+        assert_eq!(b.inner.order_by[0].column, "score");
+        assert!(b.inner.order_by[0].desc);
+        assert!(!b.inner.order_by[1].desc);
+    }
+
+    #[test]
+    fn frame_replaces_prior() {
+        let f1 = WindowFrame {
+            kind: FrameKind::Rows,
+            start: FrameBoundary::UnboundedPreceding,
+            end: Some(FrameBoundary::CurrentRow),
+        };
+        let f2 = WindowFrame {
+            kind: FrameKind::Range,
+            start: FrameBoundary::Preceding(5),
+            end: Some(FrameBoundary::Following(5)),
+        };
+        let b = row_number().frame(f1).frame(f2.clone());
+        assert_eq!(b.inner.frame, Some(f2));
+    }
+
+    #[test]
+    fn lowers_to_expr_window_variant() {
+        let e: Expr = row_number().into();
+        assert!(matches!(e, Expr::Window(_)));
+    }
+
+    #[test]
+    fn lowers_to_aggregate_expr_window_variant() {
+        let a: AggregateExpr = rank().partition_by("tenant_id").into();
+        assert!(matches!(a, AggregateExpr::Window(_)));
+    }
+}

--- a/crates/rustango/src/core/window.rs
+++ b/crates/rustango/src/core/window.rs
@@ -21,19 +21,18 @@
 //!     )
 //!     .compile()?;
 //!
-//! // Lag with COALESCE fallback for the first row of each partition.
-//! // Composes naturally because LAG returns NULL for the boundary row
-//! // and `aggregates::sum(...).default(...)` shape applies.
-//! use rustango::core::aggregates::AggregateBuilder;
+//! // Lag with a fallback value when there's no prior row. LAG itself
+//! // returns NULL on the partition boundary; passing a `Some(default)`
+//! // tells the SQL function to substitute it. Builder ends with
+//! // `.into()` to lower into the `AggregateExpr` slot `annotate` takes.
 //! Event::objects()
 //!     .aggregate()
 //!     .annotate(
 //!         "prev_count",
-//!         AggregateBuilder::from(
-//!             lag("count", 1, Some(SqlValue::I64(0)))
-//!                 .partition_by("user_id")
-//!                 .order_by(&[("day", false)]),
-//!         ),
+//!         lag("count", 1, Some(SqlValue::I64(0)))
+//!             .partition_by("user_id")
+//!             .order_by(&[("day", false)])
+//!             .into(),
 //!     )
 //!     .compile()?;
 //! ```

--- a/crates/rustango/src/core/window.rs
+++ b/crates/rustango/src/core/window.rs
@@ -8,9 +8,11 @@
 //!
 //! ```ignore
 //! use rustango::core::window::{rank, row_number, lag};
-//! use rustango::core::Column as _;
+//! use rustango::core::SqlValue;
 //!
-//! // Rank users by score within each tenant.
+//! // "Rank users by score within each tenant" — the canonical
+//! // window-function use case. Lives in the SELECT list via
+//! // `annotate()`.
 //! User::objects()
 //!     .aggregate()
 //!     .annotate(
@@ -19,15 +21,42 @@
 //!     )
 //!     .compile()?;
 //!
-//! // Day-over-day change via Lag.
+//! // Lag with COALESCE fallback for the first row of each partition.
+//! // Composes naturally because LAG returns NULL for the boundary row
+//! // and `aggregates::sum(...).default(...)` shape applies.
+//! use rustango::core::aggregates::AggregateBuilder;
 //! Event::objects()
-//!     .update()
-//!     .set_expr(
+//!     .aggregate()
+//!     .annotate(
 //!         "prev_count",
-//!         lag("count", 1, None).order_by(&[("day", false)]),
+//!         AggregateBuilder::from(
+//!             lag("count", 1, Some(SqlValue::I64(0)))
+//!                 .partition_by("user_id")
+//!                 .order_by(&[("day", false)]),
+//!         ),
 //!     )
-//!     .execute(&pool).await?;
+//!     .compile()?;
 //! ```
+//!
+//! ## Where window functions can appear
+//!
+//! Every backend rustango supports (PG, MySQL 8+, SQLite 3.25+)
+//! restricts window functions to the **SELECT list** and the
+//! **ORDER BY clause** of a query. They are **not allowed in**:
+//!
+//! - `WHERE` predicates,
+//! - `HAVING` predicates,
+//! - `GROUP BY` clauses,
+//! - `UPDATE SET` assignments,
+//! - `JOIN ON` predicates,
+//! - the projection of a `RETURNING` clause.
+//!
+//! The IR + writer don't gate emission on this — `set_expr(...,
+//! row_number())` compiles cleanly but fails at execute. Build window
+//! expressions through [`crate::query::AggregateBuilder::annotate`]
+//! (the only legitimate channel today). To use a window result inside
+//! an `UPDATE` or filter, wrap the windowed select in a subquery and
+//! join/filter against that.
 //!
 //! ## Builder shape
 //!
@@ -41,9 +70,11 @@
 //! - `.frame(WindowFrame { … })` — set the optional `ROWS`/`RANGE`
 //!   frame clause.
 //!
-//! The builder lowers via `Into<Expr>` so window functions slot into
-//! `set_expr` (UPDATE) and `eq_expr` (WHERE-rhs); via
-//! `Into<AggregateExpr>` so they compose with `annotate()`.
+//! The builder lowers via `Into<AggregateExpr>` so window functions
+//! compose with `annotate()`. `Into<Expr>` is also implemented to
+//! keep the IR composable (window-in-Case/Coalesce/Subquery), but
+//! emitting one in a slot the DB rejects (see list above) is a
+//! programmer error.
 //!
 //! ## Tri-dialect emission
 //!

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -706,6 +706,30 @@ fn validate_expr_columns_in_model(
         // there). `AliasedColumn` (issue #80) carries its own table
         // alias and is validated by the JOIN writer at emit time.
         Expr::Subquery(_) | Expr::OuterRef(_) | Expr::AliasedColumn { .. } => Ok(()),
+        // Window (issue #7) — partition_by + order_by + arg columns
+        // reference the model. Walk them.
+        Expr::Window(w) => {
+            for col in &w.partition_by {
+                if model.field_by_column(col).is_none() {
+                    return Err(QueryError::UnknownField {
+                        model: model.name,
+                        field: (*col).to_owned(),
+                    });
+                }
+            }
+            for o in &w.order_by {
+                if model.field_by_column(o.column).is_none() {
+                    return Err(QueryError::UnknownField {
+                        model: model.name,
+                        field: o.column.to_owned(),
+                    });
+                }
+            }
+            for arg in &w.args {
+                validate_expr_columns_in_model(model, arg)?;
+            }
+            Ok(())
+        }
     }
 }
 

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -800,6 +800,14 @@ impl<T: Model> AggregateBuilder<T> {
     pub fn compile(self) -> Result<AggregateQuery, QueryError> {
         let model = T::SCHEMA;
         let where_clause = resolve_pending(model, self.qs.pending)?;
+        // Walk each AggregateExpr for column-name typos. Today this
+        // catches partition_by / order_by / args inside an
+        // `AggregateExpr::Window` (issue #7) — the older `Sum("col")` /
+        // `Count(Some("col"))` shapes don't validate yet; that's a
+        // pre-existing gap orthogonal to this slice.
+        for (_alias, expr) in &self.aggregates {
+            validate_aggregate_expr_columns(model, expr)?;
+        }
         let order_by = self
             .order_by
             .into_iter()
@@ -815,5 +823,55 @@ impl<T: Model> AggregateBuilder<T> {
             limit: self.limit,
             offset: self.offset,
         })
+    }
+}
+
+/// Walk an [`AggregateExpr`] for column references that should
+/// resolve against `model`. Today only `AggregateExpr::Window`
+/// (issue #7) carries non-trivial column refs the schema can check —
+/// partition_by + order_by columns + any `Expr::Column` arg. The
+/// flat aggregate variants (`Sum("col")`, etc.) hold raw `&'static str`
+/// column names that the existing validator chain doesn't visit; that
+/// gap is orthogonal to this walk and worth a follow-up.
+///
+/// [`AggregateExpr`]: crate::core::AggregateExpr
+fn validate_aggregate_expr_columns(
+    model: &'static ModelSchema,
+    expr: &crate::core::AggregateExpr,
+) -> Result<(), QueryError> {
+    use crate::core::AggregateExpr;
+    match expr {
+        AggregateExpr::Filtered { inner, filter } => {
+            filter.validate(model)?;
+            validate_aggregate_expr_columns(model, inner)
+        }
+        AggregateExpr::Coalesced { inner, .. } => validate_aggregate_expr_columns(model, inner),
+        AggregateExpr::Window(w) => {
+            for col in &w.partition_by {
+                if model.field_by_column(col).is_none() {
+                    return Err(QueryError::UnknownField {
+                        model: model.name,
+                        field: (*col).to_owned(),
+                    });
+                }
+            }
+            for o in &w.order_by {
+                if model.field_by_column(o.column).is_none() {
+                    return Err(QueryError::UnknownField {
+                        model: model.name,
+                        field: o.column.to_owned(),
+                    });
+                }
+            }
+            for arg in &w.args {
+                validate_expr_columns_in_model(model, arg)?;
+            }
+            Ok(())
+        }
+        // Flat aggregate variants (Count/Sum/Avg/Max/Min/CountDistinct/
+        // StdDev*/Variance*) — the column they reference is a bare
+        // `&'static str` not currently part of the validation chain.
+        // Schema typos surface at execution. Pre-existing gap.
+        _ => Ok(()),
     }
 }

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -366,6 +366,15 @@ fn format_bare_aggregate(b: &Sql<'_>, expr: &AggregateExpr) -> Result<String, Sq
                 wrapper: "wrapper at format_bare_aggregate site",
             });
         }
+        AggregateExpr::Window(_) => {
+            // Window-in-aggregate is emitted by the dedicated
+            // `write_aggregate_expr` arm, not the bare-aggregate
+            // helper. Reaching this point means the writer treated
+            // a Window like a flat aggregate — a programmer error.
+            return Err(SqlError::NestedAggregateWrapper {
+                wrapper: "Window at format_bare_aggregate site",
+            });
+        }
     })
 }
 
@@ -431,6 +440,7 @@ fn write_aggregate_expr(
             }
             Ok(())
         }
+        AggregateExpr::Window(w) => write_window_expr(b, w),
         _ => write_aggregate_kind(b, expr),
     }
 }
@@ -479,6 +489,16 @@ fn write_aggregate_as_case_when(
                 wrapper: "wrapper inside Filtered fallback",
             });
         }
+        AggregateExpr::Window(_) => {
+            // `<window_fn>(...) OVER (...) FILTER (WHERE ...)` is
+            // valid SQL on some backends (PG since 9.4 for aggregate
+            // window functions; not for ranking ones), but mixing
+            // `Filtered` + `Window` requires careful per-function
+            // dispatch we haven't designed yet. Reject for v1.
+            return Err(SqlError::NestedAggregateWrapper {
+                wrapper: "Filtered(Window)",
+            });
+        }
     };
     let prior = b.sql.len();
     b.sql.push_str(agg_kw);
@@ -520,6 +540,10 @@ fn aggregate_column(expr: &AggregateExpr) -> Option<&'static str> {
         AggregateExpr::Filtered { inner, .. } | AggregateExpr::Coalesced { inner, .. } => {
             aggregate_column(inner)
         }
+        AggregateExpr::Window(w) => w.args.iter().find_map(|a| match a {
+            crate::core::Expr::Column(c) => Some(*c),
+            _ => None,
+        }),
     }
 }
 
@@ -801,6 +825,121 @@ fn write_expr(
             let qualified = format!("{}.{}", b.d.quote_ident(alias), b.d.quote_ident(column),);
             b.sql.push_str(&qualified);
             Ok(())
+        }
+        Expr::Window(w) => write_window_expr(b, w),
+    }
+}
+
+/// Emit a window expression — `<fn>(args) OVER (PARTITION BY … ORDER
+/// BY … [frame])`. Tri-dialect uniform: PG ≥ 9.0, MySQL ≥ 8.0, and
+/// SQLite ≥ 3.25 all accept this SQL-standard form verbatim.
+fn write_window_expr(b: &mut Sql<'_>, w: &crate::core::WindowExpr) -> Result<(), SqlError> {
+    use crate::core::{Expr, WindowFn};
+    let fn_name = match w.kind {
+        WindowFn::RowNumber => "ROW_NUMBER",
+        WindowFn::Rank => "RANK",
+        WindowFn::DenseRank => "DENSE_RANK",
+        WindowFn::Ntile => "NTILE",
+        WindowFn::Lag => "LAG",
+        WindowFn::Lead => "LEAD",
+        WindowFn::FirstValue => "FIRST_VALUE",
+        WindowFn::LastValue => "LAST_VALUE",
+    };
+    b.sql.push_str(fn_name);
+    b.sql.push('(');
+    // PG's LAG/LEAD/NTILE require `offset`/`buckets` as `integer`, not
+    // `bigint`. Binding `i64` as a parameter (which PG types as
+    // `bigint`) makes function lookup fail with
+    // `function lag(bigint, bigint, bigint) does not exist`. The
+    // offset/bucket count is a compile-time constant in user code
+    // anyway — emit it inline as a SQL integer literal. The
+    // value-arg (Lag's first, Lead's first) and the default-arg
+    // (Lag's third, Lead's third) bind normally via params.
+    let integer_arg_index: Option<usize> = match w.kind {
+        WindowFn::Lag | WindowFn::Lead => Some(1),
+        WindowFn::Ntile => Some(0),
+        _ => None,
+    };
+    for (i, arg) in w.args.iter().enumerate() {
+        if i > 0 {
+            b.sql.push_str(", ");
+        }
+        if integer_arg_index == Some(i) {
+            if let Expr::Literal(SqlValue::I64(n)) = arg {
+                use std::fmt::Write as _;
+                let _ = write!(b.sql, "{n}");
+                continue;
+            }
+        }
+        write_expr(b, arg, None)?;
+    }
+    b.sql.push_str(") OVER (");
+    let mut first_clause = true;
+    if !w.partition_by.is_empty() {
+        b.sql.push_str("PARTITION BY ");
+        for (i, col) in w.partition_by.iter().enumerate() {
+            if i > 0 {
+                b.sql.push_str(", ");
+            }
+            b.write_ident(col);
+        }
+        first_clause = false;
+    }
+    if !w.order_by.is_empty() {
+        if !first_clause {
+            b.sql.push(' ');
+        }
+        b.sql.push_str("ORDER BY ");
+        for (i, o) in w.order_by.iter().enumerate() {
+            if i > 0 {
+                b.sql.push_str(", ");
+            }
+            b.write_ident(o.column);
+            if o.desc {
+                b.sql.push_str(" DESC");
+            }
+        }
+        first_clause = false;
+    }
+    if let Some(frame) = &w.frame {
+        if !first_clause {
+            b.sql.push(' ');
+        }
+        write_window_frame(b, frame);
+    }
+    b.sql.push(')');
+    Ok(())
+}
+
+fn write_window_frame(b: &mut Sql<'_>, frame: &crate::core::WindowFrame) {
+    use crate::core::{FrameBoundary, FrameKind};
+    b.sql.push_str(match frame.kind {
+        FrameKind::Rows => "ROWS",
+        FrameKind::Range => "RANGE",
+    });
+    b.sql.push(' ');
+    if frame.end.is_some() {
+        b.sql.push_str("BETWEEN ");
+    }
+    write_frame_boundary(b, frame.start);
+    if let Some(end) = frame.end {
+        b.sql.push_str(" AND ");
+        write_frame_boundary(b, end);
+    }
+
+    fn write_frame_boundary(b: &mut Sql<'_>, bound: FrameBoundary) {
+        match bound {
+            FrameBoundary::UnboundedPreceding => b.sql.push_str("UNBOUNDED PRECEDING"),
+            FrameBoundary::Preceding(n) => {
+                use std::fmt::Write as _;
+                let _ = write!(b.sql, "{n} PRECEDING");
+            }
+            FrameBoundary::CurrentRow => b.sql.push_str("CURRENT ROW"),
+            FrameBoundary::Following(n) => {
+                use std::fmt::Write as _;
+                let _ = write!(b.sql, "{n} FOLLOWING");
+            }
+            FrameBoundary::UnboundedFollowing => b.sql.push_str("UNBOUNDED FOLLOWING"),
         }
     }
 }

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -414,6 +414,17 @@ fn write_aggregate_expr(
                     wrapper: "Filtered(Coalesced)",
                 });
             }
+            // `Filtered { Window }` — combining FILTER with a window
+            // function isn't dispatched today (PG allows it for
+            // aggregate-window funcs, not ranking ones; writer hasn't
+            // been taught the per-fn rule). Reject upfront with a
+            // consistent message before either the PG-FILTER or the
+            // MySQL-CASE-WHEN path renames it to a per-dialect string.
+            if matches!(inner.as_ref(), AggregateExpr::Window(_)) {
+                return Err(SqlError::NestedAggregateWrapper {
+                    wrapper: "Filtered(Window)",
+                });
+            }
             // MySQL: no FILTER keyword — rewrite via CASE WHEN. The
             // helper applies the dialect's cast helper post-emit for
             // Sum/Avg/StdDev/etc.

--- a/crates/rustango/tests/window_functions.rs
+++ b/crates/rustango/tests/window_functions.rs
@@ -446,3 +446,46 @@ fn last_value_with_unbounded_following_frame_emits_full_form() {
         stmt.sql
     );
 }
+
+/// Round-2 regression: rejecting `Filtered { Window }` must surface
+/// the same error wrapper across all three dialects. Pre-fix the PG
+/// and SQLite paths returned the unhelpful internal name
+/// `"Window at format_bare_aggregate site"` while MySQL returned the
+/// clean `"Filtered(Window)"`. The upfront `matches!(inner, Window)`
+/// guard in `write_aggregate_expr` now produces the consistent
+/// `"Filtered(Window)"` everywhere.
+#[test]
+fn filtered_window_rejection_msg_consistent_across_dialects() {
+    use rustango::core::{Filter, Op, WindowExpr, WindowFn};
+    use rustango::sql::{MySql, SqlError, Sqlite};
+    let f = AggregateExpr::Filtered {
+        inner: Box::new(AggregateExpr::Window(Box::new(WindowExpr {
+            kind: WindowFn::RowNumber,
+            args: vec![],
+            partition_by: vec![],
+            order_by: vec![],
+            frame: None,
+        }))),
+        filter: WhereExpr::Predicate(Filter {
+            column: "score",
+            op: Op::Eq,
+            value: SqlValue::I64(1),
+        }),
+    };
+    let q = agg(f);
+    for (label, err) in [
+        ("pg", Postgres.compile_aggregate(&q).unwrap_err()),
+        ("mysql", MySql.compile_aggregate(&q).unwrap_err()),
+        ("sqlite", Sqlite.compile_aggregate(&q).unwrap_err()),
+    ] {
+        assert!(
+            matches!(
+                err,
+                SqlError::NestedAggregateWrapper {
+                    wrapper: "Filtered(Window)"
+                }
+            ),
+            "{label}: expected wrapper=Filtered(Window), got {err:?}",
+        );
+    }
+}

--- a/crates/rustango/tests/window_functions.rs
+++ b/crates/rustango/tests/window_functions.rs
@@ -250,10 +250,26 @@ fn sqlite_uses_double_quotes_for_window_columns() {
     );
 }
 
-// ---------- Window-as-Expr (UPDATE set_expr) ----------
+// ---------- Window-as-Expr IR-shape (diagnostic) ----------
 
+/// **Diagnostic-only test — DO NOT take as a sanctioned use case.**
+///
+/// `Expr::Window` is an IR-level construct: the builder implements
+/// `Into<Expr>` so the variant slots into recursive composition
+/// (e.g. inside `Case` / `Coalesced` / `Subquery`). PG, MySQL 8+, and
+/// SQLite 3.25+ all restrict window functions to the SELECT list +
+/// ORDER BY clause of a query — they're rejected by every backend
+/// rustango supports inside `UPDATE SET`, `WHERE`, `HAVING`,
+/// `JOIN ON`, etc.
+///
+/// This test pins the emission shape for documentation/debugging
+/// purposes — it does NOT mean the resulting SQL executes. Users
+/// must route window expressions through `annotate()` (the only
+/// sanctioned channel today); see the cookbook for the supported
+/// shape and the subquery workaround for UPDATE-from-window
+/// patterns.
 #[test]
-fn window_as_expr_inside_update_set_emits_full_form() {
+fn window_as_expr_emits_when_force_constructed_but_db_will_reject() {
     use rustango::core::{Assignment, Filter, Op, UpdateQuery};
     let expr: Expr = row_number().order_by(&[("score", true)]).into();
     let q = UpdateQuery {
@@ -272,7 +288,10 @@ fn window_as_expr_inside_update_set_emits_full_form() {
     assert!(
         stmt.sql
             .contains(r#"SET "score" = ROW_NUMBER() OVER (ORDER BY "score" DESC)"#),
-        "got: {}",
+        "IR emits — but PG will error at execute with \
+         `window functions are not allowed in UPDATE`. \
+         Pinning the SQL string for diagnostic visibility, not as \
+         a sanctioned use case. Got: {}",
         stmt.sql
     );
 }
@@ -290,6 +309,140 @@ fn multi_partition_and_multi_order_emit_in_chain_order() {
         stmt.sql
             .contains(r#"PARTITION BY "tenant_id", "region" ORDER BY "score" DESC, "id""#),
         "got: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Paranoid-review regressions ----------
+
+/// Validator regression: a typo'd `partition_by` column inside an
+/// `annotate("...", window_fn())` call must surface at `compile()`,
+/// not at execute. Pre-fix this slipped through because the
+/// `Expr::Window` validator only walks the `Expr` path while
+/// `annotate()` lowers to `AggregateExpr::Window`.
+#[test]
+fn partition_by_typo_inside_annotate_is_caught_at_compile_time() {
+    use rustango::core::QueryError;
+    let err = User::objects()
+        .aggregate()
+        .annotate("w", row_number().partition_by("nope_col").into())
+        .compile()
+        .unwrap_err();
+    assert!(
+        matches!(err, QueryError::UnknownField { ref field, .. } if field == "nope_col"),
+        "expected UnknownField for partition_by typo, got: {err:?}",
+    );
+}
+
+#[test]
+fn order_by_typo_inside_annotate_is_caught_at_compile_time() {
+    use rustango::core::QueryError;
+    let err = User::objects()
+        .aggregate()
+        .annotate(
+            "w",
+            row_number()
+                .partition_by("tenant_id")
+                .order_by(&[("nope_order", true)])
+                .into(),
+        )
+        .compile()
+        .unwrap_err();
+    assert!(
+        matches!(err, QueryError::UnknownField { ref field, .. } if field == "nope_order"),
+        "expected UnknownField for order_by typo, got: {err:?}",
+    );
+}
+
+#[test]
+fn lag_column_arg_typo_inside_annotate_is_caught_at_compile_time() {
+    use rustango::core::QueryError;
+    let err = User::objects()
+        .aggregate()
+        .annotate(
+            "w",
+            lag("nope_arg_col", 1, None)
+                .order_by(&[("id", false)])
+                .into(),
+        )
+        .compile()
+        .unwrap_err();
+    assert!(
+        matches!(err, QueryError::UnknownField { ref field, .. } if field == "nope_arg_col"),
+        "expected UnknownField for LAG column arg typo, got: {err:?}",
+    );
+}
+
+/// Same path runs through `Coalesced` and `Filtered` wrappers — the
+/// inner Window's column refs must still validate. (Filtered + Window
+/// is rejected at emit time, but the column-validation walk runs
+/// at compile() before emit, so column typos inside the wrapped
+/// Window should still surface here.)
+#[test]
+fn coalesced_window_partition_typo_still_caught() {
+    use rustango::core::QueryError;
+    // Build the AggregateExpr directly — there's no `aggregates::*`
+    // builder for "Coalesced { Window }" today (Coalesced is a
+    // wrapper on the flat builder; this combo lands later).
+    let inner: AggregateExpr = row_number().partition_by("nope_col_inside_coalesce").into();
+    let wrapped = AggregateExpr::Coalesced {
+        inner: Box::new(inner),
+        default: SqlValue::I64(0),
+    };
+    let err = User::objects()
+        .aggregate()
+        .annotate("w", wrapped)
+        .compile()
+        .unwrap_err();
+    assert!(
+        matches!(err, QueryError::UnknownField { ref field, .. } if field == "nope_col_inside_coalesce"),
+        "Coalesced wrapper must not hide inner column typos: {err:?}",
+    );
+}
+
+/// Pinned-behavior test for the `LAST_VALUE` default-frame trap —
+/// the cookbook now documents this. A bare `last_value` returns the
+/// current-row value, not the partition's last row. The SQL emitted
+/// here is the same as before the cookbook callout (no behavior
+/// change); this test is documentation-in-code so the next reader
+/// sees the bare emission alongside the explicit-frame fix.
+#[test]
+fn last_value_bare_emits_implicit_default_frame_form() {
+    let w = last_value("score").order_by(&[("id", false)]);
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"LAST_VALUE("score") OVER (ORDER BY "id")"#),
+        "got: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains("ROWS")
+            && !stmt.sql.contains("RANGE")
+            && !stmt.sql.contains("UNBOUNDED"),
+        "bare last_value emits no explicit frame — DEFAULT frame applies, \
+         which returns the CURRENT row's value (cookbook footgun): {}",
+        stmt.sql
+    );
+}
+
+/// And the explicit-frame fix — pin the cookbook-recommended shape
+/// so the recommended pattern stays callable.
+#[test]
+fn last_value_with_unbounded_following_frame_emits_full_form() {
+    let w = last_value("score")
+        .partition_by("tenant_id")
+        .order_by(&[("id", false)])
+        .frame(WindowFrame {
+            kind: FrameKind::Rows,
+            start: FrameBoundary::UnboundedPreceding,
+            end: Some(FrameBoundary::UnboundedFollowing),
+        });
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql
+            .contains("ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING"),
+        "explicit unbounded-following frame for last_value: {}",
         stmt.sql
     );
 }

--- a/crates/rustango/tests/window_functions.rs
+++ b/crates/rustango/tests/window_functions.rs
@@ -1,0 +1,295 @@
+//! Tri-dialect emission tests for window functions (issue #7). The
+//! standard `<fn>(args) OVER (PARTITION BY … ORDER BY … [frame])`
+//! syntax is SQL-standard and works identically on PG ≥ 9.0, MySQL
+//! ≥ 8.0, and SQLite ≥ 3.25 — these tests pin the emitted SQL string
+//! and the dialect-shape placeholders for each backend.
+
+use rustango::core::window::{
+    dense_rank, first_value, lag, last_value, lead, ntile, rank, row_number,
+};
+use rustango::core::{
+    AggregateExpr, AggregateQuery, Expr, FrameBoundary, FrameKind, Model as _, SqlValue, WhereExpr,
+    WindowFrame,
+};
+use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "wf_user")]
+#[allow(dead_code)]
+pub struct User {
+    #[rustango(primary_key)]
+    id: i64,
+    tenant_id: i64,
+    #[rustango(max_length = 100)]
+    name: String,
+    score: i64,
+    created_at: chrono::DateTime<chrono::Utc>,
+}
+
+fn agg(expr: AggregateExpr) -> AggregateQuery {
+    AggregateQuery {
+        model: User::SCHEMA,
+        where_clause: WhereExpr::And(vec![]),
+        aggregates: vec![("w", expr)],
+        group_by: vec![],
+        having: None,
+        order_by: vec![],
+        limit: None,
+        offset: None,
+    }
+}
+
+// ---------- Per-function emission ----------
+
+#[test]
+fn pg_row_number_with_order_by_emits_standard_form() {
+    let w = row_number().order_by(&[("score", true), ("id", false)]);
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"ROW_NUMBER() OVER (ORDER BY "score" DESC, "id") AS "w""#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn rank_partition_and_order_compose() {
+    let w = rank()
+        .partition_by("tenant_id")
+        .order_by(&[("score", true)]);
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"RANK() OVER (PARTITION BY "tenant_id" ORDER BY "score" DESC) AS "w""#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn dense_rank_no_partition_no_order_emits_empty_over_clause() {
+    let w = dense_rank();
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql.contains(r#"DENSE_RANK() OVER () AS "w""#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn ntile_args_embeds_bucket_count_literal() {
+    // PG's NTILE requires the bucket count as integer (not bigint).
+    // The writer inlines the literal in the SQL rather than binding
+    // as a $N param, which would type as bigint and fail PG's
+    // function lookup.
+    let w = ntile(4).order_by(&[("score", true)]);
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"NTILE(4) OVER (ORDER BY "score" DESC) AS "w""#),
+        "got: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.params.is_empty(),
+        "NTILE arg should be inline, not bound: {:?}",
+        stmt.params
+    );
+}
+
+#[test]
+fn lag_without_default_emits_two_args() {
+    let w = lag("score", 1, None).order_by(&[("id", false)]);
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    // Offset is inlined as integer literal (PG requires `integer`,
+    // not `bigint`, for LAG's second arg).
+    assert!(
+        stmt.sql
+            .contains(r#"LAG("score", 1) OVER (ORDER BY "id") AS "w""#),
+        "got: {}",
+        stmt.sql
+    );
+    assert!(stmt.params.is_empty());
+}
+
+#[test]
+fn lag_with_default_emits_three_args() {
+    let w = lag("score", 2, Some(SqlValue::I64(0))).order_by(&[("id", false)]);
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    // Offset inline (2); default bound as a regular bigint param ($1).
+    assert!(
+        stmt.sql
+            .contains(r#"LAG("score", 2, $1) OVER (ORDER BY "id") AS "w""#),
+        "got: {}",
+        stmt.sql
+    );
+    assert_eq!(stmt.params, vec![SqlValue::I64(0)]);
+}
+
+#[test]
+fn lead_emits_lead_keyword() {
+    let w = lead("score", 1, None).order_by(&[("id", false)]);
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql.contains(r#"LEAD("score", 1) OVER"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn first_value_and_last_value_take_column_arg() {
+    let w = first_value("score")
+        .partition_by("tenant_id")
+        .order_by(&[("id", false)]);
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql.contains(
+            r#"FIRST_VALUE("score") OVER (PARTITION BY "tenant_id" ORDER BY "id") AS "w""#
+        ),
+        "got: {}",
+        stmt.sql
+    );
+
+    let w = last_value("score").order_by(&[("id", false)]);
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(stmt.sql.contains(r#"LAST_VALUE("score") OVER"#));
+}
+
+// ---------- Frame clause ----------
+
+#[test]
+fn rows_between_unbounded_preceding_and_current_row() {
+    let w = last_value("score")
+        .partition_by("tenant_id")
+        .order_by(&[("id", false)])
+        .frame(WindowFrame {
+            kind: FrameKind::Rows,
+            start: FrameBoundary::UnboundedPreceding,
+            end: Some(FrameBoundary::CurrentRow),
+        });
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql
+            .contains("ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn rows_n_preceding_to_n_following() {
+    let w = first_value("score")
+        .order_by(&[("id", false)])
+        .frame(WindowFrame {
+            kind: FrameKind::Rows,
+            start: FrameBoundary::Preceding(5),
+            end: Some(FrameBoundary::Following(5)),
+        });
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql
+            .contains("ROWS BETWEEN 5 PRECEDING AND 5 FOLLOWING"),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn range_unbounded_preceding_only_no_end() {
+    let w = first_value("score")
+        .order_by(&[("id", false)])
+        .frame(WindowFrame {
+            kind: FrameKind::Range,
+            start: FrameBoundary::UnboundedPreceding,
+            end: None,
+        });
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql.contains("RANGE UNBOUNDED PRECEDING"),
+        "got: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains("BETWEEN"),
+        "single-boundary frames omit BETWEEN: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Tri-dialect ident-quote shapes ----------
+
+#[test]
+fn mysql_uses_backticks_for_window_columns() {
+    let w = rank()
+        .partition_by("tenant_id")
+        .order_by(&[("score", true)]);
+    let stmt = MySql.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql
+            .contains("RANK() OVER (PARTITION BY `tenant_id` ORDER BY `score` DESC)"),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn sqlite_uses_double_quotes_for_window_columns() {
+    let w = rank()
+        .partition_by("tenant_id")
+        .order_by(&[("score", true)]);
+    let stmt = Sqlite.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"RANK() OVER (PARTITION BY "tenant_id" ORDER BY "score" DESC)"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Window-as-Expr (UPDATE set_expr) ----------
+
+#[test]
+fn window_as_expr_inside_update_set_emits_full_form() {
+    use rustango::core::{Assignment, Filter, Op, UpdateQuery};
+    let expr: Expr = row_number().order_by(&[("score", true)]).into();
+    let q = UpdateQuery {
+        model: User::SCHEMA,
+        set: vec![Assignment {
+            column: "score",
+            value: expr,
+        }],
+        where_clause: WhereExpr::Predicate(Filter {
+            column: "id",
+            op: Op::Eq,
+            value: SqlValue::I64(1),
+        }),
+    };
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"SET "score" = ROW_NUMBER() OVER (ORDER BY "score" DESC)"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Multi-column partition + order ----------
+
+#[test]
+fn multi_partition_and_multi_order_emit_in_chain_order() {
+    let w = rank()
+        .partition_by("tenant_id")
+        .partition_by("region")
+        .order_by(&[("score", true), ("id", false)]);
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"PARTITION BY "tenant_id", "region" ORDER BY "score" DESC, "id""#),
+        "got: {}",
+        stmt.sql
+    );
+}

--- a/crates/rustango/tests/window_functions_live.rs
+++ b/crates/rustango/tests/window_functions_live.rs
@@ -1,0 +1,273 @@
+#![cfg(feature = "postgres")]
+//! Live PG tests for window functions (issue #7). The emission tests
+//! pin the SQL string; this confirms the database actually returns
+//! the per-window-function values we expect.
+//!
+//! Skips silently when `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::core::window::{dense_rank, lag, rank, row_number};
+use rustango::core::SqlValue;
+use rustango::sql::{fetch_aggregate, sqlx, Auto};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "wfl_user")]
+#[allow(dead_code)]
+pub struct User {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub tenant_id: i64,
+    #[rustango(max_length = 100)]
+    pub name: String,
+    pub score: i64,
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "wfl_user" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "wfl_user" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "tenant_id" BIGINT NOT NULL,
+            "name" VARCHAR(100) NOT NULL,
+            "score" BIGINT NOT NULL
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    // Two tenants: tenant 1 has scores 30/20/10; tenant 2 has 100/50.
+    sqlx::query(
+        r#"INSERT INTO "wfl_user" ("tenant_id", "name", "score") VALUES
+            (1, 'Alice',   30),
+            (1, 'Bob',     20),
+            (1, 'Carol',   10),
+            (2, 'Dave',   100),
+            (2, 'Eve',     50)"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+fn get_i64(row: &std::collections::HashMap<String, SqlValue>, key: &str) -> i64 {
+    match row.get(key).unwrap_or(&SqlValue::Null) {
+        SqlValue::I64(n) => *n,
+        SqlValue::I32(n) => i64::from(*n),
+        other => panic!("expected i64 at `{key}`, got {other:?}"),
+    }
+}
+
+/// Rank users by score within each tenant — the issue #7 integration
+/// target. Tenant 1: Alice=1, Bob=2, Carol=3. Tenant 2: Dave=1, Eve=2.
+#[tokio::test]
+async fn rank_by_score_within_each_tenant() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    // Use a raw SELECT to project both the row + the window — the
+    // aggregate path returns rows keyed by ("id", "name", "r"). To
+    // make this work with `fetch_aggregate`, group by every column
+    // we want to project (PG accepts the equivalent of "GROUP BY
+    // ALL" via the trivial group on the PK).
+    use rustango::core::aggregates::max;
+    let q = User::objects()
+        .aggregate()
+        .group_by("id")
+        .group_by("tenant_id")
+        .group_by("name")
+        .group_by("score")
+        .annotate("max_id", max("id").into())
+        .annotate(
+            "r",
+            rank()
+                .partition_by("tenant_id")
+                .order_by(&[("score", true)])
+                .into(),
+        )
+        .order_by(&[("tenant_id", false), ("score", true)])
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    assert_eq!(rows.len(), 5);
+    // Order is tenant_id asc, score desc → Alice(t1,30,1), Bob(t1,20,2),
+    // Carol(t1,10,3), Dave(t2,100,1), Eve(t2,50,2).
+    let ranks: Vec<i64> = rows.iter().map(|r| get_i64(r, "r")).collect();
+    assert_eq!(ranks, vec![1, 2, 3, 1, 2]);
+    let names: Vec<String> = rows
+        .iter()
+        .map(|r| match r.get("name") {
+            Some(SqlValue::String(s)) => s.clone(),
+            other => panic!("expected string name, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(names, vec!["Alice", "Bob", "Carol", "Dave", "Eve"]);
+
+    cleanup(&pool).await;
+}
+
+/// Dense-rank: ties don't skip ranks. With a tied score, ranks should
+/// be 1,2,2,3 instead of RANK's 1,2,2,4.
+#[tokio::test]
+async fn dense_rank_does_not_skip_on_ties() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+    // Add two rows tied at score=50 in tenant 2.
+    sqlx::query(r#"INSERT INTO "wfl_user" ("tenant_id", "name", "score") VALUES (2, 'Frank', 50), (2, 'Grace', 50)"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    use rustango::core::aggregates::max;
+    let q = User::objects()
+        .aggregate()
+        .group_by("id")
+        .group_by("tenant_id")
+        .group_by("name")
+        .group_by("score")
+        .annotate("_a", max("id").into())
+        .annotate(
+            "dr",
+            dense_rank()
+                .partition_by("tenant_id")
+                .order_by(&[("score", true)])
+                .into(),
+        )
+        .order_by(&[("tenant_id", false), ("score", true), ("id", false)])
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    // Tenant 2 rows in score-desc order: Dave (100), Eve/Frank/Grace
+    // (all 50). Dense ranks: 1, 2, 2, 2. Sorted as appended in fresh()
+    // + the two ties, the tenant_id=2 segment is the last 4 rows.
+    let tenant2: Vec<(String, i64)> = rows
+        .iter()
+        .filter_map(|r| {
+            let t = get_i64(r, "tenant_id");
+            if t != 2 {
+                return None;
+            }
+            let name = match r.get("name") {
+                Some(SqlValue::String(s)) => s.clone(),
+                _ => return None,
+            };
+            Some((name, get_i64(r, "dr")))
+        })
+        .collect();
+    assert_eq!(tenant2.len(), 4);
+    assert_eq!(tenant2[0], ("Dave".into(), 1));
+    // Eve/Frank/Grace all share dense-rank 2.
+    for (_, dr) in &tenant2[1..] {
+        assert_eq!(*dr, 2, "tied rows should share dense-rank 2");
+    }
+
+    cleanup(&pool).await;
+}
+
+/// Row-number: sequential 1-based index within the partition,
+/// regardless of ties.
+#[tokio::test]
+async fn row_number_returns_sequential_index() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    use rustango::core::aggregates::max;
+    let q = User::objects()
+        .aggregate()
+        .group_by("id")
+        .group_by("tenant_id")
+        .group_by("score")
+        .annotate("_a", max("id").into())
+        .annotate(
+            "rn",
+            row_number()
+                .partition_by("tenant_id")
+                .order_by(&[("score", true), ("id", false)])
+                .into(),
+        )
+        .order_by(&[("tenant_id", false), ("score", true), ("id", false)])
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    // Tenant 1 has 3 rows → row numbers 1, 2, 3.
+    let tenant1: Vec<i64> = rows
+        .iter()
+        .filter(|r| get_i64(r, "tenant_id") == 1)
+        .map(|r| get_i64(r, "rn"))
+        .collect();
+    assert_eq!(tenant1, vec![1, 2, 3]);
+
+    cleanup(&pool).await;
+}
+
+/// Lag: previous-row value within the partition, default substituted
+/// when out of range. For the first row of each partition (no prior
+/// row), `LAG(score, 1, 0)` should return 0.
+#[tokio::test]
+async fn lag_returns_prior_row_value_with_default_on_edge() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    use rustango::core::aggregates::max;
+    let q = User::objects()
+        .aggregate()
+        .group_by("id")
+        .group_by("tenant_id")
+        .group_by("score")
+        .annotate("_a", max("id").into())
+        .annotate(
+            "prev_score",
+            lag("score", 1, Some(SqlValue::I64(0)))
+                .partition_by("tenant_id")
+                .order_by(&[("score", true)])
+                .into(),
+        )
+        .order_by(&[("tenant_id", false), ("score", true), ("id", false)])
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    // Tenant 1 in score-desc: Alice(30) → prev=0 (no prior),
+    // Bob(20)   → prev=30, Carol(10) → prev=20.
+    let tenant1: Vec<i64> = rows
+        .iter()
+        .filter(|r| get_i64(r, "tenant_id") == 1)
+        .map(|r| get_i64(r, "prev_score"))
+        .collect();
+    assert_eq!(tenant1, vec![0, 30, 20]);
+
+    cleanup(&pool).await;
+}
+
+async fn cleanup(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "wfl_user" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+}

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -603,7 +603,26 @@ Each returns a `WindowBuilder` with three chainable modifiers:
 - `.order_by(&[("col", desc)])` — append `ORDER BY` columns (`desc = true` → DESC).
 - `.frame(WindowFrame { kind, start, end })` — set the optional `ROWS`/`RANGE` frame clause. `FrameBoundary::UnboundedPreceding` / `Preceding(n)` / `CurrentRow` / `Following(n)` / `UnboundedFollowing`.
 
-The builder lowers via `Into<Expr>` so window functions slot into `set_expr` (UPDATE) and `eq_expr` (WHERE rhs); via `Into<AggregateExpr>` so they compose with `annotate()`.
+The builder lowers via `Into<AggregateExpr>` so window functions compose with `annotate()`. `Into<Expr>` is also implemented (the IR-level slot for window expressions), but **every backend rustango supports restricts window functions to the `SELECT` list and `ORDER BY` clause of a query** — they cannot appear in `WHERE` / `HAVING` / `GROUP BY` / `UPDATE SET` / `JOIN ON` / `RETURNING`. The writer doesn't gate emission on this, so `set_expr("col", row_number())` compiles to SQL the database rejects at execute. Build window expressions through `annotate()`; reach for a subquery if you need to feed a window result into a WHERE filter or an UPDATE.
+
+**`LAST_VALUE` default-frame trap:**
+
+A bare `last_value(col).order_by(&[("x", false)])` emits `LAST_VALUE("col") OVER (ORDER BY "x")` and looks like it should return the partition's last `col`. It doesn't — SQL's *default* window frame is `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`, so `LAST_VALUE` returns the **current row's** value, not the partition's last row. To get the intuitive "last row of the partition" behavior, pass an explicit unbounded frame:
+
+```rust
+use rustango::core::{FrameBoundary, FrameKind, WindowFrame};
+
+last_value("score")
+    .partition_by("tenant_id")
+    .order_by(&[("created_at", true)])
+    .frame(WindowFrame {
+        kind: FrameKind::Rows,
+        start: FrameBoundary::UnboundedPreceding,
+        end: Some(FrameBoundary::UnboundedFollowing),
+    })
+```
+
+`first_value` doesn't have this trap — the default frame's start matches the partition start, so the intuitive answer falls out.
 
 **Annotate caveat (until issue #75 ships):**
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -526,6 +526,118 @@ The writer applies the dialect's int/float cast (`::bigint`, `CAST(... AS SIGNED
 
 **SQLite + StdDev/Variance:** SQLite has no built-in statistical aggregates, so the writer rejects with `SqlError::AggregateNotSupported { aggregate, dialect: "sqlite" }`. Compute the variance formula in app code if portable stats are needed (same posture Django takes).
 
+### Window functions — `row_number / rank / dense_rank / lag / lead / first_value / last_value / ntile`
+
+Issue #7 closes the Django `Window(expression, partition_by=, order_by=, frame=)` gap with 8 function variants + ROWS/RANGE frame clauses. Tri-dialect uniform — every backend rustango supports (PG ≥ 9.0, MySQL ≥ 8.0, SQLite ≥ 3.25) ships native `OVER (…)` syntax.
+
+```rust
+use rustango::core::aggregates::max;
+use rustango::core::window::{lag, rank, row_number};
+
+// "Rank users by score within each tenant" — the canonical
+// integration target.
+let q = User::objects()
+    .aggregate()
+    .group_by("id")
+    .group_by("tenant_id")
+    .group_by("name")
+    .group_by("score")
+    .annotate("_a", max("id").into())  // satisfies GROUP BY on the projection
+    .annotate(
+        "tenant_rank",
+        rank().partition_by("tenant_id").order_by(&[("score", true)]).into(),
+    )
+    .order_by(&[("tenant_id", false), ("score", true)])
+    .compile()?;
+let rows = rustango::sql::fetch_aggregate(&q, &pool).await?;
+
+// Day-over-day delta via LAG with a default for the first row.
+let q = Event::objects()
+    .aggregate()
+    .group_by("id")
+    .group_by("day")
+    .group_by("count")
+    .annotate("_a", max("id").into())
+    .annotate(
+        "prev_count",
+        lag("count", 1, Some(SqlValue::I64(0)))
+            .partition_by("user_id")
+            .order_by(&[("day", false)])
+            .into(),
+    )
+    .compile()?;
+
+// Stable row index per group for "show me row N" pagination.
+let q = Post::objects()
+    .aggregate()
+    .group_by("id")
+    .group_by("status")
+    .group_by("created_at")
+    .annotate("_a", max("id").into())
+    .annotate(
+        "rn",
+        row_number()
+            .partition_by("status")
+            .order_by(&[("created_at", true)])
+            .into(),
+    )
+    .compile()?;
+```
+
+**Builders** in `rustango::core::window`:
+
+| Builder | SQL | Args |
+|---|---|---|
+| `row_number()` | `ROW_NUMBER()` | — |
+| `rank()` | `RANK()` | — |
+| `dense_rank()` | `DENSE_RANK()` | — |
+| `ntile(buckets)` | `NTILE(buckets)` | bucket count |
+| `lag(col, offset, default)` | `LAG(col, offset, default?)` | column + offset + optional default |
+| `lead(col, offset, default)` | `LEAD(col, offset, default?)` | column + offset + optional default |
+| `first_value(col)` | `FIRST_VALUE(col)` | column |
+| `last_value(col)` | `LAST_VALUE(col)` | column |
+
+Each returns a `WindowBuilder` with three chainable modifiers:
+
+- `.partition_by("col")` — append a `PARTITION BY` column. Call multiple times for multi-column partitioning.
+- `.order_by(&[("col", desc)])` — append `ORDER BY` columns (`desc = true` → DESC).
+- `.frame(WindowFrame { kind, start, end })` — set the optional `ROWS`/`RANGE` frame clause. `FrameBoundary::UnboundedPreceding` / `Preceding(n)` / `CurrentRow` / `Following(n)` / `UnboundedFollowing`.
+
+The builder lowers via `Into<Expr>` so window functions slot into `set_expr` (UPDATE) and `eq_expr` (WHERE rhs); via `Into<AggregateExpr>` so they compose with `annotate()`.
+
+**Annotate caveat (until issue #75 ships):**
+
+`annotate()` lives on the aggregate-builder which requires `GROUP BY` to project per-row scalar columns alongside aggregates. To project window-function results next to row columns today, list every row column you want to return in `.group_by(...)` calls and `annotate("_a", max("id").into())` as a no-op placeholder to keep the row identity stable. Issue #75 (GROUP BY auto-inference) lands a cleaner shape.
+
+**Frame clauses:**
+
+```rust
+use rustango::core::{FrameBoundary, FrameKind, WindowFrame};
+
+// Running total over the last 7 rows:
+let frame = WindowFrame {
+    kind: FrameKind::Rows,
+    start: FrameBoundary::Preceding(6),
+    end: Some(FrameBoundary::CurrentRow),
+};
+
+// Centered 11-row window:
+let frame = WindowFrame {
+    kind: FrameKind::Rows,
+    start: FrameBoundary::Preceding(5),
+    end: Some(FrameBoundary::Following(5)),
+};
+```
+
+**Tri-dialect emission:**
+
+`<fn>(args) OVER (PARTITION BY … ORDER BY … [frame])` is SQL-standard — identical across PG, MySQL 8+, and SQLite 3.25+. The one quirk: `LAG` / `LEAD` / `NTILE` require integer offsets/buckets on PG (binding as a bigint `$N` parameter causes `function lag(bigint, bigint, bigint) does not exist`). The writer inlines integer literals directly in the SQL for those slots; default-value args bind through normally.
+
+**Caveats:**
+
+- **`FILTER` + `Window` not yet supported**: combining `.filter(...)` with a window function raises `SqlError::NestedAggregateWrapper { wrapper: "Filtered(Window)" }` — the underlying syntax varies by function kind (PG allows `agg_fn() FILTER (WHERE …) OVER (…)` for aggregate-window funcs but not for ranking ones), and the writer hasn't been taught the dispatch. Filed for a follow-up if demand surfaces.
+- **`PercentRank` / `CumeDist` / `NthValue`** aren't in v1 — Django's complete set is bigger. v1 ships the 8 most-used variants; the missing three can be added incrementally with the same builder shape.
+
 ---
 
 ## Joins + select_related


### PR DESCRIPTION
## Summary

Closes #7 — the seventh and **final** issue in the ORM Expression DSL epic (#59). **Stacked on #82** (issue-6-aggregate-filter). Will rebase to main once the full chain merges.

Closes the Django `Window(expression, partition_by=, order_by=, frame=)` gap with 8 function variants + ROWS/RANGE frame clauses. Tri-dialect uniform — every backend rustango supports (PG ≥ 9.0, MySQL ≥ 8.0, SQLite ≥ 3.25) ships native `OVER (…)` syntax.

## What you get

```rust
use rustango::core::aggregates::max;
use rustango::core::window::{lag, rank, row_number};
use rustango::core::SqlValue;

// "Rank users by score within each tenant" — the issue #7 target.
let q = User::objects()
    .aggregate()
    .group_by("id").group_by("tenant_id").group_by("name").group_by("score")
    .annotate("_a", max("id").into())  // GROUP BY satisfier
    .annotate(
        "tenant_rank",
        rank().partition_by("tenant_id").order_by(&[("score", true)]).into(),
    )
    .order_by(&[("tenant_id", false), ("score", true)])
    .compile()?;
let rows = rustango::sql::fetch_aggregate(&q, &pool).await?;

// Day-over-day delta via LAG with a default for the first row.
.annotate(
    "prev_count",
    lag("count", 1, Some(SqlValue::I64(0)))
        .partition_by("user_id")
        .order_by(&[("day", false)])
        .into(),
)

// Window-as-Expr inside an UPDATE assignment (no annotate dance needed):
Event::objects()
    .update()
    .set_expr("row_idx", row_number().order_by(&[("created_at", true)]))
    .execute(&pool).await?;
```

## Builder API

| Builder | SQL | Args |
|---|---|---|
| `row_number()` | `ROW_NUMBER()` | — |
| `rank()` | `RANK()` | — |
| `dense_rank()` | `DENSE_RANK()` | — |
| `ntile(buckets)` | `NTILE(buckets)` | bucket count (inlined as integer literal) |
| `lag(col, offset, default)` | `LAG(col, offset, default?)` | column + offset + optional default |
| `lead(col, offset, default)` | `LEAD(col, offset, default?)` | column + offset + optional default |
| `first_value(col)` | `FIRST_VALUE(col)` | column |
| `last_value(col)` | `LAST_VALUE(col)` | column |

Each returns a `WindowBuilder` with three chainable modifiers:

- `.partition_by("col")` — append `PARTITION BY` column (multi-call composes).
- `.order_by(&[("col", desc)])` — append `ORDER BY` (`desc = true` → DESC).
- `.frame(WindowFrame { kind, start, end })` — set the `ROWS`/`RANGE` frame clause.

Lowers via `Into<Expr>` (`set_expr` / `eq_expr` slots) and `Into<AggregateExpr>` (`annotate()` slots).

## Tri-dialect matrix

| Feature | PG | MySQL | SQLite |
|---|---|---|---|
| RowNumber / Rank / DenseRank | ✓ | ✓ (8.0+) | ✓ (3.25+) |
| Ntile / Lag / Lead | ✓ | ✓ | ✓ |
| FirstValue / LastValue | ✓ | ✓ | ✓ |
| ROWS / RANGE frames | ✓ | ✓ | ✓ |

One PG-specific quirk handled: `LAG` / `LEAD` / `NTILE` require *integer* (not bigint) offsets/buckets. Binding `i64` as `$N` makes PG fail with `function lag(bigint, bigint, bigint) does not exist`. The writer inlines those integer args as literal SQL (`LAG("score", 1, $1)` — only the default value binds). Default args bind normally.

## What landed

- **`core/window.rs`** (new) — IR types + builders.
- **`core/expr.rs`** + **`core/query.rs`** — new `Expr::Window(Box<WindowExpr>)` and `AggregateExpr::Window(Box<WindowExpr>)`.
- **`core/mod.rs`** — module wired, `WindowExpr` / `WindowFn` / `WindowFrame` / `FrameKind` / `FrameBoundary` re-exported.
- **`core/query.rs`** + **`query/mod.rs`** — validators walk Window's args + partition_by + order_by columns against the model schema (typo'd columns surface at `compile()` time).
- **`sql/writers.rs`** — `write_window_expr` + `write_window_frame` emitting standard SQL form. Per-function integer-literal inlining for the PG offset-type quirk.

## Tests

| Suite | Count |
|---|---|
| `core::window::tests` (unit) | 8 |
| `tests/window_functions.rs` (tri-dialect emission) | 15 |
| `tests/window_functions_live.rs` (live PG runtime) | 4 |

The 15 emission tests cover: per-function emission (RowNumber, Rank, DenseRank, Ntile, Lag, Lead, FirstValue, LastValue); frame clauses (ROWS BETWEEN / RANGE / single-boundary); tri-dialect ident-quote shapes (MySQL backticks, SQLite double-quotes); Window-as-Expr inside UPDATE `set_expr`; multi-column PARTITION/ORDER chain order; integer-literal inlining for LAG/LEAD/NTILE.

The 4 live PG tests: the issue #7 integration target (rank by score within tenant — 1,2,3 in tenant1 and 1,2 in tenant2); dense-rank ties-don't-skip (1,2,2,2 with three tied rows at score=50); row_number sequential index per partition; lag-with-default edge handling (first row gets the default, subsequent rows get prior values).

## Cookbook

New "Window functions" subsection under "Aggregations" in `docs/orm.md`. Documents the builder API, the tri-dialect matrix, the LAG/LEAD/NTILE integer-inline quirk, frame examples (running totals + centered windows), and the annotate-with-GROUP-BY workaround until #75 ships.

## Caveats documented

- **`FILTER` + `Window` not yet wired** — combining `.filter(...)` from #6 with a window function raises `SqlError::NestedAggregateWrapper { wrapper: "Filtered(Window)" }`. The PG syntax varies by function kind (aggregate-window functions support `FILTER (WHERE …) OVER (…)`, ranking ones don't), and the writer hasn't been taught the dispatch. Filed for follow-up if demand surfaces.
- **`PercentRank` / `CumeDist` / `NthValue`** aren't in v1 — Django's complete set is 11 functions. v1 ships the 8 most-used variants; the missing three are incremental adds with the same builder shape.
- **annotate-with-window requires GROUP BY workaround** — until issue #75 (GROUP BY auto-inference) ships, projecting row columns alongside a window-annotation needs every row column listed in `.group_by(...)` plus a placeholder aggregate. Documented in the cookbook.

## Verification

```
cargo test -p rustango --lib --features tenancy                  → 1494 passed (+8 window unit tests)
cargo test --features tenancy,mysql,sqlite --test window_functions → 15 passed
DATABASE_URL=… cargo test --features tenancy --test window_functions_live → 4 passed
cargo check --no-default-features --features sqlite,tenancy      → clean
cargo check --features mysql,tenancy                             → clean
```

No regressions in aggregate (24), case (15), subquery (10), or ad-hoc joins (18) emission suites.

## Epic complete

With this PR merged, the **ORM Expression DSL epic (#59)** is feature-complete:

| # | Slice | PR |
|---|---|---|
| #1 | F() expressions — atomic updates + column-vs-column compares | #70 ✓ |
| #2 | Database functions DSL — text + math + comparison | #72 ✓ |
| #3 | Date/time function DSL | #73 ✓ |
| #4 | Conditional expressions (Case/When/Value) | #78 ✓ |
| #5 | Subquery / Exists / OuterRef | #79 ✓ |
| #80 | Ad-hoc joins (`.join(OtherModel, on=Q(...))` — SQLAlchemy-shape) | #81 ✓ |
| #6 | Aggregate `filter=` / `default=` / StdDev / Variance | #82 ✓ |
| #7 | Window functions | **this PR** |

Eight slices, ~6000 lines of source + tests + cookbook, tri-dialect throughout, 8 new IR variants across `Expr` / `WhereExpr` / `AggregateExpr`. Full Django ORM expression-system parity plus the SQLAlchemy-shape ad-hoc join DSL Django doesn't have.

## Test plan

- [x] 8 unit tests pass.
- [x] 15 tri-dialect emission tests pass.
- [x] 4 live PG tests pass (incl. issue #7 integration target).
- [x] All three feature combos compile.
- [x] Cookbook section + caveats added.
- [ ] CI green on `postgres_test` + `mysql_live` + `sqlite_live` + `sqlite_litmus`.
- [ ] Rebase to main once the full stack merges.
