### PR TITLE
chore(release): v0.42.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.41.0"
+version = "0.42.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,8 +18,8 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros = { version = "0.40.0", path = "crates/rustango-macros" }
-rustango        = { version = "0.40.0", path = "crates/rustango" }
+rustango-macros = { version = "0.42.0", path = "crates/rustango-macros" }
+rustango        = { version = "0.42.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ Every feature works on every supported backend out of the box. The only PG-speci
 ```toml
 [dependencies]
 # Postgres (default)
-rustango = "0.41"
+rustango = "0.42"
 
 # SQLite — file-backed or in-memory, full tri-dialect framework
-rustango = { version = "0.41", default-features = false, features = ["sqlite", "tenancy", "admin", "manage"] }
+rustango = { version = "0.42", default-features = false, features = ["sqlite", "tenancy", "admin", "manage"] }
 
 # MySQL 8+
-rustango = { version = "0.41", default-features = false, features = ["mysql", "tenancy", "admin", "manage"] }
+rustango = { version = "0.42", default-features = false, features = ["mysql", "tenancy", "admin", "manage"] }
 
 # Multiple backends in one binary
-rustango = { version = "0.41", features = ["postgres", "sqlite"] }
+rustango = { version = "0.42", features = ["postgres", "sqlite"] }
 ```
 
 ### What's new in v0.42.0 (May 2026) — Django-parity gap-closure batch

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -358,7 +358,7 @@ runserver = ["dep:axum", "dep:tokio"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.41.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.42.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }


### PR DESCRIPTION
Workspace version bump 0.41.0 → 0.42.0. **Already published to crates.io** during this session:

- \`rustango-macros\` 0.42.0
- \`rustango\` 0.42.0

The previous \`workspace.package.version\` was 0.41.0 but never published to crates.io — last published was 0.40.0 — so this release brings the full v0.41 ORM Tier-1 batch (#274–#286) AND the v0.42 Django-parity batch (#519–#548) to consumers in one bump.

## Versions touched

- \`Cargo.toml\`:\`workspace.package.version\` 0.41.0 → 0.42.0
- \`Cargo.toml\`:\`workspace.dependencies.rustango{,-macros}\` 0.40.0 → 0.42.0
- \`crates/rustango/Cargo.toml\`:\`rustango-macros\` 0.41.0 → 0.42.0
- \`README.md\` install snippets 0.41 → 0.42

## CHANGELOG

See [CHANGELOG.md](CHANGELOG.md) for the v0.42.0 entry (covers the 16 feature PRs + 9 already-supported closures from this session) plus the back-filled v0.41.0 and v0.40.0 entries (PR #550).

## Test plan

- [x] \`cargo build -p rustango --no-default-features --features sqlite,tenancy\` → clean
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --lib\` → 1527 pass
- [x] \`cargo test --workspace --all-features --no-run\` → clean compile
- [x] \`cargo publish -p rustango-macros\` → real publish succeeded
- [x] \`cargo publish -p rustango\` → real publish succeeded
- [x] \`cargo search rustango\` confirms both at 0.42.0 on crates.io