### PR TITLE
fix(url_codec): mark uri_to_iri doctest ignore — fixes CI

### DIFF
--- a/crates/rustango/src/url_codec.rs
+++ b/crates/rustango/src/url_codec.rs
@@ -154,7 +154,7 @@ pub fn iri_to_uri(iri: &str) -> String {
 /// verbatim (no replacement char inserted). Single `%` followed
 /// by non-hex characters passes through as `%` plus the rest.
 ///
-/// ```
+/// ```ignore
 /// use rustango::url_codec::uri_to_iri;
 ///
 /// // Non-ASCII UTF-8 decodes back.


### PR DESCRIPTION
PR #688 introduced a runnable doctest that hits E0603 because url_codec is pub(crate). 9 CI failures since PR #688. Fix: ignore the fence to match the pattern used by iri_to_uri / escape_uri_path.