### PR TITLE
feat(orm): multi-hop select_related decoder-side stitching (closes #451)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -980,7 +980,17 @@ fn load_related_impl_tokens(struct_name: &syn::Ident, fk_relations: &[FkRelation
         };
         quote! {
             #fk_col => {
-                let _parent: #parent_ty = <#parent_ty>::__rustango_from_aliased_row(row, alias)?;
+                let mut _parent: #parent_ty = <#parent_ty>::__rustango_from_aliased_row(row, alias)?;
+                // Audit #451 — multi-hop `select_related("a__b__c")`:
+                // stitch the deeper relation onto this parent first,
+                // decoding it at the accumulated `__next_alias`. The
+                // parent type also impls `LoadRelated`, so this recurses
+                // the FK chain to arbitrary depth.
+                if let ::core::option::Option::Some(__r) = __rest {
+                    let _ = #root::sql::LoadRelated::__rustango_load_related(
+                        &mut _parent, row, __r, &__next_alias,
+                    )?;
+                }
                 // Loud-in-debug, default-in-release: a divergence
                 // between the FK field's declared `K` (drives the
                 // expected `SqlValue::<Variant>`) and the parent's
@@ -1017,7 +1027,24 @@ fn load_related_impl_tokens(struct_name: &syn::Ident, fk_relations: &[FkRelation
                 field_name: &str,
                 alias: &str,
             ) -> ::core::result::Result<bool, #root::sql::sqlx::Error> {
-                match field_name {
+                // Audit #451 — split the multi-hop path: `base` is the FK
+                // on THIS model, `__rest` (if any) is the remaining chain
+                // to stitch onto the loaded parent. `__next_alias` is the
+                // accumulated join alias the parent's columns live under
+                // (`{alias}__{next-hop}`), matching `lower_select_related`.
+                let (__base, __rest): (&str, ::core::option::Option<&str>) =
+                    match field_name.split_once("__") {
+                        ::core::option::Option::Some((b, r)) => (b, ::core::option::Option::Some(r)),
+                        ::core::option::Option::None => (field_name, ::core::option::Option::None),
+                    };
+                let __next_alias: ::std::string::String = match __rest {
+                    ::core::option::Option::Some(__r) => {
+                        let __rb = __r.split_once("__").map(|(b, _)| b).unwrap_or(__r);
+                        ::std::format!("{}__{}", alias, __rb)
+                    }
+                    ::core::option::Option::None => ::std::string::String::new(),
+                };
+                match __base {
                     #( #arms )*
                     _ => ::core::result::Result::Ok(false),
                 }
@@ -1060,8 +1087,15 @@ fn load_related_impl_my_tokens(
         // and let the macro_rules rebind it to the receiver.
         quote! {
             #fk_col => {
-                let _parent: #parent_ty =
+                let mut _parent: #parent_ty =
                     <#parent_ty>::__rustango_from_aliased_my_row(row, alias)?;
+                // Audit #451 — multi-hop: stitch the deeper relation onto
+                // the parent at the accumulated alias (see PG twin).
+                if let ::core::option::Option::Some(__r) = __rest {
+                    let _ = #root::sql::LoadRelatedMy::__rustango_load_related_my(
+                        &mut _parent, row, __r, &__next_alias,
+                    )?;
+                }
                 // See note in `load_related_impl_tokens` (PG twin) —
                 // the same loud-in-debug invariant guard.
                 let _pk = match <#parent_ty>::__rustango_pk_value(&_parent) {
@@ -1085,7 +1119,7 @@ fn load_related_impl_my_tokens(
         }
     });
     quote! {
-        #root::__impl_my_load_related!(#struct_name, |__self, row, field_name, alias| {
+        #root::__impl_my_load_related!(#struct_name, |__self, row, field_name, alias, __rest, __next_alias| {
             #( #arms )*
         });
     }
@@ -1117,8 +1151,15 @@ fn load_related_impl_sqlite_tokens(
         };
         quote! {
             #fk_col => {
-                let _parent: #parent_ty =
+                let mut _parent: #parent_ty =
                     <#parent_ty>::__rustango_from_aliased_sqlite_row(row, alias)?;
+                // Audit #451 — multi-hop: stitch the deeper relation onto
+                // the parent at the accumulated alias (see PG twin).
+                if let ::core::option::Option::Some(__r) = __rest {
+                    let _ = #root::sql::LoadRelatedSqlite::__rustango_load_related_sqlite(
+                        &mut _parent, row, __r, &__next_alias,
+                    )?;
+                }
                 let _pk = match <#parent_ty>::__rustango_pk_value(&_parent) {
                     #root::core::SqlValue::#variant_ident(v) => v,
                     _other => {
@@ -1140,7 +1181,7 @@ fn load_related_impl_sqlite_tokens(
         }
     });
     quote! {
-        #root::__impl_sqlite_load_related!(#struct_name, |__self, row, field_name, alias| {
+        #root::__impl_sqlite_load_related!(#struct_name, |__self, row, field_name, alias, __rest, __next_alias| {
             #( #arms )*
         });
     }

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -293,7 +293,7 @@ macro_rules! __impl_my_load_related {
     // Fix: capture `$self` explicitly. The proc-macro now passes it
     // through and the macro_rules substitutes it where the arms use
     // it.
-    ($struct:ty, |$self_:ident, $row:ident, $field:ident, $alias:ident| {
+    ($struct:ty, |$self_:ident, $row:ident, $field:ident, $alias:ident, $rest:ident, $next:ident| {
         $($arms:tt)*
     }) => {
         impl $crate::sql::LoadRelatedMy for $struct {
@@ -305,7 +305,23 @@ macro_rules! __impl_my_load_related {
                 $alias: &str,
             ) -> ::core::result::Result<bool, $crate::sql::sqlx::Error> {
                 let $self_ = self;
-                match $field {
+                // Audit #451 — split the multi-hop path so the arms match
+                // the base FK on THIS model and recurse on `$rest` at the
+                // accumulated `$next` alias (see the PG twin for the full
+                // walk-through).
+                let (__base, $rest): (&str, ::core::option::Option<&str>) =
+                    match $field.split_once("__") {
+                        ::core::option::Option::Some((b, r)) => (b, ::core::option::Option::Some(r)),
+                        ::core::option::Option::None => ($field, ::core::option::Option::None),
+                    };
+                let $next: ::std::string::String = match $rest {
+                    ::core::option::Option::Some(__r) => {
+                        let __rb = __r.split_once("__").map(|(b, _)| b).unwrap_or(__r);
+                        ::std::format!("{}__{}", $alias, __rb)
+                    }
+                    ::core::option::Option::None => ::std::string::String::new(),
+                };
+                match __base {
                     $($arms)*
                     _ => ::core::result::Result::Ok(false),
                 }
@@ -318,7 +334,7 @@ macro_rules! __impl_my_load_related {
 #[cfg(not(feature = "mysql"))]
 #[macro_export]
 macro_rules! __impl_my_load_related {
-    ($struct:ty, |$self_:ident, $row:ident, $field:ident, $alias:ident| {
+    ($struct:ty, |$self_:ident, $row:ident, $field:ident, $alias:ident, $rest:ident, $next:ident| {
         $($arms:tt)*
     }) => {};
 }
@@ -382,7 +398,7 @@ macro_rules! __impl_sqlite_aliased_row_decoder {
 #[cfg(feature = "sqlite")]
 #[macro_export]
 macro_rules! __impl_sqlite_load_related {
-    ($struct:ty, |$self_:ident, $row:ident, $field:ident, $alias:ident| {
+    ($struct:ty, |$self_:ident, $row:ident, $field:ident, $alias:ident, $rest:ident, $next:ident| {
         $($arms:tt)*
     }) => {
         impl $crate::sql::LoadRelatedSqlite for $struct {
@@ -394,7 +410,20 @@ macro_rules! __impl_sqlite_load_related {
                 $alias: &str,
             ) -> ::core::result::Result<bool, $crate::sql::sqlx::Error> {
                 let $self_ = self;
-                match $field {
+                // Audit #451 — split the multi-hop path (see PG twin).
+                let (__base, $rest): (&str, ::core::option::Option<&str>) =
+                    match $field.split_once("__") {
+                        ::core::option::Option::Some((b, r)) => (b, ::core::option::Option::Some(r)),
+                        ::core::option::Option::None => ($field, ::core::option::Option::None),
+                    };
+                let $next: ::std::string::String = match $rest {
+                    ::core::option::Option::Some(__r) => {
+                        let __rb = __r.split_once("__").map(|(b, _)| b).unwrap_or(__r);
+                        ::std::format!("{}__{}", $alias, __rb)
+                    }
+                    ::core::option::Option::None => ::std::string::String::new(),
+                };
+                match __base {
                     $($arms)*
                     _ => ::core::result::Result::Ok(false),
                 }
@@ -407,7 +436,7 @@ macro_rules! __impl_sqlite_load_related {
 #[cfg(not(feature = "sqlite"))]
 #[macro_export]
 macro_rules! __impl_sqlite_load_related {
-    ($struct:ty, |$self_:ident, $row:ident, $field:ident, $alias:ident| {
+    ($struct:ty, |$self_:ident, $row:ident, $field:ident, $alias:ident, $rest:ident, $next:ident| {
         $($arms:tt)*
     }) => {};
 }

--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -83,6 +83,33 @@ pub trait LoadRelated {}
 #[cfg(not(feature = "postgres"))]
 impl<T> LoadRelated for T {}
 
+/// Audit #451 — reduce all `select_related` join aliases to the **leaf**
+/// aliases (those that aren't a `__`-boundary prefix of a longer alias),
+/// each paired with its first-hop alias. `lower_select_related` emits one
+/// join per hop (`author`, `author__profile`), so for a multi-hop chain
+/// only the deepest alias is a leaf; the recursive `__rustango_load_related*`
+/// decodes the whole chain from that single leaf. Single-hop aliases come
+/// back as `(alias, alias)` — bit-identical to the pre-#451 stitch.
+pub(crate) fn select_related_leaves(aliases: &[&'static str]) -> Vec<(&'static str, &'static str)> {
+    aliases
+        .iter()
+        .copied()
+        .filter(|a| {
+            // Keep `a` only if no other alias extends it as `a__…`.
+            !aliases.iter().any(|b| {
+                *b != *a
+                    && b.len() > a.len()
+                    && b.starts_with(a)
+                    && b.as_bytes()[a.len()..].starts_with(b"__")
+            })
+        })
+        .map(|a| {
+            let first_hop = a.split_once("__").map(|(h, _)| h).unwrap_or(a);
+            (a, first_hop)
+        })
+        .collect()
+}
+
 #[cfg(feature = "postgres")]
 impl<T> QuerySet<T>
 where
@@ -127,11 +154,14 @@ where
             q = bind_query(q, value);
         }
         let raw_rows = q.fetch_all(executor).await?;
+        // Audit #451 — drive the stitch from leaf aliases so each FK
+        // chain (incl. multi-hop `a__b__c`) is decoded once, recursively.
+        let leaves = select_related_leaves(&select_related_aliases);
         let mut out = Vec::with_capacity(raw_rows.len());
         for row in &raw_rows {
             let mut t = T::from_row(row)?;
-            for alias in &select_related_aliases {
-                let _ = t.__rustango_load_related(row, alias, alias)?;
+            for (leaf, first_hop) in &leaves {
+                let _ = t.__rustango_load_related(row, leaf, first_hop)?;
             }
             out.push(t);
         }
@@ -1556,6 +1586,9 @@ where
 {
     let stmt = tx.dialect().compile_select(query)?;
     let aliases: Vec<&'static str> = query.joins.iter().map(|j| j.alias).collect();
+    // Audit #451 — drive the stitch from leaf aliases so each FK chain
+    // (incl. multi-hop `a__b__c`) is decoded once, recursively.
+    let leaves = select_related_leaves(&aliases);
     match tx {
         #[cfg(feature = "postgres")]
         PoolTx::Postgres(t) => {
@@ -1575,8 +1608,8 @@ where
             let mut out = Vec::with_capacity(raw_rows.len());
             for row in &raw_rows {
                 let mut item = T::from_row(row)?;
-                for alias in &aliases {
-                    let _ = item.__rustango_load_related(row, alias, alias)?;
+                for &(alias, first_hop) in &leaves {
+                    let _ = item.__rustango_load_related(row, alias, first_hop)?;
                 }
                 out.push(item);
             }
@@ -1601,8 +1634,8 @@ where
             let mut out = Vec::with_capacity(raw_rows.len());
             for row in &raw_rows {
                 let mut item = <T as sqlx::FromRow<sqlx::mysql::MySqlRow>>::from_row(row)?;
-                for alias in &aliases {
-                    let _ = item.__rustango_load_related_my(row, alias, alias)?;
+                for &(alias, first_hop) in &leaves {
+                    let _ = item.__rustango_load_related_my(row, alias, first_hop)?;
                 }
                 out.push(item);
             }
@@ -1631,8 +1664,8 @@ where
             let mut out = Vec::with_capacity(raw_rows.len());
             for row in &raw_rows {
                 let mut item = <T as sqlx::FromRow<sqlx::sqlite::SqliteRow>>::from_row(row)?;
-                for alias in &aliases {
-                    let _ = item.__rustango_load_related_sqlite(row, alias, alias)?;
+                for &(alias, first_hop) in &leaves {
+                    let _ = item.__rustango_load_related_sqlite(row, alias, first_hop)?;
                 }
                 out.push(item);
             }
@@ -2312,6 +2345,9 @@ where
     crate::test_assertions::query_counter::bump();
     let stmt = pool.dialect().compile_select(query)?;
     let aliases: Vec<&'static str> = query.joins.iter().map(|j| j.alias).collect();
+    // Audit #451 — drive the stitch from leaf aliases so each FK chain
+    // (incl. multi-hop `a__b__c`) is decoded once, recursively.
+    let leaves = select_related_leaves(&aliases);
 
     match pool {
         #[cfg(feature = "postgres")]
@@ -2334,8 +2370,8 @@ where
             let mut out = Vec::with_capacity(raw_rows.len());
             for row in &raw_rows {
                 let mut t = T::from_row(row)?;
-                for alias in &aliases {
-                    let _ = t.__rustango_load_related(row, alias, alias)?;
+                for &(alias, first_hop) in &leaves {
+                    let _ = t.__rustango_load_related(row, alias, first_hop)?;
                 }
                 out.push(t);
             }
@@ -2362,8 +2398,8 @@ where
             let mut out = Vec::with_capacity(raw_rows.len());
             for row in &raw_rows {
                 let mut t = <T as sqlx::FromRow<sqlx::mysql::MySqlRow>>::from_row(row)?;
-                for alias in &aliases {
-                    let _ = t.__rustango_load_related_my(row, alias, alias)?;
+                for &(alias, first_hop) in &leaves {
+                    let _ = t.__rustango_load_related_my(row, alias, first_hop)?;
                 }
                 out.push(t);
             }
@@ -2394,8 +2430,8 @@ where
             let mut out = Vec::with_capacity(raw_rows.len());
             for row in &raw_rows {
                 let mut t = <T as sqlx::FromRow<sqlx::sqlite::SqliteRow>>::from_row(row)?;
-                for alias in &aliases {
-                    let _ = t.__rustango_load_related_sqlite(row, alias, alias)?;
+                for &(alias, first_hop) in &leaves {
+                    let _ = t.__rustango_load_related_sqlite(row, alias, first_hop)?;
                 }
                 out.push(t);
             }
@@ -3003,5 +3039,37 @@ mod pool_dispatch_tests {
     fn maybe_my_from_row_resolves_for_unit_type() {
         fn check<T: super::MaybeMyFromRow>() {}
         check::<()>();
+    }
+
+    /// Audit #451 — `select_related_leaves` reduces join aliases to the
+    /// deepest in each FK chain, paired with the first-hop alias.
+    #[test]
+    fn select_related_leaves_keeps_deepest_chain_aliases() {
+        // Single-hop FKs: (alias, alias) — bit-identical to pre-#451.
+        assert_eq!(
+            super::select_related_leaves(&["author", "editor"]),
+            vec![("author", "author"), ("editor", "editor")],
+        );
+        // A multi-hop chain emits a join per hop; only the leaf survives,
+        // paired with the first hop (where the base FK lives).
+        assert_eq!(
+            super::select_related_leaves(&[
+                "author",
+                "author__profile",
+                "author__profile__country"
+            ]),
+            vec![("author__profile__country", "author")],
+        );
+        // A single-hop FK alongside a chain.
+        assert_eq!(
+            super::select_related_leaves(&["editor", "author", "author__profile"]),
+            vec![("editor", "editor"), ("author__profile", "author")],
+        );
+        // String-prefix collision that is NOT a `__` boundary must keep
+        // both (e.g. `author` vs `authorship` — not a parent/child).
+        assert_eq!(
+            super::select_related_leaves(&["author", "authorship"]),
+            vec![("author", "author"), ("authorship", "authorship")],
+        );
     }
 }

--- a/crates/rustango/tests/select_related_multihop.rs
+++ b/crates/rustango/tests/select_related_multihop.rs
@@ -254,3 +254,82 @@ fn two_separate_chains_compose_into_distinct_alias_trees() {
         "second chain: {sql}"
     );
 }
+
+// ---------- Decoder-side recursive stitching (#451) ----------
+//
+// T2.2 (#308) shipped the multi-hop JOIN *emission* (pinned above);
+// #451 is the decoder-side gap: a fetched `Post` must come back with
+// `post.author -> profile -> country` all populated as nested loaded
+// objects, not just the columns sitting in the row. Live on SQLite
+// (the cheapest dialect) so the recursive `__rustango_load_related*`
+// is exercised end-to-end.
+#[cfg(feature = "sqlite")]
+mod sqlite_live {
+    use super::Post;
+    use rustango::sql::{sqlx, FetcherPool as _, Pool};
+
+    async fn seeded_pool() -> Pool {
+        let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite mem pool");
+        for ddl in [
+            "CREATE TABLE srm_country (id INTEGER PRIMARY KEY, code TEXT NOT NULL)",
+            "CREATE TABLE srm_profile (id INTEGER PRIMARY KEY, country INTEGER NOT NULL, bio TEXT NOT NULL)",
+            "CREATE TABLE srm_author (id INTEGER PRIMARY KEY, profile INTEGER NOT NULL, name TEXT NOT NULL)",
+            "CREATE TABLE srm_post (id INTEGER PRIMARY KEY, author INTEGER NOT NULL, title TEXT NOT NULL)",
+        ] {
+            sqlx::query(ddl).execute(&sq).await.expect("ddl");
+        }
+        for dml in [
+            "INSERT INTO srm_country (id, code) VALUES (1, 'US')",
+            "INSERT INTO srm_profile (id, country, bio) VALUES (1, 1, 'hello-bio')",
+            "INSERT INTO srm_author (id, profile, name) VALUES (1, 1, 'Ada')",
+            "INSERT INTO srm_post (id, author, title) VALUES (1, 1, 'Hello')",
+        ] {
+            sqlx::query(dml).execute(&sq).await.expect("seed");
+        }
+        Pool::Sqlite(sq)
+    }
+
+    #[tokio::test]
+    async fn three_hop_select_related_stitches_nested_objects() {
+        let pool = seeded_pool().await;
+        let posts: Vec<Post> = Post::objects()
+            .select_related("author__profile__country")
+            .fetch_pool(&pool)
+            .await
+            .expect("fetch");
+        assert_eq!(posts.len(), 1);
+        let post = &posts[0];
+
+        // hop 1 — author (worked pre-#451).
+        let author = post.author.value().expect("hop 1: author stitched");
+        assert_eq!(author.name, "Ada");
+        // hop 2 — THE #451 GAP: profile was never stitched onto author
+        // before the recursive `__rustango_load_related`.
+        let profile = author.profile.value().expect("hop 2: profile stitched");
+        assert_eq!(profile.bio, "hello-bio");
+        // hop 3 — country stitched onto profile.
+        let country = profile.country.value().expect("hop 3: country stitched");
+        assert_eq!(country.code, "US");
+    }
+
+    #[tokio::test]
+    async fn single_hop_does_not_over_stitch() {
+        // Regression guard: select_related("author") must stitch the
+        // author but leave the author's own FK (profile) UNLOADED — the
+        // leaf-alias change must not accidentally pull deeper relations.
+        let pool = seeded_pool().await;
+        let posts: Vec<Post> = Post::objects()
+            .select_related("author")
+            .fetch_pool(&pool)
+            .await
+            .expect("fetch");
+        let author = posts[0].author.value().expect("author stitched");
+        assert_eq!(author.name, "Ada");
+        assert!(
+            !author.profile.is_loaded(),
+            "profile must stay unloaded when only `author` is select_related"
+        );
+    }
+}

--- a/crates/rustango/tests/select_related_multihop.rs
+++ b/crates/rustango/tests/select_related_multihop.rs
@@ -333,3 +333,102 @@ mod sqlite_live {
         );
     }
 }
+
+// Same 3-hop stitch, proven LIVE on Postgres + MySQL so the recursive
+// decoder is verified on every dialect, not just SQLite. Both skip
+// silently when their DB URL is unset (offline / CI-without-DB), matching
+// the rest of the live suite; CI's `e2e (postgres|mysql)` jobs set them.
+#[cfg(feature = "postgres")]
+mod pg_live {
+    use super::Post;
+    use rustango::sql::{sqlx, FetcherPool as _, Pool};
+
+    const DDL: [&str; 8] = [
+        "DROP TABLE IF EXISTS srm_post",
+        "DROP TABLE IF EXISTS srm_author",
+        "DROP TABLE IF EXISTS srm_profile",
+        "DROP TABLE IF EXISTS srm_country",
+        // BIGINT (int8) — the model's `id: i64` / `ForeignKey<_>` PKs
+        // decode as i64; PG is strict about int4-vs-int8.
+        "CREATE TABLE srm_country (id BIGINT PRIMARY KEY, code TEXT NOT NULL)",
+        "CREATE TABLE srm_profile (id BIGINT PRIMARY KEY, country BIGINT NOT NULL, bio TEXT NOT NULL)",
+        "CREATE TABLE srm_author (id BIGINT PRIMARY KEY, profile BIGINT NOT NULL, name TEXT NOT NULL)",
+        "CREATE TABLE srm_post (id BIGINT PRIMARY KEY, author BIGINT NOT NULL, title TEXT NOT NULL)",
+    ];
+    const SEED: [&str; 4] = [
+        "INSERT INTO srm_country (id, code) VALUES (1, 'US')",
+        "INSERT INTO srm_profile (id, country, bio) VALUES (1, 1, 'hello-bio')",
+        "INSERT INTO srm_author (id, profile, name) VALUES (1, 1, 'Ada')",
+        "INSERT INTO srm_post (id, author, title) VALUES (1, 1, 'Hello')",
+    ];
+
+    #[tokio::test]
+    async fn three_hop_select_related_stitches_nested_objects() {
+        let Ok(url) = std::env::var("DATABASE_URL") else {
+            eprintln!("DATABASE_URL unset — skipping PG multi-hop live test");
+            return;
+        };
+        let pg = sqlx::PgPool::connect(&url).await.expect("connect PG");
+        for s in DDL.iter().chain(SEED.iter()) {
+            sqlx::query(s).execute(&pg).await.expect("setup");
+        }
+        let pool = Pool::Postgres(pg);
+        let posts: Vec<Post> = Post::objects()
+            .select_related("author__profile__country")
+            .fetch_pool(&pool)
+            .await
+            .expect("fetch");
+        assert_eq!(posts.len(), 1);
+        let author = posts[0].author.value().expect("hop 1: author");
+        assert_eq!(author.name, "Ada");
+        let profile = author.profile.value().expect("hop 2: profile");
+        assert_eq!(profile.bio, "hello-bio");
+        let country = profile.country.value().expect("hop 3: country");
+        assert_eq!(country.code, "US");
+    }
+}
+
+#[cfg(feature = "mysql")]
+mod my_live {
+    use super::Post;
+    use rustango::sql::{sqlx, FetcherPool as _, Pool};
+
+    #[tokio::test]
+    async fn three_hop_select_related_stitches_nested_objects() {
+        let Ok(url) = std::env::var("MYSQL_TEST_URL") else {
+            eprintln!("MYSQL_TEST_URL unset — skipping MySQL multi-hop live test");
+            return;
+        };
+        let my = sqlx::MySqlPool::connect(&url).await.expect("connect MySQL");
+        let ddl = [
+            "DROP TABLE IF EXISTS srm_post",
+            "DROP TABLE IF EXISTS srm_author",
+            "DROP TABLE IF EXISTS srm_profile",
+            "DROP TABLE IF EXISTS srm_country",
+            "CREATE TABLE srm_country (id BIGINT PRIMARY KEY, code VARCHAR(8) NOT NULL)",
+            "CREATE TABLE srm_profile (id BIGINT PRIMARY KEY, country BIGINT NOT NULL, bio VARCHAR(200) NOT NULL)",
+            "CREATE TABLE srm_author (id BIGINT PRIMARY KEY, profile BIGINT NOT NULL, name VARCHAR(80) NOT NULL)",
+            "CREATE TABLE srm_post (id BIGINT PRIMARY KEY, author BIGINT NOT NULL, title VARCHAR(200) NOT NULL)",
+            "INSERT INTO srm_country (id, code) VALUES (1, 'US')",
+            "INSERT INTO srm_profile (id, country, bio) VALUES (1, 1, 'hello-bio')",
+            "INSERT INTO srm_author (id, profile, name) VALUES (1, 1, 'Ada')",
+            "INSERT INTO srm_post (id, author, title) VALUES (1, 1, 'Hello')",
+        ];
+        for s in ddl {
+            sqlx::query(s).execute(&my).await.expect("setup");
+        }
+        let pool = Pool::Mysql(my);
+        let posts: Vec<Post> = Post::objects()
+            .select_related("author__profile__country")
+            .fetch_pool(&pool)
+            .await
+            .expect("fetch");
+        assert_eq!(posts.len(), 1);
+        let author = posts[0].author.value().expect("hop 1: author");
+        assert_eq!(author.name, "Ada");
+        let profile = author.profile.value().expect("hop 2: profile");
+        assert_eq!(profile.bio, "hello-bio");
+        let country = profile.country.value().expect("hop 3: country");
+        assert_eq!(country.code, "US");
+    }
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -106,7 +106,7 @@ Summary: **22 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-bas
 | `.order_by(*fields)` | [order_by](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#order-by) | SHIPPED | `.order_by(&[("col", false), ...])` + `.unordered()` | |
 | `.reverse()` | [reverse](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#reverse) | SHIPPED | `QuerySet::reverse()` (#325, v0.42) — flips the `desc` flag on every pending `ORDER BY` entry. No-op when no ordering is set; `Random` entries are left untouched. | |
 | `.select_related(*fk)` (single hop) | [select_related](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#select-related) | SHIPPED | `lower_select_related` in query/mod.rs | |
-| `.select_related("a__b__c")` (multi-hop) | [select_related](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#select-related) | PARTIAL | T2.2 closed (PR #308) — JOIN emission ships; decoder-side recursive stitching deferred (#451) | Filter-on-deep-column works via `Expr::AliasedColumn`; `post.author.profile.get_pool()` auto-stitch is a follow-up. |
+| `.select_related("a__b__c")` (multi-hop) | [select_related](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#select-related) | SHIPPED | JOIN emission (PR #308) + decoder-side recursive stitching (#451): `__rustango_load_related*` splits the `__` path, decodes each hop at its accumulated alias, and recurses via the parent's own loader; executor stitches from leaf aliases (`select_related_leaves`). Tri-dialect. | Fetched rows come back with nested loaded FKs (`post.author.value().profile.value().country`) — no N+1. Tested: `select_related_multihop.rs` (sqlite live 3-hop stitch) + `select_related_leaves` unit. |
 | `.prefetch_related(*rel)` | [prefetch_related](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#prefetch-related) | SHIPPED | `sql::fetch_with_prefetch_pool` | Tri-dialect; non-i64 FK PKs supported (v0.26). |
 | `.prefetch_related(Prefetch(qs))` | [Prefetch](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#django.db.models.Prefetch) | SHIPPED | `sql::fetch_with_prefetch_filtered` (T2.1 closed, PR #309) | Global `LIMIT` only — Django's per-parent slice (LATERAL JOIN) is a follow-up. |
 | `.raw(sql)` | [raw](https://docs.djangoproject.com/en/6.0/topics/db/sql/#executing-raw-queries) | SHIPPED | `sql::raw_query_pool` | |
@@ -842,7 +842,7 @@ Ranked by how often a real-world Django project hits the gap. Refreshed 2026-06-
 
 2. **`FileField` / `ImageField` on arbitrary models** (sec 3 + 19, #339 / #340). Rustango has `Media` model + `Storage` trait, but no `pub avatar: FileField` shape on user-defined models. Major DX gap vs Django's "drop a field, get upload + URL + ORM round-trip for free."
 
-3. **`select_related("a__b__c")` decoder-side auto-stitching** (sec 2, #451). T2.2 shipped JOIN emission; `post.author.profile.get_pool(...)` auto-stitch still deferred. Multi-hop reads pay N+1 unless the user explicitly walks the JSON map. PARTIAL.
+3. ~~**`select_related("a__b__c")` decoder-side auto-stitching** (sec 2, #451).~~ **SHIPPED.** Recursive `__rustango_load_related*` (tri-dialect) + leaf-alias executor dispatch stitch the full FK chain into nested loaded objects in one query — no N+1, no manual JSON walk.
 
 4. **`abstract = True` base classes** (sec 1, #322 area). Django uses `abstract = True` for `created_at` / `updated_at` mixin patterns. Currently PARTIAL — Rust trait composition is close but not the same derive-macro UX. `managed = false` covers the operator-managed-table case via #321.
 


### PR DESCRIPTION
## Closes #451 — `.select_related("a__b__c")` (multi-hop)

### Gap
`#308` shipped multi-hop JOIN **emission**, but the decoder only stitched the **first hop**: a fetched `Post` came back with `post.author` loaded yet `author.profile` left unloaded — so multi-hop reads paid N+1 unless the caller manually walked the JSON. Audit status was PARTIAL.

### Fix — recursive decoder-side stitching (tri-dialect)
- **`__rustango_load_related*`** (PG / MySQL / SQLite) now split the `__` path into `(base, rest)`, decode the base FK at its prefix alias, and — if a remainder exists — **recurse into the parent's own loader** at the accumulated `{alias}__{next}` alias, walking the chain to arbitrary depth. Each dialect's recursion calls its matching trait (`LoadRelated` / `LoadRelatedMy` / `LoadRelatedSqlite`). `$rest`/`$next` are threaded through the `__impl_my/sqlite_load_related!` `macro_rules` to stay hygiene-safe.
- **Executor** stitches from **leaf aliases only** (`select_related_leaves`): each FK chain decodes once from its deepest alias, so single-hop behaviour is byte-identical to before. Applied to all fetch paths (`fetch_on`, `fetch_pool`, `PoolTx`).

The emitted JOIN/alias scheme (`author`, `author__profile`, `author__profile__country`) from `lower_select_related` is unchanged; this PR only changes how the returned rows are decoded.

### Result
```rust
let posts = Post::objects()
    .select_related("author__profile__country")
    .fetch_pool(&pool).await?;
let country = posts[0].author.value().unwrap()
    .profile.value().unwrap()
    .country.value().unwrap();   // all nested, one query, no N+1
```

### Tests / verification
- **Tri-dialect**: builds on `postgres`, `sqlite,tenancy` (litmus), `mysql,tenancy`, default, and the `--all-features --no-run` gate (the macro touches every `#[derive(Model)]`).
- **SQLite live** (`select_related_multihop.rs`): `three_hop_select_related_stitches_nested_objects` (nested `author→profile→country` populated) + `single_hop_does_not_over_stitch` regression guard. Existing 10 JOIN-emission tests + admin `list_select_related` / prefetch / adhoc-join tests unchanged.
- **Unit** (`select_related_leaves`): incl. the non-`__`-boundary prefix case (`author` vs `authorship`).
- Audit row `PARTIAL → SHIPPED`.