### PR TITLE
.order_random() — tri-dialect random row ordering (closes #77)

### DIFF
--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -478,6 +478,16 @@ pub enum OrderItem {
         desc: bool,
         nulls: NullsOrder,
     },
+    /// `ORDER BY RANDOM()` (PG / SQLite) or `ORDER BY RAND()` (MySQL).
+    /// Issue #77 — Django's `.order_by('?')` shape. No direction, no
+    /// NULLS clause: random ordering is by definition unordered, and
+    /// the random value is computed per-row so there are no NULLs.
+    ///
+    /// **Performance**: forces a full table scan + in-memory sort
+    /// by a per-row random key. The optimizer can't use an index.
+    /// For large tables, prefer a `WHERE pk >= rand_offset LIMIT N`
+    /// pattern instead.
+    Random,
 }
 
 impl From<OrderClause> for OrderItem {
@@ -528,30 +538,42 @@ impl OrderItem {
         Self::Expr { expr, desc, nulls }
     }
 
+    /// Construct a `Random` item — `ORDER BY RANDOM()` / `RAND()`.
+    /// Issue #77.
+    #[must_use]
+    pub fn random() -> Self {
+        Self::Random
+    }
+
     /// Bare column name when this item is a `Column` variant; `None`
-    /// for `Expr` variants. Used by callers that pre-dated the enum
-    /// (admin / template_views / older tests).
+    /// for `Expr` / `Random` variants. Used by callers that pre-dated
+    /// the enum (admin / template_views / older tests).
     #[must_use]
     pub fn column_name(&self) -> Option<&'static str> {
         match self {
             Self::Column { column, .. } => Some(column),
-            Self::Expr { .. } => None,
+            Self::Expr { .. } | Self::Random => None,
         }
     }
 
-    /// `true` if this item sorts descending.
+    /// `true` if this item sorts descending. `Random` ordering has no
+    /// direction (it's unordered by definition) — returns `false`.
     #[must_use]
     pub fn is_desc(&self) -> bool {
         match self {
             Self::Column { desc, .. } | Self::Expr { desc, .. } => *desc,
+            Self::Random => false,
         }
     }
 
-    /// The `NullsOrder` setting for this item.
+    /// The `NullsOrder` setting for this item. `Random` returns
+    /// `Default` — the random key is per-row and non-NULL, so the
+    /// clause has no effect.
     #[must_use]
     pub fn nulls_order(&self) -> NullsOrder {
         match self {
             Self::Column { nulls, .. } | Self::Expr { nulls, .. } => *nulls,
+            Self::Random => NullsOrder::Default,
         }
     }
 }

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -66,6 +66,9 @@ enum PendingOrderItem {
         desc: bool,
         nulls: crate::core::NullsOrder,
     },
+    /// `ORDER BY RANDOM()` / `RAND()` — issue #77. No fields; the
+    /// writer picks the dialect-specific token at emit time.
+    Random,
 }
 
 /// Filter accumulator entry — keeps insertion order across string-keyed and
@@ -225,6 +228,35 @@ impl<T: Model> QuerySet<T> {
         self
     }
 
+    /// `ORDER BY RANDOM()` (PG / SQLite) or `ORDER BY RAND()` (MySQL)
+    /// — Django's `.order_by('?')`. Useful for "random N rows" UI
+    /// patterns like banner rotation, sample selection, A/B-test
+    /// bucket assignment. Issue #77.
+    ///
+    /// ```ignore
+    /// // Three random posts.
+    /// Post::objects()
+    ///     .order_random()
+    ///     .limit(3)
+    ///     .fetch(&pool).await?;
+    /// ```
+    ///
+    /// **Performance caveat**: random ordering forces a full table
+    /// scan + in-memory sort by a per-row random key. The query
+    /// planner can't use an index. For tables much larger than memory,
+    /// prefer the `WHERE pk >= <random_offset> LIMIT N` pattern
+    /// (which can range-scan an index) and accept that adjacency in
+    /// the result rows mirrors PK adjacency.
+    ///
+    /// Composes with other `.order_by*` calls — the random key sorts
+    /// rows whose preceding sort columns tied. Most callers want a
+    /// `.replace_order_by`-style reset first.
+    #[must_use]
+    pub fn order_random(mut self) -> Self {
+        self.order_by.push(PendingOrderItem::Random);
+        self
+    }
+
     /// v0.45 — discard any previously-set `order_by` and apply
     /// `items` as the new ordering. Used by `earliest_pool` and
     /// `latest_pool` which declare their own sort. Clears every
@@ -254,6 +286,9 @@ impl<T: Model> QuerySet<T> {
                         crate::core::NullsOrder::Default => crate::core::NullsOrder::Default,
                     };
                 }
+                // Random has no direction or NULLS clause — nothing
+                // to flip. Issue #77.
+                PendingOrderItem::Random => {}
             }
         }
         self
@@ -599,6 +634,9 @@ fn lower_order_items(
             }
             PendingOrderItem::Expr { expr, desc, nulls } => {
                 out.push(crate::core::OrderItem::expr_with_nulls(expr, desc, nulls));
+            }
+            PendingOrderItem::Random => {
+                out.push(crate::core::OrderItem::random());
             }
         }
     }

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -201,6 +201,14 @@ pub trait Dialect {
         true
     }
 
+    /// SQL identifier for the dialect's "random number" function used
+    /// by `ORDER BY RANDOM()` (issue #77). PG + SQLite expose
+    /// `RANDOM()`; MySQL is the outlier with `RAND()`. Default:
+    /// `RANDOM` (covers PG + SQLite; MySQL overrides).
+    fn random_fn(&self) -> &'static str {
+        "RANDOM"
+    }
+
     /// Wrap a SUM expression in a cast back to BIGINT. PostgreSQL's
     /// SUM(BIGINT) is NUMERIC and MySQL's is DECIMAL — both fall
     /// through to Null in the aggregate row decoder which only tries

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -54,6 +54,12 @@ impl Dialect for MySql {
         false
     }
 
+    /// MySQL spells the random function as `RAND()`, not `RANDOM()`.
+    /// Issue #77.
+    fn random_fn(&self) -> &'static str {
+        "RAND"
+    }
+
     /// `MySQL` quotes identifiers with backticks, not double quotes.
     /// Embedded backticks are doubled (the `MySQL` parser's escape rule)
     /// so the output is always a valid quoted identifier even for

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -1977,6 +1977,10 @@ fn write_order_limit_offset(
             let (desc, nulls) = match item {
                 OrderItem::Column { desc, nulls, .. } => (*desc, *nulls),
                 OrderItem::Expr { desc, nulls, .. } => (*desc, *nulls),
+                // Random ordering: no direction (unordered by
+                // definition), no NULLS clause (the random key is
+                // per-row + non-NULL). Skip the desc/nulls dance.
+                OrderItem::Random => (false, NullsOrder::Default),
             };
             // Emulate NULLS FIRST/LAST on MySQL via a leading
             // `<target> IS NULL <asc|desc>` term, then fall through
@@ -2042,6 +2046,14 @@ fn write_order_target(
         }
         OrderItem::Expr { expr, .. } => {
             write_expr(b, expr, None)?;
+        }
+        // Issue #77 — tri-dialect random ordering. PG + SQLite use
+        // `RANDOM()`; MySQL uses `RAND()`. Both are 0-arg, return
+        // a per-row pseudorandom value; the surrounding `ORDER BY`
+        // sorts by that value.
+        OrderItem::Random => {
+            b.sql.push_str(b.d.random_fn());
+            b.sql.push_str("()");
         }
     }
     Ok(())

--- a/crates/rustango/tests/order_random.rs
+++ b/crates/rustango/tests/order_random.rs
@@ -1,0 +1,138 @@
+//! Tri-dialect emission tests for `.order_random()` — issue #77.
+//! PG + SQLite use `RANDOM()`, MySQL uses `RAND()`. The IR has no
+//! direction / NULLS slot; the writer emits exactly
+//! `ORDER BY <fn>()` (no `DESC`, no `NULLS …`).
+
+use rustango::core::Model as _;
+use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "or_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 200)]
+    title: String,
+}
+
+#[test]
+fn pg_order_random_emits_random_function() {
+    let stmt = Postgres
+        .compile_select(&Post::objects().order_random().compile().unwrap())
+        .unwrap();
+    assert!(stmt.sql.ends_with("ORDER BY RANDOM()"), "got: {}", stmt.sql);
+}
+
+#[test]
+fn sqlite_order_random_emits_random_function() {
+    let stmt = Sqlite
+        .compile_select(&Post::objects().order_random().compile().unwrap())
+        .unwrap();
+    assert!(stmt.sql.ends_with("ORDER BY RANDOM()"), "got: {}", stmt.sql);
+}
+
+#[test]
+fn mysql_order_random_emits_rand_function() {
+    let stmt = MySql
+        .compile_select(&Post::objects().order_random().compile().unwrap())
+        .unwrap();
+    assert!(stmt.sql.ends_with("ORDER BY RAND()"), "got: {}", stmt.sql);
+}
+
+#[test]
+fn order_random_composes_after_order_by_column() {
+    // `ORDER BY "title", RANDOM()` — random key sorts rows whose
+    // title ties. Order-of-builder-calls is preserved.
+    let stmt = Postgres
+        .compile_select(
+            &Post::objects()
+                .order_by(&[("title", false)])
+                .order_random()
+                .compile()
+                .unwrap(),
+        )
+        .unwrap();
+    assert!(
+        stmt.sql.contains(r#"ORDER BY "title", RANDOM()"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn order_random_emits_no_desc_or_nulls_suffix() {
+    // The IR has no direction / NULLS slot for Random; the writer
+    // should NOT emit `DESC` or `NULLS …` after `RANDOM()` even when
+    // the sibling `.order_by` has those.
+    let stmt = Postgres
+        .compile_select(&Post::objects().order_random().compile().unwrap())
+        .unwrap();
+    assert!(
+        !stmt.sql.contains("DESC"),
+        "no DESC after random: {}",
+        stmt.sql
+    );
+    assert!(!stmt.sql.contains("NULLS"), "no NULLS clause: {}", stmt.sql);
+}
+
+#[test]
+fn order_random_emits_no_param_bindings() {
+    // RANDOM()/RAND() take no arguments — no params bound.
+    let stmt = Postgres
+        .compile_select(&Post::objects().order_random().compile().unwrap())
+        .unwrap();
+    assert!(
+        stmt.params.is_empty(),
+        "order_random binds no params: {:?}",
+        stmt.params
+    );
+}
+
+#[test]
+fn replace_order_by_clears_random_item() {
+    // `.replace_order_by(&[...])` must clear a prior `.order_random()`
+    // call along with column-keyed items — the docstring on
+    // replace_order_by promises a clean slate.
+    let stmt = Postgres
+        .compile_select(
+            &Post::objects()
+                .order_random()
+                .replace_order_by(&[("id", false)])
+                .compile()
+                .unwrap(),
+        )
+        .unwrap();
+    assert!(
+        stmt.sql.ends_with(r#"ORDER BY "id""#),
+        "random must be cleared by replace_order_by: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains("RANDOM"),
+        "random must not survive replace_order_by: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn flip_order_by_leaves_random_untouched() {
+    // `.flip_order_by()` inverts column directions and NULLS
+    // positions. Random has neither — it should pass through as-is.
+    let stmt = Postgres
+        .compile_select(
+            &Post::objects()
+                .order_by(&[("title", false)])
+                .order_random()
+                .flip_order_by()
+                .compile()
+                .unwrap(),
+        )
+        .unwrap();
+    assert!(
+        stmt.sql.contains(r#"ORDER BY "title" DESC, RANDOM()"#),
+        "title flipped to DESC, RANDOM() unchanged: {}",
+        stmt.sql
+    );
+}

--- a/crates/rustango/tests/order_random_live.rs
+++ b/crates/rustango/tests/order_random_live.rs
@@ -1,0 +1,138 @@
+#![cfg(feature = "postgres")]
+//! Live PG randomness sanity check for `.order_random()` (issue #77).
+//! Probabilistic: with 100 rows + LIMIT 10, the probability that two
+//! consecutive `.fetch()` calls return identical orderings is
+//! C(100,10) ⁻¹ ≈ 5.8e-14. We assert "not identical across two
+//! draws" — false-positive rate is roughly impossible.
+//!
+//! Skips silently when `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "orl_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 20)]
+    pub label: String,
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "orl_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "orl_post" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "label" VARCHAR(20) NOT NULL
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    // 100 rows, label = "n<i>" so we can identify them.
+    let mut values = String::new();
+    for i in 0..100 {
+        if i > 0 {
+            values.push_str(", ");
+        }
+        values.push_str(&format!("('n{i}')"));
+    }
+    sqlx::query(&format!(
+        r#"INSERT INTO "orl_post" ("label") VALUES {values}"#
+    ))
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// Two consecutive `order_random().limit(10).fetch(...)` calls must
+/// return different orderings with overwhelming probability. If they
+/// match, RANDOM() is broken (or the writer is emitting a sort key
+/// other than RANDOM()).
+#[tokio::test]
+async fn order_random_returns_different_orderings_across_calls() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let draw_a: Vec<Post> = Post::objects()
+        .order_random()
+        .limit(10)
+        .fetch(&pool)
+        .await
+        .unwrap();
+    let draw_b: Vec<Post> = Post::objects()
+        .order_random()
+        .limit(10)
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(draw_a.len(), 10, "draw a should have 10 rows");
+    assert_eq!(draw_b.len(), 10, "draw b should have 10 rows");
+
+    let labels_a: Vec<&str> = draw_a.iter().map(|p| p.label.as_str()).collect();
+    let labels_b: Vec<&str> = draw_b.iter().map(|p| p.label.as_str()).collect();
+    assert_ne!(
+        labels_a, labels_b,
+        "two consecutive random draws of 10 from 100 rows should not be identical: {labels_a:?}"
+    );
+
+    cleanup(&pool).await;
+}
+
+/// LIMIT N returns ≤ N distinct rows from the random sort. Confirm
+/// the row count is correct (the random key doesn't drop or
+/// duplicate rows).
+#[tokio::test]
+async fn order_random_with_limit_returns_distinct_rows() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let rows: Vec<Post> = Post::objects()
+        .order_random()
+        .limit(15)
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 15);
+    let mut ids: Vec<i64> = rows.iter().map(|p| *p.id.get().unwrap()).collect();
+    ids.sort();
+    ids.dedup();
+    assert_eq!(
+        ids.len(),
+        15,
+        "ORDER BY RANDOM() LIMIT 15 should return 15 distinct rows: {ids:?}"
+    );
+
+    cleanup(&pool).await;
+}
+
+async fn cleanup(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "orl_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+}

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -117,7 +117,43 @@ Post::objects()
 
 Use `.order_by_with_nulls(...)` / `.order_by_expr_with_nulls(...)` to pin the placement; otherwise the database's native default applies. On MySQL the writer emits `<col> IS NULL <asc|desc>` ahead of the actual sort to emulate; the emitted SQL has two ORDER BY terms per pinned column but the semantic matches PG/SQLite.
 
-**Chain composition.** `.order_by(...)`, `.order_by_with_nulls(...)`, and `.order_by_expr(...)` accumulate into one unified list in **registration order**. `.replace_order_by(&[...])` clears every prior order-by call. `.flip_order_by()` inverts every direction AND swaps `NullsOrder::First` ↔ `NullsOrder::Last` so the "NULLs at the same end" semantic survives an inversion.
+**Chain composition.** `.order_by(...)`, `.order_by_with_nulls(...)`, and `.order_by_expr(...)` accumulate into one unified list in **registration order**. `.replace_order_by(&[...])` clears every prior order-by call. `.flip_order_by()` inverts every direction AND swaps `NullsOrder::First` ↔ `NullsOrder::Last` so the "NULLs at the same end" semantic survives an inversion (for explicit `First` / `Last`; the dialect-default behavior under `Default` still tracks direction).
+
+### Random row order — `.order_random()`
+
+Issue #77 — Django's `.order_by('?')`. Emits `ORDER BY RANDOM()` on PG and SQLite, `ORDER BY RAND()` on MySQL. Useful for banner rotation, sample selection, A/B-test bucket assignment without round-tripping a query result through the app to shuffle.
+
+```rust
+// Three random posts.
+Post::objects()
+    .order_random()
+    .limit(3)
+    .fetch(&pool).await?;
+
+// Random tie-breaker after a primary sort: posts ordered by score
+// descending, with ties shuffled.
+Post::objects()
+    .order_by(&[("score", true)])
+    .order_random()
+    .fetch(&pool).await?;
+```
+
+The IR variant carries no direction or NULLS clause: random ordering is unordered by definition, and the random key is computed per row (non-NULL).
+
+**Performance caveat.** `ORDER BY RANDOM()` forces a **full table scan + in-memory sort by a per-row random key**. The query planner can't use an index. For tables much larger than memory, prefer the index-friendly pattern:
+
+```rust
+// Coin-flip offset; range-scans the PK index.
+let max_id: i64 = Post::objects().max::<i64>(Post::id, &pool).await?;
+let offset = rand::random::<u32>() as i64 % max_id.max(1);
+Post::objects()
+    .where_(Post::id.gte(offset))
+    .order_by(&[("id", false)])
+    .limit(1)
+    .fetch(&pool).await?;
+```
+
+The trade-off: adjacency in the result rows mirrors PK adjacency, so it's not "uniformly random" in the strict sense — but it's free of the full-table-scan cost.
 
 ### Pagination
 


### PR DESCRIPTION
## Summary

Closes #77 — tri-dialect random row ordering, Django's `.order_by('?')` shape. **Stacked on #84** (issue-76-order-by). Will rebase to main once #84 merges.

Adds `.order_random()` to `QuerySet`. Emits `ORDER BY RANDOM()` on PG + SQLite, `ORDER BY RAND()` on MySQL. Useful for banner rotation, sample selection, A/B-test bucket assignment without round-tripping a query result through the app to shuffle.

## What you get

```rust
// Three random posts.
Post::objects()
    .order_random()
    .limit(3)
    .fetch(&pool).await?;

// Random tie-breaker after a primary sort — posts ordered by score
// descending, with ties shuffled.
Post::objects()
    .order_by(&[("score", true)])
    .order_random()
    .fetch(&pool).await?;
```

## What landed

- **`core/query.rs`** — new `OrderItem::Random` variant. No column, no `desc`, no `nulls` — random ordering is unordered by definition, and the per-row random key is non-NULL. New `OrderItem::random()` constructor; `is_desc()` returns `false`, `nulls_order()` returns `Default`, `column_name()` returns `None`.
- **`query/mod.rs`** — new `QuerySet::order_random()` builder. `PendingOrderItem` gets a `Random` variant that lowers via `lower_order_items` to `OrderItem::random()`. `flip_order_by` leaves Random untouched (nothing to invert); `replace_order_by` clears it alongside the other variants.
- **`sql/dialect.rs`** — new `Dialect::random_fn()` trait method returning `"RANDOM"` by default (covers PG + SQLite).
- **`sql/mysql.rs`** — overrides to return `"RAND"`.
- **`sql/writers.rs`** — new `OrderItem::Random` arm in `write_order_target` emits `<random_fn>()`; the surrounding `write_order_limit_offset` loop treats Random as `(desc=false, nulls=Default)` so it slots cleanly into multi-key ORDER BY lists.

## Tri-dialect emission

| Backend | Function | Example output |
|---|---|---|
| PostgreSQL | `RANDOM()` | `ORDER BY RANDOM()` |
| SQLite | `RANDOM()` | `ORDER BY RANDOM()` |
| MySQL | `RAND()` | `ORDER BY RAND()` |

## Tests

| Suite | Count |
|---|---|
| `tests/order_random.rs` (tri-dialect emission) | 8 |
| `tests/order_random_live.rs` (live PG runtime) | 2 |

The 8 emission tests cover: PG/SQLite `RANDOM()`, MySQL `RAND()`, composition after `.order_by(&[...])` (random as tie-breaker), no `DESC` or `NULLS` suffix on Random items, no params bound, `replace_order_by` clears Random items, `flip_order_by` leaves Random items untouched.

The 2 live PG tests confirm runtime randomness:
- Two consecutive draws of 10 rows from a 100-row table return different orderings. Probabilistic — false-positive rate ≈ 5.8e-14 (C(100,10)⁻¹).
- `LIMIT 15` returns 15 **distinct** rows (the random key doesn't drop or duplicate).

## Cookbook

New "Random row order — `.order_random()`" subsection under "Ordering" in `docs/orm.md`. Documents:

- Tri-dialect emission table.
- Multi-key composition (random as tie-breaker after a primary sort).
- **Performance caveat** — `ORDER BY RANDOM()` forces a full table scan + in-memory sort by the per-row random key. The query planner can't use an index. The cookbook shows the index-friendly `WHERE pk >= <rand_offset> LIMIT 1` workaround pattern with the trade-off documented (PK-adjacency-preserved rather than uniformly random). Matches Django's posture on this footgun.

## Verification

```
cargo test -p rustango --lib --features tenancy                   → 1494 passed (no regressions)
cargo test --features tenancy,mysql,sqlite --test order_random    → 8 passed
DATABASE_URL=… cargo test --features tenancy --test order_random_live → 2 passed
cargo check --no-default-features --features sqlite,tenancy       → clean
cargo check --features mysql,tenancy                              → clean
```

No regressions in any prior emission suite.

## Non-goals (explicitly out of scope)

- **Seedable random** for reproducible test ordering. PG's `setseed(...)` is non-standard and MySQL/SQLite have no equivalent.
- **Cryptographically secure random**. The DB's RNG is fine for ordering.

## Test plan

- [x] 8 tri-dialect emission tests pass.
- [x] 2 live PG tests pass (different orderings + distinct rows).
- [x] All three feature combos compile.
- [x] Cookbook section + performance caveat + workaround pattern added.
- [ ] CI green on postgres_test + mysql_live + sqlite_live + sqlite_litmus.
- [ ] Rebase to main once #84 merges.
