### PR TITLE
feat: i18n::tera_tags — {{ translate(...) }} fn + filter (closes #18 partial)

### DIFF
--- a/crates/rustango/src/i18n/mod.rs
+++ b/crates/rustango/src/i18n/mod.rs
@@ -40,6 +40,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::RwLock;
 
+pub mod tera_tags;
+
 // ------------------------------------------------------------------ Locale
 
 /// A locale identifier (e.g. `"en"`, `"en-US"`, `"fr"`).

--- a/crates/rustango/src/i18n/tera_tags.rs
+++ b/crates/rustango/src/i18n/tera_tags.rs
@@ -1,0 +1,266 @@
+//! Tera bindings for `rustango::i18n::Translator` — Django's
+//! `{% translate %}` / `{% blocktranslate %}` template tags.
+//! Issue #18 (partial).
+//!
+//! Tera doesn't support custom block tags (only filters + functions),
+//! so the Django `{% blocktranslate %}…{% endblocktranslate %}` and
+//! `{% language %}…{% endlanguage %}` block shapes can't be a 1:1
+//! port. This module ships the filter/function shape, which covers
+//! the common cases:
+//!
+//! ```ignore
+//! use std::sync::Arc;
+//! use rustango::i18n::{Translator, Locale};
+//!
+//! let translator = Arc::new(
+//!     Translator::new(Locale::new("en"))
+//!         .add_locale(Locale::new("en"), [
+//!             ("welcome".to_owned(), "Welcome, {name}!".to_owned()),
+//!         ].into())
+//! );
+//! let mut tera = tera::Tera::default();
+//! rustango::i18n::tera_tags::register(&mut tera, Arc::clone(&translator));
+//!
+//! // Inject the active locale into the per-request context (typically
+//! // done by middleware that reads Accept-Language).
+//! let mut ctx = tera::Context::new();
+//! ctx.insert("LANG", "en");
+//!
+//! // Now templates can call:
+//! //   {{ translate(key="welcome", locale=LANG, name=user.name) }}
+//! //   {{ "welcome" | translate(locale=LANG, name=user.name) }}
+//! ```
+//!
+//! ## Convention: `LANG` / `TIME_ZONE` context keys
+//!
+//! By Django convention rustango uses the context keys `LANG` for
+//! the active locale and `TIME_ZONE` for the active timezone. App
+//! code (or `LocaleMiddleware` once it lands) injects them before
+//! render; templates read them as plain variables — no special tag
+//! needed for `{% get_current_language %}` etc.
+//!
+//! ## What's missing vs Django
+//! - `{% blocktranslate %}…{% endblocktranslate %}` block form (Tera
+//!   has no block-tag extension API).
+//! - `{% plural %}` pluralization rules (no plural-rules table yet
+//!   in `rustango::i18n`).
+//! - `{% language 'fr' %}…{% endlanguage %}` override blocks.
+//!
+//! Workaround for blocks: precompute the translated string in
+//! handler code and pass it through the context.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tera::{Tera, Value};
+
+use super::Translator;
+
+/// Register the i18n filter + function on `tera`. Both forms share
+/// the same translator instance; clone it cheaply on each call via
+/// the `Arc`.
+pub fn register(tera: &mut Tera, translator: Arc<Translator>) {
+    let t_fn = Arc::clone(&translator);
+    tera.register_function(
+        "translate",
+        move |args: &HashMap<String, Value>| -> tera::Result<Value> {
+            let key = args
+                .get("key")
+                .and_then(Value::as_str)
+                .ok_or_else(|| tera::Error::msg("translate(): missing required `key` argument"))?;
+            Ok(Value::String(do_translate(&t_fn, key, args)))
+        },
+    );
+
+    let t_filter = Arc::clone(&translator);
+    tera.register_filter(
+        "translate",
+        move |value: &Value, args: &HashMap<String, Value>| -> tera::Result<Value> {
+            let key = value.as_str().ok_or_else(|| {
+                tera::Error::msg("translate filter: input must be a string (the translation key)")
+            })?;
+            Ok(Value::String(do_translate(&t_filter, key, args)))
+        },
+    );
+}
+
+/// Shared body for the function + filter shapes — extract the locale
+/// arg, collect every other string arg as an interpolation pair, and
+/// dispatch to [`Translator::translate`]. Non-string args are
+/// silently dropped (matches Django: only `string|string` placeholder
+/// substitutions are supported).
+fn do_translate(translator: &Translator, key: &str, args: &HashMap<String, Value>) -> String {
+    let locale = args.get("locale").and_then(Value::as_str).unwrap_or("");
+    // Collect string-valued interp args. Allocate owned strings up
+    // front so the `&str` slice we pass into `translate` stays alive.
+    let interp_owned: Vec<(String, String)> = args
+        .iter()
+        .filter(|(k, _)| k.as_str() != "key" && k.as_str() != "locale")
+        .filter_map(|(k, v)| {
+            // Strings pass through; numbers / bools render via Display
+            // so `{{ translate(key=..., count=3) }}` interpolates as
+            // "3" rather than failing.
+            let rendered = match v {
+                Value::String(s) => s.clone(),
+                Value::Number(n) => n.to_string(),
+                Value::Bool(b) => b.to_string(),
+                _ => return None,
+            };
+            Some((k.clone(), rendered))
+        })
+        .collect();
+    let interp_refs: Vec<(&str, &str)> = interp_owned
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    translator.translate(locale, key, &interp_refs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::i18n::Locale;
+    use tera::Context;
+
+    fn make_translator() -> Arc<Translator> {
+        let mut en = HashMap::new();
+        en.insert("welcome".to_owned(), "Welcome, {name}!".to_owned());
+        en.insert(
+            "items_count".to_owned(),
+            "You have {count} items".to_owned(),
+        );
+        en.insert("plain".to_owned(), "Hello world".to_owned());
+        let mut fr = HashMap::new();
+        fr.insert("welcome".to_owned(), "Bienvenue, {name} !".to_owned());
+        fr.insert("plain".to_owned(), "Bonjour le monde".to_owned());
+        Arc::new(
+            Translator::new(Locale::new("en"))
+                .add_locale(Locale::new("en"), en)
+                .add_locale(Locale::new("fr"), fr),
+        )
+    }
+
+    fn render(template: &str, ctx: &Context, translator: Arc<Translator>) -> String {
+        let mut tera = Tera::default();
+        register(&mut tera, translator);
+        tera.add_raw_template("t", template).unwrap();
+        tera.render("t", ctx).unwrap()
+    }
+
+    #[test]
+    fn translate_function_with_key_only() {
+        let out = render(
+            r#"{{ translate(key="plain", locale="en") }}"#,
+            &Context::new(),
+            make_translator(),
+        );
+        assert_eq!(out, "Hello world");
+    }
+
+    #[test]
+    fn translate_function_with_interpolation() {
+        let out = render(
+            r#"{{ translate(key="welcome", locale="en", name="Alice") }}"#,
+            &Context::new(),
+            make_translator(),
+        );
+        assert_eq!(out, "Welcome, Alice!");
+    }
+
+    #[test]
+    fn translate_function_picks_locale() {
+        let out = render(
+            r#"{{ translate(key="welcome", locale="fr", name="Alice") }}"#,
+            &Context::new(),
+            make_translator(),
+        );
+        assert_eq!(out, "Bienvenue, Alice !");
+    }
+
+    #[test]
+    fn translate_function_falls_back_to_default_locale() {
+        let out = render(
+            r#"{{ translate(key="items_count", locale="fr", count=5) }}"#,
+            &Context::new(),
+            make_translator(),
+        );
+        // fr catalog has no `items_count` → falls back to en.
+        assert_eq!(out, "You have 5 items");
+    }
+
+    #[test]
+    fn translate_function_uses_lang_context_key() {
+        let mut ctx = Context::new();
+        ctx.insert("LANG", "fr");
+        let out = render(
+            r#"{{ translate(key="plain", locale=LANG) }}"#,
+            &ctx,
+            make_translator(),
+        );
+        assert_eq!(out, "Bonjour le monde");
+    }
+
+    #[test]
+    fn translate_filter_with_string_literal_key() {
+        let out = render(
+            r#"{{ "welcome" | translate(locale="en", name="Bob") }}"#,
+            &Context::new(),
+            make_translator(),
+        );
+        assert_eq!(out, "Welcome, Bob!");
+    }
+
+    #[test]
+    fn translate_filter_with_variable_key_from_context() {
+        let mut ctx = Context::new();
+        ctx.insert("KEY", "plain");
+        let out = render(
+            r#"{{ KEY | translate(locale="en") }}"#,
+            &ctx,
+            make_translator(),
+        );
+        assert_eq!(out, "Hello world");
+    }
+
+    #[test]
+    fn translate_function_with_numeric_arg_interpolates_display() {
+        let out = render(
+            r#"{{ translate(key="items_count", locale="en", count=42) }}"#,
+            &Context::new(),
+            make_translator(),
+        );
+        assert_eq!(out, "You have 42 items");
+    }
+
+    #[test]
+    fn translate_function_returns_key_when_missing() {
+        let out = render(
+            r#"{{ translate(key="missing_key", locale="en") }}"#,
+            &Context::new(),
+            make_translator(),
+        );
+        assert_eq!(out, "missing_key");
+    }
+
+    #[test]
+    fn translate_function_errors_without_key() {
+        let mut tera = Tera::default();
+        register(&mut tera, make_translator());
+        tera.add_raw_template("t", r#"{{ translate(locale="en") }}"#)
+            .unwrap();
+        let err = tera.render("t", &Context::new()).unwrap_err();
+        // Tera wraps the function error in a "Failed to render" outer.
+        // Walk the source chain to find our message about `key`.
+        let mut chain: Vec<String> = vec![format!("{err}")];
+        let mut src: Option<&(dyn std::error::Error + 'static)> = std::error::Error::source(&err);
+        while let Some(e) = src {
+            chain.push(format!("{e}"));
+            src = e.source();
+        }
+        let joined = chain.join(" | ");
+        assert!(
+            joined.contains("key"),
+            "expected error chain to mention `key`, got: {joined}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Add Tera bindings for `rustango::i18n::Translator` so templates can call:

\`\`\`tera
{{ translate(key=\"welcome\", locale=LANG, name=user.name) }}
{{ \"welcome\" | translate(locale=LANG, name=user.name) }}
\`\`\`

Function + filter share the same `Arc<Translator>`. Numeric / bool args render via Display so `count=5` interpolates as `\"5\"` without ceremony. Missing keys fall back to the default locale, then to the raw key (matches `Translator::translate`).

## Convention: `LANG` / `TIME_ZONE` context keys
By Django convention, app code / middleware inserts the active locale into the per-request Tera Context under the `LANG` key (and `TIME_ZONE` when timezone support lands). Templates read it as a plain variable — no separate `{% get_current_language %}` tag needed.

## Scope
Filter + function shapes only. Tera has no block-tag extension API, so Django's `{% blocktranslate %}…{% endblocktranslate %}`, `{% plural %}` pluralization, and `{% language %}…{% endlanguage %}` override blocks are *not* in this slice — workaround is to precompute the translated string in the handler. Documented in the module-level doc.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test --workspace --all-features --no-run` (CI-vs-local pre-push gate)
- [x] `cargo build --no-default-features --features sqlite,tenancy` (sqlite-tenancy litmus)
- [x] 10 new `i18n::tera_tags::tests::*` cases covering: function w/ key only, w/ interpolation, locale picker, fallback to default locale, `LANG` context-key path, filter w/ literal key, filter w/ variable key from context, numeric arg → Display interpolation, missing-key → raw key, missing-required-key arg → tera::Error walking source chain
- [x] `cargo test --lib --all-features` → 1725 pass (+10 over pre-PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)