### PR TITLE
refactor(core): sweep SelectQuery sites onto by_pk / ::new — batch 3 (#562)

### DIFF
--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -181,18 +181,16 @@ fn write_compound_select(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), Sql
     // surrounded by `SELECT * FROM (<sub>)` rather than naked parens
     // (handled by the writer for nested subqueries — set ops with
     // per-branch LIMIT remain a stretch goal).
+    // #562 — struct-update over SelectQuery::new; the head copies the
+    // outer query's WHERE / search / joins but explicitly clears the
+    // compound + outer-only fields (order_by / limit / offset /
+    // lock_mode / compound) since those apply to the merged result,
+    // not the head branch.
     let head = SelectQuery {
-        model: query.model,
         where_clause: query.where_clause.clone(),
         search: query.search.clone(),
         joins: query.joins.clone(),
-        order_by: Vec::new(),
-        limit: None,
-        offset: None,
-        lock_mode: None,
-        compound: Vec::new(),
-        projection: None,
-        distinct: None,
+        ..SelectQuery::new(query.model)
     };
     write_select_inner(b, &head)?;
 

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -637,18 +637,14 @@ async fn handle_list(
         &state.vs.search_fields,
         &params,
     );
+    // #562 — struct-update over SelectQuery::new for the list+filter
+    // query (custom WHERE + paginate).
     let select_q = SelectQuery {
-        model: state.vs.schema,
         where_clause: where_clause.clone(),
-        search: None,
-        joins: vec![],
         order_by,
         limit: Some(page_size),
         offset: Some(offset),
-        lock_mode: None,
-        compound: vec![],
-        projection: None,
-        distinct: None,
+        ..SelectQuery::new(state.vs.schema)
     };
     let count_q = crate::core::CountQuery {
         model: state.vs.schema,
@@ -3410,18 +3406,14 @@ mod tenant {
             &state.vs.search_fields,
             &params,
         );
+        // #562 — struct-update over SelectQuery::new for the
+        // tenant-side list+filter query (custom WHERE + paginate).
         let select_q = SelectQuery {
-            model: state.vs.schema,
             where_clause: where_clause.clone(),
-            search: None,
-            joins: vec![],
             order_by,
             limit: Some(page_size),
             offset: Some(offset),
-            lock_mode: None,
-            compound: vec![],
-            projection: None,
-            distinct: None,
+            ..SelectQuery::new(state.vs.schema)
         };
         let count_q = crate::core::CountQuery {
             model: state.vs.schema,

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -926,18 +926,15 @@ async fn handle_list(
                 .max(1);
             let offset = (page - 1) * page_size;
 
+            // #562 — struct-update over SelectQuery::new for the
+            // paginated list query.
             let select_q = SelectQuery {
-                model: state.vs.schema,
                 where_clause: where_clause.clone(),
                 search: search_clause.clone(),
-                joins: vec![],
                 order_by: order_by.clone(),
                 limit: Some(page_size),
                 offset: Some(offset),
-                lock_mode: None,
-                compound: vec![],
-                projection: None,
-                distinct: None,
+                ..SelectQuery::new(state.vs.schema)
             };
             let count_q = CountQuery {
                 model: state.vs.schema,
@@ -1057,19 +1054,15 @@ async fn handle_list_cursor(
     // Force ordering by the cursor field (cursor pagination requires it)
     let order_by = vec![crate::core::OrderItem::column(cursor_schema.column, desc)];
 
-    // Fetch page_size+1 to detect if a next page exists.
+    // #562 — struct-update over SelectQuery::new for the cursor-
+    // paginated SELECT. Fetch page_size+1 to detect if a next page
+    // exists.
     let select_q = SelectQuery {
-        model: state.vs.schema,
         where_clause: final_where,
         search: search_clause,
-        joins: vec![],
         order_by,
         limit: Some(page_size + 1),
-        offset: None,
-        lock_mode: None,
-        compound: vec![],
-        projection: None,
-        distinct: None,
+        ..SelectQuery::new(state.vs.schema)
     };
     let rows = match acq.select_rows_as_json(&select_q, &fields).await {
         Ok(r) => r,


### PR DESCRIPTION
5 more sites: sql/writers compound-head + 4 list-query sites. 3292 lib tests pass.