### PR TITLE
feat(macros): route uuid::Uuid::nil + rust_decimal::Decimal through #root

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -9466,11 +9466,11 @@ impl DetectedKind {
                 quote!(Time),
                 quote!(<#root::__chrono::NaiveTime as ::std::default::Default>::default()),
             ),
-            Self::Uuid => (quote!(Uuid), quote!(::uuid::Uuid::nil())),
+            Self::Uuid => (quote!(Uuid), quote!(#root::__uuid::Uuid::nil())),
             Self::Json => (quote!(Json), quote!(#root::__serde_json::Value::Null)),
             Self::Decimal => (
                 quote!(Decimal),
-                quote!(<::rust_decimal::Decimal as ::std::default::Default>::default()),
+                quote!(<#root::__rust_decimal::Decimal as ::std::default::Default>::default()),
             ),
             Self::Binary => (quote!(Binary), quote!(::std::vec::Vec::<u8>::new())),
         }

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -1326,6 +1326,13 @@ pub use serde_json as __serde_json;
 #[doc(hidden)]
 pub use serde as __serde;
 
+/// Same rationale — `#[derive(Model)]` emits `rust_decimal::Decimal`
+/// at the Decimal-FK default-value site. **Not part of the public
+/// API.** #142 follow-up — closes the last hardcoded external path
+/// in the macro.
+#[doc(hidden)]
+pub use rust_decimal as __rust_decimal;
+
 /// `#[derive(Model)]` — populates the `inventory` registry the admin
 /// walks, generates `objects()` / typed columns / `insert` / `delete`
 /// / `save`.


### PR DESCRIPTION
#142 follow-up continuing from #903 / #904.

Closes the last two hardcoded external-crate paths in macro emit code:

\`\`\`rust
::uuid::Uuid::nil()                       (1 site)
::rust_decimal::Decimal as Default        (1 site)
\`\`\`

Both in \`DetectedKind::sqlvalue_match_arm\`.

Adds \`pub use rust_decimal as __rust_decimal;\` to \`rustango/lib.rs\` (matching the existing \`__chrono\` / \`__serde_json\` / \`__serde\` / \`__tracing\` / \`__uuid\` pattern). The macro now emits \`#root::__rust_decimal::Decimal\` and \`#root::__uuid::Uuid::nil()\`.

## What's left

The only non-\`#root\` external-crate path remaining in macro emit code is \`::axum::Router\` (1 site in \`expand_viewset\`). Axum is feature-gated, and ViewSet consumers virtually always have axum as a direct dep anyway — leaving it as-is until a real consumer hits the friction.

## Verification

- Lib suite **3408 / 3408** passing.
- Litmus passing.
- Smoke test (\`cargo test --package rustango-renamed-smoke\`) → 1 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)