### PR TITLE
feat(model): #[rustango(index_when(...))] — Django Index condition= partial-index parity

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -5225,6 +5225,72 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                 });
                 return Ok(());
             }
+            if meta.path.is_ident("index_when") {
+                // Django `Index(fields=..., condition=Q(...))` parity —
+                // non-unique partial index. Sibling of `unique_when`
+                // (which emits `CREATE UNIQUE INDEX ... WHERE ...`).
+                //
+                //   #[rustango(index_when(
+                //       columns   = "status, created_at",
+                //       condition = "deleted_at IS NULL",
+                //       name      = "active_status_created_idx"
+                //   ))]
+                //
+                // → `CREATE INDEX <name> ON <table> (cols) WHERE <condition>`
+                // on PG / SQLite (both ship partial indexes natively).
+                // MySQL has no native partial-index support — the writer
+                // emits a plain CREATE INDEX and the condition is lost;
+                // operators wanting that selectivity on MySQL should
+                // declare a covering index plus an application-level
+                // filter.
+                let mut columns: Option<Vec<String>> = None;
+                let mut condition: Option<String> = None;
+                let mut name: Option<String> = None;
+                let mut method: String = "btree".to_owned();
+                meta.parse_nested_meta(|inner| {
+                    if inner.path.is_ident("columns") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        columns = Some(split_field_list(&s.value()));
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("condition") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        condition = Some(s.value());
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("name") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        name = Some(s.value());
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("method") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        method = s.value();
+                        return Ok(());
+                    }
+                    Err(inner.error(
+                        "unknown index_when attribute (supported: \
+                         `columns = \"...\"`, `condition = \"...\"`, \
+                         `name = \"...\"`, `method = \"btree|gin|gist|...\"`)",
+                    ))
+                })?;
+                let columns = columns
+                    .ok_or_else(|| meta.error("`index_when(...)` requires `columns = \"...\"`"))?;
+                let condition = condition.ok_or_else(|| {
+                    meta.error("`index_when(...)` requires `condition = \"...\"`")
+                })?;
+                if columns.is_empty() {
+                    return Err(meta.error("`index_when(columns = \"\")` is empty"));
+                }
+                out.indexes.push(IndexAttr {
+                    name,
+                    columns,
+                    unique: false,
+                    method,
+                    where_clause: Some(condition),
+                });
+                return Ok(());
+            }
             if meta.path.is_ident("index") {
                 // Container-level composite index — legacy entry that
                 // was advertised with a trailing `, unique, name = ...`

--- a/crates/rustango/tests/index_when.rs
+++ b/crates/rustango/tests/index_when.rs
@@ -1,0 +1,119 @@
+//! Django parity — `Index(fields=[...], condition=Q(...))` partial index.
+//! rustango spells the attribute as `#[rustango(index_when(...))]` —
+//! sibling of `unique_when` which emits the UNIQUE variant.
+//!
+//! Both forms drop a `WHERE <expr>` tail on the `CREATE INDEX` so PG +
+//! SQLite skip rows that don't match the predicate. MySQL has no native
+//! partial-index support; the writer emits a plain CREATE INDEX with a
+//! tracing warning so the migration still applies.
+//!
+//! Issue #319 follow-up.
+
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "idxwhen_post",
+    // Non-unique partial index — useful when 90% of rows have the same
+    // `status = "draft"` and you only want fast lookups on the 10%
+    // published. Django shape: `Index(fields=["status"], condition=Q(deleted_at__isnull=True))`.
+    index_when(
+        columns = "status",
+        condition = "deleted_at IS NULL",
+        name = "active_status_idx",
+    ),
+    // Composite partial — multi-column + non-default method.
+    index_when(
+        columns = "tenant_id, created_at",
+        condition = "deleted_at IS NULL",
+        name = "active_tenant_created_idx",
+        method = "btree",
+    )
+)]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+    #[rustango(max_length = 16)]
+    pub status: String,
+    pub tenant_id: i64,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "idxwhen_plain")]
+#[allow(dead_code)]
+pub struct Plain {
+    #[rustango(primary_key)]
+    pub id: i64,
+    pub status: String,
+}
+
+#[test]
+fn schema_carries_partial_index_with_where_clause() {
+    let schema = <Post as rustango::core::Model>::SCHEMA;
+    let active = schema
+        .indexes
+        .iter()
+        .find(|i| i.name == "active_status_idx")
+        .expect("missing active_status_idx");
+    assert!(!active.unique, "index_when should emit a non-unique index");
+    assert_eq!(active.columns, &["status"]);
+    assert_eq!(active.where_clause, Some("deleted_at IS NULL"));
+
+    let composite = schema
+        .indexes
+        .iter()
+        .find(|i| i.name == "active_tenant_created_idx")
+        .expect("missing active_tenant_created_idx");
+    assert!(!composite.unique);
+    assert_eq!(composite.columns, &["tenant_id", "created_at"]);
+    assert_eq!(composite.where_clause, Some("deleted_at IS NULL"));
+}
+
+#[test]
+fn plain_model_has_no_partial_indexes() {
+    let plain = <Plain as rustango::core::Model>::SCHEMA;
+    assert!(plain.indexes.iter().all(|i| i.where_clause.is_none()));
+}
+
+#[test]
+fn diff_emits_create_index_with_where_clause() {
+    // End-to-end: `makemigrations`-shape diff. A fresh-table snapshot
+    // should emit `CreateIndex` ops carrying the partial WHERE clause
+    // so the migration-runner's DDL render emits the right SQL.
+    use rustango::migrate::diff::{detect_changes, SchemaChange};
+    use rustango::migrate::snapshot::SchemaSnapshot;
+
+    let schema = <Post as rustango::core::Model>::SCHEMA;
+    let prev = SchemaSnapshot {
+        tables: vec![],
+        m2m_tables: vec![],
+        indexes: vec![],
+        checks: vec![],
+        excludes: vec![],
+    };
+    let current = SchemaSnapshot::from_models(&[schema]);
+    let changes = detect_changes(&prev, &current);
+
+    let active = changes
+        .iter()
+        .find(
+            |c| matches!(c, SchemaChange::CreateIndex { name, .. } if name == "active_status_idx"),
+        )
+        .expect("missing CreateIndex for active_status_idx");
+    match active {
+        SchemaChange::CreateIndex {
+            unique,
+            where_clause,
+            columns,
+            ..
+        } => {
+            assert!(!unique, "index_when is non-unique");
+            assert_eq!(where_clause.as_deref(), Some("deleted_at IS NULL"));
+            assert_eq!(columns, &vec!["status".to_owned()]);
+        }
+        _ => unreachable!(),
+    }
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -20,7 +20,7 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 
 | Category | SHIPPED | PARTIAL | MISSING | N/A |
 |---|---:|---:|---:|---:|
-| 1. ORM — models / fields / Meta | 15 | 1 | 1 | 0 |
+| 1. ORM — models / fields / Meta | 16 | 1 | 1 | 0 |
 | 2. QuerySet API | 37 | 1 | 1 | 0 |
 | 3. Field types & options | 32 | 0 | 2 | 1 |
 | 4. Postgres-specific fields | 2 | 1 | 2 | 0 |
@@ -44,9 +44,9 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 22. Async support | 4 | 0 | 0 | 3 |
 | 23. DRF parity | 22 | 0 | 1 | 0 |
 | 24. contrib modules | 12 | 1 | 3 | 2 |
-| **Totals** | **362** | **11** | **21** | **19** |
+| **Totals** | **363** | **11** | **21** | **19** |
 
-Coverage = 362 / (362 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
+Coverage = 363 / (363 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
 
 Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, default_permissions #594, on_delete #592, ForeignKey on_delete enum override, extra_permissions #591, get_latest_by #590, db_table_comment #589, citext, DatabaseCache, managed=false, upload streaming, i18n).
 
@@ -61,6 +61,7 @@ Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, 
 | `Meta.ordering` | [Meta options#ordering](https://docs.djangoproject.com/en/6.0/ref/models/options/#ordering) | SHIPPED | `#[rustango(default_order = "-created, +status")]` per-query opt-in via `.with_default_order()` (closed #291) | Per-query opt-in by design — avoids Django's "every query pays" footgun. |
 | `Meta.unique_together` | [Meta#unique_together](https://docs.djangoproject.com/en/6.0/ref/models/options/#unique-together) | SHIPPED | `#[rustango(unique_together(...))]` (v0.19) | |
 | `Meta.index_together` | [Meta#index_together](https://docs.djangoproject.com/en/6.0/ref/models/options/#index-together) | SHIPPED | `#[rustango(index_together(...))]` (v0.19) | |
+| `Index(fields=..., condition=Q(...))` partial index | [Index](https://docs.djangoproject.com/en/6.0/ref/models/indexes/#django.db.models.Index) | SHIPPED | `#[rustango(index_when(columns = "...", condition = "...", name = "...", method = "btree"))]` (PR #599) — sibling of `unique_when`. Emits `CREATE INDEX <name> ON <table> (cols) WHERE <expr>` on PG / SQLite; MySQL emits a plain CREATE INDEX with a render-time warning (no native partial-index support). | |
 | `Meta.constraints` (CheckConstraint, UniqueConstraint, ExclusionConstraint) | [Constraints](https://docs.djangoproject.com/en/6.0/ref/models/constraints/) | SHIPPED | `#[rustango(check(name, expr))]` + `unique_when` (partial unique) + `#[rustango(exclude(name, using, elements, where))]` (PR #593, PG-only — MySQL/SQLite skip with `tracing::warn!`). | Row-level CHECK with full `Q(...)` lowering is still by-hand (write the SQL out in `expr`). |
 | `Meta.verbose_name` / `verbose_name_plural` | [Meta#verbose_name](https://docs.djangoproject.com/en/6.0/ref/models/options/#verbose-name) | SHIPPED | `#[rustango(verbose_name = "...", verbose_name_plural = "...")]` (#320, v0.42) — `ModelSchema::display_label()` + `display_label_plural()`; admin list / detail / form templates pick up the friendly captions via `model.label` / `model.label_plural` | |
 | `Meta.permissions` (custom codenames) | [Meta#permissions](https://docs.djangoproject.com/en/6.0/ref/models/options/#permissions) | SHIPPED | `auto_create_permissions_pool` seeds CRUD codenames; reserved `auth.access_admin` added in PR #313. Custom per-model codenames declared via `#[rustango(extra_permissions = "approve:Can approve, archive:Can archive")]` (PR #591). | |
@@ -74,7 +75,7 @@ Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, 
 | Self-referential FK | [Self FK](https://docs.djangoproject.com/en/6.0/ref/models/fields/#django.db.models.ForeignKey) | SHIPPED | `#[rustango(fk = "self")]` (v0.17.2) | Tested via `tests/self_fk_live.rs`. |
 | `ManyToManyField(through=...)` | [M2M through](https://docs.djangoproject.com/en/6.0/topics/db/models/#extra-fields-on-many-to-many-relationships) | SHIPPED | `#[rustango(m2m(... auto_create = false))]` (closed #324, v0.42). Operator declares the junction as its own `#[derive(Model)]` with extra columns; the migration writer skips emitting `CREATE TABLE` for that junction when `auto_create = false` (otherwise the through-model's own table would conflict). Implicit-junction path with `auto_create = true` (default) unchanged. | |
 
-Summary: **15 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-base field-inheritance (Rust idiom = trait composition; `#[rustango(managed = false)]` covers the operator-managed-table case via #321), MTI. ExclusionConstraint shipped in PR #593; `Meta.default_permissions` shipped in PR #594; `ForeignKey(on_delete=…)` explicit override shipped in PR #592.
+Summary: **16 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-base field-inheritance (Rust idiom = trait composition; `#[rustango(managed = false)]` covers the operator-managed-table case via #321), MTI. ExclusionConstraint shipped in PR #593; `Meta.default_permissions` shipped in PR #594; `ForeignKey(on_delete=…)` explicit override shipped in PR #592.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds Django-shape `Index(fields=[...], condition=Q(...))` parity. The attribute spells as `#[rustango(index_when(columns = "...", condition = "...", name = "...", method = "btree"))]` on the model container — sibling of `unique_when` which emits the UNIQUE variant.

The underlying `IndexSchema::where_clause` field + DDL writer's WHERE-suffix branch were already in tree (shipped for `unique_when` in #265); this PR wires the non-unique entry point.

## Render shape

- **PG + SQLite**: `CREATE INDEX <name> ON <table> (cols) WHERE <expr>` — both backends ship native partial-index support.
- **MySQL**: plain `CREATE INDEX` with the condition dropped; the diff render emits a `tracing::warn!` so the migration still applies. Operators wanting that selectivity on MySQL should declare a covering index plus an application-level filter.

## Test plan

- [x] `cargo test --features postgres,tenancy --test index_when` — 3 / 3 pass locally
- [x] `cargo build --no-default-features --features sqlite,tenancy` — multi-tenant sqlite litmus green
- Closes the audit gap: "`Index(fields=..., condition=Q(...))` partial index" — was only available via `unique_when` (which forces UNIQUE)