### PR TITLE
fix(tenancy): add FK metadata to permission models — close silent cascade-loss (#560)

### DIFF
--- a/crates/rustango/src/tenancy/auth_backends.rs
+++ b/crates/rustango/src/tenancy/auth_backends.rs
@@ -170,6 +170,7 @@ pub struct ApiKey {
     #[rustango(primary_key)]
     pub id: crate::sql::Auto<i64>,
     /// `rustango_users.id`
+    #[rustango(fk = "rustango_users", on = "id", on_delete = "cascade")]
     pub user_id: i64,
     /// 8-char hex prefix — public, used to look up the row.
     #[rustango(max_length = 8)]

--- a/crates/rustango/src/tenancy/permissions.rs
+++ b/crates/rustango/src/tenancy/permissions.rs
@@ -126,6 +126,7 @@ pub struct RolePermission {
     #[rustango(primary_key)]
     pub id: Auto<i64>,
     /// The role this permission belongs to.
+    #[rustango(fk = "rustango_roles", on = "id", on_delete = "cascade")]
     pub role_id: i64,
     /// Permission codename — `{table}.{action}`, e.g. `post.change`.
     #[rustango(max_length = 100)]
@@ -143,8 +144,10 @@ pub struct UserRole {
     #[rustango(primary_key)]
     pub id: Auto<i64>,
     /// `rustango_users.id`
+    #[rustango(fk = "rustango_users", on = "id", on_delete = "cascade")]
     pub user_id: i64,
     /// `rustango_roles.id`
+    #[rustango(fk = "rustango_roles", on = "id", on_delete = "cascade")]
     pub role_id: i64,
 }
 
@@ -164,6 +167,7 @@ pub struct UserPermission {
     #[rustango(primary_key)]
     pub id: Auto<i64>,
     /// `rustango_users.id`
+    #[rustango(fk = "rustango_users", on = "id", on_delete = "cascade")]
     pub user_id: i64,
     /// Permission codename — `{table}.{action}`.
     #[rustango(max_length = 100)]


### PR DESCRIPTION
Silent-footgun fix from #560. RolePermission/UserRole/UserPermission/ApiKey had bare i64 FKs with no rustango(fk=) annotation, so cascade deletes never fired. Add fk + on_delete=cascade annotations to 5 FK columns. 3083 lib tests pass; litmus green.