### PR TITLE
feat: explain_pool() — tri-dialect query plan helper (closes #272)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
             --test database_pools_sqlite_file_live \
             --test database_pools_sqlite_live \
             --test database_tenant_sqlite_live \
+            --test explain_pool_sqlite_live \
             --test first_last_sqlite_live \
             --test fixtures_sqlite_live \
             --test foreign_key_sqlite_live \
@@ -201,6 +202,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test -p rustango --features mysql,jobs-postgres --test jobs_mysql_live
       - run: cargo test -p rustango --features mysql --test mysql_live
+      - run: cargo test -p rustango --features mysql --test explain_pool_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy --test tenancy_manage_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy --test permissions_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy --test database_pools_mysql_live

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -1516,7 +1516,10 @@ pub enum ExplainFormat {
 impl ExplainOptions {
     /// Render the parenthesized option list (e.g. `(ANALYZE,
     /// BUFFERS, FORMAT JSON)`). Empty when every option is at its
-    /// default.
+    /// default. Used by both the PG-typed `QuerySet::explain_on` and
+    /// the tri-dialect [`explain_pool`] PG branch — the latter
+    /// inherits the same `postgres`-feature gating so MySQL / SQLite
+    /// builds don't drag this in.
     fn to_clause(&self) -> String {
         let mut bits: Vec<&'static str> = Vec::new();
         if self.analyze {
@@ -1541,6 +1544,156 @@ impl ExplainOptions {
             String::new()
         } else {
             format!("({})", bits.join(", "))
+        }
+    }
+}
+
+/// Tri-dialect query-plan helper — issue #272 / T1.10.
+///
+/// Routes to the active backend's `EXPLAIN` syntax via [`Pool::dialect`]
+/// and returns a single newline-joined string suitable for printing.
+///
+/// Per-backend behavior:
+///
+/// * **Postgres** — emits `EXPLAIN (FORMAT TEXT|JSON|YAML|XML[, ANALYZE,
+///   BUFFERS, VERBOSE]) <stmt>`. Each row's first column joined by
+///   newline. JSON cells round-trip through [`serde_json::Value`].
+///
+/// * **MySQL** — emits one of:
+///   * `EXPLAIN ANALYZE <stmt>` when `options.analyze == true` (8.0.18+).
+///     Returns a single `EXPLAIN` column as TEXT.
+///   * `EXPLAIN FORMAT=JSON <stmt>` when `options.format ==
+///     ExplainFormat::Json` (single JSON column).
+///   * `EXPLAIN FORMAT=TREE <stmt>` otherwise (8.0.16+). Returns one
+///     TEXT column with the optimizer's structured plan.
+///
+///   MySQL's classic tabular `EXPLAIN <stmt>` (multi-column) is not
+///   emitted by this helper because the single-string return shape
+///   doesn't fit. Use `raw_query_pool` if you need the tabular form.
+///
+/// * **SQLite** — emits `EXPLAIN QUERY PLAN <stmt>`. Plan-only — never
+///   executes the query, so `analyze` / `buffers` flags silently no-op.
+///   For `ExplainFormat::Text` each row's `detail` column is joined by
+///   newline. For `ExplainFormat::Json` the rows are serialized as
+///   `[{id, parent, detail}, ...]`.
+///
+/// Flags that don't apply to a backend silently no-op — the call still
+/// succeeds. The query is bound through the same parameter binding the
+/// rest of the `_pool` family uses, so user-supplied filter values are
+/// safe even with `analyze = true`.
+///
+/// # Errors
+/// SQL-writing or driver failures from the EXPLAIN.
+pub async fn explain_pool(
+    pool: &Pool,
+    query: &SelectQuery,
+    options: ExplainOptions,
+) -> Result<String, ExecError> {
+    let stmt = pool.dialect().compile_select(query)?;
+    match pool {
+        #[cfg(feature = "postgres")]
+        Pool::Postgres(pg) => {
+            let mut sql = String::with_capacity(stmt.sql.len() + 32);
+            sql.push_str("EXPLAIN ");
+            let clause = options.to_clause();
+            if !clause.is_empty() {
+                sql.push_str(&clause);
+                sql.push(' ');
+            }
+            sql.push_str(&stmt.sql);
+            let mut q: Query<'_, sqlx::Postgres, PgArguments> = sqlx::query(&sql);
+            for v in stmt.params {
+                q = bind_query(q, v);
+            }
+            let rows = q.fetch_all(pg).await?;
+            let mut parts = Vec::with_capacity(rows.len());
+            for row in &rows {
+                let line: String = match options.format {
+                    ExplainFormat::Json => {
+                        let v: serde_json::Value = sqlx::Row::try_get(row, 0)?;
+                        v.to_string()
+                    }
+                    ExplainFormat::Text | ExplainFormat::Yaml | ExplainFormat::Xml => {
+                        sqlx::Row::try_get(row, 0)?
+                    }
+                };
+                parts.push(line);
+            }
+            Ok(parts.join("\n"))
+        }
+        #[cfg(feature = "mysql")]
+        Pool::Mysql(my) => {
+            // MySQL's `EXPLAIN` keyword family is unique per shape:
+            // `EXPLAIN ANALYZE` (8.0.18+) actually runs the query and
+            // reports real timings; `EXPLAIN FORMAT=JSON|TREE` is plan-
+            // only. `analyze` wins over `format` — ANALYZE implicitly
+            // uses TREE format on text and JSON on `FORMAT=JSON` was
+            // never standardized for ANALYZE in MySQL 8.x.
+            let prefix = if options.analyze {
+                "EXPLAIN ANALYZE "
+            } else {
+                match options.format {
+                    ExplainFormat::Json => "EXPLAIN FORMAT=JSON ",
+                    _ => "EXPLAIN FORMAT=TREE ",
+                }
+            };
+            let mut sql = String::with_capacity(stmt.sql.len() + prefix.len());
+            sql.push_str(prefix);
+            sql.push_str(&stmt.sql);
+            let mut q = sqlx::query(&sql);
+            for v in stmt.params {
+                q = bind_query_my(q, v);
+            }
+            let rows = q.fetch_all(my).await?;
+            let mut parts = Vec::with_capacity(rows.len());
+            for row in &rows {
+                let line: String = match options.format {
+                    ExplainFormat::Json if !options.analyze => {
+                        let v: serde_json::Value = sqlx::Row::try_get(row, 0)?;
+                        v.to_string()
+                    }
+                    _ => sqlx::Row::try_get(row, 0)?,
+                };
+                parts.push(line);
+            }
+            Ok(parts.join("\n"))
+        }
+        #[cfg(feature = "sqlite")]
+        Pool::Sqlite(sq) => {
+            // SQLite's EXPLAIN QUERY PLAN is plan-only (never runs the
+            // query), so analyze/buffers/verbose flags silently no-op
+            // per the issue spec. Returns 4 columns: id, parent, notused,
+            // detail.
+            let sql = format!("EXPLAIN QUERY PLAN {}", stmt.sql);
+            let mut q = sqlx::query(&sql);
+            for v in stmt.params {
+                q = bind_query_sqlite(q, v);
+            }
+            let rows = q.fetch_all(sq).await?;
+            match options.format {
+                ExplainFormat::Json => {
+                    let mut arr = Vec::with_capacity(rows.len());
+                    for row in &rows {
+                        let id: i64 = sqlx::Row::try_get(row, 0)?;
+                        let parent: i64 = sqlx::Row::try_get(row, 1)?;
+                        let detail: String = sqlx::Row::try_get(row, 3)?;
+                        arr.push(serde_json::json!({
+                            "id": id,
+                            "parent": parent,
+                            "detail": detail,
+                        }));
+                    }
+                    Ok(serde_json::Value::Array(arr).to_string())
+                }
+                ExplainFormat::Text | ExplainFormat::Yaml | ExplainFormat::Xml => {
+                    let mut parts = Vec::with_capacity(rows.len());
+                    for row in &rows {
+                        let detail: String = sqlx::Row::try_get(row, 3)?;
+                        parts.push(detail);
+                    }
+                    Ok(parts.join("\n"))
+                }
+            }
         }
     }
 }

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -37,8 +37,8 @@ pub use executor::row_to_json_my;
 pub use executor::row_to_json_sqlite;
 pub use executor::{
     atomic, bulk_insert_pool, bulk_update_pool, count_rows_pool, delete_pool, delete_tx,
-    fetch_aggregate_pool, fetch_paginated_pool, fetch_with_prefetch_pool, get_or_create,
-    insert_pool, insert_returning_pool, insert_returning_tx, insert_tx, on_commit,
+    explain_pool, fetch_aggregate_pool, fetch_paginated_pool, fetch_with_prefetch_pool,
+    get_or_create, insert_pool, insert_returning_pool, insert_returning_tx, insert_tx, on_commit,
     on_commit_pending, raw_execute_pool, raw_query_pool, select_one_row_as_json,
     select_one_row_pool, select_rows_as_json, select_rows_pool, select_rows_pool_with_related,
     select_rows_tx_with_related, transaction_pool, update_or_create, update_pool, update_tx,

--- a/crates/rustango/tests/explain_pool_live.rs
+++ b/crates/rustango/tests/explain_pool_live.rs
@@ -1,0 +1,143 @@
+#![cfg(all(feature = "postgres", feature = "tenancy"))]
+//! Live PG regression for `crate::sql::explain_pool` — closes #272 / T1.10.
+//!
+//! Mirrors `tests/explain_live.rs` (the PG-typed `QuerySet::explain_on`
+//! coverage) but exercises the tri-dialect `_pool` variant through
+//! `Pool::Postgres`. Same `SelectQuery` shape as the sqlite / mysql
+//! live tests — the issue requires identical IR produces non-empty
+//! output across all three backends.
+
+use rustango::core::Column as _;
+use rustango::sql::{explain_pool, sqlx, Auto, ExplainFormat, ExplainOptions, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "_explain_pool_demo")]
+#[allow(dead_code)]
+pub struct Demo {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 64)]
+    pub label: String,
+}
+
+fn live_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pg = sqlx::PgPool::connect(&url).await.ok()?;
+    Some(Pool::Postgres(pg))
+}
+
+async fn fresh(pool: &Pool) {
+    let Pool::Postgres(pg) = pool else {
+        unreachable!()
+    };
+    sqlx::query(r#"DROP TABLE IF EXISTS "_explain_pool_demo" CASCADE"#)
+        .execute(pg)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "_explain_pool_demo" (
+            "id"    BIGSERIAL    PRIMARY KEY,
+            "label" VARCHAR(64)  NOT NULL
+        )"#,
+    )
+    .execute(pg)
+    .await
+    .unwrap();
+    for label in ["alpha", "beta", "gamma"] {
+        sqlx::query(r#"INSERT INTO "_explain_pool_demo" ("label") VALUES ($1)"#)
+            .bind(label)
+            .execute(pg)
+            .await
+            .unwrap();
+    }
+}
+
+fn select_query() -> rustango::core::SelectQuery {
+    Demo::objects()
+        .where_(Demo::label.eq("alpha"))
+        .compile()
+        .expect("compile")
+}
+
+#[tokio::test]
+async fn explain_pool_returns_plan_text_on_pg() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = select_query();
+    let plan = explain_pool(&pool, &q, ExplainOptions::default())
+        .await
+        .expect("explain text");
+    assert!(!plan.is_empty(), "EXPLAIN should return non-empty output");
+    assert!(
+        plan.contains("Scan") || plan.contains("Filter") || plan.contains("Plan"),
+        "expected planner output, got:\n{plan}"
+    );
+}
+
+#[tokio::test]
+async fn explain_pool_returns_plan_json_on_pg() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = select_query();
+    let plan = explain_pool(
+        &pool,
+        &q,
+        ExplainOptions {
+            format: ExplainFormat::Json,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("explain json");
+    assert!(!plan.is_empty(), "expected non-empty plan");
+    // PG `FORMAT JSON` returns a single-row JSON array string.
+    let parsed: serde_json::Value =
+        serde_json::from_str(&plan).expect("EXPLAIN(FORMAT JSON) output should parse");
+    assert!(parsed.is_array(), "expected JSON array, got: {parsed}");
+}
+
+#[tokio::test]
+async fn explain_pool_with_analyze_reports_actual_timings_on_pg() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = select_query();
+    let plan = explain_pool(
+        &pool,
+        &q,
+        ExplainOptions {
+            analyze: true,
+            buffers: true,
+            verbose: false,
+            format: ExplainFormat::Text,
+        },
+    )
+    .await
+    .expect("explain analyze");
+    assert!(
+        plan.contains("actual time="),
+        "ANALYZE output should include actual-timing column:\n{plan}"
+    );
+}

--- a/crates/rustango/tests/explain_pool_mysql_live.rs
+++ b/crates/rustango/tests/explain_pool_mysql_live.rs
@@ -1,0 +1,127 @@
+#![cfg(feature = "mysql")]
+//! Live MySQL regression for `crate::sql::explain_pool` — closes #272 / T1.10.
+//!
+//! Mirrors `explain_pool_sqlite_live.rs` + `explain_pool_live.rs`. Uses
+//! `EXPLAIN FORMAT=TREE` for text output (8.0.16+) and `EXPLAIN
+//! FORMAT=JSON` for JSON. `EXPLAIN ANALYZE` (8.0.18+) wins over either
+//! when `analyze = true`.
+//!
+//! Reads `MYSQL_TEST_URL`. Tests skip silently when unset so
+//! `cargo test` stays green offline.
+
+use std::sync::OnceLock;
+
+use rustango::core::Column as _;
+use rustango::sql::{explain_pool, sqlx, Auto, ExplainFormat, ExplainOptions, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "explain_mysql_demo")]
+#[rustango(app = "explain_pool_mysql_live")]
+#[allow(dead_code)]
+pub struct Demo {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 64)]
+    pub label: String,
+}
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn mysql_pool() -> Option<Pool> {
+    let url = std::env::var("MYSQL_TEST_URL").ok()?;
+    let mp = sqlx::mysql::MySqlPoolOptions::new()
+        .max_connections(5)
+        .connect(&url)
+        .await
+        .ok()?;
+    Some(Pool::Mysql(mp))
+}
+
+async fn fresh(pool: &Pool) {
+    let Pool::Mysql(my) = pool else {
+        unreachable!()
+    };
+    sqlx::query("DROP TABLE IF EXISTS `explain_mysql_demo`")
+        .execute(my)
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE TABLE `explain_mysql_demo` (
+            `id`    BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+            `label` VARCHAR(64)  NOT NULL
+        )",
+    )
+    .execute(my)
+    .await
+    .unwrap();
+    for label in ["alpha", "beta", "gamma"] {
+        sqlx::query("INSERT INTO `explain_mysql_demo` (`label`) VALUES (?)")
+            .bind(label)
+            .execute(my)
+            .await
+            .unwrap();
+    }
+}
+
+fn select_query() -> rustango::core::SelectQuery {
+    Demo::objects()
+        .where_(Demo::label.eq("alpha"))
+        .compile()
+        .expect("compile")
+}
+
+#[tokio::test]
+async fn explain_pool_returns_plan_text_on_mysql() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = mysql_pool().await else {
+        eprintln!("skipping: MYSQL_TEST_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = select_query();
+    let plan = explain_pool(&pool, &q, ExplainOptions::default())
+        .await
+        .expect("explain text");
+    assert!(!plan.is_empty(), "expected non-empty plan");
+    // MySQL FORMAT=TREE output references the source table.
+    assert!(
+        plan.to_ascii_lowercase().contains("explain_mysql_demo"),
+        "plan should reference our table, got:\n{plan}"
+    );
+}
+
+#[tokio::test]
+async fn explain_pool_returns_plan_json_on_mysql() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = mysql_pool().await else {
+        eprintln!("skipping: MYSQL_TEST_URL not set");
+        return;
+    };
+    fresh(&pool).await;
+
+    let q = select_query();
+    let plan = explain_pool(
+        &pool,
+        &q,
+        ExplainOptions {
+            format: ExplainFormat::Json,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("explain json");
+    assert!(!plan.is_empty(), "expected non-empty plan");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&plan).expect("EXPLAIN FORMAT=JSON should parse");
+    // MySQL JSON plan is an object with a `query_block` key.
+    assert!(
+        parsed.is_object(),
+        "expected JSON object from MySQL EXPLAIN, got: {parsed}"
+    );
+}

--- a/crates/rustango/tests/explain_pool_sqlite_live.rs
+++ b/crates/rustango/tests/explain_pool_sqlite_live.rs
@@ -1,0 +1,110 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite regression for `crate::sql::explain_pool` — closes #272 / T1.10.
+//!
+//! SQLite emits `EXPLAIN QUERY PLAN`, which is plan-only (never runs the
+//! query). Text-format output joins the per-row `detail` column with
+//! newlines; JSON-format emits `[{id, parent, detail}, ...]`.
+
+use rustango::core::Column as _;
+use rustango::sql::{explain_pool, sqlx, Auto, ExplainFormat, ExplainOptions, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "explain_sqlite_demo")]
+#[rustango(app = "explain_pool_sqlite_live")]
+#[allow(dead_code)]
+pub struct Demo {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 64)]
+    pub label: String,
+}
+
+async fn pool_with_schema() -> Pool {
+    let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory pool");
+    sqlx::query(
+        r#"CREATE TABLE explain_sqlite_demo (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            label TEXT NOT NULL
+        )"#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create table");
+    Pool::Sqlite(pool)
+}
+
+fn select_query() -> rustango::core::SelectQuery {
+    Demo::objects()
+        .where_(Demo::label.eq("alpha"))
+        .compile()
+        .expect("compile")
+}
+
+#[tokio::test]
+async fn explain_pool_returns_plan_text() {
+    let pool = pool_with_schema().await;
+    let q = select_query();
+    let plan = explain_pool(&pool, &q, ExplainOptions::default())
+        .await
+        .expect("explain text");
+    // SQLite's plan detail mentions the source table — proof the plan was
+    // emitted against our query, not just a no-op string.
+    assert!(!plan.is_empty(), "expected non-empty plan");
+    assert!(
+        plan.to_ascii_uppercase().contains("EXPLAIN_SQLITE_DEMO"),
+        "plan should reference our table, got:\n{plan}"
+    );
+}
+
+#[tokio::test]
+async fn explain_pool_returns_plan_json() {
+    let pool = pool_with_schema().await;
+    let q = select_query();
+    let plan = explain_pool(
+        &pool,
+        &q,
+        ExplainOptions {
+            format: ExplainFormat::Json,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("explain json");
+    assert!(!plan.is_empty(), "expected non-empty plan");
+    // JSON shape — first byte is `[`, content includes our table.
+    assert!(plan.starts_with('['), "expected JSON array, got: {plan}");
+    assert!(
+        plan.to_ascii_uppercase().contains("EXPLAIN_SQLITE_DEMO"),
+        "JSON plan should reference our table, got:\n{plan}"
+    );
+    // Validate it's parseable JSON.
+    let v: serde_json::Value = serde_json::from_str(&plan).expect("parse JSON");
+    assert!(v.is_array(), "expected JSON array");
+}
+
+#[tokio::test]
+async fn explain_pool_silently_no_ops_analyze_flag_on_sqlite() {
+    let pool = pool_with_schema().await;
+    let q = select_query();
+    // analyze=true + buffers=true are PG-only knobs. SQLite must NOT
+    // error on them — it silently ignores per the issue spec.
+    let plan = explain_pool(
+        &pool,
+        &q,
+        ExplainOptions {
+            analyze: true,
+            buffers: true,
+            verbose: true,
+            format: ExplainFormat::Text,
+        },
+    )
+    .await
+    .expect("explain analyze+buffers should silently no-op on sqlite");
+    assert!(
+        !plan.is_empty(),
+        "expected non-empty plan even with no-op flags"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #272 (T1.10 — second ticket in the Tier 1 batch [#273](https://github.com/ujeenet/rustango/issues/273)).

Adds `crate::sql::explain_pool(pool: &Pool, query: &SelectQuery, opts: ExplainOptions) -> Result<String, ExecError>` — the tri-dialect counterpart of the existing PG-typed `QuerySet::explain` / `QuerySet::explain_on`. Routes per-backend via `Pool::dialect()`.

```rust
let plan = explain_pool(&pool, &query, ExplainOptions::default()).await?;
println!(\"{plan}\");
```

## Per-backend behavior

| Backend | Text | JSON | ANALYZE | BUFFERS / VERBOSE |
|---------|------|------|---------|--------------------|
| **Postgres** | `EXPLAIN <stmt>` | `EXPLAIN (FORMAT JSON) <stmt>` | `EXPLAIN (ANALYZE) <stmt>` | passed through as flag tokens |
| **MySQL** | `EXPLAIN FORMAT=TREE <stmt>` (8.0.16+) | `EXPLAIN FORMAT=JSON <stmt>` | `EXPLAIN ANALYZE <stmt>` (8.0.18+) | no-op (silently) |
| **SQLite** | `EXPLAIN QUERY PLAN <stmt>` joined by newline | `[{id, parent, detail}, ...]` | no-op (plan-only) | no-op |

Per the issue spec, flags that don't apply silently no-op — the call still succeeds. MySQL's classic multi-column tabular `EXPLAIN <stmt>` is intentionally not emitted because the single-string return shape can't carry it; `raw_query_pool` is the escape hatch.

## Acceptance ✅

- [x] `crate::sql::explain_pool(...)` exists with the issue's exact signature.
- [x] Per-dialect dispatch through `Pool::dialect()`.
- [x] `analyze`/`buffers`/`verbose` flags silently no-op where unsupported.
- [x] Tests pin same `SelectQuery` produces non-empty output on all three backends:
  - `tests/explain_pool_sqlite_live.rs` — 3 tests (text / JSON / no-op flags) ✓
  - `tests/explain_pool_live.rs` — 3 tests (text / JSON / ANALYZE timings) ✓ (PG)
  - `tests/explain_pool_mysql_live.rs` — 2 tests (text / JSON)
- [x] CI wired: sqlite test added to the `sqlite_live` job's `--test` list; mysql test added to the `mysql_live` job's run list.

## Tri-dialect verification ✅

- `cargo build --no-default-features --features sqlite,tenancy` — passes (canonical sqlite-tenancy litmus).
- `cargo test --workspace --all-features --no-run` — passes.
- Local: SQLite 3/3 + PG 3/3 tests pass.

## Extract-surface impact

Pure work in `sql/executor.rs` + `sql/mod.rs` re-exports. No new dependencies. `ExplainOptions::to_clause` stays `#[cfg(feature = \"postgres\")]` since only the PG branch calls it.