### PR TITLE
feat(orm): `QuerySet::paginate` — filtered counterpart of Model::paginate

### DIFF
--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -28,11 +28,13 @@ pub use q::Q;
 /// * [`Self::where_`] — typed (`User::id.gt(10)`); the column is already
 ///   resolved, so it bypasses the schema lookup at compile time.
 ///
-/// `Clone` is derived so a half-built queryset can be reused as a
-/// base for divergent branches — Eloquent `Builder::clone()` /
-/// `Builder::tap(fn ($q) { ... })` parity. The clone is a deep copy
-/// of every accumulated filter / order / limit; no shared state.
-#[derive(Clone)]
+/// Implements `Clone` manually so a half-built queryset can be
+/// reused as a base for divergent branches — Eloquent
+/// `Builder::clone()` / `Builder::tap(fn ($q) { ... })` parity.
+/// Manual impl (rather than `#[derive(Clone)]`) avoids the
+/// auto-derive's spurious `T: Clone` bound; `T` here is a
+/// `Model` (compile-time `&'static SCHEMA` reference) and never
+/// needs to itself be cloned.
 pub struct QuerySet<T: Model> {
     pending: Vec<PendingFilter>,
     limit: Option<i64>,
@@ -180,6 +182,26 @@ struct RawExprAssignment {
 impl<T: Model> Default for QuerySet<T> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<T: Model> Clone for QuerySet<T> {
+    fn clone(&self) -> Self {
+        Self {
+            pending: self.pending.clone(),
+            limit: self.limit,
+            offset: self.offset,
+            distinct: self.distinct.clone(),
+            select_related: self.select_related.clone(),
+            ad_hoc_joins: self.ad_hoc_joins.clone(),
+            order_by: self.order_by.clone(),
+            lock_mode: self.lock_mode.clone(),
+            compound: self.compound.clone(),
+            is_none: self.is_none,
+            disabled_global_scopes: self.disabled_global_scopes.clone(),
+            disable_all_global_scopes: self.disable_all_global_scopes,
+            _model: std::marker::PhantomData,
+        }
     }
 }
 

--- a/crates/rustango/src/sql/executor/values.rs
+++ b/crates/rustango/src/sql/executor/values.rs
@@ -465,6 +465,54 @@ impl<T: crate::core::Model> crate::query::QuerySet<T> {
             .await
     }
 
+    /// Eloquent `Builder::paginate($per_page, $page)` on a
+    /// **filtered** queryset — fetch one page of rows AND the
+    /// filtered total in a single call. Returns `(rows, total)`.
+    ///
+    /// Counterpart of the table-wide `Model::paginate`: this
+    /// version respects the queryset's accumulated filters so the
+    /// `total` reflects "matching rows" rather than "every row of
+    /// the table".
+    ///
+    /// Two queries under the hood: `SELECT COUNT(*) FROM … WHERE …`
+    /// for the total, then `SELECT … FROM … WHERE … LIMIT N OFFSET
+    /// M` for the page. The queryset is cloned for the count step
+    /// so the page-fetch's filter chain stays intact — both halves
+    /// see the same WHERE.
+    ///
+    /// 1-indexed `page` so `paginate(1, 10)` returns rows 0..10,
+    /// `paginate(2, 10)` returns rows 10..20, etc. — matches
+    /// Eloquent and `Model::for_page`.
+    ///
+    /// # Errors
+    /// As [`crate::sql::CounterPool::count_pool`] and
+    /// [`crate::sql::FetcherPool::fetch_pool`].
+    pub async fn paginate(
+        self,
+        page: i64,
+        per_page: i64,
+        pool: &Pool,
+    ) -> Result<(Vec<T>, i64), ExecError>
+    where
+        T: crate::core::Model
+            + crate::sql::MaybePgFromRow
+            + crate::sql::MaybeMyFromRow
+            + crate::sql::MaybeSqliteFromRow
+            + crate::sql::LoadRelated
+            + crate::sql::MaybeMyLoadRelated
+            + crate::sql::MaybeSqliteLoadRelated
+            + Send
+            + Unpin,
+    {
+        use crate::sql::{CounterPool as _, FetcherPool as _};
+        let total = <crate::query::QuerySet<T> as ::core::clone::Clone>::clone(&self)
+            .count_pool(pool)
+            .await?;
+        let offset = if page > 1 { (page - 1) * per_page } else { 0 };
+        let rows = self.limit(per_page).offset(offset).fetch_pool(pool).await?;
+        Ok((rows, total))
+    }
+
     /// Eloquent `Builder::avg($col)` on a filtered queryset.
     ///
     /// # Errors

--- a/crates/rustango/tests/queryset_paginate_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_paginate_sqlite_live.rs
@@ -1,0 +1,73 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::paginate(page, per_page, &pool)
+//! -> (Vec<T>, total)` — filtered counterpart of Model::paginate.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "qpag_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub status: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE qpag_post (
+            id     INTEGER PRIMARY KEY AUTOINCREMENT,
+            status TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn seed(pool: &Pool) {
+    for i in 0..30 {
+        let mut p = Post {
+            id: Auto::default(),
+            status: if i % 3 == 0 { "draft" } else { "published" }.into(),
+        };
+        p.save_pool(pool).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn paginate_on_filtered_queryset_uses_narrowed_total() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let (rows, total) = Post::objects()
+        .filter("status", "published")
+        .paginate(1, 10, &pool)
+        .await
+        .unwrap();
+    // 30 posts; 1/3 are drafts, so 20 are published. Filtered total
+    // is 20, NOT 30.
+    assert_eq!(total, 20);
+    assert_eq!(rows.len(), 10);
+    for r in &rows {
+        assert_eq!(r.status, "published");
+    }
+}
+
+#[tokio::test]
+async fn paginate_last_page_returns_partial_on_filtered() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let (rows, total) = Post::objects()
+        .filter("status", "published")
+        .paginate(2, 15, &pool)
+        .await
+        .unwrap();
+    // 20 published. Page 2 of 15 = rows 15..20 = 5 rows.
+    assert_eq!(total, 20);
+    assert_eq!(rows.len(), 5);
+}


### PR DESCRIPTION
Eloquent `Builder::paginate` parity on a filtered queryset. Two queries (filtered COUNT + paginated SELECT) — total reflects matching rows, not table-wide.

Also fixes the QuerySet `#[derive(Clone)]` (#943) to be hand-rolled, removing the spurious `T: Clone` bound that broke generic call sites.

3422 lib + 2 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)