### PR TITLE
feat(orm): QuerySet::increment / decrement — filtered bulk-bump parity

### DIFF
--- a/crates/rustango/src/sql/executor/values.rs
+++ b/crates/rustango/src/sql/executor/values.rs
@@ -19,6 +19,10 @@ use sqlx::query::Query;
 use super::ExecError;
 use crate::core::{SelectQuery, SqlValue};
 use crate::sql::Pool;
+use crate::sql::{
+    MaybeMyFromRow, MaybeMyLoadRelated, MaybePgFromRow, MaybeSqliteFromRow, MaybeSqliteLoadRelated,
+    UpdaterPool as _,
+};
 
 #[cfg(feature = "postgres")]
 use super::{bind_match, bind_query};
@@ -642,6 +646,75 @@ impl<T: crate::core::Model> crate::query::QuerySet<T> {
         let q = self.compile()?;
         let stmt = pool.dialect().compile_select(&q)?;
         Ok(stmt)
+    }
+}
+
+impl<T> crate::query::QuerySet<T>
+where
+    T: crate::core::Model
+        + Send
+        + Unpin
+        + MaybePgFromRow
+        + MaybeMyFromRow
+        + MaybeSqliteFromRow
+        + crate::sql::LoadRelated
+        + MaybeMyLoadRelated
+        + MaybeSqliteLoadRelated,
+{
+    /// Eloquent `Builder::increment($col, $by)` — bulk
+    /// `UPDATE … SET col = col + by WHERE <queryset filters>`.
+    /// Returns rows affected.
+    ///
+    /// Sugar over
+    /// `self.update().set_expr(col, F(col) + Literal(by)).execute_pool(pool)`.
+    /// Negative `by` decrements; use [`Self::decrement`] for a
+    /// call-site that reads symmetrically.
+    ///
+    /// Differs from `Model::increment_each(col, by, &pool)` (already
+    /// shipped) in that the queryset's accumulated filters narrow
+    /// which rows get the bump — i.e. you can increment a counter
+    /// on a subset of rows rather than the whole table.
+    ///
+    /// ```ignore
+    /// // Eloquent: Post::where('published', true)->increment('views');
+    /// // rustango:
+    /// Post::objects()
+    ///     .filter("published", true)
+    ///     .increment("views", 1, &pool)
+    ///     .await?;
+    /// ```
+    ///
+    /// # Errors
+    /// As [`UpdaterPool::execute_pool`], plus
+    /// [`ExecError::Query(QueryError::UnknownField)`] when `col`
+    /// is not a declared field on `T`.
+    pub async fn increment(self, col: &str, by: i64, pool: &Pool) -> Result<u64, ExecError> {
+        let col_static = crate::sql::model_shortcuts::resolve_col::<T>(col)?;
+        self.update()
+            .set_expr(
+                col,
+                crate::sql::model_shortcuts::add_signed_expr(col_static, by),
+            )
+            .execute_pool(pool)
+            .await
+    }
+
+    /// Sibling of [`Self::increment`] — bulk-decrement.
+    /// Equivalent to `self.increment(col, -by, &pool)`; the separate
+    /// name keeps call sites readable.
+    ///
+    /// ```ignore
+    /// // Eloquent: User::where('vip', true)->decrement('credits', 10);
+    /// User::objects()
+    ///     .filter("vip", true)
+    ///     .decrement("credits", 10, &pool)
+    ///     .await?;
+    /// ```
+    ///
+    /// # Errors
+    /// As [`Self::increment`].
+    pub async fn decrement(self, col: &str, by: i64, pool: &Pool) -> Result<u64, ExecError> {
+        self.increment(col, -by, pool).await
     }
 }
 

--- a/crates/rustango/tests/queryset_increment_decrement_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_increment_decrement_sqlite_live.rs
@@ -1,0 +1,128 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::increment(col, by, &pool)` /
+//! `QuerySet::decrement(col, by, &pool)` — Eloquent
+//! `Builder::increment` / `decrement` parity. The QuerySet-filtered
+//! variant complements `Model::increment_each` (table-wide) and
+//! `model.increment` (single row) by letting the queryset's
+//! accumulated WHERE narrow which rows get the bump.
+
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "inc_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub views: i64,
+    pub published: bool,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE inc_post (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            views     INTEGER NOT NULL DEFAULT 0,
+            published INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+async fn seed(pool: &Pool) -> (Vec<i64>, Vec<i64>) {
+    let mut pub_ids = Vec::new();
+    let mut draft_ids = Vec::new();
+    for &published in &[true, false, true, false, true] {
+        let mut row = Post {
+            id: Auto::default(),
+            views: 10,
+            published,
+        };
+        row.save_pool(pool).await.unwrap();
+        let pk = *row.id.get().unwrap();
+        if published {
+            pub_ids.push(pk);
+        } else {
+            draft_ids.push(pk);
+        }
+    }
+    (pub_ids, draft_ids)
+}
+
+async fn views_for(pool: &Pool, id: i64) -> i64 {
+    Post::objects()
+        .filter("id", id)
+        .fetch_pool(pool)
+        .await
+        .unwrap()
+        .pop()
+        .unwrap()
+        .views
+}
+
+#[tokio::test]
+async fn increment_only_touches_filtered_rows() {
+    let pool = make_pool().await;
+    let (pub_ids, draft_ids) = seed(&pool).await;
+    let n = Post::objects()
+        .filter("published", true)
+        .increment("views", 5, &pool)
+        .await
+        .unwrap();
+    assert_eq!(n, pub_ids.len() as u64);
+    for id in pub_ids {
+        assert_eq!(views_for(&pool, id).await, 15);
+    }
+    for id in draft_ids {
+        assert_eq!(views_for(&pool, id).await, 10);
+    }
+}
+
+#[tokio::test]
+async fn decrement_subtracts_on_filtered_rows() {
+    let pool = make_pool().await;
+    let (_pub_ids, draft_ids) = seed(&pool).await;
+    let n = Post::objects()
+        .filter("published", false)
+        .decrement("views", 4, &pool)
+        .await
+        .unwrap();
+    assert_eq!(n, draft_ids.len() as u64);
+    for id in draft_ids {
+        assert_eq!(views_for(&pool, id).await, 6);
+    }
+}
+
+#[tokio::test]
+async fn increment_with_no_match_returns_zero() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let n = Post::objects()
+        .filter("views", 999_999_i64)
+        .increment("views", 1, &pool)
+        .await
+        .unwrap();
+    assert_eq!(n, 0);
+}
+
+#[tokio::test]
+async fn increment_unknown_column_errors() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let err = Post::objects()
+        .increment("nope", 1, &pool)
+        .await
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.to_lowercase().contains("nope"),
+        "expected unknown-field error mentioning column, got: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `QuerySet::increment(col, by, &pool)` / `QuerySet::decrement(col, by, &pool)` — the missing **filtered** form of the bulk-bump trio.
- Routes through the existing `update().set_expr(F(col) + Literal(by)).execute_pool(...)` chain (same SQL path the per-row + table-wide reaches already use).
- Negative \`by\` decrements; the \`decrement\` name keeps call sites symmetric.

Reaches now in place:
- \`Model::increment_each(col, by, &pool)\` — table-wide
- \`model.increment(col, by, &pool)\`         — single row by PK
- \`qs.increment(col, by, &pool)\`            — narrowed by filters ← NEW

## Test plan
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_increment_decrement_sqlite_live\` — 4/4 pass (filter-only-touches-matching, decrement subtracts, no-match returns 0, unknown column errors).