### PR TITLE
feat(orm): Model::where_{in,not_in,null,not_null,between}_pool — Eloquent WHERE-predicate quintet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Post-v0.42 Django-parity follow-ups. Each item is a self-contained slice that la
 - **`Model::value_pool::<U>(col, &pool) -> Option<U>`** — Eloquent `Model::query()->value($col)` parity. Single-scalar-from-first-row shortcut built on the existing `values_list_flat(col).first::<U>(pool)` chain (#877). Unknown fields surface as `QueryError::UnknownField`. Emits on every model.
 - **`Model::sum_pool` / `Model::avg_pool` / `Model::min_pool` / `Model::max_pool`** — Eloquent `Model::sum/avg/min/max($col)` parity. Each is `Model::<aggregate>_pool::<U>(col, &pool) -> Option<U>`. Returns `Ok(None)` on an empty table. Backed by the existing `fetch_aggregate_pool` primitive — no schema change, no new core types. Emits on every model.
 - **`Model::doesnt_exist_pool(&pool) -> bool`** — Eloquent `Model::doesntExist()` parity. Inverse of `exists_pool`. Emits on every model.
+- **`Model::where_in_pool` / `where_not_in_pool` / `where_null_pool` / `where_not_null_pool` / `where_between_pool`** — Eloquent `whereIn` / `whereNotIn` / `whereNull` / `whereNotNull` / `whereBetween` parity. Each routes through the existing `.filter(col__suffix, …)` lookup-suffix machinery (`__in`, `__not_in`, `__isnull`, `__between`). Empty-list semantics: `where_in_pool` with no values returns zero rows; `where_not_in_pool` with no values returns every row. Emits on every model.
 
 ### Fixed
 

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -3606,6 +3606,151 @@ fn inherent_impl_tokens(
                     .await
             }
 
+            /// Fetch every row where `<col> IN (vals)`. Eloquent
+            /// `Model::whereIn($col, $vals)->get()` parity. Empty
+            /// `vals` returns no rows (matches SQL's empty-IN
+            /// semantics).
+            ///
+            /// `vals` accepts any iterable whose items are
+            /// `Into<SqlValue>` — `Vec<i64>`, `&[&str]`, `[Uuid; N]`,
+            /// etc.
+            ///
+            /// # Errors
+            /// As [`FetcherPool::fetch_pool`].
+            ///
+            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            pub async fn where_in_pool<V>(
+                col: &str,
+                vals: impl ::core::iter::IntoIterator<Item = V>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                V: ::core::convert::Into<::rustango::core::SqlValue>,
+            {
+                use ::rustango::sql::FetcherPool as _;
+                let _values: ::std::vec::Vec<::rustango::core::SqlValue> =
+                    vals.into_iter().map(::core::convert::Into::into).collect();
+                if _values.is_empty() {
+                    return ::core::result::Result::Ok(::std::vec::Vec::new());
+                }
+                let _key = ::std::format!("{}__in", col);
+                ::rustango::query::QuerySet::<Self>::default()
+                    .filter(&_key, ::rustango::core::SqlValue::List(_values))
+                    .fetch_pool(pool)
+                    .await
+            }
+
+            /// Fetch every row where `<col> NOT IN (vals)`. Eloquent
+            /// `Model::whereNotIn($col, $vals)->get()` parity. Empty
+            /// `vals` returns every row (matches SQL's empty-NOT-IN
+            /// semantics — vacuously true for every row).
+            ///
+            /// # Errors
+            /// As [`FetcherPool::fetch_pool`].
+            ///
+            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            pub async fn where_not_in_pool<V>(
+                col: &str,
+                vals: impl ::core::iter::IntoIterator<Item = V>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                V: ::core::convert::Into<::rustango::core::SqlValue>,
+            {
+                use ::rustango::sql::FetcherPool as _;
+                let _values: ::std::vec::Vec<::rustango::core::SqlValue> =
+                    vals.into_iter().map(::core::convert::Into::into).collect();
+                if _values.is_empty() {
+                    return ::rustango::query::QuerySet::<Self>::default()
+                        .fetch_pool(pool)
+                        .await;
+                }
+                let _key = ::std::format!("{}__not_in", col);
+                ::rustango::query::QuerySet::<Self>::default()
+                    .filter(&_key, ::rustango::core::SqlValue::List(_values))
+                    .fetch_pool(pool)
+                    .await
+            }
+
+            /// Fetch every row where `<col> IS NULL`. Eloquent
+            /// `Model::whereNull($col)->get()` parity.
+            ///
+            /// # Errors
+            /// As [`FetcherPool::fetch_pool`].
+            ///
+            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            pub async fn where_null_pool(
+                col: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                use ::rustango::sql::FetcherPool as _;
+                let _key = ::std::format!("{}__isnull", col);
+                ::rustango::query::QuerySet::<Self>::default()
+                    .filter(&_key, ::rustango::core::SqlValue::Bool(true))
+                    .fetch_pool(pool)
+                    .await
+            }
+
+            /// Fetch every row where `<col> IS NOT NULL`. Eloquent
+            /// `Model::whereNotNull($col)->get()` parity.
+            ///
+            /// # Errors
+            /// As [`FetcherPool::fetch_pool`].
+            ///
+            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            pub async fn where_not_null_pool(
+                col: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                use ::rustango::sql::FetcherPool as _;
+                let _key = ::std::format!("{}__isnull", col);
+                ::rustango::query::QuerySet::<Self>::default()
+                    .filter(&_key, ::rustango::core::SqlValue::Bool(false))
+                    .fetch_pool(pool)
+                    .await
+            }
+
+            /// Fetch every row where `<col> BETWEEN lo AND hi`
+            /// (inclusive on both ends — same as SQL). Eloquent
+            /// `Model::whereBetween($col, [$lo, $hi])->get()` parity.
+            ///
+            /// # Errors
+            /// As [`FetcherPool::fetch_pool`].
+            ///
+            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            pub async fn where_between_pool(
+                col: &str,
+                lo: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                hi: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                use ::rustango::sql::FetcherPool as _;
+                let _key = ::std::format!("{}__between", col);
+                let _vals = ::rustango::core::SqlValue::List(::std::vec![
+                    ::core::convert::Into::into(lo),
+                    ::core::convert::Into::into(hi),
+                ]);
+                ::rustango::query::QuerySet::<Self>::default()
+                    .filter(&_key, _vals)
+                    .fetch_pool(pool)
+                    .await
+            }
+
             /// Fetch the first row where `<col> = <val>`. Returns
             /// `Ok(None)` when no row matches. Eloquent
             /// `Model::firstWhere($col, $val)` / Django

--- a/crates/rustango/tests/model_where_predicate_shortcuts_sqlite_live.rs
+++ b/crates/rustango/tests/model_where_predicate_shortcuts_sqlite_live.rs
@@ -1,0 +1,127 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite tests for the macro-emitted WHERE-predicate
+//! shortcuts: `where_in_pool` / `where_not_in_pool` /
+//! `where_null_pool` / `where_not_null_pool` /
+//! `where_between_pool`. Eloquent `whereIn` / `whereNotIn` /
+//! `whereNull` / `whereNotNull` / `whereBetween` parity.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "mwp2_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 80)]
+    pub status: Option<String>,
+    pub views: i64,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE mwp2_post (
+            id     INTEGER PRIMARY KEY AUTOINCREMENT,
+            title  TEXT NOT NULL,
+            status TEXT NULL,
+            views  INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn seed(pool: &Pool) {
+    for (title, status, views) in [
+        ("a", Some("draft"), 10_i64),
+        ("b", Some("published"), 20),
+        ("c", Some("archived"), 30),
+        ("d", None, 40),
+    ] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: title.into(),
+            status: status.map(str::to_string),
+            views,
+        };
+        p.save_pool(pool).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn where_in_pool_filters_matching_rows() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let rows = Post::where_in_pool("status", ["draft", "published"], &pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2);
+}
+
+#[tokio::test]
+async fn where_in_pool_empty_returns_no_rows() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let rows: Vec<Post> = Post::where_in_pool::<&str>("status", Vec::<&str>::new(), &pool)
+        .await
+        .unwrap();
+    assert!(rows.is_empty());
+}
+
+#[tokio::test]
+async fn where_not_in_pool_excludes_listed_values() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let rows = Post::where_not_in_pool("status", ["archived"], &pool)
+        .await
+        .unwrap();
+    // 'archived' excluded; NULL doesn't match NOT IN under SQL semantics
+    // → expect rows with 'draft' and 'published' only (2).
+    let titles: Vec<&str> = rows.iter().map(|r| r.title.as_str()).collect();
+    assert!(titles.contains(&"a"));
+    assert!(titles.contains(&"b"));
+    assert!(!titles.contains(&"c"));
+}
+
+#[tokio::test]
+async fn where_not_in_pool_empty_returns_all_rows() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let rows: Vec<Post> = Post::where_not_in_pool::<&str>("status", Vec::<&str>::new(), &pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 4);
+}
+
+#[tokio::test]
+async fn where_null_and_not_null_split_rows() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let nulls = Post::where_null_pool("status", &pool).await.unwrap();
+    assert_eq!(nulls.len(), 1);
+    assert_eq!(nulls[0].title, "d");
+    let non_nulls = Post::where_not_null_pool("status", &pool).await.unwrap();
+    assert_eq!(non_nulls.len(), 3);
+}
+
+#[tokio::test]
+async fn where_between_pool_inclusive_bounds() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let rows = Post::where_between_pool("views", 20_i64, 40_i64, &pool)
+        .await
+        .unwrap();
+    let titles: Vec<&str> = rows.iter().map(|r| r.title.as_str()).collect();
+    assert_eq!(titles.len(), 3);
+    assert!(titles.contains(&"b"));
+    assert!(titles.contains(&"c"));
+    assert!(titles.contains(&"d"));
+}


### PR DESCRIPTION
Five macro-emitted Eloquent WHERE-predicate shortcuts in one PR.

\`\`\`rust
// whereIn — accepts any iterable of Into<SqlValue>.
let drafts = Post::where_in_pool(
    \"status\", [\"draft\", \"published\"], &pool).await?;

// whereNotIn — empty list returns every row.
let active = Post::where_not_in_pool(
    \"status\", [\"archived\"], &pool).await?;

// whereNull / whereNotNull.
let unset = Post::where_null_pool(\"status\", &pool).await?;
let set   = Post::where_not_null_pool(\"status\", &pool).await?;

// whereBetween — inclusive on both ends, SQL standard.
let mid = Post::where_between_pool(\"views\", 10_i64, 100_i64, &pool).await?;
\`\`\`

Each routes through the existing \`.filter(\"col__suffix\", …)\` lookup-suffix machinery (\`__in\`, \`__not_in\`, \`__isnull\`, \`__between\`) so the dialect-specific SQL writer + IR validation chains are untouched.

## Empty-list semantics

- \`where_in_pool\` with no values returns zero rows (vacuous IN).
- \`where_not_in_pool\` with no values returns every row (vacuous NOT-IN is true for every row).

## Tests

6 SQLite live tests covering: matching rows, empty-list, NOT-IN excludes listed values, empty-NOT-IN returns all, NULL / NOT-NULL split, BETWEEN inclusive bounds.

Lib suite **3408 / 3408** passing. Litmus passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)