### PR TITLE
feat: inspectdb walks views + #[rustango(view)] marker (closes #293)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
             --test funcs_batch1_sqlite_live \
             --test get_or_create_sqlite_live \
             --test inspectdb_sqlite_live \
+            --test inspectdb_views_sqlite_live \
             --test jobs_sqlite_live \
             --test lock_sqlite_warning \
             --test m2m_sqlite_live \

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -801,6 +801,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         &container.composite_fks,
         &container.generic_fks,
         container.scope.as_deref(),
+        container.is_view,
     );
     let module_ident = column_module_ident(struct_name);
     let column_consts = column_const_tokens(&module_ident, &collected.column_entries);
@@ -1675,6 +1676,7 @@ fn model_impl_tokens(
     composite_fks: &[CompositeFkAttr],
     generic_fks: &[GenericFkAttr],
     scope: Option<&str>,
+    is_view: bool,
 ) -> TokenStream2 {
     let display_tokens = if let Some(name) = display {
         quote!(::core::option::Option::Some(#name))
@@ -1814,6 +1816,7 @@ fn model_impl_tokens(
                 generic_relations: &[ #(#generic_fk_tokens),* ],
                 scope: #scope_tokens,
                 default_order: &[ #(#default_order_tokens),* ],
+                is_view: #is_view,
             };
         }
     }
@@ -4287,6 +4290,11 @@ struct ContainerAttrs {
     /// `-` prefix means descending; the `+` prefix or no prefix means
     /// ascending.
     default_order: Vec<(String, bool, proc_macro2::Span)>,
+    /// `true` when `#[rustango(view)]` is present. Issue #293 / T2.10.
+    /// Routes the emitted schema's `is_view = true` so the migration
+    /// snapshot skips this model (its underlying SQL view is operator-
+    /// managed, not rustango-managed).
+    is_view: bool,
 }
 
 /// Parsed form of one index declaration (field-level or container-level).
@@ -4417,6 +4425,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
         manager_ext: None,
         manager_fns: Vec::new(),
         default_order: Vec::new(),
+        is_view: false,
     };
     for attr in &input.attrs {
         if !attr.path().is_ident("rustango") {
@@ -4644,6 +4653,20 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     out.permissions = lit.value;
                 } else {
                     out.permissions = true;
+                }
+                return Ok(());
+            }
+            if meta.path.is_ident("view") {
+                // Issue #293 / T2.10. Two forms accepted, matching
+                // the `permissions` flag pattern:
+                //   #[rustango(view)]          — flag form, true
+                //   #[rustango(view = false)]  — explicit opt-out
+                //   #[rustango(view = true)]   — explicit opt-in
+                if let Ok(v) = meta.value() {
+                    let lit: syn::LitBool = v.parse()?;
+                    out.is_view = lit.value;
+                } else {
+                    out.is_view = true;
                 }
                 return Ok(());
             }

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -249,6 +249,13 @@ pub struct ModelSchema {
     /// every query (including `.count()` / `.exists()`) pays for the
     /// sort by default.
     pub default_order: &'static [(&'static str, bool)],
+    /// `true` when the model is backed by a SQL **view** rather than a
+    /// table — set via `#[rustango(view)]` on the struct. Issue #293 /
+    /// T2.10. View-backed models are excluded from the migration
+    /// snapshot so `makemigrations` / `migrate` never emit `CREATE
+    /// TABLE` / `DROP TABLE` against them (the view is owned by the
+    /// operator, not by rustango). Reads behave like any other model.
+    pub is_view: bool,
 }
 
 /// Where a model's table lives in a tenancy deployment. Mirrors

--- a/crates/rustango/src/migrate/inspectdb.rs
+++ b/crates/rustango/src/migrate/inspectdb.rs
@@ -20,6 +20,10 @@
 //! ## What it covers
 //!
 //! - Tables (`BASE TABLE` on PG/MySQL; `type = 'table'` on SQLite)
+//! - Views — emitted with `#[rustango(view)]` so the migration runner
+//!   skips `CREATE TABLE` / `DROP TABLE` against them. The view's
+//!   `view_definition` lands in a fenced ```sql doc comment above the
+//!   emitted struct. Issue #293 / T2.10.
 //! - Standard column types per backend (integers, text/varchar,
 //!   bool, timestamp[tz], date, uuid/blob, json[b]/text-as-json,
 //!   numeric/decimal)
@@ -32,7 +36,7 @@
 //!
 //! ## What it skips (v1)
 //!
-//! - Views, materialized views, foreign tables
+//! - Materialized views, foreign tables (regular views are walked)
 //! - Composite primary keys (emits the first PK column with the
 //!   marker; the user adjusts as needed)
 //! - CHECK constraints (no rustango-side equivalent yet)
@@ -103,7 +107,9 @@ pub(super) fn parse_inspectdb_args(args: &[String]) -> Result<InspectdbArgs, Mig
 }
 
 /// Top-level entry — read the live schema, emit Rust source. v0.38 —
-/// tri-dialect via [`crate::sql::Pool`].
+/// tri-dialect via [`crate::sql::Pool`]. Issue #293 / T2.10 —
+/// walks views as well as tables; view-backed models are emitted with
+/// `#[rustango(view)]` so the migration runner skips them.
 pub(super) async fn inspectdb_cmd<W: Write>(
     pool: &Pool,
     args: &[String],
@@ -112,13 +118,18 @@ pub(super) async fn inspectdb_cmd<W: Write>(
     let parsed = parse_inspectdb_args(args)?;
     let dialect_name = pool.dialect().name();
     let tables = list_tables(pool, &parsed.schema, parsed.table.as_deref()).await?;
-    if tables.is_empty() {
+    let views = list_views(pool, &parsed.schema, parsed.table.as_deref()).await?;
+    if tables.is_empty() && views.is_empty() {
         let label = if dialect_name == "sqlite" {
             "<database file>".to_owned()
         } else {
             parsed.schema.clone()
         };
-        writeln!(w, "// no tables found in `{}`", escape_for_comment(&label))?;
+        writeln!(
+            w,
+            "// no tables or views found in `{}`",
+            escape_for_comment(&label)
+        )?;
         return Ok(());
     }
     write_header(w, &parsed.schema, dialect_name)?;
@@ -127,6 +138,12 @@ pub(super) async fn inspectdb_cmd<W: Write>(
         let pk_columns = list_pk_columns(pool, &parsed.schema, table).await?;
         let fks = list_fks(pool, &parsed.schema, table).await?;
         write_model_with_dialect(w, table, &columns, &pk_columns, &fks, dialect_name)?;
+        writeln!(w)?;
+    }
+    for view in &views {
+        let columns = list_columns(pool, &parsed.schema, view).await?;
+        let definition = view_definition(pool, &parsed.schema, view).await?;
+        write_view_model_with_dialect(w, view, &columns, definition.as_deref(), dialect_name)?;
         writeln!(w)?;
     }
     Ok(())
@@ -264,6 +281,44 @@ async fn list_fks(
     }
 }
 
+#[cfg_attr(
+    not(any(feature = "postgres", feature = "mysql")),
+    allow(unused_variables)
+)]
+async fn list_views(
+    pool: &Pool,
+    schema: &str,
+    only: Option<&str>,
+) -> Result<Vec<String>, MigrateError> {
+    match pool {
+        #[cfg(feature = "postgres")]
+        Pool::Postgres(pg) => list_views_pg(pg, schema, only).await,
+        #[cfg(feature = "mysql")]
+        Pool::Mysql(my) => list_views_my(my, schema, only).await,
+        #[cfg(feature = "sqlite")]
+        Pool::Sqlite(sq) => list_views_sqlite(sq, only).await,
+    }
+}
+
+#[cfg_attr(
+    not(any(feature = "postgres", feature = "mysql")),
+    allow(unused_variables)
+)]
+async fn view_definition(
+    pool: &Pool,
+    schema: &str,
+    view: &str,
+) -> Result<Option<String>, MigrateError> {
+    match pool {
+        #[cfg(feature = "postgres")]
+        Pool::Postgres(pg) => view_definition_pg(pg, schema, view).await,
+        #[cfg(feature = "mysql")]
+        Pool::Mysql(my) => view_definition_my(my, schema, view).await,
+        #[cfg(feature = "sqlite")]
+        Pool::Sqlite(sq) => view_definition_sqlite(sq, view).await,
+    }
+}
+
 // -------------------------------------------------------------- Postgres
 
 #[cfg(feature = "postgres")]
@@ -396,6 +451,51 @@ async fn list_fks_pg(
             )
         })
         .collect())
+}
+
+#[cfg(feature = "postgres")]
+async fn list_views_pg(
+    pool: &sqlx::PgPool,
+    schema: &str,
+    only: Option<&str>,
+) -> Result<Vec<String>, MigrateError> {
+    use sqlx::Row as _;
+    let sql = if only.is_some() {
+        r#"SELECT table_name FROM information_schema.views
+           WHERE table_schema = $1 AND table_name = $2
+           ORDER BY table_name"#
+    } else {
+        r#"SELECT table_name FROM information_schema.views
+           WHERE table_schema = $1
+           ORDER BY table_name"#
+    };
+    let mut q = sqlx::query(sql).bind(schema);
+    if let Some(v) = only {
+        q = q.bind(v);
+    }
+    let rows = q.fetch_all(pool).await.map_err(MigrateError::Driver)?;
+    Ok(rows
+        .into_iter()
+        .map(|r| r.try_get::<String, _>("table_name").unwrap_or_default())
+        .collect())
+}
+
+#[cfg(feature = "postgres")]
+async fn view_definition_pg(
+    pool: &sqlx::PgPool,
+    schema: &str,
+    view: &str,
+) -> Result<Option<String>, MigrateError> {
+    let def: Option<String> = sqlx::query_scalar(
+        r#"SELECT view_definition FROM information_schema.views
+           WHERE table_schema = $1 AND table_name = $2"#,
+    )
+    .bind(schema)
+    .bind(view)
+    .fetch_optional(pool)
+    .await
+    .map_err(MigrateError::Driver)?;
+    Ok(def)
 }
 
 // -------------------------------------------------------------- MySQL
@@ -597,6 +697,76 @@ async fn list_fks_my(
         .collect())
 }
 
+#[cfg(feature = "mysql")]
+async fn list_views_my(
+    pool: &sqlx::MySqlPool,
+    schema: &str,
+    only: Option<&str>,
+) -> Result<Vec<String>, MigrateError> {
+    use sqlx::Row as _;
+    // See `list_tables_my` for why every string column is `CAST AS CHAR`.
+    let use_default = schema == "public" || schema.is_empty();
+    let sql = match (only, use_default) {
+        (Some(_), true) => {
+            r#"SELECT CAST(TABLE_NAME AS CHAR) AS TABLE_NAME FROM information_schema.views
+               WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+               ORDER BY TABLE_NAME"#
+        }
+        (Some(_), false) => {
+            r#"SELECT CAST(TABLE_NAME AS CHAR) AS TABLE_NAME FROM information_schema.views
+               WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
+               ORDER BY TABLE_NAME"#
+        }
+        (None, true) => {
+            r#"SELECT CAST(TABLE_NAME AS CHAR) AS TABLE_NAME FROM information_schema.views
+               WHERE TABLE_SCHEMA = DATABASE()
+               ORDER BY TABLE_NAME"#
+        }
+        (None, false) => {
+            r#"SELECT CAST(TABLE_NAME AS CHAR) AS TABLE_NAME FROM information_schema.views
+               WHERE TABLE_SCHEMA = ?
+               ORDER BY TABLE_NAME"#
+        }
+    };
+    let mut q = sqlx::query(sql);
+    if !use_default {
+        q = q.bind(schema);
+    }
+    if let Some(v) = only {
+        q = q.bind(v);
+    }
+    let rows = q.fetch_all(pool).await.map_err(MigrateError::Driver)?;
+    Ok(rows
+        .into_iter()
+        .map(|r| r.try_get::<String, _>("TABLE_NAME").unwrap_or_default())
+        .collect())
+}
+
+#[cfg(feature = "mysql")]
+async fn view_definition_my(
+    pool: &sqlx::MySqlPool,
+    schema: &str,
+    view: &str,
+) -> Result<Option<String>, MigrateError> {
+    let use_default = schema == "public" || schema.is_empty();
+    let sql = if use_default {
+        r#"SELECT CAST(VIEW_DEFINITION AS CHAR) AS VIEW_DEFINITION
+           FROM information_schema.views
+           WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?"#
+    } else {
+        r#"SELECT CAST(VIEW_DEFINITION AS CHAR) AS VIEW_DEFINITION
+           FROM information_schema.views
+           WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?"#
+    };
+    let mut q = sqlx::query_scalar::<_, Option<String>>(sql);
+    if !use_default {
+        q = q.bind(schema);
+    }
+    q = q.bind(view);
+    let row = q.fetch_optional(pool).await.map_err(MigrateError::Driver)?;
+    Ok(row.flatten())
+}
+
 // -------------------------------------------------------------- SQLite
 
 #[cfg(feature = "sqlite")]
@@ -724,6 +894,43 @@ async fn list_fks_sqlite(
         out.push((local, target));
     }
     Ok(out)
+}
+
+#[cfg(feature = "sqlite")]
+async fn list_views_sqlite(
+    pool: &sqlx::SqlitePool,
+    only: Option<&str>,
+) -> Result<Vec<String>, MigrateError> {
+    use sqlx::Row as _;
+    let sql = if only.is_some() {
+        "SELECT name FROM sqlite_master WHERE type = 'view' AND name NOT LIKE 'sqlite_%' AND name = ? ORDER BY name"
+    } else {
+        "SELECT name FROM sqlite_master WHERE type = 'view' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    };
+    let mut q = sqlx::query(sql);
+    if let Some(v) = only {
+        q = q.bind(v);
+    }
+    let rows = q.fetch_all(pool).await.map_err(MigrateError::Driver)?;
+    Ok(rows
+        .into_iter()
+        .map(|r| r.try_get::<String, _>("name").unwrap_or_default())
+        .collect())
+}
+
+#[cfg(feature = "sqlite")]
+async fn view_definition_sqlite(
+    pool: &sqlx::SqlitePool,
+    view: &str,
+) -> Result<Option<String>, MigrateError> {
+    let def: Option<String> =
+        sqlx::query_scalar("SELECT sql FROM sqlite_master WHERE type = 'view' AND name = ?")
+            .bind(view)
+            .fetch_optional(pool)
+            .await
+            .map_err(MigrateError::Driver)?
+            .flatten();
+    Ok(def)
 }
 
 #[cfg(feature = "sqlite")]
@@ -918,6 +1125,57 @@ fn write_model<W: Write>(
     fks: &[(String, String)],
 ) -> std::io::Result<()> {
     write_model_with_dialect(w, table, columns, pk_columns, fks, "postgres")
+}
+
+/// Emit one `#[derive(Model)]` block for a SQL view. Issue #293 /
+/// T2.10. The struct carries `#[rustango(view)]` so the migration
+/// runner skips it (the view is operator-owned). `view_definition` —
+/// when present — lands as a fenced doc comment above the struct so
+/// reviewers can read the SQL without hunting through `pg_views`.
+///
+/// Unlike `write_model_with_dialect`, view models do NOT emit a PK
+/// attribute or FK attributes: the view's underlying expression is
+/// already constrained by the source tables. Users editing the
+/// emitted source can add `#[rustango(primary_key)]` to the column
+/// they want to use as the ORM-side identity if the view exposes
+/// one (Django's `Meta.managed = False` convention).
+fn write_view_model_with_dialect<W: Write>(
+    w: &mut W,
+    view: &str,
+    columns: &[ColumnRow],
+    definition: Option<&str>,
+    dialect: &str,
+) -> std::io::Result<()> {
+    let struct_name = table_to_struct_name(view);
+    writeln!(w, "/// Auto-emitted from view `{view}` by `inspectdb`.")?;
+    writeln!(w, "///")?;
+    writeln!(
+        w,
+        "/// This struct is backed by a SQL **view** — `#[rustango(view)]` tells the"
+    )?;
+    writeln!(
+        w,
+        "/// migration runner to skip `CREATE TABLE` / `DROP TABLE` against it."
+    )?;
+    if let Some(def) = definition {
+        let trimmed = def.trim();
+        if !trimmed.is_empty() {
+            writeln!(w, "///")?;
+            writeln!(w, "/// ```sql")?;
+            for line in trimmed.lines() {
+                writeln!(w, "/// {}", escape_for_comment(line))?;
+            }
+            writeln!(w, "/// ```")?;
+        }
+    }
+    writeln!(w, "#[derive(Model, Debug, Clone)]")?;
+    writeln!(w, r#"#[rustango(table = "{view}", view)]"#)?;
+    writeln!(w, "pub struct {struct_name} {{")?;
+    for col in columns {
+        emit_field(w, col, None, &[], dialect)?;
+    }
+    writeln!(w, "}}")?;
+    Ok(())
 }
 
 fn write_model_with_dialect<W: Write>(

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -153,9 +153,17 @@ pub struct RelationSnapshot {
 
 impl SchemaSnapshot {
     /// Capture every model registered in the binary's `inventory`.
+    ///
+    /// Issue #293 / T2.10 — models marked `#[rustango(view)]` are
+    /// excluded. Their underlying SQL view is operator-owned, not
+    /// rustango-owned, so the diff machinery must never emit
+    /// `CREATE TABLE` / `DROP TABLE` against them.
     #[must_use]
     pub fn from_registry() -> Self {
-        let entries: Vec<&ModelEntry> = inventory::iter::<ModelEntry>.into_iter().collect();
+        let entries: Vec<&ModelEntry> = inventory::iter::<ModelEntry>
+            .into_iter()
+            .filter(|e| !e.schema.is_view)
+            .collect();
         let mut tables: Vec<TableSnapshot> = entries
             .iter()
             .map(|e| TableSnapshot::from_schema(e.schema))
@@ -187,7 +195,7 @@ impl SchemaSnapshot {
     pub fn from_registry_for_scope(scope: crate::core::ModelScope) -> Self {
         let entries: Vec<&ModelEntry> = inventory::iter::<ModelEntry>
             .into_iter()
-            .filter(|e| e.schema.scope == scope)
+            .filter(|e| e.schema.scope == scope && !e.schema.is_view)
             .collect();
         let mut tables: Vec<TableSnapshot> = entries
             .iter()
@@ -272,7 +280,7 @@ impl SchemaSnapshot {
     pub fn from_registry_for_app(app: &str) -> Self {
         let entries: Vec<&ModelEntry> = inventory::iter::<ModelEntry>
             .into_iter()
-            .filter(|e| e.resolved_app_label() == Some(app))
+            .filter(|e| e.resolved_app_label() == Some(app) && !e.schema.is_view)
             .collect();
         let mut tables: Vec<TableSnapshot> = entries
             .iter()
@@ -295,8 +303,12 @@ impl SchemaSnapshot {
     /// want a curated snapshot rather than every linked model (e.g.
     /// `rustango-tenancy`'s bootstrap migrations, which pin themselves
     /// to `rustango_orgs` + `rustango_operators` + `rustango_users`).
+    ///
+    /// View-backed models (`#[rustango(view)]`) are filtered out — same
+    /// rule as [`from_registry`].
     #[must_use]
     pub fn from_models(models: &[&ModelSchema]) -> Self {
+        let models: Vec<&ModelSchema> = models.iter().copied().filter(|s| !s.is_view).collect();
         let mut tables: Vec<TableSnapshot> = models
             .iter()
             .map(|s| TableSnapshot::from_schema(s))
@@ -544,6 +556,7 @@ mod composite_fk_snapshot_tests {
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
             default_order: &[],
+            is_view: false,
         };
         &MS
     }
@@ -597,6 +610,7 @@ mod composite_fk_snapshot_tests {
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
             default_order: &[],
+            is_view: false,
         };
         let snap = TableSnapshot::from_schema(&MS);
         let json = serde_json::to_string(&snap).expect("serialize");

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -267,6 +267,7 @@ mod tests {
         generic_relations: &[],
         scope: crate::core::ModelScope::Tenant,
         default_order: &[],
+        is_view: false,
     };
 
     static MODEL_WITHOUT_SD: ModelSchema = ModelSchema {
@@ -286,6 +287,7 @@ mod tests {
         generic_relations: &[],
         scope: crate::core::ModelScope::Tenant,
         default_order: &[],
+        is_view: false,
     };
 
     #[test]

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -1259,6 +1259,7 @@ mod tests {
             // (mysql introspection isn't used for registry models).
             scope: crate::core::ModelScope::Tenant,
             default_order: &[],
+            is_view: false,
         }))
     }
 }

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -649,6 +649,7 @@ mod tests {
             generic_relations: &[],
             scope: ModelScope::Tenant,
             default_order: &[],
+            is_view: false,
         };
         let q = SelectQuery {
             model: &MODEL,

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -3866,6 +3866,7 @@ mod tests {
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
             default_order: &[],
+            is_view: false,
         }))
     }
 
@@ -3939,6 +3940,7 @@ mod tests {
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
             default_order: &[],
+            is_view: false,
         }))
     }
 
@@ -4310,6 +4312,7 @@ mod tests {
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
             default_order: &[],
+            is_view: false,
         }));
         assert!(default_order_by(no_pk).is_empty());
     }
@@ -4547,6 +4550,7 @@ mod tests {
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
             default_order: &[],
+            is_view: false,
         }));
         let pk = uuid_schema.primary_key().unwrap();
         let raw = "550e8400-e29b-41d4-a716-446655440000";
@@ -4596,6 +4600,7 @@ mod tests {
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
             default_order: &[],
+            is_view: false,
         }));
         let pk = str_schema.primary_key().unwrap();
         match coerce_pk(pk, "hello-world") {

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -405,6 +405,7 @@ mod tests {
             generic_relations: &[],
             scope: crate::core::ModelScope::Tenant,
             default_order: &[],
+            is_view: false,
         };
         &MS
     }

--- a/crates/rustango/tests/inspectdb_live.rs
+++ b/crates/rustango/tests/inspectdb_live.rs
@@ -212,7 +212,61 @@ async fn inspectdb_unknown_schema_emits_friendly_comment() {
     .expect("inspectdb succeeds even on empty schema");
     let out = String::from_utf8(buf).unwrap();
     assert!(
-        out.contains("no tables found"),
+        out.contains("no tables or views found"),
         "expected friendly empty-schema comment, got: {out}"
     );
+}
+
+/// View-walking on PG — issue #293 / T2.10. Creates a view alongside
+/// the table fixture, runs inspectdb, asserts the view emission
+/// carries the `view` marker plus the view definition in the doc
+/// comment.
+#[tokio::test]
+async fn inspectdb_emits_view_with_marker_and_definition_on_pg() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else { return };
+    fresh_fixture(&pool).await;
+    sqlx::query("DROP VIEW IF EXISTS inspectdb_published_posts")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE VIEW inspectdb_published_posts AS
+            SELECT id, author_id, slug FROM inspectdb_post WHERE published = true",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let mut buf: Vec<u8> = Vec::new();
+    let pool_enum: rustango::sql::Pool = pool.clone().into();
+    rustango::migrate::manage::run_with_writer(
+        &pool_enum,
+        std::path::Path::new("/tmp/_inspectdb_unused"),
+        vec!["inspectdb".into()],
+        &mut buf,
+    )
+    .await
+    .expect("inspectdb succeeds");
+    let out = String::from_utf8(buf).unwrap();
+
+    assert!(
+        out.contains("pub struct InspectdbPublishedPosts"),
+        "view should emit a PascalCased struct, got:\n{out}"
+    );
+    assert!(
+        out.contains(r#"#[rustango(table = "inspectdb_published_posts", view)]"#),
+        "view emission must carry the `view` marker, got:\n{out}"
+    );
+    assert!(
+        out.contains("```sql"),
+        "view definition should land in a fenced ```sql block, got:\n{out}"
+    );
+
+    // Cleanup so the next test that uses fresh_fixture isn't blocked
+    // by the dependent view.
+    sqlx::query("DROP VIEW IF EXISTS inspectdb_published_posts")
+        .execute(&pool)
+        .await
+        .unwrap();
 }

--- a/crates/rustango/tests/inspectdb_mysql_live.rs
+++ b/crates/rustango/tests/inspectdb_mysql_live.rs
@@ -137,3 +137,58 @@ async fn inspectdb_filters_by_table_flag_on_mysql() {
         "did NOT expect Posts when filtered to authors, got:\n{out}"
     );
 }
+
+/// View-walking on MySQL — issue #293 / T2.10. Creates a view over
+/// `posts`, runs inspectdb, asserts the view emission carries the
+/// `view` marker and the view body lands in the doc comment.
+#[tokio::test]
+async fn inspectdb_emits_view_with_marker_and_definition_on_mysql() {
+    let _serial = serial_lock().lock().await;
+    let Some(pool) = make_pool().await else {
+        return;
+    };
+    let pool_inner = match &pool {
+        Pool::Mysql(p) => p.clone(),
+        _ => unreachable!(),
+    };
+    let _ = sqlx::query("DROP VIEW IF EXISTS `published_posts`")
+        .execute(&pool_inner)
+        .await;
+    sqlx::query(
+        "CREATE VIEW `published_posts` AS
+            SELECT `id`, `author_id`, `title` FROM `posts` WHERE `published` = 1",
+    )
+    .execute(&pool_inner)
+    .await
+    .unwrap();
+
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::migrate::manage::run_with_writer(
+        &pool,
+        std::path::Path::new("./migrations"),
+        vec!["inspectdb".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("inspectdb_cmd");
+    let out = String::from_utf8(buf).expect("utf8 output");
+
+    assert!(
+        out.contains("pub struct PublishedPosts"),
+        "expected `pub struct PublishedPosts` (view), got:\n{out}"
+    );
+    assert!(
+        out.contains(r#"#[rustango(table = "published_posts", view)]"#),
+        "view emission must carry the `view` marker, got:\n{out}"
+    );
+    assert!(
+        out.contains("```sql"),
+        "view definition should land in a fenced ```sql block, got:\n{out}"
+    );
+
+    // Cleanup so a re-run of `make_pool` (which drops only tables)
+    // doesn't trip over a stale dependent view.
+    let _ = sqlx::query("DROP VIEW IF EXISTS `published_posts`")
+        .execute(&pool_inner)
+        .await;
+}

--- a/crates/rustango/tests/inspectdb_views_sqlite_live.rs
+++ b/crates/rustango/tests/inspectdb_views_sqlite_live.rs
@@ -1,0 +1,120 @@
+#![cfg(feature = "sqlite")]
+//! `manage inspectdb` view-walking on SQLite — closes #293 / T2.10.
+//!
+//! Creates a fixture DB with a table AND a view, runs inspectdb, and
+//! asserts the emitted source contains:
+//!   1. The table's `#[derive(Model)]` block (unchanged behavior).
+//!   2. A view-backed `#[derive(Model)]` block carrying both
+//!      `table = "..."` and the `view` marker.
+//!   3. The view's underlying SQL as a fenced ```sql doc-comment
+//!      block above the struct so reviewers can read it inline.
+
+use rustango::sql::Pool;
+
+async fn make_pool() -> Pool {
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().display());
+    std::mem::forget(tmp);
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .expect("sqlite connect");
+
+    sqlx::query(
+        "CREATE TABLE orders (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            customer  VARCHAR(80) NOT NULL,
+            total     INTEGER NOT NULL
+         )",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE VIEW big_orders AS
+            SELECT id, customer, total FROM orders WHERE total > 1000",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    Pool::Sqlite(pool)
+}
+
+#[tokio::test]
+async fn inspectdb_walks_views_and_emits_view_marker_on_sqlite() {
+    let pool = make_pool().await;
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::migrate::manage::run_with_writer(
+        &pool,
+        std::path::Path::new("./migrations"),
+        vec!["inspectdb".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("inspectdb_cmd");
+    let out = String::from_utf8(buf).expect("utf8 output");
+
+    // Table half — emitted as before.
+    assert!(
+        out.contains("pub struct Orders"),
+        "expected `pub struct Orders` (table), got:\n{out}"
+    );
+    assert!(
+        out.contains(r#"#[rustango(table = "orders")]"#),
+        "table emission should not carry the `view` flag, got:\n{out}"
+    );
+
+    // View half — emitted with the `view` marker.
+    assert!(
+        out.contains("pub struct BigOrders"),
+        "expected `pub struct BigOrders` (view), got:\n{out}"
+    );
+    assert!(
+        out.contains(r#"#[rustango(table = "big_orders", view)]"#),
+        "expected `#[rustango(table = \"big_orders\", view)]` on view emission, got:\n{out}"
+    );
+
+    // The view definition must land in the doc comment as a fenced
+    // ```sql block so reviewers can read it without `pg_views`.
+    assert!(
+        out.contains("```sql"),
+        "expected fenced ```sql block for the view definition, got:\n{out}"
+    );
+    assert!(
+        out.contains("SELECT"),
+        "expected the view body to appear in the doc comment, got:\n{out}"
+    );
+    assert!(
+        out.contains("WHERE total > 1000"),
+        "expected the view's WHERE clause in the doc comment, got:\n{out}"
+    );
+}
+
+#[tokio::test]
+async fn inspectdb_table_only_run_excludes_views_on_sqlite() {
+    let pool = make_pool().await;
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::migrate::manage::run_with_writer(
+        &pool,
+        std::path::Path::new("./migrations"),
+        vec![
+            "inspectdb".to_owned(),
+            "--table".to_owned(),
+            "orders".to_owned(),
+        ],
+        &mut buf,
+    )
+    .await
+    .expect("inspectdb_cmd --table=orders");
+    let out = String::from_utf8(buf).expect("utf8 output");
+    assert!(
+        out.contains("pub struct Orders"),
+        "expected Orders when --table=orders, got:\n{out}"
+    );
+    assert!(
+        !out.contains("pub struct BigOrders"),
+        "--table filter should not pull the view through, got:\n{out}"
+    );
+}

--- a/crates/rustango/tests/view_marker.rs
+++ b/crates/rustango/tests/view_marker.rs
@@ -1,0 +1,56 @@
+//! `#[rustango(view)]` marker — closes #293 / T2.10.
+//!
+//! Pins:
+//!   1. The flag parses and lands on `ModelSchema::is_view`.
+//!   2. View-backed models are excluded from `SchemaSnapshot::from_models`
+//!      (the snapshot is what `makemigrations` diffs against, so the
+//!      migration runner never emits CREATE/DROP TABLE for the view).
+//!   3. Default `is_view = false` when the attribute isn't present.
+
+use rustango::core::Model as _;
+use rustango::migrate::snapshot::SchemaSnapshot;
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "vmk_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 100)]
+    title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "vmk_big_post", view)]
+#[allow(dead_code)]
+pub struct BigPost {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 100)]
+    title: String,
+    views: i64,
+}
+
+#[test]
+fn view_flag_lands_on_schema() {
+    assert!(BigPost::SCHEMA.is_view, "view flag must set is_view = true");
+    assert!(
+        !Post::SCHEMA.is_view,
+        "no flag must default to is_view = false"
+    );
+}
+
+#[test]
+fn snapshot_from_models_skips_view_backed_schemas() {
+    let snap = SchemaSnapshot::from_models(&[Post::SCHEMA, BigPost::SCHEMA]);
+    let names: Vec<&str> = snap.tables.iter().map(|t| t.name.as_str()).collect();
+    assert!(
+        names.contains(&"vmk_post"),
+        "table-backed model must be in the snapshot: {names:?}"
+    );
+    assert!(
+        !names.contains(&"vmk_big_post"),
+        "view-backed model must NOT land in the snapshot (migrate would emit CREATE TABLE against the view): {names:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #293 / T2.10.

`manage inspectdb` now walks SQL views in addition to tables, and the emitted view-models carry a new `#[rustango(view)]` marker that excludes them from the migration snapshot — so `makemigrations` / `migrate` never try to manage an operator-owned view.

## What's in

### inspectdb view introspection

Per-dialect dispatch:

- **PostgreSQL** — `information_schema.views`
- **MySQL** — `information_schema.views` with the same `CAST AS CHAR` workaround for VARBINARY columns the table path already uses
- **SQLite** — `sqlite_master WHERE type = 'view'`

Each view-model is emitted with:
- `#[derive(Model, Debug, Clone)]`
- `#[rustango(table = "<view_name>", view)]`
- A fenced ```sql``` doc-comment block containing the view's `view_definition` (PG/MySQL) or its original `CREATE VIEW` SQL (SQLite) — so reviewers see the view body inline.

### `#[rustango(view)]` macro flag

- New `is_view: bool` on `ModelSchema`, default `false`.
- Macro parses both `#[rustango(view)]` (flag) and `#[rustango(view = true|false)]` (matching the existing `permissions` pattern).
- All 12 inline `ModelSchema` literal sites updated.

### Migration snapshot filter

- `SchemaSnapshot::from_registry`, `from_registry_for_scope`, `from_registry_for_app`, `from_models` all filter view-backed schemas OUT of the snapshot before diffing. This is the load-bearing skip — the diff machinery itself doesn't need to be view-aware.

## Tri-dialect

- `cargo build --no-default-features --features sqlite,tenancy` — passes
- `cargo test --workspace --all-features --no-run` — passes
- Per-dialect live tests added on all three backends

## Tests

- `tests/inspectdb_views_sqlite_live.rs` — 2 tests (view emission + `--table` filter excludes views). Added to `ci.yml` `sqlite_live` list.
- `tests/view_marker.rs` — 2 unit tests (flag → schema; snapshot filter excludes views).
- `tests/inspectdb_live.rs` — 1 new PG view-walking test + updated "no tables or views found" assertion.
- `tests/inspectdb_mysql_live.rs` — 1 new MySQL view-walking test.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy`
- [x] `cargo test --workspace --all-features --no-run`
- [x] `cargo test -p rustango --features sqlite,tenancy --test inspectdb_views_sqlite_live --test view_marker` — 4/4 pass
- [x] `cargo test -p rustango --features tenancy --lib` — 2273/2273 pass
- [x] `cargo fmt --all -- --check` + `cargo clippy -p rustango --features tenancy --lib --no-deps`