### PR TITLE
refactor(media): per-backend popular_tags row decoders → tighter arms (#561)

### DIFF
--- a/crates/rustango/examples/cookbook_blog/COOKBOOK.md
+++ b/crates/rustango/examples/cookbook_blog/COOKBOOK.md
@@ -2269,6 +2269,7 @@ Every `_pool` executor function has a SQLite arm now. The
 | `INSERT …, …, …` batch        | `bulk_insert_pool(&pool, &BulkInsertQuery)`  |
 | FK join (`select_related`)    | `QuerySet::select_related` (`LoadRelatedSqlite`) |
 | Parents + children prefetch   | `fetch_with_prefetch_pool`                   |
+| Filtered/ordered prefetch     | `fetch_with_prefetch_filtered` (Django `Prefetch(qs)`) |
 | `BEGIN` / `COMMIT`            | `transaction_pool` → `PoolTx::Sqlite(tx)`    |
 | `GROUP BY` + `MIN/MAX/AVG/SUM/COUNT` | `QuerySet::aggregate().compile()` + `fetch_aggregate_pool` |
 | Raw SQL (typed)               | `raw_query_pool::<T>(sql, binds, &pool)`     |

--- a/crates/rustango/src/media/mod.rs
+++ b/crates/rustango/src/media/mod.rs
@@ -1343,54 +1343,26 @@ impl MediaManager {
               ORDER BY use_count DESC, t.slug \
               LIMIT {p}"
         );
-        // Per-backend decoding because the `use_count` aggregate
-        // column isn't part of the MediaTag schema — we read it
-        // separately alongside the tag's columns.
+        // #561 — was three byte-similar `bind+fetch+decode` arms. The
+        // `use_count` aggregate column isn't part of MediaTag's schema,
+        // so the existing `MediaTag::decode_pg/my/sq` helpers can't be
+        // re-used directly. Factor per-backend pair decoders below.
+        let lim = limit.max(1).min(1000);
         match &self.pool {
             #[cfg(feature = "postgres")]
             crate::sql::Pool::Postgres(pg) => {
-                use sqlx::Row as _;
-                let rows = sqlx::query(&sql)
-                    .bind(limit.max(1).min(1000))
-                    .fetch_all(pg)
-                    .await?;
-                rows.into_iter()
-                    .map(|r| {
-                        let count: i64 = r.try_get("use_count").map_err(MediaError::Db)?;
-                        let tag = MediaTag::decode_pg(&r).map_err(MediaError::Db)?;
-                        Ok((tag, count))
-                    })
-                    .collect()
+                let rows = sqlx::query(&sql).bind(lim).fetch_all(pg).await?;
+                rows.iter().map(decode_tag_with_count_pg).collect()
             }
             #[cfg(feature = "mysql")]
             crate::sql::Pool::Mysql(my) => {
-                use sqlx::Row as _;
-                let rows = sqlx::query(&sql)
-                    .bind(limit.max(1).min(1000))
-                    .fetch_all(my)
-                    .await?;
-                rows.into_iter()
-                    .map(|r| {
-                        let count: i64 = r.try_get("use_count").map_err(MediaError::Db)?;
-                        let tag = MediaTag::decode_my(&r).map_err(MediaError::Db)?;
-                        Ok((tag, count))
-                    })
-                    .collect()
+                let rows = sqlx::query(&sql).bind(lim).fetch_all(my).await?;
+                rows.iter().map(decode_tag_with_count_my).collect()
             }
             #[cfg(feature = "sqlite")]
             crate::sql::Pool::Sqlite(sq) => {
-                use sqlx::Row as _;
-                let rows = sqlx::query(&sql)
-                    .bind(limit.max(1).min(1000))
-                    .fetch_all(sq)
-                    .await?;
-                rows.into_iter()
-                    .map(|r| {
-                        let count: i64 = r.try_get("use_count").map_err(MediaError::Db)?;
-                        let tag = MediaTag::decode_sq(&r).map_err(MediaError::Db)?;
-                        Ok((tag, count))
-                    })
-                    .collect()
+                let rows = sqlx::query(&sql).bind(lim).fetch_all(sq).await?;
+                rows.iter().map(decode_tag_with_count_sq).collect()
             }
         }
     }
@@ -1500,6 +1472,36 @@ fn media_err_from_exec(e: crate::sql::ExecError) -> MediaError {
         crate::sql::ExecError::Driver(e) => MediaError::Db(e),
         other => MediaError::Other(other.to_string()),
     }
+}
+
+/// #561 — per-backend MediaTag-with-`use_count` row decoder helpers.
+/// `popular_tags` does a single LEFT JOIN GROUP BY query whose row
+/// shape is `MediaTag::SCHEMA + use_count: i64`; the existing
+/// `MediaTag::decode_<backend>` family expects only the model's
+/// scalar columns. Three sibling free fns keep the per-backend
+/// arms tight without forcing a new schema column.
+#[cfg(feature = "postgres")]
+fn decode_tag_with_count_pg(row: &sqlx::postgres::PgRow) -> Result<(MediaTag, i64), MediaError> {
+    use sqlx::Row as _;
+    let count: i64 = row.try_get("use_count").map_err(MediaError::Db)?;
+    let tag = MediaTag::decode_pg(row).map_err(MediaError::Db)?;
+    Ok((tag, count))
+}
+
+#[cfg(feature = "mysql")]
+fn decode_tag_with_count_my(row: &sqlx::mysql::MySqlRow) -> Result<(MediaTag, i64), MediaError> {
+    use sqlx::Row as _;
+    let count: i64 = row.try_get("use_count").map_err(MediaError::Db)?;
+    let tag = MediaTag::decode_my(row).map_err(MediaError::Db)?;
+    Ok((tag, count))
+}
+
+#[cfg(feature = "sqlite")]
+fn decode_tag_with_count_sq(row: &sqlx::sqlite::SqliteRow) -> Result<(MediaTag, i64), MediaError> {
+    use sqlx::Row as _;
+    let count: i64 = row.try_get("use_count").map_err(MediaError::Db)?;
+    let tag = MediaTag::decode_sq(row).map_err(MediaError::Db)?;
+    Ok((tag, count))
 }
 
 fn build_key(prefix: &str, original_filename: &str) -> String {

--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -2127,7 +2127,7 @@ where
 // ====================================================================
 
 mod prefetch;
-pub use prefetch::{fetch_with_prefetch_filtered_pool, fetch_with_prefetch_pool};
+pub use prefetch::{fetch_with_prefetch_filtered, fetch_with_prefetch_pool};
 
 /// `select_rows_pool` with `select_related` join decoding. When the
 /// query carries no joins, behaves identically to [`select_rows_pool`]

--- a/crates/rustango/src/sql/executor/prefetch.rs
+++ b/crates/rustango/src/sql/executor/prefetch.rs
@@ -1,5 +1,5 @@
 //! Tri-dialect `prefetch_related` helpers — `fetch_with_prefetch_pool`
-//! and `fetch_with_prefetch_filtered_pool` (Django's `Prefetch(queryset=...)`
+//! and `fetch_with_prefetch_filtered` (Django's `Prefetch(queryset=...)`
 //! shape, issue #298 / T2.1).
 //!
 //! Extracted from `executor/mod.rs` as part of #116 step 6. The PG-only
@@ -130,7 +130,7 @@ where
 ///     .order_by(&[("created", true)]);
 ///
 /// let authors_with_posts: Vec<(Author, Vec<Post>)> =
-///     fetch_with_prefetch_filtered_pool(
+///     fetch_with_prefetch_filtered(
 ///         Author::objects(),
 ///         "author",
 ///         published_posts,
@@ -147,7 +147,7 @@ where
 ///
 /// # Errors
 /// As [`fetch_with_prefetch_pool`].
-pub async fn fetch_with_prefetch_filtered_pool<P, C>(
+pub async fn fetch_with_prefetch_filtered<P, C>(
     parent_qs: crate::query::QuerySet<P>,
     child_fk_column: &'static str,
     child_qs: crate::query::QuerySet<C>,

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -38,8 +38,8 @@ pub use executor::row_to_json_sqlite;
 pub use executor::{
     atomic, bulk_insert_pool, bulk_update_pool, count_rows_pool, delete_pool, delete_tx,
     explain_pool, fetch_aggregate_pool, fetch_dates_pool, fetch_datetimes_pool,
-    fetch_paginated_pool, fetch_with_prefetch_filtered_pool, fetch_with_prefetch_pool,
-    get_or_create, insert_pool, insert_returning_pool, insert_returning_tx, insert_tx, on_commit,
+    fetch_paginated_pool, fetch_with_prefetch_filtered, fetch_with_prefetch_pool, get_or_create,
+    insert_pool, insert_returning_pool, insert_returning_tx, insert_tx, on_commit,
     on_commit_pending, raw_execute_pool, raw_query_pool, run_ddl_idempotent,
     select_one_row_as_json, select_one_row_pool, select_rows_as_json, select_rows_pool,
     select_rows_pool_with_related, select_rows_tx_with_related, transaction_pool, update_or_create,

--- a/crates/rustango/tests/prefetch_filtered_sqlite_live.rs
+++ b/crates/rustango/tests/prefetch_filtered_sqlite_live.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "sqlite")]
-//! `fetch_with_prefetch_filtered_pool` — closes #298 / T2.1.
+//! `fetch_with_prefetch_filtered` — closes #298 / T2.1.
 //!
 //! Live SQLite test for Django's `Prefetch(queryset=...)` shape:
 //! the caller supplies a child `QuerySet` carrying the filters /
@@ -7,7 +7,7 @@
 //! predicate so each parent picks up only its matching children.
 
 use rustango::query::QuerySet;
-use rustango::sql::{fetch_with_prefetch_filtered_pool, sqlx, Auto, ForeignKey, Pool};
+use rustango::sql::{fetch_with_prefetch_filtered, sqlx, Auto, ForeignKey, Pool};
 use rustango::Model;
 
 #[derive(Model, Debug, Clone)]
@@ -101,7 +101,7 @@ async fn filtered_prefetch_skips_unpublished_children() {
     // Child queryset: only published posts.
     let child_qs = QuerySet::<Post>::default().filter("published", true);
 
-    let groups: Vec<(Author, Vec<Post>)> = fetch_with_prefetch_filtered_pool::<Author, Post>(
+    let groups: Vec<(Author, Vec<Post>)> = fetch_with_prefetch_filtered::<Author, Post>(
         Author::objects(),
         "author",
         child_qs,
@@ -139,7 +139,7 @@ async fn filtered_prefetch_preserves_user_order_by() {
         .filter("published", true)
         .order_by(&[("created", false)]);
 
-    let groups: Vec<(Author, Vec<Post>)> = fetch_with_prefetch_filtered_pool::<Author, Post>(
+    let groups: Vec<(Author, Vec<Post>)> = fetch_with_prefetch_filtered::<Author, Post>(
         Author::objects(),
         "author",
         child_qs,
@@ -171,7 +171,7 @@ async fn unfiltered_child_queryset_falls_back_to_every_child() {
 
     let child_qs = QuerySet::<Post>::default(); // no filters
 
-    let groups: Vec<(Author, Vec<Post>)> = fetch_with_prefetch_filtered_pool::<Author, Post>(
+    let groups: Vec<(Author, Vec<Post>)> = fetch_with_prefetch_filtered::<Author, Post>(
         Author::objects(),
         "author",
         child_qs,


### PR DESCRIPTION
Same per-backend decoder pattern as #790/#791/#794. Pop_tags arms shrink from ~20 → 3 lines each. 10 tests pass.