### PR TITLE
feat(orm): `QuerySet::pluck<U>(col, &pool)` — Eloquent pluck on filtered queryset

### DIFF
--- a/crates/rustango/src/sql/executor/values.rs
+++ b/crates/rustango/src/sql/executor/values.rs
@@ -380,6 +380,38 @@ impl<T: crate::core::Model> crate::query::ValuesListQuerySet<T> {
     }
 }
 
+impl<T: crate::core::Model> crate::query::QuerySet<T> {
+    /// Eloquent `Builder::pluck($col)` — single-column projection
+    /// on this queryset, decoded into `Vec<U>`. Sugar over
+    /// `self.values_list_flat(col).fetch::<U>(pool).await`.
+    ///
+    /// ```ignore
+    /// // Eloquent: Post::where('published', true)->pluck('title');
+    /// // rustango:
+    /// let titles: Vec<String> = Post::objects()
+    ///     .filter("published", true)
+    ///     .pluck::<String>("title", &pool).await?;
+    /// ```
+    ///
+    /// `U` must be decodable from the column's SQL type on every
+    /// dialect the binary targets — common picks: `i64` / `i32` /
+    /// `String` / `bool` / `f64`.
+    ///
+    /// Differs from `Model::pluck(col, &pool)` (already shipped) in
+    /// that the static-method form scans every row of the table;
+    /// this method's queryset can carry filters / ordering / limits
+    /// so you can pluck a column from a narrowed result set.
+    ///
+    /// # Errors
+    /// As [`crate::query::ValuesFlatQuerySet::fetch`].
+    pub async fn pluck<U>(self, col: &'static str, pool: &Pool) -> Result<Vec<U>, ExecError>
+    where
+        U: MaybePgScalar + MaybeMyScalar + MaybeSqliteScalar + Send + Unpin,
+    {
+        self.values_list_flat(col).fetch::<U>(pool).await
+    }
+}
+
 impl<T: crate::core::Model> crate::query::ValuesFlatQuerySet<T> {
     /// Execute the single-column projection and decode each row's cell
     /// into `U`.

--- a/crates/rustango/tests/queryset_pluck_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_pluck_sqlite_live.rs
@@ -1,0 +1,90 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::pluck<U>(col, &pool)` —
+//! Eloquent `Builder::pluck($col)` parity on filtered querysets.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "qp_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+    pub published: bool,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE qp_post (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            title     TEXT NOT NULL,
+            published INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn seed(pool: &Pool) {
+    for (t, pub_) in [
+        ("alpha", true),
+        ("beta", false),
+        ("gamma", true),
+        ("delta", true),
+    ] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: t.into(),
+            published: pub_,
+        };
+        p.save_pool(pool).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn pluck_on_filtered_queryset_returns_only_matching_column() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let mut titles: Vec<String> = Post::objects()
+        .filter("published", true)
+        .pluck::<String>("title", &pool)
+        .await
+        .unwrap();
+    titles.sort();
+    assert_eq!(titles, vec!["alpha", "delta", "gamma"]);
+}
+
+#[tokio::test]
+async fn pluck_decodes_into_any_scalar_type() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    // i64 column round-trip.
+    let mut ids: Vec<i64> = Post::objects()
+        .filter("published", true)
+        .pluck::<i64>("id", &pool)
+        .await
+        .unwrap();
+    ids.sort();
+    assert_eq!(ids.len(), 3);
+}
+
+#[tokio::test]
+async fn pluck_on_empty_queryset_returns_empty_vec() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let titles: Vec<String> = Post::objects()
+        .filter("published", false)
+        .filter("title", "alpha")
+        .pluck::<String>("title", &pool)
+        .await
+        .unwrap();
+    assert!(titles.is_empty());
+}


### PR DESCRIPTION
Eloquent `Builder::pluck($col)` parity at the QuerySet layer — single-column projection on a filtered queryset.

```rust
let titles: Vec<String> = Post::objects()
    .filter("published", true)
    .pluck::<String>("title", &pool).await?;
```

Differs from `Model::pluck` (already shipped) in that the static-method form scans every row; this method's queryset can carry filters / ordering / limits.

Pure sugar over `self.values_list_flat(col).fetch::<U>(pool)`. 3422 lib + 3 integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)