### PR TITLE
refactor(hex): single hex_encode shared across crypto / pagination / row_to_json (#562)

### DIFF
--- a/crates/rustango/src/crypto.rs
+++ b/crates/rustango/src/crypto.rs
@@ -25,17 +25,14 @@
 use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256};
 
-/// Hex-encode a byte slice using lowercase digits. ~2× faster than
-/// `format!("{b:02x}")` per byte; matches the `hex` crate's output.
+/// Hex-encode a byte slice using lowercase digits. Delegates to
+/// [`crate::hex::hex_encode`] so there's a single canonical
+/// implementation shared with the always-on call sites (`pagination`,
+/// `row_to_json`). Kept here so HMAC callers don't need to rewrite
+/// their import paths.
 #[must_use]
 pub(crate) fn hex_encode(bytes: &[u8]) -> String {
-    const HEX: &[u8] = b"0123456789abcdef";
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        out.push(HEX[(b >> 4) as usize] as char);
-        out.push(HEX[(b & 0xf) as usize] as char);
-    }
-    out
+    crate::hex::hex_encode(bytes)
 }
 
 /// `SHA-256(bytes)` rendered as a lowercase hex string. Used by the

--- a/crates/rustango/src/hex.rs
+++ b/crates/rustango/src/hex.rs
@@ -1,0 +1,43 @@
+//! Tiny lowercase-hex codec — pure, no external deps. Lives outside
+//! [`crate::crypto`] so call sites that don't compile `hmac` / `sha2`
+//! (pagination cursor encoding, `row_to_json` binary columns) can
+//! still share one implementation.
+//!
+//! Renames `crate::crypto::hex_encode` from v0.42; the older path is
+//! kept as a re-export for the `hmac`-deps codepath.
+
+/// Render `bytes` as a lowercase hex string (no separator).
+#[must_use]
+pub(crate) fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0xf) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_yields_empty() {
+        assert_eq!(hex_encode(&[]), "");
+    }
+
+    #[test]
+    fn known_byte_vector() {
+        assert_eq!(hex_encode(&[0xde, 0xad, 0xbe, 0xef]), "deadbeef");
+    }
+
+    #[test]
+    fn full_byte_range_is_lowercase() {
+        let all: Vec<u8> = (0..=255u8).collect();
+        let s = hex_encode(&all);
+        assert_eq!(s.len(), 512);
+        assert!(s.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(!s.chars().any(|c| c.is_ascii_uppercase()));
+    }
+}

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -539,6 +539,13 @@ pub mod jsonapi;
 ))]
 pub(crate) mod crypto;
 
+/// Lowercase-hex codec — pure, no external deps. Lives outside
+/// [`crate::crypto`] so always-on call sites (`pagination` cursor
+/// encoding, `row_to_json` Binary arms) can share one
+/// implementation without pulling in the `crypto` feature deps.
+/// (#562 — DRY consolidation.)
+pub(crate) mod hex;
+
 /// Tiny `application/x-www-form-urlencoded` decoder shared by
 /// [`signed_url`], [`auth_flows`], and [`tenancy::admin`]. Internal.
 #[cfg(any(feature = "signed_url", feature = "auth_flows", feature = "tenancy",))]

--- a/crates/rustango/src/pagination.rs
+++ b/crates/rustango/src/pagination.rs
@@ -1186,18 +1186,10 @@ impl<T, P: serde::Serialize> CursorPage<T, P> {
     }
 }
 
-// ---- minimal lowercase-hex codec (kept private; pagination has no
-// optional-feature gate, and base64/urlencoding are opt-in deps here) ----
-
-fn hex_encode(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for &b in bytes {
-        out.push(HEX[(b >> 4) as usize] as char);
-        out.push(HEX[(b & 0x0f) as usize] as char);
-    }
-    out
-}
+// #562 — single `hex_encode` implementation lives in `crate::hex`;
+// pagination used to ship its own copy. `hex_decode` stays local —
+// the shared module doesn't (yet) ship a decoder.
+use crate::hex::hex_encode;
 
 fn hex_decode(s: &str) -> Result<Vec<u8>, String> {
     if s.len() % 2 != 0 {

--- a/crates/rustango/src/sql/executor/row_to_json.rs
+++ b/crates/rustango/src/sql/executor/row_to_json.rs
@@ -106,20 +106,11 @@ pub fn row_to_json(
     Value::Object(map)
 }
 
-/// Render `bytes` as a lowercase hex string (no separator). Used by
-/// the `row_to_json` family for [`FieldType::Binary`] columns — the
-/// always-on crate can't pull in `base64` (gated behind several
-/// features), so hex is the lowest-dep neutral encoding.
-#[inline]
-fn hex_encode(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut s = String::with_capacity(bytes.len() * 2);
-    for &b in bytes {
-        s.push(HEX[(b >> 4) as usize] as char);
-        s.push(HEX[(b & 0x0f) as usize] as char);
-    }
-    s
-}
+// #562 — single `hex_encode` implementation lives in `crate::hex`;
+// the `row_to_json` family used to ship a verbatim copy. Re-export
+// so the local `hex_encode(...)` call sites in the per-backend
+// `Binary` arms stay byte-identical.
+use crate::hex::hex_encode;
 
 /// MySQL counterpart of [`row_to_json`]. Decodes each column by
 /// `field.ty` against `&MySqlRow`. Type mappings mirror the


### PR DESCRIPTION
## Summary

Three byte-identical copies of \`hex_encode\` lived in:

- \`crypto.rs:31\` (gated on hmac/jwt/etc feature set)
- \`pagination.rs:1192\` (private)
- \`sql/executor/row_to_json.rs:114\` (private)

Diverging crypto helpers is a known CWE-694 footgun — keeping the implementation in one place is the right move even though this specific helper is non-cryptographic. Smallest of the #562 DRY items.

## Fix

New always-on \`crate::hex\` module owns the canonical implementation. \`crypto::hex_encode\` delegates to it (kept as a thin re-export so HMAC callers don't need their imports rewritten). \`pagination.rs\` + \`row_to_json.rs\` import from \`crate::hex::hex_encode\` instead of duplicating.

The new module is feature-gate-free (pure, no deps), so pagination + row_to_json no longer transitively need the hmac/sha2 feature combo to compile their copies.

## Test plan

- [x] 3 unit tests in \`crate::hex::tests\` (empty / known vector / full-byte-range)
- [x] cargo test --no-default-features --features sqlite,tenancy --lib → 1564 pass
- [x] cargo test --workspace --all-features --no-run → clean
- [x] No behavior change — byte-identical output