### PR TITLE
feat(orm): `Model::each(batch, &pool, async cb)` — per-row Eloquent each()

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -4304,6 +4304,78 @@ fn inherent_impl_tokens(
                 }
             }
 
+            /// Eloquent `Model::each(fn ($row) { ... }, $n)` —
+            /// per-row callback companion to [`Self::chunk`].
+            /// Streams every row in keyset-paginated batches of
+            /// `batch` size, calling `cb` once per row.
+            ///
+            /// Inherits the keyset-paginated scan of
+            /// [`Self::chunk_by_id`] (O(N) total, integer PK only —
+            /// non-integer PKs are silently a no-op).
+            ///
+            /// ```ignore
+            /// Post::each(500, &pool, |p| async move {
+            ///     reindex(p).await?;
+            ///     Ok(())
+            /// }).await?;
+            /// ```
+            ///
+            /// Return `Err(...)` from the callback to abort
+            /// iteration; the error bubbles up unchanged.
+            pub async fn each<F, Fut>(
+                batch: i64,
+                pool: &#root::sql::Pool,
+                mut cb: F,
+            ) -> ::core::result::Result<(), #root::sql::ExecError>
+            where
+                F: ::core::ops::FnMut(Self) -> Fut,
+                Fut: ::core::future::Future<
+                    Output = ::core::result::Result<(), #root::sql::ExecError>,
+                >,
+            {
+                use #root::sql::FetcherPool as _;
+                let pk_col = match Self::primary_key_column() {
+                    ::core::option::Option::Some(c) => c,
+                    ::core::option::Option::None => {
+                        return ::core::result::Result::Ok(());
+                    }
+                };
+                let mut last_seen: i64 = i64::MIN;
+                loop {
+                    let key = ::std::format!("{}__gt", pk_col);
+                    let rows: ::std::vec::Vec<Self> =
+                        #root::query::QuerySet::<Self>::default()
+                            .filter(key.as_str(), last_seen)
+                            .order_by(&[(pk_col, false)])
+                            .limit(batch)
+                            .fetch_pool(pool)
+                            .await?;
+                    if rows.is_empty() {
+                        return ::core::result::Result::Ok(());
+                    }
+                    let len = rows.len() as i64;
+                    let max_pk = match rows
+                        .last()
+                        .map(|r| r.__rustango_pk_value())
+                    {
+                        ::core::option::Option::Some(
+                            #root::core::SqlValue::I64(v),
+                        ) => v,
+                        ::core::option::Option::Some(
+                            #root::core::SqlValue::I32(v),
+                        ) => i64::from(v),
+                        _ => return ::core::result::Result::Ok(()),
+                    };
+                    for row in rows {
+                        cb(row).await?;
+                    }
+                    if len < batch {
+                        return ::core::result::Result::Ok(());
+                    }
+                    last_seen = max_pk;
+                }
+            }
+
             /// Delete every row of this model — `TRUNCATE TABLE
             /// <table> RESTART IDENTITY CASCADE` on Postgres,
             /// `DELETE FROM <table>` on MySQL / SQLite (which don't

--- a/crates/rustango/tests/model_chunk_sqlite_live.rs
+++ b/crates/rustango/tests/model_chunk_sqlite_live.rs
@@ -109,6 +109,22 @@ async fn chunk_by_id_visits_every_row_via_keyset_pagination() {
 }
 
 #[tokio::test]
+async fn each_visits_every_row_individually() {
+    // Eloquent `Model::each(...)` — per-row callback. The
+    // emitted method walks every row exactly once.
+    let pool = make_pool().await;
+    seed(&pool, 12).await;
+    let count = AtomicI64::new(0);
+    Post::each(5, &pool, |_row| {
+        count.fetch_add(1, Ordering::SeqCst);
+        async { Ok(()) }
+    })
+    .await
+    .unwrap();
+    assert_eq!(count.load(Ordering::SeqCst), 12);
+}
+
+#[tokio::test]
 async fn chunk_by_id_empty_table_invokes_callback_zero_times() {
     let pool = make_pool().await;
     let calls = AtomicI64::new(0);


### PR DESCRIPTION
Eloquent `Model::each(fn ($row) { ... }, $batch)` parity. Streams every row individually via the same keyset-paginated scan `chunk_by_id` uses, but invokes the callback once per row.

```rust
Post::each(500, &pool, |p| async move { reindex(p).await }).await?;
```

3422 lib + 7 chunk-family integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)