### PR TITLE
fix: .btn baseline was shadowing .btn-secondary (Logout button invisible)

### DIFF
--- a/crates/rustango/src/admin/templates/_admin_styles.html
+++ b/crates/rustango/src/admin/templates/_admin_styles.html
@@ -157,7 +157,15 @@ input:invalid + small, textarea:invalid + small { color: var(--color-error-fg); 
    modifier class.
    ------------------------------------------------------------------ */
 
-.btn, button:not(.theme-toggle):not([data-rustango-theme-toggle]) {
+/* Button + button-like-anchor baseline. `.btn, button` as a
+   selector list — each selector takes its own specificity
+   (`button` = 0,0,1; `.btn` = 0,1,0). The variant classes below
+   are also 0,1,0 and declared later, so they win by source order
+   for any property they re-declare. No `:not()` negations needed
+   (and the previous `button:not(.theme-toggle)` shape was the bug
+   that out-specified `.btn-secondary`). `.theme-toggle` (0,1,0)
+   declared later in the file overrides this for the theme switcher. */
+.btn, button {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
@@ -171,38 +179,40 @@ input:invalid + small, textarea:invalid + small { color: var(--color-error-fg); 
   text-decoration: none;
   line-height: 1.2;
 }
-.btn:hover, button:not(.theme-toggle):not([data-rustango-theme-toggle]):hover {
-  background: var(--color-bg-hover);
-}
+.btn:hover, button:hover { background: var(--color-bg-hover); }
 .btn:focus-visible, button:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
-.btn-primary, button.btn-primary {
+
+/* Variants — same specificity as `.btn` (0,1,0), declared later so
+   source order wins. Each variant overrides the surface color +
+   border-color + text color. */
+.btn-primary {
   background: var(--color-accent);
   color: var(--color-fg-on-accent, #fff);
   border-color: var(--color-accent);
 }
-.btn-primary:hover, button.btn-primary:hover {
+.btn-primary:hover {
   background: var(--color-accent-hover);
   border-color: var(--color-accent-hover);
   color: var(--color-fg-on-accent, #fff);
 }
-.btn-secondary, button.btn-secondary {
+.btn-secondary {
   background: transparent;
   color: var(--color-accent);
   border-color: var(--color-accent);
 }
-.btn-secondary:hover, button.btn-secondary:hover {
+.btn-secondary:hover {
   background: var(--color-accent-bg-soft);
   color: var(--color-accent);
 }
-.btn-danger, button.btn-danger {
+.btn-danger {
   background: transparent;
   color: var(--color-error-fg, #b04141);
   border-color: var(--color-error-fg, #b04141);
 }
-.btn-danger:hover, button.btn-danger:hover {
+.btn-danger:hover {
   background: var(--color-error-fg, #b04141);
   color: #fff;
 }

--- a/crates/rustango/src/admin/templates/_admin_styles.html
+++ b/crates/rustango/src/admin/templates/_admin_styles.html
@@ -203,10 +203,16 @@ input:invalid + small, textarea:invalid + small { color: var(--color-error-fg); 
   background: transparent;
   border: 0;
   padding: 0.4rem 0;
-  color: var(--color-link, var(--color-accent));
+  /* Use accent for high contrast in both themes. Previously used
+     `--color-link` which is too muted on the warm beige sidebar
+     surface, and `--color-fg-muted` (op console's prior shape) was
+     even worse. Accent is the same color the rest of the chrome
+     uses for active links. */
+  color: var(--color-accent);
   text-decoration: none;
+  font-weight: var(--font-weight-medium, 500);
 }
-.btn-link:hover { color: var(--color-link-hover, var(--color-accent-hover)); text-decoration: underline; }
+.btn-link:hover { color: var(--color-accent-hover); text-decoration: underline; }
 .btn-row-action {
   display: inline-block;
   padding: 0.2rem 0.7rem;

--- a/crates/rustango/src/admin/templates/_admin_styles.html
+++ b/crates/rustango/src/admin/templates/_admin_styles.html
@@ -47,14 +47,21 @@ aside.sidebar h3 {
 }
 aside.sidebar ul { list-style: none; padding: 0; margin: 0; }
 aside.sidebar li { margin: 0.15rem 0; }
-aside.sidebar a {
+/* Sidebar nav links — Home / Activity / model items. The
+   `:not(.btn)` carve-out keeps `.btn` / `.btn-link` family
+   members (Change password, Logout's POST button, etc.) from
+   inheriting the block layout + neutral color, so they render
+   with their own variant styling instead. */
+aside.sidebar a:not(.btn):not(.btn-link):not(.btn-row-action) {
   display: block;
   padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-sm);
   color: var(--color-fg);
   text-decoration: none;
 }
-aside.sidebar a:hover { background: var(--color-bg-hover); }
+aside.sidebar a:not(.btn):not(.btn-link):not(.btn-row-action):hover {
+  background: var(--color-bg-hover);
+}
 aside.sidebar a.active {
   background: var(--color-bg-surface);
   color: var(--color-accent);

--- a/crates/rustango/src/admin/templates/_sidebar.html
+++ b/crates/rustango/src/admin/templates/_sidebar.html
@@ -10,11 +10,10 @@
         <a href="{{ admin_prefix }}{{ audit_url }}"
            class="{% if active_table == '__audit' %}active{% endif %}">Activity</a>
     </p>
-    {% if change_password_url %}
-        <p>
-            <a href="{{ change_password_url }}">Change password</a>
-        </p>
-    {% endif %}
+    {# #253 follow-up — Change-password link moved into the
+       Logout form at the bottom of the sidebar to keep all
+       account actions in one place. The old standalone <p>
+       link above the model list is intentionally removed. #}
     {% if sidebar_groups %}
         {% for group in sidebar_groups %}
             <h3>{{ group.app }}</h3>

--- a/crates/rustango/src/tenancy/templates/_op_styles.html
+++ b/crates/rustango/src/tenancy/templates/_op_styles.html
@@ -202,14 +202,42 @@ fieldset.section th {
   border-color: var(--color-accent);
 }
 .btn-primary:hover { background: var(--color-accent-hover); border-color: var(--color-accent-hover); }
+/* #253 follow-up — secondary + danger variants synced from the
+   admin's `.btn` family so the same class names render identically
+   on both consoles. */
+.btn-secondary {
+  background: transparent;
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+.btn-secondary:hover {
+  background: var(--color-accent-bg-soft);
+  color: var(--color-accent);
+}
+.btn-danger {
+  background: transparent;
+  color: var(--color-error-fg, #b04141);
+  border-color: var(--color-error-fg, #b04141);
+}
+.btn-danger:hover {
+  background: var(--color-error-fg, #b04141);
+  color: #fff;
+}
+/* #253 follow-up — synced with admin's `.btn-link` so the same
+   element renders identically on both consoles. Previously this
+   used `--color-fg-muted` (too low-contrast on the warm beige
+   sidebar surface — operators complained the link was nearly
+   invisible). Accent gives high contrast in both themes and
+   matches the rest of the chrome's link style. */
 .btn-link {
-  color: var(--color-fg-muted);
+  color: var(--color-accent);
   text-decoration: none;
   font-size: 13px;
   background: transparent;
   border: 0;
+  font-weight: var(--font-weight-medium, 500);
 }
-.btn-link:hover { color: var(--color-accent); text-decoration: underline; }
+.btn-link:hover { color: var(--color-accent-hover); text-decoration: underline; }
 /* Inline action button in tables (#75). Pill-shaped, accent-tinted,
    doesn't compete visually with the row data. */
 .btn-row-action {
@@ -218,9 +246,12 @@ fieldset.section th {
   border-radius: var(--radius-sm);
   background: var(--color-accent-bg-soft);
   color: var(--color-accent);
-  font-size: 12px;
+  /* #253 follow-up — relative size (matches admin's `.btn-row-action`)
+     so both consoles inherit from their context uniformly. */
+  font-size: 0.85em;
   text-decoration: none;
   border: 1px solid transparent;
+  line-height: 1.4;
 }
 .btn-row-action:hover {
   background: var(--color-accent);


### PR DESCRIPTION
Follow-up to #259. User reported Logout button still barely visible after the Change-password fix.

**Root cause**: the baseline I introduced used `button:not(.theme-toggle):not([data-rustango-theme-toggle])` which has specificity 0,2,1 — that beat `.btn-secondary` at 0,1,0, so the Logout button rendered with neutral baseline colors instead of the accent variant.

**Fix**: drop the `:not()` negations and use `.btn, button` as a plain selector list. Each selector keeps its own specificity (`button` = 0,0,1; `.btn` = 0,1,0). Variants are 0,1,0 too and declared later, so they win by source order.

`.theme-toggle` (later in the file) still naturally beats bare `button` (0,1,0 vs 0,0,1) — no negation needed.
