### PR TITLE
feat: PG aggregate functions — array_agg / string_agg / jsonb_agg (closes #33)

### DIFF
--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -550,6 +550,79 @@ pub enum AggregateExpr {
     Max(&'static str),
     /// `MIN(column)`.
     Min(&'static str),
+    /// PG: `array_agg(column)` — collects column values into a Postgres
+    /// array. With `distinct = true` emits `array_agg(DISTINCT column)`.
+    /// Issue #33. **Postgres-only**: MySQL/SQLite emit
+    /// `SqlError::AggregateNotSupportedInDialect`. The returned column
+    /// is a `text[]` / `int[]` depending on the input type; decode it as
+    /// `Vec<T>` via `serde_json::Value` if the SqlValue decoder doesn't
+    /// recognise the array type natively.
+    ArrayAgg {
+        column: &'static str,
+        distinct: bool,
+    },
+    /// PG: `string_agg(column, delimiter)` — concatenates column values
+    /// with `delimiter`. With `distinct = true` emits
+    /// `string_agg(DISTINCT column, delimiter)`. `delimiter` is bound as
+    /// a parameter so SQL injection through the delimiter is impossible.
+    /// Issue #33. **Postgres-only**.
+    StringAgg {
+        column: &'static str,
+        delimiter: String,
+        distinct: bool,
+    },
+    /// PG: `jsonb_agg(column)` — collects column values into a JSONB
+    /// array. Issue #33. **Postgres-only**.
+    JsonbAgg { column: &'static str },
+}
+
+impl AggregateExpr {
+    /// Ergonomic constructor for [`AggregateExpr::ArrayAgg`] without
+    /// `DISTINCT`. Issue #33.
+    #[must_use]
+    pub const fn array_agg(column: &'static str) -> Self {
+        Self::ArrayAgg {
+            column,
+            distinct: false,
+        }
+    }
+
+    /// Ergonomic constructor for `array_agg(DISTINCT column)`. Issue #33.
+    #[must_use]
+    pub const fn array_agg_distinct(column: &'static str) -> Self {
+        Self::ArrayAgg {
+            column,
+            distinct: true,
+        }
+    }
+
+    /// Ergonomic constructor for [`AggregateExpr::StringAgg`] without
+    /// `DISTINCT`. Issue #33.
+    #[must_use]
+    pub fn string_agg(column: &'static str, delimiter: impl Into<String>) -> Self {
+        Self::StringAgg {
+            column,
+            delimiter: delimiter.into(),
+            distinct: false,
+        }
+    }
+
+    /// Ergonomic constructor for `string_agg(DISTINCT column, delimiter)`.
+    /// Issue #33.
+    #[must_use]
+    pub fn string_agg_distinct(column: &'static str, delimiter: impl Into<String>) -> Self {
+        Self::StringAgg {
+            column,
+            delimiter: delimiter.into(),
+            distinct: true,
+        }
+    }
+
+    /// Ergonomic constructor for [`AggregateExpr::JsonbAgg`]. Issue #33.
+    #[must_use]
+    pub const fn jsonb_agg(column: &'static str) -> Self {
+        Self::JsonbAgg { column }
+    }
 }
 
 /// A `SELECT … GROUP BY … HAVING …` query. Returned rows are untyped

--- a/crates/rustango/src/sql/error.rs
+++ b/crates/rustango/src/sql/error.rs
@@ -119,6 +119,18 @@ pub enum SqlError {
         dialect: &'static str,
     },
 
+    /// A Postgres-specific aggregate (`array_agg`, `string_agg`,
+    /// `jsonb_agg`, etc.) was requested on a non-PG backend. Issue #33.
+    /// MySQL has `GROUP_CONCAT` and `JSON_ARRAYAGG` that overlap
+    /// semantically but the syntax differs enough that we don't
+    /// auto-translate — caller should branch on `pool.dialect().name()`
+    /// or restrict the feature to PG-only deployments.
+    #[error("aggregate `{aggregate}` is not supported by the `{dialect}` dialect")]
+    AggregateNotSupportedInDialect {
+        aggregate: &'static str,
+        dialect: &'static str,
+    },
+
     /// A scalar function (issue #2) was built with the wrong number of
     /// arguments — e.g. `Substr` with 2 args, `NullIf` with 3, or
     /// `Concat` with 0. The builder-side API constrains arity for

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -236,6 +236,52 @@ pub(super) fn write_aggregate(b: &mut Sql<'_>, query: &AggregateQuery) -> Result
                 b.write_ident(col);
                 b.sql.push(')');
             }
+            AggregateExpr::ArrayAgg { column, distinct } => {
+                if b.d.name() != "postgres" {
+                    return Err(SqlError::AggregateNotSupportedInDialect {
+                        aggregate: "array_agg",
+                        dialect: b.d.name(),
+                    });
+                }
+                b.sql.push_str("array_agg(");
+                if *distinct {
+                    b.sql.push_str("DISTINCT ");
+                }
+                b.write_ident(column);
+                b.sql.push(')');
+            }
+            AggregateExpr::StringAgg {
+                column,
+                delimiter,
+                distinct,
+            } => {
+                if b.d.name() != "postgres" {
+                    return Err(SqlError::AggregateNotSupportedInDialect {
+                        aggregate: "string_agg",
+                        dialect: b.d.name(),
+                    });
+                }
+                b.sql.push_str("string_agg(");
+                if *distinct {
+                    b.sql.push_str("DISTINCT ");
+                }
+                b.write_ident(column);
+                b.sql.push_str(", ");
+                // Delimiter binds as a parameter — no string interpolation.
+                b.push_param(crate::core::SqlValue::String(delimiter.clone()));
+                b.sql.push(')');
+            }
+            AggregateExpr::JsonbAgg { column } => {
+                if b.d.name() != "postgres" {
+                    return Err(SqlError::AggregateNotSupportedInDialect {
+                        aggregate: "jsonb_agg",
+                        dialect: b.d.name(),
+                    });
+                }
+                b.sql.push_str("jsonb_agg(");
+                b.write_ident(column);
+                b.sql.push(')');
+            }
         }
         b.sql.push_str(" AS ");
         b.write_ident(alias);

--- a/crates/rustango/tests/pg_aggregates.rs
+++ b/crates/rustango/tests/pg_aggregates.rs
@@ -1,0 +1,187 @@
+//! Tri-dialect emission tests for PG aggregate functions (issue #33):
+//! `array_agg`, `string_agg`, `jsonb_agg`. PG-only — non-PG backends
+//! must emit `SqlError::AggregateNotSupportedInDialect`.
+
+use rustango::core::{AggregateExpr, AggregateQuery, SqlValue, WhereExpr};
+use rustango::sql::{Dialect, MySql, Postgres, SqlError, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "pga_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 50)]
+    tag: String,
+    #[rustango(max_length = 50)]
+    author: String,
+}
+
+fn aggregate_query(expr: AggregateExpr, alias: &'static str) -> AggregateQuery {
+    AggregateQuery {
+        model: <Post as rustango::core::Model>::SCHEMA,
+        where_clause: WhereExpr::And(vec![]),
+        group_by: Vec::new(),
+        aggregates: vec![(alias, expr)],
+        having: None,
+        order_by: Vec::new(),
+        limit: None,
+        offset: None,
+    }
+}
+
+// ---------- array_agg ----------
+
+#[test]
+fn array_agg_emits_pg_native_call() {
+    let q = aggregate_query(AggregateExpr::array_agg("tag"), "tags");
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"array_agg("tag")"#),
+        "expected array_agg(\"tag\") in: {}",
+        stmt.sql
+    );
+    assert!(stmt.sql.contains(r#"AS "tags""#), "got: {}", stmt.sql);
+}
+
+#[test]
+fn array_agg_distinct_emits_distinct() {
+    let q = aggregate_query(AggregateExpr::array_agg_distinct("tag"), "tags");
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"array_agg(DISTINCT "tag")"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn array_agg_rejected_on_mysql() {
+    let q = aggregate_query(AggregateExpr::array_agg("tag"), "tags");
+    let r = MySql.compile_aggregate(&q);
+    match r {
+        Err(SqlError::AggregateNotSupportedInDialect { aggregate, dialect }) => {
+            assert_eq!(aggregate, "array_agg");
+            assert_eq!(dialect, "mysql");
+        }
+        other => panic!("expected AggregateNotSupportedInDialect, got {other:?}"),
+    }
+}
+
+#[test]
+fn array_agg_rejected_on_sqlite() {
+    let q = aggregate_query(AggregateExpr::array_agg("tag"), "tags");
+    let r = Sqlite.compile_aggregate(&q);
+    assert!(matches!(
+        r,
+        Err(SqlError::AggregateNotSupportedInDialect {
+            aggregate: "array_agg",
+            dialect: "sqlite"
+        })
+    ));
+}
+
+// ---------- string_agg ----------
+
+#[test]
+fn string_agg_emits_pg_call_with_bound_delimiter() {
+    let q = aggregate_query(AggregateExpr::string_agg("tag", ", "), "tag_list");
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    // The delimiter binds as $N — the SQL contains `string_agg("tag", $1)`
+    assert!(
+        stmt.sql.contains(r#"string_agg("tag", $1)"#),
+        "expected bound delimiter: {}",
+        stmt.sql
+    );
+    assert_eq!(stmt.params, vec![SqlValue::String(", ".into())]);
+}
+
+#[test]
+fn string_agg_distinct_emits_distinct() {
+    let q = aggregate_query(AggregateExpr::string_agg_distinct("tag", "; "), "tag_list");
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"string_agg(DISTINCT "tag", $1)"#),
+        "got: {}",
+        stmt.sql
+    );
+    assert_eq!(stmt.params, vec![SqlValue::String("; ".into())]);
+}
+
+#[test]
+fn string_agg_rejected_on_non_pg() {
+    let q = aggregate_query(AggregateExpr::string_agg("tag", ", "), "tags");
+    assert!(matches!(
+        MySql.compile_aggregate(&q),
+        Err(SqlError::AggregateNotSupportedInDialect {
+            aggregate: "string_agg",
+            ..
+        })
+    ));
+    assert!(matches!(
+        Sqlite.compile_aggregate(&q),
+        Err(SqlError::AggregateNotSupportedInDialect {
+            aggregate: "string_agg",
+            ..
+        })
+    ));
+}
+
+// ---------- jsonb_agg ----------
+
+#[test]
+fn jsonb_agg_emits_pg_native_call() {
+    let q = aggregate_query(AggregateExpr::jsonb_agg("tag"), "tag_json");
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"jsonb_agg("tag")"#),
+        "got: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains(r#"AS "tag_json""#),
+        "alias should be quoted: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn jsonb_agg_rejected_on_non_pg() {
+    let q = aggregate_query(AggregateExpr::jsonb_agg("tag"), "j");
+    assert!(matches!(
+        MySql.compile_aggregate(&q),
+        Err(SqlError::AggregateNotSupportedInDialect {
+            aggregate: "jsonb_agg",
+            ..
+        })
+    ));
+    assert!(matches!(
+        Sqlite.compile_aggregate(&q),
+        Err(SqlError::AggregateNotSupportedInDialect {
+            aggregate: "jsonb_agg",
+            ..
+        })
+    ));
+}
+
+// ---------- mixed with GROUP BY ----------
+
+#[test]
+fn array_agg_composes_with_group_by() {
+    let q = AggregateQuery {
+        model: <Post as rustango::core::Model>::SCHEMA,
+        where_clause: WhereExpr::And(vec![]),
+        group_by: vec!["author"],
+        aggregates: vec![("tags", AggregateExpr::array_agg("tag"))],
+        having: None,
+        order_by: Vec::new(),
+        limit: None,
+        offset: None,
+    };
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    // SELECT "author", array_agg("tag") AS "tags" FROM "pga_post" GROUP BY "author"
+    assert!(stmt.sql.contains(r#"SELECT "author""#));
+    assert!(stmt.sql.contains(r#"array_agg("tag")"#));
+    assert!(stmt.sql.contains(r#"GROUP BY "author""#));
+}

--- a/crates/rustango/tests/pg_aggregates_live.rs
+++ b/crates/rustango/tests/pg_aggregates_live.rs
@@ -1,0 +1,166 @@
+#![cfg(feature = "postgres")]
+//! Live PG end-to-end test for the new PG aggregates (issue #33).
+//! Skips silently when `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::core::{AggregateExpr, AggregateQuery, SqlValue, WhereExpr};
+use rustango::sql::{fetch_aggregate, sqlx, Auto};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "pgal_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 50)]
+    pub author: String,
+    #[rustango(max_length = 50)]
+    pub tag: String,
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "pgal_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "pgal_post" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "author" VARCHAR(50) NOT NULL,
+            "tag" VARCHAR(50) NOT NULL
+        )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    // Three rows: alice has tags "rust" and "sql"; bob has "rust".
+    for (author, tag) in [("alice", "rust"), ("alice", "sql"), ("bob", "rust")] {
+        sqlx::query(r#"INSERT INTO "pgal_post" ("author", "tag") VALUES ($1, $2)"#)
+            .bind(author)
+            .bind(tag)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+}
+
+async fn cleanup(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "pgal_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+fn agg_per_author(expr: AggregateExpr, alias: &'static str) -> AggregateQuery {
+    AggregateQuery {
+        model: <Post as rustango::core::Model>::SCHEMA,
+        where_clause: WhereExpr::And(vec![]),
+        group_by: vec!["author"],
+        aggregates: vec![(alias, expr)],
+        having: None,
+        order_by: vec![rustango::core::OrderClause {
+            column: "author",
+            desc: false,
+        }],
+        limit: None,
+        offset: None,
+    }
+}
+
+#[tokio::test]
+async fn array_agg_collects_tags_per_author() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = agg_per_author(AggregateExpr::array_agg("tag"), "tags");
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    assert_eq!(rows.len(), 2, "two distinct authors");
+
+    // Alice should have both rust + sql tags. The exact array
+    // encoding depends on the SqlValue decoder — accept either a
+    // List or a Json or a string-formatted array.
+    let alice = rows
+        .iter()
+        .find(|r| matches!(r.get("author"), Some(SqlValue::String(s)) if s == "alice"))
+        .expect("alice row");
+    let tags = alice.get("tags").expect("tags col");
+    let dbg = format!("{tags:?}");
+    assert!(
+        dbg.contains("rust") && dbg.contains("sql"),
+        "alice's tags should include rust + sql: {dbg}"
+    );
+
+    cleanup(&pool).await;
+}
+
+#[tokio::test]
+async fn string_agg_concatenates_tags_per_author() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    // Note: ordering inside string_agg is unspecified without an
+    // ORDER BY inside the aggregate; sort the inputs by inserting
+    // alphabetically before this call. For this test we accept
+    // either "rust,sql" or "sql,rust".
+    let q = agg_per_author(AggregateExpr::string_agg("tag", ","), "tag_list");
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let alice = rows
+        .iter()
+        .find(|r| matches!(r.get("author"), Some(SqlValue::String(s)) if s == "alice"))
+        .expect("alice row");
+    let list = match alice.get("tag_list") {
+        Some(SqlValue::String(s)) => s.clone(),
+        other => panic!("expected String, got {other:?}"),
+    };
+    assert!(
+        list == "rust,sql" || list == "sql,rust",
+        "alice's tag_list should be the two tags joined: got {list}"
+    );
+
+    cleanup(&pool).await;
+}
+
+#[tokio::test]
+async fn jsonb_agg_returns_json_array_per_author() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = agg_per_author(AggregateExpr::jsonb_agg("tag"), "tag_json");
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let alice = rows
+        .iter()
+        .find(|r| matches!(r.get("author"), Some(SqlValue::String(s)) if s == "alice"))
+        .expect("alice row");
+    let json = match alice.get("tag_json") {
+        Some(SqlValue::Json(v)) => v.clone(),
+        other => panic!("expected JSONB, got {other:?}"),
+    };
+    let arr = json.as_array().expect("array shape");
+    assert_eq!(arr.len(), 2, "alice has 2 tags");
+    let strs: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
+    assert!(strs.contains(&"rust") && strs.contains(&"sql"), "{arr:?}");
+
+    cleanup(&pool).await;
+}


### PR DESCRIPTION
## Summary

First slice of Django's `django.contrib.postgres.aggregates` — the three most-asked-for shapes for collecting GROUP BY rows into a container.

## Surface

Three new `AggregateExpr` variants with ergonomic constructors:

```rust
AggregateExpr::array_agg(\"tag\")              // array_agg(\"tag\")
AggregateExpr::array_agg_distinct(\"tag\")     // array_agg(DISTINCT \"tag\")
AggregateExpr::string_agg(\"tag\", \", \")       // string_agg(\"tag\", $1)
AggregateExpr::string_agg_distinct(\"tag\", \", \")
                                             // string_agg(DISTINCT \"tag\", $1)
AggregateExpr::jsonb_agg(\"tag\")              // jsonb_agg(\"tag\")
```

`string_agg`'s delimiter **binds as `$N`** — no string interpolation, so the delimiter is safe even when threaded through from user input.

## Dialect support

| Variant | Postgres | MySQL | SQLite |
|---|---|---|---|
| `array_agg` | ✅ native | ❌ rejected | ❌ rejected |
| `string_agg` | ✅ native | ❌ rejected | ❌ rejected |
| `jsonb_agg` | ✅ native | ❌ rejected | ❌ rejected |

MySQL has `GROUP_CONCAT` / `JSON_ARRAYAGG` with different semantics — auto-translation is intentionally out of scope (named overloads with different behaviour would be a footgun). Non-PG backends raise the new `SqlError::AggregateNotSupportedInDialect { aggregate, dialect }` so callers can branch on `pool.dialect().name()` or restrict the feature to PG-only deployments.

## Out of scope (v1)

- `BitAnd` / `BitOr` / `BoolAnd` / `BoolOr` — bounded follow-up
- Statistical: `Corr`, `CovarPop`, `Regr*` — separate slice
- `ORDER BY` clause inside the aggregate (e.g. `array_agg(col ORDER BY ts)`) — needs writer plumbing through `OrderClause`; deferrable since the common shape orders the outer GROUP BY query instead

## Test plan

- [x] **10 tri-dialect emission tests** in `tests/pg_aggregates.rs` — every variant + DISTINCT + bound delimiter + composes-with-GROUP-BY + non-PG rejection on both MySQL and SQLite
- [x] **3 live PG round-trip tests** in `tests/pg_aggregates_live.rs` (skip silently w/o `DATABASE_URL`): per-author tag arrays, comma-joined strings, JSONB arrays
- [x] 1469 lib tests pass with `--features tenancy`
- [x] `cargo build --no-default-features --features sqlite,tenancy` clean (the new variants compile out cleanly when PG is off)