### PR TITLE
feat(cbv): context_object_name + lookup_field on ListView/DetailView (closes #379)

### DIFF
--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -77,7 +77,7 @@ use axum::Router;
 use serde_json::Value;
 use tera::{Context, Tera};
 
-use crate::core::{Filter, ModelSchema, Op, SelectQuery, SqlValue, WhereExpr};
+use crate::core::{FieldSchema, Filter, ModelSchema, Op, SelectQuery, SqlValue, WhereExpr};
 use crate::sql::Pool;
 use crate::sql::{count_rows_pool, select_one_row_as_json, select_rows_as_json};
 
@@ -191,6 +191,11 @@ pub struct ListView {
     /// usually cheap but isn't free. Opt in via
     /// [`Self::with_fk_display`].
     fk_display: bool,
+    /// #379 — Django-shape `context_object_name`. Binds the row
+    /// list under a custom Tera variable in addition to the
+    /// default `object_list`. Empty (the default) skips the
+    /// extra binding.
+    context_object_name: String,
 }
 
 impl ListView {
@@ -215,7 +220,25 @@ impl ListView {
             confirm_delete: false,
             confirm_delete_template: None,
             fk_display: false,
+            context_object_name: String::new(),
         }
+    }
+
+    /// Django-shape `context_object_name` — bind the row list
+    /// under a custom Tera variable in addition to the default
+    /// `object_list`. Issue #379. Empty string (the default)
+    /// leaves only `object_list`.
+    ///
+    /// ```ignore
+    /// ListView::for_model(Post::SCHEMA)
+    ///     .context_object_name("posts")
+    /// // template can now read `{% for post in posts %}` AND
+    /// // `{% for post in object_list %}` — both work.
+    /// ```
+    #[must_use]
+    pub fn context_object_name(mut self, name: impl Into<String>) -> Self {
+        self.context_object_name = name.into();
+        self
     }
 
     /// Override the Tera template name.
@@ -614,6 +637,12 @@ async fn handle_list(
     let total_pages = ((total - 1).max(0) / page_size) + 1;
     let mut ctx = Context::new();
     ctx.insert("object_list", &object_list);
+    // #379 — Django-shape `context_object_name`. Adds a second
+    // binding so templates can read `{{ posts }}` instead of
+    // `{{ object_list }}`. Empty (the default) skips the rename.
+    if !state.vs.context_object_name.is_empty() {
+        ctx.insert(&state.vs.context_object_name, &object_list);
+    }
     ctx.insert("page", &page);
     ctx.insert("page_size", &page_size);
     ctx.insert("total", &total);
@@ -753,6 +782,18 @@ pub struct DetailView {
     schema: &'static ModelSchema,
     template: String,
     fields: Option<Vec<String>>,
+    /// #379 — Django-shape `context_object_name`. Renames the row
+    /// under a custom Tera variable name. The legacy `"object"`
+    /// key stays populated for back-compat; this just adds a
+    /// second binding so templates can read `{{ post.title }}`
+    /// instead of `{{ object.title }}`. Empty → no rename.
+    context_object_name: String,
+    /// #379 — Django-shape `slug_field` / `slug_url_kwarg`. When
+    /// non-empty, the URL captures the lookup value as `{lookup}`
+    /// (instead of `{pk}`) and the SELECT predicate matches
+    /// `WHERE <lookup_field> = <captured>` instead of `WHERE pk =
+    /// <captured>`. Useful for `/posts/{slug}` style URLs.
+    lookup_field: Option<String>,
 }
 
 impl DetailView {
@@ -762,6 +803,8 @@ impl DetailView {
             schema,
             template: format!("{}_detail.html", schema.table),
             fields: None,
+            context_object_name: String::new(),
+            lookup_field: None,
         }
     }
 
@@ -774,6 +817,42 @@ impl DetailView {
     #[must_use]
     pub fn fields(mut self, names: &[&str]) -> Self {
         self.fields = Some(names.iter().map(|s| (*s).to_owned()).collect());
+        self
+    }
+
+    /// Django-shape `context_object_name` — bind the row under a
+    /// custom Tera variable in addition to the default `object`.
+    /// Issue #379. Empty string (the default) leaves only the
+    /// `object` binding.
+    ///
+    /// ```ignore
+    /// // /posts/{pk} → template reads `{{ post.title }}`
+    /// DetailView::for_model(Post::SCHEMA)
+    ///     .context_object_name("post")
+    /// ```
+    #[must_use]
+    pub fn context_object_name(mut self, name: impl Into<String>) -> Self {
+        self.context_object_name = name.into();
+        self
+    }
+
+    /// Django-shape `slug_field` — look up the row by a non-PK
+    /// column. The captured URL segment matches against the named
+    /// column instead of the model's primary key. Issue #379.
+    ///
+    /// Field name must exist on the schema (Rust field name OR
+    /// SQL column name); unknown names produce a 500 at request
+    /// time with a clear `template render error: unknown lookup
+    /// field …` message.
+    ///
+    /// ```ignore
+    /// // /posts/{slug} → SELECT … WHERE slug = $1
+    /// DetailView::for_model(Post::SCHEMA)
+    ///     .lookup_field("slug")
+    /// ```
+    #[must_use]
+    pub fn lookup_field(mut self, column: impl Into<String>) -> Self {
+        self.lookup_field = Some(column.into());
         self
     }
 
@@ -813,18 +892,20 @@ async fn handle_detail(
     State(state): State<Arc<DetailViewState>>,
     Path(pk): Path<String>,
 ) -> Response {
-    let Some(pk_field) = state.vs.schema.primary_key() else {
-        return template_error(&format!(
-            "model `{}` has no primary key — DetailView can't probe by PK",
-            state.vs.schema.table
-        ));
+    // #379 — `lookup_field` opt-in: probe by the named column
+    // instead of the PK. Validate the name maps to a real field
+    // up front so the predicate carries a real `&'static str`
+    // column ident.
+    let lookup = match resolve_lookup_field(state.vs.schema, state.vs.lookup_field.as_deref()) {
+        Ok(f) => f,
+        Err(e) => return template_error(&e),
     };
     let select_q = SelectQuery {
         model: state.vs.schema,
         where_clause: WhereExpr::Predicate(Filter {
-            column: pk_field.column,
+            column: lookup.column,
             op: Op::Eq,
-            value: coerce_pk(pk_field, &pk),
+            value: coerce_pk(lookup, &pk),
         }),
         search: None,
         joins: vec![],
@@ -845,8 +926,42 @@ async fn handle_detail(
 
     let mut ctx = Context::new();
     ctx.insert("object", &object);
+    if !state.vs.context_object_name.is_empty() {
+        ctx.insert(&state.vs.context_object_name, &object);
+    }
 
     render(&state.tera, &state.vs.template, &ctx)
+}
+
+/// Resolve the DetailView lookup column (#379). Returns the PK
+/// field when `lookup_field` is `None`; otherwise the named
+/// field. Errors when the schema has no PK and no lookup_field
+/// set, or when the lookup_field name doesn't resolve.
+fn resolve_lookup_field(
+    schema: &'static ModelSchema,
+    lookup_field: Option<&str>,
+) -> Result<&'static FieldSchema, String> {
+    if let Some(name) = lookup_field {
+        // Match by Rust field name OR SQL column — same shape as
+        // resolved_fields and the rest of the framework's
+        // user-facing name resolution.
+        if let Some(f) = schema
+            .scalar_fields()
+            .find(|f| f.name == name || f.column == name)
+        {
+            return Ok(f);
+        }
+        return Err(format!(
+            "DetailView::lookup_field(\"{name}\") doesn't match any scalar field on `{}`",
+            schema.table
+        ));
+    }
+    schema.primary_key().ok_or_else(|| {
+        format!(
+            "model `{}` has no primary key — DetailView can't probe without an explicit lookup_field",
+            schema.table
+        )
+    })
 }
 
 // ============================================================== DeleteView
@@ -3345,6 +3460,11 @@ mod tenant {
         let total_pages = ((total - 1).max(0) / page_size) + 1;
         let mut ctx = Context::new();
         ctx.insert("object_list", &object_list);
+        // #379 — context_object_name (see non-tenant variant for
+        // semantics).
+        if !state.vs.context_object_name.is_empty() {
+            ctx.insert(&state.vs.context_object_name, &object_list);
+        }
         ctx.insert("page", &page);
         ctx.insert("page_size", &page_size);
         ctx.insert("total", &total);
@@ -3485,18 +3605,20 @@ mod tenant {
         Path(pk): Path<String>,
         t: Tenant,
     ) -> Response {
-        let Some(pk_field) = state.vs.schema.primary_key() else {
-            return template_error(&format!(
-                "model `{}` has no primary key — DetailView can't probe by PK",
-                state.vs.schema.table
-            ));
-        };
+        // #379 — `lookup_field` opt-in: probe by the named column
+        // instead of the PK. Tenant variant mirrors the
+        // non-tenant `handle_detail`.
+        let lookup =
+            match super::resolve_lookup_field(state.vs.schema, state.vs.lookup_field.as_deref()) {
+                Ok(f) => f,
+                Err(e) => return template_error(&e),
+            };
         let select_q = SelectQuery {
             model: state.vs.schema,
             where_clause: WhereExpr::Predicate(Filter {
-                column: pk_field.column,
+                column: lookup.column,
                 op: Op::Eq,
-                value: coerce_pk(pk_field, &pk),
+                value: coerce_pk(lookup, &pk),
             }),
             search: None,
             joins: vec![],
@@ -3517,6 +3639,9 @@ mod tenant {
 
         let mut ctx = Context::new();
         ctx.insert("object", &object);
+        if !state.vs.context_object_name.is_empty() {
+            ctx.insert(&state.vs.context_object_name, &object);
+        }
         render(&state.tera, &state.vs.template, &ctx)
     }
 

--- a/crates/rustango/tests/template_views_context_object_name_sqlite_live.rs
+++ b/crates/rustango/tests/template_views_context_object_name_sqlite_live.rs
@@ -1,0 +1,165 @@
+//! Django-parity #379 — `ListView::context_object_name` /
+//! `DetailView::context_object_name` / `DetailView::lookup_field`.
+//! Verifies the Tera context picks up the renamed binding and
+//! that `lookup_field` lets the DetailView probe by a non-PK
+//! column.
+
+#![cfg(all(feature = "template_views", feature = "sqlite"))]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use rustango::core::Model as _;
+use rustango::sql::{Auto, Pool};
+use rustango::template_views::{DetailView, ListView};
+use rustango::Model;
+use tera::Tera;
+use tower::ServiceExt;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "ctx_post", display = "title")]
+#[allow(dead_code)]
+pub struct CtxPost {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 200, unique)]
+    pub slug: String,
+}
+
+async fn fresh_pool() -> Pool {
+    let pool = Pool::connect("sqlite::memory:").await.expect("sqlite pool");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        r#"CREATE TABLE ctx_post (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            slug  TEXT NOT NULL UNIQUE
+        )"#,
+        Vec::new(),
+    )
+    .await
+    .expect("create");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        "INSERT INTO ctx_post (id, title, slug) VALUES (1, 'Hello', 'hello'), (2, 'World', 'world')",
+        Vec::new(),
+    )
+    .await
+    .expect("seed");
+    pool
+}
+
+fn tera_with(name: &str, body: &str) -> Arc<Tera> {
+    let mut t = Tera::default();
+    t.add_raw_template(name, body).unwrap();
+    Arc::new(t)
+}
+
+async fn body_of(app: axum::Router, path: &str) -> (StatusCode, String) {
+    let resp = app
+        .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8(bytes.to_vec()).unwrap())
+}
+
+#[tokio::test]
+async fn list_view_binds_context_object_name_alongside_object_list() {
+    let pool = fresh_pool().await;
+    let tera = tera_with(
+        "ctx_post_list.html",
+        "alt={{ posts | length }} legacy={{ object_list | length }}",
+    );
+    let view = ListView::for_model(CtxPost::SCHEMA).context_object_name("posts");
+    let app = view.router("/posts", tera, pool);
+    let (status, body) = body_of(app, "/posts").await;
+    assert_eq!(status, StatusCode::OK);
+    // Both bindings should resolve to 2 rows.
+    assert!(
+        body.contains("alt=2"),
+        "renamed binding missing, got {body}"
+    );
+    assert!(
+        body.contains("legacy=2"),
+        "default object_list still wired for back-compat, got {body}"
+    );
+}
+
+#[tokio::test]
+async fn list_view_without_context_object_name_only_binds_object_list() {
+    let pool = fresh_pool().await;
+    // `posts` here is NOT defined; default(value="MISSING") catches
+    // it. Tera evaluates undefined variable references against
+    // `into_json` and would raise if not guarded.
+    let tera = tera_with(
+        "ctx_post_list.html",
+        r#"alt={{ posts | default(value="MISSING") }} legacy={{ object_list | length }}"#,
+    );
+    let view = ListView::for_model(CtxPost::SCHEMA);
+    let app = view.router("/posts", tera, pool);
+    let (status, body) = body_of(app, "/posts").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("alt=MISSING"), "got {body}");
+    assert!(body.contains("legacy=2"), "got {body}");
+}
+
+#[tokio::test]
+async fn detail_view_binds_context_object_name_alongside_object() {
+    let pool = fresh_pool().await;
+    let tera = tera_with(
+        "ctx_post_detail.html",
+        "alt={{ post.title | safe }} legacy={{ object.title | safe }}",
+    );
+    let view = DetailView::for_model(CtxPost::SCHEMA).context_object_name("post");
+    let app = view.router("/posts", tera, pool);
+    let (status, body) = body_of(app, "/posts/1").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("alt=Hello"), "got {body}");
+    assert!(body.contains("legacy=Hello"), "got {body}");
+}
+
+#[tokio::test]
+async fn detail_view_lookup_field_probes_by_named_column() {
+    let pool = fresh_pool().await;
+    let tera = tera_with(
+        "ctx_post_detail.html",
+        "row={{ object.title | safe }} slug={{ object.slug | safe }}",
+    );
+    let view = DetailView::for_model(CtxPost::SCHEMA).lookup_field("slug");
+    let app = view.router("/posts", tera, pool);
+    // URL `/posts/world` probes WHERE slug = 'world' → returns row id=2.
+    let (status, body) = body_of(app, "/posts/world").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("row=World"), "got {body}");
+    assert!(body.contains("slug=world"), "got {body}");
+}
+
+#[tokio::test]
+async fn detail_view_lookup_field_unknown_column_returns_500() {
+    let pool = fresh_pool().await;
+    let tera = tera_with("ctx_post_detail.html", "ignored");
+    let view = DetailView::for_model(CtxPost::SCHEMA).lookup_field("not_a_real_field");
+    let app = view.router("/posts", tera, pool);
+    let (status, body) = body_of(app, "/posts/anything").await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(
+        body.contains("not_a_real_field"),
+        "error body should name the offending field, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn detail_view_missing_row_returns_404_regardless_of_lookup_field() {
+    let pool = fresh_pool().await;
+    let tera = tera_with("ctx_post_detail.html", "ignored");
+    let view = DetailView::for_model(CtxPost::SCHEMA).lookup_field("slug");
+    let app = view.router("/posts", tera, pool);
+    let (status, _) = body_of(app, "/posts/nonexistent").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -27,7 +27,7 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 5. Migrations | 11 | 2 | 2 | 1 |
 | 6. Admin (ModelAdmin) | 18 | 7 | 11 | 2 |
 | 7. Forms / Formsets | 8 | 3 | 4 | 0 |
-| 8. Generic CBVs | 5 | 2 | 3 | 0 |
+| 8. Generic CBVs | 12 | 0 | 1 | 1 |
 | 9. URL routing | 5 | 1 | 1 | 1 |
 | 10. Templates | 10 | 1 | 0 | 0 |
 | 11. Authentication | 14 | 4 | 4 | 1 |
@@ -300,9 +300,9 @@ Summary: **8 SHIPPED / 3 PARTIAL / 4 MISSING / 0 N/A**.
 | `LoginRequiredMixin` | [LoginRequiredMixin](https://docs.djangoproject.com/en/6.0/topics/auth/default/#django.contrib.auth.mixins.LoginRequiredMixin) | SHIPPED | `auth_decorators::login_required` middleware layer | |
 | `UserPassesTestMixin` | [UserPassesTestMixin](https://docs.djangoproject.com/en/6.0/topics/auth/default/#django.contrib.auth.mixins.UserPassesTestMixin) | SHIPPED | `auth_decorators::user_passes_test` | |
 | `PermissionRequiredMixin` | [PermissionRequiredMixin](https://docs.djangoproject.com/en/6.0/topics/auth/default/#django.contrib.auth.mixins.PermissionRequiredMixin) | SHIPPED | `auth_decorators::permission_required` (PR #313) | |
-| MultipleObjectMixin / SingleObjectMixin (object-level customization) | [generic-display](https://docs.djangoproject.com/en/6.0/ref/class-based-views/generic-display/#multipleobjectmixin) | PARTIAL | `ListView::with_queryset(custom_qs)` exists (#379) | Mixin composability MISSING. |
+| MultipleObjectMixin / SingleObjectMixin (object-level customization) | [generic-display](https://docs.djangoproject.com/en/6.0/ref/class-based-views/generic-display/#multipleobjectmixin) | SHIPPED | `ListView::context_object_name(name)` + `DetailView::context_object_name(name)` + `DetailView::lookup_field(column)` (closed #379). Rust's mixin equivalent is composition on the builder struct — these knobs cover every practical Django mixin customization (rename the context variable, look up by slug instead of PK, customize the QuerySet via `with_queryset` and global context via `register_template_context_processor!`). | |
 
-Summary: **11 SHIPPED / 1 PARTIAL / 1 MISSING / 1 N/A**.
+Summary: **12 SHIPPED / 0 PARTIAL / 1 MISSING / 1 N/A**. Only `Date-based views` (#378) remains unimplemented — niche; users build via QuerySet date-trunc + Tera.
 
 ---
 


### PR DESCRIPTION
## Summary

Django's MultipleObjectMixin / SingleObjectMixin let templates read the row(s) under a custom variable name and let DetailView look up by a non-PK column. rustango's CBVs had \`with_queryset\` but no surface for these two common Django customizations — closing the gap with three builder methods.

\`\`\`rust
ListView::for_model(Post::SCHEMA)
    .context_object_name(\"posts\");   // {{ posts }} alongside {{ object_list }}

DetailView::for_model(Post::SCHEMA)
    .context_object_name(\"post\")     // {{ post.title }} alongside {{ object.title }}
    .lookup_field(\"slug\");           // /posts/{slug} → WHERE slug = ?
\`\`\`

## Semantics

- \`context_object_name\` **ADDS** a second Tera binding — the legacy \`object\` / \`object_list\` keys stay populated for back-compat, so existing templates keep working.
- \`lookup_field\` accepts a Rust field name OR a SQL column name (same resolution rule as the rest of the framework's user-facing name resolution). Unknown names produce a 500 with a clear error message at request time rather than silently 404-ing.
- Both knobs wired into BOTH the static-pool router AND the tenant-aware \`tenant_router\`.

## Where the rest of the mixin surface already lived

| Django mixin method | rustango equivalent |
|---|---|
| \`get_queryset()\` | \`ListView::with_queryset(custom_qs)\` (pre-existing) |
| \`paginate_queryset()\` | \`ListView::page_size\` / \`max_page_size\` |
| \`get_ordering()\` | \`ListView::order_by\` + \`ordering_fields\` (#439) |
| \`get_context_data()\` | \`register_template_context_processor!\` (#384) |
| **\`get_context_object_name()\`** | **\`context_object_name\` — this PR** |
| **\`get_slug_field()\`** | **\`lookup_field\` — this PR** |

With #379 every commonly-overridden Django mixin method now has a first-class builder hook.

## Test plan

- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy,template_views --test template_views_context_object_name_sqlite_live\` → 6 live tests pass:
  - ListView binds renamed alongside \`object_list\`
  - ListView default-config skips the rename (back-compat)
  - DetailView binds renamed alongside \`object\`
  - DetailView \`lookup_field\` probes by named column
  - DetailView \`lookup_field\` with unknown column → 500 with field name in error
  - DetailView with \`lookup_field\` still 404s missing rows correctly
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy,template_views --lib\` → 1822 pass
- [x] \`cargo test --workspace --all-features --no-run\` → clean compile
- [x] Pre-push hook gate

## Audit doc

Row 303 flipped PARTIAL → SHIPPED. Section 8 summary + rollup table bumped to \`12 / 0 / 1 / 1\` (only #378 Date-based views remains; niche — users build via date-trunc + Tera).