### PR TITLE
fix(cache): DatabaseCache stores expiry in milliseconds, not seconds

### DIFF
--- a/crates/rustango/src/cache/db_backend.rs
+++ b/crates/rustango/src/cache/db_backend.rs
@@ -127,16 +127,28 @@ impl DatabaseCache {
         Ok(())
     }
 
-    fn now_unix() -> i64 {
+    /// Unix epoch in **milliseconds**. Promoted from seconds in v0.42
+    /// to eliminate a second-boundary race: `set` at `HH:MM:SS.999`
+    /// followed by `get` at `HH:MM:SS+1.001` used to truncate both
+    /// readings to integer seconds (`SS` and `SS+1`), making a TTL of
+    /// 1 second look already-expired at the immediate read. The
+    /// `expires BIGINT` column stays the same — it now carries
+    /// millisecond ticks instead of second ticks; existing pre-v0.42
+    /// rows look like 1970-era timestamps under the new lens and are
+    /// lazily purged on first read (cache is regeneratable by design).
+    fn now_unix_ms() -> i64 {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
+            .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
             .unwrap_or(0)
     }
 
     fn expires_for(ttl: Option<Duration>) -> i64 {
-        ttl.map(|d| Self::now_unix().saturating_add(d.as_secs() as i64))
-            .unwrap_or(0)
+        ttl.map(|d| {
+            let ms = i64::try_from(d.as_millis()).unwrap_or(i64::MAX);
+            Self::now_unix_ms().saturating_add(ms)
+        })
+        .unwrap_or(0)
     }
 }
 
@@ -154,7 +166,7 @@ impl Cache for DatabaseCache {
         let Some((value, expires)) = rows.into_iter().next() else {
             return Ok(None);
         };
-        if expires != 0 && Self::now_unix() >= expires {
+        if expires != 0 && Self::now_unix_ms() >= expires {
             // Lazy GC — purge expired before reporting miss.
             let _ = self.delete(key).await;
             return Ok(None);
@@ -238,9 +250,14 @@ mod tests {
 
     #[test]
     fn expires_for_offsets_from_now() {
-        let before = DatabaseCache::now_unix();
+        // ms precision: a 60-second TTL adds 60_000 ms to the current
+        // unix-ms reading, bracketed by the surrounding observations.
+        let before = DatabaseCache::now_unix_ms();
         let ts = DatabaseCache::expires_for(Some(Duration::from_secs(60)));
-        let after = DatabaseCache::now_unix();
-        assert!(ts >= before + 60 && ts <= after + 60);
+        let after = DatabaseCache::now_unix_ms();
+        assert!(
+            ts >= before + 60_000 && ts <= after + 60_000,
+            "expected expires in [{before}+60_000, {after}+60_000], got {ts}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`DatabaseCache::expires` is a `BIGINT` Unix timestamp written + read by `now_unix()` + `expires_for()`. Both used `Duration::as_secs() as i64` — **integer-second precision**.

### The race

`set("k", "v", Some(Duration::from_secs(1)))` at `HH:MM:SS.999` writes `expires = SS+1`. An immediate `get` at `HH:MM:SS+1.001` reads its own `now_unix()` as `SS+1`, sees `now_unix() >= expires` (both `= SS+1`), purges the entry, and returns `None` — the freshly-set value vanishes inside a 2ms wall-clock window. Under CI load this fired often enough that `ttl_purges_lazily_on_read` failed intermittently on PR #605 (unrelated index_include changes).

### Fix

Store + compare expiry in **milliseconds**. `now_unix_ms()` reads `Duration::as_millis()`, clamped to `i64::MAX`; `expires_for(ttl)` adds `ttl.as_millis()`. The `expires BIGINT` column stays the same — it now carries millisecond ticks instead of second ticks.

### Upgrade path

Pre-v0.42 rows have second-shaped values (~1.7×10⁹). Read against the new ms-shaped `now_unix_ms()` (~1.7×10¹²), every old row's `expires` looks like 1970-era and gets lazily purged on first read. **Cache is regeneratable by design — no operator action required, no schema migration.**

## Test plan

- [x] `cargo test --features sqlite,tenancy,cache,config --test cache_db_backend_sqlite_live` — 7 / 7 pass with **original 1-second TTL** restored
- [x] `cargo test -p rustango --lib --features postgres,tenancy,cache,config` — 2417 / 2417 pass
- [x] `cargo build --no-default-features --features sqlite,tenancy` — litmus green

**Supersedes #608** (which bumped the test TTL to 3 seconds to avoid the race instead of fixing the underlying precision).