### PR TITLE
feat(orm): polymorphic many-to-many — morphToMany via GenericM2MManager (closes #818)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -892,6 +892,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         container.default_related_name.as_deref(),
     );
     let m2m_accessors = m2m_accessor_tokens(struct_name, &container.m2m);
+    let generic_m2m_accessors = generic_m2m_accessor_tokens(struct_name, &container.generic_m2m);
     // Issue #817 — `#[rustango(through(...))]` accessors.
     let through_accessors = through_accessor_tokens(struct_name, &container.through_relations);
     // Issue #830 — `#[rustango(reverse_has(...))]` static accessors.
@@ -928,6 +929,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         #column_module
         #reverse_helpers
         #m2m_accessors
+        #generic_m2m_accessors
         #through_accessors
         #reverse_has_accessors
         #generic_fk_accessors
@@ -1474,6 +1476,42 @@ fn m2m_accessor_tokens(struct_name: &syn::Ident, m2m_relations: &[M2MAttr]) -> T
                     through: #through,
                     src_col: #src_col,
                     dst_col: #dst_col,
+                }
+            }
+        }
+    });
+    quote! {
+        impl #struct_name {
+            #( #methods )*
+        }
+    }
+}
+
+/// Emit `<name>_m2m(&self) -> GenericM2MManager` inherent methods for
+/// every `#[rustango(generic_m2m(...))]` (polymorphic M2M, issue #818).
+fn generic_m2m_accessor_tokens(
+    struct_name: &syn::Ident,
+    relations: &[GenericM2MAttr],
+) -> TokenStream2 {
+    let root = rustango_root();
+    if relations.is_empty() {
+        return TokenStream2::new();
+    }
+    let methods = relations.iter().map(|rel| {
+        let method_ident = syn::Ident::new(&format!("{}_m2m", rel.name), struct_name.span());
+        let through = rel.through.as_str();
+        let pk_col = rel.pk_column.as_str();
+        let ct_col = rel.ct_column.as_str();
+        let related_col = rel.related_column.as_str();
+        quote! {
+            pub fn #method_ident(&self) -> #root::sql::GenericM2MManager {
+                #root::sql::GenericM2MManager {
+                    src_pk: self.__rustango_pk_value(),
+                    src_schema: <Self as #root::core::Model>::SCHEMA,
+                    through: #through,
+                    pk_col: #pk_col,
+                    ct_col: #ct_col,
+                    dst_col: #related_col,
                 }
             }
         }
@@ -7764,6 +7802,11 @@ struct ContainerAttrs {
     /// `#[rustango(m2m(name = "tags", to = "app_tags", through = "post_tags",
     ///                 src = "post_id", dst = "tag_id"))]`.
     m2m: Vec<M2MAttr>,
+    /// Polymorphic M2M relations declared via
+    /// `#[rustango(generic_m2m(name = "tags", through = "taggables",
+    ///   pk_column = "taggable_id", ct_column = "taggable_type",
+    ///   related_column = "tag_id"))]` (issue #818).
+    generic_m2m: Vec<GenericM2MAttr>,
     /// Composite indexes declared via
     /// `#[rustango(index("col1, col2"))]` or
     /// `#[rustango(index("col1, col2", unique, name = "my_idx"))]`.
@@ -8137,6 +8180,24 @@ struct M2MAttr {
     auto_create: bool,
 }
 
+/// Parsed form of one `#[rustango(generic_m2m(...))]` declaration —
+/// polymorphic many-to-many (Eloquent `morphToMany`, issue #818). The
+/// junction carries a ContentType discriminator so unrelated models
+/// share one pivot + related set.
+struct GenericM2MAttr {
+    /// Accessor suffix: `tags` → generates `tags_m2m()`.
+    name: String,
+    /// Polymorphic junction table (e.g. `"taggables"`).
+    through: String,
+    /// Junction column holding the owning instance PK (e.g. `"taggable_id"`).
+    pk_column: String,
+    /// Junction column holding the owning model's `content_type_id`
+    /// discriminator (e.g. `"taggable_type"`).
+    ct_column: String,
+    /// Junction column holding the related model PK (e.g. `"tag_id"`).
+    related_column: String,
+}
+
 /// Parsed shape of `#[rustango(audit(track = "name, body", source =
 /// "user"))]`. `track` is a comma-separated list of field names whose
 /// before/after values land in the JSONB `changes` column. `source`
@@ -8234,6 +8295,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
         // out-of-the-box admin invisibility regression (#62).
         permissions: true,
         m2m: Vec::new(),
+        generic_m2m: Vec::new(),
         indexes: Vec::new(),
         checks: Vec::new(),
         excludes: Vec::new(),
@@ -9665,6 +9727,55 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     return Err(meta.error("m2m requires `dst = \"...\"`"));
                 }
                 out.m2m.push(m2m);
+                return Ok(());
+            }
+            if meta.path.is_ident("generic_m2m") {
+                let mut gm = GenericM2MAttr {
+                    name: String::new(),
+                    through: String::new(),
+                    pk_column: String::new(),
+                    ct_column: String::new(),
+                    related_column: String::new(),
+                };
+                meta.parse_nested_meta(|inner| {
+                    let field = |inner: &syn::meta::ParseNestedMeta| -> syn::Result<String> {
+                        let s: LitStr = inner.value()?.parse()?;
+                        Ok(s.value())
+                    };
+                    if inner.path.is_ident("name") {
+                        gm.name = field(&inner)?;
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("through") {
+                        gm.through = field(&inner)?;
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("pk_column") {
+                        gm.pk_column = field(&inner)?;
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("ct_column") {
+                        gm.ct_column = field(&inner)?;
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("related_column") {
+                        gm.related_column = field(&inner)?;
+                        return Ok(());
+                    }
+                    Err(inner.error("unknown generic_m2m attribute (supported: `name`, `through`, `pk_column`, `ct_column`, `related_column`)"))
+                })?;
+                for (val, label) in [
+                    (&gm.name, "name"),
+                    (&gm.through, "through"),
+                    (&gm.pk_column, "pk_column"),
+                    (&gm.ct_column, "ct_column"),
+                    (&gm.related_column, "related_column"),
+                ] {
+                    if val.is_empty() {
+                        return Err(meta.error(format!("generic_m2m requires `{label} = \"...\"`")));
+                    }
+                }
+                out.generic_m2m.push(gm);
                 return Ok(());
             }
             Err(meta.error("unknown rustango container attribute"))

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -308,6 +308,29 @@ impl ContentType {
         let name = T::SCHEMA.name.to_ascii_lowercase();
         Self::get_by_natural_key(pool, app, &name).await
     }
+
+    /// [`Self::get_for_model`] keyed by a `&ModelSchema` instead of a
+    /// generic `T` — used where the model type is only known at runtime
+    /// (e.g. the polymorphic-M2M manager, issue #818, resolves the
+    /// owning model's content type from the schema it was built with).
+    /// Cached, same as `get_for_model`.
+    ///
+    /// # Errors
+    /// As [`Self::get_for_model`].
+    pub async fn get_for_schema(
+        pool: &crate::sql::Pool,
+        schema: &'static crate::core::ModelSchema,
+    ) -> Result<Option<Self>, ExecError> {
+        let entry = inventory::iter::<ModelEntry>
+            .into_iter()
+            .find(|e| e.schema.table == schema.table)
+            .ok_or_else(|| ExecError::MissingPrimaryKey {
+                table: schema.table,
+            })?;
+        let app = entry.resolved_app_label().unwrap_or("project");
+        let name = schema.name.to_ascii_lowercase();
+        Self::get_by_natural_key(pool, app, &name).await
+    }
 }
 
 // ============================================================ #89 part B — fetch helpers

--- a/crates/rustango/src/sql/error.rs
+++ b/crates/rustango/src/sql/error.rs
@@ -300,6 +300,14 @@ pub enum ExecError {
     #[error("model `{table}` has no `#[rustango(primary_key)]` field — required for FK lookup")]
     MissingPrimaryKey { table: &'static str },
 
+    /// A polymorphic relation (generic FK / generic M2M, issues #818 /
+    /// #64) needed the owning model's `content_type_id`, but no
+    /// `rustango_content_types` row exists for `{table}`. Content types
+    /// are normally auto-seeded at migrate time; run the contenttypes
+    /// seed (or `migrate`) so the discriminator can be resolved.
+    #[error("no content type registered for model `{table}` — seed `rustango_content_types` (run migrate)")]
+    ContentTypeNotRegistered { table: &'static str },
+
     /// `get_or_create` / `update_or_create` (v0.45) was called with a
     /// filter that matches more than one row. Django's
     /// `MultipleObjectsReturned`. Tighten the filter or use

--- a/crates/rustango/src/sql/m2m.rs
+++ b/crates/rustango/src/sql/m2m.rs
@@ -266,6 +266,258 @@ impl M2MManager {
     }
 }
 
+// ============================================================ polymorphic (generic) M2M
+
+/// Manages the rows in a **polymorphic** junction table for one source
+/// instance — Eloquent's `morphToMany` / `morphedByMany` (issue #818).
+///
+/// Unlike [`M2MManager`], the pivot carries a ContentType discriminator
+/// so two unrelated models (e.g. `Post` and `Video`) can share one
+/// junction (`taggables(tag_id, taggable_id, taggable_type)`) and one
+/// related set (`Tag`). Every query is scoped to the owning model's
+/// `content_type_id`, resolved from [`Self::src_schema`] via
+/// [`crate::contenttypes::ContentType::get_for_schema`] (cached).
+///
+/// Constructed by the macro-generated `<name>_m2m()` method on any model
+/// declaring `#[rustango(generic_m2m(...))]` — do not build directly.
+pub struct GenericM2MManager {
+    /// PK value of the owning model instance (the `pk_col` value).
+    pub src_pk: SqlValue,
+    /// Schema of the owning model — used to resolve its `content_type_id`
+    /// (the `ct_col` value) at call time.
+    pub src_schema: &'static crate::core::ModelSchema,
+    /// SQL name of the polymorphic junction table (e.g. `"taggables"`).
+    pub through: &'static str,
+    /// Junction column holding the owning instance's PK (e.g. `"taggable_id"`).
+    pub pk_col: &'static str,
+    /// Junction column holding the owning model's `content_type_id`
+    /// discriminator (e.g. `"taggable_type"`).
+    pub ct_col: &'static str,
+    /// Junction column holding the related model's PK (e.g. `"tag_id"`).
+    pub dst_col: &'static str,
+}
+
+impl GenericM2MManager {
+    fn src_pk_i64(&self) -> i64 {
+        match &self.src_pk {
+            SqlValue::I64(v) => *v,
+            SqlValue::I32(v) => i64::from(*v),
+            _ => 0,
+        }
+    }
+
+    /// Resolve the owning model's `content_type_id`, erroring clearly
+    /// when the content type hasn't been seeded.
+    async fn ct_id(&self, pool: &Pool) -> Result<i64, ExecError> {
+        crate::contenttypes::ContentType::get_for_schema(pool, self.src_schema)
+            .await?
+            .and_then(|ct| ct.id.get().copied())
+            .ok_or(ExecError::ContentTypeNotRegistered {
+                table: self.src_schema.table,
+            })
+    }
+
+    /// Fire `m2m_changed` for a junction mutation (reuses the monomorphic
+    /// signal context; `src_col` reports the polymorphic `pk_col`).
+    async fn signal(&self, action: crate::signals::m2m::M2mAction, dst_pks: Vec<i64>) {
+        crate::signals::m2m::send_m2m_changed(crate::signals::m2m::M2mChangedContext {
+            action,
+            through: self.through,
+            src_col: self.pk_col,
+            dst_col: self.dst_col,
+            src_pk: self.src_pk_i64(),
+            dst_pks,
+        })
+        .await;
+    }
+
+    /// Related PKs linked to this instance (scoped to its content type).
+    ///
+    /// # Errors
+    /// Driver failures, or [`ExecError::ContentTypeNotRegistered`].
+    pub async fn all(&self, pool: &Pool) -> Result<Vec<i64>, ExecError> {
+        let dialect = pool.dialect();
+        let ct = self.ct_id(pool).await?;
+        let sql = format!(
+            "SELECT {dst} FROM {through} WHERE {pk} = {p1} AND {ctc} = {p2}",
+            through = dialect.quote_ident(self.through),
+            pk = dialect.quote_ident(self.pk_col),
+            ctc = dialect.quote_ident(self.ct_col),
+            dst = dialect.quote_ident(self.dst_col),
+            p1 = dialect.placeholder(1),
+            p2 = dialect.placeholder(2),
+        );
+        let binds = vec![SqlValue::I64(self.src_pk_i64()), SqlValue::I64(ct)];
+        fetch_i64_col_pool(pool, &sql, binds, self.dst_col).await
+    }
+
+    /// Link `dst_id` to this instance. No-op if already present.
+    ///
+    /// # Errors
+    /// Driver failures, or [`ExecError::ContentTypeNotRegistered`].
+    pub async fn add(&self, dst_id: i64, pool: &Pool) -> Result<(), ExecError> {
+        let dialect = pool.dialect();
+        let ct = self.ct_id(pool).await?;
+        let (insert_kw, suffix) = match dialect.name() {
+            "mysql" => ("INSERT IGNORE INTO", ""),
+            _ => ("INSERT INTO", " ON CONFLICT DO NOTHING"),
+        };
+        let sql = format!(
+            "{insert_kw} {through} ({pk}, {ctc}, {dst}) VALUES ({p1}, {p2}, {p3}){suffix}",
+            through = dialect.quote_ident(self.through),
+            pk = dialect.quote_ident(self.pk_col),
+            ctc = dialect.quote_ident(self.ct_col),
+            dst = dialect.quote_ident(self.dst_col),
+            p1 = dialect.placeholder(1),
+            p2 = dialect.placeholder(2),
+            p3 = dialect.placeholder(3),
+        );
+        let binds = vec![
+            SqlValue::I64(self.src_pk_i64()),
+            SqlValue::I64(ct),
+            SqlValue::I64(dst_id),
+        ];
+        super::executor::raw_execute_pool(pool, &sql, binds).await?;
+        self.signal(crate::signals::m2m::M2mAction::Add, vec![dst_id])
+            .await;
+        Ok(())
+    }
+
+    /// Unlink `dst_id` from this instance. No-op if not present.
+    ///
+    /// # Errors
+    /// Driver failures, or [`ExecError::ContentTypeNotRegistered`].
+    pub async fn remove(&self, dst_id: i64, pool: &Pool) -> Result<(), ExecError> {
+        let dialect = pool.dialect();
+        let ct = self.ct_id(pool).await?;
+        let sql = format!(
+            "DELETE FROM {through} WHERE {pk} = {p1} AND {ctc} = {p2} AND {dst} = {p3}",
+            through = dialect.quote_ident(self.through),
+            pk = dialect.quote_ident(self.pk_col),
+            ctc = dialect.quote_ident(self.ct_col),
+            dst = dialect.quote_ident(self.dst_col),
+            p1 = dialect.placeholder(1),
+            p2 = dialect.placeholder(2),
+            p3 = dialect.placeholder(3),
+        );
+        let binds = vec![
+            SqlValue::I64(self.src_pk_i64()),
+            SqlValue::I64(ct),
+            SqlValue::I64(dst_id),
+        ];
+        super::executor::raw_execute_pool(pool, &sql, binds).await?;
+        self.signal(crate::signals::m2m::M2mAction::Remove, vec![dst_id])
+            .await;
+        Ok(())
+    }
+
+    /// Replace the full linked set with `ids` — atomic DELETE + INSERT in
+    /// one transaction, scoped to this instance's content type.
+    ///
+    /// # Errors
+    /// Driver failures, or [`ExecError::ContentTypeNotRegistered`].
+    pub async fn set(&self, ids: &[i64], pool: &Pool) -> Result<(), ExecError> {
+        let dialect = pool.dialect();
+        let ct = self.ct_id(pool).await?;
+        let src_pk = self.src_pk_i64();
+        let del_sql = format!(
+            "DELETE FROM {through} WHERE {pk} = {p1} AND {ctc} = {p2}",
+            through = dialect.quote_ident(self.through),
+            pk = dialect.quote_ident(self.pk_col),
+            ctc = dialect.quote_ident(self.ct_col),
+            p1 = dialect.placeholder(1),
+            p2 = dialect.placeholder(2),
+        );
+        let ins = if ids.is_empty() {
+            None
+        } else {
+            let mut sql = format!(
+                "INSERT INTO {through} ({pk}, {ctc}, {dst}) VALUES ",
+                through = dialect.quote_ident(self.through),
+                pk = dialect.quote_ident(self.pk_col),
+                ctc = dialect.quote_ident(self.ct_col),
+                dst = dialect.quote_ident(self.dst_col),
+            );
+            let mut binds = Vec::with_capacity(ids.len() * 3);
+            for (i, dst_id) in ids.iter().enumerate() {
+                if i > 0 {
+                    sql.push_str(", ");
+                }
+                let p1 = dialect.placeholder(i * 3 + 1);
+                let p2 = dialect.placeholder(i * 3 + 2);
+                let p3 = dialect.placeholder(i * 3 + 3);
+                sql.push_str(&format!("({p1}, {p2}, {p3})"));
+                binds.push(SqlValue::I64(src_pk));
+                binds.push(SqlValue::I64(ct));
+                binds.push(SqlValue::I64(*dst_id));
+            }
+            Some((sql, binds))
+        };
+        let mut tx = crate::sql::transaction_pool(pool).await?;
+        crate::sql::raw_execute_tx(
+            &mut tx,
+            &del_sql,
+            vec![SqlValue::I64(src_pk), SqlValue::I64(ct)],
+        )
+        .await?;
+        if let Some((ins_sql, binds)) = ins {
+            crate::sql::raw_execute_tx(&mut tx, &ins_sql, binds).await?;
+        }
+        tx.commit().await.map_err(ExecError::Driver)?;
+        self.signal(crate::signals::m2m::M2mAction::Set, ids.to_vec())
+            .await;
+        Ok(())
+    }
+
+    /// Unlink every related row for this instance (scoped to its CT).
+    ///
+    /// # Errors
+    /// Driver failures, or [`ExecError::ContentTypeNotRegistered`].
+    pub async fn clear(&self, pool: &Pool) -> Result<(), ExecError> {
+        let dialect = pool.dialect();
+        let ct = self.ct_id(pool).await?;
+        let sql = format!(
+            "DELETE FROM {through} WHERE {pk} = {p1} AND {ctc} = {p2}",
+            through = dialect.quote_ident(self.through),
+            pk = dialect.quote_ident(self.pk_col),
+            ctc = dialect.quote_ident(self.ct_col),
+            p1 = dialect.placeholder(1),
+            p2 = dialect.placeholder(2),
+        );
+        let binds = vec![SqlValue::I64(self.src_pk_i64()), SqlValue::I64(ct)];
+        super::executor::raw_execute_pool(pool, &sql, binds).await?;
+        self.signal(crate::signals::m2m::M2mAction::Clear, Vec::new())
+            .await;
+        Ok(())
+    }
+
+    /// `true` if `dst_id` is linked to this instance (within its CT).
+    ///
+    /// # Errors
+    /// Driver failures, or [`ExecError::ContentTypeNotRegistered`].
+    pub async fn contains(&self, dst_id: i64, pool: &Pool) -> Result<bool, ExecError> {
+        let dialect = pool.dialect();
+        let ct = self.ct_id(pool).await?;
+        let sql = format!(
+            "SELECT 1 AS hit FROM {through} WHERE {pk} = {p1} AND {ctc} = {p2} AND {dst} = {p3} LIMIT 1",
+            through = dialect.quote_ident(self.through),
+            pk = dialect.quote_ident(self.pk_col),
+            ctc = dialect.quote_ident(self.ct_col),
+            dst = dialect.quote_ident(self.dst_col),
+            p1 = dialect.placeholder(1),
+            p2 = dialect.placeholder(2),
+            p3 = dialect.placeholder(3),
+        );
+        let binds = vec![
+            SqlValue::I64(self.src_pk_i64()),
+            SqlValue::I64(ct),
+            SqlValue::I64(dst_id),
+        ];
+        let rows = fetch_i64_col_pool(pool, &sql, binds, "hit").await?;
+        Ok(!rows.is_empty())
+    }
+}
+
 // ============================================================ deprecated _pool aliases
 
 /// Source-compat shims for callers still using the pre-#891

--- a/crates/rustango/src/sql/m2m.rs
+++ b/crates/rustango/src/sql/m2m.rs
@@ -498,8 +498,11 @@ impl GenericM2MManager {
     pub async fn contains(&self, dst_id: i64, pool: &Pool) -> Result<bool, ExecError> {
         let dialect = pool.dialect();
         let ct = self.ct_id(pool).await?;
+        // Select the (bigint) `dst` column rather than a literal `1`:
+        // Postgres types a bare `SELECT 1` as `int4`, which the
+        // `i64`/`int8`-typed decoder in `fetch_i64_col_pool` rejects.
         let sql = format!(
-            "SELECT 1 AS hit FROM {through} WHERE {pk} = {p1} AND {ctc} = {p2} AND {dst} = {p3} LIMIT 1",
+            "SELECT {dst} FROM {through} WHERE {pk} = {p1} AND {ctc} = {p2} AND {dst} = {p3} LIMIT 1",
             through = dialect.quote_ident(self.through),
             pk = dialect.quote_ident(self.pk_col),
             ctc = dialect.quote_ident(self.ct_col),

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -89,7 +89,7 @@ pub use executor::LoadRelatedMy;
 #[cfg(feature = "sqlite")]
 pub use executor::LoadRelatedSqlite;
 pub use foreign_key::ForeignKey;
-pub use m2m::M2MManager;
+pub use m2m::{GenericM2MManager, M2MManager};
 #[cfg(feature = "mysql")]
 pub use mysql::MySql;
 #[cfg(all(feature = "sqlite", feature = "manage"))]

--- a/crates/rustango/tests/generic_m2m_pg_live.rs
+++ b/crates/rustango/tests/generic_m2m_pg_live.rs
@@ -1,0 +1,114 @@
+#![cfg(feature = "postgres")]
+//! Live PostgreSQL round-trip for polymorphic M2M (`morphToMany`, issue
+//! #818) — the same coverage as the SQLite live test against PG, so the
+//! tri-dialect `INSERT … ON CONFLICT` / placeholder / quote-ident paths
+//! are exercised on a second backend.
+//!
+//! Skips silently when `DATABASE_URL` is unset (runs in CI's
+//! `postgres_test` job).
+
+use std::sync::OnceLock;
+
+use rustango::contenttypes;
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn suite_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gm2mpg_post", app = "gm2mpg")]
+#[rustango(generic_m2m(
+    name = "tags",
+    through = "gm2mpg_taggables",
+    pk_column = "taggable_id",
+    ct_column = "taggable_type",
+    related_column = "tag_id"
+))]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 120)]
+    pub title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gm2mpg_video", app = "gm2mpg")]
+#[rustango(generic_m2m(
+    name = "tags",
+    through = "gm2mpg_taggables",
+    pk_column = "taggable_id",
+    ct_column = "taggable_type",
+    related_column = "tag_id"
+))]
+#[allow(dead_code)]
+pub struct Video {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 120)]
+    pub url: String,
+}
+
+async fn pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pool: Pool = sqlx::PgPool::connect(&url).await.ok()?.into();
+    contenttypes::ensure_seeded(&pool).await.ok()?;
+    contenttypes::clear_cache();
+    let pg = pool.as_postgres().unwrap();
+    for ddl in [
+        r#"DROP TABLE IF EXISTS "gm2mpg_taggables" CASCADE"#,
+        r#"CREATE TABLE IF NOT EXISTS "gm2mpg_post" ("id" BIGSERIAL PRIMARY KEY, "title" VARCHAR(120) NOT NULL)"#,
+        r#"CREATE TABLE IF NOT EXISTS "gm2mpg_video" ("id" BIGSERIAL PRIMARY KEY, "url" VARCHAR(120) NOT NULL)"#,
+        r#"CREATE TABLE "gm2mpg_taggables" (
+            "taggable_id"   BIGINT NOT NULL,
+            "taggable_type" BIGINT NOT NULL,
+            "tag_id"        BIGINT NOT NULL,
+            UNIQUE("taggable_id", "taggable_type", "tag_id"))"#,
+    ] {
+        sqlx::query(ddl).execute(pg).await.unwrap();
+    }
+    Some(pool)
+}
+
+#[tokio::test]
+async fn polymorphic_m2m_round_trips_and_isolates_by_content_type_on_pg() {
+    let _g = suite_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+
+    let post = Post {
+        id: Auto::from(1),
+        title: "P".into(),
+    };
+    let video = Video {
+        id: Auto::from(1),
+        url: "v".into(),
+    };
+
+    // add + idempotent add + contains + remove
+    post.tags_m2m().add(10, &pool).await.unwrap();
+    post.tags_m2m().add(10, &pool).await.unwrap(); // ON CONFLICT DO NOTHING
+    post.tags_m2m().add(11, &pool).await.unwrap();
+    assert!(post.tags_m2m().contains(10, &pool).await.unwrap());
+    post.tags_m2m().remove(11, &pool).await.unwrap();
+
+    // set replaces; isolated from Video which shares PK=1 in the pivot.
+    post.tags_m2m().set(&[10, 12], &pool).await.unwrap();
+    video.tags_m2m().set(&[20], &pool).await.unwrap();
+
+    let mut post_tags = post.tags_m2m().all(&pool).await.unwrap();
+    post_tags.sort_unstable();
+    assert_eq!(post_tags, vec![10, 12]);
+    assert_eq!(video.tags_m2m().all(&pool).await.unwrap(), vec![20]);
+    assert!(!post.tags_m2m().contains(20, &pool).await.unwrap());
+
+    post.tags_m2m().clear(&pool).await.unwrap();
+    assert!(post.tags_m2m().all(&pool).await.unwrap().is_empty());
+    // Video untouched by Post's clear (CT-scoped).
+    assert_eq!(video.tags_m2m().all(&pool).await.unwrap(), vec![20]);
+}

--- a/crates/rustango/tests/generic_m2m_sqlite_live.rs
+++ b/crates/rustango/tests/generic_m2m_sqlite_live.rs
@@ -1,0 +1,200 @@
+#![cfg(all(feature = "sqlite", feature = "signals"))]
+//! Live SQLite test for polymorphic many-to-many — Eloquent
+//! `morphToMany` (issue #818). Two unrelated models (`Post`, `Video`)
+//! share one `taggables` pivot + one `Tag` set, isolated by the
+//! ContentType discriminator. Exercises add / remove / set / clear /
+//! contains / all + `m2m_changed`.
+
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+use rustango::contenttypes;
+use rustango::signals::m2m::{clear_all, connect_m2m_changed, M2mAction, M2mChangedContext};
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+/// One suite-wide lock — every test mutates two process-global registries
+/// (the contenttypes cache + the m2m_changed signal registry).
+fn suite_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gm2m_post", app = "gm2m")]
+#[rustango(generic_m2m(
+    name = "tags",
+    through = "gm2m_taggables",
+    pk_column = "taggable_id",
+    ct_column = "taggable_type",
+    related_column = "tag_id"
+))]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 120)]
+    pub title: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gm2m_video", app = "gm2m")]
+#[rustango(generic_m2m(
+    name = "tags",
+    through = "gm2m_taggables",
+    pk_column = "taggable_id",
+    ct_column = "taggable_type",
+    related_column = "tag_id"
+))]
+#[allow(dead_code)]
+pub struct Video {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 120)]
+    pub url: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gm2m_tag", app = "gm2m")]
+#[allow(dead_code)]
+pub struct Tag {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 40)]
+    pub label: String,
+}
+
+async fn fresh_pool() -> Pool {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    let pool = Pool::Sqlite(sq);
+    contenttypes::ensure_seeded(&pool)
+        .await
+        .expect("ensure_seeded");
+    // Cache may hold (app, model) → id from a sibling test's pool; this
+    // fresh in-memory DB re-seeds with its own ids, so clear it.
+    contenttypes::clear_cache();
+    let Pool::Sqlite(ref s) = pool else {
+        unreachable!()
+    };
+    for ddl in [
+        "CREATE TABLE gm2m_post (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL)",
+        "CREATE TABLE gm2m_video (id INTEGER PRIMARY KEY AUTOINCREMENT, url TEXT NOT NULL)",
+        "CREATE TABLE gm2m_tag (id INTEGER PRIMARY KEY AUTOINCREMENT, label TEXT NOT NULL)",
+        "CREATE TABLE gm2m_taggables (\
+            taggable_id   INTEGER NOT NULL, \
+            taggable_type INTEGER NOT NULL, \
+            tag_id        INTEGER NOT NULL, \
+            UNIQUE(taggable_id, taggable_type, tag_id))",
+    ] {
+        sqlx::query(ddl).execute(s).await.unwrap();
+    }
+    pool
+}
+
+#[tokio::test]
+async fn add_all_contains_remove() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+    let pool = fresh_pool().await;
+
+    let post = Post {
+        id: Auto::from(1),
+        title: "Hello".into(),
+    };
+    post.tags_m2m().add(10, &pool).await.unwrap();
+    post.tags_m2m().add(20, &pool).await.unwrap();
+    // idempotent
+    post.tags_m2m().add(10, &pool).await.unwrap();
+
+    let mut tags = post.tags_m2m().all(&pool).await.unwrap();
+    tags.sort_unstable();
+    assert_eq!(tags, vec![10, 20]);
+    assert!(post.tags_m2m().contains(10, &pool).await.unwrap());
+    assert!(!post.tags_m2m().contains(99, &pool).await.unwrap());
+
+    post.tags_m2m().remove(10, &pool).await.unwrap();
+    assert_eq!(post.tags_m2m().all(&pool).await.unwrap(), vec![20]);
+}
+
+#[tokio::test]
+async fn set_then_clear() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+    let pool = fresh_pool().await;
+
+    let post = Post {
+        id: Auto::from(7),
+        title: "Set".into(),
+    };
+    post.tags_m2m().add(1, &pool).await.unwrap();
+    post.tags_m2m().set(&[2, 3, 4], &pool).await.unwrap();
+    let mut tags = post.tags_m2m().all(&pool).await.unwrap();
+    tags.sort_unstable();
+    assert_eq!(tags, vec![2, 3, 4]);
+
+    post.tags_m2m().clear(&pool).await.unwrap();
+    assert!(post.tags_m2m().all(&pool).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn two_unrelated_models_share_pivot_isolated_by_content_type() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+    let pool = fresh_pool().await;
+
+    // Same PK (1) on both models — only the ContentType discriminator
+    // keeps their tag sets apart in the shared `gm2m_taggables` pivot.
+    let post = Post {
+        id: Auto::from(1),
+        title: "P".into(),
+    };
+    let video = Video {
+        id: Auto::from(1),
+        url: "v".into(),
+    };
+
+    post.tags_m2m().set(&[10, 11], &pool).await.unwrap();
+    video.tags_m2m().set(&[20, 21], &pool).await.unwrap();
+
+    let mut post_tags = post.tags_m2m().all(&pool).await.unwrap();
+    post_tags.sort_unstable();
+    let mut video_tags = video.tags_m2m().all(&pool).await.unwrap();
+    video_tags.sort_unstable();
+
+    assert_eq!(post_tags, vec![10, 11], "post tags leaked video's");
+    assert_eq!(video_tags, vec![20, 21], "video tags leaked post's");
+    // Cross-checks: post doesn't see video's tags and vice-versa.
+    assert!(!post.tags_m2m().contains(20, &pool).await.unwrap());
+    assert!(!video.tags_m2m().contains(10, &pool).await.unwrap());
+}
+
+#[tokio::test]
+async fn m2m_changed_fires_on_add() {
+    let _g = suite_lock().lock().await;
+    clear_all();
+
+    let captured: Arc<Mutex<Vec<M2mChangedContext>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    connect_m2m_changed(move |ctx| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().await.push(ctx);
+        }
+    });
+
+    let pool = fresh_pool().await;
+    let post = Post {
+        id: Auto::from(5),
+        title: "Sig".into(),
+    };
+    post.tags_m2m().add(42, &pool).await.unwrap();
+
+    let events = captured.lock().await;
+    assert_eq!(events.len(), 1, "expected one m2m_changed event");
+    assert!(matches!(events[0].action, M2mAction::Add));
+    assert_eq!(events[0].through, "gm2m_taggables");
+    assert_eq!(events[0].dst_pks, vec![42]);
+}


### PR DESCRIPTION
## What

Closes #818. Eloquent's `morphToMany` / `morphedByMany` — a pivot that combines M2M with a **ContentType discriminator**, so two unrelated models (`Post`, `Video`) share one junction (`taggables(tag_id, taggable_id, taggable_type)`) and one related set (`Tag`).

```rust
#[derive(Model)]
#[rustango(table = "post")]
#[rustango(generic_m2m(name = "tags", through = "taggables",
    pk_column = "taggable_id", ct_column = "taggable_type", related_column = "tag_id"))]
struct Post { #[rustango(primary_key)] id: Auto<i64>, /* … */ }
// Video declares the same generic_m2m → shares the pivot + Tag set.

post.tags_m2m().add(42, &pool).await?;
post.tags_m2m().set(&[1, 2, 3], &pool).await?;
let ids = post.tags_m2m().all(&pool).await?;   // scoped to Post's content type
```

## Design

- **`GenericM2MManager`** (`sql/m2m.rs`) — `all`/`add`/`remove`/`set`/`clear`/`contains`, parallel to `M2MManager` but every query is scoped to the owning model's `content_type_id`, resolved from the owning `ModelSchema` via `ContentType::get_for_schema` (cached). Tri-dialect via the same `quote_ident`/`placeholder`/`_pool` paths (`INSERT … ON CONFLICT DO NOTHING` / `INSERT IGNORE` like the monomorphic manager). Fires `m2m_changed` on every mutation.
- **`ContentType::get_for_schema(pool, &ModelSchema)`** — schema-keyed sibling of `get_for_model`, for the runtime-typed manager.
- **`ExecError::ContentTypeNotRegistered { table }`** — clear error when the content type hasn't been seeded.
- **Macro** `#[rustango(generic_m2m(name, through, pk_column, ct_column, related_column))]` → a `<name>_m2m() -> GenericM2MManager` accessor (mirrors the monomorphic `m2m` attr + codegen).

The polymorphic junction is operator-declared (raw migration or a through `#[derive(Model)]`) — same posture as monomorphic M2M with `auto_create = false`.

## Tests

- `generic_m2m_sqlite_live.rs` — 4: add/all/contains/remove, set/clear, **two unrelated models (`Post`+`Video`, same PK) isolated by content type** in one shared pivot, `m2m_changed` fires.
- `generic_m2m_pg_live.rs` — 1: full round-trip + CT isolation, verified against real PostgreSQL.

## Gates

- ✅ Litmus `cargo build --no-default-features --features sqlite,tenancy`
- ✅ `cargo test --workspace --all-features --no-run` compiles
- ✅ 3179 lib tests pass

Closes #818.