### PR TITLE
feat(orm): `QuerySet::when` / `unless` / `tap` — Eloquent conditional builders

### DIFF
--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1001,6 +1001,80 @@ impl<T: Model> QuerySet<T> {
         self
     }
 
+    /// Eloquent `Builder::when($condition, $callback)` — apply
+    /// `f` to `self` only when `condition` is `true`, otherwise
+    /// return `self` unchanged. Sugars the otherwise-noisy
+    /// "conditionally compose a filter" pattern:
+    ///
+    /// ```ignore
+    /// let qs = Post::objects()
+    ///     .when(only_active, |qs| qs.filter("active", true))
+    ///     .when(category_id.is_some(), |qs| {
+    ///         qs.filter("category_id", category_id.unwrap())
+    ///     });
+    /// ```
+    ///
+    /// Equivalent to:
+    ///
+    /// ```ignore
+    /// let mut qs = Post::objects();
+    /// if only_active { qs = qs.filter("active", true); }
+    /// if let Some(id) = category_id { qs = qs.filter("category_id", id); }
+    /// ```
+    ///
+    /// The closure form preserves builder-style chaining when the
+    /// condition isn't a simple `bool` but the result of an
+    /// in-line predicate. Issue [#830](https://github.com/ujeenet/rustango/issues/830) follow-up.
+    #[must_use]
+    pub fn when<F>(self, condition: bool, f: F) -> Self
+    where
+        F: FnOnce(Self) -> Self,
+    {
+        if condition {
+            f(self)
+        } else {
+            self
+        }
+    }
+
+    /// Eloquent `Builder::unless($condition, $callback)` — inverse
+    /// of [`Self::when`]. Apply `f` only when `condition` is
+    /// `false`. Mirrors Eloquent's twin helper so `.unless(...)`
+    /// reads naturally in code that's clearer when the guard is
+    /// stated negatively (e.g. `qs.unless(is_admin, |q|
+    /// q.filter("public", true))`).
+    #[must_use]
+    pub fn unless<F>(self, condition: bool, f: F) -> Self
+    where
+        F: FnOnce(Self) -> Self,
+    {
+        if condition {
+            self
+        } else {
+            f(self)
+        }
+    }
+
+    /// Eloquent `Builder::tap($callback)` — run a side-effecting
+    /// callback against the queryset and return it unchanged. Lets
+    /// you slot logging / metrics / debug-print into a builder
+    /// chain without breaking the fluent shape:
+    ///
+    /// ```ignore
+    /// let rows = Post::objects()
+    ///     .filter("active", true)
+    ///     .tap(|qs| tracing::debug!(?qs, "about to fetch"))
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    #[must_use]
+    pub fn tap<F>(self, f: F) -> Self
+    where
+        F: FnOnce(&Self),
+    {
+        f(&self);
+        self
+    }
+
     /// Filter to only rows that have NOT been soft-deleted.
     ///
     /// When `T` carries `#[rustango(soft_delete)]` on a nullable

--- a/crates/rustango/tests/queryset_when_unless_tap.rs
+++ b/crates/rustango/tests/queryset_when_unless_tap.rs
@@ -1,0 +1,85 @@
+//! Eloquent-shape conditional / side-effect builder helpers on
+//! `QuerySet`: `.when(cond, f)` / `.unless(cond, f)` / `.tap(f)`.
+//! Unit tests verify the conditional semantics without touching
+//! a real DB — the goal is to assert the closure ran or didn't
+//! based on the boolean flag.
+
+use rustango::core::Model as _;
+use rustango::sql::Auto;
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "wut_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub status: String,
+}
+
+#[test]
+fn when_true_runs_closure_and_when_false_skips() {
+    // Sentinel: the closure pushes a filter; whether it fired is
+    // observable by the SQL the queryset compiles to. We don't
+    // compile here (would need a dialect) — instead use a captured
+    // `Cell<bool>` that flips when the closure runs.
+    use std::cell::Cell;
+    let fired = Cell::new(false);
+    let _qs = Post::objects().when(true, |qs| {
+        fired.set(true);
+        qs.filter("status", "draft")
+    });
+    assert!(fired.get(), "when(true) must run the closure");
+
+    let fired = Cell::new(false);
+    let _qs = Post::objects().when(false, |qs| {
+        fired.set(true);
+        qs.filter("status", "draft")
+    });
+    assert!(!fired.get(), "when(false) must NOT run the closure");
+}
+
+#[test]
+fn unless_inverts_when_semantics() {
+    use std::cell::Cell;
+    let fired = Cell::new(false);
+    let _qs = Post::objects().unless(false, |qs| {
+        fired.set(true);
+        qs.filter("status", "draft")
+    });
+    assert!(fired.get(), "unless(false) must run the closure");
+
+    let fired = Cell::new(false);
+    let _qs = Post::objects().unless(true, |qs| {
+        fired.set(true);
+        qs.filter("status", "draft")
+    });
+    assert!(!fired.get(), "unless(true) must NOT run the closure");
+}
+
+#[test]
+fn tap_runs_side_effect_and_returns_self_unchanged() {
+    use std::cell::Cell;
+    let observed = Cell::new(false);
+    let _qs = Post::objects()
+        .filter("status", "draft")
+        .tap(|_qs| observed.set(true));
+    assert!(observed.get());
+}
+
+#[test]
+fn when_chains_compose_naturally() {
+    // Build a queryset whose final shape depends on runtime
+    // flags. The point of `.when()` is that this stays in
+    // fluent-builder shape instead of breaking into imperative
+    // mut-shadowing.
+    let only_drafts = true;
+    let with_author: Option<i64> = Some(42);
+    let _qs = Post::objects()
+        .when(only_drafts, |q| q.filter("status", "draft"))
+        .when(with_author.is_some(), |q| {
+            q.filter("id", with_author.unwrap_or_default())
+        });
+}


### PR DESCRIPTION
Three Eloquent-shape builder helpers on `QuerySet<T>`:

```rust
let qs = Post::objects()
    .when(only_active, |qs| qs.filter("active", true))
    .unless(is_admin, |qs| qs.filter("public", true))
    .tap(|qs| tracing::debug!(?qs, "before fetch"));
```

Pure builder helpers — no IR change. 3422 lib + 4 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)