### PR TITLE
feat(orm): `#[rustango(choices = "…")]` field option (closes #446)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
       - run: cargo clippy -p rustango --no-default-features --features sqlite,tenancy --lib --no-deps
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test sqlite_pragmas_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_fk_no_postgres
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_choices
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -5139,6 +5139,14 @@ struct FieldAttrs {
     /// `FieldSchema::help_text` so admin / serializer / OpenAPI
     /// layers can read it.
     help_text: Option<String>,
+    /// `#[rustango(choices = "value:Label, value:Label")]` — Django-shape
+    /// enumerated allowed values. Threaded into `FieldSchema::choices`
+    /// as a `&'static [(&'static str, &'static str)]` slice. When
+    /// present, the admin form renders a `<select>` instead of `<input>`
+    /// and the validator rejects values not in the list. Only meaningful
+    /// for `FieldType::String`; the macro errors at compile time if
+    /// applied to a non-string field.
+    choices: Option<Vec<(String, String)>>,
 }
 
 fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
@@ -5163,6 +5171,7 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
         index_method: "btree".to_owned(),
         generated_as: None,
         help_text: None,
+        choices: None,
     };
     for attr in &field.attrs {
         if !attr.path().is_ident("rustango") {
@@ -5221,6 +5230,36 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
             if meta.path.is_ident("help_text") {
                 let s: LitStr = meta.value()?.parse()?;
                 out.help_text = Some(s.value());
+                return Ok(());
+            }
+            if meta.path.is_ident("choices") {
+                let s: LitStr = meta.value()?.parse()?;
+                let raw = s.value();
+                let mut pairs: Vec<(String, String)> = Vec::new();
+                for chunk in raw.split(',') {
+                    let chunk = chunk.trim();
+                    if chunk.is_empty() {
+                        continue;
+                    }
+                    let (value, label) = match chunk.split_once(':') {
+                        Some((v, l)) => (v.trim().to_owned(), l.trim().to_owned()),
+                        None => (chunk.to_owned(), chunk.to_owned()),
+                    };
+                    if value.is_empty() {
+                        return Err(syn::Error::new(
+                            s.span(),
+                            "`choices` entry has empty value before `:`",
+                        ));
+                    }
+                    pairs.push((value, label));
+                }
+                if pairs.is_empty() {
+                    return Err(syn::Error::new(
+                        s.span(),
+                        "`choices = \"…\"` must contain at least one value",
+                    ));
+                }
+                out.choices = Some(pairs);
                 return Ok(());
             }
             if meta.path.is_ident("auto_uuid") {
@@ -5576,6 +5615,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
     let unique = attrs.unique;
     let generated_as = optional_str(attrs.generated_as.as_deref());
     let help_text = optional_str(attrs.help_text.as_deref());
+    let choices = optional_choices(attrs.choices.as_deref());
     let schema = quote! {
         ::rustango::core::FieldSchema {
             name: #name,
@@ -5592,6 +5632,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
             unique: #unique,
             generated_as: #generated_as,
             help_text: #help_text,
+            choices: #choices,
         }
     };
 
@@ -5636,6 +5677,14 @@ fn check_bound_compatibility(
             "`max_length` is only valid on `String` fields (or `Option<String>`)",
         ));
     }
+    if attrs.choices.is_some() && kind != DetectedKind::String {
+        return Err(syn::Error::new_spanned(
+            field,
+            "`choices` is only valid on `String` fields (or `Option<String>`) — \
+             integer-valued enumerations should be modeled with a Rust enum and \
+             custom (de)serializer for now",
+        ));
+    }
     if (attrs.min.is_some() || attrs.max.is_some()) && !kind.is_integer() {
         return Err(syn::Error::new_spanned(
             field,
@@ -5675,6 +5724,14 @@ fn optional_str(value: Option<&str>) -> TokenStream2 {
     } else {
         quote!(::core::option::Option::None)
     }
+}
+
+fn optional_choices(pairs: Option<&[(String, String)]>) -> TokenStream2 {
+    let Some(pairs) = pairs else {
+        return quote!(::core::option::Option::None);
+    };
+    let entries = pairs.iter().map(|(v, l)| quote!((#v, #l)));
+    quote!(::core::option::Option::Some(&[#(#entries),*]))
 }
 
 fn relation_tokens(

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -180,6 +180,28 @@ pub(crate) fn render_input(field: &FieldSchema, value: &str, pk_locked: bool) ->
     // `#[rustango(admin(...))]`.
     let readonly = if pk_locked { " readonly" } else { "" };
 
+    // `#[rustango(choices = "...")]` renders as a `<select>` regardless of
+    // FieldType. The option values are emitted as-is and the admin form
+    // parser already accepts the string back through the field's column.
+    if let Some(choices) = field.choices {
+        let disabled = if pk_locked { " disabled" } else { "" };
+        let mut out = format!(r#"<select name="{name}" id="{name}"{required}{disabled}>"#);
+        if field.nullable {
+            out.push_str(r#"<option value=""></option>"#);
+        }
+        for (v, label) in choices {
+            let v_esc = escape(v);
+            let label_esc = escape(label);
+            let selected = if value == *v { " selected" } else { "" };
+            let _ = write!(
+                out,
+                r#"<option value="{v_esc}"{selected}>{label_esc}</option>"#
+            );
+        }
+        out.push_str("</select>");
+        return out;
+    }
+
     match field.ty {
         FieldType::Bool => {
             let checked = if value == "true" { " checked" } else { "" };
@@ -496,6 +518,7 @@ mod tests {
             relation: None,
             generated_as: None,
             help_text: None,
+            choices: None,
         }
     }
 
@@ -593,5 +616,56 @@ mod tests {
         let f = field("count", "count", FieldType::I64);
         let v = read_value_as_json_from_json(&row, &f);
         assert_eq!(v, json!(7));
+    }
+
+    /// `#[rustango(choices = "...")]` swaps the rendered `<input>` for a
+    /// `<select>` populated with the declared options, with the current
+    /// value pre-selected. NULL columns get a blank leading option so
+    /// the user can clear the field; NOT NULL columns omit it.
+    #[test]
+    fn render_input_emits_select_when_choices_present() {
+        let mut f = field("status", "status", FieldType::String);
+        f.choices = Some(&[("draft", "Draft"), ("published", "Published")]);
+        f.nullable = false;
+
+        let html = render_input(&f, "published", false);
+        assert!(
+            html.starts_with("<select "),
+            "expected <select>, got: {html}"
+        );
+        assert!(html.contains(r#"<option value="draft">Draft</option>"#));
+        assert!(html.contains(r#"<option value="published" selected>Published</option>"#));
+        assert!(
+            !html.contains(r#"<option value="">"#),
+            "NOT NULL field should not have empty option, got: {html}"
+        );
+        assert!(html.contains(" required"));
+    }
+
+    #[test]
+    fn render_input_choices_include_blank_option_when_nullable() {
+        let mut f = field("status", "status", FieldType::String);
+        f.choices = Some(&[("a", "Alpha"), ("b", "Beta")]);
+        f.nullable = true;
+
+        let html = render_input(&f, "", false);
+        assert!(html.contains(r#"<option value=""></option>"#));
+        // No selection ⇒ no "selected" attribute on any option
+        assert!(!html.contains("selected"));
+        // Nullable ⇒ no `required` attribute
+        assert!(!html.contains(" required"));
+    }
+
+    #[test]
+    fn render_input_choices_escape_html() {
+        let mut f = field("status", "status", FieldType::String);
+        f.choices = Some(&[(r#"<a>"#, r#"<b>"#)]);
+        f.nullable = false;
+
+        let html = render_input(&f, "<a>", false);
+        assert!(html.contains("&lt;a&gt;"));
+        assert!(html.contains("&lt;b&gt;"));
+        assert!(!html.contains("<a>"));
+        assert!(!html.contains("<b>"));
     }
 }

--- a/crates/rustango/src/core/error.rs
+++ b/crates/rustango/src/core/error.rs
@@ -35,6 +35,19 @@ pub enum QueryError {
         max: Option<i64>,
     },
 
+    /// `#[rustango(choices = "…")]` declared a closed set of allowed
+    /// values and the bound value isn't one of them. Mirrors Django's
+    /// `ValidationError` raised on save when `choices` is set.
+    #[error(
+        "field `{model}.{field}` value `{value}` is not one of the declared choices: {allowed:?}"
+    )]
+    InvalidChoice {
+        model: &'static str,
+        field: String,
+        value: String,
+        allowed: Vec<&'static str>,
+    },
+
     /// `QuerySet::select_related("foo")` couldn't be lowered: the
     /// field doesn't exist, isn't a `ForeignKey<T>`, the target
     /// table isn't registered in `inventory`, or the target has no

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -57,6 +57,15 @@ pub struct FieldSchema {
     /// (DRF serializer schemas, OpenAPI descriptions, ModelForm
     /// `<label>` annotations) can read the same string.
     pub help_text: Option<&'static str>,
+    /// Django-shape `choices=[(value, label), ...]` — enumerated
+    /// allowed values for a string field. Set via
+    /// `#[rustango(choices = "draft:Draft, published:Published")]`
+    /// (each pair is `value:label`, separated by commas; if no
+    /// `:` is present the value is reused as the label). When
+    /// `Some`, the admin renders a `<select>` instead of `<input>`,
+    /// and `validate_value` rejects values not in the list. Only
+    /// meaningful for `FieldType::String`.
+    pub choices: Option<&'static [(&'static str, &'static str)]>,
 }
 
 /// Static description of a relation to another model.

--- a/crates/rustango/src/core/validate.rs
+++ b/crates/rustango/src/core/validate.rs
@@ -22,7 +22,10 @@ pub fn validate_value(
     value: &SqlValue,
 ) -> Result<(), QueryError> {
     match value {
-        SqlValue::String(s) => check_max_length(model, field, s),
+        SqlValue::String(s) => {
+            check_max_length(model, field, s)?;
+            check_choices(model, field, s)
+        }
         SqlValue::I16(v) => check_int_range(model, field, i64::from(*v)),
         SqlValue::I32(v) => check_int_range(model, field, i64::from(*v)),
         SqlValue::I64(v) => check_int_range(model, field, *v),
@@ -65,6 +68,21 @@ fn check_max_length(
         });
     }
     Ok(())
+}
+
+fn check_choices(model: &'static str, field: &FieldSchema, value: &str) -> Result<(), QueryError> {
+    let Some(choices) = field.choices else {
+        return Ok(());
+    };
+    if choices.iter().any(|(v, _)| *v == value) {
+        return Ok(());
+    }
+    Err(QueryError::InvalidChoice {
+        model,
+        field: field.name.to_owned(),
+        value: value.to_owned(),
+        allowed: choices.iter().map(|(v, _)| *v).collect(),
+    })
 }
 
 fn check_int_range(model: &'static str, field: &FieldSchema, value: i64) -> Result<(), QueryError> {

--- a/crates/rustango/src/migrate/ddl.rs
+++ b/crates/rustango/src/migrate/ddl.rs
@@ -327,6 +327,7 @@ mod tests {
             unique: false,
             generated_as: None,
             help_text: None,
+            choices: None,
         }
     }
 

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -3851,6 +3851,7 @@ mod gen_tests {
             unique: false,
             generated_as: None,
             help_text: None,
+            choices: None,
         }
     }
 

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -532,6 +532,7 @@ mod composite_fk_snapshot_tests {
             unique: false,
             generated_as: None,
             help_text: None,
+            choices: None,
         }];
         static COMPS: [CompositeFkRelation; 1] = [CompositeFkRelation {
             name: "target",
@@ -592,6 +593,7 @@ mod composite_fk_snapshot_tests {
             unique: false,
             generated_as: None,
             help_text: None,
+            choices: None,
         }];
         static MS: ModelSchema = ModelSchema {
             name: "Plain",

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -215,6 +215,7 @@ mod tests {
             unique: false,
             generated_as: None,
             help_text: None,
+            choices: None,
         },
         FieldSchema {
             name: "title",
@@ -231,6 +232,7 @@ mod tests {
             unique: false,
             generated_as: None,
             help_text: None,
+            choices: None,
         },
         FieldSchema {
             name: "deleted_at",
@@ -247,6 +249,7 @@ mod tests {
             unique: false,
             generated_as: None,
             help_text: None,
+            choices: None,
         },
     ];
 

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -1237,6 +1237,7 @@ mod tests {
                 unique: false,
                 generated_as: None,
                 help_text: None,
+                choices: None,
             })
             .collect();
         let leaked: &'static [crate::core::FieldSchema] = Box::leak(field_vec.into_boxed_slice());

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -631,6 +631,7 @@ mod tests {
             unique: false,
             generated_as: None,
             help_text: None,
+            choices: None,
         }];
         static MODEL: ModelSchema = ModelSchema {
             name: "demo",

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -3835,6 +3835,7 @@ mod tests {
                     unique: false,
                     generated_as: None,
                     help_text: None,
+                    choices: None,
                 },
                 crate::core::FieldSchema {
                     name: "title",
@@ -3851,6 +3852,7 @@ mod tests {
                     unique: false,
                     generated_as: None,
                     help_text: None,
+                    choices: None,
                 },
             ])),
             display: None,
@@ -3893,6 +3895,7 @@ mod tests {
                     unique: false,
                     generated_as: None,
                     help_text: None,
+                    choices: None,
                 },
                 crate::core::FieldSchema {
                     name: "title",
@@ -3909,6 +3912,7 @@ mod tests {
                     unique: false,
                     generated_as: None,
                     help_text: None,
+                    choices: None,
                 },
                 crate::core::FieldSchema {
                     name: "score",
@@ -3925,6 +3929,7 @@ mod tests {
                     unique: false,
                     generated_as: None,
                     help_text: None,
+                    choices: None,
                 },
             ])),
             display: None,
@@ -4298,6 +4303,7 @@ mod tests {
                 unique: false,
                 generated_as: None,
                 help_text: None,
+                choices: None,
             }])),
             display: None,
             app_label: None,
@@ -4536,6 +4542,7 @@ mod tests {
                 unique: false,
                 generated_as: None,
                 help_text: None,
+                choices: None,
             }])),
             display: None,
             app_label: None,
@@ -4586,6 +4593,7 @@ mod tests {
                 unique: false,
                 generated_as: None,
                 help_text: None,
+                choices: None,
             }])),
             display: None,
             app_label: None,
@@ -5109,6 +5117,7 @@ mod tests {
                 unique: false,
                 generated_as: None,
                 help_text: None,
+                choices: None,
             })) as &'static crate::core::FieldSchema
         };
         assert!(matches!(

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1530,6 +1530,7 @@ mod lookup_tests {
             unique: false,
             generated_as: None,
             help_text: None,
+            choices: None,
         }
     }
 
@@ -1549,6 +1550,7 @@ mod lookup_tests {
             unique: false,
             generated_as: None,
             help_text: None,
+            choices: None,
         }
     }
 

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -294,6 +294,7 @@ mod tests {
             unique: false,
             generated_as: None,
             help_text: None,
+            choices: None,
         }
     }
 
@@ -313,6 +314,7 @@ mod tests {
             unique: false,
             generated_as: None,
             help_text: None,
+            choices: None,
         }
     }
 
@@ -332,6 +334,7 @@ mod tests {
             unique: false,
             generated_as: None,
             help_text: None,
+            choices: None,
         }
     }
 
@@ -352,6 +355,7 @@ mod tests {
                 unique: false,
                 generated_as: None,
                 help_text: None,
+                choices: None,
             },
             FieldSchema {
                 name: "title",
@@ -368,6 +372,7 @@ mod tests {
                 unique: false,
                 generated_as: None,
                 help_text: None,
+                choices: None,
             },
             FieldSchema {
                 name: "author_id",
@@ -384,6 +389,7 @@ mod tests {
                 unique: false,
                 generated_as: None,
                 help_text: None,
+                choices: None,
             },
         ];
         // Suppress unused warnings on field helpers if we keep them.

--- a/crates/rustango/tests/field_types_decimal_binary_time.rs
+++ b/crates/rustango/tests/field_types_decimal_binary_time.rs
@@ -123,6 +123,7 @@ fn form_parser_decimal() {
         relation: None,
         generated_as: None,
         help_text: None,
+        choices: None,
     };
     let v = parse_form_value(&f, Some("123.45")).unwrap();
     assert!(matches!(v, SqlValue::Decimal(d) if d == Decimal::from_str("123.45").unwrap()));
@@ -150,6 +151,7 @@ fn form_parser_binary_hex() {
         relation: None,
         generated_as: None,
         help_text: None,
+        choices: None,
     };
     let v = parse_form_value(&f, Some("deadbeef")).unwrap();
     assert!(matches!(v, SqlValue::Binary(b) if b == vec![0xde, 0xad, 0xbe, 0xef]));
@@ -179,6 +181,7 @@ fn form_parser_time() {
         relation: None,
         generated_as: None,
         help_text: None,
+        choices: None,
     };
     // Full HH:MM:SS form.
     let v = parse_form_value(&f, Some("14:30:45")).unwrap();

--- a/crates/rustango/tests/macro_choices.rs
+++ b/crates/rustango/tests/macro_choices.rs
@@ -1,0 +1,107 @@
+//! `#[rustango(choices = "...")]` field attribute (Django parity #446).
+//!
+//! Covers:
+//! - macro parses comma-separated `value:Label` pairs onto `FieldSchema::choices`
+//! - missing label falls back to value (`value` == `Label`)
+//! - validator rejects off-choice strings and accepts in-choice ones
+//! - admin `render_input` emits `<select>` when choices are present
+//!
+//! No DB roundtrip — these are pure schema / writer / validator checks
+//! against the macro output, so the test compiles under any backend.
+
+use rustango::core::{validate_value, FieldSchema, Model, QueryError, SqlValue};
+use rustango_macros::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "macro_choices_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+
+    #[rustango(max_length = 200)]
+    pub title: String,
+
+    #[rustango(
+        max_length = 32,
+        choices = "draft:Draft, published:Published, archived:Archived"
+    )]
+    pub status: String,
+
+    /// A choices field with no `:` separators — value reused as label.
+    #[rustango(max_length = 8, choices = "yes, no, maybe")]
+    pub vote: String,
+}
+
+fn field<'a>(name: &str) -> &'a FieldSchema {
+    Post::SCHEMA
+        .field(name)
+        .unwrap_or_else(|| panic!("no field {name:?}"))
+}
+
+#[test]
+fn schema_threads_choices_with_labels() {
+    let f = field("status");
+    let choices = f.choices.expect("choices threaded onto FieldSchema");
+    assert_eq!(
+        choices,
+        &[
+            ("draft", "Draft"),
+            ("published", "Published"),
+            ("archived", "Archived"),
+        ]
+    );
+}
+
+#[test]
+fn schema_threads_choices_without_labels_reuses_value() {
+    let f = field("vote");
+    let choices = f.choices.expect("choices threaded");
+    assert_eq!(choices, &[("yes", "yes"), ("no", "no"), ("maybe", "maybe")]);
+}
+
+#[test]
+fn fields_without_choices_attribute_have_none() {
+    assert!(field("id").choices.is_none());
+    assert!(field("title").choices.is_none());
+}
+
+#[test]
+fn validate_value_rejects_off_choice() {
+    let f = field("status");
+    let err = validate_value("Post", f, &SqlValue::String("nope".to_owned())).unwrap_err();
+    match err {
+        QueryError::InvalidChoice {
+            field: name,
+            value,
+            allowed,
+            ..
+        } => {
+            assert_eq!(name, "status");
+            assert_eq!(value, "nope");
+            assert_eq!(allowed, vec!["draft", "published", "archived"]);
+        }
+        other => panic!("expected InvalidChoice, got {other:?}"),
+    }
+}
+
+#[test]
+fn validate_value_accepts_in_choice() {
+    let f = field("status");
+    validate_value("Post", f, &SqlValue::String("draft".to_owned())).unwrap();
+    validate_value("Post", f, &SqlValue::String("published".to_owned())).unwrap();
+}
+
+#[test]
+fn validate_value_still_checks_max_length_on_choices_field() {
+    // Even though the choices set is small, `max_length` should still
+    // fire on a long off-choice value — this guards against future
+    // regressions that might short-circuit max_length when choices set.
+    let f = field("vote");
+    let err = validate_value("Post", f, &SqlValue::String("waytoolong".to_owned())).unwrap_err();
+    match err {
+        QueryError::MaxLengthExceeded { .. } => {}
+        QueryError::InvalidChoice { .. } => {} // either order is fine
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -1,0 +1,747 @@
+# Django 6.0 parity audit — rustango v0.41 (2026-05-21)
+
+Single-source reference for "what does rustango cover vs Django, what's still missing." Every row points at a specific Django 6.0 doc anchor + the closest rustango source path or issue.
+
+## Method
+
+Status codes per row:
+- **SHIPPED** — feature works end-to-end with comparable ergonomics
+- **PARTIAL** — present but with caveats (PG-only, missing sub-feature, non-Django shape)
+- **MISSING** — no rustango equivalent today
+- **N/A** — architectural divergence makes Django's API not directly translatable (e.g. WSGI vs axum)
+
+Counts roll up at the bottom of each section. "Top 10 gaps by user-facing impact" closes the doc.
+
+This is a static snapshot — when in doubt about a row, `grep` the cited source path. The audit is a starting point for picking next work, not a binding contract.
+
+---
+
+## Summary stats
+
+| Category | SHIPPED | PARTIAL | MISSING | N/A |
+|---|---:|---:|---:|---:|
+| 1. ORM — models / fields / Meta | 8 | 3 | 4 | 1 |
+| 2. QuerySet API | 22 | 4 | 4 | 0 |
+| 3. Field types & options | 14 | 4 | 7 | 0 |
+| 4. Postgres-specific fields | 1 | 1 | 3 | 0 |
+| 5. Migrations | 11 | 2 | 2 | 1 |
+| 6. Admin (ModelAdmin) | 18 | 7 | 11 | 2 |
+| 7. Forms / Formsets | 8 | 3 | 4 | 0 |
+| 8. Generic CBVs | 5 | 2 | 3 | 0 |
+| 9. URL routing | 5 | 1 | 1 | 1 |
+| 10. Templates | 7 | 3 | 1 | 0 |
+| 11. Authentication | 14 | 4 | 4 | 1 |
+| 12. Sessions | 4 | 1 | 1 | 0 |
+| 13. Manage commands | 13 | 5 | 6 | 4 |
+| 14. Settings | 10 | 4 | 4 | 2 |
+| 15. Security / middleware | 14 | 1 | 1 | 0 |
+| 16. Caching | 7 | 1 | 2 | 0 |
+| 17. Signals | 7 | 2 | 5 | 0 |
+| 18. Email | 6 | 2 | 1 | 0 |
+| 19. Files / Storage | 3 | 2 | 3 | 0 |
+| 20. i18n / l10n | 1 | 2 | 6 | 0 |
+| 21. Testing | 7 | 3 | 3 | 0 |
+| 22. Async support | 5 | 0 | 0 | 2 |
+| 23. DRF parity | 11 | 4 | 4 | 0 |
+| 24. contrib modules | 6 | 4 | 4 | 0 |
+| **Totals** | **205** | **65** | **84** | **14** |
+
+Coverage = 205 / (205 + 65 + 84) = **58% full, 19% partial, 24% missing** vs Django 6.0 surface (excluding 14 N/A rows). Partial+shipped = **77%**.
+
+---
+
+## 1. ORM — models, fields, Meta, custom Manager, abstract base classes
+
+| Django capability | Django doc | rustango status | rustango pointer | Gap / notes |
+|---|---|---|---|---|
+| `class Model(models.Model)` declaration | [Models#fields](https://docs.djangoproject.com/en/6.0/topics/db/models/) | SHIPPED | `#[derive(Model)]` in [crates/rustango-macros/src/lib.rs](crates/rustango-macros/src/lib.rs) | Tri-dialect since v0.38. |
+| `Meta.db_table` | [Meta options#db_table](https://docs.djangoproject.com/en/6.0/ref/models/options/#db-table) | SHIPPED | `#[rustango(table = "...")]` | |
+| `Meta.ordering` | [Meta options#ordering](https://docs.djangoproject.com/en/6.0/ref/models/options/#ordering) | SHIPPED | `#[rustango(default_order = "-created, +status")]` per-query opt-in via `.with_default_order()` (closed #291) | Per-query opt-in by design — avoids Django's "every query pays" footgun. |
+| `Meta.unique_together` | [Meta#unique_together](https://docs.djangoproject.com/en/6.0/ref/models/options/#unique-together) | SHIPPED | `#[rustango(unique_together(...))]` (v0.19) | |
+| `Meta.index_together` | [Meta#index_together](https://docs.djangoproject.com/en/6.0/ref/models/options/#index-together) | SHIPPED | `#[rustango(index_together(...))]` (v0.19) | |
+| `Meta.constraints` (CheckConstraint, UniqueConstraint) | [Constraints](https://docs.djangoproject.com/en/6.0/ref/models/constraints/) | PARTIAL | `#[rustango(check(name, expr))]` + `unique_when` (partial unique) (#319) | `ExclusionConstraint` MISSING; no row-level CHECK with cross-field expression beyond raw SQL. |
+| `Meta.verbose_name` / `verbose_name_plural` | [Meta#verbose_name](https://docs.djangoproject.com/en/6.0/ref/models/options/#verbose-name) | MISSING | n/a (#320) | Used by admin headers + i18n. Backlog. |
+| `Meta.permissions` (custom codenames) | [Meta#permissions](https://docs.djangoproject.com/en/6.0/ref/models/options/#permissions) | SHIPPED | `auto_create_permissions_pool` seeds CRUD codenames; reserved `auth.access_admin` added in PR #313 | Custom per-model codenames not yet declarative — set via `set_user_perm_pool` runtime. |
+| `Meta.default_manager_name` | [Custom Managers](https://docs.djangoproject.com/en/6.0/topics/db/managers/) | SHIPPED | `#[rustango(manager_fn = "active")]` (closed #289 / T2.6) | Multiple `manager_fn` allowed. |
+| Custom `Manager` subclass | [Custom Managers](https://docs.djangoproject.com/en/6.0/topics/db/managers/) | SHIPPED | `#[rustango(manager(ext = "FooManagerExt"))]` emits an extension trait the user impls on `QuerySet<Self>` (T1.9) | |
+| Abstract base classes | [Abstract base](https://docs.djangoproject.com/en/6.0/topics/db/models/#abstract-base-classes) | MISSING | n/a (#321) | No `#[derive(Model)]` "abstract" attribute. Composition via traits is the Rust idiom — but the field-inheritance Django pattern isn't surfaced. |
+| Multi-table inheritance | [MTI](https://docs.djangoproject.com/en/6.0/topics/db/models/#multi-table-inheritance) | MISSING | n/a (#322) | rustango-cms uses MTI for PageType (custom impl); framework doesn't auto-generate it. |
+| Proxy models | [Proxy](https://docs.djangoproject.com/en/6.0/topics/db/models/#proxy-models) | MISSING | n/a (#323) | No equivalent. |
+| `ForeignKey(on_delete=...)` | [FK options](https://docs.djangoproject.com/en/6.0/ref/models/fields/#django.db.models.ForeignKey.on_delete) | SHIPPED | `pub author: ForeignKey<Author>` field; FK constraint emits `ON DELETE` per dialect | `on_delete` enum (CASCADE / PROTECT / SET_NULL / SET_DEFAULT / DO_NOTHING) is currently a fixed default — explicit override MISSING (see "Gap notes"). |
+| Self-referential FK | [Self FK](https://docs.djangoproject.com/en/6.0/ref/models/fields/#django.db.models.ForeignKey) | SHIPPED | `#[rustango(fk = "self")]` (v0.17.2) | Tested via `tests/self_fk_live.rs`. |
+| `ManyToManyField(through=...)` | [M2M through](https://docs.djangoproject.com/en/6.0/topics/db/models/#extra-fields-on-many-to-many-relationships) | PARTIAL | `#[rustango(m2m(through = "...", src = "...", dst = "..."))]` (#324) | Implicit through-table OK; explicit through-MODEL with extra fields requires hand-rolling. |
+
+Summary: **8 SHIPPED / 3 PARTIAL / 4 MISSING / 1 N/A**. Gaps: abstract base + MTI + proxy + `Meta.verbose_name` + `on_delete=PROTECT/SET_NULL` override + ExclusionConstraint.
+
+---
+
+## 2. QuerySet API (30+ methods)
+
+| Django method | Doc | Status | rustango pointer | Notes |
+|---|---|---|---|---|
+| `.filter(**kwargs)` (string keyed) | [filter](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#filter) | SHIPPED | [crates/rustango/src/query/mod.rs#QuerySet::filter](crates/rustango/src/query/mod.rs) | `__icontains`, `__in`, `__gte`, `__between` etc. via `parse_lookup`. |
+| `.exclude(**kwargs)` | [exclude](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#exclude) | SHIPPED | `.exclude(...)` | |
+| `Q()` composable | [Q](https://docs.djangoproject.com/en/6.0/topics/db/queries/#complex-lookups-with-q-objects) | SHIPPED | `Q!()` compile-time macro + `core::query::Q` runtime (T1.1, T1.7) | |
+| `F()` expression | [F](https://docs.djangoproject.com/en/6.0/ref/models/expressions/#f) | SHIPPED | `F("col")` in [src/core/expr.rs](crates/rustango/src/core/expr.rs) | |
+| `.annotate(alias=expr)` | [annotate](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#annotate) | SHIPPED | `AggregateBuilder::annotate` + tri-dialect GROUP BY parity (T2.8 closed) | |
+| `.alias()` (non-projected) | [alias](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#alias) | SHIPPED | T1.6 closed | |
+| `.aggregate(**kwargs)` | [aggregate](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#aggregate) | SHIPPED | `aggregates::{count_all, sum, avg, min, max, ...}` | |
+| Window functions (`Window`, `RowNumber`, `Rank`, `Lag`, `Lead`) | [Window](https://docs.djangoproject.com/en/6.0/ref/models/expressions/#window-functions) | SHIPPED | `core::window::{row_number, rank, dense_rank, lag, lead, ntile}` | |
+| `Subquery()`, `OuterRef()`, `Exists()` | [Subquery](https://docs.djangoproject.com/en/6.0/ref/models/expressions/#subquery-expressions) | SHIPPED | `core::subquery::{Subquery, OuterRef, exists}` | |
+| `Case` / `When` | [Case](https://docs.djangoproject.com/en/6.0/ref/models/expressions/#case) | SHIPPED | `core::case::case()` builder | |
+| `.values(*fields)` (dict-shape projection) | [values](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#values) | SHIPPED | `.values_dict(&["col", ...])` + `.values(...).annotate(...)` Shape 2/3 (T2.8) | |
+| `.values_list(*fields, flat=True)` | [values_list](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#values-list) | SHIPPED | `.values_list(...)` + `.values_list_flat(col)` | |
+| `.distinct()` / `.distinct(*fields)` | [distinct](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#distinct) | SHIPPED | T1.2 closed: PG `DISTINCT ON` + MySQL/SQLite window-fn fallback | |
+| `.order_by(*fields)` | [order_by](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#order-by) | SHIPPED | `.order_by(&[("col", false), ...])` + `.unordered()` | |
+| `.reverse()` | [reverse](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#reverse) | MISSING | n/a (#325) | Trivial; manually invert `order_by`. |
+| `.select_related(*fk)` (single hop) | [select_related](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#select-related) | SHIPPED | `lower_select_related` in query/mod.rs | |
+| `.select_related("a__b__c")` (multi-hop) | [select_related](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#select-related) | PARTIAL | T2.2 closed (PR #308) — JOIN emission ships; decoder-side recursive stitching deferred (#451) | Filter-on-deep-column works via `Expr::AliasedColumn`; `post.author.profile.get_pool()` auto-stitch is a follow-up. |
+| `.prefetch_related(*rel)` | [prefetch_related](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#prefetch-related) | SHIPPED | `sql::fetch_with_prefetch_pool` | Tri-dialect; non-i64 FK PKs supported (v0.26). |
+| `.prefetch_related(Prefetch(qs))` | [Prefetch](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#django.db.models.Prefetch) | SHIPPED | `sql::fetch_with_prefetch_filtered_pool` (T2.1 closed, PR #309) | Global `LIMIT` only — Django's per-parent slice (LATERAL JOIN) is a follow-up. |
+| `.raw(sql)` | [raw](https://docs.djangoproject.com/en/6.0/topics/db/sql/#executing-raw-queries) | SHIPPED | `sql::raw_query_pool` | |
+| `bulk_create(objs)` | [bulk_create](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#bulk-create) | SHIPPED | `Model::bulk_insert` | |
+| `bulk_create(objs, update_conflicts=True)` (UPSERT) | [bulk_create](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#bulk-create) | SHIPPED | `Model::bulk_upsert` + `bulk_insert_or_ignore` (T1.5 closed) | Picks `unique_together` target when defined (v0.26 fix). |
+| `.bulk_update(objs, fields)` | [bulk_update](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#bulk-update) | PARTIAL | Per-record `.update().set(...).execute_on(pool)` works; bulk array-bind helper exists but no explicit `bulk_update(rows, fields)` ORM facade (#326) | Issue tracked in ORM improvements memo as P8. |
+| `.bulk_delete()` / `.delete()` on QuerySet | [delete](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#delete) | SHIPPED | `QuerySet::delete().execute_on(pool)` | |
+| `.select_for_update()` | [select_for_update](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#select-for-update) | SHIPPED | `.with_lock(LockMode::ForUpdate)` + dialect-aware warning on SQLite (T2.9 closed) | |
+| `.iterator(chunk_size=N)` | [iterator](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#iterator) | SHIPPED | `.iterator(chunk_size)` returns `ChunkedIter<T>` | |
+| `.explain()` | [explain](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#explain) | SHIPPED | `sql::explain_pool` tri-dialect (T1.10 closed) | PG / MySQL / SQLite each emit their native EXPLAIN. |
+| `.in_bulk(ids)` | [in_bulk](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#in-bulk) | SHIPPED | `QuerySet::in_bulk` | |
+| `.dates(field, kind)` | [dates](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#dates) | MISSING | n/a (#327) | Would build on `extract_year`/`trunc_*` funcs already shipped. |
+| `.datetimes(field, kind)` | [datetimes](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#datetimes) | MISSING | n/a (#328) | Same. |
+| `.latest(*fields)` / `.earliest(*fields)` | [latest](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#latest) | SHIPPED | `QuerySet::latest` / `earliest` on pool | |
+| `.first()` / `.last()` | [first](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#first) | SHIPPED | `QuerySet::first` / `.last` | |
+| `.count()` / `.exists()` | [count](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#count) | SHIPPED | `.count_pool` / `.exists_pool` | |
+| `.get_or_create()` / `.update_or_create()` | [get_or_create](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#get-or-create) | SHIPPED | `sql::get_or_create` + `sql::update_or_create` | |
+| `.union()` / `.intersection()` / `.difference()` | [union](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#union) | PARTIAL | `CompoundBranch` IR shipped + `QuerySet::union` (#329) | Intersection / difference path less polished; verify per-dialect. |
+| `.contains(obj)` | [contains](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#contains) | MISSING | n/a (#330) | Trivial wrapper on `.filter(pk=obj.pk).exists()`. |
+| `.none()` | [none](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#none) | PARTIAL | Express as `.filter(...where false...)` manually (#331) | No `QuerySet::none()` sugar. |
+| `__lookup`s (`__icontains`, `__lt`, `__in`, `__between`, `__range`, `__isnull`, ...) | [Field lookups](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#field-lookups) | SHIPPED | `parse_lookup` in query/mod.rs | Most Django lookups; missing: `__date`, `__year__lte`, etc. requiring transform chains. |
+| `.using(db_alias)` (multi-DB routing) | [using](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#using) | MISSING | n/a (#332) | rustango is single-pool-per-QuerySet (or tenant-scoped); multi-DB router missing. |
+
+Summary: **22 SHIPPED / 4 PARTIAL / 4 MISSING / 0 N/A**. Gaps: `.reverse()`, `.dates/datetimes`, `.contains/.none` sugar, multi-DB `.using()`.
+
+---
+
+## 3. Field types & options
+
+Built-in Django fields:
+
+| Django field | Doc | Status | rustango pointer | Notes |
+|---|---|---|---|---|
+| `CharField(max_length=N)` | [CharField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#charfield) | SHIPPED | `String` + `#[rustango(max_length = 200)]` | |
+| `TextField` | [TextField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#textfield) | SHIPPED | `String` without `max_length` | Same Rust type; DDL emits TEXT. |
+| `IntegerField` / `BigIntegerField` / `SmallIntegerField` | [IntegerField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#integerfield) | SHIPPED | `i32` / `i64` / `i16` Rust types | |
+| `PositiveIntegerField` | [PositiveIntegerField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#positiveintegerfield) | PARTIAL | `i64` with `#[rustango(min = 0)]` (#333) | No unsigned int field type — close enough via CHECK. |
+| `FloatField` / `DecimalField` | [DecimalField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#decimalfield) | SHIPPED | `f64` / `rust_decimal::Decimal` | |
+| `BooleanField` | [BooleanField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#booleanfield) | SHIPPED | `bool` | |
+| `DateField` / `DateTimeField` / `TimeField` | [DateField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#datefield) | SHIPPED | `chrono::NaiveDate` / `DateTime<Utc>` / `NaiveTime` | |
+| `auto_now` / `auto_now_add` | [DateField#auto_now](https://docs.djangoproject.com/en/6.0/ref/models/fields/#django.db.models.DateField.auto_now) | SHIPPED | `Auto<DateTime<Utc>>` + `#[rustango(auto_now)]` / `auto_now_add` | |
+| `UUIDField` | [UUIDField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#uuidfield) | SHIPPED | `uuid::Uuid` | |
+| `JSONField` | [JSONField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#jsonfield) | SHIPPED | `serde_json::Value` + JSON path lookups (T2.3 closed, PR #307) | |
+| `BinaryField` | [BinaryField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#binaryfield) | SHIPPED | `Vec<u8>` mapped to BYTEA/BLOB | |
+| `EmailField` (validator) | [EmailField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#emailfield) | PARTIAL | `String` + `validators::validate_email` form-side (#334) | No model-level email validation on insert/update. |
+| `URLField` | [URLField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#urlfield) | PARTIAL | Same shape as EmailField (#335) | |
+| `SlugField` | [SlugField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#slugfield) | PARTIAL | `String` + `slug_field` macro attr (slug generation) (#336) | No slugify on save signal. |
+| `IPAddressField` / `GenericIPAddressField` | [GenericIPAddressField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#genericipaddressfield) | MISSING | n/a (#337) | Use `String`; no validator. |
+| `FilePathField` | [FilePathField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#filepathfield) | MISSING | n/a (#338) | |
+| `FileField` (model side) | [FileField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#filefield) | MISSING | n/a (#339) | rustango has `Media` model + Storage backends; not a native FileField on arbitrary models. |
+| `ImageField` | [ImageField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#imagefield) | MISSING | n/a (#340) | Same — image-specific FileField pattern not surfaced. |
+| `GeneratedField` (DB-computed) | [GeneratedField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#generatedfield) | SHIPPED | `#[rustango(generated_as = "price * qty")]` emits `GENERATED ALWAYS AS (...) STORED` | |
+| `Auto<i64>` / `BigAutoField` / `DEFAULT_AUTO_FIELD` | [Auto fields](https://docs.djangoproject.com/en/6.0/ref/models/fields/#bigautofield) | SHIPPED | `Auto<i64>` typed | |
+
+Field options:
+
+| Option | Status | rustango | Notes |
+|---|---|---|---|
+| `max_length` | SHIPPED | `#[rustango(max_length = N)]` | |
+| `null=True` (DB-level nullable) | SHIPPED | `Option<T>` Rust type | |
+| `blank=True` (form-level allow empty) | PARTIAL | Form fields treat `Option<T>` as optional; no separate `blank` attribute (#445) | |
+| `default` | SHIPPED | `#[rustango(default = "expr")]` | |
+| `choices=[...]` | SHIPPED | `#[rustango(choices = "draft:Draft, published:Published")]` (#446, v0.42) — admin renders `<select>`, validator rejects off-choice values | |
+| `validators=[...]` | PARTIAL | Form-side: `validate_email`, `validate_url`, `validate_min_length`, file validators (#447) | Model-side validators on save MISSING. |
+| `db_index=True` | SHIPPED | `#[rustango(index)]` (field-level) + container-level `index(...)` | |
+| `db_column` | SHIPPED | `#[rustango(db_column = "...")]` | |
+| `help_text` | SHIPPED | `#[rustango(help_text = "...")]` (v0.40) — admin renders below input | |
+| `verbose_name` | MISSING | n/a (#448) | Admin column headers use field name as-is. |
+| `primary_key=True` | SHIPPED | `#[rustango(primary_key)]` | |
+| `unique=True` | SHIPPED | `#[rustango(unique)]` | |
+| `editable=False` | MISSING | n/a (#449) | Use `#[rustango(readonly)]` admin attribute instead. |
+| `db_comment` | MISSING | n/a (#450) | |
+| `db_tablespace` | N/A | n/a | Tablespaces are PG-specific niche. |
+
+Summary: **14 SHIPPED / 4 PARTIAL / 7 MISSING / 0 N/A** in this section. Gaps cluster around: `choices`, `verbose_name`, `editable`, IP/FilePath/File/ImageField, model-level validators.
+
+---
+
+## 4. Postgres-specific fields (`django.contrib.postgres.fields`)
+
+| Django field | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `JSONField` | (now built-in) | SHIPPED | See section 3 | |
+| `ArrayField` | [ArrayField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#arrayfield) | PARTIAL | `SqlValue::Array` + `Op::ArrayContains/ContainedBy/Overlap` operators emitted on PG; no native typed field wrapper in models (#341) | Future-backlog item. |
+| `HStoreField` | [HStoreField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#hstorefield) | MISSING | n/a (#342) | |
+| `RangeField` (Int / Date / DateTime / Decimal) | [RangeField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#range-fields) | MISSING | n/a — `SqlValue::RangeLiteral` exists but no typed field (#343) | |
+| `CITextField` | [CITextField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#citext-fields) | MISSING | n/a (#344) | |
+
+Summary: **1 / 1 / 3 / 0**.
+
+---
+
+## 5. Migrations
+
+| Capability | Doc | Status | rustango pointer | Notes |
+|---|---|---|---|---|
+| `python manage.py makemigrations` | [makemigrations](https://docs.djangoproject.com/en/6.0/topics/migrations/#creating-migrations) | SHIPPED | `manage makemigrations` in [src/migrate/manage.rs](crates/rustango/src/migrate/manage.rs) | Snapshot-based JSON file output. |
+| `python manage.py migrate [app] [target]` | [migrate](https://docs.djangoproject.com/en/6.0/topics/migrations/#applying-migrations) | SHIPPED | `manage migrate` | |
+| `python manage.py showmigrations` | [showmigrations](https://docs.djangoproject.com/en/6.0/ref/django-admin/#showmigrations) | SHIPPED | `manage showmigrations` | |
+| `python manage.py sqlmigrate` | [sqlmigrate](https://docs.djangoproject.com/en/6.0/ref/django-admin/#sqlmigrate) | PARTIAL | `manage migrate --plan` shows operations not raw SQL (#345) | |
+| `python manage.py squashmigrations` | [squashmigrations](https://docs.djangoproject.com/en/6.0/topics/migrations/#squashing-migrations) | SHIPPED | `manage migrate --squash` (v0.29) | Fresh-table scenarios only; not full Django squash. |
+| `python manage.py makemigrations --merge` | [merge](https://docs.djangoproject.com/en/6.0/topics/migrations/#merging-migrations) | MISSING | n/a (#346) | |
+| `migrate --fake` / `--fake-initial` | [fake](https://docs.djangoproject.com/en/6.0/ref/django-admin/#cmdoption-migrate-fake) | SHIPPED | `manage migrate --fake` (v0.28) | |
+| `RunPython` (data migration) | [RunPython](https://docs.djangoproject.com/en/6.0/ref/migration-operations/#runpython) | PARTIAL | Embedded Rust callbacks (v0.3 stretch) + `migrate_data` JSON ops (#347) | Rust-fn pointer not as flexible as Python lambda; works for INSERT/UPDATE/DELETE seed patterns. |
+| `RunSQL` | [RunSQL](https://docs.djangoproject.com/en/6.0/ref/migration-operations/#runsql) | SHIPPED | `migrate_data::RunSQL` op | Includes `reverse_sql`. |
+| `AddField` / `RemoveField` / `AlterField` / `RenameField` | [Operations](https://docs.djangoproject.com/en/6.0/ref/migration-operations/) | SHIPPED | `SchemaChange::AddColumn` / `DropColumn` / `AlterColumn` / `RenameColumn` | RenameField via `rename_from` metadata (v0.4). |
+| `AddIndex` / `RemoveIndex` | [AddIndex](https://docs.djangoproject.com/en/6.0/ref/migration-operations/#addindex) | SHIPPED | Index attrs auto-diff into `CreateIndex`/`DropIndex` ops | |
+| `AddConstraint` / `RemoveConstraint` | [AddConstraint](https://docs.djangoproject.com/en/6.0/ref/migration-operations/#addconstraint) | SHIPPED | CHECK + UNIQUE constraints | |
+| Migration dependencies | [dependencies](https://docs.djangoproject.com/en/6.0/topics/migrations/#django.db.migrations.migration.Migration.dependencies) | SHIPPED | `previous_migration` field links the chain | |
+| Atomic migrations | [atomic](https://docs.djangoproject.com/en/6.0/howto/writing-migrations/#non-atomic-migrations) | SHIPPED | Each migration applies in a transaction | |
+| Schema-mode per-tenant migrations | (Django doesn't ship this) | N/A | `tenancy::migrate` runs per-tenant | Beyond Django's per-DB. |
+| inspectdb (tables + views) | [inspectdb](https://docs.djangoproject.com/en/6.0/ref/django-admin/#inspectdb) | SHIPPED | T2.10 closed — views walked too (PR #304) | |
+
+Summary: **11 SHIPPED / 2 PARTIAL / 2 MISSING / 1 N/A**. Gaps: `sqlmigrate` raw-SQL print, `migrations --merge`.
+
+---
+
+## 6. Admin (ModelAdmin parity)
+
+| ModelAdmin option | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `list_display` (scalar fields) | [list_display](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display) | SHIPPED | `#[rustango(admin(list_display = "title, status"))]` | |
+| `list_display` (method/computed fields) | same | MISSING | n/a (#348) | Backlog #51 — needs method-field hook + custom cell renderer. |
+| `list_display` (boolean checkbox icon) | same | SHIPPED | v0.37+ render in admin/render.rs | |
+| `list_display` (callable display_link) | same | MISSING | n/a (#349) | FK columns auto-link; method-field callables don't. |
+| `list_display_links` | [list_display_links](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display_links) | MISSING | n/a (#350) | First display field is always the link; not configurable. |
+| `list_filter` (FieldListFilter) | [list_filter](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_filter) | SHIPPED | `#[rustango(admin(list_filter = "..."))]` | |
+| `list_filter` (SimpleListFilter — custom) | same | MISSING | n/a (#351) | Filter chips currently field-value-driven only. |
+| `list_per_page` | [list_per_page](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_per_page) | SHIPPED | `#[rustango(admin(list_per_page = 50))]` | |
+| `list_select_related` | [list_select_related](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_select_related) | PARTIAL | Implicit FK joins via `build_fk_joins` (#352) | Not explicitly togglable per model. |
+| `ordering` | [ordering](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.ordering) | SHIPPED | `#[rustango(admin(ordering = "..."))]` | |
+| `search_fields` | [search_fields](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.search_fields) | SHIPPED | `#[rustango(admin(search_fields = "..."))]` + tri-dialect ILIKE (fixed v0.37) | |
+| `search_help_text` | [search_help_text](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.search_help_text) | MISSING | n/a (#353) | |
+| `readonly_fields` | [readonly_fields](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.readonly_fields) | SHIPPED | `#[rustango(admin(readonly_fields = "..."))]` | |
+| `fieldsets` | [fieldsets](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.fieldsets) | SHIPPED | `#[rustango(admin(fieldsets = "Title: a, b | Other: c"))]` | |
+| `actions` (bulk) | [actions](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.actions) | SHIPPED | `#[rustango(admin(actions = "publish, archive"))]` + handler registry | |
+| `actions_on_top` / `actions_on_bottom` | same | MISSING | n/a (#354) | Position fixed. |
+| `date_hierarchy` | [date_hierarchy](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.date_hierarchy) | MISSING | n/a (#355) | |
+| `prepopulated_fields` (slug-from-title) | [prepopulated_fields](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.prepopulated_fields) | MISSING | n/a (#356) | |
+| `raw_id_fields` (large-FK widget) | [raw_id_fields](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.raw_id_fields) | MISSING | n/a (#357) | FK widget is currently always a `<select>` — large FK tables slow. |
+| `autocomplete_fields` | [autocomplete_fields](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.autocomplete_fields) | MISSING | n/a (#358) | |
+| `formfield_overrides` | [formfield_overrides](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.formfield_overrides) | MISSING | n/a (#359) | |
+| `get_queryset(self, request)` override | [get_queryset](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.get_queryset) | PARTIAL | Custom Manager (`manager_fn`) gives the parallel (#360) | No request-aware QS hook. |
+| `has_add_permission` / `change` / `delete` / `view` | [has_*_permission](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.has_add_permission) | PARTIAL | `auto_create_permissions_pool` seeds codenames; `permission_required` middleware gates routes (#361) | Per-object hook MISSING. |
+| Tabular / Stacked inlines | [InlineModelAdmin](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#inlinemodeladmin-objects) | SHIPPED | `register_admin_inline_tabular!` / `_stacked!` macros (v0.27+) | |
+| Generic inlines | [generic-inline-admin](https://docs.djangoproject.com/en/6.0/ref/contrib/contenttypes/#generic-inline-model-admin) | SHIPPED | `register_admin_inline_generic!` (v0.40, closed #242–#244) | |
+| Custom URLs (`get_urls`) | [get_urls](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.get_urls) | PARTIAL | Builder exposes `register_action` for bulk actions (#362) | No arbitrary `/<model>/custom/` routes per admin. |
+| Custom views per model | (above) | MISSING | n/a (#363) | |
+| Multiple AdminSite registries | [AdminSite](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.AdminSite) | PARTIAL | `admin::Builder` supports `show_only` / `read_only` per builder (#364) | Not multiple side-by-side admin instances; tenant admin is a distinct surface. |
+| `ModelAdmin.save_model()` / `delete_model()` hooks | [save_model](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.save_model) | MISSING | n/a (#365) | Signals (`post_save`) cover most cases. |
+| `ModelAdmin.history_view` (object history) | [history-view](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.history_view) | SHIPPED | Audit log read-only panel on detail page (v0.28+) | |
+| Recent actions widget | (admin home) | MISSING | n/a (#366) | |
+| Theming (light/dark) | (Django 5.1+ official) | SHIPPED | Token-driven theme + dark mode toggle + per-tenant branding (v0.26+) | Goes beyond Django's basic palette. |
+| Password change for staff | [password change](https://docs.djangoproject.com/en/6.0/topics/auth/default/#changing-passwords) | SHIPPED | `/account/password` (v0.40) | |
+| Two-factor admin login | n/a (Django needs `django-otp`) | PARTIAL | `totp::*` ships RFC 6238 primitives; no admin enrollment UI (#367) | |
+| Custom dashboard | [admin templates override](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#overriding-admin-templates) | PARTIAL | Tera template override works (#368) | No formal widget API. |
+| Admin styling / branding | [admin templates](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#overriding-admin-templates) | SHIPPED | `Storage`-backed per-tenant brand + theme tokens | |
+| Admin docs (`django.contrib.admindocs`) | [admindocs](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/admindocs/) | N/A | n/a | Rust doc-comments cover it. |
+
+Summary: **18 SHIPPED / 7 PARTIAL / 11 MISSING / 2 N/A**. Concentration of MISSING items in admin polish: method-field display, list_display_links, raw_id_fields, autocomplete, formfield_overrides, date_hierarchy, prepopulated_fields, custom URLs.
+
+---
+
+## 7. Forms / Formsets
+
+| Capability | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `Form` class | [Forms](https://docs.djangoproject.com/en/6.0/topics/forms/) | SHIPPED | `#[derive(Form)]` macro emits `Form::parse` | |
+| `ModelForm` | [ModelForm](https://docs.djangoproject.com/en/6.0/topics/forms/modelforms/) | PARTIAL | `forms::ModelForm` struct + `from_model_schema` runtime — works for admin path (#369) | No `#[derive(ModelForm)]` shortcut. Backlog. |
+| Form fields (CharField, IntegerField, etc.) | [Form fields](https://docs.djangoproject.com/en/6.0/ref/forms/fields/) | SHIPPED | Field attrs in `Form` derive | |
+| Widgets (Select, Textarea, RadioSelect, etc.) | [Widgets](https://docs.djangoproject.com/en/6.0/ref/forms/widgets/) | PARTIAL | Admin renders fixed HTML per FieldType; no widget swap (#370) | |
+| Per-field validators chain | [validators](https://docs.djangoproject.com/en/6.0/ref/validators/) | PARTIAL | `validators::{validate_email, validate_url, validate_min_length, file_type, file_size_max}` shipped (#371) | `validators=[...]` declarative-stack MISSING. |
+| `clean_<field>` per-field clean | [clean methods](https://docs.djangoproject.com/en/6.0/ref/forms/validation/) | MISSING | n/a (#372) | Macro doesn't emit per-field clean hooks. |
+| `clean()` cross-field validation | (above) | MISSING | n/a (#373) | Closes ORM-improvement backlog #9. |
+| `FormErrors` (multi-error) | [error handling](https://docs.djangoproject.com/en/6.0/ref/forms/validation/) | SHIPPED | `forms::FormErrors` collects all field+non-field errors | |
+| Formsets (`formset_factory`) | [Formsets](https://docs.djangoproject.com/en/6.0/topics/forms/formsets/) | SHIPPED | `forms::formset` module — `<prefix>-<N>-<field>` keying | |
+| Model formsets / inline formsets | [modelformsets](https://docs.djangoproject.com/en/6.0/topics/forms/modelforms/#model-formsets) | PARTIAL | Admin inlines use formset POST shape (#374) | Standalone `inline_formset_factory(parent, child)` MISSING. |
+| `DynamicForm` (runtime schema) | n/a (Django) | SHIPPED | `forms::DynamicForm` — Django doesn't ship this; rustango ahead | |
+| File upload | [File uploads](https://docs.djangoproject.com/en/6.0/topics/http/file-uploads/) | SHIPPED | `uploads::*` + multer | |
+| `save(commit=False)` + `save_m2m()` | [ModelForm.save](https://docs.djangoproject.com/en/6.0/topics/forms/modelforms/#the-save-method) | MISSING | n/a (#375) | `ModelForm::save(pool)` is one-shot. |
+| CSRF token | [CSRF](https://docs.djangoproject.com/en/6.0/ref/csrf/) | SHIPPED | `forms::csrf::CsrfLayer` + `{{ csrf_token \| csrf_input \| safe }}` Tera | |
+| `UniqueTogetherValidator` | [DRF form-level uniqueness](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/constraints/) | MISSING | n/a (#376) | Backlog: friendly form-error on `unique_together` violation. |
+
+Summary: **8 SHIPPED / 3 PARTIAL / 4 MISSING / 0 N/A**.
+
+---
+
+## 8. Generic class-based views
+
+| Django CBV | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `View` (base) | [base View](https://docs.djangoproject.com/en/6.0/ref/class-based-views/base/#view) | N/A | axum handlers play the role | |
+| `TemplateView` | [TemplateView](https://docs.djangoproject.com/en/6.0/ref/class-based-views/base/#templateview) | PARTIAL | `shortcuts::render(template, ctx)` (#377) | No view builder — handler renders directly. |
+| `RedirectView` | [RedirectView](https://docs.djangoproject.com/en/6.0/ref/class-based-views/base/#redirectview) | SHIPPED | `redirects::*` table-driven + `shortcuts::redirect()` | |
+| `ListView` | [ListView](https://docs.djangoproject.com/en/6.0/ref/class-based-views/generic-display/#listview) | SHIPPED | `template_views::ListView::for_model(...)` (v0.21+, tri-dialect v0.38) | |
+| `DetailView` | [DetailView](https://docs.djangoproject.com/en/6.0/ref/class-based-views/generic-display/#detailview) | SHIPPED | `template_views::DetailView` | |
+| `FormView` | [FormView](https://docs.djangoproject.com/en/6.0/ref/class-based-views/generic-editing/#formview) | SHIPPED | `template_views::CreateView` plays both roles | |
+| `CreateView` | (above) | SHIPPED | `template_views::CreateView` | |
+| `UpdateView` | [UpdateView](https://docs.djangoproject.com/en/6.0/ref/class-based-views/generic-editing/#updateview) | SHIPPED | `template_views::UpdateView` | |
+| `DeleteView` | [DeleteView](https://docs.djangoproject.com/en/6.0/ref/class-based-views/generic-editing/#deleteview) | SHIPPED | `template_views::DeleteView` | |
+| Date-based views (ArchiveIndexView, YearArchiveView, etc.) | [date views](https://docs.djangoproject.com/en/6.0/ref/class-based-views/generic-date-based/) | MISSING | n/a (#378) | Niche; build via QuerySet date-trunc + Tera. |
+| `LoginRequiredMixin` | [LoginRequiredMixin](https://docs.djangoproject.com/en/6.0/topics/auth/default/#django.contrib.auth.mixins.LoginRequiredMixin) | SHIPPED | `auth_decorators::login_required` middleware layer | |
+| `UserPassesTestMixin` | [UserPassesTestMixin](https://docs.djangoproject.com/en/6.0/topics/auth/default/#django.contrib.auth.mixins.UserPassesTestMixin) | SHIPPED | `auth_decorators::user_passes_test` | |
+| `PermissionRequiredMixin` | [PermissionRequiredMixin](https://docs.djangoproject.com/en/6.0/topics/auth/default/#django.contrib.auth.mixins.PermissionRequiredMixin) | SHIPPED | `auth_decorators::permission_required` (PR #313) | |
+| MultipleObjectMixin / SingleObjectMixin (object-level customization) | [generic-display](https://docs.djangoproject.com/en/6.0/ref/class-based-views/generic-display/#multipleobjectmixin) | PARTIAL | `ListView::with_queryset(custom_qs)` exists (#379) | Mixin composability MISSING. |
+
+Summary: **5 SHIPPED / 2 PARTIAL / 3 MISSING / 0 N/A**.
+
+---
+
+## 9. URL routing
+
+| Capability | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `path("/foo", view)` | [URL dispatcher](https://docs.djangoproject.com/en/6.0/topics/http/urls/) | SHIPPED | axum `Router::route` | |
+| `re_path()` (regex) | same | N/A | axum uses path patterns (not regex by default) | Use axum's `:param` and `*rest`. |
+| `include("app.urls")` | [include](https://docs.djangoproject.com/en/6.0/topics/http/urls/#including-other-urlconfs) | SHIPPED | `Router::nest("/app", app::router())` | |
+| URL namespaces | [namespaces](https://docs.djangoproject.com/en/6.0/topics/http/urls/#url-namespaces) | MISSING | n/a (#380) | Just nest paths. |
+| `reverse("name")` | [reverse](https://docs.djangoproject.com/en/6.0/ref/urlresolvers/#reverse) | PARTIAL | RouteConfig URL building via `format!("{admin_prefix}/...")` (#381) | No name-based reverse lookup. |
+| `{% url 'name' %}` template tag | [url tag](https://docs.djangoproject.com/en/6.0/ref/templates/builtins/#url) | PARTIAL | Templates use `{{ admin_prefix }}/` literal interpolation (#382) | |
+| Static + media URLs | [static](https://docs.djangoproject.com/en/6.0/ref/contrib/staticfiles/) | SHIPPED | `Cli::with_static(prefix, dir)` + `Media` model + `Storage` | |
+
+Summary: **5 / 1 / 1 / 1**.
+
+---
+
+## 10. Templates
+
+| Capability | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| Template engine | [Templates](https://docs.djangoproject.com/en/6.0/topics/templates/) | SHIPPED | Tera (Jinja2-shape) | Django ships DTL + Jinja2; rustango picks Tera. |
+| Template inheritance (`{% extends %}` / `{% block %}`) | [inheritance](https://docs.djangoproject.com/en/6.0/ref/templates/language/#template-inheritance) | SHIPPED | Tera native | |
+| `{% include %}` | [include](https://docs.djangoproject.com/en/6.0/ref/templates/builtins/#include) | SHIPPED | Tera | |
+| Built-in filters (`pluralize`, `truncatewords`, `linebreaks`, `default_if_none`) | [filters](https://docs.djangoproject.com/en/6.0/ref/templates/builtins/#built-in-filter-reference) | SHIPPED | Django-shape filters via `template_filters::register_all()` | |
+| Custom template tags | [custom tags](https://docs.djangoproject.com/en/6.0/howto/custom-template-tags/) | PARTIAL | Tera function registration (`tera.register_function`) (#383) | Django's `{% mytag %}` block tags are deeper than Tera supports. |
+| Context processors | [context_processors](https://docs.djangoproject.com/en/6.0/ref/templates/api/#built-in-template-context-processors) | PARTIAL | Per-handler context build manually; no global registry (#384) | |
+| Template loaders | [loaders](https://docs.djangoproject.com/en/6.0/ref/templates/api/#template-loader-types) | SHIPPED | `Tera::new(glob)` | |
+| Autoescaping | [autoescape](https://docs.djangoproject.com/en/6.0/ref/templates/language/#automatic-html-escaping) | SHIPPED | Tera default-on | |
+| staticfiles app | [staticfiles](https://docs.djangoproject.com/en/6.0/ref/contrib/staticfiles/) | SHIPPED | `Cli::with_static(prefix, dir)` + `Storage` | |
+| `{% csrf_token %}` template tag | [csrf](https://docs.djangoproject.com/en/6.0/ref/csrf/) | SHIPPED | `{{ csrf_token \| csrf_input \| safe }}` | |
+| `{% cache %}` template fragment | [template fragment caching](https://docs.djangoproject.com/en/6.0/topics/cache/#template-fragment-caching) | PARTIAL | `cache_fragment::cached_render(key, fn)` exists; not a Tera tag (#385) | |
+| Template debug page | (Django DEBUG) | MISSING | n/a (#386) | Tera errors go to stderr; no DEBUG template-error overlay yet. |
+
+Summary: **7 / 3 / 1 / 0**.
+
+---
+
+## 11. Authentication
+
+| Capability | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `User` model | [User model](https://docs.djangoproject.com/en/6.0/ref/contrib/auth/#django.contrib.auth.models.User) | SHIPPED | `tenancy::auth::User` + per-tenant `rustango_users` | |
+| Customize User model (`AUTH_USER_MODEL`) | [custom user](https://docs.djangoproject.com/en/6.0/topics/auth/customizing/) | SHIPPED | `TenantUserModel` trait + `Cli::user_model(...)` | |
+| `Group` model | [Group](https://docs.djangoproject.com/en/6.0/ref/contrib/auth/#django.contrib.auth.models.Group) | SHIPPED | `tenancy::permissions::Role` + `RolePermission` | Called "Role" not "Group"; same semantic. |
+| `Permission` model | [Permission](https://docs.djangoproject.com/en/6.0/ref/contrib/auth/#django.contrib.auth.models.Permission) | SHIPPED | `rustango_permissions` registry + per-user / per-role grants | |
+| `auth.authenticate()` | [authenticate](https://docs.djangoproject.com/en/6.0/topics/auth/default/#django.contrib.auth.authenticate) | SHIPPED | `tenancy::admin::login_submit` + `password::verify` | |
+| `auth.login()` / `auth.logout()` | [login](https://docs.djangoproject.com/en/6.0/topics/auth/default/#django.contrib.auth.login) | SHIPPED | Tenancy login_submit / logout handlers | |
+| Authentication backends (`AUTHENTICATION_BACKENDS`) | [backends](https://docs.djangoproject.com/en/6.0/topics/auth/customizing/#specifying-authentication-backends) | SHIPPED | `auth_backends::{UsernameBackend, EmailBackend, RemoteUserBackend}` + chain | |
+| Password hashing (`PASSWORD_HASHERS`) | [password management](https://docs.djangoproject.com/en/6.0/topics/auth/passwords/) | SHIPPED | `passwords::*` (Argon2id) + `password_hashers::PasswordHasher` chain for migration | |
+| Auto-upgrade hash on login | (above) | SHIPPED | v0.27+ | |
+| Password validators (`AUTH_PASSWORD_VALIDATORS`) | [password validators](https://docs.djangoproject.com/en/6.0/topics/auth/passwords/#module-django.contrib.auth.password_validation) | SHIPPED | `password_validators::*` (MinimumLength, NumericPassword, CommonPassword, etc.) | |
+| Password reset flow | [password reset](https://docs.djangoproject.com/en/6.0/topics/auth/default/#password-management-in-django) | PARTIAL | `auth_flows::PasswordReset` primitive + token + signed URL; no built-in views for tenant user self-serve (#387) | Backlog #77. |
+| Email verification | (custom in Django) | SHIPPED | `auth_flows::EmailVerification` | |
+| Magic-link login | n/a | SHIPPED | `auth_flows` magic-link | Rustango ahead. |
+| Session middleware | [sessions](https://docs.djangoproject.com/en/6.0/topics/http/sessions/) | SHIPPED | `session::*` + admin + tenancy variants | |
+| OAuth2 / Social auth | n/a in Django core (needs `django-allauth`) | SHIPPED | `oauth2::OAuth2Registry` + PKCE + OIDC | Rustango ahead. |
+| Built-in JWT auth | n/a in Django core (needs `simplejwt`) | PARTIAL | `jwt::*` primitives + `JwtLifecycle` + `JwtBackend`; no `auth_routes::jwt_router()` one-liner (#388) | Backlog #81. |
+| API keys | n/a in Django core | SHIPPED | `api_keys::*` (Argon2 hash) | |
+| TOTP / 2FA | n/a in Django core | PARTIAL | `totp::*` primitives + QR `otpauth_url`; no enrollment UI (#389) | |
+| Rate limiting / account lockout | n/a | SHIPPED | `account_lockout::Lockout` + `rate_limit::*` | |
+| LoginView / LogoutView CBVs | [Auth CBVs](https://docs.djangoproject.com/en/6.0/topics/auth/default/#all-authentication-views) | PARTIAL | Tenancy admin handles routes inline; not a class (#390) | |
+| PasswordChangeView CBV | (above) | SHIPPED | `/account/password` (v0.40) | |
+| PasswordResetConfirmView | (above) | MISSING | n/a (#391) | Email + token machinery is there; no view scaffold. |
+| Passkey / WebAuthn | (Django 5.2+) | MISSING | n/a (#392) | |
+
+Summary: **14 SHIPPED / 4 PARTIAL / 4 MISSING / 1 N/A**.
+
+---
+
+## 12. Sessions
+
+| Backend / capability | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| Signed-cookie session | [signed cookies](https://docs.djangoproject.com/en/6.0/topics/http/sessions/#using-cookie-based-sessions) | SHIPPED | `session::SessionSecret` HMAC-SHA256 signed cookie (v0.40 admin) | |
+| Cache-backed session | [cache backend](https://docs.djangoproject.com/en/6.0/topics/http/sessions/#using-cache-sessions) | SHIPPED | Server-side opaque-id sessions via `Cache` backend (v0.24+) | |
+| Database-backed session | [database backend](https://docs.djangoproject.com/en/6.0/topics/http/sessions/#using-database-backed-sessions) | PARTIAL | Indirect — DB-backed via `Cache` (`PgCache`) (#393) | No direct DB-only session model. |
+| File-backed session | [file backend](https://docs.djangoproject.com/en/6.0/topics/http/sessions/#using-file-based-sessions) | MISSING | n/a (#394) | Niche. |
+| Cached-DB hybrid | [cached_db backend](https://docs.djangoproject.com/en/6.0/topics/http/sessions/#using-cached-database-sessions) | SHIPPED | Cache backend can wrap any storage | |
+| Session expiry / `SESSION_COOKIE_AGE` | (cookie options) | SHIPPED | Configurable TTL per backend | |
+| Session middleware (autoinstall) | (auto in MIDDLEWARE) | SHIPPED | `Cli::tenancy()` and `Admin::Builder` auto-attach | |
+
+Summary: **4 / 1 / 1 / 0**.
+
+---
+
+## 13. Manage commands
+
+Django built-in management commands:
+
+| Command | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `startproject` | [startproject](https://docs.djangoproject.com/en/6.0/ref/django-admin/#startproject) | PARTIAL | `cargo rustango new <name>` — version-pin bug filed #79 | |
+| `startapp` | [startapp](https://docs.djangoproject.com/en/6.0/ref/django-admin/#startapp) | SHIPPED | `manage startapp <name>` | Scaffolds model + views + tests + migrations. |
+| `makemigrations` | (sec 5) | SHIPPED | `manage makemigrations` | |
+| `migrate` | (sec 5) | SHIPPED | `manage migrate` | |
+| `showmigrations` | (sec 5) | SHIPPED | `manage showmigrations` | |
+| `sqlmigrate` | (sec 5) | PARTIAL | `manage migrate --plan` (#395) | |
+| `squashmigrations` | (sec 5) | SHIPPED | `manage migrate --squash` | |
+| `runserver` | (Django) | N/A | rustango uses axum's runserver — `manage run-server` or `Cli::new().run().await` | |
+| `runserver_plus` (django-extensions) | n/a | N/A | n/a | |
+| `shell` (REPL) | [shell](https://docs.djangoproject.com/en/6.0/ref/django-admin/#shell) | MISSING | n/a (#396) | Rust doesn't have a REPL story. |
+| `shell_plus` (django-extensions) | n/a | N/A | n/a | |
+| `dbshell` | [dbshell](https://docs.djangoproject.com/en/6.0/ref/django-admin/#dbshell) | SHIPPED | `manage dbshell` (psql / mysql / sqlite3 via execvp) | |
+| `createsuperuser` | [createsuperuser](https://docs.djangoproject.com/en/6.0/ref/django-admin/#createsuperuser) | SHIPPED | `manage create-admin` + `manage create-user --superuser` | |
+| `changepassword` | [changepassword](https://docs.djangoproject.com/en/6.0/ref/django-admin/#changepassword) | SHIPPED | `manage reset-password <slug> <user> --password ...` | |
+| `collectstatic` | [collectstatic](https://docs.djangoproject.com/en/6.0/ref/contrib/staticfiles/#django-admin-collectstatic) | N/A | n/a — rustango bundles static via `Cli::with_static(prefix, dir)` | |
+| `findstatic` | (above) | N/A | n/a | |
+| `loaddata` | [loaddata](https://docs.djangoproject.com/en/6.0/ref/django-admin/#loaddata) | SHIPPED | `fixtures::load_pool` + `manage load-fixture` | |
+| `dumpdata` | [dumpdata](https://docs.djangoproject.com/en/6.0/ref/django-admin/#dumpdata) | MISSING | n/a (#397) | |
+| `makemessages` | [makemessages](https://docs.djangoproject.com/en/6.0/ref/django-admin/#makemessages) | MISSING | n/a (#398) | i18n scaffolding deferred. |
+| `compilemessages` | (above) | MISSING | n/a (#399) | |
+| `test` | [test](https://docs.djangoproject.com/en/6.0/ref/django-admin/#test) | N/A | `cargo test` is the canonical entry | |
+| `check` | [check](https://docs.djangoproject.com/en/6.0/ref/django-admin/#check) | SHIPPED | `manage check` + `manage check --deploy` (v0.29) | |
+| `check --deploy` (security audit) | (above) | SHIPPED | (above) | |
+| `inspectdb` | (sec 5) | SHIPPED | `manage inspectdb` | |
+| `sendtestemail` | [sendtestemail](https://docs.djangoproject.com/en/6.0/ref/django-admin/#sendtestemail) | SHIPPED | `manage sendtestemail` (config feature) | |
+| `flush` | [flush](https://docs.djangoproject.com/en/6.0/ref/django-admin/#flush) | SHIPPED | `manage flush` | |
+| `make:viewset` / `make:serializer` / etc. (rustango-specific generators) | n/a | SHIPPED | 8 generators (viewset, serializer, form, job, notification, middleware, test, api-routes) | Rustango ahead. |
+| `create-tenant` / `create-operator` (rustango-specific) | n/a | SHIPPED | tenancy verbs | |
+| `migrate-tenant-storage` (rustango-specific) | n/a | SHIPPED | v0.26 | |
+
+Summary: **13 SHIPPED / 5 PARTIAL / 6 MISSING / 4 N/A**. Gaps: `shell` REPL (Rust constraint), `dumpdata`, i18n scaffolding (`makemessages` / `compilemessages`).
+
+---
+
+## 14. Settings
+
+| Setting / capability | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `DATABASES` (multi-DB) | [databases](https://docs.djangoproject.com/en/6.0/ref/settings/#databases) | PARTIAL | One Pool per app or per tenant; per-app multi-DB routing MISSING (#400) | No `default`/`replica` routing. |
+| `DATABASE_ROUTERS` | [database routers](https://docs.djangoproject.com/en/6.0/topics/db/multi-db/#database-routers) | MISSING | n/a (#401) | Read replicas not surfaced. |
+| `DEFAULT_AUTO_FIELD` | [DEFAULT_AUTO_FIELD](https://docs.djangoproject.com/en/6.0/ref/settings/#default-auto-field) | SHIPPED | `Auto<i64>` is canonical — `BigAutoField` equivalent | |
+| `INSTALLED_APPS` | [installed apps](https://docs.djangoproject.com/en/6.0/ref/settings/#installed-apps) | N/A | n/a — inventory-based registration | |
+| `MIDDLEWARE` (ordered list) | [middleware](https://docs.djangoproject.com/en/6.0/ref/settings/#middleware) | N/A | axum per-router `.layer(...)` idiom | |
+| `TEMPLATES` (engines list) | [templates](https://docs.djangoproject.com/en/6.0/ref/settings/#templates) | SHIPPED | One Tera engine per app | |
+| `CACHES` (backends) | [caches](https://docs.djangoproject.com/en/6.0/ref/settings/#caches) | SHIPPED | `Settings.cache` section (v0.29) | |
+| `SESSION_ENGINE` | [session_engine](https://docs.djangoproject.com/en/6.0/ref/settings/#session-engine) | SHIPPED | Pluggable session storage via `Cache` | |
+| `EMAIL_BACKEND` | [email_backend](https://docs.djangoproject.com/en/6.0/ref/settings/#email-backend) | SHIPPED | `Mailer` trait + backends (SMTP, console, locmem, dummy) | |
+| `STATIC_URL` / `MEDIA_URL` | [static_url](https://docs.djangoproject.com/en/6.0/ref/settings/#static-url) | SHIPPED | RouteConfig + Cli::with_static() | |
+| `SECURE_*` (HSTS, XSS, content-type sniff, etc.) | [security settings](https://docs.djangoproject.com/en/6.0/ref/settings/#security) | SHIPPED | `security_headers::*` + Settings.security section | |
+| `TIME_ZONE` / `USE_TZ` | [time_zone](https://docs.djangoproject.com/en/6.0/ref/settings/#std-setting-TIME_ZONE) | PARTIAL | `Settings.locale.tz` exists; per-user TZ activation via `i18n::timezone::with_tz` (#402) | App-wide TZ override not fully wired into ORM date formatters. |
+| `LANGUAGE_CODE` / `LANGUAGES` / `LOCALE_PATHS` | [language](https://docs.djangoproject.com/en/6.0/ref/settings/#language-code) | PARTIAL | `i18n::Translator` per-locale JSON; no gettext .po pipeline (#403) | Backlog. |
+| `LOGGING` (dictConfig) | [logging](https://docs.djangoproject.com/en/6.0/ref/settings/#logging) | PARTIAL | `tracing-subscriber` env-filter; not Django's dictConfig shape (#404) | |
+| `DATA_UPLOAD_MAX_MEMORY_SIZE` | [data_upload](https://docs.djangoproject.com/en/6.0/ref/settings/#data-upload-max-memory-size) | SHIPPED | `body_limit::*` middleware | |
+| Tiered config (dev/staging/prod files) | n/a (Django uses env-var + manual import) | SHIPPED | `dev_settings.toml` / `staging_settings.toml` / `prod_settings.toml` (v0.29 closed #87) | Rustango ahead. |
+| Detected features at runtime | n/a | SHIPPED | `Settings::detected_features` | |
+| Settings validation (`manage check --deploy`) | [check --deploy](https://docs.djangoproject.com/en/6.0/ref/django-admin/#cmdoption-check-deploy) | SHIPPED | (sec 13) | |
+| Secrets manager integration (Vault, AWS Secrets, etc.) | n/a in Django core | MISSING | n/a — `secrets::*` is local-env focus (#405) | Backlog #47. |
+
+Summary: **10 / 4 / 4 / 2**. Multi-DB routing is the headline MISSING.
+
+---
+
+## 15. Security / middleware
+
+| Middleware | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `SecurityMiddleware` (HSTS, XSS, content-type-nosniff) | [SecurityMiddleware](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.middleware.security.SecurityMiddleware) | SHIPPED | `security_headers::*` (HSTS, X-Frame, Referrer, COOP, Permissions-Policy) (v0.20+) | |
+| `CsrfViewMiddleware` | [CSRF](https://docs.djangoproject.com/en/6.0/ref/csrf/) | SHIPPED | `forms::csrf::CsrfLayer` | Double-submit-cookie. |
+| `XFrameOptionsMiddleware` | [clickjacking](https://docs.djangoproject.com/en/6.0/ref/clickjacking/) | SHIPPED | Part of security_headers | |
+| `SessionMiddleware` | [sessions](https://docs.djangoproject.com/en/6.0/topics/http/sessions/) | SHIPPED | (sec 12) | |
+| `AuthenticationMiddleware` | [auth middleware](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.contrib.auth.middleware.AuthenticationMiddleware) | SHIPPED | `SessionUser` extractor | |
+| `MessageMiddleware` | [messages](https://docs.djangoproject.com/en/6.0/ref/contrib/messages/) | SHIPPED | `messages::*` flash-message store | |
+| `CommonMiddleware` (trailing slash) | [CommonMiddleware](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.middleware.common.CommonMiddleware) | SHIPPED | `trailing_slash::*` | |
+| `LocaleMiddleware` | [LocaleMiddleware](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.middleware.locale.LocaleMiddleware) | PARTIAL | `i18n::Translator` Accept-Language negotiation + cookie (#406) | Per-URL locale prefix MISSING. |
+| `GZipMiddleware` | [GZip](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.middleware.gzip.GZipMiddleware) | SHIPPED | `compression::*` (gzip + deflate) | |
+| `ConditionalGetMiddleware` (ETag / Last-Modified) | [ConditionalGet](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.middleware.http.ConditionalGetMiddleware) | SHIPPED | `etag::*` body-hash + 304 | |
+| Real-IP extraction | n/a in Django core | SHIPPED | `real_ip::*` (X-Forwarded-For / X-Real-IP / RFC 7239) | |
+| Request ID middleware | n/a | SHIPPED | `request_id::*` | |
+| CORS | n/a (Django needs `django-cors-headers`) | SHIPPED | `cors::*` allowlist + presets | |
+| Rate limiting | n/a (Django needs `django-ratelimit`) | SHIPPED | `rate_limit::*` + `rate_limit_cache::*` | |
+| Access logging with PII redaction | n/a | SHIPPED | `access_log::*` (v0.22+) | |
+| Request timeout | n/a | SHIPPED | `request_timeout::*` | |
+| Idempotency keys | n/a | SHIPPED | `idempotency::*` (Stripe-shape) | |
+| Maintenance mode | n/a | SHIPPED | `maintenance::*` | |
+| Method override (`X-HTTP-Method-Override`) | n/a | SHIPPED | `method_override::*` | |
+| OpenTelemetry / traceparent | n/a | SHIPPED | `tracing_layer::*` | |
+| Body size limit | [DATA_UPLOAD_MAX_MEMORY_SIZE](https://docs.djangoproject.com/en/6.0/ref/settings/#data-upload-max-memory-size) | SHIPPED | `body_limit::*` | |
+| IP allowlist / blocklist | n/a | SHIPPED | `ip_filter::*` | |
+| Server-Timing header | n/a | SHIPPED | `server_timing::*` | |
+| CSP nonce | [CSP](https://docs.djangoproject.com/en/6.0/topics/security/#content-security-policy) | SHIPPED | `csp_nonce::*` middleware | |
+| `SECURE_PROXY_SSL_HEADER` | [proxy headers](https://docs.djangoproject.com/en/6.0/ref/settings/#secure-proxy-ssl-header) | SHIPPED | Real-IP layer handles it | |
+| API versioning (header / query / prefix) | n/a | SHIPPED | `api_version::*` | |
+
+Summary: **14 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A** for the dimensions enumerated. Rustango is notably ahead on per-request observability + CSRF / rate limiting / CSP / OTel out-of-the-box.
+
+---
+
+## 16. Caching
+
+| Capability | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| Cache trait + pluggable backends | [cache framework](https://docs.djangoproject.com/en/6.0/topics/cache/) | SHIPPED | `cache::Cache` trait | |
+| Memcached backend | [memcached](https://docs.djangoproject.com/en/6.0/topics/cache/#memcached) | MISSING | n/a (#407) | Use Redis or in-memory. |
+| Redis backend | [redis](https://docs.djangoproject.com/en/6.0/topics/cache/#redis) | SHIPPED | `cache-redis` feature (v0.18) | |
+| File-system cache | [filesystem](https://docs.djangoproject.com/en/6.0/topics/cache/#file-system-caching) | MISSING | n/a (#408) | |
+| In-memory cache | [local-memory](https://docs.djangoproject.com/en/6.0/topics/cache/#local-memory-caching) | SHIPPED | `InMemoryCache` | |
+| Database cache | [db](https://docs.djangoproject.com/en/6.0/topics/cache/#database-caching) | PARTIAL | DB tables can back the trait; no first-class `DbCache` (#409) | |
+| `@cache_page` view decorator | [cache_page](https://docs.djangoproject.com/en/6.0/topics/cache/#the-per-view-cache) | SHIPPED | `cache_page::cache_page_layer` (v0.19) | |
+| `@cache_control` headers | [cache_control](https://docs.djangoproject.com/en/6.0/topics/cache/#using-vary-headers) | SHIPPED | Cache-Control header helpers | |
+| `@vary_on_headers` / `@vary_on_cookie` | [vary](https://docs.djangoproject.com/en/6.0/topics/cache/#using-vary-headers) | SHIPPED | Vary header helpers | |
+| Template fragment caching | [template fragments](https://docs.djangoproject.com/en/6.0/topics/cache/#template-fragment-caching) | SHIPPED | `cache_fragment::cached_render` | |
+
+Summary: **7 / 1 / 2 / 0**.
+
+---
+
+## 17. Signals
+
+| Signal | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `pre_save` / `post_save` | [signals](https://docs.djangoproject.com/en/6.0/topics/signals/) | SHIPPED | `signals::connect_pre_save` / `_post_save` | |
+| `pre_delete` / `post_delete` | (above) | SHIPPED | (above) | |
+| `m2m_changed` | (above) | MISSING | n/a (#410) | M2M operations don't fire signals yet. |
+| `pre_migrate` / `post_migrate` | [pre_migrate](https://docs.djangoproject.com/en/6.0/ref/signals/#pre-migrate) | MISSING | n/a (#411) | |
+| `class_prepared` | (above) | N/A — Rust doesn't have lazy class creation | n/a | |
+| `request_started` / `request_finished` | [request signals](https://docs.djangoproject.com/en/6.0/ref/signals/#django.core.signals.request_started) | PARTIAL | tower `Service` semantics + tracing layer cover this (#412) | Not a discrete signal. |
+| `got_request_exception` | (above) | PARTIAL | tower error handling + tracing (#413) | |
+| `user_logged_in` / `user_logged_out` / `user_login_failed` | [auth signals](https://docs.djangoproject.com/en/6.0/ref/contrib/auth/#module-django.contrib.auth.signals) | MISSING | n/a (#414) | Useful for audit. Wire a `pre_save` on user-row or expose explicit signals. |
+| `setting_changed` | (above) | MISSING | n/a (#415) | |
+| Disconnect / weak references | (above) | SHIPPED | `signals::disconnect_*` | |
+| Async receivers | (Django 4.1+ async receivers) | SHIPPED | All rustango signal receivers are `async fn` | |
+
+Summary: **7 / 2 / 5 / 0**. Gaps cluster around `m2m_changed`, migrate signals, auth signals.
+
+---
+
+## 18. Email
+
+| Capability | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `EmailMessage` builder | [email message](https://docs.djangoproject.com/en/6.0/topics/email/#emailmessage-and-emailmultialternatives) | SHIPPED | `email::Email` + `Mailable` pattern | |
+| `EmailMultiAlternatives` (HTML+text) | (above) | SHIPPED | `email::Email::with_html(...)` | |
+| `send_mail()` shortcut | [send_mail](https://docs.djangoproject.com/en/6.0/topics/email/#send-mail) | SHIPPED | `email::send_pool(mailer, msg)` | |
+| `mail_admins` / `mail_managers` | [mail_admins](https://docs.djangoproject.com/en/6.0/topics/email/#mail-admins) | PARTIAL | Manual recipient list (#416) | No `ADMINS` setting hook. |
+| Console backend | [console backend](https://docs.djangoproject.com/en/6.0/topics/email/#console-backend) | SHIPPED | `email::ConsoleMailer` | |
+| In-memory / dummy backend | [locmem](https://docs.djangoproject.com/en/6.0/topics/email/#in-memory-backend) | SHIPPED | `email::InMemoryMailer` + `NullMailer` | |
+| SMTP backend | [smtp](https://docs.djangoproject.com/en/6.0/topics/email/#smtp-backend) | SHIPPED | `SmtpMailer` via lettre + rustls (`email-smtp` feature) | |
+| Email templates (Tera) | n/a in Django core | SHIPPED | `email_templates::EmailRenderer` | |
+| File backend | [file backend](https://docs.djangoproject.com/en/6.0/topics/email/#file-backend) | MISSING | n/a (#417) | Niche dev tool. |
+| Email job queue integration | n/a | SHIPPED | `email_jobs::dispatch_email` | |
+| Multi-channel notifications (Mail + Slack + DB) | n/a (Django needs `django-notifications`) | PARTIAL | `notifications::*` skeleton (v0.21); incomplete provider set (#418) | |
+
+Summary: **6 / 2 / 1 / 0**.
+
+---
+
+## 19. Files / Storage
+
+| Capability | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `FileField` (on model) | [FileField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#filefield) | MISSING | n/a — manage via `Media` table FK (#419) | (see sec 3) |
+| `ImageField` | [ImageField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#imagefield) | MISSING | n/a (#420) | (sec 3) |
+| `Storage` trait | [Storage](https://docs.djangoproject.com/en/6.0/ref/files/storage/) | SHIPPED | `storage::Storage` trait | |
+| `FileSystemStorage` | [FileSystemStorage](https://docs.djangoproject.com/en/6.0/ref/files/storage/#filesystemstorage) | SHIPPED | `LocalStorage` | |
+| `S3Storage` / GCS / Azure (3rd-party) | n/a in Django core | SHIPPED | `S3Storage` (S3 / R2 / B2 / MinIO) hand-rolled SigV4 | |
+| In-memory storage (tests) | n/a | SHIPPED | `InMemoryStorage` | |
+| File upload handlers (chunked, memory, etc.) | [upload handlers](https://docs.djangoproject.com/en/6.0/topics/http/file-uploads/#upload-handlers) | PARTIAL | multer-driven via `uploads::*` (#421) | No pluggable upload handler abstraction. |
+| File validators (type, size, extension) | n/a (Django has separate validators) | SHIPPED | `validators::{file_type, file_size_max, file_extension}` (v0.25) | |
+| `Media` model | n/a (each Django project rolls its own) | SHIPPED | `media::Media` model (v0.24) | Rustango ahead. |
+
+Summary: **3 / 2 / 3 / 0**.
+
+---
+
+## 20. i18n / l10n
+
+| Capability | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `gettext` / `pgettext` / `ngettext` translation API | [translation](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/) | PARTIAL | `i18n::Translator::t(key)` lookup against JSON per-locale (#422) | Not gettext shape; ICU MessageFormat partial. |
+| `.po` / `.mo` compilation (`makemessages`, `compilemessages`) | (sec 13) | MISSING | n/a (#423) | |
+| Per-language URL prefix (`/en/foo` / `/es/foo`) | [URL i18n](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/#internationalization-in-url-patterns) | MISSING | n/a — rustango-cms ships a `LocaleMode::PathOrQuery` for itself, framework doesn't (#424) | |
+| Fallback locales | [fallbacks](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/#how-django-discovers-translations) | PARTIAL | `Translator` falls back to default locale (#425) | |
+| Per-user TIME_ZONE activation | [time zones](https://docs.djangoproject.com/en/6.0/topics/i18n/timezones/) | SHIPPED | `i18n::timezone::with_tz(fixed_offset, future)` task-local + `tz_offset` cookie middleware | rustango-cms uses this end-to-end. |
+| Locale-aware number / date formatting | [formatting](https://docs.djangoproject.com/en/6.0/topics/i18n/formatting/) | MISSING | n/a (#426) | |
+| `{% trans %}` / `{% blocktrans %}` template tags | [template translation](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/#internationalization-in-template-code) | MISSING | n/a (#427) | Tera filter exists in rustango-cms; framework-side missing. |
+| Currency / region formatting | [LANGUAGES setting](https://docs.djangoproject.com/en/6.0/ref/settings/#languages) | MISSING | n/a (#428) | |
+| Right-to-left layout support | [BiDi text](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/#translator-comments-in-templates) | MISSING | n/a (#429) | |
+
+Summary: **1 SHIPPED / 2 PARTIAL / 6 MISSING / 0 N/A**. **One of the weakest sections.** Backlog #87 sub-bullets track this; deliberate deferral pending demand signal.
+
+---
+
+## 21. Testing
+
+| Capability | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `TestCase` (transactional) | [TestCase](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#testcase) | SHIPPED | `test_db::with_rollback()` | |
+| `TransactionTestCase` | [TransactionTestCase](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#transactiontestcase) | SHIPPED | Plain `#[tokio::test]` against live pool | |
+| `LiveServerTestCase` | [LiveServerTestCase](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#liveservertestcase) | SHIPPED | `test_server::*` random-port bind | |
+| `Client` (HTTP test client) | [Client](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#the-test-client) | SHIPPED | `test_client::*` in-process axum::Router | |
+| `RequestFactory` | [RequestFactory](https://docs.djangoproject.com/en/6.0/topics/testing/advanced/#django.test.RequestFactory) | PARTIAL | `axum::http::Request::builder` covers it (#430) | |
+| `override_settings` | [override_settings](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#django.test.override_settings) | SHIPPED | `test_settings::with_settings(...).await` task-local | |
+| `setUpTestData` (class-level fixtures) | [setUpTestData](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#django.test.TestCase.setUpTestData) | SHIPPED | `setup_test_data!(...)` macro | |
+| Test tags (`@tag('slow')`) | [tags](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#tagging-tests) | SHIPPED | `test_filter::*` (`#[rustango_test(tag = "slow")]`) | |
+| Fixtures (JSON / YAML) | [fixtures](https://docs.djangoproject.com/en/6.0/howto/initial-data/) | SHIPPED | `fixtures::load_pool` | |
+| Test assertions (`assertContains`, `assertRedirects`, `assertStatus`, etc.) | [assertions](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#assertions) | SHIPPED | `test_assertions::*` | |
+| `assertNumQueries(N)` | [assertNumQueries](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#django.test.TransactionTestCase.assertNumQueries) | MISSING | n/a (#431) | Per-query counter would need sqlx interceptor. |
+| Email outbox assertions | [mail outbox](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#django.core.mail.outbox) | SHIPPED | `InMemoryMailer.messages()` | |
+| Factories (factory-boy shape) | n/a (3rd-party) | PARTIAL | `test_data::*` shipped basics; less ergonomic (#432) | |
+| `selenium` / `playwright` integration | (Django uses LiveServerTestCase + selenium) | MISSING | n/a (#433) | Playwright MCP available externally. |
+
+Summary: **7 / 3 / 3 / 0**.
+
+---
+
+## 22. Async support
+
+| Capability | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| Async views | [async](https://docs.djangoproject.com/en/6.0/topics/async/) | N/A | All rustango handlers are `async fn` | |
+| Async ORM (`.aget`, `.aupdate`, etc.) | [async ORM](https://docs.djangoproject.com/en/6.0/topics/async/#queryset-and-manager) | SHIPPED | All ORM methods are `async fn` natively | |
+| Async middleware | (above) | SHIPPED | tower `Layer` is async | |
+| Async signal receivers | [async signals](https://docs.djangoproject.com/en/6.0/topics/signals/#defining-and-sending-signals) | SHIPPED | All receivers are `async fn` | |
+| `asgi.py` (ASGI entry) | [asgi](https://docs.djangoproject.com/en/6.0/howto/deployment/asgi/) | N/A | Rustango binds via `axum::serve` directly | |
+| Async send_mail | (Django 5.x+) | SHIPPED | `email::send_pool(mailer, msg).await` | |
+| Sync-to-async / async-to-sync bridging | [sync_to_async](https://docs.djangoproject.com/en/6.0/topics/async/#sync-to-async-async-to-sync) | N/A | Pure async — no bridging needed | |
+
+Summary: **5 / 0 / 0 / 2**. Async is native; no parity gap.
+
+---
+
+## 23. DRF (Django REST Framework) parity
+
+| DRF capability | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `Serializer` class | [serializers](https://www.django-rest-framework.org/api-guide/serializers/) | SHIPPED | `#[derive(Serializer)]` macro (v0.18) | |
+| `ModelSerializer` | [ModelSerializer](https://www.django-rest-framework.org/api-guide/serializers/#modelserializer) | SHIPPED | `ModelSerializer` trait via macro | |
+| `HyperlinkedModelSerializer` | [HyperlinkedModelSerializer](https://www.django-rest-framework.org/api-guide/serializers/#hyperlinkedmodelserializer) | MISSING | n/a (#434) | Niche. |
+| `ListSerializer` (bulk shape) | [ListSerializer](https://www.django-rest-framework.org/api-guide/serializers/#listserializer) | PARTIAL | Vec serialization works; bulk-create from `ListSerializer` shape MISSING (#435) | |
+| Field-level options (read_only, write_only, source, skip) | (above) | SHIPPED | All four supported | |
+| Nested serializer (one-to-many auto-expand) | [nested](https://www.django-rest-framework.org/api-guide/serializers/#dealing-with-nested-objects) | SHIPPED | `#[serializer(nested = ChildSerializer)]` (v0.18) | |
+| `SerializerMethodField` | [SerializerMethodField](https://www.django-rest-framework.org/api-guide/fields/#serializermethodfield) | SHIPPED | v0.18 | |
+| Per-field validators chain | (above) | SHIPPED | v0.18 | |
+| Cross-field validation (`validate()`) | [object-level validation](https://www.django-rest-framework.org/api-guide/serializers/#object-level-validation) | MISSING | n/a (#436) | Backlog. |
+| `UniqueTogetherValidator` | [UniqueTogetherValidator](https://www.django-rest-framework.org/api-guide/validators/#uniquetogethervalidator) | MISSING | n/a (#437) | Friendly form errors on `unique_together`. |
+| `ViewSet` | [ViewSet](https://www.django-rest-framework.org/api-guide/viewsets/) | SHIPPED | `#[derive(ViewSet)]` (v0.16+, tri-dialect v0.38) | |
+| `ModelViewSet` | [ModelViewSet](https://www.django-rest-framework.org/api-guide/viewsets/#modelviewset) | SHIPPED | (above, includes list/retrieve/create/update/delete) | |
+| Routers (`DefaultRouter`, `SimpleRouter`) | [routers](https://www.django-rest-framework.org/api-guide/routers/) | SHIPPED | `ViewSet::router(prefix, &Pool)` + `tenant_router(prefix)` | |
+| `DjangoFilterBackend` | [filtering](https://www.django-rest-framework.org/api-guide/filtering/) | SHIPPED | `?field=value` querystring filtering via `Q!` (v0.41) | |
+| `SearchFilter` | (above) | PARTIAL | Manual `?q=...` parse; no `search_fields` declarative (#438) | |
+| `OrderingFilter` | (above) | PARTIAL | Manual `?ordering=...` parse (#439) | |
+| Pagination — PageNumber / LimitOffset | [pagination](https://www.django-rest-framework.org/api-guide/pagination/) | SHIPPED | `pagination::*` + RFC 5988 Link headers | |
+| Pagination — Cursor | [cursor pagination](https://www.django-rest-framework.org/api-guide/pagination/#cursorpagination) | MISSING | n/a (#440) | Backlog. |
+| Throttling (Anon / User / Scoped) | [throttling](https://www.django-rest-framework.org/api-guide/throttling/) | SHIPPED | `rate_limit::*` (per-IP / per-user) | |
+| Permission classes (IsAuthenticated, AllowAny, IsAdminUser, etc.) | [permissions](https://www.django-rest-framework.org/api-guide/permissions/) | SHIPPED | `auth_decorators::*` + `viewset::permissions` | |
+| Authentication classes (TokenAuth, BasicAuth, SessionAuth) | [authentication](https://www.django-rest-framework.org/api-guide/authentication/) | SHIPPED | `hmac_auth`, `api_keys`, `jwt`, session auth | |
+| Browsable API HTML | [browsable](https://www.django-rest-framework.org/topics/browsable-api/) | MISSING | n/a (#441) | Use Swagger UI mount instead. |
+| OpenAPI schema (drf-spectacular) | [schema](https://www.django-rest-framework.org/api-guide/schemas/) | SHIPPED | `openapi::*` (v0.24) + Swagger UI mount | |
+
+Summary: **11 SHIPPED / 4 PARTIAL / 4 MISSING / 0 N/A**.
+
+---
+
+## 24. contrib modules
+
+| `django.contrib.*` | Doc | Status | rustango | Notes |
+|---|---|---|---|---|
+| `contenttypes` | [contenttypes](https://docs.djangoproject.com/en/6.0/ref/contrib/contenttypes/) | SHIPPED | `contenttypes::*` + GenericForeignKey + admin inlines | |
+| `auth` | (sec 11) | SHIPPED | tenancy::auth + permissions | |
+| `sessions` | (sec 12) | SHIPPED | session backends | |
+| `admin` | (sec 6) | SHIPPED | admin::Builder | |
+| `staticfiles` | [staticfiles](https://docs.djangoproject.com/en/6.0/ref/contrib/staticfiles/) | SHIPPED | `Cli::with_static` | |
+| `messages` | [messages](https://docs.djangoproject.com/en/6.0/ref/contrib/messages/) | SHIPPED | `messages::*` cookie-backed flash | |
+| `humanize` (template filters: naturaltime, intcomma) | [humanize](https://docs.djangoproject.com/en/6.0/ref/contrib/humanize/) | SHIPPED | `humanize::*` | |
+| `sites` | [sites](https://docs.djangoproject.com/en/6.0/ref/contrib/sites/) | N/A | Multi-tenancy supersedes Site model | |
+| `sitemaps` | [sitemaps](https://docs.djangoproject.com/en/6.0/ref/contrib/sitemaps/) | SHIPPED | `sitemaps::*` (v0.23) | |
+| `syndication` (RSS / Atom feeds) | [syndication](https://docs.djangoproject.com/en/6.0/ref/contrib/syndication/) | SHIPPED | `syndication::*` (v0.23) | |
+| `flatpages` | [flatpages](https://docs.djangoproject.com/en/6.0/ref/contrib/flatpages/) | SHIPPED | `flatpages::*` (v0.22) | |
+| `redirects` | [redirects](https://docs.djangoproject.com/en/6.0/ref/contrib/redirects/) | SHIPPED | `redirects::*` (v0.22) | |
+| `admindocs` | [admindocs](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/admindocs/) | N/A | Rust doc-comments + cargo doc | |
+| `postgres` (ArrayField, JSONField, RangeField, HStoreField, CITextField) | (sec 4) | PARTIAL | JSONField shipped; Array/Range partial; HStore/CIText MISSING (#442) | |
+| `gis` (GeoDjango) | [gis](https://docs.djangoproject.com/en/6.0/ref/contrib/gis/) | MISSING | [#58](https://github.com/ujeenet/rustango/issues/58) | |
+| `gis.geos` (geometry types) | (above) | MISSING | (above) (#443) | |
+| `gis.gdal` (raster) | (above) | MISSING | (above) (#444) | |
+| Generic relations admin (GenericTabularInline) | [generic-inline](https://docs.djangoproject.com/en/6.0/ref/contrib/contenttypes/#generic-relations-and-aggregation) | SHIPPED | `register_admin_inline_generic!` | |
+
+Summary: **6 SHIPPED / 4 PARTIAL / 4 MISSING / 0 N/A** (within Django contrib scope).
+
+---
+
+## Top 10 gaps by user-facing impact
+
+Ranked by how often a real-world Django project hits the gap. Each gets a one-liner reasoning.
+
+1. **Multi-DB routing / read replicas** (sec 14 — `DATABASES`, `DATABASE_ROUTERS`). Every non-trivial production app eventually wants read replicas. Currently MISSING; ORM is single-pool-per-QuerySet. Closest existing primitive: `Cli::api(...).migrations_dir(...).run()` is single-registry-pool.
+
+2. **`FileField` / `ImageField` on arbitrary models** (sec 3 + 19). Rustango has `Media` model + `Storage` trait, but no `pub avatar: FileField` shape on user-defined models. Major DX gap vs Django's "drop a field, get upload + URL + ORM round-trip for free."
+
+3. **`choices=[...]` field option + ChoiceField in forms** (sec 3). Single most-used Django field option after `max_length`. Currently MISSING — users define their own enum + manual coerce.
+
+4. **Method-field display in admin (`list_display = [..., "method_name"]`)** (sec 6). Backlog #51. Common pattern for "show a derived value in the list view." Currently MISSING.
+
+5. **Per-tenant + per-app i18n / l10n** (sec 20). Translations (`gettext`), locale-aware formatting, per-language URL prefixes — only 1 SHIPPED out of 9 in this category. Most weakly-covered area.
+
+6. **`raw_id_fields` / `autocomplete_fields` in admin** (sec 6). FK widgets currently always `<select>` — chokes on tables with >1000 rows. Backlog item, real production blocker.
+
+7. **`select_related("a__b__c")` decoder-side auto-stitching** (sec 2). T2.2 shipped JOIN emission; `post.author.profile.get_pool(...)` auto-stitch is deferred. Multi-hop reads still pay N+1 unless the user explicitly walks the JSON map.
+
+8. **Auth signals (`user_logged_in`, `user_logged_out`, `user_login_failed`)** (sec 17). Every audit-log story needs these. Currently MISSING — manual hook via login_submit override.
+
+9. **Cursor pagination** (sec 23). For high-volume APIs, page/offset gets slow at large offsets. Backlog. Trivial to add atop existing pagination primitive.
+
+10. **`abstract = True` base classes** (sec 1). Pattern Django uses for `created_at` / `updated_at` mixins. Currently MISSING — Rust trait composition is close but not the same UX.
+
+---
+
+## Honorable mentions (high-impact for niche use cases)
+
+- **`select_for_update(of=...)` PG-specific clauses** — currently always whole-row lock.
+- **`Meta.verbose_name` / `verbose_name_plural`** — admin headers, i18n footing.
+- **`raw_id_fields`-equivalent on FK admin widgets** — see #6.
+- **`history_view` time-travel (rebuild row from audit log)** — admin history panel is read-only listing today.
+- **Per-request perm cache for `permission_required` middleware** — one `has_perm_pool` round-trip per request; high-RPS admin would benefit from session-level caching.
+- **Maintenance mode UI** (backlog `A6`) — shipped middleware, no template scaffold.
+- **`makemigrations --merge`** for divergent branch chains.
+- **Async signal `m2m_changed`** — currently dispatchers exist for pre/post-save only.
+
+---
+
+## Source pointers used for this audit
+
+- Capability inventory + known-gaps research from the two agent reports earlier in the planning conversation
+- `crates/rustango/Cargo.toml` (49 features)
+- `crates/rustango/src/lib.rs` (top-level module gating)
+- `crates/rustango/src/core/field_type.rs` (`FieldType` enum — 14 variants)
+- `crates/rustango-macros/src/lib.rs` (`#[rustango(...)]` attr surface)
+- `crates/rustango/src/migrate/manage.rs` (manage verbs)
+- `crates/rustango/src/admin/` (admin Builder + helpers + render)
+- `crates/rustango/src/template_views.rs` (CBV-equivalents)
+- `crates/rustango/src/i18n/timezone.rs` (i18n surface)
+- `crates/rustango/src/sql/executor.rs` (QuerySet executor)
+- `crates/rustango/src/tenancy/permissions.rs` (auth + permissions)
+- `~/.claude/projects/.../memory/future-backlog.md` (89-item backlog)
+- `~/.claude/projects/.../memory/framework-comparison-2026-05-02.md` (prior 5-dim audit)
+- `gh issue list --state open` (18 open issues, last checked 2026-05-21)
+- Django 6.0 docs (https://docs.djangoproject.com/en/6.0/) — all linked inline
+
+This audit is dated **2026-05-21** and represents rustango at the SHA on `main` right after PR #316 merged. Re-run on a quarterly cadence (or when ≥10 SHIPPED items accumulate) to keep the inventory honest.


### PR DESCRIPTION
First implementation pulled from the Django-parity audit batch
(`docs/django-parity-audit-2026-05-21.md`, 134 issues filed earlier today).

## Summary

- New `#[rustango(choices = "value:Label, value:Label, …")]` attribute on
  `String` model fields. Bare entries (no `:`) reuse the value as the label.
- Macro errors at compile time when applied to a non-String column —
  integer-valued enumerations stay on the existing "Rust enum + custom
  (de)serializer" path until we revisit.
- Threaded through `FieldSchema.choices: Option<&'static [(&'static str, &'static str)]>`
  so admin/serializer/OpenAPI/etc. can all read the same source of truth.
- `core::validate_value()` rejects off-choice strings via a new
  `QueryError::InvalidChoice` variant — applies to every INSERT/UPDATE
  routed through the query layer.
- `admin::render::render_input()` emits `<select>` with the declared
  options when `choices` is `Some`, regardless of `FieldType`. Nullable
  columns get a leading blank option; NOT NULL columns omit it so the
  browser-side `required` attribute does its job.

## Usage

```rust
#[derive(Model)]
struct Post {
    #[rustango(primary_key)] pub id: i64,
    #[rustango(max_length = 200)] pub title: String,
    #[rustango(max_length = 32, choices = "draft:Draft, published:Published, archived:Archived")]
    pub status: String,
}
```

## Tests

- `crates/rustango/tests/macro_choices.rs` — 6 cases: schema threading,
  bare-value fallback, off-choice rejection, in-choice acceptance,
  `max_length` still fires on choice fields.
- `crates/rustango/src/admin/render.rs::tests` — 3 cases: `<select>`
  rendering, blank-option nullable behavior, HTML escaping.

## CI

`macro_choices` test added to the `sqlite_litmus` job — runs on
`--no-default-features --features sqlite,tenancy` so the parity bit is
covered on the cheapest dialect.

## Notes for review

- Touches 16 `FieldSchema` literal sites to add `choices: None,` — pattern
  identical to how `help_text` was added in v0.40.
- No DB-side codegen (no DDL change) — `choices` is enforced in the
  application layer only, matching Django's behavior (Django's `choices`
  doesn't emit a CHECK constraint either; that's what `Meta.constraints`
  is for).
- Bundled with the audit doc baseline commit (`docs/django-parity-audit-2026-05-21.md`,
  +747 lines) as the entry point for the parity-batch work; subsequent
  parity PRs will reference rows in that doc rather than re-introduce it.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — passes
- [x] `cargo test --workspace --all-features --no-run` — compiles
- [x] `cargo test -p rustango --lib --no-default-features --features sqlite,tenancy` — 1440 passed
- [x] `cargo test -p rustango --lib --all-features` — 2345 passed
- [x] `cargo test -p rustango --test macro_choices --no-default-features --features sqlite,tenancy` — 6/6 passed
- [ ] CI green (multi-job: fmt / clippy / deny / doc / sqlite_litmus / sqlite_live / mysql_live / postgres_test)

Closes #446.