### PR TITLE
fix(tests): poll for scheduler fires in job_fires_after_one_period

### DIFF
--- a/crates/rustango/src/scheduler/mod.rs
+++ b/crates/rustango/src/scheduler/mod.rs
@@ -198,8 +198,22 @@ mod tests {
             }
         });
         let handle = s.start();
-        // Wait for ~3 ticks (60ms gives us 3 fires at 20ms intervals)
-        tokio::time::sleep(Duration::from_millis(70)).await;
+        // Poll up to 2 seconds for at least 2 fires. Earlier the test
+        // used a fixed 70ms sleep, expecting 3 fires at the 20ms
+        // cadence — but CI's busy runner can deliver the first tick
+        // 50ms+ late, leaving the assertion at 1 fire and red. Polling
+        // converges as soon as the assertion holds; the upper bound
+        // is generous so we don't false-fail under heavy load.
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            if counter.load(Ordering::SeqCst) >= 2 {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
         let count = counter.load(Ordering::SeqCst);
         assert!(count >= 2, "expected at least 2 fires, got {count}");
         handle.shutdown().await;


### PR DESCRIPTION
## Summary
Main-branch CI was failing on PR #157's merge run with `scheduler::tests::job_fires_after_one_period` panicking at \"expected at least 2 fires, got 1\". Pre-existing flake — the test slept exactly 70ms and asserted on the counter, but CI's busy runner often delivers the first scheduler tick 50ms+ after start, leaving the counter at 1 fire.

Replace the fixed sleep with a poll loop: wait up to 2 seconds for the counter to reach 2, breaking out as soon as it does. Converges quickly on a healthy runner; tolerates significant scheduling lag on a saturated one.

No behaviour change locally. Same shape as the flake fixes in PRs #137 (`on_commit_live`) and #139 (`jobs_pg_live`).

## Test plan
- [x] `cargo fmt --all`
- [x] Local re-run passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)