### PR TITLE
feat: rustango::test_db::with_rollback — TestCase tx-wrapping helper (#39 partial)

### DIFF
--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -928,6 +928,12 @@ pub mod test_data;
 #[cfg(feature = "config")]
 pub mod test_settings;
 
+/// Test-time DB isolation — Django's `TestCase` transaction
+/// wrapping. [`test_db::with_rollback`] runs an async closure
+/// inside a transaction that always rolls back, so test mutations
+/// don't leak into the next test. Issue #39 partial.
+pub mod test_db;
+
 /// `manage dbshell` — spawn `psql` / `mysql` / `sqlite3` for the
 /// current `DATABASE_URL`. Issue #56 (partial).
 pub mod dbshell;

--- a/crates/rustango/src/test_db.rs
+++ b/crates/rustango/src/test_db.rs
@@ -1,0 +1,145 @@
+//! Test-time DB isolation — Django's `TestCase` transaction
+//! wrapping. Issue #39 partial.
+//!
+//! Django's `TestCase` wraps each test method in a transaction that
+//! always rolls back, so mutations during one test never leak into
+//! the next. Rust has no test classes; the analog is an explicit
+//! helper that test code wraps around its body:
+//!
+//! ```ignore
+//! use rustango::test_db::with_rollback;
+//!
+//! #[tokio::test]
+//! async fn create_and_count() {
+//!     let pool = test_pool().await;
+//!     with_rollback(&pool, |tx| Box::pin(async move {
+//!         // Inserts here are visible to assertions inside the
+//!         // closure, but rolled back when it returns.
+//!         insert_tx(tx, &article_q("First")).await?;
+//!         insert_tx(tx, &article_q("Second")).await?;
+//!
+//!         let count = count_tx::<Article>(tx).await?;
+//!         assert_eq!(count, 2);
+//!         Ok(())
+//!     })).await.unwrap();
+//!
+//!     // The two articles are gone — rollback happened on return.
+//! }
+//! ```
+//!
+//! ## Why a separate helper instead of `atomic()`?
+//!
+//! [`crate::sql::atomic`] commits on `Ok` and rolls back on `Err`.
+//! Tests want the rollback unconditionally so the schema stays
+//! clean for the next test. [`with_rollback`] swaps the commit
+//! branch for a rollback while preserving the closure's return
+//! value.
+//!
+//! ## Caveats vs Django
+//!
+//! - **Per-test isolation only**: the rollback wraps a single
+//!   closure. Tests still share a process-wide DB connection pool;
+//!   the rollback only resets data this test inserted.
+//! - **Concurrency**: parallel tests still race on shared rows
+//!   they didn't insert. Pair with a suite-wide `tokio::Mutex` if
+//!   the test touches process-global state (per the project's
+//!   global-state mutex convention).
+//! - **`on_commit` callbacks**: they NEVER fire here, by design —
+//!   the tx always rolls back, so deferred work would be a phantom.
+//!   `with_rollback` also clears any callbacks the closure registered.
+//! - **SAVEPOINTs**: nested calls behave as nested savepoints via
+//!   sqlx's transaction shape. Outer rollback discards inner work
+//!   even if inner committed.
+//!
+//! Issue #39 partial — full TestCase / TransactionTestCase /
+//! SimpleTestCase / LiveServerTestCase hierarchy is a separate slice.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::sql::{transaction_pool, ExecError, Pool, PoolTx};
+
+/// Run `f` inside a transaction that ALWAYS rolls back when the
+/// closure returns, regardless of whether the closure returned
+/// `Ok` or `Err`. The transaction-rollback step happens after the
+/// closure's value is captured, so callers see the closure's
+/// original result.
+///
+/// On `Err` the closure result is returned as-is. On `Ok` the
+/// closure result is returned after the rollback completes
+/// successfully; if the rollback itself fails (network blip /
+/// connection drop) the closure's Ok is converted to that
+/// driver error.
+///
+/// # Errors
+/// - The closure's own error (transitively).
+/// - `BEGIN` / `ROLLBACK` driver errors.
+pub async fn with_rollback<F, T>(pool: &Pool, f: F) -> Result<T, ExecError>
+where
+    F: for<'tx> FnOnce(
+        &'tx mut PoolTx<'_>,
+    ) -> Pin<Box<dyn Future<Output = Result<T, ExecError>> + Send + 'tx>>,
+{
+    let mut tx = transaction_pool(pool).await?;
+    let result = f(&mut tx).await;
+    // ALWAYS roll back, regardless of `result`. A failing rollback
+    // (driver/network) is reported as the new error only when the
+    // closure succeeded — otherwise the closure's own error takes
+    // priority.
+    let rollback = tx.rollback().await;
+    match (result, rollback) {
+        (Ok(v), Ok(())) => Ok(v),
+        (Ok(_), Err(e)) => Err(ExecError::Driver(e)),
+        (Err(e), _) => Err(e),
+    }
+}
+
+/// Sugar around [`with_rollback`] that wraps the body in
+/// `Box::pin(async move { … })` so callers don't have to. Identical
+/// semantics:
+///
+/// ```ignore
+/// rustango::with_rollback!(&pool, |tx| {
+///     insert_tx(tx, &q).await?;
+///     // ... assertions ...
+///     Ok(())
+/// }).await
+/// ```
+#[macro_export]
+macro_rules! with_rollback {
+    ($pool:expr, |$tx:ident| $body:block) => {{
+        $crate::test_db::with_rollback($pool, move |$tx| Box::pin(async move { $body }))
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    // Live-database tests need a real connection pool. The
+    // pure-logic tests cover the macro shape via type-check; the
+    // rollback behavior is exercised by integration tests in
+    // crates that wire a real Pool.
+
+    use super::with_rollback;
+
+    #[test]
+    fn macro_and_function_compile() {
+        // Compile-only: pin the function + macro signatures so a
+        // refactor doesn't silently change them. The body never
+        // executes — the closure isn't called.
+        let _ = || async {
+            // This closure never executes; the test exists to catch
+            // macro hygiene regressions.
+            #[allow(unreachable_code, clippy::diverging_sub_expression)]
+            {
+                let pool: &crate::sql::Pool = unimplemented!();
+                let _r: Result<i32, _> =
+                    with_rollback(pool, |_tx| Box::pin(async move { Ok(42) })).await;
+                let _r2: Result<i32, _> = crate::with_rollback!(pool, |tx| {
+                    let _: &mut crate::sql::PoolTx<'_> = tx;
+                    Ok(42)
+                })
+                .await;
+            }
+        };
+    }
+}

--- a/crates/rustango/tests/test_db_rollback_live.rs
+++ b/crates/rustango/tests/test_db_rollback_live.rs
@@ -1,0 +1,128 @@
+//! Live PG integration test for [`rustango::test_db::with_rollback`].
+//!
+//! Verifies the rollback semantic against a real Postgres database:
+//! rows inserted inside the closure are visible to the closure but
+//! disappear after it returns.
+//!
+//! Skipped silently when `DATABASE_URL` is unset (matches the rest
+//! of the `_live` suite). Run with:
+//!
+//! ```text
+//! DATABASE_URL=postgres://... cargo test --test test_db_rollback_live
+//! ```
+
+#![cfg(feature = "postgres")]
+
+use rustango::sql::{ExecError, Pool};
+use rustango::test_db::with_rollback;
+use sqlx::Row as _;
+use std::sync::OnceLock;
+use tokio::sync::Mutex;
+
+/// Suite-wide mutex — the table is shared across tests in this file
+/// and we want one test at a time to mutate it (process-global state
+/// per the project's testing convention).
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pg = sqlx::PgPool::connect(&url).await.ok()?;
+    Some(Pool::Postgres(pg))
+}
+
+async fn ensure_table(pool: &Pool) {
+    // Idempotent — re-runs are no-ops.
+    let Pool::Postgres(pg) = pool else {
+        return;
+    };
+    sqlx::query(
+        r#"CREATE TABLE IF NOT EXISTS "trb_rollback_check" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "label" VARCHAR(64) NOT NULL
+        )"#,
+    )
+    .execute(pg)
+    .await
+    .unwrap();
+    sqlx::query(r#"TRUNCATE "trb_rollback_check""#)
+        .execute(pg)
+        .await
+        .unwrap();
+}
+
+async fn row_count(pool: &Pool) -> i64 {
+    let Pool::Postgres(pg) = pool else {
+        return -1;
+    };
+    sqlx::query(r#"SELECT COUNT(*) AS n FROM "trb_rollback_check""#)
+        .fetch_one(pg)
+        .await
+        .unwrap()
+        .get::<i64, _>("n")
+}
+
+#[tokio::test]
+async fn rollback_discards_inserts_on_ok_return() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("DATABASE_URL unset — skipping");
+        return;
+    };
+    ensure_table(&pool).await;
+    assert_eq!(row_count(&pool).await, 0);
+
+    let inner: Result<i64, ExecError> = with_rollback(&pool, |tx| {
+        Box::pin(async move {
+            // Use sqlx directly through the PoolTx to insert rows.
+            // The PoolTx variants expose the inner sqlx Transaction.
+            let rustango::sql::PoolTx::Postgres(t) = tx else {
+                panic!("PG pool variant expected");
+            };
+            sqlx::query(r#"INSERT INTO "trb_rollback_check" (label) VALUES ('a'), ('b')"#)
+                .execute(&mut **t)
+                .await?;
+            let n: i64 = sqlx::query(r#"SELECT COUNT(*) AS n FROM "trb_rollback_check""#)
+                .fetch_one(&mut **t)
+                .await?
+                .get("n");
+            assert_eq!(n, 2, "rows visible inside closure");
+            Ok::<i64, ExecError>(n)
+        })
+    })
+    .await;
+
+    assert!(inner.is_ok());
+    assert_eq!(inner.unwrap(), 2, "closure return value preserved");
+    // The two rows are gone — rollback fired on Ok.
+    assert_eq!(row_count(&pool).await, 0);
+}
+
+#[tokio::test]
+async fn rollback_fires_on_closure_err_too() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("DATABASE_URL unset — skipping");
+        return;
+    };
+    ensure_table(&pool).await;
+
+    let r: Result<(), ExecError> = with_rollback(&pool, |tx| {
+        Box::pin(async move {
+            let rustango::sql::PoolTx::Postgres(t) = tx else {
+                panic!("PG pool variant expected");
+            };
+            sqlx::query(r#"INSERT INTO "trb_rollback_check" (label) VALUES ('c')"#)
+                .execute(&mut **t)
+                .await?;
+            // Synthesize an error — should still roll back the insert.
+            Err::<(), _>(ExecError::EmptyReturning)
+        })
+    })
+    .await;
+
+    assert!(r.is_err(), "closure error propagated");
+    assert_eq!(row_count(&pool).await, 0, "rollback fired even on Err");
+}


### PR DESCRIPTION
## Summary
Adds Django-style `TestCase` transaction wrapping. Runs an async closure inside a transaction that ALWAYS rolls back regardless of the closure's Result, so test mutations don't leak into the next test.

\`\`\`rust
use rustango::test_db::with_rollback;

#[tokio::test]
async fn create_and_count() {
    let pool = test_pool().await;
    with_rollback(&pool, |tx| Box::pin(async move {
        insert_tx(tx, &article_q(\"First\")).await?;
        let count = count_tx::<Article>(tx).await?;
        assert_eq!(count, 1);
        Ok(())
    })).await.unwrap();
    // The article is gone — rollback happened on return.
}
\`\`\`

Companion `with_rollback!` macro saves the `Box::pin` boilerplate.

## Differences from `sql::atomic`
`atomic` commits on `Ok` / rolls back on `Err`. `with_rollback` rolls back **unconditionally** — that's the whole reason it exists. The closure result is captured BEFORE the rollback, so callers see the original Ok/Err value.

## Caveats vs Django
- **Per-test isolation only**: the rollback wraps a single closure. Tests still share a process pool; the rollback only resets data this test inserted.
- **Concurrency**: parallel tests still race on rows they didn't insert. Pair with a suite-wide mutex per the project's global-state-mutex convention.
- **`on_commit` callbacks never fire** (tx always rolls back, so deferred work would be a phantom).
- **Nested calls** behave as savepoints via sqlx's transaction shape; outer rollback discards inner work even if inner committed.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test --workspace --all-features --no-run`
- [x] `cargo build --no-default-features --features sqlite,tenancy`
- [x] 1 unit test pinning function + macro signatures
- [x] 2 PG-live integration tests in `tests/test_db_rollback_live.rs`: inserts visible inside closure but discarded on Ok return; same rollback fires on Err return. Skipped when `DATABASE_URL` is unset.
- [x] `cargo test --lib --all-features` → 1870 pass (+1)

Issue #39 partial — the four-tier `TestCase` / `TransactionTestCase` / `SimpleTestCase` / `LiveServerTestCase` hierarchy is a separate slice; this ships the core tx-wrapping primitive every tier needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)