### PR TITLE
feat(test_assertions): `assert_num_queries` + `QueryCounter` (closes #431)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_blank
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_search_filter_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_ordering_filter_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test assert_num_queries_sqlite_live
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/sql/executor.rs
+++ b/crates/rustango/src/sql/executor.rs
@@ -715,6 +715,7 @@ pub async fn select_rows_as_json(
     query: &SelectQuery,
     fields: &[&'static crate::core::FieldSchema],
 ) -> Result<Vec<serde_json::Value>, ExecError> {
+    crate::test_assertions::query_counter::bump();
     let stmt = pool.dialect().compile_select(query)?;
     match pool {
         #[cfg(feature = "postgres")]
@@ -863,6 +864,7 @@ pub async fn select_one_row_as_json(
     query: &SelectQuery,
     fields: &[&'static crate::core::FieldSchema],
 ) -> Result<Option<serde_json::Value>, ExecError> {
+    crate::test_assertions::query_counter::bump();
     let stmt = pool.dialect().compile_select(query)?;
     match pool {
         #[cfg(feature = "postgres")]
@@ -2253,6 +2255,7 @@ pub async fn insert_returning_pool(
     pool: &Pool,
     query: &InsertQuery,
 ) -> Result<InsertReturningPool, ExecError> {
+    crate::test_assertions::query_counter::bump();
     query.validate()?;
     if query.returning.is_empty() {
         return Err(ExecError::EmptyReturning);
@@ -2424,6 +2427,9 @@ pub async fn raw_execute_pool(
 /// Execute a parameterized statement that doesn't return rows. Used
 /// by every non-`FromRow` `_pool` function.
 async fn execute_pool(pool: &Pool, sql: &str, binds: Vec<SqlValue>) -> Result<u64, ExecError> {
+    // #431 — bump the per-task query counter when an `assert_num_queries`
+    // scope is active. No-op in production (try_with returns Err).
+    crate::test_assertions::query_counter::bump();
     match pool {
         #[cfg(feature = "postgres")]
         Pool::Postgres(pg) => {
@@ -2934,6 +2940,7 @@ pub async fn select_one_row_pool<T>(
 where
     T: MaybePgFromRow + MaybeMyFromRow + MaybeSqliteFromRow + Send + Unpin,
 {
+    crate::test_assertions::query_counter::bump();
     let stmt = pool.dialect().compile_select(query)?;
     match pool {
         #[cfg(feature = "postgres")]
@@ -3858,6 +3865,7 @@ where
         + Send
         + Unpin,
 {
+    crate::test_assertions::query_counter::bump();
     let stmt = pool.dialect().compile_select(query)?;
     let aliases: Vec<&'static str> = query.joins.iter().map(|j| j.alias).collect();
 

--- a/crates/rustango/src/test_assertions.rs
+++ b/crates/rustango/src/test_assertions.rs
@@ -77,6 +77,9 @@ use axum::body::to_bytes;
 use axum::http::header;
 use axum::response::Response;
 
+pub mod query_counter;
+pub use query_counter::{assert_num_queries, QueryCounter};
+
 /// Maximum bytes consumed from a response body for inspection.
 /// 1 MiB is far above any reasonable test payload; gives a clean
 /// error if a streamed body would otherwise hang the test.

--- a/crates/rustango/src/test_assertions/query_counter.rs
+++ b/crates/rustango/src/test_assertions/query_counter.rs
@@ -1,0 +1,238 @@
+//! Django-shape `assertNumQueries` — count SQL queries executed inside
+//! a scoped async block, then assert the count matches an expectation.
+//! Django-parity #431.
+//!
+//! ## Quick start
+//!
+//! ```ignore
+//! use rustango::test_assertions::assert_num_queries;
+//!
+//! #[tokio::test]
+//! async fn list_view_uses_exactly_two_queries() {
+//!     let pool = make_pool().await;
+//!     assert_num_queries(2, async {
+//!         // 1: SELECT count(*) FROM posts (for pagination)
+//!         // 2: SELECT * FROM posts LIMIT 20
+//!         my_list_handler(&pool).await;
+//!     })
+//!     .await;
+//! }
+//! ```
+//!
+//! ## Scoped guard form
+//!
+//! For more control (multiple intermediate checks, custom messages),
+//! use [`QueryCounter`] directly:
+//!
+//! ```ignore
+//! use rustango::test_assertions::QueryCounter;
+//!
+//! QueryCounter::scope(async {
+//!     read_some_data().await;
+//!     assert_eq!(QueryCounter::current(), 1);
+//!     write_some_data().await;
+//!     assert_eq!(QueryCounter::current(), 2);
+//! })
+//! .await;
+//! ```
+//!
+//! ## Semantics
+//!
+//! The counter is **per-task** via [`tokio::task_local!`] — calls from
+//! tasks outside an active scope are no-ops, so production code paths
+//! pay zero cost. Spawning a new task inside the scope does NOT
+//! inherit the counter unless you propagate it manually (tokio
+//! task-locals don't cross `spawn` boundaries).
+//!
+//! ## What gets counted
+//!
+//! Every `_pool` entry point in [`crate::sql`] that hits a real query:
+//!
+//! - `raw_execute_pool` — fall-through raw SQL
+//! - `select_rows_as_json` / `select_one_row_as_json` — JSON-bridge reads
+//! - `select_rows_pool_with_related` / `select_one_row_pool` — typed reads
+//! - `insert_pool` / `update_pool` / `delete_pool` — single-row writes
+//!
+//! Each call increments by 1 regardless of how many rows the query
+//! returns — mirroring Django's `assertNumQueries` (one SQL statement
+//! = one count, even if it returns thousands of rows).
+
+use std::cell::Cell;
+use std::future::Future;
+
+tokio::task_local! {
+    /// Per-task SQL query counter. `None`-equivalent (the `try_with`
+    /// returns `Err`) outside an active scope, which is the production
+    /// path — every `_pool` call's `bump()` is a no-op.
+    static COUNTER: Cell<usize>;
+}
+
+/// Bump the per-task query counter by 1. No-op when called outside an
+/// active [`assert_num_queries`] or [`QueryCounter::scope`] block, so
+/// production code paths pay zero runtime cost.
+///
+/// Called by every `_pool` entry point in [`crate::sql::executor`].
+pub(crate) fn bump() {
+    let _ = COUNTER.try_with(|c| c.set(c.get() + 1));
+}
+
+/// Scoped query counter. See module docs for the chained API
+/// (`scope` / `current` / `take`).
+pub struct QueryCounter;
+
+impl QueryCounter {
+    /// Run `fut` inside a fresh counter scope. Inside the scope, every
+    /// `_pool` query increments the counter; [`Self::current`] reads
+    /// it. The counter is dropped when the future returns.
+    ///
+    /// Use this when you want intermediate counts during the scope.
+    /// For the simple "assert N total at the end" case use the
+    /// top-level [`assert_num_queries`] helper.
+    pub async fn scope<F: Future>(fut: F) -> F::Output {
+        COUNTER.scope(Cell::new(0), fut).await
+    }
+
+    /// Read the current count inside an active scope. Panics if
+    /// called outside [`Self::scope`] / [`assert_num_queries`] — the
+    /// caller should only invoke it inside a guarded block.
+    #[must_use]
+    pub fn current() -> usize {
+        COUNTER
+            .try_with(Cell::get)
+            .expect("QueryCounter::current() called outside an active scope")
+    }
+
+    /// Read the count and reset to 0 atomically. Useful when one test
+    /// runs multiple unrelated operations and wants to count each
+    /// segment independently.
+    pub fn take() -> usize {
+        COUNTER
+            .try_with(|c| {
+                let n = c.get();
+                c.set(0);
+                n
+            })
+            .expect("QueryCounter::take() called outside an active scope")
+    }
+}
+
+/// Run `fut` and assert that exactly `expected` SQL queries executed
+/// during it. Panics on mismatch with a Django-shape message.
+///
+/// Returns the future's output so callers can chain assertions on the
+/// produced value the same way Django's `assertNumQueries` returns a
+/// context manager that captures the wrapped code's return value.
+///
+/// # Panics
+/// When the observed count differs from `expected`.
+pub async fn assert_num_queries<F: Future>(expected: usize, fut: F) -> F::Output {
+    QueryCounter::scope(async move {
+        let result = fut.await;
+        let actual = QueryCounter::current();
+        assert_eq!(
+            actual, expected,
+            "assertNumQueries failed: expected {expected} queries, observed {actual}"
+        );
+        result
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn bump_outside_scope_is_no_op() {
+        // Calling bump() outside any scope must not panic.
+        bump();
+        bump();
+        bump();
+        // No way to observe — just confirming the no-op path.
+    }
+
+    #[tokio::test]
+    async fn assert_num_queries_passes_on_exact_count() {
+        assert_num_queries(3, async {
+            bump();
+            bump();
+            bump();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn assert_num_queries_passes_on_zero_when_no_queries() {
+        assert_num_queries(0, async {
+            // No SQL — count stays 0.
+            let _ = 1 + 1;
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "assertNumQueries failed: expected 2 queries, observed 3")]
+    async fn assert_num_queries_panics_with_count_in_message() {
+        assert_num_queries(2, async {
+            bump();
+            bump();
+            bump();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn returns_inner_future_output() {
+        let value = assert_num_queries(1, async {
+            bump();
+            42
+        })
+        .await;
+        assert_eq!(value, 42);
+    }
+
+    #[tokio::test]
+    async fn current_reads_running_count_mid_scope() {
+        QueryCounter::scope(async {
+            assert_eq!(QueryCounter::current(), 0);
+            bump();
+            assert_eq!(QueryCounter::current(), 1);
+            bump();
+            bump();
+            assert_eq!(QueryCounter::current(), 3);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn take_resets_counter_atomically() {
+        QueryCounter::scope(async {
+            bump();
+            bump();
+            assert_eq!(QueryCounter::take(), 2);
+            assert_eq!(QueryCounter::current(), 0);
+            bump();
+            assert_eq!(QueryCounter::take(), 1);
+            assert_eq!(QueryCounter::current(), 0);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn parallel_scopes_count_independently() {
+        // Two simultaneous scopes do NOT see each other's bumps.
+        let (a, b) = tokio::join!(
+            assert_num_queries(2, async {
+                bump();
+                bump();
+            }),
+            assert_num_queries(5, async {
+                for _ in 0..5 {
+                    bump();
+                }
+            }),
+        );
+        assert_eq!(a, ());
+        assert_eq!(b, ());
+    }
+}

--- a/crates/rustango/tests/assert_num_queries_sqlite_live.rs
+++ b/crates/rustango/tests/assert_num_queries_sqlite_live.rs
@@ -1,0 +1,171 @@
+//! End-to-end live test for `assert_num_queries` against a real
+//! SQLite pool (Django-parity #431). Verifies the per-task counter
+//! actually fires from every instrumented `_pool` entry point in
+//! [`rustango::sql`].
+//!
+//! The unit tests (`test_assertions::query_counter::tests`) cover the
+//! counter mechanics; this file proves the integration with real SQL
+//! execution paths.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+
+use rustango::core::{Column as _, Model as _};
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
+use rustango::test_assertions::{assert_num_queries, QueryCounter};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "assert_nq_post")]
+#[rustango(app = "assert_nq_app")]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+async fn fresh_pool() -> Pool {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE assert_nq_post (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            title TEXT NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .expect("create");
+    Pool::Sqlite(sq)
+}
+
+#[tokio::test]
+async fn assert_num_queries_counts_single_select() {
+    let pool = fresh_pool().await;
+
+    // Seed 3 rows OUTSIDE the assert block.
+    for i in 0..3 {
+        let mut p = Post {
+            id: Auto::default(),
+            title: format!("seed-{i}"),
+        };
+        p.insert_pool(&pool).await.unwrap();
+    }
+
+    assert_num_queries(1, async {
+        let rows: Vec<Post> = Post::objects().fetch_pool(&pool).await.unwrap();
+        assert_eq!(rows.len(), 3);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn assert_num_queries_counts_insert_then_select() {
+    let pool = fresh_pool().await;
+
+    assert_num_queries(2, async {
+        let mut p = Post {
+            id: Auto::default(),
+            title: "hello".into(),
+        };
+        p.insert_pool(&pool).await.unwrap();
+
+        let rows: Vec<Post> = Post::objects().fetch_pool(&pool).await.unwrap();
+        assert_eq!(rows.len(), 1);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn assert_num_queries_counts_update_delete() {
+    let pool = fresh_pool().await;
+
+    // Seed one row outside the block.
+    let mut p = Post {
+        id: Auto::default(),
+        title: "before".into(),
+    };
+    p.insert_pool(&pool).await.unwrap();
+    let id: i64 = *p.id.get().expect("PK assigned");
+
+    assert_num_queries(2, async {
+        // 1: UPDATE
+        rustango::sql::raw_execute_pool(
+            &pool,
+            "UPDATE assert_nq_post SET title = 'after' WHERE id = ?",
+            vec![rustango::core::SqlValue::I64(id)],
+        )
+        .await
+        .unwrap();
+        // 2: DELETE
+        rustango::sql::raw_execute_pool(
+            &pool,
+            "DELETE FROM assert_nq_post WHERE id = ?",
+            vec![rustango::core::SqlValue::I64(id)],
+        )
+        .await
+        .unwrap();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn outside_scope_bumps_are_silently_dropped() {
+    let pool = fresh_pool().await;
+
+    // Fire 5 queries OUTSIDE any scope — counter doesn't track them.
+    for i in 0..5 {
+        let mut p = Post {
+            id: Auto::default(),
+            title: format!("untracked-{i}"),
+        };
+        p.insert_pool(&pool).await.unwrap();
+    }
+
+    // Now open a scope and run exactly 1 query — count must be 1, not 6.
+    assert_num_queries(1, async {
+        let rows: Vec<Post> = Post::objects().fetch_pool(&pool).await.unwrap();
+        assert_eq!(rows.len(), 5);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn scope_take_resets_mid_block() {
+    let pool = fresh_pool().await;
+
+    QueryCounter::scope(async {
+        // First segment: 2 inserts
+        for i in 0..2 {
+            let mut p = Post {
+                id: Auto::default(),
+                title: format!("a-{i}"),
+            };
+            p.insert_pool(&pool).await.unwrap();
+        }
+        assert_eq!(QueryCounter::take(), 2);
+
+        // Second segment: 1 select
+        let rows: Vec<Post> = Post::objects().fetch_pool(&pool).await.unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(QueryCounter::take(), 1);
+    })
+    .await;
+}
+
+#[tokio::test]
+#[should_panic(expected = "assertNumQueries failed: expected 1 queries, observed 2")]
+async fn fails_loudly_when_count_diverges() {
+    let pool = fresh_pool().await;
+
+    assert_num_queries(1, async {
+        // Two real queries — should panic.
+        let mut p = Post {
+            id: Auto::default(),
+            title: "x".into(),
+        };
+        p.insert_pool(&pool).await.unwrap();
+        let _rows: Vec<Post> = Post::objects().fetch_pool(&pool).await.unwrap();
+    })
+    .await;
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -603,7 +603,7 @@ Summary: **1 SHIPPED / 2 PARTIAL / 6 MISSING / 0 N/A**. **One of the weakest sec
 | Test tags (`@tag('slow')`) | [tags](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#tagging-tests) | SHIPPED | `test_filter::*` (`#[rustango_test(tag = "slow")]`) | |
 | Fixtures (JSON / YAML) | [fixtures](https://docs.djangoproject.com/en/6.0/howto/initial-data/) | SHIPPED | `fixtures::load_pool` | |
 | Test assertions (`assertContains`, `assertRedirects`, `assertStatus`, etc.) | [assertions](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#assertions) | SHIPPED | `test_assertions::*` | |
-| `assertNumQueries(N)` | [assertNumQueries](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#django.test.TransactionTestCase.assertNumQueries) | MISSING | n/a (#431) | Per-query counter would need sqlx interceptor. |
+| `assertNumQueries(N)` | [assertNumQueries](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#django.test.TransactionTestCase.assertNumQueries) | SHIPPED | `test_assertions::assert_num_queries(N, async {...}).await` + `QueryCounter::{scope, current, take}` (#431, v0.42). Per-task counter via `tokio::task_local!`; instrumented at every `*_pool` chokepoint in `sql::executor`. Zero overhead outside an active scope. | |
 | Email outbox assertions | [mail outbox](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#django.core.mail.outbox) | SHIPPED | `InMemoryMailer.messages()` | |
 | Factories (factory-boy shape) | n/a (3rd-party) | PARTIAL | `test_data::*` shipped basics; less ergonomic (#432) | |
 | `selenium` / `playwright` integration | (Django uses LiveServerTestCase + selenium) | MISSING | n/a (#433) | Playwright MCP available externally. |


### PR DESCRIPTION
Django-parity #431 — `assertNumQueries`. Count SQL queries executed
inside a scoped async block, then assert the count matches an
expectation. Mirrors Django's `TestCase.assertNumQueries` shape.

## API

```rust
use rustango::test_assertions::{assert_num_queries, QueryCounter};

// Wrapped form — the common case
assert_num_queries(2, async {
    let mut p = Post { ... };
    p.insert_pool(&pool).await.unwrap();                              // 1
    let _rows: Vec<Post> = Post::objects().fetch_pool(&pool).await?;  // 2
}).await;

// Scoped guard — multiple intermediate checks
QueryCounter::scope(async {
    step_one().await;
    assert_eq!(QueryCounter::take(), 2);
    step_two().await;
    assert_eq!(QueryCounter::take(), 1);
}).await;
```

## Mechanics

- `tokio::task_local!` carries the counter scope across async
  awaits. Calls from tasks outside an active scope no-op
  (`try_with` returns Err) → zero production overhead.
- Spawning a new task inside the scope does NOT inherit the counter
  unless the user propagates the task-local manually — standard
  tokio semantics, documented in the module rustdoc.

## Instrumented chokepoints (`sql::executor`)

- `execute_pool` — covers `raw_execute_pool` / `insert_pool` /
  `update_pool` / `delete_pool` (all non-RETURNING writes)
- `insert_returning_pool` — `Auto<T>` PK inserts route through this,
  not `execute_pool`
- `select_rows_as_json` / `select_one_row_as_json` — JSON-bridge reads
- `select_rows_pool_with_related` / `select_one_row_pool` — typed reads

Each entry bumps by 1 — one SQL statement = one count, regardless of
row count returned. Matches Django.

## Tests

`crates/rustango/src/test_assertions/query_counter.rs` (8 unit cases):
- `bump()` outside scope is no-op
- Exact-count match passes
- Zero-count passes when no queries ran
- Mismatched count panics with `actual` + `expected` in the message
- Inner future's return value passes through
- Mid-scope `current()` reads the running count
- `take()` reset semantics
- Parallel scopes count independently (no cross-talk)

`crates/rustango/tests/assert_num_queries_sqlite_live.rs` (6 live cases):
- Single SELECT counted as 1
- INSERT + SELECT counted as 2
- UPDATE + DELETE counted as 2
- Outside-scope bumps silently dropped (5 inserts before scope = 0 counted)
- Mid-scope `take()` resets cleanly between segments
- Mismatched expectation panics with the Django-shape message

CI: `assert_num_queries_sqlite_live` wired into `sqlite_litmus`.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — passes
- [x] `cargo test -p rustango --lib --no-default-features --features sqlite,tenancy` — 1458 passed
- [x] `cargo test -p rustango --lib --all-features` — 2363 passed
- [x] `cargo test -p rustango --test assert_num_queries_sqlite_live` — 6/6 passed
- [ ] CI green (multi-job)

Closes #431.