### PR TITLE
feat(orm): pgvector vector column + similarity search (closes #824)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,15 +51,18 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        # Pulled from AWS Public ECR's Docker Hub mirror to side-step
-        # the intermittent `registry-1.docker.io context deadline
-        # exceeded` failures that occasionally hit the e2e job (no
-        # rate-limit info in the error — just a connectivity flake).
-        # `public.ecr.aws/docker/library/` is a verbatim mirror of
-        # Docker Hub's official-image namespace; same digests, same
-        # tags, far better availability for CI traffic. (Issue: CI
-        # Docker timeouts after PR #848 / #866.)
-        image: public.ecr.aws/docker/library/postgres:16-alpine
+        # pgvector/pgvector:pg16 = postgres:16 + the `vector` extension
+        # preinstalled (issue #824 — the vector live tests run
+        # `CREATE EXTENSION vector`). A superset of the stock image, so
+        # every existing PG test runs unchanged.
+        #
+        # NOTE: the other PG services here pull from the AWS Public ECR
+        # mirror (`public.ecr.aws/docker/library/`) to dodge the
+        # intermittent `registry-1.docker.io context deadline exceeded`
+        # flakes (PR #848 / #866). That mirror only carries Docker Hub's
+        # official `library/` namespace; pgvector lives in a user
+        # namespace, so this one image comes straight from Docker Hub.
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: rustango
           POSTGRES_PASSWORD: rustango

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -10178,6 +10178,10 @@ struct FieldAttrs {
     /// silently ignored on non-FK fields. Follow-up to #816.
     related_name: Option<String>,
     max_length: Option<u32>,
+    /// `#[rustango(vector(dims = N))]` — pgvector column dimension (#824).
+    /// Threaded into `FieldType::Vector(N)` at emission. `None` → an
+    /// unconstrained `vector` column.
+    vector_dims: Option<u32>,
     min: Option<i64>,
     max: Option<i64>,
     default: Option<String>,
@@ -10290,6 +10294,7 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
         on_delete: None,
         related_name: None,
         max_length: None,
+        vector_dims: None,
         min: None,
         max: None,
         default: None,
@@ -10394,6 +10399,20 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
             if meta.path.is_ident("max_length") {
                 let lit: syn::LitInt = meta.value()?.parse()?;
                 out.max_length = Some(lit.base10_parse::<u32>()?);
+                return Ok(());
+            }
+            // `#[rustango(vector(dims = N))]` — pgvector column
+            // dimension (#824). Nested-meta form so it reads like the
+            // other typed-column attrs.
+            if meta.path.is_ident("vector") {
+                meta.parse_nested_meta(|inner| {
+                    if inner.path.is_ident("dims") {
+                        let lit: syn::LitInt = inner.value()?.parse()?;
+                        out.vector_dims = Some(lit.base10_parse::<u32>()?);
+                        return Ok(());
+                    }
+                    Err(inner.error("unknown `vector` attribute (supported: `dims`)"))
+                })?;
                 return Ok(());
             }
             if meta.path.is_ident("min") {
@@ -10912,7 +10931,17 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
     }
     let relation = relation_tokens(field, &attrs, fk_inner, table)?;
     let column_lit = column.as_str();
-    let field_type_tokens = kind.variant_tokens();
+    // pgvector (#824): the `vector(dims = N)` attribute supplies the
+    // dimension that the bare `Vector` Rust type can't carry, so emit
+    // `FieldType::Vector(N)` here rather than the `variant_tokens`
+    // fallback of `Vector(0)`.
+    let field_type_tokens = if kind == DetectedKind::Vector {
+        let root = rustango_root();
+        let dims = attrs.vector_dims.unwrap_or(0);
+        quote!(#root::core::FieldType::Vector(#dims))
+    } else {
+        kind.variant_tokens()
+    };
     let max_length = optional_u32(attrs.max_length);
     let min = optional_i64(attrs.min);
     let max = optional_i64(attrs.max);
@@ -11176,6 +11205,10 @@ enum DetectedKind {
     RangeDateTime,
     /// `HStore` → PG `hstore` (#342).
     HStore,
+    /// `Vector` → pgvector `vector(N)` (#824). The dimension `N` comes
+    /// from the `#[rustango(vector(dims = N))]` field attribute, threaded
+    /// in at the `FieldType` emission site (not carried on this enum).
+    Vector,
 }
 
 impl DetectedKind {
@@ -11221,6 +11254,9 @@ impl DetectedKind {
                 quote!(#root::core::FieldType::Range(#root::core::RangeElem::DateTime))
             }
             Self::HStore => quote!(#root::core::FieldType::HStore),
+            // Dimension comes from the `vector(dims = N)` attribute,
+            // applied at the emission site; `0` here is just a fallback.
+            Self::Vector => quote!(#root::core::FieldType::Vector(0)),
         }
     }
 
@@ -11278,6 +11314,8 @@ impl DetectedKind {
             | Self::RangeDateTime => (quote!(RangeLiteral), quote!(::std::string::String::new())),
             // HStore (#342) can't be a FK PK — never reached.
             Self::HStore => (quote!(HStore), quote!(::std::vec::Vec::new())),
+            // Vector (#824) can't be a FK PK — never reached.
+            Self::Vector => (quote!(Vector), quote!(::std::vec::Vec::new())),
         }
     }
 }
@@ -11520,6 +11558,16 @@ fn detect_type(ty: &syn::Type) -> syn::Result<DetectedType<'_>> {
         "HStore" => {
             return Ok(DetectedType {
                 kind: DetectedKind::HStore,
+                nullable: false,
+                auto: false,
+                fk_inner: None,
+            });
+        }
+        // `Vector` → pgvector `vector(N)` (#824). The dimension is
+        // supplied by `#[rustango(vector(dims = N))]`, not the type.
+        "Vector" => {
+            return Ok(DetectedType {
+                kind: DetectedKind::Vector,
                 nullable: false,
                 auto: false,
                 fk_inner: None,

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -125,6 +125,8 @@ pub(crate) fn render_value_for_input_json(row: &serde_json::Value, field: &Field
         FieldType::Range(_) => v.as_str().map_or_else(|| v.to_string(), str::to_owned),
         // #342 — PG hstore: compact JSON object form.
         FieldType::HStore => v.to_string(),
+        // #824 — pgvector: compact JSON array form.
+        FieldType::Vector(_) => v.to_string(),
     }
 }
 
@@ -348,6 +350,10 @@ fn render_input_default(field: &FieldSchema, value: &str, pk_locked: bool) -> St
         FieldType::HStore => format!(
             r#"<input type="text" name="{name}" id="{name}" value="{val}" placeholder="{{&quot;key&quot;: &quot;value&quot;}}"{required}{readonly}>"#
         ),
+        // #824 — pgvector: a JSON-array text input (`[0.1, 0.2, ...]`).
+        FieldType::Vector(_) => format!(
+            r#"<input type="text" name="{name}" id="{name}" value="{val}" placeholder="[0.1, 0.2, ...]"{required}{readonly}>"#
+        ),
     }
 }
 
@@ -527,6 +533,10 @@ pub(crate) fn render_value_json(row: &serde_json::Value, field: &FieldSchema) ->
         FieldType::HStore => serde_json::to_string(v)
             .map(|s| escape(&s))
             .unwrap_or_default(),
+        // #824 — pgvector: compact JSON array in the list cell.
+        FieldType::Vector(_) => serde_json::to_string(v)
+            .map(|s| escape(&s))
+            .unwrap_or_default(),
     }
 }
 
@@ -603,6 +613,8 @@ pub(crate) fn read_joined_value_as_html_json(
         FieldType::Range(_) => None,
         // #342 — hstore isn't a meaningful select_related join target.
         FieldType::HStore => None,
+        // #824 — vector isn't a meaningful select_related join target.
+        FieldType::Vector(_) => None,
     };
     text.map(|s| escape(&s))
 }

--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -1278,6 +1278,9 @@ fn bind_value_pg(
         SqlValue::HStore(_) => {
             unreachable!("HStore values never reach audited-save bind path")
         }
+        SqlValue::Vector(_) => {
+            unreachable!("Vector values never reach audited-save bind path")
+        }
     }
 }
 
@@ -1311,6 +1314,9 @@ fn bind_value_my(
         }
         SqlValue::HStore(_) => {
             unreachable!("HStore values never reach audited-save bind path")
+        }
+        SqlValue::Vector(_) => {
+            unreachable!("Vector values never reach audited-save bind path")
         }
     }
 }
@@ -1347,6 +1353,9 @@ fn bind_value_sqlite<'q>(
         }
         SqlValue::HStore(_) => {
             unreachable!("HStore values never reach audited-save bind path")
+        }
+        SqlValue::Vector(_) => {
+            unreachable!("Vector values never reach audited-save bind path")
         }
     }
 }

--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -78,6 +78,43 @@ pub enum BinOp {
     BitShl,
     /// Right shift.
     BitShr,
+    /// pgvector L2 (Euclidean) distance — `<->`. **PG-only** (#824); the
+    /// writer raises `OpNotSupportedInDialect` on MySQL / SQLite.
+    L2Distance,
+    /// pgvector cosine distance — `<=>`. **PG-only** (#824).
+    CosineDistance,
+    /// pgvector (negative) inner product — `<#>`. **PG-only** (#824).
+    /// pgvector returns the negative inner product, so ascending order
+    /// still ranks most-similar first.
+    InnerProduct,
+}
+
+/// Distance metric for pgvector similarity search (#824) — the
+/// user-facing selector for [`crate::query::QuerySet::order_by_distance`]
+/// / [`k_nearest`](crate::query::QuerySet::k_nearest). Maps to the
+/// pgvector distance operator ([`BinOp::L2Distance`] / `CosineDistance`
+/// / `InnerProduct`). Ascending order always ranks the most-similar row
+/// first (pgvector's `<#>` returns the *negative* inner product).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VectorMetric {
+    /// L2 / Euclidean distance — pgvector `<->`.
+    L2,
+    /// Cosine distance — pgvector `<=>`.
+    Cosine,
+    /// (Negative) inner product — pgvector `<#>`.
+    InnerProduct,
+}
+
+impl VectorMetric {
+    /// The [`BinOp`] distance operator this metric lowers to.
+    #[must_use]
+    pub const fn to_binop(self) -> BinOp {
+        match self {
+            Self::L2 => BinOp::L2Distance,
+            Self::Cosine => BinOp::CosineDistance,
+            Self::InnerProduct => BinOp::InnerProduct,
+        }
+    }
 }
 
 /// RHS expression — literal, column reference, arithmetic tree, or

--- a/crates/rustango/src/core/field_type.rs
+++ b/crates/rustango/src/core/field_type.rs
@@ -61,6 +61,13 @@ pub enum FieldType {
     /// / SQLite degrade to `TEXT` and the decode path errors there.
     /// Requires the `hstore` extension on the database.
     HStore,
+    /// Native pgvector `vector(N)` embedding column — Eloquent 13's
+    /// `vector(...)` (#824). `N` is the dimension; `0` means
+    /// unconstrained (`vector`). Rust type: [`crate::sql::Vector`].
+    /// **PG-only by language semantics** like [`Self::Array`]: MySQL /
+    /// SQLite degrade to `TEXT`, and the decode path + distance
+    /// operators error there. Requires the `vector` extension.
+    Vector(u32),
 }
 
 /// Element type of a [`FieldType::Range`] column (#343). Selects the
@@ -151,6 +158,7 @@ impl FieldType {
             Self::Range(RangeElem::Date) => "Range<NaiveDate>",
             Self::Range(RangeElem::DateTime) => "Range<DateTime<Utc>>",
             Self::HStore => "HStore",
+            Self::Vector(_) => "Vector",
         }
     }
 }

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -22,7 +22,7 @@ pub mod window;
 pub use case::{case, value, CaseBuilder};
 pub use column::{Column, TypedAssignment, TypedExpr, TypedFieldList, TypedFilter};
 pub use error::QueryError;
-pub use expr::{BinOp, CaseBranch, Expr, JsonPathStep, ScalarFn, F};
+pub use expr::{BinOp, CaseBranch, Expr, JsonPathStep, ScalarFn, VectorMetric, F};
 pub use field_type::{ArrayElem, FieldType, RangeElem};
 pub use query::{
     AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ColumnFilter,

--- a/crates/rustango/src/core/validate.rs
+++ b/crates/rustango/src/core/validate.rs
@@ -47,7 +47,8 @@ pub fn validate_value(
         | SqlValue::Json(_)
         | SqlValue::Decimal(_)
         | SqlValue::Binary(_)
-        | SqlValue::HStore(_) => Ok(()),
+        | SqlValue::HStore(_)
+        | SqlValue::Vector(_) => Ok(()),
     }
 }
 

--- a/crates/rustango/src/core/value.rs
+++ b/crates/rustango/src/core/value.rs
@@ -77,6 +77,12 @@ pub enum SqlValue {
     /// (no `hstore` type). Built from [`crate::sql::HStore`] via
     /// `Into<SqlValue>`.
     HStore(Vec<(String, Option<String>)>),
+    /// pgvector embedding — a dense `Vec<f32>`. Issue #824. Backend-
+    /// neutral at this layer; the PG bind path encodes it as the
+    /// pgvector `vector` wire format (via [`crate::sql::Vector`]), MySQL
+    /// / SQLite reject (no `vector` type). Built from
+    /// [`crate::sql::Vector`] via `Into<SqlValue>`.
+    Vector(Vec<f32>),
 }
 
 impl SqlValue {
@@ -123,6 +129,10 @@ impl SqlValue {
                     .collect();
                 format!("hstore{{{}}}", inner.join(", "))
             }
+            Self::Vector(items) => {
+                let inner: Vec<String> = items.iter().map(f32::to_string).collect();
+                format!("vector[{}]", inner.join(", "))
+            }
         }
     }
 
@@ -134,7 +144,11 @@ impl SqlValue {
             | Self::List(_)
             | Self::Array(_)
             | Self::RangeLiteral(_)
-            | Self::HStore(_) => return None,
+            | Self::HStore(_)
+            // `Vector` carries no dimension here; the column's
+            // `FieldType::Vector(dims)` comes from the schema, so a bound
+            // value can't be type-checked against it. Skip (like Array).
+            | Self::Vector(_) => return None,
             Self::I16(_) => FieldType::I16,
             Self::I32(_) => FieldType::I32,
             Self::I64(_) => FieldType::I64,

--- a/crates/rustango/src/forms/mod.rs
+++ b/crates/rustango/src/forms/mod.rs
@@ -239,10 +239,12 @@ pub fn parse_pk_string(field: &FieldSchema, raw: &str) -> Result<SqlValue, FormE
         | FieldType::Json
         | FieldType::Decimal
         | FieldType::Binary
-        // #341 / #343 / #342 — array / range / hstore can't be a PK.
+        // #341 / #343 / #342 / #824 — array / range / hstore / vector
+        // can't be a PK.
         | FieldType::Array(_)
         | FieldType::Range(_)
-        | FieldType::HStore => Err(FormError::UnsupportedPk {
+        | FieldType::HStore
+        | FieldType::Vector(_) => Err(FormError::UnsupportedPk {
             field: field.name.to_owned(),
             ty: field.ty.as_str(),
         }),
@@ -417,6 +419,13 @@ pub fn parse_form_value(field: &FieldSchema, raw: Option<&str>) -> Result<SqlVal
             let map: std::collections::BTreeMap<String, Option<String>> = serde_json::from_str(raw)
                 .map_err(|e| make_parse_err("hstore (JSON object)", &e))?;
             Ok(SqlValue::HStore(map.into_iter().collect()))
+        }
+        // #824 — pgvector column from a form field: a JSON array of
+        // numbers (`[0.1, 0.2, 0.3]`).
+        FieldType::Vector(_) => {
+            let vec: Vec<f32> = serde_json::from_str(raw)
+                .map_err(|e| make_parse_err("vector (JSON array of numbers)", &e))?;
+            Ok(SqlValue::Vector(vec))
         }
     }
 }

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -3004,6 +3004,21 @@ fn json_to_sql_value(
                 .collect::<Result<Vec<_>, _>>()?;
             Ok(SqlValue::HStore(pairs))
         }
+        // #824 — pgvector column from a fixture: a JSON array of numbers.
+        FieldType::Vector(_) => {
+            let arr = v
+                .as_array()
+                .ok_or_else(|| format!("expected JSON array for Vector column, got {v}"))?;
+            let items = arr
+                .iter()
+                .map(|el| {
+                    el.as_f64()
+                        .map(|n| n as f32)
+                        .ok_or_else(|| format!("expected numeric vector element, got {el}"))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(SqlValue::Vector(items))
+        }
     }
 }
 

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -528,6 +528,10 @@ pub(crate) fn field_type_name(ty: FieldType) -> &'static str {
         FieldType::Range(crate::core::RangeElem::DateTime) => "range_datetime",
         // #342 — PG hstore.
         FieldType::HStore => "hstore",
+        // #824 — pgvector. NOTE: dims aren't encoded here (this returns
+        // `&'static str`), so a dimension-only change (`vector(3)` →
+        // `vector(4)`) isn't surfaced as a schema diff.
+        FieldType::Vector(_) => "vector",
     }
 }
 

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -776,6 +776,63 @@ impl<T: Model> QuerySet<T> {
         self
     }
 
+    /// Order rows by pgvector similarity to `query` over the `column`
+    /// vector column — Eloquent 13's `whereVectorSimilarTo(...)` auto-
+    /// ordering (#824). Ascending distance, so the **nearest** rows come
+    /// first (pgvector's `<#>` returns the negative inner product, so
+    /// ascending ranks most-similar first for every metric).
+    ///
+    /// Emits `ORDER BY <column> <op> $vec` where `<op>` is the pgvector
+    /// distance operator for `metric` (`<->` / `<=>` / `<#>`). **PG-only**
+    /// — the writer raises `OpNotSupportedInDialect` on MySQL / SQLite.
+    /// Pair with `.limit(k)` (or use [`Self::k_nearest`]) for a k-NN
+    /// query. The column should be a [`crate::sql::Vector`] /
+    /// `#[rustango(vector(dims = N))]` field.
+    ///
+    /// ```ignore
+    /// use rustango::core::VectorMetric;
+    /// // 5 nearest documents to `query_embedding` by cosine distance.
+    /// let hits = Doc::objects()
+    ///     .order_by_distance("embedding", query_embedding, VectorMetric::Cosine)
+    ///     .limit(5)
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    #[must_use]
+    pub fn order_by_distance(
+        self,
+        column: &'static str,
+        query: Vec<f32>,
+        metric: crate::core::VectorMetric,
+    ) -> Self {
+        let expr = crate::core::Expr::BinOp {
+            left: Box::new(crate::core::Expr::Column(column)),
+            op: metric.to_binop(),
+            right: Box::new(crate::core::Expr::Literal(SqlValue::Vector(query))),
+        };
+        self.order_by_expr(expr, /*desc=*/ false)
+    }
+
+    /// k-nearest-neighbour shortcut: [`Self::order_by_distance`] followed
+    /// by `.limit(k)` — the `k` rows closest to `query` under `metric`.
+    /// Issue #824, **PG-only**.
+    ///
+    /// ```ignore
+    /// use rustango::core::VectorMetric;
+    /// let top3 = Doc::objects()
+    ///     .k_nearest("embedding", query_embedding, 3, VectorMetric::L2)
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    #[must_use]
+    pub fn k_nearest(
+        self,
+        column: &'static str,
+        query: Vec<f32>,
+        k: i64,
+        metric: crate::core::VectorMetric,
+    ) -> Self {
+        self.order_by_distance(column, query, metric).limit(k)
+    }
+
     /// Same as [`Self::order_by_expr`] but with an explicit
     /// `NullsOrder`. Issue #76.
     #[must_use]

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -364,6 +364,10 @@ pub trait Dialect {
             FieldType::Range(crate::core::RangeElem::DateTime) => "tstzrange",
             // PG hstore CAST target (#342).
             FieldType::HStore => "hstore",
+            // pgvector `vector(N)` carries a dynamic dimension, so it
+            // has no `&'static` CAST spelling — casting to it isn't
+            // supported through this path (#824).
+            FieldType::Vector(_) => return None,
         })
     }
 
@@ -407,6 +411,10 @@ pub trait Dialect {
             // Native PG hstore column (#342). Requires the `hstore`
             // extension on the database.
             FieldType::HStore => "hstore".into(),
+            // pgvector `vector(N)` column (#824); `0` = unconstrained
+            // dimension. Requires the `vector` extension.
+            FieldType::Vector(0) => "vector".into(),
+            FieldType::Vector(dims) => format!("vector({dims})"),
         }
     }
 

--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -764,6 +764,10 @@ macro_rules! bind_match {
             SqlValue::HStore(pairs) => {
                 $q.bind(sqlx::postgres::types::PgHstore(pairs.into_iter().collect()))
             }
+            // pgvector embedding (#824) — bind via the `Vector` newtype's
+            // PG `Encode` (binary wire format); the column/param type is
+            // `vector`, resolved by name.
+            SqlValue::Vector(v) => $q.bind(crate::sql::Vector(v)),
             // PG single-parameter array (issue #30). v1 supports
             // I32/I64/String/Bool elements; other element kinds
             // panic at bind time. Homogeneous-element arrays are
@@ -848,6 +852,9 @@ macro_rules! bind_match_mysql {
             SqlValue::HStore(_) => {
                 unreachable!("MySQL has no hstore type; `HStore` columns are PG-only. Issue #342.")
             }
+            SqlValue::Vector(_) => unreachable!(
+                "MySQL has no vector type; pgvector distance operators are rejected before bind. Issue #824."
+            ),
         }
     };
 }
@@ -892,6 +899,9 @@ macro_rules! bind_match_sqlite {
             SqlValue::HStore(_) => {
                 unreachable!("SQLite has no hstore type; `HStore` columns are PG-only. Issue #342.")
             }
+            SqlValue::Vector(_) => unreachable!(
+                "SQLite has no vector type; pgvector distance operators are rejected before bind. Issue #824."
+            ),
         }
     };
 }

--- a/crates/rustango/src/sql/executor/row_to_json.rs
+++ b/crates/rustango/src/sql/executor/row_to_json.rs
@@ -144,6 +144,8 @@ where
             FieldType::Range(_) => Value::Null,
             // #342 — PG hstore columns; same generic-decode story.
             FieldType::HStore => Value::Null,
+            // #824 — pgvector columns; typed fetch decodes via `Vector`.
+            FieldType::Vector(_) => Value::Null,
         };
         map.insert(field.name.to_owned(), value);
     }
@@ -285,6 +287,8 @@ pub fn row_to_json_sqlite(
             FieldType::Range(_) => Value::Null,
             // #342 — hstore is PG-only; never present on SQLite.
             FieldType::HStore => Value::Null,
+            // #824 — pgvector is PG-only; typed fetch decodes via `Vector`.
+            FieldType::Vector(_) => Value::Null,
         };
         map.insert(field.name.to_owned(), value);
     }

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -25,6 +25,7 @@ mod postgres;
 mod range;
 #[cfg(feature = "sqlite")]
 mod sqlite;
+mod vector;
 mod writers;
 
 pub use array::Array;
@@ -38,6 +39,7 @@ pub use dialect::Dialect;
 pub use error::{is_mysql_dup_index_error, ExecError, SqlError};
 pub use hstore::HStore;
 pub use range::Range;
+pub use vector::Vector;
 // Always-on: tri-dialect entry points + traits that don't pin on PG.
 #[cfg(feature = "mysql")]
 pub use executor::row_to_json_my;

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -148,7 +148,8 @@ impl Dialect for MySql {
             | FieldType::Json
             | FieldType::Array(_)
             | FieldType::Range(_)
-            | FieldType::HStore => return None,
+            | FieldType::HStore
+            | FieldType::Vector(_) => return None,
         })
     }
 
@@ -202,6 +203,8 @@ impl Dialect for MySql {
             FieldType::Range(_) => "TEXT".into(),
             // Ditto for PG hstore columns (#342).
             FieldType::HStore => "TEXT".into(),
+            // Ditto for pgvector `vector` columns (#824).
+            FieldType::Vector(_) => "TEXT".into(),
         }
     }
 

--- a/crates/rustango/src/sql/postgres.rs
+++ b/crates/rustango/src/sql/postgres.rs
@@ -121,6 +121,10 @@ impl Dialect for Postgres {
                 | "tablespaces"
                 | "json_path"
                 | "json_query"
+                // pgvector similarity search (#824). Requires the
+                // `vector` extension to be installed/enabled.
+                | "pgvector"
+                | "vector"
         ) || self.default_supports(token)
     }
 

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -191,6 +191,8 @@ impl Dialect for Sqlite {
             FieldType::Range(_) => "TEXT",
             // Ditto for PG hstore columns (#342).
             FieldType::HStore => "TEXT",
+            // Ditto for pgvector `vector` columns (#824).
+            FieldType::Vector(_) => "TEXT",
         })
     }
 
@@ -221,6 +223,8 @@ impl Dialect for Sqlite {
             FieldType::Range(_) => "TEXT".into(),
             // Ditto for PG hstore columns (#342).
             FieldType::HStore => "TEXT".into(),
+            // Ditto for pgvector `vector` columns (#824).
+            FieldType::Vector(_) => "TEXT".into(),
         }
     }
 

--- a/crates/rustango/src/sql/vector.rs
+++ b/crates/rustango/src/sql/vector.rs
@@ -1,0 +1,307 @@
+//! `Vector` — pgvector embedding column wrapper (Eloquent 13
+//! `vector(...)` / similarity search, issue #824).
+//!
+//! Declare a `vector(N)` column on a model and round-trip it as a Rust
+//! `Vec<f32>`:
+//!
+//! ```ignore
+//! #[derive(Model)]
+//! #[rustango(table = "doc")]
+//! struct Doc {
+//!     #[rustango(primary_key)]
+//!     id: Auto<i64>,
+//!     // → DDL `embedding vector(3)`; round-trips as a `Vec<f32>`.
+//!     #[rustango(vector(dims = 3))]
+//!     embedding: Vector,
+//! }
+//! ```
+//!
+//! Pairs with the distance operators
+//! ([`crate::core::BinOp::L2Distance`] / `CosineDistance` /
+//! `InnerProduct`, pgvector `<->` / `<=>` / `<#>`) and the queryset
+//! helpers [`crate::query::QuerySet::order_by_distance`] /
+//! [`k_nearest`](crate::query::QuerySet::k_nearest).
+//!
+//! ## PostgreSQL only, by language semantics
+//!
+//! `vector` is a Postgres extension type (pgvector). Like trigram /
+//! full-text / `Array<T>`, `Vector` is **PG-only by language
+//! semantics**: the migration writer emits a degraded `TEXT` column on
+//! MySQL / SQLite, and the [`sqlx::Decode`] path + the distance
+//! operators raise a clear error on those backends rather than silently
+//! mis-storing. The type still *compiles* under every backend (the
+//! per-backend [`sqlx::Type`] / [`sqlx::Decode`] impls below are total),
+//! so the `sqlite,tenancy` litmus build keeps passing.
+//!
+//! ## Why a newtype rather than a bare `Vec<f32>`
+//!
+//! Same rationale as [`crate::sql::Array`]: `#[derive(Model)]` emits one
+//! shared `FromRow` body reused across the PG / MySQL / SQLite decoders.
+//! A bare `Vec<f32>` doesn't decode the pgvector `vector` type at all,
+//! and would fail to compile the non-PG decoder arms. `Vector` carries
+//! total `Decode` / `Type` impls for all three backends (a real
+//! pgvector binary codec on PG, erroring stubs elsewhere).
+
+use std::ops::{Deref, DerefMut};
+
+/// pgvector embedding column — see the [module docs](self). Transparent
+/// newtype over `Vec<f32>`.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Vector(pub Vec<f32>);
+
+impl Vector {
+    /// Wrap a `Vec<f32>` as a vector column value.
+    #[must_use]
+    pub fn new(items: Vec<f32>) -> Self {
+        Self(items)
+    }
+
+    /// Consume the wrapper, returning the inner `Vec<f32>`.
+    #[must_use]
+    pub fn into_inner(self) -> Vec<f32> {
+        self.0
+    }
+
+    /// pgvector text representation — `[1,2,3]`. Used when binding the
+    /// query vector as a text literal isn't needed (we bind the binary
+    /// form), but handy for diagnostics + the text decode fallback.
+    #[must_use]
+    pub fn to_pg_text(&self) -> String {
+        let mut s = String::with_capacity(self.0.len() * 4 + 2);
+        s.push('[');
+        for (i, v) in self.0.iter().enumerate() {
+            if i > 0 {
+                s.push(',');
+            }
+            s.push_str(&v.to_string());
+        }
+        s.push(']');
+        s
+    }
+}
+
+impl Deref for Vector {
+    type Target = Vec<f32>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Vector {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<Vec<f32>> for Vector {
+    fn from(v: Vec<f32>) -> Self {
+        Self(v)
+    }
+}
+
+impl From<Vector> for Vec<f32> {
+    fn from(v: Vector) -> Self {
+        v.0
+    }
+}
+
+impl FromIterator<f32> for Vector {
+    fn from_iter<I: IntoIterator<Item = f32>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+// ---- serde: behave exactly like the inner Vec (plain JSON array) ----
+
+impl serde::Serialize for Vector {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Vector {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Vec::<f32>::deserialize(deserializer).map(Self)
+    }
+}
+
+// ---- `Vector` → `SqlValue` (INSERT / UPDATE bind, via SqlValue::Vector) ----
+
+impl From<Vector> for crate::core::SqlValue {
+    fn from(v: Vector) -> Self {
+        crate::core::SqlValue::Vector(v.0)
+    }
+}
+
+// ---- pgvector binary wire format -------------------------------------
+//
+// A `vector` value is `[int16 dim][int16 unused][float4 × dim]`, all
+// big-endian. (Matches the `pgvector` crate's encoding so we don't take
+// a dependency on it.)
+
+#[cfg(feature = "postgres")]
+fn encode_pgvector(v: &[f32], buf: &mut Vec<u8>) {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    let dim = v.len() as i16;
+    buf.extend_from_slice(&dim.to_be_bytes());
+    buf.extend_from_slice(&0i16.to_be_bytes()); // unused
+    for &x in v {
+        buf.extend_from_slice(&x.to_be_bytes());
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn decode_pgvector_binary(bytes: &[u8]) -> Result<Vec<f32>, sqlx::error::BoxDynError> {
+    if bytes.len() < 4 {
+        return Err("pgvector binary value too short (missing header)".into());
+    }
+    let dim = i16::from_be_bytes([bytes[0], bytes[1]]) as usize;
+    let body = &bytes[4..];
+    if body.len() != dim * 4 {
+        return Err(format!(
+            "pgvector binary value: header dim {dim} != {} float4 payload bytes",
+            body.len()
+        )
+        .into());
+    }
+    let mut out = Vec::with_capacity(dim);
+    for chunk in body.chunks_exact(4) {
+        out.push(f32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+    }
+    Ok(out)
+}
+
+#[cfg(feature = "postgres")]
+fn decode_pgvector_text(s: &str) -> Result<Vec<f32>, sqlx::error::BoxDynError> {
+    // `[1,2,3]`
+    let inner = s.trim().trim_start_matches('[').trim_end_matches(']');
+    if inner.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    inner
+        .split(',')
+        .map(|p| p.trim().parse::<f32>().map_err(Into::into))
+        .collect()
+}
+
+#[cfg(feature = "postgres")]
+impl sqlx::Type<sqlx::Postgres> for Vector {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        // pgvector's `vector` is an extension type with a dynamic OID;
+        // resolve it by name.
+        sqlx::postgres::PgTypeInfo::with_name("vector")
+    }
+
+    fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+        use sqlx::TypeInfo as _;
+        ty.name().eq_ignore_ascii_case("vector")
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl sqlx::Encode<'_, sqlx::Postgres> for Vector {
+    fn encode_by_ref(
+        &self,
+        buf: &mut sqlx::postgres::PgArgumentBuffer,
+    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+        let mut bytes = Vec::with_capacity(4 + self.0.len() * 4);
+        encode_pgvector(&self.0, &mut bytes);
+        buf.extend_from_slice(&bytes);
+        Ok(sqlx::encode::IsNull::No)
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl sqlx::Decode<'_, sqlx::Postgres> for Vector {
+    fn decode(value: sqlx::postgres::PgValueRef<'_>) -> Result<Self, sqlx::error::BoxDynError> {
+        use sqlx::ValueRef as _;
+        let inner = match value.format() {
+            sqlx::postgres::PgValueFormat::Binary => decode_pgvector_binary(value.as_bytes()?)?,
+            sqlx::postgres::PgValueFormat::Text => decode_pgvector_text(value.as_str()?)?,
+        };
+        Ok(Self(inner))
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl sqlx::Type<sqlx::MySql> for Vector {
+    fn type_info() -> sqlx::mysql::MySqlTypeInfo {
+        <Vec<u8> as sqlx::Type<sqlx::MySql>>::type_info()
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl sqlx::Decode<'_, sqlx::MySql> for Vector {
+    fn decode(_value: sqlx::mysql::MySqlValueRef<'_>) -> Result<Self, sqlx::error::BoxDynError> {
+        Err(
+            "`Vector` columns are PostgreSQL/pgvector-only; cannot decode on MySQL (issue #824)"
+                .into(),
+        )
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl sqlx::Type<sqlx::Sqlite> for Vector {
+    fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
+        <Vec<u8> as sqlx::Type<sqlx::Sqlite>>::type_info()
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl sqlx::Decode<'_, sqlx::Sqlite> for Vector {
+    fn decode(_value: sqlx::sqlite::SqliteValueRef<'_>) -> Result<Self, sqlx::error::BoxDynError> {
+        Err(
+            "`Vector` columns are PostgreSQL/pgvector-only; cannot decode on SQLite (issue #824)"
+                .into(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deref_from_vec_and_text() {
+        let v: Vector = vec![1.0, 2.0, 3.0].into();
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.to_pg_text(), "[1,2,3]");
+        assert_eq!(v.into_inner(), vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn serde_round_trips_as_plain_array() {
+        let v = Vector::new(vec![0.5, 1.5]);
+        let json = serde_json::to_string(&v).unwrap();
+        assert_eq!(json, "[0.5,1.5]");
+        let back: Vector = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn into_sqlvalue_vector() {
+        let sv: crate::core::SqlValue = Vector(vec![1.0, 2.0]).into();
+        match sv {
+            crate::core::SqlValue::Vector(items) => assert_eq!(items, vec![1.0, 2.0]),
+            _ => panic!("expected SqlValue::Vector"),
+        }
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn pgvector_binary_round_trip() {
+        let mut buf = Vec::new();
+        encode_pgvector(&[1.0, -2.5, 3.0], &mut buf);
+        assert_eq!(decode_pgvector_binary(&buf).unwrap(), vec![1.0, -2.5, 3.0]);
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn pgvector_text_parse() {
+        assert_eq!(
+            decode_pgvector_text("[1,2,3]").unwrap(),
+            vec![1.0, 2.0, 3.0]
+        );
+        assert_eq!(decode_pgvector_text("[]").unwrap(), Vec::<f32>::new());
+    }
+}

--- a/crates/rustango/src/sql/vector.rs
+++ b/crates/rustango/src/sql/vector.rs
@@ -214,7 +214,6 @@ impl sqlx::Encode<'_, sqlx::Postgres> for Vector {
 #[cfg(feature = "postgres")]
 impl sqlx::Decode<'_, sqlx::Postgres> for Vector {
     fn decode(value: sqlx::postgres::PgValueRef<'_>) -> Result<Self, sqlx::error::BoxDynError> {
-        use sqlx::ValueRef as _;
         let inner = match value.format() {
             sqlx::postgres::PgValueFormat::Binary => decode_pgvector_binary(value.as_bytes()?)?,
             sqlx::postgres::PgValueFormat::Text => decode_pgvector_text(value.as_str()?)?,

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -1323,6 +1323,19 @@ fn write_expr(
                     dialect: b.d.name(),
                 });
             }
+            // pgvector distance operators are Postgres-only (#824).
+            if matches!(op, BO::L2Distance | BO::CosineDistance | BO::InnerProduct)
+                && b.d.name() != "postgres"
+            {
+                return Err(SqlError::OpNotSupportedInDialect {
+                    op: match op {
+                        BO::L2Distance => "<-> (pgvector L2 distance)",
+                        BO::CosineDistance => "<=> (pgvector cosine distance)",
+                        _ => "<#> (pgvector inner product)",
+                    },
+                    dialect: b.d.name(),
+                });
+            }
             b.sql.push('(');
             // Nested casts only apply at the literal leaf — clear here
             // so an outer NULL cast doesn't bleed into the operand.
@@ -1347,6 +1360,10 @@ fn write_expr(
                 }
                 BO::BitShl => "<<",
                 BO::BitShr => ">>",
+                // pgvector distance operators (#824); PG-gated above.
+                BO::L2Distance => "<->",
+                BO::CosineDistance => "<=>",
+                BO::InnerProduct => "<#>",
             });
             b.sql.push(' ');
             write_expr(b, right, None)?;

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -1519,6 +1519,8 @@ fn field_type_label(ty: crate::core::FieldType) -> &'static str {
         T::Range(_) => "range",
         // #342 — PG hstore columns.
         T::HStore => "hstore",
+        // #824 — pgvector columns.
+        T::Vector(_) => "vector",
     }
 }
 

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -283,6 +283,8 @@ fn field_type_to_schema(t: FieldType) -> Schema {
             additional_properties: Some(Box::new(Schema::string())),
             ..Default::default()
         },
+        // #824 — pgvector embedding: a JSON array of numbers.
+        FieldType::Vector(_) => Schema::array_of(Schema::number()),
     }
 }
 

--- a/crates/rustango/tests/vector_pgvector.rs
+++ b/crates/rustango/tests/vector_pgvector.rs
@@ -1,0 +1,105 @@
+//! Tri-dialect emission + DDL tests for the pgvector vector column and
+//! similarity-search operators — issue #824.
+//!
+//! pgvector is **PG-only by language semantics**: `vector(N)` DDL +
+//! `<->` / `<=>` / `<#>` distance operators emit on Postgres; MySQL /
+//! SQLite degrade the column to `TEXT` and the distance operators raise
+//! `OpNotSupportedInDialect` at emit time. These tests pin both.
+
+use rustango::core::{FieldType, Model as _, VectorMetric};
+use rustango::sql::Vector;
+use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "vec_doc")]
+#[allow(dead_code)]
+pub struct Doc {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(max_length = 80)]
+    title: String,
+    #[rustango(vector(dims = 3))]
+    embedding: Vector,
+}
+
+#[test]
+fn schema_field_is_vector_with_declared_dims() {
+    let f = Doc::SCHEMA
+        .fields
+        .iter()
+        .find(|f| f.column == "embedding")
+        .expect("embedding field");
+    assert_eq!(f.ty, FieldType::Vector(3));
+}
+
+#[test]
+fn ddl_column_type_is_vector_n_on_pg_text_elsewhere() {
+    assert_eq!(
+        Postgres.column_type(FieldType::Vector(3), None),
+        "vector(3)"
+    );
+    // 0 dims = unconstrained `vector`.
+    assert_eq!(Postgres.column_type(FieldType::Vector(0), None), "vector");
+    assert_eq!(MySql.column_type(FieldType::Vector(3), None), "TEXT");
+    assert_eq!(Sqlite.column_type(FieldType::Vector(3), None), "TEXT");
+}
+
+fn distance_sql<D: Dialect>(
+    d: &D,
+    metric: VectorMetric,
+) -> Result<String, rustango::sql::SqlError> {
+    let q = Doc::objects()
+        .order_by_distance("embedding", vec![1.0, 2.0, 3.0], metric)
+        .compile()
+        .expect("compile order_by_distance");
+    d.compile_select(&q).map(|s| s.sql)
+}
+
+#[test]
+fn pg_order_by_distance_emits_l2_operator_and_binds_vector() {
+    let sql = distance_sql(&Postgres, VectorMetric::L2).expect("emit");
+    assert!(
+        sql.contains(r#"ORDER BY ("embedding" <-> $1)"#),
+        "L2 order-by should use <->: {sql}"
+    );
+}
+
+#[test]
+fn pg_each_metric_emits_its_operator() {
+    assert!(distance_sql(&Postgres, VectorMetric::L2)
+        .unwrap()
+        .contains("<->"));
+    assert!(distance_sql(&Postgres, VectorMetric::Cosine)
+        .unwrap()
+        .contains("<=>"));
+    assert!(distance_sql(&Postgres, VectorMetric::InnerProduct)
+        .unwrap()
+        .contains("<#>"));
+}
+
+#[test]
+fn k_nearest_adds_limit() {
+    let q = Doc::objects()
+        .k_nearest("embedding", vec![1.0, 2.0, 3.0], 5, VectorMetric::Cosine)
+        .compile()
+        .expect("compile");
+    let sql = Postgres.compile_select(&q).expect("emit").sql;
+    assert!(sql.contains("<=>"), "cosine op: {sql}");
+    assert!(sql.contains("LIMIT 5"), "k limit: {sql}");
+}
+
+#[test]
+fn distance_operators_error_cleanly_on_mysql_and_sqlite() {
+    for (name, res) in [
+        ("mysql", distance_sql(&MySql, VectorMetric::L2)),
+        ("sqlite", distance_sql(&Sqlite, VectorMetric::L2)),
+    ] {
+        let err = res.expect_err(&format!("{name} should reject the pgvector operator"));
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("pgvector") || msg.to_lowercase().contains("not supported"),
+            "{name} error should name the unsupported pgvector op: {msg}"
+        );
+    }
+}

--- a/crates/rustango/tests/vector_pgvector_pg_live.rs
+++ b/crates/rustango/tests/vector_pgvector_pg_live.rs
@@ -1,0 +1,102 @@
+#![cfg(feature = "postgres")]
+//! Live Postgres + pgvector test for the vector column + k-NN search —
+//! issue #824. Requires a pgvector-enabled Postgres (the CI / local
+//! `docker-compose` Postgres is `pgvector/pgvector:pg16`); skips when
+//! `DATABASE_URL` is unset.
+//!
+//! Exercises the full round-trip: `CREATE EXTENSION vector`, a
+//! `vector(3)` column migrated implicitly via raw DDL, typed inserts
+//! (the `Vector` PG binary `Encode`), a k-NN query ordered by L2
+//! distance, and typed decode of the stored embedding back to `Vec<f32>`.
+
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool, Vector};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "vec_doc_live")]
+#[allow(dead_code)]
+pub struct Doc {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 40)]
+    pub title: String,
+    #[rustango(vector(dims = 3))]
+    pub embedding: Vector,
+}
+
+#[tokio::test]
+async fn vector_column_round_trip_and_knn() {
+    let Ok(url) = std::env::var("DATABASE_URL") else {
+        eprintln!("DATABASE_URL unset — skipping pgvector live test");
+        return;
+    };
+    let pg = sqlx::PgPool::connect(&url).await.expect("connect PG");
+
+    // pgvector must be enabled; the test image (pgvector/pgvector:pg16)
+    // ships it. If it's somehow unavailable, skip rather than fail so a
+    // non-pgvector PG doesn't break the suite.
+    if sqlx::query("CREATE EXTENSION IF NOT EXISTS vector")
+        .execute(&pg)
+        .await
+        .is_err()
+    {
+        eprintln!("`vector` extension unavailable — skipping pgvector live test");
+        return;
+    }
+    for ddl in [
+        "DROP TABLE IF EXISTS vec_doc_live",
+        "CREATE TABLE vec_doc_live (id BIGSERIAL PRIMARY KEY, title VARCHAR(40) NOT NULL, embedding vector(3) NOT NULL)",
+    ] {
+        sqlx::query(ddl).execute(&pg).await.expect(ddl);
+    }
+    let pool: Pool = pg.into();
+
+    // Typed inserts — exercises the `Vector` binary `Encode`.
+    for (title, emb) in [
+        ("A", vec![1.0_f32, 0.0, 0.0]),
+        ("B", vec![0.8, 0.2, 0.0]),
+        ("C", vec![0.0, 1.0, 0.0]),
+    ] {
+        let mut d = Doc {
+            id: Auto::default(),
+            title: title.to_owned(),
+            embedding: Vector::new(emb),
+        };
+        d.save_pool(&pool).await.unwrap();
+    }
+
+    // k-NN: the 2 nearest to [1,0,0] by L2 distance are A (dist 0) then B.
+    use rustango::core::VectorMetric;
+    let nearest: Vec<String> = Doc::objects()
+        .k_nearest("embedding", vec![1.0, 0.0, 0.0], 2, VectorMetric::L2)
+        .fetch_pool(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|d| d.title)
+        .collect();
+    assert_eq!(nearest, vec!["A", "B"], "k-NN order by L2 distance");
+
+    // Full ordering across all three, + typed decode of the embedding.
+    let all: Vec<Doc> = Doc::objects()
+        .order_by_distance("embedding", vec![1.0, 0.0, 0.0], VectorMetric::L2)
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    let order: Vec<&str> = all.iter().map(|d| d.title.as_str()).collect();
+    assert_eq!(order, vec!["A", "B", "C"], "full distance ordering");
+    // The stored embedding decodes back to the inserted `Vec<f32>`.
+    assert_eq!(
+        all[0].embedding.0,
+        vec![1.0, 0.0, 0.0],
+        "A decodes its vector"
+    );
+
+    // Cosine ordering ranks A first too (identical direction → 0 distance).
+    let cos_first = Doc::objects()
+        .k_nearest("embedding", vec![1.0, 0.0, 0.0], 1, VectorMetric::Cosine)
+        .fetch_pool(&pool)
+        .await
+        .unwrap();
+    assert_eq!(cos_first[0].title, "A");
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 services:
   postgres:
-    image: postgres:16-alpine
+    # pgvector/pgvector:pg16 is postgres:16 + the `vector` extension
+    # preinstalled (issue #824). A drop-in superset of the stock image —
+    # every existing PG test runs unchanged; the vector live tests can
+    # `CREATE EXTENSION vector`.
+    image: pgvector/pgvector:pg16
     environment:
       POSTGRES_USER: rustango
       POSTGRES_PASSWORD: rustango


### PR DESCRIPTION
## What

Closes **#824** — the headline new Eloquent 13 feature: a pgvector `vector(N)` column type + similarity search. **PostgreSQL/pgvector-only by language semantics** (like FTS #28/#29 + trigram #295); MySQL/SQLite degrade the column to `TEXT` and the distance operators error cleanly.

```rust
use rustango::sql::Vector;
use rustango::core::VectorMetric;

#[derive(Model)]
#[rustango(table = "doc")]
struct Doc {
    #[rustango(primary_key)] id: Auto<i64>,
    #[rustango(vector(dims = 3))] embedding: Vector,   // → DDL `vector(3)`
}

// k-nearest-neighbour, ordered by distance:
let hits = Doc::objects()
    .k_nearest("embedding", query_embedding, 5, VectorMetric::Cosine)
    .fetch_pool(&pool).await?;
```

Embedding *generation* (Laravel's AI-SDK auto-embed) is out of scope, as the issue specifies — you bring a pre-computed `Vec<f32>`.

## How
- **`crate::sql::Vector`** — newtype over `Vec<f32>` with a real pgvector binary `Encode`/`Decode` on Postgres (the `[i16 dim][i16 unused][f32×dim]` wire format — no `pgvector` crate dependency) and total erroring stubs on MySQL/SQLite, so the shared `#[derive(Model)]` `FromRow` compiles on every backend (same pattern as `Array<T>`).
- **`FieldType::Vector(N)`** + `#[rustango(vector(dims = N))]` → `vector(N)` DDL on PG (`0` = unconstrained `vector`), `TEXT` degrade on MySQL/SQLite.
- **Distance operators** — `BinOp::{L2Distance, CosineDistance, InnerProduct}` emit `<->` / `<=>` / `<#>`, PG-gated (raise `OpNotSupportedInDialect` on MySQL/SQLite).
- **`QuerySet::order_by_distance(col, vec, metric)` + `k_nearest(col, vec, k, metric)`** + the `VectorMetric` selector. Ascending order ranks most-similar first for every metric (pgvector's `<#>` returns the negative inner product).
- **`SqlValue::Vector`** bind path — PG encodes via the `Vector` binary format; MySQL/SQLite are `unreachable!` (the operators error before bind).
- `required_db_features` advertises `pgvector` on PG; `manage check --deploy` warns if a vector model runs on a non-PG backend.

## CI / infra
The vector live tests need the `vector` extension, which stock `postgres:16-alpine` doesn't bundle. The `postgres_test` CI service + local `docker-compose` Postgres now use **`pgvector/pgvector:pg16`** (a superset — postgres:16 + pgvector preinstalled, so every existing PG test runs unchanged). The e2e showcase Postgres stays on the ECR alpine mirror (no vector columns; keeps the Docker Hub timeout fix from #848/#866).

## Tests
- **6 tri-dialect unit tests** (`vector_pgvector.rs`): `vector(3)`/`vector`/`TEXT` DDL, `order_by_distance`/`k_nearest` SQL for all three operators + `LIMIT`, and MySQL/SQLite raising a clean `OpNotSupportedInDialect`.
- **1 PG live test** (`vector_pgvector_pg_live.rs`, runs against `pgvector/pgvector:pg16`): `CREATE EXTENSION vector`, typed insert (exercises the binary `Encode`), k-NN ordering by L2 + cosine distance, and typed decode round-trip of the stored embedding.
- 3371 lib tests pass; `all-features --no-run` green; clippy clean; `sqlite,tenancy` litmus builds.

## Notes / minor gaps
- Snapshot serialization records `vector` without dims (the snapshot name is `&'static str`), so a dimension-*only* change (`vector(3)`→`vector(4)`) isn't surfaced as a schema diff. Documented inline.
- `row_to_json` renders a vector column as `null` in the raw-JSON/admin paths (mirrors `Array`/`HStore`); typed `fetch` decodes the embedding fully.