### PR TITLE
feat(i18n): explicit fallback locale chain (closes #425)

### DIFF
--- a/crates/rustango/src/i18n/mod.rs
+++ b/crates/rustango/src/i18n/mod.rs
@@ -89,6 +89,10 @@ pub enum I18nError {
 /// Translation backend — keyed by `(locale, key)`.
 pub struct Translator {
     default_locale: Locale,
+    /// Optional explicit fallback chain — checked AFTER the
+    /// requested locale + its base language, BEFORE `default_locale`.
+    /// Django parity #425. Lowercased on insert.
+    fallback_chain: Vec<Locale>,
     catalogs: RwLock<HashMap<Locale, HashMap<String, String>>>,
 }
 
@@ -98,8 +102,42 @@ impl Translator {
     pub fn new(default_locale: Locale) -> Self {
         Self {
             default_locale,
+            fallback_chain: Vec::new(),
             catalogs: RwLock::new(HashMap::new()),
         }
+    }
+
+    /// Set an explicit fallback chain (#425, Django parity). When
+    /// `translate(locale, key, ...)` doesn't find a key in `locale`
+    /// or its base language, the lookup walks `chain` in order
+    /// before falling through to the default locale.
+    ///
+    /// ```ignore
+    /// // Spanish missing? try Portuguese, then English (default).
+    /// let t = Translator::new(Locale::new("en"))
+    ///     .with_fallback_chain(&["pt"]);
+    /// ```
+    ///
+    /// Duplicate entries and entries equal to `default_locale` are
+    /// silently dropped (the default-locale check is already at the
+    /// end of the chain).
+    #[must_use]
+    pub fn with_fallback_chain(mut self, chain: &[&str]) -> Self {
+        let mut seen: std::collections::HashSet<Locale> = std::collections::HashSet::new();
+        seen.insert(self.default_locale.clone());
+        self.fallback_chain = chain
+            .iter()
+            .map(|s| Locale::new(*s))
+            .filter(|loc| seen.insert(loc.clone()))
+            .collect();
+        self
+    }
+
+    /// Current explicit fallback chain (without the implicit
+    /// default-locale terminus). Useful for diagnostics.
+    #[must_use]
+    pub fn fallback_chain(&self) -> &[Locale] {
+        &self.fallback_chain
     }
 
     /// Add a translation catalog for `locale`. Replaces any existing
@@ -121,8 +159,9 @@ impl Translator {
             .insert(locale, catalog);
     }
 
-    /// Look up `key` in `locale`'s catalog, falling back to the default
-    /// locale, and finally to `key` itself if nothing matches.
+    /// Look up `key` in `locale`'s catalog, walking the fallback
+    /// chain in order: exact locale → base language → explicit
+    /// `fallback_chain` (#425) → default locale → `key` itself.
     ///
     /// `params` substitutes `{name}` placeholders in the result.
     #[must_use]
@@ -130,16 +169,31 @@ impl Translator {
         let cats = self.catalogs.read().expect("translator poisoned");
         let req = Locale::new(locale);
 
-        // Try exact locale, then base language, then default
-        let template = cats
+        // Walk the lookup chain in priority order.
+        let mut template: Option<String> = cats
             .get(&req)
             .and_then(|c| c.get(key))
             .or_else(|| {
                 cats.get(&Locale::new(req.base_language()))
                     .and_then(|c| c.get(key))
             })
-            .or_else(|| cats.get(&self.default_locale).and_then(|c| c.get(key)))
-            .cloned()
+            .cloned();
+
+        if template.is_none() {
+            for fb in &self.fallback_chain {
+                if let Some(v) = cats.get(fb).and_then(|c| c.get(key)) {
+                    template = Some(v.clone());
+                    break;
+                }
+            }
+        }
+
+        let template = template
+            .or_else(|| {
+                cats.get(&self.default_locale)
+                    .and_then(|c| c.get(key))
+                    .cloned()
+            })
             .unwrap_or_else(|| key.to_owned());
 
         substitute(&template, params)
@@ -327,6 +381,57 @@ mod tests {
         assert!(t.has_locale("fr"));
         assert!(t.has_locale("en-US"));
         assert!(!t.has_locale("ja"));
+    }
+
+    /// Issue #425 — explicit fallback chain. Build a translator where
+    /// only Spanish is missing the key; it should walk pt → en (default).
+    #[test]
+    fn fallback_chain_walks_in_order() {
+        let mut es: HashMap<String, String> = HashMap::new();
+        es.insert("welcome".into(), "Bienvenido".into());
+        // No `hello` in `es`.
+        let mut pt: HashMap<String, String> = HashMap::new();
+        pt.insert("hello".into(), "Olá".into());
+        let mut en: HashMap<String, String> = HashMap::new();
+        en.insert("hello".into(), "Hello".into());
+
+        let t = Translator::new(Locale::new("en"))
+            .with_fallback_chain(&["pt"])
+            .add_locale(Locale::new("es"), es)
+            .add_locale(Locale::new("pt"), pt)
+            .add_locale(Locale::new("en"), en);
+
+        // `welcome` exists in `es` — direct hit.
+        assert_eq!(t.translate("es", "welcome", &[]), "Bienvenido");
+        // `hello` is missing in `es`; chain says try `pt` next.
+        assert_eq!(t.translate("es", "hello", &[]), "Olá");
+    }
+
+    /// Issue #425 — default locale is still the last terminus when
+    /// nothing in the chain has the key.
+    #[test]
+    fn fallback_chain_then_default() {
+        let mut en: HashMap<String, String> = HashMap::new();
+        en.insert("hello".into(), "Hello".into());
+        let pt: HashMap<String, String> = HashMap::new();
+
+        let t = Translator::new(Locale::new("en"))
+            .with_fallback_chain(&["pt"])
+            .add_locale(Locale::new("pt"), pt)
+            .add_locale(Locale::new("en"), en);
+
+        // `es` not in catalogs, chain entry `pt` doesn't have the key,
+        // default `en` does.
+        assert_eq!(t.translate("es", "hello", &[]), "Hello");
+    }
+
+    /// Issue #425 — chain accessor returns what was set, sans duplicates
+    /// and sans the default-locale entry.
+    #[test]
+    fn fallback_chain_accessor_deduplicates() {
+        let t = Translator::new(Locale::new("en")).with_fallback_chain(&["pt", "pt", "en", "es"]);
+        let chain: Vec<&str> = t.fallback_chain().iter().map(Locale::as_str).collect();
+        assert_eq!(chain, vec!["pt", "es"]);
     }
 
     #[test]

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -578,14 +578,14 @@ Summary: **3 / 2 / 3 / 0**.
 | `gettext` / `pgettext` / `ngettext` translation API | [translation](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/) | PARTIAL | `i18n::Translator::t(key)` lookup against JSON per-locale (#422) | Not gettext shape; ICU MessageFormat partial. |
 | `.po` / `.mo` compilation (`makemessages`, `compilemessages`) | (sec 13) | MISSING | n/a (#423) | |
 | Per-language URL prefix (`/en/foo` / `/es/foo`) | [URL i18n](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/#internationalization-in-url-patterns) | SHIPPED | `Router::nest("/<lang>", router.layer(LocaleMiddleware::new(&[lang])))` composes per-locale prefixes — axum-shape parity with Django's `i18n_patterns()`. Documented in `i18n::middleware` + regression test `tests/locale_middleware.rs::router_nest_per_locale_pattern`. | |
-| Fallback locales | [fallbacks](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/#how-django-discovers-translations) | PARTIAL | `Translator` falls back to default locale (#425) | |
+| Fallback locales | [fallbacks](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/#how-django-discovers-translations) | SHIPPED | `Translator::new(...).with_fallback_chain(&["pt", "es"])` walks exact → base lang → explicit chain → default. `Translator::fallback_chain()` returns the configured chain. `i18n/mod.rs`. | |
 | Per-user TIME_ZONE activation | [time zones](https://docs.djangoproject.com/en/6.0/topics/i18n/timezones/) | SHIPPED | `i18n::timezone::with_tz(fixed_offset, future)` task-local + `tz_offset` cookie middleware | rustango-cms uses this end-to-end. |
 | Locale-aware number / date formatting | [formatting](https://docs.djangoproject.com/en/6.0/topics/i18n/formatting/) | MISSING | n/a (#426) | |
 | `{% trans %}` / `{% blocktrans %}` template tags | [template translation](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/#internationalization-in-template-code) | PARTIAL | `i18n::tera_tags::register(&mut tera, translator)` ships both function + filter (`{{ translate(key="welcome", locale=LANG, name=user.name) }}` and `{{ "welcome" \| translate(locale=LANG) }}`) — framework-side IS there ([`i18n/tera_tags.rs`](crates/rustango/src/i18n/tera_tags.rs)). Block-tag `{% blocktrans %}…{% endblocktrans %}` and `{% language 'fr' %}` override blocks aren't ported (Tera grammar has no custom-block-tag extension). Closes #427's "framework-side missing" claim — block-tag follow-up tracked separately. |
 | Currency / region formatting | [LANGUAGES setting](https://docs.djangoproject.com/en/6.0/ref/settings/#languages) | MISSING | n/a (#428) | |
 | Right-to-left layout support | [BiDi text](https://docs.djangoproject.com/en/6.0/topics/i18n/translation/#translator-comments-in-templates) | MISSING | n/a (#429) | |
 
-Summary: **2 SHIPPED / 2 PARTIAL / 5 MISSING / 0 N/A**. **Still one of the weaker sections.** Backlog #87 sub-bullets track this; deliberate deferral pending demand signal.
+Summary: **3 SHIPPED / 1 PARTIAL / 5 MISSING / 0 N/A**. **Still one of the weaker sections.** Backlog #87 sub-bullets track this; deliberate deferral pending demand signal.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `Translator::with_fallback_chain(&[\"pt\", \"es\"])` so apps can declare an ordered fallback path between the requested locale (and its base language) and the default-locale terminus. Mirrors Django's `LANGUAGE_CODE` + `LANGUAGES` fallback semantics.
- Adds `Translator::fallback_chain()` accessor for diagnostics.
- Lookup order: exact → base language → explicit chain → default → key itself.
- Duplicates and entries equal to default_locale are silently dropped.

## Closes
#425

## Test plan
- [x] 3 new inline tests cover order-walking, default-locale terminus, and dedup behavior.
- [x] Existing 12 i18n inline tests still pass.
- [x] Litmus clean.
- [x] Audit row #425 flipped PARTIAL → SHIPPED; category 20 summary updated.