### PR TITLE
feat: QuerySet::defer / only — column pruning (closes #20)

### DIFF
--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -801,6 +801,65 @@ impl<T: Model> QuerySet<T> {
         ValuesFlatQuerySet { qs: self, col }
     }
 
+    /// Project only the listed columns — Django's `.only('id', 'name')`.
+    /// Issue #20. Equivalent to [`Self::values_dict`] semantically — the
+    /// SQL is `SELECT cols FROM …` and the result is
+    /// `Vec<HashMap<String, SqlValue>>` keyed by column name. The
+    /// distinct entry point preserves Django muscle-memory at the
+    /// chain site.
+    ///
+    /// Columns are validated at `.compile()` time — typos surface as
+    /// [`QueryError::UnknownField`]; an empty list surfaces
+    /// [`QueryError::EmptyValuesProjection`].
+    ///
+    /// Note: unlike Django's `.only()`, the return shape is a
+    /// `HashMap`, not a partially-hydrated `Model` instance — rustango
+    /// has no equivalent of Django's lazy-attribute descriptor magic.
+    /// Typed partial-row decode is queued for a future slice.
+    #[must_use]
+    pub fn only(self, cols: &[&'static str]) -> ValuesQuerySet<T> {
+        self.values_dict(cols)
+    }
+
+    /// Project every scalar column EXCEPT the listed ones — Django's
+    /// `.defer('big_field', 'huge_blob')`. Issue #20. Compute the
+    /// complement against the model schema; the resulting SELECT
+    /// omits the named columns, saving IO on wide tables.
+    ///
+    /// Same return shape as [`Self::only`] (`Vec<HashMap<String, SqlValue>>`)
+    /// with the same Django parity caveat.
+    ///
+    /// Typo'd defer columns surface as [`QueryError::UnknownField`]
+    /// at `.compile()` time (any column the caller named that doesn't
+    /// exist on the model is rejected just like an `.only(...)` typo).
+    /// Empty defer list returns every scalar column on the model —
+    /// semantically a no-op vs. `.values_dict(all_cols)`.
+    #[must_use]
+    pub fn defer(self, cols: &[&'static str]) -> ValuesQuerySet<T> {
+        let model = T::SCHEMA;
+        let exclude: std::collections::HashSet<&'static str> = cols.iter().copied().collect();
+        let kept: Vec<&'static str> = model
+            .scalar_fields()
+            .filter(|f| !exclude.contains(f.column))
+            .map(|f| f.column)
+            .collect();
+        // Validate the defer list itself — any column the caller named
+        // that doesn't exist on the model gets surfaced via the same
+        // `UnknownField` path as `.only(...)`. We do this by passing the
+        // bad cols alongside `kept` so compile sees and rejects them.
+        // (Real defer cols are excluded from `kept` above; only the
+        // typo'd ones survive.)
+        let model_cols: std::collections::HashSet<&'static str> =
+            model.scalar_fields().map(|f| f.column).collect();
+        let mut all = kept;
+        for &col in cols {
+            if !model_cols.contains(col) {
+                all.push(col);
+            }
+        }
+        self.values_dict(&all)
+    }
+
     /// Lower this queryset to a `DeleteQuery` — same WHERE clause, no projection.
     ///
     /// # Errors

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -838,26 +838,19 @@ impl<T: Model> QuerySet<T> {
     pub fn defer(self, cols: &[&'static str]) -> ValuesQuerySet<T> {
         let model = T::SCHEMA;
         let exclude: std::collections::HashSet<&'static str> = cols.iter().copied().collect();
-        let kept: Vec<&'static str> = model
+        let mut projection: Vec<&'static str> = model
             .scalar_fields()
             .filter(|f| !exclude.contains(f.column))
             .map(|f| f.column)
             .collect();
-        // Validate the defer list itself — any column the caller named
-        // that doesn't exist on the model gets surfaced via the same
-        // `UnknownField` path as `.only(...)`. We do this by passing the
-        // bad cols alongside `kept` so compile sees and rejects them.
-        // (Real defer cols are excluded from `kept` above; only the
-        // typo'd ones survive.)
-        let model_cols: std::collections::HashSet<&'static str> =
-            model.scalar_fields().map(|f| f.column).collect();
-        let mut all = kept;
+        // Typo'd defer cols get forwarded into the projection so
+        // `values_dict`'s `UnknownField` check rejects them at compile.
         for &col in cols {
-            if !model_cols.contains(col) {
-                all.push(col);
+            if model.field_by_column(col).is_none() {
+                projection.push(col);
             }
         }
-        self.values_dict(&all)
+        self.values_dict(&projection)
     }
 
     /// Lower this queryset to a `DeleteQuery` — same WHERE clause, no projection.

--- a/crates/rustango/tests/defer_only_emission.rs
+++ b/crates/rustango/tests/defer_only_emission.rs
@@ -127,6 +127,42 @@ fn only_empty_list_errors_at_compile() {
 }
 
 #[test]
+fn defer_preserves_where_clause() {
+    use rustango::core::Column as _;
+    let q = Post::objects()
+        .where_(Post::view_count.gt(100))
+        .defer(&["body"])
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"WHERE "view_count" > $1"#),
+        "where survives: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains(r#""body""#),
+        "body still excluded: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn defer_every_field_errors_at_compile() {
+    // Edge case: deferring every scalar column on the model leaves
+    // an empty projection — must surface EmptyValuesProjection, not
+    // silently emit `SELECT FROM …`.
+    let err = Post::objects()
+        .defer(&["id", "title", "body", "view_count"])
+        .compile()
+        .unwrap_err();
+    assert!(
+        matches!(err, QueryError::EmptyValuesProjection),
+        "got: {err:?}"
+    );
+}
+
+#[test]
 fn defer_and_only_compose_with_order_limit() {
     let q = Post::objects()
         .order_by(&[("id", false)])

--- a/crates/rustango/tests/defer_only_emission.rs
+++ b/crates/rustango/tests/defer_only_emission.rs
@@ -1,0 +1,140 @@
+//! Emission tests for `QuerySet::defer` / `QuerySet::only` (issue #20).
+//! Both lower to the same projection IR as `.values_dict`, so the SQL
+//! shape is identical — these tests pin the column-list semantics:
+//! `.only(&[a, b])` selects exactly a + b, and `.defer(&[a])` selects
+//! everything except a.
+
+use rustango::core::QueryError;
+use rustango::sql::{Dialect, Postgres};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "do_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 64)]
+    title: String,
+    /// Imagine a TEXT column we want to defer on list views.
+    body: String,
+    view_count: i64,
+}
+
+#[test]
+fn only_emits_select_with_just_listed_cols() {
+    let q = Post::objects().only(&["id", "title"]).compile().unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql
+            .starts_with(r#"SELECT "id", "title" FROM "do_post""#),
+        "only: {}",
+        stmt.sql
+    );
+    // body and view_count must NOT appear.
+    assert!(!stmt.sql.contains(r#""body""#), "{}", stmt.sql);
+    assert!(!stmt.sql.contains(r#""view_count""#), "{}", stmt.sql);
+}
+
+#[test]
+fn defer_emits_select_with_all_cols_minus_excluded() {
+    let q = Post::objects().defer(&["body"]).compile().unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    // Surviving columns: id, title, view_count — in model declaration order.
+    assert!(
+        stmt.sql
+            .starts_with(r#"SELECT "id", "title", "view_count" FROM "do_post""#),
+        "defer: {}",
+        stmt.sql
+    );
+    assert!(!stmt.sql.contains(r#""body""#), "{}", stmt.sql);
+}
+
+#[test]
+fn defer_multiple_cols_excludes_all_named() {
+    let q = Post::objects()
+        .defer(&["body", "view_count"])
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql
+            .starts_with(r#"SELECT "id", "title" FROM "do_post""#),
+        "defer multi: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn defer_empty_list_returns_all_columns() {
+    // Edge case: `.defer(&[])` is a semantic no-op — every column
+    // survives. Matches Django's behavior.
+    let q = Post::objects().defer(&[]).compile().unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql
+            .starts_with(r#"SELECT "id", "title", "body", "view_count" FROM "do_post""#),
+        "defer(empty): {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn only_preserves_where_clause() {
+    use rustango::core::Column as _;
+    let q = Post::objects()
+        .where_(Post::view_count.gt(100))
+        .only(&["id", "title"])
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"WHERE "view_count" > $1"#),
+        "where survives: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn only_with_typo_errors_at_compile() {
+    let err = Post::objects().only(&["id", "nope"]).compile().unwrap_err();
+    assert!(
+        matches!(err, QueryError::UnknownField { ref field, .. } if field == "nope"),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn defer_with_typo_errors_at_compile() {
+    // A typo'd defer column shouldn't silently project all cols —
+    // surface UnknownField so the caller learns about the typo.
+    let err = Post::objects().defer(&["nope_col"]).compile().unwrap_err();
+    assert!(
+        matches!(err, QueryError::UnknownField { ref field, .. } if field == "nope_col"),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn only_empty_list_errors_at_compile() {
+    // `.only(&[])` is asking for "no columns" — same shape as
+    // `.values_dict(&[])`, same error.
+    let err = Post::objects().only(&[]).compile().unwrap_err();
+    assert!(
+        matches!(err, QueryError::EmptyValuesProjection),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn defer_and_only_compose_with_order_limit() {
+    let q = Post::objects()
+        .order_by(&[("id", false)])
+        .limit(5)
+        .only(&["id", "title"])
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(stmt.sql.contains("ORDER BY \"id\""), "{}", stmt.sql);
+    assert!(stmt.sql.contains("LIMIT 5"), "{}", stmt.sql);
+}

--- a/crates/rustango/tests/defer_only_live.rs
+++ b/crates/rustango/tests/defer_only_live.rs
@@ -1,0 +1,116 @@
+#![cfg(feature = "postgres")]
+//! Live PG test for `QuerySet::defer` / `QuerySet::only` (issue #20).
+//! Verifies the projection actually skips columns at the wire level —
+//! the returned HashMap should contain the kept keys and NOT contain
+//! the deferred ones. Skips silently when `DATABASE_URL` is unset.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use rustango::core::SqlValue;
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "do_post_live")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 64)]
+    pub title: String,
+    /// Pretend this is a multi-kilobyte TEXT column the user wants to
+    /// skip on list views.
+    pub body: String,
+    pub view_count: i64,
+}
+
+fn lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn fresh_pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pg = sqlx::PgPool::connect(&url).await.ok()?;
+    sqlx::query(r#"DROP TABLE IF EXISTS "do_post_live" CASCADE"#)
+        .execute(&pg)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"
+        CREATE TABLE "do_post_live" (
+            id BIGSERIAL PRIMARY KEY,
+            title VARCHAR(64) NOT NULL,
+            body TEXT NOT NULL,
+            view_count BIGINT NOT NULL
+        )
+        "#,
+    )
+    .execute(&pg)
+    .await
+    .unwrap();
+    let pool = Pool::Postgres(pg);
+    for (title, body, vc) in [
+        ("First", "lots of body text 1", 10_i64),
+        ("Second", "lots of body text 2", 20),
+        ("Third", "lots of body text 3", 30),
+    ] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: title.into(),
+            body: body.into(),
+            view_count: vc,
+        };
+        p.insert_pool(&pool).await.unwrap();
+    }
+    Some(pool)
+}
+
+/// `.only(&["id", "title"])` returns only id + title — the body
+/// column is never touched at the wire level.
+#[tokio::test]
+async fn only_returns_just_requested_cols() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+        .only(&["id", "title"])
+        .fetch(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(rows.len(), 3);
+    for row in &rows {
+        assert_eq!(row.len(), 2, "only id + title: {row:?}");
+        assert!(row.contains_key("id"));
+        assert!(row.contains_key("title"));
+        assert!(!row.contains_key("body"));
+        assert!(!row.contains_key("view_count"));
+    }
+}
+
+/// `.defer(&["body"])` returns every column EXCEPT body — id, title,
+/// and view_count survive.
+#[tokio::test]
+async fn defer_returns_all_cols_except_excluded() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let rows: Vec<HashMap<String, SqlValue>> =
+        Post::objects().defer(&["body"]).fetch(&pool).await.unwrap();
+
+    assert_eq!(rows.len(), 3);
+    for row in &rows {
+        assert_eq!(row.len(), 3, "id + title + view_count: {row:?}");
+        assert!(row.contains_key("id"));
+        assert!(row.contains_key("title"));
+        assert!(row.contains_key("view_count"));
+        assert!(!row.contains_key("body"));
+    }
+}

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -409,6 +409,30 @@ let ids: Vec<i64> = Post::objects()
 
 **Why not change the existing `.values()` to do pure projection?** `QuerySet::values(cols)` already promotes to [`AggregateBuilder`] for the GROUP BY auto-inference path (issue #75). Renaming would break ~20 existing call sites. The new `.values_dict()` / `.values_list()` / `.values_list_flat()` chain methods sit alongside, leaving the aggregate path untouched. The pre-existing `QueryError::ValuesRequiresAggregate` error still fires for `.values(cols).compile()` without a subsequent `.annotate(...)` — its message now points callers at the new pure-projection methods.
 
+### Column pruning — `.defer()` / `.only()`
+
+Django's [`.defer('big_field')` / `.only('id', 'name')`](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#defer) — issue #20. Same projection IR as `.values_dict()` (above), exposed in Django's exclusion-list / inclusion-list shape. Use on wide tables where TEXT / BLOB / JSONB columns blow up list-view IO costs:
+
+```rust
+// .only(...) — fetch only the named columns.
+let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+    .where_(Post::published.eq(true))
+    .only(&["id", "title"])
+    .fetch(&pool).await?;
+
+// .defer(...) — fetch everything except the named columns.
+// Useful for "list view: skip body / metadata / large JSON".
+let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+    .defer(&["body", "raw_html"])
+    .fetch(&pool).await?;
+```
+
+**Semantics**: `.only(&[cols])` is a synonym for `.values_dict(cols)` — same IR, same return shape, separate entry point for Django-shape readability. `.defer(&[cols])` computes the complement against the model schema (every scalar column on the model EXCEPT the listed ones) and routes to the same path.
+
+**Caveat — return type differs from Django.** Django's `.only()` / `.defer()` return partially-hydrated `Model` instances where the deferred fields lazy-load on attribute access. rustango has no equivalent of Python's descriptor magic; the return shape is `Vec<HashMap<String, SqlValue>>` (or `Vec<Vec<SqlValue>>` if you swap in `.values_list(...)` instead). Typed partial-row decode is queued for a future slice.
+
+**Typo-safety**: `.defer(&["nope_col"])` surfaces `QueryError::UnknownField` at `.compile()` time — the typo doesn't silently turn into "project all columns." `.only(&[])` surfaces `QueryError::EmptyValuesProjection`; `.defer(&[])` is a semantic no-op (projects every column).
+
 ### Regex lookups — `.regex()` / `.iregex()` and negated variants
 
 Django's [`__regex` / `__iregex`](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#regex) — issue #26. Match a column against a regular-expression pattern, with case-sensitive and case-insensitive flavors plus negated forms.


### PR DESCRIPTION
**Stacked on #115 (issue #22)** — depends on the `SelectQuery::projection` IR field. Will rebase onto main once #115 merges.

## Summary

- Django parity for `.defer('big_field')` / `.only('id', 'name')` — column pruning on read for wide tables.
- Both methods lower to the projection IR from #115 (no new IR), exposed in Django's exclusion-list / inclusion-list shape.
- `.only(&[cols])` is a synonym for `.values_dict(cols)`; `.defer(&[cols])` computes the complement against the model schema.
- Return-shape caveat: rustango returns `Vec<HashMap<String, SqlValue>>` (not partially-hydrated `Model` instances like Django) — no Rust analog of Python's descriptor magic. Typed partial-row decode queued as a future slice.
- Typo-safe: `.defer(&[\"nope_col\"])` surfaces `QueryError::UnknownField` at `.compile()` (not silently absorbed into \"project everything\").

## Test plan

- [x] 9 emission tests (`tests/defer_only_emission.rs`) — column-list semantics, declaration-order preservation, WHERE / ORDER / LIMIT composition, typo errors, empty-list errors.
- [x] 2 live PG tests (`tests/defer_only_live.rs`) — verify deferred columns don't come back at the wire level.
- [x] `cargo build --no-default-features --features sqlite,tenancy` — SQLite-tenancy litmus passes.
- [x] `cargo test --workspace --all-features --no-run` — all-features build clean.
- [x] `cargo test -p rustango --lib --features tenancy,mysql,sqlite` — 1553 lib tests pass.

Closes #20.