### PR TITLE
feat(macros): route tracing through rustango::__tracing — drops smoke crate's direct tracing dep

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -2594,7 +2594,7 @@ fn inherent_impl_tokens(
                         pool: &#root::sql::Pool,
                     ) -> ::core::result::Result<(), #root::sql::ExecError> {
                         if fields.is_empty() {
-                            ::tracing::warn!(
+                            #root::__tracing::warn!(
                                 target: "rustango::save_partial",
                                 model = <Self as #root::core::Model>::SCHEMA.name,
                                 "save_partial called with empty field list — no-op"
@@ -2628,7 +2628,7 @@ fn inherent_impl_tokens(
                             .filter(|a| _wanted_cols.contains(a.column))
                             .collect();
                         if _filtered.is_empty() {
-                            ::tracing::warn!(
+                            #root::__tracing::warn!(
                                 target: "rustango::save_partial",
                                 model = _schema.name,
                                 "save_partial: every named field maps to a non-assignable column — no-op"
@@ -2774,7 +2774,7 @@ fn inherent_impl_tokens(
                     pool: &#root::sql::Pool,
                 ) -> ::core::result::Result<(), #root::sql::ExecError> {
                     if fields.is_empty() {
-                        ::tracing::warn!(
+                        #root::__tracing::warn!(
                             target: "rustango::save_partial",
                             model = <Self as #root::core::Model>::SCHEMA.name,
                             "save_partial called with empty field list — no-op"
@@ -2815,7 +2815,7 @@ fn inherent_impl_tokens(
                         // non-assignable slots (PK column, computed/
                         // virtual fields, relations without an
                         // assignment). Same no-op semantic as Django.
-                        ::tracing::warn!(
+                        #root::__tracing::warn!(
                             target: "rustango::save_partial",
                             model = _schema.name,
                             "save_partial: every named field maps to a non-assignable column — no-op"

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -33,10 +33,12 @@ postgres = ["orm/postgres"]
 # `postgres` feature is just for matching the macro's cfg-gates.
 orm = { package = "rustango", path = "../rustango" }
 chrono = { workspace = true }
-# The macro emits `::tracing::warn!(...)` and `::sqlx::Row`, etc.
-# directly — not routed through `#root` (#142 follow-up). Real-world
-# consumers usually have these already; the smoke crate adds them.
-tracing = "0.1"
+# The macro emits `::sqlx::Row` etc. directly — not routed through
+# `#root` (#142 follow-up). Real-world consumers usually have these
+# already; the smoke crate adds them. `tracing` is no longer in
+# this list — the 4 `::tracing::warn!` emits in the macro now
+# route through `rustango::__tracing::` so the smoke crate doesn't
+# need a direct tracing dep.
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rustango-renamed-smoke/src/lib.rs
+++ b/crates/rustango-renamed-smoke/src/lib.rs
@@ -16,33 +16,51 @@
 //!
 //! The crate doesn't need to do anything at runtime — just compile.
 //! If it builds, the test passes.
+//!
+//! The body is gated on this crate's own `postgres` feature for
+//! two reasons:
+//!
+//! 1. The macro emits `#[cfg(feature = "postgres")] impl LoadRelated
+//!    for #StructName` etc. against the CONSUMER's feature flags.
+//!    Without the postgres feature on the consumer side, those impls
+//!    get silently dropped and the trait bounds elsewhere go
+//!    unsatisfied.
+//! 2. The litmus `cargo build --no-default-features --features
+//!    sqlite,tenancy` run from the workspace root must keep passing.
+//!    Under those flags this crate's `postgres` feature is OFF, so
+//!    the body compiles to nothing and the smoke crate is
+//!    effectively absent from the litmus build.
 
 #![allow(dead_code)]
 
-use orm::sql::Auto;
-use orm::Model;
+#[cfg(feature = "postgres")]
+mod gated {
+    use orm::sql::Auto;
+    use orm::Model;
 
-#[derive(Model, Debug, Clone)]
-#[rustango(table = "rrs_demo")]
-pub struct RenamedDemo {
-    #[rustango(primary_key)]
-    pub id: Auto<i64>,
-    #[rustango(max_length = 80)]
-    pub name: String,
-    pub views: i64,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-}
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "rrs_demo")]
+    pub struct RenamedDemo {
+        #[rustango(primary_key)]
+        pub id: Auto<i64>,
+        #[rustango(max_length = 80)]
+        pub name: String,
+        pub views: i64,
+        pub created_at: chrono::DateTime<chrono::Utc>,
+    }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use orm::core::Model as _;
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use orm::core::Model as _;
 
-    #[test]
-    fn schema_resolves_through_renamed_dep() {
-        // If the macro's path resolution broke, this wouldn't even
-        // compile. Reaching this assertion at all is the test.
-        assert_eq!(RenamedDemo::SCHEMA.table, "rrs_demo");
-        assert!(RenamedDemo::SCHEMA.primary_key().is_some());
+        #[test]
+        fn schema_resolves_through_renamed_dep() {
+            // If the macro's path resolution broke, this wouldn't
+            // even compile. Reaching this assertion at all is the
+            // test.
+            assert_eq!(RenamedDemo::SCHEMA.table, "rrs_demo");
+            assert!(RenamedDemo::SCHEMA.primary_key().is_some());
+        }
     }
 }

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -1296,6 +1296,16 @@ pub use rustango_macros as macros;
 #[doc(hidden)]
 pub use uuid as __uuid;
 
+/// Re-exported so `#[derive(Model)]`-emitted `tracing::warn!` calls
+/// (currently 4 sites in `save_partial` / similar) resolve through
+/// the rustango facade — downstream consumers don't need a direct
+/// `tracing` dep just to derive Model. **Not part of the public
+/// API** — names here may change between minors.
+///
+/// #142 follow-up surfaced by [#902](https://github.com/ujeenet/rustango/pull/902).
+#[doc(hidden)]
+pub use tracing as __tracing;
+
 /// `#[derive(Model)]` — populates the `inventory` registry the admin
 /// walks, generates `objects()` / typed columns / `insert` / `delete`
 /// / `save`.


### PR DESCRIPTION
#142 follow-up surfaced by PR #902.

The derive macro emits 4 \`::tracing::warn!(...)\` calls inside \`save_partial\` / similar logging sites. These were hardcoded absolute paths, requiring the consumer crate to have \`tracing\` as a direct Cargo.toml dep just to derive Model — even though most of the macro's other emits route through \`#root::...\` after #142.

## Change

- \`pub use tracing as __tracing;\` added to \`rustango/lib.rs\` (matches existing \`__uuid\` / \`__private_runtime\` pattern).
- 4 macro sites updated: \`::tracing::warn!\` → \`#root::__tracing::warn!\`.

Downstream consumers no longer need a direct \`tracing\` dep just for \`#[derive(Model)]\`.

## Smoke proof

\`crates/rustango-renamed-smoke/Cargo.toml\` previously had \`tracing = \"0.1\"\` as a direct dep for exactly this reason — removed in this PR. The smoke test still compiles + passes.

Also gated the smoke crate's \`RenamedDemo\` in a \`#[cfg(feature = \"postgres\")] mod gated { ... }\` so the litmus build (\`cargo build --no-default-features --features sqlite,tenancy\`) keeps passing — the consumer's postgres feature is OFF under those flags, so the body compiles to nothing.

## Follow-up still open

The macro also emits \`::sqlx::...\` (36 sites), \`::serde_json::...\` (19), \`::chrono::...\` (7), etc. directly. The smoke crate adds them as direct deps for now (realistic — most apps use these). Future PRs can apply the same re-export pattern when a real consumer hits the friction.

## Verification

- Lib suite **3408 / 3408** passing.
- Litmus (\`cargo build --no-default-features --features sqlite,tenancy\`) passing.
- Workspace check passing.
- Smoke test (\`cargo test --package rustango-renamed-smoke\`) → 1 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)