### PR TITLE
feat(orm): QuerySet::order_by_desc / order_by_asc — single-column ORDER BY shortcuts

### DIFF
--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -619,6 +619,37 @@ impl<T: Model> QuerySet<T> {
         self
     }
 
+    /// Single-column shortcut for `ORDER BY <col> DESC`. Appends to the
+    /// existing ORDER BY list (use [`Self::reorder`] first to replace).
+    ///
+    /// Eloquent ships this as `Builder::latest($column)` but rustango's
+    /// [`Self::latest`] is the Django-style async fetcher — so the
+    /// chainable form lives here under the explicit name.
+    ///
+    /// ```ignore
+    /// Post::objects().order_by_desc("created_at").fetch_pool(&pool).await?;
+    /// // SELECT ... FROM post ORDER BY created_at DESC
+    /// ```
+    #[must_use]
+    pub fn order_by_desc(self, column: &str) -> Self {
+        self.order_by(&[(column, true)])
+    }
+
+    /// Single-column shortcut for `ORDER BY <col> ASC`. Appends to the
+    /// existing ORDER BY list.
+    ///
+    /// Counterpart of [`Self::order_by_desc`]; mirrors Eloquent's
+    /// `Builder::oldest($column)`.
+    ///
+    /// ```ignore
+    /// Post::objects().order_by_asc("created_at").fetch_pool(&pool).await?;
+    /// // SELECT ... FROM post ORDER BY created_at ASC
+    /// ```
+    #[must_use]
+    pub fn order_by_asc(self, column: &str) -> Self {
+        self.order_by(&[(column, false)])
+    }
+
     /// Apply the schema-declared `default_order` for `T`. Issue #291
     /// / T2.5. Each entry from `#[rustango(default_order = "...")]`
     /// gets pre-pended to the queryset's pending ORDER BY list, so a

--- a/crates/rustango/tests/queryset_order_by_desc_asc_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_order_by_desc_asc_sqlite_live.rs
@@ -1,0 +1,70 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::order_by_desc(col)` /
+//! `QuerySet::order_by_asc(col)` — single-column ORDER BY shortcuts
+//! (chainable Eloquent `Builder::latest(col)` / `Builder::oldest(col)`
+//! shape; rustango's `latest` / `earliest` are async fetchers, so the
+//! chainable form lives under the explicit names).
+
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "lo_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub seq: i64,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE lo_post (
+            id  INTEGER PRIMARY KEY AUTOINCREMENT,
+            seq INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+async fn seed(pool: &Pool, n: i64) {
+    for i in 0..n {
+        let mut row = Post {
+            id: Auto::default(),
+            seq: i,
+        };
+        row.save_pool(pool).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn order_by_desc_appends_descending_order() {
+    let pool = make_pool().await;
+    seed(&pool, 5).await;
+    let rows = Post::objects()
+        .order_by_desc("seq")
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    let ns: Vec<i64> = rows.iter().map(|r| r.seq).collect();
+    assert_eq!(ns, vec![4, 3, 2, 1, 0]);
+}
+
+#[tokio::test]
+async fn order_by_asc_appends_ascending_order() {
+    let pool = make_pool().await;
+    seed(&pool, 5).await;
+    let rows = Post::objects()
+        .order_by_asc("seq")
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    let ns: Vec<i64> = rows.iter().map(|r| r.seq).collect();
+    assert_eq!(ns, vec![0, 1, 2, 3, 4]);
+}


### PR DESCRIPTION
## Summary
- Adds `QuerySet::order_by_desc(col)` and `QuerySet::order_by_asc(col)` chainable single-column shortcuts.
- Eloquent ships these as `Builder::latest($col)` / `Builder::oldest($col)`, but rustango's `QuerySet::latest` / `QuerySet::earliest` are Django-style **async fetchers** (return `Result<Option<T>, _>`) — so the chainable form lives under the explicit names.
- Both append to the existing ORDER BY list; use `reorder()` first to replace.

## Test plan
- [x] `cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_order_by_desc_asc_sqlite_live` — 2 / 2 pass.