### PR TITLE
refactor(audit): collapse delete_one_with_audit onto raw_execute_tx + emit_one_tx (#561)

### DIFF
--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -1104,46 +1104,34 @@ pub async fn delete_one_with_audit(
     entry: &PendingEntry,
 ) -> Result<u64, crate::sql::ExecError> {
     let stmt = pool.dialect().compile_delete(query)?;
-    match pool {
+    // #561 — was a 3-arm `match pool` that opened a per-backend tx,
+    // bound stmt.params, executed, called the per-backend
+    // `emit_one_<backend>`, committed. The new `raw_execute_tx`
+    // combinator (#798) + the `emit_one_tx` shim below let the body
+    // collapse to one flat path.
+    let mut tx = crate::sql::transaction_pool(pool).await?;
+    let affected = crate::sql::raw_execute_tx(&mut tx, &stmt.sql, stmt.params).await?;
+    emit_one_tx(&mut tx, entry).await?;
+    tx.commit().await?;
+    Ok(affected)
+}
+
+/// Per-backend dispatch for the audit emit inside an open `PoolTx`.
+/// Wraps the existing per-backend `emit_one` / `emit_one_my` /
+/// `emit_one_sqlite` helpers (which take a sqlx-typed executor) so
+/// callers can stay on the `PoolTx` API instead of unwrapping the
+/// variant.
+async fn emit_one_tx(
+    tx: &mut crate::sql::PoolTx<'_>,
+    entry: &PendingEntry,
+) -> Result<(), sqlx::Error> {
+    match tx {
         #[cfg(feature = "postgres")]
-        crate::sql::Pool::Postgres(pg) => {
-            let mut tx = pg.begin().await?;
-            let mut q: sqlx::query::Query<'_, sqlx::Postgres, sqlx::postgres::PgArguments> =
-                sqlx::query(&stmt.sql);
-            for v in stmt.params {
-                q = bind_value_pg(q, v);
-            }
-            let affected = q.execute(&mut *tx).await?.rows_affected();
-            emit_one(&mut *tx, entry).await?;
-            tx.commit().await?;
-            Ok(affected)
-        }
+        crate::sql::PoolTx::Postgres(t) => emit_one(&mut **t, entry).await,
         #[cfg(feature = "mysql")]
-        crate::sql::Pool::Mysql(my) => {
-            let mut tx = my.begin().await?;
-            let mut q: sqlx::query::Query<'_, sqlx::MySql, sqlx::mysql::MySqlArguments> =
-                sqlx::query(&stmt.sql);
-            for v in stmt.params {
-                q = bind_value_my(q, v);
-            }
-            let affected = q.execute(&mut *tx).await?.rows_affected();
-            emit_one_my(&mut *tx, entry).await?;
-            tx.commit().await?;
-            Ok(affected)
-        }
+        crate::sql::PoolTx::Mysql(t) => emit_one_my(&mut **t, entry).await,
         #[cfg(feature = "sqlite")]
-        crate::sql::Pool::Sqlite(sq) => {
-            let mut tx = sq.begin().await?;
-            let mut q: sqlx::query::Query<'_, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'_>> =
-                sqlx::query(&stmt.sql);
-            for v in stmt.params {
-                q = bind_value_sqlite(q, v);
-            }
-            let affected = q.execute(&mut *tx).await?.rows_affected();
-            emit_one_sqlite(&mut *tx, entry).await?;
-            tx.commit().await?;
-            Ok(affected)
-        }
+        crate::sql::PoolTx::Sqlite(t) => emit_one_sqlite(&mut **t, entry).await,
     }
 }
 

--- a/crates/rustango/tests/prefetch_filtered_sqlite_live.rs
+++ b/crates/rustango/tests/prefetch_filtered_sqlite_live.rs
@@ -101,14 +101,10 @@ async fn filtered_prefetch_skips_unpublished_children() {
     // Child queryset: only published posts.
     let child_qs = QuerySet::<Post>::default().filter("published", true);
 
-    let groups: Vec<(Author, Vec<Post>)> = fetch_with_prefetch_filtered::<Author, Post>(
-        Author::objects(),
-        "author",
-        child_qs,
-        &pool,
-    )
-    .await
-    .expect("prefetch filtered");
+    let groups: Vec<(Author, Vec<Post>)> =
+        fetch_with_prefetch_filtered::<Author, Post>(Author::objects(), "author", child_qs, &pool)
+            .await
+            .expect("prefetch filtered");
 
     assert_eq!(groups.len(), 2, "two authors");
     for (author, posts) in &groups {
@@ -139,14 +135,10 @@ async fn filtered_prefetch_preserves_user_order_by() {
         .filter("published", true)
         .order_by(&[("created", false)]);
 
-    let groups: Vec<(Author, Vec<Post>)> = fetch_with_prefetch_filtered::<Author, Post>(
-        Author::objects(),
-        "author",
-        child_qs,
-        &pool,
-    )
-    .await
-    .expect("prefetch filtered");
+    let groups: Vec<(Author, Vec<Post>)> =
+        fetch_with_prefetch_filtered::<Author, Post>(Author::objects(), "author", child_qs, &pool)
+            .await
+            .expect("prefetch filtered");
 
     // Find Ada's group; her published children should be ordered by
     // `created` ASC: Engine notes (100) before Poems on iteration (200).
@@ -171,14 +163,10 @@ async fn unfiltered_child_queryset_falls_back_to_every_child() {
 
     let child_qs = QuerySet::<Post>::default(); // no filters
 
-    let groups: Vec<(Author, Vec<Post>)> = fetch_with_prefetch_filtered::<Author, Post>(
-        Author::objects(),
-        "author",
-        child_qs,
-        &pool,
-    )
-    .await
-    .expect("prefetch filtered");
+    let groups: Vec<(Author, Vec<Post>)> =
+        fetch_with_prefetch_filtered::<Author, Post>(Author::objects(), "author", child_qs, &pool)
+            .await
+            .expect("prefetch filtered");
 
     let by_name: std::collections::HashMap<String, usize> = groups
         .iter()


### PR DESCRIPTION
First consumer of #798. 42-line match → 7-line body. 27 audit tests pass.