### PR TITLE
fix(notifications): gate database channel behind postgres feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,cache,sessions --test file_backed_sessions
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,template_views --test template_view
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test locale_middleware
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,notifications,http-client --test slack_notification
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/notifications/mod.rs
+++ b/crates/rustango/src/notifications/mod.rs
@@ -161,10 +161,18 @@ pub type BroadcastFn = Arc<
 ///
 /// Build once at startup and pass by reference to every `notify()` call.
 /// Channels you don't configure get silently skipped.
+///
+/// The `database` channel requires the `postgres` feature — it currently
+/// emits PG-typed JSONB INSERTs (the column is `JSONB`, placeholders are
+/// `$1, $2, $3`). Tri-dialect support is on the roadmap; until then,
+/// non-PG builds get a struct without the database channel + a
+/// `with_database` method that doesn't exist.
 #[derive(Default, Clone)]
 pub struct NotificationContext {
     mailer: Option<BoxedMailer>,
+    #[cfg(feature = "postgres")]
     database_pool: Option<crate::sql::sqlx::PgPool>,
+    #[cfg(feature = "postgres")]
     database_table: Option<String>,
     broadcast: Option<BroadcastFn>,
 }
@@ -184,6 +192,9 @@ impl NotificationContext {
     /// Configure the database channel — INSERTs into `table` with columns:
     /// `(notifiable_id BIGINT, type TEXT, data JSONB, created_at TIMESTAMPTZ DEFAULT NOW())`.
     /// Create the table separately via your migrations.
+    ///
+    /// Requires the `postgres` feature.
+    #[cfg(feature = "postgres")]
     #[must_use]
     pub fn with_database(
         mut self,
@@ -280,7 +291,8 @@ pub async fn notify<N: Notifiable, T: Notification<N>>(
         };
     }
 
-    // Database
+    // Database (postgres-only for now — see NotificationContext docs).
+    #[cfg(feature = "postgres")]
     if let Some(payload) = &dispatch.database {
         result.database = match (
             &ctx.database_pool,
@@ -303,6 +315,11 @@ pub async fn notify<N: Notifiable, T: Notification<N>>(
             }
             (_, _, None) => ChannelOutcome::Skipped, // recipient opted out via notification_id
         };
+    }
+    #[cfg(not(feature = "postgres"))]
+    if dispatch.database.is_some() {
+        result.database =
+            ChannelOutcome::Failed("database channel requires the `postgres` feature".into());
     }
 
     // Log
@@ -339,6 +356,7 @@ pub async fn notify_many<N: Notifiable, T: Notification<N>>(
     out
 }
 
+#[cfg(feature = "postgres")]
 async fn insert_database_notification(
     pool: &crate::sql::sqlx::PgPool,
     table: &str,
@@ -360,6 +378,7 @@ async fn insert_database_notification(
 }
 
 /// Reject table names with characters that could break the quoted form.
+#[cfg(feature = "postgres")]
 fn validate_table_name(name: &str) -> Result<(), String> {
     if name.is_empty() {
         return Err("table name is empty".into());

--- a/crates/rustango/tests/slack_notification.rs
+++ b/crates/rustango/tests/slack_notification.rs
@@ -5,11 +5,7 @@
 //! NotificationContext, fires a broadcast, and inspects the captured
 //! POST body to verify the Slack envelope shape.
 
-#![cfg(all(
-    feature = "notifications",
-    feature = "http-client",
-    feature = "postgres"
-))]
+#![cfg(all(feature = "notifications", feature = "http-client"))]
 
 use std::sync::Arc;
 


### PR DESCRIPTION
## Summary
- The \`notifications\` module's database channel uses \`crate::sql::sqlx::PgPool\` unconditionally — \`cargo build --no-default-features --features sqlite,tenancy,notifications\` failed with \`cannot find type PgPool\`.
- Gates the database channel (struct fields, \`with_database\` builder, INSERT helper, table-name validator) behind \`feature = \"postgres\"\`.
- Non-PG builds get a working \`NotificationContext\` without the database channel; a dispatch that sets \`database: Some(...)\` in a non-PG build records a \`ChannelOutcome::Failed\` explaining the feature requirement.
- Slack test no longer needs \`postgres\` — moved to \`sqlite_litmus\`.

## Test plan
- [x] \`cargo check --no-default-features --features sqlite,tenancy,notifications\` clean (was failing pre-fix).
- [x] \`cargo check --all-features\` clean.
- [x] Slack live tests pass on sqlite_litmus feature set.