### PR TITLE
feat: composite_pk module — Django 5.2 CompositePrimaryKey via Auto<i64>+unique_together (closes #46)

### DIFF
--- a/crates/rustango/src/composite_pk.rs
+++ b/crates/rustango/src/composite_pk.rs
@@ -1,0 +1,132 @@
+//! Composite-primary-key patterns — Django 5.2's `CompositePrimaryKey`
+//! adapted to rustango idioms. Issue #46.
+//!
+//! Django 5.2 shipped first-class composite-PK support:
+//!
+//! ```python
+//! class OrderLine(models.Model):
+//!     pk = models.CompositePrimaryKey("order_id", "line_no")
+//!     order_id = models.BigIntegerField()
+//!     line_no = models.IntegerField()
+//!     sku = models.CharField(max_length=64)
+//! ```
+//!
+//! rustango is single-`Auto<i64>`-PK only at the ORM layer today;
+//! native `#[rustango(primary_key = ("a", "b"))]` is a v0.48 large-lift
+//! item (touches `Model` trait, FK target resolution, admin pk-parser,
+//! `inspectdb`, and tri-dialect DDL emitters).
+//!
+//! **You don't have to wait for v0.48** — the canonical Django-pre-5.2
+//! pattern (which Django itself shipped for a decade before
+//! `CompositePrimaryKey` landed) maps directly to rustango today and
+//! covers every real-world composite-key use case: invoices with line
+//! numbers, tenant-scoped resources, M2M through-tables, audit logs.
+//!
+//! ## The pattern: surrogate `Auto<i64>` + `unique_together`
+//!
+//! 1. Keep an `Auto<i64>` surrogate PK on every model (what the
+//!    framework needs for `save()`, FK targets, admin row links).
+//! 2. Declare the *logical* composite uniqueness with
+//!    `#[rustango(unique_together = "a, b")]` — shipped since v0.19.
+//! 3. Look rows up by the composite via a `.where_(a.eq).where_(b.eq)`
+//!    chain — the underlying UNIQUE INDEX makes it index-equivalent to
+//!    a primary-key lookup.
+//!
+//! ```ignore
+//! use rustango::sql::Auto;
+//!
+//! #[derive(rustango::Model, Debug)]
+//! #[rustango(table = "order_line")]
+//! #[rustango(unique_together = "order_id, line_no")]
+//! pub struct OrderLine {
+//!     #[rustango(primary_key)]
+//!     pub id: Auto<i64>,
+//!     pub order_id: i64,
+//!     pub line_no: i32,
+//!     #[rustango(max_length = 64)]
+//!     pub sku: String,
+//! }
+//! ```
+//!
+//! The schema this produces is *identical* in shape to a real
+//! composite PK except for the extra `id BIGINT` column — a `UNIQUE`
+//! index on `(order_id, line_no)` enforces the same invariant the
+//! composite PK would.
+//!
+//! ## Tenant-scoped composite keys
+//!
+//! The single most common composite-PK shape — "this row is unique
+//! *within this tenant*" — fits the pattern exactly:
+//!
+//! ```ignore
+//! #[derive(rustango::Model, Debug)]
+//! #[rustango(table = "invoice")]
+//! #[rustango(unique_together = "tenant_id, invoice_number")]
+//! pub struct Invoice {
+//!     #[rustango(primary_key)]
+//!     pub id: Auto<i64>,
+//!     pub tenant_id: i64,
+//!     #[rustango(max_length = 32)]
+//!     pub invoice_number: String,
+//!     #[rustango(max_length = 200)]
+//!     pub customer: String,
+//! }
+//! ```
+//!
+//! Two different tenants can each have `invoice_number = "INV-0001"`,
+//! same as Django's `CompositePrimaryKey("tenant_id", "invoice_number")`
+//! would allow.
+//!
+//! ## Looking up by the composite key
+//!
+//! The query the framework would auto-generate for a `CompositePrimaryKey`
+//! lookup is exactly what you write today:
+//!
+//! ```ignore
+//! use rustango::core::Column as _;
+//! use rustango::query::QuerySet;
+//!
+//! let line = Invoice::objects()
+//!     .where_(Invoice::tenant_id.eq(7))
+//!     .where_(Invoice::invoice_number.eq("INV-0001"))
+//!     .first_pool(&pool)
+//!     .await?;
+//! ```
+//!
+//! Because the `(tenant_id, invoice_number)` UNIQUE INDEX is present,
+//! Postgres / MySQL / SQLite all serve this as a single index seek —
+//! same physical access path as a true composite PK.
+//!
+//! ## When to wait for v0.48 native support
+//!
+//! Three cases the surrogate-id workaround doesn't fully cover:
+//!
+//! 1. **Composite FK targets.** If a downstream model needs an FK
+//!    *whose target is the composite*, you have to choose one column
+//!    as the FK column today (or carry both columns + a denormalized
+//!    `parent_id` surrogate). Native composite PK lets you reference
+//!    `(order_id, line_no)` as a real FK pair.
+//! 2. **`inspectdb` round-trip against legacy composite-PK tables.**
+//!    rustango will emit a warning and pick one column; you have to
+//!    add the surrogate column by hand to the generated struct.
+//! 3. **Strict Django parity in ORM lookups.** Django auto-builds the
+//!    composite WHERE on `.get(pk=(7, "INV-0001"))`. You write the two
+//!    `.filter()` calls instead — same SQL, three more keystrokes.
+//!
+//! When any of these blocks you, file a `+1` on issue #46 — the
+//! priority list is driven by demand.
+//!
+//! ## Summary
+//!
+//! | Django shape | rustango idiom | Status |
+//! |---|---|---|
+//! | `CompositePrimaryKey("a", "b")` | `Auto<i64>` + `unique_together = "a, b"` | shipped (v0.19) |
+//! | `.get(pk=(7, "x"))` | `.where_(a.eq(7)).where_(b.eq("x"))` | shipped |
+//! | composite FK target | denormalized parent surrogate column | v0.48 native |
+//! | `inspectdb` composite round-trip | manual surrogate-column add | v0.48 native |
+//!
+//! See `tests/composite_pk_pattern.rs` for compile + behavior pins
+//! against real `#[derive(Model)]` types.
+
+// Doc-only module; the pattern this documents is exercised in
+// `tests/composite_pk_pattern.rs`.

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -870,6 +870,11 @@ pub mod manager;
 /// [`inheritance`] for the canonical worked mappings. Issue #51.
 pub mod inheritance;
 
+/// Composite-primary-key patterns — Django 5.2's `CompositePrimaryKey`
+/// mapped to `Auto<i64>` surrogate + `unique_together`. See
+/// [`composite_pk`] for the canonical worked pattern. Issue #46.
+pub mod composite_pk;
+
 /// Named URL reversal — Django's `reverse(name, params)` +
 /// `get_absolute_url()`. Pair with [`register_url!`]. Issue #8.
 pub mod urls;

--- a/crates/rustango/tests/composite_pk_pattern.rs
+++ b/crates/rustango/tests/composite_pk_pattern.rs
@@ -1,0 +1,133 @@
+//! Compile + type-check coverage for the composite-primary-key
+//! pattern documented in `crate::composite_pk` (Issue #46).
+//!
+//! Pins:
+//! 1. `#[rustango(unique_together = "...")]` accepts the composite
+//!    column tuple and propagates into [`ModelSchema::indexes`] as a
+//!    UNIQUE btree index.
+//! 2. The `.where_(a.eq).where_(b.eq)` lookup chain type-checks
+//!    against a real `#[derive(Model)]` type — the SQL it emits is
+//!    the same composite-key seek Django's native
+//!    `CompositePrimaryKey` lookup would generate.
+//!
+//! No live DB required — all assertions are Rust-side.
+
+#![cfg(feature = "postgres")]
+
+use rustango::core::{Column as _, Model as _, ModelSchema};
+use rustango::query::QuerySet;
+use rustango::sql::Auto;
+use rustango::Model;
+
+// ============================================================
+// Canonical shape: tenant-scoped invoice (the textbook
+// composite-PK use case — invoice numbers unique per tenant).
+// ============================================================
+
+#[derive(Model, Debug)]
+#[rustango(table = "cpk_invoice")]
+#[rustango(unique_together = "tenant_id, invoice_number")]
+#[allow(dead_code)]
+pub struct Invoice {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub tenant_id: i64,
+    #[rustango(max_length = 32)]
+    pub invoice_number: String,
+    #[rustango(max_length = 200)]
+    pub customer: String,
+}
+
+// ============================================================
+// Three-column variant: line items inside an invoice
+// (tenant_id, invoice_id, line_no all together).
+// ============================================================
+
+#[derive(Model, Debug)]
+#[rustango(table = "cpk_invoice_line")]
+#[rustango(unique_together = "tenant_id, invoice_id, line_no")]
+#[allow(dead_code)]
+pub struct InvoiceLine {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub tenant_id: i64,
+    pub invoice_id: i64,
+    pub line_no: i32,
+    #[rustango(max_length = 64)]
+    pub sku: String,
+}
+
+// ============================================================
+
+#[test]
+fn unique_together_propagates_into_schema_as_composite_unique_index() {
+    // Pin: the macro registers an `IndexSchema { unique: true,
+    // columns: &[...] }` on the schema — this is the row Django's
+    // `CompositePrimaryKey` would create implicitly, and the row the
+    // DDL emitter turns into `CREATE UNIQUE INDEX ... (tenant_id,
+    // invoice_number)`.
+    let schema: &ModelSchema = Invoice::SCHEMA;
+    let composite_uniques: Vec<_> = schema
+        .indexes
+        .iter()
+        .filter(|i| i.unique && i.columns.len() >= 2)
+        .collect();
+    assert!(
+        !composite_uniques.is_empty(),
+        "Invoice::SCHEMA should carry at least one composite UNIQUE index"
+    );
+    let cols: Vec<&str> = composite_uniques[0].columns.iter().copied().collect();
+    assert_eq!(cols, vec!["tenant_id", "invoice_number"]);
+}
+
+#[test]
+fn three_column_unique_together_round_trips() {
+    let schema: &ModelSchema = InvoiceLine::SCHEMA;
+    let three_col: Vec<_> = schema
+        .indexes
+        .iter()
+        .filter(|i| i.unique && i.columns.len() == 3)
+        .collect();
+    assert_eq!(
+        three_col.len(),
+        1,
+        "InvoiceLine should have exactly one 3-column UNIQUE index"
+    );
+    let cols: Vec<&str> = three_col[0].columns.iter().copied().collect();
+    assert_eq!(cols, vec!["tenant_id", "invoice_id", "line_no"]);
+}
+
+#[test]
+fn composite_key_lookup_chains_type_check_against_querysets() {
+    // Pin: the documented `.where_(a.eq).where_(b.eq)` chain — the
+    // direct stand-in for Django's `.get(pk=(7, "INV-0001"))` —
+    // produces a usable `QuerySet<T>` against a real Model derive.
+    let _by_composite: QuerySet<Invoice> = Invoice::objects()
+        .where_(Invoice::tenant_id.eq(7))
+        .where_(Invoice::invoice_number.eq("INV-0001"));
+
+    // And the three-column variant chains the same way.
+    let _by_three: QuerySet<InvoiceLine> = InvoiceLine::objects()
+        .where_(InvoiceLine::tenant_id.eq(7))
+        .where_(InvoiceLine::invoice_id.eq(42))
+        .where_(InvoiceLine::line_no.eq(1));
+}
+
+#[test]
+fn surrogate_id_is_still_the_framework_pk() {
+    // Pin: even though `(tenant_id, invoice_number)` is the *logical*
+    // composite key, `Auto<i64>` remains the framework PK — so admin
+    // row links, FK targets, and `save()` all keep working unchanged.
+    // The composite-PK pattern is purely additive on top of that.
+    let schema: &ModelSchema = Invoice::SCHEMA;
+    let pk_field = schema
+        .fields
+        .iter()
+        .find(|f| f.primary_key)
+        .expect("Invoice should have a primary-key field");
+    assert_eq!(pk_field.name, "id");
+    assert!(
+        pk_field.auto,
+        "the surrogate PK is the framework's Auto<i64> column"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #46. Doc-only `composite_pk` module + `tests/composite_pk_pattern.rs` worked-example pin mapping Django 5.2's `CompositePrimaryKey(\"a\", \"b\")` to the existing `Auto<i64>` surrogate + `unique_together` idiom that rustango has shipped since v0.19.

Same doc-pattern shape as #51 (inheritance) and #52 (manager): no new framework surface, no changes to the ORM-extraction lane (`core/` / `sql/` / `query/` / `migrate/`), just documents the canonical Rust idiom and pins it with worked-example tests.

### The pattern

\`\`\`rust
#[derive(Model)]
#[rustango(unique_together = \"tenant_id, invoice_number\")]
pub struct Invoice {
    #[rustango(primary_key)]
    pub id: Auto<i64>,            // surrogate keeps admin / FK / save() working
    pub tenant_id: i64,
    pub invoice_number: String,   // unique *per tenant*
    ...
}

Invoice::objects()
    .where_(Invoice::tenant_id.eq(7))
    .where_(Invoice::invoice_number.eq(\"INV-0001\"))
    .first_pool(&pool).await?;
\`\`\`

The `(tenant_id, invoice_number)` UNIQUE INDEX gives PG / MySQL / SQLite the same physical access path a real composite PK would — single index seek.

### What's pinned

- two-column `unique_together` propagates into `ModelSchema.indexes` as a UNIQUE composite index
- three-column variant round-trips identically
- `.where_(a.eq).where_(b.eq)` chain type-checks (the rustango stand-in for `.get(pk=(7, \"x\"))`)
- `Auto<i64>` remains the framework PK so existing machinery is unaffected

### What still wants v0.48 native support

The doc module is honest about three cases the workaround doesn't fully cover:
1. **Composite FK targets** — referencing `(order_id, line_no)` as a real FK pair
2. **`inspectdb` composite round-trip** — currently warns + picks one column
3. **Strict `.get(pk=tuple)` parity** — write two `.where_()` calls instead

Each is called out as a v0.48 backlog item; readers know exactly when to file a `+1`.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo build --no-default-features --features sqlite,tenancy` (sqlite-tenancy litmus)
- [x] `cargo test --workspace --all-features --test composite_pk_pattern` (4/4 pass)
- [x] `cargo test --workspace --all-features --no-run` (full compile gate)
- [x] `cargo test --workspace --all-features --lib` (2327 pass)
- [x] pre-push hook (lib tests + clippy)