### PR TITLE
feat(auth): permission_required gate + auth.access_admin codename (closes #311)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
           cargo test -p rustango \
             --no-default-features \
             --features sqlite,tenancy,admin,jobs-postgres,media,passwords,serializer \
+            --test access_admin_codename_sqlite_live \
             --test admin_sqlite_live \
             --test audit_pool_sqlite_live \
             --test bulk_upsert_sqlite_live \

--- a/crates/rustango/src/auth_decorators.rs
+++ b/crates/rustango/src/auth_decorators.rs
@@ -404,6 +404,217 @@ pub fn active_required_or_403() -> impl tower::Layer<
     user_passes_test_or_403(|u| u.active)
 }
 
+/// Permission-codename access gate. Issue #311.
+///
+/// Asynchronous counterpart to [`user_passes_test`] — the predicate
+/// is a permission check against the tenant's perm engine rather
+/// than a sync closure over the `User` row. Anonymous requests 302
+/// to `login_url` with the original URL in `?next=`; authenticated
+/// users without the codename receive `403 Forbidden`. Superusers
+/// bypass the codename check entirely (the bypass is baked into
+/// [`crate::tenancy::permissions::has_perm_pool`]).
+///
+/// ```ignore
+/// use rustango::auth_decorators::permission_required;
+/// use rustango::tenancy::permissions::ACCESS_ADMIN_CODENAME;
+///
+/// // Gate the framework admin behind the reserved codename. Existing
+/// // superusers keep working (bypass is automatic); non-superusers
+/// // need an explicit grant via `set_user_perm_pool(uid,
+/// // ACCESS_ADMIN_CODENAME, true, ...)`.
+/// let admin = Router::new()
+///     .route("/admin", get(dashboard))
+///     .layer(permission_required("/login", ACCESS_ADMIN_CODENAME));
+/// ```
+///
+/// **Tenant resolution**: the gate extracts [`crate::extractors::Tenant`]
+/// to obtain the tenant-scoped pool that `has_perm_pool` queries.
+/// Routes that compose this middleware MUST therefore be mounted under
+/// the tenant context (Settings-driven `TenantContext` in extensions);
+/// untenant'd routes get a 500.
+///
+/// **Per-request cost**: one extractor call for `SessionUser` + one for
+/// `Tenant` + one `has_perm_pool` round-trip (three indexed lookups on
+/// PG/MySQL/SQLite). For high-RPS admin surfaces, the perm result can
+/// be cached at the session layer in a follow-up; today every request
+/// pays the lookup.
+#[cfg(all(feature = "tenancy", feature = "postgres"))]
+pub fn permission_required(
+    login_url: impl Into<String>,
+    codename: &'static str,
+) -> impl tower::Layer<
+    axum::routing::Route,
+    Service = impl tower::Service<
+        Request<Body>,
+        Response = Response,
+        Error = std::convert::Infallible,
+        Future = impl Send + 'static,
+    > + Clone
+                  + Send
+                  + Sync
+                  + 'static,
+> + Clone {
+    let cfg = Arc::new(LoginRequiredConfig {
+        login_url: login_url.into(),
+        ..Default::default()
+    });
+    axum::middleware::from_fn(move |req: Request<Body>, next: Next| {
+        let cfg = cfg.clone();
+        async move { handle_permission_required(cfg, codename, req, next).await }
+    })
+}
+
+/// API-endpoint counterpart to [`permission_required`] — returns 401
+/// for anonymous and 403 for authenticated-but-unauthorized requests
+/// instead of redirecting to a login page. Same codename semantics +
+/// superuser bypass as [`permission_required`].
+///
+/// ```ignore
+/// use rustango::auth_decorators::permission_required_or_403;
+///
+/// let api = Router::new()
+///     .route("/api/admin/stats", get(stats))
+///     .layer(permission_required_or_403("auth.access_admin"));
+/// ```
+#[cfg(all(feature = "tenancy", feature = "postgres"))]
+pub fn permission_required_or_403(
+    codename: &'static str,
+) -> impl tower::Layer<
+    axum::routing::Route,
+    Service = impl tower::Service<
+        Request<Body>,
+        Response = Response,
+        Error = std::convert::Infallible,
+        Future = impl Send + 'static,
+    > + Clone
+                  + Send
+                  + Sync
+                  + 'static,
+> + Clone {
+    axum::middleware::from_fn(move |req: Request<Body>, next: Next| async move {
+        handle_permission_required_or_403(codename, req, next).await
+    })
+}
+
+#[cfg(all(feature = "tenancy", feature = "postgres"))]
+async fn handle_permission_required(
+    cfg: Arc<LoginRequiredConfig>,
+    codename: &'static str,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    use axum::extract::FromRequestParts as _;
+    let (mut parts, body) = req.into_parts();
+    let user = crate::extractors::SessionUser::from_request_parts(&mut parts, &())
+        .await
+        .unwrap_or(crate::extractors::SessionUser(None));
+    let Some(u) = user.0.as_ref() else {
+        // Anonymous → redirect to login with ?next=.
+        let original = parts
+            .uri
+            .path_and_query()
+            .map(|p| p.as_str().to_owned())
+            .unwrap_or_else(|| "/".to_owned());
+        return redirect_to_login(&cfg.login_url, &cfg.redirect_field, &original);
+    };
+    let uid = match u.id.get().copied() {
+        Some(id) => id,
+        None => {
+            // Auto<i64> with no value — a session pointing at an unsaved
+            // user is a framework bug. Treat as 500 so it gets investigated.
+            return Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::empty())
+                .expect("500 + empty body is always valid");
+        }
+    };
+    // Need the tenant-scoped pool to query the perm engine. Tenant
+    // resolution failure (missing TenantContext, unknown tenant)
+    // surfaces as 500 — the user IS authenticated but we can't tell
+    // whether they're authorised.
+    let tenant = match crate::extractors::Tenant::<sqlx::Postgres>::from_request_parts(
+        &mut parts,
+        &(),
+    )
+    .await
+    {
+        Ok(t) => t,
+        Err(_) => {
+            return Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::empty())
+                .expect("500 + empty body is always valid");
+        }
+    };
+    let has = crate::tenancy::permissions::has_perm_pool(uid, codename, tenant.pool())
+        .await
+        .unwrap_or(false);
+    if has {
+        let req = Request::from_parts(parts, body);
+        return next.run(req).await;
+    }
+    Response::builder()
+        .status(StatusCode::FORBIDDEN)
+        .body(Body::empty())
+        .expect("403 + empty body is always valid")
+}
+
+#[cfg(all(feature = "tenancy", feature = "postgres"))]
+async fn handle_permission_required_or_403(
+    codename: &'static str,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    use axum::extract::FromRequestParts as _;
+    let (mut parts, body) = req.into_parts();
+    let user = crate::extractors::SessionUser::from_request_parts(&mut parts, &())
+        .await
+        .unwrap_or(crate::extractors::SessionUser(None));
+    let Some(u) = user.0.as_ref() else {
+        // Anonymous → 401 (RFC 7231: "you need to authenticate").
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .body(Body::empty())
+            .expect("401 + empty body is always valid");
+    };
+    let uid = match u.id.get().copied() {
+        Some(id) => id,
+        None => {
+            // Auto<i64> with no value — a session pointing at an unsaved
+            // user is a framework bug. Treat as 500 so it gets investigated.
+            return Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::empty())
+                .expect("500 + empty body is always valid");
+        }
+    };
+    let tenant = match crate::extractors::Tenant::<sqlx::Postgres>::from_request_parts(
+        &mut parts,
+        &(),
+    )
+    .await
+    {
+        Ok(t) => t,
+        Err(_) => {
+            return Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::empty())
+                .expect("500 + empty body is always valid");
+        }
+    };
+    let has = crate::tenancy::permissions::has_perm_pool(uid, codename, tenant.pool())
+        .await
+        .unwrap_or(false);
+    if has {
+        let req = Request::from_parts(parts, body);
+        return next.run(req).await;
+    }
+    Response::builder()
+        .status(StatusCode::FORBIDDEN)
+        .body(Body::empty())
+        .expect("403 + empty body is always valid")
+}
+
 #[cfg(all(feature = "tenancy", feature = "postgres"))]
 async fn handle_login_required(
     cfg: Arc<LoginRequiredConfig>,

--- a/crates/rustango/src/tenancy/permissions.rs
+++ b/crates/rustango/src/tenancy/permissions.rs
@@ -56,6 +56,30 @@ use crate::Model;
 
 use super::error::TenancyError;
 
+// ------------------------------------------------------------------ Reserved codenames (issue #311)
+
+/// Reserved permission codename gating the framework's auto-admin
+/// surface (`/__admin/`, `/admin/`). Issue #311.
+///
+/// Granting this codename to a user (or to a role they belong to)
+/// lets them load the framework admin without `is_superuser = true`.
+/// Superusers bypass this check (and every other codename check) —
+/// the bypass is baked into [`has_perm_pool`].
+///
+/// Downstream consuming crates (`rustango-cms`, etc.) declare their
+/// own admin codenames following the same convention:
+/// `auth.access_<crate>_admin`. They seed the row at their own
+/// migration time and check it with
+/// [`crate::auth_decorators::permission_required`].
+pub const ACCESS_ADMIN_CODENAME: &str = "auth.access_admin";
+
+/// Logical "table" prefix used when seeding non-model-bound codenames
+/// into `rustango_permissions`. The auto-admin model-CRUD codenames
+/// use the model's actual table name; reserved cross-cutting
+/// codenames like [`ACCESS_ADMIN_CODENAME`] sit under the `auth`
+/// namespace.
+const AUTH_NAMESPACE: &str = "auth";
+
 // ------------------------------------------------------------------ Models
 
 /// A named group of permissions (Django `Group` equivalent).
@@ -1486,6 +1510,17 @@ pub async fn auto_create_permissions(pool: &PgPool) -> Result<(), sqlx::Error> {
 pub async fn auto_create_permissions_pool(pool: &crate::sql::Pool) -> Result<(), TenancyError> {
     use crate::core::{inventory, ModelEntry};
 
+    // Seed the framework-reserved codenames first — they aren't
+    // model-bound so the inventory loop below doesn't cover them.
+    // Issue #311.
+    seed_reserved_codename_pool(
+        pool,
+        AUTH_NAMESPACE,
+        ACCESS_ADMIN_CODENAME,
+        "Can access framework admin",
+    )
+    .await?;
+
     let action_names = [
         ("add", "Can add"),
         ("change", "Can change"),
@@ -1542,6 +1577,53 @@ pub async fn auto_create_permissions_pool(pool: &crate::sql::Pool) -> Result<(),
             })?;
         }
     }
+    Ok(())
+}
+
+/// Idempotently insert one row into `rustango_permissions` for a
+/// non-model-bound (cross-cutting) codename. Used by
+/// [`auto_create_permissions_pool`] to seed reserved codenames like
+/// [`ACCESS_ADMIN_CODENAME`]. Downstream consuming crates can call
+/// this directly at their own migration time to register their own
+/// reserved codenames (e.g. `auth.access_cms_admin`).
+///
+/// # Errors
+/// Driver / SQL failures from the INSERT.
+pub async fn seed_reserved_codename_pool(
+    pool: &crate::sql::Pool,
+    namespace: &str,
+    codename: &str,
+    display_name: &str,
+) -> Result<(), TenancyError> {
+    let dialect = pool.dialect();
+    let perm_t = dialect.quote_ident("rustango_permissions");
+    let table_col = dialect.quote_ident("table_name");
+    let codename_col = dialect.quote_ident("codename");
+    let name_col = dialect.quote_ident("name");
+    let p1 = dialect.placeholder(1);
+    let p2 = dialect.placeholder(2);
+    let p3 = dialect.placeholder(3);
+    let conflict_tail = dialect.insert_on_conflict_skip(&[&table_col, &codename_col]);
+    let sql = format!(
+        "INSERT INTO {perm_t} ({table_col}, {codename_col}, {name_col}) \
+         VALUES ({p1}, {p2}, {p3}) \
+         {conflict_tail}"
+    );
+    crate::sql::raw_execute_pool(
+        pool,
+        &sql,
+        vec![
+            SqlValue::from(namespace.to_owned()),
+            SqlValue::from(codename.to_owned()),
+            SqlValue::from(display_name.to_owned()),
+        ],
+    )
+    .await
+    .map_err(|e| {
+        TenancyError::Validation(format!(
+            "seed_reserved_codename_pool: INSERT for `{codename}` failed: {e}"
+        ))
+    })?;
     Ok(())
 }
 

--- a/crates/rustango/tests/access_admin_codename_sqlite_live.rs
+++ b/crates/rustango/tests/access_admin_codename_sqlite_live.rs
@@ -1,0 +1,168 @@
+#![allow(irrefutable_let_patterns)] // Pool is single-variant under sqlite-only builds.
+//! Live SQLite regression for the `auth.access_admin` reserved
+//! codename + the `permission_required` gate's underlying perm
+//! resolution. Closes #311.
+//!
+//! Exercises:
+//!   1. `seed_reserved_codename_pool` inserts a `rustango_permissions`
+//!      row and is idempotent on re-seed.
+//!   2. `has_perm_pool(uid, ACCESS_ADMIN_CODENAME, _)` returns false
+//!      for a non-superuser without a grant.
+//!   3. The superuser bypass returns true with no explicit grant.
+//!   4. An explicit `set_user_perm_pool` grant flows through to
+//!      `has_perm_pool`.
+//!   5. `auto_create_permissions_pool` seeds the reserved row too
+//!      (covers the boot-time path used by `manage migrate`).
+
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+
+use rustango::sql::{sqlx, Pool};
+use rustango::tenancy::permissions::{
+    auto_create_permissions_pool, ensure_tables_pool, has_perm_pool, seed_reserved_codename_pool,
+    set_user_perm_pool, ACCESS_ADMIN_CODENAME,
+};
+
+async fn fresh_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory pool");
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS rustango_users (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            username TEXT NOT NULL UNIQUE, \
+            password_hash TEXT NOT NULL DEFAULT '', \
+            is_superuser INTEGER NOT NULL DEFAULT 0, \
+            active INTEGER NOT NULL DEFAULT 1, \
+            data TEXT NOT NULL DEFAULT '{}', \
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')), \
+            password_changed_at TEXT)",
+    )
+    .execute(&p)
+    .await
+    .expect("create rustango_users");
+    let pool = Pool::Sqlite(p);
+    ensure_tables_pool(&pool).await.expect("ensure_tables_pool");
+    pool
+}
+
+async fn make_user(pool: &Pool, name: &str, is_superuser: bool) -> i64 {
+    let Pool::Sqlite(sq) = pool else {
+        unreachable!("test uses sqlite only")
+    };
+    sqlx::query("INSERT INTO rustango_users (username, is_superuser) VALUES (?, ?)")
+        .bind(name)
+        .bind(i64::from(is_superuser))
+        .execute(sq)
+        .await
+        .expect("insert user");
+    let (id,): (i64,) = sqlx::query_as("SELECT id FROM rustango_users WHERE username = ?")
+        .bind(name)
+        .fetch_one(sq)
+        .await
+        .expect("fetch id");
+    id
+}
+
+async fn count_rustango_permissions(pool: &Pool, codename: &str) -> i64 {
+    let Pool::Sqlite(sq) = pool else {
+        unreachable!()
+    };
+    let (n,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM rustango_permissions WHERE codename = ?")
+            .bind(codename)
+            .fetch_one(sq)
+            .await
+            .expect("count");
+    n
+}
+
+#[tokio::test]
+async fn seed_reserved_codename_pool_inserts_and_is_idempotent() {
+    let pool = fresh_pool().await;
+    assert_eq!(
+        count_rustango_permissions(&pool, ACCESS_ADMIN_CODENAME).await,
+        0
+    );
+    seed_reserved_codename_pool(
+        &pool,
+        "auth",
+        ACCESS_ADMIN_CODENAME,
+        "Can access framework admin",
+    )
+    .await
+    .expect("first seed");
+    assert_eq!(
+        count_rustango_permissions(&pool, ACCESS_ADMIN_CODENAME).await,
+        1
+    );
+    // Idempotent re-seed.
+    seed_reserved_codename_pool(
+        &pool,
+        "auth",
+        ACCESS_ADMIN_CODENAME,
+        "Can access framework admin",
+    )
+    .await
+    .expect("re-seed");
+    assert_eq!(
+        count_rustango_permissions(&pool, ACCESS_ADMIN_CODENAME).await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn has_perm_pool_returns_false_for_non_superuser_without_grant() {
+    let pool = fresh_pool().await;
+    let uid = make_user(&pool, "alice_no_grant", false).await;
+    let ok = has_perm_pool(uid, ACCESS_ADMIN_CODENAME, &pool)
+        .await
+        .expect("has_perm_pool");
+    assert!(!ok, "no grant + non-superuser ⇒ no access");
+}
+
+#[tokio::test]
+async fn superuser_bypasses_access_admin_codename() {
+    let pool = fresh_pool().await;
+    let uid = make_user(&pool, "root_sb", true).await;
+    let ok = has_perm_pool(uid, ACCESS_ADMIN_CODENAME, &pool)
+        .await
+        .expect("has_perm_pool");
+    assert!(
+        ok,
+        "is_superuser=true ⇒ bypass every codename check (existing semantic)"
+    );
+}
+
+#[tokio::test]
+async fn explicit_grant_flows_through_to_has_perm_pool() {
+    let pool = fresh_pool().await;
+    let uid = make_user(&pool, "carol_granted", false).await;
+    set_user_perm_pool(uid, ACCESS_ADMIN_CODENAME, true, &pool)
+        .await
+        .expect("set_user_perm_pool");
+    let ok = has_perm_pool(uid, ACCESS_ADMIN_CODENAME, &pool)
+        .await
+        .expect("has_perm_pool");
+    assert!(
+        ok,
+        "explicit per-user grant ⇒ access (no superuser bit needed)"
+    );
+}
+
+#[tokio::test]
+async fn auto_create_permissions_pool_seeds_reserved_codename() {
+    let pool = fresh_pool().await;
+    assert_eq!(
+        count_rustango_permissions(&pool, ACCESS_ADMIN_CODENAME).await,
+        0
+    );
+    auto_create_permissions_pool(&pool)
+        .await
+        .expect("auto_create_permissions_pool");
+    assert_eq!(
+        count_rustango_permissions(&pool, ACCESS_ADMIN_CODENAME).await,
+        1,
+        "auto_create_permissions_pool MUST also seed the reserved codename — \
+         tenants that run `manage migrate` get the row without an extra call"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #311. Splits framework-admin access from app-specific admin surfaces via a **pure-codename design** — no `rustango_users` schema change.

Downstream consumers (rustango-cms etc.) now have a way to gate their own admin surface (e.g. `/cms-admin/`) on a codename like `auth.access_cms_admin` while the framework admin gates on `auth.access_admin`. Both go through the same perm engine; superusers bypass every codename check (existing semantic, baked into `has_perm_pool`).

The issue's draft proposed a hybrid (bool column for framework, codename for app). I pushed back during design (see chat-issue thread) and we agreed on **pure-codename** — same gating outcome, zero schema migration, one mechanism not two.

## What's in

**`tenancy/permissions.rs`**
- `pub const ACCESS_ADMIN_CODENAME: &str = "auth.access_admin";`
- `seed_reserved_codename_pool(pool, namespace, codename, display_name)` — idempotent INSERT into `rustango_permissions`. Downstream crates call it at migration time to register their own admin codenames.
- `auto_create_permissions_pool` now also seeds the reserved row, so a fresh `manage migrate` brings up the perm without any extra app code.

**`auth_decorators.rs`**
- `permission_required(login_url, codename)` — async middleware. Resolves SessionUser + Tenant, calls `has_perm_pool(uid, codename, tenant.pool())`. Redirects anonymous to login (with `?next=`), 403s authenticated-but-unauthorized, continues otherwise.
- `permission_required_or_403(codename)` — API-endpoint variant. 401 for anonymous, 403 for unauthorized.
- Both inherit superuser bypass for free (it's already in `has_perm_pool`).

## What's intentionally NOT in

- **No new `can_access_admin: bool` column on `rustango_users`** (the issue's `Acceptance` proposed one). Pure-codename achieves the same outcome without a schema migration. Existing superuser-only admins keep working unchanged; non-superuser grants go through `set_user_perm_pool(uid, ACCESS_ADMIN_CODENAME, true, ...)`.
- **No per-request perm cache yet.** Each gate request pays one `has_perm_pool` round-trip. Caching at the session layer is a follow-up.

## Migration story

- Existing deployments: **zero migration**. Superusers bypass; nothing breaks.
- Run `auto_create_permissions_pool` at boot (most consumers already do) — picks up `auth.access_admin` automatically.
- Non-superuser admin: `set_user_perm_pool(uid, ACCESS_ADMIN_CODENAME, true, pool).await?`.

## Downstream wiring (e.g. ujeenet/rustango-cms#10)

```rust
use rustango::auth_decorators::permission_required;
use rustango::tenancy::permissions::seed_reserved_codename_pool;

// Migration / boot:
seed_reserved_codename_pool(pool, "auth", "auth.access_cms_admin",
                            "Can access CMS admin").await?;

// Router:
let cms_admin = Router::new()
    .route("/cms-admin", get(dashboard))
    .layer(permission_required("/login", "auth.access_cms_admin"));
```

## Tests

- `tests/access_admin_codename_sqlite_live.rs` — 5 sqlite live tests pinning:
  - `seed_reserved_codename_pool` inserts + is idempotent
  - Non-superuser without grant ⇒ false
  - Superuser ⇒ true via bypass (no explicit grant needed)
  - Explicit `set_user_perm_pool` grant ⇒ true
  - `auto_create_permissions_pool` also seeds the reserved row

Wired into the `sqlite_live` CI matrix.

## Test plan

- [x] `cargo test -p rustango --no-default-features --features sqlite,tenancy --test access_admin_codename_sqlite_live` — 5/5
- [x] `cargo build --no-default-features --features sqlite,tenancy` — tri-dialect litmus
- [x] `cargo test --workspace --all-features --no-run` — every test compiles
- [x] `cargo test -p rustango --features tenancy --lib` — 2273/2273
- [x] `cargo fmt --all -- --check` + `cargo clippy -p rustango --features tenancy --lib --no-deps`