### PR TITLE
docs(audit): note escapejs + truncate_html + humanize public API

### DIFF
--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -44,12 +44,12 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 22. Async support | 4 | 0 | 0 | 3 |
 | 23. DRF parity | 22 | 0 | 1 | 0 |
 | 24. contrib modules | 12 | 1 | 3 | 2 |
-| 25. `django.utils.*` helpers | 57 | 0 | 0 | 0 |
-| **Totals** | **427** | **11** | **21** | **19** |
+| 25. `django.utils.*` helpers | 62 | 0 | 0 | 0 |
+| **Totals** | **432** | **11** | **21** | **19** |
 
-Coverage = 427 / (427 + 11 + 21) = **93% full, 2% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
+Coverage = 432 / (432 + 11 + 21) = **93% full, 2% partial, 5% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **95%**.
 
-Snapshot date: 2026-06-05 (post-v0.42 plus 55+ Django `utils.*` parity helpers across PRs #619–#679: 11 new modules + 10 widened modules — see Section 25 for the per-helper table).
+Snapshot date: 2026-06-05 (post-v0.42 plus 60+ Django `utils.*` parity helpers across PRs #619–#683: 11 new modules + 11 widened modules — see Section 25 for the per-helper table).
 
 ---
 
@@ -731,6 +731,12 @@ below corresponds to a Django module / function the port targets.
 | `django.utils.html.strip_spaces_between_tags` | [strip_spaces_between_tags](https://docs.djangoproject.com/en/6.0/ref/utils/#django.utils.html.strip_spaces_between_tags) | SHIPPED | `text::strip_spaces_between_tags` (PR #668) — `{% spaceless %}` template tag analog |
 | `django.utils.html.json_script` | [json_script](https://docs.djangoproject.com/en/6.0/ref/utils/#django.utils.html.json_script) | SHIPPED | `text::json_script(value, element_id)` (PR #677) — wraps a JSON-serialized value in `<script id="..." type="application/json">` with XSS-defang escaping (`<`/`>`/`&` → `\uXXXX`) + HTML-attr-escaped element_id |
 | `django.utils.timesince.{timesince,timeuntil}` | [timesince](https://docs.djangoproject.com/en/6.0/ref/utils/#django.utils.timesince.timesince) | SHIPPED | `timesince::timesince(d, now, depth)` + `timeuntil` (PR #678) — Django-style depth-respecting "4 days, 6 hours" output. Unconditional module (no `template_views` gate); Tera filter wrappers stay in `humanize::` for the single-unit short form |
+| `django.utils.html.escapejs` | [escapejs](https://docs.djangoproject.com/en/6.0/ref/utils/#django.utils.html.escapejs) | SHIPPED | `text::escapejs(s)` (PR #681) — escape for safe embedding inside a JS string literal in HTML. Set: quote/backslash chars + HTML breakout (`<`/`>`/`&`) + event-handler defense (`=`/`-`/`;`) + U+2028/U+2029 + all ASCII control chars. Tera filter delegates. |
+| `django.utils.text.Truncator(s).chars(html=True)` | [Truncator](https://docs.djangoproject.com/en/6.0/ref/utils/#django.utils.text.Truncator) | SHIPPED | `text::truncate_html_chars(html, max, suffix)` + `truncate_html_words` (PR #682) — count visible chars/words outside tag brackets; maintain open-tag stack; close tags in reverse after suffix; HTML5 void-element list (`br`/`img`/etc.) doesn't stack; entities count as 1 unit |
+| `django.contrib.humanize.intword` | [intword](https://docs.djangoproject.com/en/6.0/ref/contrib/humanize/#intword) | SHIPPED | `humanize::intword(n)` (PR #683) — "1.2 million" / "1.0 billion"; million..decillion scale |
+| `django.contrib.humanize.naturalsize` | [naturalsize](https://docs.djangoproject.com/en/6.0/ref/contrib/humanize/#naturalsize) | SHIPPED | `humanize::naturalsize(n)` (PR #683) — KiB-scale binary "1.0 KB" / "1.5 MB"; "1 byte" singular |
+| `django.contrib.humanize.ordinal` | [ordinal](https://docs.djangoproject.com/en/6.0/ref/contrib/humanize/#ordinal) | SHIPPED | `humanize::ordinal(n)` (PR #683) — "1st"/"2nd"/"3rd"/"11th"; teens special-cased |
+| `django.contrib.humanize.apnumber` | [apnumber](https://docs.djangoproject.com/en/6.0/ref/contrib/humanize/#apnumber) | SHIPPED | `humanize::apnumber(n)` (PR #683) — AP-style "one".."nine" for 1..=9 |
 | `django.utils.crypto.get_random_string` | [get_random_string](https://docs.djangoproject.com/en/6.0/ref/utils/#django.utils.crypto.get_random_string) | SHIPPED | `random::get_random_string(length, allowed_chars)` + `get_random_string_default` (PR #637) — CSPRNG-backed `crate::random` module with 5 predefined alphabets |
 | `django.utils.crypto.constant_time_compare` | [constant_time_compare](https://docs.djangoproject.com/en/6.0/ref/utils/#django.utils.crypto.constant_time_compare) | SHIPPED | `crypto::constant_time_compare(a, b)` (PR #647) — consolidates 2 prior private copies |
 | `django.utils.encoding.iri_to_uri` | [iri_to_uri](https://docs.djangoproject.com/en/6.0/ref/unicode/#django.utils.encoding.iri_to_uri) | SHIPPED | `url_codec::iri_to_uri` (PR #648) |
@@ -773,12 +779,12 @@ below corresponds to a Django module / function the port targets.
 | Mail settings (SERVER_EMAIL / EMAIL_SUBJECT_PREFIX / EMAIL_TIMEOUT) | (sec 14) | SHIPPED | `MailSettings.{server_email, email_subject_prefix, smtp_timeout_secs}` (PRs #619, #626) |
 | Email attachments | (sec 18) | SHIPPED | `Email::attach(filename, bytes, mimetype)` + `attach_text` (PR #621) |
 
-Summary: **57 SHIPPED / 0 PARTIAL / 0 MISSING / 0 N/A** (Django `utils.*` helpers).
+Summary: **62 SHIPPED / 0 PARTIAL / 0 MISSING / 0 N/A** (Django `utils.*` helpers).
 
 Net effect of the 2026-06-04→06-05 batch:
 * **11 new public modules**: `random`, `base36`, `base62`, `lorem`, `http_date`, `http_methods`, `cookies`, `numberformat`, `dateparse`, `dateformat`, `timesince`
-* **Widened existing modules**: `text` (+16 helpers incl. `json_script`), `url_codec` (+4), `shortcuts` (+9), `validators` (+7), `email` (+5 incl. parseaddr / Email::send / send_mail / send_many / BadHeader), `crypto` (+1), `compression` (+2), `cache_fragment` (+1), `cache_page` (+1), `cache` (+3), `urls` (+3), `dateformat` (+5 codes P/f/W/t/o via PR #679)
-* **31 PRs admin-merged across the sweep**: #619–#679 (gaps in numbering are doc-only PRs that landed in the same window)
+* **Widened existing modules**: `text` (+19 helpers incl. `json_script`, `escapejs`, `truncate_html_chars`, `truncate_html_words`), `url_codec` (+4), `shortcuts` (+9), `validators` (+7), `email` (+5 incl. parseaddr / Email::send / send_mail / send_many / BadHeader), `crypto` (+1), `compression` (+2), `cache_fragment` (+1), `cache_page` (+1), `cache` (+3), `urls` (+3), `dateformat` (+5 codes P/f/W/t/o via PR #679), `humanize` (+4 public — intword/naturalsize/ordinal/apnumber via PR #683)
+* **35 PRs admin-merged across the sweep**: #619–#683 (gaps in numbering are doc-only PRs that landed in the same window)
 
 Bulk closure of Django `utils.*` API surface — the most-common helper functions a Django port reaches for during translation now have direct rustango equivalents. Outstanding gaps in this category: `regex_helper.normalize` (URL-conf regex normalization — niche), `formats.localize` (locale-aware value rendering — large lift, requires per-locale config wiring), `safestring.mark_safe` (N/A — Tera handles autoescape natively).
 


### PR DESCRIPTION
Section 25 57 → 62 SHIPPED after PRs #681/#682/#683. Totals 427 → 432.