### PR TITLE
feat(orm): `Model::last(&pool) -> Option<Self>` — bare-name sibling of Model::first

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -3995,6 +3995,33 @@ fn inherent_impl_tokens(
                 }
             },
         );
+        let last_method = emit_if_no_field_collision(
+            "last",
+            quote! {
+                /// Last row of this model by primary-key DESC.
+                /// Eloquent `Model::query()->latest('id')->first()`
+                /// parity — fetches the highest-PK row without
+                /// requiring the caller to spell the PK column.
+                /// Returns `None` on an empty table.
+                ///
+                /// Equivalent to `QuerySet::<Self>::default().last(&pool)`.
+                /// Skipped on models that already declare a field
+                /// named `last`.
+                ///
+                /// # Errors
+                /// As `QuerySet::last`.
+                pub async fn last(
+                    pool: &#root::sql::Pool,
+                ) -> ::core::result::Result<
+                    ::core::option::Option<Self>,
+                    #root::sql::ExecError,
+                > {
+                    #root::query::QuerySet::<Self>::default()
+                        .last(pool)
+                        .await
+                }
+            },
+        );
         quote! {
             /// Re-SELECT this row by its primary key and overwrite
             /// every in-memory field with the freshly-fetched value.
@@ -4224,6 +4251,8 @@ fn inherent_impl_tokens(
             }
 
             #first_method
+
+            #last_method
 
             /// Throwing counterpart of [`Self::first_pool`] —
             /// errors with `RowNotFound` when the table is empty.

--- a/crates/rustango/tests/model_last_sqlite_live.rs
+++ b/crates/rustango/tests/model_last_sqlite_live.rs
@@ -1,0 +1,52 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `Model::last(&pool) -> Option<Self>` —
+//! Eloquent `Model::query()->latest('id')->first()` shortcut.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "lst_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE lst_post (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+#[tokio::test]
+async fn last_returns_highest_pk_row() {
+    let pool = make_pool().await;
+    for t in ["a", "b", "c"] {
+        let mut p = Post {
+            id: Auto::default(),
+            title: t.into(),
+        };
+        p.save_pool(&pool).await.unwrap();
+    }
+    let last = Post::last(&pool).await.unwrap().unwrap();
+    assert_eq!(last.title, "c");
+}
+
+#[tokio::test]
+async fn last_on_empty_table_returns_none() {
+    let pool = make_pool().await;
+    assert!(Post::last(&pool).await.unwrap().is_none());
+}


### PR DESCRIPTION
Eloquent `Model::query()->latest('id')->first()` shortcut. Returns the last row by PK DESC without making the caller spell the PK column.

```rust
let newest = Post::last(&pool).await?;
```

3422 lib + 2 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)