### PR TITLE
feat(orm): multi-database registry + QuerySet::using(alias) (closes #332)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,template_views --test template_view
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test locale_middleware
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,notifications,http-client --test slack_notification
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test databases_using_sqlite_live
 
   # Per-dialect SQLite live suite — runs every `_sqlite_live.rs` file
   # explicitly under `--no-default-features --features sqlite,...`. This

--- a/crates/rustango/src/databases.rs
+++ b/crates/rustango/src/databases.rs
@@ -1,0 +1,193 @@
+//! Named multi-database registry — Django's `DATABASES` setting +
+//! `QuerySet.using(alias)` (issues #332 / #400).
+//!
+//! rustango is single-pool-per-call by default: every terminal takes an
+//! explicit connection (`fetch_pool(&pool)` / `fetch_on(executor)`), so
+//! multi-DB routing is already possible by passing the right pool. This
+//! module adds the Django-shaped **named-alias** convenience on top: a
+//! process-wide registry of `alias → Pool` plus a `.using("alias")` verb
+//! that resolves the alias and runs against the matching pool — the
+//! read-replica / multi-DB ergonomics without threading a `Pool` through
+//! every call site.
+//!
+//! ```ignore
+//! // At startup (the `DATABASES` equivalent):
+//! rustango::databases::register("default", primary_pool);
+//! rustango::databases::register("replica", replica_pool);
+//!
+//! // Route a read to the replica — Django's `.using("replica")`:
+//! let posts = Post::objects()
+//!     .filter("published", true)
+//!     .using("replica")
+//!     .fetch()
+//!     .await?;
+//! ```
+//!
+//! **Writes** still route through the explicit `fetch_pool(&pool)` family
+//! on purpose — `.using` exposes only the read terminals so a write
+//! can't be silently sent to a read replica. Automatic per-model routing
+//! (Django's `DATABASE_ROUTERS`, #401) is a separate layer on top of this
+//! registry.
+
+use std::collections::HashMap;
+use std::sync::{OnceLock, RwLock};
+
+use crate::sql::Pool;
+
+/// The conventional alias for the primary connection (Django's
+/// `DATABASES["default"]`).
+pub const DEFAULT_ALIAS: &str = "default";
+
+static REGISTRY: OnceLock<RwLock<HashMap<String, Pool>>> = OnceLock::new();
+
+fn registry() -> &'static RwLock<HashMap<String, Pool>> {
+    REGISTRY.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Register (or replace) the connection pool under `alias`. Call once
+/// per database at startup. The `"default"` alias is the conventional
+/// primary; any other name (`"replica"`, `"analytics"`, …) is yours.
+pub fn register(alias: impl Into<String>, pool: impl Into<Pool>) {
+    registry()
+        .write()
+        .expect("databases registry not poisoned")
+        .insert(alias.into(), pool.into());
+}
+
+/// Resolve `alias` to its pool, or `None` if nothing is registered under
+/// it. Prefer [`pool`] when the alias is expected to exist.
+#[must_use]
+pub fn get(alias: &str) -> Option<Pool> {
+    registry()
+        .read()
+        .expect("databases registry not poisoned")
+        .get(alias)
+        .cloned()
+}
+
+/// The `"default"` connection, if registered.
+#[must_use]
+pub fn default() -> Option<Pool> {
+    get(DEFAULT_ALIAS)
+}
+
+/// Resolve `alias`, panicking with a clear message if it isn't
+/// registered — the rustango analogue of Django's
+/// `ConnectionDoesNotExist`. An unknown alias is a startup-wiring bug,
+/// so this fails loudly rather than silently picking a wrong database.
+#[must_use]
+pub fn pool(alias: &str) -> Pool {
+    get(alias).unwrap_or_else(|| {
+        panic!(
+            "no database registered under alias `{alias}` — \
+             call `rustango::databases::register(\"{alias}\", pool)` at startup \
+             (registered: {:?})",
+            aliases()
+        )
+    })
+}
+
+/// Every registered alias, sorted — handy for diagnostics / `manage`
+/// introspection.
+#[must_use]
+pub fn aliases() -> Vec<String> {
+    let mut v: Vec<String> = registry()
+        .read()
+        .expect("databases registry not poisoned")
+        .keys()
+        .cloned()
+        .collect();
+    v.sort();
+    v
+}
+
+/// Remove every registered connection. Intended for test isolation.
+pub fn clear() {
+    registry()
+        .write()
+        .expect("databases registry not poisoned")
+        .clear();
+}
+
+impl<T: crate::core::Model> crate::query::QuerySet<T> {
+    /// Route this queryset to the connection registered under `alias` —
+    /// Django's [`QuerySet.using(alias)`](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#using).
+    /// Issue #332.
+    ///
+    /// Returns a [`UsingQuerySet`] exposing the read terminals
+    /// (`fetch` / `first` / `count` / `exists`) bound to the resolved
+    /// pool. Panics at call time if `alias` isn't registered (see
+    /// [`pool`]). Writes intentionally aren't routed here — use the
+    /// explicit `fetch_pool(&pool)` family for those.
+    #[must_use]
+    pub fn using(self, alias: &str) -> UsingQuerySet<T> {
+        UsingQuerySet {
+            qs: self,
+            pool: pool(alias),
+        }
+    }
+}
+
+/// A queryset bound to a specific registered connection via
+/// [`QuerySet::using`]. Carries the read terminals that resolve against
+/// the chosen pool.
+pub struct UsingQuerySet<T: crate::core::Model> {
+    qs: crate::query::QuerySet<T>,
+    pool: Pool,
+}
+
+impl<T> UsingQuerySet<T>
+where
+    T: crate::core::Model
+        + crate::sql::MaybePgFromRow
+        + crate::sql::MaybeMyFromRow
+        + crate::sql::MaybeSqliteFromRow
+        + crate::sql::LoadRelated
+        + crate::sql::MaybeMyLoadRelated
+        + crate::sql::MaybeSqliteLoadRelated
+        + Send
+        + Unpin,
+{
+    /// Run the query against the chosen connection — like
+    /// `fetch_pool(&pool)` but routed by alias.
+    ///
+    /// # Errors
+    /// As [`crate::sql::FetcherPool::fetch_pool`].
+    pub async fn fetch(self) -> Result<Vec<T>, crate::sql::ExecError> {
+        use crate::sql::FetcherPool as _;
+        self.qs.fetch_pool(&self.pool).await
+    }
+
+    /// The first matching row (applies `LIMIT 1`).
+    ///
+    /// # Errors
+    /// As [`Self::fetch`].
+    pub async fn first(self) -> Result<Option<T>, crate::sql::ExecError> {
+        use crate::sql::FetcherPool as _;
+        Ok(self
+            .qs
+            .limit(1)
+            .fetch_pool(&self.pool)
+            .await?
+            .into_iter()
+            .next())
+    }
+
+    /// `SELECT COUNT(*)` against the chosen connection.
+    ///
+    /// # Errors
+    /// As [`crate::sql::CounterPool::count_pool`].
+    pub async fn count(self) -> Result<i64, crate::sql::ExecError> {
+        use crate::sql::CounterPool as _;
+        self.qs.count_pool(&self.pool).await
+    }
+
+    /// `EXISTS` against the chosen connection.
+    ///
+    /// # Errors
+    /// As [`crate::sql::ExistsPool::exists_pool`].
+    pub async fn exists(self) -> Result<bool, crate::sql::ExecError> {
+        use crate::sql::ExistsPool as _;
+        self.qs.exists_pool(&self.pool).await
+    }
+}

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -448,6 +448,8 @@ pub mod audit;
 /// Sub-slice F.1 of the v0.15.0 plan.
 pub mod contenttypes;
 pub mod core;
+/// Named multi-database registry + `QuerySet::using(alias)` (#332/#400).
+pub mod databases;
 pub mod migrate;
 pub mod query;
 pub mod sql;

--- a/crates/rustango/tests/databases_using_sqlite_live.rs
+++ b/crates/rustango/tests/databases_using_sqlite_live.rs
@@ -1,0 +1,119 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for the multi-database registry + `QuerySet::using`
+//! (issues #332 / #400). Registers two separate SQLite databases under
+//! aliases, seeds them with *different* rows, and asserts that
+//! `.using(alias)` routes each read to the right one.
+//!
+//! Uses globally-unique alias names (the registry is process-wide) and
+//! never calls `databases::clear()`, so it stays independent of any
+//! other test touching the registry.
+
+use rustango::databases;
+use rustango::sql::{sqlx, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "md_widget")]
+#[allow(dead_code)]
+pub struct Widget {
+    #[rustango(primary_key)]
+    pub id: i64,
+    #[rustango(max_length = 40)]
+    pub name: String,
+}
+
+/// A single-connection SQLite pool seeded with one `md_widget` row per
+/// name. `max_connections(1)` keeps the seed + later reads on the same
+/// in-memory database.
+async fn pool_with(names: &[&str]) -> Pool {
+    let p = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("sqlite");
+    sqlx::query("CREATE TABLE md_widget (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+        .execute(&p)
+        .await
+        .unwrap();
+    for (i, name) in names.iter().enumerate() {
+        sqlx::query("INSERT INTO md_widget (id, name) VALUES (?, ?)")
+            .bind(i64::try_from(i).unwrap() + 1)
+            .bind(*name)
+            .execute(&p)
+            .await
+            .unwrap();
+    }
+    p.into()
+}
+
+#[tokio::test]
+async fn using_routes_reads_to_the_registered_alias() {
+    let primary = pool_with(&["alpha"]).await;
+    let replica = pool_with(&["beta", "gamma"]).await;
+    databases::register("md332_primary", primary);
+    databases::register("md332_replica", replica);
+
+    // Registry lookups.
+    assert!(databases::get("md332_primary").is_some());
+    assert!(databases::get("md332_missing").is_none());
+    assert!(databases::aliases().contains(&"md332_replica".to_owned()));
+
+    // `.using(alias).fetch()` reads from the matching database.
+    let from_primary: Vec<String> = Widget::objects()
+        .using("md332_primary")
+        .fetch()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|w| w.name)
+        .collect();
+    assert_eq!(from_primary, vec!["alpha"]);
+
+    let from_replica: Vec<String> = Widget::objects()
+        .order_by(&[("name", false)])
+        .using("md332_replica")
+        .fetch()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|w| w.name)
+        .collect();
+    assert_eq!(from_replica, vec!["beta", "gamma"]);
+
+    // count / exists / first route to the chosen alias too.
+    assert_eq!(
+        Widget::objects()
+            .using("md332_replica")
+            .count()
+            .await
+            .unwrap(),
+        2
+    );
+    assert!(Widget::objects()
+        .using("md332_primary")
+        .exists()
+        .await
+        .unwrap());
+    let first = Widget::objects()
+        .filter("name", "gamma")
+        .using("md332_replica")
+        .first()
+        .await
+        .unwrap();
+    assert_eq!(first.unwrap().name, "gamma");
+
+    // A row that only exists on the replica is absent from the primary.
+    assert!(!Widget::objects()
+        .filter("name", "beta")
+        .using("md332_primary")
+        .exists()
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+#[should_panic(expected = "no database registered under alias")]
+async fn using_unknown_alias_panics_with_a_clear_message() {
+    // Never registered → loud failure (Django's ConnectionDoesNotExist).
+    let _ = Widget::objects().using("md332_definitely_unregistered_alias");
+}


### PR DESCRIPTION
## What

Closes **#332** — Django's [`QuerySet.using(db_alias)`](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#using) for multi-DB / read-replica routing, plus the `DATABASES`-style registry it needs (lands the registry half of #400).

```rust
// At startup (the DATABASES equivalent):
rustango::databases::register("default", primary_pool);
rustango::databases::register("replica", replica_pool);

// Route a read to the replica:
let posts = Post::objects().filter("published", true)
    .using("replica").fetch().await?;
```

## Investigation (per the issue's required process)
rustango is single-pool-per-call — every terminal takes an explicit connection (`fetch_pool(&pool)` / `fetch_on(executor)`), so multi-DB routing was *already possible* by passing the replica pool. The genuine gap was the **named-alias** DX (a global registry + the `.using()` verb); there was no non-tenancy global pool registry. (Full findings posted on the issue.)

## How
- **`crate::databases`** — a process-wide `alias → Pool` registry: `register` / `get` / `default` / `pool` (panics with a clear `ConnectionDoesNotExist`-style message on an unknown alias) / `aliases` / `clear`.
- **`QuerySet::using(alias)`** returns a `UsingQuerySet<T>` exposing read terminals `fetch` / `first` / `count` / `exists`, resolved against the registered pool. Reuses the existing `_pool` terminal family verbatim — no parallel query path, and **no churn to the `QuerySet` struct** (the alias is resolved into the wrapper).
- **Reads only, by design** — writes still go through the explicit `fetch_pool(&pool)` family, so a write can't be silently routed to a read replica. Automatic per-model routing (`DATABASE_ROUTERS`, #401) is a separate layer on top of this registry.

## Tests
A SQLite live test (`databases_using_sqlite_live.rs`) registers **two** separate SQLite databases under aliases, seeds them with different rows, and asserts `.using(alias)` routes each `fetch`/`first`/`count`/`exists` to the right one — plus a `#[should_panic]` for an unregistered alias. Single-connection pools + globally-unique alias names keep it independent of the process-wide registry.

3371 lib tests pass; `all-features --no-run` green; clippy clean; `sqlite,tenancy` litmus builds. Registered in the `sqlite_litmus` CI job so it runs on the SQLite side too.

## Follow-ups
`DATABASE_ROUTERS` (#401, auto per-model/operation routing) builds on this registry; `.using()` write terminals can be added if there's demand (deliberately omitted to avoid replica-write footguns).