### PR TITLE
feat: WhereExpr::Xor + TypedExpr::xor() — Django 4.1 Q XOR (closes #27)

### DIFF
--- a/crates/rustango/src/core/column.rs
+++ b/crates/rustango/src/core/column.rs
@@ -271,6 +271,14 @@ impl<M: Model> TypedFilter<M> {
         TypedExpr::from(self).or(rhs)
     }
 
+    /// Compose with another predicate or expression via SQL `XOR` —
+    /// Django 4.1+ `Q(a) ^ Q(b)` (issue #27). Returns a [`TypedExpr`]
+    /// so further `.and()` / `.or()` / `.xor()` calls can chain.
+    #[must_use]
+    pub fn xor<E: Into<TypedExpr<M>>>(self, rhs: E) -> TypedExpr<M> {
+        TypedExpr::from(self).xor(rhs)
+    }
+
     /// Negate this predicate — emits `NOT (col op val)`.
     #[must_use]
     pub fn not(self) -> TypedExpr<M> {
@@ -388,6 +396,36 @@ impl<M: Model> TypedExpr<M> {
                 WhereExpr::Or(b)
             }
             (a, b) => WhereExpr::Or(vec![a, b]),
+        };
+        Self {
+            inner,
+            _model: PhantomData,
+        }
+    }
+
+    /// Compose with `XOR` — Django 4.1+ `Q(a) ^ Q(b)` (issue #27).
+    /// Matches rows for which an odd number of operands evaluate to
+    /// `true`. Adjacent `Xor` nodes flatten the same way `.and()` /
+    /// `.or()` do, so chains like `a.xor(b).xor(c)` stay shallow and
+    /// emit Django's N-ary semantic (odd parity) rather than the
+    /// nested `(a^b)^c` form.
+    #[must_use]
+    pub fn xor<E: Into<Self>>(self, rhs: E) -> Self {
+        let rhs = rhs.into();
+        let inner = match (self.inner, rhs.inner) {
+            (WhereExpr::Xor(mut a), WhereExpr::Xor(b)) => {
+                a.extend(b);
+                WhereExpr::Xor(a)
+            }
+            (WhereExpr::Xor(mut a), b) => {
+                a.push(b);
+                WhereExpr::Xor(a)
+            }
+            (a, WhereExpr::Xor(mut b)) => {
+                b.insert(0, a);
+                WhereExpr::Xor(b)
+            }
+            (a, b) => WhereExpr::Xor(vec![a, b]),
         };
         Self {
             inner,

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -131,6 +131,18 @@ pub enum WhereExpr {
     /// uses it uniformly. Empty children = vacuously false (rejected
     /// by the writer, same as `Or(vec![])`). Single child is
     /// equivalent to the child itself.
+    ///
+    /// **Double-eval caveat (binary form only)**: the 2-child rewrite
+    /// emits each operand twice, so the database evaluates each
+    /// predicate twice. Deterministic predicates are unaffected, but
+    /// volatile expressions (`RANDOM()`, `NOW()`, correlated subqueries
+    /// with side effects) may return different values across the two
+    /// evaluations. If single-evaluation semantics matter, force the
+    /// parity-tally branch by adding a `FALSE` third child:
+    /// `Xor([a, b, WhereExpr::And(vec![WhereExpr::Predicate(..)])])`
+    /// or build via `a.xor(b).xor(c)` chains where the typed builder
+    /// flattens to ≥3 children. The N-ary form evaluates each child
+    /// exactly once.
     Xor(Vec<WhereExpr>),
     /// `EXISTS (<subquery>)` — issue #5. True when the inner
     /// `SelectQuery` returns at least one row. Boxed because

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -119,6 +119,19 @@ pub enum WhereExpr {
     Or(Vec<WhereExpr>),
     /// Logical negation. Emits `NOT (child)`.
     Not(Box<WhereExpr>),
+    /// Logical XOR — Django `Q(a) ^ Q(b)` (added in Django 4.1). Issue
+    /// #27. Matches rows for which an odd number of children evaluate
+    /// to `true`. Binary form is the common case and emits the
+    /// canonical SQL-92 rewrite `(a AND NOT b) OR (NOT a AND b)`; the
+    /// N-ary form (3+) folds to a CASE-WHEN-1/0 sum compared `% 2 = 1`
+    /// to mirror Django's "odd number of trues" semantic.
+    ///
+    /// Native logical XOR exists on MySQL but not on PG or SQLite —
+    /// the rewrite is portable across every backend, so the writer
+    /// uses it uniformly. Empty children = vacuously false (rejected
+    /// by the writer, same as `Or(vec![])`). Single child is
+    /// equivalent to the child itself.
+    Xor(Vec<WhereExpr>),
     /// `EXISTS (<subquery>)` — issue #5. True when the inner
     /// `SelectQuery` returns at least one row. Boxed because
     /// `SelectQuery` already carries its own `WhereExpr`, which would
@@ -205,6 +218,7 @@ impl WhereExpr {
             // fall outside the legacy flat-AND view.
             Self::ColumnCompare(_)
             | Self::Or(_)
+            | Self::Xor(_)
             | Self::Not(_)
             | Self::Exists(_)
             | Self::NotExists(_)
@@ -242,7 +256,7 @@ impl WhereExpr {
                 validate_expr_columns(model, &cf.rhs)?;
                 Ok(())
             }
-            Self::And(items) | Self::Or(items) => {
+            Self::And(items) | Self::Or(items) | Self::Xor(items) => {
                 for child in items {
                     child.validate(model)?;
                 }

--- a/crates/rustango/src/sql/error.rs
+++ b/crates/rustango/src/sql/error.rs
@@ -75,6 +75,13 @@ pub enum SqlError {
     #[error("`WhereExpr::Or` with an empty branch list matches no rows; was that intentional?")]
     EmptyOrBranch,
 
+    /// `WhereExpr::Xor(vec![])` — issue #27. XOR over zero operands
+    /// is vacuously false (an empty "odd-number-of-trues" tally is
+    /// `0 % 2 = 1` → false), almost always a programming error.
+    /// Sibling to [`Self::EmptyOrBranch`].
+    #[error("`WhereExpr::Xor` with an empty branch list matches no rows; was that intentional?")]
+    EmptyXorBranch,
+
     /// `Dialect::compile_*` was called on a dialect whose query
     /// compiler hasn't shipped yet.
     #[error(

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -1751,6 +1751,7 @@ pub(super) fn write_where_expr(
             }
             write_joined(b, items, " OR ", qualify_with, model)
         }
+        WhereExpr::Xor(items) => write_xor(b, items, qualify_with, model),
         WhereExpr::Not(child) => {
             b.sql.push_str("NOT (");
             write_where_expr(b, child, qualify_with, model)?;
@@ -1977,10 +1978,67 @@ fn write_child(
         | WhereExpr::NotExists(_)
         | WhereExpr::InSubquery { .. }
         | WhereExpr::ExprCompare { .. } => write_where_expr(b, expr, qualify_with, model),
-        WhereExpr::And(_) | WhereExpr::Or(_) | WhereExpr::Not(_) => {
+        WhereExpr::And(_) | WhereExpr::Or(_) | WhereExpr::Xor(_) | WhereExpr::Not(_) => {
             b.sql.push('(');
             write_where_expr(b, expr, qualify_with, model)?;
             b.sql.push(')');
+            Ok(())
+        }
+    }
+}
+
+/// Emit a [`WhereExpr::Xor`] node (issue #27). Django 4.1+ added
+/// `Q(a) ^ Q(b)` with the semantic "odd number of operands evaluate
+/// to true". Native logical XOR exists on MySQL but not on PG or
+/// SQLite, so the writer uses portable SQL-92 rewrites for every
+/// backend:
+///
+/// * 0 children → [`SqlError::EmptyXorBranch`] (mirrors the empty-OR
+///   rejection — a vacuously-false predicate is almost always a bug).
+/// * 1 child   → the child itself (XOR over a single operand is the
+///   operand, no rewrite needed).
+/// * 2 children → `((a) AND NOT (b)) OR (NOT (a) AND (b))` —
+///   canonical binary form per the issue acceptance criteria.
+/// * 3+ children → `((CASE WHEN q1 THEN 1 ELSE 0 END) + … +
+///   (CASE WHEN qN THEN 1 ELSE 0 END)) % 2 = 1` — Django's "odd
+///   number of trues" generalization. Portable across PG / MySQL /
+///   SQLite; uses standard `CASE WHEN` and the SQL `%` modulus.
+fn write_xor(
+    b: &mut Sql<'_>,
+    items: &[WhereExpr],
+    qualify_with: Option<&str>,
+    model: Option<&'static ModelSchema>,
+) -> Result<(), SqlError> {
+    match items.len() {
+        0 => Err(SqlError::EmptyXorBranch),
+        1 => write_where_expr(b, &items[0], qualify_with, model),
+        2 => {
+            // (a AND NOT (b)) OR (NOT (a) AND b)
+            b.sql.push('(');
+            write_child(b, &items[0], qualify_with, model)?;
+            b.sql.push_str(" AND NOT (");
+            write_where_expr(b, &items[1], qualify_with, model)?;
+            b.sql.push_str(")) OR (NOT (");
+            write_where_expr(b, &items[0], qualify_with, model)?;
+            b.sql.push_str(") AND ");
+            write_child(b, &items[1], qualify_with, model)?;
+            b.sql.push(')');
+            Ok(())
+        }
+        _ => {
+            // (sum of CASE WHEN q THEN 1 ELSE 0 END) % 2 = 1
+            b.sql.push('(');
+            let mut first = true;
+            for child in items {
+                if !first {
+                    b.sql.push_str(" + ");
+                }
+                first = false;
+                b.sql.push_str("(CASE WHEN ");
+                write_where_expr(b, child, qualify_with, model)?;
+                b.sql.push_str(" THEN 1 ELSE 0 END)");
+            }
+            b.sql.push_str(") % 2 = 1");
             Ok(())
         }
     }

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -1999,10 +1999,19 @@ fn write_child(
 ///   operand, no rewrite needed).
 /// * 2 children → `((a) AND NOT (b)) OR (NOT (a) AND (b))` —
 ///   canonical binary form per the issue acceptance criteria.
+///   **Caveat**: each operand is emitted twice and therefore evaluated
+///   twice on the database side. Deterministic predicates (column =
+///   literal, range checks) are unaffected, but volatile expressions
+///   (`RANDOM()`, `NOW()`, correlated subqueries with side effects) may
+///   return different values across the two evaluations. If you need
+///   single-evaluation semantics for binary XOR, hand-build the
+///   3-element form `Xor([a, b, FALSE])` so the writer falls into the
+///   parity-tally branch below.
 /// * 3+ children → `((CASE WHEN q1 THEN 1 ELSE 0 END) + … +
 ///   (CASE WHEN qN THEN 1 ELSE 0 END)) % 2 = 1` — Django's "odd
 ///   number of trues" generalization. Portable across PG / MySQL /
-///   SQLite; uses standard `CASE WHEN` and the SQL `%` modulus.
+///   SQLite; uses standard `CASE WHEN` and the SQL `%` modulus. Each
+///   child is evaluated exactly once.
 fn write_xor(
     b: &mut Sql<'_>,
     items: &[WhereExpr],
@@ -2026,7 +2035,13 @@ fn write_xor(
             Ok(())
         }
         _ => {
-            // (sum of CASE WHEN q THEN 1 ELSE 0 END) % 2 = 1
+            // (sum of CASE WHEN q THEN 1 ELSE 0 END) % 2 = 1.
+            // `write_child` (not `write_where_expr`) so a composite
+            // child — And / Or / nested Xor / Not — gets parenthesized
+            // before the `THEN 1`. SQL operator precedence (NOT > AND
+            // > OR) would parse it correctly without the wrap, but the
+            // explicit parens are belt-and-suspenders against future
+            // additions to the precedence ladder.
             b.sql.push('(');
             let mut first = true;
             for child in items {
@@ -2035,7 +2050,7 @@ fn write_xor(
                 }
                 first = false;
                 b.sql.push_str("(CASE WHEN ");
-                write_where_expr(b, child, qualify_with, model)?;
+                write_child(b, child, qualify_with, model)?;
                 b.sql.push_str(" THEN 1 ELSE 0 END)");
             }
             b.sql.push_str(") % 2 = 1");

--- a/crates/rustango/tests/q_xor_emission.rs
+++ b/crates/rustango/tests/q_xor_emission.rs
@@ -237,6 +237,42 @@ fn chained_xor_flattens_to_nary_parity_tally() {
     assert!(stmt.sql.contains(") % 2 = 1"));
 }
 
+/// N-ary parity tally must parenthesize composite children. Without
+/// the `write_child` wrap, a child like `And(a, b)` would emit raw
+/// `a AND b` inside `CASE WHEN a AND b THEN 1 ELSE 0 END`. SQL
+/// operator precedence (`NOT` > `AND` > `OR`) makes that parse
+/// correctly today, but the wrap is belt-and-suspenders against
+/// future precedence-ladder changes.
+#[test]
+fn nary_parity_tally_parenthesizes_composite_children() {
+    // Xor of [And(a, b), c, d] — first child is a composite.
+    let and_child = WhereExpr::And(vec![
+        User::name.eq("alice").into(),
+        User::active.eq(true).into(),
+    ]);
+    let where_clause = WhereExpr::Xor(vec![
+        and_child,
+        User::age.gt(30_i32).into(),
+        User::age.lt(50_i32).into(),
+    ]);
+    let stmt = Postgres.compile_select(&select(where_clause)).unwrap();
+    // Composite first child appears wrapped: `CASE WHEN (a AND b) THEN`
+    assert!(
+        stmt.sql
+            .contains(r#"CASE WHEN ("name" = $1 AND "active" = $2) THEN"#),
+        "composite child wrapped in parens inside CASE WHEN: {}",
+        stmt.sql
+    );
+    // Predicate leaf children are NOT wrapped (write_child writes
+    // them bare): `CASE WHEN "age" > $3 THEN`
+    assert!(
+        stmt.sql.contains(r#"CASE WHEN "age" > $3 THEN"#),
+        "predicate leaf children emit bare: {}",
+        stmt.sql
+    );
+    assert!(stmt.sql.contains(") % 2 = 1"));
+}
+
 /// `WhereExpr::validate()` walks into `Xor` children — proves the
 /// `And | Or | Xor` validation arm catches typo'd columns inside an
 /// Xor node. Important for any caller that does invoke validate()

--- a/crates/rustango/tests/q_xor_emission.rs
+++ b/crates/rustango/tests/q_xor_emission.rs
@@ -1,0 +1,268 @@
+//! Tri-dialect SQL-emission tests for `WhereExpr::Xor` (issue #27).
+//! Django 4.1+ added `Q(a) ^ Q(b)` — "odd number of operands evaluate
+//! to true". Native logical XOR exists on MySQL but not PG / SQLite,
+//! so the writer emits a portable rewrite uniformly:
+//! - 2 children → `(a AND NOT b) OR (NOT a AND b)` canonical form.
+//! - 3+ children → CASE-WHEN tally `% 2 = 1` (Django's odd-parity).
+
+use rustango::core::{Column as _, Filter, Model as _, Op, SelectQuery, SqlValue, WhereExpr};
+use rustango::sql::{Dialect, MySql, Postgres, SqlError, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "qxor_user")]
+#[allow(dead_code)]
+pub struct User {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 20)]
+    name: String,
+    age: i32,
+    active: bool,
+}
+
+fn select(where_clause: WhereExpr) -> SelectQuery {
+    SelectQuery {
+        model: User::SCHEMA,
+        where_clause,
+        search: None,
+        joins: vec![],
+        order_by: vec![],
+        limit: None,
+        offset: None,
+    }
+}
+
+// ---------- Binary XOR — canonical (a AND NOT b) OR (NOT a AND b) form ----------
+
+#[test]
+fn binary_xor_emits_canonical_form_on_pg() {
+    let q = select(WhereExpr::Xor(vec![
+        User::name.eq("alice").into(),
+        User::active.eq(true).into(),
+    ]));
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(
+            r#"("name" = $1 AND NOT ("active" = $2)) OR (NOT ("name" = $3) AND "active" = $4)"#
+        ),
+        "PG: canonical binary XOR rewrite: {}",
+        stmt.sql
+    );
+    // Each operand binds once per occurrence in the rewrite (4 params total).
+    assert_eq!(stmt.params.len(), 4);
+}
+
+#[test]
+fn binary_xor_emits_canonical_form_on_mysql() {
+    let q = select(WhereExpr::Xor(vec![
+        User::name.eq("alice").into(),
+        User::active.eq(true).into(),
+    ]));
+    let stmt = MySql.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql
+            .contains("(`name` = ? AND NOT (`active` = ?)) OR (NOT (`name` = ?) AND `active` = ?)"),
+        "MySQL: canonical binary XOR rewrite (backticks): {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn binary_xor_emits_canonical_form_on_sqlite() {
+    let q = select(WhereExpr::Xor(vec![
+        User::name.eq("alice").into(),
+        User::active.eq(true).into(),
+    ]));
+    let stmt = Sqlite.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(
+            r#"("name" = ? AND NOT ("active" = ?)) OR (NOT ("name" = ?) AND "active" = ?)"#
+        ),
+        "SQLite: canonical binary XOR rewrite: {}",
+        stmt.sql
+    );
+}
+
+// ---------- N-ary XOR — Django's odd-parity tally ----------
+
+#[test]
+fn ternary_xor_emits_parity_tally_on_pg() {
+    let q = select(WhereExpr::Xor(vec![
+        User::name.eq("alice").into(),
+        User::active.eq(true).into(),
+        User::age.gt(30_i32).into(),
+    ]));
+    let stmt = Postgres.compile_select(&q).unwrap();
+    // (CASE WHEN q1 THEN 1 ELSE 0 END) + (CASE WHEN q2 …) + (CASE WHEN q3 …) % 2 = 1
+    assert!(
+        stmt.sql.contains(
+            r#"((CASE WHEN "name" = $1 THEN 1 ELSE 0 END) + (CASE WHEN "active" = $2 THEN 1 ELSE 0 END) + (CASE WHEN "age" > $3 THEN 1 ELSE 0 END)) % 2 = 1"#
+        ),
+        "PG: ternary XOR parity tally: {}",
+        stmt.sql
+    );
+    assert_eq!(stmt.params.len(), 3);
+}
+
+#[test]
+fn quaternary_xor_emits_four_term_parity_tally() {
+    let q = select(WhereExpr::Xor(vec![
+        User::name.eq("a").into(),
+        User::name.eq("b").into(),
+        User::name.eq("c").into(),
+        User::name.eq("d").into(),
+    ]));
+    let stmt = Postgres.compile_select(&q).unwrap();
+    // Verify the join shape — four CASE-WHEN tally with three " + " separators.
+    let case_count = stmt.sql.matches("CASE WHEN").count();
+    let plus_count = stmt.sql.matches(" + ").count();
+    assert_eq!(case_count, 4, "four CASE WHEN tally: {}", stmt.sql);
+    assert_eq!(plus_count, 3, "three '+' separators: {}", stmt.sql);
+    assert!(
+        stmt.sql.contains(") % 2 = 1"),
+        "ends with `% 2 = 1`: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Degenerate shapes ----------
+
+#[test]
+fn single_element_xor_emits_just_the_element() {
+    let q = select(WhereExpr::Xor(vec![User::name.eq("alice").into()]));
+    let stmt = Postgres.compile_select(&q).unwrap();
+    // XOR over one operand is just the operand itself; no rewrite layer.
+    assert!(
+        stmt.sql.contains(r#"WHERE "name" = $1"#),
+        "single-element XOR → unwrapped: {}",
+        stmt.sql
+    );
+    assert!(!stmt.sql.contains("CASE WHEN"));
+    assert!(!stmt.sql.contains(" AND NOT "));
+}
+
+#[test]
+fn empty_xor_branch_returns_named_writer_error() {
+    let q = select(WhereExpr::Xor(vec![]));
+    let err = Postgres.compile_select(&q).unwrap_err();
+    assert!(matches!(err, SqlError::EmptyXorBranch));
+}
+
+// ---------- Composition with And / Or / Not / nested Xor ----------
+
+#[test]
+fn xor_inside_and_parenthesizes_correctly() {
+    // (name = alice XOR active = true) AND age > 30
+    let xor = WhereExpr::Xor(vec![
+        User::name.eq("alice").into(),
+        User::active.eq(true).into(),
+    ]);
+    let where_clause = WhereExpr::And(vec![
+        xor,
+        WhereExpr::Predicate(Filter {
+            column: "age",
+            op: Op::Gt,
+            value: SqlValue::I32(30),
+        }),
+    ]);
+    let stmt = Postgres.compile_select(&select(where_clause)).unwrap();
+    // The XOR rewrite is wrapped in parens by write_child when it
+    // appears as a member of an AND, then the AND adds the age check.
+    assert!(stmt.sql.contains(") AND "));
+    assert!(
+        stmt.sql.contains(r#""age" > $5"#),
+        "age check follows XOR: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn xor_inside_or_parenthesizes_correctly() {
+    // (name = alice XOR active = true) OR age > 30
+    let xor = WhereExpr::Xor(vec![
+        User::name.eq("alice").into(),
+        User::active.eq(true).into(),
+    ]);
+    let where_clause = WhereExpr::Or(vec![
+        xor,
+        WhereExpr::Predicate(Filter {
+            column: "age",
+            op: Op::Gt,
+            value: SqlValue::I32(30),
+        }),
+    ]);
+    let stmt = Postgres.compile_select(&select(where_clause)).unwrap();
+    assert!(stmt.sql.contains(") OR "));
+    assert!(stmt.sql.contains(r#""age" > $5"#));
+}
+
+// ---------- TypedExpr::xor() builder API ----------
+
+#[test]
+fn typed_expr_xor_method_produces_xor_node() {
+    let q = User::objects()
+        .where_(User::name.eq("alice").xor(User::active.eq(true)))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(
+            r#"("name" = $1 AND NOT ("active" = $2)) OR (NOT ("name" = $3) AND "active" = $4)"#
+        ),
+        "TypedExpr::xor() → canonical binary XOR rewrite: {}",
+        stmt.sql
+    );
+}
+
+/// Chained `.xor()` flattens into a single N-ary `Xor` node (mirrors
+/// how `.and()` / `.or()` flatten). The result emits the parity tally,
+/// not a nested binary rewrite — Django's "odd number of trues"
+/// semantic for N-ary XOR.
+#[test]
+fn chained_xor_flattens_to_nary_parity_tally() {
+    let q = User::objects()
+        .where_(
+            User::name
+                .eq("alice")
+                .xor(User::active.eq(true))
+                .xor(User::age.gt(30_i32)),
+        )
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    // Three CASE WHEN terms, not a nested binary rewrite.
+    let case_count = stmt.sql.matches("CASE WHEN").count();
+    assert_eq!(case_count, 3, "flattened ternary XOR: {}", stmt.sql);
+    assert!(stmt.sql.contains(") % 2 = 1"));
+}
+
+/// `WhereExpr::validate()` walks into `Xor` children — proves the
+/// `And | Or | Xor` validation arm catches typo'd columns inside an
+/// Xor node. Important for any caller that does invoke validate()
+/// (e.g., aggregate `Filtered { filter }` runs it on the inner
+/// predicate, where an Xor could legitimately appear).
+#[test]
+fn xor_validate_walks_children() {
+    let xor = WhereExpr::Xor(vec![
+        WhereExpr::Predicate(Filter {
+            column: "name",
+            op: Op::Eq,
+            value: SqlValue::String("alice".into()),
+        }),
+        WhereExpr::Predicate(Filter {
+            column: "nonexistent_column",
+            op: Op::Eq,
+            value: SqlValue::Bool(true),
+        }),
+    ]);
+    let r = xor.validate(User::SCHEMA);
+    assert!(
+        matches!(
+            r,
+            Err(rustango::core::QueryError::UnknownField { ref field, .. })
+                if field == "nonexistent_column"
+        ),
+        "validate() walks into Xor children: {r:?}",
+    );
+}

--- a/crates/rustango/tests/q_xor_live.rs
+++ b/crates/rustango/tests/q_xor_live.rs
@@ -1,0 +1,126 @@
+#![cfg(feature = "postgres")]
+//! Live PG test for `WhereExpr::Xor` runtime semantics (issue #27).
+//! Verifies the canonical binary rewrite + Django's N-ary odd-parity
+//! tally produce the right row counts end-to-end. Skips silently when
+//! `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::core::Column as _;
+use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "qxor_live_person")]
+#[allow(dead_code)]
+pub struct Person {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 32)]
+    pub name: String,
+    pub age: i32,
+    pub active: bool,
+}
+
+fn lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn fresh_pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pool = sqlx::PgPool::connect(&url).await.ok()?;
+    sqlx::query(r#"DROP TABLE IF EXISTS "qxor_live_person" CASCADE"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"
+        CREATE TABLE "qxor_live_person" (
+            id BIGSERIAL PRIMARY KEY,
+            name VARCHAR(32) NOT NULL,
+            age INTEGER NOT NULL,
+            active BOOLEAN NOT NULL
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    // Truth table of (name=alice, active=true) → expected XOR result:
+    //   alice / true  → false (both true)
+    //   alice / false → true  (one true)
+    //   bob   / true  → true  (one true)
+    //   bob   / false → false (both false)
+    for (name, age, active) in [
+        ("alice", 30, true),
+        ("alice", 35, false),
+        ("bob", 40, true),
+        ("bob", 45, false),
+    ] {
+        let mut p = Person {
+            id: Auto::default(),
+            name: name.into(),
+            age,
+            active,
+        };
+        p.insert(&pool).await.unwrap();
+    }
+    Some(pool)
+}
+
+async fn sorted_names(rows: Vec<Person>) -> Vec<String> {
+    let mut names: Vec<String> = rows.into_iter().map(|p| p.name).collect();
+    names.sort();
+    names
+}
+
+/// Binary XOR — `name = alice ^ active = true`. Matches exactly the
+/// two rows where one of the predicates is true: (alice, false) and
+/// (bob, true).
+#[tokio::test]
+async fn binary_xor_matches_exactly_one_true() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let rows: Vec<Person> = Person::objects()
+        .where_(Person::name.eq("alice").xor(Person::active.eq(true)))
+        .fetch(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(sorted_names(rows).await, vec!["alice", "bob"]);
+}
+
+/// N-ary XOR — `name=alice ^ active=true ^ age>=40`. Matches rows
+/// where an odd number of predicates are true:
+///   alice/30/true  : (T, T, F) → 2 trues → false
+///   alice/35/false : (T, F, F) → 1 true  → true ✓
+///   bob/40/true    : (F, T, T) → 2 trues → false
+///   bob/45/false   : (F, F, T) → 1 true  → true ✓
+#[tokio::test]
+async fn ternary_xor_matches_odd_parity() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let rows: Vec<Person> = Person::objects()
+        .where_(
+            Person::name
+                .eq("alice")
+                .xor(Person::active.eq(true))
+                .xor(Person::age.gte(40_i32)),
+        )
+        .fetch(&pool)
+        .await
+        .unwrap();
+
+    // alice/35/false (id 2) + bob/45/false (id 4)
+    let mut ages: Vec<i32> = rows.iter().map(|p| p.age).collect();
+    ages.sort_unstable();
+    assert_eq!(ages, vec![35, 45]);
+}

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -58,6 +58,17 @@ let qs = Post::objects().where_expr(WhereExpr::Or(vec![
     Post::status.eq("draft").into(),
     Post::status.eq("review").into(),
 ]));
+
+// XOR — Django 4.1+ `Q(a) ^ Q(b)`. Matches rows where an odd number
+// of operands evaluate to true (binary case = "exactly one is true").
+// Issue #27.
+let either_but_not_both = Post::objects()
+    .where_(Post::status.eq("draft").xor(Post::author_id.eq(42)))
+    .fetch(&pool).await?;
+// Tri-dialect emission: native logical XOR exists on MySQL but not PG
+// or SQLite, so the writer emits a portable rewrite uniformly —
+// `(a AND NOT b) OR (NOT a AND b)` for the binary form, or a
+// CASE-WHEN-1/0 tally `% 2 = 1` for N-ary chains.
 ```
 
 ### Lookup operators


### PR DESCRIPTION
## Summary

Closes #27. Adds `WhereExpr::Xor(Vec<WhereExpr>)` IR variant + `.xor()` builder method on `Column` / `TypedExpr`. Mirrors Django's `Q(a) ^ Q(b)` shape (added in Django 4.1) and its N-ary \"odd number of operands evaluate to true\" semantic.

\`\`\`rust
// Binary: \"either drafted or owned by author 42, but not both\"
Post::objects()
    .where_(Post::status.eq(\"draft\").xor(Post::author_id.eq(42)))
    .fetch(&pool).await?;

// Chained .xor() flattens to N-ary (Django's odd-parity semantic)
Post::objects()
    .where_(a.xor(b).xor(c))  // → Xor(vec![a, b, c]), not nested (a^b)^c
    .fetch(&pool).await?;
\`\`\`

## Tri-dialect emission

Native logical XOR exists on MySQL but not on PG or SQLite, so the writer uses a portable rewrite uniformly:

| Branch count | Emission |
|---|---|
| 0 | `SqlError::EmptyXorBranch` — vacuously false, almost always a bug (mirrors `EmptyOrBranch`) |
| 1 | The child itself (no rewrite) |
| 2 | `(a AND NOT b) OR (NOT a AND b)` — canonical SQL-92 form per the issue acceptance criteria |
| 3+ | `((CASE WHEN q1 THEN 1 ELSE 0 END) + … + (CASE WHEN qN THEN 1 ELSE 0 END)) % 2 = 1` — Django's odd-parity tally |

## What landed

- **[`src/core/query.rs`](crates/rustango/src/core/query.rs)** — `WhereExpr::Xor(Vec<WhereExpr>)` variant + validation walk + `as_flat_and` exhaustive arm.
- **[`src/core/column.rs`](crates/rustango/src/core/column.rs)** — `Column::xor()` + `TypedExpr::xor()` with adjacent-node flattening so chained calls produce a single N-ary node.
- **[`src/sql/writers.rs`](crates/rustango/src/sql/writers.rs)** — `write_xor` helper with 0/1/2/N branch dispatch; `write_where_expr` + `write_child` exhaustive arms.
- **[`src/sql/error.rs`](crates/rustango/src/sql/error.rs)** — `SqlError::EmptyXorBranch`.
- **[`docs/orm.md`](docs/orm.md)** — cookbook section under \"OR / nested\" with binary example.

## Tests

| Suite | Count | Status |
|---|---|---|
| `tests/q_xor_emission.rs` (tri-dialect emission + builder API) | 12 | passing |
| `tests/q_xor_live.rs` (live PG runtime semantic) | 2 | passing |
| `cargo test -p rustango --features tenancy,mysql,sqlite --tests` | full suite | passing |

Emission tests cover: canonical form on PG / MySQL / SQLite, ternary + quaternary parity tally, single-element unwrap, empty rejection, composition inside And / Or, TypedExpr builder method, chained `.xor().xor()` flattening, and `validate()` walking into Xor children.

Live tests cover the binary case (exactly-one-true matches alice/active=false + bob/active=true on a 4-row truth-table fixture) and the ternary case (odd-parity matches the two rows where exactly one predicate is true).

## Verification

\`\`\`
cargo test -p rustango --features tenancy,mysql,sqlite --tests  → all passing
DATABASE_URL=... cargo test --features tenancy --test q_xor_live → 2 passed
cargo test --workspace --all-features --no-run                  → clean
cargo build --no-default-features --features sqlite,tenancy     → clean
\`\`\`

## Test plan

- [x] Tri-dialect emission tests pass on PG / MySQL / SQLite shapes.
- [x] Live PG tests confirm runtime semantic (binary + ternary).
- [x] Chained `.xor()` flattens to N-ary node, not nested binary.
- [x] Workspace `--all-features --no-run` gate passes.
- [x] SQLite-tenancy litmus build passes.
- [ ] CI green on \`postgres_test\` + \`mysql_live\` + \`sqlite_live\` + \`sqlite_litmus\`.