### PR TITLE
feat(model): #[rustango(required_db_vendor = "...")] — Django Meta parity

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -807,6 +807,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         container.verbose_name_plural.as_deref(),
         container.managed,
         container.base_manager_name.as_deref(),
+        container.required_db_vendor.as_deref(),
         container.default_related_name.as_deref(),
         container.db_table_comment.as_deref(),
         container
@@ -1704,6 +1705,7 @@ fn model_impl_tokens(
     verbose_name_plural: Option<&str>,
     managed: bool,
     base_manager_name: Option<&str>,
+    required_db_vendor: Option<&str>,
     default_related_name: Option<&str>,
     db_table_comment: Option<&str>,
     get_latest_by: Option<(&str, bool)>,
@@ -1743,6 +1745,7 @@ fn model_impl_tokens(
     let verbose_name_tokens = optional_str(verbose_name);
     let verbose_name_plural_tokens = optional_str(verbose_name_plural);
     let base_manager_name_tokens = optional_str(base_manager_name);
+    let required_db_vendor_tokens = optional_str(required_db_vendor);
     let default_related_name_tokens = optional_str(default_related_name);
     let db_table_comment_tokens = optional_str(db_table_comment);
     let get_latest_by_tokens = match get_latest_by {
@@ -1896,6 +1899,7 @@ fn model_impl_tokens(
                 verbose_name_plural: #verbose_name_plural_tokens,
                 managed: #managed,
                 base_manager_name: #base_manager_name_tokens,
+                required_db_vendor: #required_db_vendor_tokens,
                 default_related_name: #default_related_name_tokens,
                 db_table_comment: #db_table_comment_tokens,
                 get_latest_by: #get_latest_by_tokens,
@@ -4472,6 +4476,13 @@ struct ContainerAttrs {
     /// `#[rustango(base_manager_name = "...")]`. Threaded into
     /// `ModelSchema::base_manager_name`. Declarative-only today.
     base_manager_name: Option<String>,
+    /// Django-shape `Meta.required_db_vendor` from
+    /// `#[rustango(required_db_vendor = "postgres|mysql|sqlite")]`.
+    /// Normalized to the dialect name `manage check --deploy`
+    /// compares against `Settings.database.backend`. Aliases
+    /// (`postgresql` / `pg` / `mariadb` / `sqlite3`) accepted but
+    /// stored under the canonical name.
+    required_db_vendor: Option<String>,
     /// Django-shape `Meta.default_related_name` from
     /// `#[rustango(default_related_name = "...")]`. Threaded into
     /// `ModelSchema::default_related_name`. Reverse-relation accessor
@@ -4718,6 +4729,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
         verbose_name: None,
         verbose_name_plural: None,
         base_manager_name: None,
+        required_db_vendor: None,
         default_related_name: None,
         db_table_comment: None,
         get_latest_by: None,
@@ -5059,6 +5071,42 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                 // table-level comment attached to the DB catalog.
                 let s: LitStr = meta.value()?.parse()?;
                 out.db_table_comment = Some(s.value());
+                return Ok(());
+            }
+            if meta.path.is_ident("required_db_vendor") {
+                // Django-shape `Meta.required_db_vendor` — the model
+                // is only meant to run against the named DB backend.
+                // `manage check --deploy` flags a mismatch so
+                // ops catches "I forgot to switch DATABASE_URL" at
+                // deploy time rather than runtime.
+                //
+                // Django spells it as a free-form string; rustango
+                // restricts to the three backends it ships dialects
+                // for so the check verb can compare reliably.
+                let s: LitStr = meta.value()?.parse()?;
+                let raw = s.value().to_ascii_lowercase();
+                match raw.as_str() {
+                    "postgresql" | "postgres" | "pg" => {
+                        out.required_db_vendor = Some("postgres".to_owned());
+                    }
+                    "mysql" | "mariadb" => {
+                        out.required_db_vendor = Some("mysql".to_owned());
+                    }
+                    "sqlite" | "sqlite3" => {
+                        out.required_db_vendor = Some("sqlite".to_owned());
+                    }
+                    _ => {
+                        return Err(syn::Error::new(
+                            s.span(),
+                            format!(
+                                "unknown required_db_vendor `{raw}` — \
+                                 expected `postgres` (aliases: `postgresql`, `pg`), \
+                                 `mysql` (alias: `mariadb`), or `sqlite` \
+                                 (alias: `sqlite3`)"
+                            ),
+                        ));
+                    }
+                }
                 return Ok(());
             }
             if meta.path.is_ident("base_manager_name") {

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -487,6 +487,19 @@ pub struct ModelSchema {
     /// Declarative-only today: rustango doesn't auto-emit reverse
     /// managers yet — parallel to `default_related_name`.
     pub base_manager_name: Option<&'static str>,
+    /// Django-shape `Meta.required_db_vendor` — the DB backend this
+    /// model is intended to run against. Set via
+    /// `#[rustango(required_db_vendor = "postgres|mysql|sqlite")]`.
+    /// `manage check --deploy` reads this and warns when the active
+    /// `Settings.database.backend` doesn't match, catching
+    /// "I forgot to switch DATABASE_URL" at deploy time rather than
+    /// the first request that hits a PG-only feature on SQLite.
+    ///
+    /// Macro normalizes Django-style aliases — `"postgresql"` / `"pg"`
+    /// → `"postgres"`, `"mariadb"` → `"mysql"`, `"sqlite3"` →
+    /// `"sqlite"` — so callers can compare to a single canonical
+    /// token. `None` means "any backend is fine" (the default).
+    pub required_db_vendor: Option<&'static str>,
     /// Django-shape `Meta.get_latest_by` — default sort field that
     /// `QuerySet::latest_default()` / `earliest_default()` use when
     /// the caller doesn't pass a field name explicitly. A string

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -1456,6 +1456,25 @@ async fn check_cmd<W: Write>(
         // Gated by the `config` feature; no-op without it.
         #[cfg(feature = "config")]
         run_settings_audit(&mut audit);
+        // Django-parity `Meta.required_db_vendor` audit — every model
+        // declaring `#[rustango(required_db_vendor = "postgres")]`
+        // (etc.) gets compared against the active pool's dialect.
+        // Mismatches surface as warnings so ops catches "I forgot to
+        // switch DATABASE_URL" at deploy time rather than the first
+        // request that hits a PG-only feature on SQLite.
+        let active = pool.dialect().name();
+        for entry in crate::core::inventory::iter::<crate::core::ModelEntry>.into_iter() {
+            if let Some(want) = entry.schema.required_db_vendor {
+                if want != active {
+                    audit.warnings.push(format!(
+                        "model `{}` declares `required_db_vendor = \"{want}\"` \
+                         but the active database backend is `{active}` — \
+                         queries that depend on backend-specific features may fail",
+                        entry.schema.name,
+                    ));
+                }
+            }
+        }
         info.extend(audit.info);
         warnings.extend(audit.warnings);
         errors.extend(audit.errors);

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -656,6 +656,7 @@ mod composite_fk_snapshot_tests {
             db_table_comment: None,
             default_related_name: None,
             base_manager_name: None,
+            required_db_vendor: None,
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -730,6 +731,7 @@ mod composite_fk_snapshot_tests {
             db_table_comment: None,
             default_related_name: None,
             base_manager_name: None,
+            required_db_vendor: None,
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -759,6 +761,7 @@ mod composite_fk_snapshot_tests {
             db_table_comment: None,
             default_related_name: None,
             base_manager_name: None,
+            required_db_vendor: None,
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -826,6 +829,7 @@ mod composite_fk_snapshot_tests {
             db_table_comment: None,
             default_related_name: None,
             base_manager_name: None,
+            required_db_vendor: None,
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -300,6 +300,7 @@ mod tests {
         db_table_comment: None,
         default_related_name: None,
         base_manager_name: None,
+        required_db_vendor: None,
         get_latest_by: None,
         extra_permissions: &[],
     };
@@ -330,6 +331,7 @@ mod tests {
         db_table_comment: None,
         default_related_name: None,
         base_manager_name: None,
+        required_db_vendor: None,
         get_latest_by: None,
         extra_permissions: &[],
     };

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -1354,6 +1354,7 @@ mod tests {
             db_table_comment: None,
             default_related_name: None,
             base_manager_name: None,
+            required_db_vendor: None,
             get_latest_by: None,
             extra_permissions: &[],
         }))

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -676,6 +676,7 @@ mod tests {
             db_table_comment: None,
             default_related_name: None,
             base_manager_name: None,
+            required_db_vendor: None,
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -4080,6 +4080,7 @@ mod tests {
             db_table_comment: None,
             default_related_name: None,
             base_manager_name: None,
+            required_db_vendor: None,
             get_latest_by: None,
             extra_permissions: &[],
         }))
@@ -4188,6 +4189,7 @@ mod tests {
             db_table_comment: None,
             default_related_name: None,
             base_manager_name: None,
+            required_db_vendor: None,
             get_latest_by: None,
             extra_permissions: &[],
         }))
@@ -4578,6 +4580,7 @@ mod tests {
             db_table_comment: None,
             default_related_name: None,
             base_manager_name: None,
+            required_db_vendor: None,
             get_latest_by: None,
             extra_permissions: &[],
         }));
@@ -4834,6 +4837,7 @@ mod tests {
             db_table_comment: None,
             default_related_name: None,
             base_manager_name: None,
+            required_db_vendor: None,
             get_latest_by: None,
             extra_permissions: &[],
         }));
@@ -4902,6 +4906,7 @@ mod tests {
             db_table_comment: None,
             default_related_name: None,
             base_manager_name: None,
+            required_db_vendor: None,
             get_latest_by: None,
             extra_permissions: &[],
         }));

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -471,6 +471,7 @@ mod tests {
             db_table_comment: None,
             default_related_name: None,
             base_manager_name: None,
+            required_db_vendor: None,
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/tests/required_db_vendor.rs
+++ b/crates/rustango/tests/required_db_vendor.rs
@@ -1,0 +1,84 @@
+//! Django parity — `Meta.required_db_vendor` lets a model declare
+//! which DB backend it's intended to run against. `manage check
+//! --deploy` flags a mismatch so ops catches "I forgot to switch
+//! DATABASE_URL" at deploy time rather than the first request that
+//! hits a PG-only feature on SQLite.
+//!
+//! rustango spells the attribute as
+//! `#[rustango(required_db_vendor = "postgres|mysql|sqlite")]` on
+//! the model container. Django aliases (`postgresql` / `pg` /
+//! `mariadb` / `sqlite3`) accepted; macro normalizes to the canonical
+//! dialect name so the check verb can compare against
+//! `pool.dialect().name()` directly.
+
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rdv_pg_only", required_db_vendor = "postgres")]
+#[allow(dead_code)]
+pub struct PgOnly {
+    #[rustango(primary_key)]
+    pub id: i64,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rdv_pg_via_alias", required_db_vendor = "postgresql")]
+#[allow(dead_code)]
+pub struct PgViaAlias {
+    #[rustango(primary_key)]
+    pub id: i64,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rdv_mysql_via_mariadb", required_db_vendor = "mariadb")]
+#[allow(dead_code)]
+pub struct MariaAlias {
+    #[rustango(primary_key)]
+    pub id: i64,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rdv_sqlite3", required_db_vendor = "sqlite3")]
+#[allow(dead_code)]
+pub struct SqliteViaAlias {
+    #[rustango(primary_key)]
+    pub id: i64,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rdv_any")]
+#[allow(dead_code)]
+pub struct Any {
+    #[rustango(primary_key)]
+    pub id: i64,
+}
+
+#[test]
+fn canonical_vendor_round_trips() {
+    let s = <PgOnly as rustango::core::Model>::SCHEMA;
+    assert_eq!(s.required_db_vendor, Some("postgres"));
+}
+
+#[test]
+fn postgresql_alias_normalizes_to_postgres() {
+    let s = <PgViaAlias as rustango::core::Model>::SCHEMA;
+    assert_eq!(s.required_db_vendor, Some("postgres"));
+}
+
+#[test]
+fn mariadb_alias_normalizes_to_mysql() {
+    let s = <MariaAlias as rustango::core::Model>::SCHEMA;
+    assert_eq!(s.required_db_vendor, Some("mysql"));
+}
+
+#[test]
+fn sqlite3_alias_normalizes_to_sqlite() {
+    let s = <SqliteViaAlias as rustango::core::Model>::SCHEMA;
+    assert_eq!(s.required_db_vendor, Some("sqlite"));
+}
+
+#[test]
+fn no_attribute_means_any_backend() {
+    let s = <Any as rustango::core::Model>::SCHEMA;
+    assert!(s.required_db_vendor.is_none());
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -20,7 +20,7 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 
 | Category | SHIPPED | PARTIAL | MISSING | N/A |
 |---|---:|---:|---:|---:|
-| 1. ORM — models / fields / Meta | 18 | 1 | 1 | 0 |
+| 1. ORM — models / fields / Meta | 19 | 1 | 1 | 0 |
 | 2. QuerySet API | 37 | 1 | 1 | 0 |
 | 3. Field types & options | 32 | 0 | 2 | 1 |
 | 4. Postgres-specific fields | 2 | 1 | 2 | 0 |
@@ -44,9 +44,9 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 22. Async support | 4 | 0 | 0 | 3 |
 | 23. DRF parity | 22 | 0 | 1 | 0 |
 | 24. contrib modules | 12 | 1 | 3 | 2 |
-| **Totals** | **365** | **11** | **21** | **19** |
+| **Totals** | **366** | **11** | **21** | **19** |
 
-Coverage = 365 / (365 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
+Coverage = 366 / (366 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
 
 Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, default_permissions #594, on_delete #592, ForeignKey on_delete enum override, extra_permissions #591, get_latest_by #590, db_table_comment #589, citext, DatabaseCache, managed=false, upload streaming, i18n).
 
@@ -69,6 +69,7 @@ Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, 
 | `Meta.default_permissions` | [Meta#default_permissions](https://docs.djangoproject.com/en/6.0/ref/models/options/#default-permissions) | SHIPPED | `#[rustango(default_permissions = "view,change")]` (PR #594) — opt out of `add` / `delete` codenames for read-mostly tables; empty (default) seeds all four CRUD codenames | |
 | `Meta.default_manager_name` | [Custom Managers](https://docs.djangoproject.com/en/6.0/topics/db/managers/) | SHIPPED | `#[rustango(manager_fn = "active")]` (closed #289 / T2.6) | Multiple `manager_fn` allowed. |
 | `Meta.base_manager_name` | [Meta#base_manager_name](https://docs.djangoproject.com/en/6.0/ref/models/options/#base-manager-name) | SHIPPED | `#[rustango(base_manager_name = "ManagerExt")]` — stored on `ModelSchema::base_manager_name`. Declarative-only today; foundation for reverse-manager codegen + DRF schema emit + admin templates that need to pick the right Manager subclass for `<instance>.<relation>_set` resolution. | |
+| `Meta.required_db_vendor` | [Meta#required_db_vendor](https://docs.djangoproject.com/en/6.0/ref/models/options/#required-db-vendor) | SHIPPED | `#[rustango(required_db_vendor = "postgres|mysql|sqlite")]` (PR #602). Django aliases (`postgresql` / `pg` / `mariadb` / `sqlite3`) normalize to canonical dialect names. `manage check --deploy` warns when a model's declared vendor doesn't match the active `pool.dialect().name()` — catches "wrong DATABASE_URL" at deploy time rather than first runtime hit. | |
 | Custom `Manager` subclass | [Custom Managers](https://docs.djangoproject.com/en/6.0/topics/db/managers/) | SHIPPED | `#[rustango(manager(ext = "FooManagerExt"))]` emits an extension trait the user impls on `QuerySet<Self>` (T1.9) | |
 | Abstract base classes | [Abstract base](https://docs.djangoproject.com/en/6.0/topics/db/models/#abstract-base-classes) | PARTIAL | `#[rustango(managed = false)]` opts a model out of migration auto-gen (operator-managed schema, #321). Field-inheritance via Rust trait composition is the idiom; no derive-macro shorthand yet for "mix in these timestamp fields". | |
 | Multi-table inheritance | [MTI](https://docs.djangoproject.com/en/6.0/topics/db/models/#multi-table-inheritance) | MISSING | n/a (#322) | rustango-cms uses MTI for PageType (custom impl); framework doesn't auto-generate it. |
@@ -77,7 +78,7 @@ Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, 
 | Self-referential FK | [Self FK](https://docs.djangoproject.com/en/6.0/ref/models/fields/#django.db.models.ForeignKey) | SHIPPED | `#[rustango(fk = "self")]` (v0.17.2) | Tested via `tests/self_fk_live.rs`. |
 | `ManyToManyField(through=...)` | [M2M through](https://docs.djangoproject.com/en/6.0/topics/db/models/#extra-fields-on-many-to-many-relationships) | SHIPPED | `#[rustango(m2m(... auto_create = false))]` (closed #324, v0.42). Operator declares the junction as its own `#[derive(Model)]` with extra columns; the migration writer skips emitting `CREATE TABLE` for that junction when `auto_create = false` (otherwise the through-model's own table would conflict). Implicit-junction path with `auto_create = true` (default) unchanged. | |
 
-Summary: **18 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-base field-inheritance (Rust idiom = trait composition; `#[rustango(managed = false)]` covers the operator-managed-table case via #321), MTI. ExclusionConstraint shipped in PR #593; `Meta.default_permissions` shipped in PR #594; `ForeignKey(on_delete=…)` explicit override shipped in PR #592.
+Summary: **19 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-base field-inheritance (Rust idiom = trait composition; `#[rustango(managed = false)]` covers the operator-managed-table case via #321), MTI. ExclusionConstraint shipped in PR #593; `Meta.default_permissions` shipped in PR #594; `ForeignKey(on_delete=…)` explicit override shipped in PR #592.
 
 ---
 


### PR DESCRIPTION
## Summary

Declares the DB backend a model is intended to run against. Spelled as `#[rustango(required_db_vendor = "postgres|mysql|sqlite")]`; Django aliases (`postgresql` / `pg` / `mariadb` / `sqlite3`) are accepted and normalized to canonical dialect names so the check verb compares against `pool.dialect().name()` directly.

`manage check --deploy` reads `ModelSchema::required_db_vendor` and emits a warning for every model whose declared vendor doesn't match the active pool — catches "I forgot to switch DATABASE_URL" at deploy time rather than the first runtime hit on a backend-specific feature.

## What changed

- New `ModelSchema::required_db_vendor: Option<&'static str>` populated by the macro for every model.
- `migrate::manage::check_cmd` walks the inventory in the `--deploy` branch and pushes a warning per mismatch.
- Macro validates input at derive time so the operator catches typos at compile time (clear error pointing at the literal span).

## Test plan

- [x] `cargo test --features postgres,tenancy --test required_db_vendor` — 5 / 5 pass locally
- [x] `cargo test --workspace --all-features --no-run` — pre-push gate green
- [x] `cargo build --no-default-features --features sqlite,tenancy` — litmus green

Stacks naturally with #600 / #601 — extends the same `ModelSchema` declarative-metadata surface that future codegen reads.