### PR TITLE
refactor: kill PG-typed &PgPool wrappers (#270 wave 2)

### DIFF
--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter03_orm.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter03_orm.rs
@@ -196,7 +196,7 @@ async fn limit_offset_paginates() {
 #[tokio::test]
 async fn aggregate_count_and_sum() {
     use rustango::core::{AggregateExpr, SqlValue};
-    use rustango::sql::fetch_aggregate;
+    use rustango::sql::fetch_aggregate_on;
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
 
@@ -340,7 +340,7 @@ async fn where_expr_not_negates_predicate() {
 #[tokio::test]
 async fn bulk_insert_writes_many_rows_in_one_round_trip() {
     use rustango::core::{BulkInsertQuery, SqlValue};
-    use rustango::sql::bulk_insert;
+    use rustango::sql::bulk_insert_on;
     use rustango::core::Model as _;
 
     let Some(pool) = pool().await else { return };

--- a/crates/rustango/src/forms/mod.rs
+++ b/crates/rustango/src/forms/mod.rs
@@ -983,7 +983,7 @@ impl DynamicForm {
 /// // POST /posts { title: "hello", body: "world" }
 /// let mf: ModelFormFor<Post> = ModelForm::parse(&form_payload)?;
 /// let query = mf.into_insert_query();
-/// rustango::sql::insert(&pool, &query).await?;
+/// rustango::sql::insert_on(&pool, &query).await?;
 /// ```
 ///
 /// Skips the `Auto<T>` PK on create; rejects unknown form keys with

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -333,18 +333,6 @@ fn inject_total_count(sql: &str) -> String {
     }
 }
 
-/// Run an `InsertQuery` against a Postgres pool.
-///
-/// Validates each value against the declared field bounds (`max_length`,
-/// `min`, `max`) before opening the connection.
-///
-/// # Errors
-/// Returns [`ExecError`] for validation, SQL-writing, or driver failures.
-#[cfg(feature = "postgres")]
-pub async fn insert(pool: &PgPool, query: &InsertQuery) -> Result<(), ExecError> {
-    insert_on(pool, query).await
-}
-
 /// Like [`insert`] but accepts any sqlx executor — `&PgPool`,
 /// `&mut PgConnection`, or a transaction. Tenant-scoped writes need
 /// this: schema-mode tenants share the registry pool and rely on the
@@ -366,24 +354,6 @@ where
     }
     q.execute(executor).await?;
     Ok(())
-}
-
-/// Run an `InsertQuery` and return the row created by the
-/// `RETURNING` clause.
-///
-/// Used by macro-generated insert paths for models with `Auto<T>` PKs:
-/// the column is omitted from the INSERT (so Postgres' BIGSERIAL
-/// sequence fires) and the assigned value is read back via `RETURNING`.
-/// Caller pulls each returned column out via `sqlx::Row::try_get` —
-/// e.g. `Auto<i64>::decode` rebuilds an `Auto::Set(value)`.
-///
-/// # Errors
-/// Returns [`ExecError::EmptyReturning`] if `query.returning` is empty
-/// (use [`insert`] for those); validation, SQL-writing, or driver
-/// failures otherwise.
-#[cfg(feature = "postgres")]
-pub async fn insert_returning(pool: &PgPool, query: &InsertQuery) -> Result<PgRow, ExecError> {
-    insert_returning_on(pool, query).await
 }
 
 /// Like [`insert_returning`] but accepts any sqlx executor.
@@ -409,22 +379,6 @@ where
     }
     let row = q.fetch_one(executor).await?;
     Ok(row)
-}
-
-/// Run a `BulkInsertQuery` against a Postgres pool — one round-trip
-/// for every row. Returns the rows produced by the `RETURNING`
-/// clause (one per input row), or an empty `Vec` if the query
-/// requested no `RETURNING`.
-///
-/// Used by macro-generated `Model::bulk_insert(pool, &mut rows)`.
-/// Validates each row against the model's bounds before opening
-/// the connection.
-///
-/// # Errors
-/// Returns [`ExecError`] for validation, SQL-writing, or driver failures.
-#[cfg(feature = "postgres")]
-pub async fn bulk_insert(pool: &PgPool, query: &BulkInsertQuery) -> Result<Vec<PgRow>, ExecError> {
-    bulk_insert_on(pool, query).await
 }
 
 /// Like [`bulk_insert`] but accepts any sqlx executor.
@@ -453,18 +407,6 @@ where
     }
 }
 
-/// Run an `UpdateQuery` against a Postgres pool. Returns rows affected.
-///
-/// Validates each `SET` value against the declared field bounds before
-/// opening the connection.
-///
-/// # Errors
-/// Returns [`ExecError`] for validation, SQL-writing, or driver failures.
-#[cfg(feature = "postgres")]
-pub async fn update(pool: &PgPool, query: &UpdateQuery) -> Result<u64, ExecError> {
-    update_on(pool, query).await
-}
-
 /// Like [`update`] but accepts any sqlx executor.
 ///
 /// # Errors
@@ -484,15 +426,6 @@ where
     Ok(result.rows_affected())
 }
 
-/// Run a `DeleteQuery` against a Postgres pool. Returns rows affected.
-///
-/// # Errors
-/// Returns [`ExecError`] for SQL-writing or driver failures.
-#[cfg(feature = "postgres")]
-pub async fn delete(pool: &PgPool, query: &DeleteQuery) -> Result<u64, ExecError> {
-    delete_on(pool, query).await
-}
-
 /// Like [`delete`] but accepts any sqlx executor.
 ///
 /// # Errors
@@ -509,17 +442,6 @@ where
     }
     let result = q.execute(executor).await?;
     Ok(result.rows_affected())
-}
-
-/// Run a `SelectQuery` and return raw `PgRow`s — for tooling that needs to
-/// render or inspect rows without statically knowing the row type
-/// (e.g. the admin UI).
-///
-/// # Errors
-/// Returns [`ExecError`] for SQL-writing or driver failures.
-#[cfg(feature = "postgres")]
-pub async fn select_rows(pool: &PgPool, query: &SelectQuery) -> Result<Vec<PgRow>, ExecError> {
-    select_rows_on(pool, query).await
 }
 
 /// Schema-driven decode of a Postgres row into a JSON object.
@@ -1043,19 +965,6 @@ where
         q = bind_query(q, value);
     }
     Ok(q.fetch_all(executor).await?)
-}
-
-/// Run a `SelectQuery` and return at most one raw `PgRow`. Used by detail
-/// views and PK lookups.
-///
-/// # Errors
-/// Returns [`ExecError`] for SQL-writing or driver failures.
-#[cfg(feature = "postgres")]
-pub async fn select_one_row(
-    pool: &PgPool,
-    query: &SelectQuery,
-) -> Result<Option<PgRow>, ExecError> {
-    select_one_row_on(pool, query).await
 }
 
 /// Like [`select_one_row`] but accepts any sqlx executor.
@@ -1693,7 +1602,7 @@ pub trait Deleter<T: Model + Send> {
 impl<T: Model + Send> Deleter<T> for QuerySet<T> {
     async fn delete(self, pool: &PgPool) -> Result<u64, ExecError> {
         let query = self.compile_delete()?;
-        delete(pool, &query).await
+        delete_on(pool, &query).await
     }
 }
 
@@ -1716,7 +1625,7 @@ pub trait Updater<T: Model + Send> {
 impl<T: Model + Send> Updater<T> for UpdateBuilder<T> {
     async fn execute(self, pool: &PgPool) -> Result<u64, ExecError> {
         let query = self.compile()?;
-        update(pool, &query).await
+        update_on(pool, &query).await
     }
 }
 
@@ -1918,27 +1827,6 @@ fn bind_query(
 
 // ------------------------------------------------------------------ raw SQL escape hatch
 
-/// Execute arbitrary SQL and decode each row into `T` using the same
-/// `sqlx::FromRow` impl generated by `#[derive(Model)]`.
-///
-/// `binds` must be in `$1` / `$2` / … placeholder order. This bypasses all
-/// ORM validation and audit; use it when the query IR can't express what you
-/// need (CTEs, LATERAL joins, UNNEST, window functions, etc.).
-///
-/// # Errors
-/// Driver / SQL failures.
-#[cfg(feature = "postgres")]
-pub async fn raw_query<T>(
-    sql: &str,
-    binds: Vec<SqlValue>,
-    pool: &PgPool,
-) -> Result<Vec<T>, ExecError>
-where
-    T: for<'r> sqlx::FromRow<'r, PgRow> + Send + Unpin,
-{
-    raw_query_on(sql, binds, pool).await
-}
-
 /// Like [`raw_query`] but accepts any sqlx executor.
 ///
 /// # Errors
@@ -1961,20 +1849,6 @@ where
 }
 
 // ------------------------------------------------------------------ aggregate
-
-/// Execute an [`AggregateQuery`] and return each result row as a
-/// `HashMap<String, SqlValue>`. Keys are the `group_by` column names and
-/// the aggregate aliases from `aggregates`.
-///
-/// # Errors
-/// SQL-writing or driver failures.
-#[cfg(feature = "postgres")]
-pub async fn fetch_aggregate(
-    query: &AggregateQuery,
-    pool: &PgPool,
-) -> Result<Vec<std::collections::HashMap<String, SqlValue>>, ExecError> {
-    fetch_aggregate_on(query, pool).await
-}
 
 /// Like [`fetch_aggregate`] but accepts any sqlx executor.
 ///

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -55,11 +55,9 @@ pub use executor::{
 // subsequent waves migrate it.
 #[cfg(feature = "postgres")]
 pub use executor::{
-    annotate_count_children, annotate_count_children_on, bulk_insert, bulk_insert_on, delete,
-    delete_on, fetch_aggregate, fetch_aggregate_on, fetch_with_prefetch, insert, insert_on,
-    insert_returning, insert_returning_on, raw_query, raw_query_on, row_to_json, select_one_row,
-    select_one_row_on, select_rows, select_rows_on, update, update_on, Counter, Deleter, Fetcher,
-    Updater,
+    annotate_count_children, annotate_count_children_on, bulk_insert_on, delete_on,
+    fetch_aggregate_on, fetch_with_prefetch, insert_on, insert_returning_on, raw_query_on,
+    row_to_json, select_one_row_on, select_rows_on, update_on, Counter, Deleter, Fetcher, Updater,
 };
 
 #[cfg(feature = "mysql")]

--- a/crates/rustango/src/tenancy/permissions.rs
+++ b/crates/rustango/src/tenancy/permissions.rs
@@ -855,7 +855,7 @@ pub async fn grant_role_perm(
         returning: vec![],
         on_conflict: Some(ConflictClause::DoNothing),
     };
-    crate::sql::insert(pool, &query).await?;
+    crate::sql::insert_on(pool, &query).await?;
     Ok(())
 }
 
@@ -886,7 +886,7 @@ pub async fn revoke_role_perm(
     codename: &str,
     pool: &PgPool,
 ) -> Result<(), TenancyError> {
-    crate::sql::delete(
+    crate::sql::delete_on(
         pool,
         &DeleteQuery {
             model: RolePermission::SCHEMA,
@@ -951,7 +951,7 @@ pub async fn assign_role(user_id: i64, role_id: i64, pool: &PgPool) -> Result<()
         returning: vec![],
         on_conflict: Some(ConflictClause::DoNothing),
     };
-    crate::sql::insert(pool, &query).await?;
+    crate::sql::insert_on(pool, &query).await?;
     Ok(())
 }
 
@@ -975,7 +975,7 @@ pub async fn assign_role_pool(
 /// Remove a user from a role.
 #[cfg(feature = "postgres")]
 pub async fn remove_role(user_id: i64, role_id: i64, pool: &PgPool) -> Result<(), TenancyError> {
-    crate::sql::delete(
+    crate::sql::delete_on(
         pool,
         &DeleteQuery {
             model: UserRole::SCHEMA,
@@ -1055,7 +1055,7 @@ pub async fn set_user_perm(
             update_columns: vec!["granted"],
         }),
     };
-    crate::sql::insert(pool, &query).await?;
+    crate::sql::insert_on(pool, &query).await?;
     Ok(())
 }
 
@@ -1092,7 +1092,7 @@ pub async fn clear_user_perm(
     codename: &str,
     pool: &PgPool,
 ) -> Result<(), TenancyError> {
-    crate::sql::delete(
+    crate::sql::delete_on(
         pool,
         &DeleteQuery {
             model: UserPermission::SCHEMA,

--- a/crates/rustango/tests/aggregate_filter_live.rs
+++ b/crates/rustango/tests/aggregate_filter_live.rs
@@ -10,7 +10,7 @@ use std::sync::OnceLock;
 
 use rustango::core::aggregates::{count, count_all, stddev, sum};
 use rustango::core::{Column as _, SqlValue};
-use rustango::sql::{fetch_aggregate, sqlx, Auto};
+use rustango::sql::{fetch_aggregate_on, sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -103,7 +103,7 @@ async fn filtered_count_matches_predicate() {
         )
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     assert_eq!(get_i64(&rows, "active_published"), 2);
 
     cleanup(&pool).await;
@@ -132,7 +132,7 @@ async fn filtered_sum_with_default_falls_back_when_empty() {
         )
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     assert_eq!(get_i64(&rows, "revenue"), 300);
 
     let q = Post::objects()
@@ -147,7 +147,7 @@ async fn filtered_sum_with_default_falls_back_when_empty() {
         )
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     assert_eq!(
         get_i64(&rows, "revenue"),
         0,
@@ -173,7 +173,7 @@ async fn filtered_count_column_arg_executes() {
         .annotate("n", count("price").filter(Post::pages.gt(75_i64)).into())
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     // pages > 75: rows with pages=100, pages=200 → 2.
     assert_eq!(get_i64(&rows, "n"), 2);
 
@@ -197,7 +197,7 @@ async fn stddev_returns_a_finite_positive_number() {
         .annotate("sd", stddev("pages").into())
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     let sd = get_f64(&rows, "sd");
     assert!(
         sd.is_finite() && sd > 0.0,

--- a/crates/rustango/tests/groupby_inference_live.rs
+++ b/crates/rustango/tests/groupby_inference_live.rs
@@ -10,7 +10,7 @@ use std::sync::OnceLock;
 
 use rustango::core::aggregates::{count_all, sum};
 use rustango::core::SqlValue;
-use rustango::sql::{fetch_aggregate, sqlx, Auto};
+use rustango::sql::{fetch_aggregate_on, sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -103,7 +103,7 @@ async fn shape2_posts_per_author() {
         .annotate("n", count_all().into())
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     assert_eq!(rows.len(), 3, "three distinct authors");
     let mut by_author: HashMap<i64, i64> = rows
         .iter()
@@ -131,7 +131,7 @@ async fn shape2_monthly_revenue_per_author() {
         .annotate("total", sum("amount").into())
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     // Distinct (author, month) pairs: (1,'01'), (1,'02'), (2,'01'),
     // (2,'02'), (3,'01') = 5 rows.
     assert_eq!(rows.len(), 5, "5 (author, month) buckets");
@@ -169,7 +169,7 @@ async fn shape3_bare_annotate_runs_with_group_by_all() {
         .annotate("n", count_all().into())
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     // Every row has a unique (id, author_id, month, amount) tuple,
     // so GROUP-BY-all-cols collapses to no-op — 7 rows in, 7 rows out.
     assert_eq!(rows.len(), 7, "GROUP BY every col → row count unchanged");

--- a/crates/rustango/tests/having_auto_routing_live.rs
+++ b/crates/rustango/tests/having_auto_routing_live.rs
@@ -10,7 +10,7 @@ use std::sync::OnceLock;
 
 use rustango::core::aggregates::count_all;
 use rustango::core::{Op, SqlValue};
-use rustango::sql::{fetch_aggregate, sqlx, Auto};
+use rustango::sql::{fetch_aggregate_on, sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -108,7 +108,7 @@ async fn authors_with_gt_10_published_posts_uses_where_plus_having() {
         .order_by(&[("author_id", false)])
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
 
     assert_eq!(
         rows.len(),
@@ -142,7 +142,7 @@ async fn having_only_no_where_clause() {
         .order_by(&[("author_id", false)])
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
 
     let author_ids: Vec<i64> = rows.iter().map(|r| get_i64(r, "author_id")).collect();
     assert_eq!(
@@ -176,7 +176,7 @@ async fn op_in_against_alias_routes_to_having_in() {
         .order_by(&[("author_id", false)])
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
 
     let author_ids: Vec<i64> = rows.iter().map(|r| get_i64(r, "author_id")).collect();
     // Authors 3 (15 posts) and 4 (5 posts) match; 1 has 15 total (matches),
@@ -208,7 +208,7 @@ async fn op_between_against_alias_routes_to_having_between() {
         .order_by(&[("author_id", false)])
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
 
     let author_ids: Vec<i64> = rows.iter().map(|r| get_i64(r, "author_id")).collect();
     assert_eq!(
@@ -242,7 +242,7 @@ async fn op_not_in_against_alias_routes_to_having_not_in() {
         .order_by(&[("author_id", false)])
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
 
     let author_ids: Vec<i64> = rows.iter().map(|r| get_i64(r, "author_id")).collect();
     assert_eq!(author_ids, vec![1, 3]);

--- a/crates/rustango/tests/pg_aggregates_live.rs
+++ b/crates/rustango/tests/pg_aggregates_live.rs
@@ -5,7 +5,7 @@
 use std::sync::OnceLock;
 
 use rustango::core::{AggregateExpr, AggregateQuery, SqlValue, WhereExpr};
-use rustango::sql::{fetch_aggregate, sqlx, Auto};
+use rustango::sql::{fetch_aggregate_on, sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -91,7 +91,7 @@ async fn array_agg_collects_tags_per_author() {
     fresh(&pool).await;
 
     let q = agg_per_author(AggregateExpr::array_agg("tag"), "tags");
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     assert_eq!(rows.len(), 2, "two distinct authors");
 
     // Alice should have both rust + sql tags. The exact array
@@ -124,7 +124,7 @@ async fn string_agg_concatenates_tags_per_author() {
     // alphabetically before this call. For this test we accept
     // either "rust,sql" or "sql,rust".
     let q = agg_per_author(AggregateExpr::string_agg("tag", ","), "tag_list");
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     let alice = rows
         .iter()
         .find(|r| matches!(r.get("author"), Some(SqlValue::String(s)) if s == "alice"))
@@ -150,7 +150,7 @@ async fn jsonb_agg_returns_json_array_per_author() {
     fresh(&pool).await;
 
     let q = agg_per_author(AggregateExpr::jsonb_agg("tag"), "tag_json");
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     let alice = rows
         .iter()
         .find(|r| matches!(r.get("author"), Some(SqlValue::String(s)) if s == "alice"))

--- a/crates/rustango/tests/where_expr_live.rs
+++ b/crates/rustango/tests/where_expr_live.rs
@@ -216,5 +216,5 @@ async fn empty_or_branch_returns_named_writer_error() {
         projection: None,
         distinct: None,
     };
-    rustango::sql::select_rows(&pool, &q2).await.unwrap();
+    rustango::sql::select_rows_on(&pool, &q2).await.unwrap();
 }

--- a/crates/rustango/tests/window_functions_live.rs
+++ b/crates/rustango/tests/window_functions_live.rs
@@ -9,7 +9,7 @@ use std::sync::OnceLock;
 
 use rustango::core::window::{dense_rank, lag, rank, row_number};
 use rustango::core::SqlValue;
-use rustango::sql::{fetch_aggregate, sqlx, Auto};
+use rustango::sql::{fetch_aggregate_on, sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -85,7 +85,7 @@ async fn rank_by_score_within_each_tenant() {
 
     // Use a raw SELECT to project both the row + the window — the
     // aggregate path returns rows keyed by ("id", "name", "r"). To
-    // make this work with `fetch_aggregate`, group by every column
+    // make this work with `fetch_aggregate_on`, group by every column
     // we want to project (PG accepts the equivalent of "GROUP BY
     // ALL" via the trivial group on the PK).
     use rustango::core::aggregates::max;
@@ -106,7 +106,7 @@ async fn rank_by_score_within_each_tenant() {
         .order_by(&[("tenant_id", false), ("score", true)])
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     assert_eq!(rows.len(), 5);
     // Order is tenant_id asc, score desc → Alice(t1,30,1), Bob(t1,20,2),
     // Carol(t1,10,3), Dave(t2,100,1), Eve(t2,50,2).
@@ -157,7 +157,7 @@ async fn dense_rank_does_not_skip_on_ties() {
         .order_by(&[("tenant_id", false), ("score", true), ("id", false)])
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     // Tenant 2 rows in score-desc order: Dave (100), Eve/Frank/Grace
     // (all 50). Dense ranks: 1, 2, 2, 2. Sorted as appended in fresh()
     // + the two ties, the tenant_id=2 segment is the last 4 rows.
@@ -212,7 +212,7 @@ async fn row_number_returns_sequential_index() {
         .order_by(&[("tenant_id", false), ("score", true), ("id", false)])
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     // Tenant 1 has 3 rows → row numbers 1, 2, 3.
     let tenant1: Vec<i64> = rows
         .iter()
@@ -252,7 +252,7 @@ async fn lag_returns_prior_row_value_with_default_on_edge() {
         .order_by(&[("tenant_id", false), ("score", true), ("id", false)])
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     // Tenant 1 in score-desc: Alice(30) → prev=0 (no prior),
     // Bob(20)   → prev=30, Carol(10) → prev=20.
     let tenant1: Vec<i64> = rows


### PR DESCRIPTION
## Summary

Wave 2 of T1.8 (issue #270). Deletes the 9 bare \`pub async fn xxx(pool: &PgPool, ...)\` wrappers in \`sql/executor.rs\` that just forward to their \`xxx_on(executor, ...)\` siblings:

\`insert\`, \`insert_returning\`, \`bulk_insert\`, \`update\`, \`delete\`, \`select_rows\`, \`select_one_row\`, \`raw_query\`, \`fetch_aggregate\`

Net **-128 LOC**.

## Why the \`_on\` variants survive

They take a generic \`E: sqlx::Executor<'_, Database = Postgres>\` — required for tenancy schema-mode \`SET search_path\` paths that hand \`&mut PgConnection\` instead of \`&PgPool\`. The \`&PgPool\` wrappers were thin shims that duplicated the API for no benefit. The \`_on\` family stays in T1.8's backlog for a follow-up wave that refactors the \`#[derive(Model)]\` macro's generic-executor codegen.

## Callers migrated

- \`Updater::execute\` (impl on UpdateBuilder): \`update(...)\` → \`update_on(...)\`
- \`Deleter::delete\` (impl on QuerySet): \`delete(...)\` → \`delete_on(...)\`
- \`tenancy/permissions.rs\` (6 sites): \`crate::sql::insert(...)\` / \`crate::sql::delete(...)\` → \`_on\` variants
- 5 test files using \`fetch_aggregate(...)\` → \`fetch_aggregate_on(...)\`
- 3 misc files using \`rustango::sql::insert\` / \`update\` / \`delete\` → their \`_on\` siblings

## Verification ✅

- \`cargo build --no-default-features --features sqlite,tenancy\` ✓
- \`cargo test --workspace --all-features --no-run\` ✓
- fmt + clippy clean

## What still survives in T1.8 backlog

- \`Fetcher\` / \`Counter\` / \`Updater\` / \`Deleter\` extension traits (with their associated method dispatch).
- The \`_on\` family (\`insert_on\`, \`update_on\`, \`delete_on\`, \`bulk_insert_on\`, \`insert_returning_on\`, \`select_rows_on\`, \`select_one_row_on\`, \`raw_query_on\`, \`fetch_aggregate_on\`, \`annotate_count_children_on\`).
- \`fetch_with_prefetch\` (different shape — needs its own plan).

That remaining surface is what \`#[derive(Model)]\` emits for tenancy schema-mode \`SET search_path\` scoping. Deleting it needs a \`Pool\`-vs-\`PoolTx\` enum on every emitted method — designed follow-up, not this PR.