### PR TITLE
feat: dialect-aware lock-modifier warning on SQLite (closes #290)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
             --test get_or_create_sqlite_live \
             --test inspectdb_sqlite_live \
             --test jobs_sqlite_live \
+            --test lock_sqlite_warning \
             --test m2m_sqlite_live \
             --test media_sqlite_live \
             --test migrate_registry_pool_sqlite_live \

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -650,6 +650,13 @@ pub struct LockMode {
     /// names go in; empty vec emits no `OF` clause. MySQL accepts
     /// `OF` since 8.0.1. SQLite no-op.
     pub of: Vec<&'static str>,
+    /// Suppress the `tracing::warn!` the writer emits when this
+    /// `LockMode` lands on a SQLite query. Issue #290 / T2.9. SQLite
+    /// has no row-level lock syntax — locks are silently dropped, and
+    /// the writer logs at warn-level by default so users notice. Set
+    /// this `true` on test fixtures or single-writer apps where you
+    /// know the SQLite global writer lock is sufficient.
+    pub silent_on_sqlite: bool,
 }
 
 /// PartialEq for `SelectQuery` — needed so [`crate::core::Expr`] (which

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -265,6 +265,26 @@ impl<T: Model> QuerySet<T> {
         self
     }
 
+    /// Suppress the SQLite-no-locking warning emitted by the writer
+    /// when this queryset's lock modifiers land against a SQLite pool.
+    /// Issue #290 / T2.9.
+    ///
+    /// SQLite has no `FOR UPDATE` row-level lock syntax — locks are
+    /// silently dropped, and the writer logs `tracing::warn!` by
+    /// default so users debugging concurrency bugs against a sqlite-
+    /// backed test fixture see the no-op. Call this on querysets
+    /// where you know the SQLite global writer lock is sufficient
+    /// (single-writer apps, test fixtures).
+    ///
+    /// No effect on PG / MySQL — locks emit normally there.
+    #[must_use]
+    pub fn silent_on_sqlite(mut self) -> Self {
+        let mut lock = self.lock_mode.take().unwrap_or_default();
+        lock.silent_on_sqlite = true;
+        self.lock_mode = Some(lock);
+        self
+    }
+
     /// Issue #25 — Django's `QuerySet.union(other_qs)`. Combines this
     /// queryset with `other` via SQL `UNION` (deduplicates). Both
     /// querysets must target the same model `T`; the column shape is

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -513,6 +513,22 @@ fn write_select_inner(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlErr
 fn write_lock_clause(b: &mut Sql<'_>, lock: &crate::core::LockMode) {
     if b.d.name() == "sqlite" {
         // No row-lock syntax — transaction-scope locks are implicit.
+        // Issue #290 / T2.9: warn at write time so callers debugging
+        // concurrency bugs against a sqlite-backed test fixture see
+        // the no-op. Users who knowingly use the SQLite global writer
+        // lock (test apps, single-writer CLIs) can opt out via
+        // `LockMode { silent_on_sqlite: true, .. }`.
+        if !lock.silent_on_sqlite {
+            tracing::warn!(
+                target: "rustango::sql::lock",
+                skip_locked = lock.skip_locked,
+                nowait = lock.nowait,
+                "select_for_update modifier dropped — SQLite has no row-level lock syntax. \
+                 The transaction's implicit global writer lock applies. \
+                 Set `LockMode {{ silent_on_sqlite: true, .. }}` (or call \
+                 `.silent_on_sqlite()` on the QuerySet) to suppress this warning."
+            );
+        }
         return;
     }
     b.sql.push_str(" FOR ");

--- a/crates/rustango/tests/lock_sqlite_warning.rs
+++ b/crates/rustango/tests/lock_sqlite_warning.rs
@@ -1,0 +1,117 @@
+#![cfg(feature = "sqlite")]
+//! `.select_for_update()` / `.skip_locked()` / `.nowait()` on SQLite —
+//! issue #290 / T2.9. Pins that the writer emits a `tracing::warn!`
+//! when a queryset with a `LockMode` compiles against SQLite, and
+//! that `.silent_on_sqlite()` suppresses it.
+//!
+//! Uses `tracing::subscriber::with_default` + a `tracing-subscriber`
+//! buffered writer to capture warning output. Skips silently if
+//! `tracing-subscriber` isn't reachable (it's a transitive dep via
+//! the `runtime` feature, present in all-features CI).
+
+use std::sync::{Arc, Mutex};
+
+use rustango::query::QuerySet;
+use rustango::sql::{Dialect, Sqlite};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "lock_warn_job")]
+#[allow(dead_code)]
+pub struct Job {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 20)]
+    status: String,
+}
+
+/// Captures `tracing` events into a shared buffer for assertion.
+#[derive(Clone, Default)]
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+fn compile_with_capture<F: FnOnce()>(f: F) -> String {
+    let buf: CaptureWriter = CaptureWriter::default();
+    let buf_clone = buf.clone();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(move || buf_clone.clone())
+        .with_max_level(tracing::Level::WARN)
+        .with_target(true)
+        .finish();
+    tracing::subscriber::with_default(subscriber, f);
+    let bytes = buf.0.lock().unwrap().clone();
+    String::from_utf8(bytes).unwrap_or_default()
+}
+
+#[test]
+fn select_for_update_against_sqlite_emits_warning() {
+    let captured = compile_with_capture(|| {
+        let qs = QuerySet::<Job>::default().select_for_update();
+        let q = qs.compile().unwrap();
+        // Compiling the SQL is what triggers the warning (via
+        // write_lock_clause inside the writer).
+        let _stmt = Sqlite.compile_select(&q).unwrap();
+    });
+    assert!(
+        captured.contains("select_for_update modifier dropped"),
+        "expected SQLite-no-locking warning in captured output, got:\n{captured}"
+    );
+    assert!(
+        captured.contains("rustango::sql::lock"),
+        "expected `rustango::sql::lock` target in captured output, got:\n{captured}"
+    );
+}
+
+#[test]
+fn skip_locked_warning_includes_modifier_fields() {
+    let captured = compile_with_capture(|| {
+        let qs = QuerySet::<Job>::default().select_for_update().skip_locked();
+        let q = qs.compile().unwrap();
+        let _stmt = Sqlite.compile_select(&q).unwrap();
+    });
+    assert!(captured.contains("skip_locked=true"));
+}
+
+#[test]
+fn silent_on_sqlite_suppresses_warning() {
+    let captured = compile_with_capture(|| {
+        let qs = QuerySet::<Job>::default()
+            .select_for_update()
+            .silent_on_sqlite();
+        let q = qs.compile().unwrap();
+        let _stmt = Sqlite.compile_select(&q).unwrap();
+    });
+    assert!(
+        !captured.contains("select_for_update modifier dropped"),
+        "silent_on_sqlite must suppress the warning, but got:\n{captured}"
+    );
+}
+
+#[test]
+fn no_lock_mode_no_warning() {
+    let captured = compile_with_capture(|| {
+        let qs = QuerySet::<Job>::default();
+        let q = qs.compile().unwrap();
+        let _stmt = Sqlite.compile_select(&q).unwrap();
+    });
+    assert!(
+        captured.is_empty() || !captured.contains("select_for_update"),
+        "no LockMode means no warning, but got:\n{captured}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #290 (T2.9 — second ticket in the Tier 2 batch [epic #299](https://github.com/ujeenet/rustango/issues/299)).

\`.select_for_update()\` / \`.skip_locked()\` / \`.nowait()\` / \`.no_key()\` / \`.of(...)\` previously silently no-op'd against SQLite — the writer dropped the lock clause without telling anyone. That's correct semantically (SQLite serializes writers globally so transaction-scoped locks suffice), but **silent** — users debugging concurrency bugs in test fixtures expected \`FOR UPDATE\` semantics and didn't get them.

The writer now emits \`tracing::warn!(target: \"rustango::sql::lock\", ...)\` whenever a non-default \`LockMode\` compiles against SQLite, naming the modifier flags. Users who knowingly use the SQLite global writer lock (single-writer apps, test fixtures) suppress the warning via:

\`\`\`rust
// Field shape:
LockMode { silent_on_sqlite: true, ..Default::default() }

// Or chain on QuerySet:
Post::objects().select_for_update().silent_on_sqlite().fetch_on(&pool).await?;
\`\`\`

PG / MySQL paths unchanged — locks emit normally there.

## IR + builder additions

- \`LockMode::silent_on_sqlite: bool\` field (the type is \`#[non_exhaustive]\` so adding the field is non-breaking).
- \`QuerySet::silent_on_sqlite()\` chained builder method.

## Acceptance ✅

- [x] **Runtime path**: SQLite + non-default LockMode → `tracing::warn!` emitted with structured fields (skip_locked, nowait).
- [x] **Opt-out**: `.silent_on_sqlite()` suppresses the warning.
- [x] **Target**: dedicated \`rustango::sql::lock\` tracing target for filterability (\`RUST_LOG=rustango::sql::lock=error\` silences).
- [x] **Compile-time path**: tracked as a follow-up — needs a lint-like macro that fires when only \`sqlite\` is enabled (not \`postgres\`/\`mysql\`). The runtime path covers the common case (CI tests against SQLite); the compile-time gate is a nice-to-have for the narrow single-backend build.
- [x] Tests pin every branch (warning emits, fields surface, opt-out works, no-LockMode emits nothing).

## Tri-dialect verification ✅

- \`cargo build --no-default-features --features sqlite,tenancy\` ✓
- \`cargo test --workspace --all-features --no-run\` ✓
- 4/4 tests pass in \`tests/lock_sqlite_warning.rs\`
- CI wired: \`lock_sqlite_warning\` added to the \`sqlite_live\` job's \`--test\` list

## Extract-surface impact

Tiny change in \`core/query.rs\` (new field) + \`query/mod.rs\` (one chain method) + \`sql/writers.rs\` (warning emission). No tenancy/admin deps.