### PR TITLE
feat(orm): QuerySet::where_key / where_key_not — whereKey($pk) parity

### DIFF
--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1095,6 +1095,53 @@ impl<T: Model> QuerySet<T> {
         self.filter_op(field, Op::Eq, value)
     }
 
+    /// Eloquent `Builder::whereKey($pk)` — filter on the model's
+    /// primary-key column without spelling its name. Reads the PK
+    /// field from `T::SCHEMA.primary_key()`.
+    ///
+    /// ```ignore
+    /// // Eloquent: Post::query()->whereKey(42)->first();
+    /// // rustango:
+    /// let post = Post::objects()
+    ///     .where_key(42_i64)
+    ///     .first_pool(&pool).await?;
+    /// ```
+    ///
+    /// Models without `#[rustango(primary_key)]` surface as
+    /// [`QueryError::UnknownField`] (field `"<pk>"`) at compile time.
+    #[must_use]
+    pub fn where_key(self, pk: impl Into<SqlValue>) -> Self {
+        match T::SCHEMA.primary_key() {
+            Some(f) => self.filter_op(f.name, Op::Eq, pk),
+            None => self.with_pending_error(QueryError::UnknownField {
+                model: T::SCHEMA.name,
+                field: "<pk>".to_string(),
+            }),
+        }
+    }
+
+    /// Eloquent `Builder::whereKeyNot($pk)` — opposite of
+    /// [`Self::where_key`]; matches every row whose PK ≠ `pk`.
+    ///
+    /// ```ignore
+    /// // Eloquent: Post::query()->whereKeyNot(1)->get();
+    /// let others = Post::objects()
+    ///     .where_key_not(1_i64)
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    ///
+    /// Errors as [`Self::where_key`] when the model carries no PK.
+    #[must_use]
+    pub fn where_key_not(self, pk: impl Into<SqlValue>) -> Self {
+        match T::SCHEMA.primary_key() {
+            Some(f) => self.filter_op(f.name, Op::Ne, pk),
+            None => self.with_pending_error(QueryError::UnknownField {
+                model: T::SCHEMA.name,
+                field: "<pk>".to_string(),
+            }),
+        }
+    }
+
     /// Append a typed predicate or boolean expression built via the
     /// [`Column`](crate::core::Column) API. Accepts either a single
     /// [`TypedFilter`](crate::core::TypedFilter) (`User::id.gt(10)`)

--- a/crates/rustango/tests/queryset_where_key_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_where_key_sqlite_live.rs
@@ -1,0 +1,93 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::where_key(pk)` /
+//! `QuerySet::where_key_not(pk)` — Eloquent
+//! `Builder::whereKey($pk)` / `Builder::whereKeyNot($pk)` parity that
+//! filters on the model's PK column without spelling its name.
+
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "wk_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 40)]
+    pub title: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE wk_post (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+async fn seed(pool: &Pool) -> Vec<i64> {
+    let mut ids = Vec::new();
+    for t in ["a", "b", "c", "d"] {
+        let mut row = Post {
+            id: Auto::default(),
+            title: t.into(),
+        };
+        row.save_pool(pool).await.unwrap();
+        ids.push(*row.id.get().unwrap());
+    }
+    ids
+}
+
+#[tokio::test]
+async fn where_key_filters_to_single_row() {
+    let pool = make_pool().await;
+    let ids = seed(&pool).await;
+    let target = ids[2];
+    let rows = Post::objects()
+        .where_key(target)
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(*rows[0].id.get().unwrap(), target);
+    assert_eq!(rows[0].title, "c");
+}
+
+#[tokio::test]
+async fn where_key_not_excludes_pk() {
+    let pool = make_pool().await;
+    let ids = seed(&pool).await;
+    let excluded = ids[1];
+    let mut got: Vec<i64> = Post::objects()
+        .where_key_not(excluded)
+        .fetch_pool(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|r| *r.id.get().unwrap())
+        .collect();
+    got.sort_unstable();
+    let mut expected: Vec<i64> = ids.into_iter().filter(|&i| i != excluded).collect();
+    expected.sort_unstable();
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+async fn where_key_no_match_returns_empty() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let rows = Post::objects()
+        .where_key(999_999_i64)
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert!(rows.is_empty());
+}


### PR DESCRIPTION
## Summary
- Adds \`QuerySet::where_key(pk)\` / \`QuerySet::where_key_not(pk)\` chainable PK-equality / PK-inequality filters.
- Eloquent \`Builder::whereKey(\$pk)\` / \`Builder::whereKeyNot(\$pk)\` parity. Reads the PK field name from \`T::SCHEMA.primary_key()\` — call site doesn't spell \"id\".
- Models without \`#[rustango(primary_key)]\` surface as \`QueryError::UnknownField { field: \"<pk>\", … }\` via the existing deferred-error path.

## Test plan
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_where_key_sqlite_live\` — 3/3 pass.