### PR TITLE
feat: QuerySet::iterator(chunk_size) — chunked streaming (closes #23)

### DIFF
--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -3355,6 +3355,65 @@ where
         Ok(rows.into_iter().next())
     }
 
+    /// Issue #23 — Django's `QuerySet.iterator(chunk_size=2000)`.
+    /// Return a chunked iterator over results, fetching `chunk_size`
+    /// rows at a time via `LIMIT N OFFSET M`. Never buffers the full
+    /// result set — apps processing million-row exports can stream
+    /// rows without OOM.
+    ///
+    /// Compiles the queryset eagerly so any schema validation error
+    /// surfaces here rather than mid-stream. The compiled `SelectQuery`
+    /// is then re-issued per chunk with rotating `OFFSET`.
+    ///
+    /// ```ignore
+    /// // Two iteration styles, both work:
+    /// let mut iter = Post::objects()
+    ///     .where_(Post::published.eq(true))
+    ///     .order_by(&[("id", false)])
+    ///     .iterator(2_000)?;
+    ///
+    /// // 1. Whole-chunk loop:
+    /// while let Some(chunk) = iter.next_chunk(&pool).await? {
+    ///     for post in chunk { /* … */ }
+    /// }
+    ///
+    /// // 2. Row-by-row loop (buffer one chunk internally):
+    /// while let Some(post) = iter.next_row(&pool).await? {
+    ///     /* … */
+    /// }
+    /// ```
+    ///
+    /// **Order-by recommended.** `OFFSET` without a stable sort returns
+    /// unpredictable rows across chunks — set `.order_by(&[("pk", …)])`
+    /// before `.iterator()` so each chunk picks up where the previous
+    /// left off. The method doesn't enforce it (some queries
+    /// legitimately want no ordering, e.g. a one-shot drain).
+    ///
+    /// **Trade-off vs server-side cursors.** This is a simple
+    /// LIMIT/OFFSET chunker — each chunk re-runs the query with a
+    /// larger offset. On a btree-indexed column with `OFFSET N`,
+    /// Postgres scans the first N rows before returning the (N+1)th,
+    /// so deep pagination is O(n²) total work. For truly streaming
+    /// reads on PG, callers can drop into `transaction()` + the raw
+    /// `sqlx::query(...).fetch(...)` Stream API directly — that uses
+    /// the extended protocol with no offset reseek. The chunker is the
+    /// simple choice that works on every backend.
+    ///
+    /// # Errors
+    /// Returns [`QueryError`] if the queryset fails to compile.
+    pub fn iterator(self, chunk_size: i64) -> Result<ChunkedIter<T>, crate::core::QueryError> {
+        let query = self.compile()?;
+        Ok(ChunkedIter {
+            query,
+            chunk_size,
+            offset: 0,
+            exhausted: false,
+            buffer: std::collections::VecDeque::new(),
+            seen: 0,
+            _model: std::marker::PhantomData,
+        })
+    }
+
     /// Issue #24 — Django's `Model.objects.in_bulk(ids, field_name=)`:
     /// fetch a set of rows by a column value list and return them
     /// keyed by that column in a `HashMap`.
@@ -3652,6 +3711,159 @@ where
     async fn fetch_tx(self, tx: &mut PoolTx<'_>) -> Result<Vec<T>, ExecError> {
         let select = self.compile()?;
         select_rows_tx_with_related(tx, &select).await
+    }
+}
+
+/// Chunked async iterator over a compiled query — Django's
+/// `QuerySet.iterator(chunk_size=...)`. Issue #23.
+///
+/// Constructed via [`crate::query::QuerySet::iterator`]. Internally
+/// re-runs the underlying `SELECT` with rotating `OFFSET` per chunk
+/// so the full result set never lives in memory at once. Two
+/// consumption styles:
+///
+/// - [`Self::next_chunk`] yields `Option<Vec<T>>` — a whole batch at
+///   a time. `None` means iteration is done.
+/// - [`Self::next_row`] yields `Option<T>` one at a time, buffering
+///   the current chunk internally between calls.
+///
+/// Mix freely on the same iterator — both methods share the same
+/// buffer + offset state.
+///
+/// Iteration is **exhausted-aware**: once the underlying query
+/// returns a chunk smaller than `chunk_size` (or no rows), the
+/// iterator marks itself exhausted and every subsequent call to
+/// `next_chunk` / `next_row` returns `Ok(None)` without re-querying.
+pub struct ChunkedIter<T> {
+    /// Compiled `SelectQuery` re-issued per chunk with rotating
+    /// `OFFSET`. Cloned every chunk so the per-chunk `limit` /
+    /// `offset` mutation doesn't mutate the original.
+    query: crate::core::SelectQuery,
+    /// Per-chunk row cap. Picked at construction; doesn't change.
+    chunk_size: i64,
+    /// Next `OFFSET` to issue on the next chunk fetch. Bumped by the
+    /// number of rows actually returned (not by `chunk_size`) so a
+    /// short final chunk doesn't skip ahead.
+    offset: i64,
+    /// `true` once a fetched chunk came back smaller than
+    /// `chunk_size`. Further `next_chunk` / `next_row` calls skip the
+    /// DB and return `Ok(None)`.
+    exhausted: bool,
+    /// One-chunk buffer for the row-by-row [`Self::next_row`] path.
+    /// `VecDeque` so `pop_front` is O(1); a `Vec` would be O(n) per
+    /// row. Empty when no rows are buffered or the iterator has been
+    /// drained chunk-by-chunk via [`Self::next_chunk`].
+    buffer: std::collections::VecDeque<T>,
+    /// Cumulative row count yielded so far (across both `next_chunk`
+    /// and `next_row` paths). Used for [`Self::rows_seen`].
+    seen: i64,
+    _model: std::marker::PhantomData<fn() -> T>,
+}
+
+impl<T> ChunkedIter<T>
+where
+    T: Model
+        + MaybePgFromRow
+        + MaybeMyFromRow
+        + MaybeSqliteFromRow
+        + LoadRelated
+        + MaybeMyLoadRelated
+        + MaybeSqliteLoadRelated
+        + Send
+        + Unpin,
+{
+    /// Fetch the next chunk. Returns `Ok(None)` when iteration is done.
+    ///
+    /// If `next_row` was previously called and left rows in the
+    /// internal buffer, those rows are drained as the head of the
+    /// returned chunk before any new DB query — mixing `next_row` and
+    /// `next_chunk` on the same iterator preserves row order.
+    ///
+    /// # Errors
+    /// As [`select_rows_pool_with_related`].
+    pub async fn next_chunk(&mut self, pool: &Pool) -> Result<Option<Vec<T>>, ExecError> {
+        // Drain any rows left in the per-row buffer first.
+        let buffered: Vec<T> = self.buffer.drain(..).collect();
+        if !buffered.is_empty() {
+            self.seen += buffered.len() as i64;
+            return Ok(Some(buffered));
+        }
+        if self.exhausted {
+            return Ok(None);
+        }
+        // Clone so the per-chunk LIMIT/OFFSET tweaks don't mutate the
+        // original (the iterator may be re-used across many chunks).
+        let mut q = self.query.clone();
+        q.limit = Some(self.chunk_size);
+        q.offset = Some(self.offset);
+        let rows = select_rows_pool_with_related::<T>(pool, &q).await?;
+        let n = rows.len() as i64;
+        if rows.is_empty() {
+            self.exhausted = true;
+            return Ok(None);
+        }
+        if n < self.chunk_size {
+            self.exhausted = true;
+        }
+        self.offset += n;
+        self.seen += n;
+        Ok(Some(rows))
+    }
+
+    /// Yield one row at a time, buffering an internal chunk between
+    /// calls. Returns `Ok(None)` when iteration is done.
+    ///
+    /// O(1) per row — uses `VecDeque::pop_front` against the internal
+    /// buffer, refilling from the next chunk only when empty.
+    ///
+    /// # Errors
+    /// As [`Self::next_chunk`].
+    pub async fn next_row(&mut self, pool: &Pool) -> Result<Option<T>, ExecError> {
+        if let Some(row) = self.buffer.pop_front() {
+            self.seen += 1;
+            return Ok(Some(row));
+        }
+        if self.exhausted {
+            return Ok(None);
+        }
+        // Fetch a fresh chunk directly (bypass next_chunk to avoid
+        // its buffer-drain branch, which would only confuse the
+        // accounting here).
+        let mut q = self.query.clone();
+        q.limit = Some(self.chunk_size);
+        q.offset = Some(self.offset);
+        let rows = select_rows_pool_with_related::<T>(pool, &q).await?;
+        let n = rows.len() as i64;
+        if rows.is_empty() {
+            self.exhausted = true;
+            return Ok(None);
+        }
+        if n < self.chunk_size {
+            self.exhausted = true;
+        }
+        self.offset += n;
+        self.buffer.extend(rows);
+        let row = self.buffer.pop_front();
+        if row.is_some() {
+            self.seen += 1;
+        }
+        Ok(row)
+    }
+
+    /// Cumulative count of rows yielded so far across both
+    /// `next_chunk` and `next_row` calls. Useful for progress
+    /// reporting on long drains.
+    #[must_use]
+    pub fn rows_seen(&self) -> i64 {
+        self.seen
+    }
+
+    /// `true` once iteration has been exhausted — every subsequent
+    /// `next_chunk` / `next_row` call will return `Ok(None)` without
+    /// hitting the database.
+    #[must_use]
+    pub fn is_exhausted(&self) -> bool {
+        self.exhausted && self.buffer.is_empty()
     }
 }
 

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -3402,19 +3402,29 @@ where
     /// **Concurrent-write hazard.** Each chunk is its own query, so
     /// rows inserted ahead of the current offset between fetches can
     /// be skipped, and rows deleted can shift a row down into the
-    /// next chunk and be returned twice. If the table is being
-    /// written concurrently while iterating, wrap the whole drain in
-    /// a snapshot-isolation transaction (PG / SQLite:
-    /// `SET TRANSACTION ISOLATION LEVEL REPEATABLE READ`; pair with
-    /// `pool.begin()`). For read-only / append-only tables — the
-    /// usual export use case — this isn't a concern.
+    /// next chunk and be returned twice. **The chunker API is
+    /// `&Pool`-only — it can't run inside a `&mut Transaction`** —
+    /// so for write-concurrent tables you have to hand-roll the
+    /// LIMIT/OFFSET loop against [`select_rows_on`] inside your
+    /// `pool.begin()` + `SET TRANSACTION ISOLATION LEVEL REPEATABLE
+    /// READ` block. See the cookbook for the boilerplate. For
+    /// read-only / append-only tables (the typical export use case)
+    /// this isn't a concern.
     ///
     /// **`select_for_update()` does NOT propagate.** Row locks
     /// acquired by a `.select_for_update()` call on the queryset are
     /// released between chunks because each chunk runs in its own
-    /// implicit transaction. To hold the locks for the full drain,
-    /// wrap iteration in `pool.begin()` and call `.fetch_on(&mut *tx)`
-    /// against the lock-scoped tx instead of using the chunker.
+    /// implicit transaction, and the chunker API doesn't take a
+    /// transaction. Two compromises for a locked drain:
+    ///
+    /// * `.fetch_on(&mut *tx)` — single round trip, returns full
+    ///   `Vec<T>`; fine when the result fits in memory.
+    /// * Hand-roll LIMIT/OFFSET inside the tx via [`select_rows_on`]
+    ///   — same shape as the snapshot-isolation pattern; streams
+    ///   chunks but outside the [`ChunkedIter`] API.
+    ///
+    /// A future `iterator_on(&mut *tx, chunk_size)` companion would
+    /// close this gap; not in scope for issue #23.
     ///
     /// # Errors
     /// Returns [`QueryError`] if the queryset fails to compile.

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -3399,9 +3399,36 @@ where
     /// the extended protocol with no offset reseek. The chunker is the
     /// simple choice that works on every backend.
     ///
+    /// **Concurrent-write hazard.** Each chunk is its own query, so
+    /// rows inserted ahead of the current offset between fetches can
+    /// be skipped, and rows deleted can shift a row down into the
+    /// next chunk and be returned twice. If the table is being
+    /// written concurrently while iterating, wrap the whole drain in
+    /// a snapshot-isolation transaction (PG / SQLite:
+    /// `SET TRANSACTION ISOLATION LEVEL REPEATABLE READ`; pair with
+    /// `pool.begin()`). For read-only / append-only tables — the
+    /// usual export use case — this isn't a concern.
+    ///
+    /// **`select_for_update()` does NOT propagate.** Row locks
+    /// acquired by a `.select_for_update()` call on the queryset are
+    /// released between chunks because each chunk runs in its own
+    /// implicit transaction. To hold the locks for the full drain,
+    /// wrap iteration in `pool.begin()` and call `.fetch_on(&mut *tx)`
+    /// against the lock-scoped tx instead of using the chunker.
+    ///
     /// # Errors
     /// Returns [`QueryError`] if the queryset fails to compile.
+    ///
+    /// # Panics
+    /// If `chunk_size <= 0`. Zero or negative chunk sizes silently
+    /// yield no rows, which is almost always a programmer error
+    /// (e.g. `iterator(unchecked_user_input as i64)`); the assert
+    /// surfaces it loudly.
     pub fn iterator(self, chunk_size: i64) -> Result<ChunkedIter<T>, crate::core::QueryError> {
+        assert!(
+            chunk_size > 0,
+            "QuerySet::iterator: chunk_size must be > 0; got {chunk_size}"
+        );
         let query = self.compile()?;
         Ok(ChunkedIter {
             query,
@@ -3782,12 +3809,57 @@ where
     /// # Errors
     /// As [`select_rows_pool_with_related`].
     pub async fn next_chunk(&mut self, pool: &Pool) -> Result<Option<Vec<T>>, ExecError> {
-        // Drain any rows left in the per-row buffer first.
-        let buffered: Vec<T> = self.buffer.drain(..).collect();
-        if !buffered.is_empty() {
+        // Drain any rows left in the per-row buffer first — they were
+        // pre-fetched by an earlier `next_row` call and need to come
+        // out before any new DB fetch.
+        if !self.buffer.is_empty() {
+            let buffered: Vec<T> = self.buffer.drain(..).collect();
             self.seen += buffered.len() as i64;
             return Ok(Some(buffered));
         }
+        match self.fetch_next_chunk(pool).await? {
+            Some(rows) => {
+                self.seen += rows.len() as i64;
+                Ok(Some(rows))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Yield one row at a time, buffering an internal chunk between
+    /// calls. Returns `Ok(None)` when iteration is done.
+    ///
+    /// O(1) per row — uses `VecDeque::pop_front` against the internal
+    /// buffer, refilling from the next chunk only when empty.
+    ///
+    /// # Errors
+    /// As [`Self::next_chunk`].
+    pub async fn next_row(&mut self, pool: &Pool) -> Result<Option<T>, ExecError> {
+        if let Some(row) = self.buffer.pop_front() {
+            self.seen += 1;
+            return Ok(Some(row));
+        }
+        match self.fetch_next_chunk(pool).await? {
+            Some(rows) => {
+                self.buffer.extend(rows);
+                let row = self.buffer.pop_front();
+                if row.is_some() {
+                    self.seen += 1;
+                }
+                Ok(row)
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Shared fetch path for [`Self::next_chunk`] / [`Self::next_row`].
+    /// Clones the compiled query, rotates `LIMIT`/`OFFSET` for this
+    /// chunk, runs the fetch, advances `offset`, and flips the
+    /// `exhausted` flag when the chunk comes back short or empty.
+    /// Does NOT touch `self.seen` — that's the caller's
+    /// responsibility because the row-by-row path counts as rows pop
+    /// out of the buffer, not as the chunk arrives.
+    async fn fetch_next_chunk(&mut self, pool: &Pool) -> Result<Option<Vec<T>>, ExecError> {
         if self.exhausted {
             return Ok(None);
         }
@@ -3806,48 +3878,7 @@ where
             self.exhausted = true;
         }
         self.offset += n;
-        self.seen += n;
         Ok(Some(rows))
-    }
-
-    /// Yield one row at a time, buffering an internal chunk between
-    /// calls. Returns `Ok(None)` when iteration is done.
-    ///
-    /// O(1) per row — uses `VecDeque::pop_front` against the internal
-    /// buffer, refilling from the next chunk only when empty.
-    ///
-    /// # Errors
-    /// As [`Self::next_chunk`].
-    pub async fn next_row(&mut self, pool: &Pool) -> Result<Option<T>, ExecError> {
-        if let Some(row) = self.buffer.pop_front() {
-            self.seen += 1;
-            return Ok(Some(row));
-        }
-        if self.exhausted {
-            return Ok(None);
-        }
-        // Fetch a fresh chunk directly (bypass next_chunk to avoid
-        // its buffer-drain branch, which would only confuse the
-        // accounting here).
-        let mut q = self.query.clone();
-        q.limit = Some(self.chunk_size);
-        q.offset = Some(self.offset);
-        let rows = select_rows_pool_with_related::<T>(pool, &q).await?;
-        let n = rows.len() as i64;
-        if rows.is_empty() {
-            self.exhausted = true;
-            return Ok(None);
-        }
-        if n < self.chunk_size {
-            self.exhausted = true;
-        }
-        self.offset += n;
-        self.buffer.extend(rows);
-        let row = self.buffer.pop_front();
-        if row.is_some() {
-            self.seen += 1;
-        }
-        Ok(row)
     }
 
     /// Cumulative count of rows yielded so far across both

--- a/crates/rustango/tests/iterator_live.rs
+++ b/crates/rustango/tests/iterator_live.rs
@@ -170,6 +170,7 @@ async fn mixed_next_row_and_next_chunk_preserve_order() {
         values.push(iter.next_row(&pool).await.unwrap().unwrap().value);
     }
     assert_eq!(values, (0..50).collect::<Vec<i64>>());
+    assert_eq!(iter.rows_seen(), 50, "mid-iteration row count");
 
     // Now switch to next_chunk — it should first drain the 50
     // buffered rows as one chunk, then continue with fresh DB

--- a/crates/rustango/tests/iterator_live.rs
+++ b/crates/rustango/tests/iterator_live.rs
@@ -1,0 +1,251 @@
+#![cfg(feature = "postgres")]
+//! Live PG test for `QuerySet::iterator` chunked streaming (issue #23).
+//! Verifies LIMIT/OFFSET chunking against a 1000-row fixture: 5
+//! chunks of 200, both whole-chunk and row-by-row iteration paths
+//! see every row exactly once in stable order, the iterator
+//! exhausts itself when the result runs out, and the `seen` counter
+//! tracks correctly. Skips silently when `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::core::Column as _;
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "iter_live_row")]
+#[allow(dead_code)]
+pub struct Row {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub value: i64,
+}
+
+fn lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn fresh_pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pg = sqlx::PgPool::connect(&url).await.ok()?;
+    sqlx::query(r#"DROP TABLE IF EXISTS "iter_live_row" CASCADE"#)
+        .execute(&pg)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"
+        CREATE TABLE "iter_live_row" (
+            id BIGSERIAL PRIMARY KEY,
+            value BIGINT NOT NULL
+        )
+        "#,
+    )
+    .execute(&pg)
+    .await
+    .unwrap();
+    // 1000-row fixture — value mirrors id-1 (0..999).
+    let mut values = String::new();
+    for i in 0..1000 {
+        if i > 0 {
+            values.push_str(", ");
+        }
+        values.push_str(&format!("({i})"));
+    }
+    sqlx::query(&format!(
+        r#"INSERT INTO "iter_live_row" ("value") VALUES {values}"#
+    ))
+    .execute(&pg)
+    .await
+    .unwrap();
+    Some(Pool::Postgres(pg))
+}
+
+async fn cleanup(pool: &Pool) {
+    // Single-variant Pool with only the `postgres` feature on; the
+    // pattern is irrefutable but stays configuration-honest in case
+    // mysql/sqlite features ever get co-enabled in this binary.
+    #[allow(irrefutable_let_patterns)]
+    let Pool::Postgres(pg) = pool
+    else {
+        return;
+    };
+    sqlx::query(r#"DROP TABLE IF EXISTS "iter_live_row" CASCADE"#)
+        .execute(pg)
+        .await
+        .unwrap();
+}
+
+/// 1000-row table, chunk_size = 200. Expect 5 chunks of 200 + an
+/// `Ok(None)` terminator. Every row is yielded exactly once, in `id
+/// ASC` order.
+#[tokio::test]
+async fn next_chunk_yields_all_rows_in_order() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let mut iter = Row::objects()
+        .order_by(&[("id", false)])
+        .iterator(200)
+        .unwrap();
+
+    let mut all_values: Vec<i64> = Vec::new();
+    let mut chunks_seen = 0;
+    while let Some(chunk) = iter.next_chunk(&pool).await.unwrap() {
+        chunks_seen += 1;
+        assert!(
+            chunk.len() <= 200,
+            "no chunk exceeds chunk_size: {}",
+            chunk.len()
+        );
+        for row in chunk {
+            all_values.push(row.value);
+        }
+    }
+    assert_eq!(chunks_seen, 5, "1000 / 200 = 5 chunks");
+    assert_eq!(all_values.len(), 1000);
+    // Verify order — values should be 0, 1, 2, …, 999.
+    for (i, v) in all_values.iter().enumerate() {
+        assert_eq!(*v, i as i64, "row at position {i} has value {v}");
+    }
+    assert_eq!(iter.rows_seen(), 1000);
+    assert!(iter.is_exhausted());
+
+    cleanup(&pool).await;
+}
+
+/// Row-by-row path: 1000 calls to `next_row`, each yielding one row
+/// in `id ASC` order. Verifies the internal `VecDeque` buffer
+/// refills correctly between chunks.
+#[tokio::test]
+async fn next_row_yields_every_row_with_internal_buffering() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let mut iter = Row::objects()
+        .order_by(&[("id", false)])
+        .iterator(150) // chunk_size doesn't divide 1000 evenly (7 chunks: 6×150 + 100)
+        .unwrap();
+
+    let mut count = 0_i64;
+    while let Some(row) = iter.next_row(&pool).await.unwrap() {
+        assert_eq!(
+            row.value, count,
+            "row at position {count} has value {}",
+            row.value
+        );
+        count += 1;
+    }
+    assert_eq!(count, 1000);
+    assert_eq!(iter.rows_seen(), 1000);
+    assert!(iter.is_exhausted());
+
+    cleanup(&pool).await;
+}
+
+/// Mix `next_chunk` and `next_row` on the same iterator — the
+/// internal buffer must drain in row order before the next DB
+/// fetch, so row order is preserved across the boundary.
+#[tokio::test]
+async fn mixed_next_row_and_next_chunk_preserve_order() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let mut iter = Row::objects()
+        .order_by(&[("id", false)])
+        .iterator(100)
+        .unwrap();
+
+    // Pull 50 rows via next_row — fills + half-drains the first
+    // chunk (100 rows fetched, 50 remain in buffer).
+    let mut values: Vec<i64> = Vec::new();
+    for _ in 0..50 {
+        values.push(iter.next_row(&pool).await.unwrap().unwrap().value);
+    }
+    assert_eq!(values, (0..50).collect::<Vec<i64>>());
+
+    // Now switch to next_chunk — it should first drain the 50
+    // buffered rows as one chunk, then continue with fresh DB
+    // fetches.
+    let next = iter.next_chunk(&pool).await.unwrap().unwrap();
+    assert_eq!(
+        next.len(),
+        50,
+        "drained-buffer chunk has 50 rows: got {}",
+        next.len()
+    );
+    for (i, row) in next.iter().enumerate() {
+        assert_eq!(row.value, (50 + i) as i64);
+    }
+
+    // Continue with full-chunk fetches until exhausted.
+    let mut full = values.clone();
+    full.extend(next.iter().map(|r| r.value));
+    while let Some(chunk) = iter.next_chunk(&pool).await.unwrap() {
+        full.extend(chunk.iter().map(|r| r.value));
+    }
+    assert_eq!(full.len(), 1000);
+    for (i, v) in full.iter().enumerate() {
+        assert_eq!(*v, i as i64, "mixed-path position {i} value {v}");
+    }
+
+    cleanup(&pool).await;
+}
+
+/// Filter narrows the result — iterator only sees matching rows.
+/// `value BETWEEN 100 AND 199` → 100 rows, chunk_size = 30, expect
+/// 4 chunks: 30, 30, 30, 10.
+#[tokio::test]
+async fn iterator_respects_where_clause_and_short_final_chunk() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let mut iter = Row::objects()
+        .where_(Row::value.gte(100_i64))
+        .where_(Row::value.lt(200_i64))
+        .order_by(&[("value", false)])
+        .iterator(30)
+        .unwrap();
+
+    let mut chunks: Vec<usize> = Vec::new();
+    while let Some(chunk) = iter.next_chunk(&pool).await.unwrap() {
+        chunks.push(chunk.len());
+    }
+    assert_eq!(chunks, vec![30, 30, 30, 10], "got {chunks:?}");
+    assert_eq!(iter.rows_seen(), 100);
+
+    cleanup(&pool).await;
+}
+
+/// Empty result set — iterator yields one `Ok(None)` immediately.
+#[tokio::test]
+async fn empty_result_yields_none_first_call() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let mut iter = Row::objects()
+        .where_(Row::value.gte(10_000_i64)) // no row matches
+        .iterator(200)
+        .unwrap();
+
+    assert!(iter.next_chunk(&pool).await.unwrap().is_none());
+    assert!(iter.is_exhausted());
+    assert_eq!(iter.rows_seen(), 0);
+
+    // Subsequent calls also return None — no extra DB query.
+    assert!(iter.next_chunk(&pool).await.unwrap().is_none());
+    assert!(iter.next_row(&pool).await.unwrap().is_none());
+
+    cleanup(&pool).await;
+}

--- a/crates/rustango/tests/iterator_validation.rs
+++ b/crates/rustango/tests/iterator_validation.rs
@@ -1,0 +1,38 @@
+//! Sync (no-DB) tests for `QuerySet::iterator` argument validation
+//! (issue #23). Runtime semantics live in `iterator_live.rs`; this
+//! file pins the construction-time guards.
+
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "iter_validation_row")]
+#[allow(dead_code)]
+pub struct Row {
+    #[rustango(primary_key)]
+    id: i64,
+    value: i64,
+}
+
+/// `chunk_size <= 0` is almost always a programmer error (e.g.
+/// `iterator(unchecked_user_input as i64)` where the input is 0 or
+/// negative). Silently producing an immediately-exhausted iterator
+/// would lose every row. Assert surfaces the misuse loudly.
+#[test]
+#[should_panic(expected = "chunk_size must be > 0")]
+fn iterator_with_zero_chunk_size_panics() {
+    let _ = Row::objects().iterator(0);
+}
+
+#[test]
+#[should_panic(expected = "chunk_size must be > 0")]
+fn iterator_with_negative_chunk_size_panics() {
+    let _ = Row::objects().iterator(-100);
+}
+
+/// Positive chunk size goes through cleanly — no DB call yet, just
+/// compiles the queryset.
+#[test]
+fn iterator_with_positive_chunk_size_compiles() {
+    let r = Row::objects().iterator(2_000);
+    assert!(r.is_ok(), "positive chunk_size compiles");
+}

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -327,6 +327,22 @@ while let Some(post) = iter.next_row(&pool).await? {
 
 Both `.rows_seen()` (cumulative count) and `.is_exhausted()` (post-drain flag) are available for progress reporting and termination checks.
 
+**Concurrent-write hazard.** Each chunk is a separate query, so rows inserted/deleted between chunks can be skipped or duplicated (the classic OFFSET-pagination "windowing" problem). For read-only / append-only tables — the typical export use case — this isn't a concern. For tables being written concurrently, wrap iteration in a snapshot-isolation transaction so every chunk sees the same view:
+
+```rust
+// Pseudo — apply ISO level then run the iteration inside the tx.
+let mut tx = pool.begin().await?;
+sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+    .execute(&mut *tx).await?;
+// ... iterate using next_chunk_on(&mut *tx) etc., or compile to a
+// SelectQuery and run it directly through select_rows_on per chunk.
+tx.commit().await?;
+```
+
+**`select_for_update()` doesn't propagate across chunks.** Row locks held by `.select_for_update()` are released at the end of each chunk's implicit transaction. To hold the locks across the whole drain, open one `pool.begin()` transaction and run the locking query inside it via `.fetch_on(&mut *tx)` — at that point you're outside the chunker API entirely.
+
+**`chunk_size` must be > 0.** Zero or negative values panic. Pick a value that fits your row-size budget (Django's default is `2000`; reasonable for narrow rows, lower for wide TEXT/JSONB columns).
+
 ---
 
 ## F() expressions + database functions

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -327,19 +327,38 @@ while let Some(post) = iter.next_row(&pool).await? {
 
 Both `.rows_seen()` (cumulative count) and `.is_exhausted()` (post-drain flag) are available for progress reporting and termination checks.
 
-**Concurrent-write hazard.** Each chunk is a separate query, so rows inserted/deleted between chunks can be skipped or duplicated (the classic OFFSET-pagination "windowing" problem). For read-only / append-only tables — the typical export use case — this isn't a concern. For tables being written concurrently, wrap iteration in a snapshot-isolation transaction so every chunk sees the same view:
+**Concurrent-write hazard.** Each chunk is a separate query, so rows inserted/deleted between chunks can be skipped or duplicated (the classic OFFSET-pagination "windowing" problem). For read-only / append-only tables — the typical export use case — this isn't a concern. For tables being written concurrently you need a snapshot-isolation transaction so every chunk sees the same view. **`ChunkedIter` takes `&Pool`, not a `&mut Transaction`, so the chunker API can't be used inside the tx directly** — hand-roll the chunked SELECT against the tx instead:
 
 ```rust
-// Pseudo — apply ISO level then run the iteration inside the tx.
+use rustango::sql::select_rows_on;
+
 let mut tx = pool.begin().await?;
 sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
     .execute(&mut *tx).await?;
-// ... iterate using next_chunk_on(&mut *tx) etc., or compile to a
-// SelectQuery and run it directly through select_rows_on per chunk.
+
+// Compile once, then hand-loop LIMIT/OFFSET chunks against the tx.
+let base = Post::objects().order_by(&[("id", false)]).compile()?;
+let chunk_size = 2_000_i64;
+let mut offset = 0_i64;
+loop {
+    let mut q = base.clone();
+    q.limit = Some(chunk_size);
+    q.offset = Some(offset);
+    let rows: Vec<Post> = select_rows_on(&mut *tx, &q).await?;
+    if rows.is_empty() { break; }
+    for post in &rows { /* … */ }
+    if (rows.len() as i64) < chunk_size { break; }
+    offset += rows.len() as i64;
+}
 tx.commit().await?;
 ```
 
-**`select_for_update()` doesn't propagate across chunks.** Row locks held by `.select_for_update()` are released at the end of each chunk's implicit transaction. To hold the locks across the whole drain, open one `pool.begin()` transaction and run the locking query inside it via `.fetch_on(&mut *tx)` — at that point you're outside the chunker API entirely.
+**`select_for_update()` doesn't propagate across chunks.** Row locks held by `.select_for_update()` are released at the end of each chunk's implicit transaction. There's no chunker-shaped fix: the `.iterator()` builder takes `&Pool`, the locking variants need a `&mut Transaction`, and the two don't compose. For a locked drain you have two paths, each with a trade-off:
+
+- **Whole-result `.fetch_on(&mut *tx)`** — single round trip, full `Vec<T>` in memory. Fine when the result fits.
+- **Hand-rolled LIMIT/OFFSET inside the tx** — same shape as the snapshot-isolation snippet above; chunks stay streamed but you're outside the `ChunkedIter` API.
+
+A future `iterator_on(&mut *tx, chunk_size)` companion (issue follow-up) would close this gap. Not in scope for issue #23.
 
 **`chunk_size` must be > 0.** Zero or negative values panic. Pick a value that fits your row-size budget (Django's default is `2000`; reasonable for narrow rows, lower for wide TEXT/JSONB columns).
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -298,6 +298,35 @@ let mixed = qs_a
 
 **Error path on the typed builder**: `.union(other_qs)` (and `.intersection()` / `.difference()`) compiles the branch eagerly and panics if the branch fails to compile (typo'd column, etc.). For fallible composition where the caller wants a `Result`, compile the branch first and pass it via `.with_compound(SetOp::Union, branch)` — one generic entry point covers every operator. The panic shape matches Django's: a bad branch is a programmer error, not a runtime data condition.
 
+### Stream large result sets — `.iterator(chunk_size)`
+
+Django's [`QuerySet.iterator(chunk_size=2000)`](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#iterator) — issue #23. Returns a chunked iterator that fetches `chunk_size` rows at a time via `LIMIT N OFFSET M`, never buffering the whole result set in memory. Right tool for million-row exports, ETL pipelines, batch processors.
+
+```rust
+// 1. Whole-chunk loop — process N rows at a time.
+let mut iter = Post::objects()
+    .where_(Post::published.eq(true))
+    .order_by(&[("id", false)])
+    .iterator(2_000)?;
+while let Some(chunk) = iter.next_chunk(&pool).await? {
+    for post in chunk { /* … */ }
+}
+
+// 2. Row-by-row loop — buffer one chunk internally, yield one row.
+let mut iter = Post::objects().order_by(&[("id", false)]).iterator(2_000)?;
+while let Some(post) = iter.next_row(&pool).await? {
+    /* … */
+}
+```
+
+**Set an `order_by`.** `OFFSET` against a query with no stable sort returns unpredictable rows across chunks — typically `.order_by(&[("pk", false)])` so each chunk picks up cleanly. The method doesn't enforce ordering (some queries legitimately want no sort, e.g. a one-shot drain), but unsorted iteration is a footgun.
+
+**Trade-off vs server-side cursors.** This is a simple LIMIT/OFFSET chunker. On a btree-indexed sort column, Postgres scans the first N rows before returning the (N+1)th — so deep pagination is `O(n²)` total work. For a 10M-row drain this matters; for 100k rows it usually doesn't. The chunker wins on portability (works on all backends with no transaction overhead) and simplicity (no cursor lifecycle management). For truly streaming reads on PG, drop into `transaction()` + raw `sqlx::query(...).fetch(pool)` Stream API directly — the extended protocol streams from the server without offset reseek.
+
+**Mixing `next_chunk` and `next_row` on the same iterator is safe.** The internal `VecDeque` buffer drains in row order before any new DB fetch, so `next_chunk` after a partial `next_row` drain yields the remaining buffered rows first, then continues with fresh chunks.
+
+Both `.rows_seen()` (cumulative count) and `.is_exhausted()` (post-drain flag) are available for progress reporting and termination checks.
+
 ---
 
 ## F() expressions + database functions


### PR DESCRIPTION
## Summary

Closes #23. Django parity for `QuerySet.iterator(chunk_size=2000)`. Returns a `ChunkedIter<T>` that fetches `chunk_size` rows at a time via `LIMIT N OFFSET M` — never buffers the full result set. Right tool for million-row exports / ETL pipelines / batch processors that would OOM with `fetch_pool` returning `Vec<T>`.

\`\`\`rust
let mut iter = Post::objects()
    .where_(Post::published.eq(true))
    .order_by(&[(\"id\", false)])
    .iterator(2_000)?;

// 1. Whole-chunk loop:
while let Some(chunk) = iter.next_chunk(&pool).await? {
    for post in chunk { /* … */ }
}

// 2. Row-by-row loop (internal VecDeque buffer, O(1) per row):
let mut iter = Post::objects().order_by(&[(\"id\", false)]).iterator(2_000)?;
while let Some(post) = iter.next_row(&pool).await? { /* … */ }
\`\`\`

## API

| Method | Returns | Description |
|---|---|---|
| `QuerySet::iterator(chunk_size)` | `Result<ChunkedIter<T>>` | Compiles eagerly — schema errors surface here, not mid-stream |
| `ChunkedIter::next_chunk(&pool)` | `Result<Option<Vec<T>>>` | Whole-chunk; `None` = done |
| `ChunkedIter::next_row(&pool)` | `Result<Option<T>>` | Row-by-row; buffers one chunk internally |
| `ChunkedIter::rows_seen()` | `i64` | Cumulative count (progress reporting) |
| `ChunkedIter::is_exhausted()` | `bool` | Post-drain flag |

Mixing `next_chunk` and `next_row` on the same iterator is safe — the buffer drains in row order before any new DB fetch.

## Design notes

- **LIMIT/OFFSET chunker, not a server-side cursor.** Portable across PG / MySQL / SQLite with no transaction overhead. Trade-off documented in the cookbook: O(n²) total work on deep pagination (each chunk reseeks). For truly streaming PG reads, drop into `transaction()` + raw `sqlx::query(...).fetch` Stream directly.
- **VecDeque buffer for row-by-row path.** O(1) `pop_front` per row; a `Vec::remove(0)` would be O(n).
- **Exhaustion is sticky.** Once a chunk comes back smaller than `chunk_size` (or empty), the iterator marks itself exhausted and every subsequent call returns `Ok(None)` without re-querying.
- **No new dependencies.** Considered exposing a `Stream` impl via `futures-core` but went with the simpler `next_chunk` / `next_row` async-method API — zero new deps, two ergonomic styles, no Pin/Unpin gymnastics in user code.

## Tri-dialect

Works on every backend — LIMIT/OFFSET is the portable common denominator. Cookbook flags the deep-pagination trade-off + the PG escape hatch.

## What landed

- **[\`src/sql/executor.rs\`](crates/rustango/src/sql/executor.rs)** — \`ChunkedIter<T>\` struct + \`QuerySet::iterator(chunk_size)\` + 4 methods on \`ChunkedIter\`.
- **[\`tests/iterator_live.rs\`](crates/rustango/tests/iterator_live.rs)** — 5 live PG tests against a 1000-row fixture.
- **[\`docs/orm.md\`](docs/orm.md)** — cookbook section under \"Row-level locks\".

## Tests

| Suite | Count | Status |
|---|---|---|
| \`tests/iterator_live.rs\` (live PG, 1000-row fixture) | 5 | passing |
| \`cargo test -p rustango --features tenancy,mysql,sqlite --tests\` (full suite) | all | passing |

Live tests cover:
- **next_chunk_yields_all_rows_in_order** — 5 chunks of 200, row order preserved.
- **next_row_yields_every_row_with_internal_buffering** — chunk_size that doesn't divide evenly (150 → 7 chunks: 6×150 + 100).
- **mixed_next_row_and_next_chunk_preserve_order** — partial drain via next_row, then next_chunk yields buffered remainder before refetching.
- **iterator_respects_where_clause_and_short_final_chunk** — narrowed filter, short final chunk (4 chunks: 30, 30, 30, 10).
- **empty_result_yields_none_first_call** — no DB hit on subsequent calls after exhaustion.

## Verification

\`\`\`
cargo test -p rustango --features tenancy,mysql,sqlite --tests   → all passing
DATABASE_URL=... cargo test --features tenancy --test iterator_live → 5 passed
cargo test --workspace --all-features --no-run                   → clean
cargo build --no-default-features --features sqlite,tenancy      → clean
\`\`\`

## Test plan

- [x] 1000-row fixture iterated chunk-by-chunk in order.
- [x] 1000-row fixture iterated row-by-row in order.
- [x] Mixed next_chunk + next_row preserves order.
- [x] WHERE filter respected.
- [x] Short final chunk.
- [x] Empty result short-circuits.
- [x] `rows_seen()` tracks correctly across both paths.
- [x] `is_exhausted()` becomes true once drained.
- [x] Workspace `--all-features --no-run` gate passes.
- [x] SQLite-tenancy litmus build passes.
- [ ] CI green on \`postgres_test\` + \`mysql_live\` + \`sqlite_live\` + \`sqlite_litmus\`.