### PR TITLE
feat(orm): QuerySet::where_exists / where_not_exists — whereExists() parity

### DIFF
--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1158,6 +1158,52 @@ impl<T: Model> QuerySet<T> {
         }
     }
 
+    /// Eloquent `Builder::whereExists($closure)` — AND-join an
+    /// `EXISTS (subquery)` predicate onto this queryset's WHERE.
+    ///
+    /// `subquery` is an already-compiled [`SelectQuery`] — build it
+    /// with the inner model's `objects()` chain and call `.compile()`
+    /// to propagate any column-typo errors at the inner queryset.
+    /// Use [`crate::core::subquery::outer_ref`] to correlate against
+    /// columns of the outer model.
+    ///
+    /// ```ignore
+    /// use rustango::core::Column as _;
+    /// use rustango::core::subquery::outer_ref;
+    ///
+    /// // Authors who have at least one book.
+    /// let with_books = Book::objects()
+    ///     .where_(Book::author_id.eq_expr(outer_ref("id")))
+    ///     .compile()?;
+    /// let authors = Author::objects()
+    ///     .where_exists(with_books)
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    ///
+    /// Sugar over `self.where_raw(subquery::exists(subquery))`.
+    #[must_use]
+    pub fn where_exists(self, subquery: SelectQuery) -> Self {
+        self.where_raw(crate::core::subquery::exists(subquery))
+    }
+
+    /// Eloquent `Builder::whereNotExists($closure)` — AND-join a
+    /// `NOT EXISTS (subquery)` predicate. Inverse of
+    /// [`Self::where_exists`]; canonical "find rows in A with no
+    /// related row in B" shape.
+    ///
+    /// ```ignore
+    /// let no_books = Book::objects()
+    ///     .where_(Book::author_id.eq_expr(outer_ref("id")))
+    ///     .compile()?;
+    /// let empty = Author::objects()
+    ///     .where_not_exists(no_books)
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    #[must_use]
+    pub fn where_not_exists(self, subquery: SelectQuery) -> Self {
+        self.where_raw(crate::core::subquery::not_exists(subquery))
+    }
+
     /// Append a typed predicate or boolean expression built via the
     /// [`Column`](crate::core::Column) API. Accepts either a single
     /// [`TypedFilter`](crate::core::TypedFilter) (`User::id.gt(10)`)

--- a/crates/rustango/tests/queryset_where_exists_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_where_exists_sqlite_live.rs
@@ -1,0 +1,115 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::where_exists(subquery)` /
+//! `QuerySet::where_not_exists(subquery)` — Eloquent
+//! `Builder::whereExists` / `whereNotExists` parity. Routes through
+//! the existing `subquery::exists` / `not_exists` free functions but
+//! drops the `where_raw(...)` wrapper from call sites.
+
+use rustango::core::subquery::outer_ref;
+use rustango::core::Column as _;
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "we_author")]
+#[allow(dead_code)]
+pub struct Author {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 40)]
+    pub name: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "we_book")]
+#[allow(dead_code)]
+pub struct Book {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub author_id: i64,
+    #[rustango(max_length = 40)]
+    pub title: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE we_author (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE TABLE we_book (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            author_id INTEGER NOT NULL,
+            title     TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+async fn seed(pool: &Pool) {
+    // Alice has 1 book; Bob has 0.
+    let mut alice = Author {
+        id: Auto::default(),
+        name: "Alice".into(),
+    };
+    alice.save_pool(pool).await.unwrap();
+    let alice_id = *alice.id.get().unwrap();
+
+    let mut bob = Author {
+        id: Auto::default(),
+        name: "Bob".into(),
+    };
+    bob.save_pool(pool).await.unwrap();
+
+    let mut book = Book {
+        id: Auto::default(),
+        author_id: alice_id,
+        title: "Alpha".into(),
+    };
+    book.save_pool(pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn where_exists_finds_authors_with_books() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let inner = Book::objects()
+        .where_(Book::author_id.eq_expr(outer_ref("id")))
+        .compile()
+        .unwrap();
+    let rows = Author::objects()
+        .where_exists(inner)
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "Alice");
+}
+
+#[tokio::test]
+async fn where_not_exists_finds_authors_with_no_books() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let inner = Book::objects()
+        .where_(Book::author_id.eq_expr(outer_ref("id")))
+        .compile()
+        .unwrap();
+    let rows = Author::objects()
+        .where_not_exists(inner)
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "Bob");
+}


### PR DESCRIPTION
## Summary
- Adds \`QuerySet::where_exists(SelectQuery)\` / \`QuerySet::where_not_exists(SelectQuery)\` chainable wrappers around \`crate::core::subquery::exists\` / \`not_exists\`.
- Drops the \`where_raw(...)\` wrapper at call sites — \`qs.where_exists(inner)\` reads exactly like Eloquent's \`->whereExists(\$closure)\`.
- Plumbing unchanged: \`WhereExpr::Exists\` / \`NotExists\` + scope-stack resolver emit SQL for all three dialects.

## Test plan
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_where_exists_sqlite_live\` — 2/2 pass (authors-with-books, authors-with-no-books).