### PR TITLE
fix(tests): add IndexSnapshot.method field in migrate_diff test fixture

### DIFF
--- a/crates/rustango/tests/migrate_diff.rs
+++ b/crates/rustango/tests/migrate_diff.rs
@@ -728,6 +728,7 @@ fn snap_with_index(name: &str, columns: &[&str], unique: bool) -> SchemaSnapshot
             table: "diff_user".into(),
             columns: columns.iter().map(|s| (*s).into()).collect(),
             unique,
+            method: "btree".into(),
         }],
         ..Default::default()
     }


### PR DESCRIPTION
## Summary
PR #159 (Index types DSL) added a `method: String` field to `IndexSnapshot` but missed updating the `snap_with_index` helper in `tests/migrate_diff.rs`. The local `cargo test --no-run` pass happened to not pick up the test rebuild from cache; CI's clean build caught it on the merge commit.

Fill in the default `\"btree\"` token to match the new struct shape.

## Test plan
- [x] `cargo test --workspace --all-features --no-run`
- [x] `cargo fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)