### PR TITLE
fix(macros)!: emit ::rustango for Itself case — fixes example/test breakage

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -21,9 +21,13 @@ use syn::{
 /// slice of the [orm-extract epic](https://github.com/ujeenet/rustango/issues/149).
 ///
 /// Returns one of:
-/// - `quote!(crate)` — the consumer IS the `rustango` crate itself
-///   (used when rustango's own internal `#[derive(Model)]` invocations
-///   compile against the local crate).
+/// - `quote!(::rustango)` — the consumer IS the `rustango` crate
+///   itself. We emit the absolute path `::rustango` (NOT `crate`)
+///   because examples and integration tests inside the rustango
+///   package compile as separate binaries — their own `crate::`
+///   namespace is the example/test file, not rustango's lib root.
+///   The absolute `::rustango` resolves correctly in both contexts
+///   (rustango lib code AND rustango/examples/*.rs).
 /// - `quote!(::ident)` — the consumer renamed the dep; emit the
 ///   user's chosen ident.
 /// - `quote!(::rustango)` — fallback when `proc-macro-crate` can't
@@ -33,7 +37,7 @@ use syn::{
 fn rustango_root() -> TokenStream2 {
     use proc_macro_crate::{crate_name, FoundCrate};
     match crate_name("rustango") {
-        Ok(FoundCrate::Itself) => quote!(crate),
+        Ok(FoundCrate::Itself) => quote!(::rustango),
         Ok(FoundCrate::Name(name)) => {
             let ident = proc_macro2::Ident::new(&name, proc_macro2::Span::call_site());
             quote!(::#ident)


### PR DESCRIPTION
CI regression caught after #898–#905 landed.

The \`rustango_root()\` helper introduced in #898 returned \`quote!(crate)\` for the \`FoundCrate::Itself\` arm — the standard proc-macro-crate pattern. But rustango has examples + integration tests inside its own crate directory. Those compile as separate binaries that:

1. Share the workspace member's Cargo.toml.
2. Are bound by proc-macro-crate's \`crate_name(\"rustango\")\` → returns \`Itself\`.
3. Have their OWN \`crate::\` namespace — the example/test file, NOT the rustango lib root.

Result: macro emits \`crate::__impl_my_aliased_row_decoder!(...)\`, the example tries to resolve against its own (empty) crate root, fails with \"could not find \`__impl_my_aliased_row_decoder\` in the crate root\".

## Fix

Emit \`::rustango\` (absolute path) for the \`Itself\` arm. The absolute path resolves correctly everywhere:

- The rustango lib itself.
- Examples / integration tests inside the rustango package.
- Downstream renamed consumers (handled by the \`Name(...)\` arm, unchanged).

## Verification

- \`cargo build --example sqlite_orm_demo --features sqlite\` ✅ (was broken)
- Lib suite **3408 / 3408** passing
- Smoke test (\`cargo test --package rustango-renamed-smoke\`) → 1 passed ✅
- Litmus (\`cargo build -p rustango --no-default-features --features sqlite,tenancy\`) ✅

Closes the CI regression flagged on PRs #898–#905. The renamed-crate functionality (the actual point of #142) is unchanged — \`FoundCrate::Name(...)\` arm still handles it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)