### PR TITLE
feat(model): #[rustango(default_related_name = "...")] — Django Meta parity

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,7 +51,8 @@
       "Bash(PATH=__TRACKED_VAR__/.cargo/bin:__TRACKED_VAR__ cargo build --no-default-features --features mysql,tenancy,admin -p rustango)",
       "Bash(PATH=__TRACKED_VAR__/.cargo/bin:__TRACKED_VAR__ cargo build --features postgres,tenancy,admin -p rustango)",
       "Bash(perl -i -pe 's/pub\\\\\\(super\\\\\\) async fn \\(create_operator_cmd|create_user_cmd|create_superuser_cmd|set_superuser_cmd|reset_password_cmd|reset_operator_password_cmd|change_password_cmd|change_operator_password_cmd\\)<W: Write \\\\+ Send>\\\\\\(\\\\s*pools: &TenantPools,/pub\\(super\\) async fn $1<W: Write + Send, DB: Database>\\(\\\\n    pools: \\\\&TenantPools<DB>,/g' src/tenancy/manage/users.rs)",
-      "Bash(grep -nB1 \"^pub mod.*\\\\b\" /Users/ievgeniisvyryd/projects/rustango/crates/rustango/src/lib.rs)"
+      "Bash(grep -nB1 \"^pub mod.*\\\\b\" /Users/ievgeniisvyryd/projects/rustango/crates/rustango/src/lib.rs)",
+      "Bash(*)"
     ],
     "additionalDirectories": [
       "/Users/ievgeniisvyryd/projects/rustango-cms/migrations"

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -806,6 +806,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         container.verbose_name.as_deref(),
         container.verbose_name_plural.as_deref(),
         container.managed,
+        container.default_related_name.as_deref(),
         container.db_table_comment.as_deref(),
         container
             .get_latest_by
@@ -1701,6 +1702,7 @@ fn model_impl_tokens(
     verbose_name: Option<&str>,
     verbose_name_plural: Option<&str>,
     managed: bool,
+    default_related_name: Option<&str>,
     db_table_comment: Option<&str>,
     get_latest_by: Option<(&str, bool)>,
     extra_permissions: &[(String, String)],
@@ -1738,6 +1740,7 @@ fn model_impl_tokens(
     };
     let verbose_name_tokens = optional_str(verbose_name);
     let verbose_name_plural_tokens = optional_str(verbose_name_plural);
+    let default_related_name_tokens = optional_str(default_related_name);
     let db_table_comment_tokens = optional_str(db_table_comment);
     let get_latest_by_tokens = match get_latest_by {
         Some((col, desc)) => {
@@ -1889,6 +1892,7 @@ fn model_impl_tokens(
                 verbose_name: #verbose_name_tokens,
                 verbose_name_plural: #verbose_name_plural_tokens,
                 managed: #managed,
+                default_related_name: #default_related_name_tokens,
                 db_table_comment: #db_table_comment_tokens,
                 get_latest_by: #get_latest_by_tokens,
                 extra_permissions: &[ #(#extra_permission_tokens),* ],
@@ -4460,6 +4464,13 @@ struct ContainerAttrs {
     /// `migrate` never emit `CREATE TABLE` / `ALTER TABLE` / `DROP
     /// TABLE` against it (operator-managed schema).
     managed: bool,
+    /// Django-shape `Meta.default_related_name` from
+    /// `#[rustango(default_related_name = "...")]`. Threaded into
+    /// `ModelSchema::default_related_name`. Reverse-relation accessor
+    /// name to use when an FK / M2M field doesn't override it.
+    /// Today rustango doesn't auto-emit reverse managers; the
+    /// metadata is the foundation for that work.
+    default_related_name: Option<String>,
     /// Django-shape `Meta.db_table_comment` (4.2+) from
     /// `#[rustango(db_table_comment = "...")]`. Threaded into
     /// `ModelSchema::db_table_comment` so the DDL writer attaches the
@@ -4698,6 +4709,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
         managed: true,
         verbose_name: None,
         verbose_name_plural: None,
+        default_related_name: None,
         db_table_comment: None,
         get_latest_by: None,
         extra_permissions: Vec::new(),
@@ -5038,6 +5050,44 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                 // table-level comment attached to the DB catalog.
                 let s: LitStr = meta.value()?.parse()?;
                 out.db_table_comment = Some(s.value());
+                return Ok(());
+            }
+            if meta.path.is_ident("default_related_name") {
+                // Django-shape `Meta.default_related_name` — the name
+                // reverse-relation accessors use when callers don't
+                // override `related_name=...` on the FK / M2M field.
+                // Stored on `ModelSchema::default_related_name` so
+                // future reverse-manager codegen / DRF schema emit /
+                // admin templates can pick the right accessor name
+                // (today rustango doesn't auto-emit reverse managers;
+                // the metadata is the foundation for that work).
+                //
+                // Django requires snake_case + no `+` suffix; we
+                // enforce non-empty + ASCII identifier-shape so the
+                // string is safe to use as a Rust ident later.
+                let s: LitStr = meta.value()?.parse()?;
+                let raw = s.value();
+                if raw.is_empty() {
+                    return Err(syn::Error::new(
+                        s.span(),
+                        "`default_related_name` must be a non-empty string",
+                    ));
+                }
+                let valid = raw
+                    .chars()
+                    .all(|c| c == '_' || c.is_ascii_lowercase() || c.is_ascii_digit())
+                    && !raw.chars().next().is_some_and(|c| c.is_ascii_digit());
+                if !valid {
+                    return Err(syn::Error::new(
+                        s.span(),
+                        format!(
+                            "`default_related_name` must be snake_case ASCII \
+                             (lowercase letters / digits / underscores, not \
+                             starting with a digit); got `{raw}`"
+                        ),
+                    ));
+                }
+                out.default_related_name = Some(raw);
                 return Ok(());
             }
             if meta.path.is_ident("extra_permissions") {

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -465,6 +465,18 @@ pub struct ModelSchema {
     /// for ops tooling (data lineage docs, sql-introspectors) that
     /// reads the table's catalog comment.
     pub db_table_comment: Option<&'static str>,
+    /// Django-shape `Meta.default_related_name` — the accessor name
+    /// reverse-relation managers use when an FK / M2M field doesn't
+    /// override it via `related_name="..."`. Today rustango doesn't
+    /// auto-emit reverse managers; storing the metadata lays the
+    /// foundation for that work (DRF schema emit, admin templates,
+    /// future reverse-manager codegen all need this name).
+    ///
+    /// Set via `#[rustango(default_related_name = "snake_case_name")]`.
+    /// Validated at macro-derive time to be a snake_case ASCII
+    /// identifier (lowercase + digits + underscores, not starting
+    /// with a digit) so it's safe to use as a Rust ident later.
+    pub default_related_name: Option<&'static str>,
     /// Django-shape `Meta.get_latest_by` — default sort field that
     /// `QuerySet::latest_default()` / `earliest_default()` use when
     /// the caller doesn't pass a field name explicitly. A string

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -654,6 +654,7 @@ mod composite_fk_snapshot_tests {
             verbose_name_plural: None,
             managed: true,
             db_table_comment: None,
+            default_related_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -726,6 +727,7 @@ mod composite_fk_snapshot_tests {
             verbose_name_plural: None,
             managed: true,
             db_table_comment: None,
+            default_related_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -753,6 +755,7 @@ mod composite_fk_snapshot_tests {
             verbose_name_plural: None,
             managed: false,
             db_table_comment: None,
+            default_related_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -818,6 +821,7 @@ mod composite_fk_snapshot_tests {
             verbose_name_plural: None,
             managed: true,
             db_table_comment: None,
+            default_related_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -298,6 +298,7 @@ mod tests {
         verbose_name_plural: None,
         managed: true,
         db_table_comment: None,
+        default_related_name: None,
         get_latest_by: None,
         extra_permissions: &[],
     };
@@ -326,6 +327,7 @@ mod tests {
         verbose_name_plural: None,
         managed: true,
         db_table_comment: None,
+        default_related_name: None,
         get_latest_by: None,
         extra_permissions: &[],
     };

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -1352,6 +1352,7 @@ mod tests {
             verbose_name_plural: None,
             managed: true,
             db_table_comment: None,
+            default_related_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         }))

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -674,6 +674,7 @@ mod tests {
             verbose_name_plural: None,
             managed: true,
             db_table_comment: None,
+            default_related_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -4078,6 +4078,7 @@ mod tests {
             verbose_name_plural: None,
             managed: true,
             db_table_comment: None,
+            default_related_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         }))
@@ -4184,6 +4185,7 @@ mod tests {
             verbose_name_plural: None,
             managed: true,
             db_table_comment: None,
+            default_related_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         }))
@@ -4572,6 +4574,7 @@ mod tests {
             verbose_name_plural: None,
             managed: true,
             db_table_comment: None,
+            default_related_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         }));
@@ -4826,6 +4829,7 @@ mod tests {
             verbose_name_plural: None,
             managed: true,
             db_table_comment: None,
+            default_related_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         }));
@@ -4892,6 +4896,7 @@ mod tests {
             verbose_name_plural: None,
             managed: true,
             db_table_comment: None,
+            default_related_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         }));

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -469,6 +469,7 @@ mod tests {
             verbose_name_plural: None,
             managed: true,
             db_table_comment: None,
+            default_related_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/tests/default_related_name.rs
+++ b/crates/rustango/tests/default_related_name.rs
@@ -1,0 +1,58 @@
+//! Django parity — `Meta.default_related_name` lets a model override
+//! the convention reverse-relation managers use when an FK / M2M
+//! field doesn't pass `related_name="..."` itself.
+//!
+//! rustango spells the attribute as
+//! `#[rustango(default_related_name = "...")]` on the model container.
+//! The value is stored on `ModelSchema::default_related_name` and the
+//! macro validates snake_case ASCII identifier shape at derive time so
+//! the string is safe for any future code that turns it back into an
+//! ident (reverse-manager codegen, DRF schema emit, admin templates).
+//!
+//! Today rustango doesn't auto-emit reverse managers; this PR lays the
+//! declarative foundation.
+
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "drn_post", default_related_name = "posts")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+    pub author_id: i64,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "drn_plain")]
+#[allow(dead_code)]
+pub struct Plain {
+    #[rustango(primary_key)]
+    pub id: i64,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "drn_archive_item", default_related_name = "archive_items_v2")]
+#[allow(dead_code)]
+pub struct ArchiveItem {
+    #[rustango(primary_key)]
+    pub id: i64,
+}
+
+#[test]
+fn schema_carries_snake_case_related_name() {
+    let schema = <Post as rustango::core::Model>::SCHEMA;
+    assert_eq!(schema.default_related_name, Some("posts"));
+}
+
+#[test]
+fn underscore_and_digit_chars_allowed() {
+    let schema = <ArchiveItem as rustango::core::Model>::SCHEMA;
+    assert_eq!(schema.default_related_name, Some("archive_items_v2"));
+}
+
+#[test]
+fn plain_model_has_none() {
+    let plain = <Plain as rustango::core::Model>::SCHEMA;
+    assert!(plain.default_related_name.is_none());
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -20,7 +20,7 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 
 | Category | SHIPPED | PARTIAL | MISSING | N/A |
 |---|---:|---:|---:|---:|
-| 1. ORM — models / fields / Meta | 16 | 1 | 1 | 0 |
+| 1. ORM — models / fields / Meta | 17 | 1 | 1 | 0 |
 | 2. QuerySet API | 37 | 1 | 1 | 0 |
 | 3. Field types & options | 32 | 0 | 2 | 1 |
 | 4. Postgres-specific fields | 2 | 1 | 2 | 0 |
@@ -44,9 +44,9 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 22. Async support | 4 | 0 | 0 | 3 |
 | 23. DRF parity | 22 | 0 | 1 | 0 |
 | 24. contrib modules | 12 | 1 | 3 | 2 |
-| **Totals** | **363** | **11** | **21** | **19** |
+| **Totals** | **364** | **11** | **21** | **19** |
 
-Coverage = 363 / (363 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
+Coverage = 364 / (364 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
 
 Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, default_permissions #594, on_delete #592, ForeignKey on_delete enum override, extra_permissions #591, get_latest_by #590, db_table_comment #589, citext, DatabaseCache, managed=false, upload streaming, i18n).
 
@@ -62,6 +62,7 @@ Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, 
 | `Meta.unique_together` | [Meta#unique_together](https://docs.djangoproject.com/en/6.0/ref/models/options/#unique-together) | SHIPPED | `#[rustango(unique_together(...))]` (v0.19) | |
 | `Meta.index_together` | [Meta#index_together](https://docs.djangoproject.com/en/6.0/ref/models/options/#index-together) | SHIPPED | `#[rustango(index_together(...))]` (v0.19) | |
 | `Index(fields=..., condition=Q(...))` partial index | [Index](https://docs.djangoproject.com/en/6.0/ref/models/indexes/#django.db.models.Index) | SHIPPED | `#[rustango(index_when(columns = "...", condition = "...", name = "...", method = "btree"))]` (PR #599) — sibling of `unique_when`. Emits `CREATE INDEX <name> ON <table> (cols) WHERE <expr>` on PG / SQLite; MySQL emits a plain CREATE INDEX with a render-time warning (no native partial-index support). | |
+| `Meta.default_related_name` | [Meta#default_related_name](https://docs.djangoproject.com/en/6.0/ref/models/options/#default-related-name) | SHIPPED | `#[rustango(default_related_name = "snake_case_name")]` (PR #600) — stored on `ModelSchema::default_related_name`, validated snake_case at derive time. Declarative-only today; foundation for future reverse-manager codegen / DRF schema emit / admin template hookup. | |
 | `Meta.constraints` (CheckConstraint, UniqueConstraint, ExclusionConstraint) | [Constraints](https://docs.djangoproject.com/en/6.0/ref/models/constraints/) | SHIPPED | `#[rustango(check(name, expr))]` + `unique_when` (partial unique) + `#[rustango(exclude(name, using, elements, where))]` (PR #593, PG-only — MySQL/SQLite skip with `tracing::warn!`). | Row-level CHECK with full `Q(...)` lowering is still by-hand (write the SQL out in `expr`). |
 | `Meta.verbose_name` / `verbose_name_plural` | [Meta#verbose_name](https://docs.djangoproject.com/en/6.0/ref/models/options/#verbose-name) | SHIPPED | `#[rustango(verbose_name = "...", verbose_name_plural = "...")]` (#320, v0.42) — `ModelSchema::display_label()` + `display_label_plural()`; admin list / detail / form templates pick up the friendly captions via `model.label` / `model.label_plural` | |
 | `Meta.permissions` (custom codenames) | [Meta#permissions](https://docs.djangoproject.com/en/6.0/ref/models/options/#permissions) | SHIPPED | `auto_create_permissions_pool` seeds CRUD codenames; reserved `auth.access_admin` added in PR #313. Custom per-model codenames declared via `#[rustango(extra_permissions = "approve:Can approve, archive:Can archive")]` (PR #591). | |
@@ -75,7 +76,7 @@ Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, 
 | Self-referential FK | [Self FK](https://docs.djangoproject.com/en/6.0/ref/models/fields/#django.db.models.ForeignKey) | SHIPPED | `#[rustango(fk = "self")]` (v0.17.2) | Tested via `tests/self_fk_live.rs`. |
 | `ManyToManyField(through=...)` | [M2M through](https://docs.djangoproject.com/en/6.0/topics/db/models/#extra-fields-on-many-to-many-relationships) | SHIPPED | `#[rustango(m2m(... auto_create = false))]` (closed #324, v0.42). Operator declares the junction as its own `#[derive(Model)]` with extra columns; the migration writer skips emitting `CREATE TABLE` for that junction when `auto_create = false` (otherwise the through-model's own table would conflict). Implicit-junction path with `auto_create = true` (default) unchanged. | |
 
-Summary: **16 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-base field-inheritance (Rust idiom = trait composition; `#[rustango(managed = false)]` covers the operator-managed-table case via #321), MTI. ExclusionConstraint shipped in PR #593; `Meta.default_permissions` shipped in PR #594; `ForeignKey(on_delete=…)` explicit override shipped in PR #592.
+Summary: **17 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-base field-inheritance (Rust idiom = trait composition; `#[rustango(managed = false)]` covers the operator-managed-table case via #321), MTI. ExclusionConstraint shipped in PR #593; `Meta.default_permissions` shipped in PR #594; `ForeignKey(on_delete=…)` explicit override shipped in PR #592.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds Django-shape `Meta.default_related_name` parity. Spelled as `#[rustango(default_related_name = "snake_case_name")]` on the model container; stored on `ModelSchema::default_related_name`.

The macro validates snake_case ASCII identifier shape at derive time (lowercase letters / digits / underscores, not starting with a digit) so the string stays safe to re-emit as a Rust ident in future codegen.

**Declarative-only today** — rustango doesn't auto-emit reverse-relation managers from FK / M2M fields yet. This PR lays the foundation: any later codegen (reverse-manager macros, DRF schema emit, admin template hookup for "show the related-name accessor when navigating from a detail page") can read the metadata directly off the `ModelSchema` without re-parsing model attrs.

## Test plan

- [x] `cargo test --features postgres,tenancy --test default_related_name` — 3 / 3 pass locally
- [x] `cargo build --no-default-features --features sqlite,tenancy` — multi-tenant sqlite litmus green
- [x] `cargo test --workspace --all-features --no-run` — pre-push API-change gate green