### PR TITLE
feat(sessions): file-backed sessions via FileCache (closes #394)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,cache,config --test file_cache_backend
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test factories
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,config,email --test file_email_backend
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,cache,sessions --test file_backed_sessions
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/tests/file_backed_sessions.rs
+++ b/crates/rustango/tests/file_backed_sessions.rs
@@ -1,0 +1,107 @@
+//! Django-parity #394 — file-based session backend.
+//!
+//! Rustango's `SessionStore` is a thin wrapper over the `Cache`
+//! trait, so any `Cache` implementation becomes a session backend
+//! for free. This test pins that composition for the file-system
+//! backend (#408): a `SessionStore::new(Arc::new(FileCache::new(dir)))`
+//! round-trips through disk, survives a fresh `SessionStore`
+//! instance built on the same directory (process-restart durability),
+//! and respects `destroy()`.
+
+#![cfg(all(feature = "sessions", feature = "cache"))]
+
+use std::sync::Arc;
+
+use rustango::cache::{BoxedCache, FileCache};
+use rustango::sessions::{Session, SessionStore};
+
+fn unique_tmp_dir(label: &str) -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("rustango-file-session-{label}-{pid}-{nanos}"))
+}
+
+fn file_store(dir: &std::path::Path) -> SessionStore {
+    let cache: BoxedCache = Arc::new(FileCache::new(dir));
+    SessionStore::new(cache)
+}
+
+#[tokio::test]
+async fn save_then_load_round_trips_through_disk() {
+    let dir = unique_tmp_dir("rt");
+    let store = file_store(&dir);
+
+    let mut s = Session::new();
+    s.set("user_id", 42_i64);
+    s.set("flash", "welcome");
+
+    let id = store.save(&s).await.expect("save ok");
+    let loaded = store
+        .load(&id)
+        .await
+        .expect("load ok")
+        .expect("session should exist");
+    assert_eq!(loaded.get::<i64>("user_id"), Some(42));
+    assert_eq!(loaded.get::<String>("flash"), Some("welcome".into()));
+    assert!(!loaded.is_dirty(), "freshly-loaded session is clean");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn session_survives_fresh_store_on_same_dir() {
+    // The whole point of file-backed sessions is process-restart
+    // durability — a new SessionStore on the same dir must see
+    // sessions previously written by another instance.
+    let dir = unique_tmp_dir("survive");
+    let id = {
+        let store = file_store(&dir);
+        let mut s = Session::new();
+        s.set("flag", true);
+        store.save(&s).await.expect("save ok")
+    };
+
+    // Drop the first store + cache, build a brand-new pair.
+    let store2 = file_store(&dir);
+    let loaded = store2
+        .load(&id)
+        .await
+        .expect("load ok")
+        .expect("session should survive into the second store");
+    assert_eq!(loaded.get::<bool>("flag"), Some(true));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn destroy_removes_session_from_disk() {
+    let dir = unique_tmp_dir("destroy");
+    let store = file_store(&dir);
+
+    let mut s = Session::new();
+    s.set("k", "v");
+    let id = store.save(&s).await.expect("save ok");
+    assert!(store.load(&id).await.unwrap().is_some());
+    store.destroy(&id).await.expect("destroy ok");
+    assert!(
+        store.load(&id).await.unwrap().is_none(),
+        "destroyed session should be gone"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn unknown_id_loads_as_none() {
+    let dir = unique_tmp_dir("missing");
+    let store = file_store(&dir);
+    let loaded = store
+        .load("does-not-exist-id")
+        .await
+        .expect("load ok — missing returns Ok(None)");
+    assert!(loaded.is_none());
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -382,12 +382,12 @@ Summary: **14 SHIPPED / 4 PARTIAL / 4 MISSING / 1 N/A**.
 | Signed-cookie session | [signed cookies](https://docs.djangoproject.com/en/6.0/topics/http/sessions/#using-cookie-based-sessions) | SHIPPED | `session::SessionSecret` HMAC-SHA256 signed cookie (v0.40 admin) | |
 | Cache-backed session | [cache backend](https://docs.djangoproject.com/en/6.0/topics/http/sessions/#using-cache-sessions) | SHIPPED | Server-side opaque-id sessions via `Cache` backend (v0.24+) | |
 | Database-backed session | [database backend](https://docs.djangoproject.com/en/6.0/topics/http/sessions/#using-database-backed-sessions) | SHIPPED | `sessions::SessionStore` (`sessions.rs:130`) wraps the `Cache` trait; `PgCache` backend persists session blobs in a database table, matching Django's `db_session` semantics. Closes #393. | |
-| File-backed session | [file backend](https://docs.djangoproject.com/en/6.0/topics/http/sessions/#using-file-based-sessions) | MISSING | n/a (#394) | Niche. |
+| File-backed session | [file backend](https://docs.djangoproject.com/en/6.0/topics/http/sessions/#using-file-based-sessions) | SHIPPED | `SessionStore::new(Arc::new(FileCache::new(dir)))` composes the file-system cache (#408) into a session backend — process-restart-durable, zero new code. Regression test: `tests/file_backed_sessions.rs`. | |
 | Cached-DB hybrid | [cached_db backend](https://docs.djangoproject.com/en/6.0/topics/http/sessions/#using-cached-database-sessions) | SHIPPED | Cache backend can wrap any storage | |
 | Session expiry / `SESSION_COOKIE_AGE` | (cookie options) | SHIPPED | Configurable TTL per backend | |
 | Session middleware (autoinstall) | (auto in MIDDLEWARE) | SHIPPED | `Cli::tenancy()` and `Admin::Builder` auto-attach | |
 
-Summary: **4 / 1 / 1 / 0**.
+Summary: **7 / 0 / 0 / 0**.
 
 ---
 


### PR DESCRIPTION
## Summary
- Pins file-system session storage as a regression test. No new code is needed: `SessionStore` already accepts any `Cache` backend, and #408 shipped `cache::FileCache`, so the composition `SessionStore::new(Arc::new(FileCache::new(dir)))` is the Django \`file\` session backend equivalent today.
- Four sqlite-litmus live tests prove the value: save→load round trip through disk, session survives a fresh `SessionStore` on the same dir (process-restart durability — the whole point of file-backed), `destroy()` removes from disk, unknown id reads as `None`.

## Closes
#394

## Test plan
- [x] `cargo test --no-default-features --features sqlite,tenancy,cache,sessions --test file_backed_sessions` — 4 tests pass.
- [x] Litmus: `cargo check --no-default-features --features sqlite,tenancy` clean.
- [x] Audit row #394 flipped MISSING → SHIPPED; category 12 summary updated to 7/0/0/0.
- [x] CI line added under `sqlite_litmus`.