### PR TITLE
feat(orm): bare-name Eloquent shortcuts — drop _pool suffix from user-facing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ Post-v0.42 Django-parity follow-ups. Each item is a self-contained slice that la
 - **`Model::update_where_pool` / `Model::delete_where_pool` / `Model::update_all_pool`** — Eloquent `Model::where($col, $val)->update([$col2 => $val2])` / `Model::where($col, $val)->delete()` / `Model::query()->update([$col => $val])` parity. Bulk mutation shortcuts: `update_where_pool` sets one column on filtered rows, `delete_where_pool` removes them, `update_all_pool` sets one column on every row of the table. Multi-column updates drop into the queryset-builder + `.update().set(...).set(...)` chain.
 - **`Model::where_not_like_pool` / `where_not_ilike_pool` / `where_not_between_pool`** — Eloquent `whereNotLike` / `whereNotILike` / `whereNotBetween` parity. Negated companions to the LIKE / BETWEEN shortcuts shipped earlier. Route through the existing `__not_like` / `__not_ilike` / `__not_between` lookup suffixes.
 - **`Model::table_name() -> &'static str` + `Model::primary_key_column() -> Option<&'static str>` + `Model::get_key(&self) -> SqlValue`** — Eloquent `getTable()` / `getKeyName()` / `getKey()` parity. Cheap inline introspection helpers for templating, logging, and adapter glue that needs the raw schema names + primary-key value without re-reading the SCHEMA constant.
+- **Bare-name aliases for every Eloquent shortcut** — drops the `_pool` suffix on the user-facing API. `Post::find(id, &pool)` / `Post::where_in(col, vals, &pool)` / `post.increment("views", 1, &pool)` etc. now all work. The `_pool` versions are retained as silent back-compat aliases so the existing test suite + downstream code continue compiling. New Eloquent-shape methods added to the macro from now on emit bare names directly (no `_pool` alias). `ContentType::all` (manual, ordered) renamed to `all_ordered` to avoid colliding with the macro-emitted bare-name `all`.
+
+### Changed
+
+- `crate::contenttypes::ContentType::all` renamed to `ContentType::all_ordered` (sole caller updated in `admin::views`). The macro-emitted `Model::all` is now the canonical "every row, unordered" shortcut on every model.
 
 ### Fixed
 

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -5760,6 +5760,86 @@ fn inherent_impl_tokens(
                         .fetch_pool(pool)
                         .await
                 }
+
+                // Bare-name soft-delete aliases (see the general
+                // bare-name alias block on `pk_methods` for context).
+
+                /// Eloquent `$model->delete()` (soft-delete model)
+                /// — bare-name alias for [`Self::soft_delete_pool`].
+                ///
+                /// # Errors
+                /// As [`Self::soft_delete_pool`].
+                pub async fn soft_delete(
+                    &self,
+                    pool: &::rustango::sql::Pool,
+                ) -> ::core::result::Result<u64, ::rustango::sql::ExecError> {
+                    Self::soft_delete_pool(self, pool).await
+                }
+
+                /// Eloquent `$model->restore()` — bare-name alias
+                /// for [`Self::restore_pool`].
+                ///
+                /// # Errors
+                /// As [`Self::restore_pool`].
+                pub async fn restore(
+                    &self,
+                    pool: &::rustango::sql::Pool,
+                ) -> ::core::result::Result<u64, ::rustango::sql::ExecError> {
+                    Self::restore_pool(self, pool).await
+                }
+
+                /// Eloquent `$model->forceDelete()` — bare-name alias
+                /// for [`Self::force_delete_pool`].
+                ///
+                /// # Errors
+                /// As [`Self::force_delete_pool`].
+                pub async fn force_delete(
+                    &self,
+                    pool: &::rustango::sql::Pool,
+                ) -> ::core::result::Result<u64, ::rustango::sql::ExecError> {
+                    Self::force_delete_pool(self, pool).await
+                }
+
+                /// Bare-name alias for [`Self::active_pool`].
+                ///
+                /// # Errors
+                /// As [`Self::active_pool`].
+                pub async fn active(
+                    pool: &::rustango::sql::Pool,
+                ) -> ::core::result::Result<
+                    ::std::vec::Vec<Self>,
+                    ::rustango::sql::ExecError,
+                > {
+                    Self::active_pool(pool).await
+                }
+
+                /// Eloquent `Model::onlyTrashed()->get()` —
+                /// bare-name alias for [`Self::only_trashed_pool`].
+                ///
+                /// # Errors
+                /// As [`Self::only_trashed_pool`].
+                pub async fn only_trashed(
+                    pool: &::rustango::sql::Pool,
+                ) -> ::core::result::Result<
+                    ::std::vec::Vec<Self>,
+                    ::rustango::sql::ExecError,
+                > {
+                    Self::only_trashed_pool(pool).await
+                }
+
+                /// Eloquent `Model::withTrashed()->get()` —
+                /// bare-name alias for [`Self::with_trashed_pool`].
+                ///
+                /// # Errors
+                /// As [`Self::with_trashed_pool`].
+                pub async fn with_trashed(
+                    pool: &::rustango::sql::Pool,
+                ) -> ::core::result::Result<
+                    ::std::vec::Vec<Self>,
+                    ::rustango::sql::ExecError,
+                > {
+                    Self::with_trashed_pool(pool).await
+                }
             }
         } else {
             quote!()
@@ -5865,6 +5945,963 @@ fn inherent_impl_tokens(
             #[must_use]
             pub fn get_key(&self) -> ::rustango::core::SqlValue {
                 ::core::convert::Into::into(::core::clone::Clone::clone(&self.#pk_ident))
+            }
+
+            // =====================================================
+            // Bare-name aliases for Eloquent-shape shortcuts.
+            //
+            // The `_pool` suffix is a v0.42 artifact callers found
+            // noisy ("rustango bare-name preference", 2026-06-07).
+            // The shortcuts below ARE the user-facing API; the
+            // matching `_pool` versions are silent back-compat
+            // aliases retained so the existing test suite +
+            // downstream code continue to compile unchanged.
+            //
+            // Rules of thumb:
+            // - `where` is a Rust keyword → bare-name keeps the
+            //   trailing-underscore `where_pool` is just left as
+            //   the named entry (no `where_` alias added — callers
+            //   keep using `Self::query().filter(...)` for that
+            //   shape). Every other shortcut gets a bare alias.
+            // - `save` / `insert` / `delete` keep `_pool` for now
+            //   (~140 test call sites; rename is a separate PR).
+            // =====================================================
+
+            /// Eloquent `Model::find($pk)` — bare-name alias for
+            /// [`Self::find_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::find_pool`].
+            pub async fn find(
+                pk: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::find_pool(pk, pool).await
+            }
+
+            /// Eloquent `Model::findOrFail($pk)` — bare-name alias for
+            /// [`Self::find_or_fail_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::find_or_fail_pool`].
+            pub async fn find_or_fail(
+                pk: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<Self, ::rustango::sql::ExecError> {
+                Self::find_or_fail_pool(pk, pool).await
+            }
+
+            /// Eloquent `Model::find([$id1, $id2, ...])` — bare-name
+            /// alias for [`Self::find_many_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::find_many_pool`].
+            pub async fn find_many<V>(
+                pks: impl ::core::iter::IntoIterator<Item = V>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                V: ::core::convert::Into<::rustango::core::SqlValue>,
+            {
+                Self::find_many_pool(pks, pool).await
+            }
+
+            /// Eloquent `Model::findOr($pk, fn() => …)` — bare-name
+            /// alias for [`Self::find_or_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::find_or_pool`].
+            pub async fn find_or<F>(
+                pk: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+                fallback: F,
+            ) -> ::core::result::Result<Self, ::rustango::sql::ExecError>
+            where
+                F: ::core::ops::FnOnce() -> Self,
+            {
+                Self::find_or_pool(pk, pool, fallback).await
+            }
+
+            /// Eloquent `Model::first()` — bare-name alias for
+            /// [`Self::first_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::first_pool`].
+            pub async fn first(
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::first_pool(pool).await
+            }
+
+            /// Eloquent `Model::firstOrFail()` — bare-name alias for
+            /// [`Self::first_or_fail_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::first_or_fail_pool`].
+            pub async fn first_or_fail(
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<Self, ::rustango::sql::ExecError> {
+                Self::first_or_fail_pool(pool).await
+            }
+
+            /// Eloquent `Model::firstOr(fn() => …)` — bare-name alias
+            /// for [`Self::first_or_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::first_or_pool`].
+            pub async fn first_or<F>(
+                pool: &::rustango::sql::Pool,
+                fallback: F,
+            ) -> ::core::result::Result<Self, ::rustango::sql::ExecError>
+            where
+                F: ::core::ops::FnOnce() -> Self,
+            {
+                Self::first_or_pool(pool, fallback).await
+            }
+
+            /// Eloquent `Model::firstWhere($col, $val)` — bare-name
+            /// alias for [`Self::first_where_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::first_where_pool`].
+            pub async fn first_where(
+                col: &str,
+                val: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::first_where_pool(col, val, pool).await
+            }
+
+            /// Eloquent `Model::all()` — bare-name alias for
+            /// [`Self::all_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::all_pool`].
+            pub async fn all(
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::all_pool(pool).await
+            }
+
+            /// Eloquent `Model::count()` — bare-name alias for
+            /// [`Self::count_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::count_pool`].
+            pub async fn count(
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<i64, ::rustango::sql::ExecError> {
+                Self::count_pool(pool).await
+            }
+
+            /// Eloquent `Model::exists()` — bare-name alias for
+            /// [`Self::exists_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::exists_pool`].
+            pub async fn exists(
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<bool, ::rustango::sql::ExecError> {
+                Self::exists_pool(pool).await
+            }
+
+            /// Eloquent `Model::doesntExist()` — bare-name alias for
+            /// [`Self::doesnt_exist_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::doesnt_exist_pool`].
+            pub async fn doesnt_exist(
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<bool, ::rustango::sql::ExecError> {
+                Self::doesnt_exist_pool(pool).await
+            }
+
+            /// Eloquent `Model::sole($col, $val)` — bare-name alias
+            /// for [`Self::sole_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::sole_pool`].
+            pub async fn sole(
+                col: &str,
+                val: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<Self, ::rustango::sql::ExecError> {
+                Self::sole_pool(col, val, pool).await
+            }
+
+            /// Eloquent `Model::query()->value($col)` — bare-name
+            /// alias for [`Self::value_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::value_pool`].
+            pub async fn value<U>(
+                col: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<U>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                U: ::rustango::sql::MaybePgScalar
+                    + ::rustango::sql::MaybeMyScalar
+                    + ::rustango::sql::MaybeSqliteScalar
+                    + ::core::marker::Send
+                    + ::core::marker::Unpin,
+            {
+                Self::value_pool::<U>(col, pool).await
+            }
+
+            /// Eloquent `Model::pluck($col)` — bare-name alias for
+            /// [`Self::pluck_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::pluck_pool`].
+            pub async fn pluck<U>(
+                col: &'static str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<::std::vec::Vec<U>, ::rustango::sql::ExecError>
+            where
+                U: ::rustango::sql::MaybePgScalar
+                    + ::rustango::sql::MaybeMyScalar
+                    + ::rustango::sql::MaybeSqliteScalar
+                    + ::core::marker::Send
+                    + ::core::marker::Unpin,
+            {
+                Self::pluck_pool::<U>(col, pool).await
+            }
+
+            /// Eloquent `Model::sum($col)` — bare-name alias for
+            /// [`Self::sum_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::sum_pool`].
+            pub async fn sum<U>(
+                col: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<U>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                (::core::option::Option<U>,): ::rustango::sql::MaybePgFromRow
+                    + ::rustango::sql::MaybeMyFromRow
+                    + ::rustango::sql::MaybeSqliteFromRow
+                    + ::core::marker::Send
+                    + ::core::marker::Unpin,
+            {
+                Self::sum_pool::<U>(col, pool).await
+            }
+
+            /// Eloquent `Model::avg($col)` — bare-name alias for
+            /// [`Self::avg_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::avg_pool`].
+            pub async fn avg<U>(
+                col: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<U>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                (::core::option::Option<U>,): ::rustango::sql::MaybePgFromRow
+                    + ::rustango::sql::MaybeMyFromRow
+                    + ::rustango::sql::MaybeSqliteFromRow
+                    + ::core::marker::Send
+                    + ::core::marker::Unpin,
+            {
+                Self::avg_pool::<U>(col, pool).await
+            }
+
+            /// Eloquent `Model::min($col)` — bare-name alias for
+            /// [`Self::min_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::min_pool`].
+            pub async fn min<U>(
+                col: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<U>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                (::core::option::Option<U>,): ::rustango::sql::MaybePgFromRow
+                    + ::rustango::sql::MaybeMyFromRow
+                    + ::rustango::sql::MaybeSqliteFromRow
+                    + ::core::marker::Send
+                    + ::core::marker::Unpin,
+            {
+                Self::min_pool::<U>(col, pool).await
+            }
+
+            /// Eloquent `Model::max($col)` — bare-name alias for
+            /// [`Self::max_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::max_pool`].
+            pub async fn max<U>(
+                col: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<U>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                (::core::option::Option<U>,): ::rustango::sql::MaybePgFromRow
+                    + ::rustango::sql::MaybeMyFromRow
+                    + ::rustango::sql::MaybeSqliteFromRow
+                    + ::core::marker::Send
+                    + ::core::marker::Unpin,
+            {
+                Self::max_pool::<U>(col, pool).await
+            }
+
+            /// Eloquent `Model::take($n)->get()` — bare-name alias
+            /// for [`Self::take_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::take_pool`].
+            pub async fn take(
+                n: i64,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::take_pool(n, pool).await
+            }
+
+            /// Eloquent `Model::query()->forPage($p, $pp)->get()` —
+            /// bare-name alias for [`Self::for_page_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::for_page_pool`].
+            pub async fn for_page(
+                page: i64,
+                per_page: i64,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::for_page_pool(page, per_page, pool).await
+            }
+
+            /// Eloquent `Model::oldest($field)->get()` — bare-name
+            /// alias for [`Self::oldest_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::oldest_pool`].
+            pub async fn oldest(
+                field: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::oldest_pool(field, pool).await
+            }
+
+            /// Eloquent `Model::latest($field)->get()` (multi-row) —
+            /// bare-name alias for [`Self::newest_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::newest_pool`].
+            pub async fn newest(
+                field: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::newest_pool(field, pool).await
+            }
+
+            /// Eloquent `Model::latest($field)->first()` — bare-name
+            /// alias for [`Self::latest_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::latest_pool`].
+            pub async fn latest(
+                field: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::latest_pool(field, pool).await
+            }
+
+            /// Eloquent `Model::oldest($field)->first()` — bare-name
+            /// alias for [`Self::earliest_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::earliest_pool`].
+            pub async fn earliest(
+                field: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::earliest_pool(field, pool).await
+            }
+
+            /// Eloquent `Model::inRandomOrder()->first()` — bare-name
+            /// alias for [`Self::random_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::random_pool`].
+            pub async fn random(
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::random_pool(pool).await
+            }
+
+            /// Eloquent `Model::inRandomOrder()->limit($n)->get()` —
+            /// bare-name alias for [`Self::random_n_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::random_n_pool`].
+            pub async fn random_n(
+                n: i64,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::random_n_pool(n, pool).await
+            }
+
+            /// Eloquent `Model::truncate()` — bare-name alias for
+            /// [`Self::truncate_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::truncate_pool`].
+            pub async fn truncate(
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<u64, ::rustango::sql::ExecError> {
+                Self::truncate_pool(pool).await
+            }
+
+            /// Eloquent `Model::query()->where(...)->get()` — bare-
+            /// name alias for [`Self::where_pool`]. (The
+            /// `_pool`-less spelling for `where` itself would be
+            /// `where_`, which Rust syntax already uses for the typed
+            /// queryset surface — callers are unlikely to confuse
+            /// the two.)
+            ///
+            /// # Errors
+            /// As [`Self::where_pool`].
+            pub async fn where_<W>(
+                col: &str,
+                val: W,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                W: ::core::convert::Into<::rustango::core::SqlValue>,
+            {
+                Self::where_pool(col, val, pool).await
+            }
+
+            /// Eloquent `Model::whereIn($col, $vals)` — bare-name
+            /// alias for [`Self::where_in_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_in_pool`].
+            pub async fn where_in<V>(
+                col: &str,
+                vals: impl ::core::iter::IntoIterator<Item = V>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                V: ::core::convert::Into<::rustango::core::SqlValue>,
+            {
+                Self::where_in_pool(col, vals, pool).await
+            }
+
+            /// Eloquent `Model::whereNotIn($col, $vals)` — bare-name
+            /// alias for [`Self::where_not_in_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_not_in_pool`].
+            pub async fn where_not_in<V>(
+                col: &str,
+                vals: impl ::core::iter::IntoIterator<Item = V>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            >
+            where
+                V: ::core::convert::Into<::rustango::core::SqlValue>,
+            {
+                Self::where_not_in_pool(col, vals, pool).await
+            }
+
+            /// Eloquent `Model::whereNull($col)` — bare-name alias
+            /// for [`Self::where_null_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_null_pool`].
+            pub async fn where_null(
+                col: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_null_pool(col, pool).await
+            }
+
+            /// Eloquent `Model::whereNotNull($col)` — bare-name alias
+            /// for [`Self::where_not_null_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_not_null_pool`].
+            pub async fn where_not_null(
+                col: &str,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_not_null_pool(col, pool).await
+            }
+
+            /// Eloquent `Model::whereBetween($col, [$lo, $hi])` —
+            /// bare-name alias for [`Self::where_between_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_between_pool`].
+            pub async fn where_between(
+                col: &str,
+                lo: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                hi: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_between_pool(col, lo, hi, pool).await
+            }
+
+            /// Eloquent `Model::whereNotBetween($col, [$lo, $hi])` —
+            /// bare-name alias for [`Self::where_not_between_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_not_between_pool`].
+            pub async fn where_not_between(
+                col: &str,
+                lo: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                hi: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_not_between_pool(col, lo, hi, pool).await
+            }
+
+            /// Eloquent `Model::whereLike($col, $pat)` — bare-name
+            /// alias for [`Self::where_like_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_like_pool`].
+            pub async fn where_like(
+                col: &str,
+                pattern: impl ::core::convert::Into<::std::string::String>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_like_pool(col, pattern, pool).await
+            }
+
+            /// Eloquent `Model::whereLike($col, $pat)` (case-
+            /// insensitive) — bare-name alias for
+            /// [`Self::where_ilike_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_ilike_pool`].
+            pub async fn where_ilike(
+                col: &str,
+                pattern: impl ::core::convert::Into<::std::string::String>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_ilike_pool(col, pattern, pool).await
+            }
+
+            /// Eloquent `Model::whereNotLike($col, $pat)` — bare-name
+            /// alias for [`Self::where_not_like_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_not_like_pool`].
+            pub async fn where_not_like(
+                col: &str,
+                pattern: impl ::core::convert::Into<::std::string::String>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_not_like_pool(col, pattern, pool).await
+            }
+
+            /// Eloquent `Model::whereNotLike` (case-insensitive) —
+            /// bare-name alias for [`Self::where_not_ilike_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_not_ilike_pool`].
+            pub async fn where_not_ilike(
+                col: &str,
+                pattern: impl ::core::convert::Into<::std::string::String>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_not_ilike_pool(col, pattern, pool).await
+            }
+
+            /// Django `__startswith` / Eloquent
+            /// `whereLike("col", "$prefix%")` — bare-name alias for
+            /// [`Self::where_starts_with_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_starts_with_pool`].
+            pub async fn where_starts_with(
+                col: &str,
+                prefix: impl ::core::convert::Into<::std::string::String>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_starts_with_pool(col, prefix, pool).await
+            }
+
+            /// Django `__endswith` / Eloquent
+            /// `whereLike("col", "%$suffix")` — bare-name alias for
+            /// [`Self::where_ends_with_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_ends_with_pool`].
+            pub async fn where_ends_with(
+                col: &str,
+                suffix: impl ::core::convert::Into<::std::string::String>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_ends_with_pool(col, suffix, pool).await
+            }
+
+            /// Django `__contains` / Eloquent
+            /// `whereLike("col", "%$str%")` — bare-name alias for
+            /// [`Self::where_contains_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_contains_pool`].
+            pub async fn where_contains(
+                col: &str,
+                substr: impl ::core::convert::Into<::std::string::String>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_contains_pool(col, substr, pool).await
+            }
+
+            /// Eloquent `Model::whereYear($col, $y)` — bare-name
+            /// alias for [`Self::where_year_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_year_pool`].
+            pub async fn where_year(
+                col: &str,
+                year: i64,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_year_pool(col, year, pool).await
+            }
+
+            /// Eloquent `Model::whereMonth($col, $m)` — bare-name
+            /// alias for [`Self::where_month_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_month_pool`].
+            pub async fn where_month(
+                col: &str,
+                month: i64,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_month_pool(col, month, pool).await
+            }
+
+            /// Eloquent `Model::whereDay($col, $d)` — bare-name alias
+            /// for [`Self::where_day_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_day_pool`].
+            pub async fn where_day(
+                col: &str,
+                day: i64,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_day_pool(col, day, pool).await
+            }
+
+            /// Eloquent `Model::whereHour($col, $h)` — bare-name
+            /// alias for [`Self::where_hour_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_hour_pool`].
+            pub async fn where_hour(
+                col: &str,
+                hour: i64,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_hour_pool(col, hour, pool).await
+            }
+
+            /// Eloquent `Model::whereMinute($col, $m)` — bare-name
+            /// alias for [`Self::where_minute_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_minute_pool`].
+            pub async fn where_minute(
+                col: &str,
+                minute: i64,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_minute_pool(col, minute, pool).await
+            }
+
+            /// Eloquent `Model::where($col, ">", $val)` — bare-name
+            /// alias for [`Self::where_gt_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_gt_pool`].
+            pub async fn where_gt(
+                col: &str,
+                val: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_gt_pool(col, val, pool).await
+            }
+
+            /// Eloquent `Model::where($col, ">=", $val)` — bare-name
+            /// alias for [`Self::where_gte_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_gte_pool`].
+            pub async fn where_gte(
+                col: &str,
+                val: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_gte_pool(col, val, pool).await
+            }
+
+            /// Eloquent `Model::where($col, "<", $val)` — bare-name
+            /// alias for [`Self::where_lt_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_lt_pool`].
+            pub async fn where_lt(
+                col: &str,
+                val: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_lt_pool(col, val, pool).await
+            }
+
+            /// Eloquent `Model::where($col, "<=", $val)` — bare-name
+            /// alias for [`Self::where_lte_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_lte_pool`].
+            pub async fn where_lte(
+                col: &str,
+                val: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_lte_pool(col, val, pool).await
+            }
+
+            /// Eloquent `Model::where($col, "!=", $val)` — bare-name
+            /// alias for [`Self::where_ne_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::where_ne_pool`].
+            pub async fn where_ne(
+                col: &str,
+                val: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::where_ne_pool(col, val, pool).await
+            }
+
+            /// Eloquent
+            /// `Model::where($wc, $wv)->update([$sc => $sv])` —
+            /// bare-name alias for [`Self::update_where_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::update_where_pool`].
+            pub async fn update_where(
+                where_col: &str,
+                where_val: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                set_col: &str,
+                set_val: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<u64, ::rustango::sql::ExecError> {
+                Self::update_where_pool(where_col, where_val, set_col, set_val, pool).await
+            }
+
+            /// Eloquent `Model::where($wc, $wv)->delete()` —
+            /// bare-name alias for [`Self::delete_where_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::delete_where_pool`].
+            pub async fn delete_where(
+                where_col: &str,
+                where_val: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<u64, ::rustango::sql::ExecError> {
+                Self::delete_where_pool(where_col, where_val, pool).await
+            }
+
+            /// Eloquent `Model::query()->update([$col => $val])` —
+            /// bare-name alias for [`Self::update_all_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::update_all_pool`].
+            pub async fn update_all(
+                set_col: &str,
+                set_val: impl ::core::convert::Into<::rustango::core::SqlValue>,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<u64, ::rustango::sql::ExecError> {
+                Self::update_all_pool(set_col, set_val, pool).await
+            }
+
+            // Instance helpers.
+
+            /// Eloquent `$model->fresh()` — bare-name alias for
+            /// [`Self::fresh_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::fresh_pool`].
+            pub async fn fresh(
+                &self,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<Self>,
+                ::rustango::sql::ExecError,
+            > {
+                Self::fresh_pool(self, pool).await
+            }
+
+            /// Django `Model.refresh_from_db()` — bare-name alias
+            /// for [`Self::refresh_from_db_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::refresh_from_db_pool`].
+            pub async fn refresh_from_db(
+                &mut self,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<(), ::rustango::sql::ExecError> {
+                Self::refresh_from_db_pool(self, pool).await
+            }
+
+            /// Eloquent `$model->increment($col, $by)` — bare-name
+            /// alias for [`Self::increment_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::increment_pool`].
+            pub async fn increment(
+                &self,
+                col: &str,
+                by: i64,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<u64, ::rustango::sql::ExecError> {
+                Self::increment_pool(self, col, by, pool).await
+            }
+
+            /// Eloquent `$model->decrement($col, $by)` — bare-name
+            /// alias for [`Self::decrement_pool`].
+            ///
+            /// # Errors
+            /// As [`Self::decrement_pool`].
+            pub async fn decrement(
+                &self,
+                col: &str,
+                by: i64,
+                pool: &::rustango::sql::Pool,
+            ) -> ::core::result::Result<u64, ::rustango::sql::ExecError> {
+                Self::decrement_pool(self, col, by, pool).await
             }
         }
     });

--- a/crates/rustango/src/admin/views.rs
+++ b/crates/rustango/src/admin/views.rs
@@ -1869,7 +1869,7 @@ async fn preload_gfk_cts(
     if model.generic_relations.is_empty() {
         return Vec::new();
     }
-    crate::contenttypes::ContentType::all(&state.pool)
+    crate::contenttypes::ContentType::all_ordered(&state.pool)
         .await
         .unwrap_or_default()
 }

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -186,7 +186,7 @@ impl ContentType {
         if wanted.is_empty() {
             return Ok(std::collections::HashMap::new());
         }
-        let all = Self::all(pool).await?;
+        let all = Self::all_ordered(pool).await?;
         let mut out =
             std::collections::HashMap::<(String, String), Self>::with_capacity(wanted.len());
         for ct in all {
@@ -198,13 +198,17 @@ impl ContentType {
         Ok(out)
     }
 
-    /// Tri-dialect counterpart of [`Self::all`] (v0.38) — every
-    /// registered ContentType ordered by `(app_label, model_name)`,
-    /// across any backend the [`crate::sql::Pool`] enum carries.
+    /// Every registered ContentType ordered by `(app_label,
+    /// model_name)`. Tri-dialect. The order-aware companion of the
+    /// macro-emitted [`Self::all`] (which returns unordered rows).
+    ///
+    /// Renamed from `all` to `all_ordered` 2026-06-07 because the
+    /// macro now emits `Model::all` on every model (Eloquent bare-
+    /// name parity — see issue #893).
     ///
     /// # Errors
     /// As [`Self::for_model`].
-    pub async fn all(pool: &crate::sql::Pool) -> Result<Vec<Self>, ExecError> {
+    pub async fn all_ordered(pool: &crate::sql::Pool) -> Result<Vec<Self>, ExecError> {
         let rows: Vec<Self> = Self::objects()
             .order_by(&[("app_label", false), ("model_name", false)])
             .fetch_pool(pool)

--- a/crates/rustango/tests/model_bare_name_aliases_sqlite_live.rs
+++ b/crates/rustango/tests/model_bare_name_aliases_sqlite_live.rs
@@ -1,0 +1,226 @@
+#![cfg(feature = "sqlite")]
+//! Smoke tests for the bare-name Eloquent aliases. Confirms that
+//! every common shortcut now works WITHOUT the `_pool` suffix —
+//! `Post::find(id, &pool)` instead of `Post::find_pool(id, &pool)`,
+//! `post.increment("views", 1, &pool)` instead of
+//! `post.increment_pool(...)`, etc.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "mba_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 80)]
+    pub status: String,
+    pub views: i64,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE mba_post (
+            id     INTEGER PRIMARY KEY AUTOINCREMENT,
+            title  TEXT NOT NULL,
+            status TEXT NOT NULL,
+            views  INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn seed(pool: &Pool) {
+    for (t, s, v) in [
+        ("a", "draft", 10_i64),
+        ("b", "draft", 20),
+        ("c", "published", 30),
+    ] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: t.into(),
+            status: s.into(),
+            views: v,
+        };
+        p.save_pool(pool).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn bare_name_static_methods_work() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    // find / first / all / count / exists / doesnt_exist.
+    assert!(Post::find(1_i64, &pool).await.unwrap().is_some());
+    assert!(Post::find_or_fail(1_i64, &pool).await.is_ok());
+    assert_eq!(
+        Post::find_many([1_i64, 2, 3], &pool).await.unwrap().len(),
+        3
+    );
+    assert!(Post::first(&pool).await.unwrap().is_some());
+    assert!(Post::first_or_fail(&pool).await.is_ok());
+    assert_eq!(Post::all(&pool).await.unwrap().len(), 3);
+    assert_eq!(Post::count(&pool).await.unwrap(), 3);
+    assert!(Post::exists(&pool).await.unwrap());
+    assert!(!Post::doesnt_exist(&pool).await.unwrap());
+
+    // sole.
+    assert!(Post::sole("status", "published", &pool).await.is_ok());
+
+    // first_where.
+    assert!(Post::first_where("status", "draft", &pool)
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn bare_name_filter_methods_work() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    assert_eq!(
+        Post::where_("status", "draft", &pool).await.unwrap().len(),
+        2
+    );
+    assert_eq!(
+        Post::where_in("status", ["draft", "published"], &pool)
+            .await
+            .unwrap()
+            .len(),
+        3
+    );
+    assert_eq!(
+        Post::where_not_in("status", ["draft"], &pool)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        Post::where_between("views", 15_i64, 25_i64, &pool)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        Post::where_not_between("views", 15_i64, 25_i64, &pool)
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
+    assert_eq!(
+        Post::where_gt("views", 15_i64, &pool).await.unwrap().len(),
+        2
+    );
+    assert_eq!(
+        Post::where_gte("views", 20_i64, &pool).await.unwrap().len(),
+        2
+    );
+    assert_eq!(
+        Post::where_lt("views", 20_i64, &pool).await.unwrap().len(),
+        1
+    );
+    assert_eq!(
+        Post::where_lte("views", 20_i64, &pool).await.unwrap().len(),
+        2
+    );
+    assert_eq!(
+        Post::where_ne("status", "draft", &pool)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn bare_name_like_methods_work() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let _ = Post::where_like("title", "a%", &pool).await.unwrap();
+    let _ = Post::where_ilike("title", "A%", &pool).await.unwrap();
+    let _ = Post::where_not_like("title", "z%", &pool).await.unwrap();
+    let _ = Post::where_not_ilike("title", "Z%", &pool).await.unwrap();
+    let _ = Post::where_starts_with("title", "a", &pool).await.unwrap();
+    let _ = Post::where_ends_with("title", "c", &pool).await.unwrap();
+    let _ = Post::where_contains("title", "b", &pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn bare_name_aggregate_and_ordering_work() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    assert_eq!(Post::sum::<i64>("views", &pool).await.unwrap(), Some(60));
+    assert_eq!(Post::min::<i64>("views", &pool).await.unwrap(), Some(10));
+    assert_eq!(Post::max::<i64>("views", &pool).await.unwrap(), Some(30));
+    assert!(Post::avg::<f64>("views", &pool).await.unwrap().is_some());
+    assert!(Post::random(&pool).await.unwrap().is_some());
+    assert_eq!(Post::random_n(2, &pool).await.unwrap().len(), 2);
+    assert_eq!(Post::oldest("views", &pool).await.unwrap()[0].views, 10);
+    assert_eq!(Post::newest("views", &pool).await.unwrap()[0].views, 30);
+    assert!(Post::latest("views", &pool).await.unwrap().is_some());
+    assert!(Post::earliest("views", &pool).await.unwrap().is_some());
+    assert_eq!(Post::take(2, &pool).await.unwrap().len(), 2);
+    assert_eq!(Post::for_page(2, 2, &pool).await.unwrap().len(), 1);
+    assert_eq!(
+        Post::value::<String>("title", &pool).await.unwrap(),
+        Some("a".into())
+    );
+    assert_eq!(
+        Post::pluck::<String>("title", &pool).await.unwrap().len(),
+        3
+    );
+}
+
+#[tokio::test]
+async fn bare_name_instance_methods_work() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let p = Post::find(1_i64, &pool).await.unwrap().unwrap();
+    let _ = p.fresh(&pool).await.unwrap();
+    let _ = p.increment("views", 1, &pool).await.unwrap();
+    let _ = p.decrement("views", 1, &pool).await.unwrap();
+    let mut p2 = Post::find(1_i64, &pool).await.unwrap().unwrap();
+    p2.refresh_from_db(&pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn bare_name_bulk_methods_work() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let n = Post::update_where("status", "draft", "status", "archived", &pool)
+        .await
+        .unwrap();
+    assert_eq!(n, 2);
+    let n = Post::delete_where("status", "published", &pool)
+        .await
+        .unwrap();
+    assert_eq!(n, 1);
+    let n = Post::update_all("title", "stamped", &pool).await.unwrap();
+    assert_eq!(n, 2);
+    let _ = Post::truncate(&pool).await.unwrap();
+    assert!(Post::doesnt_exist(&pool).await.unwrap());
+}
+
+#[tokio::test]
+async fn bare_name_date_part_methods_work() {
+    // Type-check only — no rows seeded with datetime cols in this test;
+    // we just confirm the aliases compile + reach the DB.
+    let pool = make_pool().await;
+    let _ = Post::where_year("views", 2024, &pool).await;
+    let _ = Post::where_month("views", 1, &pool).await;
+    let _ = Post::where_day("views", 1, &pool).await;
+    let _ = Post::where_hour("views", 1, &pool).await;
+    let _ = Post::where_minute("views", 1, &pool).await;
+}


### PR DESCRIPTION
Fix for user feedback: \`_pool\` everywhere is noise. Common Eloquent methods should read bare:

\`\`\`rust
// Before (every Eloquent shortcut had _pool):
Post::find_pool(id, &pool).await?;
post.increment_pool(\"views\", 1, &pool).await?;
Post::where_in_pool(\"status\", [\"draft\"], &pool).await?;
Post::sum_pool::<i64>(\"views\", &pool).await?;

// After (bare names primary, _pool kept as silent back-compat):
Post::find(id, &pool).await?;
post.increment(\"views\", 1, &pool).await?;
Post::where_in(\"status\", [\"draft\"], &pool).await?;
Post::sum::<i64>(\"views\", &pool).await?;
\`\`\`

The existing \`_pool\` versions are retained as silent back-compat aliases (~140 test call sites + downstream code keep compiling). No behavior change — just the calling style.

## Bare names emitted (~55 total)

- Lookup / fallback: \`find\` / \`find_or_fail\` / \`find_many\` / \`find_or\` / \`first\` / \`first_or_fail\` / \`first_or\` / \`first_where\` / \`sole\`
- Set ops: \`all\` / \`count\` / \`exists\` / \`doesnt_exist\` / \`value\` / \`pluck\`
- Aggregates: \`sum\` / \`avg\` / \`min\` / \`max\`
- Filters: \`where_\` / \`where_in\` / \`where_not_in\` / \`where_null\` / \`where_not_null\` / \`where_between\` / \`where_not_between\`
- LIKE family: \`where_like\` / \`where_ilike\` / \`where_not_like\` / \`where_not_ilike\` / \`where_starts_with\` / \`where_ends_with\` / \`where_contains\`
- Date-part: \`where_year\` / \`where_month\` / \`where_day\` / \`where_hour\` / \`where_minute\`
- Comparison: \`where_gt\` / \`where_gte\` / \`where_lt\` / \`where_lte\` / \`where_ne\`
- Pagination / ordering: \`take\` / \`for_page\` / \`random\` / \`random_n\` / \`oldest\` / \`newest\` / \`latest\` / \`earliest\`
- Bulk mutation: \`truncate\` / \`update_where\` / \`delete_where\` / \`update_all\`
- Instance: \`fresh\` / \`refresh_from_db\` / \`increment\` / \`decrement\`
- Soft-delete (only on \`#[rustango(soft_delete)]\` models): \`soft_delete\` / \`restore\` / \`force_delete\` / \`active\` / \`only_trashed\` / \`with_trashed\`

## Going-forward rule

Every new Eloquent-shape \`Model::\` shortcut added to the macro emits the bare name DIRECTLY. No more \`xxx_pool\` + alias for new methods.

## Conflicts resolved

\`crate::contenttypes::ContentType::all\` was a manually-defined method (with ordering) that collided with the new macro-emitted bare-name \`all\`. Renamed manual one to \`all_ordered\`; sole caller (\`admin::views\`) updated.

## Tests

7 SQLite smoke tests exercise every alias surface (static / filter / like / aggregate / instance / bulk / date-part). Lib suite **3408 / 3408** passing. Litmus passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)