### PR TITLE
dry(admin): admin_config_or_default + primary_key_or_internal — closes last open #562 sub-item except tenant-CBV

### DIFF
--- a/crates/rustango/src/admin/helpers.rs
+++ b/crates/rustango/src/admin/helpers.rs
@@ -234,15 +234,57 @@ pub(crate) fn resolve_model_and_pk(
     crate::admin::errors::AdminError,
 > {
     let model = resolve_model(state, table)?;
-    let pk_field = model.primary_key().ok_or_else(|| {
+    let pk_field = primary_key_or_internal(model)?;
+    let pk_value = crate::forms::parse_pk_string(pk_field, pk_raw)
+        .map_err(crate::admin::errors::AdminError::Form)?;
+    Ok((model, pk_field, pk_value))
+}
+
+/// Return the model's `#[rustango(admin(...))]` block, falling back to
+/// [`crate::core::AdminConfig::DEFAULT`] when none is declared. Folds
+/// the third prologue pattern that recurs across every list / detail /
+/// create / update / delete handler:
+///
+/// ```ignore
+/// let admin_cfg = model
+///     .admin
+///     .copied()
+///     .unwrap_or(crate::core::AdminConfig::DEFAULT);
+/// ```
+///
+/// Issue #562 (admin CRUD-handler prologue dedup).
+#[must_use]
+pub(crate) fn admin_config_or_default(model: &'static ModelSchema) -> crate::core::AdminConfig {
+    model
+        .admin
+        .copied()
+        .unwrap_or(crate::core::AdminConfig::DEFAULT)
+}
+
+/// Resolve the model's primary-key `FieldSchema`, mapping the
+/// `Option::None` no-PK case to [`AdminError::Internal`]. Folds the
+/// fourth prologue pattern that recurs across every detail / create /
+/// update / delete handler that doesn't go through
+/// [`resolve_model_and_pk`] (because they don't have a `pk_raw` to
+/// parse — e.g. list endpoints that just need to know the PK column
+/// name for ordering).
+///
+/// ```ignore
+/// let pk_field = model.primary_key().ok_or_else(|| {
+///     AdminError::Internal(format!("model `{}` has no primary key", model.name))
+/// })?;
+/// ```
+///
+/// Issue #562 (admin CRUD-handler prologue dedup).
+pub(crate) fn primary_key_or_internal(
+    model: &'static ModelSchema,
+) -> Result<&'static crate::core::FieldSchema, crate::admin::errors::AdminError> {
+    model.primary_key().ok_or_else(|| {
         crate::admin::errors::AdminError::Internal(format!(
             "model `{}` has no primary key",
             model.name
         ))
-    })?;
-    let pk_value = crate::forms::parse_pk_string(pk_field, pk_raw)
-        .map_err(crate::admin::errors::AdminError::Form)?;
-    Ok((model, pk_field, pk_value))
+    })
 }
 
 /// Resolve `table` to a `ModelSchema`, but only if the admin is configured

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -16,8 +16,9 @@ use axum::response::{Html, IntoResponse, Redirect, Response};
 use super::errors::AdminError;
 use super::forms;
 use super::helpers::{
-    build_fk_joins, chrome_context, fk_map_from_joined_rows_json, lookup_model, pager_suffix,
-    render_cell_json, render_form, resolve_model, resolve_model_and_pk,
+    admin_config_or_default, build_fk_joins, chrome_context, fk_map_from_joined_rows_json,
+    lookup_model, pager_suffix, primary_key_or_internal, render_cell_json, render_form,
+    resolve_model, resolve_model_and_pk,
 };
 use super::render;
 use super::templates::render_with_chrome;
@@ -238,10 +239,7 @@ pub(crate) async fn table_view(
 ) -> Result<Html<String>, AdminError> {
     let model = resolve_model(&state, &table)?;
     let pk_field = model.primary_key();
-    let admin_cfg = model
-        .admin
-        .copied()
-        .unwrap_or(crate::core::AdminConfig::DEFAULT);
+    let admin_cfg = admin_config_or_default(model);
     // Resolve per-model page size (fall back to framework default when unset).
     let page_size: i64 = if admin_cfg.list_per_page == 0 {
         DEFAULT_PAGE_SIZE
@@ -1534,10 +1532,7 @@ pub(crate) async fn autocomplete_view(
     State(state): State<AppState>,
 ) -> Result<axum::Json<serde_json::Value>, AdminError> {
     let model = resolve_model(&state, &table)?;
-    let admin_cfg = model
-        .admin
-        .copied()
-        .unwrap_or(crate::core::AdminConfig::DEFAULT);
+    let admin_cfg = admin_config_or_default(model);
     let q = params
         .get("q")
         .map(String::as_str)
@@ -1899,15 +1894,10 @@ pub(crate) async fn create_submit(
         });
     }
 
-    let pk_field = model.primary_key().ok_or_else(|| {
-        AdminError::Internal(format!("model `{}` has no primary key", model.name))
-    })?;
+    let pk_field = primary_key_or_internal(model)?;
     // Auto-PK fields are server-assigned; readonly_fields are display-only
     // and must not be part of the INSERT. Build the combined skip list.
-    let admin_cfg = model
-        .admin
-        .copied()
-        .unwrap_or(crate::core::AdminConfig::DEFAULT);
+    let admin_cfg = admin_config_or_default(model);
     let mut skip: Vec<&str> = admin_cfg.readonly_fields.to_vec();
     if pk_field.auto {
         skip.push(pk_field.name);
@@ -2058,9 +2048,7 @@ pub(crate) async fn update_submit(
             table: model.table.to_owned(),
         });
     }
-    let pk_field = model.primary_key().ok_or_else(|| {
-        AdminError::Internal(format!("model `{}` has no primary key", model.name))
-    })?;
+    let pk_field = primary_key_or_internal(model)?;
     let pk_value = forms::parse_pk_string(pk_field, &pk_raw).map_err(AdminError::Form)?;
 
     // #361 — `has_change_permission(request, obj)`. Fetch the row
@@ -2094,10 +2082,7 @@ pub(crate) async fn update_submit(
     // user-marked `readonly_fields` (slice 10.5): the form rendered
     // them as `readonly` inputs, but a malicious POST could still
     // include them; skip server-side too.
-    let admin_cfg = model
-        .admin
-        .copied()
-        .unwrap_or(crate::core::AdminConfig::DEFAULT);
+    let admin_cfg = admin_config_or_default(model);
     let mut skip: Vec<&'static str> = vec![pk_field.name];
     skip.extend(admin_cfg.readonly_fields.iter().copied());
     let collected = match forms::collect_values(model, &form, &skip) {
@@ -2186,9 +2171,7 @@ pub(crate) async fn delete_submit(
             table: model.table.to_owned(),
         });
     }
-    let pk_field = model.primary_key().ok_or_else(|| {
-        AdminError::Internal(format!("model `{}` has no primary key", model.name))
-    })?;
+    let pk_field = primary_key_or_internal(model)?;
     let pk_value = forms::parse_pk_string(pk_field, &pk_raw).map_err(AdminError::Form)?;
 
     // v0.12.3: SELECT the row before delete so the audit entry
@@ -2346,10 +2329,7 @@ pub(crate) async fn action_submit(
         );
     }
 
-    let admin_cfg = model
-        .admin
-        .copied()
-        .unwrap_or(crate::core::AdminConfig::DEFAULT);
+    let admin_cfg = admin_config_or_default(model);
     if !admin_cfg.actions.iter().any(|a| *a == action) {
         return Err(AdminError::Internal(format!(
             "action `{action}` not registered for `{}`",
@@ -2357,9 +2337,7 @@ pub(crate) async fn action_submit(
         )));
     }
 
-    let pk_field = model.primary_key().ok_or_else(|| {
-        AdminError::Internal(format!("model `{}` has no primary key", model.name))
-    })?;
+    let pk_field = primary_key_or_internal(model)?;
 
     let pk_values: Vec<SqlValue> = selected_raw
         .iter()


### PR DESCRIPTION
Closes the admin CRUD-handler prologue dedup sub-item of #562. Two new helpers in \`admin::helpers\`:

* \`admin_config_or_default(model) -> AdminConfig\` — folds the \`model.admin.copied().unwrap_or(AdminConfig::DEFAULT)\` pattern that recurred verbatim ×5 across list / detail / create / update / delete handlers.
* \`primary_key_or_internal(model) -> Result<&'static FieldSchema, AdminError>\` — folds the \`model.primary_key().ok_or_else(|| AdminError::Internal(...))\` pattern that recurred verbatim ×4. \`resolve_model_and_pk\` (which existed already) now delegates to it.

Net **9 call sites collapsed**, no behaviour change. Each helper is \`pub(crate)\` so the crate API stays unchanged.

## #562 status after this PR

| Sub-item | Status |
|---|---|
| SelectQuery constructor | SHIPPED (PRs #783–#789) |
| Legacy &PgPool fns delegating | SHIPPED (\`permissions.rs\` et al.) |
| hex_encode ×3 | SHIPPED (\`crate::hex::hex_encode\`) |
| row_to_json PG == MySQL | SHIPPED (\`row_to_json_generic\`) |
| null_cast → cast_type | SHIPPED |
| stringify_facet_value × 3 | SHIPPED (\`decode_facet_row<R>\`) |
| Admin CRUD prologue helpers | **SHIPPED (this PR)** |
| template_views \`tenant\` module dedup (~560 LOC) | OPEN — substantial \`PoolSource\` adoption refactor; deferred |

Only the template_views \`tenant\` module sub-item remains; tracking as a follow-up since it's a multi-day refactor.

Lib suite **3390 / 3390** passing. \`cargo build --no-default-features --features sqlite,tenancy\` litmus passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)