### PR TITLE
feat(orm): `QuerySet::lock_for_update` — Eloquent alias of select_for_update

### DIFF
--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -341,6 +341,16 @@ impl<T: Model> QuerySet<T> {
         self
     }
 
+    /// Eloquent `Builder::lockForUpdate()` — bare-name alias of
+    /// [`Self::select_for_update`] matching Laravel muscle memory.
+    /// Same `FOR UPDATE` semantics: must run inside a transaction
+    /// (PG / MySQL); SQLite no-ops because it has no row-level lock
+    /// syntax.
+    #[must_use]
+    pub fn lock_for_update(self) -> Self {
+        self.select_for_update()
+    }
+
     /// PG / MySQL 8+: append `SKIP LOCKED` to the lock clause —
     /// "claim next available row" pattern. Rows currently locked by
     /// another transaction are silently filtered out instead of

--- a/crates/rustango/tests/queryset_lock_for_update_emission.rs
+++ b/crates/rustango/tests/queryset_lock_for_update_emission.rs
@@ -1,0 +1,24 @@
+//! Unit test for `QuerySet::lock_for_update` — Eloquent alias of
+//! `select_for_update`. Verifies both spelling produce identical
+//! compiled SelectQuery state.
+
+use rustango::sql::Auto;
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "lfu_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+}
+
+#[test]
+fn lock_for_update_is_alias_of_select_for_update() {
+    let q1 = Post::objects().lock_for_update().compile().unwrap();
+    let q2 = Post::objects().select_for_update().compile().unwrap();
+    assert_eq!(q1.lock_mode, q2.lock_mode);
+    assert!(q1.lock_mode.is_some());
+}


### PR DESCRIPTION
Eloquent muscle-memory alias for the existing Django-shape `select_for_update`. Same FOR UPDATE row-lock semantics.

3422 lib + 1 unit test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)