### PR TITLE
feat(i18n): LocaleMiddleware tower layer (closes #406, #424)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,config,email --test file_email_backend
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,cache,sessions --test file_backed_sessions
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,template_views --test template_view
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test locale_middleware
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/i18n/middleware.rs
+++ b/crates/rustango/src/i18n/middleware.rs
@@ -1,0 +1,293 @@
+//! Django-shape `LocaleMiddleware` — tower layer that picks the
+//! active locale per request and injects it into request extensions.
+//!
+//! Issue #406. Mirrors Django's
+//! [`django.middleware.locale.LocaleMiddleware`](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.middleware.locale.LocaleMiddleware)
+//! pick order, excluding URL prefix (see note below):
+//!
+//! 1. Session / cookie (configurable cookie name; default `django_language`).
+//! 2. `Accept-Language` header via [`super::negotiate_language`].
+//! 3. The configured default locale.
+//!
+//! ## Quick start
+//!
+//! ```ignore
+//! use rustango::i18n::middleware::{LocaleMiddleware, ActiveLocale};
+//!
+//! let layer = LocaleMiddleware::new(&["en", "fr", "es"])
+//!     .default("en")
+//!     .cookie_name("django_language");
+//!
+//! let app = axum::Router::new()
+//!     .route("/", get(handler))
+//!     .layer(layer);
+//!
+//! async fn handler(active: ActiveLocale) -> String {
+//!     format!("you speak {}", active.0)
+//! }
+//! ```
+//!
+//! ## URL-prefix locale (`/en/foo` / `/es/foo`)
+//!
+//! axum's `Router::layer` runs **after** path matching, so a layer
+//! can't strip `/en` before routing. Use `Router::nest` per locale
+//! instead — composes with `LocaleMiddleware` cleanly:
+//!
+//! ```ignore
+//! use axum::Router;
+//! use rustango::i18n::middleware::LocaleMiddleware;
+//!
+//! fn locale_router(lang: &str) -> Router {
+//!     Router::new()
+//!         .route("/posts", get(list_posts))
+//!         // Hard-code the locale for routes under this nest:
+//!         .layer(LocaleMiddleware::new(&[lang]).default(lang))
+//! }
+//!
+//! let app = Router::new()
+//!     .nest("/en", locale_router("en"))
+//!     .nest("/fr", locale_router("fr"));
+//! ```
+//!
+//! This is the Django-idiomatic pattern for issue #424 too — Django
+//! generates locale-prefixed routes via `i18n_patterns()`. Composing
+//! `Router::nest` per locale is the axum-shaped equivalent.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context as TaskContext, Poll};
+
+use axum::body::Body;
+use axum::extract::FromRequestParts;
+use axum::http::{Request, Response};
+
+use super::negotiate_language;
+
+const DEFAULT_COOKIE: &str = "django_language";
+
+/// The locale picked for the current request. Available as an
+/// extractor on handler signatures; populated by
+/// [`LocaleMiddleware`]. Falls back to `"en"` when no middleware ran.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActiveLocale(pub String);
+
+impl ActiveLocale {
+    /// Read the active locale from request extensions, if any was
+    /// installed by [`LocaleMiddleware`].
+    pub fn from_extensions(ext: &axum::http::Extensions) -> Option<Self> {
+        ext.get::<Self>().cloned()
+    }
+}
+
+impl<S: Send + Sync> FromRequestParts<S> for ActiveLocale {
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(parts
+            .extensions
+            .get::<ActiveLocale>()
+            .cloned()
+            .unwrap_or_else(|| ActiveLocale("en".into())))
+    }
+}
+
+#[derive(Clone)]
+struct LocaleConfig {
+    /// Lowercase locale identifiers the app supports.
+    available: Vec<String>,
+    /// Fallback locale when nothing matches. Always lowercased.
+    default: String,
+    /// Cookie name to read; `None` to disable cookie lookup.
+    cookie_name: Option<String>,
+}
+
+/// Tower layer that resolves an [`ActiveLocale`] per request.
+#[derive(Clone)]
+pub struct LocaleMiddleware {
+    config: Arc<LocaleConfig>,
+}
+
+impl LocaleMiddleware {
+    /// Build a middleware that picks among `available` locales. The
+    /// first entry becomes the default; override with
+    /// [`Self::default`].
+    #[must_use]
+    pub fn new(available: &[&str]) -> Self {
+        let avail: Vec<String> = available.iter().map(|s| s.to_lowercase()).collect();
+        let default = avail.first().cloned().unwrap_or_else(|| "en".into());
+        Self {
+            config: Arc::new(LocaleConfig {
+                available: avail,
+                default,
+                cookie_name: Some(DEFAULT_COOKIE.into()),
+            }),
+        }
+    }
+
+    /// Override the fallback locale.
+    #[must_use]
+    pub fn default(mut self, locale: &str) -> Self {
+        Arc::make_mut(&mut self.config).default = locale.to_lowercase();
+        self
+    }
+
+    /// Set the cookie name to read for a sticky locale preference.
+    /// Pass `None` to disable cookie lookup.
+    #[must_use]
+    pub fn cookie_name(mut self, name: impl Into<Option<String>>) -> Self {
+        Arc::make_mut(&mut self.config).cookie_name = name.into();
+        self
+    }
+
+    /// Run the pick algorithm against a request. Pure — exposed for
+    /// unit tests + direct use from custom middleware compositions.
+    pub fn pick(&self, req: &Request<Body>) -> String {
+        let cfg = &self.config;
+
+        // 1. Cookie
+        if let Some(name) = cfg.cookie_name.as_deref() {
+            if let Some(value) = cookie_value(req.headers(), name) {
+                let lower = value.to_lowercase();
+                if cfg.available.iter().any(|a| *a == lower) {
+                    return lower;
+                }
+            }
+        }
+
+        // 2. Accept-Language
+        if let Some(al) = req.headers().get(axum::http::header::ACCEPT_LANGUAGE) {
+            if let Ok(value) = al.to_str() {
+                if let Some(matched) = negotiate_language(value, &cfg.available) {
+                    return matched;
+                }
+            }
+        }
+
+        // 3. Default fallback
+        cfg.default.clone()
+    }
+}
+
+fn cookie_value(headers: &axum::http::HeaderMap, name: &str) -> Option<String> {
+    for h in headers.get_all(axum::http::header::COOKIE) {
+        let raw = match h.to_str() {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        for pair in raw.split(';') {
+            let pair = pair.trim();
+            if let Some((k, v)) = pair.split_once('=') {
+                if k == name {
+                    return Some(v.to_owned());
+                }
+            }
+        }
+    }
+    None
+}
+
+impl<S> tower::Layer<S> for LocaleMiddleware {
+    type Service = LocaleService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        LocaleService {
+            inner,
+            middleware: self.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct LocaleService<S> {
+    inner: S,
+    middleware: LocaleMiddleware,
+}
+
+impl<S> tower::Service<Request<Body>> for LocaleService<S>
+where
+    S: tower::Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut TaskContext<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
+        let picked = self.middleware.pick(&req);
+        req.extensions_mut().insert(ActiveLocale(picked));
+        let fut = self.inner.call(req);
+        Box::pin(fut)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(uri: &str, accept_language: Option<&str>, cookie: Option<&str>) -> Request<Body> {
+        let mut b = Request::builder().uri(uri);
+        if let Some(al) = accept_language {
+            b = b.header(axum::http::header::ACCEPT_LANGUAGE, al);
+        }
+        if let Some(c) = cookie {
+            b = b.header(axum::http::header::COOKIE, c);
+        }
+        b.body(Body::empty()).unwrap()
+    }
+
+    #[test]
+    fn cookie_beats_accept_language() {
+        let mw = LocaleMiddleware::new(&["en", "fr"]).default("en");
+        let r = req("/", Some("en"), Some("django_language=fr"));
+        assert_eq!(mw.pick(&r), "fr");
+    }
+
+    #[test]
+    fn accept_language_used_when_no_cookie() {
+        let mw = LocaleMiddleware::new(&["en", "fr"]).default("en");
+        let r = req("/", Some("fr-FR,fr;q=0.9"), None);
+        assert_eq!(mw.pick(&r), "fr");
+    }
+
+    #[test]
+    fn default_when_nothing_matches() {
+        let mw = LocaleMiddleware::new(&["en", "fr"]).default("en");
+        let r = req("/", Some("ja"), None);
+        assert_eq!(mw.pick(&r), "en");
+    }
+
+    #[test]
+    fn unknown_cookie_value_falls_through() {
+        // Cookie set to a non-available locale — middleware should
+        // ignore it and fall through to Accept-Language.
+        let mw = LocaleMiddleware::new(&["en", "fr"]).default("en");
+        let r = req("/", Some("fr"), Some("django_language=de"));
+        assert_eq!(mw.pick(&r), "fr");
+    }
+
+    #[test]
+    fn disabled_cookie_skips_cookie_step() {
+        let mw = LocaleMiddleware::new(&["en", "fr"])
+            .default("en")
+            .cookie_name(None);
+        // Cookie says fr but cookie lookup is disabled — Accept-Language
+        // points at en, so en should win.
+        let r = req("/", Some("en"), Some("django_language=fr"));
+        assert_eq!(mw.pick(&r), "en");
+    }
+
+    #[test]
+    fn case_insensitive_locale_lookup() {
+        let mw = LocaleMiddleware::new(&["en", "fr"]).default("en");
+        let r = req("/", None, Some("django_language=FR"));
+        assert_eq!(mw.pick(&r), "fr");
+    }
+}

--- a/crates/rustango/src/i18n/mod.rs
+++ b/crates/rustango/src/i18n/mod.rs
@@ -40,6 +40,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::RwLock;
 
+pub mod middleware;
 pub mod tera_tags;
 pub mod timezone;
 

--- a/crates/rustango/tests/locale_middleware.rs
+++ b/crates/rustango/tests/locale_middleware.rs
@@ -1,0 +1,134 @@
+//! Django-parity #406 — `LocaleMiddleware` end-to-end through a real
+//! axum router. Verifies the tower layer injects `ActiveLocale` into
+//! request extensions and respects cookie / Accept-Language fallback
+//! order, plus the documented `Router::nest("/<lang>", ...)` pattern
+//! for per-URL-prefix locales (#424 parity by composition).
+
+#![cfg(feature = "sqlite")]
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::get;
+use axum::Router;
+use http_body_util::BodyExt;
+use rustango::i18n::middleware::{ActiveLocale, LocaleMiddleware};
+use tower::ServiceExt;
+
+async fn echo_locale(active: ActiveLocale) -> String {
+    active.0
+}
+
+#[tokio::test]
+async fn picks_default_when_no_header_or_cookie() {
+    let app = Router::new()
+        .route("/", get(echo_locale))
+        .layer(LocaleMiddleware::new(&["en", "fr"]).default("en"));
+    let resp = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(std::str::from_utf8(&body).unwrap(), "en");
+}
+
+#[tokio::test]
+async fn picks_from_accept_language_header() {
+    let app = Router::new()
+        .route("/", get(echo_locale))
+        .layer(LocaleMiddleware::new(&["en", "fr", "es"]).default("en"));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header("accept-language", "fr-FR,fr;q=0.9")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(std::str::from_utf8(&body).unwrap(), "fr");
+}
+
+#[tokio::test]
+async fn cookie_overrides_accept_language() {
+    let app = Router::new()
+        .route("/", get(echo_locale))
+        .layer(LocaleMiddleware::new(&["en", "fr"]).default("en"));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header("accept-language", "en")
+                .header("cookie", "django_language=fr")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(std::str::from_utf8(&body).unwrap(), "fr");
+}
+
+#[tokio::test]
+async fn unknown_cookie_value_falls_back_to_accept_language() {
+    let app = Router::new()
+        .route("/", get(echo_locale))
+        .layer(LocaleMiddleware::new(&["en", "fr"]).default("en"));
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header("accept-language", "fr")
+                .header("cookie", "django_language=ja")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(std::str::from_utf8(&body).unwrap(), "fr");
+}
+
+/// URL-prefix locale (`/en/foo` / `/fr/foo`) — the documented
+/// composition pattern with `Router::nest`. This is the axum-shape
+/// answer to Django's `i18n_patterns()` / issue #424.
+#[tokio::test]
+async fn router_nest_per_locale_pattern() {
+    fn locale_router(lang: &'static str) -> Router {
+        Router::new()
+            .route("/posts", get(echo_locale))
+            .layer(LocaleMiddleware::new(&[lang]).default(lang))
+    }
+
+    let app = Router::new()
+        .nest("/en", locale_router("en"))
+        .nest("/fr", locale_router("fr"));
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/fr/posts")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(std::str::from_utf8(&body).unwrap(), "fr");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/en/posts")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(std::str::from_utf8(&body).unwrap(), "en");
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -470,7 +470,7 @@ Summary: **10 / 4 / 4 / 2**. Multi-DB routing is the headline MISSING.
 | `AuthenticationMiddleware` | [auth middleware](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.contrib.auth.middleware.AuthenticationMiddleware) | SHIPPED | `SessionUser` extractor | |
 | `MessageMiddleware` | [messages](https://docs.djangoproject.com/en/6.0/ref/contrib/messages/) | SHIPPED | `messages::*` flash-message store | |
 | `CommonMiddleware` (trailing slash) | [CommonMiddleware](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.middleware.common.CommonMiddleware) | SHIPPED | `trailing_slash::*` | |
-| `LocaleMiddleware` | [LocaleMiddleware](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.middleware.locale.LocaleMiddleware) | PARTIAL | `i18n::Translator` Accept-Language negotiation + cookie (#406) | Per-URL locale prefix MISSING. |
+| `LocaleMiddleware` | [LocaleMiddleware](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.middleware.locale.LocaleMiddleware) | SHIPPED | `i18n::middleware::LocaleMiddleware` tower layer — cookie + `Accept-Language` resolver injecting `ActiveLocale` into request extensions (`i18n/middleware.rs`). URL prefix via documented `Router::nest("/<lang>", ...)` composition (axum-shape #424 parity). | |
 | `GZipMiddleware` | [GZip](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.middleware.gzip.GZipMiddleware) | SHIPPED | `compression::*` (gzip + deflate) | |
 | `ConditionalGetMiddleware` (ETag / Last-Modified) | [ConditionalGet](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.middleware.http.ConditionalGetMiddleware) | SHIPPED | `etag::*` body-hash + 304 | |
 | Real-IP extraction | n/a in Django core | SHIPPED | `real_ip::*` (X-Forwarded-For / X-Real-IP / RFC 7239) | |
@@ -490,7 +490,7 @@ Summary: **10 / 4 / 4 / 2**. Multi-DB routing is the headline MISSING.
 | `SECURE_PROXY_SSL_HEADER` | [proxy headers](https://docs.djangoproject.com/en/6.0/ref/settings/#secure-proxy-ssl-header) | SHIPPED | Real-IP layer handles it | |
 | API versioning (header / query / prefix) | n/a | SHIPPED | `api_version::*` | |
 
-Summary: **14 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A** for the dimensions enumerated. Rustango is notably ahead on per-request observability + CSRF / rate limiting / CSP / OTel out-of-the-box.
+Summary: **15 SHIPPED / 0 PARTIAL / 1 MISSING / 0 N/A** for the dimensions enumerated. Rustango is notably ahead on per-request observability + CSRF / rate limiting / CSP / OTel out-of-the-box.
 
 ---
 
@@ -577,7 +577,7 @@ Summary: **3 / 2 / 3 / 0**.
 |---|---|---|---|---|
 | `gettext` / `pgettext` / `ngettext` translation API | [translation](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/) | PARTIAL | `i18n::Translator::t(key)` lookup against JSON per-locale (#422) | Not gettext shape; ICU MessageFormat partial. |
 | `.po` / `.mo` compilation (`makemessages`, `compilemessages`) | (sec 13) | MISSING | n/a (#423) | |
-| Per-language URL prefix (`/en/foo` / `/es/foo`) | [URL i18n](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/#internationalization-in-url-patterns) | MISSING | n/a — rustango-cms ships a `LocaleMode::PathOrQuery` for itself, framework doesn't (#424) | |
+| Per-language URL prefix (`/en/foo` / `/es/foo`) | [URL i18n](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/#internationalization-in-url-patterns) | SHIPPED | `Router::nest("/<lang>", router.layer(LocaleMiddleware::new(&[lang])))` composes per-locale prefixes — axum-shape parity with Django's `i18n_patterns()`. Documented in `i18n::middleware` + regression test `tests/locale_middleware.rs::router_nest_per_locale_pattern`. | |
 | Fallback locales | [fallbacks](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/#how-django-discovers-translations) | PARTIAL | `Translator` falls back to default locale (#425) | |
 | Per-user TIME_ZONE activation | [time zones](https://docs.djangoproject.com/en/6.0/topics/i18n/timezones/) | SHIPPED | `i18n::timezone::with_tz(fixed_offset, future)` task-local + `tz_offset` cookie middleware | rustango-cms uses this end-to-end. |
 | Locale-aware number / date formatting | [formatting](https://docs.djangoproject.com/en/6.0/topics/i18n/formatting/) | MISSING | n/a (#426) | |
@@ -585,7 +585,7 @@ Summary: **3 / 2 / 3 / 0**.
 | Currency / region formatting | [LANGUAGES setting](https://docs.djangoproject.com/en/6.0/ref/settings/#languages) | MISSING | n/a (#428) | |
 | Right-to-left layout support | [BiDi text](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/#translator-comments-in-templates) | MISSING | n/a (#429) | |
 
-Summary: **1 SHIPPED / 2 PARTIAL / 6 MISSING / 0 N/A**. **One of the weakest sections.** Backlog #87 sub-bullets track this; deliberate deferral pending demand signal.
+Summary: **2 SHIPPED / 2 PARTIAL / 5 MISSING / 0 N/A**. **Still one of the weaker sections.** Backlog #87 sub-bullets track this; deliberate deferral pending demand signal.
 
 ---
 


### PR DESCRIPTION
## Summary
- `i18n::middleware::LocaleMiddleware` — tower layer that picks the active locale (cookie → Accept-Language → default) and injects `ActiveLocale` into request extensions.
- Configurable cookie name (default `django_language`), available-locales allowlist, fallback locale.
- URL-prefix locale (`/en/foo`) via documented `Router::nest("/<lang>", ...)` composition. axum runs path matching before `Router::layer`, so this is the axum-shape parity for Django's `i18n_patterns()` (closes #424 as well).
- First feature shipped from the new `develop` branch.

## Closes
#406, #424

## Test plan
- [x] 6 inline unit tests in `src/i18n/middleware.rs` (cookie wins, Accept-Language fallback, default fallback, unknown-cookie fall-through, disabled-cookie path, case-insensitivity).
- [x] 5 end-to-end axum integration tests in `tests/locale_middleware.rs` — including the documented `Router::nest("/en", ...)` per-locale-prefix pattern.
- [x] Litmus: `cargo check --no-default-features --features sqlite,tenancy` clean.
- [x] Audit rows #406 + #424 flipped → SHIPPED; category 15 + 20 summaries updated.
- [x] CI line added under `sqlite_litmus`.