### PR TITLE
feat: phraseto_tsquery / websearch_to_tsquery / to_tsquery / ts_rank_cd (issue #28 follow-up)

### DIFF
--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -353,6 +353,27 @@ pub enum ScalarFn {
     /// `OpNotSupportedInDialect`. Pairs with `to_tsvector` /
     /// `plainto_tsquery` / `ts_rank`. Issue #28 follow-up.
     TsHeadline,
+    /// `phraseto_tsquery(<expr>)` — Postgres FTS query parser that
+    /// preserves word order (`'rust orm'` → `'rust' <-> 'orm'`).
+    /// Use when "exact phrase" semantics matter. Arity 1. **PG-only**.
+    /// Issue #28 follow-up.
+    PhraseToTsQuery,
+    /// `websearch_to_tsquery(<expr>)` — Postgres FTS query parser
+    /// that accepts Google-style operators: quoted "exact phrase",
+    /// unary `-exclude`, the literal `OR`. Arity 1. **PG-only**.
+    /// Issue #28 follow-up.
+    WebsearchToTsQuery,
+    /// `to_tsquery(<expr>)` — Postgres FTS query parser for the
+    /// raw `tsquery` syntax (`'rust & orm'`, `'rust | python'`,
+    /// `'rust & !python'`). Lower-level than `plainto_tsquery`;
+    /// expects pre-parsed input. Arity 1. **PG-only**. Issue #28
+    /// follow-up.
+    ToTsQuery,
+    /// `ts_rank_cd(<tsvector>, <tsquery>)` — cover-density variant
+    /// of `ts_rank`. Same shape, different ranking algorithm
+    /// (better for short documents). Arity 2. **PG-only**. Issue
+    /// #28 follow-up.
+    TsRankCd,
 }
 
 impl Expr {

--- a/crates/rustango/src/core/funcs.rs
+++ b/crates/rustango/src/core/funcs.rs
@@ -505,6 +505,47 @@ pub fn ts_headline_with(
     }
 }
 
+/// `phraseto_tsquery(<expr>)` — Postgres FTS phrase-preserving query
+/// parser. Builds a `tsquery` from a phrase, preserving word order:
+/// `"rust orm"` → `'rust' <-> 'orm'`. Use when exact-phrase semantics
+/// matter (vs `plainto_tsquery`, which ignores word order). **PG-only**.
+#[must_use]
+pub fn phraseto_tsquery(arg: impl Into<Expr>) -> Expr {
+    unary(ScalarFn::PhraseToTsQuery, arg)
+}
+
+/// `websearch_to_tsquery(<expr>)` — Postgres FTS query parser that
+/// accepts Google-style search syntax: quoted `"exact phrase"`,
+/// unary `-exclude`, the literal `OR`. Best fit for end-user search
+/// boxes. **PG-only**.
+#[must_use]
+pub fn websearch_to_tsquery(arg: impl Into<Expr>) -> Expr {
+    unary(ScalarFn::WebsearchToTsQuery, arg)
+}
+
+/// `to_tsquery(<expr>)` — Postgres FTS query parser for the raw
+/// `tsquery` operator syntax (`'rust & orm'`, `'rust | python'`,
+/// `'rust & !python'`). Lower-level than [`plainto_tsquery`]; the
+/// caller is responsible for valid `tsquery` syntax. Use when the
+/// app constructs queries programmatically (composed AND/OR/NOT)
+/// rather than from raw user input. **PG-only**.
+#[must_use]
+pub fn to_tsquery(arg: impl Into<Expr>) -> Expr {
+    unary(ScalarFn::ToTsQuery, arg)
+}
+
+/// `ts_rank_cd(<tsvector>, <tsquery>)` — Postgres FTS cover-density
+/// ranking. Same shape as [`ts_rank`], different algorithm (factors
+/// in how closely matched terms cluster — better for short
+/// documents and phrase searches). **PG-only**.
+#[must_use]
+pub fn ts_rank_cd(vector: impl Into<Expr>, query: impl Into<Expr>) -> Expr {
+    Expr::Function {
+        kind: ScalarFn::TsRankCd,
+        args: vec![vector.into(), query.into()],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -1652,6 +1652,58 @@ fn write_function(
             b.sql.push(')');
             Ok(())
         }
+        F::PhraseToTsQuery | F::WebsearchToTsQuery | F::ToTsQuery => {
+            let fname = match kind {
+                F::PhraseToTsQuery => "phraseto_tsquery",
+                F::WebsearchToTsQuery => "websearch_to_tsquery",
+                F::ToTsQuery => "to_tsquery",
+                _ => unreachable!(),
+            };
+            if args.len() != 1 {
+                return Err(SqlError::FunctionArityMismatch {
+                    func: fname,
+                    expected: "1",
+                    got: args.len(),
+                });
+            }
+            if b.d.name() != "postgres" {
+                return Err(SqlError::OpNotSupportedInDialect {
+                    op: match kind {
+                        F::PhraseToTsQuery => "phraseto_tsquery (FTS) is Postgres-only",
+                        F::WebsearchToTsQuery => "websearch_to_tsquery (FTS) is Postgres-only",
+                        F::ToTsQuery => "to_tsquery (FTS) is Postgres-only",
+                        _ => unreachable!(),
+                    },
+                    dialect: b.d.name(),
+                });
+            }
+            b.sql.push_str(fname);
+            b.sql.push('(');
+            write_expr(b, &args[0], None)?;
+            b.sql.push(')');
+            Ok(())
+        }
+        F::TsRankCd => {
+            if args.len() != 2 {
+                return Err(SqlError::FunctionArityMismatch {
+                    func: "ts_rank_cd",
+                    expected: "2",
+                    got: args.len(),
+                });
+            }
+            if b.d.name() != "postgres" {
+                return Err(SqlError::OpNotSupportedInDialect {
+                    op: "ts_rank_cd (FTS) is Postgres-only",
+                    dialect: b.d.name(),
+                });
+            }
+            b.sql.push_str("ts_rank_cd(");
+            write_expr(b, &args[0], None)?;
+            b.sql.push_str(", ");
+            write_expr(b, &args[1], None)?;
+            b.sql.push(')');
+            Ok(())
+        }
     }
 }
 

--- a/crates/rustango/tests/fts_tsquery_variants_emission.rs
+++ b/crates/rustango/tests/fts_tsquery_variants_emission.rs
@@ -1,0 +1,182 @@
+//! Emission tests for the Postgres FTS `tsquery` parser family +
+//! `ts_rank_cd`. Issue #28 follow-up — fills out the FTS scalar-
+//! function surface alongside `to_tsvector` / `plainto_tsquery` /
+//! `ts_rank` (PR #136) and `ts_headline` (PR #138).
+
+use rustango::core::funcs::{
+    phraseto_tsquery, to_tsquery, to_tsvector, ts_rank_cd, websearch_to_tsquery,
+};
+use rustango::core::{
+    Assignment, Expr, Filter, Model as _, Op, ScalarFn, SqlValue, UpdateQuery, WhereExpr, F,
+};
+#[cfg(feature = "mysql")]
+use rustango::sql::MySql;
+#[cfg(feature = "sqlite")]
+use rustango::sql::Sqlite;
+use rustango::sql::{Dialect, Postgres, SqlError};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "fts_doc_tsquery")]
+#[allow(dead_code)]
+pub struct Doc {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 200)]
+    body: String,
+    rank: f64,
+}
+
+fn update_set(value: Expr) -> UpdateQuery {
+    UpdateQuery {
+        model: Doc::SCHEMA,
+        set: vec![Assignment {
+            column: "rank",
+            value,
+        }],
+        where_clause: WhereExpr::Predicate(Filter {
+            column: "id",
+            op: Op::Eq,
+            value: SqlValue::I64(1),
+        }),
+    }
+}
+
+// ---------- PG emission ----------
+
+#[test]
+fn pg_emits_phraseto_tsquery() {
+    let q = update_set(phraseto_tsquery("rust orm"));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains("phraseto_tsquery($"),
+        "PG phraseto_tsquery: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn pg_emits_websearch_to_tsquery() {
+    let q = update_set(websearch_to_tsquery("\"rust orm\" -python"));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains("websearch_to_tsquery($"),
+        "PG websearch_to_tsquery: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn pg_emits_to_tsquery() {
+    let q = update_set(to_tsquery("rust & orm"));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains("to_tsquery($"),
+        "PG to_tsquery: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn pg_emits_ts_rank_cd_composed() {
+    let q = update_set(ts_rank_cd(
+        to_tsvector(F("body")),
+        phraseto_tsquery("rust orm"),
+    ));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql
+            .contains("ts_rank_cd(to_tsvector(\"body\"), phraseto_tsquery($"),
+        "PG ts_rank_cd composed: {}",
+        stmt.sql
+    );
+}
+
+// ---------- MySQL / SQLite reject ----------
+
+#[cfg(feature = "mysql")]
+#[test]
+fn mysql_rejects_phraseto_tsquery() {
+    let err = MySql
+        .compile_update(&update_set(phraseto_tsquery("q")))
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        SqlError::OpNotSupportedInDialect { op, .. } if op.contains("phraseto_tsquery")
+    ));
+}
+
+#[cfg(feature = "mysql")]
+#[test]
+fn mysql_rejects_websearch_to_tsquery() {
+    let err = MySql
+        .compile_update(&update_set(websearch_to_tsquery("q")))
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        SqlError::OpNotSupportedInDialect { op, .. } if op.contains("websearch_to_tsquery")
+    ));
+}
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn sqlite_rejects_to_tsquery() {
+    let err = Sqlite
+        .compile_update(&update_set(to_tsquery("q")))
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        SqlError::OpNotSupportedInDialect { op, .. } if op.contains("to_tsquery")
+    ));
+}
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn sqlite_rejects_ts_rank_cd() {
+    let err = Sqlite
+        .compile_update(&update_set(ts_rank_cd(
+            to_tsvector(F("body")),
+            phraseto_tsquery("q"),
+        )))
+        .unwrap_err();
+    // Inside-out evaluation: to_tsvector reaches first.
+    assert!(matches!(
+        err,
+        SqlError::OpNotSupportedInDialect { op, .. }
+            if op.contains("to_tsvector") || op.contains("ts_rank_cd")
+    ));
+}
+
+// ---------- Arity ----------
+
+#[test]
+fn phraseto_tsquery_with_two_args_arity_error() {
+    let bad = Expr::Function {
+        kind: ScalarFn::PhraseToTsQuery,
+        args: vec![F("body").into(), F("body").into()],
+    };
+    let err = Postgres.compile_update(&update_set(bad)).unwrap_err();
+    assert!(matches!(
+        err,
+        SqlError::FunctionArityMismatch {
+            func: "phraseto_tsquery",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn ts_rank_cd_with_one_arg_arity_error() {
+    let bad = Expr::Function {
+        kind: ScalarFn::TsRankCd,
+        args: vec![F("body").into()],
+    };
+    let err = Postgres.compile_update(&update_set(bad)).unwrap_err();
+    assert!(matches!(
+        err,
+        SqlError::FunctionArityMismatch {
+            func: "ts_rank_cd",
+            ..
+        }
+    ));
+}


### PR DESCRIPTION
## Summary
Round out the Postgres FTS scalar-function surface alongside `to_tsvector` / `plainto_tsquery` / `ts_rank` (PR #136) and `ts_headline` (PR #138):

- `phraseto_tsquery(expr)` — preserves word order (`\"rust orm\"` → `'rust' <-> 'orm'`); use for exact-phrase search
- `websearch_to_tsquery(expr)` — Google-style operators (quoted `\"exact phrase\"`, unary `-exclude`, literal `OR`); best fit for end-user search boxes
- `to_tsquery(expr)` — lower-level parser for the raw `tsquery` operator syntax (`'rust & orm'`, `'rust | python'`)
- `ts_rank_cd(vec, query)` — cover-density ranking variant of `ts_rank` (factors in term clustering; better for short docs)

All PG-only; MySQL/SQLite reject at compile time with `OpNotSupportedInDialect`. Wrong arity → `FunctionArityMismatch`.

## Composes
\`\`\`rust
use rustango::core::funcs::{ts_rank_cd, to_tsvector, websearch_to_tsquery};
use rustango::core::F;

ts_rank_cd(
    to_tsvector(F(\"body\")),
    websearch_to_tsquery(\"\\\"rust orm\\\" -python\"),
)
\`\`\`

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test --workspace --all-features --no-run`
- [x] `cargo build --no-default-features --features sqlite,tenancy`
- [x] New `crates/rustango/tests/fts_tsquery_variants_emission.rs` — 10 tests: PG emit for each parser, composed `ts_rank_cd(to_tsvector, phraseto_tsquery)`, MySQL rejection (phraseto/websearch), SQLite rejection (to_tsquery + composed ts_rank_cd inside-out), arity-2 → FunctionArityMismatch on `phraseto_tsquery`, arity-1 → FunctionArityMismatch on `ts_rank_cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)