### PR TITLE
feat(orm): hasManyThrough — `#[rustango(through(...))]` accessor — closes #817

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -891,6 +891,8 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         container.default_related_name.as_deref(),
     );
     let m2m_accessors = m2m_accessor_tokens(struct_name, &container.m2m);
+    // Issue #817 — `#[rustango(through(...))]` accessors.
+    let through_accessors = through_accessor_tokens(struct_name, &container.through_relations);
     let generic_fk_accessors = generic_fk_accessor_tokens(
         struct_name,
         &container.generic_fks,
@@ -922,6 +924,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         #column_module
         #reverse_helpers
         #m2m_accessors
+        #through_accessors
         #generic_fk_accessors
         #manager_trait
 
@@ -1467,6 +1470,84 @@ fn m2m_accessor_tokens(struct_name: &syn::Ident, m2m_relations: &[M2MAttr]) -> T
                     src_col: #src_col,
                     dst_col: #dst_col,
                 }
+            }
+        }
+    });
+    quote! {
+        impl #struct_name {
+            #( #methods )*
+        }
+    }
+}
+
+/// Emit `<name>_through(&self) -> QuerySet<Far>` accessors for each
+/// `#[rustango(through(...))]` attribute. Issue #817.
+///
+/// Each accessor builds a correlated subquery via
+/// `WhereExpr::InSubquery`: the inner `SelectQuery` reads from the
+/// intermediate table, filters on the FK column pointing at this
+/// model, and projects the intermediate PK. The outer queryset
+/// filters the far model by its FK-to-intermediate column being in
+/// that set.
+///
+/// The returned `QuerySet<Far>` is **chainable** — the subquery
+/// lives inside a `where_raw` clause so the user's later
+/// `.filter()` / `.order_by()` / `.limit()` compositions don't
+/// disturb it.
+///
+/// Tri-dialect: `IN (subquery)` is portable across PG / MySQL /
+/// SQLite — no LATERAL or backend-specific syntax involved.
+fn through_accessor_tokens(
+    struct_name: &syn::Ident,
+    through_relations: &[ThroughAttr],
+) -> TokenStream2 {
+    let root = rustango_root();
+    if through_relations.is_empty() {
+        return TokenStream2::new();
+    }
+    let methods = through_relations.iter().map(|rel| {
+        let method_name = format!("{}_through", rel.name);
+        let method_ident = syn::Ident::new(&method_name, struct_name.span());
+        let far = &rel.far;
+        let intermediate = &rel.intermediate;
+        let far_fk_column = rel.far_fk_column.as_str();
+        let intermediate_fk_column = rel.intermediate_fk_column.as_str();
+        let intermediate_pk_column = rel.intermediate_pk_column.as_str();
+        let doc = format!(
+            "Eloquent `hasManyThrough` accessor — returns a \
+             `QuerySet<{far}>` whose rows reach this `{struct_name}` \
+             instance through the intermediate `{intermediate}` table. \
+             Generated SQL shape: \
+             `… WHERE {far_fk_column} IN (SELECT \
+             {intermediate_pk_column} FROM <{intermediate}> WHERE \
+             {intermediate_fk_column} = self.pk)`. Chainable like any \
+             other QuerySet — compose `.filter()` / `.order_by()` / \
+             `.limit()` etc. on top.",
+        );
+        quote! {
+            #[doc = #doc]
+            pub fn #method_ident(&self) -> #root::query::QuerySet<#far> {
+                use #root::core::{Filter, Model as _, Op, SelectQuery, WhereExpr};
+                let intermediate_schema =
+                    <#intermediate as #root::core::Model>::SCHEMA;
+                let sub = SelectQuery {
+                    where_clause: WhereExpr::Predicate(Filter {
+                        column: #intermediate_fk_column,
+                        op: Op::Eq,
+                        value: self.__rustango_pk_value(),
+                    }),
+                    projection: ::core::option::Option::Some(
+                        ::std::vec![#intermediate_pk_column],
+                    ),
+                    ..SelectQuery::new(intermediate_schema)
+                };
+                #root::query::QuerySet::<#far>::new().where_raw(
+                    WhereExpr::InSubquery {
+                        column: #far_fk_column,
+                        negated: false,
+                        subquery: ::std::boxed::Box::new(sub),
+                    },
+                )
             }
         }
     });
@@ -6944,6 +7025,15 @@ struct ContainerAttrs {
     /// `fn() -> WhereExpr` path that the macro emits into
     /// `ModelSchema::global_scopes`. Multiple attributes accumulate.
     global_scopes: Vec<GlobalScopeAttr>,
+    /// Eloquent `hasManyThrough` / `hasOneThrough` declarations from
+    /// `#[rustango(through(name, far, far_fk_column, intermediate,
+    /// intermediate_fk_column, intermediate_pk_column))]` — issue
+    /// [#817](https://github.com/ujeenet/rustango/issues/817). Each
+    /// entry emits an inherent `<name>_through(&self)` accessor that
+    /// returns a `QuerySet<Far>` filtered via a correlated subquery
+    /// (`WHERE far_fk_column IN (SELECT intermediate_pk_column FROM
+    /// intermediate WHERE intermediate_fk_column = <my_pk>)`).
+    through_relations: Vec<ThroughAttr>,
 }
 
 /// Parsed `#[rustango(global_scope(name = "...", apply = fn_path))]`
@@ -6954,6 +7044,63 @@ struct ContainerAttrs {
 struct GlobalScopeAttr {
     name: String,
     apply: syn::Path,
+}
+
+/// Parsed `#[rustango(through(...))]` declaration. Issue
+/// [#817](https://github.com/ujeenet/rustango/issues/817) — Eloquent
+/// `hasManyThrough` / `hasOneThrough` parity.
+///
+/// `Country hasManyThrough Post via User` declares as:
+///
+/// ```ignore
+/// #[rustango(through(
+///     name                   = "posts",
+///     far                    = "Post",
+///     far_fk_column          = "author_id",
+///     intermediate           = "User",
+///     intermediate_fk_column = "country_id",
+/// ))]
+/// struct Country { ... }
+/// ```
+///
+/// The macro emits `Country::posts_through(&self) -> QuerySet<Post>`
+/// which returns a queryset filtered via a correlated subquery —
+/// `Post WHERE author_id IN (SELECT id FROM tr_user WHERE country_id
+/// = <my_pk>)`. The returned `QuerySet<Post>` is **chainable**:
+/// `.filter()` / `.order_by()` / `.limit()` etc. compose normally
+/// because the subquery lives inside a `WhereExpr::InSubquery` node
+/// and the outer queryset's pending list stays empty.
+///
+/// All four required arguments use **SQL column / table names**
+/// (not Rust field names) to sidestep the multi-hop-filter substrate
+/// gap. Once that substrate lands, a higher-level Rust-field-name
+/// shorthand can be added without breaking this surface.
+struct ThroughAttr {
+    /// Accessor method name. `name = "posts"` → emits `posts_through()`.
+    name: String,
+    /// Far model type identifier. `far = "Post"` → returns
+    /// `QuerySet<Post>`. Resolved verbatim against the scope where
+    /// the derive expands.
+    far: syn::Ident,
+    /// SQL column on the far model's table that references the
+    /// intermediate model's primary key. For `Post`'s
+    /// `author: ForeignKey<User>` the column is `"author_id"` (rustango's
+    /// default `<field>_id` convention) or whatever the user
+    /// declared via `#[rustango(db_column = "...")]`.
+    far_fk_column: String,
+    /// Intermediate model type identifier. Needed to look up its
+    /// `SCHEMA` so the subquery's `FROM` clause points at the
+    /// intermediate table. `intermediate = "User"`.
+    intermediate: syn::Ident,
+    /// SQL column on the intermediate's table that references the
+    /// source (this) model's primary key. For `User`'s
+    /// `country: ForeignKey<Country>` the column is `"country_id"`.
+    intermediate_fk_column: String,
+    /// SQL primary-key column on the intermediate's table — the
+    /// column the subquery projects. Optional; defaults to `"id"`
+    /// (rustango's default PK column name). Override when the
+    /// intermediate declares a custom PK column.
+    intermediate_pk_column: String,
 }
 
 /// Parsed form of one index declaration (field-level or container-level).
@@ -7171,6 +7318,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
         extra_permissions: Vec::new(),
         default_permissions: Vec::new(),
         global_scopes: Vec::new(),
+        through_relations: Vec::new(),
     };
     for attr in &input.attrs {
         if !attr.path().is_ident("rustango") {
@@ -7492,6 +7640,142 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     ));
                 }
                 out.global_scopes.push(GlobalScopeAttr { name, apply });
+                return Ok(());
+            }
+            if meta.path.is_ident("through") {
+                // `#[rustango(through(name = "posts", far = "Post",
+                //  far_fk_column = "author_id", intermediate = "User",
+                //  intermediate_fk_column = "country_id"
+                //  [, intermediate_pk_column = "id"]))]` — issue #817.
+                let span = meta.path.span();
+                let mut accessor_name: Option<String> = None;
+                let mut far_ident: Option<syn::Ident> = None;
+                let mut far_fk_column: Option<String> = None;
+                let mut intermediate_ident: Option<syn::Ident> = None;
+                let mut intermediate_fk_column: Option<String> = None;
+                let mut intermediate_pk_column: Option<String> = None;
+                fn parse_nonempty_string(
+                    inner: &syn::meta::ParseNestedMeta<'_>,
+                    field: &str,
+                ) -> syn::Result<String> {
+                    let s: LitStr = inner.value()?.parse()?;
+                    let raw = s.value();
+                    let trimmed = raw.trim();
+                    if trimmed.is_empty() {
+                        return Err(syn::Error::new(
+                            s.span(),
+                            format!("`through({field} = \"...\")` must not be empty"),
+                        ));
+                    }
+                    Ok(trimmed.to_owned())
+                }
+                meta.parse_nested_meta(|inner| {
+                    if inner.path.is_ident("name") {
+                        accessor_name = Some(parse_nonempty_string(&inner, "name")?);
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("far") {
+                        // Far model name accepted as a string literal
+                        // so the attribute fits inside the existing
+                        // `parse_nested_meta` shape; parsed back into a
+                        // `syn::Ident` so the emitted accessor can
+                        // reference the type directly.
+                        let s: LitStr = inner.value()?.parse()?;
+                        let raw = s.value();
+                        let trimmed = raw.trim();
+                        if trimmed.is_empty() {
+                            return Err(syn::Error::new(
+                                s.span(),
+                                "`through(far = \"...\")` must not be empty",
+                            ));
+                        }
+                        far_ident = Some(syn::Ident::new(trimmed, s.span()));
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("far_fk_column") {
+                        far_fk_column =
+                            Some(parse_nonempty_string(&inner, "far_fk_column")?);
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("intermediate") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        let raw = s.value();
+                        let trimmed = raw.trim();
+                        if trimmed.is_empty() {
+                            return Err(syn::Error::new(
+                                s.span(),
+                                "`through(intermediate = \"...\")` must not be empty",
+                            ));
+                        }
+                        intermediate_ident = Some(syn::Ident::new(trimmed, s.span()));
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("intermediate_fk_column") {
+                        intermediate_fk_column =
+                            Some(parse_nonempty_string(&inner, "intermediate_fk_column")?);
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("intermediate_pk_column") {
+                        intermediate_pk_column =
+                            Some(parse_nonempty_string(&inner, "intermediate_pk_column")?);
+                        return Ok(());
+                    }
+                    Err(inner.error(
+                        "unknown `through` attribute (supported: \
+                         `name`, `far`, `far_fk_column`, \
+                         `intermediate`, `intermediate_fk_column`, \
+                         `intermediate_pk_column`)",
+                    ))
+                })?;
+                let Some(name) = accessor_name else {
+                    return Err(syn::Error::new(
+                        span,
+                        "`through` requires `name = \"...\"`",
+                    ));
+                };
+                let Some(far) = far_ident else {
+                    return Err(syn::Error::new(
+                        span,
+                        "`through` requires `far = \"FarModelType\"`",
+                    ));
+                };
+                let Some(far_fk_column) = far_fk_column else {
+                    return Err(syn::Error::new(
+                        span,
+                        "`through` requires `far_fk_column = \"<column>\"`",
+                    ));
+                };
+                let Some(intermediate) = intermediate_ident else {
+                    return Err(syn::Error::new(
+                        span,
+                        "`through` requires `intermediate = \"IntermediateModelType\"`",
+                    ));
+                };
+                let Some(intermediate_fk_column) = intermediate_fk_column else {
+                    return Err(syn::Error::new(
+                        span,
+                        "`through` requires `intermediate_fk_column = \"<column>\"`",
+                    ));
+                };
+                let intermediate_pk_column =
+                    intermediate_pk_column.unwrap_or_else(|| "id".to_owned());
+                if out.through_relations.iter().any(|t| t.name == name) {
+                    return Err(syn::Error::new(
+                        span,
+                        format!(
+                            "duplicate `through(name = \"{name}\")` — \
+                             pick a unique accessor name"
+                        ),
+                    ));
+                }
+                out.through_relations.push(ThroughAttr {
+                    name,
+                    far,
+                    far_fk_column,
+                    intermediate,
+                    intermediate_fk_column,
+                    intermediate_pk_column,
+                });
                 return Ok(());
             }
             if meta.path.is_ident("audit") {

--- a/crates/rustango/tests/model_through_relation_sqlite_live.rs
+++ b/crates/rustango/tests/model_through_relation_sqlite_live.rs
@@ -1,0 +1,227 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite tests for the Eloquent `hasManyThrough` /
+//! `hasOneThrough` accessor — closes issue
+//! [#817](https://github.com/ujeenet/rustango/issues/817).
+//!
+//! Canonical example from the Eloquent docs (`Country hasMany Posts
+//! through Users`):
+//!
+//! ```ignore
+//! Country ──< User ──< Post
+//! ```
+//!
+//! The `Country` model declares the through relation:
+//!
+//! ```ignore
+//! #[rustango(through(
+//!     name = "posts",
+//!     far = "Post",
+//!     far_fk_column = "author_id",
+//!     intermediate = "User",
+//!     intermediate_fk_column = "country_id",
+//! ))]
+//! ```
+//!
+//! and gets a `country.posts_through()` accessor returning a
+//! `QuerySet<Post>` filtered via the correlated subquery
+//! `WHERE author_id IN (SELECT id FROM tr_user WHERE country_id = ?)`.
+//! The accessor is chainable — additional filters, ordering, and
+//! limits compose normally on top of the through-clause.
+
+use rustango::sql::{sqlx, Auto, FetcherPool as _, ForeignKey, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "tr_country",
+    through(
+        name = "posts",
+        far = "Post",
+        far_fk_column = "author_id",
+        intermediate = "User",
+        intermediate_fk_column = "country_id",
+    )
+)]
+#[allow(dead_code)]
+pub struct Country {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub name: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "tr_user")]
+#[allow(dead_code)]
+pub struct User {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub name: String,
+    pub country_id: ForeignKey<Country, i64>,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "tr_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 120)]
+    pub title: String,
+    pub author_id: ForeignKey<User, i64>,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE tr_country (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE TABLE tr_user (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            name       TEXT NOT NULL,
+            country_id INTEGER NOT NULL REFERENCES tr_country(id)
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE TABLE tr_post (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            title     TEXT NOT NULL,
+            author_id INTEGER NOT NULL REFERENCES tr_user(id)
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+/// Seed two countries with their own user-tree. Returns the two
+/// country IDs.
+async fn seed(pool: &Pool) -> (i64, i64) {
+    let mut a = Country {
+        id: Auto::default(),
+        name: "Atlantis".into(),
+    };
+    a.save_pool(pool).await.unwrap();
+    let a_id = a.id.get().copied().unwrap();
+    let mut b = Country {
+        id: Auto::default(),
+        name: "Brookland".into(),
+    };
+    b.save_pool(pool).await.unwrap();
+    let b_id = b.id.get().copied().unwrap();
+
+    for (country_id, names) in [
+        (a_id, ["alice", "andrew"].as_slice()),
+        (b_id, ["bob", "betty", "barry"].as_slice()),
+    ] {
+        for n in names.iter() {
+            let mut u = User {
+                id: Auto::default(),
+                name: (*n).into(),
+                country_id: ForeignKey::unloaded(country_id),
+            };
+            u.save_pool(pool).await.unwrap();
+            let user_id = u.id.get().copied().unwrap();
+            for i in 0..3 {
+                let mut p = Post {
+                    id: Auto::default(),
+                    title: format!("{n}-post-{i}"),
+                    author_id: ForeignKey::unloaded(user_id),
+                };
+                p.save_pool(pool).await.unwrap();
+            }
+        }
+    }
+    (a_id, b_id)
+}
+
+#[tokio::test]
+async fn posts_through_returns_only_far_model_rows_for_this_country() {
+    let pool = make_pool().await;
+    let (a_id, b_id) = seed(&pool).await;
+
+    let a = Country::find(a_id, &pool).await.unwrap().unwrap();
+    let posts = a.posts_through().fetch_pool(&pool).await.unwrap();
+    // Country A has 2 users × 3 posts each = 6 far-model rows.
+    assert_eq!(posts.len(), 6);
+    for p in &posts {
+        assert!(
+            p.title.starts_with("alice-") || p.title.starts_with("andrew-"),
+            "unexpected far-side title: {}",
+            p.title
+        );
+    }
+
+    let b = Country::find(b_id, &pool).await.unwrap().unwrap();
+    let posts_b = b.posts_through().fetch_pool(&pool).await.unwrap();
+    // Country B has 3 users × 3 posts each = 9.
+    assert_eq!(posts_b.len(), 9);
+    for p in &posts_b {
+        assert!(
+            p.title.starts_with("bob-")
+                || p.title.starts_with("betty-")
+                || p.title.starts_with("barry-"),
+            "unexpected far-side title: {}",
+            p.title
+        );
+    }
+}
+
+#[tokio::test]
+async fn through_accessor_is_chainable_with_filter_and_limit() {
+    let pool = make_pool().await;
+    let (a_id, _) = seed(&pool).await;
+    let a = Country::find(a_id, &pool).await.unwrap().unwrap();
+
+    // Compose .filter() on top of the through accessor — narrows
+    // the 6 country-A posts down to the ones whose title begins
+    // with "alice-".
+    let alice_posts = a
+        .posts_through()
+        .filter("title__startswith", "alice-")
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(alice_posts.len(), 3);
+    for p in &alice_posts {
+        assert!(p.title.starts_with("alice-"));
+    }
+
+    // Compose .order_by() + .limit() — proves the InSubquery WHERE
+    // sits alongside an outer ORDER BY + LIMIT correctly.
+    let first_two = a
+        .posts_through()
+        .order_by(&[("id", false)])
+        .limit(2)
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(first_two.len(), 2);
+}
+
+#[tokio::test]
+async fn through_accessor_returns_empty_for_country_with_no_users() {
+    let pool = make_pool().await;
+    // Insert a country with no users → 0 far-side rows.
+    let mut empty = Country {
+        id: Auto::default(),
+        name: "Empty".into(),
+    };
+    empty.save_pool(&pool).await.unwrap();
+    let posts = empty.posts_through().fetch_pool(&pool).await.unwrap();
+    assert!(posts.is_empty());
+}


### PR DESCRIPTION
Closes #817. Eloquent \`hasManyThrough\` / \`hasOneThrough\` parity.

## Surface

\`\`\`rust
#[derive(Model)]
#[rustango(
    table = "country",
    through(
        name                   = "posts",
        far                    = "Post",
        far_fk_column          = "author_id",
        intermediate           = "User",
        intermediate_fk_column = "country_id",
    ),
)]
struct Country { … }

// Direct fetch:
let posts: Vec<Post> = country.posts_through().fetch_pool(&pool).await?;

// Chainable like any other QuerySet:
country.posts_through()
    .filter("title__startswith", "alice-")
    .order_by(&[("id", false)])
    .limit(10)
    .fetch_pool(&pool).await?;
\`\`\`

## SQL shape

\`\`\`sql
SELECT post.* FROM post
WHERE author_id IN (
    SELECT id FROM tr_user WHERE country_id = ?
)
\`\`\`

Built via \`WhereExpr::InSubquery\` (shipped under #79). The outer \`QuerySet<Post>\` wraps the InSubquery in a \`where_raw\` clause so user filters, ordering, and limits compose naturally on top.

## Why SQL column names, not Rust field names

Rustango's single-hop filter resolver doesn't yet support multi-hop relation paths (\`.filter("author__country", v)\` — a separate substrate gap orthogonal to this issue). Using SQL identifiers directly sidesteps the gap and keeps the surface forward-compatible: a higher-level Rust-field-name shorthand can be added later without breaking this surface.

## Tri-dialect

\`IN (subquery)\` is portable across PG / MySQL / SQLite — no LATERAL or backend-specific syntax. Live tests cover sqlite; the same SQL emits cleanly on PG/MySQL via the shared writer.

## Tests

\`tests/model_through_relation_sqlite_live.rs\` — 3 tests:
- Canonical Country → User → Post traversal returns only reachable far-model rows
- \`.posts_through().filter(...).order_by(...).limit(...)\` chains preserve the through-clause
- Empty case: country with no users returns 0 far-side rows

## Verification

- \`cargo test -p rustango --lib --all-features\` → **3422 / 3422** ✅
- \`cargo test -p rustango --test model_through_relation_sqlite_live --features sqlite\` → **3 / 3** ✅
- \`cargo build -p rustango --no-default-features --features sqlite,tenancy\` (litmus) → ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)