### PR TITLE
feat: rustango::test_filter + tags! macro — Django @tag parity (closes #45 partial)

### DIFF
--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -847,6 +847,13 @@ pub mod auth_decorators;
 /// Response objects. Issue #40.
 pub mod test_assertions;
 
+/// Tag-based test filtering — Django's `@tag('slow')` +
+/// `manage test --tag fast --exclude-tag slow`. Drop `tags!("slow")`
+/// at the top of a `#[test]` body; the test self-skips when the
+/// `RUSTANGO_TEST_TAGS` / `RUSTANGO_TEST_EXCLUDE_TAGS` env vars
+/// filter it out. Issue #45.
+pub mod test_filter;
+
 /// `manage dbshell` — spawn `psql` / `mysql` / `sqlite3` for the
 /// current `DATABASE_URL`. Issue #56 (partial).
 pub mod dbshell;

--- a/crates/rustango/src/test_filter.rs
+++ b/crates/rustango/src/test_filter.rs
@@ -1,0 +1,214 @@
+//! Tag-based test filtering — Django's `@tag('slow', 'core')` +
+//! `manage test --tag fast --exclude-tag slow`. Issue #45.
+//!
+//! Rust has no built-in per-test tag mechanism (`cargo test` only
+//! filters on substring match against the test name). This module
+//! provides a thin convention that works with stock `#[test]` /
+//! `#[tokio::test]`:
+//!
+//! ```ignore
+//! use rustango::test_filter::tags;
+//!
+//! #[tokio::test]
+//! async fn expensive_integration() {
+//!     tags!("slow", "integration");
+//!     // ...heavy work...
+//! }
+//! ```
+//!
+//! The [`tags!`] macro reads the `RUSTANGO_TEST_TAGS` (CSV, include
+//! list) and `RUSTANGO_TEST_EXCLUDE_TAGS` (CSV, exclude list) env
+//! vars and early-returns from the test if filtered out. The test
+//! still shows as `ok` in `cargo test` output — that's the same
+//! shape `#[ignore]` would give, just gated on runtime env instead
+//! of source-time attribute.
+//!
+//! ## Semantics
+//!
+//! - Include list **empty** (env unset) → include everything.
+//! - Include list **non-empty** → run only tests whose tag set
+//!   intersects the include list.
+//! - Exclude list always wins: any tag in the exclude list filters
+//!   the test out.
+//! - Tags are case-sensitive and trimmed; empty CSV tokens are
+//!   ignored.
+//!
+//! ## Examples
+//!
+//! ```text
+//! # default — run every test
+//! cargo test
+//!
+//! # only `slow`-tagged tests
+//! RUSTANGO_TEST_TAGS=slow cargo test
+//!
+//! # skip `slow`-tagged tests
+//! RUSTANGO_TEST_EXCLUDE_TAGS=slow cargo test
+//!
+//! # combine: only `core` *and* not `flaky`
+//! RUSTANGO_TEST_TAGS=core RUSTANGO_TEST_EXCLUDE_TAGS=flaky cargo test
+//! ```
+
+/// Environment variable name for the CSV include list.
+pub const ENV_INCLUDE: &str = "RUSTANGO_TEST_TAGS";
+
+/// Environment variable name for the CSV exclude list.
+pub const ENV_EXCLUDE: &str = "RUSTANGO_TEST_EXCLUDE_TAGS";
+
+/// Decide whether a test marked with `tags` should execute.
+///
+/// Reads `RUSTANGO_TEST_TAGS` / `RUSTANGO_TEST_EXCLUDE_TAGS` at call
+/// time. Returns `true` to run; `false` to skip.
+#[must_use]
+pub fn should_run(tags: &[&str]) -> bool {
+    should_run_with(tags, |name| std::env::var(name).ok())
+}
+
+/// Same as [`should_run`] but reads env vars through an injectable
+/// resolver. The standard `should_run` is a thin wrapper that passes
+/// `std::env::var(...).ok()`; this variant lets tests inject a fake
+/// resolver without touching process-global env (which is unsafe to
+/// mutate under `forbid(unsafe_code)` on Rust 2024+).
+#[must_use]
+pub fn should_run_with(tags: &[&str], env_get: impl Fn(&str) -> Option<String>) -> bool {
+    let include = env_get(ENV_INCLUDE).unwrap_or_default();
+    let exclude = env_get(ENV_EXCLUDE).unwrap_or_default();
+    decide(tags, &include, &exclude)
+}
+
+/// Pure decision function — same logic as [`should_run`] but with
+/// explicit `include`/`exclude` CSV strings. Useful for unit-testing
+/// the policy without env-var fiddling.
+#[must_use]
+pub fn decide(tags: &[&str], include_csv: &str, exclude_csv: &str) -> bool {
+    let include: Vec<&str> = csv(include_csv);
+    let exclude: Vec<&str> = csv(exclude_csv);
+
+    // Exclude wins: any overlap with the exclude list filters out.
+    if tags.iter().any(|t| exclude.contains(t)) {
+        return false;
+    }
+    // Empty include list = run everything.
+    if include.is_empty() {
+        return true;
+    }
+    // Non-empty include: at least one of the test's tags must
+    // appear in the include list.
+    tags.iter().any(|t| include.contains(t))
+}
+
+fn csv(s: &str) -> Vec<&str> {
+    s.split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .collect()
+}
+
+/// Declare this test's tags and early-return if the current
+/// `RUSTANGO_TEST_TAGS` / `RUSTANGO_TEST_EXCLUDE_TAGS` env vars
+/// say it shouldn't run. Place at the top of the test body —
+/// before any setup that you don't want to run for filtered-out
+/// tests.
+///
+/// ```ignore
+/// #[tokio::test]
+/// async fn slow_integration() {
+///     rustango::tags!("slow", "integration");
+///     // ...
+/// }
+/// ```
+#[macro_export]
+macro_rules! tags {
+    ($($tag:expr),+ $(,)?) => {
+        if !$crate::test_filter::should_run(&[$($tag),+]) {
+            return;
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_include_and_exclude_runs_everything() {
+        assert!(decide(&["slow"], "", ""));
+        assert!(decide(&[], "", ""));
+        assert!(decide(&["a", "b"], "", ""));
+    }
+
+    #[test]
+    fn include_filters_in_matching_tags() {
+        assert!(decide(&["slow"], "slow", ""));
+        assert!(decide(&["slow", "core"], "core", ""));
+        assert!(!decide(&["slow"], "fast", ""));
+        assert!(
+            !decide(&[], "fast", ""),
+            "untagged test skipped when include set"
+        );
+    }
+
+    #[test]
+    fn exclude_filters_out_matching_tags() {
+        assert!(!decide(&["slow"], "", "slow"));
+        assert!(!decide(&["slow", "core"], "", "slow"));
+        assert!(decide(&["core"], "", "slow"));
+    }
+
+    #[test]
+    fn exclude_wins_over_include() {
+        // tagged with both — include says yes, exclude says no →
+        // exclude wins.
+        assert!(!decide(&["core", "flaky"], "core", "flaky"));
+    }
+
+    #[test]
+    fn csv_handles_whitespace_and_empties() {
+        assert!(decide(&["slow"], " slow , fast ", ""));
+        assert!(!decide(&["slow"], "fast,, ,", ""));
+        assert!(!decide(&["slow"], "", " slow , "));
+    }
+
+    #[test]
+    fn case_sensitive_tags() {
+        // Tags are case-sensitive — `Slow` and `slow` are distinct.
+        assert!(!decide(&["Slow"], "slow", ""));
+        assert!(decide(&["slow"], "slow", ""));
+    }
+
+    #[test]
+    fn macro_compiles_with_one_tag() {
+        // We can't easily test the early-return without spawning a
+        // child process, but we *can* verify the macro expands and
+        // type-checks. This test always runs (the include list is
+        // empty under normal cargo test invocation).
+        crate::tags!("compile-check");
+        // If we got here, the macro didn't filter us out.
+        let _ = 1 + 1;
+    }
+
+    #[test]
+    fn macro_compiles_with_multiple_tags_and_trailing_comma() {
+        crate::tags!("a", "b", "c",);
+        let _ = 1 + 1;
+    }
+
+    #[test]
+    fn should_run_with_uses_injected_env_resolver() {
+        let env = |name: &str| match name {
+            ENV_INCLUDE => Some("fast".to_owned()),
+            ENV_EXCLUDE => Some("slow".to_owned()),
+            _ => None,
+        };
+        assert!(should_run_with(&["fast"], &env));
+        assert!(!should_run_with(&["slow"], &env));
+        assert!(!should_run_with(&["other"], &env));
+    }
+
+    #[test]
+    fn should_run_with_empty_resolver_runs_everything() {
+        let env = |_: &str| None;
+        assert!(should_run_with(&["slow"], &env));
+        assert!(should_run_with(&[], &env));
+    }
+}


### PR DESCRIPTION
## Summary
Add `rustango::test_filter` module + `tags!` macro for Django-style test tagging:

\`\`\`rust
#[tokio::test]
async fn expensive_integration() {
    rustango::tags!(\"slow\", \"integration\");
    // ...heavy work, only runs when filter allows...
}
\`\`\`

The macro reads `RUSTANGO_TEST_TAGS` (CSV include) and `RUSTANGO_TEST_EXCLUDE_TAGS` (CSV exclude) and early-returns from the test if filtered out — same `ok` shape as `#[ignore]`, but gated on runtime env instead of source-time attribute.

## Semantics
- Empty include → run everything
- Non-empty include → run iff tag set intersects include
- Exclude always wins
- Case-sensitive, whitespace-trimmed, empty CSV tokens ignored

## Why a runtime macro instead of a proc-attribute?
- Works with both `#[test]` and `#[tokio::test]` without per-runtime adapters
- No proc-macro dep added; lib already heavy
- `should_run_with(tags, env_get)` exposes the same logic with an injectable env resolver — needed for unit tests because `std::env::set_var` is `unsafe` under Rust 2024 and the workspace `forbid(unsafe_code)`s

## Scope
Covers Django `@tag` semantics + the env-var filter shape. The full ticket also asks for `manage test --tag fast` integration — that hooks into a future `manage test` verb (today's manage runner only proxies `make:*`); queued separately.

## Usage examples
\`\`\`text
# default — run every test
cargo test

# only slow-tagged tests
RUSTANGO_TEST_TAGS=slow cargo test

# skip slow-tagged tests
RUSTANGO_TEST_EXCLUDE_TAGS=slow cargo test

# combine: only core *and* not flaky
RUSTANGO_TEST_TAGS=core RUSTANGO_TEST_EXCLUDE_TAGS=flaky cargo test
\`\`\`

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test --workspace --all-features --no-run` (CI-vs-local pre-push gate)
- [x] `cargo build --no-default-features --features sqlite,tenancy` (sqlite-tenancy litmus)
- [x] 10 new `test_filter::tests::*` cases covering: empty-env-runs-all, include filter, exclude filter, exclude-wins-over-include, CSV trim + empty-token handling, case sensitivity, macro compile-check w/ single + multi-tag-trailing-comma forms, `should_run_with` injection
- [x] `cargo test --lib --all-features` → 1715 pass (+10 over pre-PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)