### PR TITLE
chore: zero warnings on the sqlite,tenancy litmus build

### DIFF
--- a/crates/rustango/src/auth_decorators.rs
+++ b/crates/rustango/src/auth_decorators.rs
@@ -61,11 +61,14 @@
 //!   non-session auth (JWT, basic auth) plug their own predicate.
 
 use std::collections::HashMap;
+#[cfg(all(feature = "tenancy", feature = "postgres"))]
 use std::sync::Arc;
 
 use axum::body::Body;
+#[cfg(all(feature = "tenancy", feature = "postgres"))]
 use axum::extract::Request;
 use axum::http::{header, HeaderValue, StatusCode};
+#[cfg(all(feature = "tenancy", feature = "postgres"))]
 use axum::middleware::Next;
 use axum::response::Response;
 

--- a/crates/rustango/src/i18n/timezone.rs
+++ b/crates/rustango/src/i18n/timezone.rs
@@ -44,7 +44,11 @@
 
 use std::future::Future;
 
-use chrono::{DateTime, FixedOffset, TimeZone, Utc};
+use chrono::{DateTime, FixedOffset, Utc};
+// `TimeZone` is the trait that supplies `Utc.timestamp_opt(...)` —
+// only used by the `template_views`-gated Tera filter below.
+#[cfg(feature = "template_views")]
+use chrono::TimeZone;
 
 tokio::task_local! {
     /// The active timezone for this request / task. `None` (no

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -1590,7 +1590,12 @@ impl<T: Model + Send> UpdaterPool<T> for UpdateBuilder<T> {
 }
 
 /// Match on `SqlValue` and bind to a sqlx query builder. Used twice below for
-/// `Query` and `QueryAs`, which don't share a bind trait.
+/// `Query` and `QueryAs`, which don't share a bind trait. PG-only — the
+/// macro depends on `sqlx::types::Json` round-tripping through
+/// `PgArguments` and `SqlValue::Array` binding as a typed PG array,
+/// neither of which exists on MySQL / SQLite. The bi-directional
+/// counterparts are `bind_match_mysql!` + `bind_match_sqlite!`.
+#[cfg(feature = "postgres")]
 macro_rules! bind_match {
     ($q:expr, $value:expr) => {
         match $value {


### PR DESCRIPTION
## Summary

5 warnings on \`cargo build --no-default-features --features sqlite,tenancy\` → **zero**. Each was a feature-gating gap: items used only by feature-gated code paths but imported unconditionally.

## Fixes

- **\`auth_decorators.rs\`** — \`std::sync::Arc\`, \`axum::extract::Request\`, \`axum::middleware::Next\` are used only by the \`#[cfg(all(feature = "tenancy", feature = "postgres"))]\`-gated middlewares (\`login_required\`, \`user_passes_test\`, \`permission_required\`, etc.). Same gate applied to the imports.
- **\`i18n/timezone.rs\`** — \`chrono::TimeZone\` is needed only by the \`#[cfg(feature = "template_views")]\`-gated Tera filter (which calls \`Utc.timestamp_opt(...)\`). Split out as a feature-gated import.
- **\`sql/executor.rs:bind_match!\`** — The macro is invoked only by PG-typed \`bind_query\` / \`bind_query_as\` (both \`#[cfg(feature = "postgres")]\`). Added \`#[cfg(feature = "postgres")]\` to the macro definition.

## Verification

- [x] \`cargo build --no-default-features --features sqlite,tenancy\` — **0 warnings**
- [x] \`cargo build --all-features\` — **0 warnings**
- [x] \`cargo test --workspace --all-features --no-run\` — passes
- [x] \`cargo test -p rustango --features tenancy --lib\` — 2273/2273
- [x] \`cargo fmt --all -- --check\` — clean

Net +14 / -2 LOC. Tiny, surgical.

Stacks cleanly on PR #314 + #315 (already merged); zero overlap.