### PR TITLE
fix(sql): implement SQLite bulk_update via CTE + correlated subqueries (#560)

### DIFF
--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -30,8 +30,8 @@ use crate::core::{
 };
 
 use super::writers::{
-    write_aggregate, write_bulk_insert, write_count, write_delete, write_insert, write_select,
-    write_update, Sql,
+    write_aggregate, write_bulk_insert, write_bulk_update_sqlite, write_count, write_delete,
+    write_insert, write_select, write_update, Sql,
 };
 use super::{CompiledStatement, Dialect, SqlError};
 
@@ -454,14 +454,15 @@ impl Dialect for Sqlite {
     }
 
     fn compile_bulk_update(&self, query: &BulkUpdateQuery) -> Result<CompiledStatement, SqlError> {
-        // BulkUpdateQuery uses Postgres' `UPDATE … FROM (VALUES …)`
-        // shape. SQLite supports `UPDATE … FROM` since 3.33 but the
-        // current `writers::write_bulk_update` is Postgres-shaped
-        // enough that SQLite needs its own write path. Surface a
-        // clear "not implemented yet" error rather than emit
-        // possibly-broken SQL — Phase 2 ships the SQLite variant.
-        let _ = query;
-        Err(SqlError::DialectQueryCompilationNotImplemented { dialect: "sqlite" })
+        // #560 — SQLite's UPDATE-FROM doesn't accept the
+        // column-list-alias-on-inline-VALUES form Postgres uses
+        // (`FROM (VALUES …) AS __data(pk, col, …)` → `near "(":
+        // syntax error`). Route to a CTE + correlated-subquery
+        // shape that parses on every SQLite that supports CTEs
+        // (3.8.3, 2014); see `writers::write_bulk_update_sqlite`.
+        let mut b = Sql::new(self);
+        write_bulk_update_sqlite(&mut b, query)?;
+        Ok(b.finish())
     }
 
     fn compile_delete(&self, query: &DeleteQuery) -> Result<CompiledStatement, SqlError> {

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -2903,6 +2903,79 @@ pub(super) fn write_delete(b: &mut Sql<'_>, query: &DeleteQuery) -> Result<(), S
 // error in its own compile_bulk_update.
 // ====================================================================
 
+/// #560 — SQLite variant of `bulk_update`. SQLite supports
+/// `UPDATE … FROM <subquery>` since 3.33, but **not** the
+/// column-list-alias-on-inline-VALUES form Postgres uses
+/// (`FROM (VALUES …) AS __data(pk, col, …)`); SQLite raises
+/// `near "(": syntax error` at the alias parens. The
+/// CTE + correlated-subquery shape below parses everywhere
+/// SQLite has supported CTEs (3.8.3, 2014).
+pub(super) fn write_bulk_update_sqlite(
+    b: &mut Sql<'_>,
+    query: &BulkUpdateQuery,
+) -> Result<(), SqlError> {
+    if query.rows.is_empty() {
+        return Err(SqlError::EmptyBulkInsert);
+    }
+    if query.update_columns.is_empty() {
+        return Err(SqlError::EmptyUpdateSet);
+    }
+    let pk_field = query
+        .model
+        .primary_key()
+        .ok_or(SqlError::MissingPrimaryKey)?;
+
+    // WITH __data(<pk>, <c1>, …) AS (VALUES (?, …), (?, …))
+    b.sql.push_str("WITH __data(");
+    b.write_ident(pk_field.column);
+    for col in &query.update_columns {
+        b.sql.push_str(", ");
+        b.write_ident(col);
+    }
+    b.sql.push_str(") AS (VALUES ");
+    let mut first_row = true;
+    for row in &query.rows {
+        if !first_row {
+            b.sql.push_str(", ");
+        }
+        first_row = false;
+        b.sql.push('(');
+        for (i, val) in row.iter().enumerate() {
+            if i > 0 {
+                b.sql.push_str(", ");
+            }
+            b.push_param(val.clone());
+        }
+        b.sql.push(')');
+    }
+    b.sql.push_str(") UPDATE ");
+    b.write_ident(query.model.table);
+    b.sql.push_str(" SET ");
+    let mut first_col = true;
+    for col in &query.update_columns {
+        if !first_col {
+            b.sql.push_str(", ");
+        }
+        first_col = false;
+        b.write_ident(col);
+        b.sql.push_str(" = (SELECT ");
+        b.write_ident(col);
+        b.sql.push_str(" FROM __data WHERE __data.");
+        b.write_ident(pk_field.column);
+        b.sql.push_str(" = ");
+        b.write_ident(query.model.table);
+        b.sql.push('.');
+        b.write_ident(pk_field.column);
+        b.sql.push(')');
+    }
+    b.sql.push_str(" WHERE ");
+    b.write_ident(pk_field.column);
+    b.sql.push_str(" IN (SELECT ");
+    b.write_ident(pk_field.column);
+    b.sql.push_str(" FROM __data)");
+    Ok(())
+}
+
 pub(super) fn write_bulk_update_pg(
     b: &mut Sql<'_>,
     query: &BulkUpdateQuery,

--- a/crates/rustango/tests/sqlite_bulk_update_live.rs
+++ b/crates/rustango/tests/sqlite_bulk_update_live.rs
@@ -1,0 +1,144 @@
+//! Issue #560 — SQLite `bulk_update_pool` runtime failure. Previously
+//! `Sqlite::compile_bulk_update` returned
+//! `DialectQueryCompilationNotImplemented` so any call to the
+//! framework's `bulk_update_pool(&pool, &query)` against a SQLite
+//! `Pool` errored at execution time. SQLite's UPDATE-FROM doesn't
+//! accept the column-list-alias on an inline `VALUES` the way
+//! Postgres does (`AS __data(pk, …)` → `near "(": syntax error`),
+//! so the fix routes through a CTE + correlated-subquery writer
+//! (`write_bulk_update_sqlite`) that parses on every SQLite with
+//! CTE support (3.8.3, 2014).
+
+#![cfg(feature = "sqlite")]
+
+use rustango::core::{BulkUpdateQuery, Model as _, SqlValue};
+use rustango::sql::{bulk_update_pool, sqlx, Dialect as _, Pool, Sqlite};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "sbu_user")]
+#[allow(dead_code)]
+pub struct User {
+    #[rustango(primary_key)]
+    pub id: i64,
+    #[rustango(max_length = 80)]
+    pub name: String,
+    pub age: i64,
+}
+
+async fn fresh_pool() -> Pool {
+    let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE sbu_user (\
+            id INTEGER PRIMARY KEY, \
+            name TEXT NOT NULL, \
+            age INTEGER NOT NULL DEFAULT 0)",
+    )
+    .execute(&pool)
+    .await
+    .expect("create table");
+    for (i, name) in ["alice", "bob", "carol"].iter().enumerate() {
+        sqlx::query("INSERT INTO sbu_user (id, name, age) VALUES (?, ?, ?)")
+            .bind((i + 1) as i64)
+            .bind(*name)
+            .bind(0i64)
+            .execute(&pool)
+            .await
+            .expect("seed");
+    }
+    Pool::Sqlite(pool)
+}
+
+#[test]
+fn compile_bulk_update_emits_cte_correlated_subquery_shape() {
+    // Previously this errored with DialectQueryCompilationNotImplemented.
+    // The PG `FROM (VALUES …) AS __data(...)` shape doesn't parse on
+    // SQLite (column-list-alias on inline VALUES → `near "(": syntax
+    // error`), so SQLite gets its own CTE + correlated-subquery
+    // shape — supported on every SQLite that supports CTEs (3.8.3+).
+    let model = <User as rustango::core::Model>::SCHEMA;
+    let q = BulkUpdateQuery {
+        model,
+        update_columns: vec!["name", "age"],
+        rows: vec![
+            vec![
+                SqlValue::I64(1),
+                SqlValue::String("Alice".into()),
+                SqlValue::I64(30),
+            ],
+            vec![
+                SqlValue::I64(2),
+                SqlValue::String("Bob".into()),
+                SqlValue::I64(40),
+            ],
+        ],
+    };
+    let stmt = Sqlite
+        .compile_bulk_update(&q)
+        .expect("sqlite bulk_update must compile post-#560");
+    assert!(
+        stmt.sql
+            .starts_with("WITH __data(\"id\", \"name\", \"age\")"),
+        "expected CTE prelude; got: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains("AS (VALUES (?, ?, ?), (?, ?, ?))"),
+        "expected VALUES rows in CTE; got: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains("UPDATE \"sbu_user\" SET"),
+        "expected UPDATE … SET; got: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql
+            .contains("WHERE \"id\" IN (SELECT \"id\" FROM __data)"),
+        "expected PK IN-subquery; got: {}",
+        stmt.sql
+    );
+    assert_eq!(stmt.params.len(), 6);
+}
+
+#[tokio::test]
+async fn bulk_update_round_trips_against_sqlite_live_pool() {
+    let pool = fresh_pool().await;
+    let model = <User as rustango::core::Model>::SCHEMA;
+    let q = BulkUpdateQuery {
+        model,
+        update_columns: vec!["name", "age"],
+        rows: vec![
+            vec![
+                SqlValue::I64(1),
+                SqlValue::String("ALICE".into()),
+                SqlValue::I64(31),
+            ],
+            vec![
+                SqlValue::I64(3),
+                SqlValue::String("CAROL".into()),
+                SqlValue::I64(33),
+            ],
+        ],
+    };
+    let affected = bulk_update_pool(&pool, &q)
+        .await
+        .expect("bulk_update_pool must succeed on sqlite post-#560");
+    assert_eq!(affected, 2, "two rows in the VALUES set, two updates");
+
+    // Verify the round-trip — alice + carol got updated; bob untouched.
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!()
+    };
+    let mut rows: Vec<(i64, String, i64)> =
+        sqlx::query_as("SELECT id, name, age FROM sbu_user ORDER BY id")
+            .fetch_all(sq)
+            .await
+            .unwrap();
+    rows.sort_by_key(|r| r.0);
+    assert_eq!(rows[0], (1, "ALICE".into(), 31));
+    assert_eq!(rows[1], (2, "bob".into(), 0)); // untouched
+    assert_eq!(rows[2], (3, "CAROL".into(), 33));
+}


### PR DESCRIPTION
## Summary

\`Sqlite::compile_bulk_update\` previously returned \`DialectQueryCompilationNotImplemented\`, so any \`bulk_update_pool(&pool, &query)\` against a SQLite \`Pool\` failed at runtime. Reported in #560.

## Why not reuse the PG writer

The PG shape is \`UPDATE … FROM (VALUES (…), (…)) AS __data(pk, c1, …)\`. SQLite supports \`UPDATE … FROM <subquery>\` since 3.33, but **not** the column-list-alias on an inline \`VALUES\`:

\`\`\`
sqlite> UPDATE t SET c = __d.c FROM (VALUES (1, 'x')) AS __d(id, c) WHERE …;
Error: near \"(\": syntax error
\`\`\`

The parser rejects the \`(id, c)\` after \`__d\`. PG accepts this; MySQL has its own \`INNER JOIN (VALUES ROW(…)) AS __d(…)\` form; SQLite needs its own writer.

## SQLite shape

CTE + correlated subqueries — parses on every SQLite that supports CTEs (3.8.3, 2014):

\`\`\`sql
WITH __data(\"id\", \"name\", \"age\") AS (VALUES (?, ?, ?), (?, ?, ?))
UPDATE \"table\"
   SET \"name\" = (SELECT \"name\" FROM __data WHERE __data.\"id\" = \"table\".\"id\"),
       \"age\"  = (SELECT \"age\"  FROM __data WHERE __data.\"id\" = \"table\".\"id\")
 WHERE \"id\" IN (SELECT \"id\" FROM __data)
\`\`\`

The column-list alias on the CTE works (\`WITH name(c1, c2) AS …\`) where the same on \`FROM (VALUES …)\` doesn't.

## Test plan

- [x] Compile-shape test asserting CTE prelude + correlated subqueries + IN-subquery
- [x] Live round-trip on \`sqlite::memory:\` — seeds 3 rows, bulk-updates 2 of them, verifies the updated rows changed AND the untouched row didn't
- [x] cargo test --no-default-features --features sqlite,tenancy --lib → 1547 pass
- [x] cargo test --workspace --all-features --no-run → clean