### PR TITLE
feat(serializer): UniqueTogetherValidator helper (closes #437/#376)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_dates
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,admin --test admin_list_select_related_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test form_clean_methods
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test unique_together_validator
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/serializer/mod.rs
+++ b/crates/rustango/src/serializer/mod.rs
@@ -174,3 +174,128 @@ pub trait ModelSerializer: serde::Serialize + Sized {
     /// incoming JSON body.
     fn writable_fields() -> &'static [&'static str];
 }
+
+/// Django-shape `UniqueTogetherValidator` — pre-save check that a
+/// candidate row doesn't collide with an existing row on any of the
+/// model's declared `unique_together` constraints. Issue #437.
+///
+/// Returns `Ok(())` when no collision is detected. Returns `Err(FormErrors)`
+/// with a non-field error per colliding constraint (DRF shape:
+/// `"The fields a, b must be unique together"`).
+///
+/// ## Usage
+///
+/// ```ignore
+/// use std::collections::HashMap;
+/// use rustango::core::SqlValue;
+/// use rustango::serializer::check_unique_together_pool;
+///
+/// let mut values: HashMap<&'static str, SqlValue> = HashMap::new();
+/// values.insert("org_id", SqlValue::I64(self.org_id));
+/// values.insert("user_id", SqlValue::I64(self.user_id));
+/// check_unique_together_pool(&pool, Membership::SCHEMA, &values, None).await?;
+/// ```
+///
+/// Pass `exclude_pk = Some(&pk)` on updates so the row being edited
+/// doesn't collide with itself. The PK column is read off
+/// `ModelSchema::primary_key()` — pass `None` for inserts.
+///
+/// Partial unique constraints (`unique_when` / `WHERE`-clause partial
+/// indexes) are skipped — their conflict semantics depend on the
+/// predicate, which this layer doesn't evaluate.
+///
+/// # Errors
+/// - [`crate::sql::ExecError`] forwarded from the underlying query.
+/// - The check is non-fatal on errors: a query failure surfaces as
+///   `Err` rather than masking as "no collision".
+pub async fn check_unique_together_pool(
+    pool: &crate::sql::Pool,
+    schema: &'static crate::core::ModelSchema,
+    values: &std::collections::HashMap<&'static str, crate::core::SqlValue>,
+    exclude_pk: Option<&crate::core::SqlValue>,
+) -> Result<(), crate::forms::FormErrors> {
+    use crate::core::{Filter, Op};
+
+    let mut errors = crate::forms::FormErrors::default();
+
+    for index in schema.indexes {
+        // Only multi-column unique indexes — Django's `unique_together`.
+        // Single-column UNIQUE is the `unique` field attr (caught by
+        // INSERT's RETURNING-on-conflict). Partial unique
+        // (`where_clause = Some(_)`) skipped — predicate evaluation
+        // would need a stub planner we don't have today.
+        if !index.unique || index.columns.len() < 2 || index.where_clause.is_some() {
+            continue;
+        }
+
+        // Build the AND-of-equality WHERE clause. Missing column values
+        // skip the constraint — Django's behavior when only a partial
+        // subset of the unique-together fields is bound.
+        let mut predicates: Vec<Filter> = Vec::with_capacity(index.columns.len());
+        let mut all_bound = true;
+        for col in index.columns {
+            let Some(val) = values.get(*col) else {
+                all_bound = false;
+                break;
+            };
+            predicates.push(Filter {
+                column: col,
+                op: Op::Eq,
+                value: val.clone(),
+            });
+        }
+        if !all_bound {
+            continue;
+        }
+
+        // Exclude-self on updates: PK != $N.
+        if let (Some(pk_field), Some(pk_value)) = (schema.primary_key(), exclude_pk) {
+            predicates.push(Filter {
+                column: pk_field.column,
+                op: Op::Ne,
+                value: pk_value.clone(),
+            });
+        }
+
+        // SELECT 1 FROM table WHERE … LIMIT 1.
+        let dialect = pool.dialect();
+        let table_q = dialect.quote_ident(schema.table);
+        let mut clauses: Vec<String> = Vec::with_capacity(predicates.len());
+        let mut params: Vec<crate::core::SqlValue> = Vec::with_capacity(predicates.len());
+        for (i, pred) in predicates.iter().enumerate() {
+            let col = dialect.quote_ident(pred.column);
+            let op_str = match pred.op {
+                Op::Eq => "=",
+                Op::Ne => "<>",
+                _ => unreachable!("only Eq/Ne above"),
+            };
+            let placeholder = dialect.placeholder(i + 1);
+            clauses.push(format!("{col} {op_str} {placeholder}"));
+            params.push(pred.value.clone());
+        }
+        let where_sql = clauses.join(" AND ");
+        let sql = format!("SELECT 1 FROM {table_q} WHERE {where_sql} LIMIT 1");
+
+        // Use `raw_query_pool::<(i64,)>` and ignore the actual returned
+        // value — presence of any row means a collision.
+        let hits: Vec<(i64,)> = crate::sql::raw_query_pool(&sql, params, pool)
+            .await
+            .map_err(|e| {
+                let mut errs = crate::forms::FormErrors::default();
+                errs.add_non_field(format!("unique_together check failed: {e}"));
+                errs
+            })?;
+        if !hits.is_empty() {
+            errors.add_non_field(format!(
+                "The fields {} must be unique together.",
+                index.columns.join(", "),
+            ));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}

--- a/crates/rustango/tests/unique_together_validator.rs
+++ b/crates/rustango/tests/unique_together_validator.rs
@@ -1,0 +1,126 @@
+//! Django-parity #437 — DRF `UniqueTogetherValidator`. Pre-save
+//! check that a candidate row doesn't collide on any of the model's
+//! declared `unique_together` constraints.
+
+#![cfg(all(feature = "sqlite", feature = "serializer", feature = "tenancy"))]
+
+use std::collections::HashMap;
+
+use rustango::core::{Model as _, SqlValue};
+use rustango::serializer::check_unique_together_pool;
+use rustango::sql::Pool;
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "utv_membership", unique_together = "org_id, user_id")]
+#[allow(dead_code)]
+pub struct UtvMembership {
+    #[rustango(primary_key)]
+    id: rustango::Auto<i64>,
+    org_id: i64,
+    user_id: i64,
+}
+
+async fn build_pool() -> Pool {
+    let pool = Pool::connect("sqlite::memory:").await.expect("sqlite pool");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        r#"CREATE TABLE IF NOT EXISTS "utv_membership" (
+            "id"      INTEGER PRIMARY KEY AUTOINCREMENT,
+            "org_id"  INTEGER NOT NULL,
+            "user_id" INTEGER NOT NULL,
+            UNIQUE ("org_id", "user_id")
+        )"#,
+        Vec::new(),
+    )
+    .await
+    .expect("create");
+    // Seed one row — (org=1, user=2).
+    rustango::sql::raw_execute_pool(
+        &pool,
+        r#"INSERT INTO "utv_membership" ("org_id", "user_id") VALUES (1, 2)"#,
+        Vec::new(),
+    )
+    .await
+    .expect("seed");
+    pool
+}
+
+fn values(org_id: i64, user_id: i64) -> HashMap<&'static str, SqlValue> {
+    let mut m = HashMap::new();
+    m.insert("org_id", SqlValue::I64(org_id));
+    m.insert("user_id", SqlValue::I64(user_id));
+    m
+}
+
+#[tokio::test]
+async fn validator_returns_ok_when_no_collision() {
+    let pool = build_pool().await;
+    check_unique_together_pool(&pool, UtvMembership::SCHEMA, &values(1, 99), None)
+        .await
+        .expect("non-colliding pair should be accepted");
+}
+
+#[tokio::test]
+async fn validator_returns_err_on_collision() {
+    let pool = build_pool().await;
+    let err = check_unique_together_pool(&pool, UtvMembership::SCHEMA, &values(1, 2), None)
+        .await
+        .unwrap_err();
+    let msg = err.non_field().join(" | ");
+    assert!(
+        msg.contains("org_id")
+            && msg.contains("user_id")
+            && msg.contains("must be unique together"),
+        "expected unique-together message, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn exclude_pk_lets_a_row_re_save_its_own_values() {
+    // Updating row id=1 with the same (org=1, user=2) should not
+    // collide with itself — pass exclude_pk = Some(id).
+    let pool = build_pool().await;
+    check_unique_together_pool(
+        &pool,
+        UtvMembership::SCHEMA,
+        &values(1, 2),
+        Some(&SqlValue::I64(1)),
+    )
+    .await
+    .expect("self-update should not flag a collision");
+}
+
+#[tokio::test]
+async fn exclude_pk_still_catches_collisions_against_other_rows() {
+    // Seed a second row, then try to update row 1 to look like row 2.
+    let pool = build_pool().await;
+    rustango::sql::raw_execute_pool(
+        &pool,
+        r#"INSERT INTO "utv_membership" ("org_id", "user_id") VALUES (2, 3)"#,
+        Vec::new(),
+    )
+    .await
+    .expect("seed second");
+    let err = check_unique_together_pool(
+        &pool,
+        UtvMembership::SCHEMA,
+        &values(2, 3),
+        Some(&SqlValue::I64(1)),
+    )
+    .await
+    .unwrap_err();
+    assert!(!err.non_field().is_empty());
+}
+
+#[tokio::test]
+async fn partial_value_set_skips_the_check() {
+    // Only org_id provided — not enough to identify a unique-together
+    // collision, so the check skips.
+    let pool = build_pool().await;
+    let mut partial = HashMap::new();
+    partial.insert("org_id", SqlValue::I64(1));
+    check_unique_together_pool(&pool, UtvMembership::SCHEMA, &partial, None)
+        .await
+        .expect("partial bind should be a silent skip, not an error");
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -277,7 +277,7 @@ Summary: **18 SHIPPED / 7 PARTIAL / 11 MISSING / 2 N/A**. Concentration of MISSI
 | File upload | [File uploads](https://docs.djangoproject.com/en/6.0/topics/http/file-uploads/) | SHIPPED | `uploads::*` + multer | |
 | `save(commit=False)` + `save_m2m()` | [ModelForm.save](https://docs.djangoproject.com/en/6.0/topics/forms/modelforms/#the-save-method) | MISSING | n/a (#375) | `ModelForm::save(pool)` is one-shot. |
 | CSRF token | [CSRF](https://docs.djangoproject.com/en/6.0/ref/csrf/) | SHIPPED | `forms::csrf::CsrfLayer` + `{{ csrf_token \| csrf_input \| safe }}` Tera | |
-| `UniqueTogetherValidator` | [DRF form-level uniqueness](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/constraints/) | MISSING | n/a (#376) | Backlog: friendly form-error on `unique_together` violation. |
+| `UniqueTogetherValidator` | [DRF form-level uniqueness](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/constraints/) | SHIPPED | `serializer::check_unique_together_pool` — see the DRF section row for #437 (v0.42). #376 is a duplicate; closing alongside #437. | |
 
 Summary: **8 SHIPPED / 3 PARTIAL / 4 MISSING / 0 N/A**.
 
@@ -641,7 +641,7 @@ Summary: **5 / 0 / 0 / 2**. Async is native; no parity gap.
 | `SerializerMethodField` | [SerializerMethodField](https://www.django-rest-framework.org/api-guide/fields/#serializermethodfield) | SHIPPED | v0.18 | |
 | Per-field validators chain | (above) | SHIPPED | v0.18 | |
 | Cross-field validation (`validate()`) | [object-level validation](https://www.django-rest-framework.org/api-guide/serializers/#object-level-validation) | SHIPPED | `#[serializer(validate = "fn_name")]` container attr (closed #436, v0.42) — emitted `validate()` runs per-field validators first, then `self.<fn_name>()` returning `Result<(), FormErrors>`, merging both via new `FormErrors::merge`. | |
-| `UniqueTogetherValidator` | [UniqueTogetherValidator](https://www.django-rest-framework.org/api-guide/validators/#uniquetogethervalidator) | MISSING | n/a (#437) | Friendly form errors on `unique_together`. |
+| `UniqueTogetherValidator` | [UniqueTogetherValidator](https://www.django-rest-framework.org/api-guide/validators/#uniquetogethervalidator) | SHIPPED | `serializer::check_unique_together_pool(pool, schema, &values, exclude_pk)` (closed #437, v0.42). Walks `ModelSchema.indexes` for multi-column `unique=true` entries (the migration writer's `unique_together` deposit), runs `SELECT 1 FROM <table> WHERE … LIMIT 1` for each, and attaches a non-field error per collision. `exclude_pk` lets row updates skip self-collisions; partial-bound value maps silently skip the check (Django shape). | |
 | `ViewSet` | [ViewSet](https://www.django-rest-framework.org/api-guide/viewsets/) | SHIPPED | `#[derive(ViewSet)]` (v0.16+, tri-dialect v0.38) | |
 | `ModelViewSet` | [ModelViewSet](https://www.django-rest-framework.org/api-guide/viewsets/#modelviewset) | SHIPPED | (above, includes list/retrieve/create/update/delete) | |
 | Routers (`DefaultRouter`, `SimpleRouter`) | [routers](https://www.django-rest-framework.org/api-guide/routers/) | SHIPPED | `ViewSet::router(prefix, &Pool)` + `tenant_router(prefix)` | |


### PR DESCRIPTION
## Summary

Closes **#437** (DRF section row) and **#376** (Forms section duplicate). DRF-shape pre-save check that a candidate row doesn't collide on any of the model's declared \`unique_together\` constraints.

\`\`\`rust
use std::collections::HashMap;
use rustango::core::SqlValue;
use rustango::serializer::check_unique_together_pool;

let mut values: HashMap<&'static str, SqlValue> = HashMap::new();
values.insert("org_id",  SqlValue::I64(self.org_id));
values.insert("user_id", SqlValue::I64(self.user_id));
check_unique_together_pool(
    &pool,
    Membership::SCHEMA,
    &values,
    None,           // exclude_pk: Some(&pk) on updates
).await?;
\`\`\`

### How it works

- Walks \`ModelSchema.indexes\` for multi-column \`unique = true\` entries — the migration writer's \`unique_together\` deposit.
- For each, builds a \`SELECT 1 FROM <table> WHERE c1 = $1 AND c2 = $2 [AND pk != $3] LIMIT 1\` via the dialect emitter.
- Returns \`Err(FormErrors)\` with a non-field error per collision: \`"The fields org_id, user_id must be unique together."\` (DRF shape).

### Semantics
- **\`exclude_pk\`**: on update flows, pass \`Some(&pk_value)\` so the row being edited doesn't trip on its own row.
- **Partial value maps**: if not all unique-together columns are bound, that constraint is silently skipped (Django shape).
- **Partial unique** (\`WHERE\`-clause indexes): skipped — predicate evaluation requires a planner this layer doesn't ship.

## Test plan
- [x] **5 sqlite live tests** (\`tests/unique_together_validator.rs\`):
  - Happy path: non-colliding pair accepted
  - Collision: error names both columns + "must be unique together"
  - \`exclude_pk\` lets a row re-save its own values
  - \`exclude_pk\` still catches collisions against OTHER rows
  - Partial-bound value map silently skips the check
- [x] Litmus: \`cargo build --no-default-features --features sqlite,tenancy,serializer\`
- [x] Lib regression: 1466 tests pass
- [x] CI: \`unique_together_validator\` added to \`sqlite_litmus\` job
- [x] Audit doc: both #437 and #376 rows flipped MISSING → SHIPPED