### PR TITLE
feat(auth_flows): PasswordResetConfirmView helper (closes #391)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test form_clean_methods
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test unique_together_validator
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test m2m_through_model
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,passwords,auth_flows --test password_reset_confirm
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/auth_flows/mod.rs
+++ b/crates/rustango/src/auth_flows/mod.rs
@@ -60,6 +60,18 @@ pub enum AuthFlowError {
     Expired,
     #[error("token is for the wrong purpose ({0})")]
     WrongPurpose(String),
+    /// `confirm_password_reset_pool` rejected the new password — too
+    /// short, too common, or otherwise out-of-spec. Message is the
+    /// validator's complaint, suitable for surfacing to the user.
+    /// Issue #391.
+    #[error("password rejected: {0}")]
+    WeakPassword(String),
+    /// Driver / SQL failure during the password UPDATE. The message
+    /// carries the underlying driver error; callers typically log it
+    /// and surface a generic "try again" message to the operator.
+    /// Issue #391.
+    #[error("database error: {0}")]
+    Database(String),
 }
 
 impl From<SignedUrlError> for AuthFlowError {
@@ -113,6 +125,92 @@ impl PasswordReset {
             .parse::<i64>()
             .map_err(|_| AuthFlowError::Malformed)
     }
+}
+
+/// Django-shape `PasswordResetConfirmView` — verifies a reset URL,
+/// validates the new password, hashes it, and updates the named
+/// user row. Returns the `user_id` on success. Issue #391.
+///
+/// Sensible defaults:
+/// - `user_table` = `"rustango_users"`
+/// - `pk_column` = `"id"`
+/// - `password_column` = `"password_hash"`
+///
+/// The password is rejected if shorter than 8 characters
+/// (`AuthFlowError::WeakPassword`); operators wanting stricter rules
+/// run their own validators on the input before calling this helper.
+///
+/// Pairs with [`PasswordReset::issue`] — issue the URL, email it,
+/// and call this helper from your POST `/password-reset/confirm`
+/// endpoint to land the new password.
+///
+/// # Errors
+/// - [`AuthFlowError`] from `PasswordReset::verify` (Malformed,
+///   InvalidSignature, Expired, WrongPurpose).
+/// - [`AuthFlowError::WeakPassword`] when `new_password.len() < 8`.
+/// - [`AuthFlowError::Database`] for SQL / driver failures.
+#[cfg(feature = "passwords")]
+pub async fn confirm_password_reset_pool(
+    pool: &crate::sql::Pool,
+    url: &str,
+    new_password: &str,
+    secret: &[u8],
+) -> Result<i64, AuthFlowError> {
+    confirm_password_reset_pool_into(
+        pool,
+        url,
+        new_password,
+        secret,
+        "rustango_users",
+        "id",
+        "password_hash",
+    )
+    .await
+}
+
+/// As [`confirm_password_reset_pool`] but writes the new hash into a
+/// caller-named table / columns. Use when the user model lives in a
+/// custom table (e.g. tenant `app_users`) rather than the framework's
+/// default `rustango_users`. Issue #391.
+///
+/// # Errors
+/// Same shape as [`confirm_password_reset_pool`].
+#[cfg(feature = "passwords")]
+pub async fn confirm_password_reset_pool_into(
+    pool: &crate::sql::Pool,
+    url: &str,
+    new_password: &str,
+    secret: &[u8],
+    user_table: &str,
+    pk_column: &str,
+    password_column: &str,
+) -> Result<i64, AuthFlowError> {
+    let user_id = PasswordReset::verify(url, secret)?;
+    if new_password.len() < 8 {
+        return Err(AuthFlowError::WeakPassword(
+            "Password must be at least 8 characters.".into(),
+        ));
+    }
+    let hash =
+        crate::passwords::hash(new_password).map_err(|e| AuthFlowError::Database(e.to_string()))?;
+    let dialect = pool.dialect();
+    let t = dialect.quote_ident(user_table);
+    let pw = dialect.quote_ident(password_column);
+    let pk = dialect.quote_ident(pk_column);
+    let p1 = dialect.placeholder(1);
+    let p2 = dialect.placeholder(2);
+    let sql = format!("UPDATE {t} SET {pw} = {p1} WHERE {pk} = {p2}");
+    crate::sql::raw_execute_pool(
+        pool,
+        &sql,
+        vec![
+            crate::core::SqlValue::String(hash),
+            crate::core::SqlValue::I64(user_id),
+        ],
+    )
+    .await
+    .map_err(|e| AuthFlowError::Database(e.to_string()))?;
+    Ok(user_id)
 }
 
 // ------------------------------------------------------------------ Email verification

--- a/crates/rustango/tests/password_reset_confirm.rs
+++ b/crates/rustango/tests/password_reset_confirm.rs
@@ -1,0 +1,164 @@
+//! Django-parity #391 — `PasswordResetConfirmView`.
+//!
+//! Verifies `auth_flows::confirm_password_reset_pool_into` against
+//! sqlite: token round-trips, password gets hashed + written, weak
+//! passwords rejected, expired / tampered tokens rejected.
+
+#![cfg(all(feature = "sqlite", feature = "passwords", feature = "auth_flows"))]
+
+use std::time::Duration;
+
+use rustango::auth_flows::{confirm_password_reset_pool_into, AuthFlowError, PasswordReset};
+use rustango::core::SqlValue;
+use rustango::sql::Pool;
+
+const SECRET: &[u8] = b"a-strong-32-byte-secret-key-here";
+
+async fn build_pool_with_user(initial_hash: &str) -> Pool {
+    let pool = Pool::connect("sqlite::memory:").await.expect("sqlite pool");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        r#"CREATE TABLE IF NOT EXISTS "prc_users" (
+            "id"            INTEGER PRIMARY KEY AUTOINCREMENT,
+            "username"      TEXT NOT NULL,
+            "password_hash" TEXT NOT NULL
+        )"#,
+        Vec::new(),
+    )
+    .await
+    .expect("create");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        r#"INSERT INTO "prc_users" ("username", "password_hash") VALUES (?, ?)"#,
+        vec![
+            SqlValue::String("alice".into()),
+            SqlValue::String(initial_hash.into()),
+        ],
+    )
+    .await
+    .expect("seed user");
+    pool
+}
+
+async fn current_hash(pool: &Pool, user_id: i64) -> String {
+    use sqlx::Row;
+    let sql = r#"SELECT "password_hash" FROM "prc_users" WHERE "id" = ?"#;
+    match pool {
+        Pool::Sqlite(sq) => {
+            let row = sqlx::query(sql)
+                .bind(user_id)
+                .fetch_one(sq)
+                .await
+                .expect("fetch hash");
+            row.try_get::<String, _>("password_hash").unwrap()
+        }
+        #[allow(unreachable_patterns)]
+        _ => unreachable!("test is sqlite-only"),
+    }
+}
+
+#[tokio::test]
+async fn confirm_updates_password_on_valid_token() {
+    let pool = build_pool_with_user("OLD-HASH").await;
+    let url = PasswordReset::issue(
+        "https://example.com/auth/reset",
+        1,
+        SECRET,
+        Duration::from_secs(60),
+    );
+    let user_id = confirm_password_reset_pool_into(
+        &pool,
+        &url,
+        "brand-new-strong-password",
+        SECRET,
+        "prc_users",
+        "id",
+        "password_hash",
+    )
+    .await
+    .expect("valid confirm");
+    assert_eq!(user_id, 1);
+    let stored = current_hash(&pool, 1).await;
+    assert_ne!(stored, "OLD-HASH", "hash should have rotated");
+    assert!(
+        stored.starts_with("$argon2") || stored.starts_with("$2"),
+        "stored hash should be a real password hash: {stored}"
+    );
+    // The hash should verify against the cleartext we passed in.
+    assert!(rustango::passwords::verify("brand-new-strong-password", &stored).unwrap());
+}
+
+#[tokio::test]
+async fn weak_password_rejected_without_writing() {
+    let pool = build_pool_with_user("OLD-HASH").await;
+    let url = PasswordReset::issue(
+        "https://example.com/auth/reset",
+        1,
+        SECRET,
+        Duration::from_secs(60),
+    );
+    let err = confirm_password_reset_pool_into(
+        &pool,
+        &url,
+        "short",
+        SECRET,
+        "prc_users",
+        "id",
+        "password_hash",
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, AuthFlowError::WeakPassword(_)));
+    // The old hash is still in place — no write happened.
+    assert_eq!(current_hash(&pool, 1).await, "OLD-HASH");
+}
+
+#[tokio::test]
+async fn tampered_signature_rejected() {
+    let pool = build_pool_with_user("OLD-HASH").await;
+    let url = PasswordReset::issue(
+        "https://example.com/auth/reset",
+        1,
+        SECRET,
+        Duration::from_secs(60),
+    );
+    // Flip a single character of the URL after the `?` so the
+    // signature no longer matches.
+    let tampered = url.replacen("user_id=1", "user_id=2", 1);
+    let err = confirm_password_reset_pool_into(
+        &pool,
+        &tampered,
+        "brand-new-strong-password",
+        SECRET,
+        "prc_users",
+        "id",
+        "password_hash",
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, AuthFlowError::InvalidSignature));
+    assert_eq!(current_hash(&pool, 1).await, "OLD-HASH");
+}
+
+#[tokio::test]
+async fn wrong_secret_rejected() {
+    let pool = build_pool_with_user("OLD-HASH").await;
+    let url = PasswordReset::issue(
+        "https://example.com/auth/reset",
+        1,
+        SECRET,
+        Duration::from_secs(60),
+    );
+    let err = confirm_password_reset_pool_into(
+        &pool,
+        &url,
+        "brand-new-strong-password",
+        b"different-secret-32-bytes-long-xxx",
+        "prc_users",
+        "id",
+        "password_hash",
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, AuthFlowError::InvalidSignature));
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -368,7 +368,7 @@ Summary: **7 / 3 / 1 / 0**.
 | Rate limiting / account lockout | n/a | SHIPPED | `account_lockout::Lockout` + `rate_limit::*` | |
 | LoginView / LogoutView CBVs | [Auth CBVs](https://docs.djangoproject.com/en/6.0/topics/auth/default/#all-authentication-views) | SHIPPED | `admin::login_view::{public_router, protected_router, login_submit, logout_submit}` (`admin/login_view.rs:37, 88, 353`) — bundled login/logout views with session-cookie mint + redirect handling; `tenancy::auth_routes::jwt_router` provides the JWT analog. Closes #390. | |
 | PasswordChangeView CBV | (above) | SHIPPED | `/account/password` (v0.40) | |
-| PasswordResetConfirmView | (above) | MISSING | n/a (#391) | Email + token machinery is there; no view scaffold. |
+| PasswordResetConfirmView | (above) | SHIPPED | `auth_flows::confirm_password_reset_pool(pool, url, new_password, secret)` + `confirm_password_reset_pool_into(... table, pk_col, password_col)` (closed #391, v0.42). Verifies the signed reset URL via `PasswordReset::verify`, validates new-password length (≥ 8 → `AuthFlowError::WeakPassword`), hashes via `passwords::hash`, and writes the new hash to the named user table. Defaults target `rustango_users(id, password_hash)`; the `_into` variant takes table + column names for custom user models. | |
 | Passkey / WebAuthn | (Django 5.2+) | MISSING | n/a (#392) | |
 
 Summary: **14 SHIPPED / 4 PARTIAL / 4 MISSING / 1 N/A**.


### PR DESCRIPTION
## Summary

Closes #391 — Django's \`PasswordResetConfirmView\`. The pure \`PasswordReset\` signed-URL primitive already shipped; this PR adds the "verify → hash → write" composite operation that the audit row flagged as missing.

\`\`\`rust
use rustango::auth_flows::confirm_password_reset_pool;

let user_id = confirm_password_reset_pool(
    &pool,
    &incoming_url,
    &new_password,
    secret,
).await?;
\`\`\`

### Two variants

- **\`confirm_password_reset_pool\`** — sensible-default form targeting \`rustango_users(id, password_hash)\`.
- **\`confirm_password_reset_pool_into(pool, url, new_pw, secret, table, pk_col, password_col)\`** — custom user-model variant. Use when your user table is named differently (\`app_users\`, \`accounts\`, tenant-scoped, etc.).

Both helpers run:
1. \`PasswordReset::verify(url, secret)\` → user_id (or \`AuthFlowError\`).
2. Validate \`new_password.len() >= 8\` → otherwise \`AuthFlowError::WeakPassword\`.
3. \`passwords::hash(new_password)\` → argon2 hash.
4. \`UPDATE <table> SET <password_col> = $1 WHERE <pk_col> = $2\`.
5. Return user_id on success.

Two new \`AuthFlowError\` variants:
- \`WeakPassword(String)\` — validator message, suitable for surfacing to the user.
- \`Database(String)\` — driver-error envelope (caller logs + shows generic message).

Pre-existing \`Malformed\` / \`InvalidSignature\` / \`Expired\` / \`WrongPurpose\` continue to propagate from \`PasswordReset::verify\`.

## Test plan
- [x] **4 sqlite live tests** (\`tests/password_reset_confirm.rs\`):
  - Valid round-trip — hash rotates, verifies against cleartext via \`passwords::verify\`.
  - Weak password (<8 chars) — \`WeakPassword\` returned, no write.
  - Tampered signature — \`InvalidSignature\` returned, no write.
  - Wrong secret — \`InvalidSignature\` returned.
- [x] Litmus: \`cargo build --no-default-features --features sqlite,tenancy\`.
- [x] Lib regression: 1466 tests pass.
- [x] CI: \`password_reset_confirm\` added to \`sqlite_litmus\` job (gated on \`passwords,auth_flows\`).
- [x] Audit doc: row flipped MISSING → SHIPPED.