### PR TITLE
feat(orm): ArrayField — Array<T> typed PostgreSQL array column (closes #341)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -10835,6 +10835,12 @@ enum DetectedKind {
     Json,
     Decimal,
     Binary,
+    /// `Array<String>` → PG `text[]` (#341).
+    ArrayText,
+    /// `Array<i32>` → PG `integer[]` (#341).
+    ArrayInt,
+    /// `Array<i64>` → PG `bigint[]` (#341).
+    ArrayBigInt,
 }
 
 impl DetectedKind {
@@ -10855,6 +10861,15 @@ impl DetectedKind {
             Self::Json => quote!(#root::core::FieldType::Json),
             Self::Decimal => quote!(#root::core::FieldType::Decimal),
             Self::Binary => quote!(#root::core::FieldType::Binary),
+            Self::ArrayText => {
+                quote!(#root::core::FieldType::Array(#root::core::ArrayElem::Text))
+            }
+            Self::ArrayInt => {
+                quote!(#root::core::FieldType::Array(#root::core::ArrayElem::Int))
+            }
+            Self::ArrayBigInt => {
+                quote!(#root::core::FieldType::Array(#root::core::ArrayElem::BigInt))
+            }
         }
     }
 
@@ -10898,6 +10913,12 @@ impl DetectedKind {
                 quote!(<#root::__rust_decimal::Decimal as ::std::default::Default>::default()),
             ),
             Self::Binary => (quote!(Binary), quote!(::std::vec::Vec::<u8>::new())),
+            // Arrays (#341) can never be a foreign-key primary key, so
+            // this arm is never reached at runtime — but the match must
+            // stay total. A bare empty `SqlValue::Array` is the dummy.
+            Self::ArrayText | Self::ArrayInt | Self::ArrayBigInt => {
+                (quote!(Array), quote!(::std::vec::Vec::new()))
+            }
         }
     }
 }
@@ -11055,8 +11076,38 @@ fn detect_type(ty: &syn::Type) -> syn::Result<DetectedType<'_>> {
             }
             return Err(syn::Error::new_spanned(
                 ty,
-                "unsupported `Vec<T>` field — only `Vec<u8>` (→ Binary) is supported",
+                "unsupported `Vec<T>` field — only `Vec<u8>` (→ Binary) is supported; \
+                 for a PostgreSQL array column use `Array<String>` / `Array<i32>` / `Array<i64>`",
             ));
+        }
+        // `Array<String>` / `Array<i32>` / `Array<i64>` → PG `text[]` /
+        // `integer[]` / `bigint[]` (Django `ArrayField`, #341).
+        "Array" => {
+            let (inner, _) = generic_pair(ty, &last.arguments, "Array")?;
+            let elem = match inner {
+                Type::Path(TypePath { path, qself: None }) => {
+                    path.segments.last().map(|s| s.ident.to_string())
+                }
+                _ => None,
+            };
+            let kind = match elem.as_deref() {
+                Some("String") => DetectedKind::ArrayText,
+                Some("i32") => DetectedKind::ArrayInt,
+                Some("i64") => DetectedKind::ArrayBigInt,
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        ty,
+                        "unsupported `Array<T>` element — only `Array<String>` (→ text[]), \
+                         `Array<i32>` (→ integer[]), and `Array<i64>` (→ bigint[]) are supported (#341)",
+                    ));
+                }
+            };
+            return Ok(DetectedType {
+                kind,
+                nullable: false,
+                auto: false,
+                fk_inner: None,
+            });
         }
         other => {
             return Err(syn::Error::new_spanned(

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -119,6 +119,8 @@ pub(crate) fn render_value_for_input_json(row: &serde_json::Value, field: &Field
         // Decimal round-trips as a string via `row_to_json` to
         // preserve precision; Binary likewise (hex-encoded).
         FieldType::Decimal | FieldType::Binary => v.as_str().unwrap_or("").to_owned(),
+        // #341 — PG array: render the JSON form compactly.
+        FieldType::Array(_) => v.to_string(),
     }
 }
 
@@ -329,6 +331,11 @@ fn render_input_default(field: &FieldSchema, value: &str, pk_locked: bool) -> St
         FieldType::Binary => format!(
             r#"<input type="text" name="{name}" id="{name}" value="{val}" pattern="[0-9a-f]*" inputmode="latin"{readonly} style="font-family:monospace">"#
         ),
+        // #341 — PG array: comma-separated text input (the form parser
+        // splits on `,`). Placeholder hints the expected shape.
+        FieldType::Array(_) => format!(
+            r#"<input type="text" name="{name}" id="{name}" value="{val}" placeholder="comma, separated, values"{required}{readonly}>"#
+        ),
     }
 }
 
@@ -498,6 +505,10 @@ pub(crate) fn render_value_json(row: &serde_json::Value, field: &FieldSchema) ->
                 .map(|s| escape(&s))
                 .unwrap_or_default()
         }
+        // #341 — PG array: compact JSON form in the list cell.
+        FieldType::Array(_) => serde_json::to_string(v)
+            .map(|s| escape(&s))
+            .unwrap_or_default(),
     }
 }
 
@@ -568,6 +579,8 @@ pub(crate) fn read_joined_value_as_html_json(
             }
         }),
         FieldType::Json => None,
+        // #341 — arrays aren't a meaningful select_related join target.
+        FieldType::Array(_) => None,
     };
     text.map(|s| escape(&s))
 }

--- a/crates/rustango/src/core/field_type.rs
+++ b/crates/rustango/src/core/field_type.rs
@@ -42,6 +42,40 @@ pub enum FieldType {
     /// `TIME`, MySQL `TIME(6)`, SQLite `TIME` (text affinity, `HH:MM:SS`
     /// shape). Rust type: `chrono::NaiveTime`.
     Time,
+    /// Native PostgreSQL array — Django's `ArrayField` (#341). Rust type:
+    /// [`crate::sql::Array<T>`]. The element kind selects the column type
+    /// (`text[]` / `integer[]` / `bigint[]`). **PG-only by language
+    /// semantics**: MySQL / SQLite have no array column type, so the DDL
+    /// writer degrades to `TEXT` and the bind / decode paths error there.
+    Array(ArrayElem),
+}
+
+/// Element type of a [`FieldType::Array`] column (#341). Selects the
+/// PostgreSQL array column type emitted by the migration writer. Kept a
+/// small `Copy` enum so [`FieldType`] stays `Copy`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ArrayElem {
+    /// `text[]` — element type `String` ([`crate::sql::Array<String>`]).
+    /// Django `ArrayField(CharField/TextField)`.
+    Text,
+    /// `integer[]` — element type `i32` ([`crate::sql::Array<i32>`]).
+    /// Django `ArrayField(IntegerField)`.
+    Int,
+    /// `bigint[]` — element type `i64` ([`crate::sql::Array<i64>`]).
+    /// Django `ArrayField(BigIntegerField)`.
+    BigInt,
+}
+
+impl ArrayElem {
+    /// Scalar SQL element type (the part before `[]`). Postgres spelling.
+    #[must_use]
+    pub const fn pg_element_type(self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Int => "integer",
+            Self::BigInt => "bigint",
+        }
+    }
 }
 
 impl FieldType {
@@ -63,6 +97,9 @@ impl FieldType {
             Self::Decimal => "rust_decimal::Decimal",
             Self::Binary => "Vec<u8>",
             Self::Time => "NaiveTime",
+            Self::Array(ArrayElem::Text) => "Array<String>",
+            Self::Array(ArrayElem::Int) => "Array<i32>",
+            Self::Array(ArrayElem::BigInt) => "Array<i64>",
         }
     }
 }

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -23,7 +23,7 @@ pub use case::{case, value, CaseBuilder};
 pub use column::{Column, TypedAssignment, TypedExpr, TypedFieldList, TypedFilter};
 pub use error::QueryError;
 pub use expr::{BinOp, CaseBranch, Expr, JsonPathStep, ScalarFn, F};
-pub use field_type::FieldType;
+pub use field_type::{ArrayElem, FieldType};
 pub use query::{
     AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ColumnFilter,
     CompoundBranch, ConflictClause, CountQuery, DeleteQuery, DistinctMode, Filter, InsertQuery,

--- a/crates/rustango/src/forms/mod.rs
+++ b/crates/rustango/src/forms/mod.rs
@@ -238,7 +238,9 @@ pub fn parse_pk_string(field: &FieldSchema, raw: &str) -> Result<SqlValue, FormE
         | FieldType::Time
         | FieldType::Json
         | FieldType::Decimal
-        | FieldType::Binary => Err(FormError::UnsupportedPk {
+        | FieldType::Binary
+        // #341 — an array can't be a primary key.
+        | FieldType::Array(_) => Err(FormError::UnsupportedPk {
             field: field.name.to_owned(),
             ty: field.ty.as_str(),
         }),
@@ -375,6 +377,35 @@ pub fn parse_form_value(field: &FieldSchema, raw: Option<&str>) -> Result<SqlVal
             .or_else(|_| chrono::NaiveTime::parse_from_str(raw, "%H:%M"))
             .map(SqlValue::Time)
             .map_err(|e| make_parse_err("Time", &e)),
+        // #341 — PG array column from a form field: comma-separated
+        // input (`a, b, c`). Empty / whitespace-only input → empty array.
+        FieldType::Array(elem) => {
+            let parts: Vec<&str> = if raw.trim().is_empty() {
+                Vec::new()
+            } else {
+                raw.split(',').map(str::trim).collect()
+            };
+            match elem {
+                crate::core::ArrayElem::Text => Ok(SqlValue::Array(
+                    parts
+                        .into_iter()
+                        .map(|s| SqlValue::String(s.to_owned()))
+                        .collect(),
+                )),
+                crate::core::ArrayElem::Int => parts
+                    .into_iter()
+                    .map(|s| s.parse::<i32>().map(SqlValue::I32))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map(SqlValue::Array)
+                    .map_err(|e| make_parse_err("array<i32>", &e)),
+                crate::core::ArrayElem::BigInt => parts
+                    .into_iter()
+                    .map(|s| s.parse::<i64>().map(SqlValue::I64))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map(SqlValue::Array)
+                    .map_err(|e| make_parse_err("array<i64>", &e)),
+            }
+        }
     }
 }
 

--- a/crates/rustango/src/migrate/diff.rs
+++ b/crates/rustango/src/migrate/diff.rs
@@ -1197,6 +1197,10 @@ fn pg_type_for_ty_name(ty: &str) -> String {
         "json" => "JSONB".into(),
         "decimal" => "NUMERIC".into(),
         "binary" => "BYTEA".into(),
+        // #341 — PG array element kinds.
+        "array_text" => "text[]".into(),
+        "array_int" => "integer[]".into(),
+        "array_bigint" => "bigint[]".into(),
         other => other.to_uppercase(),
     }
 }
@@ -1420,6 +1424,11 @@ fn sql_type_with_dialect(f: &FieldSnapshot, dialect: &dyn crate::sql::Dialect) -
         "json" => Some(FieldType::Json),
         "decimal" => Some(FieldType::Decimal),
         "binary" => Some(FieldType::Binary),
+        // #341 — PG array element kinds; route through `column_type`
+        // (→ `text[]` / `integer[]` / `bigint[]` on PG).
+        "array_text" => Some(FieldType::Array(crate::core::ArrayElem::Text)),
+        "array_int" => Some(FieldType::Array(crate::core::ArrayElem::Int)),
+        "array_bigint" => Some(FieldType::Array(crate::core::ArrayElem::BigInt)),
         _ => None,
     };
     // v0.13.2: `auto = true` historically meant "PK SERIAL/BIGSERIAL"

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -2957,6 +2957,31 @@ fn json_to_sql_value(
                 .collect();
             Ok(SqlValue::Binary(bytes))
         }
+        // #341 — PG array column from a fixture JSON array.
+        FieldType::Array(elem) => {
+            let arr = v
+                .as_array()
+                .ok_or_else(|| format!("expected JSON array for Array column, got {v}"))?;
+            let items = arr
+                .iter()
+                .map(|el| match elem {
+                    crate::core::ArrayElem::Text => el
+                        .as_str()
+                        .map(|s| SqlValue::String(s.to_owned()))
+                        .ok_or_else(|| format!("expected string array element, got {el}")),
+                    crate::core::ArrayElem::Int => el
+                        .as_i64()
+                        .and_then(|n| i32::try_from(n).ok())
+                        .map(SqlValue::I32)
+                        .ok_or_else(|| format!("expected i32 array element, got {el}")),
+                    crate::core::ArrayElem::BigInt => el
+                        .as_i64()
+                        .map(SqlValue::I64)
+                        .ok_or_else(|| format!("expected i64 array element, got {el}")),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(SqlValue::Array(items))
+        }
     }
 }
 

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -516,6 +516,10 @@ pub(crate) fn field_type_name(ty: FieldType) -> &'static str {
         FieldType::Json => "json",
         FieldType::Decimal => "decimal",
         FieldType::Binary => "binary",
+        // #341 — stable snapshot names for PG array element kinds.
+        FieldType::Array(crate::core::ArrayElem::Text) => "array_text",
+        FieldType::Array(crate::core::ArrayElem::Int) => "array_int",
+        FieldType::Array(crate::core::ArrayElem::BigInt) => "array_bigint",
     }
 }
 

--- a/crates/rustango/src/sql/array.rs
+++ b/crates/rustango/src/sql/array.rs
@@ -1,0 +1,259 @@
+//! `Array<T>` — typed PostgreSQL array column wrapper (Django's
+//! `ArrayField`, issue #341).
+//!
+//! Declare a native PG array column on a model:
+//!
+//! ```ignore
+//! #[derive(Model)]
+//! #[rustango(table = "post")]
+//! struct Post {
+//!     #[rustango(primary_key)]
+//!     id: Auto<i64>,
+//!     #[rustango(max_length = 200)]
+//!     title: String,
+//!     // → DDL `tags text[]`; round-trips as a Rust `Vec<String>`.
+//!     tags: Array<String>,
+//! }
+//! ```
+//!
+//! The element type drives the column type emitted by the migration
+//! writer: `Array<String>` → `text[]`, `Array<i32>` → `integer[]`,
+//! `Array<i64>` → `bigint[]`. Pairs with the already-shipped value-layer
+//! array operators ([`crate::core::Op::ArrayContains`] / `ArrayContainedBy`
+//! / `ArrayOverlap`, PG `@>` / `<@` / `&&`).
+//!
+//! ## PostgreSQL only, by language semantics
+//!
+//! Native typed arrays are a Postgres feature; MySQL and SQLite have no
+//! equivalent column type. Like trigram / full-text / pgvector, `Array<T>`
+//! is **PG-only by language semantics**: the migration writer emits a
+//! degraded `TEXT` column on MySQL / SQLite, and the [`sqlx::Decode`] /
+//! `SqlValue` bind paths on those backends return / raise a clear error
+//! rather than silently mis-storing. Use `Array<T>` only on a Postgres
+//! deployment. The type still *compiles* under every backend (the
+//! per-backend [`sqlx::Type`] / [`sqlx::Decode`] impls below are total)
+//! so the `sqlite,tenancy` litmus build keeps passing.
+//!
+//! ## Why a newtype rather than a bare `Vec<T>`
+//!
+//! `#[derive(Model)]` emits one shared `FromRow` body reused across the
+//! Postgres / MySQL / SQLite decoders (`Row::try_get::<FieldTy>(…)`).
+//! `Vec<String>` implements `sqlx::Decode` only for Postgres, so a bare
+//! `Vec<String>` field would fail to compile the SQLite / MySQL decoder
+//! arms. `Array<T>` carries total `Decode` / `Type` impls for all three
+//! backends (real on PG, erroring stubs elsewhere), so the shared
+//! `FromRow` body compiles everywhere. Same pattern as [`crate::sql::Auto`].
+
+use std::ops::{Deref, DerefMut};
+
+/// Typed PostgreSQL array column — see the [module docs](self).
+///
+/// Transparent newtype over `Vec<T>`: `Deref`s to the inner vector,
+/// converts from/into `Vec<T>`, and (de)serializes as a plain JSON
+/// array. The `Model` derive maps `Array<String>` / `Array<i32>` /
+/// `Array<i64>` fields to `text[]` / `integer[]` / `bigint[]` DDL.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct Array<T>(pub Vec<T>);
+
+impl<T> Array<T> {
+    /// Wrap a `Vec<T>` as an array column value.
+    #[must_use]
+    pub fn new(items: Vec<T>) -> Self {
+        Self(items)
+    }
+
+    /// Consume the wrapper, returning the inner `Vec<T>`.
+    #[must_use]
+    pub fn into_inner(self) -> Vec<T> {
+        self.0
+    }
+}
+
+impl<T> Deref for Array<T> {
+    type Target = Vec<T>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Array<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> From<Vec<T>> for Array<T> {
+    fn from(v: Vec<T>) -> Self {
+        Self(v)
+    }
+}
+
+impl<T> From<Array<T>> for Vec<T> {
+    fn from(a: Array<T>) -> Self {
+        a.0
+    }
+}
+
+impl<T> FromIterator<T> for Array<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+// ---- serde: behave exactly like the inner Vec (plain JSON array) ----
+
+impl<T: serde::Serialize> serde::Serialize for Array<T> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T> serde::Deserialize<'de> for Array<T>
+where
+    T: serde::Deserialize<'de>,
+{
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Vec::<T>::deserialize(deserializer).map(Self)
+    }
+}
+
+// ---- `Array<T>` → `SqlValue` (INSERT / UPDATE bind, via SqlValue::Array) ----
+//
+// The Model derive binds field values through `Into<SqlValue>`, so each
+// supported element type needs a concrete conversion into the
+// single-parameter `SqlValue::Array` (which the PG bind path lowers to a
+// typed array; the MySQL / SQLite bind paths reject it — PG-only).
+
+impl From<Array<String>> for crate::core::SqlValue {
+    fn from(a: Array<String>) -> Self {
+        crate::core::SqlValue::Array(a.0.into_iter().map(crate::core::SqlValue::String).collect())
+    }
+}
+
+impl From<Array<i32>> for crate::core::SqlValue {
+    fn from(a: Array<i32>) -> Self {
+        crate::core::SqlValue::Array(a.0.into_iter().map(crate::core::SqlValue::I32).collect())
+    }
+}
+
+impl From<Array<i64>> for crate::core::SqlValue {
+    fn from(a: Array<i64>) -> Self {
+        crate::core::SqlValue::Array(a.0.into_iter().map(crate::core::SqlValue::I64).collect())
+    }
+}
+
+// ---- sqlx Type + Decode (FromRow read path) ----
+//
+// Postgres: delegate to `Vec<T>` (the real, functional array decode).
+// MySQL / SQLite: total stubs so the shared `FromRow` body compiles —
+// `Type` borrows a placeholder type-info, `Decode` errors at runtime.
+// Encode is intentionally NOT implemented: the bind path goes through
+// `SqlValue::Array`, never the raw `Array<T>`.
+
+#[cfg(feature = "postgres")]
+impl<'r, T> sqlx::Decode<'r, sqlx::Postgres> for Array<T>
+where
+    Vec<T>: sqlx::Decode<'r, sqlx::Postgres>,
+{
+    fn decode(
+        value: <sqlx::Postgres as sqlx::Database>::ValueRef<'r>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        Ok(Self(<Vec<T> as sqlx::Decode<'r, sqlx::Postgres>>::decode(
+            value,
+        )?))
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<T> sqlx::Type<sqlx::Postgres> for Array<T>
+where
+    Vec<T>: sqlx::Type<sqlx::Postgres>,
+{
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        <Vec<T> as sqlx::Type<sqlx::Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+        <Vec<T> as sqlx::Type<sqlx::Postgres>>::compatible(ty)
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl<'r, T> sqlx::Decode<'r, sqlx::MySql> for Array<T> {
+    fn decode(
+        _value: <sqlx::MySql as sqlx::Database>::ValueRef<'r>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        Err("`Array<T>` columns are PostgreSQL-only; cannot decode on MySQL (issue #341)".into())
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl<T> sqlx::Type<sqlx::MySql> for Array<T> {
+    fn type_info() -> sqlx::mysql::MySqlTypeInfo {
+        // Placeholder so the trait is total; the column is never actually
+        // a MySQL array (decode errors before any value is produced).
+        <Vec<u8> as sqlx::Type<sqlx::MySql>>::type_info()
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'r, T> sqlx::Decode<'r, sqlx::Sqlite> for Array<T> {
+    fn decode(
+        _value: <sqlx::Sqlite as sqlx::Database>::ValueRef<'r>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        Err("`Array<T>` columns are PostgreSQL-only; cannot decode on SQLite (issue #341)".into())
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<T> sqlx::Type<sqlx::Sqlite> for Array<T> {
+    fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
+        <Vec<u8> as sqlx::Type<sqlx::Sqlite>>::type_info()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deref_and_from_vec() {
+        let a: Array<String> = vec!["x".to_owned(), "y".to_owned()].into();
+        assert_eq!(a.len(), 2);
+        assert_eq!(a[0], "x");
+        assert_eq!(a.into_inner(), vec!["x".to_owned(), "y".to_owned()]);
+    }
+
+    #[test]
+    fn serde_round_trips_as_plain_array() {
+        let a: Array<i32> = Array::new(vec![1, 2, 3]);
+        let json = serde_json::to_string(&a).unwrap();
+        assert_eq!(json, "[1,2,3]");
+        let back: Array<i32> = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, a);
+    }
+
+    #[test]
+    fn into_sqlvalue_array_string() {
+        let v: crate::core::SqlValue = Array(vec!["a".to_owned(), "b".to_owned()]).into();
+        match v {
+            crate::core::SqlValue::Array(items) => {
+                assert_eq!(items.len(), 2);
+                assert!(matches!(items[0], crate::core::SqlValue::String(_)));
+            }
+            _ => panic!("expected SqlValue::Array"),
+        }
+    }
+
+    #[test]
+    fn into_sqlvalue_array_ints() {
+        let v: crate::core::SqlValue = Array(vec![1i32, 2, 3]).into();
+        match v {
+            crate::core::SqlValue::Array(items) => {
+                assert_eq!(items.len(), 3);
+                assert!(matches!(items[0], crate::core::SqlValue::I32(1)));
+            }
+            _ => panic!("expected SqlValue::Array"),
+        }
+    }
+}

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -352,6 +352,10 @@ pub trait Dialect {
             FieldType::Decimal => "NUMERIC",
             FieldType::Binary => "BYTEA",
             FieldType::Time => "TIME",
+            // PG array CAST targets (#341).
+            FieldType::Array(crate::core::ArrayElem::Text) => "text[]",
+            FieldType::Array(crate::core::ArrayElem::Int) => "integer[]",
+            FieldType::Array(crate::core::ArrayElem::BigInt) => "bigint[]",
         })
     }
 
@@ -386,6 +390,10 @@ pub trait Dialect {
             FieldType::Json => "JSONB".into(),
             FieldType::Decimal => "NUMERIC".into(),
             FieldType::Binary => "BYTEA".into(),
+            // Native PG array column — `text[]` / `integer[]` /
+            // `bigint[]` (#341). `max_length` is ignored (arrays carry
+            // no length cap at the type level).
+            FieldType::Array(elem) => format!("{}[]", elem.pg_element_type()),
         }
     }
 

--- a/crates/rustango/src/sql/executor/row_to_json.rs
+++ b/crates/rustango/src/sql/executor/row_to_json.rs
@@ -133,6 +133,12 @@ where
                 .try_get::<chrono::NaiveTime, _>(field.column)
                 .map(|t| json!(t.to_string()))
                 .unwrap_or(Value::Null),
+            // #341 — PG array columns. This cross-backend JSON path is
+            // generic over the row type and has no `Vec<T>: Decode`
+            // bound, so it can't decode the array here; emit null.
+            // (Typed `#[derive(Model)]` fetch decodes arrays via
+            // `Array<T>`; this affects only the dynamic admin/JSON view.)
+            FieldType::Array(_) => Value::Null,
         };
         map.insert(field.name.to_owned(), value);
     }
@@ -268,6 +274,8 @@ pub fn row_to_json_sqlite(
                         .map(|s| json!(s))
                         .unwrap_or(Value::Null)
                 }),
+            // #341 — arrays are PG-only; never present on SQLite.
+            FieldType::Array(_) => Value::Null,
         };
         map.insert(field.name.to_owned(), value);
     }

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -6,6 +6,7 @@
 //! ships Postgres only; `SQLite` and `MySQL` slot in as additional
 //! `Dialect` arms in v0.2+.
 
+mod array;
 mod auto;
 mod backend;
 mod compiled;
@@ -24,6 +25,7 @@ mod postgres;
 mod sqlite;
 mod writers;
 
+pub use array::Array;
 pub use auto::Auto;
 pub use backend::{
     apply_auto_pk, try_get_returning, try_get_returning_my, try_get_returning_sqlite,

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -142,8 +142,9 @@ impl Dialect for MySql {
             // MySQL has no `CAST AS JSON` form — `JSON_EXTRACT` /
             // string parsing are the substitutes. UUID has no CAST
             // target either (it's CHAR(36) in DDL but the user would
-            // cast to CHAR in expression form).
-            FieldType::Uuid | FieldType::Json => return None,
+            // cast to CHAR in expression form). Arrays (#341) are
+            // PG-only by language — no MySQL CAST target.
+            FieldType::Uuid | FieldType::Json | FieldType::Array(_) => return None,
         })
     }
 
@@ -189,6 +190,10 @@ impl Dialect for MySql {
             // `TIME(6)` for microsecond precision — matches the
             // `DATETIME(6)` choice elsewhere in this writer.
             FieldType::Time => "TIME(6)".into(),
+            // MySQL has no native array column type — `Array<T>` (#341)
+            // is PG-only by language semantics. Degrade to `TEXT` so the
+            // DDL stays emittable; the bind / decode paths error on MySQL.
+            FieldType::Array(_) => "TEXT".into(),
         }
     }
 

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -184,6 +184,9 @@ impl Dialect for Sqlite {
             | FieldType::Json => "TEXT",
             FieldType::Decimal => "NUMERIC",
             FieldType::Binary => "BLOB",
+            // SQLite has no array type — `Array<T>` (#341) is PG-only.
+            // Degrade the CAST target to TEXT affinity.
+            FieldType::Array(_) => "TEXT",
         })
     }
 
@@ -206,6 +209,10 @@ impl Dialect for Sqlite {
             FieldType::Decimal => "NUMERIC".into(),
             // `BLOB` storage class — round-trips `Vec<u8>` directly.
             FieldType::Binary => "BLOB".into(),
+            // SQLite has no native array type — `Array<T>` (#341) is
+            // PG-only by language semantics. Degrade to `TEXT`; the
+            // bind / decode paths error on SQLite.
+            FieldType::Array(_) => "TEXT".into(),
         }
     }
 

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -1513,6 +1513,8 @@ fn field_type_label(ty: crate::core::FieldType) -> &'static str {
         T::Json => "json",
         T::Decimal => "decimal",
         T::Binary => "binary",
+        // #341 — PG array columns.
+        T::Array(_) => "array",
     }
 }
 

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -263,6 +263,16 @@ fn field_type_to_schema(t: FieldType) -> Schema {
         FieldType::Json => Schema::default(), // free-form
         FieldType::Decimal => Schema::decimal(),
         FieldType::Binary => Schema::binary(),
+        // #341 — PG array column: `type: array` with element-typed items.
+        FieldType::Array(elem) => {
+            use crate::core::ArrayElem;
+            let items = match elem {
+                ArrayElem::Text => Schema::string(),
+                ArrayElem::Int => Schema::int32(),
+                ArrayElem::BigInt => Schema::integer(),
+            };
+            Schema::array_of(items)
+        }
     }
 }
 

--- a/crates/rustango/tests/array_field.rs
+++ b/crates/rustango/tests/array_field.rs
@@ -1,0 +1,99 @@
+//! Unit coverage for `Array<T>` PostgreSQL array columns — Django
+//! `ArrayField` (#341). No database required: asserts the derived
+//! schema's `FieldType::Array` mapping and the per-dialect column-type
+//! emission (`text[]` / `integer[]` / `bigint[]` on PG; degraded `TEXT`
+//! on MySQL / SQLite, where arrays are unsupported by language).
+
+use rustango::core::{ArrayElem, FieldType, Model as _};
+use rustango::sql::{Array, Dialect, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "arr_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 200)]
+    title: String,
+    tags: Array<String>,
+    scores: Array<i32>,
+    big_scores: Array<i64>,
+}
+
+fn field(name: &str) -> &'static rustango::core::FieldSchema {
+    Post::SCHEMA
+        .fields
+        .iter()
+        .find(|f| f.name == name)
+        .unwrap_or_else(|| panic!("no field {name}"))
+}
+
+#[test]
+fn derive_maps_array_fields_to_array_field_type() {
+    assert_eq!(field("tags").ty, FieldType::Array(ArrayElem::Text));
+    assert_eq!(field("scores").ty, FieldType::Array(ArrayElem::Int));
+    assert_eq!(field("big_scores").ty, FieldType::Array(ArrayElem::BigInt));
+    // Sanity: a plain String field is unaffected.
+    assert_eq!(field("title").ty, FieldType::String);
+}
+
+#[test]
+fn postgres_column_types_are_native_arrays() {
+    assert_eq!(Postgres.column_type(field("tags").ty, None), "text[]");
+    assert_eq!(Postgres.column_type(field("scores").ty, None), "integer[]");
+    assert_eq!(
+        Postgres.column_type(field("big_scores").ty, None),
+        "bigint[]"
+    );
+}
+
+#[test]
+fn postgres_cast_types_are_native_arrays() {
+    assert_eq!(
+        Postgres.cast_type(FieldType::Array(ArrayElem::Text)),
+        Some("text[]")
+    );
+    assert_eq!(
+        Postgres.cast_type(FieldType::Array(ArrayElem::Int)),
+        Some("integer[]")
+    );
+    assert_eq!(
+        Postgres.cast_type(FieldType::Array(ArrayElem::BigInt)),
+        Some("bigint[]")
+    );
+}
+
+#[test]
+fn non_pg_dialects_degrade_to_text() {
+    // Arrays are PG-only by language semantics — MySQL / SQLite have no
+    // native array column type, so the DDL writer emits TEXT (the bind /
+    // decode paths error on those backends).
+    for ty in [
+        FieldType::Array(ArrayElem::Text),
+        FieldType::Array(ArrayElem::Int),
+        FieldType::Array(ArrayElem::BigInt),
+    ] {
+        assert_eq!(MySql.column_type(ty, None), "TEXT");
+        assert_eq!(Sqlite.column_type(ty, None), "TEXT");
+        // No native CAST target on MySQL.
+        assert_eq!(MySql.cast_type(ty), None);
+    }
+}
+
+#[test]
+fn array_element_type_tokens() {
+    assert_eq!(ArrayElem::Text.pg_element_type(), "text");
+    assert_eq!(ArrayElem::Int.pg_element_type(), "integer");
+    assert_eq!(ArrayElem::BigInt.pg_element_type(), "bigint");
+}
+
+#[test]
+fn array_into_sqlvalue_is_single_param_array() {
+    use rustango::core::SqlValue;
+    let v: SqlValue = Array(vec!["rust".to_owned(), "orm".to_owned()]).into();
+    match v {
+        SqlValue::Array(items) => assert_eq!(items.len(), 2),
+        other => panic!("expected SqlValue::Array, got {other:?}"),
+    }
+}

--- a/crates/rustango/tests/array_field_pg_live.rs
+++ b/crates/rustango/tests/array_field_pg_live.rs
@@ -1,0 +1,142 @@
+#![cfg(feature = "postgres")]
+//! Live PostgreSQL round-trip for `Array<T>` columns — Django
+//! `ArrayField` (#341). Proves the typed field wrapper writes a native
+//! PG array (`text[]` / `integer[]`) on INSERT and decodes it back into
+//! `Array<T>` on SELECT, and that the `@>` containment operator filters
+//! on it.
+//!
+//! Skips silently when `DATABASE_URL` is unset (runs in CI's
+//! `postgres_test` job).
+
+use std::sync::OnceLock;
+
+use rustango::core::Column as _;
+use rustango::sql::{sqlx, Array, Auto, FetcherPool as _, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "arr_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub tags: Array<String>,
+    pub scores: Array<i32>,
+}
+
+async fn pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pg = sqlx::PgPool::connect(&url).await.ok()?;
+    Some(pg.into())
+}
+
+async fn fresh(pool: &Pool) {
+    let pg = pool.as_postgres().expect("postgres pool");
+    sqlx::query(r#"DROP TABLE IF EXISTS "arr_post" CASCADE"#)
+        .execute(pg)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "arr_post" (
+            "id"     BIGSERIAL PRIMARY KEY,
+            "title"  VARCHAR(200) NOT NULL,
+            "tags"   text[] NOT NULL DEFAULT '{}',
+            "scores" integer[] NOT NULL DEFAULT '{}'
+        )"#,
+    )
+    .execute(pg)
+    .await
+    .unwrap();
+}
+
+async fn insert(pool: &Pool, title: &str, tags: &[&str], scores: &[i32]) -> i64 {
+    let mut p = Post {
+        id: Auto::default(),
+        title: title.to_owned(),
+        tags: Array(tags.iter().map(|s| (*s).to_owned()).collect()),
+        scores: Array(scores.to_vec()),
+    };
+    p.save_pool(pool).await.unwrap();
+    *p.id.get().unwrap()
+}
+
+#[tokio::test]
+async fn array_columns_round_trip() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let id = insert(&pool, "hello", &["rust", "orm", "pg"], &[10, 20, 30]).await;
+
+    let row = Post::objects()
+        .filter("id", id)
+        .first(&pool)
+        .await
+        .unwrap()
+        .expect("row present");
+    assert_eq!(row.title, "hello");
+    assert_eq!(&*row.tags, &["rust", "orm", "pg"]);
+    assert_eq!(&*row.scores, &[10, 20, 30]);
+}
+
+#[tokio::test]
+async fn empty_array_round_trips() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let id = insert(&pool, "empty", &[], &[]).await;
+    let row = Post::objects()
+        .filter("id", id)
+        .first(&pool)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(row.tags.is_empty());
+    assert!(row.scores.is_empty());
+}
+
+#[tokio::test]
+async fn array_contains_operator_filters() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    insert(&pool, "rusty", &["rust", "orm"], &[1]).await;
+    insert(&pool, "pythonic", &["python", "orm"], &[2]).await;
+
+    // `tags @> ARRAY['rust']` — only the first post.
+    let mut titles: Vec<String> = Post::objects()
+        .where_(Post::tags.array_contains(["rust".to_owned()]))
+        .fetch_pool(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.title)
+        .collect();
+    titles.sort();
+    assert_eq!(titles, vec!["rusty"]);
+
+    // `tags @> ARRAY['orm']` — both posts.
+    let n = Post::objects()
+        .where_(Post::tags.array_contains(["orm".to_owned()]))
+        .fetch_pool(&pool)
+        .await
+        .unwrap()
+        .len();
+    assert_eq!(n, 2);
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -23,7 +23,7 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 1. ORM — models / fields / Meta | 22 | 1 | 1 | 0 |
 | 2. QuerySet API | 38 | 1 | 1 | 0 |
 | 3. Field types & options | 32 | 0 | 2 | 1 |
-| 4. Postgres-specific fields | 2 | 1 | 2 | 0 |
+| 4. Postgres-specific fields | 3 | 0 | 2 | 0 |
 | 5. Migrations | 15 | 0 | 0 | 1 |
 | 6. Admin (ModelAdmin) | 35 | 1 | 0 | 1 |
 | 7. Forms / Formsets | 14 | 1 | 0 | 0 |
@@ -191,7 +191,7 @@ Summary: **32 SHIPPED / 0 PARTIAL / 2 MISSING / 1 N/A** in this section. Gaps cl
 | Django field | Doc | Status | rustango | Notes |
 |---|---|---|---|---|
 | `JSONField` | (now built-in) | SHIPPED | See section 3 | |
-| `ArrayField` | [ArrayField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#arrayfield) | PARTIAL | `SqlValue::Array` + `Op::ArrayContains/ContainedBy/Overlap` operators emitted on PG; no native typed field wrapper in models (#341) | Future-backlog item. |
+| `ArrayField` | [ArrayField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#arrayfield) | SHIPPED | `Array<T>` typed field wrapper (#341) — `Array<String>`/`Array<i32>`/`Array<i64>` map to `text[]`/`integer[]`/`bigint[]` DDL via `FieldType::Array(ArrayElem)`; INSERT binds a single-param PG array, SELECT decodes back to `Array<T>`; composes with the already-shipped `array_contains`/`array_contained_by`/`array_overlap` operators. PG-only by language semantics (degrades to `TEXT` + erroring decode on MySQL/SQLite, like trigram/FTS). See `crates/rustango/src/sql/array.rs` + `tests/array_field{,_pg_live}.rs`. | |
 | `HStoreField` | [HStoreField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#hstorefield) | MISSING | n/a (#342) | |
 | `RangeField` (Int / Date / DateTime / Decimal) | [RangeField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#range-fields) | MISSING | n/a — `SqlValue::RangeLiteral` exists but no typed field (#343) | |
 | `CITextField` | [CITextField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#citext-fields) | SHIPPED | `#[rustango(citext)]` (#344) — DDL emits `CITEXT` on PG (with `CREATE EXTENSION IF NOT EXISTS citext;` prelude available via `dialect.ci_text_extension_sql()`), `TEXT COLLATE NOCASE` on SQLite, `VARCHAR(N)/TEXT COLLATE utf8mb4_general_ci` on MySQL. Column-level case-insensitivity propagates to `=` / `LIKE` / `ORDER BY` without query-side `LOWER(...)` wrapping. | |
@@ -695,7 +695,7 @@ Summary: **22 SHIPPED / 0 PARTIAL / 1 MISSING / 0 N/A**.
 | `flatpages` | [flatpages](https://docs.djangoproject.com/en/6.0/ref/contrib/flatpages/) | SHIPPED | `flatpages::*` (v0.22) | |
 | `redirects` | [redirects](https://docs.djangoproject.com/en/6.0/ref/contrib/redirects/) | SHIPPED | `redirects::*` (v0.22) | |
 | `admindocs` | [admindocs](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/admindocs/) | N/A | Rust doc-comments + cargo doc | |
-| `postgres` (ArrayField, JSONField, RangeField, HStoreField, CITextField) | (sec 4) | PARTIAL | JSONField + CITextField shipped (#344); Array/Range partial via `SqlValue::Array` / `RangeLiteral` (no typed field wrapper yet); HStore MISSING (#442) | |
+| `postgres` (ArrayField, JSONField, RangeField, HStoreField, CITextField) | (sec 4) | PARTIAL | JSONField + CITextField shipped (#344); ArrayField shipped via `Array<T>` typed field (#341); Range partial via `RangeLiteral` (no typed field wrapper yet, #343); HStore MISSING (#442) | |
 | `gis` (GeoDjango) | [gis](https://docs.djangoproject.com/en/6.0/ref/contrib/gis/) | MISSING | [#58](https://github.com/ujeenet/rustango/issues/58) | |
 | `gis.geos` (geometry types) | (above) | MISSING | (above) (#443) | |
 | `gis.gdal` (raster) | (above) | MISSING | (above) (#444) | |


### PR DESCRIPTION
## What

Closes #341. Django's `ArrayField` — a typed model-field wrapper for native PostgreSQL array columns.

```rust
#[derive(Model)]
#[rustango(table = "post")]
struct Post {
    #[rustango(primary_key)] id: Auto<i64>,
    #[rustango(max_length = 200)] title: String,
    tags: Array<String>,   // → text[]
    scores: Array<i32>,    // → integer[]
}

// round-trips natively; composes with the existing array operators
let rusty = Post::objects()
    .where_(Post::tags.array_contains(["rust".to_owned()]))   // tags @> ARRAY['rust']
    .fetch_pool(&pool).await?;
```

## The gap (audit said PARTIAL)

`SqlValue::Array` + `array_contains` / `array_contained_by` / `array_overlap` operators already shipped at the value layer; what was missing was the **typed field wrapper** so a model could declare an array column that emits the right DDL and round-trips. This adds it.

## Design

- **`sql/array.rs`** — `Array<T>` newtype over `Vec<T>` (Deref / From / serde / `Into<SqlValue>`). It carries **total** sqlx `Type`+`Decode` impls for all three backends: real on Postgres (delegates to `Vec<T>`), erroring stubs on MySQL/SQLite. This matters because `#[derive(Model)]` emits **one shared `FromRow` body** (`try_get::<FieldTy>`) reused across all three backend decoders — a bare `Vec<String>` field (no `Decode<Sqlite>`) wouldn't compile the SQLite/MySQL arms. Same newtype pattern as `Auto<T>`; avoids splitting FromRow per backend.
- **`FieldType::Array(ArrayElem{Text,Int,BigInt})`** — one `Copy` sub-enum, so each `match FieldType` site gains a single arm.
- **PG-only by language semantics** (like trigram / FTS / pgvector): DDL emits `text[]`/`integer[]`/`bigint[]` on PG; MySQL/SQLite degrade to `TEXT` and the bind/decode paths error there. The `sqlite,tenancy` litmus build still compiles (the per-backend impls are total).

## Wired through every `FieldType` consumer

DDL (`dialect`/`mysql`/`sqlite` column_type + cast_type), macro `detect_type`, migrate snapshot round-trip (`array_text`/`array_int`/`array_bigint`) + diff, `row_to_json` (null on the generic cross-backend path — typed fetch decodes via `Array<T>`), admin render/widget (comma-separated), forms parse (comma-separated), fixtures `json_to_sql_value` (JSON array), OpenAPI (`type: array` with element items), template_views label.

## Tests

- `tests/array_field.rs` — 6 unit: derived schema maps to `FieldType::Array`, PG column/cast types are `text[]`/`integer[]`/`bigint[]`, MySQL/SQLite degrade to TEXT, `Into<SqlValue>`.
- `tests/array_field_pg_live.rs` — 3 live (verified against real PostgreSQL): insert→fetch round-trip for `text[]`+`integer[]`, empty arrays, `@>` containment filter.

## Gates

- ✅ Litmus `cargo build --no-default-features --features sqlite,tenancy`
- ✅ `cargo test --workspace --all-features --no-run` compiles
- ✅ 3170 lib tests pass
- ✅ Audit row #341 PARTIAL → SHIPPED

Closes #341.