### PR TITLE
feat(cache): Cache::has_key + Cache::decr — Django parity aliases

### DIFF
--- a/crates/rustango/src/cache/mod.rs
+++ b/crates/rustango/src/cache/mod.rs
@@ -208,6 +208,32 @@ pub trait Cache: Send + Sync + 'static {
         }
         Ok(())
     }
+
+    /// Django-parity `cache.has_key(key)` — direct alias for
+    /// [`Self::exists`]. Django spells the membership check as
+    /// `has_key`; rustango shipped `exists` first (Rust convention)
+    /// but the Django method name is the one most users reach for
+    /// when translating from a Django codebase.
+    ///
+    /// Default implementation delegates to `exists`; backends never
+    /// need to override.
+    async fn has_key(&self, key: &str) -> Result<bool, CacheError> {
+        self.exists(key).await
+    }
+
+    /// Django-parity `cache.decr(key, delta=1)` — atomically decrement
+    /// the integer counter at `key` by `by` and return the new value.
+    ///
+    /// Equivalent to [`Self::incr`] with a negated `by` — the default
+    /// implementation simply forwards to `incr(-by)`, so backends that
+    /// override `incr` for atomicity (Redis `INCRBY -N`) get the
+    /// matching atomic `decr` for free.
+    ///
+    /// `ttl` semantics mirror `incr` — treat as a hint; backends with
+    /// native counters typically only set TTL on first creation.
+    async fn decr(&self, key: &str, by: i64, ttl: Option<Duration>) -> Result<i64, CacheError> {
+        self.incr(key, by.saturating_neg(), ttl).await
+    }
 }
 
 /// `Arc<dyn Cache>` alias — the standard way to share a cache instance.

--- a/crates/rustango/tests/cache_backends.rs
+++ b/crates/rustango/tests/cache_backends.rs
@@ -386,3 +386,80 @@ async fn delete_many_ignores_missing_keys() {
     c.delete_many(&["ghost1", "kept", "ghost2"]).await.unwrap();
     assert!(c.get("kept").await.unwrap().is_none());
 }
+
+// ------------------------------------------------------------------ has_key + decr (Django parity)
+
+#[tokio::test]
+async fn has_key_returns_true_when_present() {
+    // Django parity: `cache.has_key("k")` is the alias most users
+    // translate from `if "k" in cache:` — should match `exists`.
+    let c = InMemoryCache::new();
+    c.set("present", "v", None).await.unwrap();
+    assert!(c.has_key("present").await.unwrap());
+}
+
+#[tokio::test]
+async fn has_key_returns_false_when_absent() {
+    let c = InMemoryCache::new();
+    assert!(!c.has_key("ghost").await.unwrap());
+}
+
+#[tokio::test]
+async fn has_key_returns_false_after_expiry() {
+    let c = InMemoryCache::new();
+    c.set("ttl", "v", Some(Duration::from_millis(20)))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    assert!(!c.has_key("ttl").await.unwrap());
+}
+
+#[tokio::test]
+async fn has_key_matches_exists_for_same_keys() {
+    // Belt-and-suspenders: has_key should never disagree with exists.
+    let c = InMemoryCache::new();
+    c.set("yes", "v", None).await.unwrap();
+    assert_eq!(
+        c.has_key("yes").await.unwrap(),
+        c.exists("yes").await.unwrap(),
+    );
+    assert_eq!(
+        c.has_key("no").await.unwrap(),
+        c.exists("no").await.unwrap(),
+    );
+}
+
+#[tokio::test]
+async fn decr_decrements_existing_counter() {
+    let c = InMemoryCache::new();
+    c.set("counter", "10", None).await.unwrap();
+    let new = c.decr("counter", 3, None).await.unwrap();
+    assert_eq!(new, 7);
+    assert_eq!(c.get("counter").await.unwrap().as_deref(), Some("7"));
+}
+
+#[tokio::test]
+async fn decr_underflows_to_negative_when_unbounded() {
+    // Django semantics: decr doesn't clamp at zero — returns whatever
+    // arithmetic yields. Apps that want a clamp do it client-side.
+    let c = InMemoryCache::new();
+    c.set("counter", "2", None).await.unwrap();
+    let new = c.decr("counter", 5, None).await.unwrap();
+    assert_eq!(new, -3);
+}
+
+#[tokio::test]
+async fn decr_treats_missing_key_as_zero() {
+    // Matches incr's default-impl behavior: missing → start from 0.
+    let c = InMemoryCache::new();
+    let new = c.decr("ghost", 4, None).await.unwrap();
+    assert_eq!(new, -4);
+}
+
+#[tokio::test]
+async fn decr_is_inverse_of_incr() {
+    let c = InMemoryCache::new();
+    c.incr("k", 7, None).await.unwrap();
+    let after = c.decr("k", 7, None).await.unwrap();
+    assert_eq!(after, 0);
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -510,7 +510,7 @@ Summary: **27 SHIPPED / 0 PARTIAL / 0 MISSING / 0 N/A** for the dimensions enume
 
 | Capability | Doc | Status | rustango | Notes |
 |---|---|---|---|---|
-| Cache trait + pluggable backends | [cache framework](https://docs.djangoproject.com/en/6.0/topics/cache/) | SHIPPED | `cache::Cache` trait. Django-shape methods: `get` / `set` / `delete` / `clear` / `add` (#615) / `touch` (#615) / `get_many` (#616) / `set_many` (#616) / `delete_many` (#616) / `incr` / `decr` (PR #621) / `has_key` (PR #621) / `exists`. | |
+| Cache trait + pluggable backends | [cache framework](https://docs.djangoproject.com/en/6.0/topics/cache/) | SHIPPED | `cache::Cache` trait. Django-shape methods: `get` / `set` / `delete` / `clear` / `add` (#615) / `touch` (#615) / `get_many` (#616) / `set_many` (#616) / `delete_many` (#616) / `incr` / `decr` (PR #620) / `has_key` (PR #620) / `exists`. | |
 | Memcached backend | [memcached](https://docs.djangoproject.com/en/6.0/topics/cache/#memcached) | MISSING | n/a (#407) | Use Redis or in-memory. |
 | Redis backend | [redis](https://docs.djangoproject.com/en/6.0/topics/cache/#redis) | SHIPPED | `cache-redis` feature (v0.18) | |
 | File-system cache | [filesystem](https://docs.djangoproject.com/en/6.0/topics/cache/#file-system-caching) | SHIPPED | `cache::FileCache` (`backend = "file"` + `[cache].file_cache_dir`) — `src/cache/mod.rs` | |

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -510,7 +510,7 @@ Summary: **27 SHIPPED / 0 PARTIAL / 0 MISSING / 0 N/A** for the dimensions enume
 
 | Capability | Doc | Status | rustango | Notes |
 |---|---|---|---|---|
-| Cache trait + pluggable backends | [cache framework](https://docs.djangoproject.com/en/6.0/topics/cache/) | SHIPPED | `cache::Cache` trait | |
+| Cache trait + pluggable backends | [cache framework](https://docs.djangoproject.com/en/6.0/topics/cache/) | SHIPPED | `cache::Cache` trait. Django-shape methods: `get` / `set` / `delete` / `clear` / `add` (#615) / `touch` (#615) / `get_many` (#616) / `set_many` (#616) / `delete_many` (#616) / `incr` / `decr` (PR #621) / `has_key` (PR #621) / `exists`. | |
 | Memcached backend | [memcached](https://docs.djangoproject.com/en/6.0/topics/cache/#memcached) | MISSING | n/a (#407) | Use Redis or in-memory. |
 | Redis backend | [redis](https://docs.djangoproject.com/en/6.0/topics/cache/#redis) | SHIPPED | `cache-redis` feature (v0.18) | |
 | File-system cache | [filesystem](https://docs.djangoproject.com/en/6.0/topics/cache/#file-system-caching) | SHIPPED | `cache::FileCache` (`backend = "file"` + `[cache].file_cache_dir`) — `src/cache/mod.rs` | |


### PR DESCRIPTION
## Summary

Two default-impl methods on the `Cache` trait close direct Django API translations:

* **`has_key(key)`** — Django's spelling of the membership check (`if 'k' in cache:` → `cache.has_key('k')`). rustango shipped `exists()` first (Rust convention) but users translating from a Django codebase reach for `has_key` first. Default impl delegates straight to `exists` — backends never need to override.

* **`decr(key, by, ttl)`** — Django's decrement counterpart to `incr`. Default impl forwards to `self.incr(key, by.saturating_neg(), ttl)` so backends that override `incr` for atomicity (Redis `INCRBY -N`) inherit the matching atomic decrement for free. Matches Django's **no-floor semantics** — decrementing below zero yields negatives; apps that want a clamp do it client-side.

## Test plan

- [x] `cargo test --features postgres,tenancy,cache --test cache_backends` — **45 / 45 pass** (37 pre-existing + 8 new)
  - has_key true/false/expired/agrees-with-exists
  - decr-decrements / decr-no-floor / decr-missing-as-zero / decr-inverse-of-incr
- [x] `cargo build --no-default-features --features sqlite,tenancy` — litmus green
- [x] `cargo test --workspace --all-features --no-run` — pre-push gate green