### PR TITLE
feat: #[rustango(unique_when(...))] partial unique constraints (closes #265)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
             --test tenant_extractor_sqlite_live \
             --test tenant_pools_sqlite_live \
             --test tx_methods_sqlite_live \
+            --test unique_when_sqlite_live \
             --test viewset_sqlite_live
 
   # v0.41 MySQL parity — the marketing claim is tri-dialect end-to-end

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -763,6 +763,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
                     columns: vec![col_name],
                     unique: fa.index_unique,
                     method: fa.index_method,
+                    where_clause: None,
                 });
             }
         }
@@ -1704,12 +1705,17 @@ fn model_impl_tokens(
             "bloom" => quote!(::rustango::core::IndexMethod::Bloom),
             _ => quote!(::rustango::core::IndexMethod::BTree),
         };
+        let where_clause = match &idx.where_clause {
+            Some(s) => quote!(::core::option::Option::Some(#s)),
+            None => quote!(::core::option::Option::None),
+        };
         quote! {
             ::rustango::core::IndexSchema {
                 name: #name,
                 columns: &[ #(#cols),* ],
                 unique: #unique,
                 method: #method_variant,
+                where_clause: #where_clause,
             }
         }
     });
@@ -4231,6 +4237,10 @@ struct IndexAttr {
     /// the `USING` clause and the backend uses its own default
     /// (btree on every supported dialect).
     method: String,
+    /// Optional `WHERE <expr>` clause for partial indexes. Issue #265 /
+    /// T1.3. Set via `#[rustango(unique_when(columns = "...",
+    /// condition = "...", name = "..."))]`. `None` for plain indexes.
+    where_clause: Option<String>,
 }
 
 /// Parsed form of one `#[rustango(check(name = "…", expr = "…"))]` declaration.
@@ -4510,6 +4520,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     columns,
                     unique: true,
                     method: "btree".to_owned(),
+                    where_clause: None,
                 });
                 return Ok(());
             }
@@ -4525,6 +4536,65 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     columns,
                     unique: false,
                     method: "btree".to_owned(),
+                    where_clause: None,
+                });
+                return Ok(());
+            }
+            if meta.path.is_ident("unique_when") {
+                // Django 4.0+ `UniqueConstraint(condition=Q(...))` —
+                // partial unique index. Issue #265 / T1.3.
+                //
+                //   #[rustango(unique_when(
+                //       columns   = "email",
+                //       condition = "deleted_at IS NULL",
+                //       name      = "unique_active_email"
+                //   ))]
+                //
+                // → `CREATE UNIQUE INDEX <name> ON <table> (cols) WHERE <condition>`
+                // on PG / SQLite (both ship partial indexes natively).
+                // MySQL falls back to a plain UNIQUE index — the
+                // condition is lost; document the limitation in the
+                // generated migration.
+                let mut columns: Option<Vec<String>> = None;
+                let mut condition: Option<String> = None;
+                let mut name: Option<String> = None;
+                meta.parse_nested_meta(|inner| {
+                    if inner.path.is_ident("columns") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        columns = Some(split_field_list(&s.value()));
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("condition") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        condition = Some(s.value());
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("name") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        name = Some(s.value());
+                        return Ok(());
+                    }
+                    Err(inner.error(
+                        "unknown unique_when attribute (supported: \
+                         `columns = \"...\"`, `condition = \"...\"`, \
+                         `name = \"...\"`)",
+                    ))
+                })?;
+                let columns = columns.ok_or_else(|| {
+                    meta.error("`unique_when(...)` requires `columns = \"...\"`")
+                })?;
+                let condition = condition.ok_or_else(|| {
+                    meta.error("`unique_when(...)` requires `condition = \"...\"`")
+                })?;
+                if columns.is_empty() {
+                    return Err(meta.error("`unique_when(columns = \"\")` is empty"));
+                }
+                out.indexes.push(IndexAttr {
+                    name,
+                    columns,
+                    unique: true,
+                    method: "btree".to_owned(),
+                    where_clause: Some(condition),
                 });
                 return Ok(());
             }
@@ -4543,6 +4613,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     columns,
                     unique: false,
                     method: "btree".to_owned(),
+                    where_clause: None,
                 });
                 return Ok(());
             }

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -317,6 +317,16 @@ pub struct IndexSchema {
     /// specified. Selects the `USING <method>` clause emitted by
     /// the DDL writer. Issue #34.
     pub method: IndexMethod,
+    /// Optional `WHERE <expr>` clause for partial indexes — Django's
+    /// `UniqueConstraint(condition=Q(...))`. Issue #265 / T1.3.
+    /// `None` (default) emits a plain index. `Some(expr)` emits
+    /// `CREATE UNIQUE INDEX <name> ON <table> (cols) WHERE <expr>` on
+    /// PG / SQLite (both ship partial indexes natively); MySQL has no
+    /// native support and silently degrades to a plain UNIQUE index
+    /// with a doc-level warning (the SQL accepted; the partial filter
+    /// is ignored, so duplicates outside the partition would also be
+    /// rejected — document the limitation).
+    pub where_clause: Option<&'static str>,
 }
 
 /// Index access method — Postgres `CREATE INDEX … USING <method>`.

--- a/crates/rustango/src/migrate/diff.rs
+++ b/crates/rustango/src/migrate/diff.rs
@@ -120,6 +120,14 @@ pub enum SchemaChange {
         /// compatible.
         #[serde(default = "default_index_method_diff")]
         method: String,
+        /// Optional partial-index `WHERE` clause — Django
+        /// `UniqueConstraint(condition=Q(...))`. Issue #265 / T1.3.
+        /// `None` for plain indexes; `Some(expr)` emits
+        /// `CREATE UNIQUE INDEX ... WHERE <expr>` on PG / SQLite.
+        /// MySQL has no partial-index syntax — the writer drops the
+        /// WHERE clause with a doc-level warning.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        where_clause: Option<String>,
     },
     /// Drop an index by name.
     DropIndex {
@@ -288,6 +296,7 @@ pub fn detect_changes(prev: &SchemaSnapshot, current: &SchemaSnapshot) -> Vec<Sc
                 columns: idx.columns.clone(),
                 unique: idx.unique,
                 method: idx.method.clone(),
+                where_clause: idx.where_clause.clone(),
             });
         }
     }
@@ -311,6 +320,7 @@ pub fn detect_changes(prev: &SchemaSnapshot, current: &SchemaSnapshot) -> Vec<Sc
                 || prev_idx.unique != idx.unique
                 || prev_idx.table != idx.table
                 || prev_idx.method != idx.method
+                || prev_idx.where_clause != idx.where_clause
             {
                 changes.push(SchemaChange::DropIndex {
                     name: idx.name.clone(),
@@ -321,6 +331,7 @@ pub fn detect_changes(prev: &SchemaSnapshot, current: &SchemaSnapshot) -> Vec<Sc
                     columns: idx.columns.clone(),
                     unique: idx.unique,
                     method: idx.method.clone(),
+                    where_clause: idx.where_clause.clone(),
                 });
             }
         }
@@ -549,6 +560,7 @@ pub fn render_changes(
     let RenderedBatch {
         mut immediate,
         deferred_fks,
+        warnings: _,
     } = render_changes_split(changes, current)?;
     immediate.extend(deferred_fks);
     Ok(immediate)
@@ -570,6 +582,11 @@ pub struct RenderedBatch {
     /// for new tables in this batch. Run them after every other
     /// migration op has executed so the referenced tables exist.
     pub deferred_fks: Vec<String>,
+    /// Non-fatal advisories the writer surfaced during rendering —
+    /// e.g. "MySQL has no partial-index syntax; emitted plain UNIQUE
+    /// INDEX, add an application-level uniqueness check". Issue #265
+    /// / T1.3. Empty when there's nothing to flag.
+    pub warnings: Vec<String>,
 }
 
 /// Same as [`render_changes`] but keeps FK ALTER constraints in a
@@ -750,6 +767,7 @@ fn render_changes_split_inner(
                 columns,
                 unique,
                 method,
+                where_clause,
             } => {
                 let unique_kw = if *unique { "UNIQUE " } else { "" };
                 let if_not_exists = if dialect.supports_create_index_if_not_exists() {
@@ -767,8 +785,30 @@ fn render_changes_split_inner(
                 // don't support the method silently fall through to
                 // their default (btree); see `IndexMethod` docs.
                 let using = dialect.index_method_clause(method);
+                // Partial-index `WHERE <expr>` — issue #265 / T1.3.
+                // PG / SQLite ship native partial indexes; MySQL has
+                // no equivalent (the writer drops the clause + emits
+                // a warning so the rest of the migration still
+                // applies). The dialect controls inclusion.
+                let where_suffix = if let Some(expr) = where_clause {
+                    if dialect.supports_partial_index() {
+                        format!(" WHERE {expr}")
+                    } else {
+                        out.warnings.push(format!(
+                            "index {name:?} declares a partial WHERE \
+                             clause ({expr:?}); {} has no partial-index \
+                             syntax — emitting plain UNIQUE INDEX. Add \
+                             an application-level uniqueness check to \
+                             cover the partition.",
+                            dialect.name()
+                        ));
+                        String::new()
+                    }
+                } else {
+                    String::new()
+                };
                 out.immediate.push(format!(
-                    "CREATE {unique_kw}INDEX {if_not_exists}{} ON {}{} ({cols})",
+                    "CREATE {unique_kw}INDEX {if_not_exists}{} ON {}{} ({cols}){where_suffix}",
                     dialect.quote_ident(name),
                     dialect.quote_ident(table),
                     using,

--- a/crates/rustango/src/migrate/invert.rs
+++ b/crates/rustango/src/migrate/invert.rs
@@ -208,6 +208,7 @@ fn invert_one(op: &Operation, prev: &SchemaSnapshot) -> Result<Operation, Migrat
                 columns: idx.columns.clone(),
                 unique: idx.unique,
                 method: idx.method.clone(),
+                where_clause: idx.where_clause.clone(),
             }))
         }
         Operation::Schema(SchemaChange::CreateM2MTable {

--- a/crates/rustango/src/migrate/mod.rs
+++ b/crates/rustango/src/migrate/mod.rs
@@ -37,7 +37,10 @@ mod runner;
 pub mod scaffold;
 pub mod snapshot;
 
-pub use diff::{detect_changes, detect_unsupported_field_changes, render_changes, SchemaChange};
+pub use diff::{
+    detect_changes, detect_unsupported_field_changes, render_changes,
+    render_changes_split_with_dialect, RenderedBatch, SchemaChange,
+};
 pub use error::MigrateError;
 pub use file::{discover_migration_dirs, list_dirs, DataOp, Migration, MigrationScope, Operation};
 pub use invert::invert;

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -52,6 +52,12 @@ pub struct IndexSnapshot {
     /// regular btree).
     #[serde(default = "default_index_method")]
     pub method: String,
+    /// Optional partial-index `WHERE <expr>` clause — Django's
+    /// `UniqueConstraint(condition=Q(...))`. Issue #265 / T1.3.
+    /// `None` (default) emits a plain index. Older snapshots without
+    /// this key deserialize cleanly via `#[serde(default)]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub where_clause: Option<String>,
 }
 
 fn default_index_method() -> String {
@@ -462,6 +468,7 @@ fn collect_indexes<'a>(schemas: impl Iterator<Item = &'a ModelSchema>) -> Vec<In
                     columns: idx.columns.iter().map(|&c| c.to_owned()).collect(),
                     unique: idx.unique,
                     method: idx.method.as_str().to_owned(),
+                    where_clause: idx.where_clause.map(str::to_owned),
                 });
             }
         }

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -255,6 +255,16 @@ pub trait Dialect {
         None
     }
 
+    /// Whether `CREATE [UNIQUE] INDEX ... WHERE <expr>` partial-index
+    /// syntax is supported. PG and SQLite (3.8+) both ship it natively;
+    /// MySQL has no equivalent (the migration writer drops the WHERE
+    /// clause + emits a warning so the rest of the migration still
+    /// applies). Default `true`; MySQL overrides to `false`. Issue
+    /// #265 / T1.3.
+    fn supports_partial_index(&self) -> bool {
+        true
+    }
+
     /// Dialect-specific SQL type token for the rhs of `CAST(<expr> AS <ty>)`
     /// — distinct from [`Self::null_cast`] (which is PG-specific) and
     /// [`Self::column_type`] (DDL, which includes lengths like

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -231,6 +231,17 @@ impl Dialect for MySql {
         false
     }
 
+    /// MySQL has no `CREATE INDEX ... WHERE <expr>` syntax. Issue #265
+    /// / T1.3. The migration writer drops the WHERE clause + surfaces
+    /// a warning so a partial-unique declaration still creates the
+    /// underlying UNIQUE index (just without the partial filter).
+    /// Document the limitation; users requiring strict partial
+    /// uniqueness on MySQL should add an application-level check or
+    /// a CHECK constraint over a generated column.
+    fn supports_partial_index(&self) -> bool {
+        false
+    }
+
     /// MySQL has no `ON CONFLICT`. The semantic equivalent is
     /// `ON DUPLICATE KEY UPDATE <col> = <col>` — a no-op write
     /// against an existing row that satisfies MySQL's requirement

--- a/crates/rustango/tests/index_types_dsl.rs
+++ b/crates/rustango/tests/index_types_dsl.rs
@@ -62,6 +62,7 @@ fn index_schema_default_method_is_btree() {
         columns: &["foo"],
         unique: false,
         method: IndexMethod::default(),
+        where_clause: None,
     };
     assert_eq!(idx.method, IndexMethod::BTree);
 }

--- a/crates/rustango/tests/migrate_diff.rs
+++ b/crates/rustango/tests/migrate_diff.rs
@@ -729,6 +729,7 @@ fn snap_with_index(name: &str, columns: &[&str], unique: bool) -> SchemaSnapshot
             columns: columns.iter().map(|s| (*s).into()).collect(),
             unique,
             method: "btree".into(),
+            where_clause: None,
         }],
         ..Default::default()
     }

--- a/crates/rustango/tests/unique_when_emission.rs
+++ b/crates/rustango/tests/unique_when_emission.rs
@@ -1,0 +1,124 @@
+//! `#[rustango(unique_when(...))]` — partial unique index DDL emission.
+//! Closes #265 / T1.3.
+//!
+//! Pins:
+//!   1. The `unique_when` attribute parses + populates the IndexSchema
+//!      with the WHERE clause.
+//!   2. The migration writer emits `WHERE <expr>` on PG / SQLite.
+//!   3. MySQL silently drops the WHERE clause (no native partial-index
+//!      syntax) and surfaces a warning in the rendered batch.
+
+use rustango::core::Model as _;
+use rustango::migrate::{render_changes_split_with_dialect, SchemaChange, SchemaSnapshot};
+use rustango::sql::{MySql, Postgres, Sqlite};
+
+#[derive(rustango::Model, Debug, Clone)]
+#[rustango(table = "uw_user")]
+#[rustango(unique_when(
+    columns = "email",
+    condition = "deleted_at IS NULL",
+    name = "uw_unique_active_email"
+))]
+#[allow(dead_code)]
+pub struct User {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 200)]
+    email: String,
+    deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+fn unique_when_index() -> &'static rustango::core::IndexSchema {
+    User::SCHEMA
+        .indexes
+        .iter()
+        .find(|i| i.name == "uw_unique_active_email")
+        .expect("indexes registers unique_when")
+}
+
+fn create_index_change() -> SchemaChange {
+    let idx = unique_when_index();
+    SchemaChange::CreateIndex {
+        name: idx.name.to_owned(),
+        table: User::SCHEMA.table.to_owned(),
+        columns: idx.columns.iter().map(|&s| s.to_owned()).collect(),
+        unique: idx.unique,
+        method: idx.method.as_str().to_owned(),
+        where_clause: idx.where_clause.map(str::to_owned),
+    }
+}
+
+// ---------- Attribute parsing ----------
+
+#[test]
+fn attribute_populates_where_clause_on_schema() {
+    let idx = unique_when_index();
+    assert!(idx.unique, "unique_when must produce a UNIQUE index");
+    assert_eq!(idx.columns, &["email"]);
+    assert_eq!(idx.where_clause, Some("deleted_at IS NULL"));
+}
+
+// ---------- PG ----------
+
+#[test]
+fn pg_emits_where_clause_natively() {
+    let snap = SchemaSnapshot::default();
+    let batch =
+        render_changes_split_with_dialect(&[create_index_change()], &snap, &Postgres).unwrap();
+    assert_eq!(batch.warnings.len(), 0);
+    let sql = batch.immediate.join("\n");
+    assert!(
+        sql.contains(r#"CREATE UNIQUE INDEX"#),
+        "expected CREATE UNIQUE INDEX, got:\n{sql}"
+    );
+    assert!(
+        sql.contains("WHERE deleted_at IS NULL"),
+        "PG should emit WHERE clause natively, got:\n{sql}"
+    );
+}
+
+// ---------- SQLite ----------
+
+#[test]
+fn sqlite_emits_where_clause_natively() {
+    let snap = SchemaSnapshot::default();
+    let batch =
+        render_changes_split_with_dialect(&[create_index_change()], &snap, &Sqlite).unwrap();
+    assert_eq!(batch.warnings.len(), 0);
+    let sql = batch.immediate.join("\n");
+    assert!(
+        sql.contains("WHERE deleted_at IS NULL"),
+        "SQLite should emit WHERE clause natively, got:\n{sql}"
+    );
+}
+
+// ---------- MySQL ----------
+
+#[test]
+fn mysql_drops_where_clause_and_warns() {
+    let snap = SchemaSnapshot::default();
+    let batch = render_changes_split_with_dialect(&[create_index_change()], &snap, &MySql).unwrap();
+    let sql = batch.immediate.join("\n");
+    // MySQL has no partial index — the WHERE clause is dropped.
+    assert!(
+        !sql.contains("WHERE deleted_at IS NULL"),
+        "MySQL must NOT emit WHERE clause, got:\n{sql}"
+    );
+    // Still emits the UNIQUE INDEX (just without the partial filter).
+    assert!(
+        sql.contains("CREATE UNIQUE INDEX"),
+        "MySQL still emits UNIQUE INDEX, got:\n{sql}"
+    );
+    // Warning surfaced so the caller knows.
+    assert_eq!(
+        batch.warnings.len(),
+        1,
+        "expected one warning, got: {:?}",
+        batch.warnings
+    );
+    assert!(
+        batch.warnings[0].contains("partial"),
+        "warning should mention partial: {}",
+        batch.warnings[0]
+    );
+}

--- a/crates/rustango/tests/unique_when_sqlite_live.rs
+++ b/crates/rustango/tests/unique_when_sqlite_live.rs
@@ -1,0 +1,74 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite regression for `#[rustango(unique_when(...))]` —
+//! closes #265 / T1.3.
+//!
+//! Pins that the partial unique constraint:
+//!   1. Allows multiple rows where the condition is FALSE (e.g.
+//!      soft-deleted rows can all share an email).
+//!   2. Rejects a second row where the condition is TRUE (e.g. only
+//!      one active email per partition).
+
+use rustango::sql::sqlx;
+
+#[tokio::test]
+async fn partial_unique_index_blocks_active_duplicates_on_sqlite() {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+
+    // Materialize a schema with the partial unique index. We emit
+    // the DDL directly here rather than going through the migration
+    // runner; the emission tests (`tests/unique_when_emission.rs`)
+    // pin that the migration writer produces this same SQL.
+    sqlx::query(
+        "CREATE TABLE uw_live_user (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            email      TEXT NOT NULL,
+            deleted_at TEXT
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE UNIQUE INDEX uw_live_unique_active_email \
+         ON uw_live_user (email) WHERE deleted_at IS NULL",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+
+    // First active row: succeeds.
+    sqlx::query(r#"INSERT INTO uw_live_user (email, deleted_at) VALUES ('a@x', NULL)"#)
+        .execute(&p)
+        .await
+        .expect("first active insert");
+    // Soft-deleted row with the SAME email: succeeds (predicate FALSE).
+    sqlx::query(r#"INSERT INTO uw_live_user (email, deleted_at) VALUES ('a@x', '2026-01-01')"#)
+        .execute(&p)
+        .await
+        .expect("soft-deleted shares email");
+    // A second soft-deleted row with the same email: also succeeds.
+    sqlx::query(r#"INSERT INTO uw_live_user (email, deleted_at) VALUES ('a@x', '2026-02-01')"#)
+        .execute(&p)
+        .await
+        .expect("second soft-delete");
+
+    // Second ACTIVE row with the same email: REJECTED — the partition
+    // already has one active row.
+    let err = sqlx::query(r#"INSERT INTO uw_live_user (email, deleted_at) VALUES ('a@x', NULL)"#)
+        .execute(&p)
+        .await
+        .expect_err("partial unique must reject second active duplicate");
+    let msg = format!("{err}");
+    assert!(
+        msg.to_lowercase().contains("unique"),
+        "expected unique-constraint violation, got: {msg}"
+    );
+
+    // Different active email: succeeds.
+    sqlx::query(r#"INSERT INTO uw_live_user (email, deleted_at) VALUES ('b@x', NULL)"#)
+        .execute(&p)
+        .await
+        .expect("different active email");
+}


### PR DESCRIPTION
## Summary

Closes #265 (T1.3 — ninth ticket in the Tier 1 batch [#273](https://github.com/ujeenet/rustango/issues/273)).

Django 4.0+ ships `UniqueConstraint(fields=..., condition=Q(...))` for partial unique indexes — \"unique email per non-deleted row\", \"unique slug per tenant\", \"unique active subscription per user\". Universal multi-tenant pattern.

```rust
#[derive(Model)]
#[rustango(unique_when(
    columns   = \"email\",
    condition = \"deleted_at IS NULL\",
    name      = \"unique_active_email\",
))]
pub struct User { ... }
```

Lowers per-dialect:

| Backend | Emission |
|---------|----------|
| **Postgres** | `CREATE UNIQUE INDEX <name> ON <table> (cols) WHERE <expr>` — native |
| **SQLite (3.8+)** | Same native syntax as PG |
| **MySQL** | `CREATE UNIQUE INDEX <name> ON <table> (cols)` — partial filter **dropped** (no native syntax); `RenderedBatch.warnings` surfaces a one-line advisory |

## Acceptance ✅

- [x] New container attribute `#[rustango(unique_when(columns = \"...\", condition = \"...\", name = \"...\"))]`. Multiple per model allowed.
- [x] `IndexSchema` gains `where_clause: Option<&'static str>`. `IndexSnapshot` gains matching field with `#[serde(default)]` for back-compat.
- [x] `SchemaChange::CreateIndex` carries the WHERE clause; the DDL emitter renders it per dialect.
- [x] PG / SQLite: emit `CREATE UNIQUE INDEX <name> ON <table> (cols) WHERE <expr>`.
- [x] MySQL: drop the WHERE clause, emit `RenderedBatch.warnings` advisory pointing at app-level uniqueness check / generated-column workaround.
- [x] Tests pin the constraint actually rejects duplicates within the partition and accepts duplicates outside it.

## Tri-dialect verification ✅

- `cargo build --no-default-features --features sqlite,tenancy` ✓
- `cargo test --workspace --all-features --no-run` ✓
- 4/4 emission tests pass: attribute parsing, PG/SQLite WHERE emitted, MySQL WHERE dropped + warning
- 1/1 SQLite live test pins end-to-end: multiple soft-deleted rows can share email; second active row rejected; different active email succeeds

CI: `unique_when_sqlite_live` added to `sqlite_live` `--test` list.

## MySQL limitation (documented)

Native MySQL 8.0 has no partial-index syntax. The writer drops the WHERE clause and emits a warning rather than failing the migration — the underlying UNIQUE index still gets created (just without the partial filter). Users requiring strict partial uniqueness on MySQL should add an application-level check or a CHECK constraint over a STORED generated column. A future follow-up can emit the generated-column shape automatically.

## Extract-surface impact

Pure ORM work in `core/schema.rs` + `migrate/{snapshot,diff,invert}.rs` + macros + Dialect trait. No tenancy/admin deps.

## New `RenderedBatch.warnings`

The migration runner can now surface non-fatal advisories from the DDL emitter. The MySQL partial-index case is the first user; future dialect-divergent emissions can route through the same channel (e.g. SQLite's `power`/`sqrt` build-flag issue could surface a similar warning at migration time if it ever lands in DDL).