### PR TITLE
feat: inheritance module — Meta.abstract / multi-table / proxy mapped to Rust (closes #51)

### DIFF
--- a/crates/rustango/src/inheritance.rs
+++ b/crates/rustango/src/inheritance.rs
@@ -1,0 +1,143 @@
+//! Model-inheritance patterns — Django's `Meta.abstract`, multi-table,
+//! and proxy shapes adapted to Rust. Issue #51.
+//!
+//! Django ships three flavors of model inheritance:
+//!
+//! 1. **Abstract base classes** (`Meta.abstract = True`) — share
+//!    fields + methods across child models. The base has no DB
+//!    table; every child gets its own table with the base's fields
+//!    physically copied in.
+//! 2. **Multi-table inheritance** — child gets its OWN table with an
+//!    implicit `OneToOne` FK back to the parent. Queries against the
+//!    child JOIN to the parent.
+//! 3. **Proxy models** (`Meta.proxy = True`) — same table as the
+//!    parent, but a different Manager / Meta / methods.
+//!
+//! ## Rust mappings
+//!
+//! Rust doesn't have class inheritance, but every Django use case
+//! for model inheritance has a clean Rust-idiomatic counterpart
+//! that the framework already supports today:
+//!
+//! ### 1. Abstract base classes → traits + composition
+//!
+//! Django's abstract base is about sharing *behavior* (methods)
+//! and *fields* (schema). In Rust:
+//!
+//! - **Share behavior**: define a trait with the shared methods,
+//!   `impl` it on each model.
+//! - **Share fields**: not natively possible without a proc-macro.
+//!   The pragmatic shape is to either (a) `derive` a helper proc-macro
+//!   per shared block, or (b) accept the duplication on the field
+//!   declarations and share the BEHAVIOR via trait.
+//!
+//! ```ignore
+//! use chrono::{DateTime, Utc};
+//!
+//! /// Shared "timestamps" behavior. Implemented on every model that
+//! /// wants the `created_at` / `updated_at` audit pair.
+//! pub trait Timestamped {
+//!     fn created_at(&self) -> DateTime<Utc>;
+//!     fn updated_at(&self) -> DateTime<Utc>;
+//! }
+//!
+//! #[derive(rustango::Model)]
+//! pub struct Article {
+//!     #[rustango(primary_key)]
+//!     pub id: rustango::core::Auto<i64>,
+//!     #[rustango(max_length = 200)]
+//!     pub title: String,
+//!     pub created_at: DateTime<Utc>,
+//!     pub updated_at: DateTime<Utc>,
+//! }
+//!
+//! impl Timestamped for Article {
+//!     fn created_at(&self) -> DateTime<Utc> { self.created_at }
+//!     fn updated_at(&self) -> DateTime<Utc> { self.updated_at }
+//! }
+//! ```
+//!
+//! The field declarations live on each model (Rust requirement),
+//! but every shared helper / query method that takes `<T: Timestamped>`
+//! works polymorphically — same dispatch shape Django gets from the
+//! abstract base class.
+//!
+//! ### 2. Multi-table inheritance → explicit OneToOne FK
+//!
+//! Already supported. `#[rustango(o2o = "ParentTable", on = "parent_id")]`
+//! declares an implicit-OneToOne FK to the parent table:
+//!
+//! ```ignore
+//! #[derive(rustango::Model)]
+//! #[rustango(table = "place")]
+//! pub struct Place {
+//!     #[rustango(primary_key)]
+//!     pub id: rustango::core::Auto<i64>,
+//!     #[rustango(max_length = 200)]
+//!     pub name: String,
+//!     #[rustango(max_length = 200)]
+//!     pub address: String,
+//! }
+//!
+//! #[derive(rustango::Model)]
+//! #[rustango(table = "restaurant")]
+//! pub struct Restaurant {
+//!     /// One-to-one back to Place — semantically "Restaurant IS-A Place".
+//!     #[rustango(primary_key)]
+//!     #[rustango(o2o = "place", on = "id")]
+//!     pub place_id: i64,
+//!     pub serves_hot_dogs: bool,
+//! }
+//! ```
+//!
+//! Django's `Restaurant.objects.all()` returns rows with both place
+//! and restaurant fields joined; in rustango the equivalent is
+//! `Restaurant::objects().select_related("place_id")` (or fetch
+//! the parent rows separately via `place_ids = restaurants.iter().map(|r| r.place_id)`).
+//!
+//! ### 3. Proxy models → extension trait
+//!
+//! Django's proxy is "different Manager / Meta on the same table."
+//! The Rust shape is an extension trait on `QuerySet<T>` that adds
+//! domain-specific shortcuts — fully documented in the
+//! [`crate::manager`] module. Same physical table, multiple
+//! "personalities."
+//!
+//! ```ignore
+//! pub trait PublishedArticleExt: Sized {
+//!     fn only_published(self) -> Self;
+//! }
+//! impl PublishedArticleExt for rustango::query::QuerySet<Article> {
+//!     fn only_published(self) -> Self {
+//!         use rustango::core::Column as _;
+//!         self.where_(Article::published.eq(true))
+//!     }
+//! }
+//!
+//! // Acts as a "PublishedArticle" proxy:
+//! Article::objects().only_published().fetch_pool(&pool).await?;
+//! ```
+//!
+//! ## Summary table
+//!
+//! | Django shape | Rust idiom | Framework support |
+//! |--------------|-----------|-------------------|
+//! | Abstract base class | trait + per-model field declarations | trait dispatch (Rust built-in) |
+//! | Multi-table inheritance | explicit `#[rustango(o2o)]` FK | shipped |
+//! | Proxy model | extension trait on `QuerySet<T>` | see [`crate::manager`] |
+//!
+//! ## Why no `#[rustango(abstract)]` proc-macro attribute?
+//!
+//! True field-inlining (parent fields physically copied into child
+//! at macro time) would need the `Model` derive to consult a
+//! parent struct's field list. Doable but a substantial
+//! proc-macro lift, and the trait-based "share behavior" approach
+//! is strictly more flexible — multiple traits can layer onto
+//! one struct, where a single abstract parent can't.
+//!
+//! File a follow-up if your project repeatedly hand-copies the
+//! same 5+ fields across N models — at that point a proc-macro
+//! pays for itself.
+
+// Doc-only module; the patterns this documents are exercised in
+// `tests/inheritance_patterns.rs`.

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -865,6 +865,11 @@ pub mod validators;
 /// the canonical worked examples. Issue #52.
 pub mod manager;
 
+/// Model-inheritance patterns — Django's `Meta.abstract`,
+/// multi-table, and proxy shapes adapted to Rust idioms. See
+/// [`inheritance`] for the canonical worked mappings. Issue #51.
+pub mod inheritance;
+
 /// Named URL reversal — Django's `reverse(name, params)` +
 /// `get_absolute_url()`. Pair with [`register_url!`]. Issue #8.
 pub mod urls;

--- a/crates/rustango/tests/inheritance_patterns.rs
+++ b/crates/rustango/tests/inheritance_patterns.rs
@@ -1,0 +1,189 @@
+//! Compile + type-check coverage for the three Django model-inheritance
+//! shapes adapted to Rust idioms (Issue #51). Lives alongside the
+//! `inheritance` module's rustdoc — proves the patterns compile
+//! end-to-end against real `#[derive(Model)]` types.
+//!
+//! No live DB required — all assertions are about Rust-side
+//! type / method resolution.
+
+#![cfg(feature = "postgres")]
+
+use chrono::{DateTime, Utc};
+use rustango::core::Column as _;
+use rustango::query::QuerySet;
+use rustango::sql::Auto;
+use rustango::Model;
+
+// ============================================================
+// SHAPE 1 — Abstract base class → shared TRAIT + per-model fields
+// ============================================================
+
+/// Django's "Timestamped" abstract base: every child gets
+/// `created_at` / `updated_at`. In Rust we declare the BEHAVIOR
+/// as a trait; field declarations live on each model.
+pub trait Timestamped {
+    fn created_at(&self) -> DateTime<Utc>;
+    fn updated_at(&self) -> DateTime<Utc>;
+}
+
+#[derive(Model, Debug)]
+#[rustango(table = "inh_article")]
+#[allow(dead_code)]
+pub struct Article {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Timestamped for Article {
+    fn created_at(&self) -> DateTime<Utc> {
+        self.created_at
+    }
+    fn updated_at(&self) -> DateTime<Utc> {
+        self.updated_at
+    }
+}
+
+#[derive(Model, Debug)]
+#[rustango(table = "inh_comment")]
+#[allow(dead_code)]
+pub struct Comment {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub article_id: i64,
+    #[rustango(max_length = 500)]
+    pub body: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Timestamped for Comment {
+    fn created_at(&self) -> DateTime<Utc> {
+        self.created_at
+    }
+    fn updated_at(&self) -> DateTime<Utc> {
+        self.updated_at
+    }
+}
+
+/// Generic helper that operates on any `Timestamped` model. This
+/// is the Rust equivalent of methods Django would put on the
+/// abstract base class — write once, reuse across every child.
+fn age_in_seconds<T: Timestamped>(item: &T, now: DateTime<Utc>) -> i64 {
+    now.signed_duration_since(item.created_at()).num_seconds()
+}
+
+#[test]
+fn abstract_base_via_trait_dispatches_across_child_models() {
+    // Both Article and Comment share the `Timestamped` behavior
+    // via trait dispatch — same shape Django's abstract base
+    // class gives via Python inheritance.
+    let t = "2026-01-15T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+    let a = Article {
+        id: Auto::Set(1),
+        title: "Hello".into(),
+        created_at: t,
+        updated_at: t,
+    };
+    let c = Comment {
+        id: Auto::Set(1),
+        article_id: 1,
+        body: "Nice post".into(),
+        created_at: t,
+        updated_at: t,
+    };
+    let now = "2026-01-15T12:01:00Z".parse::<DateTime<Utc>>().unwrap();
+    assert_eq!(age_in_seconds(&a, now), 60);
+    assert_eq!(age_in_seconds(&c, now), 60);
+}
+
+// ============================================================
+// SHAPE 2 — Multi-table inheritance → explicit OneToOne FK
+// ============================================================
+
+/// "Place IS-A entity with a name + address." Django would put
+/// this in the base; in rustango it's just a regular Model with
+/// its own table.
+#[derive(Model, Debug)]
+#[rustango(table = "inh_place")]
+#[allow(dead_code)]
+pub struct Place {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub name: String,
+    #[rustango(max_length = 200)]
+    pub address: String,
+}
+
+/// "Restaurant IS-A Place." The OneToOne FK to Place gives
+/// Django's multi-table inheritance shape — Restaurant has its
+/// own table, but every Restaurant row corresponds to exactly one
+/// Place row.
+#[derive(Model, Debug)]
+#[rustango(table = "inh_restaurant")]
+#[allow(dead_code)]
+pub struct Restaurant {
+    /// FK back to Place — the implicit OneToOne Django wires for you.
+    #[rustango(primary_key)]
+    #[rustango(o2o = "inh_place", on = "id")]
+    pub place_id: i64,
+    pub serves_hot_dogs: bool,
+}
+
+#[test]
+fn multi_table_inheritance_via_one_to_one_fk_compiles() {
+    // Type-check: the relation is wired correctly through the
+    // schema. The behavior pin lives in the OneToOne tests
+    // elsewhere — here we just confirm the inheritance shape
+    // compiles against `#[derive(Model)]`.
+    let _r = Restaurant {
+        place_id: 7,
+        serves_hot_dogs: true,
+    };
+    // Both QuerySets are usable independently — same dispatch
+    // shape Django gives via `Restaurant.objects.all()` / `place.restaurant`.
+    let _: QuerySet<Restaurant> = Restaurant::objects();
+    let _: QuerySet<Place> = Place::objects();
+}
+
+// ============================================================
+// SHAPE 3 — Proxy model → extension trait on QuerySet<T>
+// ============================================================
+
+#[derive(Model, Debug)]
+#[rustango(table = "inh_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub published: bool,
+}
+
+/// Proxy-style "view" — different Manager personality on the same
+/// table. Django writes `class PublishedPost(Post): Meta.proxy = True`;
+/// in Rust it's an extension trait on `QuerySet<Post>`.
+trait PublishedPostExt: Sized {
+    fn only_published(self) -> Self;
+}
+
+impl PublishedPostExt for QuerySet<Post> {
+    fn only_published(self) -> Self {
+        self.where_(Post::published.eq(true))
+    }
+}
+
+#[test]
+fn proxy_model_via_extension_trait_chains_with_framework_methods() {
+    // Pin: a "proxy-style" extension method composes with the
+    // framework's built-in QuerySet methods — same chain Django
+    // gets from `PublishedPost.objects.all()`.
+    let _chain: QuerySet<Post> = Post::objects()
+        .only_published() // proxy-style
+        .limit(20); // framework
+}


### PR DESCRIPTION
## Summary

Closes #51. Doc-only `inheritance` module + `tests/inheritance_patterns.rs` worked-example pin covering all three Django model-inheritance shapes via existing Rust idioms — no new framework surface, just the canonical mappings.

| Django shape | Rust idiom | Status |
|---|---|---|
| Abstract base class | trait + per-model field declarations | trait dispatch (built-in) |
| Multi-table inheritance | `#[rustango(o2o = "...", on = "...")]` PK FK | already shipped |
| Proxy model | extension trait on `QuerySet<T>` | see [`crate::manager`] |

### Worked examples (all compile against `#[derive(Model)]`)

- **Abstract base** → `Timestamped` trait implemented on `Article` + `Comment`; generic helper `age_in_seconds<T: Timestamped>` dispatches across both child models.
- **Multi-table** → `Restaurant.place_id` carries `#[rustango(primary_key)]` + `#[rustango(o2o = "inh_place", on = "id")]` — exactly the shape Django's hidden OneToOne creates.
- **Proxy** → `PublishedPostExt::only_published` extension trait on `QuerySet<Post>` chains with the framework's `.limit(20)`.

### Why no `#[rustango(abstract)]` proc-macro attribute?

Documented in `inheritance.rs` rustdoc: trait-based \"share behavior\" composes more flexibly than a single abstract parent ever could — multiple traits can layer onto one struct. A field-inlining macro is a substantial proc-macro lift; the doc invites a follow-up if a project hand-copies 5+ fields across N models.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo build --no-default-features --features sqlite,tenancy` (sqlite-tenancy litmus)
- [x] `cargo test --workspace --all-features --test inheritance_patterns` (3/3 pass)
- [x] `cargo test --workspace --all-features --no-run` (full compile gate)
- [x] `cargo test --workspace --all-features --lib` (2327 pass)
- [x] pre-push hook (lib tests + clippy)