### PR TITLE
feat(viewset): `ordering_fields` whitelist + SQLite live test (closes #439)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_editable
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_blank
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_search_filter_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_ordering_filter_sqlite_live
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -184,6 +184,11 @@ pub struct ViewSet {
     fields: Option<Vec<String>>,
     filter_fields: Vec<String>,
     search_fields: Vec<String>,
+    /// DRF `ordering_fields` whitelist — when non-empty, only the
+    /// listed fields are honored via `?ordering=`. Unknown names get
+    /// silently dropped. When empty (the default), any field on the
+    /// schema is sortable — the v0.30 behavior. Issue #439.
+    ordering_fields: Vec<String>,
     default_page_size: usize,
     default_ordering: Vec<(String, bool)>,
     perms: ViewSetPerms,
@@ -204,6 +209,7 @@ impl ViewSet {
             fields: None,
             filter_fields: Vec::new(),
             search_fields: Vec::new(),
+            ordering_fields: Vec::new(),
             default_page_size: 20,
             default_ordering: Vec::new(),
             perms: ViewSetPerms::default(),
@@ -292,6 +298,16 @@ impl ViewSet {
     /// Fields searched by the `?search=` query param.
     pub fn search_fields(mut self, fields: &[&str]) -> Self {
         self.search_fields = fields.iter().map(|&s| s.to_owned()).collect();
+        self
+    }
+
+    /// DRF `ordering_fields` whitelist — when set, only the listed
+    /// field names are honored via `?ordering=`. Unknown names are
+    /// silently dropped so a hostile client can't sort on a sensitive
+    /// column. When unset (the default), any schema field is sortable.
+    /// Issue #439.
+    pub fn ordering_fields(mut self, fields: &[&str]) -> Self {
+        self.ordering_fields = fields.iter().map(|&s| s.to_owned()).collect();
         self
     }
 
@@ -853,7 +869,12 @@ async fn handle_list(
             .collect(),
     });
 
-    // Ordering
+    // Ordering — #439 honors the DRF `ordering_fields` whitelist when
+    // set: only listed field names are sortable via `?ordering=`. An
+    // empty whitelist (the default) keeps the v0.30 behavior of
+    // allowing any schema field. Unknown / off-whitelist names are
+    // silently dropped (mirrors DRF's defensive default — a hostile
+    // client can't sort on `password_hash` just because it's a column).
     let ordering_param = params.get("ordering").cloned();
     let order_by: Vec<crate::core::OrderItem> = ordering_param
         .as_deref()
@@ -866,6 +887,11 @@ async fn handle_list(
                     } else {
                         (part, false)
                     };
+                    if !state.vs.ordering_fields.is_empty()
+                        && !state.vs.ordering_fields.iter().any(|f| f == field_name)
+                    {
+                        return None;
+                    }
                     state
                         .vs
                         .schema

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -175,13 +175,22 @@ impl ViewSet {
                 )),
             );
         }
-        // Ordering (only when default_ordering is configured — otherwise sort
-        // is always default and irrelevant).
-        if !self.default_ordering.is_empty() {
-            out.push(
-                Parameter::query("ordering", Schema::string())
-                    .description("Comma-separated field names; prefix `-` for DESC"),
-            );
+        // Ordering — surface the `?ordering=` parameter when EITHER a
+        // default ordering is configured OR an explicit
+        // `ordering_fields` whitelist is set (#439). The description
+        // enumerates the allowed fields when a whitelist is in play
+        // so clients can discover the API surface without reading code.
+        if !self.default_ordering.is_empty() || !self.ordering_fields.is_empty() {
+            let description = if self.ordering_fields.is_empty() {
+                "Comma-separated field names; prefix `-` for DESC".to_owned()
+            } else {
+                format!(
+                    "Comma-separated field names from: {}. Prefix `-` for DESC. \
+                     Unknown / off-whitelist names are silently dropped.",
+                    self.ordering_fields.join(", "),
+                )
+            };
+            out.push(Parameter::query("ordering", Schema::string()).description(description));
         }
         // One filter param per filter_field. We don't enumerate all the
         // Django-style lookups individually — the description tells the

--- a/crates/rustango/tests/viewset_ordering_filter_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_ordering_filter_sqlite_live.rs
@@ -1,0 +1,229 @@
+//! End-to-end live test for `ViewSet::ordering` + new
+//! `ordering_fields(...)` whitelist on SQLite (Django-parity #439 —
+//! DRF `OrderingFilter`).
+//!
+//! The DSL (`ViewSet::ordering` for the default sort) + the `?ordering=`
+//! query-param parse have shipped since v0.30. This PR closed the
+//! remaining DRF gap: the `ordering_fields` whitelist that limits which
+//! columns clients can sort by. Live tests cover both the new
+//! whitelist enforcement and the previously-untested asc/desc query
+//! parsing on a non-PG dialect.
+//!
+//! Covers:
+//! - default ordering (from `.ordering(...)`) applies when no
+//!   `?ordering=` is supplied
+//! - explicit `?ordering=field` overrides the default (ASC)
+//! - `?ordering=-field` flips to DESC via the `-` prefix
+//! - comma-separated multi-field ordering chains correctly
+//! - `ordering_fields` whitelist silently drops off-list field names
+//!   (mirrors DRF's defensive default for unknown columns)
+
+#![cfg(all(feature = "sqlite", feature = "tenancy", feature = "serializer"))]
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use rustango::core::Model as _;
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use serde_json::Value;
+use tower::ServiceExt as _;
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "vs_order_post")]
+#[rustango(app = "vs_order_app")]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub rating: i32,
+    /// Imagine this is a sensitive column we don't want clients
+    /// sorting on — used to exercise the whitelist drop.
+    #[rustango(max_length = 200)]
+    pub secret_score: String,
+}
+
+async fn fresh_pool() -> Pool {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE vs_order_post (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            title TEXT NOT NULL, \
+            rating INTEGER NOT NULL, \
+            secret_score TEXT NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .expect("create");
+    Pool::Sqlite(sq)
+}
+
+async fn body_json(resp: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .expect("body bytes");
+    serde_json::from_slice(&bytes).expect("json")
+}
+
+fn get(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn post_row(app: &axum::Router, title: &str, rating: i32) {
+    let payload =
+        serde_json::json!({ "title": title, "rating": rating, "secret_score": "x" }).to_string();
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/posts")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(payload))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "POST {title:?} failed");
+}
+
+fn ids(body: &Value) -> Vec<i64> {
+    body["results"]
+        .as_array()
+        .expect("results")
+        .iter()
+        .map(|r| r["id"].as_i64().expect("id i64"))
+        .collect()
+}
+
+#[tokio::test]
+async fn default_ordering_applies_when_no_query_param() {
+    let pool = fresh_pool().await;
+    let app = rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .ordering(&[("rating", true)])
+        .router_pool("/posts", pool);
+
+    post_row(&app, "a", 3).await; // id 1
+    post_row(&app, "b", 1).await; // id 2
+    post_row(&app, "c", 2).await; // id 3
+
+    // Default ordering = rating DESC → 1(=3), 3(=2), 2(=1).
+    let resp = app.clone().oneshot(get("/posts")).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(ids(&body), vec![1, 3, 2]);
+}
+
+#[tokio::test]
+async fn explicit_ordering_overrides_default_and_handles_desc_prefix() {
+    let pool = fresh_pool().await;
+    let app = rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .ordering(&[("rating", true)]) // default DESC on rating
+        .router_pool("/posts", pool);
+
+    post_row(&app, "a", 3).await; // id 1
+    post_row(&app, "b", 1).await; // id 2
+    post_row(&app, "c", 2).await; // id 3
+
+    // `?ordering=rating` (ASC) flips the default.
+    let body = body_json(
+        app.clone()
+            .oneshot(get("/posts?ordering=rating"))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(ids(&body), vec![2, 3, 1]);
+
+    // `?ordering=-rating` mirrors the default.
+    let body = body_json(
+        app.clone()
+            .oneshot(get("/posts?ordering=-rating"))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(ids(&body), vec![1, 3, 2]);
+}
+
+#[tokio::test]
+async fn comma_separated_multi_field_ordering() {
+    let pool = fresh_pool().await;
+    let app = rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .router_pool("/posts", pool);
+
+    // Same rating, different titles
+    post_row(&app, "charlie", 1).await; // id 1
+    post_row(&app, "alpha", 1).await; // id 2
+    post_row(&app, "bravo", 2).await; // id 3
+
+    // ORDER BY rating ASC, title ASC → rating=1 first (alpha, charlie),
+    // then rating=2 (bravo).
+    let body = body_json(
+        app.clone()
+            .oneshot(get("/posts?ordering=rating,title"))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(ids(&body), vec![2, 1, 3]);
+}
+
+#[tokio::test]
+async fn ordering_fields_whitelist_drops_off_list_names() {
+    let pool = fresh_pool().await;
+    let app = rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .ordering(&[("id", false)])
+        .ordering_fields(&["title", "rating"]) // `secret_score` NOT whitelisted
+        .router_pool("/posts", pool);
+
+    post_row(&app, "a", 3).await; // id 1
+    post_row(&app, "b", 1).await; // id 2
+    post_row(&app, "c", 2).await; // id 3
+
+    // Attempt to sort by `secret_score` — silently dropped (the
+    // resulting ORDER BY list is empty, so default ordering kicks in
+    // would NOT happen because `?ordering=` was supplied; the rows
+    // come back in implementation order, which sqlite returns by
+    // insert order for our case). We assert that the row count + ids
+    // are still correct (the request didn't 4xx) and that ANY
+    // explicit order on a whitelisted field still works:
+    let body = body_json(
+        app.clone()
+            .oneshot(get("/posts?ordering=secret_score"))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(body["results"].as_array().expect("results").len(), 3);
+
+    // Whitelisted column still works.
+    let body = body_json(
+        app.clone()
+            .oneshot(get("/posts?ordering=-rating"))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(ids(&body), vec![1, 3, 2]);
+
+    // Mixed valid + invalid — valid one is honored, invalid silently dropped.
+    let body = body_json(
+        app.clone()
+            .oneshot(get("/posts?ordering=secret_score,rating"))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(ids(&body), vec![2, 3, 1]); // rating ASC
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -647,7 +647,7 @@ Summary: **5 / 0 / 0 / 2**. Async is native; no parity gap.
 | Routers (`DefaultRouter`, `SimpleRouter`) | [routers](https://www.django-rest-framework.org/api-guide/routers/) | SHIPPED | `ViewSet::router(prefix, &Pool)` + `tenant_router(prefix)` | |
 | `DjangoFilterBackend` | [filtering](https://www.django-rest-framework.org/api-guide/filtering/) | SHIPPED | `?field=value` querystring filtering via `Q!` (v0.41) | |
 | `SearchFilter` | (above) | SHIPPED | `ViewSet::search_fields(&["title", "body"])` + `?search=q` (closed #438, v0.42) — emits per-column ILIKE OR'd via dialect `write_ilike`; tri-dialect (PG/MySQL/SQLite). Same PR fixed a multi-column placeholder bug that affected MySQL+SQLite. | |
-| `OrderingFilter` | (above) | PARTIAL | Manual `?ordering=...` parse (#439) | |
+| `OrderingFilter` | (above) | SHIPPED | `ViewSet::ordering(&[(...,desc)])` default + `ordering_fields(&[...])` whitelist + `?ordering=field,-other` query parse (#439, v0.42). Whitelist silently drops off-list names so clients can't sort by sensitive columns. | |
 | Pagination — PageNumber / LimitOffset | [pagination](https://www.django-rest-framework.org/api-guide/pagination/) | SHIPPED | `pagination::*` + RFC 5988 Link headers | |
 | Pagination — Cursor | [cursor pagination](https://www.django-rest-framework.org/api-guide/pagination/#cursorpagination) | SHIPPED | `ViewSet::cursor_pagination("id")` / `cursor_pagination_desc("id")` + `pagination::CursorPaginator` (closed #440 — audit was wrong; primitive already shipped, just lacked an HTTP end-to-end test) | |
 | Throttling (Anon / User / Scoped) | [throttling](https://www.django-rest-framework.org/api-guide/throttling/) | SHIPPED | `rate_limit::*` (per-IP / per-user) | |


### PR DESCRIPTION
Django-parity #439 (DRF `OrderingFilter`). Adds the DRF
`ordering_fields` whitelist that limits which columns clients can
sort via `?ordering=`. Closes the audit's PARTIAL row: `?ordering=`
parsing already worked, but a hostile client could sort by any
schema column (including ones like `password_hash` that should be
opaque).

## API

```rust
ViewSet::for_model(Post::SCHEMA)
    .ordering(&[("rating", true)])           // default sort
    .ordering_fields(&["title", "rating"])   // whitelist; #439
    .router_pool("/posts", pool);
```

When `ordering_fields` is empty (the v0.30 default) any schema field
is sortable. When set, off-whitelist field names are silently dropped
mid-parse — matches DRF's defensive default. The valid parts of a
mixed-quality input (e.g. `?ordering=password_hash,rating`) are still
honored.

## OpenAPI doc

- `?ordering=` parameter now surfaces whenever EITHER a default
  ordering or an explicit `ordering_fields` whitelist is set
  (previously: only when default ordering was set).
- Description enumerates the whitelist when in play so API consumers
  can discover the allowed fields without reading code.

## Live test

`crates/rustango/tests/viewset_ordering_filter_sqlite_live.rs` — 4
cases against a real `sqlite::memory:` pool:

- Default ordering applies when no `?ordering=`
- Explicit `?ordering=` overrides default; `-` prefix flips to DESC
- Comma-separated multi-field ordering chains correctly
- `ordering_fields` whitelist silently drops off-list names; valid
  parts of a mixed input are still honored

CI: `viewset_ordering_filter_sqlite_live` wired into `sqlite_litmus`.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — passes
- [x] `cargo test -p rustango --lib --no-default-features --features sqlite,tenancy` — 1442 passed
- [x] `cargo test -p rustango --lib --all-features` — 2347 passed
- [x] `cargo test -p rustango --test viewset_ordering_filter_sqlite_live` — 4/4 passed
- [ ] CI green (multi-job)

Closes #439.