### PR TITLE
feat(orm): relation existence/aggregates for M2M + generic-FK (closes #830)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -857,6 +857,7 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         &container.default_permissions,
         &container.global_scopes,
         &container.reverse_has_relations,
+        &container.generic_has_relations,
     );
     let module_ident = column_module_ident(struct_name);
     let column_consts = column_const_tokens(&module_ident, &collected.column_entries);
@@ -2320,6 +2321,7 @@ fn model_impl_tokens(
     default_permissions: &[String],
     global_scopes: &[GlobalScopeAttr],
     reverse_has_relations: &[ReverseHasAttr],
+    generic_has_relations: &[GenericHasAttr],
 ) -> TokenStream2 {
     let root = rustango_root();
     let display_tokens = if let Some(name) = display {
@@ -2533,6 +2535,34 @@ fn model_impl_tokens(
             }
         }
     };
+    // Issue #830 — `Model::generic_reverse_relations()` override for
+    // `#[rustango(generic_has(...))]` (the reverse generic-FK arm).
+    let generic_reverse_relations_override = if generic_has_relations.is_empty() {
+        quote!()
+    } else {
+        let entries = generic_has_relations.iter().map(|rel| {
+            let name = rel.name.as_str();
+            let child = &rel.child;
+            let ct_column = rel.ct_column.as_str();
+            let pk_column = rel.pk_column.as_str();
+            let self_pk_column = rel.self_pk_column.as_str();
+            quote! {
+                #root::core::GenericReverseRelation {
+                    name: #name,
+                    child_schema: <#child as #root::core::Model>::SCHEMA,
+                    ct_column: #ct_column,
+                    pk_column: #pk_column,
+                    self_pk_column: #self_pk_column,
+                }
+            }
+        });
+        quote! {
+            fn generic_reverse_relations() -> &'static [#root::core::GenericReverseRelation] {
+                const RELS: &[#root::core::GenericReverseRelation] = &[ #(#entries),* ];
+                RELS
+            }
+        }
+    };
     quote! {
         impl #root::core::Model for #struct_name {
             const SCHEMA: &'static #root::core::ModelSchema = &#root::core::ModelSchema {
@@ -2571,6 +2601,7 @@ fn model_impl_tokens(
             };
 
             #reverse_relations_override
+            #generic_reverse_relations_override
         }
     }
 }
@@ -8002,6 +8033,11 @@ struct ContainerAttrs {
     /// over a correlated subquery against the child table. Users
     /// drop the result into `QuerySet::where_raw(...)`.
     reverse_has_relations: Vec<ReverseHasAttr>,
+    /// `#[rustango(generic_has(...))]` reverse generic-FK declarations —
+    /// issue #830. Each emits a `Model::generic_reverse_relations()`
+    /// entry so the relation-existence family resolves polymorphic
+    /// children by name.
+    generic_has_relations: Vec<GenericHasAttr>,
 }
 
 /// Parsed `#[rustango(global_scope(name = "...", apply = fn_path))]`
@@ -8124,6 +8160,28 @@ struct ReverseHasAttr {
     /// SQL primary-key column on **this** model's table — the column
     /// the `OuterRef` resolves to. Optional; defaults to `"id"`
     /// (rustango's default PK column name).
+    self_pk_column: String,
+}
+
+/// Parsed `#[rustango(generic_has(name, child, ct_column, pk_column
+/// [, self_pk_column]))]` — the reverse generic-FK (GFK) arm of the
+/// relation-existence family (issue #830). The child is a polymorphic,
+/// content-type-discriminated model; emits a `Model::
+/// generic_reverse_relations()` entry the queryset resolves by name.
+struct GenericHasAttr {
+    /// Accessor name, e.g. `name = "tags"`.
+    name: String,
+    /// Child model type identifier (`child = "Tag"`) — looked up for its
+    /// `SCHEMA` so the subquery's `FROM` points at the child table.
+    child: syn::Ident,
+    /// Column on the child table holding the parent's content-type id.
+    /// Optional; defaults to `"content_type_id"`.
+    ct_column: String,
+    /// Column on the child table holding the parent's PK value.
+    /// Optional; defaults to `"object_pk"`.
+    pk_column: String,
+    /// SQL primary-key column on **this** (parent) model's table.
+    /// Optional; defaults to `"id"`.
     self_pk_column: String,
 }
 
@@ -8363,6 +8421,7 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
         global_scopes: Vec::new(),
         through_relations: Vec::new(),
         reverse_has_relations: Vec::new(),
+        generic_has_relations: Vec::new(),
     };
     for attr in &input.attrs {
         if !attr.path().is_ident("rustango") {
@@ -8921,6 +8980,118 @@ fn parse_container_attrs(input: &DeriveInput) -> syn::Result<ContainerAttrs> {
                     name,
                     child,
                     child_fk_column,
+                    self_pk_column,
+                });
+                return Ok(());
+            }
+            if meta.path.is_ident("generic_has") {
+                // `#[rustango(generic_has(name = "tags",
+                //  child = "Tag", ct_column = "content_type_id",
+                //  pk_column = "object_pk" [, self_pk_column = "id"]))]`
+                //  — issue #830, the reverse generic-FK (GFK) arm of the
+                //  relation-existence family.
+                let span = meta.path.span();
+                let mut accessor_name: Option<String> = None;
+                let mut child_ident: Option<syn::Ident> = None;
+                let mut ct_column: Option<String> = None;
+                let mut pk_column: Option<String> = None;
+                let mut self_pk_column: Option<String> = None;
+                meta.parse_nested_meta(|inner| {
+                    if inner.path.is_ident("name") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        let raw = s.value();
+                        if raw.trim().is_empty() {
+                            return Err(syn::Error::new(
+                                s.span(),
+                                "`generic_has(name = \"...\")` must not be empty",
+                            ));
+                        }
+                        accessor_name = Some(raw);
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("child") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        let trimmed = s.value().trim().to_owned();
+                        if trimmed.is_empty() {
+                            return Err(syn::Error::new(
+                                s.span(),
+                                "`generic_has(child = \"...\")` must not be empty",
+                            ));
+                        }
+                        child_ident = Some(syn::Ident::new(&trimmed, s.span()));
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("ct_column") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        let trimmed = s.value().trim().to_owned();
+                        if trimmed.is_empty() {
+                            return Err(syn::Error::new(
+                                s.span(),
+                                "`generic_has(ct_column = \"...\")` must not be empty",
+                            ));
+                        }
+                        ct_column = Some(trimmed);
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("pk_column") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        let trimmed = s.value().trim().to_owned();
+                        if trimmed.is_empty() {
+                            return Err(syn::Error::new(
+                                s.span(),
+                                "`generic_has(pk_column = \"...\")` must not be empty",
+                            ));
+                        }
+                        pk_column = Some(trimmed);
+                        return Ok(());
+                    }
+                    if inner.path.is_ident("self_pk_column") {
+                        let s: LitStr = inner.value()?.parse()?;
+                        let trimmed = s.value().trim().to_owned();
+                        if trimmed.is_empty() {
+                            return Err(syn::Error::new(
+                                s.span(),
+                                "`generic_has(self_pk_column = \"...\")` must not be empty",
+                            ));
+                        }
+                        self_pk_column = Some(trimmed);
+                        return Ok(());
+                    }
+                    Err(inner.error(
+                        "unknown `generic_has` attribute (supported: \
+                         `name`, `child`, `ct_column`, `pk_column`, \
+                         `self_pk_column`)",
+                    ))
+                })?;
+                let Some(name) = accessor_name else {
+                    return Err(syn::Error::new(
+                        span,
+                        "`generic_has` requires `name = \"...\"`",
+                    ));
+                };
+                let Some(child) = child_ident else {
+                    return Err(syn::Error::new(
+                        span,
+                        "`generic_has` requires `child = \"ChildModelType\"`",
+                    ));
+                };
+                let ct_column = ct_column.unwrap_or_else(|| "content_type_id".to_owned());
+                let pk_column = pk_column.unwrap_or_else(|| "object_pk".to_owned());
+                let self_pk_column = self_pk_column.unwrap_or_else(|| "id".to_owned());
+                if out.generic_has_relations.iter().any(|r| r.name == name) {
+                    return Err(syn::Error::new(
+                        span,
+                        format!(
+                            "duplicate `generic_has(name = \"{name}\")` — \
+                             pick a unique accessor name"
+                        ),
+                    ));
+                }
+                out.generic_has_relations.push(GenericHasAttr {
+                    name,
+                    child,
+                    ct_column,
+                    pk_column,
                     self_pk_column,
                 });
                 return Ok(());

--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -151,6 +151,20 @@ pub enum Expr {
     ///
     /// [`AggregateQuery`]: crate::core::AggregateQuery
     AggregateSubquery(Box<super::query::AggregateQuery>),
+    /// Correlated aggregate over a **raw relation table** — the M2M /
+    /// GFK counterpart of [`AggregateSubquery`](Expr::AggregateSubquery)
+    /// for tables that have no `ModelSchema` (issue #830). Emits
+    /// `(SELECT <kind>(<column> | *) FROM <table> WHERE <correlation>)`.
+    /// `column` is `None` for `COUNT(*)` and `Some(col)` for
+    /// `SUM`/`AVG`/`MAX`/`MIN`. The correlation back to the outer row
+    /// (and, for M2M target aggregates, the junction membership) lives
+    /// in [`RelCorrelation`](super::query::RelCorrelation).
+    RelAggregate {
+        kind: super::query::RelAggKind,
+        column: Option<&'static str>,
+        table: &'static str,
+        correlation: super::query::RelCorrelation,
+    },
     /// Reference to an outer query's column from inside a correlated
     /// subquery (issue #5). Emitted as `"<outer_table>"."<col>"`; the
     /// outer table is threaded through the writer at emit time so

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -26,15 +26,15 @@ pub use expr::{BinOp, CaseBranch, Expr, JsonPathStep, ScalarFn, F};
 pub use field_type::{ArrayElem, FieldType, RangeElem};
 pub use query::{
     AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ColumnFilter,
-    CompoundBranch, ConflictClause, CountQuery, DeleteQuery, DistinctMode, Filter, InsertQuery,
-    Join, JoinKind, LockMode, NullsOrder, Op, OrderClause, OrderItem, SearchClause, SelectQuery,
-    SetOp, SubqueryJoin, UpdateQuery, WhereExpr,
+    CompoundBranch, ConflictClause, CountQuery, CtFilter, DeleteQuery, DistinctMode, Filter,
+    InsertQuery, Join, JoinKind, LockMode, NullsOrder, Op, OrderClause, OrderItem, RelAggKind,
+    RelCorrelation, SearchClause, SelectQuery, SetOp, SubqueryJoin, UpdateQuery, WhereExpr,
 };
 pub use schema::{
     infer_app_label_from_module_path, AdminConfig, CheckConstraint, CompositeFkRelation,
-    ExclusionConstraint, FieldSchema, Fieldset, GenericRelation, GlobalScope, IndexMethod,
-    IndexSchema, ListSelectRelated, M2MRelation, Model, ModelEntry, ModelSchema, ModelScope,
-    OnDeleteAction, PrepopulatedField, Relation, ReverseRelation,
+    ExclusionConstraint, FieldSchema, Fieldset, GenericRelation, GenericReverseRelation,
+    GlobalScope, IndexMethod, IndexSchema, ListSelectRelated, M2MRelation, Model, ModelEntry,
+    ModelSchema, ModelScope, OnDeleteAction, PrepopulatedField, Relation, ReverseRelation,
 };
 pub use validate::validate_value;
 pub use value::SqlValue;

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -267,6 +267,73 @@ pub enum WhereExpr {
     /// `Gt`, `Gte`) make sense here; the writer rejects other ops
     /// the same way it does for `ColumnFilter`.
     ExprCompare { lhs: Expr, op: Op, rhs: Expr },
+    /// `[NOT ]EXISTS (SELECT 1 FROM <table> WHERE <correlation>)` over a
+    /// **raw table** — the M2M / GFK arm of the relation-existence
+    /// family (issue #830). Unlike [`Self::Exists`] it doesn't embed a
+    /// [`SelectQuery`] (which would need a `ModelSchema` to project): an
+    /// M2M junction table has no model, and the GFK case only needs a
+    /// literal `SELECT 1`. The correlation back to the outer row (and,
+    /// for GFK, the content-type discriminator) lives in
+    /// [`RelCorrelation`].
+    RelExists {
+        table: &'static str,
+        correlation: RelCorrelation,
+        negated: bool,
+    },
+}
+
+/// Aggregate function for a correlated raw-table relation aggregate
+/// ([`Expr::RelAggregate`]). Distinct from [`AggregateExpr`] because the
+/// raw-table path (M2M / GFK, issue #830) has no `ModelSchema` and only
+/// supports this fixed set — `COUNT(*)` / `SUM` / `AVG` / `MAX` / `MIN`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelAggKind {
+    Count,
+    Sum,
+    Avg,
+    Max,
+    Min,
+}
+
+/// Content-type discriminator for a generic-FK (GFK) relation — AND-ed
+/// into a [`RelCorrelation::Fk`] so a polymorphic child table is
+/// filtered to rows pointing at *this* parent model. Emits
+/// `<ct_column> = (SELECT <ct_pk> FROM <ct_table> WHERE <ct_table_col> =
+/// '<parent_table>')`, resolving the parent's content-type id via a
+/// nested subquery keyed on the compile-time-constant parent table name
+/// (so no async content-type lookup is needed at query-build time).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CtFilter {
+    pub ct_column: &'static str,
+    pub parent_table: &'static str,
+    pub ct_table: &'static str,
+    pub ct_pk: &'static str,
+    pub ct_table_col: &'static str,
+}
+
+/// How a raw-table relation subquery ([`WhereExpr::RelExists`] /
+/// [`Expr::RelAggregate`]) correlates back to the enclosing row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RelCorrelation {
+    /// `<table>.<fk_column> = <outer>.<outer_column>` (plus an optional
+    /// GFK content-type filter). Covers an M2M junction (`fk_column` =
+    /// junction src column) and a generic child (`fk_column` = the
+    /// `object_pk` column, with `ct` set).
+    Fk {
+        fk_column: &'static str,
+        outer_column: &'static str,
+        ct: Option<CtFilter>,
+    },
+    /// `<table>.<target_pk> IN (SELECT <dst_col> FROM <through> WHERE
+    /// <src_col> = <outer>.<outer_column>)` — an M2M aggregate over a
+    /// column on the *target* table, reached through the junction.
+    Membership {
+        target_pk: &'static str,
+        through: &'static str,
+        dst_col: &'static str,
+        src_col: &'static str,
+        outer_column: &'static str,
+    },
 }
 
 impl WhereExpr {
@@ -333,7 +400,8 @@ impl WhereExpr {
             | Self::Exists(_)
             | Self::NotExists(_)
             | Self::InSubquery { .. }
-            | Self::ExprCompare { .. } => None,
+            | Self::ExprCompare { .. }
+            | Self::RelExists { .. } => None,
         }
     }
 
@@ -379,6 +447,12 @@ impl WhereExpr {
             // model's perspective there is nothing to check beyond
             // the column on the LHS of `InSubquery`.
             Self::Exists(_) | Self::NotExists(_) => Ok(()),
+            // Raw-table relation existence (M2M / GFK, issue #830) — the
+            // `table`/correlation columns live on a junction or
+            // polymorphic child, not on `model`; the framework builds
+            // them from trusted relation metadata. Nothing to validate
+            // against the outer model.
+            Self::RelExists { .. } => Ok(()),
             Self::InSubquery { column, .. } => {
                 if model.field_by_column(column).is_none() {
                     return Err(QueryError::UnknownField {
@@ -451,6 +525,11 @@ fn validate_expr_columns(model: &'static ModelSchema, expr: &Expr) -> Result<(),
         Expr::Subquery(_)
         | Expr::AggregateSubquery(_)
         | Expr::OuterRef(_)
+        // `RelAggregate` (issue #830) aggregates a raw relation table
+        // (M2M junction/target or GFK child); its columns live there,
+        // not on `model`, and the framework builds it from trusted
+        // relation metadata — nothing to validate against this model.
+        | Expr::RelAggregate { .. }
         | Expr::AliasedColumn { .. } => Ok(()),
         // Window (issue #7) — args / partition_by / order_by all
         // reference the outer model's columns. Validate them.

--- a/crates/rustango/src/core/schema.rs
+++ b/crates/rustango/src/core/schema.rs
@@ -265,6 +265,39 @@ pub struct ReverseRelation {
     pub self_pk_column: &'static str,
 }
 
+/// Runtime metadata for a **reverse generic-FK** relation, declared via
+/// `#[rustango(generic_has(name, child, ct_column, pk_column))]`. The
+/// M2M/GFK arm of the relation-existence family (issue #830): lets a
+/// parent model resolve "do polymorphic children point at me?" by name
+/// from the queryset, the way [`ReverseRelation`] does for plain
+/// reverse-FK relations.
+///
+/// The child is content-type-discriminated: its `pk_column` (e.g.
+/// `object_pk`) holds the parent's PK and its `ct_column` (e.g.
+/// `content_type_id`) holds the parent model's content-type id. The
+/// existence subquery AND-s a `ct_column = (SELECT id FROM
+/// rustango_content_types WHERE "table" = '<parent_table>')` predicate so
+/// only children pointing at *this* model match — the parent table name
+/// is a compile-time constant, so no async content-type lookup is needed.
+#[derive(Debug, Clone, Copy)]
+pub struct GenericReverseRelation {
+    /// Relation accessor name as declared in `generic_has(name = "tags")`.
+    pub name: &'static str,
+    /// `ModelSchema` of the **child** model — the `FROM` clause of the
+    /// correlated subquery (filled by the macro from
+    /// `<Child as Model>::SCHEMA`).
+    pub child_schema: &'static ModelSchema,
+    /// Column on the child table holding the parent's content-type id
+    /// (e.g. `"content_type_id"`).
+    pub ct_column: &'static str,
+    /// Column on the child table holding the parent's primary-key value
+    /// (e.g. `"object_pk"`) — the `OuterRef` correlation target's match.
+    pub pk_column: &'static str,
+    /// SQL primary-key column on **this** (parent) model's table.
+    /// Defaults to `"id"`.
+    pub self_pk_column: &'static str,
+}
+
 /// Multi-column ("composite") foreign key relation, declared at the
 /// model level rather than the field level — single-column FKs stay
 /// in [`FieldSchema::relation`], composite FKs live here so each
@@ -1145,6 +1178,19 @@ pub trait Model: Sized + Send + Sync + 'static {
     /// `(child_table, child_fk_column, self_pk_column)` without
     /// needing a concrete `self`. Issue #830 sub-piece.
     fn reverse_relations() -> &'static [ReverseRelation] {
+        &[]
+    }
+
+    /// Reverse **generic-FK** existence relations declared via
+    /// `#[rustango(generic_has(name, child, ct_column, pk_column))]`.
+    /// The macro overrides this to return the populated slice; models
+    /// with no `generic_has` declarations inherit the empty default.
+    ///
+    /// Used by the relation-existence family
+    /// ([`crate::query::QuerySet::where_has`] /
+    /// [`crate::query::QuerySet::annotate_count`] / …) to resolve a
+    /// content-type-discriminated child relation by name. Issue #830.
+    fn generic_reverse_relations() -> &'static [GenericReverseRelation] {
         &[]
     }
 }

--- a/crates/rustango/src/core/subquery.rs
+++ b/crates/rustango/src/core/subquery.rs
@@ -62,8 +62,10 @@
 //! executed. Build the subquery first, propagate `?`, then embed.
 
 use super::expr::{CaseBranch, Expr};
-use super::query::{AggregateExpr, AggregateQuery, Op, SelectQuery, WhereExpr};
-use super::schema::ReverseRelation;
+use super::query::{
+    AggregateExpr, AggregateQuery, CtFilter, Op, RelAggKind, RelCorrelation, SelectQuery, WhereExpr,
+};
+use super::schema::{GenericReverseRelation, M2MRelation, ReverseRelation};
 use super::SqlValue;
 
 /// `EXISTS (subquery)` — true when the subquery returns at least one
@@ -204,10 +206,11 @@ pub fn reverse_has_count(rel: &ReverseRelation) -> Expr {
     reverse_has_aggregate(rel, AggregateExpr::Count(None))
 }
 
-/// Build a correlated `CASE WHEN EXISTS (SELECT 1 FROM <child> WHERE
-/// <child_fk> = <outer>.<pk>) THEN 1 ELSE 0 END` projection [`Expr`]
-/// for the given reverse-FK relation — backs
-/// [`crate::query::QuerySet::annotate_exists`] (`withExists`).
+/// Wrap any existence predicate (`EXISTS` / `NOT EXISTS` / `RelExists`,
+/// from the reverse-FK, M2M, or GFK builders) in `CASE WHEN <exists>
+/// THEN 1 ELSE 0 END` so it can be **projected** as a column — backs
+/// [`crate::query::QuerySet::annotate_exists`] (`withExists`) for every
+/// relation kind.
 ///
 /// Integer `1`/`0` literals (rather than booleans) are deliberate: the
 /// projected `<rel>_exists` column then decodes as `SqlValue::I64(0|1)`
@@ -215,10 +218,10 @@ pub fn reverse_has_count(rel: &ReverseRelation) -> Expr {
 /// would return a native `bool` on Postgres but `0|1` on the other two,
 /// so the dict-row value would vary by backend.
 #[must_use]
-pub fn reverse_has_exists_expr(rel: &ReverseRelation) -> Expr {
+pub fn exists_as_int(exists: WhereExpr) -> Expr {
     Expr::Case {
         branches: vec![CaseBranch {
-            condition: reverse_has_exists(rel),
+            condition: exists,
             then: Expr::Literal(SqlValue::I64(1)),
         }],
         default: Some(Box::new(Expr::Literal(SqlValue::I64(0)))),
@@ -242,6 +245,133 @@ pub fn reverse_has_exists_expr(rel: &ReverseRelation) -> Expr {
 #[must_use]
 pub fn outer_ref(column: &'static str) -> Expr {
     Expr::OuterRef(column)
+}
+
+// ----------------------------------------------------------- M2M (#830)
+
+/// `[NOT ]EXISTS (SELECT 1 FROM <through> WHERE <src_col> =
+/// <outer>.<self_pk>)` — many-to-many relation existence over the
+/// junction table. `self_pk` is the parent model's primary-key column.
+/// Backs [`crate::query::QuerySet::where_has`] for M2M relations.
+#[must_use]
+pub fn m2m_has_exists(m2m: &M2MRelation, self_pk: &'static str, negated: bool) -> WhereExpr {
+    WhereExpr::RelExists {
+        table: m2m.through,
+        correlation: RelCorrelation::Fk {
+            fk_column: m2m.src_col,
+            outer_column: self_pk,
+            ct: None,
+        },
+        negated,
+    }
+}
+
+/// Correlated many-to-many aggregate. `Count` counts **junction rows**
+/// (`SELECT COUNT(*) FROM <through> WHERE <src_col> = <outer>.<self_pk>`);
+/// `Sum`/`Avg`/`Max`/`Min` aggregate `column` on the **target** table,
+/// reached through the junction:
+///
+/// ```text
+/// (SELECT <agg>(<column>) FROM <to>
+///  WHERE <to>.id IN (SELECT <dst_col> FROM <through>
+///                    WHERE <src_col> = <outer>.<self_pk>))
+/// ```
+///
+/// The target PK is assumed to be `"id"` — rustango's surrogate-PK
+/// convention; [`M2MRelation`] doesn't carry the target PK column.
+#[must_use]
+pub fn m2m_has_aggregate(
+    m2m: &M2MRelation,
+    self_pk: &'static str,
+    kind: RelAggKind,
+    column: Option<&'static str>,
+) -> Expr {
+    match kind {
+        RelAggKind::Count => Expr::RelAggregate {
+            kind: RelAggKind::Count,
+            column: None,
+            table: m2m.through,
+            correlation: RelCorrelation::Fk {
+                fk_column: m2m.src_col,
+                outer_column: self_pk,
+                ct: None,
+            },
+        },
+        _ => Expr::RelAggregate {
+            kind,
+            column,
+            table: m2m.to,
+            correlation: RelCorrelation::Membership {
+                target_pk: "id",
+                through: m2m.through,
+                dst_col: m2m.dst_col,
+                src_col: m2m.src_col,
+                outer_column: self_pk,
+            },
+        },
+    }
+}
+
+// ----------------------------------------------------- GFK / generic (#830)
+
+/// Build the content-type discriminator for a generic-FK relation. The
+/// registry coordinates (`rustango_content_types` / `id` / `table`)
+/// mirror [`crate::contenttypes::ContentType`]; they're inlined here
+/// rather than read off `ContentType::SCHEMA` so `core` stays free of a
+/// dependency on the higher-level contenttypes app module.
+fn ct_filter(rel: &GenericReverseRelation, parent_table: &'static str) -> CtFilter {
+    CtFilter {
+        ct_column: rel.ct_column,
+        parent_table,
+        ct_table: "rustango_content_types",
+        ct_pk: "id",
+        ct_table_col: "table",
+    }
+}
+
+/// `[NOT ]EXISTS (SELECT 1 FROM <child> WHERE <pk_column> =
+/// <outer>.<self_pk> AND <ct_column> = (SELECT id FROM
+/// rustango_content_types WHERE "table" = '<parent_table>'))` — generic
+/// (polymorphic) relation existence. `parent_table` is the querying
+/// model's table name (a compile-time constant), used to resolve its
+/// content-type id via the nested subquery — no async lookup needed.
+#[must_use]
+pub fn generic_has_exists(
+    rel: &GenericReverseRelation,
+    parent_table: &'static str,
+    negated: bool,
+) -> WhereExpr {
+    WhereExpr::RelExists {
+        table: rel.child_schema.table,
+        correlation: RelCorrelation::Fk {
+            fk_column: rel.pk_column,
+            outer_column: rel.self_pk_column,
+            ct: Some(ct_filter(rel, parent_table)),
+        },
+        negated,
+    }
+}
+
+/// Correlated generic-FK aggregate over a `child` column. The child
+/// table carries the data column, so a single-table aggregate suffices
+/// (no junction). `Count` ignores `column`.
+#[must_use]
+pub fn generic_has_aggregate(
+    rel: &GenericReverseRelation,
+    parent_table: &'static str,
+    kind: RelAggKind,
+    column: Option<&'static str>,
+) -> Expr {
+    Expr::RelAggregate {
+        kind,
+        column,
+        table: rel.child_schema.table,
+        correlation: RelCorrelation::Fk {
+            fk_column: rel.pk_column,
+            outer_column: rel.self_pk_column,
+            ct: Some(ct_filter(rel, parent_table)),
+        },
+    }
 }
 
 #[cfg(test)]

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1350,44 +1350,109 @@ impl<T: Model> QuerySet<T> {
     }
 
     /// Filter to rows that have at least one related row via the
-    /// reverse-FK relation named `name` — Django
-    /// `filter(<name>__isnull=False)` shape via
-    /// `T::reverse_relations()` metadata.
+    /// relation named `name` — Eloquent `has($rel)` / Django
+    /// `filter(<rel>__isnull=False)`. Issue #830.
     ///
-    /// `name` must match a declared
-    /// `#[rustango(reverse_has(name = "...", child = Child,
-    /// child_fk_column = "..."))]` on `T`. The method emits a
-    /// correlated `EXISTS (SELECT 1 FROM <child_table> WHERE
-    /// <child_fk_column> = <outer>.<self_pk_column>)` predicate that
-    /// the writer's scope-stack threads through PG / MySQL / SQLite
-    /// identically.
+    /// `name` is resolved across all three relation kinds (in this
+    /// order), so the same call works regardless of how the relation is
+    /// declared on `T`:
+    /// - **reverse-FK** — `#[rustango(reverse_has(name, child,
+    ///   child_fk_column))]` → `EXISTS (SELECT 1 FROM <child> WHERE
+    ///   <child_fk> = <outer>.<pk>)`.
+    /// - **many-to-many** — `#[rustango(m2m(name, to, through, src,
+    ///   dst))]` → `EXISTS (SELECT 1 FROM <through> WHERE <src> =
+    ///   <outer>.<pk>)` over the junction table.
+    /// - **generic-FK** — `#[rustango(generic_has(name, child,
+    ///   ct_column, pk_column))]` → the same `EXISTS` over the
+    ///   polymorphic child, AND-ed with a content-type discriminator so
+    ///   only children pointing at *this* model match.
     ///
-    /// Unknown relation names surface as
-    /// [`QueryError::UnknownField`] (field set to the unknown name)
-    /// at `compile()` time via the deferred-error path.
+    /// All three lower identically across PG / MySQL / SQLite (the
+    /// writer's scope stack threads the correlation). Unknown relation
+    /// names surface as [`QueryError::UnknownField`] at `compile()` time.
     ///
     /// ```ignore
-    /// // Requires Author declared with
-    /// // `#[rustango(reverse_has(name = "books", child = Book,
-    /// //            child_fk_column = "author_id"))]`.
+    /// // Authors with at least one book (reverse-FK relation "books").
     /// let with_books = Author::objects()
     ///     .where_has("books")
     ///     .fetch_pool(&pool).await?;
     /// ```
-    ///
-    /// Issue #830 — first slice (existence only). Builds on the
-    /// existing per-instance `<name>_exists_expr()` accessor by
-    /// lifting the relation triple into runtime `Model` metadata so
-    /// callers don't need a concrete `self` to resolve it.
     #[must_use]
     pub fn where_has(self, name: &str) -> Self {
-        match T::reverse_relations().iter().find(|r| r.name == name) {
-            Some(rel) => self.where_raw(crate::core::subquery::reverse_has_exists(rel)),
+        match Self::resolve_rel_exists(name, /*negated=*/ false) {
+            Some(expr) => self.where_raw(expr),
             None => self.with_pending_error(QueryError::UnknownField {
                 model: T::SCHEMA.name,
                 field: name.to_string(),
             }),
         }
+    }
+
+    /// This model's primary-key column name (defaults to `"id"`). Used
+    /// to correlate M2M relation subqueries back to the parent row.
+    fn self_pk_column() -> &'static str {
+        T::SCHEMA.primary_key().map_or("id", |f| f.column)
+    }
+
+    /// Resolve a relation `name` — reverse-FK, many-to-many, or
+    /// generic-FK — into a correlated `[NOT ]EXISTS` predicate (issue
+    /// #830). Returns `None` when the name matches no declared relation,
+    /// so callers can surface a [`QueryError::UnknownField`]. Resolution
+    /// order is reverse-FK → M2M → GFK; relation names are expected to
+    /// be unique across the three within a model.
+    fn resolve_rel_exists(name: &str, negated: bool) -> Option<WhereExpr> {
+        use crate::core::subquery;
+        if let Some(rel) = T::reverse_relations().iter().find(|r| r.name == name) {
+            return Some(if negated {
+                subquery::reverse_has_not_exists(rel)
+            } else {
+                subquery::reverse_has_exists(rel)
+            });
+        }
+        if let Some(m2m) = T::SCHEMA.m2m.iter().find(|m| m.name == name) {
+            return Some(subquery::m2m_has_exists(
+                m2m,
+                Self::self_pk_column(),
+                negated,
+            ));
+        }
+        if let Some(g) = T::generic_reverse_relations()
+            .iter()
+            .find(|g| g.name == name)
+        {
+            return Some(subquery::generic_has_exists(g, T::SCHEMA.table, negated));
+        }
+        None
+    }
+
+    /// Resolve a relation `name` into a correlated scalar `COUNT`
+    /// [`Expr`] (the left-hand side of a `has($rel, op, n)` comparison),
+    /// across reverse-FK / M2M / GFK. `None` if unknown. Issue #830.
+    fn resolve_rel_count(name: &str) -> Option<Expr> {
+        use crate::core::{subquery, RelAggKind};
+        if let Some(rel) = T::reverse_relations().iter().find(|r| r.name == name) {
+            return Some(subquery::reverse_has_count(rel));
+        }
+        if let Some(m2m) = T::SCHEMA.m2m.iter().find(|m| m.name == name) {
+            return Some(subquery::m2m_has_aggregate(
+                m2m,
+                Self::self_pk_column(),
+                RelAggKind::Count,
+                None,
+            ));
+        }
+        if let Some(g) = T::generic_reverse_relations()
+            .iter()
+            .find(|g| g.name == name)
+        {
+            return Some(subquery::generic_has_aggregate(
+                g,
+                T::SCHEMA.table,
+                RelAggKind::Count,
+                None,
+            ));
+        }
+        None
     }
 
     /// Opposite of [`Self::where_has`] — filter to rows that have
@@ -1403,8 +1468,8 @@ impl<T: Model> QuerySet<T> {
     /// ```
     #[must_use]
     pub fn where_doesnt_have(self, name: &str) -> Self {
-        match T::reverse_relations().iter().find(|r| r.name == name) {
-            Some(rel) => self.where_raw(crate::core::subquery::reverse_has_not_exists(rel)),
+        match Self::resolve_rel_exists(name, /*negated=*/ true) {
+            Some(expr) => self.where_raw(expr),
             None => self.with_pending_error(QueryError::UnknownField {
                 model: T::SCHEMA.name,
                 field: name.to_string(),
@@ -1533,15 +1598,12 @@ impl<T: Model> QuerySet<T> {
     /// ```
     #[must_use]
     pub fn where_has_count(self, name: &str, op: Op, n: i64) -> Self {
-        match T::reverse_relations().iter().find(|r| r.name == name) {
-            Some(rel) => {
-                let lhs = crate::core::subquery::reverse_has_count(rel);
-                self.where_raw(WhereExpr::ExprCompare {
-                    lhs,
-                    op,
-                    rhs: Expr::Literal(SqlValue::I64(n)),
-                })
-            }
+        match Self::resolve_rel_count(name) {
+            Some(lhs) => self.where_raw(WhereExpr::ExprCompare {
+                lhs,
+                op,
+                rhs: Expr::Literal(SqlValue::I64(n)),
+            }),
             None => self.with_pending_error(QueryError::UnknownField {
                 model: T::SCHEMA.name,
                 field: name.to_string(),
@@ -1635,10 +1697,13 @@ impl<T: Model> QuerySet<T> {
     #[must_use]
     pub fn annotate_exists(self, name: &str) -> AggregateBuilder<T> {
         let mut builder = self.aggregate();
-        match T::reverse_relations().iter().find(|r| r.name == name) {
-            Some(rel) => {
+        // Reuse the existence resolver (reverse-FK / M2M / GFK), then
+        // wrap whatever `[NOT ]EXISTS` it produced in a `CASE WHEN …
+        // THEN 1 ELSE 0` so it projects as an `I64(0|1)` column.
+        match Self::resolve_rel_exists(name, /*negated=*/ false) {
+            Some(exists) => {
                 let expr = AggregateExpr::RelatedAggregate(Box::new(
-                    crate::core::subquery::reverse_has_exists_expr(rel),
+                    crate::core::subquery::exists_as_int(exists),
                 ));
                 builder
                     .aggregates
@@ -1675,38 +1740,91 @@ impl<T: Model> QuerySet<T> {
         agg: AggregateExpr,
         suffix: &str,
     ) -> AggregateBuilder<T> {
+        use crate::core::{subquery, RelAggKind};
         let mut builder = self.aggregate();
-        match T::reverse_relations().iter().find(|r| r.name == name) {
-            Some(rel) => {
-                if let Some(col) = column {
-                    if rel.child_schema.field_by_column(col).is_none() {
-                        builder
-                            .deferred_error
-                            .get_or_insert(QueryError::UnknownField {
-                                model: rel.child_schema.name,
-                                field: col.to_owned(),
-                            });
-                        return builder;
-                    }
+        // `<name>_count` (no column) or `<name>_<suffix>_<column>`.
+        let alias = || match column {
+            Some(col) => std::borrow::Cow::Owned(format!("{name}_{suffix}_{col}")),
+            None => std::borrow::Cow::Owned(format!("{name}_{suffix}")),
+        };
+        // Map the reverse-FK `AggregateExpr` onto the raw-table
+        // `RelAggKind` used by the M2M / GFK builders.
+        let rel_kind = |a: &AggregateExpr| match a {
+            AggregateExpr::Sum(_) => RelAggKind::Sum,
+            AggregateExpr::Avg(_) => RelAggKind::Avg,
+            AggregateExpr::Max(_) => RelAggKind::Max,
+            AggregateExpr::Min(_) => RelAggKind::Min,
+            _ => RelAggKind::Count,
+        };
+
+        // Reverse-FK relation — aggregate over the child table directly.
+        if let Some(rel) = T::reverse_relations().iter().find(|r| r.name == name) {
+            if let Some(col) = column {
+                if rel.child_schema.field_by_column(col).is_none() {
+                    builder
+                        .deferred_error
+                        .get_or_insert(QueryError::UnknownField {
+                            model: rel.child_schema.name,
+                            field: col.to_owned(),
+                        });
+                    return builder;
                 }
-                let alias = match column {
-                    Some(col) => std::borrow::Cow::Owned(format!("{name}_{suffix}_{col}")),
-                    None => std::borrow::Cow::Owned(format!("{name}_{suffix}")),
-                };
-                let expr = AggregateExpr::RelatedAggregate(Box::new(
-                    crate::core::subquery::reverse_has_aggregate(rel, agg),
-                ));
-                builder.aggregates.push((alias, expr));
             }
-            None => {
-                builder
-                    .deferred_error
-                    .get_or_insert(QueryError::UnknownField {
-                        model: T::SCHEMA.name,
-                        field: name.to_owned(),
-                    });
-            }
+            let expr = AggregateExpr::RelatedAggregate(Box::new(subquery::reverse_has_aggregate(
+                rel, agg,
+            )));
+            builder.aggregates.push((alias(), expr));
+            return builder;
         }
+
+        // Many-to-many — `Count` over the junction; `Sum`/`Avg`/`Max`/
+        // `Min` over a target column reached through the junction. The
+        // target table has no `ModelSchema`, so `column` can't be
+        // validated here (a bad column surfaces at the database).
+        if let Some(m2m) = T::SCHEMA.m2m.iter().find(|m| m.name == name) {
+            let expr = AggregateExpr::RelatedAggregate(Box::new(subquery::m2m_has_aggregate(
+                m2m,
+                Self::self_pk_column(),
+                rel_kind(&agg),
+                column,
+            )));
+            builder.aggregates.push((alias(), expr));
+            return builder;
+        }
+
+        // Generic-FK — aggregate over the polymorphic child table,
+        // discriminated by content type.
+        if let Some(g) = T::generic_reverse_relations()
+            .iter()
+            .find(|g| g.name == name)
+        {
+            if let Some(col) = column {
+                if g.child_schema.field_by_column(col).is_none() {
+                    builder
+                        .deferred_error
+                        .get_or_insert(QueryError::UnknownField {
+                            model: g.child_schema.name,
+                            field: col.to_owned(),
+                        });
+                    return builder;
+                }
+            }
+            let expr = AggregateExpr::RelatedAggregate(Box::new(subquery::generic_has_aggregate(
+                g,
+                T::SCHEMA.table,
+                rel_kind(&agg),
+                column,
+            )));
+            builder.aggregates.push((alias(), expr));
+            return builder;
+        }
+
+        builder
+            .deferred_error
+            .get_or_insert(QueryError::UnknownField {
+                model: T::SCHEMA.name,
+                field: name.to_owned(),
+            });
         builder
     }
 
@@ -3146,6 +3264,9 @@ fn validate_expr_columns_in_model(
         Expr::Subquery(_)
         | Expr::AggregateSubquery(_)
         | Expr::OuterRef(_)
+        // `RelAggregate` (issue #830) aggregates a raw relation table;
+        // its columns resolve there, not on this model.
+        | Expr::RelAggregate { .. }
         | Expr::AliasedColumn { .. } => Ok(()),
         // Window (issue #7) — partition_by + order_by + arg columns
         // reference the model. Walk them.

--- a/crates/rustango/src/sql/error.rs
+++ b/crates/rustango/src/sql/error.rs
@@ -43,6 +43,13 @@ pub enum SqlError {
     #[error("bulk UPDATE requires a primary key on the model")]
     MissingPrimaryKey,
 
+    /// A relation aggregate (`Expr::RelAggregate`, issue #830) other than
+    /// `COUNT` was emitted without a target column. The builder should
+    /// always supply one for `SUM`/`AVG`/`MAX`/`MIN`; this guards the
+    /// writer against a malformed node rather than emitting invalid SQL.
+    #[error("relation aggregate `{kind}` requires a target column")]
+    RelAggregateMissingColumn { kind: &'static str },
+
     /// `Op::In` with an empty list — Postgres does not accept `IN ()`.
     #[error("empty `IN` list is not supported")]
     EmptyInList,

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -1410,6 +1410,42 @@ fn write_expr(
             b.sql.push(')');
             Ok(())
         }
+        Expr::RelAggregate {
+            kind,
+            column,
+            table,
+            correlation,
+        } => {
+            use crate::core::RelAggKind;
+            // `(SELECT <kind>(<col>|*) FROM <table> WHERE <correlation>)`
+            // over a raw relation table (M2M junction/target or GFK
+            // child, issue #830). SUM/AVG get the dialect's decoder-side
+            // cast so the scalar decodes as i64/f64 just like the flat
+            // aggregate path; MAX/MIN/COUNT need none.
+            let col_sql = |c: Option<&'static str>, k: &'static str| -> Result<String, SqlError> {
+                c.map(|c| b.d.quote_ident(c))
+                    .ok_or(SqlError::RelAggregateMissingColumn { kind: k })
+            };
+            let agg = match kind {
+                RelAggKind::Count => "COUNT(*)".to_string(),
+                RelAggKind::Sum => {
+                    b.d.cast_aggregate_to_int(&format!("SUM({})", col_sql(*column, "SUM")?))
+                }
+                RelAggKind::Avg => {
+                    b.d.cast_aggregate_to_float(&format!("AVG({})", col_sql(*column, "AVG")?))
+                }
+                RelAggKind::Max => format!("MAX({})", col_sql(*column, "MAX")?),
+                RelAggKind::Min => format!("MIN({})", col_sql(*column, "MIN")?),
+            };
+            b.sql.push_str("(SELECT ");
+            b.sql.push_str(&agg);
+            b.sql.push_str(" FROM ");
+            b.write_ident(table);
+            b.sql.push_str(" WHERE ");
+            write_rel_correlation(b, table, correlation)?;
+            b.sql.push(')');
+            Ok(())
+        }
         Expr::OuterRef(col) => {
             // Resolve against the immediate enclosing scope. The top
             // frame is the *current* query (the subquery emitting
@@ -3292,6 +3328,106 @@ pub(super) fn write_where_expr(
             Ok(())
         }
         WhereExpr::ExprCompare { lhs, op, rhs } => write_expr_compare(b, lhs, *op, rhs),
+        WhereExpr::RelExists {
+            table,
+            correlation,
+            negated,
+        } => {
+            b.sql
+                .push_str(if *negated { "NOT EXISTS (" } else { "EXISTS (" });
+            b.sql.push_str("SELECT 1 FROM ");
+            b.write_ident(table);
+            b.sql.push_str(" WHERE ");
+            write_rel_correlation(b, table, correlation)?;
+            b.sql.push(')');
+            Ok(())
+        }
+    }
+}
+
+/// Emit the WHERE-clause body that correlates a raw-table relation
+/// subquery ([`WhereExpr::RelExists`] / [`Expr::RelAggregate`], issue
+/// #830) back to the enclosing row. These nodes don't embed a
+/// [`SelectQuery`] and therefore push no scope frame of their own, so
+/// the enclosing query is the **top** of the scope stack (unlike
+/// [`Expr::OuterRef`], whose referent is the second-from-top frame).
+fn write_rel_correlation(
+    b: &mut Sql<'_>,
+    table: &str,
+    correlation: &crate::core::RelCorrelation,
+) -> Result<(), SqlError> {
+    use crate::core::RelCorrelation;
+    let outer_table = match b.scope_stack.last() {
+        Some(m) => m.table,
+        // Relation subqueries are only ever emitted inside a query that
+        // pushed its model frame; reaching here means a bug.
+        None => {
+            return Err(SqlError::OuterRefOutsideSubquery {
+                column: "<relation>",
+            })
+        }
+    };
+    match correlation {
+        RelCorrelation::Fk {
+            fk_column,
+            outer_column,
+            ct,
+        } => {
+            // <table>.<fk_column> = <outer>.<outer_column>
+            b.write_ident(table);
+            b.sql.push('.');
+            b.write_ident(fk_column);
+            b.sql.push_str(" = ");
+            b.write_ident(outer_table);
+            b.sql.push('.');
+            b.write_ident(outer_column);
+            // GFK content-type discriminator:
+            //   AND <table>.<ct_column> =
+            //       (SELECT <ct_pk> FROM <ct_table> WHERE <ct_table_col> = $param)
+            if let Some(ct) = ct {
+                b.sql.push_str(" AND ");
+                b.write_ident(table);
+                b.sql.push('.');
+                b.write_ident(ct.ct_column);
+                b.sql.push_str(" = (SELECT ");
+                b.write_ident(ct.ct_pk);
+                b.sql.push_str(" FROM ");
+                b.write_ident(ct.ct_table);
+                b.sql.push_str(" WHERE ");
+                b.write_ident(ct.ct_table_col);
+                b.sql.push_str(" = ");
+                b.push_param(crate::core::SqlValue::String(ct.parent_table.to_owned()));
+                b.sql.push(')');
+            }
+            Ok(())
+        }
+        RelCorrelation::Membership {
+            target_pk,
+            through,
+            dst_col,
+            src_col,
+            outer_column,
+        } => {
+            // <table>.<target_pk> IN
+            //   (SELECT <dst_col> FROM <through> WHERE <src_col> = <outer>.<outer_column>)
+            b.write_ident(table);
+            b.sql.push('.');
+            b.write_ident(target_pk);
+            b.sql.push_str(" IN (SELECT ");
+            b.write_ident(dst_col);
+            b.sql.push_str(" FROM ");
+            b.write_ident(through);
+            b.sql.push_str(" WHERE ");
+            b.write_ident(through);
+            b.sql.push('.');
+            b.write_ident(src_col);
+            b.sql.push_str(" = ");
+            b.write_ident(outer_table);
+            b.sql.push('.');
+            b.write_ident(outer_column);
+            b.sql.push(')');
+            Ok(())
+        }
     }
 }
 
@@ -3503,7 +3639,8 @@ fn write_child(
         WhereExpr::Exists(_)
         | WhereExpr::NotExists(_)
         | WhereExpr::InSubquery { .. }
-        | WhereExpr::ExprCompare { .. } => write_where_expr(b, expr, qualify_with, model),
+        | WhereExpr::ExprCompare { .. }
+        | WhereExpr::RelExists { .. } => write_where_expr(b, expr, qualify_with, model),
         WhereExpr::And(_) | WhereExpr::Or(_) | WhereExpr::Xor(_) | WhereExpr::Not(_) => {
             b.sql.push('(');
             write_where_expr(b, expr, qualify_with, model)?;

--- a/crates/rustango/tests/queryset_rel_m2m_gfk.rs
+++ b/crates/rustango/tests/queryset_rel_m2m_gfk.rs
@@ -1,0 +1,284 @@
+//! Tri-dialect emission tests for the **M2M** and **generic-FK (GFK)**
+//! arms of the relation-existence / eager-aggregate family — issue #830.
+//!
+//! `where_has` / `where_doesnt_have` / `where_has_count` and
+//! `annotate_count` / `annotate_sum` / `annotate_exists` resolve a
+//! relation by name across reverse-FK **and** M2M (junction table) **and**
+//! GFK (content-type-discriminated child). These tests pin the generated
+//! SQL — the raw-table `EXISTS`/aggregate that the junction (no
+//! `ModelSchema`) and the polymorphic child require.
+
+use rustango::core::{Model as _, Op};
+use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+// ---- M2M: Post <-> Tag through rmg_post_tags --------------------------
+
+#[derive(Model)]
+#[rustango(
+    table = "rmg_post",
+    m2m(
+        name = "tags",
+        to = "rmg_tag",
+        through = "rmg_post_tags",
+        src = "post_id",
+        dst = "tag_id",
+        auto_create = false,
+    )
+)]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 80)]
+    title: String,
+}
+
+#[derive(Model)]
+#[rustango(table = "rmg_tag")]
+#[allow(dead_code)]
+pub struct Tag {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 40)]
+    name: String,
+    weight: i64,
+}
+
+// ---- GFK: Article with generic comments (GComment points back) --------
+
+#[derive(Model)]
+#[rustango(
+    table = "rmg_article",
+    generic_has(
+        name = "comments",
+        child = "GComment",
+        ct_column = "content_type_id",
+        pk_column = "object_pk"
+    )
+)]
+#[allow(dead_code)]
+pub struct Article {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 80)]
+    title: String,
+}
+
+#[derive(Model)]
+#[rustango(table = "rmg_gcomment")]
+#[allow(dead_code)]
+pub struct GComment {
+    #[rustango(primary_key)]
+    id: i64,
+    content_type_id: i64,
+    object_pk: i64,
+    #[rustango(max_length = 200)]
+    body: String,
+    score: i64,
+}
+
+// ----------------------------------------------------------------- M2M
+
+#[test]
+fn m2m_where_has_emits_exists_over_junction() {
+    let q = Post::objects()
+        .where_has("tags")
+        .compile()
+        .expect("compile");
+    let sql = Postgres.compile_select(&q).expect("emit").sql;
+    assert!(
+        sql.contains(
+            r#"EXISTS (SELECT 1 FROM "rmg_post_tags" WHERE "rmg_post_tags"."post_id" = "rmg_post"."id")"#
+        ),
+        "M2M where_has should EXISTS over the junction: {sql}"
+    );
+}
+
+#[test]
+fn m2m_where_doesnt_have_emits_not_exists() {
+    let q = Post::objects()
+        .where_doesnt_have("tags")
+        .compile()
+        .expect("compile");
+    let sql = Sqlite.compile_select(&q).expect("emit").sql;
+    assert!(
+        sql.contains(r#"NOT EXISTS (SELECT 1 FROM "rmg_post_tags" WHERE "rmg_post_tags"."post_id" = "rmg_post"."id")"#),
+        "M2M where_doesnt_have should NOT EXISTS over the junction: {sql}"
+    );
+}
+
+#[test]
+fn m2m_where_has_count_emits_correlated_junction_count() {
+    let q = Post::objects()
+        .where_has_count("tags", Op::Gt, 2)
+        .compile()
+        .expect("compile");
+    let sql = Postgres.compile_select(&q).expect("emit").sql;
+    assert!(
+        sql.contains(
+            r#"(SELECT COUNT(*) FROM "rmg_post_tags" WHERE "rmg_post_tags"."post_id" = "rmg_post"."id") > $1"#
+        ),
+        "M2M has(count) should compare a correlated junction COUNT: {sql}"
+    );
+}
+
+#[test]
+fn m2m_annotate_count_projects_junction_count() {
+    let q = Post::objects()
+        .annotate_count("tags")
+        .compile()
+        .expect("compile");
+    let sql = Postgres.compile_aggregate(&q).expect("emit").sql;
+    assert!(
+        sql.contains(
+            r#"(SELECT COUNT(*) FROM "rmg_post_tags" WHERE "rmg_post_tags"."post_id" = "rmg_post"."id") AS "tags_count""#
+        ),
+        "M2M annotate_count column: {sql}"
+    );
+    assert!(
+        sql.contains(r#"GROUP BY "id", "title""#),
+        "Shape-3 GROUP BY over parent columns: {sql}"
+    );
+}
+
+#[test]
+fn m2m_annotate_sum_aggregates_target_column_through_junction() {
+    let q = Post::objects()
+        .annotate_sum("tags", "weight")
+        .compile()
+        .expect("compile");
+    let sql = Postgres.compile_aggregate(&q).expect("emit").sql;
+    // SUM over the *target* table, members selected via the junction.
+    assert!(
+        sql.contains(r#"SUM("weight")"#),
+        "missing SUM(weight): {sql}"
+    );
+    assert!(
+        sql.contains(
+            r#"FROM "rmg_tag" WHERE "rmg_tag"."id" IN (SELECT "tag_id" FROM "rmg_post_tags" WHERE "rmg_post_tags"."post_id" = "rmg_post"."id")"#
+        ),
+        "M2M sum should reach the target via a junction membership: {sql}"
+    );
+    assert!(
+        sql.contains(r#"AS "tags_sum_weight""#),
+        "auto-named alias: {sql}"
+    );
+}
+
+#[test]
+fn m2m_annotate_exists_emits_case_over_junction() {
+    let q = Post::objects()
+        .annotate_exists("tags")
+        .compile()
+        .expect("compile");
+    let sql = Postgres.compile_aggregate(&q).expect("emit").sql;
+    assert!(
+        sql.contains(r#"CASE WHEN EXISTS (SELECT 1 FROM "rmg_post_tags" WHERE "rmg_post_tags"."post_id" = "rmg_post"."id")"#),
+        "M2M annotate_exists CASE/EXISTS: {sql}"
+    );
+    assert!(sql.contains(r#"AS "tags_exists""#), "alias: {sql}");
+}
+
+#[test]
+fn m2m_uses_backtick_quoting_on_mysql() {
+    let q = Post::objects()
+        .where_has("tags")
+        .compile()
+        .expect("compile");
+    let sql = MySql.compile_select(&q).expect("emit").sql;
+    assert!(
+        sql.contains(
+            "EXISTS (SELECT 1 FROM `rmg_post_tags` WHERE `rmg_post_tags`.`post_id` = `rmg_post`.`id`)"
+        ),
+        "MySQL backtick quoting: {sql}"
+    );
+}
+
+// ----------------------------------------------------------------- GFK
+
+#[test]
+fn gfk_where_has_emits_exists_with_content_type_filter() {
+    let q = Article::objects()
+        .where_has("comments")
+        .compile()
+        .expect("compile");
+    let sql = Postgres.compile_select(&q).expect("emit").sql;
+    assert!(
+        sql.contains(
+            r#"EXISTS (SELECT 1 FROM "rmg_gcomment" WHERE "rmg_gcomment"."object_pk" = "rmg_article"."id" AND "rmg_gcomment"."content_type_id" = (SELECT "id" FROM "rustango_content_types" WHERE "table" = $1)"#
+        ),
+        "GFK where_has should EXISTS over the child with a content-type discriminator: {sql}"
+    );
+}
+
+#[test]
+fn gfk_annotate_count_projects_count_with_ct_filter() {
+    let q = Article::objects()
+        .annotate_count("comments")
+        .compile()
+        .expect("compile");
+    let sql = Postgres.compile_aggregate(&q).expect("emit").sql;
+    assert!(
+        sql.contains(r#"(SELECT COUNT(*) FROM "rmg_gcomment" WHERE "rmg_gcomment"."object_pk" = "rmg_article"."id" AND "rmg_gcomment"."content_type_id" = (SELECT "id" FROM "rustango_content_types" WHERE "table" = $1)) AS "comments_count""#),
+        "GFK annotate_count column: {sql}"
+    );
+}
+
+#[test]
+fn gfk_annotate_sum_aggregates_child_column() {
+    let q = Article::objects()
+        .annotate_sum("comments", "score")
+        .compile()
+        .expect("compile");
+    let sql = Postgres.compile_aggregate(&q).expect("emit").sql;
+    assert!(sql.contains(r#"SUM("score")"#), "missing SUM(score): {sql}");
+    assert!(
+        sql.contains(r#"FROM "rmg_gcomment" WHERE "rmg_gcomment"."object_pk" = "rmg_article"."id" AND "rmg_gcomment"."content_type_id" ="#),
+        "GFK sum over child + ct filter: {sql}"
+    );
+    assert!(
+        sql.contains(r#"AS "comments_sum_score""#),
+        "auto-named alias: {sql}"
+    );
+}
+
+#[test]
+fn gfk_uses_backtick_quoting_on_mysql() {
+    let q = Article::objects()
+        .where_has("comments")
+        .compile()
+        .expect("compile");
+    let sql = MySql.compile_select(&q).expect("emit").sql;
+    assert!(
+        sql.contains("FROM `rmg_gcomment` WHERE `rmg_gcomment`.`object_pk` = `rmg_article`.`id`")
+            && sql.contains("(SELECT `id` FROM `rustango_content_types` WHERE `table` = ?)"),
+        "MySQL GFK shape: {sql}"
+    );
+}
+
+// ----------------------------------------------------------- resolution
+
+#[test]
+fn unknown_relation_errors_at_compile_time() {
+    let err = Post::objects().where_has("nope").compile().unwrap_err();
+    assert!(format!("{err}").contains("nope"));
+    let err = Article::objects()
+        .annotate_count("nope")
+        .compile()
+        .unwrap_err();
+    assert!(format!("{err}").contains("nope"));
+}
+
+#[test]
+fn metadata_accessors_expose_m2m_and_generic_relations() {
+    assert_eq!(Post::SCHEMA.m2m.len(), 1);
+    assert_eq!(Post::SCHEMA.m2m[0].name, "tags");
+    assert_eq!(Post::SCHEMA.m2m[0].through, "rmg_post_tags");
+    let g = Article::generic_reverse_relations();
+    assert_eq!(g.len(), 1);
+    assert_eq!(g[0].name, "comments");
+    assert_eq!(g[0].child_schema.table, "rmg_gcomment");
+    assert_eq!(g[0].ct_column, "content_type_id");
+    assert_eq!(g[0].pk_column, "object_pk");
+}

--- a/crates/rustango/tests/queryset_rel_m2m_gfk_live.rs
+++ b/crates/rustango/tests/queryset_rel_m2m_gfk_live.rs
@@ -1,0 +1,339 @@
+//! Live, multi-dialect tests for the **M2M** and **generic-FK (GFK)**
+//! arms of the relation-existence / eager-aggregate family — issue #830.
+//!
+//! Validates end-to-end against real engines that `where_has` /
+//! `annotate_count` / `annotate_sum` resolve M2M (junction) and GFK
+//! (content-type-discriminated child) relations correctly. The GFK
+//! fixture includes a **wrong-content-type decoy** child row to prove
+//! the content-type discriminator excludes children pointing at a
+//! different model.
+//!
+//! - SQLite always runs (in-memory).
+//! - Postgres runs when `DATABASE_URL` is set; MySQL when
+//!   `MYSQL_TEST_URL` is set — each `DROP`s + recreates its tables.
+
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use rustango::core::SqlValue;
+use rustango::sql::FetcherPool as _;
+use rustango::Model;
+
+// M2M: Post <-> Tag through rmg_post_tags
+#[derive(Model)]
+#[rustango(
+    table = "rmg_post",
+    m2m(
+        name = "tags",
+        to = "rmg_tag",
+        through = "rmg_post_tags",
+        src = "post_id",
+        dst = "tag_id",
+        auto_create = false,
+    )
+)]
+pub struct Post {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 80)]
+    title: String,
+}
+
+#[derive(Model)]
+#[rustango(table = "rmg_tag")]
+pub struct Tag {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 40)]
+    name: String,
+    weight: i64,
+}
+
+// GFK: Article with generic comments
+#[derive(Model)]
+#[rustango(
+    table = "rmg_article",
+    generic_has(
+        name = "comments",
+        child = "GComment",
+        ct_column = "content_type_id",
+        pk_column = "object_pk"
+    )
+)]
+pub struct Article {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 80)]
+    title: String,
+}
+
+#[derive(Model)]
+#[rustango(table = "rmg_gcomment")]
+pub struct GComment {
+    #[rustango(primary_key)]
+    id: i64,
+    content_type_id: i64,
+    object_pk: i64,
+    #[rustango(max_length = 200)]
+    body: String,
+    score: i64,
+}
+
+fn get_i64(row: &HashMap<String, SqlValue>, key: &str) -> i64 {
+    match row.get(key).unwrap_or(&SqlValue::Null) {
+        SqlValue::I64(n) => *n,
+        other => panic!("expected i64 at `{key}`, got {other:?}"),
+    }
+}
+
+fn get_string<'r>(row: &'r HashMap<String, SqlValue>, key: &str) -> &'r str {
+    match row.get(key).unwrap_or(&SqlValue::Null) {
+        SqlValue::String(s) => s,
+        other => panic!("expected string at `{key}`, got {other:?}"),
+    }
+}
+
+/// `Some(n)` for an integer cell, `None` for SQL `NULL`. `SUM` over zero
+/// rows is standard-SQL `NULL` on PG/MySQL (SQLite's `CAST` yields 0), so
+/// the sum maps skip childless rows rather than pin that per-dialect quirk.
+fn get_i64_opt(row: &HashMap<String, SqlValue>, key: &str) -> Option<i64> {
+    match row.get(key).unwrap_or(&SqlValue::Null) {
+        SqlValue::I64(n) => Some(*n),
+        SqlValue::Null => None,
+        other => panic!("expected i64/NULL at `{key}`, got {other:?}"),
+    }
+}
+
+/// The shared assertions, run against an already-seeded pool (see
+/// [`seed_sql`] for the fixture). A gcomment under a *different* content
+/// type must be excluded by the GFK discriminator — that's article `R`.
+async fn assert_relations(pool: &rustango::sql::Pool) {
+    // --- M2M counts: A=2, B=1, C=0 ---
+    let by_post: HashMap<String, i64> = Post::objects()
+        .annotate_count("tags")
+        .fetch(pool)
+        .await
+        .unwrap()
+        .iter()
+        .map(|r| (get_string(r, "title").to_owned(), get_i64(r, "tags_count")))
+        .collect();
+    assert_eq!(by_post.get("A"), Some(&2), "post A has 2 tags");
+    assert_eq!(by_post.get("B"), Some(&1));
+    assert_eq!(by_post.get("C"), Some(&0), "post C has no tags");
+
+    // --- M2M sum of a target column through the junction: A=12, B=5 ---
+    let weights: HashMap<String, i64> = Post::objects()
+        .annotate_sum("tags", "weight")
+        .fetch(pool)
+        .await
+        .unwrap()
+        .iter()
+        .filter_map(|r| {
+            Some((
+                get_string(r, "title").to_owned(),
+                get_i64_opt(r, "tags_sum_weight")?,
+            ))
+        })
+        .collect();
+    assert_eq!(weights.get("A"), Some(&12), "A: weights 5 + 7");
+    assert_eq!(weights.get("B"), Some(&5));
+
+    // --- M2M where_has: A, B (not C) ---
+    let mut has_tags: Vec<String> = Post::objects()
+        .where_has("tags")
+        .fetch_pool(pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.title)
+        .collect();
+    has_tags.sort();
+    assert_eq!(has_tags, vec!["A", "B"]);
+
+    // --- GFK counts: P=2, Q=1, R=0 (decoy under a different ct excluded) ---
+    let by_article: HashMap<String, i64> = Article::objects()
+        .annotate_count("comments")
+        .fetch(pool)
+        .await
+        .unwrap()
+        .iter()
+        .map(|r| {
+            (
+                get_string(r, "title").to_owned(),
+                get_i64(r, "comments_count"),
+            )
+        })
+        .collect();
+    assert_eq!(by_article.get("P"), Some(&2), "P has 2 comments");
+    assert_eq!(by_article.get("Q"), Some(&1));
+    assert_eq!(
+        by_article.get("R"),
+        Some(&0),
+        "R's only comment is under a different content type — must be excluded"
+    );
+
+    // --- GFK sum of a child column: P=7, Q=10 ---
+    let scores: HashMap<String, i64> = Article::objects()
+        .annotate_sum("comments", "score")
+        .fetch(pool)
+        .await
+        .unwrap()
+        .iter()
+        .filter_map(|r| {
+            Some((
+                get_string(r, "title").to_owned(),
+                get_i64_opt(r, "comments_sum_score")?,
+            ))
+        })
+        .collect();
+    assert_eq!(scores.get("P"), Some(&7), "P: scores 3 + 4");
+    assert_eq!(scores.get("Q"), Some(&10));
+
+    // --- GFK where_has: P, Q (not R) ---
+    let mut commented: Vec<String> = Article::objects()
+        .where_has("comments")
+        .fetch_pool(pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|a| a.title)
+        .collect();
+    commented.sort();
+    assert_eq!(commented, vec!["P", "Q"]);
+}
+
+/// Seed statements shared across dialects. `reserved_table` is the
+/// dialect-quoted form of the reserved `table` column (`"table"` on
+/// PG/SQLite, `` `table` `` on MySQL). Content-type id `1` maps to
+/// `rmg_article`; id `99` is a decoy model — the gcomment under ct `99`
+/// (pointing at article `3`/`R`) must be excluded by the GFK
+/// discriminator.
+fn seed_sql(reserved_table: &str) -> Vec<String> {
+    vec![
+        "INSERT INTO rmg_post (id, title) VALUES (1, 'A'), (2, 'B'), (3, 'C')".to_owned(),
+        "INSERT INTO rmg_tag (id, name, weight) VALUES (10, 'x', 5), (20, 'y', 7)".to_owned(),
+        "INSERT INTO rmg_post_tags (post_id, tag_id) VALUES (1, 10), (1, 20), (2, 10)".to_owned(),
+        "INSERT INTO rmg_article (id, title) VALUES (1, 'P'), (2, 'Q'), (3, 'R')".to_owned(),
+        // content type rows: id 1 = rmg_article, id 99 = some other model.
+        format!(
+            "INSERT INTO rustango_content_types (id, app_label, model_name, {reserved_table}) \
+             VALUES (1, 'app', 'article', 'rmg_article'), (99, 'app', 'other', 'rmg_other')"
+        ),
+        // comments: P(obj 1) x2, Q(obj 2) x1 under ct 1; one decoy under ct 99 → R(obj 3).
+        format!(
+            "INSERT INTO rmg_gcomment (id, content_type_id, object_pk, body, score) VALUES \
+             (1, 1, 1, 'a', 3), (2, 1, 1, 'b', 4), (3, 1, 2, 'c', 10), (4, 99, 3, 'decoy', 1000)"
+        ),
+    ]
+}
+
+// ----------------------------------------------------------------- SQLite
+
+#[cfg(feature = "sqlite")]
+mod sqlite_live {
+    use super::*;
+    use rustango::sql::{sqlx, Pool};
+
+    async fn pool() -> Pool {
+        let p = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite");
+        for ddl in [
+            "CREATE TABLE rmg_post (id INTEGER PRIMARY KEY, title TEXT NOT NULL)",
+            "CREATE TABLE rmg_tag (id INTEGER PRIMARY KEY, name TEXT NOT NULL, weight INTEGER NOT NULL)",
+            "CREATE TABLE rmg_post_tags (post_id INTEGER NOT NULL, tag_id INTEGER NOT NULL)",
+            "CREATE TABLE rmg_article (id INTEGER PRIMARY KEY, title TEXT NOT NULL)",
+            "CREATE TABLE rmg_gcomment (id INTEGER PRIMARY KEY, content_type_id INTEGER NOT NULL, object_pk INTEGER NOT NULL, body TEXT NOT NULL, score INTEGER NOT NULL)",
+            "CREATE TABLE rustango_content_types (id INTEGER PRIMARY KEY, app_label TEXT NOT NULL, model_name TEXT NOT NULL, \"table\" TEXT NOT NULL)",
+        ] {
+            sqlx::query(ddl).execute(&p).await.expect(ddl);
+        }
+        for stmt in seed_sql("\"table\"") {
+            sqlx::query(&stmt).execute(&p).await.expect(&stmt);
+        }
+        p.into()
+    }
+
+    #[tokio::test]
+    async fn m2m_and_gfk_relations() {
+        let pool = pool().await;
+        assert_relations(&pool).await;
+    }
+}
+
+// --------------------------------------------------------------- Postgres
+
+#[cfg(feature = "postgres")]
+mod pg_live {
+    use super::*;
+    use rustango::sql::{sqlx, Pool};
+
+    #[tokio::test]
+    async fn m2m_and_gfk_relations() {
+        let Ok(url) = std::env::var("DATABASE_URL") else {
+            eprintln!("DATABASE_URL unset — skipping PG M2M/GFK live test");
+            return;
+        };
+        let pg = sqlx::PgPool::connect(&url).await.expect("connect PG");
+        for ddl in [
+            "DROP TABLE IF EXISTS rmg_post_tags",
+            "DROP TABLE IF EXISTS rmg_gcomment",
+            "DROP TABLE IF EXISTS rmg_post",
+            "DROP TABLE IF EXISTS rmg_tag",
+            "DROP TABLE IF EXISTS rmg_article",
+            "DROP TABLE IF EXISTS rustango_content_types",
+            "CREATE TABLE rmg_post (id BIGINT PRIMARY KEY, title VARCHAR(80) NOT NULL)",
+            "CREATE TABLE rmg_tag (id BIGINT PRIMARY KEY, name VARCHAR(40) NOT NULL, weight BIGINT NOT NULL)",
+            "CREATE TABLE rmg_post_tags (post_id BIGINT NOT NULL, tag_id BIGINT NOT NULL)",
+            "CREATE TABLE rmg_article (id BIGINT PRIMARY KEY, title VARCHAR(80) NOT NULL)",
+            "CREATE TABLE rmg_gcomment (id BIGINT PRIMARY KEY, content_type_id BIGINT NOT NULL, object_pk BIGINT NOT NULL, body VARCHAR(200) NOT NULL, score BIGINT NOT NULL)",
+            "CREATE TABLE rustango_content_types (id BIGINT PRIMARY KEY, app_label VARCHAR(100) NOT NULL, model_name VARCHAR(100) NOT NULL, \"table\" VARCHAR(100) NOT NULL)",
+        ] {
+            sqlx::query(ddl).execute(&pg).await.expect(ddl);
+        }
+        for stmt in seed_sql("\"table\"") {
+            sqlx::query(&stmt).execute(&pg).await.expect(&stmt);
+        }
+        let pool: Pool = pg.into();
+        assert_relations(&pool).await;
+    }
+}
+
+// ------------------------------------------------------------------ MySQL
+
+#[cfg(feature = "mysql")]
+mod my_live {
+    use super::*;
+    use rustango::sql::{sqlx, Pool};
+
+    #[tokio::test]
+    async fn m2m_and_gfk_relations() {
+        let Ok(url) = std::env::var("MYSQL_TEST_URL") else {
+            eprintln!("MYSQL_TEST_URL unset — skipping MySQL M2M/GFK live test");
+            return;
+        };
+        let my = sqlx::MySqlPool::connect(&url).await.expect("connect MySQL");
+        for ddl in [
+            "DROP TABLE IF EXISTS rmg_post_tags",
+            "DROP TABLE IF EXISTS rmg_gcomment",
+            "DROP TABLE IF EXISTS rmg_post",
+            "DROP TABLE IF EXISTS rmg_tag",
+            "DROP TABLE IF EXISTS rmg_article",
+            "DROP TABLE IF EXISTS rustango_content_types",
+            "CREATE TABLE rmg_post (id BIGINT PRIMARY KEY, title VARCHAR(80) NOT NULL)",
+            "CREATE TABLE rmg_tag (id BIGINT PRIMARY KEY, name VARCHAR(40) NOT NULL, weight BIGINT NOT NULL)",
+            "CREATE TABLE rmg_post_tags (post_id BIGINT NOT NULL, tag_id BIGINT NOT NULL)",
+            "CREATE TABLE rmg_article (id BIGINT PRIMARY KEY, title VARCHAR(80) NOT NULL)",
+            "CREATE TABLE rmg_gcomment (id BIGINT PRIMARY KEY, content_type_id BIGINT NOT NULL, object_pk BIGINT NOT NULL, body VARCHAR(200) NOT NULL, score BIGINT NOT NULL)",
+            "CREATE TABLE rustango_content_types (id BIGINT PRIMARY KEY, app_label VARCHAR(100) NOT NULL, model_name VARCHAR(100) NOT NULL, `table` VARCHAR(100) NOT NULL)",
+        ] {
+            sqlx::query(ddl).execute(&my).await.expect(ddl);
+        }
+        for stmt in seed_sql("`table`") {
+            sqlx::query(&stmt).execute(&my).await.expect(&stmt);
+        }
+        let pool: Pool = my.into();
+        assert_relations(&pool).await;
+    }
+}


### PR DESCRIPTION
## What

Closes **#830** — extends the relation-existence family (`where_has` / `where_doesnt_have` / `where_has_count`) and the eager-aggregate family (`annotate_count` / `_sum` / `_avg` / `_max` / `_min` / `_exists`) to resolve **many-to-many** and **generic-FK (GFK)** relations by name, alongside the reverse-FK support shipped in #979–#981 + #992. One `where_has("tags")` / `annotate_count("tags")` call now works regardless of how the relation is declared.

```rust
// M2M — #[rustango(m2m(name="tags", to=, through=, src=, dst=))]
Post::objects().where_has("tags")               // EXISTS over the junction
Post::objects().annotate_count("tags")          // tags_count (junction rows)
Post::objects().annotate_sum("tags", "weight")  // over the target, via the junction

// GFK — #[rustango(generic_has(name="comments", child=, ct_column=, pk_column=))]
Article::objects().where_has("comments")         // EXISTS + content-type discriminator
Article::objects().annotate_count("comments")    // comments_count
```

> Stacked on #992 (`feat/annotate-count-relation-830`) — based on that branch so this diff is M2M/GFK-only. GitHub will retarget to `develop` when #992 merges.

## How

Both kinds need a correlated subquery over a table with **no `ModelSchema`** (an M2M junction) or a **polymorphic** one (a GFK child) — which the `SelectQuery`/`AggregateQuery`-based subqueries (used for reverse-FK) can't express, since they project a model's scalar fields. Added two purpose-built IR nodes that unify both kinds and touch **zero** existing query literals:

- `WhereExpr::RelExists { table, correlation, negated }`
- `Expr::RelAggregate { kind, column, table, correlation }`
- `RelCorrelation::{ Fk { fk_column, outer_column, ct }, Membership { target_pk, through, dst_col, src_col, outer_column } }`

The writer emits `[NOT ]EXISTS (SELECT 1 FROM <table> WHERE …)` / `(SELECT <agg> FROM <table> WHERE …)`, correlating to the enclosing row via the scope stack — identical lowering on PG / MySQL / SQLite.

- **M2M** existence/count correlate over the junction (`<src> = outer.pk`); sum/avg/max/min aggregate a *target* column reached through the junction (`<target>.id IN (SELECT <dst> FROM <through> WHERE <src> = outer.pk)`).
- **GFK** correlate over the polymorphic child (`<object_pk> = outer.pk`), AND-ed with a content-type discriminator `<ct_column> = (SELECT id FROM rustango_content_types WHERE "table" = '<parent_table>')`. The parent table is a compile-time constant, so the content-type id resolves via a **nested subquery — no async lookup** at query-build time.

### Plumbing
- New `#[rustango(generic_has(name, child, ct_column, pk_column [, self_pk_column]))]` attribute + `GenericReverseRelation` metadata + `Model::generic_reverse_relations()` (mirrors the `reverse_has` path). M2M reuses the existing `ModelSchema::m2m` metadata — **no new attribute**.
- `where_has` / `annotate_*` dispatch **reverse-FK → M2M → GFK** by name.
- `core::subquery`: `m2m_has_exists` / `m2m_has_aggregate` / `generic_has_exists` / `generic_has_aggregate`; `exists_as_int` generalizes the `withExists` CASE wrapper to any existence predicate.

## Tests
- **13 tri-dialect SQL-emission unit tests** (`queryset_rel_m2m_gfk.rs`) — junction EXISTS/count, target-membership SUM, GFK child + content-type subquery, per-dialect quoting, metadata accessors, unknown-relation errors.
- **3 live tests** across SQLite / PG16 / MySQL8.0 (`queryset_rel_m2m_gfk_live.rs`). The GFK fixture includes a **wrong-content-type decoy** child to prove the discriminator excludes children pointing at a different model.
- Full suite: **3366 lib tests pass**; reverse-FK regression green (the dispatch refactor preserves it); `cargo test --workspace --all-features --no-run` green; CI clippy clean; `sqlite,tenancy` litmus builds.

## Closes #830
With M2M + GFK landed, the relation-existence + eager-aggregate family covers all three relation kinds the issue's acceptance criteria call for. The one deliberate simplification: M2M target aggregates assume the target PK is `id` (rustango's surrogate-PK convention; `M2MRelation` doesn't carry the target PK column).