### PR TITLE
fix(macros): accept Decimal/NaiveTime/Vec<u8> in detect_type (closes #524)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -6131,8 +6131,11 @@ enum DetectedKind {
     String,
     DateTime,
     Date,
+    Time,
     Uuid,
     Json,
+    Decimal,
+    Binary,
 }
 
 impl DetectedKind {
@@ -6147,8 +6150,11 @@ impl DetectedKind {
             Self::String => quote!(::rustango::core::FieldType::String),
             Self::DateTime => quote!(::rustango::core::FieldType::DateTime),
             Self::Date => quote!(::rustango::core::FieldType::Date),
+            Self::Time => quote!(::rustango::core::FieldType::Time),
             Self::Uuid => quote!(::rustango::core::FieldType::Uuid),
             Self::Json => quote!(::rustango::core::FieldType::Json),
+            Self::Decimal => quote!(::rustango::core::FieldType::Decimal),
+            Self::Binary => quote!(::rustango::core::FieldType::Binary),
         }
     }
 
@@ -6180,8 +6186,17 @@ impl DetectedKind {
                 quote!(Date),
                 quote!(<::chrono::NaiveDate as ::std::default::Default>::default()),
             ),
+            Self::Time => (
+                quote!(Time),
+                quote!(<::chrono::NaiveTime as ::std::default::Default>::default()),
+            ),
             Self::Uuid => (quote!(Uuid), quote!(::uuid::Uuid::nil())),
             Self::Json => (quote!(Json), quote!(::serde_json::Value::Null)),
+            Self::Decimal => (
+                quote!(Decimal),
+                quote!(<::rust_decimal::Decimal as ::std::default::Default>::default()),
+            ),
+            Self::Binary => (quote!(Binary), quote!(::std::vec::Vec::<u8>::new())),
         }
     }
 }
@@ -6316,12 +6331,36 @@ fn detect_type(ty: &syn::Type) -> syn::Result<DetectedType<'_>> {
         "String" => DetectedKind::String,
         "DateTime" => DetectedKind::DateTime,
         "NaiveDate" => DetectedKind::Date,
+        "NaiveTime" => DetectedKind::Time,
         "Uuid" => DetectedKind::Uuid,
         "Value" => DetectedKind::Json,
+        "Decimal" => DetectedKind::Decimal,
+        // `Vec<u8>` → BYTEA / LONGBLOB / BLOB. Reject any other
+        // `Vec<T>` so we don't silently accept e.g. `Vec<String>`
+        // — that would emit Binary DDL and decode-fail at runtime.
+        "Vec" => {
+            let (inner, _) = generic_pair(ty, &last.arguments, "Vec")?;
+            if let Type::Path(TypePath { path, qself: None }) = inner {
+                if let Some(seg) = path.segments.last() {
+                    if seg.ident == "u8" && seg.arguments.is_empty() {
+                        return Ok(DetectedType {
+                            kind: DetectedKind::Binary,
+                            nullable: false,
+                            auto: false,
+                            fk_inner: None,
+                        });
+                    }
+                }
+            }
+            return Err(syn::Error::new_spanned(
+                ty,
+                "unsupported `Vec<T>` field — only `Vec<u8>` (→ Binary) is supported",
+            ));
+        }
         other => {
             return Err(syn::Error::new_spanned(
                 ty,
-                format!("unsupported field type `{other}`; v0.1 supports i32/i64/f32/f64/bool/String/DateTime/NaiveDate/Uuid/serde_json::Value, optionally wrapped in Option or Auto (Auto only on integers)"),
+                format!("unsupported field type `{other}`; supports i16/i32/i64/f32/f64/bool/String/DateTime/NaiveDate/NaiveTime/Uuid/serde_json::Value/Decimal/Vec<u8>, optionally wrapped in Option or Auto (Auto only on integers/Uuid/DateTime)"),
             ));
         }
     };

--- a/crates/rustango/tests/macro_decimal_time_binary.rs
+++ b/crates/rustango/tests/macro_decimal_time_binary.rs
@@ -1,0 +1,105 @@
+//! Issue #524 — `#[derive(Model)]` accepts `Decimal` / `NaiveTime` /
+//! `Vec<u8>` and maps each to the right `FieldType` (`Decimal`,
+//! `Time`, `Binary`). Before this fix, the macro rejected these
+//! types outright in `detect_type` (`rustango-macros/src/lib.rs`)
+//! and showcase apps had to fall back to `i64` for money columns.
+//!
+//! The test is a pure macro-emission check — never touches a DB.
+//! Build-only is enough to prove the macro accepts the types and
+//! emits the right `FieldType`, without entangling the test with
+//! sqlx's per-backend `Decode/Type` impls.
+//!
+//! ## Backend split
+//!
+//! `chrono::NaiveTime` and `Vec<u8>` have `Decode`/`Type` impls for
+//! every sqlx backend, so the `WaresTimeBin` struct compiles
+//! anywhere.
+//!
+//! `rust_decimal::Decimal` only has impls for `Postgres` + `MySql`
+//! in sqlx 0.8 (sqlite has no native NUMERIC type and ships no
+//! `Decimal: Decode<Sqlite>` impl — documented in
+//! `sql::executor::mod.rs::bind_match_sqlite!`). The macro's
+//! `__impl_sqlite_from_row!` fires unconditionally when the sqlite
+//! feature is on, so the `WaresDecimal` struct has to be gated to
+//! `not(feature = "sqlite")` builds.
+
+#![allow(dead_code)]
+
+use rustango::core::FieldType;
+use rustango::core::Model as _;
+use rustango::core::SqlValue;
+use rustango::sql::Auto;
+use rustango::Model;
+
+// ---- Universal: Time + Binary work on every backend. ---------------
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "wares_524_timebin")]
+pub struct WaresTimeBin {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub opens: chrono::NaiveTime,
+    pub payload: Vec<u8>,
+}
+
+#[test]
+fn time_and_binary_emit_right_field_types() {
+    let fields: Vec<(&'static str, FieldType)> = WaresTimeBin::SCHEMA
+        .scalar_fields()
+        .map(|f| (f.name, f.ty))
+        .collect();
+    assert!(
+        fields.contains(&("opens", FieldType::Time)),
+        "NaiveTime → FieldType::Time: {fields:?}"
+    );
+    assert!(
+        fields.contains(&("payload", FieldType::Binary)),
+        "Vec<u8> → FieldType::Binary: {fields:?}"
+    );
+}
+
+#[test]
+fn sqlvalue_into_for_time_and_binary() {
+    // Smoke that the macro's emitted `Into<SqlValue>` walks each
+    // type cleanly — without these, the `_columns/_values` push
+    // chain in the generated `insert_pool` would fail to compile.
+    let t: SqlValue = chrono::NaiveTime::from_hms_opt(9, 30, 0).unwrap().into();
+    assert!(matches!(t, SqlValue::Time(_)));
+
+    let b: SqlValue = vec![0u8, 1, 2, 3].into();
+    assert!(matches!(b, SqlValue::Binary(_)));
+}
+
+// ---- Decimal: PG + MySQL only (sqlx-sqlite has no impl). -----------
+
+#[cfg(all(any(feature = "postgres", feature = "mysql"), not(feature = "sqlite")))]
+mod decimal_pg_mysql {
+    use super::*;
+    use rust_decimal::Decimal;
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "wares_524_decimal")]
+    pub struct WaresDecimal {
+        #[rustango(primary_key)]
+        pub id: Auto<i64>,
+        pub price: Decimal,
+    }
+
+    #[test]
+    fn decimal_emits_right_field_type() {
+        let fields: Vec<(&'static str, FieldType)> = WaresDecimal::SCHEMA
+            .scalar_fields()
+            .map(|f| (f.name, f.ty))
+            .collect();
+        assert!(
+            fields.contains(&("price", FieldType::Decimal)),
+            "Decimal → FieldType::Decimal: {fields:?}"
+        );
+    }
+
+    #[test]
+    fn sqlvalue_into_for_decimal() {
+        let d: SqlValue = Decimal::new(1995, 2).into();
+        assert!(matches!(d, SqlValue::Decimal(_)));
+    }
+}


### PR DESCRIPTION
## Summary

- Three new `DetectedKind` arms (`Time`, `Decimal`, `Binary`) on `crates/rustango-macros/src/lib.rs` so `#[derive(Model)]` accepts `chrono::NaiveTime`, `rust_decimal::Decimal`, and `Vec<u8>` and emits the matching `FieldType` — closing the macro gap surfaced while building the E2E showcase shop app (#522 follow-up).
- The framework's `FieldType` enum, dialect compilers, `bind_match!`, and `row_to_json` already supported all three; the macro's `detect_type` was the only missing link.
- `Vec<T>` is generic-arg-inspected: only `Vec<u8>` maps to `Binary`; every other `Vec<T>` still errors with a pointed message.

## Why this matters

Before this PR, adding `price: rust_decimal::Decimal` to a model rejected with *"unsupported field type Decimal; v0.1 supports …"*. The showcase shop app workaround was `price_cents: i64` (multiply by 100). Same story for `payload: Vec<u8>` (binary blobs) and `opens: NaiveTime` (time-of-day columns).

## Backend caveat

`sqlx-sqlite` ships no `Decimal: Decode<Sqlite>` impl (SQLite has no native NUMERIC type — `bind_match_sqlite!` round-trips Decimal through `to_string()` only). So the regression test gates its `WaresDecimal` struct to `cfg(any(postgres, mysql), not(sqlite))`. `NaiveTime` + `Vec<u8>` work on every backend and are tested universally.

## Test plan

- [x] `cargo test -p rustango --all-features --test macro_decimal_time_binary` → 2 pass (Decimal struct correctly elided)
- [x] `cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_decimal_time_binary` → 2 pass
- [x] `cargo test -p rustango --no-default-features --features postgres,tenancy --test macro_decimal_time_binary` → 4 pass (Decimal arm enabled)
- [x] `cargo test --workspace --all-features --no-run` → clean compile
- [x] `cargo test -p rustango --no-default-features --features sqlite,tenancy --lib` → 1484 pass
- [x] Pre-push hook: 2324 tests pass in 8.21s