### PR TITLE
feat(orm): `QuerySet::sum / avg / min / max` — aggregate scalars on filtered querysets

### DIFF
--- a/crates/rustango/src/sql/executor/values.rs
+++ b/crates/rustango/src/sql/executor/values.rs
@@ -441,6 +441,118 @@ impl<T: crate::core::Model> crate::query::QuerySet<T> {
         Ok(stmt.sql)
     }
 
+    /// Eloquent `Builder::sum($col)` on a filtered queryset —
+    /// `SELECT SUM(col) FROM <table> WHERE …`. Returns `Ok(None)`
+    /// when the filtered result set is empty.
+    ///
+    /// Differs from `Model::sum(col, &pool)` (already shipped)
+    /// which sums over every row of the table; this method respects
+    /// the queryset's accumulated filters.
+    ///
+    /// # Errors
+    /// As [`crate::sql::fetch_aggregate_pool`]; plus
+    /// [`ExecError::Query(QueryError::UnknownField)`] when `col`
+    /// isn't declared on the model.
+    pub async fn sum<U>(self, col: &str, pool: &Pool) -> Result<Option<U>, ExecError>
+    where
+        (Option<U>,): crate::sql::MaybePgFromRow
+            + crate::sql::MaybeMyFromRow
+            + crate::sql::MaybeSqliteFromRow
+            + Send
+            + Unpin,
+    {
+        self.queryset_aggregate_one::<U>(col, crate::core::AggregateExpr::Sum, pool)
+            .await
+    }
+
+    /// Eloquent `Builder::avg($col)` on a filtered queryset.
+    ///
+    /// # Errors
+    /// As [`Self::sum`].
+    pub async fn avg<U>(self, col: &str, pool: &Pool) -> Result<Option<U>, ExecError>
+    where
+        (Option<U>,): crate::sql::MaybePgFromRow
+            + crate::sql::MaybeMyFromRow
+            + crate::sql::MaybeSqliteFromRow
+            + Send
+            + Unpin,
+    {
+        self.queryset_aggregate_one::<U>(col, crate::core::AggregateExpr::Avg, pool)
+            .await
+    }
+
+    /// Eloquent `Builder::min($col)` on a filtered queryset.
+    ///
+    /// # Errors
+    /// As [`Self::sum`].
+    pub async fn min<U>(self, col: &str, pool: &Pool) -> Result<Option<U>, ExecError>
+    where
+        (Option<U>,): crate::sql::MaybePgFromRow
+            + crate::sql::MaybeMyFromRow
+            + crate::sql::MaybeSqliteFromRow
+            + Send
+            + Unpin,
+    {
+        self.queryset_aggregate_one::<U>(col, crate::core::AggregateExpr::Min, pool)
+            .await
+    }
+
+    /// Eloquent `Builder::max($col)` on a filtered queryset.
+    ///
+    /// # Errors
+    /// As [`Self::sum`].
+    pub async fn max<U>(self, col: &str, pool: &Pool) -> Result<Option<U>, ExecError>
+    where
+        (Option<U>,): crate::sql::MaybePgFromRow
+            + crate::sql::MaybeMyFromRow
+            + crate::sql::MaybeSqliteFromRow
+            + Send
+            + Unpin,
+    {
+        self.queryset_aggregate_one::<U>(col, crate::core::AggregateExpr::Max, pool)
+            .await
+    }
+
+    /// Internal: shared aggregate-on-queryset helper for `sum` /
+    /// `avg` / `min` / `max`. Validates the column against the
+    /// model schema, lifts the queryset's filters into the
+    /// aggregate's WHERE clause, then runs through
+    /// `fetch_aggregate_pool` and extracts the single column value.
+    async fn queryset_aggregate_one<U>(
+        self,
+        col: &str,
+        build: fn(&'static str) -> crate::core::AggregateExpr,
+        pool: &Pool,
+    ) -> Result<Option<U>, ExecError>
+    where
+        (Option<U>,): crate::sql::MaybePgFromRow
+            + crate::sql::MaybeMyFromRow
+            + crate::sql::MaybeSqliteFromRow
+            + Send
+            + Unpin,
+    {
+        let col_static = crate::sql::model_shortcuts::resolve_col::<T>(col)?;
+        // Lower this queryset to a SELECT to grab its WHERE clause,
+        // then hand-build the AggregateQuery so the aggregate's
+        // projection is exactly `<build>(col)` (no extra columns) —
+        // matches the shape `aggregate_one_pool` uses table-wide so
+        // the `Vec<(Option<U>,)>` decode lines up.
+        let select_q = self.compile()?;
+        let aggregate_q = crate::core::AggregateQuery {
+            model: <T as crate::core::Model>::SCHEMA,
+            where_clause: select_q.where_clause,
+            group_by: Vec::new(),
+            aggregates: vec![("v", build(col_static))],
+            aliases: Vec::new(),
+            having: None,
+            order_by: Vec::new(),
+            limit: None,
+            offset: None,
+        };
+        let rows: Vec<(Option<U>,)> = crate::sql::fetch_aggregate_pool(pool, &aggregate_q).await?;
+        Ok(rows.into_iter().next().and_then(|t| t.0))
+    }
+
     /// Like [`Self::to_sql`] but returns the full
     /// [`crate::sql::CompiledStatement`] (SQL + bound parameters).
     /// Use this when you need the binds — e.g. logging both halves

--- a/crates/rustango/tests/queryset_aggregates_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_aggregates_sqlite_live.rs
@@ -1,0 +1,100 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::sum / avg / min / max` —
+//! Eloquent aggregate builders on a filtered queryset. Differ
+//! from `Model::sum / avg / min / max` (table-wide) in that the
+//! queryset's accumulated filters narrow the aggregate's input.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "qa_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub views: i64,
+    pub published: bool,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE qa_post (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            views     INTEGER NOT NULL,
+            published INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn seed(pool: &Pool) {
+    for (v, pub_) in [
+        (10_i64, true),
+        (20, true),
+        (30, true),
+        (1000, false), // outlier — only present in unfiltered queries
+    ] {
+        let mut p = Post {
+            id: Auto::default(),
+            views: v,
+            published: pub_,
+        };
+        p.save_pool(pool).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn sum_on_filtered_queryset_excludes_unmatched_rows() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let s: Option<i64> = Post::objects()
+        .filter("published", true)
+        .sum::<i64>("views", &pool)
+        .await
+        .unwrap();
+    // 10 + 20 + 30 = 60. The 1000-view outlier is excluded.
+    assert_eq!(s, Some(60));
+}
+
+#[tokio::test]
+async fn min_max_avg_on_filtered_queryset() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let min: Option<i64> = Post::objects()
+        .filter("published", true)
+        .min::<i64>("views", &pool)
+        .await
+        .unwrap();
+    let max: Option<i64> = Post::objects()
+        .filter("published", true)
+        .max::<i64>("views", &pool)
+        .await
+        .unwrap();
+    let avg: Option<f64> = Post::objects()
+        .filter("published", true)
+        .avg::<f64>("views", &pool)
+        .await
+        .unwrap();
+    assert_eq!(min, Some(10));
+    assert_eq!(max, Some(30));
+    assert!((avg.unwrap() - 20.0).abs() < 0.001);
+}
+
+#[tokio::test]
+async fn sum_on_empty_filtered_set_returns_none() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let s: Option<i64> = Post::objects()
+        .filter("views__gt", 9999_i64)
+        .sum::<i64>("views", &pool)
+        .await
+        .unwrap();
+    assert_eq!(s, None);
+}


### PR DESCRIPTION
Eloquent `Builder::sum/avg/min/max` parity. Filtered versions of `Model::sum` / `Model::avg` / `Model::min` / `Model::max` (table-wide).

```rust
let total: Option<i64> = Post::objects().filter("published", true).sum::<i64>("views", &pool).await?;
```

3422 lib + 3 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)