### PR TITLE
refactor: kill PG-typed transaction/count_rows/raw_execute/bulk_update (#270 wave 1)

### DIFF
--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -1078,33 +1078,6 @@ where
     Ok(q.fetch_optional(executor).await?)
 }
 
-/// Run a `CountQuery` and return the row count.
-///
-/// # Errors
-/// Returns [`ExecError`] for SQL-writing or driver failures.
-#[cfg(feature = "postgres")]
-pub async fn count_rows(pool: &PgPool, query: &CountQuery) -> Result<i64, ExecError> {
-    count_rows_on(pool, query).await
-}
-
-/// Like [`count_rows`] but accepts any sqlx executor.
-///
-/// # Errors
-/// As [`count_rows`].
-#[cfg(feature = "postgres")]
-pub async fn count_rows_on<'c, E>(executor: E, query: &CountQuery) -> Result<i64, ExecError>
-where
-    E: sqlx::Executor<'c, Database = sqlx::Postgres>,
-{
-    let stmt = Postgres.compile_count(query)?;
-    let mut q: Query<'_, sqlx::Postgres, PgArguments> = sqlx::query(&stmt.sql);
-    for value in stmt.params {
-        q = bind_query(q, value);
-    }
-    let row = q.fetch_one(executor).await?;
-    Ok(sqlx::Row::try_get::<i64, _>(&row, 0)?)
-}
-
 /// Slice 9.0b — annotate each parent row with the COUNT of its
 /// children, returning `Vec<(Parent, i64)>` from a **single** SQL:
 ///
@@ -1394,15 +1367,18 @@ impl<T: Model + Send> QuerySet<T> {
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
         let select = self.compile()?;
-        count_rows_on(
-            executor,
-            &CountQuery {
-                model: select.model,
-                where_clause: select.where_clause,
-                search: select.search,
-            },
-        )
-        .await
+        let stmt = Postgres.compile_count(&CountQuery {
+            model: select.model,
+            where_clause: select.where_clause,
+            search: select.search,
+        })?;
+        let mut q: Query<'_, sqlx::Postgres, PgArguments> = sqlx::query(&stmt.sql);
+        for value in stmt.params {
+            q = bind_query(q, value);
+        }
+        let row = q.fetch_one(executor).await?;
+        let count: i64 = sqlx::Row::try_get(&row, 0)?;
+        Ok(count)
     }
 
     /// Run `EXPLAIN [(...)] <select>` against this queryset and return
@@ -1940,37 +1916,6 @@ fn bind_query(
 
 // ------------------------------------------------------------------ bulk UPDATE
 
-/// Execute a [`BulkUpdateQuery`] — `UPDATE … FROM (VALUES …)` — and return
-/// the number of rows affected. One round-trip for any number of rows.
-///
-/// # Errors
-/// SQL-writing or driver failures, or [`SqlError::EmptyBulkInsert`] if
-/// `query.rows` is empty (the caller should short-circuit).
-#[cfg(feature = "postgres")]
-pub async fn bulk_update(pool: &PgPool, query: &BulkUpdateQuery) -> Result<u64, ExecError> {
-    bulk_update_on(pool, query).await
-}
-
-/// Like [`bulk_update`] but accepts any sqlx executor.
-///
-/// # Errors
-/// As [`bulk_update`].
-#[cfg(feature = "postgres")]
-pub async fn bulk_update_on<'c, E>(executor: E, query: &BulkUpdateQuery) -> Result<u64, ExecError>
-where
-    E: sqlx::Executor<'c, Database = sqlx::Postgres>,
-{
-    if query.rows.is_empty() {
-        return Ok(0);
-    }
-    let stmt = Postgres.compile_bulk_update(query)?;
-    let mut q: Query<'_, sqlx::Postgres, PgArguments> = sqlx::query(&stmt.sql);
-    for p in stmt.params {
-        q = bind_query(q, p);
-    }
-    Ok(q.execute(executor).await?.rows_affected())
-}
-
 // ------------------------------------------------------------------ raw SQL escape hatch
 
 /// Execute arbitrary SQL and decode each row into `T` using the same
@@ -2013,36 +1958,6 @@ where
         q = bind_query_as(q, b);
     }
     Ok(q.fetch_all(executor).await?)
-}
-
-/// Execute arbitrary SQL that does not return rows (INSERT / UPDATE / DELETE /
-/// DDL). Returns the number of rows affected.
-///
-/// # Errors
-/// Driver / SQL failures.
-#[cfg(feature = "postgres")]
-pub async fn raw_execute(sql: &str, binds: Vec<SqlValue>, pool: &PgPool) -> Result<u64, ExecError> {
-    raw_execute_on(sql, binds, pool).await
-}
-
-/// Like [`raw_execute`] but accepts any sqlx executor.
-///
-/// # Errors
-/// As [`raw_execute`].
-#[cfg(feature = "postgres")]
-pub async fn raw_execute_on<'c, E>(
-    sql: &str,
-    binds: Vec<SqlValue>,
-    executor: E,
-) -> Result<u64, ExecError>
-where
-    E: sqlx::Executor<'c, Database = sqlx::Postgres>,
-{
-    let mut q: Query<'_, sqlx::Postgres, PgArguments> = sqlx::query(sql);
-    for b in binds {
-        q = bind_query(q, b);
-    }
-    Ok(q.execute(executor).await?.rows_affected())
 }
 
 // ------------------------------------------------------------------ aggregate
@@ -2130,42 +2045,6 @@ where
 }
 
 // ------------------------------------------------------------------ transaction
-
-/// Run `f` inside a Postgres transaction. Commits on `Ok`, rolls back on `Err`.
-///
-/// Every `_on(executor)` method accepts `&mut PgConnection`, which is what the
-/// closure receives — so all ORM writes can be composed inside a single atomic
-/// block with no extra boilerplate:
-///
-/// ```ignore
-/// rustango::sql::transaction(&pool, |conn| async move {
-///     user.save_on(conn).await?;
-///     post.save_on(conn).await?;
-///     Ok(())
-/// }).await?;
-/// ```
-///
-/// # Errors
-/// Returns the first `ExecError` produced by `f`, or a driver error if
-/// `BEGIN` / `COMMIT` / `ROLLBACK` fails.
-#[cfg(feature = "postgres")]
-pub async fn transaction<F, Fut, T>(pool: &PgPool, f: F) -> Result<T, ExecError>
-where
-    F: FnOnce(&mut sqlx::PgConnection) -> Fut,
-    Fut: std::future::Future<Output = Result<T, ExecError>>,
-{
-    let mut tx = pool.begin().await?;
-    match f(&mut *tx).await {
-        Ok(val) => {
-            tx.commit().await?;
-            Ok(val)
-        }
-        Err(e) => {
-            let _ = tx.rollback().await;
-            Err(e)
-        }
-    }
-}
 
 // ====================================================================
 // `transaction_pool` — user-facing bi-dialect transaction helper

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -46,15 +46,20 @@ pub use executor::{
     InsertReturningPool, LoadRelated, MaybeMyFromRow, MaybeMyLoadRelated, MaybePgFromRow,
     MaybeSqliteFromRow, MaybeSqliteLoadRelated, Page, PoolTx, UpdaterPool,
 };
-// PG-typed back-compat surface: only re-exported when `postgres` is on.
+// PG-typed back-compat surface (issue #270 / T1.8 — wave 1):
+// Deleted: `count_rows` / `count_rows_on` / `raw_execute` /
+// `raw_execute_on` / `bulk_update` / `bulk_update_on` / `transaction`
+// — every one has a tri-dialect `_pool` counterpart (`count_rows_pool`,
+// `raw_execute_pool`, `bulk_update_pool`, `transaction_pool`). Use
+// those instead. The rest of the PG-typed surface stays for now;
+// subsequent waves migrate it.
 #[cfg(feature = "postgres")]
 pub use executor::{
-    annotate_count_children, annotate_count_children_on, bulk_insert, bulk_insert_on, bulk_update,
-    bulk_update_on, count_rows, count_rows_on, delete, delete_on, fetch_aggregate,
-    fetch_aggregate_on, fetch_with_prefetch, insert, insert_on, insert_returning,
-    insert_returning_on, raw_execute, raw_execute_on, raw_query, raw_query_on, row_to_json,
-    select_one_row, select_one_row_on, select_rows, select_rows_on, transaction, update, update_on,
-    Counter, Deleter, Fetcher, Updater,
+    annotate_count_children, annotate_count_children_on, bulk_insert, bulk_insert_on, delete,
+    delete_on, fetch_aggregate, fetch_aggregate_on, fetch_with_prefetch, insert, insert_on,
+    insert_returning, insert_returning_on, raw_query, raw_query_on, row_to_json, select_one_row,
+    select_one_row_on, select_rows, select_rows_on, update, update_on, Counter, Deleter, Fetcher,
+    Updater,
 };
 
 #[cfg(feature = "mysql")]


### PR DESCRIPTION
## Summary

Issue #270 / T1.8 (final ticket in the Tier 1 batch [#273](https://github.com/ujeenet/rustango/issues/273)). **Wave 1 of likely 4** — deletes the standalone PG-typed executor functions that have clean, single-step migration paths to the tri-dialect \`_pool\` family.

Deleted from \`sql/executor.rs\`:
- \`pub async fn transaction(&PgPool, ...)\` → use \`transaction_pool(&Pool, ...)\`
- \`pub async fn count_rows(&PgPool, ...)\` + \`count_rows_on\` → use \`count_rows_pool(&Pool, ...)\` or \`CounterPool::count_pool()\`
- \`pub async fn raw_execute(...)\` + \`raw_execute_on\` → use \`raw_execute_pool(...)\`
- \`pub async fn bulk_update(...)\` + \`bulk_update_on\` → use \`bulk_update_pool(...)\`

Net **-120 LOC**.

## What's NOT touched in this PR

The wider PG-typed surface stays for now — deleting it requires a macro refactor that exceeds the autonomous PR loop's safety budget:

- \`Fetcher\` / \`Counter\` / \`Updater\` / \`Deleter\` extension traits (used by 25+ test files and the tenancy \`&mut PgConnection\` paths).
- \`pub async fn insert\` / \`update\` / \`delete\` / \`select_rows\` / \`select_one_row\` (+ \`_on\` variants) — directly called by the \`#[derive(Model)]\` macro's emitted \`Self::save_on(executor)\` / \`Self::delete_on(executor)\` / etc. for tenancy schema-mode \`SET search_path\` scoping. Replacing them needs a \`Pool\`-or-\`PoolTx\` enum on every emitted method.
- \`bulk_insert\` / \`insert_returning\` / \`fetch_with_prefetch\` / \`raw_query\` / \`fetch_aggregate\` / \`annotate_count_children\` and their \`_on\` siblings.

These follow-up waves are tracked in the todo list; each is a separate multi-file PR.

## In-tree callers

The only internal caller of any deleted function was \`QuerySet::count_on\` calling \`count_rows_on\`. Migrated to inline \`compile_count\` + \`bind_query\` + \`fetch_one\` so the public method signature is preserved.

## Tri-dialect verification ✅

- \`cargo build --no-default-features --features sqlite,tenancy\` ✓
- \`cargo test --workspace --all-features --no-run\` ✓
- No new tests — the deleted functions had no dedicated test coverage (they were thin wrappers around the writer + sqlx). The \`_pool\` family's existing test coverage exercises the surviving canonical paths.

## Why partial scope

The user's directive ("just kill it") was to remove the entire PG-typed legacy surface, not to ship the deprecation cycle. The original analysis estimated the **full** removal at ~200 LOC, but auditing revealed it actually cascades through:

1. 25+ test files using \`Fetcher\` / \`.fetch(pool)\` / \`Updater\` / \`.update(pool)\` / etc.
2. \`#[derive(Model)]\` macro emissions calling \`sql::insert_on\` / \`sql::update_on\` / \`sql::delete_on\` / \`sql::bulk_insert_on\` / \`sql::insert_returning_on\` with a generic \`Executor<Database = Postgres>\` for tenancy connection scoping.
3. Tenancy code using \`&mut PgConnection\` for schema-mode \`SET search_path\`.

The full deletion is genuinely multi-day work. Shipping it as one PR exceeds the loop's 3-fix-attempt budget. This PR ships the bounded subset that has no macro / generic-executor entanglement.

Follow-up issues will track waves 2–4.