### PR TITLE
chore(warnings): clear 6 dead-code / unused-import warnings; promote url_codec to pub mod

### DIFF
--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -546,10 +546,17 @@ pub(crate) mod crypto;
 /// (#562 — DRY consolidation.)
 pub(crate) mod hex;
 
-/// Tiny `application/x-www-form-urlencoded` decoder shared by
-/// [`signed_url`], [`auth_flows`], and [`tenancy::admin`]. Internal.
+/// Django `django.utils.encoding` + `django.utils.http` URL/IRI/URI
+/// helpers — `url_encode`, `uri_to_iri`, `iri_to_uri`,
+/// `escape_uri_path`, `filepath_to_uri`, `urlsafe_base64_encode` /
+/// `_decode`, etc. Originally an internal `pub(crate)` module used
+/// by [`signed_url`], [`auth_flows`], and [`tenancy::admin`]; promoted
+/// to `pub` so consumer crates can reach the Django-parity helpers
+/// directly (otherwise the `uri_to_iri` / `filepath_to_uri` /
+/// `escape_uri_path` / `is_uri_reserved` helpers shipped by the
+/// `django.utils` parity sweep would be unreachable).
 #[cfg(any(feature = "signed_url", feature = "auth_flows", feature = "tenancy",))]
-pub(crate) mod url_codec;
+pub mod url_codec;
 
 /// AWS-style canonical request signed with SHA-256, replay-bounded
 /// by an X-Date tolerance window. See [`hmac_auth::HmacAuthLayer`].

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -2908,6 +2908,7 @@ pub(super) fn write_delete(b: &mut Sql<'_>, query: &DeleteQuery) -> Result<(), S
 /// `near "(": syntax error` at the alias parens. The
 /// CTE + correlated-subquery shape below parses everywhere
 /// SQLite has supported CTEs (3.8.3, 2014).
+#[cfg(feature = "sqlite")]
 pub(super) fn write_bulk_update_sqlite(
     b: &mut Sql<'_>,
     query: &BulkUpdateQuery,

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -2733,7 +2733,6 @@ async fn fetch_fk_display_map_pool(
 }
 
 fn build_fk_display_query(fk: &FkLookup) -> SelectQuery {
-    use crate::core::{Filter, Op};
     // Synthesize a one-off `&'static ModelSchema` to use as the
     // SelectQuery's model — actually no, we need a real schema
     // because select_rows compiles the query against it. Use the


### PR DESCRIPTION
Three independent fixes for the warnings the framework currently emits:

1. **\`url_codec\` was \`pub(crate) mod\`** despite shipping \`uri_to_iri\` / \`filepath_to_uri\` / \`escape_uri_path\` / \`is_uri_reserved\` as Django \`django.utils.encoding\` / \`django.utils.http\` parity helpers (PRs #619–#731). The public-fn helpers were therefore unreachable from consumer crates AND triggered dead-code warnings inside the framework. Promote to \`pub mod\`.
2. **\`write_bulk_update_sqlite\`** is consumed only by \`sql/sqlite.rs\` which is \`#[cfg(feature = "sqlite")]\`. Gate the writer behind the same feature flag.
3. **Stale \`use crate::core::{Filter, Op};\`** in \`template_views::build_fk_display_query\` (orphaned after PR #814 migrated the FK display query to \`SelectQuery::by_pk_in\`). Removed.

## Verification

\`\`\`
cargo build -p rustango --features postgres,tenancy                     → warning-free
cargo build --no-default-features --features sqlite,tenancy             → warning-free
cargo build -p rustango --features postgres,mysql,sqlite,tenancy        → warning-free
cargo test --workspace --all-features --no-run                          → builds
cargo test -p rustango --features postgres,mysql,sqlite,tenancy --lib   → 3386 / 3386
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)