### PR TITLE
feat: admin inlines slice 2 — editable inline rows via FormSet POST handler (closes #50)

### DIFF
--- a/crates/rustango/src/admin/helpers.rs
+++ b/crates/rustango/src/admin/helpers.rs
@@ -503,3 +503,115 @@ pub(crate) fn render_form(
         chrome_context(state, Some(model.table)),
     )
 }
+
+/// As [`render_form`] but threads a list of `InlineFormPanel` into
+/// the form context so the template can render editable inline
+/// panels below the parent fieldsets. Used by `edit_form` only —
+/// the create form runs before the parent PK exists, so child rows
+/// can't be attached yet (Django's create-form-doesn't-render-inlines
+/// behavior).
+pub(crate) fn render_form_with_inlines(
+    state: &AppState,
+    model: &'static ModelSchema,
+    prefill: Option<&HashMap<String, String>>,
+    pk_locked: bool,
+    error_msg: Option<&str>,
+    inline_panels: Vec<super::inlines::InlineFormPanel>,
+) -> String {
+    let admin_prefix = state.config.admin_prefix.as_str();
+    let (action, edit_pk) = if pk_locked {
+        let pk_field = model.primary_key().expect("pk_locked requires a PK");
+        let pk_value = prefill
+            .and_then(|m| m.get(pk_field.name).cloned())
+            .unwrap_or_default();
+        (
+            format!(
+                "{admin_prefix}/{}/{}",
+                model.table,
+                render::escape(&pk_value)
+            ),
+            Some(pk_value),
+        )
+    } else {
+        (format!("{admin_prefix}/{}", model.table), None)
+    };
+    let title = if pk_locked {
+        format!("Edit {}", model.name)
+    } else {
+        format!("New {}", model.name)
+    };
+    let admin_cfg = model
+        .admin
+        .copied()
+        .unwrap_or(crate::core::AdminConfig::DEFAULT);
+    let row_for_field = |f: &'static FieldSchema| -> serde_json::Value {
+        let value = prefill
+            .and_then(|m| m.get(f.name))
+            .map_or("", String::as_str);
+        let is_readonly_field = admin_cfg.readonly_fields.iter().any(|n| *n == f.name);
+        let extra = if f.primary_key {
+            " <small>(pk)</small>"
+        } else if is_readonly_field {
+            " <small>read-only</small>"
+        } else if f.auto {
+            " <small>auto</small>"
+        } else if !f.nullable {
+            " <small>required</small>"
+        } else {
+            ""
+        };
+        let lock_input = f.auto || (pk_locked && (f.primary_key || is_readonly_field));
+        serde_json::json!({
+            "label": f.name,
+            "extra": extra,
+            "input": render::render_input(f, value, lock_input),
+        })
+    };
+    let visible = |f: &&'static FieldSchema| -> bool {
+        if f.auto && !pk_locked {
+            return false;
+        }
+        true
+    };
+    let fieldsets_ctx: Vec<serde_json::Value> = if admin_cfg.fieldsets.is_empty() {
+        let rows: Vec<serde_json::Value> = model
+            .scalar_fields()
+            .filter(visible)
+            .map(row_for_field)
+            .collect();
+        vec![serde_json::json!({ "title": "", "rows": rows })]
+    } else {
+        admin_cfg
+            .fieldsets
+            .iter()
+            .map(|set| {
+                let rows: Vec<serde_json::Value> = set
+                    .fields
+                    .iter()
+                    .filter_map(|name| model.field(name))
+                    .filter(visible)
+                    .map(row_for_field)
+                    .collect();
+                serde_json::json!({ "title": set.title, "rows": rows })
+            })
+            .collect()
+    };
+    let inline_form_panels_ctx: Vec<serde_json::Value> = inline_panels
+        .into_iter()
+        .map(|p| serde_json::to_value(p).unwrap_or(serde_json::Value::Null))
+        .collect();
+    let mut ctx = serde_json::json!({
+        "model": { "name": model.name, "table": model.table },
+        "title": title,
+        "action": action,
+        "edit_pk": edit_pk,
+        "error": error_msg,
+        "fieldsets": fieldsets_ctx,
+        "inline_form_panels": inline_form_panels_ctx,
+    });
+    super::templates::render_with_chrome(
+        "form.html",
+        &mut ctx,
+        chrome_context(state, Some(model.table)),
+    )
+}

--- a/crates/rustango/src/admin/inlines.rs
+++ b/crates/rustango/src/admin/inlines.rs
@@ -374,6 +374,494 @@ fn stringify_pk(value: &serde_json::Value) -> String {
     }
 }
 
+// ============================================================ Editable rendering (slice 2)
+
+/// One editable inline panel for the `form.html` template. Mirrors
+/// [`InlinePanel`] but each cell carries pre-rendered `<input>`
+/// HTML instead of a static value, plus the FormSet management-form
+/// fields and Django's `<prefix>-N-<field>` naming.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct InlineFormPanel {
+    /// Panel header text.
+    pub label: String,
+    /// Child model's SQL table — used by the POST processor to look
+    /// up the schema. Also surfaces in the rendered DOM so JS could
+    /// scope row-add buttons to this panel.
+    pub child_table: String,
+    /// `"tabular"` or `"stacked"`.
+    pub kind: String,
+    /// FormSet prefix used for every input on every row. Stable across
+    /// GET + POST (defaults to `child_table`).
+    pub prefix: String,
+    /// Total form rows (existing + extra blanks). Drives the
+    /// `<prefix>-TOTAL_FORMS` management input.
+    pub total_forms: usize,
+    /// Existing-rows count. Drives `<prefix>-INITIAL_FORMS`.
+    pub initial_forms: usize,
+    /// `<prefix>-MAX_NUM_FORMS` value; `None` renders as empty
+    /// (Django's "no cap" sentinel).
+    pub max_num: Option<usize>,
+    /// Column headers, in render order. Padded with a final
+    /// `"Delete"` column when at least one existing row is present
+    /// (so the delete-checkbox column lines up with the others).
+    pub field_labels: Vec<String>,
+    /// One entry per form row. Each row carries pre-rendered
+    /// `{ label, input_html }` cells, plus `pk` (empty for new rows)
+    /// and `delete_input_html` (empty for new rows).
+    pub rows: Vec<serde_json::Value>,
+}
+
+/// As [`render_for_parent`] but produces an editable [`InlineFormPanel`]
+/// — N existing-row inputs prefilled, then `extra` blank rows below.
+/// Each existing row carries a hidden `<prefix>-N-<pk>` input + a
+/// `<prefix>-N-DELETE` checkbox so the POST handler can identify which
+/// rows to UPDATE vs DELETE.
+///
+/// Pair with [`apply_post`] to round-trip a submitted edit page.
+///
+/// # Errors
+/// As [`render_for_parent`].
+pub async fn render_form_for_parent(
+    pool: &Pool,
+    parent_model: &'static ModelSchema,
+    parent_pk: SqlValue,
+) -> Result<Vec<InlineFormPanel>, ExecError> {
+    let registrations = for_parent_table(parent_model.table);
+    if registrations.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut panels = Vec::with_capacity(registrations.len());
+    for inline in registrations {
+        let Some(child_model) = find_model_by_table(inline.child_table) else {
+            continue;
+        };
+        if child_model.field_by_column(inline.fk_column).is_none() {
+            continue;
+        }
+
+        let display_fields = resolve_render_fields(child_model, inline);
+        let pk_field = child_model.primary_key();
+        let select_fields: Vec<&'static FieldSchema> = match pk_field {
+            Some(pk) if !display_fields.iter().any(|f| f.column == pk.column) => {
+                let mut v = Vec::with_capacity(display_fields.len() + 1);
+                v.push(pk);
+                v.extend_from_slice(&display_fields);
+                v
+            }
+            _ => display_fields.clone(),
+        };
+        let order_pk: Vec<OrderItem> = pk_field
+            .map(|pk| OrderItem::Column {
+                column: pk.column,
+                desc: false,
+                nulls: NullsOrder::Default,
+            })
+            .into_iter()
+            .collect();
+
+        let rows = select_rows_as_json(
+            pool,
+            &SelectQuery {
+                model: child_model,
+                where_clause: WhereExpr::Predicate(Filter {
+                    column: inline.fk_column,
+                    op: Op::Eq,
+                    value: parent_pk.clone(),
+                }),
+                search: None,
+                joins: vec![],
+                order_by: order_pk,
+                limit: None,
+                offset: None,
+                lock_mode: None,
+                compound: vec![],
+                projection: None,
+            },
+            &select_fields,
+        )
+        .await?;
+
+        let prefix = child_model.table.to_owned();
+        let initial_forms = rows.len();
+        let total_forms = initial_forms + inline.extra;
+        let pk_column = pk_field.map(|p| p.column).unwrap_or("id");
+
+        let mut field_labels: Vec<String> =
+            display_fields.iter().map(|f| f.name.to_owned()).collect();
+        // Append a Delete column only when there's something to delete.
+        if initial_forms > 0 {
+            field_labels.push("Delete".to_owned());
+        }
+
+        let mut rendered_rows: Vec<serde_json::Value> = Vec::with_capacity(total_forms);
+        for (idx, row) in rows.iter().enumerate() {
+            let pk_text = row.get(pk_column).map(stringify_pk).unwrap_or_default();
+            let cells: Vec<serde_json::Value> = display_fields
+                .iter()
+                .map(|f| {
+                    let raw_str = row
+                        .get(f.column)
+                        .map(value_as_form_string)
+                        .unwrap_or_default();
+                    let input_html = render_prefixed_input(f, &raw_str, &prefix, idx, false);
+                    serde_json::json!({
+                        "label": f.name,
+                        "input_html": input_html,
+                    })
+                })
+                .collect();
+            // Hidden PK input keeps the row identifiable through the
+            // round-trip even if the operator changes nothing else.
+            let pk_field_name = pk_field.map(|p| p.name).unwrap_or("id");
+            let hidden_pk = format!(
+                r#"<input type="hidden" name="{p}-{i}-{n}" value="{v}">"#,
+                p = html_escape(&prefix),
+                i = idx,
+                n = html_escape(pk_field_name),
+                v = html_escape(&pk_text),
+            );
+            let delete_input_html = format!(
+                r#"<input type="checkbox" name="{p}-{i}-DELETE" value="on">"#,
+                p = html_escape(&prefix),
+                i = idx,
+            );
+            rendered_rows.push(serde_json::json!({
+                "pk": pk_text,
+                "cells": cells,
+                "hidden_pk": hidden_pk,
+                "delete_input_html": delete_input_html,
+            }));
+        }
+        // Extra blank rows for adding new children. No hidden PK (the
+        // POST handler treats absence as "INSERT") and no DELETE box.
+        for idx in initial_forms..total_forms {
+            let cells: Vec<serde_json::Value> = display_fields
+                .iter()
+                .map(|f| {
+                    let input_html = render_prefixed_input(f, "", &prefix, idx, false);
+                    serde_json::json!({
+                        "label": f.name,
+                        "input_html": input_html,
+                    })
+                })
+                .collect();
+            rendered_rows.push(serde_json::json!({
+                "pk": "",
+                "cells": cells,
+                "hidden_pk": "",
+                "delete_input_html": "",
+            }));
+        }
+
+        let label = if inline.label.is_empty() {
+            child_model.name.to_owned()
+        } else {
+            inline.label.to_owned()
+        };
+
+        panels.push(InlineFormPanel {
+            label,
+            child_table: child_model.table.to_owned(),
+            kind: match inline.kind {
+                InlineKind::Tabular => "tabular".to_owned(),
+                InlineKind::Stacked => "stacked".to_owned(),
+            },
+            prefix,
+            total_forms,
+            initial_forms,
+            max_num: inline.max_num,
+            field_labels,
+            rows: rendered_rows,
+        });
+    }
+    Ok(panels)
+}
+
+/// Wrap `super::render::render_input` so the generated `name=` /
+/// `id=` attributes are prefix-mangled into Django's FormSet
+/// `<prefix>-<idx>-<field>` shape. We accomplish this with a
+/// `str::replace` on the rendered HTML — `render_input` always emits
+/// `name="<field>"` and `id="<field>"`, so the substitution is
+/// uniquely targetable.
+fn render_prefixed_input(
+    field: &FieldSchema,
+    value: &str,
+    prefix: &str,
+    idx: usize,
+    pk_locked: bool,
+) -> String {
+    let base = crate::admin::render::render_input(field, value, pk_locked);
+    let target_name = format!(r#"name="{}""#, field.name);
+    let new_name = format!(r#"name="{prefix}-{idx}-{}""#, field.name);
+    let target_id = format!(r#"id="{}""#, field.name);
+    let new_id = format!(r#"id="{prefix}-{idx}-{}""#, field.name);
+    base.replacen(&target_name, &new_name, 1)
+        .replacen(&target_id, &new_id, 1)
+}
+
+/// Convert a JSON value into the string form an HTML `<input>` would
+/// have produced for it. Mirrors `render::render_value_for_input_json`
+/// at the rough level needed for inline rows — JSON / Binary fall
+/// back to the raw text representation so the operator can still see
+/// the value.
+fn value_as_form_string(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+// ============================================================ POST processing (slice 2)
+
+/// Outcome of processing a single inline POST payload. Aggregated
+/// across panels by [`apply_post`] so the caller can report counts to
+/// the operator without caring about per-row mechanics.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct InlineApplyOutcome {
+    /// Existing rows successfully updated.
+    pub updated: usize,
+    /// Existing rows successfully deleted (DELETE checkbox was on).
+    pub deleted: usize,
+    /// New rows successfully inserted (extra/empty slots with content).
+    pub inserted: usize,
+    /// Rows that failed to validate or write — counted but skipped.
+    pub failed: usize,
+}
+
+impl InlineApplyOutcome {
+    fn add(&mut self, other: Self) {
+        self.updated += other.updated;
+        self.deleted += other.deleted;
+        self.inserted += other.inserted;
+        self.failed += other.failed;
+    }
+}
+
+/// Process every inline FormSet payload on a parent edit POST. For
+/// each row: an empty PK + any non-empty field → INSERT; a present PK
+/// + DELETE checkbox → DELETE; a present PK + no DELETE → UPDATE.
+///
+/// `parent_pk` is the parent's primary-key value — every INSERT pins
+/// the FK column to it.
+///
+/// Best-effort: a row that fails to validate or write increments
+/// `failed` and is skipped; other rows continue. The caller decides
+/// whether to surface the failure (the admin's `update_submit`
+/// reports a flash message via the audit log path).
+///
+/// # Errors
+/// Only when the registration's child model isn't in the registry —
+/// per-row write errors are absorbed into `failed`.
+pub async fn apply_post(
+    pool: &Pool,
+    parent_model: &'static ModelSchema,
+    parent_pk: SqlValue,
+    form: &std::collections::HashMap<String, String>,
+) -> Result<InlineApplyOutcome, ExecError> {
+    let registrations = for_parent_table(parent_model.table);
+    let mut total = InlineApplyOutcome::default();
+    for inline in registrations {
+        let Some(child_model) = find_model_by_table(inline.child_table) else {
+            continue;
+        };
+        if child_model.field_by_column(inline.fk_column).is_none() {
+            continue;
+        }
+        let prefix = child_model.table;
+        let total_forms = match crate::forms::formset::total_forms(form, prefix) {
+            Ok(n) => n,
+            Err(_) => {
+                // No management form for this inline (operator left
+                // the panel hidden, JS didn't render it, etc.). Skip
+                // silently — slice 1's display path doesn't render
+                // the management inputs either.
+                continue;
+            }
+        };
+        let outcome = apply_one_inline(
+            pool,
+            child_model,
+            inline,
+            prefix,
+            total_forms,
+            &parent_pk,
+            form,
+        )
+        .await;
+        total.add(outcome);
+    }
+    Ok(total)
+}
+
+async fn apply_one_inline(
+    pool: &Pool,
+    child_model: &'static ModelSchema,
+    inline: &InlineAdmin,
+    prefix: &str,
+    total_forms: usize,
+    parent_pk: &SqlValue,
+    form: &std::collections::HashMap<String, String>,
+) -> InlineApplyOutcome {
+    let mut outcome = InlineApplyOutcome::default();
+    let pk_field = match child_model.primary_key() {
+        Some(p) => p,
+        None => return outcome,
+    };
+    let display_fields = resolve_render_fields(child_model, inline);
+
+    for idx in 0..total_forms {
+        let row = crate::forms::formset::row_payload(form, prefix, idx);
+        let raw_pk = row.get(pk_field.name).cloned().unwrap_or_default();
+        let has_pk = !raw_pk.trim().is_empty();
+        let delete_flag = row
+            .get("DELETE")
+            .map(|s| s == "on" || s == "true" || s == "1")
+            .unwrap_or(false);
+
+        // Existing row + DELETE → DELETE child row.
+        if has_pk && delete_flag {
+            let pk_val = match crate::forms::parse_pk_string(pk_field, &raw_pk) {
+                Ok(v) => v,
+                Err(_) => {
+                    outcome.failed += 1;
+                    continue;
+                }
+            };
+            let q = crate::core::DeleteQuery {
+                model: child_model,
+                where_clause: WhereExpr::Predicate(Filter {
+                    column: pk_field.column,
+                    op: Op::Eq,
+                    value: pk_val,
+                }),
+            };
+            match crate::sql::delete_pool(pool, &q).await {
+                Ok(_) => outcome.deleted += 1,
+                Err(_) => outcome.failed += 1,
+            }
+            continue;
+        }
+
+        // Existing row, no DELETE → UPDATE child row.
+        if has_pk {
+            let pk_val = match crate::forms::parse_pk_string(pk_field, &raw_pk) {
+                Ok(v) => v,
+                Err(_) => {
+                    outcome.failed += 1;
+                    continue;
+                }
+            };
+            let assignments = match build_assignments(&display_fields, &row, Some(inline.fk_column))
+            {
+                Ok(a) => a,
+                Err(_) => {
+                    outcome.failed += 1;
+                    continue;
+                }
+            };
+            if assignments.is_empty() {
+                // Nothing changed; not a failure.
+                continue;
+            }
+            let q = crate::core::UpdateQuery {
+                model: child_model,
+                set: assignments,
+                where_clause: WhereExpr::Predicate(Filter {
+                    column: pk_field.column,
+                    op: Op::Eq,
+                    value: pk_val,
+                }),
+            };
+            match crate::sql::update_pool(pool, &q).await {
+                Ok(_) => outcome.updated += 1,
+                Err(_) => outcome.failed += 1,
+            }
+            continue;
+        }
+
+        // No PK → INSERT, but only when the operator typed something
+        // into at least one display field. Empty extras stay empty.
+        let row_nonempty = display_fields.iter().any(|f| {
+            row.get(f.name)
+                .map(|s| !s.trim().is_empty())
+                .unwrap_or(false)
+        });
+        if !row_nonempty {
+            continue;
+        }
+        let assignments = match build_assignments(&display_fields, &row, None) {
+            Ok(a) => a,
+            Err(_) => {
+                outcome.failed += 1;
+                continue;
+            }
+        };
+        // Pin the FK to the parent's PK so the new row attaches.
+        // `build_assignments` returns `Assignment` whose `value` is an
+        // `Expr::Literal(SqlValue)` — unwrap back to the SqlValue for
+        // InsertQuery's positional `values: Vec<SqlValue>` shape.
+        let mut columns: Vec<&'static str> = assignments.iter().map(|a| a.column).collect();
+        let mut values: Vec<SqlValue> = assignments
+            .into_iter()
+            .map(|a| match a.value {
+                crate::core::Expr::Literal(v) => v,
+                _ => SqlValue::Null,
+            })
+            .collect();
+        // Skip duplicate FK assignment if for some reason the operator
+        // also submitted the FK column directly.
+        if !columns.contains(&inline.fk_column) {
+            columns.push(inline.fk_column);
+            values.push(parent_pk.clone());
+        }
+        let q = crate::core::InsertQuery {
+            model: child_model,
+            columns,
+            values,
+            returning: vec![],
+            on_conflict: None,
+        };
+        match crate::sql::insert_pool(pool, &q).await {
+            Ok(_) => outcome.inserted += 1,
+            Err(_) => outcome.failed += 1,
+        }
+    }
+
+    outcome
+}
+
+/// Translate one row payload into `Assignment` values keyed on SQL
+/// columns. `skip_column`, when set, drops that column from the
+/// output — UPDATE skips the FK so a malicious POST can't reparent
+/// a child row to another parent.
+fn build_assignments(
+    display_fields: &[&'static FieldSchema],
+    row: &std::collections::HashMap<String, String>,
+    skip_column: Option<&str>,
+) -> Result<Vec<crate::core::Assignment>, crate::forms::FormError> {
+    let mut out = Vec::with_capacity(display_fields.len());
+    for f in display_fields {
+        if let Some(skip) = skip_column {
+            if f.column == skip {
+                continue;
+            }
+        }
+        let raw = row.get(f.name).map(String::as_str);
+        // Empty strings + nullable → NULL. Empty strings + required:
+        // bubble up the FormError so the panel marks this row failed.
+        let value = crate::forms::parse_form_value(f, raw)?;
+        out.push(crate::core::Assignment {
+            column: f.column,
+            value: crate::core::Expr::Literal(value),
+        });
+    }
+    Ok(out)
+}
+
 /// Minimal HTML-escape — pre-rendered cells are dropped into the
 /// detail template with `| safe` so untrusted strings need escaping
 /// here. Mirrors the helper the list view uses.

--- a/crates/rustango/src/admin/mod.rs
+++ b/crates/rustango/src/admin/mod.rs
@@ -58,5 +58,5 @@ mod views;
 pub use auth::protect_with_basic_auth;
 pub use computed_fields::{ComputedField, ComputedFieldRenderFn};
 pub use errors::AdminError;
-pub use inlines::{InlineAdmin, InlineKind, InlinePanel};
+pub use inlines::{InlineAdmin, InlineApplyOutcome, InlineFormPanel, InlineKind, InlinePanel};
 pub use urls::{router, AdminActionFn, AdminActionFuture, Builder};

--- a/crates/rustango/src/admin/templates/form.html
+++ b/crates/rustango/src/admin/templates/form.html
@@ -27,6 +27,61 @@
     </table>
   </fieldset>
 {% endfor %}
+{# #50 slice 2 — editable inline panels. Mirrors the read-only
+   layout in `_inline_panels.html` but each cell renders an <input>
+   and each panel carries the FormSet management form. #}
+{% if inline_form_panels and inline_form_panels | length > 0 %}
+  {% for panel in inline_form_panels %}
+    <section class="admin-inline-form admin-inline-form-{{ panel.kind }}"
+             data-child-table="{{ panel.child_table }}">
+      <h2>{{ panel.label }}</h2>
+      <input type="hidden" name="{{ panel.prefix }}-TOTAL_FORMS" value="{{ panel.total_forms }}">
+      <input type="hidden" name="{{ panel.prefix }}-INITIAL_FORMS" value="{{ panel.initial_forms }}">
+      <input type="hidden" name="{{ panel.prefix }}-MAX_NUM_FORMS"
+             value="{% if panel.max_num %}{{ panel.max_num }}{% endif %}">
+      {% if panel.kind == "tabular" %}
+        <table class="inline-form-table">
+          <thead>
+            <tr>
+              {% for label in panel.field_labels %}<th>{{ label }}</th>{% endfor %}
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in panel.rows %}
+              <tr>
+                {% for cell in row.cells %}<td>{{ cell.input_html | safe }}</td>{% endfor %}
+                {% if row.pk %}<td>{{ row.delete_input_html | safe }}{{ row.hidden_pk | safe }}</td>{% endif %}
+                {% if not row.pk and panel.initial_forms > 0 %}<td></td>{% endif %}
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        {# stacked #}
+        {% for row in panel.rows %}
+          <fieldset class="inline-form-stacked">
+            {% if row.pk %}
+              <legend>#{{ row.pk }}</legend>
+              {{ row.hidden_pk | safe }}
+            {% else %}
+              <legend>New</legend>
+            {% endif %}
+            <dl>
+              {% for cell in row.cells %}
+                <dt>{{ cell.label }}</dt>
+                <dd>{{ cell.input_html | safe }}</dd>
+              {% endfor %}
+              {% if row.pk %}
+                <dt>Delete</dt>
+                <dd>{{ row.delete_input_html | safe }}</dd>
+              {% endif %}
+            </dl>
+          </fieldset>
+        {% endfor %}
+      {% endif %}
+    </section>
+  {% endfor %}
+{% endif %}
   <p class="form-submit-row">
     <button type="submit" name="_save">Save</button>
     <button type="submit" name="_continue">Save and continue editing</button>

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -1154,7 +1154,7 @@ pub(crate) async fn edit_form(
             where_clause: WhereExpr::Predicate(Filter {
                 column: pk_field.column,
                 op: Op::Eq,
-                value: pk_value,
+                value: pk_value.clone(),
             }),
             search: None,
             joins: vec![],
@@ -1180,7 +1180,20 @@ pub(crate) async fn edit_form(
             render::render_value_for_input_json(&row, f),
         );
     }
-    Ok(Html(render_form(&state, model, Some(&prefill), true, None)))
+    // #50 slice 2 — editable inline panels under the parent form.
+    // Best-effort: a child-table fetch failure drops the inlines to
+    // empty rather than breaking the whole edit page.
+    let inline_panels = super::inlines::render_form_for_parent(&state.pool, model, pk_value)
+        .await
+        .unwrap_or_default();
+    Ok(Html(super::helpers::render_form_with_inlines(
+        &state,
+        model,
+        Some(&prefill),
+        true,
+        None,
+        inline_panels,
+    )))
 }
 
 pub(crate) async fn update_submit(
@@ -1277,6 +1290,16 @@ pub(crate) async fn update_submit(
     // `tenancy::admin`, so operators get a "who changed what" trail
     // automatically.
     super::audit::emit_admin_audit_diff(&state, model, &pk_raw, before_row.as_ref(), &form).await;
+
+    // #50 slice 2 — process inline FormSet payloads. Best-effort: a
+    // per-row write failure increments `outcome.failed` and is logged
+    // separately, but the parent UPDATE has already committed at this
+    // point. Matches the existing audit-emit posture (no cross-row
+    // transaction wrapping).
+    let parent_pk_for_inlines =
+        forms::parse_pk_string(pk_field, &pk_raw).map_err(AdminError::Form)?;
+    let _ = super::inlines::apply_post(&state.pool, model, parent_pk_for_inlines, &form).await;
+
     let target = post_save_redirect(&state.config.admin_prefix, model.table, &pk_raw, &form);
     Ok(Redirect::to(&target).into_response())
 }

--- a/crates/rustango/tests/admin_inlines_edit_live.rs
+++ b/crates/rustango/tests/admin_inlines_edit_live.rs
@@ -1,0 +1,318 @@
+//! Live test for the editable inline flow (#50 slice 2).
+//!
+//! Spins up two models (`ile_blog` + `ile_blog_post`), registers an
+//! inline with `extra = 2` blank rows, then exercises the round-trip:
+//!
+//! 1. GET the edit page — assert the management form + per-row inputs
+//!    render with prefix-mangled names.
+//! 2. POST a payload that UPDATEs one existing row, DELETEs another,
+//!    and INSERTs a fresh row via one of the blank `extra` slots.
+//! 3. Re-GET and assert all three writes took effect.
+
+#![cfg(feature = "postgres")]
+
+use std::collections::HashMap;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{header, Method, Request, StatusCode};
+use rustango::admin::inlines::InlineKind;
+use rustango::register_admin_inline;
+use rustango::sql::sqlx;
+use rustango::sql::Auto;
+use rustango::Model;
+use tower::ServiceExt;
+
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+#[derive(Model, Debug)]
+#[rustango(table = "ile_blog")]
+#[allow(dead_code)]
+pub struct Blog {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 100)]
+    pub name: String,
+}
+
+#[derive(Model, Debug)]
+#[rustango(table = "ile_blog_post")]
+#[allow(dead_code)]
+pub struct BlogPost {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(fk = "ile_blog", on = "id")]
+    pub blog_id: i64,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 500)]
+    pub body: String,
+}
+
+register_admin_inline!(
+    parent = "ile_blog",
+    child = "ile_blog_post",
+    fk = "blog_id",
+    kind = InlineKind::Tabular,
+    label = "Posts",
+    fields = &["title", "body"],
+    extra = 2,
+);
+
+async fn fresh(pool: &sqlx::PgPool) {
+    for t in ["ile_blog_post", "ile_blog"] {
+        sqlx::query(&format!(r#"DROP TABLE IF EXISTS "{t}" CASCADE"#))
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+    sqlx::query(
+        r#"CREATE TABLE "ile_blog" (
+               id BIGSERIAL PRIMARY KEY,
+               name VARCHAR(100) NOT NULL
+           )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "ile_blog_post" (
+               id BIGSERIAL PRIMARY KEY,
+               blog_id BIGINT NOT NULL REFERENCES "ile_blog"(id),
+               title VARCHAR(200) NOT NULL,
+               body VARCHAR(500) NOT NULL
+           )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+fn urlencode(form: &HashMap<&str, &str>) -> String {
+    let mut out = String::new();
+    for (i, (k, v)) in form.iter().enumerate() {
+        if i > 0 {
+            out.push('&');
+        }
+        out.push_str(&urlencoding::encode(k));
+        out.push('=');
+        out.push_str(&urlencoding::encode(v));
+    }
+    out
+}
+
+#[tokio::test]
+async fn edit_page_round_trips_update_delete_insert_across_inline_rows() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+
+    let mut blog = Blog {
+        id: Auto::default(),
+        name: "Edit Inlines Blog".into(),
+    };
+    blog.insert(&pool).await.unwrap();
+    let blog_id = *blog.id.get().expect("PK assigned");
+
+    let mut post_keep = BlogPost {
+        id: Auto::default(),
+        blog_id,
+        title: "Keep me".into(),
+        body: "original body".into(),
+    };
+    post_keep.insert(&pool).await.unwrap();
+    let keep_id = *post_keep.id.get().expect("PK assigned");
+
+    let mut post_drop = BlogPost {
+        id: Auto::default(),
+        blog_id,
+        title: "Drop me".into(),
+        body: "to be removed".into(),
+    };
+    post_drop.insert(&pool).await.unwrap();
+    let drop_id = *post_drop.id.get().expect("PK assigned");
+
+    // ----- 1. GET edit form -----
+    let app = rustango::admin::router(pool.clone());
+    let req = Request::builder()
+        .uri(format!("/ile_blog/{blog_id}/edit"))
+        .body(Body::empty())
+        .unwrap();
+    let res = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = to_bytes(res.into_body(), 1_000_000).await.unwrap();
+    let html = String::from_utf8(body.to_vec()).unwrap();
+
+    // Management form fields rendered with the child table as prefix.
+    assert!(
+        html.contains(r#"name="ile_blog_post-TOTAL_FORMS""#),
+        "TOTAL_FORMS missing: {html}"
+    );
+    // 2 existing rows + 2 extras = 4 total.
+    assert!(
+        html.contains(r#"value="4""#),
+        "total_forms=4 not present: {html}"
+    );
+    // Prefix-mangled inputs for the first existing row.
+    assert!(
+        html.contains(r#"name="ile_blog_post-0-title""#),
+        "row 0 title input missing: {html}"
+    );
+    // DELETE checkbox on existing rows only.
+    assert!(
+        html.contains(r#"name="ile_blog_post-0-DELETE""#),
+        "row 0 DELETE checkbox missing: {html}"
+    );
+    // No DELETE checkbox on the blank extras (idx 2 + 3).
+    assert!(
+        !html.contains(r#"name="ile_blog_post-2-DELETE""#),
+        "extras shouldn't render DELETE: {html}"
+    );
+    // Hidden PK input round-trips the existing row identity.
+    assert!(
+        html.contains(r#"name="ile_blog_post-0-id""#),
+        "hidden PK input missing on row 0: {html}"
+    );
+
+    // ----- 2. POST edit -----
+    //
+    // Row 0 (keep): change title.
+    // Row 1 (drop): mark DELETE.
+    // Row 2 (extra): INSERT a fresh post.
+    // Row 3 (extra): leave blank — should be a no-op.
+    let mut form: HashMap<&str, &str> = HashMap::new();
+    form.insert("name", "Edit Inlines Blog");
+    form.insert("ile_blog_post-TOTAL_FORMS", "4");
+    form.insert("ile_blog_post-INITIAL_FORMS", "2");
+    form.insert("ile_blog_post-MAX_NUM_FORMS", "");
+
+    let keep_id_s = keep_id.to_string();
+    let drop_id_s = drop_id.to_string();
+    form.insert("ile_blog_post-0-id", keep_id_s.as_str());
+    form.insert("ile_blog_post-0-title", "Renamed keeper");
+    form.insert("ile_blog_post-0-body", "updated body");
+
+    form.insert("ile_blog_post-1-id", drop_id_s.as_str());
+    form.insert("ile_blog_post-1-title", "Drop me");
+    form.insert("ile_blog_post-1-body", "to be removed");
+    form.insert("ile_blog_post-1-DELETE", "on");
+
+    form.insert("ile_blog_post-2-title", "Brand new");
+    form.insert("ile_blog_post-2-body", "freshly inserted");
+
+    // Row 3: intentionally blank — empty extras stay empty.
+
+    let payload = urlencode(&form);
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/ile_blog/{blog_id}"))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(Body::from(payload))
+        .unwrap();
+    let res = app.clone().oneshot(req).await.unwrap();
+    assert!(
+        res.status() == StatusCode::SEE_OTHER
+            || res.status() == StatusCode::FOUND
+            || res.status() == StatusCode::TEMPORARY_REDIRECT,
+        "POST should redirect; got {}",
+        res.status()
+    );
+
+    // ----- 3. Verify the writes via direct SQL -----
+    let rows: Vec<(i64, String, String)> = sqlx::query_as(
+        r#"SELECT id, title, body FROM "ile_blog_post" WHERE blog_id = $1 ORDER BY id"#,
+    )
+    .bind(blog_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let titles: Vec<&str> = rows.iter().map(|r| r.1.as_str()).collect();
+    assert_eq!(
+        rows.len(),
+        2,
+        "expected 2 rows after update+delete+insert, got {:?}",
+        rows
+    );
+    // Kept row got renamed.
+    let kept = rows
+        .iter()
+        .find(|r| r.0 == keep_id)
+        .expect("keeper survived");
+    assert_eq!(kept.1, "Renamed keeper", "UPDATE didn't apply: {kept:?}");
+    assert_eq!(kept.2, "updated body");
+    // Dropped row is gone.
+    assert!(
+        !rows.iter().any(|r| r.0 == drop_id),
+        "DELETE didn't remove drop_id: {rows:?}"
+    );
+    // Inserted row landed with the parent FK.
+    assert!(
+        titles.contains(&"Brand new"),
+        "INSERT didn't add Brand new: titles={titles:?}"
+    );
+}
+
+#[tokio::test]
+async fn edit_page_skips_blank_extra_rows_without_failures() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+
+    let mut blog = Blog {
+        id: Auto::default(),
+        name: "Blank Extras Blog".into(),
+    };
+    blog.insert(&pool).await.unwrap();
+    let blog_id = *blog.id.get().expect("PK assigned");
+
+    let app = rustango::admin::router(pool.clone());
+    let mut form: HashMap<&str, &str> = HashMap::new();
+    form.insert("name", "Blank Extras Blog");
+    form.insert("ile_blog_post-TOTAL_FORMS", "2");
+    form.insert("ile_blog_post-INITIAL_FORMS", "0");
+    form.insert("ile_blog_post-MAX_NUM_FORMS", "");
+    // Both extras blank.
+    form.insert("ile_blog_post-0-title", "");
+    form.insert("ile_blog_post-0-body", "");
+    form.insert("ile_blog_post-1-title", "");
+    form.insert("ile_blog_post-1-body", "");
+
+    let payload = urlencode(&form);
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/ile_blog/{blog_id}"))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(Body::from(payload))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert!(
+        res.status() == StatusCode::SEE_OTHER || res.status() == StatusCode::FOUND,
+        "should redirect even with all-empty extras, got {}",
+        res.status()
+    );
+
+    // Verify no rows were created.
+    let count: (i64,) =
+        sqlx::query_as(r#"SELECT COUNT(*) FROM "ile_blog_post" WHERE blog_id = $1"#)
+            .bind(blog_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(count.0, 0, "blank extras shouldn't have created rows");
+}


### PR DESCRIPTION
## Summary

Closes #50. Slice 2 on top of PR #237 (read-only display). Inlines are now fully editable: existing rows have prefilled inputs + a DELETE checkbox, `extra` blank rows let the operator add new children, and the POST handler routes each row through UPDATE / INSERT / DELETE.

### New surface

\`\`\`rust
register_admin_inline!(
    parent = \"blog_post\",
    child  = \"blog_comment\",
    fk     = \"post_id\",
    kind   = InlineKind::Tabular,
    label  = \"Comments\",
    fields = &[\"body\", \"created_at\"],
    extra  = 2,                     // 2 blank rows for adding new children
);
\`\`\`

The parent's `/__admin/<table>/<pk>/edit` page renders one editable panel per registered inline, complete with Django-shape FormSet management form (`<prefix>-TOTAL_FORMS`, `<prefix>-INITIAL_FORMS`, `<prefix>-MAX_NUM_FORMS`), prefix-mangled `<prefix>-<idx>-<field>` inputs, hidden PK for round-tripping, and a per-row DELETE checkbox on existing rows.

### Dispatch table (per row)

| Submitted shape | Action |
|---|---|
| Hidden PK + `DELETE=on` | `delete_pool` the child row |
| Hidden PK + no DELETE | `update_pool` (FK column always skipped — no reparenting) |
| No PK + any non-empty display field | `insert_pool` with FK pinned to parent's PK |
| Empty extra row | no-op |

### What lands

- `inlines::InlineFormPanel` — editable counterpart of slice 1's `InlinePanel`.
- `inlines::render_form_for_parent(pool, parent_model, parent_pk)` — builds the editable panels, projecting both child PK + display fields.
- `inlines::apply_post(pool, parent_model, parent_pk, form)` — walks every registered inline, slices the FormSet payload via `crate::forms::formset::{total_forms, row_payload}` (already shipped in #49), dispatches per-row writes. Returns `InlineApplyOutcome` with `{ updated, deleted, inserted, failed }` counters.
- `helpers::render_form_with_inlines(...)` — sibling of `render_form` that threads inline panels into the form context.
- `views::edit_form` + `views::update_submit` — wired through.
- `templates/form.html` — new `<section class=\"admin-inline-form\">` rendering with tabular or stacked variant.

### Posture

- **Per-row failure isolation**: a row that fails to validate or write increments `outcome.failed` and is skipped; other rows continue. Matches the existing audit-emit posture — no cross-row transaction wrapping. The parent UPDATE has already committed by the time inline writes run.
- **FK column always skipped on UPDATE**: prevents a malicious POST from reparenting a child row by manually crafting the inline `<prefix>-N-blog_id` input.
- **max_num** is wired through the struct + management form output but not enforced server-side yet — flagged as a follow-up since it adds error-rendering scope that isn't blocking.

### Tests

`tests/admin_inlines_edit_live.rs` — two PG live tests against the `ile_blog` / `ile_blog_post` fixture (`extra = 2`):
- Full round-trip: GET asserts the rendered FormSet shape (management form + prefix-mangled inputs + hidden PK + DELETE on existing rows only); POST mixes UPDATE / DELETE / INSERT / blank-extra; direct SQL verifies all writes landed.
- Empty-extras-only POST: confirms zero rows get created when every extra is blank.

### Stays out of ORM extraction surface

Zero new content in `core/` / `sql/` / `query/` / `migrate/`. The POST handler uses the existing `_pool` family (`insert_pool` / `update_pool` / `delete_pool`) as a consumer.

## Test plan
- [x] \`cargo fmt --all\`
- [x] \`cargo build --no-default-features --features sqlite,tenancy\`
- [x] \`cargo test --workspace --all-features --no-run\`
- [x] \`cargo test --workspace --all-features --lib\` (2330 pass)
- [x] \`cargo test --test admin_inlines_edit_live --all-features\` against live PG (2/2 pass)
- [x] \`cargo test --test admin_inlines_live --all-features\` against live PG — slice 1's read-only tests still pass
- [x] pre-push hook (lib tests + clippy)