### PR TITLE
fix(tests): serialize on_commit_live DROP+CREATE with a suite-wide mutex

### DIFF
--- a/crates/rustango/tests/on_commit_live.rs
+++ b/crates/rustango/tests/on_commit_live.rs
@@ -6,9 +6,22 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use rustango::sql::{on_commit, on_commit_pending, sqlx, ExecError, Pool, PoolTx};
+use tokio::sync::{Mutex, MutexGuard};
 
-async fn fresh_pool() -> Option<Pool> {
+/// Suite-wide mutex — every test in this file shares the `oc_widget`
+/// table for DROP + CREATE + INSERT + SELECT. Cargo runs tests in
+/// parallel by default, so without this lock two `fresh_pool()` calls
+/// race the `CREATE TABLE` and PG returns `pg_type_typname_nsp_index`
+/// unique-violation. The lock serializes the entire test body, not
+/// just the DDL, so commit-counter observations stay deterministic.
+static TABLE_LOCK: Mutex<()> = Mutex::const_new(());
+
+async fn fresh_pool() -> Option<(Pool, MutexGuard<'static, ()>)> {
     let url = std::env::var("DATABASE_URL").ok()?;
+    // Poison-tolerant: tokio's Mutex doesn't poison on panic, so a
+    // panicking test won't strand the lock — but we still want a
+    // single owner at a time.
+    let guard = TABLE_LOCK.lock().await;
     let pg = sqlx::PgPool::connect(&url).await.ok()?;
     sqlx::query(r#"DROP TABLE IF EXISTS "oc_widget" CASCADE"#)
         .execute(&pg)
@@ -25,7 +38,7 @@ async fn fresh_pool() -> Option<Pool> {
     .execute(&pg)
     .await
     .unwrap();
-    Some(Pool::Postgres(pg))
+    Some((Pool::Postgres(pg), guard))
 }
 
 async fn count_widgets(pool: &Pool) -> i64 {
@@ -40,7 +53,7 @@ async fn count_widgets(pool: &Pool) -> i64 {
 
 #[tokio::test]
 async fn callback_fires_after_commit() {
-    let Some(pool) = fresh_pool().await else {
+    let Some((pool, _guard)) = fresh_pool().await else {
         return;
     };
     let counter = Arc::new(AtomicUsize::new(0));
@@ -72,7 +85,7 @@ async fn callback_fires_after_commit() {
 
 #[tokio::test]
 async fn callback_does_not_fire_after_rollback() {
-    let Some(pool) = fresh_pool().await else {
+    let Some((pool, _guard)) = fresh_pool().await else {
         return;
     };
     let counter = Arc::new(AtomicUsize::new(0));
@@ -105,7 +118,7 @@ async fn callback_does_not_fire_after_rollback() {
 
 #[tokio::test]
 async fn callbacks_fire_in_registration_order() {
-    let Some(pool) = fresh_pool().await else {
+    let Some((pool, _guard)) = fresh_pool().await else {
         return;
     };
     let order = Arc::new(std::sync::Mutex::new(Vec::<u32>::new()));
@@ -129,7 +142,7 @@ async fn callbacks_fire_in_registration_order() {
 
 #[tokio::test]
 async fn on_commit_pending_reflects_queue_depth() {
-    let Some(pool) = fresh_pool().await else {
+    let Some((pool, _guard)) = fresh_pool().await else {
         return;
     };
     rustango::atomic!(&pool, |_tx| {
@@ -170,7 +183,7 @@ async fn on_commit_outside_atomic_panics() {
 
 #[tokio::test]
 async fn nested_atomic_inner_rollback_isolated_from_outer() {
-    let Some(pool) = fresh_pool().await else {
+    let Some((pool, _guard)) = fresh_pool().await else {
         return;
     };
     let outer = Arc::new(AtomicUsize::new(0));
@@ -211,7 +224,7 @@ async fn nested_atomic_inner_rollback_isolated_from_outer() {
 
 #[tokio::test]
 async fn nested_atomic_outer_rollback_drops_both_queues() {
-    let Some(pool) = fresh_pool().await else {
+    let Some((pool, _guard)) = fresh_pool().await else {
         return;
     };
     let outer = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
## Summary
Main-branch CI was failing intermittently after PR #128 with `pg_type_typname_nsp_index` / `pg_class_relname_nsp_index` duplicate-key violations on the `oc_widget` table — two `#[tokio::test]`s in `tests/on_commit_live.rs` racing `fresh_pool()` and both reaching `CREATE TABLE` simultaneously against the shared CI Postgres database.

This is the textbook \"tests on global state need a mutex\" pattern. Fix:

- Add a `static TABLE_LOCK: tokio::sync::Mutex<()>` in the test file.
- `fresh_pool()` returns `Option<(Pool, MutexGuard<'static, ()>)>` — the guard lives in each test's scope, so DROP + CREATE + every assertion runs while holding the lock.
- Every test destructures `let Some((pool, _guard)) = fresh_pool().await else { return; };`.

Tests in other binaries are unaffected — only this file's tests serialize. Local impact: when `DATABASE_URL` is unset, every test still early-returns (no behaviour change).

## Why this happened
The original `fresh_pool()` did `DROP TABLE IF EXISTS oc_widget; CREATE TABLE oc_widget(...)`. Cargo runs tests in parallel by default; on CI's busy runner the window between two parallel DROPs and two parallel CREATEs collides on PG's `pg_type` / `pg_class` catalog unique indexes.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test --workspace --all-features --no-run` (CI-vs-local pre-push gate)
- [x] `cargo test --all-features --test on_commit_live` locally — all 8 pass (most early-return without DATABASE_URL; real coverage is the postgres_test CI lane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)