### PR TITLE
fix: sidebar <a> selector was shadowing .btn-link color

### DIFF
--- a/crates/rustango/src/admin/templates/_admin_styles.html
+++ b/crates/rustango/src/admin/templates/_admin_styles.html
@@ -203,10 +203,16 @@ input:invalid + small, textarea:invalid + small { color: var(--color-error-fg); 
   background: transparent;
   border: 0;
   padding: 0.4rem 0;
-  color: var(--color-link, var(--color-accent));
+  /* Use accent for high contrast in both themes. Previously used
+     `--color-link` which is too muted on the warm beige sidebar
+     surface, and `--color-fg-muted` (op console's prior shape) was
+     even worse. Accent is the same color the rest of the chrome
+     uses for active links. */
+  color: var(--color-accent);
   text-decoration: none;
+  font-weight: var(--font-weight-medium, 500);
 }
-.btn-link:hover { color: var(--color-link-hover, var(--color-accent-hover)); text-decoration: underline; }
+.btn-link:hover { color: var(--color-accent-hover); text-decoration: underline; }
 .btn-row-action {
   display: inline-block;
   padding: 0.2rem 0.7rem;

--- a/crates/rustango/src/admin/templates/_admin_styles.html
+++ b/crates/rustango/src/admin/templates/_admin_styles.html
@@ -47,14 +47,21 @@ aside.sidebar h3 {
 }
 aside.sidebar ul { list-style: none; padding: 0; margin: 0; }
 aside.sidebar li { margin: 0.15rem 0; }
-aside.sidebar a {
+/* Sidebar nav links — Home / Activity / model items. The
+   `:not(.btn)` carve-out keeps `.btn` / `.btn-link` family
+   members (Change password, Logout's POST button, etc.) from
+   inheriting the block layout + neutral color, so they render
+   with their own variant styling instead. */
+aside.sidebar a:not(.btn):not(.btn-link):not(.btn-row-action) {
   display: block;
   padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-sm);
   color: var(--color-fg);
   text-decoration: none;
 }
-aside.sidebar a:hover { background: var(--color-bg-hover); }
+aside.sidebar a:not(.btn):not(.btn-link):not(.btn-row-action):hover {
+  background: var(--color-bg-hover);
+}
 aside.sidebar a.active {
   background: var(--color-bg-surface);
   color: var(--color-accent);

--- a/crates/rustango/src/admin/templates/_sidebar.html
+++ b/crates/rustango/src/admin/templates/_sidebar.html
@@ -10,11 +10,10 @@
         <a href="{{ admin_prefix }}{{ audit_url }}"
            class="{% if active_table == '__audit' %}active{% endif %}">Activity</a>
     </p>
-    {% if change_password_url %}
-        <p>
-            <a href="{{ change_password_url }}">Change password</a>
-        </p>
-    {% endif %}
+    {# #253 follow-up — Change-password link moved into the
+       Logout form at the bottom of the sidebar to keep all
+       account actions in one place. The old standalone <p>
+       link above the model list is intentionally removed. #}
     {% if sidebar_groups %}
         {% for group in sidebar_groups %}
             <h3>{{ group.app }}</h3>

--- a/crates/rustango/src/tenancy/templates/_op_styles.html
+++ b/crates/rustango/src/tenancy/templates/_op_styles.html
@@ -202,14 +202,42 @@ fieldset.section th {
   border-color: var(--color-accent);
 }
 .btn-primary:hover { background: var(--color-accent-hover); border-color: var(--color-accent-hover); }
+/* #253 follow-up — secondary + danger variants synced from the
+   admin's `.btn` family so the same class names render identically
+   on both consoles. */
+.btn-secondary {
+  background: transparent;
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+.btn-secondary:hover {
+  background: var(--color-accent-bg-soft);
+  color: var(--color-accent);
+}
+.btn-danger {
+  background: transparent;
+  color: var(--color-error-fg, #b04141);
+  border-color: var(--color-error-fg, #b04141);
+}
+.btn-danger:hover {
+  background: var(--color-error-fg, #b04141);
+  color: #fff;
+}
+/* #253 follow-up — synced with admin's `.btn-link` so the same
+   element renders identically on both consoles. Previously this
+   used `--color-fg-muted` (too low-contrast on the warm beige
+   sidebar surface — operators complained the link was nearly
+   invisible). Accent gives high contrast in both themes and
+   matches the rest of the chrome's link style. */
 .btn-link {
-  color: var(--color-fg-muted);
+  color: var(--color-accent);
   text-decoration: none;
   font-size: 13px;
   background: transparent;
   border: 0;
+  font-weight: var(--font-weight-medium, 500);
 }
-.btn-link:hover { color: var(--color-accent); text-decoration: underline; }
+.btn-link:hover { color: var(--color-accent-hover); text-decoration: underline; }
 /* Inline action button in tables (#75). Pill-shaped, accent-tinted,
    doesn't compete visually with the row data. */
 .btn-row-action {
@@ -218,9 +246,12 @@ fieldset.section th {
   border-radius: var(--radius-sm);
   background: var(--color-accent-bg-soft);
   color: var(--color-accent);
-  font-size: 12px;
+  /* #253 follow-up — relative size (matches admin's `.btn-row-action`)
+     so both consoles inherit from their context uniformly. */
+  font-size: 0.85em;
   text-decoration: none;
   border: 1px solid transparent;
+  line-height: 1.4;
 }
 .btn-row-action:hover {
   background: var(--color-accent);


### PR DESCRIPTION
Follow-up to #258. User reported \"no improvements\" with a screenshot showing the Change-password link still bold dark.

**Root cause**: \`aside.sidebar a { color: var(--color-fg); }\` (specificity 0,1,1) was beating \`.btn-link\` (specificity 0,1,0). Also \`display: block\` forced the link onto its own line, breaking the \`.action-row\` flex layout.

**Fix**: scope the sidebar-link reset with \`:not(.btn):not(.btn-link):not(.btn-row-action)\` so \`.btn\` family members opt out and render with their own variant styling.

Verified: served HTML now has the carve-out, Change-password renders in accent terracotta inline next to Logout.