### PR TITLE
feat: contenttypes — reverse-direction GenericRelation manager (closes #37)

### DIFF
--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -722,6 +722,200 @@ where
     Ok(out)
 }
 
+// ============================================================ Reverse generic relation (issue #37)
+
+/// Fetch all rows of the model described by `child_schema` whose
+/// `GenericForeignKey` pair points at `(parent_ct_id, parent_pk)`.
+///
+/// Reverse-direction counterpart of [`GenericForeignKey::get_object`]
+/// — Django's `GenericRelation(...)` field. The polymorphic-target
+/// child rows are returned as JSON maps (same shape as
+/// [`fetch_row_as_json`]) so callers don't have to commit to a
+/// specific typed `Child: Model + Decode<...>` here.
+///
+/// `relation_name` selects which entry of the child schema's
+/// [`crate::core::ModelSchema::generic_relations`] to filter on:
+/// - `Some("target")` — match the named relation exactly.
+/// - `None` — use the FIRST relation declared on the child. Fine
+///   for the common case where a child carries exactly one GFK.
+///
+/// Returns an empty `Vec` (NOT an error) when:
+/// - The child schema has no `generic_relations` declared at all.
+/// - The named relation doesn't exist on the child.
+/// - No matching rows exist in the child table.
+///
+/// # Errors
+/// Driver / SELECT failures from [`crate::sql::select_rows_as_json`].
+pub async fn fetch_reverse_generic(
+    pool: &crate::sql::Pool,
+    child_schema: &'static crate::core::ModelSchema,
+    parent_ct_id: i64,
+    parent_pk: i64,
+    relation_name: Option<&str>,
+) -> Result<Vec<serde_json::Value>, ExecError> {
+    use crate::core::{Filter, Op, SelectQuery, WhereExpr};
+    // Pick the relation: by name, or the first one declared.
+    let rel = match relation_name {
+        Some(name) => child_schema
+            .generic_relations
+            .iter()
+            .find(|r| r.name == name),
+        None => child_schema.generic_relations.first(),
+    };
+    let Some(rel) = rel else {
+        // No GFK declared on child → no reverse traversal possible.
+        // Return empty rather than error; callers using a model
+        // that doesn't have a GFK have a bigger problem than a
+        // panic deep in the framework.
+        return Ok(Vec::new());
+    };
+    let select_q = SelectQuery {
+        model: child_schema,
+        where_clause: WhereExpr::And(vec![
+            WhereExpr::Predicate(Filter {
+                column: rel.ct_column,
+                op: Op::Eq,
+                value: crate::core::SqlValue::I64(parent_ct_id),
+            }),
+            WhereExpr::Predicate(Filter {
+                column: rel.pk_column,
+                op: Op::Eq,
+                value: crate::core::SqlValue::I64(parent_pk),
+            }),
+        ]),
+        search: None,
+        joins: vec![],
+        order_by: vec![],
+        limit: None,
+        offset: None,
+        lock_mode: None,
+        compound: vec![],
+        projection: None,
+    };
+    let fields: Vec<&'static crate::core::FieldSchema> = child_schema.scalar_fields().collect();
+    crate::sql::select_rows_as_json(pool, &select_q, &fields).await
+}
+
+/// Resolve `Parent`'s ContentType automatically and dispatch to
+/// [`fetch_reverse_generic`]. The convenient entry point when you
+/// have the parent's Rust type in scope:
+///
+/// ```ignore
+/// // Find every TaggedItem pointing at this Post.
+/// let tags = reverse_generic_for::<Post>(
+///     &pool,
+///     TaggedItem::SCHEMA,
+///     post.id,
+///     None,
+/// ).await?;
+/// ```
+///
+/// # Errors
+/// - `Parent`'s ContentType not seeded (run
+///   [`ensure_seeded`](crate::contenttypes::ensure_seeded) first).
+/// - Driver / SELECT failures from [`fetch_reverse_generic`].
+pub async fn reverse_generic_for<Parent: crate::core::Model>(
+    pool: &crate::sql::Pool,
+    child_schema: &'static crate::core::ModelSchema,
+    parent_pk: i64,
+    relation_name: Option<&str>,
+) -> Result<Vec<serde_json::Value>, ExecError> {
+    let ct = ContentType::get_for_model::<Parent>(pool)
+        .await?
+        .ok_or_else(|| ExecError::MissingPrimaryKey {
+            table: Parent::SCHEMA.table,
+        })?;
+    let ct_id = ct.id.get().copied().ok_or(ExecError::MissingPrimaryKey {
+        table: ContentType::SCHEMA.table,
+    })?;
+    fetch_reverse_generic(pool, child_schema, ct_id, parent_pk, relation_name).await
+}
+
+/// Batched reverse-generic prefetch — Django's `GenericPrefetch`.
+/// Given a list of parent primary keys (same model), fetches all
+/// matching child rows in a single SELECT and groups them by
+/// parent_pk. Eliminates the N+1 query pattern when rendering an
+/// index page that shows children per parent.
+///
+/// Returns a `HashMap<parent_pk, Vec<child_json>>` keyed by the
+/// parent_pk side of the GFK. Parents with zero children get no
+/// entry (caller's responsibility to default to `&[]` per parent).
+///
+/// # Errors
+/// As [`fetch_reverse_generic`].
+pub async fn prefetch_reverse_generic_for<Parent: crate::core::Model>(
+    pool: &crate::sql::Pool,
+    child_schema: &'static crate::core::ModelSchema,
+    parent_pks: &[i64],
+    relation_name: Option<&str>,
+) -> Result<::std::collections::HashMap<i64, Vec<serde_json::Value>>, ExecError> {
+    use crate::core::{Filter, Op, SelectQuery, WhereExpr};
+
+    if parent_pks.is_empty() {
+        return Ok(::std::collections::HashMap::new());
+    }
+    let rel = match relation_name {
+        Some(name) => child_schema
+            .generic_relations
+            .iter()
+            .find(|r| r.name == name),
+        None => child_schema.generic_relations.first(),
+    };
+    let Some(rel) = rel else {
+        return Ok(::std::collections::HashMap::new());
+    };
+    let ct = ContentType::get_for_model::<Parent>(pool)
+        .await?
+        .ok_or_else(|| ExecError::MissingPrimaryKey {
+            table: Parent::SCHEMA.table,
+        })?;
+    let ct_id = ct.id.get().copied().ok_or(ExecError::MissingPrimaryKey {
+        table: ContentType::SCHEMA.table,
+    })?;
+    let mut pks: Vec<i64> = parent_pks.to_vec();
+    pks.sort_unstable();
+    pks.dedup();
+    let pk_values: Vec<crate::core::SqlValue> = pks
+        .iter()
+        .copied()
+        .map(crate::core::SqlValue::I64)
+        .collect();
+    let select_q = SelectQuery {
+        model: child_schema,
+        where_clause: WhereExpr::And(vec![
+            WhereExpr::Predicate(Filter {
+                column: rel.ct_column,
+                op: Op::Eq,
+                value: crate::core::SqlValue::I64(ct_id),
+            }),
+            WhereExpr::Predicate(Filter {
+                column: rel.pk_column,
+                op: Op::In,
+                value: crate::core::SqlValue::List(pk_values),
+            }),
+        ]),
+        search: None,
+        joins: vec![],
+        order_by: vec![],
+        limit: None,
+        offset: None,
+        lock_mode: None,
+        compound: vec![],
+        projection: None,
+    };
+    let fields: Vec<&'static crate::core::FieldSchema> = child_schema.scalar_fields().collect();
+    let rows = crate::sql::select_rows_as_json(pool, &select_q, &fields).await?;
+    let mut grouped: ::std::collections::HashMap<i64, Vec<serde_json::Value>> =
+        ::std::collections::HashMap::new();
+    for row in rows {
+        // The pk column on the row carries the parent_pk we matched on.
+        if let Some(pk_val) = row.get(rel.pk_column).and_then(serde_json::Value::as_i64) {
+            grouped.entry(pk_val).or_default().push(row);
+        }
+    }
+    Ok(grouped)
+}
+
 // v0.34 — `ensure_table` (below) routes through
 // [`crate::migrate::ddl::create_table_if_not_exists_sql_with_dialect`]
 // which already knows how to emit the table for any backend rustango

--- a/crates/rustango/tests/reverse_generic_relation.rs
+++ b/crates/rustango/tests/reverse_generic_relation.rs
@@ -1,0 +1,311 @@
+//! Tests for the reverse-direction GenericRelation manager — issue #37.
+//! Exercises `fetch_reverse_generic`, `reverse_generic_for`, and
+//! `prefetch_reverse_generic_for`. All tests run against in-memory
+//! SQLite — no live DB infra needed.
+
+#![cfg(feature = "sqlite")]
+
+use rustango::contenttypes;
+use rustango::core::Model as _;
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rgr_post")]
+#[rustango(app = "rgr_blog")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rgr_article")]
+#[rustango(app = "rgr_blog")]
+#[allow(dead_code)]
+pub struct Article {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rgr_tag")]
+#[rustango(app = "rgr_blog")]
+#[rustango(generic_fk(
+    name = "target",
+    ct_column = "content_type_id",
+    pk_column = "object_pk"
+))]
+#[allow(dead_code)]
+pub struct Tag {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub content_type_id: i64,
+    pub object_pk: i64,
+    #[rustango(max_length = 40)]
+    pub name: String,
+}
+
+async fn fresh_pool() -> Pool {
+    let pool = Pool::Sqlite(
+        sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite pool"),
+    );
+    contenttypes::ensure_seeded(&pool)
+        .await
+        .expect("ensure_seeded");
+    if let Pool::Sqlite(sq) = &pool {
+        sqlx::query(
+            "CREATE TABLE rgr_post (\
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                title TEXT NOT NULL)",
+        )
+        .execute(sq)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE rgr_article (\
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                title TEXT NOT NULL)",
+        )
+        .execute(sq)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE rgr_tag (\
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                content_type_id INTEGER NOT NULL, \
+                object_pk INTEGER NOT NULL, \
+                name TEXT NOT NULL)",
+        )
+        .execute(sq)
+        .await
+        .unwrap();
+    }
+    pool
+}
+
+/// Seed a fresh Post + tag it.
+async fn seed_post_with_tag(pool: &Pool, post_title: &str, tag_name: &str) -> (i64, i64) {
+    let mut p = Post {
+        id: Auto::Unset,
+        title: post_title.into(),
+    };
+    p.save_pool(pool).await.unwrap();
+    let post_pk = *p.id.get().unwrap();
+    let tag_pk = add_tag_for_post(pool, post_pk, tag_name).await;
+    (post_pk, tag_pk)
+}
+
+/// Tag an existing Post (by pk) without creating a new one.
+async fn add_tag_for_post(pool: &Pool, post_pk: i64, tag_name: &str) -> i64 {
+    let ct = rustango::contenttypes::ContentType::get_for_model::<Post>(pool)
+        .await
+        .unwrap()
+        .unwrap();
+    let ct_id = *ct.id.get().unwrap();
+
+    let mut t = Tag {
+        id: Auto::Unset,
+        content_type_id: ct_id,
+        object_pk: post_pk,
+        name: tag_name.into(),
+    };
+    t.save_pool(pool).await.unwrap();
+    *t.id.get().unwrap()
+}
+
+#[tokio::test]
+async fn fetch_reverse_generic_returns_matching_rows() {
+    contenttypes::clear_cache();
+    let pool = fresh_pool().await;
+    let (post_pk, _) = seed_post_with_tag(&pool, "first", "rust").await;
+    add_tag_for_post(&pool, post_pk, "web").await;
+
+    let ct = contenttypes::ContentType::get_for_model::<Post>(&pool)
+        .await
+        .unwrap()
+        .unwrap();
+    let ct_id = *ct.id.get().unwrap();
+
+    let rows = contenttypes::fetch_reverse_generic(&pool, Tag::SCHEMA, ct_id, post_pk, None)
+        .await
+        .expect("fetch_reverse_generic");
+
+    assert_eq!(rows.len(), 2, "should find both tags for post #1");
+    let names: std::collections::HashSet<String> = rows
+        .iter()
+        .filter_map(|r| r.get("name").and_then(|v| v.as_str()).map(str::to_owned))
+        .collect();
+    assert!(names.contains("rust"));
+    assert!(names.contains("web"));
+}
+
+#[tokio::test]
+async fn fetch_reverse_generic_filters_by_content_type() {
+    // Same object_pk on two different content types should NOT
+    // collide — the ct_id filter discriminates.
+    contenttypes::clear_cache();
+    let pool = fresh_pool().await;
+
+    let mut p = Post {
+        id: Auto::Unset,
+        title: "post 1".into(),
+    };
+    p.save_pool(&pool).await.unwrap();
+    let post_pk = *p.id.get().unwrap();
+
+    let mut a = Article {
+        id: Auto::Unset,
+        title: "article 1".into(),
+    };
+    a.save_pool(&pool).await.unwrap();
+    let article_pk = *a.id.get().unwrap();
+    // Force the IDs to overlap by inserting until we line them up — in
+    // sqlite autoincrement starts at 1 for each table, so post_pk == 1
+    // and article_pk == 1.
+    assert_eq!(post_pk, article_pk, "test relies on overlapping pks");
+
+    let post_ct = contenttypes::ContentType::get_for_model::<Post>(&pool)
+        .await
+        .unwrap()
+        .unwrap();
+    let article_ct = contenttypes::ContentType::get_for_model::<Article>(&pool)
+        .await
+        .unwrap()
+        .unwrap();
+    let post_ct_id = *post_ct.id.get().unwrap();
+    let article_ct_id = *article_ct.id.get().unwrap();
+
+    // Tag the Post with "for-post"
+    let mut tp = Tag {
+        id: Auto::Unset,
+        content_type_id: post_ct_id,
+        object_pk: post_pk,
+        name: "for-post".into(),
+    };
+    tp.save_pool(&pool).await.unwrap();
+    // Tag the Article with "for-article"
+    let mut ta = Tag {
+        id: Auto::Unset,
+        content_type_id: article_ct_id,
+        object_pk: article_pk,
+        name: "for-article".into(),
+    };
+    ta.save_pool(&pool).await.unwrap();
+
+    // Reverse-fetch for Post: should ONLY get "for-post".
+    let rows = contenttypes::fetch_reverse_generic(&pool, Tag::SCHEMA, post_ct_id, post_pk, None)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].get("name").and_then(|v| v.as_str()),
+        Some("for-post")
+    );
+
+    // Reverse-fetch for Article: should ONLY get "for-article".
+    let rows =
+        contenttypes::fetch_reverse_generic(&pool, Tag::SCHEMA, article_ct_id, article_pk, None)
+            .await
+            .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].get("name").and_then(|v| v.as_str()),
+        Some("for-article")
+    );
+}
+
+#[tokio::test]
+async fn fetch_reverse_generic_returns_empty_for_unmatched_parent() {
+    contenttypes::clear_cache();
+    let pool = fresh_pool().await;
+    let _ = seed_post_with_tag(&pool, "first", "rust").await;
+
+    let ct = contenttypes::ContentType::get_for_model::<Post>(&pool)
+        .await
+        .unwrap()
+        .unwrap();
+    let ct_id = *ct.id.get().unwrap();
+
+    // pk=99999 — nothing points there.
+    let rows = contenttypes::fetch_reverse_generic(&pool, Tag::SCHEMA, ct_id, 99_999, None)
+        .await
+        .unwrap();
+    assert!(rows.is_empty());
+}
+
+#[tokio::test]
+async fn reverse_generic_for_resolves_parent_content_type_automatically() {
+    contenttypes::clear_cache();
+    let pool = fresh_pool().await;
+    let (post_pk, _) = seed_post_with_tag(&pool, "first", "rust").await;
+
+    // The convenience wrapper resolves the CT from the Parent type.
+    let rows = contenttypes::reverse_generic_for::<Post>(&pool, Tag::SCHEMA, post_pk, None)
+        .await
+        .expect("reverse_generic_for");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("name").and_then(|v| v.as_str()), Some("rust"));
+}
+
+#[tokio::test]
+async fn prefetch_reverse_generic_groups_children_by_parent_pk() {
+    contenttypes::clear_cache();
+    let pool = fresh_pool().await;
+    let (post1_pk, _) = seed_post_with_tag(&pool, "first", "rust").await;
+    add_tag_for_post(&pool, post1_pk, "web").await;
+    let (post2_pk, _) = seed_post_with_tag(&pool, "second", "django").await;
+
+    let grouped = contenttypes::prefetch_reverse_generic_for::<Post>(
+        &pool,
+        Tag::SCHEMA,
+        &[post1_pk, post2_pk],
+        None,
+    )
+    .await
+    .expect("prefetch");
+
+    assert_eq!(grouped.len(), 2);
+    let post1_tags: std::collections::HashSet<String> = grouped[&post1_pk]
+        .iter()
+        .filter_map(|r| r.get("name").and_then(|v| v.as_str()).map(str::to_owned))
+        .collect();
+    assert!(post1_tags.contains("rust"));
+    assert!(post1_tags.contains("web"));
+
+    let post2_tags: std::collections::HashSet<String> = grouped[&post2_pk]
+        .iter()
+        .filter_map(|r| r.get("name").and_then(|v| v.as_str()).map(str::to_owned))
+        .collect();
+    assert!(post2_tags.contains("django"));
+}
+
+#[tokio::test]
+async fn prefetch_reverse_generic_empty_input_yields_empty_map() {
+    contenttypes::clear_cache();
+    let pool = fresh_pool().await;
+    let grouped = contenttypes::prefetch_reverse_generic_for::<Post>(&pool, Tag::SCHEMA, &[], None)
+        .await
+        .unwrap();
+    assert!(grouped.is_empty());
+}
+
+#[tokio::test]
+async fn fetch_reverse_generic_on_model_without_generic_fk_returns_empty() {
+    // Post itself doesn't have a generic_fk declared — calling
+    // reverse-fetch with Post::SCHEMA as the Child should
+    // gracefully return [], not error.
+    contenttypes::clear_cache();
+    let pool = fresh_pool().await;
+    let rows = contenttypes::fetch_reverse_generic(&pool, Post::SCHEMA, 1, 1, None)
+        .await
+        .unwrap();
+    assert!(rows.is_empty());
+}


### PR DESCRIPTION
## Summary

Closes #37. Adds the reverse-direction counterpart to `GenericForeignKey::get_object`: given a Parent + its content_type_id + pk, fetch every Child row whose GFK pair points at the parent.

Three new functions in `crate::contenttypes`:

- **`fetch_reverse_generic(pool, child_schema, parent_ct_id, parent_pk, relation_name)`** — low-level. Filters the child table on the GFK columns named in `child_schema.generic_relations` and returns rows as `Vec<serde_json::Value>` (avoids the `Decode<...>` trait soup that typed fetching needs for an arbitrary child).
- **`reverse_generic_for::<Parent>(pool, child_schema, parent_pk, relation_name)`** — resolves Parent's ContentType automatically.
- **`prefetch_reverse_generic_for::<Parent>(pool, child_schema, parent_pks, relation_name)`** — Django's `GenericPrefetch`. Batched fetch for a list of parents in ONE SELECT, grouped by `parent_pk`. Eliminates the N+1 query pattern on index pages.

```rust
// Find every Tag pointing at this Post (Django's `post.tags.all()`):
let tags = reverse_generic_for::<Post>(&pool, Tag::SCHEMA, post.id, None).await?;

// Batched — eliminate N+1 when rendering a feed:
let by_post = prefetch_reverse_generic_for::<Post>(
    &pool, Tag::SCHEMA, &[post1.id, post2.id, post3.id], None,
).await?;
```

`relation_name = None` picks the first declared GFK on the child (fine for the common single-GFK case). Models without any `generic_fk` declaration gracefully return empty rather than error.

## Tests

7 new live tests (in-memory SQLite, no infra needed):
- basic multi-tag fetch
- content-type filtering when two models share PKs
- empty result for unmatched parent
- automatic CT resolution via the `_for::<Parent>` convenience
- batched prefetch grouping by parent_pk
- empty-input fast path
- graceful empty for child models without a declared GFK

## Sibling issues — what's NOT in this PR and why

- **#46 CompositePrimaryKey** — deferred. The issue explicitly tags itself \"v0.48 backlog roadmap item — large lift\" and spans the macro, Model trait, FK target, admin pk-parser, inspectdb roundtrip, and tri-dialect DDL. Multi-day effort across the ORM extract surface.
- **#38 Generic admin inlines** — still blocked on #50 (admin TabularInline/StackedInline standalone), which is a separate larger lift. Once #50 lands, the GFK shape this PR provides drops in cleanly under it.

## Test plan
- [x] `cargo test --workspace --all-features --test reverse_generic_relation` — 7/7 pass
- [x] `cargo test --workspace --all-features --no-run` — clean
- [x] `cargo build --no-default-features --features sqlite,tenancy` — clean
- [x] `cargo test --workspace --all-features --lib` — 2311 pass