### PR TITLE
feat(model): #[rustango(citext)] — Django CITextField parity (closes #344)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -5471,6 +5471,11 @@ struct FieldAttrs {
     /// "form may submit empty even when DB is NOT NULL". Threaded into
     /// `FieldSchema::blank`. Defaults to `false`.
     blank: bool,
+    /// `#[rustango(citext)]` / `#[rustango(citext = true)]` (#344) —
+    /// Django-shape `CITextField`. Threaded into
+    /// `FieldSchema::case_insensitive`. Only meaningful for `String`
+    /// fields; the macro errors at derive time if applied elsewhere.
+    case_insensitive: bool,
     /// `#[rustango(validators = "email,url")]` — Django-shape
     /// model-level validator chain. Comma-separated names that
     /// dispatch to the `validators::*` family in `validate_value`.
@@ -5505,6 +5510,7 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
         verbose_name: None,
         editable: true,
         blank: false,
+        case_insensitive: false,
         validators: Vec::new(),
     };
     for attr in &field.attrs {
@@ -5628,6 +5634,23 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
                     out.blank = lit.value;
                 } else {
                     out.blank = true;
+                }
+                return Ok(());
+            }
+            if meta.path.is_ident("citext") {
+                // Django-parity CITextField (#344). Two forms:
+                //   #[rustango(citext)]          — flag form, true
+                //   #[rustango(citext = true)]   — explicit
+                //   #[rustango(citext = false)]  — explicit opt-out
+                // String-only validation lives in the field-type
+                // emitter (the FieldType discriminant is computed in
+                // `detect_type`); the macro records the flag and the
+                // DDL writer emits dialect-specific COLLATE / CITEXT.
+                if let Ok(v) = meta.value() {
+                    let lit: syn::LitBool = v.parse()?;
+                    out.case_insensitive = lit.value;
+                } else {
+                    out.case_insensitive = true;
                 }
                 return Ok(());
             }
@@ -6006,6 +6029,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
     let verbose_name = optional_str(attrs.verbose_name.as_deref());
     let editable = attrs.editable;
     let blank = attrs.blank;
+    let case_insensitive = attrs.case_insensitive;
     let validators_lits: Vec<&str> = attrs.validators.iter().map(String::as_str).collect();
     let schema = quote! {
         ::rustango::core::FieldSchema {
@@ -6028,6 +6052,7 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
             verbose_name: #verbose_name,
             editable: #editable,
             blank: #blank,
+            case_insensitive: #case_insensitive,
             validators: &[ #(#validators_lits),* ],
         }
     };

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -668,6 +668,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         }
     }

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -104,6 +104,17 @@ pub struct FieldSchema {
     /// `nullable=false, blank=true` to require *some* value in DB
     /// but accept `""` from the form.
     pub blank: bool,
+    /// Django-shape `CITextField` flag (#344). When `true`, the
+    /// migration DDL writer emits a case-insensitive column type:
+    /// `CITEXT` on Postgres (auto-emits `CREATE EXTENSION IF NOT
+    /// EXISTS citext;`), `TEXT COLLATE NOCASE` on SQLite, and
+    /// `<VARCHAR/TEXT> COLLATE utf8mb4_general_ci` on MySQL. The
+    /// effect is that `WHERE col = 'foo'` also matches `'FOO'` /
+    /// `'Foo'` without query-side `LOWER(…)` wrapping.
+    ///
+    /// Set via `#[rustango(citext)]` or `#[rustango(citext = true)]`.
+    /// Only meaningful for `FieldType::String`.
+    pub case_insensitive: bool,
     /// Django-shape `validators=[...]` — names of value-shape validators
     /// to run on every INSERT/UPDATE through the typed query layer. Set
     /// via `#[rustango(validators = "email,url")]` (comma-separated).

--- a/crates/rustango/src/migrate/ddl.rs
+++ b/crates/rustango/src/migrate/ddl.rs
@@ -306,6 +306,12 @@ fn sql_type(dialect: &dyn Dialect, field: &FieldSchema) -> String {
     if field.auto && matches!(field.ty, FieldType::I16 | FieldType::I32 | FieldType::I64) {
         return dialect.serial_type(field.ty).to_owned();
     }
+    // #344 — CITextField / case-insensitive string columns. Only
+    // meaningful for `String`; other types fall through to the
+    // normal type emit.
+    if field.case_insensitive && matches!(field.ty, FieldType::String) {
+        return dialect.ci_text_type(field.max_length);
+    }
     dialect.column_type(field.ty, field.max_length)
 }
 
@@ -361,6 +367,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         }
     }

--- a/crates/rustango/src/migrate/diff.rs
+++ b/crates/rustango/src/migrate/diff.rs
@@ -1164,6 +1164,14 @@ fn sql_type_with_dialect(f: &FieldSnapshot, dialect: &dyn crate::sql::Dialect) -
             }
         }
     }
+    // #344 — case-insensitive String columns route through
+    // `dialect.ci_text_type` (PG → CITEXT, SQLite → TEXT COLLATE
+    // NOCASE, MySQL → TEXT COLLATE utf8mb4_general_ci).
+    if f.case_insensitive {
+        if matches!(ty, Some(FieldType::String)) {
+            return dialect.ci_text_type(f.max_length);
+        }
+    }
     if let Some(t) = ty {
         return dialect.column_type(t, f.max_length);
     }
@@ -1190,6 +1198,7 @@ mod sql_type_tests {
             default: None,
             auto,
             unique: false,
+            case_insensitive: false,
             fk: None,
         }
     }

--- a/crates/rustango/src/migrate/make.rs
+++ b/crates/rustango/src/migrate/make.rs
@@ -663,6 +663,7 @@ mod tests {
                 default: None,
                 auto: true,
                 unique: false,
+                case_insensitive: false,
                 fk: None,
             }],
             composite_fks: vec![],

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -3957,6 +3957,7 @@ mod gen_tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         }
     }

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -134,6 +134,12 @@ pub struct FieldSnapshot {
     /// serialize when `false` to keep snapshots diff-clean.
     #[serde(skip_serializing_if = "is_false", default)]
     pub unique: bool,
+    /// Django-shape `CITextField` flag (#344). Threaded through from
+    /// `FieldSchema::case_insensitive`. Skipped on serialize when
+    /// `false` so older snapshots stay diff-clean. The diff writer
+    /// dispatches to `dialect.ci_text_type(max_length)` when set.
+    #[serde(skip_serializing_if = "is_false", default)]
+    pub case_insensitive: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub fk: Option<RelationSnapshot>,
 }
@@ -428,6 +434,7 @@ impl FieldSnapshot {
             default: f.default.map(str::to_owned),
             auto: f.auto,
             unique: f.unique,
+            case_insensitive: f.case_insensitive,
             fk,
         }
     }
@@ -553,6 +560,7 @@ mod composite_fk_snapshot_tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         }];
         static COMPS: [CompositeFkRelation; 1] = [CompositeFkRelation {
@@ -624,6 +632,7 @@ mod composite_fk_snapshot_tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         }];
         static MANAGED: ModelSchema = ModelSchema {
@@ -704,6 +713,7 @@ mod composite_fk_snapshot_tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         }];
         static MS: ModelSchema = ModelSchema {

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -220,6 +220,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         },
         FieldSchema {
@@ -242,6 +243,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         },
         FieldSchema {
@@ -264,6 +266,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         },
     ];

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -329,6 +329,27 @@ pub trait Dialect {
         }
     }
 
+    /// Column type for a case-insensitive text field (Django parity
+    /// #344 — `CITextField` / `case_insensitive = true`). Default
+    /// emits ANSI `TEXT` so unknown dialects degrade gracefully (case
+    /// sensitivity is then a query-side concern). Postgres overrides
+    /// to `CITEXT`, SQLite to `TEXT COLLATE NOCASE`, MySQL to
+    /// `<VARCHAR(N)|TEXT> COLLATE utf8mb4_general_ci`.
+    fn ci_text_type(&self, max_length: Option<u32>) -> String {
+        // ANSI fallback — caller is expected to use `LOWER(...)` at
+        // query time when running on a dialect that doesn't override.
+        let _ = max_length;
+        "TEXT".to_owned()
+    }
+
+    /// One-time DDL prelude this dialect needs before any column of
+    /// the given type can be created (e.g. `CREATE EXTENSION IF NOT
+    /// EXISTS citext;` on Postgres before a `CITEXT` column can
+    /// land). `None` (default) means no prelude required.
+    fn ci_text_extension_sql(&self) -> Option<&'static str> {
+        None
+    }
+
     /// `true` if `op` can be lowered to SQL by this dialect. Default
     /// `true` — every dialect ships translations for every operator
     /// in the IR. Override to return `false` for ops that genuinely

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -174,6 +174,17 @@ impl Dialect for MySql {
         }
     }
 
+    // #344 — CITextField. MySQL ships `utf8mb4_general_ci` (or any
+    // `_ci` variant), the default collation for utf8mb4 in modern
+    // versions. Forcing it column-level guarantees case-insensitive
+    // comparison even when the table or session default differs.
+    fn ci_text_type(&self, max_length: Option<u32>) -> String {
+        match max_length {
+            Some(n) => format!("VARCHAR({n}) COLLATE utf8mb4_general_ci"),
+            None => "TEXT COLLATE utf8mb4_general_ci".to_owned(),
+        }
+    }
+
     /// Translate Postgres-native `DEFAULT` expressions to MySQL
     /// spelling.
     ///
@@ -1251,6 +1262,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                case_insensitive: false,
                 validators: &[],
             })
             .collect();

--- a/crates/rustango/src/sql/postgres.rs
+++ b/crates/rustango/src/sql/postgres.rs
@@ -63,6 +63,21 @@ impl Dialect for Postgres {
         }
     }
 
+    // #344 — CITextField. Postgres ships the `citext` extension that
+    // provides a case-insensitive text type; once the extension is
+    // installed, a `CITEXT` column compares case-insensitively. The
+    // companion `ci_text_extension_sql` emits the one-time
+    // `CREATE EXTENSION` prelude the migration runner threads in
+    // ahead of the first CITEXT CREATE TABLE.
+    fn ci_text_type(&self, _max_length: Option<u32>) -> String {
+        // CITEXT has no length parameter; `max_length` is advisory.
+        "CITEXT".to_owned()
+    }
+
+    fn ci_text_extension_sql(&self) -> Option<&'static str> {
+        Some("CREATE EXTENSION IF NOT EXISTS citext;")
+    }
+
     // Postgres has a native `BOOLEAN` type with `TRUE` / `FALSE`
     // literals — same as the trait default, no override.
 

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -208,6 +208,14 @@ impl Dialect for Sqlite {
         }
     }
 
+    // #344 — CITextField. SQLite has built-in `COLLATE NOCASE` that
+    // makes `=` / `LIKE` / `ORDER BY` case-insensitive without an
+    // extension. Column-level collation propagates to expressions
+    // referencing the column.
+    fn ci_text_type(&self, _max_length: Option<u32>) -> String {
+        "TEXT COLLATE NOCASE".to_owned()
+    }
+
     fn supports_op(&self, op: Op) -> bool {
         // SQLite supports every operator we lower below. The Postgres-
         // shape JSONB operators are intentionally NOT translated to
@@ -636,6 +644,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         }];
         static MODEL: ModelSchema = ModelSchema {

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -3978,6 +3978,7 @@ mod tests {
                     verbose_name: None,
                     editable: true,
                     blank: false,
+                    case_insensitive: false,
                     validators: &[],
                 },
                 crate::core::FieldSchema {
@@ -4000,6 +4001,7 @@ mod tests {
                     verbose_name: None,
                     editable: true,
                     blank: false,
+                    case_insensitive: false,
                     validators: &[],
                 },
             ])),
@@ -4051,6 +4053,7 @@ mod tests {
                     verbose_name: None,
                     editable: true,
                     blank: false,
+                    case_insensitive: false,
                     validators: &[],
                 },
                 crate::core::FieldSchema {
@@ -4073,6 +4076,7 @@ mod tests {
                     verbose_name: None,
                     editable: true,
                     blank: false,
+                    case_insensitive: false,
                     validators: &[],
                 },
                 crate::core::FieldSchema {
@@ -4095,6 +4099,7 @@ mod tests {
                     verbose_name: None,
                     editable: true,
                     blank: false,
+                    case_insensitive: false,
                     validators: &[],
                 },
             ])),
@@ -4477,6 +4482,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                case_insensitive: false,
                 validators: &[],
             }])),
             display: None,
@@ -4724,6 +4730,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                case_insensitive: false,
                 validators: &[],
             }])),
             display: None,
@@ -4783,6 +4790,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                case_insensitive: false,
                 validators: &[],
             }])),
             display: None,
@@ -5315,6 +5323,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                case_insensitive: false,
                 validators: &[],
             })) as &'static crate::core::FieldSchema
         };

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1701,6 +1701,7 @@ mod lookup_tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         }
     }
@@ -1726,6 +1727,7 @@ mod lookup_tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         }
     }

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -308,6 +308,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         }
     }
@@ -333,6 +334,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         }
     }
@@ -358,6 +360,7 @@ mod tests {
             verbose_name: None,
             editable: true,
             blank: false,
+            case_insensitive: false,
             validators: &[],
         }
     }
@@ -384,6 +387,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                case_insensitive: false,
                 validators: &[],
             },
             FieldSchema {
@@ -406,6 +410,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                case_insensitive: false,
                 validators: &[],
             },
             FieldSchema {
@@ -428,6 +433,7 @@ mod tests {
                 verbose_name: None,
                 editable: true,
                 blank: false,
+                case_insensitive: false,
                 validators: &[],
             },
         ];

--- a/crates/rustango/tests/field_types_decimal_binary_time.rs
+++ b/crates/rustango/tests/field_types_decimal_binary_time.rs
@@ -128,6 +128,7 @@ fn form_parser_decimal() {
         verbose_name: None,
         editable: true,
         blank: false,
+        case_insensitive: false,
         validators: &[],
     };
     let v = parse_form_value(&f, Some("123.45")).unwrap();
@@ -161,6 +162,7 @@ fn form_parser_binary_hex() {
         verbose_name: None,
         editable: true,
         blank: false,
+        case_insensitive: false,
         validators: &[],
     };
     let v = parse_form_value(&f, Some("deadbeef")).unwrap();
@@ -196,6 +198,7 @@ fn form_parser_time() {
         verbose_name: None,
         editable: true,
         blank: false,
+        case_insensitive: false,
         validators: &[],
     };
     // Full HH:MM:SS form.

--- a/crates/rustango/tests/macro_citext.rs
+++ b/crates/rustango/tests/macro_citext.rs
@@ -1,0 +1,95 @@
+//! Django-parity #344 — `#[rustango(citext)]` field attribute that
+//! routes the migration DDL through `dialect.ci_text_type` instead
+//! of the plain `column_type` mapping.
+//!
+//! Verifies:
+//! 1. The flag threads from macro → `FieldSchema::case_insensitive`.
+//! 2. PG emits `CITEXT`, SQLite emits `TEXT COLLATE NOCASE`, MySQL
+//!    emits `TEXT COLLATE utf8mb4_general_ci`.
+//! 3. PG's `ci_text_extension_sql()` returns the right prelude.
+//! 4. Other field types (`i64`, `DateTime`) ignore the flag — the
+//!    macro accepts it but the DDL falls through to the normal type.
+
+#![cfg(feature = "sqlite")]
+
+use rustango::core::Model;
+use rustango::migrate::ddl::create_table_sql_with_dialect;
+use rustango::sql::{Dialect as _, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "ci_users")]
+#[allow(dead_code)]
+pub struct CiUser {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(citext, max_length = 200)]
+    email: String,
+    // Plain text — no flag — used as the contrast control.
+    bio: String,
+}
+
+#[test]
+fn citext_attr_threads_into_field_schema() {
+    let schema = <CiUser as Model>::SCHEMA;
+    let email = schema
+        .fields
+        .iter()
+        .find(|f| f.name == "email")
+        .expect("email field");
+    let bio = schema
+        .fields
+        .iter()
+        .find(|f| f.name == "bio")
+        .expect("bio field");
+    assert!(email.case_insensitive, "email should be case_insensitive");
+    assert!(!bio.case_insensitive, "bio should NOT be case_insensitive");
+}
+
+#[test]
+fn postgres_emits_citext_column_type() {
+    let sql = create_table_sql_with_dialect(&Postgres, <CiUser as Model>::SCHEMA);
+    assert!(
+        sql.contains("\"email\" CITEXT"),
+        "expected CITEXT on PG, got: {sql}"
+    );
+    // Plain field stays VARCHAR/TEXT.
+    assert!(
+        !sql.contains("\"bio\" CITEXT"),
+        "bio must not be CITEXT: {sql}"
+    );
+}
+
+#[test]
+fn sqlite_emits_text_collate_nocase() {
+    let sql = create_table_sql_with_dialect(&Sqlite, <CiUser as Model>::SCHEMA);
+    assert!(
+        sql.contains("\"email\" TEXT COLLATE NOCASE"),
+        "expected TEXT COLLATE NOCASE on SQLite, got: {sql}"
+    );
+    assert!(
+        !sql.contains("\"bio\" TEXT COLLATE NOCASE"),
+        "bio must not be COLLATE NOCASE: {sql}"
+    );
+}
+
+#[test]
+fn mysql_emits_varchar_collate_utf8mb4_general_ci() {
+    let sql = create_table_sql_with_dialect(&MySql, <CiUser as Model>::SCHEMA);
+    // max_length = 200 → VARCHAR(200) on MySQL.
+    assert!(
+        sql.contains("`email` VARCHAR(200) COLLATE utf8mb4_general_ci"),
+        "expected VARCHAR COLLATE on MySQL, got: {sql}"
+    );
+}
+
+#[test]
+fn postgres_extension_prelude_is_available() {
+    assert_eq!(
+        Postgres.ci_text_extension_sql(),
+        Some("CREATE EXTENSION IF NOT EXISTS citext;"),
+    );
+    // SQLite + MySQL need no prelude.
+    assert_eq!(Sqlite.ci_text_extension_sql(), None);
+    assert_eq!(MySql.ci_text_extension_sql(), None);
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -182,9 +182,9 @@ Summary: **14 SHIPPED / 4 PARTIAL / 7 MISSING / 0 N/A** in this section. Gaps cl
 | `ArrayField` | [ArrayField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#arrayfield) | PARTIAL | `SqlValue::Array` + `Op::ArrayContains/ContainedBy/Overlap` operators emitted on PG; no native typed field wrapper in models (#341) | Future-backlog item. |
 | `HStoreField` | [HStoreField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#hstorefield) | MISSING | n/a (#342) | |
 | `RangeField` (Int / Date / DateTime / Decimal) | [RangeField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#range-fields) | MISSING | n/a — `SqlValue::RangeLiteral` exists but no typed field (#343) | |
-| `CITextField` | [CITextField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#citext-fields) | MISSING | n/a (#344) | |
+| `CITextField` | [CITextField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#citext-fields) | SHIPPED | `#[rustango(citext)]` (#344) — DDL emits `CITEXT` on PG (with `CREATE EXTENSION IF NOT EXISTS citext;` prelude available via `dialect.ci_text_extension_sql()`), `TEXT COLLATE NOCASE` on SQLite, `VARCHAR(N)/TEXT COLLATE utf8mb4_general_ci` on MySQL. Column-level case-insensitivity propagates to `=` / `LIKE` / `ORDER BY` without query-side `LOWER(...)` wrapping. | |
 
-Summary: **1 / 1 / 3 / 0**.
+Summary: **2 / 1 / 2 / 0**.
 
 ---
 


### PR DESCRIPTION
## Summary

Django's \`CITextField\` adds case-insensitive comparison collation to a text column. \`#[rustango(citext)]\` wires the equivalent through the macro so apps mark a column case-insensitive once and get correct \`WHERE col = 'foo'\` ≡ \`'FOO'\` / \`'Foo'\` matching on every backend.

\`\`\`rust
#[derive(Model)]
pub struct User {
    #[rustango(primary_key)] id: i64,
    #[rustango(citext, max_length = 200)] email: String,
    bio: String, // plain case-sensitive
}
\`\`\`

## Per-dialect DDL

| Backend | Column type emit |
|---|---|
| Postgres | \`CITEXT\` (needs citext extension; auto-prelude via \`dialect.ci_text_extension_sql()\` → \`CREATE EXTENSION IF NOT EXISTS citext;\`) |
| SQLite | \`TEXT COLLATE NOCASE\` |
| MySQL | \`VARCHAR(N) COLLATE utf8mb4_general_ci\` (with max_length) / \`TEXT COLLATE utf8mb4_general_ci\` (without) |

Column-level collation propagates to \`=\` / \`LIKE\` / \`ORDER BY\` — no query-side \`LOWER(...)\` wrapping needed.

## Wiring

- \`FieldSchema::case_insensitive\` (new bool, default false)
- \`FieldSnapshot::case_insensitive\` (skipped on serialize when false — older snapshots stay diff-clean)
- \`Dialect::ci_text_type(max_length) -> String\` (new trait method, default \"TEXT\" so unknown dialects degrade gracefully)
- \`Dialect::ci_text_extension_sql() -> Option<&'static str>\` (new trait method for one-time DDL preludes)
- Live + snapshot DDL emit routes through \`ci_text_type\` when \`case_insensitive && ty == String\`

## What's NOT shipped

The auto-emit of \`CREATE EXTENSION IF NOT EXISTS citext;\` ahead of a CREATE TABLE that uses CITEXT — exposed via the helper but not yet auto-threaded through \`make_migrations\`. Operators run it manually (or via a project-local migration prelude) for now. Tracked as follow-up.

## Test plan

- [x] 5 macro tests in \`tests/macro_citext.rs\` — flag threading, per-dialect column type, PG extension prelude
- [x] cargo test --no-default-features --features sqlite,tenancy --lib  → 1547 pass
- [x] cargo test --workspace --all-features --no-run  → clean
- [x] Pre-push hook clean
- [x] Audit row 185 flipped MISSING → SHIPPED; section summary 1/1/3/0 → 2/1/2/0