### PR TITLE
feat(model): #[rustango(extra_permissions = "...")] — Django Meta.permissions parity

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -810,6 +810,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
             .get_latest_by
             .as_ref()
             .map(|(c, d)| (c.as_str(), *d)),
+        &container.extra_permissions,
     );
     let module_ident = column_module_ident(struct_name);
     let column_consts = column_const_tokens(&module_ident, &collected.column_entries);
@@ -1699,6 +1700,7 @@ fn model_impl_tokens(
     managed: bool,
     db_table_comment: Option<&str>,
     get_latest_by: Option<(&str, bool)>,
+    extra_permissions: &[(String, String)],
 ) -> TokenStream2 {
     let display_tokens = if let Some(name) = display {
         quote!(::core::option::Option::Some(#name))
@@ -1739,6 +1741,10 @@ fn model_impl_tokens(
         }
         None => quote!(::core::option::Option::None),
     };
+    let extra_permission_tokens: Vec<_> = extra_permissions
+        .iter()
+        .map(|(c, l)| quote!((#c, #l)))
+        .collect();
     let indexes_tokens = indexes.iter().map(|idx| {
         let name = idx.name.as_deref().unwrap_or("unnamed_index");
         let cols: Vec<&str> = idx.columns.iter().map(String::as_str).collect();
@@ -1855,6 +1861,7 @@ fn model_impl_tokens(
                 managed: #managed,
                 db_table_comment: #db_table_comment_tokens,
                 get_latest_by: #get_latest_by_tokens,
+                extra_permissions: &[ #(#extra_permission_tokens),* ],
             };
         }
     }
@@ -4429,6 +4436,11 @@ struct ContainerAttrs {
     /// attribute value starts with `-`. Threaded into
     /// `ModelSchema::get_latest_by`.
     get_latest_by: Option<(String, bool)>,
+    /// Django-shape `Meta.permissions = [(codename, name), ...]`
+    /// from `#[rustango(extra_permissions = "approve:Can approve,
+    /// archive:Can archive")]`. Comma-separated `codename:label`
+    /// pairs. Threaded into `ModelSchema::extra_permissions`.
+    extra_permissions: Vec<(String, String)>,
     /// `#[rustango(verbose_name = "blog post")]` — Django-shape
     /// human-readable singular label for the model. Threaded into
     /// `ModelSchema::verbose_name` so admin section headers /
@@ -4626,6 +4638,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
         verbose_name_plural: None,
         db_table_comment: None,
         get_latest_by: None,
+        extra_permissions: Vec::new(),
     };
     for attr in &input.attrs {
         if !attr.path().is_ident("rustango") {
@@ -4962,6 +4975,35 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                 // table-level comment attached to the DB catalog.
                 let s: LitStr = meta.value()?.parse()?;
                 out.db_table_comment = Some(s.value());
+                return Ok(());
+            }
+            if meta.path.is_ident("extra_permissions") {
+                // Django-shape `Meta.permissions = [(codename, name), ...]`.
+                // Comma-separated `codename:label` pairs.
+                let s: LitStr = meta.value()?.parse()?;
+                let raw = s.value();
+                let mut pairs = Vec::new();
+                for entry in raw.split(',') {
+                    let entry = entry.trim();
+                    if entry.is_empty() {
+                        continue;
+                    }
+                    let (codename, label) = match entry.split_once(':') {
+                        Some((c, l)) => (c.trim().to_owned(), l.trim().to_owned()),
+                        None => (entry.to_owned(), entry.to_owned()),
+                    };
+                    if codename.is_empty() {
+                        return Err(meta.error(
+                            "`extra_permissions` entries must be `codename:label` pairs",
+                        ));
+                    }
+                    pairs.push((codename, label));
+                }
+                if pairs.is_empty() {
+                    return Err(meta
+                        .error("`extra_permissions = \"…\"` must list at least one pair"));
+                }
+                out.extra_permissions = pairs;
                 return Ok(());
             }
             if meta.path.is_ident("get_latest_by") {

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -399,6 +399,17 @@ pub struct ModelSchema {
     /// `#[rustango(get_latest_by = "-priority")]`. `None` means the
     /// default-less variants return an error pointing at this attr.
     pub get_latest_by: Option<(&'static str, bool)>,
+    /// Django-shape `Meta.permissions = [(codename, name), ...]` —
+    /// extra permission codenames to register alongside the default
+    /// `add/change/delete/view` set. Each tuple is `(codename,
+    /// display_name)`. `auto_create_permissions_pool` walks this list
+    /// after the CRUD codenames so apps can declare custom
+    /// authorization buckets like `("approve", "Can approve posts")`.
+    ///
+    /// Set via `#[rustango(extra_permissions = "approve:Can approve,
+    /// archive:Can archive")]` — comma-separated `codename:label`
+    /// pairs, same shape as the existing `choices = "..."` attribute.
+    pub extra_permissions: &'static [(&'static str, &'static str)],
 }
 
 impl ModelSchema {

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -592,6 +592,7 @@ mod composite_fk_snapshot_tests {
             managed: true,
             db_table_comment: None,
             get_latest_by: None,
+            extra_permissions: &[],
         };
         &MS
     }
@@ -660,6 +661,7 @@ mod composite_fk_snapshot_tests {
             managed: true,
             db_table_comment: None,
             get_latest_by: None,
+            extra_permissions: &[],
         };
         static UNMANAGED: ModelSchema = ModelSchema {
             name: "Unmanaged",
@@ -684,6 +686,7 @@ mod composite_fk_snapshot_tests {
             managed: false,
             db_table_comment: None,
             get_latest_by: None,
+            extra_permissions: &[],
         };
         let snap = SchemaSnapshot::from_models(&[&MANAGED, &UNMANAGED]);
         let table_names: Vec<&str> = snap.tables.iter().map(|t| t.name.as_str()).collect();
@@ -745,6 +748,7 @@ mod composite_fk_snapshot_tests {
             managed: true,
             db_table_comment: None,
             get_latest_by: None,
+            extra_permissions: &[],
         };
         let snap = TableSnapshot::from_schema(&MS);
         let json = serde_json::to_string(&snap).expect("serialize");

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -294,6 +294,7 @@ mod tests {
         managed: true,
         db_table_comment: None,
         get_latest_by: None,
+        extra_permissions: &[],
     };
 
     static MODEL_WITHOUT_SD: ModelSchema = ModelSchema {
@@ -319,6 +320,7 @@ mod tests {
         managed: true,
         db_table_comment: None,
         get_latest_by: None,
+        extra_permissions: &[],
     };
 
     #[test]

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -1350,6 +1350,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             get_latest_by: None,
+            extra_permissions: &[],
         }))
     }
 }

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -672,6 +672,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             get_latest_by: None,
+            extra_permissions: &[],
         };
         let q = SelectQuery {
             model: &MODEL,

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -4075,6 +4075,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             get_latest_by: None,
+            extra_permissions: &[],
         }))
     }
 
@@ -4175,6 +4176,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             get_latest_by: None,
+            extra_permissions: &[],
         }))
     }
 
@@ -4559,6 +4561,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             get_latest_by: None,
+            extra_permissions: &[],
         }));
         assert!(default_order_by(no_pk).is_empty());
     }
@@ -4809,6 +4812,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             get_latest_by: None,
+            extra_permissions: &[],
         }));
         let pk = uuid_schema.primary_key().unwrap();
         let raw = "550e8400-e29b-41d4-a716-446655440000";
@@ -4871,6 +4875,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             get_latest_by: None,
+            extra_permissions: &[],
         }));
         let pk = str_schema.primary_key().unwrap();
         match coerce_pk(pk, "hello-world") {

--- a/crates/rustango/src/tenancy/permissions.rs
+++ b/crates/rustango/src/tenancy/permissions.rs
@@ -1442,6 +1442,43 @@ pub async fn auto_create_permissions_pool(pool: &crate::sql::Pool) -> Result<(),
         }
         let table = entry.schema.table;
         let model_name = entry.schema.name;
+        // Django Meta.permissions — extra (codename, name) pairs seeded
+        // alongside the auto CRUD codenames so apps can declare custom
+        // authorization buckets (`("approve", "Can approve posts")`).
+        // The codename is stored as `<table>.<codename>` for consistency
+        // with the CRUD codenames the loop below seeds.
+        for (codename, display) in entry.schema.extra_permissions {
+            let dialect = pool.dialect();
+            let perm_t = dialect.quote_ident("rustango_permissions");
+            let table_col = dialect.quote_ident("table_name");
+            let codename_col = dialect.quote_ident("codename");
+            let name_col = dialect.quote_ident("name");
+            let p1 = dialect.placeholder(1);
+            let p2 = dialect.placeholder(2);
+            let p3 = dialect.placeholder(3);
+            let conflict_tail = dialect.insert_on_conflict_skip(&[&table_col, &codename_col]);
+            let sql = format!(
+                "INSERT INTO {perm_t} ({table_col}, {codename_col}, {name_col}) \
+                 VALUES ({p1}, {p2}, {p3}) \
+                 {conflict_tail}"
+            );
+            let full_codename = format!("{table}.{codename}");
+            crate::sql::raw_execute_pool(
+                pool,
+                &sql,
+                vec![
+                    SqlValue::from(table.to_owned()),
+                    SqlValue::from(full_codename),
+                    SqlValue::from((*display).to_owned()),
+                ],
+            )
+            .await
+            .map_err(|e| {
+                TenancyError::Validation(format!(
+                    "auto_create_permissions_pool: INSERT for `{table}.{codename}` failed: {e}"
+                ))
+            })?;
+        }
         for (action, verb) in &action_names {
             // Hand-rolled `INSERT … ON CONFLICT (...) DO NOTHING`
             // via the dialect emitter — `rustango_permissions` isn't

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -462,6 +462,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             get_latest_by: None,
+            extra_permissions: &[],
         };
         &MS
     }

--- a/crates/rustango/tests/extra_permissions_live.rs
+++ b/crates/rustango/tests/extra_permissions_live.rs
@@ -1,0 +1,122 @@
+//! Django parity — `Meta.permissions = [(codename, name), ...]`
+//! lets a model declare custom authorization buckets alongside the
+//! auto-generated CRUD codenames. rustango spells the attribute as
+//! `#[rustango(extra_permissions = "codename:label, codename:label")]`
+//! and `auto_create_permissions_pool` seeds the
+//! `rustango_permissions` table with one row per pair.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+
+use rustango::core::Model as _;
+use rustango::sql::{sqlx, Pool};
+use rustango::tenancy::permissions::{auto_create_permissions_pool, ensure_tables_pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "xperms_post",
+    permissions,
+    extra_permissions = "approve:Can approve posts, archive:Can archive posts"
+)]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+    pub title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "xperms_plain", permissions)]
+#[allow(dead_code)]
+pub struct Plain {
+    #[rustango(primary_key)]
+    pub id: i64,
+}
+
+async fn fresh_pool() -> Pool {
+    let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    Pool::Sqlite(pool)
+}
+
+#[test]
+fn schema_carries_extra_permission_tuples() {
+    let schema = <Post as rustango::core::Model>::SCHEMA;
+    assert_eq!(
+        schema.extra_permissions,
+        &[
+            ("approve", "Can approve posts"),
+            ("archive", "Can archive posts"),
+        ]
+    );
+    let plain = <Plain as rustango::core::Model>::SCHEMA;
+    assert!(plain.extra_permissions.is_empty());
+}
+
+#[tokio::test]
+async fn auto_create_permissions_seeds_extra_codenames() {
+    let pool = fresh_pool().await;
+    ensure_tables_pool(&pool).await.unwrap();
+    auto_create_permissions_pool(&pool).await.unwrap();
+
+    // Verify the extra codenames landed under the model's table.
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!()
+    };
+    let rows: Vec<(String, String, String)> = sqlx::query_as(
+        "SELECT table_name, codename, name FROM rustango_permissions \
+         WHERE table_name = 'xperms_post' ORDER BY codename",
+    )
+    .fetch_all(sq)
+    .await
+    .unwrap();
+
+    // Per-model: 4 CRUD codenames + 2 extras = 6 rows.
+    assert_eq!(rows.len(), 6, "got: {rows:?}");
+
+    // Verify the two extras specifically.
+    let approve = rows.iter().find(|(_, c, _)| c == "xperms_post.approve");
+    let archive = rows.iter().find(|(_, c, _)| c == "xperms_post.archive");
+    assert!(approve.is_some(), "missing xperms_post.approve: {rows:?}");
+    assert!(archive.is_some(), "missing xperms_post.archive: {rows:?}");
+    assert_eq!(approve.unwrap().2, "Can approve posts");
+    assert_eq!(archive.unwrap().2, "Can archive posts");
+}
+
+#[tokio::test]
+async fn idempotent_re_seed_doesnt_duplicate_extras() {
+    let pool = fresh_pool().await;
+    ensure_tables_pool(&pool).await.unwrap();
+    auto_create_permissions_pool(&pool).await.unwrap();
+    // Second call should be a no-op via the existing ON CONFLICT DO NOTHING
+    // tail in the INSERT — both extras + CRUD codenames stay at one row each.
+    auto_create_permissions_pool(&pool).await.unwrap();
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!()
+    };
+    let count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM rustango_permissions WHERE table_name = 'xperms_post'",
+    )
+    .fetch_one(sq)
+    .await
+    .unwrap();
+    assert_eq!(count.0, 6, "double-seed must stay idempotent");
+}
+
+#[tokio::test]
+async fn plain_model_seeds_only_crud_codenames() {
+    let pool = fresh_pool().await;
+    ensure_tables_pool(&pool).await.unwrap();
+    auto_create_permissions_pool(&pool).await.unwrap();
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!()
+    };
+    let count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM rustango_permissions WHERE table_name = 'xperms_plain'",
+    )
+    .fetch_one(sq)
+    .await
+    .unwrap();
+    assert_eq!(count.0, 4, "no extra_permissions → only CRUD 4 codenames");
+}


### PR DESCRIPTION
## Summary

Django's \`Meta.permissions = [(codename, name), ...]\` lets a model declare custom authorization buckets alongside the auto-generated \`add/change/delete/view\` set. rustango previously only generated the CRUD codenames via \`auto_create_permissions_pool\`.

\`\`\`rust
#[derive(Model)]
#[rustango(
    table = "posts",
    permissions,                                              // opt-in to seeding
    extra_permissions = "approve:Can approve posts, archive:Can archive posts"
)]
pub struct Post { /* … */ }
\`\`\`

Comma-separated \`codename:label\` pairs (same shape as the existing \`choices = \"...\"\` attribute). Each entry is stored as \`(codename, display_name)\` on \`ModelSchema::extra_permissions\`.

## Seeding

\`auto_create_permissions_pool\` walks the new array right before the CRUD codename loop, inserting one row per pair into \`rustango_permissions\` with the same \`<table>.<codename>\` namespace + the existing \`INSERT … ON CONFLICT DO NOTHING\` / \`ON DUPLICATE KEY UPDATE\` idempotency. Models without the attribute seed only the CRUD codenames (byte-identical behavior).

## Test plan

- [x] 4 live tests in \`tests/extra_permissions_live.rs\`
- [x] cargo test --no-default-features --features sqlite,tenancy --lib → 1564 pass
- [x] cargo test --workspace --all-features --no-run → clean