### PR TITLE
feat(orm): QuerySet::sole(&pool) — Builder::sole() parity on scoped queryset

### DIFF
--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -2579,6 +2579,40 @@ where
         self.where_key(pk).first_or_fail(pool).await
     }
 
+    /// Eloquent `Builder::sole()` — fetch the **single** row matching
+    /// this queryset's accumulated filters. Errors when zero match
+    /// ([`sqlx::Error::RowNotFound`]) or more than one matches
+    /// ([`ExecError::MultipleRowsReturned`]).
+    ///
+    /// Scoped counterpart of `Model::sole(col, val, &pool)` — honors
+    /// pre-applied filters / global scopes / chained `.filter(...)`
+    /// calls. Uses `LIMIT 2` so the >1 case is detected without
+    /// scanning the whole result set.
+    ///
+    /// ```ignore
+    /// // Eloquent: Post::where('slug', $slug)->sole();
+    /// let post = Post::objects()
+    ///     .filter("slug", "hello-world".to_string())
+    ///     .sole(&pool).await?;
+    /// ```
+    ///
+    /// # Errors
+    /// As [`FetcherPool::fetch_pool`]; additionally
+    /// [`ExecError::Driver(sqlx::Error::RowNotFound)`] on empty
+    /// result, [`ExecError::MultipleRowsReturned`] on >1 matches.
+    pub async fn sole(self, pool: &Pool) -> Result<T, ExecError> {
+        let mut rows = self.limit(2).fetch_pool(pool).await?;
+        match rows.len() {
+            0 => Err(ExecError::Driver(sqlx::Error::RowNotFound)),
+            1 => Ok(rows.remove(0)),
+            n => Err(ExecError::MultipleRowsReturned {
+                op: "sole",
+                table: T::SCHEMA.name,
+                count: n,
+            }),
+        }
+    }
+
     /// Django `QuerySet.latest()` — picks the largest row by the
     /// column set in `Meta.get_latest_by`. The model must declare
     /// `#[rustango(get_latest_by = "<col>")]`; without it this

--- a/crates/rustango/tests/queryset_sole_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_sole_sqlite_live.rs
@@ -1,0 +1,89 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::sole(&pool)` — Eloquent
+//! `Builder::sole()` parity: exactly one match required, else error.
+
+use rustango::sql::{sqlx, Auto, ExecError, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "sl_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub slug: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE sl_post (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            slug TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+async fn insert(pool: &Pool, slug: &str) {
+    let mut row = Post {
+        id: Auto::default(),
+        slug: slug.into(),
+    };
+    row.save_pool(pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn sole_returns_single_match() {
+    let pool = make_pool().await;
+    insert(&pool, "hello").await;
+    insert(&pool, "world").await;
+    let row = Post::objects()
+        .filter("slug", "hello".to_string())
+        .sole(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.slug, "hello");
+}
+
+#[tokio::test]
+async fn sole_errors_on_empty_match_with_row_not_found() {
+    let pool = make_pool().await;
+    insert(&pool, "hello").await;
+    let err = Post::objects()
+        .filter("slug", "missing".to_string())
+        .sole(&pool)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, ExecError::Driver(sqlx::Error::RowNotFound)),
+        "expected RowNotFound, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn sole_errors_on_multiple_matches_with_multiple_rows_returned() {
+    let pool = make_pool().await;
+    insert(&pool, "dup").await;
+    insert(&pool, "dup").await;
+    insert(&pool, "dup").await;
+    let err = Post::objects()
+        .filter("slug", "dup".to_string())
+        .sole(&pool)
+        .await
+        .unwrap_err();
+    match err {
+        ExecError::MultipleRowsReturned { op, count, .. } => {
+            assert_eq!(op, "sole");
+            // Limit 2 caps the count at 2 — that's enough to flag.
+            assert_eq!(count, 2);
+        }
+        other => panic!("expected MultipleRowsReturned, got: {other}"),
+    }
+}


### PR DESCRIPTION
## Summary
- Adds \`QuerySet::sole(&pool) -> Result<T, ExecError>\` — fetches the **single** row matching the queryset's filters.
- Errors: \`RowNotFound\` on 0 matches; \`MultipleRowsReturned { op: \"sole\", … }\` on >1.
- Scoped counterpart of \`Model::sole(col, val, &pool)\` — honors pre-applied filters / global scopes / chained \`.filter\` calls.
- Uses \`LIMIT 2\` for cheap >1 detection.

## Test plan
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_sole_sqlite_live\` — 3/3 pass.