### PR TITLE
chore(tests): drop stale `_pool` references from test docstrings

### DIFF
--- a/crates/rustango/tests/model_aggregate_shortcuts_sqlite_live.rs
+++ b/crates/rustango/tests/model_aggregate_shortcuts_sqlite_live.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "sqlite")]
 //! Live SQLite tests for the macro-emitted aggregate-shortcut
-//! family: `Model::sum_pool` / `avg_pool` / `min_pool` / `max_pool`
-//! / `doesnt_exist_pool`. Eloquent `Model::sum($col)` /
+//! family: `Model::sum` / `avg` / `min` / `max` /
+//! `doesnt_exist`. Eloquent `Model::sum($col)` /
 //! `Model::avg($col)` / `Model::min($col)` / `Model::max($col)` /
 //! `Model::doesntExist()` parity.
 

--- a/crates/rustango/tests/model_count_exists_sqlite_live.rs
+++ b/crates/rustango/tests/model_count_exists_sqlite_live.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "sqlite")]
-//! Live SQLite tests for the macro-emitted `Model::count_pool` /
-//! `Model::exists_pool` shortcuts — Eloquent `Model::count()` /
+//! Live SQLite tests for the macro-emitted `Model::count` /
+//! `Model::exists` shortcuts — Eloquent `Model::count()` /
 //! `Model::query()->exists()` parity.
 
 use rustango::sql::{sqlx, Auto, Pool};

--- a/crates/rustango/tests/model_soft_delete_scope_pool_sqlite_live.rs
+++ b/crates/rustango/tests/model_soft_delete_scope_pool_sqlite_live.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "sqlite")]
 //! Live SQLite tests for the macro-emitted soft-delete query
-//! shortcuts — `Model::active_pool`, `Model::only_trashed_pool`,
-//! `Model::with_trashed_pool`. Eloquent
+//! shortcuts — `Model::active`, `Model::only_trashed`,
+//! `Model::with_trashed`. Eloquent
 //! `Model::onlyTrashed()->get()` / `Model::withTrashed()->get()`
 //! parity. Closes #821 partial.
 


### PR DESCRIPTION
After PR #891 dropped \`_pool\` from the macro-emitted Eloquent shortcuts, three test files still mentioned the old names in their \`//!\` module docstrings:

| File | Old refs | Updated |
|---|---|---|
| \`model_count_exists_sqlite_live.rs\` | \`Model::count_pool\` / \`exists_pool\` | \`count\` / \`exists\` |
| \`model_soft_delete_scope_pool_sqlite_live.rs\` | \`active_pool\` / \`only_trashed_pool\` / \`with_trashed_pool\` | \`active\` / \`only_trashed\` / \`with_trashed\` |
| \`model_aggregate_shortcuts_sqlite_live.rs\` | \`sum_pool\` / \`avg_pool\` / \`min_pool\` / \`max_pool\` / \`doesnt_exist_pool\` | \`sum\` / \`avg\` / \`min\` / \`max\` / \`doesnt_exist\` |

Docstring-only — the test code itself was already updated to the bare names back in #891. No behavior change.

\`bulk_upsert_pool\` / \`save_pool\` etc. write-path docs unchanged — those methods still have the \`_pool\` suffix (PG-only siblings carry real discrimination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)