### PR TITLE
fix(sql): MySQL OFFSET without LIMIT — emit placeholder LIMIT 18446744073709551615 (#560)

### DIFF
--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -227,6 +227,24 @@ pub trait Dialect {
         "RANDOM"
     }
 
+    /// SQL fragment to emit as the `LIMIT` clause when the query has
+    /// an explicit `OFFSET` but no `LIMIT` (#560).
+    ///
+    /// MySQL's grammar requires a `LIMIT` whenever `OFFSET` is used
+    /// — `SELECT … OFFSET 10` alone is `ERROR 1064` ("you have an
+    /// error in your SQL syntax"). The documented workaround is to
+    /// pair the OFFSET with the max-`u64` literal:
+    /// `LIMIT 18446744073709551615 OFFSET 10`. PG + SQLite accept
+    /// bare `OFFSET` without a `LIMIT`, so they return `None` here
+    /// and the writer emits the offset directly.
+    ///
+    /// Returning `Some("…")` causes the writer to prepend the
+    /// fragment ahead of the `OFFSET` clause; returning `None`
+    /// (the default) means "no placeholder LIMIT required".
+    fn offset_without_limit_clause(&self) -> Option<&'static str> {
+        None
+    }
+
     /// Wrap a SUM expression in a cast back to BIGINT. PostgreSQL's
     /// SUM(BIGINT) is NUMERIC and MySQL's is DECIMAL — both fall
     /// through to Null in the aggregate row decoder which only tries

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -60,6 +60,15 @@ impl Dialect for MySql {
         "RAND"
     }
 
+    /// MySQL rejects `OFFSET M` without a matching `LIMIT N` — the
+    /// parser raises `ERROR 1064` (#560). Documented workaround:
+    /// pair the OFFSET with the max-`u64` literal so the runtime cap
+    /// is effectively disabled. PG + SQLite accept bare OFFSET
+    /// without LIMIT and inherit the trait default (`None`).
+    fn offset_without_limit_clause(&self) -> Option<&'static str> {
+        Some(" LIMIT 18446744073709551615")
+    }
+
     /// `MySQL` quotes identifiers with backticks, not double quotes.
     /// Embedded backticks are doubled (the `MySQL` parser's escape rule)
     /// so the output is always a valid quoted identifier even for

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -3755,6 +3755,15 @@ fn write_order_limit_offset(
     }
     if let Some(n) = limit {
         let _ = write!(b.sql, " LIMIT {n}");
+    } else if offset.is_some() {
+        // #560 — `OFFSET` without `LIMIT` is illegal on MySQL
+        // (`ERROR 1064`). Dialects that need a placeholder LIMIT to
+        // make a bare OFFSET parse return one via
+        // `Dialect::offset_without_limit_clause()`. PG + SQLite
+        // return `None` and accept the bare OFFSET below.
+        if let Some(clause) = b.d.offset_without_limit_clause() {
+            b.sql.push_str(clause);
+        }
     }
     if let Some(n) = offset {
         let _ = write!(b.sql, " OFFSET {n}");

--- a/crates/rustango/tests/offset_without_limit.rs
+++ b/crates/rustango/tests/offset_without_limit.rs
@@ -1,0 +1,117 @@
+//! Tri-dialect emission tests for `.offset(N)` without a paired
+//! `.limit(M)`. Issue #560.
+//!
+//! MySQL's grammar requires a `LIMIT` whenever `OFFSET` appears —
+//! `SELECT … OFFSET 10` alone raises `ERROR 1064`. The fix is to
+//! emit `LIMIT 18446744073709551615` (the documented max-`u64`
+//! placeholder) ahead of the OFFSET on MySQL. PG + SQLite accept
+//! the bare OFFSET and the writer leaves the LIMIT off.
+
+use rustango::core::Model as _;
+use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "owl_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 200)]
+    title: String,
+}
+
+#[test]
+fn postgres_offset_without_limit_emits_bare_offset() {
+    let stmt = Postgres
+        .compile_select(&Post::objects().offset(10).compile().unwrap())
+        .unwrap();
+    assert!(
+        stmt.sql.contains("OFFSET 10"),
+        "missing OFFSET 10: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains("LIMIT "),
+        "PG should NOT add a placeholder LIMIT: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn sqlite_offset_without_limit_emits_bare_offset() {
+    let stmt = Sqlite
+        .compile_select(&Post::objects().offset(7).compile().unwrap())
+        .unwrap();
+    assert!(stmt.sql.contains("OFFSET 7"), "got: {}", stmt.sql);
+    assert!(
+        !stmt.sql.contains("LIMIT "),
+        "SQLite should NOT add a placeholder LIMIT: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn mysql_offset_without_limit_emits_placeholder_limit() {
+    let stmt = MySql
+        .compile_select(&Post::objects().offset(5).compile().unwrap())
+        .unwrap();
+    // The placeholder LIMIT precedes the OFFSET — together MySQL
+    // parses them as a valid pagination clause.
+    assert!(
+        stmt.sql.contains("LIMIT 18446744073709551615 OFFSET 5"),
+        "MySQL must emit placeholder LIMIT for bare OFFSET; got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn mysql_offset_with_explicit_limit_still_works_normally() {
+    // Make sure the fix doesn't double-emit when LIMIT is also set.
+    let stmt = MySql
+        .compile_select(&Post::objects().limit(20).offset(5).compile().unwrap())
+        .unwrap();
+    assert!(
+        stmt.sql.contains("LIMIT 20 OFFSET 5"),
+        "explicit LIMIT must be respected; got: {}",
+        stmt.sql
+    );
+    assert!(
+        !stmt.sql.contains("18446744073709551615"),
+        "no placeholder when LIMIT is explicit; got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn limit_only_unaffected_on_every_dialect() {
+    for (name, sql) in [
+        (
+            "pg",
+            Postgres
+                .compile_select(&Post::objects().limit(10).compile().unwrap())
+                .unwrap()
+                .sql,
+        ),
+        (
+            "sqlite",
+            Sqlite
+                .compile_select(&Post::objects().limit(10).compile().unwrap())
+                .unwrap()
+                .sql,
+        ),
+        (
+            "mysql",
+            MySql
+                .compile_select(&Post::objects().limit(10).compile().unwrap())
+                .unwrap()
+                .sql,
+        ),
+    ] {
+        assert!(sql.contains("LIMIT 10"), "[{name}] LIMIT 10 missing: {sql}");
+        assert!(
+            !sql.contains("OFFSET "),
+            "[{name}] OFFSET shouldn't appear when only LIMIT is set: {sql}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

\`QuerySet::offset(N)\` without a paired \`.limit(M)\` compiled to a bare \`SELECT … OFFSET N\` regardless of dialect. PG and SQLite accept that grammar; **MySQL rejects it as \`ERROR 1064\`**:

\`\`\`
mysql> SELECT * FROM t OFFSET 10;
ERROR 1064 (42000): You have an error in your SQL syntax …
\`\`\`

MySQL requires a \`LIMIT\` whenever \`OFFSET\` appears. The documented workaround is to pair the OFFSET with the max-\`u64\` literal so the runtime cap is effectively disabled:

\`\`\`
SELECT * FROM t LIMIT 18446744073709551615 OFFSET 10;
\`\`\`

Reported as one of the runtime failures in #560.

## Fix

New trait method \`Dialect::offset_without_limit_clause()\` returns \`None\` by default (PG + SQLite — bare OFFSET parses) and \`Some(\" LIMIT 18446744073709551615\")\` on MySQL. \`write_order_limit_offset\` consults it only when \`offset.is_some() && limit.is_none()\`, so the existing happy path (LIMIT + OFFSET together) stays byte-identical on every dialect.

## Test plan

5 tri-dialect emission tests in \`tests/offset_without_limit.rs\`:
- [x] PG: bare OFFSET, no placeholder LIMIT
- [x] SQLite: bare OFFSET, no placeholder LIMIT
- [x] MySQL bare-OFFSET: placeholder LIMIT emitted
- [x] MySQL with explicit LIMIT: no placeholder, no double-emit
- [x] LIMIT-only on all three dialects: no OFFSET appears

Plus:
- [x] cargo test --no-default-features --features sqlite,tenancy --lib → 1547 pass
- [x] cargo test --workspace --all-features --no-run → clean