### PR TITLE
feat(viewset): ListSerializer bulk-create on POST (closes #435)

### DIFF
--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1189,8 +1189,9 @@ async fn handle_create(
         return json_error(StatusCode::FORBIDDEN, "permission denied");
     }
 
-    let form = match extract_form_body(parts, body).await {
-        Ok(f) => f,
+    // #435 — sniff for bulk shape (JSON array body) and dispatch.
+    let create_body = match extract_create_body(parts, body).await {
+        Ok(b) => b,
         Err(e) => return json_error(StatusCode::BAD_REQUEST, &e),
     };
 
@@ -1202,12 +1203,6 @@ async fn handle_create(
         .map(|f| f.name)
         .collect();
 
-    let collected = match collect_values(state.vs.schema, &form, &skip) {
-        Ok(v) => v,
-        Err(e) => return json_error(StatusCode::BAD_REQUEST, &e.to_string()),
-    };
-    let (columns, values): (Vec<_>, Vec<_>) = collected.into_iter().unzip();
-
     let pk_field = match state.pk_field() {
         Some(f) => f,
         None => {
@@ -1217,6 +1212,27 @@ async fn handle_create(
             )
         }
     };
+
+    match create_body {
+        CreateBody::Single(form) => create_one(&state, &mut acq, &form, &skip, pk_field).await,
+        CreateBody::Bulk(rows) => create_many(&state, &mut acq, &rows, &skip, pk_field).await,
+    }
+}
+
+/// Single-row create — used by both the form-urlencoded codepath
+/// and the JSON-object body codepath. Returns 201 + the row JSON.
+async fn create_one(
+    state: &Arc<ViewSetState>,
+    acq: &mut AcquiredConn,
+    form: &HashMap<String, String>,
+    skip: &[&str],
+    pk_field: &'static crate::core::FieldSchema,
+) -> Response {
+    let collected = match collect_values(state.vs.schema, form, skip) {
+        Ok(v) => v,
+        Err(e) => return json_error(StatusCode::BAD_REQUEST, &e.to_string()),
+    };
+    let (columns, values): (Vec<_>, Vec<_>) = collected.into_iter().unzip();
     let query = InsertQuery {
         model: state.vs.schema,
         columns,
@@ -1224,19 +1240,96 @@ async fn handle_create(
         returning: vec![pk_field.column],
         on_conflict: None,
     };
-
     let pk_val = match acq.insert_returning_pk(&query, pk_field).await {
         Ok(v) => v,
         Err(e) => return json_error(StatusCode::BAD_REQUEST, &e.to_string()),
     };
     let fields = state.effective_fields();
-    match fetch_by_pk(&state, &mut acq, pk_field, pk_val, &fields).await {
+    match fetch_by_pk(state, acq, pk_field, pk_val, &fields).await {
         Some(obj) => json_created(obj),
         None => json_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "created but could not retrieve",
         ),
     }
+}
+
+/// Bulk create — Django DRF `ListSerializer(many=True)` shape.
+/// Validates every entry first; on first failure, the WHOLE bulk
+/// is rejected with the index + message (atomic-validate, not
+/// atomic-insert — partial-insert recovery is a separate concern).
+/// On success, inserts each row sequentially and returns 201 + the
+/// JSON array of created rows in submission order.
+///
+/// Issue #435.
+async fn create_many(
+    state: &Arc<ViewSetState>,
+    acq: &mut AcquiredConn,
+    rows: &[HashMap<String, String>],
+    skip: &[&str],
+    pk_field: &'static crate::core::FieldSchema,
+) -> Response {
+    if rows.is_empty() {
+        return json_created(Value::Array(Vec::new()));
+    }
+
+    // Atomic validation: collect every (columns, values) up front
+    // so a bad row near the end of the list doesn't leave half the
+    // INSERTs committed. DRF's default ListSerializer.create has
+    // the same shape — validate the whole list before any save.
+    let mut prepared: Vec<(Vec<&'static str>, Vec<SqlValue>)> = Vec::with_capacity(rows.len());
+    for (i, row) in rows.iter().enumerate() {
+        let collected = match collect_values(state.vs.schema, row, skip) {
+            Ok(v) => v,
+            Err(e) => {
+                return json_error(StatusCode::BAD_REQUEST, &format!("bulk entry {i}: {e}"));
+            }
+        };
+        prepared.push(collected.into_iter().unzip());
+    }
+
+    // Insert sequentially. We loop INSERT-RETURNING rather than
+    // emitting one multi-row INSERT because:
+    //
+    // 1. Per-row PK extraction stays straightforward (one returning
+    //    row per call, no fan-out parsing).
+    // 2. The framework's `bulk_insert_pool` path is typed-model-
+    //    shaped; this dynamic-JSON codepath doesn't have a typed
+    //    handle to feed it.
+    // 3. Most ListSerializer.create callers are submitting tens of
+    //    rows, not millions. A real high-volume bulk endpoint
+    //    should mount its own custom handler with bulk_insert_pool.
+    //
+    // The trade-off: N round-trips per request. We document
+    // accordingly in the issue + viewset docs.
+    let fields = state.effective_fields();
+    let mut created: Vec<Value> = Vec::with_capacity(prepared.len());
+    for (i, (columns, values)) in prepared.into_iter().enumerate() {
+        let query = InsertQuery {
+            model: state.vs.schema,
+            columns,
+            values,
+            returning: vec![pk_field.column],
+            on_conflict: None,
+        };
+        let pk_val = match acq.insert_returning_pk(&query, pk_field).await {
+            Ok(v) => v,
+            Err(e) => {
+                return json_error(StatusCode::BAD_REQUEST, &format!("bulk entry {i}: {e}"));
+            }
+        };
+        match fetch_by_pk(state, acq, pk_field, pk_val, &fields).await {
+            Some(obj) => created.push(obj),
+            None => {
+                return json_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!("bulk entry {i}: created but could not retrieve"),
+                );
+            }
+        }
+    }
+
+    json_created(Value::Array(created))
 }
 
 async fn handle_update(
@@ -1416,6 +1509,29 @@ async fn extract_form_body(
     parts: axum::http::request::Parts,
     body: Body,
 ) -> Result<HashMap<String, String>, String> {
+    match extract_create_body(parts, body).await? {
+        CreateBody::Single(form) => Ok(form),
+        CreateBody::Bulk(_) => Err("expected a JSON object; got an array".into()),
+    }
+}
+
+/// Sniff a POST body and return either a single record (object body
+/// or form-urlencoded body) or a bulk list (JSON array body — DRF's
+/// `ListSerializer(many=True)` shape). Issue #435.
+///
+/// Bulk shape is only recognized for `application/json` content-type
+/// + a JSON array body — form-urlencoded payloads always parse as
+/// single records (multi-row form encoding doesn't have a portable
+/// shape).
+pub(crate) enum CreateBody {
+    Single(HashMap<String, String>),
+    Bulk(Vec<HashMap<String, String>>),
+}
+
+pub(crate) async fn extract_create_body(
+    parts: axum::http::request::Parts,
+    body: Body,
+) -> Result<CreateBody, String> {
     use axum::body::to_bytes;
 
     let content_type = parts
@@ -1429,25 +1545,49 @@ async fn extract_form_body(
         .map_err(|e| e.to_string())?;
 
     if content_type.contains("application/json") {
-        // JSON body: flatten top-level string/number values to strings
         let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|e| e.to_string())?;
-        let obj = value.as_object().ok_or("expected a JSON object")?;
-        let mut form = HashMap::new();
-        for (k, v) in obj {
-            let s = match v {
-                Value::String(s) => s.clone(),
-                Value::Number(n) => n.to_string(),
-                Value::Bool(b) => b.to_string(),
-                Value::Null => String::new(),
-                other => other.to_string(),
-            };
-            form.insert(k.clone(), s);
+        if let Some(array) = value.as_array() {
+            // Bulk shape: each element must be an object.
+            let mut bulk: Vec<HashMap<String, String>> = Vec::with_capacity(array.len());
+            for (i, entry) in array.iter().enumerate() {
+                let obj = entry
+                    .as_object()
+                    .ok_or_else(|| format!("bulk entry {i} is not a JSON object"))?;
+                bulk.push(json_object_to_form(obj));
+            }
+            return Ok(CreateBody::Bulk(bulk));
         }
-        Ok(form)
+        let obj = value
+            .as_object()
+            .ok_or("expected a JSON object or array of objects")?;
+        Ok(CreateBody::Single(json_object_to_form(obj)))
     } else {
-        // form-urlencoded (default)
-        serde_urlencoded::from_bytes::<HashMap<String, String>>(&bytes).map_err(|e| e.to_string())
+        // form-urlencoded (default) — single only.
+        let form = serde_urlencoded::from_bytes::<HashMap<String, String>>(&bytes)
+            .map_err(|e| e.to_string())?;
+        Ok(CreateBody::Single(form))
     }
+}
+
+/// Flatten a JSON object's top-level values into the
+/// `HashMap<String, String>` shape every existing collector expects.
+/// Numeric / boolean / null primitives stringify; nested objects /
+/// arrays serialize back to JSON text (caller can re-parse if it
+/// needs typed access). Extracted from the inlined `extract_form_body`
+/// path so both single and bulk codepaths share it.
+fn json_object_to_form(obj: &serde_json::Map<String, Value>) -> HashMap<String, String> {
+    let mut form = HashMap::with_capacity(obj.len());
+    for (k, v) in obj {
+        let s = match v {
+            Value::String(s) => s.clone(),
+            Value::Number(n) => n.to_string(),
+            Value::Bool(b) => b.to_string(),
+            Value::Null => String::new(),
+            other => other.to_string(),
+        };
+        form.insert(k.clone(), s);
+    }
+    form
 }
 
 #[cfg(test)]

--- a/crates/rustango/tests/viewset_bulk_create_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_bulk_create_sqlite_live.rs
@@ -1,0 +1,162 @@
+//! Django-parity #435 — DRF `ListSerializer(many=True)` shape.
+//! `POST <prefix>` with a JSON array body bulk-creates every entry
+//! and returns the created rows in submission order. Validation
+//! is atomic: a single bad entry rejects the whole bulk before
+//! any insert lands.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use http_body_util::BodyExt;
+use rustango::core::Model as _;
+use rustango::sql::{Auto, Pool};
+use rustango::viewset::ViewSet;
+use rustango::Model;
+use tower::ServiceExt;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "bulk_widget", display = "label")]
+#[allow(dead_code)]
+pub struct Widget {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 60)]
+    pub label: String,
+    pub priority: i32,
+}
+
+async fn fresh_pool() -> Pool {
+    let pool = Pool::connect("sqlite::memory:").await.expect("sqlite pool");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        r#"CREATE TABLE bulk_widget (
+            id       INTEGER PRIMARY KEY AUTOINCREMENT,
+            label    TEXT NOT NULL,
+            priority INTEGER NOT NULL
+        )"#,
+        Vec::new(),
+    )
+    .await
+    .expect("create");
+    pool
+}
+
+fn build_app(pool: Pool) -> axum::Router {
+    ViewSet::for_model(Widget::SCHEMA).router_pool("/widgets", pool)
+}
+
+async fn post_json(app: axum::Router, body: &str) -> (StatusCode, String) {
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/widgets")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_owned()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8(bytes.to_vec()).unwrap())
+}
+
+#[tokio::test]
+async fn json_array_body_bulk_creates_rows_in_order() {
+    let pool = fresh_pool().await;
+    let app = build_app(pool.clone());
+    let body = r#"[
+        {"label":"first","priority":1},
+        {"label":"second","priority":2},
+        {"label":"third","priority":3}
+    ]"#;
+    let (status, body) = post_json(app, body).await;
+    assert_eq!(status, StatusCode::CREATED, "got {status} {body}");
+    let arr: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let rows = arr.as_array().expect("expected JSON array response");
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0]["label"], "first");
+    assert_eq!(rows[1]["label"], "second");
+    assert_eq!(rows[2]["label"], "third");
+    // PKs auto-assigned in order.
+    assert_eq!(rows[0]["id"], 1);
+    assert_eq!(rows[2]["id"], 3);
+}
+
+#[tokio::test]
+async fn empty_array_returns_201_with_empty_array() {
+    let pool = fresh_pool().await;
+    let app = build_app(pool);
+    let (status, body) = post_json(app, "[]").await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(body, "[]");
+}
+
+#[tokio::test]
+async fn single_object_body_still_returns_single_row() {
+    // Back-compat — the existing single-object shape must keep
+    // working (returns a single JSON object, not an array).
+    let pool = fresh_pool().await;
+    let app = build_app(pool);
+    let body = r#"{"label":"solo","priority":7}"#;
+    let (status, body) = post_json(app, body).await;
+    assert_eq!(status, StatusCode::CREATED);
+    let row: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert!(
+        row.is_object(),
+        "single-object body should return an object, got {body}"
+    );
+    assert_eq!(row["label"], "solo");
+    assert_eq!(row["id"], 1);
+}
+
+#[tokio::test]
+async fn bulk_entry_with_invalid_field_rejects_whole_bulk_atomically() {
+    let pool = fresh_pool().await;
+    let app = build_app(pool.clone());
+    // Second entry is missing the required `priority` field.
+    let body = r#"[
+        {"label":"valid","priority":5},
+        {"label":"missing_priority"}
+    ]"#;
+    let (status, msg) = post_json(app, body).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        msg.contains("bulk entry 1"),
+        "error message should identify the failing index, got: {msg}"
+    );
+    // Atomic-validate — the first entry must NOT have been inserted.
+    let count =
+        rustango::sql::raw_execute_pool(&pool, "SELECT COUNT(*) FROM bulk_widget", Vec::new())
+            .await;
+    assert!(count.is_ok());
+    let Pool::Sqlite(sp) = &pool else {
+        panic!("test gated to sqlite");
+    };
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM bulk_widget")
+        .fetch_one(sp)
+        .await
+        .unwrap();
+    assert_eq!(
+        total, 0,
+        "atomic-validate: a bad row must reject the whole bulk before any insert lands"
+    );
+}
+
+#[tokio::test]
+async fn bulk_entry_that_is_not_an_object_returns_400() {
+    let pool = fresh_pool().await;
+    let app = build_app(pool);
+    let body = r#"[
+        {"label":"ok","priority":1},
+        42
+    ]"#;
+    let (status, msg) = post_json(app, body).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        msg.contains("not a JSON object") || msg.contains("entry 1"),
+        "error message should call out the bad shape, got: {msg}"
+    );
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -635,7 +635,7 @@ Summary: **5 / 0 / 0 / 2**. Async is native; no parity gap.
 | `Serializer` class | [serializers](https://www.django-rest-framework.org/api-guide/serializers/) | SHIPPED | `#[derive(Serializer)]` macro (v0.18) | |
 | `ModelSerializer` | [ModelSerializer](https://www.django-rest-framework.org/api-guide/serializers/#modelserializer) | SHIPPED | `ModelSerializer` trait via macro | |
 | `HyperlinkedModelSerializer` | [HyperlinkedModelSerializer](https://www.django-rest-framework.org/api-guide/serializers/#hyperlinkedmodelserializer) | MISSING | n/a (#434) | Niche. |
-| `ListSerializer` (bulk shape) | [ListSerializer](https://www.django-rest-framework.org/api-guide/serializers/#listserializer) | PARTIAL | Vec serialization works; bulk-create from `ListSerializer` shape MISSING (#435) | |
+| `ListSerializer` (bulk shape) | [ListSerializer](https://www.django-rest-framework.org/api-guide/serializers/#listserializer) | SHIPPED | `POST <prefix>` with a JSON array body bulk-creates every entry and returns the created rows in submission order (closed #435). Validation is atomic — a single bad entry rejects the whole bulk before any insert lands. `Vec::many_to_value` still covers the read direction. | |
 | Field-level options (read_only, write_only, source, skip) | (above) | SHIPPED | All four supported | |
 | Nested serializer (one-to-many auto-expand) | [nested](https://www.django-rest-framework.org/api-guide/serializers/#dealing-with-nested-objects) | SHIPPED | `#[serializer(nested = ChildSerializer)]` (v0.18) | |
 | `SerializerMethodField` | [SerializerMethodField](https://www.django-rest-framework.org/api-guide/fields/#serializermethodfield) | SHIPPED | v0.18 | |


### PR DESCRIPTION
## Summary

DRF's \`ListSerializer(many=True)\` shape — \`POST <prefix>\` with a JSON array body bulk-creates every entry and returns 201 + the created rows in submission order. Single-object bodies keep their existing semantics (returns one object), so this is opt-in via request shape.

\`\`\`
POST /widgets
Content-Type: application/json

[
  {\"label\":\"first\",\"priority\":1},
  {\"label\":\"second\",\"priority\":2}
]

HTTP/1.1 201 Created
[
  {\"id\":1,\"label\":\"first\",\"priority\":1},
  {\"id\":2,\"label\":\"second\",\"priority\":2}
]
\`\`\`

## Semantics

- **Atomic validate, sequential insert.** Validation runs against every entry up front; a single bad entry rejects the whole bulk with \`bulk entry N: <reason>\` before any insert lands.
- **Single-object body** keeps its existing shape (returns one object, not an array). Sniff happens at body-parse time; form-urlencoded bodies always parse as single.
- **Empty array** returns 201 + \`[]\`. No error, no state change.
- **Per-entry rejection** stamps the offending index into the error message so clients can map back to submission order.

## Wiring

- New \`CreateBody\` enum + \`extract_create_body\` sniff helper
- New \`create_one\` / \`create_many\` extracted from the old \`handle_create\` so both shapes reuse the same validate + insert chain
- \`extract_form_body\` keeps its previous signature for the strict single-object form path; internally delegates to the new helper and errors on bulk shape

## Trade-off

Sequential INSERT-RETURNING is fine for tens-of-rows DRF ListSerializer use cases. High-volume ingest endpoints should mount their own handler with \`bulk_insert_pool\` (typed-model path).

## Test plan

- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test viewset_bulk_create_sqlite_live\` → 5 live tests pass:
  - JSON array → bulk-creates in order with auto PKs
  - empty array → 201 + \`[]\`
  - single object → unchanged (returns one object)
  - bad entry → atomic-validate (no partial inserts)
  - non-object entry → 400 with index in message
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --lib\` → 1527 pass
- [x] \`cargo test --workspace --all-features --no-run\` → clean compile
- [x] Pre-push hook gate

## Audit doc

Row 638 flipped PARTIAL → SHIPPED.