### PR TITLE
feat(sql): raw_query_tx combinator — bi-dialect SELECT inside an open PoolTx (#561)

### DIFF
--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -1917,6 +1917,61 @@ where
     }
 }
 
+/// Bi-dialect SELECT inside an open [`PoolTx`]. Companion to
+/// [`raw_query_pool`] for queries scoped to a transaction (read-
+/// after-write, FOR UPDATE row locks, lookup-then-modify flows).
+///
+/// Dispatches per `PoolTx` variant; binds via the canonical
+/// `bind_query_as*` helpers (same path the macro-emitted
+/// `_pool` / `_tx` fetchers use).
+///
+/// # Errors
+/// Driver / SQL failures.
+pub async fn raw_query_tx<T>(
+    tx: &mut tx::PoolTx<'_>,
+    sql: &str,
+    binds: Vec<SqlValue>,
+) -> Result<Vec<T>, ExecError>
+where
+    T: MaybePgFromRow + MaybeMyFromRow + MaybeSqliteFromRow + Send + Unpin,
+{
+    // #431 — bump the per-task query counter when an `assert_num_queries`
+    // scope is active. No-op in production (try_with returns Err).
+    crate::test_assertions::query_counter::bump();
+    match tx {
+        #[cfg(feature = "postgres")]
+        tx::PoolTx::Postgres(t) => {
+            let mut q: QueryAs<'_, sqlx::Postgres, T, PgArguments> = sqlx::query_as::<_, T>(sql);
+            for v in binds {
+                q = bind_query_as(q, v);
+            }
+            Ok(q.fetch_all(&mut **t).await?)
+        }
+        #[cfg(feature = "mysql")]
+        tx::PoolTx::Mysql(t) => {
+            let mut q: sqlx::query::QueryAs<'_, sqlx::MySql, T, sqlx::mysql::MySqlArguments> =
+                sqlx::query_as::<_, T>(sql);
+            for v in binds {
+                q = bind_query_as_my(q, v);
+            }
+            Ok(q.fetch_all(&mut **t).await?)
+        }
+        #[cfg(feature = "sqlite")]
+        tx::PoolTx::Sqlite(t) => {
+            let mut q: sqlx::query::QueryAs<
+                '_,
+                sqlx::Sqlite,
+                T,
+                sqlx::sqlite::SqliteArguments<'_>,
+            > = sqlx::query_as::<_, T>(sql);
+            for v in binds {
+                q = bind_query_as_sqlite(q, v);
+            }
+            Ok(q.fetch_all(&mut **t).await?)
+        }
+    }
+}
+
 /// Django `.dates(field, kind)` terminal — issue #327. Compiles the
 /// underlying queryset to a `SELECT … WHERE …` statement, then wraps
 /// it in `SELECT DISTINCT <trunc(col)> FROM (<inner>) ORDER BY d` to

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -40,13 +40,13 @@ pub use executor::{
     explain_pool, fetch_aggregate_pool, fetch_dates_pool, fetch_datetimes_pool,
     fetch_paginated_pool, fetch_with_prefetch_filtered, fetch_with_prefetch_pool, get_or_create,
     insert_pool, insert_returning_pool, insert_returning_tx, insert_tx, on_commit,
-    on_commit_pending, raw_execute_pool, raw_execute_tx, raw_query_pool, run_ddl_idempotent,
-    select_one_row_as_json, select_one_row_pool, select_rows_as_json, select_rows_pool,
-    select_rows_pool_with_related, select_rows_tx_with_related, transaction_pool, update_or_create,
-    update_pool, update_tx, CounterPool, ExistsPool, ExplainFormat, ExplainOptions, FetcherPool,
-    FetcherTx, FkPkAccess, HasPkValue, InsertReturningPool, LoadRelated, MaybeMyFromRow,
-    MaybeMyLoadRelated, MaybePgFromRow, MaybeSqliteFromRow, MaybeSqliteLoadRelated, Page, PoolTx,
-    UpdaterPool,
+    on_commit_pending, raw_execute_pool, raw_execute_tx, raw_query_pool, raw_query_tx,
+    run_ddl_idempotent, select_one_row_as_json, select_one_row_pool, select_rows_as_json,
+    select_rows_pool, select_rows_pool_with_related, select_rows_tx_with_related, transaction_pool,
+    update_or_create, update_pool, update_tx, CounterPool, ExistsPool, ExplainFormat,
+    ExplainOptions, FetcherPool, FetcherTx, FkPkAccess, HasPkValue, InsertReturningPool,
+    LoadRelated, MaybeMyFromRow, MaybeMyLoadRelated, MaybePgFromRow, MaybeSqliteFromRow,
+    MaybeSqliteLoadRelated, Page, PoolTx, UpdaterPool,
 };
 // PG-typed back-compat surface gone (issue #270 / T1.8 waves 1–4):
 // the entire family of `_on` functions + `&PgPool` wrappers + the


### PR DESCRIPTION
Sibling of raw_execute_tx (#798). Unlocks read-after-write patterns inside a tx. 3299 tests pass.