### PR TITLE
refactor(sql): run_ddl_idempotent owns the DDL split-dispatch-swallow loop (#561)

### DIFF
--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -560,52 +560,21 @@ CREATE INDEX IF NOT EXISTS "rustango_audit_log_occurred_idx"
 /// Driver / SQL failures other than the swallowed duplicate-index
 /// errors on MySQL.
 pub async fn ensure_table_pool(pool: &crate::sql::Pool) -> Result<(), sqlx::Error> {
-    let dialect = pool.dialect();
-    let ddl = match dialect.name() {
+    let ddl = match pool.dialect().name() {
         "postgres" => CREATE_TABLE_SQL,
         "mysql" => CREATE_TABLE_SQL_MYSQL,
         "sqlite" => CREATE_TABLE_SQL_SQLITE,
-        // Future dialects fall through to a portable best-effort using
-        // `Dialect::column_type` for the timestamp + JSON columns; for
-        // the backends rustango ships against, hand-rolled DDL is
-        // simpler and produces tighter SQL.
+        // Future dialects fall through to a portable best-effort
+        // using `Dialect::column_type` for the timestamp + JSON
+        // columns; for the backends rustango ships against, hand-
+        // rolled DDL is simpler and produces tighter SQL.
         _ => CREATE_TABLE_SQL,
     };
-    for stmt in ddl.split(';') {
-        let trimmed = stmt.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        match pool {
-            #[cfg(feature = "postgres")]
-            crate::sql::Pool::Postgres(pg) => {
-                sqlx::query(trimmed).execute(pg).await?;
-            }
-            #[cfg(feature = "mysql")]
-            crate::sql::Pool::Mysql(my) => {
-                if let Err(e) = sqlx::query(trimmed).execute(my).await {
-                    // MySQL has no CREATE INDEX IF NOT EXISTS — the
-                    // index-create statements raise error 1061 when
-                    // the index already exists. Swallow that one
-                    // case so the bootstrap stays idempotent;
-                    // surface every other error.
-                    if !is_mysql_dup_index_error(&e) {
-                        return Err(e);
-                    }
-                }
-            }
-            #[cfg(feature = "sqlite")]
-            crate::sql::Pool::Sqlite(sq) => {
-                sqlx::query(trimmed).execute(sq).await?;
-            }
-        }
-    }
-    Ok(())
+    // #561 — the split-by-`;` + dispatch + swallow-dup-index loop
+    // was duplicated ~6× across audit / media / jobs / contenttypes.
+    // Single owner now lives in `crate::sql::run_ddl_idempotent`.
+    crate::sql::run_ddl_idempotent(pool, ddl).await
 }
-
-// #561 — `is_mysql_dup_index_error` lives in `crate::sql::error`;
-// re-import here so the call site at :592 stays byte-identical.
-use crate::sql::is_mysql_dup_index_error;
 
 /// Per-row audit emit on a `MySqlConnection`-shape executor —
 /// counterpart of [`emit_one`] using `?` placeholders + backtick

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -967,12 +967,11 @@ pub async fn ensure_table(pool: &crate::sql::Pool) -> Result<(), crate::sql::sql
         dialect,
         &ContentType::SCHEMA,
     );
-    exec_one(pool, &table_ddl).await?;
-
     // UNIQUE INDEX on the natural key. PG + SQLite support
     // `CREATE UNIQUE INDEX IF NOT EXISTS`; MySQL doesn't — we drop
-    // the `IF NOT EXISTS` clause there and swallow the dup-index
-    // error (1061) so re-runs stay idempotent. Hand-rolled until
+    // the `IF NOT EXISTS` clause there. `run_ddl_idempotent` then
+    // swallows MySQL's dup-index error (1061) so re-runs stay
+    // idempotent. Hand-rolled until
     // `crate::migrate::diff::render_changes` goes bi-dialect; once
     // it does, this collapses to a `SchemaChange::CreateIndex` op.
     let table_q = dialect.quote_ident("rustango_content_types");
@@ -985,37 +984,18 @@ pub async fn ensure_table(pool: &crate::sql::Pool) -> Result<(), crate::sql::sql
     } else {
         format!("CREATE UNIQUE INDEX {idx_q} ON {table_q} ({col_app}, {col_name})")
     };
-    match exec_one(pool, &index_ddl).await {
-        Ok(()) => Ok(()),
-        Err(e) if dialect.name() == "mysql" && is_mysql_dup_index_error(&e) => Ok(()),
-        Err(e) => Err(e),
-    }
+    // #561 — table + index DDL go through the shared
+    // `run_ddl_idempotent` runner: split-by-`;` + dispatch +
+    // swallow-dup-index. The local `exec_one` helper used to ship
+    // its own match-on-pool dispatch alongside an inline dup-index
+    // arm; both collapse to one call.
+    let combined = format!("{table_ddl}; {index_ddl}");
+    crate::sql::run_ddl_idempotent(pool, &combined).await
 }
 
-/// Execute a single SQL statement against `pool`, dispatching on the
-/// backend variant. Internal bootstrap helper — production code
-/// should reach for the ORM (`fetch_pool` / `insert_pool` / …).
-async fn exec_one(pool: &crate::sql::Pool, sql: &str) -> Result<(), crate::sql::sqlx::Error> {
-    match pool {
-        #[cfg(feature = "postgres")]
-        crate::sql::Pool::Postgres(pg) => {
-            crate::sql::sqlx::query(sql).execute(pg).await?;
-        }
-        #[cfg(feature = "mysql")]
-        crate::sql::Pool::Mysql(my) => {
-            crate::sql::sqlx::query(sql).execute(my).await?;
-        }
-        #[cfg(feature = "sqlite")]
-        crate::sql::Pool::Sqlite(sq) => {
-            crate::sql::sqlx::query(sql).execute(sq).await?;
-        }
-    }
-    Ok(())
-}
-
-// #561 — `is_mysql_dup_index_error` lives in `crate::sql::error`;
-// re-import for the call site at :990.
-use crate::sql::is_mysql_dup_index_error;
+// #561 — `is_mysql_dup_index_error` is now consumed inside
+// `crate::sql::run_ddl_idempotent` (the shared DDL runner); the
+// direct import here is unused after the `ensure_table` collapse.
 
 /// Backend-agnostic counterpart of [`ensure_seeded`]. Walks the
 /// inventory of registered models and INSERTs a `ContentType` row for

--- a/crates/rustango/src/jobs/pg.rs
+++ b/crates/rustango/src/jobs/pg.rs
@@ -239,31 +239,9 @@ impl PgJobQueue {
             "sqlite" => CREATE_JOBS_TABLE_SQL_SQLITE,
             _ => CREATE_JOBS_TABLE_SQL_PG,
         };
-        for stmt in ddl.split(';') {
-            let trimmed = stmt.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            match pool {
-                #[cfg(feature = "postgres")]
-                Pool::Postgres(pg) => {
-                    sqlx::query(trimmed).execute(pg).await?;
-                }
-                #[cfg(feature = "mysql")]
-                Pool::Mysql(my) => {
-                    if let Err(e) = sqlx::query(trimmed).execute(my).await {
-                        if !is_mysql_dup_index_error(&e) {
-                            return Err(e);
-                        }
-                    }
-                }
-                #[cfg(feature = "sqlite")]
-                Pool::Sqlite(sq) => {
-                    sqlx::query(trimmed).execute(sq).await?;
-                }
-            }
-        }
-        Ok(())
+        // #561 — split-by-`;` + dispatch + swallow-dup-index loop
+        // is shared via `crate::sql::run_ddl_idempotent`.
+        crate::sql::run_ddl_idempotent(pool, ddl).await
     }
 
     /// PG-typed back-compat shim around [`Self::reclaim_stuck_jobs_pool`].
@@ -761,9 +739,9 @@ impl HandlerRegistry {
     }
 }
 
-// #561 — `is_mysql_dup_index_error` lives in `crate::sql::error`;
-// re-import for the call site at :255.
-use crate::sql::is_mysql_dup_index_error;
+// #561 — `is_mysql_dup_index_error` is now consumed only inside
+// `crate::sql::run_ddl_idempotent` (the shared DDL runner). The
+// import here is unused after the `ensure_table_pool` collapse.
 
 /// Best-effort `gethostname` without pulling a dep — read the env var
 /// most container runtimes set.

--- a/crates/rustango/src/media/collection.rs
+++ b/crates/rustango/src/media/collection.rs
@@ -101,31 +101,8 @@ impl MediaCollection {
             "sqlite" => CREATE_TABLE_SQL_SQLITE,
             _ => CREATE_TABLE_SQL_PG,
         };
-        for stmt in ddl.split(';') {
-            let trimmed = stmt.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            match pool {
-                #[cfg(feature = "postgres")]
-                crate::sql::Pool::Postgres(pg) => {
-                    sqlx::query(trimmed).execute(pg).await?;
-                }
-                #[cfg(feature = "mysql")]
-                crate::sql::Pool::Mysql(my) => {
-                    if let Err(e) = sqlx::query(trimmed).execute(my).await {
-                        if !super::tag::is_mysql_dup_index_error(&e) {
-                            return Err(e);
-                        }
-                    }
-                }
-                #[cfg(feature = "sqlite")]
-                crate::sql::Pool::Sqlite(sq) => {
-                    sqlx::query(trimmed).execute(sq).await?;
-                }
-            }
-        }
-        Ok(())
+        // #561 — shared split-+-dispatch-+-swallow-dup-index loop.
+        crate::sql::run_ddl_idempotent(pool, ddl).await
     }
 
     /// PG row decoder — kept for in-crate callers using `PgRow`.

--- a/crates/rustango/src/media/mod.rs
+++ b/crates/rustango/src/media/mod.rs
@@ -280,31 +280,9 @@ impl Media {
             "sqlite" => CREATE_MEDIA_TABLE_SQL_SQLITE,
             _ => CREATE_MEDIA_TABLE_SQL_PG,
         };
-        for stmt in ddl.split(';') {
-            let trimmed = stmt.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            match pool {
-                #[cfg(feature = "postgres")]
-                crate::sql::Pool::Postgres(pg) => {
-                    sqlx::query(trimmed).execute(pg).await?;
-                }
-                #[cfg(feature = "mysql")]
-                crate::sql::Pool::Mysql(my) => {
-                    if let Err(e) = sqlx::query(trimmed).execute(my).await {
-                        if !crate::media::tag::is_mysql_dup_index_error(&e) {
-                            return Err(e);
-                        }
-                    }
-                }
-                #[cfg(feature = "sqlite")]
-                crate::sql::Pool::Sqlite(sq) => {
-                    sqlx::query(trimmed).execute(sq).await?;
-                }
-            }
-        }
-        Ok(())
+        // #561 — shared split-+-dispatch-+-swallow-dup-index loop
+        // lives in `crate::sql::run_ddl_idempotent`.
+        crate::sql::run_ddl_idempotent(pool, ddl).await
     }
 
     /// Typed status accessor.

--- a/crates/rustango/src/media/tag.rs
+++ b/crates/rustango/src/media/tag.rs
@@ -109,31 +109,8 @@ impl MediaTag {
             "sqlite" => CREATE_TABLE_SQL_SQLITE,
             _ => CREATE_TABLE_SQL_PG,
         };
-        for stmt in ddl.split(';') {
-            let trimmed = stmt.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            match pool {
-                #[cfg(feature = "postgres")]
-                crate::sql::Pool::Postgres(pg) => {
-                    sqlx::query(trimmed).execute(pg).await?;
-                }
-                #[cfg(feature = "mysql")]
-                crate::sql::Pool::Mysql(my) => {
-                    if let Err(e) = sqlx::query(trimmed).execute(my).await {
-                        if !is_mysql_dup_index_error(&e) {
-                            return Err(e);
-                        }
-                    }
-                }
-                #[cfg(feature = "sqlite")]
-                crate::sql::Pool::Sqlite(sq) => {
-                    sqlx::query(trimmed).execute(sq).await?;
-                }
-            }
-        }
-        Ok(())
+        // #561 — shared split-+-dispatch-+-swallow-dup-index loop.
+        crate::sql::run_ddl_idempotent(pool, ddl).await
     }
 
     /// PG row decoder — kept for in-crate callers that still acquire
@@ -201,13 +178,12 @@ impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for MediaTag {
     }
 }
 
-// #561 — `is_mysql_dup_index_error` was a `pub(super)` copy here so
-// `media::mod` + `media::collection` could reach across modules to
-// dodge a 5th duplicate. Re-export from `crate::sql::is_mysql_dup_index_error`
-// keeps those existing `super::tag::is_mysql_dup_index_error` /
-// `crate::media::tag::is_mysql_dup_index_error` paths working
-// without touching their call sites.
-pub(super) use crate::sql::is_mysql_dup_index_error;
+// #561 — the pub(super) `is_mysql_dup_index_error` re-export here
+// was a shim for media::mod + media::collection that reached
+// across modules to dodge a 5th copy of the predicate. Both of
+// those callers now route through `crate::sql::run_ddl_idempotent`
+// (the shared DDL runner already swallows MySQL's dup-index
+// error), so the re-export has no remaining consumers.
 
 /// MySQL DATETIME(6) decoder — sqlx returns `NaiveDateTime` by default
 /// for `DATETIME` (no TZ); promote to `DateTime<Utc>` assuming the

--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -1250,6 +1250,46 @@ pub async fn raw_execute_pool(
     execute_pool(pool, sql, binds).await
 }
 
+/// Run a `;`-separated DDL script idempotently across every backend.
+/// Each statement is dispatched through [`raw_execute_pool`]; on
+/// MySQL the helper swallows `ER_DUP_KEYNAME` (1061) so that index-
+/// create statements in a bootstrap script can re-run without
+/// failing (MySQL has no `CREATE INDEX IF NOT EXISTS`).
+///
+/// This is the canonical "ensure-this-DDL-applied" primitive for
+/// modules that ship hand-written per-dialect schema constants
+/// (`audit::ensure_table_pool`, `media::*::ensure_table`, the
+/// JSON-side `jobs::pg::ensure_jobs_table`, etc.). The non-MySQL
+/// errors surface as [`sqlx::Error`] verbatim (driver-level); only
+/// the dup-index case is swallowed.
+///
+/// Empty / whitespace-only fragments between `;` separators are
+/// skipped — convenient for the multi-statement DDL constants the
+/// callers ship.
+///
+/// #561 — single owner of the "split-by-`;` + dispatch + swallow
+/// dup-index" loop that used to live as ~6 copies in `audit.rs`,
+/// `media/*.rs`, `jobs/pg.rs`, and `contenttypes.rs`.
+///
+/// # Errors
+/// `sqlx::Error` forwarded from the executor on any statement other
+/// than the dup-index swallowed case. Non-driver `ExecError`
+/// variants (counter / structural) map to `sqlx::Error::Protocol`.
+pub async fn run_ddl_idempotent(pool: &Pool, ddl: &str) -> Result<(), sqlx::Error> {
+    for stmt in ddl.split(';').map(str::trim).filter(|s| !s.is_empty()) {
+        match execute_pool(pool, stmt, Vec::new()).await {
+            Ok(_) => {}
+            Err(crate::sql::ExecError::Driver(err)) => {
+                if !crate::sql::is_mysql_dup_index_error(&err) {
+                    return Err(err);
+                }
+            }
+            Err(other) => return Err(sqlx::Error::Protocol(format!("{other}"))),
+        }
+    }
+    Ok(())
+}
+
 // ---- internal dispatch helpers ----
 
 /// Execute a parameterized statement that doesn't return rows. Used

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -40,12 +40,13 @@ pub use executor::{
     explain_pool, fetch_aggregate_pool, fetch_dates_pool, fetch_datetimes_pool,
     fetch_paginated_pool, fetch_with_prefetch_filtered_pool, fetch_with_prefetch_pool,
     get_or_create, insert_pool, insert_returning_pool, insert_returning_tx, insert_tx, on_commit,
-    on_commit_pending, raw_execute_pool, raw_query_pool, select_one_row_as_json,
-    select_one_row_pool, select_rows_as_json, select_rows_pool, select_rows_pool_with_related,
-    select_rows_tx_with_related, transaction_pool, update_or_create, update_pool, update_tx,
-    CounterPool, ExistsPool, ExplainFormat, ExplainOptions, FetcherPool, FetcherTx, FkPkAccess,
-    HasPkValue, InsertReturningPool, LoadRelated, MaybeMyFromRow, MaybeMyLoadRelated,
-    MaybePgFromRow, MaybeSqliteFromRow, MaybeSqliteLoadRelated, Page, PoolTx, UpdaterPool,
+    on_commit_pending, raw_execute_pool, raw_query_pool, run_ddl_idempotent,
+    select_one_row_as_json, select_one_row_pool, select_rows_as_json, select_rows_pool,
+    select_rows_pool_with_related, select_rows_tx_with_related, transaction_pool, update_or_create,
+    update_pool, update_tx, CounterPool, ExistsPool, ExplainFormat, ExplainOptions, FetcherPool,
+    FetcherTx, FkPkAccess, HasPkValue, InsertReturningPool, LoadRelated, MaybeMyFromRow,
+    MaybeMyLoadRelated, MaybePgFromRow, MaybeSqliteFromRow, MaybeSqliteLoadRelated, Page, PoolTx,
+    UpdaterPool,
 };
 // PG-typed back-compat surface gone (issue #270 / T1.8 waves 1–4):
 // the entire family of `_on` functions + `&PgPool` wrappers + the


### PR DESCRIPTION
## Summary

The \"split by \`;\` → match pool → execute → swallow MySQL dup-index\" loop was re-rolled six times, each ~25 lines of backend-fan-out paired with the predicate from #581:

- \`audit.rs::ensure_table_pool\`
- \`contenttypes.rs::ensure_table\` (local \`exec_one\` + inline dup-index arm)
- \`jobs/pg.rs::Job::ensure_table_pool\`
- \`media/mod.rs::Media::ensure_table_pool\`
- \`media/tag.rs::MediaTag::ensure_table_pool\`
- \`media/collection.rs::MediaCollection::ensure_table_pool\`

#561's second sub-item — collapse them onto one shared helper.

## New helper

\`crate::sql::run_ddl_idempotent(pool, ddl)\`:
- Splits the DDL string on \`;\`, skips empty/whitespace-only fragments
- Dispatches each through canonical \`execute_pool\`
- Swallows MySQL's \`ER_DUP_KEYNAME\` so \`CREATE INDEX\` statements stay idempotent on a backend that has no \`CREATE INDEX IF NOT EXISTS\`
- Forwards every other \`sqlx::Error\` verbatim; non-driver \`ExecError\` variants map to \`sqlx::Error::Protocol\`

## Migrated

Each of the six sites collapses to one line:

\`\`\`rust
crate::sql::run_ddl_idempotent(pool, ddl).await
\`\`\`

The local \`media::tag::is_mysql_dup_index_error\` re-export shim that \`media::mod\` + \`media::collection\` reached across modules to share now has no consumers — the shared runner consumes the predicate internally.

Net delete: ~150 lines.

## Test plan

- [x] cargo build --no-default-features --features sqlite,tenancy clean
- [x] cargo build --no-default-features --features postgres,tenancy clean
- [x] cargo build --no-default-features --features mysql,tenancy clean
- [x] cargo test --no-default-features --features sqlite,tenancy --lib → 1564 pass
- [x] cargo test --workspace --all-features --no-run → clean