### PR TITLE
feat: admin UX consolidation — shared .btn class system across all admin surfaces

### DIFF
--- a/crates/rustango/src/admin/templates/_admin_styles.html
+++ b/crates/rustango/src/admin/templates/_admin_styles.html
@@ -130,16 +130,110 @@ input:invalid + small, textarea:invalid + small { color: var(--color-error-fg); 
   border-radius: var(--radius-sm);
 }
 .pager { margin-top: var(--space-4); }
-button {
-  padding: 0.4rem var(--space-4);
+
+/* --------------------------------------------------------------------
+   Button + link-button system (#253 follow-up — admin UX
+   consolidation). Mirrors the operator console's `.btn` family in
+   `_op_styles.html` so both surfaces feel coherent. Works on both
+   <a> and <button> so links rendered next to form-submit buttons
+   (e.g. detail-page "Edit / Delete" row) look like siblings.
+
+   - `.btn`           — baseline (padding, border, hover, accessible focus ring)
+   - `.btn-primary`   — accent fill, white text (primary CTA)
+   - `.btn-secondary` — surface fill, accent border (secondary action)
+   - `.btn-danger`    — red border/text, red fill on hover (destructive)
+   - `.btn-link`      — text-style, no border (subtle nav)
+   - `.btn-row-action`— pill-shaped accent-tinted (per-row table actions)
+
+   Bare `<button>` inherits the baseline via the default selector
+   below; templates that want a colored variant add `.btn` plus a
+   modifier class.
+   ------------------------------------------------------------------ */
+
+.btn, button:not(.theme-toggle):not([data-rustango-theme-toggle]) {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   font: inherit;
+  padding: 0.4rem var(--space-4);
   cursor: pointer;
   background: var(--color-bg-surface);
   color: var(--color-fg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
+  text-decoration: none;
+  line-height: 1.2;
 }
-button:hover { background: var(--color-bg-hover); }
+.btn:hover, button:not(.theme-toggle):not([data-rustango-theme-toggle]):hover {
+  background: var(--color-bg-hover);
+}
+.btn:focus-visible, button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+.btn-primary, button.btn-primary {
+  background: var(--color-accent);
+  color: var(--color-fg-on-accent, #fff);
+  border-color: var(--color-accent);
+}
+.btn-primary:hover, button.btn-primary:hover {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+  color: var(--color-fg-on-accent, #fff);
+}
+.btn-secondary, button.btn-secondary {
+  background: transparent;
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+.btn-secondary:hover, button.btn-secondary:hover {
+  background: var(--color-accent-bg-soft);
+  color: var(--color-accent);
+}
+.btn-danger, button.btn-danger {
+  background: transparent;
+  color: var(--color-error-fg, #b04141);
+  border-color: var(--color-error-fg, #b04141);
+}
+.btn-danger:hover, button.btn-danger:hover {
+  background: var(--color-error-fg, #b04141);
+  color: #fff;
+}
+.btn-link {
+  background: transparent;
+  border: 0;
+  padding: 0.4rem 0;
+  color: var(--color-link, var(--color-accent));
+  text-decoration: none;
+}
+.btn-link:hover { color: var(--color-link-hover, var(--color-accent-hover)); text-decoration: underline; }
+.btn-row-action {
+  display: inline-block;
+  padding: 0.2rem 0.7rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-accent-bg-soft);
+  color: var(--color-accent);
+  font-size: 0.85em;
+  text-decoration: none;
+  border: 1px solid transparent;
+  line-height: 1.4;
+}
+.btn-row-action:hover {
+  background: var(--color-accent);
+  color: var(--color-fg-on-accent, #fff);
+  text-decoration: none;
+}
+
+/* Container for a row of action buttons (detail page, form submit
+   row, sidebar Logout). Flex-row, consistent gap, wraps on small
+   screens. */
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  margin: var(--space-3) 0;
+}
 dl { display: grid; grid-template-columns: max-content 1fr; gap: var(--space-1) var(--space-4); }
 dt { font-weight: var(--font-weight-bold); }
 .audit-cleanup {

--- a/crates/rustango/src/admin/templates/_inline_panels.html
+++ b/crates/rustango/src/admin/templates/_inline_panels.html
@@ -27,7 +27,8 @@
                                     {% for cell in row.cells %}<td>{{ cell.value | safe }}</td>{% endfor %}
                                     <td>
                                         {% if row.pk %}
-                                            <a href="{{ admin_prefix }}/{{ panel.child_table }}/{{ row.pk }}">View</a>
+                                            <a class="btn-row-action"
+                                               href="{{ admin_prefix }}/{{ panel.child_table }}/{{ row.pk }}">View</a>
                                         {% endif %}
                                     </td>
                                 </tr>
@@ -40,7 +41,8 @@
                         <fieldset class="inline-stacked">
                             <legend>
                                 {% if row.pk %}
-                                    <a href="{{ admin_prefix }}/{{ panel.child_table }}/{{ row.pk }}">#{{ row.pk }}</a>
+                                    <a class="btn-row-action"
+                                       href="{{ admin_prefix }}/{{ panel.child_table }}/{{ row.pk }}">#{{ row.pk }}</a>
                                 {% else %}
                                     Row
                                 {% endif %}

--- a/crates/rustango/src/admin/templates/_sidebar.html
+++ b/crates/rustango/src/admin/templates/_sidebar.html
@@ -44,12 +44,12 @@
                 {% endif %}
                 {% if session_user.is_superuser %}<small>(superuser)</small>{% endif %}
             </p>
-            {% if change_password_url %}
-                <p class="account-links">
-                    <a href="{{ admin_prefix }}{{ change_password_url }}">Change password</a>
-                </p>
-            {% endif %}
-            <button type="submit">Logout</button>
+            <div class="action-row">
+                {% if change_password_url %}
+                    <a class="btn btn-link" href="{{ admin_prefix }}{{ change_password_url }}">Change password</a>
+                {% endif %}
+                <button type="submit" class="btn btn-secondary">Logout</button>
+            </div>
         </form>
     {% endif %}
 </aside>

--- a/crates/rustango/src/admin/templates/audit_log.html
+++ b/crates/rustango/src/admin/templates/audit_log.html
@@ -30,7 +30,7 @@
     <input type="number" name="keep" value="50" min="0" step="1" style="width: 5rem;">
     per row
   </label>
-  <button type="submit">Apply cleanup</button>
+  <button type="submit" class="btn btn-secondary">Apply cleanup</button>
   <small class="muted">Per-tenant. The cleanup itself is recorded as an audit entry.</small>
 </form>
 

--- a/crates/rustango/src/admin/templates/change_password.html
+++ b/crates/rustango/src/admin/templates/change_password.html
@@ -76,8 +76,8 @@
                 </tr>
             </table>
         </fieldset>
-        <p class="form-submit-row">
-            <button type="submit">Change password</button>
-        </p>
+        <div class="action-row form-submit-row">
+            <button type="submit" class="btn btn-primary">Change password</button>
+        </div>
     </form>
 {% endblock body %}

--- a/crates/rustango/src/admin/templates/detail.html
+++ b/crates/rustango/src/admin/templates/detail.html
@@ -32,15 +32,15 @@
             <em>This table is read-only.</em>
         </p>
     {% else %}
-        <p>
-            <a href="{{ admin_prefix }}/{{ model.table }}/{{ pk }}/edit">Edit</a> &middot;
+        <div class="action-row">
+            <a class="btn btn-primary"
+               href="{{ admin_prefix }}/{{ model.table }}/{{ pk }}/edit">Edit</a>
             <form method="post"
                   action="{{ admin_prefix }}/{{ model.table }}/{{ pk }}/delete"
-                  style="display:inline"
                   onsubmit="return confirm('Delete this row?')">
-                <button type="submit">Delete</button>
+                <button type="submit" class="btn btn-danger">Delete</button>
             </form>
-        </p>
+        </div>
     {% endif %}
     {% include "_inline_panels.html" %}
     {% if user_roles_panel %}

--- a/crates/rustango/src/admin/templates/form.html
+++ b/crates/rustango/src/admin/templates/form.html
@@ -82,10 +82,10 @@
     </section>
   {% endfor %}
 {% endif %}
-  <p class="form-submit-row">
-    <button type="submit" name="_save">Save</button>
-    <button type="submit" name="_continue">Save and continue editing</button>
-    <button type="submit" name="_addanother">Save and add another</button>
-  </p>
+  <div class="action-row form-submit-row">
+    <button type="submit" name="_save" class="btn btn-primary">Save</button>
+    <button type="submit" name="_continue" class="btn btn-secondary">Save and continue editing</button>
+    <button type="submit" name="_addanother" class="btn btn-secondary">Save and add another</button>
+  </div>
 </form>
 {% endblock body %}

--- a/crates/rustango/src/admin/templates/list.html
+++ b/crates/rustango/src/admin/templates/list.html
@@ -26,7 +26,7 @@
 {% if has_searchable %}
 <form method="get" action="{{ admin_prefix }}/{{ model.table }}" class="search">
   <input type="search" name="q" value="{{ q }}" placeholder="Search&hellip;">
-  <button type="submit">Go</button>
+  <button type="submit" class="btn btn-secondary">Go</button>
   {% for f in active_filters %}
     <input type="hidden" name="{{ f.key }}" value="{{ f.value }}">
   {% endfor %}
@@ -55,7 +55,7 @@
         {% endfor %}
       </select>
     </label>
-    <button type="submit">Go</button>
+    <button type="submit" class="btn btn-secondary">Go</button>
   </div>
   {% endif %}
   <table>


### PR DESCRIPTION
## Summary

Fixes the user-reported mismatch: detail-page \"Edit\" rendered as a bare link while \"Delete\" was a styled button, making the row look broken.

Ports the operator-console \`.btn\` family from \`_op_styles.html\` to \`_admin_styles.html\` so every action surface across the admin looks coherent. Both consoles now feel like one product.

## New class system

| Class | Use |
|---|---|
| \`.btn\` | Baseline padding/border/focus ring (default for bare \`<button>\` via \`button:not(.theme-toggle)\` so existing pages keep working) |
| \`.btn-primary\` | Accent-filled CTA — Save, Edit, Change password |
| \`.btn-secondary\` | Accent-bordered ghost — Save-and-continue, Logout, list \"Go\", audit \"Apply cleanup\" |
| \`.btn-danger\` | Red outline → red fill on hover — Delete |
| \`.btn-link\` | Text-only, accent on hover — sidebar Change-password link |
| \`.btn-row-action\` | Pill, accent-bg-soft — per-row inline \"View\" links |
| \`.action-row\` | Flex container, consistent gap, wraps on small screens |

All variants work on both \`<a>\` and \`<button>\` — links can sit next to form-submit buttons with no visual mismatch.

## Templates updated

- **\`detail.html\`** — Edit + Delete inside one \`.action-row\` with matching button shapes (the original bug)
- **\`form.html\`** — Save = btn-primary, Save-and-X = btn-secondary
- **\`_sidebar.html\`** — Logout + Change password wrapped in \`.action-row\`; visual hierarchy reflects role (Logout = bordered button, Change password = link)
- **\`_inline_panels.html\`** — tabular + stacked variants both use \`.btn-row-action\` for row links
- **\`list.html\`** + **\`audit_log.html\`** + **\`change_password.html\`** — submit buttons now carry explicit classes

\`login.html\` keeps its self-contained card styling (rendered before chrome).

## Verified live (curl against gfk_demo)

- detail page emits \`<a class=\"btn btn-primary\">Edit</a>\` + \`<button class=\"btn btn-danger\">Delete</button>\` inside \`<div class=\"action-row\">\`
- sidebar emits \`<button class=\"btn btn-secondary\">Logout</button>\` + \`<a class=\"btn btn-link\">Change password</a>\`
- 7× \`class=\"btn-row-action\"\` on the inline panel rows

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo build --no-default-features --features sqlite,tenancy\`
- [x] \`cargo build --all-features\`
- [x] \`cargo test --workspace --all-features --lib\` (**2336 pass**)
- [x] Live curl smoke against gfk_demo