### PR TITLE
feat: admin list view renders GFK pair as single clickable target link (closes #241)

### DIFF
--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -23,6 +23,43 @@ use super::render;
 use super::templates::render_with_chrome;
 use super::urls::AppState;
 
+/// Render a single GFK cell — reads `(ct_column, pk_column)` off the
+/// JSON row and emits a clickable target link using the preloaded
+/// ContentType map. Mirrors `contenttypes::render_generic_fk_link`'s
+/// output shape, but synchronous — the caller (list view) batch-loads
+/// every distinct CT touched on the page before entering the per-row
+/// loop, so this helper is hot-path with no further DB I/O. Issue #241.
+fn render_gfk_cell(
+    row: &serde_json::Value,
+    gr: &crate::core::GenericRelation,
+    ct_map: &HashMap<i64, crate::contenttypes::ContentType>,
+) -> String {
+    let ct_id = row
+        .get(gr.ct_column)
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or_default();
+    let object_pk = row
+        .get(gr.pk_column)
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or_default();
+    if ct_id == 0 && object_pk == 0 {
+        return "<em>NULL</em>".to_owned();
+    }
+    let Some(ct) = ct_map.get(&ct_id) else {
+        // CT stale / not seeded — same fallback `render_generic_fk_link` uses.
+        return format!("<em>(ct={ct_id}, pk={object_pk})</em>");
+    };
+    let label = format!("{}.{}", ct.app_label, ct.model_name);
+    let table_esc = render::escape(&ct.table);
+    let label_esc = render::escape(&label);
+    format!(
+        r#"<a href="/{table}/{pk}">{label} #{pk}</a>"#,
+        table = table_esc,
+        pk = object_pk,
+        label = label_esc,
+    )
+}
+
 // ============================================================== INDEX
 
 pub(crate) async fn index(State(state): State<AppState>) -> Html<String> {
@@ -286,13 +323,17 @@ pub(crate) async fn table_view(
     // 2. a registered computed field for this table (the
     //    `register_admin_computed!` path — receives the row and returns
     //    HTML),
+    // 3. a `#[rustango(generic_fk(name = "…"))]` declaration (#241) —
+    //    the `(ct_column, pk_column)` pair collapses into a single
+    //    clickable target link.
     //
-    // Names that match neither are silently dropped. Empty
+    // Names that match none are silently dropped. Empty
     // `list_display` falls back to every scalar field (today's
     // behavior).
     enum DisplayItem {
         Field(&'static FieldSchema),
         Computed(&'static crate::admin::computed_fields::ComputedField),
+        GenericFk(&'static crate::core::GenericRelation),
     }
     let display_items: Vec<DisplayItem> = if admin_cfg.list_display.is_empty() {
         model.scalar_fields().map(DisplayItem::Field).collect()
@@ -301,12 +342,52 @@ pub(crate) async fn table_view(
             .list_display
             .iter()
             .filter_map(|name| {
-                model.field(name).map(DisplayItem::Field).or_else(|| {
-                    crate::admin::computed_fields::find(model.table, name)
-                        .map(DisplayItem::Computed)
-                })
+                model
+                    .field(name)
+                    .map(DisplayItem::Field)
+                    .or_else(|| {
+                        crate::admin::computed_fields::find(model.table, name)
+                            .map(DisplayItem::Computed)
+                    })
+                    .or_else(|| {
+                        model
+                            .generic_relations
+                            .iter()
+                            .find(|gr| gr.name == *name)
+                            .map(DisplayItem::GenericFk)
+                    })
             })
             .collect()
+    };
+
+    // #241 — preload every ContentType referenced by any
+    // `DisplayItem::GenericFk` cell so the row loop renders synchronously
+    // from a `HashMap<ct_id, ContentType>` instead of issuing an async
+    // CT lookup per cell. CT registry is process-cached, so this is
+    // usually a single DB round-trip per distinct ct_id (often just
+    // one for a homogeneous page).
+    let gfk_ct_map: std::collections::HashMap<i64, crate::contenttypes::ContentType> = {
+        use std::collections::HashSet;
+        let mut needed: HashSet<i64> = HashSet::new();
+        for gr in model.generic_relations {
+            if display_items
+                .iter()
+                .any(|i| matches!(i, DisplayItem::GenericFk(g) if g.name == gr.name))
+            {
+                for row in &rows {
+                    if let Some(id) = row.get(gr.ct_column).and_then(serde_json::Value::as_i64) {
+                        needed.insert(id);
+                    }
+                }
+            }
+        }
+        let mut map = std::collections::HashMap::with_capacity(needed.len());
+        for id in needed {
+            if let Ok(Some(ct)) = crate::contenttypes::ContentType::by_id(&state.pool, id).await {
+                map.insert(id, ct);
+            }
+        }
+        map
     };
 
     // Per-column header label. Scalar columns get a `<small>(pk)</small>`
@@ -326,6 +407,7 @@ pub(crate) async fn table_view(
                 DisplayItem::Computed(m) => {
                     render::escape(if m.label.is_empty() { m.name } else { m.label })
                 }
+                DisplayItem::GenericFk(gr) => render::escape(gr.name),
             };
             serde_json::json!({ "label": label })
         })
@@ -346,6 +428,7 @@ pub(crate) async fn table_view(
                 .map(|item| match item {
                     DisplayItem::Field(f) => render_cell_json(row, f, &fk_map),
                     DisplayItem::Computed(m) => (m.render)(row),
+                    DisplayItem::GenericFk(gr) => render_gfk_cell(row, gr, &gfk_ct_map),
                 })
                 .collect();
             let pk =

--- a/crates/rustango/tests/admin_gfk_list_render_live.rs
+++ b/crates/rustango/tests/admin_gfk_list_render_live.rs
@@ -1,0 +1,251 @@
+//! Live test for admin list-view rendering of `#[rustango(generic_fk)]`
+//! columns as clickable target links. Issue #241.
+//!
+//! Seeds a Comment model carrying `(content_type_id, object_pk)`
+//! pointing at two different target tables (Post + Article), declares
+//! `list_display = "body, content_object"`, then GETs the list page
+//! and asserts the `content_object` column renders an `<a href>` for
+//! each row.
+
+#![cfg(feature = "postgres")]
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use rustango::contenttypes;
+use rustango::sql::sqlx;
+use rustango::sql::Auto;
+use rustango::Model;
+use tower::ServiceExt;
+
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gfklist_post")]
+#[rustango(app = "gfklist_blog")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gfklist_article")]
+#[rustango(app = "gfklist_blog")]
+#[allow(dead_code)]
+pub struct Article {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gfklist_comment")]
+#[rustango(app = "gfklist_blog")]
+#[rustango(generic_fk(
+    name = "content_object",
+    ct_column = "content_type_id",
+    pk_column = "object_pk"
+))]
+// list_display includes the GFK relation by its `name` —
+// `content_object` collapses the (ct_column, pk_column) pair into a
+// single clickable cell.
+#[rustango(admin(list_display = "body, content_object"))]
+#[allow(dead_code)]
+pub struct Comment {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub content_type_id: i64,
+    pub object_pk: i64,
+    #[rustango(max_length = 500)]
+    pub body: String,
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    let p = rustango::sql::Pool::from(pool.clone());
+    contenttypes::ensure_seeded(&p).await.unwrap();
+    for t in ["gfklist_comment", "gfklist_article", "gfklist_post"] {
+        sqlx::query(&format!(r#"DROP TABLE IF EXISTS "{t}" CASCADE"#))
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+    sqlx::query(
+        r#"CREATE TABLE "gfklist_post" (
+               id BIGSERIAL PRIMARY KEY,
+               title VARCHAR(200) NOT NULL
+           )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "gfklist_article" (
+               id BIGSERIAL PRIMARY KEY,
+               title VARCHAR(200) NOT NULL
+           )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "gfklist_comment" (
+               id BIGSERIAL PRIMARY KEY,
+               content_type_id BIGINT NOT NULL,
+               object_pk BIGINT NOT NULL,
+               body VARCHAR(500) NOT NULL
+           )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn list_view_renders_gfk_pair_as_single_clickable_cell() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+    let p = rustango::sql::Pool::from(pool.clone());
+
+    // Seed one Post + one Article.
+    let mut post = Post {
+        id: Auto::Unset,
+        title: "Post target".into(),
+    };
+    post.save_pool(&p).await.unwrap();
+    let post_pk = *post.id.get().unwrap();
+
+    let mut article = Article {
+        id: Auto::Unset,
+        title: "Article target".into(),
+    };
+    article.save_pool(&p).await.unwrap();
+    let article_pk = *article.id.get().unwrap();
+
+    // Comment 1 → Post, Comment 2 → Article. Uses the typed setter
+    // from #240 to populate (content_type_id, object_pk).
+    let mut c1 = Comment {
+        id: Auto::Unset,
+        content_type_id: 0,
+        object_pk: 0,
+        body: "comment on post".into(),
+    };
+    c1.set_content_object_for::<Post>(&p, post_pk)
+        .await
+        .unwrap();
+    c1.save_pool(&p).await.unwrap();
+
+    let mut c2 = Comment {
+        id: Auto::Unset,
+        content_type_id: 0,
+        object_pk: 0,
+        body: "comment on article".into(),
+    };
+    c2.set_content_object_for::<Article>(&p, article_pk)
+        .await
+        .unwrap();
+    c2.save_pool(&p).await.unwrap();
+
+    // GET the comment list view.
+    let app = rustango::admin::router(pool.clone());
+    let req = Request::builder()
+        .uri("/gfklist_comment")
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = to_bytes(res.into_body(), 1_000_000).await.unwrap();
+    let html = String::from_utf8(body.to_vec()).unwrap();
+
+    // The `content_object` column header is rendered (matches the
+    // generic_fk `name`).
+    assert!(
+        html.contains(">content_object<"),
+        "GFK column header missing: {html}"
+    );
+    // Comment 1 → Post link.
+    let post_link = format!(r#"<a href="/gfklist_post/{post_pk}">"#);
+    assert!(
+        html.contains(&post_link),
+        "Post link missing for comment 1: looked for `{post_link}` in: {html}"
+    );
+    assert!(
+        html.contains(&format!("gfklist_blog.post #{post_pk}")),
+        "Post label missing: {html}"
+    );
+    // Comment 2 → Article link.
+    let article_link = format!(r#"<a href="/gfklist_article/{article_pk}">"#);
+    assert!(
+        html.contains(&article_link),
+        "Article link missing for comment 2: looked for `{article_link}` in: {html}"
+    );
+    assert!(
+        html.contains(&format!("gfklist_blog.article #{article_pk}")),
+        "Article label missing: {html}"
+    );
+    // Neither the raw ct_column nor the raw pk_column should appear as
+    // standalone header cells — the GFK declaration folds them into
+    // the single `content_object` column.
+    assert!(
+        !html.contains(">content_type_id<"),
+        "raw ct_column header should not render when GFK folds the pair: {html}"
+    );
+    assert!(
+        !html.contains(">object_pk<"),
+        "raw pk_column header should not render when GFK folds the pair: {html}"
+    );
+}
+
+#[tokio::test]
+async fn list_view_falls_back_to_placeholder_on_stale_content_type() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+
+    // Insert a comment carrying a ct_id that's NOT seeded — simulates
+    // "the source app got uninstalled but the comment row stuck around".
+    sqlx::query(
+        r#"INSERT INTO "gfklist_comment" (content_type_id, object_pk, body)
+           VALUES (999999, 42, 'orphan')"#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let app = rustango::admin::router(pool.clone());
+    let req = Request::builder()
+        .uri("/gfklist_comment")
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = to_bytes(res.into_body(), 1_000_000).await.unwrap();
+    let html = String::from_utf8(body.to_vec()).unwrap();
+
+    // Stale CT renders as `(ct=N, pk=M)` placeholder, same shape as
+    // contenttypes::render_generic_fk_link's fallback.
+    assert!(
+        html.contains("(ct=999999, pk=42)"),
+        "stale-CT fallback missing: {html}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #241. Second slice of epic #246 (after #239 + #240 in PR #247).

`#[rustango(generic_fk(name = \"content_object\", ...))]` columns now fold into a single clickable cell in the admin list view when the operator names the GFK in `list_display`.

\`\`\`rust
#[derive(Model)]
#[rustango(generic_fk(name = \"content_object\",
                       ct_column = \"content_type_id\",
                       pk_column = \"object_pk\"))]
#[rustango(admin(list_display = \"body, content_object\"))]
pub struct Comment { /* content_type_id: i64, object_pk: i64, body: String, ... */ }
\`\`\`

Renders one column titled `content_object` whose cells are `<a href=\"/{target_table}/{pk}\">{app_label}.{model_name} #{pk}</a>` — the same shape `contenttypes::render_generic_fk_link` already emits on the detail page. Stale CT falls back to `<em>(ct=N, pk=M)</em>`.

### Implementation

- New `DisplayItem::GenericFk(&GenericRelation)` variant in `admin/views.rs::table_view`. `list_display` name resolution falls through **Field → Computed → GenericFk**; an entry matching `model.generic_relations[].name` becomes a `GenericFk` item.
- Before entering the row loop, walk the page's rows once and collect every distinct `ct_id` referenced by any GFK column. Batch-fetch those `ContentType` rows into a `HashMap<i64, ContentType>` via the already-cached `ContentType::by_id`. Usually 1 DB round-trip per distinct CT (most pages are homogeneous → often just 1 total). Keeps the row loop sync.
- New `render_gfk_cell` synchronous helper reads `(ct_column, pk_column)` off the JSON row and emits the link from the preloaded CT map.

### Stays out of ORM extraction surface

Only `admin/views.rs` + a test file touched.

### Tests

`tests/admin_gfk_list_render_live.rs` — 2 PG live tests:
- **Heterogeneous page** (one comment → Post, one comment → Article): both links render correctly, raw `ct_column` / `pk_column` headers don't appear when the GFK folds the pair.
- **Stale CT** (ct_id with no seeded row): renders the `(ct=N, pk=M)` placeholder fallback.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo build --no-default-features --features sqlite,tenancy`
- [x] `cargo test --workspace --all-features --lib` (2330 pass)
- [x] `cargo test --test admin_gfk_list_render_live --all-features` against live PG (2/2 pass)
- [x] pre-push hook (lib tests + clippy)

## Epic status (#246)

| # | Slice | Status |
|---|---|---|
| #239 | Typed accessor codegen | ✅ PR #247 |
| #240 | Typed setter codegen | ✅ PR #247 |
| #241 | Admin list view: GFK columns as clickable links | ✅ this PR |
| #242 | `register_admin_inline_generic!` read-only | next |
| #243 | `register_admin_inline_generic!` editable | |
| #244 | Generic inline picker UI | |
| #245 | Cookbook chapter | |