### PR TITLE
feat(orm): `Model::find_many_or_fail(pks, &pool)` — Eloquent findOrFail with multi-ID

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -5666,6 +5666,62 @@ fn inherent_impl_tokens(
                 }
             }
 
+            /// Look up multiple rows by primary key, **failing** if
+            /// any requested PK is missing. Eloquent
+            /// `Model::findOrFail([1, 2, 3])` parity. Returns rows in
+            /// inventory order (NOT request order — same as
+            /// [`Self::find_many`]).
+            ///
+            /// Empty `pks` returns an empty `Vec` (no rows requested
+            /// → nothing to fail on).
+            ///
+            /// Differs from [`Self::find_many`] in that this method
+            /// requires every PK to resolve. If even one is missing,
+            /// the call surfaces `sqlx::Error::RowNotFound` (wrapped
+            /// in `ExecError::Driver`). Rows are deduped at the SQL
+            /// layer, so passing the same PK twice in `pks` counts as
+            /// one expected row.
+            ///
+            /// # Errors
+            /// As [`Self::find_many`], plus `RowNotFound` when the
+            /// returned row count is less than the count of distinct
+            /// requested PKs.
+            pub async fn find_many_or_fail<V>(
+                pks: impl ::core::iter::IntoIterator<Item = V>,
+                pool: &#root::sql::Pool,
+            ) -> ::core::result::Result<
+                ::std::vec::Vec<Self>,
+                #root::sql::ExecError,
+            >
+            where
+                V: ::core::convert::Into<#root::core::SqlValue>,
+            {
+                let _values: ::std::vec::Vec<#root::core::SqlValue> =
+                    pks.into_iter().map(::core::convert::Into::into).collect();
+                if _values.is_empty() {
+                    return ::core::result::Result::Ok(::std::vec::Vec::new());
+                }
+                // Dedup the requested PK list before counting so
+                // duplicate-PK requests don't false-fail (the SQL
+                // `IN (...)` clause naturally dedups too).
+                let mut _seen: ::std::collections::HashSet<
+                    ::std::string::String,
+                > = ::std::collections::HashSet::new();
+                for v in &_values {
+                    _seen.insert(v.to_display_string());
+                }
+                let _expected = _seen.len();
+                let _rows = Self::find_many(_values, pool).await?;
+                if _rows.len() < _expected {
+                    return ::core::result::Result::Err(
+                        #root::sql::ExecError::Driver(
+                            #root::sql::sqlx::Error::RowNotFound,
+                        ),
+                    );
+                }
+                ::core::result::Result::Ok(_rows)
+            }
+
             /// Find by primary key or run `fallback` to produce a
             /// default row to return. Eloquent
             /// `Model::findOr($pk, fn() => …)` parity.

--- a/crates/rustango/tests/model_find_many_or_fail_sqlite_live.rs
+++ b/crates/rustango/tests/model_find_many_or_fail_sqlite_live.rs
@@ -1,0 +1,84 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `Model::find_many_or_fail(pks, &pool)` —
+//! Eloquent `Model::findOrFail([1, 2, 3])` parity.
+
+use rustango::sql::{sqlx, Auto, ExecError, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "fmf_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE fmf_post (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn seed(pool: &Pool) -> Vec<i64> {
+    let mut ids = Vec::new();
+    for t in ["alpha", "beta", "gamma"] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: t.into(),
+        };
+        p.save_pool(pool).await.unwrap();
+        ids.push(p.id.get().copied().unwrap());
+    }
+    ids
+}
+
+#[tokio::test]
+async fn find_many_or_fail_returns_all_requested_rows() {
+    let pool = make_pool().await;
+    let ids = seed(&pool).await;
+    let rows = Post::find_many_or_fail(ids.clone(), &pool).await.unwrap();
+    assert_eq!(rows.len(), 3);
+}
+
+#[tokio::test]
+async fn find_many_or_fail_errors_when_any_pk_missing() {
+    let pool = make_pool().await;
+    let ids = seed(&pool).await;
+    // Add a non-existent PK; should fail.
+    let mut request = ids;
+    request.push(999_999);
+    let err = Post::find_many_or_fail(request, &pool).await.unwrap_err();
+    matches!(err, ExecError::Driver(sqlx::Error::RowNotFound));
+}
+
+#[tokio::test]
+async fn find_many_or_fail_empty_input_returns_empty() {
+    let pool = make_pool().await;
+    let empty: Vec<i64> = Vec::new();
+    let rows = Post::find_many_or_fail(empty, &pool).await.unwrap();
+    assert!(rows.is_empty());
+}
+
+#[tokio::test]
+async fn find_many_or_fail_dedups_duplicate_pks() {
+    // Passing the same PK twice should not double-count the
+    // expected row count.
+    let pool = make_pool().await;
+    let ids = seed(&pool).await;
+    let dup_request = vec![ids[0], ids[0], ids[1]];
+    let rows = Post::find_many_or_fail(dup_request, &pool).await.unwrap();
+    // Two distinct PKs → two distinct rows back, no error.
+    assert_eq!(rows.len(), 2);
+}


### PR DESCRIPTION
Sibling of `find_or_fail` (single PK) and `find_many` (multi PK, silent on missing). Returns all matched rows or errors with `RowNotFound` if any requested PK is missing.

```rust
let posts = Post::find_many_or_fail([1, 2, 3], &pool).await?;
```

Dedups duplicate PKs before counting; empty input returns empty Vec.

3422 lib + 4 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)