### PR TITLE
feat: __regex / __iregex lookups — Django regex parity (closes #26)

### DIFF
--- a/crates/rustango/src/core/column.rs
+++ b/crates/rustango/src/core/column.rs
@@ -76,6 +76,37 @@ pub trait Column: Copy + 'static {
         TypedFilter::scalar(Self::COLUMN, Op::NotILike, value.into().into())
     }
 
+    /// `column REGEXP pattern` — POSIX regex match. Django `__regex`
+    /// (issue #26). Pattern is bound as a `String` parameter. Emits
+    /// PG `~`, MySQL `REGEXP`, SQLite `REGEXP` (requires the regex
+    /// extension at runtime; sqlx-sqlite loads it automatically).
+    fn regex(self, pattern: impl Into<String>) -> TypedFilter<Self::Model> {
+        TypedFilter::scalar(Self::COLUMN, Op::Regex, SqlValue::String(pattern.into()))
+    }
+
+    /// `NOT column REGEXP pattern`. Django `~Q(field__regex=...)`.
+    fn not_regex(self, pattern: impl Into<String>) -> TypedFilter<Self::Model> {
+        TypedFilter::scalar(Self::COLUMN, Op::NotRegex, SqlValue::String(pattern.into()))
+    }
+
+    /// Case-insensitive POSIX regex match. Django `__iregex` (issue
+    /// #26). Emits PG `~*`; MySQL + SQLite fall back to
+    /// `LOWER(col) REGEXP LOWER(pattern)` for collation-independent
+    /// case folding.
+    fn iregex(self, pattern: impl Into<String>) -> TypedFilter<Self::Model> {
+        TypedFilter::scalar(Self::COLUMN, Op::IRegex, SqlValue::String(pattern.into()))
+    }
+
+    /// Case-insensitive POSIX regex non-match. Django
+    /// `~Q(field__iregex=...)`.
+    fn not_iregex(self, pattern: impl Into<String>) -> TypedFilter<Self::Model> {
+        TypedFilter::scalar(
+            Self::COLUMN,
+            Op::NotIRegex,
+            SqlValue::String(pattern.into()),
+        )
+    }
+
     /// `column IS NULL`.
     fn is_null(self) -> TypedFilter<Self::Model> {
         TypedFilter::scalar(Self::COLUMN, Op::IsNull, SqlValue::Bool(true))

--- a/crates/rustango/src/core/column.rs
+++ b/crates/rustango/src/core/column.rs
@@ -78,13 +78,17 @@ pub trait Column: Copy + 'static {
 
     /// `column REGEXP pattern` — POSIX regex match. Django `__regex`
     /// (issue #26). Pattern is bound as a `String` parameter. Emits
-    /// PG `~`, MySQL `REGEXP`, SQLite `REGEXP` (requires the regex
-    /// extension at runtime; sqlx-sqlite loads it automatically).
+    /// PG `~`, MySQL `REGEXP`, SQLite `REGEXP`. SQLite's `REGEXP`
+    /// delegates to a `regexp(pattern, value)` user-function the
+    /// caller must register — sqlx-sqlite does not register it
+    /// automatically (the `regexp` cargo feature on sqlx-sqlite
+    /// adds a `.with_regexp()` builder that does).
     fn regex(self, pattern: impl Into<String>) -> TypedFilter<Self::Model> {
         TypedFilter::scalar(Self::COLUMN, Op::Regex, SqlValue::String(pattern.into()))
     }
 
     /// `NOT column REGEXP pattern`. Django `~Q(field__regex=...)`.
+    /// Same SQLite caveat as [`Column::regex`].
     fn not_regex(self, pattern: impl Into<String>) -> TypedFilter<Self::Model> {
         TypedFilter::scalar(Self::COLUMN, Op::NotRegex, SqlValue::String(pattern.into()))
     }

--- a/crates/rustango/src/core/error.rs
+++ b/crates/rustango/src/core/error.rs
@@ -78,7 +78,7 @@ pub enum QueryError {
         "unknown lookup suffix `__{suffix}` on field `{field}` — \
          supported: exact, iexact, contains, icontains, startswith, \
          istartswith, endswith, iendswith, gt, gte, lt, lte, ne, in, \
-         isnull, between, range"
+         isnull, between, range, regex, iregex"
     )]
     UnknownLookup { field: String, suffix: String },
 

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -55,6 +55,29 @@ pub enum Op {
     /// JSONB `?&` — all of the text keys exist. Bind a `SqlValue::List`
     /// of `SqlValue::String`.
     JsonHasAllKeys,
+    /// POSIX regex match — Django's `__regex` lookup. Case-sensitive.
+    /// Bind a `SqlValue::String` containing the regex pattern.
+    /// Tri-dialect: PG `~`, MySQL `REGEXP`, SQLite `REGEXP`. SQLite's
+    /// `REGEXP` delegates to a `regexp(pattern, value)` user-function
+    /// the connection must register — sqlx-sqlite does not register
+    /// it automatically. Issue #26.
+    Regex,
+    /// POSIX regex non-match — Django's `~Q(name__regex=...)` shape
+    /// rolled into a single op. PG `!~`, MySQL `NOT REGEXP`,
+    /// SQLite `NOT REGEXP` (same user-function caveat as [`Op::Regex`]).
+    /// Issue #26.
+    NotRegex,
+    /// Case-insensitive POSIX regex match — Django's `__iregex`.
+    /// PG `~*` (native ASCII-folded match). MySQL and SQLite have
+    /// no native case-insensitive regex operator, so the writer
+    /// unconditionally wraps both sides in `LOWER(...)` for
+    /// collation-independent ASCII case folding. Issue #26.
+    IRegex,
+    /// Case-insensitive POSIX regex non-match — Django's
+    /// `~Q(name__iregex=...)`. PG `!~*`. MySQL and SQLite use
+    /// `LOWER(<col>) NOT REGEXP LOWER(<pattern>)` for the same
+    /// reason as [`Op::IRegex`]. Issue #26.
+    NotIRegex,
 }
 
 /// One predicate in a `WHERE` clause: `column <op> value`. Always

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1135,6 +1135,22 @@ fn parse_lookup(key: &str, value: SqlValue) -> Result<(String, Op, SqlValue), Qu
             }
             Ok((field, Op::Between, value))
         }
+        "regex" | "iregex" => {
+            if !matches!(value, SqlValue::String(_)) {
+                return Err(QueryError::InvalidLookupValue {
+                    field,
+                    suffix: suffix.to_owned(),
+                    expected: "SqlValue::String(<regex pattern>)",
+                    actual: sql_value_shape_name(&value),
+                });
+            }
+            let op = if suffix == "regex" {
+                Op::Regex
+            } else {
+                Op::IRegex
+            };
+            Ok((field, op, value))
+        }
         unknown => Err(QueryError::UnknownLookup {
             field,
             suffix: unknown.to_owned(),

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -295,6 +295,39 @@ pub trait Dialect {
         sql.push_str(placeholder);
     }
 
+    /// POSIX regex match — Django `__regex` / `__iregex`. Issue #26.
+    ///
+    /// Default emits the Postgres shape:
+    /// - `case_sensitive=true`,  `negated=false`: `<col> ~ <p>`
+    /// - `case_sensitive=true`,  `negated=true`:  `<col> !~ <p>`
+    /// - `case_sensitive=false`, `negated=false`: `<col> ~* <p>`
+    /// - `case_sensitive=false`, `negated=true`:  `<col> !~* <p>`
+    ///
+    /// MySQL and SQLite override to use the `REGEXP` / `NOT REGEXP`
+    /// keyword. Neither has a native case-insensitive regex operator,
+    /// so both wrap `<col>` and `<placeholder>` in `LOWER(...)` for
+    /// the case-insensitive variants. The pattern is bound as a
+    /// single string parameter — `placeholder` is the slot it goes
+    /// into; the dialect doesn't rewrite the bound value.
+    fn write_regex(
+        &self,
+        sql: &mut String,
+        qualified_col: &str,
+        placeholder: &str,
+        case_sensitive: bool,
+        negated: bool,
+    ) {
+        sql.push_str(qualified_col);
+        let op = match (case_sensitive, negated) {
+            (true, false) => " ~ ",
+            (true, true) => " !~ ",
+            (false, false) => " ~* ",
+            (false, true) => " !~* ",
+        };
+        sql.push_str(op);
+        sql.push_str(placeholder);
+    }
+
     /// Null-safe equality. Postgres: `<col> IS [NOT] DISTINCT FROM <p>`.
     /// `distinct = true` means "not equal under null-safe semantics".
     fn write_null_safe_eq(

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -222,6 +222,39 @@ impl Dialect for MySql {
         sql.push(')');
     }
 
+    /// MySQL has `REGEXP` for case-sensitive matching but no native
+    /// case-insensitive operator — column collation drives it.
+    /// To guarantee case-insensitivity independent of collation
+    /// (mirror of the ILIKE approach), lowercase both sides for the
+    /// `IRegex` / `NotIRegex` variants. Issue #26.
+    fn write_regex(
+        &self,
+        sql: &mut String,
+        qualified_col: &str,
+        placeholder: &str,
+        case_sensitive: bool,
+        negated: bool,
+    ) {
+        let kw = if negated { " NOT REGEXP " } else { " REGEXP " };
+        if case_sensitive {
+            sql.push_str(qualified_col);
+            sql.push_str(kw);
+            sql.push_str(placeholder);
+        } else {
+            // LOWER(<col>) REGEXP LOWER(<p>) — the pattern is bound
+            // as a single param, so wrapping in LOWER(...) at SQL
+            // level forces the comparison to be case-insensitive
+            // regardless of the column's collation.
+            sql.push_str("LOWER(");
+            sql.push_str(qualified_col);
+            sql.push(')');
+            sql.push_str(kw);
+            sql.push_str("LOWER(");
+            sql.push_str(placeholder);
+            sql.push(')');
+        }
+    }
+
     fn write_null_safe_eq(
         &self,
         sql: &mut String,

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -209,6 +209,37 @@ impl Dialect for Sqlite {
         }
     }
 
+    /// SQLite's `REGEXP` operator delegates to a user-defined `regexp`
+    /// function — sqlx-sqlite registers one for `:memory:` and file
+    /// URIs by default (case-sensitive). For case-insensitive
+    /// matching, we mirror the ILIKE strategy: lowercase both sides
+    /// so the comparison is collation-independent. This works for
+    /// ASCII case-folding; non-ASCII patterns may not behave as
+    /// expected without the ICU extension. Issue #26.
+    fn write_regex(
+        &self,
+        sql: &mut String,
+        qualified_col: &str,
+        placeholder: &str,
+        case_sensitive: bool,
+        negated: bool,
+    ) {
+        let kw = if negated { " NOT REGEXP " } else { " REGEXP " };
+        if case_sensitive {
+            sql.push_str(qualified_col);
+            sql.push_str(kw);
+            sql.push_str(placeholder);
+        } else {
+            sql.push_str("LOWER(");
+            sql.push_str(qualified_col);
+            sql.push(')');
+            sql.push_str(kw);
+            sql.push_str("LOWER(");
+            sql.push_str(placeholder);
+            sql.push(')');
+        }
+    }
+
     /// SQLite's `IS` / `IS NOT` are null-safe equality / inequality
     /// (both `NULL IS NULL` and `1 IS 1` evaluate to true). Same
     /// semantics as Postgres' `IS [NOT] DISTINCT FROM` — we just

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -209,13 +209,18 @@ impl Dialect for Sqlite {
         }
     }
 
-    /// SQLite's `REGEXP` operator delegates to a user-defined `regexp`
-    /// function — sqlx-sqlite registers one for `:memory:` and file
-    /// URIs by default (case-sensitive). For case-insensitive
-    /// matching, we mirror the ILIKE strategy: lowercase both sides
-    /// so the comparison is collation-independent. This works for
-    /// ASCII case-folding; non-ASCII patterns may not behave as
-    /// expected without the ICU extension. Issue #26.
+    /// SQLite's `REGEXP` operator delegates to a user-defined
+    /// `regexp(pattern, value)` function. sqlx-sqlite does **not**
+    /// register one by default — callers either enable sqlx-sqlite's
+    /// `regexp` cargo feature (which adds a `.with_regexp()` builder
+    /// on `SqliteConnectOptions`) or register their own via
+    /// `SqliteConnection::lock_handle()` + raw FFI. Without one
+    /// registered, the query fails at execution with `no such
+    /// function: REGEXP` (parser-clean, runtime-only). For case-
+    /// insensitive matching we mirror the ILIKE strategy: lowercase
+    /// both sides so the comparison is collation-independent. ASCII-
+    /// only folding; non-ASCII patterns may not behave as expected
+    /// without the ICU extension. Issue #26.
     fn write_regex(
         &self,
         sql: &mut String,

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -2217,6 +2217,24 @@ fn write_filter(
                 matches!(filter.op, Op::NotILike),
             );
         }
+        Op::Regex | Op::NotRegex | Op::IRegex | Op::NotIRegex => {
+            // Pattern shape is checked upstream — the typed builder
+            // `Column::regex(...)` only accepts `impl Into<String>`,
+            // and the Django-shape parser rejects non-strings with
+            // `QueryError::InvalidLookupValue`. Mirroring LIKE we
+            // pass the param through and let the DB surface any
+            // residual type mismatch.
+            require_op(b.d, filter.op)?;
+            b.params.push(filter.value.clone());
+            let p = b.d.placeholder(b.params.len());
+            b.d.write_regex(
+                &mut b.sql,
+                &qualified_col,
+                &p,
+                matches!(filter.op, Op::Regex | Op::NotRegex),
+                matches!(filter.op, Op::NotRegex | Op::NotIRegex),
+            );
+        }
         Op::In | Op::NotIn => {
             let SqlValue::List(elements) = &filter.value else {
                 return Err(SqlError::InRequiresList);
@@ -2393,6 +2411,10 @@ fn op_label(op: Op) -> &'static str {
         Op::JsonHasKey => "? (json)",
         Op::JsonHasAnyKey => "?| (json)",
         Op::JsonHasAllKeys => "?& (json)",
+        Op::Regex => "~ (regex)",
+        Op::NotRegex => "!~ (regex)",
+        Op::IRegex => "~* (iregex)",
+        Op::NotIRegex => "!~* (iregex)",
     }
 }
 

--- a/crates/rustango/tests/regex_emission.rs
+++ b/crates/rustango/tests/regex_emission.rs
@@ -1,0 +1,243 @@
+//! Tri-dialect emission tests for `__regex` / `__iregex` lookups
+//! (issue #26). Django parity for `Q(name__regex='^foo.*')` /
+//! `Q(name__iregex=...)` plus the negated forms. PG uses native
+//! `~` / `~*` / `!~` / `!~*` POSIX operators; MySQL uses `REGEXP`
+//! (with LOWER fallback for case-insensitive); SQLite uses
+//! `REGEXP` (delegating to the loaded `regexp` user-function),
+//! same LOWER fallback for case-insensitive.
+
+use rustango::core::Column as _;
+#[cfg(feature = "mysql")]
+use rustango::sql::MySql;
+#[cfg(feature = "sqlite")]
+use rustango::sql::Sqlite;
+use rustango::sql::{Dialect, Postgres};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "rx_user")]
+#[allow(dead_code)]
+pub struct User {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 64)]
+    name: String,
+}
+
+// ---------- PG: native POSIX operators ----------
+
+#[test]
+fn regex_emits_tilde_on_pg() {
+    let q = User::objects()
+        .where_(User::name.regex("^al.*"))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""name" ~ $1"#),
+        "PG regex: {}",
+        stmt.sql
+    );
+    assert!(!stmt.sql.contains("~*"), "case-sensitive: {}", stmt.sql);
+}
+
+#[test]
+fn not_regex_emits_bang_tilde_on_pg() {
+    let q = User::objects()
+        .where_(User::name.not_regex("^bad"))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(stmt.sql.contains(r#""name" !~ $1"#), "PG !~: {}", stmt.sql);
+}
+
+#[test]
+fn iregex_emits_tilde_star_on_pg() {
+    let q = User::objects()
+        .where_(User::name.iregex("^[A-Z][a-z]+"))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""name" ~* $1"#),
+        "PG iregex: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn not_iregex_emits_bang_tilde_star_on_pg() {
+    let q = User::objects()
+        .where_(User::name.not_iregex("admin"))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""name" !~* $1"#),
+        "PG !~*: {}",
+        stmt.sql
+    );
+}
+
+// ---------- MySQL: REGEXP keyword + LOWER fallback ----------
+
+#[cfg(feature = "mysql")]
+#[test]
+fn regex_emits_regexp_keyword_on_mysql() {
+    let q = User::objects()
+        .where_(User::name.regex("^al.*"))
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains("`name` REGEXP ?"),
+        "MySQL REGEXP: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains("LOWER"),
+        "case-sensitive on MySQL — no LOWER wrap: {}",
+        stmt.sql
+    );
+}
+
+#[cfg(feature = "mysql")]
+#[test]
+fn not_regex_emits_not_regexp_keyword_on_mysql() {
+    let q = User::objects()
+        .where_(User::name.not_regex("^x"))
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains("`name` NOT REGEXP ?"),
+        "MySQL NOT REGEXP: {}",
+        stmt.sql
+    );
+}
+
+#[cfg(feature = "mysql")]
+#[test]
+fn iregex_wraps_lower_on_mysql() {
+    let q = User::objects()
+        .where_(User::name.iregex("admin"))
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains("LOWER(`name`) REGEXP LOWER(?)"),
+        "MySQL iregex LOWER fallback: {}",
+        stmt.sql
+    );
+}
+
+#[cfg(feature = "mysql")]
+#[test]
+fn not_iregex_wraps_lower_on_mysql() {
+    let q = User::objects()
+        .where_(User::name.not_iregex("admin"))
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains("LOWER(`name`) NOT REGEXP LOWER(?)"),
+        "MySQL NOT iregex LOWER fallback: {}",
+        stmt.sql
+    );
+}
+
+// ---------- SQLite: REGEXP user-function + LOWER fallback ----------
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn regex_emits_regexp_keyword_on_sqlite() {
+    let q = User::objects()
+        .where_(User::name.regex("^al.*"))
+        .compile()
+        .unwrap();
+    let stmt = Sqlite.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""name" REGEXP ?"#),
+        "SQLite REGEXP: {}",
+        stmt.sql
+    );
+}
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn iregex_wraps_lower_on_sqlite() {
+    let q = User::objects()
+        .where_(User::name.iregex("admin"))
+        .compile()
+        .unwrap();
+    let stmt = Sqlite.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"LOWER("name") REGEXP LOWER(?)"#),
+        "SQLite iregex LOWER fallback: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Django-shape lookup-suffix parser ----------
+
+#[test]
+fn regex_lookup_via_filter_string_parser() {
+    // `.filter("name__regex", pattern)` — Django's string-keyed form
+    // (issue #71 parser). Should route to Op::Regex.
+    let q = User::objects()
+        .filter("name__regex", "^foo.*")
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""name" ~ $1"#),
+        "filter(\"name__regex\", pattern) routes to Op::Regex: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn iregex_lookup_via_filter_string_parser() {
+    let q = User::objects()
+        .filter("name__iregex", "ADMIN")
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""name" ~* $1"#),
+        "filter(\"name__iregex\", pattern) routes to Op::IRegex: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn regex_with_non_string_value_rejects_at_compile() {
+    use rustango::core::SqlValue;
+    let r = User::objects()
+        .filter("name__regex", SqlValue::I64(42))
+        .compile();
+    assert!(
+        matches!(
+            r,
+            Err(rustango::core::QueryError::InvalidLookupValue { ref suffix, .. })
+                if suffix == "regex"
+        ),
+        "non-string value to __regex surfaces InvalidLookupValue: {r:?}",
+    );
+}
+
+// ---------- Param binding sanity ----------
+
+#[test]
+fn regex_binds_pattern_as_single_string_param() {
+    let q = User::objects()
+        .where_(User::name.regex("^test$"))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert_eq!(stmt.params.len(), 1, "one param");
+    match &stmt.params[0] {
+        rustango::core::SqlValue::String(s) => assert_eq!(s, "^test$"),
+        other => panic!("expected SqlValue::String, got {other:?}"),
+    }
+}

--- a/crates/rustango/tests/regex_live.rs
+++ b/crates/rustango/tests/regex_live.rs
@@ -1,0 +1,173 @@
+#![cfg(feature = "postgres")]
+//! Live PG tests for `__regex` / `__iregex` lookups (issue #26).
+//! Verifies the typed `.regex()` / `.iregex()` / negated variants on
+//! `Column` plus the Django-shape `.filter("name__regex", pattern)`
+//! parser route at runtime against PG's native POSIX operators
+//! (`~`, `~*`, `!~`, `!~*`). Skips silently when `DATABASE_URL` is unset.
+
+use std::sync::OnceLock;
+
+use rustango::core::Column as _;
+use rustango::sql::{sqlx, Auto, FetcherPool, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rx_user_live")]
+#[allow(dead_code)]
+pub struct User {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 64)]
+    pub name: String,
+}
+
+fn lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn fresh_pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pg = sqlx::PgPool::connect(&url).await.ok()?;
+    sqlx::query(r#"DROP TABLE IF EXISTS "rx_user_live" CASCADE"#)
+        .execute(&pg)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"
+        CREATE TABLE "rx_user_live" (
+            id BIGSERIAL PRIMARY KEY,
+            name VARCHAR(64) NOT NULL
+        )
+        "#,
+    )
+    .execute(&pg)
+    .await
+    .unwrap();
+    let pool = Pool::Postgres(pg);
+    for name in ["alice", "Alice-2", "bob", "Bob-3", "admin", "ADMIN-root"] {
+        let mut u = User {
+            id: Auto::default(),
+            name: name.into(),
+        };
+        u.insert_pool(&pool).await.unwrap();
+    }
+    Some(pool)
+}
+
+fn names(rows: &[User]) -> Vec<String> {
+    let mut v: Vec<String> = rows.iter().map(|u| u.name.clone()).collect();
+    v.sort();
+    v
+}
+
+/// Case-sensitive `__regex` — PG emits `name ~ $1`. Pattern `^al.*`
+/// matches `alice` but not `Alice-2` (capital A).
+#[tokio::test]
+async fn regex_case_sensitive_matches_lowercase_only() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let rows: Vec<User> = User::objects()
+        .where_(User::name.regex("^al.*"))
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(names(&rows), vec!["alice".to_string()]);
+}
+
+/// Case-insensitive `__iregex` — PG emits `name ~* $1`. Same pattern
+/// now picks up `alice` AND `Alice-2`.
+#[tokio::test]
+async fn iregex_case_insensitive_matches_both_cases() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let rows: Vec<User> = User::objects()
+        .where_(User::name.iregex("^al.*"))
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        names(&rows),
+        vec!["Alice-2".to_string(), "alice".to_string()]
+    );
+}
+
+/// Negated `__regex` — PG `!~`. `^admin` excludes only lowercase
+/// "admin" (5 rows survive: alice, Alice-2, bob, Bob-3, ADMIN-root).
+#[tokio::test]
+async fn not_regex_excludes_case_sensitive_matches() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let rows: Vec<User> = User::objects()
+        .where_(User::name.not_regex("^admin"))
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        names(&rows),
+        vec![
+            "ADMIN-root".to_string(),
+            "Alice-2".to_string(),
+            "Bob-3".to_string(),
+            "alice".to_string(),
+            "bob".to_string(),
+        ]
+    );
+}
+
+/// Negated `__iregex` — PG `!~*`. `^admin` now excludes BOTH
+/// "admin" and "ADMIN-root" (4 rows survive).
+#[tokio::test]
+async fn not_iregex_excludes_both_cases() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let rows: Vec<User> = User::objects()
+        .where_(User::name.not_iregex("^admin"))
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        names(&rows),
+        vec![
+            "Alice-2".to_string(),
+            "Bob-3".to_string(),
+            "alice".to_string(),
+            "bob".to_string(),
+        ]
+    );
+}
+
+/// Django-shape `.filter("name__iregex", "...")` — string-keyed
+/// parser routes to Op::IRegex and runs against PG `~*` at runtime.
+#[tokio::test]
+async fn filter_string_iregex_routes_at_runtime() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let rows: Vec<User> = User::objects()
+        .filter("name__iregex", "^bob")
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(names(&rows), vec!["Bob-3".to_string(), "bob".to_string()]);
+}

--- a/crates/rustango/tests/regex_sqlite_live.rs
+++ b/crates/rustango/tests/regex_sqlite_live.rs
@@ -1,0 +1,108 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite coverage for `__regex` / `__iregex` (issue #26).
+//!
+//! SQLite's `REGEXP` keyword delegates to a `regexp(pattern, value)`
+//! user-function. sqlx-sqlite 0.8 does *not* register one by default
+//! (that's behind the `regexp` cargo feature which rustango doesn't
+//! enable). We verify two things:
+//!
+//! 1. **Emission is well-formed** — when `regexp` isn't registered,
+//!    SQLite surfaces `no such function: REGEXP` (or `regexp`) at
+//!    execution. That's a runtime error from SQLite itself, not a
+//!    syntax error from the parser — proving the dialect emits SQL
+//!    SQLite accepts up to the function-resolution step.
+//!
+//! 2. **`__iregex` LOWER-fallback is parser-clean for both sides** —
+//!    same shape, SQLite parses `LOWER("col") REGEXP LOWER(?)` and
+//!    fails at the same resolution step rather than e.g. mis-quoting
+//!    the LOWER call.
+
+use rustango::core::{Column as _, Model as _};
+use rustango::sql::{Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rx_sqlite_user")]
+#[allow(dead_code)]
+pub struct User {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 64)]
+    pub name: String,
+}
+
+async fn seeded_pool() -> Pool {
+    let pool = Pool::connect("sqlite::memory:").await.expect("sqlite");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        "CREATE TABLE rx_sqlite_user (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)",
+        vec![],
+    )
+    .await
+    .unwrap();
+    for name in ["alice", "Bob", "ADMIN"] {
+        rustango::sql::raw_execute_pool(
+            &pool,
+            "INSERT INTO rx_sqlite_user(name) VALUES (?)",
+            vec![rustango::core::SqlValue::String(name.to_owned())],
+        )
+        .await
+        .unwrap();
+    }
+    let _ = User::SCHEMA; // silence unused-import warning paths
+    pool
+}
+
+/// `.regex(...)` emits `"name" REGEXP ?` against SQLite. Without a
+/// `regexp` user-function registered, SQLite returns
+/// `no such function: REGEXP` at execution — proving the SQL is
+/// syntactically well-formed and the failure is purely the missing
+/// extension.
+#[tokio::test]
+async fn regex_emission_parses_clean_runtime_error_on_missing_extension() {
+    use rustango::sql::FetcherPool;
+    let pool = seeded_pool().await;
+
+    let err = User::objects()
+        .where_(User::name.regex("^al.*"))
+        .fetch_pool(&pool)
+        .await
+        .expect_err("should error — regexp not registered");
+
+    let msg = format!("{err}").to_lowercase();
+    assert!(
+        msg.contains("regexp") || msg.contains("function"),
+        "expected missing-regexp error, got: {err}"
+    );
+    // Confirm it's NOT a parse error — the error mentions regexp/function,
+    // not `near "REGEXP"` or `syntax error`.
+    assert!(
+        !msg.contains("syntax error") && !msg.contains("near \"regexp\""),
+        "should be runtime not syntax error: {err}"
+    );
+}
+
+/// Same check for `__iregex` — the LOWER-wrap shape parses cleanly
+/// (LOWER is built into SQLite, so the only resolution that can fail
+/// is the missing `regexp`).
+#[tokio::test]
+async fn iregex_lower_wrap_parses_clean_runtime_error() {
+    use rustango::sql::FetcherPool;
+    let pool = seeded_pool().await;
+
+    let err = User::objects()
+        .where_(User::name.iregex("^al.*"))
+        .fetch_pool(&pool)
+        .await
+        .expect_err("should error — regexp not registered");
+
+    let msg = format!("{err}").to_lowercase();
+    assert!(
+        msg.contains("regexp") || msg.contains("function"),
+        "expected missing-regexp error, got: {err}"
+    );
+    assert!(
+        !msg.contains("syntax error"),
+        "should be runtime not syntax error: {err}"
+    );
+}

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -398,11 +398,22 @@ User::objects()
 | MySQL | `` `col` REGEXP ? `` / `` `col` NOT REGEXP ? `` | `LOWER(`col`) REGEXP LOWER(?)` (negated wraps `NOT`) | LOWER() fallback for `i*` |
 | SQLite | `"col" REGEXP ?` / `"col" NOT REGEXP ?` | `LOWER("col") REGEXP LOWER(?)` (negated wraps `NOT`) | Needs the `regexp` user-function loaded on the connection |
 
-**SQLite requires a registered `regexp` user-function** — it's not built in. sqlx's `sqlite` driver picks up one if the connection has it; for projects targeting SQLite, register a `regexp(pattern, value)` scalar function on the connection (e.g. via `sqlx::sqlite::SqliteConnectOptions::extension(...)` or a `connect_with` hook). Without it, the query emits valid `REGEXP` SQL that SQLite rejects at execution time with `no such function: regexp`.
+**SQLite requires a registered `regexp` user-function** — it's not built in. sqlx-sqlite 0.8 does **not** register one by default. Two paths to enable it:
+
+1. **Easy** — enable sqlx-sqlite's `regexp` cargo feature, then opt the connection in:
+   ```rust
+   use sqlx::sqlite::SqliteConnectOptions;
+   let opts = SqliteConnectOptions::new()
+       .filename("app.db")
+       .with_regexp();  // gated on sqlx-sqlite/regexp
+   ```
+2. **Manual** — register a Rust closure via `SqliteConnection::lock_handle()` + raw FFI (`sqlite3_create_function_v2`).
+
+Without one, the query emits valid `REGEXP` SQL that SQLite rejects at execution with `no such function: regexp` (parser-clean — `tests/regex_sqlite_live.rs` pins this).
 
 **Pattern dialect differs across backends.** Postgres uses POSIX extended regex; MySQL uses ICU-based regex with its own flavor; SQLite delegates to whatever the user-function implements (typically Rust's `regex` crate). Patterns that lean on dialect-specific syntax (e.g. PG's `\m` / `\M` word boundaries) don't round-trip — stick to the portable subset (`^`, `$`, `.`, `*`, `+`, `?`, `[...]`, `()`, `|`) if the same model is queried from multiple backends.
 
-**Non-string values are rejected at `.compile()`** — passing `SqlValue::I64(42)` to `__regex` surfaces `QueryError::InvalidLookupValue { suffix: "regex", expected: "string", … }` rather than silently casting.
+**Non-string values are rejected at `.compile()`** — passing `SqlValue::I64(42)` to `__regex` surfaces `QueryError::InvalidLookupValue { suffix: "regex", expected: "SqlValue::String(<regex pattern>)", … }` rather than silently casting.
 
 ---
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -362,6 +362,48 @@ A future `iterator_on(&mut *tx, chunk_size)` companion (issue follow-up) would c
 
 **`chunk_size` must be > 0.** Zero or negative values panic. Pick a value that fits your row-size budget (Django's default is `2000`; reasonable for narrow rows, lower for wide TEXT/JSONB columns).
 
+### Regex lookups — `.regex()` / `.iregex()` and negated variants
+
+Django's [`__regex` / `__iregex`](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#regex) — issue #26. Match a column against a regular-expression pattern, with case-sensitive and case-insensitive flavors plus negated forms.
+
+```rust
+use rustango::core::Column as _;
+
+// Names starting with "al" (case-sensitive).
+User::objects()
+    .where_(User::name.regex("^al.*"))
+    .fetch(&pool).await?;
+
+// Names starting with "al" — case-insensitive.
+User::objects()
+    .where_(User::name.iregex("^al.*"))
+    .fetch(&pool).await?;
+
+// Negated: exclude names starting with "admin" (case-sensitive).
+User::objects()
+    .where_(User::name.not_regex("^admin"))
+    .fetch(&pool).await?;
+
+// Django-shape lookup-suffix form.
+User::objects()
+    .filter("name__iregex", "^bob")
+    .fetch(&pool).await?;
+```
+
+**Tri-dialect emission**:
+
+| Dialect | Case-sensitive | Case-insensitive | Notes |
+|---|---|---|---|
+| PostgreSQL | `<col> ~ ?` / `<col> !~ ?` | `<col> ~* ?` / `<col> !~* ?` | Native POSIX operators |
+| MySQL | `` `col` REGEXP ? `` / `` `col` NOT REGEXP ? `` | `LOWER(`col`) REGEXP LOWER(?)` (negated wraps `NOT`) | LOWER() fallback for `i*` |
+| SQLite | `"col" REGEXP ?` / `"col" NOT REGEXP ?` | `LOWER("col") REGEXP LOWER(?)` (negated wraps `NOT`) | Needs the `regexp` user-function loaded on the connection |
+
+**SQLite requires a registered `regexp` user-function** — it's not built in. sqlx's `sqlite` driver picks up one if the connection has it; for projects targeting SQLite, register a `regexp(pattern, value)` scalar function on the connection (e.g. via `sqlx::sqlite::SqliteConnectOptions::extension(...)` or a `connect_with` hook). Without it, the query emits valid `REGEXP` SQL that SQLite rejects at execution time with `no such function: regexp`.
+
+**Pattern dialect differs across backends.** Postgres uses POSIX extended regex; MySQL uses ICU-based regex with its own flavor; SQLite delegates to whatever the user-function implements (typically Rust's `regex` crate). Patterns that lean on dialect-specific syntax (e.g. PG's `\m` / `\M` word boundaries) don't round-trip — stick to the portable subset (`^`, `$`, `.`, `*`, `+`, `?`, `[...]`, `()`, `|`) if the same model is queried from multiple backends.
+
+**Non-string values are rejected at `.compile()`** — passing `SqlValue::I64(42)` to `__regex` surfaces `QueryError::InvalidLookupValue { suffix: "regex", expected: "string", … }` rather than silently casting.
+
 ---
 
 ## F() expressions + database functions
@@ -1483,6 +1525,7 @@ Post::objects().where_(Post::author_id.eq(42));
 | `__in` | `IN (…)` | `SqlValue::List` | rejects non-list values |
 | `__isnull` | `IS NULL` / `IS NOT NULL` | `bool` | `true` → IS NULL, `false` → IS NOT NULL |
 | `__between` / `__range` | `BETWEEN … AND …` | 2-elt `SqlValue::List` | inclusive on both ends |
+| `__regex` / `__iregex` | PG `~` / `~*`, MySQL/SQLite `REGEXP` | string | case-insensitive emulated on MySQL/SQLite via `LOWER()` wrap; SQLite needs a `regexp` user-function |
 
 **Errors surface at `.compile()`, not at `.filter()` call time** — value-shape mismatches (e.g. `__in` with a scalar, `__isnull` with a non-bool, `__between` with the wrong arity) and unknown suffixes (`status__nope`) return `QueryError::UnknownLookup` / `QueryError::InvalidLookupValue` from `.compile()` so the fluent chain stays type-clean. Chained traversals (`author__name__icontains`) are **not** supported in v0.39 — the splitter takes the suffix after the first `__`, so the whole tail `name__icontains` is treated as an unknown suffix.
 


### PR DESCRIPTION
## Summary

- Four new IR ops (`Op::Regex` / `NotRegex` / `IRegex` / `NotIRegex`) + `Dialect::write_regex` trait method + typed `Column::regex()` / `iregex()` / `not_regex()` / `not_iregex()` builders + Django-shape `__regex` / `__iregex` lookup-suffix parser route.
- Tri-dialect: PG native `~` / `!~` / `~*` / `!~*`; MySQL `REGEXP` / `NOT REGEXP` keyword with `LOWER()` wrap fallback for case-insensitive; SQLite same `REGEXP` keyword shape (delegates to a `regexp(pattern, value)` user-function — sqlx-sqlite 0.8 does NOT auto-register it, the caller must).
- New "Regex lookups" section in `docs/orm.md` with the tri-dialect emission table, SQLite user-function caveat, and pattern-dialect portability note. `__regex` / `__iregex` added to the supported-suffixes table.

## Test plan

- [x] 14 tri-dialect emission tests (`tests/regex_emission.rs`) — every case × negation × dialect combo + parser route + `InvalidLookupValue` error path.
- [x] 5 live PG tests (`tests/regex_live.rs`) — runtime semantics for `~` / `~*` / `!~` / `!~*` against mixed-case data; covers each typed builder + the string-keyed parser.
- [x] 2 live SQLite tests (`tests/regex_sqlite_live.rs`) — prove emission is parser-clean (runtime "no such function" error, not syntax error) without the `regexp` user-function registered.
- [x] `cargo build --no-default-features --features sqlite,tenancy` — sqlite-tenancy litmus passes.
- [x] `cargo test --workspace --all-features --no-run` — all-features build clean.
- [x] `cargo test -p rustango --lib --features tenancy,mysql,sqlite` — 1553 lib tests pass.

Closes #26.