### PR TITLE
feat: pg_trgm trigram lookups — __trigram_similar / __trigram_word_similar (closes #29 partial)

### DIFF
--- a/crates/rustango/src/core/column.rs
+++ b/crates/rustango/src/core/column.rs
@@ -111,6 +111,32 @@ pub trait Column: Copy + 'static {
         )
     }
 
+    /// `column % pattern` — pg_trgm trigram similarity. Django's
+    /// `__trigram_similar` (issue #29). Whole-string similarity at
+    /// the default `pg_trgm.similarity_threshold` (0.3 unless
+    /// overridden). **PG-only** — MySQL / SQLite reject at compile
+    /// time. Requires `CREATE EXTENSION pg_trgm` on the database.
+    fn trigram_similar(self, pattern: impl Into<String>) -> TypedFilter<Self::Model> {
+        TypedFilter::scalar(
+            Self::COLUMN,
+            Op::TrigramSimilar,
+            SqlValue::String(pattern.into()),
+        )
+    }
+
+    /// `column %> pattern` — pg_trgm word-similarity. Django's
+    /// `__trigram_word_similar` (issue #29). Matches when **any
+    /// word** in `column` is trigram-similar to the pattern.
+    /// **PG-only**, same `pg_trgm` extension requirement as
+    /// [`Column::trigram_similar`].
+    fn trigram_word_similar(self, pattern: impl Into<String>) -> TypedFilter<Self::Model> {
+        TypedFilter::scalar(
+            Self::COLUMN,
+            Op::TrigramWordSimilar,
+            SqlValue::String(pattern.into()),
+        )
+    }
+
     /// `column IS NULL`.
     fn is_null(self) -> TypedFilter<Self::Model> {
         TypedFilter::scalar(Self::COLUMN, Op::IsNull, SqlValue::Bool(true))

--- a/crates/rustango/src/core/error.rs
+++ b/crates/rustango/src/core/error.rs
@@ -78,7 +78,8 @@ pub enum QueryError {
         "unknown lookup suffix `__{suffix}` on field `{field}` — \
          supported: exact, iexact, contains, icontains, startswith, \
          istartswith, endswith, iendswith, gt, gte, lt, lte, ne, in, \
-         isnull, between, range, regex, iregex"
+         isnull, between, range, regex, iregex, trigram_similar, \
+         trigram_word_similar"
     )]
     UnknownLookup { field: String, suffix: String },
 

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -78,6 +78,20 @@ pub enum Op {
     /// `LOWER(<col>) NOT REGEXP LOWER(<pattern>)` for the same
     /// reason as [`Op::IRegex`]. Issue #26.
     NotIRegex,
+    /// pg_trgm trigram similarity — Django's `__trigram_similar`
+    /// lookup. PG emits `<col> % <pattern>` using the `%` operator
+    /// supplied by the `pg_trgm` extension (default similarity
+    /// threshold is `0.3`; adjust via `SET pg_trgm.similarity_threshold`).
+    /// Requires `CREATE EXTENSION pg_trgm` on the database.
+    /// **PG-only** — MySQL / SQLite have no equivalent and reject
+    /// at compile time. Bind a `SqlValue::String`. Issue #29.
+    TrigramSimilar,
+    /// pg_trgm word-similarity — Django's `__trigram_word_similar`
+    /// lookup. PG emits `<col> %> <pattern>` using the `%>` operator.
+    /// Matches when any **word** in `<col>` is trigram-similar to the
+    /// pattern (the bare `%` requires the WHOLE string be similar).
+    /// **PG-only**, same `pg_trgm` extension requirement. Issue #29.
+    TrigramWordSimilar,
 }
 
 /// One predicate in a `WHERE` clause: `column <op> value`. Always

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1256,6 +1256,22 @@ fn parse_lookup(key: &str, value: SqlValue) -> Result<(String, Op, SqlValue), Qu
             };
             Ok((field, op, value))
         }
+        "trigram_similar" | "trigram_word_similar" => {
+            if !matches!(value, SqlValue::String(_)) {
+                return Err(QueryError::InvalidLookupValue {
+                    field,
+                    suffix: suffix.to_owned(),
+                    expected: "SqlValue::String(<trigram pattern>)",
+                    actual: sql_value_shape_name(&value),
+                });
+            }
+            let op = if suffix == "trigram_similar" {
+                Op::TrigramSimilar
+            } else {
+                Op::TrigramWordSimilar
+            };
+            Ok((field, op, value))
+        }
         unknown => Err(QueryError::UnknownLookup {
             field,
             suffix: unknown.to_owned(),

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -328,6 +328,36 @@ pub trait Dialect {
         sql.push_str(placeholder);
     }
 
+    /// `pg_trgm` trigram similarity match — Django's
+    /// `__trigram_similar` / `__trigram_word_similar`. Issue #29.
+    ///
+    /// Default emits the Postgres shape:
+    /// - `word=false`: `<col> % <p>` (whole-string similarity)
+    /// - `word=true`:  `<col> %> <p>` (any word similar)
+    ///
+    /// Requires `CREATE EXTENSION pg_trgm` on the database.
+    ///
+    /// **MySQL and SQLite have no equivalent** — they override to
+    /// return [`SqlError::OpNotSupportedInDialect`] so the typo of
+    /// using a trigram lookup against the wrong backend surfaces
+    /// cleanly at compile time rather than as a driver syntax error.
+    ///
+    /// # Errors
+    /// `OpNotSupportedInDialect` when the dialect doesn't support
+    /// trigram operators.
+    fn write_trigram_similar(
+        &self,
+        sql: &mut String,
+        qualified_col: &str,
+        placeholder: &str,
+        word: bool,
+    ) -> Result<(), super::SqlError> {
+        sql.push_str(qualified_col);
+        sql.push_str(if word { " %> " } else { " % " });
+        sql.push_str(placeholder);
+        Ok(())
+    }
+
     /// Null-safe equality. Postgres: `<col> IS [NOT] DISTINCT FROM <p>`.
     /// `distinct = true` means "not equal under null-safe semantics".
     fn write_null_safe_eq(

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -255,6 +255,27 @@ impl Dialect for MySql {
         }
     }
 
+    /// `pg_trgm` trigram operators are Postgres-only. MySQL has no
+    /// equivalent (text similarity via `FULLTEXT` is a different
+    /// shape). Reject at compile time so the user retargets the
+    /// query rather than discovering the gap at run time. Issue #29.
+    fn write_trigram_similar(
+        &self,
+        _sql: &mut String,
+        _qualified_col: &str,
+        _placeholder: &str,
+        word: bool,
+    ) -> Result<(), super::SqlError> {
+        Err(super::SqlError::OpNotSupportedInDialect {
+            op: if word {
+                "trigram_word_similar (%>) — pg_trgm is Postgres-only"
+            } else {
+                "trigram_similar (%) — pg_trgm is Postgres-only"
+            },
+            dialect: "mysql",
+        })
+    }
+
     fn write_null_safe_eq(
         &self,
         sql: &mut String,

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -245,6 +245,27 @@ impl Dialect for Sqlite {
         }
     }
 
+    /// `pg_trgm` trigram operators are Postgres-only. SQLite has no
+    /// equivalent. Reject at compile time so the user retargets the
+    /// query rather than seeing a driver-level syntax error at run
+    /// time. Issue #29.
+    fn write_trigram_similar(
+        &self,
+        _sql: &mut String,
+        _qualified_col: &str,
+        _placeholder: &str,
+        word: bool,
+    ) -> Result<(), super::SqlError> {
+        Err(super::SqlError::OpNotSupportedInDialect {
+            op: if word {
+                "trigram_word_similar (%>) — pg_trgm is Postgres-only"
+            } else {
+                "trigram_similar (%) — pg_trgm is Postgres-only"
+            },
+            dialect: "sqlite",
+        })
+    }
+
     /// SQLite's `IS` / `IS NOT` are null-safe equality / inequality
     /// (both `NULL IS NULL` and `1 IS 1` evaluate to true). Same
     /// semantics as Postgres' `IS [NOT] DISTINCT FROM` — we just

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -2254,6 +2254,21 @@ fn write_filter(
                 matches!(filter.op, Op::NotRegex | Op::NotIRegex),
             );
         }
+        Op::TrigramSimilar | Op::TrigramWordSimilar => {
+            // pg_trgm operators — Postgres-only by language semantic.
+            // The dialect's `write_trigram_similar` default returns
+            // `OpNotSupportedInDialect` for MySQL/SQLite; Postgres
+            // emits `<col> % <p>` or `<col> %> <p>`.
+            require_op(b.d, filter.op)?;
+            b.params.push(filter.value.clone());
+            let p = b.d.placeholder(b.params.len());
+            b.d.write_trigram_similar(
+                &mut b.sql,
+                &qualified_col,
+                &p,
+                matches!(filter.op, Op::TrigramWordSimilar),
+            )?;
+        }
         Op::In | Op::NotIn => {
             let SqlValue::List(elements) = &filter.value else {
                 return Err(SqlError::InRequiresList);
@@ -2432,6 +2447,8 @@ fn op_label(op: Op) -> &'static str {
         Op::JsonHasAllKeys => "?& (json)",
         Op::Regex => "~ (regex)",
         Op::NotRegex => "!~ (regex)",
+        Op::TrigramSimilar => "% (trigram_similar)",
+        Op::TrigramWordSimilar => "%> (trigram_word_similar)",
         Op::IRegex => "~* (iregex)",
         Op::NotIRegex => "!~* (iregex)",
     }

--- a/crates/rustango/tests/trigram_emission.rs
+++ b/crates/rustango/tests/trigram_emission.rs
@@ -1,0 +1,178 @@
+//! Emission tests for `__trigram_similar` / `__trigram_word_similar`
+//! (issue #29). PG emits `%` / `%>` pg_trgm operators; MySQL and
+//! SQLite reject with `OpNotSupportedInDialect` at compile time.
+
+use rustango::core::Column as _;
+#[cfg(feature = "mysql")]
+use rustango::sql::MySql;
+#[cfg(feature = "sqlite")]
+use rustango::sql::Sqlite;
+use rustango::sql::{Dialect, Postgres};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "trg_user")]
+#[allow(dead_code)]
+pub struct User {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 64)]
+    name: String,
+}
+
+// ---------- PG: native pg_trgm operators ----------
+
+#[test]
+fn trigram_similar_emits_percent_on_pg() {
+    let q = User::objects()
+        .where_(User::name.trigram_similar("Rusty"))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""name" % $1"#),
+        "PG trigram_similar: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn trigram_word_similar_emits_percent_gt_on_pg() {
+    let q = User::objects()
+        .where_(User::name.trigram_word_similar("Rust"))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""name" %> $1"#),
+        "PG trigram_word_similar: {}",
+        stmt.sql
+    );
+}
+
+// ---------- MySQL: rejected with clean error ----------
+
+#[cfg(feature = "mysql")]
+#[test]
+fn trigram_similar_rejects_on_mysql_with_op_not_supported() {
+    use rustango::sql::SqlError;
+    let q = User::objects()
+        .where_(User::name.trigram_similar("Rusty"))
+        .compile()
+        .unwrap();
+    let err = MySql.compile_select(&q).unwrap_err();
+    match err {
+        SqlError::OpNotSupportedInDialect { op, dialect } => {
+            assert!(op.contains("trigram"), "op label: {op}");
+            assert_eq!(dialect, "mysql");
+        }
+        other => panic!("expected OpNotSupportedInDialect, got: {other:?}"),
+    }
+}
+
+#[cfg(feature = "mysql")]
+#[test]
+fn trigram_word_similar_rejects_on_mysql() {
+    use rustango::sql::SqlError;
+    let q = User::objects()
+        .where_(User::name.trigram_word_similar("Rust"))
+        .compile()
+        .unwrap();
+    let err = MySql.compile_select(&q).unwrap_err();
+    assert!(matches!(err, SqlError::OpNotSupportedInDialect { .. }));
+}
+
+// ---------- SQLite: rejected with clean error ----------
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn trigram_similar_rejects_on_sqlite_with_op_not_supported() {
+    use rustango::sql::SqlError;
+    let q = User::objects()
+        .where_(User::name.trigram_similar("Rusty"))
+        .compile()
+        .unwrap();
+    let err = Sqlite.compile_select(&q).unwrap_err();
+    match err {
+        SqlError::OpNotSupportedInDialect { op, dialect } => {
+            assert!(op.contains("trigram"), "op label: {op}");
+            assert_eq!(dialect, "sqlite");
+        }
+        other => panic!("expected OpNotSupportedInDialect, got: {other:?}"),
+    }
+}
+
+// ---------- Django-shape lookup parser ----------
+
+#[test]
+fn trigram_similar_lookup_via_filter_string_parser() {
+    let q = User::objects()
+        .filter("name__trigram_similar", "Rusty")
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""name" % $1"#),
+        "filter(\"name__trigram_similar\", ...) routes to Op::TrigramSimilar: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn trigram_word_similar_lookup_via_filter_string_parser() {
+    let q = User::objects()
+        .filter("name__trigram_word_similar", "Rust")
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""name" %> $1"#),
+        "filter(\"name__trigram_word_similar\", ...) routes to Op::TrigramWordSimilar: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn trigram_lookup_with_non_string_value_rejects_at_compile() {
+    use rustango::core::SqlValue;
+    let r = User::objects()
+        .filter("name__trigram_similar", SqlValue::I64(42))
+        .compile();
+    assert!(
+        matches!(
+            r,
+            Err(rustango::core::QueryError::InvalidLookupValue { ref suffix, .. })
+                if suffix == "trigram_similar"
+        ),
+        "non-string value to __trigram_similar surfaces InvalidLookupValue: {r:?}",
+    );
+}
+
+#[test]
+fn unknown_lookup_error_mentions_trigram_suffixes() {
+    let r = User::objects().filter("name__nope_typo", "value").compile();
+    let err = r.unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("trigram_similar"),
+        "supported-lookups list should advertise trigram_similar: {msg}"
+    );
+    assert!(
+        msg.contains("trigram_word_similar"),
+        "supported-lookups list should advertise trigram_word_similar: {msg}"
+    );
+}
+
+#[test]
+fn trigram_binds_pattern_as_single_string_param() {
+    let q = User::objects()
+        .where_(User::name.trigram_similar("Rust"))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert_eq!(stmt.params.len(), 1, "one param");
+    match &stmt.params[0] {
+        rustango::core::SqlValue::String(s) => assert_eq!(s, "Rust"),
+        other => panic!("expected SqlValue::String, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Op::TrigramSimilar` + `Op::TrigramWordSimilar` to the query IR
- Postgres emits the native `pg_trgm` operators `<col> % <pattern>` and `<col> %> <pattern>`
- MySQL + SQLite reject with `SqlError::OpNotSupportedInDialect { op: \"trigram_similar\" / \"trigram_word_similar\", dialect }` at compile time
- Column trait methods `Column::trigram_similar(pattern)` + `Column::trigram_word_similar(pattern)` for typed-IR use
- Django-shape parser routes `.filter(\"name__trigram_similar\", value)` / `.filter(\"name__trigram_word_similar\", value)` to the new ops; non-string value surfaces as `InvalidLookupValue`
- `UnknownLookup` error advertises the new suffixes so `__nope_typo` errors point users at trigram

## Scope
This is the **partial** half of issue #29 — the two lookups. The full ticket also covers `TrigramSimilarity`/`TrigramWordSimilarity` annotation functions (numeric similarity score in SELECT) and a `CreateExtension(\"pg_trgm\")` migration helper; those land in a follow-up.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test --workspace --all-features --no-run` (the CI-vs-local gate)
- [x] `cargo build --no-default-features --features sqlite,tenancy` (sqlite-tenancy litmus)
- [x] New `crates/rustango/tests/trigram_emission.rs` — 10 tests covering: PG `%` / `%>` emission, MySQL + SQLite OpNotSupportedInDialect rejection (with op-label assertion), Django-shape parser routing, non-string value → `InvalidLookupValue`, `__nope_typo` error advertises the trigram suffixes, single-string param binding

🤖 Generated with [Claude Code](https://claude.com/claude-code)