### PR TITLE
feat(orm): `#[rustango(blank)]` field option (closes #445)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_verbose_name
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_meta_verbose_name
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_editable
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_blank
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -5196,6 +5196,10 @@ struct FieldAttrs {
     /// (the value is still visible on detail / list views, just not
     /// editable).
     editable: bool,
+    /// `#[rustango(blank)]` / `#[rustango(blank = true)]` — Django-shape
+    /// "form may submit empty even when DB is NOT NULL". Threaded into
+    /// `FieldSchema::blank`. Defaults to `false`.
+    blank: bool,
 }
 
 fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
@@ -5224,6 +5228,7 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
         db_comment: None,
         verbose_name: None,
         editable: true,
+        blank: false,
     };
     for attr in &field.attrs {
         if !attr.path().is_ident("rustango") {
@@ -5334,6 +5339,18 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
                     out.editable = lit.value;
                 } else {
                     out.editable = true;
+                }
+                return Ok(());
+            }
+            if meta.path.is_ident("blank") {
+                // Two forms accepted:
+                //   #[rustango(blank)] — flag form, true
+                //   #[rustango(blank = false)] / true — explicit
+                if let Ok(v) = meta.value() {
+                    let lit: syn::LitBool = v.parse()?;
+                    out.blank = lit.value;
+                } else {
+                    out.blank = true;
                 }
                 return Ok(());
             }
@@ -5694,6 +5711,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
     let db_comment = optional_str(attrs.db_comment.as_deref());
     let verbose_name = optional_str(attrs.verbose_name.as_deref());
     let editable = attrs.editable;
+    let blank = attrs.blank;
     let schema = quote! {
         ::rustango::core::FieldSchema {
             name: #name,
@@ -5714,6 +5732,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
             db_comment: #db_comment,
             verbose_name: #verbose_name,
             editable: #editable,
+            blank: #blank,
         }
     };
 

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -168,12 +168,20 @@ pub(crate) fn render_gfk_select(
 pub(crate) fn render_input(field: &FieldSchema, value: &str, pk_locked: bool) -> String {
     let name = escape(field.name);
     let val = escape(value);
-    let required =
-        if field.nullable || field.ty == FieldType::Bool || field.auto || field.primary_key {
-            ""
-        } else {
-            " required"
-        };
+    // #445 — Django-shape `blank = true` drops the `required` HTML
+    // attribute even on NOT-NULL columns (form may submit empty
+    // even when the DB is NOT NULL — empty string is a valid
+    // non-null value for CharField).
+    let required = if field.nullable
+        || field.ty == FieldType::Bool
+        || field.auto
+        || field.primary_key
+        || field.blank
+    {
+        ""
+    } else {
+        " required"
+    };
     // Caller passes `pk_locked=true` to mean "render this field as
     // read-only" — used both for PKs on edit forms (slice 10.5
     // pre-existing behavior) and for `readonly_fields` flagged via
@@ -522,6 +530,7 @@ mod tests {
             db_comment: None,
             verbose_name: None,
             editable: true,
+            blank: false,
         }
     }
 
@@ -670,5 +679,37 @@ mod tests {
         assert!(html.contains("&lt;b&gt;"));
         assert!(!html.contains("<a>"));
         assert!(!html.contains("<b>"));
+    }
+
+    /// `#[rustango(blank)]` drops the `required` HTML attribute even
+    /// on NOT NULL columns — Django-shape "form may submit empty even
+    /// when DB is NOT NULL" semantics (#445).
+    #[test]
+    fn render_input_blank_drops_required_on_not_null_column() {
+        let mut f = field("subtitle", "subtitle", FieldType::String);
+        f.nullable = false; // DB-side NOT NULL
+        f.blank = true; // form-side allow empty
+        f.max_length = Some(50);
+
+        let html = render_input(&f, "", false);
+        assert!(
+            !html.contains(" required"),
+            "blank=true should drop `required`, got: {html}"
+        );
+    }
+
+    /// NOT NULL + blank=false (default) still emits `required`.
+    #[test]
+    fn render_input_keeps_required_on_not_null_when_blank_false() {
+        let mut f = field("title", "title", FieldType::String);
+        f.nullable = false;
+        f.blank = false;
+        f.max_length = Some(50);
+
+        let html = render_input(&f, "", false);
+        assert!(
+            html.contains(" required"),
+            "NOT NULL non-blank field should be required, got: {html}"
+        );
     }
 }

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -91,6 +91,19 @@ pub struct FieldSchema {
     /// `admin.readonly_fields` which renders the input disabled —
     /// `editable = false` removes the input entirely.
     pub editable: bool,
+    /// Django-shape `blank` flag — `true` means the form layer
+    /// allows the field to be submitted empty even when the column
+    /// is `NOT NULL`. Set via `#[rustango(blank)]` or
+    /// `#[rustango(blank = true)]`. The admin form drops the
+    /// `required` HTML attribute when this is set, and form-side
+    /// validators treat an empty string as valid (the DB still
+    /// enforces NOT NULL — empty string is a valid non-null value).
+    ///
+    /// Distinct from `nullable` (which controls whether the SQL
+    /// column accepts NULL): a CharField can be
+    /// `nullable=false, blank=true` to require *some* value in DB
+    /// but accept `""` from the form.
+    pub blank: bool,
 }
 
 impl FieldSchema {

--- a/crates/rustango/src/migrate/ddl.rs
+++ b/crates/rustango/src/migrate/ddl.rs
@@ -360,6 +360,7 @@ mod tests {
             db_comment: None,
             verbose_name: None,
             editable: true,
+            blank: false,
         }
     }
 

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -3855,6 +3855,7 @@ mod gen_tests {
             db_comment: None,
             verbose_name: None,
             editable: true,
+            blank: false,
         }
     }
 

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -536,6 +536,7 @@ mod composite_fk_snapshot_tests {
             db_comment: None,
             verbose_name: None,
             editable: true,
+            blank: false,
         }];
         static COMPS: [CompositeFkRelation; 1] = [CompositeFkRelation {
             name: "target",
@@ -602,6 +603,7 @@ mod composite_fk_snapshot_tests {
             db_comment: None,
             verbose_name: None,
             editable: true,
+            blank: false,
         }];
         static MS: ModelSchema = ModelSchema {
             name: "Plain",

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -219,6 +219,7 @@ mod tests {
             db_comment: None,
             verbose_name: None,
             editable: true,
+            blank: false,
         },
         FieldSchema {
             name: "title",
@@ -239,6 +240,7 @@ mod tests {
             db_comment: None,
             verbose_name: None,
             editable: true,
+            blank: false,
         },
         FieldSchema {
             name: "deleted_at",
@@ -259,6 +261,7 @@ mod tests {
             db_comment: None,
             verbose_name: None,
             editable: true,
+            blank: false,
         },
     ];
 

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -1250,6 +1250,7 @@ mod tests {
                 db_comment: None,
                 verbose_name: None,
                 editable: true,
+                blank: false,
             })
             .collect();
         let leaked: &'static [crate::core::FieldSchema] = Box::leak(field_vec.into_boxed_slice());

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -635,6 +635,7 @@ mod tests {
             db_comment: None,
             verbose_name: None,
             editable: true,
+            blank: false,
         }];
         static MODEL: ModelSchema = ModelSchema {
             name: "demo",

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -3839,6 +3839,7 @@ mod tests {
                     db_comment: None,
                     verbose_name: None,
                     editable: true,
+                    blank: false,
                 },
                 crate::core::FieldSchema {
                     name: "title",
@@ -3859,6 +3860,7 @@ mod tests {
                     db_comment: None,
                     verbose_name: None,
                     editable: true,
+                    blank: false,
                 },
             ])),
             display: None,
@@ -3907,6 +3909,7 @@ mod tests {
                     db_comment: None,
                     verbose_name: None,
                     editable: true,
+                    blank: false,
                 },
                 crate::core::FieldSchema {
                     name: "title",
@@ -3927,6 +3930,7 @@ mod tests {
                     db_comment: None,
                     verbose_name: None,
                     editable: true,
+                    blank: false,
                 },
                 crate::core::FieldSchema {
                     name: "score",
@@ -3947,6 +3951,7 @@ mod tests {
                     db_comment: None,
                     verbose_name: None,
                     editable: true,
+                    blank: false,
                 },
             ])),
             display: None,
@@ -4326,6 +4331,7 @@ mod tests {
                 db_comment: None,
                 verbose_name: None,
                 editable: true,
+                blank: false,
             }])),
             display: None,
             app_label: None,
@@ -4570,6 +4576,7 @@ mod tests {
                 db_comment: None,
                 verbose_name: None,
                 editable: true,
+                blank: false,
             }])),
             display: None,
             app_label: None,
@@ -4626,6 +4633,7 @@ mod tests {
                 db_comment: None,
                 verbose_name: None,
                 editable: true,
+                blank: false,
             }])),
             display: None,
             app_label: None,
@@ -5155,6 +5163,7 @@ mod tests {
                 db_comment: None,
                 verbose_name: None,
                 editable: true,
+                blank: false,
             })) as &'static crate::core::FieldSchema
         };
         assert!(matches!(

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1534,6 +1534,7 @@ mod lookup_tests {
             db_comment: None,
             verbose_name: None,
             editable: true,
+            blank: false,
         }
     }
 
@@ -1557,6 +1558,7 @@ mod lookup_tests {
             db_comment: None,
             verbose_name: None,
             editable: true,
+            blank: false,
         }
     }
 

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -298,6 +298,7 @@ mod tests {
             db_comment: None,
             verbose_name: None,
             editable: true,
+            blank: false,
         }
     }
 
@@ -321,6 +322,7 @@ mod tests {
             db_comment: None,
             verbose_name: None,
             editable: true,
+            blank: false,
         }
     }
 
@@ -344,6 +346,7 @@ mod tests {
             db_comment: None,
             verbose_name: None,
             editable: true,
+            blank: false,
         }
     }
 
@@ -368,6 +371,7 @@ mod tests {
                 db_comment: None,
                 verbose_name: None,
                 editable: true,
+                blank: false,
             },
             FieldSchema {
                 name: "title",
@@ -388,6 +392,7 @@ mod tests {
                 db_comment: None,
                 verbose_name: None,
                 editable: true,
+                blank: false,
             },
             FieldSchema {
                 name: "author_id",
@@ -408,6 +413,7 @@ mod tests {
                 db_comment: None,
                 verbose_name: None,
                 editable: true,
+                blank: false,
             },
         ];
         // Suppress unused warnings on field helpers if we keep them.

--- a/crates/rustango/tests/field_types_decimal_binary_time.rs
+++ b/crates/rustango/tests/field_types_decimal_binary_time.rs
@@ -127,6 +127,7 @@ fn form_parser_decimal() {
         db_comment: None,
         verbose_name: None,
         editable: true,
+        blank: false,
     };
     let v = parse_form_value(&f, Some("123.45")).unwrap();
     assert!(matches!(v, SqlValue::Decimal(d) if d == Decimal::from_str("123.45").unwrap()));
@@ -158,6 +159,7 @@ fn form_parser_binary_hex() {
         db_comment: None,
         verbose_name: None,
         editable: true,
+        blank: false,
     };
     let v = parse_form_value(&f, Some("deadbeef")).unwrap();
     assert!(matches!(v, SqlValue::Binary(b) if b == vec![0xde, 0xad, 0xbe, 0xef]));
@@ -191,6 +193,7 @@ fn form_parser_time() {
         db_comment: None,
         verbose_name: None,
         editable: true,
+        blank: false,
     };
     // Full HH:MM:SS form.
     let v = parse_form_value(&f, Some("14:30:45")).unwrap();

--- a/crates/rustango/tests/macro_blank.rs
+++ b/crates/rustango/tests/macro_blank.rs
@@ -1,0 +1,85 @@
+//! `#[rustango(blank)]` field attribute (Django parity #445).
+//!
+//! Covers:
+//! - macro threads the value through to `FieldSchema::blank`
+//! - flag form (`#[rustango(blank)]`) parses as `true`
+//! - explicit form (`#[rustango(blank = true / false)]`) parses verbatim
+//! - default is `false` for un-attributed fields
+//! - DDL stays unchanged (form-layer flag, not schema-layer)
+
+use rustango::core::{FieldSchema, Model};
+use rustango::migrate::ddl::create_table_sql_with_dialect;
+use rustango::sql::Postgres;
+use rustango_macros::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "macro_empty_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+
+    /// Default — no `blank` attribute → form treats as required.
+    #[rustango(max_length = 200)]
+    pub title: String,
+
+    /// Flag form sets `blank = true`.
+    #[rustango(blank)]
+    pub subtitle: String,
+
+    /// Explicit-true form.
+    #[rustango(blank = true)]
+    pub summary: String,
+
+    /// Explicit-false: same as default.
+    #[rustango(blank = false)]
+    pub author: String,
+}
+
+fn field<'a>(name: &str) -> &'a FieldSchema {
+    Post::SCHEMA
+        .field(name)
+        .unwrap_or_else(|| panic!("no field {name:?}"))
+}
+
+#[test]
+fn schema_threads_blank_default_false() {
+    assert!(!field("id").blank, "PK defaults to blank=false");
+    assert!(!field("title").blank, "no attr → blank=false");
+    assert!(!field("author").blank, "explicit false → blank=false");
+}
+
+#[test]
+fn schema_threads_blank_flag_form() {
+    assert!(field("subtitle").blank, "flag form should set blank=true");
+}
+
+#[test]
+fn schema_threads_blank_explicit_true() {
+    assert!(
+        field("summary").blank,
+        "explicit true should set blank=true"
+    );
+}
+
+/// `blank` is a form-layer flag — must never affect the DDL. Column
+/// stays in CREATE TABLE with the same NOT NULL constraint regardless
+/// of the attribute.
+#[test]
+fn blank_does_not_change_ddl() {
+    let sql = create_table_sql_with_dialect(&Postgres, Post::SCHEMA);
+    // subtitle is NOT NULL despite `blank = true` (blank is form-only)
+    assert!(
+        sql.contains(r#""subtitle" TEXT NOT NULL"#),
+        "subtitle should still be NOT NULL in DDL, got: {sql}"
+    );
+    assert!(
+        sql.contains(r#""summary" TEXT NOT NULL"#),
+        "summary should still be NOT NULL in DDL, got: {sql}"
+    );
+    // No "blank" keyword leaks anywhere.
+    assert!(
+        !sql.to_lowercase().contains("blank"),
+        "blank keyword leaked into DDL: {sql}"
+    );
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -156,7 +156,7 @@ Field options:
 |---|---|---|---|
 | `max_length` | SHIPPED | `#[rustango(max_length = N)]` | |
 | `null=True` (DB-level nullable) | SHIPPED | `Option<T>` Rust type | |
-| `blank=True` (form-level allow empty) | PARTIAL | Form fields treat `Option<T>` as optional; no separate `blank` attribute (#445) | |
+| `blank=True` (form-level allow empty) | SHIPPED | `#[rustango(blank)]` (#445, v0.42) — admin form drops the `required` HTML attribute even on NOT NULL columns; distinct from `Option<T>` which controls SQL nullability | |
 | `default` | SHIPPED | `#[rustango(default = "expr")]` | |
 | `choices=[...]` | SHIPPED | `#[rustango(choices = "draft:Draft, published:Published")]` (#446, v0.42) — admin renders `<select>`, validator rejects off-choice values | |
 | `validators=[...]` | PARTIAL | Form-side: `validate_email`, `validate_url`, `validate_min_length`, file validators (#447) | Model-side validators on save MISSING. |


### PR DESCRIPTION
Django-parity #445. Form-layer "may be submitted empty" flag, decoupled
from SQL nullability. Closes the gap the audit flagged: the admin
previously only routed required-ness off `Option<T>` (= nullable),
conflating two distinct Django concepts.

## Syntax

```rust
#[derive(Model)]
struct Post {
    #[rustango(primary_key)] pub id: i64,
    pub title: String,                    // required in form, NOT NULL
    #[rustango(blank)]
    pub subtitle: String,                 // form accepts empty, still NOT NULL
    #[rustango(blank = true)]
    pub summary: String,                  // same as above, explicit form
}
```

## Semantics

| Flag | Controls |
|---|---|
| `nullable` (= `Option<T>`) | SQL column accepts NULL |
| `blank` | admin form accepts empty submission even when DB column is NOT NULL |

A field can be `nullable=false, blank=true`: DB requires non-NULL but
admin operator may submit `""`. Empty string is a valid non-null
value for SQL `TEXT`/`VARCHAR`, mirroring Django's CharField semantics.

## Surfaces wired

- `FieldSchema.blank: bool` (default `false`)
- `admin::render::render_input` drops the `required` HTML attribute
  when `field.blank` is true, alongside the existing nullable / Bool /
  auto / primary_key exemptions.

## Tests

`crates/rustango/tests/macro_blank.rs` — 4 cases:
- Default → `blank=false`
- Flag form (`#[rustango(blank)]`) → `blank=true`
- Explicit-true form → `blank=true`
- `blank` does NOT affect the DDL (column stays NOT NULL)

`admin::render::tests` — 2 cases:
- NOT NULL + `blank=true` drops the `required` attribute
- NOT NULL + `blank=false` keeps the `required` attribute

CI: `macro_blank` wired into the `sqlite_litmus` job.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — passes
- [x] `cargo test --workspace --all-features --no-run` — compiles
- [x] `cargo test -p rustango --lib --no-default-features --features sqlite,tenancy` — 1440 passed
- [x] `cargo test -p rustango --lib --all-features` — 2345 passed
- [x] `cargo test -p rustango --test macro_blank` — 4/4 passed
- [ ] CI green (multi-job)

Closes #445.