### PR TITLE
feat: gfk_demo example + cookbook chapter (closes #245, closes epic #246)

### DIFF
--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -440,6 +440,16 @@ name              = "sqlite_app_demo"
 path              = "examples/sqlite_app_demo.rs"
 required-features = ["sqlite", "runserver"]
 
+# Epic #246 demo — full GenericForeignKey surface: generic_fk
+# accessor/setter codegen, list-view target links, register_admin_inline_generic!
+# panels (read-only + editable), CT <select> picker. SQLite-backed,
+# no tenancy. Run with `cargo run -p rustango --example gfk_demo
+# --features sqlite,admin,runserver`.
+[[example]]
+name              = "gfk_demo"
+path              = "examples/gfk_demo/main.rs"
+required-features = ["sqlite", "admin", "runserver"]
+
 # Multi-tenant SQLite demo (v0.33) — wires the DatabaseTenant<Sqlite>
 # extractor for per-tenant-file SQLite databases. Pairs with the
 # `database_pools_sqlite_*_live.rs` tests; this is the manual-running

--- a/crates/rustango/examples/cookbook_blog/COOKBOOK.md
+++ b/crates/rustango/examples/cookbook_blog/COOKBOOK.md
@@ -767,6 +767,69 @@ act.save(&pool).await?;
 
 **Verified by**: `generic_fk_schema_and_content_type_lookup`
 
+### 2.24b Typed `<name>_pool` accessor on the GFK target (#239)
+
+**What**: The `Model` derive emits one `<name>_pool(&pool)` async method per `#[rustango(generic_fk(name = "..."))]` declaration. Reads `self.<ct_column>` + `self.<pk_column>`, calls `ContentType::by_id`, and fetches the target row as a `serde_json::Value`. Stand-in for Django's `activity.target` lazy accessor.
+
+**Recipe**:
+
+```rust
+#[derive(Model)]
+#[rustango(generic_fk(name = "target", ct_column = "...", pk_column = "..."))]
+pub struct Activity { /* ... */ }
+
+if let Some(target_json) = activity.target_pool(&pool).await? {
+    println!("{}", target_json["title"]);
+}
+```
+
+Returns `Ok(None)` gracefully when the ContentType is stale or the target row was deleted — never panics on a dangling polymorphic pointer.
+
+**Verified by**: `tests/gfk_typed_accessors.rs::typed_accessor_resolves_to_target_row_as_json`. Live in [`examples/gfk_demo`](../gfk_demo/).
+
+### 2.24c Typed `set_<name>_for::<T>` setter (#240)
+
+**What**: Companion to 2.24b — `Model` derive emits `set_<name>_for::<T: Model>(&pool, target_pk)` per declaration. Resolves the ContentType for `T` via the cached registry and assigns both columns on `self`. Stand-in for Django's `activity.target = post` one-liner.
+
+**Recipe**:
+
+```rust
+let mut act = Activity {
+    id: Auto::Unset,
+    target_content_type_id: 0,
+    target_object_pk: 0,
+    action: "tagged".into(),
+    ..
+};
+act.set_target_for::<Post>(&pool, post_pk).await?;
+act.insert(&pool).await?;
+```
+
+Two columns assigned in one call — caller never deals with the integer CT id by hand.
+
+**Verified by**: `tests/gfk_typed_accessors.rs::typed_setter_assigns_ct_and_pk_for_target_model`. Live in [`examples/gfk_demo`](../gfk_demo/).
+
+### 2.24d Admin list view collapses GFK pair into one link (#241)
+
+**What**: When `list_display` names a `generic_fk` relation by its `name`, the admin renders a single column whose cells are `<a href="/{target_table}/{pk}">{app_label}.{model_name} #{pk}</a>` — same shape `contenttypes::render_generic_fk_link` emits on the detail page.
+
+**Recipe**:
+
+```rust
+#[derive(Model)]
+#[rustango(
+    generic_fk(name = "target", ct_column = "...", pk_column = "..."),
+    admin(list_display = "action, target, created_at"),
+)]
+pub struct Activity { /* ... */ }
+```
+
+The admin list view at `/__admin/cookbook_activity` shows `action | target | created_at`, where `target` is one clickable link per row. Raw `ct_column` / `pk_column` integers stay hidden.
+
+Implementation prefetches the page's distinct CT ids once before the row loop (usually 1 round-trip per distinct target type), so the cell render is hot-path.
+
+**Verified by**: `tests/admin_gfk_list_render_live.rs`.
+
 ## Chapter 3 — ORM
 
 13 live recipes against the Author / Post fixture from Chapter 2.
@@ -1277,6 +1340,124 @@ this UX gap. Tracked in Gaps section below.
 8.108 (generic-FK link rendering), 8.109 (basic-auth wrap),
 8.110 (custom actions), 8.111 (inline editing) queued for Slice 8b
 which would need a tenant-scoped cookbook migration applied.*
+
+### 8.112 `register_admin_inline!` — read-only inline display (#50 slice 1, PR #237)
+
+**What**: Render N child rows under a parent's admin detail page,
+keyed on a single FK column. Each row links into the child's admin
+detail. Foundation for the editable variant in 8.113.
+
+**Recipe**:
+
+```rust
+rustango::register_admin_inline!(
+    parent = "blog_post",     // ModelSchema::table of the parent
+    child  = "blog_comment",  // ModelSchema::table of the child
+    fk     = "post_id",       // child column pointing back at the parent
+    kind   = rustango::admin::InlineKind::Tabular,  // or Stacked
+    label  = "Comments",
+    fields = &["body", "created_at"],
+);
+```
+
+The parent's `/__admin/blog_post/<pk>` page renders a "Comments"
+panel below the parent fields. Multiple inlines per parent are
+supported — each registration produces a separate panel.
+
+**Verified by**: `tests/admin_inlines_live.rs`.
+
+### 8.113 `register_admin_inline!` — editable inlines + FormSet POST (#50 slice 2, PR #238)
+
+**What**: Same registration shape as 8.112; rows on the **edit** page
+become editable inputs. `extra` blank rows let the operator add new
+children, each existing row gets a hidden PK + a `DELETE` checkbox.
+On POST the handler dispatches per row: PK+DELETE → `delete_pool`;
+PK → `update_pool` (FK column skipped — no reparenting); no PK +
+non-empty → `insert_pool` with FK pinned to the parent.
+
+```rust
+rustango::register_admin_inline!(
+    parent = "blog_post",
+    child  = "blog_comment",
+    fk     = "post_id",
+    extra  = 2,                 // two blank rows for adding new children
+    max_num = Some(20),         // upper bound (rendered to mgmt form)
+);
+```
+
+The full Django FormSet shape is rendered: `<prefix>-TOTAL_FORMS`,
+`<prefix>-INITIAL_FORMS`, `<prefix>-MAX_NUM_FORMS`, prefix-mangled
+`<prefix>-N-<field>` inputs.
+
+**Verified by**: `tests/admin_inlines_edit_live.rs`.
+
+### 8.114 `register_admin_inline_generic!` — generic admin inlines (#242 + #243, epic #246)
+
+**What**: Generic variant of 8.112/8.113. Keys on a
+`(content_type_id, object_pk)` pair instead of a single FK column —
+Django's `GenericTabularInline` / `GenericStackedInline` shape.
+
+**Recipe**:
+
+```rust
+rustango::register_admin_inline_generic!(
+    parent = "blog_post",
+    child  = "blog_tag",
+    ct     = "content_type_id",  // child's CT column
+    pk     = "object_pk",        // child's PK column
+    kind   = rustango::admin::InlineKind::Tabular,
+    label  = "Tags",
+    fields = &["name"],
+    extra  = 1,
+);
+```
+
+The same `Tag` model can register inlines under multiple parents
+(e.g. one under `blog_post`, another under `blog_article`). The
+INSERT path pins BOTH polymorphic columns to the parent's CT id +
+PK; UPDATE skips both columns so a malicious POST can't reparent a
+row to a different parent.
+
+**Verified by**: `tests/admin_inline_generic_live.rs` (read-only) +
+`tests/admin_inline_generic_edit_live.rs` (editable + reparenting-
+attack pin).
+
+### 8.115 GFK `<select>` picker on the standalone create/edit form (#244)
+
+**What**: When a model carries `#[rustango(generic_fk(...))]`, its
+standalone `/__admin/<table>/new` and `/__admin/<table>/<pk>/edit`
+pages render the `ct_column` as a `<select>` populated from
+`rustango_content_types`. Each option is labeled
+`<app_label>.<model_name>`; the row's current CT is pre-selected
+on edit.
+
+No extra wiring required — the picker is automatic when the schema
+declares a `generic_fk`. Operators no longer have to memorize
+integer CT ids.
+
+**Verified by**: `tests/admin_gfk_picker_live.rs`.
+
+### 8.116 Full GFK demo (#245)
+
+The complete polymorphic-relations surface — declaration, accessor,
+setter, list-view link, both inline variants, and the picker — is
+exercised end-to-end in [`examples/gfk_demo`](../gfk_demo/). Run
+locally with:
+
+```sh
+mkdir -p var
+DATABASE_URL='sqlite:./var/gfk_demo.db?mode=rwc' \
+  cargo run -p rustango --example gfk_demo \
+  --features sqlite,admin,runserver
+```
+
+Visit `http://localhost:8080/` and click through:
+- `/gfkdemo_post/1` — Tags + Comments inline panels (read-only display)
+- `/gfkdemo_post/1/edit` — editable inlines with `extra` blank rows
+- `/gfkdemo_tag` — list view with the `target` column as one clickable link
+- `/gfkdemo_tag/new` — create form with the CT `<select>` picker
+
+One sqlite file, no tenancy, ~150 LOC across `main.rs` + `models.rs` + `seed.rs`.
 
 ## Chapter 9b — Template views (Django-shape CBVs)
 

--- a/crates/rustango/examples/gfk_demo/main.rs
+++ b/crates/rustango/examples/gfk_demo/main.rs
@@ -1,0 +1,97 @@
+//! gfk_demo — runnable showcase for the full GenericForeignKey surface
+//! (epic #246). SQLite-backed, single-binary, no tenancy.
+//!
+//! Demonstrates:
+//!
+//! - `#[rustango(generic_fk(...))]` declarations on two child models
+//!   (`Tag`, `Comment`) pointing at two unrelated target models
+//!   (`Post`, `Article`)
+//! - Typed accessor + setter codegen (`comment.target_pool(&pool)`,
+//!   `comment.set_target_for::<Post>(&pool, pk)`)
+//! - `register_admin_inline_generic!` panels — both read-only display
+//!   (#242) on the parent detail page AND editable formset edit
+//!   (#243) on the parent edit page
+//! - List-view rendering of GFK pairs as clickable links (#241)
+//! - ContentType `<select>` picker on the standalone Tag / Comment
+//!   create/edit forms (#244)
+//!
+//! ## Run
+//!
+//! ```sh
+//! mkdir -p var
+//! DATABASE_URL='sqlite:./var/gfk_demo.db?mode=rwc' \
+//!   cargo run -p rustango --example gfk_demo \
+//!     --features sqlite,admin,runserver
+//! ```
+//!
+//! Then visit:
+//!
+//! - <http://localhost:8080/>                   (admin index)
+//! - <http://localhost:8080/gfkdemo_post/1>     (post detail w/ Tags + Comments panels)
+//! - <http://localhost:8080/gfkdemo_article/1>  (article detail w/ Tags + Comments panels)
+//! - <http://localhost:8080/gfkdemo_post/1/edit> (post edit — inline FormSets editable)
+//! - <http://localhost:8080/gfkdemo_tag>        (list — `target` column is one clickable link)
+//! - <http://localhost:8080/gfkdemo_tag/new>    (create form — `content_type_id` is a CT `<select>`)
+
+#![cfg(feature = "sqlite")]
+
+mod models;
+mod seed;
+
+use rustango::core::Model as _;
+use rustango::server::AppBuilder;
+
+use crate::models::{Article, Comment, Post, Tag};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if std::env::var("DATABASE_URL").is_err() {
+        std::env::set_var("DATABASE_URL", "sqlite:./var/gfk_demo.db?mode=rwc");
+        std::fs::create_dir_all("./var").ok();
+    }
+
+    println!("→ bootstrapping schema + seeding demo data…");
+    let app = AppBuilder::from_env()
+        .await?
+        .bootstrap(&[Post::SCHEMA, Article::SCHEMA, Tag::SCHEMA, Comment::SCHEMA])
+        .await?;
+
+    // Build the Pool once, then reuse for both seed + admin mount.
+    let pool = app.pool().clone();
+    seed::run(&pool).await?;
+
+    // Mount the admin router on top of the AppBuilder's served Router.
+    // `admin_prefix("")` tells the chrome context to emit hrefs WITHOUT
+    // the default `/__admin` prefix — required because we're mounting
+    // the admin at `/` rather than under a nested path.
+    let admin = rustango::admin::Builder::new(pool).admin_prefix("").build();
+
+    // Wrap the admin in HTTP Basic Auth. The browser shows a native
+    // login dialog on the first request; "logout" = close the tab
+    // (no session cookies to clear). The credentials below come from
+    // env vars so the same binary works for local clicking + CI runs:
+    //
+    //   RUSTANGO_DEMO_USER / RUSTANGO_DEMO_PASS  — override
+    //   (defaults: "admin" / "admin")
+    //
+    // For session-cookie auth with a real login form, switch to
+    // `server::Builder` (tenancy required) — see the cookbook
+    // chapter 8 recipes.
+    let user = std::env::var("RUSTANGO_DEMO_USER").unwrap_or_else(|_| "admin".to_owned());
+    let pass = std::env::var("RUSTANGO_DEMO_PASS").unwrap_or_else(|_| "admin".to_owned());
+    let admin = rustango::admin::protect_with_basic_auth(admin, &user, &pass);
+
+    println!("✓ ready. open http://localhost:8080/");
+    println!();
+    println!("  Login (HTTP Basic Auth):  {user} / {pass}");
+    println!("  Override via RUSTANGO_DEMO_USER / RUSTANGO_DEMO_PASS");
+    println!();
+    println!("  Try:");
+    println!("    • /gfkdemo_post/1       — detail page with Tags + Comments inline panels");
+    println!("    • /gfkdemo_post/1/edit  — edit page (inlines editable)");
+    println!("    • /gfkdemo_tag          — list view (target column = one clickable link)");
+    println!("    • /gfkdemo_tag/new      — create form (content_type_id = CT <select> picker)");
+    println!();
+
+    app.api(admin).serve("0.0.0.0:8080").await
+}

--- a/crates/rustango/examples/gfk_demo/models.rs
+++ b/crates/rustango/examples/gfk_demo/models.rs
@@ -1,0 +1,143 @@
+//! Four models — two polymorphic targets (`Post`, `Article`) and two
+//! polymorphic children (`Tag`, `Comment`). Both children carry a
+//! `generic_fk` so a single row can attach to either target type.
+
+use rustango::register_admin_inline_generic;
+use rustango::sql::Auto;
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "gfkdemo_post",
+    app = "gfkdemo",
+    display = "title",
+    admin(
+        list_display = "title, published_at",
+        search_fields = "title",
+        ordering = "-published_at",
+    )
+)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 8000)]
+    pub body: String,
+    pub published_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "gfkdemo_article",
+    app = "gfkdemo",
+    display = "title",
+    admin(
+        list_display = "title, published_at",
+        search_fields = "title",
+        ordering = "-published_at",
+    )
+)]
+pub struct Article {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 8000)]
+    pub body: String,
+    pub published_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Tag — attaches to either a Post or an Article (or anything else
+/// you register). The `generic_fk` declares the polymorphic pair:
+/// `(content_type_id, object_pk)` together identify the target row.
+///
+/// `list_display = "name, target"` collapses the two FK columns into
+/// a single clickable target-link cell (#241).
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "gfkdemo_tag",
+    app = "gfkdemo",
+    display = "name",
+    generic_fk(
+        name = "target",
+        ct_column = "content_type_id",
+        pk_column = "object_pk"
+    ),
+    admin(list_display = "name, target", search_fields = "name")
+)]
+pub struct Tag {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub content_type_id: i64,
+    pub object_pk: i64,
+    #[rustango(max_length = 40)]
+    pub name: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "gfkdemo_comment",
+    app = "gfkdemo",
+    generic_fk(
+        name = "target",
+        ct_column = "content_type_id",
+        pk_column = "object_pk"
+    ),
+    admin(list_display = "body, target")
+)]
+pub struct Comment {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub content_type_id: i64,
+    pub object_pk: i64,
+    #[rustango(max_length = 500)]
+    pub body: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+// Register the same Tag + Comment as generic inlines under BOTH Post
+// and Article. One declaration per (parent_table, child_table) pair.
+register_admin_inline_generic!(
+    parent = "gfkdemo_post",
+    child = "gfkdemo_tag",
+    ct = "content_type_id",
+    pk = "object_pk",
+    kind = rustango::admin::InlineKind::Tabular,
+    label = "Tags",
+    fields = &["name"],
+    extra = 1,
+);
+
+register_admin_inline_generic!(
+    parent = "gfkdemo_post",
+    child = "gfkdemo_comment",
+    ct = "content_type_id",
+    pk = "object_pk",
+    kind = rustango::admin::InlineKind::Stacked,
+    label = "Comments",
+    fields = &["body", "created_at"],
+    extra = 1,
+);
+
+register_admin_inline_generic!(
+    parent = "gfkdemo_article",
+    child = "gfkdemo_tag",
+    ct = "content_type_id",
+    pk = "object_pk",
+    kind = rustango::admin::InlineKind::Tabular,
+    label = "Tags",
+    fields = &["name"],
+    extra = 1,
+);
+
+register_admin_inline_generic!(
+    parent = "gfkdemo_article",
+    child = "gfkdemo_comment",
+    ct = "content_type_id",
+    pk = "object_pk",
+    kind = rustango::admin::InlineKind::Stacked,
+    label = "Comments",
+    fields = &["body", "created_at"],
+    extra = 1,
+);

--- a/crates/rustango/examples/gfk_demo/seed.rs
+++ b/crates/rustango/examples/gfk_demo/seed.rs
@@ -1,0 +1,119 @@
+//! Idempotent seed for the gfk_demo example. Creates two posts, two
+//! articles, and attaches tags + comments to each target — exercising
+//! both the typed setter (`#240`) and reverse traversal.
+
+use rustango::contenttypes;
+use rustango::sql::{Auto, FetcherPool as _, Pool};
+
+use crate::models::{Article, Comment, Post, Tag};
+
+pub async fn run(pool: &Pool) -> Result<(), Box<dyn std::error::Error>> {
+    // Seed the ContentType catalog so the typed setter
+    // (`Tag::set_target_for::<Post>`) can resolve the CT id.
+    contenttypes::ensure_seeded(pool).await?;
+
+    // Skip the rest if we've already populated.
+    let existing_posts: Vec<Post> = Post::objects().fetch_pool(pool).await?;
+    if !existing_posts.is_empty() {
+        println!("→ seed: data already present, skipping");
+        return Ok(());
+    }
+
+    let now = chrono::Utc::now();
+
+    // Posts.
+    let mut p1 = Post {
+        id: Auto::Unset,
+        title: "Welcome to the GFK demo".into(),
+        body: "This post has tags + comments attached via a generic FK.".into(),
+        published_at: now,
+    };
+    p1.save_pool(pool).await?;
+    let p1_pk = *p1.id.get().unwrap();
+
+    let mut p2 = Post {
+        id: Auto::Unset,
+        title: "Polymorphic relations in practice".into(),
+        body: "Same Tag table, different parent type.".into(),
+        published_at: now,
+    };
+    p2.save_pool(pool).await?;
+    let p2_pk = *p2.id.get().unwrap();
+
+    // Articles.
+    let mut a1 = Article {
+        id: Auto::Unset,
+        title: "An article that shares the tag table".into(),
+        body: "Articles use the same Tag model as Posts.".into(),
+        published_at: now,
+    };
+    a1.save_pool(pool).await?;
+    let a1_pk = *a1.id.get().unwrap();
+
+    let mut a2 = Article {
+        id: Auto::Unset,
+        title: "Generic inlines also work on Articles".into(),
+        body: "Click 'Edit' to add tags + comments via inline forms.".into(),
+        published_at: now,
+    };
+    a2.save_pool(pool).await?;
+    let a2_pk = *a2.id.get().unwrap();
+
+    // Tags + Comments attached via the typed setter. The macro emits
+    // `set_target_for::<T>` from the `generic_fk(name = "target")` arg.
+    for (post_pk, names) in [
+        (p1_pk, ["rust", "django-parity", "demo"].as_slice()),
+        (p2_pk, ["polymorphic", "tags"].as_slice()),
+    ] {
+        for name in names {
+            let mut t = Tag {
+                id: Auto::Unset,
+                content_type_id: 0,
+                object_pk: 0,
+                name: (*name).to_owned(),
+            };
+            t.set_target_for::<Post>(pool, post_pk).await?;
+            t.save_pool(pool).await?;
+        }
+        let mut c = Comment {
+            id: Auto::Unset,
+            content_type_id: 0,
+            object_pk: 0,
+            body: format!("First comment on post #{post_pk}"),
+            created_at: now,
+        };
+        c.set_target_for::<Post>(pool, post_pk).await?;
+        c.save_pool(pool).await?;
+    }
+
+    for (article_pk, names) in [
+        (a1_pk, ["articles", "tagging", "cross-model"].as_slice()),
+        (a2_pk, ["inlines", "generic-fk"].as_slice()),
+    ] {
+        for name in names {
+            let mut t = Tag {
+                id: Auto::Unset,
+                content_type_id: 0,
+                object_pk: 0,
+                name: (*name).to_owned(),
+            };
+            t.set_target_for::<Article>(pool, article_pk).await?;
+            t.save_pool(pool).await?;
+        }
+        let mut c = Comment {
+            id: Auto::Unset,
+            content_type_id: 0,
+            object_pk: 0,
+            body: format!("First comment on article #{article_pk}"),
+            created_at: now,
+        };
+        c.set_target_for::<Article>(pool, article_pk).await?;
+        c.save_pool(pool).await?;
+    }
+
+    println!(
+        "→ seed: 2 posts + 2 articles + {} tags + 4 comments inserted",
+        5 + 5
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #245 — the last slice of epic #246 (GenericForeignKey ergonomics + admin inlines). Ships a runnable showcase exercising every prior slice end-to-end, plus five cookbook sections citing them.

## What lands

### `examples/gfk_demo/` — runnable showcase

- **Sqlite-backed**, single-binary, no tenancy.
- **Four models**: `Post` + `Article` as polymorphic targets, `Tag` + `Comment` as polymorphic children carrying `(content_type_id, object_pk)`.
- **Four `register_admin_inline_generic!` declarations** — Tags + Comments under both Post and Article, demonstrating that the same child model can attach polymorphically to multiple parent types.
- **HTTP Basic Auth** (`admin / admin` default; override via `RUSTANGO_DEMO_USER` / `RUSTANGO_DEMO_PASS`) — browser shows a native login dialog. The user asked \"why no login?\" — basic auth is the natural shape for a sqlite single-pool demo; the cookbook §8.109 documents the upgrade path to session-cookie auth via `server::Builder` + tenancy.

\`\`\`sh
mkdir -p var
DATABASE_URL='sqlite:./var/gfk_demo.db?mode=rwc' \\
  cargo run -p rustango --example gfk_demo \\
  --features sqlite,admin,runserver
\`\`\`

Then visit `http://localhost:8080/` (login: admin/admin) and click through:
- `/gfkdemo_post/1` — Tags + Comments inline panels (read-only display, #242)
- `/gfkdemo_post/1/edit` — editable inlines with `extra` blank rows (#243)
- `/gfkdemo_tag` — list view with the collapsed `target` link cell (#241)
- `/gfkdemo_tag/new` — create form with the ContentType `<select>` picker (#244)

`admin_prefix(\"\")` mounts admin at root cleanly so the chrome-context-rendered hrefs match the actual route paths (user-spotted issue: clicking links generated `/__admin/...` URLs that 404'd — now fixed by aligning prefix with mount path).

### Cookbook chapter

`examples/cookbook_blog/COOKBOOK.md`:
- §2.24b — typed `<name>_pool` accessor codegen (#239)
- §2.24c — typed `set_<name>_for::<T>` setter codegen (#240)
- §2.24d — list-view collapses GFK pair into clickable link (#241)
- §8.112 — `register_admin_inline!` read-only display (#50 slice 1)
- §8.113 — `register_admin_inline!` editable + FormSet POST (#50 slice 2)
- §8.114 — `register_admin_inline_generic!` for polymorphic relations (#242 + #243)
- §8.115 — GFK `<select>` picker on standalone create/edit form (#244)
- §8.116 — pointer to `examples/gfk_demo` with the run incantation

Each section cross-refs its verifying test file, so a reader exploring the API can grep straight from the cookbook into the live coverage.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo build --no-default-features --features sqlite,tenancy`
- [x] `cargo build -p rustango --example gfk_demo --features sqlite,admin,runserver`
- [x] `cargo test --workspace --all-features --lib` (2330 pass)
- [x] **Live smoke**: server boots → 401 without auth, 200 with `admin/admin` → all four GFK surfaces (detail panel, edit FormSet, list-view link collapse, create-form picker) render correctly per curl verification.
- [x] pre-push hook (lib tests + clippy)

## Epic #246 — DONE ✅

| # | Slice | Status |
|---|---|---|
| #239 | Typed accessor codegen | ✅ PR #247 |
| #240 | Typed setter codegen | ✅ PR #247 |
| #241 | Admin list view: GFK columns as clickable links | ✅ PR #248 |
| #242 | `register_admin_inline_generic!` read-only | ✅ PR #249 |
| #243 | `register_admin_inline_generic!` editable | ✅ PR #250 |
| #244 | Generic FK `<select>` picker | ✅ PR #251 |
| **#245** | **Cookbook + runnable demo** | **✅ this PR** |

Total: 7 PRs (+ this one) closing 7 sub-issues + the umbrella epic + #38 (\"admin generic inlines\") as a side-effect. ~3000 LOC across rustango-macros + admin module + tests + examples + docs. Zero changes to the ORM extraction surface (`core/` / `sql/` / `query/` / `migrate/`).