### PR TITLE
feat: JSON path lookups — Expr::JsonPath + tri-dialect emission (closes #296)

### DIFF
--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -186,6 +186,39 @@ pub enum Expr {
         expr: Box<Expr>,
         ty: super::field_type::FieldType,
     },
+    /// JSON path extraction — `<source> -> 'k1' -> 'k2' ->> 'k3'` on PG,
+    /// `JSON_UNQUOTE(JSON_EXTRACT(<source>, '$.k1.k2.k3'))` on MySQL,
+    /// `json_extract(<source>, '$.k1.k2.k3')` on SQLite. Issue #296 /
+    /// T2.3. `as_text = true` requests the unwrapped-text form
+    /// (`->>` / `JSON_UNQUOTE` / `json_extract` returns text by default
+    /// for scalars); `false` keeps the JSON-typed form for further
+    /// chaining or for use as a JSON-shape value.
+    JsonPath {
+        source: Box<Expr>,
+        path: Vec<JsonPathStep>,
+        as_text: bool,
+    },
+}
+
+/// One segment of a [`Expr::JsonPath`] traversal. Keys are dictionary
+/// lookups (`{"k": v}` → `JsonPathStep::Key("k")`); indices are array
+/// lookups (`[a, b, c]` → `JsonPathStep::Index(0)`).
+///
+/// Negative indices follow PG's convention: PG's `->` accepts negative
+/// indices ("count from the end"); MySQL / SQLite emit `$[N]` which
+/// only accepts non-negative — the writer rejects negative indices on
+/// non-PG with a clear error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JsonPathStep {
+    /// Object key lookup. The string is emitted as a quoted SQL
+    /// literal on PG (`-> 'name'`) and as part of the JSON-pointer
+    /// path on MySQL / SQLite (`$.name`). Caller-supplied keys must
+    /// be JSON-pointer-safe: ASCII alphanumeric plus `_`. Other
+    /// characters are rejected at writer time to keep the inlined
+    /// path string injection-safe.
+    Key(String),
+    /// Array index lookup, 0-based.
+    Index(i64),
 }
 
 /// One arm of a [`Expr::Case`] expression — `WHEN <condition> THEN <then>`.

--- a/crates/rustango/src/core/funcs.rs
+++ b/crates/rustango/src/core/funcs.rs
@@ -787,6 +787,57 @@ pub fn trunc_with_tz(ts: impl Into<Expr>, unit: &'static str, tz: &'static str) 
     }
 }
 
+// ---------- JSON path extraction (issue #296 / T2.3) ----------
+
+/// `<source> -> 'k1' -> 'k2' ->> 'k3'` (PG) /
+/// `JSON_UNQUOTE(JSON_EXTRACT(...))` (MySQL) /
+/// `json_extract(...)` (SQLite). Issue #296 / T2.3.
+///
+/// Builds an [`Expr::JsonPath`] over a JSON-typed column or expression.
+/// Each `&str` in `path` is treated as an object-key step (`$.<key>`).
+/// `as_text = true` requests the unwrapped scalar form (PG's `->>`),
+/// `false` keeps the JSON-typed form.
+///
+/// ```ignore
+/// use rustango::core::F;
+/// use rustango::core::funcs::json_path;
+///
+/// // data->'address'->>'city' (PG) /
+/// // JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) (MySQL) /
+/// // json_extract(data, '$.address.city') (SQLite)
+/// json_path(F("data"), &["address", "city"], true);
+/// ```
+///
+/// Use [`json_path_indexed`] when array indices are needed.
+#[must_use]
+pub fn json_path(source: impl Into<Expr>, keys: &[&str], as_text: bool) -> Expr {
+    use super::JsonPathStep;
+    Expr::JsonPath {
+        source: Box::new(source.into()),
+        path: keys
+            .iter()
+            .map(|k| JsonPathStep::Key((*k).to_owned()))
+            .collect(),
+        as_text,
+    }
+}
+
+/// Like [`json_path`] but accepts a heterogeneous list of key + index
+/// steps — `&[JsonPathStep::Key("items"), JsonPathStep::Index(0),
+/// JsonPathStep::Key("name")]` for `data.items[0].name`.
+#[must_use]
+pub fn json_path_indexed(
+    source: impl Into<Expr>,
+    steps: impl IntoIterator<Item = super::JsonPathStep>,
+    as_text: bool,
+) -> Expr {
+    Expr::JsonPath {
+        source: Box::new(source.into()),
+        path: steps.into_iter().collect(),
+        as_text,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -22,7 +22,7 @@ pub mod window;
 pub use case::{case, value, CaseBuilder};
 pub use column::{Column, TypedAssignment, TypedExpr, TypedFieldList, TypedFilter};
 pub use error::QueryError;
-pub use expr::{BinOp, CaseBranch, Expr, ScalarFn, F};
+pub use expr::{BinOp, CaseBranch, Expr, JsonPathStep, ScalarFn, F};
 pub use field_type::FieldType;
 pub use query::{
     AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ColumnFilter,

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -469,6 +469,10 @@ fn validate_expr_columns(model: &'static ModelSchema, expr: &Expr) -> Result<(),
         // aggregates are validated via the dedicated walker called
         // from AggregateBuilder::compile().
         Expr::Aggregate(_) => Ok(()),
+        // JsonPath (issue #296 / T2.3) — only the `source` expression
+        // references a model column; path steps are JSON-pointer
+        // keys/indices.
+        Expr::JsonPath { source, .. } => validate_expr_columns(model, source),
     }
 }
 

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1811,6 +1811,10 @@ fn validate_expr_columns_in_model(
         // gap. Window-shaped aggregates are validated via the
         // dedicated walker in `validate_aggregate_expr_columns`.
         Expr::Aggregate(_) => Ok(()),
+        // JsonPath (issue #296 / T2.3) — the `source` is a column
+        // expression to validate; the path steps are JSON-pointer
+        // keys/indices and don't reference model columns themselves.
+        Expr::JsonPath { source, .. } => validate_expr_columns_in_model(model, source),
     }
 }
 

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -1319,7 +1319,129 @@ fn write_expr(
                 .expect("Expr::Aggregate emitted outside any scope frame");
             write_aggregate_expr(b, agg, model)
         }
+        Expr::JsonPath {
+            source,
+            path,
+            as_text,
+        } => write_json_path(b, source, path, *as_text),
     }
+}
+
+/// Emit a JSON-path traversal — issue #296 / T2.3.
+///
+/// **PG**: chained `->` operators, with the final hop using `->>`
+/// when `as_text` (which returns the unwrapped scalar text instead of
+/// JSON). Each key/index is bound as a parameter so user-supplied
+/// strings can't break out of the SQL.
+///
+/// **MySQL / SQLite**: a single `JSON_EXTRACT` / `json_extract` call
+/// with a JSON-pointer-style path string (`$.k1.k2[0]`). The path is
+/// inlined into the SQL because both backends require a literal
+/// string for the path argument. To keep the inlined path safe,
+/// keys are validated against a strict charset (`A-Za-z0-9_`) at
+/// write time — anything outside emits `OpNotSupportedInDialect`.
+fn write_json_path(
+    b: &mut Sql<'_>,
+    source: &crate::core::Expr,
+    path: &[crate::core::JsonPathStep],
+    as_text: bool,
+) -> Result<(), SqlError> {
+    use crate::core::{JsonPathStep, SqlValue};
+    if path.is_empty() {
+        return Err(SqlError::OpNotSupportedInDialect {
+            op: "JsonPath requires at least one path step",
+            dialect: b.d.name(),
+        });
+    }
+    // Key safety: ASCII alphanumeric + `_` for MySQL / SQLite inlining.
+    // PG binds keys as parameters so the validation isn't strictly
+    // necessary there, but apply the same rule for consistency.
+    let key_safe =
+        |s: &str| !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+    for step in path {
+        if let JsonPathStep::Key(k) = step {
+            if !key_safe(k) {
+                return Err(SqlError::OpNotSupportedInDialect {
+                    op: "JsonPath key contains characters outside the safe set [A-Za-z0-9_]",
+                    dialect: b.d.name(),
+                });
+            }
+        }
+    }
+    let dialect = b.d.name();
+    if dialect == "postgres" {
+        // Chained `->` … `->>` form. Negative array indices are PG-
+        // native (count-from-end).
+        write_expr(b, source, None)?;
+        for (i, step) in path.iter().enumerate() {
+            let is_last = i + 1 == path.len();
+            let op = if is_last && as_text { " ->> " } else { " -> " };
+            b.sql.push_str(op);
+            match step {
+                JsonPathStep::Key(k) => {
+                    b.params.push(SqlValue::String(k.clone()));
+                    let p = b.d.placeholder(b.params.len());
+                    b.sql.push_str(&p);
+                }
+                JsonPathStep::Index(n) => {
+                    // PG's `->` accepts integer literals inline; binding
+                    // as a parameter forces a `text` cast (PG infers
+                    // `text` from the unknown-typed `$N`) and the
+                    // operator overload resolution then fails. Inline
+                    // the integer.
+                    b.sql.push_str(&n.to_string());
+                }
+            }
+        }
+        return Ok(());
+    }
+    // MySQL + SQLite — build `$.<k>.<k>[<n>]` path string and call
+    // the dialect's JSON_EXTRACT.
+    let mut json_path = String::from("$");
+    for step in path {
+        match step {
+            JsonPathStep::Key(k) => {
+                json_path.push('.');
+                json_path.push_str(k);
+            }
+            JsonPathStep::Index(n) => {
+                if *n < 0 {
+                    return Err(SqlError::OpNotSupportedInDialect {
+                        op: "JsonPath negative indices are PG-only (MySQL/SQLite require non-negative)",
+                        dialect,
+                    });
+                }
+                json_path.push('[');
+                json_path.push_str(&n.to_string());
+                json_path.push(']');
+            }
+        }
+    }
+    if dialect == "mysql" {
+        if as_text {
+            b.sql.push_str("JSON_UNQUOTE(JSON_EXTRACT(");
+            write_expr(b, source, None)?;
+            b.sql.push_str(", '");
+            b.sql.push_str(&json_path);
+            b.sql.push_str("'))");
+        } else {
+            b.sql.push_str("JSON_EXTRACT(");
+            write_expr(b, source, None)?;
+            b.sql.push_str(", '");
+            b.sql.push_str(&json_path);
+            b.sql.push_str("')");
+        }
+        return Ok(());
+    }
+    // SQLite — json_extract returns scalars unquoted already, so
+    // `as_text` is a no-op on this backend.
+    let _ = as_text;
+    b.sql.push_str("json_extract(");
+    write_expr(b, source, None)?;
+    b.sql.push_str(", '");
+    b.sql.push_str(&json_path);
+    b.sql.push_str("')");
+    Ok(())
 }
 
 /// Emit a window expression — `<fn>(args) OVER (PARTITION BY … ORDER

--- a/crates/rustango/tests/json_path_lookups.rs
+++ b/crates/rustango/tests/json_path_lookups.rs
@@ -1,0 +1,187 @@
+//! JSON path lookups — closes #296 / T2.3.
+//!
+//! Per-dialect emission snapshots for `Expr::JsonPath` /
+//! `funcs::json_path` / `funcs::json_path_indexed`. Same IR produces
+//! per-dialect-correct SQL on PG / MySQL / SQLite:
+//!
+//!   PG     — `<source> -> 'k1' -> 'k2' ->> 'k3'`
+//!   MySQL  — `JSON_UNQUOTE(JSON_EXTRACT(<source>, '$.k1.k2.k3'))`
+//!   SQLite — `json_extract(<source>, '$.k1.k2.k3')`
+
+use rustango::core::funcs::{json_path, json_path_indexed};
+use rustango::core::{Expr, JsonPathStep, F};
+use rustango::sql::{Dialect, MySql, Postgres, SqlError, Sqlite};
+
+fn pg(e: &Expr) -> Result<String, SqlError> {
+    write_for_test(&Postgres, e)
+}
+
+fn my(e: &Expr) -> Result<String, SqlError> {
+    write_for_test(&MySql, e)
+}
+
+fn sqlite(e: &Expr) -> Result<String, SqlError> {
+    write_for_test(&Sqlite, e)
+}
+
+fn write_for_test(dialect: &dyn Dialect, e: &Expr) -> Result<String, SqlError> {
+    use rustango::core::{Op, SqlValue, WhereExpr};
+    let qs = rustango::query::QuerySet::<NoModel>::default().where_raw(WhereExpr::ExprCompare {
+        lhs: e.clone(),
+        op: Op::Eq,
+        rhs: Expr::Literal(SqlValue::Bool(true)),
+    });
+    let select = qs.compile().unwrap();
+    Ok(dialect.compile_select(&select)?.sql)
+}
+
+#[derive(rustango::Model, Debug, Clone)]
+#[rustango(table = "json_path_demo")]
+#[allow(dead_code)]
+pub struct NoModel {
+    #[rustango(primary_key)]
+    id: i64,
+    data: serde_json::Value,
+}
+
+// ---------- Single-key path ----------
+
+#[test]
+fn single_key_as_text_emits_double_arrow_on_pg() {
+    let e = json_path(F("data"), &["city"], true);
+    let pg = pg(&e).unwrap();
+    assert!(pg.contains(r#""data" ->> $1"#), "PG `->>` form: {pg}");
+}
+
+#[test]
+fn single_key_json_typed_emits_single_arrow_on_pg() {
+    let e = json_path(F("data"), &["address"], false);
+    let pg = pg(&e).unwrap();
+    assert!(
+        pg.contains(r#""data" -> $1"#),
+        "PG `->` JSON-typed form: {pg}"
+    );
+    assert!(!pg.contains("->>"), "must not use `->>` form: {pg}");
+}
+
+#[test]
+fn single_key_emits_json_extract_on_sqlite_and_mysql() {
+    let e = json_path(F("data"), &["city"], true);
+    let my = my(&e).unwrap();
+    let lite = sqlite(&e).unwrap();
+    assert!(
+        my.contains("JSON_UNQUOTE(JSON_EXTRACT(`data`, '$.city'))"),
+        "MySQL JSON_UNQUOTE form: {my}"
+    );
+    assert!(
+        lite.contains(r#"json_extract("data", '$.city')"#),
+        "SQLite json_extract: {lite}"
+    );
+}
+
+// ---------- Multi-key chain ----------
+
+#[test]
+fn multi_key_chain_emits_arrow_chain_on_pg() {
+    let e = json_path(F("data"), &["address", "city"], true);
+    let pg = pg(&e).unwrap();
+    // Last hop uses `->>`, prior hops use `->`.
+    assert!(pg.contains(r#""data" -> $1 ->> $2"#), "PG chain: {pg}");
+}
+
+#[test]
+fn multi_key_chain_emits_dotted_path_on_mysql_and_sqlite() {
+    let e = json_path(F("data"), &["address", "city"], true);
+    let my = my(&e).unwrap();
+    let lite = sqlite(&e).unwrap();
+    assert!(
+        my.contains("JSON_UNQUOTE(JSON_EXTRACT(`data`, '$.address.city'))"),
+        "MySQL: {my}"
+    );
+    assert!(
+        lite.contains(r#"json_extract("data", '$.address.city')"#),
+        "SQLite: {lite}"
+    );
+}
+
+// ---------- Array index step ----------
+
+#[test]
+fn array_index_step_emits_per_dialect_form() {
+    let e = json_path_indexed(
+        F("data"),
+        [
+            JsonPathStep::Key("items".into()),
+            JsonPathStep::Index(0),
+            JsonPathStep::Key("name".into()),
+        ],
+        true,
+    );
+    let pg = pg(&e).unwrap();
+    let my = my(&e).unwrap();
+    let lite = sqlite(&e).unwrap();
+    // PG: keys bind as params, indices inline.
+    assert!(
+        pg.contains(r#""data" -> $1 -> 0 ->> $2"#),
+        "PG indexed: {pg}"
+    );
+    // MySQL/SQLite use `$.items[0].name`.
+    assert!(my.contains("'$.items[0].name'"), "MySQL indexed: {my}");
+    assert!(lite.contains("'$.items[0].name'"), "SQLite indexed: {lite}");
+}
+
+#[test]
+fn negative_index_is_pg_only() {
+    let e = json_path_indexed(F("data"), [JsonPathStep::Index(-1)], false);
+    // PG accepts negative indices natively.
+    let pg = pg(&e).unwrap();
+    assert!(pg.contains(r#""data" -> -1"#), "PG negative index: {pg}");
+    // MySQL and SQLite must error — their `$[N]` syntax requires non-negative.
+    for err in [my(&e).unwrap_err(), sqlite(&e).unwrap_err()] {
+        assert!(matches!(err, SqlError::OpNotSupportedInDialect { .. }));
+    }
+}
+
+// ---------- Safety guards ----------
+
+#[test]
+fn unsafe_key_chars_rejected_on_every_dialect() {
+    // Even on PG, where keys bind as parameters, we reject keys with
+    // characters outside `[A-Za-z0-9_]` for consistency. The point is
+    // to keep the MySQL/SQLite inline-path safe; uniform rejection
+    // avoids the footgun of "works on PG, breaks on MySQL".
+    let e = json_path(F("data"), &["bad'; DROP TABLE x;--"], true);
+    for err in [
+        pg(&e).unwrap_err(),
+        my(&e).unwrap_err(),
+        sqlite(&e).unwrap_err(),
+    ] {
+        assert!(matches!(err, SqlError::OpNotSupportedInDialect { .. }));
+    }
+}
+
+#[test]
+fn empty_path_is_rejected() {
+    let e = json_path(F("data"), &[], false);
+    for err in [
+        pg(&e).unwrap_err(),
+        my(&e).unwrap_err(),
+        sqlite(&e).unwrap_err(),
+    ] {
+        assert!(matches!(err, SqlError::OpNotSupportedInDialect { .. }));
+    }
+}
+
+// ---------- as_text noop on SQLite ----------
+
+#[test]
+fn as_text_is_a_noop_on_sqlite_json_extract_returns_scalars_unquoted() {
+    let with_text = json_path(F("data"), &["city"], true);
+    let without_text = json_path(F("data"), &["city"], false);
+    let lite_text = sqlite(&with_text).unwrap();
+    let lite_json = sqlite(&without_text).unwrap();
+    assert_eq!(
+        lite_text, lite_json,
+        "SQLite emits identical SQL regardless of as_text"
+    );
+}

--- a/crates/rustango/tests/json_path_sqlite_live.rs
+++ b/crates/rustango/tests/json_path_sqlite_live.rs
@@ -1,0 +1,85 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite regression for JSON path lookups — issue #296 / T2.3.
+//!
+//! Runs the emitted `json_extract(<col>, '$.path...')` SQL against an
+//! in-memory SQLite database to prove the writer's emission is
+//! actually executable, not just syntactically plausible.
+
+use rustango::core::funcs::{json_path, json_path_indexed};
+use rustango::core::{Expr, JsonPathStep, Op, SqlValue, WhereExpr, F};
+use rustango::sql::{explain_pool, sqlx, Auto, ExplainOptions, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "json_path_demo")]
+#[rustango(app = "json_path_sqlite_live")]
+#[allow(dead_code)]
+pub struct Demo {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub data: serde_json::Value,
+}
+
+async fn pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE json_path_demo (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            data TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    sqlx::query(r#"INSERT INTO json_path_demo (data) VALUES ('{"address":{"city":"NYC"},"items":[{"name":"x"}]}')"#)
+        .execute(&p)
+        .await
+        .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn assert_expr_parses(p: &Pool, e: Expr) {
+    use rustango::query::QuerySet;
+    let qs = QuerySet::<Demo>::default().where_raw(WhereExpr::ExprCompare {
+        lhs: e,
+        op: Op::Eq,
+        rhs: Expr::Literal(SqlValue::String("NYC".into())),
+    });
+    let q = qs.compile().unwrap();
+    let plan = explain_pool(p, &q, ExplainOptions::default())
+        .await
+        .expect("explain SHOULD parse");
+    assert!(!plan.is_empty(), "expected non-empty plan");
+}
+
+#[tokio::test]
+async fn single_key_path_parses_on_sqlite() {
+    let p = pool().await;
+    assert_expr_parses(&p, json_path(F("data"), &["city"], true)).await;
+}
+
+#[tokio::test]
+async fn nested_key_path_parses_on_sqlite() {
+    let p = pool().await;
+    assert_expr_parses(&p, json_path(F("data"), &["address", "city"], true)).await;
+}
+
+#[tokio::test]
+async fn array_indexed_path_parses_on_sqlite() {
+    let p = pool().await;
+    assert_expr_parses(
+        &p,
+        json_path_indexed(
+            F("data"),
+            [
+                JsonPathStep::Key("items".into()),
+                JsonPathStep::Index(0),
+                JsonPathStep::Key("name".into()),
+            ],
+            true,
+        ),
+    )
+    .await;
+}


### PR DESCRIPTION
## Summary

Closes #296 / T2.3.

Path-based JSON traversal — same IR produces per-dialect-correct SQL on PG / MySQL / SQLite. Closes the gap between rustango v0.41's whole-object JSON ops (`JsonContains` / `JsonHasKey`) and Django's `data__address__city__icontains` shape.

```rust
use rustango::core::F;
use rustango::core::funcs::{json_path, json_path_indexed};
use rustango::core::JsonPathStep;

// data.address.city — text scalar
json_path(F("data"), &["address", "city"], true);
// PG:     "data" -> $1 ->> $2
// MySQL:  JSON_UNQUOTE(JSON_EXTRACT(`data`, '$.address.city'))
// SQLite: json_extract("data", '$.address.city')

// data.items[0].name — mixed keys + indices
json_path_indexed(F("data"), [
    JsonPathStep::Key("items".into()),
    JsonPathStep::Index(0),
    JsonPathStep::Key("name".into()),
], true);
```

## What's in

- `Expr::JsonPath { source, path, as_text }` + `JsonPathStep::{Key, Index}` (re-exported from `crate::core`).
- `funcs::json_path(source, keys, as_text)` (key-only sugar) + `funcs::json_path_indexed(source, steps, as_text)` for mixed paths.
- Per-dialect writer:
  - **PG**: chained `->` operators; last hop is `->>` when `as_text`. Keys bind as parameters; indices inline.
  - **MySQL**: `JSON_UNQUOTE(JSON_EXTRACT(<src>, '$.key.key[N]'))` (text) or plain `JSON_EXTRACT(...)` (json-typed).
  - **SQLite**: `json_extract(<src>, '$.key.key[N]')`. `as_text` is a no-op — SQLite returns scalars unquoted.

## Safety

- Keys validated against `[A-Za-z0-9_]` on every dialect — keeps the inlined MySQL/SQLite path injection-safe.
- Negative indices rejected on MySQL/SQLite (PG-native only).
- Empty path rejected uniformly.
- `validate_expr_columns` recurses into `source` so model-column validation still applies.

## Tri-dialect

- `cargo build --no-default-features --features sqlite,tenancy` — passes
- `cargo test --workspace --all-features --no-run` — passes

## Tests

- `tests/json_path_lookups.rs` — 10 emission snapshots + safety/negative pins
- `tests/json_path_sqlite_live.rs` — 3 live SQLite executes proving `json_extract` SQL is actually planner-accepted

## Test plan

- [x] `cargo test -p rustango --features sqlite,mysql,postgres,tenancy --test json_path_lookups` — 10/10
- [x] `cargo test -p rustango --features sqlite,tenancy --test json_path_sqlite_live` — 3/3
- [x] `cargo build --no-default-features --features sqlite,tenancy`
- [x] `cargo test --workspace --all-features --no-run`
- [x] `cargo fmt --all -- --check` + `cargo clippy -p rustango --features tenancy --lib --no-deps`

## Deferred (T2.3 follow-up)

The string-keyed `.filter("data__address__city__icontains", ...)` parser-level path expansion is NOT in this PR — that needs additional schema awareness in `query::compile()` to recognize JSON columns and split the `__`-separated key on the LAST recognized lookup suffix rather than the last `__`. The typed-column entry point (`funcs::json_path(F("data"), &["address", "city"], true)`) is the canonical discoverable surface today; the string-keyed shortcut can follow in a sibling PR.

Also: `tests/json_path_sqlite_live.rs` is intentionally NOT yet added to `ci.yml`'s `sqlite_live` list — separate from the bundle to avoid the OAuth `workflow` scope wall on the merge. The test still runs locally and via the `postgres_test --all-features` job.