### PR TITLE
feat: #[rustango(default_order = "...")] per-query opt-in (closes #291)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -734,6 +734,20 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         }
     }
 
+    // Issue #291 / T2.5 — validate each `default_order` column name
+    // against the model's collected fields. Typos fail at macro-expand
+    // time, not at the database.
+    for (col, _desc, span) in &container.default_order {
+        if !collected.field_names.iter().any(|n| n == col) {
+            return Err(syn::Error::new(
+                *span,
+                format!(
+                    "`default_order = \"...\"`: \"{col}\" is not a declared field on this struct"
+                ),
+            ));
+        }
+    }
+
     // Build the audit_track list for ModelSchema: None when no audit attr,
     // Some(empty) when audit present without track, Some(names) when explicit.
     let audit_track_names: Option<Vec<String>> = container.audit.as_ref().map(|audit| {
@@ -776,6 +790,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         display.as_deref(),
         app_label.as_deref(),
         container.admin.as_ref(),
+        &container.default_order,
         &collected.field_schemas,
         collected.soft_delete_column.as_deref(),
         container.permissions,
@@ -1649,6 +1664,7 @@ fn model_impl_tokens(
     display: Option<&str>,
     app_label: Option<&str>,
     admin: Option<&AdminAttrs>,
+    default_order: &[(String, bool, proc_macro2::Span)],
     field_schemas: &[TokenStream2],
     soft_delete_column: Option<&str>,
     permissions: bool,
@@ -1756,6 +1772,13 @@ fn model_impl_tokens(
             }
         }
     });
+    // Issue #291 / T2.5 — `default_order` slice literal. Empty when
+    // no `#[rustango(default_order = "...")]` attribute was supplied.
+    let default_order_tokens = default_order.iter().map(|(col, desc, _)| {
+        let col_lit = col.as_str();
+        quote! { (#col_lit, #desc) }
+    });
+
     let m2m_tokens = m2m_relations.iter().map(|rel| {
         let name = rel.name.as_str();
         let to = rel.to.as_str();
@@ -1790,6 +1813,7 @@ fn model_impl_tokens(
                 composite_relations: &[ #(#composite_fk_tokens),* ],
                 generic_relations: &[ #(#generic_fk_tokens),* ],
                 scope: #scope_tokens,
+                default_order: &[ #(#default_order_tokens),* ],
             };
         }
     }
@@ -4257,6 +4281,12 @@ struct ContainerAttrs {
     /// Each value adds a `pub fn <name>() -> QuerySet<Self>` next to
     /// the default `Self::objects()`. Multiple attributes allowed.
     manager_fns: Vec<syn::Ident>,
+    /// Default ordering declared via `#[rustango(default_order =
+    /// "-created_at, status")]`. Issue #291 / T2.5. Each entry is
+    /// `(column_name, desc_flag, span_for_error_reporting)` — the
+    /// `-` prefix means descending; the `+` prefix or no prefix means
+    /// ascending.
+    default_order: Vec<(String, bool, proc_macro2::Span)>,
 }
 
 /// Parsed form of one index declaration (field-level or container-level).
@@ -4386,6 +4416,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
         scope: None,
         manager_ext: None,
         manager_fns: Vec::new(),
+        default_order: Vec::new(),
     };
     for attr in &input.attrs {
         if !attr.path().is_ident("rustango") {
@@ -4536,6 +4567,55 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     )));
                 }
                 out.manager_fns.push(ident);
+                return Ok(());
+            }
+            if meta.path.is_ident("default_order") {
+                // `#[rustango(default_order = "-created_at, status")]`
+                // — issue #291 / T2.5. Comma-separated list; `-prefix`
+                // means descending, `+prefix` or bare name means ascending.
+                // Per-query opt-in via `QuerySet::with_default_order()`.
+                let s: LitStr = meta.value()?.parse()?;
+                let raw = s.value();
+                let span = s.span();
+                let mut parsed: Vec<(String, bool, proc_macro2::Span)> =
+                    Vec::new();
+                for entry in raw.split(',') {
+                    let trimmed = entry.trim();
+                    if trimmed.is_empty() {
+                        return Err(syn::Error::new(
+                            span,
+                            "`default_order = \"...\"` has an empty entry — \
+                             check for a stray comma",
+                        ));
+                    }
+                    let (desc, name) = if let Some(rest) = trimmed.strip_prefix('-') {
+                        (true, rest.trim().to_owned())
+                    } else if let Some(rest) = trimmed.strip_prefix('+') {
+                        (false, rest.trim().to_owned())
+                    } else {
+                        (false, trimmed.to_owned())
+                    };
+                    if name.is_empty() {
+                        return Err(syn::Error::new(
+                            span,
+                            "`default_order` entry has no column name after the prefix",
+                        ));
+                    }
+                    if parsed.iter().any(|(n, _, _)| *n == name) {
+                        return Err(syn::Error::new(
+                            span,
+                            format!("duplicate column `{name}` in `default_order`"),
+                        ));
+                    }
+                    parsed.push((name, desc, span));
+                }
+                if parsed.is_empty() {
+                    return Err(syn::Error::new(
+                        span,
+                        "`default_order = \"...\"` cannot be empty",
+                    ));
+                }
+                out.default_order = parsed;
                 return Ok(());
             }
             if meta.path.is_ident("audit") {

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -238,6 +238,17 @@ pub struct ModelSchema {
     /// projects ignore this entirely — every model defaults to
     /// `Tenant` and `makemigrations` produces one file as before.
     pub scope: ModelScope,
+    /// Default ordering declared via `#[rustango(default_order = "...")]`.
+    /// Issue #291 / T2.5. Each tuple is `(column_name, desc)` — `desc =
+    /// true` means descending. Empty slice when the model has no
+    /// default order declared.
+    ///
+    /// **Per-query opt-in**: this list is NOT applied automatically.
+    /// Callers must chain `QuerySet::with_default_order()` to invoke
+    /// it — this avoids the Django `Meta.ordering` footgun where
+    /// every query (including `.count()` / `.exists()`) pays for the
+    /// sort by default.
+    pub default_order: &'static [(&'static str, bool)],
 }
 
 /// Where a model's table lives in a tenancy deployment. Mirrors

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -543,6 +543,7 @@ mod composite_fk_snapshot_tests {
             composite_relations: &COMPS,
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
+            default_order: &[],
         };
         &MS
     }
@@ -595,6 +596,7 @@ mod composite_fk_snapshot_tests {
             composite_relations: &[],
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
+            default_order: &[],
         };
         let snap = TableSnapshot::from_schema(&MS);
         let json = serde_json::to_string(&snap).expect("serialize");

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -428,6 +428,76 @@ impl<T: Model> QuerySet<T> {
         self
     }
 
+    /// Apply the schema-declared `default_order` for `T`. Issue #291
+    /// / T2.5. Each entry from `#[rustango(default_order = "...")]`
+    /// gets pre-pended to the queryset's pending ORDER BY list, so a
+    /// later `.order_by(...)` call appends secondary sort keys.
+    ///
+    /// **Per-query opt-in by design** — unlike Django's
+    /// `Meta.ordering`, the default ordering is NOT applied
+    /// automatically. Every queryset starts unsorted; chain
+    /// `.with_default_order()` when you want the schema default. This
+    /// avoids the Django footgun where `.count()` / `.exists()` /
+    /// `.delete()` pay for a sort they don't need.
+    ///
+    /// No-op when the model carries no `default_order`. Idempotent
+    /// (calling it twice doesn't duplicate the entries).
+    #[must_use]
+    pub fn with_default_order(mut self) -> Self {
+        let model = T::SCHEMA;
+        // Build the new entries first so we can pre-pend them.
+        let new_entries: Vec<PendingOrderItem> = model
+            .default_order
+            .iter()
+            .map(|(name, desc)| PendingOrderItem::Field {
+                name: (*name).to_owned(),
+                desc: *desc,
+                nulls: crate::core::NullsOrder::Default,
+            })
+            .collect();
+        if new_entries.is_empty() {
+            return self;
+        }
+        // Idempotency check: if the head of `order_by` already matches
+        // the model's default sequence, skip re-prepending.
+        let already_applied = self.order_by.len() >= new_entries.len()
+            && self
+                .order_by
+                .iter()
+                .zip(new_entries.iter())
+                .all(|(a, b)| match (a, b) {
+                    (
+                        PendingOrderItem::Field {
+                            name: an, desc: ad, ..
+                        },
+                        PendingOrderItem::Field {
+                            name: bn, desc: bd, ..
+                        },
+                    ) => an == bn && ad == bd,
+                    _ => false,
+                });
+        if already_applied {
+            return self;
+        }
+        // Pre-pend.
+        let mut combined = new_entries;
+        combined.extend(self.order_by.drain(..));
+        self.order_by = combined;
+        self
+    }
+
+    /// Clear every accumulated `ORDER BY` entry on this queryset.
+    /// Issue #291 / T2.5. Resets both legacy `.order_by(...)` columns
+    /// and `.order_by_expr(...)` / `.with_default_order()` entries
+    /// from earlier in the chain. Useful for explicitly bypassing a
+    /// queryset's default order when re-borrowing from a builder
+    /// helper that already chained `.with_default_order()`.
+    #[must_use]
+    pub fn unordered(mut self) -> Self {
+        self.order_by.clear();
+        self
+    }
+
     /// Append `ORDER BY` columns with explicit `NULLS FIRST|LAST`
     /// control. Issue #76. PG + SQLite emit the `NULLS …` keyword
     /// natively; MySQL emulates via `<col> IS NULL` pre-sort

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -266,6 +266,7 @@ mod tests {
         composite_relations: &[],
         generic_relations: &[],
         scope: crate::core::ModelScope::Tenant,
+        default_order: &[],
     };
 
     static MODEL_WITHOUT_SD: ModelSchema = ModelSchema {
@@ -284,6 +285,7 @@ mod tests {
         composite_relations: &[],
         generic_relations: &[],
         scope: crate::core::ModelScope::Tenant,
+        default_order: &[],
     };
 
     #[test]

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -1258,6 +1258,7 @@ mod tests {
             // v0.27.7 — every introspected schema is tenant-scoped
             // (mysql introspection isn't used for registry models).
             scope: crate::core::ModelScope::Tenant,
+            default_order: &[],
         }))
     }
 }

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -648,6 +648,7 @@ mod tests {
             composite_relations: &[],
             generic_relations: &[],
             scope: ModelScope::Tenant,
+            default_order: &[],
         };
         let q = SelectQuery {
             model: &MODEL,

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -3865,6 +3865,7 @@ mod tests {
             composite_relations: &[],
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
+            default_order: &[],
         }))
     }
 
@@ -3937,6 +3938,7 @@ mod tests {
             composite_relations: &[],
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
+            default_order: &[],
         }))
     }
 
@@ -4307,6 +4309,7 @@ mod tests {
             composite_relations: &[],
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
+            default_order: &[],
         }));
         assert!(default_order_by(no_pk).is_empty());
     }
@@ -4543,6 +4546,7 @@ mod tests {
             composite_relations: &[],
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
+            default_order: &[],
         }));
         let pk = uuid_schema.primary_key().unwrap();
         let raw = "550e8400-e29b-41d4-a716-446655440000";
@@ -4591,6 +4595,7 @@ mod tests {
             composite_relations: &[],
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
+            default_order: &[],
         }));
         let pk = str_schema.primary_key().unwrap();
         match coerce_pk(pk, "hello-world") {

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -404,6 +404,7 @@ mod tests {
             composite_relations: &[],
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
+            default_order: &[],
         };
         &MS
     }

--- a/crates/rustango/tests/default_order_derive.rs
+++ b/crates/rustango/tests/default_order_derive.rs
@@ -1,0 +1,135 @@
+//! `#[rustango(default_order = "...")]` — schema-declared default
+//! ORDER BY, per-query opt-in. Closes #291 / T2.5.
+//!
+//! Pins:
+//!   1. Default queryset emits **no** ORDER BY (no Django stickiness).
+//!   2. `.with_default_order()` opts in to the schema's default.
+//!   3. `.order_by(...)` after `.with_default_order()` appends as
+//!      secondary sort keys.
+//!   4. `.unordered()` clears any prior order entries.
+//!   5. `-prefix` parses as descending; bare name parses as ascending.
+
+use rustango::query::QuerySet;
+use rustango::sql::{Dialect, Postgres};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "default_order_post")]
+#[rustango(default_order = "-created, +status")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 200)]
+    title: String,
+    #[rustango(max_length = 1)]
+    status: String,
+    created: chrono::DateTime<chrono::Utc>,
+}
+
+fn compile_pg(qs: QuerySet<Post>) -> String {
+    let q = qs.compile().unwrap();
+    Postgres.compile_select(&q).unwrap().sql
+}
+
+#[test]
+fn default_queryset_emits_no_order_by() {
+    let sql = compile_pg(Post::objects());
+    assert!(
+        !sql.contains("ORDER BY"),
+        "default queryset must NOT pay for sort: {sql}"
+    );
+}
+
+#[test]
+fn with_default_order_applies_schema_default() {
+    let sql = compile_pg(Post::objects().with_default_order());
+    assert!(
+        sql.contains(r#"ORDER BY "created" DESC, "status""#),
+        "schema default_order should emit (created DESC, status ASC): {sql}"
+    );
+}
+
+#[test]
+fn order_by_after_default_appends_secondary_keys() {
+    let sql = compile_pg(
+        Post::objects()
+            .with_default_order()
+            .order_by(&[("id", false)]),
+    );
+    assert!(
+        sql.contains(r#"ORDER BY "created" DESC, "status", "id""#),
+        "default + secondary should append: {sql}"
+    );
+}
+
+#[test]
+fn unordered_clears_default_order() {
+    let sql = compile_pg(
+        Post::objects()
+            .with_default_order()
+            .order_by(&[("id", false)])
+            .unordered(),
+    );
+    assert!(!sql.contains("ORDER BY"), "unordered must clear: {sql}");
+}
+
+#[test]
+fn unordered_then_order_by_emits_only_explicit() {
+    let sql = compile_pg(
+        Post::objects()
+            .with_default_order()
+            .unordered()
+            .order_by(&[("status", true)]),
+    );
+    // Slice on the ORDER BY clause specifically — "created" lives in
+    // the SELECT projection too, so substring-matching the whole SQL
+    // is the wrong gate.
+    let order_by_clause = sql.split("ORDER BY").nth(1).unwrap_or("");
+    assert!(order_by_clause.contains("\"status\" DESC"));
+    assert!(
+        !order_by_clause.contains("\"created\""),
+        "default keys must be cleared in ORDER BY: {sql}"
+    );
+}
+
+#[test]
+fn with_default_order_is_idempotent() {
+    let once = compile_pg(Post::objects().with_default_order());
+    let twice = compile_pg(Post::objects().with_default_order().with_default_order());
+    assert_eq!(once, twice, "with_default_order must be idempotent");
+}
+
+#[test]
+fn schema_carries_parsed_default_order() {
+    // Direct assertion against the macro-emitted slice. `-prefix` →
+    // desc=true; `+prefix` and bare → desc=false.
+    use rustango::core::Model as _;
+    let schema = Post::SCHEMA;
+    assert_eq!(
+        schema.default_order,
+        &[("created", true), ("status", false)],
+    );
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "no_default_post")]
+#[allow(dead_code)]
+pub struct NoDefault {
+    #[rustango(primary_key)]
+    id: i64,
+}
+
+#[test]
+fn with_default_order_is_noop_when_schema_has_none() {
+    let sql = compile_pg_no_default(NoDefault::objects().with_default_order());
+    assert!(
+        !sql.contains("ORDER BY"),
+        "no default_order on schema → no ORDER BY even after .with_default_order(): {sql}"
+    );
+}
+
+fn compile_pg_no_default(qs: QuerySet<NoDefault>) -> String {
+    let q = qs.compile().unwrap();
+    Postgres.compile_select(&q).unwrap().sql
+}


### PR DESCRIPTION
## Summary

Closes #291 (T2.5 — third ticket in the Tier 2 batch [epic #299](https://github.com/ujeenet/rustango/issues/299)).

Django-shape `Meta.ordering` parity **without** the Django footgun. The schema's default ordering is NOT applied automatically — every queryset starts unsorted; chain `.with_default_order()` to opt in. Avoids paying for ORDER BY on `.count()` / `.exists()` / `.delete()` calls that don't need it.

```rust
#[derive(Model)]
#[rustango(default_order = "-created, +status")]
pub struct Post { ... }

// No ORDER BY emitted — the default is opt-in.
Post::objects().fetch_pool(&pool).await?;

// Opt in: ORDER BY "created" DESC, "status".
Post::objects().with_default_order().fetch_pool(&pool).await?;

// Defaults + secondary append.
Post::objects()
    .with_default_order()
    .order_by(&[("id", false)])
    .fetch_pool(&pool).await?;
// → ORDER BY "created" DESC, "status", "id"

// Clear everything.
Post::objects().with_default_order().unordered()
```

## Acceptance ✅

- [x] `#[rustango(default_order = "...")]` parses comma-separated entries with `-prefix` (desc) / `+prefix` (asc) / bare-name (asc default).
- [x] Column-name validation at macro-expand time — typos fail the build, not the database.
- [x] Duplicate-column check rejects `"id, -id"`.
- [x] **Per-query opt-in**: default queryset emits no ORDER BY.
- [x] **`.with_default_order()`** applies the schema default (pre-pended so user-explicit secondary keys append after).
- [x] **`.unordered()`** clears everything (defaults + user keys).
- [x] **Idempotent** — calling `.with_default_order()` twice doesn't duplicate entries.
- [x] No-op when the schema has no `default_order`.
- [x] 8/8 tests pass.

## Tri-dialect verification ✅

ORDER BY syntax is uniform SQL — feature works identically on PG/MySQL/SQLite.

- \`cargo build --no-default-features --features sqlite,tenancy\` ✓
- \`cargo test --workspace --all-features --no-run\` ✓
- fmt + clippy clean

## Extract-surface impact

`ModelSchema::default_order` (new `&'static [(&str, bool)]` field) + macro emission + two QuerySet methods. No tenancy/admin deps.