### PR TITLE
refactor(m2m): fetch_i64_col_pool through raw_query_pool (#561)

### DIFF
--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -786,35 +786,27 @@ pub async fn list(
 /// # Errors
 /// Driver / SQL failures from the SELECT COUNT(*).
 pub async fn count(pool: &crate::sql::Pool, filter: &AuditFilter) -> Result<i64, sqlx::Error> {
+    use crate::core::SqlValue;
     let pairs = filter.active_pairs();
     let sql = audit_count_sql(pool.dialect(), &pairs);
-    let binds: Vec<&str> = pairs.iter().map(|(_, v)| *v).collect();
-    match pool {
-        #[cfg(feature = "postgres")]
-        crate::sql::Pool::Postgres(pg) => {
-            let mut q = sqlx::query_scalar::<_, i64>(&sql);
-            for v in &binds {
-                q = q.bind(*v);
-            }
-            q.fetch_one(pg).await
-        }
-        #[cfg(feature = "mysql")]
-        crate::sql::Pool::Mysql(my) => {
-            let mut q = sqlx::query_scalar::<_, i64>(&sql);
-            for v in &binds {
-                q = q.bind(*v);
-            }
-            q.fetch_one(my).await
-        }
-        #[cfg(feature = "sqlite")]
-        crate::sql::Pool::Sqlite(sq) => {
-            let mut q = sqlx::query_scalar::<_, i64>(&sql);
-            for v in &binds {
-                q = q.bind(*v);
-            }
-            q.fetch_one(sq).await
-        }
-    }
+    let binds: Vec<SqlValue> = pairs
+        .iter()
+        .map(|(_, v)| SqlValue::String((*v).to_owned()))
+        .collect();
+    // #561 — was a 3-arm `match pool` doing the same query_scalar
+    // bind-loop per backend. Routes through `raw_query_pool::<(i64,)>`
+    // for the single-column COUNT result; the tuple decoder works
+    // identically on every backend that has a `FromRow` impl, which
+    // includes the bound triple via the `Maybe*FromRow` blanket
+    // impls.
+    let rows: Vec<(i64,)> = crate::sql::raw_query_pool(&sql, binds, pool)
+        .await
+        .map_err(|e| match e {
+            crate::sql::ExecError::Driver(err) => err,
+            other => sqlx::Error::Protocol(format!("{other}")),
+        })?;
+    // COUNT(*) always returns exactly one row.
+    Ok(rows.into_iter().next().map_or(0, |t| t.0))
 }
 
 /// v0.37 — tri-dialect facet (column, count) groupby for the admin
@@ -837,44 +829,17 @@ pub async fn facet_counts(
         return Err(sqlx::Error::ColumnNotFound(column.to_owned()));
     }
     let sql = audit_facet_sql(pool.dialect(), column);
-    match pool {
-        #[cfg(feature = "postgres")]
-        crate::sql::Pool::Postgres(pg) => {
-            use sqlx::Row as _;
-            let rows = sqlx::query(&sql).fetch_all(pg).await?;
-            let mut out = Vec::with_capacity(rows.len());
-            for r in rows {
-                let v: String = r.try_get("facet_value").unwrap_or_default();
-                let c: i64 = r.try_get("facet_count").unwrap_or(0);
-                out.push((v, c));
-            }
-            Ok(out)
-        }
-        #[cfg(feature = "mysql")]
-        crate::sql::Pool::Mysql(my) => {
-            use sqlx::Row as _;
-            let rows = sqlx::query(&sql).fetch_all(my).await?;
-            let mut out = Vec::with_capacity(rows.len());
-            for r in rows {
-                let v: String = r.try_get("facet_value").unwrap_or_default();
-                let c: i64 = r.try_get("facet_count").unwrap_or(0);
-                out.push((v, c));
-            }
-            Ok(out)
-        }
-        #[cfg(feature = "sqlite")]
-        crate::sql::Pool::Sqlite(sq) => {
-            use sqlx::Row as _;
-            let rows = sqlx::query(&sql).fetch_all(sq).await?;
-            let mut out = Vec::with_capacity(rows.len());
-            for r in rows {
-                let v: String = r.try_get("facet_value").unwrap_or_default();
-                let c: i64 = r.try_get("facet_count").unwrap_or(0);
-                out.push((v, c));
-            }
-            Ok(out)
-        }
-    }
+    // #561 — was three byte-identical `try_get("facet_value") + try_get("facet_count")`
+    // copies, one per backend. The `(String, i64)` tuple decoder
+    // works on every backend via the `Maybe*FromRow` blanket impls;
+    // it decodes positionally so it matches the `SELECT … AS facet_value,
+    // COUNT(*) AS facet_count` column order in `audit_facet_sql`.
+    crate::sql::raw_query_pool::<(String, i64)>(&sql, Vec::new(), pool)
+        .await
+        .map_err(|e| match e {
+            crate::sql::ExecError::Driver(err) => err,
+            other => sqlx::Error::Protocol(format!("{other}")),
+        })
 }
 
 /// v0.37 — render the audit-log activity-feed SELECT (paginated, with

--- a/crates/rustango/src/jobs/pg.rs
+++ b/crates/rustango/src/jobs/pg.rs
@@ -268,6 +268,7 @@ impl PgJobQueue {
         pool: &Pool,
         older_than: Duration,
     ) -> Result<u64, sqlx::Error> {
+        use crate::core::SqlValue;
         let cutoff: DateTime<Utc> = Utc::now()
             - chrono::Duration::from_std(older_than).unwrap_or(chrono::Duration::seconds(0));
         let p = pool.dialect().placeholder(1);
@@ -276,29 +277,18 @@ impl PgJobQueue {
                 SET locked_at = NULL, locked_by = NULL \
               WHERE locked_at IS NOT NULL AND locked_at < {p}"
         );
-        match pool {
-            #[cfg(feature = "postgres")]
-            Pool::Postgres(pg) => Ok(sqlx::query(&sql)
-                .bind(cutoff)
-                .execute(pg)
-                .await?
-                .rows_affected()),
-            #[cfg(feature = "mysql")]
-            Pool::Mysql(my) => Ok(sqlx::query(&sql)
-                .bind(cutoff)
-                .execute(my)
-                .await?
-                .rows_affected()),
-            #[cfg(feature = "sqlite")]
-            Pool::Sqlite(sq) => {
-                // SQLite stores TEXT-ISO-8601; bind as RFC3339 string.
-                Ok(sqlx::query(&sql)
-                    .bind(cutoff.to_rfc3339())
-                    .execute(sq)
-                    .await?
-                    .rows_affected())
-            }
-        }
+        // #561 — was a 3-arm `match pool`. `SqlValue::DateTime`
+        // encodes as TIMESTAMPTZ on PG, DATETIME(6) on MySQL, and
+        // RFC3339 TEXT on SQLite (via the executor's `bind_match!`
+        // macros) — same shapes as the per-arm hand-bind, including
+        // the SQLite `.to_rfc3339()` path the old SQLite arm did
+        // explicitly.
+        crate::sql::raw_execute_pool(pool, &sql, vec![SqlValue::DateTime(cutoff)])
+            .await
+            .map_err(|e| match e {
+                crate::sql::ExecError::Driver(err) => err,
+                other => sqlx::Error::Protocol(format!("{other}")),
+            })
     }
 }
 
@@ -309,6 +299,7 @@ impl JobQueue for PgJobQueue {
     }
 
     async fn dispatch<T: Job>(&self, payload: &T) -> Result<(), JobError> {
+        use crate::core::SqlValue;
         let value = serde_json::to_value(payload).map_err(|e| JobError::Queue(e.to_string()))?;
         let max_attempts = i32::try_from(T::MAX_ATTEMPTS).unwrap_or(i32::MAX);
         let dialect = self.pool.dialect();
@@ -320,41 +311,24 @@ impl JobQueue for PgJobQueue {
         let sql = format!(
             "INSERT INTO rustango_jobs (name, payload, max_attempts) VALUES ({p1}, {p2}, {p3})"
         );
-        match &self.pool {
-            #[cfg(feature = "postgres")]
-            Pool::Postgres(pg) => {
-                sqlx::query(&sql)
-                    .bind(T::NAME)
-                    .bind(&value)
-                    .bind(max_attempts)
-                    .execute(pg)
-                    .await
-                    .map_err(|e| JobError::Queue(e.to_string()))?;
-            }
-            #[cfg(feature = "mysql")]
-            Pool::Mysql(my) => {
-                sqlx::query(&sql)
-                    .bind(T::NAME)
-                    .bind(sqlx::types::Json(&value))
-                    .bind(max_attempts)
-                    .execute(my)
-                    .await
-                    .map_err(|e| JobError::Queue(e.to_string()))?;
-            }
-            #[cfg(feature = "sqlite")]
-            Pool::Sqlite(sq) => {
-                // SQLite stores payload as TEXT-as-JSON.
-                let json_text =
-                    serde_json::to_string(&value).map_err(|e| JobError::Queue(e.to_string()))?;
-                sqlx::query(&sql)
-                    .bind(T::NAME)
-                    .bind(json_text)
-                    .bind(max_attempts)
-                    .execute(sq)
-                    .await
-                    .map_err(|e| JobError::Queue(e.to_string()))?;
-            }
-        }
+        // #561 — was a 3-arm `match pool` each doing the bind +
+        // execute by hand (PG `&Value`, MySQL `sqlx::types::Json(&v)`,
+        // SQLite `serde_json::to_string` → TEXT). The executor's
+        // `bind_match!` macros already wrap `SqlValue::Json(v)` in
+        // `sqlx::types::Json(v)` on every backend, which encodes as
+        // JSONB on PG, JSON on MySQL, and TEXT on SQLite — same
+        // on-disk shape as the per-arm hand-bind.
+        crate::sql::raw_execute_pool(
+            &self.pool,
+            &sql,
+            vec![
+                SqlValue::String(T::NAME.to_owned()),
+                SqlValue::Json(value),
+                SqlValue::I32(max_attempts),
+            ],
+        )
+        .await
+        .map_err(|e| JobError::Queue(e.to_string()))?;
         // Wake up to one waiting worker so the new job starts running
         // before the next poll tick.
         self.notify.notify_one();
@@ -628,22 +602,12 @@ async fn run_one(
 }
 
 async fn delete_job(pool: &Pool, id: i64) {
+    use crate::core::SqlValue;
     let p = pool.dialect().placeholder(1);
     let sql = format!("DELETE FROM rustango_jobs WHERE id = {p}");
-    match pool {
-        #[cfg(feature = "postgres")]
-        Pool::Postgres(pg) => {
-            let _ = sqlx::query(&sql).bind(id).execute(pg).await;
-        }
-        #[cfg(feature = "mysql")]
-        Pool::Mysql(my) => {
-            let _ = sqlx::query(&sql).bind(id).execute(my).await;
-        }
-        #[cfg(feature = "sqlite")]
-        Pool::Sqlite(sq) => {
-            let _ = sqlx::query(&sql).bind(id).execute(sq).await;
-        }
-    }
+    // #561 — was a 3-arm `match pool` doing identical `bind(id).execute()`
+    // per backend. Route through the shared `raw_execute_pool`.
+    let _ = crate::sql::raw_execute_pool(pool, &sql, vec![SqlValue::I64(id)]).await;
 }
 
 async fn schedule_retry(
@@ -653,6 +617,7 @@ async fn schedule_retry(
     next_run: DateTime<Utc>,
     last_error: &str,
 ) {
+    use crate::core::SqlValue;
     let d = pool.dialect();
     let sql = format!(
         "UPDATE rustango_jobs \
@@ -665,38 +630,24 @@ async fn schedule_retry(
         p3 = d.placeholder(3),
         p4 = d.placeholder(4),
     );
-    match pool {
-        #[cfg(feature = "postgres")]
-        Pool::Postgres(pg) => {
-            let _ = sqlx::query(&sql)
-                .bind(next_attempt)
-                .bind(next_run)
-                .bind(last_error)
-                .bind(id)
-                .execute(pg)
-                .await;
-        }
-        #[cfg(feature = "mysql")]
-        Pool::Mysql(my) => {
-            let _ = sqlx::query(&sql)
-                .bind(next_attempt)
-                .bind(next_run)
-                .bind(last_error)
-                .bind(id)
-                .execute(my)
-                .await;
-        }
-        #[cfg(feature = "sqlite")]
-        Pool::Sqlite(sq) => {
-            let _ = sqlx::query(&sql)
-                .bind(next_attempt)
-                .bind(next_run.to_rfc3339())
-                .bind(last_error)
-                .bind(id)
-                .execute(sq)
-                .await;
-        }
-    }
+    // #561 — was a 3-arm `match pool`; the only divergence was the
+    // SQLite arm binding `next_run.to_rfc3339()` as a string while
+    // PG / MySQL passed the `DateTime<Utc>` directly. `SqlValue::DateTime`
+    // on every backend produces the right encoding via the executor's
+    // `bind_match!` macros (RFC3339 string on SQLite, native
+    // TIMESTAMPTZ / DATETIME(6) on PG / MySQL), so a single shared
+    // path now works for all three.
+    let _ = crate::sql::raw_execute_pool(
+        pool,
+        &sql,
+        vec![
+            SqlValue::I32(next_attempt),
+            SqlValue::DateTime(next_run),
+            SqlValue::String(last_error.to_owned()),
+            SqlValue::I64(id),
+        ],
+    )
+    .await;
 }
 
 async fn handle_dead_letter(

--- a/crates/rustango/src/migrate/ddl.rs
+++ b/crates/rustango/src/migrate/ddl.rs
@@ -213,7 +213,7 @@ fn write_column_def(s: &mut String, dialect: &dyn Dialect, field: &FieldSchema) 
         let _ = write!(
             s,
             " DEFAULT {}",
-            dialect.translate_default_expr(expr, ty_name)
+            dialect.translate_default_expr(expr, ty_name, field.max_length)
         );
     }
     if !field.nullable {

--- a/crates/rustango/src/migrate/diff.rs
+++ b/crates/rustango/src/migrate/diff.rs
@@ -979,7 +979,7 @@ fn create_table_sql_from_snapshot_with_dialect(
             let _ = write!(
                 sql,
                 " DEFAULT {}",
-                dialect.translate_default_expr(expr, &f.ty)
+                dialect.translate_default_expr(expr, &f.ty, f.max_length)
             );
         }
         if !f.nullable {
@@ -1097,7 +1097,7 @@ fn add_column_sql(table: &str, f: &FieldSnapshot, dialect: &dyn crate::sql::Dial
         let _ = write!(
             sql,
             " DEFAULT {}",
-            dialect.translate_default_expr(expr, &f.ty)
+            dialect.translate_default_expr(expr, &f.ty, f.max_length)
         );
     }
     if !f.nullable {

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -129,8 +129,14 @@ pub trait Dialect {
     ///
     /// Default: pass-through (Postgres-native). SQLite overrides
     /// `now()` → `CURRENT_TIMESTAMP` and strips `::type` casts.
-    /// MySQL overrides similarly plus wraps JSON defaults in parens.
-    fn translate_default_expr(&self, expr: &str, _ty: &str) -> String {
+    /// MySQL overrides similarly plus wraps defaults on its
+    /// LOB-rendered columns (JSON / TEXT / BLOB) in parens.
+    ///
+    /// `max_length` is the field's declared length cap (PG/SQLite
+    /// ignore it here); MySQL needs it to tell an unbounded `String`
+    /// (→ `TEXT`, which forbids a literal `DEFAULT`) apart from a
+    /// bounded one (→ `VARCHAR(n)`, which allows it).
+    fn translate_default_expr(&self, expr: &str, _ty: &str, _max_length: Option<u32>) -> String {
         expr.to_owned()
     }
 

--- a/crates/rustango/src/sql/m2m.rs
+++ b/crates/rustango/src/sql/m2m.rs
@@ -371,52 +371,22 @@ impl M2MManager {
 // ============================================================ small per-backend helpers
 
 /// Run a SELECT that returns one `i64` column per row and collect the
-/// values. Used by `all_pool` + `contains_pool`. Routes through the
-/// `Pool` enum so PG / MySQL / SQLite all share the same call site.
+/// values. Used by `all_pool` + `contains_pool`. Routes through
+/// `raw_query_pool` (single-column tuple decode) — #561 collapsed
+/// what was a 3-arm `match pool` with byte-identical
+/// `try_get::<i64, _>(col_name)` loops.
+///
+/// The `col_name` argument is no longer consulted (the underlying
+/// SELECT must already be single-column, which both callers honor):
+/// `raw_query_pool::<(i64,)>` decodes positionally.
 async fn fetch_i64_col_pool(
     pool: &Pool,
     sql: &str,
     binds: Vec<SqlValue>,
-    col_name: &str,
+    _col_name: &str,
 ) -> Result<Vec<i64>, ExecError> {
-    match pool {
-        #[cfg(feature = "postgres")]
-        Pool::Postgres(pg) => {
-            use sqlx::Row as _;
-            let mut q = sqlx::query(sql);
-            for v in binds {
-                q = bind_pg(q, v);
-            }
-            let rows = q.fetch_all(pg).await.map_err(ExecError::Driver)?;
-            rows.iter()
-                .map(|r| r.try_get::<i64, _>(col_name).map_err(ExecError::Driver))
-                .collect()
-        }
-        #[cfg(feature = "mysql")]
-        Pool::Mysql(my) => {
-            use sqlx::Row as _;
-            let mut q = sqlx::query(sql);
-            for v in binds {
-                q = bind_my(q, v);
-            }
-            let rows = q.fetch_all(my).await.map_err(ExecError::Driver)?;
-            rows.iter()
-                .map(|r| r.try_get::<i64, _>(col_name).map_err(ExecError::Driver))
-                .collect()
-        }
-        #[cfg(feature = "sqlite")]
-        Pool::Sqlite(sq) => {
-            use sqlx::Row as _;
-            let mut q = sqlx::query(sql);
-            for v in binds {
-                q = bind_sqlite(q, v);
-            }
-            let rows = q.fetch_all(sq).await.map_err(ExecError::Driver)?;
-            rows.iter()
-                .map(|r| r.try_get::<i64, _>(col_name).map_err(ExecError::Driver))
-                .collect()
-        }
-    }
+    let rows: Vec<(i64,)> = crate::sql::raw_query_pool(sql, binds, pool).await?;
+    Ok(rows.into_iter().map(|(v,)| v).collect())
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -204,12 +204,18 @@ impl Dialect for MySql {
     ///   to carry `(6)` too, otherwise MySQL fails with
     ///   `1067 (42000): Invalid default value`.
     /// - `'<lit>'::<type>` → `'<lit>'` (strip Postgres cast).
-    /// - JSON columns (`ty == "json"`): wrap the result in parens —
-    ///   `DEFAULT '{}'` is rejected by MySQL on JSON/TEXT/BLOB
-    ///   (`1101 (42000)`), but the MySQL-8.0.13+ expression-default
-    ///   form `DEFAULT (<expr>)` is accepted.
+    /// - LOB-rendered columns: wrap the result in parens. MySQL rejects
+    ///   a literal `DEFAULT '{}'` on its no-default-allowed column
+    ///   families (`1101 (42000)`) — JSON, every TEXT/BLOB variant, and
+    ///   GEOMETRY — but the MySQL-8.0.13+ expression-default form
+    ///   `DEFAULT (<expr>)` is accepted. Per [`Self::column_type`] the
+    ///   types that land in that bucket are `Json` (→ `JSON`), `Binary`
+    ///   (→ `LONGBLOB`), and an unbounded `String` (→ `TEXT`); a bounded
+    ///   `String` renders as `VARCHAR(n)` and keeps its literal default.
+    ///   That's why `max_length` is needed: it's the only thing that
+    ///   distinguishes the `TEXT` case from the `VARCHAR` case.
     /// - Everything else passes through.
-    fn translate_default_expr(&self, expr: &str, ty: &str) -> String {
+    fn translate_default_expr(&self, expr: &str, ty: &str, max_length: Option<u32>) -> String {
         let mut out = expr.trim().to_owned();
         match out.as_str() {
             "now()" | "NOW()" | "current_timestamp" | "CURRENT_TIMESTAMP" => {
@@ -228,7 +234,10 @@ impl Dialect for MySql {
                 }
             }
         }
-        if ty.eq_ignore_ascii_case("json") {
+        let renders_as_lob = ty.eq_ignore_ascii_case("json")
+            || ty.eq_ignore_ascii_case("binary")
+            || (ty.eq_ignore_ascii_case("string") && max_length.is_none());
+        if renders_as_lob {
             // Skip wrapping if the caller already produced a
             // parenthesized expression (defensive — current renderers
             // never do this).
@@ -785,6 +794,37 @@ mod tests {
     #[test]
     fn does_not_support_concurrent_index() {
         assert!(!MySql.supports_concurrent_index());
+    }
+
+    #[test]
+    fn default_on_lob_columns_uses_expression_form() {
+        // MySQL rejects a *literal* `DEFAULT` on its no-default column
+        // families — JSON, every TEXT/BLOB variant, GEOMETRY (error
+        // 1101) — but accepts the 8.0.13+ `DEFAULT (<expr>)` form. The
+        // renderer must wrap defaults for exactly those types.
+        //
+        // Regression for #315: `cms_page_log.data_json` is an unbounded
+        // `String` (→ `TEXT`, max_length = None), so its `'{}'` default
+        // failed `CREATE TABLE` on MySQL until it got wrapped.
+        assert_eq!(
+            MySql.translate_default_expr("'{}'", "string", None),
+            "('{}')"
+        );
+        assert_eq!(MySql.translate_default_expr("'{}'", "json", None), "('{}')");
+        assert_eq!(MySql.translate_default_expr("''", "binary", None), "('')");
+        // A bounded String renders as VARCHAR(n) — a literal default is
+        // legal there, so it must NOT be wrapped.
+        assert_eq!(
+            MySql.translate_default_expr("''", "string", Some(500)),
+            "''"
+        );
+        // Non-LOB scalars are never wrapped.
+        assert_eq!(MySql.translate_default_expr("0", "i64", None), "0");
+        // now() still normalizes to the (6)-precision form (not a LOB).
+        assert_eq!(
+            MySql.translate_default_expr("now()", "datetime", None),
+            "CURRENT_TIMESTAMP(6)"
+        );
     }
 
     #[test]

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -94,9 +94,10 @@ impl Dialect for Sqlite {
     /// - `'<lit>'::<type>` → `'<lit>'` (SQLite has no `::` cast syntax;
     ///   the bare literal is the right encoding for JSON-as-TEXT,
     ///   boolean-as-INTEGER, etc.).
-    /// - Everything else passes through. `_ty` is ignored — SQLite has
-    ///   no per-type DEFAULT syntax quirks.
-    fn translate_default_expr(&self, expr: &str, _ty: &str) -> String {
+    /// - Everything else passes through. `_ty` / `_max_length` are
+    ///   ignored — SQLite has no per-type DEFAULT syntax quirks and
+    ///   accepts literal defaults on every column type.
+    fn translate_default_expr(&self, expr: &str, _ty: &str, _max_length: Option<u32>) -> String {
         let trimmed = expr.trim();
         match trimmed {
             "now()" | "NOW()" | "current_timestamp" | "CURRENT_TIMESTAMP" => {


### PR DESCRIPTION
## Summary

\`m2m::fetch_i64_col_pool\` was a 3-arm \`match pool\` doing byte-identical \`try_get::<i64, _>(col_name)\` loops per backend.

Collapses to \`raw_query_pool::<(i64,)>\` — positional tuple decode works on every backend via the \`Maybe*FromRow\` blanket impls. Both callers (\`all_pool\`, \`contains_pool\`) already emit single-column SELECTs, so the positional decode is guaranteed to land on the same column the old \`col_name\` lookup did. The \`col_name\` argument stays in the signature (prefixed \`_col_name\`) so external callers compile unchanged.

Skipped \`m2m::set_pool\` from #561's same-file callout — it needs the \`_tx\` helpers (\`raw_execute_tx\` / \`with_pool_tx\`) that the issue's final sub-bullet promises but the crate doesn't ship yet.

## Test plan

- [x] cargo test --no-default-features --features sqlite,tenancy --lib → 1564 pass
- [x] cargo test --workspace --all-features --no-run → clean
- [x] Net delete: ~40 lines