### PR TITLE
feat: rustango::urls — named URL reversal (closes #8 partial)

### DIFF
--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -830,6 +830,10 @@ pub mod shortcuts;
 #[cfg(feature = "template_views")]
 pub mod humanize;
 
+/// Named URL reversal — Django's `reverse(name, params)` +
+/// `get_absolute_url()`. Pair with [`register_url!`]. Issue #8.
+pub mod urls;
+
 /// Django-style runserver — [`server::Builder`] owns every line of
 /// boilerplate every tenancy app would otherwise rewrite (DB pool,
 /// resolver chain, host dispatch, operator console, bind + serve).

--- a/crates/rustango/src/urls.rs
+++ b/crates/rustango/src/urls.rs
@@ -1,0 +1,275 @@
+//! Named URL reversal — Django's `reverse()` + `get_absolute_url()`.
+//! Issue #8.
+//!
+//! Routes can be registered with a stable name at module-load time
+//! via the [`register_url!`] macro, then resolved back to a URL string
+//! through [`reverse`]. The shape mirrors Django's URL conf:
+//!
+//! ```ignore
+//! use rustango::register_url;
+//! use rustango::urls::reverse;
+//! use std::collections::HashMap;
+//!
+//! // At module scope — registers globally via `inventory`.
+//! register_url!("post-detail", "/posts/{id}");
+//! register_url!("home", "/");
+//!
+//! // Anywhere at runtime.
+//! let url = reverse("home", &HashMap::new()).unwrap();
+//! assert_eq!(url, "/");
+//!
+//! let mut p = HashMap::new();
+//! p.insert("id", "42".to_owned());
+//! let url = reverse("post-detail", &p).unwrap();
+//! assert_eq!(url, "/posts/42");
+//! ```
+//!
+//! Path-template placeholders use axum 0.8's `{name}` shape. Param
+//! values are percent-encoded on substitution so caller-supplied
+//! values are safe even when they contain `/` / `?` / `#`. Missing
+//! or extra params return a [`ReverseError`] at call time — there's
+//! no compile-time check today (would require either codegen or a
+//! shared sentinel; queued as a future enhancement).
+//!
+//! Namespaced reverse (Django's `reverse("app:detail")` /
+//! `include("app.urls", namespace=...)`) is **out of scope for v1** —
+//! the same plain name appears in the global registry. Two PRs in the
+//! same binary registering `"detail"` will collide; defer namespace
+//! support until users hit it.
+
+use std::collections::{HashMap, HashSet};
+
+/// A named route — pattern + stable name. Registered at static-init
+/// time via [`register_url!`] (which calls `inventory::submit!`
+/// under the hood) and looked up by [`reverse`] at runtime.
+#[derive(Debug, Clone)]
+pub struct NamedRoute {
+    /// Stable name used by [`reverse`] / Django's `{% url %}`.
+    pub name: &'static str,
+    /// axum 0.8 path template — placeholders use `{name}` syntax.
+    pub pattern: &'static str,
+}
+
+inventory::collect!(NamedRoute);
+
+/// Register a named URL pattern at module-load time. Picks up
+/// `rustango::inventory` so callers don't need their own dep.
+///
+/// ```ignore
+/// register_url!("post-detail", "/posts/{id}");
+/// ```
+#[macro_export]
+macro_rules! register_url {
+    ($name:expr, $pattern:expr) => {
+        $crate::inventory::submit! {
+            $crate::urls::NamedRoute {
+                name: $name,
+                pattern: $pattern,
+            }
+        }
+    };
+}
+
+/// Failure modes for [`reverse`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ReverseError {
+    /// No `register_url!("name", ...)` has run for this name. Either
+    /// the registration is in a module that wasn't loaded, or the
+    /// name is a typo.
+    #[error("no URL registered for name `{0}`")]
+    UnknownName(String),
+
+    /// The pattern has a `{param}` placeholder but `params` didn't
+    /// include a value for it.
+    #[error("URL `{name}` requires placeholder `{{{param}}}` — pass it in `params`")]
+    MissingParam { name: String, param: String },
+
+    /// `params` had keys that don't appear in the pattern. Surfaced
+    /// to catch typos that would otherwise silently disappear.
+    #[error("URL `{name}` doesn't have a `{{{param}}}` placeholder")]
+    UnexpectedParam { name: String, param: String },
+}
+
+/// Resolve a registered name + parameters into a concrete URL string.
+///
+/// Substitutes every `{name}` placeholder in the pattern with the
+/// corresponding entry in `params`, percent-encoding the value so the
+/// resulting URL is safe to use as a `Location` header or template
+/// link. Extra `params` keys that don't appear in the pattern surface
+/// as [`ReverseError::UnexpectedParam`] — strict by default so typos
+/// don't disappear.
+///
+/// # Errors
+/// - [`ReverseError::UnknownName`] if no route matches `name`.
+/// - [`ReverseError::MissingParam`] if a placeholder has no value.
+/// - [`ReverseError::UnexpectedParam`] if `params` has an extra key.
+pub fn reverse(name: &str, params: &HashMap<&str, String>) -> Result<String, ReverseError> {
+    let route = inventory::iter::<NamedRoute>
+        .into_iter()
+        .find(|r| r.name == name)
+        .ok_or_else(|| ReverseError::UnknownName(name.to_owned()))?;
+    substitute(name, route.pattern, params)
+}
+
+/// Same as [`reverse`] but with `String` keys — convenience for the
+/// JSON / template-tag path where keys come from dynamic input.
+///
+/// # Errors
+/// As [`reverse`].
+pub fn reverse_owned(name: &str, params: &HashMap<String, String>) -> Result<String, ReverseError> {
+    let route = inventory::iter::<NamedRoute>
+        .into_iter()
+        .find(|r| r.name == name)
+        .ok_or_else(|| ReverseError::UnknownName(name.to_owned()))?;
+    let borrowed: HashMap<&str, String> = params
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.clone()))
+        .collect();
+    substitute(name, route.pattern, &borrowed)
+}
+
+fn substitute(
+    name: &str,
+    pattern: &str,
+    params: &HashMap<&str, String>,
+) -> Result<String, ReverseError> {
+    let mut out = String::with_capacity(pattern.len() + 16);
+    let mut used: HashSet<&str> = HashSet::new();
+    let mut chars = pattern.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '{' {
+            out.push(c);
+            continue;
+        }
+        // Read until the matching '}'. Bail with a clear error if the
+        // pattern has an unclosed placeholder — that's a programmer
+        // bug, but the message is more useful than a stuck loop.
+        let mut placeholder = String::new();
+        let mut closed = false;
+        for nc in chars.by_ref() {
+            if nc == '}' {
+                closed = true;
+                break;
+            }
+            placeholder.push(nc);
+        }
+        if !closed {
+            return Err(ReverseError::MissingParam {
+                name: name.to_owned(),
+                param: format!("(unclosed `{{{placeholder}`)"),
+            });
+        }
+        // Strip axum-style type annotations like `{id:int}` — axum 0.8
+        // doesn't use them by default but Django patterns sometimes
+        // carry `<int:id>`. We accept either `name` or `type:name`.
+        let key = placeholder.split(':').next_back().unwrap_or(&placeholder);
+        let value = params.get(key).ok_or_else(|| ReverseError::MissingParam {
+            name: name.to_owned(),
+            param: key.to_owned(),
+        })?;
+        out.push_str(&crate::url_codec::url_encode(value));
+        // Find the params key with the same identity (str pointer is
+        // unreliable since they come from the caller's HashMap). Look
+        // it up by string equality to mark "used."
+        if let Some((k, _)) = params.iter().find(|(k, _)| **k == key) {
+            used.insert(*k);
+        }
+    }
+    // Reject extra params.
+    for k in params.keys() {
+        if !used.contains(k) {
+            return Err(ReverseError::UnexpectedParam {
+                name: name.to_owned(),
+                param: (*k).to_owned(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Registered at module-init time via the macro. Names are
+    // prefixed `__test_` to keep collision risk low if other test
+    // files in the binary ever register routes too.
+    register_url!("__test_home", "/");
+    register_url!("__test_post_detail", "/posts/{id}");
+    register_url!("__test_two_args", "/users/{user_id}/posts/{post_id}");
+    register_url!("__test_typed_placeholder", "/items/{int:id}");
+
+    fn params(pairs: &[(&'static str, &str)]) -> HashMap<&'static str, String> {
+        pairs.iter().map(|(k, v)| (*k, (*v).to_owned())).collect()
+    }
+
+    #[test]
+    fn reverse_resolves_static_pattern() {
+        assert_eq!(reverse("__test_home", &HashMap::new()).unwrap(), "/");
+    }
+
+    #[test]
+    fn reverse_substitutes_single_placeholder() {
+        let p = params(&[("id", "42")]);
+        assert_eq!(reverse("__test_post_detail", &p).unwrap(), "/posts/42");
+    }
+
+    #[test]
+    fn reverse_substitutes_multiple_placeholders() {
+        let p = params(&[("user_id", "5"), ("post_id", "10")]);
+        assert_eq!(reverse("__test_two_args", &p).unwrap(), "/users/5/posts/10");
+    }
+
+    #[test]
+    fn reverse_percent_encodes_param_values() {
+        // `/` in a value must NOT escape the path segment.
+        let p = params(&[("id", "hello world")]);
+        let url = reverse("__test_post_detail", &p).unwrap();
+        assert_eq!(url, "/posts/hello%20world");
+    }
+
+    #[test]
+    fn reverse_unknown_name_errors() {
+        let err = reverse("nope_doesnt_exist", &HashMap::new()).unwrap_err();
+        assert!(matches!(err, ReverseError::UnknownName(ref n) if n == "nope_doesnt_exist"));
+    }
+
+    #[test]
+    fn reverse_missing_param_errors_with_param_name() {
+        let err = reverse("__test_post_detail", &HashMap::new()).unwrap_err();
+        match err {
+            ReverseError::MissingParam { name, param } => {
+                assert_eq!(name, "__test_post_detail");
+                assert_eq!(param, "id");
+            }
+            other => panic!("expected MissingParam, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reverse_unexpected_param_errors() {
+        let p = params(&[("id", "1"), ("typo_extra", "x")]);
+        let err = reverse("__test_post_detail", &p).unwrap_err();
+        assert!(
+            matches!(err, ReverseError::UnexpectedParam { ref param, .. } if param == "typo_extra"),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn reverse_accepts_axum_style_typed_placeholder() {
+        // Pattern `/items/{int:id}` — `id` is the parameter name.
+        let p = params(&[("id", "7")]);
+        assert_eq!(reverse("__test_typed_placeholder", &p).unwrap(), "/items/7");
+    }
+
+    #[test]
+    fn reverse_owned_takes_string_keyed_params() {
+        let mut p: HashMap<String, String> = HashMap::new();
+        p.insert("id".into(), "99".into());
+        assert_eq!(
+            reverse_owned("__test_post_detail", &p).unwrap(),
+            "/posts/99"
+        );
+    }
+}

--- a/crates/rustango/src/urls.rs
+++ b/crates/rustango/src/urls.rs
@@ -31,11 +31,29 @@
 //! no compile-time check today (would require either codegen or a
 //! shared sentinel; queued as a future enhancement).
 //!
+//! **Manual sync with axum routes**: `register_url!` only registers
+//! the *pattern string* with the reverse-lookup table — it does NOT
+//! mount a route on any axum `Router`. Callers must keep their
+//! axum routing in sync with their `register_url!` calls. A common
+//! shape is to put both side-by-side in `src/urls.rs`:
+//!
+//! ```ignore
+//! register_url!("post-detail", "/posts/{id}");
+//! pub fn router() -> axum::Router {
+//!     axum::Router::new().route("/posts/{id}", get(post_detail_view))
+//! }
+//! ```
+//!
+//! **Duplicate names**: two `register_url!("name", ...)` calls in the
+//! same binary collide silently — `reverse` picks the first match it
+//! finds in the inventory. Call [`duplicates`] at boot to surface any
+//! name registered more than once. Future work: a startup validator
+//! that turns this into a clean error before the server binds.
+//!
 //! Namespaced reverse (Django's `reverse("app:detail")` /
-//! `include("app.urls", namespace=...)`) is **out of scope for v1** —
-//! the same plain name appears in the global registry. Two PRs in the
-//! same binary registering `"detail"` will collide; defer namespace
-//! support until users hit it.
+//! `include("app.urls", namespace=...)`) is **out of scope for v1**.
+//! Use unique per-app name prefixes (`"posts:detail"` / `"users:detail"`)
+//! as a manual convention until namespace support lands.
 
 use std::collections::{HashMap, HashSet};
 
@@ -88,6 +106,45 @@ pub enum ReverseError {
     /// to catch typos that would otherwise silently disappear.
     #[error("URL `{name}` doesn't have a `{{{param}}}` placeholder")]
     UnexpectedParam { name: String, param: String },
+
+    /// The registered pattern is malformed — most commonly an
+    /// unclosed `{` placeholder. Programmer bug at `register_url!`
+    /// time; surfaces from `reverse` so it's at least catchable.
+    #[error("URL `{name}` has a malformed pattern: {detail}")]
+    MalformedPattern { name: String, detail: String },
+}
+
+/// Snapshot of the route registry — every entry registered via
+/// [`register_url!`] across every loaded module. Useful for boot-time
+/// diagnostics (see [`duplicates`]) or admin endpoints that surface
+/// the URL map.
+#[must_use]
+pub fn all_routes() -> Vec<&'static NamedRoute> {
+    inventory::iter::<NamedRoute>.into_iter().collect()
+}
+
+/// List every name that's been registered more than once. Empty
+/// vec on a clean registry. Call at app boot — duplicates surface
+/// as silent "first wins" otherwise.
+///
+/// ```ignore
+/// let dups = rustango::urls::duplicates();
+/// if !dups.is_empty() {
+///     panic!("duplicate URL registrations: {dups:?}");
+/// }
+/// ```
+#[must_use]
+pub fn duplicates() -> Vec<&'static str> {
+    let mut seen: std::collections::HashMap<&'static str, usize> = std::collections::HashMap::new();
+    for r in inventory::iter::<NamedRoute> {
+        *seen.entry(r.name).or_insert(0) += 1;
+    }
+    let mut out: Vec<&'static str> = seen
+        .into_iter()
+        .filter_map(|(name, count)| (count > 1).then_some(name))
+        .collect();
+    out.sort_unstable();
+    out
 }
 
 /// Resolve a registered name + parameters into a concrete URL string.
@@ -134,16 +191,16 @@ fn substitute(
     params: &HashMap<&str, String>,
 ) -> Result<String, ReverseError> {
     let mut out = String::with_capacity(pattern.len() + 16);
-    let mut used: HashSet<&str> = HashSet::new();
+    let mut used: HashSet<String> = HashSet::new();
     let mut chars = pattern.chars().peekable();
     while let Some(c) = chars.next() {
         if c != '{' {
             out.push(c);
             continue;
         }
-        // Read until the matching '}'. Bail with a clear error if the
-        // pattern has an unclosed placeholder — that's a programmer
-        // bug, but the message is more useful than a stuck loop.
+        // Read until the matching '}'. An unclosed placeholder is a
+        // programmer bug in the registered pattern — surface it
+        // cleanly via `MalformedPattern`.
         let mut placeholder = String::new();
         let mut closed = false;
         for nc in chars.by_ref() {
@@ -154,30 +211,25 @@ fn substitute(
             placeholder.push(nc);
         }
         if !closed {
-            return Err(ReverseError::MissingParam {
+            return Err(ReverseError::MalformedPattern {
                 name: name.to_owned(),
-                param: format!("(unclosed `{{{placeholder}`)"),
+                detail: format!("unclosed placeholder starting at `{{{placeholder}`"),
             });
         }
-        // Strip axum-style type annotations like `{id:int}` — axum 0.8
-        // doesn't use them by default but Django patterns sometimes
-        // carry `<int:id>`. We accept either `name` or `type:name`.
+        // Strip axum-style / Django-style type annotations like
+        // `{id:int}` — accept both `name` and `type:name` shapes so
+        // patterns ported from Django routes work as-is.
         let key = placeholder.split(':').next_back().unwrap_or(&placeholder);
         let value = params.get(key).ok_or_else(|| ReverseError::MissingParam {
             name: name.to_owned(),
             param: key.to_owned(),
         })?;
         out.push_str(&crate::url_codec::url_encode(value));
-        // Find the params key with the same identity (str pointer is
-        // unreliable since they come from the caller's HashMap). Look
-        // it up by string equality to mark "used."
-        if let Some((k, _)) = params.iter().find(|(k, _)| **k == key) {
-            used.insert(*k);
-        }
+        used.insert(key.to_owned());
     }
-    // Reject extra params.
+    // Reject extra params (typo-safety).
     for k in params.keys() {
-        if !used.contains(k) {
+        if !used.contains(*k) {
             return Err(ReverseError::UnexpectedParam {
                 name: name.to_owned(),
                 param: (*k).to_owned(),
@@ -271,5 +323,47 @@ mod tests {
             reverse_owned("__test_post_detail", &p).unwrap(),
             "/posts/99"
         );
+    }
+
+    // Pattern intentionally malformed — unclosed `{`.
+    register_url!("__test_malformed", "/items/{unclosed");
+
+    #[test]
+    fn reverse_malformed_pattern_surfaces_dedicated_error() {
+        let err = reverse("__test_malformed", &HashMap::new()).unwrap_err();
+        match err {
+            ReverseError::MalformedPattern { name, detail } => {
+                assert_eq!(name, "__test_malformed");
+                assert!(detail.contains("unclosed"), "detail: {detail}");
+            }
+            other => panic!("expected MalformedPattern, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn all_routes_returns_at_least_registered_test_routes() {
+        let names: Vec<&str> = all_routes().iter().map(|r| r.name).collect();
+        for required in [
+            "__test_home",
+            "__test_post_detail",
+            "__test_two_args",
+            "__test_typed_placeholder",
+            "__test_malformed",
+        ] {
+            assert!(names.contains(&required), "missing {required}: {names:?}");
+        }
+    }
+
+    #[test]
+    fn duplicates_helper_is_callable() {
+        // The test registry has no intentional duplicates among
+        // `__test_*` names. Other test files in the same binary may
+        // or may not register routes; just confirm the function
+        // doesn't panic and returns a Vec of names (sorted).
+        let dups = duplicates();
+        // Sort property: every two adjacent entries are ordered.
+        for w in dups.windows(2) {
+            assert!(w[0] <= w[1], "duplicates() must return sorted: {dups:?}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Django's most-felt-when-missing feature lands as `rustango::urls::reverse(name, params)` + a `register_url!` macro that registers entries at module-load time via `inventory`. Foundation for `{% url %}` (#14), `redirect('view-name', pk=1)` shape, `Model::get_absolute_url()`, and any link-out-by-name pattern.

```rust
use rustango::register_url;
use rustango::urls::reverse;

register_url!(\"post-detail\", \"/posts/{id}\");

let mut p = HashMap::new();
p.insert(\"id\", \"42\".to_owned());
assert_eq!(reverse(\"post-detail\", &p).unwrap(), \"/posts/42\");
```

- Path templates use axum 0.8's `{name}` syntax; Django-style `{int:id}` typed placeholders are accepted (type prefix stripped).
- Param values are percent-encoded on substitution (caller-supplied `/` / `?` / `#` are safe).
- Strict-by-default: extra / missing / unknown-name all surface as typed errors so typos don't disappear silently.
- Two entry points: `reverse(name, &HashMap<&str, String>)` for the common case, `reverse_owned(name, &HashMap<String, String>)` for template-tag / JSON paths.

## Out of scope (queued as follow-ups)

Issue #8 lists three pieces; this PR ships the first:
1. **`reverse()` + `register_url!`** — this PR.
2. **Namespaced reverse** (`reverse(\"app:detail\")` with `include(\"app.urls\", namespace=...)`) — deferred. Two PRs registering the same name will collide today; revisit when users hit it.
3. **`Model::get_absolute_url()` trait + `#[rustango(absolute_url = \"...\")]` attribute** — small follow-up that builds on this PR.

The Tera `{% url %}` template tag is issue #14, separately.

## Test plan

- [x] 9 unit tests in `src/urls.rs` covering static patterns, single + multi-placeholder substitution, percent-encoding, three error paths (unknown name / missing param / unexpected param), Django-style typed placeholders, and the `reverse_owned` variant.
- [x] `cargo test --workspace --all-features --no-run` — all-features build clean.
- [x] `cargo build --no-default-features --features sqlite,tenancy` — sqlite-tenancy litmus passes.
- [x] `cargo test -p rustango --lib --features tenancy,mysql,sqlite` — 1592 lib tests pass.

Closes #8 (partial — namespaces + `get_absolute_url()` queued as follow-ups).