### PR TITLE
feat(orm): `Model::insert_or_ignore(&pool)` — Eloquent insertOrIgnore

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -2781,6 +2781,39 @@ fn inherent_impl_tokens(
                     };
                     #root::sql::insert_pool(pool, &_query).await
                 }
+
+                /// Eloquent `Model::insertOrIgnore()` — same shape
+                /// as the auto-PK branch above. Returns `Ok(true)`
+                /// when inserted, `Ok(false)` when a conflict caused
+                /// the INSERT to silently skip.
+                ///
+                /// # Errors
+                /// As [`Self::insert`].
+                pub async fn insert_or_ignore(
+                    &mut self,
+                    pool: &#root::sql::Pool,
+                ) -> ::core::result::Result<bool, #root::sql::ExecError> {
+                    let mut _columns: ::std::vec::Vec<&'static str> =
+                        ::std::vec::Vec::new();
+                    let mut _values: ::std::vec::Vec<#root::core::SqlValue> =
+                        ::std::vec::Vec::new();
+                    #( #pushes )*
+                    let _query = #root::core::InsertQuery {
+                        model: <Self as #root::core::Model>::SCHEMA,
+                        columns: _columns,
+                        values: _values,
+                        returning: ::std::vec::Vec::new(),
+                        on_conflict: ::core::option::Option::Some(
+                            #root::core::ConflictClause::DoNothing,
+                        ),
+                    };
+                    let dialect = pool.dialect();
+                    let stmt = dialect.compile_insert(&_query)?;
+                    let rows = #root::sql::raw_execute_pool(
+                        pool, &stmt.sql, stmt.params,
+                    ).await?;
+                    ::core::result::Result::Ok(rows > 0)
+                }
             }
         } else {
             quote! {
@@ -2810,6 +2843,48 @@ fn inherent_impl_tokens(
                     ).await?;
                     #root::sql::apply_auto_pk(_result, self)
                 }
+
+                /// Eloquent `Model::insertOrIgnore()` — INSERT this
+                /// row or silently skip on unique-constraint
+                /// violation. Returns `Ok(true)` when a row was
+                /// inserted, `Ok(false)` when a conflict caused the
+                /// INSERT to silently skip.
+                ///
+                /// **Caveat on auto-PK models**: when the row is
+                /// skipped (conflict), this instance's `Auto<T>`
+                /// fields stay `Unset` — no PK is back-populated
+                /// because the server didn't auto-assign one. For
+                /// "insert then read back the PK or the existing
+                /// row's PK", use the `upsert` family or
+                /// `get_or_create`.
+                ///
+                /// # Errors
+                /// As [`Self::insert`].
+                pub async fn insert_or_ignore(
+                    &mut self,
+                    pool: &#root::sql::Pool,
+                ) -> ::core::result::Result<bool, #root::sql::ExecError> {
+                    let mut _columns: ::std::vec::Vec<&'static str> =
+                        ::std::vec::Vec::new();
+                    let mut _values: ::std::vec::Vec<#root::core::SqlValue> =
+                        ::std::vec::Vec::new();
+                    #( #pushes )*
+                    let _query = #root::core::InsertQuery {
+                        model: <Self as #root::core::Model>::SCHEMA,
+                        columns: _columns,
+                        values: _values,
+                        returning: ::std::vec::Vec::new(),
+                        on_conflict: ::core::option::Option::Some(
+                            #root::core::ConflictClause::DoNothing,
+                        ),
+                    };
+                    let dialect = pool.dialect();
+                    let stmt = dialect.compile_insert(&_query)?;
+                    let rows = #root::sql::raw_execute_pool(
+                        pool, &stmt.sql, stmt.params,
+                    ).await?;
+                    ::core::result::Result::Ok(rows > 0)
+                }
             }
         }
     } else {
@@ -2834,6 +2909,44 @@ fn inherent_impl_tokens(
                     on_conflict: ::core::option::Option::None,
                 };
                 #root::sql::insert_pool(pool, &_query).await
+            }
+
+            /// Eloquent `Model::insertOrIgnore()` — INSERT this row
+            /// or silently skip on unique-constraint violation. Maps
+            /// to per-dialect "INSERT ... DO NOTHING on conflict":
+            /// PG `INSERT … ON CONFLICT DO NOTHING`, SQLite
+            /// `INSERT … ON CONFLICT DO NOTHING` (3.24+), MySQL
+            /// `INSERT IGNORE INTO …`.
+            ///
+            /// Returns `Ok(true)` when a row was inserted,
+            /// `Ok(false)` when a conflict caused the INSERT to
+            /// silently skip.
+            ///
+            /// Use for "create-if-absent" patterns where you don't
+            /// need the row back. For "find-or-create with the row
+            /// returned", use the queryset-level
+            /// `crate::sql::get_or_create` free function.
+            ///
+            /// # Errors
+            /// As [`Self::insert`], plus any dialect-specific
+            /// translation error from the ConflictClause writer.
+            pub async fn insert_or_ignore(
+                &self,
+                pool: &#root::sql::Pool,
+            ) -> ::core::result::Result<bool, #root::sql::ExecError> {
+                let _query = #root::core::InsertQuery {
+                    model: <Self as #root::core::Model>::SCHEMA,
+                    columns: ::std::vec![ #( #insert_columns ),* ],
+                    values: ::std::vec![ #( #insert_values ),* ],
+                    returning: ::std::vec::Vec::new(),
+                    on_conflict: ::core::option::Option::Some(
+                        #root::core::ConflictClause::DoNothing,
+                    ),
+                };
+                let dialect = pool.dialect();
+                let stmt = dialect.compile_insert(&_query)?;
+                let rows = #root::sql::raw_execute_pool(pool, &stmt.sql, stmt.params).await?;
+                ::core::result::Result::Ok(rows > 0)
             }
         }
     };

--- a/crates/rustango/tests/model_insert_or_ignore_sqlite_live.rs
+++ b/crates/rustango/tests/model_insert_or_ignore_sqlite_live.rs
@@ -1,0 +1,64 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `Model::insert_or_ignore(&pool)` —
+//! Eloquent `Model::insertOrIgnore()` parity.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "ioi_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80, unique)]
+    pub slug: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE ioi_post (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            slug TEXT NOT NULL UNIQUE
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+#[tokio::test]
+async fn insert_or_ignore_returns_true_when_row_is_new() {
+    let pool = make_pool().await;
+    let mut p = Post {
+        id: Auto::default(),
+        slug: "hello-world".into(),
+    };
+    let inserted = p.insert_or_ignore(&pool).await.unwrap();
+    assert!(inserted);
+}
+
+#[tokio::test]
+async fn insert_or_ignore_returns_false_when_unique_conflict() {
+    let pool = make_pool().await;
+    let mut p1 = Post {
+        id: Auto::default(),
+        slug: "dup".into(),
+    };
+    p1.save_pool(&pool).await.unwrap();
+
+    // Second insert with the same unique slug → conflict → skip.
+    let mut p2 = Post {
+        id: Auto::default(),
+        slug: "dup".into(),
+    };
+    let inserted = p2.insert_or_ignore(&pool).await.unwrap();
+    assert!(
+        !inserted,
+        "duplicate slug must hit the unique conflict + DO NOTHING"
+    );
+}


### PR DESCRIPTION
INSERT or silently skip on unique-constraint violation. Returns `bool` (inserted vs conflict-skipped). Per-dialect: PG/SQLite `ON CONFLICT DO NOTHING`, MySQL `INSERT IGNORE`.

```rust
let mut p = Post { id: Auto::default(), slug: "hello".into() };
let inserted = p.insert_or_ignore(&pool).await?;
```

Emitted on all three macro branches (uuid-auto, int-auto, manual PK).

3422 lib + 2 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)