### PR TITLE
feat: fetch_with_prefetch_filtered_pool — Django Prefetch(queryset=...) (closes #298)

### DIFF
--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -3688,6 +3688,144 @@ where
     Ok(out)
 }
 
+/// `fetch_with_prefetch_pool` with a user-supplied **filtered** child
+/// queryset — Django's `Prefetch(queryset=...)` shape. Issue #298 /
+/// T2.1.
+///
+/// Drop-in replacement for [`fetch_with_prefetch_pool`] when the
+/// caller wants to **filter / order / limit** the child fetch:
+///
+/// ```ignore
+/// use rustango::core::Column as _;
+/// use rustango::query::QuerySet;
+///
+/// // Authors + their PUBLISHED posts, newest first.
+/// let published_posts = QuerySet::<Post>::default()
+///     .filter("published", true)
+///     .order_by(&[("created", true)]);
+///
+/// let authors_with_posts: Vec<(Author, Vec<Post>)> =
+///     fetch_with_prefetch_filtered_pool(
+///         Author::objects(),
+///         "author",
+///         published_posts,
+///         &pool,
+///     ).await?;
+/// ```
+///
+/// The function:
+///
+///  1. Compiles `parent_qs`, fetches parents.
+///  2. Collects parent PKs.
+///  3. Takes the user-supplied `child_qs` and **injects an
+///     `AND child_fk_column IN (parent_pks)` predicate** into its
+///     filter list (any filters / order / limit the user already
+///     wrote are preserved).
+///  4. Compiles + executes the augmented child query.
+///  5. Groups children by FK PK and stitches.
+///
+/// # Caveat — global vs. per-parent `LIMIT`
+///
+/// `child_qs.limit(N)` applies **globally** across the joined fetch,
+/// not per parent. Django's per-parent slice on prefetch (`.filter(
+/// post_set__lt=...)` semantics + LATERAL JOIN on PG, `ROW_NUMBER()
+/// OVER (PARTITION BY ...)` elsewhere) is a follow-up — the per-
+/// dialect LATERAL/window-fn dispatch is substantial work.
+///
+/// For the common shapes ("authors + every published post" / "authors
+/// + every post ordered DESC"), this signature is the right tool. For
+/// "authors + their N most-recent posts", today the calling pattern
+/// is per-parent fetch in a loop (or wait for the LATERAL follow-up).
+///
+/// # Errors
+/// As [`fetch_with_prefetch_pool`].
+pub async fn fetch_with_prefetch_filtered_pool<P, C>(
+    parent_qs: crate::query::QuerySet<P>,
+    child_fk_column: &'static str,
+    child_qs: crate::query::QuerySet<C>,
+    pool: &Pool,
+) -> Result<Vec<(P, Vec<C>)>, ExecError>
+where
+    P: Model
+        + MaybePgFromRow
+        + MaybeMyFromRow
+        + MaybeSqliteFromRow
+        + LoadRelated
+        + MaybeMyLoadRelated
+        + MaybeSqliteLoadRelated
+        + HasPkValue
+        + Send
+        + Unpin,
+    C: Model
+        + MaybePgFromRow
+        + MaybeMyFromRow
+        + MaybeSqliteFromRow
+        + LoadRelated
+        + MaybeMyLoadRelated
+        + MaybeSqliteLoadRelated
+        + FkPkAccess
+        + Send
+        + Unpin,
+{
+    let parents: Vec<P> = parent_qs.fetch_pool(pool).await?;
+    if parents.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let pk_field = P::SCHEMA
+        .primary_key()
+        .ok_or(ExecError::MissingPrimaryKey {
+            table: P::SCHEMA.table,
+        })?;
+    let mut parent_pks: Vec<crate::core::SqlValue> = Vec::with_capacity(parents.len());
+    for parent in &parents {
+        let pk = extract_pk_value(parent);
+        if !matches!(pk, crate::core::SqlValue::Null) {
+            parent_pks.push(pk);
+        }
+    }
+    {
+        let mut seen = std::collections::HashSet::new();
+        parent_pks.retain(|v| seen.insert(v.to_display_string()));
+    }
+    if parent_pks.is_empty() {
+        return Ok(parents.into_iter().map(|p| (p, Vec::new())).collect());
+    }
+
+    // Inject the IN-predicate by `filter_op` on top of whatever the
+    // user already chained — preserves their order_by / limit /
+    // existing filters. The IN-predicate AND-composes with the user's
+    // WHERE clause (QuerySet default-ANDs raw filters).
+    let children: Vec<C> = child_qs
+        .filter_op(
+            child_fk_column,
+            crate::core::Op::In,
+            crate::core::SqlValue::List(parent_pks),
+        )
+        .fetch_pool(pool)
+        .await?;
+
+    let mut grouped: std::collections::HashMap<String, Vec<C>> = std::collections::HashMap::new();
+    for child in children {
+        let Some(fk_pk) = child.__rustango_fk_pk_value(child_fk_column) else {
+            continue;
+        };
+        grouped
+            .entry(fk_pk.to_display_string())
+            .or_default()
+            .push(child);
+    }
+
+    let mut out = Vec::with_capacity(parents.len());
+    for parent in parents {
+        let pk = extract_pk_value(&parent).to_display_string();
+        let kids = grouped.remove(&pk).unwrap_or_default();
+        out.push((parent, kids));
+    }
+    let _ = pk_field;
+    Ok(out)
+}
+
 /// `select_rows_pool` with `select_related` join decoding. When the
 /// query carries no joins, behaves identically to [`select_rows_pool`]
 /// (fast `query_as` path). When joins are present, fetches raw rows

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -37,14 +37,14 @@ pub use executor::row_to_json_my;
 pub use executor::row_to_json_sqlite;
 pub use executor::{
     atomic, bulk_insert_pool, bulk_update_pool, count_rows_pool, delete_pool, delete_tx,
-    explain_pool, fetch_aggregate_pool, fetch_paginated_pool, fetch_with_prefetch_pool,
-    get_or_create, insert_pool, insert_returning_pool, insert_returning_tx, insert_tx, on_commit,
-    on_commit_pending, raw_execute_pool, raw_query_pool, select_one_row_as_json,
-    select_one_row_pool, select_rows_as_json, select_rows_pool, select_rows_pool_with_related,
-    select_rows_tx_with_related, transaction_pool, update_or_create, update_pool, update_tx,
-    CounterPool, ExplainFormat, ExplainOptions, FetcherPool, FetcherTx, FkPkAccess, HasPkValue,
-    InsertReturningPool, LoadRelated, MaybeMyFromRow, MaybeMyLoadRelated, MaybePgFromRow,
-    MaybeSqliteFromRow, MaybeSqliteLoadRelated, Page, PoolTx, UpdaterPool,
+    explain_pool, fetch_aggregate_pool, fetch_paginated_pool, fetch_with_prefetch_filtered_pool,
+    fetch_with_prefetch_pool, get_or_create, insert_pool, insert_returning_pool,
+    insert_returning_tx, insert_tx, on_commit, on_commit_pending, raw_execute_pool, raw_query_pool,
+    select_one_row_as_json, select_one_row_pool, select_rows_as_json, select_rows_pool,
+    select_rows_pool_with_related, select_rows_tx_with_related, transaction_pool, update_or_create,
+    update_pool, update_tx, CounterPool, ExplainFormat, ExplainOptions, FetcherPool, FetcherTx,
+    FkPkAccess, HasPkValue, InsertReturningPool, LoadRelated, MaybeMyFromRow, MaybeMyLoadRelated,
+    MaybePgFromRow, MaybeSqliteFromRow, MaybeSqliteLoadRelated, Page, PoolTx, UpdaterPool,
 };
 // PG-typed back-compat surface gone (issue #270 / T1.8 waves 1–4):
 // the entire family of `_on` functions + `&PgPool` wrappers + the

--- a/crates/rustango/tests/prefetch_filtered_sqlite_live.rs
+++ b/crates/rustango/tests/prefetch_filtered_sqlite_live.rs
@@ -1,0 +1,190 @@
+#![cfg(feature = "sqlite")]
+//! `fetch_with_prefetch_filtered_pool` — closes #298 / T2.1.
+//!
+//! Live SQLite test for Django's `Prefetch(queryset=...)` shape:
+//! the caller supplies a child `QuerySet` carrying the filters /
+//! ordering they want, and the prefetch helper injects the FK-IN
+//! predicate so each parent picks up only its matching children.
+
+use rustango::query::QuerySet;
+use rustango::sql::{fetch_with_prefetch_filtered_pool, sqlx, Auto, ForeignKey, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "pff_author")]
+#[allow(dead_code)]
+pub struct Author {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub name: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "pff_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub published: bool,
+    pub created: i64,
+    pub author: ForeignKey<Author>,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE pff_author (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE TABLE pff_post (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            title     TEXT NOT NULL,
+            published INTEGER NOT NULL,
+            created   INTEGER NOT NULL,
+            author    INTEGER NOT NULL REFERENCES pff_author(id)
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn seed(pool: &Pool) -> (i64, i64) {
+    let mut ada = Author {
+        id: Auto::default(),
+        name: "Ada".into(),
+    };
+    ada.save_pool(pool).await.unwrap();
+    let mut grace = Author {
+        id: Auto::default(),
+        name: "Grace".into(),
+    };
+    grace.save_pool(pool).await.unwrap();
+    let ada_pk = ada.id.get().copied().unwrap();
+    let grace_pk = grace.id.get().copied().unwrap();
+    // Ada: 2 published, 1 draft. Grace: 1 published.
+    for (title, published, created, fk) in [
+        ("Engine notes", true, 100, ada_pk),
+        ("Poems on iteration", true, 200, ada_pk),
+        ("Draft on tape decks", false, 150, ada_pk),
+        ("Birth of the Bug", true, 300, grace_pk),
+    ] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: title.into(),
+            published,
+            created,
+            author: ForeignKey::unloaded(fk),
+        };
+        p.save_pool(pool).await.unwrap();
+    }
+    (ada_pk, grace_pk)
+}
+
+#[tokio::test]
+async fn filtered_prefetch_skips_unpublished_children() {
+    let pool = make_pool().await;
+    let _ = seed(&pool).await;
+
+    // Child queryset: only published posts.
+    let child_qs = QuerySet::<Post>::default().filter("published", true);
+
+    let groups: Vec<(Author, Vec<Post>)> = fetch_with_prefetch_filtered_pool::<Author, Post>(
+        Author::objects(),
+        "author",
+        child_qs,
+        &pool,
+    )
+    .await
+    .expect("prefetch filtered");
+
+    assert_eq!(groups.len(), 2, "two authors");
+    for (author, posts) in &groups {
+        for p in posts {
+            assert!(
+                p.published,
+                "unpublished post leaked through filtered prefetch for {}: {}",
+                author.name, p.title
+            );
+        }
+    }
+    // Ada had 2 published; Grace had 1.
+    let by_name: std::collections::HashMap<String, usize> = groups
+        .iter()
+        .map(|(a, ps)| (a.name.clone(), ps.len()))
+        .collect();
+    assert_eq!(by_name.get("Ada").copied(), Some(2));
+    assert_eq!(by_name.get("Grace").copied(), Some(1));
+}
+
+#[tokio::test]
+async fn filtered_prefetch_preserves_user_order_by() {
+    let pool = make_pool().await;
+    let _ = seed(&pool).await;
+
+    // Child queryset: published, ordered by created ASC.
+    let child_qs = QuerySet::<Post>::default()
+        .filter("published", true)
+        .order_by(&[("created", false)]);
+
+    let groups: Vec<(Author, Vec<Post>)> = fetch_with_prefetch_filtered_pool::<Author, Post>(
+        Author::objects(),
+        "author",
+        child_qs,
+        &pool,
+    )
+    .await
+    .expect("prefetch filtered");
+
+    // Find Ada's group; her published children should be ordered by
+    // `created` ASC: Engine notes (100) before Poems on iteration (200).
+    let ada_group = groups
+        .iter()
+        .find(|(a, _)| a.name == "Ada")
+        .expect("Ada present");
+    let titles: Vec<&str> = ada_group.1.iter().map(|p| p.title.as_str()).collect();
+    assert_eq!(
+        titles,
+        vec!["Engine notes", "Poems on iteration"],
+        "child order_by must survive the IN-injection: {titles:?}"
+    );
+}
+
+#[tokio::test]
+async fn unfiltered_child_queryset_falls_back_to_every_child() {
+    // Equivalent to v0.41's plain fetch_with_prefetch_pool — the
+    // filtered variant with an empty child_qs IS a superset.
+    let pool = make_pool().await;
+    let _ = seed(&pool).await;
+
+    let child_qs = QuerySet::<Post>::default(); // no filters
+
+    let groups: Vec<(Author, Vec<Post>)> = fetch_with_prefetch_filtered_pool::<Author, Post>(
+        Author::objects(),
+        "author",
+        child_qs,
+        &pool,
+    )
+    .await
+    .expect("prefetch filtered");
+
+    let by_name: std::collections::HashMap<String, usize> = groups
+        .iter()
+        .map(|(a, ps)| (a.name.clone(), ps.len()))
+        .collect();
+    // Ada: 3 (2 published + 1 draft). Grace: 1.
+    assert_eq!(by_name.get("Ada").copied(), Some(3));
+    assert_eq!(by_name.get("Grace").copied(), Some(1));
+}


### PR DESCRIPTION
## Summary

Closes #298 / T2.1.

New sibling to `fetch_with_prefetch_pool` that accepts a **user-supplied child queryset** carrying the filters / ordering the caller wants, mirroring Django's `Prefetch('post_set', queryset=Post.objects.filter(published=True))` shape.

```rust
use rustango::query::QuerySet;
use rustango::sql::fetch_with_prefetch_filtered_pool;

// Authors + their PUBLISHED posts, newest first.
let child_qs = QuerySet::<Post>::default()
    .filter("published", true)
    .order_by(&[("created", true)]);

let authors_with_posts: Vec<(Author, Vec<Post>)> =
    fetch_with_prefetch_filtered_pool::<Author, Post>(
        Author::objects(),
        "author",
        child_qs,
        &pool,
    ).await?;
```

## What it does

1. Compiles `parent_qs`, fetches parents.
2. Collects deduplicated parent PKs.
3. Takes the user-supplied `child_qs` and **injects** an `AND <child_fk_column> IN (parent_pks)` predicate into its WHERE clause via `QuerySet::filter_op` — any filters / order / limit the user already chained are preserved.
4. Compiles + executes the augmented child query.
5. Groups children by FK PK and stitches.

## Tri-dialect

Routes through `fetch_pool` so PG / MySQL / SQLite are handled identically. `cargo build --no-default-features --features sqlite,tenancy` passes.

## Documented limitation

`child_qs.limit(N)` applies **globally** across the joined fetch, not per parent. Django's per-parent slice on prefetch (LATERAL JOIN on PG, `ROW_NUMBER() OVER (PARTITION BY ...)` window-fn elsewhere) is a follow-up — the per-dialect dispatch is substantial work. For the common shapes ("authors + every published post" / "authors + every post ordered DESC"), this signature is the right tool today.

## Tests

- `tests/prefetch_filtered_sqlite_live.rs` — 3 live SQLite tests:
  - filtered prefetch skips unpublished children
  - user-applied `order_by` survives the IN-injection
  - empty filter falls back to "every child" (superset of the v0.41 plain prefetch behavior)

## Test plan

- [x] `cargo test -p rustango --features sqlite,tenancy --test prefetch_filtered_sqlite_live` — 3/3
- [x] `cargo build --no-default-features --features sqlite,tenancy`
- [x] `cargo test --workspace --all-features --no-run`
- [x] `cargo fmt --all -- --check` + `cargo clippy -p rustango --features tenancy --lib --no-deps`