### PR TITLE
fix(ci): contenttypes::all_ordered + smoke crate version pin

### DIFF
--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -51,5 +51,5 @@ postgres = ["orm/postgres"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango" }
+orm = { package = "rustango", path = "../rustango", version = "0.42.0" }
 chrono = { workspace = true }

--- a/crates/rustango/tests/contenttypes_live.rs
+++ b/crates/rustango/tests/contenttypes_live.rs
@@ -260,7 +260,9 @@ async fn all_returns_seeded_rows_ordered() {
     contenttypes::ensure_seeded(&pool.clone().into())
         .await
         .expect("seed");
-    let rows = ContentType::all(&pool.clone().into()).await.expect("all");
+    let rows = ContentType::all_ordered(&pool.clone().into())
+        .await
+        .expect("all");
     assert!(rows.len() >= 2, "at least two seeded models");
     // Confirm sort order: app_label asc, model_name asc.
     let mut last: Option<(String, String)> = None;


### PR DESCRIPTION
Two CI regressions surfaced after #890 (the \`ContentType::all\` rename) and #902 (the renamed-smoke crate):

## 1. \`contenttypes_live::all_returns_seeded_rows_ordered\`

Still calling \`ContentType::all()\` and expecting sorted-by-(app_label, model_name) rows. After PR #890, \`::all\` is the macro-emitted unordered shortcut; the manual ordered method was renamed to \`::all_ordered\`. Test updated to call \`all_ordered\`.

## 2. cargo-deny wildcard

\`rustango-renamed-smoke\`'s \`orm = { package = \"rustango\", path = \"../rustango\" }\` was flagged by \`[bans] wildcards = \"deny\"\` because path-only deps without a version constraint are treated as wildcards. Added \`version = \"0.42.0\"\` to match the workspace's other path-dep pattern.

Both regressions only surfaced in CI; local sqlite-only / lib-only builds + the smoke test all passed. Session takeaway: always run \`cargo deny check\` + live postgres tests before admin-merging macro changes.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)