### PR TITLE
refactor: hide PG-typed _on family + fetch_with_prefetch behind __macro_internals (#270 wave 4, closes T1.8)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -3200,7 +3200,7 @@ fn inherent_impl_tokens(
                         }
                     ),
                 };
-                let _ = ::rustango::sql::update_on(
+                let _ = ::rustango::sql::__macro_internals::update_on(
                     #executor_passes_to_data_write,
                     &_query,
                 ).await?;
@@ -3270,7 +3270,7 @@ fn inherent_impl_tokens(
                     returning: ::std::vec![ #( #upsert_returning ),* ],
                     on_conflict: ::core::option::Option::Some(#conflict_clause),
                 };
-                let _returning_row_v = ::rustango::sql::insert_returning_on(
+                let _returning_row_v = ::rustango::sql::__macro_internals::insert_returning_on(
                     #executor_passes_to_data_write,
                     &query,
                 ).await?;
@@ -3331,7 +3331,7 @@ fn inherent_impl_tokens(
                             }
                         ),
                     };
-                    let _affected = ::rustango::sql::update_on(
+                    let _affected = ::rustango::sql::__macro_internals::update_on(
                         #executor_passes_to_data_write,
                         &_query,
                     ).await?;
@@ -3371,7 +3371,7 @@ fn inherent_impl_tokens(
                             }
                         ),
                     };
-                    let _affected = ::rustango::sql::update_on(
+                    let _affected = ::rustango::sql::__macro_internals::update_on(
                         #executor_passes_to_data_write,
                         &_query,
                     ).await?;
@@ -3423,7 +3423,7 @@ fn inherent_impl_tokens(
                         }
                     ),
                 };
-                let _affected = ::rustango::sql::delete_on(
+                let _affected = ::rustango::sql::__macro_internals::delete_on(
                     #executor_passes_to_data_write,
                     &query,
                 ).await?;
@@ -3501,7 +3501,7 @@ fn inherent_impl_tokens(
                     returning: ::std::vec![ #( #returning_cols ),* ],
                     on_conflict: ::core::option::Option::None,
                 };
-                let _returning_row_v = ::rustango::sql::insert_returning_on(
+                let _returning_row_v = ::rustango::sql::__macro_internals::insert_returning_on(
                     #executor_passes_to_data_write,
                     &query,
                 ).await?;
@@ -3564,7 +3564,7 @@ fn inherent_impl_tokens(
                     returning: ::std::vec::Vec::new(),
                     on_conflict: ::core::option::Option::None,
                 };
-                ::rustango::sql::insert_on(_executor, &query).await
+                ::rustango::sql::__macro_internals::insert_on(_executor, &query).await
             }
         }
     };
@@ -3652,7 +3652,7 @@ fn inherent_impl_tokens(
                     returning: ::std::vec![ #( #returning_cols ),* ],
                     on_conflict: ::core::option::Option::None,
                 };
-                let _returned = ::rustango::sql::bulk_insert_on(
+                let _returned = ::rustango::sql::__macro_internals::bulk_insert_on(
                     #executor_passes_to_data_write,
                     &_query,
                 ).await?;
@@ -3726,7 +3726,7 @@ fn inherent_impl_tokens(
                     returning: ::std::vec::Vec::new(),
                     on_conflict: ::core::option::Option::None,
                 };
-                let _ = ::rustango::sql::bulk_insert_on(_executor, &_query).await?;
+                let _ = ::rustango::sql::__macro_internals::bulk_insert_on(_executor, &_query).await?;
                 ::core::result::Result::Ok(())
             }
         }

--- a/crates/rustango/examples/cookbook_blog/src/apps/blog/urls.rs
+++ b/crates/rustango/examples/cookbook_blog/src/apps/blog/urls.rs
@@ -120,7 +120,7 @@ async fn submit_new_form(
         }
     };
     let query = mf.into_insert_query();
-    if let Err(e) = rustango::sql::insert_on(tenant.conn(), &query).await {
+    if let Err(e) = rustango::sql::__macro_internals::insert_on(tenant.conn(), &query).await {
         return new_form(Some(&e.to_string()), Some(&form))
             .await
             .into_response();
@@ -166,7 +166,7 @@ async fn submit_edit_form(
         Some(q) => q,
         None => return (StatusCode::INTERNAL_SERVER_ERROR, "Author has no PK").into_response(),
     };
-    if let Err(e) = rustango::sql::update_on(tenant.conn(), &query).await {
+    if let Err(e) = rustango::sql::__macro_internals::update_on(tenant.conn(), &query).await {
         let preview = form_preview(&form);
         return edit_form(id, &preview, Some(&e.to_string())).into_response();
     }

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter03_orm.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter03_orm.rs
@@ -188,7 +188,7 @@ async fn limit_offset_paginates() {
 #[tokio::test]
 async fn aggregate_count_and_sum() {
     use rustango::core::{AggregateExpr, SqlValue};
-    use rustango::sql::fetch_aggregate_on;
+    use rustango::sql::__macro_internals::fetch_aggregate_on;
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
 
@@ -329,7 +329,7 @@ async fn where_expr_not_negates_predicate() {
 #[tokio::test]
 async fn bulk_insert_writes_many_rows_in_one_round_trip() {
     use rustango::core::{BulkInsertQuery, SqlValue};
-    use rustango::sql::bulk_insert_on;
+    use rustango::sql::__macro_internals::bulk_insert_on;
     use rustango::core::Model as _;
 
     let Some(pool) = pool().await else { return };

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -46,19 +46,33 @@ pub use executor::{
     InsertReturningPool, LoadRelated, MaybeMyFromRow, MaybeMyLoadRelated, MaybePgFromRow,
     MaybeSqliteFromRow, MaybeSqliteLoadRelated, Page, PoolTx, UpdaterPool,
 };
-// PG-typed back-compat surface (issue #270 / T1.8 — wave 1):
-// Deleted: `count_rows` / `count_rows_on` / `raw_execute` /
-// `raw_execute_on` / `bulk_update` / `bulk_update_on` / `transaction`
-// — every one has a tri-dialect `_pool` counterpart (`count_rows_pool`,
-// `raw_execute_pool`, `bulk_update_pool`, `transaction_pool`). Use
-// those instead. The rest of the PG-typed surface stays for now;
-// subsequent waves migrate it.
+// PG-typed back-compat surface gone (issue #270 / T1.8 waves 1–4):
+// the entire family of `_on` functions + `&PgPool` wrappers + the
+// `Fetcher`/`Counter`/`Updater`/`Deleter` extension traits is deleted
+// from the public API. Use the tri-dialect `_pool` family
+// (`insert_pool`, `update_pool`, `select_rows_pool`, `count_rows_pool`,
+// …) or the inherent `_on` methods on QuerySet / UpdateBuilder
+// (`fetch_on`, `count_on`, `delete_on`, `execute_on`). `row_to_json` is
+// still useful for raw-row decoders and stays exported.
 #[cfg(feature = "postgres")]
-pub use executor::{
-    annotate_count_children, annotate_count_children_on, bulk_insert_on, delete_on,
-    fetch_aggregate_on, fetch_with_prefetch, insert_on, insert_returning_on, raw_query_on,
-    row_to_json, select_one_row_on, select_rows_on, update_on,
-};
+pub use executor::row_to_json;
+
+/// Hidden path for the `#[derive(Model)]` macro's generic-executor
+/// emissions. The functions inside are PG-typed (`E: sqlx::Executor<
+/// Database = Postgres>`) and exist purely to support the macro's
+/// `Self::save_on` / `Self::delete_on` / `Self::insert_on` /
+/// `Self::insert_returning_on` / `Self::bulk_insert_on` codegen that
+/// needs a generic executor for tenancy schema-mode `SET search_path`
+/// scoping. **Not part of the public API; do not import.**
+#[cfg(feature = "postgres")]
+#[doc(hidden)]
+pub mod __macro_internals {
+    pub use super::executor::{
+        annotate_count_children, annotate_count_children_on, bulk_insert_on, delete_on,
+        fetch_aggregate_on, fetch_with_prefetch, insert_on, insert_returning_on, raw_query_on,
+        select_one_row_on, select_rows_on, update_on,
+    };
+}
 
 #[cfg(feature = "mysql")]
 pub use executor::LoadRelatedMy;

--- a/crates/rustango/src/tenancy/permissions.rs
+++ b/crates/rustango/src/tenancy/permissions.rs
@@ -855,7 +855,7 @@ pub async fn grant_role_perm(
         returning: vec![],
         on_conflict: Some(ConflictClause::DoNothing),
     };
-    crate::sql::insert_on(pool, &query).await?;
+    crate::sql::__macro_internals::insert_on(pool, &query).await?;
     Ok(())
 }
 
@@ -886,7 +886,7 @@ pub async fn revoke_role_perm(
     codename: &str,
     pool: &PgPool,
 ) -> Result<(), TenancyError> {
-    crate::sql::delete_on(
+    crate::sql::__macro_internals::delete_on(
         pool,
         &DeleteQuery {
             model: RolePermission::SCHEMA,
@@ -951,7 +951,7 @@ pub async fn assign_role(user_id: i64, role_id: i64, pool: &PgPool) -> Result<()
         returning: vec![],
         on_conflict: Some(ConflictClause::DoNothing),
     };
-    crate::sql::insert_on(pool, &query).await?;
+    crate::sql::__macro_internals::insert_on(pool, &query).await?;
     Ok(())
 }
 
@@ -975,7 +975,7 @@ pub async fn assign_role_pool(
 /// Remove a user from a role.
 #[cfg(feature = "postgres")]
 pub async fn remove_role(user_id: i64, role_id: i64, pool: &PgPool) -> Result<(), TenancyError> {
-    crate::sql::delete_on(
+    crate::sql::__macro_internals::delete_on(
         pool,
         &DeleteQuery {
             model: UserRole::SCHEMA,
@@ -1055,7 +1055,7 @@ pub async fn set_user_perm(
             update_columns: vec!["granted"],
         }),
     };
-    crate::sql::insert_on(pool, &query).await?;
+    crate::sql::__macro_internals::insert_on(pool, &query).await?;
     Ok(())
 }
 
@@ -1092,7 +1092,7 @@ pub async fn clear_user_perm(
     codename: &str,
     pool: &PgPool,
 ) -> Result<(), TenancyError> {
-    crate::sql::delete_on(
+    crate::sql::__macro_internals::delete_on(
         pool,
         &DeleteQuery {
             model: UserPermission::SCHEMA,

--- a/crates/rustango/tests/aggregate_filter_live.rs
+++ b/crates/rustango/tests/aggregate_filter_live.rs
@@ -10,7 +10,8 @@ use std::sync::OnceLock;
 
 use rustango::core::aggregates::{count, count_all, stddev, sum};
 use rustango::core::{Column as _, SqlValue};
-use rustango::sql::{fetch_aggregate_on, sqlx, Auto};
+use rustango::sql::__macro_internals::fetch_aggregate_on;
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 

--- a/crates/rustango/tests/groupby_inference_live.rs
+++ b/crates/rustango/tests/groupby_inference_live.rs
@@ -10,7 +10,8 @@ use std::sync::OnceLock;
 
 use rustango::core::aggregates::{count_all, sum};
 use rustango::core::SqlValue;
-use rustango::sql::{fetch_aggregate_on, sqlx, Auto};
+use rustango::sql::__macro_internals::fetch_aggregate_on;
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 

--- a/crates/rustango/tests/having_auto_routing_live.rs
+++ b/crates/rustango/tests/having_auto_routing_live.rs
@@ -10,7 +10,8 @@ use std::sync::OnceLock;
 
 use rustango::core::aggregates::count_all;
 use rustango::core::{Op, SqlValue};
-use rustango::sql::{fetch_aggregate_on, sqlx, Auto};
+use rustango::sql::__macro_internals::fetch_aggregate_on;
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 

--- a/crates/rustango/tests/order_by_annotate_live.rs
+++ b/crates/rustango/tests/order_by_annotate_live.rs
@@ -7,7 +7,8 @@
 
 use std::sync::OnceLock;
 
-use rustango::sql::{annotate_count_children, annotate_count_children_on, sqlx, Auto, ForeignKey};
+use rustango::sql::__macro_internals::{annotate_count_children, annotate_count_children_on};
+use rustango::sql::{sqlx, Auto, ForeignKey};
 use rustango::Model;
 use tokio::sync::Mutex;
 

--- a/crates/rustango/tests/pg_aggregates_live.rs
+++ b/crates/rustango/tests/pg_aggregates_live.rs
@@ -5,7 +5,8 @@
 use std::sync::OnceLock;
 
 use rustango::core::{AggregateExpr, AggregateQuery, SqlValue, WhereExpr};
-use rustango::sql::{fetch_aggregate_on, sqlx, Auto};
+use rustango::sql::__macro_internals::fetch_aggregate_on;
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 

--- a/crates/rustango/tests/prefetch_non_i64_pk_live.rs
+++ b/crates/rustango/tests/prefetch_non_i64_pk_live.rs
@@ -11,7 +11,8 @@
 
 #![cfg(feature = "tenancy")]
 
-use rustango::sql::{fetch_with_prefetch, sqlx, Auto, ForeignKey};
+use rustango::sql::__macro_internals::fetch_with_prefetch;
+use rustango::sql::{sqlx, Auto, ForeignKey};
 
 #[derive(rustango::Model, Debug, Clone)]
 #[rustango(table = "_pf_str_tenant", display = "slug")]

--- a/crates/rustango/tests/prefetch_related_live.rs
+++ b/crates/rustango/tests/prefetch_related_live.rs
@@ -9,7 +9,8 @@
 
 use std::sync::OnceLock;
 
-use rustango::sql::{fetch_with_prefetch, sqlx, Auto, ForeignKey};
+use rustango::sql::__macro_internals::fetch_with_prefetch;
+use rustango::sql::{sqlx, Auto, ForeignKey};
 use rustango::Model;
 use tokio::sync::Mutex;
 

--- a/crates/rustango/tests/where_expr_live.rs
+++ b/crates/rustango/tests/where_expr_live.rs
@@ -216,5 +216,7 @@ async fn empty_or_branch_returns_named_writer_error() {
         projection: None,
         distinct: None,
     };
-    rustango::sql::select_rows_on(&pool, &q2).await.unwrap();
+    rustango::sql::__macro_internals::select_rows_on(&pool, &q2)
+        .await
+        .unwrap();
 }

--- a/crates/rustango/tests/window_functions_live.rs
+++ b/crates/rustango/tests/window_functions_live.rs
@@ -9,7 +9,8 @@ use std::sync::OnceLock;
 
 use rustango::core::window::{dense_rank, lag, rank, row_number};
 use rustango::core::SqlValue;
-use rustango::sql::{fetch_aggregate_on, sqlx, Auto};
+use rustango::sql::__macro_internals::fetch_aggregate_on;
+use rustango::sql::{sqlx, Auto};
 use rustango::Model;
 use tokio::sync::Mutex;
 


### PR DESCRIPTION
## Summary

Final wave of T1.8 (issue #270) — the PG-typed executor surface is **gone from the public API**.

The remaining \`_on\` functions (\`insert_on\`, \`update_on\`, \`delete_on\`, \`bulk_insert_on\`, \`insert_returning_on\`, \`select_rows_on\`, \`select_one_row_on\`, \`raw_query_on\`, \`fetch_aggregate_on\`, \`annotate_count_children\` / \`_on\`) + \`fetch_with_prefetch\` move to **\`crate::sql::__macro_internals\`** — a \`#[doc(hidden)] pub mod\`.

These functions still exist (the \`#[derive(Model)]\` macro emissions need them for \`Self::save_on(executor)\` / \`Self::insert_on(executor)\` / \`Self::delete_on(executor)\` / \`Self::bulk_insert_on(executor)\` / \`Self::insert_returning_on(executor)\`'s generic-executor tenancy schema-mode \`SET search_path\` paths), but the public API surface no longer mentions them.

## Outcomes for end users

| Before | After |
|--------|-------|
| \`use rustango::sql::insert_on;\` | unresolved → use \`Self::insert_on(executor)\` or \`insert_pool(&Pool, ...)\` |
| \`use rustango::sql::fetch_with_prefetch;\` | unresolved → use \`fetch_with_prefetch_pool(&Pool, ...)\` |
| rustdoc lists \`insert_on\` / \`update_on\` / etc. | hidden — rustdoc only shows the canonical \`_pool\` family |

The \`__macro_internals\` module is explicitly marked NOT public API — the leading \`__\` + \`#[doc(hidden)]\` is the project's convention for \"if you import this, you're on your own when v1.0 ships and we delete it for real\".

## In-tree callers migrated

- \`rustango-macros/src/lib.rs\` — 9 emission sites (\`sql::insert_on\` / \`update_on\` / \`delete_on\` / \`bulk_insert_on\` / \`insert_returning_on\`) rewritten to \`sql::__macro_internals::...\`.
- \`tenancy/permissions.rs\` — 6 internal call sites.
- 9 test files using the old \`_on\` / \`annotate_count_children\` / \`fetch_with_prefetch\` direct imports rewritten.

## Tri-dialect verification ✅

- \`cargo build --no-default-features --features sqlite,tenancy\` ✓
- \`cargo test --workspace --all-features --no-run\` ✓
- fmt + clippy clean

## T1.8 complete

The full Tier 1 batch (10 of 10 tickets) including the entire T1.8 \"kill PG-typed executor\" backlog is now done across waves 1–4:

| Wave | PR | What |
|------|----|------|
| 1 | #283 | transaction, count_rows, raw_execute, bulk_update |
| 2 | #284 | \`&PgPool\` wrappers (insert, update, delete, ...) |
| 3 | #285 | Fetcher / Counter / Updater / Deleter extension traits |
| 4 | this PR | \`_on\` family + fetch_with_prefetch → hidden module |

Closes issue #270.