### PR TITLE
release: v0.41.0 — Tier 1 ORM gap-closure batch (10 tickets, 14 PRs)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.40.0"
+version = "0.41.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -350,7 +350,7 @@ runserver = ["dep:axum", "dep:tokio"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.40.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.41.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }


### PR DESCRIPTION
## Release notes

Bumps workspace version **0.40.0 → 0.41.0**. Closes the Tier 1 ORM gap-closure batch ([epic #273](https://github.com/ujeenet/rustango/issues/273)) — every one of the 10 strategic-plan tickets shipped.

## Highlights

**Marketing-ready: Django-shape syntax + Rust-shape compile-time safety.**

- `Q!(User.email__icontains = "alice")` — Django strings, typed-column resolution, compile-fail on typos. ([#276](https://github.com/ujeenet/rustango/pull/276))
- `Q::eq("name", "alice") & Q::gt("age", 18)` — runtime-composable predicate trees for dynamic filters. ([#279](https://github.com/ujeenet/rustango/pull/279))
- `Post::objects().distinct_on(&["author_id"]).order_by(&[("author_id", false), ("created", true)])` — \"latest per group\" on every backend (PG native, window-fn fallback on MySQL/SQLite). ([#280](https://github.com/ujeenet/rustango/pull/280))
- `Post::bulk_upsert_pool(rows, &[\"slug\"], &[\"title\", \"updated_at\"], &pool)` — Django `bulk_create(update_conflicts=True)` tri-dialect. ([#281](https://github.com/ujeenet/rustango/pull/281))
- `#[rustango(unique_when(columns = \"email\", condition = \"deleted_at IS NULL\"))]` — partial unique constraints (PG/SQLite native, MySQL warns and falls back). ([#282](https://github.com/ujeenet/rustango/pull/282))
- `explain_pool(&pool, &query, ExplainOptions::default())` — tri-dialect query-plan helper. ([#275](https://github.com/ujeenet/rustango/pull/275))

## Tickets

### Feature

| # | PR | What |
|---|------|------|
| T1.1 | [#279](https://github.com/ujeenet/rustango/pull/279) | `Q()` runtime composable predicate |
| T1.2 | [#280](https://github.com/ujeenet/rustango/pull/280) | `.distinct(*fields)` + window-fn fallback |
| T1.3 | [#282](https://github.com/ujeenet/rustango/pull/282) | `#[rustango(unique_when(...))]` partial unique |
| T1.4 | [#277](https://github.com/ujeenet/rustango/pull/277) | DB functions batch 1 (Cast/LPad/MD5/SHA256/Position/Repeat/Reverse/Sign/Mod/Power/Sqrt) |
| T1.5 | [#281](https://github.com/ujeenet/rustango/pull/281) | `bulk_upsert_pool` / `bulk_insert_or_ignore_pool` |
| T1.6 | [#274](https://github.com/ujeenet/rustango/pull/274) | `AggregateBuilder::alias()` non-projected annotation |
| T1.7 | [#276](https://github.com/ujeenet/rustango/pull/276) | `Q!()` compile-time macro (headline ergonomic win) |
| T1.9 | [#278](https://github.com/ujeenet/rustango/pull/278) | Manager derive |
| T1.10 | [#275](https://github.com/ujeenet/rustango/pull/275) | `explain_pool()` tri-dialect |

### T1.8 — kill PG-typed legacy executor (4 waves)

| Wave | PR | What |
|------|------|------|
| 1 | [#283](https://github.com/ujeenet/rustango/pull/283) | `transaction`, `count_rows`, `raw_execute`, `bulk_update` (-120 LOC) |
| 2 | [#284](https://github.com/ujeenet/rustango/pull/284) | 9 `&PgPool` wrapper fns (-128 LOC) |
| 3 | [#285](https://github.com/ujeenet/rustango/pull/285) | `Fetcher`/`Counter`/`Updater`/`Deleter` extension traits (-89 LOC, 38 files migrated) |
| 4 | [#286](https://github.com/ujeenet/rustango/pull/286) | `_on` family + `fetch_with_prefetch` → `__macro_internals` (hidden) |

The entire PG-typed legacy executor surface is gone from the public API. The remaining `_on` functions live in `crate::sql::__macro_internals` (doc-hidden) and exist only for `#[derive(Model)]` macro emissions that need generic-executor support for tenancy schema-mode `SET search_path` scoping.

## Tri-dialect verification ✅

Every shipped feature works on Postgres, MySQL, and SQLite. The canonical `cargo build --no-default-features --features sqlite,tenancy` litmus passes on every merge.

## Breaking changes for downstream

- `use rustango::sql::{Fetcher, Counter, Updater, Deleter};` → all four trait imports unresolved. Drop them; the methods are now inherent on `QuerySet` / `UpdateBuilder` (`.fetch_on`, `.count_on`, `.delete_on`, `.execute_on`).
- `use rustango::sql::{insert, update, delete, select_rows, ...};` → bare `&PgPool` wrappers unresolved. Use `_pool` (tri-dialect) or the `_on` siblings (now under `__macro_internals` — internal-only).
- `qs.where_(...).fetch(&pool)` → `qs.where_(...).fetch_on(&pool)`.
- `qs.where_(...).delete(&pool)` → `qs.where_(...).delete_on(&pool)`.
- `qs.update().set(...).execute(&pool)` → `qs.update().set(...).execute_on(&pool)`.

Migration is mechanical — see PR #285's body for the recipe.

## No crates.io publish

Per project convention this PR doesn't publish to crates.io. That's a separate authorized step run after merge.