### PR TITLE
feat(admin): `actions_on_top` / `actions_on_bottom` (closes #354)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
             --test admin_sqlite_live \
             --test admin_list_display_links_sqlite_live \
             --test admin_search_help_text_sqlite_live \
+            --test admin_actions_position_sqlite_live \
             --test audit_pool_sqlite_live \
             --test bulk_upsert_sqlite_live \
             --test count_distinct_sqlite_live \

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -1904,6 +1904,8 @@ fn admin_config_tokens(admin: Option<&AdminAttrs>) -> TokenStream2 {
     let list_display_links_lits = list_display_links.iter().map(|s| s.as_str());
 
     let search_help_text = admin.search_help_text.as_deref().unwrap_or("");
+    let actions_on_top = admin.actions_on_top.unwrap_or(true);
+    let actions_on_bottom = admin.actions_on_bottom.unwrap_or(false);
 
     let list_per_page = admin.list_per_page.unwrap_or(0);
 
@@ -1930,6 +1932,8 @@ fn admin_config_tokens(admin: Option<&AdminAttrs>) -> TokenStream2 {
             fieldsets: &[ #( #fieldset_tokens ),* ],
             list_display_links: &[ #( #list_display_links_lits ),* ],
             search_help_text: #search_help_text,
+            actions_on_top: #actions_on_top,
+            actions_on_bottom: #actions_on_bottom,
         })
     }
 }
@@ -4444,6 +4448,13 @@ struct AdminAttrs {
     /// caption rendered beside the admin list view's search box.
     /// Issue #353.
     search_help_text: Option<String>,
+    /// `admin(actions_on_top = false)` — Django-shape. Hides the
+    /// action-bar above the table. Default `true`. Issue #354.
+    actions_on_top: Option<bool>,
+    /// `admin(actions_on_bottom = true)` — Django-shape. Renders an
+    /// additional action-bar below the table. Default `false`.
+    /// Issue #354.
+    actions_on_bottom: Option<bool>,
 }
 
 fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
@@ -4580,12 +4591,23 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                         admin.search_help_text = Some(s.value());
                         return Ok(());
                     }
+                    if inner.path.is_ident("actions_on_top") {
+                        let lit: syn::LitBool = inner.value()?.parse()?;
+                        admin.actions_on_top = Some(lit.value);
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("actions_on_bottom") {
+                        let lit: syn::LitBool = inner.value()?.parse()?;
+                        admin.actions_on_bottom = Some(lit.value);
+                        return Ok(());
+                    }
                     Err(inner.error(
                         "unknown admin attribute (supported: \
                          `list_display`, `list_display_links`, \
                          `search_fields`, `search_help_text`, \
                          `readonly_fields`, \
                          `list_filter`, `list_per_page`, `ordering`, `actions`, \
+                         `actions_on_top`, `actions_on_bottom`, \
                          `fieldsets`)",
                     ))
                 })?;

--- a/crates/rustango/src/admin/templates/list.html
+++ b/crates/rustango/src/admin/templates/list.html
@@ -46,8 +46,8 @@
 <p><em>No rows on this page.</em></p>
 {% else %}
 <form method="post" action="/{{ model.table }}/__action" class="list-form">
-  {% if actions and actions | length > 0 and not read_only %}
-  <div class="action-bar">
+  {% if actions and actions | length > 0 and not read_only and actions_on_top %}
+  <div class="action-bar action-bar-top">
     <label>Action:
       <select name="action">
         <option value="">— Select —</option>
@@ -83,6 +83,19 @@
     {% endfor %}
     </tbody>
   </table>
+  {% if actions and actions | length > 0 and not read_only and actions_on_bottom %}
+  <div class="action-bar action-bar-bottom">
+    <label>Action:
+      <select name="action_bottom">
+        <option value="">— Select —</option>
+        {% for a in actions %}
+        <option value="{{ a.name }}">{{ a.label }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <button type="submit" class="btn btn-secondary">Go</button>
+  </div>
+  {% endif %}
 </form>
 {% endif %}
 

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -548,6 +548,10 @@ pub(crate) async fn table_view(
         // #353 — Django-shape `search_help_text`. Empty string means
         // suppress the caption (today's behavior).
         "search_help_text": admin_cfg.search_help_text,
+        // #354 — Django-shape action-bar position flags. Default
+        // top=true, bottom=false; templates gate the render on these.
+        "actions_on_top": admin_cfg.actions_on_top,
+        "actions_on_bottom": admin_cfg.actions_on_bottom,
         "q": q.unwrap_or_default(),
         "active_filters": active_filters_ctx,
         "facets": facets_ctx,
@@ -1660,10 +1664,14 @@ pub(crate) async fn action_submit(
     let pairs: Vec<(String, String)> = serde_urlencoded::from_bytes(&body)
         .map_err(|e| AdminError::Internal(format!("parse action form: {e}")))?;
 
+    // #354 — bottom action-bar uses `action_bottom` to avoid clashing
+    // with the top bar's empty default. The first non-empty value
+    // wins regardless of which bar emitted it; an empty value never
+    // overrides a previously-set one.
     let mut action_name: Option<String> = None;
     let mut selected_raw: Vec<String> = Vec::new();
     for (k, v) in pairs {
-        if k == "action" {
+        if (k == "action" || k == "action_bottom") && !v.is_empty() && action_name.is_none() {
             action_name = Some(v);
         } else if k == "_selected" {
             selected_raw.push(v);

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -593,6 +593,14 @@ pub struct AdminConfig {
     /// caption. Lets operators know what fields the search actually
     /// matches against (`"by title and author"`, etc.). Issue #353.
     pub search_help_text: &'static str,
+    /// Django-shape `actions_on_top` (default `true`). When `false`,
+    /// suppresses the action-bar above the table. Issue #354.
+    pub actions_on_top: bool,
+    /// Django-shape `actions_on_bottom` (default `false`). When
+    /// `true`, an additional action-bar renders BELOW the table —
+    /// useful for long list pages where the operator has scrolled
+    /// past the top bar. Issue #354.
+    pub actions_on_bottom: bool,
 }
 
 /// One group of fields on a create/edit form (slice 10.5).
@@ -622,6 +630,8 @@ impl AdminConfig {
         fieldsets: &[],
         list_display_links: &[],
         search_help_text: "",
+        actions_on_top: true,
+        actions_on_bottom: false,
     };
 }
 

--- a/crates/rustango/tests/admin_actions_position_sqlite_live.rs
+++ b/crates/rustango/tests/admin_actions_position_sqlite_live.rs
@@ -1,0 +1,154 @@
+//! Django-parity #354 — `admin.actions_on_top` / `actions_on_bottom`.
+//! Position knobs for the action-bar on the list view.
+
+#![cfg(all(feature = "sqlite", feature = "admin", feature = "tenancy"))]
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use http_body_util::BodyExt;
+use rustango::core::Model as _;
+use rustango::sql::Pool;
+use rustango::Model;
+use tower::ServiceExt;
+
+// Default model: actions_on_top=true (Django default), actions_on_bottom=false.
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "ap_top_post",
+    admin(list_display = "title", actions = "delete_selected")
+)]
+pub struct ApTopPost {
+    #[rustango(primary_key)]
+    id: rustango::Auto<i64>,
+    #[rustango(max_length = 200)]
+    title: String,
+}
+
+// Model with both bars enabled.
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "ap_both_post",
+    admin(
+        list_display = "title",
+        actions = "delete_selected",
+        actions_on_top = true,
+        actions_on_bottom = true,
+    )
+)]
+pub struct ApBothPost {
+    #[rustango(primary_key)]
+    id: rustango::Auto<i64>,
+    #[rustango(max_length = 200)]
+    title: String,
+}
+
+// Model with only the bottom bar (top suppressed).
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "ap_bottom_post",
+    admin(
+        list_display = "title",
+        actions = "delete_selected",
+        actions_on_top = false,
+        actions_on_bottom = true,
+    )
+)]
+pub struct ApBottomPost {
+    #[rustango(primary_key)]
+    id: rustango::Auto<i64>,
+    #[rustango(max_length = 200)]
+    title: String,
+}
+
+fn build_app(pool: Pool) -> axum::Router {
+    rustango::admin::Builder::new(pool).admin_prefix("").build()
+}
+
+async fn seeded_pool(table: &str) -> Pool {
+    let pool = Pool::connect("sqlite::memory:").await.expect("sqlite pool");
+    let ddl = format!(
+        r#"CREATE TABLE IF NOT EXISTS "{table}" (
+            "id"    INTEGER PRIMARY KEY AUTOINCREMENT,
+            "title" TEXT NOT NULL
+        )"#,
+    );
+    rustango::sql::raw_execute_pool(&pool, &ddl, Vec::new())
+        .await
+        .expect("create");
+    // Seed one row so the action-bar branch renders (the template
+    // skips action-bar when `rows | length == 0`).
+    let app = build_app(pool.clone());
+    let body = "title=Hello";
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(format!("/{table}"))
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        resp.status() == StatusCode::SEE_OTHER || resp.status() == StatusCode::OK,
+        "seed POST failed: {}",
+        resp.status()
+    );
+    pool
+}
+
+async fn fetch_body(pool: Pool, uri: &str) -> String {
+    let app = build_app(pool);
+    let resp = app
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[test]
+fn defaults_match_django_top_true_bottom_false() {
+    let cfg = ApTopPost::SCHEMA.admin.expect("admin attr set");
+    assert!(cfg.actions_on_top);
+    assert!(!cfg.actions_on_bottom);
+}
+
+#[tokio::test]
+async fn default_renders_top_bar_only() {
+    let pool = seeded_pool("ap_top_post").await;
+    let body = fetch_body(pool, "/ap_top_post").await;
+    assert!(
+        body.contains("action-bar-top"),
+        "expected top bar, got: {body}"
+    );
+    assert!(
+        !body.contains("action-bar-bottom"),
+        "default model should not render bottom bar"
+    );
+}
+
+#[tokio::test]
+async fn both_flags_render_both_bars() {
+    let pool = seeded_pool("ap_both_post").await;
+    let body = fetch_body(pool, "/ap_both_post").await;
+    assert!(body.contains("action-bar-top"));
+    assert!(body.contains("action-bar-bottom"));
+}
+
+#[tokio::test]
+async fn only_bottom_renders_only_bottom_bar() {
+    let pool = seeded_pool("ap_bottom_post").await;
+    let body = fetch_body(pool, "/ap_bottom_post").await;
+    assert!(
+        !body.contains("action-bar-top"),
+        "top bar should be suppressed when actions_on_top = false"
+    );
+    assert!(
+        body.contains("action-bar-bottom"),
+        "expected bottom bar, got: {body}"
+    );
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -232,7 +232,7 @@ Summary: **11 SHIPPED / 2 PARTIAL / 2 MISSING / 1 N/A**. Gaps: `sqlmigrate` raw-
 | `readonly_fields` | [readonly_fields](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.readonly_fields) | SHIPPED | `#[rustango(admin(readonly_fields = "..."))]` | |
 | `fieldsets` | [fieldsets](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.fieldsets) | SHIPPED | `#[rustango(admin(fieldsets = "Title: a, b | Other: c"))]` | |
 | `actions` (bulk) | [actions](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.actions) | SHIPPED | `#[rustango(admin(actions = "publish, archive"))]` + handler registry | |
-| `actions_on_top` / `actions_on_bottom` | same | MISSING | n/a (#354) | Position fixed. |
+| `actions_on_top` / `actions_on_bottom` | same | SHIPPED | `admin(actions_on_top = false, actions_on_bottom = true)` (#354, v0.42). Defaults match Django: top=true, bottom=false. Bottom selector uses `name="action_bottom"` to avoid clobbering top's empty default; handler picks first non-empty value. | |
 | `date_hierarchy` | [date_hierarchy](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.date_hierarchy) | MISSING | n/a (#355) | |
 | `prepopulated_fields` (slug-from-title) | [prepopulated_fields](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.prepopulated_fields) | MISSING | n/a (#356) | |
 | `raw_id_fields` (large-FK widget) | [raw_id_fields](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.raw_id_fields) | MISSING | n/a (#357) | FK widget is currently always a `<select>` — large FK tables slow. |


### PR DESCRIPTION
Django-parity #354 — `admin.actions_on_top` and
`admin.actions_on_bottom`. Position knobs for the bulk-action
selector on the list view. Defaults match Django: top=true,
bottom=false.

## API

```rust
#[rustango(admin(
    actions = "delete_selected",
    actions_on_top = false,
    actions_on_bottom = true,
))]
struct Post { ... }
```

## Behavior

- Default model gets the top bar only (today's behavior preserved).
- Both flags on → both bars render.
- `actions_on_top = false` suppresses the top bar entirely.
- Bottom selector uses `name="action_bottom"` to avoid clobbering
  the top bar's empty default. Handler picks the first non-empty
  `action=` or `action_bottom=` submitted.
- CSS hooks: `.action-bar-top` / `.action-bar-bottom` classes let
  projects style each independently.

## Surfaces wired

- `AdminConfig.actions_on_top: bool` (default `true`)
- `AdminConfig.actions_on_bottom: bool` (default `false`)
- `AdminConfig::DEFAULT` extended
- Container-attr parser accepts both keys
- Macro emission threads them through
- `list.html` guards each render block on the flag
- `views.rs` ctx adds both keys
- `views.rs` action handler picks first non-empty value from either field

## Tests

`crates/rustango/tests/admin_actions_position_sqlite_live.rs` — 4 cases:
- Defaults match Django (top true, bottom false) — schema round-trip
- Default model renders top bar only
- Both flags on → both bars present
- Only-bottom suppresses top entirely

CI: `admin_actions_position_sqlite_live` wired into `sqlite_live`.

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — passes
- [x] `cargo test -p rustango --lib --no-default-features --features sqlite,tenancy` — 1458 passed
- [x] `cargo test -p rustango --lib --all-features` — 2363 passed
- [x] `cargo test -p rustango --test admin_actions_position_sqlite_live --features sqlite,admin,tenancy` — 4/4 passed
- [ ] CI green (multi-job)

Closes #354.