### PR TITLE
feat(orm): `<name>_first` / `<name>_through_first` hasOne shortcuts

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -1518,11 +1518,13 @@ fn reverse_has_accessor_tokens(
         let not_exists_name = format!("{}_not_exists_expr", rel.name);
         let count_name = format!("{}_count", rel.name);
         let fetch_name = format!("{}_fetch", rel.name);
+        let first_name = format!("{}_first", rel.name);
         let accessor_name = rel.name.as_str();
         let exists_ident = syn::Ident::new(&exists_name, struct_name.span());
         let not_exists_ident = syn::Ident::new(&not_exists_name, struct_name.span());
         let count_ident = syn::Ident::new(&count_name, struct_name.span());
         let fetch_ident = syn::Ident::new(&fetch_name, struct_name.span());
+        let first_ident = syn::Ident::new(&first_name, struct_name.span());
         let accessor_ident = syn::Ident::new(accessor_name, struct_name.span());
         let child = &rel.child;
         let child_fk_column = rel.child_fk_column.as_str();
@@ -1586,6 +1588,22 @@ fn reverse_has_accessor_tokens(
             > {
                 use #root::sql::FetcherPool as _;
                 self.#accessor_ident().fetch_pool(pool).await
+            }
+
+            /// Eloquent `$model->relation->first()` / `hasOne`
+            /// semantics — bare-name shortcut over
+            /// `self.<name>().first(&pool)`. Returns `None` when no
+            /// child rows match. Useful when the relation is
+            /// nominally many-to-one in shape but at most one row is
+            /// expected (latest comment, primary tag, etc.).
+            pub async fn #first_ident(
+                &self,
+                pool: &#root::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<#child>,
+                #root::sql::ExecError,
+            > {
+                self.#accessor_ident().first(pool).await
             }
 
             #[doc = #exists_doc]
@@ -1672,9 +1690,11 @@ fn through_accessor_tokens(
         let method_name = format!("{}_through", rel.name);
         let count_name = format!("{}_through_count", rel.name);
         let fetch_name = format!("{}_through_fetch", rel.name);
+        let first_name = format!("{}_through_first", rel.name);
         let method_ident = syn::Ident::new(&method_name, struct_name.span());
         let count_ident = syn::Ident::new(&count_name, struct_name.span());
         let fetch_ident = syn::Ident::new(&fetch_name, struct_name.span());
+        let first_ident = syn::Ident::new(&first_name, struct_name.span());
         let far = &rel.far;
         let intermediate = &rel.intermediate;
         let far_fk_column = rel.far_fk_column.as_str();
@@ -1754,6 +1774,22 @@ fn through_accessor_tokens(
             > {
                 use #root::sql::FetcherPool as _;
                 self.#method_ident().fetch_pool(pool).await
+            }
+
+            /// Eloquent `hasOneThrough` analog — bare-name shortcut
+            /// over `self.<name>_through().first(&pool)`. Returns
+            /// `None` when no far rows are reachable through the
+            /// intermediate. Useful when at most one row is
+            /// expected (latest comment by country, primary tag,
+            /// etc.).
+            pub async fn #first_ident(
+                &self,
+                pool: &#root::sql::Pool,
+            ) -> ::core::result::Result<
+                ::core::option::Option<#far>,
+                #root::sql::ExecError,
+            > {
+                self.#method_ident().first(pool).await
             }
         }
     });

--- a/crates/rustango/tests/model_reverse_has_sqlite_live.rs
+++ b/crates/rustango/tests/model_reverse_has_sqlite_live.rs
@@ -199,6 +199,23 @@ async fn comments_accessor_returns_chainable_queryset() {
 }
 
 #[tokio::test]
+async fn comments_first_returns_first_child_or_none() {
+    // Eloquent `$post->comments->first()` analog — `post.comments_first()`
+    // returns Some(first child) or None.
+    let pool = make_pool().await;
+    let (p1_id, _p2_id, p3_id) = seed(&pool).await;
+    let p1 = Post::find(p1_id, &pool).await.unwrap().unwrap();
+    let p3 = Post::find(p3_id, &pool).await.unwrap().unwrap();
+
+    let first = p1.comments_first(&pool).await.unwrap();
+    assert!(first.is_some());
+    assert!(first.unwrap().body.starts_with("comment-"));
+
+    // p3 has no comments → None.
+    assert!(p3.comments_first(&pool).await.unwrap().is_none());
+}
+
+#[tokio::test]
 async fn comments_fetch_bare_name_hot_path() {
     // Bare-name hot path — `post.comments_fetch(&pool)` is the
     // suffix-free shortcut over `post.comments().fetch_pool(&pool)`.

--- a/crates/rustango/tests/model_through_relation_sqlite_live.rs
+++ b/crates/rustango/tests/model_through_relation_sqlite_live.rs
@@ -250,6 +250,27 @@ async fn posts_through_count_returns_far_side_count() {
 }
 
 #[tokio::test]
+async fn posts_through_first_returns_first_far_or_none() {
+    // Eloquent `hasOneThrough` analog — `posts_through_first(&pool)`
+    // returns Some(first far row) or None when no rows match.
+    let pool = make_pool().await;
+    let (a_id, _b_id) = seed(&pool).await;
+
+    let a = Country::find(a_id, &pool).await.unwrap().unwrap();
+    let first = a.posts_through_first(&pool).await.unwrap();
+    assert!(first.is_some());
+    let t = first.unwrap().title;
+    assert!(t.starts_with("alice-") || t.starts_with("andrew-"));
+
+    let mut empty = Country {
+        id: Auto::default(),
+        name: "Empty".into(),
+    };
+    empty.save_pool(&pool).await.unwrap();
+    assert!(empty.posts_through_first(&pool).await.unwrap().is_none());
+}
+
+#[tokio::test]
 async fn posts_through_fetch_bare_name_hot_path() {
     // Bare-name hot path — `posts_through_fetch(&pool)` is the
     // suffix-free shortcut over `posts_through().fetch_pool(&pool)`.


### PR DESCRIPTION
Adds Eloquent `$model->relation->first()` / `hasOneThrough` sugar to both relation attributes.

```rust
let first: Option<Comment> = post.comments_first(&pool).await?;
let first: Option<Post>    = country.posts_through_first(&pool).await?;
```

Pure sugar over `QuerySet::first(&pool)` (PK-ASC fallback for determinism). No new IR.

**reverse_has** now emits 6 items per relation; **through** now emits 4. Both relation attributes share the same five-shape contract: chainable accessor + bare-name `_fetch` / `_first` / `_count` hot paths.

Lib 3422/3422. Integration 8/8 + 6/6. Litmus clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)