### PR TITLE
feat(orm): QuerySet::where_column / where_column_op — whereColumn() parity

### DIFF
--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1234,6 +1234,48 @@ impl<T: Model> QuerySet<T> {
         self.where_raw(crate::core::subquery::not_in_subquery(column, subquery))
     }
 
+    /// Eloquent `Builder::whereColumn($col1, $col2)` — emits
+    /// `<col1> = <col2>`, comparing two columns instead of column
+    /// vs literal. Equality is the overwhelming majority of uses;
+    /// for any other comparison, see [`Self::where_column_op`].
+    ///
+    /// Both column names are validated by the schema at
+    /// `compile()`-time via the existing
+    /// [`WhereExpr::ExprCompare`](crate::core::WhereExpr::ExprCompare)
+    /// path.
+    ///
+    /// ```ignore
+    /// // Eloquent: User::whereColumn('first_name', 'last_name');
+    /// User::objects()
+    ///     .where_column("first_name", "last_name")
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    #[must_use]
+    pub fn where_column(self, col1: &'static str, col2: &'static str) -> Self {
+        self.where_column_op(col1, Op::Eq, col2)
+    }
+
+    /// Eloquent `Builder::whereColumn($col1, $op, $col2)` — column-
+    /// vs-column comparison with an explicit operator. Use the
+    /// shorter [`Self::where_column`] when the op is `Eq`.
+    ///
+    /// ```ignore
+    /// use rustango::core::Op;
+    /// // start_date < end_date — Eloquent: whereColumn('start_date', '<', 'end_date')
+    /// Reservation::objects()
+    ///     .where_column_op("start_date", Op::Lt, "end_date")
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    #[must_use]
+    pub fn where_column_op(self, col1: &'static str, op: Op, col2: &'static str) -> Self {
+        use crate::core::F;
+        self.where_raw(WhereExpr::ExprCompare {
+            lhs: F(col1).into(),
+            op,
+            rhs: F(col2).into(),
+        })
+    }
+
     /// Append a typed predicate or boolean expression built via the
     /// [`Column`](crate::core::Column) API. Accepts either a single
     /// [`TypedFilter`](crate::core::TypedFilter) (`User::id.gt(10)`)

--- a/crates/rustango/tests/queryset_where_column_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_where_column_sqlite_live.rs
@@ -1,0 +1,85 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::where_column(col1, col2)` /
+//! `QuerySet::where_column_op(col1, op, col2)` — Eloquent
+//! `Builder::whereColumn` parity that compares two columns instead
+//! of column-vs-literal.
+
+use rustango::core::Op;
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "wc_resv")]
+#[allow(dead_code)]
+pub struct Reservation {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub start_day: i64,
+    pub end_day: i64,
+    #[rustango(max_length = 40)]
+    pub label: String,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE wc_resv (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            start_day INTEGER NOT NULL,
+            end_day   INTEGER NOT NULL,
+            label     TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+async fn insert(pool: &Pool, start: i64, end: i64, label: &str) {
+    let mut r = Reservation {
+        id: Auto::default(),
+        start_day: start,
+        end_day: end,
+        label: label.into(),
+    };
+    r.save_pool(pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn where_column_eq_matches_rows_with_equal_columns() {
+    let pool = make_pool().await;
+    insert(&pool, 5, 5, "same").await;
+    insert(&pool, 1, 9, "diff").await;
+    insert(&pool, 7, 7, "same2").await;
+    let mut got: Vec<String> = Reservation::objects()
+        .where_column("start_day", "end_day")
+        .fetch_pool(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|r| r.label)
+        .collect();
+    got.sort();
+    assert_eq!(got, vec!["same", "same2"]);
+}
+
+#[tokio::test]
+async fn where_column_op_lt_finds_rows_where_start_before_end() {
+    let pool = make_pool().await;
+    insert(&pool, 1, 9, "valid").await;
+    insert(&pool, 5, 5, "zero-len").await;
+    insert(&pool, 9, 1, "reversed").await;
+    let mut got: Vec<String> = Reservation::objects()
+        .where_column_op("start_day", Op::Lt, "end_day")
+        .fetch_pool(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|r| r.label)
+        .collect();
+    got.sort();
+    assert_eq!(got, vec!["valid"]);
+}


### PR DESCRIPTION
## Summary
- Adds chainable column-vs-column comparison: \`where_column(c1, c2)\` (equality) and \`where_column_op(c1, op, c2)\` (explicit \`Op\`).
- Eloquent \`Builder::whereColumn(\$col1, \$col2)\` / \`whereColumn(\$col1, \$op, \$col2)\` parity.
- Routes through the existing \`WhereExpr::ExprCompare { F(c1), op, F(c2) }\` writer; schema validation happens at \`compile()\` time.

## Test plan
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_where_column_sqlite_live\` — 2/2 pass.