### PR TITLE
feat(orm): `#[rustango(verbose_name = "…")]` field option (closes #448)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test auth_signals
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_cursor_pagination_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_db_comment
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_verbose_name
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -5153,6 +5153,12 @@ struct FieldAttrs {
     /// `COMMENT ON COLUMN` statement after the table is created;
     /// SQLite silently drops the value (no native column comments).
     db_comment: Option<String>,
+    /// `#[rustango(verbose_name = "…")]` — Django-shape human-readable
+    /// label for the field. Threaded into `FieldSchema::verbose_name`
+    /// so admin column headers, form labels, and other display
+    /// surfaces can prefer the friendly caption over the Rust
+    /// identifier. `None` means renderers fall back to the field name.
+    verbose_name: Option<String>,
 }
 
 fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
@@ -5179,6 +5185,7 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
         help_text: None,
         choices: None,
         db_comment: None,
+        verbose_name: None,
     };
     for attr in &field.attrs {
         if !attr.path().is_ident("rustango") {
@@ -5272,6 +5279,11 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
             if meta.path.is_ident("db_comment") {
                 let s: LitStr = meta.value()?.parse()?;
                 out.db_comment = Some(s.value());
+                return Ok(());
+            }
+            if meta.path.is_ident("verbose_name") {
+                let s: LitStr = meta.value()?.parse()?;
+                out.verbose_name = Some(s.value());
                 return Ok(());
             }
             if meta.path.is_ident("auto_uuid") {
@@ -5629,6 +5641,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
     let help_text = optional_str(attrs.help_text.as_deref());
     let choices = optional_choices(attrs.choices.as_deref());
     let db_comment = optional_str(attrs.db_comment.as_deref());
+    let verbose_name = optional_str(attrs.verbose_name.as_deref());
     let schema = quote! {
         ::rustango::core::FieldSchema {
             name: #name,
@@ -5647,6 +5660,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
             help_text: #help_text,
             choices: #choices,
             db_comment: #db_comment,
+            verbose_name: #verbose_name,
         }
     };
 

--- a/crates/rustango/src/admin/helpers.rs
+++ b/crates/rustango/src/admin/helpers.rs
@@ -461,7 +461,7 @@ fn render_form_with_inlines_and_pickers(
             render::render_input(f, value, lock_input)
         };
         serde_json::json!({
-            "label": f.name,
+            "label": f.display_label(),
             "extra": extra,
             "input": input_html,
             // Django-shape `help_text` (#admin-helptext) — short

--- a/crates/rustango/src/admin/inlines.rs
+++ b/crates/rustango/src/admin/inlines.rs
@@ -385,7 +385,7 @@ pub async fn render_for_parent(
                             .cloned()
                             .unwrap_or(serde_json::Value::Null);
                         serde_json::json!({
-                            "label": f.name,
+                            "label": f.display_label(),
                             "value": render_cell_text(&raw),
                         })
                     })
@@ -534,7 +534,7 @@ pub async fn render_generic_for_parent(
                             .cloned()
                             .unwrap_or(serde_json::Value::Null);
                         serde_json::json!({
-                            "label": f.name,
+                            "label": f.display_label(),
                             "value": render_cell_text(&raw),
                         })
                     })
@@ -795,7 +795,7 @@ pub async fn render_form_for_parent(
                         .unwrap_or_default();
                     let input_html = render_prefixed_input(f, &raw_str, &prefix, idx, false);
                     serde_json::json!({
-                        "label": f.name,
+                        "label": f.display_label(),
                         "input_html": input_html,
                     })
                 })
@@ -830,7 +830,7 @@ pub async fn render_form_for_parent(
                 .map(|f| {
                     let input_html = render_prefixed_input(f, "", &prefix, idx, false);
                     serde_json::json!({
-                        "label": f.name,
+                        "label": f.display_label(),
                         "input_html": input_html,
                     })
                 })
@@ -1263,7 +1263,7 @@ pub async fn render_form_generic_for_parent(
                         .unwrap_or_default();
                     let input_html = render_prefixed_input(f, &raw_str, &prefix, idx, false);
                     serde_json::json!({
-                        "label": f.name,
+                        "label": f.display_label(),
                         "input_html": input_html,
                     })
                 })
@@ -1294,7 +1294,7 @@ pub async fn render_form_generic_for_parent(
                 .map(|f| {
                     let input_html = render_prefixed_input(f, "", &prefix, idx, false);
                     serde_json::json!({
-                        "label": f.name,
+                        "label": f.display_label(),
                         "input_html": input_html,
                     })
                 })

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -520,6 +520,7 @@ mod tests {
             help_text: None,
             choices: None,
             db_comment: None,
+            verbose_name: None,
         }
     }
 

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -399,10 +399,13 @@ pub(crate) async fn table_view(
         .map(|item| {
             let label = match item {
                 DisplayItem::Field(f) => {
+                    // #448 — `#[rustango(verbose_name = "...")]` overrides
+                    // the Rust identifier on admin list column headers.
+                    let caption = f.display_label();
                     if f.primary_key {
-                        format!("{} <small>(pk)</small>", render::escape(f.name))
+                        format!("{} <small>(pk)</small>", render::escape(caption))
                     } else {
-                        render::escape(f.name)
+                        render::escape(caption)
                     }
                 }
                 DisplayItem::Computed(m) => {
@@ -971,7 +974,7 @@ pub(crate) async fn detail_view(
         .scalar_fields()
         .map(|f| {
             serde_json::json!({
-                "label": f.name,
+                "label": f.display_label(),
                 "value": render_cell_json(&row, f, &fk_map),
             })
         })

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -74,6 +74,24 @@ pub struct FieldSchema {
     /// after the table is created; SQLite has no native column
     /// comments and silently drops the value.
     pub db_comment: Option<&'static str>,
+    /// Django-shape `verbose_name` — human-readable label for the
+    /// field, used in admin column headers, form labels, and any
+    /// other surface that wants to display the field with a friendly
+    /// caption instead of the Rust identifier. Set via
+    /// `#[rustango(verbose_name = "Display title")]`. `None` means
+    /// callers should fall back to [`Self::name`].
+    pub verbose_name: Option<&'static str>,
+}
+
+impl FieldSchema {
+    /// Human-readable label for this field — `verbose_name` if set,
+    /// otherwise the Rust field identifier (`name`). Use this from
+    /// admin / form / serializer renderers that want a friendly
+    /// caption without re-implementing the fallback each time.
+    #[must_use]
+    pub fn display_label(&self) -> &'static str {
+        self.verbose_name.unwrap_or(self.name)
+    }
 }
 
 /// Static description of a relation to another model.

--- a/crates/rustango/src/migrate/ddl.rs
+++ b/crates/rustango/src/migrate/ddl.rs
@@ -358,6 +358,7 @@ mod tests {
             help_text: None,
             choices: None,
             db_comment: None,
+            verbose_name: None,
         }
     }
 

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -3853,6 +3853,7 @@ mod gen_tests {
             help_text: None,
             choices: None,
             db_comment: None,
+            verbose_name: None,
         }
     }
 

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -534,6 +534,7 @@ mod composite_fk_snapshot_tests {
             help_text: None,
             choices: None,
             db_comment: None,
+            verbose_name: None,
         }];
         static COMPS: [CompositeFkRelation; 1] = [CompositeFkRelation {
             name: "target",
@@ -596,6 +597,7 @@ mod composite_fk_snapshot_tests {
             help_text: None,
             choices: None,
             db_comment: None,
+            verbose_name: None,
         }];
         static MS: ModelSchema = ModelSchema {
             name: "Plain",

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -217,6 +217,7 @@ mod tests {
             help_text: None,
             choices: None,
             db_comment: None,
+            verbose_name: None,
         },
         FieldSchema {
             name: "title",
@@ -235,6 +236,7 @@ mod tests {
             help_text: None,
             choices: None,
             db_comment: None,
+            verbose_name: None,
         },
         FieldSchema {
             name: "deleted_at",
@@ -253,6 +255,7 @@ mod tests {
             help_text: None,
             choices: None,
             db_comment: None,
+            verbose_name: None,
         },
     ];
 

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -1248,6 +1248,7 @@ mod tests {
                 help_text: None,
                 choices: None,
                 db_comment: None,
+                verbose_name: None,
             })
             .collect();
         let leaked: &'static [crate::core::FieldSchema] = Box::leak(field_vec.into_boxed_slice());

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -633,6 +633,7 @@ mod tests {
             help_text: None,
             choices: None,
             db_comment: None,
+            verbose_name: None,
         }];
         static MODEL: ModelSchema = ModelSchema {
             name: "demo",

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -3837,6 +3837,7 @@ mod tests {
                     help_text: None,
                     choices: None,
                     db_comment: None,
+                    verbose_name: None,
                 },
                 crate::core::FieldSchema {
                     name: "title",
@@ -3855,6 +3856,7 @@ mod tests {
                     help_text: None,
                     choices: None,
                     db_comment: None,
+                    verbose_name: None,
                 },
             ])),
             display: None,
@@ -3899,6 +3901,7 @@ mod tests {
                     help_text: None,
                     choices: None,
                     db_comment: None,
+                    verbose_name: None,
                 },
                 crate::core::FieldSchema {
                     name: "title",
@@ -3917,6 +3920,7 @@ mod tests {
                     help_text: None,
                     choices: None,
                     db_comment: None,
+                    verbose_name: None,
                 },
                 crate::core::FieldSchema {
                     name: "score",
@@ -3935,6 +3939,7 @@ mod tests {
                     help_text: None,
                     choices: None,
                     db_comment: None,
+                    verbose_name: None,
                 },
             ])),
             display: None,
@@ -4310,6 +4315,7 @@ mod tests {
                 help_text: None,
                 choices: None,
                 db_comment: None,
+                verbose_name: None,
             }])),
             display: None,
             app_label: None,
@@ -4550,6 +4556,7 @@ mod tests {
                 help_text: None,
                 choices: None,
                 db_comment: None,
+                verbose_name: None,
             }])),
             display: None,
             app_label: None,
@@ -4602,6 +4609,7 @@ mod tests {
                 help_text: None,
                 choices: None,
                 db_comment: None,
+                verbose_name: None,
             }])),
             display: None,
             app_label: None,
@@ -5127,6 +5135,7 @@ mod tests {
                 help_text: None,
                 choices: None,
                 db_comment: None,
+                verbose_name: None,
             })) as &'static crate::core::FieldSchema
         };
         assert!(matches!(

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1532,6 +1532,7 @@ mod lookup_tests {
             help_text: None,
             choices: None,
             db_comment: None,
+            verbose_name: None,
         }
     }
 
@@ -1553,6 +1554,7 @@ mod lookup_tests {
             help_text: None,
             choices: None,
             db_comment: None,
+            verbose_name: None,
         }
     }
 

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -296,6 +296,7 @@ mod tests {
             help_text: None,
             choices: None,
             db_comment: None,
+            verbose_name: None,
         }
     }
 
@@ -317,6 +318,7 @@ mod tests {
             help_text: None,
             choices: None,
             db_comment: None,
+            verbose_name: None,
         }
     }
 
@@ -338,6 +340,7 @@ mod tests {
             help_text: None,
             choices: None,
             db_comment: None,
+            verbose_name: None,
         }
     }
 
@@ -360,6 +363,7 @@ mod tests {
                 help_text: None,
                 choices: None,
                 db_comment: None,
+                verbose_name: None,
             },
             FieldSchema {
                 name: "title",
@@ -378,6 +382,7 @@ mod tests {
                 help_text: None,
                 choices: None,
                 db_comment: None,
+                verbose_name: None,
             },
             FieldSchema {
                 name: "author_id",
@@ -396,6 +401,7 @@ mod tests {
                 help_text: None,
                 choices: None,
                 db_comment: None,
+                verbose_name: None,
             },
         ];
         // Suppress unused warnings on field helpers if we keep them.

--- a/crates/rustango/tests/field_types_decimal_binary_time.rs
+++ b/crates/rustango/tests/field_types_decimal_binary_time.rs
@@ -125,6 +125,7 @@ fn form_parser_decimal() {
         help_text: None,
         choices: None,
         db_comment: None,
+        verbose_name: None,
     };
     let v = parse_form_value(&f, Some("123.45")).unwrap();
     assert!(matches!(v, SqlValue::Decimal(d) if d == Decimal::from_str("123.45").unwrap()));
@@ -154,6 +155,7 @@ fn form_parser_binary_hex() {
         help_text: None,
         choices: None,
         db_comment: None,
+        verbose_name: None,
     };
     let v = parse_form_value(&f, Some("deadbeef")).unwrap();
     assert!(matches!(v, SqlValue::Binary(b) if b == vec![0xde, 0xad, 0xbe, 0xef]));
@@ -185,6 +187,7 @@ fn form_parser_time() {
         help_text: None,
         choices: None,
         db_comment: None,
+        verbose_name: None,
     };
     // Full HH:MM:SS form.
     let v = parse_form_value(&f, Some("14:30:45")).unwrap();

--- a/crates/rustango/tests/macro_verbose_name.rs
+++ b/crates/rustango/tests/macro_verbose_name.rs
@@ -1,0 +1,73 @@
+//! `#[rustango(verbose_name = "...")]` field attribute (Django parity #448).
+//!
+//! Covers:
+//! - macro threads the value through to `FieldSchema::verbose_name`
+//! - `display_label()` returns `verbose_name` when set, else `name`
+//! - PG/MySQL/SQLite DDL is unaffected (label is presentation-only)
+
+use rustango::core::{FieldSchema, Model};
+use rustango::migrate::ddl::create_table_sql_with_dialect;
+use rustango::sql::Postgres;
+use rustango_macros::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "macro_vn_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+
+    #[rustango(max_length = 200, verbose_name = "Display title")]
+    pub title: String,
+
+    /// Field without verbose_name — display_label() falls back to name.
+    pub status: String,
+
+    #[rustango(verbose_name = "Author's full name")]
+    pub author: String,
+}
+
+fn field<'a>(name: &str) -> &'a FieldSchema {
+    Post::SCHEMA
+        .field(name)
+        .unwrap_or_else(|| panic!("no field {name:?}"))
+}
+
+#[test]
+fn schema_threads_verbose_name() {
+    assert_eq!(field("title").verbose_name, Some("Display title"));
+    assert_eq!(field("author").verbose_name, Some("Author's full name"));
+    assert!(field("status").verbose_name.is_none());
+    assert!(field("id").verbose_name.is_none());
+}
+
+#[test]
+fn display_label_returns_verbose_name_when_set() {
+    assert_eq!(field("title").display_label(), "Display title");
+    assert_eq!(field("author").display_label(), "Author's full name");
+}
+
+#[test]
+fn display_label_falls_back_to_name_when_unset() {
+    assert_eq!(field("status").display_label(), "status");
+    assert_eq!(field("id").display_label(), "id");
+}
+
+/// `verbose_name` is presentation-only and must never affect the DDL —
+/// no rogue `COMMENT` text, no rename of the column. Belt-and-braces
+/// regression test against future changes that conflate the two.
+#[test]
+fn verbose_name_does_not_change_ddl() {
+    let sql = create_table_sql_with_dialect(&Postgres, Post::SCHEMA);
+    assert!(
+        !sql.contains("Display title"),
+        "verbose_name leaked into DDL: {sql}"
+    );
+    assert!(
+        !sql.contains("Author"),
+        "verbose_name leaked into DDL: {sql}"
+    );
+    // Column names are still the Rust identifiers.
+    assert!(sql.contains(r#""title""#));
+    assert!(sql.contains(r#""author""#));
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -163,7 +163,7 @@ Field options:
 | `db_index=True` | SHIPPED | `#[rustango(index)]` (field-level) + container-level `index(...)` | |
 | `db_column` | SHIPPED | `#[rustango(db_column = "...")]` | |
 | `help_text` | SHIPPED | `#[rustango(help_text = "...")]` (v0.40) — admin renders below input | |
-| `verbose_name` | MISSING | n/a (#448) | Admin column headers use field name as-is. |
+| `verbose_name` | SHIPPED | `#[rustango(verbose_name = "Display title")]` (#448, v0.42) — admin column headers + form labels render via `FieldSchema::display_label()` | |
 | `primary_key=True` | SHIPPED | `#[rustango(primary_key)]` | |
 | `unique=True` | SHIPPED | `#[rustango(unique)]` | |
 | `editable=False` | MISSING | n/a (#449) | Use `#[rustango(readonly)]` admin attribute instead. |


### PR DESCRIPTION
Django-parity #448. Human-readable field label for admin column headers
and form labels — Django's `verbose_name` on model fields, no DDL impact.

## Syntax

```rust
#[derive(Model)]
struct Post {
    #[rustango(primary_key)] pub id: i64,
    #[rustango(max_length = 200, verbose_name = "Display title")]
    pub title: String,
    pub status: String,  // no override — admin renders "status"
}
```

## Surfaces wired

- `FieldSchema.verbose_name: Option<&'static str>`
- `FieldSchema::display_label()` — `verbose_name` when set, else `name`
- Admin list view column header — `admin/views.rs::columns_ctx`
- Admin change-form input labels — `admin/helpers.rs` + every inline path
  (`admin/inlines.rs`, 6 sites) + the detail view (`admin/views.rs:974`)

Total: 8 label sites flipped from `f.name` to `f.display_label()`.

## DDL invariance

`verbose_name` is presentation-only — column names stay the Rust
identifier, no `COMMENT` emission, no rename. There's a dedicated
regression test that asserts the label string never appears in the
generated CREATE TABLE.

## Tests

`crates/rustango/tests/macro_verbose_name.rs` — 4 cases:
- Schema threading + `None` on un-attributed fields
- `display_label()` returns `verbose_name` when set
- `display_label()` falls back to `name` otherwise
- `verbose_name` does NOT leak into the DDL (regression guard)

CI: `macro_verbose_name` wired into the `sqlite_litmus` job.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — passes
- [x] `cargo test --workspace --all-features --no-run` — compiles
- [x] `cargo test -p rustango --lib --no-default-features --features sqlite,tenancy` — 1440 passed
- [x] `cargo test -p rustango --lib --all-features` — 2345 passed
- [x] `cargo test -p rustango --test macro_verbose_name` — 4/4 passed
- [ ] CI green (multi-job)

Closes #448.