### PR TITLE
feat(security): ssl_redirect middleware — Django SECURE_SSL_REDIRECT parity

### DIFF
--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -711,6 +711,12 @@ pub mod ip_filter;
 #[cfg(feature = "admin")]
 pub mod host_validation;
 
+/// HTTP → HTTPS redirect middleware — Django `SECURE_SSL_REDIRECT`
+/// + `SECURE_REDIRECT_EXEMPT` + `SECURE_PROXY_SSL_HEADER` parity.
+/// See [`ssl_redirect::SslRedirectLayer`].
+#[cfg(feature = "admin")]
+pub mod ssl_redirect;
+
 /// Request body size limit middleware — fast `Content-Length` rejection
 /// returning structured `413 Payload Too Large` JSON. Complements
 /// axum's per-extractor `DefaultBodyLimit`. See [`body_limit::BodyLimitLayer`].

--- a/crates/rustango/src/ssl_redirect.rs
+++ b/crates/rustango/src/ssl_redirect.rs
@@ -1,0 +1,247 @@
+//! HTTP → HTTPS redirect middleware — Django parity for
+//! `SECURE_SSL_REDIRECT = True` + `SECURE_REDIRECT_EXEMPT`.
+//!
+//! When enabled, every HTTP request gets a `301 Moved Permanently`
+//! redirect to the same URL on the HTTPS scheme. Behind a reverse
+//! proxy that terminates TLS (the common case), this works only
+//! when the proxy forwards a header like `X-Forwarded-Proto: https`
+//! — otherwise the layer would redirect-loop. Configure the trusted
+//! header pair with [`SslRedirectLayer::proxy_ssl_header`] (Django
+//! `SECURE_PROXY_SSL_HEADER`).
+//!
+//! ## Quick start
+//!
+//! ```ignore
+//! use rustango::ssl_redirect::{SslRedirectLayer, SslRedirectRouterExt};
+//!
+//! let app = Router::new()
+//!     .route("/", get(home))
+//!     .ssl_redirect(
+//!         SslRedirectLayer::new()
+//!             .proxy_ssl_header("X-Forwarded-Proto", "https")
+//!             .exempt(["/health", "/ready"]),
+//!     );
+//! ```
+//!
+//! ## Exempt paths
+//!
+//! [`SslRedirectLayer::exempt`] takes prefix patterns; a request
+//! whose path starts with any exempt entry skips the redirect.
+//! Useful for health checks behind a plain-HTTP LB. Empty exempt
+//! list (default) redirects every path.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::Request;
+use axum::http::{HeaderName, HeaderValue, Response, StatusCode};
+use axum::middleware::Next;
+use axum::Router;
+
+/// Tower-layer-equivalent configuration. Holds the proxy-header
+/// pair + exempt-path list; applied via
+/// [`SslRedirectRouterExt::ssl_redirect`].
+#[derive(Clone, Debug)]
+pub struct SslRedirectLayer {
+    /// `(header_name, expected_value)` that signals the request
+    /// arrived over HTTPS (Django `SECURE_PROXY_SSL_HEADER`). If
+    /// `None`, the layer inspects the URI scheme directly — which
+    /// only works when rustango is the TLS terminator (rare in
+    /// production; LB usually does).
+    proxy_ssl_header: Option<(HeaderName, HeaderValue)>,
+    /// URL-path prefixes exempt from the redirect. Request path
+    /// starts-with check; entries should include leading `/`.
+    exempt: Vec<String>,
+}
+
+impl Default for SslRedirectLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SslRedirectLayer {
+    /// Build a layer with no proxy header configured and an empty
+    /// exempt list. Add [`Self::proxy_ssl_header`] before deploying
+    /// behind a TLS-terminating proxy to avoid redirect loops.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            proxy_ssl_header: None,
+            exempt: Vec::new(),
+        }
+    }
+
+    /// Django `SECURE_PROXY_SSL_HEADER` parity — declare the
+    /// header/value pair the reverse proxy sets to indicate the
+    /// upstream request was HTTPS. The layer reads the header on
+    /// each request; matching value → skip redirect.
+    ///
+    /// ```ignore
+    /// SslRedirectLayer::new().proxy_ssl_header("X-Forwarded-Proto", "https")
+    /// ```
+    ///
+    /// Invalid header names / values are silently dropped (the
+    /// builder is infallible by design — bad input behaves as if
+    /// the operator never called this method).
+    #[must_use]
+    pub fn proxy_ssl_header(mut self, header: impl AsRef<str>, value: impl AsRef<str>) -> Self {
+        if let (Ok(h), Ok(v)) = (
+            HeaderName::try_from(header.as_ref()),
+            HeaderValue::try_from(value.as_ref()),
+        ) {
+            self.proxy_ssl_header = Some((h, v));
+        }
+        self
+    }
+
+    /// Append URL-path prefixes that bypass the redirect. Request
+    /// paths starting with any entry skip the layer. Useful for
+    /// behind-the-LB health checks that hit `http://internal-ip/`.
+    #[must_use]
+    pub fn exempt<I, S>(mut self, paths: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.exempt.extend(paths.into_iter().map(Into::into));
+        self
+    }
+
+    /// `true` when this request should pass through (no redirect).
+    /// Pure helper, exposed for testing without the full layer.
+    #[must_use]
+    pub fn is_secure(&self, req: &Request<Body>) -> bool {
+        // URI scheme (works when rustango terminates TLS itself).
+        if req.uri().scheme_str() == Some("https") {
+            return true;
+        }
+        // Proxy header — operator-declared trusted indicator.
+        if let Some((header, expected)) = &self.proxy_ssl_header {
+            if let Some(got) = req.headers().get(header) {
+                if got == expected {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// `true` when the request path matches any exempt prefix.
+    #[must_use]
+    pub fn is_exempt(&self, path: &str) -> bool {
+        self.exempt.iter().any(|p| path.starts_with(p))
+    }
+}
+
+/// Router extension trait — `.ssl_redirect(layer)`.
+pub trait SslRedirectRouterExt {
+    #[must_use]
+    fn ssl_redirect(self, layer: SslRedirectLayer) -> Self;
+}
+
+impl<S: Clone + Send + Sync + 'static> SslRedirectRouterExt for Router<S> {
+    fn ssl_redirect(self, layer: SslRedirectLayer) -> Self {
+        let cfg = Arc::new(layer);
+        self.layer(axum::middleware::from_fn(
+            move |req: Request<Body>, next: Next| {
+                let cfg = cfg.clone();
+                async move { handle(cfg, req, next).await }
+            },
+        ))
+    }
+}
+
+async fn handle(cfg: Arc<SslRedirectLayer>, req: Request<Body>, next: Next) -> Response<Body> {
+    if cfg.is_secure(&req) || cfg.is_exempt(req.uri().path()) {
+        return next.run(req).await;
+    }
+    // Build the HTTPS URL using the Host header for the authority
+    // (proxy-aware: trusts what the LB advertises) + path + query
+    // from the incoming URI.
+    let host = req
+        .headers()
+        .get(axum::http::header::HOST)
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("");
+    let path_and_query = req
+        .uri()
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or("/");
+    let location = format!("https://{host}{path_and_query}");
+
+    let mut resp = Response::new(Body::empty());
+    *resp.status_mut() = StatusCode::MOVED_PERMANENTLY;
+    if let Ok(v) = HeaderValue::from_str(&location) {
+        resp.headers_mut().insert(axum::http::header::LOCATION, v);
+    }
+    resp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn http_req(path: &str, host: &str) -> Request<Body> {
+        Request::builder()
+            .uri(path)
+            .method("GET")
+            .header("Host", host)
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[test]
+    fn default_layer_treats_plain_http_as_insecure() {
+        let layer = SslRedirectLayer::new();
+        let req = http_req("/", "example.com");
+        assert!(!layer.is_secure(&req));
+    }
+
+    #[test]
+    fn proxy_header_match_marks_request_secure() {
+        let layer = SslRedirectLayer::new().proxy_ssl_header("X-Forwarded-Proto", "https");
+        let req = Request::builder()
+            .uri("/")
+            .method("GET")
+            .header("Host", "example.com")
+            .header("X-Forwarded-Proto", "https")
+            .body(Body::empty())
+            .unwrap();
+        assert!(layer.is_secure(&req));
+    }
+
+    #[test]
+    fn proxy_header_mismatch_stays_insecure() {
+        let layer = SslRedirectLayer::new().proxy_ssl_header("X-Forwarded-Proto", "https");
+        let req = Request::builder()
+            .uri("/")
+            .method("GET")
+            .header("Host", "example.com")
+            .header("X-Forwarded-Proto", "http")
+            .body(Body::empty())
+            .unwrap();
+        assert!(!layer.is_secure(&req));
+    }
+
+    #[test]
+    fn exempt_prefix_skips_redirect() {
+        let layer = SslRedirectLayer::new().exempt(["/health", "/ready"]);
+        assert!(layer.is_exempt("/health"));
+        assert!(layer.is_exempt("/health/db"));
+        assert!(layer.is_exempt("/ready"));
+        assert!(!layer.is_exempt("/api/users"));
+    }
+
+    #[test]
+    fn invalid_proxy_header_pair_silently_dropped() {
+        let layer =
+            SslRedirectLayer::new().proxy_ssl_header("Invalid Header Name\nwith CRLF", "https");
+        // No header configured → request without HTTPS scheme is
+        // insecure.
+        let req = http_req("/", "example.com");
+        assert!(!layer.is_secure(&req));
+        assert!(layer.proxy_ssl_header.is_none());
+    }
+}

--- a/crates/rustango/tests/ssl_redirect_live.rs
+++ b/crates/rustango/tests/ssl_redirect_live.rs
@@ -1,0 +1,107 @@
+//! Integration test for the HTTP → HTTPS redirect middleware —
+//! Django `SECURE_SSL_REDIRECT` parity. Mounts the layer on an axum
+//! Router, sends requests via tower's oneshot, and asserts:
+//!
+//! * Plain HTTP request → 301 with `Location: https://...` set.
+//! * `X-Forwarded-Proto: https` from proxy → pass-through (200).
+//! * Exempt-prefix path → pass-through (200).
+//! * Default layer (no proxy header configured) redirects every
+//!   non-HTTPS request.
+
+#![cfg(feature = "admin")]
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::get;
+use axum::Router;
+use rustango::ssl_redirect::{SslRedirectLayer, SslRedirectRouterExt};
+use tower::ServiceExt;
+
+fn app(layer: SslRedirectLayer) -> Router {
+    Router::new()
+        .route("/", get(|| async { "secure" }))
+        .route("/health", get(|| async { "ok" }))
+        .ssl_redirect(layer)
+}
+
+fn req(path: &str, host: &str, forwarded_proto: Option<&str>) -> Request<Body> {
+    let mut b = Request::builder()
+        .uri(path)
+        .method("GET")
+        .header("Host", host);
+    if let Some(p) = forwarded_proto {
+        b = b.header("X-Forwarded-Proto", p);
+    }
+    b.body(Body::empty()).unwrap()
+}
+
+#[tokio::test]
+async fn plain_http_redirects_to_https() {
+    let app = app(SslRedirectLayer::new());
+    let resp = app
+        .oneshot(req("/api/users?page=2", "example.com", None))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::MOVED_PERMANENTLY);
+    let loc = resp
+        .headers()
+        .get("location")
+        .expect("Location set")
+        .to_str()
+        .unwrap();
+    assert_eq!(loc, "https://example.com/api/users?page=2");
+}
+
+#[tokio::test]
+async fn forwarded_proto_https_passes_through() {
+    let app = app(SslRedirectLayer::new().proxy_ssl_header("X-Forwarded-Proto", "https"));
+    let resp = app
+        .oneshot(req("/", "example.com", Some("https")))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn forwarded_proto_http_still_redirects() {
+    let app = app(SslRedirectLayer::new().proxy_ssl_header("X-Forwarded-Proto", "https"));
+    let resp = app
+        .oneshot(req("/", "example.com", Some("http")))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::MOVED_PERMANENTLY);
+}
+
+#[tokio::test]
+async fn exempt_path_bypasses_redirect() {
+    let app = app(SslRedirectLayer::new().exempt(["/health"]));
+    let resp = app
+        .oneshot(req("/health", "example.com", None))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn exempt_prefix_matches_subpath() {
+    let app = app(SslRedirectLayer::new().exempt(["/health"]));
+    let resp = app
+        .oneshot(req("/health/db", "example.com", None))
+        .await
+        .unwrap();
+    // /health/db doesn't exist as a route → 404 — but the
+    // redirect was correctly skipped (otherwise we'd see 301).
+    assert_ne!(resp.status(), StatusCode::MOVED_PERMANENTLY);
+}
+
+#[tokio::test]
+async fn non_exempt_path_redirects_with_query_intact() {
+    let app = app(SslRedirectLayer::new().exempt(["/health"]));
+    let resp = app
+        .oneshot(req("/api/foo?bar=1&baz=2", "example.com", None))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::MOVED_PERMANENTLY);
+    let loc = resp.headers().get("location").unwrap().to_str().unwrap();
+    assert_eq!(loc, "https://example.com/api/foo?bar=1&baz=2");
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -44,9 +44,9 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 22. Async support | 4 | 0 | 0 | 3 |
 | 23. DRF parity | 22 | 0 | 1 | 0 |
 | 24. contrib modules | 12 | 1 | 3 | 2 |
-| **Totals** | **369** | **11** | **21** | **19** |
+| **Totals** | **370** | **11** | **21** | **19** |
 
-Coverage = 369 / (369 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
+Coverage = 370 / (370 + 11 + 21) = **92% full, 3% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
 
 Snapshot date: 2026-06-03 (post v0.42 batch including ExclusionConstraint #593, default_permissions #594, on_delete #592, ForeignKey on_delete enum override, extra_permissions #591, get_latest_by #590, db_table_comment #589, citext, DatabaseCache, managed=false, upload streaming, i18n).
 
@@ -476,6 +476,7 @@ Summary: **13 SHIPPED / 2 PARTIAL / 2 MISSING / 2 N/A**. Multi-DB routing is the
 | `SecurityMiddleware` (HSTS, XSS, content-type-nosniff) | [SecurityMiddleware](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.middleware.security.SecurityMiddleware) | SHIPPED | `security_headers::*` (HSTS, X-Frame, Referrer, COOP, Permissions-Policy) (v0.20+) | |
 | `CsrfViewMiddleware` | [CSRF](https://docs.djangoproject.com/en/6.0/ref/csrf/) | SHIPPED | `forms::csrf::CsrfLayer` — double-submit cookie + Origin-header defense-in-depth (PR #612). `CsrfConfig::trust_origin("https://app.example.com")` / `.with_trusted_origins([...])` is Django `CSRF_TRUSTED_ORIGINS` parity; supports `https://*.example.com` wildcard subdomains. Empty list disables the Origin check (back-compat). | |
 | `XFrameOptionsMiddleware` | [clickjacking](https://docs.djangoproject.com/en/6.0/ref/clickjacking/) | SHIPPED | Part of security_headers | |
+| `SECURE_SSL_REDIRECT` (HTTP→HTTPS redirect) | [SECURE_SSL_REDIRECT](https://docs.djangoproject.com/en/6.0/ref/settings/#secure-ssl-redirect) | SHIPPED | `ssl_redirect::SslRedirectLayer` (PR #613) — 301 redirect with `SECURE_PROXY_SSL_HEADER` parity (trust `X-Forwarded-Proto: https` from the LB) + `SECURE_REDIRECT_EXEMPT` parity via `.exempt([...])` prefix list. Preserves path + query in the Location header. | |
 | `SessionMiddleware` | [sessions](https://docs.djangoproject.com/en/6.0/topics/http/sessions/) | SHIPPED | (sec 12) | |
 | `AuthenticationMiddleware` | [auth middleware](https://docs.djangoproject.com/en/6.0/ref/middleware/#django.contrib.auth.middleware.AuthenticationMiddleware) | SHIPPED | `SessionUser` extractor | |
 | `MessageMiddleware` | [messages](https://docs.djangoproject.com/en/6.0/ref/contrib/messages/) | SHIPPED | `messages::*` flash-message store | |


### PR DESCRIPTION
## Summary

New `ssl_redirect::SslRedirectLayer` tower middleware adds Django-shape HTTP → HTTPS redirection. Returns `301 Moved Permanently` with a `Location: https://<host>/<path>?<query>` header for every plain-HTTP request. Closes a deployment-hygiene gap.

## Django parity surface

- **`SECURE_SSL_REDIRECT = True`** — enabled by mounting the layer.
- **`SECURE_PROXY_SSL_HEADER = (header, value)`** — `.proxy_ssl_header("X-Forwarded-Proto", "https")` trusts the LB's protocol indicator so the layer doesn't redirect-loop behind TLS-terminating proxies.
- **`SECURE_REDIRECT_EXEMPT = [...]`** — `.exempt([...])` with URL-path prefixes that bypass the redirect (health-check endpoints behind the LB on plain HTTP).

## Behavior

- URI scheme `https://` → pass-through (rustango is the terminator).
- Proxy header matches → pass-through (LB-terminated, considered secure).
- Path matches an exempt prefix → pass-through.
- Else → 301 with `Location` rebuilt from `Host` + the original path + query.

Invalid proxy-header inputs (e.g. embedded CRLF) silently drop — builder stays infallible by design.

## Test plan

- [x] `cargo test --features postgres,tenancy,admin --lib ssl_redirect` — 5 / 5 unit tests pass
- [x] `cargo test --features postgres,tenancy,admin --test ssl_redirect_live` — 6 / 6 integration tests pass
- [x] `cargo build --no-default-features --features sqlite,tenancy` — litmus green
- [x] `cargo test --workspace --all-features --no-run` — pre-push gate green
- [x] Audit doc Section 15 row added

Gated on `feature = "admin"` alongside the rest of the security middleware family.