### PR TITLE
feat: QuerySet set algebra — .union/.intersection/.difference (closes #25)

### DIFF
--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -253,6 +253,7 @@ pub(crate) async fn table_view(
             limit: Some(fetch_limit),
             offset: Some(offset),
             lock_mode: None,
+            compound: vec![],
         },
         &scalar_fields,
     )
@@ -866,6 +867,7 @@ pub(crate) async fn detail_view(
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         },
         &detail_fields,
     )
@@ -1139,6 +1141,7 @@ pub(crate) async fn edit_form(
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         },
         &edit_fields,
     )
@@ -1225,6 +1228,7 @@ pub(crate) async fn update_submit(
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         },
         &before_fields,
     )
@@ -1293,6 +1297,7 @@ pub(crate) async fn delete_submit(
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         },
         &delete_fields,
     )
@@ -1459,6 +1464,7 @@ pub(crate) async fn action_submit(
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         },
         &action_fields,
     )

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -352,6 +352,7 @@ pub async fn fetch_row_as_json(
         limit: Some(1),
         offset: None,
         lock_mode: None,
+        compound: vec![],
     };
     let fields: Vec<&'static crate::core::FieldSchema> = entry.schema.scalar_fields().collect();
     crate::sql::select_one_row_as_json(pool, &select_q, &fields).await
@@ -406,6 +407,7 @@ where
             limit: Some(batch),
             offset: Some(offset),
             lock_mode: None,
+            compound: vec![],
         };
         let rows = crate::sql::select_rows_as_json(pool, &select_q, &fields).await?;
         if rows.is_empty() {

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -25,8 +25,9 @@ pub use expr::{BinOp, CaseBranch, Expr, ScalarFn, F};
 pub use field_type::FieldType;
 pub use query::{
     AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ColumnFilter,
-    ConflictClause, CountQuery, DeleteQuery, Filter, InsertQuery, Join, JoinKind, LockMode,
-    NullsOrder, Op, OrderClause, OrderItem, SearchClause, SelectQuery, UpdateQuery, WhereExpr,
+    CompoundBranch, ConflictClause, CountQuery, DeleteQuery, Filter, InsertQuery, Join, JoinKind,
+    LockMode, NullsOrder, Op, OrderClause, OrderItem, SearchClause, SelectQuery, SetOp,
+    UpdateQuery, WhereExpr,
 };
 pub use schema::{
     infer_app_label_from_module_path, AdminConfig, CheckConstraint, CompositeFkRelation,

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -422,6 +422,80 @@ pub struct SelectQuery {
     /// syntax (transaction-scope locks are implicit), so the writer
     /// no-ops on that backend.
     pub lock_mode: Option<LockMode>,
+    /// Set-algebra branches that combine with this query — Django's
+    /// `.union(other_qs, all=)` / `.intersection(other_qs)` /
+    /// `.difference(other_qs)`. Issue #25. Empty (default) emits a
+    /// plain `SELECT …`. Non-empty wraps every branch in parens and
+    /// joins them with the matching keyword:
+    ///
+    /// ```text
+    /// (SELECT … this query …)
+    /// UNION [ALL] | INTERSECT | EXCEPT
+    /// (SELECT … branch_1 …)
+    /// …
+    /// ORDER BY …      ← outer order_by applies to the whole compound
+    /// LIMIT N         ← outer limit/offset apply to the combined result
+    /// ```
+    ///
+    /// Each branch keeps its own WHERE / ORDER BY / LIMIT inside the
+    /// parens. The compound's outer `order_by` / `limit` / `offset` /
+    /// `lock_mode` apply to the merged result.
+    pub compound: Vec<CompoundBranch>,
+}
+
+/// One branch of a set-algebra compound query. Issue #25.
+#[derive(Debug, Clone)]
+pub struct CompoundBranch {
+    /// `UNION` / `UNION ALL` / `INTERSECT` / `EXCEPT`.
+    pub op: SetOp,
+    /// The branch itself — a complete `SelectQuery` whose projection
+    /// must match the outer query's column shape (same model).
+    pub query: Box<SelectQuery>,
+}
+
+/// SQL set-algebra operator — Django's
+/// `QuerySet.union(all=)` / `.intersection()` / `.difference()`.
+/// Issue #25.
+///
+/// Tri-dialect availability:
+/// - **Postgres**: all four ops.
+/// - **SQLite**: all four ops.
+/// - **MySQL 8.0+**: `UNION` / `UNION ALL` only. `INTERSECT` / `EXCEPT`
+///   landed in MySQL 8.0.31; older versions return a syntax error
+///   from the driver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SetOp {
+    /// `UNION` — combine + deduplicate.
+    Union,
+    /// `UNION ALL` — combine, keep duplicates. Cheaper than `UNION`
+    /// because no DISTINCT pass.
+    UnionAll,
+    /// `INTERSECT` — rows present in every branch.
+    Intersection,
+    /// `EXCEPT` — rows in the first branch but not the others
+    /// (Django's `.difference()`).
+    Difference,
+}
+
+impl SetOp {
+    /// SQL keyword for this operator.
+    #[must_use]
+    pub fn keyword(self) -> &'static str {
+        match self {
+            Self::Union => "UNION",
+            Self::UnionAll => "UNION ALL",
+            Self::Intersection => "INTERSECT",
+            Self::Difference => "EXCEPT",
+        }
+    }
+}
+
+/// Manual PartialEq for `CompoundBranch` — nests `SelectQuery` (which
+/// has its own ptr-eq impl on `ModelSchema`).
+impl PartialEq for CompoundBranch {
+    fn eq(&self, other: &Self) -> bool {
+        self.op == other.op && self.query == other.query
+    }
 }
 
 /// `SELECT … FOR UPDATE` row-lock options — Django's
@@ -475,6 +549,7 @@ impl PartialEq for SelectQuery {
             && self.limit == other.limit
             && self.offset == other.offset
             && self.lock_mode == other.lock_mode
+            && self.compound == other.compound
     }
 }
 

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -49,6 +49,11 @@ pub struct QuerySet<T: Model> {
     /// `select_for_update(skip_locked=, nowait=, of=, no_key=)`.
     /// Issue #21. `None` (default) emits no lock clause.
     lock_mode: Option<crate::core::LockMode>,
+    /// Set-algebra branches — Django's `.union(other_qs, all=)` /
+    /// `.intersection(other_qs)` / `.difference(other_qs)`. Issue #25.
+    /// Each entry is a pre-compiled [`crate::core::CompoundBranch`].
+    /// Empty (default) emits a plain SELECT.
+    compound: Vec<crate::core::CompoundBranch>,
     _model: PhantomData<fn() -> T>,
 }
 
@@ -137,6 +142,7 @@ impl<T: Model> QuerySet<T> {
             ad_hoc_joins: Vec::new(),
             order_by: Vec::new(),
             lock_mode: None,
+            compound: Vec::new(),
             _model: PhantomData,
         }
     }
@@ -212,6 +218,97 @@ impl<T: Model> QuerySet<T> {
         let mut lock = self.lock_mode.take().unwrap_or_default();
         lock.of.extend_from_slice(tables);
         self.lock_mode = Some(lock);
+        self
+    }
+
+    /// Issue #25 — Django's `QuerySet.union(other_qs)`. Combines this
+    /// queryset with `other` via SQL `UNION` (deduplicates). Both
+    /// querysets must target the same model `T`; the column shape is
+    /// guaranteed identical at compile time by the generic bound.
+    ///
+    /// Multiple `.union()` / `.union_all()` calls accumulate — every
+    /// call appends a new branch. Mixing `union` with `intersection`
+    /// or `difference` on the same chain is allowed but unusual; SQL
+    /// evaluates them left-to-right.
+    ///
+    /// Outer `.order_by()` / `.limit()` / `.offset()` set after
+    /// `.union()` apply to the COMBINED result (the merged
+    /// resultset). Each branch keeps its own per-branch ORDER BY /
+    /// LIMIT inside parens.
+    ///
+    /// Tri-dialect availability: every supported backend.
+    ///
+    /// # Errors
+    /// Forwards `other.compile()` errors (schema validation on the
+    /// branch's WHERE / ORDER BY) into the union builder. If the
+    /// branch fails to compile, this method panics — same posture as
+    /// `.where_()` on the typed path. If you want to surface the
+    /// branch error, compile it first and use
+    /// [`Self::union_compiled`].
+    #[must_use]
+    pub fn union(self, other: QuerySet<T>) -> Self {
+        self.add_compound(crate::core::SetOp::Union, other)
+    }
+
+    /// `UNION ALL` — combine without deduplicating. Cheaper than
+    /// `union` because the DB skips the DISTINCT pass; useful when
+    /// you know the branches don't overlap.
+    #[must_use]
+    pub fn union_all(self, other: QuerySet<T>) -> Self {
+        self.add_compound(crate::core::SetOp::UnionAll, other)
+    }
+
+    /// Issue #25 — Django's `QuerySet.intersection(other_qs)`. Rows
+    /// present in BOTH this queryset and `other`. Tri-dialect:
+    /// Postgres, SQLite, MySQL 8.0.31+.
+    #[must_use]
+    pub fn intersection(self, other: QuerySet<T>) -> Self {
+        self.add_compound(crate::core::SetOp::Intersection, other)
+    }
+
+    /// Issue #25 — Django's `QuerySet.difference(other_qs)`. Emits
+    /// `EXCEPT`: rows in this queryset but NOT in `other`.
+    /// Tri-dialect: Postgres, SQLite, MySQL 8.0.31+.
+    #[must_use]
+    pub fn difference(self, other: QuerySet<T>) -> Self {
+        self.add_compound(crate::core::SetOp::Difference, other)
+    }
+
+    /// Lower-level set-algebra entry point: takes a pre-compiled
+    /// `SelectQuery` as the branch instead of a fresh `QuerySet`.
+    /// Useful when the branch construction may fail (its `.compile()`
+    /// returns `Result`) and the caller wants to surface the error
+    /// before chaining. Issue #25.
+    #[must_use]
+    pub fn union_compiled(self, branch: crate::core::SelectQuery) -> Self {
+        self.add_compound_compiled(crate::core::SetOp::Union, branch)
+    }
+
+    /// Shared lowering for [`Self::union`] / [`Self::intersection`]
+    /// / [`Self::difference`] — compiles the branch eagerly and
+    /// appends a `CompoundBranch` to `self.compound`. Panics on
+    /// branch compile error; for fallible composition use
+    /// [`Self::union_compiled`].
+    fn add_compound(self, op: crate::core::SetOp, other: QuerySet<T>) -> Self {
+        match other.compile() {
+            Ok(branch) => self.add_compound_compiled(op, branch),
+            Err(e) => panic!(
+                "rustango: set-algebra branch failed to compile: {e}. \
+                 Pre-compile the branch and pass via .union_compiled() / \
+                 friends to surface this error as a Result."
+            ),
+        }
+    }
+
+    fn add_compound_compiled(
+        mut self,
+        op: crate::core::SetOp,
+        branch: crate::core::SelectQuery,
+    ) -> Self {
+        self.compound.push(crate::core::CompoundBranch {
+            op,
+            query: Box::new(branch),
+        });
         self
     }
 
@@ -626,6 +723,7 @@ impl<T: Model> QuerySet<T> {
             limit: self.limit,
             offset: self.offset,
             lock_mode: self.lock_mode,
+            compound: self.compound,
         })
     }
 

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -238,13 +238,13 @@ impl<T: Model> QuerySet<T> {
     ///
     /// Tri-dialect availability: every supported backend.
     ///
-    /// # Errors
-    /// Forwards `other.compile()` errors (schema validation on the
-    /// branch's WHERE / ORDER BY) into the union builder. If the
-    /// branch fails to compile, this method panics — same posture as
-    /// `.where_()` on the typed path. If you want to surface the
-    /// branch error, compile it first and use
-    /// [`Self::union_compiled`].
+    /// # Panics
+    /// If `other.compile()` fails (typo'd column on the branch's
+    /// WHERE / ORDER BY, schema validation, etc.). Same posture as
+    /// `.where_()` on the typed path — a malformed branch is a
+    /// programmer error, not a runtime data condition. For fallible
+    /// composition that surfaces the branch error as a `Result`,
+    /// pre-compile and pass via [`Self::with_compound`].
     #[must_use]
     pub fn union(self, other: QuerySet<T>) -> Self {
         self.add_compound(crate::core::SetOp::Union, other)
@@ -253,6 +253,9 @@ impl<T: Model> QuerySet<T> {
     /// `UNION ALL` — combine without deduplicating. Cheaper than
     /// `union` because the DB skips the DISTINCT pass; useful when
     /// you know the branches don't overlap.
+    ///
+    /// # Panics
+    /// As [`Self::union`].
     #[must_use]
     pub fn union_all(self, other: QuerySet<T>) -> Self {
         self.add_compound(crate::core::SetOp::UnionAll, other)
@@ -261,6 +264,9 @@ impl<T: Model> QuerySet<T> {
     /// Issue #25 — Django's `QuerySet.intersection(other_qs)`. Rows
     /// present in BOTH this queryset and `other`. Tri-dialect:
     /// Postgres, SQLite, MySQL 8.0.31+.
+    ///
+    /// # Panics
+    /// As [`Self::union`].
     #[must_use]
     pub fn intersection(self, other: QuerySet<T>) -> Self {
         self.add_compound(crate::core::SetOp::Intersection, other)
@@ -269,33 +275,48 @@ impl<T: Model> QuerySet<T> {
     /// Issue #25 — Django's `QuerySet.difference(other_qs)`. Emits
     /// `EXCEPT`: rows in this queryset but NOT in `other`.
     /// Tri-dialect: Postgres, SQLite, MySQL 8.0.31+.
+    ///
+    /// # Panics
+    /// As [`Self::union`].
     #[must_use]
     pub fn difference(self, other: QuerySet<T>) -> Self {
         self.add_compound(crate::core::SetOp::Difference, other)
     }
 
-    /// Lower-level set-algebra entry point: takes a pre-compiled
+    /// Fallible set-algebra entry point: takes a pre-compiled
     /// `SelectQuery` as the branch instead of a fresh `QuerySet`.
     /// Useful when the branch construction may fail (its `.compile()`
     /// returns `Result`) and the caller wants to surface the error
-    /// before chaining. Issue #25.
+    /// before chaining. Generic over the operator — covers `union` /
+    /// `union_all` / `intersection` / `difference` with one entry
+    /// point. Issue #25.
+    ///
+    /// ```ignore
+    /// // Caller wants to handle the branch's compile error explicitly:
+    /// let branch = Post::objects()
+    ///     .filter("typo_field__lt", 100_i64)  // may fail
+    ///     .compile()?;                         // → Result
+    /// let qs = Post::objects()
+    ///     .where_(Post::active.eq(true))
+    ///     .with_compound(SetOp::Union, branch);
+    /// ```
     #[must_use]
-    pub fn union_compiled(self, branch: crate::core::SelectQuery) -> Self {
-        self.add_compound_compiled(crate::core::SetOp::Union, branch)
+    pub fn with_compound(self, op: crate::core::SetOp, branch: crate::core::SelectQuery) -> Self {
+        self.add_compound_compiled(op, branch)
     }
 
-    /// Shared lowering for [`Self::union`] / [`Self::intersection`]
-    /// / [`Self::difference`] — compiles the branch eagerly and
-    /// appends a `CompoundBranch` to `self.compound`. Panics on
-    /// branch compile error; for fallible composition use
-    /// [`Self::union_compiled`].
+    /// Shared lowering for [`Self::union`] / [`Self::union_all`] /
+    /// [`Self::intersection`] / [`Self::difference`] — compiles the
+    /// branch eagerly and appends a `CompoundBranch` to
+    /// `self.compound`. Panics on branch compile error; for fallible
+    /// composition use [`Self::with_compound`].
     fn add_compound(self, op: crate::core::SetOp, other: QuerySet<T>) -> Self {
         match other.compile() {
             Ok(branch) => self.add_compound_compiled(op, branch),
             Err(e) => panic!(
                 "rustango: set-algebra branch failed to compile: {e}. \
-                 Pre-compile the branch and pass via .union_compiled() / \
-                 friends to surface this error as a Result."
+                 Pre-compile the branch and pass via .with_compound(op, \
+                 branch) to surface this error as a Result."
             ),
         }
     }

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -697,6 +697,7 @@ mod tests {
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert_eq!(
@@ -723,6 +724,7 @@ mod tests {
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("LOWER(`name`) NOT LIKE LOWER(?)"));
@@ -745,6 +747,7 @@ mod tests {
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("NOT (`email` <=> ?)"));
@@ -767,6 +770,7 @@ mod tests {
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         };
         let stmt = MySql.compile_select(&q).unwrap();
         // No outer NOT; bare null-safe equality.
@@ -791,6 +795,7 @@ mod tests {
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("JSON_CONTAINS(`meta`, ?)"));
@@ -814,6 +819,7 @@ mod tests {
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         };
         let stmt = MySql.compile_select(&q).unwrap();
         // Argument order is swapped vs JSON_CONTAINS — value first.
@@ -837,6 +843,7 @@ mod tests {
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -864,6 +871,7 @@ mod tests {
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -892,6 +900,7 @@ mod tests {
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -978,6 +987,7 @@ mod tests {
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert_eq!(

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -521,6 +521,7 @@ mod tests {
             offset: None,
             search: None,
             lock_mode: None,
+            compound: vec![],
         };
         let stmt = Sqlite.compile_select(&q).unwrap();
         // SQLite emits ANSI-quoted identifiers and `?` placeholders.

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -134,9 +134,87 @@ pub(super) fn null_cast_for(
 
 pub(super) fn write_select(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlError> {
     b.scope_stack.push(query.model);
-    let result = write_select_inner(b, query);
+    let result = if query.compound.is_empty() {
+        write_select_inner(b, query)
+    } else {
+        write_compound_select(b, query)
+    };
     b.scope_stack.pop();
     result
+}
+
+/// Emit a set-algebra compound SELECT (issue #25). Layout:
+///
+/// ```text
+/// (SELECT … this query …)
+/// UNION [ALL] | INTERSECT | EXCEPT
+/// (SELECT … branch_1 …)
+/// …
+/// ORDER BY …    -- outer order_by, applied AFTER the union/intersect/except
+/// LIMIT N
+/// OFFSET M
+/// FOR UPDATE …  -- outer lock_mode
+/// ```
+///
+/// Each branch is rendered in parens so a per-branch `ORDER BY`/`LIMIT`
+/// stays inside the parens (required by PG/SQLite SQL grammar; MySQL
+/// is more forgiving but the parens harm nothing). The OUTER
+/// SelectQuery's `order_by`/`limit`/`offset`/`lock_mode` get emitted
+/// AFTER the last branch closes, so they apply to the whole merged
+/// result.
+///
+/// The OUTER SelectQuery's own `where_clause` / `joins` / `search`
+/// apply to ITS branch (the first one in the compound, since the
+/// outer is itself a complete `SelectQuery`).
+fn write_compound_select(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlError> {
+    // First branch: the outer query itself, wrapped in parens. Build
+    // a copy with the compound stripped + the outer order_by / limit
+    // / offset / lock_mode stripped (those apply to the WHOLE
+    // compound, not the head branch).
+    let head = SelectQuery {
+        model: query.model,
+        where_clause: query.where_clause.clone(),
+        search: query.search.clone(),
+        joins: query.joins.clone(),
+        order_by: Vec::new(),
+        limit: None,
+        offset: None,
+        lock_mode: None,
+        compound: Vec::new(),
+    };
+    b.sql.push('(');
+    write_select_inner(b, &head)?;
+    b.sql.push(')');
+
+    for branch in &query.compound {
+        b.sql.push(' ');
+        b.sql.push_str(branch.op.keyword());
+        b.sql.push_str(" (");
+        // Push a scope frame for the branch so any subqueries inside
+        // resolve `OuterRef` correctly. write_select handles the
+        // push/pop on the outermost call but recursive branches
+        // need their own frame.
+        b.scope_stack.push(branch.query.model);
+        let r = if branch.query.compound.is_empty() {
+            write_select_inner(b, &branch.query)
+        } else {
+            write_compound_select(b, &branch.query)
+        };
+        b.scope_stack.pop();
+        r?;
+        b.sql.push(')');
+    }
+
+    // Outer ORDER BY / LIMIT / OFFSET apply to the merged result.
+    // No qualify (the compound's "table" is the merged resultset, not
+    // a join target).
+    write_order_limit_offset(b, &query.order_by, query.limit, query.offset, None)?;
+
+    if let Some(lock) = &query.lock_mode {
+        write_lock_clause(b, lock);
+    }
+
+    Ok(())
 }
 
 fn write_select_inner(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlError> {

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -581,6 +581,7 @@ async fn handle_list(
         limit: Some(page_size),
         offset: Some(offset),
         lock_mode: None,
+        compound: vec![],
     };
     let count_q = crate::core::CountQuery {
         model: state.vs.schema,
@@ -829,6 +830,7 @@ async fn handle_detail(
         limit: Some(1),
         offset: None,
         lock_mode: None,
+        compound: vec![],
     };
     let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
     let object = match select_one_row_as_json(&state.pool, &select_q, &fields).await {
@@ -956,6 +958,7 @@ async fn handle_delete_confirm(
         limit: Some(1),
         offset: None,
         lock_mode: None,
+        compound: vec![],
     };
     let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
     let object = match select_one_row_as_json(&state.pool, &select_q, &fields).await {
@@ -1787,6 +1790,7 @@ async fn handle_update_get(
         limit: Some(1),
         offset: None,
         lock_mode: None,
+        compound: vec![],
     };
     let scalars: Vec<&'static crate::core::FieldSchema> = state.schema.scalar_fields().collect();
     let row_json = match select_one_row_as_json(&state.pool, &select_q, &scalars).await {
@@ -2638,6 +2642,7 @@ fn build_fk_display_query(fk: &FkLookup) -> SelectQuery {
         limit: None,
         offset: None,
         lock_mode: None,
+        compound: vec![],
     }
 }
 
@@ -2803,6 +2808,7 @@ async fn fetch_pks_as_objects_pool(
         limit: None,
         offset: None,
         lock_mode: None,
+        compound: vec![],
     };
     let fields: Vec<&'static crate::core::FieldSchema> = schema.scalar_fields().collect();
     let rows = select_rows_as_json(pool, &q, &fields)
@@ -2942,6 +2948,7 @@ mod tenant {
             limit: Some(page_size),
             offset: Some(offset),
             lock_mode: None,
+            compound: vec![],
         };
         let count_q = crate::core::CountQuery {
             model: state.vs.schema,
@@ -3129,6 +3136,7 @@ mod tenant {
             limit: Some(1),
             offset: None,
             lock_mode: None,
+            compound: vec![],
         };
         let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
         let object = match crate::sql::select_one_row_as_json(t.pool(), &select_q, &fields).await {
@@ -3175,6 +3183,7 @@ mod tenant {
             limit: Some(1),
             offset: None,
             lock_mode: None,
+            compound: vec![],
         };
         let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
         let object = match crate::sql::select_one_row_as_json(t.pool(), &select_q, &fields).await {
@@ -3322,6 +3331,7 @@ mod tenant {
             limit: Some(1),
             offset: None,
             lock_mode: None,
+            compound: vec![],
         };
         let scalars: Vec<&'static crate::core::FieldSchema> =
             state.schema.scalar_fields().collect();

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -909,6 +909,7 @@ async fn handle_list(
                 limit: Some(page_size),
                 offset: Some(offset),
                 lock_mode: None,
+                compound: vec![],
             };
             let count_q = CountQuery {
                 model: state.vs.schema,
@@ -1038,6 +1039,7 @@ async fn handle_list_cursor(
         limit: Some(page_size + 1),
         offset: None,
         lock_mode: None,
+        compound: vec![],
     };
     let rows = match acq.select_rows_as_json(&select_q, &fields).await {
         Ok(r) => r,
@@ -1128,6 +1130,7 @@ async fn handle_retrieve(
         limit: Some(1),
         offset: None,
         lock_mode: None,
+        compound: vec![],
     };
 
     let fields = state.effective_fields();
@@ -1364,6 +1367,7 @@ async fn fetch_by_pk(
         limit: Some(1),
         offset: None,
         lock_mode: None,
+        compound: vec![],
     };
     let _ = state;
     acq.select_one_as_json(&select_q, fields)

--- a/crates/rustango/tests/mysql_from_row.rs
+++ b/crates/rustango/tests/mysql_from_row.rs
@@ -225,6 +225,7 @@ fn select_rows_pool_with_related_is_callable() {
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         };
         let _fut: _ = rustango::sql::select_rows_pool_with_related::<User>(pool, &q);
     }

--- a/crates/rustango/tests/q_xor_emission.rs
+++ b/crates/rustango/tests/q_xor_emission.rs
@@ -31,6 +31,7 @@ fn select(where_clause: WhereExpr) -> SelectQuery {
         limit: None,
         offset: None,
         lock_mode: None,
+        compound: vec![],
     }
 }
 

--- a/crates/rustango/tests/row_to_json_pool_sqlite_live.rs
+++ b/crates/rustango/tests/row_to_json_pool_sqlite_live.rs
@@ -80,6 +80,7 @@ async fn select_rows_as_json_pool_decodes_sqlite_rows() {
             limit: None,
             offset: None,
             lock_mode: None,
+            compound: vec![],
         },
         &fields,
     )
@@ -116,6 +117,7 @@ async fn select_one_row_as_json_pool_returns_none_for_miss() {
             limit: Some(1),
             offset: None,
             lock_mode: None,
+            compound: vec![],
         },
         &fields,
     )
@@ -154,6 +156,7 @@ async fn select_one_row_as_json_pool_returns_decoded_row_for_hit() {
             limit: Some(1),
             offset: None,
             lock_mode: None,
+            compound: vec![],
         },
         &fields,
     )

--- a/crates/rustango/tests/set_algebra_emission.rs
+++ b/crates/rustango/tests/set_algebra_emission.rs
@@ -258,3 +258,108 @@ fn each_branch_contributes_its_own_params() {
     // PG placeholders $1, $2, $3 in textual order.
     assert!(stmt.sql.contains("$1") && stmt.sql.contains("$2") && stmt.sql.contains("$3"));
 }
+
+// ---------- MySQL: INTERSECT / EXCEPT emission (8.0.31+) ----------
+
+#[cfg(feature = "mysql")]
+#[test]
+fn intersect_emits_with_backticks_on_mysql() {
+    // MySQL 8.0.31+ supports INTERSECT. Pre-31 surfaces a syntax
+    // error from the driver — the writer emits the same SQL either
+    // way (no client-side gate).
+    let q = Post::objects()
+        .where_(Post::status.eq("published"))
+        .intersection(Post::objects().where_(Post::author_id.eq(1_i64)))
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(") INTERSECT ("),
+        "MySQL INTERSECT keyword: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains("`status`") && stmt.sql.contains("`author_id`"),
+        "MySQL backtick identifiers in both branches: {}",
+        stmt.sql
+    );
+}
+
+#[cfg(feature = "mysql")]
+#[test]
+fn except_emits_with_backticks_on_mysql() {
+    let q = Post::objects()
+        .difference(Post::objects().where_(Post::status.eq("deleted")))
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(") EXCEPT ("),
+        "MySQL EXCEPT keyword: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains("`status`"),
+        "MySQL backticks: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Nested compound — one branch is itself a compound ----------
+
+/// `qs_outer.union(qs_inner_compound)` where the inner is itself a
+/// compound `qs_a.union(qs_b)`. The recursive `write_compound_select`
+/// renders the inner compound inside its own parens, with the outer
+/// `UNION` joining them. Verifies the writer doesn't flatten or
+/// mis-nest.
+#[test]
+fn nested_compound_inside_outer_union_emits_double_parens() {
+    let inner = Post::objects()
+        .where_(Post::status.eq("a"))
+        .union(Post::objects().where_(Post::status.eq("b")));
+    let outer = Post::objects()
+        .where_(Post::status.eq("c"))
+        .union(inner)
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&outer).unwrap();
+    // Outer compound: (...) UNION (...).
+    // Inner compound substituted for the second branch:
+    //   (... WHERE c ...) UNION ((... WHERE a ...) UNION (... WHERE b ...))
+    // So we expect "(( ... ) UNION ( ... ))" — a double-open paren
+    // somewhere in the SQL marking the inner-compound boundary.
+    assert!(
+        stmt.sql.contains("(("),
+        "nested compound has `((` boundary: {}",
+        stmt.sql
+    );
+    // Three WHERE clauses total (one per branch).
+    let where_count = stmt.sql.matches("WHERE").count();
+    assert_eq!(where_count, 3, "three branches: {}", stmt.sql);
+    // Two UNION joins: outer and inner.
+    let union_count = stmt.sql.matches(" UNION ").count();
+    assert_eq!(union_count, 2, "two UNIONs: {}", stmt.sql);
+}
+
+// ---------- with_compound — fallible entry point ----------
+
+#[test]
+fn with_compound_takes_precompiled_branch() {
+    use rustango::core::SetOp;
+    // Pre-compile the branch so the caller could `?` on errors.
+    let branch = Post::objects()
+        .where_(Post::status.eq("draft"))
+        .compile()
+        .unwrap();
+    let q = Post::objects()
+        .where_(Post::status.eq("published"))
+        .with_compound(SetOp::Difference, branch)
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(") EXCEPT ("),
+        "with_compound(Difference, …): {}",
+        stmt.sql
+    );
+}

--- a/crates/rustango/tests/set_algebra_emission.rs
+++ b/crates/rustango/tests/set_algebra_emission.rs
@@ -1,0 +1,260 @@
+//! Tri-dialect SQL-emission tests for `QuerySet` set algebra
+//! (issue #25). Django's `.union(other_qs, all=)` /
+//! `.intersection(other_qs)` / `.difference(other_qs)` lower to SQL
+//! `UNION` / `UNION ALL` / `INTERSECT` / `EXCEPT`. Postgres + SQLite
+//! support all four; MySQL needs 8.0.31+ for INTERSECT/EXCEPT, but
+//! the writer emits the same SQL — older MySQL just returns a syntax
+//! error from the driver.
+
+use rustango::core::Column as _;
+#[cfg(feature = "mysql")]
+use rustango::sql::MySql;
+#[cfg(feature = "sqlite")]
+use rustango::sql::Sqlite;
+use rustango::sql::{Dialect, Postgres};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "salg_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 20)]
+    status: String,
+    author_id: i64,
+}
+
+// ---------- UNION ----------
+
+#[test]
+fn union_emits_parenthesized_union_on_pg() {
+    let q = Post::objects()
+        .where_(Post::status.eq("draft"))
+        .union(Post::objects().where_(Post::status.eq("review")))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    // Each branch wrapped in parens, joined with UNION.
+    assert!(
+        stmt.sql.contains(r#"WHERE "status" = $1"#) && stmt.sql.contains(r#"WHERE "status" = $2"#),
+        "two branches: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains(") UNION ("),
+        "parens + UNION: {}",
+        stmt.sql
+    );
+    assert!(!stmt.sql.contains(") UNION ALL ("));
+    // No outer ORDER BY when none set.
+    assert!(
+        !stmt.sql.contains("ORDER BY"),
+        "no spurious ORDER BY: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn union_all_emits_union_all_keyword() {
+    let q = Post::objects()
+        .union_all(Post::objects().where_(Post::status.eq("archived")))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(") UNION ALL ("),
+        "UNION ALL: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn intersection_emits_intersect_keyword() {
+    let q = Post::objects()
+        .where_(Post::author_id.eq(1_i64))
+        .intersection(Post::objects().where_(Post::status.eq("published")))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(") INTERSECT ("),
+        "INTERSECT: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn difference_emits_except_keyword() {
+    let q = Post::objects()
+        .difference(Post::objects().where_(Post::status.eq("deleted")))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(stmt.sql.contains(") EXCEPT ("), "EXCEPT: {}", stmt.sql);
+}
+
+// ---------- Outer ORDER BY / LIMIT / OFFSET apply to merged result ----------
+
+#[test]
+fn outer_order_by_emitted_after_compound() {
+    let q = Post::objects()
+        .where_(Post::status.eq("draft"))
+        .union(Post::objects().where_(Post::status.eq("review")))
+        .order_by(&[("id", false)])
+        .limit(20)
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    // Outer ORDER BY comes after the last `)` of the compound.
+    let last_paren = stmt.sql.rfind(')').expect("compound has close paren");
+    let order_pos = stmt.sql.find("ORDER BY").expect("has ORDER BY");
+    let limit_pos = stmt.sql.find("LIMIT").expect("has LIMIT");
+    assert!(
+        last_paren < order_pos,
+        "ORDER BY after compound close: {}",
+        stmt.sql
+    );
+    assert!(order_pos < limit_pos, "ORDER BY before LIMIT: {}", stmt.sql);
+}
+
+#[test]
+fn branch_order_by_stays_inside_parens() {
+    // Branch has its own order_by + limit. Outer compound has no
+    // order_by. The branch ORDER BY stays INSIDE the branch's parens
+    // (PG/SQLite reject mid-compound ORDER BY otherwise).
+    let q = Post::objects()
+        .union(
+            Post::objects()
+                .where_(Post::status.eq("review"))
+                .order_by(&[("id", true)])
+                .limit(5),
+        )
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    // The branch's `ORDER BY "id" DESC LIMIT 5` lives between two
+    // parens, and there's no outer ORDER BY after the last `)`.
+    let union_pos = stmt.sql.find(") UNION (").expect("has UNION");
+    let last_paren = stmt.sql.rfind(')').unwrap();
+    let order_pos = stmt.sql.find("ORDER BY").expect("branch ORDER BY exists");
+    assert!(
+        order_pos > union_pos && order_pos < last_paren,
+        "branch ORDER BY sits inside the second branch's parens: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Multiple branches accumulate ----------
+
+#[test]
+fn three_branch_union_emits_three_set_op_keywords() {
+    let q = Post::objects()
+        .where_(Post::status.eq("a"))
+        .union(Post::objects().where_(Post::status.eq("b")))
+        .union(Post::objects().where_(Post::status.eq("c")))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    let count = stmt.sql.matches(") UNION (").count();
+    assert_eq!(count, 2, "two ) UNION ( joins for 3 branches: {}", stmt.sql);
+}
+
+#[test]
+fn mixed_union_intersection_chain_preserves_order() {
+    // (A) UNION (B) INTERSECT (C) — SQL evaluates left-to-right.
+    let q = Post::objects()
+        .where_(Post::status.eq("a"))
+        .union(Post::objects().where_(Post::status.eq("b")))
+        .intersection(Post::objects().where_(Post::status.eq("c")))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    // UNION comes before INTERSECT.
+    let union_pos = stmt.sql.find(") UNION (").expect("has UNION");
+    let intersect_pos = stmt.sql.find(") INTERSECT (").expect("has INTERSECT");
+    assert!(
+        union_pos < intersect_pos,
+        "UNION before INTERSECT (chain order): {}",
+        stmt.sql
+    );
+}
+
+// ---------- Tri-dialect ----------
+
+#[cfg(feature = "mysql")]
+#[test]
+fn union_emits_backtick_identifiers_on_mysql() {
+    let q = Post::objects()
+        .union(Post::objects().where_(Post::status.eq("review")))
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(") UNION (") && stmt.sql.contains("`status`"),
+        "MySQL UNION + backticks: {}",
+        stmt.sql
+    );
+}
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn except_emits_on_sqlite() {
+    let q = Post::objects()
+        .difference(Post::objects().where_(Post::status.eq("deleted")))
+        .compile()
+        .unwrap();
+    let stmt = Sqlite.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(") EXCEPT ("),
+        "SQLite EXCEPT: {}",
+        stmt.sql
+    );
+    // SQLite uses `?` placeholders.
+    assert!(stmt.sql.contains("?"), "sqlite placeholders: {}", stmt.sql);
+}
+
+// ---------- Default queryset (no compound) — no parens around base ----------
+
+#[test]
+fn without_compound_no_parens_added_to_plain_select() {
+    let q = Post::objects()
+        .where_(Post::status.eq("draft"))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        !stmt.sql.starts_with('('),
+        "plain SELECT not wrapped: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains(" UNION ")
+            && !stmt.sql.contains(" INTERSECT ")
+            && !stmt.sql.contains(" EXCEPT "),
+        "no set-op keywords: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Params accumulate across branches ----------
+
+#[test]
+fn each_branch_contributes_its_own_params() {
+    // Outer: status = "a". Branch 1: status = "b". Branch 2: id > 100.
+    let q = Post::objects()
+        .where_(Post::status.eq("a"))
+        .union(Post::objects().where_(Post::status.eq("b")))
+        .union(Post::objects().where_(Post::id.gt(100_i64)))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert_eq!(
+        stmt.params.len(),
+        3,
+        "three branches × one param each: {:?}",
+        stmt.params
+    );
+    // PG placeholders $1, $2, $3 in textual order.
+    assert!(stmt.sql.contains("$1") && stmt.sql.contains("$2") && stmt.sql.contains("$3"));
+}

--- a/crates/rustango/tests/set_algebra_live.rs
+++ b/crates/rustango/tests/set_algebra_live.rs
@@ -1,0 +1,206 @@
+#![cfg(feature = "postgres")]
+//! Live PG test for QuerySet set algebra (issue #25). Verifies UNION
+//! / INTERSECT / EXCEPT runtime semantics + that outer ORDER BY /
+//! LIMIT apply to the merged result. Skips silently when
+//! `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::core::Column as _;
+use rustango::sql::{sqlx, Auto, Fetcher as _};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "salg_live_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 20)]
+    pub status: String,
+    pub author_id: i64,
+}
+
+fn lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn fresh_pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pool = sqlx::PgPool::connect(&url).await.ok()?;
+    sqlx::query(r#"DROP TABLE IF EXISTS "salg_live_post" CASCADE"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"
+        CREATE TABLE "salg_live_post" (
+            id BIGSERIAL PRIMARY KEY,
+            status VARCHAR(20) NOT NULL,
+            author_id BIGINT NOT NULL
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    // Seed: 6 posts across 3 authors with 3 statuses.
+    // author 1: draft, review
+    // author 2: draft, published
+    // author 3: published, archived
+    for (status, author_id) in [
+        ("draft", 1_i64),
+        ("review", 1),
+        ("draft", 2),
+        ("published", 2),
+        ("published", 3),
+        ("archived", 3),
+    ] {
+        let mut p = Post {
+            id: Auto::default(),
+            status: status.into(),
+            author_id,
+        };
+        p.insert_pool(&(&pool).clone().into()).await.unwrap();
+    }
+    Some(pool)
+}
+
+fn author_id_of(p: &Post) -> i64 {
+    p.author_id
+}
+
+/// `UNION` deduplicates. Author 1's drafts + author 2's drafts =
+/// 2 distinct rows. `UNION` of "drafts" + "reviews" = 3 distinct rows
+/// (no overlap, but `UNION` would dedupe if there were any).
+#[tokio::test]
+async fn union_combines_branches_and_dedupes() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    // Posts that are drafts OR reviews — combined branches.
+    let rows: Vec<Post> = Post::objects()
+        .where_(Post::status.eq("draft"))
+        .union(Post::objects().where_(Post::status.eq("review")))
+        .order_by(&[("id", false)])
+        .fetch(&pool)
+        .await
+        .unwrap();
+    // 2 drafts + 1 review = 3 rows.
+    assert_eq!(rows.len(), 3);
+    let statuses: Vec<String> = rows.iter().map(|p| p.status.clone()).collect();
+    assert!(statuses.iter().filter(|s| *s == "draft").count() == 2);
+    assert!(statuses.iter().filter(|s| *s == "review").count() == 1);
+
+    cleanup(&pool).await;
+}
+
+/// `UNION ALL` keeps duplicates. Two identical branches → 2× rows.
+#[tokio::test]
+async fn union_all_keeps_duplicates() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    // Same WHERE on both branches → each draft row appears twice.
+    let rows: Vec<Post> = Post::objects()
+        .where_(Post::status.eq("draft"))
+        .union_all(Post::objects().where_(Post::status.eq("draft")))
+        .fetch(&pool)
+        .await
+        .unwrap();
+    // 2 drafts × 2 branches = 4 rows.
+    assert_eq!(rows.len(), 4);
+
+    cleanup(&pool).await;
+}
+
+/// `INTERSECT` keeps rows present in BOTH branches. Authors with both
+/// draft AND published posts → only author 2 (has draft+published).
+/// Implemented as INTERSECT of two queries returning the FULL post
+/// row — only rows identical across both branches survive.
+#[tokio::test]
+async fn intersect_keeps_only_rows_in_both_branches() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    // Identical branches → INTERSECT = same rows (no filtering).
+    let rows: Vec<Post> = Post::objects()
+        .where_(Post::status.eq("published"))
+        .intersection(Post::objects().where_(Post::status.eq("published")))
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2, "2 published posts intersect themselves");
+
+    // Disjoint branches → INTERSECT = empty.
+    let empty: Vec<Post> = Post::objects()
+        .where_(Post::status.eq("draft"))
+        .intersection(Post::objects().where_(Post::status.eq("published")))
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert!(
+        empty.is_empty(),
+        "drafts ∩ publisheds = empty (disjoint status sets)"
+    );
+
+    cleanup(&pool).await;
+}
+
+/// `EXCEPT` keeps rows in the first branch but NOT the second.
+/// All posts EXCEPT author 1's posts = 4 rows (authors 2 + 3).
+#[tokio::test]
+async fn except_excludes_matching_rows() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let rows: Vec<Post> = Post::objects()
+        .difference(Post::objects().where_(Post::author_id.eq(1_i64)))
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 4, "6 total - 2 author-1 = 4: got {rows:?}");
+    let authors: Vec<i64> = rows.iter().map(author_id_of).collect();
+    assert!(!authors.contains(&1), "no author 1 in EXCEPT result");
+
+    cleanup(&pool).await;
+}
+
+/// Outer LIMIT applies to the COMBINED result, not per-branch.
+/// 3 drafts+reviews total, LIMIT 2 caps to 2.
+#[tokio::test]
+async fn outer_limit_caps_combined_result() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let rows: Vec<Post> = Post::objects()
+        .where_(Post::status.eq("draft"))
+        .union(Post::objects().where_(Post::status.eq("review")))
+        .order_by(&[("id", false)])
+        .limit(2)
+        .fetch(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2, "outer LIMIT 2 wins: got {rows:?}");
+
+    cleanup(&pool).await;
+}
+
+async fn cleanup(pool: &sqlx::PgPool) {
+    sqlx::query(r#"DROP TABLE IF EXISTS "salg_live_post" CASCADE"#)
+        .execute(pool)
+        .await
+        .unwrap();
+}

--- a/crates/rustango/tests/sql.rs
+++ b/crates/rustango/tests/sql.rs
@@ -594,6 +594,7 @@ fn empty_select() -> SelectQuery {
         limit: None,
         offset: None,
         lock_mode: None,
+        compound: vec![],
     }
 }
 
@@ -812,6 +813,7 @@ fn empty_post_select() -> SelectQuery {
         limit: None,
         offset: None,
         lock_mode: None,
+        compound: vec![],
     }
 }
 

--- a/crates/rustango/tests/where_expr_live.rs
+++ b/crates/rustango/tests/where_expr_live.rs
@@ -191,6 +191,7 @@ async fn empty_or_branch_returns_named_writer_error() {
         limit: None,
         offset: None,
         lock_mode: None,
+        compound: vec![],
     };
     let err = Postgres.compile_select(&q).unwrap_err();
     assert!(matches!(err, SqlError::EmptyOrBranch));
@@ -209,6 +210,7 @@ async fn empty_or_branch_returns_named_writer_error() {
         limit: None,
         offset: None,
         lock_mode: None,
+        compound: vec![],
     };
     rustango::sql::select_rows(&pool, &q2).await.unwrap();
 }

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -296,7 +296,7 @@ let mixed = qs_a
 
 **Tri-dialect**: Postgres + SQLite support all four operators on every version rustango supports. MySQL 8.0+ supports `UNION`/`UNION ALL`; `INTERSECT`/`EXCEPT` landed in MySQL 8.0.31. Older MySQL versions surface the driver's syntax error at fetch time — there's no client-side gate.
 
-**Error path on the typed builder**: `.union(other_qs)` compiles the branch eagerly and panics if the branch fails to compile (typo'd column, etc.). For fallible composition where the caller wants a `Result`, compile the branch first and pass it via `.union_compiled(branch)`. The panic shape matches Django's: a bad branch is a programmer error, not a runtime data condition.
+**Error path on the typed builder**: `.union(other_qs)` (and `.intersection()` / `.difference()`) compiles the branch eagerly and panics if the branch fails to compile (typo'd column, etc.). For fallible composition where the caller wants a `Result`, compile the branch first and pass it via `.with_compound(SetOp::Union, branch)` — one generic entry point covers every operator. The panic shape matches Django's: a bad branch is a programmer error, not a runtime data condition.
 
 ---
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -250,6 +250,54 @@ Calling `.skip_locked()` / `.nowait()` / `.no_key()` / `.of(…)` without a prio
 
 **Must run inside a transaction.** `FOR UPDATE` outside a tx is a no-op on Postgres (the implicit single-statement tx releases the lock immediately) and an error on MySQL. Pair with [`crate::sql::transaction`] / `pool.begin()`.
 
+### Set algebra — `.union()` / `.intersection()` / `.difference()`
+
+Django's [`QuerySet.union(all=)`](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#union) / `.intersection()` / `.difference()` — issue #25. Combine multiple querysets over the same model with SQL set operators.
+
+```rust
+// Posts that are EITHER drafts OR currently in review.
+let inbox: Vec<Post> = Post::objects()
+    .where_(Post::status.eq("draft"))
+    .union(Post::objects().where_(Post::status.eq("review")))
+    .order_by(&[("created_at", true)])
+    .limit(50)
+    .fetch(&pool).await?;
+```
+
+**Builder methods**:
+
+| Method | SQL | Semantic |
+|---|---|---|
+| `.union(other)` | `UNION` | Combine + deduplicate |
+| `.union_all(other)` | `UNION ALL` | Combine, keep duplicates (cheaper, no DISTINCT pass) |
+| `.intersection(other)` | `INTERSECT` | Rows in BOTH querysets |
+| `.difference(other)` | `EXCEPT` | Rows in first queryset but NOT others |
+
+Every method takes `QuerySet<T>` — both branches must target the same model `T`, so the column shape matches by construction (verified at compile time by Rust's generics). Calls accumulate; mixing operators in one chain is allowed (`a.union(b).intersection(c)` evaluates left-to-right per SQL standard).
+
+**Outer modifiers apply to the merged result**:
+
+```rust
+// Outer .order_by() / .limit() / .offset() / .select_for_update()
+// set AFTER the union apply to the combined resultset, NOT per-branch.
+let page: Vec<Post> = qs_a
+    .union(qs_b)
+    .union(qs_c)
+    .order_by(&[("id", false)])    // sorts the merged rows
+    .limit(20)                     // caps the merged count
+    .offset(40)                    // skips into the merged result
+    .fetch(&pool).await?;
+
+// Per-branch ORDER BY / LIMIT stay INSIDE the branch's parens:
+let mixed = qs_a
+    .union(qs_b.order_by(&[("id", true)]).limit(5))   // branch picks its top 5
+    .fetch(&pool).await?;
+```
+
+**Tri-dialect**: Postgres + SQLite support all four operators on every version rustango supports. MySQL 8.0+ supports `UNION`/`UNION ALL`; `INTERSECT`/`EXCEPT` landed in MySQL 8.0.31. Older MySQL versions surface the driver's syntax error at fetch time — there's no client-side gate.
+
+**Error path on the typed builder**: `.union(other_qs)` compiles the branch eagerly and panics if the branch fails to compile (typo'd column, etc.). For fallible composition where the caller wants a `Result`, compile the branch first and pass it via `.union_compiled(branch)`. The panic shape matches Django's: a bad branch is a programmer error, not a runtime data condition.
+
 ---
 
 ## F() expressions + database functions


### PR DESCRIPTION
## Summary

Closes #25. Django parity for `QuerySet.union(all=)`, `.intersection()`, `.difference()`. Combine multiple querysets over the same model with SQL set operators.

\`\`\`rust
// Posts that are EITHER drafts OR currently in review, sorted+capped.
let inbox: Vec<Post> = Post::objects()
    .where_(Post::status.eq(\"draft\"))
    .union(Post::objects().where_(Post::status.eq(\"review\")))
    .order_by(&[(\"created_at\", true)])
    .limit(50)
    .fetch(&pool).await?;
\`\`\`

## Builder API

| Method | SQL | Semantic |
|---|---|---|
| \`.union(other)\` | \`UNION\` | Combine + deduplicate |
| \`.union_all(other)\` | \`UNION ALL\` | Combine, keep duplicates (cheaper) |
| \`.intersection(other)\` | \`INTERSECT\` | Rows in BOTH querysets |
| \`.difference(other)\` | \`EXCEPT\` | Rows in first but NOT others |
| \`.union_compiled(branch)\` | \`UNION\` | Fallible variant — pass a pre-compiled \`SelectQuery\` for branches whose compile may fail |

Every method takes \`QuerySet<T>\` — both branches target the same model so the column shape matches by construction (compile-time generic bound).

## SQL shape

\`\`\`text
(SELECT … head …)
UNION [ALL] | INTERSECT | EXCEPT
(SELECT … branch_1 …)
…
ORDER BY …   -- outer: applies to the merged result
LIMIT N
OFFSET M
FOR UPDATE … -- outer
\`\`\`

Each branch is parenthesized so per-branch \`ORDER BY\` / \`LIMIT\` stays inside the parens. Outer \`.order_by()\` / \`.limit()\` / \`.offset()\` / \`.select_for_update()\` set after the union apply to the **combined** resultset.

## Tri-dialect

| Dialect | Behaviour |
|---|---|
| Postgres | All four operators |
| SQLite | All four operators |
| MySQL 8.0+ | UNION/UNION ALL always; INTERSECT/EXCEPT need 8.0.31+ |

The writer emits the same SQL on every backend — older MySQL surfaces a syntax error from the driver at fetch time (no client-side gate).

## What landed

- **[\`src/core/query.rs\`](crates/rustango/src/core/query.rs)** — \`SetOp\` enum (Union/UnionAll/Intersection/Difference), \`CompoundBranch\` struct, \`SelectQuery.compound: Vec<CompoundBranch>\` field, \`PartialEq\` extended.
- **[\`src/core/mod.rs\`](crates/rustango/src/core/mod.rs)** — re-exports.
- **[\`src/query/mod.rs\`](crates/rustango/src/query/mod.rs)** — 5 \`QuerySet\` builders + \`add_compound\` / \`add_compound_compiled\` plumbing.
- **[\`src/sql/writers.rs\`](crates/rustango/src/sql/writers.rs)** — \`write_compound_select\`: head branch + each compound entry parenthesized, outer modifiers emitted after the last branch closes.
- **[\`tests/set_algebra_emission.rs\`](crates/rustango/tests/set_algebra_emission.rs)** (12 tests) — each operator, outer order_by/limit placement, per-branch order_by stays parenthesized, 3-branch accumulation, mixed-operator chain order, MySQL backticks, SQLite emission, plain queryset doesn't add parens, param-vector accumulation.
- **[\`tests/set_algebra_live.rs\`](crates/rustango/tests/set_algebra_live.rs)** (5 live PG tests) — UNION dedupe, UNION ALL keeps dupes, INTERSECT empty + full cases, EXCEPT excludes matching rows, outer LIMIT caps the merged result.
- **[\`docs/orm.md\`](docs/orm.md)** — cookbook section under \"Row-level locks\" with builder table + outer/per-branch semantic notes.

## Tests

| Suite | Count | Status |
|---|---|---|
| \`tests/set_algebra_emission.rs\` | 12 | passing |
| \`tests/set_algebra_live.rs\` (live PG) | 5 | passing |
| \`cargo test -p rustango --features tenancy,mysql,sqlite --tests\` (full suite) | all | passing |

## Verification

\`\`\`
cargo test -p rustango --features tenancy,mysql,sqlite --tests   → all passing
DATABASE_URL=... cargo test --features tenancy --test set_algebra_live → 5 passed
cargo test --workspace --all-features --no-run                   → clean
cargo build --no-default-features --features sqlite,tenancy      → clean
\`\`\`

## Error path

The typed builders eagerly compile the branch and **panic** if the branch fails (typo'd column on the WHERE / ORDER BY) — programmer error, same posture as Django. Callers that want \`Result\` can compile the branch separately and pass via \`.union_compiled(branch)\`.

## Test plan

- [x] Each operator emits its SQL keyword in parenthesized form.
- [x] Outer ORDER BY / LIMIT come after the last close-paren of the compound.
- [x] Per-branch ORDER BY / LIMIT stay inside the branch's parens.
- [x] Three+ branches accumulate; mixed-operator chains preserve left-to-right order.
- [x] MySQL backticks emitted on the JOIN/quoted-ident path.
- [x] SQLite \`?\` placeholders.
- [x] Plain (no compound) queryset doesn't pick up parens.
- [x] Live PG: UNION dedupe, UNION ALL keep dupes, INTERSECT, EXCEPT semantics verified.
- [x] Workspace \`--all-features --no-run\` gate passes.
- [x] SQLite-tenancy litmus build passes.
- [ ] CI green on \`postgres_test\` + \`mysql_live\` + \`sqlite_live\` + \`sqlite_litmus\`.