### PR TITLE
feat(orm): Model::find_or / first_or / sole — Eloquent fallback + exactly-one trio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Post-v0.42 Django-parity follow-ups. Each item is a self-contained slice that la
 - **`Model::sum_pool` / `Model::avg_pool` / `Model::min_pool` / `Model::max_pool`** — Eloquent `Model::sum/avg/min/max($col)` parity. Each is `Model::<aggregate>_pool::<U>(col, &pool) -> Option<U>`. Returns `Ok(None)` on an empty table. Backed by the existing `fetch_aggregate_pool` primitive — no schema change, no new core types. Emits on every model.
 - **`Model::doesnt_exist_pool(&pool) -> bool`** — Eloquent `Model::doesntExist()` parity. Inverse of `exists_pool`. Emits on every model.
 - **`Model::where_in_pool` / `where_not_in_pool` / `where_null_pool` / `where_not_null_pool` / `where_between_pool`** — Eloquent `whereIn` / `whereNotIn` / `whereNull` / `whereNotNull` / `whereBetween` parity. Each routes through the existing `.filter(col__suffix, …)` lookup-suffix machinery (`__in`, `__not_in`, `__isnull`, `__between`). Empty-list semantics: `where_in_pool` with no values returns zero rows; `where_not_in_pool` with no values returns every row. Emits on every model.
+- **`Model::find_or_pool` / `Model::first_or_pool` / `Model::sole_pool`** — Eloquent `findOr` / `firstOr` / `sole` parity. `find_or_pool(pk, &pool, fallback_fn)` and `first_or_pool(&pool, fallback_fn)` return the matched row or invoke the closure to produce a default. `sole_pool(col, val, &pool)` returns the exactly-one match or errors: `RowNotFound` on zero, `ExecError::MultipleRowsReturned { op: "sole", … }` on >1.
 
 ### Fixed
 

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -4220,6 +4220,83 @@ fn inherent_impl_tokens(
                     ),
                 }
             }
+
+            /// Find by primary key or run `fallback` to produce a
+            /// default row to return. Eloquent
+            /// `Model::findOr($pk, fn() => …)` parity.
+            ///
+            /// Unlike [`Self::find_or_fail_pool`] (which raises on
+            /// miss), this is the "give me something sensible"
+            /// branch: typical use is "fetch the user's row, else
+            /// fall back to an anonymous/guest stub".
+            ///
+            /// `fallback` runs only when no row matches — the DB
+            /// round-trip happens unconditionally.
+            ///
+            /// # Errors
+            /// As [`Self::find_pool`].
+            pub async fn find_or_pool<F>(
+                pk: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+                fallback: F,
+            ) -> ::core::result::Result<Self, ::rustango::sql::ExecError>
+            where
+                F: ::core::ops::FnOnce() -> Self,
+            {
+                ::core::result::Result::Ok(
+                    Self::find_pool(pk, pool).await?.unwrap_or_else(fallback),
+                )
+            }
+
+            /// Fetch the first row of the table, or run `fallback`
+            /// when the table is empty. Eloquent
+            /// `Model::firstOr(fn() => …)` parity.
+            ///
+            /// # Errors
+            /// As [`Self::first_pool`].
+            pub async fn first_or_pool<F>(
+                pool: &::rustango::sql::Pool,
+                fallback: F,
+            ) -> ::core::result::Result<Self, ::rustango::sql::ExecError>
+            where
+                F: ::core::ops::FnOnce() -> Self,
+            {
+                ::core::result::Result::Ok(
+                    Self::first_pool(pool).await?.unwrap_or_else(fallback),
+                )
+            }
+
+            /// Fetch exactly one row matching `<col> = <val>`. Errors
+            /// when zero rows match (`ExecError::Driver(RowNotFound)`)
+            /// or more than one matches
+            /// (`ExecError::Query(QueryError::Sql(MultipleRowsReturned))`).
+            /// Eloquent `Model::sole($col, $val)` parity.
+            ///
+            /// # Errors
+            /// As [`Self::where_pool`] plus the explicit
+            /// `RowNotFound` / `MultipleRowsReturned` cases above.
+            pub async fn sole_pool(
+                col: &str,
+                val: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<Self, ::rustango::sql::ExecError> {
+                let mut _rows = Self::where_pool(col, val, pool).await?;
+                match _rows.len() {
+                    0 => ::core::result::Result::Err(
+                        ::rustango::sql::ExecError::Driver(
+                            ::rustango::sql::sqlx::Error::RowNotFound,
+                        ),
+                    ),
+                    1 => ::core::result::Result::Ok(_rows.remove(0)),
+                    n => ::core::result::Result::Err(
+                        ::rustango::sql::ExecError::MultipleRowsReturned {
+                            op: "sole",
+                            table: <Self as ::rustango::core::Model>::SCHEMA.name,
+                            count: n,
+                        },
+                    ),
+                }
+            }
         }
     } else {
         quote!()

--- a/crates/rustango/tests/model_find_or_first_or_sole_sqlite_live.rs
+++ b/crates/rustango/tests/model_find_or_first_or_sole_sqlite_live.rs
@@ -1,0 +1,127 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite tests for `Model::find_or_pool` / `first_or_pool` /
+//! `sole_pool`. Eloquent `findOr` / `firstOr` / `sole` parity.
+
+use rustango::sql::{sqlx, Auto, ExecError, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "mfs_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 80)]
+    pub status: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE mfs_post (
+            id     INTEGER PRIMARY KEY AUTOINCREMENT,
+            title  TEXT NOT NULL,
+            status TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+fn anon() -> Post {
+    Post {
+        id: Auto::default(),
+        title: "anonymous".into(),
+        status: "ghost".into(),
+    }
+}
+
+#[tokio::test]
+async fn find_or_pool_returns_row_when_found() {
+    let pool = make_pool().await;
+    let mut p = Post {
+        id: Auto::default(),
+        title: "real".into(),
+        status: "live".into(),
+    };
+    p.save_pool(&pool).await.unwrap();
+    let r = Post::find_or_pool(1_i64, &pool, anon).await.unwrap();
+    assert_eq!(r.title, "real");
+}
+
+#[tokio::test]
+async fn find_or_pool_returns_fallback_when_missing() {
+    let pool = make_pool().await;
+    let r = Post::find_or_pool(999_i64, &pool, anon).await.unwrap();
+    assert_eq!(r.title, "anonymous");
+    assert_eq!(r.status, "ghost");
+}
+
+#[tokio::test]
+async fn first_or_pool_returns_first_when_present() {
+    let pool = make_pool().await;
+    let mut p = Post {
+        id: Auto::default(),
+        title: "first".into(),
+        status: "live".into(),
+    };
+    p.save_pool(&pool).await.unwrap();
+    let r = Post::first_or_pool(&pool, anon).await.unwrap();
+    assert_eq!(r.title, "first");
+}
+
+#[tokio::test]
+async fn first_or_pool_returns_fallback_on_empty() {
+    let pool = make_pool().await;
+    let r = Post::first_or_pool(&pool, anon).await.unwrap();
+    assert_eq!(r.title, "anonymous");
+}
+
+#[tokio::test]
+async fn sole_pool_returns_row_on_unique_match() {
+    let pool = make_pool().await;
+    for (t, s) in [("a", "draft"), ("b", "published")] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: t.into(),
+            status: s.into(),
+        };
+        p.save_pool(&pool).await.unwrap();
+    }
+    let r = Post::sole_pool("status", "published", &pool).await.unwrap();
+    assert_eq!(r.title, "b");
+}
+
+#[tokio::test]
+async fn sole_pool_errors_on_zero_match() {
+    let pool = make_pool().await;
+    let err = Post::sole_pool("status", "nope", &pool).await.unwrap_err();
+    assert!(matches!(err, ExecError::Driver(sqlx::Error::RowNotFound)));
+}
+
+#[tokio::test]
+async fn sole_pool_errors_on_multi_match() {
+    let pool = make_pool().await;
+    for t in ["a", "b", "c"] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: t.into(),
+            status: "draft".into(),
+        };
+        p.save_pool(&pool).await.unwrap();
+    }
+    let err = Post::sole_pool("status", "draft", &pool).await.unwrap_err();
+    match err {
+        ExecError::MultipleRowsReturned { op, count, .. } => {
+            assert_eq!(op, "sole");
+            assert_eq!(count, 3);
+        }
+        other => panic!("expected MultipleRowsReturned, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Three Eloquent-shape Model shortcuts in one PR.

\`\`\`rust
// findOr / firstOr — callback fallback on miss.
let user = User::find_or_pool(id, &pool, anon_user).await?;
let any  = User::first_or_pool(&pool, anon_user).await?;

// sole — exactly one row matching (col, val). Errors on 0 or >1.
let row = Setting::sole_pool(\"key\", \"feature_flag_x\", &pool).await?;
\`\`\`

\`find_or_pool(pk, &pool, fallback_fn)\` and \`first_or_pool(&pool, fallback_fn)\` route through \`find_pool\` / \`first_pool\` and invoke the closure only on miss.

\`sole_pool(col, val, &pool)\` is a thin wrapper over \`where_pool\` that returns the exactly-one match or errors:
- \`ExecError::Driver(sqlx::Error::RowNotFound)\` on zero matches.
- \`ExecError::MultipleRowsReturned { op: \"sole\", table, count }\` on more than one match.

Reuses the existing \`ExecError::MultipleRowsReturned\` variant (shipped pre-v0.42 for \`get_or_create\` / \`update_or_create\`).

## Tests

7 SQLite live tests:
- \`find_or_pool\` row-found + fallback-used.
- \`first_or_pool\` row-found + empty-fallback.
- \`sole_pool\` unique-match + zero-match-RowNotFound + multi-match-MultipleRowsReturned.

Lib suite **3408 / 3408** passing. Litmus passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)