### PR TITLE
feat(orm): `Model::contains_pk(pk, &pool)` — Eloquent whereKey()->exists() shortcut

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -5646,6 +5646,29 @@ fn inherent_impl_tokens(
                 Self::exists(pool).await.map(|e| !e)
             }
 
+            /// Eloquent `Model::query()->whereKey($pk)->exists()` —
+            /// `true` when a row with primary key `pk` exists in
+            /// the table. Sugar over
+            /// `QuerySet::<Self>::default().contains_pk(pool, pk)`.
+            ///
+            /// Differs from [`Self::exists`] (which checks "any row
+            /// in the table") by checking a specific PK existence.
+            /// Cheaper than `Self::find(pk, &pool).await?.is_some()`
+            /// because the row is never materialized — the SQL is
+            /// `SELECT COUNT(*) > 0 FROM <table> WHERE pk = ?`.
+            ///
+            /// # Errors
+            /// As [`#root::sql::ExistsPool::contains_pk`].
+            pub async fn contains_pk(
+                pk: impl ::core::convert::Into<#root::core::SqlValue> + ::core::marker::Send,
+                pool: &#root::sql::Pool,
+            ) -> ::core::result::Result<bool, #root::sql::ExecError> {
+                use #root::sql::ExistsPool as _;
+                #root::query::QuerySet::<Self>::default()
+                    .contains_pk(pool, pk)
+                    .await
+            }
+
             #sum_method
             #avg_method
             #min_method

--- a/crates/rustango/tests/model_contains_pk_sqlite_live.rs
+++ b/crates/rustango/tests/model_contains_pk_sqlite_live.rs
@@ -1,0 +1,56 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `Model::contains_pk(pk, &pool)` —
+//! Eloquent `Model::query()->whereKey($pk)->exists()` shortcut.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "cpk_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE cpk_post (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+#[tokio::test]
+async fn contains_pk_returns_true_when_row_exists() {
+    let pool = make_pool().await;
+    let mut p = Post {
+        id: Auto::default(),
+        title: "alpha".into(),
+    };
+    p.save_pool(&pool).await.unwrap();
+    let pk = p.id.get().copied().unwrap();
+    assert!(Post::contains_pk(pk, &pool).await.unwrap());
+}
+
+#[tokio::test]
+async fn contains_pk_returns_false_when_pk_missing() {
+    let pool = make_pool().await;
+    assert!(!Post::contains_pk(999_999_i64, &pool).await.unwrap());
+}
+
+#[tokio::test]
+async fn contains_pk_on_empty_table_returns_false() {
+    let pool = make_pool().await;
+    assert!(!Post::contains_pk(1_i64, &pool).await.unwrap());
+}


### PR DESCRIPTION
Sugar over the existing `QuerySet::contains_pk`. Cheaper than `find(pk).await?.is_some()` because no row materialization.

```rust
if Post::contains_pk(42_i64, &pool).await? { … }
```

3422 lib + 3 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)