### PR TITLE
feat(admin): TOTP two-factor admin login (closes #367)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
       - run: |
           cargo test -p rustango \
             --no-default-features \
-            --features sqlite,tenancy,admin,jobs-postgres,media,passwords,serializer \
+            --features sqlite,tenancy,admin,jobs-postgres,media,passwords,serializer,totp \
             --test access_admin_codename_sqlite_live \
             --test admin_sqlite_live \
             --test admin_list_display_links_sqlite_live \
@@ -244,7 +244,9 @@ jobs:
             --test tenant_pools_sqlite_live \
             --test tx_methods_sqlite_live \
             --test unique_when_sqlite_live \
-            --test viewset_sqlite_live
+            --test viewset_sqlite_live \
+            --test admin_totp_2fa_sqlite_live \
+            --test admin_totp_2fa_e2e
 
   # v0.41 MySQL parity — the marketing claim is tri-dialect end-to-end
   # since v0.38, but every MySQL `_live.rs` test was skipped silently

--- a/crates/rustango/src/admin/login_view.rs
+++ b/crates/rustango/src/admin/login_view.rs
@@ -46,12 +46,18 @@ pub(crate) fn public_router(state: AppState) -> Router {
 /// can't reach the password-change form. Mounted from
 /// [`crate::admin::Builder::build`] when `with_session_auth` is set.
 pub(crate) fn protected_router(state: AppState) -> Router {
-    Router::new()
-        .route(
-            "/account/password",
-            get(change_password_form).post(change_password_submit),
-        )
-        .with_state(state)
+    let router = Router::new().route(
+        "/account/password",
+        get(change_password_form).post(change_password_submit),
+    );
+    // Issue #367 — TOTP two-factor enrollment (self-service, behind the
+    // session gate). Only mounted when the `totp` feature is on.
+    #[cfg(feature = "totp")]
+    let router = router.route(
+        "/account/totp",
+        get(totp_enroll_form).post(totp_enroll_submit),
+    );
+    router.with_state(state)
 }
 
 // ============================================================ Login form (GET)
@@ -96,6 +102,11 @@ fn render_login_form(state: &AppState, error: Option<&str>, csrf_input: &str) ->
             .unwrap_or("Rustango Admin"),
         "admin_prefix": admin_prefix,
         "static_url": &state.config.static_url,
+        // Issue #367 — show the optional authenticator-code field when
+        // the `totp` feature is compiled in. The field is harmless for
+        // non-enrolled users (left blank), so a build-time flag is
+        // enough; no per-request DB lookup on the login GET.
+        "totp_enabled": cfg!(feature = "totp"),
     });
     render_template("login.html", &ctx)
 }
@@ -111,6 +122,17 @@ struct LoginInput {
     /// rejection.
     #[serde(rename = "_csrf", default)]
     csrf_token: Option<String>,
+    /// Authenticator (TOTP) code — issue #367. Optional: only enrolled
+    /// users need it, and the field is always present on the form so a
+    /// 2FA user submits username + password + code in one step (no
+    /// hidden-password second round). Ignored when the `totp` feature is
+    /// off or the user has no confirmed device.
+    // Read only when the `totp` feature compiles the 2FA challenge; the
+    // field stays on the form unconditionally so enabling the feature
+    // doesn't change the wire format.
+    #[cfg_attr(not(feature = "totp"), allow(dead_code))]
+    #[serde(default)]
+    totp_code: Option<String>,
 }
 
 async fn login_submit(
@@ -240,6 +262,35 @@ async fn login_submit(
         })
         .await;
         return login_response(&state, &headers, Some("Invalid credentials."));
+    }
+
+    // Issue #367 — two-factor challenge. If the user has a confirmed
+    // TOTP device, a valid authenticator code is required before the
+    // session is granted. The password is already verified at this
+    // point; a missing/wrong code re-renders the login form (the
+    // password counts as "spent" so we don't reveal 2FA-enrolled status
+    // any differently than a normal failure beyond the message).
+    #[cfg(feature = "totp")]
+    {
+        if let Some(totp_secret) = super::totp_store::confirmed_secret(&state.pool, id).await {
+            let code = form.totp_code.as_deref().unwrap_or("").trim();
+            // 30s step, 6 digits, ±1 window — standard authenticator app
+            // defaults, tolerant of one step of clock skew.
+            if code.is_empty() || !crate::totp::verify(&totp_secret, code, 30, 6, 1) {
+                send_user_login_failed(UserLoginFailedContext {
+                    source: "admin",
+                    attempted_username: Some(form.username.clone()),
+                    reason: AuthFailureReason::InvalidCredentials,
+                    request: meta.clone(),
+                })
+                .await;
+                return login_response(
+                    &state,
+                    &headers,
+                    Some("Enter the 6-digit code from your authenticator app."),
+                );
+            }
+        }
     }
 
     // Audit M1 — successful login clears the failure counter + any lock.
@@ -449,6 +500,179 @@ fn render_change_password_form(
         &mut ctx,
         super::helpers::chrome_context(state, None),
     )
+}
+
+// ===================================================== TOTP 2FA enrollment (#367)
+
+#[cfg(feature = "totp")]
+#[derive(serde::Deserialize)]
+struct TotpEnrollInput {
+    #[serde(default)]
+    totp_code: Option<String>,
+    /// Present (`reset=1`) when re-enrolling from an already-enabled
+    /// account — wipes the current device and shows a fresh setup.
+    #[serde(default)]
+    reset: Option<String>,
+}
+
+#[cfg(feature = "totp")]
+fn render_totp_enroll(
+    state: &AppState,
+    already_enabled: bool,
+    secret_base32: &str,
+    otpauth_url: &str,
+    error: Option<&str>,
+    success: Option<&str>,
+) -> String {
+    let admin_prefix = &state.config.admin_prefix;
+    let ctx = serde_json::json!({
+        "title": "Two-factor authentication",
+        "action": format!("{admin_prefix}/account/totp"),
+        "admin_title": state.config.title.as_deref().unwrap_or("Rustango Admin"),
+        "admin_prefix": admin_prefix,
+        "static_url": &state.config.static_url,
+        "already_enabled": already_enabled,
+        "secret_base32": secret_base32,
+        "otpauth_url": otpauth_url,
+        "error": error,
+        "success": success,
+    });
+    render_template("totp_enroll.html", &ctx)
+}
+
+/// Build an `otpauth://` URI for the session user against `secret`.
+#[cfg(feature = "totp")]
+fn enroll_otpauth(state: &AppState, account: &str, secret: &crate::totp::TotpSecret) -> String {
+    let issuer = state.config.title.as_deref().unwrap_or("Rustango Admin");
+    crate::totp::otpauth_url(issuer, account, secret)
+}
+
+#[cfg(feature = "totp")]
+async fn totp_enroll_form(State(state): State<AppState>) -> Response {
+    let Some(session) = super::session::current() else {
+        return (StatusCode::UNAUTHORIZED, "session required").into_response();
+    };
+    let _ = super::totp_store::ensure_table(&state.pool).await;
+    let device = super::totp_store::device(&state.pool, session.user_id).await;
+    if device.as_ref().is_some_and(|d| d.confirmed) {
+        return Html(render_totp_enroll(&state, true, "", "", None, None)).into_response();
+    }
+    // Reuse the pending secret if one exists, else generate + persist a
+    // fresh (unconfirmed) one so a page reload is stable.
+    let secret = match device.and_then(|d| crate::totp::TotpSecret::from_base32(&d.secret_base32)) {
+        Some(s) => s,
+        None => {
+            let s = crate::totp::TotpSecret::generate();
+            if super::totp_store::start_enrollment(&state.pool, session.user_id, &s)
+                .await
+                .is_err()
+            {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "could not start enrollment",
+                )
+                    .into_response();
+            }
+            s
+        }
+    };
+    let otpauth = enroll_otpauth(&state, &session.username, &secret);
+    Html(render_totp_enroll(
+        &state,
+        false,
+        &secret.to_base32(),
+        &otpauth,
+        None,
+        None,
+    ))
+    .into_response()
+}
+
+#[cfg(feature = "totp")]
+async fn totp_enroll_submit(
+    State(state): State<AppState>,
+    Form(form): Form<TotpEnrollInput>,
+) -> Response {
+    let Some(session) = super::session::current() else {
+        return (StatusCode::UNAUTHORIZED, "session required").into_response();
+    };
+    let _ = super::totp_store::ensure_table(&state.pool).await;
+
+    // Re-enroll: wipe + regenerate, then show the fresh setup.
+    if form.reset.is_some() {
+        let s = crate::totp::TotpSecret::generate();
+        let _ = super::totp_store::start_enrollment(&state.pool, session.user_id, &s).await;
+        let otpauth = enroll_otpauth(&state, &session.username, &s);
+        return Html(render_totp_enroll(
+            &state,
+            false,
+            &s.to_base32(),
+            &otpauth,
+            None,
+            None,
+        ))
+        .into_response();
+    }
+
+    // Confirm: verify the submitted code against the pending secret.
+    let Some(device) = super::totp_store::device(&state.pool, session.user_id).await else {
+        return Html(render_totp_enroll(
+            &state,
+            false,
+            "",
+            "",
+            Some("No enrollment in progress — reload the page."),
+            None,
+        ))
+        .into_response();
+    };
+    let Some(secret) = crate::totp::TotpSecret::from_base32(&device.secret_base32) else {
+        return Html(render_totp_enroll(
+            &state,
+            false,
+            "",
+            "",
+            Some("Stored setup key is invalid — re-enroll."),
+            None,
+        ))
+        .into_response();
+    };
+    let code = form.totp_code.as_deref().unwrap_or("").trim();
+    if code.is_empty() || !crate::totp::verify(&secret, code, 30, 6, 1) {
+        let otpauth = enroll_otpauth(&state, &session.username, &secret);
+        return Html(render_totp_enroll(
+            &state,
+            false,
+            &device.secret_base32,
+            &otpauth,
+            Some("That code didn't match. Try again."),
+            None,
+        ))
+        .into_response();
+    }
+    if super::totp_store::confirm(&state.pool, session.user_id)
+        .await
+        .is_err()
+    {
+        return Html(render_totp_enroll(
+            &state,
+            false,
+            "",
+            "",
+            Some("Could not save — please try again."),
+            None,
+        ))
+        .into_response();
+    }
+    Html(render_totp_enroll(
+        &state,
+        true,
+        "",
+        "",
+        None,
+        Some("Two-factor authentication is now enabled."),
+    ))
+    .into_response()
 }
 
 // ============================================================ Logout (POST)

--- a/crates/rustango/src/admin/mod.rs
+++ b/crates/rustango/src/admin/mod.rs
@@ -54,6 +54,10 @@ mod manage_admin;
 pub mod object_permissions;
 pub mod queryset_hooks;
 pub mod session;
+/// Admin TOTP (two-factor) device persistence — issue #367. Gated on
+/// the `totp` feature; admin builds without it have no 2FA challenge.
+#[cfg(feature = "totp")]
+pub mod totp_store;
 pub mod user;
 // `pub(crate)` so the operator console can reuse `render_input` /
 // `render_value_for_input` for its `/orgs/{slug}/edit` form. Stays

--- a/crates/rustango/src/admin/templates.rs
+++ b/crates/rustango/src/admin/templates.rs
@@ -40,6 +40,11 @@ fn templates() -> &'static tera::Tera {
                 include_str!("templates/change_password.html"),
             ),
             ("audit_log.html", include_str!("templates/audit_log.html")),
+            // Issue #367 — TOTP two-factor enrollment page.
+            (
+                "totp_enroll.html",
+                include_str!("templates/totp_enroll.html"),
+            ),
         ])
         .expect("admin templates compile");
         tera

--- a/crates/rustango/src/admin/templates/login.html
+++ b/crates/rustango/src/admin/templates/login.html
@@ -82,6 +82,13 @@
       Password
       <input type="password" name="password" autocomplete="current-password" required>
     </label>
+    {% if totp_enabled %}
+    <label>
+      Authenticator code <span class="hint">(if two-factor is enabled)</span>
+      <input type="text" name="totp_code" inputmode="numeric" autocomplete="one-time-code"
+             pattern="[0-9]*" maxlength="8" placeholder="123456">
+    </label>
+    {% endif %}
     <button type="submit">Sign in</button>
   </form>
 </body>

--- a/crates/rustango/src/admin/templates/totp_enroll.html
+++ b/crates/rustango/src/admin/templates/totp_enroll.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ title }} · {{ admin_title }}</title>
+  <link rel="stylesheet" href="{{ static_url }}/admin.css">
+  <style>
+    .totp-wrap { max-width: 32rem; margin: 3rem auto; padding: 0 1rem; }
+    .totp-secret { font-family: monospace; font-size: 1.1rem; letter-spacing: .1em;
+      background: #f3f4f6; padding: .5rem .75rem; border-radius: .375rem; word-break: break-all; }
+    .totp-uri { font-family: monospace; font-size: .8rem; color: #555; word-break: break-all; }
+    .totp-msg.error { color: #b91c1c; }
+    .totp-msg.ok { color: #15803d; }
+    .hint { color: #6b7280; font-weight: normal; }
+  </style>
+</head>
+<body>
+  <div class="totp-wrap">
+    <h1>Two-factor authentication</h1>
+
+    {% if error %}<p class="totp-msg error">{{ error }}</p>{% endif %}
+    {% if success %}<p class="totp-msg ok">{{ success }}</p>{% endif %}
+
+    {% if already_enabled %}
+      <p>Two-factor authentication is <strong>enabled</strong> for your account.</p>
+      <p>To re-enroll (e.g. on a new device), submit the form below with a fresh setup —
+         this replaces your current device.</p>
+      <form method="post" action="{{ action }}">
+        <button type="submit" name="reset" value="1">Re-enroll</button>
+      </form>
+    {% else %}
+      <p>Scan this setup key in your authenticator app (Google Authenticator, 1Password,
+         Authy, …), or enter it manually, then confirm with the 6-digit code it shows.</p>
+
+      <p><strong>Setup key</strong></p>
+      <p class="totp-secret">{{ secret_base32 }}</p>
+
+      <p><strong>otpauth URI</strong> <span class="hint">(for manual / QR import)</span></p>
+      <p class="totp-uri">{{ otpauth_url }}</p>
+
+      <form method="post" action="{{ action }}">
+        <label>
+          Verification code
+          <input type="text" name="totp_code" inputmode="numeric" autocomplete="one-time-code"
+                 pattern="[0-9]*" maxlength="8" placeholder="123456" autofocus required>
+        </label>
+        <button type="submit">Enable two-factor</button>
+      </form>
+    {% endif %}
+
+    <p><a href="{{ admin_prefix }}/">← Back to admin</a></p>
+  </div>
+</body>
+</html>

--- a/crates/rustango/src/admin/totp_store.rs
+++ b/crates/rustango/src/admin/totp_store.rs
@@ -1,0 +1,138 @@
+//! Persistence for admin TOTP (two-factor) devices — issue #367.
+//!
+//! The RFC 6238 crypto lives in [`crate::totp`]; this module is the
+//! admin-side storage + lookup that the enrollment page and the login
+//! challenge share. One device per admin user, keyed by `user_id`.
+//!
+//! The table is **operator-managed** (`#[rustango(managed = false)]`) and
+//! bootstrapped idempotently via [`ensure_table`] (the same pattern as
+//! the audit log), so it never enters the migration graph. Gated behind
+//! the `totp` feature; admin builds without `totp` are unchanged (no
+//! 2FA challenge).
+
+use crate::sql::Pool;
+use crate::totp::TotpSecret;
+use crate::Model;
+
+/// One admin TOTP device. `confirmed = false` is a half-finished
+/// enrollment (secret generated + QR shown, code not yet verified);
+/// only a `confirmed` device gates login.
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rustango_admin_totp", managed = false)]
+#[allow(dead_code)]
+pub struct AdminTotp {
+    /// Admin user id this device belongs to (one per user).
+    #[rustango(primary_key)]
+    pub user_id: i64,
+    /// Base32-encoded shared secret (RFC 4648, no padding).
+    #[rustango(max_length = 64)]
+    pub secret_base32: String,
+    /// `true` once the user has verified a code against the secret.
+    #[rustango(default = "false")]
+    pub confirmed: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+const CREATE_TABLE_PG: &str = r#"
+CREATE TABLE IF NOT EXISTS "rustango_admin_totp" (
+    "user_id"       BIGINT PRIMARY KEY,
+    "secret_base32" VARCHAR(64) NOT NULL,
+    "confirmed"     BOOLEAN NOT NULL DEFAULT false,
+    "created_at"    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+"#;
+
+const CREATE_TABLE_MYSQL: &str = r#"
+CREATE TABLE IF NOT EXISTS `rustango_admin_totp` (
+    `user_id`       BIGINT PRIMARY KEY,
+    `secret_base32` VARCHAR(64) NOT NULL,
+    `confirmed`     TINYINT(1) NOT NULL DEFAULT 0,
+    `created_at`    DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+);
+"#;
+
+const CREATE_TABLE_SQLITE: &str = r#"
+CREATE TABLE IF NOT EXISTS "rustango_admin_totp" (
+    "user_id"       INTEGER PRIMARY KEY,
+    "secret_base32" TEXT NOT NULL,
+    "confirmed"     INTEGER NOT NULL DEFAULT 0,
+    "created_at"    TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+"#;
+
+/// Idempotently create the `rustango_admin_totp` table for the active
+/// backend.
+///
+/// # Errors
+/// Driver / SQL failures from `CREATE TABLE IF NOT EXISTS`.
+pub async fn ensure_table(pool: &Pool) -> Result<(), sqlx::Error> {
+    let ddl = match pool.dialect().name() {
+        "mysql" => CREATE_TABLE_MYSQL,
+        "sqlite" => CREATE_TABLE_SQLITE,
+        _ => CREATE_TABLE_PG,
+    };
+    crate::sql::run_ddl_idempotent(pool, ddl).await
+}
+
+/// Fetch the device row for `user_id`, if any.
+pub async fn device(pool: &Pool, user_id: i64) -> Option<AdminTotp> {
+    use crate::sql::FetcherPool as _;
+    AdminTotp::objects()
+        .filter("user_id", user_id)
+        .fetch_pool(pool)
+        .await
+        .ok()
+        .and_then(|rows| rows.into_iter().next())
+}
+
+/// The user's **confirmed** TOTP secret, decoded — `None` when the user
+/// has no device or an unconfirmed (pending) one. This is the gate the
+/// login challenge checks.
+pub async fn confirmed_secret(pool: &Pool, user_id: i64) -> Option<TotpSecret> {
+    let d = device(pool, user_id).await?;
+    if !d.confirmed {
+        return None;
+    }
+    TotpSecret::from_base32(&d.secret_base32)
+}
+
+/// Start (or restart) enrollment: store a fresh, unconfirmed secret for
+/// `user_id`, replacing any existing device. Returns the stored secret.
+///
+/// # Errors
+/// Driver / SQL failures.
+pub async fn start_enrollment(
+    pool: &Pool,
+    user_id: i64,
+    secret: &TotpSecret,
+) -> Result<(), crate::sql::ExecError> {
+    // One device per user — clear any prior (pending or confirmed) row.
+    let del = AdminTotp::objects()
+        .filter("user_id", user_id)
+        .compile_delete()?;
+    crate::sql::delete_pool(pool, &del).await?;
+    let row = AdminTotp {
+        user_id,
+        secret_base32: secret.to_base32(),
+        confirmed: false,
+        created_at: chrono::Utc::now(),
+    };
+    row.insert_pool(pool).await?;
+    Ok(())
+}
+
+/// Mark the user's device confirmed (called once a code verifies during
+/// enrollment). No-op if there's no pending device.
+///
+/// # Errors
+/// Driver / SQL failures.
+pub async fn confirm(pool: &Pool, user_id: i64) -> Result<(), crate::sql::ExecError> {
+    use crate::sql::UpdaterPool as _;
+    AdminTotp::objects()
+        .filter("user_id", user_id)
+        .update()
+        .set("confirmed", true)
+        .execute_pool(pool)
+        .await?;
+    Ok(())
+}

--- a/crates/rustango/tests/admin_totp_2fa_e2e.rs
+++ b/crates/rustango/tests/admin_totp_2fa_e2e.rs
@@ -1,0 +1,191 @@
+#![cfg(all(feature = "sqlite", feature = "admin", feature = "totp"))]
+//! End-to-end HTTP test for admin TOTP two-factor login — issue #367.
+//!
+//! Builds the real admin router via the public `admin::Builder` API
+//! (session auth on) against a seeded SQLite database, then drives
+//! `POST /login` through the full axum stack and asserts the challenge
+//! gates correctly:
+//! - enrolled user, **no code** → rejected (200 re-render, no session);
+//! - enrolled user, **wrong code** → rejected;
+//! - enrolled user, **correct code** → 303 + session cookie;
+//! - **non-enrolled** user → logs in normally (no code required).
+
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use rustango::admin::{totp_store, AdminUser, Builder};
+use rustango::session::SessionSecret;
+use rustango::sql::{sqlx, FetcherPool as _, Pool};
+use rustango::totp::TotpSecret;
+use tower::ServiceExt as _;
+
+// `Builder::build()` merges the login/protected routes at the router
+// root (the admin_prefix only rewrites internal links; the caller nests
+// the whole router). So the login route is `/login`, not prefixed.
+const PREFIX: &str = "";
+
+async fn seed() -> (Pool, TotpSecret) {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite");
+    // AdminUser table (matches `rustango_admin_users` / AdminUser::SCHEMA).
+    sqlx::query(
+        r#"CREATE TABLE rustango_admin_users (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            username      TEXT NOT NULL UNIQUE,
+            password_hash TEXT NOT NULL,
+            is_superuser  INTEGER NOT NULL DEFAULT 0,
+            active        INTEGER NOT NULL DEFAULT 1,
+            created_at    TEXT NOT NULL
+        )"#,
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    let pool: Pool = p.into();
+    totp_store::ensure_table(&pool).await.unwrap();
+
+    // Two users: "alice" (2FA-enrolled, confirmed) and "bob" (no 2FA).
+    for (name, su) in [("alice", true), ("bob", false)] {
+        let mut u = AdminUser::new_with_password(name, "correct horse", su).unwrap();
+        u.insert_pool(&pool).await.unwrap();
+    }
+    let alice_id = AdminUser::objects()
+        .filter("username", "alice")
+        .fetch_pool(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap()
+        .id;
+    let alice_id = *alice_id.get().unwrap();
+
+    let secret = TotpSecret::generate();
+    totp_store::start_enrollment(&pool, alice_id, &secret)
+        .await
+        .unwrap();
+    totp_store::confirm(&pool, alice_id).await.unwrap();
+
+    (pool, secret)
+}
+
+fn router(pool: Pool) -> axum::Router {
+    Builder::new(pool)
+        .admin_prefix("")
+        .with_session_auth(SessionSecret::from_bytes(vec![7u8; 32]))
+        .build()
+}
+
+/// GET the login page, returning the `rustango_csrf` cookie value (the
+/// double-submit token = the cookie value).
+async fn fetch_csrf(app: &axum::Router) -> String {
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("{PREFIX}/login"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let set_cookie = resp
+        .headers()
+        .get_all(header::SET_COOKIE)
+        .iter()
+        .find_map(|v| {
+            let s = v.to_str().ok()?;
+            s.strip_prefix("rustango_csrf=")
+                .map(|rest| rest.split(';').next().unwrap_or("").to_owned())
+        })
+        .expect("csrf cookie issued on GET /login");
+    assert!(!set_cookie.is_empty());
+    set_cookie
+}
+
+/// POST /login with the given credentials + code. Returns
+/// `(status, issued_session_cookie)`.
+async fn login(
+    app: &axum::Router,
+    csrf: &str,
+    username: &str,
+    password: &str,
+    totp_code: &str,
+) -> (StatusCode, bool) {
+    let body = format!(
+        "_csrf={csrf}&username={username}&password={password}&totp_code={totp_code}",
+        password = urlencoding(password),
+    );
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("{PREFIX}/login"))
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header(header::COOKIE, format!("rustango_csrf={csrf}"))
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = resp.status();
+    let issued_session = resp.headers().get_all(header::SET_COOKIE).iter().any(|v| {
+        v.to_str()
+            .map(|s| s.contains("rustango_admin_session="))
+            .unwrap_or(false)
+    });
+    (status, issued_session)
+}
+
+fn urlencoding(s: &str) -> String {
+    s.replace(' ', "%20")
+}
+
+#[tokio::test]
+async fn enrolled_user_is_gated_by_the_totp_code() {
+    let (pool, secret) = seed().await;
+    let app = router(pool);
+    let csrf = fetch_csrf(&app).await;
+
+    // Correct password, NO code → rejected (re-render, no session).
+    let (status, sess) = login(&app, &csrf, "alice", "correct horse", "").await;
+    assert!(!sess, "no session without a TOTP code: {status}");
+
+    // Correct password, WRONG code → rejected.
+    let (_s, sess) = login(&app, &csrf, "alice", "correct horse", "000000").await;
+    assert!(!sess, "no session with a wrong TOTP code");
+
+    // Correct password + correct code → session granted (303 redirect).
+    let code = rustango::totp::generate(&secret, 30, 6);
+    let (status, sess) = login(&app, &csrf, "alice", "correct horse", &code).await;
+    assert!(sess, "valid code grants a session (status {status})");
+    assert_eq!(status, StatusCode::SEE_OTHER, "success redirects");
+}
+
+#[tokio::test]
+async fn non_enrolled_user_logs_in_without_a_code() {
+    let (pool, _secret) = seed().await;
+    let app = router(pool);
+    let csrf = fetch_csrf(&app).await;
+
+    // Bob has no 2FA device — a blank code is fine.
+    let (status, sess) = login(&app, &csrf, "bob", "correct horse", "").await;
+    assert!(
+        sess,
+        "non-enrolled user logs in with no code (status {status})"
+    );
+    assert_eq!(status, StatusCode::SEE_OTHER);
+}
+
+#[tokio::test]
+async fn wrong_password_never_reaches_the_totp_step() {
+    let (pool, secret) = seed().await;
+    let app = router(pool);
+    let csrf = fetch_csrf(&app).await;
+
+    // Even with a valid code, a wrong password fails (no session).
+    let code = rustango::totp::generate(&secret, 30, 6);
+    let (_s, sess) = login(&app, &csrf, "alice", "wrong", &code).await;
+    assert!(!sess, "wrong password is rejected regardless of the code");
+}

--- a/crates/rustango/tests/admin_totp_2fa_e2e.rs
+++ b/crates/rustango/tests/admin_totp_2fa_e2e.rs
@@ -24,7 +24,14 @@ use tower::ServiceExt as _;
 const PREFIX: &str = "";
 
 async fn seed() -> (Pool, TotpSecret) {
-    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+    // `max_connections(1)`: a `sqlite::memory:` database is per-connection,
+    // so a multi-connection pool would hand the router a *different*
+    // (empty) DB than the one we seed on. Pinning to one connection keeps
+    // the seed + every request on the same in-memory database. (Passes
+    // locally either way, but CI's timing can open a second connection.)
+    let p = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
         .await
         .expect("sqlite");
     // AdminUser table (matches `rustango_admin_users` / AdminUser::SCHEMA).

--- a/crates/rustango/tests/admin_totp_2fa_sqlite_live.rs
+++ b/crates/rustango/tests/admin_totp_2fa_sqlite_live.rs
@@ -1,0 +1,85 @@
+#![cfg(all(feature = "sqlite", feature = "admin", feature = "totp"))]
+//! Live SQLite test for the admin TOTP 2FA store + gating logic —
+//! issue #367. Covers the security-critical invariants the login
+//! challenge relies on:
+//! - only a **confirmed** device gates login (`confirmed_secret`
+//!   returns `None` for a pending enrollment);
+//! - the stored secret round-trips so a code generated against it
+//!   verifies (this is exactly what `login_submit` does);
+//! - re-enrollment replaces the device and drops back to pending.
+//!
+//! The RFC 6238 math itself is covered by `crate::totp`'s own tests;
+//! here we exercise the persistence + the enroll → confirm → verify
+//! lifecycle end-to-end against a real engine.
+
+use rustango::admin::totp_store;
+use rustango::sql::{sqlx, Pool};
+use rustango::totp::{self, TotpSecret};
+
+async fn pool() -> Pool {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    let pool: Pool = p.into();
+    totp_store::ensure_table(&pool).await.expect("ensure_table");
+    pool
+}
+
+#[tokio::test]
+async fn enroll_confirm_verify_lifecycle() {
+    let pool = pool().await;
+    let uid = 42_i64;
+
+    // No device yet → nothing gates login.
+    assert!(totp_store::confirmed_secret(&pool, uid).await.is_none());
+    assert!(totp_store::device(&pool, uid).await.is_none());
+
+    // Start enrollment → a *pending* (unconfirmed) device exists, but it
+    // must NOT gate login until confirmed.
+    let secret = TotpSecret::generate();
+    totp_store::start_enrollment(&pool, uid, &secret)
+        .await
+        .expect("start_enrollment");
+    let dev = totp_store::device(&pool, uid).await.expect("device");
+    assert!(!dev.confirmed, "fresh enrollment is pending");
+    assert!(
+        totp_store::confirmed_secret(&pool, uid).await.is_none(),
+        "a pending device must not gate login"
+    );
+
+    // Confirm → now it gates login, and the stored secret round-trips.
+    totp_store::confirm(&pool, uid).await.expect("confirm");
+    let got = totp_store::confirmed_secret(&pool, uid)
+        .await
+        .expect("confirmed secret present");
+    assert_eq!(got.0, secret.0, "stored secret round-trips byte-for-byte");
+
+    // A code generated against the stored secret verifies (the exact
+    // check `login_submit` performs); a wrong code does not.
+    let t = 1_700_000_000_u64;
+    let code = totp::generate_at(&got, t, 30, 6);
+    assert!(
+        totp::verify_at(&got, &code, t, 30, 6, 1),
+        "valid code passes"
+    );
+    let bad = if code == "000000" { "111111" } else { "000000" };
+    assert!(
+        !totp::verify_at(&got, bad, t, 30, 6, 1),
+        "wrong code rejected"
+    );
+
+    // Re-enrollment replaces the device and drops back to pending.
+    let secret2 = TotpSecret::generate();
+    totp_store::start_enrollment(&pool, uid, &secret2)
+        .await
+        .expect("re-enroll");
+    assert!(
+        totp_store::confirmed_secret(&pool, uid).await.is_none(),
+        "re-enrollment is pending until confirmed again"
+    );
+    // Exactly one device per user (the old row was replaced, not added).
+    totp_store::confirm(&pool, uid).await.unwrap();
+    let got2 = totp_store::confirmed_secret(&pool, uid).await.unwrap();
+    assert_eq!(got2.0, secret2.0, "new secret is the active one");
+    assert_ne!(got2.0, secret.0, "old secret no longer stored");
+}

--- a/crates/rustango/tests/admin_totp_2fa_sqlite_live.rs
+++ b/crates/rustango/tests/admin_totp_2fa_sqlite_live.rs
@@ -17,7 +17,12 @@ use rustango::sql::{sqlx, Pool};
 use rustango::totp::{self, TotpSecret};
 
 async fn pool() -> Pool {
-    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+    // Pin to one connection: a `sqlite::memory:` DB is per-connection, so
+    // a multi-connection pool could route the seed and a later query to
+    // different (empty) databases.
+    let p = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
         .await
         .expect("sqlite memory");
     let pool: Pool = p.into();


### PR DESCRIPTION
## What

Closes **#367** — two-factor (TOTP) authentication for admin login: self-service enrollment + a code challenge at sign-in. The RFC 6238 crypto already shipped in `crate::totp` (PARTIAL status in the audit); this PR is the **admin-side integration** that was the actual gap.

## How
- **Storage** — a new operator-managed `rustango_admin_totp` table (one device per admin user), bootstrapped idempotently via the audit-style `ensure_table` (3-dialect DDL), so it never enters the migration graph. An internal `#[rustango(managed = false)]` model gives clean tri-dialect CRUD. Helpers: `device` / `confirmed_secret` (the login gate — **only a confirmed device counts**) / `start_enrollment` / `confirm`.
- **Login challenge** — after the password + active checks pass (and **before** the session cookie is granted), a user with a confirmed device must supply a valid 6-digit code (30 s step, ±1 window). Single-form UX: username + password + code in one POST (no hidden-password second round); the optional authenticator-code field renders on the login form when the `totp` feature is compiled in. A missing/wrong code re-renders with a clear message.
- **Self-service enrollment** at `GET/POST /account/totp` (behind the session gate): GET generates + persists a *pending* secret and shows the setup key + `otpauth://` URI (scan or manual entry); POST verifies a code and confirms (or re-enrolls, replacing the device).

### Safety / gating
- Entirely behind the **`totp`** feature — admin builds without it are unchanged (no 2FA field, no challenge, no table).
- CSRF on the protected enrollment POST is covered by the SameSite=Lax session cookie (same model as the existing change-password form).
- Only a *confirmed* device gates login, so a half-finished enrollment can't lock anyone out.

## Tests
A SQLite live test (`admin_totp_2fa_sqlite_live.rs`) exercises the full lifecycle and the exact invariants `login_submit` relies on: enroll → **pending does not gate** → confirm → **gates + the stored secret round-trips so a generated code verifies** → re-enroll resets to pending and replaces the device. The RFC 6238 math itself is covered by `crate::totp`'s own tests.

3371 lib tests pass; `all-features --no-run` green; clippy clean (both gates); `sqlite,tenancy` litmus builds.

## Notes / follow-ups
- Enrollment shows the setup key + `otpauth://` URI rather than a rendered QR image (no QR-encoding dependency added); authenticator apps accept manual key entry or scanning the URI. A server-rendered QR is an easy follow-up if desired.
- Scoped to the standard `admin` session-auth surface; the tenancy operator-console + tenant-admin surfaces can reuse the same `totp_store` in a follow-up.