### PR TITLE
chore(docs): fix broken intra-doc links left over from the _pool rename

### DIFF
--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -142,7 +142,7 @@ impl ContentType {
         Self::by_natural_key(pool, app, &name).await
     }
 
-    /// Batch counterpart of [`Self::by_natural_key_pool`] — issue #35.
+    /// Batch counterpart of [`Self::by_natural_key`] — issue #35.
     /// Resolves a list of `(app_label, model_name)` pairs to their
     /// `ContentType` rows in a **single** DB round trip, returning a
     /// `HashMap` keyed by the natural pair (cloned strings). Pairs
@@ -150,7 +150,7 @@ impl ContentType {
     /// the map (no error — same shape Django's `get_for_models`
     /// gives back when a model isn't migrated yet).
     ///
-    /// Implemented as `all_pool` + a Rust-side filter — the
+    /// Implemented as `all_ordered` + a Rust-side filter — the
     /// `rustango_content_types` table is O(dozens) of rows in
     /// realistic apps, so one un-filtered fetch is cheaper than N
     /// round trips OR a complex composite-key `WHERE`. If your
@@ -169,7 +169,7 @@ impl ContentType {
     /// ```
     ///
     /// # Errors
-    /// As [`Self::all_pool`].
+    /// As [`Self::all_ordered`].
     pub async fn get_for_models<A, B, I>(
         pool: &crate::sql::Pool,
         pairs: I,
@@ -251,14 +251,14 @@ pub fn clear_cache() {
 }
 
 impl ContentType {
-    /// Cached counterpart of [`Self::by_natural_key_pool`] — issue #35.
+    /// Cached counterpart of [`Self::by_natural_key`] — issue #35.
     /// First call for a given `(app_label, model_name)` hits the DB;
     /// subsequent calls return the cached row. `Ok(None)` results
     /// are **not** cached (so a follow-up `ensure_seeded` doesn't
     /// leave you with a stale negative).
     ///
     /// # Errors
-    /// As [`Self::by_natural_key_pool`].
+    /// As [`Self::by_natural_key`].
     pub async fn get_by_natural_key(
         pool: &crate::sql::Pool,
         app_label: &str,


### PR DESCRIPTION
PR #891 dropped \`_pool\` from the macro-emitted Eloquent surface but left a few stale references in \`contenttypes.rs\`'s docstrings:

- \`[Self::by_natural_key_pool]\` → \`[Self::by_natural_key]\` (pre-existing typo; the method has always been named \`by_natural_key\` — \`_pool\` suffix on the link was never accurate, unmasked by \`rustdoc::broken_intra_doc_links\` after the rename).
- \`[Self::all_pool]\` → \`[Self::all_ordered]\` (the rename of \`ContentType::all\` → \`ContentType::all_ordered\` in PR #890 carried the wrong target through to the new \`get_for_models\` doc).
- One body-comment reference to \`all_pool\` → \`all_ordered\`.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)