### PR TITLE
feat: manage showmodels — print registered model registry (#60 partial)

### DIFF
--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -115,6 +115,7 @@ pub async fn run_with_writer<W: Write + Send>(
         "dumpdata" => dumpdata_cmd(pool, &args[1..], writer).await,
         "loaddata" => loaddata_cmd(pool, &args[1..], writer).await,
         "showurls" => showurls_cmd(&args[1..], writer),
+        "showmodels" => showmodels_cmd(&args[1..], writer),
         // v0.38 — `inspectdb` is tri-dialect: PG + MySQL via
         // `information_schema`, SQLite via `PRAGMA table_info` +
         // `sqlite_master`. Dispatch happens inside `inspectdb_cmd`.
@@ -239,6 +240,15 @@ fn print_help<W: Write>(w: &mut W) -> std::io::Result<()> {
         "      misconfigurations. With --deploy: production hardening checks."
     )?;
     writeln!(w, "      Exits non-zero on any error-level finding.\n")?;
+    writeln!(w, "  showmodels [--format plain|json] [--app <label>]")?;
+    writeln!(
+        w,
+        "      Print every model registered via #[derive(Model)] + inventory."
+    )?;
+    writeln!(
+        w,
+        "      Confirms registration / debugs missing-model surprises.\n"
+    )?;
     writeln!(w, "  showurls [--format plain|json]")?;
     writeln!(
         w,
@@ -2804,6 +2814,140 @@ fn showurls_cmd<W: Write>(args: &[String], w: &mut W) -> Result<(), MigrateError
     Ok(())
 }
 
+/// `manage showmodels [--format plain|json] [--app <label>]` —
+/// print every model registered via `#[derive(Model)]` + `inventory`.
+/// Useful for confirming model registration in CI / debugging
+/// "where did my model go?" / cross-checking the admin sidebar
+/// against the inventory.
+///
+/// - `--format plain` (default): one row per model. Columns are
+///   app, model name, table, field count.
+/// - `--format json`: JSON array of `{"app", "name", "table",
+///   "fields"}` for piping to `jq`.
+/// - `--app <label>`: filter to one app's models. Useful when the
+///   binary registers many apps.
+///
+/// Sorted by `(app, name)` for deterministic output.
+fn showmodels_cmd<W: Write>(args: &[String], w: &mut W) -> Result<(), MigrateError> {
+    let mut format = "plain";
+    let mut app_filter: Option<String> = None;
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--help" | "-h" => {
+                writeln!(w, "showmodels [--format plain|json] [--app <label>]")?;
+                writeln!(w)?;
+                writeln!(
+                    w,
+                    "  Print every model registered via #[derive(Model)] + inventory."
+                )?;
+                writeln!(w, "  --format plain (default) | json")?;
+                writeln!(w, "  --app <label>          Limit to a single app.")?;
+                return Ok(());
+            }
+            "--format" => {
+                let v = iter
+                    .next()
+                    .ok_or_else(|| MigrateError::Validation("--format expects a value".into()))?;
+                match v.as_str() {
+                    "plain" => format = "plain",
+                    "json" => format = "json",
+                    other => {
+                        return Err(MigrateError::Validation(format!(
+                            "--format: unknown value `{other}` (expected `plain` or `json`)"
+                        )));
+                    }
+                }
+            }
+            "--app" => {
+                let v = iter
+                    .next()
+                    .ok_or_else(|| MigrateError::Validation("--app expects a value".into()))?;
+                app_filter = Some(v.clone());
+            }
+            other if other.starts_with('-') => {
+                return Err(MigrateError::Validation(format!("unknown flag: {other}")));
+            }
+            other => {
+                return Err(MigrateError::Validation(format!(
+                    "unexpected positional argument: {other}"
+                )));
+            }
+        }
+    }
+
+    // Collect + filter + sort.
+    #[derive(Debug)]
+    struct Row {
+        app: String,
+        name: &'static str,
+        table: &'static str,
+        fields: usize,
+    }
+    let mut rows: Vec<Row> = inventory::iter::<crate::core::ModelEntry>()
+        .map(|entry| Row {
+            app: entry.resolved_app_label().unwrap_or("").to_owned(),
+            name: entry.schema.name,
+            table: entry.schema.table,
+            fields: entry.schema.fields.len(),
+        })
+        .filter(|r| app_filter.as_deref().is_none_or(|f| r.app == f))
+        .collect();
+    rows.sort_by(|a, b| (a.app.as_str(), a.name).cmp(&(b.app.as_str(), b.name)));
+
+    match format {
+        "json" => {
+            let items: Vec<serde_json::Value> = rows
+                .iter()
+                .map(|r| {
+                    serde_json::json!({
+                        "app": r.app,
+                        "name": r.name,
+                        "table": r.table,
+                        "fields": r.fields,
+                    })
+                })
+                .collect();
+            let rendered = serde_json::to_string_pretty(&items).map_err(|e| {
+                MigrateError::Validation(format!("showmodels: serialize JSON: {e}"))
+            })?;
+            writeln!(w, "{rendered}")?;
+        }
+        _ => {
+            if rows.is_empty() {
+                let suffix = app_filter
+                    .as_deref()
+                    .map(|f| format!(" for app `{f}`"))
+                    .unwrap_or_default();
+                writeln!(w, "(no models registered{suffix})")?;
+                return Ok(());
+            }
+            let max_app = rows.iter().map(|r| r.app.len()).max().unwrap_or(0).max(3); // "app"
+            let max_name = rows.iter().map(|r| r.name.len()).max().unwrap_or(0).max(5);
+            let max_table = rows.iter().map(|r| r.table.len()).max().unwrap_or(0).max(5);
+            for r in &rows {
+                let app = if r.app.is_empty() {
+                    "-"
+                } else {
+                    r.app.as_str()
+                };
+                writeln!(
+                    w,
+                    "  {:<aw$}  {:<nw$}  {:<tw$}  {} fields",
+                    app,
+                    r.name,
+                    r.table,
+                    r.fields,
+                    aw = max_app,
+                    nw = max_name,
+                    tw = max_table,
+                )?;
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Mask the password in a `postgres://user:pass@host/db` connection
 /// URL so it doesn't leak into log output.
 fn redact(argv: &[String]) -> Vec<String> {
@@ -3486,6 +3630,84 @@ mod gen_tests {
         // Must be valid JSON.
         let parsed: serde_json::Value = serde_json::from_str(s.trim()).unwrap();
         assert!(parsed.is_array(), "expected JSON array, got: {s}");
+    }
+
+    // -------- showmodels --------
+
+    #[test]
+    fn showmodels_help_short_circuits() {
+        let mut buf: Vec<u8> = Vec::new();
+        let r = showmodels_cmd(&["--help".into()], &mut buf);
+        assert!(r.is_ok());
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("showmodels"));
+        assert!(s.contains("--app"));
+    }
+
+    #[test]
+    fn showmodels_rejects_unknown_format() {
+        let mut buf: Vec<u8> = Vec::new();
+        let r = showmodels_cmd(&["--format".into(), "xml".into()], &mut buf);
+        assert!(r.is_err());
+        let e = format!("{}", r.unwrap_err());
+        assert!(e.contains("unknown value"));
+    }
+
+    #[test]
+    fn showmodels_rejects_unknown_flag() {
+        let mut buf: Vec<u8> = Vec::new();
+        let r = showmodels_cmd(&["--badflag".into()], &mut buf);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn showmodels_rejects_positional() {
+        let mut buf: Vec<u8> = Vec::new();
+        let r = showmodels_cmd(&["unexpected".into()], &mut buf);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn showmodels_app_filter_requires_value() {
+        let mut buf: Vec<u8> = Vec::new();
+        let r = showmodels_cmd(&["--app".into()], &mut buf);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn showmodels_plain_runs_clean() {
+        // Inventory contents depend on what's linked in the test
+        // binary; we just verify the verb completes without error.
+        let mut buf: Vec<u8> = Vec::new();
+        let r = showmodels_cmd(&[], &mut buf);
+        assert!(r.is_ok(), "showmodels should not error: {r:?}");
+    }
+
+    #[test]
+    fn showmodels_json_emits_parseable_array() {
+        let mut buf: Vec<u8> = Vec::new();
+        let r = showmodels_cmd(&["--format".into(), "json".into()], &mut buf);
+        assert!(r.is_ok());
+        let s = String::from_utf8(buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(s.trim()).unwrap();
+        assert!(parsed.is_array());
+    }
+
+    #[test]
+    fn showmodels_app_filter_excludes_other_apps() {
+        // Filter to an app name that definitely doesn't exist —
+        // result should be the "no models registered" message.
+        let mut buf: Vec<u8> = Vec::new();
+        let r = showmodels_cmd(
+            &["--app".into(), "xyz_definitely_not_an_app".into()],
+            &mut buf,
+        );
+        assert!(r.is_ok());
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("no models registered"),
+            "expected empty-output marker for unknown app, got: {s}"
+        );
     }
 
     /// Default template (no `--tenant`) keeps the v0.28


### PR DESCRIPTION
## Summary
Companion to `manage showurls` (#172). Walks `inventory::iter::<ModelEntry>` and prints every model registered via `#[derive(Model)]`. Useful for:
- Confirming model registration in CI (no missing-model surprises).
- Auditing the inventory before a migration squash.
- Cross-checking the admin sidebar against what's actually wired.

\`\`\`
\$ cargo run manage showmodels
  blog   Article   blog_article   12 fields
  blog   Author    blog_author     5 fields
  shop   Order     shop_order     18 fields

\$ cargo run manage showmodels --format json --app blog
[
  {\"app\": \"blog\", \"name\": \"Article\", \"table\": \"blog_article\", \"fields\": 12},
  {\"app\": \"blog\", \"name\": \"Author\",  \"table\": \"blog_author\",  \"fields\": 5}
]
\`\`\`

## Flags
- `--format plain` (default): name + table + field count aligned columns, sorted by `(app, name)`.
- `--format json`: JSON array of `{app, name, table, fields}` for `jq` piping.
- `--app <label>`: limit to a single app. Unknown app emits the `(no models registered for app \`<label>\`)` marker.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test --workspace --all-features --no-run`
- [x] `cargo build --no-default-features --features sqlite,tenancy`
- [x] 8 new tests: --help short-circuits, rejects unknown format, rejects unknown flag, rejects positional, --app requires value, plain runs clean, --format json emits parseable array, --app unknown emits empty-output marker
- [x] `cargo test --lib --all-features` → 1900 pass (+8)

Issue #60 partial — round-trips with #172 (showurls) for the \"what's wired in this binary?\" inspection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)