### PR TITLE
feat: Postgres full-text-search builder — SearchVector/Query/Rank/Headline (closes #295)

### DIFF
--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -480,6 +480,20 @@ pub enum ScalarFn {
     /// "hour" | "minute" | "second"`. Other values emit
     /// `OpNotSupportedInDialect`. Arity 3: `(ts, unit, tz)`.
     TruncWithTz,
+
+    // --- Full-text-search builder (issue #295 / T2.4) ---
+    /// `setweight(<tsvector>, <'A'|'B'|'C'|'D'>)` — Postgres weighting
+    /// modifier used by [`crate::core::fts::SearchVector::weighted`].
+    /// **PG-only**; MySQL / SQLite reject with
+    /// `OpNotSupportedInDialect`. Arity 2: `(tsvector, weight_literal)`
+    /// where the weight literal is an `Expr::Literal(SqlValue::String("A"))`-shaped value.
+    SetWeight,
+    /// `(a || b || c)` over tsvector operands — Postgres uses the `||`
+    /// operator to concatenate tsvectors. The builder uses this rather
+    /// than `Concat` (which would emit `CONCAT(...)` returning text
+    /// and dropping tsvector semantics). **PG-only**; MySQL / SQLite
+    /// reject with `OpNotSupportedInDialect`. Variadic ≥ 2 args.
+    TsConcat,
 }
 
 impl Expr {

--- a/crates/rustango/src/core/fts.rs
+++ b/crates/rustango/src/core/fts.rs
@@ -1,0 +1,297 @@
+//! Postgres full-text search builder — closes #295 / T2.4.
+//!
+//! Composable wrapper over the `to_tsvector` / `*_tsquery` / `ts_rank` /
+//! `ts_headline` scalar functions added in #266 / T1.4. Replaces the
+//! hand-rolled `Expr::Function { kind: ScalarFn::ToTsVector, … }`
+//! incantation with a discoverable builder shape that matches Django's
+//! `django.contrib.postgres.search` API.
+//!
+//! **Postgres-only by language semantics.** MySQL's `MATCH … AGAINST`
+//! requires a `FULLTEXT INDEX` on the column and only matches against
+//! the indexed columns; SQLite's FTS5 virtual tables require a
+//! separate `CREATE VIRTUAL TABLE` and don't compose against bare
+//! columns. Neither shape maps onto this builder's "build a tsvector
+//! from arbitrary expressions, match it against a tsquery" semantics,
+//! so the writer emits [`crate::sql::SqlError::OpNotSupportedInDialect`]
+//! on non-PG.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use rustango::core::F;
+//! use rustango::core::fts::{SearchQuery, SearchRank, SearchVector, Weight};
+//!
+//! // Weighted multi-column vector — `title` matches outweigh `body`.
+//! let v = SearchVector::weighted(&[(F("title"), Weight::A), (F("body"), Weight::B)]);
+//! let q = SearchQuery::plain("alice");
+//!
+//! Post::objects()
+//!     .annotate("rank", SearchRank::new(&v, &q))
+//!     .where_raw(v.matches(&q))
+//!     .order_by_expr(SearchRank::new(&v, &q), true) // rank DESC
+//!     .fetch_pool(&pool).await?;
+//! ```
+//!
+//! ## API surface
+//!
+//! - [`Weight`] — A / B / C / D weighting class (Django parity).
+//! - [`SearchVector::single`] / [`SearchVector::weighted`] — tsvector LHS.
+//! - [`SearchQuery::plain`] / [`::phrase`] / [`::websearch`] / [`::raw`] —
+//!   tsquery RHS, mapping onto the four PG parsers
+//!   (`plainto_tsquery`, `phraseto_tsquery`, `websearch_to_tsquery`,
+//!   `to_tsquery`).
+//! - [`SearchVector::matches`] — composes a
+//!   [`WhereExpr`](crate::core::WhereExpr) for `.where_raw(...)`.
+//! - [`SearchRank::new`] / [`SearchHeadline::new`] — `Expr`-returning
+//!   annotations.
+
+use super::expr::{Expr, ScalarFn};
+use super::query::{Op, WhereExpr};
+use super::value::SqlValue;
+
+/// Postgres tsvector weight class — Django parity.
+///
+/// Weights bias `ts_rank` so matches in higher-weighted positions
+/// outrank lower-weighted ones. Customary use is A for title, B for
+/// summary, C for body, D for tags / metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Weight {
+    /// Highest priority. `setweight(..., 'A')`.
+    A,
+    /// `setweight(..., 'B')`.
+    B,
+    /// `setweight(..., 'C')`.
+    C,
+    /// Lowest priority. `setweight(..., 'D')`.
+    D,
+}
+
+impl Weight {
+    fn as_literal(self) -> Expr {
+        let s = match self {
+            Self::A => "A",
+            Self::B => "B",
+            Self::C => "C",
+            Self::D => "D",
+        };
+        Expr::Literal(SqlValue::String(s.to_owned()))
+    }
+}
+
+/// A Postgres `tsvector` — the searchable side of a `@@` match.
+///
+/// Built from one or more text expressions. Construct via
+/// [`SearchVector::single`] (single column / expression) or
+/// [`SearchVector::weighted`] (multi-column with per-column weighting).
+#[derive(Debug, Clone)]
+pub struct SearchVector {
+    /// The compiled tsvector expression. For `single` this is
+    /// `to_tsvector(<col>)`; for `weighted` it's `(setweight(...) ||
+    /// setweight(...) || …)`.
+    expr: Expr,
+}
+
+impl SearchVector {
+    /// `to_tsvector(<expr>)` — single-column vector. The expression is
+    /// typically a column reference via `F("title")`, but any text-
+    /// returning expression works.
+    #[must_use]
+    pub fn single(text: impl Into<Expr>) -> Self {
+        Self {
+            expr: Expr::Function {
+                kind: ScalarFn::ToTsVector,
+                args: vec![text.into()],
+            },
+        }
+    }
+
+    /// `setweight(to_tsvector(c1), 'A') || setweight(to_tsvector(c2),
+    /// 'B') || …` — weighted multi-column vector. Each `(expr, weight)`
+    /// pair becomes one `setweight(to_tsvector(...))` clause; the
+    /// emitter concatenates them with the PG `||` operator.
+    ///
+    /// Returns a vector that matches Django's
+    /// `SearchVector('title', weight='A') + SearchVector('body',
+    /// weight='B')` shape. Empty input is rejected at write time with
+    /// a clear error.
+    #[must_use]
+    pub fn weighted<I, E>(pairs: I) -> Self
+    where
+        I: IntoIterator<Item = (E, Weight)>,
+        E: Into<Expr>,
+    {
+        let weighted: Vec<Expr> = pairs
+            .into_iter()
+            .map(|(text, w)| Expr::Function {
+                kind: ScalarFn::SetWeight,
+                args: vec![
+                    Expr::Function {
+                        kind: ScalarFn::ToTsVector,
+                        args: vec![text.into()],
+                    },
+                    w.as_literal(),
+                ],
+            })
+            .collect();
+        // Single-column weighted case: emit one setweight, no TsConcat
+        // wrapper (the wrapper's arity gate would reject a 1-arg input).
+        let expr = if weighted.len() == 1 {
+            // Take the only element out of the Vec by index.
+            weighted.into_iter().next().expect("weighted.len() == 1")
+        } else {
+            Expr::Function {
+                kind: ScalarFn::TsConcat,
+                args: weighted,
+            }
+        };
+        Self { expr }
+    }
+
+    /// Borrow the underlying [`Expr`]. Useful for compositional callers
+    /// that want to inject the vector into a larger expression tree.
+    #[must_use]
+    pub fn as_expr(&self) -> &Expr {
+        &self.expr
+    }
+
+    /// Produce a [`WhereExpr`] that matches this vector against the
+    /// supplied [`SearchQuery`]: `<vector> @@ <query>`.
+    ///
+    /// Chain into `.where_raw(...)` on a [`QuerySet`](crate::query::QuerySet).
+    #[must_use]
+    pub fn matches(&self, query: &SearchQuery) -> WhereExpr {
+        WhereExpr::ExprCompare {
+            lhs: self.expr.clone(),
+            op: Op::Search,
+            rhs: query.as_expr().clone(),
+        }
+    }
+}
+
+/// A Postgres `tsquery` — the search-term side of a `@@` match.
+///
+/// Built from a free-form query string via one of the four PG query
+/// parsers. Each variant maps onto a different syntax flavor:
+///
+/// - [`SearchQuery::plain`] — `plainto_tsquery`: user-facing keyword
+///   list, AND semantics, no operator characters.
+/// - [`SearchQuery::phrase`] — `phraseto_tsquery`: word-order
+///   preserving (`'rust orm'` → `'rust' <-> 'orm'`).
+/// - [`SearchQuery::websearch`] — `websearch_to_tsquery`: Google-style
+///   syntax (quoted "exact phrase", `-exclude`, the literal `OR`).
+/// - [`SearchQuery::raw`] — `to_tsquery`: low-level pre-parsed syntax
+///   (`'rust & orm'`, `'rust | python'`, `'rust & !python'`). Caller
+///   is responsible for valid tsquery syntax.
+#[derive(Debug, Clone)]
+pub struct SearchQuery {
+    expr: Expr,
+}
+
+impl SearchQuery {
+    /// `plainto_tsquery(<text>)`.
+    #[must_use]
+    pub fn plain(text: impl Into<String>) -> Self {
+        Self::from_parser(ScalarFn::PlainToTsQuery, text)
+    }
+
+    /// `phraseto_tsquery(<text>)`. Preserves word order.
+    #[must_use]
+    pub fn phrase(text: impl Into<String>) -> Self {
+        Self::from_parser(ScalarFn::PhraseToTsQuery, text)
+    }
+
+    /// `websearch_to_tsquery(<text>)`. Google-style operators.
+    #[must_use]
+    pub fn websearch(text: impl Into<String>) -> Self {
+        Self::from_parser(ScalarFn::WebsearchToTsQuery, text)
+    }
+
+    /// `to_tsquery(<text>)` — pre-parsed `tsquery` syntax. Caller must
+    /// produce a valid query (`'rust & orm'`, `'rust | python'`,
+    /// `'rust & !python'`).
+    #[must_use]
+    pub fn raw(text: impl Into<String>) -> Self {
+        Self::from_parser(ScalarFn::ToTsQuery, text)
+    }
+
+    fn from_parser(kind: ScalarFn, text: impl Into<String>) -> Self {
+        Self {
+            expr: Expr::Function {
+                kind,
+                args: vec![Expr::Literal(SqlValue::String(text.into()))],
+            },
+        }
+    }
+
+    /// Borrow the underlying [`Expr`].
+    #[must_use]
+    pub fn as_expr(&self) -> &Expr {
+        &self.expr
+    }
+}
+
+/// `ts_rank(<vector>, <query>)` — relevance score (`real` between
+/// 0.0 and 1.0). Annotate via `.annotate("rank", SearchRank::new(...))`
+/// and sort by it via `.order_by_expr(..., true)` for "best first".
+#[derive(Debug, Clone)]
+pub struct SearchRank;
+
+impl SearchRank {
+    /// Build the `ts_rank(<vector>, <query>)` [`Expr`].
+    #[must_use]
+    pub fn new(vector: &SearchVector, query: &SearchQuery) -> Expr {
+        Expr::Function {
+            kind: ScalarFn::TsRank,
+            args: vec![vector.expr.clone(), query.expr.clone()],
+        }
+    }
+
+    /// Build `ts_rank_cd(<vector>, <query>)` — cover-density variant,
+    /// better for short documents.
+    #[must_use]
+    pub fn cover_density(vector: &SearchVector, query: &SearchQuery) -> Expr {
+        Expr::Function {
+            kind: ScalarFn::TsRankCd,
+            args: vec![vector.expr.clone(), query.expr.clone()],
+        }
+    }
+}
+
+/// `ts_headline(<doc>, <query> [, <options>])` — Postgres FTS snippet
+/// generator. Returns the document with matching terms wrapped in
+/// highlight markers (`<b>…</b>` by default).
+///
+/// `doc` is the text to highlight (typically `F("body")`); `query` is
+/// the same `SearchQuery` you passed to `SearchRank` / `matches`.
+#[derive(Debug, Clone)]
+pub struct SearchHeadline;
+
+impl SearchHeadline {
+    /// `ts_headline(<doc>, <query>)` — default highlight markers.
+    #[must_use]
+    pub fn new(doc: impl Into<Expr>, query: &SearchQuery) -> Expr {
+        Expr::Function {
+            kind: ScalarFn::TsHeadline,
+            args: vec![doc.into(), query.expr.clone()],
+        }
+    }
+
+    /// `ts_headline(<doc>, <query>, <options>)` — override the highlight
+    /// markers and fragment count via PG's options-string syntax, e.g.
+    /// `"StartSel='<mark>', StopSel='</mark>', MaxFragments=1"`.
+    #[must_use]
+    pub fn with_options(
+        doc: impl Into<Expr>,
+        query: &SearchQuery,
+        options: impl Into<String>,
+    ) -> Expr {
+        Expr::Function {
+            kind: ScalarFn::TsHeadline,
+            args: vec![
+                doc.into(),
+                query.expr.clone(),
+                Expr::Literal(SqlValue::String(options.into())),
+            ],
+        }
+    }
+}

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -9,6 +9,7 @@ mod column;
 mod error;
 mod expr;
 mod field_type;
+pub mod fts;
 pub mod funcs;
 pub mod joins;
 mod query;

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -1954,6 +1954,10 @@ fn write_function(
         F::MakeInterval => write_make_interval(b, args),
         F::Age => write_age(b, args),
         F::TruncWithTz => write_trunc_with_tz(b, args),
+
+        // -------- Full-text search builder (issue #295 / T2.4) --------
+        F::SetWeight => write_setweight(b, args),
+        F::TsConcat => write_ts_concat(b, args),
     }
 }
 
@@ -2453,6 +2457,82 @@ fn sqlite_trunc_mask(unit: &str) -> &'static str {
     }
 }
 
+// ====================================================================
+// Full-text-search builder (issue #295 / T2.4)
+// ====================================================================
+
+/// `setweight(<tsvector>, '<weight>')`. **PG-only**. The weight is
+/// carried as `Expr::Literal(SqlValue::String("A"))` so the writer can
+/// inline it (PG's `setweight` requires the weight literal to live in
+/// the SQL text, not in a bound parameter — `bind` rejects char-typed
+/// inputs and a quoted `'A'` is the only portable form).
+fn write_setweight(b: &mut Sql<'_>, args: &[crate::core::Expr]) -> Result<(), SqlError> {
+    use crate::core::{Expr, SqlValue};
+    if args.len() != 2 {
+        return Err(SqlError::FunctionArityMismatch {
+            func: "setweight",
+            expected: "2",
+            got: args.len(),
+        });
+    }
+    if b.d.name() != "postgres" {
+        return Err(SqlError::OpNotSupportedInDialect {
+            op: "setweight (FTS) is Postgres-only",
+            dialect: b.d.name(),
+        });
+    }
+    let weight = match &args[1] {
+        Expr::Literal(SqlValue::String(w)) => w.as_str(),
+        _ => {
+            return Err(SqlError::OpNotSupportedInDialect {
+                op: "setweight weight argument must be a string literal — build via fts::SearchVector::weighted",
+                dialect: b.d.name(),
+            });
+        }
+    };
+    if !matches!(weight, "A" | "B" | "C" | "D") {
+        return Err(SqlError::OpNotSupportedInDialect {
+            op: "setweight weight must be one of 'A' | 'B' | 'C' | 'D'",
+            dialect: b.d.name(),
+        });
+    }
+    b.sql.push_str("setweight(");
+    write_expr(b, &args[0], None)?;
+    b.sql.push_str(", '");
+    b.sql.push_str(weight);
+    b.sql.push_str("')");
+    Ok(())
+}
+
+/// `(a || b || c)` — Postgres tsvector concatenation. **PG-only**;
+/// MySQL / SQLite reject because their FTS shapes are schema-bound
+/// (FULLTEXT INDEX + MATCH/AGAINST on MySQL, FTS5 virtual tables on
+/// SQLite) and don't compose with `||`.
+fn write_ts_concat(b: &mut Sql<'_>, args: &[crate::core::Expr]) -> Result<(), SqlError> {
+    if args.len() < 2 {
+        return Err(SqlError::FunctionArityMismatch {
+            func: "ts_concat (||)",
+            expected: ">= 2",
+            got: args.len(),
+        });
+    }
+    if b.d.name() != "postgres" {
+        return Err(SqlError::OpNotSupportedInDialect {
+            op: "tsvector `||` concatenation (FTS) is Postgres-only",
+            dialect: b.d.name(),
+        });
+    }
+    b.sql.push('(');
+    for (i, a) in args.iter().enumerate() {
+        if i > 0 {
+            b.sql.push_str(" || ");
+        }
+        write_expr(b, a, None)?;
+    }
+    b.sql.push(')');
+    Ok(())
+}
+
 /// Emit an `EXTRACT(<field> FROM x)` family call. PG uses the SQL
 /// standard syntax + cast to integer; MySQL has direct per-field
 /// functions; SQLite routes through `strftime` + cast.
@@ -2892,6 +2972,19 @@ fn write_expr_compare(
     }
 
     match op {
+        Op::Search => {
+            // PG full-text search match: `<tsvector> @@ <tsquery>`.
+            // **PG-only by language semantics** — MySQL's MATCH … AGAINST
+            // and SQLite's FTS5 virtual tables don't compose with bare
+            // expression operands. `require_op` routes through the
+            // dialect to surface the same OpNotSupportedInDialect that
+            // the column-bound Op::Search path emits on non-PG.
+            require_op(b.d, op)?;
+            write_expr(b, lhs, None)?;
+            b.sql.push_str(" @@ ");
+            write_expr(b, rhs, None)?;
+            Ok(())
+        }
         Op::ILike | Op::NotILike => {
             require_op(b.d, op)?;
             // Render lhs first so its params land in the param vector

--- a/crates/rustango/tests/fts_builder.rs
+++ b/crates/rustango/tests/fts_builder.rs
@@ -1,0 +1,224 @@
+//! Full-text-search builder — closes #295 / T2.4.
+//!
+//! Pins the PG emission shape for `SearchVector` / `SearchQuery` /
+//! `SearchRank` / `SearchHeadline` and verifies MySQL + SQLite reject
+//! with `OpNotSupportedInDialect`. FTS is **PG-only by language
+//! semantics**, so non-PG dialects MUST surface a clear error rather
+//! than silently fall back to ILIKE.
+
+use rustango::core::fts::{SearchHeadline, SearchQuery, SearchRank, SearchVector, Weight};
+use rustango::core::{Expr, F};
+use rustango::sql::{Dialect, MySql, Postgres, SqlError, Sqlite};
+
+fn pg(e: &Expr) -> Result<String, SqlError> {
+    write_for_test(&Postgres, e)
+}
+
+fn my(e: &Expr) -> Result<String, SqlError> {
+    write_for_test(&MySql, e)
+}
+
+fn sqlite(e: &Expr) -> Result<String, SqlError> {
+    write_for_test(&Sqlite, e)
+}
+
+fn write_for_test(dialect: &dyn Dialect, e: &Expr) -> Result<String, SqlError> {
+    use rustango::core::{Op, SqlValue, WhereExpr};
+    let qs = rustango::query::QuerySet::<NoModel>::default().where_raw(WhereExpr::ExprCompare {
+        lhs: e.clone(),
+        op: Op::Eq,
+        rhs: Expr::Literal(SqlValue::Bool(true)),
+    });
+    let select = qs.compile().unwrap();
+    Ok(dialect.compile_select(&select)?.sql)
+}
+
+fn write_where_for_test(
+    dialect: &dyn Dialect,
+    w: rustango::core::WhereExpr,
+) -> Result<String, SqlError> {
+    let qs = rustango::query::QuerySet::<NoModel>::default().where_raw(w);
+    let select = qs.compile().unwrap();
+    Ok(dialect.compile_select(&select)?.sql)
+}
+
+#[derive(rustango::Model, Debug, Clone)]
+#[rustango(table = "fts_demo")]
+#[allow(dead_code)]
+pub struct NoModel {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 200)]
+    title: String,
+    body: String,
+}
+
+// ---------- SearchVector ----------
+
+#[test]
+fn search_vector_single_emits_to_tsvector_call() {
+    let v = SearchVector::single(F("title"));
+    let pg = pg(v.as_expr()).unwrap();
+    assert!(pg.contains(r#"to_tsvector("title")"#), "PG: {pg}");
+}
+
+#[test]
+fn search_vector_weighted_emits_setweight_chain_on_pg() {
+    let v = SearchVector::weighted([(F("title"), Weight::A), (F("body"), Weight::B)]);
+    let pg = pg(v.as_expr()).unwrap();
+    assert!(
+        pg.contains(r#"setweight(to_tsvector("title"), 'A')"#),
+        "PG setweight A: {pg}"
+    );
+    assert!(
+        pg.contains(r#"setweight(to_tsvector("body"), 'B')"#),
+        "PG setweight B: {pg}"
+    );
+    // The two clauses must be joined by `||`.
+    assert!(pg.contains(" || "), "PG `||` concat: {pg}");
+}
+
+#[test]
+fn search_vector_weighted_single_pair_omits_concat_wrapper() {
+    // Single-column weighted: just one setweight, no `||` chain.
+    let v = SearchVector::weighted([(F("title"), Weight::A)]);
+    let pg = pg(v.as_expr()).unwrap();
+    assert!(
+        pg.contains(r#"setweight(to_tsvector("title"), 'A')"#),
+        "PG: {pg}"
+    );
+    assert!(!pg.contains(" || "), "single-pair must not chain: {pg}");
+}
+
+#[test]
+fn search_vector_weighted_errors_on_non_pg() {
+    let v = SearchVector::weighted([(F("title"), Weight::A), (F("body"), Weight::B)]);
+    for err in [
+        my(v.as_expr()).unwrap_err(),
+        sqlite(v.as_expr()).unwrap_err(),
+    ] {
+        assert!(matches!(err, SqlError::OpNotSupportedInDialect { .. }));
+    }
+}
+
+// ---------- SearchQuery ----------
+
+#[test]
+fn search_query_plain_emits_plainto_tsquery() {
+    let q = SearchQuery::plain("alice");
+    let pg = pg(q.as_expr()).unwrap();
+    assert!(pg.contains("plainto_tsquery("), "PG plain: {pg}");
+}
+
+#[test]
+fn search_query_phrase_emits_phraseto_tsquery() {
+    let q = SearchQuery::phrase("hello world");
+    let pg = pg(q.as_expr()).unwrap();
+    assert!(pg.contains("phraseto_tsquery("), "PG phrase: {pg}");
+}
+
+#[test]
+fn search_query_websearch_emits_websearch_to_tsquery() {
+    let q = SearchQuery::websearch(r#""rust orm" -django"#);
+    let pg = pg(q.as_expr()).unwrap();
+    assert!(pg.contains("websearch_to_tsquery("), "PG websearch: {pg}");
+}
+
+#[test]
+fn search_query_raw_emits_to_tsquery() {
+    let q = SearchQuery::raw("rust & !python");
+    let pg = pg(q.as_expr()).unwrap();
+    assert!(pg.contains("to_tsquery("), "PG raw: {pg}");
+}
+
+// ---------- matches() → WhereExpr ----------
+
+#[test]
+fn matches_emits_tsvector_at_at_tsquery_on_pg() {
+    let v = SearchVector::single(F("title"));
+    let q = SearchQuery::plain("alice");
+    let pg = write_where_for_test(&Postgres, v.matches(&q)).unwrap();
+    assert!(
+        pg.contains(r#"to_tsvector("title") @@ plainto_tsquery("#),
+        "PG @@ match: {pg}"
+    );
+}
+
+#[test]
+fn matches_errors_on_non_pg() {
+    let v = SearchVector::single(F("title"));
+    let q = SearchQuery::plain("alice");
+    for err in [
+        write_where_for_test(&MySql, v.matches(&q)).unwrap_err(),
+        write_where_for_test(&Sqlite, v.matches(&q)).unwrap_err(),
+    ] {
+        assert!(matches!(err, SqlError::OpNotSupportedInDialect { .. }));
+    }
+}
+
+// ---------- SearchRank ----------
+
+#[test]
+fn search_rank_emits_ts_rank_with_vector_and_query() {
+    let v = SearchVector::single(F("title"));
+    let q = SearchQuery::plain("alice");
+    let e = SearchRank::new(&v, &q);
+    let pg = pg(&e).unwrap();
+    assert!(
+        pg.contains(r#"ts_rank(to_tsvector("title"), plainto_tsquery("#),
+        "PG ts_rank: {pg}"
+    );
+}
+
+#[test]
+fn search_rank_cover_density_emits_ts_rank_cd() {
+    let v = SearchVector::single(F("title"));
+    let q = SearchQuery::plain("alice");
+    let e = SearchRank::cover_density(&v, &q);
+    let pg = pg(&e).unwrap();
+    assert!(pg.contains("ts_rank_cd("), "PG ts_rank_cd: {pg}");
+}
+
+// ---------- SearchHeadline ----------
+
+#[test]
+fn search_headline_emits_ts_headline_two_arg() {
+    let q = SearchQuery::plain("alice");
+    let e = SearchHeadline::new(F("body"), &q);
+    let pg = pg(&e).unwrap();
+    assert!(
+        pg.contains(r#"ts_headline("body", plainto_tsquery("#),
+        "PG ts_headline: {pg}"
+    );
+}
+
+#[test]
+fn search_headline_with_options_emits_three_arg_form() {
+    let q = SearchQuery::plain("alice");
+    let e = SearchHeadline::with_options(
+        F("body"),
+        &q,
+        "StartSel='<mark>', StopSel='</mark>', MaxFragments=1",
+    );
+    let pg = pg(&e).unwrap();
+    assert!(pg.contains("ts_headline("), "PG ts_headline: {pg}");
+    // Options string lands as a bound parameter ($N), not inline.
+    assert!(
+        pg.contains("$"),
+        "options arg should bind as a parameter: {pg}"
+    );
+}
+
+// ---------- Weighted multi-column composed with ts_rank ----------
+
+#[test]
+fn full_composition_weighted_vector_with_ts_rank() {
+    let v = SearchVector::weighted([(F("title"), Weight::A), (F("body"), Weight::B)]);
+    let q = SearchQuery::plain("alice");
+    let pg_rank = pg(&SearchRank::new(&v, &q)).unwrap();
+    // The weighted vector must appear unchanged inside ts_rank.
+    assert!(
+        pg_rank.contains("ts_rank(") && pg_rank.contains("setweight(to_tsvector"),
+        "PG ts_rank with weighted vector: {pg_rank}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #295 / T2.4.

New module `crate::core::fts` ships a Django-shape full-text-search builder over the existing PG scalar functions (`to_tsvector`, `plainto_tsquery` family, `ts_rank`, `ts_rank_cd`, `ts_headline`) added in T1.4 / #266.

```rust
use rustango::core::fts::{SearchQuery, SearchRank, SearchVector, Weight};
use rustango::core::F;

let v = SearchVector::weighted([
    (F("title"), Weight::A),
    (F("body"),  Weight::B),
]);
let q = SearchQuery::plain("alice");

Post::objects()
    .annotate("rank", SearchRank::new(&v, &q))
    .where_raw(v.matches(&q))
    .order_by_expr(SearchRank::new(&v, &q), true) // rank DESC
    .fetch_pool(&pool).await?;
```

## API

- `Weight` enum (A / B / C / D — Django parity).
- `SearchVector::single(expr)` / `::weighted(pairs)` — tsvector LHS.
- `SearchQuery::plain` / `::phrase` / `::websearch` / `::raw` — the four PG tsquery parsers.
- `SearchVector::matches(&q)` → `WhereExpr` (`<tsvec> @@ <tsquery>`).
- `SearchRank::new` / `::cover_density` (ts_rank / ts_rank_cd).
- `SearchHeadline::new` / `::with_options` (with optional highlight-config string).

## Two new ScalarFn variants

- `SetWeight` — `setweight(<tsvec>, '<A|B|C|D>')`. PG-only; the weight char travels as a string literal so the writer can validate + inline it (PG rejects bound params for the char weight argument).
- `TsConcat` — variadic `(a || b || c)` over tsvector operands. PG-only by language semantics. The existing `Concat` would emit `CONCAT(...)` / `||` on text — wrong return type for tsvectors.

Plus an `Op::Search` arm in `write_expr_compare` so the new builder's `<tsvector> @@ <tsquery>` shape compiles end-to-end. The path hits the same `require_op` dialect gate that the column-bound `Op::Search` uses — MySQL + SQLite reject with `OpNotSupportedInDialect`.

## Tri-dialect

PG-only by language semantics (MySQL's `MATCH … AGAINST` requires `FULLTEXT INDEX`; SQLite FTS5 needs `CREATE VIRTUAL TABLE` — neither composes with bare columns). Every non-PG path surfaces `OpNotSupportedInDialect` at write time. Tri-dialect litmus build passes.

## Tests

- `tests/fts_builder.rs` — 15 emission snapshots pinning the PG shape for every builder, plus negative pins on MySQL + SQLite for `matches()` + weighted vector.

## Test plan

- [x] `cargo test -p rustango --features sqlite,mysql,postgres,tenancy --test fts_builder` — 15/15
- [x] `cargo build --no-default-features --features sqlite,tenancy` — tri-dialect litmus
- [x] `cargo fmt --all -- --check` + `cargo clippy -p rustango --features tenancy --lib --no-deps`