### PR TITLE
feat(orm): QuerySet::pks::<K>(&pool) — modelKeys() shortcut

### DIFF
--- a/crates/rustango/src/sql/executor/values.rs
+++ b/crates/rustango/src/sql/executor/values.rs
@@ -415,6 +415,41 @@ impl<T: crate::core::Model> crate::query::QuerySet<T> {
         self.values_list_flat(col).fetch::<U>(pool).await
     }
 
+    /// Eloquent `Collection::modelKeys()` / Laravel
+    /// `$query->pluck($model->getKeyName())` shortcut — pluck the
+    /// primary-key column on this (possibly-filtered) queryset and
+    /// decode into `Vec<K>`.
+    ///
+    /// Sugar over `self.pluck::<K>(pk_column, &pool)` where
+    /// `pk_column` is read from the model's schema, so the call site
+    /// doesn't need to spell the PK name.
+    ///
+    /// ```ignore
+    /// // Eloquent: Post::where('published', true)->pluck('id');
+    /// // rustango:
+    /// let ids: Vec<i64> = Post::objects()
+    ///     .filter("published", true)
+    ///     .pks::<i64>(&pool).await?;
+    /// ```
+    ///
+    /// # Errors
+    /// Returns
+    /// [`ExecError::Query(QueryError::UnknownField)`] (with field
+    /// `"<pk>"`) when the model carries no `#[rustango(primary_key)]`,
+    /// otherwise as [`Self::pluck`].
+    pub async fn pks<K>(self, pool: &Pool) -> Result<Vec<K>, ExecError>
+    where
+        K: MaybePgScalar + MaybeMyScalar + MaybeSqliteScalar + Send + Unpin,
+    {
+        let pk_col = T::SCHEMA.primary_key().map(|f| f.column).ok_or_else(|| {
+            ExecError::Query(crate::core::QueryError::UnknownField {
+                model: T::SCHEMA.name,
+                field: "<pk>".to_string(),
+            })
+        })?;
+        self.pluck::<K>(pk_col, pool).await
+    }
+
     /// Eloquent `Builder::value($col)` — fetch a single column from
     /// the first row of this (possibly-filtered) queryset, or
     /// `None` when the queryset is empty.

--- a/crates/rustango/tests/queryset_pks_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_pks_sqlite_live.rs
@@ -1,0 +1,89 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::pks::<K>(&pool)` — Eloquent
+//! `Collection::modelKeys()` / `$query->pluck($model->getKeyName())`
+//! shortcut that plucks the model's PK column without spelling it.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "pk_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub published: bool,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE pk_post (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            published INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+async fn seed(pool: &Pool) -> (Vec<i64>, Vec<i64>) {
+    let mut pubs = Vec::new();
+    let mut drafts = Vec::new();
+    for &published in &[true, false, true, true, false] {
+        let mut row = Post {
+            id: Auto::default(),
+            published,
+        };
+        row.save_pool(pool).await.unwrap();
+        let pk = *row.id.get().unwrap();
+        if published {
+            pubs.push(pk);
+        } else {
+            drafts.push(pk);
+        }
+    }
+    (pubs, drafts)
+}
+
+#[tokio::test]
+async fn pks_returns_filtered_primary_keys() {
+    let pool = make_pool().await;
+    let (pubs, _drafts) = seed(&pool).await;
+    let mut got: Vec<i64> = Post::objects()
+        .filter("published", true)
+        .pks::<i64>(&pool)
+        .await
+        .unwrap();
+    got.sort_unstable();
+    let mut expected = pubs.clone();
+    expected.sort_unstable();
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+async fn pks_on_empty_queryset_returns_empty_vec() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let got: Vec<i64> = Post::objects()
+        .filter("id", 999_999_i64)
+        .pks::<i64>(&pool)
+        .await
+        .unwrap();
+    assert!(got.is_empty());
+}
+
+#[tokio::test]
+async fn pks_unfiltered_returns_every_row() {
+    let pool = make_pool().await;
+    let (pubs, drafts) = seed(&pool).await;
+    let mut got: Vec<i64> = Post::objects().pks::<i64>(&pool).await.unwrap();
+    got.sort_unstable();
+    let mut expected: Vec<i64> = pubs.into_iter().chain(drafts).collect();
+    expected.sort_unstable();
+    assert_eq!(got, expected);
+}


### PR DESCRIPTION
## Summary
- Adds \`QuerySet::pks::<K>(&pool) -> Vec<K>\` — single-shot pluck of the model's primary-key column on the (possibly-filtered) queryset.
- Eloquent's \`Collection::modelKeys()\` + \`\$query->pluck(\$model->getKeyName())\` parity.
- Reads \`pk_column\` from \`T::SCHEMA.primary_key()\` so the caller doesn't have to spell \"id\". Models with no PK return \`UnknownField { field: \"<pk>\", … }\`.

## Test plan
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_pks_sqlite_live\` — 3/3 pass.