### PR TITLE
feat(orm): reverse_has — `<name>_exists_expr()` / `<name>_not_exists_expr()` for Eloquent whereHas — addresses #830 (FK-reverse subset)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -893,6 +893,9 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let m2m_accessors = m2m_accessor_tokens(struct_name, &container.m2m);
     // Issue #817 — `#[rustango(through(...))]` accessors.
     let through_accessors = through_accessor_tokens(struct_name, &container.through_relations);
+    // Issue #830 — `#[rustango(reverse_has(...))]` static accessors.
+    let reverse_has_accessors =
+        reverse_has_accessor_tokens(struct_name, &container.reverse_has_relations);
     let generic_fk_accessors = generic_fk_accessor_tokens(
         struct_name,
         &container.generic_fks,
@@ -925,6 +928,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         #reverse_helpers
         #m2m_accessors
         #through_accessors
+        #reverse_has_accessors
         #generic_fk_accessors
         #manager_trait
 
@@ -1470,6 +1474,97 @@ fn m2m_accessor_tokens(struct_name: &syn::Ident, m2m_relations: &[M2MAttr]) -> T
                     src_col: #src_col,
                     dst_col: #dst_col,
                 }
+            }
+        }
+    });
+    quote! {
+        impl #struct_name {
+            #( #methods )*
+        }
+    }
+}
+
+/// Emit `<name>_exists_expr()` + `<name>_not_exists_expr()`
+/// associated functions for each `#[rustango(reverse_has(...))]`
+/// attribute. Issue #830.
+///
+/// The two emitted functions return ready-to-use `WhereExpr` nodes
+/// that downstream callers drop into
+/// `QuerySet::<Self>::where_raw(...)`:
+///
+/// - `<name>_exists_expr()` → `EXISTS (SELECT 1 FROM <child> WHERE
+///   <child_fk_column> = OuterRef("<self_pk_column>"))`. Eloquent
+///   `whereHas` parity (without the closure-style sub-predicate
+///   refinement — that's a follow-up; users can layer additional
+///   predicates by constructing the SelectQuery themselves and
+///   calling `where_raw(exists(query))` from `crate::core::subquery`).
+/// - `<name>_not_exists_expr()` → same but `NOT EXISTS`. Eloquent
+///   `whereDoesntHave` parity.
+///
+/// Tri-dialect: `EXISTS` / `NOT EXISTS` over a correlated subquery
+/// is portable across PG / MySQL / SQLite. The writer's scope-stack
+/// machinery threads the outer-table reference through automatically
+/// (`OuterRef(col)` resolves to `<outer>.<col>` at emit time).
+fn reverse_has_accessor_tokens(
+    struct_name: &syn::Ident,
+    reverse_has_relations: &[ReverseHasAttr],
+) -> TokenStream2 {
+    let root = rustango_root();
+    if reverse_has_relations.is_empty() {
+        return TokenStream2::new();
+    }
+    let methods = reverse_has_relations.iter().map(|rel| {
+        let exists_name = format!("{}_exists_expr", rel.name);
+        let not_exists_name = format!("{}_not_exists_expr", rel.name);
+        let exists_ident = syn::Ident::new(&exists_name, struct_name.span());
+        let not_exists_ident = syn::Ident::new(&not_exists_name, struct_name.span());
+        let child = &rel.child;
+        let child_fk_column = rel.child_fk_column.as_str();
+        let self_pk_column = rel.self_pk_column.as_str();
+        let exists_doc = format!(
+            "Eloquent `whereHas` analog — yields `EXISTS (SELECT 1 \
+             FROM <{child}> WHERE {child_fk_column} = <outer>.{self_pk_column})`. \
+             Drop into `QuerySet::<{struct_name}>::where_raw(...)` to \
+             filter to {struct_name}s with at least one matching child.",
+        );
+        let not_exists_doc = format!(
+            "Eloquent `whereDoesntHave` analog — yields `NOT EXISTS \
+             (SELECT 1 FROM <{child}> WHERE {child_fk_column} = \
+             <outer>.{self_pk_column})`. Drop into \
+             `QuerySet::<{struct_name}>::where_raw(...)` to filter to \
+             {struct_name}s with **no** matching child.",
+        );
+        quote! {
+            #[doc = #exists_doc]
+            pub fn #exists_ident() -> #root::core::WhereExpr {
+                use #root::core::{Expr, Model as _, Op, SelectQuery, WhereExpr};
+                let child_schema =
+                    <#child as #root::core::Model>::SCHEMA;
+                let inner = SelectQuery {
+                    where_clause: WhereExpr::ExprCompare {
+                        lhs: Expr::Column(#child_fk_column),
+                        op: Op::Eq,
+                        rhs: Expr::OuterRef(#self_pk_column),
+                    },
+                    ..SelectQuery::new(child_schema)
+                };
+                WhereExpr::Exists(::std::boxed::Box::new(inner))
+            }
+
+            #[doc = #not_exists_doc]
+            pub fn #not_exists_ident() -> #root::core::WhereExpr {
+                use #root::core::{Expr, Model as _, Op, SelectQuery, WhereExpr};
+                let child_schema =
+                    <#child as #root::core::Model>::SCHEMA;
+                let inner = SelectQuery {
+                    where_clause: WhereExpr::ExprCompare {
+                        lhs: Expr::Column(#child_fk_column),
+                        op: Op::Eq,
+                        rhs: Expr::OuterRef(#self_pk_column),
+                    },
+                    ..SelectQuery::new(child_schema)
+                };
+                WhereExpr::NotExists(::std::boxed::Box::new(inner))
             }
         }
     });
@@ -7034,6 +7129,15 @@ struct ContainerAttrs {
     /// (`WHERE far_fk_column IN (SELECT intermediate_pk_column FROM
     /// intermediate WHERE intermediate_fk_column = <my_pk>)`).
     through_relations: Vec<ThroughAttr>,
+    /// Eloquent `whereHas` / `whereDoesntHave` declarations from
+    /// `#[rustango(reverse_has(name, child, child_fk_column))]` —
+    /// issue [#830](https://github.com/ujeenet/rustango/issues/830).
+    /// Each entry emits two associated functions on the parent —
+    /// `<name>_exists_expr()` and `<name>_not_exists_expr()` —
+    /// returning a `WhereExpr::Exists` / `WhereExpr::NotExists`
+    /// over a correlated subquery against the child table. Users
+    /// drop the result into `QuerySet::where_raw(...)`.
+    reverse_has_relations: Vec<ReverseHasAttr>,
 }
 
 /// Parsed `#[rustango(global_scope(name = "...", apply = fn_path))]`
@@ -7101,6 +7205,62 @@ struct ThroughAttr {
     /// (rustango's default PK column name). Override when the
     /// intermediate declares a custom PK column.
     intermediate_pk_column: String,
+}
+
+/// Parsed `#[rustango(reverse_has(name = "...", child = "...",
+/// child_fk_column = "..."))]` declaration. Issue
+/// [#830](https://github.com/ujeenet/rustango/issues/830) — Eloquent
+/// `whereHas` / `whereDoesntHave` parity.
+///
+/// `Post hasMany Comment` declares as:
+///
+/// ```ignore
+/// #[rustango(reverse_has(
+///     name             = "comments",
+///     child            = "Comment",
+///     child_fk_column  = "post_id",
+/// ))]
+/// struct Post { ... }
+/// ```
+///
+/// The macro emits two associated functions on `Post`:
+///
+/// - `Post::comments_exists_expr() -> WhereExpr` — yields
+///   `EXISTS (SELECT … FROM comment WHERE comment.post_id =
+///   <outer>.<self_pk_column>)`.
+/// - `Post::comments_not_exists_expr() -> WhereExpr` — same shape
+///   but `NOT EXISTS`, the `whereDoesntHave` analog.
+///
+/// User code:
+///
+/// ```ignore
+/// // Posts with at least one comment:
+/// Post::objects().where_raw(Post::comments_exists_expr()).fetch_pool(&pool)
+/// // Posts with no comments:
+/// Post::objects().where_raw(Post::comments_not_exists_expr()).fetch_pool(&pool)
+/// ```
+///
+/// As with #817, all column / table identifiers are **SQL names**
+/// (not Rust field names) so the substrate is independent of the
+/// outstanding multi-hop filter resolver gap. The emitted
+/// `Expr::OuterRef("…")` resolves to the outer queryset's table at
+/// SQL-emit time via the writer's scope stack.
+struct ReverseHasAttr {
+    /// Accessor name. `name = "comments"` → emits
+    /// `comments_exists_expr()` + `comments_not_exists_expr()`.
+    name: String,
+    /// Child model type identifier. `child = "Comment"` — needed to
+    /// look up the child's `SCHEMA` so the subquery's `FROM` clause
+    /// points at the child table.
+    child: syn::Ident,
+    /// SQL column on the child's table that references this model's
+    /// primary key. For `Comment`'s `post: ForeignKey<Post>` the
+    /// column is `"post_id"`.
+    child_fk_column: String,
+    /// SQL primary-key column on **this** model's table — the column
+    /// the `OuterRef` resolves to. Optional; defaults to `"id"`
+    /// (rustango's default PK column name).
+    self_pk_column: String,
 }
 
 /// Parsed form of one index declaration (field-level or container-level).
@@ -7319,6 +7479,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
         default_permissions: Vec::new(),
         global_scopes: Vec::new(),
         through_relations: Vec::new(),
+        reverse_has_relations: Vec::new(),
     };
     for attr in &input.attrs {
         if !attr.path().is_ident("rustango") {
@@ -7775,6 +7936,109 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     intermediate,
                     intermediate_fk_column,
                     intermediate_pk_column,
+                });
+                return Ok(());
+            }
+            if meta.path.is_ident("reverse_has") {
+                // `#[rustango(reverse_has(name = "comments",
+                //  child = "Comment", child_fk_column = "post_id"
+                //  [, self_pk_column = "id"]))]` — issue #830.
+                let span = meta.path.span();
+                let mut accessor_name: Option<String> = None;
+                let mut child_ident: Option<syn::Ident> = None;
+                let mut child_fk_column: Option<String> = None;
+                let mut self_pk_column: Option<String> = None;
+                meta.parse_nested_meta(|inner| {
+                    if inner.path.is_ident("name") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        let raw = s.value();
+                        if raw.trim().is_empty() {
+                            return Err(syn::Error::new(
+                                s.span(),
+                                "`reverse_has(name = \"...\")` must not be empty",
+                            ));
+                        }
+                        accessor_name = Some(raw);
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("child") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        let raw = s.value();
+                        let trimmed = raw.trim();
+                        if trimmed.is_empty() {
+                            return Err(syn::Error::new(
+                                s.span(),
+                                "`reverse_has(child = \"...\")` must not be empty",
+                            ));
+                        }
+                        child_ident = Some(syn::Ident::new(trimmed, s.span()));
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("child_fk_column") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        let raw = s.value();
+                        let trimmed = raw.trim();
+                        if trimmed.is_empty() {
+                            return Err(syn::Error::new(
+                                s.span(),
+                                "`reverse_has(child_fk_column = \"...\")` must not be empty",
+                            ));
+                        }
+                        child_fk_column = Some(trimmed.to_owned());
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("self_pk_column") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        let raw = s.value();
+                        let trimmed = raw.trim();
+                        if trimmed.is_empty() {
+                            return Err(syn::Error::new(
+                                s.span(),
+                                "`reverse_has(self_pk_column = \"...\")` must not be empty",
+                            ));
+                        }
+                        self_pk_column = Some(trimmed.to_owned());
+                        return Ok(());
+                    }
+                    Err(inner.error(
+                        "unknown `reverse_has` attribute (supported: \
+                         `name`, `child`, `child_fk_column`, \
+                         `self_pk_column`)",
+                    ))
+                })?;
+                let Some(name) = accessor_name else {
+                    return Err(syn::Error::new(
+                        span,
+                        "`reverse_has` requires `name = \"...\"`",
+                    ));
+                };
+                let Some(child) = child_ident else {
+                    return Err(syn::Error::new(
+                        span,
+                        "`reverse_has` requires `child = \"ChildModelType\"`",
+                    ));
+                };
+                let Some(child_fk_column) = child_fk_column else {
+                    return Err(syn::Error::new(
+                        span,
+                        "`reverse_has` requires `child_fk_column = \"<column>\"`",
+                    ));
+                };
+                let self_pk_column = self_pk_column.unwrap_or_else(|| "id".to_owned());
+                if out.reverse_has_relations.iter().any(|r| r.name == name) {
+                    return Err(syn::Error::new(
+                        span,
+                        format!(
+                            "duplicate `reverse_has(name = \"{name}\")` — \
+                             pick a unique accessor name"
+                        ),
+                    ));
+                }
+                out.reverse_has_relations.push(ReverseHasAttr {
+                    name,
+                    child,
+                    child_fk_column,
+                    self_pk_column,
                 });
                 return Ok(());
             }

--- a/crates/rustango/tests/model_reverse_has_sqlite_live.rs
+++ b/crates/rustango/tests/model_reverse_has_sqlite_live.rs
@@ -1,0 +1,172 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite tests for the Eloquent `whereHas` / `whereDoesntHave`
+//! family — closes issue
+//! [#830](https://github.com/ujeenet/rustango/issues/830).
+//!
+//! `Post hasMany Comment` declared via `#[rustango(reverse_has(...))]`
+//! emits two associated functions on `Post`:
+//!
+//! - `Post::comments_exists_expr() -> WhereExpr` — yields the
+//!   correlated `EXISTS (SELECT 1 FROM comment WHERE comment.post_id
+//!   = post.id)` subquery for `whereHas`.
+//! - `Post::comments_not_exists_expr() -> WhereExpr` — same shape
+//!   but `NOT EXISTS`, the `whereDoesntHave` analog.
+//!
+//! Users drop the result into `QuerySet::where_raw(...)`:
+//!
+//! ```ignore
+//! Post::objects()
+//!     .where_raw(Post::comments_exists_expr())
+//!     .fetch_pool(&pool).await?;
+//! ```
+//!
+//! Tri-dialect: `EXISTS` is portable across PG / MySQL / SQLite —
+//! the IR + writer paths are shared.
+
+use rustango::sql::{sqlx, Auto, FetcherPool as _, ForeignKey, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "rh_post",
+    reverse_has(name = "comments", child = "Comment", child_fk_column = "post_id",)
+)]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 120)]
+    pub title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rh_comment")]
+#[allow(dead_code)]
+pub struct Comment {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub body: String,
+    pub post_id: ForeignKey<Post, i64>,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE rh_post (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE TABLE rh_comment (
+            id      INTEGER PRIMARY KEY AUTOINCREMENT,
+            body    TEXT NOT NULL,
+            post_id INTEGER NOT NULL REFERENCES rh_post(id)
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+/// Seed three posts. First two have comments; third is bare.
+async fn seed(pool: &Pool) -> (i64, i64, i64) {
+    let mut p1 = Post {
+        id: Auto::default(),
+        title: "Has comments".into(),
+    };
+    p1.save_pool(pool).await.unwrap();
+    let p1_id = p1.id.get().copied().unwrap();
+    let mut p2 = Post {
+        id: Auto::default(),
+        title: "Also has one".into(),
+    };
+    p2.save_pool(pool).await.unwrap();
+    let p2_id = p2.id.get().copied().unwrap();
+    let mut p3 = Post {
+        id: Auto::default(),
+        title: "Lonely post".into(),
+    };
+    p3.save_pool(pool).await.unwrap();
+    let p3_id = p3.id.get().copied().unwrap();
+
+    for (post_id, n) in [(p1_id, 3_i32), (p2_id, 1)] {
+        for i in 0..n {
+            let mut c = Comment {
+                id: Auto::default(),
+                body: format!("comment-{i}"),
+                post_id: ForeignKey::unloaded(post_id),
+            };
+            c.save_pool(pool).await.unwrap();
+        }
+    }
+    (p1_id, p2_id, p3_id)
+}
+
+#[tokio::test]
+async fn where_has_returns_only_posts_with_at_least_one_comment() {
+    let pool = make_pool().await;
+    let (p1_id, p2_id, _p3_id) = seed(&pool).await;
+
+    let mut posts = Post::objects()
+        .where_raw(Post::comments_exists_expr())
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    posts.sort_by_key(|p| p.id.get().copied().unwrap());
+
+    assert_eq!(posts.len(), 2);
+    let ids: Vec<i64> = posts.iter().map(|p| p.id.get().copied().unwrap()).collect();
+    assert_eq!(ids, vec![p1_id, p2_id]);
+}
+
+#[tokio::test]
+async fn where_doesnt_have_returns_only_posts_with_zero_comments() {
+    let pool = make_pool().await;
+    let (_, _, p3_id) = seed(&pool).await;
+
+    let posts = Post::objects()
+        .where_raw(Post::comments_not_exists_expr())
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(posts.len(), 1);
+    assert_eq!(posts[0].id.get().copied().unwrap(), p3_id);
+    assert_eq!(posts[0].title, "Lonely post");
+}
+
+#[tokio::test]
+async fn reverse_has_composes_with_user_filters() {
+    let pool = make_pool().await;
+    let _ = seed(&pool).await;
+
+    // Posts that have comments AND whose title starts with "Has".
+    // Only one post matches both: "Has comments".
+    let posts = Post::objects()
+        .where_raw(Post::comments_exists_expr())
+        .filter("title__startswith", "Has")
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(posts.len(), 1);
+    assert_eq!(posts[0].title, "Has comments");
+}
+
+#[tokio::test]
+async fn empty_child_table_returns_zero_via_where_has() {
+    let pool = make_pool().await;
+    // No seeding — comment table is empty so EXISTS never matches.
+    let posts = Post::objects()
+        .where_raw(Post::comments_exists_expr())
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert!(posts.is_empty());
+}


### PR DESCRIPTION
Addresses #830 — Eloquent \`whereHas\` / \`whereDoesntHave\` for the FK-reverse case.

## Surface

\`\`\`rust
#[derive(Model)]
#[rustango(
    table = "post",
    reverse_has(name = "comments", child = "Comment",
                child_fk_column = "post_id"),
)]
struct Post { … }

// whereHas:
Post::objects().where_raw(Post::comments_exists_expr()).fetch_pool(&pool).await?;

// whereDoesntHave:
Post::objects().where_raw(Post::comments_not_exists_expr()).fetch_pool(&pool).await?;
\`\`\`

## SQL shape

\`\`\`sql
SELECT post.* FROM post
WHERE EXISTS (SELECT 1 FROM rh_comment
              WHERE rh_comment.post_id = post.id)
\`\`\`

Uses \`WhereExpr::Exists\` + \`Expr::OuterRef\` (substrate from #5). The writer's scope-stack resolves \`OuterRef("id")\` to the outer queryset's table at SQL-emit time.

## Why static fns, not \`QuerySet::filter_has(name)\`?

The issue proposes a queryset method. Adding inherent methods to \`rustango::query::QuerySet<Self>\` from a downstream crate's macro expansion is blocked by Rust's orphan rule. A trait-based extension would work but is a separate lift — the static-fn surface ships the EXISTS substrate now and a future PR can layer the queryset method on top without breaking changes.

## What this closes vs leaves open

| Capability | This PR |
|---|---|
| \`whereHas\` (FK-reverse, no sub-predicate) | ✅ |
| \`whereDoesntHave\` (FK-reverse) | ✅ |
| \`whereHas\` with closure sub-predicate | ❌ (compose manually via \`crate::core::subquery::exists\`) |
| \`has(rel, '>', N)\` count comparison | ❌ |
| M2M / GFK \`whereHas\` | ❌ |
| \`withCount\` / \`withSum\` annotate-by-relation | ❌ |
| \`QuerySet::filter_has(name)\` method | ❌ (orphan rule; trait extension is follow-up) |

#830 **stays open** until the remaining slices land.

## Tests

\`tests/model_reverse_has_sqlite_live.rs\` — 4 tests:
- \`where_has\` returns only posts with at least one comment
- \`where_doesnt_have\` returns only posts with zero comments
- Composes with outer-queryset \`.filter()\`
- Empty child table → zero results via \`where_has\`

## Verification

- \`cargo test -p rustango --lib --all-features\` → **3422 / 3422** ✅
- \`cargo test -p rustango --test model_reverse_has_sqlite_live --features sqlite\` → **4 / 4** ✅
- \`cargo build -p rustango --no-default-features --features sqlite,tenancy\` (litmus) → ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)