### PR TITLE
feat(orm): `Model::paginate(page, per_page, &pool) -> (Vec<Self>, total)`

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -5286,6 +5286,34 @@ fn inherent_impl_tokens(
                     .await
             }
 
+            /// Eloquent `Model::paginate($per_page, $page)` — fetch
+            /// one page of rows AND the total row count in one
+            /// call. Returns `(rows, total)`. Two queries: a
+            /// LIMIT/OFFSET SELECT for the page + a `SELECT COUNT(*)`
+            /// for the total.
+            ///
+            /// Useful for paginated UIs that need both the visible
+            /// rows AND a "Page X of Y" / total-count widget. For
+            /// large tables prefer keyset pagination + cached count;
+            /// every call to `paginate` re-counts the full table.
+            ///
+            /// Same 1-indexed `page` convention as [`Self::for_page`].
+            ///
+            /// # Errors
+            /// As [`Self::for_page`] and [`Self::count`].
+            pub async fn paginate(
+                page: i64,
+                per_page: i64,
+                pool: &#root::sql::Pool,
+            ) -> ::core::result::Result<
+                (::std::vec::Vec<Self>, i64),
+                #root::sql::ExecError,
+            > {
+                let total = Self::count(pool).await?;
+                let rows = Self::for_page(page, per_page, pool).await?;
+                ::core::result::Result::Ok((rows, total))
+            }
+
             /// Bulk-update — set `set_col = set_val` on every row
             /// matching `where_col = where_val`. Returns affected row
             /// count. Eloquent

--- a/crates/rustango/tests/model_paginate_sqlite_live.rs
+++ b/crates/rustango/tests/model_paginate_sqlite_live.rs
@@ -1,0 +1,68 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `Model::paginate(page, per_page, &pool) ->
+//! (Vec<Self>, total)` — Eloquent paginate parity.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "pag_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE pag_post (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn seed(pool: &Pool, n: i32) {
+    for i in 0..n {
+        let mut p = Post {
+            id: Auto::default(),
+            title: format!("post-{i}"),
+        };
+        p.save_pool(pool).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn paginate_returns_page_rows_and_total() {
+    let pool = make_pool().await;
+    seed(&pool, 25).await;
+    let (rows, total) = Post::paginate(2, 10, &pool).await.unwrap();
+    assert_eq!(total, 25);
+    assert_eq!(rows.len(), 10);
+}
+
+#[tokio::test]
+async fn paginate_last_page_returns_partial() {
+    let pool = make_pool().await;
+    seed(&pool, 25).await;
+    let (rows, total) = Post::paginate(3, 10, &pool).await.unwrap();
+    assert_eq!(total, 25);
+    assert_eq!(rows.len(), 5);
+}
+
+#[tokio::test]
+async fn paginate_empty_table_returns_empty_with_zero_total() {
+    let pool = make_pool().await;
+    let (rows, total) = Post::paginate(1, 10, &pool).await.unwrap();
+    assert_eq!(total, 0);
+    assert!(rows.is_empty());
+}


### PR DESCRIPTION
Eloquent `paginate` parity — fetches one page + the total row count in a single call.

```rust
let (posts, total) = Post::paginate(2, 10, &pool).await?;
```

Two queries (LIMIT/OFFSET SELECT + COUNT(*)). 3422 lib + 3 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)