### PR TITLE
feat(orm): QuerySet::where_has / where_doesnt_have — relation-name resolver (#830 slice 1)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -856,6 +856,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         &container.extra_permissions,
         &container.default_permissions,
         &container.global_scopes,
+        &container.reverse_has_relations,
     );
     let module_ident = column_module_ident(struct_name);
     let column_consts = column_const_tokens(&module_ident, &collected.column_entries);
@@ -2239,6 +2240,7 @@ fn model_impl_tokens(
     extra_permissions: &[(String, String)],
     default_permissions: &[String],
     global_scopes: &[GlobalScopeAttr],
+    reverse_has_relations: &[ReverseHasAttr],
 ) -> TokenStream2 {
     let root = rustango_root();
     let display_tokens = if let Some(name) = display {
@@ -2423,6 +2425,35 @@ fn model_impl_tokens(
             }
         }
     });
+    // Issue #830 sub-piece: emit `Model::reverse_relations()` override
+    // when the model declares `#[rustango(reverse_has(...))]`. Each
+    // entry uses `<Child as Model>::SCHEMA.table` so the literal stays
+    // a const expression. Models without reverse_has fall through to
+    // the trait's empty default — no override emitted.
+    let reverse_relations_override = if reverse_has_relations.is_empty() {
+        quote!()
+    } else {
+        let entries = reverse_has_relations.iter().map(|rel| {
+            let name = rel.name.as_str();
+            let child = &rel.child;
+            let child_fk_column = rel.child_fk_column.as_str();
+            let self_pk_column = rel.self_pk_column.as_str();
+            quote! {
+                #root::core::ReverseRelation {
+                    name: #name,
+                    child_schema: <#child as #root::core::Model>::SCHEMA,
+                    child_fk_column: #child_fk_column,
+                    self_pk_column: #self_pk_column,
+                }
+            }
+        });
+        quote! {
+            fn reverse_relations() -> &'static [#root::core::ReverseRelation] {
+                const RELS: &[#root::core::ReverseRelation] = &[ #(#entries),* ];
+                RELS
+            }
+        }
+    };
     quote! {
         impl #root::core::Model for #struct_name {
             const SCHEMA: &'static #root::core::ModelSchema = &#root::core::ModelSchema {
@@ -2459,6 +2490,8 @@ fn model_impl_tokens(
                 default_permissions: &[ #(#default_permission_tokens),* ],
                 global_scopes: &[ #(#global_scope_tokens),* ],
             };
+
+            #reverse_relations_override
         }
     }
 }

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -34,7 +34,7 @@ pub use schema::{
     infer_app_label_from_module_path, AdminConfig, CheckConstraint, CompositeFkRelation,
     ExclusionConstraint, FieldSchema, Fieldset, GenericRelation, GlobalScope, IndexMethod,
     IndexSchema, ListSelectRelated, M2MRelation, Model, ModelEntry, ModelSchema, ModelScope,
-    OnDeleteAction, PrepopulatedField, Relation,
+    OnDeleteAction, PrepopulatedField, Relation, ReverseRelation,
 };
 pub use validate::validate_value;
 pub use value::SqlValue;

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -229,6 +229,42 @@ pub struct GenericRelation {
     pub pk_column: &'static str,
 }
 
+/// Reverse-FK existence metadata declared via
+/// `#[rustango(reverse_has(name, child, child_fk_column))]`. Captures
+/// the (child table, child FK column, self PK column) triple that
+/// makes a correlated `EXISTS (SELECT 1 FROM child WHERE
+/// child_fk_column = <outer>.self_pk_column)` query writable from the
+/// parent's queryset.
+///
+/// **Why runtime metadata, not just macro emit:** the macro already
+/// emits per-instance `<name>_exists_expr()` helpers, but the
+/// queryset-level shortcuts (`QuerySet::where_has(name)` /
+/// `where_doesnt_have(name)` — issue #830) need to resolve a relation
+/// name **without** a concrete `self` value at the call site. Lifting
+/// the same triple into `ModelSchema` lets the queryset look it up
+/// by name. Sub-issue of #830.
+#[derive(Debug, Clone, Copy)]
+pub struct ReverseRelation {
+    /// Relation accessor name as declared in
+    /// `reverse_has(name = "books")`. Used for lookup from queryset
+    /// shortcuts.
+    pub name: &'static str,
+    /// `ModelSchema` of the **child** model — the `FROM` clause of
+    /// the correlated subquery. Macro fills this in from
+    /// `<Child as Model>::SCHEMA` so the embeddable
+    /// [`super::query::SelectQuery`] can be constructed without
+    /// re-resolving the child type at runtime.
+    pub child_schema: &'static ModelSchema,
+    /// SQL column on the child table that references this model's
+    /// primary key. For `Book::author_id: ForeignKey<Author>` the
+    /// column is `"author_id"`.
+    pub child_fk_column: &'static str,
+    /// SQL primary-key column on **this** model's table — the
+    /// `OuterRef("…")` target. Defaults to `"id"` when
+    /// `reverse_has(...)` doesn't specify `self_pk_column`.
+    pub self_pk_column: &'static str,
+}
+
 /// Multi-column ("composite") foreign key relation, declared at the
 /// model level rather than the field level — single-column FKs stay
 /// in [`FieldSchema::relation`], composite FKs live here so each
@@ -1097,6 +1133,20 @@ impl ModelSchema {
 /// reach the model's metadata without an instance.
 pub trait Model: Sized + Send + Sync + 'static {
     const SCHEMA: &'static ModelSchema;
+
+    /// Reverse-FK existence relations declared via
+    /// `#[rustango(reverse_has(name, child, child_fk_column))]`. The
+    /// macro overrides this to return the populated slice; models
+    /// with no reverse-has declarations inherit the empty default.
+    ///
+    /// Used by [`crate::query::QuerySet::where_has`] /
+    /// [`crate::query::QuerySet::where_doesnt_have`] to resolve a
+    /// relation name into the correlated-subquery triple
+    /// `(child_table, child_fk_column, self_pk_column)` without
+    /// needing a concrete `self`. Issue #830 sub-piece.
+    fn reverse_relations() -> &'static [ReverseRelation] {
+        &[]
+    }
 }
 
 /// Inventory entry submitted by the `#[derive(Model)]` macro for each model.

--- a/crates/rustango/src/core/subquery.rs
+++ b/crates/rustango/src/core/subquery.rs
@@ -62,7 +62,8 @@
 //! executed. Build the subquery first, propagate `?`, then embed.
 
 use super::expr::Expr;
-use super::query::{SelectQuery, WhereExpr};
+use super::query::{Op, SelectQuery, WhereExpr};
+use super::schema::ReverseRelation;
 
 /// `EXISTS (subquery)` — true when the subquery returns at least one
 /// row. Mirrors Django's [`Exists`] expression and is by far the most
@@ -115,6 +116,44 @@ pub fn not_in_subquery(column: &'static str, subquery: SelectQuery) -> WhereExpr
 #[must_use]
 pub fn subquery(inner: SelectQuery) -> Expr {
     Expr::Subquery(Box::new(inner))
+}
+
+/// Build the correlated `EXISTS (SELECT 1 FROM <child_table> WHERE
+/// <child_fk_column> = <outer>.<self_pk_column>)` predicate for the
+/// given [`ReverseRelation`] — issue #830 sub-piece backing
+/// [`crate::query::QuerySet::where_has`].
+///
+/// The inner `SelectQuery` projects nothing (the dialect writer
+/// reads no rows out — `EXISTS` only cares about row presence) and
+/// joins via `OuterRef(self_pk_column)`. The writer's scope stack
+/// rewrites `OuterRef` to the parent queryset's table qualifier at
+/// emit time, so the SQL stays unambiguous across dialects.
+#[must_use]
+pub fn reverse_has_exists(rel: &ReverseRelation) -> WhereExpr {
+    let inner = SelectQuery {
+        where_clause: WhereExpr::ExprCompare {
+            lhs: Expr::Column(rel.child_fk_column),
+            op: Op::Eq,
+            rhs: Expr::OuterRef(rel.self_pk_column),
+        },
+        ..SelectQuery::new(rel.child_schema)
+    };
+    WhereExpr::Exists(Box::new(inner))
+}
+
+/// `NOT EXISTS (subquery)` counterpart of [`reverse_has_exists`].
+/// Backs [`crate::query::QuerySet::where_doesnt_have`].
+#[must_use]
+pub fn reverse_has_not_exists(rel: &ReverseRelation) -> WhereExpr {
+    let inner = SelectQuery {
+        where_clause: WhereExpr::ExprCompare {
+            lhs: Expr::Column(rel.child_fk_column),
+            op: Op::Eq,
+            rhs: Expr::OuterRef(rel.self_pk_column),
+        },
+        ..SelectQuery::new(rel.child_schema)
+    };
+    WhereExpr::NotExists(Box::new(inner))
 }
 
 /// `OuterRef("col")` — reference a column from the enclosing query

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1234,6 +1234,69 @@ impl<T: Model> QuerySet<T> {
         self.where_raw(crate::core::subquery::not_in_subquery(column, subquery))
     }
 
+    /// Filter to rows that have at least one related row via the
+    /// reverse-FK relation named `name` — Django
+    /// `filter(<name>__isnull=False)` shape via
+    /// `T::reverse_relations()` metadata.
+    ///
+    /// `name` must match a declared
+    /// `#[rustango(reverse_has(name = "...", child = Child,
+    /// child_fk_column = "..."))]` on `T`. The method emits a
+    /// correlated `EXISTS (SELECT 1 FROM <child_table> WHERE
+    /// <child_fk_column> = <outer>.<self_pk_column>)` predicate that
+    /// the writer's scope-stack threads through PG / MySQL / SQLite
+    /// identically.
+    ///
+    /// Unknown relation names surface as
+    /// [`QueryError::UnknownField`] (field set to the unknown name)
+    /// at `compile()` time via the deferred-error path.
+    ///
+    /// ```ignore
+    /// // Requires Author declared with
+    /// // `#[rustango(reverse_has(name = "books", child = Book,
+    /// //            child_fk_column = "author_id"))]`.
+    /// let with_books = Author::objects()
+    ///     .where_has("books")
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    ///
+    /// Issue #830 — first slice (existence only). Builds on the
+    /// existing per-instance `<name>_exists_expr()` accessor by
+    /// lifting the relation triple into runtime `Model` metadata so
+    /// callers don't need a concrete `self` to resolve it.
+    #[must_use]
+    pub fn where_has(self, name: &str) -> Self {
+        match T::reverse_relations().iter().find(|r| r.name == name) {
+            Some(rel) => self.where_raw(crate::core::subquery::reverse_has_exists(rel)),
+            None => self.with_pending_error(QueryError::UnknownField {
+                model: T::SCHEMA.name,
+                field: name.to_string(),
+            }),
+        }
+    }
+
+    /// Opposite of [`Self::where_has`] — filter to rows that have
+    /// **no** related row via the named reverse-FK relation. Emits
+    /// `NOT EXISTS (subquery)`. Same relation-resolution semantics +
+    /// error shape.
+    ///
+    /// ```ignore
+    /// // Authors with zero books.
+    /// let empty = Author::objects()
+    ///     .where_doesnt_have("books")
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    #[must_use]
+    pub fn where_doesnt_have(self, name: &str) -> Self {
+        match T::reverse_relations().iter().find(|r| r.name == name) {
+            Some(rel) => self.where_raw(crate::core::subquery::reverse_has_not_exists(rel)),
+            None => self.with_pending_error(QueryError::UnknownField {
+                model: T::SCHEMA.name,
+                field: name.to_string(),
+            }),
+        }
+    }
+
     /// Eloquent `Builder::whereColumn($col1, $col2)` — emits
     /// `<col1> = <col2>`, comparing two columns instead of column
     /// vs literal. Equality is the overwhelming majority of uses;

--- a/crates/rustango/tests/queryset_where_has_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_where_has_sqlite_live.rs
@@ -1,0 +1,140 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::where_has(name)` /
+//! `QuerySet::where_doesnt_have(name)` — issue #830 slice 1
+//! (relation-name → correlated `EXISTS` resolver).
+//!
+//! Builds on the existing macro-emitted `<name>_exists_expr()` /
+//! `<name>_not_exists_expr()` accessors. The QuerySet shortcut
+//! resolves the relation via `Model::reverse_relations()` so the
+//! caller doesn't need a concrete `self`.
+
+use rustango::core::Model as _;
+use rustango::sql::{sqlx, Auto, FetcherPool as _, ForeignKey, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "wh_author",
+    reverse_has(name = "books", child = "Book", child_fk_column = "author_id",)
+)]
+#[allow(dead_code)]
+pub struct Author {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 40)]
+    pub name: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "wh_book")]
+#[allow(dead_code)]
+pub struct Book {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+    pub author_id: ForeignKey<Author, i64>,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE wh_author (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE TABLE wh_book (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            title     TEXT NOT NULL,
+            author_id INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+async fn seed(pool: &Pool) {
+    let mut alice = Author {
+        id: Auto::default(),
+        name: "Alice".into(),
+    };
+    alice.save_pool(pool).await.unwrap();
+    let alice_id = *alice.id.get().unwrap();
+    let mut bob = Author {
+        id: Auto::default(),
+        name: "Bob".into(),
+    };
+    bob.save_pool(pool).await.unwrap();
+    // Alice has a book; Bob doesn't.
+    let mut book = Book {
+        id: Auto::default(),
+        title: "Alpha".into(),
+        author_id: ForeignKey::from(alice_id),
+    };
+    book.save_pool(pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn where_has_resolves_relation_name_to_exists() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let rows = Author::objects()
+        .where_has("books")
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "Alice");
+}
+
+#[tokio::test]
+async fn where_doesnt_have_resolves_relation_name_to_not_exists() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let rows = Author::objects()
+        .where_doesnt_have("books")
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "Bob");
+}
+
+#[tokio::test]
+async fn where_has_unknown_relation_errors_at_compile_time() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let err = Author::objects()
+        .where_has("nonexistent")
+        .fetch_pool(&pool)
+        .await
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("nonexistent"),
+        "expected UnknownField for missing relation, got: {msg}"
+    );
+}
+
+#[test]
+fn reverse_relations_runtime_metadata_is_populated() {
+    // Author has 1 reverse-has declaration → metadata visible at runtime.
+    let rels = Author::reverse_relations();
+    assert_eq!(rels.len(), 1);
+    assert_eq!(rels[0].name, "books");
+    assert_eq!(rels[0].child_schema.table, "wh_book");
+    assert_eq!(rels[0].child_fk_column, "author_id");
+    assert_eq!(rels[0].self_pk_column, "id");
+
+    // Book has none → empty slice (the trait default).
+    assert!(Book::reverse_relations().is_empty());
+}


### PR DESCRIPTION
Closes part of #830 — first slice (existence only).

## Summary
- New \`Model::reverse_relations() -> &'static [ReverseRelation]\` trait method (empty-slice default; macro overrides for models with \`#[rustango(reverse_has(...))]\`).
- \`QuerySet::where_has(name)\` / \`QuerySet::where_doesnt_have(name)\` resolve the relation by name and emit a correlated \`EXISTS\` / \`NOT EXISTS\` subquery — tri-dialect via the existing scope-stack writer.
- Unknown relation names surface as \`QueryError::UnknownField\` at \`compile()\` time.

## Design choices
- **Trait-default method, not a new \`ModelSchema\` field.** ~9 hand-rolled \`ModelSchema { ... }\` literals (\`template_views\` / \`soft_delete\` / \`forms\` / admin / mysql / sqlite / etc.) would break if we added a required field. The trait-default path is zero-churn.
- **Reuses existing substrate.** \`crate::core::subquery::reverse_has_exists\` builds the correlated \`SelectQuery\` and routes through \`WhereExpr::Exists\` / \`NotExists\` — the same path tested in \`tests/subquery_expressions_live.rs\` since #79.
- **Schema reference, not just table name.** \`ReverseRelation::child_schema: &'static ModelSchema\` carries the full schema so the inner \`SelectQuery\` constructor doesn't have to resolve the child type at runtime.

## What's NOT in this PR (next slices)
- \`whereHas(name, closure)\` — optional related-row predicate on the inner subquery. Substrate is ready; needs a builder API for the closure.
- \`has(name, op, n)\` count-comparator. Needs the correlated count-aggregate path that's also a sub-piece of #830's \`withCount\` half.
- \`withCount(name)\` annotated-count. Larger lift (aggregate by relation, careful with double-counting on joins).

## Test plan
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_where_has_sqlite_live\` — 4/4 pass (EXISTS resolves, NOT EXISTS resolves, unknown relation errors, runtime metadata populated).
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test model_reverse_has_sqlite_live\` — 9/9 still pass (existing per-instance accessors unaffected).