### PR TITLE
feat(signals): auth lifecycle signals (closes #414)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test sqlite_pragmas_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_fk_no_postgres
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_choices
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test auth_signals
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -277,6 +277,11 @@ admin = [
     # the relationship explicit so `--features sqlite,admin` builds
     # cleanly without `tenancy` or `passwords` named.
     "passwords",
+    # #414 — login / logout handlers fire the auth lifecycle signals
+    # (`user_logged_in` / `user_logged_out` / `user_login_failed`).
+    # Tokio was already in the admin closure; signals adds only the
+    # in-process registry helpers.
+    "signals",
     "dep:axum",
     "dep:tera",
     "dep:base64",
@@ -314,6 +319,9 @@ tenancy = [
     # depending on the target deployment. Apps that *also* want
     # schema-mode tenants get `postgres` automatically by including it.
     "runtime",
+    # #414 — tenant admin + operator console login_submit / logout
+    # fire the auth lifecycle signals.
+    "signals",
     "storage",
     "uploads",
     "dep:async-trait",

--- a/crates/rustango/src/admin/login_view.rs
+++ b/crates/rustango/src/admin/login_view.rs
@@ -85,7 +85,17 @@ struct LoginInput {
     password: String,
 }
 
-async fn login_submit(State(state): State<AppState>, Form(form): Form<LoginInput>) -> Response {
+async fn login_submit(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+    Form(form): Form<LoginInput>,
+) -> Response {
+    use crate::signals::auth::{
+        meta_from_headers, send_user_logged_in, send_user_login_failed, AuthFailureReason,
+        UserLoggedInContext, UserLoginFailedContext,
+    };
+    let meta = meta_from_headers(&headers, Some("/login"));
+
     let Some(secret) = state.config.session_secret.clone() else {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -120,6 +130,13 @@ async fn login_submit(State(state): State<AppState>, Form(form): Form<LoginInput
         .flatten();
 
     let Some(row) = row else {
+        send_user_login_failed(UserLoginFailedContext {
+            source: "admin",
+            attempted_username: Some(form.username.clone()),
+            reason: AuthFailureReason::InvalidCredentials,
+            request: meta.clone(),
+        })
+        .await;
         return Html(render_login_form(&state, Some("Invalid credentials."))).into_response();
     };
     let id = row.get("id").and_then(|v| v.as_i64()).unwrap_or_default();
@@ -134,9 +151,23 @@ async fn login_submit(State(state): State<AppState>, Form(form): Form<LoginInput
         .unwrap_or(false);
 
     if !is_active {
+        send_user_login_failed(UserLoginFailedContext {
+            source: "admin",
+            attempted_username: Some(form.username.clone()),
+            reason: AuthFailureReason::Inactive,
+            request: meta.clone(),
+        })
+        .await;
         return Html(render_login_form(&state, Some("Account is disabled."))).into_response();
     }
     if !crate::passwords::verify(&form.password, stored_hash).unwrap_or(false) {
+        send_user_login_failed(UserLoginFailedContext {
+            source: "admin",
+            attempted_username: Some(form.username.clone()),
+            reason: AuthFailureReason::InvalidCredentials,
+            request: meta.clone(),
+        })
+        .await;
         return Html(render_login_form(&state, Some("Invalid credentials."))).into_response();
     }
 
@@ -162,6 +193,14 @@ async fn login_submit(State(state): State<AppState>, Form(form): Form<LoginInput
     if let Ok(v) = HeaderValue::from_str(&cookie) {
         resp.headers_mut().insert(header::SET_COOKIE, v);
     }
+    send_user_logged_in(UserLoggedInContext {
+        source: "admin",
+        user_id: id,
+        username: form.username.clone(),
+        is_superuser,
+        request: meta,
+    })
+    .await;
     resp
 }
 
@@ -311,7 +350,30 @@ fn render_change_password_form(
 
 // ============================================================ Logout (POST)
 
-async fn logout_submit(State(state): State<AppState>) -> Response {
+async fn logout_submit(State(state): State<AppState>, headers: axum::http::HeaderMap) -> Response {
+    use crate::signals::auth::{meta_from_headers, send_user_logged_out, UserLoggedOutContext};
+    let meta = meta_from_headers(&headers, Some("/logout"));
+
+    // Best-effort session decode so the signal carries the user id /
+    // username when the cookie is still valid. Receivers that key off
+    // those fields fall through to the `None` branch cleanly.
+    let (user_id, username) = state
+        .config
+        .session_secret
+        .as_ref()
+        .and_then(|secret| {
+            let raw = headers.get(header::COOKIE)?.to_str().ok()?;
+            for part in raw.split(';').map(str::trim) {
+                if let Some(val) = part.strip_prefix(&format!("{SESSION_COOKIE}=")) {
+                    if let Some(sess) = session::decode(secret, val) {
+                        return Some((Some(sess.user_id), Some(sess.username)));
+                    }
+                }
+            }
+            None
+        })
+        .unwrap_or((None, None));
+
     let cookie = format!(
         "{name}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0",
         name = SESSION_COOKIE,
@@ -320,6 +382,13 @@ async fn logout_submit(State(state): State<AppState>) -> Response {
     if let Ok(v) = HeaderValue::from_str(&cookie) {
         resp.headers_mut().insert(header::SET_COOKIE, v);
     }
+    send_user_logged_out(UserLoggedOutContext {
+        source: "admin",
+        user_id,
+        username,
+        request: meta,
+    })
+    .await;
     resp
 }
 

--- a/crates/rustango/src/signals/auth.rs
+++ b/crates/rustango/src/signals/auth.rs
@@ -1,0 +1,331 @@
+//! Django-shape auth lifecycle signals — `user_logged_in`,
+//! `user_logged_out`, `user_login_failed`. Django-parity #414.
+//!
+//! Receivers register globally (no per-model dispatch — these are
+//! lifecycle events, not row events) and run sequentially in
+//! registration order. Each signal fires from inside the framework's
+//! login / logout / failed-login paths.
+//!
+//! ## Quick start
+//!
+//! ```ignore
+//! use rustango::signals::auth::{
+//!     connect_user_logged_in, connect_user_login_failed,
+//!     UserLoggedInContext, UserLoginFailedContext,
+//! };
+//!
+//! connect_user_logged_in(|ctx| Box::pin(async move {
+//!     tracing::info!(user_id = ctx.user_id, source = ctx.source, "login ok");
+//! }));
+//! connect_user_login_failed(|ctx| Box::pin(async move {
+//!     tracing::warn!(username = ?ctx.attempted_username, reason = ?ctx.reason, "login failed");
+//! }));
+//! ```
+//!
+//! ## Where each signal fires
+//!
+//! - `user_logged_in` — every successful login (admin POST `/login`,
+//!   tenant admin login, operator-console login, …). The
+//!   [`UserLoggedInContext`] carries the resolved user id, username,
+//!   `is_superuser` flag, and a free-form `source` tag identifying the
+//!   login path so receivers can filter by surface.
+//! - `user_logged_out` — every logout path (admin POST `/logout`,
+//!   tenant logout, operator logout). `user_id` and `username` are
+//!   optional because some logout endpoints don't require an active
+//!   session (e.g. a stale-cookie probe).
+//! - `user_login_failed` — every failed credential check or
+//!   inactive-account rejection. `attempted_username` is `None` when
+//!   the form is so malformed we can't extract it.
+//!
+//! ## Semantics
+//!
+//! - Receivers run **sequentially** in registration order, awaited one
+//!   at a time. Wrap a body in `tokio::spawn` for fanout.
+//! - A panicking receiver aborts the dispatch chain and propagates;
+//!   wrap in `tokio::spawn` if you need isolation.
+//! - Each receiver gets a `Clone`d context — no borrow lifetimes.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock, RwLock};
+
+/// Future returned by auth-signal receivers. `'static` because the
+/// receiver is stored as `Arc<dyn ...>` and may run after the caller
+/// has returned.
+pub type ReceiverFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+/// Opaque identifier returned by `connect_*` for later use with
+/// `disconnect_*`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ReceiverId(u64);
+
+// ---------------------------------------------------------------- Context types
+
+/// Per-request metadata shared by every auth signal context — the
+/// origin IP, user agent, and (when available) the originating path.
+/// All fields are optional; the framework populates them on a
+/// best-effort basis depending on which layers ran before the auth
+/// handler. Audit-log receivers typically lift these straight into
+/// their record.
+#[derive(Debug, Clone, Default)]
+pub struct AuthRequestMeta {
+    /// Origin IP — resolved through `real_ip` middleware when present,
+    /// otherwise the peer socket address.
+    pub ip_address: Option<String>,
+    /// Raw `User-Agent` header value.
+    pub user_agent: Option<String>,
+    /// Request path including query string. Mostly for debugging /
+    /// audit; not used for routing decisions.
+    pub path: Option<String>,
+}
+
+/// Payload delivered to `user_logged_in` receivers.
+#[derive(Debug, Clone)]
+pub struct UserLoggedInContext {
+    /// Free-form identifier for the login surface — e.g. `"admin"`,
+    /// `"tenant_admin"`, `"operator"`, `"jwt"`. Lets a single receiver
+    /// audit across multiple login paths and tell them apart.
+    pub source: &'static str,
+    /// Primary-key id of the user that just authenticated.
+    pub user_id: i64,
+    /// Username (or whatever the framework uses as the login
+    /// identifier on this surface).
+    pub username: String,
+    /// Whether the resolved user has framework-level superuser rights.
+    pub is_superuser: bool,
+    /// Origin metadata — see [`AuthRequestMeta`].
+    pub request: AuthRequestMeta,
+}
+
+/// Payload delivered to `user_logged_out` receivers.
+///
+/// `user_id` / `username` are `Option` because logout endpoints
+/// occasionally fire on a request where no session was ever
+/// established (e.g. a stale-cookie probe). Audit receivers that
+/// only care about real logouts should filter on `user_id.is_some()`.
+#[derive(Debug, Clone)]
+pub struct UserLoggedOutContext {
+    pub source: &'static str,
+    pub user_id: Option<i64>,
+    pub username: Option<String>,
+    pub request: AuthRequestMeta,
+}
+
+/// Reason a credential check rejected the attempt. Receivers can
+/// pivot on this to alert on credential stuffing
+/// ([`AuthFailureReason::InvalidCredentials`]) vs. operational
+/// rejections ([`AuthFailureReason::Inactive`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AuthFailureReason {
+    /// Username didn't exist, or password verify returned false.
+    InvalidCredentials,
+    /// User row exists but `active = false` (or whatever the surface
+    /// uses to mark soft-disabled accounts).
+    Inactive,
+    /// Lockout / rate-limit / captcha — surface-specific.
+    Locked,
+    /// Anything else the surface wants to flag; framework code uses
+    /// the named variants above so [`AuthFailureReason::Other`] is
+    /// rare in practice.
+    Other,
+}
+
+/// Payload delivered to `user_login_failed` receivers.
+#[derive(Debug, Clone)]
+pub struct UserLoginFailedContext {
+    pub source: &'static str,
+    /// Username submitted in the form. `None` when the form is so
+    /// malformed we couldn't extract it (rare — most surfaces require
+    /// the field at the schema layer).
+    pub attempted_username: Option<String>,
+    pub reason: AuthFailureReason,
+    pub request: AuthRequestMeta,
+}
+
+// ---------------------------------------------------------------- Internal storage
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum SignalKind {
+    LoggedIn,
+    LoggedOut,
+    LoginFailed,
+}
+
+type ReceiverEntry = (ReceiverId, Box<dyn Any + Send + Sync>);
+type Bag = Vec<ReceiverEntry>;
+
+fn registry() -> &'static RwLock<HashMap<SignalKind, Bag>> {
+    static REG: OnceLock<RwLock<HashMap<SignalKind, Bag>>> = OnceLock::new();
+    REG.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+fn next_id() -> ReceiverId {
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    ReceiverId(COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+fn insert_receiver<R: Any + Send + Sync>(kind: SignalKind, receiver: R) -> ReceiverId {
+    let id = next_id();
+    let mut reg = registry().write().unwrap_or_else(|e| e.into_inner());
+    reg.entry(kind).or_default().push((id, Box::new(receiver)));
+    id
+}
+
+fn remove_receiver(kind: SignalKind, id: ReceiverId) -> bool {
+    let mut reg = registry().write().unwrap_or_else(|e| e.into_inner());
+    let Some(bag) = reg.get_mut(&kind) else {
+        return false;
+    };
+    let before = bag.len();
+    bag.retain(|(rid, _)| *rid != id);
+    bag.len() != before
+}
+
+fn snapshot<R: Any + Send + Sync + Clone>(kind: SignalKind) -> Vec<R> {
+    let reg = registry().read().unwrap_or_else(|e| e.into_inner());
+    let Some(bag) = reg.get(&kind) else {
+        return Vec::new();
+    };
+    bag.iter()
+        .filter_map(|(_, b)| b.downcast_ref::<R>().cloned())
+        .collect()
+}
+
+// ---------------------------------------------------------------- Receiver type aliases
+
+type LoggedInReceiver = Arc<dyn Fn(UserLoggedInContext) -> ReceiverFuture + Send + Sync>;
+type LoggedOutReceiver = Arc<dyn Fn(UserLoggedOutContext) -> ReceiverFuture + Send + Sync>;
+type LoginFailedReceiver = Arc<dyn Fn(UserLoginFailedContext) -> ReceiverFuture + Send + Sync>;
+
+// ---------------------------------------------------------------- user_logged_in
+
+/// Register a `user_logged_in` receiver. Fires after every successful
+/// authentication on any of the framework's login surfaces.
+pub fn connect_user_logged_in<F, Fut>(receiver: F) -> ReceiverId
+where
+    F: Fn(UserLoggedInContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let boxed: LoggedInReceiver = Arc::new(move |ctx| Box::pin(receiver(ctx)));
+    insert_receiver(SignalKind::LoggedIn, boxed)
+}
+
+/// Remove a previously-connected `user_logged_in` receiver. Returns
+/// `true` when an entry was removed.
+pub fn disconnect_user_logged_in(id: ReceiverId) -> bool {
+    remove_receiver(SignalKind::LoggedIn, id)
+}
+
+/// Fire `user_logged_in` for `ctx`. Awaits every connected receiver
+/// in registration order.
+pub async fn send_user_logged_in(ctx: UserLoggedInContext) {
+    let receivers: Vec<LoggedInReceiver> = snapshot(SignalKind::LoggedIn);
+    for r in receivers {
+        r(ctx.clone()).await;
+    }
+}
+
+// ---------------------------------------------------------------- user_logged_out
+
+/// Register a `user_logged_out` receiver.
+pub fn connect_user_logged_out<F, Fut>(receiver: F) -> ReceiverId
+where
+    F: Fn(UserLoggedOutContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let boxed: LoggedOutReceiver = Arc::new(move |ctx| Box::pin(receiver(ctx)));
+    insert_receiver(SignalKind::LoggedOut, boxed)
+}
+
+/// Remove a previously-connected `user_logged_out` receiver.
+pub fn disconnect_user_logged_out(id: ReceiverId) -> bool {
+    remove_receiver(SignalKind::LoggedOut, id)
+}
+
+/// Fire `user_logged_out` for `ctx`.
+pub async fn send_user_logged_out(ctx: UserLoggedOutContext) {
+    let receivers: Vec<LoggedOutReceiver> = snapshot(SignalKind::LoggedOut);
+    for r in receivers {
+        r(ctx.clone()).await;
+    }
+}
+
+// ---------------------------------------------------------------- user_login_failed
+
+/// Register a `user_login_failed` receiver. Fires on every rejected
+/// credential check — invalid username, wrong password, inactive
+/// account, etc. See [`AuthFailureReason`].
+pub fn connect_user_login_failed<F, Fut>(receiver: F) -> ReceiverId
+where
+    F: Fn(UserLoginFailedContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let boxed: LoginFailedReceiver = Arc::new(move |ctx| Box::pin(receiver(ctx)));
+    insert_receiver(SignalKind::LoginFailed, boxed)
+}
+
+/// Remove a previously-connected `user_login_failed` receiver.
+pub fn disconnect_user_login_failed(id: ReceiverId) -> bool {
+    remove_receiver(SignalKind::LoginFailed, id)
+}
+
+/// Fire `user_login_failed` for `ctx`.
+pub async fn send_user_login_failed(ctx: UserLoginFailedContext) {
+    let receivers: Vec<LoginFailedReceiver> = snapshot(SignalKind::LoginFailed);
+    for r in receivers {
+        r(ctx.clone()).await;
+    }
+}
+
+// ---------------------------------------------------------------- Helpers
+
+/// Best-effort extraction of [`AuthRequestMeta`] from an axum request.
+/// Inspects the `User-Agent` header and the `X-Real-IP` /
+/// `X-Forwarded-For` chain that `real_ip` middleware sets. Returns a
+/// fully-default-`None` instance when neither is present so callers can
+/// always populate `request:` without conditional logic.
+pub fn meta_from_headers(headers: &axum::http::HeaderMap, path: Option<&str>) -> AuthRequestMeta {
+    let header_str = |name: &str| {
+        headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned)
+    };
+    let ip_address = header_str("x-real-ip").or_else(|| {
+        header_str("x-forwarded-for").and_then(|s| s.split(',').next().map(|f| f.trim().to_owned()))
+    });
+    let user_agent = header_str("user-agent");
+    AuthRequestMeta {
+        ip_address,
+        user_agent,
+        path: path.map(str::to_owned),
+    }
+}
+
+// ---------------------------------------------------------------- Maintenance
+
+/// Remove **all** auth-signal receivers. Useful in tests to reset
+/// registry state between cases.
+pub fn clear_all() {
+    registry()
+        .write()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
+}
+
+/// Total receivers currently registered across all three auth signals.
+/// Useful in tests to assert connection state.
+pub fn receiver_count() -> usize {
+    let reg = registry().read().unwrap_or_else(|e| e.into_inner());
+    [
+        SignalKind::LoggedIn,
+        SignalKind::LoggedOut,
+        SignalKind::LoginFailed,
+    ]
+    .iter()
+    .map(|kind| reg.get(kind).map_or(0, Vec::len))
+    .sum()
+}

--- a/crates/rustango/src/signals/mod.rs
+++ b/crates/rustango/src/signals/mod.rs
@@ -55,6 +55,7 @@ use std::sync::{Arc, OnceLock, RwLock};
 
 use crate::core::Model;
 
+pub mod auth;
 pub mod request;
 
 /// Future returned by signal receivers. `'static` because the receiver

--- a/crates/rustango/src/tenancy/admin.rs
+++ b/crates/rustango/src/tenancy/admin.rs
@@ -456,6 +456,20 @@ where
             };
         }
         if path == routes.logout_url && method == axum::http::Method::POST {
+            use crate::signals::auth::{
+                meta_from_headers, send_user_logged_out, UserLoggedOutContext,
+            };
+            // Best-effort: decode the session cookie so the signal
+            // carries user_id / username. Receivers tolerate `None`.
+            let (uid, uname) = decode_session_user(&parts.headers, cfg, &org.slug);
+            let meta = meta_from_headers(&parts.headers, Some(routes.logout_url.as_str()));
+            send_user_logged_out(UserLoggedOutContext {
+                source: "tenant_admin",
+                user_id: uid,
+                username: uname,
+                request: meta,
+            })
+            .await;
             return logout_response(routes);
         }
         // v0.27.8 (#78) — end-impersonation routes. Recognized
@@ -618,6 +632,28 @@ enum SessionCheck {
     },
     Anonymous,
     Error(String),
+}
+
+/// Best-effort: extract `(user_id, username_unknown)` from a session
+/// cookie so the auth-logout signal can carry the user id even when no
+/// further DB lookup is feasible. Returns `(None, None)` on any decode
+/// error (missing cookie, bad signature, expired, wrong slug).
+///
+/// Username is unrecoverable from the cookie payload alone (the tenant
+/// session payload only stores `uid`), so we return `None` for it and
+/// leave the receiver responsible for a username lookup if needed.
+fn decode_session_user(
+    headers: &HeaderMap,
+    cfg: &TenantSessionConfig,
+    slug: &str,
+) -> (Option<i64>, Option<String>) {
+    let Some(cookie_value) = read_cookie(headers, tenant_console::COOKIE_NAME) else {
+        return (None, None);
+    };
+    match tenant_console::decode(&cfg.secret, slug, &cookie_value) {
+        Ok(p) => (Some(p.uid), None),
+        Err(_) => (None, None),
+    }
 }
 
 async fn validate_session(
@@ -787,11 +823,17 @@ async fn login_submit(
     cfg: &TenantSessionConfig,
     tenant_pool: &crate::sql::Pool,
     routes: &super::routes::RouteConfig,
-    _headers: HeaderMap,
+    headers: HeaderMap,
     body: Body,
 ) -> Response {
     use crate::core::Column as _;
+    use crate::signals::auth::{
+        meta_from_headers, send_user_logged_in, send_user_login_failed, AuthFailureReason,
+        UserLoggedInContext, UserLoginFailedContext,
+    };
     use crate::sql::FetcherPool as _;
+
+    let meta = meta_from_headers(&headers, Some(routes.login_url.as_str()));
 
     let bytes = match http_body_util::BodyExt::collect(body).await {
         Ok(b) => b.to_bytes(),
@@ -826,10 +868,21 @@ async fn login_submit(
         ))
         .into_response()
     };
+    let fire_failed = |reason: AuthFailureReason| {
+        let ctx = UserLoginFailedContext {
+            source: "tenant_admin",
+            attempted_username: Some(form.username.clone()),
+            reason,
+            request: meta.clone(),
+        };
+        async move { send_user_login_failed(ctx).await }
+    };
     let Some(user) = users.into_iter().next() else {
+        fire_failed(AuthFailureReason::InvalidCredentials).await;
         return bad_creds();
     };
     if !user.active {
+        fire_failed(AuthFailureReason::Inactive).await;
         return bad_creds();
     }
     let hash = user.password_hash.clone();
@@ -838,10 +891,12 @@ async fn login_submit(
         Err(_) => false,
     };
     if !ok {
+        fire_failed(AuthFailureReason::InvalidCredentials).await;
         return bad_creds();
     }
     let uid: i64 = user.id.get().copied().unwrap_or(0);
     if uid == 0 {
+        fire_failed(AuthFailureReason::InvalidCredentials).await;
         return bad_creds();
     }
     let ttl_secs = i64::try_from(routes.tenant_session_ttl.as_secs())
@@ -859,6 +914,14 @@ async fn login_submit(
         header::SET_COOKIE,
         HeaderValue::from_str(&cookie.to_string()).expect("cookie is ascii"),
     );
+    send_user_logged_in(UserLoggedInContext {
+        source: "tenant_admin",
+        user_id: uid,
+        username: form.username.clone(),
+        is_superuser: user.is_superuser,
+        request: meta,
+    })
+    .await;
     resp
 }
 

--- a/crates/rustango/src/tenancy/auth_routes.rs
+++ b/crates/rustango/src/tenancy/auth_routes.rs
@@ -185,10 +185,28 @@ pub struct LoginOutput {
     pub user: UserBrief,
 }
 
-async fn login(t: Tenant, Json(body): Json<LoginInput>) -> Result<Json<LoginOutput>, Response> {
+async fn login(
+    t: Tenant,
+    headers: axum::http::HeaderMap,
+    Json(body): Json<LoginInput>,
+) -> Result<Json<LoginOutput>, Response> {
     use crate::core::Column as _;
+    use crate::signals::auth::{
+        meta_from_headers, send_user_logged_in, send_user_login_failed, AuthFailureReason,
+        UserLoggedInContext, UserLoginFailedContext,
+    };
     use crate::sql::FetcherPool as _;
     use crate::tenancy::auth::User;
+
+    let meta = meta_from_headers(&headers, Some("/auth/login"));
+    let fire_failed = |reason: AuthFailureReason| -> UserLoginFailedContext {
+        UserLoginFailedContext {
+            source: "jwt",
+            attempted_username: Some(body.username.clone()),
+            reason,
+            request: meta.clone(),
+        }
+    };
 
     let users = User::objects()
         .where_(User::username.eq(body.username.clone()))
@@ -196,22 +214,32 @@ async fn login(t: Tenant, Json(body): Json<LoginInput>) -> Result<Json<LoginOutp
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response())?;
 
-    let user = users
-        .into_iter()
-        .next()
-        .ok_or_else(|| (StatusCode::UNAUTHORIZED, "invalid credentials").into_response())?;
+    let Some(user) = users.into_iter().next() else {
+        send_user_login_failed(fire_failed(AuthFailureReason::InvalidCredentials)).await;
+        return Err((StatusCode::UNAUTHORIZED, "invalid credentials").into_response());
+    };
 
     if !user.active {
+        send_user_login_failed(fire_failed(AuthFailureReason::Inactive)).await;
         return Err((StatusCode::FORBIDDEN, "account inactive").into_response());
     }
 
     let ok = crate::tenancy::password::verify(&body.password, &user.password_hash)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response())?;
     if !ok {
+        send_user_login_failed(fire_failed(AuthFailureReason::InvalidCredentials)).await;
         return Err((StatusCode::UNAUTHORIZED, "invalid credentials").into_response());
     }
 
     let user_id = user.id.get().copied().unwrap_or(0);
+    send_user_logged_in(UserLoggedInContext {
+        source: "jwt",
+        user_id,
+        username: user.username.clone(),
+        is_superuser: user.is_superuser,
+        request: meta,
+    })
+    .await;
     // Bake the resolved tenant's slug into the token so a JWT
     // signed on `acme.<apex>` cannot be replayed on
     // `sju.<apex>` — even though both tenants share
@@ -264,8 +292,24 @@ async fn refresh(Json(body): Json<RefreshInput>) -> Result<Json<RefreshOutput>, 
 /// Revoke the access token's `jti`. Subsequent requests with the
 /// same token return 401 even though `exp` would otherwise still be
 /// valid.
-async fn logout(bearer: Bearer) -> Result<StatusCode, Response> {
+async fn logout(headers: axum::http::HeaderMap, bearer: Bearer) -> Result<StatusCode, Response> {
+    use crate::signals::auth::{meta_from_headers, send_user_logged_out, UserLoggedOutContext};
+    // Best-effort: decode the bearer to recover the user id for the
+    // signal. We don't reject on verify-failure here — the revoke
+    // call below still runs, and a stale/expired token logout is a
+    // valid audit event in its own right.
+    let user_id = jwt_handle().verify_access(&bearer.0).map(|c| c.sub);
+    let meta = meta_from_headers(&headers, Some("/auth/logout"));
+
     jwt_handle().revoke(&bearer.0);
+
+    send_user_logged_out(UserLoggedOutContext {
+        source: "jwt",
+        user_id,
+        username: None,
+        request: meta,
+    })
+    .await;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -612,8 +612,14 @@ struct LoginSubmit {
 
 async fn login_submit(
     State(state): State<ConsoleState>,
+    headers: axum::http::HeaderMap,
     Form(form): Form<LoginSubmit>,
 ) -> Response<Body> {
+    use crate::signals::auth::{
+        meta_from_headers, send_user_logged_in, send_user_login_failed, AuthFailureReason,
+        UserLoggedInContext, UserLoginFailedContext,
+    };
+    let meta = meta_from_headers(&headers, Some("/login"));
     let next = sanitize_next(form.next.as_deref());
     let principal =
         match auth::authenticate_operator_pool(&state.registry, &form.username, &form.password)
@@ -621,6 +627,13 @@ async fn login_submit(
         {
             Ok(Some(op)) => op,
             Ok(None) => {
+                send_user_login_failed(UserLoginFailedContext {
+                    source: "operator",
+                    attempted_username: Some(form.username.clone()),
+                    reason: AuthFailureReason::InvalidCredentials,
+                    request: meta,
+                })
+                .await;
                 return Redirect::to(&format!(
                     "/login?error=Invalid+credentials&next={}",
                     urlencoding_lite(&next)
@@ -646,10 +659,29 @@ async fn login_submit(
         header::SET_COOKIE,
         HeaderValue::from_str(&cookie.to_string()).expect("cookie is ascii"),
     );
+    send_user_logged_in(UserLoggedInContext {
+        source: "operator",
+        user_id: oid,
+        username: form.username.clone(),
+        // Operator principals are uniformly "superuser-equivalent" at
+        // the framework boundary — they're the people minting tenant
+        // sessions. There's no separate flag on the Operator row.
+        is_superuser: true,
+        request: meta,
+    })
+    .await;
     resp
 }
 
-async fn logout(State(_state): State<ConsoleState>) -> Response<Body> {
+async fn logout(
+    State(state): State<ConsoleState>,
+    headers: axum::http::HeaderMap,
+) -> Response<Body> {
+    use crate::signals::auth::{meta_from_headers, send_user_logged_out, UserLoggedOutContext};
+    // Best-effort: decode the session cookie so the signal carries
+    // operator_id. Receivers tolerate `None`.
+    let oid = decode_operator_session(&headers, &state.session_secret);
+    let meta = meta_from_headers(&headers, Some("/logout"));
     let clear = Cookie::build((COOKIE_NAME, ""))
         .path("/")
         .http_only(true)
@@ -661,7 +693,28 @@ async fn logout(State(_state): State<ConsoleState>) -> Response<Body> {
         header::SET_COOKIE,
         HeaderValue::from_str(&clear.to_string()).expect("cookie is ascii"),
     );
+    send_user_logged_out(UserLoggedOutContext {
+        source: "operator",
+        user_id: oid,
+        username: None,
+        request: meta,
+    })
+    .await;
     resp
+}
+
+/// Best-effort: decode the operator session cookie to recover the
+/// operator id for audit signals. `None` on any error.
+fn decode_operator_session(headers: &axum::http::HeaderMap, secret: &SessionSecret) -> Option<i64> {
+    let raw = headers.get(header::COOKIE)?.to_str().ok()?;
+    for part in raw.split(';').map(str::trim) {
+        if let Some(val) = part.strip_prefix(&format!("{COOKIE_NAME}=")) {
+            if let Ok(p) = session::decode(secret, val) {
+                return Some(p.oid);
+            }
+        }
+    }
+    None
 }
 
 // ----------------------------- views

--- a/crates/rustango/tests/auth_signals.rs
+++ b/crates/rustango/tests/auth_signals.rs
@@ -1,0 +1,224 @@
+//! Django-parity #414 — `user_logged_in` / `user_logged_out` /
+//! `user_login_failed` lifecycle signals.
+//!
+//! Pure in-memory registry test — connects a receiver per signal, fires
+//! the signal manually, asserts the receiver saw the context. No DB
+//! roundtrip; the live wiring (admin / tenant / operator login handlers
+//! calling `send_*`) is covered by separate live tests under each
+//! console's existing test suite.
+
+#![cfg(feature = "signals")]
+
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use rustango::signals::auth::{
+    clear_all, connect_user_logged_in, connect_user_logged_out, connect_user_login_failed,
+    disconnect_user_logged_in, receiver_count, send_user_logged_in, send_user_logged_out,
+    send_user_login_failed, AuthFailureReason, AuthRequestMeta, UserLoggedInContext,
+    UserLoggedOutContext, UserLoginFailedContext,
+};
+
+/// Cargo's default parallel harness runs these tests on shared global
+/// signal state. Take a suite-wide mutex at entry so two tests don't
+/// race on `clear_all` between each other's setup and assert.
+fn suite_lock() -> &'static tokio::sync::Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[tokio::test]
+async fn user_logged_in_fires_with_full_context() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let captured: Arc<Mutex<Option<UserLoggedInContext>>> = Arc::new(Mutex::new(None));
+    let sink = captured.clone();
+    let id = connect_user_logged_in(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            *sink.lock().await = Some(ctx);
+        }
+    });
+
+    send_user_logged_in(UserLoggedInContext {
+        source: "admin",
+        user_id: 42,
+        username: "alice".into(),
+        is_superuser: true,
+        request: AuthRequestMeta {
+            ip_address: Some("1.2.3.4".into()),
+            user_agent: Some("curl/8".into()),
+            path: Some("/login".into()),
+        },
+    })
+    .await;
+
+    let got = captured.lock().await.clone().expect("receiver fired");
+    assert_eq!(got.user_id, 42);
+    assert_eq!(got.username, "alice");
+    assert!(got.is_superuser);
+    assert_eq!(got.source, "admin");
+    assert_eq!(got.request.ip_address.as_deref(), Some("1.2.3.4"));
+    assert_eq!(got.request.path.as_deref(), Some("/login"));
+
+    assert!(rustango::signals::auth::disconnect_user_logged_in(id));
+}
+
+#[tokio::test]
+async fn user_login_failed_carries_failure_reason() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let captured: Arc<Mutex<Vec<UserLoginFailedContext>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    connect_user_login_failed(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().await.push(ctx);
+        }
+    });
+
+    for reason in [
+        AuthFailureReason::InvalidCredentials,
+        AuthFailureReason::Inactive,
+        AuthFailureReason::Locked,
+    ] {
+        send_user_login_failed(UserLoginFailedContext {
+            source: "tenant_admin",
+            attempted_username: Some("eve".into()),
+            reason,
+            request: AuthRequestMeta::default(),
+        })
+        .await;
+    }
+
+    let got = captured.lock().await;
+    assert_eq!(got.len(), 3);
+    assert_eq!(got[0].reason, AuthFailureReason::InvalidCredentials);
+    assert_eq!(got[1].reason, AuthFailureReason::Inactive);
+    assert_eq!(got[2].reason, AuthFailureReason::Locked);
+    assert!(got
+        .iter()
+        .all(|c| c.attempted_username.as_deref() == Some("eve")));
+}
+
+#[tokio::test]
+async fn user_logged_out_supports_optional_user_id() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let captured: Arc<Mutex<Vec<UserLoggedOutContext>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    connect_user_logged_out(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().await.push(ctx);
+        }
+    });
+
+    // Authenticated logout
+    send_user_logged_out(UserLoggedOutContext {
+        source: "operator",
+        user_id: Some(7),
+        username: Some("op".into()),
+        request: AuthRequestMeta::default(),
+    })
+    .await;
+    // Stale-cookie logout — receivers tolerate both Nones
+    send_user_logged_out(UserLoggedOutContext {
+        source: "operator",
+        user_id: None,
+        username: None,
+        request: AuthRequestMeta::default(),
+    })
+    .await;
+
+    let got = captured.lock().await;
+    assert_eq!(got.len(), 2);
+    assert_eq!(got[0].user_id, Some(7));
+    assert_eq!(got[1].user_id, None);
+}
+
+#[tokio::test]
+async fn receivers_run_in_registration_order() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let log: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    for tag in 1u8..=3 {
+        let log = log.clone();
+        connect_user_logged_in(move |_| {
+            let log = log.clone();
+            async move {
+                log.lock().await.push(tag);
+            }
+        });
+    }
+    send_user_logged_in(UserLoggedInContext {
+        source: "admin",
+        user_id: 1,
+        username: "u".into(),
+        is_superuser: false,
+        request: AuthRequestMeta::default(),
+    })
+    .await;
+    assert_eq!(&*log.lock().await, &[1, 2, 3]);
+}
+
+#[tokio::test]
+async fn disconnect_removes_only_the_named_receiver() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let counter: Arc<Mutex<u32>> = Arc::new(Mutex::new(0));
+    let mut ids = Vec::new();
+    for _ in 0..3 {
+        let counter = counter.clone();
+        ids.push(connect_user_logged_in(move |_| {
+            let counter = counter.clone();
+            async move {
+                *counter.lock().await += 1;
+            }
+        }));
+    }
+    assert_eq!(receiver_count(), 3);
+
+    assert!(disconnect_user_logged_in(ids[1]));
+    assert_eq!(receiver_count(), 2);
+
+    send_user_logged_in(UserLoggedInContext {
+        source: "admin",
+        user_id: 1,
+        username: "u".into(),
+        is_superuser: false,
+        request: AuthRequestMeta::default(),
+    })
+    .await;
+
+    assert_eq!(*counter.lock().await, 2);
+}
+
+#[test]
+fn meta_from_headers_extracts_real_ip_and_ua() {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert("user-agent", "test-agent/1.0".parse().unwrap());
+    headers.insert("x-forwarded-for", "203.0.113.7, 10.0.0.1".parse().unwrap());
+
+    let meta = rustango::signals::auth::meta_from_headers(&headers, Some("/login"));
+    assert_eq!(meta.user_agent.as_deref(), Some("test-agent/1.0"));
+    // First IP in X-Forwarded-For wins.
+    assert_eq!(meta.ip_address.as_deref(), Some("203.0.113.7"));
+    assert_eq!(meta.path.as_deref(), Some("/login"));
+}
+
+#[test]
+fn meta_from_headers_prefers_x_real_ip_over_xff() {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert("x-real-ip", "10.0.0.99".parse().unwrap());
+    headers.insert("x-forwarded-for", "203.0.113.7".parse().unwrap());
+    let meta = rustango::signals::auth::meta_from_headers(&headers, None);
+    assert_eq!(meta.ip_address.as_deref(), Some("10.0.0.99"));
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -524,7 +524,7 @@ Summary: **7 / 1 / 2 / 0**.
 | `class_prepared` | (above) | N/A — Rust doesn't have lazy class creation | n/a | |
 | `request_started` / `request_finished` | [request signals](https://docs.djangoproject.com/en/6.0/ref/signals/#django.core.signals.request_started) | PARTIAL | tower `Service` semantics + tracing layer cover this (#412) | Not a discrete signal. |
 | `got_request_exception` | (above) | PARTIAL | tower error handling + tracing (#413) | |
-| `user_logged_in` / `user_logged_out` / `user_login_failed` | [auth signals](https://docs.djangoproject.com/en/6.0/ref/contrib/auth/#module-django.contrib.auth.signals) | MISSING | n/a (#414) | Useful for audit. Wire a `pre_save` on user-row or expose explicit signals. |
+| `user_logged_in` / `user_logged_out` / `user_login_failed` | [auth signals](https://docs.djangoproject.com/en/6.0/ref/contrib/auth/#module-django.contrib.auth.signals) | SHIPPED | `signals::auth::*` (#414, v0.42) — fired from admin / tenant admin / operator console / JWT login + logout paths with `AuthRequestMeta` context | |
 | `setting_changed` | (above) | MISSING | n/a (#415) | |
 | Disconnect / weak references | (above) | SHIPPED | `signals::disconnect_*` | |
 | Async receivers | (Django 4.1+ async receivers) | SHIPPED | All rustango signal receivers are `async fn` | |


### PR DESCRIPTION
Django-parity #414. Wires `user_logged_in` / `user_logged_out` /
`user_login_failed` signals into every login + logout path the
framework ships, so audit-log / SIEM / rate-limiter receivers can hook
a single registry instead of overriding each handler.

## Surface

New module `signals::auth` (gated implicitly on `admin` / `tenancy`):

```rust
use rustango::signals::auth::{
    connect_user_logged_in, AuthFailureReason, UserLoggedInContext,
};

connect_user_logged_in(|ctx| Box::pin(async move {
    tracing::info!(user_id = ctx.user_id, source = ctx.source, "login");
}));
```

Three context types — `UserLoggedInContext`, `UserLoggedOutContext`,
`UserLoginFailedContext` — each carries `source: &'static str`,
identifying primary key + name + `AuthRequestMeta` (ip / user-agent /
path). Failure context adds `reason: AuthFailureReason {
InvalidCredentials | Inactive | Locked | Other }`.

Connect/disconnect/send + `receiver_count` + `clear_all` mirror the
existing `signals::request` pattern.

`meta_from_headers(headers, path?)` — helper for callers to extract
ip (X-Real-IP, then X-Forwarded-For first hop) + user_agent.

## Sites wired

| File | Source tag |
|---|---|
| `admin/login_view::login_submit` / `logout_submit` | `admin` |
| `tenancy/admin::login_submit` + `/logout` POST | `tenant_admin` |
| `tenancy/operator_console::login_submit` / `logout` | `operator` |
| `tenancy/auth_routes::login` / `logout` | `jwt` |

Every failure branch (no user / inactive / bad password / db error)
fires `user_login_failed`. Logout paths do a best-effort cookie /
bearer decode so the signal carries `user_id` when available;
receivers tolerate `None`.

## Feature graph

`admin` and `tenancy` now imply `signals` — both already pull
`dep:tokio`, so cost is just the in-process registry helpers. Keeps
the `sqlite,tenancy` litmus build flowing without an extra flag.

## Tests

`crates/rustango/tests/auth_signals.rs` — 7 cases:
- full-context fire
- failure-reason carry-through (3 reasons)
- optional `user_id` on logout
- receiver ordering
- disconnect-by-id
- `meta_from_headers` extracts X-Forwarded-For first hop
- `meta_from_headers` prefers X-Real-IP over X-Forwarded-For

CI: `auth_signals` test added to the `sqlite_litmus` job alongside
`macro_choices`.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — passes
- [x] `cargo test --workspace --all-features --no-run` — compiles
- [x] `cargo test -p rustango --lib --no-default-features --features sqlite,tenancy` — 1440 passed
- [x] `cargo test -p rustango --lib --all-features` — 2345 passed
- [x] `cargo test -p rustango --test auth_signals --no-default-features --features sqlite,tenancy` — 7/7 passed
- [ ] CI green (multi-job)

Closes #414.