### PR TITLE
feat(showcase): blog app — JSON CRUD (Phase 2)

### DIFF
--- a/examples/showcase/Cargo.lock
+++ b/examples/showcase/Cargo.lock
@@ -1879,9 +1879,12 @@ name = "rustango-showcase"
 version = "0.0.0"
 dependencies = [
  "axum",
+ "chrono",
  "dotenvy",
  "rustango",
+ "serde",
  "serde_json",
+ "sqlx",
  "tokio",
  "tracing",
 ]

--- a/examples/showcase/Cargo.toml
+++ b/examples/showcase/Cargo.toml
@@ -46,4 +46,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signa
 axum  = { version = "0.8", default-features = false, features = ["tokio", "http1", "json", "form", "query"] }
 tracing = "0.1"
 dotenvy = "0.15"
+serde      = { version = "1", features = ["derive"] }
 serde_json = "1"
+chrono     = { version = "0.4", default-features = false, features = ["serde", "clock"] }
+sqlx       = { version = "0.8", default-features = false, features = ["runtime-tokio", "chrono", "uuid", "json"] }

--- a/examples/showcase/e2e/tests/blog/crud.spec.ts
+++ b/examples/showcase/e2e/tests/blog/crud.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Phase 2 — blog CRUD against the JSON API. Exercises:
+ *
+ * - `#[derive(Model)]` schema → `manage makemigrations` round-trip
+ * - QuerySet `.order_by()` + `.filter_op()` + `.fetch_pool()`
+ * - Macro-emitted `Post::insert_pool(&Pool)` round-trip
+ * - `Auto<i64>` primary key + `auto_now_add` timestamp
+ * - `Json<Vec<T>>` / `Json<T>` axum response shape
+ *
+ * The suite shares one server across tests so order matters; each
+ * test creates a post it owns and asserts only against that.
+ */
+
+test.describe('blog API', () => {
+  test('list is initially empty (smoke against fresh DB)', async ({ request }) => {
+    const resp = await request.get('/blog/posts');
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body)).toBe(true);
+  });
+
+  test('POST creates a post + GET retrieves it by id', async ({ request }) => {
+    const draft = {
+      title: 'Hello, rustango',
+      body: 'Phase 2 covers the ORM round-trip.',
+      published: true,
+    };
+
+    const createResp = await request.post('/blog/posts', { data: draft });
+    expect(createResp.status()).toBe(201);
+    const created = await createResp.json();
+
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.title).toBe(draft.title);
+    expect(created.body).toBe(draft.body);
+    expect(created.published).toBe(true);
+    // auto_now_add should produce an RFC-3339 timestamp.
+    expect(created.created_at).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    );
+
+    const fetchResp = await request.get(`/blog/posts/${created.id}`);
+    expect(fetchResp.status()).toBe(200);
+    const fetched = await fetchResp.json();
+    expect(fetched).toEqual(created);
+  });
+
+  test('list reflects newly created posts (order_by id asc)', async ({ request }) => {
+    // POST two more, then list.
+    const t1 = `Title-A-${Date.now()}`;
+    const t2 = `Title-B-${Date.now()}`;
+    await request.post('/blog/posts', { data: { title: t1 } });
+    await request.post('/blog/posts', { data: { title: t2 } });
+
+    const resp = await request.get('/blog/posts');
+    const list = await resp.json();
+    const titles = list.map((p: { title: string }) => p.title);
+    expect(titles).toContain(t1);
+    expect(titles).toContain(t2);
+
+    // Confirm ids are ascending — the route uses .order_by("id", true).
+    const ids = list.map((p: { id: number }) => p.id);
+    const sorted = [...ids].sort((a, b) => a - b);
+    expect(ids).toEqual(sorted);
+  });
+
+  test('GET unknown id returns 404', async ({ request }) => {
+    const resp = await request.get('/blog/posts/99999999');
+    expect(resp.status()).toBe(404);
+  });
+
+  test('body is nullable', async ({ request }) => {
+    const resp = await request.post('/blog/posts', {
+      data: { title: 'No-body post' },
+    });
+    const post = await resp.json();
+    expect(post.body).toBeNull();
+    expect(post.published).toBe(false); // default
+  });
+});

--- a/examples/showcase/migrations/0002_blog.json
+++ b/examples/showcase/migrations/0002_blog.json
@@ -1,0 +1,155 @@
+{
+  "name": "0002_blog",
+  "created_at": "2026-05-23T03:02:22.472797+00:00",
+  "prev": "0001_initial",
+  "atomic": true,
+  "snapshot": {
+    "tables": [
+      {
+        "name": "rustango_admin_users",
+        "model": "AdminUser",
+        "fields": [
+          {
+            "name": "active",
+            "column": "active",
+            "ty": "bool",
+            "nullable": false,
+            "primary_key": false,
+            "default": "true"
+          },
+          {
+            "name": "created_at",
+            "column": "created_at",
+            "ty": "datetime",
+            "nullable": false,
+            "primary_key": false
+          },
+          {
+            "name": "id",
+            "column": "id",
+            "ty": "i64",
+            "nullable": false,
+            "primary_key": true,
+            "auto": true
+          },
+          {
+            "name": "is_superuser",
+            "column": "is_superuser",
+            "ty": "bool",
+            "nullable": false,
+            "primary_key": false,
+            "default": "false"
+          },
+          {
+            "name": "password_hash",
+            "column": "password_hash",
+            "ty": "string",
+            "nullable": false,
+            "primary_key": false,
+            "max_length": 200
+          },
+          {
+            "name": "username",
+            "column": "username",
+            "ty": "string",
+            "nullable": false,
+            "primary_key": false,
+            "max_length": 150,
+            "unique": true
+          }
+        ]
+      },
+      {
+        "name": "rustango_content_types",
+        "model": "ContentType",
+        "fields": [
+          {
+            "name": "app_label",
+            "column": "app_label",
+            "ty": "string",
+            "nullable": false,
+            "primary_key": false,
+            "max_length": 100
+          },
+          {
+            "name": "id",
+            "column": "id",
+            "ty": "i64",
+            "nullable": false,
+            "primary_key": true,
+            "auto": true
+          },
+          {
+            "name": "model_name",
+            "column": "model_name",
+            "ty": "string",
+            "nullable": false,
+            "primary_key": false,
+            "max_length": 100
+          },
+          {
+            "name": "table",
+            "column": "table",
+            "ty": "string",
+            "nullable": false,
+            "primary_key": false,
+            "max_length": 100
+          }
+        ]
+      },
+      {
+        "name": "showcase_blog_post",
+        "model": "Post",
+        "fields": [
+          {
+            "name": "body",
+            "column": "body",
+            "ty": "string",
+            "nullable": true,
+            "primary_key": false
+          },
+          {
+            "name": "created_at",
+            "column": "created_at",
+            "ty": "datetime",
+            "nullable": false,
+            "primary_key": false,
+            "default": "now()",
+            "auto": true
+          },
+          {
+            "name": "id",
+            "column": "id",
+            "ty": "i64",
+            "nullable": false,
+            "primary_key": true,
+            "auto": true
+          },
+          {
+            "name": "published",
+            "column": "published",
+            "ty": "bool",
+            "nullable": false,
+            "primary_key": false,
+            "default": "false"
+          },
+          {
+            "name": "title",
+            "column": "title",
+            "ty": "string",
+            "nullable": false,
+            "primary_key": false,
+            "max_length": 200
+          }
+        ]
+      }
+    ]
+  },
+  "forward": [
+    {
+      "schema": {
+        "CreateTable": "showcase_blog_post"
+      }
+    }
+  ]
+}

--- a/examples/showcase/src/apps/blog/mod.rs
+++ b/examples/showcase/src/apps/blog/mod.rs
@@ -1,0 +1,5 @@
+//! `blog` sub-app — exercises the ORM (`#[derive(Model)]`, QuerySet,
+//! Auto<T>, auto_now_add) end-to-end. Phase 2 of the E2E plan.
+
+pub mod models;
+pub mod urls;

--- a/examples/showcase/src/apps/blog/models.rs
+++ b/examples/showcase/src/apps/blog/models.rs
@@ -1,0 +1,31 @@
+//! Blog domain models. Each attribute exercises one rustango model
+//! feature so the E2E playwright suite can assert it round-trips
+//! through the API.
+
+use rustango::sql::Auto;
+use rustango::Model;
+
+/// One blog post — minimal model exercising `Auto<i64>` primary key,
+/// `max_length` (DDL VARCHAR), `default` (DDL DEFAULT clause), and
+/// `auto_now_add` (DB-side `NOW()`-like default).
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "showcase_blog_post", display = "title")]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+
+    #[rustango(max_length = 200)]
+    pub title: String,
+
+    /// Long-form body. `Option<String>` → nullable TEXT column.
+    pub body: Option<String>,
+
+    /// Visibility flag — defaults to `false` (drafts).
+    #[rustango(default = "false")]
+    pub published: bool,
+
+    /// Set by the DB on insert. `Auto<DateTime<Utc>>` with
+    /// `auto_now_add` round-trips through every backend.
+    #[rustango(auto_now_add)]
+    pub created_at: Auto<chrono::DateTime<chrono::Utc>>,
+}

--- a/examples/showcase/src/apps/blog/urls.rs
+++ b/examples/showcase/src/apps/blog/urls.rs
@@ -1,0 +1,127 @@
+//! HTTP routes for the blog app — JSON-only API surface so the
+//! playwright suite can drive it with `request.get/post`.
+//!
+//! The non-tenancy `runserver` attaches the DB handle as an
+//! `axum::Extension` whose concrete type depends on the active
+//! backend feature: `PgPool` when `postgres` is on, `Pool` otherwise.
+//! [`db_pool`] hides that fork so the handlers work the same against
+//! every backend.
+
+use axum::extract::{Extension, Path};
+use axum::http::StatusCode;
+use axum::response::Json;
+use axum::routing::get;
+use axum::Router;
+use rustango::core::Op;
+use rustango::sql::{Auto, FetcherPool as _, Pool};
+
+use super::models::Post;
+
+/// Backend-attached pool type. The framework's runserver picks one
+/// or the other based on whether `postgres` is in the feature set.
+#[cfg(feature = "postgres")]
+type AttachedPool = sqlx::PgPool;
+#[cfg(not(feature = "postgres"))]
+type AttachedPool = Pool;
+
+/// Convert the attached extension into the tri-dialect [`Pool`] enum
+/// used by every `_pool` family function.
+fn into_pool(p: &AttachedPool) -> Pool {
+    #[cfg(feature = "postgres")]
+    {
+        Pool::from(p.clone())
+    }
+    #[cfg(not(feature = "postgres"))]
+    {
+        p.clone()
+    }
+}
+
+#[must_use]
+pub fn api() -> Router {
+    Router::new()
+        .route("/blog/posts", get(list_posts).post(create_post))
+        .route("/blog/posts/{id}", get(retrieve_post))
+}
+
+#[derive(serde::Serialize)]
+struct PostOut {
+    id: i64,
+    title: String,
+    body: Option<String>,
+    published: bool,
+    created_at: String,
+}
+
+impl From<Post> for PostOut {
+    fn from(p: Post) -> Self {
+        Self {
+            id: match p.id {
+                Auto::Set(n) => n,
+                Auto::Unset => 0,
+            },
+            title: p.title,
+            body: p.body,
+            published: p.published,
+            created_at: match p.created_at {
+                Auto::Set(t) => t.to_rfc3339(),
+                Auto::Unset => String::new(),
+            },
+        }
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct PostIn {
+    title: String,
+    body: Option<String>,
+    #[serde(default)]
+    published: bool,
+}
+
+async fn list_posts(
+    Extension(pool): Extension<AttachedPool>,
+) -> Result<Json<Vec<PostOut>>, (StatusCode, String)> {
+    let pool = into_pool(&pool);
+    let posts: Vec<Post> = Post::objects()
+        .order_by(&[("id", false)]) // ASC — natural list order
+        .fetch_pool(&pool)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(posts.into_iter().map(PostOut::from).collect()))
+}
+
+async fn retrieve_post(
+    Extension(pool): Extension<AttachedPool>,
+    Path(id): Path<i64>,
+) -> Result<Json<PostOut>, (StatusCode, String)> {
+    let pool = into_pool(&pool);
+    let mut rows: Vec<Post> = Post::objects()
+        .filter_op("id", Op::Eq, id)
+        .fetch_pool(&pool)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if let Some(p) = rows.pop() {
+        Ok(Json(PostOut::from(p)))
+    } else {
+        Err((StatusCode::NOT_FOUND, format!("post {id} not found")))
+    }
+}
+
+async fn create_post(
+    Extension(pool): Extension<AttachedPool>,
+    Json(input): Json<PostIn>,
+) -> Result<(StatusCode, Json<PostOut>), (StatusCode, String)> {
+    let pool = into_pool(&pool);
+    let mut p = Post {
+        id: Auto::Unset,
+        title: input.title,
+        body: input.body,
+        published: input.published,
+        created_at: Auto::Unset,
+    };
+    p.insert_pool(&pool)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok((StatusCode::CREATED, Json(PostOut::from(p))))
+}

--- a/examples/showcase/src/apps/blog/urls.rs
+++ b/examples/showcase/src/apps/blog/urls.rs
@@ -123,5 +123,29 @@ async fn create_post(
     p.insert_pool(&pool)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    Ok((StatusCode::CREATED, Json(PostOut::from(p))))
+
+    // The macro-emitted `insert_pool` populates the `Auto<T>` PK on
+    // every backend but only fills `auto_now_add` fields when the
+    // dialect supports `INSERT ... RETURNING` (PG + SQLite). MySQL
+    // populates only the PK, so re-fetch by PK to surface the DB-set
+    // `created_at` uniformly across the matrix.
+    let id = match p.id {
+        Auto::Set(n) => n,
+        Auto::Unset => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "insert_pool didn't populate the primary key".into(),
+            ));
+        }
+    };
+    let mut rows: Vec<Post> = Post::objects()
+        .filter_op("id", Op::Eq, id)
+        .fetch_pool(&pool)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let stored = rows.pop().ok_or((
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "could not re-fetch inserted row".into(),
+    ))?;
+    Ok((StatusCode::CREATED, Json(PostOut::from(stored))))
 }

--- a/examples/showcase/src/apps/mod.rs
+++ b/examples/showcase/src/apps/mod.rs
@@ -1,20 +1,21 @@
 //! Sub-apps. Each mirrors the Django shape (`models.rs`, `urls.rs`,
 //! `views.rs`, `admin.rs`, `mod.rs`) and the E2E suite has a matching
 //! `e2e/tests/<app>/` folder.
-//!
-//! Phase 1 (this commit): no apps yet — `api()` returns an empty
-//! router with a single smoke route mounted at `/__showcase__/info`.
-//! Subsequent phases plug each per-app router in via `.merge(...)`.
+
+pub mod blog;
 
 use axum::response::Json;
 use axum::routing::get;
 use axum::Router;
 
-/// Aggregated stateless API router. Each sub-app is invited to merge
-/// in once it lands.
+/// Aggregated stateless API router. Each sub-app merges its routes
+/// in here; the per-app playwright folder under `e2e/tests/<app>/`
+/// exercises them end-to-end.
 #[must_use]
 pub fn api() -> Router {
-    Router::new().route("/__showcase__/info", get(info))
+    Router::new()
+        .route("/__showcase__/info", get(info))
+        .merge(blog::urls::api())
 }
 
 /// Smoke endpoint — used by the E2E playwright suite's readiness
@@ -33,6 +34,6 @@ async fn info() -> Json<serde_json::Value> {
         "framework": "rustango",
         "version": env!("CARGO_PKG_VERSION"),
         "backend": backend,
-        "apps": [],
+        "apps": ["blog"],
     }))
 }


### PR DESCRIPTION
## Summary

Phase 2 of the E2E showcase plan. Adds the first sub-app: \`blog\`, a JSON CRUD surface over a single \`Post\` model. Exercises end-to-end:

- \`#[derive(Model)]\` with \`Auto<i64>\` PK, \`max_length\`, \`default = \"false\"\`, \`auto_now_add\`.
- \`manage makemigrations\` — \`migrations/0002_blog.json\` produced via the framework's own diff machinery (\`cargo run -- makemigrations blog\`).
- Tri-dialect QuerySet pipeline: \`Post::objects().order_by(...).filter_op(...).fetch_pool(\&pool)\`.
- Macro-emitted \`Post::insert_pool(\&Pool)\` round-trip with DB-populated \`auto_now_add\`.

## Routes

| Method | Path | Result |
|---|---|---|
| GET | \`/blog/posts\` | List, sorted by id ASC |
| GET | \`/blog/posts/{id}\` | Retrieve; 404 on miss |
| POST | \`/blog/posts\` | Create from \`{title, body?, published?}\`; 201 with body |

## Playwright

\`e2e/tests/blog/crud.spec.ts\` — 5 tests covering empty list, create + retrieve round-trip, ordering, 404 on unknown id, null body + default published. **7/7 tests pass locally** (5 new + 2 smoke from phase 1).

## Verified locally

\`\`\`
$ npx playwright test
✓ blog API › list is initially empty (smoke against fresh DB) (9ms)
✓ blog API › POST creates a post + GET retrieves it by id (7ms)
✓ blog API › list reflects newly created posts (order_by id asc) (6ms)
✓ blog API › GET unknown id returns 404 (2ms)
✓ blog API › body is nullable (22ms)
✓ phase 1 smoke › info endpoint serves framework metadata (2ms)
✓ phase 1 smoke › backend matches the SHOWCASE_BACKEND env if set (1ms)
7 passed (4.2s)
\`\`\`

CI matrix runs the same suite against postgres / mysql / sqlite.