### PR TITLE
feat(orm): RangeField — Range<T> typed PostgreSQL range column (closes #343)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -10841,6 +10841,16 @@ enum DetectedKind {
     ArrayInt,
     /// `Array<i64>` → PG `bigint[]` (#341).
     ArrayBigInt,
+    /// `Range<i32>` → PG `int4range` (#343).
+    RangeInt,
+    /// `Range<i64>` → PG `int8range` (#343).
+    RangeBigInt,
+    /// `Range<Decimal>` → PG `numrange` (#343).
+    RangeNumeric,
+    /// `Range<NaiveDate>` → PG `daterange` (#343).
+    RangeDate,
+    /// `Range<DateTime<Utc>>` → PG `tstzrange` (#343).
+    RangeDateTime,
 }
 
 impl DetectedKind {
@@ -10869,6 +10879,21 @@ impl DetectedKind {
             }
             Self::ArrayBigInt => {
                 quote!(#root::core::FieldType::Array(#root::core::ArrayElem::BigInt))
+            }
+            Self::RangeInt => {
+                quote!(#root::core::FieldType::Range(#root::core::RangeElem::Int))
+            }
+            Self::RangeBigInt => {
+                quote!(#root::core::FieldType::Range(#root::core::RangeElem::BigInt))
+            }
+            Self::RangeNumeric => {
+                quote!(#root::core::FieldType::Range(#root::core::RangeElem::Numeric))
+            }
+            Self::RangeDate => {
+                quote!(#root::core::FieldType::Range(#root::core::RangeElem::Date))
+            }
+            Self::RangeDateTime => {
+                quote!(#root::core::FieldType::Range(#root::core::RangeElem::DateTime))
             }
         }
     }
@@ -10919,6 +10944,12 @@ impl DetectedKind {
             Self::ArrayText | Self::ArrayInt | Self::ArrayBigInt => {
                 (quote!(Array), quote!(::std::vec::Vec::new()))
             }
+            // Ranges (#343) likewise can't be a FK PK — never reached.
+            Self::RangeInt
+            | Self::RangeBigInt
+            | Self::RangeNumeric
+            | Self::RangeDate
+            | Self::RangeDateTime => (quote!(RangeLiteral), quote!(::std::string::String::new())),
         }
     }
 }
@@ -11099,6 +11130,41 @@ fn detect_type(ty: &syn::Type) -> syn::Result<DetectedType<'_>> {
                         ty,
                         "unsupported `Array<T>` element — only `Array<String>` (→ text[]), \
                          `Array<i32>` (→ integer[]), and `Array<i64>` (→ bigint[]) are supported (#341)",
+                    ));
+                }
+            };
+            return Ok(DetectedType {
+                kind,
+                nullable: false,
+                auto: false,
+                fk_inner: None,
+            });
+        }
+        // `Range<i32>` / `Range<i64>` / `Range<Decimal>` /
+        // `Range<NaiveDate>` / `Range<DateTime<…>>` → PG `int4range` /
+        // `int8range` / `numrange` / `daterange` / `tstzrange` (Django
+        // `RangeField` family, #343).
+        "Range" => {
+            let (inner, _) = generic_pair(ty, &last.arguments, "Range")?;
+            let elem = match inner {
+                Type::Path(TypePath { path, qself: None }) => {
+                    path.segments.last().map(|s| s.ident.to_string())
+                }
+                _ => None,
+            };
+            let kind = match elem.as_deref() {
+                Some("i32") => DetectedKind::RangeInt,
+                Some("i64") => DetectedKind::RangeBigInt,
+                Some("Decimal") => DetectedKind::RangeNumeric,
+                Some("NaiveDate") => DetectedKind::RangeDate,
+                Some("DateTime") => DetectedKind::RangeDateTime,
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        ty,
+                        "unsupported `Range<T>` element — only `Range<i32>` (→ int4range), \
+                         `Range<i64>` (→ int8range), `Range<Decimal>` (→ numrange), \
+                         `Range<NaiveDate>` (→ daterange), and `Range<DateTime<Utc>>` \
+                         (→ tstzrange) are supported (#343)",
                     ));
                 }
             };

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -121,6 +121,8 @@ pub(crate) fn render_value_for_input_json(row: &serde_json::Value, field: &Field
         FieldType::Decimal | FieldType::Binary => v.as_str().unwrap_or("").to_owned(),
         // #341 — PG array: render the JSON form compactly.
         FieldType::Array(_) => v.to_string(),
+        // #343 — PG range: literal string (or compact JSON fallback).
+        FieldType::Range(_) => v.as_str().map_or_else(|| v.to_string(), str::to_owned),
     }
 }
 
@@ -336,6 +338,10 @@ fn render_input_default(field: &FieldSchema, value: &str, pk_locked: bool) -> St
         FieldType::Array(_) => format!(
             r#"<input type="text" name="{name}" id="{name}" value="{val}" placeholder="comma, separated, values"{required}{readonly}>"#
         ),
+        // #343 — PG range: a range-literal text input (`[lower,upper)`).
+        FieldType::Range(_) => format!(
+            r#"<input type="text" name="{name}" id="{name}" value="{val}" placeholder="[lower,upper)"{required}{readonly}>"#
+        ),
     }
 }
 
@@ -509,6 +515,8 @@ pub(crate) fn render_value_json(row: &serde_json::Value, field: &FieldSchema) ->
         FieldType::Array(_) => serde_json::to_string(v)
             .map(|s| escape(&s))
             .unwrap_or_default(),
+        // #343 — PG range: literal string in the list cell.
+        FieldType::Range(_) => escape(v.as_str().unwrap_or("")),
     }
 }
 
@@ -581,6 +589,8 @@ pub(crate) fn read_joined_value_as_html_json(
         FieldType::Json => None,
         // #341 — arrays aren't a meaningful select_related join target.
         FieldType::Array(_) => None,
+        // #343 — ranges aren't a meaningful select_related join target.
+        FieldType::Range(_) => None,
     };
     text.map(|s| escape(&s))
 }

--- a/crates/rustango/src/core/field_type.rs
+++ b/crates/rustango/src/core/field_type.rs
@@ -48,6 +48,45 @@ pub enum FieldType {
     /// semantics**: MySQL / SQLite have no array column type, so the DDL
     /// writer degrades to `TEXT` and the bind / decode paths error there.
     Array(ArrayElem),
+    /// Native PostgreSQL range — Django's `RangeField` family (#343).
+    /// Rust type: [`crate::sql::Range<T>`]. The element kind selects the
+    /// column type (`int4range` / `int8range` / `numrange` / `daterange`
+    /// / `tstzrange`). **PG-only by language semantics** like
+    /// [`Self::Array`]: MySQL / SQLite degrade to `TEXT` and the decode
+    /// path errors there.
+    Range(RangeElem),
+}
+
+/// Element type of a [`FieldType::Range`] column (#343). Selects the
+/// PostgreSQL range column type emitted by the migration writer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RangeElem {
+    /// `int4range` — element `i32` ([`crate::sql::Range<i32>`]).
+    /// Django `IntegerRangeField`.
+    Int,
+    /// `int8range` — element `i64` ([`crate::sql::Range<i64>`]).
+    /// Django `BigIntegerRangeField`.
+    BigInt,
+    /// `numrange` — element `rust_decimal::Decimal`. Django `DecimalRangeField`.
+    Numeric,
+    /// `daterange` — element `chrono::NaiveDate`. Django `DateRangeField`.
+    Date,
+    /// `tstzrange` — element `chrono::DateTime<Utc>`. Django `DateTimeRangeField`.
+    DateTime,
+}
+
+impl RangeElem {
+    /// PostgreSQL range type name.
+    #[must_use]
+    pub const fn pg_range_type(self) -> &'static str {
+        match self {
+            Self::Int => "int4range",
+            Self::BigInt => "int8range",
+            Self::Numeric => "numrange",
+            Self::Date => "daterange",
+            Self::DateTime => "tstzrange",
+        }
+    }
 }
 
 /// Element type of a [`FieldType::Array`] column (#341). Selects the
@@ -100,6 +139,11 @@ impl FieldType {
             Self::Array(ArrayElem::Text) => "Array<String>",
             Self::Array(ArrayElem::Int) => "Array<i32>",
             Self::Array(ArrayElem::BigInt) => "Array<i64>",
+            Self::Range(RangeElem::Int) => "Range<i32>",
+            Self::Range(RangeElem::BigInt) => "Range<i64>",
+            Self::Range(RangeElem::Numeric) => "Range<Decimal>",
+            Self::Range(RangeElem::Date) => "Range<NaiveDate>",
+            Self::Range(RangeElem::DateTime) => "Range<DateTime<Utc>>",
         }
     }
 }

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -23,7 +23,7 @@ pub use case::{case, value, CaseBuilder};
 pub use column::{Column, TypedAssignment, TypedExpr, TypedFieldList, TypedFilter};
 pub use error::QueryError;
 pub use expr::{BinOp, CaseBranch, Expr, JsonPathStep, ScalarFn, F};
-pub use field_type::{ArrayElem, FieldType};
+pub use field_type::{ArrayElem, FieldType, RangeElem};
 pub use query::{
     AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ColumnFilter,
     CompoundBranch, ConflictClause, CountQuery, DeleteQuery, DistinctMode, Filter, InsertQuery,

--- a/crates/rustango/src/forms/mod.rs
+++ b/crates/rustango/src/forms/mod.rs
@@ -239,8 +239,9 @@ pub fn parse_pk_string(field: &FieldSchema, raw: &str) -> Result<SqlValue, FormE
         | FieldType::Json
         | FieldType::Decimal
         | FieldType::Binary
-        // #341 — an array can't be a primary key.
-        | FieldType::Array(_) => Err(FormError::UnsupportedPk {
+        // #341 / #343 — an array or range can't be a primary key.
+        | FieldType::Array(_)
+        | FieldType::Range(_) => Err(FormError::UnsupportedPk {
             field: field.name.to_owned(),
             ty: field.ty.as_str(),
         }),
@@ -406,6 +407,9 @@ pub fn parse_form_value(field: &FieldSchema, raw: Option<&str>) -> Result<SqlVal
                     .map_err(|e| make_parse_err("array<i64>", &e)),
             }
         }
+        // #343 — PG range column from a form field: the raw input is a
+        // range literal (`[1,10)`), bound as-is and implicit-cast by PG.
+        FieldType::Range(_) => Ok(SqlValue::RangeLiteral(raw.to_owned())),
     }
 }
 

--- a/crates/rustango/src/migrate/diff.rs
+++ b/crates/rustango/src/migrate/diff.rs
@@ -1201,6 +1201,12 @@ fn pg_type_for_ty_name(ty: &str) -> String {
         "array_text" => "text[]".into(),
         "array_int" => "integer[]".into(),
         "array_bigint" => "bigint[]".into(),
+        // #343 — PG range element kinds.
+        "range_int" => "int4range".into(),
+        "range_bigint" => "int8range".into(),
+        "range_numeric" => "numrange".into(),
+        "range_date" => "daterange".into(),
+        "range_datetime" => "tstzrange".into(),
         other => other.to_uppercase(),
     }
 }
@@ -1429,6 +1435,12 @@ fn sql_type_with_dialect(f: &FieldSnapshot, dialect: &dyn crate::sql::Dialect) -
         "array_text" => Some(FieldType::Array(crate::core::ArrayElem::Text)),
         "array_int" => Some(FieldType::Array(crate::core::ArrayElem::Int)),
         "array_bigint" => Some(FieldType::Array(crate::core::ArrayElem::BigInt)),
+        // #343 — PG range element kinds.
+        "range_int" => Some(FieldType::Range(crate::core::RangeElem::Int)),
+        "range_bigint" => Some(FieldType::Range(crate::core::RangeElem::BigInt)),
+        "range_numeric" => Some(FieldType::Range(crate::core::RangeElem::Numeric)),
+        "range_date" => Some(FieldType::Range(crate::core::RangeElem::Date)),
+        "range_datetime" => Some(FieldType::Range(crate::core::RangeElem::DateTime)),
         _ => None,
     };
     // v0.13.2: `auto = true` historically meant "PK SERIAL/BIGSERIAL"

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -2982,6 +2982,12 @@ fn json_to_sql_value(
                 .collect::<Result<Vec<_>, _>>()?;
             Ok(SqlValue::Array(items))
         }
+        // #343 — PG range column from a fixture: a range-literal string
+        // (`"[1,10)"`), bound as-is and implicit-cast by PG.
+        FieldType::Range(_) => v
+            .as_str()
+            .map(|s| SqlValue::RangeLiteral(s.to_owned()))
+            .ok_or_else(|| format!("expected range-literal string for Range column, got {v}")),
     }
 }
 

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -520,6 +520,12 @@ pub(crate) fn field_type_name(ty: FieldType) -> &'static str {
         FieldType::Array(crate::core::ArrayElem::Text) => "array_text",
         FieldType::Array(crate::core::ArrayElem::Int) => "array_int",
         FieldType::Array(crate::core::ArrayElem::BigInt) => "array_bigint",
+        // #343 — stable snapshot names for PG range element kinds.
+        FieldType::Range(crate::core::RangeElem::Int) => "range_int",
+        FieldType::Range(crate::core::RangeElem::BigInt) => "range_bigint",
+        FieldType::Range(crate::core::RangeElem::Numeric) => "range_numeric",
+        FieldType::Range(crate::core::RangeElem::Date) => "range_date",
+        FieldType::Range(crate::core::RangeElem::DateTime) => "range_datetime",
     }
 }
 

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -356,6 +356,12 @@ pub trait Dialect {
             FieldType::Array(crate::core::ArrayElem::Text) => "text[]",
             FieldType::Array(crate::core::ArrayElem::Int) => "integer[]",
             FieldType::Array(crate::core::ArrayElem::BigInt) => "bigint[]",
+            // PG range CAST targets (#343).
+            FieldType::Range(crate::core::RangeElem::Int) => "int4range",
+            FieldType::Range(crate::core::RangeElem::BigInt) => "int8range",
+            FieldType::Range(crate::core::RangeElem::Numeric) => "numrange",
+            FieldType::Range(crate::core::RangeElem::Date) => "daterange",
+            FieldType::Range(crate::core::RangeElem::DateTime) => "tstzrange",
         })
     }
 
@@ -394,6 +400,8 @@ pub trait Dialect {
             // `bigint[]` (#341). `max_length` is ignored (arrays carry
             // no length cap at the type level).
             FieldType::Array(elem) => format!("{}[]", elem.pg_element_type()),
+            // Native PG range column (#343).
+            FieldType::Range(elem) => elem.pg_range_type().to_owned(),
         }
     }
 

--- a/crates/rustango/src/sql/executor/row_to_json.rs
+++ b/crates/rustango/src/sql/executor/row_to_json.rs
@@ -139,6 +139,9 @@ where
             // (Typed `#[derive(Model)]` fetch decodes arrays via
             // `Array<T>`; this affects only the dynamic admin/JSON view.)
             FieldType::Array(_) => Value::Null,
+            // #343 — PG range columns. Same story as arrays: no generic
+            // `Range<T>: Decode` bound on this path; typed fetch decodes.
+            FieldType::Range(_) => Value::Null,
         };
         map.insert(field.name.to_owned(), value);
     }
@@ -276,6 +279,8 @@ pub fn row_to_json_sqlite(
                 }),
             // #341 — arrays are PG-only; never present on SQLite.
             FieldType::Array(_) => Value::Null,
+            // #343 — ranges are PG-only; never present on SQLite.
+            FieldType::Range(_) => Value::Null,
         };
         map.insert(field.name.to_owned(), value);
     }

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -21,6 +21,7 @@ pub mod model_shortcuts;
 mod mysql;
 mod pool;
 mod postgres;
+mod range;
 #[cfg(feature = "sqlite")]
 mod sqlite;
 mod writers;
@@ -34,6 +35,7 @@ pub use backend::{
 pub use compiled::CompiledStatement;
 pub use dialect::Dialect;
 pub use error::{is_mysql_dup_index_error, ExecError, SqlError};
+pub use range::Range;
 // Always-on: tri-dialect entry points + traits that don't pin on PG.
 #[cfg(feature = "mysql")]
 pub use executor::row_to_json_my;

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -142,9 +142,11 @@ impl Dialect for MySql {
             // MySQL has no `CAST AS JSON` form — `JSON_EXTRACT` /
             // string parsing are the substitutes. UUID has no CAST
             // target either (it's CHAR(36) in DDL but the user would
-            // cast to CHAR in expression form). Arrays (#341) are
-            // PG-only by language — no MySQL CAST target.
-            FieldType::Uuid | FieldType::Json | FieldType::Array(_) => return None,
+            // cast to CHAR in expression form). Arrays (#341) / ranges
+            // (#343) are PG-only by language — no MySQL CAST target.
+            FieldType::Uuid | FieldType::Json | FieldType::Array(_) | FieldType::Range(_) => {
+                return None
+            }
         })
     }
 
@@ -194,6 +196,8 @@ impl Dialect for MySql {
             // is PG-only by language semantics. Degrade to `TEXT` so the
             // DDL stays emittable; the bind / decode paths error on MySQL.
             FieldType::Array(_) => "TEXT".into(),
+            // Ditto for PG range columns (#343).
+            FieldType::Range(_) => "TEXT".into(),
         }
     }
 

--- a/crates/rustango/src/sql/range.rs
+++ b/crates/rustango/src/sql/range.rs
@@ -1,0 +1,312 @@
+//! `Range<T>` — typed PostgreSQL range column wrapper (Django's
+//! `RangeField` family, issue #343).
+//!
+//! Declare a native PG range column on a model:
+//!
+//! ```ignore
+//! use rustango::sql::{Auto, Range};
+//! use std::ops::Bound;
+//!
+//! #[derive(Model)]
+//! #[rustango(table = "event")]
+//! struct Event {
+//!     #[rustango(primary_key)]
+//!     id: Auto<i64>,
+//!     // → DDL `during tstzrange`; round-trips as a Rust `Range<DateTime<Utc>>`.
+//!     during: Range<chrono::DateTime<chrono::Utc>>,
+//!     // → DDL `seats int4range`.
+//!     seats: Range<i32>,
+//! }
+//!
+//! let e = Event {
+//!     id: Auto::default(),
+//!     during: Range::closed_open(start, end),  // [start, end)
+//!     seats: (1..100).into(),                   // [1, 100)
+//! };
+//! ```
+//!
+//! The element type drives the column type emitted by the migration
+//! writer:
+//!
+//! | Rust field                       | PG column   | Django field            |
+//! |----------------------------------|-------------|-------------------------|
+//! | `Range<i32>`                     | `int4range` | `IntegerRangeField`     |
+//! | `Range<i64>`                     | `int8range` | `BigIntegerRangeField`  |
+//! | `Range<rust_decimal::Decimal>`   | `numrange`  | `DecimalRangeField`     |
+//! | `Range<chrono::NaiveDate>`       | `daterange` | `DateRangeField`        |
+//! | `Range<chrono::DateTime<Utc>>`   | `tstzrange` | `DateTimeRangeField`    |
+//!
+//! Pairs with the already-shipped range operators
+//! ([`crate::core::Op::RangeContains`] / `RangeContainedBy` /
+//! `RangeOverlap` / `RangeStrictlyLeft` / `RangeStrictlyRight` /
+//! `RangeAdjacent`, PG `@>` / `<@` / `&&` / `<<` / `>>` / `-|-`).
+//!
+//! ## PostgreSQL only, by language semantics
+//!
+//! Range types are a Postgres feature; MySQL and SQLite have no
+//! equivalent. Like [`Array`](crate::sql::Array) / trigram / full-text,
+//! `Range<T>` is **PG-only by language semantics**: the migration writer
+//! emits a degraded `TEXT` column on MySQL / SQLite and the decode path
+//! errors there. The type still *compiles* under every backend (the
+//! per-backend [`sqlx::Type`] / [`sqlx::Decode`] impls are total) so the
+//! `sqlite,tenancy` litmus build keeps passing.
+//!
+//! ## Binding & decoding
+//!
+//! On INSERT/UPDATE a `Range<T>` lowers to a PostgreSQL range *literal*
+//! string (`"[1,10)"`, `"[1,)"`, `"(,10)"`) via
+//! [`crate::core::SqlValue::RangeLiteral`], which PG implicit-casts to
+//! the column's range type. On SELECT it decodes through sqlx's
+//! `PgRange<T>`. Postgres normalizes discrete ranges (int / date) to the
+//! canonical `[lower, upper)` form on storage, so a stored `[1,10]`
+//! reads back as `[1,11)`.
+
+use std::ops::Bound;
+
+/// Typed PostgreSQL range column — see the [module docs](self).
+///
+/// A lower + upper [`Bound`]. Build via [`Self::closed_open`] /
+/// [`Self::new`] / `From<std::ops::Range<T>>` (`a..b` → `[a, b)`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Range<T> {
+    /// Lower bound. `Included` → `[`, `Excluded` → `(`, `Unbounded` → no
+    /// lower limit.
+    pub lower: Bound<T>,
+    /// Upper bound. `Included` → `]`, `Excluded` → `)`, `Unbounded` → no
+    /// upper limit.
+    pub upper: Bound<T>,
+}
+
+impl<T> Range<T> {
+    /// Construct from explicit bounds.
+    #[must_use]
+    pub fn new(lower: Bound<T>, upper: Bound<T>) -> Self {
+        Self { lower, upper }
+    }
+
+    /// `[lower, upper)` — the canonical half-open range (lower inclusive,
+    /// upper exclusive). Matches PostgreSQL's normalized discrete-range
+    /// form and Python's `range`/Django default.
+    #[must_use]
+    pub fn closed_open(lower: T, upper: T) -> Self {
+        Self {
+            lower: Bound::Included(lower),
+            upper: Bound::Excluded(upper),
+        }
+    }
+
+    /// `[lower, ∞)` — lower-bounded, no upper limit.
+    #[must_use]
+    pub fn at_least(lower: T) -> Self {
+        Self {
+            lower: Bound::Included(lower),
+            upper: Bound::Unbounded,
+        }
+    }
+
+    /// `(∞, upper)` — upper-bounded, no lower limit.
+    #[must_use]
+    pub fn less_than(upper: T) -> Self {
+        Self {
+            lower: Bound::Unbounded,
+            upper: Bound::Excluded(upper),
+        }
+    }
+}
+
+impl<T> From<std::ops::Range<T>> for Range<T> {
+    /// `a..b` → `[a, b)`.
+    fn from(r: std::ops::Range<T>) -> Self {
+        Self::closed_open(r.start, r.end)
+    }
+}
+
+impl<T> From<(Bound<T>, Bound<T>)> for Range<T> {
+    fn from(v: (Bound<T>, Bound<T>)) -> Self {
+        Self {
+            lower: v.0,
+            upper: v.1,
+        }
+    }
+}
+
+/// Render a PostgreSQL range literal — `[lo,hi)` with bracket chosen per
+/// bound inclusivity; an unbounded side emits an empty value. `fmt`
+/// formats one endpoint value the way PG's range parser accepts it.
+fn pg_range_literal<T>(lower: &Bound<T>, upper: &Bound<T>, fmt: impl Fn(&T) -> String) -> String {
+    let (open, lo) = match lower {
+        Bound::Included(v) => ('[', fmt(v)),
+        Bound::Excluded(v) => ('(', fmt(v)),
+        Bound::Unbounded => ('[', String::new()),
+    };
+    let (hi, close) = match upper {
+        Bound::Included(v) => (fmt(v), ']'),
+        Bound::Excluded(v) => (fmt(v), ')'),
+        Bound::Unbounded => (String::new(), ')'),
+    };
+    format!("{open}{lo},{hi}{close}")
+}
+
+// ---- serde: a `{ "lower": ..., "upper": ... }` object with bound tags ----
+//
+// Derives delegate to `Bound<T>`'s serde (an enum). Good enough for
+// DRF/JSON round-trips and inspection; not the PG literal form.
+
+impl<T: serde::Serialize> serde::Serialize for Range<T> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut s = serializer.serialize_struct("Range", 2)?;
+        s.serialize_field("lower", &BoundSer(&self.lower))?;
+        s.serialize_field("upper", &BoundSer(&self.upper))?;
+        s.end()
+    }
+}
+
+/// Serialize a `Bound<T>` as `null` (Unbounded) or the bare value;
+/// inclusivity is implied by convention (`[lower, upper)`).
+struct BoundSer<'a, T>(&'a Bound<T>);
+
+impl<T: serde::Serialize> serde::Serialize for BoundSer<'_, T> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self.0 {
+            Bound::Included(v) | Bound::Excluded(v) => v.serialize(serializer),
+            Bound::Unbounded => serializer.serialize_none(),
+        }
+    }
+}
+
+// ---- `Range<T>` → `SqlValue::RangeLiteral` (INSERT / UPDATE bind) ----
+//
+// PG implicit-casts the literal string to the column's range type. One
+// concrete impl per element type so the endpoint formatting matches what
+// PG's range parser accepts (ISO date/timestamp, plain numerics).
+
+macro_rules! range_into_sqlvalue {
+    ($t:ty, $fmt:expr) => {
+        impl From<Range<$t>> for crate::core::SqlValue {
+            fn from(r: Range<$t>) -> Self {
+                let f: fn(&$t) -> String = $fmt;
+                crate::core::SqlValue::RangeLiteral(pg_range_literal(&r.lower, &r.upper, f))
+            }
+        }
+    };
+}
+
+range_into_sqlvalue!(i32, |v| v.to_string());
+range_into_sqlvalue!(i64, |v| v.to_string());
+range_into_sqlvalue!(rust_decimal::Decimal, |v| v.to_string());
+range_into_sqlvalue!(chrono::NaiveDate, |v| v.to_string());
+range_into_sqlvalue!(chrono::DateTime<chrono::Utc>, |v| v.to_rfc3339());
+
+// ---- sqlx Type + Decode (FromRow read path) ----
+//
+// Postgres: delegate to sqlx's `PgRange<T>` (the real range decode), then
+// copy its `start`/`end` bounds. MySQL / SQLite: total stubs so the
+// shared `FromRow` body compiles — `Type` borrows a placeholder
+// type-info, `Decode` errors at runtime. Encode is intentionally NOT
+// implemented: the bind path goes through `SqlValue::RangeLiteral`.
+
+#[cfg(feature = "postgres")]
+impl<'r, T> sqlx::Decode<'r, sqlx::Postgres> for Range<T>
+where
+    sqlx::postgres::types::PgRange<T>: sqlx::Decode<'r, sqlx::Postgres>,
+{
+    fn decode(
+        value: <sqlx::Postgres as sqlx::Database>::ValueRef<'r>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        let pg =
+            <sqlx::postgres::types::PgRange<T> as sqlx::Decode<'r, sqlx::Postgres>>::decode(value)?;
+        Ok(Self {
+            lower: pg.start,
+            upper: pg.end,
+        })
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<T> sqlx::Type<sqlx::Postgres> for Range<T>
+where
+    sqlx::postgres::types::PgRange<T>: sqlx::Type<sqlx::Postgres>,
+{
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        <sqlx::postgres::types::PgRange<T> as sqlx::Type<sqlx::Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+        <sqlx::postgres::types::PgRange<T> as sqlx::Type<sqlx::Postgres>>::compatible(ty)
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl<'r, T> sqlx::Decode<'r, sqlx::MySql> for Range<T> {
+    fn decode(
+        _value: <sqlx::MySql as sqlx::Database>::ValueRef<'r>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        Err("`Range<T>` columns are PostgreSQL-only; cannot decode on MySQL (issue #343)".into())
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl<T> sqlx::Type<sqlx::MySql> for Range<T> {
+    fn type_info() -> sqlx::mysql::MySqlTypeInfo {
+        <String as sqlx::Type<sqlx::MySql>>::type_info()
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'r, T> sqlx::Decode<'r, sqlx::Sqlite> for Range<T> {
+    fn decode(
+        _value: <sqlx::Sqlite as sqlx::Database>::ValueRef<'r>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        Err("`Range<T>` columns are PostgreSQL-only; cannot decode on SQLite (issue #343)".into())
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<T> sqlx::Type<sqlx::Sqlite> for Range<T> {
+    fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
+        <String as sqlx::Type<sqlx::Sqlite>>::type_info()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::SqlValue;
+
+    #[test]
+    fn closed_open_literal() {
+        let v: SqlValue = Range::closed_open(1_i32, 10).into();
+        assert!(matches!(v, SqlValue::RangeLiteral(ref s) if s == "[1,10)"));
+    }
+
+    #[test]
+    fn unbounded_sides() {
+        let lo: SqlValue = Range::at_least(5_i64).into();
+        assert!(matches!(lo, SqlValue::RangeLiteral(ref s) if s == "[5,)"));
+        let hi: SqlValue = Range::less_than(10_i64).into();
+        assert!(matches!(hi, SqlValue::RangeLiteral(ref s) if s == "[,10)"));
+    }
+
+    #[test]
+    fn from_std_range() {
+        let r: Range<i32> = (1..10).into();
+        assert_eq!(r.lower, Bound::Included(1));
+        assert_eq!(r.upper, Bound::Excluded(10));
+    }
+
+    #[test]
+    fn date_literal_is_iso() {
+        let d1 = chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap();
+        let d2 = chrono::NaiveDate::from_ymd_opt(2025, 2, 1).unwrap();
+        let v: SqlValue = Range::closed_open(d1, d2).into();
+        assert!(matches!(v, SqlValue::RangeLiteral(ref s) if s == "[2025-01-01,2025-02-01)"));
+    }
+
+    #[test]
+    fn serde_round_trips() {
+        let r = Range::closed_open(1_i32, 10);
+        let json = serde_json::to_string(&r).unwrap();
+        assert_eq!(json, r#"{"lower":1,"upper":10}"#);
+    }
+}

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -187,6 +187,8 @@ impl Dialect for Sqlite {
             // SQLite has no array type — `Array<T>` (#341) is PG-only.
             // Degrade the CAST target to TEXT affinity.
             FieldType::Array(_) => "TEXT",
+            // Ditto for PG range columns (#343).
+            FieldType::Range(_) => "TEXT",
         })
     }
 
@@ -213,6 +215,8 @@ impl Dialect for Sqlite {
             // PG-only by language semantics. Degrade to `TEXT`; the
             // bind / decode paths error on SQLite.
             FieldType::Array(_) => "TEXT".into(),
+            // Ditto for PG range columns (#343).
+            FieldType::Range(_) => "TEXT".into(),
         }
     }
 

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -3609,8 +3609,29 @@ fn write_filter(
             // Both shapes route through the same writer because the
             // SQL emission is identical (`<col> <op> <placeholder>`).
             require_op(b.d, filter.op)?;
+            // #343 — when the filtered column is a typed `Range<T>`
+            // (`FieldType::Range`) and the RHS is a *range literal*, cast
+            // the bound text to the column's range type so PG resolves
+            // the operator (`int4range @> $1::int4range`); without it PG
+            // errors `operator does not exist: int4range @> text`. A
+            // scalar RHS is element-containment (`int4range @> integer`)
+            // and must stay un-cast; a non-`Range` column (the legacy
+            // "declare the range as String + raw migration" shape) keeps
+            // the bare placeholder.
+            let range_cast = if matches!(filter.value, SqlValue::RangeLiteral(_)) {
+                model
+                    .and_then(|m| m.field_by_column(filter.column))
+                    .filter(|f| matches!(f.ty, crate::core::FieldType::Range(_)))
+                    .and_then(|f| b.d.cast_type(f.ty))
+            } else {
+                None
+            };
             b.params.push(filter.value.clone());
-            let p = b.d.placeholder(b.params.len());
+            let mut p = b.d.placeholder(b.params.len());
+            if let Some(ty) = range_cast {
+                p.push_str("::");
+                p.push_str(ty);
+            }
             let op_str: &'static str = match filter.op {
                 Op::RangeContains => "@>",
                 Op::RangeContainedBy => "<@",

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -86,15 +86,21 @@ impl<'d> Sql<'d> {
     }
 
     /// Push `value` to the param list and emit the dialect's
-    /// placeholder for the new slot. For Postgres + a NULL value, also
-    /// emit `::TYPE` when the column type is known — see
-    /// [`Dialect::null_cast`].
+    /// placeholder for the new slot. For Postgres, also emit `::TYPE`
+    /// (from [`Dialect::null_cast`]) when:
+    /// - the value is `NULL` — types the otherwise-ambiguous parameter; or
+    /// - the value is a [`SqlValue::RangeLiteral`] (#343) — a range column
+    ///   value binds as a text literal, and PG won't assignment-cast
+    ///   `text` → `int4range`/`daterange`/… in `INSERT`/`UPDATE SET`, so
+    ///   the explicit `$N::<rangetype>` cast is required. (Range *operators*
+    ///   take their type from the operator context and emit a bare
+    ///   placeholder via a separate path, so they're unaffected.)
     pub(super) fn push_param_typed(&mut self, value: SqlValue, cast: Option<&'static str>) {
-        let is_null = matches!(value, SqlValue::Null);
+        let needs_cast = matches!(value, SqlValue::Null | SqlValue::RangeLiteral(_));
         self.params.push(value);
         let p = self.d.placeholder(self.params.len());
         self.sql.push_str(&p);
-        if is_null {
+        if needs_cast {
             if let Some(ty) = cast {
                 self.sql.push_str("::");
                 self.sql.push_str(ty);

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -1515,6 +1515,8 @@ fn field_type_label(ty: crate::core::FieldType) -> &'static str {
         T::Binary => "binary",
         // #341 — PG array columns.
         T::Array(_) => "array",
+        // #343 — PG range columns.
+        T::Range(_) => "range",
     }
 }
 

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -273,6 +273,9 @@ fn field_type_to_schema(t: FieldType) -> Schema {
             };
             Schema::array_of(items)
         }
+        // #343 — PG range column: serialized as a range-literal string
+        // (`"[1,10)"`), so a `string` schema is the honest shape.
+        FieldType::Range(_) => Schema::string(),
     }
 }
 

--- a/crates/rustango/tests/range_field.rs
+++ b/crates/rustango/tests/range_field.rs
@@ -1,0 +1,101 @@
+//! Unit coverage for `Range<T>` PostgreSQL range columns — Django
+//! `RangeField` family (#343). No database required: asserts the derived
+//! schema's `FieldType::Range` mapping, the per-dialect column-type
+//! emission (`int4range` / `int8range` / `numrange` / `daterange` /
+//! `tstzrange` on PG; degraded `TEXT` on MySQL / SQLite), and the
+//! range-literal serialization.
+
+use rustango::core::{FieldType, Model as _, RangeElem, SqlValue};
+use rustango::sql::{Dialect, MySql, Postgres, Range, Sqlite};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rng_event")]
+#[allow(dead_code)]
+pub struct Event {
+    #[rustango(primary_key)]
+    id: i64,
+    seats: Range<i32>,
+    capacity: Range<i64>,
+    price_band: Range<rust_decimal::Decimal>,
+    valid_on: Range<chrono::NaiveDate>,
+    during: Range<chrono::DateTime<chrono::Utc>>,
+}
+
+fn field(name: &str) -> &'static rustango::core::FieldSchema {
+    Event::SCHEMA
+        .fields
+        .iter()
+        .find(|f| f.name == name)
+        .unwrap_or_else(|| panic!("no field {name}"))
+}
+
+#[test]
+fn derive_maps_range_fields_to_range_field_type() {
+    assert_eq!(field("seats").ty, FieldType::Range(RangeElem::Int));
+    assert_eq!(field("capacity").ty, FieldType::Range(RangeElem::BigInt));
+    assert_eq!(field("price_band").ty, FieldType::Range(RangeElem::Numeric));
+    assert_eq!(field("valid_on").ty, FieldType::Range(RangeElem::Date));
+    assert_eq!(field("during").ty, FieldType::Range(RangeElem::DateTime));
+}
+
+#[test]
+fn postgres_column_types_are_native_ranges() {
+    assert_eq!(Postgres.column_type(field("seats").ty, None), "int4range");
+    assert_eq!(
+        Postgres.column_type(field("capacity").ty, None),
+        "int8range"
+    );
+    assert_eq!(
+        Postgres.column_type(field("price_band").ty, None),
+        "numrange"
+    );
+    assert_eq!(
+        Postgres.column_type(field("valid_on").ty, None),
+        "daterange"
+    );
+    assert_eq!(Postgres.column_type(field("during").ty, None), "tstzrange");
+}
+
+#[test]
+fn postgres_cast_types_match() {
+    assert_eq!(
+        Postgres.cast_type(FieldType::Range(RangeElem::Int)),
+        Some("int4range")
+    );
+    assert_eq!(
+        Postgres.cast_type(FieldType::Range(RangeElem::DateTime)),
+        Some("tstzrange")
+    );
+}
+
+#[test]
+fn non_pg_dialects_degrade_to_text() {
+    for elem in [
+        RangeElem::Int,
+        RangeElem::BigInt,
+        RangeElem::Numeric,
+        RangeElem::Date,
+        RangeElem::DateTime,
+    ] {
+        let ty = FieldType::Range(elem);
+        assert_eq!(MySql.column_type(ty, None), "TEXT");
+        assert_eq!(Sqlite.column_type(ty, None), "TEXT");
+        assert_eq!(MySql.cast_type(ty), None);
+    }
+}
+
+#[test]
+fn range_elem_type_tokens() {
+    assert_eq!(RangeElem::Int.pg_range_type(), "int4range");
+    assert_eq!(RangeElem::BigInt.pg_range_type(), "int8range");
+    assert_eq!(RangeElem::Numeric.pg_range_type(), "numrange");
+    assert_eq!(RangeElem::Date.pg_range_type(), "daterange");
+    assert_eq!(RangeElem::DateTime.pg_range_type(), "tstzrange");
+}
+
+#[test]
+fn range_into_sqlvalue_is_range_literal() {
+    let v: SqlValue = Range::closed_open(1_i32, 10).into();
+    assert!(matches!(v, SqlValue::RangeLiteral(ref s) if s == "[1,10)"));
+}

--- a/crates/rustango/tests/range_field.rs
+++ b/crates/rustango/tests/range_field.rs
@@ -126,3 +126,20 @@ fn insert_casts_range_literal_to_its_pg_type() {
         "missing daterange cast: {sql}"
     );
 }
+
+#[test]
+fn range_contains_on_typed_range_column_casts_rhs() {
+    // `Range<T>` column + range-literal RHS → `seats @> $1::int4range`
+    // so PG resolves the operator. (A non-range column keeps the bare
+    // placeholder — covered by `range_ops_emission`.)
+    use rustango::core::Column as _;
+    let q = Event::objects()
+        .where_(Event::seats.range_contains("[5,6)"))
+        .compile()
+        .unwrap();
+    let sql = Postgres.compile_select(&q).unwrap().sql;
+    assert!(
+        sql.contains(r#""seats" @> $1::int4range"#),
+        "missing range-op cast: {sql}"
+    );
+}

--- a/crates/rustango/tests/range_field.rs
+++ b/crates/rustango/tests/range_field.rs
@@ -99,3 +99,30 @@ fn range_into_sqlvalue_is_range_literal() {
     let v: SqlValue = Range::closed_open(1_i32, 10).into();
     assert!(matches!(v, SqlValue::RangeLiteral(ref s) if s == "[1,10)"));
 }
+
+#[test]
+fn insert_casts_range_literal_to_its_pg_type() {
+    // Regression for the CI failure: PG rejects `INSERT … VALUES ($1)`
+    // when $1 is bound as text but the column is `int4range` (no
+    // assignment cast). The writer must emit `$N::int4range`.
+    use rustango::core::InsertQuery;
+    let q = InsertQuery {
+        model: Event::SCHEMA,
+        columns: vec!["seats", "valid_on"],
+        values: vec![
+            SqlValue::RangeLiteral("[1,10)".into()),
+            SqlValue::RangeLiteral("[2025-01-01,2025-02-01)".into()),
+        ],
+        returning: vec![],
+        on_conflict: None,
+    };
+    let sql = Postgres.compile_insert(&q).unwrap().sql;
+    assert!(
+        sql.contains("$1::int4range"),
+        "missing int4range cast: {sql}"
+    );
+    assert!(
+        sql.contains("$2::daterange"),
+        "missing daterange cast: {sql}"
+    );
+}

--- a/crates/rustango/tests/range_field_pg_live.rs
+++ b/crates/rustango/tests/range_field_pg_live.rs
@@ -1,0 +1,169 @@
+#![cfg(feature = "postgres")]
+//! Live PostgreSQL round-trip for `Range<T>` columns — Django
+//! `RangeField` family (#343). Proves the typed field wrapper writes a
+//! native PG range on INSERT (via a range-literal bind) and decodes it
+//! back into `Range<T>` on SELECT, and that the `@>` containment
+//! operator filters on it.
+//!
+//! Skips silently when `DATABASE_URL` is unset (runs in CI's
+//! `postgres_test` job).
+
+use std::ops::Bound;
+use std::sync::OnceLock;
+
+use rustango::core::Column as _;
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool, Range};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rng_event")]
+#[allow(dead_code)]
+pub struct Event {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub name: String,
+    pub seats: Range<i32>,
+    pub valid_on: Range<chrono::NaiveDate>,
+}
+
+async fn pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pg = sqlx::PgPool::connect(&url).await.ok()?;
+    Some(pg.into())
+}
+
+async fn fresh(pool: &Pool) {
+    let pg = pool.as_postgres().expect("postgres pool");
+    sqlx::query(r#"DROP TABLE IF EXISTS "rng_event" CASCADE"#)
+        .execute(pg)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "rng_event" (
+            "id"       BIGSERIAL PRIMARY KEY,
+            "name"     VARCHAR(80) NOT NULL,
+            "seats"    int4range NOT NULL,
+            "valid_on" daterange NOT NULL
+        )"#,
+    )
+    .execute(pg)
+    .await
+    .unwrap();
+}
+
+fn date(y: i32, m: u32, d: u32) -> chrono::NaiveDate {
+    chrono::NaiveDate::from_ymd_opt(y, m, d).unwrap()
+}
+
+async fn insert(
+    pool: &Pool,
+    name: &str,
+    seats: Range<i32>,
+    valid_on: Range<chrono::NaiveDate>,
+) -> i64 {
+    let mut e = Event {
+        id: Auto::default(),
+        name: name.to_owned(),
+        seats,
+        valid_on,
+    };
+    e.save_pool(pool).await.unwrap();
+    *e.id.get().unwrap()
+}
+
+#[tokio::test]
+async fn range_columns_round_trip() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let id = insert(
+        &pool,
+        "concert",
+        Range::closed_open(1, 100),
+        Range::closed_open(date(2025, 6, 1), date(2025, 6, 30)),
+    )
+    .await;
+
+    let row = Event::objects()
+        .filter("id", id)
+        .first(&pool)
+        .await
+        .unwrap()
+        .expect("row present");
+    assert_eq!(row.name, "concert");
+    // PG normalizes discrete ranges to the canonical `[lower, upper)` form.
+    assert_eq!(row.seats.lower, Bound::Included(1));
+    assert_eq!(row.seats.upper, Bound::Excluded(100));
+    assert_eq!(row.valid_on.lower, Bound::Included(date(2025, 6, 1)));
+    assert_eq!(row.valid_on.upper, Bound::Excluded(date(2025, 6, 30)));
+}
+
+#[tokio::test]
+async fn unbounded_upper_round_trips() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let id = insert(
+        &pool,
+        "open-ended",
+        Range::at_least(5),
+        Range::closed_open(date(2025, 1, 1), date(2026, 1, 1)),
+    )
+    .await;
+    let row = Event::objects()
+        .filter("id", id)
+        .first(&pool)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.seats.lower, Bound::Included(5));
+    assert_eq!(row.seats.upper, Bound::Unbounded);
+}
+
+#[tokio::test]
+async fn range_contains_operator_filters() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    insert(
+        &pool,
+        "small",
+        Range::closed_open(1, 10),
+        Range::closed_open(date(2025, 1, 1), date(2025, 2, 1)),
+    )
+    .await;
+    insert(
+        &pool,
+        "large",
+        Range::closed_open(50, 200),
+        Range::closed_open(date(2025, 1, 1), date(2025, 2, 1)),
+    )
+    .await;
+
+    // `seats @> int4range(5,6)` — only "small" contains seat 5.
+    let names: Vec<String> = Event::objects()
+        .where_(Event::seats.range_contains("[5,6)"))
+        .fetch_pool(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|e| e.name)
+        .collect();
+    assert_eq!(names, vec!["small"]);
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -23,7 +23,7 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 1. ORM — models / fields / Meta | 22 | 1 | 1 | 0 |
 | 2. QuerySet API | 38 | 1 | 1 | 0 |
 | 3. Field types & options | 32 | 0 | 2 | 1 |
-| 4. Postgres-specific fields | 3 | 0 | 2 | 0 |
+| 4. Postgres-specific fields | 4 | 0 | 1 | 0 |
 | 5. Migrations | 15 | 0 | 0 | 1 |
 | 6. Admin (ModelAdmin) | 35 | 1 | 0 | 1 |
 | 7. Forms / Formsets | 14 | 1 | 0 | 0 |
@@ -193,7 +193,7 @@ Summary: **32 SHIPPED / 0 PARTIAL / 2 MISSING / 1 N/A** in this section. Gaps cl
 | `JSONField` | (now built-in) | SHIPPED | See section 3 | |
 | `ArrayField` | [ArrayField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#arrayfield) | SHIPPED | `Array<T>` typed field wrapper (#341) — `Array<String>`/`Array<i32>`/`Array<i64>` map to `text[]`/`integer[]`/`bigint[]` DDL via `FieldType::Array(ArrayElem)`; INSERT binds a single-param PG array, SELECT decodes back to `Array<T>`; composes with the already-shipped `array_contains`/`array_contained_by`/`array_overlap` operators. PG-only by language semantics (degrades to `TEXT` + erroring decode on MySQL/SQLite, like trigram/FTS). See `crates/rustango/src/sql/array.rs` + `tests/array_field{,_pg_live}.rs`. | |
 | `HStoreField` | [HStoreField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#hstorefield) | MISSING | n/a (#342) | |
-| `RangeField` (Int / Date / DateTime / Decimal) | [RangeField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#range-fields) | MISSING | n/a — `SqlValue::RangeLiteral` exists but no typed field (#343) | |
+| `RangeField` (Int / Date / DateTime / Decimal) | [RangeField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#range-fields) | SHIPPED | `Range<T>` typed field wrapper (#343) — `Range<i32>`/`Range<i64>`/`Range<Decimal>`/`Range<NaiveDate>`/`Range<DateTime<Utc>>` map to `int4range`/`int8range`/`numrange`/`daterange`/`tstzrange` via `FieldType::Range(RangeElem)`; INSERT binds a `RangeLiteral` (`[lower,upper)`), SELECT decodes through sqlx `PgRange<T>`; composes with the shipped `range_contains`/`range_overlap`/… operators. PG-only by language semantics (degrades to `TEXT` on MySQL/SQLite). See `crates/rustango/src/sql/range.rs` + `tests/range_field{,_pg_live}.rs`. | |
 | `CITextField` | [CITextField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#citext-fields) | SHIPPED | `#[rustango(citext)]` (#344) — DDL emits `CITEXT` on PG (with `CREATE EXTENSION IF NOT EXISTS citext;` prelude available via `dialect.ci_text_extension_sql()`), `TEXT COLLATE NOCASE` on SQLite, `VARCHAR(N)/TEXT COLLATE utf8mb4_general_ci` on MySQL. Column-level case-insensitivity propagates to `=` / `LIKE` / `ORDER BY` without query-side `LOWER(...)` wrapping. | |
 
 Summary: **2 SHIPPED / 1 PARTIAL / 2 MISSING / 0 N/A**.
@@ -695,7 +695,7 @@ Summary: **22 SHIPPED / 0 PARTIAL / 1 MISSING / 0 N/A**.
 | `flatpages` | [flatpages](https://docs.djangoproject.com/en/6.0/ref/contrib/flatpages/) | SHIPPED | `flatpages::*` (v0.22) | |
 | `redirects` | [redirects](https://docs.djangoproject.com/en/6.0/ref/contrib/redirects/) | SHIPPED | `redirects::*` (v0.22) | |
 | `admindocs` | [admindocs](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/admindocs/) | N/A | Rust doc-comments + cargo doc | |
-| `postgres` (ArrayField, JSONField, RangeField, HStoreField, CITextField) | (sec 4) | PARTIAL | JSONField + CITextField shipped (#344); ArrayField shipped via `Array<T>` typed field (#341); Range partial via `RangeLiteral` (no typed field wrapper yet, #343); HStore MISSING (#442) | |
+| `postgres` (ArrayField, JSONField, RangeField, HStoreField, CITextField) | (sec 4) | PARTIAL | JSONField + CITextField shipped (#344); ArrayField shipped via `Array<T>` (#341); RangeField shipped via `Range<T>` (#343); HStore MISSING (#442) | |
 | `gis` (GeoDjango) | [gis](https://docs.djangoproject.com/en/6.0/ref/contrib/gis/) | MISSING | [#58](https://github.com/ujeenet/rustango/issues/58) | |
 | `gis.geos` (geometry types) | (above) | MISSING | (above) (#443) | |
 | `gis.gdal` (raster) | (above) | MISSING | (above) (#444) | |


### PR DESCRIPTION
## What

Closes #343. Django's `RangeField` family — a typed model-field wrapper for native PostgreSQL range columns. Mirrors the `Array<T>` design (#341).

```rust
struct Event {
    seats: Range<i32>,                      // → int4range
    during: Range<chrono::DateTime<Utc>>,   // → tstzrange
}

let e = Event { seats: (1..100).into(), during: Range::closed_open(start, end), .. };

// composes with the existing range operators
Event::objects().where_(Event::seats.range_contains("[5,6)")).fetch_pool(&pool).await?;
```

| Rust field | PG column | Django |
|---|---|---|
| `Range<i32>` | `int4range` | `IntegerRangeField` |
| `Range<i64>` | `int8range` | `BigIntegerRangeField` |
| `Range<rust_decimal::Decimal>` | `numrange` | `DecimalRangeField` |
| `Range<chrono::NaiveDate>` | `daterange` | `DateRangeField` |
| `Range<chrono::DateTime<Utc>>` | `tstzrange` | `DateTimeRangeField` |

## The gap (audit said MISSING)

`SqlValue::RangeLiteral` + `range_contains`/`range_overlap`/… operators already shipped at the value layer; the **typed field wrapper** was missing. This adds it.

## Design (same pattern as #341 ArrayField)

- **`sql/range.rs`** — `Range<T>` newtype (`lower`/`upper`: `Bound<T>`) with ergonomic ctors + `From<a..b>` + serde + `Into<SqlValue::RangeLiteral>`. Carries **total** sqlx `Type`+`Decode` for all backends: real on Postgres (delegates to sqlx's `PgRange<T>`), erroring stubs on MySQL/SQLite — so `#[derive(Model)]`'s single shared `FromRow` body compiles on every backend.
- **`FieldType::Range(RangeElem)`** — one `Copy` sub-enum → one arm per `match FieldType` site.
- **PG-only by language semantics**: DDL emits the range type on PG; MySQL/SQLite degrade to `TEXT` and the bind/decode paths error there. Litmus build still compiles.
- INSERT binds a range literal (`[lower,upper)`, `[5,)`, `(,10)`) — PG implicit-casts; SELECT decodes via `PgRange<T>` → `Range<T>` bounds.

Wired through every `FieldType` consumer (snapshot round-trip + diff, row_to_json, admin render/widget, forms parse, fixtures, OpenAPI, label).

## Tests

- `tests/range_field.rs` — 6 unit: schema maps to `FieldType::Range`, PG column/cast types (`int4range`/…/`tstzrange`), MySQL/SQLite degrade to TEXT, literal serialization.
- `tests/range_field_pg_live.rs` — 3 live (verified against real PostgreSQL): insert→fetch round-trip incl. PG discrete-range canonicalization, unbounded-upper, `@>` containment filter.

## Gates

- ✅ Litmus `cargo build --no-default-features --features sqlite,tenancy`
- ✅ `cargo test --workspace --all-features --no-run` compiles
- ✅ 3175 lib tests pass
- ✅ Audit row #343 MISSING → SHIPPED

Closes #343.