### PR TITLE
feat(orm): global scopes — auto-applied query filters — closes #820

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -855,6 +855,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
             .map(|(c, d)| (c.as_str(), *d)),
         &container.extra_permissions,
         &container.default_permissions,
+        &container.global_scopes,
     );
     let module_ident = column_module_ident(struct_name);
     let column_consts = column_const_tokens(&module_ident, &collected.column_entries);
@@ -1861,6 +1862,7 @@ fn model_impl_tokens(
     get_latest_by: Option<(&str, bool)>,
     extra_permissions: &[(String, String)],
     default_permissions: &[String],
+    global_scopes: &[GlobalScopeAttr],
 ) -> TokenStream2 {
     let root = rustango_root();
     let display_tokens = if let Some(name) = display {
@@ -2012,6 +2014,21 @@ fn model_impl_tokens(
         quote! { (#col_lit, #desc) }
     });
 
+    // Issue #820 — `global_scopes` slice literal. Empty when no
+    // `#[rustango(global_scope(...))]` attribute was supplied. The
+    // `apply` path is re-emitted verbatim so it resolves in the
+    // consumer's scope; the name is stored as a string literal.
+    let global_scope_tokens = global_scopes.iter().map(|s| {
+        let name = s.name.as_str();
+        let apply = &s.apply;
+        quote! {
+            #root::core::GlobalScope {
+                name: #name,
+                apply: #apply,
+            }
+        }
+    });
+
     let m2m_tokens = m2m_relations.iter().map(|rel| {
         let name = rel.name.as_str();
         let to = rel.to.as_str();
@@ -2064,6 +2081,7 @@ fn model_impl_tokens(
                 get_latest_by: #get_latest_by_tokens,
                 extra_permissions: &[ #(#extra_permission_tokens),* ],
                 default_permissions: &[ #(#default_permission_tokens),* ],
+                global_scopes: &[ #(#global_scope_tokens),* ],
             };
         }
     }
@@ -6920,6 +6938,22 @@ struct ContainerAttrs {
     /// plural form. Threaded into `ModelSchema::verbose_name_plural`.
     /// When unset, `display_label_plural()` auto-suffixes `s`.
     verbose_name_plural: Option<String>,
+    /// Eloquent-shape **global scopes** from `#[rustango(global_scope(name
+    /// = "...", apply = path::to::fn))]` — issue #820. Each entry pairs
+    /// a name (used by `QuerySet::without_global_scope`) with a
+    /// `fn() -> WhereExpr` path that the macro emits into
+    /// `ModelSchema::global_scopes`. Multiple attributes accumulate.
+    global_scopes: Vec<GlobalScopeAttr>,
+}
+
+/// Parsed `#[rustango(global_scope(name = "...", apply = fn_path))]`
+/// declaration. Each entry becomes one `core::GlobalScope` in the
+/// emitted schema literal; `apply` resolves at macro-expand time
+/// against the consumer's scope so the function must be in scope at
+/// the use site. Issue #820.
+struct GlobalScopeAttr {
+    name: String,
+    apply: syn::Path,
 }
 
 /// Parsed form of one index declaration (field-level or container-level).
@@ -7136,6 +7170,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
         get_latest_by: None,
         extra_permissions: Vec::new(),
         default_permissions: Vec::new(),
+        global_scopes: Vec::new(),
     };
     for attr in &input.attrs {
         if !attr.path().is_ident("rustango") {
@@ -7399,6 +7434,64 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     ));
                 }
                 out.default_order = parsed;
+                return Ok(());
+            }
+            if meta.path.is_ident("global_scope") {
+                // `#[rustango(global_scope(name = "active", apply =
+                //  path::to::fn))]` — issue #820. The apply function
+                // path resolves at macro-expand time in the consumer's
+                // scope; the macro re-emits it verbatim into the
+                // `ModelSchema::global_scopes` slice literal.
+                let span = meta.path.span();
+                let mut scope_name: Option<String> = None;
+                let mut apply_path: Option<syn::Path> = None;
+                meta.parse_nested_meta(|inner| {
+                    if inner.path.is_ident("name") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        let raw = s.value();
+                        if raw.trim().is_empty() {
+                            return Err(syn::Error::new(
+                                s.span(),
+                                "`global_scope(name = \"...\")` must not be empty",
+                            ));
+                        }
+                        scope_name = Some(raw);
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("apply") {
+                        let p: syn::Path = inner.value()?.parse()?;
+                        apply_path = Some(p);
+                        return Ok(());
+                    }
+                    Err(inner.error(
+                        "unknown `global_scope` attribute (supported: \
+                         `name`, `apply`)",
+                    ))
+                })?;
+                let Some(name) = scope_name else {
+                    return Err(syn::Error::new(
+                        span,
+                        "`global_scope` requires `name = \"...\"`",
+                    ));
+                };
+                let Some(apply) = apply_path else {
+                    return Err(syn::Error::new(
+                        span,
+                        "`global_scope` requires `apply = fn_path`",
+                    ));
+                };
+                if out.global_scopes.iter().any(|s| s.name == name) {
+                    return Err(syn::Error::new(
+                        span,
+                        format!(
+                            "duplicate global scope name `{name}` — \
+                             pick a unique identifier so \
+                             `QuerySet::without_global_scope(\"{name}\")` \
+                             is unambiguous"
+                        ),
+                    ));
+                }
+                out.global_scopes.push(GlobalScopeAttr { name, apply });
                 return Ok(());
             }
             if meta.path.is_ident("audit") {

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -32,9 +32,9 @@ pub use query::{
 };
 pub use schema::{
     infer_app_label_from_module_path, AdminConfig, CheckConstraint, CompositeFkRelation,
-    ExclusionConstraint, FieldSchema, Fieldset, GenericRelation, IndexMethod, IndexSchema,
-    ListSelectRelated, M2MRelation, Model, ModelEntry, ModelSchema, ModelScope, OnDeleteAction,
-    PrepopulatedField, Relation,
+    ExclusionConstraint, FieldSchema, Fieldset, GenericRelation, GlobalScope, IndexMethod,
+    IndexSchema, ListSelectRelated, M2MRelation, Model, ModelEntry, ModelSchema, ModelScope,
+    OnDeleteAction, PrepopulatedField, Relation,
 };
 pub use validate::validate_value;
 pub use value::SqlValue;

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -562,6 +562,51 @@ pub struct ModelSchema {
     /// archive:Can archive")]` — comma-separated `codename:label`
     /// pairs, same shape as the existing `choices = "..."` attribute.
     pub extra_permissions: &'static [(&'static str, &'static str)],
+    /// Eloquent-shape **global scopes** — filters auto-applied to every
+    /// [`crate::query::QuerySet`] built for this model. Issue #820.
+    /// Each entry pairs a name (used by
+    /// [`crate::query::QuerySet::without_global_scope`]) with a
+    /// constructor function that returns a [`crate::core::WhereExpr`]
+    /// at query-build time.
+    ///
+    /// Empty slice means "no auto-applied filters" (every QuerySet
+    /// starts unfiltered, like Django). Non-empty means every
+    /// queryset is implicitly `qs.filter(<scope_expr>)` unless the
+    /// caller chains
+    /// [`crate::query::QuerySet::without_global_scope`] or
+    /// [`crate::query::QuerySet::without_global_scopes`].
+    ///
+    /// Set via repeated `#[rustango(global_scope(name = "...", apply =
+    /// fn_path))]` attributes on the struct. The `fn_path` must
+    /// resolve to a `fn() -> WhereExpr` in scope when the macro
+    /// expands. Substrate for soft-delete auto-hiding and tenant-
+    /// isolation patterns.
+    pub global_scopes: &'static [GlobalScope],
+}
+
+/// A single auto-applied query filter — declared via
+/// `#[rustango(global_scope(name = "...", apply = fn))]` on the
+/// model struct and folded into every [`crate::query::QuerySet`]
+/// built for that model. Issue #820.
+///
+/// The `apply` function is invoked at query compile time so it can
+/// pull in any state (e.g. `chrono::Utc::now()` for a "published
+/// before now" scope). Keep it cheap — it runs once per `compile()`
+/// call.
+#[derive(Debug, Clone, Copy)]
+pub struct GlobalScope {
+    /// Identifier used by
+    /// [`crate::query::QuerySet::without_global_scope`] to opt out of
+    /// this specific scope on a per-query basis. Should be unique
+    /// among the model's `global_scopes` slice; rustango doesn't
+    /// enforce uniqueness today but a duplicate name makes the
+    /// escape hatch ambiguous.
+    pub name: &'static str,
+    /// Constructor invoked at query-compile time. Returns the
+    /// `WhereExpr` that gets `AND`-ed into the WHERE clause. The
+    /// signature is `fn() -> WhereExpr` (not a closure) so the
+    /// declaration fits in a `const`-friendly slice.
+    pub apply: fn() -> crate::core::WhereExpr,
 }
 
 impl ModelSchema {

--- a/crates/rustango/src/migrate/ddl.rs
+++ b/crates/rustango/src/migrate/ddl.rs
@@ -660,6 +660,7 @@ mod tests {
             proxy: false,
             get_latest_by: None,
             extra_permissions: &[],
+            global_scopes: &[],
         }
     }
 

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -688,6 +688,7 @@ mod composite_fk_snapshot_tests {
             proxy: false,
             get_latest_by: None,
             extra_permissions: &[],
+            global_scopes: &[],
         };
         &MS
     }
@@ -766,6 +767,7 @@ mod composite_fk_snapshot_tests {
             proxy: false,
             get_latest_by: None,
             extra_permissions: &[],
+            global_scopes: &[],
         };
         static UNMANAGED: ModelSchema = ModelSchema {
             name: "Unmanaged",
@@ -799,6 +801,7 @@ mod composite_fk_snapshot_tests {
             proxy: false,
             get_latest_by: None,
             extra_permissions: &[],
+            global_scopes: &[],
         };
         let snap = SchemaSnapshot::from_models(&[&MANAGED, &UNMANAGED]);
         let table_names: Vec<&str> = snap.tables.iter().map(|t| t.name.as_str()).collect();
@@ -870,6 +873,7 @@ mod composite_fk_snapshot_tests {
             proxy: false,
             get_latest_by: None,
             extra_permissions: &[],
+            global_scopes: &[],
         };
         let snap = TableSnapshot::from_schema(&MS);
         let json = serde_json::to_string(&snap).expect("serialize");
@@ -992,6 +996,7 @@ mod generated_as_and_db_comment_capture {
             proxy: false,
             get_latest_by: None,
             extra_permissions: &[],
+            global_scopes: &[],
         };
         &MS
     }

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -69,6 +69,21 @@ pub struct QuerySet<T: Model> {
     /// chained after `.none()` keep accumulating filters / orderings,
     /// matching Django's "an immutable empty queryset" semantic.
     is_none: bool,
+    /// Issue #820 — Eloquent `withoutGlobalScope($name)`. Names from
+    /// `T::SCHEMA.global_scopes` whose auto-applied filters should be
+    /// skipped on this queryset. Empty (default) keeps every scope
+    /// active. Populated by [`Self::without_global_scope`]. When
+    /// [`Self::disable_all_global_scopes`] is also set, this list is
+    /// ignored (the wholesale opt-out wins).
+    disabled_global_scopes: Vec<&'static str>,
+    /// Issue #820 — Eloquent `withoutGlobalScopes()`. When `true`,
+    /// every scope on `T::SCHEMA.global_scopes` is skipped (this
+    /// queryset behaves like the model carries no scopes). Set by
+    /// [`Self::without_global_scopes`]. Once true the
+    /// [`Self::disabled_global_scopes`] per-name list becomes
+    /// redundant — left intact so re-chaining `without_global_scope`
+    /// after `without_global_scopes` doesn't surprise the caller.
+    disable_all_global_scopes: bool,
     _model: PhantomData<fn() -> T>,
 }
 
@@ -175,7 +190,78 @@ impl<T: Model> QuerySet<T> {
             lock_mode: None,
             compound: Vec::new(),
             is_none: false,
+            disabled_global_scopes: Vec::new(),
+            disable_all_global_scopes: false,
             _model: PhantomData,
+        }
+    }
+
+    /// Issue #820 — Eloquent `Model::query()->withoutGlobalScope($name)`.
+    /// Suppress one named entry from
+    /// [`crate::core::ModelSchema::global_scopes`] on this queryset.
+    /// Repeated calls accumulate — pass each name to suppress.
+    ///
+    /// Unknown names are silently ignored (matches Eloquent + lets
+    /// downstream code add scopes without breaking call sites that
+    /// pre-emptively opt out of names that don't exist yet).
+    ///
+    /// No-op when the model declares no global scopes.
+    #[must_use]
+    pub fn without_global_scope(mut self, name: &'static str) -> Self {
+        if !self.disabled_global_scopes.contains(&name) {
+            self.disabled_global_scopes.push(name);
+        }
+        self
+    }
+
+    /// Issue #820 — Eloquent `Model::query()->withoutGlobalScopes()`.
+    /// Suppress *every* scope from
+    /// [`crate::core::ModelSchema::global_scopes`] on this queryset
+    /// — useful for admin or migration code paths that need to see
+    /// soft-deleted / unpublished / cross-tenant rows the application
+    /// hides by default.
+    ///
+    /// Composes with later [`Self::without_global_scope`] calls
+    /// without changing the wholesale opt-out (once disabled,
+    /// everything stays disabled on that queryset).
+    #[must_use]
+    pub fn without_global_scopes(mut self) -> Self {
+        self.disable_all_global_scopes = true;
+        self
+    }
+
+    /// Issue #820 — fold the schema-declared global scopes into the
+    /// pending filter list, respecting per-queryset opt-outs. Called
+    /// at the top of every `compile*` entry point so the WHERE walks
+    /// the scope expressions through the same resolver as any other
+    /// typed filter.
+    ///
+    /// The method **prepends** scope filters in declared order so the
+    /// final WHERE reads `scope_a AND scope_b AND <user filters>`.
+    /// `AND` is commutative; the order matters only for predicate-
+    /// trace readability in `EXPLAIN`.
+    ///
+    /// No-op when the model carries no scopes or when
+    /// `disable_all_global_scopes` is set.
+    fn apply_global_scopes(&mut self) {
+        if self.disable_all_global_scopes {
+            return;
+        }
+        let schema = T::SCHEMA;
+        if schema.global_scopes.is_empty() {
+            return;
+        }
+        let mut prefixed: Vec<PendingFilter> = Vec::new();
+        for scope in schema.global_scopes {
+            if self.disabled_global_scopes.contains(&scope.name) {
+                continue;
+            }
+            let expr = (scope.apply)();
+            prefixed.push(PendingFilter::Expr(expr));
+        }
+        if !prefixed.is_empty() {
+            prefixed.append(&mut self.pending);
+            self.pending = prefixed;
         }
     }
 
@@ -984,7 +1070,14 @@ impl<T: Model> QuerySet<T> {
     /// Returns [`QueryError::UnknownField`] if a filter names a field not
     /// present on the model, and [`QueryError::TypeMismatch`] if the bound
     /// value's type does not match the field's declared type.
-    pub fn compile(self) -> Result<SelectQuery, QueryError> {
+    pub fn compile(mut self) -> Result<SelectQuery, QueryError> {
+        // Issue #820 — Eloquent global scopes. Fold the schema-declared
+        // auto-applied filters into the pending list (respecting any
+        // `without_global_scope` / `without_global_scopes` opt-outs)
+        // BEFORE we hand `self.pending` to the resolver. From here on
+        // the resolver doesn't know or care which filters were scopes
+        // and which were user-provided.
+        self.apply_global_scopes();
         let model: &'static ModelSchema = T::SCHEMA;
         let where_clause = resolve_pending(model, self.pending)?;
         let mut joins = lower_select_related(model, &self.select_related)?;
@@ -1170,7 +1263,13 @@ impl<T: Model> QuerySet<T> {
     ///
     /// # Errors
     /// As [`QuerySet::compile`].
-    pub fn compile_delete(self) -> Result<DeleteQuery, QueryError> {
+    pub fn compile_delete(mut self) -> Result<DeleteQuery, QueryError> {
+        // Issue #820 — fold global scopes into the WHERE so a
+        // `Post.objects().delete_pool(&pool)` honors the same
+        // auto-applied filter that `Post.objects().fetch_pool(&pool)`
+        // does (e.g. a `published_only` scope means a wholesale delete
+        // still won't reach unpublished rows).
+        self.apply_global_scopes();
         let model: &'static ModelSchema = T::SCHEMA;
         let where_clause = resolve_pending(model, self.pending)?;
         // #331 — `.none().delete()` is a guaranteed no-op. Append an
@@ -1369,7 +1468,11 @@ impl<T: Model> UpdateBuilder<T> {
     /// Returns [`QueryError::UnknownField`] if any `set` or filter names an
     /// unknown field, and [`QueryError::TypeMismatch`] if any bound value's
     /// type doesn't match the field's declared type.
-    pub fn compile(self) -> Result<UpdateQuery, QueryError> {
+    pub fn compile(mut self) -> Result<UpdateQuery, QueryError> {
+        // Issue #820 — same rationale as the SELECT / DELETE paths:
+        // an `.update().set(...)` shouldn't escape the model's global
+        // scopes any more than a plain `.fetch_pool` would.
+        self.qs.apply_global_scopes();
         let model: &'static ModelSchema = T::SCHEMA;
 
         let assignments = self
@@ -2481,13 +2584,18 @@ impl<T: Model> AggregateBuilder<T> {
     ///   per-row).
     ///
     /// Explicit `.group_by(...)` always wins.
-    pub fn compile(self) -> Result<AggregateQuery, QueryError> {
+    pub fn compile(mut self) -> Result<AggregateQuery, QueryError> {
         // Surface any builder-time deferred error first (e.g. an
         // `Op::In` against an annotation alias) so the user sees the
         // real cause rather than a downstream compile failure.
         if let Some(e) = self.deferred_error {
             return Err(e);
         }
+        // Issue #820 — fold global scopes into the WHERE so aggregates
+        // honor the same auto-applied filter (e.g. `.count_pool()`
+        // against a `published_only`-scoped model counts published
+        // rows only, not the table's full row count).
+        self.qs.apply_global_scopes();
         let model = T::SCHEMA;
         let where_clause = resolve_pending(model, self.qs.pending)?;
         // Walk each AggregateExpr for column-name typos. Today this

--- a/crates/rustango/src/soft_delete.rs
+++ b/crates/rustango/src/soft_delete.rs
@@ -306,6 +306,7 @@ mod tests {
         proxy: false,
         get_latest_by: None,
         extra_permissions: &[],
+        global_scopes: &[],
     };
 
     static MODEL_WITHOUT_SD: ModelSchema = ModelSchema {
@@ -340,6 +341,7 @@ mod tests {
         proxy: false,
         get_latest_by: None,
         extra_permissions: &[],
+        global_scopes: &[],
     };
 
     #[test]

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -1360,6 +1360,7 @@ mod tests {
             proxy: false,
             get_latest_by: None,
             extra_permissions: &[],
+            global_scopes: &[],
         }))
     }
 }

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -682,6 +682,7 @@ mod tests {
             proxy: false,
             get_latest_by: None,
             extra_permissions: &[],
+            global_scopes: &[],
         };
         let q = SelectQuery {
             model: &MODEL,

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -3927,6 +3927,7 @@ mod tests {
             proxy: false,
             get_latest_by: None,
             extra_permissions: &[],
+            global_scopes: &[],
         }))
     }
 
@@ -4039,6 +4040,7 @@ mod tests {
             proxy: false,
             get_latest_by: None,
             extra_permissions: &[],
+            global_scopes: &[],
         }))
     }
 
@@ -4433,6 +4435,7 @@ mod tests {
             proxy: false,
             get_latest_by: None,
             extra_permissions: &[],
+            global_scopes: &[],
         }));
         assert!(default_order_by(no_pk).is_empty());
     }
@@ -4693,6 +4696,7 @@ mod tests {
             proxy: false,
             get_latest_by: None,
             extra_permissions: &[],
+            global_scopes: &[],
         }));
         let pk = uuid_schema.primary_key().unwrap();
         let raw = "550e8400-e29b-41d4-a716-446655440000";
@@ -4765,6 +4769,7 @@ mod tests {
             proxy: false,
             get_latest_by: None,
             extra_permissions: &[],
+            global_scopes: &[],
         }));
         let pk = str_schema.primary_key().unwrap();
         match coerce_pk(pk, "hello-world") {

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -477,6 +477,7 @@ mod tests {
             proxy: false,
             get_latest_by: None,
             extra_permissions: &[],
+            global_scopes: &[],
         };
         &MS
     }

--- a/crates/rustango/tests/model_global_scope_sqlite_live.rs
+++ b/crates/rustango/tests/model_global_scope_sqlite_live.rs
@@ -1,0 +1,225 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite tests for Eloquent-shape **global scopes** —
+//! auto-applied query filters declared via
+//! `#[rustango(global_scope(name = "...", apply = path::to::fn))]`
+//! on the model struct.
+//!
+//! Closes issue [#820](https://github.com/ujeenet/rustango/issues/820).
+//!
+//! The substrate covers:
+//!
+//! 1. **Auto-application** — every QuerySet built via `Post::objects()`
+//!    / `Post::all(&pool)` carries the scope's WHERE without the
+//!    caller chaining `.filter(...)` explicitly.
+//! 2. **Per-name opt-out** — `qs.without_global_scope("active")`
+//!    suppresses one scope; other scopes (if any) keep applying.
+//! 3. **Wholesale opt-out** — `qs.without_global_scopes()` returns the
+//!    same WHERE you'd get on a model with no scopes declared.
+//! 4. **Apply across query verbs** — SELECT (`fetch_pool` /
+//!    `Model::all`) and aggregate (`count_pool` / `Model::count`) both
+//!    fold the scope in. DELETE is exercised via the free
+//!    `rustango::sql::delete_pool` to prove `compile_delete()` honors
+//!    the scope too.
+//! 5. **Composition with user filters** — `qs.filter(...)` on top of a
+//!    scoped queryset AND-composes; no scope is silently dropped.
+
+use rustango::core::{Filter, Op, SqlValue, WhereExpr};
+use rustango::sql::{delete_pool, sqlx, Auto, CounterPool as _, FetcherPool as _, Pool};
+use rustango::Model;
+
+/// The scope's filter constructor — referenced from the model's
+/// `#[rustango(global_scope(... apply = active_only))]` attribute.
+/// Returns `is_active = true` so every queryset for `Post` is
+/// implicitly `Post::objects().filter(is_active = true)`.
+fn active_only() -> WhereExpr {
+    WhereExpr::Predicate(Filter {
+        column: "is_active",
+        op: Op::Eq,
+        value: SqlValue::Bool(true),
+    })
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gs_post", global_scope(name = "active", apply = active_only))]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub is_active: bool,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE gs_post (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            title     TEXT NOT NULL,
+            is_active INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn seed(pool: &Pool) {
+    for (t, active) in [
+        ("alpha", true),
+        ("beta", false),
+        ("gamma", true),
+        ("delta", false),
+        ("epsilon", true),
+    ] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: t.into(),
+            is_active: active,
+        };
+        p.save_pool(pool).await.unwrap();
+    }
+}
+
+#[test]
+fn schema_carries_one_global_scope() {
+    use rustango::core::Model as _;
+    let scopes = Post::SCHEMA.global_scopes;
+    assert_eq!(scopes.len(), 1);
+    assert_eq!(scopes[0].name, "active");
+    // The fn pointer round-trips through the schema — invoking it
+    // returns the same WHERE we'd build by hand.
+    let expr = (scopes[0].apply)();
+    match expr {
+        WhereExpr::Predicate(f) => {
+            assert_eq!(f.column, "is_active");
+            assert_eq!(f.op, Op::Eq);
+            assert_eq!(f.value, SqlValue::Bool(true));
+        }
+        _ => panic!("expected Predicate, got {expr:?}"),
+    }
+}
+
+#[tokio::test]
+async fn default_queryset_hides_inactive_rows() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    // `Post::all(&pool)` is the macro-emitted shortcut over
+    // `Post::objects().fetch_pool(&pool)` — the scope should fold in
+    // here just as in the explicit chain.
+    let visible = Post::all(&pool).await.unwrap();
+    assert_eq!(visible.len(), 3, "scope must filter to active rows only");
+    for row in &visible {
+        assert!(row.is_active);
+    }
+}
+
+#[tokio::test]
+async fn without_global_scope_by_name_sees_every_row() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let all = Post::objects()
+        .without_global_scope("active")
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 5);
+}
+
+#[tokio::test]
+async fn without_global_scopes_sees_every_row() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let all = Post::objects()
+        .without_global_scopes()
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 5);
+}
+
+#[tokio::test]
+async fn unknown_scope_name_is_silently_ignored() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    // `nope` doesn't exist on the model — Eloquent silently ignores
+    // unknown scope names; rustango matches that to keep call sites
+    // robust against scope renames.
+    let visible = Post::objects()
+        .without_global_scope("nope")
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(visible.len(), 3);
+}
+
+#[tokio::test]
+async fn count_pool_honors_global_scope() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let active_count = Post::count(&pool).await.unwrap();
+    assert_eq!(active_count, 3);
+
+    let total = Post::objects()
+        .without_global_scopes()
+        .count_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(total, 5);
+}
+
+#[tokio::test]
+async fn user_filters_compose_with_global_scope() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    // Scoped + user filter — only matches `alpha` since it's the only
+    // active row whose title equals "alpha".
+    let rows = Post::objects()
+        .filter("title", "alpha")
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].title, "alpha");
+
+    // Filter targeting an inactive row — scoped queryset MUST return
+    // empty (scope hides it); unscoped MUST find it.
+    let beta_scoped = Post::objects()
+        .filter("title", "beta")
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert!(beta_scoped.is_empty(), "scope must hide inactive `beta`");
+    let beta_unscoped = Post::objects()
+        .without_global_scopes()
+        .filter("title", "beta")
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(beta_unscoped.len(), 1);
+}
+
+#[tokio::test]
+async fn compile_delete_honors_global_scope() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    // Wholesale delete via the scoped queryset must only remove the
+    // active rows. The two inactive rows survive — proves the scope
+    // folds into the WHERE on `compile_delete()` not just SELECT.
+    let query = Post::objects().compile_delete().unwrap();
+    let removed = delete_pool(&pool, &query).await.unwrap();
+    assert_eq!(removed, 3, "delete must respect the global scope");
+
+    let survivors = Post::objects()
+        .without_global_scopes()
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(survivors.len(), 2);
+    for s in &survivors {
+        assert!(!s.is_active);
+    }
+}


### PR DESCRIPTION
Closes #820. Substrate for soft-delete auto-hiding, tenant isolation, "published only" lenses.

## Surface

\`\`\`rust
fn active_only() -> WhereExpr {
    WhereExpr::Predicate(Filter {
        column: "is_active",
        op: Op::Eq,
        value: SqlValue::Bool(true),
    })
}

#[derive(Model)]
#[rustango(table = "post",
           global_scope(name = "active", apply = active_only))]
struct Post { ... }

// Auto-applied:
Post::objects().fetch_pool(&pool)
// → SELECT … FROM post WHERE is_active = true

// Per-name opt-out (Eloquent withoutGlobalScope):
Post::objects().without_global_scope("active").fetch_pool(&pool)

// Wholesale opt-out (Eloquent withoutGlobalScopes):
Post::objects().without_global_scopes().fetch_pool(&pool)
\`\`\`

Repeated \`#[rustango(global_scope(...))]\` attributes accumulate; duplicate names are rejected at macro-parse time so the \`without_global_scope("name")\` escape hatch is never ambiguous.

## Coverage

Scopes fold in at **every compile entry**: SELECT (\`fetch_pool\` / \`Model::all\`), DELETE (\`compile_delete()\`), aggregate (\`count_pool\` / \`Model::count\`), UPDATE (\`UpdateBuilder\`). Values / values_list / values_list_flat / dates / datetimes inherit via their delegating \`compile()\` impls.

## Scope of this PR

- ✅ Declarative \`global_scope(name, apply)\` attribute
- ✅ Auto-application at every compile entry point
- ✅ \`without_global_scope(name)\` / \`without_global_scopes()\` escape hatches
- ✅ Tri-dialect (pure WHERE composition; SQLite live tests prove + lib tests cover the macro emit)
- ❌ Runtime \`addGlobalScope\` (out of scope — declarative-first)
- ❌ Migrating soft-delete / tenant filters onto this substrate (separate sequencing item)

## Tests

\`tests/model_global_scope_sqlite_live.rs\` — 8 tests:
- Schema round-trip (fn-pointer survives macro emit)
- Default queryset filters via \`Model::all(&pool)\`
- \`without_global_scope(name)\` exposes full table
- \`without_global_scopes()\` exposes full table
- Unknown scope names silently ignored (Eloquent parity)
- \`count_pool\` honors scope
- User filters AND-compose
- \`compile_delete()\` honors scope (no escape via DELETE)

## Verification

- \`cargo test -p rustango --lib --all-features\` → **3408 / 3408**
- \`cargo test -p rustango --test model_global_scope_sqlite_live --features sqlite\` → **8 / 8**
- \`cargo build -p rustango --no-default-features --features sqlite,tenancy\` (litmus) → ✅
- \`cargo check --workspace --all-features\` → ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)