### PR TITLE
feat(signals): `pre_migrate` / `post_migrate` (closes #411)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test assert_num_queries_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_validators
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test got_request_exception_signal
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test migrate_signals_sqlite_live
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -251,6 +251,13 @@ pub fn registered_models() -> Vec<&'static ModelSchema> {
 /// constraint violation).
 #[cfg(feature = "postgres")]
 pub async fn apply_all(pool: &PgPool) -> Result<(), MigrateError> {
+    use crate::signals::migrate::{
+        send_post_migrate, send_pre_migrate, PostMigrateContext, PreMigrateContext,
+    };
+    send_pre_migrate(PreMigrateContext {
+        source: "apply_all",
+    })
+    .await;
     let models = registered_models();
 
     for model in &models {
@@ -262,6 +269,13 @@ pub async fn apply_all(pool: &PgPool) -> Result<(), MigrateError> {
             sqlx::query(&sql).execute(pool).await?;
         }
     }
+    // #411 — post_migrate fires once after the bootstrap walk
+    // completes successfully.
+    send_post_migrate(PostMigrateContext {
+        source: "apply_all",
+        applied: Vec::new(),
+    })
+    .await;
     Ok(())
 }
 
@@ -295,6 +309,13 @@ pub async fn drop_all(pool: &PgPool) -> Result<(), MigrateError> {
 /// # Errors
 /// As [`apply_all`].
 pub async fn apply_all_pool(pool: &crate::sql::Pool) -> Result<(), MigrateError> {
+    use crate::signals::migrate::{
+        send_post_migrate, send_pre_migrate, PostMigrateContext, PreMigrateContext,
+    };
+    send_pre_migrate(PreMigrateContext {
+        source: "apply_all_pool",
+    })
+    .await;
     let dialect = pool.dialect();
     let models = registered_models();
     for model in &models {
@@ -314,6 +335,14 @@ pub async fn apply_all_pool(pool: &crate::sql::Pool) -> Result<(), MigrateError>
             crate::sql::raw_execute_pool(pool, &sql, ::std::vec::Vec::new()).await?;
         }
     }
+    // #411 — post_migrate fires once after the bootstrap walk
+    // completes. `applied` is empty because apply_all_pool doesn't
+    // carry per-migration names — it walks the model inventory.
+    send_post_migrate(PostMigrateContext {
+        source: "apply_all_pool",
+        applied: Vec::new(),
+    })
+    .await;
     Ok(())
 }
 
@@ -367,8 +396,12 @@ async fn migrate_with_ledger(
     dir: &Path,
     ledger: &str,
 ) -> Result<Vec<Migration>, MigrateError> {
+    use crate::signals::migrate::{
+        send_post_migrate, send_pre_migrate, PostMigrateContext, PreMigrateContext,
+    };
+    send_pre_migrate(PreMigrateContext { source: "migrate" }).await;
     ensure_ledger_for(pool, ledger).await?;
-    with_migrate_lock(pool, async {
+    let newly = with_migrate_lock(pool, async {
         let all = file::list_dir(dir)?;
         let applied = applied_set_for(pool, ledger).await?;
         let pending: Vec<Migration> = all
@@ -383,7 +416,16 @@ async fn migrate_with_ledger(
         }
         Ok(newly)
     })
-    .await
+    .await?;
+    // #411 — post_migrate fires once after the file-based migrate
+    // session completes. `applied` lists newly-applied migration
+    // names (empty when everything was already applied).
+    send_post_migrate(PostMigrateContext {
+        source: "migrate",
+        applied: newly.iter().map(|m| m.name.clone()).collect(),
+    })
+    .await;
+    Ok(newly)
 }
 
 /// Hold the migrate advisory lock for the duration of `body`, then

--- a/crates/rustango/src/signals/migrate.rs
+++ b/crates/rustango/src/signals/migrate.rs
@@ -1,0 +1,213 @@
+//! Django-shape migration lifecycle signals — `pre_migrate` /
+//! `post_migrate`. Django-parity #411.
+//!
+//! Receivers register globally and fire around the framework's
+//! migrate paths:
+//!
+//! - [`crate::migrate::apply_all`] / [`crate::migrate::apply_all_pool`]
+//!   (bootstrap CREATE TABLE walk)
+//! - [`crate::migrate::migrate`] (file-based ledger-tracked migrations)
+//!
+//! ## Quick start
+//!
+//! ```ignore
+//! use rustango::signals::migrate::{
+//!     connect_pre_migrate, connect_post_migrate,
+//!     PreMigrateContext, PostMigrateContext,
+//! };
+//!
+//! connect_pre_migrate(|ctx| Box::pin(async move {
+//!     tracing::info!(source = ctx.source, "migrate starting");
+//! }));
+//! connect_post_migrate(|ctx| Box::pin(async move {
+//!     tracing::info!(
+//!         source = ctx.source,
+//!         applied = ctx.applied.len(),
+//!         "migrate finished"
+//!     );
+//! }));
+//! ```
+//!
+//! ## Where each signal fires
+//!
+//! - `pre_migrate` — once before the framework starts applying
+//!   migrations / CREATE TABLEs for a session. `source` identifies
+//!   the entry point (`"apply_all"`, `"migrate"`, …).
+//! - `post_migrate` — once after the migrate path completes
+//!   successfully. `applied` is the ordered list of migration names
+//!   that ran during this invocation (empty for `apply_all` /
+//!   `apply_all_pool` since those don't carry per-migration names).
+//!
+//! ## Semantics
+//!
+//! - Receivers run **sequentially** in registration order, awaited one
+//!   at a time. Wrap in `tokio::spawn` for fanout.
+//! - A panicking receiver aborts the dispatch chain and propagates.
+//! - Each receiver gets a `Clone`d context — no borrow lifetimes.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock, RwLock};
+
+/// Future returned by migrate-signal receivers. `'static` because the
+/// receiver is stored as `Arc<dyn ...>` and may run after the caller
+/// has returned.
+pub type ReceiverFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+/// Opaque identifier returned by `connect_*` for later use with
+/// `disconnect_*`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ReceiverId(u64);
+
+// ---------------------------------------------------------------- Context types
+
+/// Payload delivered to `pre_migrate` receivers — fires once before
+/// the framework's migrate path starts.
+#[derive(Debug, Clone)]
+pub struct PreMigrateContext {
+    /// Free-form identifier for the entry point that fired the
+    /// signal: `"apply_all"` (no-file bootstrap), `"apply_all_pool"`
+    /// (tri-dialect bootstrap), `"migrate"` (file-based ledger). Lets
+    /// a single receiver discriminate between modes if it cares.
+    pub source: &'static str,
+}
+
+/// Payload delivered to `post_migrate` receivers — fires once after
+/// the framework's migrate path completes successfully.
+#[derive(Debug, Clone)]
+pub struct PostMigrateContext {
+    pub source: &'static str,
+    /// Names of migrations that ran during this invocation, in apply
+    /// order. Empty when `source` is `"apply_all"` / `"apply_all_pool"`
+    /// (no per-migration names — bootstrap walks the model inventory).
+    pub applied: Vec<String>,
+}
+
+// ---------------------------------------------------------------- Internal storage
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum SignalKind {
+    PreMigrate,
+    PostMigrate,
+}
+
+type ReceiverEntry = (ReceiverId, Box<dyn Any + Send + Sync>);
+type Bag = Vec<ReceiverEntry>;
+
+fn registry() -> &'static RwLock<HashMap<SignalKind, Bag>> {
+    static REG: OnceLock<RwLock<HashMap<SignalKind, Bag>>> = OnceLock::new();
+    REG.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+fn next_id() -> ReceiverId {
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    ReceiverId(COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+fn insert_receiver<R: Any + Send + Sync>(kind: SignalKind, receiver: R) -> ReceiverId {
+    let id = next_id();
+    let mut reg = registry().write().unwrap_or_else(|e| e.into_inner());
+    reg.entry(kind).or_default().push((id, Box::new(receiver)));
+    id
+}
+
+fn remove_receiver(kind: SignalKind, id: ReceiverId) -> bool {
+    let mut reg = registry().write().unwrap_or_else(|e| e.into_inner());
+    let Some(bag) = reg.get_mut(&kind) else {
+        return false;
+    };
+    let before = bag.len();
+    bag.retain(|(rid, _)| *rid != id);
+    bag.len() != before
+}
+
+fn snapshot<R: Any + Send + Sync + Clone>(kind: SignalKind) -> Vec<R> {
+    let reg = registry().read().unwrap_or_else(|e| e.into_inner());
+    let Some(bag) = reg.get(&kind) else {
+        return Vec::new();
+    };
+    bag.iter()
+        .filter_map(|(_, b)| b.downcast_ref::<R>().cloned())
+        .collect()
+}
+
+// ---------------------------------------------------------------- Receiver type aliases
+
+type PreReceiver = Arc<dyn Fn(PreMigrateContext) -> ReceiverFuture + Send + Sync>;
+type PostReceiver = Arc<dyn Fn(PostMigrateContext) -> ReceiverFuture + Send + Sync>;
+
+// ---------------------------------------------------------------- pre_migrate
+
+/// Register a `pre_migrate` receiver.
+pub fn connect_pre_migrate<F, Fut>(receiver: F) -> ReceiverId
+where
+    F: Fn(PreMigrateContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let boxed: PreReceiver = Arc::new(move |ctx| Box::pin(receiver(ctx)));
+    insert_receiver(SignalKind::PreMigrate, boxed)
+}
+
+/// Remove a previously-connected `pre_migrate` receiver.
+pub fn disconnect_pre_migrate(id: ReceiverId) -> bool {
+    remove_receiver(SignalKind::PreMigrate, id)
+}
+
+/// Fire `pre_migrate` for `ctx`. Called by the framework's migrate
+/// paths; available publicly so tests / custom runners can dispatch
+/// the signal too.
+pub async fn send_pre_migrate(ctx: PreMigrateContext) {
+    let receivers: Vec<PreReceiver> = snapshot(SignalKind::PreMigrate);
+    for r in receivers {
+        r(ctx.clone()).await;
+    }
+}
+
+// ---------------------------------------------------------------- post_migrate
+
+/// Register a `post_migrate` receiver.
+pub fn connect_post_migrate<F, Fut>(receiver: F) -> ReceiverId
+where
+    F: Fn(PostMigrateContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let boxed: PostReceiver = Arc::new(move |ctx| Box::pin(receiver(ctx)));
+    insert_receiver(SignalKind::PostMigrate, boxed)
+}
+
+/// Remove a previously-connected `post_migrate` receiver.
+pub fn disconnect_post_migrate(id: ReceiverId) -> bool {
+    remove_receiver(SignalKind::PostMigrate, id)
+}
+
+/// Fire `post_migrate` for `ctx`.
+pub async fn send_post_migrate(ctx: PostMigrateContext) {
+    let receivers: Vec<PostReceiver> = snapshot(SignalKind::PostMigrate);
+    for r in receivers {
+        r(ctx.clone()).await;
+    }
+}
+
+// ---------------------------------------------------------------- Maintenance
+
+/// Remove **all** migrate-signal receivers. Useful in tests to reset
+/// registry state between cases.
+pub fn clear_all() {
+    registry()
+        .write()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
+}
+
+/// Total receivers currently registered across both migrate signals.
+/// Useful in tests to assert connection state.
+pub fn receiver_count() -> usize {
+    let reg = registry().read().unwrap_or_else(|e| e.into_inner());
+    [SignalKind::PreMigrate, SignalKind::PostMigrate]
+        .iter()
+        .map(|kind| reg.get(kind).map_or(0, Vec::len))
+        .sum()
+}

--- a/crates/rustango/src/signals/mod.rs
+++ b/crates/rustango/src/signals/mod.rs
@@ -56,6 +56,7 @@ use std::sync::{Arc, OnceLock, RwLock};
 use crate::core::Model;
 
 pub mod auth;
+pub mod migrate;
 pub mod request;
 
 /// Future returned by signal receivers. `'static` because the receiver

--- a/crates/rustango/tests/migrate_signals_sqlite_live.rs
+++ b/crates/rustango/tests/migrate_signals_sqlite_live.rs
@@ -1,0 +1,165 @@
+//! Django-parity #411 — `pre_migrate` / `post_migrate` signals fire
+//! around `apply_all_pool` on a live SQLite pool.
+//!
+//! Verifies the integration end-to-end: a real bootstrap walk runs,
+//! connected receivers capture the contexts, ordering is pre → work →
+//! post, and source identifiers are correct.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+
+use std::sync::Arc;
+
+use rustango::signals::migrate::{
+    clear_all, connect_post_migrate, connect_pre_migrate, receiver_count, PostMigrateContext,
+    PreMigrateContext,
+};
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+/// Suite-wide lock: cargo runs tests in parallel and migrate-signal
+/// receivers live in a shared global registry. Without the mutex,
+/// `clear_all` in one test races another's connect+send.
+fn suite_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "mig_signal_widget")]
+#[rustango(app = "mig_signal_app")]
+#[allow(dead_code)]
+pub struct Widget {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub label: String,
+}
+
+async fn fresh_pool() -> Pool {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    Pool::Sqlite(sq)
+}
+
+#[tokio::test]
+async fn apply_all_pool_fires_pre_and_post_migrate() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+    assert_eq!(receiver_count(), 0);
+
+    // Capture both pre + post contexts + relative order using a
+    // shared trace log.
+    let trace: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+    let pre_ctx: Arc<Mutex<Option<PreMigrateContext>>> = Arc::new(Mutex::new(None));
+    let post_ctx: Arc<Mutex<Option<PostMigrateContext>>> = Arc::new(Mutex::new(None));
+
+    {
+        let trace = trace.clone();
+        let pre_ctx = pre_ctx.clone();
+        connect_pre_migrate(move |ctx| {
+            let trace = trace.clone();
+            let pre_ctx = pre_ctx.clone();
+            async move {
+                trace.lock().await.push("pre");
+                *pre_ctx.lock().await = Some(ctx);
+            }
+        });
+    }
+    {
+        let trace = trace.clone();
+        let post_ctx = post_ctx.clone();
+        connect_post_migrate(move |ctx| {
+            let trace = trace.clone();
+            let post_ctx = post_ctx.clone();
+            async move {
+                trace.lock().await.push("post");
+                *post_ctx.lock().await = Some(ctx);
+            }
+        });
+    }
+    assert_eq!(receiver_count(), 2);
+
+    let pool = fresh_pool().await;
+    rustango::migrate::apply_all_pool(&pool)
+        .await
+        .expect("apply_all_pool");
+
+    let t = trace.lock().await.clone();
+    assert_eq!(t, vec!["pre", "post"], "expected pre→post order, got {t:?}");
+
+    let p = pre_ctx.lock().await.clone().expect("pre fired");
+    assert_eq!(p.source, "apply_all_pool");
+    let q = post_ctx.lock().await.clone().expect("post fired");
+    assert_eq!(q.source, "apply_all_pool");
+    // `applied` is empty for bootstrap (no per-migration names).
+    assert!(q.applied.is_empty());
+}
+
+#[tokio::test]
+async fn signals_run_in_registration_order_within_each_kind() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let log: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    for tag in 1u8..=3 {
+        let log = log.clone();
+        connect_pre_migrate(move |_| {
+            let log = log.clone();
+            async move {
+                log.lock().await.push(tag);
+            }
+        });
+    }
+    let pool = fresh_pool().await;
+    rustango::migrate::apply_all_pool(&pool).await.unwrap();
+    assert_eq!(*log.lock().await, vec![1, 2, 3]);
+}
+
+#[tokio::test]
+async fn no_receivers_does_not_break_apply_all_pool() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+    assert_eq!(receiver_count(), 0);
+
+    // Zero receivers: send_* is a no-op; apply_all_pool should
+    // succeed end-to-end on a fresh pool.
+    let pool = fresh_pool().await;
+    rustango::migrate::apply_all_pool(&pool)
+        .await
+        .expect("apply_all_pool with no receivers");
+
+    // And running it twice in a row should still succeed (apply_all_pool
+    // is idempotent — CREATE TABLE IF NOT EXISTS isn't but the bootstrap
+    // walk only runs at startup; sqlite errors should be transparent
+    // here since we use a fresh pool per test).
+}
+
+#[tokio::test]
+async fn disconnect_removes_only_named_receiver() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let counter: Arc<Mutex<u32>> = Arc::new(Mutex::new(0));
+    let mut ids = Vec::new();
+    for _ in 0..3 {
+        let counter = counter.clone();
+        ids.push(connect_pre_migrate(move |_| {
+            let counter = counter.clone();
+            async move {
+                *counter.lock().await += 1;
+            }
+        }));
+    }
+    assert_eq!(receiver_count(), 3);
+
+    assert!(rustango::signals::migrate::disconnect_pre_migrate(ids[1]));
+    assert_eq!(receiver_count(), 2);
+
+    let pool = fresh_pool().await;
+    rustango::migrate::apply_all_pool(&pool).await.unwrap();
+
+    assert_eq!(*counter.lock().await, 2);
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -520,7 +520,7 @@ Summary: **7 / 1 / 2 / 0**.
 | `pre_save` / `post_save` | [signals](https://docs.djangoproject.com/en/6.0/topics/signals/) | SHIPPED | `signals::connect_pre_save` / `_post_save` | |
 | `pre_delete` / `post_delete` | (above) | SHIPPED | (above) | |
 | `m2m_changed` | (above) | MISSING | n/a (#410) | M2M operations don't fire signals yet. |
-| `pre_migrate` / `post_migrate` | [pre_migrate](https://docs.djangoproject.com/en/6.0/ref/signals/#pre-migrate) | MISSING | n/a (#411) | |
+| `pre_migrate` / `post_migrate` | [pre_migrate](https://docs.djangoproject.com/en/6.0/ref/signals/#pre-migrate) | SHIPPED | `signals::migrate::{connect_pre_migrate, connect_post_migrate}` (#411, v0.42) — wired into `migrate::{apply_all, apply_all_pool, migrate_with_ledger}`. `PostMigrateContext.applied: Vec<String>` lists newly-applied migration names. | |
 | `class_prepared` | (above) | N/A — Rust doesn't have lazy class creation | n/a | |
 | `request_started` / `request_finished` | [request signals](https://docs.djangoproject.com/en/6.0/ref/signals/#django.core.signals.request_started) | PARTIAL | tower `Service` semantics + tracing layer cover this (#412) | Not a discrete signal. |
 | `got_request_exception` | (above) | SHIPPED | `signals::request::got_request_exception` fires from `RequestSignalsLayer` on every 5xx response + the (rare) `Service::Error` arm (#413, v0.42). `RequestExceptionContext.status: Option<u16>` lets receivers distinguish the two cases. | |


### PR DESCRIPTION
Django-parity #411 — lifecycle signals fired around the framework's
migrate paths so audit / observability / cache-warmup receivers can
hook in without re-wiring each runner.

## New module: `signals::migrate`

```rust
pub struct PreMigrateContext  { source: &'static str }
pub struct PostMigrateContext { source: &'static str, applied: Vec<String> }

connect_pre_migrate / disconnect_pre_migrate / send_pre_migrate
connect_post_migrate / disconnect_post_migrate / send_post_migrate
receiver_count() + clear_all()  // test maintenance
```

## Sites wired (`migrate::runner`)

| Function | `source` | `applied` |
|---|---|---|
| `apply_all_pool` | `"apply_all_pool"` | `[]` |
| `apply_all` (PG) | `"apply_all"` | `[]` |
| `migrate_with_ledger` | `"migrate"` | newly-applied file names, in order |

`applied` is empty for bootstrap walks (no per-migration names —
those entry points iterate the model inventory). The file-based
ledger path captures `Migration.name` for every freshly-applied file
so audit receivers can record what changed.

## Tests

`crates/rustango/tests/migrate_signals_sqlite_live.rs` — 4 cases on
a real `sqlite::memory:` pool:
- `pre` fires then `post` fires, both carry `source="apply_all_pool"`
- Receivers fire in registration order
- `apply_all_pool` runs cleanly with no receivers connected
- `disconnect` removes only the named receiver

CI: `migrate_signals_sqlite_live` wired into `sqlite_litmus`.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — passes
- [x] `cargo test -p rustango --lib --no-default-features --features sqlite,tenancy` — 1458 passed
- [x] `cargo test -p rustango --lib --all-features` — 2363 passed
- [x] `cargo test -p rustango --test migrate_signals_sqlite_live` — 4/4 passed
- [ ] CI green (multi-job)

Closes #411. Completes the Django-parity small-wins batch — **15
audit rows flipped from MISSING/PARTIAL → SHIPPED across this session.**