### PR TITLE
fix: aggregate decoder for PG arrays / jsonb + contenttypes_live pool migration

### DIFF
--- a/crates/rustango/examples/blog_demo/models.rs
+++ b/crates/rustango/examples/blog_demo/models.rs
@@ -77,6 +77,10 @@ rustango::register_admin_computed!("post", "word_count", "Words", |row| {
     ordering      = "-published_at",
     page_size     = 20,
 )]
+// `PostViewSet` / `AuthorViewSet` are mounted by `urls.rs` at runtime —
+// the `#[derive(ViewSet)]` macro registers them via inventory. Compiler
+// can't see the indirect use through inventory walking, hence the allow.
+#[allow(dead_code)]
 pub struct PostViewSet;
 
 /// Read-only viewset for authors.
@@ -88,4 +92,5 @@ pub struct PostViewSet;
     ordering      = "name",
     read_only,
 )]
+#[allow(dead_code)]
 pub struct AuthorViewSet;

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -1695,6 +1695,9 @@ where
         for (i, col) in row.columns().iter().enumerate() {
             let name = col.name().to_owned();
             // Try to decode as each possible SqlValue type, falling back to Null.
+            // Order matters: try cheaper / more-specific decoders first.
+            // PG-specific composite types (jsonb, arrays) handled after
+            // scalars so int8/text aren't accidentally decoded as JSON.
             let val: SqlValue = if let Ok(v) = row.try_get::<i64, _>(i) {
                 SqlValue::I64(v)
             } else if let Ok(v) = row.try_get::<i32, _>(i) {
@@ -1705,6 +1708,24 @@ where
                 SqlValue::Bool(v)
             } else if let Ok(v) = row.try_get::<String, _>(i) {
                 SqlValue::String(v)
+            } else if let Ok(v) = row.try_get::<serde_json::Value, _>(i) {
+                // jsonb / json — issue #33's jsonb_agg returns this.
+                SqlValue::Json(v)
+            } else if let Ok(v) = row.try_get::<Vec<String>, _>(i) {
+                // text[] / varchar[] — issue #33's array_agg on a text col
+                // returns this. Wrap as a JSON array so the aggregate
+                // result map stays a Vec<HashMap<String, SqlValue>> shape
+                // — SqlValue has no Vec<T> variant.
+                SqlValue::Json(serde_json::Value::Array(
+                    v.into_iter().map(serde_json::Value::String).collect(),
+                ))
+            } else if let Ok(v) = row.try_get::<Vec<i64>, _>(i) {
+                // bigint[] — array_agg on an integer column.
+                SqlValue::Json(serde_json::Value::Array(
+                    v.into_iter()
+                        .map(|n| serde_json::Value::Number(n.into()))
+                        .collect(),
+                ))
             } else {
                 SqlValue::Null
             };

--- a/crates/rustango/tests/admin_sqlite_live.rs
+++ b/crates/rustango/tests/admin_sqlite_live.rs
@@ -23,7 +23,6 @@
 use axum::body::Body;
 use axum::http::{header, Method, Request, StatusCode};
 use http_body_util::BodyExt;
-use rustango::core::Model as _;
 use rustango::sql::Pool;
 use rustango::Model;
 use tower::ServiceExt;

--- a/crates/rustango/tests/admin_user_roles_panel_live.rs
+++ b/crates/rustango/tests/admin_user_roles_panel_live.rs
@@ -1,4 +1,7 @@
 #![cfg(feature = "postgres")]
+// Tests intentionally exercise the deprecated `ensure_tables(&PgPool)`
+// path — that's what they're testing.
+#![allow(deprecated)]
 //! Live test for the v0.28 user-roles+permissions panel rendered on
 //! the `rustango_users` admin detail page (Step 5 / item #76).
 //!

--- a/crates/rustango/tests/contenttypes_batch_cache.rs
+++ b/crates/rustango/tests/contenttypes_batch_cache.rs
@@ -1,12 +1,33 @@
 //! Tests for `ContentType::get_for_models` batch lookup and the
 //! `get_for_model` / `get_by_natural_key` cache layer
 //! (issue #35). Runs against in-memory SQLite — no infra needed.
+//!
+//! ## Why the suite-wide serializing mutex
+//!
+//! The ContentType cache (`contenttypes::clear_cache` / the static
+//! HashMap behind `get_*` methods) is **process-global**. Under
+//! cargo's default parallel test harness, two tests racing on
+//! `clear_cache()` between another test's "populate" and "assert HIT"
+//! calls would evict the entry and force a DB hit — which then fails
+//! on a dropped table in the table-drop tests below. The lock makes
+//! every test in this file run sequentially against the shared cache.
 
 #![cfg(feature = "sqlite")]
+
+use std::sync::OnceLock;
 
 use rustango::contenttypes::{self, ContentType};
 use rustango::sql::{sqlx, Auto, Pool};
 use rustango::Model;
+use tokio::sync::Mutex;
+
+/// Suite-wide lock — gates every test against the process-global
+/// ContentType cache so the cache state stays coherent across the
+/// "clear → populate → assert" pattern each test follows.
+fn cache_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
 
 #[derive(Model, Debug, Clone)]
 #[rustango(table = "ct_bc_post")]
@@ -46,6 +67,7 @@ async fn sqlite_pool() -> Pool {
 /// Both `&str` literals and `String` values are accepted.
 #[tokio::test]
 async fn get_for_models_returns_matching_rows() {
+    let _g = cache_lock().lock().await;
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
 
@@ -76,6 +98,7 @@ async fn get_for_models_returns_matching_rows() {
 /// migrated yet.
 #[tokio::test]
 async fn get_for_models_omits_unknown_pairs() {
+    let _g = cache_lock().lock().await;
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
     let cts = ContentType::get_for_models(&pool, [("ct_bc_blog", "post"), ("nonexistent", "nope")])
@@ -90,6 +113,7 @@ async fn get_for_models_omits_unknown_pairs() {
 /// the lookup entirely when they have nothing to ask about).
 #[tokio::test]
 async fn get_for_models_empty_input_is_empty_output() {
+    let _g = cache_lock().lock().await;
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
     let cts = ContentType::get_for_models(&pool, std::iter::empty::<(String, String)>())
@@ -102,6 +126,7 @@ async fn get_for_models_empty_input_is_empty_output() {
 /// path — the cache doesn't change semantics, only speed.
 #[tokio::test]
 async fn get_by_natural_key_matches_uncached() {
+    let _g = cache_lock().lock().await;
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
     let uncached = ContentType::by_natural_key(&pool, "ct_bc_blog", "post")
@@ -123,6 +148,7 @@ async fn get_by_natural_key_matches_uncached() {
 /// still succeed.
 #[tokio::test]
 async fn get_by_natural_key_serves_from_cache_on_repeat() {
+    let _g = cache_lock().lock().await;
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
     let _ = ContentType::get_by_natural_key(&pool, "ct_bc_blog", "post")
@@ -150,6 +176,7 @@ async fn get_by_natural_key_serves_from_cache_on_repeat() {
 /// (which after the table drop above means a fresh seed must re-occur).
 #[tokio::test]
 async fn clear_cache_forces_db_round_trip_again() {
+    let _g = cache_lock().lock().await;
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
     let _ = ContentType::get_by_natural_key(&pool, "ct_bc_blog", "post")
@@ -179,6 +206,7 @@ async fn clear_cache_forces_db_round_trip_again() {
 /// blocked by a stale negative entry.
 #[tokio::test]
 async fn negative_results_are_not_cached() {
+    let _g = cache_lock().lock().await;
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
     // First lookup against an unknown pair → None.
@@ -211,6 +239,7 @@ async fn negative_results_are_not_cached() {
 /// `for_model::<T>` and uses the natural-key cache.
 #[tokio::test]
 async fn get_for_model_resolves_type() {
+    let _g = cache_lock().lock().await;
     contenttypes::clear_cache();
     let pool = sqlite_pool().await;
     let cached = ContentType::get_for_model::<Post>(&pool)

--- a/crates/rustango/tests/contenttypes_live.rs
+++ b/crates/rustango/tests/contenttypes_live.rs
@@ -187,7 +187,7 @@ async fn ensure_seeded_inserts_a_row_per_model() {
         eprintln!("DATABASE_URL unset — skipping");
         return;
     };
-    let inserted = contenttypes::ensure_seeded(&pool)
+    let inserted = contenttypes::ensure_seeded(&pool.clone().into())
         .await
         .expect("ensure_seeded");
     assert!(
@@ -195,7 +195,7 @@ async fn ensure_seeded_inserts_a_row_per_model() {
         "expected at least the two test models seeded, got {inserted}"
     );
     // Re-running should be a no-op.
-    let inserted_again = contenttypes::ensure_seeded(&pool)
+    let inserted_again = contenttypes::ensure_seeded(&pool.clone().into())
         .await
         .expect("ensure_seeded idempotent");
     assert_eq!(
@@ -211,8 +211,10 @@ async fn for_model_resolves_to_correct_row() {
         eprintln!("DATABASE_URL unset — skipping");
         return;
     };
-    contenttypes::ensure_seeded(&pool).await.expect("seed");
-    let ct = ContentType::for_model::<Post>(&pool)
+    contenttypes::ensure_seeded(&pool.clone().into())
+        .await
+        .expect("seed");
+    let ct = ContentType::for_model::<Post>(&pool.clone().into())
         .await
         .expect("for_model")
         .expect("Post ContentType row exists");
@@ -229,8 +231,10 @@ async fn by_natural_key_round_trips() {
         eprintln!("DATABASE_URL unset — skipping");
         return;
     };
-    contenttypes::ensure_seeded(&pool).await.expect("seed");
-    let ct = ContentType::by_natural_key(&pool, "auth", "user")
+    contenttypes::ensure_seeded(&pool.clone().into())
+        .await
+        .expect("seed");
+    let ct = ContentType::by_natural_key(&pool.clone().into(), "auth", "user")
         .await
         .expect("by_natural_key")
         .expect("auth.user exists");
@@ -238,7 +242,7 @@ async fn by_natural_key_round_trips() {
     let pk = ct.id.get().copied().expect("auto pk populated");
 
     // by_id should return the same row.
-    let by_id = ContentType::by_id(&pool, pk)
+    let by_id = ContentType::by_id(&pool.clone().into(), pk)
         .await
         .expect("by_id")
         .expect("pk exists");
@@ -253,8 +257,10 @@ async fn all_returns_seeded_rows_ordered() {
         eprintln!("DATABASE_URL unset — skipping");
         return;
     };
-    contenttypes::ensure_seeded(&pool).await.expect("seed");
-    let rows = ContentType::all(&pool).await.expect("all");
+    contenttypes::ensure_seeded(&pool.clone().into())
+        .await
+        .expect("seed");
+    let rows = ContentType::all(&pool.clone().into()).await.expect("all");
     assert!(rows.len() >= 2, "at least two seeded models");
     // Confirm sort order: app_label asc, model_name asc.
     let mut last: Option<(String, String)> = None;
@@ -312,15 +318,17 @@ async fn ensure_seeded_skips_content_type_table_itself() {
         eprintln!("DATABASE_URL unset — skipping");
         return;
     };
-    contenttypes::ensure_seeded(&pool).await.expect("seed");
-    let row = ContentType::by_natural_key(&pool, "project", "contenttype")
+    contenttypes::ensure_seeded(&pool.clone().into())
+        .await
+        .expect("seed");
+    let row = ContentType::by_natural_key(&pool.clone().into(), "project", "contenttype")
         .await
         .expect("query");
     assert!(
         row.is_none(),
         "ContentType should not have a self-referential row"
     );
-    let alt = ContentType::by_natural_key(&pool, "contenttypes", "contenttype")
+    let alt = ContentType::by_natural_key(&pool.clone().into(), "contenttypes", "contenttype")
         .await
         .expect("query");
     assert!(alt.is_none(), "ContentType should not seed itself");
@@ -346,11 +354,13 @@ async fn for_target_resolves_via_content_type() {
         eprintln!("DATABASE_URL unset — skipping");
         return;
     };
-    contenttypes::ensure_seeded(&pool).await.expect("seed");
-    let g = GenericForeignKey::for_target::<Post>(&pool, 99)
+    contenttypes::ensure_seeded(&pool.clone().into())
+        .await
+        .expect("seed");
+    let g = GenericForeignKey::for_target::<Post>(&pool.clone().into(), 99)
         .await
         .expect("for_target");
-    let post_ct = ContentType::for_model::<Post>(&pool)
+    let post_ct = ContentType::for_model::<Post>(&pool.clone().into())
         .await
         .expect("for_model")
         .expect("Post CT exists");
@@ -394,10 +404,14 @@ async fn prefetch_soft_groups_children_by_fk_value() {
     }
 
     let parent_pks = vec![p1_id, p2_id];
-    let by_post =
-        contenttypes::prefetch_soft::<Comment, _>(&pool, &parent_pks, "post_id", |c| c.post_id)
-            .await
-            .expect("prefetch_soft");
+    let by_post = contenttypes::prefetch_soft::<Comment, _>(
+        &pool.clone().into(),
+        &parent_pks,
+        "post_id",
+        |c| c.post_id,
+    )
+    .await
+    .expect("prefetch_soft");
 
     let p1_kids = by_post.get(&p1_id).expect("p1 has kids");
     assert_eq!(p1_kids.len(), 2);
@@ -413,7 +427,10 @@ async fn prefetch_soft_short_circuits_on_empty_parent_list() {
         eprintln!("DATABASE_URL unset — skipping");
         return;
     };
-    let by_post = contenttypes::prefetch_soft::<Comment, _>(&pool, &[], "post_id", |c| c.post_id)
+    let by_post =
+        contenttypes::prefetch_soft::<Comment, _>(&pool.clone().into(), &[], "post_id", |c| {
+            c.post_id
+        })
         .await
         .expect("prefetch_soft");
     assert!(by_post.is_empty());
@@ -427,7 +444,9 @@ async fn prefetch_generic_hydrates_typed_targets() {
         eprintln!("DATABASE_URL unset — skipping");
         return;
     };
-    contenttypes::ensure_seeded(&pool).await.expect("seed");
+    contenttypes::ensure_seeded(&pool.clone().into())
+        .await
+        .expect("seed");
 
     // Seed 2 posts + 1 user. Build a list of generic FKs pointing at
     // both kinds. prefetch_generic::<Post>(...) should hydrate only
@@ -452,13 +471,13 @@ async fn prefetch_generic_hydrates_typed_targets() {
     let p2_pk = p2.id.get().copied().unwrap();
     let u_pk = u.id.get().copied().unwrap();
 
-    let g_p1 = GenericForeignKey::for_target::<Post>(&pool, p1_pk)
+    let g_p1 = GenericForeignKey::for_target::<Post>(&pool.clone().into(), p1_pk)
         .await
         .expect("g_p1");
-    let g_p2 = GenericForeignKey::for_target::<Post>(&pool, p2_pk)
+    let g_p2 = GenericForeignKey::for_target::<Post>(&pool.clone().into(), p2_pk)
         .await
         .expect("g_p2");
-    let g_u = GenericForeignKey::for_target::<User>(&pool, u_pk)
+    let g_u = GenericForeignKey::for_target::<User>(&pool.clone().into(), u_pk)
         .await
         .expect("g_u");
     let pairs = vec![
@@ -467,7 +486,7 @@ async fn prefetch_generic_hydrates_typed_targets() {
         (g_u.content_type_id, g_u.object_pk),
     ];
 
-    let posts = contenttypes::prefetch_generic::<Post>(&pool, &pairs)
+    let posts = contenttypes::prefetch_generic::<Post>(&pool.clone().into(), &pairs)
         .await
         .expect("prefetch_generic Post");
     assert_eq!(
@@ -500,8 +519,10 @@ async fn prefetch_generic_short_circuits_on_empty_pairs() {
         eprintln!("DATABASE_URL unset — skipping");
         return;
     };
-    contenttypes::ensure_seeded(&pool).await.expect("seed");
-    let out = contenttypes::prefetch_generic::<Post>(&pool, &[])
+    contenttypes::ensure_seeded(&pool.clone().into())
+        .await
+        .expect("seed");
+    let out = contenttypes::prefetch_generic::<Post>(&pool.clone().into(), &[])
         .await
         .expect("prefetch_generic empty");
     assert!(out.is_empty());
@@ -532,7 +553,9 @@ async fn render_generic_fk_link_resolves_via_content_type() {
         eprintln!("DATABASE_URL unset — skipping");
         return;
     };
-    contenttypes::ensure_seeded(&pool).await.expect("seed");
+    contenttypes::ensure_seeded(&pool.clone().into())
+        .await
+        .expect("seed");
     let mut p = Post {
         id: Auto::Unset,
         title: "rendered".into(),
@@ -540,10 +563,10 @@ async fn render_generic_fk_link_resolves_via_content_type() {
     p.insert(&pool).await.expect("insert post");
     let pk = p.id.get().copied().unwrap();
 
-    let gfk = GenericForeignKey::for_target::<Post>(&pool, pk)
+    let gfk = GenericForeignKey::for_target::<Post>(&pool.clone().into(), pk)
         .await
         .expect("for_target");
-    let html = render_generic_fk_link(&pool, gfk)
+    let html = render_generic_fk_link(&pool.clone().into(), gfk)
         .await
         .expect("render_generic_fk_link");
 
@@ -562,9 +585,11 @@ async fn render_generic_fk_link_falls_back_on_unknown_ct_id() {
         eprintln!("DATABASE_URL unset — skipping");
         return;
     };
-    contenttypes::ensure_seeded(&pool).await.expect("seed");
+    contenttypes::ensure_seeded(&pool.clone().into())
+        .await
+        .expect("seed");
     let gfk = GenericForeignKey::new(/* unknown */ 99_999_999, 42);
-    let html = render_generic_fk_link(&pool, gfk)
+    let html = render_generic_fk_link(&pool.clone().into(), gfk)
         .await
         .expect("render_generic_fk_link");
     // Fallback shape — raw pair, no anchor link, italics for visibility.

--- a/crates/rustango/tests/explain_live.rs
+++ b/crates/rustango/tests/explain_live.rs
@@ -10,7 +10,7 @@
 
 #![cfg(feature = "tenancy")]
 
-use rustango::core::{Column as _, Model as _};
+use rustango::core::Column as _;
 use rustango::sql::{sqlx, Auto, ExplainFormat, ExplainOptions};
 
 #[derive(rustango::Model, Debug, Clone)]

--- a/crates/rustango/tests/generated_columns_live.rs
+++ b/crates/rustango/tests/generated_columns_live.rs
@@ -7,7 +7,7 @@
 
 #![cfg(feature = "tenancy")]
 
-use rustango::core::{Column as _, Model as _};
+use rustango::core::Column as _;
 use rustango::sql::{sqlx, Auto, Fetcher};
 
 #[derive(rustango::Model, Debug, Clone)]

--- a/crates/rustango/tests/media_collections_tags_live.rs
+++ b/crates/rustango/tests/media_collections_tags_live.rs
@@ -4,12 +4,11 @@
 //! silently when DATABASE_URL or RUSTANGO_S3_TEST_* are unset.
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use rustango::media::router::media_router;
-use rustango::media::{ensure_all_tables, MediaManager, SaveOpts, UploadIntent};
+use rustango::media::{ensure_all_tables, MediaManager, SaveOpts};
 use rustango::storage::s3::{S3Config, S3Storage};
 use rustango::storage::{BoxedStorage, StorageRegistry};
 use sqlx::PgPool;

--- a/crates/rustango/tests/migrate_manage.rs
+++ b/crates/rustango/tests/migrate_manage.rs
@@ -12,8 +12,8 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use rustango::migrate::{
-    self, append_data_op, file, make_data_migration, manage, DataOp, MigrateError, Migration,
-    Operation, SchemaChange, SchemaSnapshot, TableSnapshot,
+    self, append_data_op, file, make_data_migration, manage, MigrateError, Migration, Operation,
+    SchemaChange, SchemaSnapshot, TableSnapshot,
 };
 use rustango::sql::sqlx::{self, PgPool, Row};
 

--- a/crates/rustango/tests/migrate_tenant_storage_live.rs
+++ b/crates/rustango/tests/migrate_tenant_storage_live.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use rustango::core::Model as _;
 use rustango::sql::sqlx::PgPool;
 use rustango::sql::Auto;
 use rustango::tenancy::{manage::run_with_writer, Org, StorageMode, TenantPools};

--- a/crates/rustango/tests/non_superuser_admin_visibility_live.rs
+++ b/crates/rustango/tests/non_superuser_admin_visibility_live.rs
@@ -1,4 +1,8 @@
 #![cfg(feature = "postgres")]
+// Tests intentionally exercise the deprecated `ensure_tables(&PgPool)`
+// path — covers the legacy-bootstrap behaviour, not the migration
+// that replaces it.
+#![allow(deprecated)]
 //! Live integration test for #67 — the "scaffold an app, see it in
 //! admin as a non-superuser" loop that #61–#66 collectively broke.
 //!

--- a/crates/rustango/tests/operator_console_orgs_edit_live.rs
+++ b/crates/rustango/tests/operator_console_orgs_edit_live.rs
@@ -22,12 +22,12 @@ use std::sync::Arc;
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
 use rustango::core::Column as _;
+use rustango::migrate as rmig;
 use rustango::sql::{sqlx, Auto, Fetcher};
 use rustango::tenancy::{
     operator_console::{router_with_pools, SessionSecret},
     Org, StorageMode, TenantPools,
 };
-use rustango::{migrate as rmig, Model};
 use tower::ServiceExt;
 
 static UNIQ: AtomicU64 = AtomicU64::new(0);

--- a/crates/rustango/tests/permissions_upsert_live.rs
+++ b/crates/rustango/tests/permissions_upsert_live.rs
@@ -10,8 +10,12 @@
 //! existing row instead of inserting a duplicate.
 
 #![cfg(feature = "tenancy")]
+// The legacy `ensure_tables(&PgPool)` is intentionally exercised
+// below — these tests cover the upsert behaviour, not the migration
+// path that superseded it.
+#![allow(deprecated)]
 
-use rustango::core::{Column as _, Model as _};
+use rustango::core::Column as _;
 use rustango::sql::sqlx;
 use rustango::sql::{Auto, Fetcher};
 use rustango::tenancy::permissions::{

--- a/crates/rustango/tests/prefetch_non_i64_pk_live.rs
+++ b/crates/rustango/tests/prefetch_non_i64_pk_live.rs
@@ -11,7 +11,6 @@
 
 #![cfg(feature = "tenancy")]
 
-use rustango::core::{Column as _, Model as _};
 use rustango::sql::{fetch_with_prefetch, sqlx, Auto, ForeignKey};
 
 #[derive(rustango::Model, Debug, Clone)]
@@ -79,7 +78,7 @@ async fn fetch_with_prefetch_groups_children_under_string_pk_parents() {
 
     // Seed: two parents, three children (2 + 1).
     for slug in ["acme", "globex"] {
-        let mut t = StrTenant {
+        let t = StrTenant {
             slug: slug.into(),
             display_name: slug.to_uppercase(),
         };

--- a/crates/rustango/tests/serializer_derive.rs
+++ b/crates/rustango/tests/serializer_derive.rs
@@ -98,6 +98,7 @@ fn read_only_field_excluded_from_writable_fields() {
 
 #[derive(Serializer, Default)]
 #[serializer(model = Post)]
+#[allow(dead_code)] // body field is write-only by design — tested via Serializer reflection, never directly read.
 struct PostWithWriteOnly {
     pub title: String,
     #[serializer(write_only)]
@@ -277,6 +278,7 @@ mod openapi_auto_derive {
 
     #[derive(Serializer, Default)]
     #[serializer(model = Post)]
+    #[allow(dead_code)] // secret field is write-only by design.
     struct WithWriteOnly {
         pub title: String,
         #[serializer(write_only)]

--- a/crates/rustango/tests/sqlite_registry_proof_live.rs
+++ b/crates/rustango/tests/sqlite_registry_proof_live.rs
@@ -24,7 +24,7 @@
 #![cfg(all(feature = "tenancy", feature = "sqlite"))]
 
 use rustango::core::Column as _;
-use rustango::sql::{sqlx, Auto, Fetcher as _, FetcherPool as _, Pool};
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
 use rustango::tenancy::Org;
 
 const BOOTSTRAP_SQL: &str = r#"

--- a/crates/rustango/tests/tenancy_manage_sqlite_live.rs
+++ b/crates/rustango/tests/tenancy_manage_sqlite_live.rs
@@ -16,7 +16,7 @@
 
 #![cfg(all(feature = "sqlite", feature = "tenancy"))]
 
-use rustango::sql::{sqlx, Pool};
+use rustango::sql::sqlx;
 use rustango::tenancy::TenantPools;
 
 /// Build a sqlite tenant-pools handle backed by a tempfile DB.

--- a/crates/rustango/tests/upsert_unique_together_live.rs
+++ b/crates/rustango/tests/upsert_unique_together_live.rs
@@ -13,7 +13,7 @@
 
 #![cfg(feature = "tenancy")]
 
-use rustango::core::{Column as _, Model as _};
+use rustango::core::Column as _;
 use rustango::sql::sqlx;
 use rustango::sql::{Auto, Fetcher};
 


### PR DESCRIPTION
Two latent bugs from recently-merged work, shipped in one hotfix so CI goes fully green:

## 1. `array_agg` / `jsonb_agg` decoded as `SqlValue::Null`

PR #99 (issue #33) shipped the SQL emission for `array_agg` / `string_agg` / `jsonb_agg` but the `fetch_aggregate` decoder's try-chain stopped at `String`. `array_agg(\"tag\")` returns `text[]` and `jsonb_agg(\"tag\")` returns `jsonb` — neither matched any decoder, so both became `Null`.

Live CI caught it:
- `array_agg_collects_tags_per_author` — FAILED (got `Null`)
- `jsonb_agg_returns_json_array_per_author` — FAILED (got `Some(Null)`)
- `string_agg_concatenates_tags_per_author` — PASSED (text, decoder handles)

### Fix

Extend the try-chain with three more decode attempts after the scalar fallbacks:

| Decode attempt | Handles |
|---|---|
| `serde_json::Value` | `jsonb` / `json` (jsonb_agg + any jsonb column projected) |
| `Vec<String>` | `text[]` / `varchar[]` (array_agg on text) |
| `Vec<i64>` | `bigint[]` (array_agg on integer columns / PKs) |

Array variants wrap in `SqlValue::Json(Value::Array(...))` since `SqlValue` has no `Vec<T>` variant — JSON-array is the natural round-trip for the `Vec<HashMap<String, SqlValue>>` result type. Order matters: scalars first so an `int8` column isn't mis-decoded as JSON.

## 2. `contenttypes_live.rs` still uses `&PgPool` (was PR #101)

Cherry-picked PR #101's commit. The `_pool` rename in PR #98 missed this PG-gated test file, breaking `postgres_test` on every downstream PR. Consolidating into one hotfix.

## Verification

`cargo test --workspace --all-features --no-run` clean — the **CI-equivalent gate** (newly added to my memory as the mandatory pre-push check) now passes against main + these two fixes. Every test binary compiles, including all the PG-gated live ones.