### PR TITLE
feat: auth_decorators::superuser_required + _or_403 — sugar for is_superuser predicate (#11 follow-up)

### DIFF
--- a/crates/rustango/src/auth_decorators.rs
+++ b/crates/rustango/src/auth_decorators.rs
@@ -300,6 +300,57 @@ pub fn login_required_or_401() -> impl tower::Layer<
     user_passes_test_or_403(|_| true)
 }
 
+/// Convenience wrapper: gate a route to active superusers only.
+/// Equivalent to
+/// `user_passes_test(login_url, |u| u.is_superuser && u.active)`
+/// but reads tighter at call sites and pins the common
+/// "is_superuser && active" predicate so individual handlers don't
+/// silently diverge on whether `active = false` users still count.
+///
+/// ```ignore
+/// use rustango::auth_decorators::superuser_required;
+///
+/// let admin_routes = Router::new()
+///     .route("/admin/dashboard", get(dashboard))
+///     .layer(superuser_required("/login"));
+/// ```
+#[cfg(all(feature = "tenancy", feature = "postgres"))]
+pub fn superuser_required(
+    login_url: impl Into<String>,
+) -> impl tower::Layer<
+    axum::routing::Route,
+    Service = impl tower::Service<
+        Request<Body>,
+        Response = Response,
+        Error = std::convert::Infallible,
+        Future = impl Send + 'static,
+    > + Clone
+                  + Send
+                  + Sync
+                  + 'static,
+> + Clone {
+    user_passes_test(login_url, |u| u.is_superuser && u.active)
+}
+
+/// API-endpoint variant of [`superuser_required`] — returns
+/// 401 for anonymous and 403 for non-superuser, instead of
+/// redirecting.
+#[cfg(all(feature = "tenancy", feature = "postgres"))]
+pub fn superuser_required_or_403() -> impl tower::Layer<
+    axum::routing::Route,
+    Service = impl tower::Service<
+        Request<Body>,
+        Response = Response,
+        Error = std::convert::Infallible,
+        Future = impl Send + 'static,
+    > + Clone
+                  + Send
+                  + Sync
+                  + 'static,
+> + Clone {
+    user_passes_test_or_403(|u| u.is_superuser && u.active)
+}
+
 #[cfg(all(feature = "tenancy", feature = "postgres"))]
 async fn handle_login_required(
     cfg: Arc<LoginRequiredConfig>,
@@ -706,5 +757,69 @@ mod tests {
         let _ = || {
             let _layer = login_required_or_401();
         };
+    }
+
+    #[cfg(all(feature = "tenancy", feature = "postgres"))]
+    #[tokio::test]
+    async fn superuser_required_redirects_anonymous_to_login() {
+        use axum::body::Body;
+        use axum::routing::get;
+        use axum::Router;
+        use tower::ServiceExt as _;
+
+        async fn admin_only() -> &'static str {
+            "admin zone"
+        }
+
+        let app = Router::new()
+            .route("/admin/dashboard", get(admin_only))
+            .layer(superuser_required("/login"));
+
+        let res = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/admin/dashboard")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::FOUND);
+        let loc = res
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .unwrap();
+        assert_eq!(loc, "/login?next=%2Fadmin%2Fdashboard");
+    }
+
+    #[cfg(all(feature = "tenancy", feature = "postgres"))]
+    #[tokio::test]
+    async fn superuser_required_or_403_returns_401_for_anonymous() {
+        use axum::body::Body;
+        use axum::routing::get;
+        use axum::Router;
+        use tower::ServiceExt as _;
+
+        async fn admin_api() -> &'static str {
+            "ok"
+        }
+
+        let app = Router::new()
+            .route("/api/admin", get(admin_api))
+            .layer(superuser_required_or_403());
+
+        let res = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/admin")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
## Summary

Two convenience wrappers around the existing `user_passes_test` / `user_passes_test_or_403` for the very common \"is_superuser && active\" predicate. Reads tighter at call sites AND pins the \"active = false users don't count\" invariant so individual handlers don't silently diverge on that question.

- **`superuser_required(login_url)`** — page-flow variant; 302s anonymous and non-superuser to `login_url`.
- **`superuser_required_or_403()`** — API-flow variant; 401 for anonymous, 403 for non-superuser, no redirect.

```rust
let admin = Router::new()
    .route(\"/admin/dashboard\", get(dashboard))
    .layer(superuser_required(\"/login\"));

let admin_api = Router::new()
    .route(\"/api/admin/stats\", get(stats))
    .layer(superuser_required_or_403());
```

## Tests

2 new tests:
- `superuser_required` redirects anonymous to `/login?next=...`
- `superuser_required_or_403` returns 401 for anonymous

## Test plan
- [x] `cargo test --workspace --all-features --lib \"auth_decorators::tests::superuser_required\"` — 2/2 pass
- [x] `cargo test --workspace --all-features --no-run` — clean
- [x] `cargo build --no-default-features --features sqlite,tenancy` — clean
- [x] `cargo test --workspace --all-features --lib` — 2103 pass (2101 → 2103)