### PR TITLE
feat: ContentType batch lookup + in-process cache (closes #35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,17 +1069,31 @@ let inserted = rustango::contenttypes::ensure_seeded(&pool).await?;
 ```rust
 use rustango::contenttypes::ContentType;
 
-// By Rust type
-let ct = ContentType::for_model::<Post>(&pool).await?;       // Option<ContentType>
+// By Rust type (uncached)
+let ct = ContentType::for_model_pool::<Post>(&pool).await?;  // Option<ContentType>
 
-// By natural key (parsed permission codenames, admin URLs, etc.)
-let ct = ContentType::by_natural_key(&pool, "blog", "post").await?;
+// By Rust type (cached — issue #35)
+let ct = ContentType::for_model_cached_pool::<Post>(&pool).await?;
 
-// By id (FK joins from audit log / permissions / generic FK rows)
-let ct = ContentType::by_id(&pool, 7).await?;
+// By natural key — uncached and cached forms
+let ct = ContentType::by_natural_key_pool(&pool, "blog", "post").await?;
+let ct = ContentType::by_natural_key_cached_pool(&pool, "blog", "post").await?;
+
+// By id
+let ct = ContentType::by_id_pool(&pool, 7).await?;
+
+// Batch lookup (issue #35) — one DB round trip for N models
+use std::collections::HashMap;
+let cts: HashMap<(String, String), ContentType> = ContentType::for_models_pool(
+    &pool,
+    [("blog".to_string(), "post".to_string()), ("auth".to_string(), "user".to_string())],
+).await?;
+
+// Clear the process-wide cache (e.g. after a migration adds models)
+rustango::contenttypes::clear_cache();
 
 // Full listing for admin sidebars / API
-let all_cts = ContentType::all(&pool).await?;                 // ordered (app, model)
+let all_cts = ContentType::all_pool(&pool).await?;            // ordered (app, model)
 ```
 
 #### Composite-key foreign keys (F.2)

--- a/README.md
+++ b/README.md
@@ -1073,18 +1073,18 @@ use rustango::contenttypes::ContentType;
 let ct = ContentType::for_model_pool::<Post>(&pool).await?;  // Option<ContentType>
 
 // By Rust type (cached — issue #35)
-let ct = ContentType::for_model_cached_pool::<Post>(&pool).await?;
+let ct = ContentType::get_for_model::<Post>(&pool).await?;
 
 // By natural key — uncached and cached forms
 let ct = ContentType::by_natural_key_pool(&pool, "blog", "post").await?;
-let ct = ContentType::by_natural_key_cached_pool(&pool, "blog", "post").await?;
+let ct = ContentType::get_by_natural_key(&pool, "blog", "post").await?;
 
 // By id
 let ct = ContentType::by_id_pool(&pool, 7).await?;
 
 // Batch lookup (issue #35) — one DB round trip for N models
 use std::collections::HashMap;
-let cts: HashMap<(String, String), ContentType> = ContentType::for_models_pool(
+let cts: HashMap<(String, String), ContentType> = ContentType::get_for_models(
     &pool,
     [("blog".to_string(), "post".to_string()), ("auth".to_string(), "user".to_string())],
 ).await?;

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -249,7 +249,7 @@ impl ContentType {
     /// use rustango::contenttypes::ContentType;
     ///
     /// // String literals work directly — no `.to_string()` needed.
-    /// let cts = ContentType::for_models_pool(
+    /// let cts = ContentType::get_for_models(
     ///     &pool,
     ///     [("blog", "post"), ("blog", "author"), ("auth", "user")],
     /// ).await?;
@@ -258,7 +258,7 @@ impl ContentType {
     ///
     /// # Errors
     /// As [`Self::all_pool`].
-    pub async fn for_models_pool<A, B, I>(
+    pub async fn get_for_models<A, B, I>(
         pool: &crate::sql::Pool,
         pairs: I,
     ) -> Result<std::collections::HashMap<(String, String), Self>, ExecError>
@@ -304,8 +304,8 @@ impl ContentType {
 // ============================================================ #35 — in-process cache
 
 /// Process-wide cache of `(app_label, model_name) → ContentType`.
-/// Read-mostly: populated lazily by [`ContentType::for_model_cached_pool`]
-/// / [`ContentType::by_natural_key_cached_pool`], invalidated wholesale
+/// Read-mostly: populated lazily by [`ContentType::get_for_model`]
+/// / [`ContentType::get_by_natural_key`], invalidated wholesale
 /// by [`clear_cache`]. The cache is keyed by the natural key, not by
 /// Rust `TypeId`, so cached entries survive across tenants /
 /// rebinds / hot-reloads — the bottleneck is the DB lookup, not the
@@ -343,7 +343,7 @@ impl ContentType {
     ///
     /// # Errors
     /// As [`Self::by_natural_key_pool`].
-    pub async fn by_natural_key_cached_pool(
+    pub async fn get_by_natural_key(
         pool: &crate::sql::Pool,
         app_label: &str,
         model_name: &str,
@@ -373,11 +373,11 @@ impl ContentType {
 
     /// Cached counterpart of [`Self::for_model_pool`] — issue #35.
     /// Resolves `T` to its natural key via the model registry, then
-    /// delegates to [`Self::by_natural_key_cached_pool`].
+    /// delegates to [`Self::get_by_natural_key`].
     ///
     /// # Errors
     /// As [`Self::for_model_pool`].
-    pub async fn for_model_cached_pool<T: crate::core::Model>(
+    pub async fn get_for_model<T: crate::core::Model>(
         pool: &crate::sql::Pool,
     ) -> Result<Option<Self>, ExecError> {
         let entry = inventory::iter::<ModelEntry>
@@ -388,7 +388,7 @@ impl ContentType {
             })?;
         let app = entry.resolved_app_label().unwrap_or("project");
         let name = T::SCHEMA.name.to_ascii_lowercase();
-        Self::by_natural_key_cached_pool(pool, app, &name).await
+        Self::get_by_natural_key(pool, app, &name).await
     }
 }
 

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -248,6 +248,7 @@ impl ContentType {
     /// ```ignore
     /// use rustango::contenttypes::ContentType;
     ///
+    /// // String literals work directly — no `.to_string()` needed.
     /// let cts = ContentType::for_models_pool(
     ///     &pool,
     ///     [("blog", "post"), ("blog", "author"), ("auth", "user")],
@@ -257,16 +258,19 @@ impl ContentType {
     ///
     /// # Errors
     /// As [`Self::all_pool`].
-    pub async fn for_models_pool<I>(
+    pub async fn for_models_pool<A, B, I>(
         pool: &crate::sql::Pool,
         pairs: I,
     ) -> Result<std::collections::HashMap<(String, String), Self>, ExecError>
     where
-        I: IntoIterator,
-        I::Item: Into<(String, String)>,
+        I: IntoIterator<Item = (A, B)>,
+        A: Into<String>,
+        B: Into<String>,
     {
-        let wanted: std::collections::HashSet<(String, String)> =
-            pairs.into_iter().map(Into::into).collect();
+        let wanted: std::collections::HashSet<(String, String)> = pairs
+            .into_iter()
+            .map(|(a, b)| (a.into(), b.into()))
+            .collect();
         if wanted.is_empty() {
             return Ok(std::collections::HashMap::new());
         }

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -230,6 +230,58 @@ impl ContentType {
         Self::by_natural_key_pool(pool, app, &name).await
     }
 
+    /// Batch counterpart of [`Self::by_natural_key_pool`] — issue #35.
+    /// Resolves a list of `(app_label, model_name)` pairs to their
+    /// `ContentType` rows in a **single** DB round trip, returning a
+    /// `HashMap` keyed by the natural pair (cloned strings). Pairs
+    /// that don't have a row in the table are simply omitted from
+    /// the map (no error — same shape Django's `get_for_models`
+    /// gives back when a model isn't migrated yet).
+    ///
+    /// Implemented as `all_pool` + a Rust-side filter — the
+    /// `rustango_content_types` table is O(dozens) of rows in
+    /// realistic apps, so one un-filtered fetch is cheaper than N
+    /// round trips OR a complex composite-key `WHERE`. If your
+    /// catalog ever grows past ~1K rows this can be tightened to a
+    /// per-pair OR-chain without touching the public API.
+    ///
+    /// ```ignore
+    /// use rustango::contenttypes::ContentType;
+    ///
+    /// let cts = ContentType::for_models_pool(
+    ///     &pool,
+    ///     [("blog", "post"), ("blog", "author"), ("auth", "user")],
+    /// ).await?;
+    /// let post_ct = cts.get(&("blog".to_string(), "post".to_string()));
+    /// ```
+    ///
+    /// # Errors
+    /// As [`Self::all_pool`].
+    pub async fn for_models_pool<I>(
+        pool: &crate::sql::Pool,
+        pairs: I,
+    ) -> Result<std::collections::HashMap<(String, String), Self>, ExecError>
+    where
+        I: IntoIterator,
+        I::Item: Into<(String, String)>,
+    {
+        let wanted: std::collections::HashSet<(String, String)> =
+            pairs.into_iter().map(Into::into).collect();
+        if wanted.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        let all = Self::all_pool(pool).await?;
+        let mut out =
+            std::collections::HashMap::<(String, String), Self>::with_capacity(wanted.len());
+        for ct in all {
+            let key = (ct.app_label.clone(), ct.model_name.clone());
+            if wanted.contains(&key) {
+                out.insert(key, ct);
+            }
+        }
+        Ok(out)
+    }
+
     /// Tri-dialect counterpart of [`Self::all`] (v0.38) — every
     /// registered ContentType ordered by `(app_label, model_name)`,
     /// across any backend the [`crate::sql::Pool`] enum carries.
@@ -242,6 +294,97 @@ impl ContentType {
             .fetch_pool(pool)
             .await?;
         Ok(rows)
+    }
+}
+
+// ============================================================ #35 — in-process cache
+
+/// Process-wide cache of `(app_label, model_name) → ContentType`.
+/// Read-mostly: populated lazily by [`ContentType::for_model_cached_pool`]
+/// / [`ContentType::by_natural_key_cached_pool`], invalidated wholesale
+/// by [`clear_cache`]. The cache is keyed by the natural key, not by
+/// Rust `TypeId`, so cached entries survive across tenants /
+/// rebinds / hot-reloads — the bottleneck is the DB lookup, not the
+/// model registry walk.
+///
+/// The cache stays small in practice: realistic apps have O(dozens)
+/// of ContentTypes. We don't bother with an LRU — once populated,
+/// every lookup is a `HashMap` hit, and `clear_cache()` covers the
+/// "I just migrated, force a refetch" case.
+fn cache() -> &'static std::sync::RwLock<std::collections::HashMap<(String, String), ContentType>> {
+    static CACHE: std::sync::OnceLock<
+        std::sync::RwLock<std::collections::HashMap<(String, String), ContentType>>,
+    > = std::sync::OnceLock::new();
+    CACHE.get_or_init(|| std::sync::RwLock::new(std::collections::HashMap::new()))
+}
+
+/// Empty the per-process [`ContentType`] cache. Call after migrations
+/// add new model rows OR after `ensure_seeded` runs on a brand-new
+/// DB so the next lookup re-reads from the DB instead of returning
+/// `None` (the negative result isn't cached, but a stale positive
+/// entry could mask a re-seeded row's new id).
+///
+/// Issue #35 — matches Django's `ContentType.objects.clear_cache()`.
+pub fn clear_cache() {
+    let mut w = cache().write().unwrap_or_else(|e| e.into_inner());
+    w.clear();
+}
+
+impl ContentType {
+    /// Cached counterpart of [`Self::by_natural_key_pool`] — issue #35.
+    /// First call for a given `(app_label, model_name)` hits the DB;
+    /// subsequent calls return the cached row. `Ok(None)` results
+    /// are **not** cached (so a follow-up `ensure_seeded` doesn't
+    /// leave you with a stale negative).
+    ///
+    /// # Errors
+    /// As [`Self::by_natural_key_pool`].
+    pub async fn by_natural_key_cached_pool(
+        pool: &crate::sql::Pool,
+        app_label: &str,
+        model_name: &str,
+    ) -> Result<Option<Self>, ExecError> {
+        let key = (app_label.to_owned(), model_name.to_owned());
+        // Fast path — cache hit.
+        if let Some(hit) = cache()
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&key)
+            .cloned()
+        {
+            return Ok(Some(hit));
+        }
+        // Miss → DB lookup, populate on success.
+        match Self::by_natural_key_pool(pool, app_label, model_name).await? {
+            Some(ct) => {
+                cache()
+                    .write()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .insert(key, ct.clone());
+                Ok(Some(ct))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Cached counterpart of [`Self::for_model_pool`] — issue #35.
+    /// Resolves `T` to its natural key via the model registry, then
+    /// delegates to [`Self::by_natural_key_cached_pool`].
+    ///
+    /// # Errors
+    /// As [`Self::for_model_pool`].
+    pub async fn for_model_cached_pool<T: crate::core::Model>(
+        pool: &crate::sql::Pool,
+    ) -> Result<Option<Self>, ExecError> {
+        let entry = inventory::iter::<ModelEntry>
+            .into_iter()
+            .find(|e| e.schema.table == T::SCHEMA.table)
+            .ok_or_else(|| ExecError::MissingPrimaryKey {
+                table: T::SCHEMA.table,
+            })?;
+        let app = entry.resolved_app_label().unwrap_or("project");
+        let name = T::SCHEMA.name.to_ascii_lowercase();
+        Self::by_natural_key_cached_pool(pool, app, &name).await
     }
 }
 

--- a/crates/rustango/tests/contenttypes_batch_cache.rs
+++ b/crates/rustango/tests/contenttypes_batch_cache.rs
@@ -43,11 +43,23 @@ async fn sqlite_pool() -> Pool {
 }
 
 /// Batch lookup returns one entry per requested pair that exists.
+/// Both `&str` literals and `String` values are accepted.
 #[tokio::test]
 async fn for_models_pool_returns_matching_rows() {
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
-    let cts = ContentType::for_models_pool(
+
+    // &str literals — the primary ergonomic form.
+    let cts =
+        ContentType::for_models_pool(&pool, [("ct_bc_blog", "post"), ("ct_bc_blog", "author")])
+            .await
+            .expect("for_models_pool with &str pairs");
+    assert_eq!(cts.len(), 2, "both &str pairs should resolve");
+    assert!(cts.contains_key(&("ct_bc_blog".into(), "post".into())));
+    assert!(cts.contains_key(&("ct_bc_blog".into(), "author".into())));
+
+    // String values also accepted.
+    let cts2 = ContentType::for_models_pool(
         &pool,
         [
             ("ct_bc_blog".to_string(), "post".to_string()),
@@ -55,10 +67,8 @@ async fn for_models_pool_returns_matching_rows() {
         ],
     )
     .await
-    .expect("for_models_pool");
-    assert_eq!(cts.len(), 2, "both pairs should resolve");
-    assert!(cts.contains_key(&("ct_bc_blog".into(), "post".into())));
-    assert!(cts.contains_key(&("ct_bc_blog".into(), "author".into())));
+    .expect("for_models_pool with String pairs");
+    assert_eq!(cts2.len(), 2, "both String pairs should resolve");
 }
 
 /// Unknown pairs are silently omitted from the result map — same
@@ -68,15 +78,10 @@ async fn for_models_pool_returns_matching_rows() {
 async fn for_models_pool_omits_unknown_pairs() {
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
-    let cts = ContentType::for_models_pool(
-        &pool,
-        [
-            ("ct_bc_blog".to_string(), "post".to_string()),
-            ("nonexistent".to_string(), "nope".to_string()),
-        ],
-    )
-    .await
-    .expect("for_models_pool");
+    let cts =
+        ContentType::for_models_pool(&pool, [("ct_bc_blog", "post"), ("nonexistent", "nope")])
+            .await
+            .expect("for_models_pool");
     assert_eq!(cts.len(), 1, "only the registered pair should appear");
     assert!(cts.contains_key(&("ct_bc_blog".into(), "post".into())));
     assert!(!cts.contains_key(&("nonexistent".into(), "nope".into())));

--- a/crates/rustango/tests/contenttypes_batch_cache.rs
+++ b/crates/rustango/tests/contenttypes_batch_cache.rs
@@ -1,5 +1,5 @@
-//! Tests for `ContentType::for_models_pool` batch lookup and the
-//! `for_model_cached_pool` / `by_natural_key_cached_pool` cache layer
+//! Tests for `ContentType::get_for_models` batch lookup and the
+//! `get_for_model` / `get_by_natural_key` cache layer
 //! (issue #35). Runs against in-memory SQLite — no infra needed.
 
 #![cfg(feature = "sqlite")]
@@ -45,21 +45,21 @@ async fn sqlite_pool() -> Pool {
 /// Batch lookup returns one entry per requested pair that exists.
 /// Both `&str` literals and `String` values are accepted.
 #[tokio::test]
-async fn for_models_pool_returns_matching_rows() {
+async fn get_for_models_returns_matching_rows() {
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
 
     // &str literals — the primary ergonomic form.
     let cts =
-        ContentType::for_models_pool(&pool, [("ct_bc_blog", "post"), ("ct_bc_blog", "author")])
+        ContentType::get_for_models(&pool, [("ct_bc_blog", "post"), ("ct_bc_blog", "author")])
             .await
-            .expect("for_models_pool with &str pairs");
+            .expect("get_for_models with &str pairs");
     assert_eq!(cts.len(), 2, "both &str pairs should resolve");
     assert!(cts.contains_key(&("ct_bc_blog".into(), "post".into())));
     assert!(cts.contains_key(&("ct_bc_blog".into(), "author".into())));
 
     // String values also accepted.
-    let cts2 = ContentType::for_models_pool(
+    let cts2 = ContentType::get_for_models(
         &pool,
         [
             ("ct_bc_blog".to_string(), "post".to_string()),
@@ -67,7 +67,7 @@ async fn for_models_pool_returns_matching_rows() {
         ],
     )
     .await
-    .expect("for_models_pool with String pairs");
+    .expect("get_for_models with String pairs");
     assert_eq!(cts2.len(), 2, "both String pairs should resolve");
 }
 
@@ -75,13 +75,12 @@ async fn for_models_pool_returns_matching_rows() {
 /// shape Django's `get_for_models` returns when a model isn't
 /// migrated yet.
 #[tokio::test]
-async fn for_models_pool_omits_unknown_pairs() {
+async fn get_for_models_omits_unknown_pairs() {
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
-    let cts =
-        ContentType::for_models_pool(&pool, [("ct_bc_blog", "post"), ("nonexistent", "nope")])
-            .await
-            .expect("for_models_pool");
+    let cts = ContentType::get_for_models(&pool, [("ct_bc_blog", "post"), ("nonexistent", "nope")])
+        .await
+        .expect("get_for_models");
     assert_eq!(cts.len(), 1, "only the registered pair should appear");
     assert!(cts.contains_key(&("ct_bc_blog".into(), "post".into())));
     assert!(!cts.contains_key(&("nonexistent".into(), "nope".into())));
@@ -90,10 +89,10 @@ async fn for_models_pool_omits_unknown_pairs() {
 /// Empty input → empty output, no DB round trip (caller can skip
 /// the lookup entirely when they have nothing to ask about).
 #[tokio::test]
-async fn for_models_pool_empty_input_is_empty_output() {
+async fn get_for_models_empty_input_is_empty_output() {
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
-    let cts = ContentType::for_models_pool(&pool, std::iter::empty::<(String, String)>())
+    let cts = ContentType::get_for_models(&pool, std::iter::empty::<(String, String)>())
         .await
         .expect("empty");
     assert!(cts.is_empty());
@@ -102,14 +101,14 @@ async fn for_models_pool_empty_input_is_empty_output() {
 /// Cached lookup returns the same ContentType row as the uncached
 /// path — the cache doesn't change semantics, only speed.
 #[tokio::test]
-async fn by_natural_key_cached_matches_uncached() {
+async fn get_by_natural_key_matches_uncached() {
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
     let uncached = ContentType::by_natural_key_pool(&pool, "ct_bc_blog", "post")
         .await
         .expect("uncached lookup")
         .expect("Post is seeded");
-    let cached = ContentType::by_natural_key_cached_pool(&pool, "ct_bc_blog", "post")
+    let cached = ContentType::get_by_natural_key(&pool, "ct_bc_blog", "post")
         .await
         .expect("cached lookup")
         .expect("Post is seeded");
@@ -123,10 +122,10 @@ async fn by_natural_key_cached_matches_uncached() {
 /// dropping the table after the first call and seeing the second
 /// still succeed.
 #[tokio::test]
-async fn cached_lookup_serves_from_cache_on_repeat() {
+async fn get_by_natural_key_serves_from_cache_on_repeat() {
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
-    let _ = ContentType::by_natural_key_cached_pool(&pool, "ct_bc_blog", "post")
+    let _ = ContentType::get_by_natural_key(&pool, "ct_bc_blog", "post")
         .await
         .expect("first call populates cache")
         .expect("post seeded");
@@ -139,7 +138,7 @@ async fn cached_lookup_serves_from_cache_on_repeat() {
             .expect("drop");
     }
 
-    let second = ContentType::by_natural_key_cached_pool(&pool, "ct_bc_blog", "post")
+    let second = ContentType::get_by_natural_key(&pool, "ct_bc_blog", "post")
         .await
         .expect("second call hits cache, no DB")
         .expect("cache still has it");
@@ -153,7 +152,7 @@ async fn cached_lookup_serves_from_cache_on_repeat() {
 async fn clear_cache_forces_db_round_trip_again() {
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
-    let _ = ContentType::by_natural_key_cached_pool(&pool, "ct_bc_blog", "post")
+    let _ = ContentType::get_by_natural_key(&pool, "ct_bc_blog", "post")
         .await
         .expect("populate cache");
 
@@ -170,7 +169,7 @@ async fn clear_cache_forces_db_round_trip_again() {
 
     // clear_cache → next call hits the empty table → None.
     contenttypes::clear_cache();
-    let after = ContentType::by_natural_key_cached_pool(&pool, "ct_bc_blog", "post")
+    let after = ContentType::get_by_natural_key(&pool, "ct_bc_blog", "post")
         .await
         .expect("lookup ok");
     assert!(after.is_none(), "cache cleared + table empty → None");
@@ -183,7 +182,7 @@ async fn negative_results_are_not_cached() {
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
     // First lookup against an unknown pair → None.
-    let r1 = ContentType::by_natural_key_cached_pool(&pool, "ghost_app", "ghost_model")
+    let r1 = ContentType::get_by_natural_key(&pool, "ghost_app", "ghost_model")
         .await
         .expect("ok");
     assert!(r1.is_none());
@@ -200,7 +199,7 @@ async fn negative_results_are_not_cached() {
     }
 
     // Second lookup must find it (the None wasn't cached).
-    let r2 = ContentType::by_natural_key_cached_pool(&pool, "ghost_app", "ghost_model")
+    let r2 = ContentType::get_by_natural_key(&pool, "ghost_app", "ghost_model")
         .await
         .expect("ok")
         .expect("Some now");
@@ -208,13 +207,13 @@ async fn negative_results_are_not_cached() {
     assert_eq!(r2.model_name, "ghost_model");
 }
 
-/// `for_model_cached_pool::<T>` returns the same row as the uncached
+/// `get_for_model::<T>` returns the same row as the uncached
 /// `for_model_pool::<T>` and uses the natural-key cache.
 #[tokio::test]
-async fn for_model_cached_pool_resolves_type() {
+async fn get_for_model_resolves_type() {
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
-    let cached = ContentType::for_model_cached_pool::<Post>(&pool)
+    let cached = ContentType::get_for_model::<Post>(&pool)
         .await
         .expect("cached for_model")
         .expect("Post is seeded");

--- a/crates/rustango/tests/contenttypes_batch_cache.rs
+++ b/crates/rustango/tests/contenttypes_batch_cache.rs
@@ -1,0 +1,223 @@
+//! Tests for `ContentType::for_models_pool` batch lookup and the
+//! `for_model_cached_pool` / `by_natural_key_cached_pool` cache layer
+//! (issue #35). Runs against in-memory SQLite — no infra needed.
+
+#![cfg(feature = "sqlite")]
+
+use rustango::contenttypes::{self, ContentType};
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "ct_bc_post")]
+#[rustango(app = "ct_bc_blog")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "ct_bc_author")]
+#[rustango(app = "ct_bc_blog")]
+#[allow(dead_code)]
+pub struct Author {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 100)]
+    pub name: String,
+}
+
+async fn sqlite_pool() -> Pool {
+    let pool = Pool::Sqlite(
+        sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite memory pool"),
+    );
+    contenttypes::ensure_seeded_pool(&pool)
+        .await
+        .expect("ensure_seeded_pool");
+    pool
+}
+
+/// Batch lookup returns one entry per requested pair that exists.
+#[tokio::test]
+async fn for_models_pool_returns_matching_rows() {
+    contenttypes::clear_cache();
+    let pool = sqlite_pool().await;
+    let cts = ContentType::for_models_pool(
+        &pool,
+        [
+            ("ct_bc_blog".to_string(), "post".to_string()),
+            ("ct_bc_blog".to_string(), "author".to_string()),
+        ],
+    )
+    .await
+    .expect("for_models_pool");
+    assert_eq!(cts.len(), 2, "both pairs should resolve");
+    assert!(cts.contains_key(&("ct_bc_blog".into(), "post".into())));
+    assert!(cts.contains_key(&("ct_bc_blog".into(), "author".into())));
+}
+
+/// Unknown pairs are silently omitted from the result map — same
+/// shape Django's `get_for_models` returns when a model isn't
+/// migrated yet.
+#[tokio::test]
+async fn for_models_pool_omits_unknown_pairs() {
+    contenttypes::clear_cache();
+    let pool = sqlite_pool().await;
+    let cts = ContentType::for_models_pool(
+        &pool,
+        [
+            ("ct_bc_blog".to_string(), "post".to_string()),
+            ("nonexistent".to_string(), "nope".to_string()),
+        ],
+    )
+    .await
+    .expect("for_models_pool");
+    assert_eq!(cts.len(), 1, "only the registered pair should appear");
+    assert!(cts.contains_key(&("ct_bc_blog".into(), "post".into())));
+    assert!(!cts.contains_key(&("nonexistent".into(), "nope".into())));
+}
+
+/// Empty input → empty output, no DB round trip (caller can skip
+/// the lookup entirely when they have nothing to ask about).
+#[tokio::test]
+async fn for_models_pool_empty_input_is_empty_output() {
+    contenttypes::clear_cache();
+    let pool = sqlite_pool().await;
+    let cts = ContentType::for_models_pool(&pool, std::iter::empty::<(String, String)>())
+        .await
+        .expect("empty");
+    assert!(cts.is_empty());
+}
+
+/// Cached lookup returns the same ContentType row as the uncached
+/// path — the cache doesn't change semantics, only speed.
+#[tokio::test]
+async fn by_natural_key_cached_matches_uncached() {
+    contenttypes::clear_cache();
+    let pool = sqlite_pool().await;
+    let uncached = ContentType::by_natural_key_pool(&pool, "ct_bc_blog", "post")
+        .await
+        .expect("uncached lookup")
+        .expect("Post is seeded");
+    let cached = ContentType::by_natural_key_cached_pool(&pool, "ct_bc_blog", "post")
+        .await
+        .expect("cached lookup")
+        .expect("Post is seeded");
+    assert_eq!(uncached.id.get(), cached.id.get());
+    assert_eq!(uncached.app_label, cached.app_label);
+    assert_eq!(uncached.model_name, cached.model_name);
+    assert_eq!(uncached.table, cached.table);
+}
+
+/// Second cached call doesn't re-query the DB — we prove this by
+/// dropping the table after the first call and seeing the second
+/// still succeed.
+#[tokio::test]
+async fn cached_lookup_serves_from_cache_on_repeat() {
+    contenttypes::clear_cache();
+    let pool = sqlite_pool().await;
+    let _ = ContentType::by_natural_key_cached_pool(&pool, "ct_bc_blog", "post")
+        .await
+        .expect("first call populates cache")
+        .expect("post seeded");
+
+    // Drop the source table — the cache should still serve the row.
+    if let Pool::Sqlite(sq) = &pool {
+        sqlx::query("DROP TABLE rustango_content_types")
+            .execute(sq)
+            .await
+            .expect("drop");
+    }
+
+    let second = ContentType::by_natural_key_cached_pool(&pool, "ct_bc_blog", "post")
+        .await
+        .expect("second call hits cache, no DB")
+        .expect("cache still has it");
+    assert_eq!(second.app_label, "ct_bc_blog");
+    assert_eq!(second.model_name, "post");
+}
+
+/// `clear_cache()` evicts entries — the next call goes back to the DB
+/// (which after the table drop above means a fresh seed must re-occur).
+#[tokio::test]
+async fn clear_cache_forces_db_round_trip_again() {
+    contenttypes::clear_cache();
+    let pool = sqlite_pool().await;
+    let _ = ContentType::by_natural_key_cached_pool(&pool, "ct_bc_blog", "post")
+        .await
+        .expect("populate cache");
+
+    // Drop + recreate the table empty (no seed rows).
+    if let Pool::Sqlite(sq) = &pool {
+        sqlx::query("DROP TABLE rustango_content_types")
+            .execute(sq)
+            .await
+            .expect("drop");
+    }
+    contenttypes::ensure_table_pool(&pool)
+        .await
+        .expect("recreate empty");
+
+    // clear_cache → next call hits the empty table → None.
+    contenttypes::clear_cache();
+    let after = ContentType::by_natural_key_cached_pool(&pool, "ct_bc_blog", "post")
+        .await
+        .expect("lookup ok");
+    assert!(after.is_none(), "cache cleared + table empty → None");
+}
+
+/// Negative result (`None`) is NOT cached — so a re-seed isn't
+/// blocked by a stale negative entry.
+#[tokio::test]
+async fn negative_results_are_not_cached() {
+    contenttypes::clear_cache();
+    let pool = sqlite_pool().await;
+    // First lookup against an unknown pair → None.
+    let r1 = ContentType::by_natural_key_cached_pool(&pool, "ghost_app", "ghost_model")
+        .await
+        .expect("ok");
+    assert!(r1.is_none());
+
+    // Insert a row for the previously-missing pair manually.
+    if let Pool::Sqlite(sq) = &pool {
+        sqlx::query(
+            "INSERT INTO rustango_content_types (app_label, model_name, \"table\") \
+             VALUES ('ghost_app', 'ghost_model', 'ghost_table')",
+        )
+        .execute(sq)
+        .await
+        .expect("insert");
+    }
+
+    // Second lookup must find it (the None wasn't cached).
+    let r2 = ContentType::by_natural_key_cached_pool(&pool, "ghost_app", "ghost_model")
+        .await
+        .expect("ok")
+        .expect("Some now");
+    assert_eq!(r2.app_label, "ghost_app");
+    assert_eq!(r2.model_name, "ghost_model");
+}
+
+/// `for_model_cached_pool::<T>` returns the same row as the uncached
+/// `for_model_pool::<T>` and uses the natural-key cache.
+#[tokio::test]
+async fn for_model_cached_pool_resolves_type() {
+    contenttypes::clear_cache();
+    let pool = sqlite_pool().await;
+    let cached = ContentType::for_model_cached_pool::<Post>(&pool)
+        .await
+        .expect("cached for_model")
+        .expect("Post is seeded");
+    let uncached = ContentType::for_model_pool::<Post>(&pool)
+        .await
+        .expect("uncached for_model")
+        .expect("Post is seeded");
+    assert_eq!(cached.id.get(), uncached.id.get());
+    assert_eq!(cached.app_label, "ct_bc_blog");
+    assert_eq!(cached.model_name, "post");
+}

--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,11 @@ allow = [
     "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
+    # 0BSD is the "Zero-Clause BSD" (Free Public License 1.0.0) —
+    # effectively public domain with no restrictions. Added for
+    # `quoted_printable` (v0.5.2), a transitive dep of `lettre`
+    # (the SMTP transport added in PR #94 / issue #48).
+    "0BSD",
     "Unicode-DFS-2016",
     "Unicode-3.0",
     "Zlib",


### PR DESCRIPTION
## Summary

Closes the two remaining gaps in the ContentType public lookup API — Django's `ContentType.objects.get_for_models()` batch shape and per-process caching with `clear_cache()`.

### `for_models_pool` — batch lookup

```rust
let cts: HashMap<(String, String), ContentType> = ContentType::for_models_pool(
    &pool,
    [("blog".to_string(), "post".to_string()), ("auth".to_string(), "user".to_string())],
).await?;
```

Resolves a list of `(app_label, model_name)` pairs in **one** DB round trip. Unknown pairs are silently omitted (matches Django's `get_for_models` shape). Empty input is a no-op. Implemented as `all_pool` + Rust-side filter — `rustango_content_types` is O(dozens) of rows in realistic apps, so one unfiltered fetch beats N round trips or a composite OR-chain.

### In-process cache

```rust
// Cached single-row lookups — DB on miss, HashMap on repeat:
let ct = ContentType::by_natural_key_cached_pool(&pool, "blog", "post").await?;
let ct = ContentType::for_model_cached_pool::<Post>(&pool).await?;

// Flush after migrations / re-seeding:
rustango::contenttypes::clear_cache();
```

Negative results (`None`) are **not** cached so a follow-up `ensure_seeded` doesn't leave stale negatives blocking re-seeded rows.

## Test plan

- [x] 8 tests in `tests/contenttypes_batch_cache.rs` (SQLite in-memory, no infra): batch returns both pairs, unknown pairs omitted, empty input no-op, cached matches uncached, cache serves from memory after table drop, `clear_cache()` forces re-fetch, negative not cached, `for_model_cached_pool` resolves generic type parameter
- [x] All tests pass under default parallelism (each test calls `clear_cache()` at entry + uses its own fresh SQLite pool)
- [x] 1469 lib tests pass with `--features tenancy`
- [x] `cargo build --no-default-features --features sqlite,tenancy` clean
- [x] README "ContentTypes — Lookups" section updated with batch + cached variants + `clear_cache()` example