### PR TITLE
feat(orm): through — `<name>_through_count(&pool)` instance method — extends #817

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -1627,7 +1627,9 @@ fn through_accessor_tokens(
     }
     let methods = through_relations.iter().map(|rel| {
         let method_name = format!("{}_through", rel.name);
+        let count_name = format!("{}_through_count", rel.name);
         let method_ident = syn::Ident::new(&method_name, struct_name.span());
+        let count_ident = syn::Ident::new(&count_name, struct_name.span());
         let far = &rel.far;
         let intermediate = &rel.intermediate;
         let far_fk_column = rel.far_fk_column.as_str();
@@ -1643,6 +1645,15 @@ fn through_accessor_tokens(
              {intermediate_fk_column} = self.pk)`. Chainable like any \
              other QuerySet — compose `.filter()` / `.order_by()` / \
              `.limit()` etc. on top.",
+        );
+        let count_doc = format!(
+            "Eloquent `$model->{name}->count()` analog for the \
+             through-relation — returns the number of `{far}` rows \
+             reachable through `{intermediate}`. Equivalent to \
+             `self.{name}_through().count_pool(pool)` but spelled \
+             as a bare instance method for parity with the \
+             `reverse_has` `<name>_count` shape.",
+            name = rel.name,
         );
         quote! {
             #[doc = #doc]
@@ -1668,6 +1679,18 @@ fn through_accessor_tokens(
                         subquery: ::std::boxed::Box::new(sub),
                     },
                 )
+            }
+
+            #[doc = #count_doc]
+            pub async fn #count_ident(
+                &self,
+                pool: &#root::sql::Pool,
+            ) -> ::core::result::Result<
+                i64,
+                #root::sql::ExecError,
+            > {
+                use #root::sql::CounterPool as _;
+                self.#method_ident().count_pool(pool).await
             }
         }
     });

--- a/crates/rustango/tests/model_through_relation_sqlite_live.rs
+++ b/crates/rustango/tests/model_through_relation_sqlite_live.rs
@@ -225,3 +225,26 @@ async fn through_accessor_returns_empty_for_country_with_no_users() {
     let posts = empty.posts_through().fetch_pool(&pool).await.unwrap();
     assert!(posts.is_empty());
 }
+
+#[tokio::test]
+async fn posts_through_count_returns_far_side_count() {
+    // Eloquent `$country->posts->count()` analog for the
+    // through-relation — `posts_through_count(&pool)` returns the
+    // number of far rows reachable from this country via users.
+    let pool = make_pool().await;
+    let (a_id, b_id) = seed(&pool).await;
+
+    let a = Country::find(a_id, &pool).await.unwrap().unwrap();
+    let b = Country::find(b_id, &pool).await.unwrap().unwrap();
+
+    // Country A: 2 users × 3 posts each = 6. Country B: 3 × 3 = 9.
+    assert_eq!(a.posts_through_count(&pool).await.unwrap(), 6);
+    assert_eq!(b.posts_through_count(&pool).await.unwrap(), 9);
+
+    let mut empty = Country {
+        id: Auto::default(),
+        name: "Empty".into(),
+    };
+    empty.save_pool(&pool).await.unwrap();
+    assert_eq!(empty.posts_through_count(&pool).await.unwrap(), 0);
+}


### PR DESCRIPTION
Adds a bare-name count companion to `#[rustango(through(...))]` paralleling `<name>_count` on `reverse_has`. Pure sugar over the existing through-accessor + `CounterPool` chain.

```rust
let n: i64 = country.posts_through_count(&pool).await?;
// → equivalent to country.posts_through().count_pool(pool).await
```

## Verification

- `cargo test -p rustango --lib --all-features` → **3422 / 3422** ✅
- `cargo test -p rustango --test model_through_relation_sqlite_live --features sqlite` → **4 / 4** ✅
- `cargo build -p rustango --no-default-features --features sqlite,tenancy` (litmus) → ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)