### PR TITLE
feat(orm): QuerySet::{get,first,update}_or_create chainable methods

### DIFF
--- a/crates/rustango/src/sql/executor/get_or_create.rs
+++ b/crates/rustango/src/sql/executor/get_or_create.rs
@@ -152,3 +152,80 @@ where
         }),
     }
 }
+
+impl<T> crate::query::QuerySet<T>
+where
+    T: Model
+        + MaybePgFromRow
+        + MaybeMyFromRow
+        + MaybeSqliteFromRow
+        + LoadRelated
+        + MaybeMyLoadRelated
+        + MaybeSqliteLoadRelated
+        + Send
+        + Unpin,
+{
+    /// Chainable form of [`get_or_create`]. Sugar for
+    /// `get_or_create(self, create_fn, pool)` so call sites read as
+    /// `Post::objects().filter(...).get_or_create(|pool| ..., &pool)`.
+    ///
+    /// Returns `(row, created)` where `created` is `true` when the
+    /// closure was invoked.
+    ///
+    /// # Errors
+    /// As [`get_or_create`].
+    pub async fn get_or_create<F, Fut>(
+        self,
+        create_fn: F,
+        pool: &Pool,
+    ) -> Result<(T, bool), ExecError>
+    where
+        F: FnOnce(Pool) -> Fut,
+        Fut: std::future::Future<Output = Result<T, ExecError>>,
+    {
+        get_or_create(self, create_fn, pool).await
+    }
+
+    /// Eloquent `Model::firstOrCreate($attributes, $values)` alias
+    /// for [`Self::get_or_create`]. Identical semantics; the
+    /// separate name keeps Laravel muscle-memory call sites
+    /// readable.
+    ///
+    /// # Errors
+    /// As [`Self::get_or_create`].
+    pub async fn first_or_create<F, Fut>(
+        self,
+        create_fn: F,
+        pool: &Pool,
+    ) -> Result<(T, bool), ExecError>
+    where
+        F: FnOnce(Pool) -> Fut,
+        Fut: std::future::Future<Output = Result<T, ExecError>>,
+    {
+        self.get_or_create(create_fn, pool).await
+    }
+
+    /// Chainable form of [`update_or_create`]. Sugar for
+    /// `update_or_create(self, update_fn, create_fn, pool)`.
+    ///
+    /// Returns `(row, created)` where `created` is `true` when the
+    /// `create_fn` closure was invoked (i.e. no row matched the
+    /// queryset).
+    ///
+    /// # Errors
+    /// As [`update_or_create`].
+    pub async fn update_or_create<UF, UFut, CF, CFut>(
+        self,
+        update_fn: UF,
+        create_fn: CF,
+        pool: &Pool,
+    ) -> Result<(T, bool), ExecError>
+    where
+        UF: FnOnce(Pool, T) -> UFut,
+        UFut: std::future::Future<Output = Result<T, ExecError>>,
+        CF: FnOnce(Pool) -> CFut,
+        CFut: std::future::Future<Output = Result<T, ExecError>>,
+    {
+        update_or_create(self, update_fn, create_fn, pool).await
+    }
+}

--- a/crates/rustango/tests/queryset_get_or_create_method_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_get_or_create_method_sqlite_live.rs
@@ -1,0 +1,158 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for chainable `QuerySet::get_or_create` /
+//! `QuerySet::first_or_create` / `QuerySet::update_or_create`
+//! methods — sugar over the existing `rustango::sql::get_or_create`
+//! and `update_or_create` free functions.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "goc_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 40)]
+    pub slug: String,
+    #[rustango(max_length = 80)]
+    pub title: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE goc_post (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            slug  TEXT NOT NULL,
+            title TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+#[tokio::test]
+async fn get_or_create_creates_when_missing() {
+    let pool = make_pool().await;
+    let (post, created) = Post::objects()
+        .filter("slug", "hello".to_string())
+        .get_or_create(
+            |pool| async move {
+                let mut p = Post {
+                    id: Auto::default(),
+                    slug: "hello".into(),
+                    title: "Hello!".into(),
+                };
+                p.save_pool(&pool).await?;
+                Ok(p)
+            },
+            &pool,
+        )
+        .await
+        .unwrap();
+    assert!(created);
+    assert_eq!(post.title, "Hello!");
+}
+
+#[tokio::test]
+async fn get_or_create_returns_existing_row() {
+    let pool = make_pool().await;
+    let mut existing = Post {
+        id: Auto::default(),
+        slug: "hello".into(),
+        title: "Original".into(),
+    };
+    existing.save_pool(&pool).await.unwrap();
+
+    let (post, created) = Post::objects()
+        .filter("slug", "hello".to_string())
+        .get_or_create(
+            |_pool| async move {
+                panic!("should not reach create_fn — row already exists");
+            },
+            &pool,
+        )
+        .await
+        .unwrap();
+    assert!(!created);
+    assert_eq!(post.title, "Original");
+}
+
+#[tokio::test]
+async fn first_or_create_is_alias_for_get_or_create() {
+    let pool = make_pool().await;
+    let (post, created) = Post::objects()
+        .filter("slug", "x".to_string())
+        .first_or_create(
+            |pool| async move {
+                let mut p = Post {
+                    id: Auto::default(),
+                    slug: "x".into(),
+                    title: "Xebra".into(),
+                };
+                p.save_pool(&pool).await?;
+                Ok(p)
+            },
+            &pool,
+        )
+        .await
+        .unwrap();
+    assert!(created);
+    assert_eq!(post.title, "Xebra");
+}
+
+#[tokio::test]
+async fn update_or_create_updates_existing_row() {
+    let pool = make_pool().await;
+    let mut existing = Post {
+        id: Auto::default(),
+        slug: "hello".into(),
+        title: "Old".into(),
+    };
+    existing.save_pool(&pool).await.unwrap();
+
+    let (post, created) = Post::objects()
+        .filter("slug", "hello".to_string())
+        .update_or_create(
+            |pool, mut row| async move {
+                row.title = "New".into();
+                row.save_pool(&pool).await?;
+                Ok(row)
+            },
+            |_pool| async move { panic!("should hit update branch") },
+            &pool,
+        )
+        .await
+        .unwrap();
+    assert!(!created);
+    assert_eq!(post.title, "New");
+}
+
+#[tokio::test]
+async fn update_or_create_creates_when_missing() {
+    let pool = make_pool().await;
+    let (post, created) = Post::objects()
+        .filter("slug", "fresh".to_string())
+        .update_or_create(
+            |_pool, _row| async move { panic!("should hit create branch") },
+            |pool| async move {
+                let mut p = Post {
+                    id: Auto::default(),
+                    slug: "fresh".into(),
+                    title: "Fresh".into(),
+                };
+                p.save_pool(&pool).await?;
+                Ok(p)
+            },
+            &pool,
+        )
+        .await
+        .unwrap();
+    assert!(created);
+    assert_eq!(post.title, "Fresh");
+}


### PR DESCRIPTION
## Summary
- Adds chainable \`QuerySet::get_or_create\` / \`first_or_create\` (Eloquent alias) / \`update_or_create\` inherent methods.
- Sugar over the existing \`rustango::sql::get_or_create\` / \`update_or_create\` free functions — flips
  \`get_or_create(qs, …, &pool)\` to \`qs.get_or_create(…, &pool)\`.
- \`first_or_create\` matches Eloquent's \`firstOrCreate(\$attrs, \$values)\` shape for muscle memory.

## Test plan
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_get_or_create_method_sqlite_live\` — 5/5 pass (create, return-existing, alias, update-existing, create-missing).