### PR TITLE
feat: test_db::with_truncate_after — TransactionTestCase analog (#39 partial)

### DIFF
--- a/crates/rustango/src/test_db.rs
+++ b/crates/rustango/src/test_db.rs
@@ -1,5 +1,31 @@
-//! Test-time DB isolation — Django's `TestCase` transaction
-//! wrapping. Issue #39 partial.
+//! Test-time DB isolation — Django's `TestCase` / `TransactionTestCase`
+//! analogs. Issue #39.
+//!
+//! ## Four-tier shape
+//!
+//! Django ships four test base classes with distinct DB semantics.
+//! rustango is a function-style framework, so the analogs are
+//! helpers that callers wrap around the test body:
+//!
+//! | Django class            | rustango analog                        | Use when …                                              |
+//! |-------------------------|----------------------------------------|---------------------------------------------------------|
+//! | `SimpleTestCase`        | plain `#[tokio::test]`                 | no DB access — fastest.                                 |
+//! | `TestCase`              | [`with_rollback`]                      | reads / writes that should be rolled back at end.       |
+//! | `TransactionTestCase`   | [`with_truncate_after`]                | code under test commits (signals, on_commit hooks).     |
+//! | `LiveServerTestCase`    | [`crate::test_server::LiveServer`]     | needs a real listening socket (Selenium, websockets).   |
+//!
+//! ## Why a separate helper per tier?
+//!
+//! Each tier has a different "what happens between tests" guarantee:
+//!
+//! - `with_rollback` wraps the body in a transaction that ALWAYS
+//!   rolls back. Fastest. But invisible to code paths that check for
+//!   a committed state (signals, `on_commit` hooks, FK triggers
+//!   firing on real commit).
+//! - `with_truncate_after` commits real rows during the body, then
+//!   truncates the listed tables after — so the body sees committed
+//!   state, and the next test starts clean. Slower than
+//!   `with_rollback` because every test pays the truncate cost.
 //!
 //! Django's `TestCase` wraps each test method in a transaction that
 //! always rolls back, so mutations during one test never leak into
@@ -57,7 +83,7 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::sql::{transaction_pool, ExecError, Pool, PoolTx};
+use crate::sql::{raw_execute_pool, transaction_pool, ExecError, Pool, PoolTx};
 
 /// Run `f` inside a transaction that ALWAYS rolls back when the
 /// closure returns, regardless of whether the closure returned
@@ -112,6 +138,137 @@ macro_rules! with_rollback {
     }};
 }
 
+/// Run `f` to completion, then truncate `tables` regardless of the
+/// closure's result. Django's `TransactionTestCase` analog: the
+/// closure's writes COMMIT (so it sees real post-commit state —
+/// signals fire, `on_commit` hooks fire, FK triggers fire), and the
+/// teardown step clears those tables so the next test starts clean.
+///
+/// Per-dialect strategy mirrors [`crate::migrate::manage`] `flush`:
+/// - **Postgres**: one `TRUNCATE TABLE t1, t2, ... RESTART IDENTITY
+///   CASCADE` statement. Atomic, FK-aware, sequence-resetting.
+/// - **MySQL / SQLite**: per-table `DELETE FROM "<table>"` in
+///   the listed order. Sequences are NOT reset.
+///
+/// The closure's return value is preserved unchanged. Truncate
+/// failures surface as the new error ONLY when the closure
+/// succeeded — otherwise the closure's error takes priority (so the
+/// real failure isn't masked by a noisy teardown).
+///
+/// **Concurrency**: this helper commits real rows. Tests calling it
+/// against the same tables must serialize (the project convention
+/// is a suite-wide `tokio::sync::Mutex<()>`) — see the
+/// "Tests on global state need a mutex" memory note. Truncate races
+/// across parallel `cargo test` workers would otherwise wipe each
+/// other's setup mid-flight.
+///
+/// **Passing tables explicitly**: callers list only the tables they
+/// touch. Truncating every registered model table would couple every
+/// test to every other app's tables — slow and brittle. If a test
+/// really wants the "wipe everything" shape, `manage flush --yes`
+/// does that.
+///
+/// ```ignore
+/// use rustango::test_db::with_truncate_after;
+///
+/// #[tokio::test]
+/// async fn create_article_fires_post_save_signal() {
+///     let pool = test_pool().await;
+///     let _g = SUITE_MUTEX.lock().await;
+///     with_truncate_after(&pool, &["articles"], || async move {
+///         create_article("First").await?; // COMMITS — post_save fires
+///         assert_signal_fired();
+///         Ok(())
+///     }).await.unwrap();
+///     // The article is gone — truncate happened on return.
+/// }
+/// ```
+///
+/// # Errors
+/// - The closure's own error (transitively).
+/// - Truncate driver errors (only when the closure succeeded).
+pub async fn with_truncate_after<F, Fut, T>(
+    pool: &Pool,
+    tables: &[&str],
+    f: F,
+) -> Result<T, ExecError>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T, ExecError>> + Send,
+{
+    let result = f().await;
+    let truncate = truncate_tables(pool, tables).await;
+    match (result, truncate) {
+        (Ok(v), Ok(())) => Ok(v),
+        (Ok(_), Err(e)) => Err(e),
+        (Err(e), _) => Err(e),
+    }
+}
+
+/// Truncate every table in `tables`, dialect-aware. Public so callers
+/// can reuse the per-dialect clear logic outside [`with_truncate_after`]
+/// (custom test fixtures, manual teardown).
+///
+/// On Postgres this is one `TRUNCATE` statement; on MySQL/SQLite it's
+/// per-table `DELETE FROM`. Returns the first driver error, but does
+/// NOT short-circuit — every remaining table is still attempted on
+/// the per-table path so partial cleanup happens even when one fails.
+///
+/// Passing an empty slice is a no-op (returns `Ok(())`).
+///
+/// # Errors
+/// - The first driver error encountered (per-table path collects
+///   subsequent errors but reports only the first).
+pub async fn truncate_tables(pool: &Pool, tables: &[&str]) -> Result<(), ExecError> {
+    if tables.is_empty() {
+        return Ok(());
+    }
+    let dialect = pool.dialect().name();
+    if dialect == "postgres" {
+        let quoted: Vec<String> = tables
+            .iter()
+            .map(|t| format!(r#""{}""#, t.replace('"', r#""""#)))
+            .collect();
+        let sql = format!(
+            "TRUNCATE TABLE {} RESTART IDENTITY CASCADE",
+            quoted.join(", "),
+        );
+        raw_execute_pool(pool, &sql, Vec::new()).await?;
+        Ok(())
+    } else {
+        let mut first_err: Option<ExecError> = None;
+        for table in tables {
+            let sql = format!(r#"DELETE FROM "{}""#, table.replace('"', r#""""#));
+            if let Err(e) = raw_execute_pool(pool, &sql, Vec::new()).await {
+                if first_err.is_none() {
+                    first_err = Some(e);
+                }
+            }
+        }
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+}
+
+/// Sugar around [`with_truncate_after`] mirroring the
+/// [`with_rollback!`](crate::with_rollback) macro shape:
+///
+/// ```ignore
+/// rustango::with_truncate_after!(&pool, &["articles", "comments"], {
+///     create_article("First").await?;
+///     create_comment("…").await?;
+///     Ok(())
+/// }).await
+/// ```
+#[macro_export]
+macro_rules! with_truncate_after {
+    ($pool:expr, $tables:expr, $body:block) => {{
+        $crate::test_db::with_truncate_after($pool, $tables, move || async move { $body })
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     // Live-database tests need a real connection pool. The
@@ -119,7 +276,7 @@ mod tests {
     // rollback behavior is exercised by integration tests in
     // crates that wire a real Pool.
 
-    use super::with_rollback;
+    use super::{truncate_tables, with_rollback, with_truncate_after};
 
     #[test]
     fn macro_and_function_compile() {
@@ -139,6 +296,11 @@ mod tests {
                     Ok(42)
                 })
                 .await;
+                let _r3: Result<i32, _> =
+                    with_truncate_after(pool, &["t1", "t2"], || async move { Ok(7) }).await;
+                let _r4: Result<i32, _> =
+                    crate::with_truncate_after!(pool, &["t1"], { Ok(7) }).await;
+                let _r5: Result<(), _> = truncate_tables(pool, &["t1"]).await;
             }
         };
     }

--- a/crates/rustango/tests/test_db_truncate_live.rs
+++ b/crates/rustango/tests/test_db_truncate_live.rs
@@ -1,0 +1,155 @@
+//! Live PG integration test for [`rustango::test_db::with_truncate_after`].
+//!
+//! Verifies the truncate-after semantic against a real Postgres
+//! database: rows COMMIT during the closure (so handlers / signals
+//! observing committed state work), and the named tables come back
+//! to zero rows once the closure returns.
+//!
+//! Skipped silently when `DATABASE_URL` is unset (matches the rest
+//! of the `_live` suite).
+
+#![cfg(feature = "postgres")]
+
+use rustango::sql::{ExecError, Pool};
+use rustango::test_db::{truncate_tables, with_truncate_after};
+use sqlx::Row as _;
+use std::sync::OnceLock;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pg = sqlx::PgPool::connect(&url).await.ok()?;
+    Some(Pool::Postgres(pg))
+}
+
+async fn ensure_table(pool: &Pool) {
+    let Pool::Postgres(pg) = pool else {
+        return;
+    };
+    sqlx::query(
+        r#"CREATE TABLE IF NOT EXISTS "trb_truncate_check" (
+            "id" BIGSERIAL PRIMARY KEY,
+            "label" VARCHAR(64) NOT NULL
+        )"#,
+    )
+    .execute(pg)
+    .await
+    .unwrap();
+    // Start clean — prior runs may have left rows behind on Err.
+    sqlx::query(r#"TRUNCATE "trb_truncate_check" RESTART IDENTITY"#)
+        .execute(pg)
+        .await
+        .unwrap();
+}
+
+async fn row_count(pool: &Pool) -> i64 {
+    let Pool::Postgres(pg) = pool else {
+        return -1;
+    };
+    sqlx::query(r#"SELECT COUNT(*) AS n FROM "trb_truncate_check""#)
+        .fetch_one(pg)
+        .await
+        .unwrap()
+        .get::<i64, _>("n")
+}
+
+async fn insert(pool: &Pool, label: &str) {
+    let Pool::Postgres(pg) = pool else {
+        return;
+    };
+    sqlx::query(r#"INSERT INTO "trb_truncate_check" (label) VALUES ($1)"#)
+        .bind(label)
+        .execute(pg)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn truncate_after_clears_table_when_closure_returns_ok() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("DATABASE_URL unset — skipping");
+        return;
+    };
+    ensure_table(&pool).await;
+    assert_eq!(row_count(&pool).await, 0);
+
+    let r: Result<i32, ExecError> = with_truncate_after(&pool, &["trb_truncate_check"], || {
+        let pool = pool.clone();
+        async move {
+            insert(&pool, "a").await;
+            insert(&pool, "b").await;
+            // Mid-closure read should see committed rows — proves
+            // these are real INSERTs, not a transaction-scoped
+            // illusion.
+            assert_eq!(row_count(&pool).await, 2);
+            Ok(99)
+        }
+    })
+    .await;
+
+    assert_eq!(r.unwrap(), 99);
+    assert_eq!(
+        row_count(&pool).await,
+        0,
+        "truncate ran on Ok closure return",
+    );
+}
+
+#[tokio::test]
+async fn truncate_after_clears_table_even_when_closure_errs() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("DATABASE_URL unset — skipping");
+        return;
+    };
+    ensure_table(&pool).await;
+
+    let r: Result<(), ExecError> = with_truncate_after(&pool, &["trb_truncate_check"], || {
+        let pool = pool.clone();
+        async move {
+            insert(&pool, "c").await;
+            insert(&pool, "d").await;
+            assert_eq!(row_count(&pool).await, 2);
+            Err::<(), _>(ExecError::EmptyReturning)
+        }
+    })
+    .await;
+
+    assert!(r.is_err(), "closure error propagated through helper");
+    assert_eq!(
+        row_count(&pool).await,
+        0,
+        "truncate ran on Err closure return too",
+    );
+}
+
+#[tokio::test]
+async fn truncate_tables_empty_slice_is_noop() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("DATABASE_URL unset — skipping");
+        return;
+    };
+    ensure_table(&pool).await;
+    insert(&pool, "survivor").await;
+    assert_eq!(row_count(&pool).await, 1);
+
+    truncate_tables(&pool, &[]).await.unwrap();
+    assert_eq!(
+        row_count(&pool).await,
+        1,
+        "empty slice is a no-op — row should still be there",
+    );
+
+    // Cleanup so the next test starts at zero.
+    truncate_tables(&pool, &["trb_truncate_check"])
+        .await
+        .unwrap();
+    assert_eq!(row_count(&pool).await, 0);
+}


### PR DESCRIPTION
## Summary

Add a Django `TransactionTestCase`-shaped helper to pair with the existing `with_rollback` (TestCase) and `LiveServer` (LiveServerTestCase) helpers — closing the last tier of the four-tier test class hierarchy.

`with_truncate_after(pool, &[\"t1\", \"t2\"], || async { ... })` runs the closure to completion (so writes **COMMIT** — signals fire, `on_commit` hooks fire, FK triggers fire) and then truncates the listed tables regardless of the closure's result. The closure's return value is preserved; truncate errors only surface when the closure itself succeeded (so a real test failure isn't masked by a noisy teardown).

Dialect-aware (mirrors `manage flush`):
- **Postgres**: one `TRUNCATE … RESTART IDENTITY CASCADE` statement.
- **MySQL / SQLite**: per-table `DELETE FROM \"<table>\"`.

`truncate_tables` is exposed publicly so custom fixtures can reuse the per-dialect clear logic without the closure wrapper. Empty slice is a no-op.

Module rustdoc gains a 4-tier mapping table at the top so the hierarchy is discoverable from rustango docs without grepping.

| Django class            | rustango analog                        |
|-------------------------|----------------------------------------|
| `SimpleTestCase`        | plain `#[tokio::test]`                 |
| `TestCase`              | `with_rollback`                        |
| `TransactionTestCase`   | `with_truncate_after` **(new)**        |
| `LiveServerTestCase`    | `test_server::LiveServer`              |

## Tests

- 1 lib-level compile guard (function + macro signatures).
- 3 live PG tests (`truncate_after_clears_table_when_closure_returns_ok`, `truncate_after_clears_table_even_when_closure_errs`, `truncate_tables_empty_slice_is_noop`).
- Gates: 1914 lib tests pass; `cargo test --workspace --all-features --no-run` clean; sqlite+tenancy build clean.

## Test plan
- [x] `cargo test --workspace --all-features --test test_db_truncate_live` — 3/3 pass against live PG
- [x] `cargo test --workspace --all-features --lib test_db::` — 1/1 passes
- [x] `cargo test --workspace --all-features --no-run` — clean
- [x] `cargo build --no-default-features --features sqlite,tenancy` — clean
- [x] `cargo test --workspace --all-features --lib` — 1914 pass