### PR TITLE
feat: Django-shape `.filter("field__lookup", value)` (closes #71)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ env:
   # pre-push hook treats warnings as warnings; CI now does the
   # same. Real type errors / broken tests still fail the build.
   DATABASE_URL: postgres://rustango:rustango@localhost:5432/rustango_test
+  # CI builds the workspace once per job — incremental codegen
+  # only bloats target/ (~10–15% on this tree). Disabling it
+  # buys back disk space on the heavy `postgres_test` job that
+  # builds ~100+ integration test binaries with `--all-features`.
+  CARGO_INCREMENTAL: 0
 
 jobs:
   fmt:
@@ -65,6 +70,19 @@ jobs:
           --health-retries 20
     steps:
       - uses: actions/checkout@v4
+      # `cargo test --workspace --all-features` compiles ~100+
+      # integration-test binaries with debug info — combined with
+      # the preinstalled toolchains on `ubuntu-latest`, the 14 GB
+      # runner disk fills before the linker finishes. Reclaim
+      # ~20 GB by removing toolchains this workspace doesn't use
+      # (Android SDK, .NET SDK, GHC, the CodeQL bundle).
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          df -h
       - uses: dtolnay/rust-toolchain@1.88
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --all-features

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -942,7 +942,7 @@ fn reverse_helper_tokens(child_ident: &syn::Ident, fk_relations: &[FkRelation]) 
                 {
                     let _pk: ::rustango::core::SqlValue = self.__rustango_pk_value();
                     ::rustango::query::QuerySet::<#child_ident>::new()
-                        .filter(#fk_col, ::rustango::core::Op::Eq, _pk)
+                        .filter_op(#fk_col, ::rustango::core::Op::Eq, _pk)
                         .fetch_on(_executor)
                         .await
                 }

--- a/crates/rustango/examples/cookbook_blog/COOKBOOK.md
+++ b/crates/rustango/examples/cookbook_blog/COOKBOOK.md
@@ -772,7 +772,7 @@ act.save(&pool).await?;
 13 live recipes against the Author / Post fixture from Chapter 2.
 Run with `DATABASE_URL=... cargo test --test cookbook_chapter03_orm -- --test-threads=1`.
 
-* §3.31 `Post::objects().filter("published", Op::Eq, true).fetch(&pool)` →
+* §3.31 `Post::objects().filter_op("published", Op::Eq, true).fetch(&pool)` →
   `filter_eq_fetch_returns_matching_rows`
 * §3.34 `Op::Gt` / `Op::Lt` / `Op::ILike` / `Op::In` / `Op::Between` /
   `Op::IsNull` — six tests covering the full Op surface.
@@ -1871,7 +1871,7 @@ API:         [`crates/rustango/src/sql/sqlite.rs`](../../src/sql/sqlite.rs)
 Recipe:
 ```rust,ignore
 Post::objects()
-    .filter("title", Op::ILike, "%hello%")
+    .filter_op("title", Op::ILike, "%hello%")
     .fetch_pool(&pool).await?;  // emits: WHERE LOWER(title) LIKE LOWER(?)
 ```
 

--- a/crates/rustango/examples/cookbook_blog/src/apps/blog/urls.rs
+++ b/crates/rustango/examples/cookbook_blog/src/apps/blog/urls.rs
@@ -37,7 +37,7 @@ async fn retrieve(
     Path(id): Path<i64>,
 ) -> Result<Json<AuthorOut>, (StatusCode, String)> {
     let row: Vec<Author> = Author::objects()
-        .filter("id", Op::Eq, id)
+        .filter_op("id", Op::Eq, id)
         .fetch_on(tenant.conn())
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -136,7 +136,7 @@ async fn show_edit_form(
     Path(id): Path<i64>,
 ) -> Result<Html<String>, (StatusCode, String)> {
     let mut rows: Vec<Author> = Author::objects()
-        .filter("id", Op::Eq, id)
+        .filter_op("id", Op::Eq, id)
         .fetch_on(tenant.conn())
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter02_models.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter02_models.rs
@@ -209,7 +209,7 @@ async fn option_field_round_trips_null() {
 
     let id = match a.id { Auto::Set(v) => v, Auto::Unset => unreachable!() };
     let row: Vec<Author> = Author::objects()
-        .filter("id", Op::Eq, id)
+        .filter_op("id", Op::Eq, id)
         .fetch(&pool).await.unwrap();
     assert_eq!(row.len(), 1);
     assert_eq!(row[0].bio, None, "Option<String>::None should round-trip as NULL");
@@ -232,7 +232,7 @@ async fn auto_now_add_assigns_at_insert() {
     let id = match a.id { Auto::Set(v) => v, Auto::Unset => unreachable!() };
 
     let row: Vec<Author> = Author::objects()
-        .filter("id", Op::Eq, id)
+        .filter_op("id", Op::Eq, id)
         .fetch(&pool).await.unwrap();
     let joined = match row[0].joined_at {
         Auto::Set(t) => t,
@@ -323,7 +323,7 @@ async fn fk_column_round_trips() {
     p.save(&pool).await.unwrap();
 
     let posts: Vec<Post> = Post::objects()
-        .filter("author_id", Op::Eq, author_id)
+        .filter_op("author_id", Op::Eq, author_id)
         .fetch(&pool).await.unwrap();
     assert_eq!(posts.len(), 1);
     assert_eq!(posts[0].title, "first");
@@ -364,7 +364,7 @@ async fn jsonb_field_round_trips_structured_data() {
     p.save(&pool).await.unwrap();
 
     let posts: Vec<Post> = Post::objects()
-        .filter("slug", Op::Eq, "j")
+        .filter_op("slug", Op::Eq, "j")
         .fetch(&pool).await.unwrap();
     assert_eq!(posts[0].metadata, payload);
 }
@@ -410,9 +410,9 @@ async fn datetime_option_round_trips() {
     };
     p2.save(&pool).await.unwrap();
 
-    let now_back: Vec<Post> = Post::objects().filter("slug", Op::Eq, "now").fetch(&pool).await.unwrap();
+    let now_back: Vec<Post> = Post::objects().filter_op("slug", Op::Eq, "now").fetch(&pool).await.unwrap();
     assert!(now_back[0].published_at.is_some(), "Some(when) lost on round-trip");
-    let never_back: Vec<Post> = Post::objects().filter("slug", Op::Eq, "never").fetch(&pool).await.unwrap();
+    let never_back: Vec<Post> = Post::objects().filter_op("slug", Op::Eq, "never").fetch(&pool).await.unwrap();
     assert_eq!(never_back[0].published_at, None);
 }
 
@@ -590,7 +590,7 @@ async fn generic_fk_schema_and_content_type_lookup() {
     act.save(&pool).await.expect("activity insert");
 
     let rows: Vec<Activity> = Activity::objects()
-        .filter("target_object_pk", Op::Eq, author_id)
+        .filter_op("target_object_pk", Op::Eq, author_id)
         .fetch(&pool).await.unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].action, "viewed");
@@ -611,7 +611,7 @@ async fn soft_delete_column_round_trips_and_deleted_at_defaults_null() {
     let id = match n.id { Auto::Set(v) => v, _ => unreachable!() };
 
     let rows: Vec<ArchiveNote> = ArchiveNote::objects()
-        .filter("id", Op::Eq, id)
+        .filter_op("id", Op::Eq, id)
         .fetch(&pool).await.unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].deleted_at, None, "fresh row deleted_at should be NULL");

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter03_orm.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter03_orm.rs
@@ -87,7 +87,7 @@ async fn filter_eq_fetch_returns_matching_rows() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let published: Vec<Post> = Post::objects()
-        .filter("published", Op::Eq, true)
+        .filter_op("published", Op::Eq, true)
         .fetch(&pool).await.unwrap();
     assert_eq!(published.len(), 3, "3 of 5 posts are published");
     for p in &published { assert!(p.published, "filter must keep only published"); }
@@ -101,7 +101,7 @@ async fn filter_with_gt_lt_op() {
     let popular: Vec<Post> = Post::objects()
         // Bind as i64 — the column is BIGINT, and `90` would otherwise
         // infer as i32 and trip rustango's TypeMismatch guard.
-        .filter("view_count", Op::Gt, 90i64)
+        .filter_op("view_count", Op::Gt, 90i64)
         .fetch(&pool).await.unwrap();
     assert_eq!(popular.len(), 2, "view_count>90: rust-orm(100) + django-shape(250)");
     let titles: Vec<&str> = popular.iter().map(|p| p.title.as_str()).collect();
@@ -115,7 +115,7 @@ async fn filter_with_ilike_case_insensitive() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let drafts: Vec<Post> = Post::objects()
-        .filter("title", Op::ILike, "%draft%")
+        .filter_op("title", Op::ILike, "%draft%")
         .fetch(&pool).await.unwrap();
     assert_eq!(drafts.len(), 2);
 }
@@ -127,7 +127,7 @@ async fn filter_with_in_list() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let picks: Vec<Post> = Post::objects()
-        .filter("slug", Op::In, SqlValue::List(vec![
+        .filter_op("slug", Op::In, SqlValue::List(vec![
             SqlValue::String("rust-orm".into()),
             SqlValue::String("axum-101".into()),
         ]))
@@ -142,7 +142,7 @@ async fn filter_with_between_range() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let mid: Vec<Post> = Post::objects()
-        .filter("view_count", Op::Between, SqlValue::List(vec![
+        .filter_op("view_count", Op::Between, SqlValue::List(vec![
             SqlValue::I64(50), SqlValue::I64(150),
         ]))
         .fetch(&pool).await.unwrap();
@@ -156,7 +156,7 @@ async fn filter_with_is_null_unpublished() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let drafts: Vec<Post> = Post::objects()
-        .filter("published_at", Op::IsNull, SqlValue::Bool(true))
+        .filter_op("published_at", Op::IsNull, SqlValue::Bool(true))
         .fetch(&pool).await.unwrap();
     assert_eq!(drafts.len(), 2, "draft-1 + draft-2 have NULL published_at");
 }
@@ -167,7 +167,7 @@ async fn order_by_view_count_desc() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let by_views: Vec<Post> = Post::objects()
-        .filter("published", Op::Eq, true)
+        .filter_op("published", Op::Eq, true)
         // QuerySet::order_by uses (column, desc): true = DESC, false = ASC.
         .order_by(&[("view_count", true)])
         .fetch(&pool).await.unwrap();
@@ -201,7 +201,7 @@ async fn aggregate_count_and_sum() {
     let _ = fresh_blog(&pool).await;
 
     let q = Post::objects()
-        .filter("published", Op::Eq, true)
+        .filter_op("published", Op::Eq, true)
         .aggregate()
         .annotate("total", AggregateExpr::Count(None))
         .annotate("views", AggregateExpr::Sum("view_count"))
@@ -242,7 +242,7 @@ async fn save_inserts_then_updates_in_place() {
     p.save(&pool).await.unwrap();
 
     let back: Vec<Post> = Post::objects()
-        .filter("id", Op::Eq, id)
+        .filter_op("id", Op::Eq, id)
         .fetch(&pool).await.unwrap();
     assert_eq!(back[0].body, "v2");
     assert!(back[0].published);

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter12_bidialect.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter12_bidialect.rs
@@ -60,7 +60,7 @@ async fn cookbook_rating_round_trips_against_mysql() {
     assert!(id > 0, "MySQL AUTO_INCREMENT must assign positive id");
 
     let rows: Vec<Rating> = Rating::objects()
-        .filter("id", Op::Eq, id)
+        .filter_op("id", Op::Eq, id)
         .fetch_pool(&p).await.expect("fetch_pool against mysql");
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].score, 4);
@@ -95,7 +95,7 @@ async fn mysql_multi_auto_inserts_then_refetches_for_remaining_fields() {
     // path — same shape as Django apps that .refresh_from_db() after
     // save when they need server-set timestamps.
     let rows: Vec<Author> = Author::objects()
-        .filter("id", Op::Eq, id)
+        .filter_op("id", Op::Eq, id)
         .fetch_pool(&p).await.unwrap();
     assert_eq!(rows.len(), 1);
     let loaded_joined_at = match rows[0].joined_at {

--- a/crates/rustango/examples/sqlite_orm_demo.rs
+++ b/crates/rustango/examples/sqlite_orm_demo.rs
@@ -152,20 +152,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n== 4. filter operators (Eq / Gt / In / Like / ILike / Between) ==");
 
     let alice_posts: Vec<Post> = Post::objects()
-        .filter("author_id", Op::Eq, alice_id)
+        .filter_op("author_id", Op::Eq, alice_id)
         .order_by(&[("title", false)])
         .fetch_pool(&pool)
         .await?;
     println!("Alice has {} post(s)", alice_posts.len());
 
     let popular: Vec<Post> = Post::objects()
-        .filter("views", Op::Gt, 0_i64)
+        .filter_op("views", Op::Gt, 0_i64)
         .fetch_pool(&pool)
         .await?;
     println!("posts with views > 0: {}", popular.len());
 
     let by_known_authors: Vec<Post> = Post::objects()
-        .filter(
+        .filter_op(
             "author_id",
             Op::In,
             SqlValue::List(vec![SqlValue::I64(alice_id), SqlValue::I64(bob_id)]),
@@ -175,20 +175,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("posts by Alice or Bob: {}", by_known_authors.len());
 
     let titles_with_pks: Vec<Post> = Post::objects()
-        .filter("title", Op::Like, "%PKs%")
+        .filter_op("title", Op::Like, "%PKs%")
         .fetch_pool(&pool)
         .await?;
     println!("LIKE '%PKs%': {}", titles_with_pks.len());
 
     // ILIKE — translated to LOWER(col) LIKE LOWER(?) on SQLite.
     let titles_ilike: Vec<Post> = Post::objects()
-        .filter("title", Op::ILike, "%hello%")
+        .filter_op("title", Op::ILike, "%hello%")
         .fetch_pool(&pool)
         .await?;
     println!("ILIKE '%hello%': {}", titles_ilike.len());
 
     let mid_views: Vec<Post> = Post::objects()
-        .filter(
+        .filter_op(
             "views",
             Op::Between,
             SqlValue::List(vec![SqlValue::I64(1), SqlValue::I64(50)]),
@@ -225,7 +225,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     first.views = 999;
     first.save_pool(&pool).await?;
     let refetched: Post = QuerySet::<Post>::new()
-        .filter("id", Op::Eq, *first.id.get().unwrap())
+        .filter_op("id", Op::Eq, *first.id.get().unwrap())
         .fetch_pool(&pool)
         .await?
         .pop()
@@ -255,7 +255,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tx.commit().await?;
     }
     let alice_after: Author = QuerySet::<Author>::new()
-        .filter("id", Op::Eq, alice_id)
+        .filter_op("id", Op::Eq, alice_id)
         .fetch_pool(&pool)
         .await?
         .pop()
@@ -313,7 +313,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("\n== 12. delete_pool removes a row ==");
     let doomed = Post::objects()
-        .filter("title", Op::Eq, "Draft")
+        .filter_op("title", Op::Eq, "Draft")
         .fetch_pool(&pool)
         .await?
         .pop()

--- a/crates/rustango/src/admin/urls.rs
+++ b/crates/rustango/src/admin/urls.rs
@@ -45,7 +45,7 @@ pub type AdminActionFuture<'a> = Pin<Box<dyn Future<Output = Result<(), AdminErr
 ///     Box::pin(async move {
 ///         use rustango::sql::{UpdaterPool as _, Pool};
 ///         Post::objects()
-///             .filter("id", rustango::core::Op::In, pks.into())
+///             .filter_op("id", rustango::core::Op::In, pks.into())
 ///             .update()
 ///             .set("published_at", chrono::Utc::now())
 ///             .execute_pool(pool)

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -115,12 +115,12 @@ impl ContentType {
         model_name: &str,
     ) -> Result<Option<Self>, ExecError> {
         let rows: Vec<Self> = Self::objects()
-            .filter(
+            .filter_op(
                 "app_label",
                 crate::core::Op::Eq,
                 SqlValue::String(app_label.into()),
             )
-            .filter(
+            .filter_op(
                 "model_name",
                 crate::core::Op::Eq,
                 SqlValue::String(model_name.into()),
@@ -138,7 +138,7 @@ impl ContentType {
     /// As [`Self::for_model`].
     pub async fn by_id(pool: &PgPool, id: i64) -> Result<Option<Self>, ExecError> {
         let rows: Vec<Self> = Self::objects()
-            .filter("id", crate::core::Op::Eq, SqlValue::I64(id))
+            .filter_op("id", crate::core::Op::Eq, SqlValue::I64(id))
             .limit(1)
             .fetch(pool)
             .await?;
@@ -178,12 +178,12 @@ impl ContentType {
         model_name: &str,
     ) -> Result<Option<Self>, ExecError> {
         let rows: Vec<Self> = Self::objects()
-            .filter(
+            .filter_op(
                 "app_label",
                 crate::core::Op::Eq,
                 SqlValue::String(app_label.into()),
             )
-            .filter(
+            .filter_op(
                 "model_name",
                 crate::core::Op::Eq,
                 SqlValue::String(model_name.into()),
@@ -201,7 +201,7 @@ impl ContentType {
     /// As [`Self::for_model`].
     pub async fn by_id_pool(pool: &crate::sql::Pool, id: i64) -> Result<Option<Self>, ExecError> {
         let rows: Vec<Self> = Self::objects()
-            .filter("id", crate::core::Op::Eq, SqlValue::I64(id))
+            .filter_op("id", crate::core::Op::Eq, SqlValue::I64(id))
             .limit(1)
             .fetch_pool(pool)
             .await?;
@@ -662,7 +662,7 @@ where
         .map(crate::core::SqlValue::I64)
         .collect();
     let children: Vec<C> = crate::query::QuerySet::<C>::new()
-        .filter(
+        .filter_op(
             target_fk_column,
             crate::core::Op::In,
             crate::core::SqlValue::List(pk_values),
@@ -760,7 +760,7 @@ where
             table: C::SCHEMA.table,
         })?;
     let rows: Vec<C> = crate::query::QuerySet::<C>::new()
-        .filter(
+        .filter_op(
             pk_field.column,
             crate::core::Op::In,
             crate::core::SqlValue::List(pk_values),
@@ -821,7 +821,7 @@ where
         .map(crate::core::SqlValue::I64)
         .collect();
     let children: Vec<C> = crate::query::QuerySet::<C>::new()
-        .filter(
+        .filter_op(
             target_fk_column,
             crate::core::Op::In,
             crate::core::SqlValue::List(pk_values),
@@ -899,7 +899,7 @@ where
             table: C::SCHEMA.table,
         })?;
     let rows: Vec<C> = crate::query::QuerySet::<C>::new()
-        .filter(
+        .filter_op(
             pk_field.column,
             crate::core::Op::In,
             crate::core::SqlValue::List(pk_values),

--- a/crates/rustango/src/core/error.rs
+++ b/crates/rustango/src/core/error.rs
@@ -96,4 +96,21 @@ pub enum QueryError {
         expected: &'static str,
         actual: &'static str,
     },
+
+    /// `.values(cols)` was called without a subsequent aggregating
+    /// `.annotate(name, ...)`. Issue #75 v1 supports `.values()` only
+    /// as a GROUP BY hint paired with an aggregate annotation; pure
+    /// projection (returning `Vec<HashMap<String, SqlValue>>` with
+    /// only the requested columns) needs a separate writer path and
+    /// is queued for a follow-up. Until then, use the typed
+    /// `QuerySet::fetch(...)` path to read whole rows, or build an
+    /// `AggregateQuery` directly if you need a custom SELECT shape.
+    #[error(
+        "AggregateBuilder::values({cols:?}) requires at least one \
+         aggregating annotation (Count / Sum / Avg / Max / Min / \
+         StdDev / Variance). Pure projection without GROUP BY is not \
+         supported yet; chain `.annotate(\"alias\", aggregate)` or \
+         use `QuerySet::fetch` instead."
+    )]
+    ValuesRequiresAggregate { cols: Vec<&'static str> },
 }

--- a/crates/rustango/src/core/error.rs
+++ b/crates/rustango/src/core/error.rs
@@ -65,4 +65,35 @@ pub enum QueryError {
          `AggregateBuilder::having`."
     )]
     HavingOpNotSupported { alias: String, op: super::Op },
+
+    /// Django-shape `.filter("field__lookup", value)` got a lookup
+    /// suffix the parser doesn't recognize. Issue #71. The supported
+    /// set (exact / iexact / contains / icontains / startswith /
+    /// istartswith / endswith / iendswith / gt / gte / lt / lte / ne
+    /// / in / isnull / between / range) is documented on
+    /// [`crate::query::QuerySet::filter`]. Chained lookups
+    /// (`author__name__icontains`) aren't supported in v1.
+    #[error(
+        "unknown lookup suffix `__{suffix}` on field `{field}` — \
+         supported: exact, iexact, contains, icontains, startswith, \
+         istartswith, endswith, iendswith, gt, gte, lt, lte, ne, in, \
+         isnull, between, range"
+    )]
+    UnknownLookup { field: String, suffix: String },
+
+    /// Django-shape `.filter("field__lookup", value)` got a value
+    /// whose shape doesn't fit the chosen lookup. Issue #71.
+    /// Examples: `__in` with a non-list, `__isnull` with a
+    /// non-bool, `__between` with a list that isn't exactly 2
+    /// elements.
+    #[error(
+        "lookup `__{suffix}` on field `{field}` requires {expected}; \
+         got a value of shape {actual}"
+    )]
+    InvalidLookupValue {
+        field: String,
+        suffix: String,
+        expected: &'static str,
+        actual: &'static str,
+    },
 }

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -914,6 +914,35 @@ pub enum AggregateExpr {
     Window(Box<super::window::WindowExpr>),
 }
 
+impl AggregateExpr {
+    /// Whether this annotation actually aggregates rows (and therefore
+    /// triggers GROUP BY auto-inference, issue #75).
+    ///
+    /// - `Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` /
+    ///   `StdDev*` / `Variance*` → **aggregating** (collapses rows).
+    /// - `Window` → **not aggregating** (per-row computation over a frame).
+    /// - `Filtered { inner }` / `Coalesced { inner }` → recurse on `inner`.
+    #[must_use]
+    pub fn is_aggregating(&self) -> bool {
+        match self {
+            AggregateExpr::Count(_)
+            | AggregateExpr::CountDistinct(_)
+            | AggregateExpr::Sum(_)
+            | AggregateExpr::Avg(_)
+            | AggregateExpr::Max(_)
+            | AggregateExpr::Min(_)
+            | AggregateExpr::StdDev(_)
+            | AggregateExpr::StdDevPop(_)
+            | AggregateExpr::Variance(_)
+            | AggregateExpr::VariancePop(_) => true,
+            AggregateExpr::Window(_) => false,
+            AggregateExpr::Filtered { inner, .. } | AggregateExpr::Coalesced { inner, .. } => {
+                inner.is_aggregating()
+            }
+        }
+    }
+}
+
 /// A `SELECT … GROUP BY … HAVING …` query. Returned rows are untyped
 /// (`HashMap<String, SqlValue>`) because the projection is dynamic.
 ///

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -574,6 +574,13 @@ impl<T: Model> QuerySet<T> {
     /// Start an [`AggregateBuilder`] carrying this queryset's filters as the
     /// WHERE clause. Chain `.group_by`, `.annotate`, `.having`, `.order_by`,
     /// `.limit`, `.offset` then call `.compile()` to get an [`AggregateQuery`].
+    ///
+    /// This is the rustango-native (non-Django-shape) entry point — the
+    /// builder it returns does **not** trigger Shape 3 GROUP BY auto-inference
+    /// at compile time. `.aggregate().annotate(agg)` without an explicit
+    /// `.group_by(...)` stays a scalar single-row aggregate, mirroring
+    /// Django's terminal `aggregate()` distinct from per-row `.annotate(...)`.
+    /// Use [`Self::annotate`] / [`Self::values`] for the auto-inferring path.
     #[must_use]
     pub fn aggregate(self) -> AggregateBuilder<T> {
         AggregateBuilder {
@@ -586,6 +593,7 @@ impl<T: Model> QuerySet<T> {
             offset: None,
             deferred_error: None,
             values: None,
+            django_shape: false,
         }
     }
 
@@ -619,6 +627,7 @@ impl<T: Model> QuerySet<T> {
             offset: None,
             deferred_error: None,
             values: Some(columns.to_vec()),
+            django_shape: true,
         }
     }
 
@@ -638,7 +647,9 @@ impl<T: Model> QuerySet<T> {
     /// ```
     #[must_use]
     pub fn annotate(self, alias: &'static str, expr: AggregateExpr) -> AggregateBuilder<T> {
-        self.aggregate().annotate(alias, expr)
+        let mut b = self.aggregate();
+        b.django_shape = true;
+        b.annotate(alias, expr)
     }
 }
 
@@ -1199,10 +1210,21 @@ pub struct AggregateBuilder<T: Model> {
     /// Issue #75 — projection columns set via [`Self::values`] (or
     /// [`QuerySet::values`]). When `Some(cols)` and the user hasn't
     /// called `.group_by(...)` explicitly, `compile()` derives
-    /// `GROUP BY cols`. When `None` and an aggregating annotation is
-    /// present, `compile()` falls back to Django Shape 3 — `GROUP BY`
-    /// every non-aggregate scalar column on the model.
+    /// `GROUP BY cols`.
     values: Option<Vec<&'static str>>,
+    /// Issue #75 — `true` when the builder was constructed via the
+    /// Django-shape entries [`QuerySet::annotate`] / [`QuerySet::values`]
+    /// (or after [`Self::values`] is called mid-chain). Only then does
+    /// `compile()` apply **Shape 3** auto-inference — `GROUP BY` every
+    /// non-aggregate scalar column when no group_by / values are set
+    /// and an aggregating annotation is present.
+    ///
+    /// `false` when constructed via the rustango-native
+    /// [`QuerySet::aggregate`] entry. That path preserves the historical
+    /// "no group_by → no `GROUP BY` clause → scalar single-row aggregate"
+    /// semantic, which mirrors Django's distinction between
+    /// `.aggregate()` (terminal scalar) and `.annotate()` (per-row).
+    django_shape: bool,
 }
 
 impl<T: Model> AggregateBuilder<T> {
@@ -1224,6 +1246,12 @@ impl<T: Model> AggregateBuilder<T> {
     #[must_use]
     pub fn values(mut self, columns: &[&'static str]) -> Self {
         self.values = Some(columns.to_vec());
+        // Calling `.values(...)` mid-chain opts the builder into the
+        // Django-shape inference path (issue #75) — without this flip,
+        // a `.aggregate().values(cols).annotate(agg)` chain would still
+        // emit a scalar query because `.aggregate()` started with
+        // `django_shape = false`.
+        self.django_shape = true;
         self
     }
 
@@ -1432,14 +1460,19 @@ impl<T: Model> AggregateBuilder<T> {
                 }
             }
             cols.clone()
-        } else if has_aggregating {
+        } else if has_aggregating && self.django_shape {
             // Shape 3 — group by every scalar column on the model.
             // Mirrors Django's "implicit GROUP BY all selected
-            // non-aggregate columns".
+            // non-aggregate columns". Gated on `django_shape` so the
+            // rustango-native `.aggregate().annotate(agg)` path stays
+            // a scalar single-row aggregate (the historical semantic
+            // every pre-#75 test relied on).
             model.scalar_fields().map(|f| f.column).collect()
         } else {
-            // No aggregating annotation, no values — pure window
-            // annotation path (issue #7) or empty builder. No GROUP BY.
+            // No GROUP BY — either:
+            //   * `.aggregate().annotate(agg)` (scalar aggregate)
+            //   * pure window-only annotation (issue #7)
+            //   * empty builder
             Vec::new()
         };
 

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -83,6 +83,11 @@ enum PendingFilter {
     /// typed-column API). Already validated; contributes a whole
     /// sub-tree to the WHERE clause.
     Expr(WhereExpr),
+    /// Deferred error surfaced at `compile()` time. Used by
+    /// [`QuerySet::filter`] (issue #71) when the lookup-suffix
+    /// parser fails — keeps the builder API non-Result while
+    /// surfacing the cause at the natural error-checking point.
+    Error(QueryError),
 }
 
 #[derive(Debug, Clone)]
@@ -386,12 +391,21 @@ impl<T: Model> QuerySet<T> {
         self
     }
 
-    /// Append a `WHERE field <op> value` predicate.
+    /// Append a `WHERE field <op> value` predicate using the
+    /// **explicit-op** shape. This is the lower-level form used by
+    /// callers that already know which `Op` they want; for the
+    /// Django muscle-memory `filter("field__lookup", value)` shape
+    /// see [`Self::filter`] (issue #71).
     ///
-    /// `field` is the Rust-side field name; the column is looked up from the
-    /// schema at compile time.
+    /// `field` is the Rust-side field name; the column is looked up
+    /// from the schema at compile time.
     #[must_use]
-    pub fn filter(mut self, field: impl Into<String>, op: Op, value: impl Into<SqlValue>) -> Self {
+    pub fn filter_op(
+        mut self,
+        field: impl Into<String>,
+        op: Op,
+        value: impl Into<SqlValue>,
+    ) -> Self {
         self.pending.push(PendingFilter::Raw(RawFilter {
             field: field.into(),
             op,
@@ -400,10 +414,68 @@ impl<T: Model> QuerySet<T> {
         self
     }
 
-    /// Sugar for `filter(field, Op::Eq, value)`.
+    /// Django-shape `filter()` — parses a `"field"` or
+    /// `"field__lookup"` key and dispatches to the matching `Op`.
+    /// Issue #71.
+    ///
+    /// | Suffix | SQL | Value treatment |
+    /// |---|---|---|
+    /// | (none) / `__exact` | `<col> = ?` | as-is |
+    /// | `__iexact` | `<col> ILIKE ?` | as-is (no wildcards) |
+    /// | `__contains` | `<col> LIKE ?` | wrap `%value%` |
+    /// | `__icontains` | `<col> ILIKE ?` | wrap `%value%` |
+    /// | `__startswith` | `<col> LIKE ?` | wrap `value%` |
+    /// | `__istartswith` | `<col> ILIKE ?` | wrap `value%` |
+    /// | `__endswith` | `<col> LIKE ?` | wrap `%value` |
+    /// | `__iendswith` | `<col> ILIKE ?` | wrap `%value` |
+    /// | `__gt` / `__gte` / `__lt` / `__lte` | direct map | as-is |
+    /// | `__ne` | `<col> <> ?` | as-is |
+    /// | `__in` | `<col> IN (...)` | value must be `SqlValue::List` |
+    /// | `__isnull` | `<col> IS NULL` / `IS NOT NULL` | value must be `bool` |
+    /// | `__between` / `__range` | `<col> BETWEEN ? AND ?` | value must be 2-element `SqlValue::List` |
+    ///
+    /// ```ignore
+    /// Post::objects()
+    ///     .filter("title__icontains", "rust")
+    ///     .filter("views__gt", 100_i64)
+    ///     .filter("author_id__in", rustango::core::SqlValue::List(vec![
+    ///         1_i64.into(), 2_i64.into(), 3_i64.into(),
+    ///     ]))
+    ///     .fetch(&pool).await?;
+    /// ```
+    ///
+    /// Unknown suffixes surface as [`QueryError::UnknownLookup`] at
+    /// `compile()`. Value-shape mismatches (e.g. `__in` with a
+    /// non-list value) surface as
+    /// [`QueryError::InvalidLookupValue`].
+    ///
+    /// **Chained lookups** (`author__name__icontains`) are out of
+    /// scope — that's join-traversal territory (`select_related` /
+    /// `prefetch_related`). v1 supports single-table fields only.
+    #[must_use]
+    pub fn filter(self, key: &str, value: impl Into<SqlValue>) -> Self {
+        let raw = value.into();
+        match parse_lookup(key, raw) {
+            Ok((field, op, parsed_value)) => self.filter_op(field, op, parsed_value),
+            Err(e) => self.with_pending_error(e),
+        }
+    }
+
+    /// Stash a builder-time error to surface at `compile()` time.
+    /// Used by [`Self::filter`] when the lookup-suffix parser fails.
+    fn with_pending_error(mut self, e: QueryError) -> Self {
+        // Add a `PendingFilter::Error` so `compile()`'s
+        // `resolve_pending` walk surfaces it. Mirrors the deferred-
+        // error pattern in `AggregateBuilder` for `HavingOpNotSupported`.
+        self.pending.push(PendingFilter::Error(e));
+        self
+    }
+
+    /// Sugar for `filter_op(field, Op::Eq, value)`. Kept for
+    /// backward compatibility with the per-op shorthand surface.
     #[must_use]
     pub fn eq(self, field: impl Into<String>, value: impl Into<SqlValue>) -> Self {
-        self.filter(field, Op::Eq, value)
+        self.filter_op(field, Op::Eq, value)
     }
 
     /// Append a typed predicate or boolean expression built via the
@@ -714,6 +786,154 @@ fn lower_select_related(
     Ok(out)
 }
 
+/// Parse a Django-shape `"field"` or `"field__suffix"` key + raw
+/// value into the matching `(field, Op, transformed_value)` triple.
+/// Issue #71.
+///
+/// The suffix table is documented on [`QuerySet::filter`]. Failures:
+///
+/// - Unknown `__suffix` → [`QueryError::UnknownLookup`].
+/// - Value-shape mismatch for `__in` / `__isnull` / `__between` /
+///   `__range` → [`QueryError::InvalidLookupValue`].
+///
+/// Chained lookups (`a__b__icontains`) are NOT decomposed in v1 — the
+/// FIRST `__` splits field from suffix, anything after stays as part
+/// of the suffix and errors as `UnknownLookup`.
+fn parse_lookup(key: &str, value: SqlValue) -> Result<(String, Op, SqlValue), QueryError> {
+    // Bare field (no `__`) → exact match.
+    let Some(split_at) = key.find("__") else {
+        return Ok((key.to_owned(), Op::Eq, value));
+    };
+    let field = key[..split_at].to_owned();
+    let suffix = &key[split_at + 2..];
+
+    match suffix {
+        "exact" => Ok((field, Op::Eq, value)),
+        "ne" => Ok((field, Op::Ne, value)),
+        "gt" => Ok((field, Op::Gt, value)),
+        "gte" => Ok((field, Op::Gte, value)),
+        "lt" => Ok((field, Op::Lt, value)),
+        "lte" => Ok((field, Op::Lte, value)),
+        "iexact" => Ok((field, Op::ILike, value)),
+        "contains" => {
+            let v = wrap_like(&value, "%", "%", &field, suffix)?;
+            Ok((field, Op::Like, v))
+        }
+        "icontains" => {
+            let v = wrap_like(&value, "%", "%", &field, suffix)?;
+            Ok((field, Op::ILike, v))
+        }
+        "startswith" => {
+            let v = wrap_like(&value, "", "%", &field, suffix)?;
+            Ok((field, Op::Like, v))
+        }
+        "istartswith" => {
+            let v = wrap_like(&value, "", "%", &field, suffix)?;
+            Ok((field, Op::ILike, v))
+        }
+        "endswith" => {
+            let v = wrap_like(&value, "%", "", &field, suffix)?;
+            Ok((field, Op::Like, v))
+        }
+        "iendswith" => {
+            let v = wrap_like(&value, "%", "", &field, suffix)?;
+            Ok((field, Op::ILike, v))
+        }
+        "in" => {
+            if !matches!(value, SqlValue::List(_)) {
+                return Err(QueryError::InvalidLookupValue {
+                    field,
+                    suffix: suffix.to_owned(),
+                    expected: "SqlValue::List(...)",
+                    actual: sql_value_shape_name(&value),
+                });
+            }
+            Ok((field, Op::In, value))
+        }
+        "isnull" => {
+            if !matches!(value, SqlValue::Bool(_)) {
+                return Err(QueryError::InvalidLookupValue {
+                    field,
+                    suffix: suffix.to_owned(),
+                    expected: "SqlValue::Bool(true|false)",
+                    actual: sql_value_shape_name(&value),
+                });
+            }
+            Ok((field, Op::IsNull, value))
+        }
+        "between" | "range" => {
+            match &value {
+                SqlValue::List(items) if items.len() == 2 => {}
+                SqlValue::List(_) => {
+                    return Err(QueryError::InvalidLookupValue {
+                        field,
+                        suffix: suffix.to_owned(),
+                        expected: "SqlValue::List with exactly 2 elements [lo, hi]",
+                        actual: "SqlValue::List with wrong arity",
+                    });
+                }
+                other => {
+                    return Err(QueryError::InvalidLookupValue {
+                        field,
+                        suffix: suffix.to_owned(),
+                        expected: "SqlValue::List([lo, hi])",
+                        actual: sql_value_shape_name(other),
+                    });
+                }
+            }
+            Ok((field, Op::Between, value))
+        }
+        unknown => Err(QueryError::UnknownLookup {
+            field,
+            suffix: unknown.to_owned(),
+        }),
+    }
+}
+
+/// Wrap a `SqlValue::String` with leading/trailing wildcard tokens
+/// for `__contains` / `__startswith` / `__endswith` and their `i*`
+/// case-insensitive variants. Issue #71.
+///
+/// Non-string values are rejected with [`QueryError::InvalidLookupValue`]
+/// — LIKE patterns require text input.
+fn wrap_like(
+    value: &SqlValue,
+    prefix: &str,
+    suffix_char: &str,
+    field: &str,
+    suffix: &str,
+) -> Result<SqlValue, QueryError> {
+    let s = match value {
+        SqlValue::String(s) => s,
+        other => {
+            return Err(QueryError::InvalidLookupValue {
+                field: field.to_owned(),
+                suffix: suffix.to_owned(),
+                expected: "SqlValue::String(...)",
+                actual: sql_value_shape_name(other),
+            });
+        }
+    };
+    Ok(SqlValue::String(format!("{prefix}{s}{suffix_char}")))
+}
+
+/// Human-readable shape name for an `SqlValue` — used in
+/// [`QueryError::InvalidLookupValue`] messages.
+fn sql_value_shape_name(v: &SqlValue) -> &'static str {
+    match v {
+        SqlValue::Null => "SqlValue::Null",
+        SqlValue::I16(_) => "SqlValue::I16",
+        SqlValue::I32(_) => "SqlValue::I32",
+        SqlValue::I64(_) => "SqlValue::I64",
+        SqlValue::F32(_) => "SqlValue::F32",
+        SqlValue::F64(_) => "SqlValue::F64",
+        SqlValue::Bool(_) => "SqlValue::Bool",
+        SqlValue::String(_) => "SqlValue::String",
+        SqlValue::List(_) => "SqlValue::List",
+        _ => "SqlValue::<other>",
+    }
+}
+
 fn resolve_pending(
     model: &'static ModelSchema,
     pending: Vec<PendingFilter>,
@@ -729,6 +949,11 @@ fn resolve_pending(
             }
             PendingFilter::Expr(expr) => {
                 nodes.push(expr);
+            }
+            PendingFilter::Error(e) => {
+                // Issue #71 — bubble the deferred lookup-parse error
+                // up at the natural `compile()` checkpoint.
+                return Err(e);
             }
         }
     }
@@ -1033,7 +1258,7 @@ impl<T: Model> AggregateBuilder<T> {
             // Forward to the underlying QuerySet's WHERE path. Same
             // schema-validation rules apply at `resolve_pending` time
             // — typo'd model columns get caught at `compile()`.
-            self.qs = self.qs.filter(field, op, value);
+            self.qs = self.qs.filter_op(field, op, value);
         }
         self
     }

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -585,7 +585,60 @@ impl<T: Model> QuerySet<T> {
             limit: None,
             offset: None,
             deferred_error: None,
+            values: None,
         }
+    }
+
+    /// Django-shape `.values(&[...]).annotate(...)` projection — issue #75.
+    ///
+    /// Switches the queryset into aggregate mode and records the projection
+    /// columns. When followed by `.annotate("alias", aggregate)`, the writer
+    /// emits `SELECT cols, AGGR(...) FROM t GROUP BY cols` — GROUP BY is
+    /// inferred from the values list.
+    ///
+    /// ```ignore
+    /// // "Posts per author" — Django's canonical example.
+    /// Post::objects()
+    ///     .values(&["author_id"])
+    ///     .annotate("n", count_all().into())
+    ///     .compile()?;
+    /// // → SELECT "author_id", COUNT(*) AS "n" FROM "post" GROUP BY "author_id"
+    /// ```
+    ///
+    /// Calling `.values()` without a subsequent aggregating `.annotate(...)`
+    /// is a pure projection (no GROUP BY emitted).
+    #[must_use]
+    pub fn values(self, columns: &[&'static str]) -> AggregateBuilder<T> {
+        AggregateBuilder {
+            qs: self,
+            group_by: Vec::new(),
+            aggregates: Vec::new(),
+            having: None,
+            order_by: Vec::new(),
+            limit: None,
+            offset: None,
+            deferred_error: None,
+            values: Some(columns.to_vec()),
+        }
+    }
+
+    /// Django-shape `.annotate(...)` without explicit `.aggregate()` — issue #75.
+    ///
+    /// Promotes to an [`AggregateBuilder`]. If the annotation aggregates rows
+    /// (`Count`, `Sum`, `Avg`, …) and `.values()` wasn't called, `compile()`
+    /// auto-populates GROUP BY with every non-aggregate scalar column on the
+    /// model (Django Shape 3 — "per-row count of children").
+    ///
+    /// ```ignore
+    /// // "Each author + their post count" — every column of `Author`
+    /// // ends up in the SELECT list AND in GROUP BY.
+    /// Author::objects()
+    ///     .annotate("post_count", count_all().into())
+    ///     .compile()?;
+    /// ```
+    #[must_use]
+    pub fn annotate(self, alias: &'static str, expr: AggregateExpr) -> AggregateBuilder<T> {
+        self.aggregate().annotate(alias, expr)
     }
 }
 
@@ -1143,13 +1196,34 @@ pub struct AggregateBuilder<T: Model> {
     /// on first error; subsequent builder calls are no-ops so the
     /// original cause isn't masked. Surfaced from `compile()`.
     deferred_error: Option<crate::core::QueryError>,
+    /// Issue #75 — projection columns set via [`Self::values`] (or
+    /// [`QuerySet::values`]). When `Some(cols)` and the user hasn't
+    /// called `.group_by(...)` explicitly, `compile()` derives
+    /// `GROUP BY cols`. When `None` and an aggregating annotation is
+    /// present, `compile()` falls back to Django Shape 3 — `GROUP BY`
+    /// every non-aggregate scalar column on the model.
+    values: Option<Vec<&'static str>>,
 }
 
 impl<T: Model> AggregateBuilder<T> {
     /// Add a `GROUP BY` column. Call multiple times to group by multiple columns.
+    ///
+    /// Explicit `.group_by(...)` calls always win — when paired with
+    /// [`Self::values`] / [`QuerySet::values`], the explicit list is what
+    /// reaches the writer; the values list still drives the projection
+    /// SELECT list (issue #75).
     #[must_use]
     pub fn group_by(mut self, column: &'static str) -> Self {
         self.group_by.push(column);
+        self
+    }
+
+    /// Set the projection column list — same semantic as
+    /// [`QuerySet::values`] but available mid-chain when you started
+    /// from `.aggregate()` rather than `.values(...)`. Issue #75.
+    #[must_use]
+    pub fn values(mut self, columns: &[&'static str]) -> Self {
+        self.values = Some(columns.to_vec());
         self
     }
 
@@ -1287,7 +1361,22 @@ impl<T: Model> AggregateBuilder<T> {
     /// Compile to an [`AggregateQuery`] IR.
     ///
     /// # Errors
-    /// Returns [`QueryError`] if any filter or having clause names an unknown field.
+    /// Returns [`QueryError`] if any filter or having clause names an
+    /// unknown field, or if `.values()` was called without a
+    /// subsequent aggregating `.annotate(...)`.
+    ///
+    /// # GROUP BY inference (issue #75)
+    ///
+    /// When the user hasn't called `.group_by(...)` explicitly, the
+    /// builder fills it in:
+    ///
+    /// * `.values(cols).annotate(agg)` → `GROUP BY cols` (Django Shape 2).
+    /// * `.annotate(agg)` (no values) → `GROUP BY` every non-aggregate
+    ///   scalar column on the model (Django Shape 3).
+    /// * `.annotate(window)` only → no GROUP BY (window functions are
+    ///   per-row).
+    ///
+    /// Explicit `.group_by(...)` always wins.
     pub fn compile(self) -> Result<AggregateQuery, QueryError> {
         // Surface any builder-time deferred error first (e.g. an
         // `Op::In` against an annotation alias) so the user sees the
@@ -1310,10 +1399,54 @@ impl<T: Model> AggregateBuilder<T> {
             .into_iter()
             .map(|(col, desc)| crate::core::OrderItem::column(col, desc))
             .collect();
+
+        // Issue #75 — GROUP BY auto-inference.
+        let has_aggregating = self.aggregates.iter().any(|(_, e)| e.is_aggregating());
+        let group_by = if !self.group_by.is_empty() {
+            // Explicit `.group_by(...)` always wins. Validate columns
+            // belong to the model (caught early — typos otherwise
+            // surface at the DB).
+            for col in &self.group_by {
+                if model.field_by_column(col).is_none() {
+                    return Err(QueryError::UnknownField {
+                        model: model.name,
+                        field: (*col).to_owned(),
+                    });
+                }
+            }
+            self.group_by
+        } else if let Some(cols) = self.values.as_ref() {
+            // `.values(cols)` set. Without an aggregating annotation
+            // we'd produce a degenerate `SELECT cols GROUP BY cols`
+            // (distinct-projection) — refuse and point the user at
+            // the right path for pure projection.
+            if !has_aggregating {
+                return Err(QueryError::ValuesRequiresAggregate { cols: cols.clone() });
+            }
+            for col in cols {
+                if model.field_by_column(col).is_none() {
+                    return Err(QueryError::UnknownField {
+                        model: model.name,
+                        field: (*col).to_owned(),
+                    });
+                }
+            }
+            cols.clone()
+        } else if has_aggregating {
+            // Shape 3 — group by every scalar column on the model.
+            // Mirrors Django's "implicit GROUP BY all selected
+            // non-aggregate columns".
+            model.scalar_fields().map(|f| f.column).collect()
+        } else {
+            // No aggregating annotation, no values — pure window
+            // annotation path (issue #7) or empty builder. No GROUP BY.
+            Vec::new()
+        };
+
         Ok(AggregateQuery {
             model,
             where_clause,
-            group_by: self.group_by,
+            group_by,
             aggregates: self.aggregates,
             having: self.having,
             order_by,

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -1185,7 +1185,7 @@ where
     // Batch-fetch the children where their FK column points at any
     // of the parent PKs.
     let children: Vec<C> = crate::query::QuerySet::<C>::new()
-        .filter(
+        .filter_op(
             child_fk_column,
             crate::core::Op::In,
             crate::core::SqlValue::List(parent_pks),
@@ -3012,7 +3012,7 @@ where
     }
 
     let children: Vec<C> = crate::query::QuerySet::<C>::new()
-        .filter(
+        .filter_op(
             child_fk_column,
             crate::core::Op::In,
             crate::core::SqlValue::List(parent_pks),
@@ -3313,7 +3313,7 @@ where
 ///
 /// ```ignore
 /// let (post, created) = rustango::sql::get_or_create_pool(
-///     Post::objects().filter("slug", Op::Eq, "hello"),
+///     Post::objects().filter("slug", "hello"),
 ///     |pool| async move {
 ///         let mut p = Post {
 ///             id: Auto::Unset,
@@ -3378,7 +3378,7 @@ where
 ///
 /// ```ignore
 /// let (post, created) = rustango::sql::update_or_create_pool(
-///     Post::objects().filter("slug", Op::Eq, "hello"),
+///     Post::objects().filter("slug", "hello"),
 ///     |pool, mut existing| async move {
 ///         existing.title = "New title".into();
 ///         existing.save_pool(&pool).await?;

--- a/crates/rustango/src/sql/foreign_key.rs
+++ b/crates/rustango/src/sql/foreign_key.rs
@@ -299,7 +299,7 @@ where
                     table: T::SCHEMA.table,
                 })?;
             let mut rows: Vec<T> = QuerySet::<T>::new()
-                .filter(pk_field.column, Op::Eq, pk.clone())
+                .filter_op(pk_field.column, Op::Eq, pk.clone())
                 .fetch_on(executor)
                 .await?;
             let value = rows.pop().ok_or_else(|| {
@@ -368,7 +368,7 @@ where
                     table: T::SCHEMA.table,
                 })?;
             let mut rows: Vec<T> = QuerySet::<T>::new()
-                .filter(pk_field.column, Op::Eq, pk.clone())
+                .filter_op(pk_field.column, Op::Eq, pk.clone())
                 .fetch_pool(pool)
                 .await?;
             let value = rows.pop().ok_or_else(|| {

--- a/crates/rustango/tests/filter_lookup.rs
+++ b/crates/rustango/tests/filter_lookup.rs
@@ -1,0 +1,342 @@
+//! Tri-dialect emission tests for Django-shape `.filter("field__lookup", value)`
+//! (issue #71). The suffix parser is dialect-independent — these tests
+//! pin the SQL string + the placeholder dialect shape + the
+//! transformed-value (e.g. `%rust%` wrapping for `__icontains`).
+
+use rustango::core::SqlValue;
+use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "fl_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 200)]
+    title: String,
+    #[rustango(max_length = 20)]
+    status: String,
+    views: i64,
+    author_id: i64,
+    deleted_at: Option<i64>,
+}
+
+// ---------- Bare field = exact-eq ----------
+
+#[test]
+fn bare_field_is_exact_eq() {
+    let qs = Post::objects().filter("status", "draft");
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#"WHERE "status" = $1"#),
+        "bare field → Eq: {}",
+        stmt.sql
+    );
+    assert_eq!(stmt.params, vec![SqlValue::String("draft".into())]);
+}
+
+#[test]
+fn explicit_exact_suffix_is_eq() {
+    let qs = Post::objects().filter("status__exact", "draft");
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(stmt.sql.contains(r#"WHERE "status" = $1"#));
+}
+
+// ---------- Comparison suffixes ----------
+
+#[test]
+fn gt_gte_lt_lte_ne_map_directly() {
+    for (suffix, op_sql) in [
+        ("gt", " > "),
+        ("gte", " >= "),
+        ("lt", " < "),
+        ("lte", " <= "),
+        ("ne", " <> "),
+    ] {
+        let qs = Post::objects().filter(&format!("views__{suffix}"), 100_i64);
+        let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+        assert!(
+            stmt.sql.contains(&format!(r#""views"{op_sql}$1"#)),
+            "__{suffix} should emit {op_sql} — got {}",
+            stmt.sql
+        );
+    }
+}
+
+// ---------- LIKE wrappers ----------
+
+#[test]
+fn contains_wraps_value_in_percent() {
+    let qs = Post::objects().filter("title__contains", "rust");
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(stmt.sql.contains(r#""title" LIKE $1"#), "got: {}", stmt.sql);
+    assert_eq!(stmt.params, vec![SqlValue::String("%rust%".into())]);
+}
+
+#[test]
+fn icontains_uses_ilike_with_percent_wrap() {
+    let qs = Post::objects().filter("title__icontains", "rust");
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#""title" ILIKE $1"#),
+        "got: {}",
+        stmt.sql
+    );
+    assert_eq!(stmt.params, vec![SqlValue::String("%rust%".into())]);
+}
+
+#[test]
+fn startswith_wraps_value_with_trailing_percent_only() {
+    let qs = Post::objects().filter("title__startswith", "Hello");
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(stmt.sql.contains(r#""title" LIKE $1"#));
+    assert_eq!(stmt.params, vec![SqlValue::String("Hello%".into())]);
+}
+
+#[test]
+fn endswith_wraps_value_with_leading_percent_only() {
+    let qs = Post::objects().filter("title__endswith", "!");
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(stmt.sql.contains(r#""title" LIKE $1"#));
+    assert_eq!(stmt.params, vec![SqlValue::String("%!".into())]);
+}
+
+#[test]
+fn iexact_uses_ilike_without_wildcards() {
+    let qs = Post::objects().filter("title__iexact", "Hello World");
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(stmt.sql.contains(r#""title" ILIKE $1"#));
+    // No wildcard wrapping for iexact — exact case-insensitive match.
+    assert_eq!(stmt.params, vec![SqlValue::String("Hello World".into())]);
+}
+
+#[test]
+fn istartswith_iendswith_use_ilike() {
+    let qs = Post::objects()
+        .filter("title__istartswith", "Hello")
+        .filter("title__iendswith", "!");
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(stmt.sql.contains("ILIKE"));
+    assert_eq!(
+        stmt.params,
+        vec![
+            SqlValue::String("Hello%".into()),
+            SqlValue::String("%!".into()),
+        ]
+    );
+}
+
+// ---------- __in / __isnull / __between ----------
+
+#[test]
+fn in_emits_in_clause_with_list_value() {
+    let qs = Post::objects().filter(
+        "author_id__in",
+        SqlValue::List(vec![SqlValue::I64(1), SqlValue::I64(2), SqlValue::I64(3)]),
+    );
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#""author_id" IN ($1, $2, $3)"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn isnull_true_emits_is_null() {
+    let qs = Post::objects().filter("deleted_at__isnull", true);
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#""deleted_at" IS NULL"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn isnull_false_emits_is_not_null() {
+    let qs = Post::objects().filter("deleted_at__isnull", false);
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#""deleted_at" IS NOT NULL"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn between_emits_between_clause() {
+    let qs = Post::objects().filter(
+        "views__between",
+        SqlValue::List(vec![SqlValue::I64(10), SqlValue::I64(100)]),
+    );
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#""views" BETWEEN $1 AND $2"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn range_alias_emits_between_clause() {
+    // Django uses `__range`; rustango accepts both for ergonomics.
+    let qs = Post::objects().filter(
+        "views__range",
+        SqlValue::List(vec![SqlValue::I64(10), SqlValue::I64(100)]),
+    );
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(stmt.sql.contains(r#""views" BETWEEN $1 AND $2"#));
+}
+
+// ---------- Error paths ----------
+
+#[test]
+fn unknown_suffix_errors_at_compile() {
+    use rustango::core::QueryError;
+    let r = Post::objects().filter("status__nope", "draft").compile();
+    match r {
+        Err(QueryError::UnknownLookup { field, suffix }) => {
+            assert_eq!(field, "status");
+            assert_eq!(suffix, "nope");
+        }
+        other => panic!("expected UnknownLookup, got: {other:?}"),
+    }
+}
+
+#[test]
+fn chained_lookup_unknown_suffix_errors_at_compile() {
+    // `author__name__icontains` — v1 doesn't support join-traversal,
+    // so the suffix `"name__icontains"` is rejected as unknown.
+    use rustango::core::QueryError;
+    let r = Post::objects()
+        .filter("author__name__icontains", "alice")
+        .compile();
+    assert!(matches!(
+        r,
+        Err(QueryError::UnknownLookup { ref suffix, .. })
+            if suffix == "name__icontains"
+    ));
+}
+
+#[test]
+fn in_with_non_list_value_errors_at_compile() {
+    use rustango::core::QueryError;
+    let r = Post::objects()
+        .filter("author_id__in", 42_i64) // not a list
+        .compile();
+    assert!(matches!(
+        r,
+        Err(QueryError::InvalidLookupValue {
+            ref suffix,
+            ..
+        }) if suffix == "in"
+    ));
+}
+
+#[test]
+fn isnull_with_non_bool_errors_at_compile() {
+    use rustango::core::QueryError;
+    let r = Post::objects()
+        .filter("deleted_at__isnull", 0_i64) // not a bool
+        .compile();
+    assert!(matches!(
+        r,
+        Err(QueryError::InvalidLookupValue {
+            ref suffix,
+            ..
+        }) if suffix == "isnull"
+    ));
+}
+
+#[test]
+fn between_with_wrong_arity_errors_at_compile() {
+    use rustango::core::QueryError;
+    let r = Post::objects()
+        .filter(
+            "views__between",
+            SqlValue::List(vec![SqlValue::I64(1)]), // only 1 element
+        )
+        .compile();
+    assert!(matches!(
+        r,
+        Err(QueryError::InvalidLookupValue {
+            ref suffix,
+            ..
+        }) if suffix == "between"
+    ));
+}
+
+#[test]
+fn contains_with_non_string_value_errors_at_compile() {
+    use rustango::core::QueryError;
+    let r = Post::objects()
+        .filter("title__contains", 42_i64) // LIKE requires String
+        .compile();
+    assert!(matches!(
+        r,
+        Err(QueryError::InvalidLookupValue {
+            ref suffix,
+            ..
+        }) if suffix == "contains"
+    ));
+}
+
+#[test]
+fn unknown_field_errors_at_compile() {
+    use rustango::core::QueryError;
+    let r = Post::objects().filter("nope_field__eq", "x").compile();
+    // Filter through to where_clause; resolve_pending catches it.
+    assert!(matches!(
+        r,
+        Err(QueryError::UnknownLookup { ref suffix, .. }) if suffix == "eq"
+    ));
+    // (NB: `__eq` isn't in the supported set — Django doesn't have
+    // `__eq`, only `__exact`. Document this in the cookbook.)
+}
+
+// ---------- Multiple filters AND-join ----------
+
+#[test]
+fn multiple_filters_compose_into_and_chain() {
+    let qs = Post::objects()
+        .filter("status", "published")
+        .filter("views__gt", 100_i64)
+        .filter("title__icontains", "rust");
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#""status" = $1"#)
+            && stmt.sql.contains(r#""views" > $2"#)
+            && stmt.sql.contains(r#""title" ILIKE $3"#)
+            && stmt.sql.contains(" AND "),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Tri-dialect ident-quote shapes ----------
+
+#[test]
+fn mysql_uses_backticks_for_filter_columns() {
+    let qs = Post::objects().filter("title__icontains", "rust");
+    let stmt = MySql.compile_select(&qs.compile().unwrap()).unwrap();
+    // MySQL has no native ILIKE; the writer routes through
+    // dialect.write_ilike which emulates with LOWER().
+    assert!(
+        stmt.sql.contains("`title`") || stmt.sql.contains("LOWER(`title`)"),
+        "MySQL backticks: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn sqlite_keeps_double_quotes_for_filter_columns() {
+    let qs = Post::objects().filter("title__contains", "rust");
+    let stmt = Sqlite.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#""title" LIKE ?"#),
+        "SQLite shape: {}",
+        stmt.sql
+    );
+}

--- a/crates/rustango/tests/filter_lookup_live.rs
+++ b/crates/rustango/tests/filter_lookup_live.rs
@@ -1,0 +1,281 @@
+#![cfg(feature = "postgres")]
+//! Live PG end-to-end sanity test for Django-shape `.filter("field__lookup", value)`
+//! (issue #71). Emission already covered by [`filter_lookup.rs`]; this file
+//! proves that each major suffix family actually round-trips against a real
+//! Postgres backend.
+//!
+//! Skips silently when `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::core::SqlValue;
+use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "fll_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 20)]
+    pub status: String,
+    pub views: i64,
+    pub author_id: i64,
+    pub deleted_at: Option<i64>,
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "fll_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "fll_post" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "title" VARCHAR(200) NOT NULL,
+            "status" VARCHAR(20) NOT NULL,
+            "views" BIGINT NOT NULL,
+            "author_id" BIGINT NOT NULL,
+            "deleted_at" BIGINT
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"INSERT INTO "fll_post" ("title", "status", "views", "author_id", "deleted_at") VALUES
+            ('Hello Rust',     'published', 100,   1, NULL),
+            ('Hello World',    'published',  50,   2, NULL),
+            ('Goodbye Rust',   'draft',      10,   1, 1700000000),
+            ('Crab Cakes',     'published', 250,   3, NULL),
+            ('Rusty Spoon',    'draft',       5,   2, 1700000001)"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn cleanup(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "fll_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn live_bare_field_eq() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let rows: Vec<Post> = Post::objects()
+        .filter("status", "published")
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 3, "three published rows");
+    assert!(rows.iter().all(|r| r.status == "published"));
+
+    cleanup(&pool).await;
+}
+
+#[tokio::test]
+async fn live_gt_lt_comparisons() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let rows: Vec<Post> = Post::objects()
+        .filter("views__gt", 50_i64)
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2, "two rows with views > 50");
+    assert!(rows.iter().all(|r| r.views > 50));
+
+    let rows: Vec<Post> = Post::objects()
+        .filter("views__lte", 10_i64)
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2, "two rows with views <= 10");
+
+    cleanup(&pool).await;
+}
+
+#[tokio::test]
+async fn live_icontains_matches_case_insensitively() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    // Lowercase "rust" must match titles containing "Rust" / "Rusty"
+    // → "Hello Rust", "Goodbye Rust", "Rusty Spoon".
+    let rows: Vec<Post> = Post::objects()
+        .filter("title__icontains", "rust")
+        .fetch(&pool)
+        .await
+        .unwrap();
+    let titles: Vec<&str> = rows.iter().map(|r| r.title.as_str()).collect();
+    assert_eq!(rows.len(), 3, "expected 3 hits for 'rust': got {titles:?}");
+    assert!(titles.contains(&"Hello Rust"));
+    assert!(titles.contains(&"Goodbye Rust"));
+    assert!(titles.contains(&"Rusty Spoon"));
+
+    cleanup(&pool).await;
+}
+
+#[tokio::test]
+async fn live_startswith_endswith() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let rows: Vec<Post> = Post::objects()
+        .filter("title__startswith", "Hello")
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2, "two titles start with 'Hello'");
+    assert!(rows.iter().all(|r| r.title.starts_with("Hello")));
+
+    let rows: Vec<Post> = Post::objects()
+        .filter("title__endswith", "Rust")
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2, "two titles end with 'Rust'");
+    assert!(rows.iter().all(|r| r.title.ends_with("Rust")));
+
+    cleanup(&pool).await;
+}
+
+#[tokio::test]
+async fn live_in_list_filters_match() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let rows: Vec<Post> = Post::objects()
+        .filter(
+            "author_id__in",
+            SqlValue::List(vec![SqlValue::I64(1), SqlValue::I64(3)]),
+        )
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 3, "authors 1 and 3 own three rows total");
+    assert!(rows.iter().all(|r| r.author_id == 1 || r.author_id == 3));
+
+    cleanup(&pool).await;
+}
+
+#[tokio::test]
+async fn live_isnull_true_and_false() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let live_rows: Vec<Post> = Post::objects()
+        .filter("deleted_at__isnull", true)
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(live_rows.len(), 3, "three non-deleted rows");
+    assert!(live_rows.iter().all(|r| r.deleted_at.is_none()));
+
+    let dead_rows: Vec<Post> = Post::objects()
+        .filter("deleted_at__isnull", false)
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(dead_rows.len(), 2, "two soft-deleted rows");
+    assert!(dead_rows.iter().all(|r| r.deleted_at.is_some()));
+
+    cleanup(&pool).await;
+}
+
+#[tokio::test]
+async fn live_between_range_alias() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    // __between
+    let rows: Vec<Post> = Post::objects()
+        .filter(
+            "views__between",
+            SqlValue::List(vec![SqlValue::I64(10), SqlValue::I64(100)]),
+        )
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 3, "views in [10,100] hits 3 rows");
+    assert!(rows.iter().all(|r| (10..=100).contains(&r.views)));
+
+    // __range (Django alias)
+    let rows: Vec<Post> = Post::objects()
+        .filter(
+            "views__range",
+            SqlValue::List(vec![SqlValue::I64(10), SqlValue::I64(100)]),
+        )
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 3);
+
+    cleanup(&pool).await;
+}
+
+#[tokio::test]
+async fn live_multi_filter_and_chain() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let rows: Vec<Post> = Post::objects()
+        .filter("status", "published")
+        .filter("views__gt", 50_i64)
+        .filter("title__icontains", "rust")
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        rows.len(),
+        1,
+        "only 'Hello Rust' is published, has views > 50, and matches 'rust'"
+    );
+    assert_eq!(rows[0].title, "Hello Rust");
+
+    cleanup(&pool).await;
+}

--- a/crates/rustango/tests/foreign_key_live.rs
+++ b/crates/rustango/tests/foreign_key_live.rs
@@ -112,7 +112,7 @@ async fn fetched_book_has_unloaded_fk_then_get_resolves_parent() {
 
     // Round-trip via fetch — confirms FromRow lands in Unloaded.
     let mut fetched: Vec<Book> = Book::objects()
-        .filter("id", Op::Eq, book.id)
+        .filter_op("id", Op::Eq, book.id)
         .fetch(&pool)
         .await
         .unwrap();
@@ -260,7 +260,7 @@ async fn string_pk_fk_round_trips_with_lazy_load() {
 
     // Round-trip through fetch — confirms FromRow decodes a String FK.
     let mut rows: Vec<StrPost> = StrPost::objects()
-        .filter("id", Op::Eq, post.id)
+        .filter_op("id", Op::Eq, post.id)
         .fetch(&pool)
         .await
         .unwrap();

--- a/crates/rustango/tests/groupby_inference.rs
+++ b/crates/rustango/tests/groupby_inference.rs
@@ -1,0 +1,295 @@
+//! Tri-dialect emission tests for Django-shape GROUP BY auto-inference
+//! (issue #75). The inference rule:
+//!   * `.values(cols).annotate(agg)` → `GROUP BY cols` (Shape 2)
+//!   * `.annotate(agg)` alone        → `GROUP BY` every scalar column (Shape 3)
+//!   * `.annotate(window)` only      → no GROUP BY (window funcs are per-row)
+//!   * Explicit `.group_by(...)`     → always wins; values still drives nothing
+//!     (we trust the explicit list).
+
+use rustango::core::aggregates::{count_all, sum};
+use rustango::core::window::row_number;
+use rustango::core::{Column as _, QueryError};
+use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "gbi_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    author_id: i64,
+    #[rustango(max_length = 20)]
+    status: String,
+    views: i64,
+    revenue: i64,
+}
+
+// ---------- Shape 2: .values(cols).annotate(agg) → GROUP BY cols ----------
+
+#[test]
+fn values_then_aggregate_emits_group_by_values() {
+    let q = Post::objects()
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"SELECT "author_id""#),
+        "projection: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains(r#"GROUP BY "author_id""#),
+        "group by: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn values_multi_column_groups_by_all_listed_cols() {
+    let q = Post::objects()
+        .values(&["author_id", "status"])
+        .annotate("revenue_total", sum("revenue").into())
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"GROUP BY "author_id", "status""#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn values_with_filter_emits_where_before_group_by() {
+    let q = Post::objects()
+        .where_(Post::status.eq("published".to_owned()))
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    let wh = stmt.sql.find("WHERE").unwrap();
+    let gb = stmt.sql.find("GROUP BY").unwrap();
+    assert!(wh < gb, "WHERE before GROUP BY: {}", stmt.sql);
+}
+
+// ---------- Shape 3: bare .annotate(agg) → GROUP BY all scalar cols ----------
+
+#[test]
+fn bare_annotate_groups_by_every_scalar_column() {
+    let q = Post::objects()
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    for col in ["id", "author_id", "status", "views", "revenue"] {
+        assert!(
+            stmt.sql.contains(&format!(r#""{col}""#)),
+            "Shape 3 must include every scalar col in GROUP BY — missing `{col}`: {}",
+            stmt.sql
+        );
+    }
+    assert!(stmt.sql.contains("GROUP BY"), "got: {}", stmt.sql);
+}
+
+// ---------- Window-only: no GROUP BY ----------
+
+#[test]
+fn window_only_annotate_emits_no_group_by() {
+    let q = Post::objects()
+        .aggregate()
+        // Window functions are per-row; no GROUP BY required.
+        .annotate("rn", row_number().order_by(&[("views", true)]).into())
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        !stmt.sql.contains("GROUP BY"),
+        "window-only must not emit GROUP BY: {}",
+        stmt.sql
+    );
+    assert!(stmt.sql.contains("ROW_NUMBER()"), "got: {}", stmt.sql);
+}
+
+// ---------- Explicit .group_by(...) wins ----------
+
+#[test]
+fn explicit_group_by_overrides_values() {
+    // User asked .values("author_id") but also .group_by("status") —
+    // we trust the explicit list and emit GROUP BY status (not author_id).
+    let q = Post::objects()
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .group_by("status")
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"GROUP BY "status""#),
+        "explicit wins: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains(r#"GROUP BY "author_id""#),
+        "values list should not leak into GROUP BY when explicit was set: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn explicit_group_by_skips_shape_3_inference() {
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"GROUP BY "author_id""#),
+        "got: {}",
+        stmt.sql
+    );
+    // Other scalar cols must NOT have crept in.
+    assert!(
+        !stmt.sql.contains(r#"GROUP BY "id", "author_id""#),
+        "Shape 3 fallback should not fire when group_by is explicit: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Error paths ----------
+
+#[test]
+fn values_alone_without_aggregate_errors() {
+    let r = Post::objects().values(&["author_id"]).compile();
+    match r {
+        Err(QueryError::ValuesRequiresAggregate { cols }) => {
+            assert_eq!(cols, vec!["author_id"]);
+        }
+        other => panic!("expected ValuesRequiresAggregate, got: {other:?}"),
+    }
+}
+
+#[test]
+fn values_with_only_window_annotation_errors() {
+    // Window doesn't aggregate — same path as no aggregate at all.
+    let r = Post::objects()
+        .values(&["author_id"])
+        .annotate("rn", row_number().order_by(&[("views", true)]).into())
+        .compile();
+    assert!(matches!(r, Err(QueryError::ValuesRequiresAggregate { .. })));
+}
+
+#[test]
+fn values_with_unknown_column_errors() {
+    let r = Post::objects()
+        .values(&["nope_col"])
+        .annotate("n", count_all().into())
+        .compile();
+    match r {
+        Err(QueryError::UnknownField { field, .. }) => assert_eq!(field, "nope_col"),
+        other => panic!("expected UnknownField, got: {other:?}"),
+    }
+}
+
+#[test]
+fn explicit_group_by_unknown_column_errors() {
+    let r = Post::objects()
+        .aggregate()
+        .group_by("nope_col")
+        .annotate("n", count_all().into())
+        .compile();
+    match r {
+        Err(QueryError::UnknownField { field, .. }) => assert_eq!(field, "nope_col"),
+        other => panic!("expected UnknownField, got: {other:?}"),
+    }
+}
+
+// ---------- Tri-dialect ident-quote shapes ----------
+
+#[test]
+fn mysql_backticks_in_values_path() {
+    let q = Post::objects()
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains("`author_id`") && stmt.sql.contains("GROUP BY `author_id`"),
+        "MySQL shape: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn sqlite_double_quotes_in_values_path() {
+    let q = Post::objects()
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = Sqlite.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""author_id""#) && stmt.sql.contains(r#"GROUP BY "author_id""#),
+        "SQLite shape: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn mysql_backticks_in_shape3_path() {
+    let q = Post::objects()
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_aggregate(&q).unwrap();
+    // Sanity — MySQL backticks present + GROUP BY contains every scalar col.
+    for col in ["id", "author_id", "status", "views", "revenue"] {
+        assert!(
+            stmt.sql.contains(&format!("`{col}`")),
+            "MySQL Shape 3 missing `{col}`: {}",
+            stmt.sql
+        );
+    }
+}
+
+#[test]
+fn sqlite_shape3_includes_all_cols() {
+    let q = Post::objects()
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = Sqlite.compile_aggregate(&q).unwrap();
+    for col in ["id", "author_id", "status", "views", "revenue"] {
+        assert!(
+            stmt.sql.contains(&format!(r#""{col}""#)),
+            "SQLite Shape 3 missing \"{col}\": {}",
+            stmt.sql
+        );
+    }
+}
+
+// ---------- QuerySet::annotate shortcut ----------
+
+#[test]
+fn queryset_annotate_promotes_to_aggregate_builder() {
+    // Calling `.annotate()` directly on QuerySet (without `.aggregate()`)
+    // should produce the same SQL as the explicit two-step form.
+    let q1 = Post::objects()
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let q2 = Post::objects()
+        .aggregate()
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let s1 = Postgres.compile_aggregate(&q1).unwrap().sql;
+    let s2 = Postgres.compile_aggregate(&q2).unwrap().sql;
+    assert_eq!(s1, s2, "shortcut SQL must match explicit aggregate path");
+}

--- a/crates/rustango/tests/groupby_inference.rs
+++ b/crates/rustango/tests/groupby_inference.rs
@@ -95,6 +95,27 @@ fn bare_annotate_groups_by_every_scalar_column() {
     assert!(stmt.sql.contains("GROUP BY"), "got: {}", stmt.sql);
 }
 
+// ---------- Scalar aggregate via .aggregate().annotate(): NO GROUP BY ----------
+
+#[test]
+fn aggregate_then_annotate_stays_scalar() {
+    // Regression pin: the rustango-native `.aggregate().annotate(agg)` path
+    // must remain a scalar single-row aggregate. Adding Shape 3 inference
+    // to this path broke every pre-existing aggregate-filter live test
+    // (PR #82) and the entire aggregations cookbook chapter.
+    let q = Post::objects()
+        .aggregate()
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        !stmt.sql.contains("GROUP BY"),
+        ".aggregate().annotate(agg) must NOT emit GROUP BY (scalar aggregate): {}",
+        stmt.sql
+    );
+}
+
 // ---------- Window-only: no GROUP BY ----------
 
 #[test]
@@ -277,19 +298,28 @@ fn sqlite_shape3_includes_all_cols() {
 // ---------- QuerySet::annotate shortcut ----------
 
 #[test]
-fn queryset_annotate_promotes_to_aggregate_builder() {
-    // Calling `.annotate()` directly on QuerySet (without `.aggregate()`)
-    // should produce the same SQL as the explicit two-step form.
-    let q1 = Post::objects()
+fn queryset_annotate_is_django_shape_aggregate_is_scalar() {
+    // The two entry points are intentionally distinct (Django's
+    // `aggregate()` vs `annotate()` distinction):
+    //   * QuerySet::annotate(...)         → Django Shape 3 — GROUP BY all cols
+    //   * QuerySet::aggregate().annotate  → scalar single-row aggregate (no GROUP BY)
+    let django_shape = Post::objects()
         .annotate("n", count_all().into())
         .compile()
         .unwrap();
-    let q2 = Post::objects()
+    let scalar = Post::objects()
         .aggregate()
         .annotate("n", count_all().into())
         .compile()
         .unwrap();
-    let s1 = Postgres.compile_aggregate(&q1).unwrap().sql;
-    let s2 = Postgres.compile_aggregate(&q2).unwrap().sql;
-    assert_eq!(s1, s2, "shortcut SQL must match explicit aggregate path");
+    let s1 = Postgres.compile_aggregate(&django_shape).unwrap().sql;
+    let s2 = Postgres.compile_aggregate(&scalar).unwrap().sql;
+    assert!(
+        s1.contains("GROUP BY"),
+        "QuerySet::annotate should auto-infer Shape 3 GROUP BY: {s1}"
+    );
+    assert!(
+        !s2.contains("GROUP BY"),
+        "QuerySet::aggregate().annotate stays scalar (no GROUP BY): {s2}"
+    );
 }

--- a/crates/rustango/tests/groupby_inference_live.rs
+++ b/crates/rustango/tests/groupby_inference_live.rs
@@ -1,0 +1,182 @@
+#![cfg(feature = "postgres")]
+//! Live PG end-to-end tests for GROUP BY auto-inference (issue #75).
+//! The emission tests pin the SQL strings; this confirms the database
+//! actually groups rows the way we expect.
+//!
+//! Skips silently when `DATABASE_URL` is unset.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use rustango::core::aggregates::{count_all, sum};
+use rustango::core::SqlValue;
+use rustango::sql::{fetch_aggregate, sqlx, Auto};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gbi_sale")]
+#[allow(dead_code)]
+pub struct Sale {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub author_id: i64,
+    #[rustango(max_length = 10)]
+    pub month: String,
+    pub amount: i64,
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "gbi_sale" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "gbi_sale" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "author_id" BIGINT NOT NULL,
+            "month" VARCHAR(10) NOT NULL,
+            "amount" BIGINT NOT NULL
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"INSERT INTO "gbi_sale" ("author_id", "month", "amount") VALUES
+            (1, '2026-01',  100),
+            (1, '2026-01',   50),
+            (1, '2026-02',  200),
+            (2, '2026-01',  300),
+            (2, '2026-02',  400),
+            (2, '2026-02',   50),
+            (3, '2026-01',  999)"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn cleanup(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "gbi_sale" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+fn get_i64(row: &HashMap<String, SqlValue>, key: &str) -> i64 {
+    match row.get(key).unwrap_or(&SqlValue::Null) {
+        SqlValue::I64(n) => *n,
+        other => panic!("expected i64 at `{key}`, got {other:?}"),
+    }
+}
+
+fn get_string<'r>(row: &'r HashMap<String, SqlValue>, key: &str) -> &'r str {
+    match row.get(key).unwrap_or(&SqlValue::Null) {
+        SqlValue::String(s) => s.as_str(),
+        other => panic!("expected String at `{key}`, got {other:?}"),
+    }
+}
+
+/// Shape 2 — `.values("author_id").annotate("n", count(*))`.
+/// "Sales per author" — the Django canonical example.
+#[tokio::test]
+async fn shape2_posts_per_author() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Sale::objects()
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    assert_eq!(rows.len(), 3, "three distinct authors");
+    let mut by_author: HashMap<i64, i64> = rows
+        .iter()
+        .map(|r| (get_i64(r, "author_id"), get_i64(r, "n")))
+        .collect();
+    assert_eq!(by_author.remove(&1), Some(3), "author 1 → 3 sales");
+    assert_eq!(by_author.remove(&2), Some(3), "author 2 → 3 sales");
+    assert_eq!(by_author.remove(&3), Some(1), "author 3 → 1 sale");
+
+    cleanup(&pool).await;
+}
+
+/// Shape 2 multi-column — `.values("author_id", "month").annotate("total", sum)`.
+/// "Monthly revenue per author".
+#[tokio::test]
+async fn shape2_monthly_revenue_per_author() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Sale::objects()
+        .values(&["author_id", "month"])
+        .annotate("total", sum("amount").into())
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    // Distinct (author, month) pairs: (1,'01'), (1,'02'), (2,'01'),
+    // (2,'02'), (3,'01') = 5 rows.
+    assert_eq!(rows.len(), 5, "5 (author, month) buckets");
+
+    // Spot-check author 1 / month 2026-01 totals 100 + 50 = 150.
+    let row = rows
+        .iter()
+        .find(|r| get_i64(r, "author_id") == 1 && get_string(r, "month") == "2026-01")
+        .expect("author=1, month=2026-01 row");
+    assert_eq!(get_i64(row, "total"), 150);
+
+    // Author 2 / month 2026-02 totals 400 + 50 = 450.
+    let row = rows
+        .iter()
+        .find(|r| get_i64(r, "author_id") == 2 && get_string(r, "month") == "2026-02")
+        .expect("author=2, month=2026-02 row");
+    assert_eq!(get_i64(row, "total"), 450);
+
+    cleanup(&pool).await;
+}
+
+/// Shape 3 — bare `.annotate(...)` without `.values(...)`. Django's
+/// implicit "GROUP BY every selected non-aggregate column" rule. The
+/// test runs the query and proves the database accepts the inferred
+/// SELECT-all-cols + GROUP-BY-all-cols shape.
+#[tokio::test]
+async fn shape3_bare_annotate_runs_with_group_by_all() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Sale::objects()
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    // Every row has a unique (id, author_id, month, amount) tuple,
+    // so GROUP-BY-all-cols collapses to no-op — 7 rows in, 7 rows out.
+    assert_eq!(rows.len(), 7, "GROUP BY every col → row count unchanged");
+    // Every result row should carry n=1 (each input row is its own group).
+    for r in &rows {
+        assert_eq!(get_i64(r, "n"), 1, "GROUP BY all cols → COUNT = 1 per row");
+    }
+
+    cleanup(&pool).await;
+}

--- a/crates/rustango/tests/live_pg.rs
+++ b/crates/rustango/tests/live_pg.rs
@@ -98,7 +98,7 @@ async fn read_pipeline_filters_and_in_clause() {
     };
 
     let actives: Vec<LiveUser> = LiveUser::objects()
-        .filter("is_active", Op::Eq, true)
+        .filter_op("is_active", Op::Eq, true)
         .fetch(&pool)
         .await
         .unwrap();
@@ -108,7 +108,7 @@ async fn read_pipeline_filters_and_in_clause() {
     assert!(actives.iter().all(|u| u.is_active));
 
     let picked: Vec<LiveUser> = LiveUser::objects()
-        .filter(
+        .filter_op(
             "id",
             Op::In,
             SqlValue::List(vec![SqlValue::I64(1), SqlValue::I64(3)]),
@@ -263,7 +263,7 @@ async fn bulk_delete_with_in_clause_removes_listed_rows() {
     };
 
     let affected = LiveUser::objects()
-        .filter(
+        .filter_op(
             "id",
             Op::In,
             SqlValue::List(vec![SqlValue::I64(1), SqlValue::I64(3)]),
@@ -603,7 +603,7 @@ async fn typed_filter_validates_at_compile_runtime_match() {
 
     let rows: Vec<LiveUser> = LiveUser::objects()
         .where_(LiveUser::is_active.eq(true))
-        .filter("name", Op::Like, "alic%")
+        .filter_op("name", Op::Like, "alic%")
         .fetch(&pool)
         .await
         .unwrap();

--- a/crates/rustango/tests/orm_advanced_sqlite_live.rs
+++ b/crates/rustango/tests/orm_advanced_sqlite_live.rs
@@ -124,7 +124,7 @@ async fn where_in_list_filters_on_sqlite() {
     seed_posts(&pool, alice, &[("a1", true)]).await;
     seed_posts(&pool, bob, &[("b1", true)]).await;
     let posts: Vec<Post> = Post::objects()
-        .filter(
+        .filter_op(
             "author",
             rustango::core::Op::In,
             SqlValue::List(vec![SqlValue::I64(alice), SqlValue::I64(bob)]),

--- a/crates/rustango/tests/queryset.rs
+++ b/crates/rustango/tests/queryset.rs
@@ -61,7 +61,7 @@ fn o2o_defaults_on_to_id() {
 fn objects_compiles_with_resolved_columns() {
     let q = User::objects()
         .eq("name", "alice")
-        .filter("is_active", Op::Eq, true)
+        .filter_op("is_active", Op::Eq, true)
         .compile()
         .unwrap();
 
@@ -104,7 +104,7 @@ fn type_mismatch_is_rejected_at_compile() {
 #[test]
 fn null_value_skips_type_check() {
     let q = User::objects()
-        .filter("name", Op::Eq, Option::<String>::None)
+        .filter_op("name", Op::Eq, Option::<String>::None)
         .compile()
         .unwrap();
     assert_eq!(

--- a/crates/rustango/tests/save_live.rs
+++ b/crates/rustango/tests/save_live.rs
@@ -104,7 +104,7 @@ async fn save_updates_when_pk_set_without_changing_pk() {
     assert_eq!(original_id, after_id);
 
     let fetched: Vec<Thing> = Thing::objects()
-        .filter("id", Op::Eq, after_id)
+        .filter_op("id", Op::Eq, after_id)
         .fetch(&pool)
         .await
         .unwrap();

--- a/crates/rustango/tests/self_fk_live.rs
+++ b/crates/rustango/tests/self_fk_live.rs
@@ -122,7 +122,7 @@ async fn live_self_fk_round_trip() -> Result<(), Box<dyn std::error::Error>> {
     grand.save(&pool).await?;
 
     let mut root_children: Vec<Page> = Page::objects()
-        .filter("parent_id", Op::Eq, root_id)
+        .filter_op("parent_id", Op::Eq, root_id)
         .fetch(&pool)
         .await?;
     root_children.sort_by(|a, b| a.title.cmp(&b.title));
@@ -131,7 +131,7 @@ async fn live_self_fk_round_trip() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(root_children[1].title, "child_b");
 
     let grandkids: Vec<Page> = Page::objects()
-        .filter("parent_id", Op::Eq, child_b_id)
+        .filter_op("parent_id", Op::Eq, child_b_id)
         .fetch(&pool)
         .await?;
     assert_eq!(grandkids.len(), 1);

--- a/crates/rustango/tests/sql.rs
+++ b/crates/rustango/tests/sql.rs
@@ -92,8 +92,8 @@ fn multiple_filters_join_with_and_and_increment_placeholders() {
         .compile_select(
             &User::objects()
                 .eq("name", "alice")
-                .filter("is_active", Op::Eq, true)
-                .filter("id", Op::Gt, 10_i64)
+                .filter_op("is_active", Op::Eq, true)
+                .filter_op("id", Op::Gt, 10_i64)
                 .compile()
                 .unwrap(),
         )
@@ -117,8 +117,8 @@ fn is_null_does_not_consume_placeholder() {
     let stmt = pg()
         .compile_select(
             &User::objects()
-                .filter("name", Op::IsNull, true)
-                .filter("id", Op::Eq, 1_i64)
+                .filter_op("name", Op::IsNull, true)
+                .filter_op("id", Op::Eq, 1_i64)
                 .compile()
                 .unwrap(),
         )
@@ -135,7 +135,7 @@ fn is_not_null_emitted_for_false() {
     let stmt = pg()
         .compile_select(
             &User::objects()
-                .filter("name", Op::IsNull, false)
+                .filter_op("name", Op::IsNull, false)
                 .compile()
                 .unwrap(),
         )
@@ -151,7 +151,7 @@ fn in_list_expands_to_one_placeholder_per_element() {
     let stmt = pg()
         .compile_select(
             &User::objects()
-                .filter(
+                .filter_op(
                     "id",
                     Op::In,
                     SqlValue::List(vec![SqlValue::I64(1), SqlValue::I64(2), SqlValue::I64(3)]),
@@ -175,7 +175,7 @@ fn empty_in_list_is_rejected() {
     let err = pg()
         .compile_select(
             &User::objects()
-                .filter("id", Op::In, SqlValue::List(vec![]))
+                .filter_op("id", Op::In, SqlValue::List(vec![]))
                 .compile()
                 .unwrap(),
         )
@@ -188,7 +188,7 @@ fn in_with_non_list_is_rejected() {
     let err = pg()
         .compile_select(
             &User::objects()
-                .filter("id", Op::In, 1_i64)
+                .filter_op("id", Op::In, 1_i64)
                 .compile()
                 .unwrap(),
         )
@@ -201,7 +201,7 @@ fn is_null_with_non_bool_is_rejected() {
     let err = pg()
         .compile_select(
             &User::objects()
-                .filter("name", Op::IsNull, "alice")
+                .filter_op("name", Op::IsNull, "alice")
                 .compile()
                 .unwrap(),
         )

--- a/crates/rustango/tests/typed_columns.rs
+++ b/crates/rustango/tests/typed_columns.rs
@@ -90,7 +90,7 @@ fn typed_filters_can_be_mixed_with_string_keyed_in_order() {
     let q = User::objects()
         .eq("name", "alice")
         .where_(User::is_active.eq(true))
-        .filter("id", Op::Gt, 0_i64)
+        .filter_op("id", Op::Gt, 0_i64)
         .compile()
         .unwrap();
     let filters = q.where_clause.as_flat_and().unwrap();
@@ -111,7 +111,7 @@ fn typed_filters_compile_to_same_postgres_sql() {
 
     let string_keyed = User::objects()
         .eq("name", "alice")
-        .filter("is_active", Op::Eq, true)
+        .filter_op("is_active", Op::Eq, true)
         .compile()
         .unwrap();
     let stmt_string = Postgres.compile_select(&string_keyed).unwrap();

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -549,14 +549,17 @@ let rows = rustango::sql::fetch_aggregate(&by_author, &pool).await?;
 
 Issue #75 closes the Django ergonomic gap: GROUP BY is **inferred** from the queryset's shape — you never call a `.group_by(...)` builder unless you're overriding the inference.
 
-| Shape | Builder | Resulting `GROUP BY` |
+| Entry shape | Builder | Resulting `GROUP BY` |
 |---|---|---|
-| **2 — values + aggregate** | `.values(&["author_id"]).annotate("n", count_all().into())` | `GROUP BY "author_id"` |
-| **3 — bare aggregate** | `.annotate("n", count_all().into())` | `GROUP BY` every non-aggregate scalar column on the model |
-| **Window-only** | `.aggregate().annotate("rn", row_number()…)` | (no `GROUP BY` — window funcs are per-row) |
-| **Explicit override** | `.aggregate().group_by("month").annotate(...)` | `GROUP BY "month"` — explicit wins |
+| **Django annotate** | `.annotate("n", count_all().into())` | every non-aggregate scalar column on the model (Shape 3) |
+| **Django values + aggregate** | `.values(&["author_id"]).annotate("n", count_all().into())` | `GROUP BY "author_id"` (Shape 2) |
+| **rustango scalar aggregate** | `.aggregate().annotate("n", count_all().into())` | none — single-row scalar result |
+| **Window-only** | `.aggregate().annotate("rn", row_number()…)` | none — window funcs are per-row |
+| **Explicit override** | `.aggregate().group_by("month").annotate(...)` | the explicit list wins |
 
-The classifier `AggregateExpr::is_aggregating()` distinguishes the row-collapsing variants (`Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` / `StdDev*` / `Variance*` — plus recursive `Filtered` / `Coalesced` wrappers) from `Window`, which is per-row. Only the aggregating variants trigger Shape 3 inference.
+**The two entry points are intentionally distinct.** `QuerySet::annotate(...)` (Django-shape, sugar over `aggregate().annotate(...)` + auto-inference) treats the annotation as a per-row computed column and infers GROUP BY. `QuerySet::aggregate().annotate(...)` (rustango-native, explicit) treats the annotation as a terminal scalar aggregation and emits no `GROUP BY` — mirroring Django's distinction between `.aggregate(...)` (returns one dict) and `.annotate(...)` (returns a queryset with an extra column per row).
+
+The classifier `AggregateExpr::is_aggregating()` distinguishes the row-collapsing variants (`Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` / `StdDev*` / `Variance*` — plus recursive `Filtered` / `Coalesced` wrappers) from `Window`, which is per-row. Only aggregating variants on the Django-shape entry trigger Shape 3 inference.
 
 ```rust
 use rustango::core::aggregates::{count_all, sum};

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -533,13 +533,52 @@ let total_views = Post::objects().sum::<i64>(Post::view_count, &pool).await?;
 let avg_views = Post::objects().avg(Post::view_count, &pool).await?;
 let max_views = Post::objects().max::<i64>(Post::view_count, &pool).await?;
 
-// Annotate (per-row aggregation)
-use rustango::core::AggregateExpr;
-let counts = Author::objects()
-    .annotate("post_count", AggregateExpr::CountChildren("posts", "author_id"))
-    .fetch(&pool).await?;
-// each Author gets a `post_count` extra field accessible via the annotated row
+// Annotate + GROUP BY (issue #75 — Django-shape auto-inference)
+use rustango::core::aggregates::{count_all, sum};
+
+// "Posts per author" — `.values()` lists the GROUP BY columns.
+let by_author = Sale::objects()
+    .values(&["author_id"])
+    .annotate("n", count_all().into())
+    .compile()?;
+let rows = rustango::sql::fetch_aggregate(&by_author, &pool).await?;
+// rows: Vec<HashMap<String, SqlValue>> — { author_id: 1, n: 3 }, …
 ```
+
+### GROUP BY auto-inference — `.values().annotate()` / bare `.annotate()`
+
+Issue #75 closes the Django ergonomic gap: GROUP BY is **inferred** from the queryset's shape — you never call a `.group_by(...)` builder unless you're overriding the inference.
+
+| Shape | Builder | Resulting `GROUP BY` |
+|---|---|---|
+| **2 — values + aggregate** | `.values(&["author_id"]).annotate("n", count_all().into())` | `GROUP BY "author_id"` |
+| **3 — bare aggregate** | `.annotate("n", count_all().into())` | `GROUP BY` every non-aggregate scalar column on the model |
+| **Window-only** | `.aggregate().annotate("rn", row_number()…)` | (no `GROUP BY` — window funcs are per-row) |
+| **Explicit override** | `.aggregate().group_by("month").annotate(...)` | `GROUP BY "month"` — explicit wins |
+
+The classifier `AggregateExpr::is_aggregating()` distinguishes the row-collapsing variants (`Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` / `StdDev*` / `Variance*` — plus recursive `Filtered` / `Coalesced` wrappers) from `Window`, which is per-row. Only the aggregating variants trigger Shape 3 inference.
+
+```rust
+use rustango::core::aggregates::{count_all, sum};
+
+// Shape 2 — "monthly revenue per author".
+Sale::objects()
+    .where_(Sale::status.eq("paid"))
+    .values(&["author_id", "month"])
+    .annotate("total", sum("amount").into())
+    .compile()?;
+// → SELECT "author_id", "month", SUM("amount")::bigint AS "total"
+//   FROM "sale" WHERE "status" = $1
+//   GROUP BY "author_id", "month"
+
+// Shape 3 — "each author + their post count". Every Author column
+// lands in both the SELECT list and the GROUP BY.
+Author::objects()
+    .annotate("post_count", count_all().filter(Author::id.eq(Post::author_id)).into())
+    .compile()?;
+```
+
+**Pure projection caveat.** `.values(cols)` *alone* (no aggregate annotation) is **not** supported in v0.40 — `compile()` returns `QueryError::ValuesRequiresAggregate`. Pure projection-as-dicts needs a separate writer path (it's a SELECT without GROUP BY, decoded into `Vec<HashMap>`) and is queued for a follow-up. For now, use the typed `QuerySet::fetch(...)` to read whole rows.
 
 ### Conditional aggregates — `filter=` + `default=` + StdDev/Variance
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1149,20 +1149,52 @@ Use `select_related("author")` on the queryset to pre-load a batch.
 
 ## QuerySet vs string-keyed filters
 
-Three syntaxes — pick by context:
+Four syntaxes — pick by context:
 
 ```rust
 // 1. HTTP query string (set via ViewSet filter_fields)
 //    GET /api/posts?author_id=42&status__ne=archived
 
-// 2. String-keyed (validated at compile of the queryset; runtime field lookup)
-Post::objects().filter("author_id", Op::Eq, SqlValue::I64(42));
+// 2. Django-shape string lookup (the same `field__lookup` grammar your
+//    URL parser uses, but inside Rust). Suffix decides the operator
+//    and value-shape; bare key is exact-eq. Field name is validated
+//    at `.compile()`.
+Post::objects()
+    .filter("status", "published")                 // exact-eq
+    .filter("title__icontains", "rust")            // ILIKE %rust%
+    .filter("views__gt", 100_i64);
 
-// 3. Typed columns (compile-time field check; preferred in app code)
+// 3. Explicit operator (legacy 3-arg shape — when you want to pass
+//    an Op directly without parsing a suffix)
+Post::objects().filter_op("author_id", Op::Eq, SqlValue::I64(42));
+
+// 4. Typed columns (compile-time field check; preferred in app code)
 Post::objects().where_(Post::author_id.eq(42));
 ```
 
-**Convention:** typed in app code, string-keyed in admin / generic CRUD code, HTTP query for the public API surface.
+**Convention:** typed in app code, Django-shape in admin / generic CRUD code, `filter_op` only when you've already computed an `Op` (e.g. from a request parser), HTTP query for the public API surface.
+
+### Django-shape lookups — supported suffixes
+
+| Suffix | SQL operator | Value shape | Notes |
+|---|---|---|---|
+| *(none)* / `__exact` | `=` | scalar | bare key is exact-eq |
+| `__ne` | `<>` | scalar | |
+| `__gt` / `__gte` / `__lt` / `__lte` | `>` `>=` `<` `<=` | scalar | |
+| `__contains` | `LIKE` | string | wraps value as `%v%` |
+| `__icontains` | `ILIKE` | string | wraps value as `%v%`; MySQL emulated via `LOWER()` |
+| `__startswith` | `LIKE` | string | wraps as `v%` |
+| `__istartswith` | `ILIKE` | string | wraps as `v%` |
+| `__endswith` | `LIKE` | string | wraps as `%v` |
+| `__iendswith` | `ILIKE` | string | wraps as `%v` |
+| `__iexact` | `ILIKE` | string | no wildcard wrapping — exact case-insensitive match |
+| `__in` | `IN (…)` | `SqlValue::List` | rejects non-list values |
+| `__isnull` | `IS NULL` / `IS NOT NULL` | `bool` | `true` → IS NULL, `false` → IS NOT NULL |
+| `__between` / `__range` | `BETWEEN … AND …` | 2-elt `SqlValue::List` | inclusive on both ends |
+
+**Errors surface at `.compile()`, not at `.filter()` call time** — value-shape mismatches (e.g. `__in` with a scalar, `__isnull` with a non-bool, `__between` with the wrong arity) and unknown suffixes (`status__nope`) return `QueryError::UnknownLookup` / `QueryError::InvalidLookupValue` from `.compile()` so the fluent chain stays type-clean. Chained traversals (`author__name__icontains`) are **not** supported in v0.39 — the splitter takes the suffix after the first `__`, so the whole tail `name__icontains` is treated as an unknown suffix.
+
+Each filter call AND-joins to any preceding ones; mix Django-shape, `filter_op`, and `where_` freely on the same queryset.
 
 ---
 


### PR DESCRIPTION
## Summary

Reclaims `.filter()` for the 2-arg string-keyed Django form your URL parser already speaks. The legacy 3-arg explicit-Op shape moves to `.filter_op(field, Op, value)`; `AggregateBuilder::filter` is unchanged (its semantic is still WHERE/HAVING auto-routing with a passed `Op`).

### Suffix table

| Suffix | SQL | Value shape | Notes |
|---|---|---|---|
| *(none)* / `__exact` | `=` | scalar | bare key = exact-eq |
| `__ne` | `<>` | scalar | |
| `__gt` / `__gte` / `__lt` / `__lte` | `>` `>=` `<` `<=` | scalar | |
| `__contains` / `__icontains` | `LIKE` / `ILIKE` | string | wraps `%v%` |
| `__startswith` / `__istartswith` | `LIKE` / `ILIKE` | string | wraps `v%` |
| `__endswith` / `__iendswith` | `LIKE` / `ILIKE` | string | wraps `%v` |
| `__iexact` | `ILIKE` | string | no wildcards |
| `__in` | `IN (…)` | `SqlValue::List` | rejects non-list |
| `__isnull` | `IS NULL` / `IS NOT NULL` | `bool` | |
| `__between` / `__range` | `BETWEEN … AND …` | 2-elt `SqlValue::List` | |

### Error path

Errors at `.compile()` — not at call time — via a deferred `PendingFilter::Error` variant so the fluent chain stays `Result`-free. Two new `QueryError` variants: `UnknownLookup { field, suffix }` and `InvalidLookupValue { field, suffix, expected, actual }`.

### What's intentionally *not* in this slice

Chained join-traversals (`author__name__icontains`) are rejected as `UnknownLookup` — the splitter takes the suffix after the first `__`, so the tail surfaces unchanged. v1 ORM doesn't do join-traversal yet; left as future work alongside `select_related` enhancements.

## Test plan

- [x] 24 tri-dialect emission tests in `tests/filter_lookup.rs` covering PG / MySQL / SQLite quoting, every suffix, every value-shape mismatch error path, multi-filter AND-join
- [x] 8 live PG round-trip tests in `tests/filter_lookup_live.rs` (skip silently w/o `DATABASE_URL`)
- [x] 1494 lib tests pass with `--features tenancy`
- [x] Abstract-code litmus: `cargo build --no-default-features --features sqlite,tenancy` clean
- [x] Cookbook (`docs/orm.md`) updated with suffix table + the four `.filter()` shapes
- [x] Macro emission + 21 internal call sites migrated to `.filter_op`
- [x] Stale doc-comments in `executor.rs` and `admin/urls.rs` updated