### PR TITLE
feat(orm): `Model::chunk(n, &pool, async cb)` — Eloquent batch iteration

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -4165,6 +4165,70 @@ fn inherent_impl_tokens(
                     .await
             }
 
+            /// Eloquent `Model::chunk($n, fn ($chunk) { ... })` —
+            /// stream every row of this model in batches of `n`,
+            /// invoking the callback once per batch. Stable PK-ASC
+            /// ordering so the LIMIT/OFFSET pagination is
+            /// deterministic across drivers.
+            ///
+            /// The callback is async — it can do further DB work
+            /// (writes, related-row lookups, queue dispatch) per
+            /// batch. Return `Err(...)` from the callback to abort
+            /// the iteration early; the error bubbles up.
+            ///
+            /// **When to use**: bulk processing flows that can't
+            /// fit the whole table in memory — sending newsletters,
+            /// running data migrations, computing summary
+            /// statistics. For small / known-bounded tables, plain
+            /// `Self::all(&pool)` is simpler.
+            ///
+            /// **Caveat**: ascending OFFSET pagination is O(N²) on
+            /// large tables. For multi-million-row scans prefer
+            /// keyset-by-PK (the standard "WHERE id > last_seen"
+            /// shape) over `chunk(...)`.
+            ///
+            /// Skipped on models without a primary key — chunking
+            /// needs a stable order to avoid skipping / repeating
+            /// rows across batches.
+            pub async fn chunk<F, Fut>(
+                n: i64,
+                pool: &#root::sql::Pool,
+                mut cb: F,
+            ) -> ::core::result::Result<(), #root::sql::ExecError>
+            where
+                F: ::core::ops::FnMut(::std::vec::Vec<Self>) -> Fut,
+                Fut: ::core::future::Future<
+                    Output = ::core::result::Result<(), #root::sql::ExecError>,
+                >,
+            {
+                use #root::sql::FetcherPool as _;
+                let pk_col = match Self::primary_key_column() {
+                    ::core::option::Option::Some(c) => c,
+                    ::core::option::Option::None => {
+                        return ::core::result::Result::Ok(());
+                    }
+                };
+                let mut offset: i64 = 0;
+                loop {
+                    let rows: ::std::vec::Vec<Self> =
+                        #root::query::QuerySet::<Self>::default()
+                            .order_by(&[(pk_col, false)])
+                            .limit(n)
+                            .offset(offset)
+                            .fetch_pool(pool)
+                            .await?;
+                    if rows.is_empty() {
+                        return ::core::result::Result::Ok(());
+                    }
+                    let len = rows.len() as i64;
+                    cb(rows).await?;
+                    if len < n {
+                        return ::core::result::Result::Ok(());
+                    }
+                    offset += n;
+                }
+            }
+
             /// Delete every row of this model — `TRUNCATE TABLE
             /// <table> RESTART IDENTITY CASCADE` on Postgres,
             /// `DELETE FROM <table>` on MySQL / SQLite (which don't

--- a/crates/rustango/tests/model_chunk_sqlite_live.rs
+++ b/crates/rustango/tests/model_chunk_sqlite_live.rs
@@ -1,0 +1,106 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for Eloquent `Model::chunk($n, fn($chunk) { ... })`
+//! parity — the macro-emitted batch-iteration shortcut.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "chunk_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE chunk_post (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn seed(pool: &Pool, n: i32) {
+    for i in 0..n {
+        let mut p = Post {
+            id: Auto::default(),
+            title: format!("post-{i}"),
+        };
+        p.save_pool(pool).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn chunk_visits_every_row_in_pk_order() {
+    let pool = make_pool().await;
+    seed(&pool, 25).await;
+    let count = AtomicI64::new(0);
+    Post::chunk(7, &pool, |batch| {
+        count.fetch_add(batch.len() as i64, Ordering::SeqCst);
+        async { Ok(()) }
+    })
+    .await
+    .unwrap();
+    assert_eq!(count.load(Ordering::SeqCst), 25);
+}
+
+#[tokio::test]
+async fn chunk_callback_receives_batches_of_n() {
+    let pool = make_pool().await;
+    seed(&pool, 25).await;
+    let sizes = std::sync::Mutex::new(Vec::<usize>::new());
+    Post::chunk(7, &pool, |batch| {
+        sizes.lock().unwrap().push(batch.len());
+        async { Ok(()) }
+    })
+    .await
+    .unwrap();
+    let sizes = sizes.into_inner().unwrap();
+    // 25 rows in batches of 7 → 7, 7, 7, 4.
+    assert_eq!(sizes, vec![7, 7, 7, 4]);
+}
+
+#[tokio::test]
+async fn chunk_empty_table_invokes_callback_zero_times() {
+    let pool = make_pool().await;
+    let calls = AtomicI64::new(0);
+    Post::chunk(10, &pool, |_batch| {
+        calls.fetch_add(1, Ordering::SeqCst);
+        async { Ok(()) }
+    })
+    .await
+    .unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn chunk_propagates_callback_error() {
+    let pool = make_pool().await;
+    seed(&pool, 5).await;
+    // Surface a driver-level error via an obviously invalid raw
+    // query — the callback returns the wrapped result so chunk()
+    // propagates it.
+    let result = Post::chunk(2, &pool, |_batch| async {
+        let bogus = rustango::sql::raw_execute_pool(
+            &Pool::Sqlite(sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap()),
+            "NOT A VALID SQL STATEMENT;",
+            vec![],
+        )
+        .await;
+        bogus.map(|_| ())
+    })
+    .await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Eloquent `Model::chunk($n, fn ($chunk) { ... })` parity. Iterates every row in batches of `n` invoking an async callback once per batch. Stable PK-ASC ordering. Skipped on PK-less models.

```rust
Post::chunk(1000, &pool, |batch| async move {
    for p in &batch { process(p).await?; }
    Ok(())
}).await?;
```

**Caveat**: O(N²) OFFSET scan on large tables; prefer keyset-by-PK for multi-million-row sweeps.

3422 lib + 4 chunk integration tests pass. Litmus clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)