### PR TITLE
feat(orm): `#[rustango(validators = "…")]` model-side chain (closes #447, #371)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_search_filter_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_ordering_filter_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test assert_num_queries_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_validators
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -5200,6 +5200,11 @@ struct FieldAttrs {
     /// "form may submit empty even when DB is NOT NULL". Threaded into
     /// `FieldSchema::blank`. Defaults to `false`.
     blank: bool,
+    /// `#[rustango(validators = "email,url")]` — Django-shape
+    /// model-level validator chain. Comma-separated names that
+    /// dispatch to the `validators::*` family in `validate_value`.
+    /// Empty by default; fires on every typed INSERT/UPDATE.
+    validators: Vec<String>,
 }
 
 fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
@@ -5229,6 +5234,7 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
         verbose_name: None,
         editable: true,
         blank: false,
+        validators: Vec::new(),
     };
     for attr in &field.attrs {
         if !attr.path().is_ident("rustango") {
@@ -5351,6 +5357,23 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
                     out.blank = lit.value;
                 } else {
                     out.blank = true;
+                }
+                return Ok(());
+            }
+            if meta.path.is_ident("validators") {
+                let s: LitStr = meta.value()?.parse()?;
+                let raw = s.value();
+                out.validators = raw
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_owned)
+                    .collect();
+                if out.validators.is_empty() {
+                    return Err(syn::Error::new(
+                        s.span(),
+                        "`validators = \"…\"` must list at least one name",
+                    ));
                 }
                 return Ok(());
             }
@@ -5712,6 +5735,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
     let verbose_name = optional_str(attrs.verbose_name.as_deref());
     let editable = attrs.editable;
     let blank = attrs.blank;
+    let validators_lits: Vec<&str> = attrs.validators.iter().map(String::as_str).collect();
     let schema = quote! {
         ::rustango::core::FieldSchema {
             name: #name,
@@ -5733,6 +5757,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
             verbose_name: #verbose_name,
             editable: #editable,
             blank: #blank,
+            validators: &[ #(#validators_lits),* ],
         }
     };
 

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -531,6 +531,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            validators: &[],
         }
     }
 

--- a/crates/rustango/src/core/error.rs
+++ b/crates/rustango/src/core/error.rs
@@ -48,6 +48,27 @@ pub enum QueryError {
         allowed: Vec<&'static str>,
     },
 
+    /// `#[rustango(validators = "email,url")]` named a validator that's
+    /// not in the dispatch table. Names must match one of the entries
+    /// documented on [`crate::core::FieldSchema::validators`].
+    #[error("field `{model}.{field}` references unknown validator `{validator}`")]
+    UnknownValidator {
+        model: &'static str,
+        field: String,
+        validator: &'static str,
+    },
+
+    /// One of the named [`crate::core::FieldSchema::validators`] rejected
+    /// the bound value. Mirrors Django's `ValidationError` raised on
+    /// save when a custom validator on `Field.validators=[]` fails.
+    #[error("field `{model}.{field}` validator `{validator}` rejected value: {reason}")]
+    ValidatorFailed {
+        model: &'static str,
+        field: String,
+        validator: &'static str,
+        reason: String,
+    },
+
     /// `QuerySet::select_related("foo")` couldn't be lowered: the
     /// field doesn't exist, isn't a `ForeignKey<T>`, the target
     /// table isn't registered in `inventory`, or the target has no

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -104,6 +104,17 @@ pub struct FieldSchema {
     /// `nullable=false, blank=true` to require *some* value in DB
     /// but accept `""` from the form.
     pub blank: bool,
+    /// Django-shape `validators=[...]` — names of value-shape validators
+    /// to run on every INSERT/UPDATE through the typed query layer. Set
+    /// via `#[rustango(validators = "email,url")]` (comma-separated).
+    /// Names dispatch to the `validators::*` family
+    /// ([`crate::validators::validate_email`], `validate_url`,
+    /// `validate_slug`, `validate_unicode_slug`, `validate_phone_e164`,
+    /// `validate_hex_color`, `validate_uuid`, `validate_iso_date`,
+    /// `validate_iso_time`, `validate_iso_datetime`, `validate_ipv4`,
+    /// `validate_ipv6`, `validate_no_null`). Unknown names error at
+    /// runtime via [`crate::core::QueryError::UnknownValidator`].
+    pub validators: &'static [&'static str],
 }
 
 impl FieldSchema {

--- a/crates/rustango/src/core/validate.rs
+++ b/crates/rustango/src/core/validate.rs
@@ -24,7 +24,8 @@ pub fn validate_value(
     match value {
         SqlValue::String(s) => {
             check_max_length(model, field, s)?;
-            check_choices(model, field, s)
+            check_choices(model, field, s)?;
+            check_named_validators(model, field, s)
         }
         SqlValue::I16(v) => check_int_range(model, field, i64::from(*v)),
         SqlValue::I32(v) => check_int_range(model, field, i64::from(*v)),
@@ -83,6 +84,56 @@ fn check_choices(model: &'static str, field: &FieldSchema, value: &str) -> Resul
         value: value.to_owned(),
         allowed: choices.iter().map(|(v, _)| *v).collect(),
     })
+}
+
+/// Dispatch each `#[rustango(validators = "...")]` name in
+/// `field.validators` to the built-in `validators::*` family. #447.
+///
+/// Unknown names surface as [`QueryError::UnknownValidator`]; a
+/// validator that rejects the value surfaces as
+/// [`QueryError::ValidatorFailed`].
+fn check_named_validators(
+    model: &'static str,
+    field: &FieldSchema,
+    value: &str,
+) -> Result<(), QueryError> {
+    use crate::validators as v;
+
+    for name in field.validators {
+        let result = match *name {
+            "email" => v::validate_email(value),
+            "url" => v::validate_url(value),
+            "slug" => v::validate_slug(value),
+            "unicode_slug" => v::validate_unicode_slug(value),
+            "phone_e164" => v::validate_phone_e164(value),
+            "hex_color" => v::validate_hex_color(value),
+            "uuid" => v::validate_uuid(value),
+            "iso_date" => v::validate_iso_date(value),
+            "iso_time" => v::validate_iso_time(value),
+            "iso_datetime" => v::validate_iso_datetime(value),
+            "ipv4" => v::validate_ipv4_address(value),
+            "ipv6" => v::validate_ipv6_address(value),
+            "no_null" => v::validate_prohibit_null_characters(value),
+            "email_list" => v::validate_email_list(value),
+            "integer" => v::validate_integer(value),
+            other => {
+                return Err(QueryError::UnknownValidator {
+                    model,
+                    field: field.name.to_owned(),
+                    validator: other,
+                });
+            }
+        };
+        if let Err(e) = result {
+            return Err(QueryError::ValidatorFailed {
+                model,
+                field: field.name.to_owned(),
+                validator: name,
+                reason: e.to_string(),
+            });
+        }
+    }
+    Ok(())
 }
 
 fn check_int_range(model: &'static str, field: &FieldSchema, value: i64) -> Result<(), QueryError> {

--- a/crates/rustango/src/migrate/ddl.rs
+++ b/crates/rustango/src/migrate/ddl.rs
@@ -361,6 +361,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            validators: &[],
         }
     }
 

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -3856,6 +3856,7 @@ mod gen_tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            validators: &[],
         }
     }
 

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -537,6 +537,7 @@ mod composite_fk_snapshot_tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            validators: &[],
         }];
         static COMPS: [CompositeFkRelation; 1] = [CompositeFkRelation {
             name: "target",
@@ -604,6 +605,7 @@ mod composite_fk_snapshot_tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            validators: &[],
         }];
         static MS: ModelSchema = ModelSchema {
             name: "Plain",

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -220,6 +220,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            validators: &[],
         },
         FieldSchema {
             name: "title",
@@ -241,6 +242,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            validators: &[],
         },
         FieldSchema {
             name: "deleted_at",
@@ -262,6 +264,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            validators: &[],
         },
     ];
 

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -1251,6 +1251,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                validators: &[],
             })
             .collect();
         let leaked: &'static [crate::core::FieldSchema] = Box::leak(field_vec.into_boxed_slice());

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -636,6 +636,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            validators: &[],
         }];
         static MODEL: ModelSchema = ModelSchema {
             name: "demo",

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -3840,6 +3840,7 @@ mod tests {
                     verbose_name: None,
                     editable: true,
                     blank: false,
+                    validators: &[],
                 },
                 crate::core::FieldSchema {
                     name: "title",
@@ -3861,6 +3862,7 @@ mod tests {
                     verbose_name: None,
                     editable: true,
                     blank: false,
+                    validators: &[],
                 },
             ])),
             display: None,
@@ -3910,6 +3912,7 @@ mod tests {
                     verbose_name: None,
                     editable: true,
                     blank: false,
+                    validators: &[],
                 },
                 crate::core::FieldSchema {
                     name: "title",
@@ -3931,6 +3934,7 @@ mod tests {
                     verbose_name: None,
                     editable: true,
                     blank: false,
+                    validators: &[],
                 },
                 crate::core::FieldSchema {
                     name: "score",
@@ -3952,6 +3956,7 @@ mod tests {
                     verbose_name: None,
                     editable: true,
                     blank: false,
+                    validators: &[],
                 },
             ])),
             display: None,
@@ -4332,6 +4337,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                validators: &[],
             }])),
             display: None,
             app_label: None,
@@ -4577,6 +4583,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                validators: &[],
             }])),
             display: None,
             app_label: None,
@@ -4634,6 +4641,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                validators: &[],
             }])),
             display: None,
             app_label: None,
@@ -5164,6 +5172,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                validators: &[],
             })) as &'static crate::core::FieldSchema
         };
         assert!(matches!(

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1561,6 +1561,7 @@ mod lookup_tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            validators: &[],
         }
     }
 
@@ -1585,6 +1586,7 @@ mod lookup_tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            validators: &[],
         }
     }
 

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -308,6 +308,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            validators: &[],
         }
     }
 
@@ -332,6 +333,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            validators: &[],
         }
     }
 
@@ -356,6 +358,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            validators: &[],
         }
     }
 
@@ -381,6 +384,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                validators: &[],
             },
             FieldSchema {
                 name: "title",
@@ -402,6 +406,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                validators: &[],
             },
             FieldSchema {
                 name: "author_id",
@@ -423,6 +428,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                validators: &[],
             },
         ];
         // Suppress unused warnings on field helpers if we keep them.

--- a/crates/rustango/tests/field_types_decimal_binary_time.rs
+++ b/crates/rustango/tests/field_types_decimal_binary_time.rs
@@ -128,6 +128,7 @@ fn form_parser_decimal() {
         verbose_name: None,
         editable: true,
         blank: false,
+        validators: &[],
     };
     let v = parse_form_value(&f, Some("123.45")).unwrap();
     assert!(matches!(v, SqlValue::Decimal(d) if d == Decimal::from_str("123.45").unwrap()));
@@ -160,6 +161,7 @@ fn form_parser_binary_hex() {
         verbose_name: None,
         editable: true,
         blank: false,
+        validators: &[],
     };
     let v = parse_form_value(&f, Some("deadbeef")).unwrap();
     assert!(matches!(v, SqlValue::Binary(b) if b == vec![0xde, 0xad, 0xbe, 0xef]));
@@ -194,6 +196,7 @@ fn form_parser_time() {
         verbose_name: None,
         editable: true,
         blank: false,
+        validators: &[],
     };
     // Full HH:MM:SS form.
     let v = parse_form_value(&f, Some("14:30:45")).unwrap();

--- a/crates/rustango/tests/macro_validators.rs
+++ b/crates/rustango/tests/macro_validators.rs
@@ -1,0 +1,135 @@
+//! `#[rustango(validators = "...")]` model-side validators
+//! (Django-parity #447).
+//!
+//! Covers:
+//! - macro threads comma-separated names onto `FieldSchema::validators`
+//! - `validate_value` accepts in-spec values
+//! - `validate_value` rejects off-spec values with
+//!   `QueryError::ValidatorFailed` carrying the validator name + reason
+//! - unknown validator names surface `QueryError::UnknownValidator`
+//! - multiple validators chain — first failure wins
+//! - `validators` is presentation/runtime-only — no DDL impact
+
+use rustango::core::{validate_value, FieldSchema, Model, QueryError, SqlValue};
+use rustango::migrate::ddl::create_table_sql_with_dialect;
+use rustango::sql::Postgres;
+use rustango_macros::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "macro_vchain_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+
+    /// Single validator.
+    #[rustango(max_length = 200, validators = "email")]
+    pub author_email: String,
+
+    /// Two validators — both must pass.
+    #[rustango(max_length = 200, validators = "url, no_null")]
+    pub homepage: String,
+
+    /// No validators declared.
+    #[rustango(max_length = 64)]
+    pub title: String,
+
+    /// Bad name — caught at runtime when validate_value fires.
+    #[rustango(max_length = 64, validators = "this_does_not_exist")]
+    pub bad: String,
+}
+
+fn field<'a>(name: &str) -> &'a FieldSchema {
+    Post::SCHEMA
+        .field(name)
+        .unwrap_or_else(|| panic!("no field {name:?}"))
+}
+
+#[test]
+fn schema_threads_comma_separated_validator_names() {
+    assert_eq!(field("author_email").validators, &["email"]);
+    assert_eq!(field("homepage").validators, &["url", "no_null"]);
+    assert!(field("title").validators.is_empty());
+    assert!(field("id").validators.is_empty());
+}
+
+#[test]
+fn validate_value_accepts_in_spec_value() {
+    validate_value(
+        "Post",
+        field("author_email"),
+        &SqlValue::String("alice@example.com".into()),
+    )
+    .unwrap();
+}
+
+#[test]
+fn validate_value_rejects_off_spec_email() {
+    let err = validate_value(
+        "Post",
+        field("author_email"),
+        &SqlValue::String("not-an-email".into()),
+    )
+    .unwrap_err();
+    match err {
+        QueryError::ValidatorFailed {
+            field: name,
+            validator,
+            ..
+        } => {
+            assert_eq!(name, "author_email");
+            assert_eq!(validator, "email");
+        }
+        other => panic!("expected ValidatorFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn validate_value_chains_multiple_validators_first_failure_wins() {
+    // `homepage` = url + no_null. Non-URL value → url validator fails first.
+    let err =
+        validate_value("Post", field("homepage"), &SqlValue::String("nope".into())).unwrap_err();
+    match err {
+        QueryError::ValidatorFailed { validator, .. } => assert_eq!(validator, "url"),
+        other => panic!("expected ValidatorFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn validate_value_passes_when_all_validators_pass() {
+    validate_value(
+        "Post",
+        field("homepage"),
+        &SqlValue::String("https://example.com/page".into()),
+    )
+    .unwrap();
+}
+
+#[test]
+fn unknown_validator_name_surfaces_clear_error() {
+    let err = validate_value("Post", field("bad"), &SqlValue::String("x".into())).unwrap_err();
+    match err {
+        QueryError::UnknownValidator {
+            field: name,
+            validator,
+            ..
+        } => {
+            assert_eq!(name, "bad");
+            assert_eq!(validator, "this_does_not_exist");
+        }
+        other => panic!("expected UnknownValidator, got {other:?}"),
+    }
+}
+
+#[test]
+fn validators_do_not_affect_ddl() {
+    let sql = create_table_sql_with_dialect(&Postgres, Post::SCHEMA);
+    assert!(
+        !sql.contains("validators"),
+        "validators leaked into DDL: {sql}"
+    );
+    assert!(
+        !sql.to_lowercase().contains("validator"),
+        "validator string leaked into DDL: {sql}"
+    );
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -159,7 +159,7 @@ Field options:
 | `blank=True` (form-level allow empty) | SHIPPED | `#[rustango(blank)]` (#445, v0.42) — admin form drops the `required` HTML attribute even on NOT NULL columns; distinct from `Option<T>` which controls SQL nullability | |
 | `default` | SHIPPED | `#[rustango(default = "expr")]` | |
 | `choices=[...]` | SHIPPED | `#[rustango(choices = "draft:Draft, published:Published")]` (#446, v0.42) — admin renders `<select>`, validator rejects off-choice values | |
-| `validators=[...]` | PARTIAL | Form-side: `validate_email`, `validate_url`, `validate_min_length`, file validators (#447) | Model-side validators on save MISSING. |
+| `validators=[...]` | SHIPPED | `#[rustango(validators = "email,url")]` (#447, v0.42) — comma-separated names dispatch to the `validators::*` family on every typed INSERT/UPDATE via `core::validate_value`. Supports email, url, slug, unicode_slug, phone_e164, hex_color, uuid, iso_date, iso_time, iso_datetime, ipv4, ipv6, no_null, email_list, integer. | |
 | `db_index=True` | SHIPPED | `#[rustango(index)]` (field-level) + container-level `index(...)` | |
 | `db_column` | SHIPPED | `#[rustango(db_column = "...")]` | |
 | `help_text` | SHIPPED | `#[rustango(help_text = "...")]` (v0.40) — admin renders below input | |
@@ -267,7 +267,7 @@ Summary: **18 SHIPPED / 7 PARTIAL / 11 MISSING / 2 N/A**. Concentration of MISSI
 | `ModelForm` | [ModelForm](https://docs.djangoproject.com/en/6.0/topics/forms/modelforms/) | PARTIAL | `forms::ModelForm` struct + `from_model_schema` runtime — works for admin path (#369) | No `#[derive(ModelForm)]` shortcut. Backlog. |
 | Form fields (CharField, IntegerField, etc.) | [Form fields](https://docs.djangoproject.com/en/6.0/ref/forms/fields/) | SHIPPED | Field attrs in `Form` derive | |
 | Widgets (Select, Textarea, RadioSelect, etc.) | [Widgets](https://docs.djangoproject.com/en/6.0/ref/forms/widgets/) | PARTIAL | Admin renders fixed HTML per FieldType; no widget swap (#370) | |
-| Per-field validators chain | [validators](https://docs.djangoproject.com/en/6.0/ref/validators/) | PARTIAL | `validators::{validate_email, validate_url, validate_min_length, file_type, file_size_max}` shipped (#371) | `validators=[...]` declarative-stack MISSING. |
+| Per-field validators chain | [validators](https://docs.djangoproject.com/en/6.0/ref/validators/) | SHIPPED | `#[rustango(validators = "email,url")]` (#447, v0.42) — declarative comma-separated chain dispatched in `core::validate_value` on every INSERT/UPDATE. Closes #371 alongside this PR. | |
 | `clean_<field>` per-field clean | [clean methods](https://docs.djangoproject.com/en/6.0/ref/forms/validation/) | MISSING | n/a (#372) | Macro doesn't emit per-field clean hooks. |
 | `clean()` cross-field validation | (above) | MISSING | n/a (#373) | Closes ORM-improvement backlog #9. |
 | `FormErrors` (multi-error) | [error handling](https://docs.djangoproject.com/en/6.0/ref/forms/validation/) | SHIPPED | `forms::FormErrors` collects all field+non-field errors | |


### PR DESCRIPTION
Django-parity #447 — `validators=[...]` declarative chain on model
fields. Closes the gap the audit flagged: form-side validators
existed but raw `Model::insert_pool` / `update_pool` bypassed them.
Also closes #371 (per-field validators chain — same feature).

## API

```rust
#[rustango(max_length = 200, validators = "email")]
pub author_email: String,

#[rustango(max_length = 200, validators = "url, no_null")]
pub homepage: String,
```

Comma-separated names dispatch to the `validators::*` family. Built-in
table:

```
email, url, slug, unicode_slug, phone_e164, hex_color, uuid,
iso_date, iso_time, iso_datetime, ipv4, ipv6, no_null,
email_list, integer
```

## Surfaces wired

- `FieldSchema.validators: &'static [&'static str]`
- `core::validate_value` dispatches each name on String values AFTER
  `max_length` + `choices`, BEFORE returning `Ok`. Fires on every
  typed INSERT/UPDATE via the IR-bind chain in `query.rs`.
- New `QueryError` variants:
  - `UnknownValidator { model, field, validator }` — name not in table
  - `ValidatorFailed { model, field, validator, reason }` — value rejected

## Behavioral difference vs Django (intentional)

Django's `validators=[]` runs on `ModelForm.save()` — `Model.save()`
bypasses it unless you call `full_clean()` manually. rustango fires
on every typed save by default, which matches the more common Rust
expectation that the ORM doesn't silently let invalid data through.
A future PR can add an opt-out flag if the auto-fire surprises users.

## Tests

`crates/rustango/tests/macro_validators.rs` — 7 cases:
- Comma-separated names thread to FieldSchema correctly
- Valid email accepted
- Invalid email rejected with `ValidatorFailed` carrying name + reason
- Multi-validator field: first failure wins
- All validators pass → `Ok`
- Unknown validator name → `UnknownValidator` with the bad name
- `validators` string does NOT leak into the DDL

CI: `macro_validators` wired into `sqlite_litmus`.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — passes
- [x] `cargo test -p rustango --lib --no-default-features --features sqlite,tenancy` — 1458 passed
- [x] `cargo test -p rustango --lib --all-features` — 2363 passed
- [x] `cargo test -p rustango --test macro_validators` — 7/7 passed
- [ ] CI green (multi-job)

Closes #447. Also closes #371.