### PR TITLE
feat(orm): `QuerySet::is_empty(&pool)` — inverse of exists_pool

### DIFF
--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -2097,6 +2097,18 @@ pub trait ExistsPool<T: Model + Send> {
         pool: &Pool,
     ) -> impl std::future::Future<Output = Result<bool, ExecError>> + Send;
 
+    /// `Ok(true)` when the queryset matches zero rows, `Ok(false)`
+    /// otherwise — inverse of [`Self::exists_pool`]. Reads naturally
+    /// in negation-flavored code (`if qs.is_empty(&pool).await? {
+    /// ... }`) where `!qs.exists_pool(...).await?` is awkward.
+    ///
+    /// # Errors
+    /// As [`Self::exists_pool`].
+    fn is_empty(
+        self,
+        pool: &Pool,
+    ) -> impl std::future::Future<Output = Result<bool, ExecError>> + Send;
+
     /// `Ok(true)` when a row with `pk = pk_value` is contained in the
     /// queryset. #330. Looks up the PK column from `T::SCHEMA`; errors
     /// when the model has no primary key (very rare — view-backed
@@ -2116,6 +2128,11 @@ impl<T: Model + Send> ExistsPool<T> for QuerySet<T> {
     async fn exists_pool(self, pool: &Pool) -> Result<bool, ExecError> {
         let count = self.count_pool(pool).await?;
         Ok(count > 0)
+    }
+
+    async fn is_empty(self, pool: &Pool) -> Result<bool, ExecError> {
+        let count = self.count_pool(pool).await?;
+        Ok(count == 0)
     }
 
     async fn contains_pk(

--- a/crates/rustango/tests/queryset_is_empty_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_is_empty_sqlite_live.rs
@@ -1,0 +1,70 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::is_empty(&pool)` — inverse of
+//! `exists_pool`, more readable in negation-flavored code.
+
+use rustango::sql::{sqlx, Auto, ExistsPool as _, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "ie_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE ie_post (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+#[tokio::test]
+async fn is_empty_returns_true_for_empty_filter() {
+    let pool = make_pool().await;
+    assert!(Post::objects().is_empty(&pool).await.unwrap());
+}
+
+#[tokio::test]
+async fn is_empty_returns_false_when_rows_match() {
+    let pool = make_pool().await;
+    let mut p = Post {
+        id: Auto::default(),
+        title: "alpha".into(),
+    };
+    p.save_pool(&pool).await.unwrap();
+    assert!(!Post::objects().is_empty(&pool).await.unwrap());
+}
+
+#[tokio::test]
+async fn is_empty_is_inverse_of_exists_pool() {
+    let pool = make_pool().await;
+    // Empty table — exists=false, is_empty=true.
+    assert_eq!(
+        Post::objects().exists_pool(&pool).await.unwrap(),
+        !Post::objects().is_empty(&pool).await.unwrap()
+    );
+
+    // After insert — exists=true, is_empty=false.
+    let mut p = Post {
+        id: Auto::default(),
+        title: "beta".into(),
+    };
+    p.save_pool(&pool).await.unwrap();
+    assert_eq!(
+        Post::objects().exists_pool(&pool).await.unwrap(),
+        !Post::objects().is_empty(&pool).await.unwrap()
+    );
+}


### PR DESCRIPTION
`is_empty` returns `Ok(true)` when the queryset matches zero rows. Reads more naturally than `!qs.exists_pool(...)` in negation-flavored code. Added to the `ExistsPool` trait.

3422 lib + 3 integration tests pass. Litmus clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)