### PR TITLE
feat(csrf): CSRF_TRUSTED_ORIGINS + Origin-header check — Django parity

### DIFF
--- a/crates/rustango/src/forms/csrf.rs
+++ b/crates/rustango/src/forms/csrf.rs
@@ -101,6 +101,23 @@ pub struct CsrfConfig {
     /// `manage check --deploy` continues to warn when this is `false`
     /// on a prod tier.
     pub secure: bool,
+    /// Django-parity `CSRF_TRUSTED_ORIGINS` — extra origins that may
+    /// submit cross-origin POSTs without being rejected by the
+    /// Origin-header check. Each entry is a scheme+host (optionally
+    /// with port), e.g. `"https://app.example.com"` or
+    /// `"https://*.example.com"` for a wildcard subdomain.
+    ///
+    /// Default `[]` (empty) — disables the Origin-header check
+    /// entirely so existing deployments don't break. To enable
+    /// defense-in-depth Origin-based CSRF protection, populate this
+    /// list with at least the application's own canonical origin.
+    ///
+    /// When non-empty, the layer ALSO accepts the request's own
+    /// Host header as an implicit trusted origin (same-origin
+    /// requests always pass). Defense-in-depth: even if an XSS
+    /// attacker steals the cookie token, they can't submit from a
+    /// different origin.
+    pub trusted_origins: Vec<String>,
 }
 
 impl Default for CsrfConfig {
@@ -109,6 +126,7 @@ impl Default for CsrfConfig {
             cookie_name: CSRF_COOKIE.to_owned(),
             header_name: CSRF_HEADER.to_owned(),
             secure: true,
+            trusted_origins: Vec::new(),
         }
     }
 }
@@ -123,6 +141,106 @@ impl CsrfConfig {
         self.secure = false;
         self
     }
+
+    /// Builder — append a trusted origin (scheme+host, optionally
+    /// `*.` wildcard subdomain). Django-parity for
+    /// `CSRF_TRUSTED_ORIGINS`.
+    #[must_use]
+    pub fn trust_origin(mut self, origin: impl Into<String>) -> Self {
+        self.trusted_origins.push(origin.into());
+        self
+    }
+
+    /// Builder — replace the trusted-origins list wholesale.
+    /// Convenient when wiring from settings:
+    /// `CsrfConfig::default().with_trusted_origins(settings.security.csrf_trusted_origins.clone())`.
+    #[must_use]
+    pub fn with_trusted_origins<I, S>(mut self, origins: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.trusted_origins = origins.into_iter().map(Into::into).collect();
+        self
+    }
+}
+
+/// Origin-header check — defense-in-depth over the double-submit
+/// cookie. Returns `true` if the request's Origin header is allowed:
+///
+/// * No Origin header → allow (some clients / curl don't send it).
+/// * Origin scheme+host matches the request's Host header → allow
+///   (same-origin POST is the common case).
+/// * Origin matches an entry in `trusted_origins` (exact or
+///   `*.subdomain.example.com` wildcard) → allow.
+/// * Anything else → reject.
+///
+/// When `trusted_origins` is empty, the layer skips the check
+/// entirely (back-compat default) — the Origin header alone is
+/// not consulted.
+fn origin_allowed(req: &Request<Body>, trusted: &[String]) -> bool {
+    if trusted.is_empty() {
+        return true;
+    }
+    let Some(origin) = req
+        .headers()
+        .get(axum::http::header::ORIGIN)
+        .and_then(|h| h.to_str().ok())
+    else {
+        // No Origin header — fall back to legacy behavior. Browsers
+        // always send Origin on cross-origin POST, so the missing
+        // case is curl / server-to-server which already gets
+        // protected by the double-submit token check.
+        return true;
+    };
+    // Same-origin: Origin's host matches the request's Host header.
+    if let Some(host) = req
+        .headers()
+        .get(axum::http::header::HOST)
+        .and_then(|h| h.to_str().ok())
+    {
+        let origin_host = origin
+            .split("://")
+            .nth(1)
+            .unwrap_or(origin)
+            .trim_end_matches('/');
+        if origin_host == host {
+            return true;
+        }
+    }
+    // Trusted-origin allowlist. Support `*.example.com` wildcard.
+    for entry in trusted {
+        let entry = entry.trim().trim_end_matches('/');
+        if entry == origin {
+            return true;
+        }
+        if let Some(wild) = entry.strip_prefix("https://*.") {
+            // Match `https://anything.<wild>` exactly.
+            if let Some(prefix) = origin.strip_prefix("https://") {
+                if prefix == wild {
+                    return true;
+                }
+                if let Some(rest) = prefix.strip_suffix(wild) {
+                    if rest.ends_with('.') {
+                        return true;
+                    }
+                }
+            }
+        }
+        if let Some(wild) = entry.strip_prefix("http://*.") {
+            if let Some(prefix) = origin.strip_prefix("http://") {
+                if prefix == wild {
+                    return true;
+                }
+                if let Some(rest) = prefix.strip_suffix(wild) {
+                    if rest.ends_with('.') {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
 }
 
 /// The tower [`Layer`] implementation. Wraps inner services with
@@ -181,6 +299,14 @@ where
 
             // Enforce on unsafe methods.
             let req = if !is_safe_method(req.method()) {
+                // Origin-header defense-in-depth. Skipped when
+                // `trusted_origins` is empty (back-compat default).
+                if !origin_allowed(&req, &cfg.trusted_origins) {
+                    return Ok(forbid_response(
+                        "CSRF: request Origin not in CSRF_TRUSTED_ORIGINS \
+                         and does not match Host",
+                    ));
+                }
                 let header_value = req
                     .headers()
                     .get(&cfg.header_name)

--- a/crates/rustango/src/manage.rs
+++ b/crates/rustango/src/manage.rs
@@ -1380,6 +1380,7 @@ mod tests {
             cookie_name: "custom_csrf".into(),
             header_name: "X-Custom-CSRF".into(),
             secure: true,
+            trusted_origins: Vec::new(),
         });
         let csrf = cli.csrf.expect("with_csrf_config should set csrf");
         assert_eq!(csrf.cookie_name, "custom_csrf");

--- a/crates/rustango/tests/csrf_trusted_origins.rs
+++ b/crates/rustango/tests/csrf_trusted_origins.rs
@@ -1,0 +1,162 @@
+//! Django parity — `CSRF_TRUSTED_ORIGINS` setting. Adds Origin-header
+//! defense-in-depth to the CSRF middleware on top of the existing
+//! double-submit-cookie token check.
+//!
+//! Behavior:
+//! * Default `trusted_origins: []` → Origin-header check disabled
+//!   (back-compat). Only the token check runs.
+//! * Non-empty list → on unsafe methods, request's Origin must be
+//!   either same-host or match one of the trusted entries.
+//! * `https://*.example.com` wildcard matches any subdomain.
+
+#![cfg(feature = "csrf")]
+
+use axum::body::Body;
+use axum::http::{HeaderValue, Request, StatusCode};
+use axum::routing::post;
+use axum::Router;
+use rustango::forms::csrf::{with_config, CsrfConfig};
+use tower::ServiceExt;
+
+const TOKEN: &str = "tokvalue";
+
+fn app(cfg: CsrfConfig) -> Router {
+    let cookie_name = cfg.cookie_name.clone();
+    Router::new()
+        .route("/post", post(|| async { "ok" }))
+        .layer(with_config(cfg))
+        .layer(axum::middleware::from_fn(
+            move |mut req: Request<Body>, next: axum::middleware::Next| {
+                // Seed the CSRF cookie so token-match passes when
+                // the test sends a matching header. Pre-layer
+                // middleware so the cookie is visible to the CSRF
+                // service.
+                let cookie_name = cookie_name.clone();
+                async move {
+                    let cookie = format!("{cookie_name}={TOKEN}");
+                    if !req.headers().contains_key("cookie") {
+                        req.headers_mut()
+                            .insert("cookie", HeaderValue::from_str(&cookie).unwrap());
+                    }
+                    next.run(req).await
+                }
+            },
+        ))
+}
+
+async fn post_with_headers(app: Router, host: &str, origin: Option<&str>) -> StatusCode {
+    let mut req = Request::builder()
+        .uri("/post")
+        .method("POST")
+        .header("Host", host)
+        .header("X-CSRF-Token", TOKEN)
+        .header("Cookie", format!("rustango_csrf={TOKEN}"));
+    if let Some(o) = origin {
+        req = req.header("Origin", o);
+    }
+    let req = req.body(Body::empty()).unwrap();
+    app.oneshot(req).await.unwrap().status()
+}
+
+#[tokio::test]
+async fn empty_trusted_origins_disables_origin_check() {
+    let app = app(CsrfConfig::default().allow_insecure_for_dev());
+    // Cross-origin POST passes when trusted_origins is empty
+    // (back-compat with pre-v0.43 token-only checking).
+    assert_eq!(
+        post_with_headers(app, "example.com", Some("https://attacker.com")).await,
+        StatusCode::OK
+    );
+}
+
+#[tokio::test]
+async fn same_host_origin_passes_with_trusted_origins_set() {
+    let app = app(CsrfConfig::default()
+        .allow_insecure_for_dev()
+        .trust_origin("https://other.example.com"));
+    assert_eq!(
+        post_with_headers(app, "example.com", Some("https://example.com")).await,
+        StatusCode::OK
+    );
+}
+
+#[tokio::test]
+async fn cross_origin_rejected_when_not_in_trusted_list() {
+    let app = app(CsrfConfig::default()
+        .allow_insecure_for_dev()
+        .trust_origin("https://other.example.com"));
+    assert_eq!(
+        post_with_headers(app, "example.com", Some("https://attacker.com")).await,
+        StatusCode::FORBIDDEN
+    );
+}
+
+#[tokio::test]
+async fn cross_origin_in_trusted_list_passes() {
+    let app = app(CsrfConfig::default()
+        .allow_insecure_for_dev()
+        .trust_origin("https://app.example.com"));
+    assert_eq!(
+        post_with_headers(app, "example.com", Some("https://app.example.com")).await,
+        StatusCode::OK
+    );
+}
+
+#[tokio::test]
+async fn wildcard_subdomain_pattern_matches() {
+    let app = app(CsrfConfig::default()
+        .allow_insecure_for_dev()
+        .trust_origin("https://*.example.com"));
+    // Subdomain matches.
+    assert_eq!(
+        post_with_headers(
+            app.clone(),
+            "api.example.com",
+            Some("https://web.example.com")
+        )
+        .await,
+        StatusCode::OK
+    );
+    // Unrelated host doesn't match.
+    assert_eq!(
+        post_with_headers(app, "api.example.com", Some("https://evilexample.com")).await,
+        StatusCode::FORBIDDEN
+    );
+}
+
+#[tokio::test]
+async fn missing_origin_falls_back_to_token_check_only() {
+    // No Origin header (curl / server-to-server) → trusted_origins
+    // setting is bypassed; only the double-submit token gates.
+    let app = app(CsrfConfig::default()
+        .allow_insecure_for_dev()
+        .trust_origin("https://app.example.com"));
+    assert_eq!(
+        post_with_headers(app, "example.com", None).await,
+        StatusCode::OK
+    );
+}
+
+#[tokio::test]
+async fn with_trusted_origins_replaces_list() {
+    let cfg = CsrfConfig::default()
+        .allow_insecure_for_dev()
+        .trust_origin("https://first.example.com")
+        .with_trusted_origins(["https://second.example.com"]);
+    // `with_trusted_origins` replaces — `first.example.com` is no
+    // longer trusted.
+    let app = app(cfg);
+    assert_eq!(
+        post_with_headers(
+            app.clone(),
+            "example.com",
+            Some("https://first.example.com")
+        )
+        .await,
+        StatusCode::FORBIDDEN
+    );
+    assert_eq!(
+        post_with_headers(app, "example.com", Some("https://second.example.com")).await,
+        StatusCode::OK
+    );
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -474,7 +474,7 @@ Summary: **13 SHIPPED / 2 PARTIAL / 2 MISSING / 2 N/A**. Multi-DB routing is the
 | Middleware | Doc | Status | rustango | Notes |
 |---|---|---|---|---|
 | `SecurityMiddleware` (HSTS, XSS, content-type-nosniff) | [SecurityMiddleware](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.middleware.security.SecurityMiddleware) | SHIPPED | `security_headers::*` (HSTS, X-Frame, Referrer, COOP, Permissions-Policy) (v0.20+) | |
-| `CsrfViewMiddleware` | [CSRF](https://docs.djangoproject.com/en/6.0/ref/csrf/) | SHIPPED | `forms::csrf::CsrfLayer` | Double-submit-cookie. |
+| `CsrfViewMiddleware` | [CSRF](https://docs.djangoproject.com/en/6.0/ref/csrf/) | SHIPPED | `forms::csrf::CsrfLayer` — double-submit cookie + Origin-header defense-in-depth (PR #612). `CsrfConfig::trust_origin("https://app.example.com")` / `.with_trusted_origins([...])` is Django `CSRF_TRUSTED_ORIGINS` parity; supports `https://*.example.com` wildcard subdomains. Empty list disables the Origin check (back-compat). | |
 | `XFrameOptionsMiddleware` | [clickjacking](https://docs.djangoproject.com/en/6.0/ref/clickjacking/) | SHIPPED | Part of security_headers | |
 | `SessionMiddleware` | [sessions](https://docs.djangoproject.com/en/6.0/topics/http/sessions/) | SHIPPED | (sec 12) | |
 | `AuthenticationMiddleware` | [auth middleware](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.contrib.auth.middleware.AuthenticationMiddleware) | SHIPPED | `SessionUser` extractor | |


### PR DESCRIPTION
## Summary

Adds **defense-in-depth** to the CSRF middleware. The existing double-submit-cookie token check stays the gating mechanism; the new Origin-header check fires alongside it when `trusted_origins` is non-empty, blocking cross-origin POSTs **even if an attacker has stolen the cookie token via XSS**.

New `CsrfConfig::trusted_origins: Vec<String>` mirrors Django's `CSRF_TRUSTED_ORIGINS`. Each entry is a scheme+host, e.g. `"https://app.example.com"`. The `https://*.example.com` wildcard syntax matches any subdomain (including the bare base).

## API

```rust
CsrfConfig::default()
    .trust_origin("https://app.example.com")
    .trust_origin("https://*.staging.example.com")
```

Or replace wholesale from settings:

```rust
CsrfConfig::default()
    .with_trusted_origins(settings.security.csrf_trusted_origins.clone())
```

## Origin-header check behavior

- Empty `trusted_origins` (default) → check disabled, back-compat with pre-PR CSRF.
- Non-empty list, no Origin header on request → fall back to token-only (curl / server-to-server clients don't send Origin).
- Origin's host matches request Host → same-origin pass.
- Origin matches an entry exactly OR via `*.` wildcard → pass.
- Else → 403 `CSRF: request Origin not in CSRF_TRUSTED_ORIGINS`.

## Test plan

- [x] `cargo test --features postgres,tenancy,csrf --lib forms::csrf` — 17 existing tests still pass (gate initialization correctly defaults the new field)
- [x] `cargo test --features postgres,tenancy,csrf --test csrf_trusted_origins` — 7 / 7 axum integration tests pass
- [x] `cargo test --workspace --all-features --no-run` — pre-push gate green
- [x] `cargo build --no-default-features --features sqlite,tenancy` — litmus green
- [x] Audit doc Section 15 CSRF row updated