### PR TITLE
fix(text): shorten doctest — width 11 to force truncation, was 12 (exact fit)

### DIFF
--- a/crates/rustango/src/text.rs
+++ b/crates/rustango/src/text.rs
@@ -1530,7 +1530,7 @@ pub fn wrap(text: &str, width: usize) -> String {
 ///
 /// ```
 /// use rustango::text::shorten;
-/// assert_eq!(shorten("Hello   world!", 12, " [...]"), "Hello [...]");
+/// assert_eq!(shorten("Hello   world!", 11, " [...]"), "Hello [...]");
 /// assert_eq!(shorten("short text", 80, " [...]"), "short text");
 /// assert_eq!(shorten("one two three four", 11, "..."), "one two...");
 /// ```


### PR DESCRIPTION
Hotfix CI doctest. Width 12 = exact fit for 'Hello world!' — drop to 11 to demonstrate truncation path.