### PR TITLE
feat(admin): list_display data.<key> JSON dotted-path (closes #348)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,7 @@ jobs:
             --test admin_save_hook_sqlite_live \
             --test admin_recent_actions_sqlite_live \
             --test admin_simple_list_filter_sqlite_live \
+            --test admin_list_display_jsonpath_sqlite_live \
             --test audit_pool_sqlite_live \
             --test bulk_upsert_sqlite_live \
             --test count_distinct_sqlite_live \

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -23,6 +23,51 @@ use super::render;
 use super::templates::render_with_chrome;
 use super::urls::AppState;
 
+/// Render a `data.<key>` cell — drills into a JSON column at the
+/// supplied key path and emits an HTML-escaped scalar. Issue #348.
+///
+/// Supports dotted paths (`a.b.c`) and bracketed array indexing
+/// (`items.0` for `data["items"][0]`). Returns `<em>NULL</em>` when
+/// the path doesn't resolve.
+fn render_json_path_cell(
+    row: &serde_json::Value,
+    field: &'static crate::core::FieldSchema,
+    key: &str,
+) -> String {
+    let mut node = match row.get(field.column).or_else(|| row.get(field.name)) {
+        Some(v) => v,
+        None => return "<em>NULL</em>".to_owned(),
+    };
+    for seg in key.split('.') {
+        if seg.is_empty() {
+            continue;
+        }
+        let next = if let Ok(idx) = seg.parse::<usize>() {
+            node.as_array().and_then(|a| a.get(idx))
+        } else {
+            node.as_object().and_then(|o| o.get(seg))
+        };
+        node = match next {
+            Some(n) => n,
+            None => return "<em>NULL</em>".to_owned(),
+        };
+    }
+    match node {
+        serde_json::Value::Null => "<em>NULL</em>".to_owned(),
+        serde_json::Value::String(s) => render::escape(s),
+        serde_json::Value::Bool(true) => {
+            r#"<span class="rcms-bool yes" aria-label="true">☑</span>"#.to_owned()
+        }
+        serde_json::Value::Bool(false) => {
+            r#"<span class="rcms-bool no" aria-label="false">☐</span>"#.to_owned()
+        }
+        serde_json::Value::Number(n) => n.to_string(),
+        // Nested objects / arrays serialize as compact JSON — readable
+        // in the list cell, full structure visible on the detail page.
+        other => render::escape(&other.to_string()),
+    }
+}
+
 /// Render a single GFK cell — reads `(ct_column, pk_column)` off the
 /// JSON row and emits a clickable target link using the preloaded
 /// ContentType map. Mirrors `contenttypes::render_generic_fk_link`'s
@@ -409,6 +454,11 @@ pub(crate) async fn table_view(
         Field(&'static FieldSchema),
         Computed(&'static crate::admin::computed_fields::ComputedField),
         GenericFk(&'static crate::core::GenericRelation),
+        /// #348 — `list_display = "data.title"` drills into a JSON
+        /// column at a dotted key path. The first segment names a
+        /// `FieldType::Json` column; everything after the first `.`
+        /// is the JSON pointer path.
+        JsonPath(&'static FieldSchema, &'static str),
     }
     let display_items: Vec<DisplayItem> = if admin_cfg.list_display.is_empty() {
         model.scalar_fields().map(DisplayItem::Field).collect()
@@ -430,6 +480,17 @@ pub(crate) async fn table_view(
                             .iter()
                             .find(|gr| gr.name == *name)
                             .map(DisplayItem::GenericFk)
+                    })
+                    .or_else(|| {
+                        // #348 — `data.title` dotted-path syntax. Look up
+                        // the head segment as a Json column on the model.
+                        let (head, tail) = name.split_once('.')?;
+                        let field = model.field(head)?;
+                        if field.ty == crate::core::FieldType::Json {
+                            Some(DisplayItem::JsonPath(field, tail))
+                        } else {
+                            None
+                        }
                     })
             })
             .collect()
@@ -486,6 +547,9 @@ pub(crate) async fn table_view(
                     render::escape(if m.label.is_empty() { m.name } else { m.label })
                 }
                 DisplayItem::GenericFk(gr) => render::escape(gr.name),
+                DisplayItem::JsonPath(f, key) => {
+                    render::escape(&format!("{}.{}", f.display_label(), key))
+                }
             };
             serde_json::json!({ "label": label })
         })
@@ -509,6 +573,9 @@ pub(crate) async fn table_view(
                 DisplayItem::Field(f) => f.name,
                 DisplayItem::Computed(m) => m.name,
                 DisplayItem::GenericFk(gr) => gr.name,
+                // JsonPath columns aren't link targets — their value is
+                // a nested datum, not the row's identity.
+                DisplayItem::JsonPath(_, _) => return false,
             };
             link_columns.contains(name)
         })
@@ -551,6 +618,7 @@ pub(crate) async fn table_view(
                         DisplayItem::Field(f) => render_cell_json(row, f, &fk_map),
                         DisplayItem::Computed(m) => (m.render)(row),
                         DisplayItem::GenericFk(gr) => render_gfk_cell(row, gr, &gfk_ct_map),
+                        DisplayItem::JsonPath(f, key) => render_json_path_cell(row, f, key),
                     };
                     match (
                         cell_is_link.get(idx).copied().unwrap_or(false),

--- a/crates/rustango/tests/admin_list_display_jsonpath_sqlite_live.rs
+++ b/crates/rustango/tests/admin_list_display_jsonpath_sqlite_live.rs
@@ -1,0 +1,123 @@
+//! Django-parity #348 — `list_display` supports `data.<key>` dotted
+//! paths into JSON columns.
+
+#![cfg(all(feature = "sqlite", feature = "admin", feature = "tenancy"))]
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use rustango::sql::Pool;
+use rustango::Model;
+use tower::ServiceExt;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "jp_post",
+    admin(list_display = "title,data.headline,data.featured")
+)]
+#[allow(dead_code)]
+pub struct JpPost {
+    #[rustango(primary_key)]
+    id: rustango::Auto<i64>,
+    #[rustango(max_length = 200)]
+    title: String,
+    data: serde_json::Value,
+}
+
+async fn build_pool() -> Pool {
+    let pool = Pool::connect("sqlite::memory:").await.expect("sqlite pool");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        r#"CREATE TABLE IF NOT EXISTS "jp_post" (
+            "id"    INTEGER PRIMARY KEY AUTOINCREMENT,
+            "title" TEXT NOT NULL,
+            "data"  TEXT NOT NULL
+        )"#,
+        Vec::new(),
+    )
+    .await
+    .expect("create");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        r#"INSERT INTO "jp_post" ("title", "data") VALUES (?, ?)"#,
+        vec![
+            rustango::core::SqlValue::String("First".into()),
+            rustango::core::SqlValue::Json(serde_json::json!({
+                "headline": "Breaking news",
+                "featured": true,
+            })),
+        ],
+    )
+    .await
+    .expect("seed");
+    pool
+}
+
+fn build_app(pool: Pool) -> axum::Router {
+    rustango::admin::Builder::new(pool).admin_prefix("").build()
+}
+
+async fn body_of(pool: Pool, uri: &str) -> String {
+    let app = build_app(pool);
+    let resp = app
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "GET {uri} returned non-200");
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn list_renders_json_subkey_value() {
+    let pool = build_pool().await;
+    let body = body_of(pool, "/jp_post").await;
+    // Dotted-path string value renders inline.
+    assert!(
+        body.contains("Breaking news"),
+        "dotted-path JSON string missing: {body}"
+    );
+    // Dotted-path bool value renders as the checkbox glyph.
+    assert!(
+        body.contains("rcms-bool yes"),
+        "bool checkbox glyph missing: {body}"
+    );
+    // Column header shows the dotted path.
+    assert!(
+        body.contains("data.headline"),
+        "dotted-path header missing: {body}"
+    );
+}
+
+#[tokio::test]
+async fn list_renders_null_for_missing_key() {
+    let pool = Pool::connect("sqlite::memory:").await.expect("sqlite pool");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        r#"CREATE TABLE IF NOT EXISTS "jp_post" (
+            "id"    INTEGER PRIMARY KEY AUTOINCREMENT,
+            "title" TEXT NOT NULL,
+            "data"  TEXT NOT NULL
+        )"#,
+        Vec::new(),
+    )
+    .await
+    .expect("create");
+    // Row with empty data — no headline key.
+    rustango::sql::raw_execute_pool(
+        &pool,
+        r#"INSERT INTO "jp_post" ("title", "data") VALUES (?, ?)"#,
+        vec![
+            rustango::core::SqlValue::String("Empty".into()),
+            rustango::core::SqlValue::Json(serde_json::json!({})),
+        ],
+    )
+    .await
+    .expect("seed");
+    let body = body_of(pool, "/jp_post").await;
+    // Missing key drilldown emits `<em>NULL</em>`.
+    assert!(
+        body.contains("<em>NULL</em>"),
+        "expected NULL fallback for missing key: {body}"
+    );
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -218,7 +218,7 @@ Summary: **11 SHIPPED / 2 PARTIAL / 2 MISSING / 1 N/A**. Gaps: `sqlmigrate` raw-
 | ModelAdmin option | Doc | Status | rustango | Notes |
 |---|---|---|---|---|
 | `list_display` (scalar fields) | [list_display](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display) | SHIPPED | `#[rustango(admin(list_display = "title, status"))]` | |
-| `list_display` (method/computed fields) | same | MISSING | n/a (#348) | Backlog #51 — needs method-field hook + custom cell renderer. |
+| `list_display` (method/computed fields) | same | SHIPPED | Two paths: `register_admin_computed!(table, name, label, fn)` for arbitrary HTML renderers (pre-v0.42), and `list_display = "data.headline"` dotted-path syntax for JSON-column subkeys (closed #348, v0.42). The dotted path drills into a `FieldType::Json` column at `.split('.')` segments (numeric segments index arrays); bools render as ☑/☐ glyphs, missing paths fall back to `<em>NULL</em>`. | |
 | `list_display` (boolean checkbox icon) | same | SHIPPED | v0.37+ render in admin/render.rs | |
 | `list_display` (callable display_link) | same | MISSING | n/a (#349) | FK columns auto-link; method-field callables don't. |
 | `list_display_links` | [list_display_links](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display_links) | SHIPPED | `admin(list_display_links = "title, views")` (#350, v0.42) — comma-separated names from `list_display`. Each matched cell wraps its inner HTML in `<a href="{admin_prefix}/{table}/{pk}">…</a>`. Empty whitelist keeps the trailing "View" column as the only link. | |


### PR DESCRIPTION
## Summary

Closes #348 — the last gap from the May 2026 admin list-display follow-up.

\`\`\`rust
#[derive(Model)]
#[rustango(
    table = "post",
    admin(list_display = "title, data.headline, data.featured"),
)]
pub struct Post {
    data: serde_json::Value,
    /* … */
}
\`\`\`

The dotted-path syntax drills into a \`FieldType::Json\` column at the configured key path. Resolves objects via key lookup; numeric segments index arrays (\`items.0\`). Bools render as ☑/☐ glyphs; missing paths fall back to \`<em>NULL</em>\`.

The pre-existing \`register_admin_computed!\` macro continues to cover arbitrary HTML renderers / method-style derivations. This PR is the **no-macro shortcut for the common case** — pulling a named subkey out of a JSON column.

Column header reads as \`field.path\` so operators can see at a glance which field is being drilled. JsonPath cells aren't link targets (their value is a nested datum, not the row identity), so \`list_display_links\` skips them.

## Test plan
- [x] **Live SQLite** (2 tests) — string subkey renders inline; bool subkey renders as glyph; column header reflects the dotted path; missing key emits \`<em>NULL</em>\`.
- [x] Litmus: \`cargo build --no-default-features --features sqlite,tenancy\`.
- [x] Lib regression: 1465 tests pass.
- [x] CI: \`admin_list_display_jsonpath_sqlite_live\` added to \`sqlite_live\` job.
- [x] Audit doc: row flipped MISSING → SHIPPED.