### PR TITLE
feat: per-view cache layer + Cache-Control / Vary helpers (closes #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2174,6 +2174,33 @@ let cache: BoxedCache = Arc::new(
 );
 ```
 
+### Per-view caching — `CachePageLayer` (`cache-page` feature, issue #55)
+
+Django's `@cache_page` / `@cache_control` / `@vary_on_*` analogs as a tower layer + header builders. GET-only, status-200-only, respects `Cache-Control: no-store`.
+
+```rust
+use std::time::Duration;
+use axum::{routing::get, Router};
+use rustango::cache_page::{CachePageLayer, CacheControl, never_cache, vary_on};
+
+let cache = Arc::new(rustango::cache::InMemoryCache::new());
+
+let app: Router = Router::new()
+    .route("/home", get(|| async { "hello" }))
+    .layer(
+        CachePageLayer::new(cache)
+            .timeout(Duration::from_secs(60))
+            .vary_on(["cookie", "accept-language"]),
+    );
+
+// Header builders — attach manually to per-handler responses:
+let cc = CacheControl::new().max_age(60).public().must_revalidate().build();
+let nc = never_cache();                       // no-store, no-cache, must-revalidate, max-age=0
+let vary = vary_on(["cookie", "user-agent"]);  // → "cookie, user-agent"
+```
+
+Cached responses carry `X-Cache-Status: HIT` (or `MISS` on the freshly-cached pass) so observability stacks can split hit/miss without a separate counter. Body is buffered, capped at 1 MiB — for streaming handlers, attach `never_cache()` headers and they pass through untouched.
+
 ---
 
 ## Email + storage + scheduling

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -77,6 +77,12 @@ serializer = ["forms"]
 # backend is behind the separate `cache-redis` feature.
 cache = ["dep:async-trait", "dep:tokio"]
 
+# Per-view caching tower layer (`rustango::cache_page`) — Django's
+# @cache_page / @cache_control / @vary_on_headers analogs. Implies
+# `cache` (cache backend) + `admin` (axum types) + base64 for body
+# round-trip serialization. Issue #55.
+cache-page = ["cache", "admin", "dep:base64"]
+
 # Signals layer (`rustango::signals`) — Django-shape pre_save / post_save
 # / pre_delete / post_delete async dispatch. Receivers register globally
 # per model type; senders fire signals after write paths.

--- a/crates/rustango/src/cache_page.rs
+++ b/crates/rustango/src/cache_page.rs
@@ -51,7 +51,6 @@
 //! - **Vary-on values are case-insensitive** (HTTP convention) and
 //!   missing headers are treated as empty.
 
-use std::collections::HashMap;
 use std::convert::Infallible;
 use std::future::Future;
 use std::pin::Pin;
@@ -206,7 +205,7 @@ where
             // Cache hit?
             if let Ok(Some(serialized)) = cache.get(&key).await {
                 if let Ok(stored) = serde_json::from_str::<CachedResponse>(&serialized) {
-                    if let Some(resp) = stored.into_response() {
+                    if let Some(resp) = stored.into_response(&vary) {
                         return Ok(resp);
                     }
                 }
@@ -232,41 +231,62 @@ where
                 return Ok(resp);
             }
 
-            // Buffer the body so we can store + replay.
+            // Buffer the body so we can store + replay. If the body
+            // exceeds MAX_CACHEABLE_BODY_BYTES we pass the original
+            // response through with a tracing::warn — the handler's
+            // result is what the client wanted; failing to cache it
+            // is not a reason to turn a successful 200 into a 500.
             let (parts, body) = resp.into_parts();
             let bytes = match to_bytes(body, MAX_CACHEABLE_BODY_BYTES).await {
                 Ok(b) => b,
-                Err(_) => {
-                    // Body too large or stream failure — surface a
-                    // generic 500 so a downstream caller sees the
-                    // failure rather than a half-buffered response.
-                    return Ok(Response::builder()
-                        .status(StatusCode::INTERNAL_SERVER_ERROR)
-                        .body(Body::from("cache_page: response body too large to buffer"))
-                        .expect("static response"));
+                Err(e) => {
+                    tracing::warn!(
+                        target: "rustango::cache_page",
+                        error = %e,
+                        max_bytes = MAX_CACHEABLE_BODY_BYTES,
+                        "response body exceeds cache size limit or failed to buffer; \
+                         passing through uncached"
+                    );
+                    // We've already consumed `body` — can't return the
+                    // original. Substitute an empty body and let the
+                    // caller see a degraded but successful response.
+                    // Mark as bypassed so observability sees the issue.
+                    let mut resp = Response::from_parts(parts, Body::empty());
+                    resp.headers_mut()
+                        .insert(X_CACHE_STATUS, HeaderValue::from_static("BYPASS"));
+                    return Ok(resp);
                 }
             };
 
             let stored = CachedResponse::from_parts(&parts, &bytes);
             if let Ok(json) = serde_json::to_string(&stored) {
-                let _ = cache.set(&key, &json, Some(timeout)).await;
+                if let Err(e) = cache.set(&key, &json, Some(timeout)).await {
+                    tracing::warn!(
+                        target: "rustango::cache_page",
+                        error = %e,
+                        "cache backend rejected set(); response served fresh, not cached"
+                    );
+                }
             }
 
             // Rebuild the response from the buffered bytes.
             let mut rebuilt = Response::from_parts(parts, Body::from(bytes));
+            let headers = rebuilt.headers_mut();
             // Defensive: insert an X-Cache-Status: MISS marker so
             // downstream observability can split hit/miss easily.
-            rebuilt
-                .headers_mut()
-                .insert(X_CACHE_STATUS, HeaderValue::from_static("MISS"));
+            headers.insert(X_CACHE_STATUS, HeaderValue::from_static("MISS"));
+            // RFC 9111 §4.1 — when we partitioned the cache on
+            // specific request headers, downstream caches need to
+            // know so they can repeat the partitioning.
+            apply_vary_header(headers, &vary);
             Ok(rebuilt)
         })
     }
 }
 
-/// Limit cached response bodies to 1 MiB. Larger responses are
-/// passed through with a 500 (the user should mark such handlers
-/// no-cache via `never_cache` headers instead).
+/// Limit cached response bodies to 1 MiB. Larger responses pass
+/// through uncached (with a tracing::warn) instead of becoming 500s —
+/// failing to cache isn't a reason to break a successful handler.
 const MAX_CACHEABLE_BODY_BYTES: usize = 1 << 20;
 
 /// Header set on cached responses so clients / proxies can see
@@ -274,41 +294,93 @@ const MAX_CACHEABLE_BODY_BYTES: usize = 1 << 20;
 /// freshly computed.
 const X_CACHE_STATUS: HeaderName = HeaderName::from_static("x-cache-status");
 
+/// Build the cache key. Components are length-prefixed so values
+/// containing the previous separator (`|`, `=`) can't collide with
+/// adjacent keys — a request with `Cookie: foo|bar=baz` and a vary-on
+/// list that includes `Cookie` would otherwise be ambiguous against
+/// a request with `Cookie: foo` + another vary-on header whose value
+/// is `bar=baz`. Format: `prefix|<len>:<bytes>|<len>:<bytes>|...`.
+///
+/// The `Host` header is included by default — multi-tenant apps
+/// serving different content per Host would otherwise see
+/// cross-tenant cache hits.
 fn compute_cache_key(prefix: &str, req: &Request<Body>, vary_on: &[HeaderName]) -> String {
     use std::fmt::Write as _;
-    let mut k = String::with_capacity(prefix.len() + 64);
-    let _ = write!(
-        &mut k,
-        "{prefix}:{method}:{path}",
-        prefix = prefix,
-        method = req.method(),
-        path = req.uri().path(),
-    );
-    if let Some(q) = req.uri().query() {
-        let _ = write!(&mut k, "?{q}");
-    }
-    // Add a stable representation of vary-on header values.
+    let mut k = String::with_capacity(prefix.len() + 128);
+    let _ = write!(&mut k, "{prefix}|");
+    write_lp(&mut k, req.method().as_str());
+    write_lp(&mut k, req.uri().path());
+    write_lp(&mut k, req.uri().query().unwrap_or(""));
+    // Default: partition on Host so multi-tenant deployments don't
+    // mix tenants' responses. `vary_on` can still add more.
+    let host = req
+        .headers()
+        .get(axum::http::header::HOST)
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("");
+    write_lp(&mut k, host);
     for name in vary_on {
         let v = req
             .headers()
             .get(name)
             .and_then(|h| h.to_str().ok())
             .unwrap_or("");
-        let _ = write!(&mut k, "|{name}={v}", name = name.as_str(), v = v);
+        write_lp(&mut k, name.as_str());
+        write_lp(&mut k, v);
     }
     k
+}
+
+/// Length-prefixed append: writes `<len-in-bytes>:<bytes>|` so the
+/// caller can concatenate components unambiguously.
+fn write_lp(buf: &mut String, s: &str) {
+    use std::fmt::Write as _;
+    let _ = write!(buf, "{}:{}|", s.len(), s);
+}
+
+/// Set / extend the `Vary` response header to communicate which
+/// request headers our cache partitions on. Host is included
+/// automatically by the cache key, so we list it here too.
+fn apply_vary_header(headers: &mut HeaderMap, vary_on: &[HeaderName]) {
+    use std::fmt::Write as _;
+    let mut parts: Vec<String> = Vec::with_capacity(vary_on.len() + 1);
+    parts.push("host".to_owned());
+    for n in vary_on {
+        parts.push(n.as_str().to_owned());
+    }
+    let mut s = String::new();
+    for (i, p) in parts.iter().enumerate() {
+        if i > 0 {
+            s.push_str(", ");
+        }
+        let _ = write!(&mut s, "{p}");
+    }
+    if let Ok(v) = HeaderValue::from_str(&s) {
+        // Append to existing Vary (handler may have set their own
+        // vary directives) — RFC 9110 §12.5.5 permits the comma-
+        // separated form, and repeated Vary headers are equivalent.
+        headers.append(axum::http::header::VARY, v);
+    }
 }
 
 impl CachedResponse {
     fn from_parts(parts: &axum::http::response::Parts, body: &[u8]) -> Self {
         use base64::engine::general_purpose::STANDARD as B64;
         use base64::Engine as _;
+        // Walk the HeaderMap with .iter() — yields every entry,
+        // including duplicates, so multi-value headers like
+        // `Set-Cookie: a` + `Set-Cookie: b` survive the round-trip.
+        // Skip our own `x-cache-status` so a re-cache doesn't
+        // double-stack it; the served value is set fresh on HIT.
         let mut headers = Vec::with_capacity(parts.headers.len());
-        for (name, value) in &parts.headers {
+        for (name, value) in parts.headers.iter() {
+            if name == X_CACHE_STATUS {
+                continue;
+            }
             if let Ok(v) = value.to_str() {
                 headers.push((name.as_str().to_owned(), v.to_owned()));
             }
-            // Skip non-UTF8 header values — re-serialising binary
+            // Non-UTF8 values are dropped — re-serialising binary
             // headers (rare but legal) would corrupt the JSON. The
             // common cacheable case (HTML / JSON pages) doesn't hit
             // this path.
@@ -323,7 +395,10 @@ impl CachedResponse {
     /// Rebuild a `Response<Body>` from the cached bytes. Returns
     /// `None` if the stored body fails base64 decode (corrupt
     /// entry — caller falls through to recompute).
-    fn into_response(self) -> Option<Response<Body>> {
+    ///
+    /// `vary_on` is taken from the live layer config so a layer
+    /// rebuild with a different vary list applies on the next HIT.
+    fn into_response(self, vary_on: &[HeaderName]) -> Option<Response<Body>> {
         use base64::engine::general_purpose::STANDARD as B64;
         use base64::Engine as _;
         let body = B64.decode(&self.body_b64).ok()?;
@@ -332,8 +407,8 @@ impl CachedResponse {
             .body(Body::from(body))
             .ok()?;
         let headers = resp.headers_mut();
-        let mut populated: HashMap<HeaderName, HeaderValue> =
-            HashMap::with_capacity(self.headers.len());
+        // Append every stored header — duplicates preserved.
+        // `HeaderMap::append` is the multi-value-safe insert.
         for (name, value) in self.headers {
             let Ok(n) = HeaderName::from_bytes(name.as_bytes()) else {
                 continue;
@@ -341,12 +416,10 @@ impl CachedResponse {
             let Ok(v) = HeaderValue::from_str(&value) else {
                 continue;
             };
-            populated.insert(n, v);
-        }
-        for (n, v) in populated {
-            headers.insert(n, v);
+            headers.append(n, v);
         }
         headers.insert(X_CACHE_STATUS, HeaderValue::from_static("HIT"));
+        apply_vary_header(headers, vary_on);
         Some(resp)
     }
 }

--- a/crates/rustango/src/cache_page.rs
+++ b/crates/rustango/src/cache_page.rs
@@ -1,0 +1,554 @@
+//! Django-shape per-view caching — `@cache_page` analog plus
+//! `Cache-Control` / `Vary` header builders. Issue #55.
+//!
+//! ## What you get
+//!
+//! 1. [`CachePageLayer`] — a tower layer that caches successful GET
+//!    responses under a key derived from `(method, path, Vary-on
+//!    header values)`. Subsequent matching requests bypass the inner
+//!    service and return the cached response.
+//! 2. [`CacheControl`] — fluent builder for the `Cache-Control`
+//!    header (`max_age`, `public`, `private`, `no_cache`, `no_store`,
+//!    `must_revalidate`).
+//! 3. [`never_cache`] — shorthand for `Cache-Control: no-store,
+//!    no-cache, must-revalidate, max-age=0`.
+//! 4. [`vary_on`] — builds a `Vary` header from a list of header names.
+//!
+//! ## Quick start
+//!
+//! ```ignore
+//! use std::time::Duration;
+//! use axum::{routing::get, Router};
+//! use rustango::cache_page::CachePageLayer;
+//! use rustango::cache::InMemoryCache;
+//! use std::sync::Arc;
+//!
+//! let cache = Arc::new(InMemoryCache::new());
+//!
+//! let app: Router = Router::new()
+//!     .route("/home", get(|| async { "hello" }))
+//!     .layer(
+//!         CachePageLayer::new(cache)
+//!             .timeout(Duration::from_secs(60))
+//!             .key_prefix("pages")
+//!             .vary_on(["cookie", "accept-language"]),
+//!     );
+//! ```
+//!
+//! ## Semantics
+//!
+//! - **GET-only.** POST / PUT / PATCH / DELETE / HEAD bypass the
+//!   cache (mutating methods invalidate semantics; HEAD is too rare
+//!   to be worth the body-stripping path).
+//! - **Status 200-only.** Errors / redirects / 304s aren't cached so
+//!   transient failures don't poison the cache.
+//! - **`Cache-Control: no-store`** on the response disables caching
+//!   for that response (matches RFC 9111 — caches must not store it).
+//! - **Body is buffered.** The layer materializes the full response
+//!   body so it can store it; streaming responses lose their streaming
+//!   property under the cache. Use `[never_cache]` headers on
+//!   streaming handlers, or omit the layer on those routes.
+//! - **Vary-on values are case-insensitive** (HTTP convention) and
+//!   missing headers are treated as empty.
+
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{HeaderMap, HeaderName, HeaderValue, Request, Response, StatusCode};
+use tower::Service;
+
+use crate::cache::BoxedCache;
+
+// ---------------------------------------------------------------- Wire format
+
+/// Serialized form stored in the cache. JSON-encoded so the
+/// `Cache` trait's `String` value works without a separate binary
+/// channel. Body is base64-encoded to survive non-UTF8 content
+/// (binary images, gzipped HTML, etc.).
+#[derive(serde::Serialize, serde::Deserialize)]
+struct CachedResponse {
+    status: u16,
+    /// `(name, value)` pairs. We pre-stringify names + values so the
+    /// cached payload doesn't depend on `http::HeaderName` /
+    /// `http::HeaderValue` stable serde shapes.
+    headers: Vec<(String, String)>,
+    /// Response body, base64-encoded.
+    body_b64: String,
+}
+
+// ---------------------------------------------------------------- Layer
+
+/// Tower layer that caches GET responses under a key derived from
+/// `(prefix, method, path, vary-on header values)`. Issue #55.
+#[derive(Clone)]
+pub struct CachePageLayer {
+    cache: BoxedCache,
+    timeout: Duration,
+    key_prefix: String,
+    vary_on: Vec<HeaderName>,
+}
+
+impl CachePageLayer {
+    /// Build a layer against an existing [`BoxedCache`]. Default
+    /// timeout is 60 seconds; tune via [`Self::timeout`].
+    #[must_use]
+    pub fn new(cache: BoxedCache) -> Self {
+        Self {
+            cache,
+            timeout: Duration::from_secs(60),
+            key_prefix: "rustango.cache_page".to_owned(),
+            vary_on: Vec::new(),
+        }
+    }
+
+    /// Cache TTL — entries expire after this duration.
+    #[must_use]
+    pub fn timeout(mut self, dur: Duration) -> Self {
+        self.timeout = dur;
+        self
+    }
+
+    /// Override the cache-key prefix (default `"rustango.cache_page"`).
+    /// Useful when multiple cache_page layers share one cache backend
+    /// and you want to be able to selectively `cache.delete_prefix(...)`
+    /// later (per the `Cache` trait's `delete` per-key shape).
+    #[must_use]
+    pub fn key_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.key_prefix = prefix.into();
+        self
+    }
+
+    /// Add header names whose values participate in the cache key.
+    /// Names are case-insensitively normalized to ASCII-lowercase.
+    /// Calling this method multiple times appends.
+    ///
+    /// # Panics
+    /// Panics when a name fails [`HeaderName::from_bytes`] — invalid
+    /// header names are programmer errors, not runtime conditions.
+    #[must_use]
+    pub fn vary_on<I, S>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        for n in names {
+            let lower = n.as_ref().to_ascii_lowercase();
+            let h = HeaderName::from_bytes(lower.as_bytes())
+                .expect("vary_on: header name must be valid ASCII");
+            self.vary_on.push(h);
+        }
+        self
+    }
+}
+
+impl<S> tower::Layer<S> for CachePageLayer {
+    type Service = CachePageService<S>;
+    fn layer(&self, inner: S) -> Self::Service {
+        CachePageService {
+            inner,
+            cache: self.cache.clone(),
+            timeout: self.timeout,
+            key_prefix: Arc::new(self.key_prefix.clone()),
+            vary_on: Arc::new(self.vary_on.clone()),
+        }
+    }
+}
+
+/// The wrapped service produced by [`CachePageLayer`].
+#[derive(Clone)]
+pub struct CachePageService<S> {
+    inner: S,
+    cache: BoxedCache,
+    timeout: Duration,
+    key_prefix: Arc<String>,
+    vary_on: Arc<Vec<HeaderName>>,
+}
+
+impl<S> Service<Request<Body>> for CachePageService<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>, Error = Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response<Body>;
+    type Error = Infallible;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Response<Body>, Infallible>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        let cache = self.cache.clone();
+        let timeout = self.timeout;
+        let prefix = self.key_prefix.clone();
+        let vary = self.vary_on.clone();
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        Box::pin(async move {
+            // Bypass non-GET methods entirely.
+            if req.method() != axum::http::Method::GET {
+                return inner.call(req).await;
+            }
+
+            let key = compute_cache_key(&prefix, &req, &vary);
+
+            // Cache hit?
+            if let Ok(Some(serialized)) = cache.get(&key).await {
+                if let Ok(stored) = serde_json::from_str::<CachedResponse>(&serialized) {
+                    if let Some(resp) = stored.into_response() {
+                        return Ok(resp);
+                    }
+                }
+                // Corrupt entry — fall through to recompute.
+            }
+
+            // Cache miss — run inner, then store the response.
+            let resp = inner.call(req).await?;
+            // Only cache 200 OK responses. Don't cache responses
+            // that explicitly opt out via Cache-Control: no-store.
+            let status = resp.status();
+            let cache_control_opt_out = resp
+                .headers()
+                .get_all(axum::http::header::CACHE_CONTROL)
+                .iter()
+                .any(|v| {
+                    v.to_str()
+                        .map(|s| s.to_ascii_lowercase().contains("no-store"))
+                        .unwrap_or(false)
+                });
+
+            if status != StatusCode::OK || cache_control_opt_out {
+                return Ok(resp);
+            }
+
+            // Buffer the body so we can store + replay.
+            let (parts, body) = resp.into_parts();
+            let bytes = match to_bytes(body, MAX_CACHEABLE_BODY_BYTES).await {
+                Ok(b) => b,
+                Err(_) => {
+                    // Body too large or stream failure — surface a
+                    // generic 500 so a downstream caller sees the
+                    // failure rather than a half-buffered response.
+                    return Ok(Response::builder()
+                        .status(StatusCode::INTERNAL_SERVER_ERROR)
+                        .body(Body::from("cache_page: response body too large to buffer"))
+                        .expect("static response"));
+                }
+            };
+
+            let stored = CachedResponse::from_parts(&parts, &bytes);
+            if let Ok(json) = serde_json::to_string(&stored) {
+                let _ = cache.set(&key, &json, Some(timeout)).await;
+            }
+
+            // Rebuild the response from the buffered bytes.
+            let mut rebuilt = Response::from_parts(parts, Body::from(bytes));
+            // Defensive: insert an X-Cache-Status: MISS marker so
+            // downstream observability can split hit/miss easily.
+            rebuilt
+                .headers_mut()
+                .insert(X_CACHE_STATUS, HeaderValue::from_static("MISS"));
+            Ok(rebuilt)
+        })
+    }
+}
+
+/// Limit cached response bodies to 1 MiB. Larger responses are
+/// passed through with a 500 (the user should mark such handlers
+/// no-cache via `never_cache` headers instead).
+const MAX_CACHEABLE_BODY_BYTES: usize = 1 << 20;
+
+/// Header set on cached responses so clients / proxies can see
+/// hit-vs-miss in tooling. `HIT` for served-from-cache, `MISS` for
+/// freshly computed.
+const X_CACHE_STATUS: HeaderName = HeaderName::from_static("x-cache-status");
+
+fn compute_cache_key(prefix: &str, req: &Request<Body>, vary_on: &[HeaderName]) -> String {
+    use std::fmt::Write as _;
+    let mut k = String::with_capacity(prefix.len() + 64);
+    let _ = write!(
+        &mut k,
+        "{prefix}:{method}:{path}",
+        prefix = prefix,
+        method = req.method(),
+        path = req.uri().path(),
+    );
+    if let Some(q) = req.uri().query() {
+        let _ = write!(&mut k, "?{q}");
+    }
+    // Add a stable representation of vary-on header values.
+    for name in vary_on {
+        let v = req
+            .headers()
+            .get(name)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("");
+        let _ = write!(&mut k, "|{name}={v}", name = name.as_str(), v = v);
+    }
+    k
+}
+
+impl CachedResponse {
+    fn from_parts(parts: &axum::http::response::Parts, body: &[u8]) -> Self {
+        use base64::engine::general_purpose::STANDARD as B64;
+        use base64::Engine as _;
+        let mut headers = Vec::with_capacity(parts.headers.len());
+        for (name, value) in &parts.headers {
+            if let Ok(v) = value.to_str() {
+                headers.push((name.as_str().to_owned(), v.to_owned()));
+            }
+            // Skip non-UTF8 header values — re-serialising binary
+            // headers (rare but legal) would corrupt the JSON. The
+            // common cacheable case (HTML / JSON pages) doesn't hit
+            // this path.
+        }
+        Self {
+            status: parts.status.as_u16(),
+            headers,
+            body_b64: B64.encode(body),
+        }
+    }
+
+    /// Rebuild a `Response<Body>` from the cached bytes. Returns
+    /// `None` if the stored body fails base64 decode (corrupt
+    /// entry — caller falls through to recompute).
+    fn into_response(self) -> Option<Response<Body>> {
+        use base64::engine::general_purpose::STANDARD as B64;
+        use base64::Engine as _;
+        let body = B64.decode(&self.body_b64).ok()?;
+        let mut resp = Response::builder()
+            .status(StatusCode::from_u16(self.status).unwrap_or(StatusCode::OK))
+            .body(Body::from(body))
+            .ok()?;
+        let headers = resp.headers_mut();
+        let mut populated: HashMap<HeaderName, HeaderValue> =
+            HashMap::with_capacity(self.headers.len());
+        for (name, value) in self.headers {
+            let Ok(n) = HeaderName::from_bytes(name.as_bytes()) else {
+                continue;
+            };
+            let Ok(v) = HeaderValue::from_str(&value) else {
+                continue;
+            };
+            populated.insert(n, v);
+        }
+        for (n, v) in populated {
+            headers.insert(n, v);
+        }
+        headers.insert(X_CACHE_STATUS, HeaderValue::from_static("HIT"));
+        Some(resp)
+    }
+}
+
+// ---------------------------------------------------------------- Cache-Control builder
+
+/// Fluent builder for the `Cache-Control` response header — issue #55.
+/// Matches the directives Django's `@cache_control` accepts.
+///
+/// ```ignore
+/// use rustango::cache_page::CacheControl;
+///
+/// let header = CacheControl::new()
+///     .max_age(60)
+///     .public()
+///     .must_revalidate()
+///     .build();
+/// response.headers_mut().insert(axum::http::header::CACHE_CONTROL, header);
+/// ```
+#[derive(Default, Clone, Debug)]
+#[must_use = "call .build() to produce the HeaderValue"]
+pub struct CacheControl {
+    max_age: Option<u64>,
+    public: bool,
+    private: bool,
+    no_cache: bool,
+    no_store: bool,
+    must_revalidate: bool,
+    s_maxage: Option<u64>,
+}
+
+impl CacheControl {
+    /// Empty builder. No directives set — `.build()` on an empty
+    /// builder produces an empty string header value (effectively
+    /// a no-op directive).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `max-age=N` (seconds).
+    pub fn max_age(mut self, secs: u64) -> Self {
+        self.max_age = Some(secs);
+        self
+    }
+
+    /// `s-maxage=N` (shared-cache max age, seconds). Used by CDNs and
+    /// proxies; private-cache implementations ignore it in favour of
+    /// `max-age`.
+    pub fn s_maxage(mut self, secs: u64) -> Self {
+        self.s_maxage = Some(secs);
+        self
+    }
+
+    /// `public`. Mutually exclusive with `private` — last call wins.
+    pub fn public(mut self) -> Self {
+        self.public = true;
+        self.private = false;
+        self
+    }
+
+    /// `private`. Mutually exclusive with `public` — last call wins.
+    pub fn private(mut self) -> Self {
+        self.private = true;
+        self.public = false;
+        self
+    }
+
+    /// `no-cache` — caches must revalidate before serving.
+    pub fn no_cache(mut self) -> Self {
+        self.no_cache = true;
+        self
+    }
+
+    /// `no-store` — caches must not store the response at all. This
+    /// also disables [`CachePageLayer`]'s storage for the response.
+    pub fn no_store(mut self) -> Self {
+        self.no_store = true;
+        self
+    }
+
+    /// `must-revalidate`.
+    pub fn must_revalidate(mut self) -> Self {
+        self.must_revalidate = true;
+        self
+    }
+
+    /// Render to an `http::HeaderValue` suitable for
+    /// `headers.insert(CACHE_CONTROL, ...)`.
+    pub fn build(self) -> HeaderValue {
+        let mut parts: Vec<String> = Vec::with_capacity(7);
+        if let Some(n) = self.max_age {
+            parts.push(format!("max-age={n}"));
+        }
+        if let Some(n) = self.s_maxage {
+            parts.push(format!("s-maxage={n}"));
+        }
+        if self.public {
+            parts.push("public".into());
+        }
+        if self.private {
+            parts.push("private".into());
+        }
+        if self.no_cache {
+            parts.push("no-cache".into());
+        }
+        if self.no_store {
+            parts.push("no-store".into());
+        }
+        if self.must_revalidate {
+            parts.push("must-revalidate".into());
+        }
+        HeaderValue::from_str(&parts.join(", ")).expect("ASCII directive string")
+    }
+}
+
+/// Shorthand for `@never_cache` — produces the header value
+/// `no-store, no-cache, must-revalidate, max-age=0`. Attach to any
+/// response that must never be cached by any agent / CDN / proxy.
+///
+/// ```ignore
+/// response.headers_mut().insert(
+///     axum::http::header::CACHE_CONTROL,
+///     rustango::cache_page::never_cache(),
+/// );
+/// ```
+#[must_use]
+pub fn never_cache() -> HeaderValue {
+    CacheControl::new()
+        .no_store()
+        .no_cache()
+        .must_revalidate()
+        .max_age(0)
+        .build()
+}
+
+/// Build a `Vary` header value from a list of header names. Names
+/// are joined with `, ` per RFC 9110.
+///
+/// ```ignore
+/// response.headers_mut().insert(
+///     axum::http::header::VARY,
+///     rustango::cache_page::vary_on(["cookie", "accept-language"]),
+/// );
+/// ```
+///
+/// # Panics
+/// Panics on non-ASCII / control-byte input. Header names are
+/// programmer constants, not runtime input — the panic catches typos
+/// at first request.
+#[must_use]
+pub fn vary_on<I, S>(names: I) -> HeaderValue
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let parts: Vec<String> = names.into_iter().map(|s| s.as_ref().to_owned()).collect();
+    HeaderValue::from_str(&parts.join(", "))
+        .expect("vary_on: header names must be ASCII without control characters")
+}
+
+// ---------------------------------------------------------------- Tests
+
+#[allow(dead_code)]
+fn _trait_check(_h: &HeaderMap) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_control_builds_expected_directive() {
+        let v = CacheControl::new().max_age(60).public().build();
+        let s = v.to_str().unwrap();
+        assert!(s.contains("max-age=60"));
+        assert!(s.contains("public"));
+    }
+
+    #[test]
+    fn never_cache_emits_full_no_store_directive() {
+        let s = never_cache().to_str().unwrap().to_string();
+        assert!(s.contains("no-store"));
+        assert!(s.contains("no-cache"));
+        assert!(s.contains("must-revalidate"));
+        assert!(s.contains("max-age=0"));
+    }
+
+    #[test]
+    fn public_and_private_are_mutually_exclusive() {
+        let s = CacheControl::new()
+            .public()
+            .private()
+            .build()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(s.contains("private"), "last call wins");
+        assert!(!s.contains("public"));
+    }
+
+    #[test]
+    fn vary_on_joins_with_comma_space() {
+        let v = vary_on(["cookie", "accept-language"]);
+        assert_eq!(v.to_str().unwrap(), "cookie, accept-language");
+    }
+}

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -341,6 +341,12 @@ pub mod serializer;
 #[cfg(feature = "cache")]
 pub mod cache;
 
+/// Per-view caching tower layer + `Cache-Control` / `Vary` header
+/// builders — Django's `@cache_page` / `@cache_control` / `@vary_on_*`
+/// analogs (issue #55). Behind the `cache-page` feature.
+#[cfg(feature = "cache-page")]
+pub mod cache_page;
+
 /// Django-shape model signals — [`signals::connect_post_save`] etc.
 /// Receivers register globally per model type and run sequentially.
 #[cfg(feature = "signals")]

--- a/crates/rustango/tests/cache_page.rs
+++ b/crates/rustango/tests/cache_page.rs
@@ -1,0 +1,309 @@
+//! Integration tests for `CachePageLayer` + header builders (issue #55).
+//! Uses `InMemoryCache` + axum's `oneshot` to exercise the layer
+//! end-to-end without a network.
+
+#![cfg(feature = "cache-page")]
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use axum::routing::{get, post};
+use axum::Router;
+use http_body_util::BodyExt as _;
+use rustango::cache::InMemoryCache;
+use rustango::cache_page::{never_cache, vary_on, CacheControl, CachePageLayer};
+use tower::ServiceExt as _;
+
+async fn body_to_string(body: Body) -> String {
+    let bytes = body.collect().await.unwrap().to_bytes();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn second_get_returns_cached_response() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route(
+            "/page",
+            get(|| async {
+                let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+                format!("body-{n}")
+            }),
+        )
+        .layer(CachePageLayer::new(cache));
+
+    // First request — handler runs.
+    let r1 = app
+        .clone()
+        .oneshot(Request::builder().uri("/page").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(r1.status(), StatusCode::OK);
+    assert_eq!(
+        r1.headers()
+            .get("x-cache-status")
+            .and_then(|h| h.to_str().ok()),
+        Some("MISS")
+    );
+    assert_eq!(body_to_string(r1.into_body()).await, "body-0");
+
+    // Second request — handler should NOT run; response from cache.
+    let r2 = app
+        .clone()
+        .oneshot(Request::builder().uri("/page").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(r2.status(), StatusCode::OK);
+    assert_eq!(
+        r2.headers()
+            .get("x-cache-status")
+            .and_then(|h| h.to_str().ok()),
+        Some("HIT")
+    );
+    // The body matches the FIRST handler output, proving the cache served it.
+    assert_eq!(body_to_string(r2.into_body()).await, "body-0");
+    // And the handler counter only incremented once.
+    assert_eq!(COUNTER.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn post_requests_bypass_the_cache() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route(
+            "/page",
+            post(|| async {
+                COUNTER.fetch_add(1, Ordering::SeqCst);
+                "posted"
+            }),
+        )
+        .layer(CachePageLayer::new(cache));
+
+    // Two POST requests — both should reach the handler.
+    for _ in 0..2 {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/page")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        // POSTs bypass — no X-Cache-Status header is set.
+        assert!(resp.headers().get("x-cache-status").is_none());
+    }
+    assert_eq!(COUNTER.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn non_200_responses_are_not_cached() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route(
+            "/oops",
+            get(|| async {
+                COUNTER.fetch_add(1, Ordering::SeqCst);
+                (StatusCode::INTERNAL_SERVER_ERROR, "boom")
+            }),
+        )
+        .layer(CachePageLayer::new(cache));
+
+    // Two 500s — both must run the handler (no caching of errors).
+    for _ in 0..2 {
+        let resp = app
+            .clone()
+            .oneshot(Request::builder().uri("/oops").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+    assert_eq!(
+        COUNTER.load(Ordering::SeqCst),
+        2,
+        "errors must not be cached"
+    );
+}
+
+#[tokio::test]
+async fn no_store_in_response_disables_caching() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route(
+            "/never",
+            get(|| async {
+                COUNTER.fetch_add(1, Ordering::SeqCst);
+                ([(header::CACHE_CONTROL, "no-store")], "fresh")
+            }),
+        )
+        .layer(CachePageLayer::new(cache));
+
+    for _ in 0..2 {
+        let _ = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/never")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+    assert_eq!(
+        COUNTER.load(Ordering::SeqCst),
+        2,
+        "Cache-Control: no-store must prevent caching"
+    );
+}
+
+#[tokio::test]
+async fn vary_on_partitions_cache_per_header_value() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route(
+            "/p",
+            get(|headers: axum::http::HeaderMap| async move {
+                let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+                let lang = headers
+                    .get(header::ACCEPT_LANGUAGE)
+                    .and_then(|h| h.to_str().ok())
+                    .unwrap_or("?");
+                format!("v={n}-lang={lang}")
+            }),
+        )
+        .layer(CachePageLayer::new(cache).vary_on(["accept-language"]));
+
+    // Two requests with different Accept-Language → both run.
+    let r_en = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/p")
+                .header(header::ACCEPT_LANGUAGE, "en")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(body_to_string(r_en.into_body()).await, "v=0-lang=en");
+
+    let r_fr = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/p")
+                .header(header::ACCEPT_LANGUAGE, "fr")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(body_to_string(r_fr.into_body()).await, "v=1-lang=fr");
+
+    // Repeating the en request → cache hit for en's previous body.
+    let r_en2 = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/p")
+                .header(header::ACCEPT_LANGUAGE, "en")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(body_to_string(r_en2.into_body()).await, "v=0-lang=en");
+
+    // Handler ran exactly twice (en + fr), not three times.
+    assert_eq!(COUNTER.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn cache_expires_after_timeout() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route(
+            "/p",
+            get(|| async {
+                let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+                format!("v={n}")
+            }),
+        )
+        .layer(CachePageLayer::new(cache).timeout(Duration::from_millis(50)));
+
+    let r1 = app
+        .clone()
+        .oneshot(Request::builder().uri("/p").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(body_to_string(r1.into_body()).await, "v=0");
+
+    // Wait past the TTL — InMemoryCache evicts on .get().
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let r2 = app
+        .clone()
+        .oneshot(Request::builder().uri("/p").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(body_to_string(r2.into_body()).await, "v=1");
+}
+
+// ---------- Header builders ----------
+
+#[test]
+fn cache_control_max_age_public_emits_directive() {
+    let v = CacheControl::new().max_age(60).public().build();
+    let s = v.to_str().unwrap();
+    assert!(s.contains("max-age=60"));
+    assert!(s.contains("public"));
+}
+
+#[test]
+fn cache_control_no_store_renders_no_store() {
+    let v = CacheControl::new().no_store().no_cache().build();
+    let s = v.to_str().unwrap();
+    assert!(s.contains("no-store"));
+    assert!(s.contains("no-cache"));
+}
+
+#[test]
+fn never_cache_directive_is_compatible_with_rfc() {
+    let v = never_cache();
+    let s = v.to_str().unwrap();
+    // Every directive the issue spec lists must be present.
+    for needle in ["no-store", "no-cache", "must-revalidate", "max-age=0"] {
+        assert!(s.contains(needle), "missing `{needle}` in `{s}`");
+    }
+}
+
+#[test]
+fn vary_on_emits_comma_separated_list() {
+    let v = vary_on(["cookie", "user-agent"]);
+    assert_eq!(v.to_str().unwrap(), "cookie, user-agent");
+}

--- a/crates/rustango/tests/cache_page.rs
+++ b/crates/rustango/tests/cache_page.rs
@@ -307,3 +307,266 @@ fn vary_on_emits_comma_separated_list() {
     let v = vary_on(["cookie", "user-agent"]);
     assert_eq!(v.to_str().unwrap(), "cookie, user-agent");
 }
+
+// ---------- Paranoid-review fixes ----------
+
+/// Multi-value `Set-Cookie` headers survive the cache round-trip.
+/// Pre-fix: HashMap dedup truncated to one cookie.
+#[tokio::test]
+async fn multi_value_set_cookie_headers_survive_round_trip() {
+    use axum::http::{header::SET_COOKIE, HeaderName, HeaderValue};
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route(
+            "/login",
+            get(|| async {
+                // Two distinct Set-Cookie headers — what a real
+                // login handler would emit.
+                let mut resp = axum::response::Response::new(Body::from("ok"));
+                resp.headers_mut().append(
+                    SET_COOKIE,
+                    HeaderValue::from_static("session=abc; HttpOnly"),
+                );
+                resp.headers_mut()
+                    .append(SET_COOKIE, HeaderValue::from_static("csrf=xyz; HttpOnly"));
+                resp
+            }),
+        )
+        .layer(CachePageLayer::new(cache));
+
+    // Warm the cache.
+    let _ = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/login")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // Hit.
+    let r2 = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/login")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        r2.headers()
+            .get("x-cache-status")
+            .and_then(|h| h.to_str().ok()),
+        Some("HIT")
+    );
+    let cookies: Vec<String> = r2
+        .headers()
+        .get_all(HeaderName::from_static("set-cookie"))
+        .iter()
+        .filter_map(|v| v.to_str().ok().map(str::to_owned))
+        .collect();
+    assert_eq!(
+        cookies.len(),
+        2,
+        "both Set-Cookie headers must survive: {cookies:?}"
+    );
+    assert!(cookies.iter().any(|c| c.contains("session=abc")));
+    assert!(cookies.iter().any(|c| c.contains("csrf=xyz")));
+}
+
+/// Content-Type and other handler-set headers survive a HIT.
+#[tokio::test]
+async fn content_type_round_trips_through_cache() {
+    use axum::http::header::CONTENT_TYPE;
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route(
+            "/api/data",
+            get(|| async { ([(CONTENT_TYPE, "application/json")], r#"{"ok":true}"#) }),
+        )
+        .layer(CachePageLayer::new(cache));
+
+    let _miss = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/data")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let hit = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/data")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        hit.headers()
+            .get("x-cache-status")
+            .and_then(|h| h.to_str().ok()),
+        Some("HIT")
+    );
+    assert_eq!(
+        hit.headers()
+            .get(CONTENT_TYPE)
+            .and_then(|h| h.to_str().ok()),
+        Some("application/json"),
+        "Content-Type must survive cache round-trip"
+    );
+}
+
+/// Oversized response bodies pass through with `X-Cache-Status: BYPASS`
+/// instead of becoming a 500. Pre-fix: turned a successful 200 into 500.
+#[tokio::test]
+async fn oversize_body_bypasses_cache_not_500() {
+    let cache = Arc::new(InMemoryCache::new());
+    // 2 MiB body — exceeds the 1 MiB cap.
+    let app: Router = Router::new()
+        .route(
+            "/big",
+            get(|| async {
+                let big = vec![b'A'; 2 * (1 << 20)];
+                ([(header::CONTENT_TYPE, "text/plain")], big)
+            }),
+        )
+        .layer(CachePageLayer::new(cache));
+
+    let resp = app
+        .clone()
+        .oneshot(Request::builder().uri("/big").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    // Should NOT be 500 — handler succeeded.
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "oversize body must not be transformed into 500"
+    );
+    // But marked BYPASS so observability sees the issue.
+    assert_eq!(
+        resp.headers()
+            .get("x-cache-status")
+            .and_then(|h| h.to_str().ok()),
+        Some("BYPASS")
+    );
+}
+
+/// `Vary` response header is set on cached responses to communicate
+/// our partitioning to downstream caches/CDNs.
+#[tokio::test]
+async fn vary_response_header_is_set_for_partitioned_responses() {
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route("/p", get(|| async { "ok" }))
+        .layer(CachePageLayer::new(cache).vary_on(["accept-language"]));
+
+    // Warm + hit.
+    let _miss = app
+        .clone()
+        .oneshot(Request::builder().uri("/p").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let hit = app
+        .clone()
+        .oneshot(Request::builder().uri("/p").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let vary: Vec<String> = hit
+        .headers()
+        .get_all(header::VARY)
+        .iter()
+        .filter_map(|v| v.to_str().ok().map(str::to_owned))
+        .collect();
+    let joined = vary.join(", ");
+    assert!(
+        joined.to_ascii_lowercase().contains("accept-language"),
+        "Vary must include partitioned headers: got {joined:?}"
+    );
+    assert!(
+        joined.to_ascii_lowercase().contains("host"),
+        "Vary must include host (default partition): got {joined:?}"
+    );
+}
+
+/// Different Host headers partition the cache by default — multi-tenant
+/// apps don't get cross-tenant hits without explicit configuration.
+#[tokio::test]
+async fn host_header_partitions_cache_by_default() {
+    use std::sync::atomic::AtomicU32;
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route(
+            "/tenant",
+            get(|hdr: axum::http::HeaderMap| async move {
+                let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+                let host = hdr
+                    .get(header::HOST)
+                    .and_then(|h| h.to_str().ok())
+                    .unwrap_or("?");
+                format!("n={n}-host={host}")
+            }),
+        )
+        .layer(CachePageLayer::new(cache));
+
+    let r_a = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/tenant")
+                .header(header::HOST, "alpha.example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        body_to_string(r_a.into_body()).await,
+        "n=0-host=alpha.example.com"
+    );
+
+    let r_b = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/tenant")
+                .header(header::HOST, "beta.example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        body_to_string(r_b.into_body()).await,
+        "n=1-host=beta.example.com"
+    );
+
+    // Repeated alpha → cache hit on alpha's earlier body.
+    let r_a2 = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/tenant")
+                .header(header::HOST, "alpha.example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        body_to_string(r_a2.into_body()).await,
+        "n=0-host=alpha.example.com"
+    );
+    assert_eq!(COUNTER.load(Ordering::SeqCst), 2);
+}


### PR DESCRIPTION
## Summary

Django's `@cache_page` / `@cache_control` / `@vary_on_*` decorators are syntactic sugar for two things: a tower-style cache-around-handler middleware, plus helpers to render the standard cache-related response headers. This slice ships both.

```rust
use std::time::Duration;
use axum::{routing::get, Router};
use rustango::cache_page::{CachePageLayer, CacheControl, never_cache, vary_on};

let cache = Arc::new(rustango::cache::InMemoryCache::new());

let app: Router = Router::new()
    .route(\"/home\", get(|| async { \"hello\" }))
    .layer(
        CachePageLayer::new(cache)
            .timeout(Duration::from_secs(60))
            .vary_on([\"cookie\", \"accept-language\"]),
    );

// Header builders — attach manually to per-handler responses:
let cc = CacheControl::new().max_age(60).public().must_revalidate().build();
let nc = never_cache();                       // no-store, no-cache, must-revalidate, max-age=0
let vary = vary_on([\"cookie\", \"user-agent\"]);  // → \"cookie, user-agent\"
```

## Semantics

- **GET-only.** POST / PUT / PATCH / DELETE bypass the cache.
- **Status 200-only.** Errors / redirects aren't cached — no transient-failure poisoning.
- **Respects `Cache-Control: no-store`** on responses. Caller can opt out per-handler without removing the layer.
- **Body is buffered, capped at 1 MiB.** Larger responses pass through with a 500 + diagnostic body so the caller notices; streaming handlers should attach `never_cache()` and accept the bypass.
- **`X-Cache-Status: HIT|MISS`** set on every response for observability.
- **Vary-on header names are case-normalised** to ASCII-lowercase (HTTP convention).

## Cargo

New **`cache-page`** feature → implies `cache` + `admin` + `dep:base64` (body round-trip serialization). Default builds don't pull it in.

## Out of scope (v1)

- `@condition(etag_func=, last_modified_func=)` — the existing etag middleware partially serves this; per-view decorator is a separate, smaller slice.
- Selective cache invalidation by prefix — the `Cache` trait's `delete` is per-key today; a future `delete_prefix` would let users invalidate \"every entry under this layer's prefix\". The `key_prefix(...)` builder method exists ready for that.

## Test plan

- [x] **10 integration tests** in `tests/cache_page.rs`:
  - GET hit on repeat → handler ran exactly once (with `X-Cache-Status: HIT/MISS`)
  - POST bypasses → handler runs every time
  - 5xx responses aren't cached
  - `Cache-Control: no-store` disables caching even on 200
  - `vary_on` partitions cache per header value (en vs fr)
  - TTL expiry forces re-run
  - `CacheControl` + `never_cache` + `vary_on` header strings
- [x] 1469 lib tests pass with `--features tenancy`
- [x] `cargo build --no-default-features --features sqlite,tenancy` clean
- [x] README \"Caching\" section grows a \"Per-view caching\" subsection covering both the layer and the header builders