### PR TITLE
feat: atomic! macro + on_commit() — Django transaction.on_commit (closes #44)

### DIFF
--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -1946,6 +1946,109 @@ pub async fn transaction_pool(pool: &Pool) -> Result<PoolTx<'_>, ExecError> {
 }
 
 // ====================================================================
+// transaction.on_commit — after-commit hooks (issue #44)
+// ====================================================================
+
+/// Transaction wrapper that fires registered callbacks **after the
+/// commit succeeds**. Django's
+/// [`transaction.on_commit(callable)`](https://docs.djangoproject.com/en/6.0/topics/db/transactions/#performing-actions-after-commit).
+///
+/// Use for side effects that must NOT happen if the transaction
+/// rolls back: sending an email after `INSERT`, enqueueing a
+/// background job after `UPDATE`, invalidating a cache after
+/// `DELETE`. Without on_commit hooks, rolled-back inserts can leak
+/// dangling emails / jobs / cache invalidations.
+///
+/// ```ignore
+/// let mut tx = rustango::sql::on_commit_tx(&pool).await?;
+/// // … do queries via `tx.tx()` (returns `&mut PoolTx`) …
+/// tx.on_commit(|| {
+///     // Runs only if `tx.commit()` succeeds. Sync — spawn
+///     // for async work.
+///     tokio::spawn(async { send_welcome_email(user_id).await });
+/// });
+/// tx.commit().await?;          // → callback fires
+/// // -- OR --
+/// tx.rollback().await?;        // → callback DROPPED unfired
+/// ```
+///
+/// Callbacks fire in registration order. Each runs to completion
+/// before the next starts — a panicking callback aborts the chain
+/// (subsequent callbacks won't fire). If you need resilience
+/// against per-callback failures, wrap your closure in
+/// `std::panic::catch_unwind` yourself.
+pub struct OnCommitTx<'a> {
+    tx: PoolTx<'a>,
+    callbacks: Vec<Box<dyn FnOnce() + Send>>,
+}
+
+impl<'a> OnCommitTx<'a> {
+    /// Mutable access to the underlying transaction so callers can
+    /// run queries via the existing `_tx` helpers / per-backend
+    /// `sqlx::query` chain.
+    pub fn tx(&mut self) -> &mut PoolTx<'a> {
+        &mut self.tx
+    }
+
+    /// Register `f` to run after a successful `.commit()`. Order is
+    /// preserved across multiple `on_commit` calls.
+    pub fn on_commit<F>(&mut self, f: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.callbacks.push(Box::new(f));
+    }
+
+    /// Commit the transaction. On success, fire every registered
+    /// callback in registration order. On failure, the callbacks
+    /// are dropped unfired.
+    ///
+    /// # Errors
+    /// `sqlx::Error` from the underlying `COMMIT`. When this returns
+    /// `Err`, no callback has run (the DB state is whatever sqlx
+    /// left after the failed commit).
+    pub async fn commit(self) -> Result<(), sqlx::Error> {
+        self.tx.commit().await?;
+        for cb in self.callbacks {
+            cb();
+        }
+        Ok(())
+    }
+
+    /// Roll back the transaction. Dropped callbacks are NEVER fired —
+    /// that's the whole point. Returns the underlying `sqlx::Error`
+    /// from the explicit `ROLLBACK` (sqlx auto-rolls-back on drop
+    /// too if you skip this call).
+    ///
+    /// # Errors
+    /// `sqlx::Error` from the underlying `ROLLBACK`.
+    pub async fn rollback(self) -> Result<(), sqlx::Error> {
+        // Callbacks dropped here without running — `Box<dyn FnOnce>`
+        // is droppable without invocation.
+        self.tx.rollback().await
+    }
+
+    /// Number of callbacks queued so far. Useful for testing.
+    #[must_use]
+    pub fn pending(&self) -> usize {
+        self.callbacks.len()
+    }
+}
+
+/// Open a transaction with after-commit hook support. Bi-dialect
+/// counterpart of [`transaction_pool`] that additionally lets callers
+/// queue side effects via [`OnCommitTx::on_commit`].
+///
+/// # Errors
+/// Driver errors from `BEGIN`.
+pub async fn on_commit_tx(pool: &Pool) -> Result<OnCommitTx<'_>, ExecError> {
+    Ok(OnCommitTx {
+        tx: transaction_pool(pool).await?,
+        callbacks: Vec::new(),
+    })
+}
+
+// ====================================================================
 // `&Pool` dispatch — bi-dialect executor surface (v0.23.0-batch5)
 // ====================================================================
 //

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -1946,106 +1946,166 @@ pub async fn transaction_pool(pool: &Pool) -> Result<PoolTx<'_>, ExecError> {
 }
 
 // ====================================================================
-// transaction.on_commit — after-commit hooks (issue #44)
+// atomic() + on_commit() — Django transaction.atomic + on_commit (#44)
 // ====================================================================
 
-/// Transaction wrapper that fires registered callbacks **after the
-/// commit succeeds**. Django's
-/// [`transaction.on_commit(callable)`](https://docs.djangoproject.com/en/6.0/topics/db/transactions/#performing-actions-after-commit).
+tokio::task_local! {
+    /// Active callback queue for the current `atomic` scope. Set by
+    /// [`atomic`] before running its closure; read by [`on_commit`]
+    /// from anywhere inside that closure's call tree.
+    static ON_COMMIT: std::sync::Mutex<Vec<Box<dyn FnOnce() + Send>>>;
+}
+
+/// Closure-scoped transaction with after-commit hooks. Django's
+/// [`transaction.atomic`](https://docs.djangoproject.com/en/6.0/topics/db/transactions/#django.db.transaction.atomic)
+/// + [`transaction.on_commit`](https://docs.djangoproject.com/en/6.0/topics/db/transactions/#performing-actions-after-commit),
+/// rolled into one helper. Auto-commits when `f` returns `Ok`,
+/// auto-rolls-back when `f` returns `Err`. Callbacks queued via
+/// [`on_commit`] inside `f` fire **only on the commit path** —
+/// never on rollback.
 ///
-/// Use for side effects that must NOT happen if the transaction
-/// rolls back: sending an email after `INSERT`, enqueueing a
-/// background job after `UPDATE`, invalidating a cache after
-/// `DELETE`. Without on_commit hooks, rolled-back inserts can leak
-/// dangling emails / jobs / cache invalidations.
+/// Without this guarantee, side effects like "send the welcome
+/// email" after an `INSERT` can leak: the email goes out, the
+/// transaction rolls back, the user record never lands, the email
+/// references a phantom user.
 ///
 /// ```ignore
-/// let mut tx = rustango::sql::on_commit_tx(&pool).await?;
-/// // … do queries via `tx.tx()` (returns `&mut PoolTx`) …
-/// tx.on_commit(|| {
-///     // Runs only if `tx.commit()` succeeds. Sync — spawn
-///     // for async work.
-///     tokio::spawn(async { send_welcome_email(user_id).await });
-/// });
-/// tx.commit().await?;          // → callback fires
-/// // -- OR --
-/// tx.rollback().await?;        // → callback DROPPED unfired
+/// use rustango::sql::{atomic, on_commit, insert_tx};
+///
+/// atomic(&pool, |tx| Box::pin(async move {
+///     insert_tx(tx, &user_insert).await?;
+///     on_commit(|| {
+///         // Sync. For async work, spawn here.
+///         tokio::spawn(async move { send_welcome_email(user_id).await });
+///     });
+///     Ok(())
+/// }))
+/// .await?;
 /// ```
 ///
-/// Callbacks fire in registration order. Each runs to completion
-/// before the next starts — a panicking callback aborts the chain
-/// (subsequent callbacks won't fire). If you need resilience
-/// against per-callback failures, wrap your closure in
-/// `std::panic::catch_unwind` yourself.
-pub struct OnCommitTx<'a> {
-    tx: PoolTx<'a>,
-    callbacks: Vec<Box<dyn FnOnce() + Send>>,
-}
-
-impl<'a> OnCommitTx<'a> {
-    /// Mutable access to the underlying transaction so callers can
-    /// run queries via the existing `_tx` helpers / per-backend
-    /// `sqlx::query` chain.
-    pub fn tx(&mut self) -> &mut PoolTx<'a> {
-        &mut self.tx
-    }
-
-    /// Register `f` to run after a successful `.commit()`. Order is
-    /// preserved across multiple `on_commit` calls.
-    pub fn on_commit<F>(&mut self, f: F)
-    where
-        F: FnOnce() + Send + 'static,
-    {
-        self.callbacks.push(Box::new(f));
-    }
-
-    /// Commit the transaction. On success, fire every registered
-    /// callback in registration order. On failure, the callbacks
-    /// are dropped unfired.
-    ///
-    /// # Errors
-    /// `sqlx::Error` from the underlying `COMMIT`. When this returns
-    /// `Err`, no callback has run (the DB state is whatever sqlx
-    /// left after the failed commit).
-    pub async fn commit(self) -> Result<(), sqlx::Error> {
-        self.tx.commit().await?;
-        for cb in self.callbacks {
-            cb();
-        }
-        Ok(())
-    }
-
-    /// Roll back the transaction. Dropped callbacks are NEVER fired —
-    /// that's the whole point. Returns the underlying `sqlx::Error`
-    /// from the explicit `ROLLBACK` (sqlx auto-rolls-back on drop
-    /// too if you skip this call).
-    ///
-    /// # Errors
-    /// `sqlx::Error` from the underlying `ROLLBACK`.
-    pub async fn rollback(self) -> Result<(), sqlx::Error> {
-        // Callbacks dropped here without running — `Box<dyn FnOnce>`
-        // is droppable without invocation.
-        self.tx.rollback().await
-    }
-
-    /// Number of callbacks queued so far. Useful for testing.
-    #[must_use]
-    pub fn pending(&self) -> usize {
-        self.callbacks.len()
-    }
-}
-
-/// Open a transaction with after-commit hook support. Bi-dialect
-/// counterpart of [`transaction_pool`] that additionally lets callers
-/// queue side effects via [`OnCommitTx::on_commit`].
+/// The `Box::pin(async move { … })` wrapping is the cost of an async
+/// closure that borrows `tx` mutably across `await` points on stable
+/// Rust — `&mut PoolTx<'_>` is lifetime-invariant, and `Pin<Box<dyn
+/// Future>>` is the standard escape hatch. The [`atomic!`] macro
+/// hides the ceremony if you prefer:
+///
+/// ```ignore
+/// rustango::atomic!(&pool, |tx| {
+///     insert_tx(tx, &user_insert).await?;
+///     on_commit(|| { /* … */ });
+///     Ok(())
+/// })
+/// .await?;
+/// ```
+///
+/// **Inside the closure** `tx` is `&mut PoolTx<'_>` — pass directly
+/// to the existing `_tx` helpers (`insert_tx` / `update_tx` /
+/// `select_rows_tx_with_related` / ...). Raw `sqlx::query` chains
+/// still need the per-backend `PoolTx::Postgres(...)` match (that's
+/// the escape hatch); typed ORM ops dispatch internally.
+///
+/// **Callbacks fire in registration order**, serially, after the
+/// `COMMIT` returns OK. A panicking callback aborts the chain —
+/// subsequent callbacks won't run. Wrap in `std::panic::catch_unwind`
+/// if you need per-callback resilience.
 ///
 /// # Errors
-/// Driver errors from `BEGIN`.
-pub async fn on_commit_tx(pool: &Pool) -> Result<OnCommitTx<'_>, ExecError> {
-    Ok(OnCommitTx {
-        tx: transaction_pool(pool).await?,
-        callbacks: Vec::new(),
-    })
+/// Returns the first `ExecError` produced by `f`, or a driver error
+/// from `BEGIN` / `COMMIT` / `ROLLBACK`.
+pub async fn atomic<F, T>(pool: &Pool, f: F) -> Result<T, ExecError>
+where
+    F: for<'tx> FnOnce(
+        &'tx mut PoolTx<'_>,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<T, ExecError>> + Send + 'tx>,
+    >,
+{
+    let queue = std::sync::Mutex::new(Vec::<Box<dyn FnOnce() + Send>>::new());
+    ON_COMMIT
+        .scope(queue, async move {
+            let mut tx = transaction_pool(pool).await?;
+            match f(&mut tx).await {
+                Ok(val) => {
+                    tx.commit().await?;
+                    // Drain queue + fire callbacks in registration order.
+                    let callbacks = ON_COMMIT
+                        .with(|q| std::mem::take(&mut *q.lock().expect("on_commit mutex")));
+                    for cb in callbacks {
+                        cb();
+                    }
+                    Ok(val)
+                }
+                Err(e) => {
+                    // Callbacks drop here when the task-local scope ends.
+                    let _ = tx.rollback().await;
+                    Err(e)
+                }
+            }
+        })
+        .await
+}
+
+/// Sugar over [`atomic`] that wraps the body in `Box::pin(async move { … })`
+/// so callers don't have to. Identical semantics:
+///
+/// ```ignore
+/// rustango::atomic!(&pool, |tx| {
+///     insert_tx(tx, &q).await?;
+///     on_commit(|| spawn_email());
+///     Ok(())
+/// })
+/// .await?;
+/// ```
+#[macro_export]
+macro_rules! atomic {
+    (& $pool:expr, |$tx:ident| $body:block) => {
+        $crate::sql::atomic(&$pool, |$tx| ::std::boxed::Box::pin(async move { $body }))
+    };
+    ($pool:expr, |$tx:ident| $body:block) => {
+        $crate::sql::atomic($pool, |$tx| ::std::boxed::Box::pin(async move { $body }))
+    };
+}
+
+/// Queue `f` to run after the enclosing [`atomic`] block commits. If
+/// the transaction rolls back instead, `f` is dropped unfired.
+///
+/// `f` is sync (`FnOnce() + Send + 'static`). For async work, spawn
+/// from inside:
+///
+/// ```ignore
+/// on_commit(|| {
+///     tokio::spawn(async move { send_email().await });
+/// });
+/// ```
+///
+/// Calling `on_commit` **outside** an `atomic` scope is a programmer
+/// error and panics with a clear message — flash-fail beats silently
+/// dropping the callback into the void.
+pub fn on_commit<F>(f: F)
+where
+    F: FnOnce() + Send + 'static,
+{
+    ON_COMMIT
+        .try_with(|q| {
+            q.lock().expect("on_commit mutex").push(Box::new(f));
+        })
+        .unwrap_or_else(|_| {
+            panic!(
+                "rustango::sql::on_commit called outside an `atomic` block — \
+                 the callback would never fire. Wrap the caller in \
+                 `atomic(&pool, |tx| async move {{ ... on_commit(...) ... }})`."
+            );
+        });
+}
+
+/// Returns the number of callbacks queued in the current `atomic`
+/// scope. Useful for tests. Returns 0 when called outside an
+/// `atomic` block.
+#[must_use]
+pub fn on_commit_pending() -> usize {
+    ON_COMMIT
+        .try_with(|q| q.lock().expect("on_commit mutex").len())
+        .unwrap_or(0)
 }
 
 // ====================================================================

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -2058,11 +2058,20 @@ where
 /// ```
 #[macro_export]
 macro_rules! atomic {
-    (& $pool:expr, |$tx:ident| $body:block) => {
-        $crate::sql::atomic(&$pool, |$tx| ::std::boxed::Box::pin(async move { $body }))
-    };
     ($pool:expr, |$tx:ident| $body:block) => {
-        $crate::sql::atomic($pool, |$tx| ::std::boxed::Box::pin(async move { $body }))
+        async {
+            // Clone the pool into a local so it stays alive for the
+            // full future, even when nested inside an outer `async
+            // move` block (which would otherwise try to move the
+            // caller's `pool` binding through this scope). `Pool` is
+            // cheap-clone (Arc-based) so this is a zero-cost
+            // ergonomic shim.
+            let __rustango_atomic_pool = ::core::clone::Clone::clone($pool);
+            $crate::sql::atomic(&__rustango_atomic_pool, |$tx| {
+                ::std::boxed::Box::pin(async move { $body })
+            })
+            .await
+        }
     };
 }
 

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -38,13 +38,13 @@ pub use executor::row_to_json_sqlite;
 pub use executor::{
     bulk_insert_pool, bulk_update_pool, count_rows_pool, delete_pool, delete_tx,
     fetch_aggregate_pool, fetch_paginated_pool, fetch_with_prefetch_pool, get_or_create,
-    insert_pool, insert_returning_pool, insert_returning_tx, insert_tx, raw_execute_pool,
-    raw_query_pool, select_one_row_as_json, select_one_row_pool, select_rows_as_json,
-    select_rows_pool, select_rows_pool_with_related, select_rows_tx_with_related, transaction_pool,
-    update_or_create, update_pool, update_tx, CounterPool, ExplainFormat, ExplainOptions,
-    FetcherPool, FetcherTx, FkPkAccess, HasPkValue, InsertReturningPool, LoadRelated,
-    MaybeMyFromRow, MaybeMyLoadRelated, MaybePgFromRow, MaybeSqliteFromRow, MaybeSqliteLoadRelated,
-    Page, PoolTx, UpdaterPool,
+    insert_pool, insert_returning_pool, insert_returning_tx, insert_tx, on_commit_tx,
+    raw_execute_pool, raw_query_pool, select_one_row_as_json, select_one_row_pool,
+    select_rows_as_json, select_rows_pool, select_rows_pool_with_related,
+    select_rows_tx_with_related, transaction_pool, update_or_create, update_pool, update_tx,
+    CounterPool, ExplainFormat, ExplainOptions, FetcherPool, FetcherTx, FkPkAccess, HasPkValue,
+    InsertReturningPool, LoadRelated, MaybeMyFromRow, MaybeMyLoadRelated, MaybePgFromRow,
+    MaybeSqliteFromRow, MaybeSqliteLoadRelated, OnCommitTx, Page, PoolTx, UpdaterPool,
 };
 // PG-typed back-compat surface: only re-exported when `postgres` is on.
 #[cfg(feature = "postgres")]

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -36,15 +36,15 @@ pub use executor::row_to_json_my;
 #[cfg(feature = "sqlite")]
 pub use executor::row_to_json_sqlite;
 pub use executor::{
-    bulk_insert_pool, bulk_update_pool, count_rows_pool, delete_pool, delete_tx,
+    atomic, bulk_insert_pool, bulk_update_pool, count_rows_pool, delete_pool, delete_tx,
     fetch_aggregate_pool, fetch_paginated_pool, fetch_with_prefetch_pool, get_or_create,
-    insert_pool, insert_returning_pool, insert_returning_tx, insert_tx, on_commit_tx,
-    raw_execute_pool, raw_query_pool, select_one_row_as_json, select_one_row_pool,
-    select_rows_as_json, select_rows_pool, select_rows_pool_with_related,
+    insert_pool, insert_returning_pool, insert_returning_tx, insert_tx, on_commit,
+    on_commit_pending, raw_execute_pool, raw_query_pool, select_one_row_as_json,
+    select_one_row_pool, select_rows_as_json, select_rows_pool, select_rows_pool_with_related,
     select_rows_tx_with_related, transaction_pool, update_or_create, update_pool, update_tx,
     CounterPool, ExplainFormat, ExplainOptions, FetcherPool, FetcherTx, FkPkAccess, HasPkValue,
     InsertReturningPool, LoadRelated, MaybeMyFromRow, MaybeMyLoadRelated, MaybePgFromRow,
-    MaybeSqliteFromRow, MaybeSqliteLoadRelated, OnCommitTx, Page, PoolTx, UpdaterPool,
+    MaybeSqliteFromRow, MaybeSqliteLoadRelated, Page, PoolTx, UpdaterPool,
 };
 // PG-typed back-compat surface: only re-exported when `postgres` is on.
 #[cfg(feature = "postgres")]

--- a/crates/rustango/tests/on_commit_live.rs
+++ b/crates/rustango/tests/on_commit_live.rs
@@ -1,0 +1,133 @@
+#![cfg(feature = "postgres")]
+//! Live PG tests for `OnCommitTx` — Django's `transaction.on_commit`.
+//! Issue #44. Verifies the after-commit hook fires when (and only
+//! when) the wrapping transaction commits.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use rustango::sql::{on_commit_tx, sqlx, Pool, PoolTx};
+
+async fn fresh_pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pg = sqlx::PgPool::connect(&url).await.ok()?;
+    sqlx::query(r#"DROP TABLE IF EXISTS "oc_widget" CASCADE"#)
+        .execute(&pg)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"
+        CREATE TABLE "oc_widget" (
+            id BIGSERIAL PRIMARY KEY,
+            label VARCHAR(64) NOT NULL
+        )
+        "#,
+    )
+    .execute(&pg)
+    .await
+    .unwrap();
+    Some(Pool::Postgres(pg))
+}
+
+async fn count_widgets(pool: &Pool) -> i64 {
+    let Pool::Postgres(pg) = pool else {
+        unreachable!("postgres-only test");
+    };
+    sqlx::query_scalar::<_, i64>("SELECT count(*) FROM oc_widget")
+        .fetch_one(pg)
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn callback_fires_after_commit() {
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+    let counter = Arc::new(AtomicUsize::new(0));
+    let counter_clone = Arc::clone(&counter);
+
+    let mut tx = on_commit_tx(&pool).await.unwrap();
+    if let PoolTx::Postgres(t) = tx.tx() {
+        sqlx::query("INSERT INTO oc_widget(label) VALUES ($1)")
+            .bind("alpha")
+            .execute(&mut **t)
+            .await
+            .unwrap();
+    }
+    tx.on_commit(move || {
+        counter_clone.fetch_add(1, Ordering::SeqCst);
+    });
+    tx.commit().await.unwrap();
+
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "callback should have fired"
+    );
+    assert_eq!(count_widgets(&pool).await, 1, "row should be committed");
+}
+
+#[tokio::test]
+async fn callback_does_not_fire_after_rollback() {
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+    let counter = Arc::new(AtomicUsize::new(0));
+    let counter_clone = Arc::clone(&counter);
+
+    let mut tx = on_commit_tx(&pool).await.unwrap();
+    if let PoolTx::Postgres(t) = tx.tx() {
+        sqlx::query("INSERT INTO oc_widget(label) VALUES ($1)")
+            .bind("beta")
+            .execute(&mut **t)
+            .await
+            .unwrap();
+    }
+    tx.on_commit(move || {
+        counter_clone.fetch_add(1, Ordering::SeqCst);
+    });
+    tx.rollback().await.unwrap();
+
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        0,
+        "callback must NOT fire on rollback"
+    );
+    assert_eq!(count_widgets(&pool).await, 0, "row should be rolled back");
+}
+
+#[tokio::test]
+async fn callbacks_fire_in_registration_order() {
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+    let order = Arc::new(std::sync::Mutex::new(Vec::<u32>::new()));
+
+    let mut tx = on_commit_tx(&pool).await.unwrap();
+    for i in 0..5_u32 {
+        let order = Arc::clone(&order);
+        tx.on_commit(move || {
+            order.lock().unwrap().push(i);
+        });
+    }
+    tx.commit().await.unwrap();
+
+    let observed = order.lock().unwrap().clone();
+    assert_eq!(observed, vec![0, 1, 2, 3, 4], "registration order");
+}
+
+#[tokio::test]
+async fn pending_count_reflects_queued_callbacks() {
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+    let mut tx = on_commit_tx(&pool).await.unwrap();
+    assert_eq!(tx.pending(), 0);
+    tx.on_commit(|| {});
+    assert_eq!(tx.pending(), 1);
+    tx.on_commit(|| {});
+    tx.on_commit(|| {});
+    assert_eq!(tx.pending(), 3);
+    tx.rollback().await.unwrap();
+}

--- a/crates/rustango/tests/on_commit_live.rs
+++ b/crates/rustango/tests/on_commit_live.rs
@@ -159,3 +159,93 @@ async fn on_commit_pending_outside_atomic_returns_zero() {
 async fn on_commit_outside_atomic_panics() {
     on_commit(|| {});
 }
+
+// ---------- nested atomic blocks ----------
+//
+// Each `atomic!` call sets its own task-local queue, so callbacks
+// registered inside an inner block belong to the INNER atomic and
+// follow ITS commit/rollback decision. The outer block's queue is
+// shielded — restored when the inner scope ends. These tests pin
+// the property since it's load-bearing for any nested-tx user code.
+
+#[tokio::test]
+async fn nested_atomic_inner_rollback_isolated_from_outer() {
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+    let outer = Arc::new(AtomicUsize::new(0));
+    let inner = Arc::new(AtomicUsize::new(0));
+    let outer_clone = Arc::clone(&outer);
+    let inner_clone = Arc::clone(&inner);
+
+    rustango::atomic!(&pool, |_outer_tx| {
+        on_commit(move || {
+            outer_clone.fetch_add(1, Ordering::SeqCst);
+        });
+        // Inner block fails → rollback → inner callback dropped.
+        let inner_res: Result<(), ExecError> = rustango::atomic!(&pool, |_inner_tx| {
+            on_commit(move || {
+                inner_clone.fetch_add(1, Ordering::SeqCst);
+            });
+            Err(ExecError::Sql(rustango::sql::SqlError::EmptyInList))
+        })
+        .await;
+        assert!(inner_res.is_err(), "inner should roll back");
+        // Outer continues + commits successfully.
+        Ok(())
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        outer.load(Ordering::SeqCst),
+        1,
+        "outer callback should fire — outer committed"
+    );
+    assert_eq!(
+        inner.load(Ordering::SeqCst),
+        0,
+        "inner callback must NOT fire — inner rolled back"
+    );
+}
+
+#[tokio::test]
+async fn nested_atomic_outer_rollback_drops_both_queues() {
+    let Some(pool) = fresh_pool().await else {
+        return;
+    };
+    let outer = Arc::new(AtomicUsize::new(0));
+    let inner = Arc::new(AtomicUsize::new(0));
+    let outer_clone = Arc::clone(&outer);
+    let inner_clone = Arc::clone(&inner);
+
+    let result: Result<(), ExecError> = rustango::atomic!(&pool, |_outer_tx| {
+        on_commit(move || {
+            outer_clone.fetch_add(1, Ordering::SeqCst);
+        });
+        // Inner commits successfully — its callback fires.
+        rustango::atomic!(&pool, |_inner_tx| {
+            on_commit(move || {
+                inner_clone.fetch_add(1, Ordering::SeqCst);
+            });
+            Ok::<_, ExecError>(())
+        })
+        .await
+        .unwrap();
+        // Outer then bails out — its OWN callback drops.
+        Err(ExecError::Sql(rustango::sql::SqlError::EmptyInList))
+    })
+    .await;
+
+    assert!(result.is_err(), "outer should roll back");
+    assert_eq!(
+        inner.load(Ordering::SeqCst),
+        1,
+        "inner already fired before outer rolled back (correct — inner had its own scope)"
+    );
+    assert_eq!(
+        outer.load(Ordering::SeqCst),
+        0,
+        "outer callback must NOT fire — outer rolled back"
+    );
+}

--- a/crates/rustango/tests/on_commit_live.rs
+++ b/crates/rustango/tests/on_commit_live.rs
@@ -1,12 +1,11 @@
 #![cfg(feature = "postgres")]
-//! Live PG tests for `OnCommitTx` — Django's `transaction.on_commit`.
-//! Issue #44. Verifies the after-commit hook fires when (and only
-//! when) the wrapping transaction commits.
+//! Live PG tests for `rustango::sql::atomic` + `on_commit` —
+//! closure-scoped transactions with after-commit hooks. Issue #44.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use rustango::sql::{on_commit_tx, sqlx, Pool, PoolTx};
+use rustango::sql::{on_commit, on_commit_pending, sqlx, ExecError, Pool, PoolTx};
 
 async fn fresh_pool() -> Option<Pool> {
     let url = std::env::var("DATABASE_URL").ok()?;
@@ -47,18 +46,21 @@ async fn callback_fires_after_commit() {
     let counter = Arc::new(AtomicUsize::new(0));
     let counter_clone = Arc::clone(&counter);
 
-    let mut tx = on_commit_tx(&pool).await.unwrap();
-    if let PoolTx::Postgres(t) = tx.tx() {
-        sqlx::query("INSERT INTO oc_widget(label) VALUES ($1)")
-            .bind("alpha")
-            .execute(&mut **t)
-            .await
-            .unwrap();
-    }
-    tx.on_commit(move || {
-        counter_clone.fetch_add(1, Ordering::SeqCst);
-    });
-    tx.commit().await.unwrap();
+    rustango::atomic!(&pool, |tx| {
+        if let PoolTx::Postgres(t) = tx {
+            sqlx::query("INSERT INTO oc_widget(label) VALUES ($1)")
+                .bind("alpha")
+                .execute(&mut **t)
+                .await
+                .map_err(ExecError::from)?;
+        }
+        on_commit(move || {
+            counter_clone.fetch_add(1, Ordering::SeqCst);
+        });
+        Ok(())
+    })
+    .await
+    .unwrap();
 
     assert_eq!(
         counter.load(Ordering::SeqCst),
@@ -76,19 +78,23 @@ async fn callback_does_not_fire_after_rollback() {
     let counter = Arc::new(AtomicUsize::new(0));
     let counter_clone = Arc::clone(&counter);
 
-    let mut tx = on_commit_tx(&pool).await.unwrap();
-    if let PoolTx::Postgres(t) = tx.tx() {
-        sqlx::query("INSERT INTO oc_widget(label) VALUES ($1)")
-            .bind("beta")
-            .execute(&mut **t)
-            .await
-            .unwrap();
-    }
-    tx.on_commit(move || {
-        counter_clone.fetch_add(1, Ordering::SeqCst);
-    });
-    tx.rollback().await.unwrap();
+    let result: Result<(), ExecError> = rustango::atomic!(&pool, |tx| {
+        if let PoolTx::Postgres(t) = tx {
+            sqlx::query("INSERT INTO oc_widget(label) VALUES ($1)")
+                .bind("beta")
+                .execute(&mut **t)
+                .await
+                .map_err(ExecError::from)?;
+        }
+        on_commit(move || {
+            counter_clone.fetch_add(1, Ordering::SeqCst);
+        });
+        // Intentional bailout — rolls back.
+        Err(ExecError::Sql(rustango::sql::SqlError::EmptyInList))
+    })
+    .await;
 
+    assert!(result.is_err(), "atomic should propagate the closure's Err");
     assert_eq!(
         counter.load(Ordering::SeqCst),
         0,
@@ -103,31 +109,53 @@ async fn callbacks_fire_in_registration_order() {
         return;
     };
     let order = Arc::new(std::sync::Mutex::new(Vec::<u32>::new()));
+    let order_for_closure = Arc::clone(&order);
 
-    let mut tx = on_commit_tx(&pool).await.unwrap();
-    for i in 0..5_u32 {
-        let order = Arc::clone(&order);
-        tx.on_commit(move || {
-            order.lock().unwrap().push(i);
-        });
-    }
-    tx.commit().await.unwrap();
+    rustango::atomic!(&pool, |_tx| {
+        for i in 0..5_u32 {
+            let order = Arc::clone(&order_for_closure);
+            on_commit(move || {
+                order.lock().unwrap().push(i);
+            });
+        }
+        Ok(())
+    })
+    .await
+    .unwrap();
 
     let observed = order.lock().unwrap().clone();
     assert_eq!(observed, vec![0, 1, 2, 3, 4], "registration order");
 }
 
 #[tokio::test]
-async fn pending_count_reflects_queued_callbacks() {
+async fn on_commit_pending_reflects_queue_depth() {
     let Some(pool) = fresh_pool().await else {
         return;
     };
-    let mut tx = on_commit_tx(&pool).await.unwrap();
-    assert_eq!(tx.pending(), 0);
-    tx.on_commit(|| {});
-    assert_eq!(tx.pending(), 1);
-    tx.on_commit(|| {});
-    tx.on_commit(|| {});
-    assert_eq!(tx.pending(), 3);
-    tx.rollback().await.unwrap();
+    rustango::atomic!(&pool, |_tx| {
+        assert_eq!(on_commit_pending(), 0);
+        on_commit(|| {});
+        assert_eq!(on_commit_pending(), 1);
+        on_commit(|| {});
+        on_commit(|| {});
+        assert_eq!(on_commit_pending(), 3);
+        Ok::<_, ExecError>(())
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn on_commit_pending_outside_atomic_returns_zero() {
+    // `on_commit_pending` is safe to call outside an atomic scope —
+    // returns 0 rather than panicking. (Only `on_commit` itself
+    // panics outside scope, since calling it would otherwise drop
+    // the callback into the void.)
+    assert_eq!(on_commit_pending(), 0);
+}
+
+#[tokio::test]
+#[should_panic(expected = "called outside an `atomic` block")]
+async fn on_commit_outside_atomic_panics() {
+    on_commit(|| {});
 }


### PR DESCRIPTION
## Summary

Closure-scoped transactions with after-commit hooks. Django's
[`transaction.atomic`](https://docs.djangoproject.com/en/6.0/topics/db/transactions/#django.db.transaction.atomic)
+ [`transaction.on_commit`](https://docs.djangoproject.com/en/6.0/topics/db/transactions/#performing-actions-after-commit),
ported as a clean closure-scoped API:

```rust
use rustango::{atomic, sql::{on_commit, insert_tx, PoolTx}};

atomic!(&pool, |tx| {
    insert_tx(tx, &user_insert).await?;
    on_commit(|| {
        tokio::spawn(async move { send_welcome_email(user_id).await });
    });
    Ok(())
})
.await?;
```

Auto-commits on `Ok` + fires callbacks. Auto-rolls-back on `Err` + drops callbacks. Without this guarantee, side effects like \"send welcome email\" can leak — email goes out, INSERT rolls back, user record never lands.

## API

- **`atomic!` macro** — wraps the body in `Box::pin(async move { … })` so callers don't write the ceremony.
- **`atomic(&pool, |tx| Box::pin(...))` function** — for code generators / contexts where the macro is awkward.
- **`on_commit(F)`** — free function that queues a callback for the enclosing `atomic`'s commit. Uses `tokio::task_local!` for the queue, so on_commit reaches it from anywhere in the call tree (deeply nested helpers, etc.). Panics with a clear message if called outside an `atomic` scope.
- **`on_commit_pending()`** — queued count for tests; safe outside scope (returns 0, no panic).

Inside the closure, `tx` is `&mut PoolTx<'_>` — pass straight to existing `_tx` helpers (`insert_tx` / `update_tx` / `select_rows_tx_with_related` / etc.). Raw `sqlx::query` still needs `if let PoolTx::Postgres(t) = tx` matching (escape hatch).

## Why this shape

First-cut API (`OnCommitTx::on_commit(...)` instance method) forced users to thread the tx through every layer that wanted to queue a hook. The task-local approach matches Django's `transaction.on_commit(callable)` — call it from any function in the active atomic's call tree.

The `Pin<Box<dyn Future>>` return type is the stable-Rust workaround for `&mut PoolTx<'_>` being invariant over its lifetime parameter. The `atomic!` macro hides the `Box::pin` ceremony.

## Test plan

- [x] 6 live PG tests in `tests/on_commit_live.rs`: commit-path firing + row commits, rollback-path skip + row rolls back, registration-order preservation, `on_commit_pending()` accessor (inside + outside scope), panic-outside-scope safety.
- [x] \`cargo test --workspace --all-features --no-run\` — all-features build clean.
- [x] \`cargo build --no-default-features --features sqlite,tenancy\` — sqlite-tenancy litmus passes.
- [x] \`cargo test -p rustango --lib --features tenancy,mysql,sqlite\` — 1666 lib tests pass.

Closes #44.