### PR TITLE
chore: drop deprecated tenancy::permissions::ensure_tables(&PgPool)

### DIFF
--- a/crates/rustango/src/permissions.rs
+++ b/crates/rustango/src/permissions.rs
@@ -52,11 +52,10 @@ use crate::tenancy::TenancyError;
 // ----- re-export the engine for the canonical path -----
 
 #[cfg(feature = "postgres")]
-#[allow(deprecated)] // `ensure_tables` is intentionally re-exported for back-compat.
 pub use crate::tenancy::permissions::{
-    assign_role, auto_create_permissions, clear_user_perm, create_role, ensure_tables,
-    get_or_create_role, grant_role_perm, has_all_perms, has_any_perm, has_perm, remove_role,
-    revoke_role_perm, set_user_perm, user_permissions, user_roles, user_roles_qs,
+    assign_role, auto_create_permissions, clear_user_perm, create_role, get_or_create_role,
+    grant_role_perm, has_all_perms, has_any_perm, has_perm, remove_role, revoke_role_perm,
+    set_user_perm, user_permissions, user_roles, user_roles_qs,
 };
 pub use crate::tenancy::permissions::{
     auto_create_permissions_pool, clear_user_perm_pool, create_role_pool, ensure_tables_pool,

--- a/crates/rustango/src/tenancy/migrate.rs
+++ b/crates/rustango/src/tenancy/migrate.rs
@@ -546,7 +546,6 @@ where
 }
 
 #[cfg(feature = "postgres")]
-#[allow(deprecated)] // calls `permissions::ensure_tables` as a best-effort back-compat fallback for tenants on schemas/DBs that pre-date the bootstrap migration.
 async fn run_for_one_tenant(
     pools: &TenantPools,
     org: &Org,
@@ -571,8 +570,8 @@ async fn run_for_one_tenant(
             if let Err(e) = crate::audit::ensure_table(&pool).await {
                 tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "audit::ensure_table failed for schema-mode tenant");
             }
-            if let Err(e) = super::permissions::ensure_tables(&pool).await {
-                tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "permissions::ensure_tables failed for schema-mode tenant");
+            if let Err(e) = super::permissions::ensure_tables_pool(&pool.clone().into()).await {
+                tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "permissions::ensure_tables_pool failed for schema-mode tenant");
             }
             // v0.27.2 — seed the `rustango_permissions` catalog with
             // the four CRUD codenames for every registered Model
@@ -605,8 +604,10 @@ async fn run_for_one_tenant(
             if let Err(e) = crate::audit::ensure_table(tenant_pool.pool()).await {
                 tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "audit::ensure_table failed for database-mode tenant");
             }
-            if let Err(e) = super::permissions::ensure_tables(tenant_pool.pool()).await {
-                tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "permissions::ensure_tables failed for database-mode tenant");
+            if let Err(e) =
+                super::permissions::ensure_tables_pool(&tenant_pool.pool().clone().into()).await
+            {
+                tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "permissions::ensure_tables_pool failed for database-mode tenant");
             }
             // See schema-mode comment above (#61).
             if let Err(e) = super::permissions::auto_create_permissions(tenant_pool.pool()).await {

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -114,13 +114,10 @@ pub use middleware::{AuthenticatedUser, CurrentUser, RouterAuthExt};
 // v0.38 — the PG-typed permission helpers stay PG-only re-exports;
 // the tri-dialect `_pool` variants are the cross-dialect entry points.
 #[cfg(feature = "postgres")]
-#[allow(deprecated)]
-// `ensure_tables` is intentionally re-exported as `ensure_permission_tables` for back-compat.
 pub use permissions::{
-    assign_role, auto_create_permissions, clear_user_perm,
-    ensure_tables as ensure_permission_tables, get_or_create_role, grant_role_perm, has_all_perms,
-    has_any_perm, has_perm, remove_role, revoke_role_perm, set_user_perm, user_permissions,
-    user_roles,
+    assign_role, auto_create_permissions, clear_user_perm, get_or_create_role, grant_role_perm,
+    has_all_perms, has_any_perm, has_perm, remove_role, revoke_role_perm, set_user_perm,
+    user_permissions, user_roles,
 };
 pub use permissions::{
     auto_create_permissions_pool, clear_user_perm_pool, create_role_pool, ensure_tables_pool,

--- a/crates/rustango/src/tenancy/permissions.rs
+++ b/crates/rustango/src/tenancy/permissions.rs
@@ -4,7 +4,7 @@
 //! queryset ORM, the auto-admin, and `make_migrations` sees them as
 //! baseline (they live in the bootstrap snapshot, not user migrations).
 //!
-//! ## Tables (per-tenant, created via [`ensure_tables`])
+//! ## Tables (per-tenant, created via [`ensure_tables_pool`])
 //!
 //! | Model | Table | Description |
 //! |---|---|---|
@@ -176,7 +176,7 @@ pub struct UserPermission {
     pub data: serde_json::Value,
 }
 
-// ------------------------------------------------------------------ ensure_tables (DDL)
+// ------------------------------------------------------------------ ensure_tables_pool (DDL)
 
 const ENSURE_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS "rustango_permissions" (
@@ -343,38 +343,8 @@ CREATE TABLE IF NOT EXISTS `rustango_user_permissions` (
 "#;
 
 /// Ensure all four permission tables exist in `pool`'s schema.
-/// Idempotent — safe to call on every boot. The tables are framework-
-/// managed (like `rustango_audit_log`) and live outside the user's
-/// migration chain; `make_migrations` sees them as baseline.
-///
-/// # Errors
-/// Driver failures from `CREATE TABLE IF NOT EXISTS`.
-///
-/// v0.38 — deprecated. The framework's bootstrap migrations
-/// (`0001_rustango_tenant_initial.json` written by `init-tenancy`)
-/// already create every permission table the engine needs, with
-/// per-dialect DDL emitted by the migration runner. New code should
-/// rely on `migrate` / `migrate-tenants` instead of calling this
-/// directly. Kept for downstream tests that scaffold a registry by
-/// hand and expect the tables to exist mid-test.
-#[cfg(feature = "postgres")]
-#[deprecated(
-    since = "0.38.0",
-    note = "use `cargo run -- migrate` (the bootstrap tenant migration creates these tables per-dialect); this runtime DDL helper is PG-only and predates the bootstrap migrations"
-)]
-pub async fn ensure_tables(pool: &PgPool) -> Result<(), sqlx::Error> {
-    for stmt in ENSURE_SQL
-        .split(';')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-    {
-        sqlx::query(stmt).execute(pool).await?;
-    }
-    Ok(())
-}
-
-/// v0.38 — tri-dialect counterpart of [`ensure_tables`]. Picks the
-/// per-dialect DDL constant ([`ENSURE_SQL`] / [`ENSURE_SQL_SQLITE`] /
+/// Idempotent — safe to call on every boot. Picks the per-dialect
+/// DDL constant ([`ENSURE_SQL`] / [`ENSURE_SQL_SQLITE`] /
 /// [`ENSURE_SQL_MYSQL`]) and runs each statement as its own round-trip
 /// because sqlx's simple-prepare path rejects multi-statement strings.
 ///
@@ -1435,7 +1405,7 @@ pub fn model_codenames(table: &str) -> [String; 4] {
 /// codenames for every model that carries `#[rustango(permissions)]`.
 ///
 /// Idempotent — uses `ON CONFLICT DO NOTHING`. Call once at startup after
-/// [`ensure_tables`] so the catalog reflects the current model set.
+/// [`ensure_tables_pool`] so the catalog reflects the current model set.
 ///
 /// # Errors
 /// Driver / SQL failures.
@@ -1487,7 +1457,7 @@ pub async fn auto_create_permissions(pool: &PgPool) -> Result<(), sqlx::Error> {
 
 /// v0.38 — tri-dialect counterpart of [`auto_create_permissions`].
 ///
-/// Unlike [`ensure_tables`], this is *not* redundant with the
+/// Unlike [`ensure_tables_pool`], this is *not* redundant with the
 /// bootstrap migration: the migration creates the `rustango_permissions`
 /// table but cannot know which models the binary has compiled in.
 /// This walks the runtime `inventory::<ModelEntry>` and seeds one row

--- a/crates/rustango/tests/admin_user_roles_panel_live.rs
+++ b/crates/rustango/tests/admin_user_roles_panel_live.rs
@@ -1,7 +1,4 @@
 #![cfg(feature = "postgres")]
-// Tests intentionally exercise the deprecated `ensure_tables(&PgPool)`
-// path — that's what they're testing.
-#![allow(deprecated)]
 //! Live test for the v0.28 user-roles+permissions panel rendered on
 //! the `rustango_users` admin detail page (Step 5 / item #76).
 //!
@@ -14,12 +11,9 @@
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
 use rustango::sql::sqlx;
-use rustango::sql::Auto;
-// `ensure_tables` is deprecated; this fixture predates the
-// `manage migrate` path that supersedes it.
-#[allow(deprecated)]
+use rustango::sql::{Auto, Pool};
 use rustango::tenancy::permissions::{
-    assign_role, ensure_tables, get_or_create_role, grant_role_perm, set_user_perm,
+    assign_role, ensure_tables_pool, get_or_create_role, grant_role_perm, set_user_perm,
 };
 use rustango::tenancy::User;
 use tower::ServiceExt;
@@ -56,8 +50,9 @@ async fn fresh(pool: &sqlx::PgPool) {
             .await
             .unwrap();
     }
-    #[allow(deprecated)]
-    ensure_tables(pool).await.unwrap();
+    ensure_tables_pool(&Pool::Postgres(pool.clone()))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/crates/rustango/tests/non_superuser_admin_visibility_live.rs
+++ b/crates/rustango/tests/non_superuser_admin_visibility_live.rs
@@ -1,8 +1,4 @@
 #![cfg(feature = "postgres")]
-// Tests intentionally exercise the deprecated `ensure_tables(&PgPool)`
-// path — covers the legacy-bootstrap behaviour, not the migration
-// that replaces it.
-#![allow(deprecated)]
 //! Live integration test for #67 — the "scaffold an app, see it in
 //! admin as a non-superuser" loop that #61–#66 collectively broke.
 //!
@@ -24,14 +20,9 @@
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
 use rustango::sql::sqlx;
-use rustango::sql::Auto;
-// `ensure_tables` is deprecated in favor of `manage migrate` (which
-// the bootstrap tenant migration covers). The test predates that
-// helper and uses the legacy DDL path for setup — keep until the
-// fixture is migrated.
-#[allow(deprecated)]
+use rustango::sql::{Auto, Pool};
 use rustango::tenancy::permissions::{
-    assign_role, auto_create_permissions, ensure_tables, get_or_create_role, grant_role_perm,
+    assign_role, auto_create_permissions, ensure_tables_pool, get_or_create_role, grant_role_perm,
     user_permissions,
 };
 use rustango::tenancy::User;
@@ -70,8 +61,9 @@ async fn fresh(pool: &sqlx::PgPool) {
             .await
             .unwrap();
     }
-    #[allow(deprecated)]
-    ensure_tables(pool).await.unwrap();
+    ensure_tables_pool(&Pool::Postgres(pool.clone()))
+        .await
+        .unwrap();
 }
 
 /// `auto_create_permissions` walks the inventory of registered models

--- a/crates/rustango/tests/permissions_upsert_live.rs
+++ b/crates/rustango/tests/permissions_upsert_live.rs
@@ -10,17 +10,13 @@
 //! existing row instead of inserting a duplicate.
 
 #![cfg(feature = "tenancy")]
-// The legacy `ensure_tables(&PgPool)` is intentionally exercised
-// below — these tests cover the upsert behaviour, not the migration
-// path that superseded it.
-#![allow(deprecated)]
 
 use rustango::core::Column as _;
 use rustango::sql::sqlx;
-use rustango::sql::Auto;
+use rustango::sql::{Auto, Pool};
 use rustango::tenancy::permissions::{
-    assign_role, get_or_create_role, grant_role_perm, set_user_perm, RolePermission,
-    UserPermission, UserRole,
+    assign_role, ensure_tables_pool, get_or_create_role, grant_role_perm, set_user_perm,
+    RolePermission, UserPermission, UserRole,
 };
 use rustango::tenancy::User;
 
@@ -50,10 +46,10 @@ async fn fresh(pool: &sqlx::PgPool) {
     // declared in `permissions::ENSURE_SQL` (the constraints aren't
     // currently on the Model defs as `unique_together`). For these
     // tests to exercise ON CONFLICT we need those constraints, so
-    // drop the tables and let `ensure_tables` re-create them with
-    // the constraints. Production deployments hit this same code
-    // path because `ensure_tables` runs before any inventory-driven
-    // CREATE TABLE for these model types.
+    // drop the tables and let `ensure_tables_pool` re-create them
+    // with the constraints. Production deployments hit this same
+    // code path because `ensure_tables_pool` runs before any
+    // inventory-driven CREATE TABLE for these model types.
     for t in [
         "rustango_user_permissions",
         "rustango_user_roles",
@@ -65,11 +61,7 @@ async fn fresh(pool: &sqlx::PgPool) {
             .await
             .unwrap();
     }
-    // Deprecated helper still used by this fixture; migration to
-    // `manage migrate` will happen alongside the broader admin/perms
-    // test cleanup.
-    #[allow(deprecated)]
-    rustango::tenancy::ensure_permission_tables(pool)
+    ensure_tables_pool(&Pool::Postgres(pool.clone()))
         .await
         .unwrap();
 }


### PR DESCRIPTION
## Summary

`#[deprecated(since = "0.38.0")]` since v0.38; replaced by the tri-dialect `ensure_tables_pool(&Pool)` shipped the same release. **Zero callers in `src/` after this PR.** The codebase now has **zero deprecation markers** (PR #314 already dropped `FormStruct`, the other one).

Net -54 LOC.

## What's gone

- `pub async fn ensure_tables(&PgPool)` in `tenancy/permissions.rs`.
- The `ensure_tables` entry in the public re-export at `src/permissions.rs` (+ its `#[allow(deprecated)]` cover).
- The `ensure_tables as ensure_permission_tables` alias re-export in `src/tenancy/mod.rs` (+ its `#[allow(deprecated)]`).

## What got migrated

- **`tenancy/migrate.rs:run_for_one_tenant`** — the two internal fallback callsites (schema-mode + database-mode tenant bootstrap) now go through `ensure_tables_pool(&pool.clone().into())`. The function-level `#[allow(deprecated)]` is removed.
- **`tests/permissions_upsert_live.rs`** — fixture switched from `tenancy::ensure_permission_tables(pool)` to `ensure_tables_pool(&Pool::Postgres(pool.clone()))`. The file-level `#![allow(deprecated)]` is gone.
- **`tests/non_superuser_admin_visibility_live.rs`** — same migration; drops the file-level `#![allow(deprecated)]` + the per-import `#[allow(deprecated)]`.
- **`tests/admin_user_roles_panel_live.rs`** — same migration.

## What stayed

- `ENSURE_SQL` const (the PG DDL) stays — `ensure_tables_pool` still uses it as the default branch of its per-dialect match.
- `ENSURE_SQL_SQLITE` / `ENSURE_SQL_MYSQL` unchanged.
- Stale rustdoc cross-references to `[ensure_tables]` retargeted to `[ensure_tables_pool]`.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — tri-dialect litmus
- [x] `cargo test --workspace --all-features --no-run` — every test compiles
- [x] `cargo test -p rustango --features tenancy --lib` — 2273/2273
- [x] `cargo fmt --all -- --check` + `cargo clippy -p rustango --features tenancy --lib --no-deps`

Stacks cleanly on PR #314 (just merged); no overlap.