### PR TITLE
feat: richer HAVING ops on annotation aliases (closes #87)

### DIFF
--- a/crates/rustango/src/core/error.rs
+++ b/crates/rustango/src/core/error.rs
@@ -47,22 +47,23 @@ pub enum QueryError {
     },
 
     /// `AggregateBuilder::filter(alias, op, value)` was called with
-    /// an `op` outside the binary-comparison set (`Eq`/`Ne`/`Lt`/
-    /// `Lte`/`Gt`/`Gte`) — but the alias resolves to an aggregate
-    /// annotation, so the predicate would be routed to `HAVING`
-    /// via [`crate::core::WhereExpr::ExprCompare`], which today
-    /// only supports binary comparisons. Issue #74 v1.
+    /// an `op` that doesn't compose against an aggregate LHS via
+    /// [`crate::core::WhereExpr::ExprCompare`]. After issue #87,
+    /// the supported set is the binary-comparison ops (`Eq`/`Ne`/
+    /// `Lt`/`Lte`/`Gt`/`Gte`) plus the SQL-92 standard predicates
+    /// (`In`/`NotIn`, `Between`, `IsNull`, `Like`/`NotLike`,
+    /// `ILike`/`NotILike`). The JSON-op family + null-safe equality
+    /// (`IsDistinctFrom` / `IsNotDistinctFrom`) still need
+    /// dialect-specific writers that take a `&str` for the LHS,
+    /// so they're rejected here.
     ///
-    /// Use [`crate::query::AggregateBuilder::having`] with a
-    /// pre-built `WhereExpr` (e.g. an `Or`-tree of equalities for
-    /// the `Op::In` shape) until richer ExprCompare-with-Aggregate
-    /// dispatch lands as a v0.50 follow-up.
+    /// Drop into [`crate::query::AggregateBuilder::having`] with a
+    /// pre-built `WhereExpr` if you really need one of the
+    /// remaining ops against an aggregate.
     #[error(
-        "HAVING auto-routing for annotation alias `{alias}` supports only \
-         binary-comparison ops (Eq / Ne / Lt / Lte / Gt / Gte); got {op:?}. \
-         For `IN` / `BETWEEN` / `IS NULL` / `LIKE` / etc. against an \
-         aggregate, build a `WhereExpr` directly and pass it through \
-         `AggregateBuilder::having`."
+        "HAVING auto-routing for annotation alias `{alias}` doesn't support \
+         {op:?} (JSON-op family + null-safe equality). Build a `WhereExpr` \
+         directly and pass it through `AggregateBuilder::having`."
     )]
     HavingOpNotSupported { alias: String, op: super::Op },
 

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1190,11 +1190,15 @@ pub struct AggregateBuilder<T: Model> {
     limit: Option<i64>,
     offset: Option<i64>,
     /// Issue #74 — deferred error surfacing for builder-time
-    /// validation failures (e.g. `.filter(alias, Op::In, …)` against
-    /// an annotation alias, which the auto-routing rejects because
-    /// ExprCompare doesn't support `IN`/`BETWEEN`/etc. yet). Stored
-    /// on first error; subsequent builder calls are no-ops so the
-    /// original cause isn't masked. Surfaced from `compile()`.
+    /// validation failures (e.g. `.filter(alias, Op::JsonContains, …)`
+    /// against an annotation alias, which the auto-routing rejects
+    /// because the JSON-op family + null-safe equality need
+    /// dialect-specific writers that don't compose against an
+    /// aggregate LHS). Stored on first error; subsequent builder
+    /// calls are no-ops so the original cause isn't masked. Surfaced
+    /// from `compile()`. (Issue #87 widened the supported op set to
+    /// include `IN`/`BETWEEN`/`IS NULL`/`LIKE`/`ILIKE` + negated
+    /// variants.)
     deferred_error: Option<crate::core::QueryError>,
     /// Issue #75 — projection columns set via [`Self::values`] (or
     /// [`QuerySet::values`]). When `Some(cols)` and the user hasn't
@@ -1299,19 +1303,23 @@ impl<T: Model> AggregateBuilder<T> {
             .find(|(alias, _)| *alias == field)
             .map(|(_, expr)| expr.clone());
         if let Some(agg) = agg {
-            // v1 limitation: `ExprCompare` only emits binary
-            // comparison ops. `Op::In`/`Between`/`IsNull`/`Like`/etc.
-            // would emit garbage SQL via the existing writer, so
-            // catch the misuse at builder time with a message that
-            // points at the workaround (typed `.having(WhereExpr)`).
-            if !matches!(
+            // Issue #87 — `write_expr_compare` now handles the SQL-92
+            // standard predicates that compose against an aggregate
+            // LHS (`IN` / `NOT IN` / `BETWEEN` / `IS NULL` / `LIKE` /
+            // `NOT LIKE` / `ILIKE` / `NOT ILIKE`) in addition to the
+            // binary-comparison set. JSON ops and null-safe equality
+            // (`IS DISTINCT FROM` / `IS NOT DISTINCT FROM`) still
+            // need dialect-specific writers that take a `&str` for
+            // the LHS, so they keep rejecting with the targeted error.
+            if matches!(
                 op,
-                crate::core::Op::Eq
-                    | crate::core::Op::Ne
-                    | crate::core::Op::Lt
-                    | crate::core::Op::Lte
-                    | crate::core::Op::Gt
-                    | crate::core::Op::Gte
+                crate::core::Op::JsonContains
+                    | crate::core::Op::JsonContainedBy
+                    | crate::core::Op::JsonHasKey
+                    | crate::core::Op::JsonHasAnyKey
+                    | crate::core::Op::JsonHasAllKeys
+                    | crate::core::Op::IsDistinctFrom
+                    | crate::core::Op::IsNotDistinctFrom
             ) {
                 self.deferred_error = Some(crate::core::QueryError::HavingOpNotSupported {
                     alias: field.to_owned(),

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -1786,34 +1786,128 @@ pub(super) fn write_where_expr(
 }
 
 /// Emit `<lhs-expr> <op> <rhs-expr>` for [`WhereExpr::ExprCompare`].
-/// Only the binary-comparison ops make sense here — anything else is
-/// a programmer error and surfaces as
-/// [`SqlError::OpNotSupportedInDialect`] so the test suite catches it
-/// before reaching the database.
+///
+/// Covers the binary-comparison set (`Eq`/`Ne`/`Lt`/`Lte`/`Gt`/`Gte`)
+/// plus the SQL-92 standard predicates that work uniformly across
+/// every dialect inside HAVING: `IN`/`NOT IN`, `BETWEEN`, `IS NULL`/
+/// `IS NOT NULL`, `LIKE`/`NOT LIKE`. The Postgres-specific case-
+/// insensitive `ILIKE`/`NOT ILIKE` route through the dialect's
+/// `write_ilike` helper so non-PG backends fall back to `LOWER()` +
+/// `LIKE` shape automatically (issue #87).
+///
+/// JSON ops (`JsonContains` / `JsonHasKey` / etc.) and null-safe
+/// equality (`IsDistinctFrom` / `IsNotDistinctFrom`) aren't supported
+/// against an aggregate LHS — those need dialect-specific writers
+/// that take a `&str` for the LHS. The `AggregateBuilder::filter`
+/// gate rejects them at build time with [`crate::core::QueryError::HavingOpNotSupported`]
+/// so the misuse surfaces with a clear message rather than as a
+/// raw dialect error here.
 fn write_expr_compare(
     b: &mut Sql<'_>,
     lhs: &crate::core::Expr,
     op: crate::core::Op,
     rhs: &crate::core::Expr,
 ) -> Result<(), SqlError> {
-    let op_str = match op {
-        crate::core::Op::Eq => " = ",
-        crate::core::Op::Ne => " <> ",
-        crate::core::Op::Lt => " < ",
-        crate::core::Op::Lte => " <= ",
-        crate::core::Op::Gt => " > ",
-        crate::core::Op::Gte => " >= ",
-        _ => {
-            return Err(SqlError::OpNotSupportedInDialect {
-                op: "non-binary comparison in ExprCompare",
-                dialect: b.d.name(),
-            });
-        }
+    use crate::core::{Expr, Op};
+
+    let binary_op_str = match op {
+        Op::Eq => Some(" = "),
+        Op::Ne => Some(" <> "),
+        Op::Lt => Some(" < "),
+        Op::Lte => Some(" <= "),
+        Op::Gt => Some(" > "),
+        Op::Gte => Some(" >= "),
+        Op::Like => Some(" LIKE "),
+        Op::NotLike => Some(" NOT LIKE "),
+        _ => None,
     };
-    write_expr(b, lhs, None)?;
-    b.sql.push_str(op_str);
-    write_expr(b, rhs, None)?;
-    Ok(())
+    if let Some(kw) = binary_op_str {
+        write_expr(b, lhs, None)?;
+        b.sql.push_str(kw);
+        write_expr(b, rhs, None)?;
+        return Ok(());
+    }
+
+    match op {
+        Op::ILike | Op::NotILike => {
+            require_op(b.d, op)?;
+            // Render lhs first so its params land in the param vector
+            // before the rhs literal — keeps `?`-positional dialects
+            // (MySQL / SQLite) in textual order. Then carve the lhs
+            // SQL out of the buffer, bind the rhs as a string param,
+            // and ask the dialect to compose `LOWER(<lhs>) LIKE
+            // LOWER(<p>)` (or PG's native `ILIKE`).
+            let lhs_start = b.sql.len();
+            write_expr(b, lhs, None)?;
+            let lhs_str = b.sql.split_off(lhs_start);
+            let Expr::Literal(v) = rhs else {
+                return Err(SqlError::OpNotSupportedInDialect {
+                    op: "ILIKE with non-literal RHS in ExprCompare",
+                    dialect: b.d.name(),
+                });
+            };
+            b.params.push(v.clone());
+            let p = b.d.placeholder(b.params.len());
+            b.d.write_ilike(&mut b.sql, &lhs_str, &p, matches!(op, Op::NotILike));
+            Ok(())
+        }
+        Op::In | Op::NotIn => {
+            let Expr::Literal(SqlValue::List(elements)) = rhs else {
+                return Err(SqlError::InRequiresList);
+            };
+            if elements.is_empty() {
+                return Err(SqlError::EmptyInList);
+            }
+            write_expr(b, lhs, None)?;
+            b.sql.push_str(if matches!(op, Op::In) {
+                " IN ("
+            } else {
+                " NOT IN ("
+            });
+            let mut first = true;
+            for elem in elements {
+                if !first {
+                    b.sql.push_str(", ");
+                }
+                first = false;
+                b.push_param_typed(elem.clone(), None);
+            }
+            b.sql.push(')');
+            Ok(())
+        }
+        Op::Between => {
+            let Expr::Literal(SqlValue::List(bounds)) = rhs else {
+                return Err(SqlError::BetweenRequiresTwoElementList);
+            };
+            if bounds.len() != 2 {
+                return Err(SqlError::BetweenRequiresTwoElementList);
+            }
+            write_expr(b, lhs, None)?;
+            b.sql.push_str(" BETWEEN ");
+            b.push_param_typed(bounds[0].clone(), None);
+            b.sql.push_str(" AND ");
+            b.push_param_typed(bounds[1].clone(), None);
+            Ok(())
+        }
+        Op::IsNull => {
+            let Expr::Literal(SqlValue::Bool(is_null)) = rhs else {
+                return Err(SqlError::IsNullRequiresBool);
+            };
+            write_expr(b, lhs, None)?;
+            b.sql
+                .push_str(if *is_null { " IS NULL" } else { " IS NOT NULL" });
+            Ok(())
+        }
+        // JSON-op family + IsDistinctFrom / IsNotDistinctFrom — the
+        // AggregateBuilder::filter gate rejects these at build time
+        // with `HavingOpNotSupported`. If we reach here, someone
+        // hand-built an `ExprCompare` with one of these ops directly;
+        // surface the same shape of error as before.
+        _ => Err(SqlError::OpNotSupportedInDialect {
+            op: "non-binary comparison in ExprCompare",
+            dialect: b.d.name(),
+        }),
+    }
 }
 
 /// Render `<col> <op> <rhs-expr>` for a [`crate::core::ColumnFilter`].

--- a/crates/rustango/tests/having_auto_routing.rs
+++ b/crates/rustango/tests/having_auto_routing.rs
@@ -203,40 +203,59 @@ fn sqlite_emits_having_with_double_quotes() {
     );
 }
 
-// ---------- Op validation: alias + non-binary op rejected at compile() ----------
+// ---------- Richer ops on alias-routed filter (issue #87) ----------
 
-/// `Op::In` against an annotation alias is rejected at `compile()`
-/// with a clear `HavingOpNotSupported` error. v1 limitation —
-/// ExprCompare only emits binary comparison ops; richer dispatch is
-/// queued for v0.50. Pre-fix this surfaced as a cryptic
-/// `OpNotSupportedInDialect { op: "non-binary comparison in ExprCompare" }`
-/// at SQL-emit time.
+/// `Op::In` against an annotation alias emits `HAVING <agg> IN ($1, $2, …)`.
+/// Pre-#87 this rejected at `compile()` with `HavingOpNotSupported`.
 #[test]
-fn op_in_against_alias_rejected_at_compile() {
+fn op_in_against_alias_emits_having_in() {
     use rustango::core::SqlValue;
-    let r = Post::objects()
+    let q = Post::objects()
         .aggregate()
         .group_by("author_id")
         .annotate("post_count", count_all().into())
         .filter(
             "post_count",
             Op::In,
-            SqlValue::List(vec![SqlValue::I64(5), SqlValue::I64(10)]),
+            SqlValue::List(vec![SqlValue::I64(5), SqlValue::I64(10), SqlValue::I64(20)]),
         )
-        .compile();
-    match r {
-        Err(rustango::core::QueryError::HavingOpNotSupported { alias, op }) => {
-            assert_eq!(alias, "post_count");
-            assert_eq!(op, Op::In);
-        }
-        other => panic!("expected HavingOpNotSupported, got {other:?}"),
-    }
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains("HAVING COUNT(*) IN ($1, $2, $3)"),
+        "PG: HAVING aggregate IN (...): {}",
+        stmt.sql
+    );
+    assert_eq!(stmt.params.len(), 3);
 }
 
 #[test]
-fn op_between_against_alias_rejected_at_compile() {
+fn op_not_in_against_alias_emits_having_not_in() {
     use rustango::core::SqlValue;
-    let r = Post::objects()
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("post_count", count_all().into())
+        .filter(
+            "post_count",
+            Op::NotIn,
+            SqlValue::List(vec![SqlValue::I64(0), SqlValue::I64(1)]),
+        )
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains("HAVING COUNT(*) NOT IN ($1, $2)"),
+        "PG: HAVING aggregate NOT IN (...): {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn op_between_against_alias_emits_having_between() {
+    use rustango::core::SqlValue;
+    let q = Post::objects()
         .aggregate()
         .group_by("author_id")
         .annotate("post_count", count_all().into())
@@ -245,42 +264,214 @@ fn op_between_against_alias_rejected_at_compile() {
             Op::Between,
             SqlValue::List(vec![SqlValue::I64(5), SqlValue::I64(10)]),
         )
-        .compile();
-    assert!(matches!(
-        r,
-        Err(rustango::core::QueryError::HavingOpNotSupported {
-            alias,
-            op: Op::Between
-        }) if alias == "post_count"
-    ));
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains("HAVING COUNT(*) BETWEEN $1 AND $2"),
+        "PG: HAVING aggregate BETWEEN ...: {}",
+        stmt.sql
+    );
+    assert_eq!(stmt.params.len(), 2);
 }
 
 #[test]
-fn op_isnull_against_alias_rejected_at_compile() {
+fn op_isnull_against_alias_emits_having_is_null() {
     use rustango::core::SqlValue;
-    let r = Post::objects()
+    let q = Post::objects()
         .aggregate()
         .group_by("author_id")
         .annotate("post_count", count_all().into())
         .filter("post_count", Op::IsNull, SqlValue::Bool(true))
-        .compile();
-    assert!(matches!(
-        r,
-        Err(rustango::core::QueryError::HavingOpNotSupported { op: Op::IsNull, .. })
-    ));
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains("HAVING COUNT(*) IS NULL"),
+        "PG: HAVING aggregate IS NULL: {}",
+        stmt.sql
+    );
+    // No params for IS NULL.
+    assert!(stmt.params.is_empty());
 }
 
 #[test]
-fn op_like_against_alias_rejected_at_compile() {
+fn op_isnull_false_against_alias_emits_having_is_not_null() {
+    use rustango::core::SqlValue;
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("post_count", count_all().into())
+        .filter("post_count", Op::IsNull, SqlValue::Bool(false))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains("HAVING COUNT(*) IS NOT NULL"),
+        "PG: HAVING aggregate IS NOT NULL: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn op_like_against_alias_emits_having_like() {
+    use rustango::core::aggregates::max;
+    // MAX(name) returns a string — LIKE pattern makes sense.
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("max_status", max("status").into())
+        .filter("max_status", Op::Like, "publish%")
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"HAVING MAX("status") LIKE $1"#),
+        "PG: HAVING aggregate LIKE pattern: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn op_not_like_against_alias_emits_having_not_like() {
+    use rustango::core::aggregates::max;
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("max_status", max("status").into())
+        .filter("max_status", Op::NotLike, "draft%")
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"HAVING MAX("status") NOT LIKE $1"#),
+        "PG: HAVING aggregate NOT LIKE pattern: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn op_ilike_against_alias_emits_pg_native_ilike() {
+    use rustango::core::aggregates::max;
+    // PG: native ILIKE — `MAX("status") ILIKE $1`.
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("max_status", max("status").into())
+        .filter("max_status", Op::ILike, "PUBLISH%")
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"HAVING MAX("status") ILIKE $1"#),
+        "PG: HAVING aggregate ILIKE pattern: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn op_ilike_against_alias_falls_back_to_lower_on_mysql() {
+    use rustango::core::aggregates::max;
+    // MySQL has no ILIKE; the writer falls back to LOWER(...) LIKE LOWER(?).
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("max_status", max("status").into())
+        .filter("max_status", Op::ILike, "PUBLISH%")
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql
+            .contains("HAVING LOWER(MAX(`status`)) LIKE LOWER(?)"),
+        "MySQL: HAVING LOWER(agg) LIKE LOWER(?): {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn op_ilike_against_alias_falls_back_to_lower_on_sqlite() {
+    use rustango::core::aggregates::max;
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("max_status", max("status").into())
+        .filter("max_status", Op::ILike, "PUBLISH%")
+        .compile()
+        .unwrap();
+    let stmt = Sqlite.compile_aggregate(&q).unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"HAVING LOWER(MAX("status")) LIKE LOWER(?)"#),
+        "SQLite: HAVING LOWER(agg) LIKE LOWER(?): {}",
+        stmt.sql
+    );
+}
+
+/// Param-order sanity: MySQL uses positional `?`. The lhs aggregate may
+/// carry inner literals (e.g. via `Filtered`); those must bind BEFORE the
+/// `LIKE`/`ILIKE` rhs literal so positional placeholders match the
+/// param vector textually.
+#[test]
+fn ilike_alias_param_order_preserved_for_positional_dialects() {
+    use rustango::core::aggregates::max;
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("max_status", max("status").into())
+        .filter("status", Op::Eq, "published") // WHERE — first param
+        .filter("max_status", Op::ILike, "PUB%") // HAVING — second param
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_aggregate(&q).unwrap();
+    // Two params total; WHERE first, HAVING ILIKE last.
+    assert_eq!(stmt.params.len(), 2);
+    // The `=` placeholder for WHERE appears before the `LIKE LOWER(...)`
+    // placeholder for HAVING in the SQL text.
+    let where_pos = stmt.sql.find("`status` = ?").unwrap();
+    let having_pos = stmt.sql.find("LIKE LOWER(?)").unwrap();
+    assert!(where_pos < having_pos);
+}
+
+/// JSON ops + IsDistinctFrom are still rejected — they need dialect-
+/// specific writers that take a `&str` for the LHS.
+#[test]
+fn json_op_against_alias_still_rejected_at_compile() {
+    use rustango::core::aggregates::max;
+    use rustango::core::SqlValue;
+    let r = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("max_status", max("status").into())
+        .filter(
+            "max_status",
+            Op::JsonContains,
+            SqlValue::Json(serde_json::json!({"key": "value"})),
+        )
+        .compile();
+    match r {
+        Err(rustango::core::QueryError::HavingOpNotSupported { alias, op }) => {
+            assert_eq!(alias, "max_status");
+            assert_eq!(op, Op::JsonContains);
+        }
+        other => panic!("expected HavingOpNotSupported, got {other:?}"),
+    }
+}
+
+#[test]
+fn is_distinct_from_against_alias_still_rejected_at_compile() {
     let r = Post::objects()
         .aggregate()
         .group_by("author_id")
         .annotate("post_count", count_all().into())
-        .filter("post_count", Op::Like, "%foo%")
+        .filter("post_count", Op::IsDistinctFrom, 5_i64)
         .compile();
     assert!(matches!(
         r,
-        Err(rustango::core::QueryError::HavingOpNotSupported { op: Op::Like, .. })
+        Err(rustango::core::QueryError::HavingOpNotSupported {
+            op: Op::IsDistinctFrom,
+            ..
+        })
     ));
 }
 
@@ -311,12 +502,15 @@ fn deferred_error_swallows_subsequent_builder_calls() {
         .aggregate()
         .group_by("author_id")
         .annotate("post_count", count_all().into())
-        .filter("post_count", Op::Like, "junk") // sets deferred error
+        .filter("post_count", Op::IsDistinctFrom, 5_i64) // sets deferred error
         .filter("status", Op::Eq, "published") // should NOT overwrite
         .filter("post_count", Op::Gt, 10_i64) // should NOT overwrite
         .compile();
     match r {
-        Err(rustango::core::QueryError::HavingOpNotSupported { op: Op::Like, .. }) => {}
+        Err(rustango::core::QueryError::HavingOpNotSupported {
+            op: Op::IsDistinctFrom,
+            ..
+        }) => {}
         other => panic!("expected the FIRST error to survive, got {other:?}"),
     }
 }

--- a/crates/rustango/tests/having_auto_routing_live.rs
+++ b/crates/rustango/tests/having_auto_routing_live.rs
@@ -154,6 +154,102 @@ async fn having_only_no_where_clause() {
     cleanup(&pool).await;
 }
 
+/// Issue #87: `Op::In` against an annotation alias.
+/// Authors whose post_count is in {0, 8, 15} → authors 2, 3, 4.
+#[tokio::test]
+async fn op_in_against_alias_routes_to_having_in() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("total_posts", count_all().into())
+        .filter(
+            "total_posts",
+            Op::In,
+            SqlValue::List(vec![SqlValue::I64(10), SqlValue::I64(5), SqlValue::I64(15)]),
+        )
+        .order_by(&[("author_id", false)])
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+
+    let author_ids: Vec<i64> = rows.iter().map(|r| get_i64(r, "author_id")).collect();
+    // Authors 3 (15 posts) and 4 (5 posts) match; 1 has 15 total (matches),
+    // 2 has 10 total (matches). Expected: 1, 2, 3, 4.
+    assert_eq!(author_ids, vec![1, 2, 3, 4]);
+
+    cleanup(&pool).await;
+}
+
+/// Issue #87: `Op::Between` against an annotation alias.
+/// Authors whose total post count is between 6 and 12 inclusive → author 2 (10 posts).
+#[tokio::test]
+async fn op_between_against_alias_routes_to_having_between() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("total_posts", count_all().into())
+        .filter(
+            "total_posts",
+            Op::Between,
+            SqlValue::List(vec![SqlValue::I64(6), SqlValue::I64(12)]),
+        )
+        .order_by(&[("author_id", false)])
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+
+    let author_ids: Vec<i64> = rows.iter().map(|r| get_i64(r, "author_id")).collect();
+    assert_eq!(
+        author_ids,
+        vec![2],
+        "only author 2 has total_posts in [6, 12]; got: {author_ids:?}"
+    );
+
+    cleanup(&pool).await;
+}
+
+/// Issue #87: `Op::NotIn` against an annotation alias.
+/// Authors NOT in {5, 10} → author 1 (15 posts), author 3 (15 posts).
+#[tokio::test]
+async fn op_not_in_against_alias_routes_to_having_not_in() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = Post::objects()
+        .aggregate()
+        .group_by("author_id")
+        .annotate("total_posts", count_all().into())
+        .filter(
+            "total_posts",
+            Op::NotIn,
+            SqlValue::List(vec![SqlValue::I64(5), SqlValue::I64(10)]),
+        )
+        .order_by(&[("author_id", false)])
+        .compile()
+        .unwrap();
+    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+
+    let author_ids: Vec<i64> = rows.iter().map(|r| get_i64(r, "author_id")).collect();
+    assert_eq!(author_ids, vec![1, 3]);
+
+    cleanup(&pool).await;
+}
+
 async fn cleanup(pool: &sqlx::PgPool) {
     sqlx::query(r#"DROP TABLE IF EXISTS "harl_post" CASCADE"#)
         .execute(pool)

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -813,18 +813,30 @@ HAVING COUNT(*) > $2
 
 **Validator gap (matches existing aggregate posture)**: alias-routed HAVING predicates skip the model-schema column walk. Typo'd aliases surface at the database, not at `compile()`. Same gap as `Sum("typo_col")` — pre-existing and orthogonal.
 
-**Supported ops on alias-routed `.filter()`**: only the binary-comparison set — `Op::Eq` / `Ne` / `Lt` / `Lte` / `Gt` / `Gte`. Anything else (`Op::In`, `Op::Between`, `Op::IsNull`, `Op::Like`, `Op::ILike`, the JSON family) rejects at `compile()` with `QueryError::HavingOpNotSupported { alias, op }`. The writer's `ExprCompare` shape only emits binary comparisons; richer dispatch is a v0.50 follow-up. For aggregate-against-list / pattern / null checks, drop into the typed `.having(WhereExpr)` form with a pre-built predicate:
+**Supported ops on alias-routed `.filter()`** (issue #87): the binary-comparison set (`Op::Eq` / `Ne` / `Lt` / `Lte` / `Gt` / `Gte`) **plus** the SQL-92 standard predicates that compose against an aggregate LHS uniformly across every backend — `Op::In` / `NotIn`, `Between`, `IsNull`, `Like` / `NotLike`, `ILike` / `NotILike`. Each emits the predictable shape:
 
 ```rust
-use rustango::core::{Filter, Op, SqlValue, WhereExpr};
+use rustango::core::{Op, SqlValue};
 
-// HAVING COUNT(*) IN (5, 10, 20) — bypass auto-routing, hand-build
-// the OR-tree and pass to .having() directly.
-let inner_or = WhereExpr::Or(vec![
-    /* one ExprCompare per value, or a CASE-WHEN ladder */
-]);
-agg_builder.having_raw(inner_or);   // (where it exists in your code)
+// HAVING COUNT(*) IN ($1, $2, $3)
+Post::objects()
+    .aggregate()
+    .group_by("author_id")
+    .annotate("post_count", count_all().into())
+    .filter("post_count", Op::In, SqlValue::List(vec![5_i64.into(), 10_i64.into(), 20_i64.into()]))
+    .compile()?;
+
+// HAVING COUNT(*) BETWEEN $1 AND $2
+.filter("post_count", Op::Between, SqlValue::List(vec![5_i64.into(), 10_i64.into()]))
+
+// HAVING COUNT(*) IS NULL  /  IS NOT NULL  (bool: true = IS NULL)
+.filter("post_count", Op::IsNull, SqlValue::Bool(false))
+
+// HAVING MAX("name") LIKE $1  /  ILIKE $1 (PG) / LOWER(MAX("name")) LIKE LOWER(?) (MySQL/SQLite)
+.filter("max_name", Op::ILike, "SMITH%")
 ```
+
+The remaining ops — the JSON-op family (`JsonContains` / `JsonContainedBy` / `JsonHasKey` / `JsonHasAnyKey` / `JsonHasAllKeys`) and null-safe equality (`IsDistinctFrom` / `IsNotDistinctFrom`) — still need dialect-specific writers that take a `&str` for the LHS, so they reject at `compile()` with `QueryError::HavingOpNotSupported { alias, op }`. For those, drop into the typed `.having(<TypedExpr>)` form with a pre-built predicate.
 
 **Param-vector bloat with non-trivial aggregates**: when the alias targets a `Filtered { Count, filter: pred }` or `Coalesced { Sum, default: 0 }` annotation, the writer lifts the **whole aggregate expression** into HAVING — including its inner predicates and defaults. Their bound literals get fresh parameter slots in HAVING separate from the SELECT-list emission. Concretely:
 


### PR DESCRIPTION
## Summary

Closes #87. `AggregateBuilder::filter(alias, op, value)` now routes the **SQL-92 standard predicates** to HAVING in addition to the binary-comparison set:

- `Op::In` / `Op::NotIn` — list expansion: `HAVING COUNT(*) IN ($1, $2, $3)`
- `Op::Between` — two-bound: `HAVING COUNT(*) BETWEEN $1 AND $2`
- `Op::IsNull` — bool literal: `HAVING COUNT(*) IS NULL` / `IS NOT NULL`
- `Op::Like` / `Op::NotLike` — standard SQL: `HAVING MAX(\"name\") LIKE $1`
- `Op::ILike` / `Op::NotILike` — PG-native + LOWER-fallback on MySQL/SQLite: `HAVING LOWER(MAX(\"name\")) LIKE LOWER(?)`

Pre-fix these rejected at `compile()` with `QueryError::HavingOpNotSupported` and forced users into a hand-built `WhereExpr` workaround. `HavingOpNotSupported` narrows to the JSON-op family + `IsDistinctFrom`/`IsNotDistinctFrom` — those still need dialect-specific writers that take a `&str` for the LHS.

## What landed

- **[`src/sql/writers.rs`](crates/rustango/src/sql/writers.rs#L1788)** — `write_expr_compare` got op-specific dispatch. The ILIKE branch renders lhs first then binds rhs so positional `?` dialects (MySQL/SQLite) keep textual param order intact when the aggregate carries inner literals (e.g. `Filtered { … }`).
- **[`src/query/mod.rs`](crates/rustango/src/query/mod.rs#L1301)** — `AggregateBuilder::filter` gate now only rejects the JSON family + null-safe equality.
- **[`src/core/error.rs`](crates/rustango/src/core/error.rs#L49)** — `HavingOpNotSupported` doc + error message narrowed.
- **[`docs/orm.md`](docs/orm.md#L816)** — cookbook lists new supported ops with example shapes; workaround text dropped.

## Tests

| Suite | Count | Status |
|---|---|---|
| `tests/having_auto_routing.rs` (tri-dialect emission) | 24 | passing |
| `tests/having_auto_routing_live.rs` (live PG runtime) | 5 | passing |
| `cargo test -p rustango --features tenancy,mysql,sqlite --tests` (full integration) | 1553 | passing |

New SQL-emission tests cover: IN / NOT IN list expansion, BETWEEN two-bound, IS NULL + IS NOT NULL via bool literal, LIKE + NOT LIKE on a string aggregate (`MAX(\"status\")`), ILIKE tri-dialect (PG native, MySQL+SQLite LOWER-fallback), positional-`?` param order sanity for ILIKE + WHERE composition, and confirmation that JSON ops + `IsDistinctFrom` still reject.

New live PG tests pin runtime behaviour for IN, Between, NotIn against a known data shape (15 + 10 + 15 + 5 posts across 4 authors).

## Verification

\`\`\`
cargo test -p rustango --features tenancy,mysql,sqlite --tests   → 1553 passed
DATABASE_URL=... cargo test --features tenancy --test having_auto_routing_live → 5 passed
cargo test --workspace --all-features --no-run                   → clean
cargo build --no-default-features --features sqlite,tenancy      → clean
\`\`\`

## Test plan

- [x] Tri-dialect emission tests pass on PG / MySQL / SQLite shapes.
- [x] Live PG tests confirm runtime semantic.
- [x] Param-order preserved for positional-`?` dialects (MySQL test pins this).
- [x] JSON-op + IsDistinctFrom still rejected at compile.
- [x] Workspace `--all-features --no-run` gate passes.
- [ ] CI green on \`postgres_test\` + \`mysql_live\` + \`sqlite_live\` + \`sqlite_litmus\`.