### PR TITLE
feat(orm): QuerySet::first_or_fail / find_or_fail — scoped *OrFail parity

### DIFF
--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -2535,6 +2535,50 @@ where
         self.where_key(pk).first(pool).await
     }
 
+    /// Eloquent `Builder::firstOrFail()` — fetch the first row by
+    /// the current ordering, or surface
+    /// [`sqlx::Error::RowNotFound`] when the queryset is empty.
+    ///
+    /// Wrapper over [`Self::first`] that converts `None` to an
+    /// error — same shape as the table-wide
+    /// `Model::first_or_fail(&pool)`, but honors **pre-applied
+    /// scopes** (so e.g. `Post::objects().filter("published", true)
+    /// .first_or_fail(&pool)` errors only when no published post
+    /// exists, not when no post exists at all).
+    ///
+    /// # Errors
+    /// As [`Self::first`]; additionally
+    /// [`ExecError::Driver(sqlx::Error::RowNotFound)`] when the
+    /// queryset returns no rows.
+    pub async fn first_or_fail(self, pool: &Pool) -> Result<T, ExecError> {
+        match self.first(pool).await? {
+            Some(row) => Ok(row),
+            None => Err(ExecError::Driver(sqlx::Error::RowNotFound)),
+        }
+    }
+
+    /// Eloquent `Builder::findOrFail($pk)` — scoped PK lookup that
+    /// errors when no row matches. Sugar over
+    /// `self.where_key(pk).first_or_fail(pool)`.
+    ///
+    /// Like [`Self::find`] but errors on miss; like
+    /// [`Self::first_or_fail`] but adds the PK filter.
+    /// Mirrors Eloquent's `Post::published()->findOrFail(\$id)`.
+    ///
+    /// ```ignore
+    /// let post = Post::objects()
+    ///     .filter("published", true)
+    ///     .find_or_fail(42_i64, &pool).await?;
+    /// // -> Ok(post) when row 42 is published;
+    /// //    Err(RowNotFound) when missing or not published.
+    /// ```
+    ///
+    /// # Errors
+    /// As [`Self::first_or_fail`].
+    pub async fn find_or_fail(self, pk: impl Into<SqlValue>, pool: &Pool) -> Result<T, ExecError> {
+        self.where_key(pk).first_or_fail(pool).await
+    }
+
     /// Django `QuerySet.latest()` — picks the largest row by the
     /// column set in `Meta.get_latest_by`. The model must declare
     /// `#[rustango(get_latest_by = "<col>")]`; without it this

--- a/crates/rustango/tests/queryset_or_fail_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_or_fail_sqlite_live.rs
@@ -1,0 +1,118 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::first_or_fail(&pool)` /
+//! `QuerySet::find_or_fail(pk, &pool)` — Eloquent
+//! `Builder::firstOrFail()` / `Builder::findOrFail($pk)` parity that
+//! converts `None` to `sqlx::Error::RowNotFound` and honors the
+//! queryset's accumulated scope.
+
+use rustango::sql::{sqlx, Auto, ExecError, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "of_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 40)]
+    pub title: String,
+    pub published: bool,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE of_post (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            title     TEXT NOT NULL,
+            published INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+async fn seed(pool: &Pool) -> (i64, i64) {
+    let mut pub_row = Post {
+        id: Auto::default(),
+        title: "published".into(),
+        published: true,
+    };
+    pub_row.save_pool(pool).await.unwrap();
+    let pub_id = *pub_row.id.get().unwrap();
+    let mut draft_row = Post {
+        id: Auto::default(),
+        title: "draft".into(),
+        published: false,
+    };
+    draft_row.save_pool(pool).await.unwrap();
+    let draft_id = *draft_row.id.get().unwrap();
+    (pub_id, draft_id)
+}
+
+fn is_row_not_found(err: &ExecError) -> bool {
+    matches!(err, ExecError::Driver(sqlx::Error::RowNotFound))
+}
+
+#[tokio::test]
+async fn first_or_fail_returns_row_when_match() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let row = Post::objects()
+        .filter("published", true)
+        .first_or_fail(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.title, "published");
+}
+
+#[tokio::test]
+async fn first_or_fail_errors_when_scope_is_empty() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let err = Post::objects()
+        .filter("title", "nope".to_string())
+        .first_or_fail(&pool)
+        .await
+        .unwrap_err();
+    assert!(is_row_not_found(&err), "expected RowNotFound, got: {err}");
+}
+
+#[tokio::test]
+async fn find_or_fail_returns_row_in_scope() {
+    let pool = make_pool().await;
+    let (pub_id, _draft_id) = seed(&pool).await;
+    let row = Post::objects()
+        .filter("published", true)
+        .find_or_fail(pub_id, &pool)
+        .await
+        .unwrap();
+    assert_eq!(row.title, "published");
+}
+
+#[tokio::test]
+async fn find_or_fail_errors_when_pk_out_of_scope() {
+    let pool = make_pool().await;
+    let (_pub_id, draft_id) = seed(&pool).await;
+    let err = Post::objects()
+        .filter("published", true)
+        .find_or_fail(draft_id, &pool)
+        .await
+        .unwrap_err();
+    assert!(is_row_not_found(&err), "expected RowNotFound, got: {err}");
+}
+
+#[tokio::test]
+async fn find_or_fail_errors_when_pk_missing() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let err = Post::objects()
+        .find_or_fail(999_999_i64, &pool)
+        .await
+        .unwrap_err();
+    assert!(is_row_not_found(&err), "expected RowNotFound, got: {err}");
+}


### PR DESCRIPTION
## Summary
- Adds \`QuerySet::first_or_fail(&pool)\` — convert \`None\` to \`RowNotFound\`, honoring pre-applied scope.
- Adds \`QuerySet::find_or_fail(pk, &pool)\` — sugar over \`where_key(pk).first_or_fail(pool)\`.
- Eloquent \`Builder::firstOrFail()\` / \`Builder::findOrFail(\$pk)\` parity. Difference vs the table-wide \`Model::*_or_fail\` is scope-honoring.

## Test plan
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_or_fail_sqlite_live\` — 5/5 pass (scope hit, scope miss, PK in scope, PK out of scope, PK missing).