### PR TITLE
feat(orm): `Model::find_or_insert` — persisting variant of find_or_new

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -5919,6 +5919,45 @@ fn inherent_impl_tokens(
                 }
             }
 
+            /// Eloquent `Model::findOrCreate(pk, defaults)` — like
+            /// [`Self::find_or_new`] but **persists** the new row
+            /// when the PK isn't found. Returns `(row, exists: bool)`
+            /// — `exists=true` when the PK was found,
+            /// `false` when a fresh row was inserted.
+            ///
+            /// ```ignore
+            /// let (post, found) = Post::find_or_insert(
+            ///     pk,
+            ///     &pool,
+            ///     || Post { id: Auto::default(), title: "new".into() },
+            /// ).await?;
+            /// // `found` true → returned existing row;
+            /// // `found` false → fallback was inserted, `post.id` populated.
+            /// ```
+            ///
+            /// **Caveat**: two concurrent calls that both miss the
+            /// find can both INSERT, violating uniqueness. Wrap in a
+            /// transaction or rely on a UNIQUE constraint + handle
+            /// the conflict error if you need race-free semantics.
+            ///
+            /// # Errors
+            /// As [`Self::find`] and [`Self::save_pool`].
+            pub async fn find_or_insert<F>(
+                pk: impl ::core::convert::Into<#root::core::SqlValue>,
+                pool: &#root::sql::Pool,
+                fallback: F,
+            ) -> ::core::result::Result<(Self, bool), #root::sql::ExecError>
+            where
+                F: ::core::ops::FnOnce() -> Self,
+            {
+                if let ::core::option::Option::Some(_row) = Self::find(pk, pool).await? {
+                    return ::core::result::Result::Ok((_row, true));
+                }
+                let mut _new = fallback();
+                _new.save_pool(pool).await?;
+                ::core::result::Result::Ok((_new, false))
+            }
+
             /// Fetch the first row of the table, or run `fallback`
             /// when the table is empty. Eloquent
             /// `Model::firstOr(fn() => …)` parity.

--- a/crates/rustango/tests/model_find_or_insert_sqlite_live.rs
+++ b/crates/rustango/tests/model_find_or_insert_sqlite_live.rs
@@ -1,0 +1,72 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `Model::find_or_insert(pk, &pool, fallback)`
+//! — Eloquent `findOrCreate` parity (persisting variant of
+//! `find_or_new`). Returns `(row, exists: bool)`.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "foi_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE foi_post (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+#[tokio::test]
+async fn find_or_insert_returns_existing_row() {
+    let pool = make_pool().await;
+    let mut p = Post {
+        id: Auto::default(),
+        title: "existing".into(),
+    };
+    p.save_pool(&pool).await.unwrap();
+    let pk = p.id.get().copied().unwrap();
+
+    let (found, exists) = Post::find_or_insert(pk, &pool, || Post {
+        id: Auto::default(),
+        title: "fallback".into(),
+    })
+    .await
+    .unwrap();
+    assert!(exists, "row existed → exists=true");
+    assert_eq!(found.title, "existing");
+}
+
+#[tokio::test]
+async fn find_or_insert_persists_fallback_when_missing() {
+    let pool = make_pool().await;
+    let (inserted, exists) = Post::find_or_insert(999_999_i64, &pool, || Post {
+        id: Auto::default(),
+        title: "new-row".into(),
+    })
+    .await
+    .unwrap();
+    assert!(!exists, "row was missing → exists=false");
+    assert_eq!(inserted.title, "new-row");
+    // PK back-propagated.
+    assert!(inserted.id.get().is_some());
+
+    // Verify it's actually in the DB.
+    let total = Post::count(&pool).await.unwrap();
+    assert_eq!(total, 1);
+}


### PR DESCRIPTION
Eloquent `findOrCreate` parity — like `find_or_new` (#952) but persists the fallback when PK is missing. Returns `(row, exists: bool)`.

```rust
let (post, found) = Post::find_or_insert(pk, &pool, || Post {
    id: Auto::default(),
    title: "new".into(),
}).await?;
```

3422 lib + 2 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)