### PR TITLE
feat(orm): QuerySet::doesnt_exist — Builder::doesntExist() alias

### DIFF
--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -2109,6 +2109,17 @@ pub trait ExistsPool<T: Model + Send> {
         pool: &Pool,
     ) -> impl std::future::Future<Output = Result<bool, ExecError>> + Send;
 
+    /// Eloquent `Builder::doesntExist()` alias for [`Self::is_empty`]
+    /// — `Ok(true)` when no row matches the queryset's filters. One-
+    /// line muscle-memory alias; identical semantics + cost.
+    ///
+    /// # Errors
+    /// As [`Self::is_empty`].
+    fn doesnt_exist(
+        self,
+        pool: &Pool,
+    ) -> impl std::future::Future<Output = Result<bool, ExecError>> + Send;
+
     /// `Ok(true)` when a row with `pk = pk_value` is contained in the
     /// queryset. #330. Looks up the PK column from `T::SCHEMA`; errors
     /// when the model has no primary key (very rare — view-backed
@@ -2133,6 +2144,10 @@ impl<T: Model + Send> ExistsPool<T> for QuerySet<T> {
     async fn is_empty(self, pool: &Pool) -> Result<bool, ExecError> {
         let count = self.count_pool(pool).await?;
         Ok(count == 0)
+    }
+
+    async fn doesnt_exist(self, pool: &Pool) -> Result<bool, ExecError> {
+        self.is_empty(pool).await
     }
 
     async fn contains_pk(

--- a/crates/rustango/tests/queryset_doesnt_exist_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_doesnt_exist_sqlite_live.rs
@@ -1,0 +1,69 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::doesnt_exist(&pool)` — Eloquent
+//! `Builder::doesntExist()` alias for `is_empty()`.
+
+use rustango::sql::{sqlx, Auto, ExistsPool as _, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "dne_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub published: bool,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE dne_post (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            published INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+async fn insert(pool: &Pool, published: bool) {
+    let mut p = Post {
+        id: Auto::default(),
+        published,
+    };
+    p.save_pool(pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn doesnt_exist_true_on_empty_scope() {
+    let pool = make_pool().await;
+    insert(&pool, false).await;
+    insert(&pool, false).await;
+    assert!(Post::objects()
+        .filter("published", true)
+        .doesnt_exist(&pool)
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+async fn doesnt_exist_false_when_any_row_matches() {
+    let pool = make_pool().await;
+    insert(&pool, true).await;
+    insert(&pool, false).await;
+    assert!(!Post::objects()
+        .filter("published", true)
+        .doesnt_exist(&pool)
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+async fn doesnt_exist_true_on_empty_table() {
+    let pool = make_pool().await;
+    assert!(Post::objects().doesnt_exist(&pool).await.unwrap());
+}


### PR DESCRIPTION
## Summary
- Adds \`QuerySet::doesnt_exist(&pool)\` to the \`ExistsPool\` trait — Eloquent muscle-memory alias for \`is_empty(&pool)\`.
- Identical semantics + cost; reads naturally in negation guards (\`if qs.doesnt_exist(...).await?\`).

## Test plan
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_doesnt_exist_sqlite_live\` — 3/3 pass.