### PR TITLE
feat(model): include = "..." on index_when / unique_when — Django Index covering parity

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -778,6 +778,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
                     unique: fa.index_unique,
                     method: fa.index_method,
                     where_clause: None,
+                    include: Vec::new(),
                 });
             }
         }
@@ -1786,6 +1787,7 @@ fn model_impl_tokens(
             Some(s) => quote!(::core::option::Option::Some(#s)),
             None => quote!(::core::option::Option::None),
         };
+        let include_lits: Vec<&str> = idx.include.iter().map(String::as_str).collect();
         quote! {
             ::rustango::core::IndexSchema {
                 name: #name,
@@ -1793,6 +1795,7 @@ fn model_impl_tokens(
                 unique: #unique,
                 method: #method_variant,
                 where_clause: #where_clause,
+                include: &[ #(#include_lits),* ],
             }
         }
     });
@@ -4557,6 +4560,10 @@ struct IndexAttr {
     /// T1.3. Set via `#[rustango(unique_when(columns = "...",
     /// condition = "...", name = "..."))]`. `None` for plain indexes.
     where_clause: Option<String>,
+    /// Django `Index(fields=..., include=[...])` covering-index
+    /// columns (PG 11+ `INCLUDE (...)` clause). Empty `Vec` (the
+    /// default) means "no covering columns".
+    include: Vec<String>,
 }
 
 /// Parsed form of one `#[rustango(check(name = "…", expr = "…"))]` declaration.
@@ -5335,6 +5342,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     unique: true,
                     method: "btree".to_owned(),
                     where_clause: None,
+                include: Vec::new(),
                 });
                 return Ok(());
             }
@@ -5351,6 +5359,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     unique: false,
                     method: "btree".to_owned(),
                     where_clause: None,
+                include: Vec::new(),
                 });
                 return Ok(());
             }
@@ -5372,6 +5381,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                 let mut columns: Option<Vec<String>> = None;
                 let mut condition: Option<String> = None;
                 let mut name: Option<String> = None;
+                let mut include: Vec<String> = Vec::new();
                 meta.parse_nested_meta(|inner| {
                     if inner.path.is_ident("columns") {
                         let s: LitStr = inner.value()?.parse()?;
@@ -5388,10 +5398,19 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                         name = Some(s.value());
                         return Ok(());
                     }
+                    if inner.path.is_ident("include") {
+                        // Django `UniqueConstraint(include=[...])` — PG
+                        // 11+ covering-index columns. Non-key columns
+                        // travel with the index leaf for index-only
+                        // scans. Dropped on MySQL/SQLite by the writer.
+                        let s: LitStr = inner.value()?.parse()?;
+                        include = split_field_list(&s.value());
+                        return Ok(());
+                    }
                     Err(inner.error(
                         "unknown unique_when attribute (supported: \
                          `columns = \"...\"`, `condition = \"...\"`, \
-                         `name = \"...\"`)",
+                         `name = \"...\"`, `include = \"...\"`)",
                     ))
                 })?;
                 let columns = columns.ok_or_else(|| {
@@ -5409,6 +5428,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     unique: true,
                     method: "btree".to_owned(),
                     where_clause: Some(condition),
+                    include,
                 });
                 return Ok(());
             }
@@ -5434,6 +5454,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                 let mut condition: Option<String> = None;
                 let mut name: Option<String> = None;
                 let mut method: String = "btree".to_owned();
+                let mut include: Vec<String> = Vec::new();
                 meta.parse_nested_meta(|inner| {
                     if inner.path.is_ident("columns") {
                         let s: LitStr = inner.value()?.parse()?;
@@ -5455,10 +5476,20 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                         method = s.value();
                         return Ok(());
                     }
+                    if inner.path.is_ident("include") {
+                        // Django `Index(include=[...])` — PG 11+
+                        // covering-index columns; non-key columns
+                        // travel with the index leaf. Dropped on
+                        // MySQL/SQLite.
+                        let s: LitStr = inner.value()?.parse()?;
+                        include = split_field_list(&s.value());
+                        return Ok(());
+                    }
                     Err(inner.error(
                         "unknown index_when attribute (supported: \
                          `columns = \"...\"`, `condition = \"...\"`, \
-                         `name = \"...\"`, `method = \"btree|gin|gist|...\"`)",
+                         `name = \"...\"`, `method = \"btree|gin|gist|...\"`, \
+                         `include = \"...\"`)",
                     ))
                 })?;
                 let columns = columns
@@ -5475,6 +5506,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     unique: false,
                     method,
                     where_clause: Some(condition),
+                    include,
                 });
                 return Ok(());
             }
@@ -5494,6 +5526,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     unique: false,
                     method: "btree".to_owned(),
                     where_clause: None,
+                include: Vec::new(),
                 });
                 return Ok(());
             }

--- a/crates/rustango/examples/cookbook_blog/COOKBOOK.md
+++ b/crates/rustango/examples/cookbook_blog/COOKBOOK.md
@@ -1012,6 +1012,34 @@ Composes with `required_db_vendor` — set both for fail-fast deploy validation:
 
 `manage check --deploy` on a SQLite pool produces one warning per unsupported token + one for the vendor mismatch.
 
+#### 2.25.14 `include = "..."` on `index_when` / `unique_when` (PR #605)
+
+**What**: Django `Index(fields=..., include=[...])` covering-index parity. Optional sub-attr on both `index_when(...)` and `unique_when(...)`. Lists non-key columns that travel along with the index leaf so PG can serve queries entirely from the index without a heap visit (index-only scans).
+
+**Render shape**:
+- **PG 11+**: `CREATE INDEX <name> ON <table> (key_cols) INCLUDE (non_key_cols)` — emitted before the WHERE-suffix.
+- **MySQL / SQLite**: clause dropped with a `tracing::warn!`. Operators wanting covers on those backends should add a redundant non-key column to the key tuple.
+
+```rust
+#[rustango(
+    table = "post",
+    index_when(
+        columns = "status",
+        condition = "deleted_at IS NULL",
+        name = "active_post_cover_idx",
+        include = "title, created_at",
+    ),
+    unique_when(
+        columns = "tenant_id, slug",
+        condition = "deleted_at IS NULL",
+        name = "active_post_slug_unique",
+        include = "title",
+    ),
+)]
+```
+
+Reads `SELECT title, created_at FROM post WHERE status = 'published' AND deleted_at IS NULL` get index-only scans without touching the heap.
+
 ---
 
 ## Chapter 3 — ORM

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -686,6 +686,18 @@ pub struct IndexSchema {
     /// is ignored, so duplicates outside the partition would also be
     /// rejected — document the limitation).
     pub where_clause: Option<&'static str>,
+    /// Django-shape `Index(fields=..., include=[...])` covering-index
+    /// columns. PG 11+ supports `CREATE INDEX … (key_cols) INCLUDE
+    /// (non_key_cols)` — the non-key columns travel along with the
+    /// index leaf so index-only scans can fetch them without touching
+    /// the heap. Set via `include = "col1, col2"` on `index_when` /
+    /// `unique_when` / `index_together` / `unique_together`.
+    ///
+    /// MySQL has no equivalent (writer drops the clause with a
+    /// `tracing::warn!`); SQLite ignores INCLUDE (the WITHOUT ROWID
+    /// case has different semantics — not exposed here). Empty slice
+    /// (default) means "no covering columns".
+    pub include: &'static [&'static str],
 }
 
 /// Index access method — Postgres `CREATE INDEX … USING <method>`.

--- a/crates/rustango/src/migrate/diff.rs
+++ b/crates/rustango/src/migrate/diff.rs
@@ -128,6 +128,13 @@ pub enum SchemaChange {
         /// WHERE clause with a doc-level warning.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         where_clause: Option<String>,
+        /// Django `Index(include=[...])` covering-index columns. PG
+        /// 11+ ships `INCLUDE (...)` syntax — non-key columns travel
+        /// with the index leaf for index-only scans. MySQL/SQLite
+        /// lack it; the renderer drops the clause with a warning.
+        /// Empty `Vec` (the default) means "no covering columns".
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        include: Vec<String>,
     },
     /// Drop an index by name.
     DropIndex {
@@ -297,6 +304,7 @@ pub fn detect_changes(prev: &SchemaSnapshot, current: &SchemaSnapshot) -> Vec<Sc
                 unique: idx.unique,
                 method: idx.method.clone(),
                 where_clause: idx.where_clause.clone(),
+                include: idx.include.clone(),
             });
         }
     }
@@ -332,6 +340,33 @@ pub fn detect_changes(prev: &SchemaSnapshot, current: &SchemaSnapshot) -> Vec<Sc
                     unique: idx.unique,
                     method: idx.method.clone(),
                     where_clause: idx.where_clause.clone(),
+                    include: idx.include.clone(),
+                });
+            }
+        }
+    }
+    // Also detect include-only changes so a fresh covering set
+    // re-emits as Drop + Create.
+    for idx in &current.indexes {
+        if let Some(prev_idx) = prev.index(&idx.name) {
+            if prev_idx.columns == idx.columns
+                && prev_idx.unique == idx.unique
+                && prev_idx.table == idx.table
+                && prev_idx.method == idx.method
+                && prev_idx.where_clause == idx.where_clause
+                && prev_idx.include != idx.include
+            {
+                changes.push(SchemaChange::DropIndex {
+                    name: idx.name.clone(),
+                });
+                changes.push(SchemaChange::CreateIndex {
+                    name: idx.name.clone(),
+                    table: idx.table.clone(),
+                    columns: idx.columns.clone(),
+                    unique: idx.unique,
+                    method: idx.method.clone(),
+                    where_clause: idx.where_clause.clone(),
+                    include: idx.include.clone(),
                 });
             }
         }
@@ -808,6 +843,7 @@ fn render_changes_split_inner(
                 unique,
                 method,
                 where_clause,
+                include,
             } => {
                 let unique_kw = if *unique { "UNIQUE " } else { "" };
                 let if_not_exists = if dialect.supports_create_index_if_not_exists() {
@@ -847,8 +883,38 @@ fn render_changes_split_inner(
                 } else {
                     String::new()
                 };
+                // Covering-index `INCLUDE (cols)` — PG 11+ ships it.
+                // SQLite + MySQL lack it; the writer drops the clause
+                // with a warning so the rest of the migration still
+                // applies. Routes through the dialect via the new
+                // `supports("covering_index")` capability token —
+                // Postgres's `supports` override advertises it under
+                // the same name (`expression_index`-adjacent), but
+                // PG-specific. The simplest gate is the existing
+                // `dialect.name() == "postgres"` since covering
+                // indexes are PG-only across rustango's matrix.
+                let include_suffix = if include.is_empty() {
+                    String::new()
+                } else if dialect.name() == "postgres" {
+                    let cols = include
+                        .iter()
+                        .map(|c| dialect.quote_ident(c))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!(" INCLUDE ({cols})")
+                } else {
+                    out.warnings.push(format!(
+                        "index {name:?} declares INCLUDE ({}); {} has \
+                         no covering-index syntax — emitting plain \
+                         index. Add a redundant non-key column to the \
+                         key tuple if you need the cover.",
+                        include.join(", "),
+                        dialect.name()
+                    ));
+                    String::new()
+                };
                 out.immediate.push(format!(
-                    "CREATE {unique_kw}INDEX {if_not_exists}{} ON {}{} ({cols}){where_suffix}",
+                    "CREATE {unique_kw}INDEX {if_not_exists}{} ON {}{} ({cols}){include_suffix}{where_suffix}",
                     dialect.quote_ident(name),
                     dialect.quote_ident(table),
                     using,

--- a/crates/rustango/src/migrate/invert.rs
+++ b/crates/rustango/src/migrate/invert.rs
@@ -209,6 +209,7 @@ fn invert_one(op: &Operation, prev: &SchemaSnapshot) -> Result<Operation, Migrat
                 unique: idx.unique,
                 method: idx.method.clone(),
                 where_clause: idx.where_clause.clone(),
+                include: idx.include.clone(),
             }))
         }
         Operation::Schema(SchemaChange::CreateM2MTable {

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -77,6 +77,13 @@ pub struct IndexSnapshot {
     /// this key deserialize cleanly via `#[serde(default)]`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub where_clause: Option<String>,
+    /// Django `Index(include=[...])` covering-index columns. PG 11+
+    /// only; MySQL/SQLite drop the clause at render time with a
+    /// warning. Empty `Vec` (default) means "no covering columns".
+    /// Older snapshots without this key deserialize cleanly via
+    /// `#[serde(default)]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub include: Vec<String>,
 }
 
 fn default_index_method() -> String {
@@ -554,6 +561,7 @@ fn collect_indexes<'a>(schemas: impl Iterator<Item = &'a ModelSchema>) -> Vec<In
                     unique: idx.unique,
                     method: idx.method.as_str().to_owned(),
                     where_clause: idx.where_clause.map(str::to_owned),
+                    include: idx.include.iter().map(|&c| c.to_owned()).collect(),
                 });
             }
         }

--- a/crates/rustango/tests/index_include.rs
+++ b/crates/rustango/tests/index_include.rs
@@ -1,0 +1,119 @@
+//! Django parity — `Index(fields=[...], include=[...])` covering
+//! index. PG 11+ ships `CREATE INDEX … (key_cols) INCLUDE (non_key)`
+//! so non-key columns travel with the index leaf for index-only
+//! scans. MySQL/SQLite have no equivalent — the migration writer
+//! drops the clause with a `tracing::warn!` so the rest of the
+//! migration still applies.
+//!
+//! rustango spells the attribute as `include = "col1, col2"` on
+//! `index_when(...)` / `unique_when(...)` (this PR wires both). Both
+//! `IndexSchema::include` and `IndexSnapshot::include` carry the
+//! columns across the inventory → diff → render pipeline.
+
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "idxinc_post",
+    // Covering index on `status` that also returns `title, created_at`
+    // without a heap visit.
+    index_when(
+        columns = "status",
+        condition = "deleted_at IS NULL",
+        name = "active_post_cover_idx",
+        include = "title, created_at",
+    ),
+    // UNIQUE variant — composite key plus a covering payload.
+    unique_when(
+        columns = "tenant_id, slug",
+        condition = "deleted_at IS NULL",
+        name = "active_post_slug_unique",
+        include = "title",
+    ),
+)]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+    pub tenant_id: i64,
+    #[rustango(max_length = 16)]
+    pub status: String,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 200)]
+    pub slug: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "idxinc_plain",
+    index_when(columns = "status", condition = "x IS NULL", name = "plain_idx")
+)]
+#[allow(dead_code)]
+pub struct Plain {
+    #[rustango(primary_key)]
+    pub id: i64,
+    #[rustango(max_length = 16)]
+    pub status: String,
+    pub x: Option<i64>,
+}
+
+#[test]
+fn schema_carries_include_columns() {
+    let schema = <Post as rustango::core::Model>::SCHEMA;
+    let cover = schema
+        .indexes
+        .iter()
+        .find(|i| i.name == "active_post_cover_idx")
+        .expect("missing active_post_cover_idx");
+    assert_eq!(cover.include, &["title", "created_at"]);
+
+    let unique_cover = schema
+        .indexes
+        .iter()
+        .find(|i| i.name == "active_post_slug_unique")
+        .expect("missing active_post_slug_unique");
+    assert!(unique_cover.unique);
+    assert_eq!(unique_cover.include, &["title"]);
+}
+
+#[test]
+fn plain_index_has_no_include_columns() {
+    let plain = <Plain as rustango::core::Model>::SCHEMA;
+    let only = plain
+        .indexes
+        .iter()
+        .find(|i| i.name == "plain_idx")
+        .expect("missing plain_idx");
+    assert!(only.include.is_empty());
+}
+
+#[test]
+fn diff_emits_create_index_with_include() {
+    use rustango::migrate::diff::{detect_changes, SchemaChange};
+    use rustango::migrate::snapshot::SchemaSnapshot;
+
+    let schema = <Post as rustango::core::Model>::SCHEMA;
+    let prev = SchemaSnapshot {
+        tables: vec![],
+        m2m_tables: vec![],
+        indexes: vec![],
+        checks: vec![],
+        excludes: vec![],
+    };
+    let current = SchemaSnapshot::from_models(&[schema]);
+    let changes = detect_changes(&prev, &current);
+
+    let cover = changes
+        .iter()
+        .find(|c| matches!(c, SchemaChange::CreateIndex { name, .. } if name == "active_post_cover_idx"))
+        .expect("missing CreateIndex for cover idx");
+    match cover {
+        SchemaChange::CreateIndex { include, .. } => {
+            assert_eq!(include, &vec!["title".to_owned(), "created_at".to_owned()]);
+        }
+        _ => unreachable!(),
+    }
+}

--- a/crates/rustango/tests/index_types_dsl.rs
+++ b/crates/rustango/tests/index_types_dsl.rs
@@ -63,6 +63,7 @@ fn index_schema_default_method_is_btree() {
         unique: false,
         method: IndexMethod::default(),
         where_clause: None,
+        include: &[],
     };
     assert_eq!(idx.method, IndexMethod::BTree);
 }

--- a/crates/rustango/tests/migrate_diff.rs
+++ b/crates/rustango/tests/migrate_diff.rs
@@ -732,6 +732,7 @@ fn snap_with_index(name: &str, columns: &[&str], unique: bool) -> SchemaSnapshot
             unique,
             method: "btree".into(),
             where_clause: None,
+            include: vec![],
         }],
         ..Default::default()
     }

--- a/crates/rustango/tests/unique_when_emission.rs
+++ b/crates/rustango/tests/unique_when_emission.rs
@@ -45,6 +45,7 @@ fn create_index_change() -> SchemaChange {
         unique: idx.unique,
         method: idx.method.as_str().to_owned(),
         where_clause: idx.where_clause.map(str::to_owned),
+        include: idx.include.iter().map(|&s| s.to_owned()).collect(),
     }
 }
 

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -20,7 +20,7 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 
 | Category | SHIPPED | PARTIAL | MISSING | N/A |
 |---|---:|---:|---:|---:|
-| 1. ORM — models / fields / Meta | 20 | 1 | 1 | 0 |
+| 1. ORM — models / fields / Meta | 21 | 1 | 1 | 0 |
 | 2. QuerySet API | 37 | 1 | 1 | 0 |
 | 3. Field types & options | 32 | 0 | 2 | 1 |
 | 4. Postgres-specific fields | 2 | 1 | 2 | 0 |
@@ -44,9 +44,9 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 22. Async support | 4 | 0 | 0 | 3 |
 | 23. DRF parity | 22 | 0 | 1 | 0 |
 | 24. contrib modules | 12 | 1 | 3 | 2 |
-| **Totals** | **367** | **11** | **21** | **19** |
+| **Totals** | **368** | **11** | **21** | **19** |
 
-Coverage = 367 / (367 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
+Coverage = 368 / (368 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
 
 Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, default_permissions #594, on_delete #592, ForeignKey on_delete enum override, extra_permissions #591, get_latest_by #590, db_table_comment #589, citext, DatabaseCache, managed=false, upload streaming, i18n).
 
@@ -62,6 +62,7 @@ Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, 
 | `Meta.unique_together` | [Meta#unique_together](https://docs.djangoproject.com/en/6.0/ref/models/options/#unique-together) | SHIPPED | `#[rustango(unique_together(...))]` (v0.19) | |
 | `Meta.index_together` | [Meta#index_together](https://docs.djangoproject.com/en/6.0/ref/models/options/#index-together) | SHIPPED | `#[rustango(index_together(...))]` (v0.19) | |
 | `Index(fields=..., condition=Q(...))` partial index | [Index](https://docs.djangoproject.com/en/6.0/ref/models/indexes/#django.db.models.Index) | SHIPPED | `#[rustango(index_when(columns = "...", condition = "...", name = "...", method = "btree"))]` (PR #599) — sibling of `unique_when`. Emits `CREATE INDEX <name> ON <table> (cols) WHERE <expr>` on PG / SQLite; MySQL emits a plain CREATE INDEX with a render-time warning (no native partial-index support). | |
+| `Index(fields=..., include=[...])` covering index | [Index](https://docs.djangoproject.com/en/6.0/ref/models/indexes/#django.db.models.Index.include) | SHIPPED | Optional `include = "col1, col2"` sub-attr on both `index_when(...)` and `unique_when(...)` (PR #605). Emits `CREATE INDEX (key_cols) INCLUDE (non_key_cols)` on PG 11+ for index-only scans without heap visits; MySQL/SQLite drop the clause with a `tracing::warn!`. `IndexSchema::include` + `IndexSnapshot::include` carry the columns through the inventory → diff → render pipeline. | |
 | `Meta.default_related_name` | [Meta#default_related_name](https://docs.djangoproject.com/en/6.0/ref/models/options/#default-related-name) | SHIPPED | `#[rustango(default_related_name = "snake_case_name")]` (PR #600) — stored on `ModelSchema::default_related_name`, validated snake_case at derive time. Declarative-only today; foundation for future reverse-manager codegen / DRF schema emit / admin template hookup. | |
 | `Meta.constraints` (CheckConstraint, UniqueConstraint, ExclusionConstraint) | [Constraints](https://docs.djangoproject.com/en/6.0/ref/models/constraints/) | SHIPPED | `#[rustango(check(name, expr))]` + `unique_when` (partial unique) + `#[rustango(exclude(name, using, elements, where))]` (PR #593, PG-only — MySQL/SQLite skip with `tracing::warn!`). | Row-level CHECK with full `Q(...)` lowering is still by-hand (write the SQL out in `expr`). |
 | `Meta.verbose_name` / `verbose_name_plural` | [Meta#verbose_name](https://docs.djangoproject.com/en/6.0/ref/models/options/#verbose-name) | SHIPPED | `#[rustango(verbose_name = "...", verbose_name_plural = "...")]` (#320, v0.42) — `ModelSchema::display_label()` + `display_label_plural()`; admin list / detail / form templates pick up the friendly captions via `model.label` / `model.label_plural` | |
@@ -79,7 +80,7 @@ Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, 
 | Self-referential FK | [Self FK](https://docs.djangoproject.com/en/6.0/ref/models/fields/#django.db.models.ForeignKey) | SHIPPED | `#[rustango(fk = "self")]` (v0.17.2) | Tested via `tests/self_fk_live.rs`. |
 | `ManyToManyField(through=...)` | [M2M through](https://docs.djangoproject.com/en/6.0/topics/db/models/#extra-fields-on-many-to-many-relationships) | SHIPPED | `#[rustango(m2m(... auto_create = false))]` (closed #324, v0.42). Operator declares the junction as its own `#[derive(Model)]` with extra columns; the migration writer skips emitting `CREATE TABLE` for that junction when `auto_create = false` (otherwise the through-model's own table would conflict). Implicit-junction path with `auto_create = true` (default) unchanged. | |
 
-Summary: **20 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-base field-inheritance (Rust idiom = trait composition; `#[rustango(managed = false)]` covers the operator-managed-table case via #321), MTI. ExclusionConstraint shipped in PR #593; `Meta.default_permissions` shipped in PR #594; `ForeignKey(on_delete=…)` explicit override shipped in PR #592.
+Summary: **21 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-base field-inheritance (Rust idiom = trait composition; `#[rustango(managed = false)]` covers the operator-managed-table case via #321), MTI. ExclusionConstraint shipped in PR #593; `Meta.default_permissions` shipped in PR #594; `ForeignKey(on_delete=…)` explicit override shipped in PR #592.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds Django-shape `Index(fields=..., include=[...])` covering-index parity. New optional `include = "col1, col2"` sub-attr on both `index_when(...)` and `unique_when(...)`. Lists non-key columns that travel with the index leaf so the planner can serve queries from the index alone — no heap visit.

## Render shape

- **PG 11+**: `CREATE INDEX <name> ON <table> (key_cols) INCLUDE (non_key_cols)`, emitted before the WHERE-suffix.
- **MySQL / SQLite**: the writer drops the clause + emits a `tracing::warn!` so the rest of the migration applies. Operators wanting covers on those backends should add the non-key columns to the key tuple (a redundant index).

## Pipeline

- `IndexSchema::include: &'static [&'static str]` populated by the macro.
- `IndexSnapshot::include: Vec<String>` carries the columns across migration files (serde-skipped when empty for older-snapshot compat).
- `SchemaChange::CreateIndex` gains `include: Vec<String>`. Diff detects include-only changes and emits Drop+Create.
- `migrate::diff::render`'s CreateIndex branch handles emission + per-dialect drop+warning.
- `migrate::invert::invert_op` carries `include` through the DropIndex → CreateIndex round-trip.

## Test plan

- [x] `cargo test --features postgres,tenancy --test index_include` — 3 / 3 pass locally
- [x] `cargo test --workspace --all-features --no-run` — pre-push gate green
- [x] `cargo build --no-default-features --features sqlite,tenancy` — litmus green
- [x] Audit doc Section 1 + cookbook 2.25.14 updated.