### PR TITLE
feat(email): Email::attach + attach_text — Django parity attachments

### DIFF
--- a/crates/rustango/src/email/mod.rs
+++ b/crates/rustango/src/email/mod.rs
@@ -66,6 +66,28 @@ pub struct Email {
     pub body: String,
     pub html_body: Option<String>,
     pub headers: Vec<(String, String)>,
+    /// Django-parity attachments — file blobs attached to the
+    /// outgoing message. Populated via [`Email::attach`] /
+    /// [`Email::attach_text`].
+    #[serde(default)]
+    pub attachments: Vec<Attachment>,
+}
+
+/// Django-parity `EmailMessage.attach(filename, content, mimetype)` —
+/// one attached blob. `mimetype` is the MIME type lettre stamps on
+/// the SinglePart; when `None` we default to `application/octet-stream`
+/// (RFC-9110 recommendation for opaque blobs).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Attachment {
+    /// File name as it will appear in the `Content-Disposition` header
+    /// (`attachment; filename="<this>"`).
+    pub filename: String,
+    /// Raw bytes. Plain-text attachments can be built via
+    /// [`Email::attach_text`] which UTF-8 encodes a `&str`.
+    pub content: Vec<u8>,
+    /// MIME type. `None` = `application/octet-stream`. Common values:
+    /// `text/plain`, `text/csv`, `application/pdf`, `image/png`.
+    pub mimetype: Option<String>,
 }
 
 impl Email {
@@ -139,6 +161,41 @@ impl Email {
         self
     }
 
+    /// Django-parity `EmailMessage.attach(filename, content, mimetype)` —
+    /// attach a binary blob. `mimetype = None` means
+    /// `application/octet-stream`. Backends serialize the attachment
+    /// according to their capabilities:
+    ///
+    /// * [`SmtpMailer`] (feature `email-smtp`) — sent as a SinglePart
+    ///   attachment inside a `multipart/mixed` MIME container.
+    /// * [`ConsoleMailer`] — prints a one-line summary (name + size).
+    /// * [`FileMailer`] — listed by name in the dev `.eml` dump.
+    /// * [`InMemoryMailer`] — captured on the cloned `Email` for
+    ///   test assertions.
+    #[must_use]
+    pub fn attach(
+        mut self,
+        filename: impl Into<String>,
+        content: impl Into<Vec<u8>>,
+        mimetype: Option<impl Into<String>>,
+    ) -> Self {
+        self.attachments.push(Attachment {
+            filename: filename.into(),
+            content: content.into(),
+            mimetype: mimetype.map(Into::into),
+        });
+        self
+    }
+
+    /// Django-parity convenience — attach a UTF-8 text blob with
+    /// `text/plain` MIME. Equivalent to `attach(filename, content,
+    /// Some("text/plain"))` but spares the caller the `Some(_)`.
+    #[must_use]
+    pub fn attach_text(self, filename: impl Into<String>, content: impl Into<String>) -> Self {
+        let s = content.into();
+        self.attach(filename, s.into_bytes(), Some("text/plain"))
+    }
+
     /// Validate the minimum required fields: at least one recipient + non-empty subject.
     pub fn validate(&self) -> Result<(), MailError> {
         if self.to.is_empty() && self.cc.is_empty() && self.bcc.is_empty() {
@@ -208,6 +265,16 @@ impl Mailer for ConsoleMailer {
         println!("{}", email.body);
         if let Some(html) = &email.html_body {
             println!("\n--- HTML alternative ---\n{html}");
+        }
+        for att in &email.attachments {
+            println!(
+                "--- attachment: {} ({} bytes, {}) ---",
+                att.filename,
+                att.content.len(),
+                att.mimetype
+                    .as_deref()
+                    .unwrap_or("application/octet-stream"),
+            );
         }
         println!("====================================================");
         Ok(())
@@ -345,6 +412,16 @@ fn serialize_eml(email: &Email) -> String {
     if let Some(html) = &email.html_body {
         out.push_str("\n\n--- HTML alternative ---\n");
         out.push_str(html);
+    }
+    for att in &email.attachments {
+        out.push_str(&format!(
+            "\n\n--- attachment: {} ({} bytes, {}) ---",
+            att.filename,
+            att.content.len(),
+            att.mimetype
+                .as_deref()
+                .unwrap_or("application/octet-stream"),
+        ));
     }
     out
 }

--- a/crates/rustango/src/email/smtp.rs
+++ b/crates/rustango/src/email/smtp.rs
@@ -21,7 +21,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use lettre::message::{header::ContentType, Mailbox, Message, MultiPart, SinglePart};
+use lettre::message::{
+    header::ContentType, Attachment as LettreAttachment, Mailbox, Message, MultiPart, SinglePart,
+};
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::transport::smtp::client::Tls;
 use lettre::{AsyncSmtpTransport, AsyncTransport, Tokio1Executor};
@@ -252,8 +254,8 @@ impl Mailer for SmtpMailer {
         // method; lettre validates them via the typed-header machinery,
         // so unknown header names just become "Header" structs.
         // We use the loose `header::Header` form via `headers_mut`.
+        // Body part: text-only, or multipart/alternative when HTML present.
         let body_part = if let Some(html) = &email.html_body {
-            // multipart/alternative — text/plain + text/html.
             MultiPart::alternative()
                 .singlepart(
                     SinglePart::builder()
@@ -266,13 +268,31 @@ impl Mailer for SmtpMailer {
                         .body(html.clone()),
                 )
         } else {
-            // Text-only — wrap in MultiPart::mixed() of one to keep
-            // the return shape uniform.
             MultiPart::mixed().singlepart(
                 SinglePart::builder()
                     .header(ContentType::TEXT_PLAIN)
                     .body(email.body.clone()),
             )
+        };
+
+        // Attachments — wrap the body part in `multipart/mixed` plus one
+        // SinglePart per attachment when any are present. Skips the
+        // extra wrapper when the list is empty (preserves v1 layout).
+        let body_part = if email.attachments.is_empty() {
+            body_part
+        } else {
+            let mut mixed = MultiPart::mixed().multipart(body_part);
+            for att in &email.attachments {
+                let ctype: ContentType = att
+                    .mimetype
+                    .as_deref()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(ContentType::parse("application/octet-stream").unwrap());
+                mixed = mixed.singlepart(
+                    LettreAttachment::new(att.filename.clone()).body(att.content.clone(), ctype),
+                );
+            }
+            mixed
         };
 
         // NB: custom `email.headers` aren't forwarded in v1 — lettre's

--- a/crates/rustango/tests/email_attachments.rs
+++ b/crates/rustango/tests/email_attachments.rs
@@ -1,0 +1,142 @@
+//! Django-parity `EmailMessage.attach(filename, content, mimetype)` —
+//! attachment builder + backend serialization.
+
+#![cfg(feature = "email")]
+
+use rustango::email::{Attachment, ConsoleMailer, Email, FileMailer, InMemoryMailer, Mailer};
+
+fn base_email() -> Email {
+    Email::new()
+        .to("alice@example.com")
+        .from("noreply@example.com")
+        .subject("hi")
+        .body("greetings")
+}
+
+// ------------------------------------------------------------------ builder
+
+#[test]
+fn attach_appends_one_attachment() {
+    let e = base_email().attach("report.csv", b"a,b\n1,2".to_vec(), Some("text/csv"));
+    assert_eq!(e.attachments.len(), 1);
+    let a: &Attachment = &e.attachments[0];
+    assert_eq!(a.filename, "report.csv");
+    assert_eq!(a.content, b"a,b\n1,2");
+    assert_eq!(a.mimetype.as_deref(), Some("text/csv"));
+}
+
+#[test]
+fn attach_with_none_mimetype_stores_none() {
+    // None → backends substitute application/octet-stream at send-time,
+    // but the struct preserves the original None for round-tripping.
+    let e = base_email().attach("blob.bin", vec![0u8, 1, 2, 3], None::<String>);
+    assert!(e.attachments[0].mimetype.is_none());
+}
+
+#[test]
+fn attach_can_be_chained_for_multiple_files() {
+    let e = base_email()
+        .attach("a.txt", b"a".to_vec(), Some("text/plain"))
+        .attach("b.pdf", vec![0xDE, 0xAD], Some("application/pdf"));
+    assert_eq!(e.attachments.len(), 2);
+    assert_eq!(e.attachments[0].filename, "a.txt");
+    assert_eq!(e.attachments[1].filename, "b.pdf");
+}
+
+#[test]
+fn attach_text_helper_uses_text_plain() {
+    let e = base_email().attach_text("notes.txt", "hello\nworld");
+    assert_eq!(e.attachments.len(), 1);
+    let a = &e.attachments[0];
+    assert_eq!(a.filename, "notes.txt");
+    assert_eq!(a.content, b"hello\nworld");
+    assert_eq!(a.mimetype.as_deref(), Some("text/plain"));
+}
+
+#[test]
+fn default_email_has_zero_attachments() {
+    // Sanity: existing call sites that never touch .attach still get
+    // an empty vec — no behavior change for unattached mail.
+    let e = base_email();
+    assert!(e.attachments.is_empty());
+}
+
+// ------------------------------------------------------------------ InMemoryMailer roundtrip
+
+#[tokio::test]
+async fn in_memory_mailer_captures_attachments() {
+    let m = InMemoryMailer::new();
+    let e = base_email()
+        .attach("a.txt", b"hi".to_vec(), Some("text/plain"))
+        .attach("b.bin", vec![1, 2, 3], None::<String>);
+    m.send(&e).await.unwrap();
+    let sent = m.sent();
+    assert_eq!(sent.len(), 1);
+    assert_eq!(sent[0].attachments.len(), 2);
+    assert_eq!(sent[0].attachments[0].filename, "a.txt");
+    assert_eq!(sent[0].attachments[1].content, vec![1, 2, 3]);
+    assert!(sent[0].attachments[1].mimetype.is_none());
+}
+
+// ------------------------------------------------------------------ ConsoleMailer
+
+#[tokio::test]
+async fn console_mailer_accepts_email_with_attachments() {
+    // ConsoleMailer prints to stdout — we can't assert on output here
+    // (stdout is process-wide), so this is a smoke test that the
+    // render path doesn't panic / error when attachments are present.
+    let m = ConsoleMailer;
+    let e = base_email().attach_text("note.txt", "captured");
+    m.send(&e).await.unwrap();
+}
+
+// ------------------------------------------------------------------ FileMailer .eml dump
+
+#[tokio::test]
+async fn file_mailer_lists_attachments_in_eml_dump() {
+    let dir = std::env::temp_dir().join(format!("rustango-email-attach-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let m = FileMailer::new(&dir);
+    let e = base_email()
+        .attach("data.csv", b"x,y\n1,2".to_vec(), Some("text/csv"))
+        .attach("photo.png", vec![0x89, 0x50, 0x4E, 0x47], Some("image/png"));
+    m.send(&e).await.unwrap();
+    // Find the single .eml file just dropped.
+    let eml: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|d| {
+            d.path()
+                .extension()
+                .and_then(|s| s.to_str())
+                .map_or(false, |s| s == "eml")
+        })
+        .collect();
+    assert_eq!(eml.len(), 1, ".eml file present");
+    let text = std::fs::read_to_string(eml[0].path()).unwrap();
+    assert!(text.contains("attachment: data.csv"));
+    assert!(text.contains("text/csv"));
+    assert!(text.contains("attachment: photo.png"));
+    assert!(text.contains("image/png"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ------------------------------------------------------------------ unattached round-trip preserved
+
+#[tokio::test]
+async fn unattached_email_still_serializes_cleanly() {
+    // Regression guard — pre-PR call sites that build an Email and
+    // never call .attach should produce identical-looking dumps to
+    // before this PR.
+    let dir = std::env::temp_dir().join(format!("rustango-email-noattach-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let m = FileMailer::new(&dir);
+    m.send(&base_email()).await.unwrap();
+    let eml: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .collect();
+    let text = std::fs::read_to_string(eml[0].path()).unwrap();
+    assert!(!text.contains("attachment:"));
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -549,7 +549,7 @@ Summary: **10 SHIPPED / 0 PARTIAL / 0 MISSING / 1 N/A**. Gaps cluster around `m2
 
 | Capability | Doc | Status | rustango | Notes |
 |---|---|---|---|---|
-| `EmailMessage` builder | [email message](https://docs.djangoproject.com/en/6.0/topics/email/#emailmessage-and-emailmultialternatives) | SHIPPED | `email::Email` + `Mailable` pattern | |
+| `EmailMessage` builder | [email message](https://docs.djangoproject.com/en/6.0/topics/email/#emailmessage-and-emailmultialternatives) | SHIPPED | `email::Email` + `Mailable` pattern. File attachments via `Email::attach(name, bytes, mimetype)` + `attach_text(name, str)` (PR #621, Django `EmailMessage.attach`). SmtpMailer wires attachments through lettre's `multipart/mixed`; FileMailer + ConsoleMailer list them by name. | |
 | `EmailMultiAlternatives` (HTML+text) | (above) | SHIPPED | `email::Email::with_html(...)` | |
 | `send_mail()` shortcut | [send_mail](https://docs.djangoproject.com/en/6.0/topics/email/#send-mail) | SHIPPED | `email::send_pool(mailer, msg)` | |
 | `mail_admins` / `mail_managers` | [mail_admins](https://docs.djangoproject.com/en/6.0/topics/email/#mail-admins) | SHIPPED | `email::mail_admins(mailer, settings, subject, body)` + `email::mail_managers(...)` (closed #416, v0.42). Reads recipient lists from new `MailSettings.admins` / `MailSettings.managers` (TOML / env-overlay). Subject prefix configurable via `MailSettings.email_subject_prefix` (Django `EMAIL_SUBJECT_PREFIX`, PR #620) — falls back to `[admin] ` / `[manager] `. `From:` honors `MailSettings.server_email` (Django `SERVER_EMAIL`, PR #620) with fallback to `from_address` (Django `DEFAULT_FROM_EMAIL`). Empty list = silent no-op (Django shape). | |


### PR DESCRIPTION
## Summary

File attachments on the `Email` builder, matching Django `EmailMessage.attach(filename, content, mimetype)`:

* `Email::attach(filename, content, mimetype: Option<…>)` — binary blob. `None` mimetype substitutes `application/octet-stream` at send time.
* `Email::attach_text(filename, content)` — convenience for UTF-8 text/plain attachments.

New struct:

\`\`\`rust
pub struct Attachment {
    pub filename: String,
    pub content: Vec<u8>,
    pub mimetype: Option<String>,
}
\`\`\`

`Email.attachments: Vec<Attachment>` defaults to empty (serde `#[default]`) so every pre-existing call site is unchanged.

## Backend wiring

* **SmtpMailer** (`email-smtp`) — when present, wraps the body part in `multipart/mixed` plus one `lettre::message::Attachment` SinglePart per attached blob. Unattached mail keeps the v1 layout (zero MIME-shape diff).
* **ConsoleMailer** — prints `--- attachment: <name> (N bytes, <mimetype>) ---` after the body.
* **FileMailer** — same shape in the `.eml` dump so dev inspection shows what would have been attached.
* **InMemoryMailer** / **NullMailer** — captured / discarded on the cloned `Email`; no special handling.

## Test plan

- [x] `cargo test --features postgres,tenancy,email --test email_attachments` — **9 / 9 pass** (5 builder + 4 backend roundtrip + regression guard for unattached mail)
- [x] `cargo build --features email-smtp` — lettre Attachment + ContentType wiring compiles
- [x] `cargo build --no-default-features --features sqlite,tenancy` — litmus green
- [x] `cargo test --workspace --all-features --no-run` — pre-push gate green