### PR TITLE
feat: gate Expr::Aggregate emission to aggregate-accepting slots (closes #88)

### DIFF
--- a/crates/rustango/src/sql/error.rs
+++ b/crates/rustango/src/sql/error.rs
@@ -172,6 +172,27 @@ pub enum SqlError {
     )]
     OuterRefOutsideSubquery { column: &'static str },
 
+    /// `Expr::Aggregate(...)` was emitted in a SQL slot that doesn't
+    /// allow aggregate function calls (issue #88). Every dialect
+    /// (PG, MySQL, SQLite) rejects aggregates in `WHERE` /
+    /// `UPDATE SET` / `JOIN ON` / `GROUP BY` / `RETURNING` /
+    /// non-aggregate `SELECT` projections; only `HAVING`, the SELECT
+    /// list of an aggregating query, and that query's `ORDER BY`
+    /// are valid homes for an aggregate call. The writer enforces
+    /// this upfront with a clear error rather than passing the SQL
+    /// through to the database, which would surface a less
+    /// helpful "aggregate functions are not allowed in WHERE" or
+    /// equivalent. Programming error — restructure the query to
+    /// reference an aggregate annotation alias via the auto-routing
+    /// `QuerySet::filter(...)` (which goes to HAVING) or move the
+    /// aggregate to the SELECT list.
+    #[error(
+        "`Expr::Aggregate(...)` used outside of an aggregate-accepting \
+         SQL slot — aggregates may only appear in SELECT projection, \
+         HAVING predicate, or ORDER BY of an aggregating query"
+    )]
+    AggregateOutsideAggregateContext,
+
     /// A JOIN was constructed with an empty `on` predicate
     /// (`WhereExpr::And(vec![])` — the legitimate "no WHERE filter"
     /// marker at the top of an UPDATE/DELETE/SELECT). Inside a JOIN's

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -47,6 +47,14 @@ pub(super) struct Sql<'d> {
     /// Unset everywhere else for backward compatibility with top-level
     /// WHERE / UPDATE-SET emission shapes.
     pub current_qualify_alias: Option<&'static str>,
+    /// Issue #88 — whether `Expr::Aggregate` is allowed in the current
+    /// emission context. Set to `true` only while writing the SELECT
+    /// projection / HAVING predicate / ORDER BY of an aggregating
+    /// query (where SQL natively accepts an aggregate call); `false`
+    /// everywhere else (WHERE / UPDATE-SET / JOIN-ON / GROUP-BY /
+    /// RETURNING / non-aggregate-SELECT). Mirrors the runtime gate
+    /// `SqlError::OuterRefOutsideSubquery` uses for `Expr::OuterRef`.
+    pub aggregate_allowed: bool,
 }
 
 impl<'d> Sql<'d> {
@@ -57,6 +65,7 @@ impl<'d> Sql<'d> {
             params: Vec::new(),
             scope_stack: Vec::new(),
             current_qualify_alias: None,
+            aggregate_allowed: false,
         }
     }
 
@@ -67,6 +76,7 @@ impl<'d> Sql<'d> {
             params: Vec::with_capacity(cap),
             scope_stack: Vec::new(),
             current_qualify_alias: None,
+            aggregate_allowed: false,
         }
     }
 
@@ -298,10 +308,24 @@ fn write_aggregate_inner(b: &mut Sql<'_>, query: &AggregateQuery) -> Result<(), 
 
     if let Some(having) = &query.having {
         b.sql.push_str(" HAVING ");
-        write_where_expr(b, having, None, Some(query.model))?;
+        // Issue #88 — `Expr::Aggregate` lhs of a HAVING predicate is its
+        // natural home. Toggle the gate on for the predicate, restore
+        // after so nested subqueries don't inherit permission.
+        let prev = b.aggregate_allowed;
+        b.aggregate_allowed = true;
+        let r = write_where_expr(b, having, None, Some(query.model));
+        b.aggregate_allowed = prev;
+        r?;
     }
 
-    write_order_limit_offset(b, &query.order_by, query.limit, query.offset, None)?;
+    // Issue #88 — aggregating queries are allowed to ORDER BY an
+    // aggregate expression (`ORDER BY COUNT(*) DESC`). Plain SELECT's
+    // ORDER BY keeps the default `false` and rejects `Expr::Aggregate`.
+    let prev = b.aggregate_allowed;
+    b.aggregate_allowed = true;
+    let r = write_order_limit_offset(b, &query.order_by, query.limit, query.offset, None);
+    b.aggregate_allowed = prev;
+    r?;
 
     Ok(())
 }
@@ -896,8 +920,18 @@ fn write_expr(
             // `(SELECT … FROM …)` — write_select pushes/pops its own
             // scope frame so any nested OuterRef inside `inner` looks
             // up the right enclosing model.
+            //
+            // Issue #88 — subqueries today carry a plain `SelectQuery`
+            // (not an aggregating one), so any `Expr::Aggregate` inside
+            // the inner SELECT's projection / WHERE / ORDER BY would
+            // be in a non-aggregate context. Force the gate off across
+            // the boundary so the outer's permission doesn't leak in.
             b.sql.push('(');
-            write_select(b, inner)?;
+            let prev = b.aggregate_allowed;
+            b.aggregate_allowed = false;
+            let r = write_select(b, inner);
+            b.aggregate_allowed = prev;
+            r?;
             b.sql.push(')');
             Ok(())
         }
@@ -926,6 +960,15 @@ fn write_expr(
         }
         Expr::Window(w) => write_window_expr(b, w),
         Expr::Aggregate(agg) => {
+            // Issue #88 — refuse to emit an aggregate call into a SQL
+            // slot that doesn't accept one. Every backend rejects
+            // aggregates in WHERE / UPDATE-SET / JOIN-ON / GROUP-BY /
+            // RETURNING / non-aggregate SELECT lists; only HAVING,
+            // an aggregating SELECT's projection, and that query's
+            // ORDER BY toggle the gate on (see `write_aggregate_inner`).
+            if !b.aggregate_allowed {
+                return Err(SqlError::AggregateOutsideAggregateContext);
+            }
             // Issue #74 — lift the aggregate expression into the
             // current writer scope (e.g., a HAVING predicate's lhs).
             // The Aggregate writer handles dialect casting + filter

--- a/crates/rustango/tests/aggregate_context_gate.rs
+++ b/crates/rustango/tests/aggregate_context_gate.rs
@@ -1,0 +1,266 @@
+//! Issue #88 — the writer's context gate for `Expr::Aggregate`.
+//!
+//! `Expr::Aggregate(...)` is composable into any Expr slot at the type
+//! level, but every SQL backend rejects aggregate calls in
+//! WHERE / UPDATE-SET / JOIN-ON / GROUP-BY / RETURNING / non-aggregating
+//! SELECT projections. The writer surfaces the error upfront with
+//! `SqlError::AggregateOutsideAggregateContext` rather than passing
+//! through to the DB.
+//!
+//! These tests pin the contract on both sides:
+//!   1. allowed slots (HAVING, aggregating ORDER BY) still emit cleanly
+//!   2. forbidden slots (UPDATE SET, plain WHERE, subquery WHERE, etc.)
+//!      surface the typed error before SQL leaves the writer
+//!
+//! Tri-dialect: the gate is enforced equally across PG / MySQL /
+//! SQLite — the underlying SQL standard rejection is universal.
+
+use rustango::core::aggregates::count_all;
+use rustango::core::{Column as _, Expr, Op, OrderItem};
+use rustango::sql::{Dialect, MySql, Postgres, SqlError, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "acg_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+    pub author_id: i64,
+    #[rustango(max_length = 20)]
+    pub status: String,
+    pub views: i64,
+}
+
+/// Build an aggregate IR expression directly — bypassing the public
+/// builder so we can drop the bare `Expr::Aggregate` into normally-
+/// forbidden slots.
+fn count_aggregate_expr() -> Expr {
+    Expr::Aggregate(Box::new(rustango::core::AggregateExpr::Count(None)))
+}
+
+// ---------- allowed: HAVING predicate (regression for #74) ----------
+
+#[test]
+fn aggregate_in_having_compiles_on_every_dialect() {
+    // Sanity: the existing #74 HAVING path still emits clean SQL after
+    // the gate landed. `filter("alias", Op::Gt, …)` after aggregating
+    // `.annotate("c", …)` routes to HAVING through the builder's
+    // annotation-alias detection.
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("c", count_all().into())
+        .filter("c", Op::Gt, 5_i64)
+        .compile()
+        .unwrap();
+    for d in &[
+        &Postgres as &dyn Dialect,
+        &MySql as &dyn Dialect,
+        &Sqlite as &dyn Dialect,
+    ] {
+        let stmt = d.compile_aggregate(&q).expect("HAVING emit should succeed");
+        assert!(
+            stmt.sql.contains(" HAVING "),
+            "{}: expected HAVING in {}",
+            d.name(),
+            stmt.sql
+        );
+    }
+}
+
+// ---------- allowed: ORDER BY on an aggregating query ----------
+
+#[test]
+fn aggregate_in_aggregating_order_by_compiles() {
+    // `ORDER BY COUNT(*) DESC` is valid SQL when the query aggregates.
+    // The gate flips on around the aggregating query's ORDER BY emit.
+    let mut q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("c", count_all().into())
+        .compile()
+        .unwrap();
+    q.order_by = vec![OrderItem::expr(count_aggregate_expr(), true)];
+
+    for d in &[
+        &Postgres as &dyn Dialect,
+        &MySql as &dyn Dialect,
+        &Sqlite as &dyn Dialect,
+    ] {
+        let stmt = d
+            .compile_aggregate(&q)
+            .expect("aggregating ORDER BY with an aggregate Expr should compile");
+        assert!(
+            stmt.sql.contains(" ORDER BY "),
+            "{}: expected ORDER BY in {}",
+            d.name(),
+            stmt.sql
+        );
+        assert!(
+            stmt.sql.contains("COUNT(*)"),
+            "{}: expected COUNT(*) in ORDER BY position: {}",
+            d.name(),
+            stmt.sql
+        );
+    }
+}
+
+// ---------- forbidden: UPDATE SET ----------
+
+#[test]
+fn aggregate_in_update_set_value_is_rejected() {
+    // `UPDATE t SET col = COUNT(*) WHERE ...` — every backend rejects
+    // this; we catch it upfront.
+    let q = Post::objects()
+        .update()
+        .set_expr("views", count_aggregate_expr())
+        .compile()
+        .unwrap();
+    for d in &[
+        &Postgres as &dyn Dialect,
+        &MySql as &dyn Dialect,
+        &Sqlite as &dyn Dialect,
+    ] {
+        let r = d.compile_update(&q);
+        assert!(
+            matches!(r, Err(SqlError::AggregateOutsideAggregateContext)),
+            "{}: expected AggregateOutsideAggregateContext, got {:?}",
+            d.name(),
+            r
+        );
+    }
+}
+
+// ---------- forbidden: plain WHERE ----------
+
+#[test]
+fn aggregate_in_select_where_is_rejected() {
+    // `SELECT … FROM t WHERE COUNT(*) > 5` — invalid; aggregates
+    // belong in HAVING, not WHERE. Same rejection on every backend.
+    let q = Post::objects()
+        .where_(Post::views.eq_expr(count_aggregate_expr()))
+        .compile()
+        .unwrap();
+    for d in &[
+        &Postgres as &dyn Dialect,
+        &MySql as &dyn Dialect,
+        &Sqlite as &dyn Dialect,
+    ] {
+        let r = d.compile_select(&q);
+        assert!(
+            matches!(r, Err(SqlError::AggregateOutsideAggregateContext)),
+            "{}: expected AggregateOutsideAggregateContext, got {:?}",
+            d.name(),
+            r
+        );
+    }
+}
+
+// ---------- forbidden: AggregateQuery's WHERE (pre-GROUP-BY filter) ----------
+
+#[test]
+fn aggregate_in_aggregate_query_where_is_rejected() {
+    // Aggregating queries also use WHERE for pre-grouping row filters
+    // — aggregates there are illegal (same SQL-standard reason).
+    // The gate stays off for WHERE even when the surrounding query
+    // aggregates.
+    let mut q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("c", count_all().into())
+        .compile()
+        .unwrap();
+    q.where_clause = rustango::core::WhereExpr::Predicate(rustango::core::Filter {
+        column: "views",
+        op: Op::Eq,
+        value: rustango::core::SqlValue::Null,
+    });
+    // Stash an aggregate inside the WHERE via a ColumnCompare predicate.
+    q.where_clause = rustango::core::WhereExpr::ColumnCompare(rustango::core::ColumnFilter {
+        column: "views",
+        op: Op::Eq,
+        rhs: count_aggregate_expr(),
+    });
+    for d in &[
+        &Postgres as &dyn Dialect,
+        &MySql as &dyn Dialect,
+        &Sqlite as &dyn Dialect,
+    ] {
+        let r = d.compile_aggregate(&q);
+        assert!(
+            matches!(r, Err(SqlError::AggregateOutsideAggregateContext)),
+            "{}: expected AggregateOutsideAggregateContext, got {:?}",
+            d.name(),
+            r
+        );
+    }
+}
+
+// ---------- forbidden: ORDER BY of a non-aggregating SELECT ----------
+
+#[test]
+fn aggregate_in_plain_select_order_by_is_rejected() {
+    // `SELECT … FROM t ORDER BY COUNT(*) DESC` without GROUP BY /
+    // aggregating annotation is also rejected by every backend.
+    let mut q = Post::objects().compile().unwrap();
+    q.order_by = vec![OrderItem::expr(count_aggregate_expr(), true)];
+
+    for d in &[
+        &Postgres as &dyn Dialect,
+        &MySql as &dyn Dialect,
+        &Sqlite as &dyn Dialect,
+    ] {
+        let r = d.compile_select(&q);
+        assert!(
+            matches!(r, Err(SqlError::AggregateOutsideAggregateContext)),
+            "{}: expected AggregateOutsideAggregateContext, got {:?}",
+            d.name(),
+            r
+        );
+    }
+}
+
+// ---------- gate doesn't leak into a subquery ----------
+
+#[test]
+fn aggregate_in_subquery_where_is_rejected_even_inside_having() {
+    // Build a HAVING predicate whose RHS is a correlated subquery
+    // whose WHERE contains an `Expr::Aggregate`. The outer HAVING
+    // toggles the gate on for ITS body — but crossing into the
+    // subquery must restore it to off, so the inner WHERE's
+    // aggregate is correctly refused.
+    let inner = Post::objects()
+        .where_(Post::views.eq_expr(count_aggregate_expr()))
+        .compile()
+        .unwrap();
+    let mut q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("c", count_all().into())
+        .compile()
+        .unwrap();
+    // Hand-build a HAVING that references the subquery — the only
+    // way to be sure the gate's stack discipline holds across the
+    // SELECT-subquery boundary.
+    q.having = Some(rustango::core::WhereExpr::ColumnCompare(
+        rustango::core::ColumnFilter {
+            column: "c",
+            op: Op::Eq,
+            rhs: Expr::Subquery(Box::new(inner)),
+        },
+    ));
+    for d in &[
+        &Postgres as &dyn Dialect,
+        &MySql as &dyn Dialect,
+        &Sqlite as &dyn Dialect,
+    ] {
+        let r = d.compile_aggregate(&q);
+        assert!(
+            matches!(r, Err(SqlError::AggregateOutsideAggregateContext)),
+            "{}: subquery WHERE inside HAVING should still reject aggregate, got {:?}",
+            d.name(),
+            r
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds the writer-side context gate from issue #88 (Level A). PR #86 introduced `Expr::Aggregate(...)` so aggregate calls fit inside HAVING predicates, but the variant composes into UPDATE SET / WHERE / JOIN ON / GROUP BY / RETURNING just as cleanly — every backend rejects those at execute with opaque errors like ` aggregate functions are not allowed in WHERE`. The writer now surfaces the error upfront with a typed message that points at the right path.

Same posture as `SqlError::OuterRefOutsideSubquery` for issue #5.

## Changes

- New flag `Sql<'_>::aggregate_allowed` (default `false`).
- `write_aggregate_inner` flips it on around HAVING and the aggregating query's ORDER BY emit, restoring after.
- `Expr::Subquery` saves + forces `false` across the SELECT-subquery boundary so the outer's permission doesn't leak inward.
- `write_expr`'s `Expr::Aggregate` arm checks the flag, returns `SqlError::AggregateOutsideAggregateContext` if unset.

## Test plan

[tests/aggregate_context_gate.rs](crates/rustango/tests/aggregate_context_gate.rs) — 7 tri-dialect tests pin both sides:

| Test | Slot | Expected |
|---|---|---|
| `aggregate_in_having_compiles_on_every_dialect` | HAVING | allowed (regression for #74) |
| `aggregate_in_aggregating_order_by_compiles` | aggregating ORDER BY | allowed |
| `aggregate_in_update_set_value_is_rejected` | UPDATE SET | `AggregateOutsideAggregateContext` |
| `aggregate_in_select_where_is_rejected` | plain SELECT WHERE | `AggregateOutsideAggregateContext` |
| `aggregate_in_aggregate_query_where_is_rejected` | AggregateQuery WHERE | `AggregateOutsideAggregateContext` |
| `aggregate_in_plain_select_order_by_is_rejected` | non-aggregating ORDER BY | `AggregateOutsideAggregateContext` |
| `aggregate_in_subquery_where_is_rejected_even_inside_having` | subquery WHERE nested under HAVING | `AggregateOutsideAggregateContext` (gate doesn't leak) |

- [x] `cargo test --test aggregate_context_gate --features sqlite,postgres,mysql` — 7/7 pass
- [x] `cargo test --test having_auto_routing --features sqlite,postgres,mysql` — 15/15 pass (no regression for #74)
- [x] `cargo test --test aggregate_filter --features sqlite,postgres,mysql` — 24/24 pass (no regression for #6)
- [x] `cargo test --workspace --all-features --no-run` compiles clean
- [ ] CI: postgres_test, sqlite_live, mysql_live, sqlite_litmus, fmt, clippy, doc, deny

## Level B deferred

A trait-bound on every Expr-accepting slot (`ScalarExpr` for all variants except `Aggregate`/`Window`) is tighter but invasive — every `set_expr` / `eq_expr` / `where_` signature changes. Runtime gate is sufficient for v1, matches the existing #5 posture, and can be tightened later without breaking callers.