### PR TITLE
feat(model): #[rustango(required_db_features = "...")] — Django Meta capability gating

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -807,6 +807,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         container.verbose_name_plural.as_deref(),
         container.managed,
         container.base_manager_name.as_deref(),
+        &container.required_db_features,
         container.required_db_vendor.as_deref(),
         container.default_related_name.as_deref(),
         container.db_table_comment.as_deref(),
@@ -1705,6 +1706,7 @@ fn model_impl_tokens(
     verbose_name_plural: Option<&str>,
     managed: bool,
     base_manager_name: Option<&str>,
+    required_db_features: &[String],
     required_db_vendor: Option<&str>,
     default_related_name: Option<&str>,
     db_table_comment: Option<&str>,
@@ -1745,6 +1747,8 @@ fn model_impl_tokens(
     let verbose_name_tokens = optional_str(verbose_name);
     let verbose_name_plural_tokens = optional_str(verbose_name_plural);
     let base_manager_name_tokens = optional_str(base_manager_name);
+    let required_db_features_lits: Vec<&str> =
+        required_db_features.iter().map(String::as_str).collect();
     let required_db_vendor_tokens = optional_str(required_db_vendor);
     let default_related_name_tokens = optional_str(default_related_name);
     let db_table_comment_tokens = optional_str(db_table_comment);
@@ -1899,6 +1903,7 @@ fn model_impl_tokens(
                 verbose_name_plural: #verbose_name_plural_tokens,
                 managed: #managed,
                 base_manager_name: #base_manager_name_tokens,
+                required_db_features: &[ #(#required_db_features_lits),* ],
                 required_db_vendor: #required_db_vendor_tokens,
                 default_related_name: #default_related_name_tokens,
                 db_table_comment: #db_table_comment_tokens,
@@ -4476,6 +4481,12 @@ struct ContainerAttrs {
     /// `#[rustango(base_manager_name = "...")]`. Threaded into
     /// `ModelSchema::base_manager_name`. Declarative-only today.
     base_manager_name: Option<String>,
+    /// Django-shape `Meta.required_db_features` from
+    /// `#[rustango(required_db_features = "json_extract,window_functions")]`.
+    /// Each comma-separated capability token surfaces on
+    /// `ModelSchema::required_db_features` so `manage check --deploy`
+    /// can warn when the active dialect lacks one.
+    required_db_features: Vec<String>,
     /// Django-shape `Meta.required_db_vendor` from
     /// `#[rustango(required_db_vendor = "postgres|mysql|sqlite")]`.
     /// Normalized to the dialect name `manage check --deploy`
@@ -4729,6 +4740,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
         verbose_name: None,
         verbose_name_plural: None,
         base_manager_name: None,
+        required_db_features: Vec::new(),
         required_db_vendor: None,
         default_related_name: None,
         db_table_comment: None,
@@ -5071,6 +5083,39 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                 // table-level comment attached to the DB catalog.
                 let s: LitStr = meta.value()?.parse()?;
                 out.db_table_comment = Some(s.value());
+                return Ok(());
+            }
+            if meta.path.is_ident("required_db_features") {
+                // Django-shape `Meta.required_db_features` — capability
+                // tokens the model needs (e.g. `"json_extract"`,
+                // `"window_functions"`, `"row_security"`). Comma-separated.
+                // `manage check --deploy` walks every model and warns
+                // when the active backend doesn't advertise the
+                // capability.
+                //
+                // rustango ships a small registry of capability tokens
+                // each dialect supports — see `Dialect::supports`.
+                // Unknown tokens still parse (they end up on the
+                // schema and show up in the warning) so projects can
+                // declare aspirational capabilities and the check
+                // verb will keep nagging until the dialect implements
+                // them.
+                let s: LitStr = meta.value()?.parse()?;
+                let raw = s.value();
+                let features: Vec<String> = raw
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_owned)
+                    .collect();
+                if features.is_empty() {
+                    return Err(syn::Error::new(
+                        s.span(),
+                        "`required_db_features` must list at least one \
+                         comma-separated capability token",
+                    ));
+                }
+                out.required_db_features = features;
                 return Ok(());
             }
             if meta.path.is_ident("required_db_vendor") {

--- a/crates/rustango/examples/cookbook_blog/COOKBOOK.md
+++ b/crates/rustango/examples/cookbook_blog/COOKBOOK.md
@@ -982,6 +982,36 @@ Run `manage check --deploy` against a SQLite pool:
           backend-specific features may fail
 ```
 
+#### 2.25.13 `#[rustango(required_db_features = "...")]` (PR #604)
+
+**What**: Django `Meta.required_db_features` — finer-grained sibling of `required_db_vendor`. Lists capability tokens the model depends on (e.g. `"json_path"`, `"listen_notify"`, `"hstore"`, `"gist_index"`, `"window_functions"`). `manage check --deploy` walks every model and warns when the active `Dialect::supports(token)` returns `false`.
+
+**Tokens advertised by default impl** (portable across all three backends): `window_functions`, `recursive_cte`, `cte`, `json_extract`, `expression_index`, plus dialect-conditional `partial_index` + `returning`.
+
+**PG-only tokens** (advertised by `Postgres::supports`): `array_type`, `range_type`, `hstore`, `citext`, `listen_notify` / `notify`, `row_security`, `gin_index`, `gist_index`, `spgist_index`, `brin_index`, `unique_constraint_deferred`, `exclusion_constraint`, `tablespaces`, `json_path`, `json_query`.
+
+**Unknown tokens** → returns `false` so the deploy check fires (safe default for aspirational declarations).
+
+```rust
+#[rustango(
+    table = "event_outbox",
+    required_db_features = "listen_notify, json_path",
+)]
+pub struct EventOutbox { /* PG `LISTEN` channel + JSON path queries */ }
+```
+
+Composes with `required_db_vendor` — set both for fail-fast deploy validation:
+
+```rust
+#[rustango(
+    table = "spatial_audit",
+    required_db_vendor = "postgres",
+    required_db_features = "gist_index, exclusion_constraint",
+)]
+```
+
+`manage check --deploy` on a SQLite pool produces one warning per unsupported token + one for the vendor mismatch.
+
 ---
 
 ## Chapter 3 — ORM

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -500,6 +500,19 @@ pub struct ModelSchema {
     /// `"sqlite"` — so callers can compare to a single canonical
     /// token. `None` means "any backend is fine" (the default).
     pub required_db_vendor: Option<&'static str>,
+    /// Django-shape `Meta.required_db_features` — capability tokens
+    /// the model depends on (e.g. `"json_extract"`,
+    /// `"window_functions"`, `"row_security"`). Set via
+    /// `#[rustango(required_db_features = "tok1, tok2")]`.
+    ///
+    /// `manage check --deploy` walks every model and warns when the
+    /// active `Dialect::supports(token)` returns `false`. Use for
+    /// "this model needs PG's `LISTEN/NOTIFY`" / "needs MySQL 8 CTE
+    /// support" / etc. — finer-grained than `required_db_vendor`,
+    /// composes with it.
+    ///
+    /// Empty slice (default) means "no special capabilities needed".
+    pub required_db_features: &'static [&'static str],
     /// Django-shape `Meta.get_latest_by` — default sort field that
     /// `QuerySet::latest_default()` / `earliest_default()` use when
     /// the caller doesn't pass a field name explicitly. A string

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -1456,13 +1456,15 @@ async fn check_cmd<W: Write>(
         // Gated by the `config` feature; no-op without it.
         #[cfg(feature = "config")]
         run_settings_audit(&mut audit);
-        // Django-parity `Meta.required_db_vendor` audit — every model
-        // declaring `#[rustango(required_db_vendor = "postgres")]`
-        // (etc.) gets compared against the active pool's dialect.
-        // Mismatches surface as warnings so ops catches "I forgot to
-        // switch DATABASE_URL" at deploy time rather than the first
-        // request that hits a PG-only feature on SQLite.
-        let active = pool.dialect().name();
+        // Django-parity `Meta.required_db_vendor` + `required_db_features`
+        // audit — every model declaring `required_db_vendor = "postgres"`
+        // or `required_db_features = "json_path, listen_notify"` gets
+        // compared against the active pool's dialect. Mismatches surface
+        // as warnings so ops catches "I forgot to switch DATABASE_URL"
+        // (and "this model wants LISTEN/NOTIFY but you're on SQLite")
+        // at deploy time rather than the first runtime hit.
+        let dialect = pool.dialect();
+        let active = dialect.name();
         for entry in crate::core::inventory::iter::<crate::core::ModelEntry>.into_iter() {
             if let Some(want) = entry.schema.required_db_vendor {
                 if want != active {
@@ -1470,6 +1472,16 @@ async fn check_cmd<W: Write>(
                         "model `{}` declares `required_db_vendor = \"{want}\"` \
                          but the active database backend is `{active}` — \
                          queries that depend on backend-specific features may fail",
+                        entry.schema.name,
+                    ));
+                }
+            }
+            for token in entry.schema.required_db_features {
+                if !dialect.supports(token) {
+                    audit.warnings.push(format!(
+                        "model `{}` declares `required_db_features` token `{token}` \
+                         which the active `{active}` dialect does not advertise — \
+                         queries depending on it will fail at runtime",
                         entry.schema.name,
                     ));
                 }

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -657,6 +657,7 @@ mod composite_fk_snapshot_tests {
             default_related_name: None,
             base_manager_name: None,
             required_db_vendor: None,
+            required_db_features: &[],
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -732,6 +733,7 @@ mod composite_fk_snapshot_tests {
             default_related_name: None,
             base_manager_name: None,
             required_db_vendor: None,
+            required_db_features: &[],
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -762,6 +764,7 @@ mod composite_fk_snapshot_tests {
             default_related_name: None,
             base_manager_name: None,
             required_db_vendor: None,
+            required_db_features: &[],
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -830,6 +833,7 @@ mod composite_fk_snapshot_tests {
             default_related_name: None,
             base_manager_name: None,
             required_db_vendor: None,
+            required_db_features: &[],
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -301,6 +301,7 @@ mod tests {
         default_related_name: None,
         base_manager_name: None,
         required_db_vendor: None,
+        required_db_features: &[],
         get_latest_by: None,
         extra_permissions: &[],
     };
@@ -332,6 +333,7 @@ mod tests {
         default_related_name: None,
         base_manager_name: None,
         required_db_vendor: None,
+        required_db_features: &[],
         get_latest_by: None,
         extra_permissions: &[],
     };

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -289,6 +289,42 @@ pub trait Dialect {
         true
     }
 
+    /// Django-parity `Meta.required_db_features` capability query — does
+    /// this dialect advertise the given token? `manage check --deploy`
+    /// walks every model's `required_db_features` and warns when this
+    /// returns `false`, so projects can declare "needs PG `LISTEN/NOTIFY`"
+    /// or "needs MySQL 8 CTE support" and get a deploy-time signal
+    /// rather than a runtime surprise.
+    ///
+    /// Default impl whitelists tokens supported by all three backends
+    /// rustango ships (`window_functions`, `recursive_cte`,
+    /// `json_extract`, `expression_index`, `partial_index` —
+    /// the last gated on [`Self::supports_partial_index`]). Per-dialect
+    /// impls extend with PG-specific (`array_type`, `range_type`,
+    /// `hstore`, `citext`, `listen_notify`, `row_security`, `gin_index`,
+    /// `gist_index`, `unique_constraint_deferred`) or MySQL/SQLite
+    /// specifics.
+    ///
+    /// Unknown tokens return `false` (treat as "not supported" so the
+    /// deploy warning fires; that's the safer default for aspirational
+    /// declarations).
+    #[must_use]
+    fn supports(&self, token: &str) -> bool {
+        self.default_supports(token)
+    }
+
+    /// Tokens supported by all three backends rustango ships against —
+    /// per-dialect overrides of [`Self::supports`] call this for the
+    /// generic baseline and then `||`-add their specifics.
+    #[must_use]
+    fn default_supports(&self, token: &str) -> bool {
+        matches!(
+            token,
+            "window_functions" | "recursive_cte" | "cte" | "json_extract" | "expression_index"
+        ) || (token == "partial_index" && self.supports_partial_index())
+            || (token == "returning" && self.supports_returning())
+    }
+
     /// Dialect-specific SQL type token for the rhs of `CAST(<expr> AS <ty>)`
     /// — distinct from [`Self::null_cast`] (which is PG-specific) and
     /// [`Self::column_type`] (DDL, which includes lengths like

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -1355,6 +1355,7 @@ mod tests {
             default_related_name: None,
             base_manager_name: None,
             required_db_vendor: None,
+            required_db_features: &[],
             get_latest_by: None,
             extra_permissions: &[],
         }))

--- a/crates/rustango/src/sql/postgres.rs
+++ b/crates/rustango/src/sql/postgres.rs
@@ -98,6 +98,32 @@ impl Dialect for Postgres {
         true
     }
 
+    fn supports(&self, token: &str) -> bool {
+        // Postgres-specific capability tokens that aren't reachable via
+        // the default impl's whitelist. Extends the default; the
+        // generic `window_functions` / `cte` / etc. fall through to
+        // `super::Dialect::supports` via the `||`.
+        matches!(
+            token,
+            "array_type"
+                | "range_type"
+                | "hstore"
+                | "citext"
+                | "listen_notify"
+                | "notify"
+                | "row_security"
+                | "gin_index"
+                | "gist_index"
+                | "spgist_index"
+                | "brin_index"
+                | "unique_constraint_deferred"
+                | "exclusion_constraint"
+                | "tablespaces"
+                | "json_path"
+                | "json_query"
+        ) || self.default_supports(token)
+    }
+
     fn cast_aggregate_to_int(&self, expr: &str) -> String {
         // PostgreSQL accepts the shorter `<expr>::bigint` form.
         format!("{expr}::bigint")

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -677,6 +677,7 @@ mod tests {
             default_related_name: None,
             base_manager_name: None,
             required_db_vendor: None,
+            required_db_features: &[],
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -4081,6 +4081,7 @@ mod tests {
             default_related_name: None,
             base_manager_name: None,
             required_db_vendor: None,
+            required_db_features: &[],
             get_latest_by: None,
             extra_permissions: &[],
         }))
@@ -4190,6 +4191,7 @@ mod tests {
             default_related_name: None,
             base_manager_name: None,
             required_db_vendor: None,
+            required_db_features: &[],
             get_latest_by: None,
             extra_permissions: &[],
         }))
@@ -4581,6 +4583,7 @@ mod tests {
             default_related_name: None,
             base_manager_name: None,
             required_db_vendor: None,
+            required_db_features: &[],
             get_latest_by: None,
             extra_permissions: &[],
         }));
@@ -4838,6 +4841,7 @@ mod tests {
             default_related_name: None,
             base_manager_name: None,
             required_db_vendor: None,
+            required_db_features: &[],
             get_latest_by: None,
             extra_permissions: &[],
         }));
@@ -4907,6 +4911,7 @@ mod tests {
             default_related_name: None,
             base_manager_name: None,
             required_db_vendor: None,
+            required_db_features: &[],
             get_latest_by: None,
             extra_permissions: &[],
         }));

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -472,6 +472,7 @@ mod tests {
             default_related_name: None,
             base_manager_name: None,
             required_db_vendor: None,
+            required_db_features: &[],
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/tests/required_db_features.rs
+++ b/crates/rustango/tests/required_db_features.rs
@@ -1,0 +1,108 @@
+//! Django parity — `Meta.required_db_features` lets a model declare
+//! capability tokens it depends on (e.g. `"json_path"`, `"hstore"`,
+//! `"listen_notify"`). `manage check --deploy` walks every model and
+//! warns when the active dialect's `Dialect::supports(token)` returns
+//! `false`. Finer-grained than `required_db_vendor` — composes with it.
+//!
+//! rustango spells the attribute as
+//! `#[rustango(required_db_features = "tok1, tok2")]` on the model
+//! container. Stored on `ModelSchema::required_db_features` as a
+//! `&'static [&'static str]`.
+
+use rustango::sql::Dialect;
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "rdf_pg_heavy",
+    required_db_features = "listen_notify, gist_index, hstore"
+)]
+#[allow(dead_code)]
+pub struct PgHeavy {
+    #[rustango(primary_key)]
+    pub id: i64,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "rdf_portable",
+    required_db_features = "window_functions, json_extract"
+)]
+#[allow(dead_code)]
+pub struct Portable {
+    #[rustango(primary_key)]
+    pub id: i64,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rdf_plain")]
+#[allow(dead_code)]
+pub struct Plain {
+    #[rustango(primary_key)]
+    pub id: i64,
+}
+
+#[test]
+fn schema_carries_capability_tokens() {
+    let schema = <PgHeavy as rustango::core::Model>::SCHEMA;
+    assert_eq!(
+        schema.required_db_features,
+        &["listen_notify", "gist_index", "hstore"]
+    );
+}
+
+#[test]
+fn plain_model_has_no_required_features() {
+    let plain = <Plain as rustango::core::Model>::SCHEMA;
+    assert!(plain.required_db_features.is_empty());
+}
+
+#[cfg(feature = "postgres")]
+#[test]
+fn pg_supports_all_pg_heavy_tokens() {
+    let d = rustango::sql::Postgres;
+    let schema = <PgHeavy as rustango::core::Model>::SCHEMA;
+    for token in schema.required_db_features {
+        assert!(d.supports(token), "Postgres should advertise `{token}`");
+    }
+}
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn sqlite_rejects_pg_only_tokens_but_accepts_portable_ones() {
+    let d = rustango::sql::Sqlite;
+    // PG-only tokens — SQLite does not advertise.
+    assert!(!d.supports("listen_notify"));
+    assert!(!d.supports("gist_index"));
+    assert!(!d.supports("hstore"));
+    assert!(!d.supports("array_type"));
+    // Portable tokens that all three backends ship.
+    assert!(d.supports("window_functions"));
+    assert!(d.supports("json_extract"));
+    assert!(d.supports("recursive_cte"));
+}
+
+#[cfg(feature = "mysql")]
+#[test]
+fn mysql_rejects_pg_only_and_partial_index() {
+    let d = rustango::sql::MySql;
+    assert!(!d.supports("listen_notify"));
+    assert!(!d.supports("array_type"));
+    assert!(!d.supports("hstore"));
+    // MySQL has no native partial-index support.
+    assert!(!d.supports("partial_index"));
+    // But window functions + CTEs + JSON_EXTRACT all ship (MySQL 8+).
+    assert!(d.supports("window_functions"));
+    assert!(d.supports("json_extract"));
+    assert!(d.supports("recursive_cte"));
+}
+
+#[test]
+fn unknown_capability_returns_false_on_every_dialect() {
+    #[cfg(feature = "postgres")]
+    assert!(!rustango::sql::Postgres.supports("not_a_real_capability_xyz"));
+    #[cfg(feature = "sqlite")]
+    assert!(!rustango::sql::Sqlite.supports("not_a_real_capability_xyz"));
+    #[cfg(feature = "mysql")]
+    assert!(!rustango::sql::MySql.supports("not_a_real_capability_xyz"));
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -20,7 +20,7 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 
 | Category | SHIPPED | PARTIAL | MISSING | N/A |
 |---|---:|---:|---:|---:|
-| 1. ORM — models / fields / Meta | 19 | 1 | 1 | 0 |
+| 1. ORM — models / fields / Meta | 20 | 1 | 1 | 0 |
 | 2. QuerySet API | 37 | 1 | 1 | 0 |
 | 3. Field types & options | 32 | 0 | 2 | 1 |
 | 4. Postgres-specific fields | 2 | 1 | 2 | 0 |
@@ -44,9 +44,9 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 22. Async support | 4 | 0 | 0 | 3 |
 | 23. DRF parity | 22 | 0 | 1 | 0 |
 | 24. contrib modules | 12 | 1 | 3 | 2 |
-| **Totals** | **366** | **11** | **21** | **19** |
+| **Totals** | **367** | **11** | **21** | **19** |
 
-Coverage = 366 / (366 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
+Coverage = 367 / (367 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
 
 Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, default_permissions #594, on_delete #592, ForeignKey on_delete enum override, extra_permissions #591, get_latest_by #590, db_table_comment #589, citext, DatabaseCache, managed=false, upload streaming, i18n).
 
@@ -70,6 +70,7 @@ Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, 
 | `Meta.default_manager_name` | [Custom Managers](https://docs.djangoproject.com/en/6.0/topics/db/managers/) | SHIPPED | `#[rustango(manager_fn = "active")]` (closed #289 / T2.6) | Multiple `manager_fn` allowed. |
 | `Meta.base_manager_name` | [Meta#base_manager_name](https://docs.djangoproject.com/en/6.0/ref/models/options/#base-manager-name) | SHIPPED | `#[rustango(base_manager_name = "ManagerExt")]` — stored on `ModelSchema::base_manager_name`. Declarative-only today; foundation for reverse-manager codegen + DRF schema emit + admin templates that need to pick the right Manager subclass for `<instance>.<relation>_set` resolution. | |
 | `Meta.required_db_vendor` | [Meta#required_db_vendor](https://docs.djangoproject.com/en/6.0/ref/models/options/#required-db-vendor) | SHIPPED | `#[rustango(required_db_vendor = "postgres|mysql|sqlite")]` (PR #602). Django aliases (`postgresql` / `pg` / `mariadb` / `sqlite3`) normalize to canonical dialect names. `manage check --deploy` warns when a model's declared vendor doesn't match the active `pool.dialect().name()` — catches "wrong DATABASE_URL" at deploy time rather than first runtime hit. | |
+| `Meta.required_db_features` | [Meta#required_db_features](https://docs.djangoproject.com/en/6.0/ref/models/options/#required-db-features) | SHIPPED | `#[rustango(required_db_features = "json_path, listen_notify")]` (PR #604) — comma-separated capability tokens. New `Dialect::supports(token)` advertises per-backend support (default impl whitelists portable tokens like `window_functions` / `recursive_cte` / `json_extract`; PG override adds `array_type`, `hstore`, `gist_index`, `listen_notify`, `row_security`, `exclusion_constraint`, etc.). `manage check --deploy` warns on mismatch. Finer-grained than `required_db_vendor`. | |
 | Custom `Manager` subclass | [Custom Managers](https://docs.djangoproject.com/en/6.0/topics/db/managers/) | SHIPPED | `#[rustango(manager(ext = "FooManagerExt"))]` emits an extension trait the user impls on `QuerySet<Self>` (T1.9) | |
 | Abstract base classes | [Abstract base](https://docs.djangoproject.com/en/6.0/topics/db/models/#abstract-base-classes) | PARTIAL | `#[rustango(managed = false)]` opts a model out of migration auto-gen (operator-managed schema, #321). Field-inheritance via Rust trait composition is the idiom; no derive-macro shorthand yet for "mix in these timestamp fields". | |
 | Multi-table inheritance | [MTI](https://docs.djangoproject.com/en/6.0/topics/db/models/#multi-table-inheritance) | MISSING | n/a (#322) | rustango-cms uses MTI for PageType (custom impl); framework doesn't auto-generate it. |
@@ -78,7 +79,7 @@ Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, 
 | Self-referential FK | [Self FK](https://docs.djangoproject.com/en/6.0/ref/models/fields/#django.db.models.ForeignKey) | SHIPPED | `#[rustango(fk = "self")]` (v0.17.2) | Tested via `tests/self_fk_live.rs`. |
 | `ManyToManyField(through=...)` | [M2M through](https://docs.djangoproject.com/en/6.0/topics/db/models/#extra-fields-on-many-to-many-relationships) | SHIPPED | `#[rustango(m2m(... auto_create = false))]` (closed #324, v0.42). Operator declares the junction as its own `#[derive(Model)]` with extra columns; the migration writer skips emitting `CREATE TABLE` for that junction when `auto_create = false` (otherwise the through-model's own table would conflict). Implicit-junction path with `auto_create = true` (default) unchanged. | |
 
-Summary: **19 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-base field-inheritance (Rust idiom = trait composition; `#[rustango(managed = false)]` covers the operator-managed-table case via #321), MTI. ExclusionConstraint shipped in PR #593; `Meta.default_permissions` shipped in PR #594; `ForeignKey(on_delete=…)` explicit override shipped in PR #592.
+Summary: **20 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-base field-inheritance (Rust idiom = trait composition; `#[rustango(managed = false)]` covers the operator-managed-table case via #321), MTI. ExclusionConstraint shipped in PR #593; `Meta.default_permissions` shipped in PR #594; `ForeignKey(on_delete=…)` explicit override shipped in PR #592.
 
 ---
 


### PR DESCRIPTION
## Summary

Declares the dialect capability tokens a model depends on. Spelled as `#[rustango(required_db_features = "json_path, listen_notify, hstore")]`; each comma-separated token surfaces on `ModelSchema::required_db_features`.

`manage check --deploy` walks every model and warns when the active `Dialect::supports(token)` returns `false`, catching "this model needs PG's LISTEN/NOTIFY but you're deploying to SQLite" at deploy time rather than the first runtime hit.

## What changed

- New `Dialect::supports(token: &str) -> bool` trait method with a default impl that whitelists portable tokens (`window_functions`, `recursive_cte`, `cte`, `json_extract`, `expression_index`, plus dialect-conditional `partial_index` + `returning`).
- `Postgres::supports` override adds PG-specific tokens: `array_type`, `range_type`, `hstore`, `citext`, `listen_notify` / `notify`, `row_security`, `gin_index`, `gist_index`, `spgist_index`, `brin_index`, `unique_constraint_deferred`, `exclusion_constraint`, `tablespaces`, `json_path`, `json_query`.
- `migrate::manage::check_cmd` walks `entry.schema.required_db_features` alongside the existing `required_db_vendor` check.
- Composes with `required_db_vendor` from PR #602 — set both for fail-fast deploy validation.
- Unknown tokens default to `false` so aspirational declarations get a deploy warning until the dialect implements them.

## Test plan

- [x] `cargo test --features postgres,tenancy --test required_db_features` — 4 / 4 pass locally
- [x] `cargo test --no-default-features --features sqlite,tenancy --test required_db_features` — 4 / 4 pass locally
- [x] `cargo build --no-default-features --features sqlite,tenancy` — litmus green
- [x] Audit doc Section 1 + cookbook 2.25.13 updated.

Stacks naturally with #602; same `manage check --deploy` audit block extended.