### PR TITLE
feat: .values_dict / .values_list / .values_list_flat — pure projection (closes #22)

### DIFF
--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -254,6 +254,7 @@ pub(crate) async fn table_view(
             offset: Some(offset),
             lock_mode: None,
             compound: vec![],
+            projection: None,
         },
         &scalar_fields,
     )
@@ -868,6 +869,7 @@ pub(crate) async fn detail_view(
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         },
         &detail_fields,
     )
@@ -1142,6 +1144,7 @@ pub(crate) async fn edit_form(
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         },
         &edit_fields,
     )
@@ -1229,6 +1232,7 @@ pub(crate) async fn update_submit(
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         },
         &before_fields,
     )
@@ -1298,6 +1302,7 @@ pub(crate) async fn delete_submit(
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         },
         &delete_fields,
     )
@@ -1465,6 +1470,7 @@ pub(crate) async fn action_submit(
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         },
         &action_fields,
     )

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -353,6 +353,7 @@ pub async fn fetch_row_as_json(
         offset: None,
         lock_mode: None,
         compound: vec![],
+        projection: None,
     };
     let fields: Vec<&'static crate::core::FieldSchema> = entry.schema.scalar_fields().collect();
     crate::sql::select_one_row_as_json(pool, &select_q, &fields).await
@@ -408,6 +409,7 @@ where
             offset: Some(offset),
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let rows = crate::sql::select_rows_as_json(pool, &select_q, &fields).await?;
         if rows.is_empty() {

--- a/crates/rustango/src/core/error.rs
+++ b/crates/rustango/src/core/error.rs
@@ -109,9 +109,20 @@ pub enum QueryError {
     #[error(
         "AggregateBuilder::values({cols:?}) requires at least one \
          aggregating annotation (Count / Sum / Avg / Max / Min / \
-         StdDev / Variance). Pure projection without GROUP BY is not \
-         supported yet; chain `.annotate(\"alias\", aggregate)` or \
-         use `QuerySet::fetch` instead."
+         StdDev / Variance). For pure projection (no GROUP BY) use \
+         `QuerySet::values_dict` / `values_list` / `values_list_flat` \
+         instead (issue #22)."
     )]
     ValuesRequiresAggregate { cols: Vec<&'static str> },
+
+    /// `.values_dict(&[])` / `.values_list(&[])` was called with an
+    /// empty column list. Issue #22. A projection with zero columns
+    /// would emit `SELECT FROM …` which every dialect rejects as a
+    /// syntax error; we surface the problem at builder time with a
+    /// clear message instead.
+    #[error(
+        "`.values_dict(...)` / `.values_list(...)` requires at least \
+         one column. Pass the column names you want in the projection."
+    )]
+    EmptyValuesProjection,
 }

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -464,6 +464,13 @@ pub struct SelectQuery {
     /// parens. The compound's outer `order_by` / `limit` / `offset` /
     /// `lock_mode` apply to the merged result.
     pub compound: Vec<CompoundBranch>,
+    /// Column-list override for pure projection — Django's `.values()`
+    /// / `.values_list()` shape (issue #22). `None` (default) emits
+    /// every scalar field on the model; `Some(cols)` emits exactly
+    /// `cols` in the order given. Joins still contribute their
+    /// `project` columns. Validated at builder time so every column
+    /// resolves on the model schema.
+    pub projection: Option<Vec<&'static str>>,
 }
 
 /// One branch of a set-algebra compound query. Issue #25.
@@ -573,6 +580,7 @@ impl PartialEq for SelectQuery {
             && self.offset == other.offset
             && self.lock_mode == other.lock_mode
             && self.compound == other.compound
+            && self.projection == other.projection
     }
 }
 

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -745,7 +745,60 @@ impl<T: Model> QuerySet<T> {
             offset: self.offset,
             lock_mode: self.lock_mode,
             compound: self.compound,
+            projection: None,
         })
+    }
+
+    /// Project to `Vec<HashMap<String, SqlValue>>` — Django's
+    /// `.values('id', 'name')`. Issue #22. Returns a
+    /// [`ValuesQuerySet`] whose terminal `.fetch_pool(&pool)` decodes
+    /// rows into a `HashMap` keyed by column name.
+    ///
+    /// Skips the typed `Model` decode — useful when you only need a
+    /// few fields off a wide table, or when the result feeds
+    /// downstream code that wants dynamic column access (templates,
+    /// JSON serialization, CSV export). The existing
+    /// [`QuerySet::values`] method (which promotes to
+    /// [`AggregateBuilder`] for GROUP BY) is unchanged; this is a
+    /// separate, pure-projection entry point.
+    ///
+    /// Columns are validated against the model schema at `.compile()`
+    /// time — typo'd column names surface
+    /// [`QueryError::UnknownField`]. Empty `cols` surfaces
+    /// [`QueryError::EmptyValuesProjection`].
+    #[must_use]
+    pub fn values_dict(self, cols: &[&'static str]) -> ValuesQuerySet<T> {
+        ValuesQuerySet {
+            qs: self,
+            cols: cols.to_vec(),
+        }
+    }
+
+    /// Project to `Vec<Vec<SqlValue>>` — Django's
+    /// `.values_list('id', 'name')`. Issue #22. Same projection as
+    /// [`Self::values_dict`] but each row comes back as an
+    /// ordered `Vec<SqlValue>` (cell ordering matches the `cols`
+    /// argument), not a `HashMap`.
+    #[must_use]
+    pub fn values_list(self, cols: &[&'static str]) -> ValuesListQuerySet<T> {
+        ValuesListQuerySet {
+            qs: self,
+            cols: cols.to_vec(),
+        }
+    }
+
+    /// Single-column flat projection — Django's
+    /// `.values_list('id', flat=True)`. Issue #22. Returns
+    /// [`ValuesFlatQuerySet`] whose terminal `.fetch_pool::<U>(&pool)`
+    /// decodes the single column into `Vec<U>` directly via sqlx's
+    /// typed `query_scalar` path.
+    ///
+    /// `U` must be decodable from the column's SQL type on every
+    /// dialect the binary targets. Common picks: `i64` / `i32` /
+    /// `String` / `bool` / `f64`.
+    #[must_use]
+    pub fn values_list_flat(self, col: &'static str) -> ValuesFlatQuerySet<T> {
+        ValuesFlatQuerySet { qs: self, col }
     }
 
     /// Lower this queryset to a `DeleteQuery` — same WHERE clause, no projection.
@@ -1727,4 +1780,109 @@ fn validate_aggregate_expr_columns(
         // Schema typos surface at execution. Pre-existing gap.
         _ => Ok(()),
     }
+}
+
+// ====================================================================
+// Pure projection — Django `.values()` / `.values_list()` (issue #22)
+// ====================================================================
+
+/// Pure-projection queryset returned by [`QuerySet::values_dict`].
+/// Compiles to a `SELECT <cols> FROM …` with the WHERE / ORDER BY /
+/// LIMIT / OFFSET / set-algebra branches of the underlying queryset
+/// preserved. Terminal `fetch_pool` lives in
+/// [`crate::sql::fetch_values_dict_pool`].
+pub struct ValuesQuerySet<T: Model> {
+    pub(crate) qs: QuerySet<T>,
+    pub(crate) cols: Vec<&'static str>,
+}
+
+/// Pure-projection queryset returned by [`QuerySet::values_list`].
+/// Same shape as [`ValuesQuerySet`] but the terminal fetch yields
+/// `Vec<Vec<SqlValue>>` (cells ordered to match `cols`) instead of a
+/// `HashMap`.
+pub struct ValuesListQuerySet<T: Model> {
+    pub(crate) qs: QuerySet<T>,
+    pub(crate) cols: Vec<&'static str>,
+}
+
+/// Single-column flat-projection queryset returned by
+/// [`QuerySet::values_list_flat`]. Terminal fetch decodes the column
+/// directly into `Vec<U>` via sqlx's typed scalar path.
+pub struct ValuesFlatQuerySet<T: Model> {
+    pub(crate) qs: QuerySet<T>,
+    pub(crate) col: &'static str,
+}
+
+impl<T: Model> ValuesQuerySet<T> {
+    /// Compile to a [`SelectQuery`] with `projection` set to the
+    /// validated column list.
+    ///
+    /// # Errors
+    /// - [`QueryError::EmptyValuesProjection`] if `cols` is empty.
+    /// - [`QueryError::UnknownField`] if any column doesn't exist on
+    ///   the model.
+    /// - Anything [`QuerySet::compile`] surfaces.
+    pub fn compile(self) -> Result<SelectQuery, QueryError> {
+        compile_values_select(self.qs, self.cols)
+    }
+
+    /// The validated column list — exposed so the terminal fetch in
+    /// [`crate::sql`] can pass it to the row decoder.
+    #[must_use]
+    pub fn columns(&self) -> &[&'static str] {
+        &self.cols
+    }
+}
+
+impl<T: Model> ValuesListQuerySet<T> {
+    /// See [`ValuesQuerySet::compile`].
+    ///
+    /// # Errors
+    /// As [`ValuesQuerySet::compile`].
+    pub fn compile(self) -> Result<SelectQuery, QueryError> {
+        compile_values_select(self.qs, self.cols)
+    }
+
+    /// The validated column list — exposed for the terminal fetch.
+    #[must_use]
+    pub fn columns(&self) -> &[&'static str] {
+        &self.cols
+    }
+}
+
+impl<T: Model> ValuesFlatQuerySet<T> {
+    /// Compile to a [`SelectQuery`] with `projection` set to the
+    /// single column.
+    ///
+    /// # Errors
+    /// - [`QueryError::UnknownField`] if `col` doesn't exist on the
+    ///   model.
+    /// - Anything [`QuerySet::compile`] surfaces.
+    pub fn compile(self) -> Result<SelectQuery, QueryError> {
+        compile_values_select(self.qs, vec![self.col])
+    }
+}
+
+/// Shared compile path for the three values builders. Validates the
+/// column list, then delegates to `QuerySet::compile` and stamps the
+/// projection onto the resulting [`SelectQuery`].
+fn compile_values_select<T: Model>(
+    qs: QuerySet<T>,
+    cols: Vec<&'static str>,
+) -> Result<SelectQuery, QueryError> {
+    if cols.is_empty() {
+        return Err(QueryError::EmptyValuesProjection);
+    }
+    let model: &'static ModelSchema = T::SCHEMA;
+    for col in &cols {
+        if model.field_by_column(col).is_none() {
+            return Err(QueryError::UnknownField {
+                model: model.name,
+                field: (*col).to_owned(),
+            });
+        }
+    }
+    let mut q = qs.compile()?;
+    q.projection = Some(cols);
+    Ok(q)
 }

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -2828,6 +2828,379 @@ where
     }
 }
 
+// ====================================================================
+// Pure projection — Django `.values()` / `.values_list()` (issue #22)
+// ====================================================================
+
+/// Decode one per-dialect raw `SqlValue` from the i-th column of a row.
+/// Same probe order as the aggregate-row decoder so the two paths agree
+/// on how mixed types come back: scalars first, then jsonb / arrays
+/// (PG only). NULLs (or unrecognized types) fall through to
+/// [`SqlValue::Null`].
+#[cfg(feature = "postgres")]
+fn pg_cell_to_sqlvalue(row: &PgRow, i: usize) -> SqlValue {
+    use sqlx::Row as _;
+    if let Ok(v) = row.try_get::<i64, _>(i) {
+        SqlValue::I64(v)
+    } else if let Ok(v) = row.try_get::<i32, _>(i) {
+        SqlValue::I32(v)
+    } else if let Ok(v) = row.try_get::<f64, _>(i) {
+        SqlValue::F64(v)
+    } else if let Ok(v) = row.try_get::<bool, _>(i) {
+        SqlValue::Bool(v)
+    } else if let Ok(v) = row.try_get::<String, _>(i) {
+        SqlValue::String(v)
+    } else if let Ok(v) = row.try_get::<serde_json::Value, _>(i) {
+        SqlValue::Json(v)
+    } else {
+        SqlValue::Null
+    }
+}
+
+#[cfg(feature = "mysql")]
+fn my_cell_to_sqlvalue(row: &sqlx::mysql::MySqlRow, i: usize) -> SqlValue {
+    use sqlx::Row as _;
+    if let Ok(v) = row.try_get::<i64, _>(i) {
+        SqlValue::I64(v)
+    } else if let Ok(v) = row.try_get::<i32, _>(i) {
+        SqlValue::I32(v)
+    } else if let Ok(v) = row.try_get::<f64, _>(i) {
+        SqlValue::F64(v)
+    } else if let Ok(v) = row.try_get::<bool, _>(i) {
+        SqlValue::Bool(v)
+    } else if let Ok(v) = row.try_get::<String, _>(i) {
+        SqlValue::String(v)
+    } else {
+        SqlValue::Null
+    }
+}
+
+#[cfg(feature = "sqlite")]
+fn sqlite_cell_to_sqlvalue(row: &sqlx::sqlite::SqliteRow, i: usize) -> SqlValue {
+    use sqlx::Row as _;
+    if let Ok(v) = row.try_get::<i64, _>(i) {
+        SqlValue::I64(v)
+    } else if let Ok(v) = row.try_get::<i32, _>(i) {
+        SqlValue::I32(v)
+    } else if let Ok(v) = row.try_get::<f64, _>(i) {
+        SqlValue::F64(v)
+    } else if let Ok(v) = row.try_get::<bool, _>(i) {
+        SqlValue::Bool(v)
+    } else if let Ok(v) = row.try_get::<String, _>(i) {
+        SqlValue::String(v)
+    } else {
+        SqlValue::Null
+    }
+}
+
+/// Execute a [`SelectQuery`] (with `projection` set) and return each
+/// row as a `HashMap<String, SqlValue>` keyed by column name.
+/// Backs [`crate::query::ValuesQuerySet::fetch`]. Issue #22.
+///
+/// # Errors
+/// SQL compilation or driver failure.
+pub async fn fetch_values_dict(
+    pool: &Pool,
+    query: &SelectQuery,
+) -> Result<Vec<std::collections::HashMap<String, SqlValue>>, ExecError> {
+    let stmt = pool.dialect().compile_select(query)?;
+    match pool {
+        #[cfg(feature = "postgres")]
+        Pool::Postgres(pg) => {
+            let mut q: Query<'_, sqlx::Postgres, PgArguments> = sqlx::query(&stmt.sql);
+            for v in stmt.params {
+                q = bind_query(q, v);
+            }
+            let rows = q.fetch_all(pg).await?;
+            let mut out = Vec::with_capacity(rows.len());
+            for row in &rows {
+                use sqlx::Column as _;
+                use sqlx::Row as _;
+                let mut map = std::collections::HashMap::new();
+                for (i, col) in row.columns().iter().enumerate() {
+                    map.insert(col.name().to_owned(), pg_cell_to_sqlvalue(row, i));
+                }
+                out.push(map);
+            }
+            Ok(out)
+        }
+        #[cfg(feature = "mysql")]
+        Pool::Mysql(my) => {
+            let mut q: sqlx::query::Query<'_, sqlx::MySql, sqlx::mysql::MySqlArguments> =
+                sqlx::query(&stmt.sql);
+            for v in stmt.params {
+                q = bind_query_my(q, v);
+            }
+            let rows = q.fetch_all(my).await?;
+            let mut out = Vec::with_capacity(rows.len());
+            for row in &rows {
+                use sqlx::Column as _;
+                use sqlx::Row as _;
+                let mut map = std::collections::HashMap::new();
+                for (i, col) in row.columns().iter().enumerate() {
+                    map.insert(col.name().to_owned(), my_cell_to_sqlvalue(row, i));
+                }
+                out.push(map);
+            }
+            Ok(out)
+        }
+        #[cfg(feature = "sqlite")]
+        Pool::Sqlite(sq) => {
+            let mut q: sqlx::query::Query<'_, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'_>> =
+                sqlx::query(&stmt.sql);
+            for v in stmt.params {
+                q = bind_query_sqlite(q, v);
+            }
+            let rows = q.fetch_all(sq).await?;
+            let mut out = Vec::with_capacity(rows.len());
+            for row in &rows {
+                use sqlx::Column as _;
+                use sqlx::Row as _;
+                let mut map = std::collections::HashMap::new();
+                for (i, col) in row.columns().iter().enumerate() {
+                    map.insert(col.name().to_owned(), sqlite_cell_to_sqlvalue(row, i));
+                }
+                out.push(map);
+            }
+            Ok(out)
+        }
+    }
+}
+
+/// Execute a [`SelectQuery`] (with `projection` set) and return each
+/// row as a `Vec<SqlValue>` ordered to match the projection's column
+/// list. Backs [`crate::query::ValuesListQuerySet::fetch`].
+/// Issue #22.
+///
+/// # Errors
+/// SQL compilation or driver failure.
+pub async fn fetch_values_list(
+    pool: &Pool,
+    query: &SelectQuery,
+) -> Result<Vec<Vec<SqlValue>>, ExecError> {
+    let stmt = pool.dialect().compile_select(query)?;
+    match pool {
+        #[cfg(feature = "postgres")]
+        Pool::Postgres(pg) => {
+            let mut q: Query<'_, sqlx::Postgres, PgArguments> = sqlx::query(&stmt.sql);
+            for v in stmt.params {
+                q = bind_query(q, v);
+            }
+            let rows = q.fetch_all(pg).await?;
+            let mut out = Vec::with_capacity(rows.len());
+            for row in &rows {
+                use sqlx::Row as _;
+                let n = row.columns().len();
+                let mut v = Vec::with_capacity(n);
+                for i in 0..n {
+                    v.push(pg_cell_to_sqlvalue(row, i));
+                }
+                out.push(v);
+            }
+            Ok(out)
+        }
+        #[cfg(feature = "mysql")]
+        Pool::Mysql(my) => {
+            let mut q: sqlx::query::Query<'_, sqlx::MySql, sqlx::mysql::MySqlArguments> =
+                sqlx::query(&stmt.sql);
+            for v in stmt.params {
+                q = bind_query_my(q, v);
+            }
+            let rows = q.fetch_all(my).await?;
+            let mut out = Vec::with_capacity(rows.len());
+            for row in &rows {
+                use sqlx::Row as _;
+                let n = row.columns().len();
+                let mut v = Vec::with_capacity(n);
+                for i in 0..n {
+                    v.push(my_cell_to_sqlvalue(row, i));
+                }
+                out.push(v);
+            }
+            Ok(out)
+        }
+        #[cfg(feature = "sqlite")]
+        Pool::Sqlite(sq) => {
+            let mut q: sqlx::query::Query<'_, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'_>> =
+                sqlx::query(&stmt.sql);
+            for v in stmt.params {
+                q = bind_query_sqlite(q, v);
+            }
+            let rows = q.fetch_all(sq).await?;
+            let mut out = Vec::with_capacity(rows.len());
+            for row in &rows {
+                use sqlx::Row as _;
+                let n = row.columns().len();
+                let mut v = Vec::with_capacity(n);
+                for i in 0..n {
+                    v.push(sqlite_cell_to_sqlvalue(row, i));
+                }
+                out.push(v);
+            }
+            Ok(out)
+        }
+    }
+}
+
+/// Trait gate for the `.values_list_flat::<U>(...)` typed-scalar path —
+/// PG arm. Same shape as [`MaybePgFromRow`]: when the `postgres`
+/// feature is on, this is `Decode + Type<Postgres>`; otherwise an
+/// empty blanket-impl so non-PG builds compile.
+#[cfg(feature = "postgres")]
+pub trait MaybePgScalar:
+    for<'r> sqlx::Decode<'r, sqlx::Postgres> + sqlx::Type<sqlx::Postgres>
+{
+}
+#[cfg(feature = "postgres")]
+impl<T> MaybePgScalar for T where
+    T: for<'r> sqlx::Decode<'r, sqlx::Postgres> + sqlx::Type<sqlx::Postgres>
+{
+}
+#[cfg(not(feature = "postgres"))]
+pub trait MaybePgScalar {}
+#[cfg(not(feature = "postgres"))]
+impl<T> MaybePgScalar for T {}
+
+#[cfg(feature = "mysql")]
+pub trait MaybeMyScalar: for<'r> sqlx::Decode<'r, sqlx::MySql> + sqlx::Type<sqlx::MySql> {}
+#[cfg(feature = "mysql")]
+impl<T> MaybeMyScalar for T where T: for<'r> sqlx::Decode<'r, sqlx::MySql> + sqlx::Type<sqlx::MySql> {}
+#[cfg(not(feature = "mysql"))]
+pub trait MaybeMyScalar {}
+#[cfg(not(feature = "mysql"))]
+impl<T> MaybeMyScalar for T {}
+
+#[cfg(feature = "sqlite")]
+pub trait MaybeSqliteScalar:
+    for<'r> sqlx::Decode<'r, sqlx::Sqlite> + sqlx::Type<sqlx::Sqlite>
+{
+}
+#[cfg(feature = "sqlite")]
+impl<T> MaybeSqliteScalar for T where
+    T: for<'r> sqlx::Decode<'r, sqlx::Sqlite> + sqlx::Type<sqlx::Sqlite>
+{
+}
+#[cfg(not(feature = "sqlite"))]
+pub trait MaybeSqliteScalar {}
+#[cfg(not(feature = "sqlite"))]
+impl<T> MaybeSqliteScalar for T {}
+
+/// Execute a single-column [`SelectQuery`] and decode each row's only
+/// cell into `U`. Backs [`crate::query::ValuesFlatQuerySet::fetch`].
+/// Issue #22 — Django's `.values_list('col', flat=True)`.
+///
+/// # Errors
+/// SQL compilation or driver failure, including a decode error if `U`
+/// doesn't match the column's SQL type on the live database.
+pub async fn fetch_values_flat<U>(pool: &Pool, query: &SelectQuery) -> Result<Vec<U>, ExecError>
+where
+    U: MaybePgScalar + MaybeMyScalar + MaybeSqliteScalar + Send + Unpin,
+{
+    let stmt = pool.dialect().compile_select(query)?;
+    match pool {
+        #[cfg(feature = "postgres")]
+        Pool::Postgres(pg) => {
+            let mut q: sqlx::query::QueryScalar<'_, sqlx::Postgres, U, PgArguments> =
+                sqlx::query_scalar(&stmt.sql);
+            for v in stmt.params {
+                q = bind_query_scalar_pg(q, v);
+            }
+            Ok(q.fetch_all(pg).await?)
+        }
+        #[cfg(feature = "mysql")]
+        Pool::Mysql(my) => {
+            let mut q: sqlx::query::QueryScalar<'_, sqlx::MySql, U, sqlx::mysql::MySqlArguments> =
+                sqlx::query_scalar(&stmt.sql);
+            for v in stmt.params {
+                q = bind_query_scalar_my(q, v);
+            }
+            Ok(q.fetch_all(my).await?)
+        }
+        #[cfg(feature = "sqlite")]
+        Pool::Sqlite(sq) => {
+            let mut q: sqlx::query::QueryScalar<
+                '_,
+                sqlx::Sqlite,
+                U,
+                sqlx::sqlite::SqliteArguments<'_>,
+            > = sqlx::query_scalar(&stmt.sql);
+            for v in stmt.params {
+                q = bind_query_scalar_sqlite(q, v);
+            }
+            Ok(q.fetch_all(sq).await?)
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn bind_query_scalar_pg<U>(
+    q: sqlx::query::QueryScalar<'_, sqlx::Postgres, U, PgArguments>,
+    value: SqlValue,
+) -> sqlx::query::QueryScalar<'_, sqlx::Postgres, U, PgArguments> {
+    bind_match!(q, value)
+}
+
+#[cfg(feature = "mysql")]
+fn bind_query_scalar_my<U>(
+    q: sqlx::query::QueryScalar<'_, sqlx::MySql, U, sqlx::mysql::MySqlArguments>,
+    value: SqlValue,
+) -> sqlx::query::QueryScalar<'_, sqlx::MySql, U, sqlx::mysql::MySqlArguments> {
+    bind_match!(q, value)
+}
+
+#[cfg(feature = "sqlite")]
+fn bind_query_scalar_sqlite<'a, U>(
+    q: sqlx::query::QueryScalar<'a, sqlx::Sqlite, U, sqlx::sqlite::SqliteArguments<'a>>,
+    value: SqlValue,
+) -> sqlx::query::QueryScalar<'a, sqlx::Sqlite, U, sqlx::sqlite::SqliteArguments<'a>> {
+    bind_match!(q, value)
+}
+
+// Bridge methods on the values builders so callers chain `.fetch(&pool)`.
+
+impl<T: crate::core::Model> crate::query::ValuesQuerySet<T> {
+    /// Execute the projection and return rows as `Vec<HashMap<String, SqlValue>>`.
+    ///
+    /// # Errors
+    /// - [`ExecError::Query`] for SQL compilation failures (typo'd
+    ///   column, etc.).
+    /// - [`ExecError::Sqlx`] for driver / network / decode failures.
+    pub async fn fetch(
+        self,
+        pool: &Pool,
+    ) -> Result<Vec<std::collections::HashMap<String, SqlValue>>, ExecError> {
+        let q = self.compile()?;
+        fetch_values_dict(pool, &q).await
+    }
+}
+
+impl<T: crate::core::Model> crate::query::ValuesListQuerySet<T> {
+    /// Execute the projection and return rows as `Vec<Vec<SqlValue>>`.
+    ///
+    /// # Errors
+    /// As [`crate::query::ValuesQuerySet::fetch`].
+    pub async fn fetch(self, pool: &Pool) -> Result<Vec<Vec<SqlValue>>, ExecError> {
+        let q = self.compile()?;
+        fetch_values_list(pool, &q).await
+    }
+}
+
+impl<T: crate::core::Model> crate::query::ValuesFlatQuerySet<T> {
+    /// Execute the single-column projection and decode each row's cell
+    /// into `U`.
+    ///
+    /// # Errors
+    /// As [`crate::query::ValuesQuerySet::fetch`], plus per-cell
+    /// type-mismatch errors if `U` doesn't match the column's SQL type.
+    pub async fn fetch<U>(self, pool: &Pool) -> Result<Vec<U>, ExecError>
+    where
+        U: MaybePgScalar + MaybeMyScalar + MaybeSqliteScalar + Send + Unpin,
+    {
+        let q = self.compile()?;
+        fetch_values_flat::<U>(pool, &q).await
+    }
+}
+
 /// Execute arbitrary SQL with bound `SqlValue` params and decode each
 /// row into `T` via `FromRow`. Bi-dialect counterpart of
 /// [`raw_query`].

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -731,6 +731,7 @@ mod tests {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert_eq!(
@@ -758,6 +759,7 @@ mod tests {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("LOWER(`name`) NOT LIKE LOWER(?)"));
@@ -781,6 +783,7 @@ mod tests {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("NOT (`email` <=> ?)"));
@@ -804,6 +807,7 @@ mod tests {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         // No outer NOT; bare null-safe equality.
@@ -829,6 +833,7 @@ mod tests {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("JSON_CONTAINS(`meta`, ?)"));
@@ -853,6 +858,7 @@ mod tests {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         // Argument order is swapped vs JSON_CONTAINS — value first.
@@ -877,6 +883,7 @@ mod tests {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -905,6 +912,7 @@ mod tests {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -934,6 +942,7 @@ mod tests {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -1021,6 +1030,7 @@ mod tests {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert_eq!(

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -558,6 +558,7 @@ mod tests {
             search: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let stmt = Sqlite.compile_select(&q).unwrap();
         // SQLite emits ANSI-quoted identifiers and `?` placeholders.

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -181,6 +181,7 @@ fn write_compound_select(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), Sql
         offset: None,
         lock_mode: None,
         compound: Vec::new(),
+        projection: None,
     };
     b.sql.push('(');
     write_select_inner(b, &head)?;
@@ -222,16 +223,34 @@ fn write_select_inner(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlErr
 
     b.sql.push_str("SELECT ");
     let mut first_col = true;
-    for field in query.model.scalar_fields() {
-        if !first_col {
-            b.sql.push_str(", ");
+    if let Some(cols) = query.projection.as_ref() {
+        // Pure projection (issue #22 — `.values_dict()` /
+        // `.values_list()` / `.values_list_flat()`): emit exactly
+        // the listed columns in the given order. Validation that
+        // each column resolves on the model is the builder's job.
+        for col in cols {
+            if !first_col {
+                b.sql.push_str(", ");
+            }
+            first_col = false;
+            if qualify {
+                b.write_ident(query.model.table);
+                b.sql.push('.');
+            }
+            b.write_ident(col);
         }
-        first_col = false;
-        if qualify {
-            b.write_ident(query.model.table);
-            b.sql.push('.');
+    } else {
+        for field in query.model.scalar_fields() {
+            if !first_col {
+                b.sql.push_str(", ");
+            }
+            first_col = false;
+            if qualify {
+                b.write_ident(query.model.table);
+                b.sql.push('.');
+            }
+            b.write_ident(field.column);
         }
-        b.write_ident(field.column);
     }
     for join in &query.joins {
         for col in &join.project {

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -582,6 +582,7 @@ async fn handle_list(
         offset: Some(offset),
         lock_mode: None,
         compound: vec![],
+        projection: None,
     };
     let count_q = crate::core::CountQuery {
         model: state.vs.schema,
@@ -831,6 +832,7 @@ async fn handle_detail(
         offset: None,
         lock_mode: None,
         compound: vec![],
+        projection: None,
     };
     let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
     let object = match select_one_row_as_json(&state.pool, &select_q, &fields).await {
@@ -959,6 +961,7 @@ async fn handle_delete_confirm(
         offset: None,
         lock_mode: None,
         compound: vec![],
+        projection: None,
     };
     let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
     let object = match select_one_row_as_json(&state.pool, &select_q, &fields).await {
@@ -1791,6 +1794,7 @@ async fn handle_update_get(
         offset: None,
         lock_mode: None,
         compound: vec![],
+        projection: None,
     };
     let scalars: Vec<&'static crate::core::FieldSchema> = state.schema.scalar_fields().collect();
     let row_json = match select_one_row_as_json(&state.pool, &select_q, &scalars).await {
@@ -2643,6 +2647,7 @@ fn build_fk_display_query(fk: &FkLookup) -> SelectQuery {
         offset: None,
         lock_mode: None,
         compound: vec![],
+        projection: None,
     }
 }
 
@@ -2809,6 +2814,7 @@ async fn fetch_pks_as_objects_pool(
         offset: None,
         lock_mode: None,
         compound: vec![],
+        projection: None,
     };
     let fields: Vec<&'static crate::core::FieldSchema> = schema.scalar_fields().collect();
     let rows = select_rows_as_json(pool, &q, &fields)
@@ -2949,6 +2955,7 @@ mod tenant {
             offset: Some(offset),
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let count_q = crate::core::CountQuery {
             model: state.vs.schema,
@@ -3137,6 +3144,7 @@ mod tenant {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
         let object = match crate::sql::select_one_row_as_json(t.pool(), &select_q, &fields).await {
@@ -3184,6 +3192,7 @@ mod tenant {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
         let object = match crate::sql::select_one_row_as_json(t.pool(), &select_q, &fields).await {
@@ -3332,6 +3341,7 @@ mod tenant {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let scalars: Vec<&'static crate::core::FieldSchema> =
             state.schema.scalar_fields().collect();

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -910,6 +910,7 @@ async fn handle_list(
                 offset: Some(offset),
                 lock_mode: None,
                 compound: vec![],
+                projection: None,
             };
             let count_q = CountQuery {
                 model: state.vs.schema,
@@ -1040,6 +1041,7 @@ async fn handle_list_cursor(
         offset: None,
         lock_mode: None,
         compound: vec![],
+        projection: None,
     };
     let rows = match acq.select_rows_as_json(&select_q, &fields).await {
         Ok(r) => r,
@@ -1131,6 +1133,7 @@ async fn handle_retrieve(
         offset: None,
         lock_mode: None,
         compound: vec![],
+        projection: None,
     };
 
     let fields = state.effective_fields();
@@ -1368,6 +1371,7 @@ async fn fetch_by_pk(
         offset: None,
         lock_mode: None,
         compound: vec![],
+        projection: None,
     };
     let _ = state;
     acq.select_one_as_json(&select_q, fields)

--- a/crates/rustango/tests/mysql_from_row.rs
+++ b/crates/rustango/tests/mysql_from_row.rs
@@ -226,6 +226,7 @@ fn select_rows_pool_with_related_is_callable() {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         };
         let _fut: _ = rustango::sql::select_rows_pool_with_related::<User>(pool, &q);
     }

--- a/crates/rustango/tests/q_xor_emission.rs
+++ b/crates/rustango/tests/q_xor_emission.rs
@@ -32,6 +32,7 @@ fn select(where_clause: WhereExpr) -> SelectQuery {
         offset: None,
         lock_mode: None,
         compound: vec![],
+        projection: None,
     }
 }
 

--- a/crates/rustango/tests/row_to_json_pool_sqlite_live.rs
+++ b/crates/rustango/tests/row_to_json_pool_sqlite_live.rs
@@ -81,6 +81,7 @@ async fn select_rows_as_json_pool_decodes_sqlite_rows() {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         },
         &fields,
     )
@@ -118,6 +119,7 @@ async fn select_one_row_as_json_pool_returns_none_for_miss() {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         },
         &fields,
     )
@@ -157,6 +159,7 @@ async fn select_one_row_as_json_pool_returns_decoded_row_for_hit() {
             offset: None,
             lock_mode: None,
             compound: vec![],
+            projection: None,
         },
         &fields,
     )

--- a/crates/rustango/tests/sql.rs
+++ b/crates/rustango/tests/sql.rs
@@ -595,6 +595,7 @@ fn empty_select() -> SelectQuery {
         offset: None,
         lock_mode: None,
         compound: vec![],
+        projection: None,
     }
 }
 
@@ -814,6 +815,7 @@ fn empty_post_select() -> SelectQuery {
         offset: None,
         lock_mode: None,
         compound: vec![],
+        projection: None,
     }
 }
 

--- a/crates/rustango/tests/values_emission.rs
+++ b/crates/rustango/tests/values_emission.rs
@@ -1,0 +1,227 @@
+//! Tri-dialect emission tests for `QuerySet::values_dict` /
+//! `values_list` / `values_list_flat` (issue #22). Pure projection
+//! — no GROUP BY — emits `SELECT col1, col2 FROM table …` on every
+//! dialect.
+
+use rustango::core::{Column as _, QueryError};
+#[cfg(feature = "mysql")]
+use rustango::sql::MySql;
+#[cfg(feature = "sqlite")]
+use rustango::sql::Sqlite;
+use rustango::sql::{Dialect, Postgres};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "v_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 64)]
+    title: String,
+    view_count: i64,
+    published: bool,
+}
+
+// ---------- PG ----------
+
+#[test]
+fn values_dict_emits_select_only_listed_cols_on_pg() {
+    let q = Post::objects()
+        .values_dict(&["id", "title"])
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    // Exactly `SELECT "id", "title"` — no `, "view_count"` etc.
+    assert!(
+        stmt.sql
+            .starts_with(r#"SELECT "id", "title" FROM "v_post""#),
+        "PG values_dict: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains(r#""view_count""#) && !stmt.sql.contains(r#""published""#),
+        "PG values_dict should not include unlisted cols: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn values_list_emits_same_select_as_values_dict_on_pg() {
+    // Same projection shape — the SQL doesn't differ between
+    // values_dict / values_list. Only the row-decode shape on the
+    // fetch side differs.
+    let dict_q = Post::objects()
+        .values_dict(&["id", "view_count"])
+        .compile()
+        .unwrap();
+    let list_q = Post::objects()
+        .values_list(&["id", "view_count"])
+        .compile()
+        .unwrap();
+    let dict_sql = Postgres.compile_select(&dict_q).unwrap().sql;
+    let list_sql = Postgres.compile_select(&list_q).unwrap().sql;
+    assert_eq!(
+        dict_sql, list_sql,
+        "values_dict + values_list should compile to the same SQL"
+    );
+}
+
+#[test]
+fn values_list_flat_single_col_select_on_pg() {
+    let q = Post::objects().values_list_flat("title").compile().unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.starts_with(r#"SELECT "title" FROM "v_post""#),
+        "PG values_list_flat: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn values_dict_preserves_where_clause_on_pg() {
+    let q = Post::objects()
+        .where_(Post::published.eq(true))
+        .values_dict(&["id", "title"])
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql
+            .starts_with(r#"SELECT "id", "title" FROM "v_post""#),
+        "projection: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains(r#"WHERE "published" = $1"#),
+        "where clause survives: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn values_dict_preserves_order_limit_offset_on_pg() {
+    let q = Post::objects()
+        .order_by(&[("view_count", true)])
+        .limit(10)
+        .offset(20)
+        .values_dict(&["id"])
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"ORDER BY "view_count" DESC"#),
+        "{}",
+        stmt.sql
+    );
+    assert!(stmt.sql.contains("LIMIT 10"), "{}", stmt.sql);
+    assert!(stmt.sql.contains("OFFSET 20"), "{}", stmt.sql);
+}
+
+#[test]
+fn values_preserves_column_order_in_projection() {
+    // Reorder: title first, id second — the SELECT list must reflect
+    // the user's order, not the model's declaration order.
+    let q = Post::objects()
+        .values_dict(&["title", "id"])
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql
+            .starts_with(r#"SELECT "title", "id" FROM "v_post""#),
+        "{}",
+        stmt.sql
+    );
+}
+
+// ---------- MySQL ----------
+
+#[cfg(feature = "mysql")]
+#[test]
+fn values_dict_emits_backtick_quoted_select_on_mysql() {
+    let q = Post::objects()
+        .values_dict(&["id", "title"])
+        .compile()
+        .unwrap();
+    let stmt = MySql.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.starts_with("SELECT `id`, `title` FROM `v_post`"),
+        "MySQL: {}",
+        stmt.sql
+    );
+}
+
+// ---------- SQLite ----------
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn values_dict_emits_double_quoted_select_on_sqlite() {
+    let q = Post::objects()
+        .values_dict(&["id", "title"])
+        .compile()
+        .unwrap();
+    let stmt = Sqlite.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql
+            .starts_with(r#"SELECT "id", "title" FROM "v_post""#),
+        "SQLite: {}",
+        stmt.sql
+    );
+}
+
+// ---------- Validation ----------
+
+#[test]
+fn empty_cols_rejected_at_compile() {
+    let err = Post::objects().values_dict(&[]).compile().unwrap_err();
+    assert!(
+        matches!(err, QueryError::EmptyValuesProjection),
+        "got: {err:?}"
+    );
+    let err = Post::objects().values_list(&[]).compile().unwrap_err();
+    assert!(
+        matches!(err, QueryError::EmptyValuesProjection),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn unknown_column_rejected_at_compile() {
+    let err = Post::objects()
+        .values_dict(&["id", "nope_col"])
+        .compile()
+        .unwrap_err();
+    assert!(
+        matches!(err, QueryError::UnknownField { ref field, .. } if field == "nope_col"),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn values_list_flat_unknown_col_rejected() {
+    let err = Post::objects()
+        .values_list_flat("nope")
+        .compile()
+        .unwrap_err();
+    assert!(
+        matches!(err, QueryError::UnknownField { ref field, .. } if field == "nope"),
+        "got: {err:?}"
+    );
+}
+
+// ---------- Backward compat: existing `.values()` AggregateBuilder path unchanged ----------
+
+#[test]
+fn existing_values_aggregate_path_still_errors_when_no_annotate() {
+    // Sanity check the pre-existing error path still fires —
+    // `.values()` (the AggregateBuilder shortcut) without a
+    // subsequent `.annotate()` should still surface
+    // `ValuesRequiresAggregate`, not the new EmptyValuesProjection
+    // / projection path.
+    let err = Post::objects().values(&["id"]).compile().unwrap_err();
+    assert!(
+        matches!(err, QueryError::ValuesRequiresAggregate { .. }),
+        "got: {err:?}"
+    );
+}

--- a/crates/rustango/tests/values_live.rs
+++ b/crates/rustango/tests/values_live.rs
@@ -1,0 +1,191 @@
+#![cfg(feature = "postgres")]
+//! Live PG tests for `QuerySet::values_dict` / `values_list` /
+//! `values_list_flat` (issue #22). Verifies that pure projection
+//! returns the right shape against a real database with mixed-type
+//! columns. Skips silently when `DATABASE_URL` is unset.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use rustango::core::{Column as _, SqlValue};
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "v_post_live")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 64)]
+    pub title: String,
+    pub view_count: i64,
+    pub published: bool,
+}
+
+fn lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn fresh_pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pg = sqlx::PgPool::connect(&url).await.ok()?;
+    sqlx::query(r#"DROP TABLE IF EXISTS "v_post_live" CASCADE"#)
+        .execute(&pg)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"
+        CREATE TABLE "v_post_live" (
+            id BIGSERIAL PRIMARY KEY,
+            title VARCHAR(64) NOT NULL,
+            view_count BIGINT NOT NULL,
+            published BOOLEAN NOT NULL
+        )
+        "#,
+    )
+    .execute(&pg)
+    .await
+    .unwrap();
+    let pool = Pool::Postgres(pg);
+    for (title, vc, pub_) in [
+        ("Intro to Rust", 100_i64, true),
+        ("Advanced Lifetimes", 50, true),
+        ("Draft Post", 0, false),
+        ("Performance Tips", 200, true),
+    ] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: title.into(),
+            view_count: vc,
+            published: pub_,
+        };
+        p.insert_pool(&pool).await.unwrap();
+    }
+    Some(pool)
+}
+
+/// `.values_dict(&["id", "title"])` returns each row as a HashMap
+/// keyed by column name. Only the listed cols come back.
+#[tokio::test]
+async fn values_dict_returns_hashmap_per_row() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+        .where_(Post::published.eq(true))
+        .order_by(&[("id", false)])
+        .values_dict(&["id", "title"])
+        .fetch(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(rows.len(), 3, "three published posts: {rows:?}");
+    for row in &rows {
+        assert_eq!(row.len(), 2, "only id + title columns: {row:?}");
+        assert!(row.contains_key("id"));
+        assert!(row.contains_key("title"));
+        // view_count + published were NOT requested — not present
+        assert!(!row.contains_key("view_count"));
+        assert!(!row.contains_key("published"));
+    }
+    // First row by ascending id is "Intro to Rust"
+    match &rows[0]["title"] {
+        SqlValue::String(s) => assert_eq!(s, "Intro to Rust"),
+        other => panic!("expected String, got {other:?}"),
+    }
+}
+
+/// `.values_list(...)` returns rows as Vec<SqlValue> in user-specified
+/// column order.
+#[tokio::test]
+async fn values_list_returns_ordered_vec_per_row() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    // Reverse the natural order — title first, id second.
+    let rows: Vec<Vec<SqlValue>> = Post::objects()
+        .order_by(&[("id", false)])
+        .values_list(&["title", "id"])
+        .fetch(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(rows.len(), 4);
+    for row in &rows {
+        assert_eq!(row.len(), 2);
+        // [0] = title (String), [1] = id (I64)
+        assert!(matches!(row[0], SqlValue::String(_)));
+        assert!(matches!(row[1], SqlValue::I64(_)));
+    }
+}
+
+/// `.values_list_flat::<i64>("id")` returns Vec<i64> directly — no
+/// SqlValue wrapping.
+#[tokio::test]
+async fn values_list_flat_typed_i64_column() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let ids: Vec<i64> = Post::objects()
+        .order_by(&[("id", false)])
+        .values_list_flat("id")
+        .fetch::<i64>(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(ids, vec![1, 2, 3, 4], "PKs ascending: {ids:?}");
+}
+
+/// `.values_list_flat::<String>("title")` decodes the String column
+/// directly.
+#[tokio::test]
+async fn values_list_flat_typed_string_column() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let titles: Vec<String> = Post::objects()
+        .where_(Post::published.eq(true))
+        .order_by(&[("id", false)])
+        .values_list_flat("title")
+        .fetch::<String>(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        titles,
+        vec![
+            "Intro to Rust".to_owned(),
+            "Advanced Lifetimes".to_owned(),
+            "Performance Tips".to_owned(),
+        ]
+    );
+}
+
+/// `.values_list_flat::<bool>("published")` decodes a boolean.
+#[tokio::test]
+async fn values_list_flat_typed_bool_column() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let flags: Vec<bool> = Post::objects()
+        .order_by(&[("id", false)])
+        .values_list_flat("published")
+        .fetch::<bool>(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(flags, vec![true, true, false, true]);
+}

--- a/crates/rustango/tests/values_sqlite_live.rs
+++ b/crates/rustango/tests/values_sqlite_live.rs
@@ -1,0 +1,112 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite tests for `QuerySet::values_dict` / `values_list` /
+//! `values_list_flat` (issue #22). Pure projection round-trip on a
+//! sqlite::memory: pool — proves the bi-dialect emission + dynamic
+//! decode path works on SQLite as well as PG.
+
+use std::collections::HashMap;
+
+use rustango::core::{Model as _, SqlValue};
+use rustango::sql::{Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "v_post_sqlite")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 64)]
+    pub title: String,
+    pub view_count: i64,
+    pub published: bool,
+}
+
+async fn seeded_pool() -> Pool {
+    let pool = Pool::connect("sqlite::memory:").await.expect("sqlite");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        "CREATE TABLE v_post_sqlite (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            view_count INTEGER NOT NULL,
+            published INTEGER NOT NULL
+        )",
+        vec![],
+    )
+    .await
+    .unwrap();
+    for (title, vc, pub_) in [
+        ("Intro to Rust", 100_i64, 1_i64),
+        ("Advanced Lifetimes", 50, 1),
+        ("Draft", 0, 0),
+        ("Performance Tips", 200, 1),
+    ] {
+        rustango::sql::raw_execute_pool(
+            &pool,
+            "INSERT INTO v_post_sqlite(title, view_count, published) VALUES (?, ?, ?)",
+            vec![
+                SqlValue::String(title.to_owned()),
+                SqlValue::I64(vc),
+                SqlValue::I64(pub_),
+            ],
+        )
+        .await
+        .unwrap();
+    }
+    let _ = Post::SCHEMA;
+    pool
+}
+
+#[tokio::test]
+async fn values_dict_returns_hashmap_on_sqlite() {
+    let pool = seeded_pool().await;
+
+    let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+        .order_by(&[("id", false)])
+        .values_dict(&["id", "title"])
+        .fetch(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(rows.len(), 4);
+    for row in &rows {
+        assert_eq!(row.len(), 2);
+        assert!(row.contains_key("id") && row.contains_key("title"));
+        assert!(!row.contains_key("view_count"));
+    }
+    match &rows[0]["title"] {
+        SqlValue::String(s) => assert_eq!(s, "Intro to Rust"),
+        other => panic!("expected String, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn values_list_flat_typed_i64_on_sqlite() {
+    let pool = seeded_pool().await;
+
+    let view_counts: Vec<i64> = Post::objects()
+        .order_by(&[("id", false)])
+        .values_list_flat("view_count")
+        .fetch::<i64>(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(view_counts, vec![100, 50, 0, 200]);
+}
+
+#[tokio::test]
+async fn values_list_flat_typed_string_on_sqlite() {
+    let pool = seeded_pool().await;
+
+    let titles: Vec<String> = Post::objects()
+        .order_by(&[("id", false)])
+        .values_list_flat("title")
+        .fetch::<String>(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(titles.len(), 4);
+    assert_eq!(titles[0], "Intro to Rust");
+    assert_eq!(titles[3], "Performance Tips");
+}

--- a/crates/rustango/tests/where_expr_live.rs
+++ b/crates/rustango/tests/where_expr_live.rs
@@ -192,6 +192,7 @@ async fn empty_or_branch_returns_named_writer_error() {
         offset: None,
         lock_mode: None,
         compound: vec![],
+        projection: None,
     };
     let err = Postgres.compile_select(&q).unwrap_err();
     assert!(matches!(err, SqlError::EmptyOrBranch));
@@ -211,6 +212,7 @@ async fn empty_or_branch_returns_named_writer_error() {
         offset: None,
         lock_mode: None,
         compound: vec![],
+        projection: None,
     };
     rustango::sql::select_rows(&pool, &q2).await.unwrap();
 }

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -362,6 +362,53 @@ A future `iterator_on(&mut *tx, chunk_size)` companion (issue follow-up) would c
 
 **`chunk_size` must be > 0.** Zero or negative values panic. Pick a value that fits your row-size budget (Django's default is `2000`; reasonable for narrow rows, lower for wide TEXT/JSONB columns).
 
+### Pure projection — `.values_dict()` / `.values_list()` / `.values_list_flat()`
+
+Django's [`QuerySet.values('col')` / `QuerySet.values_list('col', flat=True)`](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#values) — issue #22. Skip the typed `Model` decode when you only need a few columns off a wide table, or when the result feeds dynamic downstream code (templates, CSV export, JSON serialization).
+
+```rust
+use rustango::core::SqlValue;
+use std::collections::HashMap;
+
+// 1. Column-keyed map per row — Django's `.values('id', 'title')`.
+let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+    .where_(Post::published.eq(true))
+    .order_by(&[("id", false)])
+    .values_dict(&["id", "title"])
+    .fetch(&pool).await?;
+
+// 2. Ordered tuple per row — Django's `.values_list('id', 'title')`.
+//    Cell ordering matches the column-list argument.
+let rows: Vec<Vec<SqlValue>> = Post::objects()
+    .values_list(&["title", "id"])  // title first, id second
+    .fetch(&pool).await?;
+
+// 3. Single-column typed scalar — Django's `.values_list('id', flat=True)`.
+//    Returns Vec<U> directly via sqlx's typed scalar path.
+let ids: Vec<i64> = Post::objects()
+    .where_(Post::published.eq(true))
+    .values_list_flat("id")
+    .fetch::<i64>(&pool).await?;
+```
+
+**Three builders, one IR.** All three set `SelectQuery::projection` to the validated column list — the SQL is identical across the three terminal shapes; only the row-decode differs:
+
+| Builder | SQL shape | Returns |
+|---|---|---|
+| `.values_dict(&[cols])` | `SELECT col1, col2 FROM …` | `Vec<HashMap<String, SqlValue>>` |
+| `.values_list(&[cols])` | `SELECT col1, col2 FROM …` | `Vec<Vec<SqlValue>>` (ordered by `cols`) |
+| `.values_list_flat(col)` | `SELECT col FROM …` | `Vec<U>` (typed, via `fetch::<U>(...)`) |
+
+**Composes with the rest of the QuerySet chain.** `.where_()`, `.filter()`, `.order_by()`, `.limit()`, `.offset()`, set-algebra (`.union()` / `.intersection()` / `.difference()`) — every chain method called BEFORE `.values_*` carries through. The values builders are terminal (no further chain methods on them); put query shape before, fetch after.
+
+**Validation at `.compile()` / `.fetch()` time:**
+- Empty column list (`.values_dict(&[])`) → [`QueryError::EmptyValuesProjection`].
+- Typo'd column name (`.values_dict(&["nope"])`) → [`QueryError::UnknownField`].
+
+**Tri-dialect: identical projection emission across PG / MySQL / SQLite** (only the identifier quoting differs). For `.values_list_flat::<U>(...)`, `U` must implement sqlx's `Decode + Type` on every backend the binary targets — common picks (`i64`, `i32`, `String`, `bool`, `f64`) work universally.
+
+**Why not change the existing `.values()` to do pure projection?** `QuerySet::values(cols)` already promotes to [`AggregateBuilder`] for the GROUP BY auto-inference path (issue #75). Renaming would break ~20 existing call sites. The new `.values_dict()` / `.values_list()` / `.values_list_flat()` chain methods sit alongside, leaving the aggregate path untouched. The pre-existing `QueryError::ValuesRequiresAggregate` error still fires for `.values(cols).compile()` without a subsequent `.annotate(...)` — its message now points callers at the new pure-projection methods.
+
 ### Regex lookups — `.regex()` / `.iregex()` and negated variants
 
 Django's [`__regex` / `__iregex`](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#regex) — issue #26. Match a column against a regular-expression pattern, with case-sensitive and case-insensitive flavors plus negated forms.


### PR DESCRIPTION
## Summary

- Django parity for `QuerySet.values('col')` / `QuerySet.values_list('col', flat=True)` — three new chain methods on `QuerySet<T>` that close the long-standing pure-projection gap.
- New IR field `SelectQuery::projection: Option<Vec<&'static str>>` — `None` keeps the existing \"select every scalar field\" behavior; `Some(cols)` emits exactly the listed columns.
- Three terminal builders (one IR): `ValuesQuerySet` returns `Vec<HashMap<String, SqlValue>>`, `ValuesListQuerySet` returns `Vec<Vec<SqlValue>>` (cells ordered per the user's column list), `ValuesFlatQuerySet` returns `Vec<U>` for a single typed column via sqlx's `query_scalar` path.
- Tri-dialect: PG / MySQL / SQLite emit the same SELECT shape. The typed-flat path uses `MaybePgScalar` / `MaybeMyScalar` / `MaybeSqliteScalar` marker traits in the same shape as the existing `MaybePgFromRow` family.
- Methods land without `_pool` suffix per the standing naming convention — bare `.fetch(&pool)` on each values builder.
- New `QueryError::EmptyValuesProjection` for `.values_dict(&[])`; existing `QueryError::UnknownField` for typos.
- Backward compat: the existing `QuerySet::values(cols)` AggregateBuilder shortcut (issue #75) is untouched — all 20+ existing call sites unchanged. The pre-existing `ValuesRequiresAggregate` error now points callers at the new methods.

## Test plan

- [x] 12 tri-dialect emission tests (`tests/values_emission.rs`) — projection-only SELECT shape, column-order preservation, WHERE / ORDER / LIMIT / OFFSET passthrough, validation errors, backward-compat with the AggregateBuilder path.
- [x] 5 live PG tests (`tests/values_live.rs`) — values_dict + values_list + values_list_flat::<i64 / String / bool> against mixed-type data.
- [x] 3 live SQLite tests (`tests/values_sqlite_live.rs`) — proves the bi-dialect dynamic decode path works on sqlite::memory:.
- [x] `cargo build --no-default-features --features sqlite,tenancy` — SQLite-tenancy litmus passes.
- [x] `cargo test --workspace --all-features --no-run` — all-features build clean.
- [x] `cargo test -p rustango --lib --features tenancy,mysql,sqlite` — 1553 lib tests pass.

Closes #22.