### PR TITLE
test(smoke): extend renamed-crate smoke to cover the Q!() proc-macro

### DIFF
--- a/crates/rustango-renamed-smoke/src/lib.rs
+++ b/crates/rustango-renamed-smoke/src/lib.rs
@@ -117,5 +117,26 @@ mod gated {
             assert_eq!(f.name, "ada");
             assert_eq!(f.views, 42);
         }
+
+        #[test]
+        fn q_macro_resolves_through_renamed_dep() {
+            // Q!() is a proc-macro that emits `Column::like(...)` /
+            // `eq(...)` / etc. against the model's typed column
+            // surface. Path resolution flows through `expand_q` ->
+            // `#root::core::Column::...` (migrated in #899).
+            // If the rename broke that path, this wouldn't compile.
+            //
+            // Q!() returns `TypedFilter<Model>`; call `.into_expr()`
+            // to get the dialect-neutral `WhereExpr`.
+            let q = orm::Q!(RenamedDemo.name__icontains = "ada");
+            let where_expr: orm::core::WhereExpr = q.into();
+            // The exact IR shape is an implementation detail; just
+            // assert we got a non-empty leaf — the rename is what
+            // we're testing, not the predicate writer.
+            assert!(!matches!(
+                where_expr,
+                orm::core::WhereExpr::And(ref v) if v.is_empty()
+            ));
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #909 — adds the fourth user-facing macro entry point to the smoke crate's coverage.

| Entry point | Smoke coverage |
|---|---|
| \`#[derive(Model)]\`      | #902 |
| \`#[derive(Serializer)]\` | #908 |
| \`#[derive(Form)]\`       | #909 |
| **\`Q!()\` proc-macro**   | **this PR** |
| \`#[derive(ViewSet)]\`    | not covered (axum-router dep, 1 hardcoded \`::axum::\` site left intentionally) |

## Test

Invokes \`orm::Q!(RenamedDemo.name__icontains = \"ada\")\` and converts the resulting \`TypedFilter<RenamedDemo>\` to \`WhereExpr\` via \`Into\`. If the \`expand_q\` path resolution broke (it doesn't — migrated in #899), the \`Q!()\` expansion would emit \`::rustango::core::Column::ilike(...)\` paths that don't resolve under the rename.

## Verification

- \`cargo test --package rustango-renamed-smoke\` → 4 passed ✅
- Lib suite **3408 / 3408** passing
- Litmus passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)