### PR TITLE
feat(cache): Cache::add + Cache::touch — Django cache API parity

### DIFF
--- a/crates/rustango/src/cache/mod.rs
+++ b/crates/rustango/src/cache/mod.rs
@@ -116,6 +116,52 @@ pub trait Cache: Send + Sync + 'static {
         self.set(key, &new.to_string(), ttl).await?;
         Ok(new)
     }
+
+    /// Django-parity `cache.add(key, value, timeout)` — set the value
+    /// ONLY if the key is currently absent (or expired). Returns `true`
+    /// when the value was inserted, `false` when an existing entry
+    /// blocked the write.
+    ///
+    /// The default implementation is a non-atomic `exists` + `set`
+    /// pair, which races between processes; backends with a native
+    /// "set if absent" primitive (Redis `SET NX`) should override
+    /// for atomicity. For single-process locks, the default is fine.
+    ///
+    /// Useful as a lightweight inter-process lock primitive:
+    ///
+    /// ```ignore
+    /// if cache.add("import-running", "1", Some(Duration::from_secs(60))).await? {
+    ///     // We won the race — run the import.
+    /// }
+    /// ```
+    async fn add(&self, key: &str, value: &str, ttl: Option<Duration>) -> Result<bool, CacheError> {
+        if self.exists(key).await? {
+            return Ok(false);
+        }
+        self.set(key, value, ttl).await?;
+        Ok(true)
+    }
+
+    /// Django-parity `cache.touch(key, timeout)` — extend (or replace)
+    /// the TTL on an existing key without changing the value. Returns
+    /// `true` when the key existed and the TTL was reset, `false`
+    /// when the key was absent or already expired (no-op).
+    ///
+    /// The default implementation is a non-atomic `get` + `set` round-
+    /// trip. Backends with a native `EXPIRE` / `PEXPIRE` primitive
+    /// should override for an O(1) single-RTT path.
+    ///
+    /// `ttl = None` makes the entry persist indefinitely (matching
+    /// `set(_, _, None)`).
+    async fn touch(&self, key: &str, ttl: Option<Duration>) -> Result<bool, CacheError> {
+        match self.get(key).await? {
+            Some(value) => {
+                self.set(key, &value, ttl).await?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
 }
 
 /// `Arc<dyn Cache>` alias — the standard way to share a cache instance.

--- a/crates/rustango/tests/cache_backends.rs
+++ b/crates/rustango/tests/cache_backends.rs
@@ -233,3 +233,88 @@ async fn incr_resets_on_non_integer_value() {
     // next incr returns `by`.
     assert_eq!(c.incr("counter", 7, None).await.unwrap(), 7);
 }
+
+// ------------------------------------------------------------------ add (Django parity)
+
+#[tokio::test]
+async fn add_inserts_when_key_is_absent() {
+    let c = InMemoryCache::new();
+    let inserted = c.add("lock", "1", None).await.unwrap();
+    assert!(inserted, "first add into empty cache should win the race");
+    assert_eq!(c.get("lock").await.unwrap().as_deref(), Some("1"));
+}
+
+#[tokio::test]
+async fn add_is_no_op_when_key_already_set() {
+    let c = InMemoryCache::new();
+    c.set("lock", "winner", None).await.unwrap();
+    let inserted = c.add("lock", "loser", None).await.unwrap();
+    assert!(!inserted, "second add must lose to the existing entry");
+    assert_eq!(
+        c.get("lock").await.unwrap().as_deref(),
+        Some("winner"),
+        "add must not overwrite the existing value"
+    );
+}
+
+#[tokio::test]
+async fn add_can_re_insert_after_expiry() {
+    let c = InMemoryCache::new();
+    c.set("lock", "v", Some(Duration::from_millis(50)))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    let inserted = c.add("lock", "fresh", None).await.unwrap();
+    assert!(inserted, "expired entries don't block a subsequent add");
+    assert_eq!(c.get("lock").await.unwrap().as_deref(), Some("fresh"));
+}
+
+// ------------------------------------------------------------------ touch (Django parity)
+
+#[tokio::test]
+async fn touch_extends_ttl_on_existing_key() {
+    let c = InMemoryCache::new();
+    c.set("k", "v", Some(Duration::from_millis(100)))
+        .await
+        .unwrap();
+    // Touch with a longer TTL before the original expires.
+    let touched = c.touch("k", Some(Duration::from_secs(3600))).await.unwrap();
+    assert!(touched, "touch on a live key must return true");
+    // After the original TTL would've fired the key still lives.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert_eq!(c.get("k").await.unwrap().as_deref(), Some("v"));
+}
+
+#[tokio::test]
+async fn touch_returns_false_when_key_absent() {
+    let c = InMemoryCache::new();
+    let touched = c
+        .touch("ghost", Some(Duration::from_secs(60)))
+        .await
+        .unwrap();
+    assert!(!touched);
+}
+
+#[tokio::test]
+async fn touch_with_none_ttl_persists_indefinitely() {
+    let c = InMemoryCache::new();
+    c.set("k", "v", Some(Duration::from_millis(50)))
+        .await
+        .unwrap();
+    let touched = c.touch("k", None).await.unwrap();
+    assert!(touched);
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    assert_eq!(
+        c.get("k").await.unwrap().as_deref(),
+        Some("v"),
+        "touch(None) removes the TTL so the entry survives past the original expiry"
+    );
+}
+
+#[tokio::test]
+async fn touch_does_not_alter_value() {
+    let c = InMemoryCache::new();
+    c.set("k", "original", None).await.unwrap();
+    c.touch("k", Some(Duration::from_secs(60))).await.unwrap();
+    assert_eq!(c.get("k").await.unwrap().as_deref(), Some("original"));
+}


### PR DESCRIPTION
## Summary

Adds two more Django `cache.*` API methods to the `Cache` trait with default implementations over the existing primitives. Both close real DX gaps — the inter-process lock and TTL-extension patterns are common enough that operators were wiring their own non-atomic versions on top of `get` / `set`.

## API

* **`Cache::add(key, value, ttl) -> bool`** — set-if-absent. Returns `true` when the value was inserted, `false` when an existing entry blocked the write. Useful as a lightweight inter-process lock primitive:

  ```rust
  if cache.add("import-running", "1", Some(Duration::from_secs(60))).await? {
      // We won the race — run the import.
  }
  ```

* **`Cache::touch(key, ttl) -> bool`** — extend the TTL on an existing key without changing the value. Returns `true` when the key existed and the TTL was reset; `false` when absent / already expired (no-op). `ttl = None` removes the TTL so the entry persists indefinitely.

## Atomicity

Default impls are non-atomic (`exists`+`set` / `get`+`set` pairs) — fine for single-process use. Multi-replica deployments can override on backends with native primitives:

* `RedisCache::add` → `SET NX` (atomic)
* `RedisCache::touch` → `EXPIRE` / `PEXPIRE` (single RTT)

## Test plan

- [x] `cargo test --features postgres,tenancy,cache,config --test cache_backends` — **31 / 31 pass** (24 pre-existing + 7 new)
- [x] `cargo build --no-default-features --features sqlite,tenancy` — litmus green
- [x] `cargo test --workspace --all-features --no-run` — pre-push gate green

New tests cover: first add wins, second loses, expired-then-re-add, touch extends live key, touch returns false on absent, touch(None) removes TTL, touch doesn't alter value.