### PR TITLE
feat(model): #[rustango(db_table_comment = "...")] — Django Meta.db_table_comment parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Post-v0.42 Django-parity follow-ups. Each item is a self-contained slice that la
 - **`#[rustango(managed = false)]`** (#558 closing [#321](https://github.com/ujeenet/rustango/issues/321)) — Django `class Meta: managed = False`. Opts a model out of migration auto-gen so the table stays operator-managed.
 - **`Locale::display_name()` / `native_name()` + Tera `language_display_name()` / `language_native_name()`** (#563) — 42-language picker primitives for bidi-aware UIs.
 - **`#[rustango(citext)]`** (#566 closing [#344](https://github.com/ujeenet/rustango/issues/344)) — Django `CITextField`. Per-dialect DDL emit: `CITEXT` (PG, with `dialect.ci_text_extension_sql()` exposing the `CREATE EXTENSION` prelude), `TEXT COLLATE NOCASE` (SQLite), `VARCHAR(N) COLLATE utf8mb4_general_ci` (MySQL).
+- **`#[rustango(db_table_comment = "...")]`** — Django `Meta.db_table_comment` (4.2+). Per-dialect DDL emit: PG post-table `COMMENT ON TABLE "<t>" IS '...'`, MySQL inline `COMMENT='...'` trailer after CREATE TABLE, SQLite no-op. Useful for data-lineage tooling that reads the table's catalog comment.
 
 ### Fixed
 

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -805,6 +805,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         container.verbose_name.as_deref(),
         container.verbose_name_plural.as_deref(),
         container.managed,
+        container.db_table_comment.as_deref(),
     );
     let module_ident = column_module_ident(struct_name);
     let column_consts = column_const_tokens(&module_ident, &collected.column_entries);
@@ -1692,6 +1693,7 @@ fn model_impl_tokens(
     verbose_name: Option<&str>,
     verbose_name_plural: Option<&str>,
     managed: bool,
+    db_table_comment: Option<&str>,
 ) -> TokenStream2 {
     let display_tokens = if let Some(name) = display {
         quote!(::core::option::Option::Some(#name))
@@ -1725,6 +1727,7 @@ fn model_impl_tokens(
     };
     let verbose_name_tokens = optional_str(verbose_name);
     let verbose_name_plural_tokens = optional_str(verbose_name_plural);
+    let db_table_comment_tokens = optional_str(db_table_comment);
     let indexes_tokens = indexes.iter().map(|idx| {
         let name = idx.name.as_deref().unwrap_or("unnamed_index");
         let cols: Vec<&str> = idx.columns.iter().map(String::as_str).collect();
@@ -1839,6 +1842,7 @@ fn model_impl_tokens(
                 verbose_name: #verbose_name_tokens,
                 verbose_name_plural: #verbose_name_plural_tokens,
                 managed: #managed,
+                db_table_comment: #db_table_comment_tokens,
             };
         }
     }
@@ -4400,6 +4404,12 @@ struct ContainerAttrs {
     /// `migrate` never emit `CREATE TABLE` / `ALTER TABLE` / `DROP
     /// TABLE` against it (operator-managed schema).
     managed: bool,
+    /// Django-shape `Meta.db_table_comment` (4.2+) from
+    /// `#[rustango(db_table_comment = "...")]`. Threaded into
+    /// `ModelSchema::db_table_comment` so the DDL writer attaches the
+    /// comment to the underlying table (PG: `COMMENT ON TABLE`, MySQL:
+    /// inline `COMMENT='...'`, SQLite: no-op).
+    db_table_comment: Option<String>,
     /// `#[rustango(verbose_name = "blog post")]` — Django-shape
     /// human-readable singular label for the model. Threaded into
     /// `ModelSchema::verbose_name` so admin section headers /
@@ -4595,6 +4605,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
         managed: true,
         verbose_name: None,
         verbose_name_plural: None,
+        db_table_comment: None,
     };
     for attr in &input.attrs {
         if !attr.path().is_ident("rustango") {
@@ -4924,6 +4935,13 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
             if meta.path.is_ident("verbose_name_plural") {
                 let s: LitStr = meta.value()?.parse()?;
                 out.verbose_name_plural = Some(s.value());
+                return Ok(());
+            }
+            if meta.path.is_ident("db_table_comment") {
+                // Django-shape `Meta.db_table_comment` (4.2+) — free-form
+                // table-level comment attached to the DB catalog.
+                let s: LitStr = meta.value()?.parse()?;
+                out.db_table_comment = Some(s.value());
                 return Ok(());
             }
             if meta.path.is_ident("unique_together") {

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -377,6 +377,18 @@ pub struct ModelSchema {
     /// rustango models for query / admin purposes but should not
     /// re-create.
     pub managed: bool,
+    /// Django-shape `Meta.db_table_comment` (Django 4.2+) — free-form
+    /// description attached to the underlying DB table. The migration
+    /// writer emits the comment per dialect:
+    ///
+    /// - Postgres: post-table `COMMENT ON TABLE "<t>" IS '...'`
+    /// - MySQL: inline `COMMENT='...'` trailer after the closing paren
+    /// - SQLite: no-op (no native table comments)
+    ///
+    /// Set via `#[rustango(db_table_comment = "free text")]`. Useful
+    /// for ops tooling (data lineage docs, sql-introspectors) that
+    /// reads the table's catalog comment.
+    pub db_table_comment: Option<&'static str>,
 }
 
 impl ModelSchema {

--- a/crates/rustango/src/fixtures.rs
+++ b/crates/rustango/src/fixtures.rs
@@ -202,111 +202,45 @@ async fn insert_row_pool(
         cols_sql.join(", "),
         placeholders.join(", "),
     );
-    // Bind per-backend. The JSON value → SQL parameter coercion is
-    // identical across backends for the scalar types fixtures carry;
-    // arrays / objects bind as `sqlx::types::Json<Value>` which all
-    // three sqlx backends support via the `json` feature.
-    match pool {
-        #[cfg(feature = "postgres")]
-        Pool::Postgres(pg) => {
-            let mut q = sqlx::query(&sql);
-            for col in &columns {
-                let val = &row[col.as_str()];
-                q = bind_pg(q, val);
-            }
-            q.execute(pg)
-                .await
-                .map_err(|e| FixtureError::Database(e.to_string()))?;
-        }
-        #[cfg(feature = "mysql")]
-        Pool::Mysql(my) => {
-            let mut q = sqlx::query(&sql);
-            for col in &columns {
-                let val = &row[col.as_str()];
-                q = bind_my(q, val);
-            }
-            q.execute(my)
-                .await
-                .map_err(|e| FixtureError::Database(e.to_string()))?;
-        }
-        #[cfg(feature = "sqlite")]
-        Pool::Sqlite(sq) => {
-            let mut q = sqlx::query(&sql);
-            for col in &columns {
-                let val = &row[col.as_str()];
-                q = bind_sqlite(q, val);
-            }
-            q.execute(sq)
-                .await
-                .map_err(|e| FixtureError::Database(e.to_string()))?;
-        }
-    }
+    // #561 — was three byte-identical `bind_pg`/`bind_my`/`bind_sqlite`
+    // helpers each matching on `serde_json::Value` and binding the
+    // backend-specific sqlx arg. Convert each row value to a
+    // `SqlValue` once and let `raw_execute_pool` dispatch through
+    // the canonical executor binding macros — arrays / objects go
+    // through `SqlValue::Json` which the executor wraps in
+    // `sqlx::types::Json(...)` for every backend.
+    let binds: Vec<crate::core::SqlValue> = columns
+        .iter()
+        .map(|col| value_to_sqlvalue(&row[col.as_str()]))
+        .collect();
+    crate::sql::raw_execute_pool(pool, &sql, binds)
+        .await
+        .map_err(|e| FixtureError::Database(e.to_string()))?;
     Ok(())
 }
 
-#[cfg(feature = "postgres")]
-fn bind_pg<'a>(
-    q: sqlx::query::Query<'a, sqlx::Postgres, sqlx::postgres::PgArguments>,
-    v: &'a Value,
-) -> sqlx::query::Query<'a, sqlx::Postgres, sqlx::postgres::PgArguments> {
+/// #561 — `serde_json::Value` → `SqlValue` adapter. Matches the
+/// behavior of the previous per-backend `bind_*` helpers:
+/// scalars route through the typed `SqlValue` variants; arrays and
+/// objects route through `SqlValue::Json` so the executor's
+/// `bind_match!` wraps in `sqlx::types::Json(...)` for JSONB / JSON
+/// / TEXT on PG / MySQL / SQLite respectively.
+fn value_to_sqlvalue(v: &Value) -> crate::core::SqlValue {
+    use crate::core::SqlValue;
     match v {
-        Value::Null => q.bind(None::<i64>),
-        Value::Bool(b) => q.bind(*b),
+        Value::Null => SqlValue::Null,
+        Value::Bool(b) => SqlValue::Bool(*b),
         Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                q.bind(i)
+                SqlValue::I64(i)
             } else if let Some(f) = n.as_f64() {
-                q.bind(f)
+                SqlValue::F64(f)
             } else {
-                q.bind(n.to_string())
+                SqlValue::String(n.to_string())
             }
         }
-        Value::String(s) => q.bind(s.as_str()),
-        Value::Array(_) | Value::Object(_) => q.bind(v.clone()),
-    }
-}
-
-#[cfg(feature = "mysql")]
-fn bind_my<'a>(
-    q: sqlx::query::Query<'a, sqlx::MySql, sqlx::mysql::MySqlArguments>,
-    v: &'a Value,
-) -> sqlx::query::Query<'a, sqlx::MySql, sqlx::mysql::MySqlArguments> {
-    match v {
-        Value::Null => q.bind(None::<i64>),
-        Value::Bool(b) => q.bind(*b),
-        Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                q.bind(i)
-            } else if let Some(f) = n.as_f64() {
-                q.bind(f)
-            } else {
-                q.bind(n.to_string())
-            }
-        }
-        Value::String(s) => q.bind(s.as_str()),
-        Value::Array(_) | Value::Object(_) => q.bind(sqlx::types::Json(v.clone())),
-    }
-}
-
-#[cfg(feature = "sqlite")]
-fn bind_sqlite<'a>(
-    q: sqlx::query::Query<'a, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'a>>,
-    v: &'a Value,
-) -> sqlx::query::Query<'a, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'a>> {
-    match v {
-        Value::Null => q.bind(None::<i64>),
-        Value::Bool(b) => q.bind(*b),
-        Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                q.bind(i)
-            } else if let Some(f) = n.as_f64() {
-                q.bind(f)
-            } else {
-                q.bind(n.to_string())
-            }
-        }
-        Value::String(s) => q.bind(s.as_str()),
-        Value::Array(_) | Value::Object(_) => q.bind(sqlx::types::Json(v.clone())),
+        Value::String(s) => SqlValue::String(s.clone()),
+        Value::Array(_) | Value::Object(_) => SqlValue::Json(v.clone()),
     }
 }
 

--- a/crates/rustango/src/migrate/ddl.rs
+++ b/crates/rustango/src/migrate/ddl.rs
@@ -91,7 +91,34 @@ pub fn create_table_sql_with_dialect(dialect: &dyn Dialect, model: &ModelSchema)
         write_column_def(&mut s, dialect, field);
     }
     s.push(')');
+    // Django-shape `Meta.db_table_comment` — MySQL spells it as an
+    // inline trailer (`) COMMENT='...'`); PG + SQLite emit nothing
+    // inline (PG runs a post-hoc `COMMENT ON TABLE`, SQLite is a
+    // no-op). See `table_comment_statements_with_dialect`.
+    if let Some(comment) = model.db_table_comment {
+        if let Some(inline) = dialect.write_inline_table_comment(comment) {
+            s.push_str(&inline);
+        }
+    }
     s
+}
+
+/// Per-model post-CREATE-TABLE statements for `Meta.db_table_comment`.
+/// PG emits `COMMENT ON TABLE`, MySQL handles it inline (see
+/// `create_table_sql_with_dialect` above) and returns nothing here,
+/// SQLite has no native table comments and returns nothing.
+#[must_use]
+pub fn table_comment_statements_with_dialect(
+    dialect: &dyn Dialect,
+    model: &ModelSchema,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(comment) = model.db_table_comment {
+        if let Some(stmt) = dialect.table_comment_statement(model.table, comment) {
+            out.push(stmt);
+        }
+    }
+    out
 }
 
 /// `CREATE TABLE IF NOT EXISTS …` variant of

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -1322,35 +1322,14 @@ async fn applied_set_pool_for(
     ledger: &str,
 ) -> Result<HashSet<String>, MigrateError> {
     let sql = format!("SELECT name FROM {ledger}");
-    match pool {
-        #[cfg(feature = "postgres")]
-        crate::sql::Pool::Postgres(pg) => {
-            let rows = sqlx::query(&sql).fetch_all(pg).await?;
-            let mut out = HashSet::with_capacity(rows.len());
-            for row in rows {
-                out.insert(row.try_get::<String, _>("name")?);
-            }
-            Ok(out)
-        }
-        #[cfg(feature = "mysql")]
-        crate::sql::Pool::Mysql(my) => {
-            let rows = sqlx::query(&sql).fetch_all(my).await?;
-            let mut out = HashSet::with_capacity(rows.len());
-            for row in rows {
-                out.insert(row.try_get::<String, _>("name")?);
-            }
-            Ok(out)
-        }
-        #[cfg(feature = "sqlite")]
-        crate::sql::Pool::Sqlite(sq) => {
-            let rows = sqlx::query(&sql).fetch_all(sq).await?;
-            let mut out = HashSet::with_capacity(rows.len());
-            for row in rows {
-                out.insert(row.try_get::<String, _>("name")?);
-            }
-            Ok(out)
-        }
-    }
+    // #561 — was 3-arm `match pool` doing byte-identical
+    // `try_get::<String, _>("name")` loops. The
+    // `raw_query_pool::<(String,)>` positional tuple decode pulls
+    // the single column on every backend via the `Maybe*FromRow`
+    // blanket impls. `ExecError` rides in via `MigrateError::Exec`'s
+    // `#[from]` impl.
+    let rows: Vec<(String,)> = crate::sql::raw_query_pool(&sql, Vec::new(), pool).await?;
+    Ok(rows.into_iter().map(|(name,)| name).collect())
 }
 
 /// Apply every pending migration in `dir` against either backend.

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -335,6 +335,14 @@ pub async fn apply_all_pool(pool: &crate::sql::Pool) -> Result<(), MigrateError>
             crate::sql::raw_execute_pool(pool, &sql, ::std::vec::Vec::new()).await?;
         }
     }
+    // Django Meta.db_table_comment — same shape as column-level:
+    // PG emits a post-hoc `COMMENT ON TABLE`, MySQL inlined it in
+    // CREATE TABLE, SQLite emits nothing.
+    for model in &models {
+        for sql in ddl::table_comment_statements_with_dialect(dialect, model) {
+            crate::sql::raw_execute_pool(pool, &sql, ::std::vec::Vec::new()).await?;
+        }
+    }
     // #411 — post_migrate fires once after the bootstrap walk
     // completes. `applied` is empty because apply_all_pool doesn't
     // carry per-migration names — it walks the model inventory.

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -590,6 +590,7 @@ mod composite_fk_snapshot_tests {
             verbose_name: None,
             verbose_name_plural: None,
             managed: true,
+            db_table_comment: None,
         };
         &MS
     }
@@ -656,6 +657,7 @@ mod composite_fk_snapshot_tests {
             verbose_name: None,
             verbose_name_plural: None,
             managed: true,
+            db_table_comment: None,
         };
         static UNMANAGED: ModelSchema = ModelSchema {
             name: "Unmanaged",
@@ -678,6 +680,7 @@ mod composite_fk_snapshot_tests {
             verbose_name: None,
             verbose_name_plural: None,
             managed: false,
+            db_table_comment: None,
         };
         let snap = SchemaSnapshot::from_models(&[&MANAGED, &UNMANAGED]);
         let table_names: Vec<&str> = snap.tables.iter().map(|t| t.name.as_str()).collect();
@@ -737,6 +740,7 @@ mod composite_fk_snapshot_tests {
             verbose_name: None,
             verbose_name_plural: None,
             managed: true,
+            db_table_comment: None,
         };
         let snap = TableSnapshot::from_schema(&MS);
         let json = serde_json::to_string(&snap).expect("serialize");

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -292,6 +292,7 @@ mod tests {
         verbose_name: None,
         verbose_name_plural: None,
         managed: true,
+        db_table_comment: None,
     };
 
     static MODEL_WITHOUT_SD: ModelSchema = ModelSchema {
@@ -315,6 +316,7 @@ mod tests {
         verbose_name: None,
         verbose_name_plural: None,
         managed: true,
+        db_table_comment: None,
     };
 
     #[test]

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -709,6 +709,30 @@ pub trait Dialect {
         None
     }
 
+    /// Inline table-comment fragment to splice into a CREATE TABLE
+    /// trailer for the model's `db_table_comment` attribute. MySQL
+    /// returns `" COMMENT='<escaped>'"`; Postgres + SQLite return
+    /// `None` because they need a different mechanism (post-hoc
+    /// `COMMENT ON TABLE` for Postgres, no-op for SQLite) — see
+    /// [`Self::table_comment_statement`]. Implementations are
+    /// responsible for properly escaping single quotes.
+    fn write_inline_table_comment(&self, _comment: &str) -> Option<String> {
+        None
+    }
+
+    /// Standalone `COMMENT ON TABLE "<table>" IS '<escaped>'`
+    /// statement emitted after CREATE TABLE for dialects that need
+    /// it. Postgres returns `Some(_)`; MySQL handles it inline (see
+    /// [`Self::write_inline_table_comment`]) and returns `None`;
+    /// SQLite returns `None` (no native table comments). Mirrors
+    /// the field-level [`Self::column_comment_statement`].
+    ///
+    /// Implementations are responsible for properly escaping single
+    /// quotes in the supplied comment.
+    fn table_comment_statement(&self, _table: &str, _comment: &str) -> Option<String> {
+        None
+    }
+
     // ====== Compilation (always overridden) ======
 
     /// Lower a `SelectQuery` to a `CompiledStatement` for this dialect.

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -87,6 +87,15 @@ impl Dialect for MySql {
         Some(format!(" COMMENT '{escaped}'"))
     }
 
+    /// MySQL spells table comments as a `COMMENT='<escaped>'` trailer
+    /// after the closing paren of CREATE TABLE (e.g. `CREATE TABLE
+    /// foo (...) COMMENT='blog posts'`). Single quotes are doubled.
+    /// Django parity for `Meta.db_table_comment`.
+    fn write_inline_table_comment(&self, comment: &str) -> Option<String> {
+        let escaped = comment.replace('\'', "''");
+        Some(format!(" COMMENT='{escaped}'"))
+    }
+
     // `?`-style placeholders are the trait default — no override needed.
 
     fn serial_type(&self, field_type: FieldType) -> &'static str {
@@ -1339,6 +1348,7 @@ mod tests {
             verbose_name: None,
             verbose_name_plural: None,
             managed: true,
+            db_table_comment: None,
         }))
     }
 }

--- a/crates/rustango/src/sql/postgres.rs
+++ b/crates/rustango/src/sql/postgres.rs
@@ -56,6 +56,15 @@ impl Dialect for Postgres {
         ))
     }
 
+    fn table_comment_statement(&self, table: &str, comment: &str) -> Option<String> {
+        let escaped = comment.replace('\'', "''");
+        Some(format!(
+            "COMMENT ON TABLE {} IS '{}'",
+            self.quote_ident(table),
+            escaped,
+        ))
+    }
+
     fn serial_type(&self, field_type: FieldType) -> &'static str {
         match field_type {
             FieldType::I32 => "SERIAL",

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -670,6 +670,7 @@ mod tests {
             verbose_name: None,
             verbose_name_plural: None,
             managed: true,
+            db_table_comment: None,
         };
         let q = SelectQuery {
             model: &MODEL,

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -4073,6 +4073,7 @@ mod tests {
             verbose_name: None,
             verbose_name_plural: None,
             managed: true,
+            db_table_comment: None,
         }))
     }
 
@@ -4171,6 +4172,7 @@ mod tests {
             verbose_name: None,
             verbose_name_plural: None,
             managed: true,
+            db_table_comment: None,
         }))
     }
 
@@ -4553,6 +4555,7 @@ mod tests {
             verbose_name: None,
             verbose_name_plural: None,
             managed: true,
+            db_table_comment: None,
         }));
         assert!(default_order_by(no_pk).is_empty());
     }
@@ -4801,6 +4804,7 @@ mod tests {
             verbose_name: None,
             verbose_name_plural: None,
             managed: true,
+            db_table_comment: None,
         }));
         let pk = uuid_schema.primary_key().unwrap();
         let raw = "550e8400-e29b-41d4-a716-446655440000";
@@ -4861,6 +4865,7 @@ mod tests {
             verbose_name: None,
             verbose_name_plural: None,
             managed: true,
+            db_table_comment: None,
         }));
         let pk = str_schema.primary_key().unwrap();
         match coerce_pk(pk, "hello-world") {

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -460,6 +460,7 @@ mod tests {
             verbose_name: None,
             verbose_name_plural: None,
             managed: true,
+            db_table_comment: None,
         };
         &MS
     }

--- a/crates/rustango/tests/macro_db_table_comment.rs
+++ b/crates/rustango/tests/macro_db_table_comment.rs
@@ -1,0 +1,120 @@
+//! Django parity — `Meta.db_table_comment` (Django 4.2+). Verifies the
+//! macro parses the attribute, threads it onto `ModelSchema`, and the
+//! migration DDL writer emits the right shape per dialect.
+
+#![cfg(feature = "sqlite")]
+
+use rustango::core::Model as _;
+use rustango::migrate::ddl::{
+    create_table_sql_with_dialect, table_comment_statements_with_dialect,
+};
+use rustango::sql::{Dialect as _, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(
+    table = "dtc_post",
+    db_table_comment = "Blog posts — public CMS content."
+)]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    title: String,
+}
+
+#[derive(Model)]
+#[rustango(table = "dtc_plain")]
+#[allow(dead_code)]
+pub struct Plain {
+    #[rustango(primary_key)]
+    id: i64,
+}
+
+#[test]
+fn macro_threads_comment_onto_model_schema() {
+    let schema = <Post as rustango::core::Model>::SCHEMA;
+    assert_eq!(
+        schema.db_table_comment,
+        Some("Blog posts — public CMS content.")
+    );
+    let plain = <Plain as rustango::core::Model>::SCHEMA;
+    assert_eq!(plain.db_table_comment, None);
+}
+
+#[test]
+fn postgres_emits_post_hoc_comment_on_table() {
+    let schema = <Post as rustango::core::Model>::SCHEMA;
+    // CREATE TABLE on PG has no inline comment — the trailer is empty.
+    let create = create_table_sql_with_dialect(&Postgres, schema);
+    assert!(
+        !create.contains("COMMENT"),
+        "PG CREATE TABLE must not inline the comment; got: {create}"
+    );
+    // The post-hoc COMMENT ON TABLE statement is the single entry.
+    let stmts = table_comment_statements_with_dialect(&Postgres, schema);
+    assert_eq!(stmts.len(), 1, "PG should emit one COMMENT ON TABLE");
+    assert_eq!(
+        stmts[0],
+        "COMMENT ON TABLE \"dtc_post\" IS 'Blog posts — public CMS content.'"
+    );
+}
+
+#[test]
+fn mysql_emits_inline_table_comment_trailer() {
+    let schema = <Post as rustango::core::Model>::SCHEMA;
+    let create = create_table_sql_with_dialect(&MySql, schema);
+    assert!(
+        create.ends_with(" COMMENT='Blog posts — public CMS content.'"),
+        "MySQL must inline COMMENT=… trailer; got: {create}"
+    );
+    // No post-hoc statement on MySQL.
+    let stmts = table_comment_statements_with_dialect(&MySql, schema);
+    assert!(stmts.is_empty(), "MySQL inlines, post-hoc is empty");
+}
+
+#[test]
+fn sqlite_silently_drops_table_comment() {
+    let schema = <Post as rustango::core::Model>::SCHEMA;
+    // SQLite has no native table comments — CREATE TABLE stays clean.
+    let create = create_table_sql_with_dialect(&Sqlite, schema);
+    assert!(
+        !create.contains("COMMENT"),
+        "SQLite CREATE TABLE must not include COMMENT; got: {create}"
+    );
+    let stmts = table_comment_statements_with_dialect(&Sqlite, schema);
+    assert!(stmts.is_empty(), "SQLite emits no post-hoc statement");
+}
+
+#[test]
+fn models_without_db_table_comment_emit_nothing_anywhere() {
+    let plain = <Plain as rustango::core::Model>::SCHEMA;
+    for dialect in [&Postgres as &dyn rustango::sql::Dialect, &MySql, &Sqlite] {
+        let create = create_table_sql_with_dialect(dialect, plain);
+        assert!(
+            !create.contains("COMMENT"),
+            "[{}] no-comment model must not emit COMMENT: {create}",
+            dialect.name()
+        );
+        let stmts = table_comment_statements_with_dialect(dialect, plain);
+        assert!(stmts.is_empty(), "[{}] no post-hoc", dialect.name());
+    }
+}
+
+#[test]
+fn pg_escapes_single_quotes_in_comment() {
+    // Synthesize a model with a quote-containing comment through the
+    // dialect APIs directly — the macro layer doesn't need its own
+    // escape since the SQL emitters do the work.
+    let stmt = Postgres
+        .table_comment_statement("t", "it's tricky")
+        .expect("PG emits a stmt");
+    assert!(
+        stmt.contains("'it''s tricky'"),
+        "single quotes must be doubled: {stmt}"
+    );
+    let stmt = MySql
+        .write_inline_table_comment("it's tricky")
+        .expect("MySQL emits inline");
+    assert_eq!(stmt, " COMMENT='it''s tricky'");
+}


### PR DESCRIPTION
## Summary

Django 4.2+ added \`class Meta: db_table_comment = \"...\"\`, attaching a free-form text comment to the underlying DB table. Useful for ops tooling (data lineage docs, sql-introspectors, catalog dumps) that reads the table's catalog comment.

\`\`\`rust
#[derive(Model)]
#[rustango(
    table = "posts",
    db_table_comment = "Blog posts — public CMS content."
)]
pub struct Post { /* … */ }
\`\`\`

## Per-dialect DDL

| Backend | Emit |
|---|---|
| Postgres | post-table \`COMMENT ON TABLE \"<t>\" IS '<escaped>'\` |
| MySQL | inline \`COMMENT='<escaped>'\` trailer after CREATE TABLE's closing paren |
| SQLite | no-op (no native table comments) |

Single quotes are doubled per parser escape rules. Models without \`db_table_comment\` continue to produce byte-identical DDL.

## Wiring

- \`ModelSchema::db_table_comment: Option<&'static str>\`
- Container-attr parse arm for \`#[rustango(db_table_comment = \"...\")]\`
- \`Dialect::write_inline_table_comment\` + \`table_comment_statement\` (mirror the existing field-level \`db_comment\` shape from #450)
- \`ddl::create_table_sql_with_dialect\` splices inline (MySQL); \`ddl::table_comment_statements_with_dialect\` returns post-hoc \`COMMENT ON TABLE\` (PG)
- \`runner::apply_all_pool\` runs the post-hoc statements after CREATE TABLE

## Test plan

- [x] 6 tests in \`tests/macro_db_table_comment.rs\`
- [x] cargo test --no-default-features --features sqlite,tenancy --lib → 1564 pass
- [x] cargo test --workspace --all-features --no-run → clean
- [x] Tri-backend \`cargo build --features postgres,mysql,sqlite,tenancy\` clean