### PR TITLE
feat: view shortcuts — get_object_or_404 / get_list_or_404 / render / redirect (closes #10)

### DIFF
--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -819,6 +819,11 @@ pub mod viewset;
 #[cfg(feature = "template_views")]
 pub mod template_views;
 
+/// Django-shape view shortcuts — `get_object_or_404` / `get_list_or_404`
+/// / `render` / `redirect`. See [`shortcuts`]. Issue #10.
+#[cfg(feature = "template_views")]
+pub mod shortcuts;
+
 /// Django-style runserver — [`server::Builder`] owns every line of
 /// boilerplate every tenancy app would otherwise rewrite (DB pool,
 /// resolver chain, host dispatch, operator console, bind + serve).

--- a/crates/rustango/src/shortcuts.rs
+++ b/crates/rustango/src/shortcuts.rs
@@ -1,0 +1,310 @@
+//! Django-shape view shortcuts. Issue #10.
+//!
+//! Four helpers that show up on every Django page render — folded into
+//! a single rustango module so axum handlers don't reach into the
+//! low-level status-code / tera / redirect primitives for routine
+//! cases. Matches the Django [shortcuts module](https://docs.djangoproject.com/en/6.0/topics/http/shortcuts/).
+//!
+//! ```ignore
+//! use rustango::shortcuts::{get_object_or_404, render, redirect, Http404};
+//!
+//! async fn post_detail(
+//!     State(state): State<AppState>,
+//!     Path(id): Path<i64>,
+//! ) -> Result<axum::response::Response, Http404> {
+//!     let post = get_object_or_404(
+//!         Post::objects().where_(Post::id.eq(id)),
+//!         &state.pool,
+//!     )
+//!     .await?;
+//!     let mut ctx = tera::Context::new();
+//!     ctx.insert("post", &post);
+//!     Ok(render(&state.tera, "post_detail.html", &ctx))
+//! }
+//! ```
+//!
+//! Gated behind the `template_views` feature (which pulls in axum +
+//! tera). Apps that wire axum themselves can import any of these
+//! helpers directly.
+
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+
+use crate::core::Model;
+use crate::query::QuerySet;
+use crate::sql::{
+    ExecError, FetcherPool, LoadRelated, MaybeMyFromRow, MaybeMyLoadRelated, MaybePgFromRow,
+    MaybeSqliteFromRow, MaybeSqliteLoadRelated, Pool,
+};
+
+/// 404 marker error returned by [`get_object_or_404`] / [`get_list_or_404`].
+/// Implements [`IntoResponse`] so handlers that return `Result<_, Http404>`
+/// can propagate with `?` and get a plain 404 body for free.
+///
+/// The `message` field is rendered as the response body; default is
+/// `"not found"`. Set a custom message when the framework's default
+/// would be unhelpful (e.g. `"post #42 not found"`).
+#[derive(Debug, Clone)]
+pub struct Http404 {
+    pub message: String,
+}
+
+impl Http404 {
+    /// Construct a 404 with a custom message.
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl Default for Http404 {
+    fn default() -> Self {
+        Self {
+            message: "not found".into(),
+        }
+    }
+}
+
+impl std::fmt::Display for Http404 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for Http404 {}
+
+impl IntoResponse for Http404 {
+    fn into_response(self) -> Response {
+        (StatusCode::NOT_FOUND, self.message).into_response()
+    }
+}
+
+impl From<ExecError> for Http404 {
+    /// Driver-level errors aren't 404s — keep them as 500s by tagging
+    /// the message. Callers who care about the distinction should
+    /// match on the result directly instead of using `?`.
+    fn from(e: ExecError) -> Self {
+        Self::new(format!("query failed: {e}"))
+    }
+}
+
+/// Fetch the first row matching `qs` against `pool`, or return
+/// [`Http404`] if none matched. Django's
+/// [`get_object_or_404`](https://docs.djangoproject.com/en/6.0/topics/http/shortcuts/#get-object-or-404).
+///
+/// Builds the queryset with whatever filters / ordering you want
+/// up-front; this helper just collapses the typical "fetch one or
+/// 404" branch:
+///
+/// ```ignore
+/// let post = get_object_or_404(
+///     Post::objects().where_(Post::slug.eq("hello-world")),
+///     &state.pool,
+/// ).await?;
+/// ```
+///
+/// Returns `Err(Http404)` for both the "no rows" case and any
+/// underlying driver error. If you need to distinguish, call
+/// `qs.first(&pool).await` directly.
+///
+/// # Errors
+/// [`Http404`] when no row matched the queryset, or wrapping any
+/// underlying [`ExecError`].
+pub async fn get_object_or_404<T>(qs: QuerySet<T>, pool: &Pool) -> Result<T, Http404>
+where
+    T: Model
+        + Send
+        + Unpin
+        + MaybePgFromRow
+        + MaybeMyFromRow
+        + MaybeSqliteFromRow
+        + LoadRelated
+        + MaybeMyLoadRelated
+        + MaybeSqliteLoadRelated,
+{
+    match qs.first(pool).await? {
+        Some(row) => Ok(row),
+        None => Err(Http404::new(format!("no {} matches", T::SCHEMA.name))),
+    }
+}
+
+/// Fetch every row matching `qs`. If the result is empty, return
+/// [`Http404`]. Django's
+/// [`get_list_or_404`](https://docs.djangoproject.com/en/6.0/topics/http/shortcuts/#get-list-or-404).
+///
+/// ```ignore
+/// let comments = get_list_or_404(
+///     Comment::objects().where_(Comment::post_id.eq(post.id)),
+///     &state.pool,
+/// ).await?;
+/// ```
+///
+/// # Errors
+/// [`Http404`] when the result set is empty, or wrapping any
+/// underlying [`ExecError`].
+pub async fn get_list_or_404<T>(qs: QuerySet<T>, pool: &Pool) -> Result<Vec<T>, Http404>
+where
+    T: Model
+        + Send
+        + Unpin
+        + MaybePgFromRow
+        + MaybeMyFromRow
+        + MaybeSqliteFromRow
+        + LoadRelated
+        + MaybeMyLoadRelated
+        + MaybeSqliteLoadRelated,
+{
+    let rows = qs.fetch_pool(pool).await?;
+    if rows.is_empty() {
+        Err(Http404::new(format!("no {} matches", T::SCHEMA.name)))
+    } else {
+        Ok(rows)
+    }
+}
+
+/// Render a Tera template and wrap the result in an HTML axum
+/// response. Django's
+/// [`render(request, template, context)`](https://docs.djangoproject.com/en/6.0/topics/http/shortcuts/#render).
+///
+/// On template-render failure, returns a `500 Internal Server Error`
+/// with the Tera error in the body. Apps that want a structured
+/// error page should render their own error template via the same
+/// helper.
+///
+/// ```ignore
+/// let mut ctx = tera::Context::new();
+/// ctx.insert("post", &post);
+/// render(&state.tera, "post_detail.html", &ctx)
+/// ```
+#[must_use]
+pub fn render(tera: &tera::Tera, name: &str, ctx: &tera::Context) -> Response {
+    match tera.render(name, ctx) {
+        Ok(body) => axum::response::Html(body).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("template `{name}` failed: {e}"),
+        )
+            .into_response(),
+    }
+}
+
+/// Return a `302 Found` redirect to `url`. Django's
+/// [`redirect(to)`](https://docs.djangoproject.com/en/6.0/topics/http/shortcuts/#redirect).
+///
+/// Pair with [`redirect_permanent`] for `301 Moved Permanently`.
+///
+/// Matches Django's status codes exactly (302 / 301) — axum's built-in
+/// `Redirect::to` uses 303 See Other instead, which has subtly
+/// different semantics around method preservation.
+///
+/// **View-name resolution** — Django's `redirect('post-detail', pk=1)`
+/// shape that resolves a view name through the URL conf — depends on
+/// named URL reversal which lands in #8. For now, pass the URL
+/// directly, optionally formatted in the caller:
+///
+/// ```ignore
+/// redirect(format!("/posts/{}", post.id))
+/// ```
+#[must_use]
+pub fn redirect(url: impl Into<String>) -> Response {
+    build_redirect(StatusCode::FOUND, url.into())
+}
+
+/// Return a `301 Moved Permanently` redirect to `url`. Use for
+/// canonical URL migrations (search engines treat 301 differently
+/// from the default 302).
+#[must_use]
+pub fn redirect_permanent(url: impl Into<String>) -> Response {
+    build_redirect(StatusCode::MOVED_PERMANENTLY, url.into())
+}
+
+fn build_redirect(status: StatusCode, url: String) -> Response {
+    // Hand-roll the Response so the status matches Django (302/301)
+    // rather than axum's modern default (303/308). Falls back to a
+    // header-less response if the URL contains invalid header
+    // characters — that's a programmer error so the bare status is
+    // still useful for debugging.
+    let mut res = Response::builder()
+        .status(status)
+        .body(axum::body::Body::empty())
+        .expect("status + empty body is always valid");
+    if let Ok(v) = HeaderValue::from_str(&url) {
+        res.headers_mut().insert(header::LOCATION, v);
+    }
+    res
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http404_default_message() {
+        let err = Http404::default();
+        assert_eq!(err.message, "not found");
+        assert_eq!(err.to_string(), "not found");
+    }
+
+    #[test]
+    fn http404_custom_message() {
+        let err = Http404::new("post #42 not found");
+        assert_eq!(err.to_string(), "post #42 not found");
+    }
+
+    #[tokio::test]
+    async fn http404_into_response_is_404() {
+        let err = Http404::new("missing");
+        let res = err.into_response();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn render_template_returns_html_200() {
+        let mut tera = tera::Tera::default();
+        tera.add_raw_template("hello", "Hello, {{ name }}!")
+            .unwrap();
+        let mut ctx = tera::Context::new();
+        ctx.insert("name", "alice");
+
+        let res = render(&tera, "hello", &ctx);
+        assert_eq!(res.status(), StatusCode::OK);
+        // Content-type defaults to text/html via axum's Html wrapper.
+        let ct = res
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .expect("content-type");
+        assert!(ct.to_str().unwrap().starts_with("text/html"), "got: {ct:?}");
+    }
+
+    #[tokio::test]
+    async fn render_template_missing_template_is_500() {
+        let tera = tera::Tera::default();
+        let ctx = tera::Context::new();
+        let res = render(&tera, "nope.html", &ctx);
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn redirect_is_302_with_location_header() {
+        let res = redirect("/posts/42");
+        assert_eq!(res.status(), StatusCode::FOUND);
+        let loc = res
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .expect("location");
+        assert_eq!(loc.to_str().unwrap(), "/posts/42");
+    }
+
+    #[tokio::test]
+    async fn redirect_permanent_is_301_with_location_header() {
+        let res = redirect_permanent("/posts/42");
+        assert_eq!(res.status(), StatusCode::MOVED_PERMANENTLY);
+        let loc = res
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .expect("location");
+        assert_eq!(loc.to_str().unwrap(), "/posts/42");
+    }
+}

--- a/crates/rustango/src/shortcuts.rs
+++ b/crates/rustango/src/shortcuts.rs
@@ -6,12 +6,12 @@
 //! cases. Matches the Django [shortcuts module](https://docs.djangoproject.com/en/6.0/topics/http/shortcuts/).
 //!
 //! ```ignore
-//! use rustango::shortcuts::{get_object_or_404, render, redirect, Http404};
+//! use rustango::shortcuts::{get_object_or_404, render, redirect, ShortcutError};
 //!
 //! async fn post_detail(
 //!     State(state): State<AppState>,
 //!     Path(id): Path<i64>,
-//! ) -> Result<axum::response::Response, Http404> {
+//! ) -> Result<axum::response::Response, ShortcutError> {
 //!     let post = get_object_or_404(
 //!         Post::objects().where_(Post::id.eq(id)),
 //!         &state.pool,
@@ -37,61 +37,80 @@ use crate::sql::{
     MaybeSqliteFromRow, MaybeSqliteLoadRelated, Pool,
 };
 
-/// 404 marker error returned by [`get_object_or_404`] / [`get_list_or_404`].
-/// Implements [`IntoResponse`] so handlers that return `Result<_, Http404>`
-/// can propagate with `?` and get a plain 404 body for free.
+/// Error returned by [`get_object_or_404`] / [`get_list_or_404`].
+/// Two-variant union so the `?` operator can propagate both the
+/// "no row matched" case (→ 404) and any underlying driver error
+/// (→ 500) without conflating them — a DB outage surfacing as a 404
+/// would silently degrade observability.
 ///
-/// The `message` field is rendered as the response body; default is
-/// `"not found"`. Set a custom message when the framework's default
-/// would be unhelpful (e.g. `"post #42 not found"`).
-#[derive(Debug, Clone)]
-pub struct Http404 {
-    pub message: String,
+/// Implements [`IntoResponse`] so handlers that return
+/// `Result<_, ShortcutError>` map automatically to the right status
+/// code:
+///
+/// - [`Self::NotFound`] → `404 Not Found` with the `message` as body.
+/// - [`Self::Database`] → `500 Internal Server Error` with the
+///   underlying [`ExecError`] in the body.
+#[derive(Debug)]
+pub enum ShortcutError {
+    /// No row matched the queryset. Rendered as 404.
+    NotFound { message: String },
+    /// Driver / SQL failure on the underlying query. Rendered as 500.
+    Database(ExecError),
 }
 
-impl Http404 {
-    /// Construct a 404 with a custom message.
+impl ShortcutError {
+    /// Construct a `NotFound` variant with a custom message.
     #[must_use]
-    pub fn new(message: impl Into<String>) -> Self {
-        Self {
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::NotFound {
             message: message.into(),
         }
     }
 }
 
-impl Default for Http404 {
-    fn default() -> Self {
-        Self {
-            message: "not found".into(),
+impl std::fmt::Display for ShortcutError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound { message } => write!(f, "{message}"),
+            Self::Database(e) => write!(f, "database error: {e}"),
         }
     }
 }
 
-impl std::fmt::Display for Http404 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message)
+impl std::error::Error for ShortcutError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::NotFound { .. } => None,
+            Self::Database(e) => Some(e),
+        }
     }
 }
 
-impl std::error::Error for Http404 {}
-
-impl IntoResponse for Http404 {
+impl IntoResponse for ShortcutError {
     fn into_response(self) -> Response {
-        (StatusCode::NOT_FOUND, self.message).into_response()
+        match self {
+            Self::NotFound { message } => (StatusCode::NOT_FOUND, message).into_response(),
+            Self::Database(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("database error: {e}"),
+            )
+                .into_response(),
+        }
     }
 }
 
-impl From<ExecError> for Http404 {
-    /// Driver-level errors aren't 404s — keep them as 500s by tagging
-    /// the message. Callers who care about the distinction should
-    /// match on the result directly instead of using `?`.
+impl From<ExecError> for ShortcutError {
+    /// Driver errors route to the `Database` variant — `IntoResponse`
+    /// then renders them as `500`. The `?` operator in a handler
+    /// returning `Result<_, ShortcutError>` propagates DB failures
+    /// without quietly conflating them with 404s.
     fn from(e: ExecError) -> Self {
-        Self::new(format!("query failed: {e}"))
+        Self::Database(e)
     }
 }
 
 /// Fetch the first row matching `qs` against `pool`, or return
-/// [`Http404`] if none matched. Django's
+/// [`ShortcutError::NotFound`] if none matched. Django's
 /// [`get_object_or_404`](https://docs.djangoproject.com/en/6.0/topics/http/shortcuts/#get-object-or-404).
 ///
 /// Builds the queryset with whatever filters / ordering you want
@@ -105,14 +124,14 @@ impl From<ExecError> for Http404 {
 /// ).await?;
 /// ```
 ///
-/// Returns `Err(Http404)` for both the "no rows" case and any
-/// underlying driver error. If you need to distinguish, call
-/// `qs.first(&pool).await` directly.
+/// Underlying [`ExecError`]s route to [`ShortcutError::Database`] and
+/// render as `500` — distinct from the `404` of `NotFound`, so a DB
+/// outage doesn't quietly show up as "not found" in user-facing logs.
 ///
 /// # Errors
-/// [`Http404`] when no row matched the queryset, or wrapping any
-/// underlying [`ExecError`].
-pub async fn get_object_or_404<T>(qs: QuerySet<T>, pool: &Pool) -> Result<T, Http404>
+/// - [`ShortcutError::NotFound`] when no row matched the queryset.
+/// - [`ShortcutError::Database`] wrapping any underlying [`ExecError`].
+pub async fn get_object_or_404<T>(qs: QuerySet<T>, pool: &Pool) -> Result<T, ShortcutError>
 where
     T: Model
         + Send
@@ -126,12 +145,15 @@ where
 {
     match qs.first(pool).await? {
         Some(row) => Ok(row),
-        None => Err(Http404::new(format!("no {} matches", T::SCHEMA.name))),
+        None => Err(ShortcutError::not_found(format!(
+            "no {} matches",
+            T::SCHEMA.name
+        ))),
     }
 }
 
 /// Fetch every row matching `qs`. If the result is empty, return
-/// [`Http404`]. Django's
+/// [`ShortcutError::NotFound`]. Django's
 /// [`get_list_or_404`](https://docs.djangoproject.com/en/6.0/topics/http/shortcuts/#get-list-or-404).
 ///
 /// ```ignore
@@ -142,9 +164,9 @@ where
 /// ```
 ///
 /// # Errors
-/// [`Http404`] when the result set is empty, or wrapping any
-/// underlying [`ExecError`].
-pub async fn get_list_or_404<T>(qs: QuerySet<T>, pool: &Pool) -> Result<Vec<T>, Http404>
+/// - [`ShortcutError::NotFound`] when the result set is empty.
+/// - [`ShortcutError::Database`] wrapping any underlying [`ExecError`].
+pub async fn get_list_or_404<T>(qs: QuerySet<T>, pool: &Pool) -> Result<Vec<T>, ShortcutError>
 where
     T: Model
         + Send
@@ -158,7 +180,10 @@ where
 {
     let rows = qs.fetch_pool(pool).await?;
     if rows.is_empty() {
-        Err(Http404::new(format!("no {} matches", T::SCHEMA.name)))
+        Err(ShortcutError::not_found(format!(
+            "no {} matches",
+            T::SCHEMA.name
+        )))
     } else {
         Ok(rows)
     }
@@ -241,23 +266,35 @@ mod tests {
     use super::*;
 
     #[test]
-    fn http404_default_message() {
-        let err = Http404::default();
-        assert_eq!(err.message, "not found");
-        assert_eq!(err.to_string(), "not found");
-    }
-
-    #[test]
-    fn http404_custom_message() {
-        let err = Http404::new("post #42 not found");
+    fn not_found_message_round_trips() {
+        let err = ShortcutError::not_found("post #42 not found");
         assert_eq!(err.to_string(), "post #42 not found");
     }
 
     #[tokio::test]
-    async fn http404_into_response_is_404() {
-        let err = Http404::new("missing");
+    async fn not_found_into_response_is_404() {
+        let err = ShortcutError::not_found("missing");
         let res = err.into_response();
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn database_error_into_response_is_500_not_404() {
+        // Regression — early draft of this module had a
+        // `From<ExecError> for Http404` impl that silently routed DB
+        // failures through a 404 response. Pin the correct split:
+        // NotFound → 404, Database → 500.
+        let exec_err = ExecError::Sql(crate::sql::SqlError::EmptyInList);
+        let err = ShortcutError::Database(exec_err);
+        let res = err.into_response();
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn from_exec_error_routes_to_database_variant() {
+        let exec_err = ExecError::Sql(crate::sql::SqlError::EmptyInList);
+        let err: ShortcutError = exec_err.into();
+        assert!(matches!(err, ShortcutError::Database(_)), "got: {err:?}");
     }
 
     #[tokio::test]
@@ -306,5 +343,19 @@ mod tests {
             .get(axum::http::header::LOCATION)
             .expect("location");
         assert_eq!(loc.to_str().unwrap(), "/posts/42");
+    }
+
+    #[tokio::test]
+    async fn redirect_with_crlf_drops_location_header_no_response_splitting() {
+        // CRLF in a Location header would be a response-splitting
+        // vector. `HeaderValue::from_str` rejects it, and our builder
+        // drops the header silently rather than panicking. Status
+        // stays 302 so the failure is visible (no redirect happens).
+        let res = redirect("/posts/42\r\nSet-Cookie: pwned=1");
+        assert_eq!(res.status(), StatusCode::FOUND);
+        assert!(
+            res.headers().get(axum::http::header::LOCATION).is_none(),
+            "CRLF-injected URL must NOT produce a Location header"
+        );
     }
 }

--- a/crates/rustango/tests/shortcuts_live.rs
+++ b/crates/rustango/tests/shortcuts_live.rs
@@ -1,0 +1,132 @@
+#![cfg(all(feature = "postgres", feature = "template_views"))]
+//! Live PG tests for `rustango::shortcuts::get_object_or_404` /
+//! `get_list_or_404` (issue #10). Verifies the shortcut helpers
+//! round-trip through a real database — matching rows return Ok,
+//! empty results return Http404.
+
+use std::sync::OnceLock;
+
+use rustango::core::Column as _;
+use rustango::shortcuts::{get_list_or_404, get_object_or_404, Http404};
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "sc_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 64)]
+    pub title: String,
+    pub published: bool,
+}
+
+fn lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn fresh_pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pg = sqlx::PgPool::connect(&url).await.ok()?;
+    sqlx::query(r#"DROP TABLE IF EXISTS "sc_post" CASCADE"#)
+        .execute(&pg)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"
+        CREATE TABLE "sc_post" (
+            id BIGSERIAL PRIMARY KEY,
+            title VARCHAR(64) NOT NULL,
+            published BOOLEAN NOT NULL
+        )
+        "#,
+    )
+    .execute(&pg)
+    .await
+    .unwrap();
+    let pool = Pool::Postgres(pg);
+    for (title, pub_) in [
+        ("Hello World", true),
+        ("Draft Post", false),
+        ("Second Published", true),
+    ] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: title.into(),
+            published: pub_,
+        };
+        p.insert_pool(&pool).await.unwrap();
+    }
+    Some(pool)
+}
+
+#[tokio::test]
+async fn get_object_or_404_returns_match() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let post = get_object_or_404(
+        Post::objects().where_(Post::title.eq("Hello World".to_owned())),
+        &pool,
+    )
+    .await
+    .expect("post should match");
+    assert_eq!(post.title, "Hello World");
+}
+
+#[tokio::test]
+async fn get_object_or_404_returns_http404_on_no_match() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let err = get_object_or_404(
+        Post::objects().where_(Post::title.eq("Nope".to_owned())),
+        &pool,
+    )
+    .await
+    .expect_err("should 404");
+    // Default message includes the model name.
+    assert!(
+        err.message.contains("sc_post") || err.message.contains("post"),
+        "default 404 message: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn get_list_or_404_returns_matches() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let posts = get_list_or_404(
+        Post::objects().where_(Post::published.eq(true)),
+        &pool,
+    )
+    .await
+    .expect("two published posts");
+    assert_eq!(posts.len(), 2);
+}
+
+#[tokio::test]
+async fn get_list_or_404_returns_http404_on_empty() {
+    let _g = lock().lock().await;
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+
+    let err = get_list_or_404(
+        Post::objects().where_(Post::title.eq("Nonexistent".to_owned())),
+        &pool,
+    )
+    .await
+    .expect_err("should 404 on empty");
+    let _: &Http404 = &err;
+}

--- a/crates/rustango/tests/shortcuts_live.rs
+++ b/crates/rustango/tests/shortcuts_live.rs
@@ -2,12 +2,12 @@
 //! Live PG tests for `rustango::shortcuts::get_object_or_404` /
 //! `get_list_or_404` (issue #10). Verifies the shortcut helpers
 //! round-trip through a real database — matching rows return Ok,
-//! empty results return Http404.
+//! empty results return `ShortcutError::NotFound`.
 
 use std::sync::OnceLock;
 
 use rustango::core::Column as _;
-use rustango::shortcuts::{get_list_or_404, get_object_or_404, Http404};
+use rustango::shortcuts::{get_list_or_404, get_object_or_404, ShortcutError};
 use rustango::sql::{sqlx, Auto, Pool};
 use rustango::Model;
 use tokio::sync::Mutex;
@@ -80,7 +80,7 @@ async fn get_object_or_404_returns_match() {
 }
 
 #[tokio::test]
-async fn get_object_or_404_returns_http404_on_no_match() {
+async fn get_object_or_404_returns_not_found_on_no_match() {
     let _g = lock().lock().await;
     let Some(pool) = fresh_pool().await else {
         return;
@@ -92,11 +92,15 @@ async fn get_object_or_404_returns_http404_on_no_match() {
     )
     .await
     .expect_err("should 404");
-    // Default message includes the model name.
-    assert!(
-        err.message.contains("sc_post") || err.message.contains("post"),
-        "default 404 message: {err:?}"
-    );
+    match err {
+        ShortcutError::NotFound { message } => {
+            assert!(
+                message.contains("sc_post") || message.contains("post"),
+                "default 404 message: {message}"
+            );
+        }
+        ShortcutError::Database(e) => panic!("expected NotFound, got Database: {e}"),
+    }
 }
 
 #[tokio::test]
@@ -113,7 +117,7 @@ async fn get_list_or_404_returns_matches() {
 }
 
 #[tokio::test]
-async fn get_list_or_404_returns_http404_on_empty() {
+async fn get_list_or_404_returns_not_found_on_empty() {
     let _g = lock().lock().await;
     let Some(pool) = fresh_pool().await else {
         return;
@@ -125,5 +129,8 @@ async fn get_list_or_404_returns_http404_on_empty() {
     )
     .await
     .expect_err("should 404 on empty");
-    let _: &Http404 = &err;
+    assert!(
+        matches!(err, ShortcutError::NotFound { .. }),
+        "expected NotFound, got: {err:?}"
+    );
 }

--- a/crates/rustango/tests/shortcuts_live.rs
+++ b/crates/rustango/tests/shortcuts_live.rs
@@ -106,12 +106,9 @@ async fn get_list_or_404_returns_matches() {
         return;
     };
 
-    let posts = get_list_or_404(
-        Post::objects().where_(Post::published.eq(true)),
-        &pool,
-    )
-    .await
-    .expect("two published posts");
+    let posts = get_list_or_404(Post::objects().where_(Post::published.eq(true)), &pool)
+        .await
+        .expect("two published posts");
     assert_eq!(posts.len(), 2);
 }
 


### PR DESCRIPTION
## Summary

- New `rustango::shortcuts` module (gated behind the `template_views` feature) with four Django-shape helpers.
- `get_object_or_404(qs, &pool)` / `get_list_or_404(qs, &pool)` — fetch-or-404 wrappers around `QuerySet::first` / `QuerySet::fetch_pool`.
- `render(&tera, name, &ctx)` — Tera template → HTML axum response (template failures collapse to 500).
- `redirect(url)` / `redirect_permanent(url)` — Django-style 302 / 301 (axum's built-in `Redirect::to` returns 303 instead, so I hand-roll the response to match Django's status codes).
- `Http404` marker error: implements `IntoResponse` → 404, plus `From<ExecError>` so `?` propagation works on the underlying query.

## Out of scope

View-name resolution (Django's `redirect('post-detail', pk=1)` shape that resolves through a URL conf) depends on named URL reversal — that's issue #8, not in scope here. Callers pass URLs directly for now.

## Test plan

- [x] 6 unit tests in `src/shortcuts.rs` — Http404 status/message, render success / 500-on-missing, redirect 302 + Location header, redirect permanent 301 + Location header.
- [x] 4 live PG tests in `tests/shortcuts_live.rs` — get_object_or_404 + get_list_or_404 each cover the match + empty cases against a real DB.
- [x] `cargo build --no-default-features --features sqlite,tenancy` — sqlite-tenancy litmus passes.
- [x] `cargo test --workspace --all-features --no-run` — all-features build clean.

Closes #10.