### PR TITLE
feat(orm): `QuerySet::to_sql` / `to_compiled` — Eloquent toSql() debug rendering

### DIFF
--- a/crates/rustango/src/sql/executor/values.rs
+++ b/crates/rustango/src/sql/executor/values.rs
@@ -410,6 +410,50 @@ impl<T: crate::core::Model> crate::query::QuerySet<T> {
     {
         self.values_list_flat(col).fetch::<U>(pool).await
     }
+
+    /// Eloquent `Builder::toSql()` — render this queryset to its SQL
+    /// string in the pool's dialect, without executing.
+    ///
+    /// Placeholders use the dialect-specific syntax (`$1` / `$2` on
+    /// PG, `?` on MySQL / SQLite). Bind values are NOT included in
+    /// the returned string — use [`Self::to_compiled`] if you need
+    /// the parameter list too.
+    ///
+    /// Useful for debugging, logging, snapshot tests, and copying
+    /// the SQL into a database client to run by hand.
+    ///
+    /// ```ignore
+    /// let sql = Post::objects()
+    ///     .filter("published", true)
+    ///     .order_by(&[("created_at", true)])
+    ///     .limit(10)
+    ///     .to_sql(&pool)?;
+    /// // -> "SELECT … FROM \"post\" WHERE \"published\" = $1 …"
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`ExecError::Query`] if the queryset compile step
+    /// fails (e.g. unknown field, type mismatch) and
+    /// [`ExecError::Sql`] from the dialect's writer.
+    pub fn to_sql(self, pool: &Pool) -> Result<String, ExecError> {
+        let q = self.compile()?;
+        let stmt = pool.dialect().compile_select(&q)?;
+        Ok(stmt.sql)
+    }
+
+    /// Like [`Self::to_sql`] but returns the full
+    /// [`crate::sql::CompiledStatement`] (SQL + bound parameters).
+    /// Use this when you need the binds — e.g. logging both halves
+    /// of a parameterized query or building a snapshot test that
+    /// asserts on exact placeholder shape.
+    ///
+    /// # Errors
+    /// As [`Self::to_sql`].
+    pub fn to_compiled(self, pool: &Pool) -> Result<crate::sql::CompiledStatement, ExecError> {
+        let q = self.compile()?;
+        let stmt = pool.dialect().compile_select(&q)?;
+        Ok(stmt)
+    }
 }
 
 impl<T: crate::core::Model> crate::query::ValuesFlatQuerySet<T> {

--- a/crates/rustango/tests/queryset_to_sql_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_to_sql_sqlite_live.rs
@@ -1,0 +1,62 @@
+#![cfg(feature = "sqlite")]
+//! Unit-style test for `QuerySet::to_sql(&pool)` / `to_compiled(&pool)` —
+//! Eloquent `Builder::toSql()` parity. No DB round-trip; just verifies
+//! the queryset compiles to a SQL string in the pool's dialect.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "ts_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+    pub published: bool,
+}
+
+async fn empty_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    Pool::Sqlite(p)
+}
+
+#[tokio::test]
+async fn to_sql_renders_select_with_where_and_order_by() {
+    let pool = empty_pool().await;
+    let sql = Post::objects()
+        .filter("published", true)
+        .order_by(&[("id", true)])
+        .limit(10)
+        .to_sql(&pool)
+        .unwrap();
+    // Sanity: contains the table, the WHERE filter, the ORDER BY, the LIMIT.
+    assert!(sql.contains("ts_post"));
+    assert!(sql.contains("WHERE"));
+    assert!(sql.contains("published"));
+    assert!(sql.contains("ORDER BY"));
+    assert!(sql.contains("LIMIT"));
+}
+
+#[tokio::test]
+async fn to_compiled_returns_sql_and_params() {
+    let pool = empty_pool().await;
+    let stmt = Post::objects()
+        .filter("published", true)
+        .filter("title", "alpha")
+        .to_compiled(&pool)
+        .unwrap();
+    assert!(stmt.sql.contains("WHERE"));
+    // Two filters → two bound parameters.
+    assert_eq!(stmt.params.len(), 2);
+}
+
+#[tokio::test]
+async fn to_sql_errors_on_unknown_field() {
+    let pool = empty_pool().await;
+    let result = Post::objects().filter("nope", "x").to_sql(&pool);
+    assert!(result.is_err(), "unknown field must surface as ExecError");
+}


### PR DESCRIPTION
Eloquent `Builder::toSql()` parity. Render a queryset to its SQL string in the pool's dialect without executing — useful for debug logging, snapshot tests, and copying SQL into a DB client.

```rust
let sql: String = Post::objects().filter("published", true).limit(10).to_sql(&pool)?;
let stmt: CompiledStatement = Post::objects().filter("published", true).to_compiled(&pool)?;
```

`to_sql` returns just the SQL string (Eloquent shape). `to_compiled` returns the full `CompiledStatement` with binds.

3422 lib + 3 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)