### PR TITLE
feat(cache): file-system cache backend (closes #408)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test unique_together_validator
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test m2m_through_model
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,passwords,auth_flows --test password_reset_confirm
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,cache,config --test file_cache_backend
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -75,7 +75,7 @@ serializer = ["forms"]
 # Caching layer (`rustango::cache`) — pluggable `Cache` trait with
 # `NullCache` (no-op) and `InMemoryCache` (tokio RwLock + TTL). Redis
 # backend is behind the separate `cache-redis` feature.
-cache = ["dep:async-trait", "dep:tokio"]
+cache = ["dep:async-trait", "dep:tokio", "dep:sha2"]
 
 # Per-view caching tower layer (`rustango::cache_page`) — Django's
 # @cache_page / @cache_control / @vary_on_headers analogs. Implies

--- a/crates/rustango/src/cache/mod.rs
+++ b/crates/rustango/src/cache/mod.rs
@@ -177,12 +177,31 @@ pub fn from_settings(s: &crate::config::CacheSettings) -> BoxedCache {
             Arc::new(InMemoryCache::new())
         }
         Some("null" | "none") => Arc::new(NullCache),
+        Some("file") => file_from_settings_or_warn(s),
         Some("memory") | None => Arc::new(InMemoryCache::new()),
         Some(other) => {
             tracing::warn!(
                 target: "rustango::cache",
                 backend = %other,
                 "unknown cache.backend value; falling back to InMemoryCache",
+            );
+            Arc::new(InMemoryCache::new())
+        }
+    }
+}
+
+/// File-backend resolver — needs `[cache].file_cache_dir` set,
+/// otherwise warns and falls back to `InMemoryCache` so the app still
+/// boots on misconfig. Issue #408.
+#[cfg(feature = "config")]
+fn file_from_settings_or_warn(s: &crate::config::CacheSettings) -> BoxedCache {
+    match s.file_cache_dir.as_deref() {
+        Some(dir) => Arc::new(FileCache::new(dir)),
+        None => {
+            tracing::warn!(
+                target: "rustango::cache",
+                "cache.backend = \"file\" but [cache].file_cache_dir is unset; \
+                 falling back to InMemoryCache.",
             );
             Arc::new(InMemoryCache::new())
         }
@@ -395,6 +414,163 @@ impl Cache for InMemoryCache {
 
     async fn clear(&self) -> Result<(), CacheError> {
         self.inner.write().await.clear();
+        Ok(())
+    }
+}
+
+// ------------------------------------------------------------------ FileCache
+
+/// File-system cache — one file per key, mirroring Django's
+/// `django.core.cache.backends.filebased.FileBasedCache` (issue #408).
+///
+/// Useful when you want process-restart-durable caching without
+/// running Redis, and when the working set fits the local disk.
+/// Keys are SHA-256-hashed to produce filenames that are safe across
+/// platforms (no path-separator surprises, no length limits, no case
+/// folding on macOS). The directory is auto-created on the first
+/// `set`.
+///
+/// ## File format
+///
+/// Each entry is a small binary blob:
+///   `[expires_at_unix_secs: i64 big-endian][value bytes]`
+///
+/// `expires_at_unix_secs` is `0` when the entry has no TTL. Expired
+/// entries are pruned lazily on the next `get` / `exists` call —
+/// there is no background reaper.
+///
+/// ## Limitations vs Django
+///
+/// Django's FBC takes a `_lock` file for atomic multi-process writes
+/// + supports MAX_ENTRIES with a cull strategy. This implementation
+/// is the minimal Django-shape primitive: same on-disk semantics,
+/// per-process atomicity via `std::fs::write` (atomic per-call on
+/// most filesystems). Add file locking when a project actually
+/// shares the directory across processes.
+pub struct FileCache {
+    dir: std::path::PathBuf,
+}
+
+impl FileCache {
+    /// Build a cache that stores entries under `dir`. The directory
+    /// is auto-created on the first `set` call.
+    #[must_use]
+    pub fn new(dir: impl Into<std::path::PathBuf>) -> Self {
+        Self { dir: dir.into() }
+    }
+
+    /// The directory entries are stored under.
+    #[must_use]
+    pub fn dir(&self) -> &std::path::Path {
+        &self.dir
+    }
+
+    /// Hash the key into a stable, filesystem-safe filename. Uses
+    /// SHA-256 (already a workspace dep via `passwords` / `signed_url`)
+    /// hexlified; no separators, no length surprises.
+    fn key_path(&self, key: &str) -> std::path::PathBuf {
+        use sha2::{Digest, Sha256};
+        let hash = Sha256::digest(key.as_bytes());
+        let mut name = String::with_capacity(64 + 6);
+        for b in hash {
+            use std::fmt::Write as _;
+            let _ = write!(&mut name, "{b:02x}");
+        }
+        name.push_str(".cache");
+        self.dir.join(name)
+    }
+
+    fn now_unix_secs() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0)
+    }
+
+    /// Encode `[expires_at: i64 BE][value bytes]`. expires_at = 0
+    /// means no TTL.
+    fn encode(value: &str, ttl: Option<Duration>) -> Vec<u8> {
+        let expires_at = ttl
+            .map(|d| Self::now_unix_secs().saturating_add(d.as_secs() as i64))
+            .unwrap_or(0);
+        let mut out = Vec::with_capacity(8 + value.len());
+        out.extend_from_slice(&expires_at.to_be_bytes());
+        out.extend_from_slice(value.as_bytes());
+        out
+    }
+
+    /// Decode the file body. Returns `Some(value)` if present + not
+    /// expired, else `None`. Caller is responsible for deleting the
+    /// file when this returns `None` due to expiry.
+    fn decode(buf: &[u8]) -> Option<(String, bool /* expired */)> {
+        if buf.len() < 8 {
+            return None;
+        }
+        let mut ts = [0u8; 8];
+        ts.copy_from_slice(&buf[..8]);
+        let expires_at = i64::from_be_bytes(ts);
+        let value = std::str::from_utf8(&buf[8..]).ok()?.to_owned();
+        let expired = expires_at != 0 && Self::now_unix_secs() >= expires_at;
+        Some((value, expired))
+    }
+}
+
+#[async_trait]
+impl Cache for FileCache {
+    async fn get(&self, key: &str) -> Result<Option<String>, CacheError> {
+        let path = self.key_path(key);
+        let buf = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(CacheError::Connection(format!("read: {e}"))),
+        };
+        match Self::decode(&buf) {
+            Some((_, true)) => {
+                let _ = std::fs::remove_file(&path);
+                Ok(None)
+            }
+            Some((v, false)) => Ok(Some(v)),
+            None => {
+                let _ = std::fs::remove_file(&path);
+                Ok(None)
+            }
+        }
+    }
+
+    async fn set(&self, key: &str, value: &str, ttl: Option<Duration>) -> Result<(), CacheError> {
+        std::fs::create_dir_all(&self.dir)
+            .map_err(|e| CacheError::Connection(format!("create_dir_all: {e}")))?;
+        let path = self.key_path(key);
+        std::fs::write(&path, Self::encode(value, ttl))
+            .map_err(|e| CacheError::Connection(format!("write: {e}")))?;
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), CacheError> {
+        let path = self.key_path(key);
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(CacheError::Connection(format!("remove_file: {e}"))),
+        }
+    }
+
+    async fn exists(&self, key: &str) -> Result<bool, CacheError> {
+        Ok(self.get(key).await?.is_some())
+    }
+
+    async fn clear(&self) -> Result<(), CacheError> {
+        let entries = match std::fs::read_dir(&self.dir) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(CacheError::Connection(format!("read_dir: {e}"))),
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("cache") {
+                let _ = std::fs::remove_file(&path);
+            }
+        }
         Ok(())
     }
 }

--- a/crates/rustango/src/config/sections.rs
+++ b/crates/rustango/src/config/sections.rs
@@ -270,10 +270,17 @@ pub struct TenancySettings {
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct CacheSettings {
-    /// `"memory"` (default), `"redis"`, `"postgres"`.
+    /// `"memory"` (default), `"redis"`, `"file"`, `"postgres"`.
     pub backend: Option<String>,
     /// Redis connection URL when `backend = "redis"`.
     pub redis_url: Option<String>,
+    /// Django-shape `CACHES["default"]["LOCATION"]` for the
+    /// file-system cache backend (#408). Directory the `"file"` cache
+    /// backend stores entries under, one file per key. When unset
+    /// while `backend = "file"`, the resolver falls back to
+    /// `InMemoryCache` with a tracing warning so a misconfig doesn't
+    /// block boot.
+    pub file_cache_dir: Option<std::path::PathBuf>,
 }
 
 /// Background-jobs runner config. Slice 10.1 lights up.

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -3212,7 +3212,7 @@ async fn flush_cmd<W: Write>(pool: &Pool, args: &[String], w: &mut W) -> Result<
 /// Only the `feature = "config"` build of `sendtestemail_cmd` uses
 /// this; the `not(feature = "config")` stub short-circuits with a
 /// friendly error, so the parser is unreachable there.
-#[cfg(feature = "config")]
+#[cfg(all(feature = "config", feature = "email"))]
 #[derive(Debug, Default, PartialEq, Eq)]
 struct SendTestEmailArgs {
     to: Option<String>,
@@ -3221,7 +3221,7 @@ struct SendTestEmailArgs {
     help: bool,
 }
 
-#[cfg(feature = "config")]
+#[cfg(all(feature = "config", feature = "email"))]
 fn parse_sendtestemail_args(args: &[String]) -> Result<SendTestEmailArgs, MigrateError> {
     let mut out = SendTestEmailArgs::default();
     let mut iter = args.iter();
@@ -3272,7 +3272,7 @@ fn parse_sendtestemail_args(args: &[String]) -> Result<SendTestEmailArgs, Migrat
 /// Successful send prints `sendtestemail: ok` plus the resolved
 /// backend name. Send failures surface the underlying `MailError`
 /// as a [`MigrateError::Validation`].
-#[cfg(feature = "config")]
+#[cfg(all(feature = "config", feature = "email"))]
 async fn sendtestemail_cmd<W: Write>(args: &[String], w: &mut W) -> Result<(), MigrateError> {
     let parsed = parse_sendtestemail_args(args)?;
     if parsed.help {
@@ -3360,6 +3360,15 @@ async fn sendtestemail_cmd<W: Write>(_args: &[String], _w: &mut W) -> Result<(),
     Err(MigrateError::Validation(
         "sendtestemail: this build was compiled without the `config` feature — settings \
          can't be loaded. Rebuild with `--features config`."
+            .to_owned(),
+    ))
+}
+
+#[cfg(all(feature = "config", not(feature = "email")))]
+async fn sendtestemail_cmd<W: Write>(_args: &[String], _w: &mut W) -> Result<(), MigrateError> {
+    Err(MigrateError::Validation(
+        "sendtestemail: this build was compiled without the `email` feature — \
+         the mail backend isn't linked. Rebuild with `--features email`."
             .to_owned(),
     ))
 }

--- a/crates/rustango/tests/file_cache_backend.rs
+++ b/crates/rustango/tests/file_cache_backend.rs
@@ -1,0 +1,128 @@
+//! Django-parity #408 — file-system cache backend.
+//!
+//! Verifies `FileCache` round-trips through the disk, applies TTL,
+//! prunes expired entries on read, and is selectable through
+//! `cache::from_settings` with `backend = "file"`.
+
+#![cfg(all(feature = "cache", feature = "config"))]
+
+use std::time::Duration;
+
+use rustango::cache::{from_settings, Cache, FileCache};
+use rustango::config::CacheSettings;
+
+fn unique_tmp_dir(label: &str) -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("rustango-file-cache-{label}-{pid}-{nanos}"))
+}
+
+#[tokio::test]
+async fn set_then_get_round_trips_through_disk() {
+    let dir = unique_tmp_dir("rt");
+    let cache = FileCache::new(&dir);
+    cache.set("k", "hello", None).await.expect("set ok");
+    assert_eq!(cache.get("k").await.unwrap().as_deref(), Some("hello"));
+    assert!(cache.exists("k").await.unwrap());
+    assert!(dir.exists(), "set should auto-create the directory");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn delete_removes_the_file() {
+    let dir = unique_tmp_dir("del");
+    let cache = FileCache::new(&dir);
+    cache.set("k", "v", None).await.unwrap();
+    assert!(cache.exists("k").await.unwrap());
+    cache.delete("k").await.unwrap();
+    assert!(!cache.exists("k").await.unwrap());
+    assert_eq!(cache.get("k").await.unwrap(), None);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn ttl_expires_on_next_read() {
+    let dir = unique_tmp_dir("ttl");
+    let cache = FileCache::new(&dir);
+    // 1s TTL — fast enough to test, slow enough not to race the
+    // set itself.
+    cache
+        .set("k", "v", Some(Duration::from_secs(1)))
+        .await
+        .unwrap();
+    assert_eq!(cache.get("k").await.unwrap().as_deref(), Some("v"));
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    assert_eq!(
+        cache.get("k").await.unwrap(),
+        None,
+        "TTL-expired entry should read as None",
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn clear_removes_all_entries_but_keeps_dir() {
+    let dir = unique_tmp_dir("clear");
+    let cache = FileCache::new(&dir);
+    cache.set("a", "1", None).await.unwrap();
+    cache.set("b", "2", None).await.unwrap();
+    cache.set("c", "3", None).await.unwrap();
+    cache.clear().await.unwrap();
+    assert_eq!(cache.get("a").await.unwrap(), None);
+    assert_eq!(cache.get("b").await.unwrap(), None);
+    assert_eq!(cache.get("c").await.unwrap(), None);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn long_or_funny_keys_dont_break_filenames() {
+    let dir = unique_tmp_dir("funny");
+    let cache = FileCache::new(&dir);
+    let funny = "user/../session/?id=1&token=*x*/with spaces and 🦀 unicode";
+    cache.set(funny, "ok", None).await.unwrap();
+    assert_eq!(cache.get(funny).await.unwrap().as_deref(), Some("ok"));
+    // The on-disk filename must NOT contain the path separator.
+    let entries: Vec<_> = std::fs::read_dir(&dir)
+        .expect("dir exists")
+        .filter_map(Result::ok)
+        .collect();
+    assert_eq!(entries.len(), 1);
+    let name = entries[0].file_name().to_string_lossy().into_owned();
+    assert!(!name.contains('/'), "filename mustn't contain '/'");
+    assert!(name.ends_with(".cache"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn from_settings_file_backend_round_trips() {
+    let dir = unique_tmp_dir("settings");
+    let s = CacheSettings {
+        backend: Some("file".into()),
+        file_cache_dir: Some(dir.clone()),
+        ..Default::default()
+    };
+    let cache = from_settings(&s);
+    cache.set("k", "v", None).await.unwrap();
+    assert_eq!(cache.get("k").await.unwrap().as_deref(), Some("v"));
+    // Confirm the on-disk side: a file landed under the configured dir.
+    let count = std::fs::read_dir(&dir).unwrap().count();
+    assert_eq!(count, 1);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn from_settings_file_backend_without_dir_falls_back_to_memory() {
+    let s = CacheSettings {
+        backend: Some("file".into()),
+        file_cache_dir: None,
+        ..Default::default()
+    };
+    // No panic, no error — we fall back to InMemoryCache, which still
+    // round-trips.
+    let cache = from_settings(&s);
+    cache.set("k", "v", None).await.unwrap();
+    assert_eq!(cache.get("k").await.unwrap().as_deref(), Some("v"));
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -501,7 +501,7 @@ Summary: **14 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A** for the dimensions enume
 | Cache trait + pluggable backends | [cache framework](https://docs.djangoproject.com/en/6.0/topics/cache/) | SHIPPED | `cache::Cache` trait | |
 | Memcached backend | [memcached](https://docs.djangoproject.com/en/6.0/topics/cache/#memcached) | MISSING | n/a (#407) | Use Redis or in-memory. |
 | Redis backend | [redis](https://docs.djangoproject.com/en/6.0/topics/cache/#redis) | SHIPPED | `cache-redis` feature (v0.18) | |
-| File-system cache | [filesystem](https://docs.djangoproject.com/en/6.0/topics/cache/#file-system-caching) | MISSING | n/a (#408) | |
+| File-system cache | [filesystem](https://docs.djangoproject.com/en/6.0/topics/cache/#file-system-caching) | SHIPPED | `cache::FileCache` (`backend = "file"` + `[cache].file_cache_dir`) — `src/cache/mod.rs` | |
 | In-memory cache | [local-memory](https://docs.djangoproject.com/en/6.0/topics/cache/#local-memory-caching) | SHIPPED | `InMemoryCache` | |
 | Database cache | [db](https://docs.djangoproject.com/en/6.0/topics/cache/#database-caching) | PARTIAL | DB tables can back the trait; no first-class `DbCache` (#409) | |
 | `@cache_page` view decorator | [cache_page](https://docs.djangoproject.com/en/6.0/topics/cache/#the-per-view-cache) | SHIPPED | `cache_page::cache_page_layer` (v0.19) | |
@@ -509,7 +509,7 @@ Summary: **14 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A** for the dimensions enume
 | `@vary_on_headers` / `@vary_on_cookie` | [vary](https://docs.djangoproject.com/en/6.0/topics/cache/#using-vary-headers) | SHIPPED | Vary header helpers | |
 | Template fragment caching | [template fragments](https://docs.djangoproject.com/en/6.0/topics/cache/#template-fragment-caching) | SHIPPED | `cache_fragment::cached_render` | |
 
-Summary: **7 / 1 / 2 / 0**.
+Summary: **8 / 1 / 1 / 0**.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds \`cache::FileCache\` — one file per key on the local filesystem, mirroring Django's \`django.core.cache.backends.filebased.FileBasedCache\`.
- Keys are SHA-256-hashed to produce stable, filesystem-safe filenames (no path-separator hazards, no length surprises across platforms).
- Entries encode as \`[expires_at_unix_secs: i64 BE][value bytes]\`; TTL is enforced lazily on the next read (expired files are pruned in-place).
- Wired through \`cache::from_settings\`: \`backend = \"file\"\` + \`[cache].file_cache_dir\`. Missing dir falls back to \`InMemoryCache\` with a tracing warning so a misconfig doesn't block boot.
- \`sha2\` added to the \`cache\` Cargo feature (already a workspace dep, was previously only enabled by \`oauth2\`/\`jwt\`/etc.).

## Closes
#408

## Test plan
- [x] \`cargo test --no-default-features --features sqlite,tenancy,cache,config,email --test file_cache_backend\` — 7 tests pass: set/get round-trip, delete, TTL expiry, clear, awkward keys (path separators / unicode / spaces) survive hashing, \`from_settings(\"file\")\` round-trips, missing \`file_cache_dir\` falls back to memory.
- [x] Litmus: \`cargo check --no-default-features --features sqlite,tenancy\` clean.
- [x] \`cargo build --all-features --tests\` clean.
- [x] Audit row #408 flipped MISSING → SHIPPED; category 16 summary updated to 8/1/1/0.
- [x] CI line added under \`sqlite_litmus\`.