### PR TITLE
refactor(sql): single is_mysql_dup_index_error in sql::error (#561)

### DIFF
--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -603,20 +603,9 @@ pub async fn ensure_table_pool(pool: &crate::sql::Pool) -> Result<(), sqlx::Erro
     Ok(())
 }
 
-#[cfg(feature = "mysql")]
-fn is_mysql_dup_index_error(e: &sqlx::Error) -> bool {
-    if let sqlx::Error::Database(db) = e {
-        return db.code().as_deref() == Some("42000")
-            || db.message().contains("Duplicate key name");
-    }
-    false
-}
-
-#[cfg(not(feature = "mysql"))]
-#[allow(dead_code)]
-fn is_mysql_dup_index_error(_e: &sqlx::Error) -> bool {
-    false
-}
+// #561 — `is_mysql_dup_index_error` lives in `crate::sql::error`;
+// re-import here so the call site at :592 stays byte-identical.
+use crate::sql::is_mysql_dup_index_error;
 
 /// Per-row audit emit on a `MySqlConnection`-shape executor —
 /// counterpart of [`emit_one`] using `?` placeholders + backtick

--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -334,6 +334,10 @@ fn audit_cleanup_keep_last_n_sql(dialect: &dyn crate::sql::Dialect) -> String {
 ///
 /// PG-typed back-compat; for non-PG use [`fetch_for_entity_pool`].
 ///
+/// #562 — delegates to [`fetch_for_entity_pool`] so the SELECT template
+/// + decode loop lives in one place. The PG-typed signature stays so
+/// older call sites compile unchanged.
+///
 /// # Errors
 /// Driver / SQL failures.
 #[cfg(feature = "postgres")]
@@ -342,22 +346,12 @@ pub async fn fetch_for_entity(
     entity_table: &str,
     entity_pk: &str,
 ) -> Result<Vec<AuditEntry>, sqlx::Error> {
-    let rows: Vec<PgRow> = sqlx::query(
-        r#"SELECT "id", "entity_table", "entity_pk", "operation",
-                  "source", "changes", "occurred_at"
-           FROM "rustango_audit_log"
-           WHERE "entity_table" = $1 AND "entity_pk" = $2
-           ORDER BY "occurred_at" DESC, "id" DESC"#,
+    fetch_for_entity_pool(
+        &crate::sql::Pool::from(pool.clone()),
+        entity_table,
+        entity_pk,
     )
-    .bind(entity_table)
-    .bind(entity_pk)
-    .fetch_all(pool)
-    .await?;
-    let mut out = Vec::with_capacity(rows.len());
-    for row in rows {
-        out.push(AuditEntry::from_row(&row)?);
-    }
-    Ok(out)
+    .await
 }
 
 /// Decoded audit-log row.

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -1013,20 +1013,9 @@ async fn exec_one(pool: &crate::sql::Pool, sql: &str) -> Result<(), crate::sql::
     Ok(())
 }
 
-#[cfg(feature = "mysql")]
-fn is_mysql_dup_index_error(e: &crate::sql::sqlx::Error) -> bool {
-    if let crate::sql::sqlx::Error::Database(db) = e {
-        return db.code().as_deref() == Some("42000")
-            || db.message().contains("Duplicate key name");
-    }
-    false
-}
-
-#[cfg(not(feature = "mysql"))]
-#[allow(dead_code)]
-fn is_mysql_dup_index_error(_e: &crate::sql::sqlx::Error) -> bool {
-    false
-}
+// #561 — `is_mysql_dup_index_error` lives in `crate::sql::error`;
+// re-import for the call site at :990.
+use crate::sql::is_mysql_dup_index_error;
 
 /// Backend-agnostic counterpart of [`ensure_seeded`]. Walks the
 /// inventory of registered models and INSERTs a `ContentType` row for

--- a/crates/rustango/src/jobs/pg.rs
+++ b/crates/rustango/src/jobs/pg.rs
@@ -761,14 +761,9 @@ impl HandlerRegistry {
     }
 }
 
-#[cfg(feature = "mysql")]
-fn is_mysql_dup_index_error(e: &sqlx::Error) -> bool {
-    if let sqlx::Error::Database(db) = e {
-        return db.code().as_deref() == Some("42000")
-            || db.message().contains("Duplicate key name");
-    }
-    false
-}
+// #561 — `is_mysql_dup_index_error` lives in `crate::sql::error`;
+// re-import for the call site at :255.
+use crate::sql::is_mysql_dup_index_error;
 
 /// Best-effort `gethostname` without pulling a dep — read the env var
 /// most container runtimes set.

--- a/crates/rustango/src/media/tag.rs
+++ b/crates/rustango/src/media/tag.rs
@@ -201,14 +201,13 @@ impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for MediaTag {
     }
 }
 
-#[cfg(feature = "mysql")]
-pub(super) fn is_mysql_dup_index_error(e: &sqlx::Error) -> bool {
-    if let sqlx::Error::Database(db) = e {
-        return db.code().as_deref() == Some("42000")
-            || db.message().contains("Duplicate key name");
-    }
-    false
-}
+// #561 — `is_mysql_dup_index_error` was a `pub(super)` copy here so
+// `media::mod` + `media::collection` could reach across modules to
+// dodge a 5th duplicate. Re-export from `crate::sql::is_mysql_dup_index_error`
+// keeps those existing `super::tag::is_mysql_dup_index_error` /
+// `crate::media::tag::is_mysql_dup_index_error` paths working
+// without touching their call sites.
+pub(super) use crate::sql::is_mysql_dup_index_error;
 
 /// MySQL DATETIME(6) decoder — sqlx returns `NaiveDateTime` by default
 /// for `DATETIME` (no TZ); promote to `DateTime<Utc>` assuming the

--- a/crates/rustango/src/sql/error.rs
+++ b/crates/rustango/src/sql/error.rs
@@ -302,3 +302,39 @@ pub enum ExecError {
         count: usize,
     },
 }
+
+// =====================================================================
+// Shared driver-error predicates
+// =====================================================================
+//
+// #561 — recognizing "duplicate index name" on MySQL used to live as
+// 4 byte-identical copies in `audit.rs`, `contenttypes.rs`,
+// `jobs/pg.rs`, and `media/tag.rs` (plus `#[cfg(not(mysql))]`
+// stubs returning `false`). Migration / DDL idempotency code that
+// runs `CREATE INDEX IF NOT EXISTS` against MySQL — which has no
+// such syntax — has to swallow the duplicate error to stay
+// idempotent. Predicate exposed once here; callers route through
+// `crate::sql::is_mysql_dup_index_error`.
+
+/// `true` when `e` is MySQL's `ER_DUP_KEYNAME` (1061) — raised by
+/// `CREATE INDEX` against a name that already exists. MySQL has no
+/// `CREATE INDEX IF NOT EXISTS`, so the idempotent ensure-table code
+/// catches this error and continues.
+///
+/// On a build without the `mysql` cargo feature the predicate
+/// returns `false` for every error — there's no MySQL driver
+/// compiled in so this code path can't fire.
+#[cfg(feature = "mysql")]
+pub fn is_mysql_dup_index_error(e: &crate::sql::sqlx::Error) -> bool {
+    if let crate::sql::sqlx::Error::Database(db) = e {
+        return db.code().as_deref() == Some("42000")
+            || db.message().contains("Duplicate key name");
+    }
+    false
+}
+
+/// `cfg(not(mysql))` stub — see the documented variant above.
+#[cfg(not(feature = "mysql"))]
+pub fn is_mysql_dup_index_error(_e: &crate::sql::sqlx::Error) -> bool {
+    false
+}

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -29,7 +29,7 @@ pub use backend::{
 };
 pub use compiled::CompiledStatement;
 pub use dialect::Dialect;
-pub use error::{ExecError, SqlError};
+pub use error::{is_mysql_dup_index_error, ExecError, SqlError};
 // Always-on: tri-dialect entry points + traits that don't pin on PG.
 #[cfg(feature = "mysql")]
 pub use executor::row_to_json_my;

--- a/crates/rustango/src/tenancy/auth_backends.rs
+++ b/crates/rustango/src/tenancy/auth_backends.rs
@@ -243,18 +243,14 @@ CREATE TABLE IF NOT EXISTS `rustango_api_keys` (
 /// [`ensure_api_keys_table_pool`] which picks the right per-dialect
 /// DDL constant via `pool.dialect().name()`.
 ///
+/// #562 — delegates to [`ensure_api_keys_table_pool`] so the
+/// statement-splitting loop lives in one place.
+///
 /// # Errors
 /// Driver failures.
 #[cfg(feature = "postgres")]
 pub async fn ensure_api_keys_table(pool: &crate::sql::sqlx::PgPool) -> Result<(), sqlx::Error> {
-    for stmt in API_KEY_ENSURE_SQL
-        .split(';')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-    {
-        sqlx::query(stmt).execute(pool).await?;
-    }
-    Ok(())
+    ensure_api_keys_table_pool(&crate::sql::Pool::from(pool.clone())).await
 }
 
 /// v0.38 — tri-dialect counterpart of [`ensure_api_keys_table`].


### PR DESCRIPTION
## Summary

The MySQL \`ER_DUP_KEYNAME\` predicate lived as four byte-identical copies + paired \`#[cfg(not(mysql))]\` stubs returning \`false\` in \`audit.rs\` / \`contenttypes.rs\` / \`jobs/pg.rs\` / \`media/tag.rs\`. (Plus \`media/mod.rs\` + \`media/collection.rs\` already reached across modules to \`media::tag::is_mysql_dup_index_error\` to dodge a 5th copy.)

Per #561 (first sub-item, explicitly tagged \"Do first — unblocks the rest\"), the predicate moves to \`crate::sql::error\` and the four duplicates become \`use\` imports.

## Wiring

- New \`crate::sql::is_mysql_dup_index_error\` (PG / SQLite stub returns \`false\`; MySQL impl gated on \`feature = \"mysql\"\`)
- \`audit.rs\` / \`contenttypes.rs\` / \`jobs/pg.rs\`: \`use crate::sql::is_mysql_dup_index_error;\`
- \`media/tag.rs\`: \`pub(super) use crate::sql::is_mysql_dup_index_error;\` preserves the existing cross-module paths from \`media/collection.rs:117\` + \`media/mod.rs:296\` without touching those call sites.

## Test plan

- [x] cargo build --no-default-features --features sqlite,tenancy clean
- [x] cargo build --no-default-features --features postgres,tenancy clean
- [x] cargo build --no-default-features --features mysql,tenancy clean
- [x] cargo test --no-default-features --features sqlite,tenancy --lib → 1564 pass
- [x] cargo test --workspace --all-features --no-run → clean

Unblocks the next #561 step (\`run_ddl_idempotent\` helper).