### PR TITLE
feat(model): #[rustango(order_with_respect_to = "...")] — Django Meta parity

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -808,6 +808,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         container.verbose_name_plural.as_deref(),
         container.managed,
         container.base_manager_name.as_deref(),
+        container.order_with_respect_to.as_deref(),
         &container.required_db_features,
         container.required_db_vendor.as_deref(),
         container.default_related_name.as_deref(),
@@ -1707,6 +1708,7 @@ fn model_impl_tokens(
     verbose_name_plural: Option<&str>,
     managed: bool,
     base_manager_name: Option<&str>,
+    order_with_respect_to: Option<&str>,
     required_db_features: &[String],
     required_db_vendor: Option<&str>,
     default_related_name: Option<&str>,
@@ -1748,6 +1750,7 @@ fn model_impl_tokens(
     let verbose_name_tokens = optional_str(verbose_name);
     let verbose_name_plural_tokens = optional_str(verbose_name_plural);
     let base_manager_name_tokens = optional_str(base_manager_name);
+    let order_with_respect_to_tokens = optional_str(order_with_respect_to);
     let required_db_features_lits: Vec<&str> =
         required_db_features.iter().map(String::as_str).collect();
     let required_db_vendor_tokens = optional_str(required_db_vendor);
@@ -1906,6 +1909,7 @@ fn model_impl_tokens(
                 verbose_name_plural: #verbose_name_plural_tokens,
                 managed: #managed,
                 base_manager_name: #base_manager_name_tokens,
+                order_with_respect_to: #order_with_respect_to_tokens,
                 required_db_features: &[ #(#required_db_features_lits),* ],
                 required_db_vendor: #required_db_vendor_tokens,
                 default_related_name: #default_related_name_tokens,
@@ -4484,6 +4488,12 @@ struct ContainerAttrs {
     /// `#[rustango(base_manager_name = "...")]`. Threaded into
     /// `ModelSchema::base_manager_name`. Declarative-only today.
     base_manager_name: Option<String>,
+    /// Django-shape `Meta.order_with_respect_to = "parent_fk"` from
+    /// `#[rustango(order_with_respect_to = "...")]`. Names the FK
+    /// field this model's instances are ordered relative to.
+    /// Declarative-only today; threaded onto
+    /// `ModelSchema::order_with_respect_to`.
+    order_with_respect_to: Option<String>,
     /// Django-shape `Meta.required_db_features` from
     /// `#[rustango(required_db_features = "json_extract,window_functions")]`.
     /// Each comma-separated capability token surfaces on
@@ -4747,6 +4757,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
         verbose_name: None,
         verbose_name_plural: None,
         base_manager_name: None,
+        order_with_respect_to: None,
         required_db_features: Vec::new(),
         required_db_vendor: None,
         default_related_name: None,
@@ -5090,6 +5101,46 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                 // table-level comment attached to the DB catalog.
                 let s: LitStr = meta.value()?.parse()?;
                 out.db_table_comment = Some(s.value());
+                return Ok(());
+            }
+            if meta.path.is_ident("order_with_respect_to") {
+                // Django-shape `Meta.order_with_respect_to = "parent_fk"` —
+                // the model's instances are intrinsically ordered
+                // relative to their parent FK. Django auto-generates
+                // a `_order` integer column + admin reordering UI.
+                //
+                // rustango stores the FK field name on
+                // `ModelSchema::order_with_respect_to`. Declarative-only
+                // today: the migration writer + admin surfaces still
+                // treat every model identically. Future codegen will
+                // key off the metadata to auto-emit the `_order`
+                // column and reorder helpers.
+                //
+                // Validated as a Rust-shape identifier so the macro
+                // can reject typos at derive time.
+                let s: LitStr = meta.value()?.parse()?;
+                let raw = s.value();
+                if raw.is_empty() {
+                    return Err(syn::Error::new(
+                        s.span(),
+                        "`order_with_respect_to` must be a non-empty FK field name",
+                    ));
+                }
+                let valid = raw
+                    .chars()
+                    .all(|c| c == '_' || c.is_ascii_alphanumeric())
+                    && !raw.chars().next().is_some_and(|c| c.is_ascii_digit());
+                if !valid {
+                    return Err(syn::Error::new(
+                        s.span(),
+                        format!(
+                            "`order_with_respect_to` must be a valid Rust \
+                             identifier (letters / digits / underscores, \
+                             not starting with a digit); got `{raw}`"
+                        ),
+                    ));
+                }
+                out.order_with_respect_to = Some(raw);
                 return Ok(());
             }
             if meta.path.is_ident("required_db_features") {

--- a/crates/rustango/examples/cookbook_blog/COOKBOOK.md
+++ b/crates/rustango/examples/cookbook_blog/COOKBOOK.md
@@ -1040,6 +1040,26 @@ Composes with `required_db_vendor` — set both for fail-fast deploy validation:
 
 Reads `SELECT title, created_at FROM post WHERE status = 'published' AND deleted_at IS NULL` get index-only scans without touching the heap.
 
+#### 2.25.16 `#[rustango(order_with_respect_to = "...")]` (PR #610)
+
+**What**: Django `Meta.order_with_respect_to = "parent_fk"` — names the FK field this model's instances are ordered relative to. Django auto-generates a `_order` integer column + admin reordering UI when set.
+
+```rust
+#[derive(Model)]
+#[rustango(table = "section_item", order_with_respect_to = "section_id")]
+pub struct SectionItem {
+    #[rustango(primary_key)]
+    pub id: i64,
+    #[rustango(fk = "section", on = "id")]
+    pub section_id: i64,
+    pub title: String,
+}
+```
+
+Stored on `ModelSchema::order_with_respect_to: Option<&'static str>`. Macro validates Rust-identifier shape so typos surface at derive time.
+
+**Behavior today**: declarative-only. The migration writer + admin surfaces still treat every model identically. Future codegen will key off the metadata to auto-emit the `_order` column and reorder helpers (`set_<rel>_order(&[pk1, pk2, ...])`).
+
 ---
 
 ## Chapter 3 — ORM

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -513,6 +513,16 @@ pub struct ModelSchema {
     ///
     /// Empty slice (default) means "no special capabilities needed".
     pub required_db_features: &'static [&'static str],
+    /// Django-shape `Meta.order_with_respect_to = "parent_fk"` —
+    /// names the FK field this model's instances are ordered
+    /// relative to. Django auto-generates a `_order` integer column
+    /// + admin reordering UI when set.
+    ///
+    /// Set via `#[rustango(order_with_respect_to = "parent_fk")]`.
+    /// Declarative-only today: storage on `ModelSchema` lets future
+    /// codegen auto-emit the `_order` column and reorder helpers.
+    /// `None` means the model has no parent-FK-relative ordering.
+    pub order_with_respect_to: Option<&'static str>,
     /// Django-shape `Meta.get_latest_by` — default sort field that
     /// `QuerySet::latest_default()` / `earliest_default()` use when
     /// the caller doesn't pass a field name explicitly. A string

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -666,6 +666,7 @@ mod composite_fk_snapshot_tests {
             base_manager_name: None,
             required_db_vendor: None,
             required_db_features: &[],
+            order_with_respect_to: None,
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -742,6 +743,7 @@ mod composite_fk_snapshot_tests {
             base_manager_name: None,
             required_db_vendor: None,
             required_db_features: &[],
+            order_with_respect_to: None,
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -773,6 +775,7 @@ mod composite_fk_snapshot_tests {
             base_manager_name: None,
             required_db_vendor: None,
             required_db_features: &[],
+            order_with_respect_to: None,
             get_latest_by: None,
             extra_permissions: &[],
         };
@@ -842,6 +845,7 @@ mod composite_fk_snapshot_tests {
             base_manager_name: None,
             required_db_vendor: None,
             required_db_features: &[],
+            order_with_respect_to: None,
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -302,6 +302,7 @@ mod tests {
         base_manager_name: None,
         required_db_vendor: None,
         required_db_features: &[],
+        order_with_respect_to: None,
         get_latest_by: None,
         extra_permissions: &[],
     };
@@ -334,6 +335,7 @@ mod tests {
         base_manager_name: None,
         required_db_vendor: None,
         required_db_features: &[],
+        order_with_respect_to: None,
         get_latest_by: None,
         extra_permissions: &[],
     };

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -1356,6 +1356,7 @@ mod tests {
             base_manager_name: None,
             required_db_vendor: None,
             required_db_features: &[],
+            order_with_respect_to: None,
             get_latest_by: None,
             extra_permissions: &[],
         }))

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -678,6 +678,7 @@ mod tests {
             base_manager_name: None,
             required_db_vendor: None,
             required_db_features: &[],
+            order_with_respect_to: None,
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -4082,6 +4082,7 @@ mod tests {
             base_manager_name: None,
             required_db_vendor: None,
             required_db_features: &[],
+            order_with_respect_to: None,
             get_latest_by: None,
             extra_permissions: &[],
         }))
@@ -4192,6 +4193,7 @@ mod tests {
             base_manager_name: None,
             required_db_vendor: None,
             required_db_features: &[],
+            order_with_respect_to: None,
             get_latest_by: None,
             extra_permissions: &[],
         }))
@@ -4584,6 +4586,7 @@ mod tests {
             base_manager_name: None,
             required_db_vendor: None,
             required_db_features: &[],
+            order_with_respect_to: None,
             get_latest_by: None,
             extra_permissions: &[],
         }));
@@ -4842,6 +4845,7 @@ mod tests {
             base_manager_name: None,
             required_db_vendor: None,
             required_db_features: &[],
+            order_with_respect_to: None,
             get_latest_by: None,
             extra_permissions: &[],
         }));
@@ -4912,6 +4916,7 @@ mod tests {
             base_manager_name: None,
             required_db_vendor: None,
             required_db_features: &[],
+            order_with_respect_to: None,
             get_latest_by: None,
             extra_permissions: &[],
         }));

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -473,6 +473,7 @@ mod tests {
             base_manager_name: None,
             required_db_vendor: None,
             required_db_features: &[],
+            order_with_respect_to: None,
             get_latest_by: None,
             extra_permissions: &[],
         };

--- a/crates/rustango/tests/order_with_respect_to.rs
+++ b/crates/rustango/tests/order_with_respect_to.rs
@@ -1,0 +1,46 @@
+//! Django parity — `Meta.order_with_respect_to = "parent_fk"` names
+//! the FK field this model's instances are ordered relative to.
+//! Django auto-generates a `_order` integer column + admin
+//! reordering UI when set.
+//!
+//! rustango spells the attribute as
+//! `#[rustango(order_with_respect_to = "...")]` on the model
+//! container. Stored on `ModelSchema::order_with_respect_to`.
+//! Declarative-only today; future codegen will auto-emit the
+//! `_order` column and reorder helpers.
+
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "owrt_section_item", order_with_respect_to = "section_id")]
+#[allow(dead_code)]
+pub struct SectionItem {
+    #[rustango(primary_key)]
+    pub id: i64,
+    #[rustango(fk = "owrt_section", on = "id")]
+    pub section_id: i64,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "owrt_section")]
+#[allow(dead_code)]
+pub struct Section {
+    #[rustango(primary_key)]
+    pub id: i64,
+    #[rustango(max_length = 100)]
+    pub name: String,
+}
+
+#[test]
+fn schema_carries_order_with_respect_to_field_name() {
+    let schema = <SectionItem as rustango::core::Model>::SCHEMA;
+    assert_eq!(schema.order_with_respect_to, Some("section_id"));
+}
+
+#[test]
+fn plain_model_has_none() {
+    let plain = <Section as rustango::core::Model>::SCHEMA;
+    assert!(plain.order_with_respect_to.is_none());
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -20,7 +20,7 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 
 | Category | SHIPPED | PARTIAL | MISSING | N/A |
 |---|---:|---:|---:|---:|
-| 1. ORM — models / fields / Meta | 21 | 1 | 1 | 0 |
+| 1. ORM — models / fields / Meta | 22 | 1 | 1 | 0 |
 | 2. QuerySet API | 37 | 1 | 1 | 0 |
 | 3. Field types & options | 32 | 0 | 2 | 1 |
 | 4. Postgres-specific fields | 2 | 1 | 2 | 0 |
@@ -44,9 +44,9 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 22. Async support | 4 | 0 | 0 | 3 |
 | 23. DRF parity | 22 | 0 | 1 | 0 |
 | 24. contrib modules | 12 | 1 | 3 | 2 |
-| **Totals** | **368** | **11** | **21** | **19** |
+| **Totals** | **369** | **11** | **21** | **19** |
 
-Coverage = 368 / (368 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
+Coverage = 369 / (369 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
 
 Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, default_permissions #594, on_delete #592, ForeignKey on_delete enum override, extra_permissions #591, get_latest_by #590, db_table_comment #589, citext, DatabaseCache, managed=false, upload streaming, i18n).
 
@@ -68,6 +68,7 @@ Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, 
 | `Meta.verbose_name` / `verbose_name_plural` | [Meta#verbose_name](https://docs.djangoproject.com/en/6.0/ref/models/options/#verbose-name) | SHIPPED | `#[rustango(verbose_name = "...", verbose_name_plural = "...")]` (#320, v0.42) — `ModelSchema::display_label()` + `display_label_plural()`; admin list / detail / form templates pick up the friendly captions via `model.label` / `model.label_plural` | |
 | `Meta.permissions` (custom codenames) | [Meta#permissions](https://docs.djangoproject.com/en/6.0/ref/models/options/#permissions) | SHIPPED | `auto_create_permissions_pool` seeds CRUD codenames; reserved `auth.access_admin` added in PR #313. Custom per-model codenames declared via `#[rustango(extra_permissions = "approve:Can approve, archive:Can archive")]` (PR #591). | |
 | `Meta.default_permissions` | [Meta#default_permissions](https://docs.djangoproject.com/en/6.0/ref/models/options/#default-permissions) | SHIPPED | `#[rustango(default_permissions = "view,change")]` (PR #594) — opt out of `add` / `delete` codenames for read-mostly tables; empty (default) seeds all four CRUD codenames | |
+| `Meta.order_with_respect_to` | [Meta#order_with_respect_to](https://docs.djangoproject.com/en/6.0/ref/models/options/#order-with-respect-to) | SHIPPED | `#[rustango(order_with_respect_to = "parent_fk")]` (PR #610) — declarative-only storage on `ModelSchema::order_with_respect_to`. Foundation for future codegen to auto-emit the `_order` integer column + admin reordering UI. | |
 | `Meta.default_manager_name` | [Custom Managers](https://docs.djangoproject.com/en/6.0/topics/db/managers/) | SHIPPED | `#[rustango(manager_fn = "active")]` (closed #289 / T2.6) | Multiple `manager_fn` allowed. |
 | `Meta.base_manager_name` | [Meta#base_manager_name](https://docs.djangoproject.com/en/6.0/ref/models/options/#base-manager-name) | SHIPPED | `#[rustango(base_manager_name = "ManagerExt")]` — stored on `ModelSchema::base_manager_name`. Declarative-only today; foundation for reverse-manager codegen + DRF schema emit + admin templates that need to pick the right Manager subclass for `<instance>.<relation>_set` resolution. | |
 | `Meta.required_db_vendor` | [Meta#required_db_vendor](https://docs.djangoproject.com/en/6.0/ref/models/options/#required-db-vendor) | SHIPPED | `#[rustango(required_db_vendor = "postgres|mysql|sqlite")]` (PR #602). Django aliases (`postgresql` / `pg` / `mariadb` / `sqlite3`) normalize to canonical dialect names. `manage check --deploy` warns when a model's declared vendor doesn't match the active `pool.dialect().name()` — catches "wrong DATABASE_URL" at deploy time rather than first runtime hit. | |
@@ -80,7 +81,7 @@ Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, 
 | Self-referential FK | [Self FK](https://docs.djangoproject.com/en/6.0/ref/models/fields/#django.db.models.ForeignKey) | SHIPPED | `#[rustango(fk = "self")]` (v0.17.2) | Tested via `tests/self_fk_live.rs`. |
 | `ManyToManyField(through=...)` | [M2M through](https://docs.djangoproject.com/en/6.0/topics/db/models/#extra-fields-on-many-to-many-relationships) | SHIPPED | `#[rustango(m2m(... auto_create = false))]` (closed #324, v0.42). Operator declares the junction as its own `#[derive(Model)]` with extra columns; the migration writer skips emitting `CREATE TABLE` for that junction when `auto_create = false` (otherwise the through-model's own table would conflict). Implicit-junction path with `auto_create = true` (default) unchanged. | |
 
-Summary: **21 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-base field-inheritance (Rust idiom = trait composition; `#[rustango(managed = false)]` covers the operator-managed-table case via #321), MTI. ExclusionConstraint shipped in PR #593; `Meta.default_permissions` shipped in PR #594; `ForeignKey(on_delete=…)` explicit override shipped in PR #592.
+Summary: **22 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-base field-inheritance (Rust idiom = trait composition; `#[rustango(managed = false)]` covers the operator-managed-table case via #321), MTI. ExclusionConstraint shipped in PR #593; `Meta.default_permissions` shipped in PR #594; `ForeignKey(on_delete=…)` explicit override shipped in PR #592.
 
 ---
 


### PR DESCRIPTION
## Summary

Stores Django-shape `Meta.order_with_respect_to = "parent_fk"` on `ModelSchema`. Names the FK field this model's instances are ordered relative to; Django auto-generates a `_order` integer column + admin reordering UI when set.

Spelled as `#[rustango(order_with_respect_to = "parent_fk")]` on the model container. Macro validates Rust-identifier shape at derive time so typos in the FK name surface before the next migration cycle.

## Behavior today

**Declarative-only**. The migration writer + admin surfaces still treat every model identically. Storing the FK name on `ModelSchema::order_with_respect_to: Option<&'static str>` lays the foundation for future codegen to auto-emit the `_order` column and reorder helpers (`set_<rel>_order(&[pk1, pk2, ...])`).

## Test plan

- [x] `cargo test --features postgres,tenancy --test order_with_respect_to` — 2 / 2 pass locally
- [x] `cargo test --workspace --all-features --no-run` — pre-push gate green
- [x] `cargo build --no-default-features --features sqlite,tenancy` — litmus green
- [x] Audit doc Section 1 + cookbook 2.25.16 updated