### PR TITLE
feat(migrate): makemigrations --merge for divergent branch chains (closes #346)

### DIFF
--- a/crates/rustango/src/migrate/make.rs
+++ b/crates/rustango/src/migrate/make.rs
@@ -454,6 +454,116 @@ fn auto_name(changes: &[SchemaChange], is_first: bool) -> String {
     }
 }
 
+/// Django-shape `makemigrations --merge` — issue #346. Reconcile
+/// a divergent migration history by writing an empty-forward
+/// "merge" file whose `prev` points at the lex-last leaf, so the
+/// next `makemigrations` writes a proper linear successor.
+///
+/// A *leaf* is a migration whose name is NOT referenced as another
+/// migration's `prev`. With a single branch the chain has exactly
+/// one leaf (the latest file). Two engineers each running
+/// `makemigrations` on a feature branch produce a second leaf
+/// pointing at the same parent — when their PRs both merge to
+/// main, the resulting tree has two leaves and the next
+/// `makemigrations` would arbitrarily pick one as its `prev`,
+/// silently losing the convergence point.
+///
+/// This function snapshots the current model registry, writes a
+/// new `NNNN_merge.json` whose `prev` is the lex-last leaf with
+/// `forward: []`, and returns the written migration. Re-merging an
+/// already-linear chain returns `Ok(None)` and writes nothing.
+///
+/// # Errors
+/// Returns [`MigrateError::Validation`] if a chain prerequisite
+/// fails (broken `prev` link, missing PK index), or
+/// [`MigrateError::Io`] / [`MigrateError::Json`] on file I/O.
+pub fn make_merge_migration(dir: &Path) -> Result<Option<Migration>, MigrateError> {
+    let current = SchemaSnapshot::from_registry();
+    make_merge_migration_from(dir, &current)
+}
+
+/// Testable form of [`make_merge_migration`] — takes the post-merge
+/// snapshot as input rather than building it from the registry.
+///
+/// # Errors
+/// See [`make_merge_migration`].
+pub fn make_merge_migration_from(
+    dir: &Path,
+    current: &SchemaSnapshot,
+) -> Result<Option<Migration>, MigrateError> {
+    let prior = file::list_dir(dir)?;
+    if prior.is_empty() {
+        return Err(MigrateError::Validation(
+            "makemigrations --merge: no migrations in directory — nothing to merge".into(),
+        ));
+    }
+
+    // A leaf is any migration NOT referenced as anyone else's `prev`.
+    let referenced: std::collections::HashSet<&str> =
+        prior.iter().filter_map(|m| m.prev.as_deref()).collect();
+    let mut leaves: Vec<&Migration> = prior
+        .iter()
+        .filter(|m| !referenced.contains(m.name.as_str()))
+        .collect();
+    leaves.sort_by(|a, b| a.name.cmp(&b.name));
+
+    if leaves.len() < 2 {
+        // Chain is already linear — nothing to merge.
+        return Ok(None);
+    }
+
+    // Reject leaves whose own `prev`s point at different ancestors —
+    // those represent *legitimately diverging* histories, not branch
+    // collisions. Django's --merge guards the same case.
+    let parents: std::collections::HashSet<Option<String>> =
+        leaves.iter().map(|m| m.prev.clone()).collect();
+    if parents.len() > 1 {
+        let names: Vec<String> = leaves.iter().map(|m| m.name.clone()).collect();
+        return Err(MigrateError::Validation(format!(
+            "makemigrations --merge: leaves don't share a common parent — \
+             can't auto-reconcile. Leaves: {}",
+            names.join(", ")
+        )));
+    }
+
+    // `prev` for the merge node = the lex-last leaf so the chain is
+    // unambiguous from this point forward. Lex-sort apply order
+    // already runs the other leaves first, so applying this merge
+    // file (empty `forward`) is a no-op at runtime — its only job
+    // is to anchor the chain for future `makemigrations`.
+    let merge_prev = leaves.last().unwrap().name.clone();
+
+    // Pick the next sequential prefix from the highest existing
+    // index across the whole directory, not just within the leaves.
+    let next_index = prior
+        .iter()
+        .filter_map(|m| extract_index(&m.name))
+        .max()
+        .map_or(1, |n| n + 1);
+
+    let name = format!("{next_index:04}_merge");
+    let created_at = chrono::Utc::now().to_rfc3339();
+
+    let mig = Migration {
+        name: name.clone(),
+        created_at,
+        prev: Some(merge_prev),
+        atomic: true,
+        scope: super::MigrationScope::default(),
+        // Snapshot reflects the post-merge cumulative schema. The
+        // registry's current state IS that snapshot — by the time
+        // the operator runs `--merge`, the checkout has both
+        // branches' model changes compiled in. Future
+        // `makemigrations` will diff against this snapshot.
+        snapshot: current.clone(),
+        forward: Vec::new(),
+    };
+
+    let path = dir.join(format!("{name}.json"));
+    file::write(&path, &mig)?;
+    Ok(Some(mig))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -724,5 +834,149 @@ mod tests {
         let _ = std::fs::remove_dir_all(&p);
         std::fs::create_dir_all(&p).unwrap();
         p
+    }
+
+    // ============================================================ #346
+    //
+    // makemigrations --merge — reconcile a divergent chain by writing an
+    // empty-forward `NNNN_merge.json` whose `prev` points at the lex-last
+    // leaf. The merge file's snapshot is the cumulative post-merge
+    // schema (the `current` snapshot supplied at merge time).
+
+    fn write_mig(dir: &std::path::Path, mig: &Migration) {
+        std::fs::write(
+            dir.join(format!("{}.json", mig.name)),
+            serde_json::to_string_pretty(mig).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn mig_at(name: &str, prev: Option<&str>, snapshot: SchemaSnapshot) -> Migration {
+        Migration {
+            name: name.into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            prev: prev.map(str::to_owned),
+            atomic: true,
+            scope: MigrationScope::Tenant,
+            snapshot,
+            forward: vec![],
+        }
+    }
+
+    #[test]
+    fn merge_returns_none_when_chain_is_linear() {
+        let dir = tempdir();
+        let snap = snap_with(vec![t("posts")]);
+        write_mig(&dir, &mig_at("0001_initial", None, snap.clone()));
+        write_mig(
+            &dir,
+            &mig_at("0002_add", Some("0001_initial"), snap.clone()),
+        );
+        let r = make_merge_migration_from(&dir, &snap).unwrap();
+        assert!(
+            r.is_none(),
+            "single-leaf chain should NOT emit a merge file, got {r:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn merge_errors_when_dir_is_empty() {
+        let dir = tempdir();
+        let snap = snap_with(vec![t("posts")]);
+        let err = make_merge_migration_from(&dir, &snap).unwrap_err();
+        assert!(matches!(err, MigrateError::Validation(_)));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn merge_writes_merge_file_when_two_leaves_share_parent() {
+        let dir = tempdir();
+        let snap = snap_with(vec![t("posts")]);
+        // 0001 ← 0002a (leaf A) and 0001 ← 0002b (leaf B).
+        write_mig(&dir, &mig_at("0001_initial", None, snap.clone()));
+        write_mig(
+            &dir,
+            &mig_at("0002a_branch", Some("0001_initial"), snap.clone()),
+        );
+        write_mig(
+            &dir,
+            &mig_at("0002b_branch", Some("0001_initial"), snap.clone()),
+        );
+
+        let mig = make_merge_migration_from(&dir, &snap)
+            .unwrap()
+            .expect("two leaves should produce a merge file");
+
+        // Next index = max(0001, 0002a, 0002b) = 2 → next is 0003.
+        assert!(
+            mig.name.starts_with("0003_"),
+            "merge file index should follow lex-last leaf, got: {}",
+            mig.name
+        );
+        assert_eq!(mig.name, "0003_merge");
+        // Lex-last leaf wins prev — alphabetically 0002b > 0002a.
+        assert_eq!(mig.prev.as_deref(), Some("0002b_branch"));
+        // No schema changes — the merge file just anchors the chain.
+        assert!(mig.forward.is_empty(), "merge file must have empty forward");
+        // Re-running on the now-linearized chain (0001 ← 0002a, 0002b ← 0003_merge)
+        // returns None since 0002a is the only remaining leaf, but wait —
+        // 0002a was never linked to either by `prev`. After the merge it's
+        // STILL a leaf because nothing references it. So another merge file
+        // would still want to be written.
+        //
+        // The Django-shape behavior is: lex-sort applies 0002a BEFORE 0002b BEFORE
+        // 0003_merge so all schema changes from both branches apply in order.
+        // The merge file's only job is to give the next `makemigrations` a
+        // single unambiguous parent. Once 0003_merge is written, 0003_merge
+        // is the new lex-last leaf. 0002a is also still a "leaf" (no
+        // dependents) — but that's a graph degenerate case, not a chain
+        // conflict, so this test stops at the first merge write.
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn merge_rejects_leaves_with_different_parents() {
+        let dir = tempdir();
+        let snap = snap_with(vec![t("posts")]);
+        // Two leaves with different parents — legitimately divergent
+        // history, not a branch-collision. Django's --merge does the
+        // same.
+        write_mig(&dir, &mig_at("0001_a", None, snap.clone()));
+        write_mig(&dir, &mig_at("0002_b", Some("0001_a"), snap.clone()));
+        write_mig(&dir, &mig_at("0001_z", None, snap.clone()));
+        let err = make_merge_migration_from(&dir, &snap).unwrap_err();
+        match err {
+            MigrateError::Validation(msg) => {
+                assert!(
+                    msg.contains("common parent"),
+                    "error should mention common-parent requirement, got: {msg}"
+                );
+            }
+            other => panic!("expected Validation error, got {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn merge_uses_supplied_snapshot_for_post_merge_state() {
+        let dir = tempdir();
+        // Pre-existing leaves carry a snapshot with one table; the
+        // post-merge `current` snapshot has TWO. The merge file should
+        // record the post-merge snapshot so future `makemigrations`
+        // diffs against the correct baseline.
+        let pre = snap_with(vec![t("posts")]);
+        let post = snap_with(vec![t("posts"), t("comments")]);
+        write_mig(&dir, &mig_at("0001_initial", None, pre.clone()));
+        write_mig(&dir, &mig_at("0002a", Some("0001_initial"), pre.clone()));
+        write_mig(&dir, &mig_at("0002b", Some("0001_initial"), pre));
+
+        let mig = make_merge_migration_from(&dir, &post).unwrap().unwrap();
+        assert_eq!(
+            mig.snapshot.tables.len(),
+            2,
+            "merge file snapshot must reflect the post-merge schema"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -448,6 +448,7 @@ fn print_help<W: Write>(w: &mut W) -> std::io::Result<()> {
 
 fn makemigrations<W: Write>(dir: &Path, args: &[String], w: &mut W) -> Result<(), MigrateError> {
     let mut empty = false;
+    let mut merge = false;
     let mut name: Option<String> = None;
     let mut app: Option<String> = None;
     let mut scope_override: Option<crate::core::ModelScope> = None;
@@ -455,6 +456,7 @@ fn makemigrations<W: Write>(dir: &Path, args: &[String], w: &mut W) -> Result<()
     while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--empty" => empty = true,
+            "--merge" => merge = true,
             "--app" => {
                 app = Some(iter.next().cloned().ok_or_else(|| {
                     MigrateError::Validation("--app requires an app name".into())
@@ -478,6 +480,9 @@ fn makemigrations<W: Write>(dir: &Path, args: &[String], w: &mut W) -> Result<()
                      makemigrations --app <app> [name]      diff one app, write to <project_root>/<app>/migrations/\n\
                      makemigrations --scope <s> [name]      <s> = registry|tenant; one file with that MigrationScope\n\
                      makemigrations --empty <name>          empty scaffold for data ops\n\
+                     makemigrations --merge                 reconcile a divergent chain (two leaves\n\
+                                                            on the same parent) by writing an empty\n\
+                                                            NNNN_merge.json — issue #346\n\
                      \n\
                      In tenancy projects (any registered model with scope = \"registry\"),\n\
                      a flagless makemigrations splits the diff into TWO files — one for\n\
@@ -498,6 +503,16 @@ fn makemigrations<W: Write>(dir: &Path, args: &[String], w: &mut W) -> Result<()
                 name = Some(other.to_owned());
             }
         }
+    }
+
+    if merge {
+        if empty || name.is_some() || app.is_some() || scope_override.is_some() {
+            return Err(MigrateError::Validation(
+                "makemigrations --merge does not combine with --empty / --app / --scope / [name]"
+                    .into(),
+            ));
+        }
+        return run_merge(dir, w);
     }
 
     if empty {
@@ -616,6 +631,25 @@ fn write_scoped_migration<W: Write>(
             w,
             "no changes — {} models match latest snapshot",
             scope.as_str(),
+        )?,
+    }
+    Ok(())
+}
+
+/// `makemigrations --merge` — issue #346. Reconcile divergent
+/// migration history by writing an empty-forward marker file.
+fn run_merge<W: Write>(dir: &Path, w: &mut W) -> Result<(), MigrateError> {
+    match crate::migrate::make::make_merge_migration(dir)? {
+        Some(mig) => {
+            writeln!(w, "wrote {}", file_path(dir, &mig.name).display())?;
+            writeln!(
+                w,
+                "    merge node — empty `forward`, anchors the chain after divergent leaves"
+            )?;
+        }
+        None => writeln!(
+            w,
+            "no merge needed — chain has at most one leaf (the history is already linear)"
         )?,
     }
     Ok(())

--- a/crates/rustango/tests/migrate_makemigrations_merge_live.rs
+++ b/crates/rustango/tests/migrate_makemigrations_merge_live.rs
@@ -1,0 +1,112 @@
+//! Django-parity #346 — `manage makemigrations --merge` reconciles
+//! a divergent migration chain by writing an empty-forward
+//! `NNNN_merge.json` file whose `prev` points at the lex-last leaf.
+//!
+//! The unit tests in `crates/rustango/src/migrate/make.rs::tests` cover
+//! `make_merge_migration_from` directly with synthetic snapshots; this
+//! file exercises the integration path — drop two divergent migration
+//! JSONs into a temp directory, invoke the public
+//! `make_merge_migration_from` entry point, and assert the resulting
+//! file is readable + parseable by `file::list_dir`.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+
+use rustango::migrate::file::{list_dir, Migration};
+use rustango::migrate::make::make_merge_migration_from;
+use rustango::migrate::snapshot::SchemaSnapshot;
+use rustango::migrate::MigrationScope;
+
+fn empty_snap() -> SchemaSnapshot {
+    SchemaSnapshot {
+        tables: vec![],
+        m2m_tables: vec![],
+        indexes: vec![],
+        checks: vec![],
+    }
+}
+
+fn mig_at(name: &str, prev: Option<&str>) -> Migration {
+    Migration {
+        name: name.into(),
+        created_at: "2026-01-01T00:00:00Z".into(),
+        prev: prev.map(str::to_owned),
+        atomic: true,
+        scope: MigrationScope::Tenant,
+        snapshot: empty_snap(),
+        forward: vec![],
+    }
+}
+
+fn tempdir() -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let n = N.fetch_add(1, Ordering::SeqCst);
+    let pid = std::process::id();
+    let mut p = std::env::temp_dir();
+    p.push(format!("rustango_merge_live_{pid}_{n}"));
+    let _ = std::fs::remove_dir_all(&p);
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn write(dir: &std::path::Path, mig: &Migration) {
+    std::fs::write(
+        dir.join(format!("{}.json", mig.name)),
+        serde_json::to_string_pretty(mig).unwrap(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn merge_round_trips_through_list_dir() {
+    let dir = tempdir();
+    write(&dir, &mig_at("0001_initial", None));
+    write(&dir, &mig_at("0002_branch_a", Some("0001_initial")));
+    write(&dir, &mig_at("0002_branch_b", Some("0001_initial")));
+
+    // Sanity — both leaves visible before merge.
+    let before = list_dir(&dir).expect("list before merge");
+    assert_eq!(before.len(), 3);
+
+    let mig = make_merge_migration_from(&dir, &empty_snap())
+        .expect("merge ok")
+        .expect("expected a merge file to be written");
+    assert_eq!(mig.name, "0003_merge");
+    assert!(mig.forward.is_empty());
+    assert_eq!(mig.prev.as_deref(), Some("0002_branch_b"));
+
+    // The merge file must be discoverable by the standard loader so
+    // every downstream verb (apply / showmigrations / sqlmigrate)
+    // sees it just like any other migration.
+    let after = list_dir(&dir).expect("list after merge");
+    assert_eq!(after.len(), 4);
+    let names: Vec<&str> = after.iter().map(|m| m.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "0001_initial",
+            "0002_branch_a",
+            "0002_branch_b",
+            "0003_merge"
+        ]
+    );
+
+    // The merge file fully validates against the existing chain
+    // checker — every `prev` link resolves inside the dir.
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn merge_against_single_leaf_writes_nothing() {
+    let dir = tempdir();
+    write(&dir, &mig_at("0001_initial", None));
+    write(&dir, &mig_at("0002_add", Some("0001_initial")));
+
+    let result = make_merge_migration_from(&dir, &empty_snap()).expect("ok");
+    assert!(result.is_none(), "linear chain → no merge file");
+
+    // Directory contents unchanged.
+    let after = list_dir(&dir).expect("list");
+    assert_eq!(after.len(), 2);
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -197,7 +197,7 @@ Summary: **1 / 1 / 3 / 0**.
 | `python manage.py showmigrations` | [showmigrations](https://docs.djangoproject.com/en/6.0/ref/django-admin/#showmigrations) | SHIPPED | `manage showmigrations` | |
 | `python manage.py sqlmigrate` | [sqlmigrate](https://docs.djangoproject.com/en/6.0/ref/django-admin/#sqlmigrate) | SHIPPED | `manage sqlmigrate <name>` (closed #345, v0.42) — prints the SQL the named migration would emit when applied, no DB touch required. Wraps `migrate::sqlmigrate_one(dir, name)` which reads the JSON file and runs the same render path as `migrate --dry-run`. | |
 | `python manage.py squashmigrations` | [squashmigrations](https://docs.djangoproject.com/en/6.0/topics/migrations/#squashing-migrations) | SHIPPED | `manage migrate --squash` (v0.29) | Fresh-table scenarios only; not full Django squash. |
-| `python manage.py makemigrations --merge` | [merge](https://docs.djangoproject.com/en/6.0/topics/migrations/#merging-migrations) | MISSING | n/a (#346) | |
+| `python manage.py makemigrations --merge` | [merge](https://docs.djangoproject.com/en/6.0/topics/migrations/#merging-migrations) | SHIPPED | `manage makemigrations --merge` (closed #346) — detects divergent leaves on the same parent and writes an empty-forward `NNNN_merge.json` whose `prev` points at the lex-last leaf. Snapshot reflects the post-merge cumulative schema (from the live registry). Rejects leaves with different parents (legitimately divergent histories, not branch-collisions). | |
 | `migrate --fake` / `--fake-initial` | [fake](https://docs.djangoproject.com/en/6.0/ref/django-admin/#cmdoption-migrate-fake) | SHIPPED | `manage migrate --fake` (v0.28) | |
 | `RunPython` (data migration) | [RunPython](https://docs.djangoproject.com/en/6.0/ref/migration-operations/#runpython) | SHIPPED | `register_migration_callback!(name, fn)` + `Operation::Callback { name, reverse_name }` (closed #347, v0.42). Migration JSON references the callback by name; runner looks it up in the inventory registry at apply time. Unknown names surface a clear `MigrateError::Validation` with a pointer to the registration macro. The callback runs OUTSIDE the migration's surrounding tx (owned-Pool signature) — operators wanting atomicity should set `atomic: false` on the migration. `sqlmigrate` preview emits `-- RunPython: <name>` as a comment. | |
 | `RunSQL` | [RunSQL](https://docs.djangoproject.com/en/6.0/ref/migration-operations/#runsql) | SHIPPED | `migrate_data::RunSQL` op | Includes `reverse_sql`. |
@@ -209,7 +209,7 @@ Summary: **1 / 1 / 3 / 0**.
 | Schema-mode per-tenant migrations | (Django doesn't ship this) | N/A | `tenancy::migrate` runs per-tenant | Beyond Django's per-DB. |
 | inspectdb (tables + views) | [inspectdb](https://docs.djangoproject.com/en/6.0/ref/django-admin/#inspectdb) | SHIPPED | T2.10 closed — views walked too (PR #304) | |
 
-Summary: **12 SHIPPED / 2 PARTIAL / 1 MISSING / 1 N/A**. Remaining gap: `migrations --merge` for divergent branch chains (#346).
+Summary: **13 SHIPPED / 2 PARTIAL / 0 MISSING / 1 N/A**. Section 5 is fully shipped.
 
 ---
 
@@ -721,7 +721,6 @@ Ranked by how often a real-world Django project hits the gap. Each gets a one-li
 - **`history_view` time-travel (rebuild row from audit log)** — admin history panel is read-only listing today.
 - **Per-request perm cache for `permission_required` middleware** — one `has_perm_pool` round-trip per request; high-RPS admin would benefit from session-level caching.
 - **Maintenance mode UI** (backlog `A6`) — shipped middleware, no template scaffold.
-- **`makemigrations --merge`** for divergent branch chains.
 - **Async signal `m2m_changed`** — currently dispatchers exist for pre/post-save only.
 
 ---


### PR DESCRIPTION
## Summary

Django-parity gap: two engineers each running \`makemigrations\` on a feature branch produce \`0003_a.json\` + \`0003_b.json\` both pointing at \`0002\` as \`prev\`. When their PRs both merge to main, the resulting chain has two leaves on the same parent. Without an explicit reconcile, the next \`makemigrations\` picks one leaf as its \`prev\` arbitrarily and the convergence point is silently lost.

\`makemigrations --merge\` detects two-or-more leaves sharing a parent and writes an empty-forward \`NNNN_merge.json\` whose \`prev\` points at the lex-last leaf. The merge file's snapshot reflects the post-merge cumulative schema (taken from the live registry, since by the time you run \`--merge\` the checkout has both branches' models compiled in). Future \`makemigrations\` diffs against that snapshot.

## Edge cases

- **Linear chain** → \`Ok(None)\`, writes nothing. Running \`--merge\` on a healthy history is a safe no-op.
- **Leaves with different parents** → \`Err\` with a clear message. Legitimately divergent histories (not branch-collisions) need manual reconciliation; same guard Django uses.
- **Empty directory** → \`Err(\"no migrations in directory — nothing to merge\")\`.
- **Combined flags** → rejected: \`--merge\` is exclusive with \`--empty\` / \`--app\` / \`--scope\` / positional name.

## API

\`\`\`rust
// Registry-snapshot version (production path)
migrate::make::make_merge_migration(dir) -> Result<Option<Migration>, MigrateError>

// Testable form — caller supplies the post-merge snapshot
migrate::make::make_merge_migration_from(dir, snapshot)
\`\`\`

CLI: \`manage makemigrations --merge\`.

## Test plan

- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --lib 'migrate::make::tests::merge'\` → 5 unit tests pass (linear chain returns None, empty dir errors, two leaves share parent writes file, leaves with different parents errors, snapshot reflects post-merge schema)
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test migrate_makemigrations_merge_live\` → 2 live tests pass (round-trip through \`file::list_dir\`, single-leaf is no-op)
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --lib\` → 1496 pass (was 1491; +5)
- [x] \`cargo test --workspace --all-features --no-run\` → clean compile
- [x] Pre-push hook gate

## Audit doc

Row flipped MISSING → SHIPPED; section 5 summary now \`13 SHIPPED / 2 PARTIAL / 0 MISSING / 1 N/A\` — Migrations is **fully shipped**. Stale honorable-mentions entry removed.