### PR TITLE
feat: QuerySet::in_bulk / in_bulk_on — Django in_bulk parity (closes #24)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -1617,7 +1617,7 @@ fn inherent_impl_tokens(
         // Audited models with explicit (non-Auto) PKs go through
         // the non-Auto insert path below — the audit emit is one
         // round-trip after the INSERT inside the same tx via
-        // audit::save_one_with_audit_pool? No, INSERT semantics
+        // audit::save_one_with_audit? No, INSERT semantics
         // differ. For non-Auto PK + audited, route through a
         // dedicated insert + audit emit on the same tx, but defer
         // the macro emission to the audit-bundle-aware block below
@@ -1655,7 +1655,7 @@ fn inherent_impl_tokens(
                 let _result = ::rustango::sql::insert_returning_pool(
                     pool, &_query,
                 ).await?;
-                ::rustango::sql::apply_auto_pk_pool(_result, self)
+                ::rustango::sql::apply_auto_pk(_result, self)
             }
         }
     } else {
@@ -1687,7 +1687,7 @@ fn inherent_impl_tokens(
     // pool_save_method moved to after audit_pair_tokens /
     // audit_pk_to_string (they live ~70 lines below) — needed for
     // the audited branch which builds an UpdateQuery + PendingEntry
-    // and dispatches via audit::save_one_with_audit_pool.
+    // and dispatches via audit::save_one_with_audit.
 
     // pool_delete_method moved to after audit_pair_tokens / audit_pk_to_string
     // are computed (they live ~80 lines below).
@@ -1757,7 +1757,7 @@ fn inherent_impl_tokens(
     // - non-audited, Auto-PK: same, but Auto::Unset routes to
     //   self.insert_pool which already handles RETURNING / LAST_INSERT_ID
     // - audited, plain PK: build UpdateQuery + PendingEntry, dispatch
-    //   through audit::save_one_with_audit_pool (per-backend tx wraps
+    //   through audit::save_one_with_audit (per-backend tx wraps
     //   UPDATE + audit emit atomically). Snapshot-style audit (post-
     //   write field values) — diff-style audit (with pre-UPDATE
     //   SELECT for `before` values) needs per-tracked-column codegen
@@ -1817,7 +1817,7 @@ fn inherent_impl_tokens(
                                 #( #pairs ),*
                             ]),
                         };
-                        let _ = ::rustango::audit::save_one_with_audit_pool(
+                        let _ = ::rustango::audit::save_one_with_audit(
                             pool, &_query, &_audit_entry,
                         ).await?;
                         ::core::result::Result::Ok(())
@@ -1907,7 +1907,7 @@ fn inherent_impl_tokens(
                             source: ::rustango::audit::current_source(),
                             changes: ::rustango::audit::snapshot_changes(&_narrowed),
                         };
-                        let _ = ::rustango::audit::save_one_with_audit_pool(
+                        let _ = ::rustango::audit::save_one_with_audit(
                             pool, &_query, &_audit_entry,
                         ).await?;
                         ::core::result::Result::Ok(())
@@ -2123,7 +2123,7 @@ fn inherent_impl_tokens(
     // Audited `insert_pool` (overrides the placeholder set higher up
     // in the function). v0.23.0-batch22 — both Auto-PK and non-Auto-PK
     // audited models get insert_pool routing through
-    // audit::insert_one_with_audit_pool (per-backend tx wraps INSERT
+    // audit::insert_one_with_audit (per-backend tx wraps INSERT
     // + auto-PK readback + audit emit). Snapshot-style audit (the
     // PendingEntry's `changes` carries post-write field values).
     let pool_insert_method = if audited_fields.is_some() {
@@ -2199,10 +2199,10 @@ fn inherent_impl_tokens(
                             #( #pairs ),*
                         ]),
                     };
-                    let _result = ::rustango::audit::insert_one_with_audit_pool(
+                    let _result = ::rustango::audit::insert_one_with_audit(
                         pool, &_query, &_audit_entry,
                     ).await?;
-                    ::rustango::sql::apply_auto_pk_pool(_result, self)
+                    ::rustango::sql::apply_auto_pk(_result, self)
                 }
             }
         } else {
@@ -2338,7 +2338,7 @@ fn inherent_impl_tokens(
                     };
                     let _after_pairs: ::std::vec::Vec<(&'static str, ::serde_json::Value)> =
                         ::std::vec![ #( #after_pairs_pg ),* ];
-                    ::rustango::audit::save_one_with_diff_pool(
+                    ::rustango::audit::save_one_with_diff(
                         pool,
                         &_query,
                         #pk_column_lit,
@@ -2367,7 +2367,7 @@ fn inherent_impl_tokens(
     // `delete_pool(&Pool)` — emitted for every model with a PK. Two
     // body shapes:
     // - non-audited: simple dispatch through `sql::delete_pool`
-    // - audited: routes through `audit::delete_one_with_audit_pool`,
+    // - audited: routes through `audit::delete_one_with_audit`,
     //   which opens a per-backend transaction wrapping DELETE +
     //   audit emit so the data write and audit row commit atomically.
     let pool_delete_method = {
@@ -2409,7 +2409,7 @@ fn inherent_impl_tokens(
                                 #( #pairs ),*
                             ]),
                         };
-                        ::rustango::audit::delete_one_with_audit_pool(
+                        ::rustango::audit::delete_one_with_audit(
                             pool, &_query, &_audit_entry,
                         ).await
                     }
@@ -2479,7 +2479,7 @@ fn inherent_impl_tokens(
                     on_conflict: ::core::option::Option::None,
                 };
                 let _result = ::rustango::sql::insert_returning_tx(tx, &_query).await?;
-                ::rustango::sql::apply_auto_pk_pool(_result, self)
+                ::rustango::sql::apply_auto_pk(_result, self)
             }
         }
     } else {
@@ -3392,11 +3392,11 @@ fn inherent_impl_tokens(
 
     let fk_pk_access_impl = fk_pk_access_impl_tokens(struct_name, &fields.fk_relations);
 
-    // Slice 17.1 — `AssignAutoPkPool` impl lets `apply_auto_pk_pool`
+    // Slice 17.1 — `AssignAutoPkPool` impl lets `apply_auto_pk`
     // dispatch to the right per-backend body without the macro emitting
     // any `#[cfg(feature = …)]` arm into consumer code. Always emitted
     // so audited models with non-Auto PKs (which still go through
-    // `insert_one_with_audit_pool` → `apply_auto_pk_pool`) link.
+    // `insert_one_with_audit` → `apply_auto_pk`) link.
     let assign_auto_pk_pool_impl = {
         let auto_assigns = &fields.auto_assigns;
         // SQLite ≥ 3.35 supports the same RETURNING shape as Postgres,

--- a/crates/rustango/src/admin/audit.rs
+++ b/crates/rustango/src/admin/audit.rs
@@ -86,10 +86,8 @@ pub(crate) async fn audit_log_view(
     // tri-dialect helpers in `crate::audit`. The SQL is rendered
     // through `dialect.placeholder()` / `dialect.quote_ident()` so
     // this view works against any backend the framework supports.
-    let total = crate::audit::count_pool(&state.pool, &filter)
-        .await
-        .unwrap_or(0);
-    let entries = crate::audit::list_pool(&state.pool, &filter, AUDIT_PAGE_SIZE, offset)
+    let total = crate::audit::count(&state.pool, &filter).await.unwrap_or(0);
+    let entries = crate::audit::list(&state.pool, &filter, AUDIT_PAGE_SIZE, offset)
         .await
         .unwrap_or_default();
 
@@ -105,7 +103,7 @@ pub(crate) async fn audit_log_view(
             .iter()
             .find(|(k, _)| *k == col)
             .map(|(_, v)| v.as_str());
-        let facet_pairs = crate::audit::facet_counts_pool(&state.pool, col)
+        let facet_pairs = crate::audit::facet_counts(&state.pool, col)
             .await
             .unwrap_or_default();
         let mut values: Vec<Value> = facet_pairs
@@ -321,7 +319,7 @@ pub(crate) async fn audit_cleanup_submit(
 ///
 /// v0.37 — `before_row` is now `Option<&serde_json::Value>` (the JSON
 /// bridge from slice 2 of v0.36) instead of `Option<&PgRow>`, so the
-/// caller can fetch via `select_one_row_as_json_pool` on any backend.
+/// caller can fetch via `select_one_row_as_json` on any backend.
 pub(crate) async fn emit_admin_audit_diff(
     state: &AppState,
     model: &'static crate::core::ModelSchema,

--- a/crates/rustango/src/admin/computed_fields.rs
+++ b/crates/rustango/src/admin/computed_fields.rs
@@ -4,7 +4,7 @@
 //! alongside the regular column names; the renderer dispatches to a
 //! user-supplied closure via the inventory registry. The closure
 //! receives the row as a `serde_json::Value` (a `{ field_name: value }`
-//! map produced by [`crate::sql::select_rows_as_json_pool`] — works
+//! map produced by [`crate::sql::select_rows_as_json`] — works
 //! the same on Postgres / MySQL / SQLite) so it can pull any column
 //! it wants and produce pre-escaped display HTML.
 //!

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -420,7 +420,7 @@ pub(crate) fn read_value_as_string(row: &PgRow, field: &FieldSchema) -> Option<S
 // `crate::sql::row_to_json` / `row_to_json_my` / `row_to_json_sqlite`)
 // instead of a backend-specific `Row` type. The bundled admin's
 // fetch path (v0.36 slice 4) routes every row through
-// `select_rows_as_json_pool` → these renderers, so the rendering
+// `select_rows_as_json` → these renderers, so the rendering
 // layer never sees a `PgRow` and works uniformly on PG / MySQL /
 // SQLite.
 

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -242,7 +242,7 @@ pub(crate) async fn table_view(
         page_size
     };
     let scalar_fields: Vec<&'static FieldSchema> = model.scalar_fields().collect();
-    let mut rows = crate::sql::select_rows_as_json_pool(
+    let mut rows = crate::sql::select_rows_as_json(
         &state.pool,
         &SelectQuery {
             model,
@@ -850,7 +850,7 @@ pub(crate) async fn detail_view(
     let pk_value = forms::parse_pk_string(pk_field, &pk_raw).map_err(AdminError::Form)?;
 
     let detail_fields: Vec<&'static FieldSchema> = model.scalar_fields().collect();
-    let row = crate::sql::select_one_row_as_json_pool(
+    let row = crate::sql::select_one_row_as_json(
         &state.pool,
         &SelectQuery {
             model,
@@ -1122,7 +1122,7 @@ pub(crate) async fn edit_form(
     let pk_value = forms::parse_pk_string(pk_field, &pk_raw).map_err(AdminError::Form)?;
 
     let edit_fields: Vec<&'static FieldSchema> = model.scalar_fields().collect();
-    let row = crate::sql::select_one_row_as_json_pool(
+    let row = crate::sql::select_one_row_as_json(
         &state.pool,
         &SelectQuery {
             model,
@@ -1207,7 +1207,7 @@ pub(crate) async fn update_submit(
     // v0.37 — SELECT runs through the JSON bridge and the audit emit
     // takes `Option<&serde_json::Value>` directly, no shim needed.
     let before_fields: Vec<&'static FieldSchema> = model.scalar_fields().collect();
-    let before_row = crate::sql::select_one_row_as_json_pool(
+    let before_row = crate::sql::select_one_row_as_json(
         &state.pool,
         &SelectQuery {
             model,
@@ -1274,7 +1274,7 @@ pub(crate) async fn delete_submit(
     // state). Best-effort — missing row falls back to an empty
     // changes payload, which still records the operation + source.
     let delete_fields: Vec<&'static FieldSchema> = model.scalar_fields().collect();
-    let before_row = crate::sql::select_one_row_as_json_pool(
+    let before_row = crate::sql::select_one_row_as_json(
         &state.pool,
         &SelectQuery {
             model,
@@ -1439,7 +1439,7 @@ pub(crate) async fn action_submit(
     // delete_selected this snapshots the gone rows; for user-defined
     // actions it records the row state at the time of action.
     let action_fields: Vec<&'static FieldSchema> = model.scalar_fields().collect();
-    let before_rows = crate::sql::select_rows_as_json_pool(
+    let before_rows = crate::sql::select_rows_as_json(
         &state.pool,
         &SelectQuery {
             model,

--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -702,7 +702,7 @@ pub async fn emit_one_pool(
 
 /// v0.37 — filter shape for the admin's audit-log activity feed.
 /// Each field is optional; `None` means "don't constrain that column".
-/// The `list_pool` / `count_pool` helpers turn this into a WHERE clause
+/// The `list` / `count` helpers turn this into a WHERE clause
 /// rendered via [`Dialect::placeholder`] + [`Dialect::quote_ident`].
 #[derive(Debug, Clone, Default)]
 pub struct AuditFilter {
@@ -750,7 +750,7 @@ impl AuditFilter {
 /// # Errors
 /// Driver / SQL failures from the SELECT, or JSON decode failures on
 /// SQLite if the `changes` TEXT column isn't valid JSON.
-pub async fn list_pool(
+pub async fn list(
     pool: &crate::sql::Pool,
     filter: &AuditFilter,
     page_size: i64,
@@ -829,11 +829,11 @@ pub async fn list_pool(
 }
 
 /// v0.37 — tri-dialect total count for the admin audit-log pager,
-/// honoring the same `AuditFilter` as [`list_pool`].
+/// honoring the same `AuditFilter` as [`list`].
 ///
 /// # Errors
 /// Driver / SQL failures from the SELECT COUNT(*).
-pub async fn count_pool(pool: &crate::sql::Pool, filter: &AuditFilter) -> Result<i64, sqlx::Error> {
+pub async fn count(pool: &crate::sql::Pool, filter: &AuditFilter) -> Result<i64, sqlx::Error> {
     let pairs = filter.active_pairs();
     let sql = audit_count_sql(pool.dialect(), &pairs);
     let binds: Vec<&str> = pairs.iter().map(|(_, v)| *v).collect();
@@ -875,7 +875,7 @@ pub async fn count_pool(pool: &crate::sql::Pool, filter: &AuditFilter) -> Result
 /// Driver / SQL failures from the SELECT, or
 /// `Error::ColumnNotFound` when `column` isn't in the allowlist (the
 /// caller has a bug).
-pub async fn facet_counts_pool(
+pub async fn facet_counts(
     pool: &crate::sql::Pool,
     column: &str,
 ) -> Result<Vec<(String, i64)>, sqlx::Error> {
@@ -1213,7 +1213,7 @@ pub async fn cleanup_keep_last_n_pool(
 /// Any [`crate::sql::ExecError`] from compile / bind / execute, plus
 /// `sqlx::Error` from the audit emit (wrapped as
 /// `ExecError::Driver`).
-pub async fn delete_one_with_audit_pool(
+pub async fn delete_one_with_audit(
     pool: &crate::sql::Pool,
     query: &crate::core::DeleteQuery,
     entry: &PendingEntry,
@@ -1280,7 +1280,7 @@ pub async fn delete_one_with_audit_pool(
 /// # Errors
 /// Any [`crate::sql::ExecError`] from compile / bind / execute, plus
 /// `sqlx::Error` from the audit emit.
-pub async fn save_one_with_audit_pool(
+pub async fn save_one_with_audit(
     pool: &crate::sql::Pool,
     query: &crate::core::UpdateQuery,
     entry: &PendingEntry,
@@ -1349,7 +1349,7 @@ pub async fn save_one_with_audit_pool(
 /// # Errors
 /// Any [`crate::sql::ExecError`] from compile / bind / execute, plus
 /// `sqlx::Error` from the audit emit.
-pub async fn insert_one_with_audit_pool(
+pub async fn insert_one_with_audit(
     pool: &crate::sql::Pool,
     query: &crate::core::InsertQuery,
     entry: &PendingEntry,
@@ -1560,7 +1560,7 @@ fn bind_value_sqlite<'q>(
 /// Any [`crate::sql::ExecError`] from the UPDATE/SELECT, plus
 /// `sqlx::Error` from the audit emit (mapped through `From`).
 #[allow(clippy::too_many_arguments)]
-pub async fn save_one_with_diff_pool<F1, F2, F3>(
+pub async fn save_one_with_diff<F1, F2, F3>(
     pool: &crate::sql::Pool,
     update_query: &crate::core::UpdateQuery,
     pk_column: &'static str,

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -308,7 +308,7 @@ impl ContentType {
 
 /// Tri-dialect counterpart of [`fetch_row_as_json`] (v0.38). Takes
 /// the unified [`crate::sql::Pool`] enum and routes through
-/// [`crate::sql::select_one_row_as_json_pool`] so the same body runs
+/// [`crate::sql::select_one_row_as_json`] so the same body runs
 /// against PG / SQLite / MySQL. Used by the admin's audit log + the
 /// generic-FK link renderer on every backend.
 ///
@@ -353,11 +353,11 @@ pub async fn fetch_row_as_json(
         offset: None,
     };
     let fields: Vec<&'static crate::core::FieldSchema> = entry.schema.scalar_fields().collect();
-    crate::sql::select_one_row_as_json_pool(pool, &select_q, &fields).await
+    crate::sql::select_one_row_as_json(pool, &select_q, &fields).await
 }
 
 /// Tri-dialect counterpart of [`for_each_row_of_ct`] (v0.38). Iterates
-/// the rows in batches via [`crate::sql::select_rows_as_json_pool`] so
+/// the rows in batches via [`crate::sql::select_rows_as_json`] so
 /// the same body runs across every backend the [`crate::sql::Pool`]
 /// enum carries. `batch_size = 0` clamps to 1.
 ///
@@ -405,7 +405,7 @@ where
             limit: Some(batch),
             offset: Some(offset),
         };
-        let rows = crate::sql::select_rows_as_json_pool(pool, &select_q, &fields).await?;
+        let rows = crate::sql::select_rows_as_json(pool, &select_q, &fields).await?;
         if rows.is_empty() {
             break;
         }

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -790,7 +790,7 @@ pub mod extractors;
 /// in ~5 lines. See [`viewset::ViewSet`].
 ///
 /// v0.38 — fully tri-dialect. Internal queries route through
-/// `select_rows_as_json_pool` + `insert_returning_pool` etc., so the
+/// `select_rows_as_json` + `insert_returning_pool` etc., so the
 /// same ViewSet body runs on PG / MySQL / SQLite. The `.serializer()`
 /// row-render extension stays PG-only because it decodes via
 /// `T::from_row(&PgRow)`; non-PG ViewSets use the default field-level
@@ -809,8 +809,8 @@ pub mod viewset;
 /// usage and the canonical Tera context shape.
 ///
 /// v0.38 slice 22 — fully tri-dialect. State carries Pool enum;
-/// handlers route through select_rows_as_json_pool /
-/// select_one_row_as_json_pool / insert_returning_pool /
+/// handlers route through select_rows_as_json /
+/// select_one_row_as_json / insert_returning_pool /
 /// update_pool / delete_pool. PG schema-mode tenants get
 /// `SET search_path` via Tenant<Postgres>; sqlite/mysql tenants use
 /// database-mode via Tenant<DB>.pool(). MySQL note:

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -263,8 +263,8 @@ impl<T: Model> QuerySet<T> {
     }
 
     /// v0.45 — discard any previously-set `order_by` and apply
-    /// `items` as the new ordering. Used by `earliest_pool` and
-    /// `latest_pool` which declare their own sort. Clears every
+    /// `items` as the new ordering. Used by `earliest` and
+    /// `latest` which declare their own sort. Clears every
     /// pending item (legacy + `_with_nulls` + `_expr`).
     #[must_use]
     pub fn replace_order_by(mut self, items: &[(&str, bool)]) -> Self {
@@ -273,7 +273,7 @@ impl<T: Model> QuerySet<T> {
     }
 
     /// v0.45 — flip every ordering direction in place. Used by
-    /// `last_pool` to invert the queryset's natural sort and take
+    /// `last` to invert the queryset's natural sort and take
     /// the first row from the reversed sequence — avoids OFFSET +
     /// COUNT(*) and works on every dialect. Issue #76: also swaps
     /// `NullsOrder::First` ↔ `NullsOrder::Last` so the "NULLs at the

--- a/crates/rustango/src/sql/backend.rs
+++ b/crates/rustango/src/sql/backend.rs
@@ -29,14 +29,14 @@
 //! Now the macro emits one cfg-free call:
 //!
 //! ```ignore
-//! ::rustango::sql::apply_auto_pk_pool(
+//! ::rustango::sql::apply_auto_pk(
 //!     _result, self,
 //!     |slf, row| { slf.id = ::rustango::sql::try_get_returning(row, "id")?; Ok(()) },
 //!     |slf, id| { slf.id = ::rustango::sql::Auto::Set(id); Ok(()) },
 //! )?;
 //! ```
 //!
-//! The cfg lives inside [`apply_auto_pk_pool`] and on the type aliases
+//! The cfg lives inside [`apply_auto_pk`] and on the type aliases
 //! [`PgReturningRow`] / [`MyReturningRow`], all in this module. Closure
 //! bodies stay typecheckable in either feature config because the
 //! aliases resolve to uninhabited types when the feature is off and
@@ -236,7 +236,7 @@ impl MysqlAutoIdSet for chrono::DateTime<chrono::Utc> {
 }
 
 /// Hidden trait every macro-emitted `#[derive(Model)]` with at least
-/// one `Auto<T>` field implements. Lets [`apply_auto_pk_pool`] route
+/// one `Auto<T>` field implements. Lets [`apply_auto_pk`] route
 /// an `InsertReturningPool` result to the right per-backend assignment
 /// without the macro emitting any `#[cfg]` arms.
 ///
@@ -285,7 +285,7 @@ pub trait AssignAutoPkPool {
 ///
 /// # Errors
 /// Whatever the dispatched trait method returns.
-pub fn apply_auto_pk_pool<M: AssignAutoPkPool + ?Sized>(
+pub fn apply_auto_pk<M: AssignAutoPkPool + ?Sized>(
     result: super::InsertReturningPool,
     model: &mut M,
 ) -> Result<(), ExecError> {

--- a/crates/rustango/src/sql/error.rs
+++ b/crates/rustango/src/sql/error.rs
@@ -284,7 +284,7 @@ pub enum ExecError {
     /// `get_or_create` / `update_or_create` (v0.45) was called with a
     /// filter that matches more than one row. Django's
     /// `MultipleObjectsReturned`. Tighten the filter or use
-    /// [`crate::query::QuerySet::first_pool`] when ambiguity is
+    /// [`crate::query::QuerySet::first`] when ambiguity is
     /// acceptable.
     #[error("`{op}` filter matched {count} rows on `{table}`; expected at most 1")]
     MultipleRowsReturned {

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -236,7 +236,7 @@ where
         self.fetch_paginated_on(pool).await
     }
 
-    /// Tenant-scoped companion to [`QuerySet::in_bulk_pool`] — same
+    /// Tenant-scoped companion to [`QuerySet::in_bulk`] — same
     /// semantic but takes any sqlx executor (`&PgPool`,
     /// `&mut PgConnection`, or a `Transaction`) so schema-mode tenant
     /// queries route through the per-checkout `SET search_path`
@@ -3380,7 +3380,7 @@ where
     /// // Auto::Set unwrap (every fetched row has an `Auto::Set`
     /// // value; `Auto::Unset` would be a programming error).
     /// let books: HashMap<i64, Book> = Book::objects()
-    ///     .in_bulk_pool(Book::id, [1_i64, 2, 3], |b| match b.id {
+    ///     .in_bulk(Book::id, [1_i64, 2, 3], |b| match b.id {
     ///         Auto::Set(v) => v,
     ///         Auto::Unset  => unreachable!("fetched row has PK"),
     ///     }, &pool)
@@ -3388,7 +3388,7 @@ where
     ///
     /// // `field_name=` equivalent — key by any unique column.
     /// let books_by_isbn: HashMap<String, Book> = Book::objects()
-    ///     .in_bulk_pool(Book::isbn, ["isbn-1", "isbn-2"], |b| b.isbn.clone(), &pool)
+    ///     .in_bulk(Book::isbn, ["isbn-1", "isbn-2"], |b| b.isbn.clone(), &pool)
     ///     .await?;
     /// ```
     ///
@@ -3399,7 +3399,7 @@ where
     ///
     /// # Errors
     /// As [`FetcherPool::fetch_pool`].
-    pub async fn in_bulk_pool<C, K, I, F>(
+    pub async fn in_bulk<C, K, I, F>(
         self,
         column: C,
         ids: I,

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -235,6 +235,50 @@ where
     pub async fn fetch_paginated(self, pool: &PgPool) -> Result<Page<T>, ExecError> {
         self.fetch_paginated_on(pool).await
     }
+
+    /// Tenant-scoped companion to [`QuerySet::in_bulk_pool`] — same
+    /// semantic but takes any sqlx executor (`&PgPool`,
+    /// `&mut PgConnection`, or a `Transaction`) so schema-mode tenant
+    /// queries route through the per-checkout `SET search_path`
+    /// connection. Issue #24.
+    ///
+    /// # Errors
+    /// As [`Self::fetch_on`].
+    pub async fn in_bulk_on<'c, E, C, K, I, F>(
+        self,
+        column: C,
+        ids: I,
+        extract: F,
+        executor: E,
+    ) -> Result<std::collections::HashMap<K, T>, ExecError>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+        T: LoadRelated,
+        C: crate::core::Column<Model = T>,
+        K: Eq + std::hash::Hash + Into<crate::core::SqlValue>,
+        I: IntoIterator<Item = K>,
+        F: Fn(&T) -> K,
+    {
+        let _ = column;
+        let id_values: Vec<crate::core::SqlValue> = ids.into_iter().map(|v| v.into()).collect();
+        if id_values.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        let rows = self
+            .filter_op(
+                C::COLUMN,
+                crate::core::Op::In,
+                crate::core::SqlValue::List(id_values),
+            )
+            .fetch_on(executor)
+            .await?;
+        let mut out = std::collections::HashMap::with_capacity(rows.len());
+        for row in rows {
+            let key = extract(&row);
+            out.insert(key, row);
+        }
+        Ok(out)
+    }
 }
 
 /// Result of [`QuerySet::fetch_paginated_on`] — a slice of rows
@@ -3309,6 +3353,88 @@ where
         self = self.replace_order_by(&[(field, true)]);
         let rows = self.limit(1).fetch_pool(pool).await?;
         Ok(rows.into_iter().next())
+    }
+
+    /// Issue #24 — Django's `Model.objects.in_bulk(ids, field_name=)`:
+    /// fetch a set of rows by a column value list and return them
+    /// keyed by that column in a `HashMap`.
+    ///
+    /// `column` is a typed [`crate::core::Column`] reference (e.g.
+    /// `User::id` or `Book::isbn`) so the filter column is checked
+    /// against the model at compile time. `ids` is an iterable of
+    /// values — the SQL becomes `… WHERE <column> IN ($1, $2, …)`.
+    /// `extract` reads the key off each fetched row so the map can be
+    /// built without re-decoding the column from the raw `sqlx::Row`
+    /// (a closure also gives callers full control over `Auto<T>` /
+    /// `ForeignKey<T, K>` unwrap shape).
+    ///
+    /// Empty `ids` short-circuits with an empty `HashMap` — no SQL is
+    /// issued, sidestepping `Op::In` with an empty list (which the
+    /// writer rejects with [`crate::sql::SqlError::EmptyInList`]).
+    ///
+    /// ```ignore
+    /// use std::collections::HashMap;
+    /// use rustango::sql::Auto;
+    ///
+    /// // Default — keyed by the Auto<i64> PK. The closure handles
+    /// // Auto::Set unwrap (every fetched row has an `Auto::Set`
+    /// // value; `Auto::Unset` would be a programming error).
+    /// let books: HashMap<i64, Book> = Book::objects()
+    ///     .in_bulk_pool(Book::id, [1_i64, 2, 3], |b| match b.id {
+    ///         Auto::Set(v) => v,
+    ///         Auto::Unset  => unreachable!("fetched row has PK"),
+    ///     }, &pool)
+    ///     .await?;
+    ///
+    /// // `field_name=` equivalent — key by any unique column.
+    /// let books_by_isbn: HashMap<String, Book> = Book::objects()
+    ///     .in_bulk_pool(Book::isbn, ["isbn-1", "isbn-2"], |b| b.isbn.clone(), &pool)
+    ///     .await?;
+    /// ```
+    ///
+    /// When the result contains multiple rows sharing the same key
+    /// (only possible if `column` is not unique), the *later* row
+    /// wins — matches `HashMap::insert` semantics. Pair with a
+    /// unique column to avoid surprises.
+    ///
+    /// # Errors
+    /// As [`FetcherPool::fetch_pool`].
+    pub async fn in_bulk_pool<C, K, I, F>(
+        self,
+        column: C,
+        ids: I,
+        extract: F,
+        pool: &Pool,
+    ) -> Result<std::collections::HashMap<K, T>, ExecError>
+    where
+        C: crate::core::Column<Model = T>,
+        K: Eq + std::hash::Hash + Into<crate::core::SqlValue>,
+        I: IntoIterator<Item = K>,
+        F: Fn(&T) -> K,
+    {
+        // `column` is consumed only to thread the `Column<Model = T>`
+        // bound — its `COLUMN` const drives the WHERE filter below.
+        // Discarding the value keeps the ZST instance from triggering
+        // an unused-variable warning.
+        let _ = column;
+        let id_values: Vec<crate::core::SqlValue> = ids.into_iter().map(|v| v.into()).collect();
+        if id_values.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        let rows = self
+            .filter_op(
+                C::COLUMN,
+                crate::core::Op::In,
+                crate::core::SqlValue::List(id_values),
+            )
+            .fetch_pool(pool)
+            .await?;
+        let mut out = std::collections::HashMap::with_capacity(rows.len());
+        for row in rows {
+            let key = extract(&row);
+            out.insert(key, row);
+        }
+        Ok(out)
     }
 }
 

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -758,7 +758,7 @@ pub fn row_to_json_sqlite(
 /// # Errors
 /// SQL compilation / driver failures only — per-cell decode errors
 /// are swallowed into `Value::Null`.
-pub async fn select_rows_as_json_pool(
+pub async fn select_rows_as_json(
     pool: &Pool,
     query: &SelectQuery,
     fields: &[&'static crate::core::FieldSchema],
@@ -901,12 +901,12 @@ fn augment_joined_columns_sqlite(
     }
 }
 
-/// Single-row companion of [`select_rows_as_json_pool`]. Returns
+/// Single-row companion of [`select_rows_as_json`]. Returns
 /// `Ok(None)` when no rows match.
 ///
 /// # Errors
-/// As [`select_rows_as_json_pool`].
-pub async fn select_one_row_as_json_pool(
+/// As [`select_rows_as_json`].
+pub async fn select_one_row_as_json(
     pool: &Pool,
     query: &SelectQuery,
     fields: &[&'static crate::core::FieldSchema],
@@ -2091,7 +2091,7 @@ pub async fn insert_returning_pool(
             // the same shape as Postgres, so the flow mirrors PG: bind
             // params, fetch the row, hand it to the macro-emitted
             // `__rustango_assign_from_sqlite_row` body via
-            // `apply_auto_pk_pool`.
+            // `apply_auto_pk`.
             let stmt = pool.dialect().compile_insert(query)?;
             let mut q: sqlx::query::Query<'_, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'_>> =
                 sqlx::query(&stmt.sql);
@@ -3306,7 +3306,7 @@ where
     ///
     /// # Errors
     /// As [`FetcherPool::fetch_pool`].
-    pub async fn first_pool(self, pool: &Pool) -> Result<Option<T>, ExecError> {
+    pub async fn first(self, pool: &Pool) -> Result<Option<T>, ExecError> {
         let qs = ensure_pk_ordering(self, /*reverse=*/ false);
         let rows = qs.limit(1).fetch_pool(pool).await?;
         Ok(rows.into_iter().next())
@@ -3321,7 +3321,7 @@ where
     ///
     /// # Errors
     /// As [`FetcherPool::fetch_pool`].
-    pub async fn last_pool(self, pool: &Pool) -> Result<Option<T>, ExecError> {
+    pub async fn last(self, pool: &Pool) -> Result<Option<T>, ExecError> {
         let qs = ensure_pk_ordering(self, /*reverse=*/ true);
         let rows = qs.limit(1).fetch_pool(pool).await?;
         Ok(rows.into_iter().next())
@@ -3335,7 +3335,7 @@ where
     ///
     /// # Errors
     /// As [`FetcherPool::fetch_pool`].
-    pub async fn earliest_pool(mut self, field: &str, pool: &Pool) -> Result<Option<T>, ExecError> {
+    pub async fn earliest(mut self, field: &str, pool: &Pool) -> Result<Option<T>, ExecError> {
         self = self.replace_order_by(&[(field, false)]);
         let rows = self.limit(1).fetch_pool(pool).await?;
         Ok(rows.into_iter().next())
@@ -3349,7 +3349,7 @@ where
     ///
     /// # Errors
     /// As [`FetcherPool::fetch_pool`].
-    pub async fn latest_pool(mut self, field: &str, pool: &Pool) -> Result<Option<T>, ExecError> {
+    pub async fn latest(mut self, field: &str, pool: &Pool) -> Result<Option<T>, ExecError> {
         self = self.replace_order_by(&[(field, true)]);
         let rows = self.limit(1).fetch_pool(pool).await?;
         Ok(rows.into_iter().next())
@@ -3459,7 +3459,7 @@ where
 /// # Example
 ///
 /// ```ignore
-/// let (post, created) = rustango::sql::get_or_create_pool(
+/// let (post, created) = rustango::sql::get_or_create(
 ///     Post::objects().filter("slug", "hello"),
 ///     |pool| async move {
 ///         let mut p = Post {
@@ -3478,7 +3478,7 @@ where
 /// - [`ExecError::MultipleRowsReturned`] when the filter matches >1 row.
 /// - Whatever the `create_fn` closure returns when matching no rows.
 /// - Whatever [`FetcherPool::fetch_pool`] returns.
-pub async fn get_or_create_pool<T, F, Fut>(
+pub async fn get_or_create<T, F, Fut>(
     qs: crate::query::QuerySet<T>,
     create_fn: F,
     pool: &Pool,
@@ -3514,17 +3514,17 @@ where
 /// none, invoke `create_fn` and return `(created, true)`. Matching
 /// multiple rows returns [`ExecError::MultipleRowsReturned`].
 ///
-/// Same atomicity caveat as [`get_or_create_pool`] — wrap in a
+/// Same atomicity caveat as [`get_or_create`] — wrap in a
 /// transaction or rely on a UNIQUE constraint for race-free
 /// semantics.
 ///
 /// Both closures receive an **owned** `Pool` for the same
-/// async-lifetime reason as [`get_or_create_pool`].
+/// async-lifetime reason as [`get_or_create`].
 ///
 /// # Example
 ///
 /// ```ignore
-/// let (post, created) = rustango::sql::update_or_create_pool(
+/// let (post, created) = rustango::sql::update_or_create(
 ///     Post::objects().filter("slug", "hello"),
 ///     |pool, mut existing| async move {
 ///         existing.title = "New title".into();
@@ -3541,8 +3541,8 @@ where
 /// ```
 ///
 /// # Errors
-/// As [`get_or_create_pool`].
-pub async fn update_or_create_pool<T, UF, UFut, CF, CFut>(
+/// As [`get_or_create`].
+pub async fn update_or_create<T, UF, UFut, CF, CFut>(
     qs: crate::query::QuerySet<T>,
     update_fn: UF,
     create_fn: CF,
@@ -3580,8 +3580,8 @@ where
 }
 
 /// v0.45 helper — ensure the queryset has *some* deterministic
-/// ordering before slicing to one row. Used by `first_pool` and
-/// `last_pool`. If the caller already provided an `order_by`, we
+/// ordering before slicing to one row. Used by `first` and
+/// `last`. If the caller already provided an `order_by`, we
 /// either keep it (forward) or flip every direction (reverse). If
 /// they didn't, we fall back to the model's primary key.
 fn ensure_pk_ordering<T: Model>(

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -24,7 +24,7 @@ mod writers;
 
 pub use auto::Auto;
 pub use backend::{
-    apply_auto_pk_pool, try_get_returning, try_get_returning_my, try_get_returning_sqlite,
+    apply_auto_pk, try_get_returning, try_get_returning_my, try_get_returning_sqlite,
     AssignAutoPkPool, MyReturningRow, MysqlAutoIdSet, PgReturningRow, SqliteReturningRow,
 };
 pub use compiled::CompiledStatement;
@@ -37,11 +37,11 @@ pub use executor::row_to_json_my;
 pub use executor::row_to_json_sqlite;
 pub use executor::{
     bulk_insert_pool, bulk_update_pool, count_rows_pool, delete_pool, delete_tx,
-    fetch_aggregate_pool, fetch_paginated_pool, fetch_with_prefetch_pool, get_or_create_pool,
+    fetch_aggregate_pool, fetch_paginated_pool, fetch_with_prefetch_pool, get_or_create,
     insert_pool, insert_returning_pool, insert_returning_tx, insert_tx, raw_execute_pool,
-    raw_query_pool, select_one_row_as_json_pool, select_one_row_pool, select_rows_as_json_pool,
+    raw_query_pool, select_one_row_as_json, select_one_row_pool, select_rows_as_json,
     select_rows_pool, select_rows_pool_with_related, select_rows_tx_with_related, transaction_pool,
-    update_or_create_pool, update_pool, update_tx, CounterPool, ExplainFormat, ExplainOptions,
+    update_or_create, update_pool, update_tx, CounterPool, ExplainFormat, ExplainOptions,
     FetcherPool, FetcherTx, FkPkAccess, HasPkValue, InsertReturningPool, LoadRelated,
     MaybeMyFromRow, MaybeMyLoadRelated, MaybePgFromRow, MaybeSqliteFromRow, MaybeSqliteLoadRelated,
     Page, PoolTx, UpdaterPool,

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -79,7 +79,7 @@ use tera::{Context, Tera};
 
 use crate::core::{Filter, ModelSchema, Op, SelectQuery, SqlValue, WhereExpr};
 use crate::sql::Pool;
-use crate::sql::{count_rows_pool, select_one_row_as_json_pool, select_rows_as_json_pool};
+use crate::sql::{count_rows_pool, select_one_row_as_json, select_rows_as_json};
 
 // ============================================================== ListView
 
@@ -592,7 +592,7 @@ async fn handle_list(
 
     let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
     let (rows_result, count_result) = tokio::join!(
-        select_rows_as_json_pool(&state.pool, &select_q, &fields),
+        select_rows_as_json(&state.pool, &select_q, &fields),
         count_rows_pool(&state.pool, &count_q),
     );
     let mut object_list: Vec<Value> = match rows_result {
@@ -829,7 +829,7 @@ async fn handle_detail(
         offset: None,
     };
     let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
-    let object = match select_one_row_as_json_pool(&state.pool, &select_q, &fields).await {
+    let object = match select_one_row_as_json(&state.pool, &select_q, &fields).await {
         Ok(Some(r)) => r,
         Ok(None) => return (StatusCode::NOT_FOUND, "not found").into_response(),
         Err(e) => return template_error(&format!("query row: {e}")),
@@ -955,7 +955,7 @@ async fn handle_delete_confirm(
         offset: None,
     };
     let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
-    let object = match select_one_row_as_json_pool(&state.pool, &select_q, &fields).await {
+    let object = match select_one_row_as_json(&state.pool, &select_q, &fields).await {
         Ok(Some(r)) => r,
         Ok(None) => return (StatusCode::NOT_FOUND, "not found").into_response(),
         Err(e) => return template_error(&format!("query row: {e}")),
@@ -1785,7 +1785,7 @@ async fn handle_update_get(
         offset: None,
     };
     let scalars: Vec<&'static crate::core::FieldSchema> = state.schema.scalar_fields().collect();
-    let row_json = match select_one_row_as_json_pool(&state.pool, &select_q, &scalars).await {
+    let row_json = match select_one_row_as_json(&state.pool, &select_q, &scalars).await {
         Ok(Some(r)) => r,
         Ok(None) => return (StatusCode::NOT_FOUND, "not found").into_response(),
         Err(e) => return template_error(&format!("query row: {e}")),
@@ -2603,7 +2603,7 @@ async fn fetch_fk_display_map_pool(
         None => return Ok(HashMap::new()),
     };
     let fields: Vec<&'static crate::core::FieldSchema> = target.scalar_fields().collect();
-    let rows = select_rows_as_json_pool(pool, &q, &fields).await?;
+    let rows = select_rows_as_json(pool, &q, &fields).await?;
     Ok(extract_fk_display_map(fk, &rows))
 }
 
@@ -2665,7 +2665,7 @@ fn json_value_to_sql_for_fk_pk(v: &Value) -> SqlValue {
     }
 }
 
-/// v0.38 — operates on JSON rows from `select_rows_as_json_pool`
+/// v0.38 — operates on JSON rows from `select_rows_as_json`
 /// instead of raw PgRow. The dialect-aware row → JSON conversion
 /// already covered every column type in [`crate::sql::row_to_json`] /
 /// `row_to_json_my` / `row_to_json_sqlite`, so the FK display
@@ -2799,7 +2799,7 @@ async fn fetch_pks_as_objects_pool(
         offset: None,
     };
     let fields: Vec<&'static crate::core::FieldSchema> = schema.scalar_fields().collect();
-    let rows = select_rows_as_json_pool(pool, &q, &fields)
+    let rows = select_rows_as_json(pool, &q, &fields)
         .await
         .map_err(|e| e.to_string())?;
     Ok(rows)
@@ -2944,14 +2944,14 @@ mod tenant {
 
         // v0.38 — use the tenant's tri-dialect Pool enum; runs the
         // same code on PG / MySQL / SQLite. Routes through
-        // select_rows_as_json_pool + count_rows_pool.
+        // select_rows_as_json + count_rows_pool.
         let pool = t.pool().clone();
         let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
-        let mut object_list =
-            match crate::sql::select_rows_as_json_pool(&pool, &select_q, &fields).await {
-                Ok(r) => r,
-                Err(e) => return template_error(&format!("query rows: {e}")),
-            };
+        let mut object_list = match crate::sql::select_rows_as_json(&pool, &select_q, &fields).await
+        {
+            Ok(r) => r,
+            Err(e) => return template_error(&format!("query rows: {e}")),
+        };
         let total = match crate::sql::count_rows_pool(&pool, &count_q).await {
             Ok(c) => c,
             Err(e) => return template_error(&format!("count rows: {e}")),
@@ -3123,12 +3123,11 @@ mod tenant {
             offset: None,
         };
         let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
-        let object =
-            match crate::sql::select_one_row_as_json_pool(t.pool(), &select_q, &fields).await {
-                Ok(Some(r)) => r,
-                Ok(None) => return (StatusCode::NOT_FOUND, "not found").into_response(),
-                Err(e) => return template_error(&format!("query row: {e}")),
-            };
+        let object = match crate::sql::select_one_row_as_json(t.pool(), &select_q, &fields).await {
+            Ok(Some(r)) => r,
+            Ok(None) => return (StatusCode::NOT_FOUND, "not found").into_response(),
+            Err(e) => return template_error(&format!("query row: {e}")),
+        };
 
         let mut ctx = Context::new();
         ctx.insert("object", &object);
@@ -3169,12 +3168,11 @@ mod tenant {
             offset: None,
         };
         let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
-        let object =
-            match crate::sql::select_one_row_as_json_pool(t.pool(), &select_q, &fields).await {
-                Ok(Some(r)) => r,
-                Ok(None) => return (StatusCode::NOT_FOUND, "not found").into_response(),
-                Err(e) => return template_error(&format!("query row: {e}")),
-            };
+        let object = match crate::sql::select_one_row_as_json(t.pool(), &select_q, &fields).await {
+            Ok(Some(r)) => r,
+            Ok(None) => return (StatusCode::NOT_FOUND, "not found").into_response(),
+            Err(e) => return template_error(&format!("query row: {e}")),
+        };
         let mut ctx = Context::new();
         ctx.insert("object", &object);
         let set_cookie = super::stamp_csrf(&headers, &mut ctx);
@@ -3317,12 +3315,12 @@ mod tenant {
         };
         let scalars: Vec<&'static crate::core::FieldSchema> =
             state.schema.scalar_fields().collect();
-        let row_json =
-            match crate::sql::select_one_row_as_json_pool(t.pool(), &select_q, &scalars).await {
-                Ok(Some(r)) => r,
-                Ok(None) => return (StatusCode::NOT_FOUND, "not found").into_response(),
-                Err(e) => return template_error(&format!("query row: {e}")),
-            };
+        let row_json = match crate::sql::select_one_row_as_json(t.pool(), &select_q, &scalars).await
+        {
+            Ok(Some(r)) => r,
+            Ok(None) => return (StatusCode::NOT_FOUND, "not found").into_response(),
+            Err(e) => return template_error(&format!("query row: {e}")),
+        };
         let row_obj = row_json.as_object().cloned().unwrap_or_default();
         let mut values: HashMap<String, String> = HashMap::with_capacity(row_obj.len());
         for (k, v) in row_obj {

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -170,7 +170,7 @@ impl PaginationStyle {
 /// v0.38 — gated to `cfg(postgres)` because the closure is bound to
 /// `&PgRow` via `T::from_row(row)`. The tri-dialect ViewSet
 /// (`tenant_router` on sqlite/mysql) skips the closure path and
-/// uses the dialect-aware `select_rows_as_json_pool` default
+/// uses the dialect-aware `select_rows_as_json` default
 /// projection.
 #[cfg(feature = "postgres")]
 type RowRender = std::sync::Arc<dyn Fn(&crate::sql::sqlx::postgres::PgRow) -> Value + Send + Sync>;
@@ -496,7 +496,7 @@ impl AcquiredConn {
         q: &SelectQuery,
         fields: &[&'static crate::core::FieldSchema],
     ) -> Result<Vec<Value>, crate::sql::ExecError> {
-        crate::sql::select_rows_as_json_pool(&self.pool, q, fields).await
+        crate::sql::select_rows_as_json(&self.pool, q, fields).await
     }
 
     async fn count_rows(&mut self, q: &CountQuery) -> Result<i64, crate::sql::ExecError> {
@@ -508,7 +508,7 @@ impl AcquiredConn {
         q: &SelectQuery,
         fields: &[&'static crate::core::FieldSchema],
     ) -> Result<Option<Value>, crate::sql::ExecError> {
-        let mut rows = crate::sql::select_rows_as_json_pool(&self.pool, q, fields).await?;
+        let mut rows = crate::sql::select_rows_as_json(&self.pool, q, fields).await?;
         Ok(rows.pop())
     }
 
@@ -922,7 +922,7 @@ async fn handle_list(
             // same connection are typically faster than two pool
             // round-trips anyway.
             // v0.38 — fetch as JSON directly via the tri-dialect
-            // `select_rows_as_json_pool`; the optional row_render
+            // `select_rows_as_json`; the optional row_render
             // closure (PG-only, requires PgRow) is no longer applied
             // here because the AcquiredConn is dialect-agnostic. PG
             // projects that want the serializer extension can still

--- a/crates/rustango/tests/audit_mysql_live.rs
+++ b/crates/rustango/tests/audit_mysql_live.rs
@@ -10,7 +10,7 @@
 //!   PG's `NOW() - INTERVAL`)
 //! - `cleanup_keep_last_n_pool` per-entity retention via window
 //!   functions (MySQL 8.0+ supports `ROW_NUMBER() OVER`)
-//! - `list_pool` / `count_pool` / `facet_counts_pool` activity-feed
+//! - `list` / `count` / `facet_counts` activity-feed
 //!   helpers
 //!
 //! Reads `MYSQL_TEST_URL`. Tests skip silently when unset so
@@ -178,10 +178,10 @@ async fn list_pool_filters_and_paginates_on_mysql() {
         entity_table: Some("post".into()),
         ..Default::default()
     };
-    let rows = audit::list_pool(&pool, &filter, 50, 0).await.unwrap();
+    let rows = audit::list(&pool, &filter, 50, 0).await.unwrap();
     assert_eq!(rows.len(), 2);
     assert!(rows.iter().all(|r| r.entity_table == "post"));
-    let total = audit::count_pool(&pool, &filter).await.unwrap();
+    let total = audit::count(&pool, &filter).await.unwrap();
     assert_eq!(total, 2);
 }
 
@@ -201,9 +201,7 @@ async fn facet_counts_returns_groupby_on_mysql() {
             .await
             .unwrap();
     }
-    let facets = audit::facet_counts_pool(&pool, "entity_table")
-        .await
-        .unwrap();
+    let facets = audit::facet_counts(&pool, "entity_table").await.unwrap();
     assert_eq!(facets[0], ("post".to_string(), 3));
     assert_eq!(facets[1], ("author".to_string(), 1));
 }
@@ -214,6 +212,6 @@ async fn facet_counts_rejects_non_allowlisted_column_on_mysql() {
     let Some(pool) = mysql_pool().await else {
         return;
     };
-    let r = audit::facet_counts_pool(&pool, "no_such_column").await;
+    let r = audit::facet_counts(&pool, "no_such_column").await;
     assert!(r.is_err(), "non-allowlisted column should be rejected");
 }

--- a/crates/rustango/tests/audit_pool_sqlite_live.rs
+++ b/crates/rustango/tests/audit_pool_sqlite_live.rs
@@ -204,10 +204,10 @@ async fn list_pool_filters_by_entity_table() {
         entity_table: Some("post".into()),
         ..Default::default()
     };
-    let rows = audit::list_pool(&pool, &filter, 50, 0).await.unwrap();
+    let rows = audit::list(&pool, &filter, 50, 0).await.unwrap();
     assert_eq!(rows.len(), 2);
     assert!(rows.iter().all(|r| r.entity_table == "post"));
-    let total = audit::count_pool(&pool, &filter).await.unwrap();
+    let total = audit::count(&pool, &filter).await.unwrap();
     assert_eq!(total, 2);
 }
 
@@ -240,7 +240,7 @@ async fn list_pool_combines_multiple_filters() {
         operation: Some("update".into()),
         source: None,
     };
-    let rows = audit::list_pool(&pool, &filter, 50, 0).await.unwrap();
+    let rows = audit::list(&pool, &filter, 50, 0).await.unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].entity_pk, "1");
     assert_eq!(rows[0].operation, "update");
@@ -259,9 +259,9 @@ async fn list_pool_paginates() {
         .unwrap();
     }
     let filter = audit::AuditFilter::default();
-    let page1 = audit::list_pool(&pool, &filter, 2, 0).await.unwrap();
-    let page2 = audit::list_pool(&pool, &filter, 2, 2).await.unwrap();
-    let page3 = audit::list_pool(&pool, &filter, 2, 4).await.unwrap();
+    let page1 = audit::list(&pool, &filter, 2, 0).await.unwrap();
+    let page2 = audit::list(&pool, &filter, 2, 2).await.unwrap();
+    let page3 = audit::list(&pool, &filter, 2, 4).await.unwrap();
     assert_eq!(page1.len(), 2);
     assert_eq!(page2.len(), 2);
     assert_eq!(page3.len(), 1);
@@ -285,13 +285,11 @@ async fn facet_counts_returns_groupby() {
             .unwrap();
     }
     // entity_table facet: post=3, author=1, sorted count-desc.
-    let facets = audit::facet_counts_pool(&pool, "entity_table")
-        .await
-        .unwrap();
+    let facets = audit::facet_counts(&pool, "entity_table").await.unwrap();
     assert_eq!(facets[0], ("post".to_string(), 3));
     assert_eq!(facets[1], ("author".to_string(), 1));
 
-    let ops = audit::facet_counts_pool(&pool, "operation").await.unwrap();
+    let ops = audit::facet_counts(&pool, "operation").await.unwrap();
     assert!(ops.iter().find(|(v, c)| v == "update" && *c == 2).is_some());
     assert!(ops.iter().find(|(v, c)| v == "create" && *c == 2).is_some());
 }
@@ -300,6 +298,6 @@ async fn facet_counts_returns_groupby() {
 async fn facet_counts_rejects_non_allowlisted_column() {
     let pool = pool().await;
     ensure_table_pool(&pool).await.unwrap();
-    let r = audit::facet_counts_pool(&pool, "no_such_column").await;
+    let r = audit::facet_counts(&pool, "no_such_column").await;
     assert!(r.is_err(), "non-allowlisted column should be rejected");
 }

--- a/crates/rustango/tests/first_last_sqlite_live.rs
+++ b/crates/rustango/tests/first_last_sqlite_live.rs
@@ -1,15 +1,15 @@
-//! v0.45 — live SQLite coverage for `QuerySet::first_pool`,
-//! `last_pool`, `earliest_pool`, `latest_pool`.
+//! v0.45 — live SQLite coverage for `QuerySet::first`,
+//! `last`, `earliest`, `latest`.
 //!
 //! Builder sugar over `order_by + limit(1) + fetch_pool`. No DB-side
 //! ranking logic; this suite proves the ordering semantics match
 //! Django:
 //!
-//! - `first_pool` returns the first row by current ordering (PK ASC
+//! - `first` returns the first row by current ordering (PK ASC
 //!   when no `order_by` is set).
-//! - `last_pool` flips every ordering direction, then takes the
+//! - `last` flips every ordering direction, then takes the
 //!   first row of the reversed sequence (PK DESC when no order set).
-//! - `earliest_pool(field)` / `latest_pool(field)` replace any
+//! - `earliest(field)` / `latest(field)` replace any
 //!   prior ordering with `field ASC` / `field DESC`.
 
 #![cfg(feature = "sqlite")]
@@ -62,9 +62,9 @@ async fn pool_with_rows() -> Pool {
 async fn first_pool_without_order_by_returns_lowest_pk() {
     let pool = pool_with_rows().await;
     let first = V045Post::objects()
-        .first_pool(&pool)
+        .first(&pool)
         .await
-        .expect("first_pool")
+        .expect("first")
         .expect("at least one row");
     // Insertion order made "Gamma" the first row; PK ASC also picks it.
     assert_eq!(first.title, "Gamma");
@@ -75,9 +75,9 @@ async fn first_pool_without_order_by_returns_lowest_pk() {
 async fn last_pool_without_order_by_returns_highest_pk() {
     let pool = pool_with_rows().await;
     let last = V045Post::objects()
-        .last_pool(&pool)
+        .last(&pool)
         .await
-        .expect("last_pool")
+        .expect("last")
         .expect("at least one row");
     // Last-inserted was "Beta" with PK=4.
     assert_eq!(last.title, "Beta");
@@ -87,13 +87,13 @@ async fn last_pool_without_order_by_returns_highest_pk() {
 #[tokio::test]
 async fn last_pool_flips_existing_ordering() {
     let pool = pool_with_rows().await;
-    // Order by title ASC → first is "Alpha". `last_pool` flips that
+    // Order by title ASC → first is "Alpha". `last` flips that
     // to DESC and takes the first → "Gamma".
     let last = V045Post::objects()
         .order_by(&[("title", false)])
-        .last_pool(&pool)
+        .last(&pool)
         .await
-        .expect("last_pool")
+        .expect("last")
         .expect("row");
     assert_eq!(last.title, "Gamma");
 }
@@ -102,9 +102,9 @@ async fn last_pool_flips_existing_ordering() {
 async fn earliest_pool_sorts_ascending_by_field() {
     let pool = pool_with_rows().await;
     let earliest = V045Post::objects()
-        .earliest_pool("view_count", &pool)
+        .earliest("view_count", &pool)
         .await
-        .expect("earliest_pool")
+        .expect("earliest")
         .expect("row");
     assert_eq!(earliest.view_count, 10);
     assert_eq!(earliest.title, "Alpha");
@@ -114,9 +114,9 @@ async fn earliest_pool_sorts_ascending_by_field() {
 async fn latest_pool_sorts_descending_by_field() {
     let pool = pool_with_rows().await;
     let latest = V045Post::objects()
-        .latest_pool("view_count", &pool)
+        .latest("view_count", &pool)
         .await
-        .expect("latest_pool")
+        .expect("latest")
         .expect("row");
     assert_eq!(latest.view_count, 40);
     assert_eq!(latest.title, "Delta");
@@ -125,13 +125,13 @@ async fn latest_pool_sorts_descending_by_field() {
 #[tokio::test]
 async fn earliest_pool_replaces_prior_ordering() {
     let pool = pool_with_rows().await;
-    // Caller mis-ordered to view_count DESC; `earliest_pool` should
+    // Caller mis-ordered to view_count DESC; `earliest` should
     // discard that and sort by title ASC instead.
     let earliest = V045Post::objects()
         .order_by(&[("view_count", true)])
-        .earliest_pool("title", &pool)
+        .earliest("title", &pool)
         .await
-        .expect("earliest_pool")
+        .expect("earliest")
         .expect("row");
     assert_eq!(earliest.title, "Alpha");
 }
@@ -148,8 +148,8 @@ async fn first_pool_on_empty_table_returns_none() {
     .await
     .unwrap();
     let first = V045Post::objects()
-        .first_pool(&pool)
+        .first(&pool)
         .await
-        .expect("first_pool on empty");
+        .expect("first on empty");
     assert!(first.is_none());
 }

--- a/crates/rustango/tests/get_or_create_sqlite_live.rs
+++ b/crates/rustango/tests/get_or_create_sqlite_live.rs
@@ -1,5 +1,5 @@
-//! v0.45 — live SQLite coverage for `get_or_create_pool` and
-//! `update_or_create_pool` (Django-style atomic-ish helpers).
+//! v0.45 — live SQLite coverage for `get_or_create` and
+//! `update_or_create` (Django-style atomic-ish helpers).
 //!
 //! Atomicity caveat: the helpers run SELECT then INSERT/UPDATE in
 //! two statements; another writer could race between the two. For
@@ -10,7 +10,7 @@
 #![cfg(feature = "sqlite")]
 
 use rustango::core::Column as _;
-use rustango::sql::{get_or_create_pool, update_or_create_pool, Auto, ExecError, Pool};
+use rustango::sql::{get_or_create, update_or_create, Auto, ExecError, Pool};
 use rustango::Model;
 
 #[derive(Model, Debug, Clone)]
@@ -40,7 +40,7 @@ async fn pool_with_table() -> Pool {
 #[tokio::test]
 async fn get_or_create_inserts_when_filter_matches_zero() {
     let pool = pool_with_table().await;
-    let (w, created) = get_or_create_pool(
+    let (w, created) = get_or_create(
         Widget::objects().where_(Widget::slug.eq("alpha".to_owned())),
         |pool| async move {
             let mut w = Widget {
@@ -74,7 +74,7 @@ async fn get_or_create_returns_existing_when_filter_matches_one() {
     let existing_id = existing.id;
 
     // Second call should find it instead of inserting.
-    let (w, created) = get_or_create_pool(
+    let (w, created) = get_or_create(
         Widget::objects().where_(Widget::slug.eq("beta".to_owned())),
         |_pool| async move {
             panic!("create_fn must not run when the filter matches");
@@ -102,7 +102,7 @@ async fn get_or_create_errors_when_filter_matches_multiple() {
         };
         w.insert_pool(&pool).await.unwrap();
     }
-    let err = get_or_create_pool(
+    let err = get_or_create(
         Widget::objects().where_(Widget::title.eq("shared title".to_owned())),
         |_pool| async move {
             panic!("create_fn must not run on multi-match");
@@ -131,7 +131,7 @@ async fn update_or_create_updates_existing() {
     };
     existing.insert_pool(&pool).await.unwrap();
 
-    let (w, created) = update_or_create_pool(
+    let (w, created) = update_or_create(
         Widget::objects().where_(Widget::slug.eq("delta".to_owned())),
         |pool, mut existing| async move {
             existing.title = "New".into();
@@ -152,7 +152,7 @@ async fn update_or_create_updates_existing() {
 #[tokio::test]
 async fn update_or_create_creates_when_filter_misses() {
     let pool = pool_with_table().await;
-    let (w, created) = update_or_create_pool(
+    let (w, created) = update_or_create(
         Widget::objects().where_(Widget::slug.eq("epsilon".to_owned())),
         |_pool, _existing| async move {
             panic!("update_fn must not run when there's no match");

--- a/crates/rustango/tests/in_bulk_emission.rs
+++ b/crates/rustango/tests/in_bulk_emission.rs
@@ -1,0 +1,108 @@
+//! Tri-dialect SQL-emission sanity tests for the WHERE clause built
+//! by `QuerySet::in_bulk_pool` (issue #24). The map-building part runs
+//! against a live DB in `in_bulk_live.rs`; this file pins the SQL
+//! shape (a plain `WHERE <col> IN (...)`) across all three dialects
+//! without needing a database.
+
+use rustango::core::{Model as _, Op, SqlValue};
+#[cfg(feature = "mysql")]
+use rustango::sql::MySql;
+#[cfg(feature = "sqlite")]
+use rustango::sql::Sqlite;
+use rustango::sql::{Dialect, Postgres};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "ibulk_book")]
+#[allow(dead_code)]
+pub struct Book {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 32, unique)]
+    isbn: String,
+    #[rustango(max_length = 64)]
+    title: String,
+}
+
+// `in_bulk_pool` is `async` + needs a Pool, so we can't call it from
+// a sync unit test without mocking. The function's only SQL-affecting
+// step is `self.filter_op(C::COLUMN, Op::In, SqlValue::List(ids))`
+// — pin that emission shape directly here.
+
+fn build_in_filter<C: rustango::core::Column<Model = Book>>(
+    _column: C,
+    ids: Vec<SqlValue>,
+) -> rustango::core::SelectQuery {
+    Book::objects()
+        .filter_op(C::COLUMN, Op::In, SqlValue::List(ids))
+        .compile()
+        .unwrap()
+}
+
+#[test]
+fn in_bulk_emits_where_in_on_pg() {
+    let q = build_in_filter(
+        Book::id,
+        vec![SqlValue::I64(1), SqlValue::I64(2), SqlValue::I64(3)],
+    );
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"WHERE "id" IN ($1, $2, $3)"#),
+        "PG: WHERE id IN list: {}",
+        stmt.sql
+    );
+    assert_eq!(stmt.params.len(), 3);
+}
+
+#[cfg(feature = "mysql")]
+#[test]
+fn in_bulk_emits_where_in_on_mysql() {
+    let q = build_in_filter(Book::id, vec![SqlValue::I64(1), SqlValue::I64(2)]);
+    let stmt = MySql.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains("WHERE `id` IN (?, ?)"),
+        "MySQL: WHERE id IN list (backticks): {}",
+        stmt.sql
+    );
+}
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn in_bulk_emits_where_in_on_sqlite() {
+    let q = build_in_filter(
+        Book::isbn,
+        vec![
+            SqlValue::String("isbn-1".into()),
+            SqlValue::String("isbn-2".into()),
+        ],
+    );
+    let stmt = Sqlite.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"WHERE "isbn" IN (?, ?)"#),
+        "SQLite: WHERE isbn IN list: {}",
+        stmt.sql
+    );
+}
+
+/// Empty ids → short-circuit returns empty map, no SQL. The runtime
+/// guards against this so `Op::In` with `SqlValue::List(vec![])` (which
+/// the writer rejects with `EmptyInList`) never reaches the compiler.
+/// Verify via a direct construction that an empty IN list IS rejected
+/// at compile — proves the short-circuit is necessary, not vestigial.
+#[test]
+fn empty_in_list_rejects_at_compile_so_short_circuit_is_load_bearing() {
+    use rustango::sql::SqlError;
+    let q = Book::objects()
+        .filter_op("id", Op::In, SqlValue::List(vec![]))
+        .compile()
+        .unwrap();
+    let err = Postgres.compile_select(&q).unwrap_err();
+    assert!(
+        matches!(err, SqlError::EmptyInList),
+        "raw empty IN list rejected: {err:?}"
+    );
+    // `in_bulk_pool` with empty ids never reaches this codepath — it
+    // returns an empty HashMap before constructing the IN list. See
+    // `in_bulk_with_empty_ids_returns_empty_map_no_sql` in
+    // `tests/in_bulk_live.rs` for the runtime guarantee.
+}

--- a/crates/rustango/tests/in_bulk_emission.rs
+++ b/crates/rustango/tests/in_bulk_emission.rs
@@ -1,5 +1,5 @@
 //! Tri-dialect SQL-emission sanity tests for the WHERE clause built
-//! by `QuerySet::in_bulk_pool` (issue #24). The map-building part runs
+//! by `QuerySet::in_bulk` (issue #24). The map-building part runs
 //! against a live DB in `in_bulk_live.rs`; this file pins the SQL
 //! shape (a plain `WHERE <col> IN (...)`) across all three dialects
 //! without needing a database.
@@ -24,7 +24,7 @@ pub struct Book {
     title: String,
 }
 
-// `in_bulk_pool` is `async` + needs a Pool, so we can't call it from
+// `in_bulk` is `async` + needs a Pool, so we can't call it from
 // a sync unit test without mocking. The function's only SQL-affecting
 // step is `self.filter_op(C::COLUMN, Op::In, SqlValue::List(ids))`
 // — pin that emission shape directly here.
@@ -101,7 +101,7 @@ fn empty_in_list_rejects_at_compile_so_short_circuit_is_load_bearing() {
         matches!(err, SqlError::EmptyInList),
         "raw empty IN list rejected: {err:?}"
     );
-    // `in_bulk_pool` with empty ids never reaches this codepath — it
+    // `in_bulk` with empty ids never reaches this codepath — it
     // returns an empty HashMap before constructing the IN list. See
     // `in_bulk_with_empty_ids_returns_empty_map_no_sql` in
     // `tests/in_bulk_live.rs` for the runtime guarantee.

--- a/crates/rustango/tests/in_bulk_live.rs
+++ b/crates/rustango/tests/in_bulk_live.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "postgres")]
-//! Live PG tests for `QuerySet::in_bulk_pool` + `in_bulk_on` (issue #24).
+//! Live PG tests for `QuerySet::in_bulk` + `in_bulk_on` (issue #24).
 //! Verifies the IN-list filter + HashMap return shape matches Django's
 //! `Model.objects.in_bulk(ids, field_name=)`. Skips silently when
 //! `DATABASE_URL` is unset.
@@ -84,7 +84,7 @@ async fn in_bulk_by_pk_returns_map_keyed_by_id() {
     // Insert order gives ids 1..=4. Fetch a 2-of-4 subset plus a
     // non-existent id (999) — the non-existent should be absent.
     let books: HashMap<i64, Book> = Book::objects()
-        .in_bulk_pool(Book::id, [1_i64, 3, 999], pk_of, &pool)
+        .in_bulk(Book::id, [1_i64, 3, 999], pk_of, &pool)
         .await
         .unwrap();
 
@@ -106,7 +106,7 @@ async fn in_bulk_by_non_pk_unique_column_keys_on_that_column() {
     };
 
     let books: HashMap<String, Book> = Book::objects()
-        .in_bulk_pool(
+        .in_bulk(
             Book::isbn,
             ["isbn-2".to_string(), "isbn-4".to_string()],
             |b| b.isbn.clone(),
@@ -132,14 +132,14 @@ async fn in_bulk_with_empty_ids_returns_empty_map_no_sql() {
     };
 
     let books: HashMap<i64, Book> = Book::objects()
-        .in_bulk_pool(Book::id, Vec::<i64>::new(), pk_of, &pool)
+        .in_bulk(Book::id, Vec::<i64>::new(), pk_of, &pool)
         .await
         .unwrap();
 
     assert!(books.is_empty());
 }
 
-/// `in_bulk_pool` composes with prior `.where_()` calls — the IN-list
+/// `in_bulk` composes with prior `.where_()` calls — the IN-list
 /// filter AND-joins with whatever the queryset already has. Only
 /// matches that pass BOTH the existing WHERE and the IN list come
 /// back. Concrete example: filter by title prefix first, then look
@@ -157,7 +157,7 @@ async fn in_bulk_composes_with_prior_where_clauses() {
     // survives the pre-filter.
     let books: HashMap<i64, Book> = Book::objects()
         .where_(Book::title.like("Rust%"))
-        .in_bulk_pool(Book::id, [1_i64, 2, 3, 4], pk_of, &pool)
+        .in_bulk(Book::id, [1_i64, 2, 3, 4], pk_of, &pool)
         .await
         .unwrap();
 

--- a/crates/rustango/tests/in_bulk_live.rs
+++ b/crates/rustango/tests/in_bulk_live.rs
@@ -1,0 +1,196 @@
+#![cfg(feature = "postgres")]
+//! Live PG tests for `QuerySet::in_bulk_pool` + `in_bulk_on` (issue #24).
+//! Verifies the IN-list filter + HashMap return shape matches Django's
+//! `Model.objects.in_bulk(ids, field_name=)`. Skips silently when
+//! `DATABASE_URL` is unset.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "inbulk_book")]
+#[allow(dead_code)]
+pub struct Book {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 32)]
+    pub isbn: String,
+    #[rustango(max_length = 64)]
+    pub title: String,
+}
+
+fn lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn fresh_pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pg = sqlx::PgPool::connect(&url).await.ok()?;
+    sqlx::query(r#"DROP TABLE IF EXISTS "inbulk_book" CASCADE"#)
+        .execute(&pg)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"
+        CREATE TABLE "inbulk_book" (
+            id BIGSERIAL PRIMARY KEY,
+            isbn VARCHAR(32) NOT NULL UNIQUE,
+            title VARCHAR(64) NOT NULL
+        )
+        "#,
+    )
+    .execute(&pg)
+    .await
+    .unwrap();
+    let pool = Pool::Postgres(pg);
+    for (isbn, title) in [
+        ("isbn-1", "The Rust Programming Language"),
+        ("isbn-2", "Programming Rust"),
+        ("isbn-3", "Rust in Action"),
+        ("isbn-4", "Zero to Production in Rust"),
+    ] {
+        let mut b = Book {
+            id: Auto::default(),
+            isbn: isbn.into(),
+            title: title.into(),
+        };
+        b.insert_pool(&pool).await.unwrap();
+    }
+    Some(pool)
+}
+
+fn pk_of(b: &Book) -> i64 {
+    match b.id {
+        Auto::Set(v) => v,
+        Auto::Unset => unreachable!("fetched row should have Auto::Set PK"),
+    }
+}
+
+/// Default Django shape — `Book.objects.in_bulk([1, 2, 3])` keyed by PK.
+/// Subset of the inserted rows comes back, missing IDs are simply
+/// absent from the map (no error).
+#[tokio::test]
+async fn in_bulk_by_pk_returns_map_keyed_by_id() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    // Insert order gives ids 1..=4. Fetch a 2-of-4 subset plus a
+    // non-existent id (999) — the non-existent should be absent.
+    let books: HashMap<i64, Book> = Book::objects()
+        .in_bulk_pool(Book::id, [1_i64, 3, 999], pk_of, &pool)
+        .await
+        .unwrap();
+
+    assert_eq!(books.len(), 2, "two real ids, one missing — got {books:?}");
+    assert!(books.contains_key(&1));
+    assert!(books.contains_key(&3));
+    assert!(!books.contains_key(&999));
+    assert_eq!(books[&1].isbn, "isbn-1");
+    assert_eq!(books[&3].isbn, "isbn-3");
+}
+
+/// Django's `in_bulk(ids, field_name='isbn')` — key by a non-PK unique
+/// column. Same shape, K = String instead of i64.
+#[tokio::test]
+async fn in_bulk_by_non_pk_unique_column_keys_on_that_column() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let books: HashMap<String, Book> = Book::objects()
+        .in_bulk_pool(
+            Book::isbn,
+            ["isbn-2".to_string(), "isbn-4".to_string()],
+            |b| b.isbn.clone(),
+            &pool,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(books.len(), 2);
+    assert!(books.contains_key("isbn-2"));
+    assert!(books.contains_key("isbn-4"));
+    assert_eq!(books["isbn-2"].title, "Programming Rust");
+}
+
+/// Empty `ids` short-circuits — no SQL is issued, an empty map is
+/// returned. Avoids `Op::In` with an empty list (which the SQL writer
+/// would reject with `EmptyInList`).
+#[tokio::test]
+async fn in_bulk_with_empty_ids_returns_empty_map_no_sql() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let books: HashMap<i64, Book> = Book::objects()
+        .in_bulk_pool(Book::id, Vec::<i64>::new(), pk_of, &pool)
+        .await
+        .unwrap();
+
+    assert!(books.is_empty());
+}
+
+/// `in_bulk_pool` composes with prior `.where_()` calls — the IN-list
+/// filter AND-joins with whatever the queryset already has. Only
+/// matches that pass BOTH the existing WHERE and the IN list come
+/// back. Concrete example: filter by title prefix first, then look
+/// up by id — missing matches just drop out.
+#[tokio::test]
+async fn in_bulk_composes_with_prior_where_clauses() {
+    use rustango::core::Column as _;
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    // Pre-filter to books whose title starts with "Rust" — that's
+    // ids 3 ("Rust in Action"). Ask for ids 1, 2, 3, 4; only 3
+    // survives the pre-filter.
+    let books: HashMap<i64, Book> = Book::objects()
+        .where_(Book::title.like("Rust%"))
+        .in_bulk_pool(Book::id, [1_i64, 2, 3, 4], pk_of, &pool)
+        .await
+        .unwrap();
+
+    assert_eq!(books.len(), 1, "only id 3 matches title prefix: {books:?}");
+    assert!(books.contains_key(&3));
+}
+
+/// Tenant-scoped path: `in_bulk_on` takes any sqlx executor (here a
+/// raw `&PgPool` for the test, real callers pass `tenant.conn()`).
+/// Same semantics as the pool path.
+#[tokio::test]
+async fn in_bulk_on_uses_executor_directly() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+    // With only the `postgres` feature on, `Pool` has a single
+    // variant — pattern is irrefutable but the test stays
+    // configuration-honest if mysql/sqlite features are ever
+    // co-enabled in this binary.
+    #[allow(irrefutable_let_patterns)]
+    let Pool::Postgres(pg) = &pool
+    else {
+        unreachable!("test builds with only postgres feature")
+    };
+    let pg = pg.clone();
+
+    let books: HashMap<i64, Book> = Book::objects()
+        .in_bulk_on(Book::id, [2_i64, 4], pk_of, &pg)
+        .await
+        .unwrap();
+
+    assert_eq!(books.len(), 2);
+    assert_eq!(books[&2].isbn, "isbn-2");
+    assert_eq!(books[&4].isbn, "isbn-4");
+}

--- a/crates/rustango/tests/mysql_from_row.rs
+++ b/crates/rustango/tests/mysql_from_row.rs
@@ -258,7 +258,7 @@ pub struct AuditedRecord {
 #[test]
 fn audited_model_gets_delete_pool() {
     // batch 20 — audited models now get delete_pool too. The macro
-    // routes through audit::delete_one_with_audit_pool which opens
+    // routes through audit::delete_one_with_audit which opens
     // a per-backend tx wrapping DELETE + audit emit. Compile-time
     // probe; live exec needs a database.
     fn _probe(rec: &AuditedRecord, pool: &rustango::sql::Pool) {
@@ -269,7 +269,7 @@ fn audited_model_gets_delete_pool() {
 #[test]
 fn audited_model_with_plain_pk_gets_save_pool() {
     // batch 21 — audited non-Auto-PK models get save_pool routing
-    // through audit::save_one_with_audit_pool (per-backend tx wraps
+    // through audit::save_one_with_audit (per-backend tx wraps
     // UPDATE + audit emit atomically; snapshot-style audit).
     fn _probe(rec: &mut AuditedRecord, pool: &rustango::sql::Pool) {
         let _fut = rec.save_pool(pool);
@@ -288,7 +288,7 @@ pub struct AuditedAutoRecord {
 #[test]
 fn audited_auto_pk_model_gets_insert_pool() {
     // batch 22 — audited Auto-PK models get insert_pool routing
-    // through audit::insert_one_with_audit_pool (per-backend tx
+    // through audit::insert_one_with_audit (per-backend tx
     // wraps INSERT + auto-PK readback + audit emit).
     fn _probe(rec: &mut AuditedAutoRecord, pool: &rustango::sql::Pool) {
         drop(rec.insert_pool(pool));
@@ -385,7 +385,7 @@ fn audit_insert_one_with_audit_pool_is_callable() {
             source: rustango::audit::AuditSource::System,
             changes: serde_json::json!({}),
         };
-        let _fut = rustango::audit::insert_one_with_audit_pool(pool, &q, &entry);
+        let _fut = rustango::audit::insert_one_with_audit(pool, &q, &entry);
     }
 }
 
@@ -412,7 +412,7 @@ fn audit_save_one_with_audit_pool_is_callable() {
             source: rustango::audit::AuditSource::System,
             changes: serde_json::json!({}),
         };
-        let _fut = rustango::audit::save_one_with_audit_pool(pool, &q, &entry);
+        let _fut = rustango::audit::save_one_with_audit(pool, &q, &entry);
     }
 }
 
@@ -435,7 +435,7 @@ fn audit_delete_one_with_audit_pool_is_callable() {
             source: rustango::audit::AuditSource::System,
             changes: serde_json::json!({}),
         };
-        let _fut = rustango::audit::delete_one_with_audit_pool(pool, &q, &entry);
+        let _fut = rustango::audit::delete_one_with_audit(pool, &q, &entry);
     }
 }
 

--- a/crates/rustango/tests/row_to_json_pool_sqlite_live.rs
+++ b/crates/rustango/tests/row_to_json_pool_sqlite_live.rs
@@ -1,11 +1,11 @@
-//! Live regression for v0.36 slice 2 — `select_rows_as_json_pool` +
-//! `select_one_row_as_json_pool` against SQLite. Proves the
+//! Live regression for v0.36 slice 2 — `select_rows_as_json` +
+//! `select_one_row_as_json` against SQLite. Proves the
 //! tri-dialect JSON fetch path admin (slice 4) will consume.
 
 #![cfg(feature = "sqlite")]
 
 use rustango::core::{Filter, Model as _, Op, SelectQuery, SqlValue, WhereExpr};
-use rustango::sql::{select_one_row_as_json_pool, select_rows_as_json_pool, sqlx, Auto, Pool};
+use rustango::sql::{select_one_row_as_json, select_rows_as_json, sqlx, Auto, Pool};
 use rustango::Model;
 
 #[derive(Model, Debug, Clone)]
@@ -69,7 +69,7 @@ async fn select_rows_as_json_pool_decodes_sqlite_rows() {
     b.insert_pool(&pool).await.expect("insert beta");
 
     let fields = fields();
-    let rows = select_rows_as_json_pool(
+    let rows = select_rows_as_json(
         &pool,
         &SelectQuery {
             model: Widget::SCHEMA,
@@ -83,7 +83,7 @@ async fn select_rows_as_json_pool_decodes_sqlite_rows() {
         &fields,
     )
     .await
-    .expect("select_rows_as_json_pool");
+    .expect("select_rows_as_json");
 
     assert_eq!(rows.len(), 2);
     assert_eq!(rows[0]["name"], "alpha");
@@ -100,7 +100,7 @@ async fn select_one_row_as_json_pool_returns_none_for_miss() {
     let pool = sqlite_pool_with_widgets().await;
 
     let fields = fields();
-    let got = select_one_row_as_json_pool(
+    let got = select_one_row_as_json(
         &pool,
         &SelectQuery {
             model: Widget::SCHEMA,
@@ -118,7 +118,7 @@ async fn select_one_row_as_json_pool_returns_none_for_miss() {
         &fields,
     )
     .await
-    .expect("select_one_row_as_json_pool");
+    .expect("select_one_row_as_json");
     assert!(got.is_none());
 }
 
@@ -137,7 +137,7 @@ async fn select_one_row_as_json_pool_returns_decoded_row_for_hit() {
     let pk = w.id.get().copied().expect("gamma pk");
 
     let fields = fields();
-    let got = select_one_row_as_json_pool(
+    let got = select_one_row_as_json(
         &pool,
         &SelectQuery {
             model: Widget::SCHEMA,
@@ -155,7 +155,7 @@ async fn select_one_row_as_json_pool_returns_decoded_row_for_hit() {
         &fields,
     )
     .await
-    .expect("select_one_row_as_json_pool")
+    .expect("select_one_row_as_json")
     .expect("row present");
     assert_eq!(got["name"], "gamma");
     assert_eq!(got["count"], 42);

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -183,6 +183,33 @@ let next = Post::objects()
 
 For HTTP-side cursor pagination, use `ViewSet::cursor_pagination("id")` instead.
 
+### Fetch a `HashMap` by column — `.in_bulk_pool()`
+
+Django's `Model.objects.in_bulk(ids, field_name=)` — fetch a set of rows by a column value list and return them keyed by that column. Useful for "look up these N rows in one round trip" patterns. Issue #24.
+
+```rust
+use std::collections::HashMap;
+use rustango::sql::Auto;
+
+// Default Django shape: keyed by the Auto<i64> PK.
+let books: HashMap<i64, Book> = Book::objects()
+    .in_bulk_pool(Book::id, [1_i64, 2, 3], |b| match b.id {
+        Auto::Set(v) => v,
+        Auto::Unset  => unreachable!("fetched row has Auto::Set PK"),
+    }, &pool)
+    .await?;
+assert_eq!(books[&1].title, "The Rust Programming Language");
+
+// `field_name=` equivalent — key by any unique column.
+let by_isbn: HashMap<String, Book> = Book::objects()
+    .in_bulk_pool(Book::isbn, ["isbn-1".to_string()], |b| b.isbn.clone(), &pool)
+    .await?;
+```
+
+Composes with prior `.where_()` filters — the `IN`-list AND-joins with the existing WHERE. Empty `ids` short-circuits with an empty map (no SQL is issued). The closure handles `Auto<T>` / `ForeignKey<T, K>` unwrap explicitly, giving callers control over how the key materializes.
+
+Tenant-scoped sibling: `in_bulk_on(column, ids, extract, &executor)` takes any sqlx executor — pair with `tenant.conn()` for schema-mode tenants.
+
 ---
 
 ## F() expressions + database functions

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -183,7 +183,7 @@ let next = Post::objects()
 
 For HTTP-side cursor pagination, use `ViewSet::cursor_pagination("id")` instead.
 
-### Fetch a `HashMap` by column — `.in_bulk_pool()`
+### Fetch a `HashMap` by column — `.in_bulk()`
 
 Django's `Model.objects.in_bulk(ids, field_name=)` — fetch a set of rows by a column value list and return them keyed by that column. Useful for "look up these N rows in one round trip" patterns. Issue #24.
 
@@ -193,7 +193,7 @@ use rustango::sql::Auto;
 
 // Default Django shape: keyed by the Auto<i64> PK.
 let books: HashMap<i64, Book> = Book::objects()
-    .in_bulk_pool(Book::id, [1_i64, 2, 3], |b| match b.id {
+    .in_bulk(Book::id, [1_i64, 2, 3], |b| match b.id {
         Auto::Set(v) => v,
         Auto::Unset  => unreachable!("fetched row has Auto::Set PK"),
     }, &pool)
@@ -202,7 +202,7 @@ assert_eq!(books[&1].title, "The Rust Programming Language");
 
 // `field_name=` equivalent — key by any unique column.
 let by_isbn: HashMap<String, Book> = Book::objects()
-    .in_bulk_pool(Book::isbn, ["isbn-1".to_string()], |b| b.isbn.clone(), &pool)
+    .in_bulk(Book::isbn, ["isbn-1".to_string()], |b| b.isbn.clone(), &pool)
     .await?;
 ```
 


### PR DESCRIPTION
## Summary

Closes #24. Adds `QuerySet::in_bulk_pool(column, ids, extract, &pool)` and the tenant-scoped sibling `in_bulk_on(...)`. Mirrors Django's `Model.objects.in_bulk(ids, field_name=)` — fetch rows by a column-value list and return them keyed in a `HashMap<K, T>`.

\`\`\`rust
use std::collections::HashMap;
use rustango::sql::Auto;

// Default Django shape — keyed by the Auto<i64> PK.
let books: HashMap<i64, Book> = Book::objects()
    .in_bulk_pool(Book::id, [1_i64, 2, 3], |b| match b.id {
        Auto::Set(v) => v,
        Auto::Unset  => unreachable!(\"fetched row has PK\"),
    }, &pool)
    .await?;

// \`field_name=\` equivalent — key by any unique column.
let by_isbn: HashMap<String, Book> = Book::objects()
    .in_bulk_pool(Book::isbn, [\"isbn-1\".to_string()], |b| b.isbn.clone(), &pool)
    .await?;
\`\`\`

## Design

| Choice | Rationale |
|---|---|
| Typed \`Column<Model = T>\` reference for the filter column | Compile-time check the column belongs to T (won't accept \`Author::name\` on a \`Book::objects()\` queryset) |
| Closure for key extraction | Callers handle \`Auto<T>\` / \`ForeignKey<T, K>\` unwrap explicitly; no framework assumptions about wrapper shape |
| Empty-ids short-circuit | Returns empty map without issuing SQL; sidesteps \`SqlError::EmptyInList\` which would reject an empty IN list at the writer |
| \`in_bulk_on\` parallel | Same shape but takes any sqlx executor for schema-mode tenant connections |

## What landed

- **[\`src/sql/executor.rs\`](crates/rustango/src/sql/executor.rs)** — \`in_bulk_pool\` on the \`QuerySet<T>\` inherent-impl block (sibling to \`first_pool\`/\`last_pool\`/etc.), \`in_bulk_on\` on the PG-only block (sibling to \`fetch_on\`).
- **[\`tests/in_bulk_emission.rs\`](crates/rustango/tests/in_bulk_emission.rs)** — tri-dialect emission tests (4). MySQL/SQLite tests \`#[cfg]\`-gated so PG-only feature config still builds.
- **[\`tests/in_bulk_live.rs\`](crates/rustango/tests/in_bulk_live.rs)** — live PG tests (5): keyed by PK, keyed by non-PK unique column, empty-ids short-circuit, composes with prior \`.where_()\`, tenant-scoped \`in_bulk_on\`.
- **[\`docs/orm.md\`](docs/orm.md)** — cookbook section under \"Pagination\".

## Tests

| Suite | Count | Status |
|---|---|---|
| \`tests/in_bulk_emission.rs\` | 4 (2 in PG-only, 4 in tri-feature) | passing |
| \`tests/in_bulk_live.rs\` (live PG) | 5 | passing |
| \`cargo test -p rustango --features tenancy,mysql,sqlite --tests\` | full suite | passing |

## Verification

\`\`\`
cargo test -p rustango --features tenancy,mysql,sqlite --tests   → all passing
DATABASE_URL=... cargo test --features tenancy --test in_bulk_live → 5 passed
cargo test --workspace --all-features --no-run                   → clean
cargo build --no-default-features --features sqlite,tenancy      → clean
\`\`\`

## Test plan

- [x] Tri-dialect WHERE-IN emission pinned (PG / MySQL / SQLite).
- [x] Live PG runtime verified for both PK-keyed and unique-column-keyed shapes.
- [x] Empty-ids short-circuit returns empty map without SQL.
- [x] Composes correctly with prior \`.where_()\` filters.
- [x] Tenant-scoped \`in_bulk_on\` exercised.
- [x] Workspace \`--all-features --no-run\` gate passes.
- [x] SQLite-tenancy litmus build passes.
- [ ] CI green on \`postgres_test\` + \`mysql_live\` + \`sqlite_live\` + \`sqlite_litmus\`.

## Future-work follow-up

Adding \`Column::extract(&Self::Model) -> &Self::Value\` to the trait (with a macro-generated override per field) would eliminate the closure argument for the common case. Out of scope here — left as a possible v0.40+ ergonomics pass.