### PR TITLE
feat: Django-shape GROUP BY auto-inference (closes #75)

### DIFF
--- a/crates/rustango/src/core/error.rs
+++ b/crates/rustango/src/core/error.rs
@@ -96,4 +96,21 @@ pub enum QueryError {
         expected: &'static str,
         actual: &'static str,
     },
+
+    /// `.values(cols)` was called without a subsequent aggregating
+    /// `.annotate(name, ...)`. Issue #75 v1 supports `.values()` only
+    /// as a GROUP BY hint paired with an aggregate annotation; pure
+    /// projection (returning `Vec<HashMap<String, SqlValue>>` with
+    /// only the requested columns) needs a separate writer path and
+    /// is queued for a follow-up. Until then, use the typed
+    /// `QuerySet::fetch(...)` path to read whole rows, or build an
+    /// `AggregateQuery` directly if you need a custom SELECT shape.
+    #[error(
+        "AggregateBuilder::values({cols:?}) requires at least one \
+         aggregating annotation (Count / Sum / Avg / Max / Min / \
+         StdDev / Variance). Pure projection without GROUP BY is not \
+         supported yet; chain `.annotate(\"alias\", aggregate)` or \
+         use `QuerySet::fetch` instead."
+    )]
+    ValuesRequiresAggregate { cols: Vec<&'static str> },
 }

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -914,6 +914,35 @@ pub enum AggregateExpr {
     Window(Box<super::window::WindowExpr>),
 }
 
+impl AggregateExpr {
+    /// Whether this annotation actually aggregates rows (and therefore
+    /// triggers GROUP BY auto-inference, issue #75).
+    ///
+    /// - `Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` /
+    ///   `StdDev*` / `Variance*` → **aggregating** (collapses rows).
+    /// - `Window` → **not aggregating** (per-row computation over a frame).
+    /// - `Filtered { inner }` / `Coalesced { inner }` → recurse on `inner`.
+    #[must_use]
+    pub fn is_aggregating(&self) -> bool {
+        match self {
+            AggregateExpr::Count(_)
+            | AggregateExpr::CountDistinct(_)
+            | AggregateExpr::Sum(_)
+            | AggregateExpr::Avg(_)
+            | AggregateExpr::Max(_)
+            | AggregateExpr::Min(_)
+            | AggregateExpr::StdDev(_)
+            | AggregateExpr::StdDevPop(_)
+            | AggregateExpr::Variance(_)
+            | AggregateExpr::VariancePop(_) => true,
+            AggregateExpr::Window(_) => false,
+            AggregateExpr::Filtered { inner, .. } | AggregateExpr::Coalesced { inner, .. } => {
+                inner.is_aggregating()
+            }
+        }
+    }
+}
+
 /// A `SELECT … GROUP BY … HAVING …` query. Returned rows are untyped
 /// (`HashMap<String, SqlValue>`) because the projection is dynamic.
 ///

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -585,7 +585,60 @@ impl<T: Model> QuerySet<T> {
             limit: None,
             offset: None,
             deferred_error: None,
+            values: None,
         }
+    }
+
+    /// Django-shape `.values(&[...]).annotate(...)` projection — issue #75.
+    ///
+    /// Switches the queryset into aggregate mode and records the projection
+    /// columns. When followed by `.annotate("alias", aggregate)`, the writer
+    /// emits `SELECT cols, AGGR(...) FROM t GROUP BY cols` — GROUP BY is
+    /// inferred from the values list.
+    ///
+    /// ```ignore
+    /// // "Posts per author" — Django's canonical example.
+    /// Post::objects()
+    ///     .values(&["author_id"])
+    ///     .annotate("n", count_all().into())
+    ///     .compile()?;
+    /// // → SELECT "author_id", COUNT(*) AS "n" FROM "post" GROUP BY "author_id"
+    /// ```
+    ///
+    /// Calling `.values()` without a subsequent aggregating `.annotate(...)`
+    /// is a pure projection (no GROUP BY emitted).
+    #[must_use]
+    pub fn values(self, columns: &[&'static str]) -> AggregateBuilder<T> {
+        AggregateBuilder {
+            qs: self,
+            group_by: Vec::new(),
+            aggregates: Vec::new(),
+            having: None,
+            order_by: Vec::new(),
+            limit: None,
+            offset: None,
+            deferred_error: None,
+            values: Some(columns.to_vec()),
+        }
+    }
+
+    /// Django-shape `.annotate(...)` without explicit `.aggregate()` — issue #75.
+    ///
+    /// Promotes to an [`AggregateBuilder`]. If the annotation aggregates rows
+    /// (`Count`, `Sum`, `Avg`, …) and `.values()` wasn't called, `compile()`
+    /// auto-populates GROUP BY with every non-aggregate scalar column on the
+    /// model (Django Shape 3 — "per-row count of children").
+    ///
+    /// ```ignore
+    /// // "Each author + their post count" — every column of `Author`
+    /// // ends up in the SELECT list AND in GROUP BY.
+    /// Author::objects()
+    ///     .annotate("post_count", count_all().into())
+    ///     .compile()?;
+    /// ```
+    #[must_use]
+    pub fn annotate(self, alias: &'static str, expr: AggregateExpr) -> AggregateBuilder<T> {
+        self.aggregate().annotate(alias, expr)
     }
 }
 
@@ -1143,13 +1196,34 @@ pub struct AggregateBuilder<T: Model> {
     /// on first error; subsequent builder calls are no-ops so the
     /// original cause isn't masked. Surfaced from `compile()`.
     deferred_error: Option<crate::core::QueryError>,
+    /// Issue #75 — projection columns set via [`Self::values`] (or
+    /// [`QuerySet::values`]). When `Some(cols)` and the user hasn't
+    /// called `.group_by(...)` explicitly, `compile()` derives
+    /// `GROUP BY cols`. When `None` and an aggregating annotation is
+    /// present, `compile()` falls back to Django Shape 3 — `GROUP BY`
+    /// every non-aggregate scalar column on the model.
+    values: Option<Vec<&'static str>>,
 }
 
 impl<T: Model> AggregateBuilder<T> {
     /// Add a `GROUP BY` column. Call multiple times to group by multiple columns.
+    ///
+    /// Explicit `.group_by(...)` calls always win — when paired with
+    /// [`Self::values`] / [`QuerySet::values`], the explicit list is what
+    /// reaches the writer; the values list still drives the projection
+    /// SELECT list (issue #75).
     #[must_use]
     pub fn group_by(mut self, column: &'static str) -> Self {
         self.group_by.push(column);
+        self
+    }
+
+    /// Set the projection column list — same semantic as
+    /// [`QuerySet::values`] but available mid-chain when you started
+    /// from `.aggregate()` rather than `.values(...)`. Issue #75.
+    #[must_use]
+    pub fn values(mut self, columns: &[&'static str]) -> Self {
+        self.values = Some(columns.to_vec());
         self
     }
 
@@ -1287,7 +1361,22 @@ impl<T: Model> AggregateBuilder<T> {
     /// Compile to an [`AggregateQuery`] IR.
     ///
     /// # Errors
-    /// Returns [`QueryError`] if any filter or having clause names an unknown field.
+    /// Returns [`QueryError`] if any filter or having clause names an
+    /// unknown field, or if `.values()` was called without a
+    /// subsequent aggregating `.annotate(...)`.
+    ///
+    /// # GROUP BY inference (issue #75)
+    ///
+    /// When the user hasn't called `.group_by(...)` explicitly, the
+    /// builder fills it in:
+    ///
+    /// * `.values(cols).annotate(agg)` → `GROUP BY cols` (Django Shape 2).
+    /// * `.annotate(agg)` (no values) → `GROUP BY` every non-aggregate
+    ///   scalar column on the model (Django Shape 3).
+    /// * `.annotate(window)` only → no GROUP BY (window functions are
+    ///   per-row).
+    ///
+    /// Explicit `.group_by(...)` always wins.
     pub fn compile(self) -> Result<AggregateQuery, QueryError> {
         // Surface any builder-time deferred error first (e.g. an
         // `Op::In` against an annotation alias) so the user sees the
@@ -1310,10 +1399,54 @@ impl<T: Model> AggregateBuilder<T> {
             .into_iter()
             .map(|(col, desc)| crate::core::OrderItem::column(col, desc))
             .collect();
+
+        // Issue #75 — GROUP BY auto-inference.
+        let has_aggregating = self.aggregates.iter().any(|(_, e)| e.is_aggregating());
+        let group_by = if !self.group_by.is_empty() {
+            // Explicit `.group_by(...)` always wins. Validate columns
+            // belong to the model (caught early — typos otherwise
+            // surface at the DB).
+            for col in &self.group_by {
+                if model.field_by_column(col).is_none() {
+                    return Err(QueryError::UnknownField {
+                        model: model.name,
+                        field: (*col).to_owned(),
+                    });
+                }
+            }
+            self.group_by
+        } else if let Some(cols) = self.values.as_ref() {
+            // `.values(cols)` set. Without an aggregating annotation
+            // we'd produce a degenerate `SELECT cols GROUP BY cols`
+            // (distinct-projection) — refuse and point the user at
+            // the right path for pure projection.
+            if !has_aggregating {
+                return Err(QueryError::ValuesRequiresAggregate { cols: cols.clone() });
+            }
+            for col in cols {
+                if model.field_by_column(col).is_none() {
+                    return Err(QueryError::UnknownField {
+                        model: model.name,
+                        field: (*col).to_owned(),
+                    });
+                }
+            }
+            cols.clone()
+        } else if has_aggregating {
+            // Shape 3 — group by every scalar column on the model.
+            // Mirrors Django's "implicit GROUP BY all selected
+            // non-aggregate columns".
+            model.scalar_fields().map(|f| f.column).collect()
+        } else {
+            // No aggregating annotation, no values — pure window
+            // annotation path (issue #7) or empty builder. No GROUP BY.
+            Vec::new()
+        };
+
         Ok(AggregateQuery {
             model,
             where_clause,
-            group_by: self.group_by,
+            group_by,
             aggregates: self.aggregates,
             having: self.having,
             order_by,

--- a/crates/rustango/tests/groupby_inference.rs
+++ b/crates/rustango/tests/groupby_inference.rs
@@ -1,0 +1,295 @@
+//! Tri-dialect emission tests for Django-shape GROUP BY auto-inference
+//! (issue #75). The inference rule:
+//!   * `.values(cols).annotate(agg)` → `GROUP BY cols` (Shape 2)
+//!   * `.annotate(agg)` alone        → `GROUP BY` every scalar column (Shape 3)
+//!   * `.annotate(window)` only      → no GROUP BY (window funcs are per-row)
+//!   * Explicit `.group_by(...)`     → always wins; values still drives nothing
+//!     (we trust the explicit list).
+
+use rustango::core::aggregates::{count_all, sum};
+use rustango::core::window::row_number;
+use rustango::core::{Column as _, QueryError};
+use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "gbi_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    author_id: i64,
+    #[rustango(max_length = 20)]
+    status: String,
+    views: i64,
+    revenue: i64,
+}
+
+// ---------- Shape 2: .values(cols).annotate(agg) → GROUP BY cols ----------
+
+#[test]
+fn values_then_aggregate_emits_group_by_values() {
+    let q = Post::objects()
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"SELECT "author_id""#),
+        "projection: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains(r#"GROUP BY "author_id""#),
+        "group by: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn values_multi_column_groups_by_all_listed_cols() {
+    let q = Post::objects()
+        .values(&["author_id", "status"])
+        .annotate("revenue_total", sum("revenue").into())
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"GROUP BY "author_id", "status""#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn values_with_filter_emits_where_before_group_by() {
+    let q = Post::objects()
+        .where_(Post::status.eq("published".to_owned()))
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    let wh = stmt.sql.find("WHERE").unwrap();
+    let gb = stmt.sql.find("GROUP BY").unwrap();
+    assert!(wh < gb, "WHERE before GROUP BY: {}", stmt.sql);
+}
+
+// ---------- Shape 3: bare .annotate(agg) → GROUP BY all scalar cols ----------
+
+#[test]
+fn bare_annotate_groups_by_every_scalar_column() {
+    let q = Post::objects()
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    for col in ["id", "author_id", "status", "views", "revenue"] {
+        assert!(
+            stmt.sql.contains(&format!(r#""{col}""#)),
+            "Shape 3 must include every scalar col in GROUP BY — missing `{col}`: {}",
+            stmt.sql
+        );
+    }
+    assert!(stmt.sql.contains("GROUP BY"), "got: {}", stmt.sql);
+}
+
+// ---------- Window-only: no GROUP BY ----------
+
+#[test]
+fn window_only_annotate_emits_no_group_by() {
+    let q = Post::objects()
+        .aggregate()
+        // Window functions are per-row; no GROUP BY required.
+        .annotate("rn", row_number().order_by(&[("views", true)]).into())
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        !stmt.sql.contains("GROUP BY"),
+        "window-only must not emit GROUP BY: {}",
+        stmt.sql
+    );
+    assert!(stmt.sql.contains("ROW_NUMBER()"), "got: {}", stmt.sql);
+}
+
+// ---------- Explicit .group_by(...) wins ----------
+
+#[test]
+fn explicit_group_by_overrides_values() {
+    // User asked .values("author_id") but also .group_by("status") —
+    // we trust the explicit list and emit GROUP BY status (not author_id).
+    let q = Post::objects()
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .group_by("status")
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"GROUP BY "status""#),
+        "explicit wins: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains(r#"GROUP BY "author_id""#),
+        "values list should not leak into GROUP BY when explicit was set: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn explicit_group_by_skips_shape_3_inference() {
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"GROUP BY "author_id""#),
+        "got: {}",
+        stmt.sql
+    );
+    // Other scalar cols must NOT have crept in.
+    assert!(
+        !stmt.sql.contains(r#"GROUP BY "id", "author_id""#),
+        "Shape 3 fallback should not fire when group_by is explicit: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Error paths ----------
+
+#[test]
+fn values_alone_without_aggregate_errors() {
+    let r = Post::objects().values(&["author_id"]).compile();
+    match r {
+        Err(QueryError::ValuesRequiresAggregate { cols }) => {
+            assert_eq!(cols, vec!["author_id"]);
+        }
+        other => panic!("expected ValuesRequiresAggregate, got: {other:?}"),
+    }
+}
+
+#[test]
+fn values_with_only_window_annotation_errors() {
+    // Window doesn't aggregate — same path as no aggregate at all.
+    let r = Post::objects()
+        .values(&["author_id"])
+        .annotate("rn", row_number().order_by(&[("views", true)]).into())
+        .compile();
+    assert!(matches!(r, Err(QueryError::ValuesRequiresAggregate { .. })));
+}
+
+#[test]
+fn values_with_unknown_column_errors() {
+    let r = Post::objects()
+        .values(&["nope_col"])
+        .annotate("n", count_all().into())
+        .compile();
+    match r {
+        Err(QueryError::UnknownField { field, .. }) => assert_eq!(field, "nope_col"),
+        other => panic!("expected UnknownField, got: {other:?}"),
+    }
+}
+
+#[test]
+fn explicit_group_by_unknown_column_errors() {
+    let r = Post::objects()
+        .aggregate()
+        .group_by("nope_col")
+        .annotate("n", count_all().into())
+        .compile();
+    match r {
+        Err(QueryError::UnknownField { field, .. }) => assert_eq!(field, "nope_col"),
+        other => panic!("expected UnknownField, got: {other:?}"),
+    }
+}
+
+// ---------- Tri-dialect ident-quote shapes ----------
+
+#[test]
+fn mysql_backticks_in_values_path() {
+    let q = Post::objects()
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains("`author_id`") && stmt.sql.contains("GROUP BY `author_id`"),
+        "MySQL shape: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn sqlite_double_quotes_in_values_path() {
+    let q = Post::objects()
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = Sqlite.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""author_id""#) && stmt.sql.contains(r#"GROUP BY "author_id""#),
+        "SQLite shape: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn mysql_backticks_in_shape3_path() {
+    let q = Post::objects()
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_aggregate(&q).unwrap();
+    // Sanity — MySQL backticks present + GROUP BY contains every scalar col.
+    for col in ["id", "author_id", "status", "views", "revenue"] {
+        assert!(
+            stmt.sql.contains(&format!("`{col}`")),
+            "MySQL Shape 3 missing `{col}`: {}",
+            stmt.sql
+        );
+    }
+}
+
+#[test]
+fn sqlite_shape3_includes_all_cols() {
+    let q = Post::objects()
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let stmt = Sqlite.compile_aggregate(&q).unwrap();
+    for col in ["id", "author_id", "status", "views", "revenue"] {
+        assert!(
+            stmt.sql.contains(&format!(r#""{col}""#)),
+            "SQLite Shape 3 missing \"{col}\": {}",
+            stmt.sql
+        );
+    }
+}
+
+// ---------- QuerySet::annotate shortcut ----------
+
+#[test]
+fn queryset_annotate_promotes_to_aggregate_builder() {
+    // Calling `.annotate()` directly on QuerySet (without `.aggregate()`)
+    // should produce the same SQL as the explicit two-step form.
+    let q1 = Post::objects()
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let q2 = Post::objects()
+        .aggregate()
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let s1 = Postgres.compile_aggregate(&q1).unwrap().sql;
+    let s2 = Postgres.compile_aggregate(&q2).unwrap().sql;
+    assert_eq!(s1, s2, "shortcut SQL must match explicit aggregate path");
+}

--- a/crates/rustango/tests/groupby_inference_live.rs
+++ b/crates/rustango/tests/groupby_inference_live.rs
@@ -1,0 +1,182 @@
+#![cfg(feature = "postgres")]
+//! Live PG end-to-end tests for GROUP BY auto-inference (issue #75).
+//! The emission tests pin the SQL strings; this confirms the database
+//! actually groups rows the way we expect.
+//!
+//! Skips silently when `DATABASE_URL` is unset.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use rustango::core::aggregates::{count_all, sum};
+use rustango::core::SqlValue;
+use rustango::sql::{fetch_aggregate, sqlx, Auto};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gbi_sale")]
+#[allow(dead_code)]
+pub struct Sale {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub author_id: i64,
+    #[rustango(max_length = 10)]
+    pub month: String,
+    pub amount: i64,
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "gbi_sale" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "gbi_sale" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "author_id" BIGINT NOT NULL,
+            "month" VARCHAR(10) NOT NULL,
+            "amount" BIGINT NOT NULL
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"INSERT INTO "gbi_sale" ("author_id", "month", "amount") VALUES
+            (1, '2026-01',  100),
+            (1, '2026-01',   50),
+            (1, '2026-02',  200),
+            (2, '2026-01',  300),
+            (2, '2026-02',  400),
+            (2, '2026-02',   50),
+            (3, '2026-01',  999)"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn cleanup(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "gbi_sale" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+fn get_i64(row: &HashMap<String, SqlValue>, key: &str) -> i64 {
+    match row.get(key).unwrap_or(&SqlValue::Null) {
+        SqlValue::I64(n) => *n,
+        other => panic!("expected i64 at `{key}`, got {other:?}"),
+    }
+}
+
+fn get_string<'r>(row: &'r HashMap<String, SqlValue>, key: &str) -> &'r str {
+    match row.get(key).unwrap_or(&SqlValue::Null) {
+        SqlValue::String(s) => s.as_str(),
+        other => panic!("expected String at `{key}`, got {other:?}"),
+    }
+}
+
+/// Shape 2 — `.values("author_id").annotate("n", count(*))`.
+/// "Sales per author" — the Django canonical example.
+#[tokio::test]
+async fn shape2_posts_per_author() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Sale::objects()
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    assert_eq!(rows.len(), 3, "three distinct authors");
+    let mut by_author: HashMap<i64, i64> = rows
+        .iter()
+        .map(|r| (get_i64(r, "author_id"), get_i64(r, "n")))
+        .collect();
+    assert_eq!(by_author.remove(&1), Some(3), "author 1 → 3 sales");
+    assert_eq!(by_author.remove(&2), Some(3), "author 2 → 3 sales");
+    assert_eq!(by_author.remove(&3), Some(1), "author 3 → 1 sale");
+
+    cleanup(&pool).await;
+}
+
+/// Shape 2 multi-column — `.values("author_id", "month").annotate("total", sum)`.
+/// "Monthly revenue per author".
+#[tokio::test]
+async fn shape2_monthly_revenue_per_author() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Sale::objects()
+        .values(&["author_id", "month"])
+        .annotate("total", sum("amount").into())
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    // Distinct (author, month) pairs: (1,'01'), (1,'02'), (2,'01'),
+    // (2,'02'), (3,'01') = 5 rows.
+    assert_eq!(rows.len(), 5, "5 (author, month) buckets");
+
+    // Spot-check author 1 / month 2026-01 totals 100 + 50 = 150.
+    let row = rows
+        .iter()
+        .find(|r| get_i64(r, "author_id") == 1 && get_string(r, "month") == "2026-01")
+        .expect("author=1, month=2026-01 row");
+    assert_eq!(get_i64(row, "total"), 150);
+
+    // Author 2 / month 2026-02 totals 400 + 50 = 450.
+    let row = rows
+        .iter()
+        .find(|r| get_i64(r, "author_id") == 2 && get_string(r, "month") == "2026-02")
+        .expect("author=2, month=2026-02 row");
+    assert_eq!(get_i64(row, "total"), 450);
+
+    cleanup(&pool).await;
+}
+
+/// Shape 3 — bare `.annotate(...)` without `.values(...)`. Django's
+/// implicit "GROUP BY every selected non-aggregate column" rule. The
+/// test runs the query and proves the database accepts the inferred
+/// SELECT-all-cols + GROUP-BY-all-cols shape.
+#[tokio::test]
+async fn shape3_bare_annotate_runs_with_group_by_all() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Sale::objects()
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    // Every row has a unique (id, author_id, month, amount) tuple,
+    // so GROUP-BY-all-cols collapses to no-op — 7 rows in, 7 rows out.
+    assert_eq!(rows.len(), 7, "GROUP BY every col → row count unchanged");
+    // Every result row should carry n=1 (each input row is its own group).
+    for r in &rows {
+        assert_eq!(get_i64(r, "n"), 1, "GROUP BY all cols → COUNT = 1 per row");
+    }
+
+    cleanup(&pool).await;
+}

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -533,13 +533,52 @@ let total_views = Post::objects().sum::<i64>(Post::view_count, &pool).await?;
 let avg_views = Post::objects().avg(Post::view_count, &pool).await?;
 let max_views = Post::objects().max::<i64>(Post::view_count, &pool).await?;
 
-// Annotate (per-row aggregation)
-use rustango::core::AggregateExpr;
-let counts = Author::objects()
-    .annotate("post_count", AggregateExpr::CountChildren("posts", "author_id"))
-    .fetch(&pool).await?;
-// each Author gets a `post_count` extra field accessible via the annotated row
+// Annotate + GROUP BY (issue #75 — Django-shape auto-inference)
+use rustango::core::aggregates::{count_all, sum};
+
+// "Posts per author" — `.values()` lists the GROUP BY columns.
+let by_author = Sale::objects()
+    .values(&["author_id"])
+    .annotate("n", count_all().into())
+    .compile()?;
+let rows = rustango::sql::fetch_aggregate(&by_author, &pool).await?;
+// rows: Vec<HashMap<String, SqlValue>> — { author_id: 1, n: 3 }, …
 ```
+
+### GROUP BY auto-inference — `.values().annotate()` / bare `.annotate()`
+
+Issue #75 closes the Django ergonomic gap: GROUP BY is **inferred** from the queryset's shape — you never call a `.group_by(...)` builder unless you're overriding the inference.
+
+| Shape | Builder | Resulting `GROUP BY` |
+|---|---|---|
+| **2 — values + aggregate** | `.values(&["author_id"]).annotate("n", count_all().into())` | `GROUP BY "author_id"` |
+| **3 — bare aggregate** | `.annotate("n", count_all().into())` | `GROUP BY` every non-aggregate scalar column on the model |
+| **Window-only** | `.aggregate().annotate("rn", row_number()…)` | (no `GROUP BY` — window funcs are per-row) |
+| **Explicit override** | `.aggregate().group_by("month").annotate(...)` | `GROUP BY "month"` — explicit wins |
+
+The classifier `AggregateExpr::is_aggregating()` distinguishes the row-collapsing variants (`Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` / `StdDev*` / `Variance*` — plus recursive `Filtered` / `Coalesced` wrappers) from `Window`, which is per-row. Only the aggregating variants trigger Shape 3 inference.
+
+```rust
+use rustango::core::aggregates::{count_all, sum};
+
+// Shape 2 — "monthly revenue per author".
+Sale::objects()
+    .where_(Sale::status.eq("paid"))
+    .values(&["author_id", "month"])
+    .annotate("total", sum("amount").into())
+    .compile()?;
+// → SELECT "author_id", "month", SUM("amount")::bigint AS "total"
+//   FROM "sale" WHERE "status" = $1
+//   GROUP BY "author_id", "month"
+
+// Shape 3 — "each author + their post count". Every Author column
+// lands in both the SELECT list and the GROUP BY.
+Author::objects()
+    .annotate("post_count", count_all().filter(Author::id.eq(Post::author_id)).into())
+    .compile()?;
+```
+
+**Pure projection caveat.** `.values(cols)` *alone* (no aggregate annotation) is **not** supported in v0.40 — `compile()` returns `QueryError::ValuesRequiresAggregate`. Pure projection-as-dicts needs a separate writer path (it's a SELECT without GROUP BY, decoded into `Vec<HashMap>`) and is queued for a follow-up. For now, use the typed `QuerySet::fetch(...)` to read whole rows.
 
 ### Conditional aggregates — `filter=` + `default=` + StdDev/Variance
 


### PR DESCRIPTION
## Summary

Django has no `.group_by()` method — GROUP BY is inferred from the queryset's shape. This slice ports that rule. Pairs naturally with #74 (HAVING auto-routing, just shipped) — together they close the "Django ergonomic aggregation" gap from the #62 epic.

Resolves the cookbook caveat from PR #83: *"until #75 ships, projecting row columns alongside a window-annotation needs every row column listed in `.group_by(...)` plus a placeholder aggregate."*

### Inference rule

| Shape | Builder | Resulting `GROUP BY` |
|---|---|---|
| **2** — values + aggregate | `.values(&["author_id"]).annotate("n", count_all().into())` | `GROUP BY "author_id"` |
| **3** — bare aggregate | `.annotate("n", count_all().into())` | every non-aggregate scalar column on the model |
| **Window-only** | `.aggregate().annotate("rn", row_number()...)` | none (window funcs are per-row) |
| **Explicit override** | `.aggregate().group_by("month").annotate(...)` | the explicit list wins |

### Discriminator

`AggregateExpr::is_aggregating()` distinguishes the row-collapsing variants (`Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` / `StdDev*` / `Variance*` — plus recursive `Filtered` / `Coalesced` wrappers) from `Window`, which is per-row. Only the aggregating variants trigger Shape 3 inference.

### Surface additions

- `QuerySet::values(&[&str])` — auto-promote to `AggregateBuilder` with projection set. Matches Django's `Post.objects.values('author_id').annotate(...)` shape.
- `QuerySet::annotate(alias, expr)` — same auto-promote, no projection.
- `AggregateBuilder::values(&[&str])` — mid-chain projection setter when you started from `.aggregate()`.
- `AggregateExpr::is_aggregating(&self) -> bool` — public classifier.

### Validation

Explicit `.group_by(...)` and `.values(...)` column lists are walked against the model schema; typo'd columns surface as `QueryError::UnknownField` at `compile()` time, not at the DB.

### Intentional scope limit — pure projection deferred

`.values(cols)` *alone* (no aggregate annotation) returns `QueryError::ValuesRequiresAggregate` for v1. The "`Vec<HashMap>` projection without GROUP BY" path needs a separate writer projection field (today the writer derives the SELECT list from `group_by ∪ aggregates`); that's queued as a follow-up issue. Documented in the cookbook. The error message points users at `QuerySet::fetch(...)` for now.

## Test plan

- [x] 16 tri-dialect emission tests in `tests/groupby_inference.rs` — Shape 2 / Shape 3 / Window-only / explicit-wins / error paths / MySQL backticks / SQLite double-quotes / QuerySet shortcut path
- [x] 3 live PG round-trip tests in `tests/groupby_inference_live.rs` — posts-per-author, monthly-revenue-per-author, Shape 3 GROUP-BY-all-cols-collapses-to-1-per-row
- [x] 1494 lib tests pass with `--features tenancy`
- [x] Abstract-code litmus: `cargo build --no-default-features --features sqlite,tenancy` clean
- [x] Cookbook (`docs/orm.md`) — new "GROUP BY auto-inference" section with the shape table + pure-projection caveat; stale `CountChildren` example in the opening Aggregations section replaced