### PR TITLE
feat(serializer): cross-field validate() hook (closes #436)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,config,email --test setting_changed_signal
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_ipaddress_field
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_filepath_field
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test serializer_cross_validate
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -6870,6 +6870,14 @@ fn parse_viewset_attrs(input: &DeriveInput) -> syn::Result<ViewSetAttrs> {
 
 struct SerializerContainerAttrs {
     model: syn::Path,
+    /// `#[serializer(validate = "fn_name")]` on the struct — DRF-shape
+    /// cross-field validation hook (#436). The named inherent method
+    /// must take `&self` and return
+    /// `Result<(), rustango::forms::FormErrors>`. The macro-emitted
+    /// `validate()` runs every per-field validator first; then calls
+    /// the cross-field method if declared; aggregates all errors into
+    /// one `FormErrors`.
+    cross_validate: Option<syn::Ident>,
 }
 
 #[derive(Default)]
@@ -6925,6 +6933,7 @@ struct SerializerFieldAttrs {
 
 fn parse_serializer_container_attrs(input: &DeriveInput) -> syn::Result<SerializerContainerAttrs> {
     let mut model: Option<syn::Path> = None;
+    let mut cross_validate: Option<syn::Ident> = None;
     for attr in &input.attrs {
         if !attr.path().is_ident("serializer") {
             continue;
@@ -6935,7 +6944,19 @@ fn parse_serializer_container_attrs(input: &DeriveInput) -> syn::Result<Serializ
                 model = Some(meta.input.parse()?);
                 return Ok(());
             }
-            Err(meta.error("unknown serializer container attribute (supported: `model`)"))
+            if meta.path.is_ident("validate") {
+                // #436 — container-level `validate = "fn_name"` for the
+                // DRF cross-field-validation shape. Field-level
+                // `#[serializer(validate = "...")]` on a field is
+                // parsed separately in `parse_serializer_field_attrs`.
+                let s: LitStr = meta.value()?.parse()?;
+                cross_validate = Some(syn::Ident::new(&s.value(), s.span()));
+                return Ok(());
+            }
+            Err(meta.error(
+                "unknown serializer container attribute \
+                 (supported: `model`, `validate`)",
+            ))
         })?;
     }
     let model = model.ok_or_else(|| {
@@ -6944,7 +6965,10 @@ fn parse_serializer_container_attrs(input: &DeriveInput) -> syn::Result<Serializ
             "`#[serializer(model = SomeModel)]` is required",
         )
     })?;
-    Ok(SerializerContainerAttrs { model })
+    Ok(SerializerContainerAttrs {
+        model,
+        cross_validate,
+    })
 }
 
 fn parse_serializer_field_attrs(field: &syn::Field) -> syn::Result<SerializerFieldAttrs> {
@@ -7182,17 +7206,36 @@ fn expand_serializer(input: &DeriveInput) -> syn::Result<TokenStream2> {
             })
         })
         .collect();
-    let validate_method = if validator_calls.is_empty() {
+    // #436 — DRF cross-field `validate(self)` shape. If the
+    // container declared `#[serializer(validate = "fn_name")]`,
+    // the macro-generated `validate(&self)` runs every per-field
+    // validator first, then calls the user's cross-field method,
+    // merging its `FormErrors` into the per-field errors. Either
+    // alone is enough to emit the wrapper.
+    let cross_validate_call = container.cross_validate.as_ref().map(|method_ident| {
+        quote! {
+            // Merge cross-field errors into the per-field bucket so
+            // a single .validate() call surfaces both layers.
+            if let ::core::result::Result::Err(__cross) = self.#method_ident() {
+                __errors.merge(__cross);
+            }
+        }
+    });
+    let validate_method = if validator_calls.is_empty() && container.cross_validate.is_none() {
         quote! {}
     } else {
         quote! {
             impl #struct_name {
                 /// Run every `#[serializer(validate = "...")]` per-field
-                /// validator. Aggregates errors into `FormErrors` keyed
-                /// by the field name. Returns `Ok(())` when all pass.
+                /// validator and, when declared, the container-level
+                /// cross-field validator. Aggregates errors into
+                /// `FormErrors` keyed by the field name (plus any
+                /// non-field keys the cross-field method adds).
+                /// Returns `Ok(())` when all pass.
                 pub fn validate(&self) -> ::core::result::Result<(), ::rustango::forms::FormErrors> {
                     let mut __errors = ::rustango::forms::FormErrors::default();
                     #( #validator_calls )*
+                    #cross_validate_call
                     if __errors.is_empty() {
                         ::core::result::Result::Ok(())
                     } else {

--- a/crates/rustango/src/forms/mod.rs
+++ b/crates/rustango/src/forms/mod.rs
@@ -108,6 +108,16 @@ impl FormErrors {
         &self.non_field
     }
 
+    /// Drain every entry from `other` into `self`. Used by composable
+    /// validation flows that aggregate per-field + cross-field errors
+    /// into one collection. #436.
+    pub fn merge(&mut self, mut other: FormErrors) {
+        for (field, msgs) in other.fields.drain() {
+            self.fields.entry(field).or_default().extend(msgs);
+        }
+        self.non_field.extend(other.non_field.drain(..));
+    }
+
     /// All messages for `field`, or an empty slice.
     pub fn get(&self, field: &str) -> &[String] {
         self.fields.get(field).map(Vec::as_slice).unwrap_or(&[])

--- a/crates/rustango/tests/serializer_cross_validate.rs
+++ b/crates/rustango/tests/serializer_cross_validate.rs
@@ -1,0 +1,170 @@
+//! Django-parity #436 — DRF `validate(self, data)` cross-field hook
+//! via `#[serializer(validate = "fn_name")]` at the container level.
+//!
+//! Verifies the macro:
+//! - Emits a `validate()` method even when no per-field validators are declared
+//! - Calls the named cross-field method after per-field validators
+//! - Merges cross-field `FormErrors` with per-field errors via the new
+//!   `FormErrors::merge` API
+
+#![cfg(feature = "serializer")]
+
+use rustango::core::Model;
+use rustango::forms::FormErrors;
+use rustango_macros::{Model, Serializer};
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "ser_cv_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 1000)]
+    pub body: String,
+}
+
+// Container-level cross-field validator only — no per-field validators.
+#[derive(Serializer, serde::Deserialize, Debug, Clone, Default)]
+#[serializer(model = Post, validate = "cross_validate")]
+pub struct PostSerializer {
+    pub id: i64,
+    pub title: String,
+    pub body: String,
+}
+
+impl PostSerializer {
+    fn cross_validate(&self) -> Result<(), FormErrors> {
+        let mut errs = FormErrors::default();
+        // Cross-field rule: title must not duplicate the first line of body.
+        if !self.title.is_empty() && self.body.starts_with(&self.title) {
+            errs.add_non_field("title must not match the body's first line");
+        }
+        if errs.is_empty() {
+            Ok(())
+        } else {
+            Err(errs)
+        }
+    }
+}
+
+// Mixed model — per-field validator + container-level cross-field.
+#[derive(Serializer, serde::Deserialize, Debug, Clone, Default)]
+#[serializer(model = Post, validate = "matched_pair")]
+pub struct MixedPostSerializer {
+    pub id: i64,
+    #[serializer(validate = "non_empty")]
+    pub title: String,
+    #[serializer(validate = "non_empty")]
+    pub body: String,
+}
+
+impl MixedPostSerializer {
+    fn non_empty(value: &String) -> Result<(), String> {
+        if value.trim().is_empty() {
+            Err("must not be empty".into())
+        } else {
+            Ok(())
+        }
+    }
+    fn matched_pair(&self) -> Result<(), FormErrors> {
+        let mut errs = FormErrors::default();
+        if self.title.len() < self.body.len() / 10 {
+            errs.add("title", "title must be at least 1/10 the length of body");
+        }
+        if errs.is_empty() {
+            Ok(())
+        } else {
+            Err(errs)
+        }
+    }
+}
+
+#[test]
+fn cross_validate_ok_when_rule_passes() {
+    let s = PostSerializer {
+        id: 1,
+        title: "Hello".into(),
+        body: "World wide post".into(),
+    };
+    s.validate().unwrap();
+}
+
+#[test]
+fn cross_validate_surfaces_non_field_error() {
+    let s = PostSerializer {
+        id: 1,
+        title: "Hello".into(),
+        body: "Hello world".into(),
+    };
+    let err = s.validate().unwrap_err();
+    assert!(
+        !err.non_field().is_empty(),
+        "expected non_field error, got: {err:?}"
+    );
+    assert!(err
+        .non_field()
+        .iter()
+        .any(|m| m.contains("title must not match")));
+}
+
+#[test]
+fn mixed_aggregates_per_field_then_cross_field() {
+    let s = MixedPostSerializer {
+        id: 1,
+        // Triggers per-field 'non_empty' validator AND the cross-field
+        // ratio check (since body.len() > 10 * 0).
+        title: "".into(),
+        body: "a very long body string that exceeds the cross-field ratio".into(),
+    };
+    let err = s.validate().unwrap_err();
+    // Per-field error on title:
+    let title_errs = err.fields().get("title").cloned().unwrap_or_default();
+    assert!(
+        title_errs.iter().any(|m| m.contains("must not be empty")),
+        "per-field error missing: {title_errs:?}"
+    );
+    // Cross-field error also on title key (the cross_validate added it):
+    assert!(
+        title_errs
+            .iter()
+            .any(|m| m.contains("at least 1/10 the length of body")),
+        "cross-field error missing: {title_errs:?}"
+    );
+}
+
+#[test]
+fn mixed_ok_when_both_layers_pass() {
+    let s = MixedPostSerializer {
+        id: 1,
+        title: "Hello, this is a long enough title".into(),
+        body: "Short body".into(),
+    };
+    s.validate().unwrap();
+}
+
+#[test]
+fn form_errors_merge_combines_both_buckets() {
+    let mut a = FormErrors::default();
+    a.add("title", "too short");
+    a.add_non_field("non-field A");
+
+    let mut b = FormErrors::default();
+    b.add("title", "also too long");
+    b.add("body", "missing");
+    b.add_non_field("non-field B");
+
+    a.merge(b);
+    assert_eq!(a.fields().get("title").unwrap().len(), 2);
+    assert!(a.fields().contains_key("body"));
+    assert_eq!(a.non_field().len(), 2);
+}
+
+/// Required by the Model derive — Post is referenced in the serializer
+/// header but never actually constructed here; the test surface is
+/// purely the serializer's validate(). Keeps clippy happy.
+#[test]
+fn post_schema_is_addressable() {
+    let _ = Post::SCHEMA.name;
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -640,7 +640,7 @@ Summary: **5 / 0 / 0 / 2**. Async is native; no parity gap.
 | Nested serializer (one-to-many auto-expand) | [nested](https://www.django-rest-framework.org/api-guide/serializers/#dealing-with-nested-objects) | SHIPPED | `#[serializer(nested = ChildSerializer)]` (v0.18) | |
 | `SerializerMethodField` | [SerializerMethodField](https://www.django-rest-framework.org/api-guide/fields/#serializermethodfield) | SHIPPED | v0.18 | |
 | Per-field validators chain | (above) | SHIPPED | v0.18 | |
-| Cross-field validation (`validate()`) | [object-level validation](https://www.django-rest-framework.org/api-guide/serializers/#object-level-validation) | MISSING | n/a (#436) | Backlog. |
+| Cross-field validation (`validate()`) | [object-level validation](https://www.django-rest-framework.org/api-guide/serializers/#object-level-validation) | SHIPPED | `#[serializer(validate = "fn_name")]` container attr (closed #436, v0.42) — emitted `validate()` runs per-field validators first, then `self.<fn_name>()` returning `Result<(), FormErrors>`, merging both via new `FormErrors::merge`. | |
 | `UniqueTogetherValidator` | [UniqueTogetherValidator](https://www.django-rest-framework.org/api-guide/validators/#uniquetogethervalidator) | MISSING | n/a (#437) | Friendly form errors on `unique_together`. |
 | `ViewSet` | [ViewSet](https://www.django-rest-framework.org/api-guide/viewsets/) | SHIPPED | `#[derive(ViewSet)]` (v0.16+, tri-dialect v0.38) | |
 | `ModelViewSet` | [ModelViewSet](https://www.django-rest-framework.org/api-guide/viewsets/#modelviewset) | SHIPPED | (above, includes list/retrieve/create/update/delete) | |


### PR DESCRIPTION
## Summary

Closes #436 — Django REST Framework's object-level `validate(self, data)` cross-field hook.

`#[serializer(validate = "fn_name")]` at the container level declares a cross-field validator. The macro emits a `validate()` method on the serializer that:

1. Runs every per-field `#[serializer(validate = "...")]` validator (existing v0.18 surface).
2. Calls `self.<fn_name>()` returning `Result<(), FormErrors>`.
3. Merges both error buckets via a new `FormErrors::merge` helper.

\`\`\`rust
#[derive(Serializer, serde::Deserialize)]
#[serializer(model = Post, validate = "cross_validate")]
pub struct PostSerializer { /* … */ }

impl PostSerializer {
    fn cross_validate(&self) -> Result<(), FormErrors> {
        let mut errs = FormErrors::default();
        if self.title == self.body { errs.add_non_field("title cannot equal body"); }
        if errs.is_empty() { Ok(()) } else { Err(errs) }
    }
}
\`\`\`

## Test plan
- [x] `serializer_cross_validate.rs` — 6 cases: ok / non-field error / mixed per-field + cross-field merge / both layers pass / `FormErrors::merge` unit / schema addressability.
- [x] Lib regression: 1458 lib tests pass under `sqlite,tenancy`.
- [x] Litmus: `cargo build --no-default-features --features sqlite,tenancy`.
- [x] CI: new test wired into `sqlite_litmus` job.
- [x] Audit doc: row flipped MISSING → SHIPPED.