### PR TITLE
fix: admin Change-password link visibility + dedup + sync .btn family with op console

### DIFF
--- a/crates/rustango/src/admin/templates/_admin_styles.html
+++ b/crates/rustango/src/admin/templates/_admin_styles.html
@@ -203,10 +203,16 @@ input:invalid + small, textarea:invalid + small { color: var(--color-error-fg); 
   background: transparent;
   border: 0;
   padding: 0.4rem 0;
-  color: var(--color-link, var(--color-accent));
+  /* Use accent for high contrast in both themes. Previously used
+     `--color-link` which is too muted on the warm beige sidebar
+     surface, and `--color-fg-muted` (op console's prior shape) was
+     even worse. Accent is the same color the rest of the chrome
+     uses for active links. */
+  color: var(--color-accent);
   text-decoration: none;
+  font-weight: var(--font-weight-medium, 500);
 }
-.btn-link:hover { color: var(--color-link-hover, var(--color-accent-hover)); text-decoration: underline; }
+.btn-link:hover { color: var(--color-accent-hover); text-decoration: underline; }
 .btn-row-action {
   display: inline-block;
   padding: 0.2rem 0.7rem;

--- a/crates/rustango/src/admin/templates/_sidebar.html
+++ b/crates/rustango/src/admin/templates/_sidebar.html
@@ -10,11 +10,10 @@
         <a href="{{ admin_prefix }}{{ audit_url }}"
            class="{% if active_table == '__audit' %}active{% endif %}">Activity</a>
     </p>
-    {% if change_password_url %}
-        <p>
-            <a href="{{ change_password_url }}">Change password</a>
-        </p>
-    {% endif %}
+    {# #253 follow-up — Change-password link moved into the
+       Logout form at the bottom of the sidebar to keep all
+       account actions in one place. The old standalone <p>
+       link above the model list is intentionally removed. #}
     {% if sidebar_groups %}
         {% for group in sidebar_groups %}
             <h3>{{ group.app }}</h3>

--- a/crates/rustango/src/tenancy/templates/_op_styles.html
+++ b/crates/rustango/src/tenancy/templates/_op_styles.html
@@ -202,14 +202,42 @@ fieldset.section th {
   border-color: var(--color-accent);
 }
 .btn-primary:hover { background: var(--color-accent-hover); border-color: var(--color-accent-hover); }
+/* #253 follow-up — secondary + danger variants synced from the
+   admin's `.btn` family so the same class names render identically
+   on both consoles. */
+.btn-secondary {
+  background: transparent;
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+.btn-secondary:hover {
+  background: var(--color-accent-bg-soft);
+  color: var(--color-accent);
+}
+.btn-danger {
+  background: transparent;
+  color: var(--color-error-fg, #b04141);
+  border-color: var(--color-error-fg, #b04141);
+}
+.btn-danger:hover {
+  background: var(--color-error-fg, #b04141);
+  color: #fff;
+}
+/* #253 follow-up — synced with admin's `.btn-link` so the same
+   element renders identically on both consoles. Previously this
+   used `--color-fg-muted` (too low-contrast on the warm beige
+   sidebar surface — operators complained the link was nearly
+   invisible). Accent gives high contrast in both themes and
+   matches the rest of the chrome's link style. */
 .btn-link {
-  color: var(--color-fg-muted);
+  color: var(--color-accent);
   text-decoration: none;
   font-size: 13px;
   background: transparent;
   border: 0;
+  font-weight: var(--font-weight-medium, 500);
 }
-.btn-link:hover { color: var(--color-accent); text-decoration: underline; }
+.btn-link:hover { color: var(--color-accent-hover); text-decoration: underline; }
 /* Inline action button in tables (#75). Pill-shaped, accent-tinted,
    doesn't compete visually with the row data. */
 .btn-row-action {
@@ -218,9 +246,12 @@ fieldset.section th {
   border-radius: var(--radius-sm);
   background: var(--color-accent-bg-soft);
   color: var(--color-accent);
-  font-size: 12px;
+  /* #253 follow-up — relative size (matches admin's `.btn-row-action`)
+     so both consoles inherit from their context uniformly. */
+  font-size: 0.85em;
   text-decoration: none;
   border: 1px solid transparent;
+  line-height: 1.4;
 }
 .btn-row-action:hover {
   background: var(--color-accent);


### PR DESCRIPTION
## Summary

User report (with screenshot): \"CHANGE PASSWORD IS NOT VISIBLE — make sure styling is consistent across all admins, including tenant.\" Sidebar's Change-password link rendered as ghost grey on the warm beige background.

Three concrete fixes:

### 1. Duplicate Change-password link removed

Two link sites existed in `_sidebar.html`:
- An old standalone `<p><a>` link near the top (pre-#253; from MEMORY #77 tenant-admin work)
- A new `<a class=\"btn btn-link\">` inside the Logout form (added in slice B)

Both rendered when `change_password_url` was set, and the old one used default sidebar link styling. Removed the old one — all account actions (Change password + Logout) now live in **one** Logout-form action-row.

### 2. `.btn-link` color = accent (visible)

Was `var(--color-link)` in admin and `var(--color-fg-muted)` in op console. Both technically had contrast but felt invisible on the warm beige sidebar.

Switched both consoles to `var(--color-accent)` (terracotta light / salmon dark). Same color the rest of the chrome uses for active links. Added `font-weight: medium` so the link weight matches the surrounding \"Signed in as\" caption.

### 3. Operator console `.btn` family synced with admin

Added the missing variants to `_op_styles.html` (op console previously only had `.btn`, `.btn-primary`, `.btn-link`, `.btn-row-action`):

- `.btn-secondary` — accent-bordered ghost
- `.btn-danger` — red outline → red fill

Also aligned `.btn-row-action`'s `font-size: 12px` → `0.85em` so both consoles inherit relative sizing identically.

Net effect: a Tera template using `class=\"btn btn-X\"` renders identically whether served from `admin::router(pool)` or `tenancy::operator_console`.

## Consistency map

| Surface | Templates | Now consistent? |
|---|---|---|
| **Bare admin** | `_admin_styles.html` + `_sidebar.html` | ✓ |
| **Tenant admin** | Same as bare admin (tenancy mounts `admin::router`) | ✓ (automatically) |
| **Operator console** | `_op_styles.html` + `op_layout.html` (separate) | ✓ (`.btn` family synced) |

## Test plan

- [x] cargo fmt --all
- [x] cargo test --workspace --all-features --lib (**2336 pass**)
- [x] Live curl smoke against gfk_demo: one Change-password link in sidebar, `.btn-link` rule has `color: var(--color-accent)`