### PR TITLE
docs(audit): drop stale dumpdata from Section 13 gap prose

### DIFF
--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -437,7 +437,7 @@ Django built-in management commands:
 | `create-tenant` / `create-operator` (rustango-specific) | n/a | SHIPPED | tenancy verbs | |
 | `migrate-tenant-storage` (rustango-specific) | n/a | SHIPPED | v0.26 | |
 
-Summary: **20 SHIPPED / 0 PARTIAL / 3 MISSING / 6 N/A**. Gaps: `shell` REPL (Rust constraint), `dumpdata`, i18n scaffolding (`makemessages` / `compilemessages`).
+Summary: **20 SHIPPED / 0 PARTIAL / 3 MISSING / 6 N/A**. Gaps: `shell` REPL (Rust constraint), i18n scaffolding (`makemessages` / `compilemessages`). The prior gap-prose line claimed `dumpdata` was missing, but #397 shipped it in v0.42 (see the `dumpdata` row above) — corrected.
 
 ---
 


### PR DESCRIPTION
## Summary

The Section 13 (Manage commands) Summary line still listed `dumpdata` in the \"Gaps\" enumeration even though the row immediately above marked it SHIPPED via #397 (v0.42 `manage dumpdata [--model app.Name] [--indent N]`). Trim the stale entry so the gap prose matches the table — only `shell` REPL and i18n scaffolding (`makemessages` / `compilemessages`) remain.

Numerical counts unchanged (table already counted dumpdata as SHIPPED). Doc-only.