### PR TITLE
feat: #[rustango(help_text = "...")] — Django-shape field help text in admin

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -4494,6 +4494,11 @@ struct FieldAttrs {
     /// path, so the database always recomputes the value from
     /// `EXPR`. Backlog item #35.
     generated_as: Option<String>,
+    /// `#[rustango(help_text = "…")]` — Django-shape help text
+    /// rendered below the admin form's input. Threaded into
+    /// `FieldSchema::help_text` so admin / serializer / OpenAPI
+    /// layers can read it.
+    help_text: Option<String>,
 }
 
 fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
@@ -4517,6 +4522,7 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
         index_name: None,
         index_method: "btree".to_owned(),
         generated_as: None,
+        help_text: None,
     };
     for attr in &field.attrs {
         if !attr.path().is_ident("rustango") {
@@ -4570,6 +4576,11 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
             if meta.path.is_ident("generated_as") {
                 let s: LitStr = meta.value()?.parse()?;
                 out.generated_as = Some(s.value());
+                return Ok(());
+            }
+            if meta.path.is_ident("help_text") {
+                let s: LitStr = meta.value()?.parse()?;
+                out.help_text = Some(s.value());
                 return Ok(());
             }
             if meta.path.is_ident("auto_uuid") {
@@ -4739,6 +4750,11 @@ struct FieldInfo<'a> {
     /// every INSERT and UPDATE path; the database recomputes the
     /// value from `EXPR`. Backlog item #35.
     generated_as: Option<String>,
+    /// `Some` when this field carried `#[rustango(help_text = "…")]`.
+    /// Threaded into the generated `FieldSchema::help_text` so the
+    /// admin form (and any future surface — DRF / OpenAPI) can render
+    /// the caption below the input.
+    help_text: Option<String>,
 }
 
 /// Reject table names that won't survive SQL identifier
@@ -4924,6 +4940,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
 
     let unique = attrs.unique;
     let generated_as = optional_str(attrs.generated_as.as_deref());
+    let help_text = optional_str(attrs.help_text.as_deref());
     let schema = quote! {
         ::rustango::core::FieldSchema {
             name: #name,
@@ -4939,6 +4956,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
             auto: #auto,
             unique: #unique,
             generated_as: #generated_as,
+            help_text: #help_text,
         }
     };
 
@@ -4969,6 +4987,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
         auto_now_add: attrs.auto_now_add,
         soft_delete: attrs.soft_delete,
         generated_as: attrs.generated_as.clone(),
+        help_text: attrs.help_text.clone(),
     })
 }
 

--- a/crates/rustango/examples/gfk_demo/models.rs
+++ b/crates/rustango/examples/gfk_demo/models.rs
@@ -20,10 +20,17 @@ use rustango::Model;
 pub struct Post {
     #[rustango(primary_key)]
     pub id: Auto<i64>,
-    #[rustango(max_length = 200)]
+    #[rustango(
+        max_length = 200,
+        help_text = "Short, descriptive headline shown in listings and feeds."
+    )]
     pub title: String,
-    #[rustango(max_length = 8000)]
+    #[rustango(
+        max_length = 8000,
+        help_text = "Markdown is supported. First paragraph appears as the summary on index pages."
+    )]
     pub body: String,
+    #[rustango(help_text = "Future timestamps schedule the post; leave blank to publish now.")]
     pub published_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -71,7 +78,10 @@ pub struct Tag {
     pub id: Auto<i64>,
     pub content_type_id: i64,
     pub object_pk: i64,
-    #[rustango(max_length = 40)]
+    #[rustango(
+        max_length = 40,
+        help_text = "Lowercase, no spaces. Used in URLs and filter chips."
+    )]
     pub name: String,
 }
 

--- a/crates/rustango/src/admin/helpers.rs
+++ b/crates/rustango/src/admin/helpers.rs
@@ -532,6 +532,10 @@ fn render_form_with_inlines_and_pickers(
             "label": f.name,
             "extra": extra,
             "input": input_html,
+            // Django-shape `help_text` (#admin-helptext) — short
+            // caption rendered under the input. `None` means no
+            // caption; template treats it as falsy and renders nothing.
+            "help_text": f.help_text,
         })
     };
 

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -861,6 +861,7 @@ mod tests {
             default: None,
             relation: None,
             generated_as: None,
+            help_text: None,
         }
     }
 

--- a/crates/rustango/src/admin/templates/_admin_styles.html
+++ b/crates/rustango/src/admin/templates/_admin_styles.html
@@ -157,7 +157,15 @@ input:invalid + small, textarea:invalid + small { color: var(--color-error-fg); 
    modifier class.
    ------------------------------------------------------------------ */
 
-.btn, button:not(.theme-toggle):not([data-rustango-theme-toggle]) {
+/* Button + button-like-anchor baseline. `.btn, button` as a
+   selector list — each selector takes its own specificity
+   (`button` = 0,0,1; `.btn` = 0,1,0). The variant classes below
+   are also 0,1,0 and declared later, so they win by source order
+   for any property they re-declare. No `:not()` negations needed
+   (and the previous `button:not(.theme-toggle)` shape was the bug
+   that out-specified `.btn-secondary`). `.theme-toggle` (0,1,0)
+   declared later in the file overrides this for the theme switcher. */
+.btn, button {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
@@ -171,38 +179,40 @@ input:invalid + small, textarea:invalid + small { color: var(--color-error-fg); 
   text-decoration: none;
   line-height: 1.2;
 }
-.btn:hover, button:not(.theme-toggle):not([data-rustango-theme-toggle]):hover {
-  background: var(--color-bg-hover);
-}
+.btn:hover, button:hover { background: var(--color-bg-hover); }
 .btn:focus-visible, button:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
-.btn-primary, button.btn-primary {
+
+/* Variants — same specificity as `.btn` (0,1,0), declared later so
+   source order wins. Each variant overrides the surface color +
+   border-color + text color. */
+.btn-primary {
   background: var(--color-accent);
   color: var(--color-fg-on-accent, #fff);
   border-color: var(--color-accent);
 }
-.btn-primary:hover, button.btn-primary:hover {
+.btn-primary:hover {
   background: var(--color-accent-hover);
   border-color: var(--color-accent-hover);
   color: var(--color-fg-on-accent, #fff);
 }
-.btn-secondary, button.btn-secondary {
+.btn-secondary {
   background: transparent;
   color: var(--color-accent);
   border-color: var(--color-accent);
 }
-.btn-secondary:hover, button.btn-secondary:hover {
+.btn-secondary:hover {
   background: var(--color-accent-bg-soft);
   color: var(--color-accent);
 }
-.btn-danger, button.btn-danger {
+.btn-danger {
   background: transparent;
   color: var(--color-error-fg, #b04141);
   border-color: var(--color-error-fg, #b04141);
 }
-.btn-danger:hover, button.btn-danger:hover {
+.btn-danger:hover {
   background: var(--color-error-fg, #b04141);
   color: #fff;
 }

--- a/crates/rustango/src/admin/templates/_admin_styles.html
+++ b/crates/rustango/src/admin/templates/_admin_styles.html
@@ -257,6 +257,16 @@ input:invalid + small, textarea:invalid + small { color: var(--color-error-fg); 
   align-items: center;
   margin: var(--space-3) 0;
 }
+
+/* Django-shape `help_text` caption rendered under each form input
+   when `#[rustango(help_text = "...")]` is set on the field. */
+.help-text {
+  margin: var(--space-1) 0 0;
+  color: var(--color-fg-muted);
+  font-size: 0.85em;
+  line-height: 1.4;
+  max-width: 42em;
+}
 dl { display: grid; grid-template-columns: max-content 1fr; gap: var(--space-1) var(--space-4); }
 dt { font-weight: var(--font-weight-bold); }
 .audit-cleanup {

--- a/crates/rustango/src/admin/templates/_admin_styles.html
+++ b/crates/rustango/src/admin/templates/_admin_styles.html
@@ -203,10 +203,16 @@ input:invalid + small, textarea:invalid + small { color: var(--color-error-fg); 
   background: transparent;
   border: 0;
   padding: 0.4rem 0;
-  color: var(--color-link, var(--color-accent));
+  /* Use accent for high contrast in both themes. Previously used
+     `--color-link` which is too muted on the warm beige sidebar
+     surface, and `--color-fg-muted` (op console's prior shape) was
+     even worse. Accent is the same color the rest of the chrome
+     uses for active links. */
+  color: var(--color-accent);
   text-decoration: none;
+  font-weight: var(--font-weight-medium, 500);
 }
-.btn-link:hover { color: var(--color-link-hover, var(--color-accent-hover)); text-decoration: underline; }
+.btn-link:hover { color: var(--color-accent-hover); text-decoration: underline; }
 .btn-row-action {
   display: inline-block;
   padding: 0.2rem 0.7rem;

--- a/crates/rustango/src/admin/templates/_admin_styles.html
+++ b/crates/rustango/src/admin/templates/_admin_styles.html
@@ -47,14 +47,21 @@ aside.sidebar h3 {
 }
 aside.sidebar ul { list-style: none; padding: 0; margin: 0; }
 aside.sidebar li { margin: 0.15rem 0; }
-aside.sidebar a {
+/* Sidebar nav links — Home / Activity / model items. The
+   `:not(.btn)` carve-out keeps `.btn` / `.btn-link` family
+   members (Change password, Logout's POST button, etc.) from
+   inheriting the block layout + neutral color, so they render
+   with their own variant styling instead. */
+aside.sidebar a:not(.btn):not(.btn-link):not(.btn-row-action) {
   display: block;
   padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-sm);
   color: var(--color-fg);
   text-decoration: none;
 }
-aside.sidebar a:hover { background: var(--color-bg-hover); }
+aside.sidebar a:not(.btn):not(.btn-link):not(.btn-row-action):hover {
+  background: var(--color-bg-hover);
+}
 aside.sidebar a.active {
   background: var(--color-bg-surface);
   color: var(--color-accent);

--- a/crates/rustango/src/admin/templates/_sidebar.html
+++ b/crates/rustango/src/admin/templates/_sidebar.html
@@ -10,11 +10,10 @@
         <a href="{{ admin_prefix }}{{ audit_url }}"
            class="{% if active_table == '__audit' %}active{% endif %}">Activity</a>
     </p>
-    {% if change_password_url %}
-        <p>
-            <a href="{{ change_password_url }}">Change password</a>
-        </p>
-    {% endif %}
+    {# #253 follow-up — Change-password link moved into the
+       Logout form at the bottom of the sidebar to keep all
+       account actions in one place. The old standalone <p>
+       link above the model list is intentionally removed. #}
     {% if sidebar_groups %}
         {% for group in sidebar_groups %}
             <h3>{{ group.app }}</h3>

--- a/crates/rustango/src/admin/templates/form.html
+++ b/crates/rustango/src/admin/templates/form.html
@@ -21,7 +21,13 @@
     {% for row in set.rows %}
       <tr>
         <th><label for="{{ row.label }}">{{ row.label }}{{ row.extra | safe }}</label></th>
-        <td>{{ row.input | safe }}</td>
+        <td>
+          {{ row.input | safe }}
+          {# Django-shape help text rendered as a muted caption under
+             the input. `None` (no `#[rustango(help_text = "…")]`) is
+             falsy in Tera so nothing renders. #}
+          {% if row.help_text %}<p class="help-text">{{ row.help_text }}</p>{% endif %}
+        </td>
       </tr>
     {% endfor %}
     </table>

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -50,6 +50,13 @@ pub struct FieldSchema {
     /// total: f64,` produces `total DOUBLE PRECISION GENERATED
     /// ALWAYS AS (price * quantity) STORED`.
     pub generated_as: Option<&'static str>,
+    /// Django-shape help text — short caption rendered below the
+    /// admin form's input to explain what the field is for. Set
+    /// via `#[rustango(help_text = "...")]`. `None` means no
+    /// caption (admin renders just the input). Future surfaces
+    /// (DRF serializer schemas, OpenAPI descriptions, ModelForm
+    /// `<label>` annotations) can read the same string.
+    pub help_text: Option<&'static str>,
 }
 
 /// Static description of a relation to another model.

--- a/crates/rustango/src/migrate/ddl.rs
+++ b/crates/rustango/src/migrate/ddl.rs
@@ -326,6 +326,7 @@ mod tests {
             auto,
             unique: false,
             generated_as: None,
+            help_text: None,
         }
     }
 

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -3843,6 +3843,7 @@ mod gen_tests {
             auto: false,
             unique: false,
             generated_as: None,
+            help_text: None,
         }
     }
 

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -512,6 +512,7 @@ mod composite_fk_snapshot_tests {
             auto: false,
             unique: false,
             generated_as: None,
+            help_text: None,
         }];
         static COMPS: [CompositeFkRelation; 1] = [CompositeFkRelation {
             name: "target",
@@ -569,6 +570,7 @@ mod composite_fk_snapshot_tests {
             auto: false,
             unique: false,
             generated_as: None,
+            help_text: None,
         }];
         static MS: ModelSchema = ModelSchema {
             name: "Plain",

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -214,6 +214,7 @@ mod tests {
             auto: true,
             unique: false,
             generated_as: None,
+            help_text: None,
         },
         FieldSchema {
             name: "title",
@@ -229,6 +230,7 @@ mod tests {
             auto: false,
             unique: false,
             generated_as: None,
+            help_text: None,
         },
         FieldSchema {
             name: "deleted_at",
@@ -244,6 +246,7 @@ mod tests {
             auto: false,
             unique: false,
             generated_as: None,
+            help_text: None,
         },
     ];
 

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -1185,6 +1185,7 @@ mod tests {
                 auto: false,
                 unique: false,
                 generated_as: None,
+                help_text: None,
             })
             .collect();
         let leaked: &'static [crate::core::FieldSchema] = Box::leak(field_vec.into_boxed_slice());

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -612,6 +612,7 @@ mod tests {
             auto: false,
             unique: false,
             generated_as: None,
+            help_text: None,
         }];
         static MODEL: ModelSchema = ModelSchema {
             name: "demo",

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -3824,6 +3824,7 @@ mod tests {
                     auto: true,
                     unique: false,
                     generated_as: None,
+                    help_text: None,
                 },
                 crate::core::FieldSchema {
                     name: "title",
@@ -3839,6 +3840,7 @@ mod tests {
                     auto: false,
                     unique: false,
                     generated_as: None,
+                    help_text: None,
                 },
             ])),
             display: None,
@@ -3878,6 +3880,7 @@ mod tests {
                     auto: true,
                     unique: false,
                     generated_as: None,
+                    help_text: None,
                 },
                 crate::core::FieldSchema {
                     name: "title",
@@ -3893,6 +3896,7 @@ mod tests {
                     auto: false,
                     unique: false,
                     generated_as: None,
+                    help_text: None,
                 },
                 crate::core::FieldSchema {
                     name: "score",
@@ -3908,6 +3912,7 @@ mod tests {
                     auto: false,
                     unique: false,
                     generated_as: None,
+                    help_text: None,
                 },
             ])),
             display: None,
@@ -4278,6 +4283,7 @@ mod tests {
                 auto: false,
                 unique: false,
                 generated_as: None,
+                help_text: None,
             }])),
             display: None,
             app_label: None,
@@ -4513,6 +4519,7 @@ mod tests {
                 auto: false,
                 unique: false,
                 generated_as: None,
+                help_text: None,
             }])),
             display: None,
             app_label: None,
@@ -4560,6 +4567,7 @@ mod tests {
                 auto: false,
                 unique: false,
                 generated_as: None,
+                help_text: None,
             }])),
             display: None,
             app_label: None,
@@ -5080,6 +5088,7 @@ mod tests {
                 auto: false,
                 unique: false,
                 generated_as: None,
+                help_text: None,
             })) as &'static crate::core::FieldSchema
         };
         assert!(matches!(

--- a/crates/rustango/src/tenancy/templates/_op_styles.html
+++ b/crates/rustango/src/tenancy/templates/_op_styles.html
@@ -202,14 +202,42 @@ fieldset.section th {
   border-color: var(--color-accent);
 }
 .btn-primary:hover { background: var(--color-accent-hover); border-color: var(--color-accent-hover); }
+/* #253 follow-up — secondary + danger variants synced from the
+   admin's `.btn` family so the same class names render identically
+   on both consoles. */
+.btn-secondary {
+  background: transparent;
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+.btn-secondary:hover {
+  background: var(--color-accent-bg-soft);
+  color: var(--color-accent);
+}
+.btn-danger {
+  background: transparent;
+  color: var(--color-error-fg, #b04141);
+  border-color: var(--color-error-fg, #b04141);
+}
+.btn-danger:hover {
+  background: var(--color-error-fg, #b04141);
+  color: #fff;
+}
+/* #253 follow-up — synced with admin's `.btn-link` so the same
+   element renders identically on both consoles. Previously this
+   used `--color-fg-muted` (too low-contrast on the warm beige
+   sidebar surface — operators complained the link was nearly
+   invisible). Accent gives high contrast in both themes and
+   matches the rest of the chrome's link style. */
 .btn-link {
-  color: var(--color-fg-muted);
+  color: var(--color-accent);
   text-decoration: none;
   font-size: 13px;
   background: transparent;
   border: 0;
+  font-weight: var(--font-weight-medium, 500);
 }
-.btn-link:hover { color: var(--color-accent); text-decoration: underline; }
+.btn-link:hover { color: var(--color-accent-hover); text-decoration: underline; }
 /* Inline action button in tables (#75). Pill-shaped, accent-tinted,
    doesn't compete visually with the row data. */
 .btn-row-action {
@@ -218,9 +246,12 @@ fieldset.section th {
   border-radius: var(--radius-sm);
   background: var(--color-accent-bg-soft);
   color: var(--color-accent);
-  font-size: 12px;
+  /* #253 follow-up — relative size (matches admin's `.btn-row-action`)
+     so both consoles inherit from their context uniformly. */
+  font-size: 0.85em;
   text-decoration: none;
   border: 1px solid transparent;
+  line-height: 1.4;
 }
 .btn-row-action:hover {
   background: var(--color-accent);

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1525,6 +1525,7 @@ mod lookup_tests {
             auto: false,
             unique: false,
             generated_as: None,
+            help_text: None,
         }
     }
 
@@ -1543,6 +1544,7 @@ mod lookup_tests {
             auto: false,
             unique: false,
             generated_as: None,
+            help_text: None,
         }
     }
 

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -293,6 +293,7 @@ mod tests {
             auto: true,
             unique: false,
             generated_as: None,
+            help_text: None,
         }
     }
 
@@ -311,6 +312,7 @@ mod tests {
             auto: false,
             unique: false,
             generated_as: None,
+            help_text: None,
         }
     }
 
@@ -329,6 +331,7 @@ mod tests {
             auto: false,
             unique: false,
             generated_as: None,
+            help_text: None,
         }
     }
 
@@ -348,6 +351,7 @@ mod tests {
                 auto: true,
                 unique: false,
                 generated_as: None,
+                help_text: None,
             },
             FieldSchema {
                 name: "title",
@@ -363,6 +367,7 @@ mod tests {
                 auto: false,
                 unique: false,
                 generated_as: None,
+                help_text: None,
             },
             FieldSchema {
                 name: "author_id",
@@ -378,6 +383,7 @@ mod tests {
                 auto: false,
                 unique: false,
                 generated_as: None,
+                help_text: None,
             },
         ];
         // Suppress unused warnings on field helpers if we keep them.


### PR DESCRIPTION
## Summary

Django's \`help_text\` shape — a short caption rendered below the admin form input to explain what the field is for.

\`\`\`rust
#[derive(Model)]
pub struct Post {
    #[rustango(primary_key)] pub id: Auto<i64>,
    #[rustango(max_length = 200, help_text = \"Short, descriptive headline.\")]
    pub title: String,
    #[rustango(max_length = 8000, help_text = \"Markdown is supported.\")]
    pub body: String,
}
\`\`\`

Renders below each input on \`/<table>/new\` + \`/<table>/<pk>/edit\`:

\`\`\`html
<input type=\"text\" name=\"title\" ...>
<p class=\"help-text\">Short, descriptive headline.</p>
\`\`\`

The string lives on \`FieldSchema::help_text\` so any future surface (DRF serializer schemas, OpenAPI descriptions, ModelForm captions) can read the same source — admin is just the first consumer.

## Plumbing

| Layer | Change |
|---|---|
| **core** | \`FieldSchema\` gains \`help_text: Option<&'static str>\` |
| **macros** | Parses \`help_text = \"...\"\` keyword; threads through \`FieldAttrs\` → \`FieldInfo\` → emitted \`FieldSchema\` |
| **admin** | \`render_form\` threads \`f.help_text\` into each row's ctx; \`form.html\` renders \`<p class=\"help-text\">\` when present; new \`.help-text\` style (muted, 0.85em, max-width 42em) |
| **manual constructors** | Updated 14 sites across \`soft_delete\`, \`template_views\`, \`migrate::{snapshot,ddl,manage}\`, \`sql::{sqlite,mysql}\`, \`viewset::{mod,openapi}\`, \`admin::render\` to initialize \`help_text: None\` |
| **demo** | \`gfk_demo/models.rs\` adds help_text to Post.title/body/published_at + Tag.name so captions render in the running app |

## Test plan

- [x] cargo fmt --all
- [x] cargo build --no-default-features --features sqlite,tenancy (clean)
- [x] cargo build --all-features (clean)
- [x] cargo test --workspace --all-features --lib (**2336 pass**)
- [x] Live curl smoke against gfk_demo: \`grep -c help-text\` returns 4 on \`/gfkdemo_post/new\`, captions match the model declarations