### PR TITLE
fix(tests): poll for post-panic scheduler tick in panicking_job_does_not_kill_loop

### DIFF
--- a/crates/rustango/src/scheduler/mod.rs
+++ b/crates/rustango/src/scheduler/mod.rs
@@ -258,7 +258,22 @@ mod tests {
             }
         });
         let handle = s.start();
-        tokio::time::sleep(Duration::from_millis(80)).await;
+        // Poll up to 2s for the post-panic tick to land. Earlier we
+        // slept a fixed 80ms — CI's busy runner sometimes takes 100ms+
+        // to deliver the second tick after the panicking one, so the
+        // assertion landed at 0 and red-tagged main. Polling converges
+        // as soon as `counter >= 1`. Same shape as the on_commit_live /
+        // jobs_pg_live / job_fires_after_one_period flake fixes.
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            if counter.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
         let count = counter.load(Ordering::SeqCst);
         assert!(
             count >= 1,


### PR DESCRIPTION
## Summary
Sibling flake to PRs #158 (`job_fires_after_one_period`) and #139 (`jobs_pg_live`). Main CI on PR #161's merge run failed at 0 fires because the fixed 80ms sleep wasn't long enough for the second tick on a busy runner — the loop schedules at 20ms cadence but the first iteration panics, and CI's busy scheduler can deliver the recovery tick 100ms+ later.

Replace the fixed sleep with a poll loop: wait up to 2 seconds for the counter to reach 1, breaking as soon as it does. Converges quickly on a healthy runner; tolerates lag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)