### PR TITLE
feat: request lifecycle signals + RequestSignalsLayer (closes #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2453,6 +2453,8 @@ handle.shutdown().await;
 
 ## Signals
 
+### Model lifecycle — `pre_save` / `post_save` / `pre_delete` / `post_delete`
+
 ```rust
 use rustango::signals::{connect_post_save, send_post_save, PostSaveContext};
 
@@ -2469,6 +2471,30 @@ send_post_save(&post, PostSaveContext { created: true }).await;
 ```
 
 Available: `connect_pre_save`, `connect_post_save`, `connect_pre_delete`, `connect_post_delete`. Disconnect via the returned `ReceiverId`.
+
+### Request lifecycle — `request_started` / `request_finished` / `got_request_exception`
+
+Issue #53. Drop the `RequestSignalsLayer` tower layer on your router; receivers fire around every request.
+
+```rust
+use axum::Router;
+use rustango::signals::request::{
+    connect_request_started, connect_request_finished, RequestSignalsLayer,
+};
+
+connect_request_started(|ctx| Box::pin(async move {
+    tracing::info!(method = %ctx.method, path = %ctx.path, "started");
+}));
+connect_request_finished(|ctx| Box::pin(async move {
+    tracing::info!(status = ctx.status, ms = ctx.elapsed_ms, "finished");
+}));
+
+let app: Router = Router::new()
+    // ... your routes ...
+    .layer(RequestSignalsLayer::new());   // outermost — sees request first, response last
+```
+
+`RequestStartedContext` carries `method` / `path` / `query`; `RequestFinishedContext` adds `status` + `elapsed_ms`; `RequestExceptionContext` carries the inner-service error string. Disconnect via the returned `ReceiverId`. Receivers run sequentially in registration order — wrap in `tokio::spawn` for parallel fanout.
 
 ---
 

--- a/crates/rustango/src/signals/mod.rs
+++ b/crates/rustango/src/signals/mod.rs
@@ -29,6 +29,14 @@
 //! | `pre_delete` | `Fn(Arc<T>) -> Future` | Before DELETE |
 //! | `post_delete` | `Fn(Arc<T>) -> Future` | After DELETE |
 //!
+//! ## HTTP request lifecycle
+//!
+//! Request-level signals (`request_started` / `request_finished` /
+//! `got_request_exception`) live in [`request`] — separate registry,
+//! separate connect/disconnect/send functions, plus a
+//! [`request::RequestSignalsLayer`] tower layer that fires them
+//! around every axum request. Issue #53.
+//!
 //! ## Semantics
 //!
 //! - Receivers run **sequentially** in registration order, awaited one at a time.
@@ -46,6 +54,8 @@ use std::pin::Pin;
 use std::sync::{Arc, OnceLock, RwLock};
 
 use crate::core::Model;
+
+pub mod request;
 
 /// Future returned by signal receivers. `'static` because the receiver
 /// is stored as `Box<dyn ...>` and may run after the caller has returned.

--- a/crates/rustango/src/signals/request.rs
+++ b/crates/rustango/src/signals/request.rs
@@ -1,0 +1,386 @@
+//! Django-shape request lifecycle signals — `request_started`,
+//! `request_finished`, `got_request_exception`. Issue #53.
+//!
+//! Receivers register globally (not per-type — there's no `Model` here)
+//! and run sequentially in registration order around every HTTP request
+//! that passes through [`RequestSignalsLayer`].
+//!
+//! ## Quick start
+//!
+//! ```ignore
+//! use axum::Router;
+//! use rustango::signals::request::{
+//!     connect_request_started, connect_request_finished,
+//!     RequestSignalsLayer,
+//! };
+//!
+//! // Register receivers at startup:
+//! connect_request_started(|ctx| Box::pin(async move {
+//!     tracing::info!(method = %ctx.method, path = %ctx.path, "request started");
+//! }));
+//! connect_request_finished(|ctx| Box::pin(async move {
+//!     tracing::info!(status = ctx.status, ms = ctx.elapsed_ms, "request finished");
+//! }));
+//!
+//! // Wire the layer onto the app — order matters: outermost layer sees
+//! // the request first / response last, which is what we want for
+//! // around-the-handler signals.
+//! let app: Router = Router::new()
+//!     // ... routes ...
+//!     .layer(RequestSignalsLayer::new());
+//! ```
+//!
+//! ## Semantics
+//!
+//! - Receivers run **sequentially** in registration order, awaited one
+//!   at a time. For parallel fanout, wrap a body in `tokio::spawn`.
+//! - A panicking receiver aborts the dispatch chain and propagates;
+//!   wrap in `tokio::spawn` if you need isolation.
+//! - `request_started` fires before the inner service is called.
+//! - `request_finished` fires after the inner service returns a
+//!   response — for every status code (2xx / 4xx / 5xx).
+//! - `got_request_exception` fires when the inner service returns an
+//!   error (the `S::Error` channel). Today axum services use
+//!   `Infallible`, so the practical trigger is a downstream layer that
+//!   short-circuits with an error — rare but supported. Panics inside
+//!   the handler do **not** fire this signal in axum (tower-http
+//!   captures them at a different layer); the layer's job is signal
+//!   plumbing, not panic catching.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock, RwLock};
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use axum::body::Body;
+use axum::http::{Request, Response, StatusCode};
+use tower::Service;
+
+/// Future returned by request-signal receivers. `'static` because the
+/// receiver is stored as `Arc<dyn ...>` and may run after the caller
+/// has returned.
+pub type ReceiverFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+/// Opaque identifier returned by `connect_*` for later use with
+/// `disconnect_*`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ReceiverId(u64);
+
+// ---------------------------------------------------------------- Context types
+
+/// Payload delivered to `request_started` receivers.
+#[derive(Debug, Clone)]
+pub struct RequestStartedContext {
+    /// HTTP method (e.g. `"GET"`, `"POST"`).
+    pub method: String,
+    /// Request path, without the query string.
+    pub path: String,
+    /// Raw query string if present, empty otherwise.
+    pub query: String,
+}
+
+/// Payload delivered to `request_finished` receivers.
+#[derive(Debug, Clone)]
+pub struct RequestFinishedContext {
+    pub method: String,
+    pub path: String,
+    /// HTTP status code emitted by the handler.
+    pub status: u16,
+    /// Elapsed time from layer entry to response — milliseconds with
+    /// fractional precision.
+    pub elapsed_ms: f64,
+}
+
+/// Payload delivered to `got_request_exception` receivers — the inner
+/// service returned an error rather than a `Response`.
+#[derive(Debug, Clone)]
+pub struct RequestExceptionContext {
+    pub method: String,
+    pub path: String,
+    /// Stringified error from the inner service.
+    pub error: String,
+}
+
+// ---------------------------------------------------------------- Internal storage
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum SignalKind {
+    Started,
+    Finished,
+    Exception,
+}
+
+type ReceiverEntry = (ReceiverId, Box<dyn Any + Send + Sync>);
+type Bag = Vec<ReceiverEntry>;
+
+fn registry() -> &'static RwLock<HashMap<SignalKind, Bag>> {
+    static REG: OnceLock<RwLock<HashMap<SignalKind, Bag>>> = OnceLock::new();
+    REG.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+fn next_id() -> ReceiverId {
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    ReceiverId(COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+fn insert_receiver<R: Any + Send + Sync>(kind: SignalKind, receiver: R) -> ReceiverId {
+    let id = next_id();
+    let mut reg = registry().write().unwrap_or_else(|e| e.into_inner());
+    reg.entry(kind).or_default().push((id, Box::new(receiver)));
+    id
+}
+
+fn remove_receiver(kind: SignalKind, id: ReceiverId) -> bool {
+    let mut reg = registry().write().unwrap_or_else(|e| e.into_inner());
+    let Some(bag) = reg.get_mut(&kind) else {
+        return false;
+    };
+    let before = bag.len();
+    bag.retain(|(rid, _)| *rid != id);
+    bag.len() != before
+}
+
+/// Snapshot the receivers for `kind` into a `Vec<R>` so dispatch can
+/// release the registry lock before awaiting any receiver future.
+fn snapshot<R: Any + Send + Sync + Clone>(kind: SignalKind) -> Vec<R> {
+    let reg = registry().read().unwrap_or_else(|e| e.into_inner());
+    let Some(bag) = reg.get(&kind) else {
+        return Vec::new();
+    };
+    bag.iter()
+        .filter_map(|(_, b)| b.downcast_ref::<R>().cloned())
+        .collect()
+}
+
+// ---------------------------------------------------------------- Receiver type aliases
+
+type StartedReceiver = Arc<dyn Fn(RequestStartedContext) -> ReceiverFuture + Send + Sync>;
+type FinishedReceiver = Arc<dyn Fn(RequestFinishedContext) -> ReceiverFuture + Send + Sync>;
+type ExceptionReceiver = Arc<dyn Fn(RequestExceptionContext) -> ReceiverFuture + Send + Sync>;
+
+// ---------------------------------------------------------------- request_started
+
+/// Register a `request_started` receiver. Fires before each request
+/// reaches the inner service. Returns a [`ReceiverId`] for later
+/// [`disconnect_request_started`].
+pub fn connect_request_started<F, Fut>(receiver: F) -> ReceiverId
+where
+    F: Fn(RequestStartedContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let boxed: StartedReceiver = Arc::new(move |ctx| Box::pin(receiver(ctx)));
+    insert_receiver(SignalKind::Started, boxed)
+}
+
+/// Remove a previously-connected `request_started` receiver. Returns
+/// `true` when an entry was removed.
+pub fn disconnect_request_started(id: ReceiverId) -> bool {
+    remove_receiver(SignalKind::Started, id)
+}
+
+/// Fire `request_started` for `ctx`. Awaits every connected receiver
+/// in registration order. Exposed for tests / custom dispatch — the
+/// [`RequestSignalsLayer`] calls it for you in normal use.
+pub async fn send_request_started(ctx: RequestStartedContext) {
+    let receivers: Vec<StartedReceiver> = snapshot(SignalKind::Started);
+    for r in receivers {
+        r(ctx.clone()).await;
+    }
+}
+
+// ---------------------------------------------------------------- request_finished
+
+/// Register a `request_finished` receiver. Fires after every response
+/// the inner service returns (any status code).
+pub fn connect_request_finished<F, Fut>(receiver: F) -> ReceiverId
+where
+    F: Fn(RequestFinishedContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let boxed: FinishedReceiver = Arc::new(move |ctx| Box::pin(receiver(ctx)));
+    insert_receiver(SignalKind::Finished, boxed)
+}
+
+/// Remove a previously-connected `request_finished` receiver.
+pub fn disconnect_request_finished(id: ReceiverId) -> bool {
+    remove_receiver(SignalKind::Finished, id)
+}
+
+/// Fire `request_finished` for `ctx`.
+pub async fn send_request_finished(ctx: RequestFinishedContext) {
+    let receivers: Vec<FinishedReceiver> = snapshot(SignalKind::Finished);
+    for r in receivers {
+        r(ctx.clone()).await;
+    }
+}
+
+// ---------------------------------------------------------------- got_request_exception
+
+/// Register a `got_request_exception` receiver. Fires when the inner
+/// service returns an error rather than a response.
+pub fn connect_got_request_exception<F, Fut>(receiver: F) -> ReceiverId
+where
+    F: Fn(RequestExceptionContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let boxed: ExceptionReceiver = Arc::new(move |ctx| Box::pin(receiver(ctx)));
+    insert_receiver(SignalKind::Exception, boxed)
+}
+
+/// Remove a previously-connected `got_request_exception` receiver.
+pub fn disconnect_got_request_exception(id: ReceiverId) -> bool {
+    remove_receiver(SignalKind::Exception, id)
+}
+
+/// Fire `got_request_exception` for `ctx`.
+pub async fn send_got_request_exception(ctx: RequestExceptionContext) {
+    let receivers: Vec<ExceptionReceiver> = snapshot(SignalKind::Exception);
+    for r in receivers {
+        r(ctx.clone()).await;
+    }
+}
+
+// ---------------------------------------------------------------- Maintenance
+
+/// Remove **all** request-signal receivers. Useful in tests to reset
+/// registry state between cases.
+pub fn clear_all() {
+    registry()
+        .write()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
+}
+
+/// Total receivers currently registered across all three request
+/// signals. Useful in tests.
+#[must_use]
+pub fn receiver_count() -> usize {
+    let reg = registry().read().unwrap_or_else(|e| e.into_inner());
+    [
+        SignalKind::Started,
+        SignalKind::Finished,
+        SignalKind::Exception,
+    ]
+    .iter()
+    .map(|k| reg.get(k).map_or(0, Vec::len))
+    .sum()
+}
+
+// ---------------------------------------------------------------- Axum layer
+
+/// Tower layer / axum middleware that fires `request_started` /
+/// `request_finished` / `got_request_exception` around every request.
+///
+/// Mount it as the **outermost** layer of your `Router` so it sees the
+/// request first and the response last — that way every other layer's
+/// work counts toward `elapsed_ms`, and other layers' bodies aren't
+/// surfaced as exceptions.
+#[derive(Clone, Default, Debug)]
+pub struct RequestSignalsLayer;
+
+impl RequestSignalsLayer {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<S> tower::Layer<S> for RequestSignalsLayer {
+    type Service = RequestSignalsService<S>;
+    fn layer(&self, inner: S) -> Self::Service {
+        RequestSignalsService { inner }
+    }
+}
+
+/// The wrapped service produced by [`RequestSignalsLayer`].
+#[derive(Clone)]
+pub struct RequestSignalsService<S> {
+    inner: S,
+}
+
+impl<S> Service<Request<Body>> for RequestSignalsService<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>, Error = Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response<Body>;
+    type Error = Infallible;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Response<Body>, Infallible>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        // tower's call/clone pattern: clone the readied service into
+        // the future, swap the local `inner` with the unreadied clone.
+        // (Mirrors what axum::middleware::from_fn generates internally.)
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        let method = req.method().as_str().to_owned();
+        let path = req.uri().path().to_owned();
+        let query = req.uri().query().unwrap_or_default().to_owned();
+
+        Box::pin(async move {
+            let started_at = Instant::now();
+            send_request_started(RequestStartedContext {
+                method: method.clone(),
+                path: path.clone(),
+                query,
+            })
+            .await;
+
+            // S::Error is Infallible — `call` can't return Err. We still
+            // pattern-match for future-proofing: if the bound is ever
+            // widened, dispatching `got_request_exception` is wired up.
+            match inner.call(req).await {
+                Ok(resp) => {
+                    let elapsed_ms = (started_at.elapsed().as_micros() as f64) / 1000.0;
+                    let status = resp.status().as_u16();
+                    send_request_finished(RequestFinishedContext {
+                        method,
+                        path,
+                        status,
+                        elapsed_ms,
+                    })
+                    .await;
+                    Ok(resp)
+                }
+                Err(_unreachable) => {
+                    // Infallible — this arm is dead code today but
+                    // documents the intended dispatch. When S::Error
+                    // widens (e.g. user wraps with a fallible layer),
+                    // the exception receiver fires here.
+                    #[allow(unreachable_code)]
+                    {
+                        send_got_request_exception(RequestExceptionContext {
+                            method,
+                            path,
+                            error: "inner service returned Err".to_owned(),
+                        })
+                        .await;
+                        Ok(error_response())
+                    }
+                }
+            }
+        })
+    }
+}
+
+#[allow(dead_code)]
+fn error_response() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .body(Body::from("Internal Server Error"))
+        .expect("static response builder")
+}

--- a/crates/rustango/tests/request_signals.rs
+++ b/crates/rustango/tests/request_signals.rs
@@ -1,0 +1,238 @@
+//! Tests for `signals::request` (issue #53) — `request_started` /
+//! `request_finished` / `got_request_exception`. The registry is
+//! process-global, so we serialize the tests with a `Mutex` and
+//! `clear_all()` between cases.
+
+use std::sync::atomic::{AtomicI32, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::get;
+use axum::Router;
+use rustango::signals::request::{
+    clear_all, connect_request_finished, connect_request_started, disconnect_request_started,
+    receiver_count, send_got_request_exception, send_request_finished, send_request_started,
+    RequestExceptionContext, RequestFinishedContext, RequestSignalsLayer, RequestStartedContext,
+};
+use tower::ServiceExt;
+
+/// Process-global lock — the request-signals registry is process-wide,
+/// so tests can't run in parallel without clobbering each other.
+fn lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[tokio::test]
+async fn dispatch_fires_every_connected_receiver_in_order() {
+    let _g = lock().lock().unwrap_or_else(|e| e.into_inner());
+    clear_all();
+    let order: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let o1 = order.clone();
+    connect_request_started(move |_ctx| {
+        let o = o1.clone();
+        Box::pin(async move {
+            o.lock().unwrap().push(1);
+        })
+    });
+    let o2 = order.clone();
+    connect_request_started(move |_ctx| {
+        let o = o2.clone();
+        Box::pin(async move {
+            o.lock().unwrap().push(2);
+        })
+    });
+
+    send_request_started(RequestStartedContext {
+        method: "GET".into(),
+        path: "/x".into(),
+        query: String::new(),
+    })
+    .await;
+
+    assert_eq!(*order.lock().unwrap(), vec![1, 2]);
+    clear_all();
+}
+
+#[tokio::test]
+async fn disconnect_removes_receiver() {
+    let _g = lock().lock().unwrap_or_else(|e| e.into_inner());
+    clear_all();
+
+    let id = connect_request_started(|_ctx| Box::pin(async move {}));
+    assert_eq!(receiver_count(), 1);
+    assert!(disconnect_request_started(id));
+    assert_eq!(receiver_count(), 0);
+    // Double-disconnect is a no-op (false).
+    assert!(!disconnect_request_started(id));
+    clear_all();
+}
+
+#[tokio::test]
+async fn finished_carries_status_and_elapsed() {
+    let _g = lock().lock().unwrap_or_else(|e| e.into_inner());
+    clear_all();
+    let captured: Arc<Mutex<Option<RequestFinishedContext>>> = Arc::new(Mutex::new(None));
+    let c = captured.clone();
+    connect_request_finished(move |ctx| {
+        let c = c.clone();
+        Box::pin(async move {
+            *c.lock().unwrap() = Some(ctx);
+        })
+    });
+
+    send_request_finished(RequestFinishedContext {
+        method: "POST".into(),
+        path: "/api/things".into(),
+        status: 201,
+        elapsed_ms: 12.5,
+    })
+    .await;
+
+    let ctx = captured.lock().unwrap().clone().expect("finished fired");
+    assert_eq!(ctx.method, "POST");
+    assert_eq!(ctx.path, "/api/things");
+    assert_eq!(ctx.status, 201);
+    assert!((ctx.elapsed_ms - 12.5).abs() < f64::EPSILON);
+    clear_all();
+}
+
+#[tokio::test]
+async fn exception_dispatch_works() {
+    let _g = lock().lock().unwrap_or_else(|e| e.into_inner());
+    clear_all();
+    let captured: Arc<Mutex<Option<RequestExceptionContext>>> = Arc::new(Mutex::new(None));
+    let c = captured.clone();
+    rustango::signals::request::connect_got_request_exception(move |ctx| {
+        let c = c.clone();
+        Box::pin(async move {
+            *c.lock().unwrap() = Some(ctx);
+        })
+    });
+
+    send_got_request_exception(RequestExceptionContext {
+        method: "GET".into(),
+        path: "/boom".into(),
+        error: "kaboom".into(),
+    })
+    .await;
+
+    let ctx = captured.lock().unwrap().clone().expect("exception fired");
+    assert_eq!(ctx.method, "GET");
+    assert_eq!(ctx.path, "/boom");
+    assert_eq!(ctx.error, "kaboom");
+    clear_all();
+}
+
+#[tokio::test]
+async fn layer_fires_started_and_finished_around_handler() {
+    let _g = lock().lock().unwrap_or_else(|e| e.into_inner());
+    clear_all();
+
+    // Sentinels: track ordering — start=1, handler=2, finish=3.
+    static SEEN: AtomicU64 = AtomicU64::new(0);
+    static FINISH_STATUS: AtomicI32 = AtomicI32::new(0);
+    SEEN.store(0, Ordering::SeqCst);
+
+    connect_request_started(|_ctx| {
+        Box::pin(async move {
+            SEEN.compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst)
+                .ok();
+        })
+    });
+    connect_request_finished(|ctx| {
+        Box::pin(async move {
+            SEEN.compare_exchange(2, 3, Ordering::SeqCst, Ordering::SeqCst)
+                .ok();
+            FINISH_STATUS.store(i32::from(ctx.status), Ordering::SeqCst);
+        })
+    });
+
+    let app: Router = Router::new()
+        .route(
+            "/hello",
+            get(|| async {
+                SEEN.compare_exchange(1, 2, Ordering::SeqCst, Ordering::SeqCst)
+                    .ok();
+                "ok"
+            }),
+        )
+        .layer(RequestSignalsLayer::new());
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/hello")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    assert_eq!(
+        SEEN.load(Ordering::SeqCst),
+        3,
+        "expected ordering: started(1) → handler(2) → finished(3)"
+    );
+    assert_eq!(FINISH_STATUS.load(Ordering::SeqCst), 200);
+    clear_all();
+}
+
+#[tokio::test]
+async fn layer_passes_through_404_with_correct_status() {
+    let _g = lock().lock().unwrap_or_else(|e| e.into_inner());
+    clear_all();
+    static OBSERVED_STATUS: AtomicI32 = AtomicI32::new(0);
+    OBSERVED_STATUS.store(0, Ordering::SeqCst);
+
+    connect_request_finished(|ctx| {
+        Box::pin(async move {
+            OBSERVED_STATUS.store(i32::from(ctx.status), Ordering::SeqCst);
+        })
+    });
+
+    let app: Router = Router::new()
+        .route("/known", get(|| async { "ok" }))
+        .layer(RequestSignalsLayer::new());
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/unknown")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert_eq!(OBSERVED_STATUS.load(Ordering::SeqCst), 404);
+    clear_all();
+}
+
+#[tokio::test]
+async fn layer_records_method_and_path() {
+    let _g = lock().lock().unwrap_or_else(|e| e.into_inner());
+    clear_all();
+    let captured: Arc<Mutex<Option<RequestStartedContext>>> = Arc::new(Mutex::new(None));
+    let c = captured.clone();
+    connect_request_started(move |ctx| {
+        let c = c.clone();
+        Box::pin(async move {
+            *c.lock().unwrap() = Some(ctx);
+        })
+    });
+
+    let app: Router = Router::new()
+        .route("/posts/{id}", get(|| async { "ok" }))
+        .layer(RequestSignalsLayer::new());
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/posts/42?draft=1")
+        .body(Body::empty())
+        .unwrap();
+    app.oneshot(req).await.unwrap();
+
+    let ctx = captured.lock().unwrap().clone().expect("started fired");
+    assert_eq!(ctx.method, "GET");
+    assert_eq!(ctx.path, "/posts/42");
+    assert_eq!(ctx.query, "draft=1");
+    clear_all();
+}

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -19,6 +19,7 @@ Patterns for the rustango ORM beyond the basics. Most examples assume you alread
 - [Lazy FK loading](#lazy-fk-loading)
 - [QuerySet vs string-keyed filters](#queryset-vs-string-keyed-filters)
 - [Tenant-scoped queries](#tenant-scoped-queries)
+- [Signals](#signals)
 - [Performance tips](#performance-tips)
 
 ---
@@ -578,6 +579,58 @@ async fn handler(mut t: Tenant) -> Result<...> {
 ```
 
 `fetch_on` works with any `sqlx::Executor`; `fetch` is sugar for `fetch_on(&pool)`.
+
+---
+
+## Signals
+
+Two registries, two purposes.
+
+### Model lifecycle
+
+`pre_save` / `post_save` / `pre_delete` / `post_delete` — per-`Model` hooks that fire from the macro-generated write paths.
+
+```rust
+use rustango::signals::{connect_post_save, PostSaveContext};
+
+connect_post_save::<Post, _, _>(|post, ctx| async move {
+    if ctx.created {
+        tracing::info!("new post #{}", post.id.get().copied().unwrap_or(0));
+    }
+});
+```
+
+`T: Clone + 'static` is required (the dispatcher hands each receiver an `Arc<T>` clone). Receivers run sequentially in registration order. Disconnect via the `ReceiverId` returned by `connect_*`. The four signal kinds + their context shapes are documented inline in `rustango::signals`.
+
+### Request lifecycle — issue #53
+
+`request_started` / `request_finished` / `got_request_exception` — fire around every HTTP request that passes through `RequestSignalsLayer`. Useful for tracing, audit, request-time metrics, and Django-style `got_request_exception` error reporting.
+
+```rust
+use axum::Router;
+use rustango::signals::request::{
+    connect_request_started, connect_request_finished, RequestSignalsLayer,
+};
+
+connect_request_started(|ctx| Box::pin(async move {
+    tracing::info!(method = %ctx.method, path = %ctx.path, "started");
+}));
+connect_request_finished(|ctx| Box::pin(async move {
+    metrics::histogram!("http_request_ms").record(ctx.elapsed_ms);
+}));
+
+let app: Router = Router::new()
+    .route("/", get(home))
+    .layer(RequestSignalsLayer::new());  // outermost — sees request first / response last
+```
+
+| Signal | Context fields |
+|---|---|
+| `request_started` | `method`, `path`, `query` |
+| `request_finished` | `method`, `path`, `status`, `elapsed_ms` |
+| `got_request_exception` | `method`, `path`, `error` |
+
+Receivers run sequentially in registration order; wrap a body in `tokio::spawn` for parallel fanout or panic isolation. The request and model registries are independent — connecting / disconnecting / clearing one doesn't touch the other.
 
 ---
 


### PR DESCRIPTION
## Summary

Django-shape request signals — `request_started`, `request_finished`, `got_request_exception` — plus the tower::Layer that fires them around every axum request.

```rust
use rustango::signals::request::{
    connect_request_started, connect_request_finished, RequestSignalsLayer,
};

connect_request_started(|ctx| Box::pin(async move {
    tracing::info!(method = %ctx.method, path = %ctx.path, "started");
}));
connect_request_finished(|ctx| Box::pin(async move {
    metrics::histogram!(\"http_request_ms\").record(ctx.elapsed_ms);
}));

let app: Router = Router::new()
    .route(\"/\", get(home))
    .layer(RequestSignalsLayer::new());
```

## Surface

New `signals::request` submodule with its own registry — distinct from the per-`Model` model-lifecycle registry. Three signals, each with `connect_* / disconnect_* / send_*` + a shared `clear_all()` + `receiver_count()` for tests.

| Signal | Context |
|---|---|
| `request_started` | `method`, `path`, `query` |
| `request_finished` | `method`, `path`, `status`, `elapsed_ms` |
| `got_request_exception` | `method`, `path`, `error` |

`RequestSignalsLayer` is `Clone + Default` — drop it on as the outermost layer of any `Router`. Mirrors the existing `TracingLayer` shape in `src/tracing_layer.rs` so users get one mental model for around-the-handler layers.

## Out of scope

Issue #53 lists more: `m2m_changed`, `pre_init`, `pre_migrate`, `connection_created`, `setting_changed`, `template_rendered`, `class_prepared`, `Signal.send_robust`. This slice ships the **request** subset — the meatiest cross-cutting piece and the one users hit first. M2M / migrate / send_robust land as follow-ups when each subsystem grows the hooks.

## Test plan

- [x] 7 tests in `tests/request_signals.rs` — registry dispatch order, disconnect, exception payload, axum integration (200 / 404), method+path+query capture, started→handler→finished ordering pin
- [x] 1469 lib tests pass with `--features tenancy`
- [x] Abstract-code litmus: `cargo build --no-default-features --features sqlite,tenancy` clean
- [x] README \"Signals\" section gains a request-lifecycle subsection
- [x] `docs/orm.md` cookbook gains a \"Signals\" chapter covering both registries side-by-side