### PR TITLE
docs(audit): sync section 5 summary with shipped sqlmigrate (closes #395)

### DIFF
--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -209,7 +209,7 @@ Summary: **1 / 1 / 3 / 0**.
 | Schema-mode per-tenant migrations | (Django doesn't ship this) | N/A | `tenancy::migrate` runs per-tenant | Beyond Django's per-DB. |
 | inspectdb (tables + views) | [inspectdb](https://docs.djangoproject.com/en/6.0/ref/django-admin/#inspectdb) | SHIPPED | T2.10 closed — views walked too (PR #304) | |
 
-Summary: **11 SHIPPED / 2 PARTIAL / 2 MISSING / 1 N/A**. Gaps: `sqlmigrate` raw-SQL print, `migrations --merge`.
+Summary: **12 SHIPPED / 2 PARTIAL / 1 MISSING / 1 N/A**. Remaining gap: `migrations --merge` for divergent branch chains (#346).
 
 ---
 


### PR DESCRIPTION
## Summary

Doc-only — section 5 (Migrations) summary said \`sqlmigrate raw-SQL print\` was still a gap, but the row two lines above already shows it SHIPPED in v0.42 via #345 (\`manage sqlmigrate <name>\`, source [crates/rustango/src/migrate/manage.rs:830](crates/rustango/src/migrate/manage.rs#L830)).

Closes #395 — that issue tracked the same Django capability against an older audit snapshot before #345 landed.

## Test plan

- [x] Doc-only diff — no code changes
- [x] Section 5 summary now reads \`12 SHIPPED / 2 PARTIAL / 1 MISSING / 1 N/A\` with \`migrations --merge\` (#346) as the only remaining gap