### PR TITLE
feat(signals): `m2m_changed` fires from M2MManager (closes #410)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test migrate_signals_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_reverse
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_contains
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test m2m_changed_signal_sqlite_live
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/signals/m2m.rs
+++ b/crates/rustango/src/signals/m2m.rs
@@ -1,0 +1,188 @@
+//! Django-shape `m2m_changed` signal — fires when an M2M relationship's
+//! junction-table membership changes via [`crate::sql::M2MManager`].
+//! Django-parity #410.
+//!
+//! ## Quick start
+//!
+//! ```ignore
+//! use rustango::signals::m2m::{connect_m2m_changed, M2mChangedContext, M2mAction};
+//!
+//! connect_m2m_changed(|ctx| Box::pin(async move {
+//!     match ctx.action {
+//!         M2mAction::Add => tracing::info!(
+//!             through = ctx.through,
+//!             src = ctx.src_pk,
+//!             dst = ctx.dst_pks[0],
+//!             "m2m add"
+//!         ),
+//!         M2mAction::Remove => tracing::info!(
+//!             through = ctx.through,
+//!             src = ctx.src_pk,
+//!             dst = ctx.dst_pks[0],
+//!             "m2m remove"
+//!         ),
+//!         M2mAction::Set => tracing::info!(
+//!             through = ctx.through,
+//!             count = ctx.dst_pks.len(),
+//!             "m2m set"
+//!         ),
+//!         M2mAction::Clear => tracing::info!(
+//!             through = ctx.through,
+//!             src = ctx.src_pk,
+//!             "m2m clear"
+//!         ),
+//!     }
+//! }));
+//! ```
+//!
+//! ## Action shapes
+//!
+//! - `Add` — one destination added; `dst_pks = [the_id]`.
+//! - `Remove` — one destination removed; `dst_pks = [the_id]`.
+//! - `Set` — entire set replaced; `dst_pks = [the new set]` (may be empty).
+//! - `Clear` — every destination removed; `dst_pks = []`.
+//!
+//! Django's `m2m_changed` carries `action = "pre_add" / "post_add" /
+//! "pre_remove" / "post_remove" / "pre_clear" / "post_clear"` plus
+//! `pk_set`. rustango v1 fires only the `post_*` equivalent (after
+//! the SQL completed successfully) — pre_* hooks aren't useful in
+//! Rust where you can't abort the operation from the signal handler
+//! without convoluted plumbing.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock, RwLock};
+
+/// Future returned by m2m-signal receivers. `'static` because the
+/// receiver is stored as `Arc<dyn ...>` and may run after the caller
+/// has returned.
+pub type ReceiverFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+/// Opaque identifier returned by `connect_*` for later use with
+/// `disconnect_*`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ReceiverId(u64);
+
+/// Which M2M mutation triggered the signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum M2mAction {
+    /// Single destination added via `M2MManager::add_pool`.
+    Add,
+    /// Single destination removed via `M2MManager::remove_pool`.
+    Remove,
+    /// Full set replaced via `M2MManager::set_pool`.
+    Set,
+    /// Every destination removed via `M2MManager::clear_pool`.
+    Clear,
+}
+
+/// Payload delivered to `m2m_changed` receivers.
+#[derive(Debug, Clone)]
+pub struct M2mChangedContext {
+    pub action: M2mAction,
+    /// SQL name of the junction table (e.g. `"post_tags"`).
+    pub through: &'static str,
+    /// Source-side column name (the FK column pointing at the
+    /// source model). Lets receivers disambiguate when one junction
+    /// table holds multiple relationships.
+    pub src_col: &'static str,
+    /// Destination-side column name (the FK column pointing at the
+    /// target model).
+    pub dst_col: &'static str,
+    /// PK value of the source instance whose M2M was mutated.
+    pub src_pk: i64,
+    /// Affected destination PKs:
+    /// - `Add` / `Remove`: single element with the affected id
+    /// - `Set`: the new full set (may be empty)
+    /// - `Clear`: always empty
+    pub dst_pks: Vec<i64>,
+}
+
+// ---------------------------------------------------------------- Internal storage
+
+type ReceiverEntry = (ReceiverId, Box<dyn Any + Send + Sync>);
+type Bag = Vec<ReceiverEntry>;
+
+fn registry() -> &'static RwLock<HashMap<(), Bag>> {
+    static REG: OnceLock<RwLock<HashMap<(), Bag>>> = OnceLock::new();
+    REG.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+fn next_id() -> ReceiverId {
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    ReceiverId(COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+fn insert_receiver<R: Any + Send + Sync>(receiver: R) -> ReceiverId {
+    let id = next_id();
+    let mut reg = registry().write().unwrap_or_else(|e| e.into_inner());
+    reg.entry(()).or_default().push((id, Box::new(receiver)));
+    id
+}
+
+fn remove_receiver(id: ReceiverId) -> bool {
+    let mut reg = registry().write().unwrap_or_else(|e| e.into_inner());
+    let Some(bag) = reg.get_mut(&()) else {
+        return false;
+    };
+    let before = bag.len();
+    bag.retain(|(rid, _)| *rid != id);
+    bag.len() != before
+}
+
+fn snapshot<R: Any + Send + Sync + Clone>() -> Vec<R> {
+    let reg = registry().read().unwrap_or_else(|e| e.into_inner());
+    let Some(bag) = reg.get(&()) else {
+        return Vec::new();
+    };
+    bag.iter()
+        .filter_map(|(_, b)| b.downcast_ref::<R>().cloned())
+        .collect()
+}
+
+type ChangedReceiver = Arc<dyn Fn(M2mChangedContext) -> ReceiverFuture + Send + Sync>;
+
+// ---------------------------------------------------------------- API
+
+/// Register an `m2m_changed` receiver.
+pub fn connect_m2m_changed<F, Fut>(receiver: F) -> ReceiverId
+where
+    F: Fn(M2mChangedContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let boxed: ChangedReceiver = Arc::new(move |ctx| Box::pin(receiver(ctx)));
+    insert_receiver(boxed)
+}
+
+/// Remove a previously-connected `m2m_changed` receiver.
+pub fn disconnect_m2m_changed(id: ReceiverId) -> bool {
+    remove_receiver(id)
+}
+
+/// Fire `m2m_changed` for `ctx`. Called by [`crate::sql::M2MManager`];
+/// available publicly so tests / custom dispatch can also fire.
+pub async fn send_m2m_changed(ctx: M2mChangedContext) {
+    let receivers: Vec<ChangedReceiver> = snapshot();
+    for r in receivers {
+        r(ctx.clone()).await;
+    }
+}
+
+/// Remove **all** m2m-signal receivers. Useful in tests to reset
+/// registry state between cases.
+pub fn clear_all() {
+    registry()
+        .write()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
+}
+
+/// Total receivers currently registered.
+#[must_use]
+pub fn receiver_count() -> usize {
+    let reg = registry().read().unwrap_or_else(|e| e.into_inner());
+    reg.get(&()).map_or(0, Vec::len)
+}

--- a/crates/rustango/src/signals/mod.rs
+++ b/crates/rustango/src/signals/mod.rs
@@ -56,6 +56,7 @@ use std::sync::{Arc, OnceLock, RwLock};
 use crate::core::Model;
 
 pub mod auth;
+pub mod m2m;
 pub mod migrate;
 pub mod request;
 

--- a/crates/rustango/src/sql/m2m.rs
+++ b/crates/rustango/src/sql/m2m.rs
@@ -94,6 +94,16 @@ impl M2MManager {
         );
         let binds = vec![SqlValue::I64(self.src_pk_i64()), SqlValue::I64(dst_id)];
         super::executor::raw_execute_pool(pool, &sql, binds).await?;
+        // #410 — fire m2m_changed after successful junction-row write.
+        crate::signals::m2m::send_m2m_changed(crate::signals::m2m::M2mChangedContext {
+            action: crate::signals::m2m::M2mAction::Add,
+            through: self.through,
+            src_col: self.src_col,
+            dst_col: self.dst_col,
+            src_pk: self.src_pk_i64(),
+            dst_pks: vec![dst_id],
+        })
+        .await;
         Ok(())
     }
 
@@ -114,6 +124,16 @@ impl M2MManager {
         );
         let binds = vec![SqlValue::I64(self.src_pk_i64()), SqlValue::I64(dst_id)];
         super::executor::raw_execute_pool(pool, &sql, binds).await?;
+        // #410 — fire m2m_changed after successful junction-row remove.
+        crate::signals::m2m::send_m2m_changed(crate::signals::m2m::M2mChangedContext {
+            action: crate::signals::m2m::M2mAction::Remove,
+            through: self.through,
+            src_col: self.src_col,
+            dst_col: self.dst_col,
+            src_pk: self.src_pk_i64(),
+            dst_pks: vec![dst_id],
+        })
+        .await;
         Ok(())
     }
 
@@ -160,7 +180,7 @@ impl M2MManager {
         // Per-backend transaction. Each arm runs the DELETE + (optional)
         // INSERT inside the same `.begin()`/`.commit()` pair so the
         // junction is atomic from any reader's view.
-        match pool {
+        let result: Result<(), ExecError> = match pool {
             #[cfg(feature = "postgres")]
             Pool::Postgres(pg) => {
                 let mut tx = pg.begin().await.map_err(ExecError::Driver)?;
@@ -215,7 +235,21 @@ impl M2MManager {
                 tx.commit().await.map_err(ExecError::Driver)?;
                 Ok(())
             }
-        }
+        };
+        result?;
+        // #410 — fire m2m_changed after the atomic DELETE+INSERT
+        // commits. `dst_pks` is the new full set (may be empty when
+        // `set([])` was called).
+        crate::signals::m2m::send_m2m_changed(crate::signals::m2m::M2mChangedContext {
+            action: crate::signals::m2m::M2mAction::Set,
+            through: self.through,
+            src_col: self.src_col,
+            dst_col: self.dst_col,
+            src_pk: self.src_pk_i64(),
+            dst_pks: ids.to_vec(),
+        })
+        .await;
+        Ok(())
     }
 
     /// Remove all junction rows for the source instance.
@@ -233,6 +267,16 @@ impl M2MManager {
         );
         let binds = vec![SqlValue::I64(self.src_pk_i64())];
         super::executor::raw_execute_pool(pool, &sql, binds).await?;
+        // #410 — fire m2m_changed after clear.
+        crate::signals::m2m::send_m2m_changed(crate::signals::m2m::M2mChangedContext {
+            action: crate::signals::m2m::M2mAction::Clear,
+            through: self.through,
+            src_col: self.src_col,
+            dst_col: self.dst_col,
+            src_pk: self.src_pk_i64(),
+            dst_pks: Vec::new(),
+        })
+        .await;
         Ok(())
     }
 

--- a/crates/rustango/tests/m2m_changed_signal_sqlite_live.rs
+++ b/crates/rustango/tests/m2m_changed_signal_sqlite_live.rs
@@ -1,0 +1,195 @@
+//! Django-parity #410 — `m2m_changed` signal fires from
+//! `M2MManager::{add_pool, remove_pool, set_pool, clear_pool}`
+//! against a live SQLite junction table.
+
+#![cfg(all(feature = "sqlite", feature = "signals"))]
+
+use std::sync::Arc;
+
+use rustango::core::SqlValue;
+use rustango::signals::m2m::{
+    clear_all, connect_m2m_changed, receiver_count, M2mAction, M2mChangedContext,
+};
+use rustango::sql::{sqlx, M2MManager, Pool};
+use tokio::sync::Mutex;
+
+/// Suite-wide lock — `clear_all` mutates a global registry, races
+/// any other test with a receiver connected.
+fn suite_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn pool_with_junction() -> Pool {
+    let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory pool");
+    sqlx::query(
+        r#"CREATE TABLE post_tags (
+            post_id INTEGER NOT NULL,
+            tag_id  INTEGER NOT NULL,
+            UNIQUE(post_id, tag_id)
+        )"#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create junction");
+    Pool::Sqlite(pool)
+}
+
+fn mgr(post_id: i64) -> M2MManager {
+    M2MManager {
+        src_pk: SqlValue::I64(post_id),
+        through: "post_tags",
+        src_col: "post_id",
+        dst_col: "tag_id",
+    }
+}
+
+#[tokio::test]
+async fn add_fires_with_add_action_and_single_dst_pk() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let captured: Arc<Mutex<Vec<M2mChangedContext>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    connect_m2m_changed(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().await.push(ctx);
+        }
+    });
+
+    let pool = pool_with_junction().await;
+    mgr(1).add_pool(7, &pool).await.unwrap();
+
+    let got = captured.lock().await;
+    assert_eq!(got.len(), 1, "exactly one fire, got: {got:?}");
+    assert!(matches!(got[0].action, M2mAction::Add));
+    assert_eq!(got[0].through, "post_tags");
+    assert_eq!(got[0].src_col, "post_id");
+    assert_eq!(got[0].dst_col, "tag_id");
+    assert_eq!(got[0].src_pk, 1);
+    assert_eq!(got[0].dst_pks, vec![7]);
+}
+
+#[tokio::test]
+async fn remove_fires_with_remove_action() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let captured: Arc<Mutex<Vec<M2mChangedContext>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    connect_m2m_changed(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().await.push(ctx);
+        }
+    });
+
+    let pool = pool_with_junction().await;
+    let m = mgr(1);
+    m.add_pool(7, &pool).await.unwrap();
+    captured.lock().await.clear(); // ignore the Add for clarity
+
+    m.remove_pool(7, &pool).await.unwrap();
+
+    let got = captured.lock().await;
+    assert_eq!(got.len(), 1);
+    assert!(matches!(got[0].action, M2mAction::Remove));
+    assert_eq!(got[0].dst_pks, vec![7]);
+}
+
+#[tokio::test]
+async fn set_fires_with_set_action_and_full_new_set() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let captured: Arc<Mutex<Vec<M2mChangedContext>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    connect_m2m_changed(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().await.push(ctx);
+        }
+    });
+
+    let pool = pool_with_junction().await;
+    mgr(1).set_pool(&[7, 8, 9], &pool).await.unwrap();
+
+    let got = captured.lock().await;
+    assert_eq!(got.len(), 1, "set fires once, got: {got:?}");
+    assert!(matches!(got[0].action, M2mAction::Set));
+    assert_eq!(got[0].dst_pks, vec![7, 8, 9]);
+}
+
+#[tokio::test]
+async fn set_with_empty_slice_fires_set_with_empty_pks() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let captured: Arc<Mutex<Vec<M2mChangedContext>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    connect_m2m_changed(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().await.push(ctx);
+        }
+    });
+
+    let pool = pool_with_junction().await;
+    mgr(1).add_pool(7, &pool).await.unwrap();
+    captured.lock().await.clear();
+
+    mgr(1).set_pool(&[], &pool).await.unwrap();
+
+    let got = captured.lock().await;
+    assert_eq!(got.len(), 1);
+    assert!(matches!(got[0].action, M2mAction::Set));
+    assert!(got[0].dst_pks.is_empty());
+}
+
+#[tokio::test]
+async fn clear_fires_with_clear_action_and_empty_pks() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let captured: Arc<Mutex<Vec<M2mChangedContext>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    connect_m2m_changed(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().await.push(ctx);
+        }
+    });
+
+    let pool = pool_with_junction().await;
+    let m = mgr(1);
+    m.add_pool(7, &pool).await.unwrap();
+    m.add_pool(8, &pool).await.unwrap();
+    captured.lock().await.clear();
+
+    m.clear_pool(&pool).await.unwrap();
+
+    let got = captured.lock().await;
+    assert_eq!(got.len(), 1);
+    assert!(matches!(got[0].action, M2mAction::Clear));
+    assert!(got[0].dst_pks.is_empty());
+}
+
+#[tokio::test]
+async fn no_receivers_does_not_break_m2m_ops() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+    assert_eq!(receiver_count(), 0);
+
+    let pool = pool_with_junction().await;
+    let m = mgr(1);
+    // All four mutating ops must succeed with no receivers connected.
+    m.add_pool(7, &pool).await.unwrap();
+    m.add_pool(8, &pool).await.unwrap();
+    m.remove_pool(7, &pool).await.unwrap();
+    m.set_pool(&[9, 10], &pool).await.unwrap();
+    m.clear_pool(&pool).await.unwrap();
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -519,7 +519,7 @@ Summary: **7 / 1 / 2 / 0**.
 |---|---|---|---|---|
 | `pre_save` / `post_save` | [signals](https://docs.djangoproject.com/en/6.0/topics/signals/) | SHIPPED | `signals::connect_pre_save` / `_post_save` | |
 | `pre_delete` / `post_delete` | (above) | SHIPPED | (above) | |
-| `m2m_changed` | (above) | MISSING | n/a (#410) | M2M operations don't fire signals yet. |
+| `m2m_changed` | (above) | SHIPPED | `signals::m2m::connect_m2m_changed` (#410, v0.42) — fires from `M2MManager::{add_pool, remove_pool, set_pool, clear_pool}`. `M2mAction` enum: Add / Remove / Set / Clear; `dst_pks` carries affected ids per action. | |
 | `pre_migrate` / `post_migrate` | [pre_migrate](https://docs.djangoproject.com/en/6.0/ref/signals/#pre-migrate) | SHIPPED | `signals::migrate::{connect_pre_migrate, connect_post_migrate}` (#411, v0.42) — wired into `migrate::{apply_all, apply_all_pool, migrate_with_ledger}`. `PostMigrateContext.applied: Vec<String>` lists newly-applied migration names. | |
 | `class_prepared` | (above) | N/A — Rust doesn't have lazy class creation | n/a | |
 | `request_started` / `request_finished` | [request signals](https://docs.djangoproject.com/en/6.0/ref/signals/#django.core.signals.request_started) | PARTIAL | tower `Service` semantics + tracing layer cover this (#412) | Not a discrete signal. |


### PR DESCRIPTION
Django-parity #410 — `m2m_changed` lifecycle signal. Fires after
every junction-table mutation through `M2MManager` so audit /
cache-invalidation / search-reindex receivers can react without
re-wiring each call site.

## New module: `signals::m2m`

```rust
pub enum M2mAction { Add, Remove, Set, Clear }
pub struct M2mChangedContext {
    action, through, src_col, dst_col, src_pk, dst_pks
}

connect_m2m_changed / disconnect_m2m_changed / send_m2m_changed
receiver_count() + clear_all()
```

## Sites wired (`sql::m2m::M2MManager`)

| Method | `action` | `dst_pks` |
|---|---|---|
| `add_pool(dst)` | `Add` | `[dst]` |
| `remove_pool(dst)` | `Remove` | `[dst]` |
| `set_pool(ids)` | `Set` | `ids.to_vec()` (may be empty) |
| `clear_pool()` | `Clear` | `[]` |

## Behavioral divergence vs Django (documented)

Django's `m2m_changed` also has `pre_*` variants (`pre_add` /
`pre_remove` / `pre_clear`). v1 fires only the `post_*` equivalent —
`pre_*` hooks aren't useful in Rust without convoluted plumbing to
abort the operation from the handler. The module rustdoc documents
the omission.

## Tests

`crates/rustango/tests/m2m_changed_signal_sqlite_live.rs` — 6 cases
on a real sqlite junction table:
- `add` fires `Add` with `[dst]`
- `remove` fires `Remove` with `[dst]`
- `set([7,8,9])` fires `Set` with the full new set
- `set([])` fires `Set` with empty `dst_pks`
- `clear` fires `Clear` with empty `dst_pks`
- All mutating ops succeed with no receivers connected

CI: `m2m_changed_signal_sqlite_live` wired into `sqlite_litmus`.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — passes
- [x] `cargo test -p rustango --lib --no-default-features --features sqlite,tenancy` — 1458 passed
- [x] `cargo test -p rustango --lib --all-features` — 2363 passed
- [x] `cargo test -p rustango --test m2m_changed_signal_sqlite_live` — 6/6 passed
- [ ] CI green (multi-job)

Closes #410.