### PR TITLE
refactor(admin): collapse CRUD-handler prologue via resolve_model* helpers (#562)

### DIFF
--- a/crates/rustango/src/admin/helpers.rs
+++ b/crates/rustango/src/admin/helpers.rs
@@ -192,6 +192,60 @@ pub(crate) fn sidebar_context(
         .collect()
 }
 
+/// Resolve `table` to a `ModelSchema` or emit `AdminError::TableNotFound`.
+/// Folds the `lookup_model(...).ok_or(AdminError::TableNotFound { table })`
+/// pattern repeated across every CRUD handler (issue #562). Takes
+/// `table` by reference so the caller can keep ownership for further
+/// use; the error variant clones internally on the not-found path.
+///
+/// Use this from any admin handler that needs the model + the standard
+/// 404 fallthrough. Handlers that also need the PK use
+/// [`resolve_model_and_pk`] instead.
+pub(crate) fn resolve_model(
+    state: &AppState,
+    table: &str,
+) -> Result<&'static ModelSchema, crate::admin::errors::AdminError> {
+    lookup_model(state, table).ok_or_else(|| crate::admin::errors::AdminError::TableNotFound {
+        table: table.to_owned(),
+    })
+}
+
+/// Resolve `table` to a `ModelSchema` and parse `pk_raw` against the
+/// model's primary-key field. Folds the second prologue pattern that
+/// recurs across every detail/edit/delete handler:
+///
+/// ```ignore
+/// let model = lookup_model(&state, &table).ok_or(AdminError::TableNotFound { ... })?;
+/// let pk_field = model.primary_key().ok_or_else(|| AdminError::Internal(...))?;
+/// let pk_value = forms::parse_pk_string(pk_field, &pk_raw).map_err(AdminError::Form)?;
+/// ```
+///
+/// Issue #562. Returns the model, the PK `FieldSchema`, and the parsed
+/// `SqlValue` ready to bind in a `WHERE pk = ?` clause.
+pub(crate) fn resolve_model_and_pk(
+    state: &AppState,
+    table: &str,
+    pk_raw: &str,
+) -> Result<
+    (
+        &'static ModelSchema,
+        &'static crate::core::FieldSchema,
+        crate::core::SqlValue,
+    ),
+    crate::admin::errors::AdminError,
+> {
+    let model = resolve_model(state, table)?;
+    let pk_field = model.primary_key().ok_or_else(|| {
+        crate::admin::errors::AdminError::Internal(format!(
+            "model `{}` has no primary key",
+            model.name
+        ))
+    })?;
+    let pk_value = crate::forms::parse_pk_string(pk_field, pk_raw)
+        .map_err(crate::admin::errors::AdminError::Form)?;
+    Ok((model, pk_field, pk_value))
+}
+
 /// Resolve `table` to a `ModelSchema`, but only if the admin is configured
 /// to expose it. A model that exists but is filtered out via `show_only`
 /// returns `None` here, which surfaces to users as a 404 — same response

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -17,7 +17,7 @@ use super::errors::AdminError;
 use super::forms;
 use super::helpers::{
     build_fk_joins, chrome_context, fk_map_from_joined_rows_json, lookup_model, pager_suffix,
-    render_cell_json, render_form,
+    render_cell_json, render_form, resolve_model, resolve_model_and_pk,
 };
 use super::render;
 use super::templates::render_with_chrome;
@@ -236,7 +236,7 @@ pub(crate) async fn table_view(
     Query(params): Query<HashMap<String, String>>,
     State(state): State<AppState>,
 ) -> Result<Html<String>, AdminError> {
-    let model = lookup_model(&state, &table).ok_or(AdminError::TableNotFound { table })?;
+    let model = resolve_model(&state, &table)?;
     let pk_field = model.primary_key();
     let admin_cfg = model
         .admin
@@ -1516,7 +1516,7 @@ pub(crate) async fn autocomplete_view(
     Query(params): Query<HashMap<String, String>>,
     State(state): State<AppState>,
 ) -> Result<axum::Json<serde_json::Value>, AdminError> {
-    let model = lookup_model(&state, &table).ok_or(AdminError::TableNotFound { table })?;
+    let model = resolve_model(&state, &table)?;
     let admin_cfg = model
         .admin
         .copied()
@@ -1614,13 +1614,7 @@ pub(crate) async fn detail_view(
     Path((table, pk_raw)): Path<(String, String)>,
     State(state): State<AppState>,
 ) -> Result<Html<String>, AdminError> {
-    let model = lookup_model(&state, &table).ok_or(AdminError::TableNotFound {
-        table: table.clone(),
-    })?;
-    let pk_field = model.primary_key().ok_or_else(|| {
-        AdminError::Internal(format!("model `{}` has no primary key", model.name))
-    })?;
-    let pk_value = forms::parse_pk_string(pk_field, &pk_raw).map_err(AdminError::Form)?;
+    let (model, pk_field, pk_value) = resolve_model_and_pk(&state, &table, &pk_raw)?;
 
     let detail_fields: Vec<&'static FieldSchema> = model.scalar_fields().collect();
     let row = crate::sql::select_one_row_as_json(
@@ -1836,7 +1830,7 @@ pub(crate) async fn create_form(
     Path(table): Path<String>,
     State(state): State<AppState>,
 ) -> Result<Html<String>, AdminError> {
-    let model = lookup_model(&state, &table).ok_or(AdminError::TableNotFound { table })?;
+    let model = resolve_model(&state, &table)?;
     if !state.can_add(model.table) {
         return Err(AdminError::ReadOnly {
             table: model.table.to_owned(),
@@ -1888,9 +1882,7 @@ pub(crate) async fn create_submit(
     State(state): State<AppState>,
     Form(form): Form<HashMap<String, String>>,
 ) -> Result<Response, AdminError> {
-    let model = lookup_model(&state, &table).ok_or(AdminError::TableNotFound {
-        table: table.clone(),
-    })?;
+    let model = resolve_model(&state, &table)?;
     if !state.can_add(model.table) {
         return Err(AdminError::ReadOnly {
             table: model.table.to_owned(),
@@ -1986,13 +1978,7 @@ pub(crate) async fn edit_form(
     Path((table, pk_raw)): Path<(String, String)>,
     State(state): State<AppState>,
 ) -> Result<Html<String>, AdminError> {
-    let model = lookup_model(&state, &table).ok_or(AdminError::TableNotFound {
-        table: table.clone(),
-    })?;
-    let pk_field = model.primary_key().ok_or_else(|| {
-        AdminError::Internal(format!("model `{}` has no primary key", model.name))
-    })?;
-    let pk_value = forms::parse_pk_string(pk_field, &pk_raw).map_err(AdminError::Form)?;
+    let (model, pk_field, pk_value) = resolve_model_and_pk(&state, &table, &pk_raw)?;
 
     let edit_fields: Vec<&'static FieldSchema> = model.scalar_fields().collect();
     let row = crate::sql::select_one_row_as_json(
@@ -2073,9 +2059,7 @@ pub(crate) async fn update_submit(
     State(state): State<AppState>,
     Form(form): Form<HashMap<String, String>>,
 ) -> Result<Response, AdminError> {
-    let model = lookup_model(&state, &table).ok_or(AdminError::TableNotFound {
-        table: table.clone(),
-    })?;
+    let model = resolve_model(&state, &table)?;
     if state.is_read_only(model.table) {
         return Err(AdminError::ReadOnly {
             table: model.table.to_owned(),
@@ -2237,9 +2221,7 @@ pub(crate) async fn delete_submit(
     Path((table, pk_raw)): Path<(String, String)>,
     State(state): State<AppState>,
 ) -> Result<Response, AdminError> {
-    let model = lookup_model(&state, &table).ok_or(AdminError::TableNotFound {
-        table: table.clone(),
-    })?;
+    let model = resolve_model(&state, &table)?;
     if !state.can_delete(model.table) {
         return Err(AdminError::ReadOnly {
             table: model.table.to_owned(),
@@ -2384,9 +2366,7 @@ pub(crate) async fn action_submit(
     State(state): State<AppState>,
     body: axum::body::Bytes,
 ) -> Result<Response, AdminError> {
-    let model = lookup_model(&state, &table).ok_or(AdminError::TableNotFound {
-        table: table.clone(),
-    })?;
+    let model = resolve_model(&state, &table)?;
 
     // Parse the form preserving repeats. axum's `Form<HashMap>` would
     // collapse duplicate `_selected` keys into one; we read the raw


### PR DESCRIPTION
9 TableNotFound sites + 1 detail-trio collapsed to resolve_model / resolve_model_and_pk helpers. -26 LOC net. 58 admin tests pass. Closes the admin prologue bullet of #562.