### PR TITLE
refactor: drop _pool suffix from ContentType public API

### DIFF
--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -902,7 +902,7 @@ pub(crate) async fn detail_view(
     // F.4b — append one row per #[rustango(generic_fk(...))]
     // declaration. Reads the (content_type_id, object_pk) pair off
     // the row and renders a clickable target link via
-    // `contenttypes::render_generic_fk_link_pool`. Stale references
+    // `contenttypes::render_generic_fk_link`. Stale references
     // (CT not seeded, target deleted) render as a `(ct=N, pk=M)`
     // fallback rather than failing the whole page.
     //
@@ -919,7 +919,7 @@ pub(crate) async fn detail_view(
             .and_then(serde_json::Value::as_i64)
             .unwrap_or_default();
         let g = crate::contenttypes::GenericForeignKey::new(ct_id, object_pk);
-        let html = crate::contenttypes::render_generic_fk_link_pool(&state.pool, g)
+        let html = crate::contenttypes::render_generic_fk_link(&state.pool, g)
             .await
             .unwrap_or_else(|_| format!("<em>(ct={ct_id}, pk={object_pk})</em>"));
         cells_ctx.push(serde_json::json!({

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -75,87 +75,48 @@ pub struct ContentType {
     pub table: String,
 }
 
-// v0.35 — PG-typed back-compat block. Sqlite/MySQL apps use the
-// tri-dialect `*_pool` variants further down.
+// Deprecated PG-only shims — delegate to the tri-dialect methods below.
+// Use `ContentType::by_natural_key(&pool, ...)` / `ContentType::by_id(&pool, ...)`
+// etc. where `pool: &Pool` (converts from `PgPool` via `.into()`).
 #[cfg(feature = "postgres")]
 impl ContentType {
-    /// Look up a `ContentType` row for a registered model type.
-    ///
-    /// Cheap-ish (DB round trip) — for hot paths consider
-    /// [`for_model_cached`] which memoizes per-process. Returns
-    /// `Ok(None)` when [`ensure_seeded`] hasn't been called yet for
-    /// this model (the row doesn't exist in the DB).
-    ///
-    /// # Errors
-    /// Driver / query failures from the underlying SELECT.
-    pub async fn for_model<T: crate::core::Model>(
+    #[deprecated(
+        since = "0.40.0",
+        note = "use `ContentType::by_natural_key(&pool, ...) where pool: &Pool` \
+                (PgPool converts via `.into()`)"
+    )]
+    pub async fn for_model_pg<T: crate::core::Model>(
         pool: &PgPool,
     ) -> Result<Option<Self>, ExecError> {
-        let entry = inventory::iter::<ModelEntry>
-            .into_iter()
-            .find(|e| e.schema.table == T::SCHEMA.table)
-            .ok_or_else(|| ExecError::MissingPrimaryKey {
-                table: T::SCHEMA.table,
-            })?;
-        let app = entry.resolved_app_label().unwrap_or("project");
-        let name = T::SCHEMA.name.to_ascii_lowercase();
-        Self::by_natural_key(pool, app, &name).await
+        Self::for_model::<T>(&pool.clone().into()).await
     }
 
-    /// Lookup by `(app_label, model_name)` — the natural key. Used
-    /// when the caller has the strings (e.g. parsing
-    /// `"app.action_model"` permission codenames) but not the Rust
-    /// type.
-    ///
-    /// # Errors
-    /// As [`Self::for_model`].
-    pub async fn by_natural_key(
+    #[deprecated(
+        since = "0.40.0",
+        note = "use `ContentType::by_natural_key(&pool, ...) where pool: &Pool`"
+    )]
+    pub async fn by_natural_key_pg(
         pool: &PgPool,
         app_label: &str,
         model_name: &str,
     ) -> Result<Option<Self>, ExecError> {
-        let rows: Vec<Self> = Self::objects()
-            .filter(
-                "app_label",
-                crate::core::Op::Eq,
-                SqlValue::String(app_label.into()),
-            )
-            .filter(
-                "model_name",
-                crate::core::Op::Eq,
-                SqlValue::String(model_name.into()),
-            )
-            .limit(1)
-            .fetch(pool)
-            .await?;
-        Ok(rows.into_iter().next())
+        Self::by_natural_key(&pool.clone().into(), app_label, model_name).await
     }
 
-    /// Lookup by primary key. Used by FK joins (audit log target,
-    /// permission scope, etc.).
-    ///
-    /// # Errors
-    /// As [`Self::for_model`].
-    pub async fn by_id(pool: &PgPool, id: i64) -> Result<Option<Self>, ExecError> {
-        let rows: Vec<Self> = Self::objects()
-            .filter("id", crate::core::Op::Eq, SqlValue::I64(id))
-            .limit(1)
-            .fetch(pool)
-            .await?;
-        Ok(rows.into_iter().next())
+    #[deprecated(
+        since = "0.40.0",
+        note = "use `ContentType::by_id(&pool, id) where pool: &Pool`"
+    )]
+    pub async fn by_id_pg(pool: &PgPool, id: i64) -> Result<Option<Self>, ExecError> {
+        Self::by_id(&pool.clone().into(), id).await
     }
 
-    /// All registered ContentTypes, ordered by `(app_label, model_name)`
-    /// for stable display in admin sidebars / API listings.
-    ///
-    /// # Errors
-    /// As [`Self::for_model`].
-    pub async fn all(pool: &PgPool) -> Result<Vec<Self>, ExecError> {
-        let rows: Vec<Self> = Self::objects()
-            .order_by(&[("app_label", false), ("model_name", false)])
-            .fetch(pool)
-            .await?;
-        Ok(rows)
+    #[deprecated(
+        since = "0.40.0",
+        note = "use `ContentType::all(&pool) where pool: &Pool`"
+    )]
+    pub async fn all_pg(pool: &PgPool) -> Result<Vec<Self>, ExecError> {
+        Self::all(&pool.clone().into()).await
     }
 }
 
@@ -172,7 +133,7 @@ impl ContentType {
     ///
     /// # Errors
     /// As [`Self::for_model`].
-    pub async fn by_natural_key_pool(
+    pub async fn by_natural_key(
         pool: &crate::sql::Pool,
         app_label: &str,
         model_name: &str,
@@ -199,7 +160,7 @@ impl ContentType {
     ///
     /// # Errors
     /// As [`Self::for_model`].
-    pub async fn by_id_pool(pool: &crate::sql::Pool, id: i64) -> Result<Option<Self>, ExecError> {
+    pub async fn by_id(pool: &crate::sql::Pool, id: i64) -> Result<Option<Self>, ExecError> {
         let rows: Vec<Self> = Self::objects()
             .filter("id", crate::core::Op::Eq, SqlValue::I64(id))
             .limit(1)
@@ -216,7 +177,7 @@ impl ContentType {
     ///
     /// # Errors
     /// As [`Self::for_model`].
-    pub async fn for_model_pool<T: crate::core::Model>(
+    pub async fn for_model<T: crate::core::Model>(
         pool: &crate::sql::Pool,
     ) -> Result<Option<Self>, ExecError> {
         let entry = inventory::iter::<ModelEntry>
@@ -227,7 +188,7 @@ impl ContentType {
             })?;
         let app = entry.resolved_app_label().unwrap_or("project");
         let name = T::SCHEMA.name.to_ascii_lowercase();
-        Self::by_natural_key_pool(pool, app, &name).await
+        Self::by_natural_key(pool, app, &name).await
     }
 
     /// Batch counterpart of [`Self::by_natural_key_pool`] — issue #35.
@@ -274,7 +235,7 @@ impl ContentType {
         if wanted.is_empty() {
             return Ok(std::collections::HashMap::new());
         }
-        let all = Self::all_pool(pool).await?;
+        let all = Self::all(pool).await?;
         let mut out =
             std::collections::HashMap::<(String, String), Self>::with_capacity(wanted.len());
         for ct in all {
@@ -292,7 +253,7 @@ impl ContentType {
     ///
     /// # Errors
     /// As [`Self::for_model`].
-    pub async fn all_pool(pool: &crate::sql::Pool) -> Result<Vec<Self>, ExecError> {
+    pub async fn all(pool: &crate::sql::Pool) -> Result<Vec<Self>, ExecError> {
         let rows: Vec<Self> = Self::objects()
             .order_by(&[("app_label", false), ("model_name", false)])
             .fetch_pool(pool)
@@ -359,7 +320,7 @@ impl ContentType {
             return Ok(Some(hit));
         }
         // Miss → DB lookup, populate on success.
-        match Self::by_natural_key_pool(pool, app_label, model_name).await? {
+        match Self::by_natural_key(pool, app_label, model_name).await? {
             Some(ct) => {
                 cache()
                     .write()
@@ -371,12 +332,12 @@ impl ContentType {
         }
     }
 
-    /// Cached counterpart of [`Self::for_model_pool`] — issue #35.
+    /// Cached counterpart of [`Self::for_model`] — issue #35.
     /// Resolves `T` to its natural key via the model registry, then
     /// delegates to [`Self::get_by_natural_key`].
     ///
     /// # Errors
-    /// As [`Self::for_model_pool`].
+    /// As [`Self::for_model`].
     pub async fn get_for_model<T: crate::core::Model>(
         pool: &crate::sql::Pool,
     ) -> Result<Option<Self>, ExecError> {
@@ -418,12 +379,12 @@ impl ContentType {
 /// # Errors
 /// Driver / query failures from the SELECT.
 #[cfg(feature = "postgres")]
-pub async fn fetch_row_as_json(
+pub async fn fetch_row_as_json_pg(
     pool: &PgPool,
     ct: &ContentType,
     pk: impl Into<SqlValue>,
 ) -> Result<Option<serde_json::Value>, ExecError> {
-    fetch_row_as_json_pool(&crate::sql::Pool::Postgres(pool.clone()), ct, pk).await
+    fetch_row_as_json(&crate::sql::Pool::Postgres(pool.clone()), ct, pk).await
 }
 
 /// Tri-dialect counterpart of [`fetch_row_as_json`] (v0.38). Takes
@@ -434,7 +395,7 @@ pub async fn fetch_row_as_json(
 ///
 /// # Errors
 /// As [`fetch_row_as_json`].
-pub async fn fetch_row_as_json_pool(
+pub async fn fetch_row_as_json(
     pool: &crate::sql::Pool,
     ct: &ContentType,
     pk: impl Into<SqlValue>,
@@ -490,7 +451,7 @@ pub async fn fetch_row_as_json_pool(
 /// Driver / query failures + any `Err` returned by `f` short-
 /// circuits the iteration.
 #[cfg(feature = "postgres")]
-pub async fn for_each_row_of_ct<F>(
+pub async fn for_each_row_of_ct_pg<F>(
     pool: &PgPool,
     ct: &ContentType,
     batch_size: u32,
@@ -499,7 +460,7 @@ pub async fn for_each_row_of_ct<F>(
 where
     F: FnMut(serde_json::Value) -> Result<(), ExecError>,
 {
-    for_each_row_of_ct_pool(&crate::sql::Pool::Postgres(pool.clone()), ct, batch_size, f).await
+    for_each_row_of_ct(&crate::sql::Pool::Postgres(pool.clone()), ct, batch_size, f).await
 }
 
 /// Tri-dialect counterpart of [`for_each_row_of_ct`] (v0.38). Iterates
@@ -509,7 +470,7 @@ where
 ///
 /// # Errors
 /// As [`for_each_row_of_ct`].
-pub async fn for_each_row_of_ct_pool<F>(
+pub async fn for_each_row_of_ct<F>(
     pool: &crate::sql::Pool,
     ct: &ContentType,
     batch_size: u32,
@@ -618,29 +579,29 @@ impl GenericForeignKey {
     /// # Errors
     /// As [`ContentType::for_model`].
     #[cfg(feature = "postgres")]
-    pub async fn for_target<T: crate::core::Model>(
+    pub async fn for_target_pg<T: crate::core::Model>(
         pool: &PgPool,
         object_pk: i64,
     ) -> Result<Self, ExecError> {
-        Self::for_target_pool::<T>(&crate::sql::Pool::Postgres(pool.clone()), object_pk).await
+        Self::for_target::<T>(&crate::sql::Pool::Postgres(pool.clone()), object_pk).await
     }
 
     /// Tri-dialect counterpart of [`Self::for_target`] (v0.38).
     /// Routes the ContentType lookup through
-    /// [`ContentType::for_model_pool`] so the same call site works on
+    /// [`ContentType::for_model`] so the same call site works on
     /// PG / SQLite / MySQL.
     ///
     /// # Errors
     /// As [`Self::for_target`].
-    pub async fn for_target_pool<T: crate::core::Model>(
+    pub async fn for_target<T: crate::core::Model>(
         pool: &crate::sql::Pool,
         object_pk: i64,
     ) -> Result<Self, ExecError> {
-        let ct = ContentType::for_model_pool::<T>(pool)
-            .await?
-            .ok_or_else(|| ExecError::MissingPrimaryKey {
+        let ct = ContentType::for_model::<T>(pool).await?.ok_or_else(|| {
+            ExecError::MissingPrimaryKey {
                 table: T::SCHEMA.table,
-            })?;
+            }
+        })?;
         let id = ct
             .id
             .get()
@@ -673,7 +634,7 @@ impl GenericForeignKey {
 /// Driver / SQL failures from the ContentType lookup. Caller can
 /// `unwrap_or_else(|_| ...)` to a fallback rendering.
 #[cfg(feature = "postgres")]
-pub async fn render_generic_fk_link(
+pub async fn render_generic_fk_link_pg(
     pool: &PgPool,
     gfk: GenericForeignKey,
 ) -> Result<String, ExecError> {
@@ -684,7 +645,7 @@ pub async fn render_generic_fk_link(
             .replace('"', "&quot;")
             .replace('\'', "&#x27;")
     };
-    let ct = match ContentType::by_id(pool, gfk.content_type_id).await? {
+    let ct = match ContentType::by_id(&pool.clone().into(), gfk.content_type_id).await? {
         Some(c) => c,
         None => {
             // Stale or unseeded reference — show the raw pair so
@@ -712,7 +673,7 @@ pub async fn render_generic_fk_link(
 ///
 /// # Errors
 /// As [`render_generic_fk_link`].
-pub async fn render_generic_fk_link_pool(
+pub async fn render_generic_fk_link(
     pool: &crate::sql::Pool,
     gfk: GenericForeignKey,
 ) -> Result<String, ExecError> {
@@ -723,7 +684,7 @@ pub async fn render_generic_fk_link_pool(
             .replace('"', "&quot;")
             .replace('\'', "&#x27;")
     };
-    let ct = match ContentType::by_id_pool(pool, gfk.content_type_id).await? {
+    let ct = match ContentType::by_id(&pool.clone().into(), gfk.content_type_id).await? {
         Some(c) => c,
         None => {
             return Ok(format!(
@@ -780,7 +741,7 @@ pub async fn render_generic_fk_link_pool(
 /// # Errors
 /// Driver / SQL failures from the SELECT.
 #[cfg(feature = "postgres")]
-pub async fn prefetch_soft<C, F>(
+pub async fn prefetch_soft_pg<C, F>(
     pool: &PgPool,
     parent_pks: &[i64],
     target_fk_column: &'static str,
@@ -852,7 +813,7 @@ where
 /// As [`ContentType::for_model`] + driver / SQL failures from the
 /// target SELECT.
 #[cfg(feature = "postgres")]
-pub async fn prefetch_generic<C>(
+pub async fn prefetch_generic_pg<C>(
     pool: &PgPool,
     pairs: &[(i64, i64)],
 ) -> Result<::std::collections::HashMap<(i64, i64), C>, ExecError>
@@ -870,12 +831,11 @@ where
     // Resolve C's ContentType once — every (ct_id, pk) pair whose
     // ct_id doesn't match drops out of the result map (caller's
     // expectation: typed-target prefetch).
-    let target_ct =
-        ContentType::for_model::<C>(pool)
-            .await?
-            .ok_or_else(|| ExecError::MissingPrimaryKey {
-                table: C::SCHEMA.table,
-            })?;
+    let target_ct = ContentType::for_model::<C>(&pool.clone().into())
+        .await?
+        .ok_or_else(|| ExecError::MissingPrimaryKey {
+            table: C::SCHEMA.table,
+        })?;
     let target_ct_id = target_ct
         .id
         .get()
@@ -935,7 +895,7 @@ where
 ///
 /// # Errors
 /// As [`prefetch_soft`].
-pub async fn prefetch_soft_pool<C, F>(
+pub async fn prefetch_soft<C, F>(
     pool: &crate::sql::Pool,
     parent_pks: &[i64],
     target_fk_column: &'static str,
@@ -983,13 +943,13 @@ where
 }
 
 /// Tri-dialect counterpart of [`prefetch_generic`] (v0.38). Routes the
-/// ContentType lookup through [`ContentType::for_model_pool`] and the
+/// ContentType lookup through [`ContentType::for_model`] and the
 /// target SELECT through [`crate::sql::FetcherPool::fetch_pool`] so
 /// the same body works on PG / SQLite / MySQL.
 ///
 /// # Errors
 /// As [`prefetch_generic`].
-pub async fn prefetch_generic_pool<C>(
+pub async fn prefetch_generic<C>(
     pool: &crate::sql::Pool,
     pairs: &[(i64, i64)],
 ) -> Result<::std::collections::HashMap<(i64, i64), C>, ExecError>
@@ -1010,7 +970,7 @@ where
     if pairs.is_empty() {
         return Ok(::std::collections::HashMap::new());
     }
-    let target_ct = ContentType::for_model_pool::<C>(pool)
+    let target_ct = ContentType::for_model::<C>(&pool.clone().into())
         .await?
         .ok_or_else(|| ExecError::MissingPrimaryKey {
             table: C::SCHEMA.table,
@@ -1107,7 +1067,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS "rustango_content_types_natural_key"
 /// # Errors
 /// Driver / SQL failures.
 #[cfg(feature = "postgres")]
-pub async fn ensure_table(pool: &PgPool) -> Result<(), crate::sql::sqlx::Error> {
+pub async fn ensure_table_pg(pool: &PgPool) -> Result<(), crate::sql::sqlx::Error> {
     for stmt in CREATE_TABLE_SQL.split(';') {
         let trimmed = stmt.trim();
         if trimmed.is_empty() {
@@ -1132,15 +1092,16 @@ pub async fn ensure_table(pool: &PgPool) -> Result<(), crate::sql::sqlx::Error> 
 /// # Errors
 /// Driver / query failures from the SELECT-or-INSERT loop.
 #[cfg(feature = "postgres")]
-pub async fn ensure_seeded(pool: &PgPool) -> Result<usize, ExecError> {
-    // Idempotent table-create — ensures the registry-side CT
-    // catalog has its physical home before we walk inventory.
-    // Tenant schemas already get this from the bootstrap-migration
-    // CreateTable op; the registry bootstrap doesn't include
-    // `rustango_content_types`, so the seed call would otherwise
-    // 42P01 on every fresh registry. Mirrors the
-    // `audit::ensure_table(registry)` pattern.
-    ensure_table(pool).await.map_err(ExecError::Driver)?;
+#[allow(deprecated)]
+pub async fn ensure_seeded_pg(pool: &PgPool) -> Result<usize, ExecError> {
+    ensure_seeded(&pool.clone().into()).await
+}
+
+#[cfg(feature = "postgres")]
+async fn _ensure_seeded_pg_internal(pool: &PgPool) -> Result<usize, ExecError> {
+    ensure_table(&pool.clone().into())
+        .await
+        .map_err(ExecError::Driver)?;
     let mut inserted = 0_usize;
     for entry in inventory::iter::<ModelEntry> {
         let table = entry.schema.table;
@@ -1152,7 +1113,7 @@ pub async fn ensure_seeded(pool: &PgPool) -> Result<usize, ExecError> {
         let app = entry.resolved_app_label().unwrap_or("project").to_owned();
         let name = entry.schema.name.to_ascii_lowercase();
         // Probe natural key first; skip if already seeded.
-        if ContentType::by_natural_key(pool, &app, &name)
+        if ContentType::by_natural_key(&pool.clone().into(), &app, &name)
             .await?
             .is_some()
         {
@@ -1183,7 +1144,7 @@ pub async fn ensure_seeded(pool: &PgPool) -> Result<usize, ExecError> {
 ///
 /// # Errors
 /// Driver / SQL failures from `CREATE TABLE IF NOT EXISTS`.
-pub async fn ensure_table_pool(pool: &crate::sql::Pool) -> Result<(), crate::sql::sqlx::Error> {
+pub async fn ensure_table(pool: &crate::sql::Pool) -> Result<(), crate::sql::sqlx::Error> {
     use crate::core::Model as _;
     let dialect = pool.dialect();
     // v0.34 — route the table DDL through the same emitter the
@@ -1270,8 +1231,8 @@ fn is_mysql_dup_index_error(_e: &crate::sql::sqlx::Error) -> bool {
 /// # Errors
 /// Driver / query failures from the SELECT-or-INSERT loop or the
 /// table bootstrap.
-pub async fn ensure_seeded_pool(pool: &crate::sql::Pool) -> Result<usize, ExecError> {
-    ensure_table_pool(pool).await.map_err(ExecError::Driver)?;
+pub async fn ensure_seeded(pool: &crate::sql::Pool) -> Result<usize, ExecError> {
+    ensure_table(pool).await.map_err(ExecError::Driver)?;
     let mut inserted = 0_usize;
     for entry in inventory::iter::<ModelEntry> {
         let table = entry.schema.table;
@@ -1280,7 +1241,7 @@ pub async fn ensure_seeded_pool(pool: &crate::sql::Pool) -> Result<usize, ExecEr
         }
         let app = entry.resolved_app_label().unwrap_or("project").to_owned();
         let name = entry.schema.name.to_ascii_lowercase();
-        if ContentType::by_natural_key_pool(pool, &app, &name)
+        if ContentType::by_natural_key(&pool.clone().into(), &app, &name)
             .await?
             .is_some()
         {

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -34,10 +34,6 @@
 
 use crate::core::{inventory, Model as _, ModelEntry, SqlValue};
 use crate::sql::{Auto, ExecError, FetcherPool as _};
-// PG-typed helpers below pull in `PgPool` + `Fetcher`. Sqlite/MySQL-
-// only builds get just the tri-dialect `*_pool` entry points.
-#[cfg(feature = "postgres")]
-use crate::sql::{sqlx::PgPool, Fetcher as _};
 use crate::Model;
 
 /// One row per registered model. The schema mirrors Django's
@@ -73,51 +69,6 @@ pub struct ContentType {
     /// reconstruct it from the registry every time.
     #[rustango(max_length = 100)]
     pub table: String,
-}
-
-// Deprecated PG-only shims — delegate to the tri-dialect methods below.
-// Use `ContentType::by_natural_key(&pool, ...)` / `ContentType::by_id(&pool, ...)`
-// etc. where `pool: &Pool` (converts from `PgPool` via `.into()`).
-#[cfg(feature = "postgres")]
-impl ContentType {
-    #[deprecated(
-        since = "0.40.0",
-        note = "use `ContentType::by_natural_key(&pool, ...) where pool: &Pool` \
-                (PgPool converts via `.into()`)"
-    )]
-    pub async fn for_model_pg<T: crate::core::Model>(
-        pool: &PgPool,
-    ) -> Result<Option<Self>, ExecError> {
-        Self::for_model::<T>(&pool.clone().into()).await
-    }
-
-    #[deprecated(
-        since = "0.40.0",
-        note = "use `ContentType::by_natural_key(&pool, ...) where pool: &Pool`"
-    )]
-    pub async fn by_natural_key_pg(
-        pool: &PgPool,
-        app_label: &str,
-        model_name: &str,
-    ) -> Result<Option<Self>, ExecError> {
-        Self::by_natural_key(&pool.clone().into(), app_label, model_name).await
-    }
-
-    #[deprecated(
-        since = "0.40.0",
-        note = "use `ContentType::by_id(&pool, id) where pool: &Pool`"
-    )]
-    pub async fn by_id_pg(pool: &PgPool, id: i64) -> Result<Option<Self>, ExecError> {
-        Self::by_id(&pool.clone().into(), id).await
-    }
-
-    #[deprecated(
-        since = "0.40.0",
-        note = "use `ContentType::all(&pool) where pool: &Pool`"
-    )]
-    pub async fn all_pg(pool: &PgPool) -> Result<Vec<Self>, ExecError> {
-        Self::all(&pool.clone().into()).await
-    }
 }
 
 // ============================================================ tri-dialect lookups
@@ -355,38 +306,6 @@ impl ContentType {
 
 // ============================================================ #89 part B — fetch helpers
 
-/// Look up a single row by ContentType + primary key, returning
-/// it as a JSON object keyed by Rust field names. Sidesteps
-/// Rust's compile-time-typed row decode (which would require
-/// each consumer to know `T: Model` at the call site) by
-/// driving the decode entirely from the runtime
-/// `inventory::ModelEntry` for the ContentType's table.
-///
-/// Used by the admin's audit log (resolves `entity_table` +
-/// `entity_pk` to the displayable target row), the generic-FK
-/// link renderer, and any future "operator clicks a row from a
-/// heterogeneous list" UI.
-///
-/// Returns `Ok(None)` when:
-///   - No model is registered at `ct.table` (e.g. CT row points
-///     at a table the binary no longer compiles in)
-///   - No row exists at the given PK in that table
-///
-/// `pk` accepts any `Into<SqlValue>` so callers can pass
-/// `i64` / `String` / `uuid::Uuid` / etc. — matches the
-/// underlying schema's PK type.
-///
-/// # Errors
-/// Driver / query failures from the SELECT.
-#[cfg(feature = "postgres")]
-pub async fn fetch_row_as_json_pg(
-    pool: &PgPool,
-    ct: &ContentType,
-    pk: impl Into<SqlValue>,
-) -> Result<Option<serde_json::Value>, ExecError> {
-    fetch_row_as_json(&crate::sql::Pool::Postgres(pool.clone()), ct, pk).await
-}
-
 /// Tri-dialect counterpart of [`fetch_row_as_json`] (v0.38). Takes
 /// the unified [`crate::sql::Pool`] enum and routes through
 /// [`crate::sql::select_one_row_as_json_pool`] so the same body runs
@@ -435,32 +354,6 @@ pub async fn fetch_row_as_json(
     };
     let fields: Vec<&'static crate::core::FieldSchema> = entry.schema.scalar_fields().collect();
     crate::sql::select_one_row_as_json_pool(pool, &select_q, &fields).await
-}
-
-/// Stream every row of a given ContentType through `f`. Useful
-/// for cross-table maintenance (e.g. expire audit rows whose
-/// `entity_pk` no longer points at a live row in the target
-/// table). Loads in batches of `batch_size` rows so memory
-/// stays bounded for large tables.
-///
-/// `batch_size = 0` clamps to 1; very large values are accepted
-/// but Postgres will allocate intermediate buffers proportional
-/// to the page so default to 500-1000 for most use cases.
-///
-/// # Errors
-/// Driver / query failures + any `Err` returned by `f` short-
-/// circuits the iteration.
-#[cfg(feature = "postgres")]
-pub async fn for_each_row_of_ct_pg<F>(
-    pool: &PgPool,
-    ct: &ContentType,
-    batch_size: u32,
-    f: F,
-) -> Result<usize, ExecError>
-where
-    F: FnMut(serde_json::Value) -> Result<(), ExecError>,
-{
-    for_each_row_of_ct(&crate::sql::Pool::Postgres(pool.clone()), ct, batch_size, f).await
 }
 
 /// Tri-dialect counterpart of [`for_each_row_of_ct`] (v0.38). Iterates
@@ -571,21 +464,6 @@ impl GenericForeignKey {
         }
     }
 
-    /// Construct a GFK pointing at a row of `T`. Looks up `T`'s
-    /// ContentType via the cached registry (`for_model::<T>`) — one
-    /// DB round-trip the first time, free thereafter once
-    /// memoization lands.
-    ///
-    /// # Errors
-    /// As [`ContentType::for_model`].
-    #[cfg(feature = "postgres")]
-    pub async fn for_target_pg<T: crate::core::Model>(
-        pool: &PgPool,
-        object_pk: i64,
-    ) -> Result<Self, ExecError> {
-        Self::for_target::<T>(&crate::sql::Pool::Postgres(pool.clone()), object_pk).await
-    }
-
     /// Tri-dialect counterpart of [`Self::for_target`] (v0.38).
     /// Routes the ContentType lookup through
     /// [`ContentType::for_model`] so the same call site works on
@@ -611,60 +489,6 @@ impl GenericForeignKey {
             })?;
         Ok(Self::new(id, object_pk))
     }
-}
-
-/// Render a `GenericForeignKey` value as a clickable HTML link
-/// pointing at the target row's admin detail page. Used by the
-/// admin list/detail views (sub-slice F.4) when a model declares
-/// `#[rustango(generic_fk(...))]`.
-///
-/// Resolves the ContentType via [`ContentType::by_id`] to find the
-/// target table name + a human label, builds a relative URL of the
-/// form `/<target_table>/<object_pk>` (matches the auto-admin's
-/// per-table route shape), and returns escaped HTML. Returns the
-/// raw "(ct=…, pk=…)" text fallback if the ContentType lookup fails
-/// (e.g. CT not yet seeded, table dropped, etc.) so the admin
-/// degrades gracefully instead of crashing.
-///
-/// Output is HTML-safe: both `app_label.model_name` and the link
-/// path are HTML-entity-escaped via the same routine the existing
-/// per-FK renderer uses.
-///
-/// # Errors
-/// Driver / SQL failures from the ContentType lookup. Caller can
-/// `unwrap_or_else(|_| ...)` to a fallback rendering.
-#[cfg(feature = "postgres")]
-pub async fn render_generic_fk_link_pg(
-    pool: &PgPool,
-    gfk: GenericForeignKey,
-) -> Result<String, ExecError> {
-    let escape = |s: &str| -> String {
-        s.replace('&', "&amp;")
-            .replace('<', "&lt;")
-            .replace('>', "&gt;")
-            .replace('"', "&quot;")
-            .replace('\'', "&#x27;")
-    };
-    let ct = match ContentType::by_id(&pool.clone().into(), gfk.content_type_id).await? {
-        Some(c) => c,
-        None => {
-            // Stale or unseeded reference — show the raw pair so
-            // the admin operator can spot it.
-            return Ok(format!(
-                "<em>(ct={}, pk={})</em>",
-                gfk.content_type_id, gfk.object_pk
-            ));
-        }
-    };
-    let label = format!("{}.{}", ct.app_label, ct.model_name);
-    let table_esc = escape(&ct.table);
-    let label_esc = escape(&label);
-    Ok(format!(
-        r#"<a href="/{table}/{pk}">{label} #{pk}</a>"#,
-        table = table_esc,
-        pk = gfk.object_pk,
-        label = label_esc,
-    ))
 }
 
 /// v0.37 — backend-agnostic counterpart of [`render_generic_fk_link`].
@@ -702,189 +526,6 @@ pub async fn render_generic_fk_link(
         pk = gfk.object_pk,
         label = label_esc,
     ))
-}
-
-/// Soft-FK prefetch — fetch every row of `C` whose soft-FK column
-/// matches one of `parent_pks`, then group the results by the
-/// soft-FK value via the caller-supplied extractor closure. Returns
-/// a `HashMap<i64, Vec<C>>` keyed on the soft-FK value, mirroring
-/// the shape of [`crate::sql::fetch_with_prefetch`] but for
-/// columns that aren't declared as a real `Relation::Fk` (no DDL FK
-/// constraint, no macro-generated reverse helper).
-///
-/// "Soft FK" = an integer column that conceptually points at
-/// another model's PK without a declared FK relation. Use cases:
-/// optional cross-app references, migration-period references where
-/// the constraint can't be enforced yet, audit-log `entity_pk` columns,
-/// `denormalized_user_id` snapshots, etc.
-///
-/// Two SQL round trips total max (one for the prefetch + the parent
-/// fetch the caller already did). Empty `parent_pks` short-circuits
-/// to an empty map without a round trip.
-///
-/// ```ignore
-/// // After fetching parents:
-/// let parent_pks: Vec<i64> = posts.iter().map(|p| p.id.get().copied().unwrap()).collect();
-/// let by_post: HashMap<i64, Vec<Comment>> = prefetch_soft::<Comment, _>(
-///     &pool,
-///     &parent_pks,
-///     "post_id",        // the soft-FK column on the Comment table
-///     |c| c.post_id,    // extractor: how to read the value off &Comment
-/// ).await?;
-/// for post in &posts {
-///     let comments = by_post.get(&post.id.get().copied().unwrap())
-///         .map(Vec::as_slice).unwrap_or(&[]);
-///     // ...
-/// }
-/// ```
-///
-/// # Errors
-/// Driver / SQL failures from the SELECT.
-#[cfg(feature = "postgres")]
-pub async fn prefetch_soft_pg<C, F>(
-    pool: &PgPool,
-    parent_pks: &[i64],
-    target_fk_column: &'static str,
-    extract: F,
-) -> Result<::std::collections::HashMap<i64, Vec<C>>, ExecError>
-where
-    C: crate::core::Model
-        + for<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow>
-        + Send
-        + Unpin
-        + 'static,
-    F: Fn(&C) -> i64,
-{
-    if parent_pks.is_empty() {
-        return Ok(::std::collections::HashMap::new());
-    }
-    // Dedupe to keep the IN list compact — duplicate parent PKs
-    // would otherwise pad the SQL string and bind list pointlessly.
-    let mut keys: Vec<i64> = parent_pks.to_vec();
-    keys.sort_unstable();
-    keys.dedup();
-    let pk_values: Vec<crate::core::SqlValue> = keys
-        .iter()
-        .copied()
-        .map(crate::core::SqlValue::I64)
-        .collect();
-    let children: Vec<C> = crate::query::QuerySet::<C>::new()
-        .filter(
-            target_fk_column,
-            crate::core::Op::In,
-            crate::core::SqlValue::List(pk_values),
-        )
-        .fetch(pool)
-        .await?;
-    let mut grouped: ::std::collections::HashMap<i64, Vec<C>> = ::std::collections::HashMap::new();
-    for child in children {
-        let key = extract(&child);
-        grouped.entry(key).or_default().push(child);
-    }
-    Ok(grouped)
-}
-
-/// Generic-FK prefetch — given a list of `(content_type_id, object_pk)`
-/// pairs (typically pulled off a parent set's `GenericForeignKey`
-/// fields), batches one SQL per distinct ContentType to fetch the
-/// targets, returns a `HashMap<(i64, i64), C>` keyed on the
-/// (ct_id, pk) pair.
-///
-/// **Single-target-type variant** — caller supplies the concrete
-/// `C: Model` they want hydrated. Filters out any pair whose
-/// `content_type_id` doesn't match `C`'s ContentType (the framework
-/// can't decode a `Photo` row into a `Comment`). For mixed-target
-/// hydration (one query → many target types) you'd need the
-/// boxed-trait dynamic decoder registry — that's a follow-up
-/// (`prefetch_generic_dyn`) once the registry trait is in.
-///
-/// Two SQL round trips total (one ContentType lookup + one target
-/// fetch). Empty input short-circuits to an empty map.
-///
-/// ```ignore
-/// let pairs: Vec<(i64, i64)> = audit_rows.iter()
-///     .map(|a| (a.target.content_type_id, a.target.object_pk))
-///     .collect();
-/// let posts: HashMap<(i64, i64), Post> =
-///     prefetch_generic::<Post>(&pool, &pairs).await?;
-/// ```
-///
-/// # Errors
-/// As [`ContentType::for_model`] + driver / SQL failures from the
-/// target SELECT.
-#[cfg(feature = "postgres")]
-pub async fn prefetch_generic_pg<C>(
-    pool: &PgPool,
-    pairs: &[(i64, i64)],
-) -> Result<::std::collections::HashMap<(i64, i64), C>, ExecError>
-where
-    C: crate::core::Model
-        + for<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow>
-        + crate::sql::HasPkValue
-        + Send
-        + Unpin
-        + 'static,
-{
-    if pairs.is_empty() {
-        return Ok(::std::collections::HashMap::new());
-    }
-    // Resolve C's ContentType once — every (ct_id, pk) pair whose
-    // ct_id doesn't match drops out of the result map (caller's
-    // expectation: typed-target prefetch).
-    let target_ct = ContentType::for_model::<C>(&pool.clone().into())
-        .await?
-        .ok_or_else(|| ExecError::MissingPrimaryKey {
-            table: C::SCHEMA.table,
-        })?;
-    let target_ct_id = target_ct
-        .id
-        .get()
-        .copied()
-        .ok_or_else(|| ExecError::MissingPrimaryKey {
-            table: ContentType::SCHEMA.table,
-        })?;
-
-    let mut wanted_pks: Vec<i64> = pairs
-        .iter()
-        .filter(|(ct, _)| *ct == target_ct_id)
-        .map(|(_, pk)| *pk)
-        .collect();
-    if wanted_pks.is_empty() {
-        return Ok(::std::collections::HashMap::new());
-    }
-    wanted_pks.sort_unstable();
-    wanted_pks.dedup();
-
-    let pk_values: Vec<crate::core::SqlValue> = wanted_pks
-        .iter()
-        .copied()
-        .map(crate::core::SqlValue::I64)
-        .collect();
-    let pk_field = C::SCHEMA
-        .primary_key()
-        .ok_or_else(|| ExecError::MissingPrimaryKey {
-            table: C::SCHEMA.table,
-        })?;
-    let rows: Vec<C> = crate::query::QuerySet::<C>::new()
-        .filter(
-            pk_field.column,
-            crate::core::Op::In,
-            crate::core::SqlValue::List(pk_values),
-        )
-        .fetch(pool)
-        .await?;
-
-    let mut out: ::std::collections::HashMap<(i64, i64), C> =
-        ::std::collections::HashMap::with_capacity(rows.len());
-    for row in rows {
-        // Pull the row's PK back out via the macro-generated
-        // __rustango_pk_value path through HasPkValue.
-        let pk_value = <C as crate::sql::HasPkValue>::__rustango_pk_value_impl(&row);
-        if let crate::core::SqlValue::I64(pk) = pk_value {
-            out.insert((target_ct_id, pk), row);
-        }
-    }
-    Ok(out)
 }
 
 /// Tri-dialect counterpart of [`prefetch_soft`] (v0.38). Same shape
@@ -1024,59 +665,13 @@ where
     Ok(out)
 }
 
-/// SQL that creates the `rustango_content_types` table + the
-/// `(app_label, model_name)` UNIQUE index. Idempotent
-/// (`IF NOT EXISTS`). Mounted as a runtime ensure-table so the
-/// registry pool (whose bootstrap migration only creates
-/// `rustango_orgs` + `rustango_operators`) gets the table without
-/// a separate migration JSON. Tenant schemas already get this
-/// table via the bootstrap migration's CreateTable op for every
-/// registered model.
-#[cfg(feature = "postgres")]
-const CREATE_TABLE_SQL: &str = r#"
-CREATE TABLE IF NOT EXISTS "rustango_content_types" (
-    "id"          BIGSERIAL PRIMARY KEY,
-    "app_label"   VARCHAR(100) NOT NULL,
-    "model_name"  VARCHAR(100) NOT NULL,
-    "table"       VARCHAR(100) NOT NULL
-);
-CREATE UNIQUE INDEX IF NOT EXISTS "rustango_content_types_natural_key"
-    ON "rustango_content_types" ("app_label", "model_name");
-"#;
-
-// v0.34 — note: the legacy `CREATE_TABLE_SQL` Postgres constant above
-// is kept for `ensure_table(&PgPool)` back-compat. The bi-dialect
-// `ensure_table_pool` below no longer carries hand-rolled per-backend
-// DDL constants — it routes through
+// v0.34 — `ensure_table` (below) routes through
 // [`crate::migrate::ddl::create_table_if_not_exists_sql_with_dialect`]
 // which already knows how to emit the table for any backend rustango
 // supports. The UNIQUE INDEX on `(app_label, model_name)` is still
 // hand-emitted because `crate::migrate::diff::render_changes` (the
 // index renderer in the migration system) is currently Postgres-only;
 // when index emission goes bi-dialect that block collapses too.
-
-/// Ensure `rustango_content_types` exists in `pool`'s database /
-/// schema. No-op when already present (`IF NOT EXISTS`). Used by
-/// [`ensure_seeded`] internally + callable directly for any
-/// registry-pool wiring that needs the table without a row walk.
-///
-/// Splits the statement on `;` because Postgres' simple-prepare
-/// path rejects multiple statements in one prepared call —
-/// each `CREATE TABLE` / `CREATE INDEX` runs as its own round-trip.
-///
-/// # Errors
-/// Driver / SQL failures.
-#[cfg(feature = "postgres")]
-pub async fn ensure_table_pg(pool: &PgPool) -> Result<(), crate::sql::sqlx::Error> {
-    for stmt in CREATE_TABLE_SQL.split(';') {
-        let trimmed = stmt.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        crate::sql::sqlx::query(trimmed).execute(pool).await?;
-    }
-    Ok(())
-}
 
 /// Walk the inventory of registered models and INSERT a ContentType
 /// row for every one missing. Idempotent.
@@ -1091,46 +686,6 @@ pub async fn ensure_table_pg(pool: &PgPool) -> Result<(), crate::sql::sqlx::Erro
 ///
 /// # Errors
 /// Driver / query failures from the SELECT-or-INSERT loop.
-#[cfg(feature = "postgres")]
-#[allow(deprecated)]
-pub async fn ensure_seeded_pg(pool: &PgPool) -> Result<usize, ExecError> {
-    ensure_seeded(&pool.clone().into()).await
-}
-
-#[cfg(feature = "postgres")]
-async fn _ensure_seeded_pg_internal(pool: &PgPool) -> Result<usize, ExecError> {
-    ensure_table(&pool.clone().into())
-        .await
-        .map_err(ExecError::Driver)?;
-    let mut inserted = 0_usize;
-    for entry in inventory::iter::<ModelEntry> {
-        let table = entry.schema.table;
-        // Don't seed a row for the ContentType table itself — would
-        // be circular and meaningless.
-        if table == ContentType::SCHEMA.table {
-            continue;
-        }
-        let app = entry.resolved_app_label().unwrap_or("project").to_owned();
-        let name = entry.schema.name.to_ascii_lowercase();
-        // Probe natural key first; skip if already seeded.
-        if ContentType::by_natural_key(&pool.clone().into(), &app, &name)
-            .await?
-            .is_some()
-        {
-            continue;
-        }
-        let mut row = ContentType {
-            id: Auto::Unset,
-            app_label: app,
-            model_name: name,
-            table: table.to_owned(),
-        };
-        row.insert(pool).await?;
-        inserted += 1;
-    }
-    Ok(inserted)
-}
-
 // ============================================================ v0.34 bi-dialect
 
 /// Bootstrap the `rustango_content_types` table against any

--- a/crates/rustango/src/tenancy/migrate.rs
+++ b/crates/rustango/src/tenancy/migrate.rs
@@ -286,12 +286,12 @@ pub async fn migrate_registry_pool(
     // catalog — the operator console's audit log + permissions UI
     // consult it to resolve `entity_table` strings back to a stable
     // per-model identifier. Bi-dialect via
-    // `contenttypes::ensure_seeded_pool` (v0.34 slice 1).
-    if let Err(e) = crate::contenttypes::ensure_seeded_pool(registry).await {
+    // `contenttypes::ensure_seeded` (v0.34 slice 1).
+    if let Err(e) = crate::contenttypes::ensure_seeded(registry).await {
         tracing::warn!(
             target: "crate::tenancy",
             error = %e,
-            "contenttypes::ensure_seeded_pool failed for registry pool",
+            "contenttypes::ensure_seeded failed for registry pool",
         );
     }
     info!(
@@ -512,8 +512,8 @@ where
     if let Err(e) = super::permissions::auto_create_permissions_pool(&inner_pool).await {
         tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "auto_create_permissions_pool failed for database-mode tenant");
     }
-    if let Err(e) = crate::contenttypes::ensure_seeded_pool(&inner_pool).await {
-        tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "contenttypes::ensure_seeded_pool failed for database-mode tenant");
+    if let Err(e) = crate::contenttypes::ensure_seeded(&inner_pool).await {
+        tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "contenttypes::ensure_seeded failed for database-mode tenant");
     }
     if let Err(e) = super::auth_backends::ensure_api_keys_table_pool(&inner_pool).await {
         tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "ensure_api_keys_table_pool failed for database-mode tenant");
@@ -592,7 +592,7 @@ async fn run_for_one_tenant(
             // (audit log, generic FKs, permissions UI) consults.
             // Idempotent; pre-existing rows are unchanged thanks
             // to the UNIQUE(app_label, model_name) constraint.
-            if let Err(e) = crate::contenttypes::ensure_seeded(&pool).await {
+            if let Err(e) = crate::contenttypes::ensure_seeded(&pool.clone().into()).await {
                 tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "contenttypes::ensure_seeded failed for schema-mode tenant");
             }
             if let Err(e) = super::auth_backends::ensure_api_keys_table(&pool).await {
@@ -615,7 +615,9 @@ async fn run_for_one_tenant(
                 tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "auto_create_permissions failed for database-mode tenant");
             }
             // (#89) See schema-mode comment above.
-            if let Err(e) = crate::contenttypes::ensure_seeded(tenant_pool.pool()).await {
+            if let Err(e) =
+                crate::contenttypes::ensure_seeded(&tenant_pool.pool().clone().into()).await
+            {
                 tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "contenttypes::ensure_seeded failed for database-mode tenant");
             }
             if let Err(e) = super::auth_backends::ensure_api_keys_table(tenant_pool.pool()).await {

--- a/crates/rustango/tests/contenttypes_batch_cache.rs
+++ b/crates/rustango/tests/contenttypes_batch_cache.rs
@@ -36,7 +36,7 @@ async fn sqlite_pool() -> Pool {
             .await
             .expect("sqlite memory pool"),
     );
-    contenttypes::ensure_seeded_pool(&pool)
+    contenttypes::ensure_seeded(&pool)
         .await
         .expect("ensure_seeded_pool");
     pool
@@ -104,7 +104,7 @@ async fn get_for_models_empty_input_is_empty_output() {
 async fn get_by_natural_key_matches_uncached() {
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
-    let uncached = ContentType::by_natural_key_pool(&pool, "ct_bc_blog", "post")
+    let uncached = ContentType::by_natural_key(&pool, "ct_bc_blog", "post")
         .await
         .expect("uncached lookup")
         .expect("Post is seeded");
@@ -163,7 +163,7 @@ async fn clear_cache_forces_db_round_trip_again() {
             .await
             .expect("drop");
     }
-    contenttypes::ensure_table_pool(&pool)
+    contenttypes::ensure_table(&pool)
         .await
         .expect("recreate empty");
 
@@ -208,7 +208,7 @@ async fn negative_results_are_not_cached() {
 }
 
 /// `get_for_model::<T>` returns the same row as the uncached
-/// `for_model_pool::<T>` and uses the natural-key cache.
+/// `for_model::<T>` and uses the natural-key cache.
 #[tokio::test]
 async fn get_for_model_resolves_type() {
     contenttypes::clear_cache();
@@ -217,7 +217,7 @@ async fn get_for_model_resolves_type() {
         .await
         .expect("cached for_model")
         .expect("Post is seeded");
-    let uncached = ContentType::for_model_pool::<Post>(&pool)
+    let uncached = ContentType::for_model::<Post>(&pool)
         .await
         .expect("uncached for_model")
         .expect("Post is seeded");

--- a/crates/rustango/tests/contenttypes_pool_live.rs
+++ b/crates/rustango/tests/contenttypes_pool_live.rs
@@ -50,11 +50,11 @@ async fn sqlite_pool() -> Pool {
 #[tokio::test]
 async fn ensure_table_pool_creates_sqlite_table() {
     let pool = sqlite_pool().await;
-    contenttypes::ensure_table_pool(&pool)
+    contenttypes::ensure_table(&pool)
         .await
         .expect("ensure_table_pool");
     // Idempotent — second call is a no-op.
-    contenttypes::ensure_table_pool(&pool)
+    contenttypes::ensure_table(&pool)
         .await
         .expect("ensure_table_pool idempotent");
 
@@ -73,7 +73,7 @@ async fn ensure_table_pool_creates_sqlite_table() {
 #[tokio::test]
 async fn ensure_seeded_pool_inserts_rows_on_sqlite() {
     let pool = sqlite_pool().await;
-    let inserted = contenttypes::ensure_seeded_pool(&pool)
+    let inserted = contenttypes::ensure_seeded(&pool)
         .await
         .expect("ensure_seeded_pool");
     // Inventory is process-global: every Model from every test in
@@ -88,11 +88,11 @@ async fn ensure_seeded_pool_inserts_rows_on_sqlite() {
 #[tokio::test]
 async fn ensure_seeded_pool_is_idempotent_on_sqlite() {
     let pool = sqlite_pool().await;
-    let first = contenttypes::ensure_seeded_pool(&pool)
+    let first = contenttypes::ensure_seeded(&pool)
         .await
         .expect("first seed");
     assert!(first >= 1);
-    let second = contenttypes::ensure_seeded_pool(&pool)
+    let second = contenttypes::ensure_seeded(&pool)
         .await
         .expect("second seed");
     assert_eq!(second, 0, "re-seed should insert nothing");
@@ -101,8 +101,8 @@ async fn ensure_seeded_pool_is_idempotent_on_sqlite() {
 #[tokio::test]
 async fn by_natural_key_pool_finds_seeded_row_on_sqlite() {
     let pool = sqlite_pool().await;
-    contenttypes::ensure_seeded_pool(&pool).await.expect("seed");
-    let row = ContentType::by_natural_key_pool(&pool, "blog_pool_live", "post")
+    contenttypes::ensure_seeded(&pool).await.expect("seed");
+    let row = ContentType::by_natural_key(&pool, "blog_pool_live", "post")
         .await
         .expect("lookup");
     let row = row.expect("seeded row should exist");
@@ -114,8 +114,8 @@ async fn by_natural_key_pool_finds_seeded_row_on_sqlite() {
 #[tokio::test]
 async fn by_natural_key_pool_returns_none_for_unknown_key() {
     let pool = sqlite_pool().await;
-    contenttypes::ensure_seeded_pool(&pool).await.expect("seed");
-    let row = ContentType::by_natural_key_pool(&pool, "nope", "missing")
+    contenttypes::ensure_seeded(&pool).await.expect("seed");
+    let row = ContentType::by_natural_key(&pool, "nope", "missing")
         .await
         .expect("lookup");
     assert!(row.is_none());
@@ -129,8 +129,8 @@ async fn by_natural_key_pool_returns_none_for_unknown_key() {
 #[tokio::test]
 async fn for_model_pool_resolves_model_type_on_sqlite() {
     let pool = sqlite_pool().await;
-    contenttypes::ensure_seeded_pool(&pool).await.expect("seed");
-    let row = ContentType::for_model_pool::<Post>(&pool)
+    contenttypes::ensure_seeded(&pool).await.expect("seed");
+    let row = ContentType::for_model::<Post>(&pool)
         .await
         .expect("for_model_pool");
     let row = row.expect("Post should have a CT row");
@@ -142,8 +142,8 @@ async fn for_model_pool_resolves_model_type_on_sqlite() {
 #[tokio::test]
 async fn for_model_pool_finds_user_too() {
     let pool = sqlite_pool().await;
-    contenttypes::ensure_seeded_pool(&pool).await.expect("seed");
-    let row = ContentType::for_model_pool::<User>(&pool)
+    contenttypes::ensure_seeded(&pool).await.expect("seed");
+    let row = ContentType::for_model::<User>(&pool)
         .await
         .expect("for_model_pool")
         .expect("User should have a CT row");
@@ -154,8 +154,8 @@ async fn for_model_pool_finds_user_too() {
 #[tokio::test]
 async fn all_pool_returns_seeded_rows_alphabetically() {
     let pool = sqlite_pool().await;
-    contenttypes::ensure_seeded_pool(&pool).await.expect("seed");
-    let rows = ContentType::all_pool(&pool).await.expect("all_pool");
+    contenttypes::ensure_seeded(&pool).await.expect("seed");
+    let rows = ContentType::all(&pool).await.expect("all_pool");
     assert!(
         rows.len() >= 2,
         "should have at least the Post + User rows; got {}",
@@ -180,13 +180,13 @@ async fn all_pool_returns_seeded_rows_alphabetically() {
 #[tokio::test]
 async fn for_target_pool_constructs_generic_fk_on_sqlite() {
     let pool = sqlite_pool().await;
-    contenttypes::ensure_seeded_pool(&pool).await.expect("seed");
-    let gfk = rustango::contenttypes::GenericForeignKey::for_target_pool::<Post>(&pool, 42)
+    contenttypes::ensure_seeded(&pool).await.expect("seed");
+    let gfk = rustango::contenttypes::GenericForeignKey::for_target::<Post>(&pool, 42)
         .await
         .expect("for_target_pool");
     assert_eq!(gfk.object_pk, 42);
     // ct id should match what for_model_pool returns.
-    let ct = ContentType::for_model_pool::<Post>(&pool)
+    let ct = ContentType::for_model::<Post>(&pool)
         .await
         .expect("for_model_pool")
         .expect("ct row");
@@ -201,7 +201,7 @@ async fn for_target_pool_constructs_generic_fk_on_sqlite() {
 async fn fetch_row_as_json_pool_returns_none_for_missing_pk() {
     use rustango::sql::sqlx::Executor as _;
     let pool = sqlite_pool().await;
-    contenttypes::ensure_seeded_pool(&pool).await.expect("seed");
+    contenttypes::ensure_seeded(&pool).await.expect("seed");
     // Bootstrap the Post table so `fetch_row_as_json_pool` finds the
     // schema and can issue the SELECT — and returns None for an
     // absent PK.
@@ -214,11 +214,11 @@ async fn fetch_row_as_json_pool_returns_none_for_missing_pk() {
         .await
         .expect("create post table");
     }
-    let ct = ContentType::for_model_pool::<Post>(&pool)
+    let ct = ContentType::for_model::<Post>(&pool)
         .await
         .expect("for_model_pool")
         .expect("ct row");
-    let row = contenttypes::fetch_row_as_json_pool(&pool, &ct, 9999_i64)
+    let row = contenttypes::fetch_row_as_json(&pool, &ct, 9999_i64)
         .await
         .expect("fetch_row_as_json_pool");
     assert!(row.is_none(), "no row with id=9999 should return None");
@@ -230,14 +230,14 @@ async fn render_generic_fk_link_pool_emits_clickable_html_on_sqlite() {
     // the admin to render `(content_type_id, pk)` as a link. Returns
     // graceful fallback HTML when the CT row is unknown.
     let pool = sqlite_pool().await;
-    contenttypes::ensure_seeded_pool(&pool).await.expect("seed");
-    let ct = ContentType::for_model_pool::<Post>(&pool)
+    contenttypes::ensure_seeded(&pool).await.expect("seed");
+    let ct = ContentType::for_model::<Post>(&pool)
         .await
         .expect("for_model_pool")
         .expect("ct row");
     let ct_id = ct.id.get().copied().expect("ct id");
     let gfk = rustango::contenttypes::GenericForeignKey::new(ct_id, 7);
-    let html = contenttypes::render_generic_fk_link_pool(&pool, gfk)
+    let html = contenttypes::render_generic_fk_link(&pool, gfk)
         .await
         .expect("render_generic_fk_link_pool");
     assert!(
@@ -248,7 +248,7 @@ async fn render_generic_fk_link_pool_emits_clickable_html_on_sqlite() {
     assert!(html.contains("#7"), "should mention the pk, got: {html}");
 
     // Unknown CT id → graceful fallback HTML, not an error.
-    let fallback = contenttypes::render_generic_fk_link_pool(
+    let fallback = contenttypes::render_generic_fk_link(
         &pool,
         rustango::contenttypes::GenericForeignKey::new(99_999, 7),
     )
@@ -285,7 +285,7 @@ async fn prefetch_soft_pool_groups_children_by_parent_pk_on_sqlite() {
     // HashMap<parent_pk, Vec<Child>>.
     use rustango::sql::sqlx::Executor as _;
     let pool = sqlite_pool().await;
-    contenttypes::ensure_seeded_pool(&pool).await.expect("seed");
+    contenttypes::ensure_seeded(&pool).await.expect("seed");
     if let Pool::Sqlite(sq) = &pool {
         sq.execute(
             "CREATE TABLE IF NOT EXISTS ct_pool_live_comment (\
@@ -305,11 +305,9 @@ async fn prefetch_soft_pool_groups_children_by_parent_pk_on_sqlite() {
         }
     }
     let grouped =
-        contenttypes::prefetch_soft_pool::<Comment, _>(&pool, &[1, 2], "author_id", |c| {
-            c.author_id
-        })
-        .await
-        .expect("prefetch_soft_pool");
+        contenttypes::prefetch_soft::<Comment, _>(&pool, &[1, 2], "author_id", |c| c.author_id)
+            .await
+            .expect("prefetch_soft_pool");
     assert_eq!(
         grouped.get(&1).map_or(0, |v| v.len()),
         2,
@@ -322,10 +320,9 @@ async fn prefetch_soft_pool_groups_children_by_parent_pk_on_sqlite() {
     );
 
     // Empty parent_pks list short-circuits to empty map.
-    let empty =
-        contenttypes::prefetch_soft_pool::<Comment, _>(&pool, &[], "author_id", |c| c.author_id)
-            .await
-            .expect("empty pks");
+    let empty = contenttypes::prefetch_soft::<Comment, _>(&pool, &[], "author_id", |c| c.author_id)
+        .await
+        .expect("empty pks");
     assert!(empty.is_empty(), "empty parent list short-circuits");
 }
 
@@ -336,7 +333,7 @@ async fn prefetch_generic_pool_hydrates_targets_on_sqlite() {
     // whose ct matches, returns `HashMap<(i64, i64), C>`.
     use rustango::sql::sqlx::Executor as _;
     let pool = sqlite_pool().await;
-    contenttypes::ensure_seeded_pool(&pool).await.expect("seed");
+    contenttypes::ensure_seeded(&pool).await.expect("seed");
     if let Pool::Sqlite(sq) = &pool {
         sq.execute(
             "CREATE TABLE IF NOT EXISTS ct_pool_live_post (\
@@ -351,12 +348,12 @@ async fn prefetch_generic_pool_hydrates_targets_on_sqlite() {
             .expect("seed row");
     }
     // Look up Post's CT id then ask prefetch_generic_pool to hydrate.
-    let ct = ContentType::for_model_pool::<Post>(&pool)
+    let ct = ContentType::for_model::<Post>(&pool)
         .await
         .expect("for_model_pool")
         .expect("ct row");
     let ct_id = ct.id.get().copied().expect("ct id");
-    let map = contenttypes::prefetch_generic_pool::<Post>(&pool, &[(ct_id, 1)])
+    let map = contenttypes::prefetch_generic::<Post>(&pool, &[(ct_id, 1)])
         .await
         .expect("prefetch_generic_pool");
     assert!(
@@ -371,7 +368,7 @@ async fn prefetch_generic_pool_hydrates_targets_on_sqlite() {
     );
 
     // Empty pairs short-circuit to empty map.
-    let empty = contenttypes::prefetch_generic_pool::<Post>(&pool, &[])
+    let empty = contenttypes::prefetch_generic::<Post>(&pool, &[])
         .await
         .expect("empty");
     assert!(empty.is_empty(), "empty pair list should short-circuit");
@@ -381,7 +378,7 @@ async fn prefetch_generic_pool_hydrates_targets_on_sqlite() {
 async fn for_each_row_of_ct_pool_visits_seeded_rows() {
     use rustango::sql::sqlx::Executor as _;
     let pool = sqlite_pool().await;
-    contenttypes::ensure_seeded_pool(&pool).await.expect("seed");
+    contenttypes::ensure_seeded(&pool).await.expect("seed");
     // Bootstrap + seed three Posts so the iterator has something to walk.
     if let Pool::Sqlite(sq) = &pool {
         sq.execute(
@@ -399,12 +396,12 @@ async fn for_each_row_of_ct_pool_visits_seeded_rows() {
                 .expect("insert");
         }
     }
-    let ct = ContentType::for_model_pool::<Post>(&pool)
+    let ct = ContentType::for_model::<Post>(&pool)
         .await
         .expect("for_model_pool")
         .expect("ct row");
     let mut visited = 0usize;
-    let total = contenttypes::for_each_row_of_ct_pool(&pool, &ct, 2, |_row| {
+    let total = contenttypes::for_each_row_of_ct(&pool, &ct, 2, |_row| {
         visited += 1;
         Ok(())
     })

--- a/crates/rustango/tests/migrate_registry_pool_sqlite_live.rs
+++ b/crates/rustango/tests/migrate_registry_pool_sqlite_live.rs
@@ -5,7 +5,7 @@
 //!
 //! The migration dir is intentionally empty — this test isn't about
 //! the runner's row processing, it's about verifying the auxiliary
-//! bootstrap (audit::ensure_table_pool, contenttypes::ensure_seeded_pool)
+//! bootstrap (audit::ensure_table_pool, contenttypes::ensure_seeded)
 //! that runs unconditionally after the migration loop. Combined with
 //! the existing contenttypes_pool_live + audit live tests this gives
 //! coverage of the whole `migrate_registry_pool` happy path.
@@ -24,7 +24,7 @@ async fn migrate_registry_pool_bootstraps_audit_and_contenttypes_on_sqlite() {
     );
 
     // Empty migration dir — exercises the bootstrap-only path
-    // (audit::ensure_table_pool + contenttypes::ensure_seeded_pool).
+    // (audit::ensure_table_pool + contenttypes::ensure_seeded).
     let tmp = tempfile::tempdir().expect("temp dir");
     let applied = migrate_registry_pool(&pool, tmp.path())
         .await


### PR DESCRIPTION
## Why

The `_pool` suffix was a disambiguation token to separate the tri-dialect `&Pool` variant from the legacy PG-only `&PgPool` variant. Now that `&Pool` is the primary API for all three dialects, the suffix is pure noise. `ContentType::by_natural_key(&pool, ...)` reads better than `ContentType::by_natural_key_pool(&pool, ...)`.

## What changed

| Old | New |
|---|---|
| `ContentType::by_natural_key_pool` | `ContentType::by_natural_key` |
| `ContentType::by_id_pool` | `ContentType::by_id` |
| `ContentType::for_model_pool` | `ContentType::for_model` |
| `ContentType::all_pool` | `ContentType::all` |
| `GenericForeignKey::for_target_pool` | `GenericForeignKey::for_target` |
| `ensure_seeded_pool` | `ensure_seeded` |
| `ensure_table_pool` | `ensure_table` |
| `fetch_row_as_json_pool` | `fetch_row_as_json` |
| `for_each_row_of_ct_pool` | `for_each_row_of_ct` |
| `render_generic_fk_link_pool` | `render_generic_fk_link` |
| `prefetch_soft_pool` / `prefetch_generic_pool` | `prefetch_soft` / `prefetch_generic` |

The legacy PG-only `&PgPool` methods are moved to `_pg` suffix (`by_natural_key_pg`, etc.) and marked `#[deprecated(since = "0.40.0")]`. They delegate to the tri-dialect version via `pool.clone().into()`. Callers with `&PgPool` can migrate with `.into()`.

## Three dialects

Yes — **all three dialects are supported** by the renamed methods. The `_pool` suffix was the tri-dialect marker. The renamed methods still take `&crate::sql::Pool` (the enum that dispatches to PG / MySQL / SQLite). Nothing about backend support changed.

## Test plan

- [x] 1469 lib tests pass with `--features tenancy`
- [x] `cargo build --no-default-features --features sqlite,tenancy` clean
- [x] `cargo build --features tenancy,postgres,mysql,sqlite` clean
- [x] `tests/contenttypes_batch_cache.rs` (8 tests) pass
- [x] `tests/contenttypes_pool_live.rs` compiles with new names