### PR TITLE
feat(macros): route axum::Router through #root::__axum + complete smoke coverage

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -10313,7 +10313,7 @@ fn expand_viewset(input: &DeriveInput) -> syn::Result<TokenStream2> {
         impl #struct_name {
             /// Build an `axum::Router` with the six standard REST endpoints
             /// for this ViewSet, mounted at `prefix`.
-            pub fn router(prefix: &str, pool: #root::sql::sqlx::PgPool) -> ::axum::Router {
+            pub fn router(prefix: &str, pool: #root::sql::sqlx::PgPool) -> #root::__axum::Router {
                 #root::viewset::ViewSet::for_model(
                     <#model_path as #root::core::Model>::SCHEMA
                 )

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -22,10 +22,12 @@ path = "src/lib.rs"
 # emissions silently get dropped, the trait bounds elsewhere go
 # unsatisfied, and `cargo check --workspace` fails.
 [features]
-default = ["postgres", "serializer", "forms"]
+default = ["postgres", "serializer", "forms", "admin", "tenancy"]
 postgres = ["orm/postgres"]
 serializer = ["orm/serializer"]
 forms = ["orm/forms"]
+admin = ["orm/admin"]
+tenancy = ["orm/tenancy"]
 
 [dependencies]
 # The whole point of this crate — rename rustango locally so the

--- a/crates/rustango-renamed-smoke/src/lib.rs
+++ b/crates/rustango-renamed-smoke/src/lib.rs
@@ -90,6 +90,22 @@ mod gated {
         pub views: i32,
     }
 
+    // ViewSet covers the `derive_viewset` path-resolution branch —
+    // the macro emits `pub fn router(...) -> #root::__axum::Router`
+    // (the `__axum` re-export was added as a #142 follow-up so this
+    // emit no longer needs a hardcoded `::axum::` path). ViewSet
+    // derive is gated on `tenancy` in rustango; axum on `admin`.
+    // Both features are enabled by this crate's defaults.
+    #[cfg(all(feature = "admin", feature = "tenancy"))]
+    #[derive(orm::ViewSet)]
+    #[viewset(
+        model         = RenamedDemo,
+        fields        = "id, name, views",
+        page_size     = 20,
+    )]
+    #[allow(dead_code)]
+    pub struct RenamedDemoViewSet;
+
     #[cfg(test)]
     mod tests {
         use super::*;
@@ -153,6 +169,20 @@ mod gated {
             let f = RenamedDemoForm::parse(&payload).expect("valid payload");
             assert_eq!(f.name, "ada");
             assert_eq!(f.views, 42);
+        }
+
+        #[cfg(all(feature = "admin", feature = "tenancy"))]
+        #[test]
+        fn viewset_router_method_resolves_through_renamed_dep() {
+            // ViewSet derive emits a `router(prefix, pool) ->
+            // #root::__axum::Router` method. We can't actually
+            // build the router without a real PgPool, but we can
+            // confirm the method's type signature compiles + the
+            // axum::Router return type resolves through the
+            // renamed crate. Reaching this assertion at all is
+            // the test — compilation proves the rename worked.
+            let _router_fn: fn(&str, orm::sql::sqlx::PgPool) -> orm::__axum::Router =
+                RenamedDemoViewSet::router;
         }
 
         #[test]

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -1333,6 +1333,17 @@ pub use serde as __serde;
 #[doc(hidden)]
 pub use rust_decimal as __rust_decimal;
 
+/// Same rationale — `#[derive(ViewSet)]` emits an `axum::Router`-
+/// returning method. Gated on `feature = "admin"` since that's the
+/// feature that pulls `dep:axum` into rustango's dep graph
+/// (transitively via `manage`). ViewSet consumers always enable
+/// `admin` (they're building HTTP routes), so this gating matches
+/// the practical use case.
+/// **Not part of the public API.** #142 follow-up.
+#[cfg(feature = "admin")]
+#[doc(hidden)]
+pub use axum as __axum;
+
 /// `#[derive(Model)]` — populates the `inventory` registry the admin
 /// walks, generates `objects()` / typed columns / `insert` / `delete`
 /// / `save`.


### PR DESCRIPTION
#142's **last** hardcoded external-crate path — the \`pub fn router(prefix, pool) -> ::axum::Router\` emit in \`expand_viewset\` — now routes through \`#root::__axum::Router\`.

## Change

- Added \`pub use axum as __axum;\` to \`rustango/lib.rs\` gated on \`feature = \"admin\"\` (which pulls \`dep:axum\` into rustango's dep graph).
- Migrated the 1 macro emit site: \`::axum::Router\` → \`#root::__axum::Router\`.

ViewSet derive consumers already enable \`admin\` because they're building HTTP routes — the gate matches the practical use case.

## Smoke crate completes coverage

Added \`RenamedDemoViewSet\` (unit struct + \`#[viewset(...)]\` config) under the same gated module as the other derives, with a compile-only test that confirms the \`router\` method's signature compiles end-to-end:

\`\`\`rust
let _router_fn: fn(&str, orm::sql::sqlx::PgPool) -> orm::__axum::Router
    = RenamedDemoViewSet::router;
\`\`\`

The smoke crate's default features now include \`admin\` and \`tenancy\` (the two rustango features ViewSet derive depends on).

## Macro emit is now 100% path-resolution clean

**Zero hardcoded external-crate paths remain.** Every \`::ext::\` previously emitted routes through:
- \`#root::__chrono::\` (#904)
- \`#root::__serde::\` (#904)
- \`#root::__serde_json::\` (#904)
- \`#root::__tracing::\` (#903)
- \`#root::__rust_decimal::\` (#905)
- \`#root::__uuid::\` (#905)
- **\`#root::__axum::\`** (this PR)
- \`#root::sql::sqlx::\` (pre-existing re-export)

Plus all \`::rustango::\` paths route through \`#root::\` itself (closed in PR #898–#901, completing #142).

## Verification

- \`cargo test --package rustango-renamed-smoke\` → **7 passed** ✅
- Lib suite **3408 / 3408**
- Litmus passing
- Example \`sqlite_orm_demo\` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)