### PR TITLE
feat: admin session auth — login form + sidebar Logout without tenancy (#253 slice A)

### DIFF
--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -271,9 +271,18 @@ template_views = ["forms", "dep:axum", "dep:tera", "dep:tokio"]
 admin = [
     "forms",
     "csrf",
+    # #253 — admin session auth uses argon2 via crate::passwords for
+    # the AdminUser password hash. `passwords` was already a
+    # transitive dep through forms/tenancy in practice; this makes
+    # the relationship explicit so `--features sqlite,admin` builds
+    # cleanly without `tenancy` or `passwords` named.
+    "passwords",
     "dep:axum",
     "dep:tera",
     "dep:base64",
+    "dep:hmac",
+    "dep:sha2",
+    "dep:subtle",
     "dep:http",
     "dep:http-body-util",
     "dep:serde_urlencoded",

--- a/crates/rustango/examples/gfk_demo/main.rs
+++ b/crates/rustango/examples/gfk_demo/main.rs
@@ -40,6 +40,7 @@ mod seed;
 
 use rustango::core::Model as _;
 use rustango::server::AppBuilder;
+use rustango::session::SessionSecret;
 
 use crate::models::{Article, Comment, Post, Tag};
 
@@ -53,37 +54,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("→ bootstrapping schema + seeding demo data…");
     let app = AppBuilder::from_env()
         .await?
-        .bootstrap(&[Post::SCHEMA, Article::SCHEMA, Tag::SCHEMA, Comment::SCHEMA])
+        .bootstrap(&[
+            Post::SCHEMA,
+            Article::SCHEMA,
+            Tag::SCHEMA,
+            Comment::SCHEMA,
+            rustango::admin::AdminUser::SCHEMA,
+        ])
         .await?;
 
     // Build the Pool once, then reuse for both seed + admin mount.
     let pool = app.pool().clone();
     seed::run(&pool).await?;
 
-    // Mount the admin router on top of the AppBuilder's served Router.
-    // `admin_prefix("")` tells the chrome context to emit hrefs WITHOUT
-    // the default `/__admin` prefix — required because we're mounting
-    // the admin at `/` rather than under a nested path.
-    let admin = rustango::admin::Builder::new(pool).admin_prefix("").build();
+    // #253 — opt into signed-cookie session auth. The signing key
+    // is loaded from `RUSTANGO_SESSION_SECRET` (production path) or
+    // generated randomly for dev. Pair with the admin user seeded
+    // by `seed::run` (default credentials: admin / admin).
+    let secret = SessionSecret::from_env_or_random();
+    let admin = rustango::admin::Builder::new(pool)
+        .admin_prefix("")
+        .with_session_auth(secret)
+        .build();
 
-    // Wrap the admin in HTTP Basic Auth. The browser shows a native
-    // login dialog on the first request; "logout" = close the tab
-    // (no session cookies to clear). The credentials below come from
-    // env vars so the same binary works for local clicking + CI runs:
-    //
-    //   RUSTANGO_DEMO_USER / RUSTANGO_DEMO_PASS  — override
-    //   (defaults: "admin" / "admin")
-    //
-    // For session-cookie auth with a real login form, switch to
-    // `server::Builder` (tenancy required) — see the cookbook
-    // chapter 8 recipes.
     let user = std::env::var("RUSTANGO_DEMO_USER").unwrap_or_else(|_| "admin".to_owned());
     let pass = std::env::var("RUSTANGO_DEMO_PASS").unwrap_or_else(|_| "admin".to_owned());
-    let admin = rustango::admin::protect_with_basic_auth(admin, &user, &pass);
 
     println!("✓ ready. open http://localhost:8080/");
     println!();
-    println!("  Login (HTTP Basic Auth):  {user} / {pass}");
+    println!("  Login form:  /login");
+    println!("  Credentials:  {user} / {pass}");
     println!("  Override via RUSTANGO_DEMO_USER / RUSTANGO_DEMO_PASS");
     println!();
     println!("  Try:");

--- a/crates/rustango/examples/gfk_demo/seed.rs
+++ b/crates/rustango/examples/gfk_demo/seed.rs
@@ -2,6 +2,7 @@
 //! articles, and attaches tags + comments to each target — exercising
 //! both the typed setter (`#240`) and reverse traversal.
 
+use rustango::admin::AdminUser;
 use rustango::contenttypes;
 use rustango::sql::{Auto, FetcherPool as _, Pool};
 
@@ -12,10 +13,23 @@ pub async fn run(pool: &Pool) -> Result<(), Box<dyn std::error::Error>> {
     // (`Tag::set_target_for::<Post>`) can resolve the CT id.
     contenttypes::ensure_seeded(pool).await?;
 
+    // #253 — seed the admin user used by the session-login form.
+    // Credentials default to `admin / admin`; override via the
+    // `RUSTANGO_DEMO_USER` / `RUSTANGO_DEMO_PASS` env vars.
+    let existing_admin: Vec<AdminUser> = AdminUser::objects().fetch_pool(pool).await?;
+    if existing_admin.is_empty() {
+        let username = std::env::var("RUSTANGO_DEMO_USER").unwrap_or_else(|_| "admin".to_owned());
+        let password = std::env::var("RUSTANGO_DEMO_PASS").unwrap_or_else(|_| "admin".to_owned());
+        let mut admin =
+            AdminUser::new_with_password(username, &password, /* superuser */ true)?;
+        admin.save_pool(pool).await?;
+        println!("→ seed: admin user created");
+    }
+
     // Skip the rest if we've already populated.
     let existing_posts: Vec<Post> = Post::objects().fetch_pool(pool).await?;
     if !existing_posts.is_empty() {
-        println!("→ seed: data already present, skipping");
+        println!("→ seed: demo data already present, skipping");
         return Ok(());
     }
 

--- a/crates/rustango/src/admin/helpers.rs
+++ b/crates/rustango/src/admin/helpers.rs
@@ -96,6 +96,23 @@ pub(crate) fn chrome_context(state: &AppState, active_table: Option<&str>) -> se
         // v0.28.2 (#77) — sidebar "Change password" link target.
         // Threaded from the tenant admin's RouteConfig.
         "change_password_url": &state.config.change_password_url,
+        // #253 — Logout button visibility. The bare admin's
+        // session middleware redirects unauthenticated requests to
+        // `/login`, so by the time chrome renders we know any
+        // visitor is logged in. Templates show the button when
+        // `session_user` is non-null. Tenancy admins thread their
+        // own session info through a parallel path; this signal is
+        // only set when the bare admin's `with_session_auth` is on.
+        "session_user": if state.config.session_secret.is_some() {
+            // Per-user info (username, is_superuser) is Slice B
+            // — Slice A just renders the Logout button. The
+            // `authenticated: true` marker keeps Tera's `{% if
+            // session_user %}` evaluation truthy (Tera treats
+            // empty objects as falsy).
+            serde_json::json!({ "authenticated": true })
+        } else {
+            serde_json::Value::Null
+        },
     })
 }
 

--- a/crates/rustango/src/admin/login_view.rs
+++ b/crates/rustango/src/admin/login_view.rs
@@ -1,0 +1,213 @@
+//! `GET /login` + `POST /login` + `POST /logout` + auth middleware
+//! for the bare admin's session auth (#253 slice A).
+//!
+//! Mounted by [`crate::admin::Builder::with_session_auth`]. Layered
+//! as middleware so every non-login route requires a valid session
+//! cookie; the gate redirects to `/login` (relative to
+//! `state.config.admin_prefix`) on missing / expired cookies.
+//!
+//! ## Reuse with `tenancy::admin`
+//!
+//! The HMAC signing primitive comes from `crate::session` (shared
+//! with `tenancy::session`). The password-verify call goes through
+//! `crate::passwords::verify` — the same primitive the tenancy
+//! `auth::authenticate_user` flow uses. Only the user model
+//! (`AdminUser` vs `tenancy::User`) and the cookie shape differ;
+//! all the crypto + password machinery lives in one place.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::{Form, State};
+use axum::http::{header, HeaderValue, Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::{Html, IntoResponse, Redirect, Response};
+use axum::routing::{get, post};
+use axum::Router;
+
+use super::session::{self, AdminSession, AdminSessionSecret, SESSION_COOKIE};
+use super::templates::render_template;
+use super::urls::AppState;
+use super::user::AdminUser;
+use crate::core::{Filter, Model, Op, SelectQuery, SqlValue, WhereExpr};
+
+/// Mount the login + logout routes. Returns a `Router` that should
+/// be merged into the admin router BEFORE the auth middleware is
+/// applied so the login form itself stays publicly reachable.
+pub(crate) fn router(state: AppState) -> Router {
+    Router::new()
+        .route("/login", get(login_form).post(login_submit))
+        .route("/logout", post(logout_submit))
+        .with_state(state)
+}
+
+// ============================================================ Login form (GET)
+
+async fn login_form(State(state): State<AppState>) -> Html<String> {
+    Html(render_login_form(&state, None))
+}
+
+fn render_login_form(state: &AppState, error: Option<&str>) -> String {
+    let admin_prefix = &state.config.admin_prefix;
+    let ctx = serde_json::json!({
+        "title": "Sign in",
+        "action": format!("{admin_prefix}/login"),
+        "error": error,
+        "admin_title": state
+            .config
+            .title
+            .as_deref()
+            .unwrap_or("Rustango Admin"),
+        "admin_prefix": admin_prefix,
+        "static_url": &state.config.static_url,
+    });
+    render_template("login.html", &ctx)
+}
+
+// ============================================================ Login form (POST)
+
+#[derive(serde::Deserialize)]
+struct LoginInput {
+    username: String,
+    password: String,
+}
+
+async fn login_submit(State(state): State<AppState>, Form(form): Form<LoginInput>) -> Response {
+    let Some(secret) = state.config.session_secret.clone() else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "session auth not configured",
+        )
+            .into_response();
+    };
+
+    // Schema-driven lookup so we don't depend on tenancy's
+    // typed query helpers — the bare admin compiles without `tenancy`.
+    let fields: Vec<&'static crate::core::FieldSchema> = AdminUser::SCHEMA.fields.iter().collect();
+    let select = SelectQuery {
+        model: AdminUser::SCHEMA,
+        where_clause: WhereExpr::Predicate(Filter {
+            column: "username",
+            op: Op::Eq,
+            value: SqlValue::String(form.username.clone()),
+        }),
+        search: None,
+        joins: vec![],
+        order_by: vec![],
+        limit: Some(1),
+        offset: None,
+        lock_mode: None,
+        compound: vec![],
+        projection: None,
+    };
+    let row = crate::sql::select_one_row_as_json(&state.pool, &select, &fields)
+        .await
+        .ok()
+        .flatten();
+
+    let Some(row) = row else {
+        return Html(render_login_form(&state, Some("Invalid credentials."))).into_response();
+    };
+    let id = row.get("id").and_then(|v| v.as_i64()).unwrap_or_default();
+    let stored_hash = row
+        .get("password_hash")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    let is_active = row.get("active").and_then(|v| v.as_bool()).unwrap_or(true);
+    let is_superuser = row
+        .get("is_superuser")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if !is_active {
+        return Html(render_login_form(&state, Some("Account is disabled."))).into_response();
+    }
+    if !crate::passwords::verify(&form.password, stored_hash).unwrap_or(false) {
+        return Html(render_login_form(&state, Some("Invalid credentials."))).into_response();
+    }
+
+    let cookie_value = session::encode(
+        &secret,
+        AdminSession {
+            user_id: id,
+            is_superuser,
+        },
+    );
+    let cookie = format!(
+        "{name}={val}; Path=/; HttpOnly; SameSite=Lax",
+        name = SESSION_COOKIE,
+        val = cookie_value,
+    );
+    let redirect_to = if state.config.admin_prefix.is_empty() {
+        "/".to_owned()
+    } else {
+        state.config.admin_prefix.clone()
+    };
+    let mut resp = Redirect::to(&redirect_to).into_response();
+    if let Ok(v) = HeaderValue::from_str(&cookie) {
+        resp.headers_mut().insert(header::SET_COOKIE, v);
+    }
+    resp
+}
+
+// ============================================================ Logout (POST)
+
+async fn logout_submit(State(state): State<AppState>) -> Response {
+    let cookie = format!(
+        "{name}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0",
+        name = SESSION_COOKIE,
+    );
+    let mut resp = Redirect::to(&format!("{}/login", state.config.admin_prefix)).into_response();
+    if let Ok(v) = HeaderValue::from_str(&cookie) {
+        resp.headers_mut().insert(header::SET_COOKIE, v);
+    }
+    resp
+}
+
+// ============================================================ Middleware
+
+/// State threaded into the auth middleware — the signing secret +
+/// the login URL to redirect to on missing session. Cloned per
+/// request, kept Arc<…> so the underlying key isn't copied.
+#[derive(Clone)]
+pub(crate) struct SessionGate {
+    pub(crate) secret: Arc<AdminSessionSecret>,
+    pub(crate) login_path: String,
+}
+
+/// Gate every admin request behind a valid session cookie. The
+/// `/login` route bypasses the gate (mounted before this middleware
+/// applies on the outer Router); embedded static assets at
+/// `/__static__/...` also pass through.
+///
+/// On valid session: inserts `Extension<AdminSession>` into the
+/// request so handlers can read the current user.
+pub(crate) async fn require_session(
+    State(gate): State<SessionGate>,
+    mut request: Request<Body>,
+    next: Next,
+) -> Response {
+    let path = request.uri().path();
+    if path == gate.login_path || path == "/login" || path.starts_with("/__static__") {
+        return next.run(request).await;
+    }
+
+    if let Some(session) = read_session_cookie(&request, &gate.secret) {
+        request.extensions_mut().insert(session);
+        return next.run(request).await;
+    }
+
+    // No valid session — bounce to the login form. Use 303 See Other
+    // so the GET semantics are preserved (browsers follow with GET).
+    Redirect::to(&gate.login_path).into_response()
+}
+
+fn read_session_cookie(req: &Request<Body>, secret: &AdminSessionSecret) -> Option<AdminSession> {
+    let raw = req.headers().get(header::COOKIE)?.to_str().ok()?;
+    for part in raw.split(';').map(str::trim) {
+        if let Some(val) = part.strip_prefix(&format!("{SESSION_COOKIE}=")) {
+            return session::decode(secret, val);
+        }
+    }
+    None
+}

--- a/crates/rustango/src/admin/mod.rs
+++ b/crates/rustango/src/admin/mod.rs
@@ -46,6 +46,9 @@ mod errors;
 mod forms;
 mod helpers;
 pub mod inlines;
+mod login_view;
+pub mod session;
+pub mod user;
 // `pub(crate)` so the operator console can reuse `render_input` /
 // `render_value_for_input` for its `/orgs/{slug}/edit` form. Stays
 // non-public outside the crate — the helpers' signatures are still
@@ -61,4 +64,6 @@ pub use errors::AdminError;
 pub use inlines::{
     InlineAdmin, InlineAdminGeneric, InlineApplyOutcome, InlineFormPanel, InlineKind, InlinePanel,
 };
+pub use session::{AdminSession, AdminSessionSecret};
 pub use urls::{router, AdminActionFn, AdminActionFuture, Builder};
+pub use user::AdminUser;

--- a/crates/rustango/src/admin/session.rs
+++ b/crates/rustango/src/admin/session.rs
@@ -1,0 +1,155 @@
+//! Signed-cookie session auth for the bare `admin` module.
+//!
+//! Issue #253. Gives non-tenancy projects the Django-shape admin
+//! login UX (`/login` form, signed cookie, sidebar `Logout`) without
+//! pulling in the tenancy stack.
+//!
+//! ## Reuse with `tenancy::session`
+//!
+//! The HMAC signing primitive ([`crate::session::SessionSecret`] +
+//! [`crate::session::sign`]) lives at the crate root and is shared
+//! with `tenancy::session`. Both modules layer their own payload
+//! shape on top — tenancy carries `(operator_id, exp, iat)`, admin
+//! carries `(user_id, is_superuser, exp)` — so the cookies are
+//! distinct (different name AND different shape) but the crypto is
+//! identical and lives in exactly one place.
+
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use subtle::ConstantTimeEq;
+
+use crate::session::sign;
+pub use crate::session::SessionSecret as AdminSessionSecret;
+
+/// Default session TTL — 8 hours. Operators get re-prompted once a
+/// workday. Future slice exposes this as a knob on
+/// [`crate::admin::Builder`].
+const DEFAULT_TTL_SECS: i64 = 8 * 60 * 60;
+
+/// Cookie name the admin session is stored under. Distinct from any
+/// `tenancy` cookies so the two layers can coexist on one host.
+pub(crate) const SESSION_COOKIE: &str = "rustango_admin_session";
+
+/// The user-facing handle the login middleware drops into the
+/// request extension on every authenticated request. Use as an
+/// extractor on admin-side handlers if you need to know who's
+/// signed in.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct AdminSession {
+    /// Primary key of the [`AdminUser`](super::user::AdminUser) row.
+    pub user_id: i64,
+    /// `true` when the user's `is_superuser` flag was set at
+    /// login time. Cached on the cookie so the visibility check
+    /// in the chrome doesn't need a DB hit per request.
+    pub is_superuser: bool,
+}
+
+/// Wire payload — sent through `sign` + base64. Wraps [`AdminSession`]
+/// with an `exp` timestamp so expired cookies fail closed.
+#[derive(Serialize, Deserialize)]
+struct CookiePayload {
+    user_id: i64,
+    is_superuser: bool,
+    /// Unix timestamp the session expires at.
+    exp: i64,
+}
+
+impl CookiePayload {
+    fn is_expired(&self) -> bool {
+        chrono::Utc::now().timestamp() >= self.exp
+    }
+}
+
+/// Sign a fresh session — returns the cookie value to set on the
+/// response. TTL defaults to 8 hours.
+#[must_use]
+pub(crate) fn encode(secret: &AdminSessionSecret, session: AdminSession) -> String {
+    let payload = CookiePayload {
+        user_id: session.user_id,
+        is_superuser: session.is_superuser,
+        exp: chrono::Utc::now().timestamp() + DEFAULT_TTL_SECS,
+    };
+    let json = serde_json::to_vec(&payload).expect("payload serializes");
+    let body = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&json);
+    let sig = sign(secret, body.as_bytes());
+    let sig_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(sig);
+    format!("{body}.{sig_b64}")
+}
+
+/// Verify + decode a cookie value. Returns `Some(session)` only when
+/// the signature is valid AND the payload hasn't expired. Any other
+/// failure (malformed, tampered signature, expired) maps to `None`
+/// so the caller treats the request as unauthenticated.
+#[must_use]
+pub(crate) fn decode(secret: &AdminSessionSecret, value: &str) -> Option<AdminSession> {
+    let (body, sig_b64) = value.split_once('.')?;
+    let expected = sign(secret, body.as_bytes());
+    let provided = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(sig_b64)
+        .ok()?;
+    // Constant-time comparison — same primitive `tenancy::session`
+    // uses. Defends against timing-channel cookie forgery probes.
+    if expected.ct_eq(&provided[..]).unwrap_u8() == 0 {
+        return None;
+    }
+    let json = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(body)
+        .ok()?;
+    let payload: CookiePayload = serde_json::from_slice(&json).ok()?;
+    if payload.is_expired() {
+        return None;
+    }
+    Some(AdminSession {
+        user_id: payload.user_id,
+        is_superuser: payload.is_superuser,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_recovers_session_fields() {
+        let secret = AdminSessionSecret::from_bytes(vec![42u8; 32]);
+        let cookie = encode(
+            &secret,
+            AdminSession {
+                user_id: 7,
+                is_superuser: true,
+            },
+        );
+        let session = decode(&secret, &cookie).expect("valid cookie verifies");
+        assert_eq!(session.user_id, 7);
+        assert!(session.is_superuser);
+    }
+
+    #[test]
+    fn tampered_signature_rejected() {
+        let secret = AdminSessionSecret::from_bytes(vec![1u8; 32]);
+        let cookie = encode(
+            &secret,
+            AdminSession {
+                user_id: 1,
+                is_superuser: false,
+            },
+        );
+        let (body, _sig) = cookie.split_once('.').unwrap();
+        let bad = format!("{body}.AAAA");
+        assert!(decode(&secret, &bad).is_none());
+    }
+
+    #[test]
+    fn wrong_secret_rejected() {
+        let secret_a = AdminSessionSecret::from_bytes(vec![1u8; 32]);
+        let secret_b = AdminSessionSecret::from_bytes(vec![2u8; 32]);
+        let cookie = encode(
+            &secret_a,
+            AdminSession {
+                user_id: 1,
+                is_superuser: false,
+            },
+        );
+        assert!(decode(&secret_b, &cookie).is_none());
+    }
+}

--- a/crates/rustango/src/admin/templates.rs
+++ b/crates/rustango/src/admin/templates.rs
@@ -34,6 +34,7 @@ fn templates() -> &'static tera::Tera {
                 include_str!("templates/_inline_panels.html"),
             ),
             ("form.html", include_str!("templates/form.html")),
+            ("login.html", include_str!("templates/login.html")),
             ("audit_log.html", include_str!("templates/audit_log.html")),
         ])
         .expect("admin templates compile");

--- a/crates/rustango/src/admin/templates/_sidebar.html
+++ b/crates/rustango/src/admin/templates/_sidebar.html
@@ -30,4 +30,17 @@
     {% else %}
         <p class="empty">No models registered.</p>
     {% endif %}
+    {# #253 — sidebar Logout button. Rendered as a POST form so a
+       cross-site GET can't sign the operator out. The chrome
+       context only sets `session_user` when the session-auth
+       middleware seated an `AdminSession` on the request. #}
+    {% if session_user %}
+        <form method="post" action="{{ admin_prefix }}/logout" class="logout-form">
+            <p class="signed-in-as">
+                Signed in
+                {% if session_user.is_superuser %}<small>(superuser)</small>{% endif %}
+            </p>
+            <button type="submit">Logout</button>
+        </form>
+    {% endif %}
 </aside>

--- a/crates/rustango/src/admin/templates/login.html
+++ b/crates/rustango/src/admin/templates/login.html
@@ -1,0 +1,87 @@
+{# Login form for the bare admin's session-auth layer (#253).
+   Reuses the shared theme tokens + admin styles so the form
+   matches the rest of the admin chrome. #}
+<!doctype html>
+<html lang="en" data-theme="auto">
+<head>
+<meta charset="utf-8">
+<title>{{ title }} — {{ admin_title }}</title>
+{% include "_theme_tokens.html" %}
+{% include "_admin_styles.html" %}
+<style>
+  body.admin-login {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    background: var(--color-bg);
+  }
+  .login-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-6);
+    width: min(100%, 380px);
+    box-shadow: var(--shadow-md);
+  }
+  .login-card h1 {
+    margin: 0 0 var(--space-4);
+    font-size: 1.4rem;
+  }
+  .login-card label {
+    display: block;
+    margin-top: var(--space-3);
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+  }
+  .login-card input[type="text"],
+  .login-card input[type="password"] {
+    width: 100%;
+    margin-top: var(--space-1);
+    padding: var(--space-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    background: var(--color-bg);
+    color: var(--color-text);
+    font: inherit;
+    box-sizing: border-box;
+  }
+  .login-card button {
+    margin-top: var(--space-4);
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    background: var(--color-accent);
+    color: var(--color-on-accent);
+    border: 0;
+    border-radius: var(--radius);
+    font: inherit;
+    cursor: pointer;
+  }
+  .login-card button:hover { filter: brightness(1.05); }
+  .login-card .error {
+    margin-top: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    background: color-mix(in srgb, var(--color-danger, #d33) 12%, transparent);
+    border: 1px solid var(--color-danger, #d33);
+    border-radius: var(--radius);
+    color: var(--color-danger, #d33);
+    font-size: 0.9rem;
+  }
+</style>
+</head>
+<body class="admin-login">
+  <form class="login-card" method="post" action="{{ action }}">
+    <h1>{{ admin_title }}</h1>
+    {% if error %}<p class="error">{{ error }}</p>{% endif %}
+    <label>
+      Username
+      <input type="text" name="username" autocomplete="username" autofocus required>
+    </label>
+    <label>
+      Password
+      <input type="password" name="password" autocomplete="current-password" required>
+    </label>
+    <button type="submit">Sign in</button>
+  </form>
+</body>
+</html>

--- a/crates/rustango/src/admin/urls.rs
+++ b/crates/rustango/src/admin/urls.rs
@@ -193,6 +193,14 @@ pub(crate) struct Config {
     /// Per-request override: `?count=skip` (or `?count=0`) on the
     /// list URL applies the same skip without a code change.
     pub(crate) skip_count_tables: HashSet<String>,
+    /// v0.45 (#253) — opt-in session auth. When `Some`, the
+    /// Builder installs `/login` + `/logout` routes and gates
+    /// every other admin route behind a valid signed-cookie
+    /// session. Set via
+    /// [`Builder::with_session_auth`]. `None` = legacy behavior
+    /// (no auth, or basic-auth via the separate
+    /// `protect_with_basic_auth` wrapper).
+    pub(crate) session_secret: Option<crate::session::SessionSecret>,
 }
 
 impl Builder {
@@ -302,6 +310,42 @@ impl Builder {
         let s: String = prefix.into();
         let trimmed = s.trim_end_matches('/').to_owned();
         self.config.admin_prefix = trimmed;
+        self
+    }
+
+    /// v0.45 (#253) — opt into signed-cookie session auth. When set,
+    /// `.build()` will:
+    ///
+    /// 1. Mount `/login` (GET form + POST submit) + `/logout` (POST).
+    /// 2. Wrap every other admin route in an auth middleware that
+    ///    redirects unauthenticated requests to `/login`.
+    /// 3. Render the sidebar "Logout" form so the operator can
+    ///    sign out.
+    ///
+    /// Credentials are stored in the `rustango_admin_users` table
+    /// ([`crate::admin::AdminUser`]). Bootstrap the table via
+    /// [`crate::server::AppBuilder::bootstrap`] or apply a
+    /// migration; create your first operator with
+    /// `AdminUser::new_with_password(...).insert(pool)`.
+    ///
+    /// The signing key comes from
+    /// [`crate::session::SessionSecret`] — same primitive
+    /// `tenancy::session` uses, so a host running both layers can
+    /// share one key (cookie names + payload shapes differ so the
+    /// two layers never cross-decode).
+    ///
+    /// ```ignore
+    /// use rustango::session::SessionSecret;
+    ///
+    /// let secret = SessionSecret::from_env_or_random();
+    /// let admin = rustango::admin::Builder::new(pool)
+    ///     .admin_prefix("")
+    ///     .with_session_auth(secret)
+    ///     .build();
+    /// ```
+    #[must_use]
+    pub fn with_session_auth(mut self, secret: crate::session::SessionSecret) -> Self {
+        self.config.session_secret = Some(secret);
         self
     }
 
@@ -559,7 +603,14 @@ impl Builder {
         // dialect emitters (`audit::*_pool`, `tenancy::permissions::*_pool`).
         let audit_path = self.config.audit_url.clone();
         let audit_cleanup_path = format!("{audit_path}/cleanup");
-        Router::new()
+        let session_secret = self.config.session_secret.clone();
+        let admin_prefix = self.config.admin_prefix.clone();
+        let state = AppState {
+            pool: self.pool,
+            config: Arc::new(self.config),
+        };
+
+        let protected = Router::new()
             .route("/", get(views::index))
             .route(&audit_path, get(super::audit::audit_log_view))
             .route(
@@ -578,10 +629,32 @@ impl Builder {
             )
             .route("/{table}/{pk}/edit", get(views::edit_form))
             .route("/{table}/{pk}/delete", post(views::delete_submit))
-            .with_state(AppState {
-                pool: self.pool,
-                config: Arc::new(self.config),
-            })
+            .with_state(state.clone());
+
+        // #253 — when session auth is configured, mount the
+        // `/login` + `/logout` routes BEFORE applying the auth
+        // middleware so they stay reachable while every other route
+        // requires a valid session.
+        if let Some(secret) = session_secret {
+            use std::sync::Arc as StdArc;
+            let gate = super::login_view::SessionGate {
+                secret: StdArc::new(secret),
+                login_path: if admin_prefix.is_empty() {
+                    "/login".to_owned()
+                } else {
+                    format!("{admin_prefix}/login")
+                },
+            };
+            let protected = protected.route_layer(axum::middleware::from_fn_with_state(
+                gate,
+                super::login_view::require_session,
+            ));
+            return Router::new()
+                .merge(super::login_view::router(state))
+                .merge(protected);
+        }
+
+        protected
     }
 }
 

--- a/crates/rustango/src/admin/user.rs
+++ b/crates/rustango/src/admin/user.rs
@@ -1,0 +1,75 @@
+//! `AdminUser` — credential store for the bare admin's session-auth
+//! layer. Issue #253 slice A.
+//!
+//! Single-table user store, deliberately tiny — username, password
+//! hash, superuser flag, active flag, created-at timestamp. Holds the
+//! bare minimum to support `POST /login` against
+//! [`crate::passwords::verify`] and a sidebar visibility check.
+//!
+//! Apps that need richer user shapes (roles, permissions, profile
+//! data) layer those on top in their own tables, or graduate to the
+//! `tenancy` feature where the full `tenancy::User` lives.
+
+use crate::sql::Auto;
+use crate::Model;
+
+/// Admin operator account. The table is created on bootstrap by
+/// [`crate::admin::Builder::with_session_auth`] when the schema
+/// isn't already present (mirrors the bootstrap helper
+/// `crate::server::AppBuilder::bootstrap` shape).
+///
+/// `username` is the natural login key; the table-level UNIQUE
+/// index enforces no duplicates. `password_hash` is whatever
+/// [`crate::passwords::hash`] produces (argon2id PHC string).
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "rustango_admin_users",
+    app = "admin",
+    display = "username",
+    admin(
+        list_display = "username, is_superuser, active, created_at",
+        search_fields = "username",
+        ordering = "username",
+    )
+)]
+pub struct AdminUser {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 150, unique)]
+    pub username: String,
+    /// argon2id PHC string from [`crate::passwords::hash`].
+    #[rustango(max_length = 200)]
+    pub password_hash: String,
+    /// `true` = full admin access. `false` = future-slice's
+    /// filtered-model view; today honored only by the sidebar.
+    #[rustango(default = "false")]
+    pub is_superuser: bool,
+    /// Soft-disable flag — set to `false` to lock out without
+    /// deleting. The login handler rejects inactive users.
+    #[rustango(default = "true")]
+    pub active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl AdminUser {
+    /// Hash the password and build a fresh `AdminUser` ready for
+    /// `.insert(pool)`. Returns the propagated `crate::passwords::Error`
+    /// when hashing fails.
+    ///
+    /// # Errors
+    /// [`crate::passwords::PasswordError`] from `passwords::hash`.
+    pub fn new_with_password(
+        username: impl Into<String>,
+        password: &str,
+        is_superuser: bool,
+    ) -> Result<Self, crate::passwords::PasswordError> {
+        Ok(Self {
+            id: Auto::Unset,
+            username: username.into(),
+            password_hash: crate::passwords::hash(password)?,
+            is_superuser,
+            active: true,
+            created_at: chrono::Utc::now(),
+        })
+    }
+}

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -909,6 +909,18 @@ pub mod password_validators;
 /// upgrade the stored hash. Issue #54 (partial).
 pub mod password_hashers;
 
+/// Signed-cookie session primitives — HMAC-SHA256 key wrapper +
+/// `sign(secret, msg)` helper. Shared by every layer that ships a
+/// signed cookie ([`tenancy::session`], [`admin::session`]) so the
+/// crypto lives in one place. See [`session::SessionSecret`].
+///
+/// Compiled when either the `admin` or `tenancy` feature is on —
+/// both bring in the underlying HMAC + base64 crates as transitive
+/// deps. Bare-ORM builds (`default-features = false` without admin
+/// / tenancy) skip the module entirely.
+#[cfg(any(feature = "admin", feature = "tenancy"))]
+pub mod session;
+
 /// XML sitemap rendering — `django.contrib.sitemaps`. Build a
 /// `Sitemap` impl (or pass a `Vec<SitemapEntry>` directly) and call
 /// [`sitemaps::render_sitemap`]; for large sites use

--- a/crates/rustango/src/session.rs
+++ b/crates/rustango/src/session.rs
@@ -1,0 +1,282 @@
+//! Signed-cookie session primitives — HMAC-SHA256 key wrapper, sign,
+//! and verify helpers shared across the framework.
+//!
+//! This module deliberately holds **only the crypto primitive + key
+//! management**, never payload shape. Layers above (`tenancy::session`
+//! for operator/tenant cookies, `admin::session` for the bare-admin
+//! session cookie, …) define their own payload structs and call into
+//! [`sign`] to produce the MAC. That way two layers can share one
+//! signing key safely — they just need distinct cookie names + payload
+//! shapes so neither layer accidentally decodes the other's cookie.
+//!
+//! Lives at the crate root (not under any feature flag) so the bare
+//! `admin` module can use the same primitives even when the `tenancy`
+//! feature is off — closes the duplication concern raised in #253.
+
+use base64::Engine;
+use hmac::{Hmac, Mac};
+use rand::{rngs::OsRng, RngCore};
+use sha2::Sha256;
+
+/// Error returned by [`SessionSecret::try_from_env`] when the
+/// `RUSTANGO_SESSION_SECRET` env var is set but the value isn't a
+/// valid signing key. Used by production boot paths that prefer to
+/// fail loudly over silently downgrading to an ephemeral random key.
+#[derive(Debug)]
+pub enum SessionSecretError {
+    /// The env var didn't decode as base64.
+    BadBase64 { cause: String },
+    /// Decoded successfully but the resulting key is fewer than 32
+    /// bytes — too short for HMAC-SHA256.
+    TooShort { actual: usize },
+}
+
+impl core::fmt::Display for SessionSecretError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::BadBase64 { cause } => write!(
+                f,
+                "RUSTANGO_SESSION_SECRET is not valid base64: {cause} \
+                 (generate one with: openssl rand -base64 32)"
+            ),
+            Self::TooShort { actual } => write!(
+                f,
+                "RUSTANGO_SESSION_SECRET decoded to {actual} bytes; need at least 32 \
+                 (generate one with: openssl rand -base64 32)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SessionSecretError {}
+
+/// Server-held signing key. Wrap `Vec<u8>` so callers can't
+/// accidentally print it. `Clone` is opt-in so the same secret can
+/// be shared across layers that use distinct cookie names + payload
+/// shapes (e.g. tenancy operator + tenancy tenant + bare admin —
+/// three layers, one key, three independent cookies).
+#[derive(Clone)]
+pub struct SessionSecret(Vec<u8>);
+
+impl SessionSecret {
+    /// Read the secret from `RUSTANGO_SESSION_SECRET` (base64-encoded
+    /// 32+ bytes). Falls back to a randomly generated secret with a
+    /// `tracing::warn` when the var is *unset* — sessions are then
+    /// invalidated on every server restart.
+    ///
+    /// When the var IS set but unparseable (bad base64, fewer than
+    /// 32 bytes), we ALSO print a loud `eprintln!` to stderr in
+    /// addition to the tracing::warn (history: operators who set
+    /// the var and forgot to run it through `base64` quietly lost
+    /// session persistence on every redeploy).
+    #[must_use]
+    pub fn from_env_or_random() -> Self {
+        if let Ok(raw) = std::env::var("RUSTANGO_SESSION_SECRET") {
+            match base64::engine::general_purpose::STANDARD.decode(raw.trim()) {
+                Ok(bytes) if bytes.len() >= 32 => return Self(bytes),
+                Ok(bytes) => {
+                    tracing::warn!(
+                        actual_len = bytes.len(),
+                        "RUSTANGO_SESSION_SECRET decoded to fewer than 32 bytes — falling back to random",
+                    );
+                    eprintln!(
+                        "\x1b[33;1mwarning:\x1b[0m RUSTANGO_SESSION_SECRET is set but \
+                         decoded to {} bytes (need ≥ 32). Using a random key. \
+                         Sessions will NOT survive a server restart. \
+                         Generate one with: \
+                         openssl rand -base64 32",
+                        bytes.len()
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "RUSTANGO_SESSION_SECRET is not valid base64 — falling back to random",
+                    );
+                    eprintln!(
+                        "\x1b[33;1mwarning:\x1b[0m RUSTANGO_SESSION_SECRET is set but \
+                         is not valid base64 ({e}). Using a random key. \
+                         Sessions will NOT survive a server restart. \
+                         Generate one with: \
+                         openssl rand -base64 32",
+                    );
+                }
+            }
+        } else {
+            tracing::warn!(
+                "RUSTANGO_SESSION_SECRET not set — generating random key (sessions \
+                 will not survive server restarts; set the env var for production)",
+            );
+        }
+        let mut buf = vec![0u8; 32];
+        OsRng.fill_bytes(&mut buf);
+        Self(buf)
+    }
+
+    /// Dev-friendly variant of [`Self::from_env_or_random`] that
+    /// persists the generated key to disk so sessions survive
+    /// server restarts even without `RUSTANGO_SESSION_SECRET` set.
+    ///
+    /// Resolution order:
+    /// 1. `RUSTANGO_SESSION_SECRET` env var — production path.
+    /// 2. Read `disk_path` if it exists and contains ≥ 32 bytes.
+    /// 3. Generate a random key, atomically write it to `disk_path`
+    ///    (creating parent directories as needed), and return it.
+    /// 4. If the write fails, fall back to ephemeral random + a
+    ///    `tracing::warn!`.
+    ///
+    /// Used by the runserver boot path so dev `cargo run` cycles
+    /// don't sign every operator out on every reload (#69).
+    /// Production deployments should still set
+    /// `RUSTANGO_SESSION_SECRET` so the secret lives in env / a
+    /// secret-manager rather than the filesystem.
+    #[must_use]
+    pub fn from_env_or_disk(disk_path: &std::path::Path) -> Self {
+        if let Ok(raw) = std::env::var("RUSTANGO_SESSION_SECRET") {
+            if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(raw.trim()) {
+                if bytes.len() >= 32 {
+                    return Self(bytes);
+                }
+            }
+            // Bad env var — fall through to disk/random. The loud
+            // warnings live on `from_env_or_random` for callers that
+            // want them.
+        }
+        if let Ok(bytes) = std::fs::read(disk_path) {
+            if bytes.len() >= 32 {
+                tracing::info!(
+                    path = %disk_path.display(),
+                    "loaded persisted session secret from disk",
+                );
+                return Self(bytes);
+            }
+        }
+        let mut buf = vec![0u8; 32];
+        OsRng.fill_bytes(&mut buf);
+        if let Some(parent) = disk_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let tmp_path = disk_path.with_extension("tmp");
+        match std::fs::write(&tmp_path, &buf).and_then(|_| std::fs::rename(&tmp_path, disk_path)) {
+            Ok(()) => {
+                restrict_session_secret_perms(disk_path);
+                tracing::info!(
+                    path = %disk_path.display(),
+                    "generated new session secret and persisted to disk \
+                     (set RUSTANGO_SESSION_SECRET to override; this message \
+                     only fires on first boot)",
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %disk_path.display(),
+                    error = %e,
+                    "could not persist session secret to disk — using ephemeral random key",
+                );
+                let _ = std::fs::remove_file(&tmp_path);
+            }
+        }
+        Self(buf)
+    }
+
+    /// Strict variant of [`Self::from_env_or_random`]: returns
+    /// `Err(...)` when the env var is *set but unparseable* or
+    /// *too short*. Use this from production boot paths where a
+    /// malformed secret should fail loudly instead of silently
+    /// downgrading to a random ephemeral key.
+    ///
+    /// # Errors
+    /// `SessionSecretError::BadBase64` when decode fails;
+    /// `SessionSecretError::TooShort` when the decoded bytes are
+    /// fewer than 32.
+    pub fn try_from_env() -> Result<Self, SessionSecretError> {
+        if let Ok(raw) = std::env::var("RUSTANGO_SESSION_SECRET") {
+            return match base64::engine::general_purpose::STANDARD.decode(raw.trim()) {
+                Ok(bytes) if bytes.len() >= 32 => Ok(Self(bytes)),
+                Ok(bytes) => Err(SessionSecretError::TooShort {
+                    actual: bytes.len(),
+                }),
+                Err(e) => Err(SessionSecretError::BadBase64 {
+                    cause: e.to_string(),
+                }),
+            };
+        }
+        tracing::warn!(
+            "RUSTANGO_SESSION_SECRET not set — generating random key (sessions \
+             will not survive server restarts; set the env var for production)",
+        );
+        let mut buf = vec![0u8; 32];
+        OsRng.fill_bytes(&mut buf);
+        Ok(Self(buf))
+    }
+
+    /// Construct from raw bytes — useful for tests + callers that
+    /// load the key from a custom source.
+    #[must_use]
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    /// Raw key material. `pub(crate)` so framework modules can sign
+    /// or verify payloads, but external callers go through
+    /// [`sign`] / their layer's own encode/decode helpers.
+    pub(crate) fn key(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// Restrict the persisted session-secret file to 0600 on Unix so
+/// other users on the host can't read the signing key. Windows ACL
+/// hardening is separate (DPAPI / restricted DACL).
+#[cfg(unix)]
+fn restrict_session_secret_perms(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Ok(mut perms) = std::fs::metadata(path).map(|m| m.permissions()) {
+        perms.set_mode(0o600);
+        let _ = std::fs::set_permissions(path, perms);
+    }
+}
+
+#[cfg(not(unix))]
+fn restrict_session_secret_perms(_path: &std::path::Path) {
+    // No portable equivalent.
+}
+
+/// HMAC-SHA256(secret, msg), truncated to 32 bytes. The shared MAC
+/// primitive every signed-cookie layer in the framework calls into.
+#[must_use]
+pub fn sign(secret: &SessionSecret, msg: &[u8]) -> [u8; 32] {
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(secret.key()).expect("HMAC accepts any key length");
+    mac.update(msg);
+    let bytes = mac.finalize().into_bytes();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes[..32]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sign_is_deterministic_per_key() {
+        let secret = SessionSecret::from_bytes(b"a-test-secret-thirty-two-bytes-x".to_vec());
+        let a = sign(&secret, b"hello");
+        let b = sign(&secret, b"hello");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn sign_differs_across_keys() {
+        let s1 = SessionSecret::from_bytes(vec![1u8; 32]);
+        let s2 = SessionSecret::from_bytes(vec![2u8; 32]);
+        assert_ne!(sign(&s1, b"x"), sign(&s2, b"x"));
+    }
+
+    #[test]
+    fn from_bytes_round_trip() {
+        let secret = SessionSecret::from_bytes(vec![0xab; 40]);
+        assert_eq!(secret.key().len(), 40);
+    }
+}

--- a/crates/rustango/src/tenancy/session.rs
+++ b/crates/rustango/src/tenancy/session.rs
@@ -21,11 +21,19 @@
 //! ```
 
 use base64::Engine;
-use hmac::{Hmac, Mac};
-use rand::{rngs::OsRng, RngCore};
 use serde::{Deserialize, Serialize};
-use sha2::Sha256;
 use subtle::ConstantTimeEq;
+
+// v0.45 (#253) — `SessionSecret` + `sign` were promoted to the
+// crate-root `crate::session` module so the bare `admin` module can
+// reuse the same HMAC primitives without compiling in `tenancy`.
+// The re-exports below keep every pre-existing `crate::tenancy::session::SessionSecret`
+// caller working.
+pub use crate::session::{SessionSecret, SessionSecretError};
+// `sign` re-exported at crate-internal visibility so existing
+// callers (`tenant_console`, `impersonation_handoff`) keep working
+// after the v0.45 move to `crate::session`.
+pub(crate) use crate::session::sign;
 
 /// Default cookie name. Visible in browser devtools — namespaced so
 /// it doesn't collide with tenant cookies.
@@ -86,286 +94,6 @@ impl SessionPayload {
     }
 }
 
-/// Server-held signing key. Wrap `Vec<u8>` so callers can't
-/// accidentally print it. `Clone` is opt-in so the same secret can
-/// be handed to both the operator console and the tenant admin —
-/// they use different cookie names + payload shapes, so sharing
-/// the key is safe.
-#[derive(Clone)]
-pub struct SessionSecret(Vec<u8>);
-
-/// Error returned by [`SessionSecret::try_from_env`] when the
-/// `RUSTANGO_SESSION_SECRET` env var is set but the value isn't a
-/// valid signing key. Used by production boot paths that prefer to
-/// fail loudly over silently downgrading to an ephemeral random key.
-#[derive(Debug)]
-pub enum SessionSecretError {
-    /// The env var didn't decode as base64.
-    BadBase64 { cause: String },
-    /// Decoded successfully but the resulting key is fewer than 32
-    /// bytes — too short for HMAC-SHA256.
-    TooShort { actual: usize },
-}
-
-impl core::fmt::Display for SessionSecretError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::BadBase64 { cause } => write!(
-                f,
-                "RUSTANGO_SESSION_SECRET is not valid base64: {cause} \
-                 (generate one with: openssl rand -base64 32)"
-            ),
-            Self::TooShort { actual } => write!(
-                f,
-                "RUSTANGO_SESSION_SECRET decoded to {actual} bytes; need at least 32 \
-                 (generate one with: openssl rand -base64 32)"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for SessionSecretError {}
-
-impl SessionSecret {
-    /// Read the secret from `RUSTANGO_SESSION_SECRET` (base64-encoded
-    /// 32+ bytes). Falls back to a randomly generated secret with a
-    /// `tracing::warn` when the var is *unset* — sessions are then
-    /// invalidated on every server restart.
-    ///
-    /// v0.13.2 — when the var IS set but unparseable (bad base64,
-    /// fewer than 32 bytes), we now ALSO print a loud
-    /// `eprintln!` to stderr in addition to the tracing::warn.
-    /// Operators who set the var and forget to run it through
-    /// `base64` quietly lost session persistence on every redeploy
-    /// before this fix, with the only signal being a structured
-    /// log line buried in the boot output. The eprintln! makes the
-    /// failure mode loud at the boot console.
-    #[must_use]
-    pub fn from_env_or_random() -> Self {
-        if let Ok(raw) = std::env::var("RUSTANGO_SESSION_SECRET") {
-            match base64::engine::general_purpose::STANDARD.decode(raw.trim()) {
-                Ok(bytes) if bytes.len() >= 32 => return Self(bytes),
-                Ok(bytes) => {
-                    tracing::warn!(
-                        target: "crate::tenancy",
-                        actual_len = bytes.len(),
-                        "RUSTANGO_SESSION_SECRET decoded to fewer than 32 bytes — falling back to random",
-                    );
-                    eprintln!(
-                        "\x1b[33;1mwarning:\x1b[0m RUSTANGO_SESSION_SECRET is set but \
-                         decoded to {} bytes (need ≥ 32). Using a random key. \
-                         Sessions will NOT survive a server restart. \
-                         Generate one with: \
-                         openssl rand -base64 32",
-                        bytes.len()
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        target: "crate::tenancy",
-                        error = %e,
-                        "RUSTANGO_SESSION_SECRET is not valid base64 — falling back to random",
-                    );
-                    eprintln!(
-                        "\x1b[33;1mwarning:\x1b[0m RUSTANGO_SESSION_SECRET is set but \
-                         is not valid base64 ({}). Using a random key. \
-                         Sessions will NOT survive a server restart. \
-                         Generate one with: \
-                         openssl rand -base64 32",
-                        e
-                    );
-                }
-            }
-        } else {
-            tracing::warn!(
-                target: "crate::tenancy",
-                "RUSTANGO_SESSION_SECRET not set — generating random key (sessions \
-                 will not survive server restarts; set the env var for production)",
-            );
-        }
-        let mut buf = vec![0u8; 32];
-        // v0.30.12 — use OsRng directly (cryptographic secret).
-        // Consistent with src/forms/csrf.rs + src/passwords.rs.
-        OsRng.fill_bytes(&mut buf);
-        Self(buf)
-    }
-
-    /// Dev-friendly variant of [`Self::from_env_or_random`] that
-    /// persists the generated key to disk so sessions survive
-    /// server restarts even without `RUSTANGO_SESSION_SECRET` set.
-    ///
-    /// Resolution order:
-    /// 1. `RUSTANGO_SESSION_SECRET` env var (same shape as
-    ///    [`Self::from_env_or_random`]) — production path.
-    /// 2. Read `disk_path` if it exists and contains ≥ 32 bytes.
-    /// 3. Generate a random key, atomically write it to
-    ///    `disk_path` (creating parent directories as needed),
-    ///    and return it.
-    /// 4. If the write fails (read-only filesystem, no perms),
-    ///    fall back to ephemeral random + a `tracing::warn!`.
-    ///
-    /// Used by the runserver boot path so dev `cargo run` cycles
-    /// don't sign every operator out on every reload (#69).
-    /// Production deployments should still set
-    /// `RUSTANGO_SESSION_SECRET` so the secret lives in env/secret-
-    /// manager rather than the filesystem.
-    #[must_use]
-    pub fn from_env_or_disk(disk_path: &std::path::Path) -> Self {
-        // Env var path: identical to `from_env_or_random`'s first
-        // branch. Duplicating here rather than calling the existing
-        // method because that method falls through to ephemeral
-        // random — we want disk fallback in between.
-        if let Ok(raw) = std::env::var("RUSTANGO_SESSION_SECRET") {
-            if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(raw.trim()) {
-                if bytes.len() >= 32 {
-                    return Self(bytes);
-                }
-            }
-            // Bad env var — fall through to disk/random with the
-            // same loud warnings as `from_env_or_random` would emit.
-            // (We don't re-emit them here to keep the boot log
-            // tidy — the env-var path is exercised by
-            // `from_env_or_random` if anyone wants the warnings.)
-        }
-        // Disk path: read existing key if present.
-        if let Ok(bytes) = std::fs::read(disk_path) {
-            if bytes.len() >= 32 {
-                // v0.31.1 (#7): bumped from `debug!` to `info!` so the
-                // happy-path "your session keys are persistent" message
-                // shows up in default-log boots and operators can tell
-                // at a glance whether the secret is freshly generated
-                // or carried over from a prior run.
-                tracing::info!(
-                    target: "crate::tenancy::session",
-                    path = %disk_path.display(),
-                    "loaded persisted session secret from disk",
-                );
-                return Self(bytes);
-            }
-        }
-        // Generate a fresh key and try to persist it.
-        let mut buf = vec![0u8; 32];
-        // v0.30.12 — use OsRng directly (cryptographic secret).
-        // Consistent with src/forms/csrf.rs + src/passwords.rs.
-        OsRng.fill_bytes(&mut buf);
-        if let Some(parent) = disk_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        // Atomic write: tmp file → rename. Avoids half-written
-        // keys if the process is killed mid-write.
-        let tmp_path = disk_path.with_extension("tmp");
-        match std::fs::write(&tmp_path, &buf).and_then(|_| std::fs::rename(&tmp_path, disk_path)) {
-            Ok(()) => {
-                // v0.43 — restrict to 0600 on Unix so other users on
-                // the host can't read the session-signing key. Windows
-                // ACL hardening is a separate piece of work (DPAPI /
-                // restricted DACL); the warn below documents the gap.
-                restrict_session_secret_perms(disk_path);
-                // v0.31.1 (#7): clarify the "(dev fallback)" wording —
-                // the message previously made it look like the secret
-                // was being regenerated on every boot. It only fires
-                // when no env var AND no on-disk key were found, i.e.
-                // the very first boot.
-                tracing::info!(
-                    target: "crate::tenancy::session",
-                    path = %disk_path.display(),
-                    "generated new session secret and persisted to disk \
-                     (set RUSTANGO_SESSION_SECRET to override; this message \
-                     only fires on first boot)",
-                );
-            }
-            Err(e) => {
-                tracing::warn!(
-                    target: "crate::tenancy::session",
-                    path = %disk_path.display(),
-                    error = %e,
-                    "could not persist session secret to disk — using ephemeral random key (sessions will not survive restart)",
-                );
-                let _ = std::fs::remove_file(&tmp_path);
-            }
-        }
-        Self(buf)
-    }
-
-    /// Strict variant of [`Self::from_env_or_random`]: returns
-    /// `Err(...)` when the env var is *set but unparseable* or
-    /// *too short*. Use this from production boot paths where a
-    /// malformed secret should fail loudly instead of silently
-    /// downgrading to a random ephemeral key.
-    ///
-    /// Behaviour:
-    /// * Var set + ≥ 32 bytes after base64 decode → `Ok(SessionSecret)`.
-    /// * Var set but bad base64 / too short → `Err(SessionSecretError)`.
-    /// * Var unset → `Ok(random key)` with the same warn-and-go path
-    ///   as `from_env_or_random` (this is the dev/test default and
-    ///   is fine in those contexts).
-    ///
-    /// # Errors
-    /// `SessionSecretError::BadBase64` when decode fails;
-    /// `SessionSecretError::TooShort` when the decoded bytes are
-    /// fewer than 32.
-    pub fn try_from_env() -> Result<Self, SessionSecretError> {
-        if let Ok(raw) = std::env::var("RUSTANGO_SESSION_SECRET") {
-            return match base64::engine::general_purpose::STANDARD.decode(raw.trim()) {
-                Ok(bytes) if bytes.len() >= 32 => Ok(Self(bytes)),
-                Ok(bytes) => Err(SessionSecretError::TooShort {
-                    actual: bytes.len(),
-                }),
-                Err(e) => Err(SessionSecretError::BadBase64 {
-                    cause: e.to_string(),
-                }),
-            };
-        }
-        // Var unset is the dev/test path; fall back to random.
-        tracing::warn!(
-            target: "crate::tenancy",
-            "RUSTANGO_SESSION_SECRET not set — generating random key (sessions \
-             will not survive server restarts; set the env var for production)",
-        );
-        let mut buf = vec![0u8; 32];
-        // v0.30.12 — use OsRng directly (cryptographic secret).
-        // Consistent with src/forms/csrf.rs + src/passwords.rs.
-        OsRng.fill_bytes(&mut buf);
-        Ok(Self(buf))
-    }
-
-    /// Construct from raw bytes — useful for tests.
-    #[must_use]
-    pub fn from_bytes(bytes: Vec<u8>) -> Self {
-        Self(bytes)
-    }
-
-    /// Raw key material — only callers inside the tenancy crate should
-    /// reach into this; external callers go through encode/decode.
-    pub(crate) fn key(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-/// v0.43 — chmod the persisted session-secret file to 0600 on Unix.
-/// On Windows we currently rely on user-profile ACLs inherited by
-/// `./var/`; tightening the DACL is a separate effort.
-#[cfg(unix)]
-fn restrict_session_secret_perms(path: &std::path::Path) {
-    use std::os::unix::fs::PermissionsExt;
-    if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)) {
-        tracing::warn!(
-            target: "crate::tenancy::session",
-            path = %path.display(),
-            error = %e,
-            "could not chmod session secret to 0600 — file may be world-readable",
-        );
-    }
-}
-
-#[cfg(not(unix))]
-fn restrict_session_secret_perms(_path: &std::path::Path) {
-    // No portable equivalent. On Windows the file inherits the
-    // parent directory's ACL; for hard isolation set
-    // `RUSTANGO_SESSION_SECRET` from a vault instead of relying on
-    // the on-disk fallback.
-}
-
 /// Serialize and sign a payload into a cookie value.
 #[must_use]
 pub fn encode(secret: &SessionSecret, payload: &SessionPayload) -> String {
@@ -403,18 +131,7 @@ pub fn decode(secret: &SessionSecret, value: &str) -> Result<SessionPayload, Ses
     Ok(payload)
 }
 
-/// HMAC-SHA256(secret, msg), truncated to 32 bytes (the full SHA256
-/// length). Crate-visible so the tenant console can share the same
-/// MAC primitive without duplicating crypto.
-pub(crate) fn sign(secret: &SessionSecret, msg: &[u8]) -> [u8; 32] {
-    let mut mac =
-        Hmac::<Sha256>::new_from_slice(secret.key()).expect("HMAC accepts any key length");
-    mac.update(msg);
-    let bytes = mac.finalize().into_bytes();
-    let mut out = [0u8; 32];
-    out.copy_from_slice(&bytes[..32]);
-    out
-}
+// `sign` moved to `crate::session` in v0.45 (#253) — `use` above.
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Closes the user-reported regression \"admin used to have login/logout and doesn't anymore.\" The bare `admin` module only had HTTP Basic Auth via `protect_with_basic_auth`; the styled login form + cookie sessions + sidebar Logout lived in `tenancy::admin`. Non-tenancy projects fell off the Django-shape cliff at the auth boundary.

This is **slice A** of epic #253: ship the Django-shape login UX for the bare admin without dragging in tenancy, and refactor the shared crypto so neither layer duplicates HMAC code.

## Architecture: one signing primitive, two cookies

User asked explicitly: \"make sure to use reusable approach with other admin login logout and auth features.\" Result:

- **`crate::session`** (NEW, top-level, gated on `admin OR tenancy`) — reusable primitive: `SessionSecret` (HMAC-SHA256 key wrapper with env/disk/random constructors) + `sign(secret, msg)` helper. No payload shape.
- **`tenancy::session`** keeps its operator payload (`SessionPayload { oid, exp, iat }`) but **re-exports** `SessionSecret` + `sign` from `crate::session`. ~200 lines of duplicated impl deleted.
- **`admin::session`** (NEW) carries the bare-admin payload (`AdminSession { user_id, is_superuser }`), distinct cookie name (`rustango_admin_session`). Calls into `crate::session::sign`.

One signing key, two cookie names, two payload shapes. Same `RUSTANGO_SESSION_SECRET` env var feeds both layers; cookies never cross-decode.

## New admin surface

- **`admin::AdminUser`** — `rustango_admin_users` model (username unique, argon2id password hash, is_superuser, active). Constructor `AdminUser::new_with_password(...)` hashes via `crate::passwords::hash`.
- **`admin::Builder::with_session_auth(secret)`** — opt-in knob. Mounts `/login` + `/logout` and wraps everything else in a redirect-to-login middleware.
- **`admin/templates/login.html`** — styled form reusing the admin's theme tokens + chrome.
- **Sidebar Logout button** — `_sidebar.html` renders a POST form with a Logout button when chrome detects session auth is on. Per-user info (username display) deferred to slice B.

## Behavior verified end-to-end on gfk_demo

\`\`\`
GET /         no cookie → 303 → /login
GET /login    → styled form with username/password inputs
POST /login   valid creds → 303 / + signed cookie set
GET /         with cookie → 200, sidebar shows Logout
POST /logout  → 303 /login + cookie cleared (Max-Age=0)
\`\`\`

## gfk_demo wired up

The demo's `protect_with_basic_auth` wrap is replaced with `with_session_auth(SessionSecret::from_env_or_random())`. The seed provisions an admin user (defaults: \`admin / admin\`, overridable via `RUSTANGO_DEMO_USER` / `RUSTANGO_DEMO_PASS`). Visitors now see a real Django-shape login form, not a native browser dialog.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo build --no-default-features --features sqlite,tenancy\` (sqlite-tenancy litmus, clean)
- [x] \`cargo build --all-features\` (clean)
- [x] \`cargo test --workspace --all-features --lib\` (**2336 pass**, was 2330 → +6 new unit tests across `crate::session` + `admin::session`)
- [x] Live curl smoke against gfk_demo: full 6-step auth cycle (logged out redirect, login form render, POST login + cookie, authenticated index, sidebar Logout button rendering, POST logout + cookie clearing)
- [x] pre-push hook (lib tests + clippy)

## Feature gating

- `crate::session` is gated on `cfg(any(feature = \"admin\", feature = \"tenancy\"))` so its `hmac` / `sha2` / `subtle` deps don't leak into pure-ORM builds (no admin, no tenancy = no session module).
- `admin` feature now lists `passwords` + `dep:hmac/sha2/subtle` so `--features sqlite,admin` builds cleanly without `tenancy` named.

## Slice scope notes

Slice A intentionally ships the user-facing surface + the demo verification the user requested. Deferred to follow-up PRs (filed as sub-issues on #253):

- **A.8 live tests** — full auth-cycle integration test in `tests/admin_session_auth_live.rs`. Curl-based smoke covered the same path; deferred for slice scope.
- **Slice B** — `manage create-admin` CLI verb, password-change UI, username display in sidebar.
- **Slice C** — `is_superuser` enforcement on non-superuser sidebar filtering, session-secret persistence-to-disk.

Refs #253.