### PR TITLE
feat(validators): ip_address + GenericIPAddressField parity (closes #337)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_contains
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test m2m_changed_signal_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,config,email --test setting_changed_signal
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_ipaddress_field
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -112,8 +112,10 @@ pub struct FieldSchema {
     /// `validate_slug`, `validate_unicode_slug`, `validate_phone_e164`,
     /// `validate_hex_color`, `validate_uuid`, `validate_iso_date`,
     /// `validate_iso_time`, `validate_iso_datetime`, `validate_ipv4`,
-    /// `validate_ipv6`, `validate_no_null`). Unknown names error at
-    /// runtime via [`crate::core::QueryError::UnknownValidator`].
+    /// `validate_ipv6`, `validate_ip_address` /
+    /// `validate_genericipaddress` (#337 — accepts either family),
+    /// `validate_no_null`). Unknown names error at runtime via
+    /// [`crate::core::QueryError::UnknownValidator`].
     pub validators: &'static [&'static str],
 }
 

--- a/crates/rustango/src/core/validate.rs
+++ b/crates/rustango/src/core/validate.rs
@@ -113,6 +113,10 @@ fn check_named_validators(
             "iso_datetime" => v::validate_iso_datetime(value),
             "ipv4" => v::validate_ipv4_address(value),
             "ipv6" => v::validate_ipv6_address(value),
+            // #337 — Django `GenericIPAddressField` accepts either
+            // family. Alias `genericipaddress` for callers translating
+            // verbatim from a Django Field.
+            "ip_address" | "genericipaddress" => v::validate_ip_address(value),
             "no_null" => v::validate_prohibit_null_characters(value),
             "email_list" => v::validate_email_list(value),
             "integer" => v::validate_integer(value),

--- a/crates/rustango/src/validators.rs
+++ b/crates/rustango/src/validators.rs
@@ -1567,6 +1567,24 @@ pub fn validate_ipv6_address(s: &str) -> Result<(), ValidationError> {
         .map_err(|_| ValidationError::new("invalid_ipv6_address", "Enter a valid IPv6 address."))
 }
 
+/// Validate that `s` parses as either an IPv4 or IPv6 address.
+/// Mirrors Django's `GenericIPAddressField(protocol="both")` (the
+/// default). Issue #337 / Django-parity.
+///
+/// # Errors
+/// `ValidationError { code: "invalid_ip_address", ... }` when the
+/// value doesn't parse as either family.
+pub fn validate_ip_address(s: &str) -> Result<(), ValidationError> {
+    use std::str::FromStr as _;
+    if std::net::Ipv4Addr::from_str(s).is_ok() || std::net::Ipv6Addr::from_str(s).is_ok() {
+        return Ok(());
+    }
+    Err(ValidationError::new(
+        "invalid_ip_address",
+        "Enter a valid IPv4 or IPv6 address.",
+    ))
+}
+
 // ------------------------------------------------------------------ comma-separated integer list
 
 /// Validate a comma-separated list of email addresses (e.g. a

--- a/crates/rustango/tests/macro_ipaddress_field.rs
+++ b/crates/rustango/tests/macro_ipaddress_field.rs
@@ -1,0 +1,131 @@
+//! Django-parity #337 — `GenericIPAddressField` equivalent via
+//! `#[rustango(validators = "ip_address")]`. The validator accepts
+//! either IPv4 or IPv6 strings; the alias `genericipaddress`
+//! exists for callers translating verbatim from a Django field.
+//!
+//! IPv4-only / IPv6-only protocols are covered by the existing
+//! `validate_ipv4` / `validate_ipv6` validators that shipped with #447.
+
+use rustango::core::{validate_value, FieldSchema, Model, QueryError, SqlValue};
+use rustango_macros::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "macro_ipaddr_host")]
+#[allow(dead_code)]
+pub struct Host {
+    #[rustango(primary_key)]
+    pub id: i64,
+
+    /// Both families — Django's default `GenericIPAddressField`.
+    #[rustango(max_length = 45, validators = "ip_address")]
+    pub addr: String,
+
+    /// IPv4 only.
+    #[rustango(max_length = 15, validators = "ipv4")]
+    pub v4_only: String,
+
+    /// IPv6 only.
+    #[rustango(max_length = 45, validators = "ipv6")]
+    pub v6_only: String,
+
+    /// Alias for Django-translated callers.
+    #[rustango(max_length = 45, validators = "genericipaddress")]
+    pub via_alias: String,
+}
+
+fn field<'a>(name: &str) -> &'a FieldSchema {
+    Host::SCHEMA
+        .field(name)
+        .unwrap_or_else(|| panic!("no field {name:?}"))
+}
+
+#[test]
+fn ip_address_validator_accepts_ipv4() {
+    validate_value(
+        "Host",
+        field("addr"),
+        &SqlValue::String("192.168.1.1".into()),
+    )
+    .unwrap();
+}
+
+#[test]
+fn ip_address_validator_accepts_ipv6() {
+    validate_value(
+        "Host",
+        field("addr"),
+        &SqlValue::String("2001:db8::1".into()),
+    )
+    .unwrap();
+    // Loopback.
+    validate_value("Host", field("addr"), &SqlValue::String("::1".into())).unwrap();
+}
+
+#[test]
+fn ip_address_validator_rejects_non_ip() {
+    let err =
+        validate_value("Host", field("addr"), &SqlValue::String("not-an-ip".into())).unwrap_err();
+    match err {
+        QueryError::ValidatorFailed {
+            field: name,
+            validator,
+            ..
+        } => {
+            assert_eq!(name, "addr");
+            assert_eq!(validator, "ip_address");
+        }
+        other => panic!("expected ValidatorFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn ipv4_validator_rejects_ipv6() {
+    let err =
+        validate_value("Host", field("v4_only"), &SqlValue::String("::1".into())).unwrap_err();
+    match err {
+        QueryError::ValidatorFailed { validator, .. } => assert_eq!(validator, "ipv4"),
+        other => panic!("expected ValidatorFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn ipv6_validator_rejects_ipv4() {
+    let err = validate_value(
+        "Host",
+        field("v6_only"),
+        &SqlValue::String("192.168.1.1".into()),
+    )
+    .unwrap_err();
+    match err {
+        QueryError::ValidatorFailed { validator, .. } => assert_eq!(validator, "ipv6"),
+        other => panic!("expected ValidatorFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn genericipaddress_alias_works_same_as_ip_address() {
+    validate_value(
+        "Host",
+        field("via_alias"),
+        &SqlValue::String("10.0.0.1".into()),
+    )
+    .unwrap();
+    validate_value(
+        "Host",
+        field("via_alias"),
+        &SqlValue::String("2001:db8::1".into()),
+    )
+    .unwrap();
+    let err = validate_value(
+        "Host",
+        field("via_alias"),
+        &SqlValue::String("invalid".into()),
+    )
+    .unwrap_err();
+    match err {
+        QueryError::ValidatorFailed { validator, .. } => {
+            assert_eq!(validator, "genericipaddress");
+        }
+        other => panic!("expected ValidatorFailed, got {other:?}"),
+    }
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -143,7 +143,7 @@ Built-in Django fields:
 | `EmailField` (validator) | [EmailField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#emailfield) | PARTIAL | `String` + `validators::validate_email` form-side (#334) | No model-level email validation on insert/update. |
 | `URLField` | [URLField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#urlfield) | PARTIAL | Same shape as EmailField (#335) | |
 | `SlugField` | [SlugField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#slugfield) | PARTIAL | `String` + `slug_field` macro attr (slug generation) (#336) | No slugify on save signal. |
-| `IPAddressField` / `GenericIPAddressField` | [GenericIPAddressField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#genericipaddressfield) | MISSING | n/a (#337) | Use `String`; no validator. |
+| `IPAddressField` / `GenericIPAddressField` | [GenericIPAddressField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#genericipaddressfield) | SHIPPED | `#[rustango(validators = "ip_address")]` (or `"ipv4"` / `"ipv6"` for protocol-specific) (#337, v0.42). Alias `genericipaddress` accepted for direct Django translation. Column type stays `String`. | |
 | `FilePathField` | [FilePathField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#filepathfield) | MISSING | n/a (#338) | |
 | `FileField` (model side) | [FileField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#filefield) | MISSING | n/a (#339) | rustango has `Media` model + Storage backends; not a native FileField on arbitrary models. |
 | `ImageField` | [ImageField](https://docs.djangoproject.com/en/6.0/ref/models/fields/#imagefield) | MISSING | n/a (#340) | Same — image-specific FileField pattern not surfaced. |


### PR DESCRIPTION
Django-parity #337 — `GenericIPAddressField`. Django ships three
protocol variants: `'both'` (default), `'IPv4'`, `'IPv6'`. rustango
already had `ipv4` + `ipv6` validators (shipped with #447); this PR
adds the missing `'both'` variant.

## API

```rust
#[rustango(max_length = 45, validators = "ip_address")]
pub addr: String,

// Django-translation alias
#[rustango(max_length = 45, validators = "genericipaddress")]
pub addr_alias: String,

// Protocol-specific (already shipped with #447)
#[rustango(max_length = 15, validators = "ipv4")] pub v4: String,
#[rustango(max_length = 45, validators = "ipv6")] pub v6: String,
```

## New helper

`crates/rustango/src/validators.rs::validate_ip_address` — tries
`Ipv4Addr::from_str` then `Ipv6Addr::from_str` before rejecting with
`invalid_ip_address`.

Wired into `core::validate.rs` dispatch under two names:
- `"ip_address"` — rustango canonical
- `"genericipaddress"` — Django-style alias for verbatim translation

## Tests

`crates/rustango/tests/macro_ipaddress_field.rs` — 6 cases:
- `ip_address` accepts IPv4
- `ip_address` accepts IPv6 (incl. `::1`)
- `ip_address` rejects non-IP with `ValidatorFailed`
- `ipv4` validator rejects IPv6 input (protocol-strict)
- `ipv6` validator rejects IPv4 input (protocol-strict)
- `genericipaddress` alias works identically to `ip_address`

CI: `macro_ipaddress_field` wired into `sqlite_litmus`.

Closes #337.