### PR TITLE
feat: QuerySet::select_for_update — Django row-lock builder (closes #21)

### DIFF
--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -252,6 +252,7 @@ pub(crate) async fn table_view(
             order_by,
             limit: Some(fetch_limit),
             offset: Some(offset),
+            lock_mode: None,
         },
         &scalar_fields,
     )
@@ -864,6 +865,7 @@ pub(crate) async fn detail_view(
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         },
         &detail_fields,
     )
@@ -1136,6 +1138,7 @@ pub(crate) async fn edit_form(
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         },
         &edit_fields,
     )
@@ -1221,6 +1224,7 @@ pub(crate) async fn update_submit(
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         },
         &before_fields,
     )
@@ -1288,6 +1292,7 @@ pub(crate) async fn delete_submit(
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         },
         &delete_fields,
     )
@@ -1453,6 +1458,7 @@ pub(crate) async fn action_submit(
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         },
         &action_fields,
     )

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -351,6 +351,7 @@ pub async fn fetch_row_as_json(
         order_by: vec![],
         limit: Some(1),
         offset: None,
+        lock_mode: None,
     };
     let fields: Vec<&'static crate::core::FieldSchema> = entry.schema.scalar_fields().collect();
     crate::sql::select_one_row_as_json(pool, &select_q, &fields).await
@@ -404,6 +405,7 @@ where
             .into()],
             limit: Some(batch),
             offset: Some(offset),
+            lock_mode: None,
         };
         let rows = crate::sql::select_rows_as_json(pool, &select_q, &fields).await?;
         if rows.is_empty() {

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -25,8 +25,8 @@ pub use expr::{BinOp, CaseBranch, Expr, ScalarFn, F};
 pub use field_type::FieldType;
 pub use query::{
     AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ColumnFilter,
-    ConflictClause, CountQuery, DeleteQuery, Filter, InsertQuery, Join, JoinKind, NullsOrder, Op,
-    OrderClause, OrderItem, SearchClause, SelectQuery, UpdateQuery, WhereExpr,
+    ConflictClause, CountQuery, DeleteQuery, Filter, InsertQuery, Join, JoinKind, LockMode,
+    NullsOrder, Op, OrderClause, OrderItem, SearchClause, SelectQuery, UpdateQuery, WhereExpr,
 };
 pub use schema::{
     infer_app_label_from_module_path, AdminConfig, CheckConstraint, CompositeFkRelation,

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -415,6 +415,39 @@ pub struct SelectQuery {
     pub order_by: Vec<OrderItem>,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
+    /// Row-lock mode appended after LIMIT/OFFSET — Django's
+    /// `select_for_update(skip_locked=, of=, nowait=, no_key=)`. Issue
+    /// #21. `None` (default) emits no lock clause. Must run inside a
+    /// transaction on PG and MySQL; SQLite has no row-level lock
+    /// syntax (transaction-scope locks are implicit), so the writer
+    /// no-ops on that backend.
+    pub lock_mode: Option<LockMode>,
+}
+
+/// `SELECT … FOR UPDATE` row-lock options — Django's
+/// `QuerySet.select_for_update(skip_locked=, nowait=, of=, no_key=)`.
+/// Issue #21.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LockMode {
+    /// PG 9.3+: `FOR NO KEY UPDATE` instead of `FOR UPDATE`. Holds a
+    /// weaker lock that doesn't block other writers that aren't
+    /// touching the row's PK / unique columns. MySQL has no
+    /// equivalent — the writer falls back to `FOR UPDATE`.
+    pub no_key: bool,
+    /// PG / MySQL 8+: `SKIP LOCKED`. Rows currently locked by another
+    /// transaction are silently filtered out instead of waiting.
+    /// Canonical "claim next available row" pattern.
+    pub skip_locked: bool,
+    /// PG / MySQL 8+: `NOWAIT`. Returns an error immediately if any
+    /// row in the result set is currently locked. Mutually exclusive
+    /// with `skip_locked` at the database level — if both are set,
+    /// the writer emits `SKIP LOCKED` (the more permissive option).
+    pub nowait: bool,
+    /// PG 9.3+: `FOR UPDATE OF table1, table2, …`. Restricts the lock
+    /// to the named tables when the query JOINs. Aliases / table
+    /// names go in; empty vec emits no `OF` clause. MySQL accepts
+    /// `OF` since 8.0.1. SQLite no-op.
+    pub of: Vec<&'static str>,
 }
 
 /// PartialEq for `SelectQuery` — needed so [`crate::core::Expr`] (which
@@ -433,6 +466,7 @@ impl PartialEq for SelectQuery {
             && self.order_by == other.order_by
             && self.limit == other.limit
             && self.offset == other.offset
+            && self.lock_mode == other.lock_mode
     }
 }
 

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -427,7 +427,15 @@ pub struct SelectQuery {
 /// `SELECT … FOR UPDATE` row-lock options — Django's
 /// `QuerySet.select_for_update(skip_locked=, nowait=, of=, no_key=)`.
 /// Issue #21.
+///
+/// `#[non_exhaustive]` — future per-backend lock flags (e.g. PG's
+/// `FOR KEY SHARE`, MySQL's `LOCK IN SHARE MODE`) can be added without
+/// breaking downstream code that constructs `LockMode { … }` directly.
+/// Build via [`LockMode::default`] + field assignment, or chain the
+/// [`crate::query::QuerySet`] builder methods (`.select_for_update()`,
+/// `.skip_locked()`, `.nowait()`, `.no_key()`, `.of(…)`).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct LockMode {
     /// PG 9.3+: `FOR NO KEY UPDATE` instead of `FOR UPDATE`. Holds a
     /// weaker lock that doesn't block other writers that aren't

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -45,6 +45,10 @@ pub struct QuerySet<T: Model> {
     /// time in registration order so chain order is preserved
     /// across mixed builder calls.
     order_by: Vec<PendingOrderItem>,
+    /// Row-lock mode for `SELECT … FOR UPDATE` — Django's
+    /// `select_for_update(skip_locked=, nowait=, of=, no_key=)`.
+    /// Issue #21. `None` (default) emits no lock clause.
+    lock_mode: Option<crate::core::LockMode>,
     _model: PhantomData<fn() -> T>,
 }
 
@@ -132,8 +136,83 @@ impl<T: Model> QuerySet<T> {
             select_related: Vec::new(),
             ad_hoc_joins: Vec::new(),
             order_by: Vec::new(),
+            lock_mode: None,
             _model: PhantomData,
         }
+    }
+
+    /// Issue #21 — Django's `QuerySet.select_for_update(skip_locked=,
+    /// nowait=, of=, no_key=)`. Emits `SELECT … FOR UPDATE` (PG /
+    /// MySQL 8+) or no-ops (SQLite has no row-lock syntax;
+    /// transactions hold an implicit write lock for the whole DB).
+    ///
+    /// Must run inside a transaction — `FOR UPDATE` outside a tx is
+    /// a no-op on PG and an error on MySQL. Acquire one via
+    /// [`crate::sql::transaction`] / [`crate::sql::transaction_pg`]
+    /// and call `.fetch_on(&mut *tx)` or `.fetch(&mut *tx)`.
+    ///
+    /// Default options ([`crate::core::LockMode::default`]) emit
+    /// plain `FOR UPDATE`. Use the chained variants below to set
+    /// individual flags.
+    #[must_use]
+    pub fn select_for_update(mut self) -> Self {
+        self.lock_mode = Some(crate::core::LockMode::default());
+        self
+    }
+
+    /// PG / MySQL 8+: append `SKIP LOCKED` to the lock clause —
+    /// "claim next available row" pattern. Rows currently locked by
+    /// another transaction are silently filtered out instead of
+    /// blocking. No effect on SQLite. Implies
+    /// [`Self::select_for_update`] if not already set.
+    #[must_use]
+    pub fn skip_locked(mut self) -> Self {
+        let mut lock = self.lock_mode.take().unwrap_or_default();
+        lock.skip_locked = true;
+        self.lock_mode = Some(lock);
+        self
+    }
+
+    /// PG / MySQL 8+: append `NOWAIT` — return a driver error
+    /// immediately if any matching row is currently locked. Mutually
+    /// exclusive with `skip_locked` at the database; the writer
+    /// emits `SKIP LOCKED` (the more permissive option) when both
+    /// are set. Implies [`Self::select_for_update`] if not already set.
+    #[must_use]
+    pub fn nowait(mut self) -> Self {
+        let mut lock = self.lock_mode.take().unwrap_or_default();
+        lock.nowait = true;
+        self.lock_mode = Some(lock);
+        self
+    }
+
+    /// PG 9.3+: `FOR NO KEY UPDATE` instead of `FOR UPDATE` — weaker
+    /// lock that doesn't block other writers that aren't touching
+    /// the row's PK / unique columns. Useful for high-concurrency
+    /// update paths where the surrounding `UPDATE` doesn't change
+    /// indexed columns. MySQL has no equivalent; the writer falls
+    /// back to `FOR UPDATE` (the stricter lock).
+    #[must_use]
+    pub fn no_key(mut self) -> Self {
+        let mut lock = self.lock_mode.take().unwrap_or_default();
+        lock.no_key = true;
+        self.lock_mode = Some(lock);
+        self
+    }
+
+    /// PG 9.3+ / MySQL 8.0.1+: `FOR UPDATE OF table1, table2, …` —
+    /// restrict the row lock to the named tables / aliases when the
+    /// query JOINs. Without `OF` the lock applies to every row of
+    /// every joined table the result references. SQLite no-op.
+    ///
+    /// Each call appends. Pass either base table names or join
+    /// aliases.
+    #[must_use]
+    pub fn of(mut self, tables: &[&'static str]) -> Self {
+        let mut lock = self.lock_mode.take().unwrap_or_default();
+        lock.of.extend_from_slice(tables);
+        self.lock_mode = Some(lock);
+        self
     }
 
     /// Append `ORDER BY` columns. Slice 9.0b.
@@ -546,6 +625,7 @@ impl<T: Model> QuerySet<T> {
             order_by,
             limit: self.limit,
             offset: self.offset,
+            lock_mode: self.lock_mode,
         })
     }
 

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -696,6 +696,7 @@ mod tests {
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert_eq!(
@@ -721,6 +722,7 @@ mod tests {
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("LOWER(`name`) NOT LIKE LOWER(?)"));
@@ -742,6 +744,7 @@ mod tests {
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("NOT (`email` <=> ?)"));
@@ -763,6 +766,7 @@ mod tests {
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         // No outer NOT; bare null-safe equality.
@@ -786,6 +790,7 @@ mod tests {
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("JSON_CONTAINS(`meta`, ?)"));
@@ -808,6 +813,7 @@ mod tests {
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         // Argument order is swapped vs JSON_CONTAINS — value first.
@@ -830,6 +836,7 @@ mod tests {
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -856,6 +863,7 @@ mod tests {
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -883,6 +891,7 @@ mod tests {
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -968,6 +977,7 @@ mod tests {
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert_eq!(

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -520,6 +520,7 @@ mod tests {
             limit: None,
             offset: None,
             search: None,
+            lock_mode: None,
         };
         let stmt = Sqlite.compile_select(&q).unwrap();
         // SQLite emits ANSI-quoted identifiers and `?` placeholders.

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -234,7 +234,57 @@ fn write_select_inner(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlErr
         qualify.then_some(query.model.table),
     )?;
 
+    if let Some(lock) = &query.lock_mode {
+        write_lock_clause(b, lock);
+    }
+
     Ok(())
+}
+
+/// Emit `FOR UPDATE [NO KEY] [OF t1, t2] [SKIP LOCKED | NOWAIT]` —
+/// Django's `select_for_update(...)`. Issue #21.
+///
+/// Tri-dialect dispatch:
+/// - **PG**: full support — `FOR [NO KEY] UPDATE [OF …] [SKIP LOCKED | NOWAIT]`.
+/// - **MySQL 8.0.1+**: supports `FOR UPDATE [OF] [NOWAIT | SKIP LOCKED]`.
+///   `NO KEY` has no equivalent — the writer falls back to plain
+///   `FOR UPDATE` (the stricter lock).
+/// - **SQLite**: no row-lock syntax. Transactions hold an implicit
+///   write lock for the whole database, so the lock clause is a no-op
+///   here. Callers wanting "claim next row" semantics on SQLite need
+///   a different strategy (typically a busy-wait loop on the
+///   transaction).
+///
+/// `SKIP LOCKED` wins over `NOWAIT` when both are set — `SKIP LOCKED`
+/// is the more permissive option, and both can't appear in the same
+/// statement at the database level.
+fn write_lock_clause(b: &mut Sql<'_>, lock: &crate::core::LockMode) {
+    if b.d.name() == "sqlite" {
+        // No row-lock syntax — transaction-scope locks are implicit.
+        return;
+    }
+    b.sql.push_str(" FOR ");
+    if lock.no_key && b.d.name() == "postgres" {
+        b.sql.push_str("NO KEY UPDATE");
+    } else {
+        b.sql.push_str("UPDATE");
+    }
+    if !lock.of.is_empty() {
+        b.sql.push_str(" OF ");
+        let mut first = true;
+        for t in &lock.of {
+            if !first {
+                b.sql.push_str(", ");
+            }
+            first = false;
+            b.sql.push_str(&b.d.quote_ident(t));
+        }
+    }
+    if lock.skip_locked {
+        b.sql.push_str(" SKIP LOCKED");
+    } else if lock.nowait {
+        b.sql.push_str(" NOWAIT");
+    }
 }
 
 // ====================================================================

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -580,6 +580,7 @@ async fn handle_list(
         order_by,
         limit: Some(page_size),
         offset: Some(offset),
+        lock_mode: None,
     };
     let count_q = crate::core::CountQuery {
         model: state.vs.schema,
@@ -827,6 +828,7 @@ async fn handle_detail(
         order_by: vec![],
         limit: Some(1),
         offset: None,
+        lock_mode: None,
     };
     let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
     let object = match select_one_row_as_json(&state.pool, &select_q, &fields).await {
@@ -953,6 +955,7 @@ async fn handle_delete_confirm(
         order_by: vec![],
         limit: Some(1),
         offset: None,
+        lock_mode: None,
     };
     let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
     let object = match select_one_row_as_json(&state.pool, &select_q, &fields).await {
@@ -1783,6 +1786,7 @@ async fn handle_update_get(
         order_by: vec![],
         limit: Some(1),
         offset: None,
+        lock_mode: None,
     };
     let scalars: Vec<&'static crate::core::FieldSchema> = state.schema.scalar_fields().collect();
     let row_json = match select_one_row_as_json(&state.pool, &select_q, &scalars).await {
@@ -2633,6 +2637,7 @@ fn build_fk_display_query(fk: &FkLookup) -> SelectQuery {
         order_by: vec![],
         limit: None,
         offset: None,
+        lock_mode: None,
     }
 }
 
@@ -2797,6 +2802,7 @@ async fn fetch_pks_as_objects_pool(
         order_by: vec![],
         limit: None,
         offset: None,
+        lock_mode: None,
     };
     let fields: Vec<&'static crate::core::FieldSchema> = schema.scalar_fields().collect();
     let rows = select_rows_as_json(pool, &q, &fields)
@@ -2935,6 +2941,7 @@ mod tenant {
             order_by,
             limit: Some(page_size),
             offset: Some(offset),
+            lock_mode: None,
         };
         let count_q = crate::core::CountQuery {
             model: state.vs.schema,
@@ -3121,6 +3128,7 @@ mod tenant {
             order_by: vec![],
             limit: Some(1),
             offset: None,
+            lock_mode: None,
         };
         let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
         let object = match crate::sql::select_one_row_as_json(t.pool(), &select_q, &fields).await {
@@ -3166,6 +3174,7 @@ mod tenant {
             order_by: vec![],
             limit: Some(1),
             offset: None,
+            lock_mode: None,
         };
         let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
         let object = match crate::sql::select_one_row_as_json(t.pool(), &select_q, &fields).await {
@@ -3312,6 +3321,7 @@ mod tenant {
             order_by: vec![],
             limit: Some(1),
             offset: None,
+            lock_mode: None,
         };
         let scalars: Vec<&'static crate::core::FieldSchema> =
             state.schema.scalar_fields().collect();

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -908,6 +908,7 @@ async fn handle_list(
                 order_by: order_by.clone(),
                 limit: Some(page_size),
                 offset: Some(offset),
+                lock_mode: None,
             };
             let count_q = CountQuery {
                 model: state.vs.schema,
@@ -1036,6 +1037,7 @@ async fn handle_list_cursor(
         order_by,
         limit: Some(page_size + 1),
         offset: None,
+        lock_mode: None,
     };
     let rows = match acq.select_rows_as_json(&select_q, &fields).await {
         Ok(r) => r,
@@ -1125,6 +1127,7 @@ async fn handle_retrieve(
         order_by: vec![],
         limit: Some(1),
         offset: None,
+        lock_mode: None,
     };
 
     let fields = state.effective_fields();
@@ -1360,6 +1363,7 @@ async fn fetch_by_pk(
         order_by: vec![],
         limit: Some(1),
         offset: None,
+        lock_mode: None,
     };
     let _ = state;
     acq.select_one_as_json(&select_q, fields)

--- a/crates/rustango/tests/mysql_from_row.rs
+++ b/crates/rustango/tests/mysql_from_row.rs
@@ -224,6 +224,7 @@ fn select_rows_pool_with_related_is_callable() {
             order_by: vec![],
             limit: None,
             offset: None,
+            lock_mode: None,
         };
         let _fut: _ = rustango::sql::select_rows_pool_with_related::<User>(pool, &q);
     }

--- a/crates/rustango/tests/q_xor_emission.rs
+++ b/crates/rustango/tests/q_xor_emission.rs
@@ -30,6 +30,7 @@ fn select(where_clause: WhereExpr) -> SelectQuery {
         order_by: vec![],
         limit: None,
         offset: None,
+        lock_mode: None,
     }
 }
 

--- a/crates/rustango/tests/row_to_json_pool_sqlite_live.rs
+++ b/crates/rustango/tests/row_to_json_pool_sqlite_live.rs
@@ -79,6 +79,7 @@ async fn select_rows_as_json_pool_decodes_sqlite_rows() {
             order_by: vec![rustango::core::OrderItem::column("id", false)],
             limit: None,
             offset: None,
+            lock_mode: None,
         },
         &fields,
     )
@@ -114,6 +115,7 @@ async fn select_one_row_as_json_pool_returns_none_for_miss() {
             order_by: Vec::new(),
             limit: Some(1),
             offset: None,
+            lock_mode: None,
         },
         &fields,
     )
@@ -151,6 +153,7 @@ async fn select_one_row_as_json_pool_returns_decoded_row_for_hit() {
             order_by: Vec::new(),
             limit: Some(1),
             offset: None,
+            lock_mode: None,
         },
         &fields,
     )

--- a/crates/rustango/tests/select_for_update_emission.rs
+++ b/crates/rustango/tests/select_for_update_emission.rs
@@ -1,0 +1,278 @@
+//! Tri-dialect SQL-emission tests for `QuerySet::select_for_update`
+//! (issue #21). Django's `SELECT … FOR UPDATE [NO KEY] [OF …]
+//! [SKIP LOCKED | NOWAIT]` shapes. PG supports the full set; MySQL
+//! 8.0.1+ supports most (no `NO KEY`); SQLite has no row-lock
+//! syntax and emits no clause at all.
+
+#[cfg(feature = "mysql")]
+use rustango::sql::MySql;
+#[cfg(feature = "sqlite")]
+use rustango::sql::Sqlite;
+use rustango::sql::{Dialect, Postgres};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "sfu_job")]
+#[allow(dead_code)]
+pub struct Job {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 20)]
+    status: String,
+    priority: i32,
+}
+
+// ---------- PG: full lock-clause matrix ----------
+
+#[test]
+fn select_for_update_plain_emits_for_update_on_pg() {
+    let q = Job::objects().select_for_update().compile().unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(stmt.sql.ends_with(" FOR UPDATE"), "PG plain: {}", stmt.sql);
+}
+
+#[test]
+fn skip_locked_emits_for_update_skip_locked_on_pg() {
+    let q = Job::objects()
+        .select_for_update()
+        .skip_locked()
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.ends_with(" FOR UPDATE SKIP LOCKED"),
+        "PG skip_locked: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn nowait_emits_for_update_nowait_on_pg() {
+    let q = Job::objects()
+        .select_for_update()
+        .nowait()
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.ends_with(" FOR UPDATE NOWAIT"),
+        "PG nowait: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn no_key_emits_for_no_key_update_on_pg() {
+    let q = Job::objects()
+        .select_for_update()
+        .no_key()
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.ends_with(" FOR NO KEY UPDATE"),
+        "PG no_key: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn of_emits_for_update_of_table_list_on_pg() {
+    let q = Job::objects()
+        .select_for_update()
+        .of(&["sfu_job"])
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.ends_with(r#" FOR UPDATE OF "sfu_job""#),
+        "PG of: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn full_lock_clause_combines_no_key_of_and_skip_locked() {
+    let q = Job::objects()
+        .select_for_update()
+        .no_key()
+        .of(&["sfu_job"])
+        .skip_locked()
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql
+            .ends_with(r#" FOR NO KEY UPDATE OF "sfu_job" SKIP LOCKED"#),
+        "PG full combo: {}",
+        stmt.sql
+    );
+}
+
+/// `skip_locked` and `nowait` cannot both appear in the SQL — the
+/// database rejects the combination. The writer picks `SKIP LOCKED`
+/// (more permissive) when both flags are set.
+#[test]
+fn skip_locked_wins_over_nowait_when_both_set() {
+    let q = Job::objects()
+        .select_for_update()
+        .skip_locked()
+        .nowait()
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(" SKIP LOCKED"),
+        "should pick SKIP LOCKED: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains(" NOWAIT"),
+        "should NOT also emit NOWAIT: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Default queryset (no lock) emits no clause ----------
+
+#[test]
+fn without_select_for_update_no_lock_clause_emitted() {
+    let q = Job::objects().compile().unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        !stmt.sql.contains(" FOR UPDATE"),
+        "no lock when select_for_update not called: {}",
+        stmt.sql
+    );
+}
+
+// ---------- LIMIT/OFFSET come BEFORE the lock clause ----------
+
+#[test]
+fn lock_clause_emits_after_limit_offset() {
+    let q = Job::objects()
+        .limit(10)
+        .offset(5)
+        .select_for_update()
+        .skip_locked()
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    let limit_pos = stmt.sql.find(" LIMIT ").expect("has LIMIT");
+    let for_pos = stmt.sql.find(" FOR UPDATE").expect("has FOR UPDATE");
+    assert!(limit_pos < for_pos, "LIMIT before FOR UPDATE: {}", stmt.sql);
+}
+
+// ---------- MySQL: most options work, NO KEY falls back to UPDATE ----------
+
+#[cfg(feature = "mysql")]
+#[test]
+fn select_for_update_skip_locked_on_mysql() {
+    let q = Job::objects()
+        .select_for_update()
+        .skip_locked()
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.ends_with(" FOR UPDATE SKIP LOCKED"),
+        "MySQL skip_locked: {}",
+        stmt.sql
+    );
+}
+
+#[cfg(feature = "mysql")]
+#[test]
+fn no_key_falls_back_to_plain_for_update_on_mysql() {
+    // MySQL has no `FOR NO KEY UPDATE` — falls back to `FOR UPDATE`.
+    let q = Job::objects()
+        .select_for_update()
+        .no_key()
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.ends_with(" FOR UPDATE"),
+        "MySQL no_key falls back: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains("NO KEY"),
+        "no NO KEY on MySQL: {}",
+        stmt.sql
+    );
+}
+
+#[cfg(feature = "mysql")]
+#[test]
+fn of_table_uses_backticks_on_mysql() {
+    let q = Job::objects()
+        .select_for_update()
+        .of(&["sfu_job"])
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.ends_with(" FOR UPDATE OF `sfu_job`"),
+        "MySQL `of` with backticks: {}",
+        stmt.sql
+    );
+}
+
+// ---------- SQLite: lock clause is a no-op ----------
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn select_for_update_emits_no_lock_clause_on_sqlite() {
+    let q = Job::objects()
+        .select_for_update()
+        .skip_locked()
+        .nowait()
+        .no_key()
+        .of(&["sfu_job"])
+        .compile()
+        .unwrap();
+    let stmt = Sqlite.compile_select(&q).unwrap();
+    assert!(
+        !stmt.sql.contains("FOR UPDATE"),
+        "SQLite: no row-lock syntax, lock clause skipped: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains("SKIP LOCKED"),
+        "SQLite: no SKIP LOCKED: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Chained flags compose without losing prior state ----------
+
+#[test]
+fn chained_flag_calls_imply_select_for_update() {
+    // Calling `.skip_locked()` without prior `.select_for_update()`
+    // implicitly sets the lock — Django-style ergonomics.
+    let q = Job::objects().skip_locked().compile().unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.ends_with(" FOR UPDATE SKIP LOCKED"),
+        "skip_locked alone implies FOR UPDATE: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn of_calls_accumulate() {
+    let q = Job::objects()
+        .select_for_update()
+        .of(&["sfu_job"])
+        .of(&["other_table"])
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql
+            .ends_with(r#" FOR UPDATE OF "sfu_job", "other_table""#),
+        "two .of() calls accumulate: {}",
+        stmt.sql
+    );
+}

--- a/crates/rustango/tests/select_for_update_live.rs
+++ b/crates/rustango/tests/select_for_update_live.rs
@@ -155,11 +155,16 @@ async fn nowait_errors_immediately_on_contended_row() {
     let _ = tx2.rollback().await;
 }
 
-/// `select_for_update` outside a transaction is a no-op on PG (the
-/// implicit-tx single-statement holds the lock only for the duration
-/// of the SELECT). Validates that the queryset compiles + executes
-/// cleanly against `&PgPool` directly — even though the lock is
-/// instantly released, the SQL stays well-formed.
+/// `select_for_update` against a bare `&PgPool` — the SQL is
+/// well-formed and the statement executes, but PG treats each
+/// standalone statement as an implicit transaction that ends the
+/// moment the SELECT returns. The lock IS acquired for the duration
+/// of the statement, then immediately released — so this shape is
+/// only useful for testing the writer / smoke-checking the query.
+/// **Production "claim next available row" workflows must use an
+/// explicit `pool.begin()` transaction** (see the SKIP LOCKED test
+/// above for the canonical pattern), otherwise the lock is released
+/// before any follow-up `UPDATE` runs.
 #[tokio::test]
 async fn select_for_update_against_bare_pool_runs_cleanly() {
     let _g = lock().lock().await;

--- a/crates/rustango/tests/select_for_update_live.rs
+++ b/crates/rustango/tests/select_for_update_live.rs
@@ -1,0 +1,208 @@
+#![cfg(feature = "postgres")]
+//! Live PG test for `select_for_update` runtime semantic (issue #21).
+//! Verifies `SKIP LOCKED` produces the canonical "claim next available
+//! row" pattern: two concurrent transactions each grab a different
+//! row, neither blocks. Skips silently when `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::core::Column as _;
+use rustango::sql::{sqlx, Auto};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "sfu_live_job")]
+#[allow(dead_code)]
+pub struct Job {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 20)]
+    pub status: String,
+    pub priority: i32,
+}
+
+fn lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn fresh_pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pool = sqlx::PgPool::connect(&url).await.ok()?;
+    sqlx::query(r#"DROP TABLE IF EXISTS "sfu_live_job" CASCADE"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"
+        CREATE TABLE "sfu_live_job" (
+            id BIGSERIAL PRIMARY KEY,
+            status VARCHAR(20) NOT NULL,
+            priority INTEGER NOT NULL
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    // Seed 3 pending jobs at distinct priorities.
+    for (status, priority) in [("pending", 10), ("pending", 20), ("pending", 30)] {
+        let mut j = Job {
+            id: Auto::default(),
+            status: status.into(),
+            priority,
+        };
+        j.insert_pool(&(&pool).clone().into()).await.unwrap();
+    }
+    Some(pool)
+}
+
+/// Canonical "claim next available row" pattern: two concurrent
+/// transactions each call `SELECT … FOR UPDATE SKIP LOCKED LIMIT 1`.
+/// First transaction grabs row 1; second SKIP LOCKED transaction
+/// skips row 1 (held by tx1) and grabs row 2 instead — they don't
+/// block each other.
+#[tokio::test]
+async fn skip_locked_lets_two_workers_claim_different_rows() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let mut tx1 = pool.begin().await.unwrap();
+    let mut tx2 = pool.begin().await.unwrap();
+
+    // Worker 1 grabs the lowest-priority pending row.
+    let claim1: Vec<Job> = Job::objects()
+        .where_(Job::status.eq("pending"))
+        .order_by(&[("priority", false)])
+        .limit(1)
+        .select_for_update()
+        .skip_locked()
+        .fetch_on(&mut *tx1)
+        .await
+        .unwrap();
+    assert_eq!(claim1.len(), 1, "tx1 grabbed one row");
+    let first_id = match claim1[0].id {
+        Auto::Set(v) => v,
+        Auto::Unset => unreachable!(),
+    };
+
+    // Worker 2 should skip the row locked by tx1 and grab the next.
+    let claim2: Vec<Job> = Job::objects()
+        .where_(Job::status.eq("pending"))
+        .order_by(&[("priority", false)])
+        .limit(1)
+        .select_for_update()
+        .skip_locked()
+        .fetch_on(&mut *tx2)
+        .await
+        .unwrap();
+    assert_eq!(claim2.len(), 1, "tx2 also grabbed a row (no block)");
+    let second_id = match claim2[0].id {
+        Auto::Set(v) => v,
+        Auto::Unset => unreachable!(),
+    };
+
+    assert_ne!(
+        first_id, second_id,
+        "tx1 and tx2 claimed different rows (SKIP LOCKED)"
+    );
+
+    tx1.rollback().await.unwrap();
+    tx2.rollback().await.unwrap();
+}
+
+/// `NOWAIT` on a row already locked by another transaction surfaces a
+/// driver error immediately (Postgres SQLSTATE 55P03 "lock_not_available")
+/// instead of waiting for the lock holder. Verifies the writer's
+/// `NOWAIT` keyword reaches PG and triggers the right behaviour.
+#[tokio::test]
+async fn nowait_errors_immediately_on_contended_row() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let mut tx1 = pool.begin().await.unwrap();
+    let mut tx2 = pool.begin().await.unwrap();
+
+    // tx1 locks all three rows.
+    let _claim1: Vec<Job> = Job::objects()
+        .select_for_update()
+        .fetch_on(&mut *tx1)
+        .await
+        .unwrap();
+
+    // tx2 with NOWAIT should error rather than block.
+    let r2: Result<Vec<Job>, _> = Job::objects()
+        .select_for_update()
+        .nowait()
+        .fetch_on(&mut *tx2)
+        .await;
+    assert!(r2.is_err(), "tx2 NOWAIT should error on contended rows");
+    let msg = format!("{:?}", r2.err().unwrap());
+    // PG reports SQLSTATE 55P03 (lock_not_available); the sqlx error
+    // surfaces the underlying message. Don't pin the exact wording,
+    // just confirm it mentioned lock acquisition.
+    assert!(
+        msg.to_lowercase().contains("lock") || msg.contains("55P03"),
+        "error mentions lock contention: {msg}"
+    );
+
+    tx1.rollback().await.unwrap();
+    let _ = tx2.rollback().await;
+}
+
+/// `select_for_update` outside a transaction is a no-op on PG (the
+/// implicit-tx single-statement holds the lock only for the duration
+/// of the SELECT). Validates that the queryset compiles + executes
+/// cleanly against `&PgPool` directly — even though the lock is
+/// instantly released, the SQL stays well-formed.
+#[tokio::test]
+async fn select_for_update_against_bare_pool_runs_cleanly() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    use rustango::sql::Fetcher as _;
+    let rows: Vec<Job> = Job::objects()
+        .where_(Job::status.eq("pending"))
+        .select_for_update()
+        .skip_locked()
+        .fetch(&pool)
+        .await
+        .unwrap();
+    // No other tx is competing — all 3 pending rows come back.
+    assert_eq!(rows.len(), 3);
+
+    // Tear down.
+    sqlx::query(r#"DROP TABLE "sfu_live_job""#)
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+/// Sanity check on the SQL string: when JOINs are present, `OF` only
+/// locks the named table — without it the lock applies to both.
+/// (The actual JOIN test would need a second table; here we just pin
+/// the emitted shape and confirm it executes.)
+#[tokio::test]
+async fn for_update_with_of_executes_cleanly() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let mut tx = pool.begin().await.unwrap();
+    let rows: Vec<Job> = Job::objects()
+        .select_for_update()
+        .of(&["sfu_live_job"])
+        .fetch_on(&mut *tx)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 3);
+    tx.rollback().await.unwrap();
+}

--- a/crates/rustango/tests/sql.rs
+++ b/crates/rustango/tests/sql.rs
@@ -593,6 +593,7 @@ fn empty_select() -> SelectQuery {
         order_by: vec![],
         limit: None,
         offset: None,
+        lock_mode: None,
     }
 }
 
@@ -810,6 +811,7 @@ fn empty_post_select() -> SelectQuery {
         order_by: vec![],
         limit: None,
         offset: None,
+        lock_mode: None,
     }
 }
 

--- a/crates/rustango/tests/where_expr_live.rs
+++ b/crates/rustango/tests/where_expr_live.rs
@@ -190,6 +190,7 @@ async fn empty_or_branch_returns_named_writer_error() {
         order_by: vec![],
         limit: None,
         offset: None,
+        lock_mode: None,
     };
     let err = Postgres.compile_select(&q).unwrap_err();
     assert!(matches!(err, SqlError::EmptyOrBranch));
@@ -207,6 +208,7 @@ async fn empty_or_branch_returns_named_writer_error() {
         order_by: vec![],
         limit: None,
         offset: None,
+        lock_mode: None,
     };
     rustango::sql::select_rows(&pool, &q2).await.unwrap();
 }

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -210,6 +210,46 @@ Composes with prior `.where_()` filters — the `IN`-list AND-joins with the exi
 
 Tenant-scoped sibling: `in_bulk_on(column, ids, extract, &executor)` takes any sqlx executor — pair with `tenant.conn()` for schema-mode tenants.
 
+### Row-level locks — `.select_for_update()`
+
+Django's `select_for_update(skip_locked=, nowait=, of=, no_key=)` — issue #21. Appends `SELECT … FOR UPDATE` (or its variants) to the query so the matching rows are locked for the duration of the surrounding transaction.
+
+```rust
+// Canonical "claim next available row" pattern. Worker A grabs the
+// lowest-priority pending job; concurrent worker B with SKIP LOCKED
+// skips A's row and grabs the next instead — no blocking.
+let mut tx = pool.begin().await?;
+let claim: Vec<Job> = Job::objects()
+    .where_(Job::status.eq("pending"))
+    .order_by(&[("priority", false)])
+    .limit(1)
+    .select_for_update()
+    .skip_locked()
+    .fetch_on(&mut *tx).await?;
+// ... mark claim[0] as in-progress, do work ...
+tx.commit().await?;
+```
+
+**Builder methods** — chain to opt in:
+
+- `.select_for_update()` — plain `FOR UPDATE`.
+- `.skip_locked()` — append `SKIP LOCKED`; rows held by another tx are silently filtered out instead of blocking.
+- `.nowait()` — append `NOWAIT`; surface a driver error immediately if any matching row is locked. Mutually exclusive with `skip_locked` (writer picks the more permissive `SKIP LOCKED` if both are set).
+- `.no_key()` — emit `FOR NO KEY UPDATE` instead (PG 9.3+). Weaker lock that doesn't block writers touching only non-key columns.
+- `.of(&["table_or_alias", …])` — restrict the lock to specific tables when the query JOINs.
+
+Calling `.skip_locked()` / `.nowait()` / `.no_key()` / `.of(…)` without a prior `.select_for_update()` implicitly enables the lock, matching Django's ergonomics.
+
+**Tri-dialect behaviour:**
+
+| Dialect | Behaviour |
+|---|---|
+| Postgres | Full support — every flag emits its native syntax. |
+| MySQL 8.0.1+ | Supports everything except `NO KEY` — that flag falls back to plain `FOR UPDATE` (the stricter lock). |
+| SQLite | No row-level lock syntax. The writer emits no clause at all; transactions hold an implicit write lock for the whole database. Use a different strategy for SQLite (typically a busy-wait loop on the transaction itself). |
+
+**Must run inside a transaction.** `FOR UPDATE` outside a tx is a no-op on Postgres (the implicit single-statement tx releases the lock immediately) and an error on MySQL. Pair with [`crate::sql::transaction`] / `pool.begin()`.
+
 ---
 
 ## F() expressions + database functions


### PR DESCRIPTION
## Summary

Closes #21. Adds `QuerySet::select_for_update()` plus chainable flag methods mirroring Django's `select_for_update(skip_locked=, nowait=, of=, no_key=)`. Canonical worker-queue \"claim next available row\" pattern is now a 5-line chain.

\`\`\`rust
let mut tx = pool.begin().await?;
let claim: Vec<Job> = Job::objects()
    .where_(Job::status.eq(\"pending\"))
    .order_by(&[(\"priority\", false)])
    .limit(1)
    .select_for_update()
    .skip_locked()
    .fetch_on(&mut *tx).await?;
\`\`\`

## Builder API

| Method | Effect |
|---|---|
| \`.select_for_update()\` | plain \`FOR UPDATE\` |
| \`.skip_locked()\` | append \`SKIP LOCKED\` — canonical \"claim next\" |
| \`.nowait()\` | append \`NOWAIT\` — driver error on contended row |
| \`.no_key()\` | \`FOR NO KEY UPDATE\` (PG) — weaker lock |
| \`.of(&[\"table\", …])\` | restrict lock to named tables on JOINs |

Calling \`.skip_locked()\` / \`.nowait()\` / etc. without prior \`.select_for_update()\` implicitly enables the lock — matches Django's ergonomics.

## Tri-dialect dispatch

| Dialect | Behaviour |
|---|---|
| Postgres | Full support — every flag emits native syntax |
| MySQL 8.0.1+ | All flags except \`NO KEY\` (falls back to plain \`FOR UPDATE\`) |
| SQLite | No row-lock syntax — clause is a no-op; transaction-scope locks are implicit |

\`skip_locked\` wins over \`nowait\` when both are set (more permissive, mutually exclusive at the database).

## What landed

- **[\`src/core/query.rs\`](crates/rustango/src/core/query.rs)** — \`LockMode\` struct + \`SelectQuery.lock_mode\` field, \`PartialEq\` extended.
- **[\`src/core/mod.rs\`](crates/rustango/src/core/mod.rs)** — re-export.
- **[\`src/query/mod.rs\`](crates/rustango/src/query/mod.rs)** — 5 \`QuerySet\` builder methods threaded into \`compile()\`.
- **[\`src/sql/writers.rs\`](crates/rustango/src/sql/writers.rs)** — \`write_lock_clause\` with tri-dialect dispatch, emitted after \`LIMIT/OFFSET\`.
- **[\`tests/select_for_update_emission.rs\`](crates/rustango/tests/select_for_update_emission.rs)** (15 tests) — full PG matrix, MySQL fallback, SQLite no-op, builder ergonomics.
- **[\`tests/select_for_update_live.rs\`](crates/rustango/tests/select_for_update_live.rs)** (4 live PG tests) — race-free two-worker \`SKIP LOCKED\` claim, \`NOWAIT\` driver-error path, bare-pool no-op, \`OF\` execution.
- **[\`docs/orm.md\`](docs/orm.md)** — cookbook section under \"Fetch a \`HashMap\`\".

## Tests

| Suite | Count | Status |
|---|---|---|
| \`tests/select_for_update_emission.rs\` (tri-dialect emission + builder) | 15 | passing |
| \`tests/select_for_update_live.rs\` (live PG semantic) | 4 | passing |
| \`cargo test -p rustango --features tenancy,mysql,sqlite --tests\` (full suite) | all | passing |

The canonical SKIP LOCKED test opens two PG transactions concurrently and verifies they claim different rows without blocking — that's the real \"worker queue\" race condition the feature is for.

## Verification

\`\`\`
cargo test -p rustango --features tenancy,mysql,sqlite --tests  → all passing
DATABASE_URL=... cargo test --features tenancy --test select_for_update_live → 4 passed
cargo test --workspace --all-features --no-run                  → clean
cargo build --no-default-features --features sqlite,tenancy     → clean
\`\`\`

## Test plan

- [x] PG full lock-clause matrix (plain / SKIP LOCKED / NOWAIT / NO KEY / OF / combos)
- [x] MySQL fallback for \`NO KEY\` → plain \`FOR UPDATE\` verified
- [x] SQLite no-op verified (no FOR UPDATE text in emission)
- [x] LIMIT/OFFSET come before the lock clause
- [x] \`.of()\` calls accumulate
- [x] Implicit \`select_for_update\` via standalone \`.skip_locked()\` etc.
- [x] Live PG: SKIP LOCKED race-free two-worker pattern
- [x] Live PG: NOWAIT driver-error on contended row
- [x] Workspace \`--all-features --no-run\` gate passes
- [x] SQLite-tenancy litmus build passes
- [ ] CI green on \`postgres_test\` + \`mysql_live\` + \`sqlite_live\` + \`sqlite_litmus\`