### PR TITLE
feat(orm): QuerySet::pluck_pairs::<K,V>(key, value, &pool) — pluck(, $key) parity

### DIFF
--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -865,7 +865,7 @@ pub(super) use bind_match_mysql;
 pub(super) use bind_match_sqlite;
 
 #[cfg(feature = "postgres")]
-fn bind_query_as<T>(
+pub(super) fn bind_query_as<T>(
     q: QueryAs<'_, sqlx::Postgres, T, PgArguments>,
     value: SqlValue,
 ) -> QueryAs<'_, sqlx::Postgres, T, PgArguments> {
@@ -1782,7 +1782,7 @@ where
 
 /// MySQL-typed `QueryAs` binding helper, symmetric with [`bind_query_as`].
 #[cfg(feature = "mysql")]
-fn bind_query_as_my<T>(
+pub(super) fn bind_query_as_my<T>(
     q: sqlx::query::QueryAs<'_, sqlx::MySql, T, sqlx::mysql::MySqlArguments>,
     value: SqlValue,
 ) -> sqlx::query::QueryAs<'_, sqlx::MySql, T, sqlx::mysql::MySqlArguments> {
@@ -1791,7 +1791,7 @@ fn bind_query_as_my<T>(
 
 /// SQLite-typed `QueryAs` binding helper, symmetric with [`bind_query_as`].
 #[cfg(feature = "sqlite")]
-fn bind_query_as_sqlite<'a, T>(
+pub(super) fn bind_query_as_sqlite<'a, T>(
     q: sqlx::query::QueryAs<'a, sqlx::Sqlite, T, sqlx::sqlite::SqliteArguments<'a>>,
     value: SqlValue,
 ) -> sqlx::query::QueryAs<'a, sqlx::Sqlite, T, sqlx::sqlite::SqliteArguments<'a>> {

--- a/crates/rustango/src/sql/executor/values.rs
+++ b/crates/rustango/src/sql/executor/values.rs
@@ -12,6 +12,12 @@
 //!   `.fetch(&pool)`.
 
 #[cfg(feature = "postgres")]
+use super::bind_query_as;
+#[cfg(feature = "mysql")]
+use super::bind_query_as_my;
+#[cfg(feature = "sqlite")]
+use super::bind_query_as_sqlite;
+#[cfg(feature = "postgres")]
 use sqlx::postgres::{PgArguments, PgRow};
 #[cfg(feature = "postgres")]
 use sqlx::query::Query;
@@ -331,6 +337,59 @@ where
     }
 }
 
+/// Execute a two-column [`SelectQuery`] and decode each row into
+/// `(K, V)` via sqlx's tuple `FromRow` impl. Backs
+/// [`crate::query::QuerySet::pluck_pairs`].
+///
+/// # Errors
+/// SQL compilation or driver failure, including a decode error if
+/// either `K` or `V` doesn't match the column's SQL type on the live
+/// database.
+pub async fn fetch_values_pairs<K, V>(
+    pool: &Pool,
+    query: &SelectQuery,
+) -> Result<Vec<(K, V)>, ExecError>
+where
+    K: Send + Unpin,
+    V: Send + Unpin,
+    (K, V): MaybePgFromRow + MaybeMyFromRow + MaybeSqliteFromRow + Send + Unpin,
+{
+    let stmt = pool.dialect().compile_select(query)?;
+    match pool {
+        #[cfg(feature = "postgres")]
+        Pool::Postgres(pg) => {
+            let mut q: sqlx::query::QueryAs<'_, sqlx::Postgres, (K, V), PgArguments> =
+                sqlx::query_as::<_, (K, V)>(&stmt.sql);
+            for v in stmt.params {
+                q = bind_query_as(q, v);
+            }
+            Ok(q.fetch_all(pg).await?)
+        }
+        #[cfg(feature = "mysql")]
+        Pool::Mysql(my) => {
+            let mut q: sqlx::query::QueryAs<'_, sqlx::MySql, (K, V), sqlx::mysql::MySqlArguments> =
+                sqlx::query_as::<_, (K, V)>(&stmt.sql);
+            for v in stmt.params {
+                q = bind_query_as_my(q, v);
+            }
+            Ok(q.fetch_all(my).await?)
+        }
+        #[cfg(feature = "sqlite")]
+        Pool::Sqlite(sq) => {
+            let mut q: sqlx::query::QueryAs<
+                '_,
+                sqlx::Sqlite,
+                (K, V),
+                sqlx::sqlite::SqliteArguments<'_>,
+            > = sqlx::query_as::<_, (K, V)>(&stmt.sql);
+            for v in stmt.params {
+                q = bind_query_as_sqlite(q, v);
+            }
+            Ok(q.fetch_all(sq).await?)
+        }
+    }
+}
+
 #[cfg(feature = "postgres")]
 fn bind_query_scalar_pg<U>(
     q: sqlx::query::QueryScalar<'_, sqlx::Postgres, U, PgArguments>,
@@ -448,6 +507,52 @@ impl<T: crate::core::Model> crate::query::QuerySet<T> {
             })
         })?;
         self.pluck::<K>(pk_col, pool).await
+    }
+
+    /// Eloquent `Builder::pluck($value, $key)` — project two columns
+    /// from this (possibly-filtered) queryset and decode each row
+    /// into `(K, V)`.
+    ///
+    /// Returns `Vec<(K, V)>` — the universal carrier shape; collect
+    /// into a `BTreeMap` / `HashMap` at the call site when you want
+    /// lookup semantics. `(K, V)` is decoded via sqlx's tuple
+    /// `FromRow` impl, so both components only need the same
+    /// `Decode + Type` plumbing the [`Self::pluck`] / [`Self::value`]
+    /// scalars already require.
+    ///
+    /// ```ignore
+    /// // Eloquent: Post::where('published', true)->pluck('title', 'id');
+    /// // -> {1: "Hello", 2: "World"}
+    /// // rustango:
+    /// let pairs: Vec<(i64, String)> = Post::objects()
+    ///     .filter("published", true)
+    ///     .pluck_pairs::<i64, String>("id", "title", &pool).await?;
+    /// // Lookup map:
+    /// let map: std::collections::BTreeMap<_, _> = pairs.into_iter().collect();
+    /// ```
+    ///
+    /// `key_col` comes first (matches the tuple's element order) —
+    /// note Eloquent's argument order is `(value, key)`; this method
+    /// uses the natural `(key, value)` shape to keep call sites
+    /// readable left-to-right.
+    ///
+    /// # Errors
+    /// As [`crate::sql::FetcherPool::fetch_pool`], plus per-cell
+    /// type-mismatch errors when `K` / `V` don't match the columns'
+    /// SQL types.
+    pub async fn pluck_pairs<K, V>(
+        self,
+        key_col: &'static str,
+        value_col: &'static str,
+        pool: &Pool,
+    ) -> Result<Vec<(K, V)>, ExecError>
+    where
+        K: Send + Unpin,
+        V: Send + Unpin,
+        (K, V): MaybePgFromRow + MaybeMyFromRow + MaybeSqliteFromRow + Send + Unpin,
+    {
+        let q = self.values_list(&[key_col, value_col]).compile()?;
+        fetch_values_pairs::<K, V>(pool, &q).await
     }
 
     /// Eloquent `Builder::value($col)` — fetch a single column from

--- a/crates/rustango/tests/queryset_pluck_pairs_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_pluck_pairs_sqlite_live.rs
@@ -1,0 +1,98 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for
+//! `QuerySet::pluck_pairs::<K, V>(key_col, value_col, &pool)` —
+//! Eloquent `Builder::pluck($value, $key)` parity. Returns
+//! `Vec<(K, V)>` so the caller can collect into any map shape.
+
+use std::collections::BTreeMap;
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "pp_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+    pub published: bool,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE pp_post (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            title     TEXT NOT NULL,
+            published INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+async fn seed(pool: &Pool) -> Vec<(i64, String)> {
+    let mut out = Vec::new();
+    for (title, published) in [("a", true), ("b", false), ("c", true), ("d", true)] {
+        let mut row = Post {
+            id: Auto::default(),
+            title: title.into(),
+            published,
+        };
+        row.save_pool(pool).await.unwrap();
+        if published {
+            out.push((*row.id.get().unwrap(), title.to_string()));
+        }
+    }
+    out.sort_by_key(|(k, _)| *k);
+    out
+}
+
+#[tokio::test]
+async fn pluck_pairs_projects_two_columns_for_filtered_queryset() {
+    let pool = make_pool().await;
+    let expected = seed(&pool).await;
+    let mut got: Vec<(i64, String)> = Post::objects()
+        .filter("published", true)
+        .pluck_pairs::<i64, String>("id", "title", &pool)
+        .await
+        .unwrap();
+    got.sort_by_key(|(k, _)| *k);
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+async fn pluck_pairs_collects_into_btreemap() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let map: BTreeMap<i64, String> = Post::objects()
+        .filter("published", true)
+        .pluck_pairs::<i64, String>("id", "title", &pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+    // Every value should be a published row's title.
+    for (_id, title) in &map {
+        assert!(matches!(title.as_str(), "a" | "c" | "d"));
+    }
+    assert_eq!(map.len(), 3);
+}
+
+#[tokio::test]
+async fn pluck_pairs_on_empty_queryset_returns_empty() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let got: Vec<(i64, String)> = Post::objects()
+        .filter("id", 999_999_i64)
+        .pluck_pairs::<i64, String>("id", "title", &pool)
+        .await
+        .unwrap();
+    assert!(got.is_empty());
+}


### PR DESCRIPTION
## Summary
- Adds \`QuerySet::pluck_pairs::<K, V>(key_col, value_col, &pool) -> Vec<(K, V)>\` — two-column projection on a (possibly-filtered) queryset.
- Eloquent \`Builder::pluck(\$value, \$key)\` parity. Returns the universal carrier shape \`Vec<(K, V)>\` so callers collect into \`BTreeMap\` / \`HashMap\` for lookup semantics.
- Call order is \`(key, value)\` for left-to-right readability — Eloquent's PHP arg order is reversed (\`(value, key)\`).

## Plumbing
- New \`fetch_values_pairs<K, V>(pool, &SelectQuery)\` in \`sql/executor/values.rs\` using sqlx's tuple \`FromRow\`.
- Bumped \`bind_query_as\` / \`bind_query_as_my\` / \`bind_query_as_sqlite\` to \`pub(super)\` so the submodule can dispatch binds per dialect.

## Test plan
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_pluck_pairs_sqlite_live\` — 3/3 pass (filter projection, BTreeMap collect, empty queryset).