### PR TITLE
feat(orm-macros): rustango-orm-macros carve-out — closes #143

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros = { version = "0.42.0", path = "crates/rustango-macros" }
-rustango        = { version = "0.42.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.42.0", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.42.0", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.42.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/crates/rustango-orm-macros/Cargo.toml
+++ b/crates/rustango-orm-macros/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+name = "rustango-orm-macros"
+description = "ORM-only proc-macros for rustango — Model / Form / embed_migrations. Carve-out of rustango-macros for the standalone rustango-orm crate."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+# Issue #143 — the orm-extract epic's first physical-move slice.
+#
+# Today this crate is a thin re-exporter over `rustango-macros`. We
+# expose ONLY `Model`, `Form`, and `embed_migrations!` — the three
+# proc-macros the ORM core actually needs. `Serializer`, `ViewSet`,
+# `Q!`, and `#[rustango::main]` stay in `rustango-macros` (they're
+# framework/runtime concerns, not ORM-core).
+#
+# The eventual physical move (issue #144 carve-out lands) will lift
+# the macro bodies into this crate's `src/lib.rs` and `rustango-macros`
+# will drop them. Until then the re-export shape gives downstream
+# `rustango-orm` consumers the exact API surface they'll get
+# post-split, without requiring a 3500-LOC mechanical move in one PR.
+#
+# Why a regular `[lib]` (not `proc-macro`) re-exporter works: Rust's
+# resolver walks `pub use` paths to find the proc-macro definition
+# in its original `proc-macro = true` crate. Consumers can
+# `use rustango_orm_macros::Model;` and `#[derive(Model)]` resolves
+# correctly through the rustango-macros side.
+[lib]
+name = "rustango_orm_macros"
+path = "src/lib.rs"
+
+[features]
+default = []
+# Forward the consumer's `postgres` feature into rustango — when this
+# crate's tests run with `--all-features`, rustango compiles in PG
+# mode and the integration test gets the real `LoadRelated` /
+# `MaybePgFromRow` trait bounds that the macro emits.
+postgres = ["rustango/postgres"]
+
+[dependencies]
+rustango-macros = { workspace = true }
+
+[dev-dependencies]
+# Integration test calls `Post::SCHEMA.table` etc. — the schema /
+# typed-builder surface lives in `rustango` proper, not in the macro
+# crate. This dep only kicks in for the test binary.
+rustango = { workspace = true }
+

--- a/crates/rustango-orm-macros/src/lib.rs
+++ b/crates/rustango-orm-macros/src/lib.rs
@@ -1,0 +1,51 @@
+//! Proc-macros for the standalone `rustango-orm` crate — carve-out
+//! of [`rustango-macros`](https://docs.rs/rustango-macros).
+//!
+//! This crate re-exports the ORM-only proc-macros from the
+//! workspace's `rustango-macros` crate:
+//!
+//! - [`Model`] — `#[derive(Model)]` populates the model schema,
+//!   generates inherent methods (insert / save / delete / find /
+//!   where_ / sum / etc.), and registers the model with the
+//!   `inventory` crate so the admin walks every derived model.
+//! - [`Form`] — `#[derive(Form)]` validates user input and parses
+//!   it into a strongly-typed struct.
+//! - [`embed_migrations!`] — bakes a `migrations/` directory's
+//!   `.json` files into a `&'static [(name, content)]` slice at
+//!   compile time.
+//!
+//! The framework-only derives (`Serializer`, `ViewSet`, `Q!`,
+//! `#[rustango::main]`) stay in `rustango-macros`. Downstream code
+//! that depends only on `rustango-orm-macros` literally cannot
+//! reach them — that's the carve-out half of issue
+//! [#143](https://github.com/ujeenet/rustango/issues/143).
+//!
+//! ## How re-export works for proc-macros
+//!
+//! Rust's resolver follows `pub use` paths to find a proc-macro's
+//! defining crate. The consumer writes:
+//!
+//! ```ignore
+//! use rustango_orm_macros::Model;
+//!
+//! #[derive(Model)]
+//! pub struct Post { … }
+//! ```
+//!
+//! …and the compiler looks up `Model` in this crate's scope, sees
+//! it's a re-export of `rustango_macros::Model`, walks back to the
+//! `proc-macro = true` crate where the derive is actually defined,
+//! and invokes the proc-macro entry point.
+//!
+//! Because of how proc-macros work, the re-exporter itself doesn't
+//! need `proc-macro = true`. This is a regular `[lib]` crate.
+//!
+//! After issue [#144](https://github.com/ujeenet/rustango/issues/144)
+//! lands (the physical move of the ORM modules to a standalone
+//! `rustango-orm` crate), the proc-macro bodies themselves will
+//! migrate here and `rustango-macros` will drop them, completing
+//! the carve-out.
+
+#![warn(missing_docs)]
+
+pub use rustango_macros::{embed_migrations, Form, Model};

--- a/crates/rustango-orm-macros/tests/reexport_smoke.rs
+++ b/crates/rustango-orm-macros/tests/reexport_smoke.rs
@@ -1,0 +1,52 @@
+//! Smoke test for the proc-macro re-export pattern of issue
+//! [#143](https://github.com/ujeenet/rustango/issues/143).
+//!
+//! Consumers should be able to `use rustango_orm_macros::Model;` and
+//! have `#[derive(Model)]` resolve through this crate's re-export.
+//! If the resolver couldn't follow `pub use` paths to the underlying
+//! proc-macro definition, this file wouldn't compile.
+//!
+//! Gated on `feature = "postgres"` for the same reason
+//! `rustango-renamed-smoke` is — the macro emits
+//! `#[cfg(feature = "postgres")] impl LoadRelated for #Struct`
+//! against the CONSUMER's feature flags, and the consumer here
+//! is the integration-test binary, which inherits the rustango
+//! workspace's all-features config in CI but might not in a
+//! sqlite-only litmus.
+
+#![cfg(feature = "postgres")]
+#![allow(dead_code)]
+
+use rustango::sql::Auto;
+use rustango_orm_macros::{Form, Model};
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rom_post")]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+#[derive(Form, Debug)]
+pub struct PostForm {
+    #[form(min_length = 1, max_length = 200)]
+    pub title: String,
+}
+
+#[test]
+fn model_derive_reexports_through_orm_macros_crate() {
+    use rustango::core::Model as _;
+    assert_eq!(Post::SCHEMA.table, "rom_post");
+    assert!(Post::SCHEMA.primary_key().is_some());
+}
+
+#[test]
+fn form_derive_reexports_through_orm_macros_crate() {
+    use rustango::forms::Form;
+    let mut payload = std::collections::HashMap::new();
+    payload.insert("title".to_string(), "hello".to_string());
+    let f = PostForm::parse(&payload).expect("valid");
+    assert_eq!(f.title, "hello");
+}


### PR DESCRIPTION
First physical-move slice of the [orm-extract epic #149](https://github.com/ujeenet/rustango/issues/149). Closes #143.

Creates \`crates/rustango-orm-macros/\` as a new workspace member that exposes ONLY the three proc-macros the ORM core actually needs:

\`\`\`rust
pub use rustango_macros::{embed_migrations, Form, Model};
\`\`\`

The framework-only derives (\`Serializer\`, \`ViewSet\`, \`Q!\`, \`#[rustango::main]\`) stay in \`rustango-macros\`. **Consumers that depend only on \`rustango-orm-macros\` literally cannot reach them** — exactly the acceptance criterion #143 calls out.

## Why re-export instead of physical move

The issue mentions ~3500 LOC of helpers to migrate. Doing that in one PR is genuinely risky — every match-arm on \`FieldType\`, every shared helper, every internal function reference has to thread through.

The re-export approach achieves the same observable API surface (downstream sees the carve-out) without the surgical move. When #144 lands (the standalone \`rustango-orm\` crate's physical move), the macro bodies will follow into \`rustango-orm-macros\` proper and \`rustango-macros\` will drop them. Until then this crate is a thin re-exporter.

## How proc-macro re-export works

Rust's resolver follows \`pub use\` paths to find a proc-macro's defining crate:

\`\`\`rust
use rustango_orm_macros::Model;
#[derive(Model)] pub struct Post { ... }
\`\`\`

The compiler looks up \`Model\` in this crate's scope, sees it's a re-export of \`rustango_macros::Model\`, walks back to the \`proc-macro = true\` crate, and invokes the derive. The re-exporter doesn't need \`proc-macro = true\` itself — \`rustango-orm-macros\` is a regular \`[lib]\` crate.

## Integration test

\`tests/reexport_smoke.rs\` proves the chain works end-to-end via \`Post::SCHEMA.table\` (Model derive) + \`PostForm::parse(&payload)\` (Form derive). Both pass under \`cargo test -p rustango-orm-macros --all-features\`.

## Verification

- \`cargo test -p rustango-orm-macros --all-features\` → 2 passed ✅
- Lib suite **3408 / 3408**
- Litmus passing
- Workspace check passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)