### PR TITLE
feat: Model::save_partial_typed((Col, ...), &pool) (closes #67)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -1912,6 +1912,37 @@ fn inherent_impl_tokens(
                         ).await?;
                         ::core::result::Result::Ok(())
                     }
+
+                    /// Typed-column counterpart of [`Self::save_partial`] —
+                    /// issue #67. `fields` is a tuple of [`Column`]
+                    /// constants whose `Model` matches `Self`; typos and
+                    /// model mismatches surface at *compile time*
+                    /// (`Author::name` inside a `Post::save_partial_typed`
+                    /// call is a type error, no runtime check).
+                    ///
+                    /// ```ignore
+                    /// post.save_partial_typed((Post::title, Post::slug), &pool).await?;
+                    /// ```
+                    ///
+                    /// Lowers to [`Self::save_partial`] under the hood;
+                    /// audit narrowing + every other semantic is identical.
+                    ///
+                    /// [`Column`]: ::rustango::core::Column
+                    ///
+                    /// # Errors
+                    /// As [`Self::save_partial`].
+                    pub async fn save_partial_typed<
+                        L: ::rustango::core::TypedFieldList<Self>,
+                    >(
+                        &mut self,
+                        fields: L,
+                        pool: &::rustango::sql::Pool,
+                    ) -> ::core::result::Result<(), ::rustango::sql::ExecError> {
+                        let _names = fields.rust_field_names();
+                        let _refs: ::std::vec::Vec<&str> =
+                            _names.iter().copied().collect();
+                        self.save_partial(&_refs, pool).await
+                    }
                 }
             }
         } else {
@@ -2050,6 +2081,38 @@ fn inherent_impl_tokens(
                     };
                     let _ = ::rustango::sql::update_pool(pool, &_query).await?;
                     ::core::result::Result::Ok(())
+                }
+
+                /// Typed-column counterpart of [`Self::save_partial`] —
+                /// issue #67. `fields` is a tuple of [`Column`]
+                /// constants whose `Model` matches `Self`; typos and
+                /// model mismatches surface at *compile time*
+                /// (`Author::name` inside a `Post::save_partial_typed`
+                /// call is a type error, no runtime check).
+                ///
+                /// ```ignore
+                /// post.save_partial_typed((Post::title, Post::slug), &pool).await?;
+                /// ```
+                ///
+                /// Lowers to [`Self::save_partial`] under the hood — the
+                /// tuple is reduced to a `&[&str]` slice of Rust-side
+                /// field names and forwarded.
+                ///
+                /// [`Column`]: ::rustango::core::Column
+                ///
+                /// # Errors
+                /// As [`Self::save_partial`].
+                pub async fn save_partial_typed<
+                    L: ::rustango::core::TypedFieldList<Self>,
+                >(
+                    &mut self,
+                    fields: L,
+                    pool: &::rustango::sql::Pool,
+                ) -> ::core::result::Result<(), ::rustango::sql::ExecError> {
+                    let _names = fields.rust_field_names();
+                    let _refs: ::std::vec::Vec<&str> =
+                        _names.iter().copied().collect();
+                    self.save_partial(&_refs, pool).await
                 }
             }
         }

--- a/crates/rustango/src/core/column.rs
+++ b/crates/rustango/src/core/column.rs
@@ -401,3 +401,76 @@ impl<M: Model> TypedAssignment<M> {
         self.inner
     }
 }
+
+/// Heterogeneous list of typed [`Column`] references for the same model.
+/// Issue #67 — drives `Model::save_partial_typed(...)`.
+///
+/// Each `#[derive(Model)]` field is its own zero-sized type, so
+/// `&[Post::title, Post::slug]` doesn't type-check (mixed element types).
+/// A tuple does — every element keeps its own concrete type, and the
+/// trait bound `Column<Model = M>` on each slot enforces same-model
+/// at compile time:
+///
+/// ```ignore
+/// post.save_partial_typed((Post::title, Post::slug), &pool).await?;
+/// //                       ──────────  ──────────
+/// //                       title_col   slug_col   ← distinct ZSTs
+/// //
+/// // (Post::title, Author::name)  →  compile error: Author::name's
+/// //                                  Model = Author, not Post.
+/// ```
+///
+/// The trait is sealed — only the built-in tuple impls implement it,
+/// so user code can't accidentally collide with future variants.
+pub trait TypedFieldList<M: Model>: sealed::Sealed {
+    /// Rust-side field names in the order the tuple was declared.
+    /// Forwarded directly to [`crate::core::ModelSchema::field`] for
+    /// SQL-column resolution, matching the string-keyed
+    /// [`Model::save_partial`] path.
+    ///
+    /// [`Model::save_partial`]: crate::core::Model
+    fn rust_field_names(&self) -> Vec<&'static str>;
+}
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Single-element tuple — supports the `(Post::title,)` one-field call.
+impl<M: Model, A: Column<Model = M>> TypedFieldList<M> for (A,) {
+    fn rust_field_names(&self) -> Vec<&'static str> {
+        vec![A::NAME]
+    }
+}
+impl<A> sealed::Sealed for (A,) {}
+
+// Tuple impls up to 12 elements — covers every realistic update_fields
+// shape (Django's analogue is unbounded, but if you're writing more
+// than 12 distinct fields, dropping to `save_partial(&[&str], _)` is
+// cheap and probably clearer at the call site).
+macro_rules! impl_typed_field_list_tuple {
+    ( $( ( $($T:ident),+ ) ),+ $(,)? ) => {
+        $(
+            impl<M: Model, $($T: Column<Model = M>),+> TypedFieldList<M> for ($($T,)+) {
+                fn rust_field_names(&self) -> Vec<&'static str> {
+                    vec![$($T::NAME),+]
+                }
+            }
+            impl<$($T),+> sealed::Sealed for ($($T,)+) {}
+        )+
+    };
+}
+
+impl_typed_field_list_tuple!(
+    (A, B),
+    (A, B, C),
+    (A, B, C, D),
+    (A, B, C, D, E),
+    (A, B, C, D, E, F),
+    (A, B, C, D, E, F, G),
+    (A, B, C, D, E, F, G, H),
+    (A, B, C, D, E, F, G, H, I),
+    (A, B, C, D, E, F, G, H, I, J),
+    (A, B, C, D, E, F, G, H, I, J, K),
+    (A, B, C, D, E, F, G, H, I, J, K, L),
+);

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -13,7 +13,7 @@ mod schema;
 mod validate;
 mod value;
 
-pub use column::{Column, TypedAssignment, TypedExpr, TypedFilter};
+pub use column::{Column, TypedAssignment, TypedExpr, TypedFieldList, TypedFilter};
 pub use error::QueryError;
 pub use expr::{BinOp, Expr, ScalarFn, F};
 pub use field_type::FieldType;

--- a/crates/rustango/tests/save_partial_typed.rs
+++ b/crates/rustango/tests/save_partial_typed.rs
@@ -1,0 +1,134 @@
+//! Tests for `Model::save_partial_typed((Col, Col), &pool)` — the
+//! typed-column counterpart to `save_partial` (issue #67). The shape
+//! mostly proves that the macro emission compiles and forwards to the
+//! string-keyed `save_partial` correctly; the deep semantic coverage
+//! lives in `save_partial.rs` already.
+
+#![cfg(feature = "sqlite")]
+
+use rustango::sql::{sqlx, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "spt_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 20)]
+    pub status: String,
+    pub views: i64,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "spt_author")]
+#[allow(dead_code)]
+pub struct Author {
+    #[rustango(primary_key)]
+    pub id: i64,
+    #[rustango(max_length = 80)]
+    pub name: String,
+}
+
+async fn fresh_pool() -> Pool {
+    let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE spt_post (\
+            id INTEGER PRIMARY KEY, \
+            title TEXT NOT NULL, \
+            status TEXT NOT NULL, \
+            views INTEGER NOT NULL DEFAULT 0)",
+    )
+    .execute(&pool)
+    .await
+    .expect("create table");
+    sqlx::query("INSERT INTO spt_post (id, title, status, views) VALUES (1, 'orig', 'draft', 0)")
+        .execute(&pool)
+        .await
+        .expect("seed row");
+    Pool::Sqlite(pool)
+}
+
+/// Single-field tuple `(Post::title,)` narrows the UPDATE to one column.
+#[tokio::test]
+async fn single_field_tuple_narrows_update() {
+    let pool = fresh_pool().await;
+    let mut row = Post {
+        id: 1,
+        title: "rewritten".into(),
+        status: "rewritten-status".into(),
+        views: 999,
+    };
+    // One-field tuple needs the trailing comma — standard Rust idiom.
+    row.save_partial_typed((Post::title,), &pool).await.unwrap();
+    if let Pool::Sqlite(sq) = &pool {
+        let (title, status, views): (String, String, i64) =
+            sqlx::query_as("SELECT title, status, views FROM spt_post WHERE id = 1")
+                .fetch_one(sq)
+                .await
+                .unwrap();
+        assert_eq!(title, "rewritten");
+        assert_eq!(status, "draft", "status not in tuple → DB value preserved");
+        assert_eq!(views, 0);
+    }
+}
+
+/// Two-field tuple `(Post::title, Post::views)` rewrites both, leaves
+/// the third (status) untouched.
+#[tokio::test]
+async fn multi_field_tuple_narrows_update() {
+    let pool = fresh_pool().await;
+    let mut row = Post {
+        id: 1,
+        title: "new-title".into(),
+        status: "would-be-overwritten".into(),
+        views: 50,
+    };
+    row.save_partial_typed((Post::title, Post::views), &pool)
+        .await
+        .unwrap();
+    if let Pool::Sqlite(sq) = &pool {
+        let (title, status, views): (String, String, i64) =
+            sqlx::query_as("SELECT title, status, views FROM spt_post WHERE id = 1")
+                .fetch_one(sq)
+                .await
+                .unwrap();
+        assert_eq!(title, "new-title");
+        assert_eq!(status, "draft", "status not in tuple → untouched");
+        assert_eq!(views, 50);
+    }
+}
+
+/// Sanity — the typed tuple's `rust_field_names()` returns the Rust-side
+/// field names, the same shape the string API takes. This pins the
+/// trait contract so a future macro change can't silently emit SQL
+/// column names instead.
+#[test]
+fn typed_field_list_returns_rust_field_names() {
+    use rustango::core::TypedFieldList;
+    let names = (Post::title, Post::views).rust_field_names();
+    assert_eq!(names, vec!["title", "views"]);
+    let one = (Post::status,).rust_field_names();
+    assert_eq!(one, vec!["status"]);
+}
+
+// Cross-model tuples are a compile error — `Author::name`'s
+// `Column::Model = Author`, but `Post::save_partial_typed<L>` is
+// bounded `L: TypedFieldList<Post>`, which requires every tuple slot
+// to be `Column<Model = Post>`. Asserting "this code shouldn't
+// compile" needs `trybuild`; pulling that in just for one check is
+// heavier than the doc-only note here.
+//
+// If you want to confirm the invariant manually, drop this into the
+// test body and rebuild — it should fail with `the trait bound
+// Author_cols::name_col: Column<Model = Post> is not satisfied`:
+//
+//     row.save_partial_typed((Post::title, Author::name), &pool).await
+//
+// The presence of the working `multi_field_tuple_narrows_update`
+// test above proves the trait bound IS in place; if it were missing
+// or relaxed, that test still passes but cross-model wouldn't error.

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -306,6 +306,22 @@ b.save_partial(&["status"], &pool).await?;
 
 **Auto-PK note.** `save_partial` is UPDATE-only; calling it on an `Auto::Unset` PK is a user error (use `insert_pool` / `save_pool` for that case). Unlike `save_pool` which auto-dispatches `Unset → insert_pool`, this method assumes you've already inserted.
 
+### Typed-column variant — `save_partial_typed((Cols, ...), &pool)`
+
+Issue #67. The string-keyed shape works for dynamic field lists (admin / API payloads); when the field list is static, `save_partial_typed` catches typos and renames at **compile time**:
+
+```rust
+post.save_partial_typed((Post::title, Post::slug), &pool).await?;
+//                       ──────────  ──────────
+//                       title_col   slug_col   ← distinct ZSTs
+```
+
+Each `Post::<field>` is its own zero-sized type — a homogeneous slice (`&[Post::title, Post::slug]`) doesn't type-check in Rust, so the API takes a **tuple** instead. Single-field calls use the trailing-comma idiom: `(Post::title,)`. Tuples are supported from arity 1 up to 12 — past that, drop to `save_partial(&[&str], _)`.
+
+Cross-model tuples are a **compile error** — `(Post::title, Author::name)` fails the `TypedFieldList<Post>` trait bound because `Author::name`'s `Column::Model = Author`. This is the headline value over the string-keyed shape: rename refactors on a column name surface at the typed call site, not at runtime.
+
+Internally lowers to `save_partial` — same audit narrowing, same `Auto::Unset` constraint, same empty-list no-op semantic.
+
 ---
 
 ## Bulk operations


### PR DESCRIPTION
## Summary

Resurrects the orphaned work from PR #92. Issue #67 was implemented but its PR was based on the `issue-66-save-pool-update-fields` feature branch, so when issue #66 was squash-merged via PR #91 the typed-variant commit was stranded — issue #67 stayed open on GitHub even though the code existed.

This PR cherry-picks the original commit (`588f24b`) cleanly onto current main. Code, design, and tests are unchanged from the original work.

## What

Typed-column counterpart to `save_partial` (#66). The string-keyed shape stays for dynamic field lists; this variant catches typos and renames at compile time when the list is static.

```rust
post.save_partial_typed((Post::title, Post::slug), &pool).await?;
```

New `core::TypedFieldList<M: Model>` sealed trait with implementations for tuples of arity 1..=12. The macro emits `save_partial_typed<L: TypedFieldList<Self>>` which reduces the tuple to `&[&str]` via `rust_field_names()` and forwards to the existing `save_partial` path. Audit narrowing flows through the same machinery — no audit-specific work needed.

`(Post::title, Author::name)` fails the `TypedFieldList<Post>` bound at compile time.

## Test plan

- [x] `cargo test --workspace --all-features --no-run` compiles clean
- [x] `cargo test --test save_partial_typed --features sqlite` — 3/3 pass (typed_field_list_returns_rust_field_names, single_field_tuple_narrows_update, multi_field_tuple_narrows_update)
- [ ] CI: `postgres_test`, `sqlite_live`, `mysql_live`, `clippy`, `fmt`, `doc`, `deny`