### PR TITLE
test(smoke): extend renamed-crate smoke to cover #[derive(Form)]

### DIFF
--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -22,9 +22,10 @@ path = "src/lib.rs"
 # emissions silently get dropped, the trait bounds elsewhere go
 # unsatisfied, and `cargo check --workspace` fails.
 [features]
-default = ["postgres", "serializer"]
+default = ["postgres", "serializer", "forms"]
 postgres = ["orm/postgres"]
 serializer = ["orm/serializer"]
+forms = ["orm/forms"]
 
 [dependencies]
 # The whole point of this crate — rename rustango locally so the

--- a/crates/rustango-renamed-smoke/src/lib.rs
+++ b/crates/rustango-renamed-smoke/src/lib.rs
@@ -61,6 +61,19 @@ mod gated {
         pub views: i64,
     }
 
+    // Form covers the `derive_form` path-resolution branch —
+    // the macro emits `#root::forms::Form` impls + per-field
+    // validator chains. If the rename broke the form-side emit,
+    // this struct wouldn't compile.
+    #[cfg(feature = "forms")]
+    #[derive(orm::Form, Debug)]
+    pub struct RenamedDemoForm {
+        #[form(min_length = 1, max_length = 80)]
+        pub name: String,
+        #[form(min = 0)]
+        pub views: i32,
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;
@@ -91,6 +104,18 @@ mod gated {
             let json = s.to_value();
             assert_eq!(json["name"], "ada");
             assert_eq!(json["views"], 42);
+        }
+
+        #[cfg(feature = "forms")]
+        #[test]
+        fn form_resolves_through_renamed_dep() {
+            use orm::forms::Form;
+            let mut payload = ::std::collections::HashMap::new();
+            payload.insert("name".to_string(), "ada".to_string());
+            payload.insert("views".to_string(), "42".to_string());
+            let f = RenamedDemoForm::parse(&payload).expect("valid payload");
+            assert_eq!(f.name, "ada");
+            assert_eq!(f.views, 42);
         }
     }
 }


### PR DESCRIPTION
Follow-up to #908 — adds the third of the four derive paths to the smoke crate.

| Derive | Smoke coverage |
|---|---|
| \`#[derive(Model)]\`      | #902 |
| \`#[derive(Serializer)]\` | #908 |
| **\`#[derive(Form)]\`**   | **this PR** |
| \`#[derive(ViewSet)]\`    | not yet — axum-router dep, 1 hardcoded \`::axum::\` site |

## Added

- \`forms\` feature on the smoke crate that forwards to \`orm/forms\`. Default features now include it.
- \`RenamedDemoForm\` struct deriving \`orm::Form\` with \`min_length\` / \`max_length\` / \`min\` validators (exercises the per-field validator chain emit).
- Cfg-gated test that calls \`RenamedDemoForm::parse(&payload)\` on a valid payload and asserts the parsed fields.

If the macro's \`derive_form\` emit had stale \`::rustango::\` paths (it doesn't — migrated in #899), this test would have caught it.

## Verification

- \`cargo test --package rustango-renamed-smoke\` → 3 passed ✅
- Lib suite **3408 / 3408** passing
- Litmus passing
- Workspace check passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)