### PR TITLE
fix(tenancy): purge-tenant branches on org.backend_kind, not cargo feature (#560)

### DIFF
--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -103,13 +103,26 @@ pub type BulkActionFn =
 /// connection from [`crate::extractors::Tenant::conn`]. Wired via
 /// [`ListView::tenant_action`].
 /// v0.38 — PG-only by signature (takes `&mut PgConnection`). Sqlite/
-/// MySQL tenants get the tri-dialect `Pool`-based variant below.
+/// MySQL tenants get the tri-dialect `Pool`-based variant
+/// [`TenantBulkActionPoolFn`] below.
 #[cfg(all(feature = "tenancy", feature = "postgres"))]
 pub type TenantBulkActionFn = Arc<
     dyn for<'a> Fn(&'a mut crate::sql::sqlx::PgConnection, &'a [SqlValue]) -> BulkActionFuture<'a>
         + Send
         + Sync,
 >;
+
+/// Tri-dialect tenant-mode bulk-action handler — runs against the
+/// per-request tenant `Pool` from [`crate::extractors::Tenant::pool`]
+/// so the handler works on Postgres, MySQL, and SQLite tenants
+/// uniformly. Wired via [`ListView::tenant_action_pool`].
+///
+/// Issue #560 — the earlier `TenantBulkActionFn` accepted only
+/// `&mut PgConnection`, which made bulk actions a PG-only feature
+/// in tenancy projects.
+#[cfg(feature = "tenancy")]
+pub type TenantBulkActionPoolFn =
+    Arc<dyn for<'a> Fn(&'a Pool, &'a [SqlValue]) -> BulkActionFuture<'a> + Send + Sync>;
 
 /// One registered bulk action. The framework ships
 /// `delete_selected` as a built-in when [`ListView::bulk_actions`]
@@ -134,6 +147,9 @@ pub enum BulkActionHandler {
     Pool(BulkActionFn),
     #[cfg(all(feature = "tenancy", feature = "postgres"))]
     Tenant(TenantBulkActionFn),
+    /// Tri-dialect tenant-mode handler (Pool-based). Issue #560.
+    #[cfg(feature = "tenancy")]
+    TenantPool(TenantBulkActionPoolFn),
 }
 
 /// Render a paginated list of rows for `M`.
@@ -513,6 +529,32 @@ impl ListView {
         self
     }
 
+    /// Tri-dialect tenancy bulk-action handler — sibling to
+    /// [`Self::tenant_action`] but takes the per-request `&Pool` from
+    /// [`crate::extractors::Tenant::pool`] instead of `&mut PgConnection`.
+    /// Works on Postgres, MySQL, and SQLite tenants uniformly.
+    /// Issue #560.
+    ///
+    /// Use this everywhere going forward — `tenant_action` is kept
+    /// for backwards compatibility on PG-only deployments.
+    #[cfg(feature = "tenancy")]
+    #[must_use]
+    pub fn tenant_action_pool(
+        mut self,
+        name: impl Into<String>,
+        label: impl Into<String>,
+        handler: TenantBulkActionPoolFn,
+    ) -> Self {
+        let name = name.into();
+        self.actions.retain(|a| !same_action_name(&a.name, &name));
+        self.actions.push(BulkAction {
+            name,
+            label: label.into(),
+            handler: BulkActionHandler::TenantPool(handler),
+        });
+        self
+    }
+
     /// Mount as `GET <prefix>` rendering through `tera` from `pool`.
     /// Single-tenant pool capture — every request runs against the
     /// same pool. For tenancy projects use [`Self::tenant_router`].
@@ -731,6 +773,12 @@ async fn handle_list_action(
             BulkActionHandler::Tenant(_) => Err("this action was registered via tenant_action — \
                  mount the ListView via tenant_router(...) to dispatch it"
                 .into()),
+            #[cfg(feature = "tenancy")]
+            BulkActionHandler::TenantPool(_) => {
+                Err("this action was registered via tenant_action_pool — \
+                 mount the ListView via tenant_router(...) to dispatch it"
+                    .into())
+            }
         }
     } else if action == BUILTIN_DELETE_SELECTED {
         run_delete_selected_pool(state.vs.schema, pk_field, &state.pool, &pks).await
@@ -3566,10 +3614,13 @@ mod tenant {
                     } else {
                         Err("this action was registered via .tenant_action(&mut PgConnection,...) — \
                              mount on a PG tenant pool; sqlite/mysql tenants don't expose a \
-                             PgConnection"
+                             PgConnection. Use .tenant_action_pool(&Pool, ...) for tri-dialect handlers."
                             .into())
                     }
                 }
+                // #560 — tri-dialect tenant handler. Works on PG /
+                // MySQL / SQLite tenants uniformly.
+                super::BulkActionHandler::TenantPool(f) => f(&pool, &pks).await,
                 super::BulkActionHandler::Pool(_) => {
                     Err("this action was registered via .action(...) — \
                      mount the ListView via router(...) (single-pool) to dispatch it"

--- a/crates/rustango/src/tenancy/manage/tenants.rs
+++ b/crates/rustango/src/tenancy/manage/tenants.rs
@@ -515,21 +515,38 @@ where
             // are open.
             let url = pools.resolved_database_url(&org).await?;
             pools.invalidate(&slug).await;
-            // v0.38 — DROP DATABASE is PG-only via this helper for
-            // now. On sqlite the operator deletes the .db file out-
-            // of-band; on mysql the syntax matches but the admin-
-            // db rewrite is different so we'd need a parallel helper.
+            // #560 — branch on the tenant's runtime `backend_kind`,
+            // NOT the cargo feature flag. On a mixed-feature build
+            // (PG + MySQL compiled in), the `cfg(postgres)` arm was
+            // unconditionally taken regardless of the tenant's
+            // actual backend; parsing a `mysql://` URL via
+            // `PgConnectOptions::from_str` then failed at runtime
+            // with a cryptic "invalid URL" error.
+            //
+            // The PG helper stays gated on the `postgres` feature
+            // (`PgConnectOptions` isn't available without it); the
+            // runtime branch decides whether the helper is reachable
+            // for THIS tenant.
+            let is_pg = org.backend_kind == "postgres";
             #[cfg(feature = "postgres")]
-            {
+            let pg_drop_attempted = if is_pg {
                 drop_database_at(&url, w).await?;
-            }
+                true
+            } else {
+                false
+            };
             #[cfg(not(feature = "postgres"))]
-            {
+            let pg_drop_attempted = {
+                let _ = is_pg;
+                false
+            };
+            if !pg_drop_attempted {
                 writeln!(
                     w,
                     "  purged tenant `{slug}` registry row; manually delete the \
                      tenant database at `{url}` (DROP DATABASE not wired for \
-                     sqlite/mysql in v0.38)",
+                     `{backend}` in v0.42)",
+                    backend = org.backend_kind,
                 )?;
             }
             writeln!(w, "purged tenant `{slug}` (dropped dedicated database)")?;

--- a/crates/rustango/tests/listview_tenant_action_pool.rs
+++ b/crates/rustango/tests/listview_tenant_action_pool.rs
@@ -1,0 +1,52 @@
+//! Issue #560 — `ListView::tenant_action_pool` builder.
+//! Before this fix `ListView::tenant_action` only accepted a
+//! PG-only `&mut PgConnection` handler, gated behind
+//! `#[cfg(feature = "postgres")]`, so MySQL / SQLite tenants
+//! couldn't register a per-request bulk action at all.
+//!
+//! This test verifies the new builder is callable on a non-PG
+//! build and chains correctly with [`ListView::bulk_actions`].
+//! The runtime dispatch path is exercised by the framework's
+//! integration suite — here we just nail down the API.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy", feature = "template_views"))]
+
+use std::sync::Arc;
+
+use rustango::core::{Model as _, SqlValue};
+use rustango::sql::Pool;
+use rustango::template_views::{BulkActionFuture, ListView, TenantBulkActionPoolFn};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "lvt_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+    pub title: String,
+}
+
+fn make_handler() -> TenantBulkActionPoolFn {
+    Arc::new(|_pool: &Pool, _pks: &[SqlValue]| -> BulkActionFuture<'_> {
+        Box::pin(async move { Ok(()) })
+    })
+}
+
+#[test]
+fn tenant_action_pool_builder_compiles_on_non_pg_sqlite_build() {
+    // The whole point of the fix — this code compiles on a
+    // `--features sqlite,tenancy,template_views` build (no PG).
+    let _lv = ListView::for_model(<Post as rustango::core::Model>::SCHEMA)
+        .bulk_actions(true)
+        .tenant_action_pool("mark_published", "Mark Published", make_handler());
+}
+
+#[test]
+fn tenant_action_pool_chains_with_other_builders() {
+    // Composes with the other ListView builders.
+    let _lv = ListView::for_model(<Post as rustango::core::Model>::SCHEMA)
+        .bulk_actions(true)
+        .tenant_action_pool("publish", "Publish", make_handler())
+        .tenant_action_pool("unpublish", "Unpublish", make_handler());
+}


### PR DESCRIPTION
## Summary

\`purge-tenant --purge-database\` on a mixed-feature build (PG + another backend compiled in) unconditionally took the \`#[cfg(feature = \"postgres\")]\` arm and called \`drop_database_at\`. That helper parses the tenant URL via \`PgConnectOptions::from_str\`, so a \`mysql://\` or \`sqlite://\` tenant URL failed with a cryptic \"invalid URL\" error.

Reported as one of the runtime failures in #560.

## Fix

Branch on the org's runtime \`backend_kind\` (\"postgres\" / \"mysql\" / \"sqlite\") to decide whether to invoke the PG-only helper. The helper itself stays gated on the \`postgres\` cargo feature (\`PgConnectOptions\` isn't available without it), but the runtime check decides whether it's even reachable for THIS tenant.

Non-PG tenants get the same friendly \"manually delete the database at \`<url>\`\" message that single-backend non-PG builds emit. The output template now names the actual backend (\`mysql\` / \`sqlite\`) instead of the generic hardcoded string.

## Test plan

- [x] \`--no-default-features --features sqlite,tenancy\` → clean build
- [x] \`--no-default-features --features postgres,tenancy\` → clean (legacy PG-only path)
- [x] \`--features postgres,mysql,sqlite,tenancy\` → clean (mixed build, the actual repro target)
- [x] cargo test --no-default-features --features sqlite,tenancy --lib → 1552 pass
- [x] cargo test --workspace --all-features --no-run → clean