### PR TITLE
chore: clean unused imports left behind by tri-dialect collapses

### DIFF
--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -1089,7 +1089,6 @@ where
     Option<bool>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
     i64: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
 {
-    use sqlx::Row as _;
     let raw = stringify_facet_value(row);
     let display = if expect_display {
         row.try_get::<Option<String>, _>("facet_display")
@@ -1119,7 +1118,6 @@ where
     Option<i32>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
     Option<bool>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
 {
-    use sqlx::Row as _;
     if let Ok(Some(s)) = row.try_get::<Option<String>, _>("facet_value") {
         return s;
     }

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -319,7 +319,7 @@ pub async fn fetch_row_as_json(
     ct: &ContentType,
     pk: impl Into<SqlValue>,
 ) -> Result<Option<serde_json::Value>, ExecError> {
-    use crate::core::{Filter, Op, SelectQuery, WhereExpr};
+    use crate::core::SelectQuery;
 
     // Look up the schema for the CT's table from inventory.
     // Heterogeneous-by-design: a CT row may refer to a model
@@ -361,7 +361,7 @@ pub async fn for_each_row_of_ct<F>(
 where
     F: FnMut(serde_json::Value) -> Result<(), ExecError>,
 {
-    use crate::core::{OrderClause, SelectQuery, WhereExpr};
+    use crate::core::{OrderClause, SelectQuery};
 
     let entry = inventory::iter::<ModelEntry>
         .into_iter()

--- a/crates/rustango/src/crypto.rs
+++ b/crates/rustango/src/crypto.rs
@@ -142,6 +142,8 @@ pub fn salted_hmac(key_salt: &[u8], value: &[u8], secret: &[u8]) -> Vec<u8> {
     let derived = hasher.finalize();
     hmac_sha256(&derived, value)
 }
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/crates/rustango/src/fixtures.rs
+++ b/crates/rustango/src/fixtures.rs
@@ -33,7 +33,6 @@ use std::path::Path;
 
 use serde_json::Value;
 
-use crate::sql::sqlx;
 #[cfg(feature = "postgres")]
 use crate::sql::sqlx::PgPool;
 use crate::sql::Pool;

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -15,7 +15,9 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use crate::core::{inventory, ModelEntry, ModelSchema};
-use crate::sql::sqlx::{self, Row};
+use crate::sql::sqlx;
+#[cfg(feature = "postgres")]
+use crate::sql::sqlx::Row;
 // PG-typed shims below import these; sqlite/mysql-only builds get
 // just the `_pool` entry points.
 #[cfg(feature = "postgres")]

--- a/crates/rustango/src/tenancy/permissions.rs
+++ b/crates/rustango/src/tenancy/permissions.rs
@@ -421,7 +421,6 @@ pub async fn has_perm_pool(
     codename: &str,
     pool: &crate::sql::Pool,
 ) -> Result<bool, TenancyError> {
-    use sqlx::Row as _;
     let dialect = pool.dialect();
     let users_t = dialect.quote_ident("rustango_users");
     let user_perms_t = dialect.quote_ident("rustango_user_permissions");
@@ -1078,7 +1077,6 @@ pub async fn user_roles_qs_pool(
     user_id: i64,
     pool: &crate::sql::Pool,
 ) -> Result<Vec<Role>, sqlx::Error> {
-    use sqlx::Row as _;
     let dialect = pool.dialect();
     let roles_t = dialect.quote_ident("rustango_roles");
     let user_roles_t = dialect.quote_ident("rustango_user_roles");


### PR DESCRIPTION
Cleans 9 unused imports across contenttypes/permissions/admin/fixtures/migrate. Both backend feature subsets now warning-free. 3299 tests pass.