### PR TITLE
feat(core): SelectQuery::by_pk_in + DeleteQuery::by_pk{,_in} constructors (#810)

### DIFF
--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -2386,17 +2386,10 @@ pub(crate) async fn action_submit(
     // delete_selected this snapshots the gone rows; for user-defined
     // actions it records the row state at the time of action.
     let action_fields: Vec<&'static FieldSchema> = model.scalar_fields().collect();
-    // #562 — IN-list lookup; struct-update over SelectQuery::new.
+    // #810 — IN-list lookup via the `by_pk_in` constructor.
     let before_rows = crate::sql::select_rows_as_json(
         &state.pool,
-        &SelectQuery {
-            where_clause: WhereExpr::Predicate(Filter {
-                column: pk_field.column,
-                op: Op::In,
-                value: SqlValue::List(pk_values.clone()),
-            }),
-            ..SelectQuery::new(model)
-        },
+        &SelectQuery::by_pk_in(model, pk_field.column, pk_values.clone()),
         &action_fields,
     )
     .await
@@ -2439,16 +2432,10 @@ pub(crate) async fn action_submit(
             )
             .await?;
         } else {
+            // #810 — DeleteQuery::by_pk_in for the bulk-delete shape.
             crate::sql::delete_pool(
                 &state.pool,
-                &DeleteQuery {
-                    model,
-                    where_clause: WhereExpr::Predicate(Filter {
-                        column: pk_field.column,
-                        op: Op::In,
-                        value: SqlValue::List(pk_values),
-                    }),
-                },
+                &DeleteQuery::by_pk_in(model, pk_field.column, pk_values),
             )
             .await?;
         }

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -628,6 +628,43 @@ impl SelectQuery {
             ..Self::new(model)
         }
     }
+
+    /// Multi-PK `IN (...)` lookup. Companion to [`by_pk`] for the
+    /// bulk-fetch / bulk-delete-by-id shapes that recur in
+    /// `template_views::run_delete_selected_pool`, FK display fetches,
+    /// and "fetch rows for these N pks" routines.
+    ///
+    /// Equivalent to:
+    ///
+    /// ```ignore
+    /// SelectQuery {
+    ///     where_clause: WhereExpr::Predicate(Filter {
+    ///         column: pk_column,
+    ///         op: Op::In,
+    ///         value: SqlValue::List(pk_values),
+    ///     }),
+    ///     ..SelectQuery::new(model)
+    /// }
+    /// ```
+    ///
+    /// No `LIMIT` defaulted — caller can layer one on via struct-update
+    /// syntax if needed (`SelectQuery { limit: Some(50),
+    /// ..SelectQuery::by_pk_in(...) }`).
+    #[must_use]
+    pub fn by_pk_in(
+        model: &'static ModelSchema,
+        pk_column: &'static str,
+        pk_values: Vec<SqlValue>,
+    ) -> Self {
+        Self {
+            where_clause: WhereExpr::Predicate(Filter {
+                column: pk_column,
+                op: Op::In,
+                value: SqlValue::List(pk_values),
+            }),
+            ..Self::new(model)
+        }
+    }
 }
 
 /// Distinct mode — Django's `.distinct()` / `.distinct(*fields)`.
@@ -1197,6 +1234,42 @@ impl UpdateQuery {
 pub struct DeleteQuery {
     pub model: &'static ModelSchema,
     pub where_clause: WhereExpr,
+}
+
+impl DeleteQuery {
+    /// Construct a `DELETE … WHERE <pk_column> = <pk_value>` shape.
+    /// Companion to [`SelectQuery::by_pk`] for the bulk- and
+    /// single-PK-delete patterns. #562 / #810.
+    #[must_use]
+    pub fn by_pk(model: &'static ModelSchema, pk_column: &'static str, pk_value: SqlValue) -> Self {
+        Self {
+            model,
+            where_clause: WhereExpr::Predicate(Filter {
+                column: pk_column,
+                op: Op::Eq,
+                value: pk_value,
+            }),
+        }
+    }
+
+    /// Construct a `DELETE … WHERE <pk_column> IN (...)` shape — the
+    /// "delete-selected" admin / API pattern. Companion to
+    /// [`SelectQuery::by_pk_in`]. #810.
+    #[must_use]
+    pub fn by_pk_in(
+        model: &'static ModelSchema,
+        pk_column: &'static str,
+        pk_values: Vec<SqlValue>,
+    ) -> Self {
+        Self {
+            model,
+            where_clause: WhereExpr::Predicate(Filter {
+                column: pk_column,
+                op: Op::In,
+                value: SqlValue::List(pk_values),
+            }),
+        }
+    }
 }
 
 /// Compiled `SELECT COUNT(*)` — same shape as a `DeleteQuery` (model +

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -2757,21 +2757,15 @@ fn build_fk_display_query(fk: &FkLookup) -> SelectQuery {
     // SQL writer project against the IN clause.
     let target = lookup_target_schema(fk.target_table)
         .expect("target table existed when collecting lookups");
-    // #562 — IN-list lookup, not a single-PK by_pk. Use SelectQuery::new
-    // + struct-update syntax to override just the where_clause.
-    SelectQuery {
-        where_clause: WhereExpr::Predicate(Filter {
-            column: fk.target_pk_column,
-            op: Op::In,
-            value: SqlValue::List(
-                fk.distinct_values
-                    .iter()
-                    .map(json_value_to_sql_for_fk_pk)
-                    .collect(),
-            ),
-        }),
-        ..SelectQuery::new(target)
-    }
+    // #810 — IN-list lookup via the `by_pk_in` constructor.
+    SelectQuery::by_pk_in(
+        target,
+        fk.target_pk_column,
+        fk.distinct_values
+            .iter()
+            .map(json_value_to_sql_for_fk_pk)
+            .collect(),
+    )
 }
 
 /// Convert a JSON-shaped value (read out of an object_list row)
@@ -2922,16 +2916,8 @@ async fn fetch_pks_as_objects_pool(
     pool: &Pool,
     pks: &[SqlValue],
 ) -> Result<Vec<Value>, String> {
-    use crate::core::{Filter, Op};
-    // #562 — IN-list lookup; struct-update over SelectQuery::new.
-    let q = SelectQuery {
-        where_clause: WhereExpr::Predicate(Filter {
-            column: pk_field.column,
-            op: Op::In,
-            value: SqlValue::List(pks.to_vec()),
-        }),
-        ..SelectQuery::new(schema)
-    };
+    // #810 — IN-list lookup via the `by_pk_in` constructor.
+    let q = SelectQuery::by_pk_in(schema, pk_field.column, pks.to_vec());
     let fields: Vec<&'static crate::core::FieldSchema> = schema.scalar_fields().collect();
     let rows = select_rows_as_json(pool, &q, &fields)
         .await
@@ -2949,15 +2935,8 @@ async fn run_delete_selected_pool(
     pool: &Pool,
     pks: &[SqlValue],
 ) -> Result<(), String> {
-    use crate::core::{DeleteQuery, Filter, Op};
-    let q = DeleteQuery {
-        model: schema,
-        where_clause: WhereExpr::Predicate(Filter {
-            column: pk_field.column,
-            op: Op::In,
-            value: SqlValue::List(pks.to_vec()),
-        }),
-    };
+    // #810 — `DeleteQuery::by_pk_in` for the DELETE … WHERE pk IN (...) shape.
+    let q = crate::core::DeleteQuery::by_pk_in(schema, pk_field.column, pks.to_vec());
     crate::sql::delete_pool(pool, &q)
         .await
         .map(|_| ())


### PR DESCRIPTION
Closes the first half of #810. SelectQuery::by_pk_in + DeleteQuery::by_pk/by_pk_in + 4 callsite migrations. -60 lines. 3299 tests pass.