### PR TITLE
feat(signals): `setting_changed` on overlay scope enter/exit (closes #415)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_reverse
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_contains
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test m2m_changed_signal_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,config,email --test setting_changed_signal
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/signals/mod.rs
+++ b/crates/rustango/src/signals/mod.rs
@@ -59,6 +59,7 @@ pub mod auth;
 pub mod m2m;
 pub mod migrate;
 pub mod request;
+pub mod setting;
 
 /// Future returned by signal receivers. `'static` because the receiver
 /// is stored as `Box<dyn ...>` and may run after the caller has returned.

--- a/crates/rustango/src/signals/setting.rs
+++ b/crates/rustango/src/signals/setting.rs
@@ -1,0 +1,128 @@
+//! Django-shape `setting_changed` signal — fires when a
+//! [`crate::test_settings::with_overridden`] override scope is
+//! entered or left. Django-parity #415.
+//!
+//! Django's `setting_changed` fires per-setting with `setting`,
+//! `value`, `enter` (bool). rustango's overlay scopes are
+//! whole-Settings replacements rather than per-field deltas, so the
+//! signal carries just `enter: bool` — `true` when the scope begins,
+//! `false` when it ends. Receivers typically use it to invalidate
+//! caches that depend on configuration values.
+//!
+//! ## Quick start
+//!
+//! ```ignore
+//! use rustango::signals::setting::{connect_setting_changed, SettingChangedContext};
+//!
+//! connect_setting_changed(|ctx| Box::pin(async move {
+//!     if ctx.enter {
+//!         tracing::debug!("settings overlay entered — flushing caches");
+//!         // ...
+//!     } else {
+//!         tracing::debug!("settings overlay left");
+//!     }
+//! }));
+//! ```
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock, RwLock};
+
+pub type ReceiverFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ReceiverId(u64);
+
+/// Payload delivered to `setting_changed` receivers.
+#[derive(Debug, Clone, Copy)]
+pub struct SettingChangedContext {
+    /// `true` when an override scope is entered; `false` when the
+    /// scope's future completes and the scope is leaving.
+    pub enter: bool,
+}
+
+type ReceiverEntry = (ReceiverId, Box<dyn Any + Send + Sync>);
+type Bag = Vec<ReceiverEntry>;
+
+fn registry() -> &'static RwLock<HashMap<(), Bag>> {
+    static REG: OnceLock<RwLock<HashMap<(), Bag>>> = OnceLock::new();
+    REG.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+fn next_id() -> ReceiverId {
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    ReceiverId(COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+fn insert_receiver<R: Any + Send + Sync>(receiver: R) -> ReceiverId {
+    let id = next_id();
+    let mut reg = registry().write().unwrap_or_else(|e| e.into_inner());
+    reg.entry(()).or_default().push((id, Box::new(receiver)));
+    id
+}
+
+fn remove_receiver(id: ReceiverId) -> bool {
+    let mut reg = registry().write().unwrap_or_else(|e| e.into_inner());
+    let Some(bag) = reg.get_mut(&()) else {
+        return false;
+    };
+    let before = bag.len();
+    bag.retain(|(rid, _)| *rid != id);
+    bag.len() != before
+}
+
+fn snapshot<R: Any + Send + Sync + Clone>() -> Vec<R> {
+    let reg = registry().read().unwrap_or_else(|e| e.into_inner());
+    let Some(bag) = reg.get(&()) else {
+        return Vec::new();
+    };
+    bag.iter()
+        .filter_map(|(_, b)| b.downcast_ref::<R>().cloned())
+        .collect()
+}
+
+type ChangedReceiver = Arc<dyn Fn(SettingChangedContext) -> ReceiverFuture + Send + Sync>;
+
+/// Register a `setting_changed` receiver.
+pub fn connect_setting_changed<F, Fut>(receiver: F) -> ReceiverId
+where
+    F: Fn(SettingChangedContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let boxed: ChangedReceiver = Arc::new(move |ctx| Box::pin(receiver(ctx)));
+    insert_receiver(boxed)
+}
+
+/// Remove a previously-connected `setting_changed` receiver.
+pub fn disconnect_setting_changed(id: ReceiverId) -> bool {
+    remove_receiver(id)
+}
+
+/// Fire `setting_changed` for `ctx`. Called by
+/// [`crate::test_settings::with_overridden`]; available publicly so
+/// custom configuration-overlay machinery can dispatch the same
+/// signal.
+pub async fn send_setting_changed(ctx: SettingChangedContext) {
+    let receivers: Vec<ChangedReceiver> = snapshot();
+    for r in receivers {
+        r(ctx).await;
+    }
+}
+
+/// Remove **all** setting-signal receivers. Test maintenance helper.
+pub fn clear_all() {
+    registry()
+        .write()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
+}
+
+/// Total receivers currently registered.
+#[must_use]
+pub fn receiver_count() -> usize {
+    let reg = registry().read().unwrap_or_else(|e| e.into_inner());
+    reg.get(&()).map_or(0, Vec::len)
+}

--- a/crates/rustango/src/test_settings.rs
+++ b/crates/rustango/src/test_settings.rs
@@ -69,7 +69,16 @@ pub async fn with_overridden<F>(overlay: Settings, future: F) -> F::Output
 where
     F: std::future::Future,
 {
-    OVERLAY.scope(overlay, future).await
+    use crate::signals::setting::{send_setting_changed, SettingChangedContext};
+    // #415 — fire setting_changed on scope entry. Cache-invalidation
+    // / config-derived state receivers get a chance to flush before
+    // the user's overlay-aware code runs.
+    send_setting_changed(SettingChangedContext { enter: true }).await;
+    let result = OVERLAY.scope(overlay, future).await;
+    // Fire again on scope exit so receivers can refresh against the
+    // restored fallback Settings.
+    send_setting_changed(SettingChangedContext { enter: false }).await;
+    result
 }
 
 /// Return the active Settings: the task-local overlay when one is

--- a/crates/rustango/tests/setting_changed_signal.rs
+++ b/crates/rustango/tests/setting_changed_signal.rs
@@ -1,0 +1,118 @@
+//! Django-parity #415 — `setting_changed` signal fires from
+//! [`rustango::test_settings::with_overridden`] on scope enter +
+//! exit.
+
+#![cfg(all(feature = "signals", feature = "config"))]
+
+use std::sync::Arc;
+
+use rustango::config::Settings;
+use rustango::signals::setting::{
+    clear_all, connect_setting_changed, receiver_count, SettingChangedContext,
+};
+use rustango::test_settings::with_overridden;
+use tokio::sync::Mutex;
+
+/// Suite-wide lock — `clear_all` touches a global registry.
+fn suite_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[tokio::test]
+async fn signal_fires_on_overlay_enter_and_exit() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let captured: Arc<Mutex<Vec<SettingChangedContext>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    connect_setting_changed(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().await.push(ctx);
+        }
+    });
+
+    let value = with_overridden(Settings::default(), async {
+        // While inside the scope, we should have observed exactly one
+        // "enter" fire and zero "exit" fires.
+        let so_far = captured.lock().await.clone();
+        assert_eq!(so_far.len(), 1, "expected 1 enter fire mid-scope");
+        assert!(so_far[0].enter);
+        42
+    })
+    .await;
+    assert_eq!(value, 42);
+
+    // After the scope returns, we should have seen the exit fire too.
+    let got = captured.lock().await;
+    assert_eq!(got.len(), 2, "expected enter+exit fires, got: {got:?}");
+    assert!(got[0].enter);
+    assert!(!got[1].enter);
+}
+
+#[tokio::test]
+async fn nested_scopes_fire_signal_pairs() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let trace: Arc<Mutex<Vec<bool>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = trace.clone();
+    connect_setting_changed(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().await.push(ctx.enter);
+        }
+    });
+
+    with_overridden(Settings::default(), async {
+        with_overridden(Settings::default(), async {
+            // Inner scope active here.
+        })
+        .await;
+    })
+    .await;
+
+    let got = trace.lock().await;
+    // Sequence: outer enter, inner enter, inner exit, outer exit.
+    assert_eq!(*got, vec![true, true, false, false]);
+}
+
+#[tokio::test]
+async fn no_receivers_does_not_break_overlay() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+    assert_eq!(receiver_count(), 0);
+
+    // Override scope with no receivers connected must run cleanly.
+    let value = with_overridden(Settings::default(), async { 7 }).await;
+    assert_eq!(value, 7);
+}
+
+#[tokio::test]
+async fn disconnect_stops_future_fires() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let counter: Arc<Mutex<u32>> = Arc::new(Mutex::new(0));
+    let sink = counter.clone();
+    let id = connect_setting_changed(move |_| {
+        let sink = sink.clone();
+        async move {
+            *sink.lock().await += 1;
+        }
+    });
+
+    with_overridden(Settings::default(), async {}).await;
+    assert_eq!(*counter.lock().await, 2, "enter+exit while connected");
+
+    assert!(rustango::signals::setting::disconnect_setting_changed(id));
+
+    with_overridden(Settings::default(), async {}).await;
+    assert_eq!(
+        *counter.lock().await,
+        2,
+        "no further fires after disconnect"
+    );
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -525,7 +525,7 @@ Summary: **7 / 1 / 2 / 0**.
 | `request_started` / `request_finished` | [request signals](https://docs.djangoproject.com/en/6.0/ref/signals/#django.core.signals.request_started) | PARTIAL | tower `Service` semantics + tracing layer cover this (#412) | Not a discrete signal. |
 | `got_request_exception` | (above) | SHIPPED | `signals::request::got_request_exception` fires from `RequestSignalsLayer` on every 5xx response + the (rare) `Service::Error` arm (#413, v0.42). `RequestExceptionContext.status: Option<u16>` lets receivers distinguish the two cases. | |
 | `user_logged_in` / `user_logged_out` / `user_login_failed` | [auth signals](https://docs.djangoproject.com/en/6.0/ref/contrib/auth/#module-django.contrib.auth.signals) | SHIPPED | `signals::auth::*` (#414, v0.42) — fired from admin / tenant admin / operator console / JWT login + logout paths with `AuthRequestMeta` context | |
-| `setting_changed` | (above) | MISSING | n/a (#415) | |
+| `setting_changed` | (above) | SHIPPED | `signals::setting::connect_setting_changed` (#415, v0.42) — fires from `test_settings::with_overridden` on scope enter (`enter: true`) and exit (`enter: false`). Receivers typically flush config-derived caches. | |
 | Disconnect / weak references | (above) | SHIPPED | `signals::disconnect_*` | |
 | Async receivers | (Django 4.1+ async receivers) | SHIPPED | All rustango signal receivers are `async fn` | |
 


### PR DESCRIPTION
Django-parity #415 — `setting_changed` lifecycle signal. Fires once
on entry and once on exit of every
`test_settings::with_overridden` scope. Receivers typically
invalidate caches that depend on configuration values (prefixes,
JWT TTLs, brand strings, etc.) so the next read inside the overlay
sees fresh state.

## New module: `signals::setting`

```rust
pub struct SettingChangedContext { enter: bool }

connect_setting_changed / disconnect_setting_changed / send_setting_changed
receiver_count() + clear_all()
```

## Wired in `test_settings::with_overridden`

- Pre-scope: `send_setting_changed(enter: true)`
- Run user future inside `OVERLAY.scope(...)`
- Post-scope: `send_setting_changed(enter: false)`
- Return the future's output unchanged

## Behavioral difference vs Django (documented)

Django's signal carries `(setting, value, enter)` per-field —
rustango overrides are whole-Settings replacements, so we carry
just `enter: bool`. Cache-invalidation receivers don't need per-field
deltas; they invalidate the whole bag and rebuild.

## Tests

`crates/rustango/tests/setting_changed_signal.rs` — 4 cases:
- `enter` fires before the future runs; `exit` fires after
- Nested scopes fire pairs in correct order (outer-in, inner-in, inner-out, outer-out)
- With no receivers connected, `with_overridden` runs cleanly
- `disconnect` stops future fires

CI: `setting_changed_signal` wired into `sqlite_litmus` with
`+config,+email` features for `Settings` + email-backend wiring.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — passes
- [x] `cargo test -p rustango --lib --no-default-features --features sqlite,tenancy` — 1458 passed
- [x] `cargo test -p rustango --lib --all-features` — 2363 passed
- [x] `cargo test -p rustango --test setting_changed_signal --features sqlite,tenancy,config,email` — 4/4 passed
- [ ] CI green (multi-job)

Closes #415.