### PR TITLE
feat(orm): Model::random_pool / random_n_pool / oldest_pool / newest_pool — Eloquent ordering shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Post-v0.42 Django-parity follow-ups. Each item is a self-contained slice that la
 - **`Model::doesnt_exist_pool(&pool) -> bool`** — Eloquent `Model::doesntExist()` parity. Inverse of `exists_pool`. Emits on every model.
 - **`Model::where_in_pool` / `where_not_in_pool` / `where_null_pool` / `where_not_null_pool` / `where_between_pool`** — Eloquent `whereIn` / `whereNotIn` / `whereNull` / `whereNotNull` / `whereBetween` parity. Each routes through the existing `.filter(col__suffix, …)` lookup-suffix machinery (`__in`, `__not_in`, `__isnull`, `__between`). Empty-list semantics: `where_in_pool` with no values returns zero rows; `where_not_in_pool` with no values returns every row. Emits on every model.
 - **`Model::find_or_pool` / `Model::first_or_pool` / `Model::sole_pool`** — Eloquent `findOr` / `firstOr` / `sole` parity. `find_or_pool(pk, &pool, fallback_fn)` and `first_or_pool(&pool, fallback_fn)` return the matched row or invoke the closure to produce a default. `sole_pool(col, val, &pool)` returns the exactly-one match or errors: `RowNotFound` on zero, `ExecError::MultipleRowsReturned { op: "sole", … }` on >1.
+- **`Model::random_pool` / `random_n_pool` / `oldest_pool` / `newest_pool`** — Eloquent `inRandomOrder()->first()` / `inRandomOrder()->limit($n)->get()` / `oldest($field)->get()` / `latest($field)->get()` parity. Each is a thin wrapper over the existing `QuerySet` ordering primitives (`.order_random()` + `.limit()` / `.order_by(field, false/true)`). Random ordering carries the standard full-scan caveat.
 
 ### Fixed
 

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -3722,6 +3722,96 @@ fn inherent_impl_tokens(
                     .await
             }
 
+            /// Fetch up to `n` rows in random order. Eloquent
+            /// `Model::inRandomOrder()->limit($n)->get()` /
+            /// `Model::query()->inRandomOrder()->get()->take($n)`
+            /// parity. **Performance caveat**: random ordering
+            /// forces a full table scan + per-row random key sort;
+            /// the optimizer cannot use an index. Prefer a
+            /// `pk >= rand_offset LIMIT N` walk for huge tables.
+            ///
+            /// # Errors
+            /// As [`FetcherPool::fetch_pool`].
+            ///
+            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            pub async fn random_n_pool(
+                n: i64,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                use ::rustango::sql::FetcherPool as _;
+                ::rustango::query::QuerySet::<Self>::default()
+                    .order_random()
+                    .limit(n)
+                    .fetch_pool(pool)
+                    .await
+            }
+
+            /// Fetch one row in random order. Eloquent
+            /// `Model::inRandomOrder()->first()` parity. Same
+            /// performance caveat as [`Self::random_n_pool`].
+            ///
+            /// # Errors
+            /// As [`FetcherPool::fetch_pool`].
+            ///
+            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            pub async fn random_pool(
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                ::core::result::Result::Ok(
+                    Self::random_n_pool(1, pool).await?.into_iter().next(),
+                )
+            }
+
+            /// Fetch every row ordered ASC by `field`. Eloquent
+            /// `Model::oldest($field)->get()` parity — the multi-row
+            /// counterpart of [`Self::earliest_pool`].
+            ///
+            /// # Errors
+            /// As [`FetcherPool::fetch_pool`].
+            ///
+            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            pub async fn oldest_pool(
+                field: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                use ::rustango::sql::FetcherPool as _;
+                ::rustango::query::QuerySet::<Self>::default()
+                    .order_by(&[(field, false)])
+                    .fetch_pool(pool)
+                    .await
+            }
+
+            /// Fetch every row ordered DESC by `field`. Eloquent
+            /// `Model::latest($field)->get()` parity — the multi-row
+            /// counterpart of [`Self::latest_pool`].
+            ///
+            /// # Errors
+            /// As [`FetcherPool::fetch_pool`].
+            ///
+            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            pub async fn newest_pool(
+                field: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                use ::rustango::sql::FetcherPool as _;
+                ::rustango::query::QuerySet::<Self>::default()
+                    .order_by(&[(field, true)])
+                    .fetch_pool(pool)
+                    .await
+            }
+
             /// Fetch every row where `<col> BETWEEN lo AND hi`
             /// (inclusive on both ends — same as SQL). Eloquent
             /// `Model::whereBetween($col, [$lo, $hi])->get()` parity.

--- a/crates/rustango/tests/model_random_oldest_newest_sqlite_live.rs
+++ b/crates/rustango/tests/model_random_oldest_newest_sqlite_live.rs
@@ -1,0 +1,88 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite tests for the macro-emitted ordering shortcuts:
+//! `random_pool` / `random_n_pool` / `oldest_pool` / `newest_pool`.
+//! Eloquent `inRandomOrder()->first()` /
+//! `inRandomOrder()->limit($n)->get()` / `oldest()->get()` /
+//! `latest()->get()` parity.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "mron_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub views: i64,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE mron_post (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            views INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn seed(pool: &Pool) {
+    for (t, v) in [("a", 30_i64), ("b", 20), ("c", 10), ("d", 40), ("e", 50)] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: t.into(),
+            views: v,
+        };
+        p.save_pool(pool).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn random_pool_returns_some_row_when_present() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let r = Post::random_pool(&pool).await.unwrap();
+    assert!(r.is_some());
+}
+
+#[tokio::test]
+async fn random_pool_returns_none_on_empty() {
+    let pool = make_pool().await;
+    assert!(Post::random_pool(&pool).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn random_n_pool_caps_at_table_size() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let r = Post::random_n_pool(3, &pool).await.unwrap();
+    assert_eq!(r.len(), 3);
+}
+
+#[tokio::test]
+async fn oldest_pool_ascends_by_field() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let rows = Post::oldest_pool("views", &pool).await.unwrap();
+    let views: Vec<i64> = rows.iter().map(|r| r.views).collect();
+    assert_eq!(views, vec![10, 20, 30, 40, 50]);
+}
+
+#[tokio::test]
+async fn newest_pool_descends_by_field() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let rows = Post::newest_pool("views", &pool).await.unwrap();
+    let views: Vec<i64> = rows.iter().map(|r| r.views).collect();
+    assert_eq!(views, vec![50, 40, 30, 20, 10]);
+}


### PR DESCRIPTION
Four macro-emitted Eloquent ordering shortcuts in one PR.

\`\`\`rust
// Eloquent inRandomOrder()->first() / ->limit(\$n)->get().
let one  = Banner::random_pool(&pool).await?;
let pick = Banner::random_n_pool(3, &pool).await?;

// Eloquent oldest(\$field)->get() / latest(\$field)->get() — the
// multi-row siblings of the existing earliest_pool / latest_pool.
let by_date = Post::oldest_pool(\"created_at\", &pool).await?;
let recent  = Post::newest_pool(\"created_at\", &pool).await?;
\`\`\`

Each is a thin wrapper over the existing \`QuerySet\` primitives:
- \`random_*\` route through \`.order_random()\` (#77) + \`.limit(n)\`.
- \`oldest_pool\` / \`newest_pool\` are \`.order_by(&[(field, false)])\` / \`.order_by(&[(field, true)])\`.

Random ordering carries the standard full-scan caveat (PG/SQLite \`RANDOM()\`, MySQL \`RAND()\` — no index can serve it). Documented on the helper.

## Tests

5 SQLite live tests:
- \`random_pool\` returns Some when rows exist.
- \`random_pool\` returns None on empty table.
- \`random_n_pool(3)\` caps at table size (5 → 3).
- \`oldest_pool\` produces ASC ordering.
- \`newest_pool\` produces DESC ordering.

Lib suite **3408 / 3408** passing. Litmus passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)