### PR TITLE
feat(cache): Cache::get_or — Django two-arg get default parity

### DIFF
--- a/crates/rustango/src/cache/mod.rs
+++ b/crates/rustango/src/cache/mod.rs
@@ -234,6 +234,28 @@ pub trait Cache: Send + Sync + 'static {
     async fn decr(&self, key: &str, by: i64, ttl: Option<Duration>) -> Result<i64, CacheError> {
         self.incr(key, by.saturating_neg(), ttl).await
     }
+
+    /// Django-parity `cache.get(key, default)` — returns the stored
+    /// value, or `default` (cloned) when the key is absent or expired.
+    ///
+    /// Direct translation of Django's two-arg form:
+    ///
+    /// ```python
+    /// # Django
+    /// name = cache.get('username', default='anonymous')
+    /// ```
+    ///
+    /// ```ignore
+    /// // rustango
+    /// let name = cache.get_or("username", "anonymous").await?;
+    /// ```
+    ///
+    /// `default` is taken by `&str` so callers can pass either string
+    /// literals or borrowed `String`s without an unnecessary allocation
+    /// on the hit path — the allocation only happens on miss.
+    async fn get_or(&self, key: &str, default: &str) -> Result<String, CacheError> {
+        Ok(self.get(key).await?.unwrap_or_else(|| default.to_owned()))
+    }
 }
 
 /// `Arc<dyn Cache>` alias — the standard way to share a cache instance.

--- a/crates/rustango/tests/cache_backends.rs
+++ b/crates/rustango/tests/cache_backends.rs
@@ -463,3 +463,40 @@ async fn decr_is_inverse_of_incr() {
     let after = c.decr("k", 7, None).await.unwrap();
     assert_eq!(after, 0);
 }
+
+// ------------------------------------------------------------------ get_or (Django parity)
+
+#[tokio::test]
+async fn get_or_returns_stored_value_when_present() {
+    // Django parity: `cache.get('k', default='x')` returns the value
+    // when the key exists, not the default.
+    let c = InMemoryCache::new();
+    c.set("greeting", "hello", None).await.unwrap();
+    assert_eq!(c.get_or("greeting", "ANON").await.unwrap(), "hello");
+}
+
+#[tokio::test]
+async fn get_or_returns_default_when_absent() {
+    let c = InMemoryCache::new();
+    assert_eq!(c.get_or("missing", "fallback").await.unwrap(), "fallback");
+}
+
+#[tokio::test]
+async fn get_or_returns_default_after_expiry() {
+    let c = InMemoryCache::new();
+    c.set("ttl", "fresh", Some(Duration::from_millis(20)))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    assert_eq!(c.get_or("ttl", "default").await.unwrap(), "default");
+}
+
+#[tokio::test]
+async fn get_or_does_not_write_default_back() {
+    // Subtle: Django's two-arg get just returns the default — it does
+    // NOT store it. (get_or_set is the "fetch-or-compute-and-store"
+    // shape; get_or is purely a read fallback.)
+    let c = InMemoryCache::new();
+    let _ = c.get_or("ghost", "would-not-be-stored").await.unwrap();
+    assert!(!c.has_key("ghost").await.unwrap());
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -510,7 +510,7 @@ Summary: **27 SHIPPED / 0 PARTIAL / 0 MISSING / 0 N/A** for the dimensions enume
 
 | Capability | Doc | Status | rustango | Notes |
 |---|---|---|---|---|
-| Cache trait + pluggable backends | [cache framework](https://docs.djangoproject.com/en/6.0/topics/cache/) | SHIPPED | `cache::Cache` trait. Django-shape methods: `get` / `set` / `delete` / `clear` / `add` (#615) / `touch` (#615) / `get_many` (#616) / `set_many` (#616) / `delete_many` (#616) / `incr` / `decr` (PR #620) / `has_key` (PR #620) / `exists`. | |
+| Cache trait + pluggable backends | [cache framework](https://docs.djangoproject.com/en/6.0/topics/cache/) | SHIPPED | `cache::Cache` trait. Django-shape methods: `get` / `get_or` (PR #622) / `set` / `delete` / `clear` / `add` (#615) / `touch` (#615) / `get_many` (#616) / `set_many` (#616) / `delete_many` (#616) / `incr` / `decr` (PR #620) / `has_key` (PR #620) / `exists`. | |
 | Memcached backend | [memcached](https://docs.djangoproject.com/en/6.0/topics/cache/#memcached) | MISSING | n/a (#407) | Use Redis or in-memory. |
 | Redis backend | [redis](https://docs.djangoproject.com/en/6.0/topics/cache/#redis) | SHIPPED | `cache-redis` feature (v0.18) | |
 | File-system cache | [filesystem](https://docs.djangoproject.com/en/6.0/topics/cache/#file-system-caching) | SHIPPED | `cache::FileCache` (`backend = "file"` + `[cache].file_cache_dir`) — `src/cache/mod.rs` | |


### PR DESCRIPTION
## Summary

Default-impl method on `Cache` that closes the direct `cache.get(key, default)` translation:

\`\`\`python
# Django
name = cache.get('username', default='anonymous')
\`\`\`

\`\`\`rust
// rustango
let name = cache.get_or(\"username\", \"anonymous\").await?;
\`\`\`

* **`&str` default** — caller passes a literal or borrowed `String`; the allocation only fires on miss (`unwrap_or_else`).
* **Read-only fallback** — does NOT write the default back to the cache (Django shape; `get_or_set` remains the fetch-or-compute-and-store path).
* Default delegates to `self.get` — backends never need to override.

## Test plan

- [x] `cargo test --features postgres,tenancy,cache --test cache_backends` — **49 / 49 pass** (45 pre-existing + 4 new)
- [x] `cargo build --no-default-features --features sqlite,tenancy` — litmus green
- [x] `cargo test --workspace --all-features --no-run` — pre-push gate green