### PR TITLE
feat(orm): `#[rustango(db_comment = "…")]` field option (closes #450)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_choices
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test auth_signals
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_cursor_pagination_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_db_comment
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -5147,6 +5147,12 @@ struct FieldAttrs {
     /// for `FieldType::String`; the macro errors at compile time if
     /// applied to a non-string field.
     choices: Option<Vec<(String, String)>>,
+    /// `#[rustango(db_comment = "…")]` — Django-shape DB-side column
+    /// comment. Threaded into `FieldSchema::db_comment`. MySQL inlines
+    /// the comment in CREATE TABLE; Postgres emits a separate
+    /// `COMMENT ON COLUMN` statement after the table is created;
+    /// SQLite silently drops the value (no native column comments).
+    db_comment: Option<String>,
 }
 
 fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
@@ -5172,6 +5178,7 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
         generated_as: None,
         help_text: None,
         choices: None,
+        db_comment: None,
     };
     for attr in &field.attrs {
         if !attr.path().is_ident("rustango") {
@@ -5260,6 +5267,11 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
                     ));
                 }
                 out.choices = Some(pairs);
+                return Ok(());
+            }
+            if meta.path.is_ident("db_comment") {
+                let s: LitStr = meta.value()?.parse()?;
+                out.db_comment = Some(s.value());
                 return Ok(());
             }
             if meta.path.is_ident("auto_uuid") {
@@ -5616,6 +5628,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
     let generated_as = optional_str(attrs.generated_as.as_deref());
     let help_text = optional_str(attrs.help_text.as_deref());
     let choices = optional_choices(attrs.choices.as_deref());
+    let db_comment = optional_str(attrs.db_comment.as_deref());
     let schema = quote! {
         ::rustango::core::FieldSchema {
             name: #name,
@@ -5633,6 +5646,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
             generated_as: #generated_as,
             help_text: #help_text,
             choices: #choices,
+            db_comment: #db_comment,
         }
     };
 

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -519,6 +519,7 @@ mod tests {
             generated_as: None,
             help_text: None,
             choices: None,
+            db_comment: None,
         }
     }
 

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -66,6 +66,14 @@ pub struct FieldSchema {
     /// and `validate_value` rejects values not in the list. Only
     /// meaningful for `FieldType::String`.
     pub choices: Option<&'static [(&'static str, &'static str)]>,
+    /// Django-shape `db_comment="..."` — DB-side column comment
+    /// emitted alongside CREATE TABLE. Set via
+    /// `#[rustango(db_comment = "...")]`. MySQL inlines it
+    /// (`<col> <type> COMMENT '...'`); Postgres emits a separate
+    /// `COMMENT ON COLUMN "<table>"."<col>" IS '...'` statement
+    /// after the table is created; SQLite has no native column
+    /// comments and silently drops the value.
+    pub db_comment: Option<&'static str>,
 }
 
 /// Static description of a relation to another model.

--- a/crates/rustango/src/migrate/ddl.rs
+++ b/crates/rustango/src/migrate/ddl.rs
@@ -233,6 +233,35 @@ fn write_column_def(s: &mut String, dialect: &dyn Dialect, field: &FieldSchema) 
         s.push_str(" UNIQUE");
     }
     write_check_constraint(s, dialect, field);
+    // #450 — MySQL splices `COMMENT '...'` into the column line. PG +
+    // SQLite get nothing here; PG gets a separate `COMMENT ON COLUMN`
+    // statement via `column_comment_statements_with_dialect`, SQLite
+    // is a no-op (no native column comments).
+    if let Some(comment) = field.db_comment {
+        if let Some(inline) = dialect.write_inline_column_comment(comment) {
+            s.push_str(&inline);
+        }
+    }
+}
+
+/// Per-model post-CREATE-TABLE statements for `db_comment` (#450) — one
+/// `COMMENT ON COLUMN "<table>"."<col>" IS '...'` per field on Postgres;
+/// empty `Vec` on MySQL (already inlined) and SQLite (no-op).
+#[must_use]
+pub fn column_comment_statements_with_dialect(
+    dialect: &dyn Dialect,
+    model: &ModelSchema,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    for field in model.scalar_fields() {
+        let Some(comment) = field.db_comment else {
+            continue;
+        };
+        if let Some(stmt) = dialect.column_comment_statement(model.table, field.column, comment) {
+            out.push(stmt);
+        }
+    }
+    out
 }
 
 fn write_check_constraint(s: &mut String, dialect: &dyn Dialect, field: &FieldSchema) {
@@ -328,6 +357,7 @@ mod tests {
             generated_as: None,
             help_text: None,
             choices: None,
+            db_comment: None,
         }
     }
 

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -3852,6 +3852,7 @@ mod gen_tests {
             generated_as: None,
             help_text: None,
             choices: None,
+            db_comment: None,
         }
     }
 

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -306,6 +306,14 @@ pub async fn apply_all_pool(pool: &crate::sql::Pool) -> Result<(), MigrateError>
             crate::sql::raw_execute_pool(pool, &sql, ::std::vec::Vec::new()).await?;
         }
     }
+    // #450 — post-hoc `COMMENT ON COLUMN` for dialects that need it
+    // (Postgres). MySQL already inlined comments in CREATE TABLE;
+    // SQLite returns an empty vec (no native column comments).
+    for model in &models {
+        for sql in ddl::column_comment_statements_with_dialect(dialect, model) {
+            crate::sql::raw_execute_pool(pool, &sql, ::std::vec::Vec::new()).await?;
+        }
+    }
     Ok(())
 }
 

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -533,6 +533,7 @@ mod composite_fk_snapshot_tests {
             generated_as: None,
             help_text: None,
             choices: None,
+            db_comment: None,
         }];
         static COMPS: [CompositeFkRelation; 1] = [CompositeFkRelation {
             name: "target",
@@ -594,6 +595,7 @@ mod composite_fk_snapshot_tests {
             generated_as: None,
             help_text: None,
             choices: None,
+            db_comment: None,
         }];
         static MS: ModelSchema = ModelSchema {
             name: "Plain",

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -216,6 +216,7 @@ mod tests {
             generated_as: None,
             help_text: None,
             choices: None,
+            db_comment: None,
         },
         FieldSchema {
             name: "title",
@@ -233,6 +234,7 @@ mod tests {
             generated_as: None,
             help_text: None,
             choices: None,
+            db_comment: None,
         },
         FieldSchema {
             name: "deleted_at",
@@ -250,6 +252,7 @@ mod tests {
             generated_as: None,
             help_text: None,
             choices: None,
+            db_comment: None,
         },
     ];
 

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -633,6 +633,37 @@ pub trait Dialect {
         None
     }
 
+    /// Inline column-comment fragment to splice into a CREATE TABLE
+    /// column definition for the field's `db_comment` attribute (#450).
+    /// MySQL returns `" COMMENT '<escaped>'"`; Postgres + SQLite return
+    /// `None` because they need a different mechanism (post-hoc
+    /// `COMMENT ON COLUMN` for Postgres, no-op for SQLite) — see
+    /// [`Self::column_comment_statement`].
+    ///
+    /// Implementations are responsible for properly escaping single
+    /// quotes in the supplied comment.
+    fn write_inline_column_comment(&self, _comment: &str) -> Option<String> {
+        None
+    }
+
+    /// Standalone `COMMENT ON COLUMN "<table>"."<col>" IS '<escaped>'`
+    /// statement emitted after CREATE TABLE for dialects that need it.
+    /// Postgres returns `Some(_)`; MySQL handles it inline (see
+    /// [`Self::write_inline_column_comment`]) and returns `None`;
+    /// SQLite returns `None` (no native column comments).
+    ///
+    /// The migration runner calls this for every field whose
+    /// `db_comment.is_some()` after the table is created. Implementations
+    /// are responsible for properly escaping single quotes.
+    fn column_comment_statement(
+        &self,
+        _table: &str,
+        _column: &str,
+        _comment: &str,
+    ) -> Option<String> {
+        None
+    }
+
     // ====== Compilation (always overridden) ======
 
     /// Lower a `SelectQuery` to a `CompiledStatement` for this dialect.

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -69,6 +69,15 @@ impl Dialect for MySql {
         format!("`{escaped}`")
     }
 
+    /// MySQL spells column comments inline in the CREATE TABLE column
+    /// definition (`<col> <type> [NULL/NOT NULL] [DEFAULT …] COMMENT
+    /// '<escaped>'`). Single quotes are doubled per the MySQL parser's
+    /// escape rule.
+    fn write_inline_column_comment(&self, comment: &str) -> Option<String> {
+        let escaped = comment.replace('\'', "''");
+        Some(format!(" COMMENT '{escaped}'"))
+    }
+
     // `?`-style placeholders are the trait default — no override needed.
 
     fn serial_type(&self, field_type: FieldType) -> &'static str {
@@ -1238,6 +1247,7 @@ mod tests {
                 generated_as: None,
                 help_text: None,
                 choices: None,
+                db_comment: None,
             })
             .collect();
         let leaked: &'static [crate::core::FieldSchema] = Box::leak(field_vec.into_boxed_slice());

--- a/crates/rustango/src/sql/postgres.rs
+++ b/crates/rustango/src/sql/postgres.rs
@@ -46,6 +46,16 @@ impl Dialect for Postgres {
         format!("${n}")
     }
 
+    fn column_comment_statement(&self, table: &str, column: &str, comment: &str) -> Option<String> {
+        let escaped = comment.replace('\'', "''");
+        Some(format!(
+            "COMMENT ON COLUMN {}.{} IS '{}'",
+            self.quote_ident(table),
+            self.quote_ident(column),
+            escaped,
+        ))
+    }
+
     fn serial_type(&self, field_type: FieldType) -> &'static str {
         match field_type {
             FieldType::I32 => "SERIAL",

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -632,6 +632,7 @@ mod tests {
             generated_as: None,
             help_text: None,
             choices: None,
+            db_comment: None,
         }];
         static MODEL: ModelSchema = ModelSchema {
             name: "demo",

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -3836,6 +3836,7 @@ mod tests {
                     generated_as: None,
                     help_text: None,
                     choices: None,
+                    db_comment: None,
                 },
                 crate::core::FieldSchema {
                     name: "title",
@@ -3853,6 +3854,7 @@ mod tests {
                     generated_as: None,
                     help_text: None,
                     choices: None,
+                    db_comment: None,
                 },
             ])),
             display: None,
@@ -3896,6 +3898,7 @@ mod tests {
                     generated_as: None,
                     help_text: None,
                     choices: None,
+                    db_comment: None,
                 },
                 crate::core::FieldSchema {
                     name: "title",
@@ -3913,6 +3916,7 @@ mod tests {
                     generated_as: None,
                     help_text: None,
                     choices: None,
+                    db_comment: None,
                 },
                 crate::core::FieldSchema {
                     name: "score",
@@ -3930,6 +3934,7 @@ mod tests {
                     generated_as: None,
                     help_text: None,
                     choices: None,
+                    db_comment: None,
                 },
             ])),
             display: None,
@@ -4304,6 +4309,7 @@ mod tests {
                 generated_as: None,
                 help_text: None,
                 choices: None,
+                db_comment: None,
             }])),
             display: None,
             app_label: None,
@@ -4543,6 +4549,7 @@ mod tests {
                 generated_as: None,
                 help_text: None,
                 choices: None,
+                db_comment: None,
             }])),
             display: None,
             app_label: None,
@@ -4594,6 +4601,7 @@ mod tests {
                 generated_as: None,
                 help_text: None,
                 choices: None,
+                db_comment: None,
             }])),
             display: None,
             app_label: None,
@@ -5118,6 +5126,7 @@ mod tests {
                 generated_as: None,
                 help_text: None,
                 choices: None,
+                db_comment: None,
             })) as &'static crate::core::FieldSchema
         };
         assert!(matches!(

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1531,6 +1531,7 @@ mod lookup_tests {
             generated_as: None,
             help_text: None,
             choices: None,
+            db_comment: None,
         }
     }
 
@@ -1551,6 +1552,7 @@ mod lookup_tests {
             generated_as: None,
             help_text: None,
             choices: None,
+            db_comment: None,
         }
     }
 

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -295,6 +295,7 @@ mod tests {
             generated_as: None,
             help_text: None,
             choices: None,
+            db_comment: None,
         }
     }
 
@@ -315,6 +316,7 @@ mod tests {
             generated_as: None,
             help_text: None,
             choices: None,
+            db_comment: None,
         }
     }
 
@@ -335,6 +337,7 @@ mod tests {
             generated_as: None,
             help_text: None,
             choices: None,
+            db_comment: None,
         }
     }
 
@@ -356,6 +359,7 @@ mod tests {
                 generated_as: None,
                 help_text: None,
                 choices: None,
+                db_comment: None,
             },
             FieldSchema {
                 name: "title",
@@ -373,6 +377,7 @@ mod tests {
                 generated_as: None,
                 help_text: None,
                 choices: None,
+                db_comment: None,
             },
             FieldSchema {
                 name: "author_id",
@@ -390,6 +395,7 @@ mod tests {
                 generated_as: None,
                 help_text: None,
                 choices: None,
+                db_comment: None,
             },
         ];
         // Suppress unused warnings on field helpers if we keep them.

--- a/crates/rustango/tests/field_types_decimal_binary_time.rs
+++ b/crates/rustango/tests/field_types_decimal_binary_time.rs
@@ -124,6 +124,7 @@ fn form_parser_decimal() {
         generated_as: None,
         help_text: None,
         choices: None,
+        db_comment: None,
     };
     let v = parse_form_value(&f, Some("123.45")).unwrap();
     assert!(matches!(v, SqlValue::Decimal(d) if d == Decimal::from_str("123.45").unwrap()));
@@ -152,6 +153,7 @@ fn form_parser_binary_hex() {
         generated_as: None,
         help_text: None,
         choices: None,
+        db_comment: None,
     };
     let v = parse_form_value(&f, Some("deadbeef")).unwrap();
     assert!(matches!(v, SqlValue::Binary(b) if b == vec![0xde, 0xad, 0xbe, 0xef]));
@@ -182,6 +184,7 @@ fn form_parser_time() {
         generated_as: None,
         help_text: None,
         choices: None,
+        db_comment: None,
     };
     // Full HH:MM:SS form.
     let v = parse_form_value(&f, Some("14:30:45")).unwrap();

--- a/crates/rustango/tests/macro_db_comment.rs
+++ b/crates/rustango/tests/macro_db_comment.rs
@@ -1,0 +1,113 @@
+//! `#[rustango(db_comment = "...")]` field attribute (Django parity #450).
+//!
+//! Covers:
+//! - macro threads the value through to `FieldSchema::db_comment`
+//! - DDL writer emits inline `COMMENT '...'` on MySQL
+//! - DDL writer emits post-table `COMMENT ON COLUMN ... IS '...'` on Postgres
+//! - DDL writer emits nothing on SQLite (no native column comments)
+//! - single quotes in the comment value are escaped per dialect
+//!
+//! No DB roundtrip — these are pure schema / writer checks against the
+//! macro output, so the test compiles under any backend.
+
+use rustango::core::{FieldSchema, Model};
+use rustango::migrate::ddl::{
+    column_comment_statements_with_dialect, create_table_sql_with_dialect,
+};
+#[cfg(feature = "mysql")]
+use rustango::sql::MySql;
+use rustango::sql::Postgres;
+#[cfg(feature = "sqlite")]
+use rustango::sql::Sqlite;
+use rustango_macros::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "macro_dbnote_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+
+    #[rustango(max_length = 200, db_comment = "Display title, plain text")]
+    pub title: String,
+
+    /// Comment with an embedded apostrophe — round-trips per-dialect escape.
+    #[rustango(db_comment = "Author's name (full)")]
+    pub author: String,
+
+    pub untagged: i32,
+}
+
+fn field<'a>(name: &str) -> &'a FieldSchema {
+    Post::SCHEMA
+        .field(name)
+        .unwrap_or_else(|| panic!("no field {name:?}"))
+}
+
+#[test]
+fn schema_threads_db_comment() {
+    assert_eq!(field("title").db_comment, Some("Display title, plain text"));
+    assert_eq!(field("author").db_comment, Some("Author's name (full)"));
+    assert!(field("id").db_comment.is_none());
+    assert!(field("untagged").db_comment.is_none());
+}
+
+#[cfg(feature = "mysql")]
+#[test]
+fn mysql_inlines_comment_in_create_table() {
+    let sql = create_table_sql_with_dialect(&MySql, Post::SCHEMA);
+    // Inline on the title column
+    assert!(
+        sql.contains("COMMENT 'Display title, plain text'"),
+        "expected inline COMMENT on title, got:\n{sql}"
+    );
+    // Escaped single quote on the author column
+    assert!(
+        sql.contains("COMMENT 'Author''s name (full)'"),
+        "expected escaped apostrophe on author, got:\n{sql}"
+    );
+    // No spurious comment on untagged
+    let no_comment_count = sql.matches("COMMENT '").count();
+    assert_eq!(
+        no_comment_count, 2,
+        "expected exactly 2 inline COMMENTs, got {no_comment_count} in:\n{sql}"
+    );
+    // MySQL doesn't get any post-table COMMENT ON statements
+    assert!(column_comment_statements_with_dialect(&MySql, Post::SCHEMA).is_empty());
+}
+
+#[test]
+fn postgres_emits_post_table_comment_on_column() {
+    let sql = create_table_sql_with_dialect(&Postgres, Post::SCHEMA);
+    // No inline COMMENT on PG — they come as separate statements.
+    assert!(
+        !sql.contains("COMMENT '"),
+        "PG CREATE TABLE should not inline comments, got:\n{sql}"
+    );
+
+    let stmts = column_comment_statements_with_dialect(&Postgres, Post::SCHEMA);
+    assert_eq!(
+        stmts.len(),
+        2,
+        "expected 2 COMMENT ON statements, got {stmts:?}"
+    );
+    let joined = stmts.join("\n");
+    assert!(joined.contains(
+        r#"COMMENT ON COLUMN "macro_dbnote_post"."title" IS 'Display title, plain text'"#
+    ));
+    // PG also doubles the embedded apostrophe
+    assert!(joined
+        .contains(r#"COMMENT ON COLUMN "macro_dbnote_post"."author" IS 'Author''s name (full)'"#));
+}
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn sqlite_silently_drops_db_comment() {
+    let sql = create_table_sql_with_dialect(&Sqlite, Post::SCHEMA);
+    // SQLite emits no comment text — DDL stays clean.
+    assert!(
+        !sql.to_uppercase().contains("COMMENT"),
+        "SQLite should not emit COMMENT, got:\n{sql}"
+    );
+    assert!(column_comment_statements_with_dialect(&Sqlite, Post::SCHEMA).is_empty());
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -167,7 +167,7 @@ Field options:
 | `primary_key=True` | SHIPPED | `#[rustango(primary_key)]` | |
 | `unique=True` | SHIPPED | `#[rustango(unique)]` | |
 | `editable=False` | MISSING | n/a (#449) | Use `#[rustango(readonly)]` admin attribute instead. |
-| `db_comment` | MISSING | n/a (#450) | |
+| `db_comment` | SHIPPED | `#[rustango(db_comment = "...")]` (#450, v0.42) — PG emits post-table `COMMENT ON COLUMN`, MySQL inlines `COMMENT '...'`, SQLite no-op (no native support) | |
 | `db_tablespace` | N/A | n/a | Tablespaces are PG-specific niche. |
 
 Summary: **14 SHIPPED / 4 PARTIAL / 7 MISSING / 0 N/A** in this section. Gaps cluster around: `choices`, `verbose_name`, `editable`, IP/FilePath/File/ImageField, model-level validators.


### PR DESCRIPTION
Django-parity #450. DB-side column comments emitted by every CREATE
TABLE, with per-dialect shape so the comment shows up wherever the
database's introspection tools look for it.

## Syntax

```rust
#[derive(Model)]
#[rustango(table = "post")]
struct Post {
    #[rustango(primary_key)] pub id: i64,
    #[rustango(max_length = 200, db_comment = "Display title, plain text")]
    pub title: String,
    #[rustango(db_comment = "Author's name (full)")]
    pub author: String,
}
```

## Per-dialect emission

| Dialect | Where | Statement |
|---|---|---|
| MySQL | inline in CREATE TABLE | `title VARCHAR(200) NOT NULL COMMENT 'Display title…'` |
| Postgres | post-table, emitted by `apply_all_pool` | `COMMENT ON COLUMN "post"."title" IS 'Display title…'` |
| SQLite | n/a — no native column comments | (silently dropped) |

Single-quote escaping is per-dialect: both MySQL and PG double the
quote (`''`), which is the SQL standard escape rule.

## Surfaces wired

- `FieldSchema.db_comment: Option<&'static str>`
- `Dialect::write_inline_column_comment(comment)` — MySQL override
- `Dialect::column_comment_statement(table, col, comment)` — PG override
- `ddl::column_comment_statements_with_dialect(dialect, model)` — public
  helper that produces the post-CREATE-TABLE batch
- `runner::apply_all_pool` runs the post-table batch automatically
  alongside ADD CONSTRAINT

## Tests

`crates/rustango/tests/macro_db_comment.rs` — 4 cases:
- Schema threading + absent attribute → `None`
- MySQL inline COMMENT with apostrophe-doubling (`--features mysql`)
- PG post-table `COMMENT ON COLUMN` with `''` escape
- SQLite emits no `COMMENT` text at all (`--features sqlite`)

CI: test wired into the `sqlite_litmus` job.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — passes
- [x] `cargo test --workspace --all-features --no-run` — compiles
- [x] `cargo test -p rustango --lib --no-default-features --features sqlite,tenancy` — 1440 passed
- [x] `cargo test -p rustango --lib --all-features` — 2345 passed
- [x] `cargo test -p rustango --test macro_db_comment` — 4/4 passed (sqlite + mysql + pg)
- [ ] CI green (multi-job)

Closes #450.