### PR TITLE
feat: register_admin_inline_generic! — read-only display of polymorphic children (closes #242, partial #38)

### DIFF
--- a/crates/rustango/src/admin/inlines.rs
+++ b/crates/rustango/src/admin/inlines.rs
@@ -176,6 +176,104 @@ macro_rules! register_admin_inline {
     (@or ; $default:expr) => { $default };
 }
 
+// ============================================================ InlineAdminGeneric (issue #242)
+
+/// One **generic** inline-admin registration. Mirrors [`InlineAdmin`]
+/// but keys the relation on a `(ct_column, pk_column)` pair instead
+/// of a single FK column — Django's `GenericTabularInline` /
+/// `GenericStackedInline` shape.
+///
+/// The child table carries the GFK; the inline appears on the
+/// **parent**'s admin detail page and lists every child row whose
+/// `(content_type_id, object_pk)` matches this parent. Slice 1
+/// (read-only display) is the foundation that #243 will build the
+/// editable / FormSet POST handler on top of.
+pub struct InlineAdminGeneric {
+    /// Parent model's SQL table — must match [`ModelSchema::table`].
+    pub parent_table: &'static str,
+    /// Child model's SQL table — the table carrying the GFK columns.
+    pub child_table: &'static str,
+    /// Child column holding the FK to `rustango_content_types.id`.
+    pub ct_column: &'static str,
+    /// Child column holding the target row's primary key.
+    pub pk_column: &'static str,
+    /// Tabular or stacked render variant.
+    pub kind: InlineKind,
+    /// Panel header. Falls back to the child model's `name`.
+    pub label: &'static str,
+    /// Child fields to render. Empty = every scalar except the GFK
+    /// columns (mirrors `InlineAdmin`'s default).
+    pub fields: &'static [&'static str],
+    /// Blank rows offered for adding new children — honored by the
+    /// editor in #243.
+    pub extra: usize,
+    /// Upper bound on total rows. Wired through to the management
+    /// form; enforced by #243's POST handler.
+    pub max_num: Option<usize>,
+    /// Field names rendered as plain text even in edit mode.
+    pub readonly_fields: &'static [&'static str],
+}
+
+inventory::collect!(InlineAdminGeneric);
+
+/// Every generic inline registered against `parent_table`, in
+/// declaration order.
+#[must_use]
+pub fn generic_for_parent_table(parent_table: &str) -> Vec<&'static InlineAdminGeneric> {
+    inventory::iter::<InlineAdminGeneric>
+        .into_iter()
+        .filter(|i| i.parent_table == parent_table)
+        .collect()
+}
+
+/// Register a generic admin inline. Same shape as
+/// [`register_admin_inline!`] but takes `ct` + `pk` instead of `fk`.
+///
+/// ```ignore
+/// rustango::register_admin_inline_generic!(
+///     parent = "blog_post",     // ModelSchema::table of the parent
+///     child  = "blog_tag",      // ModelSchema::table of the child
+///     ct     = "content_type_id", // child's CT column
+///     pk     = "object_pk",     // child's PK column
+///     kind   = InlineKind::Tabular,
+///     label  = "Tags",
+///     fields = &["name"],
+/// );
+/// ```
+#[macro_export]
+macro_rules! register_admin_inline_generic {
+    (
+        parent = $parent:expr,
+        child = $child:expr,
+        ct = $ct:expr,
+        pk = $pk:expr
+        $(, kind = $kind:expr)?
+        $(, label = $label:expr)?
+        $(, fields = $fields:expr)?
+        $(, extra = $extra:expr)?
+        $(, max_num = $max_num:expr)?
+        $(, readonly_fields = $ro:expr)?
+        $(,)?
+    ) => {
+        $crate::inventory::submit! {
+            $crate::admin::inlines::InlineAdminGeneric {
+                parent_table: $parent,
+                child_table: $child,
+                ct_column: $ct,
+                pk_column: $pk,
+                kind: $crate::register_admin_inline_generic!(@or $($kind)?; $crate::admin::inlines::InlineKind::Tabular),
+                label: $crate::register_admin_inline_generic!(@or $($label)?; ""),
+                fields: $crate::register_admin_inline_generic!(@or $($fields)?; &[]),
+                extra: $crate::register_admin_inline_generic!(@or $($extra)?; 0usize),
+                max_num: $crate::register_admin_inline_generic!(@or $($max_num)?; ::core::option::Option::<usize>::None),
+                readonly_fields: $crate::register_admin_inline_generic!(@or $($ro)?; &[]),
+            }
+        }
+    };
+    (@or $given:expr; $default:expr) => { $given };
+    (@or ; $default:expr) => { $default };
+}
+
 // ============================================================ Render helpers
 
 /// One inline panel ready for the Tera detail template. Built per
@@ -319,6 +417,194 @@ pub async fn render_for_parent(
         });
     }
     Ok(panels)
+}
+
+/// As [`render_for_parent`] but for generic inlines registered via
+/// [`register_admin_inline_generic!`]. Each panel lists every child row
+/// whose `(content_type_id, object_pk)` matches the parent.
+///
+/// Resolves the parent's `ContentType` via the inventory registry +
+/// `ContentType::by_natural_key` (cache-hot after the first call). The
+/// resulting WHERE pins both `ct_column` and `pk_column` on the child.
+///
+/// # Errors
+/// As [`render_for_parent`]. ContentType not seeded yields one
+/// `MissingPrimaryKey` error; the caller (detail view) swallows it
+/// just as it does for regular inlines.
+pub async fn render_generic_for_parent(
+    pool: &Pool,
+    parent_model: &'static ModelSchema,
+    parent_pk: SqlValue,
+) -> Result<Vec<InlinePanel>, ExecError> {
+    let registrations = generic_for_parent_table(parent_model.table);
+    if registrations.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Resolve the parent's ContentType id from the schema. Mirrors
+    // `ContentType::for_model<T>` but parameterized on
+    // `&'static ModelSchema` since the admin view only has the
+    // dyn schema at runtime.
+    let Some(ct_id) = resolve_ct_id_for_schema(pool, parent_model).await? else {
+        // CT not seeded — return empty panels rather than error so the
+        // detail view degrades gracefully (matches the regular-inline
+        // posture).
+        return Ok(Vec::new());
+    };
+    let parent_pk_i64 = match &parent_pk {
+        SqlValue::I64(v) => *v,
+        SqlValue::I32(v) => i64::from(*v),
+        SqlValue::I16(v) => i64::from(*v),
+        // Generic inlines only support integer parent PKs today —
+        // matches the `GenericForeignKey { object_pk: i64 }` shape.
+        _ => return Ok(Vec::new()),
+    };
+
+    let mut panels = Vec::with_capacity(registrations.len());
+    for inline in registrations {
+        let Some(child_model) = find_model_by_table(inline.child_table) else {
+            continue;
+        };
+        if child_model.field_by_column(inline.ct_column).is_none()
+            || child_model.field_by_column(inline.pk_column).is_none()
+        {
+            continue;
+        }
+
+        let display_fields = resolve_render_fields_generic(child_model, inline);
+        let pk_field = child_model.primary_key();
+        let select_fields: Vec<&'static FieldSchema> = match pk_field {
+            Some(pk) if !display_fields.iter().any(|f| f.column == pk.column) => {
+                let mut v = Vec::with_capacity(display_fields.len() + 1);
+                v.push(pk);
+                v.extend_from_slice(&display_fields);
+                v
+            }
+            _ => display_fields.clone(),
+        };
+        let order_pk: Vec<OrderItem> = pk_field
+            .map(|pk| OrderItem::Column {
+                column: pk.column,
+                desc: false,
+                nulls: NullsOrder::Default,
+            })
+            .into_iter()
+            .collect();
+
+        let rows = select_rows_as_json(
+            pool,
+            &SelectQuery {
+                model: child_model,
+                where_clause: WhereExpr::And(vec![
+                    WhereExpr::Predicate(Filter {
+                        column: inline.ct_column,
+                        op: Op::Eq,
+                        value: SqlValue::I64(ct_id),
+                    }),
+                    WhereExpr::Predicate(Filter {
+                        column: inline.pk_column,
+                        op: Op::Eq,
+                        value: SqlValue::I64(parent_pk_i64),
+                    }),
+                ]),
+                search: None,
+                joins: vec![],
+                order_by: order_pk,
+                limit: None,
+                offset: None,
+                lock_mode: None,
+                compound: vec![],
+                projection: None,
+            },
+            &select_fields,
+        )
+        .await?;
+
+        let field_labels = display_fields.iter().map(|f| f.name.to_owned()).collect();
+        let pk_column = pk_field.map(|p| p.column).unwrap_or("id");
+        let rendered_rows: Vec<serde_json::Value> = rows
+            .iter()
+            .map(|row| {
+                let cells: Vec<serde_json::Value> = display_fields
+                    .iter()
+                    .map(|f| {
+                        let raw = row
+                            .get(f.column)
+                            .cloned()
+                            .unwrap_or(serde_json::Value::Null);
+                        serde_json::json!({
+                            "label": f.name,
+                            "value": render_cell_text(&raw),
+                        })
+                    })
+                    .collect();
+                let pk_text = row.get(pk_column).map(stringify_pk).unwrap_or_default();
+                serde_json::json!({
+                    "pk": pk_text,
+                    "cells": cells,
+                })
+            })
+            .collect();
+
+        let label = if inline.label.is_empty() {
+            child_model.name.to_owned()
+        } else {
+            inline.label.to_owned()
+        };
+        let empty = rendered_rows.is_empty();
+
+        panels.push(InlinePanel {
+            label,
+            child_table: child_model.table.to_owned(),
+            kind: match inline.kind {
+                InlineKind::Tabular => "tabular".to_owned(),
+                InlineKind::Stacked => "stacked".to_owned(),
+            },
+            field_labels,
+            rows: rendered_rows,
+            empty,
+        });
+    }
+    Ok(panels)
+}
+
+/// As [`resolve_render_fields`] but for generic inlines — excludes
+/// both `ct_column` and `pk_column` from the default display field
+/// list since they're implicit on a generic-inline panel.
+fn resolve_render_fields_generic(
+    child_model: &'static ModelSchema,
+    inline: &InlineAdminGeneric,
+) -> Vec<&'static FieldSchema> {
+    if inline.fields.is_empty() {
+        return child_model
+            .scalar_fields()
+            .filter(|f| f.column != inline.ct_column && f.column != inline.pk_column)
+            .collect();
+    }
+    inline
+        .fields
+        .iter()
+        .filter_map(|name| child_model.field(name))
+        .collect()
+}
+
+/// Look up the ContentType id for `parent_model`. Mirrors
+/// `ContentType::for_model<T>`'s logic but parameterized on
+/// `&'static ModelSchema` so it works from admin code that only sees
+/// the schema at runtime.
+async fn resolve_ct_id_for_schema(
+    pool: &Pool,
+    schema: &'static ModelSchema,
+) -> Result<Option<i64>, ExecError> {
+    let entry = inventory::iter::<ModelEntry>
+        .into_iter()
+        .find(|e| e.schema.table == schema.table);
+    let Some(entry) = entry else {
+        return Ok(None);
+    };
+    let app = entry.resolved_app_label().unwrap_or("project");
+    let name = schema.name.to_ascii_lowercase();
+    let ct = crate::contenttypes::ContentType::by_natural_key(pool, app, &name).await?;
+    Ok(ct.and_then(|c| c.id.get().copied()))
 }
 
 /// Walk the model registry for a schema whose `table` matches.

--- a/crates/rustango/src/admin/mod.rs
+++ b/crates/rustango/src/admin/mod.rs
@@ -58,5 +58,7 @@ mod views;
 pub use auth::protect_with_basic_auth;
 pub use computed_fields::{ComputedField, ComputedFieldRenderFn};
 pub use errors::AdminError;
-pub use inlines::{InlineAdmin, InlineApplyOutcome, InlineFormPanel, InlineKind, InlinePanel};
+pub use inlines::{
+    InlineAdmin, InlineAdminGeneric, InlineApplyOutcome, InlineFormPanel, InlineKind, InlinePanel,
+};
 pub use urls::{router, AdminActionFn, AdminActionFuture, Builder};

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -1022,17 +1022,21 @@ pub(crate) async fn detail_view(
     // a fetch error on one panel (e.g. the child table doesn't exist
     // yet on this tenant) drops the panels list to empty rather than
     // taking down the whole detail page.
-    let inline_panels_ctx: Vec<serde_json::Value> =
-        super::inlines::render_for_parent(&state.pool, model, pk_value)
-            .await
-            .ok()
-            .map(|panels| {
-                panels
-                    .into_iter()
-                    .map(|p| serde_json::to_value(p).unwrap_or(serde_json::Value::Null))
-                    .collect()
-            })
-            .unwrap_or_default();
+    //
+    // #242 — generic (ContentType-keyed) inlines are appended after the
+    // regular FK inlines, in registration order. Mirrors Django's
+    // `GenericTabularInline` shape.
+    let mut inline_panels = super::inlines::render_for_parent(&state.pool, model, pk_value.clone())
+        .await
+        .unwrap_or_default();
+    let generic_panels = super::inlines::render_generic_for_parent(&state.pool, model, pk_value)
+        .await
+        .unwrap_or_default();
+    inline_panels.extend(generic_panels);
+    let inline_panels_ctx: Vec<serde_json::Value> = inline_panels
+        .into_iter()
+        .map(|p| serde_json::to_value(p).unwrap_or(serde_json::Value::Null))
+        .collect();
 
     // v0.12.2: Audit trail panel for this row. Best-effort — if the
     // audit table doesn't exist yet (project hasn't called

--- a/crates/rustango/tests/admin_inline_generic_live.rs
+++ b/crates/rustango/tests/admin_inline_generic_live.rs
@@ -1,0 +1,237 @@
+//! Live test for `register_admin_inline_generic!` — read-only display
+//! of polymorphic children on the parent admin detail page.
+//! Issue #242 (slice 3 of epic #246).
+//!
+//! Mirrors the regular-inline test in `admin_inlines_live.rs` (#50 slice 1),
+//! but the child carries `(content_type_id, object_pk)` columns instead
+//! of a typed FK, so the WHERE walks ContentType.
+
+#![cfg(feature = "postgres")]
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use rustango::admin::inlines::InlineKind;
+use rustango::contenttypes;
+use rustango::register_admin_inline_generic;
+use rustango::sql::sqlx;
+use rustango::sql::Auto;
+use rustango::Model;
+use tower::ServiceExt;
+
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gig_post")]
+#[rustango(app = "gig_blog")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gig_tag")]
+#[rustango(app = "gig_blog")]
+#[rustango(generic_fk(
+    name = "content_object",
+    ct_column = "content_type_id",
+    pk_column = "object_pk"
+))]
+#[allow(dead_code)]
+pub struct Tag {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub content_type_id: i64,
+    pub object_pk: i64,
+    #[rustango(max_length = 40)]
+    pub name: String,
+}
+
+register_admin_inline_generic!(
+    parent = "gig_post",
+    child = "gig_tag",
+    ct = "content_type_id",
+    pk = "object_pk",
+    kind = InlineKind::Tabular,
+    label = "Tags",
+    fields = &["name"],
+);
+
+async fn fresh(pool: &sqlx::PgPool) {
+    let p = rustango::sql::Pool::from(pool.clone());
+    contenttypes::ensure_seeded(&p).await.unwrap();
+    for t in ["gig_tag", "gig_post"] {
+        sqlx::query(&format!(r#"DROP TABLE IF EXISTS "{t}" CASCADE"#))
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+    sqlx::query(
+        r#"CREATE TABLE "gig_post" (
+               id BIGSERIAL PRIMARY KEY,
+               title VARCHAR(200) NOT NULL
+           )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "gig_tag" (
+               id BIGSERIAL PRIMARY KEY,
+               content_type_id BIGINT NOT NULL,
+               object_pk BIGINT NOT NULL,
+               name VARCHAR(40) NOT NULL
+           )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn parent_detail_renders_generic_inline_panel_with_child_rows() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+    let p = rustango::sql::Pool::from(pool.clone());
+
+    let mut post = Post {
+        id: Auto::Unset,
+        title: "Tagged Post".into(),
+    };
+    post.save_pool(&p).await.unwrap();
+    let post_pk = *post.id.get().unwrap();
+
+    // Attach two tags to the post via the typed setter (#240).
+    let mut tag_a = Tag {
+        id: Auto::Unset,
+        content_type_id: 0,
+        object_pk: 0,
+        name: "rust".into(),
+    };
+    tag_a
+        .set_content_object_for::<Post>(&p, post_pk)
+        .await
+        .unwrap();
+    tag_a.save_pool(&p).await.unwrap();
+
+    let mut tag_b = Tag {
+        id: Auto::Unset,
+        content_type_id: 0,
+        object_pk: 0,
+        name: "django-parity".into(),
+    };
+    tag_b
+        .set_content_object_for::<Post>(&p, post_pk)
+        .await
+        .unwrap();
+    tag_b.save_pool(&p).await.unwrap();
+
+    // Also attach a tag to a different Post — must NOT appear in the
+    // first post's panel.
+    let mut other_post = Post {
+        id: Auto::Unset,
+        title: "Other".into(),
+    };
+    other_post.save_pool(&p).await.unwrap();
+    let other_pk = *other_post.id.get().unwrap();
+    let mut tag_c = Tag {
+        id: Auto::Unset,
+        content_type_id: 0,
+        object_pk: 0,
+        name: "other-tag".into(),
+    };
+    tag_c
+        .set_content_object_for::<Post>(&p, other_pk)
+        .await
+        .unwrap();
+    tag_c.save_pool(&p).await.unwrap();
+
+    // GET the parent detail page.
+    let app = rustango::admin::router(pool.clone());
+    let req = Request::builder()
+        .uri(format!("/gig_post/{post_pk}"))
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = to_bytes(res.into_body(), 1_000_000).await.unwrap();
+    let html = String::from_utf8(body.to_vec()).unwrap();
+
+    // Panel header rendered with the inline's `label`.
+    assert!(
+        html.contains("Tags"),
+        "generic-inline panel header missing: {html}"
+    );
+    assert!(
+        html.contains("class=\"inline-table\""),
+        "tabular variant didn't render its <table>: {html}"
+    );
+    // Both this-post tags visible.
+    assert!(html.contains("rust"), "first tag missing: {html}");
+    assert!(html.contains("django-parity"), "second tag missing: {html}");
+    // The other-post tag must NOT appear — the WHERE pinned both
+    // content_type_id and object_pk to this post.
+    assert!(
+        !html.contains("other-tag"),
+        "other-post's tag should not appear: {html}"
+    );
+    // Edit-link target is the child admin route.
+    assert!(
+        html.contains("/gig_tag/"),
+        "row link should point at child admin route: {html}"
+    );
+}
+
+#[tokio::test]
+async fn parent_detail_renders_empty_state_when_no_generic_children() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+    let p = rustango::sql::Pool::from(pool.clone());
+
+    let mut post = Post {
+        id: Auto::Unset,
+        title: "No tags here".into(),
+    };
+    post.save_pool(&p).await.unwrap();
+    let post_pk = *post.id.get().unwrap();
+
+    let app = rustango::admin::router(pool.clone());
+    let req = Request::builder()
+        .uri(format!("/gig_post/{post_pk}"))
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = to_bytes(res.into_body(), 1_000_000).await.unwrap();
+    let html = String::from_utf8(body.to_vec()).unwrap();
+    assert!(
+        html.contains("Tags"),
+        "panel header should still render: {html}"
+    );
+    assert!(
+        html.contains("No related rows"),
+        "panel should show empty-state when no generic children: {html}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #242. Third slice of epic #246. Generic variant of `register_admin_inline!` (#50, PR #237) — children matched by `(content_type_id, object_pk)` instead of a single FK column. Read-only display in this slice; #243 will add the editable / FormSet POST handler on top.

\`\`\`rust
rustango::register_admin_inline_generic!(
    parent = \"blog_post\",       // ModelSchema::table of the parent
    child  = \"blog_tag\",        // ModelSchema::table of the child
    ct     = \"content_type_id\", // child's CT column
    pk     = \"object_pk\",       // child's PK column
    kind   = InlineKind::Tabular,
    label  = \"Tags\",
    fields = &[\"name\"],
);
\`\`\`

The parent's `/__admin/<table>/<pk>` page renders regular `InlineAdmin` panels first, then `InlineAdminGeneric` panels — both reuse the existing `_inline_panels.html` template.

### Implementation

- New `InlineAdminGeneric` struct + `inventory::collect!` + `register_admin_inline_generic!` macro. Mirrors `InlineAdmin` shape but with `ct_column` / `pk_column` instead of `fk_column`. Every Django `InlineModelAdmin` knob (`extra`, `max_num`, `readonly_fields`) carried through the struct so #243 can pick them up without struct churn.
- `inlines::render_generic_for_parent(pool, parent_model, parent_pk)` — resolves the parent's ContentType id via a new internal `resolve_ct_id_for_schema` helper (parameterized on `&'static ModelSchema` since admin code only has the dyn schema). Builds a `SelectQuery` whose WHERE pins both `ct_column = parent_ct_id` AND `pk_column = parent_pk` on the child.
- `resolve_render_fields_generic` excludes both polymorphic columns from the default display list (mirrors how the regular variant excludes the FK column).
- `views::detail_view` concatenates `render_for_parent` panels with `render_generic_for_parent` panels in registration order. Stale CT degrades gracefully → returns empty rather than failing the whole page.

### Stays out of ORM extraction surface

Only `admin/inlines.rs`, `admin/mod.rs`, `admin/views.rs`, and a test file touched. The CT lookup helper consumes `crate::contenttypes::ContentType::by_natural_key` which already shipped.

### Tests

`tests/admin_inline_generic_live.rs` — 2 PG live tests:
- Two tags attached to one Post via `set_content_object_for::<Post>` (typed setter from #240, PR #247) both render in the panel; a third tag attached to a *different* Post does NOT appear (WHERE pins both columns correctly).
- Empty-state still renders the panel header + \"No related rows\" sentinel.

## Test plan
- [x] \`cargo fmt --all\`
- [x] \`cargo build --no-default-features --features sqlite,tenancy\`
- [x] \`cargo test --workspace --all-features --lib\` (2330 pass)
- [x] \`cargo test --test admin_inline_generic_live --all-features\` against live PG (2/2 pass)
- [x] pre-push hook (lib tests + clippy)

## Epic status (#246)

| # | Slice | Status |
|---|---|---|
| #239 | Typed accessor codegen | ✅ PR #247 |
| #240 | Typed setter codegen | ✅ PR #247 |
| #241 | Admin list view: GFK columns as clickable links | ✅ PR #248 |
| #242 | \`register_admin_inline_generic!\` read-only | ✅ this PR (closes #38 read-only half) |
| #243 | \`register_admin_inline_generic!\` editable | next |
| #244 | Generic inline picker UI | |
| #245 | Cookbook chapter | |