### PR TITLE
fix(audit): bind sqlite cleanup_older_than cutoff in space-shape format (#560)

### DIFF
--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -1149,11 +1149,20 @@ pub async fn cleanup_older_than_pool(
         }
         #[cfg(feature = "sqlite")]
         crate::sql::Pool::Sqlite(sq) => {
-            // SQLite has no native TIMESTAMPTZ — sqlx encodes
-            // chrono::DateTime<Utc> as an ISO 8601 string which
-            // matches the `CURRENT_TIMESTAMP` default in
-            // `CREATE_TABLE_SQL_SQLITE`.
-            let r = sqlx::query(&sql).bind(cutoff_ts).execute(sq).await?;
+            // #560 — `occurred_at` is `TEXT DEFAULT CURRENT_TIMESTAMP`
+            // (see `CREATE_TABLE_SQL_SQLITE`). SQLite's built-in
+            // `CURRENT_TIMESTAMP` emits `"YYYY-MM-DD HH:MM:SS"` —
+            // space separator, no fractional, no timezone. sqlx-sqlite
+            // encodes a `chrono::DateTime<Utc>` as RFC3339
+            // `"YYYY-MM-DDTHH:MM:SS.ssssss+00:00"`. Comparing those two
+            // as TEXT lexicographically diverges at position 10
+            // (space `0x20` < `T` `0x54`), so any row from CURRENT_TIMESTAMP
+            // on the same calendar day as the cutoff but with a later
+            // HH:MM was silently deleted as "older". Bind the cutoff
+            // in the same CURRENT_TIMESTAMP shape so both sides of the
+            // `<` compare against the same format.
+            let cutoff_str = cutoff_ts.format("%Y-%m-%d %H:%M:%S").to_string();
+            let r = sqlx::query(&sql).bind(cutoff_str).execute(sq).await?;
             Ok(r.rows_affected())
         }
     }

--- a/crates/rustango/tests/audit_pool_sqlite_live.rs
+++ b/crates/rustango/tests/audit_pool_sqlite_live.rs
@@ -103,18 +103,118 @@ async fn fetch_for_entity_returns_empty_for_unknown_pk() {
 async fn cleanup_older_than_clears_when_cutoff_zero() {
     let pool = pool().await;
     ensure_table_pool(&pool).await.unwrap();
+    // Seed 5 rows with explicitly-old `occurred_at` so the test is
+    // deterministic regardless of how fast emit + cleanup run back to
+    // back. Bypassing `emit_one_pool`'s `CURRENT_TIMESTAMP` default
+    // also keeps the assertion stable on slow CI runners where the
+    // emit + cleanup land in the same wall-clock second.
+    //
+    // Pre-#560 the test "worked" only because the bound RFC3339
+    // cutoff lex-compared as later than every `CURRENT_TIMESTAMP`
+    // space-shape value (space `0x20` < `T` `0x54`); post-fix both
+    // sides bind in the same space format, so we need rows that
+    // genuinely sit before the cutoff.
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!()
+    };
     for i in 0..5 {
-        emit_one_pool(
-            &pool,
-            &entry("post", &format!("{i}"), AuditOp::Create, json!({"i": i})),
+        sqlx::query(
+            r#"INSERT INTO "rustango_audit_log"
+                  ("entity_table", "entity_pk", "operation", "source", "changes", "occurred_at")
+               VALUES (?, ?, ?, ?, ?, ?)"#,
         )
+        .bind("post")
+        .bind(format!("{i}"))
+        .bind("create")
+        .bind("test")
+        .bind(json!({"i": i}).to_string())
+        .bind("2020-01-01 00:00:00")
+        .execute(sq)
         .await
         .unwrap();
     }
     // `cutoff_days = 0` → cutoff timestamp is "right now" → everything
-    // is older, so the DELETE removes the lot.
+    // (stamped 2020) is older, so the DELETE removes the lot.
     let removed = cleanup_older_than_pool(&pool, 0).await.unwrap();
     assert_eq!(removed, 5);
+}
+
+/// #560 regression — SQLite's `CURRENT_TIMESTAMP` emits
+/// `"YYYY-MM-DD HH:MM:SS"` (space separator), but until the v0.43 fix
+/// `cleanup_older_than_pool` bound the chrono cutoff as an RFC3339
+/// string `"YYYY-MM-DDTHH:MM:SSZ"`. SQLite compared those two as TEXT
+/// lex-by-byte, and space (0x20) sorts BEFORE T (0x54). So a row from
+/// `CURRENT_TIMESTAMP` later in the same calendar day as the cutoff
+/// was silently judged "older than" the cutoff and DELETEd.
+///
+/// Reproduce by inserting a row at the very end of today's UTC day,
+/// then running `cleanup_older_than_pool(pool, 0)` — cutoff = now —
+/// and assert the future-today row survives. Pre-fix this assertion
+/// failed deterministically; post-fix it passes.
+#[tokio::test]
+async fn cleanup_older_than_compares_apples_to_apples_on_sqlite() {
+    use sqlx::Row as _;
+    let pool = pool().await;
+    ensure_table_pool(&pool).await.unwrap();
+
+    // Synthesize a row at the very end of today's UTC day (or tomorrow
+    // if "now" is past 23:50 — pick a stamp safely after now).
+    let now = chrono::Utc::now();
+    let future_today = now
+        .date_naive()
+        .and_hms_opt(23, 59, 59)
+        .expect("23:59:59 valid");
+    let future_today_str = future_today.format("%Y-%m-%d %H:%M:%S").to_string();
+    // If we ARE in the last 10 minutes of the day, bump to tomorrow so
+    // the row genuinely sits in the future relative to "now".
+    let stamp = if now.naive_utc() >= future_today - chrono::Duration::minutes(10) {
+        (now + chrono::Duration::days(1))
+            .date_naive()
+            .and_hms_opt(12, 0, 0)
+            .unwrap()
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string()
+    } else {
+        future_today_str
+    };
+
+    // Insert with an explicit space-shape occurred_at. Bypass
+    // `emit_one_pool` so we control the timestamp shape exactly —
+    // simulating what `CURRENT_TIMESTAMP` produces.
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!()
+    };
+    sqlx::query(
+        r#"INSERT INTO "rustango_audit_log"
+              ("entity_table", "entity_pk", "operation", "source", "changes", "occurred_at")
+           VALUES (?, ?, ?, ?, ?, ?)"#,
+    )
+    .bind("post")
+    .bind("future-row")
+    .bind("create")
+    .bind("test")
+    .bind(r#"{"k": "v"}"#)
+    .bind(&stamp)
+    .execute(sq)
+    .await
+    .unwrap();
+
+    // cutoff_days = 0 → cutoff = now → only strictly-older rows go.
+    let removed = cleanup_older_than_pool(&pool, 0).await.unwrap();
+    assert_eq!(
+        removed, 0,
+        "future row (stamp={stamp}) must survive `cutoff_days=0`; pre-fix this deleted it via space-vs-T lex compare"
+    );
+
+    // Sanity: row still queryable.
+    let count: i64 =
+        sqlx::query(r#"SELECT COUNT(*) AS c FROM "rustango_audit_log" WHERE "entity_pk" = ?"#)
+            .bind("future-row")
+            .fetch_one(sq)
+            .await
+            .unwrap()
+            .get("c");
+    assert_eq!(count, 1, "future row must still be present in storage");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

\`cleanup_older_than_pool\` was a **silent-wrong-result** on SQLite (reported in #560 alongside #557/#556/#559).

The \`occurred_at\` column is \`TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP\`, and SQLite's built-in \`CURRENT_TIMESTAMP\` emits the legacy \`\"YYYY-MM-DD HH:MM:SS\"\` shape (space separator). But the cleanup helper bound a \`chrono::DateTime<Utc>\` cutoff which sqlx-sqlite encodes as RFC3339 \`\"YYYY-MM-DDTHH:MM:SS.ssssss+00:00\"\`.

SQLite compared the two as TEXT lex byte-by-byte. At position 10 the space (\`0x20\`) sorts BEFORE \`T\` (\`0x54\`), so for ANY row whose date matched the cutoff's date, the comparison ALWAYS said \"row < cutoff\" regardless of the HH:MM:SS portion. Consequence: rows from \`CURRENT_TIMESTAMP\` LATER in the same calendar day as the cutoff were silently deleted as \"older.\"

## Fix

Bind the cutoff as \`cutoff_ts.format(\"%Y-%m-%d %H:%M:%S\")\` so both sides of \`<\` use the same \`CURRENT_TIMESTAMP\` shape. No schema change; no migration needed.

## Regression test

\`cleanup_older_than_compares_apples_to_apples_on_sqlite\` — explicitly inserts a row stamped at the END of today's UTC day (or tomorrow if \"now\" is past 23:50), calls \`cleanup_older_than_pool(pool, 0)\`, asserts the row SURVIVES. Pre-fix this assertion failed deterministically; post-fix it passes.

Also rewrote \`cleanup_older_than_clears_when_cutoff_zero\` to seed rows with an explicit 2020 stamp instead of relying on \`CURRENT_TIMESTAMP\` — the original \"passed by coincidence\" because the lex bug made every \`CURRENT_TIMESTAMP\` row look older than any RFC3339 cutoff. Post-fix we need rows that genuinely sit before the cutoff to keep the assertion stable.

## Test plan

- [x] 14/14 audit_pool_sqlite_live pass (including the new regression + the rewritten existing one)
- [x] cargo test --no-default-features --features sqlite,tenancy --lib → 1547 pass
- [x] cargo test --workspace --all-features --no-run → clean
- [x] No schema migration required