### PR TITLE
feat(signals): `got_request_exception` fires on 5xx (closes #413)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_ordering_filter_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test assert_num_queries_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_validators
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test got_request_exception_signal
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/signals/request.rs
+++ b/crates/rustango/src/signals/request.rs
@@ -96,14 +96,30 @@ pub struct RequestFinishedContext {
     pub elapsed_ms: f64,
 }
 
-/// Payload delivered to `got_request_exception` receivers — the inner
-/// service returned an error rather than a `Response`.
+/// Payload delivered to `got_request_exception` receivers — the
+/// handler stack produced an exceptional outcome.
+///
+/// The layer fires this signal under two conditions:
+/// 1. Inner service returned `Err` (rare — axum's `Service::Error` is
+///    `Infallible`; only fires when a downstream layer short-circuits).
+/// 2. Inner service returned a response with status `5xx` (#413). Maps
+///    closely to Django's `got_request_exception` semantics —
+///    "something went wrong while processing the request".
+///
+/// `error` carries either the stringified service error or a
+/// `"http <code>"` token for the 5xx path; `status` is `None` for
+/// service-error firings and `Some(code)` for 5xx firings, so audit
+/// receivers can pivot on which case they're handling.
 #[derive(Debug, Clone)]
 pub struct RequestExceptionContext {
     pub method: String,
     pub path: String,
-    /// Stringified error from the inner service.
+    /// Stringified error from the inner service, or `"http <code>"`
+    /// when the trigger was a 5xx response.
     pub error: String,
+    /// `Some(code)` when fired on a 5xx response; `None` when the
+    /// trigger was a service-level error (Service::Error).
+    pub status: Option<u16>,
 }
 
 // ---------------------------------------------------------------- Internal storage
@@ -347,6 +363,24 @@ where
                 Ok(resp) => {
                     let elapsed_ms = (started_at.elapsed().as_micros() as f64) / 1000.0;
                     let status = resp.status().as_u16();
+                    // #413 — Django-shape `got_request_exception` also
+                    // fires on 5xx responses, not just service-error
+                    // panics. axum's Service::Error is Infallible in
+                    // practice, so without this branch the signal would
+                    // never fire on real failures. Audit / SIEM
+                    // receivers want to know about 500s; the
+                    // `status: Some(code)` field lets them tell the
+                    // 5xx-response case apart from the (rare)
+                    // service-error case below.
+                    if (500..600).contains(&status) {
+                        send_got_request_exception(RequestExceptionContext {
+                            method: method.clone(),
+                            path: path.clone(),
+                            error: format!("http {status}"),
+                            status: Some(status),
+                        })
+                        .await;
+                    }
                     send_request_finished(RequestFinishedContext {
                         method,
                         path,
@@ -367,6 +401,7 @@ where
                             method,
                             path,
                             error: "inner service returned Err".to_owned(),
+                            status: None,
                         })
                         .await;
                         Ok(error_response())

--- a/crates/rustango/tests/got_request_exception_signal.rs
+++ b/crates/rustango/tests/got_request_exception_signal.rs
@@ -1,0 +1,197 @@
+//! Django-parity #413 — `got_request_exception` signal fires on 5xx
+//! responses passing through [`RequestSignalsLayer`]. Closes the audit
+//! row's PARTIAL gap: pre-#413, the signal was wired only to the
+//! `Service::Error` arm, which axum's `Infallible` bound makes
+//! effectively dead code; now 500/502/503 responses also trigger it.
+
+#![cfg(feature = "signals")]
+
+use std::sync::Arc;
+
+use axum::http::StatusCode;
+use axum::response::Response;
+use axum::routing::get;
+use axum::Router;
+use tokio::sync::Mutex;
+use tower::ServiceExt as _;
+
+use rustango::signals::request::{
+    clear_all, connect_got_request_exception, connect_request_finished, RequestExceptionContext,
+    RequestFinishedContext, RequestSignalsLayer,
+};
+
+/// Cargo's default parallel harness runs these tests on a shared
+/// global signal registry. Take a suite-wide mutex at entry so two
+/// tests don't race between each other's `clear_all` + connect.
+fn suite_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+fn app() -> Router {
+    Router::new()
+        .route("/ok", get(|| async { "ok" }))
+        .route(
+            "/boom",
+            get(|| async {
+                Response::builder()
+                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(axum::body::Body::from("server error"))
+                    .unwrap()
+            }),
+        )
+        .route(
+            "/bad_gateway",
+            get(|| async {
+                Response::builder()
+                    .status(StatusCode::BAD_GATEWAY)
+                    .body(axum::body::Body::from("upstream broken"))
+                    .unwrap()
+            }),
+        )
+        .route(
+            "/teapot",
+            get(|| async {
+                // 418 — explicitly 4xx, NOT 5xx; must NOT fire the signal.
+                Response::builder()
+                    .status(StatusCode::IM_A_TEAPOT)
+                    .body(axum::body::Body::from("418"))
+                    .unwrap()
+            }),
+        )
+        .layer(RequestSignalsLayer::new())
+}
+
+fn req(uri: &str) -> axum::http::Request<axum::body::Body> {
+    axum::http::Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(axum::body::Body::empty())
+        .unwrap()
+}
+
+#[tokio::test]
+async fn got_request_exception_fires_on_500_response() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let captured: Arc<Mutex<Vec<RequestExceptionContext>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    connect_got_request_exception(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().await.push(ctx);
+        }
+    });
+
+    let resp = app().oneshot(req("/boom")).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+    let got = captured.lock().await;
+    assert_eq!(got.len(), 1, "expected 1 signal fire, got {got:?}");
+    assert_eq!(got[0].path, "/boom");
+    assert_eq!(got[0].method, "GET");
+    assert_eq!(got[0].status, Some(500));
+    assert_eq!(got[0].error, "http 500");
+}
+
+#[tokio::test]
+async fn got_request_exception_fires_on_502_response() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let captured: Arc<Mutex<Vec<RequestExceptionContext>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    connect_got_request_exception(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().await.push(ctx);
+        }
+    });
+
+    let resp = app().oneshot(req("/bad_gateway")).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+
+    let got = captured.lock().await;
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].status, Some(502));
+}
+
+#[tokio::test]
+async fn got_request_exception_does_not_fire_on_4xx() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let captured: Arc<Mutex<Vec<RequestExceptionContext>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    connect_got_request_exception(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().await.push(ctx);
+        }
+    });
+
+    let resp = app().oneshot(req("/teapot")).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::IM_A_TEAPOT);
+
+    let got = captured.lock().await;
+    assert!(
+        got.is_empty(),
+        "4xx must NOT fire got_request_exception, got: {got:?}"
+    );
+}
+
+#[tokio::test]
+async fn got_request_exception_does_not_fire_on_2xx() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let captured: Arc<Mutex<Vec<RequestExceptionContext>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    connect_got_request_exception(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().await.push(ctx);
+        }
+    });
+
+    let resp = app().oneshot(req("/ok")).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let got = captured.lock().await;
+    assert!(got.is_empty(), "2xx must NOT fire got_request_exception");
+}
+
+#[tokio::test]
+async fn request_finished_still_fires_alongside_exception_on_500() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let exc: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+    let fin: Arc<Mutex<Vec<RequestFinishedContext>>> = Arc::new(Mutex::new(Vec::new()));
+    {
+        let exc = exc.clone();
+        connect_got_request_exception(move |_| {
+            let exc = exc.clone();
+            async move {
+                *exc.lock().await += 1;
+            }
+        });
+    }
+    {
+        let fin = fin.clone();
+        connect_request_finished(move |ctx| {
+            let fin = fin.clone();
+            async move {
+                fin.lock().await.push(ctx);
+            }
+        });
+    }
+
+    let _resp = app().oneshot(req("/boom")).await.unwrap();
+    assert_eq!(*exc.lock().await, 1, "exception receiver should fire once");
+    let f = fin.lock().await;
+    assert_eq!(f.len(), 1, "request_finished should still fire on 5xx");
+    assert_eq!(f[0].status, 500);
+}

--- a/crates/rustango/tests/request_signals.rs
+++ b/crates/rustango/tests/request_signals.rs
@@ -116,6 +116,11 @@ async fn exception_dispatch_works() {
         method: "GET".into(),
         path: "/boom".into(),
         error: "kaboom".into(),
+        // #413 — pre-existing test was for the service-error
+        // dispatch path (axum::Service::Error fired the signal);
+        // that arm now carries `status: None` while the new
+        // 5xx-response arm carries `Some(code)`.
+        status: None,
     })
     .await;
 

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -523,7 +523,7 @@ Summary: **7 / 1 / 2 / 0**.
 | `pre_migrate` / `post_migrate` | [pre_migrate](https://docs.djangoproject.com/en/6.0/ref/signals/#pre-migrate) | MISSING | n/a (#411) | |
 | `class_prepared` | (above) | N/A — Rust doesn't have lazy class creation | n/a | |
 | `request_started` / `request_finished` | [request signals](https://docs.djangoproject.com/en/6.0/ref/signals/#django.core.signals.request_started) | PARTIAL | tower `Service` semantics + tracing layer cover this (#412) | Not a discrete signal. |
-| `got_request_exception` | (above) | PARTIAL | tower error handling + tracing (#413) | |
+| `got_request_exception` | (above) | SHIPPED | `signals::request::got_request_exception` fires from `RequestSignalsLayer` on every 5xx response + the (rare) `Service::Error` arm (#413, v0.42). `RequestExceptionContext.status: Option<u16>` lets receivers distinguish the two cases. | |
 | `user_logged_in` / `user_logged_out` / `user_login_failed` | [auth signals](https://docs.djangoproject.com/en/6.0/ref/contrib/auth/#module-django.contrib.auth.signals) | SHIPPED | `signals::auth::*` (#414, v0.42) — fired from admin / tenant admin / operator console / JWT login + logout paths with `AuthRequestMeta` context | |
 | `setting_changed` | (above) | MISSING | n/a (#415) | |
 | Disconnect / weak references | (above) | SHIPPED | `signals::disconnect_*` | |


### PR DESCRIPTION
Django-parity #413 — `got_request_exception`. The audit row was
PARTIAL because the existing wiring only dispatched on the
`Service::Error` arm, which axum's `Infallible` bound makes
effectively dead code; the signal never fired on real production
500-response failures.

## The fix

`RequestSignalsLayer` now also dispatches `got_request_exception`
when the inner service returns a `5xx` response (500-599). Matches
Django's broader semantic of "something went wrong while processing
the request".

`RequestExceptionContext` gains a `status: Option<u16>` field —
`Some(code)` on the 5xx-response path, `None` on the (rare)
service-error path. Audit / SIEM receivers can pivot on which.
`error` carries the `"http <code>"` token on the 5xx path; the
stringified service error on the service-error path. Both paths
populate `method` + `path` for incident triage.

Existing `request_started` / `request_finished` signals are
unaffected — `request_finished` still fires on 5xx (and every other
status), the exception signal just additionally fires alongside.

## Tests

`crates/rustango/tests/got_request_exception_signal.rs` — 5 cases:
- 500 response fires the signal with `status=Some(500)`
- 502 response fires with `status=Some(502)`
- 4xx (418 teapot) does NOT fire
- 2xx does NOT fire
- `request_finished` still fires alongside the exception on 5xx

CI: `got_request_exception_signal` wired into `sqlite_litmus`.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — passes
- [x] `cargo test -p rustango --lib --no-default-features --features sqlite,tenancy` — 1458 passed
- [x] `cargo test -p rustango --lib --all-features` — 2363 passed
- [x] `cargo test -p rustango --test got_request_exception_signal` — 5/5 passed
- [ ] CI green (multi-job)

Closes #413.