### PR TITLE
feat(orm): `Model::chunk_by_id` — keyset-pagination batch iteration

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -4229,6 +4229,81 @@ fn inherent_impl_tokens(
                 }
             }
 
+            /// Eloquent `Model::chunkById($n, fn (...))` — same
+            /// per-batch callback shape as [`Self::chunk`], but uses
+            /// **keyset pagination** (`WHERE pk > last_seen LIMIT n`)
+            /// instead of OFFSET. O(N) total scan vs OFFSET's O(N²)
+            /// — the right choice for multi-million-row sweeps.
+            ///
+            /// Requires the primary key to be a signed integer type
+            /// (`i64` / `i32`); the keyset comparison rides on
+            /// `__rustango_pk_value()` lowering through
+            /// `SqlValue::I64` / `SqlValue::I32`. Skipped on
+            /// non-integer PKs (UUID, String) — those should use
+            /// the OFFSET-shaped [`Self::chunk`] or a hand-rolled
+            /// keyset loop.
+            ///
+            /// Callback errors abort iteration; the error bubbles up
+            /// unchanged. Empty table → callback invoked zero times.
+            pub async fn chunk_by_id<F, Fut>(
+                n: i64,
+                pool: &#root::sql::Pool,
+                mut cb: F,
+            ) -> ::core::result::Result<(), #root::sql::ExecError>
+            where
+                F: ::core::ops::FnMut(::std::vec::Vec<Self>) -> Fut,
+                Fut: ::core::future::Future<
+                    Output = ::core::result::Result<(), #root::sql::ExecError>,
+                >,
+            {
+                use #root::sql::FetcherPool as _;
+                let pk_col = match Self::primary_key_column() {
+                    ::core::option::Option::Some(c) => c,
+                    ::core::option::Option::None => {
+                        return ::core::result::Result::Ok(());
+                    }
+                };
+                // Track the largest PK seen so the next batch picks
+                // up from there. `i64::MIN` as the sentinel — the
+                // very first iteration's `> MIN` matches every row,
+                // so the loop entry is uniform with subsequent
+                // iterations.
+                let mut last_seen: i64 = i64::MIN;
+                loop {
+                    let key = ::std::format!("{}__gt", pk_col);
+                    let rows: ::std::vec::Vec<Self> =
+                        #root::query::QuerySet::<Self>::default()
+                            .filter(key.as_str(), last_seen)
+                            .order_by(&[(pk_col, false)])
+                            .limit(n)
+                            .fetch_pool(pool)
+                            .await?;
+                    if rows.is_empty() {
+                        return ::core::result::Result::Ok(());
+                    }
+                    let len = rows.len() as i64;
+                    // Capture the last row's PK BEFORE moving rows
+                    // into the callback.
+                    let max_pk = match rows
+                        .last()
+                        .map(|r| r.__rustango_pk_value())
+                    {
+                        ::core::option::Option::Some(
+                            #root::core::SqlValue::I64(v),
+                        ) => v,
+                        ::core::option::Option::Some(
+                            #root::core::SqlValue::I32(v),
+                        ) => i64::from(v),
+                        _ => return ::core::result::Result::Ok(()),
+                    };
+                    cb(rows).await?;
+                    if len < n {
+                        return ::core::result::Result::Ok(());
+                    }
+                    last_seen = max_pk;
+                }
+            }
+
             /// Delete every row of this model — `TRUNCATE TABLE
             /// <table> RESTART IDENTITY CASCADE` on Postgres,
             /// `DELETE FROM <table>` on MySQL / SQLite (which don't

--- a/crates/rustango/tests/model_chunk_sqlite_live.rs
+++ b/crates/rustango/tests/model_chunk_sqlite_live.rs
@@ -86,6 +86,42 @@ async fn chunk_empty_table_invokes_callback_zero_times() {
 }
 
 #[tokio::test]
+async fn chunk_by_id_visits_every_row_via_keyset_pagination() {
+    // Same row-count guarantee as `chunk` but using keyset
+    // pagination (`WHERE id > last LIMIT n`) — O(N) total scan
+    // vs OFFSET's O(N²).
+    let pool = make_pool().await;
+    seed(&pool, 25).await;
+    let sizes = std::sync::Mutex::new(Vec::<usize>::new());
+    Post::chunk_by_id(7, &pool, |batch| {
+        // Inside each batch, PKs are strictly ascending — proves
+        // the keyset ordering holds.
+        let pks: Vec<i64> = batch.iter().map(|p| p.id.get().copied().unwrap()).collect();
+        for w in pks.windows(2) {
+            assert!(w[0] < w[1], "non-ascending PKs in batch: {pks:?}");
+        }
+        sizes.lock().unwrap().push(batch.len());
+        async { Ok(()) }
+    })
+    .await
+    .unwrap();
+    assert_eq!(sizes.into_inner().unwrap(), vec![7, 7, 7, 4]);
+}
+
+#[tokio::test]
+async fn chunk_by_id_empty_table_invokes_callback_zero_times() {
+    let pool = make_pool().await;
+    let calls = AtomicI64::new(0);
+    Post::chunk_by_id(10, &pool, |_batch| {
+        calls.fetch_add(1, Ordering::SeqCst);
+        async { Ok(()) }
+    })
+    .await
+    .unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
 async fn chunk_propagates_callback_error() {
     let pool = make_pool().await;
     seed(&pool, 5).await;


### PR DESCRIPTION
Eloquent `Model::chunkById($n, fn ...)` parity. Keyset pagination (`WHERE pk > last_seen LIMIT n`) instead of OFFSET — O(N) total vs OFFSET's O(N²). The right choice for multi-million-row sweeps.

```rust
Post::chunk_by_id(1000, &pool, |batch| async move {
    for p in &batch { reindex(p).await?; }
    Ok(())
}).await?;
```

Skipped on non-integer PKs — use `Self::chunk` (OFFSET) for those.

3422 lib + 6 chunk integration tests pass. Litmus clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)