### PR TITLE
fix(macros): cfg-gate reverse-FK accessor behind `postgres` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
       - run: cargo check -p rustango --no-default-features --features sqlite,tenancy
       - run: cargo clippy -p rustango --no-default-features --features sqlite,tenancy --lib --no-deps
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test sqlite_pragmas_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_fk_no_postgres
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This
@@ -167,6 +168,7 @@ jobs:
             --test migrate_registry_pool_sqlite_live \
             --test orm_advanced_sqlite_live \
             --test permissions_sqlite_live \
+            --test prefetch_filtered_sqlite_live \
             --test row_to_json_pool_sqlite_live \
             --test sqlite_pragmas_live \
             --test tenancy_manage_sqlite_live \

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -1170,6 +1170,14 @@ fn fk_pk_access_impl_tokens(struct_name: &syn::Ident, fk_relations: &[FkRelation
 /// Reads the parent's PK via the macro-generated `__rustango_pk_value`
 /// and runs a single `SELECT … FROM <child_table> WHERE <fk_column> = $1`
 /// — the canonical reverse-FK fetch. One round trip, no N+1.
+///
+/// **PG-only emission**: the accessor is bounded on
+/// `sqlx::Executor<Database = sqlx::Postgres>` and calls `fetch_on`,
+/// both of which are gated behind the `postgres` cargo feature. The
+/// emitted code is wrapped in `#[cfg(feature = "postgres")]` so the
+/// model derive itself compiles on tri-dialect / sqlite-only
+/// downstream builds — the accessor just isn't materialised. A tri-
+/// dialect `_set_pool` variant is a separate follow-up.
 fn reverse_helper_tokens(child_ident: &syn::Ident, fk_relations: &[FkRelation]) -> TokenStream2 {
     if fk_relations.is_empty() {
         return TokenStream2::new();
@@ -1189,6 +1197,7 @@ fn reverse_helper_tokens(child_ident: &syn::Ident, fk_relations: &[FkRelation]) 
              further `{child_ident}::objects()` filters via direct queryset use."
         );
         quote! {
+            #[cfg(feature = "postgres")]
             impl #parent_ty {
                 #[doc = #doc]
                 ///

--- a/crates/rustango/tests/macro_fk_no_postgres.rs
+++ b/crates/rustango/tests/macro_fk_no_postgres.rs
@@ -1,0 +1,53 @@
+#![cfg(all(feature = "sqlite", not(feature = "postgres")))]
+//! Regression: `#[derive(Model)]` on a model with a `ForeignKey<T>`
+//! field must compile under non-PG feature sets.
+//!
+//! Pre-fix: the reverse-FK accessor (`parent.{child}_set(executor)`)
+//! was emitted unconditionally, with a `Database = sqlx::Postgres`
+//! executor bound + a `.fetch_on(...)` call — both gated behind the
+//! `postgres` cargo feature. Under `--no-default-features --features
+//! sqlite,tenancy` the macro expansion failed to compile.
+//!
+//! Post-fix: the reverse-FK accessor is wrapped in
+//! `#[cfg(feature = "postgres")]` inside the macro, so non-PG builds
+//! see the model derive but not the accessor. This file pins that
+//! invariant — if the cfg gate ever regresses, this file fails to
+//! compile under `cargo build -p rustango --no-default-features
+//! --features sqlite,tenancy --test macro_fk_no_postgres`, which the
+//! `sqlite_litmus` CI job runs.
+
+use rustango::sql::{Auto, ForeignKey};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "mfknp_parent")]
+#[allow(dead_code)]
+pub struct Parent {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "mfknp_child")]
+#[allow(dead_code)]
+pub struct Child {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    /// The presence of this field used to trigger PG-only emission
+    /// in the macro's `reverse_helper_tokens` — `impl Parent { pub
+    /// async fn child_set(&self, _: impl Executor<Database =
+    /// Postgres>) -> Vec<Child> }`. Now gated behind
+    /// `#[cfg(feature = "postgres")]` at emit time.
+    pub parent: ForeignKey<Parent>,
+}
+
+#[test]
+fn derives_compile_with_fk_under_sqlite_only() {
+    use rustango::core::Model as _;
+    assert_eq!(Parent::SCHEMA.table, "mfknp_parent");
+    assert_eq!(Child::SCHEMA.table, "mfknp_child");
+    // The reverse accessor `Parent::child_set` must NOT exist under
+    // sqlite-only — confirming it would require either method-call
+    // probing (not stable in Rust) or a separate negative test. The
+    // compile-time success of this file is the load-bearing assertion.
+}


### PR DESCRIPTION
## Summary

`#[derive(Model)]` on any model containing a `ForeignKey<T>` field emitted an unconditional reverse-FK accessor (`impl Parent { pub async fn <child>_set(&self, executor) -> Vec<Child> }`) whose where-clause referenced `sqlx::Executor<Database = sqlx::Postgres>` and whose body called `.fetch_on(_)`. Both pieces are gated behind the `postgres` cargo feature, so under `--no-default-features --features sqlite,tenancy` the macro expansion failed to compile:

```
error[E0412]: cannot find type `Postgres` in crate `sqlx`
error[E0599]: no method named `fetch_on` found for struct `QuerySet`
```

Concretely surfaced by the Tier 2 batch's `prefetch_filtered_sqlite_live` test (PR #309) when it landed in the `sqlite_live` CI matrix (PR #310) — had to be dropped from the matrix as a workaround.

## Fix

Wrap the emitted `impl Parent { ... }` block in `#[cfg(feature = "postgres")]` inside the macro. Non-PG builds see the model derive but not the reverse accessor — which matches the pre-fix runtime behaviour (the accessor was unusable on non-PG anyway). A tri-dialect `_set_pool` variant remains as a separate follow-up.

## Changes

- **`crates/rustango-macros/src/lib.rs:reverse_helper_tokens`** — wrap the emitted impl block in `#[cfg(feature = "postgres")]`.
- **`tests/macro_fk_no_postgres.rs`** — compile-time regression test. Pins that `#[derive(Model)]` on a `ForeignKey<Parent>`-bearing struct compiles under sqlite-only feature flags.
- **`.github/workflows/ci.yml`** — adds `macro_fk_no_postgres` to the `sqlite_litmus` job (so the cfg gate is enforced on every PR), and **re-adds `prefetch_filtered_sqlite_live` to the `sqlite_live` matrix** (previously dropped in PR #310 as a workaround).

## Test plan

- [x] `cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_fk_no_postgres` — passes (the litmus)
- [x] `cargo test -p rustango --no-default-features --features sqlite,tenancy,admin,jobs-postgres,media,passwords,serializer --test prefetch_filtered_sqlite_live` — 3/3 pass (was previously a compile error)
- [x] `cargo build --no-default-features --features sqlite,tenancy` — tri-dialect litmus
- [x] `cargo test --workspace --all-features --no-run` — every test still compiles
- [x] `cargo test -p rustango --features tenancy --lib` — 2273/2273
- [x] `cargo fmt --all -- --check` + `cargo clippy -p rustango --features tenancy --lib --no-deps`