### PR TITLE
fix(macros): paginate/first_or_fail/first_or break on count/first field collision (un-darkens CI postgres_test/sqlite_live)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -4299,7 +4299,10 @@ fn inherent_impl_tokens(
             pub async fn first_or_fail(
                 pool: &#root::sql::Pool,
             ) -> ::core::result::Result<Self, #root::sql::ExecError> {
-                match Self::first(pool).await? {
+                // Route through the queryset rather than `Self::first`,
+                // which is suppressed on models with a field named
+                // `first` (field/shortcut collision guard).
+                match #root::query::QuerySet::<Self>::default().first(pool).await? {
                     ::core::option::Option::Some(_row) => ::core::result::Result::Ok(_row),
                     ::core::option::Option::None => ::core::result::Result::Err(
                         #root::sql::ExecError::Driver(
@@ -5371,7 +5374,17 @@ fn inherent_impl_tokens(
                 (::std::vec::Vec<Self>, i64),
                 #root::sql::ExecError,
             > {
-                let total = Self::count(pool).await?;
+                // Route through the queryset rather than `Self::count`:
+                // the `count` inherent method is suppressed on models
+                // that declare a field named `count` (field/shortcut
+                // collision guard), and `paginate` must still compile
+                // for those models.
+                let total = {
+                    use #root::sql::CounterPool as _;
+                    #root::query::QuerySet::<Self>::default()
+                        .count_pool(pool)
+                        .await?
+                };
                 let rows = Self::for_page(page, per_page, pool).await?;
                 ::core::result::Result::Ok((rows, total))
             }
@@ -6056,8 +6069,14 @@ fn inherent_impl_tokens(
             where
                 F: ::core::ops::FnOnce() -> Self,
             {
+                // Route through the queryset rather than `Self::first`,
+                // which is suppressed on models with a field named
+                // `first` (field/shortcut collision guard).
                 ::core::result::Result::Ok(
-                    Self::first(pool).await?.unwrap_or_else(fallback),
+                    #root::query::QuerySet::<Self>::default()
+                        .first(pool)
+                        .await?
+                        .unwrap_or_else(fallback),
                 )
             }
 

--- a/crates/rustango/tests/macro_field_shortcut_collision_sqlite_live.rs
+++ b/crates/rustango/tests/macro_field_shortcut_collision_sqlite_live.rs
@@ -1,0 +1,108 @@
+#![cfg(feature = "sqlite")]
+//! Regression: a model that declares fields colliding with the
+//! Eloquent-style inherent shortcuts (`count`, `first`, …) must still
+//! compile **and** keep the always-emitted helpers that internally
+//! relied on those shortcuts working.
+//!
+//! The 2026-06-07 field/shortcut collision guard suppresses the
+//! conflicting shortcut (e.g. `Model::count`) when a same-named field
+//! exists — but `Model::paginate` / `first_or_fail` / `first_or` were
+//! still emitting `Self::count(...)` / `Self::first(...)` calls, which
+//! then resolved to the per-field column const → E0618 "expected
+//! function, found <field>_col". This pins the fix: those helpers route
+//! through `QuerySet` directly, independent of the guarded methods.
+
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "fsc_widget")]
+#[rustango(app = "field_shortcut_collision")]
+#[allow(dead_code)]
+pub struct Widget {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    // `count` collides with the generated `Widget::count()` shortcut;
+    // `first` collides with `Widget::first()`. Both shortcuts are
+    // suppressed — the always-emitted helpers must not reference them.
+    pub count: i32,
+    pub first: i32,
+}
+
+async fn make_pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query(
+        "CREATE TABLE fsc_widget (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            count INTEGER NOT NULL,
+            first INTEGER NOT NULL
+        )",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+async fn insert(pool: &Pool, count: i32, first: i32) {
+    let mut w = Widget {
+        id: Auto::default(),
+        count,
+        first,
+    };
+    w.save_pool(pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn paginate_compiles_and_counts_with_count_field() {
+    let pool = make_pool().await;
+    insert(&pool, 1, 10).await;
+    insert(&pool, 2, 20).await;
+    insert(&pool, 3, 30).await;
+    // `paginate` internally counts the table — must route through the
+    // queryset, not the suppressed `Widget::count` method.
+    let (rows, total) = Widget::paginate(1, 2, &pool).await.unwrap();
+    assert_eq!(total, 3, "total row count");
+    assert_eq!(rows.len(), 2, "first page of 2");
+}
+
+#[tokio::test]
+async fn first_or_fail_compiles_with_first_field() {
+    let pool = make_pool().await;
+    insert(&pool, 7, 70).await;
+    let row = Widget::first_or_fail(&pool).await.unwrap();
+    assert_eq!(row.count, 7);
+}
+
+#[tokio::test]
+async fn first_or_fail_errors_on_empty_table() {
+    let pool = make_pool().await;
+    let err = Widget::first_or_fail(&pool).await;
+    assert!(err.is_err(), "empty table → RowNotFound");
+}
+
+#[tokio::test]
+async fn first_or_compiles_and_falls_back_with_first_field() {
+    let pool = make_pool().await;
+    // Empty table → fallback closure supplies the row.
+    let row = Widget::first_or(&pool, || Widget {
+        id: Auto::default(),
+        count: -1,
+        first: -1,
+    })
+    .await
+    .unwrap();
+    assert_eq!(row.count, -1, "fallback used on empty table");
+
+    insert(&pool, 5, 50).await;
+    let row = Widget::first_or(&pool, || Widget {
+        id: Auto::default(),
+        count: -1,
+        first: -1,
+    })
+    .await
+    .unwrap();
+    assert_eq!(row.count, 5, "existing row preferred over fallback");
+}


### PR DESCRIPTION
## Problem

The field/shortcut collision guard (added 2026-06-07) suppresses a generated inherent shortcut (`Model::count`, `Model::first`, …) when the model declares a field of the same name — otherwise the per-field column const (`pub const count: count_col`) and the shortcut method would clash.

But three **always-emitted** helpers still called the now-suppressed shortcuts directly:

| helper | call |
|---|---|
| `paginate` | `Self::count(pool)` |
| `first_or_fail` | `Self::first(pool)` |
| `first_or` | `Self::first(pool)` |

On a model with a field named `count` (or `first`), the call resolves to the **column const** instead of a function:

```
error[E0618]: expected function, found `count_col`
   |          ^^^^^ call expression requires function
   |          `Widget::count` defined here
   = note: this error originates in the derive macro `Model`
```

That fails the entire `#[derive(Model)]`, and because it's a **compile** failure it takes the whole test binary down. CI's `--all-features` jobs (`postgres_test` = `cargo test --workspace --all-features`, and `sqlite_live`) have been **silently red** on this — e.g. `tests/row_to_json_pool_sqlite_live.rs`, whose `Widget` model has a `count` field. (Recent slice PRs merged with both checks red.)

## Fix

Route the three helpers through `QuerySet::<Self>::default()` directly (`.count_pool(pool)` / `.first(pool)`) so they no longer depend on the guarded inherent methods existing — exactly what those shortcut methods do internally anyway.

## Test

`tests/macro_field_shortcut_collision_sqlite_live.rs` — a `Widget` declaring **both** `count` and `first` fields, exercising `paginate` (counts), `first_or_fail` (hit + empty), and `first_or` (fallback + existing). Pins the regression.

- `cargo test --workspace --all-features --no-run` compiles again ✅
- `tests/row_to_json_pool_sqlite_live.rs` is green ✅
- new regression test 4/4 ✅

Restores the `postgres_test` + `sqlite_live` gates.