### PR TITLE
feat(orm): `QuerySet::skip` / `QuerySet::take` — Eloquent aliases

### DIFF
--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -942,6 +942,21 @@ impl<T: Model> QuerySet<T> {
         self
     }
 
+    /// Eloquent `Builder::take($n)` — alias of [`Self::limit`].
+    /// Cap the result to at most `n` rows.
+    #[must_use]
+    pub fn take(self, n: i64) -> Self {
+        self.limit(n)
+    }
+
+    /// Eloquent `Builder::skip($n)` — alias of [`Self::offset`].
+    /// Skip the first `n` matching rows. Pair with `.take(...)` /
+    /// `.limit(...)` for manual paging.
+    #[must_use]
+    pub fn skip(self, n: i64) -> Self {
+        self.offset(n)
+    }
+
     /// Append a `WHERE field <op> value` predicate using the
     /// **explicit-op** shape. This is the lower-level form used by
     /// callers that already know which `Op` they want; for the

--- a/crates/rustango/tests/queryset_skip_take_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_skip_take_sqlite_live.rs
@@ -1,0 +1,87 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::skip(n)` / `QuerySet::take(n)` —
+//! Eloquent aliases for `offset(n)` / `limit(n)`.
+
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "st_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub n: i64,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE st_post (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            n  INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    Pool::Sqlite(p)
+}
+
+async fn seed(pool: &Pool, n: i64) {
+    for i in 0..n {
+        let mut p = Post {
+            id: Auto::default(),
+            n: i,
+        };
+        p.save_pool(pool).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn skip_take_chains_correctly() {
+    let pool = make_pool().await;
+    seed(&pool, 20).await;
+    // Eloquent: ->skip(5)->take(3) gives rows 5..8 (0-indexed).
+    let rows = Post::objects()
+        .order_by(&[("n", false)])
+        .skip(5)
+        .take(3)
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    let ns: Vec<i64> = rows.iter().map(|r| r.n).collect();
+    assert_eq!(ns, vec![5, 6, 7]);
+}
+
+#[tokio::test]
+async fn take_alone_caps_result() {
+    let pool = make_pool().await;
+    seed(&pool, 10).await;
+    let rows = Post::objects()
+        .order_by(&[("n", false)])
+        .take(3)
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 3);
+}
+
+#[tokio::test]
+async fn skip_alone_with_limit_returns_remainder() {
+    // SQLite silently ignores OFFSET without LIMIT (and PG/MySQL
+    // semantics differ); the Eloquent shape is `->skip(n)->take(m)`
+    // so we test that combination.
+    let pool = make_pool().await;
+    seed(&pool, 10).await;
+    let rows = Post::objects()
+        .order_by(&[("n", false)])
+        .skip(7)
+        .take(100)
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 3);
+}


### PR DESCRIPTION
Thin aliases over `offset` / `limit` matching Eloquent muscle memory.

```rust
Post::objects().skip(10).take(5).fetch_pool(&pool).await?;
```

3422 lib + 3 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)