### PR TITLE
feat: PG array operators @> / <@ / && (closes #30 ops slice)

### DIFF
--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -1490,6 +1490,8 @@ fn bind_value_pg(
         SqlValue::Decimal(v) => q.bind(v),
         SqlValue::Binary(v) => q.bind(v),
         SqlValue::List(_) => unreachable!("List expanded to scalars by SQL writer"),
+        // Array values only flow through WHERE clauses, not audit row saves.
+        SqlValue::Array(_) => unreachable!("Array values never reach audited-save bind path"),
     }
 }
 
@@ -1516,6 +1518,8 @@ fn bind_value_my(
         SqlValue::Decimal(v) => q.bind(v),
         SqlValue::Binary(v) => q.bind(v),
         SqlValue::List(_) => unreachable!("List expanded to scalars by SQL writer"),
+        // Array values only flow through WHERE clauses, not audit row saves.
+        SqlValue::Array(_) => unreachable!("Array values never reach audited-save bind path"),
     }
 }
 
@@ -1544,6 +1548,8 @@ fn bind_value_sqlite<'q>(
         SqlValue::Decimal(v) => q.bind(v.to_string()),
         SqlValue::Binary(v) => q.bind(v),
         SqlValue::List(_) => unreachable!("List expanded to scalars by SQL writer"),
+        // Array values only flow through WHERE clauses, not audit row saves.
+        SqlValue::Array(_) => unreachable!("Array values never reach audited-save bind path"),
     }
 }
 

--- a/crates/rustango/src/core/column.rs
+++ b/crates/rustango/src/core/column.rs
@@ -147,6 +147,55 @@ pub trait Column: Copy + 'static {
         TypedFilter::scalar(Self::COLUMN, Op::Search, SqlValue::String(query.into()))
     }
 
+    /// `column @> value` — PG array containment. Django's `__contains`
+    /// lookup on `ArrayField`. Returns rows whose array column fully
+    /// contains every element of the value array. **PG-only** —
+    /// MySQL and SQLite reject at compile time (no native array
+    /// type). Issue #30.
+    ///
+    /// v1 supports `I32` / `I64` / `String` / `Bool` element types
+    /// at bind time; other element kinds panic at bind.
+    fn array_contains<V>(self, values: V) -> TypedFilter<Self::Model>
+    where
+        V: IntoIterator,
+        V::Item: Into<SqlValue>,
+    {
+        TypedFilter::scalar(
+            Self::COLUMN,
+            Op::ArrayContains,
+            SqlValue::Array(values.into_iter().map(Into::into).collect()),
+        )
+    }
+
+    /// `column <@ value` — PG array containment, inverted. Django's
+    /// `__contained_by` lookup. **PG-only**. Issue #30.
+    fn array_contained_by<V>(self, values: V) -> TypedFilter<Self::Model>
+    where
+        V: IntoIterator,
+        V::Item: Into<SqlValue>,
+    {
+        TypedFilter::scalar(
+            Self::COLUMN,
+            Op::ArrayContainedBy,
+            SqlValue::Array(values.into_iter().map(Into::into).collect()),
+        )
+    }
+
+    /// `column && value` — PG array overlap. Django's `__overlap`
+    /// lookup. Returns rows whose array shares at least one element
+    /// with the value array. **PG-only**. Issue #30.
+    fn array_overlap<V>(self, values: V) -> TypedFilter<Self::Model>
+    where
+        V: IntoIterator,
+        V::Item: Into<SqlValue>,
+    {
+        TypedFilter::scalar(
+            Self::COLUMN,
+            Op::ArrayOverlap,
+            SqlValue::Array(values.into_iter().map(Into::into).collect()),
+        )
+    }
+
     /// `column IS NULL`.
     fn is_null(self) -> TypedFilter<Self::Model> {
         TypedFilter::scalar(Self::COLUMN, Op::IsNull, SqlValue::Bool(true))

--- a/crates/rustango/src/core/error.rs
+++ b/crates/rustango/src/core/error.rs
@@ -79,7 +79,8 @@ pub enum QueryError {
          supported: exact, iexact, contains, icontains, startswith, \
          istartswith, endswith, iendswith, gt, gte, lt, lte, ne, in, \
          isnull, between, range, regex, iregex, trigram_similar, \
-         trigram_word_similar, search"
+         trigram_word_similar, search, array_contains, \
+         array_contained_by, array_overlap"
     )]
     UnknownLookup { field: String, suffix: String },
 

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -103,6 +103,22 @@ pub enum Op {
     /// and SQLite has FTS5 `MATCH`, both with incompatible semantics,
     /// so both reject at compile time. Issue #28.
     Search,
+    /// Postgres array containment — Django's `__contains` lookup on
+    /// `ArrayField`. PG emits `<col> @> <value>` where the rhs is
+    /// the bound array literal. Returns rows whose array column
+    /// fully contains every element of the value array. **PG-only**
+    /// — MySQL and SQLite have no native array type and reject at
+    /// compile time with `OpNotSupportedInDialect`. Issue #30.
+    ArrayContains,
+    /// Inverse of [`Self::ArrayContains`]: `<col> <@ <value>` —
+    /// rows whose array column is fully contained by the value
+    /// array. Django's `__contained_by` lookup. **PG-only**.
+    /// Issue #30.
+    ArrayContainedBy,
+    /// Postgres array overlap — `<col> && <value>`. Rows whose
+    /// array shares at least one element with the value array.
+    /// Django's `__overlap` lookup. **PG-only**. Issue #30.
+    ArrayOverlap,
 }
 
 /// One predicate in a `WHERE` clause: `column <op> value`. Always

--- a/crates/rustango/src/core/validate.rs
+++ b/crates/rustango/src/core/validate.rs
@@ -31,6 +31,7 @@ pub fn validate_value(
         // by the caller (used only for `IN`).
         SqlValue::Null
         | SqlValue::List(_)
+        | SqlValue::Array(_)
         | SqlValue::F32(_)
         | SqlValue::F64(_)
         | SqlValue::Bool(_)

--- a/crates/rustango/src/core/value.rs
+++ b/crates/rustango/src/core/value.rs
@@ -35,8 +35,23 @@ pub enum SqlValue {
     /// Time of day, no date component — pairs with
     /// [`FieldType::Time`]. Rust type: `chrono::NaiveTime`.
     Time(NaiveTime),
-    /// Used for `IN` and `BETWEEN` lookups.
+    /// Used for `IN` and `BETWEEN` lookups. Expanded to `($1, $2, $3)`
+    /// placeholders at writer time — each element is a separate bound
+    /// parameter.
     List(Vec<SqlValue>),
+    /// PG **single-parameter** array — binds as a single placeholder
+    /// (`$1`) holding a `Vec<T>` value. Distinct from [`Self::List`],
+    /// which fans out to one placeholder per element. Used by
+    /// [`crate::core::Op::ArrayContains`] / `ArrayContainedBy` /
+    /// `ArrayOverlap` (PG `@>` / `<@` / `&&`).
+    ///
+    /// The first element's variant determines the bind shape. **v1
+    /// supports `I64` and `String` element types** (the two most
+    /// common Django `ArrayField(IntegerField/CharField)` shapes);
+    /// other element kinds error at bind time. Empty arrays bind as
+    /// `Vec::<i32>::new()` — PG infers the element type from the
+    /// `<col> <op>` clause. Issue #30.
+    Array(Vec<SqlValue>),
 }
 
 impl SqlValue {
@@ -68,6 +83,10 @@ impl SqlValue {
                 let inner: Vec<String> = items.iter().map(Self::to_display_string).collect();
                 format!("[{}]", inner.join(", "))
             }
+            Self::Array(items) => {
+                let inner: Vec<String> = items.iter().map(Self::to_display_string).collect();
+                format!("array[{}]", inner.join(", "))
+            }
         }
     }
 
@@ -75,7 +94,7 @@ impl SqlValue {
     #[must_use]
     pub fn field_type(&self) -> Option<FieldType> {
         Some(match self {
-            Self::Null | Self::List(_) => return None,
+            Self::Null | Self::List(_) | Self::Array(_) => return None,
             Self::I16(_) => FieldType::I16,
             Self::I32(_) => FieldType::I32,
             Self::I64(_) => FieldType::I64,

--- a/crates/rustango/src/forms/mod.rs
+++ b/crates/rustango/src/forms/mod.rs
@@ -1340,6 +1340,7 @@ fn bind_sql_value_inline<'a>(
         SqlValue::Decimal(v) => q.bind(*v),
         SqlValue::Binary(v) => q.bind(v.clone()),
         SqlValue::List(_) => panic!("validate_unique_together: List not supported in pre-check"),
+        SqlValue::Array(_) => panic!("validate_unique_together: Array not supported in pre-check"),
     }
 }
 
@@ -1375,6 +1376,7 @@ fn bind_sql_value_inline_my<'a>(
         SqlValue::Decimal(v) => q.bind(*v),
         SqlValue::Binary(v) => q.bind(v.clone()),
         SqlValue::List(_) => panic!("validate_unique_together: List not supported in pre-check"),
+        SqlValue::Array(_) => panic!("validate_unique_together: Array not supported in pre-check"),
     }
 }
 
@@ -1412,6 +1414,7 @@ fn bind_sql_value_inline_sqlite<'a>(
         SqlValue::Decimal(v) => q.bind(v.to_string()),
         SqlValue::Binary(v) => q.bind(v.clone()),
         SqlValue::List(_) => panic!("validate_unique_together: List not supported in pre-check"),
+        SqlValue::Array(_) => panic!("validate_unique_together: Array not supported in pre-check"),
     }
 }
 

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1283,6 +1283,34 @@ fn parse_lookup(key: &str, value: SqlValue) -> Result<(String, Op, SqlValue), Qu
             }
             Ok((field, Op::Search, value))
         }
+        // PG array operators (issue #30). The Django shape uses
+        // `__contains` / `__contained_by` / `__overlap` on
+        // ArrayField columns, but rustango can't dispatch by
+        // field-type from the parser (the field-type info isn't
+        // threaded through `.filter()`). We use explicit
+        // `__array_*` suffixes to keep them disjoint from text
+        // `__contains`; the typed-IR `Column::array_*` methods are
+        // the preferred call site.
+        "array_contains" | "array_contained_by" | "array_overlap" => {
+            // The bound value must be a list-of-elements; we
+            // promote `SqlValue::List` to `SqlValue::Array` so the
+            // writer binds it as a single PG array parameter.
+            let SqlValue::List(elems) = value else {
+                return Err(QueryError::InvalidLookupValue {
+                    field,
+                    suffix: suffix.to_owned(),
+                    expected: "SqlValue::List(<elements>) — typed homogeneous array",
+                    actual: sql_value_shape_name(&value),
+                });
+            };
+            let op = match suffix {
+                "array_contains" => Op::ArrayContains,
+                "array_contained_by" => Op::ArrayContainedBy,
+                "array_overlap" => Op::ArrayOverlap,
+                _ => unreachable!(),
+            };
+            Ok((field, op, SqlValue::Array(elems)))
+        }
         unknown => Err(QueryError::UnknownLookup {
             field,
             suffix: unknown.to_owned(),

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -410,6 +410,33 @@ pub trait Dialect {
         Ok(())
     }
 
+    /// Postgres `ArrayField` containment / overlap operators —
+    /// `@>` / `<@` / `&&`. Issue #30.
+    ///
+    /// `op` is the literal SQL operator string (`"@>"`, `"<@"`,
+    /// `"&&"`). The default impl emits the PG shape
+    /// `<col> <op> <placeholder>`. MySQL + SQLite override to
+    /// reject with [`SqlError::OpNotSupportedInDialect`] since
+    /// neither has a native array type.
+    ///
+    /// # Errors
+    /// `OpNotSupportedInDialect` when the dialect doesn't support
+    /// PG array operators.
+    fn write_array_op(
+        &self,
+        sql: &mut String,
+        qualified_col: &str,
+        placeholder: &str,
+        op: &'static str,
+    ) -> Result<(), super::SqlError> {
+        sql.push_str(qualified_col);
+        sql.push(' ');
+        sql.push_str(op);
+        sql.push(' ');
+        sql.push_str(placeholder);
+        Ok(())
+    }
+
     /// Null-safe equality. Postgres: `<col> IS [NOT] DISTINCT FROM <p>`.
     /// `distinct = true` means "not equal under null-safe semantics".
     fn write_null_safe_eq(

--- a/crates/rustango/src/sql/error.rs
+++ b/crates/rustango/src/sql/error.rs
@@ -29,6 +29,15 @@ pub enum SqlError {
     #[error("`Op::JsonContains` / `Op::JsonContainedBy` require `SqlValue::Json`")]
     JsonOpRequiresJson,
 
+    /// PG ArrayField operators (`@>`, `<@`, `&&`) require
+    /// [`crate::core::SqlValue::Array`]. A plain `List` would expand
+    /// to comma-separated placeholders — the wrong shape for array
+    /// comparison, which needs a single PG array parameter.
+    #[error(
+        "`Op::ArrayContains` / `Op::ArrayContainedBy` / `Op::ArrayOverlap` require `SqlValue::Array`"
+    )]
+    ArrayOpRequiresArray,
+
     /// `BulkUpdateQuery` was used on a model with no `#[rustango(primary_key)]`
     /// field — the WHERE clause cannot be formed.
     #[error("bulk UPDATE requires a primary key on the model")]

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -1640,6 +1640,84 @@ macro_rules! bind_match {
             SqlValue::List(_) => {
                 unreachable!("`SqlValue::List` is expanded to scalars by the SQL writer")
             }
+            // PG single-parameter array (issue #30). v1 supports
+            // I32/I64/String/Bool elements; other element kinds
+            // panic at bind time. Homogeneous-element arrays are
+            // required by PG's typed array shape.
+            SqlValue::Array(elems) => match elems.first() {
+                None => $q.bind(Vec::<i32>::new()),
+                Some(SqlValue::I64(_)) => {
+                    let v: Vec<i64> = elems
+                        .into_iter()
+                        .filter_map(|e| if let SqlValue::I64(n) = e { Some(n) } else { None })
+                        .collect();
+                    $q.bind(v)
+                }
+                Some(SqlValue::I32(_)) => {
+                    let v: Vec<i32> = elems
+                        .into_iter()
+                        .filter_map(|e| if let SqlValue::I32(n) = e { Some(n) } else { None })
+                        .collect();
+                    $q.bind(v)
+                }
+                Some(SqlValue::String(_)) => {
+                    let v: Vec<String> = elems
+                        .into_iter()
+                        .filter_map(|e| {
+                            if let SqlValue::String(s) = e {
+                                Some(s)
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    $q.bind(v)
+                }
+                Some(SqlValue::Bool(_)) => {
+                    let v: Vec<bool> = elems
+                        .into_iter()
+                        .filter_map(|e| if let SqlValue::Bool(b) = e { Some(b) } else { None })
+                        .collect();
+                    $q.bind(v)
+                }
+                Some(_) => unreachable!(
+                    "SqlValue::Array elements other than I32/I64/String/Bool are not yet supported (v1, issue #30)"
+                ),
+            },
+        }
+    };
+}
+
+/// MySQL-only counterpart of [`bind_match`]. MySQL has no array
+/// type, so the `Array` arm is `unreachable!()` — the SQL writer
+/// rejects array operators via `write_array_op` before any bind
+/// is attempted. Otherwise identical to the PG bind_match. Issue
+/// #30.
+#[cfg(feature = "mysql")]
+macro_rules! bind_match_mysql {
+    ($q:expr, $value:expr) => {
+        match $value {
+            SqlValue::Null => $q.bind(None::<String>),
+            SqlValue::I16(v) => $q.bind(v),
+            SqlValue::I32(v) => $q.bind(v),
+            SqlValue::I64(v) => $q.bind(v),
+            SqlValue::F32(v) => $q.bind(v),
+            SqlValue::F64(v) => $q.bind(v),
+            SqlValue::Bool(v) => $q.bind(v),
+            SqlValue::String(v) => $q.bind(v),
+            SqlValue::DateTime(v) => $q.bind(v),
+            SqlValue::Date(v) => $q.bind(v),
+            SqlValue::Time(v) => $q.bind(v),
+            SqlValue::Uuid(v) => $q.bind(v),
+            SqlValue::Json(v) => $q.bind(sqlx::types::Json(v)),
+            SqlValue::Decimal(v) => $q.bind(v),
+            SqlValue::Binary(v) => $q.bind(v),
+            SqlValue::List(_) => {
+                unreachable!("`SqlValue::List` is expanded to scalars by the SQL writer")
+            }
+            SqlValue::Array(_) => unreachable!(
+                "MySQL has no array type; `write_array_op` rejects before bind. Issue #30."
+            ),
         }
     };
 }
@@ -1673,6 +1751,11 @@ macro_rules! bind_match_sqlite {
             SqlValue::List(_) => {
                 unreachable!("`SqlValue::List` is expanded to scalars by the SQL writer")
             }
+            // SQLite has no array type — the writer rejects array
+            // ops via `write_array_op` long before bind is reached.
+            SqlValue::Array(_) => unreachable!(
+                "SQLite has no array type; `write_array_op` rejects before bind. Issue #30."
+            ),
         }
     };
 }
@@ -2251,7 +2334,7 @@ fn bind_query_my(
     q: sqlx::query::Query<'_, sqlx::MySql, sqlx::mysql::MySqlArguments>,
     value: SqlValue,
 ) -> sqlx::query::Query<'_, sqlx::MySql, sqlx::mysql::MySqlArguments> {
-    bind_match!(q, value)
+    bind_match_mysql!(q, value)
 }
 
 /// SQLite counterpart of [`bind_query_my`] / [`bind_query`]. sqlx-sqlite
@@ -3038,7 +3121,7 @@ fn bind_query_as_my<T>(
     q: sqlx::query::QueryAs<'_, sqlx::MySql, T, sqlx::mysql::MySqlArguments>,
     value: SqlValue,
 ) -> sqlx::query::QueryAs<'_, sqlx::MySql, T, sqlx::mysql::MySqlArguments> {
-    bind_match!(q, value)
+    bind_match_mysql!(q, value)
 }
 
 /// SQLite-typed `QueryAs` binding helper, symmetric with [`bind_query_as`].
@@ -3421,7 +3504,7 @@ fn bind_query_scalar_my<U>(
     q: sqlx::query::QueryScalar<'_, sqlx::MySql, U, sqlx::mysql::MySqlArguments>,
     value: SqlValue,
 ) -> sqlx::query::QueryScalar<'_, sqlx::MySql, U, sqlx::mysql::MySqlArguments> {
-    bind_match!(q, value)
+    bind_match_mysql!(q, value)
 }
 
 #[cfg(feature = "sqlite")]

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -319,6 +319,22 @@ impl Dialect for MySql {
         })
     }
 
+    /// MySQL has no native array type. Reject every PG array op at
+    /// compile time. Issue #30.
+    fn write_array_op(
+        &self,
+        _sql: &mut String,
+        _qualified_col: &str,
+        _placeholder: &str,
+        _op: &'static str,
+    ) -> Result<(), super::SqlError> {
+        Err(super::SqlError::OpNotSupportedInDialect {
+            op: "array operators (@>, <@, &&) — PG ArrayField is Postgres-only; \
+                 use JSON columns + JSON-shape operators on MySQL",
+            dialect: "mysql",
+        })
+    }
+
     fn write_null_safe_eq(
         &self,
         sql: &mut String,

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -299,6 +299,22 @@ impl Dialect for Sqlite {
         })
     }
 
+    /// SQLite has no native array type. Reject every PG array op at
+    /// compile time. Issue #30.
+    fn write_array_op(
+        &self,
+        _sql: &mut String,
+        _qualified_col: &str,
+        _placeholder: &str,
+        _op: &'static str,
+    ) -> Result<(), super::SqlError> {
+        Err(super::SqlError::OpNotSupportedInDialect {
+            op: "array operators (@>, <@, &&) — PG ArrayField is Postgres-only; \
+                 use JSON-stored arrays + JSON1 functions on SQLite",
+            dialect: "sqlite",
+        })
+    }
+
     /// SQLite's `IS` / `IS NOT` are null-safe equality / inequality
     /// (both `NULL IS NULL` and `1 IS 1` evaluate to true). Same
     /// semantics as Postgres' `IS [NOT] DISTINCT FROM` — we just

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -2449,6 +2449,28 @@ fn write_filter(
             let p = b.d.placeholder(b.params.len());
             b.d.write_search(&mut b.sql, &qualified_col, &p)?;
         }
+        Op::ArrayContains | Op::ArrayContainedBy | Op::ArrayOverlap => {
+            // Postgres ArrayField operators (`@>`, `<@`, `&&`). The
+            // dialect default emits the PG shape; MySQL + SQLite
+            // override to reject with `OpNotSupportedInDialect`. The
+            // bound value MUST be `SqlValue::Array(_)` so it binds
+            // as a single PG array parameter — `List` would expand
+            // to comma-separated placeholders, which is the wrong
+            // shape for array comparison.
+            if !matches!(filter.value, SqlValue::Array(_)) {
+                return Err(SqlError::ArrayOpRequiresArray);
+            }
+            require_op(b.d, filter.op)?;
+            b.params.push(filter.value.clone());
+            let p = b.d.placeholder(b.params.len());
+            let op_str: &'static str = match filter.op {
+                Op::ArrayContains => "@>",
+                Op::ArrayContainedBy => "<@",
+                Op::ArrayOverlap => "&&",
+                _ => unreachable!(),
+            };
+            b.d.write_array_op(&mut b.sql, &qualified_col, &p, op_str)?;
+        }
         Op::In | Op::NotIn => {
             let SqlValue::List(elements) = &filter.value else {
                 return Err(SqlError::InRequiresList);
@@ -2630,6 +2652,9 @@ fn op_label(op: Op) -> &'static str {
         Op::TrigramSimilar => "% (trigram_similar)",
         Op::TrigramWordSimilar => "%> (trigram_word_similar)",
         Op::Search => "@@ (search)",
+        Op::ArrayContains => "@> (array_contains)",
+        Op::ArrayContainedBy => "<@ (array_contained_by)",
+        Op::ArrayOverlap => "&& (array_overlap)",
         Op::IRegex => "~* (iregex)",
         Op::NotIRegex => "!~* (iregex)",
     }

--- a/crates/rustango/tests/array_ops_emission.rs
+++ b/crates/rustango/tests/array_ops_emission.rs
@@ -1,0 +1,219 @@
+//! PG `ArrayField` operators (`@>`, `<@`, `&&`) — issue #30 ops slice.
+//!
+//! Ships the Op variants + Column trait helpers + Django parser
+//! routes. A `FieldType::Array(elem)` declaration shape follows in a
+//! separate slice — for v1 the column is declared via raw migration
+//! SQL (`tags TEXT[]`) and referenced by the typed-IR `Column::array_*`
+//! methods, mirroring how trigram lookups land before the
+//! `TrigramSimilarity` annotation.
+
+use rustango::core::Column as _;
+#[cfg(feature = "mysql")]
+use rustango::sql::MySql;
+#[cfg(feature = "sqlite")]
+use rustango::sql::Sqlite;
+use rustango::sql::{Dialect, Postgres};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "arr_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 64)]
+    title: String,
+}
+
+// ---------- PG: native @> / <@ / && ----------
+
+#[test]
+fn pg_emits_array_contains_operator() {
+    let q = Post::objects()
+        .where_(Post::title.array_contains(["rust", "orm"]))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""title" @> $1"#),
+        "PG array_contains: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn pg_emits_array_contained_by_operator() {
+    let q = Post::objects()
+        .where_(Post::id.array_contained_by([1_i64, 2, 3]))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""id" <@ $1"#),
+        "PG array_contained_by: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn pg_emits_array_overlap_operator() {
+    let q = Post::objects()
+        .where_(Post::title.array_overlap(["rust", "go"]))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""title" && $1"#),
+        "PG array_overlap: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn pg_binds_array_as_single_param() {
+    let q = Post::objects()
+        .where_(Post::title.array_contains(["a", "b", "c"]))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    // Single parameter — three elements bundled into one Array value,
+    // not three placeholders.
+    assert_eq!(stmt.params.len(), 1, "single PG array parameter");
+    use rustango::core::SqlValue;
+    let SqlValue::Array(elems) = &stmt.params[0] else {
+        panic!("expected SqlValue::Array, got {:?}", stmt.params[0]);
+    };
+    assert_eq!(elems.len(), 3);
+}
+
+// ---------- MySQL / SQLite reject ----------
+
+#[cfg(feature = "mysql")]
+#[test]
+fn mysql_rejects_array_contains_with_clean_error() {
+    use rustango::sql::SqlError;
+    let q = Post::objects()
+        .where_(Post::title.array_contains(["x"]))
+        .compile()
+        .unwrap();
+    let err = MySql.compile_select(&q).unwrap_err();
+    match err {
+        SqlError::OpNotSupportedInDialect { op, dialect } => {
+            assert!(op.contains("array operators"), "op label: {op}");
+            assert_eq!(dialect, "mysql");
+        }
+        other => panic!("expected OpNotSupportedInDialect, got: {other:?}"),
+    }
+}
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn sqlite_rejects_array_overlap_with_clean_error() {
+    use rustango::sql::SqlError;
+    let q = Post::objects()
+        .where_(Post::id.array_overlap([1_i64]))
+        .compile()
+        .unwrap();
+    let err = Sqlite.compile_select(&q).unwrap_err();
+    assert!(matches!(
+        err,
+        SqlError::OpNotSupportedInDialect { op, .. } if op.contains("array operators")
+    ));
+}
+
+// ---------- Django-shape parser routes ----------
+
+#[test]
+fn parser_routes_array_contains_lookup() {
+    use rustango::core::SqlValue;
+    let q = Post::objects()
+        .filter(
+            "title__array_contains",
+            SqlValue::List(vec![
+                SqlValue::String("rust".into()),
+                SqlValue::String("orm".into()),
+            ]),
+        )
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""title" @> $1"#),
+        "parser route to ArrayContains: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn parser_routes_array_overlap_lookup() {
+    use rustango::core::SqlValue;
+    let q = Post::objects()
+        .filter(
+            "id__array_overlap",
+            SqlValue::List(vec![SqlValue::I64(1), SqlValue::I64(2)]),
+        )
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#""id" && $1"#),
+        "parser route to ArrayOverlap: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn parser_rejects_non_list_value_for_array_lookup() {
+    use rustango::core::{QueryError, SqlValue};
+    let r = Post::objects()
+        .filter(
+            "title__array_contains",
+            SqlValue::String("not a list".into()),
+        )
+        .compile();
+    assert!(
+        matches!(r, Err(QueryError::InvalidLookupValue { ref suffix, .. }) if suffix == "array_contains"),
+        "non-list value rejected: {r:?}",
+    );
+}
+
+#[test]
+fn unknown_lookup_error_advertises_array_suffixes() {
+    let r = Post::objects().filter("title__nope", "value").compile();
+    let err = r.unwrap_err();
+    let msg = format!("{err}");
+    for suffix in ["array_contains", "array_contained_by", "array_overlap"] {
+        assert!(
+            msg.contains(suffix),
+            "supported-lookups list should advertise `{suffix}`: {msg}"
+        );
+    }
+}
+
+// ---------- Writer-level: shape check ----------
+//
+// `Column::array_contains` always produces a `SqlValue::Array`, so the
+// `ArrayOpRequiresArray` writer-level guard isn't reachable through
+// the typed API. It's covered defensively by `forms::collect_values`
+// (which uses `SqlValue::List`) and the `__array_*` parser route
+// (which promotes `List` → `Array` automatically). Verify that
+// promotion happens by inspecting the post-parser query:
+#[test]
+fn parser_promotes_list_to_array_so_writer_accepts_it() {
+    use rustango::core::SqlValue;
+    let q = Post::objects()
+        .filter(
+            "title__array_contains",
+            SqlValue::List(vec![SqlValue::String("rust".into())]),
+        )
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    assert!(stmt.sql.contains("@>"));
+    assert_eq!(stmt.params.len(), 1);
+    assert!(
+        matches!(&stmt.params[0], SqlValue::Array(_)),
+        "parser must promote List → Array for writer; got {:?}",
+        stmt.params[0]
+    );
+}


### PR DESCRIPTION
## Summary
Ships the Django `ArrayField` WHERE-clause shape: `__contains` / `__contained_by` / `__overlap` as Postgres `@> / <@ / &&` operators.

**ORM-extractability principle (user request)**: every new variant lives in `core/` (Op, SqlValue::Array, Column trait methods) + `sql/` (Dialect `write_array_op` + per-backend overrides) + `query/mod.rs` (parser route). No admin / tenancy coupling.

## New IR variants
- `Op::ArrayContains` / `Op::ArrayContainedBy` / `Op::ArrayOverlap`
- `SqlValue::Array(Vec<SqlValue>)` — single PG array parameter (distinct from `SqlValue::List` which fans out to N placeholders)
- `Dialect::write_array_op` — PG default; MySQL + SQLite override to reject with `OpNotSupportedInDialect`
- `SqlError::ArrayOpRequiresArray` — defensive guard

## Typed-IR API
\`\`\`rust
Post::objects()
    .where_(Post::tags.array_contains([\"rust\", \"orm\"]))
    .where_(Post::tag_ids.array_overlap([1_i64, 2, 3]))
\`\`\`

## Django parser
The `__array_contains` / `__array_contained_by` / `__array_overlap` parser routes auto-promote `SqlValue::List` → `SqlValue::Array` so the writer binds it as a single PG array parameter. Non-list values surface as `InvalidLookupValue`. We use the `__array_*` prefix (rather than Django's bare `__contains`) so the array path stays disjoint from existing text `__contains` — rustango can't field-type-dispatch at parser time today.

## Backend behaviour
- **Postgres**: emits `<col> @> $N` / `<col> <@ $N` / `<col> && $N`. The bound `Vec<T>` rides through sqlx's native array Encode for I32 / I64 / String / Bool element types.
- **MySQL** / **SQLite**: reject with `OpNotSupportedInDialect` (\"array operators (@>, <@, &&) — PG ArrayField is Postgres-only\")

## Scope note
Ships the ops only. A `FieldType::Array(elem)` declaration shape — matching Django's `ArrayField(IntegerField)` API — follows in a separate slice. For v1, columns are declared via raw migration SQL (`tags TEXT[]`) and referenced through the typed-IR methods. Same pattern as trigram (ops in #130, scalar fns in #135 later).

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test --workspace --all-features --no-run`
- [x] `cargo build --no-default-features --features sqlite,tenancy`
- [x] 11 emission tests in `tests/array_ops_emission.rs` covering: PG emission for all three ops + single-param binding, MySQL + SQLite rejection with descriptive op labels, Django parser routing + List→Array promotion + `InvalidLookupValue` + `UnknownLookup` advertising the new suffixes
- [x] `cargo test --lib --all-features` → 1814 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)