### PR TITLE
feat(model): #[rustango(base_manager_name = "...")] — Django Meta parity

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -806,6 +806,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         container.verbose_name.as_deref(),
         container.verbose_name_plural.as_deref(),
         container.managed,
+        container.base_manager_name.as_deref(),
         container.default_related_name.as_deref(),
         container.db_table_comment.as_deref(),
         container
@@ -1702,6 +1703,7 @@ fn model_impl_tokens(
     verbose_name: Option<&str>,
     verbose_name_plural: Option<&str>,
     managed: bool,
+    base_manager_name: Option<&str>,
     default_related_name: Option<&str>,
     db_table_comment: Option<&str>,
     get_latest_by: Option<(&str, bool)>,
@@ -1740,6 +1742,7 @@ fn model_impl_tokens(
     };
     let verbose_name_tokens = optional_str(verbose_name);
     let verbose_name_plural_tokens = optional_str(verbose_name_plural);
+    let base_manager_name_tokens = optional_str(base_manager_name);
     let default_related_name_tokens = optional_str(default_related_name);
     let db_table_comment_tokens = optional_str(db_table_comment);
     let get_latest_by_tokens = match get_latest_by {
@@ -1892,6 +1895,7 @@ fn model_impl_tokens(
                 verbose_name: #verbose_name_tokens,
                 verbose_name_plural: #verbose_name_plural_tokens,
                 managed: #managed,
+                base_manager_name: #base_manager_name_tokens,
                 default_related_name: #default_related_name_tokens,
                 db_table_comment: #db_table_comment_tokens,
                 get_latest_by: #get_latest_by_tokens,
@@ -4464,6 +4468,10 @@ struct ContainerAttrs {
     /// `migrate` never emit `CREATE TABLE` / `ALTER TABLE` / `DROP
     /// TABLE` against it (operator-managed schema).
     managed: bool,
+    /// Django-shape `Meta.base_manager_name` from
+    /// `#[rustango(base_manager_name = "...")]`. Threaded into
+    /// `ModelSchema::base_manager_name`. Declarative-only today.
+    base_manager_name: Option<String>,
     /// Django-shape `Meta.default_related_name` from
     /// `#[rustango(default_related_name = "...")]`. Threaded into
     /// `ModelSchema::default_related_name`. Reverse-relation accessor
@@ -4709,6 +4717,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
         managed: true,
         verbose_name: None,
         verbose_name_plural: None,
+        base_manager_name: None,
         default_related_name: None,
         db_table_comment: None,
         get_latest_by: None,
@@ -5050,6 +5059,41 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                 // table-level comment attached to the DB catalog.
                 let s: LitStr = meta.value()?.parse()?;
                 out.db_table_comment = Some(s.value());
+                return Ok(());
+            }
+            if meta.path.is_ident("base_manager_name") {
+                // Django-shape `Meta.base_manager_name` — name of the
+                // Manager subclass that `<instance>.<relation>_set`
+                // uses when resolving reverse-relation managers.
+                // Distinct from `default_manager_name` (what
+                // `Model.objects` returns at the class level).
+                // Stored on `ModelSchema::base_manager_name`.
+                //
+                // Validated as a Rust identifier so it stays safe to
+                // re-emit as code in future reverse-manager codegen.
+                let s: LitStr = meta.value()?.parse()?;
+                let raw = s.value();
+                if raw.is_empty() {
+                    return Err(syn::Error::new(
+                        s.span(),
+                        "`base_manager_name` must be a non-empty string",
+                    ));
+                }
+                let valid = raw
+                    .chars()
+                    .all(|c| c == '_' || c.is_ascii_alphanumeric())
+                    && !raw.chars().next().is_some_and(|c| c.is_ascii_digit());
+                if !valid {
+                    return Err(syn::Error::new(
+                        s.span(),
+                        format!(
+                            "`base_manager_name` must be a valid Rust \
+                             identifier (letters / digits / underscores, \
+                             not starting with a digit); got `{raw}`"
+                        ),
+                    ));
+                }
+                out.base_manager_name = Some(raw);
                 return Ok(());
             }
             if meta.path.is_ident("default_related_name") {

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -477,6 +477,16 @@ pub struct ModelSchema {
     /// identifier (lowercase + digits + underscores, not starting
     /// with a digit) so it's safe to use as a Rust ident later.
     pub default_related_name: Option<&'static str>,
+    /// Django-shape `Meta.base_manager_name` — name of the Manager
+    /// subclass that `<instance>.<relation>_set` uses when resolving
+    /// reverse-relation managers (distinct from
+    /// `default_manager_name`, which is what `Model.objects` returns
+    /// at the class level).
+    ///
+    /// Set via `#[rustango(base_manager_name = "ManagerExt")]`.
+    /// Declarative-only today: rustango doesn't auto-emit reverse
+    /// managers yet — parallel to `default_related_name`.
+    pub base_manager_name: Option<&'static str>,
     /// Django-shape `Meta.get_latest_by` — default sort field that
     /// `QuerySet::latest_default()` / `earliest_default()` use when
     /// the caller doesn't pass a field name explicitly. A string

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -655,6 +655,7 @@ mod composite_fk_snapshot_tests {
             managed: true,
             db_table_comment: None,
             default_related_name: None,
+            base_manager_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -728,6 +729,7 @@ mod composite_fk_snapshot_tests {
             managed: true,
             db_table_comment: None,
             default_related_name: None,
+            base_manager_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -756,6 +758,7 @@ mod composite_fk_snapshot_tests {
             managed: false,
             db_table_comment: None,
             default_related_name: None,
+            base_manager_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -822,6 +825,7 @@ mod composite_fk_snapshot_tests {
             managed: true,
             db_table_comment: None,
             default_related_name: None,
+            base_manager_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -299,6 +299,7 @@ mod tests {
         managed: true,
         db_table_comment: None,
         default_related_name: None,
+        base_manager_name: None,
         get_latest_by: None,
         extra_permissions: &[],
     };
@@ -328,6 +329,7 @@ mod tests {
         managed: true,
         db_table_comment: None,
         default_related_name: None,
+        base_manager_name: None,
         get_latest_by: None,
         extra_permissions: &[],
     };

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -1353,6 +1353,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             default_related_name: None,
+            base_manager_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         }))

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -675,6 +675,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             default_related_name: None,
+            base_manager_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -4079,6 +4079,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             default_related_name: None,
+            base_manager_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         }))
@@ -4186,6 +4187,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             default_related_name: None,
+            base_manager_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         }))
@@ -4575,6 +4577,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             default_related_name: None,
+            base_manager_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         }));
@@ -4830,6 +4833,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             default_related_name: None,
+            base_manager_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         }));
@@ -4897,6 +4901,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             default_related_name: None,
+            base_manager_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         }));

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -470,6 +470,7 @@ mod tests {
             managed: true,
             db_table_comment: None,
             default_related_name: None,
+            base_manager_name: None,
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/tests/base_manager_name.rs
+++ b/crates/rustango/tests/base_manager_name.rs
@@ -1,0 +1,40 @@
+//! Django parity — `Meta.base_manager_name` names the Manager
+//! subclass that `<instance>.<relation>_set` uses when resolving
+//! reverse-relation managers (distinct from `default_manager_name`,
+//! which is what `Model.objects` returns at the class level).
+//!
+//! rustango spells the attribute as
+//! `#[rustango(base_manager_name = "...")]` on the model container.
+//! Stored on `ModelSchema::base_manager_name`. Declarative-only today;
+//! future reverse-manager codegen + DRF schema emit read the
+//! metadata directly off the schema.
+
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "bmn_post", base_manager_name = "PostManagerExt")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "bmn_plain")]
+#[allow(dead_code)]
+pub struct Plain {
+    #[rustango(primary_key)]
+    pub id: i64,
+}
+
+#[test]
+fn schema_carries_base_manager_name() {
+    let schema = <Post as rustango::core::Model>::SCHEMA;
+    assert_eq!(schema.base_manager_name, Some("PostManagerExt"));
+}
+
+#[test]
+fn plain_model_has_none() {
+    let plain = <Plain as rustango::core::Model>::SCHEMA;
+    assert!(plain.base_manager_name.is_none());
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -20,7 +20,7 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 
 | Category | SHIPPED | PARTIAL | MISSING | N/A |
 |---|---:|---:|---:|---:|
-| 1. ORM — models / fields / Meta | 17 | 1 | 1 | 0 |
+| 1. ORM — models / fields / Meta | 18 | 1 | 1 | 0 |
 | 2. QuerySet API | 37 | 1 | 1 | 0 |
 | 3. Field types & options | 32 | 0 | 2 | 1 |
 | 4. Postgres-specific fields | 2 | 1 | 2 | 0 |
@@ -44,9 +44,9 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 22. Async support | 4 | 0 | 0 | 3 |
 | 23. DRF parity | 22 | 0 | 1 | 0 |
 | 24. contrib modules | 12 | 1 | 3 | 2 |
-| **Totals** | **364** | **11** | **21** | **19** |
+| **Totals** | **365** | **11** | **21** | **19** |
 
-Coverage = 364 / (364 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
+Coverage = 365 / (365 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
 
 Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, default_permissions #594, on_delete #592, ForeignKey on_delete enum override, extra_permissions #591, get_latest_by #590, db_table_comment #589, citext, DatabaseCache, managed=false, upload streaming, i18n).
 
@@ -68,6 +68,7 @@ Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, 
 | `Meta.permissions` (custom codenames) | [Meta#permissions](https://docs.djangoproject.com/en/6.0/ref/models/options/#permissions) | SHIPPED | `auto_create_permissions_pool` seeds CRUD codenames; reserved `auth.access_admin` added in PR #313. Custom per-model codenames declared via `#[rustango(extra_permissions = "approve:Can approve, archive:Can archive")]` (PR #591). | |
 | `Meta.default_permissions` | [Meta#default_permissions](https://docs.djangoproject.com/en/6.0/ref/models/options/#default-permissions) | SHIPPED | `#[rustango(default_permissions = "view,change")]` (PR #594) — opt out of `add` / `delete` codenames for read-mostly tables; empty (default) seeds all four CRUD codenames | |
 | `Meta.default_manager_name` | [Custom Managers](https://docs.djangoproject.com/en/6.0/topics/db/managers/) | SHIPPED | `#[rustango(manager_fn = "active")]` (closed #289 / T2.6) | Multiple `manager_fn` allowed. |
+| `Meta.base_manager_name` | [Meta#base_manager_name](https://docs.djangoproject.com/en/6.0/ref/models/options/#base-manager-name) | SHIPPED | `#[rustango(base_manager_name = "ManagerExt")]` — stored on `ModelSchema::base_manager_name`. Declarative-only today; foundation for reverse-manager codegen + DRF schema emit + admin templates that need to pick the right Manager subclass for `<instance>.<relation>_set` resolution. | |
 | Custom `Manager` subclass | [Custom Managers](https://docs.djangoproject.com/en/6.0/topics/db/managers/) | SHIPPED | `#[rustango(manager(ext = "FooManagerExt"))]` emits an extension trait the user impls on `QuerySet<Self>` (T1.9) | |
 | Abstract base classes | [Abstract base](https://docs.djangoproject.com/en/6.0/topics/db/models/#abstract-base-classes) | PARTIAL | `#[rustango(managed = false)]` opts a model out of migration auto-gen (operator-managed schema, #321). Field-inheritance via Rust trait composition is the idiom; no derive-macro shorthand yet for "mix in these timestamp fields". | |
 | Multi-table inheritance | [MTI](https://docs.djangoproject.com/en/6.0/topics/db/models/#multi-table-inheritance) | MISSING | n/a (#322) | rustango-cms uses MTI for PageType (custom impl); framework doesn't auto-generate it. |
@@ -76,7 +77,7 @@ Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, 
 | Self-referential FK | [Self FK](https://docs.djangoproject.com/en/6.0/ref/models/fields/#django.db.models.ForeignKey) | SHIPPED | `#[rustango(fk = "self")]` (v0.17.2) | Tested via `tests/self_fk_live.rs`. |
 | `ManyToManyField(through=...)` | [M2M through](https://docs.djangoproject.com/en/6.0/topics/db/models/#extra-fields-on-many-to-many-relationships) | SHIPPED | `#[rustango(m2m(... auto_create = false))]` (closed #324, v0.42). Operator declares the junction as its own `#[derive(Model)]` with extra columns; the migration writer skips emitting `CREATE TABLE` for that junction when `auto_create = false` (otherwise the through-model's own table would conflict). Implicit-junction path with `auto_create = true` (default) unchanged. | |
 
-Summary: **17 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-base field-inheritance (Rust idiom = trait composition; `#[rustango(managed = false)]` covers the operator-managed-table case via #321), MTI. ExclusionConstraint shipped in PR #593; `Meta.default_permissions` shipped in PR #594; `ForeignKey(on_delete=…)` explicit override shipped in PR #592.
+Summary: **18 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-base field-inheritance (Rust idiom = trait composition; `#[rustango(managed = false)]` covers the operator-managed-table case via #321), MTI. ExclusionConstraint shipped in PR #593; `Meta.default_permissions` shipped in PR #594; `ForeignKey(on_delete=…)` explicit override shipped in PR #592.
 
 ---
 


### PR DESCRIPTION
## Summary

Stores Django-shape `Meta.base_manager_name` on `ModelSchema`. Spelled as `#[rustango(base_manager_name = "ManagerExt")]`; validated Rust-identifier shape at derive time.

Distinct role from `default_manager_name` (shipped via `manager_fn`): `base_manager_name` is the Manager subclass for `<instance>.<relation>_set` reverse-relation resolution, while `default_manager_name` is what `Model.objects` returns at the class level.

Declarative-only today — rustango doesn't auto-emit reverse-relation managers yet. Parallel to PR #600's `default_related_name`; both lay the foundation for the same future codegen.

## Test plan

- [x] `cargo test --features postgres,tenancy --test base_manager_name` — 2 / 2 pass locally
- [x] `cargo test --workspace --all-features --no-run` — pre-push gate green
- [x] `cargo build --no-default-features --features sqlite,tenancy` — litmus green

Stacks naturally with #600 (`default_related_name`).