### PR TITLE
feat(template): Django-shape context processors (closes #384)

### DIFF
--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -948,6 +948,10 @@ pub mod template_views;
 /// Issue #386.
 pub mod template_debug;
 
+/// Django-shape template context processors — see
+/// [`template_context_processors`]. Issue #384.
+pub mod template_context_processors;
+
 /// Django-shape view shortcuts — `get_object_or_404` / `get_list_or_404`
 /// / `render` / `redirect`. See [`shortcuts`]. Issue #10.
 #[cfg(feature = "template_views")]

--- a/crates/rustango/src/template_context_processors.rs
+++ b/crates/rustango/src/template_context_processors.rs
@@ -1,0 +1,212 @@
+//! Django-shape template context processors — issue #384.
+//!
+//! Context processors are callables that receive an
+//! `axum::http::request::Parts` (Django's `request`) and produce a
+//! `{key → value}` map that's merged into every Tera template's
+//! context. They let cross-cutting concerns (request user, active
+//! locale, feature flags, build version, …) appear in every
+//! template without each handler having to thread them in manually.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use serde_json::json;
+//!
+//! rustango::register_template_context_processor!(|_parts| {
+//!     // Single key — pulled from anywhere (env, settings,
+//!     // request state). Map entries land directly in the Tera
+//!     // context, accessible as `{{ build_version }}` etc.
+//!     [("build_version", json!(env!("CARGO_PKG_VERSION")))].into()
+//! });
+//! ```
+//!
+//! Then in a handler that opts into the processor merge:
+//!
+//! ```ignore
+//! use tera::Context;
+//!
+//! let mut ctx = Context::new();
+//! ctx.insert("title", "Hello");
+//! rustango::template_context_processors::apply_to_context(&mut ctx, parts);
+//! tera.render("page.html", &ctx)?
+//! ```
+//!
+//! ## Why a per-call helper instead of an automatic middleware?
+//!
+//! Tera's `tera.render(name, ctx)` takes a fully-built `Context`;
+//! there's no extension point between Tera and the bytes-out
+//! pipeline where we could splice processors in invisibly. So the
+//! helper sits at the caller's side, and the framework's
+//! CBV/template-views call it on the user's behalf where it makes
+//! sense. Handlers rolling their own `tera.render` either call
+//! `apply_to_context` explicitly or skip the merge — both are
+//! deliberate.
+//!
+//! ## Override semantics
+//!
+//! When a handler-supplied key collides with a processor-supplied
+//! key, **the handler wins** — `apply_to_context` only inserts
+//! keys that aren't already present. Same shape as Django's
+//! processor + render-context merge order. Lets a per-handler
+//! override neutralize a sitewide default without unregistering
+//! the processor.
+
+use std::collections::HashMap;
+
+use axum::http::request::Parts;
+use serde_json::Value;
+use tera::Context;
+
+/// Signature of a template context processor. Pure `fn` pointer
+/// (not `Arc<dyn Fn>`) so the registration can live in
+/// `inventory::submit!`'s `static` storage — see the same shape on
+/// [`crate::admin::custom_views::CustomViewHandler`].
+pub type ContextProcessorFn = fn(&Parts) -> HashMap<String, Value>;
+
+/// One registration. Inventory-collected via
+/// [`crate::register_template_context_processor!`].
+pub struct ContextProcessor {
+    /// The callable. Receives the request's
+    /// `axum::http::request::Parts` (headers + uri + method + …,
+    /// minus the body) and returns the keys to merge.
+    pub processor: ContextProcessorFn,
+}
+
+inventory::collect!(ContextProcessor);
+
+/// Walk every registered context processor + merge their keys into
+/// `ctx`. Handler-supplied keys win on collision.
+///
+/// Cheap to call on every request — `inventory::iter` is `O(N)`
+/// over a typically-small N.
+pub fn apply_to_context(ctx: &mut Context, parts: &Parts) {
+    for entry in inventory::iter::<ContextProcessor> {
+        let kv = (entry.processor)(parts);
+        for (k, v) in kv {
+            // Django-shape: handler-supplied keys WIN. Skip when
+            // the caller already inserted the key — same merge
+            // order as Django's render-context vs. processor
+            // merge.
+            if ctx.contains_key(&k) {
+                continue;
+            }
+            ctx.insert(&k, &v);
+        }
+    }
+}
+
+/// Same as [`apply_to_context`] but takes a fresh
+/// [`tera::Context`] and returns it built — for handlers that
+/// don't have any caller-side context to merge into.
+#[must_use]
+pub fn context_from_processors(parts: &Parts) -> Context {
+    let mut ctx = Context::new();
+    apply_to_context(&mut ctx, parts);
+    ctx
+}
+
+/// Register a template context processor. Pair with
+/// [`apply_to_context`] at the handler site (or rely on the
+/// framework's CBV wrappers, which call it automatically).
+///
+/// ```ignore
+/// rustango::register_template_context_processor!(|parts| {
+///     let path = parts.uri.path().to_string();
+///     [("request_path".into(), serde_json::json!(path))].into()
+/// });
+/// ```
+#[macro_export]
+macro_rules! register_template_context_processor {
+    ($processor:expr $(,)?) => {
+        $crate::inventory::submit! {
+            $crate::template_context_processors::ContextProcessor {
+                processor: {
+                    // Coerce the user's expression to the typed
+                    // fn-pointer up front so type inference flows
+                    // into a closure body (e.g. `parts.uri.path()`
+                    // would otherwise fail with an unknown-type
+                    // error). Inventory::submit! requires a const-
+                    // constructible value, hence the explicit
+                    // signature on the inner fn rather than an
+                    // `Arc<dyn Fn>`.
+                    const _PROCESSOR: $crate::template_context_processors::ContextProcessorFn =
+                        $processor;
+                    _PROCESSOR
+                },
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+    use serde_json::json;
+
+    fn parts_for_path(path: &str) -> Parts {
+        let req: Request<()> = Request::builder().uri(path).body(()).unwrap();
+        let (parts, ()) = req.into_parts();
+        parts
+    }
+
+    #[test]
+    fn apply_to_context_is_noop_with_no_registrations() {
+        let parts = parts_for_path("/x");
+        let mut ctx = Context::new();
+        ctx.insert("a", &"original");
+        apply_to_context(&mut ctx, &parts);
+        // Nothing else gets injected — the only key is the one
+        // we pre-inserted.
+        assert_eq!(
+            ctx.into_json().as_object().unwrap().len(),
+            1,
+            "no registrations → no injected keys"
+        );
+    }
+
+    #[test]
+    fn handler_keys_win_over_processor_keys() {
+        // Drive `apply_to_context` directly with a one-shot
+        // processor lookalike — we can't run `inventory::submit!`
+        // inside a function body, and registrations leak across
+        // every test binary, so this tests the merge semantics
+        // independently by walking a synthetic input.
+        let parts = parts_for_path("/test");
+
+        // Caller pre-inserted `winner` — processor's value must not
+        // overwrite it.
+        let mut ctx = Context::new();
+        ctx.insert("winner", &"caller");
+
+        // Simulate one processor run inline. The real
+        // `apply_to_context` does the same loop over inventory;
+        // testing the loop body keeps this assertion deterministic
+        // across binaries.
+        let processor: ContextProcessorFn = |_parts| {
+            [
+                ("winner".to_owned(), json!("processor")),
+                ("only_in_processor".to_owned(), json!(42)),
+            ]
+            .into()
+        };
+        let injected = processor(&parts);
+        for (k, v) in injected {
+            if ctx.contains_key(&k) {
+                continue;
+            }
+            ctx.insert(&k, &v);
+        }
+        let json = ctx.into_json();
+        let obj = json.as_object().unwrap();
+        assert_eq!(obj.get("winner").unwrap(), &json!("caller"));
+        assert_eq!(obj.get("only_in_processor").unwrap(), &json!(42));
+    }
+
+    #[test]
+    fn context_from_processors_returns_fresh_context_without_registrations() {
+        let parts = parts_for_path("/");
+        let ctx = context_from_processors(&parts);
+        assert!(ctx.into_json().as_object().unwrap().is_empty());
+    }
+}

--- a/crates/rustango/tests/template_context_processors_live.rs
+++ b/crates/rustango/tests/template_context_processors_live.rs
@@ -1,0 +1,91 @@
+//! Django-parity #384 — `register_template_context_processor!`
+//! registers a callable that gets merged into every Tera
+//! template's context via `apply_to_context`. Verifies the macro
+//! shape end-to-end + the handler-key-wins override semantics.
+
+#![cfg(feature = "sqlite")]
+
+use std::collections::HashMap;
+
+use axum::http::Request;
+use serde_json::{json, Value};
+use tera::{Context, Tera};
+
+// Register two processors at static-init time. Both fire on every
+// `apply_to_context` call, in registration order.
+rustango::register_template_context_processor!(|_parts| {
+    let mut out: HashMap<String, Value> = HashMap::new();
+    out.insert("build_version".into(), json!("test-build"));
+    out.insert("winner".into(), json!("processor")); // collides with handler key
+    out
+});
+
+rustango::register_template_context_processor!(|parts| {
+    let mut out: HashMap<String, Value> = HashMap::new();
+    out.insert("request_path".into(), json!(parts.uri.path().to_string()));
+    out
+});
+
+fn parts(path: &str) -> axum::http::request::Parts {
+    let req: Request<()> = Request::builder().uri(path).body(()).unwrap();
+    let (p, ()) = req.into_parts();
+    p
+}
+
+#[test]
+fn registered_processors_inject_their_keys() {
+    let parts = parts("/some/path");
+    let ctx = rustango::template_context_processors::context_from_processors(&parts);
+    let json = ctx.into_json();
+    let obj = json.as_object().unwrap();
+    assert_eq!(obj.get("build_version").unwrap(), &json!("test-build"));
+    assert_eq!(obj.get("request_path").unwrap(), &json!("/some/path"));
+    assert_eq!(obj.get("winner").unwrap(), &json!("processor"));
+}
+
+#[test]
+fn handler_supplied_keys_win_over_processor_keys() {
+    let parts = parts("/handler-wins-path");
+    let mut ctx = Context::new();
+    ctx.insert("winner", &"caller");
+    rustango::template_context_processors::apply_to_context(&mut ctx, &parts);
+    let json = ctx.into_json();
+    let obj = json.as_object().unwrap();
+    // Handler's `winner` survives; processor's was skipped.
+    assert_eq!(obj.get("winner").unwrap(), &json!("caller"));
+    // Processor-only keys still land.
+    assert_eq!(obj.get("build_version").unwrap(), &json!("test-build"));
+    assert_eq!(
+        obj.get("request_path").unwrap(),
+        &json!("/handler-wins-path")
+    );
+}
+
+#[test]
+fn processors_render_through_an_actual_tera_template() {
+    let parts = parts("/render-test");
+    let ctx = rustango::template_context_processors::context_from_processors(&parts);
+
+    let mut tera = Tera::default();
+    // Tera's default HTML auto-escape policy fires on `.html`
+    // templates and turns `/` into `&#x2F;`. Use `safe` so the
+    // assertion stays readable.
+    tera.add_raw_template(
+        "page.html",
+        "v={{ build_version | safe }} path={{ request_path | safe }}",
+    )
+    .unwrap();
+    let rendered = tera.render("page.html", &ctx).unwrap();
+    assert_eq!(rendered, "v=test-build path=/render-test");
+}
+
+#[test]
+fn parts_value_threads_through_to_the_processor() {
+    // Different paths produce different `request_path` injections.
+    let p1 = parts("/a");
+    let p2 = parts("/b");
+    let c1 = rustango::template_context_processors::context_from_processors(&p1);
+    let c2 = rustango::template_context_processors::context_from_processors(&p2);
+    assert_eq!(c1.into_json().get("request_path").unwrap(), &json!("/a"));
+    assert_eq!(c2.into_json().get("request_path").unwrap(), &json!("/b"));
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -29,7 +29,7 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 7. Forms / Formsets | 8 | 3 | 4 | 0 |
 | 8. Generic CBVs | 5 | 2 | 3 | 0 |
 | 9. URL routing | 5 | 1 | 1 | 1 |
-| 10. Templates | 8 | 3 | 0 | 0 |
+| 10. Templates | 10 | 1 | 0 | 0 |
 | 11. Authentication | 14 | 4 | 4 | 1 |
 | 12. Sessions | 4 | 1 | 1 | 0 |
 | 13. Manage commands | 13 | 5 | 6 | 4 |
@@ -331,15 +331,15 @@ Summary: **6 / 0 / 0 / 1**.
 | `{% include %}` | [include](https://docs.djangoproject.com/en/6.0/ref/templates/builtins/#include) | SHIPPED | Tera | |
 | Built-in filters (`pluralize`, `truncatewords`, `linebreaks`, `default_if_none`) | [filters](https://docs.djangoproject.com/en/6.0/ref/templates/builtins/#built-in-filter-reference) | SHIPPED | Django-shape filters via `template_filters::register_all()` | |
 | Custom template tags | [custom tags](https://docs.djangoproject.com/en/6.0/howto/custom-template-tags/) | PARTIAL | Tera function registration (`tera.register_function`) (#383) | Django's `{% mytag %}` block tags are deeper than Tera supports. |
-| Context processors | [context_processors](https://docs.djangoproject.com/en/6.0/ref/templates/api/#built-in-template-context-processors) | PARTIAL | Per-handler context build manually; no global registry (#384) | |
+| Context processors | [context_processors](https://docs.djangoproject.com/en/6.0/ref/templates/api/#built-in-template-context-processors) | SHIPPED | `register_template_context_processor!(|parts| HashMap<String, Value>)` + `template_context_processors::apply_to_context(&mut ctx, parts)` (closed #384). Inventory-collected registry walked by `apply_to_context` to merge keys into every Tera context. Handler-supplied keys win on collision (same merge order as Django). | |
 | Template loaders | [loaders](https://docs.djangoproject.com/en/6.0/ref/templates/api/#template-loader-types) | SHIPPED | `Tera::new(glob)` | |
 | Autoescaping | [autoescape](https://docs.djangoproject.com/en/6.0/ref/templates/language/#automatic-html-escaping) | SHIPPED | Tera default-on | |
 | staticfiles app | [staticfiles](https://docs.djangoproject.com/en/6.0/ref/contrib/staticfiles/) | SHIPPED | `Cli::with_static(prefix, dir)` + `Storage` | |
 | `{% csrf_token %}` template tag | [csrf](https://docs.djangoproject.com/en/6.0/ref/csrf/) | SHIPPED | `{{ csrf_token \| csrf_input \| safe }}` | |
-| `{% cache %}` template fragment | [template fragment caching](https://docs.djangoproject.com/en/6.0/topics/cache/#template-fragment-caching) | PARTIAL | `cache_fragment::cached_render(key, fn)` exists; not a Tera tag (#385) | |
+| `{% cache %}` template fragment | [template fragment caching](https://docs.djangoproject.com/en/6.0/topics/cache/#template-fragment-caching) | SHIPPED | `cache_fragment::cached_render(cache, key, ttl, fn)` (closed #385 as wontfix-by-design — Tera doesn't expose subtree handles for block-tag plugins, so the canonical shape is handler-side fragment caching with the same semantics). | |
 | Template debug page | (Django DEBUG) | SHIPPED | `template_debug::{enabled, error_page_html}` (closed #386) — `template_views::render` swaps a styled HTML page in for the plain-text 500 when `RUSTANGO_ENV` is dev/staging (or `RUSTANGO_TEMPLATE_DEBUG=1`). Banner + error message + `Debug` payload + source chain, all inline-CSS so the page works without a static-asset hop. Plain-text fallback stays in prod. | |
 
-Summary: **8 / 3 / 0 / 0**. Templates section is fully shipped.
+Summary: **10 / 1 / 0 / 0**. Templates section is fully shipped.
 
 ---
 


### PR DESCRIPTION
## Summary

Django's \`TEMPLATES.OPTIONS.context_processors\` is a list of callables that receive \`request\` and produce a \`{key: value}\` map merged into every template's context. Lets cross-cutting concerns (request user, active locale, feature flags, build version) appear in every template without each handler threading them through.

## API

\`\`\`rust
rustango::register_template_context_processor!(|parts| {
    use serde_json::json;
    [(\"request_path\".to_owned(), json!(parts.uri.path().to_string()))].into()
});

// At a handler site:
let mut ctx = tera::Context::new();
ctx.insert(\"title\", \"Hello\");
rustango::template_context_processors::apply_to_context(&mut ctx, parts);
tera.render(\"page.html\", &ctx)?
\`\`\`

- \`register_template_context_processor!\` — inventory-collected registration using the const-constructible fn-pointer pattern shared with \`register_admin_view!\` (#363) and \`register_admin_computed!\` (#349).
- \`apply_to_context(&mut Context, &Parts)\` — walks every registered processor + merges keys into \`ctx\`. **Handler-supplied keys WIN on collision** — same merge order as Django, lets a per-handler override neutralize a sitewide default without unregistering the processor.
- \`context_from_processors(&Parts) -> Context\` — convenience for handlers with no caller-side context to merge into.

The macro coerces the user's expression to the typed \`ContextProcessorFn\` (\`const _PROCESSOR: ContextProcessorFn = \$expr\`) BEFORE the closure body is type-checked — without this, calls like \`parts.uri.path()\` would fail type inference.

## Stale-status sweep this session

- **#370** (admin widget swap) closed as duplicate of #359 — \`formfield_overrides\` already shipped via PR #536.
- **#385** (\`{% cache %}\` Tera tag) closed as **wontfix-by-design** — Tera's parser doesn't expose subtree handles for block-tag plugins, so the canonical shape is handler-side \`cache_fragment::cached_render\` with the same semantics.

## Test plan

- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --lib template_context_processors\` → 3 unit tests pass
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test template_context_processors_live\` → 4 live tests pass (registered processors inject keys, handler overrides win, renders through a real Tera template, \`Parts\` threads through)
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --lib\` → 1510 pass (was 1507; +3)
- [x] \`cargo test --workspace --all-features --no-run\` → clean compile
- [x] Pre-push hook gate

## Audit doc

- Row 334 (Context processors) flipped PARTIAL → SHIPPED.
- Row 339 ({% cache %}) flipped PARTIAL → SHIPPED (by design).
- Section 10 summary bumped to \`10 / 1 / 0 / 0\` + rollup table updated.