### PR TITLE
feat: SIMILARITY / WORD_SIMILARITY pg_trgm scalar fns (issue #29 follow-up)

### DIFF
--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -314,6 +314,20 @@ pub enum ScalarFn {
     /// Truncate timestamp to the start of the day. PG: `DATE_TRUNC('day', x)`
     /// (returns timestamp). MySQL / SQLite: `DATE(x)` / `date(x)` (date).
     TruncDay,
+
+    // --- pg_trgm (issue #29 follow-up) ---
+    /// `SIMILARITY(a, b)` — pg_trgm whole-string trigram similarity,
+    /// returns a `real` in `[0, 1]`. Useful as an annotation +
+    /// ORDER BY for ranked fuzzy search. Requires `CREATE EXTENSION
+    /// pg_trgm`. **PG-only** — MySQL / SQLite emit
+    /// `OpNotSupportedInDialect`. Pairs with `Op::TrigramSimilar`
+    /// (the WHERE-clause `%` operator) shipped earlier in the same
+    /// issue. Arity 2.
+    TrigramSimilarity,
+    /// `WORD_SIMILARITY(a, b)` — pg_trgm word-level similarity.
+    /// **PG-only**, same dialect rules as [`Self::TrigramSimilarity`].
+    /// Pairs with `Op::TrigramWordSimilar`. Arity 2.
+    TrigramWordSimilarity,
 }
 
 impl Expr {

--- a/crates/rustango/src/core/funcs.rs
+++ b/crates/rustango/src/core/funcs.rs
@@ -390,6 +390,43 @@ where
     }
 }
 
+// ---------- pg_trgm functions (issue #29 follow-up) ----------
+
+/// `SIMILARITY(a, b)` — pg_trgm trigram similarity, returns a `real`
+/// in `[0, 1]`. Useful as an annotation + ORDER BY for ranked fuzzy
+/// search:
+///
+/// ```ignore
+/// use rustango::core::F;
+/// use rustango::core::funcs::trigram_similarity;
+/// Article::objects()
+///     .annotate("rank", trigram_similarity(F("title"), "rusty programming"))
+///     .order_by_desc("rank")
+/// ```
+///
+/// Requires `CREATE EXTENSION pg_trgm` on the database. **PG-only** —
+/// MySQL / SQLite reject at compile time.
+#[must_use]
+pub fn trigram_similarity(a: impl Into<Expr>, b: impl Into<Expr>) -> Expr {
+    Expr::Function {
+        kind: ScalarFn::TrigramSimilarity,
+        args: vec![a.into(), b.into()],
+    }
+}
+
+/// `WORD_SIMILARITY(a, b)` — pg_trgm word-level similarity. Matches
+/// the per-word variant of [`trigram_similarity`]; pairs with the
+/// `__trigram_word_similar` WHERE-clause lookup.
+///
+/// Requires `CREATE EXTENSION pg_trgm`. **PG-only**.
+#[must_use]
+pub fn trigram_word_similarity(a: impl Into<Expr>, b: impl Into<Expr>) -> Expr {
+    Expr::Function {
+        kind: ScalarFn::TrigramWordSimilarity,
+        args: vec![a.into(), b.into()],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -1535,6 +1535,43 @@ fn write_function(
             Ok(())
         }
         F::TruncYear | F::TruncMonth | F::TruncDay => write_trunc(b, kind, args),
+
+        // -------- pg_trgm: PG-only, arity 2 --------
+        F::TrigramSimilarity | F::TrigramWordSimilarity => {
+            let fname = if matches!(kind, F::TrigramWordSimilarity) {
+                "WORD_SIMILARITY"
+            } else {
+                "SIMILARITY"
+            };
+            if args.len() != 2 {
+                return Err(SqlError::FunctionArityMismatch {
+                    func: if matches!(kind, F::TrigramWordSimilarity) {
+                        "WORD_SIMILARITY"
+                    } else {
+                        "SIMILARITY"
+                    },
+                    expected: "2",
+                    got: args.len(),
+                });
+            }
+            if b.d.name() != "postgres" {
+                return Err(SqlError::OpNotSupportedInDialect {
+                    op: if matches!(kind, F::TrigramWordSimilarity) {
+                        "WORD_SIMILARITY (pg_trgm) is Postgres-only"
+                    } else {
+                        "SIMILARITY (pg_trgm) is Postgres-only"
+                    },
+                    dialect: b.d.name(),
+                });
+            }
+            b.sql.push_str(fname);
+            b.sql.push('(');
+            write_expr(b, &args[0], None)?;
+            b.sql.push_str(", ");
+            write_expr(b, &args[1], None)?;
+            b.sql.push(')');
+            Ok(())
+        }
     }
 }
 

--- a/crates/rustango/tests/trigram_similarity_emission.rs
+++ b/crates/rustango/tests/trigram_similarity_emission.rs
@@ -1,0 +1,151 @@
+//! Emission tests for `SIMILARITY` / `WORD_SIMILARITY` pg_trgm
+//! annotation functions (issue #29 follow-up). PG emits the
+//! native calls; MySQL and SQLite reject with
+//! `OpNotSupportedInDialect`.
+//!
+//! Pairs with the `__trigram_similar` / `__trigram_word_similar`
+//! WHERE-clause lookups (already shipped).
+
+use rustango::core::funcs::{trigram_similarity, trigram_word_similarity};
+use rustango::core::{
+    Assignment, Expr, Filter, Model as _, Op, ScalarFn, SqlValue, UpdateQuery, WhereExpr, F,
+};
+#[cfg(feature = "mysql")]
+use rustango::sql::MySql;
+#[cfg(feature = "sqlite")]
+use rustango::sql::Sqlite;
+use rustango::sql::{Dialect, Postgres, SqlError};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "trg_sim_doc")]
+#[allow(dead_code)]
+pub struct Doc {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 200)]
+    title: String,
+    rank: f64,
+}
+
+fn update_set(value: Expr) -> UpdateQuery {
+    UpdateQuery {
+        model: Doc::SCHEMA,
+        set: vec![Assignment {
+            column: "rank",
+            value,
+        }],
+        where_clause: WhereExpr::Predicate(Filter {
+            column: "id",
+            op: Op::Eq,
+            value: SqlValue::I64(1),
+        }),
+    }
+}
+
+// ---------- PG: native SIMILARITY / WORD_SIMILARITY ----------
+
+#[test]
+fn pg_emits_similarity_call() {
+    let q = update_set(trigram_similarity(F("title"), "rust orm"));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"SIMILARITY("title", $1)"#),
+        "PG SIMILARITY: {}",
+        stmt.sql
+    );
+    // Pattern bound as the only string param.
+    assert!(
+        stmt.params
+            .iter()
+            .any(|p| matches!(p, SqlValue::String(s) if s == "rust orm")),
+        "pattern bound as param: {:?}",
+        stmt.params
+    );
+}
+
+#[test]
+fn pg_emits_word_similarity_call() {
+    let q = update_set(trigram_word_similarity(F("title"), "rust"));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"WORD_SIMILARITY("title", $1)"#),
+        "PG WORD_SIMILARITY: {}",
+        stmt.sql
+    );
+}
+
+// ---------- MySQL / SQLite: rejected at compile time ----------
+
+#[cfg(feature = "mysql")]
+#[test]
+fn mysql_rejects_similarity_with_clean_error() {
+    let q = update_set(trigram_similarity(F("title"), "rust"));
+    let err = MySql.compile_update(&q).unwrap_err();
+    match err {
+        SqlError::OpNotSupportedInDialect { op, dialect } => {
+            assert!(op.contains("SIMILARITY"), "op label: {op}");
+            assert_eq!(dialect, "mysql");
+        }
+        other => panic!("expected OpNotSupportedInDialect, got: {other:?}"),
+    }
+}
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn sqlite_rejects_word_similarity_with_clean_error() {
+    let q = update_set(trigram_word_similarity(F("title"), "rust"));
+    let err = Sqlite.compile_update(&q).unwrap_err();
+    match err {
+        SqlError::OpNotSupportedInDialect { op, dialect } => {
+            assert!(op.contains("WORD_SIMILARITY"), "op label: {op}");
+            assert_eq!(dialect, "sqlite");
+        }
+        other => panic!("expected OpNotSupportedInDialect, got: {other:?}"),
+    }
+}
+
+// ---------- Arity check (writer-level) ----------
+
+#[test]
+fn similarity_with_wrong_arity_returns_function_arity_mismatch() {
+    // Hand-build an Expr with arity 1 to bypass the helper fn's
+    // type-locked 2-arg signature. The writer should surface
+    // FunctionArityMismatch.
+    let bad = Expr::Function {
+        kind: ScalarFn::TrigramSimilarity,
+        args: vec![F("title").into()],
+    };
+    let q = update_set(bad);
+    let err = Postgres.compile_update(&q).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            SqlError::FunctionArityMismatch {
+                func: "SIMILARITY",
+                ..
+            }
+        ),
+        "expected FunctionArityMismatch{{ func: \"SIMILARITY\" }}, got: {err:?}"
+    );
+}
+
+#[test]
+fn word_similarity_with_three_args_arity_error() {
+    let bad = Expr::Function {
+        kind: ScalarFn::TrigramWordSimilarity,
+        args: vec![F("title").into(), F("title").into(), F("title").into()],
+    };
+    let q = update_set(bad);
+    let err = Postgres.compile_update(&q).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            SqlError::FunctionArityMismatch {
+                func: "WORD_SIMILARITY",
+                ..
+            }
+        ),
+        "expected FunctionArityMismatch{{ func: \"WORD_SIMILARITY\" }}, got: {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary
Follow-up to PR #130 (trigram WHERE-clause lookups). Adds the scalar-function half:

- `ScalarFn::TrigramSimilarity` + `ScalarFn::TrigramWordSimilarity` enum variants
- Public helpers `core::funcs::trigram_similarity(a, b)` + `trigram_word_similarity(a, b)`
- PG emits `SIMILARITY(<col>, <pattern>)` / `WORD_SIMILARITY(<col>, <pattern>)` (arity 2, returns `real` in `[0, 1]`)
- MySQL / SQLite reject at compile time with `SqlError::OpNotSupportedInDialect` (op label mentions the function name)
- Wrong arity → `FunctionArityMismatch { func: \"SIMILARITY\" / \"WORD_SIMILARITY\", ... }`

## Usage shape (once the non-aggregate annotation slot lands)
\`\`\`rust
use rustango::core::funcs::trigram_similarity;
use rustango::core::F;

Article::objects()
    .annotate(\"rank\", trigram_similarity(F(\"title\"), \"rust orm\"))
    .order_by_desc(\"rank\")
\`\`\`

## Scope note
Today's `QuerySet::annotate(...)` only accepts `AggregateExpr` — not a scalar `Expr`. So the *call site* above doesn't compile yet. This PR ships the dialect-correct **emitter** so a future non-aggregate annotation slot just routes through; users can also use the new helpers anywhere an `Expr` is accepted (e.g. `UpdateQuery::set`, `CASE`/`WHEN` branches).

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test --workspace --all-features --no-run` (CI-vs-local pre-push gate)
- [x] `cargo build --no-default-features --features sqlite,tenancy` (sqlite-tenancy litmus)
- [x] New `crates/rustango/tests/trigram_similarity_emission.rs` — 6 tests covering: PG SIMILARITY emit, PG WORD_SIMILARITY emit, pattern-as-param binding, MySQL rejection (op label contains SIMILARITY), SQLite rejection (op label contains WORD_SIMILARITY), arity-1 → FunctionArityMismatch, arity-3 → FunctionArityMismatch
- [x] `cargo test --lib --all-features` → 1725 pass (parity, no new lib tests; new tests live in the integration binary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)