### PR TITLE
refactor(audit): count/facet_counts through raw_query_pool (#561)

### DIFF
--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -786,35 +786,27 @@ pub async fn list(
 /// # Errors
 /// Driver / SQL failures from the SELECT COUNT(*).
 pub async fn count(pool: &crate::sql::Pool, filter: &AuditFilter) -> Result<i64, sqlx::Error> {
+    use crate::core::SqlValue;
     let pairs = filter.active_pairs();
     let sql = audit_count_sql(pool.dialect(), &pairs);
-    let binds: Vec<&str> = pairs.iter().map(|(_, v)| *v).collect();
-    match pool {
-        #[cfg(feature = "postgres")]
-        crate::sql::Pool::Postgres(pg) => {
-            let mut q = sqlx::query_scalar::<_, i64>(&sql);
-            for v in &binds {
-                q = q.bind(*v);
-            }
-            q.fetch_one(pg).await
-        }
-        #[cfg(feature = "mysql")]
-        crate::sql::Pool::Mysql(my) => {
-            let mut q = sqlx::query_scalar::<_, i64>(&sql);
-            for v in &binds {
-                q = q.bind(*v);
-            }
-            q.fetch_one(my).await
-        }
-        #[cfg(feature = "sqlite")]
-        crate::sql::Pool::Sqlite(sq) => {
-            let mut q = sqlx::query_scalar::<_, i64>(&sql);
-            for v in &binds {
-                q = q.bind(*v);
-            }
-            q.fetch_one(sq).await
-        }
-    }
+    let binds: Vec<SqlValue> = pairs
+        .iter()
+        .map(|(_, v)| SqlValue::String((*v).to_owned()))
+        .collect();
+    // #561 — was a 3-arm `match pool` doing the same query_scalar
+    // bind-loop per backend. Routes through `raw_query_pool::<(i64,)>`
+    // for the single-column COUNT result; the tuple decoder works
+    // identically on every backend that has a `FromRow` impl, which
+    // includes the bound triple via the `Maybe*FromRow` blanket
+    // impls.
+    let rows: Vec<(i64,)> = crate::sql::raw_query_pool(&sql, binds, pool)
+        .await
+        .map_err(|e| match e {
+            crate::sql::ExecError::Driver(err) => err,
+            other => sqlx::Error::Protocol(format!("{other}")),
+        })?;
+    // COUNT(*) always returns exactly one row.
+    Ok(rows.into_iter().next().map_or(0, |t| t.0))
 }
 
 /// v0.37 — tri-dialect facet (column, count) groupby for the admin
@@ -837,44 +829,17 @@ pub async fn facet_counts(
         return Err(sqlx::Error::ColumnNotFound(column.to_owned()));
     }
     let sql = audit_facet_sql(pool.dialect(), column);
-    match pool {
-        #[cfg(feature = "postgres")]
-        crate::sql::Pool::Postgres(pg) => {
-            use sqlx::Row as _;
-            let rows = sqlx::query(&sql).fetch_all(pg).await?;
-            let mut out = Vec::with_capacity(rows.len());
-            for r in rows {
-                let v: String = r.try_get("facet_value").unwrap_or_default();
-                let c: i64 = r.try_get("facet_count").unwrap_or(0);
-                out.push((v, c));
-            }
-            Ok(out)
-        }
-        #[cfg(feature = "mysql")]
-        crate::sql::Pool::Mysql(my) => {
-            use sqlx::Row as _;
-            let rows = sqlx::query(&sql).fetch_all(my).await?;
-            let mut out = Vec::with_capacity(rows.len());
-            for r in rows {
-                let v: String = r.try_get("facet_value").unwrap_or_default();
-                let c: i64 = r.try_get("facet_count").unwrap_or(0);
-                out.push((v, c));
-            }
-            Ok(out)
-        }
-        #[cfg(feature = "sqlite")]
-        crate::sql::Pool::Sqlite(sq) => {
-            use sqlx::Row as _;
-            let rows = sqlx::query(&sql).fetch_all(sq).await?;
-            let mut out = Vec::with_capacity(rows.len());
-            for r in rows {
-                let v: String = r.try_get("facet_value").unwrap_or_default();
-                let c: i64 = r.try_get("facet_count").unwrap_or(0);
-                out.push((v, c));
-            }
-            Ok(out)
-        }
-    }
+    // #561 — was three byte-identical `try_get("facet_value") + try_get("facet_count")`
+    // copies, one per backend. The `(String, i64)` tuple decoder
+    // works on every backend via the `Maybe*FromRow` blanket impls;
+    // it decodes positionally so it matches the `SELECT … AS facet_value,
+    // COUNT(*) AS facet_count` column order in `audit_facet_sql`.
+    crate::sql::raw_query_pool::<(String, i64)>(&sql, Vec::new(), pool)
+        .await
+        .map_err(|e| match e {
+            crate::sql::ExecError::Driver(err) => err,
+            other => sqlx::Error::Protocol(format!("{other}")),
+        })
 }
 
 /// v0.37 — render the audit-log activity-feed SELECT (paginated, with

--- a/crates/rustango/src/jobs/pg.rs
+++ b/crates/rustango/src/jobs/pg.rs
@@ -268,6 +268,7 @@ impl PgJobQueue {
         pool: &Pool,
         older_than: Duration,
     ) -> Result<u64, sqlx::Error> {
+        use crate::core::SqlValue;
         let cutoff: DateTime<Utc> = Utc::now()
             - chrono::Duration::from_std(older_than).unwrap_or(chrono::Duration::seconds(0));
         let p = pool.dialect().placeholder(1);
@@ -276,29 +277,18 @@ impl PgJobQueue {
                 SET locked_at = NULL, locked_by = NULL \
               WHERE locked_at IS NOT NULL AND locked_at < {p}"
         );
-        match pool {
-            #[cfg(feature = "postgres")]
-            Pool::Postgres(pg) => Ok(sqlx::query(&sql)
-                .bind(cutoff)
-                .execute(pg)
-                .await?
-                .rows_affected()),
-            #[cfg(feature = "mysql")]
-            Pool::Mysql(my) => Ok(sqlx::query(&sql)
-                .bind(cutoff)
-                .execute(my)
-                .await?
-                .rows_affected()),
-            #[cfg(feature = "sqlite")]
-            Pool::Sqlite(sq) => {
-                // SQLite stores TEXT-ISO-8601; bind as RFC3339 string.
-                Ok(sqlx::query(&sql)
-                    .bind(cutoff.to_rfc3339())
-                    .execute(sq)
-                    .await?
-                    .rows_affected())
-            }
-        }
+        // #561 — was a 3-arm `match pool`. `SqlValue::DateTime`
+        // encodes as TIMESTAMPTZ on PG, DATETIME(6) on MySQL, and
+        // RFC3339 TEXT on SQLite (via the executor's `bind_match!`
+        // macros) — same shapes as the per-arm hand-bind, including
+        // the SQLite `.to_rfc3339()` path the old SQLite arm did
+        // explicitly.
+        crate::sql::raw_execute_pool(pool, &sql, vec![SqlValue::DateTime(cutoff)])
+            .await
+            .map_err(|e| match e {
+                crate::sql::ExecError::Driver(err) => err,
+                other => sqlx::Error::Protocol(format!("{other}")),
+            })
     }
 }
 
@@ -309,6 +299,7 @@ impl JobQueue for PgJobQueue {
     }
 
     async fn dispatch<T: Job>(&self, payload: &T) -> Result<(), JobError> {
+        use crate::core::SqlValue;
         let value = serde_json::to_value(payload).map_err(|e| JobError::Queue(e.to_string()))?;
         let max_attempts = i32::try_from(T::MAX_ATTEMPTS).unwrap_or(i32::MAX);
         let dialect = self.pool.dialect();
@@ -320,41 +311,24 @@ impl JobQueue for PgJobQueue {
         let sql = format!(
             "INSERT INTO rustango_jobs (name, payload, max_attempts) VALUES ({p1}, {p2}, {p3})"
         );
-        match &self.pool {
-            #[cfg(feature = "postgres")]
-            Pool::Postgres(pg) => {
-                sqlx::query(&sql)
-                    .bind(T::NAME)
-                    .bind(&value)
-                    .bind(max_attempts)
-                    .execute(pg)
-                    .await
-                    .map_err(|e| JobError::Queue(e.to_string()))?;
-            }
-            #[cfg(feature = "mysql")]
-            Pool::Mysql(my) => {
-                sqlx::query(&sql)
-                    .bind(T::NAME)
-                    .bind(sqlx::types::Json(&value))
-                    .bind(max_attempts)
-                    .execute(my)
-                    .await
-                    .map_err(|e| JobError::Queue(e.to_string()))?;
-            }
-            #[cfg(feature = "sqlite")]
-            Pool::Sqlite(sq) => {
-                // SQLite stores payload as TEXT-as-JSON.
-                let json_text =
-                    serde_json::to_string(&value).map_err(|e| JobError::Queue(e.to_string()))?;
-                sqlx::query(&sql)
-                    .bind(T::NAME)
-                    .bind(json_text)
-                    .bind(max_attempts)
-                    .execute(sq)
-                    .await
-                    .map_err(|e| JobError::Queue(e.to_string()))?;
-            }
-        }
+        // #561 — was a 3-arm `match pool` each doing the bind +
+        // execute by hand (PG `&Value`, MySQL `sqlx::types::Json(&v)`,
+        // SQLite `serde_json::to_string` → TEXT). The executor's
+        // `bind_match!` macros already wrap `SqlValue::Json(v)` in
+        // `sqlx::types::Json(v)` on every backend, which encodes as
+        // JSONB on PG, JSON on MySQL, and TEXT on SQLite — same
+        // on-disk shape as the per-arm hand-bind.
+        crate::sql::raw_execute_pool(
+            &self.pool,
+            &sql,
+            vec![
+                SqlValue::String(T::NAME.to_owned()),
+                SqlValue::Json(value),
+                SqlValue::I32(max_attempts),
+            ],
+        )
+        .await
+        .map_err(|e| JobError::Queue(e.to_string()))?;
         // Wake up to one waiting worker so the new job starts running
         // before the next poll tick.
         self.notify.notify_one();
@@ -628,22 +602,12 @@ async fn run_one(
 }
 
 async fn delete_job(pool: &Pool, id: i64) {
+    use crate::core::SqlValue;
     let p = pool.dialect().placeholder(1);
     let sql = format!("DELETE FROM rustango_jobs WHERE id = {p}");
-    match pool {
-        #[cfg(feature = "postgres")]
-        Pool::Postgres(pg) => {
-            let _ = sqlx::query(&sql).bind(id).execute(pg).await;
-        }
-        #[cfg(feature = "mysql")]
-        Pool::Mysql(my) => {
-            let _ = sqlx::query(&sql).bind(id).execute(my).await;
-        }
-        #[cfg(feature = "sqlite")]
-        Pool::Sqlite(sq) => {
-            let _ = sqlx::query(&sql).bind(id).execute(sq).await;
-        }
-    }
+    // #561 — was a 3-arm `match pool` doing identical `bind(id).execute()`
+    // per backend. Route through the shared `raw_execute_pool`.
+    let _ = crate::sql::raw_execute_pool(pool, &sql, vec![SqlValue::I64(id)]).await;
 }
 
 async fn schedule_retry(
@@ -653,6 +617,7 @@ async fn schedule_retry(
     next_run: DateTime<Utc>,
     last_error: &str,
 ) {
+    use crate::core::SqlValue;
     let d = pool.dialect();
     let sql = format!(
         "UPDATE rustango_jobs \
@@ -665,38 +630,24 @@ async fn schedule_retry(
         p3 = d.placeholder(3),
         p4 = d.placeholder(4),
     );
-    match pool {
-        #[cfg(feature = "postgres")]
-        Pool::Postgres(pg) => {
-            let _ = sqlx::query(&sql)
-                .bind(next_attempt)
-                .bind(next_run)
-                .bind(last_error)
-                .bind(id)
-                .execute(pg)
-                .await;
-        }
-        #[cfg(feature = "mysql")]
-        Pool::Mysql(my) => {
-            let _ = sqlx::query(&sql)
-                .bind(next_attempt)
-                .bind(next_run)
-                .bind(last_error)
-                .bind(id)
-                .execute(my)
-                .await;
-        }
-        #[cfg(feature = "sqlite")]
-        Pool::Sqlite(sq) => {
-            let _ = sqlx::query(&sql)
-                .bind(next_attempt)
-                .bind(next_run.to_rfc3339())
-                .bind(last_error)
-                .bind(id)
-                .execute(sq)
-                .await;
-        }
-    }
+    // #561 — was a 3-arm `match pool`; the only divergence was the
+    // SQLite arm binding `next_run.to_rfc3339()` as a string while
+    // PG / MySQL passed the `DateTime<Utc>` directly. `SqlValue::DateTime`
+    // on every backend produces the right encoding via the executor's
+    // `bind_match!` macros (RFC3339 string on SQLite, native
+    // TIMESTAMPTZ / DATETIME(6) on PG / MySQL), so a single shared
+    // path now works for all three.
+    let _ = crate::sql::raw_execute_pool(
+        pool,
+        &sql,
+        vec![
+            SqlValue::I32(next_attempt),
+            SqlValue::DateTime(next_run),
+            SqlValue::String(last_error.to_owned()),
+            SqlValue::I64(id),
+        ],
+    )
+    .await;
 }
 
 async fn handle_dead_letter(


### PR DESCRIPTION
## Summary

Two more triple-arm \`match pool\` blocks from #561's sweep:

- \`audit::count\` — single-i64-column SELECT COUNT(*) for the activity-feed counter
- \`audit::facet_counts\` — \`(facet_value, facet_count)\` rows for the audit-log right-rail groupby

Both had hand-rolled per-backend dispatch with byte-identical bind loops and decode steps. The executor's \`raw_query_pool::<T>\` generic over \`T: FromRow\` handles both the scalar (\`(i64,)\`) and tuple (\`(String, i64)\`) decode through the canonical path — same \`Maybe*FromRow\` blanket impls already used for every other typed read.

Net delete: ~50 lines.

## Test plan

- [x] 1564 sqlite,tenancy lib tests pass
- [x] 14 audit_pool_sqlite_live tests pass (covers count + facet_counts)
- [x] cargo test --workspace --all-features --no-run → clean