### PR TITLE
feat(admin): list_display callable display_link via `register_admin_computed!` link callable (closes #349)

### DIFF
--- a/crates/rustango/src/admin/computed_fields.rs
+++ b/crates/rustango/src/admin/computed_fields.rs
@@ -55,6 +55,13 @@
 /// `row_to_json_my` / `row_to_json_sqlite` per the active backend.
 pub type ComputedFieldRenderFn = fn(&serde_json::Value) -> String;
 
+/// Function signature a computed field's optional link callable
+/// implements. Receives the same row JSON the renderer does and
+/// returns the cell's link target URL — `None` to render the cell
+/// inline. Issue #349 — Django parity for `list_display` callables
+/// that advertise a click target (e.g. an FK detail page).
+pub type ComputedFieldLinkFn = fn(&serde_json::Value) -> Option<String>;
+
 /// One computed-field registration. Inventory-collected; submit one
 /// per `register_admin_computed!` invocation.
 pub struct ComputedField {
@@ -70,6 +77,12 @@ pub struct ComputedField {
     /// Renderer. Pure HTML out — caller is responsible for any
     /// escaping needed.
     pub render: ComputedFieldRenderFn,
+    /// Issue #349 — optional per-row link callable. When present and
+    /// returns `Some(url)`, the admin list view wraps the rendered
+    /// cell in `<a href="{url}">…</a>`. When `None` (the default)
+    /// the cell behaves exactly as before, deferring to the
+    /// container-level `list_display_links` for whether to link.
+    pub link: Option<ComputedFieldLinkFn>,
 }
 
 inventory::collect!(ComputedField);
@@ -103,21 +116,69 @@ pub fn find(table: &str, name: &str) -> Option<&'static ComputedField> {
 ///     "word_count",          // identifier in list_display
 ///     "Words",               // column header
 ///     |row| {
-///         use sqlx::Row;
-///         let body: String = row.try_get("body").unwrap_or_default();
+///         let body = row.get("body").and_then(|v| v.as_str()).unwrap_or_default();
 ///         body.split_whitespace().count().to_string()
 ///     }
 /// );
 /// ```
+///
+/// Issue #349 — pass `link = |row| Option<String>` to advertise a
+/// per-row click target. When `Some(url)` comes back, the admin
+/// list view wraps the rendered cell in `<a href="{url}">…</a>`.
+///
+/// ```ignore
+/// rustango::register_admin_computed!(
+///     "cms_post",
+///     "author_link",
+///     "Author",
+///     |row| {
+///         row.get("author")
+///             .and_then(|a| a.get("name"))
+///             .and_then(|v| v.as_str())
+///             .unwrap_or("—")
+///             .to_string()
+///     },
+///     link = |row| {
+///         row.get("author")
+///             .and_then(|a| a.get("id"))
+///             .and_then(|v| v.as_i64())
+///             .map(|id| format!("/__admin/auth_user/{id}"))
+///     },
+/// );
+/// ```
 #[macro_export]
 macro_rules! register_admin_computed {
-    ($table:expr, $name:expr, $label:expr, $render:expr) => {
+    // 4-arg form — no link. Backwards-compatible with every existing
+    // call site; the new `link` field stays `None`.
+    ($table:expr, $name:expr, $label:expr, $render:expr $(,)?) => {
         $crate::inventory::submit! {
             $crate::admin::computed_fields::ComputedField {
                 table: $table,
                 name: $name,
                 label: $label,
                 render: $render,
+                link: ::core::option::Option::None,
+            }
+        }
+    };
+    // 5-arg form — with explicit `link = …` callable. The link
+    // expression must be of type `fn(&serde_json::Value) -> Option<String>`
+    // (typically a closure; rust will coerce a non-capturing one to
+    // the fn-pointer type expected by `ComputedFieldLinkFn`).
+    (
+        $table:expr,
+        $name:expr,
+        $label:expr,
+        $render:expr,
+        link = $link:expr $(,)?
+    ) => {
+        $crate::inventory::submit! {
+            $crate::admin::computed_fields::ComputedField {
+                table: $table,
+                name: $name,
+                label: $label,
+                render: $render,
+                link: ::core::option::Option::Some($link),
             }
         }
     };

--- a/crates/rustango/src/admin/mod.rs
+++ b/crates/rustango/src/admin/mod.rs
@@ -62,7 +62,7 @@ mod urls;
 mod views;
 
 pub use auth::protect_with_basic_auth;
-pub use computed_fields::{ComputedField, ComputedFieldRenderFn};
+pub use computed_fields::{ComputedField, ComputedFieldLinkFn, ComputedFieldRenderFn};
 pub use errors::AdminError;
 pub use inlines::{
     InlineAdmin, InlineAdminGeneric, InlineApplyOutcome, InlineFormPanel, InlineKind, InlinePanel,

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -620,6 +620,23 @@ pub(crate) async fn table_view(
                         DisplayItem::GenericFk(gr) => render_gfk_cell(row, gr, &gfk_ct_map),
                         DisplayItem::JsonPath(f, key) => render_json_path_cell(row, f, key),
                     };
+                    // #349 — computed-field `link` callable.
+                    // When the field declared a `link =` in
+                    // `register_admin_computed!`, that callable's
+                    // per-row URL wins over both the inline cell
+                    // and the container-level `list_display_links`
+                    // detail-href (the callable knows where THIS
+                    // specific cell should jump, e.g. an FK target).
+                    if let DisplayItem::Computed(cf) = item {
+                        if let Some(link_fn) = cf.link {
+                            if let Some(url) = link_fn(row) {
+                                return format!(
+                                    "<a href=\"{href}\">{inner}</a>",
+                                    href = render::escape(&url),
+                                );
+                            }
+                        }
+                    }
                     match (
                         cell_is_link.get(idx).copied().unwrap_or(false),
                         &detail_href,

--- a/crates/rustango/tests/admin_computed_field_link_sqlite_live.rs
+++ b/crates/rustango/tests/admin_computed_field_link_sqlite_live.rs
@@ -1,0 +1,147 @@
+//! Django-parity #349 — `register_admin_computed!` with `link = …`
+//! callable advertises a per-row click target. The admin list view
+//! wraps the rendered cell in `<a href="{url}">…</a>` when the
+//! callable returns `Some(url)`, and leaves it alone otherwise.
+//!
+//! Sibling of `admin_list_display_links_sqlite_live.rs`: that test
+//! covers the container-level `list_display_links` whitelist, this
+//! one covers the per-callable override. The two interact in a
+//! predictable way — the callable's URL wins over the detail-href
+//! wrap when both are eligible for the same cell (the callable
+//! knows where THIS specific cell should jump; the container fallback
+//! only knows the row's detail page).
+
+#![cfg(all(feature = "sqlite", feature = "admin", feature = "tenancy"))]
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use http_body_util::BodyExt;
+use rustango::sql::Pool;
+use rustango::Model;
+use tower::ServiceExt;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "cfl_post",
+    display = "title",
+    admin(list_display = "title, author_link, plain_summary", ordering = "-id",)
+)]
+pub struct CflPost {
+    #[rustango(primary_key)]
+    id: rustango::Auto<i64>,
+    #[rustango(max_length = 200)]
+    title: String,
+    author_id: i64,
+}
+
+// Computed field WITH link callable — should auto-link to author detail.
+rustango::register_admin_computed!(
+    "cfl_post",
+    "author_link",
+    "Author",
+    |row| {
+        let id = row
+            .get("author_id")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(0);
+        format!("user-{id}")
+    },
+    link = |row| {
+        row.get("author_id")
+            .and_then(serde_json::Value::as_i64)
+            .map(|id| format!("/auth_user/{id}"))
+    },
+);
+
+// Computed field WITHOUT link callable — should render plain text,
+// no wrapping, no detail-href (table isn't in list_display_links).
+rustango::register_admin_computed!("cfl_post", "plain_summary", "Summary", |row| {
+    let t = row
+        .get("title")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    format!("re: {t}")
+});
+
+fn build_app(pool: Pool) -> axum::Router {
+    rustango::admin::Builder::new(pool).admin_prefix("").build()
+}
+
+async fn pool_with_post() -> (Pool, String) {
+    let pool = Pool::connect("sqlite::memory:").await.expect("sqlite pool");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        r#"CREATE TABLE IF NOT EXISTS "cfl_post" (
+            "id"        INTEGER PRIMARY KEY AUTOINCREMENT,
+            "title"     TEXT NOT NULL,
+            "author_id" INTEGER NOT NULL
+        )"#,
+        Vec::new(),
+    )
+    .await
+    .expect("create");
+    let app = build_app(pool.clone());
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/cfl_post")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("title=Hello&author_id=7"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        resp.status() == StatusCode::SEE_OTHER || resp.status() == StatusCode::OK,
+        "seed POST failed: {}",
+        resp.status()
+    );
+    (pool, "/cfl_post".into())
+}
+
+async fn fetch_body(pool: Pool, uri: &str) -> String {
+    let app = build_app(pool);
+    let resp = app
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn computed_with_link_wraps_in_anchor_to_callable_url() {
+    let (pool, uri) = pool_with_post().await;
+    let body = fetch_body(pool, &uri).await;
+    // The author_link computed field's link callable returned
+    // `/auth_user/7` (escaped — the slash stays, the `/` doesn't
+    // need encoding inside an href but it's pumped through
+    // `render::escape` which only HTML-encodes & < > " ' / and `/`
+    // round-trips).
+    assert!(
+        body.contains(r#"<a href="/auth_user/7">user-7</a>"#),
+        "author_link cell should wrap inner in <a> using callable URL, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn computed_without_link_renders_plain() {
+    let (pool, uri) = pool_with_post().await;
+    let body = fetch_body(pool, &uri).await;
+    // plain_summary has no link callable AND no entry in
+    // list_display_links — must appear bare, never wrapped.
+    assert!(
+        body.contains("re: Hello"),
+        "plain_summary cell should be present, got: {body}"
+    );
+    // Make sure the unsupported pattern doesn't appear — the inner
+    // string never gets an `<a>` around it. Capture a small window
+    // by searching for an anchor that contains "re: Hello".
+    assert!(
+        !body.contains(r#">re: Hello</a>"#),
+        "plain_summary must not be wrapped in <a>, got: {body}"
+    );
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -220,7 +220,7 @@ Summary: **11 SHIPPED / 2 PARTIAL / 2 MISSING / 1 N/A**. Gaps: `sqlmigrate` raw-
 | `list_display` (scalar fields) | [list_display](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display) | SHIPPED | `#[rustango(admin(list_display = "title, status"))]` | |
 | `list_display` (method/computed fields) | same | SHIPPED | Two paths: `register_admin_computed!(table, name, label, fn)` for arbitrary HTML renderers (pre-v0.42), and `list_display = "data.headline"` dotted-path syntax for JSON-column subkeys (closed #348, v0.42). The dotted path drills into a `FieldType::Json` column at `.split('.')` segments (numeric segments index arrays); bools render as ☑/☐ glyphs, missing paths fall back to `<em>NULL</em>`. | |
 | `list_display` (boolean checkbox icon) | same | SHIPPED | v0.37+ render in admin/render.rs | |
-| `list_display` (callable display_link) | same | MISSING | n/a (#349) | FK columns auto-link; method-field callables don't. |
+| `list_display` (callable display_link) | same | SHIPPED | `register_admin_computed!(table, name, label, render, link = |row| Option<String>)` (closed #349) — the optional `link =` callable returns a per-row URL; admin list view wraps the rendered cell in `<a href="{url}">…</a>` when `Some`. Per-callable URL wins over the container-level `list_display_links` detail-href fallback. | |
 | `list_display_links` | [list_display_links](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display_links) | SHIPPED | `admin(list_display_links = "title, views")` (#350, v0.42) — comma-separated names from `list_display`. Each matched cell wraps its inner HTML in `<a href="{admin_prefix}/{table}/{pk}">…</a>`. Empty whitelist keeps the trailing "View" column as the only link. | |
 | `list_filter` (FieldListFilter) | [list_filter](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_filter) | SHIPPED | `#[rustango(admin(list_filter = "..."))]` | |
 | `list_filter` (SimpleListFilter — custom) | same | SHIPPED | `register_admin_list_filter!(table, parameter_name, title, lookups, to_filters_fn)` (closed #351, v0.42) — declares a custom filter card on the list view with operator-defined lookups + predicate function. The function maps the URL value to `Vec<Filter>` predicates that AND onto the WHERE. Rendered as a right-rail card alongside field-value facets. | |
@@ -255,7 +255,7 @@ Summary: **11 SHIPPED / 2 PARTIAL / 2 MISSING / 1 N/A**. Gaps: `sqlmigrate` raw-
 | Admin styling / branding | [admin templates](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#overriding-admin-templates) | SHIPPED | `Storage`-backed per-tenant brand + theme tokens | |
 | Admin docs (`django.contrib.admindocs`) | [admindocs](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/admindocs/) | N/A | n/a | Rust doc-comments cover it. |
 
-Summary: **18 SHIPPED / 7 PARTIAL / 11 MISSING / 2 N/A**. Concentration of MISSING items in admin polish: method-field display, list_display_links, raw_id_fields, autocomplete, formfield_overrides, date_hierarchy, prepopulated_fields, custom URLs.
+Summary: **19 SHIPPED / 7 PARTIAL / 10 MISSING / 2 N/A**. Concentration of MISSING items in admin polish: formfield_overrides, custom URLs, custom views, history view re-render, etc.
 
 ---
 


### PR DESCRIPTION
## Summary

- Django-parity gap from the audit's Top-10 (sec 6 row 223): FK columns in `list_display` auto-link to the FK target, but method-field callables registered with `register_admin_computed!` had no first-class way to advertise a click target. Users had to bake `<a>` tags into the render closure.
- Adds optional `link = |row| Option<String>` callable to `register_admin_computed!`. When `Some(url)` comes back, the admin list view wraps the rendered cell in `<a href=\"{url}\">…</a>`.
- Per-callable URL wins over the container-level `list_display_links` detail-href fallback (the callable knows where THIS specific cell should jump — e.g. the FK target's admin page — while the container fallback only knows the row's own detail page).

## API

\`\`\`rust
rustango::register_admin_computed!(
    \"cms_post\",
    \"author_link\",
    \"Author\",
    |row| { /* render author name */ },
    link = |row| {
        row.get(\"author_id\")
            .and_then(serde_json::Value::as_i64)
            .map(|id| format!(\"/__admin/auth_user/{id}\"))
    },
);
\`\`\`

The macro's 4-arg form stays 100% backwards-compatible — existing call sites get `link: None` by default.

## Test plan

- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy,admin --test admin_computed_field_link_sqlite_live\` → 2 pass (both \"with link wraps in anchor\" + \"without link renders plain\")
- [x] \`cargo test --workspace --all-features --no-run\` → clean compile
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy,admin --lib\` → 1484 pass
- [x] Pre-push hook gate
- [x] Audit doc row 223 flipped MISSING → SHIPPED; sec 6 summary bumped to 19 SHIPPED / 7 PARTIAL / 10 MISSING / 2 N/A