### PR TITLE
fix(orm): rename reverse_has `<name>_count_pool` → `<name>_count` — bare-name convention

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -1516,7 +1516,7 @@ fn reverse_has_accessor_tokens(
     let methods = reverse_has_relations.iter().map(|rel| {
         let exists_name = format!("{}_exists_expr", rel.name);
         let not_exists_name = format!("{}_not_exists_expr", rel.name);
-        let count_name = format!("{}_count_pool", rel.name);
+        let count_name = format!("{}_count", rel.name);
         let exists_ident = syn::Ident::new(&exists_name, struct_name.span());
         let not_exists_ident = syn::Ident::new(&not_exists_name, struct_name.span());
         let count_ident = syn::Ident::new(&count_name, struct_name.span());

--- a/crates/rustango/examples/cookbook_blog/COOKBOOK.md
+++ b/crates/rustango/examples/cookbook_blog/COOKBOOK.md
@@ -742,10 +742,10 @@ Post::objects()
 
 Same SQL-column-name convention as `through(...)` — sidesteps the multi-hop filter gap. Optional `self_pk_column = "..."` defaults to `"id"`.
 
-Each `reverse_has(...)` attribute also emits a third method — `<name>_count_pool(&pool) -> i64` — for Eloquent `$model->relation->count()` parity. Runs `SELECT COUNT(*) FROM <child> WHERE <child_fk_column> = <self.pk>`:
+Each `reverse_has(...)` attribute also emits a third method — `<name>_count(&pool) -> i64` — for Eloquent `$model->relation->count()` parity. Runs `SELECT COUNT(*) FROM <child> WHERE <child_fk_column> = <self.pk>`:
 
 ```rust
-let n: i64 = post.comments_count_pool(&pool).await?;
+let n: i64 = post.comments_count(&pool).await?;
 ```
 
 **Status**: FK-reverse subset only — M2M / GFK `whereHas`, sub-predicate closures, `has(rel, '>', N)` count comparisons, and `withCount`-style annotate-by-relation remain follow-up slices.

--- a/crates/rustango/tests/model_reverse_has_sqlite_live.rs
+++ b/crates/rustango/tests/model_reverse_has_sqlite_live.rs
@@ -172,10 +172,10 @@ async fn empty_child_table_returns_zero_via_where_has() {
 }
 
 #[tokio::test]
-async fn comments_count_pool_returns_per_post_count() {
+async fn comments_count_returns_per_post_count() {
     // Eloquent `$post->comments->count()` analog — the emitted
-    // `comments_count_pool(&pool)` instance method returns the
-    // number of comment rows whose `post_id` matches this post.
+    // `comments_count(&pool)` instance method returns the number
+    // of comment rows whose `post_id` matches this post.
     let pool = make_pool().await;
     let (p1_id, p2_id, p3_id) = seed(&pool).await;
 
@@ -183,7 +183,7 @@ async fn comments_count_pool_returns_per_post_count() {
     let p2 = Post::find(p2_id, &pool).await.unwrap().unwrap();
     let p3 = Post::find(p3_id, &pool).await.unwrap().unwrap();
 
-    assert_eq!(p1.comments_count_pool(&pool).await.unwrap(), 3);
-    assert_eq!(p2.comments_count_pool(&pool).await.unwrap(), 1);
-    assert_eq!(p3.comments_count_pool(&pool).await.unwrap(), 0);
+    assert_eq!(p1.comments_count(&pool).await.unwrap(), 3);
+    assert_eq!(p2.comments_count(&pool).await.unwrap(), 1);
+    assert_eq!(p3.comments_count(&pool).await.unwrap(), 0);
 }


### PR DESCRIPTION
PR #928 emitted `<name>_count_pool` but the `_pool` suffix violates the post-#891 bare-name convention for user-facing shortcuts. Renames to `<name>_count`. Trait method `QuerySet::count_pool` (internal call) stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)