### PR TITLE
feat(orm): HStoreField — HStore typed PostgreSQL hstore column (closes #342)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -10851,6 +10851,8 @@ enum DetectedKind {
     RangeDate,
     /// `Range<DateTime<Utc>>` → PG `tstzrange` (#343).
     RangeDateTime,
+    /// `HStore` → PG `hstore` (#342).
+    HStore,
 }
 
 impl DetectedKind {
@@ -10895,6 +10897,7 @@ impl DetectedKind {
             Self::RangeDateTime => {
                 quote!(#root::core::FieldType::Range(#root::core::RangeElem::DateTime))
             }
+            Self::HStore => quote!(#root::core::FieldType::HStore),
         }
     }
 
@@ -10950,6 +10953,8 @@ impl DetectedKind {
             | Self::RangeNumeric
             | Self::RangeDate
             | Self::RangeDateTime => (quote!(RangeLiteral), quote!(::std::string::String::new())),
+            // HStore (#342) can't be a FK PK — never reached.
+            Self::HStore => (quote!(HStore), quote!(::std::vec::Vec::new())),
         }
     }
 }
@@ -11170,6 +11175,16 @@ fn detect_type(ty: &syn::Type) -> syn::Result<DetectedType<'_>> {
             };
             return Ok(DetectedType {
                 kind,
+                nullable: false,
+                auto: false,
+                fk_inner: None,
+            });
+        }
+        // `HStore` → PG `hstore` (Django `HStoreField`, #342). No generic
+        // parameter — always a string→string map.
+        "HStore" => {
+            return Ok(DetectedType {
+                kind: DetectedKind::HStore,
                 nullable: false,
                 auto: false,
                 fk_inner: None,

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -123,6 +123,8 @@ pub(crate) fn render_value_for_input_json(row: &serde_json::Value, field: &Field
         FieldType::Array(_) => v.to_string(),
         // #343 — PG range: literal string (or compact JSON fallback).
         FieldType::Range(_) => v.as_str().map_or_else(|| v.to_string(), str::to_owned),
+        // #342 — PG hstore: compact JSON object form.
+        FieldType::HStore => v.to_string(),
     }
 }
 
@@ -342,6 +344,10 @@ fn render_input_default(field: &FieldSchema, value: &str, pk_locked: bool) -> St
         FieldType::Range(_) => format!(
             r#"<input type="text" name="{name}" id="{name}" value="{val}" placeholder="[lower,upper)"{required}{readonly}>"#
         ),
+        // #342 — PG hstore: a JSON-object text input (`{{"k":"v"}}`).
+        FieldType::HStore => format!(
+            r#"<input type="text" name="{name}" id="{name}" value="{val}" placeholder="{{&quot;key&quot;: &quot;value&quot;}}"{required}{readonly}>"#
+        ),
     }
 }
 
@@ -517,6 +523,10 @@ pub(crate) fn render_value_json(row: &serde_json::Value, field: &FieldSchema) ->
             .unwrap_or_default(),
         // #343 — PG range: literal string in the list cell.
         FieldType::Range(_) => escape(v.as_str().unwrap_or("")),
+        // #342 — PG hstore: compact JSON object in the list cell.
+        FieldType::HStore => serde_json::to_string(v)
+            .map(|s| escape(&s))
+            .unwrap_or_default(),
     }
 }
 
@@ -591,6 +601,8 @@ pub(crate) fn read_joined_value_as_html_json(
         FieldType::Array(_) => None,
         // #343 — ranges aren't a meaningful select_related join target.
         FieldType::Range(_) => None,
+        // #342 — hstore isn't a meaningful select_related join target.
+        FieldType::HStore => None,
     };
     text.map(|s| escape(&s))
 }

--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -1275,6 +1275,9 @@ fn bind_value_pg(
         SqlValue::RangeLiteral(_) => {
             unreachable!("RangeLiteral values never reach audited-save bind path")
         }
+        SqlValue::HStore(_) => {
+            unreachable!("HStore values never reach audited-save bind path")
+        }
     }
 }
 
@@ -1305,6 +1308,9 @@ fn bind_value_my(
         SqlValue::Array(_) => unreachable!("Array values never reach audited-save bind path"),
         SqlValue::RangeLiteral(_) => {
             unreachable!("RangeLiteral values never reach audited-save bind path")
+        }
+        SqlValue::HStore(_) => {
+            unreachable!("HStore values never reach audited-save bind path")
         }
     }
 }
@@ -1338,6 +1344,9 @@ fn bind_value_sqlite<'q>(
         SqlValue::Array(_) => unreachable!("Array values never reach audited-save bind path"),
         SqlValue::RangeLiteral(_) => {
             unreachable!("RangeLiteral values never reach audited-save bind path")
+        }
+        SqlValue::HStore(_) => {
+            unreachable!("HStore values never reach audited-save bind path")
         }
     }
 }

--- a/crates/rustango/src/core/field_type.rs
+++ b/crates/rustango/src/core/field_type.rs
@@ -55,6 +55,12 @@ pub enum FieldType {
     /// [`Self::Array`]: MySQL / SQLite degrade to `TEXT` and the decode
     /// path errors there.
     Range(RangeElem),
+    /// Native PostgreSQL `hstore` — Django's `HStoreField` (#342). A flat
+    /// string→string map. Rust type: [`crate::sql::HStore`]. **PG-only by
+    /// language semantics** like [`Self::Array`] / [`Self::Range`]; MySQL
+    /// / SQLite degrade to `TEXT` and the decode path errors there.
+    /// Requires the `hstore` extension on the database.
+    HStore,
 }
 
 /// Element type of a [`FieldType::Range`] column (#343). Selects the
@@ -144,6 +150,7 @@ impl FieldType {
             Self::Range(RangeElem::Numeric) => "Range<Decimal>",
             Self::Range(RangeElem::Date) => "Range<NaiveDate>",
             Self::Range(RangeElem::DateTime) => "Range<DateTime<Utc>>",
+            Self::HStore => "HStore",
         }
     }
 }

--- a/crates/rustango/src/core/validate.rs
+++ b/crates/rustango/src/core/validate.rs
@@ -46,7 +46,8 @@ pub fn validate_value(
         | SqlValue::Uuid(_)
         | SqlValue::Json(_)
         | SqlValue::Decimal(_)
-        | SqlValue::Binary(_) => Ok(()),
+        | SqlValue::Binary(_)
+        | SqlValue::HStore(_) => Ok(()),
     }
 }
 

--- a/crates/rustango/src/core/value.rs
+++ b/crates/rustango/src/core/value.rs
@@ -70,6 +70,13 @@ pub enum SqlValue {
     /// shape (sticking to the same "PG handles the cast" pattern as
     /// our other text-bound types like Json).
     RangeLiteral(String),
+    /// PG `hstore` map — a flat list of `(key, value)` pairs where the
+    /// value is nullable (`"k" => NULL`). Issue #342. Backend-neutral at
+    /// this layer (a `Vec` of pairs); the PG bind path reconstructs a
+    /// native `sqlx::postgres::types::PgHstore`, MySQL / SQLite reject
+    /// (no `hstore` type). Built from [`crate::sql::HStore`] via
+    /// `Into<SqlValue>`.
+    HStore(Vec<(String, Option<String>)>),
 }
 
 impl SqlValue {
@@ -106,6 +113,16 @@ impl SqlValue {
                 format!("array[{}]", inner.join(", "))
             }
             Self::RangeLiteral(s) => format!("range{s}"),
+            Self::HStore(pairs) => {
+                let inner: Vec<String> = pairs
+                    .iter()
+                    .map(|(k, v)| match v {
+                        Some(v) => format!("{k}=>{v}"),
+                        None => format!("{k}=>NULL"),
+                    })
+                    .collect();
+                format!("hstore{{{}}}", inner.join(", "))
+            }
         }
     }
 
@@ -113,7 +130,11 @@ impl SqlValue {
     #[must_use]
     pub fn field_type(&self) -> Option<FieldType> {
         Some(match self {
-            Self::Null | Self::List(_) | Self::Array(_) | Self::RangeLiteral(_) => return None,
+            Self::Null
+            | Self::List(_)
+            | Self::Array(_)
+            | Self::RangeLiteral(_)
+            | Self::HStore(_) => return None,
             Self::I16(_) => FieldType::I16,
             Self::I32(_) => FieldType::I32,
             Self::I64(_) => FieldType::I64,

--- a/crates/rustango/src/forms/mod.rs
+++ b/crates/rustango/src/forms/mod.rs
@@ -239,9 +239,10 @@ pub fn parse_pk_string(field: &FieldSchema, raw: &str) -> Result<SqlValue, FormE
         | FieldType::Json
         | FieldType::Decimal
         | FieldType::Binary
-        // #341 / #343 — an array or range can't be a primary key.
+        // #341 / #343 / #342 — array / range / hstore can't be a PK.
         | FieldType::Array(_)
-        | FieldType::Range(_) => Err(FormError::UnsupportedPk {
+        | FieldType::Range(_)
+        | FieldType::HStore => Err(FormError::UnsupportedPk {
             field: field.name.to_owned(),
             ty: field.ty.as_str(),
         }),
@@ -410,6 +411,13 @@ pub fn parse_form_value(field: &FieldSchema, raw: Option<&str>) -> Result<SqlVal
         // #343 — PG range column from a form field: the raw input is a
         // range literal (`[1,10)`), bound as-is and implicit-cast by PG.
         FieldType::Range(_) => Ok(SqlValue::RangeLiteral(raw.to_owned())),
+        // #342 — PG hstore column from a form field: a JSON object
+        // (`{"k":"v"}`, null values allowed) parsed into key→value pairs.
+        FieldType::HStore => {
+            let map: std::collections::BTreeMap<String, Option<String>> = serde_json::from_str(raw)
+                .map_err(|e| make_parse_err("hstore (JSON object)", &e))?;
+            Ok(SqlValue::HStore(map.into_iter().collect()))
+        }
     }
 }
 

--- a/crates/rustango/src/migrate/diff.rs
+++ b/crates/rustango/src/migrate/diff.rs
@@ -1207,6 +1207,8 @@ fn pg_type_for_ty_name(ty: &str) -> String {
         "range_numeric" => "numrange".into(),
         "range_date" => "daterange".into(),
         "range_datetime" => "tstzrange".into(),
+        // #342 — PG hstore.
+        "hstore" => "hstore".into(),
         other => other.to_uppercase(),
     }
 }
@@ -1441,6 +1443,8 @@ fn sql_type_with_dialect(f: &FieldSnapshot, dialect: &dyn crate::sql::Dialect) -
         "range_numeric" => Some(FieldType::Range(crate::core::RangeElem::Numeric)),
         "range_date" => Some(FieldType::Range(crate::core::RangeElem::Date)),
         "range_datetime" => Some(FieldType::Range(crate::core::RangeElem::DateTime)),
+        // #342 — PG hstore.
+        "hstore" => Some(FieldType::HStore),
         _ => None,
     };
     // v0.13.2: `auto = true` historically meant "PK SERIAL/BIGSERIAL"

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -2988,6 +2988,22 @@ fn json_to_sql_value(
             .as_str()
             .map(|s| SqlValue::RangeLiteral(s.to_owned()))
             .ok_or_else(|| format!("expected range-literal string for Range column, got {v}")),
+        // #342 — PG hstore column from a fixture: a JSON object whose
+        // values are strings or null.
+        FieldType::HStore => {
+            let obj = v
+                .as_object()
+                .ok_or_else(|| format!("expected JSON object for HStore column, got {v}"))?;
+            let pairs = obj
+                .iter()
+                .map(|(k, val)| match val {
+                    serde_json::Value::String(s) => Ok((k.clone(), Some(s.clone()))),
+                    serde_json::Value::Null => Ok((k.clone(), None)),
+                    other => Err(format!("hstore value must be string or null, got {other}")),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(SqlValue::HStore(pairs))
+        }
     }
 }
 

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -526,6 +526,8 @@ pub(crate) fn field_type_name(ty: FieldType) -> &'static str {
         FieldType::Range(crate::core::RangeElem::Numeric) => "range_numeric",
         FieldType::Range(crate::core::RangeElem::Date) => "range_date",
         FieldType::Range(crate::core::RangeElem::DateTime) => "range_datetime",
+        // #342 — PG hstore.
+        FieldType::HStore => "hstore",
     }
 }
 

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -362,6 +362,8 @@ pub trait Dialect {
             FieldType::Range(crate::core::RangeElem::Numeric) => "numrange",
             FieldType::Range(crate::core::RangeElem::Date) => "daterange",
             FieldType::Range(crate::core::RangeElem::DateTime) => "tstzrange",
+            // PG hstore CAST target (#342).
+            FieldType::HStore => "hstore",
         })
     }
 
@@ -402,6 +404,9 @@ pub trait Dialect {
             FieldType::Array(elem) => format!("{}[]", elem.pg_element_type()),
             // Native PG range column (#343).
             FieldType::Range(elem) => elem.pg_range_type().to_owned(),
+            // Native PG hstore column (#342). Requires the `hstore`
+            // extension on the database.
+            FieldType::HStore => "hstore".into(),
         }
     }
 

--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -729,6 +729,11 @@ macro_rules! bind_match {
             // PG range literal — text-bound, implicit-cast by PG to
             // the column's range type. Issue #31.
             SqlValue::RangeLiteral(s) => $q.bind(s),
+            // PG hstore — bind as a native `PgHstore` (issue #342). No
+            // text-literal escaping; sqlx encodes the map directly.
+            SqlValue::HStore(pairs) => {
+                $q.bind(sqlx::postgres::types::PgHstore(pairs.into_iter().collect()))
+            }
             // PG single-parameter array (issue #30). v1 supports
             // I32/I64/String/Bool elements; other element kinds
             // panic at bind time. Homogeneous-element arrays are
@@ -810,6 +815,9 @@ macro_rules! bind_match_mysql {
             SqlValue::RangeLiteral(_) => unreachable!(
                 "MySQL has no range type; `write_range_op` rejects before bind. Issue #31."
             ),
+            SqlValue::HStore(_) => {
+                unreachable!("MySQL has no hstore type; `HStore` columns are PG-only. Issue #342.")
+            }
         }
     };
 }
@@ -851,6 +859,9 @@ macro_rules! bind_match_sqlite {
             SqlValue::RangeLiteral(_) => unreachable!(
                 "SQLite has no range type; `write_range_op` rejects before bind. Issue #31."
             ),
+            SqlValue::HStore(_) => {
+                unreachable!("SQLite has no hstore type; `HStore` columns are PG-only. Issue #342.")
+            }
         }
     };
 }

--- a/crates/rustango/src/sql/executor/row_to_json.rs
+++ b/crates/rustango/src/sql/executor/row_to_json.rs
@@ -142,6 +142,8 @@ where
             // #343 — PG range columns. Same story as arrays: no generic
             // `Range<T>: Decode` bound on this path; typed fetch decodes.
             FieldType::Range(_) => Value::Null,
+            // #342 — PG hstore columns; same generic-decode story.
+            FieldType::HStore => Value::Null,
         };
         map.insert(field.name.to_owned(), value);
     }
@@ -281,6 +283,8 @@ pub fn row_to_json_sqlite(
             FieldType::Array(_) => Value::Null,
             // #343 — ranges are PG-only; never present on SQLite.
             FieldType::Range(_) => Value::Null,
+            // #342 — hstore is PG-only; never present on SQLite.
+            FieldType::HStore => Value::Null,
         };
         map.insert(field.name.to_owned(), value);
     }

--- a/crates/rustango/src/sql/hstore.rs
+++ b/crates/rustango/src/sql/hstore.rs
@@ -1,0 +1,235 @@
+//! `HStore` — typed PostgreSQL `hstore` (string→string map) column
+//! wrapper (Django's `HStoreField`, issue #342).
+//!
+//! Declare an `hstore` column on a model:
+//!
+//! ```ignore
+//! use rustango::sql::{Auto, HStore};
+//!
+//! #[derive(Model)]
+//! #[rustango(table = "product")]
+//! struct Product {
+//!     #[rustango(primary_key)]
+//!     id: Auto<i64>,
+//!     // → DDL `attrs hstore`; round-trips as a string→string map.
+//!     attrs: HStore,
+//! }
+//!
+//! let p = Product {
+//!     id: Auto::default(),
+//!     attrs: HStore::from_iter([("color", "red"), ("size", "L")]),
+//! };
+//! ```
+//!
+//! `hstore` stores a flat map of text keys to **nullable** text values
+//! (`"k" => NULL` is valid), so the inner type is
+//! `BTreeMap<String, Option<String>>` — matching sqlx's
+//! [`sqlx::postgres::types::PgHstore`], which `HStore` round-trips
+//! through. The migration writer emits the `hstore` column type and the
+//! values bind / decode as a native hstore (no text-literal escaping).
+//!
+//! ## Requires the `hstore` extension
+//!
+//! `hstore` is a Postgres contrib type — the database must have
+//! `CREATE EXTENSION hstore` applied before an `hstore` column can be
+//! created or queried.
+//!
+//! ## PostgreSQL only, by language semantics
+//!
+//! MySQL and SQLite have no `hstore` equivalent. Like
+//! [`Array`](crate::sql::Array) / [`Range`](crate::sql::Range), `HStore`
+//! is **PG-only by language semantics**: the migration writer degrades to
+//! `TEXT` on MySQL / SQLite and the bind / decode paths error there. The
+//! type still *compiles* under every backend (the per-backend
+//! [`sqlx::Type`] / [`sqlx::Decode`] impls are total) so the
+//! `sqlite,tenancy` litmus build keeps passing.
+
+use std::collections::BTreeMap;
+use std::ops::{Deref, DerefMut};
+
+/// Typed PostgreSQL `hstore` column — see the [module docs](self).
+///
+/// Transparent newtype over `BTreeMap<String, Option<String>>`:
+/// `Deref`s to the inner map and (de)serializes as a JSON object.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct HStore(pub BTreeMap<String, Option<String>>);
+
+impl HStore {
+    /// Empty map.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    /// Consume the wrapper, returning the inner map.
+    #[must_use]
+    pub fn into_inner(self) -> BTreeMap<String, Option<String>> {
+        self.0
+    }
+}
+
+impl Deref for HStore {
+    type Target = BTreeMap<String, Option<String>>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for HStore {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<BTreeMap<String, Option<String>>> for HStore {
+    fn from(m: BTreeMap<String, Option<String>>) -> Self {
+        Self(m)
+    }
+}
+
+impl From<BTreeMap<String, String>> for HStore {
+    fn from(m: BTreeMap<String, String>) -> Self {
+        Self(m.into_iter().map(|(k, v)| (k, Some(v))).collect())
+    }
+}
+
+/// `from_iter([("k", "v"), …])` — convenience for all-present (non-NULL)
+/// values. Keys/values can be anything `Into<String>` (e.g. `&str`).
+impl<K: Into<String>, V: Into<String>> FromIterator<(K, V)> for HStore {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        Self(
+            iter.into_iter()
+                .map(|(k, v)| (k.into(), Some(v.into())))
+                .collect(),
+        )
+    }
+}
+
+// ---- serde: a JSON object (`null` values allowed) ----
+
+impl serde::Serialize for HStore {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for HStore {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        BTreeMap::<String, Option<String>>::deserialize(deserializer).map(Self)
+    }
+}
+
+// ---- `HStore` → `SqlValue` (INSERT / UPDATE bind) ----
+//
+// Lowers to the backend-neutral `SqlValue::HStore` pair list; the PG
+// bind path reconstructs a native `PgHstore` (no text-literal escaping).
+
+impl From<HStore> for crate::core::SqlValue {
+    fn from(h: HStore) -> Self {
+        crate::core::SqlValue::HStore(h.0.into_iter().collect())
+    }
+}
+
+// ---- sqlx Type + Decode (FromRow read path) ----
+//
+// Postgres: delegate to sqlx's `PgHstore`. MySQL / SQLite: total stubs so
+// the shared `FromRow` body compiles — `Type` borrows a placeholder
+// type-info, `Decode` errors at runtime. Encode is intentionally NOT
+// implemented: the bind path goes through `SqlValue::HStore`.
+
+#[cfg(feature = "postgres")]
+impl<'r> sqlx::Decode<'r, sqlx::Postgres> for HStore {
+    fn decode(
+        value: <sqlx::Postgres as sqlx::Database>::ValueRef<'r>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        let pg =
+            <sqlx::postgres::types::PgHstore as sqlx::Decode<'r, sqlx::Postgres>>::decode(value)?;
+        Ok(Self(pg.0))
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl sqlx::Type<sqlx::Postgres> for HStore {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        <sqlx::postgres::types::PgHstore as sqlx::Type<sqlx::Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+        <sqlx::postgres::types::PgHstore as sqlx::Type<sqlx::Postgres>>::compatible(ty)
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl<'r> sqlx::Decode<'r, sqlx::MySql> for HStore {
+    fn decode(
+        _value: <sqlx::MySql as sqlx::Database>::ValueRef<'r>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        Err("`HStore` columns are PostgreSQL-only; cannot decode on MySQL (issue #342)".into())
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl sqlx::Type<sqlx::MySql> for HStore {
+    fn type_info() -> sqlx::mysql::MySqlTypeInfo {
+        <String as sqlx::Type<sqlx::MySql>>::type_info()
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'r> sqlx::Decode<'r, sqlx::Sqlite> for HStore {
+    fn decode(
+        _value: <sqlx::Sqlite as sqlx::Database>::ValueRef<'r>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        Err("`HStore` columns are PostgreSQL-only; cannot decode on SQLite (issue #342)".into())
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl sqlx::Type<sqlx::Sqlite> for HStore {
+    fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
+        <String as sqlx::Type<sqlx::Sqlite>>::type_info()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::SqlValue;
+
+    #[test]
+    fn from_iter_and_deref() {
+        let h = HStore::from_iter([("color", "red"), ("size", "L")]);
+        assert_eq!(h.len(), 2);
+        assert_eq!(h.get("color"), Some(&Some("red".to_owned())));
+    }
+
+    #[test]
+    fn into_sqlvalue_hstore() {
+        let v: SqlValue = HStore::from_iter([("k", "v")]).into();
+        match v {
+            SqlValue::HStore(pairs) => {
+                assert_eq!(pairs, vec![("k".to_owned(), Some("v".to_owned()))]);
+            }
+            other => panic!("expected SqlValue::HStore, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn serde_round_trips_as_object() {
+        let h = HStore::from_iter([("a", "1")]);
+        let json = serde_json::to_string(&h).unwrap();
+        assert_eq!(json, r#"{"a":"1"}"#);
+        let back: HStore = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, h);
+    }
+
+    #[test]
+    fn null_value_round_trips_through_serde() {
+        let mut h = HStore::new();
+        h.insert("present".to_owned(), Some("yes".to_owned()));
+        h.insert("absent".to_owned(), None);
+        let json = serde_json::to_string(&h).unwrap();
+        let back: HStore = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, h);
+    }
+}

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -14,6 +14,7 @@ mod dialect;
 mod error;
 mod executor;
 mod foreign_key;
+mod hstore;
 pub mod m2m;
 #[doc(hidden)]
 pub mod model_shortcuts;
@@ -35,6 +36,7 @@ pub use backend::{
 pub use compiled::CompiledStatement;
 pub use dialect::Dialect;
 pub use error::{is_mysql_dup_index_error, ExecError, SqlError};
+pub use hstore::HStore;
 pub use range::Range;
 // Always-on: tri-dialect entry points + traits that don't pin on PG.
 #[cfg(feature = "mysql")]

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -144,9 +144,11 @@ impl Dialect for MySql {
             // target either (it's CHAR(36) in DDL but the user would
             // cast to CHAR in expression form). Arrays (#341) / ranges
             // (#343) are PG-only by language — no MySQL CAST target.
-            FieldType::Uuid | FieldType::Json | FieldType::Array(_) | FieldType::Range(_) => {
-                return None
-            }
+            FieldType::Uuid
+            | FieldType::Json
+            | FieldType::Array(_)
+            | FieldType::Range(_)
+            | FieldType::HStore => return None,
         })
     }
 
@@ -198,6 +200,8 @@ impl Dialect for MySql {
             FieldType::Array(_) => "TEXT".into(),
             // Ditto for PG range columns (#343).
             FieldType::Range(_) => "TEXT".into(),
+            // Ditto for PG hstore columns (#342).
+            FieldType::HStore => "TEXT".into(),
         }
     }
 

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -189,6 +189,8 @@ impl Dialect for Sqlite {
             FieldType::Array(_) => "TEXT",
             // Ditto for PG range columns (#343).
             FieldType::Range(_) => "TEXT",
+            // Ditto for PG hstore columns (#342).
+            FieldType::HStore => "TEXT",
         })
     }
 
@@ -217,6 +219,8 @@ impl Dialect for Sqlite {
             FieldType::Array(_) => "TEXT".into(),
             // Ditto for PG range columns (#343).
             FieldType::Range(_) => "TEXT".into(),
+            // Ditto for PG hstore columns (#342).
+            FieldType::HStore => "TEXT".into(),
         }
     }
 

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -1517,6 +1517,8 @@ fn field_type_label(ty: crate::core::FieldType) -> &'static str {
         T::Array(_) => "array",
         // #343 — PG range columns.
         T::Range(_) => "range",
+        // #342 — PG hstore columns.
+        T::HStore => "hstore",
     }
 }
 

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -276,6 +276,13 @@ fn field_type_to_schema(t: FieldType) -> Schema {
         // #343 — PG range column: serialized as a range-literal string
         // (`"[1,10)"`), so a `string` schema is the honest shape.
         FieldType::Range(_) => Schema::string(),
+        // #342 — PG hstore: a string→string map → `object` with
+        // string-typed additionalProperties.
+        FieldType::HStore => Schema {
+            type_: Some("object".into()),
+            additional_properties: Some(Box::new(Schema::string())),
+            ..Default::default()
+        },
     }
 }
 

--- a/crates/rustango/tests/hstore_field.rs
+++ b/crates/rustango/tests/hstore_field.rs
@@ -1,0 +1,78 @@
+//! Unit coverage for `HStore` PostgreSQL hstore columns — Django
+//! `HStoreField` (#342). No database required: asserts the derived
+//! schema's `FieldType::HStore` mapping, the per-dialect column-type
+//! emission (`hstore` on PG; degraded `TEXT` on MySQL / SQLite), and the
+//! `Into<SqlValue>` lowering.
+
+use rustango::core::{FieldType, Model as _, SqlValue};
+use rustango::sql::{Dialect, HStore, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "hs_product")]
+#[allow(dead_code)]
+pub struct Product {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 80)]
+    name: String,
+    attrs: HStore,
+}
+
+fn field(name: &str) -> &'static rustango::core::FieldSchema {
+    Product::SCHEMA
+        .fields
+        .iter()
+        .find(|f| f.name == name)
+        .unwrap_or_else(|| panic!("no field {name}"))
+}
+
+#[test]
+fn derive_maps_hstore_field_to_hstore_field_type() {
+    assert_eq!(field("attrs").ty, FieldType::HStore);
+    assert_eq!(field("name").ty, FieldType::String);
+}
+
+#[test]
+fn postgres_column_type_is_hstore() {
+    assert_eq!(Postgres.column_type(field("attrs").ty, None), "hstore");
+    assert_eq!(Postgres.cast_type(FieldType::HStore), Some("hstore"));
+}
+
+#[test]
+fn non_pg_dialects_degrade_to_text() {
+    assert_eq!(MySql.column_type(FieldType::HStore, None), "TEXT");
+    assert_eq!(Sqlite.column_type(FieldType::HStore, None), "TEXT");
+    assert_eq!(MySql.cast_type(FieldType::HStore), None);
+}
+
+#[test]
+fn hstore_into_sqlvalue_is_pair_list() {
+    let v: SqlValue = HStore::from_iter([("color", "red")]).into();
+    match v {
+        SqlValue::HStore(pairs) => {
+            assert_eq!(pairs, vec![("color".to_owned(), Some("red".to_owned()))]);
+        }
+        other => panic!("expected SqlValue::HStore, got {other:?}"),
+    }
+}
+
+#[test]
+fn hstore_column_is_bound_as_a_single_param() {
+    // hstore binds natively (no text-literal cast gymnastics) — the
+    // INSERT just emits a plain placeholder for the column.
+    use rustango::core::InsertQuery;
+    let q = InsertQuery {
+        model: Product::SCHEMA,
+        columns: vec!["attrs"],
+        values: vec![SqlValue::HStore(vec![(
+            "k".to_owned(),
+            Some("v".to_owned()),
+        )])],
+        returning: vec![],
+        on_conflict: None,
+    };
+    let stmt = Postgres.compile_insert(&q).unwrap();
+    assert!(stmt.sql.contains("VALUES ($1)"), "sql: {}", stmt.sql);
+    assert!(matches!(&stmt.params[0], SqlValue::HStore(_)));
+}

--- a/crates/rustango/tests/hstore_field_pg_live.rs
+++ b/crates/rustango/tests/hstore_field_pg_live.rs
@@ -1,0 +1,144 @@
+#![cfg(feature = "postgres")]
+//! Live PostgreSQL round-trip for `HStore` columns — Django
+//! `HStoreField` (#342). Proves the typed field wrapper writes a native
+//! `hstore` (no text-literal escaping) on INSERT and decodes it back
+//! into `HStore` on SELECT.
+//!
+//! Skips silently when `DATABASE_URL` is unset OR the `hstore` extension
+//! can't be created (e.g. the test role lacks the privilege). Runs in
+//! CI's `postgres_test` job, where the role can `CREATE EXTENSION`.
+
+use std::sync::OnceLock;
+
+use rustango::sql::{sqlx, Auto, FetcherPool as _, HStore, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn live_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "hs_product")]
+#[allow(dead_code)]
+pub struct Product {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub name: String,
+    pub attrs: HStore,
+}
+
+/// Connect + ensure the `hstore` extension exists. Returns `None` (skip)
+/// when `DATABASE_URL` is unset or the extension can't be created.
+async fn pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pg = sqlx::PgPool::connect(&url).await.ok()?;
+    sqlx::query("CREATE EXTENSION IF NOT EXISTS hstore")
+        .execute(&pg)
+        .await
+        .ok()?;
+    Some(pg.into())
+}
+
+async fn fresh(pool: &Pool) {
+    let pg = pool.as_postgres().expect("postgres pool");
+    sqlx::query(r#"DROP TABLE IF EXISTS "hs_product" CASCADE"#)
+        .execute(pg)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "hs_product" (
+            "id"    BIGSERIAL PRIMARY KEY,
+            "name"  VARCHAR(80) NOT NULL,
+            "attrs" hstore NOT NULL DEFAULT ''
+        )"#,
+    )
+    .execute(pg)
+    .await
+    .unwrap();
+}
+
+async fn insert(pool: &Pool, name: &str, attrs: HStore) -> i64 {
+    let mut p = Product {
+        id: Auto::default(),
+        name: name.to_owned(),
+        attrs,
+    };
+    p.save_pool(pool).await.unwrap();
+    *p.id.get().unwrap()
+}
+
+#[tokio::test]
+async fn hstore_round_trips() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let id = insert(
+        &pool,
+        "widget",
+        HStore::from_iter([("color", "red"), ("size", "L")]),
+    )
+    .await;
+
+    let row = Product::objects()
+        .filter("id", id)
+        .first(&pool)
+        .await
+        .unwrap()
+        .expect("row present");
+    assert_eq!(row.name, "widget");
+    assert_eq!(row.attrs.get("color"), Some(&Some("red".to_owned())));
+    assert_eq!(row.attrs.get("size"), Some(&Some("L".to_owned())));
+    assert_eq!(row.attrs.len(), 2);
+}
+
+#[tokio::test]
+async fn hstore_null_value_and_special_chars_round_trip() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let mut attrs = HStore::new();
+    attrs.insert("note".to_owned(), Some("a => b, \"quoted\"".to_owned()));
+    attrs.insert("missing".to_owned(), None);
+    let id = insert(&pool, "tricky", attrs).await;
+
+    let row = Product::objects()
+        .filter("id", id)
+        .first(&pool)
+        .await
+        .unwrap()
+        .unwrap();
+    // Native bind/decode handles `=>`, commas, and quotes in values
+    // without any text-literal escaping on our side.
+    assert_eq!(
+        row.attrs.get("note"),
+        Some(&Some("a => b, \"quoted\"".to_owned()))
+    );
+    assert_eq!(row.attrs.get("missing"), Some(&None));
+}
+
+#[tokio::test]
+async fn empty_hstore_round_trips() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    fresh(&pool).await;
+
+    let id = insert(&pool, "blank", HStore::new()).await;
+    let row = Product::objects()
+        .filter("id", id)
+        .first(&pool)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(row.attrs.is_empty());
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -23,7 +23,7 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 1. ORM — models / fields / Meta | 22 | 1 | 1 | 0 |
 | 2. QuerySet API | 38 | 1 | 1 | 0 |
 | 3. Field types & options | 32 | 0 | 2 | 1 |
-| 4. Postgres-specific fields | 4 | 0 | 1 | 0 |
+| 4. Postgres-specific fields | 5 | 0 | 0 | 0 |
 | 5. Migrations | 15 | 0 | 0 | 1 |
 | 6. Admin (ModelAdmin) | 35 | 1 | 0 | 1 |
 | 7. Forms / Formsets | 14 | 1 | 0 | 0 |
@@ -192,7 +192,7 @@ Summary: **32 SHIPPED / 0 PARTIAL / 2 MISSING / 1 N/A** in this section. Gaps cl
 |---|---|---|---|---|
 | `JSONField` | (now built-in) | SHIPPED | See section 3 | |
 | `ArrayField` | [ArrayField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#arrayfield) | SHIPPED | `Array<T>` typed field wrapper (#341) — `Array<String>`/`Array<i32>`/`Array<i64>` map to `text[]`/`integer[]`/`bigint[]` DDL via `FieldType::Array(ArrayElem)`; INSERT binds a single-param PG array, SELECT decodes back to `Array<T>`; composes with the already-shipped `array_contains`/`array_contained_by`/`array_overlap` operators. PG-only by language semantics (degrades to `TEXT` + erroring decode on MySQL/SQLite, like trigram/FTS). See `crates/rustango/src/sql/array.rs` + `tests/array_field{,_pg_live}.rs`. | |
-| `HStoreField` | [HStoreField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#hstorefield) | MISSING | n/a (#342) | |
+| `HStoreField` | [HStoreField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#hstorefield) | SHIPPED | `HStore` typed field wrapper (#342) — a string→string map (`BTreeMap<String, Option<String>>`) mapping to the `hstore` column type via `FieldType::HStore`; binds/decodes as a native `sqlx::postgres::types::PgHstore` (no text-literal escaping). Requires the `hstore` extension. PG-only by language semantics (degrades to `TEXT` on MySQL/SQLite). See `crates/rustango/src/sql/hstore.rs` + `tests/hstore_field{,_pg_live}.rs`. | |
 | `RangeField` (Int / Date / DateTime / Decimal) | [RangeField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#range-fields) | SHIPPED | `Range<T>` typed field wrapper (#343) — `Range<i32>`/`Range<i64>`/`Range<Decimal>`/`Range<NaiveDate>`/`Range<DateTime<Utc>>` map to `int4range`/`int8range`/`numrange`/`daterange`/`tstzrange` via `FieldType::Range(RangeElem)`; INSERT binds a `RangeLiteral` (`[lower,upper)`), SELECT decodes through sqlx `PgRange<T>`; composes with the shipped `range_contains`/`range_overlap`/… operators. PG-only by language semantics (degrades to `TEXT` on MySQL/SQLite). See `crates/rustango/src/sql/range.rs` + `tests/range_field{,_pg_live}.rs`. | |
 | `CITextField` | [CITextField](https://docs.djangoproject.com/en/6.0/ref/contrib/postgres/fields/#citext-fields) | SHIPPED | `#[rustango(citext)]` (#344) — DDL emits `CITEXT` on PG (with `CREATE EXTENSION IF NOT EXISTS citext;` prelude available via `dialect.ci_text_extension_sql()`), `TEXT COLLATE NOCASE` on SQLite, `VARCHAR(N)/TEXT COLLATE utf8mb4_general_ci` on MySQL. Column-level case-insensitivity propagates to `=` / `LIKE` / `ORDER BY` without query-side `LOWER(...)` wrapping. | |
 
@@ -695,7 +695,7 @@ Summary: **22 SHIPPED / 0 PARTIAL / 1 MISSING / 0 N/A**.
 | `flatpages` | [flatpages](https://docs.djangoproject.com/en/6.0/ref/contrib/flatpages/) | SHIPPED | `flatpages::*` (v0.22) | |
 | `redirects` | [redirects](https://docs.djangoproject.com/en/6.0/ref/contrib/redirects/) | SHIPPED | `redirects::*` (v0.22) | |
 | `admindocs` | [admindocs](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/admindocs/) | N/A | Rust doc-comments + cargo doc | |
-| `postgres` (ArrayField, JSONField, RangeField, HStoreField, CITextField) | (sec 4) | PARTIAL | JSONField + CITextField shipped (#344); ArrayField shipped via `Array<T>` (#341); RangeField shipped via `Range<T>` (#343); HStore MISSING (#442) | |
+| `postgres` (ArrayField, JSONField, RangeField, HStoreField, CITextField) | (sec 4) | SHIPPED | All five shipped: JSONField + CITextField (#344); ArrayField via `Array<T>` (#341); RangeField via `Range<T>` (#343); HStoreField via `HStore` (#342) | |
 | `gis` (GeoDjango) | [gis](https://docs.djangoproject.com/en/6.0/ref/contrib/gis/) | MISSING | [#58](https://github.com/ujeenet/rustango/issues/58) | |
 | `gis.geos` (geometry types) | (above) | MISSING | (above) (#443) | |
 | `gis.gdal` (raster) | (above) | MISSING | (above) (#444) | |
@@ -852,7 +852,7 @@ Ranked by how often a real-world Django project hits the gap. Refreshed 2026-06-
 
 7. **TOTP admin enrollment UI** (sec 6 + 11, #367 / #389). `totp::*` ships RFC 6238 primitives + QR `otpauth_url`; no admin-side "scan this code, enter the 6-digit verification" enrollment surface. PARTIAL.
 
-8. **`HStoreField` + `RangeField` typed wrappers** (sec 4, #342 / #343). `SqlValue::Array` + `RangeLiteral` exist at the value layer; macro-side typed-field wrappers for these PG-specific types haven't landed. ArrayField also PARTIAL on the same axis (#341).
+8. ~~**`HStoreField` + `RangeField` typed wrappers** (sec 4, #342 / #343)~~ — **SHIPPED.** All three PG-specific typed-field wrappers landed: `Array<T>` (#341), `Range<T>` (#343), `HStore` (#342). Section 4 is now fully SHIPPED.
 
 9. **Memcached backend** (sec 16, #407). Cache trait + Redis / DB / file / in-memory backends all ship; memcached driver missing. Use Redis instead in the meantime — same wire-shape capabilities.
 


### PR DESCRIPTION
## What

Closes #342. Django's `HStoreField` — a typed model-field wrapper for native PostgreSQL `hstore` (string→string map) columns. **Completes the PG-specific-fields category** (audit section 4 → 5/5 SHIPPED), alongside `Array<T>` (#341) and `Range<T>` (#343).

```rust
struct Product {
    attrs: HStore,   // → DDL `attrs hstore`
}

let p = Product { attrs: HStore::from_iter([("color", "red"), ("size", "L")]), .. };
```

## Design

- **`sql/hstore.rs`** — `HStore` newtype over `BTreeMap<String, Option<String>>` (nullable values, matching sqlx's `PgHstore`). Deref / From / FromIterator / serde / `Into<SqlValue::HStore>`. Total per-backend sqlx `Type`+`Decode` (real on PG via `PgHstore`, erroring stubs on MySQL/SQLite) so the macro's single shared `FromRow` body compiles everywhere — same pattern as `Array<T>`/`Range<T>`.
- **`SqlValue::HStore(Vec<(String, Option<String>)>)`** — new bind variant. The PG bind path reconstructs a **native** `PgHstore`, so keys/values containing `=>`, commas, or quotes need no escaping and no `::hstore` cast (unlike the range text-literal path — the typed bind carries the type).
- **`FieldType::HStore`** — DDL `hstore` on PG; degrades to `TEXT` on MySQL/SQLite (PG-only by language semantics). Requires the `hstore` extension on the database.

Wired through every `FieldType` + `SqlValue` consumer (bind_match ×3, validate, audit bind ×3, snapshot round-trip + diff, row_to_json, admin render/widget, forms parse, fixtures, OpenAPI `type: object`, label).

## Tests

- `tests/hstore_field.rs` — 5 unit: schema maps to `FieldType::HStore`, PG column/cast type `hstore`, MySQL/SQLite degrade to TEXT, native single-param bind.
- `tests/hstore_field_pg_live.rs` — 3 live (verified against real PostgreSQL): round-trip, **null values + `=>`/comma/quote special chars** (proves native bind needs no escaping), empty map. Skips gracefully if the role can't `CREATE EXTENSION hstore`.

## Gates

- ✅ Litmus `cargo build --no-default-features --features sqlite,tenancy`
- ✅ `cargo test --workspace --all-features --no-run` compiles
- ✅ 3179 lib tests pass
- ✅ Audit row #342 MISSING → SHIPPED (section 4 now fully SHIPPED)

Closes #342.