### PR TITLE
feat: register_admin_inline_generic! editable + FormSet POST (closes #243, closes #38)

### DIFF
--- a/crates/rustango/src/admin/inlines.rs
+++ b/crates/rustango/src/admin/inlines.rs
@@ -1148,6 +1148,414 @@ fn build_assignments(
     Ok(out)
 }
 
+// ============================================================ Editable generic rendering (issue #243)
+
+/// As [`render_form_for_parent`] but for generic inlines (#243).
+/// Mirrors slice 2's editable shape — hidden child PK + DELETE box
+/// on existing rows, `extra` blank rows below — except the WHERE
+/// uses the parent's ContentType id + PK pair.
+///
+/// # Errors
+/// As [`render_generic_for_parent`].
+pub async fn render_form_generic_for_parent(
+    pool: &Pool,
+    parent_model: &'static ModelSchema,
+    parent_pk: SqlValue,
+) -> Result<Vec<InlineFormPanel>, ExecError> {
+    let registrations = generic_for_parent_table(parent_model.table);
+    if registrations.is_empty() {
+        return Ok(Vec::new());
+    }
+    let Some(ct_id) = resolve_ct_id_for_schema(pool, parent_model).await? else {
+        return Ok(Vec::new());
+    };
+    let parent_pk_i64 = match &parent_pk {
+        SqlValue::I64(v) => *v,
+        SqlValue::I32(v) => i64::from(*v),
+        SqlValue::I16(v) => i64::from(*v),
+        _ => return Ok(Vec::new()),
+    };
+
+    let mut panels = Vec::with_capacity(registrations.len());
+    for inline in registrations {
+        let Some(child_model) = find_model_by_table(inline.child_table) else {
+            continue;
+        };
+        if child_model.field_by_column(inline.ct_column).is_none()
+            || child_model.field_by_column(inline.pk_column).is_none()
+        {
+            continue;
+        }
+
+        let display_fields = resolve_render_fields_generic(child_model, inline);
+        let pk_field = child_model.primary_key();
+        let select_fields: Vec<&'static FieldSchema> = match pk_field {
+            Some(pk) if !display_fields.iter().any(|f| f.column == pk.column) => {
+                let mut v = Vec::with_capacity(display_fields.len() + 1);
+                v.push(pk);
+                v.extend_from_slice(&display_fields);
+                v
+            }
+            _ => display_fields.clone(),
+        };
+        let order_pk: Vec<OrderItem> = pk_field
+            .map(|pk| OrderItem::Column {
+                column: pk.column,
+                desc: false,
+                nulls: NullsOrder::Default,
+            })
+            .into_iter()
+            .collect();
+
+        let rows = select_rows_as_json(
+            pool,
+            &SelectQuery {
+                model: child_model,
+                where_clause: WhereExpr::And(vec![
+                    WhereExpr::Predicate(Filter {
+                        column: inline.ct_column,
+                        op: Op::Eq,
+                        value: SqlValue::I64(ct_id),
+                    }),
+                    WhereExpr::Predicate(Filter {
+                        column: inline.pk_column,
+                        op: Op::Eq,
+                        value: SqlValue::I64(parent_pk_i64),
+                    }),
+                ]),
+                search: None,
+                joins: vec![],
+                order_by: order_pk,
+                limit: None,
+                offset: None,
+                lock_mode: None,
+                compound: vec![],
+                projection: None,
+            },
+            &select_fields,
+        )
+        .await?;
+
+        let prefix = child_model.table.to_owned();
+        let initial_forms = rows.len();
+        let total_forms = initial_forms + inline.extra;
+        let pk_column = pk_field.map(|p| p.column).unwrap_or("id");
+
+        let mut field_labels: Vec<String> =
+            display_fields.iter().map(|f| f.name.to_owned()).collect();
+        if initial_forms > 0 {
+            field_labels.push("Delete".to_owned());
+        }
+
+        let mut rendered_rows: Vec<serde_json::Value> = Vec::with_capacity(total_forms);
+        for (idx, row) in rows.iter().enumerate() {
+            let pk_text = row.get(pk_column).map(stringify_pk).unwrap_or_default();
+            let cells: Vec<serde_json::Value> = display_fields
+                .iter()
+                .map(|f| {
+                    let raw_str = row
+                        .get(f.column)
+                        .map(value_as_form_string)
+                        .unwrap_or_default();
+                    let input_html = render_prefixed_input(f, &raw_str, &prefix, idx, false);
+                    serde_json::json!({
+                        "label": f.name,
+                        "input_html": input_html,
+                    })
+                })
+                .collect();
+            let pk_field_name = pk_field.map(|p| p.name).unwrap_or("id");
+            let hidden_pk = format!(
+                r#"<input type="hidden" name="{p}-{i}-{n}" value="{v}">"#,
+                p = html_escape(&prefix),
+                i = idx,
+                n = html_escape(pk_field_name),
+                v = html_escape(&pk_text),
+            );
+            let delete_input_html = format!(
+                r#"<input type="checkbox" name="{p}-{i}-DELETE" value="on">"#,
+                p = html_escape(&prefix),
+                i = idx,
+            );
+            rendered_rows.push(serde_json::json!({
+                "pk": pk_text,
+                "cells": cells,
+                "hidden_pk": hidden_pk,
+                "delete_input_html": delete_input_html,
+            }));
+        }
+        for idx in initial_forms..total_forms {
+            let cells: Vec<serde_json::Value> = display_fields
+                .iter()
+                .map(|f| {
+                    let input_html = render_prefixed_input(f, "", &prefix, idx, false);
+                    serde_json::json!({
+                        "label": f.name,
+                        "input_html": input_html,
+                    })
+                })
+                .collect();
+            rendered_rows.push(serde_json::json!({
+                "pk": "",
+                "cells": cells,
+                "hidden_pk": "",
+                "delete_input_html": "",
+            }));
+        }
+
+        let label = if inline.label.is_empty() {
+            child_model.name.to_owned()
+        } else {
+            inline.label.to_owned()
+        };
+
+        panels.push(InlineFormPanel {
+            label,
+            child_table: child_model.table.to_owned(),
+            kind: match inline.kind {
+                InlineKind::Tabular => "tabular".to_owned(),
+                InlineKind::Stacked => "stacked".to_owned(),
+            },
+            prefix,
+            total_forms,
+            initial_forms,
+            max_num: inline.max_num,
+            field_labels,
+            rows: rendered_rows,
+        });
+    }
+    Ok(panels)
+}
+
+/// Process every generic-inline FormSet payload on a parent edit POST.
+/// Same dispatch rules as [`apply_post`] but pins BOTH
+/// `ct_column = parent_ct_id` AND `pk_column = parent_pk` on INSERT
+/// and skips BOTH on UPDATE (so a malicious POST can't reparent a
+/// generic-inline row to a different `(content_type, target)` pair).
+///
+/// # Errors
+/// As [`apply_post`].
+pub async fn apply_post_generic(
+    pool: &Pool,
+    parent_model: &'static ModelSchema,
+    parent_pk: SqlValue,
+    form: &std::collections::HashMap<String, String>,
+) -> Result<InlineApplyOutcome, ExecError> {
+    let registrations = generic_for_parent_table(parent_model.table);
+    if registrations.is_empty() {
+        return Ok(InlineApplyOutcome::default());
+    }
+    let Some(ct_id) = resolve_ct_id_for_schema(pool, parent_model).await? else {
+        return Ok(InlineApplyOutcome::default());
+    };
+    let parent_pk_i64 = match &parent_pk {
+        SqlValue::I64(v) => *v,
+        SqlValue::I32(v) => i64::from(*v),
+        SqlValue::I16(v) => i64::from(*v),
+        _ => return Ok(InlineApplyOutcome::default()),
+    };
+
+    let mut total = InlineApplyOutcome::default();
+    for inline in registrations {
+        let Some(child_model) = find_model_by_table(inline.child_table) else {
+            continue;
+        };
+        if child_model.field_by_column(inline.ct_column).is_none()
+            || child_model.field_by_column(inline.pk_column).is_none()
+        {
+            continue;
+        }
+        let prefix = child_model.table;
+        let total_forms = match crate::forms::formset::total_forms(form, prefix) {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        let outcome = apply_one_inline_generic(
+            pool,
+            child_model,
+            inline,
+            prefix,
+            total_forms,
+            ct_id,
+            parent_pk_i64,
+            form,
+        )
+        .await;
+        total.add(outcome);
+    }
+    Ok(total)
+}
+
+async fn apply_one_inline_generic(
+    pool: &Pool,
+    child_model: &'static ModelSchema,
+    inline: &InlineAdminGeneric,
+    prefix: &str,
+    total_forms: usize,
+    parent_ct_id: i64,
+    parent_pk_i64: i64,
+    form: &std::collections::HashMap<String, String>,
+) -> InlineApplyOutcome {
+    let mut outcome = InlineApplyOutcome::default();
+    let pk_field = match child_model.primary_key() {
+        Some(p) => p,
+        None => return outcome,
+    };
+    let display_fields = resolve_render_fields_generic(child_model, inline);
+
+    for idx in 0..total_forms {
+        let row = crate::forms::formset::row_payload(form, prefix, idx);
+        let raw_pk = row.get(pk_field.name).cloned().unwrap_or_default();
+        let has_pk = !raw_pk.trim().is_empty();
+        let delete_flag = row
+            .get("DELETE")
+            .map(|s| s == "on" || s == "true" || s == "1")
+            .unwrap_or(false);
+
+        // Existing row + DELETE → DELETE child row.
+        if has_pk && delete_flag {
+            let pk_val = match crate::forms::parse_pk_string(pk_field, &raw_pk) {
+                Ok(v) => v,
+                Err(_) => {
+                    outcome.failed += 1;
+                    continue;
+                }
+            };
+            let q = crate::core::DeleteQuery {
+                model: child_model,
+                where_clause: WhereExpr::Predicate(Filter {
+                    column: pk_field.column,
+                    op: Op::Eq,
+                    value: pk_val,
+                }),
+            };
+            match crate::sql::delete_pool(pool, &q).await {
+                Ok(_) => outcome.deleted += 1,
+                Err(_) => outcome.failed += 1,
+            }
+            continue;
+        }
+
+        // Existing row, no DELETE → UPDATE child row, skipping both
+        // polymorphic columns so the relationship stays pinned to
+        // this parent.
+        if has_pk {
+            let pk_val = match crate::forms::parse_pk_string(pk_field, &raw_pk) {
+                Ok(v) => v,
+                Err(_) => {
+                    outcome.failed += 1;
+                    continue;
+                }
+            };
+            let assignments = match build_assignments_generic(
+                &display_fields,
+                &row,
+                inline.ct_column,
+                inline.pk_column,
+            ) {
+                Ok(a) => a,
+                Err(_) => {
+                    outcome.failed += 1;
+                    continue;
+                }
+            };
+            if assignments.is_empty() {
+                continue;
+            }
+            let q = crate::core::UpdateQuery {
+                model: child_model,
+                set: assignments,
+                where_clause: WhereExpr::Predicate(Filter {
+                    column: pk_field.column,
+                    op: Op::Eq,
+                    value: pk_val,
+                }),
+            };
+            match crate::sql::update_pool(pool, &q).await {
+                Ok(_) => outcome.updated += 1,
+                Err(_) => outcome.failed += 1,
+            }
+            continue;
+        }
+
+        // No PK → INSERT, but only when the operator typed something.
+        let row_nonempty = display_fields.iter().any(|f| {
+            row.get(f.name)
+                .map(|s| !s.trim().is_empty())
+                .unwrap_or(false)
+        });
+        if !row_nonempty {
+            continue;
+        }
+        let assignments = match build_assignments_generic(
+            &display_fields,
+            &row,
+            inline.ct_column,
+            inline.pk_column,
+        ) {
+            Ok(a) => a,
+            Err(_) => {
+                outcome.failed += 1;
+                continue;
+            }
+        };
+        // Pin BOTH polymorphic columns to the parent's CT id + PK.
+        let mut columns: Vec<&'static str> = assignments.iter().map(|a| a.column).collect();
+        let mut values: Vec<SqlValue> = assignments
+            .into_iter()
+            .map(|a| match a.value {
+                crate::core::Expr::Literal(v) => v,
+                _ => SqlValue::Null,
+            })
+            .collect();
+        if !columns.contains(&inline.ct_column) {
+            columns.push(inline.ct_column);
+            values.push(SqlValue::I64(parent_ct_id));
+        }
+        if !columns.contains(&inline.pk_column) {
+            columns.push(inline.pk_column);
+            values.push(SqlValue::I64(parent_pk_i64));
+        }
+        let q = crate::core::InsertQuery {
+            model: child_model,
+            columns,
+            values,
+            returning: vec![],
+            on_conflict: None,
+        };
+        match crate::sql::insert_pool(pool, &q).await {
+            Ok(_) => outcome.inserted += 1,
+            Err(_) => outcome.failed += 1,
+        }
+    }
+
+    outcome
+}
+
+/// As [`build_assignments`] but skips BOTH polymorphic columns so an
+/// UPDATE / INSERT can't smuggle in a different `(content_type_id,
+/// object_pk)` pair through the inline FormSet payload.
+fn build_assignments_generic(
+    display_fields: &[&'static FieldSchema],
+    row: &std::collections::HashMap<String, String>,
+    ct_column: &str,
+    pk_column: &str,
+) -> Result<Vec<crate::core::Assignment>, crate::forms::FormError> {
+    let mut out = Vec::with_capacity(display_fields.len());
+    for f in display_fields {
+        if f.column == ct_column || f.column == pk_column {
+            continue;
+        }
+        let raw = row.get(f.name).map(String::as_str);
+        let value = crate::forms::parse_form_value(f, raw)?;
+        out.push(crate::core::Assignment {
+            column: f.column,
+            value: crate::core::Expr::Literal(value),
+        });
+    }
+    Ok(out)
+}
+
 /// Minimal HTML-escape — pre-rendered cells are dropped into the
 /// detail template with `| safe` so untrusted strings need escaping
 /// here. Mirrors the helper the list view uses.

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -1270,9 +1270,18 @@ pub(crate) async fn edit_form(
     // #50 slice 2 — editable inline panels under the parent form.
     // Best-effort: a child-table fetch failure drops the inlines to
     // empty rather than breaking the whole edit page.
-    let inline_panels = super::inlines::render_form_for_parent(&state.pool, model, pk_value)
-        .await
-        .unwrap_or_default();
+    //
+    // #243 — editable generic inline panels are appended after the
+    // regular ones, in registration order.
+    let mut inline_panels =
+        super::inlines::render_form_for_parent(&state.pool, model, pk_value.clone())
+            .await
+            .unwrap_or_default();
+    let generic_panels =
+        super::inlines::render_form_generic_for_parent(&state.pool, model, pk_value)
+            .await
+            .unwrap_or_default();
+    inline_panels.extend(generic_panels);
     Ok(Html(super::helpers::render_form_with_inlines(
         &state,
         model,
@@ -1383,9 +1392,15 @@ pub(crate) async fn update_submit(
     // separately, but the parent UPDATE has already committed at this
     // point. Matches the existing audit-emit posture (no cross-row
     // transaction wrapping).
+    //
+    // #243 — generic (ContentType-keyed) inline payloads are processed
+    // after the regular ones with the same per-row dispatch shape.
     let parent_pk_for_inlines =
         forms::parse_pk_string(pk_field, &pk_raw).map_err(AdminError::Form)?;
-    let _ = super::inlines::apply_post(&state.pool, model, parent_pk_for_inlines, &form).await;
+    let _ =
+        super::inlines::apply_post(&state.pool, model, parent_pk_for_inlines.clone(), &form).await;
+    let _ =
+        super::inlines::apply_post_generic(&state.pool, model, parent_pk_for_inlines, &form).await;
 
     let target = post_save_redirect(&state.config.admin_prefix, model.table, &pk_raw, &form);
     Ok(Redirect::to(&target).into_response())

--- a/crates/rustango/tests/admin_inline_generic_edit_live.rs
+++ b/crates/rustango/tests/admin_inline_generic_edit_live.rs
@@ -1,0 +1,365 @@
+//! Live test for the editable generic-inline flow (#243).
+//!
+//! Mirrors `admin_inlines_edit_live.rs` (PR #238) but uses
+//! `register_admin_inline_generic!` so the WHERE pins both
+//! `(content_type_id, object_pk)` instead of one FK column.
+//!
+//! Exercises one full round-trip: GET edit page → POST with mixed
+//! UPDATE + DELETE + INSERT + blank-extra → verify via direct SQL
+//! that the writes landed.
+
+#![cfg(feature = "postgres")]
+
+use std::collections::HashMap;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{header, Method, Request, StatusCode};
+use rustango::admin::inlines::InlineKind;
+use rustango::contenttypes;
+use rustango::register_admin_inline_generic;
+use rustango::sql::sqlx;
+use rustango::sql::Auto;
+use rustango::Model;
+use tower::ServiceExt;
+
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gige_post")]
+#[rustango(app = "gige_blog")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gige_tag")]
+#[rustango(app = "gige_blog")]
+#[rustango(generic_fk(
+    name = "content_object",
+    ct_column = "content_type_id",
+    pk_column = "object_pk"
+))]
+#[allow(dead_code)]
+pub struct Tag {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub content_type_id: i64,
+    pub object_pk: i64,
+    #[rustango(max_length = 40)]
+    pub name: String,
+}
+
+register_admin_inline_generic!(
+    parent = "gige_post",
+    child = "gige_tag",
+    ct = "content_type_id",
+    pk = "object_pk",
+    kind = InlineKind::Tabular,
+    label = "Tags",
+    fields = &["name"],
+    extra = 2,
+);
+
+async fn fresh(pool: &sqlx::PgPool) {
+    let p = rustango::sql::Pool::from(pool.clone());
+    contenttypes::ensure_seeded(&p).await.unwrap();
+    for t in ["gige_tag", "gige_post"] {
+        sqlx::query(&format!(r#"DROP TABLE IF EXISTS "{t}" CASCADE"#))
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+    sqlx::query(
+        r#"CREATE TABLE "gige_post" (
+               id BIGSERIAL PRIMARY KEY,
+               title VARCHAR(200) NOT NULL
+           )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "gige_tag" (
+               id BIGSERIAL PRIMARY KEY,
+               content_type_id BIGINT NOT NULL,
+               object_pk BIGINT NOT NULL,
+               name VARCHAR(40) NOT NULL
+           )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+fn urlencode(form: &HashMap<&str, &str>) -> String {
+    let mut out = String::new();
+    for (i, (k, v)) in form.iter().enumerate() {
+        if i > 0 {
+            out.push('&');
+        }
+        out.push_str(&urlencoding::encode(k));
+        out.push('=');
+        out.push_str(&urlencoding::encode(v));
+    }
+    out
+}
+
+#[tokio::test]
+async fn edit_page_round_trips_generic_inline_update_delete_insert() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+    let p = rustango::sql::Pool::from(pool.clone());
+
+    // Seed one Post + two attached tags.
+    let mut post = Post {
+        id: Auto::Unset,
+        title: "Tagged".into(),
+    };
+    post.save_pool(&p).await.unwrap();
+    let post_pk = *post.id.get().unwrap();
+
+    let mut tag_keep = Tag {
+        id: Auto::Unset,
+        content_type_id: 0,
+        object_pk: 0,
+        name: "keep".into(),
+    };
+    tag_keep
+        .set_content_object_for::<Post>(&p, post_pk)
+        .await
+        .unwrap();
+    tag_keep.save_pool(&p).await.unwrap();
+    let keep_id = *tag_keep.id.get().unwrap();
+
+    let mut tag_drop = Tag {
+        id: Auto::Unset,
+        content_type_id: 0,
+        object_pk: 0,
+        name: "drop".into(),
+    };
+    tag_drop
+        .set_content_object_for::<Post>(&p, post_pk)
+        .await
+        .unwrap();
+    tag_drop.save_pool(&p).await.unwrap();
+    let drop_id = *tag_drop.id.get().unwrap();
+
+    // GET edit form — assert the generic-inline FormSet renders.
+    let app = rustango::admin::router(pool.clone());
+    let req = Request::builder()
+        .uri(format!("/gige_post/{post_pk}/edit"))
+        .body(Body::empty())
+        .unwrap();
+    let res = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = to_bytes(res.into_body(), 1_000_000).await.unwrap();
+    let html = String::from_utf8(body.to_vec()).unwrap();
+
+    // Management form fields rendered for the generic inline.
+    assert!(
+        html.contains(r#"name="gige_tag-TOTAL_FORMS""#),
+        "TOTAL_FORMS missing: {html}"
+    );
+    // 2 existing rows + 2 extras = 4 total.
+    assert!(
+        html.contains(r#"value="4""#),
+        "total_forms=4 not present: {html}"
+    );
+    // Prefix-mangled `name` input for row 0.
+    assert!(
+        html.contains(r#"name="gige_tag-0-name""#),
+        "row 0 name input missing: {html}"
+    );
+    // DELETE checkbox on existing rows.
+    assert!(
+        html.contains(r#"name="gige_tag-0-DELETE""#),
+        "row 0 DELETE checkbox missing: {html}"
+    );
+    // Hidden PK input.
+    assert!(
+        html.contains(r#"name="gige_tag-0-id""#),
+        "hidden PK input missing on row 0: {html}"
+    );
+
+    // POST edit:
+    //   row 0 (keep): rename
+    //   row 1 (drop): DELETE
+    //   row 2 (extra): INSERT a fresh tag
+    //   row 3 (extra): blank — no-op
+    let mut form: HashMap<&str, &str> = HashMap::new();
+    form.insert("title", "Tagged");
+    form.insert("gige_tag-TOTAL_FORMS", "4");
+    form.insert("gige_tag-INITIAL_FORMS", "2");
+    form.insert("gige_tag-MAX_NUM_FORMS", "");
+
+    let keep_id_s = keep_id.to_string();
+    let drop_id_s = drop_id.to_string();
+    form.insert("gige_tag-0-id", keep_id_s.as_str());
+    form.insert("gige_tag-0-name", "keep-renamed");
+
+    form.insert("gige_tag-1-id", drop_id_s.as_str());
+    form.insert("gige_tag-1-name", "drop");
+    form.insert("gige_tag-1-DELETE", "on");
+
+    form.insert("gige_tag-2-name", "brand-new");
+    // gige_tag-3-* intentionally absent (blank extra).
+
+    let payload = urlencode(&form);
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/gige_post/{post_pk}"))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(Body::from(payload))
+        .unwrap();
+    let res = app.clone().oneshot(req).await.unwrap();
+    assert!(
+        res.status() == StatusCode::SEE_OTHER || res.status() == StatusCode::FOUND,
+        "POST should redirect; got {}",
+        res.status()
+    );
+
+    // Verify via direct SQL.
+    let rows: Vec<(i64, String, i64, i64)> = sqlx::query_as(
+        r#"SELECT id, name, content_type_id, object_pk FROM "gige_tag"
+           ORDER BY id"#,
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    let post_ct = contenttypes::ContentType::get_for_model::<Post>(&p)
+        .await
+        .unwrap()
+        .unwrap();
+    let post_ct_id = *post_ct.id.get().unwrap();
+
+    assert_eq!(
+        rows.len(),
+        2,
+        "expected 2 tags after update+delete+insert, got {rows:?}"
+    );
+    // Kept tag got renamed.
+    let kept = rows.iter().find(|r| r.0 == keep_id).expect("keep survived");
+    assert_eq!(kept.1, "keep-renamed", "UPDATE didn't apply: {kept:?}");
+    // Polymorphic columns unchanged (UPDATE skips both).
+    assert_eq!(kept.2, post_ct_id, "ct_column drift after UPDATE: {kept:?}");
+    assert_eq!(kept.3, post_pk, "pk_column drift after UPDATE: {kept:?}");
+    // Dropped row gone.
+    assert!(
+        !rows.iter().any(|r| r.0 == drop_id),
+        "DELETE didn't remove drop_id: {rows:?}"
+    );
+    // Inserted row landed with BOTH polymorphic columns pinned.
+    let inserted = rows
+        .iter()
+        .find(|r| r.1 == "brand-new")
+        .expect("new tag not present");
+    assert_eq!(
+        inserted.2, post_ct_id,
+        "INSERT didn't pin ct_column: {inserted:?}"
+    );
+    assert_eq!(
+        inserted.3, post_pk,
+        "INSERT didn't pin pk_column: {inserted:?}"
+    );
+}
+
+#[tokio::test]
+async fn generic_inline_update_cannot_reparent_via_form_payload() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+    let p = rustango::sql::Pool::from(pool.clone());
+
+    let mut post_a = Post {
+        id: Auto::Unset,
+        title: "A".into(),
+    };
+    post_a.save_pool(&p).await.unwrap();
+    let post_a_pk = *post_a.id.get().unwrap();
+
+    let mut post_b = Post {
+        id: Auto::Unset,
+        title: "B".into(),
+    };
+    post_b.save_pool(&p).await.unwrap();
+    let post_b_pk = *post_b.id.get().unwrap();
+
+    let mut tag = Tag {
+        id: Auto::Unset,
+        content_type_id: 0,
+        object_pk: 0,
+        name: "anchor".into(),
+    };
+    tag.set_content_object_for::<Post>(&p, post_a_pk)
+        .await
+        .unwrap();
+    tag.save_pool(&p).await.unwrap();
+    let tag_id = *tag.id.get().unwrap();
+
+    // POST an edit of Post A that tries to reparent the tag to Post B
+    // by submitting `gige_tag-0-object_pk = <post_b_pk>` inline.
+    let post_b_pk_s = post_b_pk.to_string();
+    let tag_id_s = tag_id.to_string();
+    let mut form: HashMap<&str, &str> = HashMap::new();
+    form.insert("title", "A");
+    form.insert("gige_tag-TOTAL_FORMS", "1");
+    form.insert("gige_tag-INITIAL_FORMS", "1");
+    form.insert("gige_tag-MAX_NUM_FORMS", "");
+    form.insert("gige_tag-0-id", tag_id_s.as_str());
+    form.insert("gige_tag-0-name", "anchor-renamed");
+    // Malicious — try to flip object_pk to Post B's pk.
+    form.insert("gige_tag-0-object_pk", post_b_pk_s.as_str());
+
+    let app = rustango::admin::router(pool.clone());
+    let payload = urlencode(&form);
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/gige_post/{post_a_pk}"))
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(Body::from(payload))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert!(
+        res.status() == StatusCode::SEE_OTHER || res.status() == StatusCode::FOUND,
+        "POST should redirect; got {}",
+        res.status()
+    );
+
+    // The tag's name got updated but its polymorphic key did NOT — the
+    // POST handler skips ct_column + pk_column on UPDATE to prevent
+    // reparenting.
+    let (name, object_pk): (String, i64) =
+        sqlx::query_as(r#"SELECT name, object_pk FROM "gige_tag" WHERE id = $1"#)
+            .bind(tag_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(name, "anchor-renamed", "name update should still apply");
+    assert_eq!(
+        object_pk, post_a_pk,
+        "object_pk must NOT change — slice 2 skips polymorphic columns on UPDATE"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #243. Builds on #242 (PR #249) to make generic admin inlines fully editable. Closes #38 (the umbrella generic-inlines issue) — both halves now ship: read-only display in #242 + editable POST handler here.

\`\`\`rust
rustango::register_admin_inline_generic!(
    parent = \"blog_post\",
    child  = \"blog_tag\",
    ct     = \"content_type_id\",
    pk     = \"object_pk\",
    kind   = InlineKind::Tabular,
    label  = \"Tags\",
    fields = &[\"name\"],
    extra  = 2,
);
\`\`\`

The parent's `/__admin/<table>/<pk>/edit` page now renders one editable panel per registered generic inline alongside the regular ones (#242 already wired the read-only path). The POST handler routes each FormSet row through UPDATE / INSERT / DELETE, pinning both polymorphic columns on INSERT and skipping them on UPDATE.

### Dispatch table

| Submitted shape | Action |
|---|---|
| Hidden PK + `DELETE=on` | `delete_pool` |
| Hidden PK + no DELETE | `update_pool` (both `ct_column` + `pk_column` skipped — no reparenting) |
| No PK + any non-empty display field | `insert_pool` with both polymorphic columns pinned to the parent |
| Empty extra row | no-op |

### What lands

- `inlines::render_form_generic_for_parent(pool, parent_model, parent_pk)` — editable counterpart of #242's `render_generic_for_parent`. Hidden child PK + DELETE box on existing rows, `extra` blank rows below, management form.
- `inlines::apply_post_generic(pool, parent_model, parent_pk, form)` — POST handler. Resolves the parent's ContentType once, then per-row dispatch over each `InlineAdminGeneric` registration.
- `inlines::build_assignments_generic` — `build_assignments` analog that drops both polymorphic columns from the assignment list, so UPDATEs can't smuggle them in.
- `views::edit_form` + `views::update_submit` — wired through.

### Security

The reparenting-attack test (`generic_inline_update_cannot_reparent_via_form_payload`) explicitly POSTs a malicious `gige_tag-0-object_pk = <other_post_pk>` and verifies the column does NOT change. UPDATE always skips both polymorphic columns, mirroring the FK-skip in slice 2 (PR #238).

### Stays out of ORM extraction surface

Only `admin/inlines.rs`, `admin/views.rs`, and a test file touched. POST handler consumes the existing `_pool` family + `forms::formset` helpers.

### Tests

`tests/admin_inline_generic_edit_live.rs` — 2 PG live tests:
- Full round-trip mixing UPDATE / DELETE / INSERT / blank-extra; direct-SQL verification of post-write state (kept row's polymorphic columns unchanged, dropped row gone, inserted row pinned to both parent CT id + PK).
- Reparenting attempt blocked.

## Test plan
- [x] \`cargo fmt --all\`
- [x] \`cargo build --no-default-features --features sqlite,tenancy\`
- [x] \`cargo test --workspace --all-features --lib\` (2330 pass)
- [x] \`cargo test --test admin_inline_generic_edit_live --all-features\` against live PG (2/2 pass)
- [x] \`cargo test --test admin_inline_generic_live --all-features\` (slice 1 still passes)
- [x] pre-push hook (lib tests + clippy)

## Epic status (#246)

| # | Slice | Status |
|---|---|---|
| #239 | Typed accessor codegen | ✅ PR #247 |
| #240 | Typed setter codegen | ✅ PR #247 |
| #241 | Admin list view: GFK columns as clickable links | ✅ PR #248 |
| #242 | \`register_admin_inline_generic!\` read-only | ✅ PR #249 |
| #243 | \`register_admin_inline_generic!\` editable | ✅ this PR (closes #38 too) |
| #244 | Generic inline picker UI | next |
| #245 | Cookbook chapter | last |