### PR TITLE
feat(orm): reverse_has `<name>_count_pool(&pool)` — extends #830

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -1516,8 +1516,10 @@ fn reverse_has_accessor_tokens(
     let methods = reverse_has_relations.iter().map(|rel| {
         let exists_name = format!("{}_exists_expr", rel.name);
         let not_exists_name = format!("{}_not_exists_expr", rel.name);
+        let count_name = format!("{}_count_pool", rel.name);
         let exists_ident = syn::Ident::new(&exists_name, struct_name.span());
         let not_exists_ident = syn::Ident::new(&not_exists_name, struct_name.span());
+        let count_ident = syn::Ident::new(&count_name, struct_name.span());
         let child = &rel.child;
         let child_fk_column = rel.child_fk_column.as_str();
         let self_pk_column = rel.self_pk_column.as_str();
@@ -1533,6 +1535,14 @@ fn reverse_has_accessor_tokens(
              <outer>.{self_pk_column})`. Drop into \
              `QuerySet::<{struct_name}>::where_raw(...)` to filter to \
              {struct_name}s with **no** matching child.",
+        );
+        let count_doc = format!(
+            "Eloquent `$model->{name}->count()` analog — returns \
+             the number of `{child}` rows whose `{child_fk_column}` \
+             matches this `{struct_name}` instance's primary key. \
+             Issued as `SELECT COUNT(*) FROM <{child}> WHERE \
+             {child_fk_column} = <self.pk>`.",
+            name = rel.name,
         );
         quote! {
             #[doc = #exists_doc]
@@ -1565,6 +1575,21 @@ fn reverse_has_accessor_tokens(
                     ..SelectQuery::new(child_schema)
                 };
                 WhereExpr::NotExists(::std::boxed::Box::new(inner))
+            }
+
+            #[doc = #count_doc]
+            pub async fn #count_ident(
+                &self,
+                pool: &#root::sql::Pool,
+            ) -> ::core::result::Result<
+                i64,
+                #root::sql::ExecError,
+            > {
+                use #root::sql::CounterPool as _;
+                #root::query::QuerySet::<#child>::new()
+                    .filter(#child_fk_column, self.__rustango_pk_value())
+                    .count_pool(pool)
+                    .await
             }
         }
     });

--- a/crates/rustango/tests/model_reverse_has_sqlite_live.rs
+++ b/crates/rustango/tests/model_reverse_has_sqlite_live.rs
@@ -170,3 +170,20 @@ async fn empty_child_table_returns_zero_via_where_has() {
         .unwrap();
     assert!(posts.is_empty());
 }
+
+#[tokio::test]
+async fn comments_count_pool_returns_per_post_count() {
+    // Eloquent `$post->comments->count()` analog — the emitted
+    // `comments_count_pool(&pool)` instance method returns the
+    // number of comment rows whose `post_id` matches this post.
+    let pool = make_pool().await;
+    let (p1_id, p2_id, p3_id) = seed(&pool).await;
+
+    let p1 = Post::find(p1_id, &pool).await.unwrap().unwrap();
+    let p2 = Post::find(p2_id, &pool).await.unwrap().unwrap();
+    let p3 = Post::find(p3_id, &pool).await.unwrap().unwrap();
+
+    assert_eq!(p1.comments_count_pool(&pool).await.unwrap(), 3);
+    assert_eq!(p2.comments_count_pool(&pool).await.unwrap(), 1);
+    assert_eq!(p3.comments_count_pool(&pool).await.unwrap(), 0);
+}


### PR DESCRIPTION
Extends \`#[rustango(reverse_has(...))]\` (PR #926, addressing #830) with a third method per relation:

\`\`\`rust
let n: i64 = post.comments_count_pool(&pool).await?;
// → SELECT COUNT(*) FROM rh_comment WHERE post_id = \$1
\`\`\`

Eloquent \`\$post->comments->count()\` parity. Uses the existing \`CounterPool\` trait + \`QuerySet::<Child>::filter(child_fk_column, self.pk)\` so no new substrate — the macro emits the obvious 3-line wrapper.

Each \`reverse_has(...)\` attribute now emits **three** associated items on the parent:

| Method | Type | Eloquent analog |
|---|---|---|
| \`<name>_exists_expr()\` | static fn → \`WhereExpr\` | \`whereHas\` |
| \`<name>_not_exists_expr()\` | static fn → \`WhereExpr\` | \`whereDoesntHave\` |
| \`<name>_count_pool(&pool)\` | async instance method → \`i64\` | \`\$model->relation->count()\` |

#830 stays open for the remaining slices (M2M / GFK \`whereHas\`, \`withCount\` annotate-by-relation, sub-predicate closures, \`has(rel, '>', N)\`, queryset-extension \`filter_has(name)\`).

## Verification

- \`cargo test -p rustango --lib --all-features\` → **3422 / 3422** ✅
- \`cargo test -p rustango --test model_reverse_has_sqlite_live --features sqlite\` → **5 / 5** ✅
- \`cargo build -p rustango --no-default-features --features sqlite,tenancy\` (litmus) → ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)