### PR TITLE
feat(orm): `Model::find_or_new` — Eloquent findOrNew with exists flag

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -5749,6 +5749,35 @@ fn inherent_impl_tokens(
                 )
             }
 
+            /// Same as [`Self::find_or`] but also returns a `bool`
+            /// indicating whether the row was found in the DB
+            /// (`true`) or freshly built from `fallback` (`false`).
+            /// Eloquent `Model::findOrNew($pk, [attrs])` parity —
+            /// in PHP the returned model also exposes `->exists`;
+            /// here that's surfaced as the second tuple element.
+            ///
+            /// Useful for edit-or-create form handlers where the
+            /// caller needs to know whether to PATCH or POST when
+            /// the user submits the form.
+            ///
+            /// # Errors
+            /// As [`Self::find`].
+            pub async fn find_or_new<F>(
+                pk: impl ::core::convert::Into<#root::core::SqlValue>,
+                pool: &#root::sql::Pool,
+                fallback: F,
+            ) -> ::core::result::Result<(Self, bool), #root::sql::ExecError>
+            where
+                F: ::core::ops::FnOnce() -> Self,
+            {
+                match Self::find(pk, pool).await? {
+                    ::core::option::Option::Some(_row) => ::core::result::Result::Ok((_row, true)),
+                    ::core::option::Option::None => {
+                        ::core::result::Result::Ok((fallback(), false))
+                    }
+                }
+            }
+
             /// Fetch the first row of the table, or run `fallback`
             /// when the table is empty. Eloquent
             /// `Model::firstOr(fn() => …)` parity.

--- a/crates/rustango/tests/model_find_or_new_sqlite_live.rs
+++ b/crates/rustango/tests/model_find_or_new_sqlite_live.rs
@@ -1,0 +1,65 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `Model::find_or_new(pk, &pool, make_fn)` —
+//! Eloquent `findOrNew` parity returning (Self, exists: bool).
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "fon_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE fon_post (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+#[tokio::test]
+async fn find_or_new_returns_existing_with_exists_true() {
+    let pool = make_pool().await;
+    let mut p = Post {
+        id: Auto::default(),
+        title: "real".into(),
+    };
+    p.save_pool(&pool).await.unwrap();
+    let pk = p.id.get().copied().unwrap();
+
+    let (found, exists) = Post::find_or_new(pk, &pool, || Post {
+        id: Auto::default(),
+        title: "fallback".into(),
+    })
+    .await
+    .unwrap();
+    assert!(exists);
+    assert_eq!(found.title, "real");
+}
+
+#[tokio::test]
+async fn find_or_new_returns_fallback_with_exists_false() {
+    let pool = make_pool().await;
+    let (built, exists) = Post::find_or_new(999_999_i64, &pool, || Post {
+        id: Auto::default(),
+        title: "fallback".into(),
+    })
+    .await
+    .unwrap();
+    assert!(!exists);
+    assert_eq!(built.title, "fallback");
+}


### PR DESCRIPTION
Returns `(row, exists: bool)` — `exists=true` when the PK was found, `false` when the fallback was used. Useful for edit-or-create forms that need to know which path was taken.

```rust
let (post, exists) = Post::find_or_new(form.id, &pool, || Post {
    id: Auto::default(),
    title: form.title.clone(),
}).await?;
```

3422 lib + 2 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)