### PR TITLE
feat(orm): through — `<name>_through_fetch(&pool)` bare-name hot-path — extends #817

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -1671,8 +1671,10 @@ fn through_accessor_tokens(
     let methods = through_relations.iter().map(|rel| {
         let method_name = format!("{}_through", rel.name);
         let count_name = format!("{}_through_count", rel.name);
+        let fetch_name = format!("{}_through_fetch", rel.name);
         let method_ident = syn::Ident::new(&method_name, struct_name.span());
         let count_ident = syn::Ident::new(&count_name, struct_name.span());
+        let fetch_ident = syn::Ident::new(&fetch_name, struct_name.span());
         let far = &rel.far;
         let intermediate = &rel.intermediate;
         let far_fk_column = rel.far_fk_column.as_str();
@@ -1734,6 +1736,24 @@ fn through_accessor_tokens(
             > {
                 use #root::sql::CounterPool as _;
                 self.#method_ident().count_pool(pool).await
+            }
+
+            /// Eloquent `$model->relation->get()` for the
+            /// through-relation — bare-name hot-path over
+            /// `self.<name>_through().fetch_pool(&pool)`. Use this
+            /// when you don't need further `.filter()` /
+            /// `.order_by()` composition; falls back to the
+            /// chainable accessor when you do. Avoids the `_pool`
+            /// suffix on the most common call-site shape.
+            pub async fn #fetch_ident(
+                &self,
+                pool: &#root::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<#far>,
+                #root::sql::ExecError,
+            > {
+                use #root::sql::FetcherPool as _;
+                self.#method_ident().fetch_pool(pool).await
             }
         }
     });

--- a/crates/rustango/tests/model_through_relation_sqlite_live.rs
+++ b/crates/rustango/tests/model_through_relation_sqlite_live.rs
@@ -248,3 +248,14 @@ async fn posts_through_count_returns_far_side_count() {
     empty.save_pool(&pool).await.unwrap();
     assert_eq!(empty.posts_through_count(&pool).await.unwrap(), 0);
 }
+
+#[tokio::test]
+async fn posts_through_fetch_bare_name_hot_path() {
+    // Bare-name hot path — `posts_through_fetch(&pool)` is the
+    // suffix-free shortcut over `posts_through().fetch_pool(&pool)`.
+    let pool = make_pool().await;
+    let (a_id, _b_id) = seed(&pool).await;
+    let a = Country::find(a_id, &pool).await.unwrap().unwrap();
+    let posts = a.posts_through_fetch(&pool).await.unwrap();
+    assert_eq!(posts.len(), 6);
+}


### PR DESCRIPTION
Adds a bare-name hot-path companion to `#[rustango(through(...))]` paralleling PR #932 which did the same for `reverse_has`.

```rust
let posts = country.posts_through_fetch(&pool).await?;  // hot path — no _pool

country.posts_through()
    .filter("title__startswith", "Hello ")
    .fetch_pool(&pool).await?;                          // chainable — _pool only here
```

## Verification

- `cargo test -p rustango --lib --all-features` → **3422 / 3422** ✅
- `cargo test -p rustango --test model_through_relation_sqlite_live --features sqlite` → **5 / 5** ✅
- Litmus → ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)