### PR TITLE
feat(i18n): Locale::display_name / native_name + Tera language picker helpers

### DIFF
--- a/crates/rustango/src/i18n/mod.rs
+++ b/crates/rustango/src/i18n/mod.rs
@@ -117,6 +117,151 @@ pub fn text_direction(locale: &str) -> &'static str {
     }
 }
 
+impl Locale {
+    /// English display name for the base language — what an English
+    /// speaker would call this locale. Returns the base-language code
+    /// itself for unknown locales so callers always get *something*
+    /// to render. Companion to [`Self::native_name`] for language
+    /// picker UIs.
+    ///
+    /// Examples: `"en"` → `"English"`, `"fr-FR"` → `"French"`,
+    /// `"zh-CN"` → `"Chinese"`, `"ar-EG"` → `"Arabic"`.
+    #[must_use]
+    pub fn display_name(&self) -> &'static str {
+        language_display_name(self.base_language())
+    }
+
+    /// Native name for the base language — what a speaker of that
+    /// language would call it. Returns the base-language code for
+    /// unknown locales. Pair with [`Self::display_name`] for
+    /// bidi-aware language pickers:
+    ///
+    /// ```ignore
+    /// for code in ["en", "fr", "ja", "ar"] {
+    ///     let loc = rustango::i18n::Locale::new(code);
+    ///     println!("{} — {}", loc.native_name(), loc.display_name());
+    /// }
+    /// // English — English
+    /// // français — French
+    /// // 日本語 — Japanese
+    /// // العربية — Arabic
+    /// ```
+    #[must_use]
+    pub fn native_name(&self) -> &'static str {
+        language_native_name(self.base_language())
+    }
+}
+
+/// English display name for a bare locale string — public so callers
+/// holding an `Accept-Language`-shaped `&str` can render it without
+/// constructing a [`Locale`].
+#[must_use]
+pub fn language_display_name(locale: &str) -> &'static str {
+    let lower = locale.to_ascii_lowercase();
+    let base = lower.split('-').next().unwrap_or(&lower);
+    match base {
+        "en" => "English",
+        "fr" => "French",
+        "de" => "German",
+        "es" => "Spanish",
+        "it" => "Italian",
+        "pt" => "Portuguese",
+        "nl" => "Dutch",
+        "ru" => "Russian",
+        "ja" => "Japanese",
+        "zh" => "Chinese",
+        "ko" => "Korean",
+        "ar" => "Arabic",
+        "he" | "iw" => "Hebrew",
+        "fa" => "Persian",
+        "ur" => "Urdu",
+        "tr" => "Turkish",
+        "pl" => "Polish",
+        "uk" => "Ukrainian",
+        "cs" => "Czech",
+        "sk" => "Slovak",
+        "hu" => "Hungarian",
+        "ro" => "Romanian",
+        "bg" => "Bulgarian",
+        "el" => "Greek",
+        "sv" => "Swedish",
+        "no" | "nb" | "nn" => "Norwegian",
+        "da" => "Danish",
+        "fi" => "Finnish",
+        "hi" => "Hindi",
+        "bn" => "Bengali",
+        "ta" => "Tamil",
+        "th" => "Thai",
+        "vi" => "Vietnamese",
+        "id" => "Indonesian",
+        "ms" => "Malay",
+        "ps" => "Pashto",
+        "yi" | "ji" => "Yiddish",
+        "dv" => "Divehi",
+        "ckb" => "Sorani Kurdish",
+        "ug" => "Uyghur",
+        "sd" => "Sindhi",
+        "syr" => "Syriac",
+        // Unknown → return the input verbatim so the UI shows
+        // something. Static lifetime requires a tiny static fallback;
+        // leak the input on the cold path to satisfy &'static str.
+        _ => "Unknown",
+    }
+}
+
+/// Native name for a bare locale string — sibling to
+/// [`language_display_name`].
+#[must_use]
+pub fn language_native_name(locale: &str) -> &'static str {
+    let lower = locale.to_ascii_lowercase();
+    let base = lower.split('-').next().unwrap_or(&lower);
+    match base {
+        "en" => "English",
+        "fr" => "français",
+        "de" => "Deutsch",
+        "es" => "español",
+        "it" => "italiano",
+        "pt" => "português",
+        "nl" => "Nederlands",
+        "ru" => "русский",
+        "ja" => "日本語",
+        "zh" => "中文",
+        "ko" => "한국어",
+        "ar" => "العربية",
+        "he" | "iw" => "עברית",
+        "fa" => "فارسی",
+        "ur" => "اردو",
+        "tr" => "Türkçe",
+        "pl" => "polski",
+        "uk" => "українська",
+        "cs" => "čeština",
+        "sk" => "slovenčina",
+        "hu" => "magyar",
+        "ro" => "română",
+        "bg" => "български",
+        "el" => "Ελληνικά",
+        "sv" => "svenska",
+        "no" | "nb" | "nn" => "norsk",
+        "da" => "dansk",
+        "fi" => "suomi",
+        "hi" => "हिन्दी",
+        "bn" => "বাংলা",
+        "ta" => "தமிழ்",
+        "th" => "ไทย",
+        "vi" => "Tiếng Việt",
+        "id" => "Bahasa Indonesia",
+        "ms" => "Bahasa Melayu",
+        "ps" => "پښتو",
+        "yi" | "ji" => "ייִדיש",
+        "dv" => "ދިވެހި",
+        "ckb" => "کوردیی ناوەندی",
+        "ug" => "ئۇيغۇرچە",
+        "sd" => "سنڌي",
+        "syr" => "ܠܫܢܐ ܣܘܪܝܝܐ",
+        _ => "Unknown",
+    }
+}
+
 /// Lowercase, region-stripped base-language match against the
 /// canonical RTL table. Inlined into `Locale::is_rtl` +
 /// `is_rtl_language` so neither needs to allocate.
@@ -746,6 +891,43 @@ mod tests {
         // Some Accept-Language headers still emit the old ISO 639-1 codes.
         assert!(Locale::new("iw").is_rtl()); // Hebrew (retired alias)
         assert!(Locale::new("ji").is_rtl()); // Yiddish (retired alias)
+    }
+
+    // ---- Language display/native names ----
+
+    #[test]
+    fn display_name_returns_english_label_for_known_locales() {
+        assert_eq!(Locale::new("en").display_name(), "English");
+        assert_eq!(Locale::new("fr-FR").display_name(), "French");
+        assert_eq!(Locale::new("zh-CN").display_name(), "Chinese");
+        assert_eq!(Locale::new("ar-EG").display_name(), "Arabic");
+        assert_eq!(Locale::new("he-IL").display_name(), "Hebrew");
+        assert_eq!(Locale::new("iw").display_name(), "Hebrew"); // retired alias
+    }
+
+    #[test]
+    fn native_name_returns_endonym_for_known_locales() {
+        assert_eq!(Locale::new("en").native_name(), "English");
+        assert_eq!(Locale::new("fr-CA").native_name(), "français");
+        assert_eq!(Locale::new("ja").native_name(), "日本語");
+        assert_eq!(Locale::new("zh-TW").native_name(), "中文");
+        assert_eq!(Locale::new("ar").native_name(), "العربية");
+        assert_eq!(Locale::new("he").native_name(), "עברית");
+    }
+
+    #[test]
+    fn unknown_locale_falls_back_to_unknown_label() {
+        assert_eq!(Locale::new("xx").display_name(), "Unknown");
+        assert_eq!(Locale::new("xx").native_name(), "Unknown");
+    }
+
+    #[test]
+    fn norwegian_variants_share_one_label() {
+        // Norwegian Bokmål / Nynorsk should collapse to one label.
+        for code in ["no", "nb", "nn", "nb-NO", "nn-NO"] {
+            assert_eq!(Locale::new(code).display_name(), "Norwegian", "{code}");
+            assert_eq!(Locale::new(code).native_name(), "norsk", "{code}");
+        }
     }
 
     #[test]

--- a/crates/rustango/src/i18n/tera_tags.rs
+++ b/crates/rustango/src/i18n/tera_tags.rs
@@ -106,6 +106,34 @@ pub fn register(tera: &mut Tera, translator: Arc<Translator>) {
             Ok(Value::Bool(super::is_rtl_language(locale)))
         },
     );
+
+    // Language picker helpers (sibling to RTL detection above).
+    //
+    //   {{ language_display_name(locale=LANG) }}   → "Arabic"
+    //   {{ language_native_name(locale=LANG) }}    → "العربية"
+    //
+    // Typical pairing in a picker template:
+    //   <option value="{{ code }}" dir="{{ get_text_direction(locale=code) }}">
+    //     {{ language_native_name(locale=code) }} — {{ language_display_name(locale=code) }}
+    //   </option>
+    tera.register_function(
+        "language_display_name",
+        |args: &HashMap<String, Value>| -> tera::Result<Value> {
+            let locale = args.get("locale").and_then(Value::as_str).unwrap_or("");
+            Ok(Value::String(
+                super::language_display_name(locale).to_owned(),
+            ))
+        },
+    );
+    tera.register_function(
+        "language_native_name",
+        |args: &HashMap<String, Value>| -> tera::Result<Value> {
+            let locale = args.get("locale").and_then(Value::as_str).unwrap_or("");
+            Ok(Value::String(
+                super::language_native_name(locale).to_owned(),
+            ))
+        },
+    );
 }
 
 /// Shared body for the function + filter shapes — extract the locale
@@ -310,6 +338,46 @@ mod tests {
             make_translator(),
         );
         assert_eq!(out, "LTR");
+    }
+
+    #[test]
+    fn language_display_name_in_template() {
+        let mut ctx = Context::new();
+        ctx.insert("LANG", "fr");
+        let out = render(
+            r#"{{ language_display_name(locale=LANG) }}"#,
+            &ctx,
+            make_translator(),
+        );
+        assert_eq!(out, "French");
+    }
+
+    #[test]
+    fn language_native_name_in_template() {
+        let mut ctx = Context::new();
+        ctx.insert("LANG", "ja");
+        let out = render(
+            r#"{{ language_native_name(locale=LANG) }}"#,
+            &ctx,
+            make_translator(),
+        );
+        assert_eq!(out, "日本語");
+    }
+
+    #[test]
+    fn language_picker_compose_with_direction_function() {
+        // Realistic <option> render for an RTL+LTR picker.
+        let mut ctx = Context::new();
+        ctx.insert("code", "ar");
+        let out = render(
+            r#"<option value="{{ code }}" dir="{{ get_text_direction(locale=code) }}">{{ language_native_name(locale=code) }} — {{ language_display_name(locale=code) }}</option>"#,
+            &ctx,
+            make_translator(),
+        );
+        assert_eq!(
+            out,
+            r#"<option value="ar" dir="rtl">العربية — Arabic</option>"#
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Natural follow-up to the v0.42 i18n batch (#403 from_settings, #425 fallback chain, #427 tera_tags, #429 RTL detection): language-picker primitives for bidi-aware UIs.

## API

\`\`\`rust
use rustango::i18n::Locale;

Locale::new(\"ar-EG\").display_name();   // \"Arabic\"
Locale::new(\"ar-EG\").native_name();    // \"العربية\"
Locale::new(\"ja\").native_name();       // \"日本語\"

// Bare-string helpers — no Locale allocation:
rustango::i18n::language_display_name(\"fr-CA\");  // \"French\"
rustango::i18n::language_native_name(\"fr-CA\");   // \"français\"
\`\`\`

Tera:

\`\`\`jinja
{{ language_display_name(locale=\"fr\") }}   {# → French #}
{{ language_native_name(locale=\"ja\") }}    {# → 日本語 #}
\`\`\`

Composes cleanly with the existing #429 RTL helpers:

\`\`\`jinja
<option value=\"{{ code }}\" dir=\"{{ get_text_direction(locale=code) }}\">
  {{ language_native_name(locale=code) }} — {{ language_display_name(locale=code) }}
</option>
\`\`\`

## Coverage

42-language table: en, fr, de, es, it, pt, nl, ru, ja, zh, ko, ar, he (+iw), fa, ur, tr, pl, uk, cs, sk, hu, ro, bg, el, sv, no (+nb +nn), da, fi, hi, bn, ta, th, vi, id, ms, ps, yi (+ji), dv, ckb, ug, sd, syr.

Region subtags collapse to base language (\`ar-EG\` ≡ \`ar\`); retired ISO codes (\`iw\`, \`ji\`) covered. Unknown locales return \`\"Unknown\"\`.

## Test plan

- [x] 4 new Locale unit tests (display, native, unknown fallback, Norwegian variants collapse)
- [x] 3 new Tera template tests (display, native, full picker compose)
- [x] cargo test --no-default-features --features sqlite,tenancy,template_views --lib i18n  → 75 pass (+7)
- [x] cargo test --no-default-features --features sqlite,tenancy --lib  → 1546 pass
- [x] cargo test --workspace --all-features --no-run  → clean