### PR TITLE
feat: .distinct() / .distinct_on(*fields) (closes #264)

### DIFF
--- a/crates/rustango/src/admin/inlines.rs
+++ b/crates/rustango/src/admin/inlines.rs
@@ -366,6 +366,7 @@ pub async fn render_for_parent(
                 lock_mode: None,
                 compound: vec![],
                 projection: None,
+                distinct: None,
             },
             &select_fields,
         )
@@ -514,6 +515,7 @@ pub async fn render_generic_for_parent(
                 lock_mode: None,
                 compound: vec![],
                 projection: None,
+                distinct: None,
             },
             &select_fields,
         )
@@ -763,6 +765,7 @@ pub async fn render_form_for_parent(
                 lock_mode: None,
                 compound: vec![],
                 projection: None,
+                distinct: None,
             },
             &select_fields,
         )
@@ -1231,6 +1234,7 @@ pub async fn render_form_generic_for_parent(
                 lock_mode: None,
                 compound: vec![],
                 projection: None,
+                distinct: None,
             },
             &select_fields,
         )

--- a/crates/rustango/src/admin/login_view.rs
+++ b/crates/rustango/src/admin/login_view.rs
@@ -112,6 +112,7 @@ async fn login_submit(State(state): State<AppState>, Form(form): Form<LoginInput
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     let row = crate::sql::select_one_row_as_json(&state.pool, &select, &fields)
         .await
@@ -223,6 +224,7 @@ async fn change_password_submit(
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     let row = crate::sql::select_one_row_as_json(&state.pool, &select, &fields)
         .await

--- a/crates/rustango/src/admin/manage_admin.rs
+++ b/crates/rustango/src/admin/manage_admin.rs
@@ -138,6 +138,7 @@ pub async fn create_admin_cmd<W: Write + Send>(
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     let fields: Vec<&'static crate::core::FieldSchema> = AdminUser::SCHEMA.fields.iter().collect();
     let existing = crate::sql::select_one_row_as_json(pool, &select, &fields)

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -292,6 +292,7 @@ pub(crate) async fn table_view(
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         },
         &scalar_fields,
     )
@@ -953,6 +954,7 @@ pub(crate) async fn detail_view(
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         },
         &detail_fields,
     )
@@ -1278,6 +1280,7 @@ pub(crate) async fn edit_form(
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         },
         &edit_fields,
     )
@@ -1392,6 +1395,7 @@ pub(crate) async fn update_submit(
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         },
         &before_fields,
     )
@@ -1478,6 +1482,7 @@ pub(crate) async fn delete_submit(
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         },
         &delete_fields,
     )
@@ -1646,6 +1651,7 @@ pub(crate) async fn action_submit(
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         },
         &action_fields,
     )

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -354,6 +354,7 @@ pub async fn fetch_row_as_json(
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     let fields: Vec<&'static crate::core::FieldSchema> = entry.schema.scalar_fields().collect();
     crate::sql::select_one_row_as_json(pool, &select_q, &fields).await
@@ -410,6 +411,7 @@ where
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let rows = crate::sql::select_rows_as_json(pool, &select_q, &fields).await?;
         if rows.is_empty() {
@@ -791,6 +793,7 @@ pub async fn fetch_reverse_generic(
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     let fields: Vec<&'static crate::core::FieldSchema> = child_schema.scalar_fields().collect();
     crate::sql::select_rows_as_json(pool, &select_q, &fields).await
@@ -902,6 +905,7 @@ pub async fn prefetch_reverse_generic_for<Parent: crate::core::Model>(
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     let fields: Vec<&'static crate::core::FieldSchema> = child_schema.scalar_fields().collect();
     let rows = crate::sql::select_rows_as_json(pool, &select_q, &fields).await?;

--- a/crates/rustango/src/core/error.rs
+++ b/crates/rustango/src/core/error.rs
@@ -129,4 +129,23 @@ pub enum QueryError {
          one column. Pass the column names you want in the projection."
     )]
     EmptyValuesProjection,
+
+    /// `.distinct_on(&[])` was called with an empty column list — would
+    /// degenerate to `.distinct()` and is almost always a bug. Issue
+    /// #264 / T1.2.
+    #[error("`.distinct_on(...)` requires at least one column; use `.distinct()` for plain SELECT DISTINCT")]
+    DistinctOnEmpty,
+
+    /// `.distinct_on(cols)` was called but the queryset's `ORDER BY`
+    /// doesn't lead with those columns. Django enforces the same
+    /// constraint at runtime — the order is what makes the
+    /// "first row per group" deterministic. Issue #264 / T1.2.
+    #[error(
+        "`.distinct_on({distinct_on:?})` requires those columns at the head of `.order_by(...)`; \
+         got order_by={order_by:?}"
+    )]
+    DistinctOnOrderByMismatch {
+        distinct_on: Vec<String>,
+        order_by: Vec<String>,
+    },
 }

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -25,9 +25,9 @@ pub use expr::{BinOp, CaseBranch, Expr, ScalarFn, F};
 pub use field_type::FieldType;
 pub use query::{
     AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ColumnFilter,
-    CompoundBranch, ConflictClause, CountQuery, DeleteQuery, Filter, InsertQuery, Join, JoinKind,
-    LockMode, NullsOrder, Op, OrderClause, OrderItem, SearchClause, SelectQuery, SetOp,
-    UpdateQuery, WhereExpr,
+    CompoundBranch, ConflictClause, CountQuery, DeleteQuery, DistinctMode, Filter, InsertQuery,
+    Join, JoinKind, LockMode, NullsOrder, Op, OrderClause, OrderItem, SearchClause, SelectQuery,
+    SetOp, UpdateQuery, WhereExpr,
 };
 pub use schema::{
     infer_app_label_from_module_path, AdminConfig, CheckConstraint, CompositeFkRelation,

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -541,6 +541,26 @@ pub struct SelectQuery {
     /// `project` columns. Validated at builder time so every column
     /// resolves on the model schema.
     pub projection: Option<Vec<&'static str>>,
+    /// Django `.distinct(*fields)` — issue #264 / T1.2. `None` is the
+    /// default (no DISTINCT clause). `Some(DistinctMode::All)` emits
+    /// `SELECT DISTINCT ...`. `Some(DistinctMode::On(cols))` emits PG
+    /// `SELECT DISTINCT ON (cols) ...` natively; on MySQL/SQLite the
+    /// writer wraps the query in a `ROW_NUMBER() OVER (PARTITION BY
+    /// cols ORDER BY <order_by>) AS __rn` subquery with an outer
+    /// `WHERE __rn = 1` so the "first row per group" semantics carry.
+    pub distinct: Option<DistinctMode>,
+}
+
+/// Distinct mode — Django's `.distinct()` / `.distinct(*fields)`.
+/// Issue #264 / T1.2.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DistinctMode {
+    /// `SELECT DISTINCT ...` — works on every dialect identically.
+    All,
+    /// `SELECT DISTINCT ON (cols) ...` — PG-native syntax with portable
+    /// `ROW_NUMBER()` fallback on MySQL / SQLite. Empty `cols` is
+    /// rejected at builder time (would degenerate to `DISTINCT`).
+    On(Vec<&'static str>),
 }
 
 /// One branch of a set-algebra compound query. Issue #25.

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -2391,6 +2391,7 @@ async fn dumpdata_cmd<W: Write>(
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
 
         let rows = crate::sql::select_rows_as_json(pool, &query, &fields)

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -30,6 +30,10 @@ pub struct QuerySet<T: Model> {
     pending: Vec<PendingFilter>,
     limit: Option<i64>,
     offset: Option<i64>,
+    /// Django `.distinct(*fields)` — issue #264 / T1.2. `None` (default)
+    /// emits no DISTINCT clause. See [`crate::core::DistinctMode`] for
+    /// the per-mode semantics.
+    distinct: Option<crate::core::DistinctMode>,
     /// FK field names registered for [`Self::select_related`] — slice
     /// 9.0d. Each name resolves to a `Join` against the FK target at
     /// `compile()` time, so the SELECT pulls the parent rows along
@@ -141,6 +145,7 @@ impl<T: Model> QuerySet<T> {
             pending: Vec::new(),
             limit: None,
             offset: None,
+            distinct: None,
             select_related: Vec::new(),
             ad_hoc_joins: Vec::new(),
             order_by: Vec::new(),
@@ -148,6 +153,42 @@ impl<T: Model> QuerySet<T> {
             compound: Vec::new(),
             _model: PhantomData,
         }
+    }
+
+    /// Django `.distinct()` — emit `SELECT DISTINCT ...`. Works on
+    /// every dialect identically. Pair with `.order_by(...)` to
+    /// disambiguate which row survives among duplicates (DB doesn't
+    /// guarantee an order otherwise).
+    ///
+    /// For PG-shape "DISTINCT ON (cols)" (latest-per-group), use
+    /// [`Self::distinct_on`] which is portable across all three
+    /// backends via a window-function fallback.
+    ///
+    /// Issue #264 / T1.2.
+    #[must_use]
+    pub fn distinct(mut self) -> Self {
+        self.distinct = Some(crate::core::DistinctMode::All);
+        self
+    }
+
+    /// Django `.distinct(*fields)` — emit `SELECT DISTINCT ON (col1, col2)`
+    /// on PG natively; lower to a `ROW_NUMBER() OVER (PARTITION BY cols
+    /// ORDER BY <existing order_by>)` subquery wrapper on MySQL / SQLite.
+    /// In all three the result is "first row per group", where "first"
+    /// is determined by the queryset's `ORDER BY`.
+    ///
+    /// **Constraint**: the columns passed must appear at the head of
+    /// `.order_by(...)` (matches Django's runtime check). `.compile()`
+    /// returns [`QueryError::DistinctOnOrderBy`] otherwise — the order
+    /// is what makes the "first row" deterministic.
+    ///
+    /// Empty `fields` is rejected (would degenerate to `.distinct()`).
+    ///
+    /// Issue #264 / T1.2.
+    #[must_use]
+    pub fn distinct_on(mut self, fields: &[&'static str]) -> Self {
+        self.distinct = Some(crate::core::DistinctMode::On(fields.to_vec()));
+        self
     }
 
     /// Issue #21 — Django's `QuerySet.select_for_update(skip_locked=,
@@ -738,6 +779,49 @@ impl<T: Model> QuerySet<T> {
         // issue-#76 `.order_by_with_nulls(...)` / `.order_by_expr(...)`
         // calls so a mixed chain emits in the order it was written.
         let order_by = lower_order_items(model, self.order_by)?;
+        // Issue #264 / T1.2 — `.distinct_on(&[...])` requires the
+        // listed columns to head the ORDER BY (Django enforces this
+        // at runtime; we catch it at builder time). Empty list is
+        // rejected because it would degenerate to `.distinct()`.
+        if let Some(crate::core::DistinctMode::On(cols)) = &self.distinct {
+            if cols.is_empty() {
+                return Err(QueryError::DistinctOnEmpty);
+            }
+            for col in cols {
+                if model.field_by_column(col).is_none() {
+                    return Err(QueryError::UnknownField {
+                        model: model.name,
+                        field: (*col).to_owned(),
+                    });
+                }
+            }
+            // First `cols.len()` order_by items must be the distinct-on
+            // columns in the same order. Bare `OrderItem::Column` only;
+            // expressions / random can't be DISTINCT-ON keys.
+            if order_by.len() < cols.len() {
+                return Err(QueryError::DistinctOnOrderByMismatch {
+                    distinct_on: cols.iter().map(|s| (*s).to_owned()).collect(),
+                    order_by: order_by_column_names(&order_by),
+                });
+            }
+            for (i, col) in cols.iter().enumerate() {
+                let head = match &order_by[i] {
+                    crate::core::OrderItem::Column { column, .. } => *column,
+                    _ => {
+                        return Err(QueryError::DistinctOnOrderByMismatch {
+                            distinct_on: cols.iter().map(|s| (*s).to_owned()).collect(),
+                            order_by: order_by_column_names(&order_by),
+                        });
+                    }
+                };
+                if head != *col {
+                    return Err(QueryError::DistinctOnOrderByMismatch {
+                        distinct_on: cols.iter().map(|s| (*s).to_owned()).collect(),
+                        order_by: order_by_column_names(&order_by),
+                    });
+                }
+            }
+        }
         Ok(SelectQuery {
             model,
             where_clause,
@@ -749,6 +833,7 @@ impl<T: Model> QuerySet<T> {
             lock_mode: self.lock_mode,
             compound: self.compound,
             projection: None,
+            distinct: self.distinct,
         })
     }
 
@@ -1049,6 +1134,21 @@ impl<T: Model> UpdateBuilder<T> {
 /// the field name against the model schema; `Expr` variants pass
 /// through verbatim (the writer surfaces DB-side errors for typos
 /// inside expressions, matching the existing `set_expr` posture).
+/// Render the column-only view of an `order_by` list for error
+/// reporting (`DistinctOnOrderByMismatch`). `Expr` / `Random` entries
+/// render as `<expr>` / `RANDOM` so the error message still locates
+/// where the mismatch begins.
+fn order_by_column_names(order_by: &[crate::core::OrderItem]) -> Vec<String> {
+    order_by
+        .iter()
+        .map(|item| match item {
+            crate::core::OrderItem::Column { column, .. } => (*column).to_owned(),
+            crate::core::OrderItem::Expr { .. } => "<expr>".to_owned(),
+            crate::core::OrderItem::Random => "RANDOM".to_owned(),
+        })
+        .collect()
+}
+
 fn lower_order_items(
     model: &'static ModelSchema,
     items: Vec<PendingOrderItem>,

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -858,6 +858,7 @@ mod tests {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert_eq!(
@@ -886,6 +887,7 @@ mod tests {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("LOWER(`name`) NOT LIKE LOWER(?)"));
@@ -910,6 +912,7 @@ mod tests {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("NOT (`email` <=> ?)"));
@@ -934,6 +937,7 @@ mod tests {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         // No outer NOT; bare null-safe equality.
@@ -960,6 +964,7 @@ mod tests {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("JSON_CONTAINS(`meta`, ?)"));
@@ -985,6 +990,7 @@ mod tests {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         // Argument order is swapped vs JSON_CONTAINS — value first.
@@ -1010,6 +1016,7 @@ mod tests {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -1039,6 +1046,7 @@ mod tests {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -1069,6 +1077,7 @@ mod tests {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -1157,6 +1166,7 @@ mod tests {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert_eq!(

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -664,6 +664,7 @@ mod tests {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let stmt = Sqlite.compile_select(&q).unwrap();
         // SQLite emits ANSI-quoted identifiers and `?` placeholders.

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -182,6 +182,7 @@ fn write_compound_select(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), Sql
         lock_mode: None,
         compound: Vec::new(),
         projection: None,
+        distinct: None,
     };
     b.sql.push('(');
     write_select_inner(b, &head)?;
@@ -218,10 +219,164 @@ fn write_compound_select(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), Sql
     Ok(())
 }
 
+/// MySQL / SQLite portable fallback for PG's `SELECT DISTINCT ON (cols)`.
+/// Wraps the original SELECT in a subquery that adds
+/// `ROW_NUMBER() OVER (PARTITION BY cols ORDER BY <user_order>) AS __rn`
+/// and selects the outer rows where `__rn = 1`. The user-specified
+/// `ORDER BY` drives both the per-partition row pick (inside the
+/// `OVER (...)`) and the outer row order. Issue #264 / T1.2.
+///
+/// Layout:
+/// ```text
+/// SELECT <orig_cols> FROM (
+///   SELECT <orig_cols>,
+///          ROW_NUMBER() OVER (PARTITION BY <cols> ORDER BY <order>) AS __rn
+///   FROM <table> [JOIN ...] WHERE <where>
+/// ) sub
+/// WHERE __rn = 1
+/// [ORDER BY <order>] [LIMIT N] [OFFSET M]
+/// ```
+fn write_distinct_on_via_window(
+    b: &mut Sql<'_>,
+    query: &SelectQuery,
+    distinct_cols: &[&'static str],
+) -> Result<(), SqlError> {
+    // v1 limitation: the window-function rewrite doesn't yet handle
+    // joins (`.select_related` / `.join`). Tracked as a follow-up;
+    // surface a clear error so users on MySQL/SQLite know the gap
+    // rather than seeing wrong-shape SQL.
+    if !query.joins.is_empty() {
+        return Err(SqlError::OpNotSupportedInDialect {
+            op: "DISTINCT ON combined with joins (workaround: pre-collapse \
+                 with a subquery, or run on Postgres which supports DISTINCT \
+                 ON natively)",
+            dialect: b.d.name(),
+        });
+    }
+
+    // ---------- Outer SELECT — projection columns only (no __rn). ----------
+    b.sql.push_str("SELECT ");
+    let mut first_col = true;
+    if let Some(cols) = query.projection.as_ref() {
+        for col in cols {
+            if !first_col {
+                b.sql.push_str(", ");
+            }
+            first_col = false;
+            b.write_ident(col);
+        }
+    } else {
+        for field in query.model.scalar_fields() {
+            if !first_col {
+                b.sql.push_str(", ");
+            }
+            first_col = false;
+            b.write_ident(field.column);
+        }
+    }
+    b.sql.push_str(" FROM (");
+
+    // ---------- Inner SELECT — original projection + __rn. ----------
+    b.sql.push_str("SELECT ");
+    let mut inner_first = true;
+    if let Some(cols) = query.projection.as_ref() {
+        for col in cols {
+            if !inner_first {
+                b.sql.push_str(", ");
+            }
+            inner_first = false;
+            b.write_ident(col);
+        }
+    } else {
+        for field in query.model.scalar_fields() {
+            if !inner_first {
+                b.sql.push_str(", ");
+            }
+            inner_first = false;
+            b.write_ident(field.column);
+        }
+    }
+    // ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...) AS __rn
+    b.sql.push_str(", ROW_NUMBER() OVER (PARTITION BY ");
+    for (i, col) in distinct_cols.iter().enumerate() {
+        if i > 0 {
+            b.sql.push_str(", ");
+        }
+        b.write_ident(col);
+    }
+    if !query.order_by.is_empty() {
+        b.sql.push_str(" ORDER BY ");
+        for (i, item) in query.order_by.iter().enumerate() {
+            if i > 0 {
+                b.sql.push_str(", ");
+            }
+            match item {
+                crate::core::OrderItem::Column { column, desc, .. } => {
+                    b.write_ident(column);
+                    if *desc {
+                        b.sql.push_str(" DESC");
+                    }
+                }
+                crate::core::OrderItem::Expr { expr, desc, .. } => {
+                    write_expr(b, expr, None)?;
+                    if *desc {
+                        b.sql.push_str(" DESC");
+                    }
+                }
+                crate::core::OrderItem::Random => {
+                    b.sql.push_str(if b.d.name() == "mysql" {
+                        "RAND()"
+                    } else {
+                        "RANDOM()"
+                    });
+                }
+            }
+        }
+    }
+    b.sql.push_str(") AS __rn FROM ");
+    b.write_ident(query.model.table);
+    write_where(b, &query.where_clause, Some(query.model))?;
+
+    b.sql.push_str(") sub WHERE sub.__rn = 1");
+
+    // Outer ORDER BY / LIMIT / OFFSET — applied to the survivors.
+    write_order_limit_offset(b, &query.order_by, query.limit, query.offset, None)?;
+
+    Ok(())
+}
+
 fn write_select_inner(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlError> {
+    // Issue #264 / T1.2 — `.distinct_on(cols)` lowers natively on PG
+    // (`SELECT DISTINCT ON (...)`); on MySQL / SQLite the writer
+    // wraps the query in a ROW_NUMBER() OVER (PARTITION BY ...)
+    // subquery with an outer `WHERE __rn = 1`. The wrap path returns
+    // early because it owns the whole SQL emission.
+    if let Some(crate::core::DistinctMode::On(cols)) = &query.distinct {
+        if b.d.name() != "postgres" {
+            return write_distinct_on_via_window(b, query, cols);
+        }
+    }
     let qualify = !query.joins.is_empty();
 
     b.sql.push_str("SELECT ");
+    // PG native DISTINCT / DISTINCT ON. `.distinct()` (DistinctMode::All)
+    // emits on every dialect uniformly.
+    if let Some(distinct) = &query.distinct {
+        match distinct {
+            crate::core::DistinctMode::All => b.sql.push_str("DISTINCT "),
+            crate::core::DistinctMode::On(cols) => {
+                // Reached only on PG (non-PG returned early above).
+                b.sql.push_str("DISTINCT ON (");
+                for (i, col) in cols.iter().enumerate() {
+                    if i > 0 {
+                        b.sql.push_str(", ");
+                    }
+                    b.write_ident(col);
+                }
+                b.sql.push_str(") ");
+            }
+        }
+    }
     let mut first_col = true;
     if let Some(cols) = query.projection.as_ref() {
         // Pure projection (issue #22 — `.values_dict()` /

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -583,6 +583,7 @@ async fn handle_list(
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     let count_q = crate::core::CountQuery {
         model: state.vs.schema,
@@ -833,6 +834,7 @@ async fn handle_detail(
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
     let object = match select_one_row_as_json(&state.pool, &select_q, &fields).await {
@@ -962,6 +964,7 @@ async fn handle_delete_confirm(
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
     let object = match select_one_row_as_json(&state.pool, &select_q, &fields).await {
@@ -1798,6 +1801,7 @@ async fn handle_update_get(
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     let scalars: Vec<&'static crate::core::FieldSchema> = state.schema.scalar_fields().collect();
     let row_json = match select_one_row_as_json(&state.pool, &select_q, &scalars).await {
@@ -2657,6 +2661,7 @@ fn build_fk_display_query(fk: &FkLookup) -> SelectQuery {
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     }
 }
 
@@ -2824,6 +2829,7 @@ async fn fetch_pks_as_objects_pool(
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     let fields: Vec<&'static crate::core::FieldSchema> = schema.scalar_fields().collect();
     let rows = select_rows_as_json(pool, &q, &fields)
@@ -3297,6 +3303,7 @@ mod tenant {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let count_q = crate::core::CountQuery {
             model: state.vs.schema,
@@ -3486,6 +3493,7 @@ mod tenant {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
         let object = match crate::sql::select_one_row_as_json(t.pool(), &select_q, &fields).await {
@@ -3534,6 +3542,7 @@ mod tenant {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let fields = resolved_fields(state.vs.schema, state.vs.fields.as_deref());
         let object = match crate::sql::select_one_row_as_json(t.pool(), &select_q, &fields).await {
@@ -3683,6 +3692,7 @@ mod tenant {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let scalars: Vec<&'static crate::core::FieldSchema> =
             state.schema.scalar_fields().collect();

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -911,6 +911,7 @@ async fn handle_list(
                 lock_mode: None,
                 compound: vec![],
                 projection: None,
+                distinct: None,
             };
             let count_q = CountQuery {
                 model: state.vs.schema,
@@ -1042,6 +1043,7 @@ async fn handle_list_cursor(
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     let rows = match acq.select_rows_as_json(&select_q, &fields).await {
         Ok(r) => r,
@@ -1134,6 +1136,7 @@ async fn handle_retrieve(
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
 
     let fields = state.effective_fields();
@@ -1372,6 +1375,7 @@ async fn fetch_by_pk(
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     let _ = state;
     acq.select_one_as_json(&select_q, fields)

--- a/crates/rustango/tests/distinct_emission.rs
+++ b/crates/rustango/tests/distinct_emission.rs
@@ -1,0 +1,175 @@
+//! `.distinct()` / `.distinct_on(*fields)` — closes #264 / T1.2.
+//!
+//! Pins per-dialect SQL emission for:
+//!   1. `.distinct()` → `SELECT DISTINCT ...` (uniform on PG / MySQL / SQLite).
+//!   2. `.distinct_on(cols)` → `SELECT DISTINCT ON (cols) ...` on PG; portable
+//!      `ROW_NUMBER() OVER (PARTITION BY cols ORDER BY <order>) AS __rn`
+//!      subquery wrapper on MySQL / SQLite with outer `WHERE __rn = 1`.
+//!   3. `.distinct_on` requires the keys at the head of `.order_by(...)`
+//!      (Django parity — without the order, "first row per group" is
+//!      non-deterministic).
+
+use rustango::query::QuerySet;
+use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
+
+#[derive(rustango::Model, Debug, Clone)]
+#[rustango(table = "distinct_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 200)]
+    title: String,
+    author_id: i64,
+    created: chrono::DateTime<chrono::Utc>,
+}
+
+// ---------- .distinct() — uniform syntax ----------
+
+#[test]
+fn plain_distinct_pg() {
+    let qs = QuerySet::<Post>::default().distinct();
+    let sql = Postgres.compile_select(&qs.compile().unwrap()).unwrap().sql;
+    assert!(sql.starts_with("SELECT DISTINCT "), "got: {sql}");
+}
+
+#[test]
+fn plain_distinct_mysql() {
+    let qs = QuerySet::<Post>::default().distinct();
+    let sql = MySql.compile_select(&qs.compile().unwrap()).unwrap().sql;
+    assert!(sql.starts_with("SELECT DISTINCT "), "got: {sql}");
+}
+
+#[test]
+fn plain_distinct_sqlite() {
+    let qs = QuerySet::<Post>::default().distinct();
+    let sql = Sqlite.compile_select(&qs.compile().unwrap()).unwrap().sql;
+    assert!(sql.starts_with("SELECT DISTINCT "), "got: {sql}");
+}
+
+// ---------- .distinct_on(cols) — PG native ----------
+
+#[test]
+fn distinct_on_pg_emits_native_syntax() {
+    let qs = QuerySet::<Post>::default()
+        .distinct_on(&["author_id"])
+        .order_by(&[("author_id", false), ("created", true)]);
+    let sql = Postgres.compile_select(&qs.compile().unwrap()).unwrap().sql;
+    assert!(
+        sql.contains(r#"DISTINCT ON ("author_id")"#),
+        "PG should emit DISTINCT ON: {sql}"
+    );
+    assert!(
+        sql.contains(r#"ORDER BY "author_id", "created" DESC"#),
+        "outer ORDER BY preserved: {sql}"
+    );
+}
+
+// ---------- .distinct_on(cols) — portable fallback ----------
+
+#[test]
+fn distinct_on_mysql_uses_row_number_subquery() {
+    let qs = QuerySet::<Post>::default()
+        .distinct_on(&["author_id"])
+        .order_by(&[("author_id", false), ("created", true)]);
+    let sql = MySql.compile_select(&qs.compile().unwrap()).unwrap().sql;
+    // Outer SELECT only over projection columns.
+    assert!(
+        sql.starts_with("SELECT `id`, `title`, `author_id`, `created` FROM ("),
+        "MySQL fallback should wrap in subquery: {sql}"
+    );
+    // Inner: ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...).
+    assert!(
+        sql.contains("ROW_NUMBER() OVER (PARTITION BY `author_id` ORDER BY `author_id`, `created` DESC) AS __rn"),
+        "MySQL fallback should emit ROW_NUMBER window: {sql}"
+    );
+    assert!(
+        sql.contains(") sub WHERE sub.__rn = 1"),
+        "MySQL fallback should filter __rn=1: {sql}"
+    );
+}
+
+#[test]
+fn distinct_on_sqlite_uses_row_number_subquery() {
+    let qs = QuerySet::<Post>::default()
+        .distinct_on(&["author_id"])
+        .order_by(&[("author_id", false), ("created", true)]);
+    let sql = Sqlite.compile_select(&qs.compile().unwrap()).unwrap().sql;
+    assert!(
+        sql.contains(
+            r#"ROW_NUMBER() OVER (PARTITION BY "author_id" ORDER BY "author_id", "created" DESC) AS __rn"#
+        ),
+        "SQLite fallback should emit ROW_NUMBER window: {sql}"
+    );
+    assert!(
+        sql.contains(r#") sub WHERE sub.__rn = 1"#),
+        "SQLite fallback should filter __rn=1: {sql}"
+    );
+}
+
+// ---------- Order-by validation ----------
+
+#[test]
+fn distinct_on_requires_keys_at_head_of_order_by() {
+    let qs = QuerySet::<Post>::default()
+        .distinct_on(&["author_id"])
+        .order_by(&[("created", true)]);
+    let err = qs.compile().unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("DistinctOn") || msg.contains("distinct_on") || msg.contains("order_by"),
+        "expected DistinctOnOrderByMismatch error, got: {err:?}"
+    );
+}
+
+#[test]
+fn distinct_on_empty_columns_is_rejected() {
+    let qs = QuerySet::<Post>::default()
+        .distinct_on(&[])
+        .order_by(&[("id", false)]);
+    let err = qs.compile().unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("at least one column"),
+        "expected DistinctOnEmpty error, got: {err:?}"
+    );
+}
+
+#[test]
+fn distinct_on_unknown_column_is_rejected() {
+    let qs = QuerySet::<Post>::default()
+        .distinct_on(&["no_such_field"])
+        .order_by(&[("no_such_field", false)]);
+    let err = qs.compile().unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("no_such_field") || msg.contains("UnknownField"),
+        "expected UnknownField error, got: {err:?}"
+    );
+}
+
+// ---------- Tri-dialect: same query, three correct shapes ----------
+
+#[test]
+fn same_query_produces_correct_per_dialect_sql() {
+    let make_qs = || {
+        QuerySet::<Post>::default()
+            .distinct_on(&["author_id"])
+            .order_by(&[("author_id", false), ("created", true)])
+    };
+    let pg = Postgres
+        .compile_select(&make_qs().compile().unwrap())
+        .unwrap()
+        .sql;
+    let my = MySql
+        .compile_select(&make_qs().compile().unwrap())
+        .unwrap()
+        .sql;
+    let lite = Sqlite
+        .compile_select(&make_qs().compile().unwrap())
+        .unwrap()
+        .sql;
+    assert!(pg.contains("DISTINCT ON"), "PG native: {pg}");
+    assert!(my.contains("ROW_NUMBER()"), "MySQL fallback: {my}");
+    assert!(lite.contains("ROW_NUMBER()"), "SQLite fallback: {lite}");
+}

--- a/crates/rustango/tests/mysql_from_row.rs
+++ b/crates/rustango/tests/mysql_from_row.rs
@@ -227,6 +227,7 @@ fn select_rows_pool_with_related_is_callable() {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         };
         let _fut: _ = rustango::sql::select_rows_pool_with_related::<User>(pool, &q);
     }

--- a/crates/rustango/tests/q_xor_emission.rs
+++ b/crates/rustango/tests/q_xor_emission.rs
@@ -33,6 +33,7 @@ fn select(where_clause: WhereExpr) -> SelectQuery {
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     }
 }
 

--- a/crates/rustango/tests/row_to_json_pool_sqlite_live.rs
+++ b/crates/rustango/tests/row_to_json_pool_sqlite_live.rs
@@ -82,6 +82,7 @@ async fn select_rows_as_json_pool_decodes_sqlite_rows() {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         },
         &fields,
     )
@@ -120,6 +121,7 @@ async fn select_one_row_as_json_pool_returns_none_for_miss() {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         },
         &fields,
     )
@@ -160,6 +162,7 @@ async fn select_one_row_as_json_pool_returns_decoded_row_for_hit() {
             lock_mode: None,
             compound: vec![],
             projection: None,
+            distinct: None,
         },
         &fields,
     )

--- a/crates/rustango/tests/sql.rs
+++ b/crates/rustango/tests/sql.rs
@@ -596,6 +596,7 @@ fn empty_select() -> SelectQuery {
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     }
 }
 
@@ -816,6 +817,7 @@ fn empty_post_select() -> SelectQuery {
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     }
 }
 

--- a/crates/rustango/tests/where_expr_live.rs
+++ b/crates/rustango/tests/where_expr_live.rs
@@ -193,6 +193,7 @@ async fn empty_or_branch_returns_named_writer_error() {
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     let err = Postgres.compile_select(&q).unwrap_err();
     assert!(matches!(err, SqlError::EmptyOrBranch));
@@ -213,6 +214,7 @@ async fn empty_or_branch_returns_named_writer_error() {
         lock_mode: None,
         compound: vec![],
         projection: None,
+        distinct: None,
     };
     rustango::sql::select_rows(&pool, &q2).await.unwrap();
 }


### PR DESCRIPTION
## Summary

Closes #264 (T1.2 — seventh ticket in the Tier 1 batch [#273](https://github.com/ujeenet/rustango/issues/273)).

Adds Django-shape DISTINCT to `QuerySet`. Two forms:

```rust
qs.distinct()                            // SELECT DISTINCT ...

qs.distinct_on(&[\"author_id\"])           // PG: SELECT DISTINCT ON (...)
  .order_by(&[(\"author_id\", false),      // MySQL/SQLite: portable fallback
              (\"created\", true)])         //   via ROW_NUMBER() subquery
```

The \"latest per group\" report pattern — latest comment per post, latest event per user — is the canonical use case. Today users either drop to `raw_query_pool` or denormalize a `last_*_id` cache column.

## Per-backend behavior

| Backend | `.distinct()` | `.distinct_on(cols)` |
|---------|---------------|----------------------|
| **Postgres** | `SELECT DISTINCT ...` | **Native** `SELECT DISTINCT ON (cols) ...` |
| **MySQL** | `SELECT DISTINCT ...` | Portable fallback: subquery + `ROW_NUMBER() OVER (PARTITION BY cols ORDER BY <user_order>) AS __rn` with outer `WHERE __rn = 1` |
| **SQLite** | `SELECT DISTINCT ...` | Same portable fallback as MySQL |

## Acceptance ✅

- [x] `QuerySet::distinct()` (no args) → emit `SELECT DISTINCT` (uniform on all three dialects).
- [x] `QuerySet::distinct_on(&[col1, col2])` → emit `DISTINCT ON (col1, col2)` on PG; lower to `ROW_NUMBER() OVER (PARTITION BY ... ORDER BY <user_order>) AS __rn` subquery wrapper on MySQL/SQLite with outer `WHERE __rn = 1`.
- [x] Both forms participate in `ORDER BY` — `distinct_on` keys must appear first; compile-time check matching Django's runtime check (`QueryError::DistinctOnOrderByMismatch`).
- [x] Tests pin same query produces correct SQL on all three backends.
- [x] Empty `distinct_on` cols and unknown column rejected at `.compile()`.

## v1 limitation (documented)

`.distinct_on()` combined with `.select_related()` / `.join()` is not yet supported on MySQL/SQLite — the window-fn rewrite would need to flow join columns through the subquery wrapper. The writer surfaces `SqlError::OpNotSupportedInDialect` with a clear message. PG users get the native path with joins working transparently. Tracked as a follow-up.

## Tri-dialect verification ✅

- `cargo build --no-default-features --features sqlite,tenancy` ✓
- `cargo test --workspace --all-features --no-run` ✓
- 10/10 tests pass in `tests/distinct_emission.rs`

## IR change

New `SelectQuery.distinct: Option<DistinctMode>` field where `DistinctMode::All | On(Vec<&'static str>)`. The ~20 ad-hoc `SelectQuery { ... }` construction sites across `src/` + `tests/` are all patched to include `distinct: None,` as the default.

## Extract-surface impact

Pure ORM work in `core/`, `query/`, `sql/writers.rs`. No tenancy/admin deps.