### PR TITLE
refactor(url_codec): fold 6 url_encode copies onto canonical + close 2 correctness gaps (#806)

### DIFF
--- a/crates/rustango/src/admin/audit.rs
+++ b/crates/rustango/src/admin/audit.rs
@@ -454,20 +454,8 @@ pub(crate) fn split_action_marker(changes: &Value) -> (Option<String>, Value) {
     (None, changes.clone())
 }
 
-/// Tiny ASCII-safe percent encoder for query-string values.
-fn url_encode_q(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            ' ' => out.push_str("%20"),
-            '&' => out.push_str("%26"),
-            '=' => out.push_str("%3D"),
-            '?' => out.push_str("%3F"),
-            '#' => out.push_str("%23"),
-            '+' => out.push_str("%2B"),
-            '%' => out.push_str("%25"),
-            _ => out.push(c),
-        }
-    }
-    out
-}
+// #806 — the local 7-char `url_encode_q` was narrower than the
+// canonical `crate::url_codec::url_encode` and left `/` `@` plus
+// non-ASCII bytes unencoded. Route through the canonical encoder
+// under the local name.
+use crate::url_codec::url_encode as url_encode_q;

--- a/crates/rustango/src/admin/helpers.rs
+++ b/crates/rustango/src/admin/helpers.rs
@@ -3,7 +3,6 @@
 //! rendering, and pager URL composition.
 
 use std::collections::HashMap;
-use std::fmt::Write as _;
 
 use crate::core::{inventory, FieldSchema, Join, ModelEntry, ModelSchema, Relation};
 #[allow(unused_imports)]
@@ -352,21 +351,9 @@ pub(crate) fn pager_suffix(q: Option<&str>, filters: &[(&'static str, String)]) 
     out
 }
 
-/// Minimal URL-encoder for ASCII inputs. Escapes characters that have
-/// special meaning in a query string. Multibyte UTF-8 is percent-encoded
-/// byte-by-byte — Postgres handles the bytes the same on the way back.
-fn url_encode(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for byte in s.bytes() {
-        let safe = byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~');
-        if safe {
-            out.push(byte as char);
-        } else {
-            let _ = write!(out, "%{byte:02X}");
-        }
-    }
-    out
-}
+// #806 — was a byte-identical copy of `crate::url_codec::url_encode`;
+// route through the canonical codec.
+use crate::url_codec::url_encode;
 
 /// Walk a row set produced with `joins` set, and for each row build the
 /// `(target_table, source_value_string) → display_html` map entry. Tri-

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -1508,25 +1508,12 @@ fn build_query_url(admin_prefix: &str, table: &str, params: &[(String, String)])
     }
 }
 
-fn url_encode(s: &str) -> String {
-    // Bare-minimum percent-encoding for query-string values: spaces
-    // and the seven query-control characters. Avoids pulling in
-    // `urlencoding` for one call site.
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            ' ' => out.push_str("%20"),
-            '&' => out.push_str("%26"),
-            '=' => out.push_str("%3D"),
-            '?' => out.push_str("%3F"),
-            '#' => out.push_str("%23"),
-            '+' => out.push_str("%2B"),
-            '%' => out.push_str("%25"),
-            _ => out.push(c),
-        }
-    }
-    out
-}
+// #806 — the local 7-char percent-encoder was narrower than the
+// canonical `crate::url_codec::url_encode` and left `/` `@` plus
+// non-ASCII bytes unencoded — a subtle correctness gap for facet
+// filter values containing slashes or UTF-8. Route through the
+// canonical RFC-3986-unreserved-set encoder.
+use crate::url_codec::url_encode;
 
 // ============================================================== AUTOCOMPLETE
 //

--- a/crates/rustango/src/auth_flows/mod.rs
+++ b/crates/rustango/src/auth_flows/mod.rs
@@ -313,22 +313,13 @@ fn extract_query(url: &str, key: &str) -> Option<String> {
     None
 }
 
-fn url_encode(s: &str) -> String {
-    s.bytes()
-        .map(|b| {
-            if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~') {
-                (b as char).to_string()
-            } else {
-                format!("%{b:02X}")
-            }
-        })
-        .collect()
-}
-
+// #806 — was byte-identical to `crate::url_codec::url_encode`
+// (RFC 3986 unreserved set — the right alphabet for OAuth-style
+// `?next=...` redirect targets). Route through the canonical codec.
 // Percent-decoder consolidated into [`crate::url_codec`] — see the
 // note in [`crate::signed_url`]. Re-imported under the `url_decode`
 // name to keep the local call sites unchanged.
-use crate::url_codec::url_decode;
+use crate::url_codec::{url_decode, url_encode};
 
 #[cfg(test)]
 mod tests {

--- a/crates/rustango/src/pagination.rs
+++ b/crates/rustango/src/pagination.rs
@@ -174,17 +174,11 @@ impl LinkHeaderBuilder {
     }
 }
 
-fn url_encode(s: &str) -> String {
-    s.bytes()
-        .map(|b| {
-            if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~') {
-                (b as char).to_string()
-            } else {
-                format!("%{b:02X}")
-            }
-        })
-        .collect()
-}
+// #806 — was a byte-identical copy of `crate::url_codec::url_encode`.
+// Re-aliased to keep all pagination call sites inside this module
+// without churning their `url_encode(k)` shape, while routing through
+// the canonical codec.
+use crate::url_codec::url_encode;
 
 // =====================================================================
 // PageLinks — JSON-friendly URL bundle for inline `_links` responses

--- a/crates/rustango/src/totp.rs
+++ b/crates/rustango/src/totp.rs
@@ -206,17 +206,11 @@ fn constant_time_eq(a: &str, b: &str) -> bool {
     a.as_bytes().ct_eq(b.as_bytes()).unwrap_u8() == 1
 }
 
-fn url_encode(s: &str) -> String {
-    s.bytes()
-        .map(|b| {
-            if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~') {
-                (b as char).to_string()
-            } else {
-                format!("%{b:02X}")
-            }
-        })
-        .collect()
-}
+// #806 — was byte-identical to `crate::url_codec::url_encode`
+// (RFC 3986 unreserved set — the right alphabet for an otpauth URI's
+// label/issuer query-parameter encoding). Route through the canonical
+// codec.
+use crate::url_codec::url_encode;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Closes #806. 6 url_encode copies fold through url_codec::url_encode; 2 narrow copies (admin/views, admin/audit) closed correctness gap for / and non-ASCII chars. 3299 tests pass.