### PR TITLE
feat(email): file-based email backend (closes #417)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,passwords,auth_flows --test password_reset_confirm
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,cache,config --test file_cache_backend
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test factories
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,config,email --test file_email_backend
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/config/sections.rs
+++ b/crates/rustango/src/config/sections.rs
@@ -331,6 +331,12 @@ pub struct MailSettings {
     /// broader-but-less-urgent ops list than `admins`. Issue #416.
     #[serde(default)]
     pub managers: Vec<String>,
+    /// Django-shape `EMAIL_FILE_PATH` — directory the `"file"` mail
+    /// backend writes outgoing `.eml` files to (instead of sending).
+    /// Set alongside `backend = "file"`; if `backend = "file"` is
+    /// requested but this is unset, the resolver falls back to
+    /// `ConsoleMailer` with a tracing warning. Issue #417.
+    pub file_email_dir: Option<std::path::PathBuf>,
 }
 
 /// HTTP server bind + request-timeout knobs (#87).

--- a/crates/rustango/src/email/mod.rs
+++ b/crates/rustango/src/email/mod.rs
@@ -260,6 +260,111 @@ impl Mailer for InMemoryMailer {
     }
 }
 
+// ------------------------------------------------------------------ FileMailer
+
+/// Development / debug mailer — writes each outgoing email to a
+/// timestamped `.eml` file in a configured directory instead of
+/// sending it.
+///
+/// Mirrors Django's `django.core.mail.backends.filebased.EmailBackend`
+/// (issue #417). Useful when you want to inspect rendered email
+/// content (password-reset links, signup confirmations) during
+/// development without wiring an SMTP relay or piping stdout into a
+/// log file.
+///
+/// File names are `YYYYMMDDHHMMSS-<seq>.eml` so a burst of emails
+/// inside the same second still get unique paths. The directory is
+/// created on `send` if it doesn't yet exist.
+pub struct FileMailer {
+    dir: std::path::PathBuf,
+    seq: std::sync::atomic::AtomicU64,
+}
+
+impl FileMailer {
+    /// Build a mailer that writes `.eml` files into `dir`. The
+    /// directory is auto-created on the first `send` call.
+    #[must_use]
+    pub fn new(dir: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            dir: dir.into(),
+            seq: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    /// The directory `.eml` files are written into.
+    #[must_use]
+    pub fn dir(&self) -> &std::path::Path {
+        &self.dir
+    }
+}
+
+/// Serialize an `Email` to RFC-822-ish text. Headers first, blank
+/// line, then body. HTML alternative (when present) is appended as a
+/// `--- HTML alternative ---` block — this matches the human-readable
+/// shape Django's file backend uses for dev inspection. We are NOT
+/// producing a fully-spec-compliant multipart MIME message; this is a
+/// debugging dump format.
+fn serialize_eml(email: &Email) -> String {
+    let mut out = String::with_capacity(256 + email.body.len());
+    if let Some(f) = &email.from {
+        out.push_str("From: ");
+        out.push_str(f);
+        out.push('\n');
+    }
+    if !email.to.is_empty() {
+        out.push_str("To: ");
+        out.push_str(&email.to.join(", "));
+        out.push('\n');
+    }
+    if !email.cc.is_empty() {
+        out.push_str("Cc: ");
+        out.push_str(&email.cc.join(", "));
+        out.push('\n');
+    }
+    if !email.bcc.is_empty() {
+        out.push_str("Bcc: ");
+        out.push_str(&email.bcc.join(", "));
+        out.push('\n');
+    }
+    if let Some(rt) = &email.reply_to {
+        out.push_str("Reply-To: ");
+        out.push_str(rt);
+        out.push('\n');
+    }
+    out.push_str("Subject: ");
+    out.push_str(&email.subject);
+    out.push('\n');
+    for (k, v) in &email.headers {
+        out.push_str(k);
+        out.push_str(": ");
+        out.push_str(v);
+        out.push('\n');
+    }
+    out.push('\n');
+    out.push_str(&email.body);
+    if let Some(html) = &email.html_body {
+        out.push_str("\n\n--- HTML alternative ---\n");
+        out.push_str(html);
+    }
+    out
+}
+
+#[async_trait]
+impl Mailer for FileMailer {
+    async fn send(&self, email: &Email) -> Result<(), MailError> {
+        email.validate()?;
+        std::fs::create_dir_all(&self.dir)
+            .map_err(|e| MailError::Transport(format!("create_dir_all: {e}")))?;
+        let seq = self.seq.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let stamp = chrono::Utc::now().format("%Y%m%d%H%M%S");
+        let name = format!("{stamp}-{seq:04}.eml");
+        let path = self.dir.join(name);
+        std::fs::write(&path, serialize_eml(email))
+            .map_err(|e| MailError::Transport(format!("write {}: {e}", path.display())))?;
+        Ok(())
+    }
+}
+
 // ------------------------------------------------------------------ NullMailer
 
 /// Discards all emails. Useful for disabling email sending in environments
@@ -386,12 +491,31 @@ pub fn from_settings(s: &crate::config::MailSettings) -> BoxedMailer {
         Some("smtp") => smtp_from_settings_or_warn(s),
         Some("memory") => Arc::new(InMemoryMailer::new()),
         Some("null" | "none") => Arc::new(NullMailer),
+        Some("file") => file_from_settings_or_warn(s),
         Some("console") | None => Arc::new(ConsoleMailer),
         Some(other) => {
             tracing::warn!(
                 target: "rustango::email",
                 backend = %other,
                 "unknown mail.backend value; falling back to ConsoleMailer",
+            );
+            Arc::new(ConsoleMailer)
+        }
+    }
+}
+
+/// File-backend resolver — needs `[mail].file_email_dir` to be set,
+/// otherwise warns and falls back to `ConsoleMailer` so the app still
+/// boots. Issue #417.
+#[cfg(feature = "config")]
+fn file_from_settings_or_warn(s: &crate::config::MailSettings) -> BoxedMailer {
+    match s.file_email_dir.as_deref() {
+        Some(dir) => Arc::new(FileMailer::new(dir)),
+        None => {
+            tracing::warn!(
+                target: "rustango::email",
+                "mail.backend = \"file\" but [mail].file_email_dir is unset; \
+                 falling back to ConsoleMailer.",
             );
             Arc::new(ConsoleMailer)
         }

--- a/crates/rustango/tests/file_email_backend.rs
+++ b/crates/rustango/tests/file_email_backend.rs
@@ -1,0 +1,150 @@
+//! Django-parity #417 — file-based email backend.
+//!
+//! Verifies `FileMailer` writes `.eml` files containing the rendered
+//! email headers + body, gives each send a unique filename, validates
+//! input before touching the filesystem, and is selectable through
+//! `email::from_settings` with `backend = "file"`.
+
+#![cfg(all(feature = "email", feature = "config"))]
+
+use std::sync::Arc;
+
+use rustango::config::MailSettings;
+use rustango::email::{from_settings, Email, FileMailer, MailError, Mailer};
+
+fn unique_tmp_dir(label: &str) -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("rustango-file-mail-{label}-{pid}-{nanos}"))
+}
+
+#[tokio::test]
+async fn file_mailer_writes_eml_with_headers_and_body() {
+    let dir = unique_tmp_dir("basic");
+    let mailer = FileMailer::new(&dir);
+    let email = Email::new()
+        .to("alice@example.com")
+        .cc("audit@example.com")
+        .from("noreply@example.com")
+        .subject("Welcome")
+        .body("Hello, Alice.");
+    mailer.send(&email).await.expect("send ok");
+
+    let mut entries: Vec<_> = std::fs::read_dir(&dir)
+        .expect("dir exists")
+        .filter_map(Result::ok)
+        .collect();
+    assert_eq!(entries.len(), 1, "exactly one .eml written");
+    let path = entries.pop().unwrap().path();
+    assert_eq!(path.extension().and_then(|s| s.to_str()), Some("eml"));
+    let body = std::fs::read_to_string(&path).expect("read .eml");
+
+    assert!(body.contains("From: noreply@example.com"));
+    assert!(body.contains("To: alice@example.com"));
+    assert!(body.contains("Cc: audit@example.com"));
+    assert!(body.contains("Subject: Welcome"));
+    assert!(body.contains("Hello, Alice."));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn file_mailer_gives_each_send_unique_filename() {
+    let dir = unique_tmp_dir("unique");
+    let mailer = FileMailer::new(&dir);
+    let make = |i: usize| {
+        Email::new()
+            .to(format!("recipient-{i}@example.com"))
+            .from("noreply@example.com")
+            .subject(format!("Msg {i}"))
+            .body("body")
+    };
+    mailer.send(&make(1)).await.expect("send 1 ok");
+    mailer.send(&make(2)).await.expect("send 2 ok");
+    mailer.send(&make(3)).await.expect("send 3 ok");
+
+    let entries: Vec<_> = std::fs::read_dir(&dir)
+        .expect("dir exists")
+        .filter_map(Result::ok)
+        .map(|e| e.file_name())
+        .collect();
+    assert_eq!(entries.len(), 3, "three unique files");
+    let mut sorted = entries.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(
+        sorted.len(),
+        3,
+        "names should differ even within one second"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn file_mailer_rejects_invalid_email_without_writing() {
+    let dir = unique_tmp_dir("invalid");
+    let mailer = FileMailer::new(&dir);
+    let err = mailer
+        .send(&Email::new().subject("nobody-to").body("..."))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, MailError::InvalidMessage(_)));
+    // The directory may have been created (auto-create runs after
+    // validation in this impl), so check that no .eml landed.
+    if dir.exists() {
+        let entries: Vec<_> = std::fs::read_dir(&dir)
+            .expect("dir readable")
+            .filter_map(Result::ok)
+            .collect();
+        assert!(entries.is_empty(), "no .eml on invalid send");
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn from_settings_file_backend_writes_to_configured_dir() {
+    let dir = unique_tmp_dir("settings");
+    let s = MailSettings {
+        backend: Some("file".into()),
+        from_address: Some("noreply@example.com".into()),
+        file_email_dir: Some(dir.clone()),
+        ..Default::default()
+    };
+    let mailer: Arc<dyn Mailer> = from_settings(&s);
+    let email = Email::new()
+        .to("ops@example.com")
+        .from("noreply@example.com")
+        .subject("Hi")
+        .body("body");
+    mailer.send(&email).await.expect("send ok");
+
+    let entries: Vec<_> = std::fs::read_dir(&dir)
+        .expect("dir exists")
+        .filter_map(Result::ok)
+        .collect();
+    assert_eq!(entries.len(), 1);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn from_settings_file_backend_without_dir_falls_back() {
+    let s = MailSettings {
+        backend: Some("file".into()),
+        from_address: Some("noreply@example.com".into()),
+        file_email_dir: None,
+        ..Default::default()
+    };
+    // No panic, no error — just a warning + ConsoleMailer fallback.
+    let mailer = from_settings(&s);
+    let email = Email::new()
+        .to("ops@example.com")
+        .from("noreply@example.com")
+        .subject("Hi")
+        .body("body");
+    mailer.send(&email).await.expect("fallback console send ok");
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -545,11 +545,11 @@ Summary: **7 / 2 / 5 / 0**. Gaps cluster around `m2m_changed`, migrate signals, 
 | In-memory / dummy backend | [locmem](https://docs.djangoproject.com/en/6.0/topics/email/#in-memory-backend) | SHIPPED | `email::InMemoryMailer` + `NullMailer` | |
 | SMTP backend | [smtp](https://docs.djangoproject.com/en/6.0/topics/email/#smtp-backend) | SHIPPED | `SmtpMailer` via lettre + rustls (`email-smtp` feature) | |
 | Email templates (Tera) | n/a in Django core | SHIPPED | `email_templates::EmailRenderer` | |
-| File backend | [file backend](https://docs.djangoproject.com/en/6.0/topics/email/#file-backend) | MISSING | n/a (#417) | Niche dev tool. |
+| File backend | [file backend](https://docs.djangoproject.com/en/6.0/topics/email/#file-backend) | SHIPPED | `email::FileMailer` (`backend = "file"` + `[mail].file_email_dir`) — `src/email/mod.rs` | |
 | Email job queue integration | n/a | SHIPPED | `email_jobs::dispatch_email` | |
 | Multi-channel notifications (Mail + Slack + DB) | n/a (Django needs `django-notifications`) | PARTIAL | `notifications::*` skeleton (v0.21); incomplete provider set (#418) | |
 
-Summary: **6 / 2 / 1 / 0**.
+Summary: **7 / 2 / 0 / 0**.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `email::FileMailer` — writes outgoing emails as timestamped `.eml` files in a configured directory instead of sending them (Django's `django.core.mail.backends.filebased.EmailBackend`).
- New `[mail].file_email_dir` setting + `"file"` value for `[mail].backend`; `from_settings` selects `FileMailer` when both are set, falls back to `ConsoleMailer` with a tracing warning otherwise.
- `MailSettings.file_email_dir: Option<PathBuf>` added under `#[serde(default)]` (no breaking change to existing config files).

## Closes
#417

## Test plan
- [x] `cargo test --no-default-features --features sqlite,tenancy,config,email --test file_email_backend` — 5 tests pass: write produces headers+body, multiple sends get unique filenames, invalid email rejected before write, `from_settings("file")` round-trip, missing `file_email_dir` falls back to console.
- [x] Litmus: `cargo check --no-default-features --features sqlite,tenancy` clean.
- [x] `cargo build --all-features --tests` clean (pre-push gate ran full lib suite — 2302 pass).
- [x] Audit row #417 flipped MISSING → SHIPPED; category 18 summary updated to 7/2/0/0.
- [x] CI line added under `sqlite_litmus`.