### PR TITLE
feat(orm): attribute casts — Cast<C> + CastValue + EncryptedString (closes #819)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,9 @@ sha2    = "0.10"
 subtle  = "2"      # constant-time eq for MAC verify
 cookie  = "0.18"
 rand    = "0.8"    # session-secret auto-gen fallback
+# XChaCha20-Poly1305 AEAD for the `encrypted` attribute cast (#819).
+# 24-byte nonce → random per-write nonces are reuse-safe.
+chacha20poly1305 = "0.10"
 
 # Interactive manage CLI
 dotenvy   = "0.15"

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -11291,6 +11291,18 @@ fn detect_type(ty: &syn::Type) -> syn::Result<DetectedType<'_>> {
                 fk_inner: None,
             });
         }
+        // `Cast<C>` → attribute cast (#819). The column is plain `TEXT`
+        // (the `CastValue` impl bridges logical↔stored); the field's own
+        // sqlx `Decode` / `Into<SqlValue>` handle the transform, so the
+        // schema just needs `FieldType::String`.
+        "Cast" => {
+            return Ok(DetectedType {
+                kind: DetectedKind::String,
+                nullable: false,
+                auto: false,
+                fk_inner: None,
+            });
+        }
         // `HStore` → PG `hstore` (Django `HStoreField`, #342). No generic
         // parameter — always a string→string map.
         "HStore" => {

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -23,7 +23,7 @@ workspace = true
 # public forms framework. Opt in to multi-tenancy with
 # `features = ["tenancy"]`. Drop `default-features` for the bare
 # ORM (core + query + sql + migrate).
-default = ["postgres", "manage", "admin", "config", "forms", "serializer", "cache", "signals", "email", "storage", "scheduler", "secrets", "totp", "webhook", "webhook-delivery", "api_keys", "passwords", "signed_url", "notifications", "jobs", "jobs-postgres", "auth_flows", "sse", "websocket", "oauth2", "http-client", "compression", "openapi", "csp-nonce", "sessions", "hmac-auth", "jwt", "uploads", "storage-s3", "media", "runserver", "template_views"]
+default = ["postgres", "manage", "admin", "config", "forms", "serializer", "cache", "signals", "email", "storage", "scheduler", "secrets", "totp", "webhook", "webhook-delivery", "api_keys", "passwords", "signed_url", "notifications", "casts", "jobs", "jobs-postgres", "auth_flows", "sse", "websocket", "oauth2", "http-client", "compression", "openapi", "csp-nonce", "sessions", "hmac-auth", "jwt", "uploads", "storage-s3", "media", "runserver", "template_views"]
 postgres = ["sqlx/postgres"]
 
 # Unified `cargo run` / `cargo run -- <verb>` dispatcher. Pulls the
@@ -214,6 +214,10 @@ scheduler = ["dep:tokio"]
 # Secrets manager (`rustango::secrets`) — Secrets trait + EnvSecrets +
 # InMemorySecrets. Vault / AWS / GCP plug in via the trait.
 secrets = ["dep:async-trait"]
+# Attribute casts (#819) — `Cast<C>` field wrapper + `CastValue` trait;
+# the `EncryptedString` built-in pulls XChaCha20-Poly1305 + base64 + a
+# SHA-256 key derivation (`rand` for the per-write nonce).
+casts = ["dep:chacha20poly1305", "dep:base64", "dep:rand", "dep:sha2"]
 
 # TOTP / 2FA (`rustango::totp`) — RFC 6238 time-based one-time passwords
 # for second-factor authentication. SHA-1 (Google Authenticator default).
@@ -385,6 +389,7 @@ tera           = { workspace = true, optional = true }
 # `tenancy` feature deps — optional.
 argon2           = { workspace = true, optional = true }
 async-trait      = { workspace = true, optional = true }
+chacha20poly1305 = { workspace = true, optional = true }
 cookie           = { workspace = true, optional = true }
 hmac             = { workspace = true, optional = true }
 password-hash    = { workspace = true, optional = true }

--- a/crates/rustango/src/casts.rs
+++ b/crates/rustango/src/casts.rs
@@ -1,0 +1,209 @@
+//! Attribute casts — a per-field get/set transform layer (Eloquent
+//! `$casts` / `CastsAttributes`; Django `from_db_value`/`get_prep_value`).
+//! Issue #819.
+//!
+//! A model field typed [`Cast<C>`] stores its logical value `C::Value`
+//! in memory but reads/writes the database through the [`CastValue`]
+//! impl `C` — `to_db` on the way in, `from_db` on the way out. The
+//! column itself is plain `TEXT`, so casts are backend-neutral and need
+//! no migration changes.
+//!
+//! ```ignore
+//! use rustango::casts::{Cast, EncryptedString};
+//!
+//! #[derive(Model)]
+//! #[rustango(table = "patient")]
+//! struct Patient {
+//!     #[rustango(primary_key)] id: Auto<i64>,
+//!     // Stored AEAD-encrypted at rest; transparent `String` in Rust.
+//!     ssn: Cast<EncryptedString>,
+//! }
+//!
+//! let p = Patient { id: Auto::default(), ssn: Cast::new("123-45-6789".to_owned()) };
+//! // `&*p.ssn` is the plaintext; the `ssn` column holds ciphertext.
+//! ```
+//!
+//! ## Extension point
+//!
+//! Implement [`CastValue`] for your own marker type and use it as
+//! `Cast<MyCast>`. `to_db` serializes the logical value to the stored
+//! `String`; `from_db` parses it back (fallible). The
+//! [`EncryptedString`] built-in is the reference implementation; a
+//! JSON-value-object cast is one line of `serde_json`.
+
+use std::fmt;
+use std::marker::PhantomData;
+
+/// Error returned by [`CastValue::from_db`] when stored data can't be
+/// parsed back into the logical value (corrupt/tampered ciphertext,
+/// malformed JSON, …). Surfaces through sqlx's decode path as a
+/// `ColumnDecode` error.
+#[derive(Debug)]
+pub struct CastError(pub String);
+
+impl fmt::Display for CastError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "attribute cast error: {}", self.0)
+    }
+}
+
+impl std::error::Error for CastError {}
+
+/// Bridges a logical Rust value to/from its stored `TEXT` representation.
+///
+/// `to_db` is infallible (a misconfiguration — e.g. a missing encryption
+/// key — should fail fast); `from_db` is fallible (stored data may be
+/// corrupt). Implement this on a marker type and use [`Cast<Self>`].
+pub trait CastValue {
+    /// Logical in-memory type (what the model field "is").
+    type Value;
+    /// Serialize the logical value to the stored `TEXT` form.
+    fn to_db(value: &Self::Value) -> String;
+    /// Parse the stored `TEXT` form back into the logical value.
+    ///
+    /// # Errors
+    /// [`CastError`] when the stored form can't be decoded.
+    fn from_db(stored: &str) -> Result<Self::Value, CastError>;
+}
+
+/// A model field whose database representation is transformed by the
+/// [`CastValue`] impl `C`. See the [module docs](self).
+pub struct Cast<C: CastValue> {
+    value: C::Value,
+    _marker: PhantomData<fn() -> C>,
+}
+
+impl<C: CastValue> Cast<C> {
+    /// Wrap a logical value.
+    pub fn new(value: C::Value) -> Self {
+        Self {
+            value,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Consume the wrapper, returning the logical value.
+    pub fn into_inner(self) -> C::Value {
+        self.value
+    }
+}
+
+impl<C: CastValue> std::ops::Deref for Cast<C> {
+    type Target = C::Value;
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<C: CastValue> std::ops::DerefMut for Cast<C> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+// NB: no `impl From<C::Value> for Cast<C>` — `C::Value` is an
+// unconstrained associated type that could equal `Cast<C>`, which
+// collides with the std reflexive `From<T> for T`. Construct via
+// [`Cast::new`].
+
+impl<C: CastValue> fmt::Debug for Cast<C>
+where
+    C::Value: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Cast").field(&self.value).finish()
+    }
+}
+
+impl<C: CastValue> Clone for Cast<C>
+where
+    C::Value: Clone,
+{
+    fn clone(&self) -> Self {
+        Self::new(self.value.clone())
+    }
+}
+
+impl<C: CastValue> PartialEq for Cast<C>
+where
+    C::Value: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+// ---- serde: behave as the logical value ----
+
+impl<C: CastValue> serde::Serialize for Cast<C>
+where
+    C::Value: serde::Serialize,
+{
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.value.serialize(serializer)
+    }
+}
+
+impl<'de, C: CastValue> serde::Deserialize<'de> for Cast<C>
+where
+    C::Value: serde::Deserialize<'de>,
+{
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        C::Value::deserialize(deserializer).map(Self::new)
+    }
+}
+
+// ---- `Cast<C>` → `SqlValue` (INSERT / UPDATE bind, as TEXT) ----
+
+impl<C: CastValue> From<Cast<C>> for crate::core::SqlValue {
+    fn from(c: Cast<C>) -> Self {
+        crate::core::SqlValue::String(C::to_db(&c.value))
+    }
+}
+
+// ---- sqlx Type + Decode (FromRow read path): the column is TEXT ----
+//
+// Decode the stored `String` then run `C::from_db`. Type/`compatible`
+// delegate to `String`, so the column is an ordinary text column on
+// every backend.
+
+macro_rules! cast_sqlx_impls {
+    ($db:ty) => {
+        impl<'r, C: CastValue> sqlx::Decode<'r, $db> for Cast<C>
+        where
+            String: sqlx::Decode<'r, $db>,
+        {
+            fn decode(
+                value: <$db as sqlx::Database>::ValueRef<'r>,
+            ) -> Result<Self, sqlx::error::BoxDynError> {
+                let stored = <String as sqlx::Decode<'r, $db>>::decode(value)?;
+                let v = C::from_db(&stored).map_err(|e| Box::new(e) as sqlx::error::BoxDynError)?;
+                Ok(Self::new(v))
+            }
+        }
+
+        impl<C: CastValue> sqlx::Type<$db> for Cast<C> {
+            fn type_info() -> <$db as sqlx::Database>::TypeInfo {
+                <String as sqlx::Type<$db>>::type_info()
+            }
+
+            fn compatible(ty: &<$db as sqlx::Database>::TypeInfo) -> bool {
+                <String as sqlx::Type<$db>>::compatible(ty)
+            }
+        }
+    };
+}
+
+#[cfg(feature = "postgres")]
+cast_sqlx_impls!(sqlx::Postgres);
+#[cfg(feature = "mysql")]
+cast_sqlx_impls!(sqlx::MySql);
+#[cfg(feature = "sqlite")]
+cast_sqlx_impls!(sqlx::Sqlite);
+
+// ====================================================================
+// Built-in: EncryptedString (AEAD-at-rest)
+// ====================================================================
+
+mod encrypted;
+pub use encrypted::EncryptedString;

--- a/crates/rustango/src/casts/encrypted.rs
+++ b/crates/rustango/src/casts/encrypted.rs
@@ -1,0 +1,135 @@
+//! `EncryptedString` — the reference [`CastValue`] built-in (#819).
+//! Encrypts at rest with XChaCha20-Poly1305 (AEAD), key derived from the
+//! `RUSTANGO_SECRET_KEY` environment variable.
+//!
+//! Stored form: base64(`nonce(24) ‖ ciphertext+tag`). The 24-byte
+//! XChaCha nonce is random per write, so nonce reuse isn't a concern even
+//! across many encryptions under one key.
+
+use base64::Engine as _;
+use chacha20poly1305::aead::Aead;
+use chacha20poly1305::{Key, KeyInit, XChaCha20Poly1305, XNonce};
+use sha2::{Digest, Sha256};
+
+use super::{CastError, CastValue};
+
+/// 192-bit XChaCha nonce.
+const NONCE_LEN: usize = 24;
+
+/// Marker type for the encrypted-string cast — use as
+/// [`Cast<EncryptedString>`](super::Cast). The logical value is a
+/// `String`; the column stores AEAD ciphertext.
+pub enum EncryptedString {}
+
+impl CastValue for EncryptedString {
+    type Value = String;
+
+    fn to_db(value: &String) -> String {
+        // Infallible by contract; a missing key is a deploy-time
+        // misconfiguration and fails fast (like a missing DB URL).
+        encrypt(value.as_bytes()).unwrap_or_else(|e| {
+            panic!("encrypted cast write failed: {e}");
+        })
+    }
+
+    fn from_db(stored: &str) -> Result<String, CastError> {
+        let plaintext = decrypt(stored)?;
+        String::from_utf8(plaintext)
+            .map_err(|e| CastError(format!("decrypted bytes not UTF-8: {e}")))
+    }
+}
+
+/// 32-byte key = SHA-256 of `RUSTANGO_SECRET_KEY` (accepts any-length
+/// secret). Read per call so tests / key rotation see the current value.
+fn derive_key() -> Result<[u8; 32], CastError> {
+    let secret = std::env::var("RUSTANGO_SECRET_KEY").map_err(|_| {
+        CastError("RUSTANGO_SECRET_KEY is not set (required for `EncryptedString` casts)".into())
+    })?;
+    let digest = Sha256::digest(secret.as_bytes());
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&digest);
+    Ok(key)
+}
+
+fn cipher() -> Result<XChaCha20Poly1305, CastError> {
+    let key = derive_key()?;
+    Ok(XChaCha20Poly1305::new(Key::from_slice(&key)))
+}
+
+fn encrypt(plaintext: &[u8]) -> Result<String, CastError> {
+    let cipher = cipher()?;
+    let mut nonce = [0u8; NONCE_LEN];
+    rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut nonce);
+    let ciphertext = cipher
+        .encrypt(XNonce::from_slice(&nonce), plaintext)
+        .map_err(|e| CastError(format!("encrypt: {e}")))?;
+    let mut framed = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+    framed.extend_from_slice(&nonce);
+    framed.extend_from_slice(&ciphertext);
+    Ok(base64::engine::general_purpose::STANDARD.encode(framed))
+}
+
+fn decrypt(stored: &str) -> Result<Vec<u8>, CastError> {
+    let framed = base64::engine::general_purpose::STANDARD
+        .decode(stored)
+        .map_err(|e| CastError(format!("base64 decode: {e}")))?;
+    if framed.len() < NONCE_LEN {
+        return Err(CastError("ciphertext shorter than nonce".into()));
+    }
+    let (nonce, ciphertext) = framed.split_at(NONCE_LEN);
+    let cipher = cipher()?;
+    cipher
+        .decrypt(XNonce::from_slice(nonce), ciphertext)
+        .map_err(|_| CastError("decryption failed (wrong key or tampered data)".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{Cast, CastValue};
+    use super::EncryptedString;
+
+    /// Set a key for the duration of these (serial) unit tests.
+    fn with_key() {
+        // SAFETY: single-threaded unit test process for this module.
+        std::env::set_var("RUSTANGO_SECRET_KEY", "unit-test-secret-key");
+    }
+
+    #[test]
+    fn round_trips_plaintext() {
+        with_key();
+        let stored = EncryptedString::to_db(&"hello world".to_owned());
+        assert_ne!(stored, "hello world", "stored form must be ciphertext");
+        let back = EncryptedString::from_db(&stored).unwrap();
+        assert_eq!(back, "hello world");
+    }
+
+    #[test]
+    fn distinct_nonce_per_encryption() {
+        with_key();
+        let a = EncryptedString::to_db(&"same".to_owned());
+        let b = EncryptedString::to_db(&"same".to_owned());
+        assert_ne!(a, b, "random nonce → ciphertext differs each write");
+        assert_eq!(EncryptedString::from_db(&a).unwrap(), "same");
+        assert_eq!(EncryptedString::from_db(&b).unwrap(), "same");
+    }
+
+    #[test]
+    fn tampered_ciphertext_fails() {
+        with_key();
+        let mut stored = EncryptedString::to_db(&"secret".to_owned());
+        // Flip a character in the base64 body.
+        stored.replace_range(30..31, if &stored[30..31] == "A" { "B" } else { "A" });
+        assert!(EncryptedString::from_db(&stored).is_err());
+    }
+
+    #[test]
+    fn cast_wrapper_into_sqlvalue_is_ciphertext_string() {
+        with_key();
+        let c: Cast<EncryptedString> = Cast::new("x".to_owned());
+        let v: crate::core::SqlValue = c.into();
+        match v {
+            crate::core::SqlValue::String(s) => assert_ne!(s, "x"),
+            other => panic!("expected SqlValue::String, got {other:?}"),
+        }
+    }
+}

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -544,6 +544,11 @@ pub mod jsonapi;
 ))]
 pub(crate) mod crypto;
 
+/// Attribute casts (#819) — `Cast<C>` field wrapper + `CastValue` trait,
+/// with the `EncryptedString` AEAD-at-rest built-in.
+#[cfg(feature = "casts")]
+pub mod casts;
+
 /// Lowercase-hex codec — pure, no external deps. Lives outside
 /// [`crate::crypto`] so always-on call sites (`pagination` cursor
 /// encoding, `row_to_json` Binary arms) can share one

--- a/crates/rustango/tests/casts_encrypted_pg_live.rs
+++ b/crates/rustango/tests/casts_encrypted_pg_live.rs
@@ -1,0 +1,79 @@
+#![cfg(all(feature = "casts", feature = "postgres"))]
+//! Live PostgreSQL round-trip for the `EncryptedString` cast (#819) —
+//! same coverage as the SQLite test against PG, so the encrypt/decrypt +
+//! TEXT-column path is exercised on a second backend.
+//!
+//! Skips silently when `DATABASE_URL` is unset (runs in CI's
+//! `postgres_test` job).
+
+use std::sync::OnceLock;
+
+use rustango::casts::{Cast, EncryptedString};
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
+use rustango::Model;
+use tokio::sync::Mutex;
+
+fn suite_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "cast_pg_patient")]
+#[allow(dead_code)]
+pub struct Patient {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub ssn: Cast<EncryptedString>,
+}
+
+async fn pool() -> Option<Pool> {
+    std::env::set_var("RUSTANGO_SECRET_KEY", "pg-live-secret");
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pool: Pool = sqlx::PgPool::connect(&url).await.ok()?.into();
+    let pg = pool.as_postgres().unwrap();
+    sqlx::query(r#"DROP TABLE IF EXISTS "cast_pg_patient" CASCADE"#)
+        .execute(pg)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "cast_pg_patient" ("id" BIGSERIAL PRIMARY KEY, "ssn" TEXT NOT NULL)"#,
+    )
+    .execute(pg)
+    .await
+    .unwrap();
+    Some(pool)
+}
+
+#[tokio::test]
+async fn encrypted_cast_round_trips_on_pg() {
+    let _g = suite_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    let plaintext = "top-secret-value";
+
+    let mut patient = Patient {
+        id: Auto::default(),
+        ssn: Cast::new(plaintext.to_owned()),
+    };
+    patient.save_pool(&pool).await.unwrap();
+    let id = *patient.id.get().unwrap();
+
+    let fetched = Patient::objects()
+        .filter("id", id)
+        .first(&pool)
+        .await
+        .unwrap()
+        .expect("row present");
+    assert_eq!(&*fetched.ssn, plaintext);
+
+    // Raw column holds ciphertext.
+    let pg = pool.as_postgres().unwrap();
+    let raw: (String,) = sqlx::query_as(r#"SELECT "ssn" FROM "cast_pg_patient" WHERE "id" = $1"#)
+        .bind(id)
+        .fetch_one(pg)
+        .await
+        .unwrap();
+    assert_ne!(raw.0, plaintext);
+}

--- a/crates/rustango/tests/casts_encrypted_sqlite_live.rs
+++ b/crates/rustango/tests/casts_encrypted_sqlite_live.rs
@@ -1,0 +1,73 @@
+#![cfg(all(feature = "casts", feature = "sqlite"))]
+//! Live SQLite round-trip for the `EncryptedString` attribute cast
+//! (#819): a `Cast<EncryptedString>` field encrypts at rest on INSERT
+//! and decrypts on SELECT, while the raw column holds ciphertext.
+
+use rustango::casts::{Cast, EncryptedString};
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "cast_patient")]
+#[allow(dead_code)]
+pub struct Patient {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 120)]
+    pub name: String,
+    pub ssn: Cast<EncryptedString>,
+}
+
+async fn make_pool() -> Pool {
+    // Key required for the encrypted cast.
+    std::env::set_var("RUSTANGO_SECRET_KEY", "sqlite-live-secret");
+    let p = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::query(
+        "CREATE TABLE cast_patient (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, ssn TEXT NOT NULL)",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    p.into()
+}
+
+#[tokio::test]
+async fn encrypted_cast_round_trips_and_stores_ciphertext() {
+    let pool = make_pool().await;
+    let plaintext = "123-45-6789";
+
+    let mut patient = Patient {
+        id: Auto::default(),
+        name: "Ada".into(),
+        ssn: Cast::new(plaintext.to_owned()),
+    };
+    patient.save_pool(&pool).await.unwrap();
+    let id = *patient.id.get().unwrap();
+
+    // SELECT through the model → decrypts transparently.
+    let fetched = Patient::objects()
+        .filter("id", id)
+        .first(&pool)
+        .await
+        .unwrap()
+        .expect("row present");
+    assert_eq!(&*fetched.ssn, plaintext);
+
+    // Raw column holds ciphertext, not the plaintext.
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!()
+    };
+    let raw: (String,) = sqlx::query_as("SELECT ssn FROM cast_patient WHERE id = ?")
+        .bind(id)
+        .fetch_one(sq)
+        .await
+        .unwrap();
+    assert_ne!(
+        raw.0, plaintext,
+        "column must store ciphertext, not plaintext"
+    );
+    assert!(
+        raw.0.len() > plaintext.len(),
+        "ciphertext carries nonce + tag"
+    );
+}

--- a/crates/rustango/tests/casts_field.rs
+++ b/crates/rustango/tests/casts_field.rs
@@ -1,0 +1,44 @@
+#![cfg(feature = "casts")]
+//! Unit coverage for attribute casts (#819): a `Cast<C>` field maps to a
+//! plain `TEXT` column (`FieldType::String`) — the `CastValue` impl does
+//! the logical↔stored transform at bind/decode time, so no special DDL.
+
+use rustango::casts::{Cast, EncryptedString};
+use rustango::core::{FieldType, Model as _};
+use rustango::sql::{Auto, Dialect, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "cast_patient")]
+#[allow(dead_code)]
+pub struct Patient {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 120)]
+    pub name: String,
+    pub ssn: Cast<EncryptedString>,
+}
+
+fn field(name: &str) -> &'static rustango::core::FieldSchema {
+    Patient::SCHEMA
+        .fields
+        .iter()
+        .find(|f| f.name == name)
+        .unwrap_or_else(|| panic!("no field {name}"))
+}
+
+#[test]
+fn cast_field_maps_to_text_column() {
+    assert_eq!(field("ssn").ty, FieldType::String);
+    // Stored as TEXT on PG; TEXT affinity on SQLite — an ordinary text
+    // column, identical to a plain String field.
+    assert_eq!(Postgres.column_type(field("ssn").ty, None), "TEXT");
+    assert_eq!(Sqlite.column_type(field("ssn").ty, None), "TEXT");
+}
+
+#[test]
+fn cast_wraps_and_derefs_logical_value() {
+    let c: Cast<EncryptedString> = Cast::new("hi".to_owned());
+    assert_eq!(&*c, "hi");
+    assert_eq!(c.into_inner(), "hi");
+}


### PR DESCRIPTION
## What

Closes #819. Eloquent's `$casts` / `CastsAttributes` — a per-field get/set transform layer. A field typed `Cast<C>` stores its logical value in memory but reads/writes the DB through the `CastValue` impl `C`.

```rust
use rustango::casts::{Cast, EncryptedString};

#[derive(Model)]
#[rustango(table = "patient")]
struct Patient {
    #[rustango(primary_key)] id: Auto<i64>,
    ssn: Cast<EncryptedString>,   // plaintext in Rust; AEAD ciphertext in the column
}

let p = Patient { id: Auto::default(), ssn: Cast::new("123-45-6789".into()) };
// &*p.ssn is the plaintext; the `ssn` TEXT column holds ciphertext.
```

## Design

- **`CastValue` trait** (the documented extension point) — `to_db(&Value) -> String` (infallible; fail-fast on misconfig) + `from_db(&str) -> Result<Value, CastError>` (fallible). Implement it on a marker type and use `Cast<MyCast>`.
- **`Cast<C>` newtype** — Deref to the logical value, serde-transparent, `Into<SqlValue>` as TEXT, and **total** sqlx `Type`+`Decode` for PG/MySQL/SQLite (decode `String`, then `C::from_db`). Same newtype-with-custom-sqlx-impls pattern as `Array`/`Range`/`HStore`, so the macro just maps `Cast<C>` → `FieldType::String` (**one line** in `detect_type`) — no per-field bind/decode surgery.
- **`EncryptedString` built-in** — XChaCha20-Poly1305 AEAD, key = SHA-256(`RUSTANGO_SECRET_KEY`), stored as base64(24-byte random nonce ‖ ciphertext+tag). The 192-bit random nonce makes per-write nonces reuse-safe. `from_db` errors on tampered/wrong-key data (authenticated).
- New optional **`casts` feature** (default-on, consistent with the default already pulling `argon2` via `passwords` + `hmac` via `jwt`): adds `chacha20poly1305` + base64/rand/sha2. Excluded from the `sqlite,tenancy` litmus.

## Tests

- `casts_field.rs` — schema maps the cast field to a `TEXT` column; Deref.
- `casts/encrypted.rs` unit (4) — round-trip, distinct-nonce-per-write, tamper-detection, `Into<SqlValue>` is ciphertext.
- `casts_encrypted_{sqlite,pg}_live.rs` — INSERT/SELECT round-trip + **ciphertext-at-rest** (raw column ≠ plaintext), verified against real SQLite + PostgreSQL.

## Gates

- ✅ Litmus `cargo build --no-default-features --features sqlite,tenancy` (casts/chacha excluded)
- ✅ `cargo test --workspace --all-features --no-run` compiles
- ✅ 3183 lib tests pass
- ✅ New deps are RustCrypto (MIT/Apache-2.0, in the deny allowlist)

Closes #819.