### PR TITLE
feat(orm): QuerySet::in_random_order — inRandomOrder() alias

### DIFF
--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -815,6 +815,22 @@ impl<T: Model> QuerySet<T> {
         self
     }
 
+    /// Eloquent `Builder::inRandomOrder()` alias for
+    /// [`Self::order_random`] — appends a per-row random sort key.
+    /// Same performance caveat (full scan + sort, no index use).
+    ///
+    /// ```ignore
+    /// // Eloquent: Post::query()->inRandomOrder()->take(5)->get();
+    /// let five = Post::objects()
+    ///     .in_random_order()
+    ///     .take(5)
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    #[must_use]
+    pub fn in_random_order(self) -> Self {
+        self.order_random()
+    }
+
     /// v0.45 — discard any previously-set `order_by` and apply
     /// `items` as the new ordering. Used by `earliest` and
     /// `latest` which declare their own sort. Clears every

--- a/crates/rustango/tests/queryset_in_random_order_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_in_random_order_sqlite_live.rs
@@ -1,0 +1,71 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::in_random_order()` — Eloquent
+//! `Builder::inRandomOrder()` alias for `order_random()`.
+
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "ir_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub n: i64,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE ir_post (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            n  INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+#[tokio::test]
+async fn in_random_order_returns_every_row() {
+    let pool = make_pool().await;
+    for i in 0..10 {
+        let mut p = Post {
+            id: Auto::default(),
+            n: i,
+        };
+        p.save_pool(&pool).await.unwrap();
+    }
+    let rows = Post::objects()
+        .in_random_order()
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 10);
+    let mut ns: Vec<i64> = rows.iter().map(|r| r.n).collect();
+    ns.sort_unstable();
+    assert_eq!(ns, (0..10).collect::<Vec<_>>());
+}
+
+#[tokio::test]
+async fn in_random_order_with_take_caps_result() {
+    let pool = make_pool().await;
+    for i in 0..20 {
+        let mut p = Post {
+            id: Auto::default(),
+            n: i,
+        };
+        p.save_pool(&pool).await.unwrap();
+    }
+    let rows = Post::objects()
+        .in_random_order()
+        .take(5)
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 5);
+}


### PR DESCRIPTION
## Summary
- Adds \`QuerySet::in_random_order()\` — Eloquent muscle-memory alias for the existing chainable \`order_random()\`.
- Same performance caveat: \`ORDER BY RANDOM()\` / \`RAND()\` forces a full scan + sort.

## Test plan
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_in_random_order_sqlite_live\` — 2/2 pass.