### PR TITLE
test(smoke): extend renamed-crate smoke to cover embed_migrations!()

### DIFF
--- a/crates/rustango-renamed-smoke/migrations/0001_initial.json
+++ b/crates/rustango-renamed-smoke/migrations/0001_initial.json
@@ -1,0 +1,7 @@
+{
+  "name": "0001_initial",
+  "created_at": "2026-06-07T00:00:00Z",
+  "atomic": true,
+  "snapshot": { "tables": [] },
+  "forward": []
+}

--- a/crates/rustango-renamed-smoke/src/lib.rs
+++ b/crates/rustango-renamed-smoke/src/lib.rs
@@ -156,6 +156,21 @@ mod gated {
         }
 
         #[test]
+        fn embed_migrations_macro_resolves_through_renamed_dep() {
+            // embed_migrations!() is a proc-macro that walks a
+            // directory at compile time and emits a slice of
+            // (name, content) pairs. Path resolution flows through
+            // `expand_embed_migrations` (the macro entry point has
+            // no `::rustango::` sites itself — confirmed in #142
+            // Phase 2 audit — so this test mainly proves the entry
+            // point's signature works under the rename).
+            const EMBEDDED: &[(&str, &str)] = orm::embed_migrations!("./migrations");
+            assert_eq!(EMBEDDED.len(), 1);
+            assert_eq!(EMBEDDED[0].0, "0001_initial");
+            assert!(EMBEDDED[0].1.contains("\"forward\""));
+        }
+
+        #[test]
         fn q_macro_resolves_through_renamed_dep() {
             // Q!() is a proc-macro that emits `Column::like(...)` /
             // `eq(...)` / etc. against the model's typed column


### PR DESCRIPTION
Follow-up to #912. Adds the last user-facing proc-macro entry point to the smoke crate's coverage.

| Entry point | Smoke coverage |
|---|---|
| \`#[derive(Model)]\`      | #902 + #912 (with FK) |
| \`#[derive(Serializer)]\` | #908 |
| \`#[derive(Form)]\`       | #909 |
| \`Q!()\`                  | #910 |
| **\`embed_migrations!()\`** | **this PR** |
| \`#[derive(ViewSet)]\`    | not covered (axum-router dep, by design) |

Added \`crates/rustango-renamed-smoke/migrations/0001_initial.json\` fixture and a test that calls \`orm::embed_migrations!(\"./migrations\")\` through the rename, asserting the slice has one entry with the right name + content.

\`expand_embed_migrations\` itself had no \`::rustango::\` sites to migrate (confirmed during the Phase 2 audit), so this test proves the macro's entry-point signature still resolves under the renamed-dep path resolution. Useful as a regression net for future work that touches embed_migrations.

## Verification

- \`cargo test --package rustango-renamed-smoke\` → 6 passed ✅
- Lib suite **3408 / 3408**
- Litmus passing
- Workspace check passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)