### PR TITLE
docs(readme): document the renameable-dep pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ rustango = { version = "0.42", default-features = false, features = ["mysql", "t
 
 # Multiple backends in one binary
 rustango = { version = "0.42", features = ["postgres", "sqlite"] }
+
+# Renaming the dep — `#[derive(Model)]` etc. resolve the crate root
+# via `proc-macro-crate` (issue #142), so importing under a custom
+# name works without any extra wiring.
+orm = { package = "rustango", version = "0.42" }
 ```
 
 ### What's new in v0.42.0 (May 2026) — Django-parity gap-closure batch


### PR DESCRIPTION
After #142 the rustango macros resolve their crate root via \`proc-macro-crate\`, so consumers can rename the dep without hitting \`::rustango::core::Model\` resolution failures.

The quick-start section in README.md shows the various feature pickings (PG / SQLite / MySQL / multi-backend); this adds a fourth snippet showing the rename pattern explicitly:

\`\`\`toml
orm = { package = \"rustango\", version = \"0.42\" }
\`\`\`

Tiny docs-only change. The \`rustango-renamed-smoke\` workspace member (see its README from PR #915) is the regression net proving this keeps working across macro changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)