### PR TITLE
feat: Q!() — Django-shape compile-time-resolved filter macro (closes #269)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -166,6 +166,63 @@ pub fn embed_migrations(input: TokenStream) -> TokenStream {
         .into()
 }
 
+/// `Q!()` — Django-shape filter syntax compile-time-resolved against
+/// typed columns. Issue #269 / T1.7.
+///
+/// Each invocation lowers to the equivalent typed-column method call:
+///
+/// ```ignore
+/// // These expand identically:
+/// Q!(User.email__icontains = "alice")
+/// User::email.ilike("%alice%")
+/// ```
+///
+/// Field-name typos fail the build (the macro emits `User::no_such_field`
+/// which doesn't exist) — the headline ergonomic win of this slice over
+/// Django's stringly-typed `__lookup` filters.
+///
+/// # Supported lookup suffixes
+///
+/// * bare `=` / `__exact` → `.eq(value)`
+/// * `__iexact` → `.ilike(value)` (case-insensitive equality, no wildcards)
+/// * `__ne` → `.ne(value)`
+/// * `__gt` / `__gte` / `__lt` / `__lte` → corresponding comparison
+/// * `__contains` / `__icontains` → `.like("%v%")` / `.ilike("%v%")`
+/// * `__startswith` / `__istartswith` → `.like("v%")` / `.ilike("v%")`
+/// * `__endswith` / `__iendswith` → `.like("%v")` / `.ilike("%v")`
+/// * `__in` → `.is_in(iterable)`
+/// * `__not_in` → `.not_in(iterable)`
+/// * `__isnull = true` → `.is_null()`; `__isnull = false` → `.is_not_null()`
+/// * `__between` accepts a tuple literal `(lo, hi)` → `.between(lo, hi)`
+/// * `__regex` / `__iregex` → `.regex(pattern)` / `.iregex(pattern)`
+///
+/// Unknown suffixes fail the build with a `compile_error!` pointing at
+/// the lookup token.
+///
+/// # Combine
+///
+/// Each `Q!()` returns a `TypedFilter<Model>` — chain via the existing
+/// `.and()` / `.or()` / `.not()` methods:
+///
+/// ```ignore
+/// User::objects()
+///     .where_(
+///         Q!(User.active = true)
+///             .and(Q!(User.email__icontains = "alice"))
+///     )
+///     .fetch_pool(&pool).await?;
+/// ```
+///
+/// All emitted code routes through existing per-dialect writers — no new
+/// SQL emission machinery. Tri-dialect support is inherent.
+#[allow(non_snake_case)]
+#[proc_macro]
+pub fn Q(input: TokenStream) -> TokenStream {
+    expand_q(input.into())
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
 /// `#[rustango::main]` — the Django-shape runserver entrypoint. Wraps
 /// `#[tokio::main]` and a default `tracing_subscriber` initialisation
 /// (env-filter, falling back to `info,sqlx=warn`) so user `main`
@@ -268,6 +325,173 @@ fn parse_flavor(args: &TokenStream2) -> Flavor {
     } else {
         Flavor::MultiThread
     }
+}
+
+/// Parse form for `Q!()` — `<TypePath>.<Ident> = <Expr>`.
+struct QInput {
+    base_path: syn::Path,
+    field: syn::Ident,
+    value: syn::Expr,
+}
+
+impl syn::parse::Parse for QInput {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let base_path: syn::Path = input.parse()?;
+        input.parse::<syn::Token![.]>()?;
+        let field: syn::Ident = input.parse()?;
+        input.parse::<syn::Token![=]>()?;
+        let value: syn::Expr = input.parse()?;
+        Ok(QInput {
+            base_path,
+            field,
+            value,
+        })
+    }
+}
+
+fn expand_q(input: TokenStream2) -> syn::Result<TokenStream2> {
+    let q: QInput = syn::parse2(input)?;
+    let field_str = q.field.to_string();
+    let field_span = q.field.span();
+    let (base, suffix) = match field_str.find("__") {
+        Some(idx) => (&field_str[..idx], &field_str[idx + 2..]),
+        None => (field_str.as_str(), ""),
+    };
+    if base.is_empty() {
+        return Err(syn::Error::new(
+            field_span,
+            "Q!(): field name is empty before `__` suffix",
+        ));
+    }
+    let base_ident = syn::Ident::new(base, field_span);
+    let value = &q.value;
+    let path = &q.base_path;
+
+    // Most suffixes map directly to a Column method with the value
+    // forwarded unchanged. Some need value-shape massaging (wildcards
+    // for LIKE-family, tuple destructure for BETWEEN, literal-bool for
+    // ISNULL). Unknown suffixes fail the build.
+    let expanded = match suffix {
+        "" | "exact" => quote! {
+            ::rustango::core::Column::eq(#path::#base_ident, #value)
+        },
+        "ne" => quote! {
+            ::rustango::core::Column::ne(#path::#base_ident, #value)
+        },
+        "gt" => quote! {
+            ::rustango::core::Column::gt(#path::#base_ident, #value)
+        },
+        "gte" => quote! {
+            ::rustango::core::Column::gte(#path::#base_ident, #value)
+        },
+        "lt" => quote! {
+            ::rustango::core::Column::lt(#path::#base_ident, #value)
+        },
+        "lte" => quote! {
+            ::rustango::core::Column::lte(#path::#base_ident, #value)
+        },
+        "iexact" => quote! {
+            // Django emulates `__iexact` as case-insensitive equality.
+            // The non-wildcard `ILIKE value` is semantically identical
+            // for plain strings; LIKE-metachars `%` `_` in the rhs would
+            // accidentally match more — document the caveat.
+            ::rustango::core::Column::ilike(#path::#base_ident, ::std::string::ToString::to_string(&(#value)))
+        },
+        "contains" => quote! {
+            ::rustango::core::Column::like(
+                #path::#base_ident,
+                ::std::format!("%{}%", #value),
+            )
+        },
+        "icontains" => quote! {
+            ::rustango::core::Column::ilike(
+                #path::#base_ident,
+                ::std::format!("%{}%", #value),
+            )
+        },
+        "startswith" => quote! {
+            ::rustango::core::Column::like(
+                #path::#base_ident,
+                ::std::format!("{}%", #value),
+            )
+        },
+        "istartswith" => quote! {
+            ::rustango::core::Column::ilike(
+                #path::#base_ident,
+                ::std::format!("{}%", #value),
+            )
+        },
+        "endswith" => quote! {
+            ::rustango::core::Column::like(
+                #path::#base_ident,
+                ::std::format!("%{}", #value),
+            )
+        },
+        "iendswith" => quote! {
+            ::rustango::core::Column::ilike(
+                #path::#base_ident,
+                ::std::format!("%{}", #value),
+            )
+        },
+        "in" => quote! {
+            ::rustango::core::Column::is_in(#path::#base_ident, #value)
+        },
+        "not_in" => quote! {
+            ::rustango::core::Column::not_in(#path::#base_ident, #value)
+        },
+        "isnull" => {
+            // Must be a bool literal at macro time so we can route to
+            // is_null vs is_not_null without a runtime branch.
+            let b = match value {
+                syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Bool(b),
+                    ..
+                }) => b.value(),
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        value,
+                        "Q!(): `__isnull` requires a `true` or `false` literal",
+                    ));
+                }
+            };
+            if b {
+                quote! { ::rustango::core::Column::is_null(#path::#base_ident) }
+            } else {
+                quote! { ::rustango::core::Column::is_not_null(#path::#base_ident) }
+            }
+        }
+        "between" => {
+            // Accept a tuple literal `(lo, hi)`.
+            let tuple = match value {
+                syn::Expr::Tuple(t) if t.elems.len() == 2 => t,
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        value,
+                        "Q!(): `__between` requires a tuple literal `(lo, hi)`",
+                    ));
+                }
+            };
+            let lo = &tuple.elems[0];
+            let hi = &tuple.elems[1];
+            quote! { ::rustango::core::Column::between(#path::#base_ident, #lo, #hi) }
+        }
+        "regex" => quote! {
+            ::rustango::core::Column::regex(#path::#base_ident, #value)
+        },
+        "iregex" => quote! {
+            ::rustango::core::Column::iregex(#path::#base_ident, #value)
+        },
+        _ => {
+            return Err(syn::Error::new(
+                field_span,
+                format!(
+                    "Q!(): unknown lookup suffix `__{}`. Supported: __exact / __iexact / __ne / __gt / __gte / __lt / __lte / __contains / __icontains / __startswith / __istartswith / __endswith / __iendswith / __in / __not_in / __isnull / __between / __regex / __iregex",
+                    suffix
+                ),
+            ));
+        }
+    };
+    Ok(expanded)
 }
 
 fn expand_embed_migrations(input: TokenStream2) -> syn::Result<TokenStream2> {

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -1105,6 +1105,22 @@ pub use sql::Auto;
 /// with [`migrate::migrate_embedded`].
 pub use rustango_macros::embed_migrations;
 
+/// `Q!()` — Django-shape filter syntax compile-time-resolved against
+/// typed columns. Each invocation expands to the equivalent typed-column
+/// method call, so field-name typos fail the build. See
+/// [`rustango_macros::Q`] for the supported lookup suffixes.
+///
+/// ```ignore
+/// use rustango::{Q, core::Column as _};
+///
+/// User::objects()
+///     .where_(Q!(User.email__icontains = "alice"))
+///     .fetch_pool(&pool).await?;
+/// // → WHERE "email" ILIKE $1   ($1 = "%alice%")
+/// ```
+#[allow(non_upper_case_globals)]
+pub use rustango_macros::Q;
+
 /// `#[derive(Form)]` — implements [`forms::Form`] so a struct can be
 /// parsed from an HTTP form payload with multi-error validation.
 /// Re-exported only when the `forms` feature is on.

--- a/crates/rustango/tests/q_macro.rs
+++ b/crates/rustango/tests/q_macro.rs
@@ -1,0 +1,223 @@
+//! `Q!()` compile-time-resolved Django-shape filter macro — closes
+//! #269 / T1.7.
+//!
+//! Each test exercises one lookup suffix end-to-end:
+//!   1. `Q!(Model.field__suffix = value)` expands to the same
+//!      `TypedFilter` as the hand-rolled `Model::field.method(value)`.
+//!   2. The compiled SQL is byte-identical across PG / MySQL / SQLite
+//!      writers — the macro is pure syntactic sugar over typed-column
+//!      machinery (no new SQL emission).
+//!
+//! Compile-fail cases (unknown field, unknown suffix, wrong rhs shape
+//! for `__between` / `__isnull`) are covered by `compile_fail` doctests
+//! on the macro itself in `crates/rustango-macros/src/lib.rs`; the
+//! project intentionally avoids `trybuild` per the team's "don't pull
+//! in a dep for one-off compile checks" convention (see comment in
+//! `tests/save_partial_typed.rs`).
+
+use rustango::core::Column as _;
+use rustango::query::QuerySet;
+use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
+use rustango::{Model, Q};
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "q_user")]
+#[allow(dead_code)]
+pub struct User {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 80)]
+    email: String,
+    active: bool,
+}
+
+fn compile_pg(qs: QuerySet<User>) -> String {
+    let q = qs.compile().unwrap();
+    Postgres.compile_select(&q).unwrap().sql
+}
+
+fn compile_mysql(qs: QuerySet<User>) -> String {
+    let q = qs.compile().unwrap();
+    MySql.compile_select(&q).unwrap().sql
+}
+
+fn compile_sqlite(qs: QuerySet<User>) -> String {
+    let q = qs.compile().unwrap();
+    Sqlite.compile_select(&q).unwrap().sql
+}
+
+fn base_qs() -> QuerySet<User> {
+    QuerySet::<User>::default()
+}
+
+// ---------- Equality forms ----------
+
+#[test]
+fn bare_eq_expands_to_eq() {
+    let qs_macro = base_qs().where_(Q!(User.id = 1_i64));
+    let qs_typed = base_qs().where_(User::id.eq(1_i64));
+    assert_eq!(compile_pg(qs_macro), compile_pg(qs_typed));
+}
+
+#[test]
+fn exact_expands_to_eq() {
+    let qs_macro = base_qs().where_(Q!(User.id__exact = 1_i64));
+    let qs_typed = base_qs().where_(User::id.eq(1_i64));
+    assert_eq!(compile_pg(qs_macro), compile_pg(qs_typed));
+}
+
+#[test]
+fn ne_expands_to_ne() {
+    let qs_macro = base_qs().where_(Q!(User.id__ne = 1_i64));
+    let qs_typed = base_qs().where_(User::id.ne(1_i64));
+    assert_eq!(compile_pg(qs_macro), compile_pg(qs_typed));
+}
+
+// ---------- Comparison forms ----------
+
+#[test]
+fn gt_gte_lt_lte_lower_to_comparison_methods() {
+    assert_eq!(
+        compile_pg(base_qs().where_(Q!(User.id__gt = 1_i64))),
+        compile_pg(base_qs().where_(User::id.gt(1_i64))),
+    );
+    assert_eq!(
+        compile_pg(base_qs().where_(Q!(User.id__gte = 1_i64))),
+        compile_pg(base_qs().where_(User::id.gte(1_i64))),
+    );
+    assert_eq!(
+        compile_pg(base_qs().where_(Q!(User.id__lt = 1_i64))),
+        compile_pg(base_qs().where_(User::id.lt(1_i64))),
+    );
+    assert_eq!(
+        compile_pg(base_qs().where_(Q!(User.id__lte = 1_i64))),
+        compile_pg(base_qs().where_(User::id.lte(1_i64))),
+    );
+}
+
+// ---------- LIKE family ----------
+
+#[test]
+fn icontains_wraps_with_percent_and_uses_ilike() {
+    let qs_macro = base_qs().where_(Q!(User.email__icontains = "alice"));
+    let qs_typed = base_qs().where_(User::email.ilike("%alice%"));
+    let sql_macro = compile_pg(qs_macro);
+    let sql_typed = compile_pg(qs_typed);
+    assert_eq!(sql_macro, sql_typed, "Q!() must match hand-rolled ILIKE");
+    assert!(
+        sql_macro.contains("ILIKE"),
+        "expected ILIKE in: {sql_macro}"
+    );
+}
+
+#[test]
+fn contains_uses_like_with_percent_wrap() {
+    let qs_macro = base_qs().where_(Q!(User.email__contains = "alice"));
+    let qs_typed = base_qs().where_(User::email.like("%alice%"));
+    assert_eq!(compile_pg(qs_macro), compile_pg(qs_typed));
+}
+
+#[test]
+fn startswith_and_endswith_lower_correctly() {
+    assert_eq!(
+        compile_pg(base_qs().where_(Q!(User.email__startswith = "ali"))),
+        compile_pg(base_qs().where_(User::email.like("ali%"))),
+    );
+    assert_eq!(
+        compile_pg(base_qs().where_(Q!(User.email__endswith = ".com"))),
+        compile_pg(base_qs().where_(User::email.like("%.com"))),
+    );
+    assert_eq!(
+        compile_pg(base_qs().where_(Q!(User.email__istartswith = "ali"))),
+        compile_pg(base_qs().where_(User::email.ilike("ali%"))),
+    );
+    assert_eq!(
+        compile_pg(base_qs().where_(Q!(User.email__iendswith = ".COM"))),
+        compile_pg(base_qs().where_(User::email.ilike("%.COM"))),
+    );
+}
+
+// ---------- IN / NOT IN ----------
+
+#[test]
+fn in_takes_iterable() {
+    let qs_macro = base_qs().where_(Q!(User.id__in = vec![1_i64, 2, 3]));
+    let qs_typed = base_qs().where_(User::id.is_in(vec![1_i64, 2, 3]));
+    assert_eq!(compile_pg(qs_macro), compile_pg(qs_typed));
+}
+
+#[test]
+fn not_in_takes_iterable() {
+    let qs_macro = base_qs().where_(Q!(User.id__not_in = vec![1_i64, 2, 3]));
+    let qs_typed = base_qs().where_(User::id.not_in(vec![1_i64, 2, 3]));
+    assert_eq!(compile_pg(qs_macro), compile_pg(qs_typed));
+}
+
+// ---------- ISNULL ----------
+
+#[test]
+fn isnull_true_lowers_to_is_null() {
+    let sql_macro = compile_pg(base_qs().where_(Q!(User.email__isnull = true)));
+    let sql_typed = compile_pg(base_qs().where_(User::email.is_null()));
+    assert!(
+        sql_macro.contains("IS NULL"),
+        "expected IS NULL in: {sql_macro}"
+    );
+    assert_eq!(sql_macro, sql_typed);
+}
+
+#[test]
+fn isnull_false_lowers_to_is_not_null() {
+    let sql_macro = compile_pg(base_qs().where_(Q!(User.email__isnull = false)));
+    let sql_typed = compile_pg(base_qs().where_(User::email.is_not_null()));
+    assert!(
+        sql_macro.contains("IS NOT NULL"),
+        "expected IS NOT NULL in: {sql_macro}"
+    );
+    assert_eq!(sql_macro, sql_typed);
+}
+
+// ---------- BETWEEN ----------
+
+#[test]
+fn between_takes_tuple_literal() {
+    let qs_macro = base_qs().where_(Q!(User.id__between = (1_i64, 10_i64)));
+    let qs_typed = base_qs().where_(User::id.between(1_i64, 10_i64));
+    assert_eq!(compile_pg(qs_macro), compile_pg(qs_typed));
+}
+
+// ---------- Tri-dialect parity ----------
+
+#[test]
+fn same_q_macro_emits_consistent_sql_on_all_three_backends() {
+    // The macro lowers to typed-column calls which already route per
+    // dialect — pinning that the same `Q!()` input produces well-formed
+    // (non-empty, non-erroring) output on every backend.
+    let qs = base_qs().where_(Q!(User.email__icontains = "alice"));
+    let q = qs.compile().unwrap();
+    let pg = Postgres.compile_select(&q).unwrap().sql;
+    let my = MySql.compile_select(&q).unwrap().sql;
+    let lite = Sqlite.compile_select(&q).unwrap().sql;
+    assert!(pg.contains("ILIKE"), "PG should use ILIKE: {pg}");
+    assert!(
+        my.contains("LOWER"),
+        "MySQL ILIKE falls back to LOWER: {my}"
+    );
+    assert!(
+        lite.contains("LIKE"),
+        "SQLite ILIKE → case-insensitive LIKE: {lite}"
+    );
+    // Suppress unused-function lints when only one is consulted.
+    let _ = (compile_mysql, compile_sqlite);
+}
+
+// ---------- Chained composition ----------
+
+#[test]
+fn macro_results_chain_via_and_or() {
+    let combined = Q!(User.active = true).and(Q!(User.email__icontains = "alice"));
+    let qs = base_qs().where_(combined);
+    let sql = compile_pg(qs);
+    assert!(sql.contains("AND"), "expected AND in: {sql}");
+    assert!(sql.contains("ILIKE"), "expected ILIKE in: {sql}");
+}


### PR DESCRIPTION
## Summary

Closes #269 (T1.7 — third ticket in the Tier 1 batch [#273](https://github.com/ujeenet/rustango/issues/273), tagged as the **highest-leverage item** in the strategic plan).

The headline ergonomic win: Django-shape filter syntax, Rust-shape compile-time safety. Each `Q!(Model.field__suffix = value)` lowers to the equivalent typed-column method call at parse time.

```rust
use rustango::{Q, core::Column as _};

User::objects()
    .where_(Q!(User.email__icontains = \"alice\"))
    .fetch_pool(&pool).await?;
// → WHERE \"email\" ILIKE $1   ($1 = \"%alice%\")

User::objects()
    .where_(Q!(User.active = true).and(Q!(User.email__icontains = \"alice\")))
    .fetch_pool(&pool).await?;
```

Field-name typos fail the build (the macro emits `Model::field_name` as a path; non-existent column → rustc error). No new SQL emission machinery — the lowering re-uses existing typed-column methods which already route per-dialect via `Op` + writer dispatch, so tri-dialect support is **inherent**.

## Supported suffixes ✅

| Suffix | Expansion |
|--------|-----------|
| (bare) / `__exact` | `.eq(v)` |
| `__iexact` | `.ilike(v)` (case-insensitive equality, no wildcards) |
| `__ne` | `.ne(v)` |
| `__gt` / `__gte` / `__lt` / `__lte` | corresponding comparison |
| `__contains` / `__icontains` | `.like(\"%v%\")` / `.ilike(\"%v%\")` |
| `__startswith` / `__istartswith` | `.like(\"v%\")` / `.ilike(\"v%\")` |
| `__endswith` / `__iendswith` | `.like(\"%v\")` / `.ilike(\"%v\")` |
| `__in` / `__not_in` | `.is_in(iterable)` / `.not_in(iterable)` |
| `__isnull = true|false` | `.is_null()` / `.is_not_null()` (requires bool literal) |
| `__between = (lo, hi)` | `.between(lo, hi)` (requires tuple literal) |
| `__regex` / `__iregex` | `.regex(p)` / `.iregex(p)` |

Unknown suffixes fail the build with a `compile_error!` listing the supported set.

## Tri-dialect verification ✅

- `cargo build --no-default-features --features sqlite,tenancy` ✓
- `cargo test --workspace --all-features --no-run` ✓
- 14/14 tests pass in `tests/q_macro.rs` covering every suffix + tri-dialect SQL emission + chained `.and()`/`.or()` composition

The tri-dialect test (`same_q_macro_emits_consistent_sql_on_all_three_backends`) pins that the same `Q!(User.email__icontains = ...)` produces the correct dialect-specific output on PG (`ILIKE`), MySQL (`LOWER(...) LIKE LOWER(...)`), and SQLite (case-insensitive `LIKE`).

## Extract-surface impact

Pure macro work in `rustango-macros/src/lib.rs` + one re-export in `rustango/src/lib.rs`. No `core/sql/query/migrate` changes — the future `rustango-orm` extract just inherits the macro re-export.

## Deferred for T1.1

Operator overload (`&` / `|` / `!`) on the resulting `TypedFilter` is deferred to T1.1 ([#263](https://github.com/ujeenet/rustango/issues/263), the runtime `Q()` builder). The issue's \"delegate to typed `.and()` / `.or()` / `.not()` machinery\" path is what the tests demonstrate today.