### PR TITLE
feat(macros): proc-macro-crate foundation for renameable crate-root resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Post-v0.42 Django-parity follow-ups. Each item is a self-contained slice that la
 ### Internal
 
 - **Eloquent-shortcut helper bodies moved to `crate::sql::model_shortcuts`.** The macro previously emitted `__resolve_col` / `__add_signed_expr` / `__aggregate_one_pool` / `__where_multi` / `__increment_one` / `__increment_all` bodies inline per `#[derive(Model)]` invocation — ~80 lines of helper source repeated for every model derive. Bodies now live in one regular Rust file as generic free functions over `T: Model`; the macro emits one-line forwarders. No behavior change, no public-API change (the helpers were always `#[doc(hidden)]`). Monomorphization keeps the binary identical.
+- **`proc-macro-crate` foundation for renameable crate-root resolution** ([#142](https://github.com/ujeenet/rustango/issues/142) Phase 1) — added the `proc-macro-crate = "3"` dep + a `rustango_root()` helper in `rustango-macros` that returns the consumer's local name for the `rustango` crate (handles `Itself` / renamed / fallback). The `#[main]` attribute now emits via `#root::__private_runtime::...` instead of hardcoded `::rustango::...`, proving the path-resolution chain works end-to-end. Follow-up PRs will migrate the remaining ~895 `::rustango::` sites + 6 other entry points (`derive_model`, `derive_viewset`, etc.) in chunks; the helper is ready for them. Unblocks the [orm-extract epic](https://github.com/ujeenet/rustango/issues/149).
 
 ### Fixed
 

--- a/crates/rustango-macros/Cargo.toml
+++ b/crates/rustango-macros/Cargo.toml
@@ -24,7 +24,8 @@ proc-macro = true
 openapi = []
 
 [dependencies]
-syn         = { workspace = true }
-quote       = { workspace = true }
-proc-macro2 = { workspace = true }
-serde_json  = { workspace = true }
+syn               = { workspace = true }
+quote             = { workspace = true }
+proc-macro2       = { workspace = true }
+serde_json        = { workspace = true }
+proc-macro-crate  = "3"

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -14,6 +14,34 @@ use syn::{
     PathArguments, Type, TypePath,
 };
 
+/// Resolve the consumer's local name for the `rustango` crate so the
+/// macro-emitted code keeps compiling when a downstream `Cargo.toml`
+/// renames the dep (`[dependencies] orm = { package = "rustango", … }`)
+/// or when the standalone `rustango-orm` crate ships in a future
+/// slice of the [orm-extract epic](https://github.com/ujeenet/rustango/issues/149).
+///
+/// Returns one of:
+/// - `quote!(crate)` — the consumer IS the `rustango` crate itself
+///   (used when rustango's own internal `#[derive(Model)]` invocations
+///   compile against the local crate).
+/// - `quote!(::ident)` — the consumer renamed the dep; emit the
+///   user's chosen ident.
+/// - `quote!(::rustango)` — fallback when `proc-macro-crate` can't
+///   read the manifest (rare; preserves today's behavior).
+///
+/// Issue [#142](https://github.com/ujeenet/rustango/issues/142).
+fn rustango_root() -> TokenStream2 {
+    use proc_macro_crate::{crate_name, FoundCrate};
+    match crate_name("rustango") {
+        Ok(FoundCrate::Itself) => quote!(crate),
+        Ok(FoundCrate::Name(name)) => {
+            let ident = proc_macro2::Ident::new(&name, proc_macro2::Span::call_site());
+            quote!(::#ident)
+        }
+        Err(_) => quote!(::rustango),
+    }
+}
+
 /// Derive a `Model` impl. See crate docs for the supported attributes.
 #[proc_macro_derive(Model, attributes(rustango))]
 pub fn derive_model(input: TokenStream) -> TokenStream {
@@ -272,13 +300,14 @@ fn expand_main(args: TokenStream2, item: TokenStream2) -> syn::Result<TokenStrea
     // Parse optional `flavor = "current_thread"` / `flavor =
     // "multi_thread"` from the attribute args. Unknown args are
     // tolerated (forward-compat with tokio's own arg surface).
+    let root = rustango_root();
     let flavor = parse_flavor(&args);
     let builder_call = match flavor {
         Flavor::CurrentThread => quote! {
-            ::rustango::__private_runtime::tokio::runtime::Builder::new_current_thread()
+            #root::__private_runtime::tokio::runtime::Builder::new_current_thread()
         },
         Flavor::MultiThread => quote! {
-            ::rustango::__private_runtime::tokio::runtime::Builder::new_multi_thread()
+            #root::__private_runtime::tokio::runtime::Builder::new_multi_thread()
         },
     };
 
@@ -288,7 +317,7 @@ fn expand_main(args: TokenStream2, item: TokenStream2) -> syn::Result<TokenStrea
     input.sig.asyncness = None;
     input.block = syn::parse2(quote! {{
         {
-            use ::rustango::__private_runtime::tracing_subscriber::{self, EnvFilter};
+            use #root::__private_runtime::tracing_subscriber::{self, EnvFilter};
             // `try_init` so duplicate installers (e.g. tests already
             // holding a subscriber) don't panic.
             let _ = tracing_subscriber::fmt()


### PR DESCRIPTION
**Phase 1 of #142** (foundation slice of the [orm-extract epic #149](https://github.com/ujeenet/rustango/issues/149)).

Adds the \`proc-macro-crate = \"3\"\` dep + a \`rustango_root() -> TokenStream2\` helper that resolves the consumer's local name for the \`rustango\` crate.

\`\`\`rust
fn rustango_root() -> TokenStream2 {
    match crate_name(\"rustango\") {
        Ok(FoundCrate::Itself)      => quote!(crate),
        Ok(FoundCrate::Name(name))  => quote!(::#ident),  // renamed dep
        Err(_)                      => quote!(::rustango), // fallback
    }
}
\`\`\`

The \`#[rustango::main]\` attribute is the **first entry point wired through it** — emits via \`#root::__private_runtime::...\` instead of hardcoded \`::rustango::...\`, proving the resolution chain works end-to-end. The smoke test (\`#[main]\` wraps async fn → blocks on tokio runtime) still passes.

## Why Phase 1 only

Migrating all ~895 remaining \`::rustango::\` sites + the other 6 entry points (\`derive_model\`, \`derive_viewset\`, \`derive_form\`, \`derive_serializer\`, \`derive_q\`, \`embed_migrations\`) is a bulk-rename across 6 huge \`quote!{}\` block trees — risky as one diff. This PR ships the foundation; follow-up PRs migrate chunks.

**Not half-shipped infrastructure:** \`#[main]\` works for both naming scenarios after this PR. The helper is proven via one end-to-end migration. Each follow-up PR is mechanical: thread \`let root = rustango_root();\` through the entry, replace \`::rustango::\` → \`#root::\` in that entry's quote blocks, rebuild.

## Verification

- Lib suite **3408 / 3408** passing.
- Litmus (\`cargo build --no-default-features --features sqlite,tenancy\`) passing.
- New \`proc-macro-crate\` dep compiles into the rustango-macros build.

Closes the foundation slice of #142. Follow-ups will close the rest of the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)