### PR TITLE
feat(orm): Model::sum/avg/min/max_pool + doesnt_exist_pool — Eloquent aggregate-shortcut quintet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Post-v0.42 Django-parity follow-ups. Each item is a self-contained slice that la
 - **`Model::trashed(&self) -> bool`** — Eloquent `$model->trashed()` parity. Pure in-memory predicate that returns whether the row's `#[rustango(soft_delete)]` column is set. Useful in templates (`{% if post.trashed() %}…{% endif %}`) and guard clauses on restore / force-delete flows. Macro emits only on soft-delete-enabled models.
 - **`Model::is(&self, other) -> bool` + `Model::is_not(&self, other) -> bool`** — Eloquent `$model->is($other)` / `$model->isNot($other)` parity. Pure in-memory primary-key equality between two `&Self` instances; the model/table check is automatic (typed argument). Emits on every model with a primary key.
 - **`Model::value_pool::<U>(col, &pool) -> Option<U>`** — Eloquent `Model::query()->value($col)` parity. Single-scalar-from-first-row shortcut built on the existing `values_list_flat(col).first::<U>(pool)` chain (#877). Unknown fields surface as `QueryError::UnknownField`. Emits on every model.
+- **`Model::sum_pool` / `Model::avg_pool` / `Model::min_pool` / `Model::max_pool`** — Eloquent `Model::sum/avg/min/max($col)` parity. Each is `Model::<aggregate>_pool::<U>(col, &pool) -> Option<U>`. Returns `Ok(None)` on an empty table. Backed by the existing `fetch_aggregate_pool` primitive — no schema change, no new core types. Emits on every model.
+- **`Model::doesnt_exist_pool(&pool) -> bool`** — Eloquent `Model::doesntExist()` parity. Inverse of `exists_pool`. Emits on every model.
 
 ### Fixed
 

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -3768,6 +3768,181 @@ fn inherent_impl_tokens(
                     .await
             }
 
+            /// Inverse of [`Self::exists_pool`] — returns `true` when
+            /// the table has zero rows. Eloquent
+            /// `Model::doesntExist()` parity.
+            ///
+            /// # Errors
+            /// As [`Self::exists_pool`].
+            pub async fn doesnt_exist_pool(
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<bool, ::rustango::sql::ExecError> {
+                Self::exists_pool(pool).await.map(|e| !e)
+            }
+
+            /// `SUM(col)` over every row. Returns `Ok(None)` when the
+            /// table is empty (matches SQL's `SUM(empty)` shape).
+            /// Eloquent `Model::sum($col)` parity.
+            ///
+            /// `col` is the Rust field ident; unknown columns surface
+            /// as `QueryError::UnknownField`. `U` is the decoded
+            /// type — `i64` for an integer column, `f64` for a
+            /// numeric, etc. Choose `Option<U>` if you prefer to
+            /// distinguish "no rows" from a `Default::default()`.
+            ///
+            /// # Errors
+            /// As [`::rustango::sql::fetch_aggregate_pool`].
+            pub async fn sum_pool<U>(
+                col: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<U>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                (::core::option::Option<U>,): ::rustango::sql::MaybePgFromRow
+                    + ::rustango::sql::MaybeMyFromRow
+                    + ::rustango::sql::MaybeSqliteFromRow
+                    + ::core::marker::Send
+                    + ::core::marker::Unpin,
+            {
+                Self::__aggregate_one_pool::<U>(
+                    col,
+                    |c| ::rustango::core::AggregateExpr::Sum(c),
+                    pool,
+                )
+                .await
+            }
+
+            /// `AVG(col)`. Returns `Ok(None)` when the table is empty.
+            /// Eloquent `Model::avg($col)` parity.
+            ///
+            /// # Errors
+            /// As [`::rustango::sql::fetch_aggregate_pool`].
+            pub async fn avg_pool<U>(
+                col: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<U>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                (::core::option::Option<U>,): ::rustango::sql::MaybePgFromRow
+                    + ::rustango::sql::MaybeMyFromRow
+                    + ::rustango::sql::MaybeSqliteFromRow
+                    + ::core::marker::Send
+                    + ::core::marker::Unpin,
+            {
+                Self::__aggregate_one_pool::<U>(
+                    col,
+                    |c| ::rustango::core::AggregateExpr::Avg(c),
+                    pool,
+                )
+                .await
+            }
+
+            /// `MIN(col)`. Returns `Ok(None)` when the table is empty.
+            /// Eloquent `Model::min($col)` parity.
+            ///
+            /// # Errors
+            /// As [`::rustango::sql::fetch_aggregate_pool`].
+            pub async fn min_pool<U>(
+                col: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<U>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                (::core::option::Option<U>,): ::rustango::sql::MaybePgFromRow
+                    + ::rustango::sql::MaybeMyFromRow
+                    + ::rustango::sql::MaybeSqliteFromRow
+                    + ::core::marker::Send
+                    + ::core::marker::Unpin,
+            {
+                Self::__aggregate_one_pool::<U>(
+                    col,
+                    |c| ::rustango::core::AggregateExpr::Min(c),
+                    pool,
+                )
+                .await
+            }
+
+            /// `MAX(col)`. Returns `Ok(None)` when the table is empty.
+            /// Eloquent `Model::max($col)` parity.
+            ///
+            /// # Errors
+            /// As [`::rustango::sql::fetch_aggregate_pool`].
+            pub async fn max_pool<U>(
+                col: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<U>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                (::core::option::Option<U>,): ::rustango::sql::MaybePgFromRow
+                    + ::rustango::sql::MaybeMyFromRow
+                    + ::rustango::sql::MaybeSqliteFromRow
+                    + ::core::marker::Send
+                    + ::core::marker::Unpin,
+            {
+                Self::__aggregate_one_pool::<U>(
+                    col,
+                    |c| ::rustango::core::AggregateExpr::Max(c),
+                    pool,
+                )
+                .await
+            }
+
+            /// Internal: resolve `col` → SCHEMA `&'static str`, build a
+            /// single-aggregate `AggregateQuery`, run it through
+            /// `fetch_aggregate_pool::<(Option<U>,)>`, and unwrap the
+            /// first row's first column. Backs `sum_pool` / `avg_pool`
+            /// / `min_pool` / `max_pool`.
+            #[doc(hidden)]
+            pub async fn __aggregate_one_pool<U>(
+                col: &str,
+                build: fn(&'static str) -> ::rustango::core::AggregateExpr,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<U>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                (::core::option::Option<U>,): ::rustango::sql::MaybePgFromRow
+                    + ::rustango::sql::MaybeMyFromRow
+                    + ::rustango::sql::MaybeSqliteFromRow
+                    + ::core::marker::Send
+                    + ::core::marker::Unpin,
+            {
+                let _col_static: &'static str = <Self as ::rustango::core::Model>::SCHEMA
+                    .field(col)
+                    .ok_or_else(|| {
+                        ::rustango::sql::ExecError::Query(
+                            ::rustango::core::QueryError::UnknownField {
+                                model: <Self as ::rustango::core::Model>::SCHEMA.name,
+                                field: ::std::string::ToString::to_string(col),
+                            },
+                        )
+                    })?
+                    .column;
+                let _q = ::rustango::core::AggregateQuery {
+                    model: <Self as ::rustango::core::Model>::SCHEMA,
+                    where_clause: ::rustango::core::WhereExpr::And(::std::vec::Vec::new()),
+                    group_by: ::std::vec::Vec::new(),
+                    aggregates: ::std::vec![("v", build(_col_static))],
+                    aliases: ::std::vec::Vec::new(),
+                    having: ::core::option::Option::None,
+                    order_by: ::std::vec::Vec::new(),
+                    limit: ::core::option::Option::None,
+                    offset: ::core::option::Option::None,
+                };
+                let _rows: ::std::vec::Vec<(::core::option::Option<U>,)> =
+                    ::rustango::sql::fetch_aggregate_pool(pool, &_q).await?;
+                ::core::result::Result::Ok(_rows.into_iter().next().and_then(|t| t.0))
+            }
+
             /// Fetch every row of this model from `pool`. Eloquent
             /// `Model::all()` parity — a thin wrapper over
             /// `QuerySet::<Self>::default().fetch_pool(pool)`.

--- a/crates/rustango/tests/model_aggregate_shortcuts_sqlite_live.rs
+++ b/crates/rustango/tests/model_aggregate_shortcuts_sqlite_live.rs
@@ -1,0 +1,90 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite tests for the macro-emitted aggregate-shortcut
+//! family: `Model::sum_pool` / `avg_pool` / `min_pool` / `max_pool`
+//! / `doesnt_exist_pool`. Eloquent `Model::sum($col)` /
+//! `Model::avg($col)` / `Model::min($col)` / `Model::max($col)` /
+//! `Model::doesntExist()` parity.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "mas_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub views: i64,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE mas_post (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            views INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn seed(pool: &Pool) {
+    for (t, v) in [("alpha", 10_i64), ("beta", 20), ("gamma", 30)] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: t.into(),
+            views: v,
+        };
+        p.save_pool(pool).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn aggregate_quartet_on_seeded_table() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let s = Post::sum_pool::<i64>("views", &pool).await.unwrap();
+    assert_eq!(s, Some(60));
+    let mn = Post::min_pool::<i64>("views", &pool).await.unwrap();
+    assert_eq!(mn, Some(10));
+    let mx = Post::max_pool::<i64>("views", &pool).await.unwrap();
+    assert_eq!(mx, Some(30));
+    let av = Post::avg_pool::<f64>("views", &pool).await.unwrap();
+    assert!(av.is_some());
+    assert!((av.unwrap() - 20.0).abs() < 0.0001);
+}
+
+#[tokio::test]
+async fn aggregate_returns_none_on_empty_table() {
+    let pool = make_pool().await;
+    assert_eq!(Post::sum_pool::<i64>("views", &pool).await.unwrap(), None);
+    assert_eq!(Post::min_pool::<i64>("views", &pool).await.unwrap(), None);
+    assert_eq!(Post::max_pool::<i64>("views", &pool).await.unwrap(), None);
+    assert_eq!(Post::avg_pool::<f64>("views", &pool).await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn doesnt_exist_pool_is_inverse_of_exists() {
+    let pool = make_pool().await;
+    assert!(Post::doesnt_exist_pool(&pool).await.unwrap());
+    assert!(!Post::exists_pool(&pool).await.unwrap());
+    seed(&pool).await;
+    assert!(!Post::doesnt_exist_pool(&pool).await.unwrap());
+    assert!(Post::exists_pool(&pool).await.unwrap());
+}
+
+#[tokio::test]
+async fn aggregate_unknown_field_errors() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let err = Post::sum_pool::<i64>("nope", &pool).await.unwrap_err();
+    assert!(err.to_string().contains("nope"));
+}


### PR DESCRIPTION
Five new Eloquent-shape Model-level static shortcuts in one PR.

\`\`\`rust
// Aggregate quartet — Eloquent Model::sum/avg/min/max parity.
// Each returns Ok(None) on an empty table.
let total: Option<i64> = Post::sum_pool::<i64>(\"views\", &pool).await?;
let avg:   Option<f64> = Post::avg_pool::<f64>(\"views\", &pool).await?;
let lo:    Option<i64> = Post::min_pool::<i64>(\"views\", &pool).await?;
let hi:    Option<i64> = Post::max_pool::<i64>(\"views\", &pool).await?;

// Existence-check inverse.
if Post::doesnt_exist_pool(&pool).await? {
    // First-run seeding.
}
\`\`\`

## Implementation

\`sum/avg/min/max_pool::<U>(col, &pool)\` route through a hidden \`__aggregate_one_pool::<U>\` helper that:
1. Resolves \`col\` (runtime arg) to the SCHEMA-registered \`&'static str\` column (unknown columns surface as \`QueryError::UnknownField\`).
2. Builds a single-aggregate \`AggregateQuery\`.
3. Runs it through the existing \`fetch_aggregate_pool::<(Option<U>,)>\` tri-dialect primitive.
4. Unwraps the first row's first column.

No schema change, no new core types. \`doesnt_exist_pool\` is \`!exists_pool\`.

## Tests

4 SQLite live tests:
- Full quartet on seeded table (\`sum_pool\` returns 60, min 10, max 30, avg 20.0).
- All four return \`None\` on empty table.
- \`doesnt_exist_pool\` inverse of \`exists_pool\`.
- Unknown-field error message.

Lib suite **3408 / 3408** passing. Litmus passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)