### PR TITLE
feat(template_views): TemplateView regression test (closes #377)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test factories
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,config,email --test file_email_backend
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,cache,sessions --test file_backed_sessions
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,template_views --test template_view
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/tests/template_view.rs
+++ b/crates/rustango/tests/template_view.rs
@@ -1,0 +1,88 @@
+//! Django-parity #377 — `TemplateView` class-based view.
+//!
+//! Verifies `template_views::TemplateView` renders a Tera template
+//! with caller-supplied context and mounts as an axum router on the
+//! configured prefix.
+
+#![cfg(all(feature = "sqlite", feature = "template_views"))]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use rustango::template_views::TemplateView;
+use serde_json::json;
+use tera::Tera;
+use tower::ServiceExt;
+
+fn build_tera() -> Arc<Tera> {
+    let mut tera = Tera::default();
+    tera.add_raw_template(
+        "tv_hello.html",
+        "<h1>Hello, {{ name }}!</h1><p>{{ msg }}</p>",
+    )
+    .expect("add template");
+    Arc::new(tera)
+}
+
+#[tokio::test]
+async fn template_view_renders_context_value() {
+    let tera = build_tera();
+    let app = TemplateView::new("tv_hello.html")
+        .context_value("name", "Alice")
+        .context_value("msg", "Welcome.")
+        .router("/hello", tera);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/hello")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let body = std::str::from_utf8(&body_bytes).unwrap();
+    assert!(body.contains("Hello, Alice!"), "missing greeting: {body}");
+    assert!(body.contains("Welcome."), "missing msg: {body}");
+}
+
+#[tokio::test]
+async fn template_view_accepts_json_object_context() {
+    let tera = build_tera();
+    let app = TemplateView::new("tv_hello.html")
+        .context(json!({ "name": "Bob", "msg": "from JSON" }))
+        .router("/hi", tera);
+
+    let resp = app
+        .oneshot(Request::builder().uri("/hi").body(Body::empty()).unwrap())
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let body = std::str::from_utf8(&body_bytes).unwrap();
+    assert!(body.contains("Hello, Bob!"));
+    assert!(body.contains("from JSON"));
+}
+
+#[tokio::test]
+async fn template_view_later_context_value_wins() {
+    let tera = build_tera();
+    let app = TemplateView::new("tv_hello.html")
+        .context_value("name", "first")
+        .context_value("msg", "ignored")
+        .context_value("name", "winner")
+        .router("/win", tera);
+
+    let resp = app
+        .oneshot(Request::builder().uri("/win").body(Body::empty()).unwrap())
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let body = std::str::from_utf8(&body_bytes).unwrap();
+    assert!(body.contains("Hello, winner!"));
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -288,7 +288,7 @@ Summary: **8 SHIPPED / 3 PARTIAL / 4 MISSING / 0 N/A**.
 | Django CBV | Doc | Status | rustango | Notes |
 |---|---|---|---|---|
 | `View` (base) | [base View](https://docs.djangoproject.com/en/6.0/ref/class-based-views/base/#view) | N/A | axum handlers play the role | |
-| `TemplateView` | [TemplateView](https://docs.djangoproject.com/en/6.0/ref/class-based-views/base/#templateview) | PARTIAL | `shortcuts::render(template, ctx)` (#377) | No view builder — handler renders directly. |
+| `TemplateView` | [TemplateView](https://docs.djangoproject.com/en/6.0/ref/class-based-views/base/#templateview) | SHIPPED | `template_views::TemplateView::new(template).context_value(k, v).context(json!(...)).router(prefix, tera)` — builder mounts a GET route that renders the template with the accumulated context (`template_views.rs:2924`). | |
 | `RedirectView` | [RedirectView](https://docs.djangoproject.com/en/6.0/ref/class-based-views/base/#redirectview) | SHIPPED | `redirects::*` table-driven + `shortcuts::redirect()` | |
 | `ListView` | [ListView](https://docs.djangoproject.com/en/6.0/ref/class-based-views/generic-display/#listview) | SHIPPED | `template_views::ListView::for_model(...)` (v0.21+, tri-dialect v0.38) | |
 | `DetailView` | [DetailView](https://docs.djangoproject.com/en/6.0/ref/class-based-views/generic-display/#detailview) | SHIPPED | `template_views::DetailView` | |
@@ -302,7 +302,7 @@ Summary: **8 SHIPPED / 3 PARTIAL / 4 MISSING / 0 N/A**.
 | `PermissionRequiredMixin` | [PermissionRequiredMixin](https://docs.djangoproject.com/en/6.0/topics/auth/default/#django.contrib.auth.mixins.PermissionRequiredMixin) | SHIPPED | `auth_decorators::permission_required` (PR #313) | |
 | MultipleObjectMixin / SingleObjectMixin (object-level customization) | [generic-display](https://docs.djangoproject.com/en/6.0/ref/class-based-views/generic-display/#multipleobjectmixin) | PARTIAL | `ListView::with_queryset(custom_qs)` exists (#379) | Mixin composability MISSING. |
 
-Summary: **5 SHIPPED / 2 PARTIAL / 3 MISSING / 0 N/A**.
+Summary: **11 SHIPPED / 1 PARTIAL / 1 MISSING / 1 N/A**.
 
 ---
 


### PR DESCRIPTION
## Summary
- `template_views::TemplateView` was already shipped (template_views.rs:2924) but had zero regression tests. The audit row's note (\"No view builder — handler renders directly\") was stale.
- Adds three sqlite-litmus live tests pinning behavior: `.context_value(k, v)` chained inserts, `.context(json!(...))` JSON object merge, and last-write-wins on duplicate keys.
- Audit row flipped PARTIAL → SHIPPED.

## Closes
#377

## Test plan
- [x] `cargo test --no-default-features --features sqlite,tenancy,template_views --test template_view` — 3 tests pass.
- [x] Litmus + all-features clean.
- [x] CI line added under `sqlite_litmus`.
- [x] Audit row flipped PARTIAL → SHIPPED; category 8 summary recounted to 11/1/1/1.