### PR TITLE
test(macros): renamed-crate smoke test — proves #142 path resolution end-to-end

### DIFF
--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "rustango-renamed-smoke"
+version = "0.0.0"
+edition = "2021"
+rust-version.workspace = true
+license.workspace = true
+publish = false
+description = "Smoke test for #142 — confirms #[derive(Model)] compiles when the rustango crate is renamed via the consumer's Cargo.toml `package = \"rustango\"` field."
+
+[lints]
+workspace = true
+
+[lib]
+name = "rustango_renamed_smoke"
+path = "src/lib.rs"
+
+# Mirror rustango's feature gates locally. The derive macro emits
+# `#[cfg(feature = "X")]` against the CONSUMER's feature flags, so
+# the smoke crate has to declare a matching `postgres` feature that
+# forwards to `orm/postgres` — otherwise the cfg-gated
+# `impl LoadRelated for #StructName` / `impl MaybePgFromRow for ...`
+# emissions silently get dropped, the trait bounds elsewhere go
+# unsatisfied, and `cargo check --workspace` fails.
+[features]
+default = ["postgres"]
+postgres = ["orm/postgres"]
+
+[dependencies]
+# The whole point of this crate — rename rustango locally so the
+# macro must resolve its emit paths through `proc-macro-crate`.
+# Use rustango's default features (postgres + admin + tenancy +
+# etc.) so the dep graph is complete; the smoke crate's own
+# `postgres` feature is just for matching the macro's cfg-gates.
+orm = { package = "rustango", path = "../rustango" }
+chrono = { workspace = true }
+# The macro emits `::tracing::warn!(...)` and `::sqlx::Row`, etc.
+# directly — not routed through `#root` (#142 follow-up). Real-world
+# consumers usually have these already; the smoke crate adds them.
+tracing = "0.1"
+sqlx = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/rustango-renamed-smoke/src/lib.rs
+++ b/crates/rustango-renamed-smoke/src/lib.rs
@@ -1,0 +1,48 @@
+//! Smoke test for [#142](https://github.com/ujeenet/rustango/issues/142).
+//!
+//! The Cargo.toml renames the rustango dep to `orm` via `package =
+//! "rustango"`. If `#[derive(Model)]` emitted hardcoded
+//! `::rustango::...` paths (the pre-#142 behavior), this crate
+//! would fail to compile here — `::rustango::core::Model` would
+//! resolve to nothing because the consumer's Cargo.toml has no
+//! `rustango` dep entry.
+//!
+//! After the four-phase migration that closed #142 (PRs #898–#901),
+//! every macro emit routes through `rustango_root()` which reads
+//! the consumer's manifest at expansion time and returns the local
+//! name (`orm` here). The macro emits `::orm::core::Model`, the
+//! type resolves, and `cargo build --package rustango-renamed-smoke`
+//! passes.
+//!
+//! The crate doesn't need to do anything at runtime — just compile.
+//! If it builds, the test passes.
+
+#![allow(dead_code)]
+
+use orm::sql::Auto;
+use orm::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rrs_demo")]
+pub struct RenamedDemo {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub name: String,
+    pub views: i64,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orm::core::Model as _;
+
+    #[test]
+    fn schema_resolves_through_renamed_dep() {
+        // If the macro's path resolution broke, this wouldn't even
+        // compile. Reaching this assertion at all is the test.
+        assert_eq!(RenamedDemo::SCHEMA.table, "rrs_demo");
+        assert!(RenamedDemo::SCHEMA.primary_key().is_some());
+    }
+}


### PR DESCRIPTION
The acceptance criteria of #142 included:
> Test: scaffold a tiny consumer crate that depends on \`rustango = { package = \"rustango\", … }\` AND one that renames it; both compile.

This adds the renamed half. The new \`crates/rustango-renamed-smoke\` workspace member declares its dep as:

\`\`\`toml
orm = { package = \"rustango\", path = \"../rustango\" }
\`\`\`

…and uses \`use orm::Model;\` + \`#[derive(Model)] struct RenamedDemo { … }\`. If \`rustango_root()\` (introduced in #898) did not actually read the consumer's Cargo.toml and substitute the local name, the macro would emit \`::rustango::core::Model\` paths that fail to resolve because the consumer has no \`rustango\` dep entry.

**\`cargo check --workspace\` ✅ and \`cargo test --package rustango-renamed-smoke\` → 1 passed ✅** — \`RenamedDemo::SCHEMA.table\` resolves to \`\"rrs_demo\"\`, proving the typed schema traversal works through the renamed crate root.

## Quirk surfaced

The derive macro emits \`#[cfg(feature = \"postgres\")]\` against the CONSUMER's feature flags. So the smoke crate has to declare its own \`postgres\` feature that forwards to \`orm/postgres\` — otherwise the cfg-gated \`impl LoadRelated for #StructName\` etc. emissions get silently dropped and downstream trait bounds go unsatisfied. The Cargo.toml comments call this out.

## Follow-up surfaced

The macro also emits external-crate paths (\`::tracing::warn!\`, \`::sqlx::Row\`, etc.) that are NOT routed through \`#root\` — they assume the consumer has those crates as direct deps. For now the smoke crate adds them itself (realistic; most apps use them anyway). A future PR can re-export them through \`rustango::__private::*\` and have the macro emit \`#root::__private::tracing::...\` for clean isolation.

## Verification

- \`cargo check --workspace\` ✅
- \`cargo test --package rustango-renamed-smoke\` → 1 passed ✅
- Lib suite **3408 / 3408** passing.
- Litmus passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)