### PR TITLE
chore(build): disable incremental compilation in dev + test profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,13 @@ pedantic = { level = "warn", priority = -1 }
 
 [profile.dev]
 opt-level = 0
+# Disable incremental compilation — the incremental cache balloons
+# the `target/` directory by ~13 GiB on this workspace (≈35% of total)
+# and we rebuild often enough that the cache rarely hits. Forces every
+# `cargo build` / `cargo test` to use the codegen-units split alone
+# for parallelism. Saves disk, costs a few % on warm rebuilds.
+incremental = false
 
 [profile.test]
 opt-level = 0
+incremental = false


### PR DESCRIPTION
## Summary

- Sets `incremental = false` on `[profile.dev]` and `[profile.test]` in the workspace `Cargo.toml`.
- The incremental cache was ~13 GiB on this workspace (≈35% of total `target/`) and the cache rarely hits on the kind of rebuilds we actually do (macro-heavy crate, many features touch shared code).
- Trades a single-digit percentage of warm-rebuild latency for a flat-disk-usage workspace. Local volume was hitting 100% capacity.

## What changed

`Cargo.toml`:

```toml
[profile.dev]
opt-level = 0
incremental = false

[profile.test]
opt-level = 0
incremental = false
```

## Test plan

- [x] `cargo build --no-default-features --features sqlite,tenancy` — green (post-clean)
- [x] `cargo test --workspace --all-features --no-run` — pre-push gate green
- [x] `cargo test -p rustango --lib --features postgres,tenancy` — 2417 / 2417 pass (via pre-push hook)
- Codegen-units split still parallelizes the build; only the per-package incremental object-cache is disabled.