### PR TITLE
feat: pin .values().annotate() GROUP BY tri-dialect parity (closes #292)

### DIFF
--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1079,6 +1079,11 @@ impl<T: Model> QuerySet<T> {
     /// emits `SELECT cols, AGGR(...) FROM t GROUP BY cols` — GROUP BY is
     /// inferred from the values list.
     ///
+    /// This is **Django Shape 2** (`.values(cols).annotate(agg)` →
+    /// `GROUP BY cols`). The same IR compiles to structurally-equivalent
+    /// SQL on Postgres, MySQL, and SQLite; see
+    /// `tests/values_annotate_parity.rs` for the cross-dialect parity pins.
+    ///
     /// ```ignore
     /// // "Posts per author" — Django's canonical example.
     /// Post::objects()
@@ -1088,8 +1093,21 @@ impl<T: Model> QuerySet<T> {
     /// // → SELECT "author_id", COUNT(*) AS "n" FROM "post" GROUP BY "author_id"
     /// ```
     ///
+    /// Filtering by an `.annotate()` alias routes to `HAVING`; filtering
+    /// by a model column routes to `WHERE`:
+    ///
+    /// ```ignore
+    /// // Authors with > 5 published posts.
+    /// Post::objects()
+    ///     .values(&["author_id"])
+    ///     .annotate("n", count_all().into())
+    ///     .filter("status", Op::Eq, "published") // → WHERE
+    ///     .filter("n", Op::Gt, 5_i64)            // → HAVING
+    ///     .compile()?;
+    /// ```
+    ///
     /// Calling `.values()` without a subsequent aggregating `.annotate(...)`
-    /// is a pure projection (no GROUP BY emitted).
+    /// is **Django Shape 1** — a pure projection (no GROUP BY emitted).
     #[must_use]
     pub fn values(self, columns: &[&'static str]) -> AggregateBuilder<T> {
         AggregateBuilder {
@@ -1111,7 +1129,11 @@ impl<T: Model> QuerySet<T> {
     /// Promotes to an [`AggregateBuilder`]. If the annotation aggregates rows
     /// (`Count`, `Sum`, `Avg`, …) and `.values()` wasn't called, `compile()`
     /// auto-populates GROUP BY with every non-aggregate scalar column on the
-    /// model (Django Shape 3 — "per-row count of children").
+    /// model — this is **Django Shape 3** ("each row + a derived aggregate
+    /// over its children").
+    ///
+    /// The same IR compiles to structurally-equivalent SQL on Postgres,
+    /// MySQL, and SQLite; see `tests/values_annotate_parity.rs`.
     ///
     /// ```ignore
     /// // "Each author + their post count" — every column of `Author`
@@ -1120,6 +1142,14 @@ impl<T: Model> QuerySet<T> {
     ///     .annotate("post_count", count_all().into())
     ///     .compile()?;
     /// ```
+    ///
+    /// # Django shape cheat-sheet
+    ///
+    /// | Shape | Call site                                | GROUP BY        |
+    /// |-------|------------------------------------------|-----------------|
+    /// | 1     | `.values_dict(&[cols])`                  | (none)          |
+    /// | 2     | `.values(&[cols]).annotate(alias, agg)`  | the values cols |
+    /// | 3     | `.annotate(alias, agg)` (alone)          | every scalar    |
     #[must_use]
     pub fn annotate(self, alias: &'static str, expr: AggregateExpr) -> AggregateBuilder<T> {
         self.aggregate().annotate(alias, expr)

--- a/crates/rustango/tests/values_annotate_parity.rs
+++ b/crates/rustango/tests/values_annotate_parity.rs
@@ -1,0 +1,205 @@
+//! Tri-dialect parity for `.values().annotate()` — closes #292 / T2.8.
+//!
+//! The GROUP BY auto-inference rules (issue #75) are already exercised
+//! by `tests/groupby_inference.rs` on Postgres alone. This file
+//! confirms the **same** IR produces structurally-correct SQL on
+//! Postgres, MySQL, and SQLite, plus that filtering by an `.annotate()`
+//! alias lands in HAVING (not WHERE) on every backend.
+//!
+//! Closes the audit gap T2.8 asked for: the inference path was
+//! tight but **undocumented across backends**.
+
+use rustango::core::aggregates::{count_all, sum};
+use rustango::core::Op;
+use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "vap_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    author_id: i64,
+    #[rustango(max_length = 20)]
+    status: String,
+    views: i64,
+    revenue: i64,
+}
+
+// ---------- Django Shape 2: `.values(cols).annotate(agg)` → GROUP BY cols ----------
+
+#[test]
+fn shape2_emits_group_by_on_every_dialect() {
+    let q = Post::objects()
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let pg = Postgres.compile_aggregate(&q).unwrap().sql;
+    let my = MySql.compile_aggregate(&q).unwrap().sql;
+    let sq = Sqlite.compile_aggregate(&q).unwrap().sql;
+    // Projection: just the group-by column + aggregate alias.
+    assert!(
+        pg.contains(r#"SELECT "author_id", COUNT(*) AS "n""#),
+        "PG: {pg}"
+    );
+    assert!(
+        my.contains("SELECT `author_id`, COUNT(*) AS `n`"),
+        "MySQL: {my}"
+    );
+    assert!(
+        sq.contains(r#"SELECT "author_id", COUNT(*) AS "n""#),
+        "SQLite: {sq}"
+    );
+    // GROUP BY clause present on all three.
+    assert!(pg.contains(r#"GROUP BY "author_id""#), "PG: {pg}");
+    assert!(my.contains("GROUP BY `author_id`"), "MySQL: {my}");
+    assert!(sq.contains(r#"GROUP BY "author_id""#), "SQLite: {sq}");
+}
+
+#[test]
+fn shape2_multi_column_group_by() {
+    let q = Post::objects()
+        .values(&["author_id", "status"])
+        .annotate("total", sum("revenue").into())
+        .compile()
+        .unwrap();
+    let pg = Postgres.compile_aggregate(&q).unwrap().sql;
+    let sq = Sqlite.compile_aggregate(&q).unwrap().sql;
+    assert!(pg.contains(r#"GROUP BY "author_id", "status""#), "PG: {pg}");
+    assert!(
+        sq.contains(r#"GROUP BY "author_id", "status""#),
+        "SQLite: {sq}"
+    );
+}
+
+// ---------- Django Shape 3: `.annotate(agg)` alone → GROUP BY every scalar column ----------
+
+#[test]
+fn shape3_emits_group_by_every_scalar_column_on_every_dialect() {
+    // Author-shape "every column on the model PLUS the aggregate".
+    let q = Post::objects()
+        .annotate("n", count_all().into())
+        .compile()
+        .unwrap();
+    let pg = Postgres.compile_aggregate(&q).unwrap().sql;
+    let my = MySql.compile_aggregate(&q).unwrap().sql;
+    let sq = Sqlite.compile_aggregate(&q).unwrap().sql;
+    // GROUP BY contains every scalar column.
+    for col in &["id", "author_id", "status", "views", "revenue"] {
+        assert!(
+            pg.contains(&format!(r#""{col}""#)),
+            "PG must include {col}: {pg}"
+        );
+        assert!(
+            my.contains(&format!("`{col}`")),
+            "MySQL must include {col}: {my}"
+        );
+        assert!(
+            sq.contains(&format!(r#""{col}""#)),
+            "SQLite must include {col}: {sq}"
+        );
+    }
+}
+
+// ---------- HAVING routing: filtering by an annotate alias → HAVING ----------
+
+#[test]
+fn filter_on_annotate_alias_routes_to_having() {
+    // Authors with > 5 posts.
+    let q = Post::objects()
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .filter("n", Op::Gt, 5_i64)
+        .compile()
+        .unwrap();
+    let pg = Postgres.compile_aggregate(&q).unwrap().sql;
+    let my = MySql.compile_aggregate(&q).unwrap().sql;
+    let sq = Sqlite.compile_aggregate(&q).unwrap().sql;
+    // PG strictly requires the aggregate expression (not the alias) in
+    // HAVING. The framework lifts COUNT(*) > $1 into HAVING on every
+    // backend for uniformity.
+    assert!(pg.contains("HAVING COUNT(*) > $1"), "PG: {pg}");
+    assert!(my.contains("HAVING COUNT(*) > ?"), "MySQL: {my}");
+    assert!(sq.contains("HAVING COUNT(*) > ?"), "SQLite: {sq}");
+}
+
+#[test]
+fn filter_on_model_column_routes_to_where() {
+    let q = Post::objects()
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .filter("status", Op::Eq, "published")
+        .compile()
+        .unwrap();
+    let sql = Postgres.compile_aggregate(&q).unwrap().sql;
+    assert!(
+        sql.contains(r#"WHERE "status" = $1"#),
+        "model-column filter must route to WHERE: {sql}"
+    );
+    // Should NOT land the model column in HAVING.
+    assert!(
+        !sql.contains(r#"HAVING "status""#),
+        "WHERE-clause filter must not appear in HAVING: {sql}"
+    );
+}
+
+// ---------- Mixed WHERE + HAVING ----------
+
+#[test]
+fn mixed_filters_route_to_both_where_and_having() {
+    // "Published-post counts per author, where count > 5"
+    let q = Post::objects()
+        .values(&["author_id"])
+        .annotate("n", count_all().into())
+        .filter("status", Op::Eq, "published") // → WHERE
+        .filter("n", Op::Gt, 5_i64) // → HAVING (alias)
+        .compile()
+        .unwrap();
+    let pg = Postgres.compile_aggregate(&q).unwrap().sql;
+    let my = MySql.compile_aggregate(&q).unwrap().sql;
+    let sq = Sqlite.compile_aggregate(&q).unwrap().sql;
+    // Both clauses appear on every backend, in the right order
+    // (WHERE before GROUP BY, HAVING after).
+    for (name, sql) in [("PG", &pg), ("MySQL", &my), ("SQLite", &sq)] {
+        let where_pos = sql
+            .find("WHERE")
+            .unwrap_or_else(|| panic!("{name}: no WHERE: {sql}"));
+        let group_pos = sql
+            .find("GROUP BY")
+            .unwrap_or_else(|| panic!("{name}: no GROUP BY: {sql}"));
+        let having_pos = sql
+            .find("HAVING")
+            .unwrap_or_else(|| panic!("{name}: no HAVING: {sql}"));
+        assert!(
+            where_pos < group_pos,
+            "{name}: WHERE must precede GROUP BY: {sql}"
+        );
+        assert!(
+            group_pos < having_pos,
+            "{name}: GROUP BY must precede HAVING: {sql}"
+        );
+    }
+}
+
+// ---------- Bare projection: .values() alone (no annotation) ----------
+
+#[test]
+fn bare_values_emits_no_group_by_no_aggregate() {
+    // `.values()` without an aggregating `.annotate()` is a pure
+    // projection (Django Shape 1) — no GROUP BY emitted.
+    use rustango::query::QuerySet;
+    let qs: QuerySet<Post> = QuerySet::default();
+    let q = qs.values_dict(&["author_id", "status"]).compile().unwrap();
+    let sql = Postgres.compile_select(&q).unwrap().sql;
+    assert!(
+        sql.starts_with(r#"SELECT "author_id", "status""#),
+        "pure projection: {sql}"
+    );
+    assert!(
+        !sql.contains("GROUP BY"),
+        "no GROUP BY in pure projection: {sql}"
+    );
+    assert!(!sql.contains("COUNT"), "no aggregate: {sql}");
+}


### PR DESCRIPTION
## Summary

Closes #292 / T2.8.

The GROUP BY auto-inference rules from issue #75 were already covered by `tests/groupby_inference.rs` — but only on Postgres. This PR adds the cross-dialect parity gate the T2.8 audit asked for, plus shape-naming rustdoc on the public API.

## What's in

- **`tests/values_annotate_parity.rs`** — 7 tests pinning:
  - Shape 1 (`.values_dict(cols)` alone) → pure projection, no GROUP BY.
  - Shape 2 (`.values(cols).annotate(agg)`) → GROUP BY cols, on PG/MySQL/SQLite, single + multi-column.
  - Shape 3 (`.annotate(agg)` alone) → GROUP BY every scalar column, on all three.
  - HAVING routing: filter on an annotate alias → HAVING (with the aggregate expression, not the alias, for PG strict-mode parity).
  - WHERE routing: filter on a model column → WHERE, never HAVING.
  - Mixed-filter clause-ordering check: WHERE before GROUP BY before HAVING on every backend.

- **Rustdoc** on `QuerySet::values` and `QuerySet::annotate`:
  - Names the three Django shapes explicitly.
  - Documents HAVING-vs-WHERE routing with an example.
  - Adds a shape cheat-sheet table on `.annotate()`.

## Tri-dialect

Tests compile the same IR through `Postgres.compile_aggregate`, `MySql.compile_aggregate`, `Sqlite.compile_aggregate` and assert each emits structurally-correct SQL. `cargo build --no-default-features --features sqlite,tenancy` passes.

## Test plan

- [x] `cargo test -p rustango --features sqlite,mysql,postgres,tenancy --test values_annotate_parity` — 7/7 pass
- [x] `cargo build --no-default-features --features sqlite,tenancy` — tri-dialect litmus
- [x] `cargo test --workspace --all-features --no-run` — feature-gate-aware compile
- [x] `cargo fmt --all -- --check` + `cargo clippy -p rustango --features tenancy --lib --no-deps`