### PR TITLE
feat: bulk_upsert_pool() / bulk_insert_or_ignore_pool() (closes #267)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,7 @@ jobs:
             --features sqlite,tenancy,admin,jobs-postgres,media,passwords,serializer \
             --test admin_sqlite_live \
             --test audit_pool_sqlite_live \
+            --test bulk_upsert_sqlite_live \
             --test count_distinct_sqlite_live \
             --test database_pools_sqlite_file_live \
             --test database_pools_sqlite_live \
@@ -204,6 +205,7 @@ jobs:
       - run: cargo test -p rustango --features mysql,jobs-postgres --test jobs_mysql_live
       - run: cargo test -p rustango --features mysql --test mysql_live
       - run: cargo test -p rustango --features mysql --test explain_pool_mysql_live
+      - run: cargo test -p rustango --features mysql --test bulk_upsert_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy --test tenancy_manage_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy --test permissions_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy --test database_pools_mysql_live

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -3726,6 +3726,126 @@ fn inherent_impl_tokens(
         }
     };
 
+    // Tri-dialect `bulk_upsert_pool` — issue #267 / T1.5. Always emitted
+    // (no postgres-feature gate); routes through the existing
+    // `bulk_insert_pool` + per-dialect conflict writer.
+    //
+    // Auto<T> PKs are required to be `Auto::Unset` for every row so the
+    // sequence picks the PK for fresh inserts; the UPDATE branch never
+    // touches the Auto column.
+    let bulk_upsert_pool_method = {
+        // Pick the "no Auto" columns when the model has Auto fields,
+        // else every column.
+        let (upsert_cols, upsert_pushes): (Vec<_>, Vec<_>) = if fields.has_auto {
+            (
+                fields.bulk_columns_no_auto.clone(),
+                fields.bulk_pushes_no_auto.clone(),
+            )
+        } else {
+            (
+                fields.bulk_columns_all.clone(),
+                fields.bulk_pushes_all.clone(),
+            )
+        };
+        quote! {
+            /// Tri-dialect `bulk_create(update_conflicts=True)` — Django's
+            /// canonical "import a batch idempotently" shape. Issue #267
+            /// / T1.5.
+            ///
+            /// Per-row values are extracted and lowered into a
+            /// [`::rustango::core::BulkInsertQuery`] with
+            /// `on_conflict = DoUpdate { target, update_columns }`. The
+            /// writer dispatches per-dialect:
+            /// * Postgres / SQLite: `INSERT … ON CONFLICT (target) DO UPDATE SET col = EXCLUDED.col`
+            /// * MySQL: `INSERT … ON DUPLICATE KEY UPDATE col = VALUES(col)` (target ignored — MySQL matches every UNIQUE index)
+            ///
+            /// `target` names the column(s) whose unique constraint
+            /// defines the conflict (typically a `unique` or
+            /// `unique_together` natural-key column, NOT the `Auto<T>`
+            /// PK). `update_cols` names the columns to overwrite on
+            /// conflict — every other column is left untouched on the
+            /// existing row.
+            ///
+            /// Auto-PK rows must all have `Auto::Unset` (the sequence
+            /// picks the PK on insert; the update path never touches
+            /// the Auto column). Auto-set rows trigger a hard error.
+            /// Empty slice is a no-op.
+            ///
+            /// # Errors
+            /// Returns [`::rustango::sql::ExecError`] for validation,
+            /// SQL-writing, or driver failures.
+            pub async fn bulk_upsert_pool(
+                rows: &[Self],
+                target: &[&'static str],
+                update_cols: &[&'static str],
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<(), ::rustango::sql::ExecError> {
+                if rows.is_empty() {
+                    return ::core::result::Result::Ok(());
+                }
+                let mut _all_rows: ::std::vec::Vec<
+                    ::std::vec::Vec<::rustango::core::SqlValue>,
+                > = ::std::vec::Vec::with_capacity(rows.len());
+                for _row in rows.iter() {
+                    let mut _row_vals: ::std::vec::Vec<::rustango::core::SqlValue> =
+                        ::std::vec::Vec::new();
+                    #( #upsert_pushes )*
+                    _all_rows.push(_row_vals);
+                }
+                let _query = ::rustango::core::BulkInsertQuery {
+                    model: <Self as ::rustango::core::Model>::SCHEMA,
+                    columns: ::std::vec![ #( #upsert_cols ),* ],
+                    rows: _all_rows,
+                    returning: ::std::vec::Vec::new(),
+                    on_conflict: ::core::option::Option::Some(
+                        ::rustango::core::ConflictClause::DoUpdate {
+                            target: target.to_vec(),
+                            update_columns: update_cols.to_vec(),
+                        }
+                    ),
+                };
+                ::rustango::sql::bulk_insert_pool(pool, &_query).await
+            }
+
+            /// Tri-dialect `bulk_create(ignore_conflicts=True)` — silently
+            /// skip rows that would violate a unique constraint. Issue
+            /// #267 / T1.5. Same per-dialect dispatch as
+            /// [`Self::bulk_upsert_pool`] but with `ON CONFLICT … DO
+            /// NOTHING` (Postgres / SQLite) / `ON DUPLICATE KEY UPDATE
+            /// <pivot> = <pivot>` (MySQL no-op write).
+            ///
+            /// # Errors
+            /// As [`Self::bulk_upsert_pool`].
+            pub async fn bulk_insert_or_ignore_pool(
+                rows: &[Self],
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<(), ::rustango::sql::ExecError> {
+                if rows.is_empty() {
+                    return ::core::result::Result::Ok(());
+                }
+                let mut _all_rows: ::std::vec::Vec<
+                    ::std::vec::Vec<::rustango::core::SqlValue>,
+                > = ::std::vec::Vec::with_capacity(rows.len());
+                for _row in rows.iter() {
+                    let mut _row_vals: ::std::vec::Vec<::rustango::core::SqlValue> =
+                        ::std::vec::Vec::new();
+                    #( #upsert_pushes )*
+                    _all_rows.push(_row_vals);
+                }
+                let _query = ::rustango::core::BulkInsertQuery {
+                    model: <Self as ::rustango::core::Model>::SCHEMA,
+                    columns: ::std::vec![ #( #upsert_cols ),* ],
+                    rows: _all_rows,
+                    returning: ::std::vec::Vec::new(),
+                    on_conflict: ::core::option::Option::Some(
+                        ::rustango::core::ConflictClause::DoNothing
+                    ),
+                };
+                ::rustango::sql::bulk_insert_pool(pool, &_query).await
+            }
+        }
+    };
+
     let pk_value_helper = primary_key.map(|(pk_ident, _)| {
         quote! {
             /// Hidden runtime accessor for the primary-key value as a
@@ -3888,6 +4008,8 @@ fn inherent_impl_tokens(
             #insert_method
 
             #bulk_insert_method
+
+            #bulk_upsert_pool_method
 
             #save_method
 

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -990,6 +990,42 @@ pub struct BulkInsertQuery {
 }
 
 impl BulkInsertQuery {
+    /// Chainable builder — Django's `bulk_create(update_conflicts=True,
+    /// unique_fields=..., update_fields=...)`. Sets the `on_conflict`
+    /// clause to `DoUpdate { target, update_columns }`. Issue #267 / T1.5.
+    ///
+    /// Per-dialect emission (handled by the writer):
+    /// * Postgres / SQLite (3.24+): `ON CONFLICT (target) DO UPDATE SET col = EXCLUDED.col`
+    /// * MySQL: `ON DUPLICATE KEY UPDATE col = VALUES(col)` — target is
+    ///   not emitted (MySQL matches on every UNIQUE index automatically).
+    #[must_use]
+    pub fn on_conflict_do_update(
+        mut self,
+        target: &[&'static str],
+        update_columns: &[&'static str],
+    ) -> Self {
+        self.on_conflict = Some(ConflictClause::DoUpdate {
+            target: target.to_vec(),
+            update_columns: update_columns.to_vec(),
+        });
+        self
+    }
+
+    /// Chainable builder — Django's `bulk_create(ignore_conflicts=True)`.
+    /// Sets the `on_conflict` clause to `DoNothing`. Issue #267 / T1.5.
+    ///
+    /// Per-dialect emission:
+    /// * Postgres / SQLite: `ON CONFLICT DO NOTHING`
+    /// * MySQL: `ON DUPLICATE KEY UPDATE <pivot> = <pivot>` — the
+    ///   no-op write trick.
+    #[must_use]
+    pub fn on_conflict_do_nothing(mut self) -> Self {
+        self.on_conflict = Some(ConflictClause::DoNothing);
+        self
+    }
+}
+
+impl BulkInsertQuery {
     /// Walk every `(column, value)` pair in every row and check it
     /// against the field's declared bounds.
     ///

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -487,12 +487,14 @@ impl Dialect for MySql {
                 target,
                 update_columns,
             } => {
-                if !target.is_empty() {
-                    return Err(SqlError::ConflictNotSupportedInDialect {
-                        shape: "DO UPDATE with target columns",
-                        dialect: self.name(),
-                    });
-                }
+                // MySQL has no conflict-target concept — `ON DUPLICATE
+                // KEY UPDATE` matches every UNIQUE index automatically.
+                // We accept a non-empty `target` for tri-dialect call-
+                // site uniformity (PG / SQLite need it) and silently
+                // ignore the value here. Issue #267 — pre-T1.5 this
+                // path errored; the bulk_upsert API now relies on the
+                // silent-ignore.
+                let _ = target;
                 if update_columns.is_empty() {
                     return Err(SqlError::EmptyUpdateSet);
                 }
@@ -819,9 +821,13 @@ mod tests {
     }
 
     #[test]
-    fn conflict_do_update_with_target_errors() {
+    fn conflict_do_update_with_target_silently_ignores_target() {
+        // Issue #267 / T1.5 — MySQL silently ignores the conflict
+        // target (it matches on every UNIQUE index automatically).
+        // Pre-T1.5 the writer errored; the bulk_upsert API needs
+        // the silent-ignore for tri-dialect call-site uniformity.
         let mut sql = String::new();
-        let err = MySql
+        MySql
             .write_conflict_clause(
                 &mut sql,
                 &ConflictClause::DoUpdate {
@@ -829,14 +835,8 @@ mod tests {
                     update_columns: vec!["a"],
                 },
             )
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            SqlError::ConflictNotSupportedInDialect {
-                dialect: "mysql",
-                ..
-            }
-        ));
+            .expect("MySQL should accept target and silently ignore it");
+        assert_eq!(sql, " ON DUPLICATE KEY UPDATE `a` = VALUES(`a`)");
     }
 
     #[test]

--- a/crates/rustango/tests/bulk_upsert_live.rs
+++ b/crates/rustango/tests/bulk_upsert_live.rs
@@ -1,0 +1,170 @@
+#![cfg(all(feature = "postgres", feature = "tenancy"))]
+//! Live PG regression for `Model::bulk_upsert_pool` — closes #267 / T1.5.
+//!
+//! Mirrors `bulk_upsert_sqlite_live.rs` + `bulk_upsert_mysql_live.rs`.
+//! Reads `DATABASE_URL`; skips when unset.
+//!
+//! Postgres syntax: `INSERT ... ON CONFLICT (target) DO UPDATE SET col
+//! = EXCLUDED.col`. The `target` argument names the column(s) whose
+//! uniqueness constraint defines the conflict.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "_bulk_upsert_pg_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 64, unique)]
+    pub slug: String,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub view_count: i64,
+}
+
+fn live_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pg = sqlx::PgPool::connect(&url).await.ok()?;
+    sqlx::query(r#"DROP TABLE IF EXISTS "_bulk_upsert_pg_post" CASCADE"#)
+        .execute(&pg)
+        .await
+        .ok()?;
+    sqlx::query(
+        r#"CREATE TABLE "_bulk_upsert_pg_post" (
+            "id"         BIGSERIAL   PRIMARY KEY,
+            "slug"       VARCHAR(64) NOT NULL UNIQUE,
+            "title"      VARCHAR(200) NOT NULL,
+            "view_count" BIGINT      NOT NULL
+        )"#,
+    )
+    .execute(&pg)
+    .await
+    .ok()?;
+    Some(Pool::Postgres(pg))
+}
+
+async fn fetch_one(pool: &Pool, slug: &str) -> (String, i64) {
+    let Pool::Postgres(p) = pool else {
+        unreachable!()
+    };
+    let row: (String, i64) = sqlx::query_as(
+        r#"SELECT "title", "view_count" FROM "_bulk_upsert_pg_post" WHERE "slug" = $1"#,
+    )
+    .bind(slug)
+    .fetch_one(p)
+    .await
+    .expect("fetch_one");
+    row
+}
+
+async fn count(pool: &Pool) -> i64 {
+    let Pool::Postgres(p) = pool else {
+        unreachable!()
+    };
+    let (c,): (i64,) = sqlx::query_as(r#"SELECT COUNT(*) FROM "_bulk_upsert_pg_post""#)
+        .fetch_one(p)
+        .await
+        .expect("count");
+    c
+}
+
+#[tokio::test]
+async fn pg_first_call_inserts_then_second_call_updates_listed_only() {
+    let _g = live_lock().lock().await;
+    let Some(p) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    Post::bulk_upsert_pool(
+        &[Post {
+            id: Auto::default(),
+            slug: "a".into(),
+            title: "Alpha".into(),
+            view_count: 10,
+        }],
+        &["slug"],
+        &["title", "view_count"],
+        &p,
+    )
+    .await
+    .expect("first upsert");
+    assert_eq!(count(&p).await, 1);
+
+    Post::bulk_upsert_pool(
+        &[Post {
+            id: Auto::default(),
+            slug: "a".into(),
+            title: "Alpha (revised)".into(),
+            view_count: 999,
+        }],
+        &["slug"],
+        &["title"], // view_count NOT in update_cols
+        &p,
+    )
+    .await
+    .expect("second upsert");
+
+    let (title, view_count) = fetch_one(&p, "a").await;
+    assert_eq!(title, "Alpha (revised)");
+    assert_eq!(
+        view_count, 10,
+        "view_count is not in update_cols — must stay 10"
+    );
+}
+
+#[tokio::test]
+async fn pg_bulk_insert_or_ignore_skips_conflicts() {
+    let _g = live_lock().lock().await;
+    let Some(p) = pool().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    Post::bulk_upsert_pool(
+        &[Post {
+            id: Auto::default(),
+            slug: "a".into(),
+            title: "Alpha".into(),
+            view_count: 10,
+        }],
+        &["slug"],
+        &["title"],
+        &p,
+    )
+    .await
+    .expect("seed");
+
+    Post::bulk_insert_or_ignore_pool(
+        &[
+            Post {
+                id: Auto::default(),
+                slug: "a".into(),
+                title: "OVERWRITTEN".into(),
+                view_count: 999,
+            },
+            Post {
+                id: Auto::default(),
+                slug: "b".into(),
+                title: "Beta".into(),
+                view_count: 2,
+            },
+        ],
+        &p,
+    )
+    .await
+    .expect("insert_or_ignore");
+
+    assert_eq!(count(&p).await, 2);
+    let (title, _) = fetch_one(&p, "a").await;
+    assert_eq!(title, "Alpha", "existing row stays untouched");
+}

--- a/crates/rustango/tests/bulk_upsert_mysql_live.rs
+++ b/crates/rustango/tests/bulk_upsert_mysql_live.rs
@@ -1,0 +1,174 @@
+#![cfg(feature = "mysql")]
+//! Live MySQL regression for `Model::bulk_upsert_pool` — closes #267 / T1.5.
+//!
+//! Mirrors `bulk_upsert_sqlite_live.rs`. Reads `MYSQL_TEST_URL`;
+//! skips when unset.
+//!
+//! MySQL's UPSERT syntax: `INSERT ... ON DUPLICATE KEY UPDATE col =
+//! VALUES(col)`. The `target` argument is accepted but ignored — MySQL
+//! matches on every UNIQUE index automatically.
+
+use std::sync::OnceLock;
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "bulk_upsert_mysql_post")]
+#[rustango(app = "bulk_upsert_mysql_live")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 64, unique)]
+    pub slug: String,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub view_count: i64,
+}
+
+fn serial_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+async fn mysql_pool() -> Option<Pool> {
+    let url = std::env::var("MYSQL_TEST_URL").ok()?;
+    let mp = sqlx::mysql::MySqlPoolOptions::new()
+        .max_connections(5)
+        .connect(&url)
+        .await
+        .ok()?;
+    sqlx::query("DROP TABLE IF EXISTS `bulk_upsert_mysql_post`")
+        .execute(&mp)
+        .await
+        .ok()?;
+    sqlx::query(
+        "CREATE TABLE `bulk_upsert_mysql_post` (
+            `id`         BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+            `slug`       VARCHAR(64) NOT NULL UNIQUE,
+            `title`      VARCHAR(200) NOT NULL,
+            `view_count` BIGINT NOT NULL
+        )",
+    )
+    .execute(&mp)
+    .await
+    .ok()?;
+    Some(Pool::Mysql(mp))
+}
+
+async fn fetch_one(pool: &Pool, slug: &str) -> (String, i64) {
+    let Pool::Mysql(p) = pool else { unreachable!() };
+    let row: (String, i64) = sqlx::query_as(
+        "SELECT `title`, `view_count` FROM `bulk_upsert_mysql_post` WHERE `slug` = ?",
+    )
+    .bind(slug)
+    .fetch_one(p)
+    .await
+    .expect("fetch_one");
+    row
+}
+
+async fn count(pool: &Pool) -> i64 {
+    let Pool::Mysql(p) = pool else { unreachable!() };
+    let (c,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM `bulk_upsert_mysql_post`")
+        .fetch_one(p)
+        .await
+        .expect("count");
+    c
+}
+
+#[tokio::test]
+async fn first_call_inserts_then_second_call_updates_listed_columns_only() {
+    let _g = serial_lock().lock().await;
+    let Some(p) = mysql_pool().await else {
+        eprintln!("skipping: MYSQL_TEST_URL not set");
+        return;
+    };
+
+    Post::bulk_upsert_pool(
+        &[Post {
+            id: Auto::default(),
+            slug: "a".into(),
+            title: "Alpha".into(),
+            view_count: 10,
+        }],
+        &["slug"],
+        &["title", "view_count"],
+        &p,
+    )
+    .await
+    .expect("first upsert");
+    assert_eq!(count(&p).await, 1);
+    assert_eq!(fetch_one(&p, "a").await, ("Alpha".into(), 10));
+
+    // Second call — title in update_cols, view_count NOT.
+    Post::bulk_upsert_pool(
+        &[Post {
+            id: Auto::default(),
+            slug: "a".into(),
+            title: "Alpha (revised)".into(),
+            view_count: 999,
+        }],
+        &["slug"],
+        &["title"],
+        &p,
+    )
+    .await
+    .expect("second upsert");
+
+    assert_eq!(count(&p).await, 1);
+    let (title, view_count) = fetch_one(&p, "a").await;
+    assert_eq!(title, "Alpha (revised)");
+    assert_eq!(
+        view_count, 10,
+        "view_count is not in update_cols — must stay 10"
+    );
+}
+
+#[tokio::test]
+async fn bulk_insert_or_ignore_skips_conflicts_on_mysql() {
+    let _g = serial_lock().lock().await;
+    let Some(p) = mysql_pool().await else {
+        eprintln!("skipping: MYSQL_TEST_URL not set");
+        return;
+    };
+
+    Post::bulk_upsert_pool(
+        &[Post {
+            id: Auto::default(),
+            slug: "a".into(),
+            title: "Alpha".into(),
+            view_count: 10,
+        }],
+        &["slug"],
+        &["title"],
+        &p,
+    )
+    .await
+    .expect("seed");
+
+    Post::bulk_insert_or_ignore_pool(
+        &[
+            Post {
+                id: Auto::default(),
+                slug: "a".into(),
+                title: "OVERWRITTEN".into(),
+                view_count: 999,
+            },
+            Post {
+                id: Auto::default(),
+                slug: "b".into(),
+                title: "Beta".into(),
+                view_count: 2,
+            },
+        ],
+        &p,
+    )
+    .await
+    .expect("insert_or_ignore");
+
+    assert_eq!(count(&p).await, 2);
+    let (title, _) = fetch_one(&p, "a").await;
+    assert_eq!(title, "Alpha", "existing row stays untouched");
+}

--- a/crates/rustango/tests/bulk_upsert_sqlite_live.rs
+++ b/crates/rustango/tests/bulk_upsert_sqlite_live.rs
@@ -1,0 +1,193 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite regression for `Model::bulk_upsert_pool` — closes
+//! #267 / T1.5.
+//!
+//! Pins the canonical "import a batch, idempotent re-run" pattern
+//! that's the top reason users escape to raw_query_pool on every
+//! other ORM stack:
+//!   1. First call → inserts all rows.
+//!   2. Second call with overlapping natural keys → updates listed
+//!      columns; non-listed columns stay untouched.
+//!   3. ON CONFLICT (slug) DO UPDATE on PG / SQLite; ON DUPLICATE KEY
+//!      UPDATE on MySQL. Same model code path on all three.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "bulk_upsert_post")]
+#[rustango(app = "bulk_upsert_sqlite_live")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 64, unique)]
+    pub slug: String,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub view_count: i64,
+}
+
+async fn pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE bulk_upsert_post (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            slug       TEXT NOT NULL UNIQUE,
+            title      TEXT NOT NULL,
+            view_count INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn fetch_one(pool: &Pool, slug: &str) -> (String, i64) {
+    #[allow(irrefutable_let_patterns)]
+    let Pool::Sqlite(p) = pool
+    else {
+        unreachable!()
+    };
+    let row: (String, i64) =
+        sqlx::query_as(r#"SELECT title, view_count FROM bulk_upsert_post WHERE slug = $1"#)
+            .bind(slug)
+            .fetch_one(p)
+            .await
+            .expect("fetch_one");
+    row
+}
+
+async fn count(pool: &Pool) -> i64 {
+    #[allow(irrefutable_let_patterns)]
+    let Pool::Sqlite(p) = pool
+    else {
+        unreachable!()
+    };
+    let (c,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM bulk_upsert_post")
+        .fetch_one(p)
+        .await
+        .expect("count");
+    c
+}
+
+#[tokio::test]
+async fn first_call_inserts_all_rows() {
+    let p = pool().await;
+    let rows = vec![
+        Post {
+            id: Auto::default(),
+            slug: "a".into(),
+            title: "Alpha".into(),
+            view_count: 1,
+        },
+        Post {
+            id: Auto::default(),
+            slug: "b".into(),
+            title: "Beta".into(),
+            view_count: 2,
+        },
+    ];
+    Post::bulk_upsert_pool(&rows, &["slug"], &["title", "view_count"], &p)
+        .await
+        .expect("upsert first call");
+    assert_eq!(count(&p).await, 2);
+    assert_eq!(fetch_one(&p, "a").await, ("Alpha".into(), 1));
+}
+
+#[tokio::test]
+async fn second_call_updates_listed_columns_only() {
+    let p = pool().await;
+    let initial = vec![Post {
+        id: Auto::default(),
+        slug: "a".into(),
+        title: "Alpha".into(),
+        view_count: 10,
+    }];
+    Post::bulk_upsert_pool(&initial, &["slug"], &["title", "view_count"], &p)
+        .await
+        .expect("first upsert");
+
+    // Second call with the same slug — but only `title` in the update
+    // list. The view_count column should remain 10 (NOT 999) because
+    // it's not in the update_cols set.
+    let updated = vec![Post {
+        id: Auto::default(),
+        slug: "a".into(),
+        title: "Alpha (revised)".into(),
+        view_count: 999,
+    }];
+    Post::bulk_upsert_pool(&updated, &["slug"], &["title"], &p)
+        .await
+        .expect("second upsert");
+
+    // Still exactly one row.
+    assert_eq!(count(&p).await, 1);
+    let (title, view_count) = fetch_one(&p, "a").await;
+    assert_eq!(title, "Alpha (revised)", "title should update");
+    assert_eq!(
+        view_count, 10,
+        "view_count is not in update_cols — must stay 10"
+    );
+}
+
+#[tokio::test]
+async fn bulk_insert_or_ignore_skips_conflicts() {
+    let p = pool().await;
+    Post::bulk_upsert_pool(
+        &[Post {
+            id: Auto::default(),
+            slug: "a".into(),
+            title: "Alpha".into(),
+            view_count: 10,
+        }],
+        &["slug"],
+        &["title"],
+        &p,
+    )
+    .await
+    .expect("seed");
+
+    // Try to insert the same slug + a new slug — only the new one
+    // should land; the existing 'a' row stays untouched.
+    Post::bulk_insert_or_ignore_pool(
+        &[
+            Post {
+                id: Auto::default(),
+                slug: "a".into(),
+                title: "OVERWRITTEN".into(),
+                view_count: 999,
+            },
+            Post {
+                id: Auto::default(),
+                slug: "b".into(),
+                title: "Beta".into(),
+                view_count: 2,
+            },
+        ],
+        &p,
+    )
+    .await
+    .expect("insert_or_ignore");
+
+    assert_eq!(count(&p).await, 2);
+    // 'a' was preserved, not overwritten.
+    let (title, view_count) = fetch_one(&p, "a").await;
+    assert_eq!(title, "Alpha", "existing row should NOT be overwritten");
+    assert_eq!(view_count, 10);
+}
+
+#[tokio::test]
+async fn empty_batch_is_a_noop() {
+    let p = pool().await;
+    Post::bulk_upsert_pool(&[], &["slug"], &["title"], &p)
+        .await
+        .expect("empty upsert");
+    Post::bulk_insert_or_ignore_pool(&[], &p)
+        .await
+        .expect("empty insert_or_ignore");
+    assert_eq!(count(&p).await, 0);
+}


### PR DESCRIPTION
## Summary

Closes #267 (T1.5 — eighth ticket in the Tier 1 batch [#273](https://github.com/ujeenet/rustango/issues/273)).

Adds Django's `bulk_create(update_conflicts=True, unique_fields=..., update_fields=...)` shape — tri-dialect, derive-emitted on every Model:

```rust
Post::bulk_upsert_pool(
    &rows,
    &[\"slug\"],                  // unique_fields / conflict target
    &[\"title\", \"view_count\"],   // columns to overwrite on conflict
    &pool,
).await?;

Post::bulk_insert_or_ignore_pool(&rows, &pool).await?;  // ON CONFLICT DO NOTHING
```

This is the **top reason users escape to `raw_query_pool`** — every webhook ingestion / periodic ETL / \"sync from external API\" needs idempotent re-runnable batches.

## Per-backend emission

| Backend | UPSERT syntax |
|---------|---------------|
| **Postgres** | `INSERT ... ON CONFLICT (target) DO UPDATE SET col = EXCLUDED.col` |
| **SQLite (3.24+)** | Same as PG syntax |
| **MySQL** | `INSERT ... ON DUPLICATE KEY UPDATE col = VALUES(col)` — `target` is ignored (MySQL matches on every UNIQUE index automatically) |

The writer dispatch for `ConflictClause::DoUpdate` / `DoNothing` was already in place; this PR wires it to the bulk path and adds the ergonomic builder + derive surface.

## Acceptance ✅

- [x] `BulkInsertQuery::on_conflict_do_update(target, update_cols)` chainable builder.
- [x] `BulkInsertQuery::on_conflict_do_nothing()` for dedup-insert case.
- [x] Macro-level convenience on every Model: `Post::bulk_upsert_pool(...)` and `Post::bulk_insert_or_ignore_pool(...)`.
- [x] Per-dialect dispatch via the existing `ConflictClause` writer machinery.
- [x] Tests pin same upsert against all three backends — second call updates `update_cols`, leaves non-listed columns untouched.

## Tri-dialect verification ✅

- `cargo build --no-default-features --features sqlite,tenancy` ✓
- `cargo test --workspace --all-features --no-run` ✓
- SQLite live: **4/4 pass** (insert-then-update, ignore-conflicts, update-listed-cols-only, empty-batch noop)
- PG live: **2/2 pass** locally
- MySQL live: covered by `tests/bulk_upsert_mysql_live.rs` (CI executes)

CI: `bulk_upsert_sqlite_live` added to `sqlite_live` `--test` list; `bulk_upsert_mysql_live` added to `mysql_live` run.

## Auto<T> PK constraint

Models with `Auto<T>` PKs require every row's Auto field to be `Unset` — the sequence picks the PK on insert; the update path never touches the Auto column. This matches the existing `bulk_insert`'s uniformity invariant.

## Extract-surface impact

Pure ORM work in `core/query.rs` + `rustango-macros/src/lib.rs`. No tenancy/admin deps. The new macro methods are always emitted (no postgres-feature gate); the underlying `bulk_insert_pool` was already tri-dialect.