### PR TITLE
feat(email): parseaddr — Django email.utils.parseaddr parity

### DIFF
--- a/crates/rustango/src/email/mod.rs
+++ b/crates/rustango/src/email/mod.rs
@@ -299,6 +299,82 @@ pub fn formataddr(name: Option<&str>, address: &str) -> String {
     }
 }
 
+/// Django-parity inverse of [`formataddr`] — Python's
+/// `email.utils.parseaddr(address)`. Splits a `"Display Name
+/// <user@example.com>"` style header value into `(name, address)`.
+///
+/// Returns `(name, address)` as owned `String`s. When the input
+/// has no angle-bracketed address, the whole string is returned
+/// as the address with an empty name (Python shape — `parseaddr`
+/// always returns a pair, never raises).
+///
+/// Backslash escapes inside a double-quoted display name are
+/// un-escaped (`\"` → `"`, `\\` → `\`). Other escape sequences
+/// pass through literally — matching Python's email.utils
+/// behavior, which doesn't expand `\n` / `\t` inside quoted-string
+/// productions.
+///
+/// ```ignore
+/// use rustango::email::parseaddr;
+/// // Display name + address.
+/// assert_eq!(
+///     parseaddr("Alice <alice@example.com>"),
+///     ("Alice".to_owned(), "alice@example.com".to_owned())
+/// );
+/// // Quoted display name with escaped backslash + dquote.
+/// assert_eq!(
+///     parseaddr(r#""Smith, John" <john@example.com>"#),
+///     ("Smith, John".to_owned(), "john@example.com".to_owned())
+/// );
+/// // No angle brackets → entire string is the address, name is empty.
+/// assert_eq!(
+///     parseaddr("bare@example.com"),
+///     (String::new(), "bare@example.com".to_owned())
+/// );
+/// ```
+#[must_use]
+pub fn parseaddr(address: &str) -> (String, String) {
+    let trimmed = address.trim();
+    // Find the LAST `<` paired with the LAST `>` (Python takes the
+    // outermost angle-bracketed group).
+    let lt = trimmed.rfind('<');
+    let gt = trimmed.rfind('>');
+    match (lt, gt) {
+        (Some(l), Some(g)) if g > l => {
+            let name_raw = trimmed[..l].trim();
+            let addr = trimmed[l + 1..g].trim().to_owned();
+            let name = unquote_display_name(name_raw);
+            (name, addr)
+        }
+        _ => (String::new(), trimmed.to_owned()),
+    }
+}
+
+/// Strip surrounding `"..."` and un-escape backslash sequences.
+/// Internal helper for [`parseaddr`].
+fn unquote_display_name(raw: &str) -> String {
+    let raw = raw.trim();
+    if raw.len() >= 2 && raw.starts_with('"') && raw.ends_with('"') {
+        let inner = &raw[1..raw.len() - 1];
+        let mut out = String::with_capacity(inner.len());
+        let mut chars = inner.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\\' {
+                if let Some(&next) = chars.peek() {
+                    if next == '\\' || next == '"' {
+                        out.push(next);
+                        chars.next();
+                        continue;
+                    }
+                }
+            }
+            out.push(c);
+        }
+        return out;
+    }
+    raw.to_owned()
+}
+
 // ------------------------------------------------------------------ MailError
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/rustango/tests/email_self_send.rs
+++ b/crates/rustango/tests/email_self_send.rs
@@ -3,7 +3,7 @@
 
 #![cfg(feature = "email")]
 
-use rustango::email::{formataddr, Email, InMemoryMailer, Mailer, NullMailer};
+use rustango::email::{formataddr, parseaddr, Email, InMemoryMailer, Mailer, NullMailer};
 
 // ------------------------------------------------------------------ Email::send
 
@@ -127,4 +127,81 @@ fn formataddr_round_trips_through_email_from() {
         .subject("s")
         .body("b");
     assert_eq!(e.from.as_deref(), Some(formatted.as_str()));
+}
+
+// ------------------------------------------------------------------ parseaddr (Django parity inverse)
+
+#[test]
+fn parseaddr_splits_name_and_address() {
+    let (name, addr) = parseaddr("Alice <alice@example.com>");
+    assert_eq!(name, "Alice");
+    assert_eq!(addr, "alice@example.com");
+}
+
+#[test]
+fn parseaddr_bare_address_has_empty_name() {
+    let (name, addr) = parseaddr("bare@example.com");
+    assert!(name.is_empty());
+    assert_eq!(addr, "bare@example.com");
+}
+
+#[test]
+fn parseaddr_quoted_name_with_comma() {
+    // Round-trip: formataddr puts the quotes, parseaddr strips them.
+    let formatted = formataddr(Some("Smith, John"), "john@example.com");
+    let (name, addr) = parseaddr(&formatted);
+    assert_eq!(name, "Smith, John");
+    assert_eq!(addr, "john@example.com");
+}
+
+#[test]
+fn parseaddr_handles_escaped_quote_in_name() {
+    // `"O\"Brien" <o@example.com>` → name = `O"Brien`
+    let (name, addr) = parseaddr(r#""O\"Brien" <o@example.com>"#);
+    assert_eq!(name, "O\"Brien");
+    assert_eq!(addr, "o@example.com");
+}
+
+#[test]
+fn parseaddr_handles_escaped_backslash() {
+    let (name, addr) = parseaddr(r#""path\\name" <x@example.com>"#);
+    assert_eq!(name, "path\\name");
+    assert_eq!(addr, "x@example.com");
+}
+
+#[test]
+fn parseaddr_empty_input() {
+    let (name, addr) = parseaddr("");
+    assert!(name.is_empty());
+    assert!(addr.is_empty());
+}
+
+#[test]
+fn parseaddr_trims_surrounding_whitespace() {
+    let (name, addr) = parseaddr("  Alice <alice@example.com>  ");
+    assert_eq!(name, "Alice");
+    assert_eq!(addr, "alice@example.com");
+}
+
+#[test]
+fn formataddr_parseaddr_round_trip() {
+    // Every reasonable input survives the round-trip.
+    for (name_opt, addr) in [
+        (Some("Alice"), "alice@example.com"),
+        (Some("Smith, John"), "j@b.com"),
+        (None, "raw@b.com"),
+        (Some("Dr. Sarah"), "sarah@example.com"),
+    ] {
+        let formatted = formataddr(name_opt, addr);
+        let (got_name, got_addr) = parseaddr(&formatted);
+        assert_eq!(
+            got_addr, addr,
+            "addr mismatch for input {name_opt:?} {addr:?}"
+        );
+        let expected_name = name_opt.unwrap_or("");
+        assert_eq!(
+            got_name, expected_name,
+            "name mismatch for input {name_opt:?}"
+        );
+    }
 }


### PR DESCRIPTION
Inverse of formataddr — split 'Name <addr>' into tuple. 8 tests, all pass + 12 pre-existing.