### PR TITLE
feat(security): host_validation middleware — Django ALLOWED_HOSTS parity

### DIFF
--- a/crates/rustango/src/host_validation.rs
+++ b/crates/rustango/src/host_validation.rs
@@ -1,0 +1,274 @@
+//! Host-header allowlist middleware — Django parity for the
+//! `ALLOWED_HOSTS` setting + the host-validation step
+//! `SecurityMiddleware` runs implicitly before every view.
+//!
+//! Django gate: when `ALLOWED_HOSTS` is set, any request whose
+//! `Host:` header isn't in the list is rejected with a 400. The
+//! list supports exact-host entries (`example.com`), dot-prefix
+//! subdomain wildcards (`.example.com` matches `api.example.com`
+//! AND `example.com` itself), and the lone catch-all `*`.
+//!
+//! ## Quick start
+//!
+//! ```ignore
+//! use rustango::host_validation::{AllowedHostsLayer, AllowedHostsRouterExt};
+//!
+//! let app = Router::new()
+//!     .route("/", get(home))
+//!     .allowed_hosts(AllowedHostsLayer::new([
+//!         "example.com",
+//!         ".example.com",       // any subdomain
+//!         "localhost",
+//!     ]));
+//! ```
+//!
+//! Requests with a missing or non-matching `Host` header receive a
+//! `400 Bad Request` body that mirrors Django's `DisallowedHost`
+//! message; the exact host echoes back to ease ops debugging without
+//! leaking which hosts are allowed.
+//!
+//! ## Settings wiring
+//!
+//! `Settings.security.allowed_hosts: Vec<String>` (already parsed by
+//! `env::list("ALLOWED_HOSTS")`) feeds the layer via
+//! [`AllowedHostsLayer::from_settings_list`]. Empty list disables
+//! validation — matches Django's "DEBUG=True allows all" behavior
+//! by convention, but rustango doesn't have a DEBUG flag so the
+//! operator must opt in explicitly.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::Request;
+use axum::http::{Response, StatusCode};
+use axum::middleware::Next;
+use axum::Router;
+
+/// One allowed-host entry. Owns the comparison logic so the
+/// matching loop stays cheap (no per-request allocation).
+#[derive(Clone, Debug)]
+enum Pattern {
+    /// Catch-all `*` — every host matches. Use sparingly.
+    Wildcard,
+    /// Exact match: `Host` header (lowercased) equals this string.
+    Exact(String),
+    /// Dot-prefix wildcard `.example.com` — matches `example.com`
+    /// itself plus any subdomain (`api.example.com`,
+    /// `a.b.example.com`). The stored string omits the leading dot.
+    Subdomain(String),
+}
+
+impl Pattern {
+    fn parse(entry: &str) -> Option<Self> {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            return None;
+        }
+        if entry == "*" {
+            return Some(Self::Wildcard);
+        }
+        if let Some(rest) = entry.strip_prefix('.') {
+            if rest.is_empty() {
+                return None;
+            }
+            return Some(Self::Subdomain(rest.to_ascii_lowercase()));
+        }
+        Some(Self::Exact(entry.to_ascii_lowercase()))
+    }
+
+    fn matches(&self, host: &str) -> bool {
+        match self {
+            Self::Wildcard => true,
+            Self::Exact(h) => host == h,
+            Self::Subdomain(tail) => {
+                // `tail` does not include the leading dot. Match
+                // `tail` itself (the base domain) or any host whose
+                // suffix is `.<tail>` (avoids matching
+                // `eviltail.com` against `.tail.com`).
+                host == tail
+                    || host
+                        .strip_suffix(tail)
+                        .is_some_and(|prefix| prefix.ends_with('.'))
+            }
+        }
+    }
+}
+
+/// Tower-layer-equivalent configuration. Holds the parsed pattern
+/// list; applied via [`AllowedHostsRouterExt::allowed_hosts`].
+#[derive(Clone)]
+pub struct AllowedHostsLayer {
+    patterns: Arc<Vec<Pattern>>,
+}
+
+impl AllowedHostsLayer {
+    /// Build a layer from a list of allowed-host entries. Entries
+    /// support exact-match hostnames, `.example.com` subdomain
+    /// wildcards, and the lone catch-all `*`. Empty / whitespace
+    /// entries are silently dropped.
+    #[must_use]
+    pub fn new<I, S>(entries: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let patterns: Vec<Pattern> = entries
+            .into_iter()
+            .filter_map(|s| Pattern::parse(s.as_ref()))
+            .collect();
+        Self {
+            patterns: Arc::new(patterns),
+        }
+    }
+
+    /// Convenience: wire from `Settings.security.allowed_hosts`. An
+    /// empty list disables the layer (every host passes) — matches
+    /// the "no ALLOWED_HOSTS configured → no enforcement" shape
+    /// Django uses with `DEBUG=True`.
+    #[must_use]
+    pub fn from_settings_list<I, S>(entries: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Self::new(entries)
+    }
+
+    /// `true` when the configured list permits this host header.
+    /// Empty list passes every host (operator opted out of
+    /// validation by leaving the setting empty).
+    #[must_use]
+    pub fn permits(&self, host: &str) -> bool {
+        if self.patterns.is_empty() {
+            return true;
+        }
+        let host = strip_port(host).to_ascii_lowercase();
+        self.patterns.iter().any(|p| p.matches(&host))
+    }
+}
+
+/// Strip a trailing `:<port>` from a Host-header value so the
+/// allowlist comparison ignores it. Returns the input untouched if
+/// no port is present. Handles bracketed IPv6 literals too.
+fn strip_port(host: &str) -> &str {
+    if let Some(rest) = host.strip_prefix('[') {
+        // IPv6 literal: `[::1]:8080` → strip from the closing bracket.
+        if let Some(end) = rest.find(']') {
+            return &host[..end + 2.min(host.len())];
+        }
+        return host;
+    }
+    match host.rfind(':') {
+        Some(i) => &host[..i],
+        None => host,
+    }
+}
+
+/// Router extension trait — `.allowed_hosts(layer)`.
+pub trait AllowedHostsRouterExt {
+    #[must_use]
+    fn allowed_hosts(self, layer: AllowedHostsLayer) -> Self;
+}
+
+impl<S: Clone + Send + Sync + 'static> AllowedHostsRouterExt for Router<S> {
+    fn allowed_hosts(self, layer: AllowedHostsLayer) -> Self {
+        let cfg = Arc::new(layer);
+        self.layer(axum::middleware::from_fn(
+            move |req: Request<Body>, next: Next| {
+                let cfg = cfg.clone();
+                async move { handle(cfg, req, next).await }
+            },
+        ))
+    }
+}
+
+async fn handle(cfg: Arc<AllowedHostsLayer>, req: Request<Body>, next: Next) -> Response<Body> {
+    let host = req
+        .headers()
+        .get(axum::http::header::HOST)
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("");
+    if cfg.permits(host) {
+        next.run(req).await
+    } else {
+        let msg = format!(
+            "DisallowedHost: rejected Host header {host:?} — \
+             add it to Settings.security.allowed_hosts to allow"
+        );
+        let mut resp = Response::new(Body::from(msg));
+        *resp.status_mut() = StatusCode::BAD_REQUEST;
+        resp
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_list_passes_every_host() {
+        let layer = AllowedHostsLayer::new(Vec::<String>::new());
+        assert!(layer.permits("anywhere.example.com"));
+        assert!(layer.permits(""));
+    }
+
+    #[test]
+    fn exact_match_is_case_insensitive() {
+        let layer = AllowedHostsLayer::new(["Example.COM"]);
+        assert!(layer.permits("example.com"));
+        assert!(layer.permits("EXAMPLE.com"));
+        assert!(!layer.permits("api.example.com"));
+    }
+
+    #[test]
+    fn dot_prefix_wildcard_matches_subdomains_plus_base() {
+        let layer = AllowedHostsLayer::new([".example.com"]);
+        assert!(layer.permits("example.com"));
+        assert!(layer.permits("api.example.com"));
+        assert!(layer.permits("a.b.example.com"));
+        // Tricky case Django gets right: an unrelated host that
+        // *ends with* "example.com" but isn't a subdomain shouldn't
+        // match. `evilexample.com` ends with `example.com` but the
+        // boundary char isn't a dot.
+        assert!(!layer.permits("evilexample.com"));
+    }
+
+    #[test]
+    fn star_is_catchall() {
+        let layer = AllowedHostsLayer::new(["*"]);
+        assert!(layer.permits("anything"));
+        assert!(layer.permits("attacker.com"));
+    }
+
+    #[test]
+    fn port_is_stripped_before_comparison() {
+        let layer = AllowedHostsLayer::new(["example.com"]);
+        assert!(layer.permits("example.com:8080"));
+        assert!(layer.permits("example.com:443"));
+    }
+
+    #[test]
+    fn ipv6_with_port_is_handled() {
+        let layer = AllowedHostsLayer::new(["[::1]"]);
+        assert!(layer.permits("[::1]:8080"));
+    }
+
+    #[test]
+    fn whitespace_entries_are_ignored() {
+        let layer = AllowedHostsLayer::new(["", "   ", "example.com"]);
+        // Only the real entry counts; non-matching hosts still get
+        // rejected.
+        assert!(layer.permits("example.com"));
+        assert!(!layer.permits("attacker.com"));
+    }
+
+    #[test]
+    fn rejected_host_does_not_match_other_patterns_in_list() {
+        let layer = AllowedHostsLayer::new(["a.com", ".b.com", "c.com"]);
+        assert!(layer.permits("a.com"));
+        assert!(layer.permits("foo.b.com"));
+        assert!(layer.permits("c.com"));
+        assert!(!layer.permits("d.com"));
+        assert!(!layer.permits("malicious.a.com"));
+    }
+}

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -706,6 +706,11 @@ pub mod request_id;
 #[cfg(feature = "admin")]
 pub mod ip_filter;
 
+/// Host-header allowlist middleware — Django `ALLOWED_HOSTS` parity.
+/// See [`host_validation::AllowedHostsLayer`].
+#[cfg(feature = "admin")]
+pub mod host_validation;
+
 /// Request body size limit middleware — fast `Content-Length` rejection
 /// returning structured `413 Payload Too Large` JSON. Complements
 /// axum's per-extractor `DefaultBodyLimit`. See [`body_limit::BodyLimitLayer`].

--- a/crates/rustango/tests/host_validation_live.rs
+++ b/crates/rustango/tests/host_validation_live.rs
@@ -1,0 +1,100 @@
+//! Integration test for the host-validation middleware — Django
+//! `ALLOWED_HOSTS` parity. Mounts the layer on an axum Router, sends
+//! requests with various Host headers via tower's oneshot, and
+//! asserts the gate semantics:
+//!
+//! * Exact host → 200
+//! * Subdomain (via `.example.com`) → 200
+//! * Mismatched host → 400 with the Django-shape error body
+//! * Missing Host header → 400 (allowlist is non-empty)
+//! * Empty allowlist → every host passes (DEBUG-style opt-out)
+
+#![cfg(feature = "admin")]
+
+use axum::body::Body;
+use axum::http::{HeaderValue, Request, StatusCode};
+use axum::routing::get;
+use axum::Router;
+use rustango::host_validation::{AllowedHostsLayer, AllowedHostsRouterExt};
+use tower::ServiceExt;
+
+fn build_app(layer: AllowedHostsLayer) -> Router {
+    Router::new()
+        .route("/", get(|| async { "ok" }))
+        .allowed_hosts(layer)
+}
+
+async fn run(app: Router, host: Option<&str>) -> StatusCode {
+    let mut req = Request::builder().uri("/").method("GET");
+    if let Some(h) = host {
+        req = req.header("Host", HeaderValue::from_str(h).unwrap());
+    }
+    let req = req.body(Body::empty()).unwrap();
+    app.oneshot(req).await.unwrap().status()
+}
+
+#[tokio::test]
+async fn exact_host_passes() {
+    let app = build_app(AllowedHostsLayer::new(["example.com"]));
+    assert_eq!(run(app, Some("example.com")).await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn subdomain_via_dot_prefix_passes() {
+    let app = build_app(AllowedHostsLayer::new([".example.com"]));
+    assert_eq!(run(app, Some("api.example.com")).await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn subdomain_pattern_also_matches_base() {
+    let app = build_app(AllowedHostsLayer::new([".example.com"]));
+    assert_eq!(run(app, Some("example.com")).await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn mismatched_host_returns_400() {
+    let app = build_app(AllowedHostsLayer::new(["example.com"]));
+    assert_eq!(
+        run(app, Some("attacker.com")).await,
+        StatusCode::BAD_REQUEST
+    );
+}
+
+#[tokio::test]
+async fn host_header_with_port_strips_and_matches() {
+    let app = build_app(AllowedHostsLayer::new(["example.com"]));
+    assert_eq!(run(app, Some("example.com:8443")).await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn missing_host_header_is_rejected_when_list_is_set() {
+    let app = build_app(AllowedHostsLayer::new(["example.com"]));
+    assert_eq!(run(app, None).await, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn empty_list_disables_validation() {
+    let app = build_app(AllowedHostsLayer::new(Vec::<String>::new()));
+    assert_eq!(
+        run(app.clone(), Some("anywhere.example")).await,
+        StatusCode::OK
+    );
+    assert_eq!(run(app, None).await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn star_passes_every_host() {
+    let app = build_app(AllowedHostsLayer::new(["*"]));
+    assert_eq!(run(app, Some("attacker.com")).await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn suffix_collision_does_not_match_subdomain_pattern() {
+    // `.example.com` must not match `evilexample.com` — that's a
+    // Django-bug-shaped pitfall. Verify the dot-boundary check.
+    let app = build_app(AllowedHostsLayer::new([".example.com"]));
+    assert_eq!(
+        run(app, Some("evilexample.com")).await,
+        StatusCode::BAD_REQUEST
+    );
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -34,7 +34,7 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 12. Sessions | 7 | 0 | 0 | 0 |
 | 13. Manage commands | 20 | 0 | 3 | 6 |
 | 14. Settings | 13 | 2 | 2 | 2 |
-| 15. Security / middleware | 26 | 0 | 0 | 0 |
+| 15. Security / middleware | 27 | 0 | 0 | 0 |
 | 16. Caching | 9 | 0 | 1 | 0 |
 | 17. Signals | 10 | 0 | 0 | 1 |
 | 18. Email | 11 | 0 | 0 | 0 |
@@ -44,9 +44,9 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 22. Async support | 4 | 0 | 0 | 3 |
 | 23. DRF parity | 22 | 0 | 1 | 0 |
 | 24. contrib modules | 12 | 1 | 3 | 2 |
-| **Totals** | **368** | **11** | **21** | **19** |
+| **Totals** | **369** | **11** | **21** | **19** |
 
-Coverage = 368 / (368 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
+Coverage = 369 / (369 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
 
 Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, default_permissions #594, on_delete #592, ForeignKey on_delete enum override, extra_permissions #591, get_latest_by #590, db_table_comment #589, citext, DatabaseCache, managed=false, upload streaming, i18n).
 
@@ -494,12 +494,13 @@ Summary: **13 SHIPPED / 2 PARTIAL / 2 MISSING / 2 N/A**. Multi-DB routing is the
 | OpenTelemetry / traceparent | n/a | SHIPPED | `tracing_layer::*` | |
 | Body size limit | [DATA_UPLOAD_MAX_MEMORY_SIZE](https://docs.djangoproject.com/en/6.0/ref/settings/#data-upload-max-memory-size) | SHIPPED | `body_limit::*` | |
 | IP allowlist / blocklist | n/a | SHIPPED | `ip_filter::*` | |
+| `ALLOWED_HOSTS` (Host-header validation) | [ALLOWED_HOSTS](https://docs.djangoproject.com/en/6.0/ref/settings/#allowed-hosts) | SHIPPED | `host_validation::AllowedHostsLayer` (PR #611) — exact + `.example.com` subdomain wildcard + `*` catch-all; case-insensitive; port-stripped; empty list disables enforcement (DEBUG-style opt-out). Rejects unknown hosts with a 400 echoing the Django `DisallowedHost` shape. | |
 | Server-Timing header | n/a | SHIPPED | `server_timing::*` | |
 | CSP nonce | [CSP](https://docs.djangoproject.com/en/6.0/topics/security/#content-security-policy) | SHIPPED | `csp_nonce::*` middleware | |
 | `SECURE_PROXY_SSL_HEADER` | [proxy headers](https://docs.djangoproject.com/en/6.0/ref/settings/#secure-proxy-ssl-header) | SHIPPED | Real-IP layer handles it | |
 | API versioning (header / query / prefix) | n/a | SHIPPED | `api_version::*` | |
 
-Summary: **26 SHIPPED / 0 PARTIAL / 0 MISSING / 0 N/A** for the dimensions enumerated. Rustango is notably ahead on per-request observability + CSRF / rate limiting / CSP / OTel out-of-the-box.
+Summary: **27 SHIPPED / 0 PARTIAL / 0 MISSING / 0 N/A** for the dimensions enumerated. Rustango is notably ahead on per-request observability + CSRF / rate limiting / CSP / OTel out-of-the-box.
 
 ---
 


### PR DESCRIPTION
## Summary

New `host_validation::AllowedHostsLayer` tower middleware enforces a Django-shape `ALLOWED_HOSTS` allowlist on incoming requests. Closes a real security gap: `env::list("ALLOWED_HOSTS")` already parsed the setting, but no middleware ever enforced it.

## Pattern grammar

Mirrors Django's `ALLOWED_HOSTS`:

- **Exact host**: `"example.com"` matches only that hostname.
- **Dot-prefix subdomain wildcard**: `".example.com"` matches both `example.com` AND any subdomain (`api.example.com`, `a.b.example.com`). Correctly rejects `evilexample.com` — boundary char must be a dot (this is a Django-bug-shaped pitfall the test suite covers).
- **Catch-all `"*"`** — opt out of validation.

Comparisons are case-insensitive; ports stripped before matching (including bracketed IPv6 literals); an empty allowlist disables enforcement (DEBUG-style opt-out — operator must explicitly populate the list to gate).

## Behavior

Mismatched / missing Host returns `400 Bad Request` with a body mirroring Django's `DisallowedHost` message; the rejected host echoes back to ease ops debugging without leaking which hosts are allowed.

## Wiring

```rust
use rustango::host_validation::{AllowedHostsLayer, AllowedHostsRouterExt};

let app = Router::new()
    .route("/", get(home))
    .allowed_hosts(AllowedHostsLayer::new([
        "example.com",
        ".example.com",       // any subdomain
        "localhost",
    ]));
```

Settings convenience: `from_settings_list(...)` accepts the parsed `Settings.security.allowed_hosts: Vec<String>` directly.

## Test plan

- [x] `cargo test --features postgres,tenancy,admin --lib host_validation` — 8 unit tests on pattern parsing, port stripping, IPv6, empty-list opt-out, suffix-collision guard
- [x] `cargo test --features postgres,tenancy,admin --test host_validation_live` — 9 axum integration tests on the full Router + oneshot path
- [x] `cargo build --no-default-features --features sqlite,tenancy` — litmus green
- [x] Audit doc Section 15 row added