### PR TITLE
feat(orm): QuerySet::where_has_count — has($rel, $op, $n) count-comparator parity (#830 slice 3)

### DIFF
--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -133,6 +133,24 @@ pub enum Expr {
     ///
     /// [`SelectQuery`]: crate::core::SelectQuery
     Subquery(Box<super::query::SelectQuery>),
+    /// Scalar **aggregate** subquery — `(SELECT COUNT(*) FROM … WHERE …)`.
+    /// Issue #830 slice 3. Like [`Self::Subquery`] but the inner query is
+    /// an [`AggregateQuery`] so its projection is a single aggregate
+    /// (`COUNT(*)`, `SUM(col)`, …) rather than the child model's columns.
+    ///
+    /// Backs the count-comparator shortcut
+    /// [`crate::query::QuerySet::where_has_count`], which embeds a
+    /// correlated `(SELECT COUNT(*) FROM <child> WHERE <child_fk> =
+    /// <outer>.<pk>) <op> n` predicate. The writer pushes the inner
+    /// model's scope frame so any [`Self::OuterRef`] inside correlates
+    /// to the enclosing parent query — identically across PG / MySQL /
+    /// SQLite.
+    ///
+    /// Build via [`crate::core::subquery::reverse_has_count`] rather than
+    /// constructing this variant directly.
+    ///
+    /// [`AggregateQuery`]: crate::core::AggregateQuery
+    AggregateSubquery(Box<super::query::AggregateQuery>),
     /// Reference to an outer query's column from inside a correlated
     /// subquery (issue #5). Emitted as `"<outer_table>"."<col>"`; the
     /// outer table is threaded through the writer at emit time so

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -442,7 +442,14 @@ fn validate_expr_columns(model: &'static ModelSchema, expr: &Expr) -> Result<(),
         // against the outer schema when it embeds this subquery.
         // `AliasedColumn` (issue #80) carries its own table alias so
         // it doesn't resolve against the passed-in model.
-        Expr::Subquery(_) | Expr::OuterRef(_) | Expr::AliasedColumn { .. } => Ok(()),
+        // `AggregateSubquery` (issue #830) wraps an AggregateQuery over
+        // the *child* model; its columns resolve there, and any
+        // `OuterRef` names an outer column validated when the outer
+        // query embeds it — nothing to check against this model.
+        Expr::Subquery(_)
+        | Expr::AggregateSubquery(_)
+        | Expr::OuterRef(_)
+        | Expr::AliasedColumn { .. } => Ok(()),
         // Window (issue #7) — args / partition_by / order_by all
         // reference the outer model's columns. Validate them.
         Expr::Window(w) => {
@@ -1505,4 +1512,24 @@ pub struct AggregateQuery {
     pub order_by: Vec<OrderItem>,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
+}
+
+/// PartialEq for `AggregateQuery` — needed so [`crate::core::Expr`]
+/// (which embeds `Box<AggregateQuery>` for issue #830 correlated
+/// count-comparator subqueries) can keep its `#[derive(PartialEq)]`.
+/// Same treatment as [`SelectQuery`]: `ModelSchema` doesn't implement
+/// `PartialEq`, so `model` is compared by pointer identity — two
+/// queries against the same (singleton) schema register equal.
+impl PartialEq for AggregateQuery {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.model, other.model)
+            && self.where_clause == other.where_clause
+            && self.group_by == other.group_by
+            && self.aggregates == other.aggregates
+            && self.aliases == other.aliases
+            && self.having == other.having
+            && self.order_by == other.order_by
+            && self.limit == other.limit
+            && self.offset == other.offset
+    }
 }

--- a/crates/rustango/src/core/subquery.rs
+++ b/crates/rustango/src/core/subquery.rs
@@ -62,7 +62,7 @@
 //! executed. Build the subquery first, propagate `?`, then embed.
 
 use super::expr::Expr;
-use super::query::{Op, SelectQuery, WhereExpr};
+use super::query::{AggregateExpr, AggregateQuery, Op, SelectQuery, WhereExpr};
 use super::schema::ReverseRelation;
 
 /// `EXISTS (subquery)` — true when the subquery returns at least one
@@ -154,6 +154,41 @@ pub fn reverse_has_not_exists(rel: &ReverseRelation) -> WhereExpr {
         ..SelectQuery::new(rel.child_schema)
     };
     WhereExpr::NotExists(Box::new(inner))
+}
+
+/// Build the correlated `(SELECT COUNT(*) FROM <child_table> WHERE
+/// <child_fk_column> = <outer>.<self_pk_column>)` scalar-aggregate
+/// subquery for the given [`ReverseRelation`] — issue #830 slice 3,
+/// backing [`crate::query::QuerySet::where_has_count`].
+///
+/// The returned [`Expr`] is an [`Expr::AggregateSubquery`] suitable as
+/// the left-hand side of a count-comparison predicate (`… > 3`). The
+/// inner [`AggregateQuery`] projects `COUNT(*)` (no `GROUP BY`, so it
+/// yields exactly one row) and correlates to the parent via
+/// `OuterRef(self_pk_column)`; the writer's scope stack rewrites that
+/// `OuterRef` to the enclosing query's table qualifier at emit time,
+/// identically across PG / MySQL / SQLite.
+#[must_use]
+pub fn reverse_has_count(rel: &ReverseRelation) -> Expr {
+    let inner = AggregateQuery {
+        model: rel.child_schema,
+        where_clause: WhereExpr::ExprCompare {
+            lhs: Expr::Column(rel.child_fk_column),
+            op: Op::Eq,
+            rhs: Expr::OuterRef(rel.self_pk_column),
+        },
+        group_by: Vec::new(),
+        // A correlated `COUNT(*)` — the alias is inert in a scalar
+        // subquery (the outer context reads the single value, not the
+        // name) but the aggregate writer requires one.
+        aggregates: vec![("c", AggregateExpr::Count(None))],
+        aliases: Vec::new(),
+        having: None,
+        order_by: Vec::new(),
+        limit: None,
+        offset: None,
+    };
+    Expr::AggregateSubquery(Box::new(inner))
 }
 
 /// `OuterRef("col")` — reference a column from the enclosing query

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1388,6 +1388,52 @@ impl<T: Model> QuerySet<T> {
         self.where_raw(wrapped)
     }
 
+    /// Filter to rows whose **count** of related rows (via the
+    /// reverse-FK relation named `name`) satisfies `<count> <op> n` —
+    /// Eloquent `has($rel, $op, $n)` / Django
+    /// `.annotate(c=Count(<rel>)).filter(c__<op>=n)`. Issue #830
+    /// slice 3.
+    ///
+    /// Emits a correlated scalar-aggregate subquery in the WHERE
+    /// clause: `(SELECT COUNT(*) FROM <child> WHERE <child_fk> =
+    /// <outer>.<self_pk>) <op> n`. The subquery's `OuterRef` is rewritten
+    /// to the parent's table qualifier by the writer's scope stack, so
+    /// the SQL is portable across PG / MySQL / SQLite.
+    ///
+    /// `op` is one of the binary comparison operators
+    /// ([`Op::Eq`] / [`Op::Ne`] / [`Op::Lt`] / [`Op::Lte`] /
+    /// [`Op::Gt`] / [`Op::Gte`]); other operators emit a dialect error
+    /// at compile time. For the common "has at least one" / "has none"
+    /// cases prefer [`Self::where_has`] / [`Self::where_doesnt_have`],
+    /// which emit a cheaper `EXISTS` / `NOT EXISTS`.
+    ///
+    /// Unknown relation names surface as [`QueryError::UnknownField`]
+    /// at compile time, identically to [`Self::where_has`].
+    ///
+    /// ```ignore
+    /// // Eloquent: Author::has('books', '>', 3)->get();
+    /// let prolific = Author::objects()
+    ///     .where_has_count("books", Op::Gt, 3)
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    #[must_use]
+    pub fn where_has_count(self, name: &str, op: Op, n: i64) -> Self {
+        match T::reverse_relations().iter().find(|r| r.name == name) {
+            Some(rel) => {
+                let lhs = crate::core::subquery::reverse_has_count(rel);
+                self.where_raw(WhereExpr::ExprCompare {
+                    lhs,
+                    op,
+                    rhs: Expr::Literal(SqlValue::I64(n)),
+                })
+            }
+            None => self.with_pending_error(QueryError::UnknownField {
+                model: T::SCHEMA.name,
+                field: name.to_string(),
+            }),
+        }
+    }
+
     /// Eloquent `Builder::whereColumn($col1, $col2)` — emits
     /// `<col1> = <col2>`, comparing two columns instead of column
     /// vs literal. Equality is the overwhelming majority of uses;
@@ -2818,7 +2864,12 @@ fn validate_expr_columns_in_model(
         // in the outer queryset (the caller already validated it
         // there). `AliasedColumn` (issue #80) carries its own table
         // alias and is validated by the JOIN writer at emit time.
-        Expr::Subquery(_) | Expr::OuterRef(_) | Expr::AliasedColumn { .. } => Ok(()),
+        // `AggregateSubquery` (issue #830) validates against its own
+        // child model at construction; nothing resolves against this one.
+        Expr::Subquery(_)
+        | Expr::AggregateSubquery(_)
+        | Expr::OuterRef(_)
+        | Expr::AliasedColumn { .. } => Ok(()),
         // Window (issue #7) — partition_by + order_by + arg columns
         // reference the model. Walk them.
         Expr::Window(w) => {

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -1297,6 +1297,26 @@ fn write_expr(
             b.sql.push(')');
             Ok(())
         }
+        Expr::AggregateSubquery(inner) => {
+            // `(SELECT COUNT(*) FROM … WHERE … = OuterRef)` — a
+            // correlated scalar-aggregate subquery (issue #830 slice 3).
+            // `write_aggregate` pushes the child model's scope frame so
+            // the inner WHERE's `OuterRef` resolves to the enclosing
+            // parent query. The aggregate call sits in the subquery's own
+            // projection (emitted directly by `write_aggregate_inner`,
+            // not the gated `Expr::Aggregate` path), so reset the
+            // aggregate gate across the boundary exactly like
+            // `Expr::Subquery` does — the outer's HAVING permission must
+            // not leak in.
+            b.sql.push('(');
+            let prev = b.aggregate_allowed;
+            b.aggregate_allowed = false;
+            let r = write_aggregate(b, inner);
+            b.aggregate_allowed = prev;
+            r?;
+            b.sql.push(')');
+            Ok(())
+        }
         Expr::OuterRef(col) => {
             // Resolve against the immediate enclosing scope. The top
             // frame is the *current* query (the subquery emitting

--- a/crates/rustango/tests/queryset_where_has_count.rs
+++ b/crates/rustango/tests/queryset_where_has_count.rs
@@ -1,0 +1,121 @@
+//! Tri-dialect emission tests for `QuerySet::where_has_count(name, op, n)`
+//! — issue #830 slice 3 (count-comparator `has($rel, $op, $n)`).
+//!
+//! The method resolves the named reverse-FK relation via
+//! `Model::reverse_relations()` and embeds a correlated scalar-aggregate
+//! subquery `(SELECT COUNT(*) FROM <child> WHERE <child_fk> =
+//! <outer>.<pk>) <op> n` in the outer WHERE clause. The generated SQL is
+//! standard across PG / MySQL / SQLite apart from identifier quoting and
+//! the placeholder shape — these tests pin both.
+
+use rustango::core::{Model as _, Op};
+use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(
+    table = "whc_author",
+    reverse_has(name = "books", child = "Book", child_fk_column = "author_id",)
+)]
+#[allow(dead_code)]
+pub struct Author {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 40)]
+    name: String,
+}
+
+#[derive(Model)]
+#[rustango(table = "whc_book")]
+#[allow(dead_code)]
+pub struct Book {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 80)]
+    title: String,
+    author_id: i64,
+}
+
+fn compiled_sql<D: Dialect>(d: &D, op: Op, n: i64) -> String {
+    let q = Author::objects()
+        .where_has_count("books", op, n)
+        .compile()
+        .expect("compile where_has_count");
+    d.compile_select(&q).expect("emit SQL").sql
+}
+
+#[test]
+fn pg_emits_correlated_count_subquery_with_dollar_placeholder() {
+    let sql = compiled_sql(&Postgres, Op::Gt, 3);
+    // Correlated `COUNT(*)` over the child table.
+    assert!(sql.contains("COUNT(*)"), "missing COUNT(*): {sql}");
+    assert!(
+        sql.contains(r#"FROM "whc_book" WHERE "author_id" = "whc_author"."id""#),
+        "missing correlated child WHERE: {sql}"
+    );
+    // Comparator + bound count, dollar placeholder on PG.
+    assert!(sql.contains(") > $1"), "missing `) > $1`: {sql}");
+}
+
+#[test]
+fn sqlite_emits_question_mark_placeholder() {
+    let sql = compiled_sql(&Sqlite, Op::Gte, 1);
+    assert!(sql.contains("COUNT(*)"), "missing COUNT(*): {sql}");
+    assert!(
+        sql.contains(r#"FROM "whc_book" WHERE "author_id" = "whc_author"."id""#),
+        "missing correlated child WHERE: {sql}"
+    );
+    assert!(sql.contains(") >= ?"), "missing `) >= ?`: {sql}");
+}
+
+#[test]
+fn mysql_emits_backtick_quoting_and_question_mark() {
+    let sql = compiled_sql(&MySql, Op::Lt, 5);
+    assert!(sql.contains("COUNT(*)"), "missing COUNT(*): {sql}");
+    assert!(
+        sql.contains("FROM `whc_book` WHERE `author_id` = `whc_author`.`id`"),
+        "missing correlated child WHERE: {sql}"
+    );
+    assert!(sql.contains(") < ?"), "missing `) < ?`: {sql}");
+}
+
+#[test]
+fn each_comparison_operator_emits_its_symbol() {
+    for (op, sym) in [
+        (Op::Eq, " = "),
+        (Op::Ne, " <> "),
+        (Op::Lt, " < "),
+        (Op::Lte, " <= "),
+        (Op::Gt, " > "),
+        (Op::Gte, " >= "),
+    ] {
+        let sql = compiled_sql(&Postgres, op, 2);
+        assert!(
+            sql.contains(&format!("){sym}$1")),
+            "op {op:?} expected `){sym}$1` in: {sql}"
+        );
+    }
+}
+
+#[test]
+fn unknown_relation_errors_at_compile_time() {
+    let err = Author::objects()
+        .where_has_count("nope", Op::Gt, 1)
+        .compile()
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("nope"),
+        "expected UnknownField naming the bad relation, got: {msg}"
+    );
+}
+
+#[test]
+fn reverse_relations_metadata_drives_resolution() {
+    let rels = Author::reverse_relations();
+    assert_eq!(rels.len(), 1);
+    assert_eq!(rels[0].name, "books");
+    assert_eq!(rels[0].child_schema.table, "whc_book");
+    assert_eq!(rels[0].child_fk_column, "author_id");
+    assert_eq!(rels[0].self_pk_column, "id");
+}

--- a/crates/rustango/tests/queryset_where_has_count_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_where_has_count_sqlite_live.rs
@@ -1,0 +1,176 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for `QuerySet::where_has_count(name, op, n)` —
+//! issue #830 slice 3 (count-comparator `has($rel, $op, $n)`).
+//!
+//! Exercises the correlated `(SELECT COUNT(*) FROM <child> WHERE
+//! <child_fk> = <outer>.<pk>) <op> n` predicate end-to-end against a
+//! real engine: seed authors with differing book counts, then assert
+//! each comparison operator selects the right parents.
+
+use rustango::core::Op;
+use rustango::sql::{sqlx, Auto, FetcherPool as _, ForeignKey, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "whc_author",
+    reverse_has(name = "books", child = "Book", child_fk_column = "author_id",)
+)]
+#[allow(dead_code)]
+pub struct Author {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 40)]
+    pub name: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "whc_book")]
+#[allow(dead_code)]
+pub struct Book {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub title: String,
+    pub author_id: ForeignKey<Author, i64>,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE whc_author (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE TABLE whc_book (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            title     TEXT NOT NULL,
+            author_id INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+/// Insert an author with `book_count` books; return its PK.
+async fn seed_author(pool: &Pool, name: &str, book_count: usize) -> i64 {
+    let mut author = Author {
+        id: Auto::default(),
+        name: name.into(),
+    };
+    author.save_pool(pool).await.unwrap();
+    let id = *author.id.get().unwrap();
+    for i in 0..book_count {
+        let mut book = Book {
+            id: Auto::default(),
+            title: format!("{name}-{i}"),
+            author_id: ForeignKey::from(id),
+        };
+        book.save_pool(pool).await.unwrap();
+    }
+    id
+}
+
+/// Seed a fixed fixture: Zero=0 books, One=1, Three=3, Five=5.
+async fn seed(pool: &Pool) {
+    seed_author(pool, "Zero", 0).await;
+    seed_author(pool, "One", 1).await;
+    seed_author(pool, "Three", 3).await;
+    seed_author(pool, "Five", 5).await;
+}
+
+async fn names_for(pool: &Pool, op: Op, n: i64) -> Vec<String> {
+    let mut names: Vec<String> = Author::objects()
+        .where_has_count("books", op, n)
+        .fetch_pool(pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|a| a.name)
+        .collect();
+    names.sort();
+    names
+}
+
+#[tokio::test]
+async fn gt_selects_parents_above_threshold() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    // count > 3 → only Five.
+    assert_eq!(names_for(&pool, Op::Gt, 3).await, vec!["Five"]);
+}
+
+#[tokio::test]
+async fn gte_selects_at_and_above_threshold() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    // count >= 3 → Three, Five.
+    assert_eq!(names_for(&pool, Op::Gte, 3).await, vec!["Five", "Three"]);
+}
+
+#[tokio::test]
+async fn eq_selects_exact_count() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    assert_eq!(names_for(&pool, Op::Eq, 1).await, vec!["One"]);
+    // Zero books matches `= 0` — the correlated COUNT(*) returns 0, not NULL.
+    assert_eq!(names_for(&pool, Op::Eq, 0).await, vec!["Zero"]);
+}
+
+#[tokio::test]
+async fn lt_and_lte_select_below_threshold() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    // count < 3 → Zero, One.
+    assert_eq!(names_for(&pool, Op::Lt, 3).await, vec!["One", "Zero"]);
+    // count <= 1 → Zero, One.
+    assert_eq!(names_for(&pool, Op::Lte, 1).await, vec!["One", "Zero"]);
+}
+
+#[tokio::test]
+async fn ne_excludes_exact_count() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    // count != 0 → everyone with at least one book.
+    assert_eq!(
+        names_for(&pool, Op::Ne, 0).await,
+        vec!["Five", "One", "Three"]
+    );
+}
+
+#[tokio::test]
+async fn composes_with_other_filters() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    // count >= 1 AND name = "One" → just One. Confirms the correlated
+    // subquery AND-joins cleanly with a plain column predicate.
+    let rows = Author::objects()
+        .filter("name", "One")
+        .where_has_count("books", Op::Gte, 1)
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "One");
+}
+
+#[tokio::test]
+async fn unknown_relation_errors_at_compile_time() {
+    let pool = make_pool().await;
+    seed(&pool).await;
+    let err = Author::objects()
+        .where_has_count("nope", Op::Gt, 1)
+        .fetch_pool(&pool)
+        .await
+        .unwrap_err();
+    assert!(format!("{err}").contains("nope"));
+}


### PR DESCRIPTION
## What

Slice 3 of #830 — the count-comparator `has($rel, $op, $n)`.

`QuerySet::where_has_count(name, op, n)` filters parents by the **count** of related rows via a named reverse-FK relation:

```rust
// Eloquent: Author::has('books', '>', 3)->get();
// Django:   Author.objects.annotate(c=Count('books')).filter(c__gt=3)
let prolific = Author::objects()
    .where_has_count("books", Op::Gt, 3)
    .fetch_pool(&pool).await?;
```

Emits a correlated scalar-aggregate subquery in WHERE:
`(SELECT COUNT(*) FROM <child> WHERE <child_fk> = <outer>.<pk>) <op> n`.

## Unblocks the slice-3 IR blocker

The blocker logged on #830: `Expr::Subquery` only wrapped a `SelectQuery`, but a correlated count needs an aggregate projection (`COUNT(*)`). This adds a **sibling** `Expr::AggregateSubquery(Box<AggregateQuery>)` variant rather than overloading `Subquery` — narrower, more honest, and reusable by the later `withCount`/`withSum`/`withAvg`/`withMax`/`withMin` slices (an `AggregateQuery` carries any `AggregateExpr`).

## Changes

- **core/expr.rs** — new `Expr::AggregateSubquery` variant; correlates via the writer's scope stack exactly like `Subquery`.
- **core/query.rs** — manual `PartialEq for AggregateQuery` (ptr-eq the `&'static ModelSchema`, mirroring `SelectQuery`) so `Expr` keeps `#[derive(PartialEq)]`; new validate arm.
- **core/subquery.rs** — `reverse_has_count(rel)` builder.
- **sql/writers.rs** — `write_expr` arm emits the parenthesized aggregate subquery and resets the aggregate gate across the boundary.
- **query/mod.rs** — `QuerySet::where_has_count(name, op, n)`; unknown relation names → `UnknownField` at compile time, same shape as `where_has`.

## Tests

- `queryset_where_has_count.rs` — 6 unit tests pinning per-dialect SQL + placeholder shapes (PG `$1`, MySQL/SQLite `?`, backtick vs double-quote quoting) + every comparison operator + the unknown-relation error.
- `queryset_where_has_count_sqlite_live.rs` — 7 live tests: each of `Eq/Ne/Lt/Lte/Gt/Gte` against a 0/1/3/5-book fixture, composition with a plain column filter, and the compile-time error.

All 3166 lib tests pass; subquery + where_has slice-1/2 suites green; no new clippy warnings.

## Scope note

Closes the slice-3 line item on #830. Remaining #830 slices stay open: withCount/withSum/etc. annotations (needs typed-row annotation projection) and M2M/GFK relation resolution.