### PR TITLE
feat(orm): Model::active_pool / only_trashed_pool / with_trashed_pool — Eloquent soft-delete query shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Post-v0.42 Django-parity follow-ups. Each item is a self-contained slice that la
 - **`Locale::display_name()` / `native_name()` + Tera `language_display_name()` / `language_native_name()`** (#563) — 42-language picker primitives for bidi-aware UIs.
 - **`#[rustango(citext)]`** (#566 closing [#344](https://github.com/ujeenet/rustango/issues/344)) — Django `CITextField`. Per-dialect DDL emit: `CITEXT` (PG, with `dialect.ci_text_extension_sql()` exposing the `CREATE EXTENSION` prelude), `TEXT COLLATE NOCASE` (SQLite), `VARCHAR(N) COLLATE utf8mb4_general_ci` (MySQL).
 - **`#[rustango(db_table_comment = "...")]`** — Django `Meta.db_table_comment` (4.2+). Per-dialect DDL emit: PG post-table `COMMENT ON TABLE "<t>" IS '...'`, MySQL inline `COMMENT='...'` trailer after CREATE TABLE, SQLite no-op. Useful for data-lineage tooling that reads the table's catalog comment.
+- **`Model::active_pool` / `Model::only_trashed_pool` / `Model::with_trashed_pool`** (closing [#821](https://github.com/ujeenet/rustango/issues/821) partial) — macro-emitted Eloquent-shape soft-delete query shortcuts. `active_pool` returns only live rows (deleted_at IS NULL); `only_trashed_pool` returns only soft-deleted rows (drives admin Trash pages, restore flows, GDPR purge scans); `with_trashed_pool` returns every row (forward-compat marker for when auto-scoping #820 lands). All three only emit on models carrying `#[rustango(soft_delete)]`.
 
 ### Fixed
 

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -4508,6 +4508,83 @@ fn inherent_impl_tokens(
                 ) -> ::core::result::Result<u64, ::rustango::sql::ExecError> {
                     Self::delete_pool(self, pool).await
                 }
+
+                /// Fetch every row whose `#[rustango(soft_delete)]`
+                /// column is `NULL` (a.k.a. the live, non-trashed
+                /// rows). Eloquent's default `Model::all()` behavior on
+                /// a soft-delete model (Eloquent auto-scopes trashed
+                /// rows out; rustango doesn't have auto-scoping yet —
+                /// see issue #820 — so this is the explicit shortcut).
+                ///
+                /// One-liner over `QuerySet::<Self>::default()
+                /// .active().fetch_pool(pool)`. Closes #821 partial.
+                ///
+                /// # Errors
+                /// As [`::rustango::sql::FetcherPool::fetch_pool`].
+                pub async fn active_pool(
+                    pool: &::rustango::sql::Pool,
+                ) -> ::core::result::Result<
+                    ::std::vec::Vec<Self>,
+                    ::rustango::sql::ExecError,
+                > {
+                    use ::rustango::sql::FetcherPool as _;
+                    ::rustango::query::QuerySet::<Self>::default()
+                        .active()
+                        .fetch_pool(pool)
+                        .await
+                }
+
+                /// Fetch ONLY soft-deleted rows. Eloquent
+                /// `Model::onlyTrashed()->get()` parity — drives the
+                /// admin "Trash" page, restore flows, GDPR purge
+                /// scans, etc.
+                ///
+                /// One-liner over `QuerySet::<Self>::default()
+                /// .only_trashed().fetch_pool(pool)`. Closes #821
+                /// partial.
+                ///
+                /// # Errors
+                /// As [`::rustango::sql::FetcherPool::fetch_pool`].
+                pub async fn only_trashed_pool(
+                    pool: &::rustango::sql::Pool,
+                ) -> ::core::result::Result<
+                    ::std::vec::Vec<Self>,
+                    ::rustango::sql::ExecError,
+                > {
+                    use ::rustango::sql::FetcherPool as _;
+                    ::rustango::query::QuerySet::<Self>::default()
+                        .only_trashed()
+                        .fetch_pool(pool)
+                        .await
+                }
+
+                /// Fetch every row, both live and soft-deleted.
+                /// Eloquent `Model::withTrashed()->get()` parity.
+                ///
+                /// Today every queryset already includes trashed rows
+                /// (rustango has no global-scope tracking yet — issue
+                /// #820), so this is functionally equivalent to
+                /// [`Self::all_pool`]. Exposed as a named shortcut so
+                /// soft-delete-aware code reads `Model::with_trashed_pool`
+                /// rather than `Model::all_pool` — keeps intent visible
+                /// in callers and stays correct when auto-scoping lands.
+                ///
+                /// Closes #821 partial.
+                ///
+                /// # Errors
+                /// As [`::rustango::sql::FetcherPool::fetch_pool`].
+                pub async fn with_trashed_pool(
+                    pool: &::rustango::sql::Pool,
+                ) -> ::core::result::Result<
+                    ::std::vec::Vec<Self>,
+                    ::rustango::sql::ExecError,
+                > {
+                    use ::rustango::sql::FetcherPool as _;
+                    ::rustango::query::QuerySet::<Self>::default()
+                        .with_trashed()
+                        .fetch_pool(pool)
+                        .await
+                }
             }
         } else {
             quote!()

--- a/crates/rustango/tests/model_soft_delete_scope_pool_sqlite_live.rs
+++ b/crates/rustango/tests/model_soft_delete_scope_pool_sqlite_live.rs
@@ -1,0 +1,100 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite tests for the macro-emitted soft-delete query
+//! shortcuts — `Model::active_pool`, `Model::only_trashed_pool`,
+//! `Model::with_trashed_pool`. Eloquent
+//! `Model::onlyTrashed()->get()` / `Model::withTrashed()->get()`
+//! parity. Closes #821 partial.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "sds_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(soft_delete)]
+    pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE sds_post (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            title      TEXT NOT NULL,
+            deleted_at TEXT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn seed(pool: &Pool) -> (i64, i64, i64) {
+    let mut a = Post {
+        id: Auto::default(),
+        title: "alpha".into(),
+        deleted_at: None,
+    };
+    a.save_pool(pool).await.unwrap();
+    let mut b = Post {
+        id: Auto::default(),
+        title: "beta".into(),
+        deleted_at: None,
+    };
+    b.save_pool(pool).await.unwrap();
+    let mut c = Post {
+        id: Auto::default(),
+        title: "gamma".into(),
+        deleted_at: None,
+    };
+    c.save_pool(pool).await.unwrap();
+    // Soft-delete beta.
+    b.soft_delete_pool(pool).await.unwrap();
+    (
+        a.id.get().copied().unwrap(),
+        b.id.get().copied().unwrap(),
+        c.id.get().copied().unwrap(),
+    )
+}
+
+#[tokio::test]
+async fn active_pool_returns_only_live_rows() {
+    let pool = make_pool().await;
+    let (a_id, _b_id, c_id) = seed(&pool).await;
+    let mut rows = Post::active_pool(&pool).await.unwrap();
+    rows.sort_by_key(|r| r.id.get().copied().unwrap());
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].id.get().copied().unwrap(), a_id);
+    assert_eq!(rows[1].id.get().copied().unwrap(), c_id);
+    for r in &rows {
+        assert!(r.deleted_at.is_none());
+    }
+}
+
+#[tokio::test]
+async fn only_trashed_pool_returns_only_soft_deleted_rows() {
+    let pool = make_pool().await;
+    let (_a_id, b_id, _c_id) = seed(&pool).await;
+    let rows = Post::only_trashed_pool(&pool).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id.get().copied().unwrap(), b_id);
+    assert!(rows[0].deleted_at.is_some());
+}
+
+#[tokio::test]
+async fn with_trashed_pool_returns_every_row() {
+    let pool = make_pool().await;
+    let _ids = seed(&pool).await;
+    let rows = Post::with_trashed_pool(&pool).await.unwrap();
+    assert_eq!(rows.len(), 3);
+    let trashed = rows.iter().filter(|r| r.deleted_at.is_some()).count();
+    assert_eq!(trashed, 1);
+}


### PR DESCRIPTION
Closes #821 partial (Model-level shortcut half — auto-scoping is the orthogonal #820).

Macro emits three new static query shortcuts on every model carrying \`#[rustango(soft_delete)]\`:

\`\`\`rust
// Live rows only (deleted_at IS NULL).
let alive: Vec<Post> = Post::active_pool(&pool).await?;

// Only trashed rows. Drives admin "Trash" pages, restore flows,
// GDPR purge scans, etc.
let trash: Vec<Post> = Post::only_trashed_pool(&pool).await?;

// Every row, both live and trashed. Forward-compat shortcut for
// when auto-scoping (issue #820) lands.
let everything: Vec<Post> = Post::with_trashed_pool(&pool).await?;
\`\`\`

Each is a one-liner over the matching \`QuerySet::<T>::default().active()\` / \`.only_trashed()\` / \`.with_trashed()\` builder methods that have shipped since v0.21.

## Tests

3 SQLite live tests covering:
- \`active_pool\` filters out the trashed row.
- \`only_trashed_pool\` returns exactly the soft-deleted row.
- \`with_trashed_pool\` returns every row.

Lib suite **3408 / 3408** passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)