### PR TITLE
chore: silence test-binary compiler warnings (unused imports, deprecated, dead code)

### DIFF
--- a/crates/rustango/examples/blog_demo/models.rs
+++ b/crates/rustango/examples/blog_demo/models.rs
@@ -77,6 +77,10 @@ rustango::register_admin_computed!("post", "word_count", "Words", |row| {
     ordering      = "-published_at",
     page_size     = 20,
 )]
+// `PostViewSet` / `AuthorViewSet` are mounted by `urls.rs` at runtime —
+// the `#[derive(ViewSet)]` macro registers them via inventory. Compiler
+// can't see the indirect use through inventory walking, hence the allow.
+#[allow(dead_code)]
 pub struct PostViewSet;
 
 /// Read-only viewset for authors.
@@ -88,4 +92,5 @@ pub struct PostViewSet;
     ordering      = "name",
     read_only,
 )]
+#[allow(dead_code)]
 pub struct AuthorViewSet;

--- a/crates/rustango/tests/admin_sqlite_live.rs
+++ b/crates/rustango/tests/admin_sqlite_live.rs
@@ -23,7 +23,6 @@
 use axum::body::Body;
 use axum::http::{header, Method, Request, StatusCode};
 use http_body_util::BodyExt;
-use rustango::core::Model as _;
 use rustango::sql::Pool;
 use rustango::Model;
 use tower::ServiceExt;

--- a/crates/rustango/tests/admin_user_roles_panel_live.rs
+++ b/crates/rustango/tests/admin_user_roles_panel_live.rs
@@ -1,4 +1,7 @@
 #![cfg(feature = "postgres")]
+// Tests intentionally exercise the deprecated `ensure_tables(&PgPool)`
+// path — that's what they're testing.
+#![allow(deprecated)]
 //! Live test for the v0.28 user-roles+permissions panel rendered on
 //! the `rustango_users` admin detail page (Step 5 / item #76).
 //!

--- a/crates/rustango/tests/explain_live.rs
+++ b/crates/rustango/tests/explain_live.rs
@@ -10,7 +10,7 @@
 
 #![cfg(feature = "tenancy")]
 
-use rustango::core::{Column as _, Model as _};
+use rustango::core::Column as _;
 use rustango::sql::{sqlx, Auto, ExplainFormat, ExplainOptions};
 
 #[derive(rustango::Model, Debug, Clone)]

--- a/crates/rustango/tests/generated_columns_live.rs
+++ b/crates/rustango/tests/generated_columns_live.rs
@@ -7,7 +7,7 @@
 
 #![cfg(feature = "tenancy")]
 
-use rustango::core::{Column as _, Model as _};
+use rustango::core::Column as _;
 use rustango::sql::{sqlx, Auto, Fetcher};
 
 #[derive(rustango::Model, Debug, Clone)]

--- a/crates/rustango/tests/media_collections_tags_live.rs
+++ b/crates/rustango/tests/media_collections_tags_live.rs
@@ -4,12 +4,11 @@
 //! silently when DATABASE_URL or RUSTANGO_S3_TEST_* are unset.
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use rustango::media::router::media_router;
-use rustango::media::{ensure_all_tables, MediaManager, SaveOpts, UploadIntent};
+use rustango::media::{ensure_all_tables, MediaManager, SaveOpts};
 use rustango::storage::s3::{S3Config, S3Storage};
 use rustango::storage::{BoxedStorage, StorageRegistry};
 use sqlx::PgPool;

--- a/crates/rustango/tests/migrate_manage.rs
+++ b/crates/rustango/tests/migrate_manage.rs
@@ -12,8 +12,8 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use rustango::migrate::{
-    self, append_data_op, file, make_data_migration, manage, DataOp, MigrateError, Migration,
-    Operation, SchemaChange, SchemaSnapshot, TableSnapshot,
+    self, append_data_op, file, make_data_migration, manage, MigrateError, Migration, Operation,
+    SchemaChange, SchemaSnapshot, TableSnapshot,
 };
 use rustango::sql::sqlx::{self, PgPool, Row};
 

--- a/crates/rustango/tests/migrate_tenant_storage_live.rs
+++ b/crates/rustango/tests/migrate_tenant_storage_live.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use rustango::core::Model as _;
 use rustango::sql::sqlx::PgPool;
 use rustango::sql::Auto;
 use rustango::tenancy::{manage::run_with_writer, Org, StorageMode, TenantPools};

--- a/crates/rustango/tests/non_superuser_admin_visibility_live.rs
+++ b/crates/rustango/tests/non_superuser_admin_visibility_live.rs
@@ -1,4 +1,8 @@
 #![cfg(feature = "postgres")]
+// Tests intentionally exercise the deprecated `ensure_tables(&PgPool)`
+// path — covers the legacy-bootstrap behaviour, not the migration
+// that replaces it.
+#![allow(deprecated)]
 //! Live integration test for #67 — the "scaffold an app, see it in
 //! admin as a non-superuser" loop that #61–#66 collectively broke.
 //!

--- a/crates/rustango/tests/operator_console_orgs_edit_live.rs
+++ b/crates/rustango/tests/operator_console_orgs_edit_live.rs
@@ -22,12 +22,12 @@ use std::sync::Arc;
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
 use rustango::core::Column as _;
+use rustango::migrate as rmig;
 use rustango::sql::{sqlx, Auto, Fetcher};
 use rustango::tenancy::{
     operator_console::{router_with_pools, SessionSecret},
     Org, StorageMode, TenantPools,
 };
-use rustango::{migrate as rmig, Model};
 use tower::ServiceExt;
 
 static UNIQ: AtomicU64 = AtomicU64::new(0);

--- a/crates/rustango/tests/permissions_upsert_live.rs
+++ b/crates/rustango/tests/permissions_upsert_live.rs
@@ -10,8 +10,12 @@
 //! existing row instead of inserting a duplicate.
 
 #![cfg(feature = "tenancy")]
+// The legacy `ensure_tables(&PgPool)` is intentionally exercised
+// below — these tests cover the upsert behaviour, not the migration
+// path that superseded it.
+#![allow(deprecated)]
 
-use rustango::core::{Column as _, Model as _};
+use rustango::core::Column as _;
 use rustango::sql::sqlx;
 use rustango::sql::{Auto, Fetcher};
 use rustango::tenancy::permissions::{

--- a/crates/rustango/tests/prefetch_non_i64_pk_live.rs
+++ b/crates/rustango/tests/prefetch_non_i64_pk_live.rs
@@ -11,7 +11,6 @@
 
 #![cfg(feature = "tenancy")]
 
-use rustango::core::{Column as _, Model as _};
 use rustango::sql::{fetch_with_prefetch, sqlx, Auto, ForeignKey};
 
 #[derive(rustango::Model, Debug, Clone)]
@@ -79,7 +78,7 @@ async fn fetch_with_prefetch_groups_children_under_string_pk_parents() {
 
     // Seed: two parents, three children (2 + 1).
     for slug in ["acme", "globex"] {
-        let mut t = StrTenant {
+        let t = StrTenant {
             slug: slug.into(),
             display_name: slug.to_uppercase(),
         };

--- a/crates/rustango/tests/serializer_derive.rs
+++ b/crates/rustango/tests/serializer_derive.rs
@@ -98,6 +98,7 @@ fn read_only_field_excluded_from_writable_fields() {
 
 #[derive(Serializer, Default)]
 #[serializer(model = Post)]
+#[allow(dead_code)] // body field is write-only by design — tested via Serializer reflection, never directly read.
 struct PostWithWriteOnly {
     pub title: String,
     #[serializer(write_only)]
@@ -277,6 +278,7 @@ mod openapi_auto_derive {
 
     #[derive(Serializer, Default)]
     #[serializer(model = Post)]
+    #[allow(dead_code)] // secret field is write-only by design.
     struct WithWriteOnly {
         pub title: String,
         #[serializer(write_only)]

--- a/crates/rustango/tests/sqlite_registry_proof_live.rs
+++ b/crates/rustango/tests/sqlite_registry_proof_live.rs
@@ -24,7 +24,7 @@
 #![cfg(all(feature = "tenancy", feature = "sqlite"))]
 
 use rustango::core::Column as _;
-use rustango::sql::{sqlx, Auto, Fetcher as _, FetcherPool as _, Pool};
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
 use rustango::tenancy::Org;
 
 const BOOTSTRAP_SQL: &str = r#"

--- a/crates/rustango/tests/tenancy_manage_sqlite_live.rs
+++ b/crates/rustango/tests/tenancy_manage_sqlite_live.rs
@@ -16,7 +16,7 @@
 
 #![cfg(all(feature = "sqlite", feature = "tenancy"))]
 
-use rustango::sql::{sqlx, Pool};
+use rustango::sql::sqlx;
 use rustango::tenancy::TenantPools;
 
 /// Build a sqlite tenant-pools handle backed by a tempfile DB.

--- a/crates/rustango/tests/upsert_unique_together_live.rs
+++ b/crates/rustango/tests/upsert_unique_together_live.rs
@@ -13,7 +13,7 @@
 
 #![cfg(feature = "tenancy")]
 
-use rustango::core::{Column as _, Model as _};
+use rustango::core::Column as _;
 use rustango::sql::sqlx;
 use rustango::sql::{Auto, Fetcher};
 


### PR DESCRIPTION
CI was producing ~20 noisy warnings across PG-gated test files and the `blog_demo` example. None were real bugs — just signal-degrading noise. Three categories, three fixes:

## 1. Unused `use ... Model as _` trait imports (11 files)

Most live tests inherited a `use rustango::core::Model as _;` line from an older template that invoked `Model`'s trait methods. Subsequent refactors moved the calls to inherent methods or removed them, leaving the import dangling.

Fixed by `cargo fix --tests --workspace --all-features --allow-dirty` plus two manual edits where cargo fix couldn't split a multi-item brace:
- `tests/permissions_upsert_live.rs`
- `tests/admin_sqlite_live.rs`

## 2. Intentional `permissions::ensure_tables(&PgPool)` deprecation calls (3 files)

These tests *exercise* the deprecated runtime-DDL helper — that's their contract. Tagged with `#![allow(deprecated)]` at file scope + a one-line note about why:
- `tests/permissions_upsert_live.rs` — upsert behaviour
- `tests/admin_user_roles_panel_live.rs` — panel rendering
- `tests/non_superuser_admin_visibility_live.rs` — scaffolded-app visibility

## 3. Test fixtures the compiler can't see being used (4 structs)

`#[derive(ViewSet)]` / `#[serializer(...)]` register structs via inventory walking that rustc's reachability analysis can't follow:
- `tests/serializer_derive.rs` — `PostWithWriteOnly`, `WithWriteOnly`
- `examples/blog_demo/models.rs` — `PostViewSet`, `AuthorViewSet`

Tagged with `#[allow(dead_code)]` + a comment explaining the indirect-use mechanism. Better than synthesising fake usages (the user's alternative \"print them to register\" idea) — the inventory registration already does the right thing at runtime; the `#[allow]` just tells rustc that's intentional.

## Verification

`cargo test --workspace --all-features --no-run` — every warning gone. (The build error in `contenttypes_live` is PR #102's territory, unrelated to warning cleanup. When this and #102 both land, CI goes fully green.)