### PR TITLE
ORDER BY enhancements — Expr items + NULLS FIRST/LAST (closes #76)

### DIFF
--- a/crates/rustango/examples/blog_demo/models.rs
+++ b/crates/rustango/examples/blog_demo/models.rs
@@ -77,6 +77,7 @@ rustango::register_admin_computed!("post", "word_count", "Words", |row| {
     ordering      = "-published_at",
     page_size     = 20,
 )]
+#[allow(dead_code)] // Example viewset; built solely to prove the derive macro shape.
 pub struct PostViewSet;
 
 /// Read-only viewset for authors.
@@ -88,4 +89,5 @@ pub struct PostViewSet;
     ordering      = "name",
     read_only,
 )]
+#[allow(dead_code)] // Example viewset; built solely to prove the derive macro shape.
 pub struct AuthorViewSet;

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -220,17 +220,16 @@ pub(crate) async fn table_view(
     };
     let joins = build_fk_joins(&state, model);
     // Default ordering: PK ASC unless `admin.ordering` overrides.
-    let order_by: Vec<crate::core::OrderClause> = if admin_cfg.ordering.is_empty() {
+    let order_by: Vec<crate::core::OrderItem> = if admin_cfg.ordering.is_empty() {
         Vec::new()
     } else {
         admin_cfg
             .ordering
             .iter()
             .filter_map(|(name, desc)| {
-                model.field(name).map(|f| crate::core::OrderClause {
-                    column: f.column,
-                    desc: *desc,
-                })
+                model
+                    .field(name)
+                    .map(|f| crate::core::OrderItem::column(f.column, *desc))
             })
             .collect()
     };

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -399,7 +399,8 @@ where
             order_by: vec![OrderClause {
                 column: pk_field.column,
                 desc: false,
-            }],
+            }
+            .into()],
             limit: Some(batch),
             offset: Some(offset),
         };

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -25,8 +25,8 @@ pub use expr::{BinOp, CaseBranch, Expr, ScalarFn, F};
 pub use field_type::FieldType;
 pub use query::{
     AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ColumnFilter,
-    ConflictClause, CountQuery, DeleteQuery, Filter, InsertQuery, Join, JoinKind, Op, OrderClause,
-    SearchClause, SelectQuery, UpdateQuery, WhereExpr,
+    ConflictClause, CountQuery, DeleteQuery, Filter, InsertQuery, Join, JoinKind, NullsOrder, Op,
+    OrderClause, OrderItem, SearchClause, SelectQuery, UpdateQuery, WhereExpr,
 };
 pub use schema::{
     infer_app_label_from_module_path, AdminConfig, CheckConstraint, CompositeFkRelation,

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -378,9 +378,9 @@ pub struct SelectQuery {
     pub search: Option<SearchClause>,
     pub joins: Vec<Join>,
     /// `ORDER BY` clauses, in the order they should appear in SQL.
-    /// Slice 9.0b. Emitted after WHERE / JOIN / GROUP BY but before
-    /// LIMIT / OFFSET. Empty = no `ORDER BY` (existing behaviour).
-    pub order_by: Vec<OrderClause>,
+    /// Slice 9.0b + issue #76. Emitted after WHERE / JOIN / GROUP BY
+    /// but before LIMIT / OFFSET. Empty = no `ORDER BY`.
+    pub order_by: Vec<OrderItem>,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
 }
@@ -416,7 +416,13 @@ impl PartialEq for Join {
     }
 }
 
-/// Single column in an `ORDER BY` clause. Slice 9.0b.
+/// Single column in an `ORDER BY` clause. Slice 9.0b — the simple
+/// "field name + ASC/DESC" form that pre-dates [`OrderItem`].
+///
+/// New code should prefer [`OrderItem`] (issue #76) which adds Expr
+/// items and `NULLS FIRST/LAST` control. `OrderClause` remains as a
+/// convenience-constructor and converts via `Into<OrderItem>` for
+/// every `SelectQuery` / `AggregateQuery` / window-OVER ORDER BY slot.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrderClause {
     /// SQL column name on the main table — already resolved by
@@ -425,6 +431,129 @@ pub struct OrderClause {
     pub column: &'static str,
     /// `true` for `DESC`, `false` for the default `ASC`.
     pub desc: bool,
+}
+
+/// Where NULLs sort relative to non-NULL values. Issue #76.
+///
+/// Default semantics differ per dialect: PG and SQLite sort NULLs
+/// LAST on `ASC` and FIRST on `DESC` (the SQL-standard); MySQL
+/// treats NULLs as smaller than every value so they land FIRST on
+/// `ASC` and LAST on `DESC`. Pinning the order explicitly via
+/// `First` or `Last` produces consistent behavior across all three
+/// dialects (the writer emits `IFNULL(…)` workarounds on MySQL,
+/// which has no native `NULLS FIRST`/`NULLS LAST` keywords).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NullsOrder {
+    /// Backend's native default — emits no `NULLS …` clause.
+    #[default]
+    Default,
+    /// `NULLS FIRST` on PG/SQLite; emulated via `IFNULL(col, '') = ''
+    /// DESC, …` style trick on MySQL.
+    First,
+    /// `NULLS LAST` on PG/SQLite; emulated on MySQL similarly.
+    Last,
+}
+
+/// One item in a generalized `ORDER BY` list (issue #76). Carries
+/// either a plain column reference (with optional NULL-ordering) or
+/// an arbitrary [`Expr`] — `lower(col)`, `case(…)`, `F(a) + F(b)`,
+/// any builder result that lowers to `Expr`.
+///
+/// Old-shape `OrderClause` values convert into the `Column` variant
+/// via `Into<OrderItem>` so existing constructors keep working.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OrderItem {
+    /// `<col> [DESC] [NULLS FIRST|LAST]`. Equivalent of the legacy
+    /// `OrderClause` with the addition of `NullsOrder`.
+    Column {
+        column: &'static str,
+        desc: bool,
+        nulls: NullsOrder,
+    },
+    /// `<expr> [DESC] [NULLS FIRST|LAST]`. The `expr` is emitted via
+    /// the standard `Expr` writer, so function calls / `CASE` /
+    /// arithmetic / etc. all compose.
+    Expr {
+        expr: Expr,
+        desc: bool,
+        nulls: NullsOrder,
+    },
+}
+
+impl From<OrderClause> for OrderItem {
+    fn from(c: OrderClause) -> Self {
+        Self::Column {
+            column: c.column,
+            desc: c.desc,
+            nulls: NullsOrder::Default,
+        }
+    }
+}
+
+impl OrderItem {
+    /// Convenience for the most-common case — `<col> [DESC]`, default
+    /// NULL ordering.
+    #[must_use]
+    pub fn column(column: &'static str, desc: bool) -> Self {
+        Self::Column {
+            column,
+            desc,
+            nulls: NullsOrder::Default,
+        }
+    }
+
+    /// Convenience for `<col> [DESC] [NULLS FIRST|LAST]`.
+    #[must_use]
+    pub fn column_with_nulls(column: &'static str, desc: bool, nulls: NullsOrder) -> Self {
+        Self::Column {
+            column,
+            desc,
+            nulls,
+        }
+    }
+
+    /// Convenience for `<expr> [DESC]` with default NULL ordering.
+    #[must_use]
+    pub fn expr(expr: Expr, desc: bool) -> Self {
+        Self::Expr {
+            expr,
+            desc,
+            nulls: NullsOrder::Default,
+        }
+    }
+
+    /// Convenience for `<expr> [DESC] [NULLS FIRST|LAST]`.
+    #[must_use]
+    pub fn expr_with_nulls(expr: Expr, desc: bool, nulls: NullsOrder) -> Self {
+        Self::Expr { expr, desc, nulls }
+    }
+
+    /// Bare column name when this item is a `Column` variant; `None`
+    /// for `Expr` variants. Used by callers that pre-dated the enum
+    /// (admin / template_views / older tests).
+    #[must_use]
+    pub fn column_name(&self) -> Option<&'static str> {
+        match self {
+            Self::Column { column, .. } => Some(column),
+            Self::Expr { .. } => None,
+        }
+    }
+
+    /// `true` if this item sorts descending.
+    #[must_use]
+    pub fn is_desc(&self) -> bool {
+        match self {
+            Self::Column { desc, .. } | Self::Expr { desc, .. } => *desc,
+        }
+    }
+
+    /// The `NullsOrder` setting for this item.
+    #[must_use]
+    pub fn nulls_order(&self) -> NullsOrder {
+        match self {
+            Self::Column { nulls, .. } | Self::Expr { nulls, .. } => *nulls,
+        }
+    }
 }
 
 /// Which SQL `JOIN` keyword the writer should emit. Issue #80.
@@ -771,7 +900,7 @@ pub struct AggregateQuery {
     pub aggregates: Vec<(&'static str, AggregateExpr)>,
     /// Optional HAVING clause (applied after GROUP BY).
     pub having: Option<WhereExpr>,
-    pub order_by: Vec<OrderClause>,
+    pub order_by: Vec<OrderItem>,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
 }

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -10,8 +10,7 @@ use std::marker::PhantomData;
 
 use crate::core::{
     AggregateExpr, AggregateQuery, Assignment, DeleteQuery, Filter, Model, ModelSchema, Op,
-    OrderClause, QueryError, SelectQuery, SqlValue, TypedAssignment, TypedExpr, UpdateQuery,
-    WhereExpr,
+    QueryError, SelectQuery, SqlValue, TypedAssignment, TypedExpr, UpdateQuery, WhereExpr,
 };
 
 /// A lazy builder for a `SELECT` over `T`.
@@ -39,10 +38,34 @@ pub struct QuerySet<T: Model> {
     /// time so explicit user-driven joins sit alongside the automatic
     /// FK ones in the SELECT list.
     ad_hoc_joins: Vec<crate::core::Join>,
-    /// `(field_name, desc)` pairs registered via [`Self::order_by`].
-    /// Slice 9.0b. Resolved against the schema at `compile()` time.
-    order_by: Vec<(String, bool)>,
+    /// Unified pending `ORDER BY` list (slice 9.0b + issue #76).
+    /// Carries `Field { name, desc, nulls }` entries from
+    /// `.order_by(...)` / `.order_by_with_nulls(...)` plus `Expr { … }`
+    /// entries from `.order_by_expr(...)`. Lowered at `compile()`
+    /// time in registration order so chain order is preserved
+    /// across mixed builder calls.
+    order_by: Vec<PendingOrderItem>,
     _model: PhantomData<fn() -> T>,
+}
+
+/// Issue #76: order-by entry in the QuerySet's unified pending list.
+/// `Field` carries a string field name resolved against the schema
+/// at `compile()` time (sugar shared between `.order_by(...)` and
+/// `.order_by_with_nulls(...)`). `Expr` wraps an already-built
+/// expression for `.order_by_expr(...)`. The list preserves
+/// registration order so mixed builder chains compose predictably.
+#[derive(Debug, Clone)]
+enum PendingOrderItem {
+    Field {
+        name: String,
+        desc: bool,
+        nulls: crate::core::NullsOrder,
+    },
+    Expr {
+        expr: crate::core::Expr,
+        desc: bool,
+        nulls: crate::core::NullsOrder,
+    },
 }
 
 /// Filter accumulator entry — keeps insertion order across string-keyed and
@@ -127,14 +150,85 @@ impl<T: Model> QuerySet<T> {
     #[must_use]
     pub fn order_by(mut self, items: &[(&str, bool)]) -> Self {
         for (field, desc) in items {
-            self.order_by.push(((*field).to_owned(), *desc));
+            self.order_by.push(PendingOrderItem::Field {
+                name: (*field).to_owned(),
+                desc: *desc,
+                nulls: crate::core::NullsOrder::Default,
+            });
         }
+        self
+    }
+
+    /// Append `ORDER BY` columns with explicit `NULLS FIRST|LAST`
+    /// control. Issue #76. PG + SQLite emit the `NULLS …` keyword
+    /// natively; MySQL emulates via `<col> IS NULL` pre-sort
+    /// because it has no `NULLS …` syntax.
+    ///
+    /// ```ignore
+    /// use rustango::core::NullsOrder;
+    /// Post::objects()
+    ///     .order_by_with_nulls(&[("published_at", true, NullsOrder::Last)])
+    ///     .fetch(&pool).await?;
+    /// ```
+    ///
+    /// Composes with `.order_by(...)` — legacy `(name, desc)` entries
+    /// Composes with `.order_by(...)` — entries from both methods
+    /// appear in the SQL `ORDER BY` clause in **registration order**
+    /// across the chain.
+    #[must_use]
+    pub fn order_by_with_nulls(
+        mut self,
+        items: &[(&'static str, bool, crate::core::NullsOrder)],
+    ) -> Self {
+        for (field, desc, nulls) in items {
+            self.order_by.push(PendingOrderItem::Field {
+                name: (*field).to_owned(),
+                desc: *desc,
+                nulls: *nulls,
+            });
+        }
+        self
+    }
+
+    /// Append an `ORDER BY` item whose target is an arbitrary
+    /// [`Expr`] — `lower(F("title"))`, `case(...)`, `F("a") + F("b")`,
+    /// any builder result that lowers to `Expr`. Issue #76.
+    ///
+    /// `desc = true` → `DESC`; defaults to the dialect's native
+    /// NULL ordering (use [`Self::order_by_expr_with_nulls`] to pin).
+    ///
+    /// [`Expr`]: crate::core::Expr
+    #[must_use]
+    pub fn order_by_expr(mut self, expr: impl Into<crate::core::Expr>, desc: bool) -> Self {
+        self.order_by.push(PendingOrderItem::Expr {
+            expr: expr.into(),
+            desc,
+            nulls: crate::core::NullsOrder::Default,
+        });
+        self
+    }
+
+    /// Same as [`Self::order_by_expr`] but with an explicit
+    /// `NullsOrder`. Issue #76.
+    #[must_use]
+    pub fn order_by_expr_with_nulls(
+        mut self,
+        expr: impl Into<crate::core::Expr>,
+        desc: bool,
+        nulls: crate::core::NullsOrder,
+    ) -> Self {
+        self.order_by.push(PendingOrderItem::Expr {
+            expr: expr.into(),
+            desc,
+            nulls,
+        });
         self
     }
 
     /// v0.45 — discard any previously-set `order_by` and apply
     /// `items` as the new ordering. Used by `earliest_pool` and
-    /// `latest_pool` which declare their own sort.
+    /// `latest_pool` which declare their own sort. Clears every
+    /// pending item (legacy + `_with_nulls` + `_expr`).
     #[must_use]
     pub fn replace_order_by(mut self, items: &[(&str, bool)]) -> Self {
         self.order_by.clear();
@@ -144,20 +238,36 @@ impl<T: Model> QuerySet<T> {
     /// v0.45 — flip every ordering direction in place. Used by
     /// `last_pool` to invert the queryset's natural sort and take
     /// the first row from the reversed sequence — avoids OFFSET +
-    /// COUNT(*) and works on every dialect.
+    /// COUNT(*) and works on every dialect. Issue #76: also swaps
+    /// `NullsOrder::First` ↔ `NullsOrder::Last` so the "NULLs at the
+    /// same logical end as before" semantic survives an inversion.
     #[must_use]
     pub fn flip_order_by(mut self) -> Self {
         for entry in &mut self.order_by {
-            entry.1 = !entry.1;
+            match entry {
+                PendingOrderItem::Field { desc, nulls, .. }
+                | PendingOrderItem::Expr { desc, nulls, .. } => {
+                    *desc = !*desc;
+                    *nulls = match *nulls {
+                        crate::core::NullsOrder::First => crate::core::NullsOrder::Last,
+                        crate::core::NullsOrder::Last => crate::core::NullsOrder::First,
+                        crate::core::NullsOrder::Default => crate::core::NullsOrder::Default,
+                    };
+                }
+            }
         }
         self
     }
 
-    /// v0.45 — read-only view of the current `order_by` for callers
-    /// that need to inspect it (e.g. inserting a PK fallback).
+    /// v0.45 — count of registered `ORDER BY` items. Used by
+    /// `ensure_pk_ordering` (executor) to detect "no ordering set"
+    /// without inspecting the variant types. Issue #76 dropped the
+    /// `order_by_clauses() -> &[(String, bool)]` getter because the
+    /// unified pending list now carries `Expr` items that can't
+    /// flatten to that shape.
     #[must_use]
-    pub fn order_by_clauses(&self) -> &[(String, bool)] {
-        &self.order_by
+    pub fn has_order_by(&self) -> bool {
+        !self.order_by.is_empty()
     }
 
     /// Eagerly load a `ForeignKey<Parent>` field via a `LEFT JOIN` —
@@ -316,7 +426,11 @@ impl<T: Model> QuerySet<T> {
         // for legacy callers, and keeps user-driven joins next to the
         // user-driven WHERE.
         joins.extend(self.ad_hoc_joins);
-        let order_by = lower_order_by(model, &self.order_by)?;
+        // Lower the unified pending list to OrderItems. Insertion
+        // order is preserved across legacy `.order_by(...)` and
+        // issue-#76 `.order_by_with_nulls(...)` / `.order_by_expr(...)`
+        // calls so a mixed chain emits in the order it was written.
+        let order_by = lower_order_items(model, self.order_by)?;
         Ok(SelectQuery {
             model,
             where_clause,
@@ -460,24 +574,33 @@ impl<T: Model> UpdateBuilder<T> {
     }
 }
 
-/// Convert `(field_name, desc)` pairs into `OrderClause`s by
-/// resolving each field name on the schema. Slice 9.0b.
-fn lower_order_by(
+/// Issue #76: lower the unified pending order-by list to a
+/// `Vec<OrderItem>` at `compile()` time. `Field` variants resolve
+/// the field name against the model schema; `Expr` variants pass
+/// through verbatim (the writer surfaces DB-side errors for typos
+/// inside expressions, matching the existing `set_expr` posture).
+fn lower_order_items(
     model: &'static ModelSchema,
-    items: &[(String, bool)],
-) -> Result<Vec<crate::core::OrderClause>, QueryError> {
+    items: Vec<PendingOrderItem>,
+) -> Result<Vec<crate::core::OrderItem>, QueryError> {
     let mut out = Vec::with_capacity(items.len());
-    for (field_name, desc) in items {
-        let field = model
-            .field(field_name)
-            .ok_or_else(|| QueryError::UnknownField {
-                model: model.name,
-                field: field_name.clone(),
-            })?;
-        out.push(crate::core::OrderClause {
-            column: field.column,
-            desc: *desc,
-        });
+    for item in items {
+        match item {
+            PendingOrderItem::Field { name, desc, nulls } => {
+                let field = model.field(&name).ok_or_else(|| QueryError::UnknownField {
+                    model: model.name,
+                    field: name.clone(),
+                })?;
+                out.push(crate::core::OrderItem::column_with_nulls(
+                    field.column,
+                    desc,
+                    nulls,
+                ));
+            }
+            PendingOrderItem::Expr { expr, desc, nulls } => {
+                out.push(crate::core::OrderItem::expr_with_nulls(expr, desc, nulls));
+            }
+        }
     }
     Ok(out)
 }
@@ -811,7 +934,7 @@ impl<T: Model> AggregateBuilder<T> {
         let order_by = self
             .order_by
             .into_iter()
-            .map(|(col, desc)| OrderClause { column: col, desc })
+            .map(|(col, desc)| crate::core::OrderItem::column(col, desc))
             .collect();
         Ok(AggregateQuery {
             model,

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -189,6 +189,18 @@ pub trait Dialect {
         false
     }
 
+    /// `true` if the dialect understands the `ORDER BY … NULLS
+    /// FIRST|LAST` keyword (issue #76). Postgres + SQLite yes;
+    /// MySQL no — there the writer emulates `NULLS FIRST/LAST`
+    /// with an `<col> IS NULL` pre-sort term:
+    ///
+    /// - `NULLS FIRST` on `ASC`: emit `<col> IS NULL DESC, <col> ASC`
+    /// - `NULLS LAST`  on `ASC`: emit `<col> IS NULL ASC,  <col> ASC`
+    /// - same pattern for DESC.
+    fn supports_nulls_order(&self) -> bool {
+        true
+    }
+
     /// Wrap a SUM expression in a cast back to BIGINT. PostgreSQL's
     /// SUM(BIGINT) is NUMERIC and MySQL's is DECIMAL — both fall
     /// through to Null in the aggregate row decoder which only tries

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -3441,7 +3441,7 @@ fn ensure_pk_ordering<T: Model>(
     qs: crate::query::QuerySet<T>,
     reverse: bool,
 ) -> crate::query::QuerySet<T> {
-    if qs.order_by_clauses().is_empty() {
+    if !qs.has_order_by() {
         let pk = T::SCHEMA.primary_key().map(|f| f.column);
         if let Some(pk_col) = pk {
             return qs.replace_order_by(&[(pk_col, reverse)]);

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -3510,6 +3510,9 @@ where
 
 #[cfg(test)]
 mod pool_dispatch_tests {
+    // All inner tests are `#[cfg(feature = "mysql")]` gated; without
+    // that feature the imports show as unused.
+    #[allow(unused_imports)]
     use super::*;
 
     /// Smoke test: a `Pool::Mysql` from a `connect_lazy` handle picks

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -47,6 +47,13 @@ impl Dialect for MySql {
         "mysql"
     }
 
+    /// MySQL has no native `NULLS FIRST` / `NULLS LAST` keyword.
+    /// Returning `false` makes `write_order_limit_offset` emulate
+    /// via an `<col> IS NULL` pre-sort term — issue #76.
+    fn supports_nulls_order(&self) -> bool {
+        false
+    }
+
     /// `MySQL` quotes identifiers with backticks, not double quotes.
     /// Embedded backticks are doubled (the `MySQL` parser's escape rule)
     /// so the output is always a valid quoted identifier even for

--- a/crates/rustango/src/sql/postgres.rs
+++ b/crates/rustango/src/sql/postgres.rs
@@ -13,7 +13,7 @@ use crate::core::{
     FieldType, InsertQuery, Op, SelectQuery, UpdateQuery,
 };
 #[cfg(feature = "postgres")]
-use crate::core::{ModelSchema, OrderClause, SearchClause, WhereExpr};
+use crate::core::{ModelSchema, SearchClause, WhereExpr};
 
 #[cfg(feature = "postgres")]
 use super::writers;
@@ -239,7 +239,7 @@ fn write_pg_ident(sql: &mut String, name: &str) {
 pub(crate) fn compile_where_order_tail(
     where_clause: &WhereExpr,
     search: Option<&SearchClause>,
-    order_by: &[OrderClause],
+    order_by: &[crate::core::OrderItem],
     limit: Option<i64>,
     offset: Option<i64>,
     qualify_with: Option<&str>,

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -16,8 +16,8 @@ use std::fmt::Write as _;
 
 use crate::core::{
     AggregateExpr, AggregateQuery, BulkInsertQuery, BulkUpdateQuery, CountQuery, DeleteQuery,
-    Filter, InsertQuery, ModelSchema, Op, OrderClause, SearchClause, SelectQuery, SqlValue,
-    UpdateQuery, WhereExpr,
+    Filter, InsertQuery, ModelSchema, Op, SearchClause, SelectQuery, SqlValue, UpdateQuery,
+    WhereExpr,
 };
 
 use super::{CompiledStatement, Dialect, SqlError};
@@ -222,7 +222,7 @@ fn write_select_inner(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlErr
         query.limit,
         query.offset,
         qualify.then_some(query.model.table),
-    );
+    )?;
 
     Ok(())
 }
@@ -290,7 +290,7 @@ pub(super) fn write_aggregate(b: &mut Sql<'_>, query: &AggregateQuery) -> Result
         write_where_expr(b, having, None, Some(query.model))?;
     }
 
-    write_order_limit_offset(b, &query.order_by, query.limit, query.offset, None);
+    write_order_limit_offset(b, &query.order_by, query.limit, query.offset, None)?;
 
     Ok(())
 }
@@ -1960,24 +1960,56 @@ fn op_label(op: Op) -> &'static str {
 
 fn write_order_limit_offset(
     b: &mut Sql<'_>,
-    order_by: &[OrderClause],
+    order_by: &[crate::core::OrderItem],
     limit: Option<i64>,
     offset: Option<i64>,
     qualify_with: Option<&str>,
-) {
+) -> Result<(), SqlError> {
+    use crate::core::{NullsOrder, OrderItem};
     if !order_by.is_empty() {
         b.sql.push_str(" ORDER BY ");
-        for (i, clause) in order_by.iter().enumerate() {
-            if i > 0 {
+        let supports_nulls = b.d.supports_nulls_order();
+        let mut first = true;
+        for item in order_by {
+            // Resolve the (target, desc, nulls) triple uniformly.
+            // Column targets get quoted ident; Expr targets get
+            // written through the standard expr writer.
+            let (desc, nulls) = match item {
+                OrderItem::Column { desc, nulls, .. } => (*desc, *nulls),
+                OrderItem::Expr { desc, nulls, .. } => (*desc, *nulls),
+            };
+            // Emulate NULLS FIRST/LAST on MySQL via a leading
+            // `<target> IS NULL <asc|desc>` term, then fall through
+            // to the actual sort.
+            if !supports_nulls && !matches!(nulls, NullsOrder::Default) {
+                if !first {
+                    b.sql.push_str(", ");
+                }
+                first = false;
+                write_order_target(b, item, qualify_with)?;
+                b.sql.push_str(" IS NULL");
+                // NULLS FIRST → group NULLs to the top → IS NULL DESC.
+                // NULLS LAST  → group NULLs to the bottom → IS NULL ASC.
+                match nulls {
+                    NullsOrder::First => b.sql.push_str(" DESC"),
+                    NullsOrder::Last => b.sql.push_str(" ASC"),
+                    NullsOrder::Default => unreachable!(),
+                }
+            }
+            if !first {
                 b.sql.push_str(", ");
             }
-            if let Some(table) = qualify_with {
-                b.write_ident(table);
-                b.sql.push('.');
-            }
-            b.write_ident(clause.column);
-            if clause.desc {
+            first = false;
+            write_order_target(b, item, qualify_with)?;
+            if desc {
                 b.sql.push_str(" DESC");
+            }
+            if supports_nulls {
+                match nulls {
+                    NullsOrder::First => b.sql.push_str(" NULLS FIRST"),
+                    NullsOrder::Last => b.sql.push_str(" NULLS LAST"),
+                    NullsOrder::Default => {}
+                }
             }
         }
     }
@@ -1987,6 +2019,32 @@ fn write_order_limit_offset(
     if let Some(n) = offset {
         let _ = write!(b.sql, " OFFSET {n}");
     }
+    Ok(())
+}
+
+/// Emit just the column or expression part of an `OrderItem` — the
+/// `<target>` half of `<target> [DESC] [NULLS …]`. Used twice when
+/// a MySQL `NULLS …` emulation needs the target both for the
+/// `IS NULL` pre-sort term and the main sort term.
+fn write_order_target(
+    b: &mut Sql<'_>,
+    item: &crate::core::OrderItem,
+    qualify_with: Option<&str>,
+) -> Result<(), SqlError> {
+    use crate::core::OrderItem;
+    match item {
+        OrderItem::Column { column, .. } => {
+            if let Some(table) = qualify_with {
+                b.write_ident(table);
+                b.sql.push('.');
+            }
+            b.write_ident(column);
+        }
+        OrderItem::Expr { expr, .. } => {
+            write_expr(b, expr, None)?;
+        }
+    }
+    Ok(())
 }
 
 // ====================================================================
@@ -2031,7 +2089,7 @@ pub(crate) fn compile_where_order_tail(
     d: &dyn Dialect,
     where_clause: &WhereExpr,
     search: Option<&SearchClause>,
-    order_by: &[OrderClause],
+    order_by: &[crate::core::OrderItem],
     limit: Option<i64>,
     offset: Option<i64>,
     qualify_with: Option<&str>,
@@ -2039,6 +2097,6 @@ pub(crate) fn compile_where_order_tail(
 ) -> Result<CompiledStatement, SqlError> {
     let mut b = Sql::new(d);
     write_where_with_search(&mut b, where_clause, search, qualify_with, model)?;
-    write_order_limit_offset(&mut b, order_by, limit, offset, qualify_with);
+    write_order_limit_offset(&mut b, order_by, limit, offset, qualify_with)?;
     Ok(b.finish())
 }

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -77,7 +77,7 @@ use axum::Router;
 use serde_json::Value;
 use tera::{Context, Tera};
 
-use crate::core::{Filter, ModelSchema, Op, OrderClause, SelectQuery, SqlValue, WhereExpr};
+use crate::core::{Filter, ModelSchema, Op, SelectQuery, SqlValue, WhereExpr};
 use crate::sql::Pool;
 use crate::sql::{count_rows_pool, select_one_row_as_json_pool, select_rows_as_json_pool};
 
@@ -2029,7 +2029,7 @@ fn rerender_form(
 fn resolve_order_by(
     schema: &'static ModelSchema,
     spec: &[(String, bool)],
-) -> Result<Vec<OrderClause>, String> {
+) -> Result<Vec<crate::core::OrderItem>, String> {
     if spec.is_empty() {
         return Ok(default_order_by(schema));
     }
@@ -2045,10 +2045,7 @@ fn resolve_order_by(
                     name, schema.table
                 )
             })?;
-        out.push(OrderClause {
-            column: field.column,
-            desc: *desc,
-        });
+        out.push(crate::core::OrderItem::column(field.column, *desc));
     }
     Ok(out)
 }
@@ -2063,12 +2060,9 @@ fn resolve_order_by(
 /// Models without a primary key fall through to an empty clause —
 /// the application is on its own (and pagination on a PK-less model
 /// is unusual anyway).
-fn default_order_by(schema: &'static ModelSchema) -> Vec<OrderClause> {
+fn default_order_by(schema: &'static ModelSchema) -> Vec<crate::core::OrderItem> {
     match schema.primary_key() {
-        Some(pk) => vec![OrderClause {
-            column: pk.column,
-            desc: false,
-        }],
+        Some(pk) => vec![crate::core::OrderItem::column(pk.column, false)],
         None => Vec::new(),
     }
 }
@@ -2110,7 +2104,7 @@ fn resolve_active_order(
     builder_spec: &[(String, bool)],
     ordering_fields: &[String],
     params: &HashMap<String, String>,
-) -> Result<(Vec<OrderClause>, String), String> {
+) -> Result<(Vec<crate::core::OrderItem>, String), String> {
     // URL override path.
     if let Some(raw) = params.get("ordering").filter(|s| !s.is_empty()) {
         let (name, desc) = if let Some(rest) = raw.strip_prefix('-') {
@@ -2121,10 +2115,7 @@ fn resolve_active_order(
         if ordering_fields.iter().any(|f| f == name) {
             if let Some(field) = schema.field(name) {
                 return Ok((
-                    vec![OrderClause {
-                        column: field.column,
-                        desc,
-                    }],
+                    vec![crate::core::OrderItem::column(field.column, desc)],
                     raw.clone(),
                 ));
             }
@@ -3609,8 +3600,8 @@ mod tests {
         let s = schema_two_fields();
         let r = resolve_order_by(s, &[("title".into(), false)]).unwrap();
         assert_eq!(r.len(), 1);
-        assert_eq!(r[0].column, "title");
-        assert!(!r[0].desc);
+        assert_eq!(r[0].column_name(), Some("title"));
+        assert!(!r[0].is_desc());
     }
 
     /// Unknown field name surfaces a clear error string instead of
@@ -3631,8 +3622,8 @@ mod tests {
         let s = schema_two_fields();
         let out = resolve_order_by(s, &[]).unwrap();
         assert_eq!(out.len(), 1);
-        assert_eq!(out[0].column, "id");
-        assert!(!out[0].desc, "PK fallback is ASC");
+        assert_eq!(out[0].column_name(), Some("id"));
+        assert!(!out[0].is_desc(), "PK fallback is ASC");
     }
 
     /// `ListView` builder accepts filter_fields + search_fields.
@@ -4490,8 +4481,8 @@ mod tests {
         params.insert("ordering".into(), "title".into());
         let (clauses, active) = resolve_active_order(s, &[], &["title".into()], &params).unwrap();
         assert_eq!(clauses.len(), 1);
-        assert_eq!(clauses[0].column, "title");
-        assert!(!clauses[0].desc);
+        assert_eq!(clauses[0].column_name(), Some("title"));
+        assert!(!clauses[0].is_desc());
         assert_eq!(active, "title");
     }
 
@@ -4502,8 +4493,8 @@ mod tests {
         let mut params = HashMap::new();
         params.insert("ordering".into(), "-title".into());
         let (clauses, active) = resolve_active_order(s, &[], &["title".into()], &params).unwrap();
-        assert_eq!(clauses[0].column, "title");
-        assert!(clauses[0].desc);
+        assert_eq!(clauses[0].column_name(), Some("title"));
+        assert!(clauses[0].is_desc());
         assert_eq!(active, "-title");
     }
 
@@ -4532,8 +4523,8 @@ mod tests {
         let (clauses, active) = resolve_active_order(s, &[], &["title".into()], &params).unwrap();
         // PK-ASC fallback.
         assert_eq!(clauses.len(), 1);
-        assert_eq!(clauses[0].column, "id");
-        assert!(!clauses[0].desc);
+        assert_eq!(clauses[0].column_name(), Some("id"));
+        assert!(!clauses[0].is_desc());
         assert_eq!(active, "");
     }
 

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -93,7 +93,7 @@ use serde_json::{json, Value};
 
 use crate::core::{
     Assignment, CountQuery, DeleteQuery, FieldType, Filter, InsertQuery, ModelSchema, Op,
-    OrderClause, SearchClause, SelectQuery, SqlValue, UpdateQuery, WhereExpr,
+    SearchClause, SelectQuery, SqlValue, UpdateQuery, WhereExpr,
 };
 use crate::forms::{collect_values, parse_form_value, parse_pk_string, FormError};
 use crate::sql::Pool;
@@ -855,7 +855,7 @@ async fn handle_list(
 
     // Ordering
     let ordering_param = params.get("ordering").cloned();
-    let order_by: Vec<OrderClause> = ordering_param
+    let order_by: Vec<crate::core::OrderItem> = ordering_param
         .as_deref()
         .map(|raw| {
             raw.split(',')
@@ -866,10 +866,11 @@ async fn handle_list(
                     } else {
                         (part, false)
                     };
-                    state.vs.schema.field(field_name).map(|f| OrderClause {
-                        column: f.column,
-                        desc,
-                    })
+                    state
+                        .vs
+                        .schema
+                        .field(field_name)
+                        .map(|f| crate::core::OrderItem::column(f.column, desc))
                 })
                 .collect()
         })
@@ -879,10 +880,11 @@ async fn handle_list(
                 .default_ordering
                 .iter()
                 .filter_map(|(name, desc)| {
-                    state.vs.schema.field(name).map(|f| OrderClause {
-                        column: f.column,
-                        desc: *desc,
-                    })
+                    state
+                        .vs
+                        .schema
+                        .field(name)
+                        .map(|f| crate::core::OrderItem::column(f.column, *desc))
                 })
                 .collect()
         });
@@ -1023,10 +1025,7 @@ async fn handle_list_cursor(
     };
 
     // Force ordering by the cursor field (cursor pagination requires it)
-    let order_by = vec![OrderClause {
-        column: cursor_schema.column,
-        desc,
-    }];
+    let order_by = vec![crate::core::OrderItem::column(cursor_schema.column, desc)];
 
     // Fetch page_size+1 to detect if a next page exists.
     let select_q = SelectQuery {

--- a/crates/rustango/tests/admin_sqlite_live.rs
+++ b/crates/rustango/tests/admin_sqlite_live.rs
@@ -23,7 +23,6 @@
 use axum::body::Body;
 use axum::http::{header, Method, Request, StatusCode};
 use http_body_util::BodyExt;
-use rustango::core::Model as _;
 use rustango::sql::Pool;
 use rustango::Model;
 use tower::ServiceExt;

--- a/crates/rustango/tests/admin_user_roles_panel_live.rs
+++ b/crates/rustango/tests/admin_user_roles_panel_live.rs
@@ -12,6 +12,9 @@ use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
 use rustango::sql::sqlx;
 use rustango::sql::Auto;
+// `ensure_tables` is deprecated; this fixture predates the
+// `manage migrate` path that supersedes it.
+#[allow(deprecated)]
 use rustango::tenancy::permissions::{
     assign_role, ensure_tables, get_or_create_role, grant_role_perm, set_user_perm,
 };
@@ -50,6 +53,7 @@ async fn fresh(pool: &sqlx::PgPool) {
             .await
             .unwrap();
     }
+    #[allow(deprecated)]
     ensure_tables(pool).await.unwrap();
 }
 

--- a/crates/rustango/tests/contenttypes_pool_live.rs
+++ b/crates/rustango/tests/contenttypes_pool_live.rs
@@ -1,3 +1,4 @@
+#![allow(irrefutable_let_patterns)] // Pool enum is single-variant in sqlite-only builds; pattern is refutable on multi-backend builds.
 //! Live regression for the v0.34 bi-dialect `contenttypes::*_pool`
 //! family. Exercises the new `&Pool`-taking helpers against an
 //! in-memory SQLite registry — proves a sqlite-only stack can

--- a/crates/rustango/tests/date_functions.rs
+++ b/crates/rustango/tests/date_functions.rs
@@ -220,6 +220,7 @@ fn sqlite_extract_quarter_returns_op_not_supported() {
 // ---------- TruncDate — same SQL across all dialects ----------
 
 #[test]
+#[allow(non_snake_case)] // SQL keyword "DATE" preserved in test name for readability.
 fn trunc_date_emits_DATE_call_on_all_dialects() {
     let q = update_set(trunc_date(F("created_at")));
     for dialect in ["pg", "my", "sq"] {
@@ -333,6 +334,7 @@ fn sqlite_trunc_day_collapses_to_date_function() {
 // ---------- Composition with F() arithmetic ----------
 
 #[test]
+#[allow(non_snake_case)] // `F` preserved in test name to mirror the builder it tests (`F("created_at")`).
 fn extract_year_of_F_column_composes_with_other_funcs() {
     use rustango::core::funcs::{abs, greatest};
     // greatest(extract_year(F("created_at")), 2020)

--- a/crates/rustango/tests/explain_live.rs
+++ b/crates/rustango/tests/explain_live.rs
@@ -10,7 +10,7 @@
 
 #![cfg(feature = "tenancy")]
 
-use rustango::core::{Column as _, Model as _};
+use rustango::core::Column as _;
 use rustango::sql::{sqlx, Auto, ExplainFormat, ExplainOptions};
 
 #[derive(rustango::Model, Debug, Clone)]

--- a/crates/rustango/tests/fixtures_sqlite_live.rs
+++ b/crates/rustango/tests/fixtures_sqlite_live.rs
@@ -1,3 +1,5 @@
+#![allow(irrefutable_let_patterns, unreachable_patterns)]
+// Pool enum is single-variant in sqlite-only builds; patterns become refutable / reachable on multi-backend builds.
 //! Live regression for v0.35 slice 3 — `Fixture::load_into_pool` +
 //! `load_all_pool` against SQLite. Proves fixture loading works on
 //! any backend without Postgres.

--- a/crates/rustango/tests/generated_columns_live.rs
+++ b/crates/rustango/tests/generated_columns_live.rs
@@ -7,7 +7,7 @@
 
 #![cfg(feature = "tenancy")]
 
-use rustango::core::{Column as _, Model as _};
+use rustango::core::Column as _;
 use rustango::sql::{sqlx, Auto, Fetcher};
 
 #[derive(rustango::Model, Debug, Clone)]

--- a/crates/rustango/tests/jobs_sqlite_live.rs
+++ b/crates/rustango/tests/jobs_sqlite_live.rs
@@ -1,4 +1,5 @@
 #![cfg(all(feature = "sqlite", feature = "jobs-postgres"))]
+#![allow(irrefutable_let_patterns)] // Pool enum is single-variant in sqlite-only builds; pattern is refutable on multi-backend builds.
 //! Live integration test for the tri-dialect job queue on SQLite.
 //!
 //! v0.38 slice 27 — the bundled queue (struct name kept as `PgJobQueue`

--- a/crates/rustango/tests/media_collections_tags_live.rs
+++ b/crates/rustango/tests/media_collections_tags_live.rs
@@ -4,12 +4,11 @@
 //! silently when DATABASE_URL or RUSTANGO_S3_TEST_* are unset.
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use rustango::media::router::media_router;
-use rustango::media::{ensure_all_tables, MediaManager, SaveOpts, UploadIntent};
+use rustango::media::{ensure_all_tables, MediaManager, SaveOpts};
 use rustango::storage::s3::{S3Config, S3Storage};
 use rustango::storage::{BoxedStorage, StorageRegistry};
 use sqlx::PgPool;

--- a/crates/rustango/tests/migrate_manage.rs
+++ b/crates/rustango/tests/migrate_manage.rs
@@ -12,8 +12,8 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use rustango::migrate::{
-    self, append_data_op, file, make_data_migration, manage, DataOp, MigrateError, Migration,
-    Operation, SchemaChange, SchemaSnapshot, TableSnapshot,
+    self, append_data_op, file, make_data_migration, manage, MigrateError, Migration, Operation,
+    SchemaChange, SchemaSnapshot, TableSnapshot,
 };
 use rustango::sql::sqlx::{self, PgPool, Row};
 

--- a/crates/rustango/tests/migrate_registry_pool_sqlite_live.rs
+++ b/crates/rustango/tests/migrate_registry_pool_sqlite_live.rs
@@ -1,3 +1,4 @@
+#![allow(irrefutable_let_patterns)] // Pool enum is single-variant in sqlite-only builds; pattern is refutable on multi-backend builds.
 //! Live regression for v0.34 slice 2 — `migrate_registry_pool`
 //! against a SQLite registry. Proves the backend-agnostic registry
 //! bootstrap (migration runner + audit table + contenttype seed)

--- a/crates/rustango/tests/migrate_tenant_storage_live.rs
+++ b/crates/rustango/tests/migrate_tenant_storage_live.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use rustango::core::Model as _;
 use rustango::sql::sqlx::PgPool;
 use rustango::sql::Auto;
 use rustango::tenancy::{manage::run_with_writer, Org, StorageMode, TenantPools};

--- a/crates/rustango/tests/non_superuser_admin_visibility_live.rs
+++ b/crates/rustango/tests/non_superuser_admin_visibility_live.rs
@@ -21,6 +21,11 @@ use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
 use rustango::sql::sqlx;
 use rustango::sql::Auto;
+// `ensure_tables` is deprecated in favor of `manage migrate` (which
+// the bootstrap tenant migration covers). The test predates that
+// helper and uses the legacy DDL path for setup — keep until the
+// fixture is migrated.
+#[allow(deprecated)]
 use rustango::tenancy::permissions::{
     assign_role, auto_create_permissions, ensure_tables, get_or_create_role, grant_role_perm,
     user_permissions,
@@ -61,6 +66,7 @@ async fn fresh(pool: &sqlx::PgPool) {
             .await
             .unwrap();
     }
+    #[allow(deprecated)]
     ensure_tables(pool).await.unwrap();
 }
 

--- a/crates/rustango/tests/operator_console_orgs_edit_live.rs
+++ b/crates/rustango/tests/operator_console_orgs_edit_live.rs
@@ -22,12 +22,12 @@ use std::sync::Arc;
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
 use rustango::core::Column as _;
+use rustango::migrate as rmig;
 use rustango::sql::{sqlx, Auto, Fetcher};
 use rustango::tenancy::{
     operator_console::{router_with_pools, SessionSecret},
     Org, StorageMode, TenantPools,
 };
-use rustango::{migrate as rmig, Model};
 use tower::ServiceExt;
 
 static UNIQ: AtomicU64 = AtomicU64::new(0);

--- a/crates/rustango/tests/order_by_enhancements.rs
+++ b/crates/rustango/tests/order_by_enhancements.rs
@@ -1,0 +1,249 @@
+//! Tri-dialect emission tests for ORDER BY enhancements (issue #76):
+//! NULLS FIRST/LAST handling + Expr items in order_by.
+//!
+//! PG + SQLite emit the SQL-standard `NULLS …` keyword natively;
+//! MySQL has no native NULLS syntax so the writer emulates with an
+//! `<col> IS NULL` pre-sort term.
+
+use rustango::core::funcs::lower;
+use rustango::core::{Column as _, Model as _, NullsOrder, F};
+use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "ob_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 200)]
+    title: String,
+    score: Option<i64>,
+}
+
+// ---------- Backward compat: existing .order_by(&[(col, desc)]) ----------
+
+#[test]
+fn legacy_order_by_emits_no_nulls_clause_on_pg() {
+    let qs = Post::objects().order_by(&[("score", true), ("id", false)]);
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#"ORDER BY "score" DESC, "id""#),
+        "default emits no NULLS clause: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains("NULLS"),
+        "no NULLS keyword without explicit pin: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn legacy_order_by_unchanged_on_mysql_no_is_null_emulation() {
+    let qs = Post::objects().order_by(&[("score", true)]);
+    let stmt = MySql.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(stmt.sql.contains("ORDER BY `score` DESC"));
+    assert!(
+        !stmt.sql.contains("IS NULL"),
+        "default ordering on MySQL emits no IS NULL trick: {}",
+        stmt.sql
+    );
+}
+
+// ---------- NULLS FIRST / LAST on PG + SQLite ----------
+
+#[test]
+fn pg_nulls_last_emits_nulls_last_keyword() {
+    let qs = Post::objects().order_by_with_nulls(&[("score", true, NullsOrder::Last)]);
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#"ORDER BY "score" DESC NULLS LAST"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn pg_nulls_first_on_asc_emits_keyword() {
+    let qs = Post::objects().order_by_with_nulls(&[("score", false, NullsOrder::First)]);
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#"ORDER BY "score" NULLS FIRST"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn sqlite_supports_native_nulls_keyword() {
+    // SQLite 3.30+ understands NULLS FIRST/LAST — same emission as PG.
+    let qs = Post::objects().order_by_with_nulls(&[("score", true, NullsOrder::Last)]);
+    let stmt = Sqlite.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#"ORDER BY "score" DESC NULLS LAST"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+// ---------- MySQL: NULLS emulation via `<col> IS NULL` pre-sort ----------
+
+#[test]
+fn mysql_nulls_last_emulated_via_is_null_asc_prefix() {
+    // `NULLS LAST` → group NULLs to the bottom → `IS NULL ASC` term
+    // sorts non-NULLs (IS NULL = 0) before NULLs (IS NULL = 1).
+    let qs = Post::objects().order_by_with_nulls(&[("score", true, NullsOrder::Last)]);
+    let stmt = MySql.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql
+            .contains("ORDER BY `score` IS NULL ASC, `score` DESC"),
+        "MySQL NULLS LAST emulation: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains("NULLS"),
+        "no native NULLS keyword on MySQL: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn mysql_nulls_first_emulated_via_is_null_desc_prefix() {
+    let qs = Post::objects().order_by_with_nulls(&[("score", false, NullsOrder::First)]);
+    let stmt = MySql.compile_select(&qs.compile().unwrap()).unwrap();
+    // `NULLS FIRST` → group NULLs to the top → `IS NULL DESC` term.
+    assert!(
+        stmt.sql.contains("ORDER BY `score` IS NULL DESC, `score`"),
+        "MySQL NULLS FIRST emulation: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Expr items in ORDER BY ----------
+
+#[test]
+fn order_by_expr_lower_title_emits_function_call() {
+    let qs = Post::objects().order_by_expr(lower(F("title")), false);
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#"ORDER BY LOWER("title")"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn order_by_expr_with_nulls_combines_both() {
+    let qs = Post::objects().order_by_expr_with_nulls(lower(F("title")), true, NullsOrder::Last);
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"ORDER BY LOWER("title") DESC NULLS LAST"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn order_by_expr_arithmetic_emits_binop_form() {
+    let qs = Post::objects().order_by_expr(F("score") + 1_i64, true);
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    // The `score + 1` arithmetic should emit via the standard expr
+    // writer (parenthesized BinOp), DESC follows.
+    assert!(
+        stmt.sql.contains(r#"ORDER BY ("score" + $1) DESC"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Composition: legacy + extras in the same query ----------
+
+#[test]
+fn legacy_and_extras_compose_legacy_first_then_extras() {
+    let qs = Post::objects()
+        .order_by(&[("id", false)])
+        .order_by_with_nulls(&[("score", true, NullsOrder::Last)]);
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"ORDER BY "id", "score" DESC NULLS LAST"#),
+        "legacy entries emit before extras: {}",
+        stmt.sql
+    );
+}
+
+// ---------- replace_order_by clears extras ----------
+
+#[test]
+fn replace_order_by_clears_both_legacy_and_extras() {
+    let qs = Post::objects()
+        .order_by(&[("id", false)])
+        .order_by_with_nulls(&[("score", true, NullsOrder::Last)])
+        .replace_order_by(&[("title", false)]);
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    // Isolate the ORDER BY clause — "score" appears in the SELECT
+    // projection too, so a bare contains-check would false-positive.
+    let order_clause = stmt
+        .sql
+        .split("ORDER BY ")
+        .nth(1)
+        .expect("ORDER BY present");
+    assert_eq!(
+        order_clause.trim(),
+        r#""title""#,
+        "extras cleared, only `title` remains in ORDER BY: {}",
+        stmt.sql
+    );
+}
+
+// ---------- flip_order_by inverts both legacy + extras ----------
+
+#[test]
+fn flip_order_by_inverts_extras_and_swaps_nulls_first_last() {
+    let qs = Post::objects()
+        .order_by(&[("id", false)])
+        .order_by_with_nulls(&[("score", true, NullsOrder::Last)])
+        .flip_order_by();
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    // After flip: id DESC (was ASC), score ASC NULLS FIRST (was DESC NULLS LAST).
+    assert!(
+        stmt.sql
+            .contains(r#"ORDER BY "id" DESC, "score" NULLS FIRST"#),
+        "flip inverts desc + swaps First/Last: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Validator: typo in order_by_with_nulls field name ----------
+
+#[test]
+fn order_by_with_nulls_typo_caught_at_compile_time() {
+    use rustango::core::QueryError;
+    let err = Post::objects()
+        .order_by_with_nulls(&[("nope_col", true, NullsOrder::Last)])
+        .compile()
+        .unwrap_err();
+    assert!(
+        matches!(err, QueryError::UnknownField { ref field, .. } if field == "nope_col"),
+        "expected UnknownField, got: {err:?}",
+    );
+}
+
+// ---------- Dialect capability flag is set correctly ----------
+
+#[test]
+fn dialect_capability_pg_supports_nulls() {
+    assert!(Postgres.supports_nulls_order());
+}
+
+#[test]
+fn dialect_capability_sqlite_supports_nulls() {
+    assert!(Sqlite.supports_nulls_order());
+}
+
+#[test]
+fn dialect_capability_mysql_does_not_support_nulls() {
+    assert!(!MySql.supports_nulls_order());
+}

--- a/crates/rustango/tests/order_by_enhancements.rs
+++ b/crates/rustango/tests/order_by_enhancements.rs
@@ -6,7 +6,7 @@
 //! `<col> IS NULL` pre-sort term.
 
 use rustango::core::funcs::lower;
-use rustango::core::{Column as _, Model as _, NullsOrder, F};
+use rustango::core::{NullsOrder, F};
 use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
 use rustango::Model;
 

--- a/crates/rustango/tests/order_by_enhancements_live.rs
+++ b/crates/rustango/tests/order_by_enhancements_live.rs
@@ -9,7 +9,7 @@
 use std::sync::OnceLock;
 
 use rustango::core::funcs::lower;
-use rustango::core::{Column as _, NullsOrder, F};
+use rustango::core::{NullsOrder, F};
 use rustango::sql::{sqlx, Auto, Fetcher};
 use rustango::Model;
 use tokio::sync::Mutex;

--- a/crates/rustango/tests/order_by_enhancements_live.rs
+++ b/crates/rustango/tests/order_by_enhancements_live.rs
@@ -1,0 +1,150 @@
+#![cfg(feature = "postgres")]
+//! Live PG tests for ORDER BY enhancements (issue #76). The emission
+//! tests pin the SQL strings; this confirms NULLs land where the
+//! `NullsOrder` says they should and Expr items sort the way the
+//! expression dictates.
+//!
+//! Skips silently when `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::core::funcs::lower;
+use rustango::core::{Column as _, NullsOrder, F};
+use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "obl_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub score: Option<i64>,
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "obl_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "obl_post" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "title" VARCHAR(200) NOT NULL,
+            "score" BIGINT
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    // Mix of NULL + non-NULL scores; mixed-case titles.
+    sqlx::query(
+        r#"INSERT INTO "obl_post" ("title", "score") VALUES
+        ('alpha', 10),
+        ('Bravo', NULL),
+        ('charlie', 30),
+        ('Delta', 20),
+        ('echo', NULL)"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// `NULLS LAST` on `ASC` — NULLs land after every non-NULL.
+#[tokio::test]
+async fn nulls_last_on_asc_groups_nulls_after_non_nulls() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let rows: Vec<Post> = Post::objects()
+        .order_by_with_nulls(&[("score", false, NullsOrder::Last)])
+        .order_by(&[("id", false)])
+        .fetch(&pool)
+        .await
+        .unwrap();
+    // Scores ASC NULLS LAST → 10, 20, 30, NULL, NULL.
+    let scores: Vec<Option<i64>> = rows.iter().map(|p| p.score).collect();
+    assert_eq!(
+        scores,
+        vec![Some(10), Some(20), Some(30), None, None],
+        "got: {scores:?}",
+    );
+
+    cleanup(&pool).await;
+}
+
+/// `NULLS FIRST` on `DESC` — NULLs land before the largest value.
+#[tokio::test]
+async fn nulls_first_on_desc_groups_nulls_first() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let rows: Vec<Post> = Post::objects()
+        .order_by_with_nulls(&[("score", true, NullsOrder::First)])
+        .order_by(&[("id", false)])
+        .fetch(&pool)
+        .await
+        .unwrap();
+    // Scores DESC NULLS FIRST → NULL, NULL, 30, 20, 10.
+    let scores: Vec<Option<i64>> = rows.iter().map(|p| p.score).collect();
+    assert_eq!(
+        scores,
+        vec![None, None, Some(30), Some(20), Some(10)],
+        "got: {scores:?}",
+    );
+
+    cleanup(&pool).await;
+}
+
+/// Expr item: `ORDER BY LOWER(title)` — sorts case-insensitively.
+/// Without `LOWER`, uppercase comes before lowercase in PG default
+/// collation; with it, the order is alphabetic regardless of case.
+#[tokio::test]
+async fn order_by_expr_lower_title_sorts_case_insensitively() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let rows: Vec<Post> = Post::objects()
+        .order_by_expr(lower(F("title")), false)
+        .fetch(&pool)
+        .await
+        .unwrap();
+    let titles: Vec<&str> = rows.iter().map(|p| p.title.as_str()).collect();
+    assert_eq!(
+        titles,
+        vec!["alpha", "Bravo", "charlie", "Delta", "echo"],
+        "case-insensitive ascending: {titles:?}",
+    );
+
+    cleanup(&pool).await;
+}
+
+async fn cleanup(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "obl_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+}

--- a/crates/rustango/tests/orm_advanced_sqlite_live.rs
+++ b/crates/rustango/tests/orm_advanced_sqlite_live.rs
@@ -1,3 +1,4 @@
+#![allow(irrefutable_let_patterns)] // Pool enum is single-variant in sqlite-only builds; pattern is refutable on multi-backend builds.
 //! Advanced ORM coverage on SQLite — closes the gap between the
 //! basic `save_pool` / `fetch_pool` round-trips in `sqlite_live.rs`
 //! and the full PG live suite (`save_live.rs`, `select_related_live.rs`,

--- a/crates/rustango/tests/permissions_sqlite_live.rs
+++ b/crates/rustango/tests/permissions_sqlite_live.rs
@@ -1,3 +1,4 @@
+#![allow(irrefutable_let_patterns)] // Pool enum is single-variant in sqlite-only builds; pattern is refutable on multi-backend builds.
 //! Live integration tests for the tri-dialect `permissions::*_pool`
 //! family on SQLite — proves slice 25's new `_pool` companions
 //! (`has_perm_pool`, `has_any_perm_pool`, `has_all_perms_pool`,

--- a/crates/rustango/tests/permissions_upsert_live.rs
+++ b/crates/rustango/tests/permissions_upsert_live.rs
@@ -11,7 +11,7 @@
 
 #![cfg(feature = "tenancy")]
 
-use rustango::core::{Column as _, Model as _};
+use rustango::core::Column as _;
 use rustango::sql::sqlx;
 use rustango::sql::{Auto, Fetcher};
 use rustango::tenancy::permissions::{
@@ -61,6 +61,10 @@ async fn fresh(pool: &sqlx::PgPool) {
             .await
             .unwrap();
     }
+    // Deprecated helper still used by this fixture; migration to
+    // `manage migrate` will happen alongside the broader admin/perms
+    // test cleanup.
+    #[allow(deprecated)]
     rustango::tenancy::ensure_permission_tables(pool)
         .await
         .unwrap();

--- a/crates/rustango/tests/prefetch_non_i64_pk_live.rs
+++ b/crates/rustango/tests/prefetch_non_i64_pk_live.rs
@@ -11,7 +11,6 @@
 
 #![cfg(feature = "tenancy")]
 
-use rustango::core::{Column as _, Model as _};
 use rustango::sql::{fetch_with_prefetch, sqlx, Auto, ForeignKey};
 
 #[derive(rustango::Model, Debug, Clone)]
@@ -79,7 +78,7 @@ async fn fetch_with_prefetch_groups_children_under_string_pk_parents() {
 
     // Seed: two parents, three children (2 + 1).
     for slug in ["acme", "globex"] {
-        let mut t = StrTenant {
+        let t = StrTenant {
             slug: slug.into(),
             display_name: slug.to_uppercase(),
         };

--- a/crates/rustango/tests/row_to_json_pool_sqlite_live.rs
+++ b/crates/rustango/tests/row_to_json_pool_sqlite_live.rs
@@ -76,10 +76,7 @@ async fn select_rows_as_json_pool_decodes_sqlite_rows() {
             where_clause: WhereExpr::And(Vec::new()),
             search: None,
             joins: Vec::new(),
-            order_by: vec![rustango::core::OrderClause {
-                column: "id",
-                desc: false,
-            }],
+            order_by: vec![rustango::core::OrderItem::column("id", false)],
             limit: None,
             offset: None,
         },

--- a/crates/rustango/tests/serializer_derive.rs
+++ b/crates/rustango/tests/serializer_derive.rs
@@ -98,6 +98,7 @@ fn read_only_field_excluded_from_writable_fields() {
 
 #[derive(Serializer, Default)]
 #[serializer(model = Post)]
+#[allow(dead_code)] // `body` is intentionally write-only — checked by absence in the serializer output.
 struct PostWithWriteOnly {
     pub title: String,
     #[serializer(write_only)]
@@ -277,6 +278,7 @@ mod openapi_auto_derive {
 
     #[derive(Serializer, Default)]
     #[serializer(model = Post)]
+    #[allow(dead_code)] // `secret` is intentionally write-only — checked by absence in the serializer output.
     struct WithWriteOnly {
         pub title: String,
         #[serializer(write_only)]

--- a/crates/rustango/tests/sqlite_registry_proof_live.rs
+++ b/crates/rustango/tests/sqlite_registry_proof_live.rs
@@ -24,7 +24,7 @@
 #![cfg(all(feature = "tenancy", feature = "sqlite"))]
 
 use rustango::core::Column as _;
-use rustango::sql::{sqlx, Auto, Fetcher as _, FetcherPool as _, Pool};
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
 use rustango::tenancy::Org;
 
 const BOOTSTRAP_SQL: &str = r#"

--- a/crates/rustango/tests/tenancy_manage_sqlite_live.rs
+++ b/crates/rustango/tests/tenancy_manage_sqlite_live.rs
@@ -16,7 +16,7 @@
 
 #![cfg(all(feature = "sqlite", feature = "tenancy"))]
 
-use rustango::sql::{sqlx, Pool};
+use rustango::sql::sqlx;
 use rustango::tenancy::TenantPools;
 
 /// Build a sqlite tenant-pools handle backed by a tempfile DB.

--- a/crates/rustango/tests/tenant_auth_sqlite_live.rs
+++ b/crates/rustango/tests/tenant_auth_sqlite_live.rs
@@ -1,3 +1,4 @@
+#![allow(irrefutable_let_patterns)] // Pool enum is single-variant in sqlite-only builds; pattern is refutable on multi-backend builds.
 //! Live integration tests for the tri-dialect tenant-auth `_pool`
 //! helpers on SQLite — slice 25 / 27.
 //!

--- a/crates/rustango/tests/upsert_unique_together_live.rs
+++ b/crates/rustango/tests/upsert_unique_together_live.rs
@@ -13,7 +13,7 @@
 
 #![cfg(feature = "tenancy")]
 
-use rustango::core::{Column as _, Model as _};
+use rustango::core::Column as _;
 use rustango::sql::sqlx;
 use rustango::sql::{Auto, Fetcher};
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -76,6 +76,49 @@ Post::objects().where_(Post::deleted_at.is_null()).fetch(&pool).await?;
 Post::objects().where_(Post::published_at.between(start, end)).fetch(&pool).await?;
 ```
 
+### ORDER BY — column, expression, NULLS FIRST/LAST
+
+Three dimensions beyond the basic `.order_by(&[("col", desc)])`:
+
+```rust
+use rustango::core::funcs::lower;
+use rustango::core::{F, NullsOrder};
+
+// 1. Plain field + ASC/DESC (back-compat — implicit NULLS handling
+//    differs between dialects; see the dialect note below).
+Post::objects()
+    .order_by(&[("published_at", true), ("id", false)])
+    .fetch(&pool).await?;
+
+// 2. Explicit NULLS FIRST/LAST control — portable across PG, MySQL,
+//    and SQLite. MySQL has no native `NULLS …` keyword; the writer
+//    emulates with an `<col> IS NULL` pre-sort term so the on-wire
+//    ordering matches PG/SQLite.
+Post::objects()
+    .order_by_with_nulls(&[("score", true, NullsOrder::Last)])
+    .fetch(&pool).await?;
+
+// 3. Arbitrary Expr in the ORDER BY position — case-insensitive
+//    title sort via `LOWER(title)`, computed sort keys via
+//    `case() / when() / value()`, arithmetic via `F("a") + F("b")`.
+Post::objects()
+    .order_by_expr(lower(F("title")), false)
+    .order_by_expr_with_nulls(F("score") + 1_i64, true, NullsOrder::Last)
+    .fetch(&pool).await?;
+```
+
+**Per-dialect NULLS handling (no explicit `NullsOrder` set):**
+
+| Dialect | ASC default | DESC default |
+|---|---|---|
+| PostgreSQL | NULLS LAST | NULLS FIRST |
+| SQLite | NULLS LAST | NULLS FIRST |
+| MySQL | NULLs first (smallest-value semantics) | NULLs last |
+
+Use `.order_by_with_nulls(...)` / `.order_by_expr_with_nulls(...)` to pin the placement; otherwise the database's native default applies. On MySQL the writer emits `<col> IS NULL <asc|desc>` ahead of the actual sort to emulate; the emitted SQL has two ORDER BY terms per pinned column but the semantic matches PG/SQLite.
+
+**Chain composition.** `.order_by(...)`, `.order_by_with_nulls(...)`, and `.order_by_expr(...)` accumulate into one unified list in **registration order**. `.replace_order_by(&[...])` clears every prior order-by call. `.flip_order_by()` inverts every direction AND swaps `NullsOrder::First` ↔ `NullsOrder::Last` so the "NULLs at the same end" semantic survives an inversion.
+
 ### Pagination
 
 ```rust


### PR DESCRIPTION
## Summary

Closes #76 (partial) — ORDER BY enhancements: **Expr items** + **NULLS FIRST/LAST**. **Stacked on #83** (issue-7-window-functions).

The `Meta.ordering` model attribute is **deferred to a follow-up** (touches `rustango-macros` separately). Filing as a sibling ticket once this lands.

## What you get

```rust
use rustango::core::funcs::lower;
use rustango::core::{F, NullsOrder};

// 1. NULLS placement — portable across PG/MySQL/SQLite. MySQL has
//    no native `NULLS …` keyword; the writer emulates with an
//    `<col> IS NULL` pre-sort term so on-wire ordering matches.
Post::objects()
    .order_by_with_nulls(&[("score", true, NullsOrder::Last)])
    .fetch(&pool).await?;

// 2. Arbitrary Expr in ORDER BY position — case-insensitive title,
//    computed sort keys via `case() / when()`, arithmetic via F().
Post::objects()
    .order_by_expr(lower(F("title")), false)
    .order_by_expr_with_nulls(F("score") + 1_i64, true, NullsOrder::Last)
    .fetch(&pool).await?;
```

## API additions

- `NullsOrder::{Default, First, Last}` — enum re-exported from `rustango::core`.
- `OrderItem::{Column { … }, Expr { … }}` — new IR variant carried by `SelectQuery.order_by` and `AggregateQuery.order_by`.
- `QuerySet::order_by_with_nulls(&[(col, desc, NullsOrder)])` — column form with NULL pin.
- `QuerySet::order_by_expr(impl Into<Expr>, desc)` — arbitrary Expr.
- `QuerySet::order_by_expr_with_nulls(impl Into<Expr>, desc, NullsOrder)` — Expr + NULL pin.

`From<OrderClause> for OrderItem` keeps every existing call site working. All new and old order-by methods feed one unified pending list — chain order is preserved across mixed calls. `replace_order_by` clears the whole list; `flip_order_by` swaps both direction and `NullsOrder::First` ↔ `Last`.

## Tri-dialect emission matrix

| Feature | PG | MySQL | SQLite |
|---|---|---|---|
| `.order_by(...)` (legacy) | ✓ | ✓ | ✓ |
| `NullsOrder::First` / `Last` | ✓ native `NULLS …` | ✓ via `<col> IS NULL <asc|desc>` emulation | ✓ native `NULLS …` (3.30+) |
| `.order_by_expr(...)` | ✓ | ✓ | ✓ |

PG/SQLite emit `ORDER BY "col" DESC NULLS LAST`. MySQL emits `ORDER BY \`col\` IS NULL ASC, \`col\` DESC` so non-NULLs (IS NULL = 0) sort before NULLs (IS NULL = 1). Both produce identical row order.

## What landed

- **`core/query.rs`** — new `NullsOrder` enum, new `OrderItem` enum (`Column { column, desc, nulls }` / `Expr { expr, desc, nulls }`), convenience constructors + accessors (`column_name` / `is_desc` / `nulls_order`). `SelectQuery.order_by` and `AggregateQuery.order_by` retype to `Vec<OrderItem>`. Legacy `OrderClause` stays for back-compat via `From<OrderClause> for OrderItem`.
- **`core/mod.rs`** — re-exports `NullsOrder` + `OrderItem`.
- **`query/mod.rs`** — unified pending order-by list (`Vec<PendingOrderItem>`) that preserves registration order across legacy + new builder methods. `order_by_clauses()` → `has_order_by()` (the legacy getter can't flatten Expr items).
- **`sql/dialect.rs`** — new `supports_nulls_order() -> bool` capability flag (default `true`); MySQL overrides to `false`.
- **`sql/writers.rs`** — `write_order_limit_offset` rewritten to walk `OrderItem` variants. Per-dialect dispatch for NULLS placement.
- **`admin/views.rs`, `contenttypes.rs`, `template_views.rs`, `viewset/mod.rs`, `executor.rs`** — ~15 call sites migrated to the new `OrderItem` shape + `has_order_by()` predicate. No behavior change.

## Tests

| Suite | Count |
|---|---|
| `tests/order_by_enhancements.rs` (tri-dialect emission) | 17 |
| `tests/order_by_enhancements_live.rs` (live PG runtime) | 3 |

Emission covers: legacy back-compat unchanged on PG + MySQL; PG/SQLite native `NULLS …` keyword shapes; MySQL `IS NULL` emulation for both FIRST and LAST; Expr items (`lower(F("title"))`, BinOp arithmetic); chain composition (legacy + extras in registration order); `replace_order_by` clears everything; `flip_order_by` swaps direction + `NullsOrder`; validator catches typo'd field name; dialect-capability flags.

Live PG: `NULLS LAST` on ASC groups NULLs after non-NULLs in a 5-row table with 2 NULL scores; `NULLS FIRST` on DESC groups NULLs at the top; `order_by_expr(lower(F("title")))` returns case-insensitive alphabetic order across mixed-case titles.

## Cookbook

New "ORDER BY — column, expression, NULLS FIRST/LAST" subsection under "Querying" in `docs/orm.md`. Documents the three builder forms, the per-dialect NULLS default table, and chain composition semantics.

## Deferred to follow-up

- **`#[rustango(ordering = "-published_at, title")]` model attribute** — Django's `Meta.ordering` analog. Requires macro work in `rustango-macros` (parsing the attribute, threading into `ModelSchema.default_order`, applying as the QuerySet's starting order unless explicit). Will file as a sibling ticket once #76 lands; ~150 LOC.

## Verification

```
cargo test -p rustango --lib --features tenancy               → 1494 passed
cargo test --features tenancy,mysql,sqlite --test order_by_enhancements → 17 passed
DATABASE_URL=… cargo test --features tenancy --test order_by_enhancements_live → 3 passed
cargo check --no-default-features --features sqlite,tenancy   → clean
cargo check --features mysql,tenancy                          → clean
```

No regressions in case (15), subquery (10), ad-hoc joins (18), aggregate (24), window (22) emission suites.

## Test plan

- [x] 17 tri-dialect emission tests pass.
- [x] 3 live PG tests pass.
- [x] All three feature combos compile.
- [x] Cookbook section added.
- [ ] CI green on `postgres_test` + `mysql_live` + `sqlite_live` + `sqlite_litmus`.
- [ ] Follow-up: file `Meta.ordering` macro ticket.
