### PR TITLE
refactor(audit,auth): legacy &PgPool fns delegate to their _pool siblings (#562)

### DIFF
--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -334,6 +334,10 @@ fn audit_cleanup_keep_last_n_sql(dialect: &dyn crate::sql::Dialect) -> String {
 ///
 /// PG-typed back-compat; for non-PG use [`fetch_for_entity_pool`].
 ///
+/// #562 — delegates to [`fetch_for_entity_pool`] so the SELECT template
+/// + decode loop lives in one place. The PG-typed signature stays so
+/// older call sites compile unchanged.
+///
 /// # Errors
 /// Driver / SQL failures.
 #[cfg(feature = "postgres")]
@@ -342,22 +346,12 @@ pub async fn fetch_for_entity(
     entity_table: &str,
     entity_pk: &str,
 ) -> Result<Vec<AuditEntry>, sqlx::Error> {
-    let rows: Vec<PgRow> = sqlx::query(
-        r#"SELECT "id", "entity_table", "entity_pk", "operation",
-                  "source", "changes", "occurred_at"
-           FROM "rustango_audit_log"
-           WHERE "entity_table" = $1 AND "entity_pk" = $2
-           ORDER BY "occurred_at" DESC, "id" DESC"#,
+    fetch_for_entity_pool(
+        &crate::sql::Pool::from(pool.clone()),
+        entity_table,
+        entity_pk,
     )
-    .bind(entity_table)
-    .bind(entity_pk)
-    .fetch_all(pool)
-    .await?;
-    let mut out = Vec::with_capacity(rows.len());
-    for row in rows {
-        out.push(AuditEntry::from_row(&row)?);
-    }
-    Ok(out)
+    .await
 }
 
 /// Decoded audit-log row.

--- a/crates/rustango/src/tenancy/auth_backends.rs
+++ b/crates/rustango/src/tenancy/auth_backends.rs
@@ -243,18 +243,14 @@ CREATE TABLE IF NOT EXISTS `rustango_api_keys` (
 /// [`ensure_api_keys_table_pool`] which picks the right per-dialect
 /// DDL constant via `pool.dialect().name()`.
 ///
+/// #562 — delegates to [`ensure_api_keys_table_pool`] so the
+/// statement-splitting loop lives in one place.
+///
 /// # Errors
 /// Driver failures.
 #[cfg(feature = "postgres")]
 pub async fn ensure_api_keys_table(pool: &crate::sql::sqlx::PgPool) -> Result<(), sqlx::Error> {
-    for stmt in API_KEY_ENSURE_SQL
-        .split(';')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-    {
-        sqlx::query(stmt).execute(pool).await?;
-    }
-    Ok(())
+    ensure_api_keys_table_pool(&crate::sql::Pool::from(pool.clone())).await
 }
 
 /// v0.38 — tri-dialect counterpart of [`ensure_api_keys_table`].


### PR DESCRIPTION
## Summary

Two more legacy \`&PgPool\` helpers from #562's delegate list. The \`_pool\` variants already exist and route through the dialect-aware emitters; the PG-typed back-compat wrappers can now be one-liners instead of byte-identical reimplementations of the bind + decode loops.

## Refactored

- \`audit::fetch_for_entity\` → \`fetch_for_entity_pool\` (was hand-rolled \`SELECT … WHERE entity_table=\$1 AND entity_pk=\$2 ORDER BY occurred_at DESC, id DESC\` with its own \`Vec<PgRow>\` decode loop)
- \`tenancy::auth_backends::ensure_api_keys_table\` → \`ensure_api_keys_table_pool\` (was a sqlx::query split-and-execute loop)

Left untouched per #562's \"do NOT refactor these\" callouts:
- \`audit::cleanup_*\` advisory-lock variants
- \`runner::ensure_ledger_for\` (advisory-lock variant)
- \`permissions::get_or_create_role\` (single-CTE PG fast-path)

## Test plan

- [x] cargo build --features postgres,tenancy clean
- [x] cargo test --no-default-features --features sqlite,tenancy --lib → 1564 pass
- [x] cargo test --workspace --all-features --no-run → clean
- [x] No behavior change