### PR TITLE
chore(docs): fix stale Email/Cache doc claims

### DIFF
--- a/crates/rustango/src/cache/mod.rs
+++ b/crates/rustango/src/cache/mod.rs
@@ -104,8 +104,8 @@ pub trait Cache: Send + Sync + 'static {
     /// native counters typically only set TTL on first creation. Treat
     /// `ttl` as a hint, not a guarantee.
     ///
-    /// Returns 0 if the existing value isn't a valid integer (the entry
-    /// is overwritten with `by` in that case).
+    /// Non-integer existing values are treated as 0 — the counter is
+    /// overwritten with `by` and the new value is `by` itself.
     async fn incr(&self, key: &str, by: i64, ttl: Option<Duration>) -> Result<i64, CacheError> {
         let cur = self
             .get(key)

--- a/crates/rustango/src/email/mod.rs
+++ b/crates/rustango/src/email/mod.rs
@@ -22,7 +22,9 @@
 //! |---------|-------------|
 //! | [`ConsoleMailer`] | Development — prints emails to stdout. Default. |
 //! | [`InMemoryMailer`] | Tests — captures emails into a `Vec` for assertions. |
-//! | [`SmtpMailer`] | Production — connects to an SMTP relay. (Future slice — currently a stub.) |
+//! | [`FileMailer`] | Dev / staging — writes one `.eml` per send under a directory. |
+//! | [`NullMailer`] | Production guardrail — accepts and discards every send (CI / disabled mail). |
+//! | [`SmtpMailer`] | Production — async lettre + rustls SMTP relay (`email-smtp` feature). |
 //!
 //! ## Plug your own
 //!


### PR DESCRIPTION
## Summary

Two docstring corrections surfaced while auditing parity coverage. No code change.

* **`email/mod.rs` backends table** — claimed `SmtpMailer` was \"currently a stub\". It hasn't been since the lettre 0.11 wiring landed (PR #336). Also omitted `FileMailer` (#418) and `NullMailer`. Now lists all five backends with a one-line use-case each.

* **`cache/mod.rs::Cache::incr`** — docstring said \"Returns 0 if the existing value isn't a valid integer.\" Wrong: `cur` defaults to 0 on parse failure, then `new = cur.saturating_add(by) = by`, so the returned value is `by`, not 0. Rewrite to match the code.

## Test plan

- [x] `cargo build --features postgres,tenancy,email,cache` — green