### PR TITLE
refactor(migrate): applied_set_pool_for through raw_query_pool (#561)

### DIFF
--- a/crates/rustango/src/fixtures.rs
+++ b/crates/rustango/src/fixtures.rs
@@ -202,111 +202,45 @@ async fn insert_row_pool(
         cols_sql.join(", "),
         placeholders.join(", "),
     );
-    // Bind per-backend. The JSON value → SQL parameter coercion is
-    // identical across backends for the scalar types fixtures carry;
-    // arrays / objects bind as `sqlx::types::Json<Value>` which all
-    // three sqlx backends support via the `json` feature.
-    match pool {
-        #[cfg(feature = "postgres")]
-        Pool::Postgres(pg) => {
-            let mut q = sqlx::query(&sql);
-            for col in &columns {
-                let val = &row[col.as_str()];
-                q = bind_pg(q, val);
-            }
-            q.execute(pg)
-                .await
-                .map_err(|e| FixtureError::Database(e.to_string()))?;
-        }
-        #[cfg(feature = "mysql")]
-        Pool::Mysql(my) => {
-            let mut q = sqlx::query(&sql);
-            for col in &columns {
-                let val = &row[col.as_str()];
-                q = bind_my(q, val);
-            }
-            q.execute(my)
-                .await
-                .map_err(|e| FixtureError::Database(e.to_string()))?;
-        }
-        #[cfg(feature = "sqlite")]
-        Pool::Sqlite(sq) => {
-            let mut q = sqlx::query(&sql);
-            for col in &columns {
-                let val = &row[col.as_str()];
-                q = bind_sqlite(q, val);
-            }
-            q.execute(sq)
-                .await
-                .map_err(|e| FixtureError::Database(e.to_string()))?;
-        }
-    }
+    // #561 — was three byte-identical `bind_pg`/`bind_my`/`bind_sqlite`
+    // helpers each matching on `serde_json::Value` and binding the
+    // backend-specific sqlx arg. Convert each row value to a
+    // `SqlValue` once and let `raw_execute_pool` dispatch through
+    // the canonical executor binding macros — arrays / objects go
+    // through `SqlValue::Json` which the executor wraps in
+    // `sqlx::types::Json(...)` for every backend.
+    let binds: Vec<crate::core::SqlValue> = columns
+        .iter()
+        .map(|col| value_to_sqlvalue(&row[col.as_str()]))
+        .collect();
+    crate::sql::raw_execute_pool(pool, &sql, binds)
+        .await
+        .map_err(|e| FixtureError::Database(e.to_string()))?;
     Ok(())
 }
 
-#[cfg(feature = "postgres")]
-fn bind_pg<'a>(
-    q: sqlx::query::Query<'a, sqlx::Postgres, sqlx::postgres::PgArguments>,
-    v: &'a Value,
-) -> sqlx::query::Query<'a, sqlx::Postgres, sqlx::postgres::PgArguments> {
+/// #561 — `serde_json::Value` → `SqlValue` adapter. Matches the
+/// behavior of the previous per-backend `bind_*` helpers:
+/// scalars route through the typed `SqlValue` variants; arrays and
+/// objects route through `SqlValue::Json` so the executor's
+/// `bind_match!` wraps in `sqlx::types::Json(...)` for JSONB / JSON
+/// / TEXT on PG / MySQL / SQLite respectively.
+fn value_to_sqlvalue(v: &Value) -> crate::core::SqlValue {
+    use crate::core::SqlValue;
     match v {
-        Value::Null => q.bind(None::<i64>),
-        Value::Bool(b) => q.bind(*b),
+        Value::Null => SqlValue::Null,
+        Value::Bool(b) => SqlValue::Bool(*b),
         Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                q.bind(i)
+                SqlValue::I64(i)
             } else if let Some(f) = n.as_f64() {
-                q.bind(f)
+                SqlValue::F64(f)
             } else {
-                q.bind(n.to_string())
+                SqlValue::String(n.to_string())
             }
         }
-        Value::String(s) => q.bind(s.as_str()),
-        Value::Array(_) | Value::Object(_) => q.bind(v.clone()),
-    }
-}
-
-#[cfg(feature = "mysql")]
-fn bind_my<'a>(
-    q: sqlx::query::Query<'a, sqlx::MySql, sqlx::mysql::MySqlArguments>,
-    v: &'a Value,
-) -> sqlx::query::Query<'a, sqlx::MySql, sqlx::mysql::MySqlArguments> {
-    match v {
-        Value::Null => q.bind(None::<i64>),
-        Value::Bool(b) => q.bind(*b),
-        Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                q.bind(i)
-            } else if let Some(f) = n.as_f64() {
-                q.bind(f)
-            } else {
-                q.bind(n.to_string())
-            }
-        }
-        Value::String(s) => q.bind(s.as_str()),
-        Value::Array(_) | Value::Object(_) => q.bind(sqlx::types::Json(v.clone())),
-    }
-}
-
-#[cfg(feature = "sqlite")]
-fn bind_sqlite<'a>(
-    q: sqlx::query::Query<'a, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'a>>,
-    v: &'a Value,
-) -> sqlx::query::Query<'a, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'a>> {
-    match v {
-        Value::Null => q.bind(None::<i64>),
-        Value::Bool(b) => q.bind(*b),
-        Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                q.bind(i)
-            } else if let Some(f) = n.as_f64() {
-                q.bind(f)
-            } else {
-                q.bind(n.to_string())
-            }
-        }
-        Value::String(s) => q.bind(s.as_str()),
-        Value::Array(_) | Value::Object(_) => q.bind(sqlx::types::Json(v.clone())),
+        Value::String(s) => SqlValue::String(s.clone()),
+        Value::Array(_) | Value::Object(_) => SqlValue::Json(v.clone()),
     }
 }
 

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -1322,35 +1322,14 @@ async fn applied_set_pool_for(
     ledger: &str,
 ) -> Result<HashSet<String>, MigrateError> {
     let sql = format!("SELECT name FROM {ledger}");
-    match pool {
-        #[cfg(feature = "postgres")]
-        crate::sql::Pool::Postgres(pg) => {
-            let rows = sqlx::query(&sql).fetch_all(pg).await?;
-            let mut out = HashSet::with_capacity(rows.len());
-            for row in rows {
-                out.insert(row.try_get::<String, _>("name")?);
-            }
-            Ok(out)
-        }
-        #[cfg(feature = "mysql")]
-        crate::sql::Pool::Mysql(my) => {
-            let rows = sqlx::query(&sql).fetch_all(my).await?;
-            let mut out = HashSet::with_capacity(rows.len());
-            for row in rows {
-                out.insert(row.try_get::<String, _>("name")?);
-            }
-            Ok(out)
-        }
-        #[cfg(feature = "sqlite")]
-        crate::sql::Pool::Sqlite(sq) => {
-            let rows = sqlx::query(&sql).fetch_all(sq).await?;
-            let mut out = HashSet::with_capacity(rows.len());
-            for row in rows {
-                out.insert(row.try_get::<String, _>("name")?);
-            }
-            Ok(out)
-        }
-    }
+    // #561 — was 3-arm `match pool` doing byte-identical
+    // `try_get::<String, _>("name")` loops. The
+    // `raw_query_pool::<(String,)>` positional tuple decode pulls
+    // the single column on every backend via the `Maybe*FromRow`
+    // blanket impls. `ExecError` rides in via `MigrateError::Exec`'s
+    // `#[from]` impl.
+    let rows: Vec<(String,)> = crate::sql::raw_query_pool(&sql, Vec::new(), pool).await?;
+    Ok(rows.into_iter().map(|(name,)| name).collect())
 }
 
 /// Apply every pending migration in `dir` against either backend.


### PR DESCRIPTION
## Summary

\`migrate::runner::applied_set_pool_for\` was a 3-arm \`match pool\` doing byte-identical \`try_get::<String, _>(\"name\")\` loops per backend.

Collapses to \`raw_query_pool::<(String,)>\` — positional tuple decode on the single-column \`SELECT name FROM <ledger>\`. \`ExecError\` rides in via \`MigrateError::Exec\`'s \`#[from]\` impl, so the call site keeps its \`?\` shape.

## Test plan

- [x] 1564 sqlite,tenancy lib tests pass
- [x] cargo test --workspace --all-features --no-run → clean
- [x] Net delete: ~25 lines