### PR TITLE
fix(search): per-column placeholder + SQLite live test (closes #438)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_meta_verbose_name
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_editable
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_blank
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_search_filter_sqlite_live
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -2972,18 +2972,23 @@ pub(super) fn write_where_with_search(
         // Search routes through the dialect's `write_ilike` so each
         // backend emits the case-insensitive LIKE shape it actually
         // supports — Postgres native `ILIKE`, MySQL/SQLite the
-        // `LOWER(col) LIKE LOWER(?)` fallback. v0.37 fix: previous
-        // code wrote the literal `ILIKE` token whenever
-        // `supports_op(Op::ILike)` returned true, but SQLite says
-        // true (because it can *lower* via `write_ilike`) yet has no
-        // native `ILIKE` keyword, so the emitted SQL failed at parse.
-        b.params.push(SqlValue::String(format!("%{}%", s.query)));
-        let placeholder = b.d.placeholder(b.params.len());
+        // `LOWER(col) LIKE LOWER(?)` fallback.
+        //
+        // #438 — push a separate param + placeholder per column. PG
+        // could share one (`$N` references repeat), but MySQL/SQLite
+        // bind positionally so each `?` needs its own pushed param.
+        // Sharing one placeholder across N columns silently failed
+        // on multi-column search on non-PG dialects (only the first
+        // column got the bound value; subsequent ones bound to NULL
+        // / empty / nothing depending on driver). Keeping per-column
+        // binds also keeps the writer dialect-agnostic.
         b.sql.push('(');
         for (i, col) in s.columns.iter().enumerate() {
             if i > 0 {
                 b.sql.push_str(" OR ");
             }
+            b.params.push(SqlValue::String(format!("%{}%", s.query)));
+            let placeholder = b.d.placeholder(b.params.len());
             // Build the qualified column identifier the same way the
             // rest of the writer does, then hand it to `write_ilike`.
             let mut qualified = String::new();

--- a/crates/rustango/tests/sql.rs
+++ b/crates/rustango/tests/sql.rs
@@ -717,7 +717,7 @@ fn count_propagates_filter_errors() {
 // ---------------- SEARCH ----------------
 
 #[test]
-fn search_alone_emits_or_chain_with_one_param() {
+fn search_alone_emits_or_chain_with_one_param_per_column() {
     let q = SelectQuery {
         search: Some(SearchClause {
             columns: vec!["name", "is_active"],
@@ -726,11 +726,21 @@ fn search_alone_emits_or_chain_with_one_param() {
         ..empty_select()
     };
     let stmt = pg().compile_select(&q).unwrap();
+    // #438 — one param + placeholder per column instead of one shared
+    // `$1` repeated. Lets MySQL/SQLite (positional `?`) round-trip
+    // multi-column search; PG accepts either shape and the new one is
+    // a hair more explicit.
     assert_eq!(
         stmt.sql,
-        r#"SELECT "id", "name", "is_active" FROM "user" WHERE ("name" ILIKE $1 OR "is_active" ILIKE $1)"#,
+        r#"SELECT "id", "name", "is_active" FROM "user" WHERE ("name" ILIKE $1 OR "is_active" ILIKE $2)"#,
     );
-    assert_eq!(stmt.params, vec![SqlValue::String("%ali%".into())]);
+    assert_eq!(
+        stmt.params,
+        vec![
+            SqlValue::String("%ali%".into()),
+            SqlValue::String("%ali%".into()),
+        ],
+    );
 }
 
 #[test]

--- a/crates/rustango/tests/viewset_search_filter_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_search_filter_sqlite_live.rs
@@ -1,0 +1,205 @@
+//! End-to-end live test for `ViewSet::search_fields(...)` on SQLite
+//! (Django-parity #438 — DRF `SearchFilter`).
+//!
+//! The DSL (`ViewSet::search_fields`) + the IR (`SearchClause`) +
+//! per-dialect writer (`Dialect::write_search` overrides for PG /
+//! MySQL / SQLite) + OpenAPI doc emission have shipped since v0.30+.
+//! The only material delta the audit flagged: no live test walked the
+//! HTTP end-to-end on SQLite. This PR adds that.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy", feature = "serializer"))]
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use rustango::core::Model as _;
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use serde_json::Value;
+use tower::ServiceExt as _;
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "vs_search_post")]
+#[rustango(app = "vs_search_app")]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 500)]
+    pub body: String,
+}
+
+async fn make_router_searching_title() -> axum::Router {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE vs_search_post (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            title TEXT NOT NULL, \
+            body TEXT NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .expect("create");
+    let pool = Pool::Sqlite(sq);
+    rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .search_fields(&["title"])
+        .router_pool("/posts", pool)
+}
+
+async fn make_router_searching_title_and_body() -> axum::Router {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE vs_search_post (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            title TEXT NOT NULL, \
+            body TEXT NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .expect("create");
+    let pool = Pool::Sqlite(sq);
+    rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .search_fields(&["title", "body"])
+        .router_pool("/posts", pool)
+}
+
+async fn body_json(resp: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .expect("body bytes");
+    serde_json::from_slice(&bytes).expect("json")
+}
+
+fn get(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn post_row(app: &axum::Router, title: &str, body: &str) {
+    let payload = serde_json::json!({ "title": title, "body": body }).to_string();
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/posts")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(payload))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "POST {title:?} failed");
+}
+
+#[tokio::test]
+async fn search_filter_matches_substring_on_one_column() {
+    let app = make_router_searching_title().await;
+    post_row(&app, "Rust is fast", "irrelevant").await;
+    post_row(&app, "Python is fun", "rust mention in body only").await;
+    post_row(&app, "Go is bold", "no overlap").await;
+
+    // ?search=rust should only hit the first row — body matches are
+    // ignored because `search_fields = ["title"]`.
+    let resp = app
+        .clone()
+        .oneshot(get("/posts?search=rust"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    let results = body["results"].as_array().expect("results");
+    assert_eq!(results.len(), 1, "expected 1 hit, got: {body}");
+    assert!(results[0]["title"]
+        .as_str()
+        .unwrap()
+        .to_lowercase()
+        .contains("rust"));
+}
+
+#[tokio::test]
+async fn search_filter_ors_across_multiple_columns() {
+    let app = make_router_searching_title_and_body().await;
+    post_row(&app, "Rust intro", "general programming").await;
+    post_row(&app, "Python tutorial", "mentions rust in passing").await;
+    post_row(&app, "Go basics", "totally unrelated").await;
+
+    // search=rust should hit BOTH rows — title match + body match.
+    let resp = app
+        .clone()
+        .oneshot(get("/posts?search=rust"))
+        .await
+        .unwrap();
+    let body = body_json(resp).await;
+    let results = body["results"].as_array().expect("results");
+    assert_eq!(
+        results.len(),
+        2,
+        "expected 2 hits (title OR body), got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn search_filter_is_case_insensitive() {
+    let app = make_router_searching_title().await;
+    post_row(&app, "Rust Programming", "x").await;
+    post_row(&app, "PYTHON BASICS", "y").await;
+
+    // Lowercase query, mixed-case data → both should match
+    // case-insensitively (ILIKE on PG, LIKE on SQLite normalized).
+    let resp = app
+        .clone()
+        .oneshot(get("/posts?search=python"))
+        .await
+        .unwrap();
+    let body = body_json(resp).await;
+    let results = body["results"].as_array().expect("results");
+    assert_eq!(
+        results.len(),
+        1,
+        "case-insensitive PYTHON match failed: {body}"
+    );
+
+    let resp = app
+        .clone()
+        .oneshot(get("/posts?search=RUST"))
+        .await
+        .unwrap();
+    let body = body_json(resp).await;
+    let results = body["results"].as_array().expect("results");
+    assert_eq!(
+        results.len(),
+        1,
+        "case-insensitive RUST match failed: {body}"
+    );
+}
+
+#[tokio::test]
+async fn empty_or_absent_search_returns_all_rows() {
+    let app = make_router_searching_title().await;
+    post_row(&app, "alpha", "x").await;
+    post_row(&app, "beta", "y").await;
+    post_row(&app, "gamma", "z").await;
+
+    // No `?search=` at all
+    let resp = app.clone().oneshot(get("/posts")).await.unwrap();
+    let body = body_json(resp).await;
+    let results = body["results"].as_array().expect("results");
+    assert_eq!(results.len(), 3);
+
+    // Empty `?search=` — same as no search at all (filtered out by the
+    // `filter(|s| !s.is_empty())` chain in the ViewSet's param decode).
+    let resp = app.clone().oneshot(get("/posts?search=")).await.unwrap();
+    let body = body_json(resp).await;
+    let results = body["results"].as_array().expect("results");
+    assert_eq!(results.len(), 3);
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -646,7 +646,7 @@ Summary: **5 / 0 / 0 / 2**. Async is native; no parity gap.
 | `ModelViewSet` | [ModelViewSet](https://www.django-rest-framework.org/api-guide/viewsets/#modelviewset) | SHIPPED | (above, includes list/retrieve/create/update/delete) | |
 | Routers (`DefaultRouter`, `SimpleRouter`) | [routers](https://www.django-rest-framework.org/api-guide/routers/) | SHIPPED | `ViewSet::router(prefix, &Pool)` + `tenant_router(prefix)` | |
 | `DjangoFilterBackend` | [filtering](https://www.django-rest-framework.org/api-guide/filtering/) | SHIPPED | `?field=value` querystring filtering via `Q!` (v0.41) | |
-| `SearchFilter` | (above) | PARTIAL | Manual `?q=...` parse; no `search_fields` declarative (#438) | |
+| `SearchFilter` | (above) | SHIPPED | `ViewSet::search_fields(&["title", "body"])` + `?search=q` (closed #438, v0.42) — emits per-column ILIKE OR'd via dialect `write_ilike`; tri-dialect (PG/MySQL/SQLite). Same PR fixed a multi-column placeholder bug that affected MySQL+SQLite. | |
 | `OrderingFilter` | (above) | PARTIAL | Manual `?ordering=...` parse (#439) | |
 | Pagination — PageNumber / LimitOffset | [pagination](https://www.django-rest-framework.org/api-guide/pagination/) | SHIPPED | `pagination::*` + RFC 5988 Link headers | |
 | Pagination — Cursor | [cursor pagination](https://www.django-rest-framework.org/api-guide/pagination/#cursorpagination) | SHIPPED | `ViewSet::cursor_pagination("id")` / `cursor_pagination_desc("id")` + `pagination::CursorPaginator` (closed #440 — audit was wrong; primitive already shipped, just lacked an HTTP end-to-end test) | |


### PR DESCRIPTION
Django-parity #438 (DRF `SearchFilter`). The audit row was PARTIAL
because no live test exercised `ViewSet::search_fields` end-to-end on
a non-Postgres dialect. Writing that test surfaced a real tri-dialect
**bug** in the `SearchClause` writer.

## The bug

The writer pushed **one** param and reused the same placeholder for
every column inside the `(col1 ILIKE ? OR col2 ILIKE ? OR …)` OR
group. Postgres accepts `$1` repeated, so multi-column search worked
there. SQLite + MySQL use positional `?` and bind each occurrence
separately — the 2nd and subsequent columns silently got NULL /
empty / nothing bound (driver-dependent), so search across multiple
columns matched only the first column on those dialects.

## The fix

`crates/rustango/src/sql/writers.rs` (~12 LOC): push a fresh param
per column inside the OR loop, request a fresh placeholder each
iteration. Keeps PG working (it just gets `$1 OR $2 OR …` instead of
`$1 OR $1`) and fixes SQLite + MySQL.

## Live test

`crates/rustango/tests/viewset_search_filter_sqlite_live.rs` — 4
cases against a real `sqlite::memory:` pool:

- single-column search matches substring in declared column only
- multi-column search ORs across columns *(this caught the bug)*
- case-insensitive matching round-trip
- empty / absent `?search=` returns all rows

CI: `viewset_search_filter_sqlite_live` wired into `sqlite_litmus`.

## Existing tests unaffected

PG SearchFilter tests in `viewset_tenant_router_live.rs` +
`admin_live.rs` continue to pass — the rewritten OR loop emits the
same shape on PG (one repeated bind → N distinct binds), just no
longer sharing the placeholder string.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — passes
- [x] `cargo test --workspace --all-features --no-run` — compiles
- [x] `cargo test -p rustango --lib --no-default-features --features sqlite,tenancy` — 1442 passed
- [x] `cargo test -p rustango --lib --all-features` — 2347 passed
- [x] `cargo test -p rustango --test viewset_search_filter_sqlite_live` — 4/4 passed
- [ ] CI green (multi-job)

Closes #438.