### PR TITLE
feat: GFK picker — ContentType <select> on create/edit form (closes #244)

### DIFF
--- a/crates/rustango/src/admin/helpers.rs
+++ b/crates/rustango/src/admin/helpers.rs
@@ -394,6 +394,27 @@ pub(crate) fn render_form(
     pk_locked: bool,
     error_msg: Option<&str>,
 ) -> String {
+    render_form_with_inlines_and_pickers(
+        state,
+        model,
+        prefill,
+        pk_locked,
+        error_msg,
+        Vec::new(),
+        &[],
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_form_with_inlines_and_pickers(
+    state: &AppState,
+    model: &'static ModelSchema,
+    prefill: Option<&HashMap<String, String>>,
+    pk_locked: bool,
+    error_msg: Option<&str>,
+    inline_panels: Vec<super::inlines::InlineFormPanel>,
+    gfk_picker_cts: &[crate::contenttypes::ContentType],
+) -> String {
     // v0.31.1 (#5): respect `state.config.admin_prefix` instead of
     // hardcoding `/__admin`. Apps on the v0.29+ friendly default
     // (`/admin`) were getting form-action URLs that 404'd.
@@ -425,6 +446,21 @@ pub(crate) fn render_form(
         .copied()
         .unwrap_or(crate::core::AdminConfig::DEFAULT);
 
+    // #244 — collect every `generic_fk(...)` `ct_column` so the row
+    // closure can swap a raw integer input for a ContentType `<select>`
+    // when that column is being rendered. Empty when the model has no
+    // `generic_fk` declarations OR the caller didn't pre-load the CT
+    // list — both cases fall through to `render_input`'s default.
+    let gfk_ct_columns: std::collections::HashSet<&'static str> = if gfk_picker_cts.is_empty() {
+        std::collections::HashSet::new()
+    } else {
+        model
+            .generic_relations
+            .iter()
+            .map(|gr| gr.ct_column)
+            .collect()
+    };
+
     let row_for_field = |f: &'static FieldSchema| -> serde_json::Value {
         let value = prefill
             .and_then(|m| m.get(f.name))
@@ -436,6 +472,8 @@ pub(crate) fn render_form(
             " <small>read-only</small>"
         } else if f.auto {
             " <small>auto</small>"
+        } else if gfk_ct_columns.contains(f.column) {
+            " <small>generic FK</small>"
         } else if !f.nullable {
             " <small>required</small>"
         } else {
@@ -444,10 +482,17 @@ pub(crate) fn render_form(
         // PK is locked on edit; readonly_fields are locked on edit.
         // Auto fields are always locked — they're DB-assigned.
         let lock_input = f.auto || (pk_locked && (f.primary_key || is_readonly_field));
+        // #244 — swap raw integer input for a ContentType `<select>`
+        // on fields named as a `generic_fk` ct_column.
+        let input_html = if gfk_ct_columns.contains(f.column) {
+            render::render_gfk_select(f, value, lock_input, gfk_picker_cts)
+        } else {
+            render::render_input(f, value, lock_input)
+        };
         serde_json::json!({
             "label": f.name,
             "extra": extra,
-            "input": render::render_input(f, value, lock_input),
+            "input": input_html,
         })
     };
 
@@ -489,117 +534,11 @@ pub(crate) fn render_form(
             .collect()
     };
 
-    let mut ctx = serde_json::json!({
-        "model": { "name": model.name, "table": model.table },
-        "title": title,
-        "action": action,
-        "edit_pk": edit_pk,
-        "error": error_msg,
-        "fieldsets": fieldsets_ctx,
-    });
-    super::templates::render_with_chrome(
-        "form.html",
-        &mut ctx,
-        chrome_context(state, Some(model.table)),
-    )
-}
-
-/// As [`render_form`] but threads a list of `InlineFormPanel` into
-/// the form context so the template can render editable inline
-/// panels below the parent fieldsets. Used by `edit_form` only —
-/// the create form runs before the parent PK exists, so child rows
-/// can't be attached yet (Django's create-form-doesn't-render-inlines
-/// behavior).
-pub(crate) fn render_form_with_inlines(
-    state: &AppState,
-    model: &'static ModelSchema,
-    prefill: Option<&HashMap<String, String>>,
-    pk_locked: bool,
-    error_msg: Option<&str>,
-    inline_panels: Vec<super::inlines::InlineFormPanel>,
-) -> String {
-    let admin_prefix = state.config.admin_prefix.as_str();
-    let (action, edit_pk) = if pk_locked {
-        let pk_field = model.primary_key().expect("pk_locked requires a PK");
-        let pk_value = prefill
-            .and_then(|m| m.get(pk_field.name).cloned())
-            .unwrap_or_default();
-        (
-            format!(
-                "{admin_prefix}/{}/{}",
-                model.table,
-                render::escape(&pk_value)
-            ),
-            Some(pk_value),
-        )
-    } else {
-        (format!("{admin_prefix}/{}", model.table), None)
-    };
-    let title = if pk_locked {
-        format!("Edit {}", model.name)
-    } else {
-        format!("New {}", model.name)
-    };
-    let admin_cfg = model
-        .admin
-        .copied()
-        .unwrap_or(crate::core::AdminConfig::DEFAULT);
-    let row_for_field = |f: &'static FieldSchema| -> serde_json::Value {
-        let value = prefill
-            .and_then(|m| m.get(f.name))
-            .map_or("", String::as_str);
-        let is_readonly_field = admin_cfg.readonly_fields.iter().any(|n| *n == f.name);
-        let extra = if f.primary_key {
-            " <small>(pk)</small>"
-        } else if is_readonly_field {
-            " <small>read-only</small>"
-        } else if f.auto {
-            " <small>auto</small>"
-        } else if !f.nullable {
-            " <small>required</small>"
-        } else {
-            ""
-        };
-        let lock_input = f.auto || (pk_locked && (f.primary_key || is_readonly_field));
-        serde_json::json!({
-            "label": f.name,
-            "extra": extra,
-            "input": render::render_input(f, value, lock_input),
-        })
-    };
-    let visible = |f: &&'static FieldSchema| -> bool {
-        if f.auto && !pk_locked {
-            return false;
-        }
-        true
-    };
-    let fieldsets_ctx: Vec<serde_json::Value> = if admin_cfg.fieldsets.is_empty() {
-        let rows: Vec<serde_json::Value> = model
-            .scalar_fields()
-            .filter(visible)
-            .map(row_for_field)
-            .collect();
-        vec![serde_json::json!({ "title": "", "rows": rows })]
-    } else {
-        admin_cfg
-            .fieldsets
-            .iter()
-            .map(|set| {
-                let rows: Vec<serde_json::Value> = set
-                    .fields
-                    .iter()
-                    .filter_map(|name| model.field(name))
-                    .filter(visible)
-                    .map(row_for_field)
-                    .collect();
-                serde_json::json!({ "title": set.title, "rows": rows })
-            })
-            .collect()
-    };
     let inline_form_panels_ctx: Vec<serde_json::Value> = inline_panels
         .into_iter()
         .map(|p| serde_json::to_value(p).unwrap_or(serde_json::Value::Null))
         .collect();
+
     let mut ctx = serde_json::json!({
         "model": { "name": model.name, "table": model.table },
         "title": title,
@@ -613,5 +552,31 @@ pub(crate) fn render_form_with_inlines(
         "form.html",
         &mut ctx,
         chrome_context(state, Some(model.table)),
+    )
+}
+
+/// As [`render_form`] but threads a list of `InlineFormPanel` and a
+/// pre-loaded `ContentType` list into the form context. The first
+/// drives inline panel rendering (#50, slice 2); the second drives
+/// the `generic_fk` `<select>` picker (#244). Used by `edit_form` and
+/// `create_form` — pass an empty `inline_panels` from create-form
+/// (Django's create-form-doesn't-render-inlines behavior).
+pub(crate) fn render_form_with_inlines_and_picker(
+    state: &AppState,
+    model: &'static ModelSchema,
+    prefill: Option<&HashMap<String, String>>,
+    pk_locked: bool,
+    error_msg: Option<&str>,
+    inline_panels: Vec<super::inlines::InlineFormPanel>,
+    gfk_picker_cts: &[crate::contenttypes::ContentType],
+) -> String {
+    render_form_with_inlines_and_pickers(
+        state,
+        model,
+        prefill,
+        pk_locked,
+        error_msg,
+        inline_panels,
+        gfk_picker_cts,
     )
 }

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -399,6 +399,47 @@ pub(crate) fn render_value_for_input(row: &PgRow, field: &FieldSchema) -> String
     }
 }
 
+/// Render a `<select>` widget over registered ContentType rows, for
+/// the `ct_column` of a `#[rustango(generic_fk(...))]` declaration.
+/// Issue #244 — replaces the raw `<input type="number">` an operator
+/// would otherwise have to fill with a `rustango_content_types.id`
+/// integer they'd have to memorize.
+///
+/// `value` is the currently-selected CT id as a string (numeric).
+/// Empty string renders no row pre-selected. `readonly` true emits a
+/// `disabled` attribute (matches the read-only feel `pk_locked` gives
+/// the regular [`render_input`] path).
+pub(crate) fn render_gfk_select(
+    field: &FieldSchema,
+    value: &str,
+    readonly: bool,
+    cts: &[crate::contenttypes::ContentType],
+) -> String {
+    let name = escape(field.name);
+    let disabled = if readonly { " disabled" } else { "" };
+    let required = if field.nullable || field.primary_key {
+        ""
+    } else {
+        " required"
+    };
+    let mut out = format!(r#"<select name="{name}" id="{name}"{required}{disabled}>"#,);
+    out.push_str(r#"<option value="">— choose target —</option>"#);
+    for ct in cts {
+        let Some(id) = ct.id.get().copied() else {
+            continue;
+        };
+        let selected = if value == id.to_string() {
+            " selected"
+        } else {
+            ""
+        };
+        let label = escape(&format!("{}.{}", ct.app_label, ct.model_name));
+        let _ = write!(out, r#"<option value="{id}"{selected}>{label}</option>"#);
+    }
+    out.push_str("</select>");
+    out
+}
+
 /// Render a form input for `field`, optionally pre-filled with `value`.
 /// PK fields get `readonly` when `pk_locked` is true (edit mode).
 pub(crate) fn render_input(field: &FieldSchema, value: &str, pk_locked: bool) -> String {

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -1134,9 +1134,36 @@ pub(crate) async fn create_form(
             table: model.table.to_owned(),
         });
     }
-    Ok(Html(render_form(
-        &state, model, None, /* pk_locked */ false, None,
+    // #244 — pre-load the ContentType list so `generic_fk` ct_columns
+    // render as a CT `<select>` picker instead of a raw integer input.
+    // Best-effort: empty list on failure falls back to the default
+    // input via the same code path slice 1 already used.
+    let gfk_cts = preload_gfk_cts(&state, model).await;
+    Ok(Html(super::helpers::render_form_with_inlines_and_picker(
+        &state,
+        model,
+        None,
+        /* pk_locked */ false,
+        None,
+        Vec::new(),
+        &gfk_cts,
     )))
+}
+
+/// Pre-load every ContentType when the model carries any
+/// `generic_fk(...)` declaration; return empty otherwise (the picker
+/// hook only fires when both the model has a generic_fk AND the
+/// caller supplied a non-empty CT list).
+async fn preload_gfk_cts(
+    state: &AppState,
+    model: &'static crate::core::ModelSchema,
+) -> Vec<crate::contenttypes::ContentType> {
+    if model.generic_relations.is_empty() {
+        return Vec::new();
+    }
+    crate::contenttypes::ContentType::all(&state.pool)
+        .await
+        .unwrap_or_default()
 }
 
 pub(crate) async fn create_submit(
@@ -1282,13 +1309,17 @@ pub(crate) async fn edit_form(
             .await
             .unwrap_or_default();
     inline_panels.extend(generic_panels);
-    Ok(Html(super::helpers::render_form_with_inlines(
+    // #244 — same picker preload as `create_form` so the edit form
+    // also renders a CT `<select>` for `generic_fk` ct_columns.
+    let gfk_cts = preload_gfk_cts(&state, model).await;
+    Ok(Html(super::helpers::render_form_with_inlines_and_picker(
         &state,
         model,
         Some(&prefill),
         true,
         None,
         inline_panels,
+        &gfk_cts,
     )))
 }
 

--- a/crates/rustango/tests/admin_gfk_picker_live.rs
+++ b/crates/rustango/tests/admin_gfk_picker_live.rs
@@ -1,0 +1,239 @@
+//! Live test for the GenericForeignKey `<select>` picker on the
+//! standalone create/edit form. Issue #244.
+//!
+//! Without this slice, a model carrying `#[rustango(generic_fk(...))]`
+//! shows raw `<input type="number">` widgets for the `content_type_id`
+//! column on the standalone `/__admin/<table>/new` form. The operator
+//! has to memorize the integer CT id of the target. This test asserts
+//! the column now renders as a `<select>` populated from the seeded
+//! ContentType table.
+
+#![cfg(feature = "postgres")]
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use rustango::contenttypes;
+use rustango::sql::sqlx;
+use rustango::sql::Auto;
+use rustango::Model;
+use tower::ServiceExt;
+
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn pool() -> Option<sqlx::PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::PgPool::connect(&url).await.ok()
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gfp_post")]
+#[rustango(app = "gfp_blog")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gfp_article")]
+#[rustango(app = "gfp_blog")]
+#[allow(dead_code)]
+pub struct Article {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gfp_attachment")]
+#[rustango(app = "gfp_blog")]
+#[rustango(generic_fk(name = "owner", ct_column = "content_type_id", pk_column = "object_pk"))]
+#[allow(dead_code)]
+pub struct Attachment {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub content_type_id: i64,
+    pub object_pk: i64,
+    #[rustango(max_length = 200)]
+    pub file_path: String,
+}
+
+async fn fresh(pool: &sqlx::PgPool) {
+    let p = rustango::sql::Pool::from(pool.clone());
+    contenttypes::ensure_seeded(&p).await.unwrap();
+    for t in ["gfp_attachment", "gfp_article", "gfp_post"] {
+        sqlx::query(&format!(r#"DROP TABLE IF EXISTS "{t}" CASCADE"#))
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+    sqlx::query(
+        r#"CREATE TABLE "gfp_post" (id BIGSERIAL PRIMARY KEY, title VARCHAR(200) NOT NULL)"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "gfp_article" (id BIGSERIAL PRIMARY KEY, title VARCHAR(200) NOT NULL)"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "gfp_attachment" (
+               id BIGSERIAL PRIMARY KEY,
+               content_type_id BIGINT NOT NULL,
+               object_pk BIGINT NOT NULL,
+               file_path VARCHAR(200) NOT NULL
+           )"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn create_form_renders_ct_column_as_select_picker() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+
+    let app = rustango::admin::router(pool.clone());
+    let req = Request::builder()
+        .uri("/gfp_attachment/new")
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = to_bytes(res.into_body(), 1_000_000).await.unwrap();
+    let html = String::from_utf8(body.to_vec()).unwrap();
+
+    // The ct_column now renders as a `<select>` rather than a raw
+    // number input. Look for the `name="content_type_id"` select shell.
+    assert!(
+        html.contains(r#"<select name="content_type_id""#),
+        "ct_column should render as a <select>: {html}"
+    );
+    // Sentinel placeholder option.
+    assert!(
+        html.contains("— choose target —"),
+        "picker placeholder option missing: {html}"
+    );
+    // Every seeded ContentType becomes an option labeled
+    // "<app_label>.<model_name>" — Post + Article are in the
+    // registry from this test module, so both must appear.
+    assert!(
+        html.contains("gfp_blog.post"),
+        "Post should appear as a picker option: {html}"
+    );
+    assert!(
+        html.contains("gfp_blog.article"),
+        "Article should appear as a picker option: {html}"
+    );
+    // The raw `<input type="number" name="content_type_id"` MUST be
+    // gone — the picker fully replaces it.
+    assert!(
+        !html.contains(r#"<input type="number" step="1" name="content_type_id""#),
+        "raw integer input must NOT render alongside the picker: {html}"
+    );
+    // pk_column stays as a plain integer input — v1 picker scope is
+    // just ct_column; the pk_column typeahead is a deferred follow-up.
+    assert!(
+        html.contains(r#"name="object_pk""#),
+        "pk_column input still renders as a regular field: {html}"
+    );
+}
+
+#[tokio::test]
+async fn edit_form_renders_picker_with_current_ct_preselected() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+    let p = rustango::sql::Pool::from(pool.clone());
+
+    // Seed a Post + an Attachment pointing at it.
+    let mut post = Post {
+        id: Auto::Unset,
+        title: "Hello".into(),
+    };
+    post.save_pool(&p).await.unwrap();
+    let post_pk = *post.id.get().unwrap();
+
+    let mut attach = Attachment {
+        id: Auto::Unset,
+        content_type_id: 0,
+        object_pk: 0,
+        file_path: "/files/x.pdf".into(),
+    };
+    attach.set_owner_for::<Post>(&p, post_pk).await.unwrap();
+    attach.save_pool(&p).await.unwrap();
+    let attach_pk = *attach.id.get().unwrap();
+
+    // The Post's CT id — what the picker should mark as selected.
+    let post_ct_id = *contenttypes::ContentType::get_for_model::<Post>(&p)
+        .await
+        .unwrap()
+        .unwrap()
+        .id
+        .get()
+        .unwrap();
+
+    let app = rustango::admin::router(pool.clone());
+    let req = Request::builder()
+        .uri(format!("/gfp_attachment/{attach_pk}/edit"))
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = to_bytes(res.into_body(), 1_000_000).await.unwrap();
+    let html = String::from_utf8(body.to_vec()).unwrap();
+
+    // The Post's CT option must carry `selected`.
+    let expected = format!(r#"<option value="{post_ct_id}" selected>"#);
+    assert!(
+        html.contains(&expected),
+        "expected option `{expected}` to be selected, in: {html}"
+    );
+}
+
+#[tokio::test]
+async fn create_form_for_model_without_generic_fk_keeps_default_inputs() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+
+    // Post has no generic_fk — its create form should render plain
+    // inputs, no `<select>` (the picker MUST NOT leak across models).
+    let app = rustango::admin::router(pool.clone());
+    let req = Request::builder()
+        .uri("/gfp_post/new")
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = to_bytes(res.into_body(), 1_000_000).await.unwrap();
+    let html = String::from_utf8(body.to_vec()).unwrap();
+
+    assert!(
+        !html.contains("— choose target —"),
+        "non-generic-fk model should not render the picker placeholder: {html}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #244. Sixth slice of epic #246. The `content_type_id` column of any `#[rustango(generic_fk(...))]` declaration now renders as a `<select>` populated from `rustango_content_types` on the standalone create/edit form. Operators no longer have to memorize integer CT ids.

### Re-scope note

The original issue body talked about a picker on **inline new rows**. After implementing #242/#243 it became clear that Django's `GenericTabularInline` pins new inline rows to the **parent** automatically — there's no picker scenario there. The genuinely useful target is the standalone create/edit form for any model carrying a `generic_fk`. This PR ships exactly that.

\`\`\`rust
#[derive(Model)]
#[rustango(generic_fk(name = \"owner\",
                       ct_column = \"content_type_id\",
                       pk_column = \"object_pk\"))]
pub struct Attachment {
    #[rustango(primary_key)] pub id: Auto<i64>,
    pub content_type_id: i64,    // ← <select> now
    pub object_pk: i64,          // ← still <input type=\"number\"> (v1 scope)
    pub file_path: String,
}
\`\`\`

### Implementation

- `render::render_gfk_select(field, value, readonly, cts)` — emits the `<select>` widget, options labeled `<app_label>.<model_name>`, current value pre-selected on edit.
- `helpers::render_form_with_inlines_and_picker(...)` — single unified entry point for create + edit. Internal `_and_pickers` helper consolidates what used to be three near-duplicate code paths (`render_form` / `render_form_with_inlines` / `render_form_with_picker`) into one; removed the two unused wrappers per the project's \"no dead code\" rule.
- `helpers::render_form` kept as a thin wrapper for sites that don't need inlines or picker.
- `views::create_form` + `views::edit_form` pre-load the CT list via `ContentType::all` only when the model carries any generic_fk declaration (small new `preload_gfk_cts` helper centralizes the decision). Empty list → picker hook is a no-op → existing models unaffected.

### Stays out of ORM extraction surface

Only `admin/` modules + a test file touched. CT bulk-fetch shipped earlier.

### Tests

`tests/admin_gfk_picker_live.rs` — 3 PG live tests:
- Create form renders `<select>` for ct_column with every seeded CT as an option; raw integer input is gone.
- Edit form pre-selects the row's current CT via the `selected` attribute.
- A model **without** any generic_fk renders no picker (picker MUST NOT leak across models).

### Deferred to follow-up

The original issue mentioned a `for_concrete_models = &[...]` macro filter to scope the picker to a subset of CTs. Skipped for v1 — the picker shows every registered ContentType. Filter follow-up if a project hits the \"too many options\" case in practice.

## Test plan
- [x] \`cargo fmt --all\`
- [x] \`cargo build --no-default-features --features sqlite,tenancy\`
- [x] \`cargo test --workspace --all-features --lib\` (2330 pass)
- [x] \`cargo test --test admin_gfk_picker_live --all-features\` against live PG (3/3 pass)
- [x] pre-push hook (lib tests + clippy)

## Epic status (#246)

| # | Slice | Status |
|---|---|---|
| #239 | Typed accessor codegen | ✅ PR #247 |
| #240 | Typed setter codegen | ✅ PR #247 |
| #241 | Admin list view: GFK columns as clickable links | ✅ PR #248 |
| #242 | \`register_admin_inline_generic!\` read-only | ✅ PR #249 |
| #243 | \`register_admin_inline_generic!\` editable | ✅ PR #250 |
| #244 | Generic FK picker UI | ✅ this PR |
| #245 | Cookbook chapter | last slice |

After this merges, the entire GFK ergonomics surface is in. Only the cookbook chapter remains.