### PR TITLE
feat: admin inlines — TabularInline / StackedInline read-only display (#50 slice 1)

### DIFF
--- a/crates/rustango/src/admin/inlines.rs
+++ b/crates/rustango/src/admin/inlines.rs
@@ -1,0 +1,424 @@
+//! Admin inlines — Django's `TabularInline` / `StackedInline` shape
+//! for editing a model's children inside its parent detail page.
+//! Issue #50.
+//!
+//! ## Status — slice 1 (this module)
+//!
+//! Read-only display: child rows show up at the bottom of the parent's
+//! admin detail page, grouped by inline. Each child links to its own
+//! admin row.
+//!
+//! Edit / add / delete via in-page forms (the FormSet-driven POST
+//! handler) is the next slice — the [`InlineAdmin`] struct already
+//! exposes `extra`, `max_num`, `readonly_fields` etc. so registrations
+//! written today don't need to change when the editor lands.
+//!
+//! ## Registering an inline
+//!
+//! ```ignore
+//! use rustango::register_admin_inline;
+//! use rustango::admin::inlines::InlineKind;
+//!
+//! #[derive(rustango::Model)]
+//! #[rustango(table = "blog_post")]
+//! pub struct Post { /* ... */ }
+//!
+//! #[derive(rustango::Model)]
+//! #[rustango(table = "blog_comment")]
+//! pub struct Comment {
+//!     #[rustango(fk = "blog_post", on = "id")]
+//!     pub post_id: i64,
+//!     pub body: String,
+//! }
+//!
+//! register_admin_inline!(
+//!     parent = "blog_post",       // ModelSchema::table of the parent
+//!     child  = "blog_comment",    // ModelSchema::table of the child
+//!     fk     = "post_id",         // child column that points back
+//!     kind   = InlineKind::Tabular,
+//!     label  = "Comments",
+//!     fields = &["body", "created_at"],
+//!     extra  = 0,
+//!     max_num = None,
+//!     readonly_fields = &[],
+//! );
+//! ```
+//!
+//! The parent's detail page (`/__admin/blog_post/<pk>`) will render a
+//! "Comments" panel below the parent fields, listing every
+//! `blog_comment` row whose `post_id` matches.
+//!
+//! Multiple inlines per parent are supported — each registration
+//! produces a separate panel, in registration order.
+
+use crate::core::{
+    FieldSchema, Filter, ModelEntry, ModelSchema, NullsOrder, Op, OrderItem, SelectQuery, SqlValue,
+    WhereExpr,
+};
+use crate::sql::{select_rows_as_json, ExecError, Pool};
+
+// ============================================================ InlineKind
+
+/// Render variant — Django's two built-in inline shapes.
+///
+/// * [`InlineKind::Tabular`] — one HTML `<table>` row per child,
+///   columns left-to-right (compact; ideal for short rows).
+/// * [`InlineKind::Stacked`] — one `<fieldset>` per child with each
+///   field on its own line (verbose; ideal for long/multi-line rows).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InlineKind {
+    /// Table-row layout — Django's `TabularInline`.
+    Tabular,
+    /// Block layout — Django's `StackedInline`.
+    Stacked,
+}
+
+// ============================================================ InlineAdmin
+
+/// One inline-admin registration. Inventory-collected; submit one per
+/// [`register_admin_inline!`] invocation.
+///
+/// Fields mirror Django's `InlineModelAdmin` knobs. Fields the v1
+/// read-only renderer doesn't consult yet (`extra`, `max_num`,
+/// `readonly_fields`) are wired through to the struct so call-sites
+/// don't have to change when the FormSet-backed editor lands.
+pub struct InlineAdmin {
+    /// Parent model's SQL table name — must match
+    /// [`ModelSchema::table`] exactly.
+    pub parent_table: &'static str,
+    /// Child model's SQL table name.
+    pub child_table: &'static str,
+    /// Column on the child table that points back to the parent's PK.
+    /// Must exist on the child model's schema and have an FK relation
+    /// to the parent table.
+    pub fk_column: &'static str,
+    /// Tabular or stacked render variant.
+    pub kind: InlineKind,
+    /// Panel header. Falls back to the child model's `name` when
+    /// empty.
+    pub label: &'static str,
+    /// Child fields to render, in order. Empty slice means "every
+    /// scalar field except the FK column" (mirrors Django's default).
+    pub fields: &'static [&'static str],
+    /// Number of blank rows the editor offers for creating new
+    /// children. Read-only display ignores this; the FormSet editor
+    /// will append `extra` empty rows below the existing ones.
+    pub extra: usize,
+    /// Upper bound on total inline rows (existing + new). `None` =
+    /// unlimited. Honored by the FormSet editor.
+    pub max_num: Option<usize>,
+    /// Field names rendered as plain text even in edit mode. Subset
+    /// of `fields`. Read-only display treats every field as readonly.
+    pub readonly_fields: &'static [&'static str],
+}
+
+inventory::collect!(InlineAdmin);
+
+/// Every inline registered against `parent_table`, in declaration
+/// order. Cheap — the inventory iterator is `O(N)` over all
+/// registrations but `N` is bounded by the number of admin inlines
+/// declared in the whole binary.
+#[must_use]
+pub fn for_parent_table(parent_table: &str) -> Vec<&'static InlineAdmin> {
+    inventory::iter::<InlineAdmin>
+        .into_iter()
+        .filter(|i| i.parent_table == parent_table)
+        .collect()
+}
+
+// ============================================================ Registration macro
+
+/// Register an admin inline. The `parent` / `child` arguments must
+/// match the `ModelSchema::table` of two `#[derive(Model)]` types
+/// already in the registry.
+///
+/// All optional keys can be omitted — the defaults mirror Django:
+/// `kind = InlineKind::Tabular`, `label = ""` (falls back to child
+/// model name), `fields = &[]` (every scalar except the FK column),
+/// `extra = 0`, `max_num = None`, `readonly_fields = &[]`.
+///
+/// ```ignore
+/// rustango::register_admin_inline!(
+///     parent = "blog_post",
+///     child  = "blog_comment",
+///     fk     = "post_id",
+/// );
+/// ```
+#[macro_export]
+macro_rules! register_admin_inline {
+    (
+        parent = $parent:expr,
+        child = $child:expr,
+        fk = $fk:expr
+        $(, kind = $kind:expr)?
+        $(, label = $label:expr)?
+        $(, fields = $fields:expr)?
+        $(, extra = $extra:expr)?
+        $(, max_num = $max_num:expr)?
+        $(, readonly_fields = $ro:expr)?
+        $(,)?
+    ) => {
+        $crate::inventory::submit! {
+            $crate::admin::inlines::InlineAdmin {
+                parent_table: $parent,
+                child_table: $child,
+                fk_column: $fk,
+                kind: $crate::register_admin_inline!(@or $($kind)?; $crate::admin::inlines::InlineKind::Tabular),
+                label: $crate::register_admin_inline!(@or $($label)?; ""),
+                fields: $crate::register_admin_inline!(@or $($fields)?; &[]),
+                extra: $crate::register_admin_inline!(@or $($extra)?; 0usize),
+                max_num: $crate::register_admin_inline!(@or $($max_num)?; ::core::option::Option::<usize>::None),
+                readonly_fields: $crate::register_admin_inline!(@or $($ro)?; &[]),
+            }
+        }
+    };
+    (@or $given:expr; $default:expr) => { $given };
+    (@or ; $default:expr) => { $default };
+}
+
+// ============================================================ Render helpers
+
+/// One inline panel ready for the Tera detail template. Built per
+/// parent-row render via [`render_for_parent`].
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct InlinePanel {
+    /// Panel header text.
+    pub label: String,
+    /// Child model's table — used to build per-row edit links.
+    pub child_table: String,
+    /// `"tabular"` or `"stacked"` — selects the template branch.
+    pub kind: String,
+    /// Column headers, in render order.
+    pub field_labels: Vec<String>,
+    /// One entry per child row. Each row is a list of pre-rendered
+    /// `{label, value}` cells matching `field_labels` order, plus a
+    /// `pk` string for the row link.
+    pub rows: Vec<serde_json::Value>,
+    /// `true` when zero children exist; templates show a "no rows"
+    /// placeholder.
+    pub empty: bool,
+}
+
+/// Resolve every inline registered against `parent_model`, fetch the
+/// matching child rows, and return one [`InlinePanel`] per inline.
+/// Returns an empty `Vec` when the parent has no registered inlines.
+///
+/// # Errors
+/// [`ExecError`] if a child SELECT fails — caller decides whether to
+/// surface or swallow (the admin detail view swallows so one broken
+/// inline doesn't take down the whole page).
+pub async fn render_for_parent(
+    pool: &Pool,
+    parent_model: &'static ModelSchema,
+    parent_pk: SqlValue,
+) -> Result<Vec<InlinePanel>, ExecError> {
+    let registrations = for_parent_table(parent_model.table);
+    if registrations.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut panels = Vec::with_capacity(registrations.len());
+    for inline in registrations {
+        let Some(child_model) = find_model_by_table(inline.child_table) else {
+            continue;
+        };
+        // Validate the FK column exists on the child model.
+        if child_model.field_by_column(inline.fk_column).is_none() {
+            continue;
+        }
+
+        let display_fields = resolve_render_fields(child_model, inline);
+        // The SELECT must include the PK so we can render a per-row
+        // edit link even when the operator's `fields = &[...]` list
+        // doesn't include it. Build a projection that prepends the PK
+        // when it's not already in the display list.
+        let pk_field = child_model.primary_key();
+        let select_fields: Vec<&'static FieldSchema> = match pk_field {
+            Some(pk) if !display_fields.iter().any(|f| f.column == pk.column) => {
+                let mut v = Vec::with_capacity(display_fields.len() + 1);
+                v.push(pk);
+                v.extend_from_slice(&display_fields);
+                v
+            }
+            _ => display_fields.clone(),
+        };
+        let order_pk: Vec<OrderItem> = pk_field
+            .map(|pk| OrderItem::Column {
+                column: pk.column,
+                desc: false,
+                nulls: NullsOrder::Default,
+            })
+            .into_iter()
+            .collect();
+
+        let rows = select_rows_as_json(
+            pool,
+            &SelectQuery {
+                model: child_model,
+                where_clause: WhereExpr::Predicate(Filter {
+                    column: inline.fk_column,
+                    op: Op::Eq,
+                    value: parent_pk.clone(),
+                }),
+                search: None,
+                joins: vec![],
+                order_by: order_pk,
+                limit: None,
+                offset: None,
+                lock_mode: None,
+                compound: vec![],
+                projection: None,
+            },
+            &select_fields,
+        )
+        .await?;
+
+        let field_labels = display_fields.iter().map(|f| f.name.to_owned()).collect();
+        let pk_column = pk_field.map(|p| p.column).unwrap_or("id");
+        let rendered_rows: Vec<serde_json::Value> = rows
+            .iter()
+            .map(|row| {
+                let cells: Vec<serde_json::Value> = display_fields
+                    .iter()
+                    .map(|f| {
+                        let raw = row
+                            .get(f.column)
+                            .cloned()
+                            .unwrap_or(serde_json::Value::Null);
+                        serde_json::json!({
+                            "label": f.name,
+                            "value": render_cell_text(&raw),
+                        })
+                    })
+                    .collect();
+                let pk_text = row.get(pk_column).map(stringify_pk).unwrap_or_default();
+                serde_json::json!({
+                    "pk": pk_text,
+                    "cells": cells,
+                })
+            })
+            .collect();
+
+        let label = if inline.label.is_empty() {
+            child_model.name.to_owned()
+        } else {
+            inline.label.to_owned()
+        };
+        let empty = rendered_rows.is_empty();
+
+        panels.push(InlinePanel {
+            label,
+            child_table: child_model.table.to_owned(),
+            kind: match inline.kind {
+                InlineKind::Tabular => "tabular".to_owned(),
+                InlineKind::Stacked => "stacked".to_owned(),
+            },
+            field_labels,
+            rows: rendered_rows,
+            empty,
+        });
+    }
+    Ok(panels)
+}
+
+/// Walk the model registry for a schema whose `table` matches.
+fn find_model_by_table(table: &str) -> Option<&'static ModelSchema> {
+    inventory::iter::<ModelEntry>
+        .into_iter()
+        .find(|e| e.schema.table == table)
+        .map(|e| e.schema)
+}
+
+/// Resolve the field list for an inline. Empty `fields` slice falls
+/// back to every scalar field except the FK column (Django default —
+/// the FK is implicit, no need to repeat it on every row).
+fn resolve_render_fields(
+    child_model: &'static ModelSchema,
+    inline: &InlineAdmin,
+) -> Vec<&'static FieldSchema> {
+    if inline.fields.is_empty() {
+        return child_model
+            .scalar_fields()
+            .filter(|f| f.column != inline.fk_column)
+            .collect();
+    }
+    inline
+        .fields
+        .iter()
+        .filter_map(|name| child_model.field(name))
+        .collect()
+}
+
+/// Convert a JSON value into a short display string. Mirrors what the
+/// list-view cell renderer does for unknown-type cells — strings
+/// pass through, primitives stringify, complex values get debug-printed
+/// so the operator at least sees something instead of a blank cell.
+fn render_cell_text(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => html_escape(s),
+        other => html_escape(&other.to_string()),
+    }
+}
+
+/// Stringify a JSON PK for use in a URL. Numbers and strings only —
+/// any other shape returns empty (the row's edit link will simply not
+/// render, which is the right failure mode).
+fn stringify_pk(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => s.clone(),
+        _ => String::new(),
+    }
+}
+
+/// Minimal HTML-escape — pre-rendered cells are dropped into the
+/// detail template with `| safe` so untrusted strings need escaping
+/// here. Mirrors the helper the list view uses.
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn html_escape_quotes_and_brackets() {
+        assert_eq!(
+            html_escape("<a href='x'>&"),
+            "&lt;a href=&#39;x&#39;&gt;&amp;"
+        );
+    }
+
+    #[test]
+    fn render_cell_text_handles_primitives() {
+        assert_eq!(render_cell_text(&serde_json::Value::Null), "");
+        assert_eq!(render_cell_text(&serde_json::json!(42)), "42");
+        assert_eq!(render_cell_text(&serde_json::json!(true)), "true");
+        assert_eq!(
+            render_cell_text(&serde_json::json!("hi <b>")),
+            "hi &lt;b&gt;"
+        );
+    }
+
+    #[test]
+    fn stringify_pk_supports_numeric_and_string_keys() {
+        assert_eq!(stringify_pk(&serde_json::json!(7)), "7");
+        assert_eq!(stringify_pk(&serde_json::json!("INV-1")), "INV-1");
+        assert_eq!(stringify_pk(&serde_json::json!(null)), "");
+    }
+}

--- a/crates/rustango/src/admin/mod.rs
+++ b/crates/rustango/src/admin/mod.rs
@@ -45,6 +45,7 @@ pub mod computed_fields;
 mod errors;
 mod forms;
 mod helpers;
+pub mod inlines;
 // `pub(crate)` so the operator console can reuse `render_input` /
 // `render_value_for_input` for its `/orgs/{slug}/edit` form. Stays
 // non-public outside the crate — the helpers' signatures are still
@@ -57,4 +58,5 @@ mod views;
 pub use auth::protect_with_basic_auth;
 pub use computed_fields::{ComputedField, ComputedFieldRenderFn};
 pub use errors::AdminError;
+pub use inlines::{InlineAdmin, InlineKind, InlinePanel};
 pub use urls::{router, AdminActionFn, AdminActionFuture, Builder};

--- a/crates/rustango/src/admin/templates.rs
+++ b/crates/rustango/src/admin/templates.rs
@@ -29,6 +29,10 @@ fn templates() -> &'static tera::Tera {
             ("index.html", include_str!("templates/index.html")),
             ("list.html", include_str!("templates/list.html")),
             ("detail.html", include_str!("templates/detail.html")),
+            (
+                "_inline_panels.html",
+                include_str!("templates/_inline_panels.html"),
+            ),
             ("form.html", include_str!("templates/form.html")),
             ("audit_log.html", include_str!("templates/audit_log.html")),
         ])

--- a/crates/rustango/src/admin/templates/_inline_panels.html
+++ b/crates/rustango/src/admin/templates/_inline_panels.html
@@ -1,0 +1,60 @@
+{# Admin inlines — Django TabularInline / StackedInline display.
+   Issue #50 slice 1: read-only listing of child rows on the parent
+   detail page. Each panel is one `register_admin_inline!` registration.
+   Rendered with `{{ value | safe }}` because the cell renderer
+   already HTML-escapes its inputs. #}
+{% if inline_panels and inline_panels | length > 0 %}
+    {% for panel in inline_panels %}
+        <section class="admin-inline admin-inline-{{ panel.kind }}"
+                 data-child-table="{{ panel.child_table }}">
+            <h2>{{ panel.label }}</h2>
+            {% if panel.empty %}
+                <p>
+                    <em>No related rows.</em>
+                </p>
+            {% else %}
+                {% if panel.kind == "tabular" %}
+                    <table class="inline-table">
+                        <thead>
+                            <tr>
+                                {% for label in panel.field_labels %}<th>{{ label }}</th>{% endfor %}
+                                <th aria-label="actions"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in panel.rows %}
+                                <tr>
+                                    {% for cell in row.cells %}<td>{{ cell.value | safe }}</td>{% endfor %}
+                                    <td>
+                                        {% if row.pk %}
+                                            <a href="{{ admin_prefix }}/{{ panel.child_table }}/{{ row.pk }}">View</a>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% else %}
+                    {# stacked #}
+                    {% for row in panel.rows %}
+                        <fieldset class="inline-stacked">
+                            <legend>
+                                {% if row.pk %}
+                                    <a href="{{ admin_prefix }}/{{ panel.child_table }}/{{ row.pk }}">#{{ row.pk }}</a>
+                                {% else %}
+                                    Row
+                                {% endif %}
+                            </legend>
+                            <dl>
+                                {% for cell in row.cells %}
+                                    <dt>{{ cell.label }}</dt>
+                                    <dd>{{ cell.value | safe }}</dd>
+                                {% endfor %}
+                            </dl>
+                        </fieldset>
+                    {% endfor %}
+                {% endif %}
+            {% endif %}
+        </section>
+    {% endfor %}
+{% endif %}

--- a/crates/rustango/src/admin/templates/detail.html
+++ b/crates/rustango/src/admin/templates/detail.html
@@ -42,6 +42,7 @@
             </form>
         </p>
     {% endif %}
+    {% include "_inline_panels.html" %}
     {% if user_roles_panel %}
         <section class="user-roles-panel">
             <h2>Roles &amp; permissions</h2>

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -860,7 +860,7 @@ pub(crate) async fn detail_view(
             where_clause: WhereExpr::Predicate(Filter {
                 column: pk_field.column,
                 op: Op::Eq,
-                value: pk_value,
+                value: pk_value.clone(),
             }),
             search: None,
             joins: build_fk_joins(&state, model),
@@ -933,6 +933,24 @@ pub(crate) async fn detail_view(
         }));
     }
 
+    // #50 — admin inlines. Walk every `register_admin_inline!`
+    // submission keyed on this parent table, fetch the matching child
+    // rows, and hand the renderer a list of `InlinePanel`s. Best-effort:
+    // a fetch error on one panel (e.g. the child table doesn't exist
+    // yet on this tenant) drops the panels list to empty rather than
+    // taking down the whole detail page.
+    let inline_panels_ctx: Vec<serde_json::Value> =
+        super::inlines::render_for_parent(&state.pool, model, pk_value)
+            .await
+            .ok()
+            .map(|panels| {
+                panels
+                    .into_iter()
+                    .map(|p| serde_json::to_value(p).unwrap_or(serde_json::Value::Null))
+                    .collect()
+            })
+            .unwrap_or_default();
+
     // v0.12.2: Audit trail panel for this row. Best-effort — if the
     // audit table doesn't exist yet (project hasn't called
     // `audit::ensure_table` per tenant), the lookup returns Err and
@@ -979,6 +997,7 @@ pub(crate) async fn detail_view(
         "read_only": state.is_read_only(model.table),
         "audit_entries": audit_entries_ctx,
         "user_roles_panel": user_roles_ctx,
+        "inline_panels": inline_panels_ctx,
     });
     let html = render_with_chrome(
         "detail.html",

--- a/crates/rustango/tests/admin_inlines_live.rs
+++ b/crates/rustango/tests/admin_inlines_live.rs
@@ -1,0 +1,206 @@
+//! Live test for admin inlines — Django `TabularInline` /
+//! `StackedInline` read-only display on the parent detail page.
+//! Issue #50 slice 1.
+//!
+//! Spins up two models (`il_blog` + `il_blog_post`), registers an
+//! inline pointing the child at the parent, inserts one parent row +
+//! two child rows, GETs `/__admin/il_blog/<pk>`, and asserts the
+//! tabular panel renders both children.
+
+#![cfg(feature = "postgres")]
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use rustango::admin::inlines::InlineKind;
+use rustango::register_admin_inline;
+use rustango::sql::sqlx;
+use rustango::sql::Auto;
+use rustango::Model;
+use tower::ServiceExt;
+
+use tokio::sync::Mutex;
+
+/// Suite-wide lock — every test in this file mutates the shared
+/// schema and runs alongside other admin-live tests under cargo's
+/// parallel harness.
+fn live_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+#[derive(Model, Debug)]
+#[rustango(table = "il_blog")]
+#[allow(dead_code)]
+pub struct Blog {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 100)]
+    pub name: String,
+}
+
+#[derive(Model, Debug)]
+#[rustango(table = "il_blog_post")]
+#[allow(dead_code)]
+pub struct BlogPost {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(fk = "il_blog", on = "id")]
+    pub blog_id: i64,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 500)]
+    pub body: String,
+}
+
+register_admin_inline!(
+    parent = "il_blog",
+    child = "il_blog_post",
+    fk = "blog_id",
+    kind = InlineKind::Tabular,
+    label = "Posts",
+    fields = &["title", "body"],
+);
+
+async fn fresh(pool: &sqlx::PgPool) {
+    // Build only the tables this test cares about. The shared
+    // migrate::drop_all + apply_all path is too slow to run in every
+    // admin-live test.
+    for t in ["il_blog_post", "il_blog"] {
+        sqlx::query(&format!(r#"DROP TABLE IF EXISTS "{t}" CASCADE"#))
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+    sqlx::query(
+        r#"CREATE TABLE "il_blog" (
+               id BIGSERIAL PRIMARY KEY,
+               name VARCHAR(100) NOT NULL
+           )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "il_blog_post" (
+               id BIGSERIAL PRIMARY KEY,
+               blog_id BIGINT NOT NULL REFERENCES "il_blog"(id),
+               title VARCHAR(200) NOT NULL,
+               body VARCHAR(500) NOT NULL
+           )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn parent_detail_renders_inline_panel_with_child_rows() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+
+    let mut blog = Blog {
+        id: Auto::default(),
+        name: "Test Blog".into(),
+    };
+    blog.insert(&pool).await.unwrap();
+    let blog_id = *blog.id.get().expect("PK assigned");
+
+    let mut post_a = BlogPost {
+        id: Auto::default(),
+        blog_id,
+        title: "First post".into(),
+        body: "hello world".into(),
+    };
+    post_a.insert(&pool).await.unwrap();
+
+    let mut post_b = BlogPost {
+        id: Auto::default(),
+        blog_id,
+        title: "Second post".into(),
+        body: "more content".into(),
+    };
+    post_b.insert(&pool).await.unwrap();
+
+    let app = rustango::admin::router(pool.clone());
+    let req = Request::builder()
+        .uri(format!("/il_blog/{blog_id}"))
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = to_bytes(res.into_body(), 1_000_000).await.unwrap();
+    let html = String::from_utf8(body.to_vec()).unwrap();
+
+    // Panel header rendered with the inline's `label`.
+    assert!(
+        html.contains("Posts"),
+        "inline panel header missing: {html}"
+    );
+    // Tabular kind — `<table class=\"inline-table\">` is the marker.
+    assert!(
+        html.contains("class=\"inline-table\""),
+        "tabular variant didn't render its <table>: {html}"
+    );
+    // Both child rows visible.
+    assert!(html.contains("First post"), "first child missing: {html}");
+    assert!(html.contains("Second post"), "second child missing: {html}");
+    // Edit-link target is the child admin route.
+    assert!(
+        html.contains("/il_blog_post/"),
+        "row link should point at child admin route: {html}"
+    );
+    // No "No related rows." sentinel.
+    assert!(
+        !html.contains("No related rows"),
+        "panel shouldn't show empty-state when children exist: {html}"
+    );
+}
+
+#[tokio::test]
+async fn parent_detail_renders_empty_state_when_no_children() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+
+    let mut blog = Blog {
+        id: Auto::default(),
+        name: "Lonely Blog".into(),
+    };
+    blog.insert(&pool).await.unwrap();
+    let blog_id = *blog.id.get().expect("PK assigned");
+
+    let app = rustango::admin::router(pool.clone());
+    let req = Request::builder()
+        .uri(format!("/il_blog/{blog_id}"))
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = to_bytes(res.into_body(), 1_000_000).await.unwrap();
+    let html = String::from_utf8(body.to_vec()).unwrap();
+
+    // Panel still renders — but with the empty-state message.
+    assert!(
+        html.contains("Posts"),
+        "inline panel header should still render: {html}"
+    );
+    assert!(
+        html.contains("No related rows"),
+        "panel should show empty-state when no children: {html}"
+    );
+}


### PR DESCRIPTION
## Summary

First half of #50. Read-only child-row display on the parent admin detail page — the foundation Django's `TabularInline` / `StackedInline` builds on. Editable inline forms (FormSet POST handler) follow as a second slice on top of this scaffold.

### New surface

\`\`\`rust
use rustango::register_admin_inline;
use rustango::admin::inlines::InlineKind;

register_admin_inline!(
    parent = \"blog_post\",       // ModelSchema::table of the parent
    child  = \"blog_comment\",    // ModelSchema::table of the child
    fk     = \"post_id\",         // child column pointing back
    kind   = InlineKind::Tabular,
    label  = \"Comments\",
    fields = &[\"body\", \"created_at\"],
    // extra / max_num / readonly_fields all accepted today;
    // honored when the FormSet-backed editor lands in slice 2.
);
\`\`\`

The parent's `/__admin/blog_post/<pk>` page now renders a \"Comments\" panel below the parent fields, listing every `blog_comment` row whose `post_id` matches, each linked to its own admin detail.

### What lands

- `admin/inlines.rs` — `InlineAdmin` (inventory-collected), `InlineKind`, `InlinePanel` render struct, `render_for_parent(pool, parent_model, parent_pk)` query helper.
- `register_admin_inline!{ parent, child, fk, ... }` macro — every Django `InlineModelAdmin` knob wired into the struct today even though only the display fields drive slice 1.
- `_inline_panels.html` partial included from `detail.html` — tabular renders a `<table>`, stacked renders one `<fieldset>` per row, both link each row to the child's admin detail.
- `views::detail_view` calls `render_for_parent` and threads the resulting panels into the template ctx. Best-effort: a fetch error on one panel drops the panels list to empty rather than taking down the whole page (same posture as the audit-trail panel).
- The SELECT always projects the child PK even when `fields = [...]` omits it, so the per-row edit link always works.

### What still needs slice 2 (filed as follow-up scope on the issue)

Editing flow: management form parsing per inline (`<prefix>-TOTAL_FORMS` etc., already shipped in `forms::formset`), per-row create/update/delete, `extra` blank rows, `max_num` enforcement. The macro already carries those knobs — no struct change needed when the editor lands.

### Stays out of ORM extraction surface

Zero changes to `core/` / `sql/` / `query/` / `migrate/`. The inline registry lives entirely in the admin module via `inventory::collect!`, same pattern `admin/computed_fields.rs` uses.

## Test plan
- [x] \`cargo fmt --all\`
- [x] \`cargo build --no-default-features --features sqlite,tenancy\` (sqlite-tenancy litmus)
- [x] \`cargo test --workspace --all-features --no-run\` (full compile gate)
- [x] \`cargo test --workspace --all-features --lib\` (2330 pass, was 2327 — 3 new unit tests)
- [x] \`cargo test --test admin_inlines_live --all-features\` against live PG (2/2 pass)
- [x] pre-push hook (lib tests + clippy)