### PR TITLE
feat(orm): `<name>_pluck` / `<name>_through_pluck` Eloquent single-column projection

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -1519,12 +1519,14 @@ fn reverse_has_accessor_tokens(
         let count_name = format!("{}_count", rel.name);
         let fetch_name = format!("{}_fetch", rel.name);
         let first_name = format!("{}_first", rel.name);
+        let pluck_name = format!("{}_pluck", rel.name);
         let accessor_name = rel.name.as_str();
         let exists_ident = syn::Ident::new(&exists_name, struct_name.span());
         let not_exists_ident = syn::Ident::new(&not_exists_name, struct_name.span());
         let count_ident = syn::Ident::new(&count_name, struct_name.span());
         let fetch_ident = syn::Ident::new(&fetch_name, struct_name.span());
         let first_ident = syn::Ident::new(&first_name, struct_name.span());
+        let pluck_ident = syn::Ident::new(&pluck_name, struct_name.span());
         let accessor_ident = syn::Ident::new(accessor_name, struct_name.span());
         let child = &rel.child;
         let child_fk_column = rel.child_fk_column.as_str();
@@ -1604,6 +1606,31 @@ fn reverse_has_accessor_tokens(
                 #root::sql::ExecError,
             > {
                 self.#accessor_ident().first(pool).await
+            }
+
+            /// Eloquent `$model->relation->pluck($col)` — project a
+            /// single column from the child rows into a `Vec<U>`.
+            /// Skips the typed `Child` decode, which is cheaper when
+            /// you only need one column (e.g. `post.comments_pluck::<String>("body", &pool)`).
+            pub async fn #pluck_ident<U>(
+                &self,
+                col: &'static str,
+                pool: &#root::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<U>,
+                #root::sql::ExecError,
+            >
+            where
+                U: #root::sql::MaybePgScalar
+                    + #root::sql::MaybeMyScalar
+                    + #root::sql::MaybeSqliteScalar
+                    + ::core::marker::Send
+                    + ::core::marker::Unpin,
+            {
+                self.#accessor_ident()
+                    .values_list_flat(col)
+                    .fetch::<U>(pool)
+                    .await
             }
 
             #[doc = #exists_doc]
@@ -1691,10 +1718,12 @@ fn through_accessor_tokens(
         let count_name = format!("{}_through_count", rel.name);
         let fetch_name = format!("{}_through_fetch", rel.name);
         let first_name = format!("{}_through_first", rel.name);
+        let pluck_name = format!("{}_through_pluck", rel.name);
         let method_ident = syn::Ident::new(&method_name, struct_name.span());
         let count_ident = syn::Ident::new(&count_name, struct_name.span());
         let fetch_ident = syn::Ident::new(&fetch_name, struct_name.span());
         let first_ident = syn::Ident::new(&first_name, struct_name.span());
+        let pluck_ident = syn::Ident::new(&pluck_name, struct_name.span());
         let far = &rel.far;
         let intermediate = &rel.intermediate;
         let far_fk_column = rel.far_fk_column.as_str();
@@ -1790,6 +1819,30 @@ fn through_accessor_tokens(
                 #root::sql::ExecError,
             > {
                 self.#method_ident().first(pool).await
+            }
+
+            /// Pluck a single column from the far rows into `Vec<U>`
+            /// — cheaper than the typed `<Far>` decode when only one
+            /// scalar column is needed.
+            pub async fn #pluck_ident<U>(
+                &self,
+                col: &'static str,
+                pool: &#root::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<U>,
+                #root::sql::ExecError,
+            >
+            where
+                U: #root::sql::MaybePgScalar
+                    + #root::sql::MaybeMyScalar
+                    + #root::sql::MaybeSqliteScalar
+                    + ::core::marker::Send
+                    + ::core::marker::Unpin,
+            {
+                self.#method_ident()
+                    .values_list_flat(col)
+                    .fetch::<U>(pool)
+                    .await
             }
         }
     });

--- a/crates/rustango/tests/model_reverse_has_sqlite_live.rs
+++ b/crates/rustango/tests/model_reverse_has_sqlite_live.rs
@@ -199,6 +199,17 @@ async fn comments_accessor_returns_chainable_queryset() {
 }
 
 #[tokio::test]
+async fn comments_pluck_returns_one_column_per_child() {
+    // Eloquent `$post->comments->pluck('body')` analog.
+    let pool = make_pool().await;
+    let (p1_id, _, _) = seed(&pool).await;
+    let p1 = Post::find(p1_id, &pool).await.unwrap().unwrap();
+    let mut bodies: Vec<String> = p1.comments_pluck("body", &pool).await.unwrap();
+    bodies.sort();
+    assert_eq!(bodies, vec!["comment-0", "comment-1", "comment-2"]);
+}
+
+#[tokio::test]
 async fn comments_first_returns_first_child_or_none() {
     // Eloquent `$post->comments->first()` analog — `post.comments_first()`
     // returns Some(first child) or None.

--- a/crates/rustango/tests/model_through_relation_sqlite_live.rs
+++ b/crates/rustango/tests/model_through_relation_sqlite_live.rs
@@ -250,6 +250,19 @@ async fn posts_through_count_returns_far_side_count() {
 }
 
 #[tokio::test]
+async fn posts_through_pluck_returns_one_column_per_far() {
+    // Pluck a single column from the through-relation's far rows.
+    let pool = make_pool().await;
+    let (a_id, _) = seed(&pool).await;
+    let a = Country::find(a_id, &pool).await.unwrap().unwrap();
+    let titles: Vec<String> = a.posts_through_pluck("title", &pool).await.unwrap();
+    assert_eq!(titles.len(), 6);
+    for t in &titles {
+        assert!(t.starts_with("alice-") || t.starts_with("andrew-"));
+    }
+}
+
+#[tokio::test]
 async fn posts_through_first_returns_first_far_or_none() {
     // Eloquent `hasOneThrough` analog — `posts_through_first(&pool)`
     // returns Some(first far row) or None when no rows match.


### PR DESCRIPTION
Eloquent `$model->relation->pluck($col)` parity:

```rust
let bodies: Vec<String> = post.comments_pluck("body", &pool).await?;
let titles: Vec<String> = country.posts_through_pluck("title", &pool).await?;
```

Generic `U`; cheaper than typed-row decode when only one scalar is needed.

3422 lib + 16 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)