### PR TITLE
feat(orm): QuerySet::where_has_filter / where_doesnt_have_filter — whereHas($rel, $closure) (#830 slice 2)

### DIFF
--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1297,6 +1297,97 @@ impl<T: Model> QuerySet<T> {
         }
     }
 
+    /// Filter to rows that have at least one related row via the
+    /// named reverse-FK relation **AND** the related row matches the
+    /// caller-supplied inner predicate. Eloquent
+    /// `Builder::whereHas($rel, fn ($q) => …)` parity — issue #830
+    /// slice 2.
+    ///
+    /// `inner` is a fully-compiled `SelectQuery` on the child model
+    /// (typically built via `Child::objects().filter(...).compile()?`).
+    /// The method extracts its `WHERE` clause, AND-joins the
+    /// correlated `<child_fk_column> = <outer>.<self_pk_column>`
+    /// predicate, and wraps the result in `EXISTS (…)`.
+    ///
+    /// Schema validation: `inner.model` must point at the same
+    /// `ModelSchema` as the relation's `child_schema`. Mismatches
+    /// surface as [`QueryError::UnknownField`] at compile time.
+    ///
+    /// ```ignore
+    /// // Eloquent: Author::whereHas('books', fn ($q) => $q->where('published', true))->get();
+    /// let inner = Book::objects().filter("published", true).compile()?;
+    /// let authors = Author::objects()
+    ///     .where_has_filter("books", inner)
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    #[must_use]
+    pub fn where_has_filter(self, name: &str, inner: SelectQuery) -> Self {
+        self.where_has_filter_impl(name, inner, /*negated=*/ false)
+    }
+
+    /// `whereDoesntHave($rel, fn ($q) => …)` counterpart of
+    /// [`Self::where_has_filter`] — filter to rows that have **no**
+    /// related row matching the inner predicate. Emits
+    /// `NOT EXISTS (…)` over the same correlated inner SELECT.
+    #[must_use]
+    pub fn where_doesnt_have_filter(self, name: &str, inner: SelectQuery) -> Self {
+        self.where_has_filter_impl(name, inner, /*negated=*/ true)
+    }
+
+    /// Internal worker shared by [`Self::where_has_filter`] and
+    /// [`Self::where_doesnt_have_filter`]. `negated = true` wraps the
+    /// merged inner SELECT in `NOT EXISTS` instead of `EXISTS`.
+    fn where_has_filter_impl(self, name: &str, mut inner: SelectQuery, negated: bool) -> Self {
+        let rel = match T::reverse_relations().iter().find(|r| r.name == name) {
+            Some(r) => r,
+            None => {
+                return self.with_pending_error(QueryError::UnknownField {
+                    model: T::SCHEMA.name,
+                    field: name.to_string(),
+                });
+            }
+        };
+        // The user might pass an inner queryset built on the wrong
+        // child model — guard against silently producing wrong SQL.
+        // `Model::SCHEMA` is a `const &'static ModelSchema` (not a
+        // `static`), so each use-site can get its own promoted
+        // address — pointer equality is unreliable. Compare by
+        // model name (unique within the crate per `#[derive(Model)]`).
+        if inner.model.name != rel.child_schema.name {
+            return self.with_pending_error(QueryError::UnknownField {
+                model: T::SCHEMA.name,
+                field: format!(
+                    "where_has_filter({name}): inner queryset model mismatch — \
+                     expected `{}`, got `{}`",
+                    rel.child_schema.name, inner.model.name
+                ),
+            });
+        }
+        let correlated = WhereExpr::ExprCompare {
+            lhs: crate::core::Expr::Column(rel.child_fk_column),
+            op: Op::Eq,
+            rhs: crate::core::Expr::OuterRef(rel.self_pk_column),
+        };
+        // AND the correlation predicate with whatever the user
+        // already put on the inner SelectQuery. Flatten when the
+        // user's predicate is itself an `And` to keep the tree
+        // shallow.
+        inner.where_clause =
+            match std::mem::replace(&mut inner.where_clause, WhereExpr::And(Vec::new())) {
+                WhereExpr::And(mut v) => {
+                    v.push(correlated);
+                    WhereExpr::And(v)
+                }
+                other => WhereExpr::And(vec![other, correlated]),
+            };
+        let wrapped = if negated {
+            WhereExpr::NotExists(Box::new(inner))
+        } else {
+            WhereExpr::Exists(Box::new(inner))
+        };
+        self.where_raw(wrapped)
+    }
+
     /// Eloquent `Builder::whereColumn($col1, $col2)` — emits
     /// `<col1> = <col2>`, comparing two columns instead of column
     /// vs literal. Equality is the overwhelming majority of uses;

--- a/crates/rustango/tests/queryset_where_has_filter_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_where_has_filter_sqlite_live.rs
@@ -1,0 +1,177 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::where_has_filter(name, inner)` /
+//! `QuerySet::where_doesnt_have_filter(name, inner)` — issue #830
+//! slice 2 (whereHas with inner predicate).
+
+use rustango::sql::{sqlx, Auto, FetcherPool as _, ForeignKey, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "whf_author",
+    reverse_has(name = "books", child = "Book", child_fk_column = "author_id",)
+)]
+#[allow(dead_code)]
+pub struct Author {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 40)]
+    pub name: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "whf_book")]
+#[allow(dead_code)]
+pub struct Book {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+    pub author_id: ForeignKey<Author, i64>,
+    pub published: bool,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "whf_other")]
+#[allow(dead_code)]
+pub struct Other {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE whf_author (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE TABLE whf_book (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            title     TEXT NOT NULL,
+            author_id INTEGER NOT NULL,
+            published INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    sqlx::query("CREATE TABLE whf_other (id INTEGER PRIMARY KEY AUTOINCREMENT)")
+        .execute(&p)
+        .await
+        .unwrap();
+    p.into()
+}
+
+async fn seed(pool: &Pool) {
+    let mut alice = Author {
+        id: Auto::default(),
+        name: "Alice".into(),
+    };
+    alice.save_pool(pool).await.unwrap();
+    let alice_id = *alice.id.get().unwrap();
+    let mut bob = Author {
+        id: Auto::default(),
+        name: "Bob".into(),
+    };
+    bob.save_pool(pool).await.unwrap();
+    let bob_id = *bob.id.get().unwrap();
+    let mut carol = Author {
+        id: Auto::default(),
+        name: "Carol".into(),
+    };
+    carol.save_pool(pool).await.unwrap();
+
+    // Alice has a published book.
+    Book {
+        id: Auto::default(),
+        title: "Alpha".into(),
+        author_id: ForeignKey::from(alice_id),
+        published: true,
+    }
+    .save_pool(pool)
+    .await
+    .unwrap();
+    // Bob has only a draft.
+    Book {
+        id: Auto::default(),
+        title: "Beta".into(),
+        author_id: ForeignKey::from(bob_id),
+        published: false,
+    }
+    .save_pool(pool)
+    .await
+    .unwrap();
+    // Carol has no books.
+}
+
+#[tokio::test]
+async fn where_has_filter_narrows_to_authors_with_matching_child_rows() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let inner = Book::objects().filter("published", true).compile().unwrap();
+    let rows = Author::objects()
+        .where_has_filter("books", inner)
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "Alice");
+}
+
+#[tokio::test]
+async fn where_doesnt_have_filter_finds_authors_without_matching_child_rows() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    // "Authors with no published book" — Bob (draft only) and Carol (none).
+    let inner = Book::objects().filter("published", true).compile().unwrap();
+    let mut names: Vec<String> = Author::objects()
+        .where_doesnt_have_filter("books", inner)
+        .fetch_pool(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|a| a.name)
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["Bob", "Carol"]);
+}
+
+#[tokio::test]
+async fn where_has_filter_with_unknown_relation_errors() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let inner = Book::objects().compile().unwrap();
+    let err = Author::objects()
+        .where_has_filter("nonexistent", inner)
+        .fetch_pool(&pool)
+        .await
+        .unwrap_err();
+    assert!(format!("{err}").contains("nonexistent"));
+}
+
+#[tokio::test]
+async fn where_has_filter_with_wrong_child_model_errors() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    // Inner queryset is built on `Other`, but the `books` relation
+    // is declared against `Book`. Guard against silent SQL mismatch.
+    let wrong_inner = Other::objects().compile().unwrap();
+    let err = Author::objects()
+        .where_has_filter("books", wrong_inner)
+        .fetch_pool(&pool)
+        .await
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("model mismatch") || msg.contains("books"),
+        "expected mismatch error, got: {msg}"
+    );
+}


### PR DESCRIPTION
Second slice of #830 — \`whereHas\` / \`whereDoesntHave\` **with inner predicate** on the child rows.

Builds on slice 1 (#979 — name-resolver substrate): same \`Model::reverse_relations()\` lookup, same correlated \`EXISTS\` / \`NOT EXISTS\` shape, just AND-joins the caller-supplied predicate onto the correlation.

## Summary
- \`QuerySet::where_has_filter(name, inner: SelectQuery)\` — filter to parent rows that have at least one child row matching \`inner\`.
- \`QuerySet::where_doesnt_have_filter(name, inner)\` — opposite (NOT EXISTS).
- \`inner\` is built via \`Child::objects().filter(...).compile()?\`. Schema validation compares \`inner.model.name\` against \`rel.child_schema.name\` (pointer equality is unreliable because \`const SCHEMA: &'static ModelSchema = &ModelSchema { ... }\` is a const, not a static — Rust may promote \`&ModelSchema { ... }\` to different per-use-site addresses).

## Test plan
- [x] \`cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_where_has_filter_sqlite_live\` — 4/4 pass (matching narrows, NOT-matching finds, unknown-relation errors, wrong-child-model errors).
- [x] Slice-1 tests still green (\`queryset_where_has_sqlite_live\` 4/4, \`model_reverse_has_sqlite_live\` 9/9).