### PR TITLE
feat(orm): reverse_has — `<name>()` queryset + `<name>_fetch()` bare-name hot-path — extends #830

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -1517,9 +1517,13 @@ fn reverse_has_accessor_tokens(
         let exists_name = format!("{}_exists_expr", rel.name);
         let not_exists_name = format!("{}_not_exists_expr", rel.name);
         let count_name = format!("{}_count", rel.name);
+        let fetch_name = format!("{}_fetch", rel.name);
+        let accessor_name = rel.name.as_str();
         let exists_ident = syn::Ident::new(&exists_name, struct_name.span());
         let not_exists_ident = syn::Ident::new(&not_exists_name, struct_name.span());
         let count_ident = syn::Ident::new(&count_name, struct_name.span());
+        let fetch_ident = syn::Ident::new(&fetch_name, struct_name.span());
+        let accessor_ident = syn::Ident::new(accessor_name, struct_name.span());
         let child = &rel.child;
         let child_fk_column = rel.child_fk_column.as_str();
         let self_pk_column = rel.self_pk_column.as_str();
@@ -1544,7 +1548,46 @@ fn reverse_has_accessor_tokens(
              {child_fk_column} = <self.pk>`.",
             name = rel.name,
         );
+        let accessor_doc = format!(
+            "Eloquent `$model->{name}` accessor — returns a \
+             `QuerySet<{child}>` filtered to rows whose \
+             `{child_fk_column}` matches this `{struct_name}` \
+             instance's primary key. **Chainable**: compose `.filter()` \
+             / `.order_by()` / `.limit()` etc. on top, then call \
+             `.fetch_pool(&pool)` (the QuerySet trait method) when \
+             done. For the simple \"fetch all\" hot path with no \
+             further composition, prefer the bare-name \
+             `{name}_fetch(&pool)` companion.",
+            name = rel.name,
+        );
+        let fetch_doc = format!(
+            "Eloquent `$model->{name}->get()` — bare-name hot-path \
+             over `{name}(&self).fetch_pool(&pool)`. Use this when \
+             you don't need further `.filter()` / `.order_by()` \
+             composition; falls back to the chainable accessor when \
+             you do. Avoids the `_pool` suffix on the most common \
+             call-site shape.",
+            name = rel.name,
+        );
         quote! {
+            #[doc = #accessor_doc]
+            pub fn #accessor_ident(&self) -> #root::query::QuerySet<#child> {
+                #root::query::QuerySet::<#child>::new()
+                    .filter(#child_fk_column, self.__rustango_pk_value())
+            }
+
+            #[doc = #fetch_doc]
+            pub async fn #fetch_ident(
+                &self,
+                pool: &#root::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<#child>,
+                #root::sql::ExecError,
+            > {
+                use #root::sql::FetcherPool as _;
+                self.#accessor_ident().fetch_pool(pool).await
+            }
+
             #[doc = #exists_doc]
             pub fn #exists_ident() -> #root::core::WhereExpr {
                 use #root::core::{Expr, Model as _, Op, SelectQuery, WhereExpr};

--- a/crates/rustango/tests/model_reverse_has_sqlite_live.rs
+++ b/crates/rustango/tests/model_reverse_has_sqlite_live.rs
@@ -172,6 +172,48 @@ async fn empty_child_table_returns_zero_via_where_has() {
 }
 
 #[tokio::test]
+async fn comments_accessor_returns_chainable_queryset() {
+    // Eloquent `$post->comments` analog — bare-name accessor
+    // returns a `QuerySet<Comment>` pre-filtered to this post's
+    // children. Chainable like any other queryset.
+    let pool = make_pool().await;
+    let (p1_id, _p2_id, _p3_id) = seed(&pool).await;
+    let p1 = Post::find(p1_id, &pool).await.unwrap().unwrap();
+
+    let all = p1.comments().fetch_pool(&pool).await.unwrap();
+    assert_eq!(all.len(), 3);
+    for c in &all {
+        // Every fetched comment's FK matches this post's id.
+        assert_eq!(c.post_id.pk(), p1_id);
+    }
+
+    // Chain `.filter()` on top of the accessor.
+    let filtered = p1
+        .comments()
+        .filter("body", "comment-1")
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].body, "comment-1");
+}
+
+#[tokio::test]
+async fn comments_fetch_bare_name_hot_path() {
+    // Bare-name hot path — `post.comments_fetch(&pool)` is the
+    // suffix-free shortcut over `post.comments().fetch_pool(&pool)`.
+    // Same rows, no `_pool` in the user-visible spelling.
+    let pool = make_pool().await;
+    let (p1_id, _, _) = seed(&pool).await;
+    let p1 = Post::find(p1_id, &pool).await.unwrap().unwrap();
+    let rows = p1.comments_fetch(&pool).await.unwrap();
+    assert_eq!(rows.len(), 3);
+    for c in &rows {
+        assert_eq!(c.post_id.pk(), p1_id);
+    }
+}
+
+#[tokio::test]
 async fn comments_count_returns_per_post_count() {
     // Eloquent `$post->comments->count()` analog — the emitted
     // `comments_count(&pool)` instance method returns the number


### PR DESCRIPTION
Adds two methods to `#[rustango(reverse_has(...))]` emit:

- **`<name>(&self) -> QuerySet<Child>`** — chainable accessor (Eloquent `$post->comments`)
- **`<name>_fetch(&self, &pool) -> Vec<Child>`** — bare-name hot-path (Eloquent `$post->comments->get()`)

The `<name>_fetch` wrapper specifically avoids `_pool` on the most common call-site shape, per the avoid-`_pool`-by-default convention.

Each `reverse_has(...)` attribute now emits **five** items per relation:

| Method | Type | Eloquent analog |
|---|---|---|
| `<name>(&self) -> QuerySet<Child>` | bare chainable accessor | `$model->relation` |
| `<name>_fetch(&self, &pool) -> Vec<Child>` | bare hot-path | `$model->relation->get()` |
| `<name>_count(&self, &pool) -> i64` | scalar | `$model->relation->count()` |
| `<name>_exists_expr()` | `WhereExpr` | `whereHas` |
| `<name>_not_exists_expr()` | `WhereExpr` | `whereDoesntHave` |

## Verification

- `cargo test -p rustango --lib --all-features` → **3422 / 3422** ✅
- `cargo test -p rustango --test model_reverse_has_sqlite_live --features sqlite` → **7 / 7** ✅
- `cargo build -p rustango --no-default-features --features sqlite,tenancy` (litmus) → ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)