### PR TITLE
feat(cookies): Set-Cookie builder + delete_cookie — Django parity

### DIFF
--- a/crates/rustango/src/cookies.rs
+++ b/crates/rustango/src/cookies.rs
@@ -1,0 +1,408 @@
+//! Django-shape `Set-Cookie` builder.
+//!
+//! Mirrors `django.http.HttpResponse.set_cookie(key, value, max_age=None,
+//! expires=None, path='/', domain=None, secure=False, httponly=False,
+//! samesite=None)`. Produces the `Set-Cookie` header value as a string
+//! (and an axum [`HeaderValue`] convenience).
+//!
+//! ```ignore
+//! use rustango::cookies::{Cookie, SameSite};
+//! use std::time::Duration;
+//!
+//! // Build → render.
+//! let header = Cookie::new("session", "abc123")
+//!     .path("/")
+//!     .http_only()
+//!     .secure()
+//!     .same_site(SameSite::Lax)
+//!     .max_age(Duration::from_secs(3600))
+//!     .build();
+//! // -> "session=abc123; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=3600"
+//!
+//! // Delete a cookie (Django's `response.delete_cookie(key)`).
+//! let header = Cookie::deletion("session", "/").build();
+//! // -> "session=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+//! ```
+//!
+//! ## Why not the `cookie` crate?
+//!
+//! The `cookie` crate (used by axum-extra / tower-cookies) is the
+//! production-grade choice for parsing + signed/private cookies.
+//! This module is intentionally smaller — just the `Set-Cookie`
+//! emission path Django code translates to most often. The output
+//! is a plain `String` (or `HeaderValue`), so it composes cleanly
+//! with whatever cookie crate the project uses for parsing.
+//!
+//! Doesn't validate cookie names against RFC 6265 token rules —
+//! caller is responsible for sane names (the `messages` module
+//! used `rustango_messages`, the `csrf` module uses `csrftoken`,
+//! etc.). Empty names build cleanly but produce a malformed header
+//! that browsers will reject; that's a caller bug, not a crate one.
+
+use std::time::Duration;
+
+/// Django-parity `SameSite` cookie attribute values. Default `None`
+/// in the cookie struct means the attribute is omitted entirely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SameSite {
+    /// `SameSite=Strict` — cookie withheld on all cross-site requests.
+    Strict,
+    /// `SameSite=Lax` — default browser behavior; allowed on top-
+    /// level cross-site GET navigations. **Recommended for session
+    /// cookies.**
+    Lax,
+    /// `SameSite=None` — cookie sent on all cross-site requests.
+    /// Browsers require `Secure` alongside `None` since Chrome 80.
+    None,
+}
+
+impl SameSite {
+    /// String form for the header value.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Strict => "Strict",
+            Self::Lax => "Lax",
+            Self::None => "None",
+        }
+    }
+}
+
+/// Django-shape cookie builder. Construct via [`Cookie::new`] or
+/// [`Cookie::deletion`]; chain attribute methods; finalize with
+/// [`Cookie::build`] (string) or [`Cookie::header_value`]
+/// (`axum::http::HeaderValue` — falls back to a panic-safe form on
+/// invalid bytes).
+#[derive(Debug, Clone)]
+pub struct Cookie {
+    name: String,
+    value: String,
+    path: Option<String>,
+    domain: Option<String>,
+    max_age: Option<i64>,
+    expires: Option<String>,
+    http_only: bool,
+    secure: bool,
+    same_site: Option<SameSite>,
+}
+
+impl Cookie {
+    /// Start a new cookie with the given name + value. Default
+    /// attributes: no `Path`, no `Domain`, no `Max-Age`, no
+    /// `Expires`, NO `HttpOnly` / `Secure` / `SameSite`. Chain
+    /// builder methods to set them.
+    ///
+    /// Django defaults `Path=/`; we don't apply that here so the
+    /// builder is composable — callers wire `.path("/")` explicitly
+    /// (most modern axum cookies do).
+    #[must_use]
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            value: value.into(),
+            path: None,
+            domain: None,
+            max_age: None,
+            expires: None,
+            http_only: false,
+            secure: false,
+            same_site: None,
+        }
+    }
+
+    /// Django-parity `response.delete_cookie(key, path='/', domain=None)`.
+    /// Returns a builder pre-set to expire the cookie at the Unix
+    /// epoch (`Max-Age=0` + `Expires=Thu, 01 Jan 1970 00:00:00 GMT`)
+    /// so browsers drop it on receipt.
+    ///
+    /// `path` must match the original `Set-Cookie`'s path — browsers
+    /// scope the delete to the path. Django defaults to `/`; pass
+    /// the same path you used on creation.
+    #[must_use]
+    pub fn deletion(name: impl Into<String>, path: impl Into<String>) -> Self {
+        Self::new(name, "")
+            .path(path)
+            .max_age(Duration::from_secs(0))
+            .expires_at_epoch()
+    }
+
+    /// `Path=<path>` attribute. Scopes which request paths the
+    /// browser sends the cookie on. Most projects want `"/"`.
+    #[must_use]
+    pub fn path(mut self, path: impl Into<String>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    /// `Domain=<domain>` attribute. Without it the cookie is
+    /// host-only (sent only to the exact host that set it).
+    #[must_use]
+    pub fn domain(mut self, domain: impl Into<String>) -> Self {
+        self.domain = Some(domain.into());
+        self
+    }
+
+    /// `Max-Age=<secs>` attribute. Browsers prefer this over
+    /// `Expires` when both are set.
+    #[must_use]
+    pub fn max_age(mut self, ttl: Duration) -> Self {
+        self.max_age = Some(i64::try_from(ttl.as_secs()).unwrap_or(i64::MAX));
+        self
+    }
+
+    /// Explicit `Expires=<http-date>` attribute. Most callers prefer
+    /// [`Self::max_age`] which is relative + clock-independent.
+    /// Pass an RFC 1123 IMF-fixdate string
+    /// (`"Thu, 01 Jan 1970 00:00:00 GMT"`); pair with
+    /// [`crate::http_date::http_date`] to format from a Unix
+    /// timestamp.
+    #[must_use]
+    pub fn expires(mut self, http_date_str: impl Into<String>) -> Self {
+        self.expires = Some(http_date_str.into());
+        self
+    }
+
+    /// Pre-set `Expires` to the Unix epoch — convenience shorthand
+    /// for [`Self::deletion`]. Useful when chaining manually.
+    #[must_use]
+    pub fn expires_at_epoch(mut self) -> Self {
+        self.expires = Some("Thu, 01 Jan 1970 00:00:00 GMT".to_owned());
+        self
+    }
+
+    /// Set the `HttpOnly` flag — cookie unreachable from JS
+    /// (defends against XSS-stealing session cookies). Default
+    /// `false`.
+    #[must_use]
+    pub fn http_only(mut self) -> Self {
+        self.http_only = true;
+        self
+    }
+
+    /// Set the `Secure` flag — cookie only sent over HTTPS.
+    /// Required when `SameSite=None`.
+    #[must_use]
+    pub fn secure(mut self) -> Self {
+        self.secure = true;
+        self
+    }
+
+    /// Set the `SameSite=<value>` attribute. See [`SameSite`] for
+    /// strict / lax / none semantics.
+    #[must_use]
+    pub fn same_site(mut self, value: SameSite) -> Self {
+        self.same_site = Some(value);
+        self
+    }
+
+    /// Build the final `Set-Cookie` header value as a `String`.
+    /// Suitable for `axum::http::HeaderValue::from_str`.
+    ///
+    /// Attribute order follows the Django shape:
+    /// `<name>=<value>; Path; Domain; Max-Age; Expires; HttpOnly;
+    /// Secure; SameSite`.
+    #[must_use]
+    pub fn build(&self) -> String {
+        let mut s = String::with_capacity(64);
+        s.push_str(&self.name);
+        s.push('=');
+        s.push_str(&self.value);
+        if let Some(p) = &self.path {
+            s.push_str("; Path=");
+            s.push_str(p);
+        }
+        if let Some(d) = &self.domain {
+            s.push_str("; Domain=");
+            s.push_str(d);
+        }
+        if let Some(m) = self.max_age {
+            use std::fmt::Write as _;
+            let _ = write!(s, "; Max-Age={m}");
+        }
+        if let Some(e) = &self.expires {
+            s.push_str("; Expires=");
+            s.push_str(e);
+        }
+        if self.http_only {
+            s.push_str("; HttpOnly");
+        }
+        if self.secure {
+            s.push_str("; Secure");
+        }
+        if let Some(ss) = self.same_site {
+            s.push_str("; SameSite=");
+            s.push_str(ss.as_str());
+        }
+        s
+    }
+
+    /// Build as an `axum::http::HeaderValue` directly. Returns
+    /// `None` if the rendered string contains bytes axum considers
+    /// invalid (control characters, etc.) — should never happen
+    /// with sane caller-supplied names/values, but exposed as
+    /// `Option` to avoid panicking on attacker-controlled input.
+    #[must_use]
+    pub fn header_value(&self) -> Option<axum::http::HeaderValue> {
+        axum::http::HeaderValue::from_str(&self.build()).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------- basic shape --------
+
+    #[test]
+    fn minimal_cookie_renders_just_name_equals_value() {
+        let s = Cookie::new("session", "abc").build();
+        assert_eq!(s, "session=abc");
+    }
+
+    #[test]
+    fn empty_value_renders_cleanly() {
+        // Common shape during a deletion before path/expires kick in.
+        let s = Cookie::new("session", "").build();
+        assert_eq!(s, "session=");
+    }
+
+    // -------- attribute coverage --------
+
+    #[test]
+    fn path_attribute() {
+        assert_eq!(Cookie::new("k", "v").path("/").build(), "k=v; Path=/");
+    }
+
+    #[test]
+    fn domain_attribute() {
+        assert_eq!(
+            Cookie::new("k", "v").domain(".example.com").build(),
+            "k=v; Domain=.example.com"
+        );
+    }
+
+    #[test]
+    fn max_age_attribute() {
+        assert_eq!(
+            Cookie::new("k", "v")
+                .max_age(Duration::from_secs(3600))
+                .build(),
+            "k=v; Max-Age=3600"
+        );
+    }
+
+    #[test]
+    fn expires_attribute() {
+        assert_eq!(
+            Cookie::new("k", "v")
+                .expires("Thu, 01 Jan 1970 00:00:00 GMT")
+                .build(),
+            "k=v; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+        );
+    }
+
+    #[test]
+    fn http_only_flag() {
+        assert_eq!(Cookie::new("k", "v").http_only().build(), "k=v; HttpOnly");
+    }
+
+    #[test]
+    fn secure_flag() {
+        assert_eq!(Cookie::new("k", "v").secure().build(), "k=v; Secure");
+    }
+
+    #[test]
+    fn same_site_lax() {
+        assert_eq!(
+            Cookie::new("k", "v").same_site(SameSite::Lax).build(),
+            "k=v; SameSite=Lax"
+        );
+    }
+
+    #[test]
+    fn same_site_strict() {
+        assert_eq!(
+            Cookie::new("k", "v").same_site(SameSite::Strict).build(),
+            "k=v; SameSite=Strict"
+        );
+    }
+
+    #[test]
+    fn same_site_none() {
+        assert_eq!(
+            Cookie::new("k", "v").same_site(SameSite::None).build(),
+            "k=v; SameSite=None"
+        );
+    }
+
+    // -------- attribute ordering --------
+
+    #[test]
+    fn full_attribute_set_renders_in_django_order() {
+        let s = Cookie::new("session", "abc")
+            .path("/")
+            .domain("example.com")
+            .max_age(Duration::from_secs(3600))
+            .expires("Sun, 06 Nov 1994 08:49:37 GMT")
+            .http_only()
+            .secure()
+            .same_site(SameSite::Lax)
+            .build();
+        assert_eq!(
+            s,
+            "session=abc; Path=/; Domain=example.com; Max-Age=3600; Expires=Sun, 06 Nov 1994 08:49:37 GMT; HttpOnly; Secure; SameSite=Lax"
+        );
+    }
+
+    // -------- deletion (Django parity) --------
+
+    #[test]
+    fn deletion_shape() {
+        // Django `response.delete_cookie('session')` — the cookie
+        // gets set to empty with Max-Age=0 + Expires=epoch so the
+        // browser drops it.
+        let s = Cookie::deletion("session", "/").build();
+        assert_eq!(
+            s,
+            "session=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+        );
+    }
+
+    #[test]
+    fn deletion_with_domain_for_subdomain_scoping() {
+        // Browsers scope deletes by (name, path, domain). Subdomain
+        // cookies need the same Domain on delete.
+        let s = Cookie::deletion("session", "/")
+            .domain(".example.com")
+            .build();
+        assert!(s.contains("Domain=.example.com"));
+        assert!(s.contains("Max-Age=0"));
+    }
+
+    // -------- header_value --------
+
+    #[test]
+    fn header_value_returns_some_for_normal_cookie() {
+        let v = Cookie::new("session", "abc").path("/").header_value();
+        assert!(v.is_some());
+    }
+
+    #[test]
+    fn header_value_returns_none_for_invalid_chars() {
+        // A NUL byte in the value should make axum reject the
+        // HeaderValue construction.
+        let v = Cookie::new("session", "a\0b").header_value();
+        assert!(v.is_none(), "axum should reject NUL bytes in headers");
+    }
+
+    // -------- expires_at_epoch convenience --------
+
+    #[test]
+    fn expires_at_epoch_uses_canonical_imf_fixdate() {
+        let s = Cookie::new("k", "").expires_at_epoch().build();
+        assert!(
+            s.contains("Expires=Thu, 01 Jan 1970 00:00:00 GMT"),
+            "got: {s}"
+        );
+    }
+}

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -1037,6 +1037,13 @@ pub mod lorem;
 /// per RFC 1123. `http_date::http_date(secs)` + `parse_http_date(s)`.
 pub mod http_date;
 
+/// Django-shape `Set-Cookie` builder — `Cookie::new(name, value)
+/// .path("/").max_age(secs).http_only().secure().same_site(...)
+/// .build()` produces an axum-ready `HeaderValue`. Replaces
+/// scattered hand-rolled cookie strings across `messages` / `csrf`
+/// / `jwt` / `admin` / `tenancy` modules.
+pub mod cookies;
+
 /// Django messages framework — `messages.success/info/warning/error/debug`
 /// flash storage backed by a signed cookie. Issue #9.
 pub mod messages;


### PR DESCRIPTION
## Summary

Django ships `response.set_cookie(key, value, max_age, expires, path, domain, secure, httponly, samesite)` and `response.delete_cookie(key, path, domain)` as the canonical way to emit Set-Cookie headers. rustango had no canonical builder — admin / tenancy / messages / csrf / jwt each rolled their own `format!()` strings.

## New `crate::cookies` module

* **`Cookie::new(name, value)`** — builder. Chain `.path()` / `.domain()` / `.max_age(Duration)` / `.expires(http_date)` / `.http_only()` / `.secure()` / `.same_site(SameSite::{Strict,Lax,None})`. Finalize with `.build() -> String` or `.header_value() -> Option<HeaderValue>`.

* **`Cookie::deletion(name, path)`** — Django parity. Pre-set to `value=\"\"` + `Max-Age=0` + `Expires=Thu, 01 Jan 1970 00:00:00 GMT` so browsers drop the cookie on receipt.

* **`SameSite::{Strict, Lax, None}`** — typed enum matching Django's SameSite shape.

Attribute rendering follows Django's order: `name=value; Path; Domain; Max-Age; Expires; HttpOnly; Secure; SameSite`.

`header_value()` returns `Option<HeaderValue>` rather than panicking when the rendered string carries bytes axum rejects (NUL etc.) — defensive against attacker-controlled cookie values.

Existing modules (messages / csrf / jwt / admin) still ship their hand-rolled strings — this PR adds the canonical helper but doesn't refactor downstream consumers. New code should reach for `crate::cookies::Cookie` first.

## Test plan

- [x] `cargo test --lib --features postgres,tenancy cookies::` — **17 / 17 pass**
  - basic: minimal / empty value
  - attributes: path / domain / max-age / expires / http-only / secure / same-site (3 variants)
  - full attribute set renders in Django order
  - deletion: canonical shape / with-domain for subdomain scoping
  - header_value: valid → Some / NUL → None
  - expires_at_epoch uses canonical IMF-fixdate
- [x] `cargo build --no-default-features --features sqlite,tenancy` — litmus green