### PR TITLE
feat(migrate): manage sqlmigrate <name> (closes #345)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_filepath_field
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test serializer_cross_validate
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_none
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test sqlmigrate
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -94,6 +94,7 @@ pub async fn run_with_writer<W: Write + Send>(
         "migrate" => migrate(pool, dir, &args[1..], writer).await,
         "downgrade" => downgrade(pool, dir, &args[1..], writer).await,
         "showmigrations" | "status" => showmigrations(pool, dir, writer).await,
+        "sqlmigrate" => sqlmigrate_cmd(dir, &args[1..], writer),
         "forget-pending" => forget_pending_cmd(pool, dir, &args[1..], writer).await,
         "startapp" => startapp(&args[1..], writer),
         "add-data-op" => add_data_op_cmd(dir, &args[1..], writer),
@@ -201,6 +202,11 @@ fn print_help<W: Write>(w: &mut W) -> std::io::Result<()> {
     writeln!(w, "      Step back N applied migrations (default 1).\n")?;
     writeln!(w, "  showmigrations | status")?;
     writeln!(w, "      List migrations with [X]/[ ] applied marker.\n")?;
+    writeln!(w, "  sqlmigrate <name>")?;
+    writeln!(
+        w,
+        "      Print the SQL the named migration would emit when applied.\n"
+    )?;
     writeln!(w, "  forget-pending <name>")?;
     writeln!(
         w,
@@ -810,6 +816,57 @@ async fn downgrade<W: Write>(
         for m in &touched {
             writeln!(w, "  rolled back {}", m.name)?;
         }
+    }
+    Ok(())
+}
+
+/// Django-shape `sqlmigrate <name>` — print the SQL that would run
+/// when the named migration is applied, without touching the database.
+/// Issue #345.
+///
+/// Output format mirrors `migrate --dry-run` per-migration: a comment
+/// header (`-- <name> (atomic|non-atomic)`) followed by every emitted
+/// statement, semicolon-terminated, one per line.
+fn sqlmigrate_cmd<W: Write>(dir: &Path, args: &[String], w: &mut W) -> Result<(), MigrateError> {
+    let mut positional: Option<&str> = None;
+    for arg in args {
+        match arg.as_str() {
+            "--help" | "-h" => {
+                writeln!(
+                    w,
+                    "sqlmigrate <name>          print the SQL the named migration would emit\n\
+                                                without applying it"
+                )?;
+                return Ok(());
+            }
+            other if other.starts_with('-') => {
+                return Err(MigrateError::Validation(format!("unknown flag: {other}")));
+            }
+            other => {
+                if positional.is_some() {
+                    return Err(MigrateError::Validation(format!(
+                        "unexpected positional argument: {other}"
+                    )));
+                }
+                positional = Some(other);
+            }
+        }
+    }
+    let name = positional
+        .ok_or_else(|| MigrateError::Validation("sqlmigrate requires a migration name".into()))?;
+    let preview = runner::sqlmigrate_one(dir, name)?;
+    writeln!(
+        w,
+        "-- {} ({})",
+        preview.name,
+        if preview.atomic {
+            "atomic"
+        } else {
+            "non-atomic"
+        }
+    )?;
+    for stmt in &preview.statements {
+        writeln!(w, "{stmt};")?;
     }
     Ok(())
 }

--- a/crates/rustango/src/migrate/mod.rs
+++ b/crates/rustango/src/migrate/mod.rs
@@ -52,7 +52,7 @@ pub use manage::{append_data_op, make_data_migration};
 pub use runner::{
     applied_set_pool, apply_all_pool, downgrade_pool, drop_all_pool, ensure_ledger_pool,
     migrate_dry_run_pool, migrate_embedded_pool, migrate_pool, migrate_to_pool, registered_models,
-    unapply_force_pool, unapply_pool, Builder, MigrationPreview, LEDGER_TABLE,
+    sqlmigrate_one, unapply_force_pool, unapply_pool, Builder, MigrationPreview, LEDGER_TABLE,
 };
 // PG-typed back-compat: only re-exported when the `postgres` feature
 // is on. Sqlite/MySQL apps use the `_pool` variants above.

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -591,6 +591,23 @@ async fn migrate_dry_run_with_ledger(
     Ok(out)
 }
 
+/// Django-shape `sqlmigrate <name>` — Compute the SQL the named
+/// migration would emit when applied, without touching the database.
+/// Pure file I/O + render — no ledger read required.
+///
+/// Issue #345. Use from `manage sqlmigrate <name>`.
+///
+/// # Errors
+/// - [`MigrateError::Validation`] when `name` is not present in `dir`.
+/// - Any IO / parse error from [`file::list_dir`].
+pub fn sqlmigrate_one(dir: &Path, name: &str) -> Result<MigrationPreview, MigrateError> {
+    let all = file::list_dir(dir)?;
+    let mig = all.into_iter().find(|m| m.name == name).ok_or_else(|| {
+        MigrateError::Validation(format!("migration `{name}` not found in {}", dir.display()))
+    })?;
+    preview_migration(&mig, LEDGER_TABLE)
+}
+
 /// Build a [`MigrationPreview`] for a single migration. Pure —
 /// no DB access. Same render path as `apply_atomic` / `apply_loose`
 /// but the statements stream into a `Vec<String>` instead of a tx.

--- a/crates/rustango/tests/sqlmigrate.rs
+++ b/crates/rustango/tests/sqlmigrate.rs
@@ -1,0 +1,112 @@
+//! Django-parity #345 — `manage sqlmigrate <name>` prints the SQL a
+//! given migration would emit, without touching the database.
+//!
+//! `sqlmigrate_one` is pure file I/O + render, so the test
+//! can run with no `feature = "postgres"` / `feature = "sqlite"`
+//! requirement — the migration render path is dialect-agnostic at
+//! this layer (the writer picks the actual placeholder shape at
+//! `apply` time).
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use rustango::migrate::{
+    file, sqlmigrate_one, Migration, Operation, SchemaChange, SchemaSnapshot, TableSnapshot,
+};
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn fresh_dir(label: &str) -> PathBuf {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let pid = std::process::id();
+    let mut p = std::env::temp_dir();
+    p.push(format!("rustango_sqlmigrate_{label}_{pid}_{n}"));
+    let _ = std::fs::remove_dir_all(&p);
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn snapshot_with_post_table() -> SchemaSnapshot {
+    let table: TableSnapshot = serde_json::from_value(serde_json::json!({
+        "name": "sqlmig_post",
+        "model": "Post",
+        "fields": [
+            {"name": "id", "column": "id", "ty": "i64", "nullable": false, "primary_key": true},
+            {"name": "title", "column": "title", "ty": "String", "nullable": false, "primary_key": false}
+        ]
+    }))
+    .unwrap();
+    SchemaSnapshot {
+        tables: vec![table],
+        ..Default::default()
+    }
+}
+
+fn create_table_migration(name: &str) -> Migration {
+    let snap = snapshot_with_post_table();
+    Migration {
+        name: name.to_owned(),
+        created_at: "2026-05-22T00:00:00Z".into(),
+        prev: None,
+        atomic: true,
+        scope: Default::default(),
+        snapshot: snap,
+        forward: vec![Operation::Schema(SchemaChange::CreateTable(
+            "sqlmig_post".into(),
+        ))],
+    }
+}
+
+#[test]
+fn one_migration_produces_create_table_sql() {
+    let dir = fresh_dir("create");
+    let mig = create_table_migration("0001_init");
+    file::write(&dir.join("0001_init.json"), &mig).unwrap();
+
+    let preview = sqlmigrate_one(&dir, "0001_init").expect("preview");
+    assert_eq!(preview.name, "0001_init");
+    // Atomic by default → BEGIN should be the first statement, COMMIT the last.
+    assert!(preview.atomic);
+    assert_eq!(
+        preview.statements.first().map(String::as_str),
+        Some("BEGIN")
+    );
+    // The CREATE TABLE statement is rendered for the target table.
+    let body = preview.statements.join("\n");
+    assert!(
+        body.contains("CREATE TABLE") && body.contains("sqlmig_post"),
+        "expected CREATE TABLE for sqlmig_post, got:\n{body}"
+    );
+}
+
+#[test]
+fn missing_migration_returns_validation_error() {
+    let dir = fresh_dir("missing");
+    let mig = create_table_migration("0001_init");
+    file::write(&dir.join("0001_init.json"), &mig).unwrap();
+
+    let err = sqlmigrate_one(&dir, "0002_not_there").unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("0002_not_there") && msg.contains("not found"),
+        "error should name the missing migration, got: {msg}"
+    );
+}
+
+#[test]
+fn sqlmigrate_is_pure_no_writes() {
+    // After invoking sqlmigrate, the directory should still contain
+    // exactly the file we created — no ledger row, no scratch file,
+    // no application of the migration.
+    let dir = fresh_dir("pure");
+    let mig = create_table_migration("0001_init");
+    file::write(&dir.join("0001_init.json"), &mig).unwrap();
+
+    let _ = sqlmigrate_one(&dir, "0001_init").expect("preview");
+    let entries: Vec<_> = std::fs::read_dir(&dir).unwrap().collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "sqlmigrate must not write to the migrations dir"
+    );
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -195,7 +195,7 @@ Summary: **1 / 1 / 3 / 0**.
 | `python manage.py makemigrations` | [makemigrations](https://docs.djangoproject.com/en/6.0/topics/migrations/#creating-migrations) | SHIPPED | `manage makemigrations` in [src/migrate/manage.rs](crates/rustango/src/migrate/manage.rs) | Snapshot-based JSON file output. |
 | `python manage.py migrate [app] [target]` | [migrate](https://docs.djangoproject.com/en/6.0/topics/migrations/#applying-migrations) | SHIPPED | `manage migrate` | |
 | `python manage.py showmigrations` | [showmigrations](https://docs.djangoproject.com/en/6.0/ref/django-admin/#showmigrations) | SHIPPED | `manage showmigrations` | |
-| `python manage.py sqlmigrate` | [sqlmigrate](https://docs.djangoproject.com/en/6.0/ref/django-admin/#sqlmigrate) | PARTIAL | `manage migrate --plan` shows operations not raw SQL (#345) | |
+| `python manage.py sqlmigrate` | [sqlmigrate](https://docs.djangoproject.com/en/6.0/ref/django-admin/#sqlmigrate) | SHIPPED | `manage sqlmigrate <name>` (closed #345, v0.42) — prints the SQL the named migration would emit when applied, no DB touch required. Wraps `migrate::sqlmigrate_one(dir, name)` which reads the JSON file and runs the same render path as `migrate --dry-run`. | |
 | `python manage.py squashmigrations` | [squashmigrations](https://docs.djangoproject.com/en/6.0/topics/migrations/#squashing-migrations) | SHIPPED | `manage migrate --squash` (v0.29) | Fresh-table scenarios only; not full Django squash. |
 | `python manage.py makemigrations --merge` | [merge](https://docs.djangoproject.com/en/6.0/topics/migrations/#merging-migrations) | MISSING | n/a (#346) | |
 | `migrate --fake` / `--fake-initial` | [fake](https://docs.djangoproject.com/en/6.0/ref/django-admin/#cmdoption-migrate-fake) | SHIPPED | `manage migrate --fake` (v0.28) | |
@@ -402,7 +402,7 @@ Django built-in management commands:
 | `makemigrations` | (sec 5) | SHIPPED | `manage makemigrations` | |
 | `migrate` | (sec 5) | SHIPPED | `manage migrate` | |
 | `showmigrations` | (sec 5) | SHIPPED | `manage showmigrations` | |
-| `sqlmigrate` | (sec 5) | PARTIAL | `manage migrate --plan` (#395) | |
+| `sqlmigrate` | (sec 5) | SHIPPED | `manage sqlmigrate <name>` (closed #345/#395, v0.42) — see ORM row for details. | |
 | `squashmigrations` | (sec 5) | SHIPPED | `manage migrate --squash` | |
 | `runserver` | (Django) | N/A | rustango uses axum's runserver — `manage run-server` or `Cli::new().run().await` | |
 | `runserver_plus` (django-extensions) | n/a | N/A | n/a | |


### PR DESCRIPTION
## Summary

Closes #345 — Django's \`python manage.py sqlmigrate <app> <migration_name>\`. Also closes the duplicate #395 row in the audit doc's manage-commands section.

\`\`\`shell
$ cargo run -- manage sqlmigrate 0003_add_bio_to_author
-- 0003_add_bio_to_author (atomic)
BEGIN;
ALTER TABLE "author" ADD COLUMN "bio" TEXT;
INSERT INTO "rustango_migrations" ("name", "applied_at") VALUES ('0003_add_bio_to_author', NOW());
COMMIT;
\`\`\`

- New \`migrate::sqlmigrate_one(dir, name) -> MigrationPreview\` helper — pure file I/O + render, no ledger read, no DB write. Reuses the existing `migrate --dry-run` render path so output is bit-identical.
- New \`manage sqlmigrate <name>\` verb dispatches to the helper and prints \`-- <name> (atomic|non-atomic)\` followed by every statement, semicolon-terminated.
- Help banner updated. Missing migration → \`MigrateError::Validation\` with a clear "not found in <dir>" message.

## Test plan
- [x] **3 unit tests** (\`tests/sqlmigrate.rs\`) — create-table preview emits BEGIN + CREATE TABLE; missing migration returns Validation error naming the file; the call writes nothing to the migrations dir.
- [x] Litmus: \`cargo build --no-default-features --features sqlite,tenancy\`.
- [x] Lib regression: 1465 tests pass.
- [x] CI: \`sqlmigrate\` test added to \`sqlite_litmus\` job.
- [x] Audit doc: two rows flipped PARTIAL → SHIPPED.