### PR TITLE
test(smoke): extend renamed-crate smoke to cover #[derive(Serializer)]

### DIFF
--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -22,8 +22,9 @@ path = "src/lib.rs"
 # emissions silently get dropped, the trait bounds elsewhere go
 # unsatisfied, and `cargo check --workspace` fails.
 [features]
-default = ["postgres"]
+default = ["postgres", "serializer"]
 postgres = ["orm/postgres"]
+serializer = ["orm/serializer"]
 
 [dependencies]
 # The whole point of this crate — rename rustango locally so the

--- a/crates/rustango-renamed-smoke/src/lib.rs
+++ b/crates/rustango-renamed-smoke/src/lib.rs
@@ -49,6 +49,18 @@ mod gated {
         pub created_at: chrono::DateTime<chrono::Utc>,
     }
 
+    // Serializer covers the `derive_serializer` path-resolution
+    // branch — the macro emits `#root::serializer::ModelSerializer`
+    // impls plus a tuple-positional view. If the rename broke the
+    // serializer-side emit, this struct wouldn't compile.
+    #[cfg(feature = "serializer")]
+    #[derive(orm::Serializer, Default)]
+    #[serializer(model = RenamedDemo)]
+    pub struct RenamedDemoSerializer {
+        pub name: String,
+        pub views: i64,
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;
@@ -61,6 +73,24 @@ mod gated {
             // test.
             assert_eq!(RenamedDemo::SCHEMA.table, "rrs_demo");
             assert!(RenamedDemo::SCHEMA.primary_key().is_some());
+        }
+
+        #[cfg(feature = "serializer")]
+        #[test]
+        fn serializer_resolves_through_renamed_dep() {
+            use orm::serializer::ModelSerializer;
+            let demo = RenamedDemo {
+                id: Auto::Set(7),
+                name: "ada".into(),
+                views: 42,
+                created_at: chrono::Utc::now(),
+            };
+            let s = RenamedDemoSerializer::from_model(&demo);
+            assert_eq!(s.name, "ada");
+            assert_eq!(s.views, 42);
+            let json = s.to_value();
+            assert_eq!(json["name"], "ada");
+            assert_eq!(json["views"], 42);
         }
     }
 }


### PR DESCRIPTION
Builds on PR #902 / #904. The smoke crate previously only exercised \`#[derive(Model)]\`, leaving the \`derive_serializer\` path-resolution branch unverified for renamed-crate consumers.

## Added

- \`serializer\` feature on the smoke crate that forwards to \`orm/serializer\`. Default features now include it.
- \`RenamedDemoSerializer\` struct deriving \`orm::Serializer\`, bound to \`RenamedDemo\` via \`#[serializer(model = RenamedDemo)]\`.
- Cfg-gated test that calls \`from_model(&demo)\` + \`to_value()\` and asserts the JSON shape matches the bound model's fields.

If the macro's \`derive_serializer\` emit had stale \`::rustango::\` paths (it doesn't — migrated in #899), this test would have caught it. Going forward, the smoke crate covers Model AND Serializer end-to-end through the rename.

## Verification

- \`cargo test --package rustango-renamed-smoke\` → 2 passed ✅
- Lib suite **3408 / 3408** passing
- Litmus passing
- Workspace check passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)