### PR TITLE
feat(email): mail_admins / mail_managers helpers (closes #416)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test migrate_runpython_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test positive_int_field
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_dates
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,config,email --test mail_admins_managers
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,admin --test admin_list_select_related_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test form_clean_methods
 

--- a/crates/rustango/src/config/sections.rs
+++ b/crates/rustango/src/config/sections.rs
@@ -314,6 +314,16 @@ pub struct MailSettings {
     pub smtp_tls: Option<String>,
     /// `From:` address for sent mail.
     pub from_address: Option<String>,
+    /// Django-shape `ADMINS` — list of email addresses that
+    /// `email::mail_admins(...)` sends to. Typically the project's
+    /// site operators (the "5xx pages me at 3am" cohort). Issue #416.
+    #[serde(default)]
+    pub admins: Vec<String>,
+    /// Django-shape `MANAGERS` — list of email addresses that
+    /// `email::mail_managers(...)` sends to. Conventionally a
+    /// broader-but-less-urgent ops list than `admins`. Issue #416.
+    #[serde(default)]
+    pub managers: Vec<String>,
 }
 
 /// HTTP server bind + request-timeout knobs (#87).

--- a/crates/rustango/src/email/mod.rs
+++ b/crates/rustango/src/email/mod.rs
@@ -299,6 +299,86 @@ impl Mailer for NullMailer {
 /// let mailer: rustango::email::BoxedMailer =
 ///     rustango::email::from_settings(&cfg.mail);
 /// ```
+/// Django-shape `mail_admins(subject, message)` — sends to the
+/// addresses configured in `MailSettings.admins`. Returns Ok(0) when
+/// the list is empty (a no-op without warning, matching Django's
+/// "no ADMINS → silent skip" behavior). Issue #416.
+///
+/// `subject` is prefixed with `"[admin] "` to match Django's default
+/// `EMAIL_SUBJECT_PREFIX`. Override the subject yourself if you need
+/// a different prefix.
+///
+/// `from` falls back to `MailSettings.from_address`; if neither is
+/// set the mailer's `Email::validate()` will surface a
+/// `MailError::InvalidMessage`.
+///
+/// # Errors
+/// Forwarded from the mailer's `send` call. Returns `Ok(count)` on
+/// success — `count` is the number of recipients the message went to.
+#[cfg(feature = "config")]
+pub async fn mail_admins(
+    mailer: &dyn Mailer,
+    s: &crate::config::MailSettings,
+    subject: impl Into<String>,
+    body: impl Into<String>,
+) -> Result<usize, MailError> {
+    send_to_list(
+        mailer,
+        s,
+        &s.admins,
+        "[admin] ",
+        subject.into(),
+        body.into(),
+    )
+    .await
+}
+
+/// Django-shape `mail_managers(subject, message)` — sends to the
+/// addresses configured in `MailSettings.managers`. Same shape as
+/// [`mail_admins`]; subject is prefixed with `"[manager] "`. Issue #416.
+#[cfg(feature = "config")]
+pub async fn mail_managers(
+    mailer: &dyn Mailer,
+    s: &crate::config::MailSettings,
+    subject: impl Into<String>,
+    body: impl Into<String>,
+) -> Result<usize, MailError> {
+    send_to_list(
+        mailer,
+        s,
+        &s.managers,
+        "[manager] ",
+        subject.into(),
+        body.into(),
+    )
+    .await
+}
+
+#[cfg(feature = "config")]
+async fn send_to_list(
+    mailer: &dyn Mailer,
+    s: &crate::config::MailSettings,
+    list: &[String],
+    prefix: &str,
+    subject: String,
+    body: String,
+) -> Result<usize, MailError> {
+    if list.is_empty() {
+        return Ok(0);
+    }
+    let mut email = Email::new()
+        .subject(format!("{prefix}{subject}"))
+        .body(body);
+    if let Some(from) = s.from_address.as_deref() {
+        email = email.from(from.to_owned());
+    }
+    for addr in list {
+        email = email.to(addr.clone());
+    }
+    mailer.send(&email).await?;
+    Ok(list.len())
+}
+
 #[cfg(feature = "config")]
 #[must_use]
 pub fn from_settings(s: &crate::config::MailSettings) -> BoxedMailer {

--- a/crates/rustango/tests/mail_admins_managers.rs
+++ b/crates/rustango/tests/mail_admins_managers.rs
@@ -1,0 +1,67 @@
+//! Django-parity #416 — `mail_admins` / `mail_managers` helpers.
+//!
+//! Verifies the helper functions send to the right address list,
+//! respect the empty-list no-op, and apply the right subject prefix.
+
+#![cfg(all(feature = "email", feature = "config"))]
+
+use rustango::config::MailSettings;
+use rustango::email::{mail_admins, mail_managers, InMemoryMailer};
+
+fn settings_with(admins: &[&str], managers: &[&str]) -> MailSettings {
+    MailSettings {
+        backend: Some("memory".into()),
+        from_address: Some("noreply@example.com".into()),
+        admins: admins.iter().map(|s| (*s).to_string()).collect(),
+        managers: managers.iter().map(|s| (*s).to_string()).collect(),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn mail_admins_sends_to_each_admin() {
+    let mailer = InMemoryMailer::new();
+    let s = settings_with(&["alice@example.com", "bob@example.com"], &[]);
+    let n = mail_admins(&mailer, &s, "Disk full", "/var is 100%")
+        .await
+        .unwrap();
+    assert_eq!(n, 2);
+    let sent = mailer.sent();
+    assert_eq!(sent.len(), 1, "one email sent (with 2 recipients)");
+    assert_eq!(sent[0].to, vec!["alice@example.com", "bob@example.com"]);
+    assert_eq!(sent[0].subject, "[admin] Disk full");
+    assert_eq!(sent[0].body, "/var is 100%");
+    assert_eq!(sent[0].from.as_deref(), Some("noreply@example.com"));
+}
+
+#[tokio::test]
+async fn mail_admins_empty_list_is_a_silent_noop() {
+    let mailer = InMemoryMailer::new();
+    let s = settings_with(&[], &[]);
+    let n = mail_admins(&mailer, &s, "x", "y").await.unwrap();
+    assert_eq!(n, 0);
+    assert!(mailer.sent().is_empty());
+}
+
+#[tokio::test]
+async fn mail_managers_uses_manager_list_and_prefix() {
+    let mailer = InMemoryMailer::new();
+    let s = settings_with(&["dba@example.com"], &["ops-team@example.com"]);
+    // Should hit only managers, not admins.
+    let n = mail_managers(&mailer, &s, "Weekly summary", "all green")
+        .await
+        .unwrap();
+    assert_eq!(n, 1);
+    let sent = mailer.sent();
+    assert_eq!(sent[0].to, vec!["ops-team@example.com"]);
+    assert_eq!(sent[0].subject, "[manager] Weekly summary");
+}
+
+#[tokio::test]
+async fn mail_admins_uses_admin_list_not_manager_list() {
+    let mailer = InMemoryMailer::new();
+    let s = settings_with(&["dba@example.com"], &["ops-team@example.com"]);
+    mail_admins(&mailer, &s, "page", "msg").await.unwrap();
+    let sent = mailer.sent();
+    assert_eq!(sent[0].to, vec!["dba@example.com"]);
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -540,7 +540,7 @@ Summary: **7 / 2 / 5 / 0**. Gaps cluster around `m2m_changed`, migrate signals, 
 | `EmailMessage` builder | [email message](https://docs.djangoproject.com/en/6.0/topics/email/#emailmessage-and-emailmultialternatives) | SHIPPED | `email::Email` + `Mailable` pattern | |
 | `EmailMultiAlternatives` (HTML+text) | (above) | SHIPPED | `email::Email::with_html(...)` | |
 | `send_mail()` shortcut | [send_mail](https://docs.djangoproject.com/en/6.0/topics/email/#send-mail) | SHIPPED | `email::send_pool(mailer, msg)` | |
-| `mail_admins` / `mail_managers` | [mail_admins](https://docs.djangoproject.com/en/6.0/topics/email/#mail-admins) | PARTIAL | Manual recipient list (#416) | No `ADMINS` setting hook. |
+| `mail_admins` / `mail_managers` | [mail_admins](https://docs.djangoproject.com/en/6.0/topics/email/#mail-admins) | SHIPPED | `email::mail_admins(mailer, settings, subject, body)` + `email::mail_managers(...)` (closed #416, v0.42). Reads recipient lists from new `MailSettings.admins` / `MailSettings.managers` (TOML / env-overlay). Subject auto-prefixed with `[admin]` / `[manager]` matching Django's `EMAIL_SUBJECT_PREFIX`. Empty list = silent no-op (Django shape). | |
 | Console backend | [console backend](https://docs.djangoproject.com/en/6.0/topics/email/#console-backend) | SHIPPED | `email::ConsoleMailer` | |
 | In-memory / dummy backend | [locmem](https://docs.djangoproject.com/en/6.0/topics/email/#in-memory-backend) | SHIPPED | `email::InMemoryMailer` + `NullMailer` | |
 | SMTP backend | [smtp](https://docs.djangoproject.com/en/6.0/topics/email/#smtp-backend) | SHIPPED | `SmtpMailer` via lettre + rustls (`email-smtp` feature) | |


### PR DESCRIPTION
## Summary

Closes #416 — Django's \`mail_admins(subject, message)\` / \`mail_managers(subject, message)\` helpers. Reads recipient lists from the config so apps don't hand-roll the cohort.

\`\`\`rust
use rustango::email::{mail_admins, ConsoleMailer};

mail_admins(
    &ConsoleMailer,
    &settings.mail,
    "Disk full",
    "/var is 100%",
).await?;

mail_managers(
    &settings_mailer,
    &settings.mail,
    "Weekly summary",
    "all green",
).await?;
\`\`\`

### Pieces

- New \`MailSettings.admins: Vec<String>\` and \`.managers: Vec<String>\` — populated from TOML / env overlay (\`RUSTANGO__MAIL__ADMINS=...\`).
- New \`email::mail_admins\` and \`email::mail_managers\` helpers. Both:
  - Auto-prefix the subject with \`"[admin] "\` / \`"[manager] "\` matching Django's default \`EMAIL_SUBJECT_PREFIX\`.
  - Default \`From:\` to \`MailSettings.from_address\` when set.
  - Empty list → silent no-op return \`Ok(0)\` (Django shape, no warning spam).
  - Return \`Ok(count)\` on success with the recipient count.

## Test plan
- [x] **4 unit tests** (\`tests/mail_admins_managers.rs\`) — sends to each admin; empty list is a silent no-op; manager list uses \`[manager]\` prefix; admin vs manager list isolation.
- [x] Uses the existing \`InMemoryMailer\` capture backend for assertions.
- [x] Litmus: \`cargo build --no-default-features --features sqlite,tenancy\`.
- [x] CI: \`mail_admins_managers\` added to \`sqlite_litmus\` job (gated on \`config,email\`).
- [x] Audit doc: row flipped PARTIAL → SHIPPED.