### PR TITLE
docs: README + lib.rs — v0.41.0 highlights + version bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,65 @@ Every feature works on every supported backend out of the box. The only PG-speci
 ```toml
 [dependencies]
 # Postgres (default)
-rustango = "0.40"
+rustango = "0.41"
 
 # SQLite — file-backed or in-memory, full tri-dialect framework
-rustango = { version = "0.40", default-features = false, features = ["sqlite", "tenancy", "admin", "manage"] }
+rustango = { version = "0.41", default-features = false, features = ["sqlite", "tenancy", "admin", "manage"] }
 
 # MySQL 8+
-rustango = { version = "0.40", default-features = false, features = ["mysql", "tenancy", "admin", "manage"] }
+rustango = { version = "0.41", default-features = false, features = ["mysql", "tenancy", "admin", "manage"] }
 
 # Multiple backends in one binary
-rustango = { version = "0.40", features = ["postgres", "sqlite"] }
+rustango = { version = "0.41", features = ["postgres", "sqlite"] }
 ```
+
+### What's new in v0.41.0 (May 2026) — Tier 1 ORM gap-closure batch
+
+**Django-shape syntax with Rust-shape compile-time safety.** Ten ORM tickets shipped across 14 PRs, plus the PG-typed legacy executor surface is gone from the public API.
+
+```rust
+use rustango::{Q, query::Q as Qb, core::Column as _};
+
+// Compile-time-safe Django-shape filter macro (#269 — typo'd field fails build):
+User::objects()
+    .where_(Q!(User.email__icontains = "alice"))
+    .where_(Q!(User.age__gt = 18_i64))
+    .fetch_pool(&pool).await?;
+
+// Runtime-composable Q() builder (#263 — for admin filter chips, dynamic API params):
+let q = Qb::eq("active", true) & (Qb::gt("age", 18_i64) | !Qb::eq("banned", true));
+User::objects().where_(q).fetch_pool(&pool).await?;
+
+// PG DISTINCT ON + portable window-function fallback (#264 — "latest per group"):
+Post::objects()
+    .distinct_on(&["author_id"])
+    .order_by(&[("author_id", false), ("created", true)])
+    .fetch_pool(&pool).await?;
+
+// Tri-dialect UPSERT — Django's bulk_create(update_conflicts=True) (#267):
+Post::bulk_upsert_pool(
+    &rows,
+    &["slug"],                  // unique_fields / conflict target
+    &["title", "view_count"],   // update_fields
+    &pool,
+).await?;
+```
+
+Plus:
+- **`#[rustango(unique_when(columns = "email", condition = "deleted_at IS NULL"))]`** — partial unique constraints (#265). PG/SQLite native; MySQL falls back to a plain UNIQUE with a migration-time warning. Universal "unique email per non-deleted row" / "unique slug per tenant" pattern.
+- **`AggregateBuilder::alias()`** (#268) — Django 3.2 non-projected annotations. Filter/order by a derived aggregate without paying the column-decode cost.
+- **`explain_pool()`** (#272) — tri-dialect query-plan helper. PG `EXPLAIN (FORMAT JSON, ANALYZE, BUFFERS)`, MySQL `EXPLAIN ANALYZE` / `FORMAT=TREE` / `FORMAT=JSON`, SQLite `EXPLAIN QUERY PLAN`.
+- **DB functions batch 1** (#266) — `Cast`, `LPad`, `RPad`, `MD5`, `SHA1`, `SHA256`, `Position`, `Repeat`, `Reverse`, `Sign`, `Mod`, `Power`, `Sqrt`. Per-dialect emission with clear `OpNotSupportedInDialect` errors where SQLite genuinely lacks the function.
+- **`#[rustango(manager(ext = "PostManagerExt"))]`** (#271) — Django-shape custom-manager extension trait emitted next to the model.
+
+**Breaking changes** (the PG-typed legacy executor deletion — #270, 4 waves):
+- `use rustango::sql::{Fetcher, Counter, Updater, Deleter};` → all four trait imports unresolved. The methods are now inherent on `QuerySet` / `UpdateBuilder`: `.fetch_on(&pool)`, `.count_on(&pool)`, `.delete_on(&pool)`, `.update().set(...).execute_on(&pool)`.
+- `use rustango::sql::{insert, update, delete, select_rows, transaction, count_rows, raw_execute, bulk_update, ...};` → bare `&PgPool` wrappers unresolved. Use the tri-dialect `_pool` family (`insert_pool`, `update_pool`, `transaction_pool`, …).
+- `qs.fetch(&pool)` → `qs.fetch_on(&pool)` (no trait import needed); same for `.count` / `.delete` / `.execute`.
+
+Net: 9 features added, ~340 LOC removed from the public surface, every shipped feature works on all three backends via the canonical `cargo build --no-default-features --features sqlite,tenancy` litmus.
+
+Full ticket index: PRs #274–#286. Closes [epic #273](https://github.com/ujeenet/rustango/issues/273).
 
 ### What's new in v0.40.0 (May 2026) — admin auth + GFK ergonomics + field help_text
 

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -9,10 +9,75 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rustango = "0.40"                                       # Postgres (default)
-//! rustango = { version = "0.40", features = ["sqlite"] }  # SQLite
-//! rustango = { version = "0.40", features = ["mysql"] }   # MySQL 8.0+
+//! rustango = "0.41"                                       # Postgres (default)
+//! rustango = { version = "0.41", features = ["sqlite"] }  # SQLite
+//! rustango = { version = "0.41", features = ["mysql"] }   # MySQL 8.0+
 //! ```
+//!
+//! ## What's new in v0.41 (May 2026) — Tier 1 ORM gap-closure batch
+//!
+//! Django-shape syntax with Rust-shape compile-time safety. Ten ORM
+//! tickets across 14 PRs ([epic #273]):
+//!
+//! - **[`Q!()`] compile-time macro** ([#269]) — `Q!(User.email__icontains
+//!   = "alice")` expands at parse time to the typed-column call.
+//!   Typo'd field names fail the build.
+//! - **[`query::Q`] runtime composable predicate** ([#263]) — for
+//!   dynamic filter trees (admin chips, REST query params). Operator
+//!   overloads: `&` / `|` / `^` / `!`.
+//! - **[`QuerySet::distinct_on`]** ([#264]) — PG `DISTINCT ON` native +
+//!   `ROW_NUMBER()` portable fallback on MySQL/SQLite. The "latest per
+//!   group" pattern, tri-dialect.
+//! - **[`Model::bulk_upsert_pool`] / [`Model::bulk_insert_or_ignore_pool`]**
+//!   ([#267]) — Django `bulk_create(update_conflicts=True)` /
+//!   `(ignore_conflicts=True)` across PG, MySQL, and SQLite.
+//! - **`#[rustango(unique_when(...))]`** ([#265]) — partial unique
+//!   indexes (Django `UniqueConstraint(condition=Q(...))`). PG/SQLite
+//!   native; MySQL warns + falls back.
+//! - **DB functions batch 1** ([#266]) — Cast, LPad, RPad, MD5, SHA1,
+//!   SHA256, Position, Repeat, Reverse, Sign, Mod, Power, Sqrt — per-
+//!   dialect emission with clean `NotSupported` errors on SQLite for
+//!   the genuinely-missing items (hashes, Reverse, Power/Sqrt without
+//!   `SQLITE_ENABLE_MATH_FUNCTIONS`).
+//! - **`AggregateBuilder::alias()`** ([#268]) — Django 3.2 non-
+//!   projected annotation. Filter/order by a derived aggregate without
+//!   paying the column-decode cost.
+//! - **`#[rustango(manager(ext = "..."))]`** ([#271]) — derive emits
+//!   the custom-manager extension trait next to the model.
+//! - **[`sql::explain_pool`]** ([#272]) — tri-dialect query plan
+//!   helper. PG `EXPLAIN (FORMAT JSON, ANALYZE, BUFFERS)`, MySQL
+//!   `EXPLAIN ANALYZE` / `FORMAT=TREE` / `FORMAT=JSON`, SQLite
+//!   `EXPLAIN QUERY PLAN`.
+//! - **PG-typed legacy executor deleted** ([#270], 4 waves) — the
+//!   bi-API confusion is gone. `Fetcher`/`Counter`/`Updater`/`Deleter`
+//!   extension traits + the `&PgPool` standalone fns +
+//!   `transaction`/`count_rows`/`raw_execute`/`bulk_update` are
+//!   removed. The `_on` family moved to a `#[doc(hidden)]` module for
+//!   macro use only. **Migration**: drop the trait imports, switch
+//!   `.fetch(pool)` → `.fetch_on(pool)` (inherent on QuerySet),
+//!   `.delete(pool)` → `.delete_on(pool)`, `.execute(pool)` (on
+//!   UpdateBuilder) → `.execute_on(pool)`. Use the `_pool` family for
+//!   tri-dialect calls.
+//!
+//! Full ticket index: PRs #274–#286.
+//!
+//! [`Q!()`]: rustango_macros::Q
+//! [`query::Q`]: crate::query::Q
+//! [`QuerySet::distinct_on`]: crate::query::QuerySet::distinct_on
+//! [`Model::bulk_upsert_pool`]: crate::core::Model
+//! [`Model::bulk_insert_or_ignore_pool`]: crate::core::Model
+//! [`sql::explain_pool`]: crate::sql::explain_pool
+//! [epic #273]: https://github.com/ujeenet/rustango/issues/273
+//! [#263]: https://github.com/ujeenet/rustango/pull/279
+//! [#264]: https://github.com/ujeenet/rustango/pull/280
+//! [#265]: https://github.com/ujeenet/rustango/pull/282
+//! [#266]: https://github.com/ujeenet/rustango/pull/277
+//! [#267]: https://github.com/ujeenet/rustango/pull/281
+//! [#268]: https://github.com/ujeenet/rustango/pull/274
+//! [#269]: https://github.com/ujeenet/rustango/pull/276
+//! [#270]: https://github.com/ujeenet/rustango/issues/270
+//! [#271]: https://github.com/ujeenet/rustango/pull/278
+//! [#272]: https://github.com/ujeenet/rustango/pull/275
 //!
 //! ## What's new in v0.40 (May 2026)
 //!


### PR DESCRIPTION
## Summary

Lands the v0.41.0 README + crate-doc updates that pair with the [release PR #287](https://github.com/ujeenet/rustango/pull/287).

- Bumps quickstart \`rustango = \"0.40\"\` → \`\"0.41\"\` in the README install snippet and the lib.rs doc-comment install snippet.
- Adds a **What's new in v0.41.0** section to both, leading with the **\"Django-shape syntax + Rust-shape compile-time safety\"** pitch via concrete \`Q!()\` macro + \`Q()\` runtime builder + \`.distinct_on(...)\` + \`Model::bulk_upsert_pool(...)\` examples.
- Calls out the **breaking changes** from T1.8 (PG-typed legacy executor deletion) with the migration recipe:
  - Drop \`use rustango::sql::{Fetcher, Counter, Updater, Deleter};\`
  - \`qs.where_(...).fetch(&pool)\` → \`qs.where_(...).fetch_on(&pool)\`
  - \`qs.where_(...).delete(&pool)\` → \`qs.where_(...).delete_on(&pool)\`
  - \`qs.update().set(...).execute(&pool)\` → \`qs.update().set(...).execute_on(&pool)\`
  - Bare \`&PgPool\` standalone fns (\`insert\` / \`update\` / \`delete\` / \`transaction\` / \`count_rows\` / \`raw_execute\` / \`bulk_update\` / ...) → use the tri-dialect \`_pool\` family.

No code changes. \`cargo doc -p rustango --no-deps --features tenancy\` builds clean (existing intra-doc-link warnings are pre-existing).