### PR TITLE
refactor: kill Fetcher/Counter/Updater/Deleter extension traits (#270 wave 3)

### DIFF
--- a/crates/rustango/examples/cookbook_blog/COOKBOOK.md
+++ b/crates/rustango/examples/cookbook_blog/COOKBOOK.md
@@ -835,7 +835,7 @@ Implementation prefetches the page's distinct CT ids once before the row loop (u
 13 live recipes against the Author / Post fixture from Chapter 2.
 Run with `DATABASE_URL=... cargo test --test cookbook_chapter03_orm -- --test-threads=1`.
 
-* §3.31 `Post::objects().filter("published", Op::Eq, true).fetch(&pool)` →
+* §3.31 `Post::objects().filter("published", Op::Eq, true).fetch_on(&pool)` →
   `filter_eq_fetch_returns_matching_rows`
 * §3.34 `Op::Gt` / `Op::Lt` / `Op::ILike` / `Op::In` / `Op::Between` /
   `Op::IsNull` — six tests covering the full Op surface.

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter02_models.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter02_models.rs
@@ -10,7 +10,7 @@
 
 use cookbook_blog::apps::blog::models::*;
 use rustango::core::{Model as _, Op};
-use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::sql::{sqlx, Auto, };
 
 fn url() -> Option<String> {
     std::env::var("DATABASE_URL").ok()
@@ -209,8 +209,7 @@ async fn option_field_round_trips_null() {
 
     let id = match a.id { Auto::Set(v) => v, Auto::Unset => unreachable!() };
     let row: Vec<Author> = Author::objects()
-        .filter("id", Op::Eq, id)
-        .fetch(&pool).await.unwrap();
+        .filter("id", Op::Eq, id).fetch_on(&pool).await.unwrap();
     assert_eq!(row.len(), 1);
     assert_eq!(row[0].bio, None, "Option<String>::None should round-trip as NULL");
 }
@@ -232,8 +231,7 @@ async fn auto_now_add_assigns_at_insert() {
     let id = match a.id { Auto::Set(v) => v, Auto::Unset => unreachable!() };
 
     let row: Vec<Author> = Author::objects()
-        .filter("id", Op::Eq, id)
-        .fetch(&pool).await.unwrap();
+        .filter("id", Op::Eq, id).fetch_on(&pool).await.unwrap();
     let joined = match row[0].joined_at {
         Auto::Set(t) => t,
         Auto::Unset => panic!("auto_now_add did not populate joined_at"),
@@ -323,8 +321,7 @@ async fn fk_column_round_trips() {
     p.save(&pool).await.unwrap();
 
     let posts: Vec<Post> = Post::objects()
-        .filter("author_id", Op::Eq, author_id)
-        .fetch(&pool).await.unwrap();
+        .filter("author_id", Op::Eq, author_id).fetch_on(&pool).await.unwrap();
     assert_eq!(posts.len(), 1);
     assert_eq!(posts[0].title, "first");
     assert_eq!(posts[0].metadata["tags"][0], "intro");
@@ -364,8 +361,7 @@ async fn jsonb_field_round_trips_structured_data() {
     p.save(&pool).await.unwrap();
 
     let posts: Vec<Post> = Post::objects()
-        .filter("slug", Op::Eq, "j")
-        .fetch(&pool).await.unwrap();
+        .filter("slug", Op::Eq, "j").fetch_on(&pool).await.unwrap();
     assert_eq!(posts[0].metadata, payload);
 }
 
@@ -410,9 +406,9 @@ async fn datetime_option_round_trips() {
     };
     p2.save(&pool).await.unwrap();
 
-    let now_back: Vec<Post> = Post::objects().filter("slug", Op::Eq, "now").fetch(&pool).await.unwrap();
+    let now_back: Vec<Post> = Post::objects().filter("slug", Op::Eq, "now").fetch_on(&pool).await.unwrap();
     assert!(now_back[0].published_at.is_some(), "Some(when) lost on round-trip");
-    let never_back: Vec<Post> = Post::objects().filter("slug", Op::Eq, "never").fetch(&pool).await.unwrap();
+    let never_back: Vec<Post> = Post::objects().filter("slug", Op::Eq, "never").fetch_on(&pool).await.unwrap();
     assert_eq!(never_back[0].published_at, None);
 }
 
@@ -484,8 +480,7 @@ async fn m2m_through_junction_table_round_trips() {
     let t2_id = match t2.id { Auto::Set(v) => v, _ => unreachable!() };
 
     sqlx::query("INSERT INTO cookbook_post_tag (post_id, tag_id) VALUES ($1, $2), ($1, $3)")
-        .bind(post_id).bind(t1_id).bind(t2_id)
-        .execute(&pool).await.expect("link tags");
+        .bind(post_id).bind(t1_id).bind(t2_id).execute(&pool).await.expect("link tags");
 
     let count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM cookbook_post_tag WHERE post_id = $1"
@@ -590,8 +585,7 @@ async fn generic_fk_schema_and_content_type_lookup() {
     act.save(&pool).await.expect("activity insert");
 
     let rows: Vec<Activity> = Activity::objects()
-        .filter("target_object_pk", Op::Eq, author_id)
-        .fetch(&pool).await.unwrap();
+        .filter("target_object_pk", Op::Eq, author_id).fetch_on(&pool).await.unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].action, "viewed");
 }
@@ -611,8 +605,7 @@ async fn soft_delete_column_round_trips_and_deleted_at_defaults_null() {
     let id = match n.id { Auto::Set(v) => v, _ => unreachable!() };
 
     let rows: Vec<ArchiveNote> = ArchiveNote::objects()
-        .filter("id", Op::Eq, id)
-        .fetch(&pool).await.unwrap();
+        .filter("id", Op::Eq, id).fetch_on(&pool).await.unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].deleted_at, None, "fresh row deleted_at should be NULL");
 }

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter03_orm.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter03_orm.rs
@@ -7,7 +7,7 @@
 
 use cookbook_blog::apps::blog::models::*;
 use rustango::core::Op;
-use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::sql::{sqlx, Auto, };
 use rustango::Model;
 
 fn url() -> Option<String> {
@@ -87,8 +87,7 @@ async fn filter_eq_fetch_returns_matching_rows() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let published: Vec<Post> = Post::objects()
-        .filter("published", Op::Eq, true)
-        .fetch(&pool).await.unwrap();
+        .filter("published", Op::Eq, true).fetch_on(&pool).await.unwrap();
     assert_eq!(published.len(), 3, "3 of 5 posts are published");
     for p in &published { assert!(p.published, "filter must keep only published"); }
 }
@@ -101,8 +100,7 @@ async fn filter_with_gt_lt_op() {
     let popular: Vec<Post> = Post::objects()
         // Bind as i64 — the column is BIGINT, and `90` would otherwise
         // infer as i32 and trip rustango's TypeMismatch guard.
-        .filter("view_count", Op::Gt, 90i64)
-        .fetch(&pool).await.unwrap();
+        .filter("view_count", Op::Gt, 90i64).fetch_on(&pool).await.unwrap();
     assert_eq!(popular.len(), 2, "view_count>90: rust-orm(100) + django-shape(250)");
     let titles: Vec<&str> = popular.iter().map(|p| p.title.as_str()).collect();
     assert!(titles.contains(&"Rust ORM"));
@@ -115,8 +113,7 @@ async fn filter_with_ilike_case_insensitive() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let drafts: Vec<Post> = Post::objects()
-        .filter("title", Op::ILike, "%draft%")
-        .fetch(&pool).await.unwrap();
+        .filter("title", Op::ILike, "%draft%").fetch_on(&pool).await.unwrap();
     assert_eq!(drafts.len(), 2);
 }
 
@@ -130,8 +127,7 @@ async fn filter_with_in_list() {
         .filter("slug", Op::In, SqlValue::List(vec![
             SqlValue::String("rust-orm".into()),
             SqlValue::String("axum-101".into()),
-        ]))
-        .fetch(&pool).await.unwrap();
+        ])).fetch_on(&pool).await.unwrap();
     assert_eq!(picks.len(), 2);
 }
 
@@ -144,8 +140,7 @@ async fn filter_with_between_range() {
     let mid: Vec<Post> = Post::objects()
         .filter("view_count", Op::Between, SqlValue::List(vec![
             SqlValue::I64(50), SqlValue::I64(150),
-        ]))
-        .fetch(&pool).await.unwrap();
+        ])).fetch_on(&pool).await.unwrap();
     assert_eq!(mid.len(), 2, "axum-101(80) + rust-orm(100) within [50, 150]");
 }
 
@@ -156,8 +151,7 @@ async fn filter_with_is_null_unpublished() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let drafts: Vec<Post> = Post::objects()
-        .filter("published_at", Op::IsNull, SqlValue::Bool(true))
-        .fetch(&pool).await.unwrap();
+        .filter("published_at", Op::IsNull, SqlValue::Bool(true)).fetch_on(&pool).await.unwrap();
     assert_eq!(drafts.len(), 2, "draft-1 + draft-2 have NULL published_at");
 }
 
@@ -169,8 +163,7 @@ async fn order_by_view_count_desc() {
     let by_views: Vec<Post> = Post::objects()
         .filter("published", Op::Eq, true)
         // QuerySet::order_by uses (column, desc): true = DESC, false = ASC.
-        .order_by(&[("view_count", true)])
-        .fetch(&pool).await.unwrap();
+        .order_by(&[("view_count", true)]).fetch_on(&pool).await.unwrap();
     assert_eq!(by_views[0].slug, "django-shape", "250 views first");
     assert_eq!(by_views[1].slug, "rust-orm", "100 views second");
     assert_eq!(by_views[2].slug, "axum-101", "80 views third");
@@ -185,8 +178,7 @@ async fn limit_offset_paginates() {
         // ASC by id, skip 2, take 2 → posts 3 and 4 (draft-1, axum-101).
         .order_by(&[("id", false)])
         .limit(2)
-        .offset(2)
-        .fetch(&pool).await.unwrap();
+        .offset(2).fetch_on(&pool).await.unwrap();
     assert_eq!(page2.len(), 2);
     assert_eq!(page2[0].slug, "draft-1");
     assert_eq!(page2[1].slug, "axum-101");
@@ -242,8 +234,7 @@ async fn save_inserts_then_updates_in_place() {
     p.save(&pool).await.unwrap();
 
     let back: Vec<Post> = Post::objects()
-        .filter("id", Op::Eq, id)
-        .fetch(&pool).await.unwrap();
+        .filter("id", Op::Eq, id).fetch_on(&pool).await.unwrap();
     assert_eq!(back[0].body, "v2");
     assert!(back[0].published);
 }
@@ -306,8 +297,7 @@ async fn or_nested_predicates_via_where_raw() {
         }),
     ]);
     let hits: Vec<Post> = Post::objects()
-        .where_raw(predicate)
-        .fetch(&pool).await.unwrap();
+        .where_raw(predicate).fetch_on(&pool).await.unwrap();
     let slugs: Vec<&str> = hits.iter().map(|p| p.slug.as_str()).collect();
     assert!(slugs.contains(&"rust-orm"), "OR-arm-1 (slug match) missing: {slugs:?}");
     assert!(slugs.contains(&"django-shape"), "OR-arm-2 (>200 views) missing: {slugs:?}");
@@ -330,8 +320,7 @@ async fn where_expr_not_negates_predicate() {
         }),
     ));
     let drafts: Vec<Post> = Post::objects()
-        .where_raw(predicate)
-        .fetch(&pool).await.unwrap();
+        .where_raw(predicate).fetch_on(&pool).await.unwrap();
     assert_eq!(drafts.len(), 2, "2 unpublished posts");
     for p in &drafts { assert!(!p.published); }
 }
@@ -390,8 +379,7 @@ async fn select_related_smoke_compiles_and_runs() {
     // shape. (Lazy-load typed wrapper requires ForeignKey<T> field;
     // covered by tests/foreign_key_live.rs in rustango itself.)
     let posts: Vec<Post> = Post::objects()
-        .select_related("author_id")
-        .fetch(&pool).await
+        .select_related("author_id").fetch_on(&pool).await
         // Loose smoke: as long as no SQL error fires, the API accepts
         // the field. A typed FK schema (ForeignKey<Author>) is what
         // turns this into an actual JOIN — see chapter 3b plans.

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter09c_template_views.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter09c_template_views.rs
@@ -136,8 +136,7 @@ async fn list_paginates_and_renders_search_context() {
     ] {
         sqlx::query("INSERT INTO cookbook_author (name, email) VALUES ($1, $2)")
             .bind(n)
-            .bind(e)
-            .execute(&pool)
+            .bind(e).execute(&pool)
             .await
             .unwrap();
     }

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter09d_viewset_tenant_router.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter09d_viewset_tenant_router.rs
@@ -101,8 +101,7 @@ async fn fixture() -> Option<(String, sqlx::PgPool, axum::Router)> {
     let _ = sqlx::query(&format!(
         r#"DROP TABLE IF EXISTS "{}" CASCADE"#,
         rmig::LEDGER_TABLE
-    ))
-    .execute(&pool)
+    )).execute(&pool)
     .await;
     let pools_for_init = TenantPools::new(pool.clone());
     let dir = std::env::temp_dir().join(format!(
@@ -212,8 +211,7 @@ async fn tenant_router_lists_paginated_payload() {
     ] {
         sqlx::query("INSERT INTO cookbook_author (name, email) VALUES ($1, $2)")
             .bind(n)
-            .bind(e)
-            .execute(&pool)
+            .bind(e).execute(&pool)
             .await
             .unwrap();
     }
@@ -245,8 +243,7 @@ async fn tenant_router_search_param_narrows_count_and_results() {
     ] {
         sqlx::query("INSERT INTO cookbook_author (name, email) VALUES ($1, $2)")
             .bind(n)
-            .bind(e)
-            .execute(&pool)
+            .bind(e).execute(&pool)
             .await
             .unwrap();
     }
@@ -271,8 +268,7 @@ async fn tenant_router_filter_param_exact_match() {
     for (n, e) in [("Alice", "alice@x.com"), ("Bob", "bob@x.com")] {
         sqlx::query("INSERT INTO cookbook_author (name, email) VALUES ($1, $2)")
             .bind(n)
-            .bind(e)
-            .execute(&pool)
+            .bind(e).execute(&pool)
             .await
             .unwrap();
     }

--- a/crates/rustango/examples/tenant_user_extension/README.md
+++ b/crates/rustango/examples/tenant_user_extension/README.md
@@ -100,4 +100,4 @@ this example ships with `migrations/` empty for exactly that reason.
 - Extras must be `NULL`-able or carry `default = "…"` so the bootstrap
   migration applies cleanly to a fresh tenant schema.
 - Framework auth/admin still reads the seven core columns by name;
-  the two extras are only visible via `AppUser::objects().fetch(...)`.
+  the two extras are only visible via `AppUser::objects().fetch_on(...)`.

--- a/crates/rustango/examples/tenant_user_extension/src/models.rs
+++ b/crates/rustango/examples/tenant_user_extension/src/models.rs
@@ -4,7 +4,7 @@
 //!
 //! The framework's auth and admin paths read the seven core columns
 //! by name; the extras here are for the application to use via the
-//! ORM (`AppUser::objects().fetch(...)`).
+//! ORM (`AppUser::objects().fetch_on(...)`).
 
 use rustango::sql::Auto;
 use rustango::Model;

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -83,44 +83,6 @@ pub trait LoadRelated {}
 #[cfg(not(feature = "postgres"))]
 impl<T> LoadRelated for T {}
 
-/// Extension trait that drives a `QuerySet` to completion against a Postgres pool.
-///
-/// Adds `.fetch(&pool)` to any `QuerySet<T>` whose `T` is `Model + FromRow`.
-/// Pulled in via `use rustango::sql::Fetcher;`.
-#[cfg(feature = "postgres")]
-pub trait Fetcher<T>
-where
-    T: Model + for<'r> sqlx::FromRow<'r, PgRow> + Send + Unpin,
-{
-    /// Compile the queryset, write Postgres SQL, and run `fetch_all`.
-    ///
-    /// # Errors
-    /// Returns [`ExecError`] if any of the three stages fails: schema
-    /// validation, SQL writing, or the underlying sqlx call.
-    fn fetch(
-        self,
-        pool: &PgPool,
-    ) -> impl std::future::Future<Output = Result<Vec<T>, ExecError>> + Send;
-}
-
-#[cfg(feature = "postgres")]
-impl<T> Fetcher<T> for QuerySet<T>
-where
-    T: Model + for<'r> sqlx::FromRow<'r, PgRow> + Send + Unpin,
-{
-    async fn fetch(self, pool: &PgPool) -> Result<Vec<T>, ExecError> {
-        let select = self.compile()?;
-        let stmt = Postgres.compile_select(&select)?;
-
-        let mut q: QueryAs<'_, sqlx::Postgres, T, PgArguments> = sqlx::query_as::<_, T>(&stmt.sql);
-        for value in stmt.params {
-            q = bind_query_as(q, value);
-        }
-        let rows = q.fetch_all(pool).await?;
-        Ok(rows)
-    }
-}
-
 #[cfg(feature = "postgres")]
 impl<T> QuerySet<T>
 where
@@ -1144,7 +1106,7 @@ where
     P: Model + for<'r> sqlx::FromRow<'r, PgRow> + Send + Unpin + LoadRelated + HasPkValue,
     C: Model + for<'r> sqlx::FromRow<'r, PgRow> + Send + Unpin + LoadRelated + FkPkAccess,
 {
-    let parents: Vec<P> = parent_qs.fetch(pool).await?;
+    let parents: Vec<P> = parent_qs.fetch_on(pool).await?;
     if parents.is_empty() {
         return Ok(Vec::new());
     }
@@ -1184,7 +1146,7 @@ where
             crate::core::Op::In,
             crate::core::SqlValue::List(parent_pks),
         )
-        .fetch(pool)
+        .fetch_on(pool)
         .await?;
 
     // Group children by FK PK. Key is the `SqlValue::to_display_string`
@@ -1241,36 +1203,15 @@ pub trait HasPkValue {
     fn __rustango_pk_value_impl(&self) -> crate::core::SqlValue;
 }
 
-/// Extension trait that runs a `SELECT COUNT(*)` against the queryset's
-/// filters. Pulled in via `use rustango::sql::Counter;`.
 #[cfg(feature = "postgres")]
-pub trait Counter<T: Model + Send> {
-    /// Count rows matching the queryset's filters.
+impl<T: Model + Send> QuerySet<T> {
+    /// Count rows matching the queryset's filters. Issue #270 / T1.8
+    /// wave 3 — replaces the `Counter` extension trait (deleted).
+    /// Accepts any sqlx executor (`&PgPool` or `&mut PgConnection` for
+    /// tenancy-scoped reads), same as [`Self::fetch_on`].
     ///
     /// # Errors
     /// Returns [`ExecError`] for schema, SQL-writing, or driver failures.
-    fn count(
-        self,
-        pool: &PgPool,
-    ) -> impl std::future::Future<Output = Result<i64, ExecError>> + Send;
-}
-
-#[cfg(feature = "postgres")]
-impl<T: Model + Send> Counter<T> for QuerySet<T> {
-    async fn count(self, pool: &PgPool) -> Result<i64, ExecError> {
-        self.count_on(pool).await
-    }
-}
-
-#[cfg(feature = "postgres")]
-impl<T: Model + Send> QuerySet<T> {
-    /// Like [`Counter::count`] but accepts any sqlx executor — for
-    /// tenant-scoped counts against a connection that has the
-    /// `search_path` already set. See [`QuerySet::fetch_on`] for the
-    /// rationale.
-    ///
-    /// # Errors
-    /// As [`Counter::count`].
     pub async fn count_on<'c, E>(self, executor: E) -> Result<i64, ExecError>
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
@@ -1587,45 +1528,39 @@ pub async fn explain_pool(
 ///
 /// Pulled in via `use rustango::sql::Deleter;`.
 #[cfg(feature = "postgres")]
-pub trait Deleter<T: Model + Send> {
-    /// Delete every row matching the queryset's filters. Returns rows affected.
+#[cfg(feature = "postgres")]
+impl<T: Model + Send> QuerySet<T> {
+    /// Bulk-DELETE every row matching this queryset's filters. Issue
+    /// #270 / T1.8 wave 3 — replaces the `Deleter` extension trait
+    /// (deleted). Accepts any sqlx executor (`&PgPool` or `&mut
+    /// PgConnection` for tenancy-scoped writes), same as
+    /// [`Self::fetch_on`]. Returns rows affected.
     ///
     /// # Errors
     /// Returns [`ExecError`] for schema, SQL-writing, or driver failures.
-    fn delete(
-        self,
-        pool: &PgPool,
-    ) -> impl std::future::Future<Output = Result<u64, ExecError>> + Send;
-}
-
-#[cfg(feature = "postgres")]
-impl<T: Model + Send> Deleter<T> for QuerySet<T> {
-    async fn delete(self, pool: &PgPool) -> Result<u64, ExecError> {
+    pub async fn delete_on<'c, E>(self, executor: E) -> Result<u64, ExecError>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+    {
         let query = self.compile_delete()?;
-        delete_on(pool, &query).await
+        delete_on(executor, &query).await
     }
 }
 
-/// Extension trait that drives an `UpdateBuilder` to a bulk `UPDATE`.
-///
-/// Pulled in via `use rustango::sql::Updater;`.
 #[cfg(feature = "postgres")]
-pub trait Updater<T: Model + Send> {
-    /// Compile and execute the update. Returns rows affected.
+impl<T: Model + Send> UpdateBuilder<T> {
+    /// Compile + execute this `UpdateBuilder` against any sqlx
+    /// executor. Issue #270 / T1.8 wave 3 — replaces the `Updater`
+    /// extension trait (deleted). Returns rows affected.
     ///
     /// # Errors
     /// Returns [`ExecError`] for schema, SQL-writing, or driver failures.
-    fn execute(
-        self,
-        pool: &PgPool,
-    ) -> impl std::future::Future<Output = Result<u64, ExecError>> + Send;
-}
-
-#[cfg(feature = "postgres")]
-impl<T: Model + Send> Updater<T> for UpdateBuilder<T> {
-    async fn execute(self, pool: &PgPool) -> Result<u64, ExecError> {
+    pub async fn execute_on<'c, E>(self, executor: E) -> Result<u64, ExecError>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+    {
         let query = self.compile()?;
-        update_on(pool, &query).await
+        update_on(executor, &query).await
     }
 }
 

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -57,7 +57,7 @@ pub use executor::{
 pub use executor::{
     annotate_count_children, annotate_count_children_on, bulk_insert_on, delete_on,
     fetch_aggregate_on, fetch_with_prefetch, insert_on, insert_returning_on, raw_query_on,
-    row_to_json, select_one_row_on, select_rows_on, update_on, Counter, Deleter, Fetcher, Updater,
+    row_to_json, select_one_row_on, select_rows_on, update_on,
 };
 
 #[cfg(feature = "mysql")]

--- a/crates/rustango/src/tenancy/manage/migrate_storage.rs
+++ b/crates/rustango/src/tenancy/manage/migrate_storage.rs
@@ -57,7 +57,6 @@ use std::io::Write;
 use std::process::Stdio;
 
 use crate::core::Column as _;
-use crate::sql::Fetcher;
 use crate::tenancy::error::TenancyError;
 use crate::tenancy::manage::args::{next_value, quote_ident};
 use crate::tenancy::org::{Org, StorageMode};
@@ -87,7 +86,7 @@ pub(super) async fn migrate_tenant_storage_cmd<W: Write + Send>(
     // 1. Look up the Org row.
     let mut orgs: Vec<Org> = Org::objects()
         .where_(Org::slug.eq(parsed.slug.clone()))
-        .fetch(pools.registry())
+        .fetch_on(pools.registry())
         .await?;
     let mut org = orgs
         .pop()

--- a/crates/rustango/src/tenancy/migrate.rs
+++ b/crates/rustango/src/tenancy/migrate.rs
@@ -59,8 +59,6 @@ use crate::migrate;
 use crate::sql::sqlx::postgres::PgPoolOptions;
 #[cfg(feature = "postgres")]
 use crate::sql::sqlx::PgPool;
-#[cfg(feature = "postgres")]
-use crate::sql::Fetcher;
 use sqlx::Database;
 
 use super::error::TenancyError;
@@ -336,7 +334,7 @@ pub async fn migrate_tenants(
 
     let orgs: Vec<Org> = Org::objects()
         .where_(Org::active.eq(true))
-        .fetch(pools.registry())
+        .fetch_on(pools.registry())
         .await?;
 
     info!(

--- a/crates/rustango/tests/adhoc_joins_live.rs
+++ b/crates/rustango/tests/adhoc_joins_live.rs
@@ -9,7 +9,7 @@ use std::sync::OnceLock;
 
 use rustango::core::joins::aliased;
 use rustango::core::{Filter, Join, JoinKind, Model as _, Op, SqlValue, WhereExpr};
-use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -123,7 +123,7 @@ async fn inner_join_with_extra_predicate_filters_outer_rows() {
     let posts: Vec<Post> = Post::objects()
         .join(join)
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
 
@@ -163,7 +163,7 @@ async fn left_join_preserves_outer_rows_without_match() {
     let posts: Vec<Post> = Post::objects()
         .join(join)
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
 

--- a/crates/rustango/tests/auth_live.rs
+++ b/crates/rustango/tests/auth_live.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use rustango::core::Column as _;
 use rustango::migrate as rmig;
-use rustango::sql::{sqlx, Fetcher};
+use rustango::sql::sqlx;
 use rustango::tenancy::{
     authenticate_operator, authenticate_user, manage, password, Org, TenantPools,
 };
@@ -27,7 +27,7 @@ fn live_lock() -> &'static Mutex<()> {
 async fn lookup_org(pool: &sqlx::PgPool, slug: &str) -> Org {
     let mut rows: Vec<Org> = Org::objects()
         .where_(Org::slug.eq(slug.to_owned()))
-        .fetch(pool)
+        .fetch_on(pool)
         .await
         .unwrap();
     rows.pop().expect("org should exist")

--- a/crates/rustango/tests/branding_live.rs
+++ b/crates/rustango/tests/branding_live.rs
@@ -11,7 +11,7 @@ use axum::body::Body;
 use axum::http::header;
 use axum::http::Request;
 use rustango::core::Column as _;
-use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::sql::{sqlx, Auto};
 use rustango::tenancy::admin::TenantAdminBuilder;
 use rustango::tenancy::operator_console::{router_with_pools, SessionSecret};
 use rustango::tenancy::{branding, HeaderResolver, Org, StorageMode, TenantPools};
@@ -197,7 +197,7 @@ async fn upload_then_serve_round_trip() {
     // Org row picked up the new logo_path.
     let updates: Vec<Org> = Org::objects()
         .where_(Org::slug.eq(slug.clone()))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     let updated = updates.into_iter().next().expect("org row exists");

--- a/crates/rustango/tests/case_expressions_live.rs
+++ b/crates/rustango/tests/case_expressions_live.rs
@@ -11,7 +11,7 @@ use std::sync::OnceLock;
 use rustango::core::case::{case, value};
 use rustango::core::funcs::lower;
 use rustango::core::{Column as _, F};
-use rustango::sql::{sqlx, Auto, Fetcher, Updater};
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -99,13 +99,13 @@ async fn case_writes_branch_value_per_row() {
                 .when(Post::status.eq("draft"), value("Draft"))
                 .default(value("Live")),
         )
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
     let rows: Vec<Post> = Post::objects()
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     let labels: Vec<&str> = rows.iter().map(|p| p.label.as_str()).collect();
@@ -142,13 +142,13 @@ async fn case_drives_a_derived_ordering_column() {
                 .when(Post::status.eq("draft"), 2_i64)
                 .default(99_i64),
         )
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
     let ordered: Vec<Post> = Post::objects()
         .order_by(&[("priority", false), ("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     let statuses: Vec<&str> = ordered.iter().map(|p| p.status.as_str()).collect();
@@ -186,13 +186,13 @@ async fn case_with_function_in_then_branch_executes() {
                 .when(Post::status.eq("draft"), lower(F("title")))
                 .default(F("title")),
         )
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
     let rows: Vec<Post> = Post::objects()
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     // First row has status='draft', title='First Draft', should land as 'first draft'.
@@ -232,13 +232,13 @@ async fn case_with_and_or_predicate_executes() {
                 .when(Post::status.eq("published"), value("live"))
                 .default(value("pending")),
         )
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
     let rows: Vec<Post> = Post::objects()
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     // Row 1 draft → pending, row 2 review → pending,
@@ -273,13 +273,13 @@ async fn case_without_else_returns_null_for_unmatched_rows() {
             "maybe_label",
             case().when(Post::status.eq("draft"), value("Draft")),
         )
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
     let rows: Vec<Post> = Post::objects()
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     // Row 1 (draft) hits the WHEN branch; rows 2-4 fall through and

--- a/crates/rustango/tests/database_functions_live.rs
+++ b/crates/rustango/tests/database_functions_live.rs
@@ -10,7 +10,7 @@ use std::sync::OnceLock;
 
 use rustango::core::funcs::{coalesce, concat, length, lower, round_to, upper};
 use rustango::core::F;
-use rustango::sql::{sqlx, Auto, Fetcher, Updater};
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -73,11 +73,15 @@ async fn lower_upper_length_update_round_trip() {
         .eq("id", id)
         .update()
         .set_expr("name", lower(F("name")))
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
-    let after: Vec<FnDemo> = FnDemo::objects().eq("id", id).fetch(&pool).await.unwrap();
+    let after: Vec<FnDemo> = FnDemo::objects()
+        .eq("id", id)
+        .fetch_on(&pool)
+        .await
+        .unwrap();
     assert_eq!(after[0].name, "mixed case name");
 
     sqlx::query(r#"DROP TABLE IF EXISTS "fn_demo" CASCADE"#)
@@ -107,11 +111,15 @@ async fn concat_with_literal_separator_actually_concatenates() {
         .eq("id", id)
         .update()
         .set_expr("name", concat([F("name").into(), "-suffix".into()]))
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
-    let after: Vec<FnDemo> = FnDemo::objects().eq("id", id).fetch(&pool).await.unwrap();
+    let after: Vec<FnDemo> = FnDemo::objects()
+        .eq("id", id)
+        .fetch_on(&pool)
+        .await
+        .unwrap();
     assert_eq!(after[0].name, "prefix-suffix");
 
     sqlx::query(r#"DROP TABLE IF EXISTS "fn_demo" CASCADE"#)
@@ -140,11 +148,11 @@ async fn coalesce_picks_first_non_null() {
     FnDemo::objects()
         .update()
         .set_expr("name", coalesce([F("name").into(), "fallback".into()]))
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
-    let after: Vec<FnDemo> = FnDemo::objects().fetch(&pool).await.unwrap();
+    let after: Vec<FnDemo> = FnDemo::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(after[0].name, "keep");
 
     sqlx::query(r#"DROP TABLE IF EXISTS "fn_demo" CASCADE"#)
@@ -173,11 +181,11 @@ async fn round_to_two_places_works_on_double() {
     FnDemo::objects()
         .update()
         .set_expr("score", round(F("score")))
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
-    let after: Vec<FnDemo> = FnDemo::objects().fetch(&pool).await.unwrap();
+    let after: Vec<FnDemo> = FnDemo::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(after[0].score, 1.0); // 1.23456 → 1.0
 
     // round_to also compiles — we don't execute it on `double` (PG
@@ -208,11 +216,11 @@ async fn nested_function_call_executes() {
     FnDemo::objects()
         .update()
         .set_expr("name", upper(trim(F("name"))))
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
-    let after: Vec<FnDemo> = FnDemo::objects().fetch(&pool).await.unwrap();
+    let after: Vec<FnDemo> = FnDemo::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(after[0].name, "PADDED");
 
     // Bonus: LENGTH after the trim is 6, no padding.

--- a/crates/rustango/tests/date_functions_live.rs
+++ b/crates/rustango/tests/date_functions_live.rs
@@ -13,7 +13,7 @@ use rustango::core::funcs::{
     extract_month, extract_weekday, extract_year, now, trunc_date, trunc_month,
 };
 use rustango::core::F;
-use rustango::sql::{sqlx, Auto, Dialect, Fetcher, Updater};
+use rustango::sql::{sqlx, Auto, Dialect};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -76,8 +76,7 @@ async fn now_assigns_server_timestamp() {
     // Insert a row with a known-old timestamp.
     sqlx::query(
         r#"INSERT INTO "dt_signup" ("username", "created_at") VALUES ('alice', '2020-01-01 00:00:00+00')"#,
-    )
-    .execute(&pool)
+    ).execute(&pool)
     .await
     .unwrap();
 
@@ -85,12 +84,12 @@ async fn now_assigns_server_timestamp() {
     Signup::objects()
         .update()
         .set_expr("created_at", now())
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
     // Re-fetch and confirm the timestamp moved forward (year != 2020).
-    let rows: Vec<Signup> = Signup::objects().fetch(&pool).await.unwrap();
+    let rows: Vec<Signup> = Signup::objects().fetch_on(&pool).await.unwrap();
     let year_now = chrono::Utc::now().date_naive().format("%Y").to_string();
     let year_row = rows[0].created_at.date_naive().format("%Y").to_string();
     assert_eq!(year_row, year_now, "NOW() should set current year");
@@ -113,8 +112,7 @@ async fn extract_year_and_month_pull_components_out_of_timestamp() {
     // extracted ints are stable.
     sqlx::query(
         r#"INSERT INTO "dt_signup" ("username", "created_at") VALUES ('bob', '2024-03-15 14:30:00+00')"#,
-    )
-    .execute(&pool)
+    ).execute(&pool)
     .await
     .unwrap();
 
@@ -123,17 +121,17 @@ async fn extract_year_and_month_pull_components_out_of_timestamp() {
     Signup::objects()
         .update()
         .set_expr("bucket_year", extract_year(F("created_at")))
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
     Signup::objects()
         .update()
         .set_expr("bucket_month", extract_month(F("created_at")))
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
-    let rows: Vec<Signup> = Signup::objects().fetch(&pool).await.unwrap();
+    let rows: Vec<Signup> = Signup::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(rows[0].bucket_year, 2024);
     assert_eq!(rows[0].bucket_month, 3);
 
@@ -183,13 +181,13 @@ async fn count_signups_by_month_headline_acceptance() {
     Signup::objects()
         .update()
         .set_expr("bucket_year", extract_year(F("created_at")))
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
     Signup::objects()
         .update()
         .set_expr("bucket_month", extract_month(F("created_at")))
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
@@ -240,8 +238,7 @@ async fn trunc_date_and_trunc_month_smoke_check() {
 
     sqlx::query(
         r#"INSERT INTO "dt_signup" ("username", "created_at") VALUES ('x', '2024-07-15 13:45:00+00')"#,
-    )
-    .execute(&pool)
+    ).execute(&pool)
     .await
     .unwrap();
 
@@ -319,7 +316,7 @@ async fn cookbook_store_then_filter_by_weekday_pattern() {
     Signup::objects()
         .update()
         .set_expr("weekday", extract_weekday(F("created_at")))
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
@@ -329,7 +326,7 @@ async fn cookbook_store_then_filter_by_weekday_pattern() {
     use rustango::core::Column as _;
     let fridays: Vec<Signup> = Signup::objects()
         .where_(Signup::weekday.eq(5_i64))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(fridays.len(), 1, "expected exactly 1 Friday");
@@ -340,7 +337,7 @@ async fn cookbook_store_then_filter_by_weekday_pattern() {
     // EXTRACT(DOW) emitter regressing to MySQL's 1-indexed shape.
     let by_day: Vec<Signup> = Signup::objects()
         .order_by(&[("weekday", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(by_day[0].weekday, 0, "Sunday must be 0");
@@ -373,8 +370,7 @@ async fn cookbook_rust_computed_year_boundary_pattern() {
     let two_years_ago = this_year - 2;
     sqlx::query(&format!(
         r#"INSERT INTO "dt_signup" ("username", "created_at") VALUES ('old', '{two_years_ago}-06-15 12:00:00+00'), ('new', '{this_year}-06-15 12:00:00+00')"#
-    ))
-    .execute(&pool)
+    )).execute(&pool)
     .await
     .unwrap();
 
@@ -391,7 +387,7 @@ async fn cookbook_rust_computed_year_boundary_pattern() {
     use rustango::core::Column as _;
     let recent: Vec<Signup> = Signup::objects()
         .where_(Signup::created_at.gte(year_start))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(recent.len(), 1, "only 'new' should match this-year filter");

--- a/crates/rustango/tests/f_expressions_live.rs
+++ b/crates/rustango/tests/f_expressions_live.rs
@@ -28,7 +28,7 @@
 use std::sync::OnceLock;
 
 use rustango::core::{Column as _, F};
-use rustango::sql::{sqlx, Auto, Fetcher, Updater};
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -106,7 +106,7 @@ async fn f_expression_increment_is_atomic_under_concurrent_load() {
                 .eq("id", id)
                 .update()
                 .set_expr("views", F("views") + 1_i64)
-                .execute(&pool)
+                .execute_on(&pool)
                 .await
                 .expect("update succeeds");
         }));
@@ -118,7 +118,7 @@ async fn f_expression_increment_is_atomic_under_concurrent_load() {
     // Re-fetch and assert the counter equals N — no lost updates.
     let posts: Vec<Post> = Post::objects()
         .where_(Post::id.eq(id))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(posts.len(), 1);
@@ -160,7 +160,7 @@ async fn f_expression_column_to_column_compare_filters_correctly() {
     // `views > 2` — sanity literal compare baseline.
     let high: Vec<Post> = Post::objects()
         .where_(Post::views.gt(2_i64))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     // Expected matches: "ab" (10) and "abc" (3) = 2 rows.
@@ -170,7 +170,7 @@ async fn f_expression_column_to_column_compare_filters_correctly() {
     // Proves the column-vs-column path emits the right SQL with no params.
     let all: Vec<Post> = Post::objects()
         .where_(Post::views.gte_expr(F("views")))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(all.len(), 4, "self-compare matches every row: {all:?}");

--- a/crates/rustango/tests/filter_lookup_live.rs
+++ b/crates/rustango/tests/filter_lookup_live.rs
@@ -9,7 +9,7 @@
 use std::sync::OnceLock;
 
 use rustango::core::SqlValue;
-use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -86,7 +86,7 @@ async fn live_bare_field_eq() {
 
     let rows: Vec<Post> = Post::objects()
         .filter("status", "published")
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 3, "three published rows");
@@ -105,7 +105,7 @@ async fn live_gt_lt_comparisons() {
 
     let rows: Vec<Post> = Post::objects()
         .filter("views__gt", 50_i64)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 2, "two rows with views > 50");
@@ -113,7 +113,7 @@ async fn live_gt_lt_comparisons() {
 
     let rows: Vec<Post> = Post::objects()
         .filter("views__lte", 10_i64)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 2, "two rows with views <= 10");
@@ -133,7 +133,7 @@ async fn live_icontains_matches_case_insensitively() {
     // → "Hello Rust", "Goodbye Rust", "Rusty Spoon".
     let rows: Vec<Post> = Post::objects()
         .filter("title__icontains", "rust")
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     let titles: Vec<&str> = rows.iter().map(|r| r.title.as_str()).collect();
@@ -155,7 +155,7 @@ async fn live_startswith_endswith() {
 
     let rows: Vec<Post> = Post::objects()
         .filter("title__startswith", "Hello")
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 2, "two titles start with 'Hello'");
@@ -163,7 +163,7 @@ async fn live_startswith_endswith() {
 
     let rows: Vec<Post> = Post::objects()
         .filter("title__endswith", "Rust")
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 2, "two titles end with 'Rust'");
@@ -185,7 +185,7 @@ async fn live_in_list_filters_match() {
             "author_id__in",
             SqlValue::List(vec![SqlValue::I64(1), SqlValue::I64(3)]),
         )
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 3, "authors 1 and 3 own three rows total");
@@ -204,7 +204,7 @@ async fn live_isnull_true_and_false() {
 
     let live_rows: Vec<Post> = Post::objects()
         .filter("deleted_at__isnull", true)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(live_rows.len(), 3, "three non-deleted rows");
@@ -212,7 +212,7 @@ async fn live_isnull_true_and_false() {
 
     let dead_rows: Vec<Post> = Post::objects()
         .filter("deleted_at__isnull", false)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(dead_rows.len(), 2, "two soft-deleted rows");
@@ -235,7 +235,7 @@ async fn live_between_range_alias() {
             "views__between",
             SqlValue::List(vec![SqlValue::I64(10), SqlValue::I64(100)]),
         )
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 3, "views in [10,100] hits 3 rows");
@@ -247,7 +247,7 @@ async fn live_between_range_alias() {
             "views__range",
             SqlValue::List(vec![SqlValue::I64(10), SqlValue::I64(100)]),
         )
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 3);
@@ -267,7 +267,7 @@ async fn live_multi_filter_and_chain() {
         .filter("status", "published")
         .filter("views__gt", 50_i64)
         .filter("title__icontains", "rust")
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(

--- a/crates/rustango/tests/foreign_key_live.rs
+++ b/crates/rustango/tests/foreign_key_live.rs
@@ -19,7 +19,7 @@
 use std::sync::OnceLock;
 
 use rustango::core::Op;
-use rustango::sql::{sqlx, Auto, ExecError, Fetcher, ForeignKey};
+use rustango::sql::{sqlx, Auto, ExecError, ForeignKey};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -113,7 +113,7 @@ async fn fetched_book_has_unloaded_fk_then_get_resolves_parent() {
     // Round-trip via fetch — confirms FromRow lands in Unloaded.
     let mut fetched: Vec<Book> = Book::objects()
         .filter_op("id", Op::Eq, book.id)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(fetched.len(), 1);
@@ -261,7 +261,7 @@ async fn string_pk_fk_round_trips_with_lazy_load() {
     // Round-trip through fetch — confirms FromRow decodes a String FK.
     let mut rows: Vec<StrPost> = StrPost::objects()
         .filter_op("id", Op::Eq, post.id)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     let mut fetched = rows.pop().expect("post round-trip");
@@ -380,7 +380,7 @@ async fn nullable_fk_round_trip_with_some_and_none() {
 
     let rows: Vec<NlBook> = NlBook::objects()
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 2);
@@ -481,7 +481,7 @@ async fn i16_field_round_trips_against_smallint() {
 
     let rows: Vec<StatusRow> = StatusRow::objects()
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 3);

--- a/crates/rustango/tests/generated_columns_live.rs
+++ b/crates/rustango/tests/generated_columns_live.rs
@@ -8,7 +8,7 @@
 #![cfg(feature = "tenancy")]
 
 use rustango::core::Column as _;
-use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::sql::{sqlx, Auto};
 
 #[derive(rustango::Model, Debug, Clone)]
 #[rustango(table = "_gen_invoice")]
@@ -72,7 +72,7 @@ async fn generated_column_is_computed_on_insert() {
     // GENERATED column normally, so `total` should be 9.99 * 4.
     let rows: Vec<Invoice> = Invoice::objects()
         .where_(Invoice::id.eq(id))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -98,7 +98,7 @@ async fn generated_column_is_computed_on_insert() {
     let wrong_id = *wrong.id.get().unwrap();
     let rows: Vec<Invoice> = Invoice::objects()
         .where_(Invoice::id.eq(wrong_id))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     let approx = (rows[0].total - 20.0).abs() < 1e-6;
@@ -142,7 +142,7 @@ async fn generated_column_is_recomputed_on_update() {
 
     let rows: Vec<Invoice> = Invoice::objects()
         .where_(Invoice::id.eq(id))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     let approx = (rows[0].total - 30.0).abs() < 1e-6;

--- a/crates/rustango/tests/live_pg.rs
+++ b/crates/rustango/tests/live_pg.rs
@@ -11,7 +11,7 @@
 use std::sync::OnceLock;
 
 use rustango::core::{Column as _, Op, QueryError, SqlValue};
-use rustango::sql::{sqlx, Counter, Deleter, ExecError, Fetcher, Updater};
+use rustango::sql::{sqlx, ExecError};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -99,7 +99,7 @@ async fn read_pipeline_filters_and_in_clause() {
 
     let actives: Vec<LiveUser> = LiveUser::objects()
         .filter_op("is_active", Op::Eq, true)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     let mut names: Vec<&str> = actives.iter().map(|u| u.name.as_str()).collect();
@@ -113,14 +113,14 @@ async fn read_pipeline_filters_and_in_clause() {
             Op::In,
             SqlValue::List(vec![SqlValue::I64(1), SqlValue::I64(3)]),
         )
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     let mut ids: Vec<i64> = picked.iter().map(|u| u.id).collect();
     ids.sort_unstable();
     assert_eq!(ids, vec![1, 3]);
 
-    let all: Vec<LiveUser> = LiveUser::objects().fetch(&pool).await.unwrap();
+    let all: Vec<LiveUser> = LiveUser::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(all.len(), 3);
 }
 
@@ -135,14 +135,14 @@ async fn bulk_update_changes_only_matching_rows() {
         .eq("name", "alice")
         .update()
         .set("is_active", false)
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
     assert_eq!(affected, 1);
 
     let alice = LiveUser::objects()
         .eq("id", 1_i64)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(alice.len(), 1);
@@ -151,13 +151,13 @@ async fn bulk_update_changes_only_matching_rows() {
     // Bob & Carol untouched.
     let bob = LiveUser::objects()
         .eq("id", 2_i64)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert!(!bob[0].is_active); // bob was already inactive
     let carol = LiveUser::objects()
         .eq("id", 3_i64)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert!(carol[0].is_active);
@@ -173,12 +173,12 @@ async fn bulk_update_with_no_filter_touches_every_row() {
     let affected = LiveUser::objects()
         .update()
         .set("is_active", true)
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
     assert_eq!(affected, 3);
 
-    let all: Vec<LiveUser> = LiveUser::objects().fetch(&pool).await.unwrap();
+    let all: Vec<LiveUser> = LiveUser::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(all.len(), 3);
     assert!(all.iter().all(|u| u.is_active));
 }
@@ -195,14 +195,14 @@ async fn bulk_update_with_multiple_set_columns() {
         .update()
         .set("name", "BOB")
         .set("is_active", true)
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
     assert_eq!(affected, 1);
 
     let bob = LiveUser::objects()
         .eq("id", 2_i64)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(bob.len(), 1);
@@ -221,7 +221,7 @@ async fn bulk_update_matching_zero_rows_returns_zero() {
         .eq("id", 999_i64)
         .update()
         .set("is_active", false)
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
     assert_eq!(affected, 0);
@@ -237,7 +237,7 @@ async fn bulk_delete_removes_matching_rows() {
 
     let affected = LiveUser::objects()
         .eq("is_active", false)
-        .delete(&pool)
+        .delete_on(&pool)
         .await
         .unwrap();
     assert_eq!(affected, 1);
@@ -245,7 +245,7 @@ async fn bulk_delete_removes_matching_rows() {
 
     // Remaining rows are alice and carol.
     let mut remaining: Vec<i64> = LiveUser::objects()
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap()
         .into_iter()
@@ -268,12 +268,12 @@ async fn bulk_delete_with_in_clause_removes_listed_rows() {
             Op::In,
             SqlValue::List(vec![SqlValue::I64(1), SqlValue::I64(3)]),
         )
-        .delete(&pool)
+        .delete_on(&pool)
         .await
         .unwrap();
     assert_eq!(affected, 2);
 
-    let remaining: Vec<LiveUser> = LiveUser::objects().fetch(&pool).await.unwrap();
+    let remaining: Vec<LiveUser> = LiveUser::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(remaining.len(), 1);
     assert_eq!(remaining[0].id, 2);
 }
@@ -356,7 +356,7 @@ async fn insert_within_bounds_succeeds() {
     .await
     .unwrap();
 
-    let rows: Vec<BoundedUser> = BoundedUser::objects().fetch(&pool).await.unwrap();
+    let rows: Vec<BoundedUser> = BoundedUser::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].name, "alice");
     assert_eq!(rows[0].age, 30);
@@ -379,7 +379,7 @@ async fn insert_too_long_string_is_rejected_before_db() {
         ExecError::Query(QueryError::MaxLengthExceeded { max: 8, .. })
     ));
     // Confirm DB unchanged.
-    let rows: Vec<BoundedUser> = BoundedUser::objects().fetch(&pool).await.unwrap();
+    let rows: Vec<BoundedUser> = BoundedUser::objects().fetch_on(&pool).await.unwrap();
     assert!(rows.is_empty());
 }
 
@@ -446,7 +446,7 @@ async fn insert_at_inclusive_bounds_is_accepted() {
     .await
     .unwrap();
 
-    let rows: Vec<BoundedUser> = BoundedUser::objects().fetch(&pool).await.unwrap();
+    let rows: Vec<BoundedUser> = BoundedUser::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(rows.len(), 2);
 }
 
@@ -469,7 +469,7 @@ async fn update_too_long_string_is_rejected_before_db() {
         .eq("id", 7_i64)
         .update()
         .set("name", "this_is_way_too_long")
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap_err();
     assert!(matches!(
@@ -480,7 +480,7 @@ async fn update_too_long_string_is_rejected_before_db() {
     // Row unchanged.
     let rows: Vec<BoundedUser> = BoundedUser::objects()
         .eq("id", 7_i64)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows[0].name, "ok");
@@ -504,7 +504,7 @@ async fn update_out_of_range_age_is_rejected() {
     let err = BoundedUser::objects()
         .update()
         .set("age", 200_i32)
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap_err();
     assert!(matches!(
@@ -532,7 +532,7 @@ async fn filter_with_long_string_still_works_at_runtime() {
 
     let rows: Vec<BoundedUser> = BoundedUser::objects()
         .eq("name", "definitely_longer_than_eight")
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert!(rows.is_empty());
@@ -548,7 +548,7 @@ async fn typed_columns_drive_full_pipeline() {
     // Read with typed filters.
     let actives: Vec<LiveUser> = LiveUser::objects()
         .where_(LiveUser::is_active.eq(true))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     let mut names: Vec<&str> = actives.iter().map(|u| u.name.as_str()).collect();
@@ -558,7 +558,7 @@ async fn typed_columns_drive_full_pipeline() {
     // Typed IN.
     let picked: Vec<LiveUser> = LiveUser::objects()
         .where_(LiveUser::id.is_in([1_i64, 3]))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(picked.len(), 2);
@@ -569,14 +569,14 @@ async fn typed_columns_drive_full_pipeline() {
         .update()
         .set_typed(LiveUser::is_active.set(true))
         .set_typed(LiveUser::name.set("BOB"))
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
     assert_eq!(affected, 1);
 
     let bob: Vec<LiveUser> = LiveUser::objects()
         .where_(LiveUser::id.eq(2_i64))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(bob[0].name, "BOB");
@@ -585,7 +585,7 @@ async fn typed_columns_drive_full_pipeline() {
     // Typed delete.
     let affected = LiveUser::objects()
         .where_(LiveUser::id.eq(2_i64))
-        .delete(&pool)
+        .delete_on(&pool)
         .await
         .unwrap();
     assert_eq!(affected, 1);
@@ -604,7 +604,7 @@ async fn typed_filter_validates_at_compile_runtime_match() {
     let rows: Vec<LiveUser> = LiveUser::objects()
         .where_(LiveUser::is_active.eq(true))
         .filter_op("name", Op::Like, "alic%")
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -633,7 +633,7 @@ async fn full_crud_round_trip() {
         .update()
         .set("is_active", true)
         .set("name", "DAVE")
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
     assert_eq!(affected, 1);
@@ -641,7 +641,7 @@ async fn full_crud_round_trip() {
     // FETCH the updated row.
     let dave_fetched: Vec<LiveUser> = LiveUser::objects()
         .eq("id", 4_i64)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(dave_fetched.len(), 1);
@@ -651,7 +651,7 @@ async fn full_crud_round_trip() {
     // DELETE via QuerySet.
     let affected = LiveUser::objects()
         .eq("id", 4_i64)
-        .delete(&pool)
+        .delete_on(&pool)
         .await
         .unwrap();
     assert_eq!(affected, 1);
@@ -660,7 +660,7 @@ async fn full_crud_round_trip() {
     // Confirm gone.
     let gone: Vec<LiveUser> = LiveUser::objects()
         .eq("id", 4_i64)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert!(gone.is_empty());
@@ -675,7 +675,7 @@ async fn limit_caps_returned_rows() {
         return;
     };
 
-    let users = LiveUser::objects().limit(2).fetch(&pool).await.unwrap();
+    let users = LiveUser::objects().limit(2).fetch_on(&pool).await.unwrap();
     assert_eq!(users.len(), 2);
 }
 
@@ -687,7 +687,7 @@ async fn offset_skips_rows() {
     };
 
     // 3 seeded rows; offset 2 → just 1 left.
-    let users = LiveUser::objects().offset(2).fetch(&pool).await.unwrap();
+    let users = LiveUser::objects().offset(2).fetch_on(&pool).await.unwrap();
     assert_eq!(users.len(), 1);
 }
 
@@ -701,13 +701,13 @@ async fn limit_and_offset_compose_for_paging() {
     let page1 = LiveUser::objects()
         .limit(2)
         .offset(0)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     let page2 = LiveUser::objects()
         .limit(2)
         .offset(2)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(page1.len(), 2);
@@ -720,7 +720,7 @@ async fn count_returns_total_with_no_filter() {
     let Some(pool) = fresh_pool().await else {
         return;
     };
-    let n = LiveUser::objects().count(&pool).await.unwrap();
+    let n = LiveUser::objects().count_on(&pool).await.unwrap();
     assert_eq!(n, 3);
 }
 
@@ -733,7 +733,7 @@ async fn count_respects_filters_and_ignores_limit() {
 
     let actives = LiveUser::objects()
         .eq("is_active", true)
-        .count(&pool)
+        .count_on(&pool)
         .await
         .unwrap();
     assert_eq!(actives, 2);
@@ -742,7 +742,7 @@ async fn count_respects_filters_and_ignores_limit() {
     let n = LiveUser::objects()
         .limit(1)
         .offset(0)
-        .count(&pool)
+        .count_on(&pool)
         .await
         .unwrap();
     assert_eq!(n, 3);

--- a/crates/rustango/tests/manage_live.rs
+++ b/crates/rustango/tests/manage_live.rs
@@ -6,7 +6,7 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use rustango::sql::{sqlx, Fetcher};
+use rustango::sql::sqlx;
 use rustango::tenancy::{manage, Org, TenantPools};
 use rustango::{core::Column as _, migrate as rmig};
 
@@ -107,7 +107,7 @@ async fn create_tenant_inserts_row_creates_schema_and_runs_migrations() {
     // Org row landed.
     let rows: Vec<Org> = Org::objects()
         .where_(Org::slug.eq(slug.clone()))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -256,7 +256,7 @@ async fn drop_tenant_soft_deletes_with_confirm() {
 
     let rows: Vec<Org> = Org::objects()
         .where_(Org::slug.eq(slug.clone()))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1, "row preserved");

--- a/crates/rustango/tests/migrate_live.rs
+++ b/crates/rustango/tests/migrate_live.rs
@@ -8,7 +8,7 @@
 
 use rustango::core::Column as _;
 use rustango::migrate;
-use rustango::sql::{sqlx, Fetcher};
+use rustango::sql::sqlx;
 use rustango::{Auto, Model};
 use tokio::sync::Mutex;
 
@@ -88,11 +88,11 @@ async fn apply_all_creates_every_registered_table() {
     .await
     .unwrap();
 
-    let users: Vec<MigUser> = MigUser::objects().fetch(&pool).await.unwrap();
+    let users: Vec<MigUser> = MigUser::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(users.len(), 1);
     assert_eq!(users[0].name, "alice");
 
-    let posts: Vec<MigPost> = MigPost::objects().fetch(&pool).await.unwrap();
+    let posts: Vec<MigPost> = MigPost::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(posts.len(), 1);
     assert_eq!(posts[0].title, "hello");
 
@@ -233,7 +233,7 @@ async fn auto_pk_insert_populates_id_from_sequence() {
         "second insert should get a strictly-greater id; got alice={alice_id}, bob={bob_id}"
     );
 
-    let users: Vec<AutoUser> = AutoUser::objects().fetch(&pool).await.unwrap();
+    let users: Vec<AutoUser> = AutoUser::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(users.len(), 2);
 
     migrate::drop_all(&pool).await.unwrap();
@@ -284,7 +284,7 @@ async fn bulk_insert_non_auto_model_writes_n_rows_one_round_trip() {
 
     MigUser::bulk_insert(&rows, &pool).await.unwrap();
 
-    let fetched: Vec<MigUser> = MigUser::objects().fetch(&pool).await.unwrap();
+    let fetched: Vec<MigUser> = MigUser::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(fetched.len(), 10, "all 10 rows should be present");
 
     migrate::drop_all(&pool).await.unwrap();
@@ -319,7 +319,7 @@ async fn bulk_insert_auto_model_unset_path_populates_each_pk() {
         last = v;
     }
 
-    let fetched: Vec<AutoUser> = AutoUser::objects().fetch(&pool).await.unwrap();
+    let fetched: Vec<AutoUser> = AutoUser::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(fetched.len(), 5);
 
     migrate::drop_all(&pool).await.unwrap();
@@ -384,7 +384,7 @@ async fn bulk_insert_auto_model_mixed_set_unset_is_rejected() {
     );
 
     // No rows should have been inserted.
-    let fetched: Vec<AutoUser> = AutoUser::objects().fetch(&pool).await.unwrap();
+    let fetched: Vec<AutoUser> = AutoUser::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(fetched.len(), 0);
 
     migrate::drop_all(&pool).await.unwrap();
@@ -405,7 +405,7 @@ async fn bulk_insert_empty_slice_is_noop() {
     let empty_non_auto: Vec<MigUser> = Vec::new();
     MigUser::bulk_insert(&empty_non_auto, &pool).await.unwrap();
 
-    let fetched: Vec<AutoUser> = AutoUser::objects().fetch(&pool).await.unwrap();
+    let fetched: Vec<AutoUser> = AutoUser::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(fetched.len(), 0);
 
     migrate::drop_all(&pool).await.unwrap();
@@ -437,7 +437,7 @@ async fn apply_all_is_safe_to_call_after_drop_all() {
     .unwrap();
     let count = MigUser::objects()
         .where_(MigUser::id.eq(42_i64))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap()
         .len();

--- a/crates/rustango/tests/operator_console_orgs_edit_live.rs
+++ b/crates/rustango/tests/operator_console_orgs_edit_live.rs
@@ -23,7 +23,7 @@ use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
 use rustango::core::Column as _;
 use rustango::migrate as rmig;
-use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::sql::{sqlx, Auto};
 use rustango::tenancy::{
     operator_console::{router_with_pools, SessionSecret},
     Org, StorageMode, TenantPools,
@@ -250,7 +250,7 @@ async fn post_edit_updates_only_editable_fields() {
     // Re-fetch and assert.
     let row: Org = Org::objects()
         .where_(Org::slug.eq(slug.clone()))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap()
         .into_iter()
@@ -293,7 +293,7 @@ async fn post_edit_with_blank_database_url_keeps_existing() {
 
     let row: Org = Org::objects()
         .where_(Org::slug.eq(slug.clone()))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap()
         .into_iter()
@@ -334,7 +334,7 @@ async fn post_edit_active_toggle_off() {
 
     let row: Org = Org::objects()
         .where_(Org::slug.eq(slug.clone()))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap()
         .into_iter()

--- a/crates/rustango/tests/order_by_enhancements_live.rs
+++ b/crates/rustango/tests/order_by_enhancements_live.rs
@@ -10,7 +10,7 @@ use std::sync::OnceLock;
 
 use rustango::core::funcs::lower;
 use rustango::core::{NullsOrder, F};
-use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -76,7 +76,7 @@ async fn nulls_last_on_asc_groups_nulls_after_non_nulls() {
     let rows: Vec<Post> = Post::objects()
         .order_by_with_nulls(&[("score", false, NullsOrder::Last)])
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     // Scores ASC NULLS LAST → 10, 20, 30, NULL, NULL.
@@ -102,7 +102,7 @@ async fn nulls_first_on_desc_groups_nulls_first() {
     let rows: Vec<Post> = Post::objects()
         .order_by_with_nulls(&[("score", true, NullsOrder::First)])
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     // Scores DESC NULLS FIRST → NULL, NULL, 30, 20, 10.
@@ -129,7 +129,7 @@ async fn order_by_expr_lower_title_sorts_case_insensitively() {
 
     let rows: Vec<Post> = Post::objects()
         .order_by_expr(lower(F("title")), false)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     let titles: Vec<&str> = rows.iter().map(|p| p.title.as_str()).collect();

--- a/crates/rustango/tests/order_random_live.rs
+++ b/crates/rustango/tests/order_random_live.rs
@@ -9,7 +9,7 @@
 
 use std::sync::OnceLock;
 
-use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -63,7 +63,7 @@ async fn fresh(pool: &sqlx::PgPool) {
     .unwrap();
 }
 
-/// Two consecutive `order_random().limit(10).fetch(...)` calls must
+/// Two consecutive `order_random().limit(10).fetch_on(...)` calls must
 /// return different orderings with overwhelming probability. If they
 /// match, RANDOM() is broken (or the writer is emitting a sort key
 /// other than RANDOM()).
@@ -78,13 +78,13 @@ async fn order_random_returns_different_orderings_across_calls() {
     let draw_a: Vec<Post> = Post::objects()
         .order_random()
         .limit(10)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     let draw_b: Vec<Post> = Post::objects()
         .order_random()
         .limit(10)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(draw_a.len(), 10, "draw a should have 10 rows");
@@ -114,7 +114,7 @@ async fn order_random_with_limit_returns_distinct_rows() {
     let rows: Vec<Post> = Post::objects()
         .order_random()
         .limit(15)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 15);

--- a/crates/rustango/tests/org_live.rs
+++ b/crates/rustango/tests/org_live.rs
@@ -9,7 +9,7 @@
 
 use rustango::core::Column as _;
 use rustango::migrate;
-use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::sql::{sqlx, Auto};
 use rustango::tenancy::{Org, StorageMode};
 
 use tokio::sync::Mutex;
@@ -72,7 +72,7 @@ async fn org_round_trip_insert_and_fetch() {
     let acme_id = *acme.id.get().unwrap();
     assert!(acme_id > 0, "BIGSERIAL should assign a positive id");
 
-    let fetched: Vec<Org> = Org::objects().fetch(&pool).await.unwrap();
+    let fetched: Vec<Org> = Org::objects().fetch_on(&pool).await.unwrap();
     assert_eq!(fetched.len(), 1);
     assert_eq!(fetched[0].slug, "acme");
     assert_eq!(fetched[0].storage_mode, "schema");
@@ -117,7 +117,7 @@ async fn org_filter_by_slug_returns_single_match() {
 
     let matches: Vec<Org> = Org::objects()
         .where_(Org::slug.eq("globex"))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(matches.len(), 1);
@@ -131,7 +131,7 @@ async fn org_filter_by_slug_returns_single_match() {
 
     let actives: Vec<Org> = Org::objects()
         .where_(Org::active.eq(true))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(actives.len(), 3);
@@ -175,7 +175,7 @@ async fn org_inactive_orgs_are_persistable_and_queryable() {
 
     let fetched: Vec<Org> = Org::objects()
         .where_(Org::active.eq(false))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(fetched.len(), 1);

--- a/crates/rustango/tests/permissions_upsert_live.rs
+++ b/crates/rustango/tests/permissions_upsert_live.rs
@@ -17,7 +17,7 @@
 
 use rustango::core::Column as _;
 use rustango::sql::sqlx;
-use rustango::sql::{Auto, Fetcher};
+use rustango::sql::Auto;
 use rustango::tenancy::permissions::{
     assign_role, get_or_create_role, grant_role_perm, set_user_perm, RolePermission,
     UserPermission, UserRole,
@@ -115,7 +115,7 @@ async fn grant_role_perm_is_idempotent_via_on_conflict_do_nothing() {
     let rows: Vec<RolePermission> = RolePermission::objects()
         .where_(RolePermission::role_id.eq(role_id))
         .where_(RolePermission::codename.eq("post.add"))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(
@@ -145,7 +145,7 @@ async fn assign_role_is_idempotent_via_on_conflict_do_nothing() {
     let rows: Vec<UserRole> = UserRole::objects()
         .where_(UserRole::user_id.eq(user_id))
         .where_(UserRole::role_id.eq(role_id))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1, "two assigns should leave one row");
@@ -170,7 +170,7 @@ async fn set_user_perm_flips_existing_row_via_on_conflict_do_update() {
     let rows: Vec<UserPermission> = UserPermission::objects()
         .where_(UserPermission::user_id.eq(user_id))
         .where_(UserPermission::codename.eq(codename))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1, "first call should insert one row");
@@ -186,7 +186,7 @@ async fn set_user_perm_flips_existing_row_via_on_conflict_do_update() {
     let rows: Vec<UserPermission> = UserPermission::objects()
         .where_(UserPermission::user_id.eq(user_id))
         .where_(UserPermission::codename.eq(codename))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1, "second call should NOT insert a duplicate");

--- a/crates/rustango/tests/q_xor_live.rs
+++ b/crates/rustango/tests/q_xor_live.rs
@@ -7,7 +7,7 @@
 use std::sync::OnceLock;
 
 use rustango::core::Column as _;
-use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -88,7 +88,7 @@ async fn binary_xor_matches_exactly_one_true() {
 
     let rows: Vec<Person> = Person::objects()
         .where_(Person::name.eq("alice").xor(Person::active.eq(true)))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
 
@@ -115,7 +115,7 @@ async fn ternary_xor_matches_odd_parity() {
                 .xor(Person::active.eq(true))
                 .xor(Person::age.gte(40_i32)),
         )
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
 

--- a/crates/rustango/tests/save_live.rs
+++ b/crates/rustango/tests/save_live.rs
@@ -12,7 +12,7 @@
 use std::sync::OnceLock;
 
 use rustango::core::Op;
-use rustango::sql::{sqlx, Auto, Counter, Fetcher};
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -72,7 +72,7 @@ async fn save_inserts_when_pk_unset_and_populates_it() {
     t.save(&pool).await.unwrap();
 
     assert!(matches!(t.id, Auto::Set(_)));
-    assert_eq!(Thing::objects().count(&pool).await.unwrap(), 1);
+    assert_eq!(Thing::objects().count_on(&pool).await.unwrap(), 1);
 }
 
 #[tokio::test]
@@ -105,13 +105,13 @@ async fn save_updates_when_pk_set_without_changing_pk() {
 
     let fetched: Vec<Thing> = Thing::objects()
         .filter_op("id", Op::Eq, after_id)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(fetched.len(), 1);
     assert_eq!(fetched[0].label, "beta");
     assert_eq!(fetched[0].count, 42);
-    assert_eq!(Thing::objects().count(&pool).await.unwrap(), 1);
+    assert_eq!(Thing::objects().count_on(&pool).await.unwrap(), 1);
 }
 
 #[tokio::test]
@@ -128,5 +128,5 @@ async fn save_with_set_pk_matching_no_row_is_silent_ok() {
     };
     t.save(&pool).await.unwrap();
 
-    assert_eq!(Thing::objects().count(&pool).await.unwrap(), 0);
+    assert_eq!(Thing::objects().count_on(&pool).await.unwrap(), 0);
 }

--- a/crates/rustango/tests/select_for_update_live.rs
+++ b/crates/rustango/tests/select_for_update_live.rs
@@ -172,12 +172,12 @@ async fn select_for_update_against_bare_pool_runs_cleanly() {
         return;
     };
 
-    use rustango::sql::Fetcher as _;
+    // Fetcher trait deleted in T1.8 wave 3 — fetch_on is inherent on QuerySet.
     let rows: Vec<Job> = Job::objects()
         .where_(Job::status.eq("pending"))
         .select_for_update()
         .skip_locked()
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     // No other tx is competing — all 3 pending rows come back.

--- a/crates/rustango/tests/self_fk_live.rs
+++ b/crates/rustango/tests/self_fk_live.rs
@@ -23,7 +23,7 @@
 //! Reads DATABASE_URL; skips silently if unset.
 
 use rustango::core::{Model as _, Op};
-use rustango::sql::{sqlx, Auto, Fetcher};
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 
 #[derive(Model, Debug, Clone)]
@@ -123,7 +123,7 @@ async fn live_self_fk_round_trip() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut root_children: Vec<Page> = Page::objects()
         .filter_op("parent_id", Op::Eq, root_id)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await?;
     root_children.sort_by(|a, b| a.title.cmp(&b.title));
     assert_eq!(root_children.len(), 2);
@@ -132,7 +132,7 @@ async fn live_self_fk_round_trip() -> Result<(), Box<dyn std::error::Error>> {
 
     let grandkids: Vec<Page> = Page::objects()
         .filter_op("parent_id", Op::Eq, child_b_id)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await?;
     assert_eq!(grandkids.len(), 1);
     assert_eq!(grandkids[0].title, "grand");

--- a/crates/rustango/tests/set_algebra_live.rs
+++ b/crates/rustango/tests/set_algebra_live.rs
@@ -7,7 +7,7 @@
 use std::sync::OnceLock;
 
 use rustango::core::Column as _;
-use rustango::sql::{sqlx, Auto, Fetcher as _};
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -87,7 +87,7 @@ async fn union_combines_branches_and_dedupes() {
         .where_(Post::status.eq("draft"))
         .union(Post::objects().where_(Post::status.eq("review")))
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     // 2 drafts + 1 review = 3 rows.
@@ -111,7 +111,7 @@ async fn union_all_keeps_duplicates() {
     let rows: Vec<Post> = Post::objects()
         .where_(Post::status.eq("draft"))
         .union_all(Post::objects().where_(Post::status.eq("draft")))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     // 2 drafts × 2 branches = 4 rows.
@@ -135,7 +135,7 @@ async fn intersect_keeps_only_rows_in_both_branches() {
     let rows: Vec<Post> = Post::objects()
         .where_(Post::status.eq("published"))
         .intersection(Post::objects().where_(Post::status.eq("published")))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 2, "2 published posts intersect themselves");
@@ -144,7 +144,7 @@ async fn intersect_keeps_only_rows_in_both_branches() {
     let empty: Vec<Post> = Post::objects()
         .where_(Post::status.eq("draft"))
         .intersection(Post::objects().where_(Post::status.eq("published")))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert!(
@@ -166,7 +166,7 @@ async fn except_excludes_matching_rows() {
 
     let rows: Vec<Post> = Post::objects()
         .difference(Post::objects().where_(Post::author_id.eq(1_i64)))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 4, "6 total - 2 author-1 = 4: got {rows:?}");
@@ -190,7 +190,7 @@ async fn outer_limit_caps_combined_result() {
         .union(Post::objects().where_(Post::status.eq("review")))
         .order_by(&[("id", false)])
         .limit(2)
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 2, "outer LIMIT 2 wins: got {rows:?}");

--- a/crates/rustango/tests/subquery_expressions_live.rs
+++ b/crates/rustango/tests/subquery_expressions_live.rs
@@ -10,7 +10,7 @@ use std::sync::OnceLock;
 
 use rustango::core::subquery::{exists, not_exists, outer_ref};
 use rustango::core::Column as _;
-use rustango::sql::{sqlx, Auto, Fetcher, Updater};
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -114,13 +114,13 @@ async fn not_exists_finds_authors_with_no_books() {
         .where_raw(not_exists(inner))
         .update()
         .set("book_count", -1_i64)
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
     let rows: Vec<Author> = Author::objects()
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     // Alice + Bob keep 0 (they have books); Carol jumps to -1.
@@ -150,13 +150,13 @@ async fn exists_finds_authors_with_published_books() {
         .where_raw(exists(inner))
         .update()
         .set("book_count", 99_i64)
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
     let rows: Vec<Author> = Author::objects()
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     // Only Alice has a published book.
@@ -188,13 +188,13 @@ async fn exists_filters_by_correlated_inner_predicate() {
         .where_raw(exists(inner))
         .update()
         .set("book_count", 77_i64)
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
     let rows: Vec<Author> = Author::objects()
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows[0].book_count, 77, "Alice has a 200-page book");
@@ -228,13 +228,13 @@ async fn exists_composes_with_or_in_outer_where() {
         ]))
         .update()
         .set("book_count", 7_i64)
-        .execute(&pool)
+        .execute_on(&pool)
         .await
         .unwrap();
 
     let rows: Vec<Author> = Author::objects()
         .order_by(&[("id", false)])
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows[0].book_count, 7, "Alice via EXISTS");

--- a/crates/rustango/tests/upsert_unique_together_live.rs
+++ b/crates/rustango/tests/upsert_unique_together_live.rs
@@ -15,7 +15,7 @@
 
 use rustango::core::Column as _;
 use rustango::sql::sqlx;
-use rustango::sql::{Auto, Fetcher};
+use rustango::sql::Auto;
 
 #[derive(rustango::Model, Debug, Clone)]
 #[rustango(table = "_upsert_uq_demo", unique_together = "team_id, codename")]
@@ -87,7 +87,7 @@ async fn upsert_uses_unique_together_as_conflict_target() {
     let rows: Vec<DemoMembership> = DemoMembership::objects()
         .where_(DemoMembership::team_id.eq(7_i64))
         .where_(DemoMembership::codename.eq("manage"))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1, "second upsert should NOT insert a duplicate");

--- a/crates/rustango/tests/where_expr_live.rs
+++ b/crates/rustango/tests/where_expr_live.rs
@@ -19,7 +19,7 @@
 use std::sync::OnceLock;
 
 use rustango::core::{Column as _, Model as _, WhereExpr};
-use rustango::sql::{sqlx, Fetcher, SqlError};
+use rustango::sql::{sqlx, SqlError};
 use rustango::Model;
 use tokio::sync::Mutex;
 
@@ -93,7 +93,7 @@ async fn or_two_eq_predicates_matches_either() {
 
     let rows: Vec<Person> = Person::objects()
         .where_(Person::name.eq("alice").or(Person::name.eq("bob")))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
 
@@ -118,7 +118,7 @@ async fn and_after_or_groups_correctly() {
                 .or(Person::name.eq("carol")),
         )
         .where_(Person::active.eq(true))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
 
@@ -142,7 +142,7 @@ async fn nested_or_and_complex_expression() {
                 .and(Person::active.eq(false))
                 .or(Person::name.eq("alice")),
         )
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
 
@@ -161,7 +161,7 @@ async fn multiple_where_calls_still_and_at_top_level() {
     let rows: Vec<Person> = Person::objects()
         .where_(Person::name.eq("alice").or(Person::name.eq("bob")))
         .where_(Person::age.gte(35_i32))
-        .fetch(&pool)
+        .fetch_on(&pool)
         .await
         .unwrap();
 

--- a/crates/rustango/tests/window_functions_live.rs
+++ b/crates/rustango/tests/window_functions_live.rs
@@ -134,8 +134,7 @@ async fn dense_rank_does_not_skip_on_ties() {
     };
     fresh(&pool).await;
     // Add two rows tied at score=50 in tenant 2.
-    sqlx::query(r#"INSERT INTO "wfl_user" ("tenant_id", "name", "score") VALUES (2, 'Frank', 50), (2, 'Grace', 50)"#)
-        .execute(&pool)
+    sqlx::query(r#"INSERT INTO "wfl_user" ("tenant_id", "name", "score") VALUES (2, 'Frank', 50), (2, 'Grace', 50)"#).execute(&pool)
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary

Wave 3 of T1.8 (issue #270). Deletes the four PG-typed extension traits whose only methods duplicated inherent methods on QuerySet / UpdateBuilder:

| Deleted | Replacement |
|---------|-------------|
| \`Fetcher::fetch(&PgPool)\` | \`QuerySet::fetch_on<E>(E)\` (pre-existing) |
| \`Counter::count(&PgPool)\` | \`QuerySet::count_on<E>(E)\` (pre-existing) |
| \`Deleter::delete(&PgPool)\` | **\`QuerySet::delete_on<E>(E)\`** (new) |
| \`Updater::execute(&PgPool)\` | **\`UpdateBuilder::execute_on<E>(E)\`** (new) |

The new \`delete_on\` and \`execute_on\` inherent methods take any \`sqlx::Executor<Database = Postgres>\` — same generic-executor shape as \`fetch_on\` / \`count_on\` — so tenancy schema-mode \`SET search_path\` callers using \`&mut PgConnection\` keep working unchanged.

Net **-89 LOC**.

## Migration recipe for downstream code

\`\`\`rust
use rustango::sql::Fetcher;
qs.where_(...).fetch(&pool).await    // BEFORE

qs.where_(...).fetch_on(&pool).await  // AFTER (no trait import needed)

use rustango::sql::Counter;
qs.where_(...).count(&pool).await    // BEFORE

qs.where_(...).count_on(&pool).await // AFTER

use rustango::sql::Deleter;
qs.where_(...).delete(&pool).await    // BEFORE

qs.where_(...).delete_on(&pool).await // AFTER

use rustango::sql::Updater;
qs.update().set(...).execute(&pool).await    // BEFORE

qs.update().set(...).execute_on(&pool).await // AFTER
\`\`\`

Drop the trait imports; method bodies stay the same.

## Migrated in this PR

30+ test files and examples migrated off the trait imports + \`.fetch(...)\` / \`.count(...)\` / \`.delete(...)\` / \`.execute(...)\` chains. The migration was mechanical (perl regex) for most call sites; a handful with nested-paren chains (\`.set_expr(case().when(...).default(...)).execute()\`) were edited by hand.

## What still survives in T1.8 backlog

- The \`_on\` family (\`insert_on\`, \`update_on\`, \`delete_on\`, \`bulk_insert_on\`, \`insert_returning_on\`, \`select_rows_on\`, \`select_one_row_on\`, \`raw_query_on\`, \`fetch_aggregate_on\`, \`annotate_count_children_on\`).
- \`fetch_with_prefetch\` (PG-typed \`&PgPool\` taker).

Killing those needs a \`Pool\`-or-\`PoolTx\` enum on every emitted \`#[derive(Model)]\` method — designed follow-up, tracked as wave 4.

## Verification

- \`cargo build --no-default-features --features sqlite,tenancy\` ✓
- \`cargo test --workspace --all-features --no-run\` ✓
- fmt + clippy clean