### PR TITLE
fix(migrate): dialect-aware rollback / non-atomic apply + DROP arms (#559 phase 1)

### DIFF
--- a/crates/rustango/src/migrate/diff.rs
+++ b/crates/rustango/src/migrate/diff.rs
@@ -646,8 +646,11 @@ fn render_changes_split_inner(
                 }
             }
             SchemaChange::DropColumn { table, column } => {
-                out.immediate
-                    .push(format!(r#"ALTER TABLE "{table}" DROP COLUMN "{column}""#,));
+                out.immediate.push(format!(
+                    "ALTER TABLE {} DROP COLUMN {}",
+                    dialect.quote_ident(table),
+                    dialect.quote_ident(column),
+                ));
             }
             SchemaChange::AddColumn { table, column } => {
                 let t = current.table(table).ok_or_else(|| {
@@ -677,8 +680,16 @@ fn render_changes_split_inner(
                 out.immediate.push(add_column_sql(table, f, dialect));
             }
             SchemaChange::DropTable(name) => {
+                // CASCADE is Postgres-only — MySQL's parser rejects the
+                // keyword and SQLite has no equivalent. (Mirrors the gate in
+                // `ddl::drop_table_sql_with_dialect` / `drop_all_pool`.)
+                let cascade = if dialect.name() == "postgres" {
+                    " CASCADE"
+                } else {
+                    ""
+                };
                 out.immediate
-                    .push(format!(r#"DROP TABLE "{name}" CASCADE"#));
+                    .push(format!("DROP TABLE {}{cascade}", dialect.quote_ident(name)));
             }
             SchemaChange::AlterColumnType {
                 table,
@@ -898,8 +909,15 @@ fn render_changes_split_inner(
                 ));
             }
             SchemaChange::DropM2MTable { through } => {
-                out.immediate
-                    .push(format!(r#"DROP TABLE IF EXISTS "{through}" CASCADE"#));
+                let cascade = if dialect.name() == "postgres" {
+                    " CASCADE"
+                } else {
+                    ""
+                };
+                out.immediate.push(format!(
+                    "DROP TABLE IF EXISTS {}{cascade}",
+                    dialect.quote_ident(through)
+                ));
             }
             SchemaChange::AddCompositeFk {
                 table,
@@ -1219,5 +1237,48 @@ mod sql_type_tests {
     fn non_auto_passes_through_normally() {
         assert_eq!(sql_type(&fs("i64", false)), "BIGINT");
         assert_eq!(sql_type(&fs("datetime", false)), "TIMESTAMPTZ");
+    }
+
+    // #559 — DROP arms must be dialect-aware. `CASCADE` is Postgres-only
+    // (MySQL's parser rejects it, SQLite has no equivalent) and identifier
+    // quoting differs (PG/SQLite double-quote, MySQL backtick).
+    #[test]
+    fn drop_arms_are_dialect_aware() {
+        use crate::migrate::{SchemaChange, SchemaSnapshot};
+        let snap = SchemaSnapshot::from_models(&[]);
+
+        let drop_table = [SchemaChange::DropTable("foo".into())];
+        let pg =
+            render_changes_split_with_dialect(&drop_table, &snap, &crate::sql::Postgres).unwrap();
+        assert_eq!(
+            pg.immediate,
+            vec![r#"DROP TABLE "foo" CASCADE"#.to_string()]
+        );
+        #[cfg(feature = "mysql")]
+        {
+            let my =
+                render_changes_split_with_dialect(&drop_table, &snap, &crate::sql::MySql).unwrap();
+            assert_eq!(my.immediate, vec!["DROP TABLE `foo`".to_string()]);
+        }
+        #[cfg(feature = "sqlite")]
+        {
+            let sq =
+                render_changes_split_with_dialect(&drop_table, &snap, &crate::sql::Sqlite).unwrap();
+            assert_eq!(sq.immediate, vec![r#"DROP TABLE "foo""#.to_string()]);
+        }
+
+        let drop_col = [SchemaChange::DropColumn {
+            table: "t".into(),
+            column: "c".into(),
+        }];
+        #[cfg(feature = "mysql")]
+        {
+            let my =
+                render_changes_split_with_dialect(&drop_col, &snap, &crate::sql::MySql).unwrap();
+            assert_eq!(
+                my.immediate,
+                vec!["ALTER TABLE `t` DROP COLUMN `c`".to_string()]
+            );
+        }
     }
 }

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -1614,8 +1614,12 @@ async fn apply_nonatomic_pool(
     for op in &mig.forward {
         match op {
             Operation::Schema(change) => {
-                let batch = render_changes_split(std::slice::from_ref(change), &mig.snapshot)
-                    .map_err(MigrateError::Validation)?;
+                let batch = super::diff::render_changes_split_with_dialect(
+                    std::slice::from_ref(change),
+                    &mig.snapshot,
+                    pool.dialect(),
+                )
+                .map_err(MigrateError::Validation)?;
                 for stmt in batch.immediate {
                     crate::sql::raw_execute_pool(pool, &stmt, ::std::vec::Vec::new()).await?;
                 }
@@ -1998,8 +2002,12 @@ async fn unapply_atomic_pool(
             for op in inverted {
                 match op {
                     Operation::Schema(change) => {
-                        let batch = render_changes_split(std::slice::from_ref(change), snapshot)
-                            .map_err(MigrateError::Validation)?;
+                        let batch = super::diff::render_changes_split_with_dialect(
+                            std::slice::from_ref(change),
+                            snapshot,
+                            pool.dialect(),
+                        )
+                        .map_err(MigrateError::Validation)?;
                         for stmt in batch.immediate {
                             sqlx::query(&stmt).execute(&mut *tx).await?;
                         }
@@ -2030,8 +2038,12 @@ async fn unapply_atomic_pool(
             for op in inverted {
                 match op {
                     Operation::Schema(change) => {
-                        let batch = render_changes_split(std::slice::from_ref(change), snapshot)
-                            .map_err(MigrateError::Validation)?;
+                        let batch = super::diff::render_changes_split_with_dialect(
+                            std::slice::from_ref(change),
+                            snapshot,
+                            pool.dialect(),
+                        )
+                        .map_err(MigrateError::Validation)?;
                         for stmt in batch.immediate {
                             sqlx::query(&stmt).execute(&mut *tx).await?;
                         }
@@ -2062,8 +2074,12 @@ async fn unapply_atomic_pool(
             for op in inverted {
                 match op {
                     Operation::Schema(change) => {
-                        let batch = render_changes_split(std::slice::from_ref(change), snapshot)
-                            .map_err(MigrateError::Validation)?;
+                        let batch = super::diff::render_changes_split_with_dialect(
+                            std::slice::from_ref(change),
+                            snapshot,
+                            pool.dialect(),
+                        )
+                        .map_err(MigrateError::Validation)?;
                         for stmt in batch.immediate {
                             sqlx::query(&stmt).execute(&mut *tx).await?;
                         }
@@ -2163,8 +2179,12 @@ async fn unapply_nonatomic_pool(
     for op in inverted {
         match op {
             Operation::Schema(change) => {
-                let batch = render_changes_split(std::slice::from_ref(change), snapshot)
-                    .map_err(MigrateError::Validation)?;
+                let batch = super::diff::render_changes_split_with_dialect(
+                    std::slice::from_ref(change),
+                    snapshot,
+                    pool.dialect(),
+                )
+                .map_err(MigrateError::Validation)?;
                 for stmt in batch.immediate {
                     crate::sql::raw_execute_pool(pool, &stmt, ::std::vec::Vec::new()).await?;
                 }


### PR DESCRIPTION
First, highest-value slice of #559 (migration DDL rendering is only partially dialect-aware). Fixes a **shipping bug**: rolling back any migration on MySQL/SQLite emitted Postgres DDL and failed.

## The bug
`apply_atomic_pool` threads `pool.dialect()` into `render_changes_split_with_dialect`, but three sibling paths called the **PG-hardcoded** `render_changes_split` (→ `&Postgres`):
- `apply_nonatomic_pool` (runner.rs:1617)
- `unapply_atomic_pool` — all three pool arms
- `unapply_nonatomic_pool`

So on MySQL/SQLite they emitted `"`-quoted idents, `BIGSERIAL`/`JSONB`, `DROP … CASCADE` — i.e. **every rollback** (and non-atomic apply) produced Postgres SQL the backend rejects.

## Fix
- **runner.rs** — route those 4 sites through `render_changes_split_with_dialect(…, pool.dialect())`, matching the atomic apply path (`pool` is already in scope in the match arms). The 4 correct PG-typed/preview call sites are untouched.
- **diff.rs** — make the `DROP` arms dialect-aware: `DropTable` / `DropM2MTable` gate `CASCADE` to Postgres (MySQL's parser rejects it; SQLite has no equivalent) and quote via `dialect.quote_ident`; `DropColumn` quotes per dialect.

## Verified
New `drop_arms_are_dialect_aware` test pins all three: PG `DROP TABLE "foo" CASCADE`, MySQL `` DROP TABLE `foo` ``, SQLite `DROP TABLE "foo"`. **178 migrate unit tests pass; builds clean on postgres + mysql + sqlite.**

## Remaining in #559 (bigger, separable follow-ups)
`AlterColumn*` arms (SQLite has no `ALTER COLUMN` → table-rebuild; MySQL → `MODIFY COLUMN`), `CreateM2MTable` FK emission, `DropIndex` (MySQL needs `ON <table>` + no `IF EXISTS` — the variant must carry the table), CHECK / composite-FK constraint arms, the MySQL "atomic"-DDL implicit-commit caveat, and generated-column / `db_comment` snapshot capture.