### PR TITLE
fix(tenancy): tri-dialect bootstrap + MySQL TEXT/BLOB/JSON defaults

### DIFF
--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -184,10 +184,12 @@ impl Dialect for MySql {
     ///   to carry `(6)` too, otherwise MySQL fails with
     ///   `1067 (42000): Invalid default value`.
     /// - `'<lit>'::<type>` → `'<lit>'` (strip Postgres cast).
-    /// - JSON columns (`ty == "json"`): wrap the result in parens —
-    ///   `DEFAULT '{}'` is rejected by MySQL on JSON/TEXT/BLOB
-    ///   (`1101 (42000)`), but the MySQL-8.0.13+ expression-default
-    ///   form `DEFAULT (<expr>)` is accepted.
+    /// - TEXT / BLOB / JSON columns (`ty` ∈ {`json`, `string`,
+    ///   `binary`}): wrap the result in parens — `DEFAULT '{}'` is
+    ///   rejected by MySQL on JSON/TEXT/BLOB (`1101 (42000)`), but the
+    ///   MySQL-8.0.13+ expression-default form `DEFAULT (<expr>)` is
+    ///   accepted (and is a harmless wrap for bounded `string` →
+    ///   VARCHAR).
     /// - Everything else passes through.
     fn translate_default_expr(&self, expr: &str, ty: &str) -> String {
         let mut out = expr.trim().to_owned();
@@ -208,7 +210,17 @@ impl Dialect for MySql {
                 }
             }
         }
-        if ty.eq_ignore_ascii_case("json") {
+        // MySQL rejects a literal `DEFAULT <val>` on TEXT / BLOB / JSON /
+        // GEOMETRY columns (error 1101 (42000)). Of our abstract types,
+        // `json` (→ JSON), unbounded `string` (→ TEXT), and `binary`
+        // (→ BLOB) land there. The MySQL-8.0.13+ expression-default form
+        // `DEFAULT (<expr>)` is accepted for all of them — and is a
+        // harmless wrap for the bounded `string` → VARCHAR case, so we
+        // don't need the column's max_length to decide here.
+        if matches!(
+            ty.to_ascii_lowercase().as_str(),
+            "json" | "string" | "binary"
+        ) {
             // Skip wrapping if the caller already produced a
             // parenthesized expression (defensive — current renderers
             // never do this).

--- a/crates/rustango/src/tenancy/bootstrap.rs
+++ b/crates/rustango/src/tenancy/bootstrap.rs
@@ -113,9 +113,26 @@ pub fn tenant_bootstrap_migration_for<U: TenantUserModel>() -> Migration {
         atomic: true,
         scope: MigrationScope::Tenant,
         snapshot: full_snapshot_for::<U>(),
-        forward: vec![Operation::Schema(SchemaChange::CreateTable(
-            "rustango_users".into(),
-        ))],
+        // #315 — `full_snapshot_for` declares the roles/permissions
+        // tables, so the forward ops must actually CREATE them too.
+        // Previously only `rustango_users` was created, leaving the
+        // snapshot claiming five tables that never existed; any
+        // downstream migration that trusts the snapshot and FKs to them
+        // then fails at apply time on FK-enforcing dialects (MySQL err
+        // 1824) and silently leaves them missing on SQLite. FKs are
+        // deferred by the runner, so creation order is irrelevant.
+        forward: vec![
+            Operation::Schema(SchemaChange::CreateTable("rustango_users".into())),
+            Operation::Schema(SchemaChange::CreateTable("rustango_roles".into())),
+            Operation::Schema(SchemaChange::CreateTable(
+                "rustango_role_permissions".into(),
+            )),
+            Operation::Schema(SchemaChange::CreateTable("rustango_user_roles".into())),
+            Operation::Schema(SchemaChange::CreateTable(
+                "rustango_user_permissions".into(),
+            )),
+            Operation::Schema(SchemaChange::CreateTable("rustango_api_keys".into())),
+        ],
     }
 }
 


### PR DESCRIPTION
Two database-mode tenancy bugs, surfaced while bringing **rustango-cms** up on MySQL 8 (the tenancy stack had only been live-tested on Postgres schema-mode). Both also affect *any* 0.42 app using roles/permissions in database-mode tenancy.

## 1. Bootstrap declares roles tables but never creates them
`tenant_bootstrap_migration_for` builds `full_snapshot_for` (declaring `rustango_roles / _role_permissions / _user_roles / _user_permissions / _api_keys`), but its `forward` ops only `CreateTable("rustango_users")`. So the five tables are **declared-as-existing in the snapshot yet never created**. Any downstream migration that trusts the snapshot and FKs to them then:
- **MySQL/db-mode:** fails at apply (`1824: Failed to open the referenced table 'rustango_roles'`)
- **SQLite/db-mode:** silently dangles (FK enforcement off)
- **Postgres schema-mode:** masked (shared DB happens to have them)

Fix: emit the missing `CreateTable` forward ops. The runner defers FKs, so creation order is irrelevant.

## 2. MySQL literal DEFAULT on TEXT/BLOB/JSON (err 1101)
MySQL rejects `DEFAULT '{}'` on TEXT/BLOB/JSON columns. `translate_default_expr` only parenthesized `json`; extend to `string` (→ TEXT) and `binary` (→ BLOB) via the 8.0.13+ expression-default form `DEFAULT (<expr>)` (a harmless wrap for bounded `VARCHAR`).

## Verification
A rustango-cms tenant (users + roles + 42 cms tables) now migrates → seeds → serves (admin login + sitemap querying content) on **both SQLite and MySQL 8** database-mode. SQLite was already green; these two fixes close MySQL.

⚠️ CI should run the live `*_mysql_live` / `*_sqlite_live` + `migrate::ddl` suites — fix #1 changes what the tenant bootstrap creates, so any test that provisioned roles by other means may need a touch-up.