### PR TITLE
refactor(sql): Postgres null_cast delegates to cast_type (#562)

### DIFF
--- a/crates/rustango/src/sql/postgres.rs
+++ b/crates/rustango/src/sql/postgres.rs
@@ -99,22 +99,13 @@ impl Dialect for Postgres {
     }
 
     fn null_cast(&self, ty: FieldType) -> Option<&'static str> {
-        Some(match ty {
-            FieldType::I16 => "SMALLINT",
-            FieldType::I32 => "INTEGER",
-            FieldType::I64 => "BIGINT",
-            FieldType::F32 => "REAL",
-            FieldType::F64 => "DOUBLE PRECISION",
-            FieldType::Bool => "BOOLEAN",
-            FieldType::String => "TEXT",
-            FieldType::DateTime => "TIMESTAMPTZ",
-            FieldType::Date => "DATE",
-            FieldType::Uuid => "UUID",
-            FieldType::Json => "JSONB",
-            FieldType::Decimal => "NUMERIC",
-            FieldType::Binary => "BYTEA",
-            FieldType::Time => "TIME",
-        })
+        // #562 — the PG `null_cast` table was character-identical to
+        // the trait-default `cast_type` table 14 variants long.
+        // Delegate so the canonical token table lives in one place
+        // (`Dialect::cast_type` default impl); divergence between
+        // the two would silently change which `NULL::T` token PG
+        // sees.
+        self.cast_type(ty)
     }
 
     /// Postgres supports every `Op` the IR carries — `ILIKE`,


### PR DESCRIPTION
## Summary

The PG override of \`null_cast\` carried a 14-arm \`FieldType → PG-token\` map that was character-identical to the trait-default \`cast_type\` table. Two copies of the same canonical mapping is a silent footgun — adding a new \`FieldType\` variant would touch one without the other unless you knew to look at both.

## Fix

Delegate \`Postgres::null_cast(ty)\` → \`self.cast_type(ty)\`. The default \`cast_type\` impl already emits the exact PG token table (it's the canonical reference; non-PG dialects override). Byte-identical output, one canonical implementation.

## Test plan

- [x] cargo test --no-default-features --features sqlite,tenancy --lib → 1564 pass
- [x] cargo test --workspace --all-features --no-run → clean
- [x] No behavior change — both functions emitted the same tokens