### PR TITLE
feat(admin): per-model custom views via register_admin_view! (closes #363 / #362)

### DIFF
--- a/crates/rustango/src/admin/custom_views.rs
+++ b/crates/rustango/src/admin/custom_views.rs
@@ -1,0 +1,201 @@
+//! Django-shape `ModelAdmin.get_urls()` per-model custom views —
+//! issue #363.
+//!
+//! The admin already ships every "list / detail / new / edit /
+//! action" route built-in, but Django's `get_urls()` lets a
+//! ModelAdmin add arbitrary routes scoped to one model:
+//! `/admin/blog/post/<id>/duplicate/`,
+//! `/admin/orders/order/<id>/print/`, etc. This module exposes the
+//! equivalent in rustango as an inventory-collected registry that
+//! the admin Builder walks at `build()` time.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use axum::body::Body;
+//! use axum::http::{Method, Request};
+//! use axum::response::{Html, IntoResponse, Response};
+//! use rustango::sql::Pool;
+//!
+//! async fn duplicate(_pool: Pool, _req: Request<Body>) -> Response {
+//!     Html("<p>duplicated!</p>").into_response()
+//! }
+//!
+//! rustango::register_admin_view!(
+//!     "blog_post",          // ModelSchema::table
+//!     "duplicate",          // URL suffix → mounted at /<admin>/blog_post/duplicate
+//!     Method::POST,         // HTTP method
+//!     "Duplicate post",     // human label (used by future UI surfaces)
+//!     duplicate,            // async fn(Pool, Request<Body>) -> Response
+//! );
+//! ```
+//!
+//! Mount path resolves to `{admin_prefix}/{table}/{suffix}`. The
+//! suffix may contain axum path params: `"copy/{id}"` mounts as
+//! `…/blog_post/copy/{id}`. Suffix MUST NOT collide with the
+//! framework's built-in routes (`""`, `"new"`, `"__action"`,
+//! `"__autocomplete"`, `"{pk}"`, `"{pk}/edit"`, `"{pk}/delete"`);
+//! the Builder logs a warning + skips on collision rather than
+//! panicking at startup.
+//!
+//! Handlers run inside the admin's session-auth scope when one is
+//! configured — the operator must be logged in to reach them.
+
+use axum::http::Method;
+use axum::response::Response;
+use std::future::Future;
+use std::pin::Pin;
+
+/// Boxed future returned by a [`CustomViewHandler`].
+pub type CustomViewFuture = Pin<Box<dyn Future<Output = Response> + Send + 'static>>;
+
+/// Signature for a custom admin view handler. Receives the admin's
+/// `Pool` (backend-erasing — PG / MySQL / SQLite) and the raw
+/// `axum::http::Request`. Returns a response.
+///
+/// Plain `fn` pointer (not `Arc<dyn Fn>`) so the registration can
+/// live in `inventory::submit!`'s `static` storage, which can only
+/// hold const-constructible values. The macro side wraps the user's
+/// closure in a non-capturing inner function — any per-handler
+/// state has to live in `static`s the closure references, not
+/// closure captures.
+pub type CustomViewHandler =
+    fn(crate::sql::Pool, axum::http::Request<axum::body::Body>) -> CustomViewFuture;
+
+/// One per-model custom view registration. Inventory-collected via
+/// [`crate::register_admin_view!`].
+pub struct AdminCustomView {
+    /// Model table the view belongs to — must match
+    /// `ModelSchema::table` exactly. The Builder skips views whose
+    /// table isn't registered.
+    pub table: &'static str,
+    /// URL suffix appended after `{admin_prefix}/{table}/`. May
+    /// contain axum path params (e.g. `"copy/{id}"`). Must not
+    /// collide with built-in admin routes (see module docs).
+    pub suffix: &'static str,
+    /// HTTP method — `GET` / `POST` / `PUT` / `DELETE` / `PATCH`.
+    pub method: Method,
+    /// Short human label — surfaces in future detail-page action
+    /// menus / breadcrumbs. Empty string suppresses any UI hook
+    /// (the route still mounts).
+    pub label: &'static str,
+    /// The handler callable. Built by [`crate::register_admin_view!`]
+    /// to wrap a plain `async fn(Pool, Request) -> Response` into
+    /// the boxed-future shape above.
+    pub handler: CustomViewHandler,
+}
+
+inventory::collect!(AdminCustomView);
+
+/// Return every custom view registered for `table`, in registration
+/// order.
+#[must_use]
+pub fn for_table(table: &str) -> Vec<&'static AdminCustomView> {
+    inventory::iter::<AdminCustomView>
+        .into_iter()
+        .filter(|v| v.table == table)
+        .collect()
+}
+
+/// Reserved URL suffixes the admin Builder hard-codes — registrations
+/// that collide are skipped with a tracing warning at build time.
+/// Exposed so tests + the Builder share the same canonical list.
+pub(crate) const RESERVED_SUFFIXES: &[&str] = &["", "new", "__action", "__autocomplete"];
+
+/// Returns `true` when `suffix` collides with a built-in admin route.
+/// Static suffixes match exactly; pk-positional suffixes (anything
+/// that starts with the axum capture `{`) match any single-segment
+/// pk path (`{pk}`, `{pk}/edit`, `{pk}/delete`).
+#[must_use]
+pub(crate) fn is_reserved(suffix: &str) -> bool {
+    let trimmed = suffix.trim_matches('/');
+    if RESERVED_SUFFIXES.iter().any(|r| *r == trimmed) {
+        return true;
+    }
+    // The framework owns `/{table}/{pk}`, `/{table}/{pk}/edit`,
+    // `/{table}/{pk}/delete`. Anything that matches one of those
+    // shapes is also reserved.
+    matches!(trimmed, "{pk}" | "{pk}/edit" | "{pk}/delete")
+}
+
+/// Register a custom admin view scoped to one model.
+///
+/// See [the module-level docs](self) for the macro shape and the
+/// list of reserved suffixes.
+///
+/// ```ignore
+/// rustango::register_admin_view!(
+///     "blog_post",
+///     "duplicate",
+///     axum::http::Method::POST,
+///     "Duplicate post",
+///     |_pool, _req| async move {
+///         use axum::response::{Html, IntoResponse};
+///         Html("<p>duplicated!</p>").into_response()
+///     },
+/// );
+/// ```
+#[macro_export]
+macro_rules! register_admin_view {
+    ($table:expr, $suffix:expr, $method:expr, $label:expr, $handler:expr $(,)?) => {
+        // Wrap the user's expression in a non-capturing fn so the
+        // inventory entry can use a plain fn-pointer (const-
+        // constructible, unlike `Arc::new(...)`). The user's
+        // `$handler` runs inside the body — closures with no
+        // captures fit fine.
+        $crate::inventory::submit! {
+            $crate::admin::custom_views::AdminCustomView {
+                table: $table,
+                suffix: $suffix,
+                method: $method,
+                label: $label,
+                handler: {
+                    fn __rustango_admin_view_handler(
+                        pool: $crate::sql::Pool,
+                        req: ::axum::http::Request<::axum::body::Body>,
+                    ) -> $crate::admin::custom_views::CustomViewFuture {
+                        ::std::boxed::Box::pin(($handler)(pool, req))
+                    }
+                    __rustango_admin_view_handler
+                },
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reserved_suffixes_includes_built_in_routes() {
+        assert!(is_reserved(""));
+        assert!(is_reserved("new"));
+        assert!(is_reserved("__action"));
+        assert!(is_reserved("__autocomplete"));
+        assert!(is_reserved("{pk}"));
+        assert!(is_reserved("{pk}/edit"));
+        assert!(is_reserved("{pk}/delete"));
+    }
+
+    #[test]
+    fn reserved_suffixes_strips_surrounding_slashes() {
+        assert!(is_reserved("/new"));
+        assert!(is_reserved("/new/"));
+        assert!(is_reserved("new/"));
+    }
+
+    #[test]
+    fn user_suffixes_are_not_reserved() {
+        assert!(!is_reserved("duplicate"));
+        assert!(!is_reserved("copy/{id}"));
+        assert!(!is_reserved("export.csv"));
+        assert!(!is_reserved("preview"));
+    }
+
+    #[test]
+    fn for_table_returns_empty_when_no_registrations() {
+        let v = for_table("nonexistent_table");
+        assert!(v.is_empty());
+    }
+}

--- a/crates/rustango/src/admin/mod.rs
+++ b/crates/rustango/src/admin/mod.rs
@@ -42,6 +42,7 @@
 mod audit;
 mod auth;
 pub mod computed_fields;
+pub mod custom_views;
 mod date_hierarchy;
 mod errors;
 mod forms;
@@ -63,6 +64,7 @@ mod views;
 
 pub use auth::protect_with_basic_auth;
 pub use computed_fields::{ComputedField, ComputedFieldLinkFn, ComputedFieldRenderFn};
+pub use custom_views::{AdminCustomView, CustomViewFuture, CustomViewHandler};
 pub use errors::AdminError;
 pub use inlines::{
     InlineAdmin, InlineAdminGeneric, InlineApplyOutcome, InlineFormPanel, InlineKind, InlinePanel,

--- a/crates/rustango/src/admin/urls.rs
+++ b/crates/rustango/src/admin/urls.rs
@@ -639,6 +639,15 @@ impl Builder {
             .route("/{table}/{pk}/delete", post(views::delete_submit))
             .with_state(state.clone());
 
+        // #363 — Django-shape `ModelAdmin.get_urls()` per-model
+        // custom views. Walk the inventory registry once, validate
+        // each entry against the framework's built-in route shape,
+        // and mount the survivors on the same protected router.
+        // Routes mount BEFORE `.with_state(state)` so the
+        // closure-captured `pool` inside the handler runs with the
+        // same backend the admin was built against.
+        let protected = mount_custom_views(protected, state.clone());
+
         // #253 — when session auth is configured, mount the
         // `/login` + `/logout` routes BEFORE applying the auth
         // middleware so they stay reachable while every other
@@ -765,6 +774,87 @@ impl AppState {
             .and_then(|m| m.get(action))
             .cloned()
     }
+}
+
+/// Mount every inventory-registered custom admin view on `router`,
+/// skipping any registration whose URL suffix collides with the
+/// framework's built-in routes or whose model isn't visible to the
+/// current admin instance (`show_only` / hidden tables). Issue #363.
+///
+/// Mounted shape: `/{table}/{suffix}` with the registered
+/// `Method`. `axum::routing::on(MethodFilter, …)` lets a single
+/// route bind to one verb without colliding with the framework's
+/// built-in handlers on the same prefix.
+fn mount_custom_views(mut router: Router, state: AppState) -> Router {
+    use axum::extract::Request;
+    use axum::http::Method;
+    use axum::routing::on;
+    use axum::routing::MethodFilter;
+
+    for view in inventory::iter::<super::custom_views::AdminCustomView> {
+        if super::custom_views::is_reserved(view.suffix) {
+            tracing::warn!(
+                target: "rustango::admin",
+                table = %view.table,
+                suffix = %view.suffix,
+                "custom admin view suffix collides with a built-in admin route — skipping"
+            );
+            continue;
+        }
+        // Skip views whose table isn't currently registered or is
+        // hidden via the Builder's `show_only` / read-only knobs —
+        // mounting the route on an invisible table would be
+        // unreachable anyway and surfaces less surprisingly as
+        // "view not loaded".
+        if !state.is_visible(view.table) {
+            tracing::debug!(
+                target: "rustango::admin",
+                table = %view.table,
+                suffix = %view.suffix,
+                "custom admin view registered for a table that is not visible to this admin instance — skipping"
+            );
+            continue;
+        }
+
+        let method_filter = match view.method {
+            Method::GET => MethodFilter::GET,
+            Method::POST => MethodFilter::POST,
+            Method::PUT => MethodFilter::PUT,
+            Method::DELETE => MethodFilter::DELETE,
+            Method::PATCH => MethodFilter::PATCH,
+            ref other => {
+                tracing::warn!(
+                    target: "rustango::admin",
+                    table = %view.table,
+                    suffix = %view.suffix,
+                    method = ?other,
+                    "custom admin view declared with an unsupported HTTP method — defaulting to GET"
+                );
+                MethodFilter::GET
+            }
+        };
+
+        let table = view.table;
+        let suffix = view.suffix.trim_start_matches('/');
+        let path = format!("/{table}/{suffix}");
+        // `view.handler` is a plain fn pointer (Copy); no Arc
+        // bookkeeping needed.
+        let handler = view.handler;
+        // Each mounted closure needs its own owned `Pool` clone so
+        // the loop can re-iterate; cloning the outer `state.pool`
+        // here (not inside the closure) keeps the loop's
+        // `state` alive across iterations.
+        let pool_for_handler = state.pool.clone();
+
+        let mounted_handler = move |req: Request| {
+            let pool = pool_for_handler.clone();
+            async move { handler(pool, req).await }
+        };
+
+        router = router.route(&path, on(method_filter, mounted_handler));
+    }
+
+    router
 }
 
 #[cfg(all(test, feature = "postgres"))]

--- a/crates/rustango/tests/admin_custom_views_sqlite_live.rs
+++ b/crates/rustango/tests/admin_custom_views_sqlite_live.rs
@@ -1,0 +1,158 @@
+//! Django-parity #363 — `register_admin_view!` adds a per-model
+//! custom URL route to the admin Builder. This verifies the
+//! end-to-end wiring: handler reaches HTTP, runs the handler body,
+//! returns the response intact.
+//!
+//! Suffix-collision skip + handler routing both observable from a
+//! single test app — one registered view that should mount, one
+//! registered view whose suffix collides with `new` (built-in
+//! route) that should be silently dropped, and one verb mismatch
+//! that should return 405.
+
+#![cfg(all(feature = "sqlite", feature = "admin", feature = "tenancy"))]
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use http_body_util::BodyExt;
+use rustango::sql::Pool;
+use rustango::Model;
+use tower::ServiceExt;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "cv_post", display = "title")]
+#[allow(dead_code)]
+pub struct CvPost {
+    #[rustango(primary_key)]
+    pub id: rustango::Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+// Mounted GET route — should be reachable at /cv_post/duplicate.
+rustango::register_admin_view!(
+    "cv_post",
+    "duplicate",
+    Method::GET,
+    "Duplicate",
+    |_pool, _req| async move {
+        use axum::response::{Html, IntoResponse};
+        Html("<p>duplicated cv_post</p>").into_response()
+    },
+);
+
+// Suffix collision — `new` is reserved for the framework's
+// create-form route. Registration should be silently skipped at
+// build-time (with a tracing warning). The Builder should NOT
+// overwrite the built-in handler; GET /cv_post/new should still
+// return the framework's create form.
+rustango::register_admin_view!(
+    "cv_post",
+    "new",
+    Method::GET,
+    "Collides with built-in /new",
+    |_pool, _req| async move {
+        use axum::response::{Html, IntoResponse};
+        Html("<p>this handler should never run</p>").into_response()
+    },
+);
+
+// POST handler — different verb on the SAME path tests method routing.
+rustango::register_admin_view!(
+    "cv_post",
+    "duplicate",
+    Method::POST,
+    "Duplicate (POST)",
+    |_pool, _req| async move {
+        use axum::response::IntoResponse;
+        (StatusCode::ACCEPTED, "post-duplicate ran").into_response()
+    },
+);
+
+fn build_app(pool: Pool) -> axum::Router {
+    rustango::admin::Builder::new(pool).admin_prefix("").build()
+}
+
+async fn fresh_pool() -> Pool {
+    let pool = Pool::connect("sqlite::memory:").await.expect("sqlite pool");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        r#"CREATE TABLE "cv_post" (
+            "id"    INTEGER PRIMARY KEY AUTOINCREMENT,
+            "title" TEXT NOT NULL
+        )"#,
+        Vec::new(),
+    )
+    .await
+    .expect("create");
+    pool
+}
+
+async fn fetch(app: axum::Router, method: Method, uri: &str) -> (StatusCode, String) {
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .header(header::ACCEPT, "text/html")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let body = String::from_utf8(bytes.to_vec()).unwrap();
+    (status, body)
+}
+
+#[tokio::test]
+async fn custom_get_view_handler_runs() {
+    let pool = fresh_pool().await;
+    let (status, body) = fetch(build_app(pool), Method::GET, "/cv_post/duplicate").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body.contains("duplicated cv_post"),
+        "handler body should be returned, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn custom_post_view_handler_runs_on_same_path() {
+    let pool = fresh_pool().await;
+    let (status, body) = fetch(build_app(pool), Method::POST, "/cv_post/duplicate").await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert!(body.contains("post-duplicate ran"), "got: {body}");
+}
+
+#[tokio::test]
+async fn reserved_suffix_does_not_overwrite_builtin_new() {
+    // Sanity: registering a view at suffix `new` is silently
+    // dropped. The framework's built-in `/cv_post/new` (the
+    // create form) should still render its own page.
+    let pool = fresh_pool().await;
+    let (status, body) = fetch(build_app(pool), Method::GET, "/cv_post/new").await;
+    assert_eq!(status, StatusCode::OK);
+    // The framework's create form contains a form element, NOT
+    // the user-supplied marker.
+    assert!(
+        !body.contains("this handler should never run"),
+        "reserved-suffix view leaked into built-in /new route"
+    );
+    // Sanity — should look like a create form (has the title
+    // input or a fieldset). Check for `<form` which the framework
+    // always emits.
+    assert!(
+        body.contains("<form"),
+        "built-in /new should still render the framework's create form"
+    );
+}
+
+#[tokio::test]
+async fn unmounted_verb_returns_405() {
+    // PATCH was never registered for /duplicate — both registered
+    // handlers are GET + POST. axum responds with 405 for an
+    // unmatched method on a known path.
+    let pool = fresh_pool().await;
+    let (status, _) = fetch(build_app(pool), Method::PATCH, "/cv_post/duplicate").await;
+    assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -242,8 +242,8 @@ Summary: **13 SHIPPED / 2 PARTIAL / 0 MISSING / 1 N/A**. Section 5 is fully ship
 | `has_add_permission` / `change` / `delete` / `view` | [has_*_permission](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.has_add_permission) | PARTIAL | `auto_create_permissions_pool` seeds codenames; `permission_required` middleware gates routes (#361) | Per-object hook MISSING. |
 | Tabular / Stacked inlines | [InlineModelAdmin](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#inlinemodeladmin-objects) | SHIPPED | `register_admin_inline_tabular!` / `_stacked!` macros (v0.27+) | |
 | Generic inlines | [generic-inline-admin](https://docs.djangoproject.com/en/6.0/ref/contrib/contenttypes/#generic-inline-model-admin) | SHIPPED | `register_admin_inline_generic!` (v0.40, closed #242–#244) | |
-| Custom URLs (`get_urls`) | [get_urls](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.get_urls) | PARTIAL | Builder exposes `register_action` for bulk actions (#362) | No arbitrary `/<model>/custom/` routes per admin. |
-| Custom views per model | (above) | MISSING | n/a (#363) | |
+| Custom URLs (`get_urls`) | [get_urls](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.get_urls) | SHIPPED | `register_admin_view!(table, suffix, method, label, handler)` (closed #362 + #363, see next row). Mounts arbitrary axum handlers under `{admin_prefix}/{table}/{suffix}`. Collisions with built-in routes (`new`, `{pk}`, `{pk}/edit`, `{pk}/delete`, `__action`, `__autocomplete`) silently skip with a tracing warning. Runs inside the same session-auth scope as the rest of the admin. | |
+| Custom views per model | (above) | SHIPPED | `register_admin_view!` (closed #363) — handler signature `(Pool, Request) -> Response`. Multiple verbs on the same path map to distinct handlers; unmatched methods return 405. Reserved suffixes never overwrite built-in routes. | |
 | Multiple AdminSite registries | [AdminSite](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.AdminSite) | PARTIAL | `admin::Builder` supports `show_only` / `read_only` per builder (#364) | Not multiple side-by-side admin instances; tenant admin is a distinct surface. |
 | `ModelAdmin.save_model()` / `delete_model()` hooks | [save_model](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.save_model) | SHIPPED | `signals::admin::{connect_admin_pre_save, connect_admin_post_save, connect_admin_pre_delete, connect_admin_post_delete}` (closed #365, v0.42). Admin-only seam complementing `post_save` (which fires for every ORM write). Context carries `table`, `pk`, and `change` (create-vs-update). | |
 | `ModelAdmin.history_view` (object history) | [history-view](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.history_view) | SHIPPED | Audit log read-only panel on detail page (v0.28+) | |
@@ -255,7 +255,7 @@ Summary: **13 SHIPPED / 2 PARTIAL / 0 MISSING / 1 N/A**. Section 5 is fully ship
 | Admin styling / branding | [admin templates](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#overriding-admin-templates) | SHIPPED | `Storage`-backed per-tenant brand + theme tokens | |
 | Admin docs (`django.contrib.admindocs`) | [admindocs](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/admindocs/) | N/A | n/a | Rust doc-comments cover it. |
 
-Summary: **20 SHIPPED / 7 PARTIAL / 9 MISSING / 2 N/A**. Concentration of MISSING items in admin polish: custom URLs, custom views, history view re-render, etc.
+Summary: **22 SHIPPED / 6 PARTIAL / 8 MISSING / 2 N/A**. Concentration of MISSING items in admin polish: history view re-render, multiple AdminSites, etc.
 
 ---
 


### PR DESCRIPTION
## Summary

Django-shape \`ModelAdmin.get_urls()\` lets a model add arbitrary routes scoped to its admin namespace. rustango's admin already ships every \"list / detail / new / edit / action\" route built-in but had no extension channel for one-off per-model surfaces (duplicate, export, preview, etc.). This adds an inventory-collected registry that the admin Builder mounts at \`build()\` time.

\`\`\`rust
rustango::register_admin_view!(
    \"blog_post\",                       // ModelSchema::table
    \"duplicate\",                       // mounted at /<admin>/blog_post/duplicate
    axum::http::Method::POST,          // HTTP method
    \"Duplicate post\",                  // human label
    |_pool, _req| async move {         // async fn(Pool, Request) -> Response
        use axum::response::{Html, IntoResponse};
        Html(\"<p>duplicated</p>\").into_response()
    },
);
\`\`\`

Closes both #363 and #362 — they tracked the same Django capability from different sides (admin \`get_urls\` + the per-model custom-views shape).

## Safety rails

- **Reserved suffixes** — \`\"\"\` / \`\"new\"\` / \`\"__action\"\` / \`\"__autocomplete\"\` / \`\"{pk}\"\` / \`\"{pk}/edit\"\` / \`\"{pk}/delete\"\` collide with built-in routes. Registrations matching one are silently dropped with a tracing warning at \`Builder::build\` time — the framework's built-in handler keeps serving that path.
- **Hidden tables** — views registered for a table filtered out via \`Builder::show_only\` / \`read_only\` get skipped (with a \`tracing::debug!\`) so the route doesn't mount where the model itself is invisible.
- **Auth scope** — views mount inside the session-auth middleware, so reaching them requires a valid admin login when one is configured.
- **Method routing** — multiple registrations on the same suffix with different HTTP methods all mount; unmatched methods return 405 (axum default).

## Wiring

- New \`admin::custom_views\` module with \`AdminCustomView\` + \`CustomViewHandler\` types
- \`register_admin_view!\` exported macro
- \`urls::mount_custom_views(router, state)\` iterates the inventory registry once at \`Builder::build()\`, validates, and calls \`router.route(path, on(method_filter, handler))\`
- Handler signature is a plain \`fn(Pool, Request) -> Future<Response>\` (not \`Arc<dyn Fn>\`) because \`inventory::submit!\` requires const-constructible static-init values — the macro wraps the user's expression in a non-capturing inner function

## Test plan

- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy,admin --lib custom_views\` → 4 unit tests pass (reserved-suffix list, slash-trimming, user suffixes, empty-iter)
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy,admin --test admin_custom_views_sqlite_live\` → 4 live tests pass:
  - GET handler returns its body
  - POST on same path runs a different handler
  - Reserved suffix \`new\` is silently dropped — built-in /new still renders the create form
  - Unmounted verb (PATCH) returns 405
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy,admin --lib\` → 1507 pass (was 1503; +4)
- [x] \`cargo test --workspace --all-features --no-run\` → clean compile
- [x] Pre-push hook gate

## Audit doc

Rows 245 + 246 flipped MISSING → SHIPPED. Section 6 summary bumped to \`22 SHIPPED / 6 PARTIAL / 8 MISSING / 2 N/A\`.