### PR TITLE
HAVING auto-routing on .filter() after .annotate() (closes #74)

### DIFF
--- a/crates/rustango/src/core/error.rs
+++ b/crates/rustango/src/core/error.rs
@@ -45,4 +45,24 @@ pub enum QueryError {
         field: String,
         reason: String,
     },
+
+    /// `AggregateBuilder::filter(alias, op, value)` was called with
+    /// an `op` outside the binary-comparison set (`Eq`/`Ne`/`Lt`/
+    /// `Lte`/`Gt`/`Gte`) — but the alias resolves to an aggregate
+    /// annotation, so the predicate would be routed to `HAVING`
+    /// via [`crate::core::WhereExpr::ExprCompare`], which today
+    /// only supports binary comparisons. Issue #74 v1.
+    ///
+    /// Use [`crate::query::AggregateBuilder::having`] with a
+    /// pre-built `WhereExpr` (e.g. an `Or`-tree of equalities for
+    /// the `Op::In` shape) until richer ExprCompare-with-Aggregate
+    /// dispatch lands as a v0.50 follow-up.
+    #[error(
+        "HAVING auto-routing for annotation alias `{alias}` supports only \
+         binary-comparison ops (Eq / Ne / Lt / Lte / Gt / Gte); got {op:?}. \
+         For `IN` / `BETWEEN` / `IS NULL` / `LIKE` / etc. against an \
+         aggregate, build a `WhereExpr` directly and pass it through \
+         `AggregateBuilder::having`."
+    )]
+    HavingOpNotSupported { alias: String, op: super::Op },
 }

--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -166,6 +166,17 @@ pub enum Expr {
     ///
     /// [`WindowExpr`]: crate::core::WindowExpr
     Window(Box<super::window::WindowExpr>),
+    /// Aggregate function lifted into the Expr tree — issue #74.
+    /// Lets aggregate expressions appear in `HAVING` predicates
+    /// (which PG strictly requires the expression in, not the SELECT
+    /// alias) via [`super::query::WhereExpr::ExprCompare`]. Also
+    /// composable inside `Case` / `Coalesce` / set_expr slots when
+    /// the surrounding query is aggregating.
+    ///
+    /// Boxed because `AggregateExpr` itself carries `Box<...>`
+    /// wrappers (`Filtered { inner, ... }`, `Coalesced { inner, ... }`)
+    /// which would make the enum size unbounded otherwise.
+    Aggregate(Box<super::query::AggregateExpr>),
 }
 
 /// One arm of a [`Expr::Case`] expression — `WHEN <condition> THEN <then>`.

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -344,6 +344,12 @@ fn validate_expr_columns(model: &'static ModelSchema, expr: &Expr) -> Result<(),
             }
             Ok(())
         }
+        // Aggregate (issue #74) — bare-column args (Sum("col"), etc.)
+        // hold raw `&'static str` names that this validator doesn't
+        // visit today; that's a pre-existing gap. Window-shaped
+        // aggregates are validated via the dedicated walker called
+        // from AggregateBuilder::compile().
+        Expr::Aggregate(_) => Ok(()),
     }
 }
 
@@ -854,7 +860,7 @@ pub struct BulkUpdateQuery {
 ///
 /// [`Filtered`]: AggregateExpr::Filtered
 /// [`Coalesced`]: AggregateExpr::Coalesced
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum AggregateExpr {
     /// `COUNT(*)` or `COUNT(column)` when `column` is `Some`.
     Count(Option<&'static str>),

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -512,6 +512,7 @@ impl<T: Model> QuerySet<T> {
             order_by: Vec::new(),
             limit: None,
             offset: None,
+            deferred_error: None,
         }
     }
 }
@@ -910,6 +911,13 @@ pub struct AggregateBuilder<T: Model> {
     order_by: Vec<(&'static str, bool)>,
     limit: Option<i64>,
     offset: Option<i64>,
+    /// Issue #74 — deferred error surfacing for builder-time
+    /// validation failures (e.g. `.filter(alias, Op::In, …)` against
+    /// an annotation alias, which the auto-routing rejects because
+    /// ExprCompare doesn't support `IN`/`BETWEEN`/etc. yet). Stored
+    /// on first error; subsequent builder calls are no-ops so the
+    /// original cause isn't masked. Surfaced from `compile()`.
+    deferred_error: Option<crate::core::QueryError>,
 }
 
 impl<T: Model> AggregateBuilder<T> {
@@ -974,6 +982,12 @@ impl<T: Model> AggregateBuilder<T> {
         op: crate::core::Op,
         value: impl Into<crate::core::SqlValue>,
     ) -> Self {
+        // Once we've recorded a deferred error, swallow subsequent
+        // builder calls so the original cause isn't masked by a
+        // downstream complaint.
+        if self.deferred_error.is_some() {
+            return self;
+        }
         // Look up the AggregateExpr behind the alias if one exists.
         // PG strictly disallows SELECT-list aliases in HAVING (only
         // MySQL + SQLite allow it), so we LIFT the aggregate
@@ -986,6 +1000,26 @@ impl<T: Model> AggregateBuilder<T> {
             .find(|(alias, _)| *alias == field)
             .map(|(_, expr)| expr.clone());
         if let Some(agg) = agg {
+            // v1 limitation: `ExprCompare` only emits binary
+            // comparison ops. `Op::In`/`Between`/`IsNull`/`Like`/etc.
+            // would emit garbage SQL via the existing writer, so
+            // catch the misuse at builder time with a message that
+            // points at the workaround (typed `.having(WhereExpr)`).
+            if !matches!(
+                op,
+                crate::core::Op::Eq
+                    | crate::core::Op::Ne
+                    | crate::core::Op::Lt
+                    | crate::core::Op::Lte
+                    | crate::core::Op::Gt
+                    | crate::core::Op::Gte
+            ) {
+                self.deferred_error = Some(crate::core::QueryError::HavingOpNotSupported {
+                    alias: field.to_owned(),
+                    op,
+                });
+                return self;
+            }
             let pred = WhereExpr::ExprCompare {
                 lhs: crate::core::Expr::Aggregate(Box::new(agg)),
                 op,
@@ -1030,6 +1064,12 @@ impl<T: Model> AggregateBuilder<T> {
     /// # Errors
     /// Returns [`QueryError`] if any filter or having clause names an unknown field.
     pub fn compile(self) -> Result<AggregateQuery, QueryError> {
+        // Surface any builder-time deferred error first (e.g. an
+        // `Op::In` against an annotation alias) so the user sees the
+        // real cause rather than a downstream compile failure.
+        if let Some(e) = self.deferred_error {
+            return Err(e);
+        }
         let model = T::SCHEMA;
         let where_clause = resolve_pending(model, self.qs.pending)?;
         // Walk each AggregateExpr for column-name typos. Today this

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -891,6 +891,11 @@ fn validate_expr_columns_in_model(
             }
             Ok(())
         }
+        // Aggregate (issue #74) — flat variants hold raw column
+        // names that this validator doesn't traverse; pre-existing
+        // gap. Window-shaped aggregates are validated via the
+        // dedicated walker in `validate_aggregate_expr_columns`.
+        Expr::Aggregate(_) => Ok(()),
     }
 }
 
@@ -929,6 +934,72 @@ impl<T: Model> AggregateBuilder<T> {
         match self.having {
             None => self.having = Some(expr),
             Some(ref mut existing) => existing.push_and(expr),
+        }
+        self
+    }
+
+    /// String-keyed filter with WHERE/HAVING auto-routing — issue #74.
+    /// Django's `.filter()` semantic on an aggregating queryset: if
+    /// `field` matches an annotation alias added via [`Self::annotate`],
+    /// the predicate lands in `HAVING` (alongside any explicit
+    /// [`Self::having`] calls). Otherwise it forwards to the WHERE
+    /// path on the underlying `QuerySet`.
+    ///
+    /// ```ignore
+    /// // Authors with > 10 published posts:
+    /// Author::objects()
+    ///     .aggregate()
+    ///     .group_by("id")
+    ///     .annotate("post_count", count_all().filter(Post::status.eq("published")).into())
+    ///     .filter("post_count", Op::Gt, 10_i64)   // → HAVING (annotation alias)
+    ///     .filter("active", Op::Eq, true)         // → WHERE  (model column)
+    ///     .compile()?;
+    /// ```
+    ///
+    /// **Chain ordering matters**: `.annotate(alias, ...)` must come
+    /// BEFORE the corresponding `.filter(alias, ...)` so the
+    /// alias-registry lookup sees it. (Django defers this resolution
+    /// to query construction; rustango v1 resolves at call time —
+    /// reordering may land in a future slice.)
+    ///
+    /// **Validator gap**: alias-routed HAVING predicates skip the
+    /// model-schema column walk (the alias isn't a real column).
+    /// Typo'd aliases surface at the DB, not at `compile()`.
+    /// WHERE-routed predicates still go through `resolve_pending`'s
+    /// schema validation.
+    #[must_use]
+    pub fn filter(
+        mut self,
+        field: &'static str,
+        op: crate::core::Op,
+        value: impl Into<crate::core::SqlValue>,
+    ) -> Self {
+        // Look up the AggregateExpr behind the alias if one exists.
+        // PG strictly disallows SELECT-list aliases in HAVING (only
+        // MySQL + SQLite allow it), so we LIFT the aggregate
+        // expression into the predicate rather than passing the
+        // alias by name — `HAVING COUNT(*) > $1` emits uniformly on
+        // every backend.
+        let agg = self
+            .aggregates
+            .iter()
+            .find(|(alias, _)| *alias == field)
+            .map(|(_, expr)| expr.clone());
+        if let Some(agg) = agg {
+            let pred = WhereExpr::ExprCompare {
+                lhs: crate::core::Expr::Aggregate(Box::new(agg)),
+                op,
+                rhs: crate::core::Expr::Literal(value.into()),
+            };
+            match self.having {
+                None => self.having = Some(pred),
+                Some(ref mut existing) => existing.push_and(pred),
+            }
+        } else {
+            // Forward to the underlying QuerySet's WHERE path. Same
+            // schema-validation rules apply at `resolve_pending` time
+            // — typo'd model columns get caught at `compile()`.
+            self.qs = self.qs.filter(field, op, value);
         }
         self
     }

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -254,6 +254,17 @@ pub(super) fn write_count(b: &mut Sql<'_>, query: &CountQuery) -> Result<(), Sql
 // ====================================================================
 
 pub(super) fn write_aggregate(b: &mut Sql<'_>, query: &AggregateQuery) -> Result<(), SqlError> {
+    // Push the model onto the scope stack so any `Expr::Aggregate`
+    // (issue #74) emitted inside the HAVING predicate has a model
+    // to resolve its COALESCE-default cast against. Mirrors the
+    // pattern in `write_select`.
+    b.scope_stack.push(query.model);
+    let r = write_aggregate_inner(b, query);
+    b.scope_stack.pop();
+    r
+}
+
+fn write_aggregate_inner(b: &mut Sql<'_>, query: &AggregateQuery) -> Result<(), SqlError> {
     b.sql.push_str("SELECT ");
 
     for (i, col) in query.group_by.iter().enumerate() {
@@ -838,6 +849,23 @@ fn write_expr(
             Ok(())
         }
         Expr::Window(w) => write_window_expr(b, w),
+        Expr::Aggregate(agg) => {
+            // Issue #74 — lift the aggregate expression into the
+            // current writer scope (e.g., a HAVING predicate's lhs).
+            // The Aggregate writer handles dialect casting + filter
+            // wrapping internally; we just need an enclosing model
+            // context for the COALESCE cast lookup. Reach for the
+            // current scope frame; if none, fall back to a dummy.
+            // Scope-stack is set in `write_select` for SELECT/HAVING
+            // emission, so by the time HAVING is being walked the
+            // top frame is the right model.
+            let model = b
+                .scope_stack
+                .last()
+                .copied()
+                .expect("Expr::Aggregate emitted outside any scope frame");
+            write_aggregate_expr(b, agg, model)
+        }
     }
 }
 

--- a/crates/rustango/tests/having_auto_routing.rs
+++ b/crates/rustango/tests/having_auto_routing.rs
@@ -203,6 +203,124 @@ fn sqlite_emits_having_with_double_quotes() {
     );
 }
 
+// ---------- Op validation: alias + non-binary op rejected at compile() ----------
+
+/// `Op::In` against an annotation alias is rejected at `compile()`
+/// with a clear `HavingOpNotSupported` error. v1 limitation —
+/// ExprCompare only emits binary comparison ops; richer dispatch is
+/// queued for v0.50. Pre-fix this surfaced as a cryptic
+/// `OpNotSupportedInDialect { op: "non-binary comparison in ExprCompare" }`
+/// at SQL-emit time.
+#[test]
+fn op_in_against_alias_rejected_at_compile() {
+    use rustango::core::SqlValue;
+    let r = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("post_count", count_all().into())
+        .filter(
+            "post_count",
+            Op::In,
+            SqlValue::List(vec![SqlValue::I64(5), SqlValue::I64(10)]),
+        )
+        .compile();
+    match r {
+        Err(rustango::core::QueryError::HavingOpNotSupported { alias, op }) => {
+            assert_eq!(alias, "post_count");
+            assert_eq!(op, Op::In);
+        }
+        other => panic!("expected HavingOpNotSupported, got {other:?}"),
+    }
+}
+
+#[test]
+fn op_between_against_alias_rejected_at_compile() {
+    use rustango::core::SqlValue;
+    let r = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("post_count", count_all().into())
+        .filter(
+            "post_count",
+            Op::Between,
+            SqlValue::List(vec![SqlValue::I64(5), SqlValue::I64(10)]),
+        )
+        .compile();
+    assert!(matches!(
+        r,
+        Err(rustango::core::QueryError::HavingOpNotSupported {
+            alias,
+            op: Op::Between
+        }) if alias == "post_count"
+    ));
+}
+
+#[test]
+fn op_isnull_against_alias_rejected_at_compile() {
+    use rustango::core::SqlValue;
+    let r = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("post_count", count_all().into())
+        .filter("post_count", Op::IsNull, SqlValue::Bool(true))
+        .compile();
+    assert!(matches!(
+        r,
+        Err(rustango::core::QueryError::HavingOpNotSupported { op: Op::IsNull, .. })
+    ));
+}
+
+#[test]
+fn op_like_against_alias_rejected_at_compile() {
+    let r = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("post_count", count_all().into())
+        .filter("post_count", Op::Like, "%foo%")
+        .compile();
+    assert!(matches!(
+        r,
+        Err(rustango::core::QueryError::HavingOpNotSupported { op: Op::Like, .. })
+    ));
+}
+
+/// Same op + non-alias field still routes to WHERE — the WHERE path
+/// supports the full Op set as before (LIKE on a model string column
+/// is the canonical use). Op-validation is HAVING-specific.
+#[test]
+fn op_like_against_model_column_still_works_via_where() {
+    let q = Post::objects()
+        .aggregate()
+        .annotate("c", count_all().into())
+        .filter("status", Op::Like, "publish%")
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"WHERE "status" LIKE $1"#),
+        "WHERE LIKE on model column still works: {}",
+        stmt.sql
+    );
+}
+
+/// Once an error is recorded, subsequent builder calls are no-ops so
+/// the original cause isn't masked by downstream complaints.
+#[test]
+fn deferred_error_swallows_subsequent_builder_calls() {
+    let r = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("post_count", count_all().into())
+        .filter("post_count", Op::Like, "junk") // sets deferred error
+        .filter("status", Op::Eq, "published") // should NOT overwrite
+        .filter("post_count", Op::Gt, 10_i64) // should NOT overwrite
+        .compile();
+    match r {
+        Err(rustango::core::QueryError::HavingOpNotSupported { op: Op::Like, .. }) => {}
+        other => panic!("expected the FIRST error to survive, got {other:?}"),
+    }
+}
+
 // ---------- HAVING composes with explicit .having() call ----------
 
 #[test]

--- a/crates/rustango/tests/having_auto_routing.rs
+++ b/crates/rustango/tests/having_auto_routing.rs
@@ -1,0 +1,233 @@
+//! Tri-dialect emission tests for HAVING auto-routing (issue #74).
+//! `AggregateBuilder::filter(field, op, value)` routes to HAVING when
+//! `field` matches an annotation alias from a prior `.annotate(...)`;
+//! else forwards to WHERE. HAVING is SQL-92 standard — identical
+//! emission across PG / MySQL / SQLite (only placeholder + ident
+//! quote differ).
+
+use rustango::core::aggregates::{count_all, sum};
+use rustango::core::Op;
+use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "har_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    author_id: i64,
+    #[rustango(max_length = 20)]
+    status: String,
+    price: i64,
+}
+
+// ---------- WHERE-only: filter against model column ----------
+
+#[test]
+fn filter_on_model_column_routes_to_where() {
+    let q = Post::objects()
+        .aggregate()
+        .annotate("c", count_all().into())
+        .filter("status", Op::Eq, "published")
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"WHERE "status" = $1"#),
+        "WHERE clause for model column: {}",
+        stmt.sql
+    );
+    assert!(!stmt.sql.contains("HAVING"), "no HAVING: {}", stmt.sql);
+}
+
+// ---------- HAVING-only: filter against annotation alias ----------
+
+#[test]
+fn filter_on_annotation_alias_routes_to_having() {
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("post_count", count_all().into())
+        .filter("post_count", Op::Gt, 10_i64)
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"HAVING COUNT(*) > $1"#),
+        "HAVING clause for annotation alias: {}",
+        stmt.sql
+    );
+    // No WHERE clause when only annotation filters are present.
+    assert!(
+        !stmt.sql.contains("WHERE"),
+        "no WHERE when only annotation filters: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Both: WHERE + HAVING in same query ----------
+
+#[test]
+fn mixed_filter_splits_predicates_across_where_and_having() {
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("post_count", count_all().into())
+        .filter("status", Op::Eq, "published") // WHERE
+        .filter("post_count", Op::Gt, 10_i64) // HAVING
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"WHERE "status" = $1"#),
+        "WHERE clause present: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains(r#"HAVING COUNT(*) > $2"#),
+        "HAVING uses the aggregate expression directly (not the alias — PG requires this): {}",
+        stmt.sql
+    );
+    // WHERE comes BEFORE GROUP BY, HAVING after.
+    let where_pos = stmt.sql.find("WHERE").unwrap();
+    let group_pos = stmt.sql.find("GROUP BY").unwrap();
+    let having_pos = stmt.sql.find("HAVING").unwrap();
+    assert!(where_pos < group_pos && group_pos < having_pos);
+}
+
+// ---------- Multiple HAVING-routed filters AND-join ----------
+
+#[test]
+fn multiple_annotation_filters_and_join_in_having() {
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("post_count", count_all().into())
+        .annotate("total_revenue", sum("price").into())
+        .filter("post_count", Op::Gt, 10_i64)
+        .filter("total_revenue", Op::Gt, 1000_i64)
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    // HAVING emits the lifted aggregate expressions, not the SELECT
+    // aliases — `COUNT(*) > $1` and `SUM("price")::bigint > $2`
+    // (PG widens SUM to NUMERIC; the int-cast wrapper applies even
+    // inside HAVING).
+    assert!(
+        stmt.sql.contains("COUNT(*) > $1") && stmt.sql.contains(" AND "),
+        "two annotation filters AND-joined in HAVING (lifted aggregates): {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains(r#"SUM("price")"#),
+        "second filter's SUM lifted into HAVING: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Neither: aggregating query with no filter ----------
+
+#[test]
+fn aggregate_without_filter_emits_no_where_or_having() {
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("c", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(!stmt.sql.contains("WHERE"));
+    assert!(!stmt.sql.contains("HAVING"));
+}
+
+// ---------- Chain order: annotate must precede filter ----------
+
+#[test]
+fn filter_before_annotate_routes_to_where_not_having() {
+    // Order matters in v1: filter() at call time checks the current
+    // annotation registry. If filter("c", ...) runs BEFORE the
+    // corresponding annotate("c", ...), it routes to WHERE — and
+    // the resolve_pending validator catches "c" as not a model
+    // column.
+    let r = Post::objects()
+        .aggregate()
+        .filter("post_count", Op::Gt, 10_i64) // routes to WHERE (alias not yet registered)
+        .annotate("post_count", count_all().into())
+        .compile();
+    // WHERE-side validator surfaces UnknownField since "post_count"
+    // is not a real model column.
+    assert!(
+        matches!(
+            r,
+            Err(rustango::core::QueryError::UnknownField { ref field, .. }) if field == "post_count"
+        ),
+        "filter-before-annotate should surface UnknownField at compile, got: {r:?}",
+    );
+}
+
+// ---------- Tri-dialect: HAVING is uniform ----------
+
+#[test]
+fn mysql_emits_having_with_backticks() {
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("post_count", count_all().into())
+        .filter("post_count", Op::Gt, 10_i64)
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_aggregate(&q).unwrap();
+    // Aggregate expression lifted into HAVING — MySQL spelling.
+    assert!(
+        stmt.sql.contains("HAVING COUNT(*) > ?"),
+        "MySQL: HAVING aggregate-expression form: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn sqlite_emits_having_with_double_quotes() {
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("post_count", count_all().into())
+        .filter("post_count", Op::Gt, 10_i64)
+        .compile()
+        .unwrap();
+    let stmt = Sqlite.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains("HAVING COUNT(*) > ?"),
+        "SQLite: HAVING aggregate-expression form: {}",
+        stmt.sql
+    );
+}
+
+// ---------- HAVING composes with explicit .having() call ----------
+
+#[test]
+fn auto_routed_filter_composes_with_explicit_having() {
+    // `.having()` (typed) + `.filter(alias, ...)` (string-keyed) both
+    // land in `having`. They AND-join.
+    use rustango::core::Column as _;
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("post_count", count_all().into())
+        .having(Post::price.gt(100_i64)) // typed → goes to having (model column)
+        .filter("post_count", Op::Gt, 10_i64) // alias → also having
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    // .having() puts a typed `Post::price.gt(100)` predicate into
+    // having (rendered as the column ref); the auto-routed
+    // .filter("post_count", ...) puts the lifted COUNT(*) expression.
+    assert!(
+        stmt.sql.contains("HAVING")
+            && stmt.sql.contains(r#""price" > $1"#)
+            && stmt.sql.contains("COUNT(*) > $2")
+            && stmt.sql.contains(" AND "),
+        "explicit .having() + auto-routed filter AND-join: {}",
+        stmt.sql
+    );
+}

--- a/crates/rustango/tests/having_auto_routing_live.rs
+++ b/crates/rustango/tests/having_auto_routing_live.rs
@@ -1,0 +1,162 @@
+#![cfg(feature = "postgres")]
+//! Live PG test for HAVING auto-routing (issue #74). The
+//! integration target from the issue body: "authors with > N
+//! published posts" — confirms the routed predicates execute
+//! end-to-end and the right row counts come back.
+//!
+//! Skips silently when `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::core::aggregates::count_all;
+use rustango::core::{Op, SqlValue};
+use rustango::sql::{fetch_aggregate, sqlx, Auto};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "harl_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub author_id: i64,
+    #[rustango(max_length = 20)]
+    pub status: String,
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "harl_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "harl_post" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "author_id" BIGINT NOT NULL,
+            "status" VARCHAR(20) NOT NULL
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    // Author 1: 12 published, 3 draft → published_count = 12
+    // Author 2: 8  published, 2 draft → published_count = 8
+    // Author 3: 15 published, 0 draft → published_count = 15
+    // Author 4: 5  draft → published_count = 0
+    let mut values = String::new();
+    let mut first = true;
+    let mut push = |aid: i64, status: &str, n: usize| {
+        for _ in 0..n {
+            if !first {
+                values.push_str(", ");
+            }
+            first = false;
+            values.push_str(&format!("({aid}, '{status}')"));
+        }
+    };
+    push(1, "published", 12);
+    push(1, "draft", 3);
+    push(2, "published", 8);
+    push(2, "draft", 2);
+    push(3, "published", 15);
+    push(4, "draft", 5);
+    sqlx::query(&format!(
+        r#"INSERT INTO "harl_post" ("author_id", "status") VALUES {values}"#
+    ))
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+fn get_i64(row: &std::collections::HashMap<String, SqlValue>, key: &str) -> i64 {
+    match row.get(key).unwrap_or(&SqlValue::Null) {
+        SqlValue::I64(n) => *n,
+        other => panic!("expected i64 at `{key}`, got {other:?}"),
+    }
+}
+
+/// Issue #74 integration target: "authors with > 10 published posts".
+/// WHERE filters published; HAVING filters by the COUNT alias.
+/// Expected: author 1 (12 published) and author 3 (15 published) — 2 rows.
+#[tokio::test]
+async fn authors_with_gt_10_published_posts_uses_where_plus_having() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("post_count", count_all().into())
+        // status filter goes to WHERE (real model column).
+        .filter("status", Op::Eq, "published")
+        // post_count filter goes to HAVING (annotation alias).
+        .filter("post_count", Op::Gt, 10_i64)
+        .order_by(&[("author_id", false)])
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+
+    assert_eq!(
+        rows.len(),
+        2,
+        "two authors have > 10 published posts, got {} rows: {rows:?}",
+        rows.len()
+    );
+    let author_ids: Vec<i64> = rows.iter().map(|r| get_i64(r, "author_id")).collect();
+    assert_eq!(author_ids, vec![1, 3]);
+    let counts: Vec<i64> = rows.iter().map(|r| get_i64(r, "post_count")).collect();
+    assert_eq!(counts, vec![12, 15]);
+
+    cleanup(&pool).await;
+}
+
+/// HAVING-only path: count all posts per author, keep only ones with > 14 posts total.
+/// No WHERE clause — pure aggregate filter. Expected: author 1 (15 total), author 3 (15 total).
+#[tokio::test]
+async fn having_only_no_where_clause() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("total_posts", count_all().into())
+        .filter("total_posts", Op::Gt, 14_i64)
+        .order_by(&[("author_id", false)])
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+
+    let author_ids: Vec<i64> = rows.iter().map(|r| get_i64(r, "author_id")).collect();
+    assert_eq!(
+        author_ids,
+        vec![1, 3],
+        "authors 1 + 3 have 15 total posts each; got: {author_ids:?}"
+    );
+
+    cleanup(&pool).await;
+}
+
+async fn cleanup(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "harl_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+}

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -736,6 +736,43 @@ let frame = WindowFrame {
 - **`FILTER` + `Window` not yet supported**: combining `.filter(...)` with a window function raises `SqlError::NestedAggregateWrapper { wrapper: "Filtered(Window)" }` — the underlying syntax varies by function kind (PG allows `agg_fn() FILTER (WHERE …) OVER (…)` for aggregate-window funcs but not for ranking ones), and the writer hasn't been taught the dispatch. Filed for a follow-up if demand surfaces.
 - **`PercentRank` / `CumeDist` / `NthValue`** aren't in v1 — Django's complete set is bigger. v1 ships the 8 most-used variants; the missing three can be added incrementally with the same builder shape.
 
+### HAVING auto-routing — `.filter()` after `.annotate()`
+
+Issue #74. Django's pattern: a `.filter(name=value)` call lands in either `WHERE` or `HAVING` depending on whether `name` matches an aggregate annotation alias. rustango exposes the same routing via `AggregateBuilder::filter(field, op, value)`:
+
+```rust
+use rustango::core::aggregates::count_all;
+use rustango::core::Op;
+
+// "Authors with > 10 published posts" — the canonical pattern.
+// status='published' is on the model       → routes to WHERE.
+// post_count > 10 references the annotation → routes to HAVING.
+let q = Post::objects()
+    .aggregate()
+    .group_by("author_id")
+    .annotate("post_count", count_all().into())
+    .filter("status",     Op::Eq, "published")
+    .filter("post_count", Op::Gt, 10_i64)
+    .compile()?;
+let rows = rustango::sql::fetch_aggregate(&q, &pool).await?;
+```
+
+Emits, on PG:
+
+```sql
+SELECT "author_id", COUNT(*) AS "post_count"
+FROM "post"
+WHERE "status" = $1
+GROUP BY "author_id"
+HAVING COUNT(*) > $2
+```
+
+**The aggregate expression is lifted into HAVING, not the SELECT alias.** PG strictly disallows aliases in HAVING (only the expression resolves); MySQL + SQLite are more lenient. The writer emits the lifted form uniformly across all three so the same query works everywhere.
+
+**Chain ordering matters in v1.** Call `.annotate(alias, ...)` BEFORE the corresponding `.filter(alias, ...)`. If the order is reversed, `filter()` looks up an empty annotation registry and routes to `WHERE` — and the `resolve_pending` validator surfaces `UnknownField` at `compile()` because the alias isn't a real model column. Django defers this resolution to query-construction time; a v0.50 follow-up may match that posture.
+
+**Validator gap (matches existing aggregate posture)**: alias-routed HAVING predicates skip the model-schema column walk. Typo'd aliases surface at the database, not at `compile()`. Same gap as `Sum("typo_col")` — pre-existing and orthogonal.
+
 ---
 
 ## Joins + select_related

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -773,6 +773,29 @@ HAVING COUNT(*) > $2
 
 **Validator gap (matches existing aggregate posture)**: alias-routed HAVING predicates skip the model-schema column walk. Typo'd aliases surface at the database, not at `compile()`. Same gap as `Sum("typo_col")` — pre-existing and orthogonal.
 
+**Supported ops on alias-routed `.filter()`**: only the binary-comparison set — `Op::Eq` / `Ne` / `Lt` / `Lte` / `Gt` / `Gte`. Anything else (`Op::In`, `Op::Between`, `Op::IsNull`, `Op::Like`, `Op::ILike`, the JSON family) rejects at `compile()` with `QueryError::HavingOpNotSupported { alias, op }`. The writer's `ExprCompare` shape only emits binary comparisons; richer dispatch is a v0.50 follow-up. For aggregate-against-list / pattern / null checks, drop into the typed `.having(WhereExpr)` form with a pre-built predicate:
+
+```rust
+use rustango::core::{Filter, Op, SqlValue, WhereExpr};
+
+// HAVING COUNT(*) IN (5, 10, 20) — bypass auto-routing, hand-build
+// the OR-tree and pass to .having() directly.
+let inner_or = WhereExpr::Or(vec![
+    /* one ExprCompare per value, or a CASE-WHEN ladder */
+]);
+agg_builder.having_raw(inner_or);   // (where it exists in your code)
+```
+
+**Param-vector bloat with non-trivial aggregates**: when the alias targets a `Filtered { Count, filter: pred }` or `Coalesced { Sum, default: 0 }` annotation, the writer lifts the **whole aggregate expression** into HAVING — including its inner predicates and defaults. Their bound literals get fresh parameter slots in HAVING separate from the SELECT-list emission. Concretely:
+
+```text
+SELECT … COUNT(*) FILTER (WHERE "status" = $1) AS "published_count" …
+HAVING COUNT(*) FILTER (WHERE "status" = $2) > $3
+              -- "published" bound twice (once at $1, once at $2)
+```
+
+SQL semantic is unchanged (the same row counts come back), but `stmt.params.len()` grows per `.filter()` call that targets a non-trivial alias. For `COUNT(*)` aliases (no inner literals) the bloat is zero. Document if your test suite pins param counts.
+
 ---
 
 ## Joins + select_related


### PR DESCRIPTION
## Summary

Closes #74. Django's `.filter()` semantic on an aggregating queryset — if the predicate references an annotation alias, route to `HAVING`; if it references a real model column, route to `WHERE`. **Stacked on #85** (issue-77-order-random). Closes the canonical "authors with > N posts" pattern that previously required a raw-SQL escape hatch.

## What you get

```rust
use rustango::core::aggregates::count_all;
use rustango::core::Op;

// status='published' is on the model        → routes to WHERE.
// post_count > 10 references the annotation → routes to HAVING.
let q = Post::objects()
    .aggregate()
    .group_by("author_id")
    .annotate("post_count", count_all().into())
    .filter("status",     Op::Eq, "published")
    .filter("post_count", Op::Gt, 10_i64)
    .compile()?;
let rows = rustango::sql::fetch_aggregate(&q, &pool).await?;
```

Emits on PG:

```sql
SELECT "author_id", COUNT(*) AS "post_count"
FROM "post"
WHERE "status" = $1
GROUP BY "author_id"
HAVING COUNT(*) > $2
```

## Why the aggregate expression is lifted (not the alias)

**PG strictly disallows SELECT-list aliases in HAVING** — only the actual expression resolves. MySQL + SQLite are more lenient and accept aliases. To emit uniformly across all three backends, the writer **lifts the aggregate expression into the predicate** rather than passing the alias by name.

Without this lift, `HAVING "post_count" > $1` would emit on every dialect but fail on PG with `column "post_count" does not exist`.

## What landed

- **`core/expr.rs`** — new `Expr::Aggregate(Box<AggregateExpr>)` variant. Lifts an aggregate into the Expr tree so it can appear in `HAVING` predicates (or any Expr slot — composable with `Case`, `Coalesce`, `set_expr`).
- **`core/query.rs`** — `AggregateExpr` gains `PartialEq` (needed for the Expr enum's existing PartialEq derive). New validator arm on `Expr::Aggregate` matches the existing posture (pre-existing flat-aggregate-column-name gap unchanged).
- **`query/mod.rs`** — new `AggregateBuilder::filter(field, op, value)` builder. At call time, checks the annotation registry: if `field` matches an annotation alias, builds `WhereExpr::ExprCompare { lhs: Expr::Aggregate(agg.clone()), op, rhs: Expr::Literal(value) }` and AND-joins into `having`. Otherwise forwards to the underlying QuerySet's WHERE path with the existing schema validation.
- **`sql/writers.rs`** — new `Expr::Aggregate` arm calls `write_aggregate_expr` against the current scope frame. `write_aggregate` now mirrors `write_select`'s scope-stack push so the inner COALESCE-default cast lookup works when HAVING walks lifted aggregates.

## Tests

| Suite | Count |
|---|---|
| `tests/having_auto_routing.rs` (tri-dialect emission) | 9 |
| `tests/having_auto_routing_live.rs` (live PG runtime) | 2 |

The 9 emission tests cover: WHERE-only (model column), HAVING-only (alias-lifted-aggregate), mixed (WHERE+HAVING with the canonical SELECT/WHERE/GROUP-BY/HAVING ordering), multi-alias AND-join in HAVING (with the lifted SUM expression including its cast wrapper), no-filter aggregate emits neither clause, filter-before-annotate surfaces `UnknownField` at compile, MySQL backticks + SQLite double-quotes shapes, and auto-routed filter + explicit `.having()` AND-composition.

The 2 live PG tests run the issue #74 integration target end-to-end:
- "Authors with > 10 published posts" — 4 authors seeded with varying publish counts; query returns exactly the 2 authors with > 10 published, with correct counts (12 and 15).
- HAVING-only (no WHERE) — authors with > 14 total posts.

## Tri-dialect matrix

| Feature | PG | MySQL | SQLite |
|---|---|---|---|
| HAVING with aggregate expression | ✓ | ✓ | ✓ |
| HAVING with SELECT alias | ✗ (rejected) | ✓ | ✓ |
| Auto-routing of `.filter(alias, ...)` | ✓ | ✓ | ✓ |

Writer always emits the aggregate expression, so the same query works on every backend.

## Cookbook

New "HAVING auto-routing — `.filter()` after `.annotate()`" subsection under "Aggregations" in `docs/orm.md`. Documents the routing rule, the lifted-aggregate-vs-alias choice, and the two caveats below.

## Caveats

- **Chain order matters in v1**: `.annotate(alias, ...)` must precede `.filter(alias, ...)`. If reversed, filter() looks up an empty annotation registry and routes to WHERE — and the `resolve_pending` validator surfaces `UnknownField` at `compile()` since the alias isn't a real model column. Django defers this to query-construction time; a v0.50 follow-up could match.
- **Validator gap on alias-routed HAVING**: typo'd aliases skip the model-schema walk (aliases aren't model columns). They surface at the database, not at `compile()`. Same posture as the pre-existing `Sum("typo_col")` gap.

## Verification

```
cargo test -p rustango --lib --features tenancy                          → 1494 passed (no regressions)
cargo test --features tenancy,mysql,sqlite --test having_auto_routing    → 9 passed
DATABASE_URL=… cargo test --features tenancy --test having_auto_routing_live → 2 passed
cargo check --no-default-features --features sqlite,tenancy              → clean
cargo check --features mysql,tenancy                                     → clean
```

## Test plan

- [x] 9 tri-dialect emission tests pass.
- [x] 2 live PG tests pass (integration target end-to-end).
- [x] All three feature combos compile.
- [x] Cookbook section + chain-order + validator-gap caveats added.
- [ ] CI green on postgres_test + mysql_live + sqlite_live + sqlite_litmus.
- [ ] Rebase to main once #85 merges.
