### PR TITLE
feat(orm): ergonomic Model::bulk_update(objs, fields) — Django's QuerySet.bulk_update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,7 @@ jobs:
             --test admin_simple_list_filter_sqlite_live \
             --test admin_list_display_jsonpath_sqlite_live \
             --test audit_pool_sqlite_live \
+            --test bulk_update_api_sqlite_live \
             --test bulk_upsert_sqlite_live \
             --test count_distinct_sqlite_live \
             --test database_pools_sqlite_file_live \

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -7485,6 +7485,133 @@ fn inherent_impl_tokens(
         }
     };
 
+    // Ergonomic `Model::bulk_update(objs, fields)` — Django's
+    // `QuerySet.bulk_update`. The SQL/IR/executor stack
+    // (`BulkUpdateQuery` + `bulk_update_pool` + the per-dialect
+    // `write_bulk_update_*` writers) already existed; what was missing
+    // was the per-model constructor that maps `&[Self]` + a runtime
+    // column list into rows of `[pk, col_vals…]` so callers don't
+    // hand-build the IR. Emitted only when the model has a primary key
+    // (the PK is the join key and can't itself be updated).
+    let bulk_update_method = match &fields.primary_key {
+        None => quote! {},
+        Some((pk_ident, pk_col)) => {
+            // One pair of match arms per non-PK column: a validation arm
+            // resolving the runtime name to its `&'static str` column,
+            // and a value arm pushing that field off the row.
+            let mut col_arms: Vec<TokenStream2> = Vec::new();
+            let mut val_arms: Vec<TokenStream2> = Vec::new();
+            for entry in &fields.column_entries {
+                if &entry.column == pk_col {
+                    continue;
+                }
+                let col = &entry.column;
+                let ident = &entry.ident;
+                col_arms.push(quote! { #col => #col, });
+                val_arms.push(quote! {
+                    #col => _row_vals.push(
+                        ::core::convert::Into::<#root::core::SqlValue>::into(
+                            ::core::clone::Clone::clone(&_o.#ident)
+                        )
+                    ),
+                });
+            }
+            quote! {
+                /// Django's `QuerySet.bulk_update(objs, fields)` — write
+                /// per-row-different values for the named `fields` across
+                /// every object in `objs` in a single statement, matched
+                /// by primary key.
+                ///
+                /// `fields` names the **columns** to update. The primary
+                /// key identifies each row and cannot itself be updated
+                /// (pass it and you get
+                /// [`#root::core::QueryError::BulkUpdatePrimaryKey`]).
+                /// Empty `objs` or `fields` is a no-op returning `0`.
+                /// Objects whose PK matches no row are simply not updated.
+                /// Returns the number of rows affected.
+                ///
+                /// Tri-dialect: lowers to one
+                /// [`#root::core::BulkUpdateQuery`] and dispatches
+                /// per-backend — `UPDATE … FROM (VALUES …)` on Postgres,
+                /// a CTE + correlated subquery on SQLite, an inner
+                /// `JOIN (VALUES …)` on MySQL.
+                ///
+                /// # Errors
+                /// [`#root::core::QueryError::UnknownField`] for a name
+                /// that isn't a column on this model,
+                /// [`#root::core::QueryError::BulkUpdatePrimaryKey`] if
+                /// `fields` names the PK, or [`#root::sql::ExecError`] for
+                /// SQL-writing / driver failures.
+                pub async fn bulk_update(
+                    objs: &[Self],
+                    fields: &[&str],
+                    pool: &#root::sql::Pool,
+                ) -> ::core::result::Result<u64, #root::sql::ExecError> {
+                    if objs.is_empty() || fields.is_empty() {
+                        return ::core::result::Result::Ok(0);
+                    }
+                    let _model_name = <Self as #root::core::Model>::SCHEMA.name;
+                    let mut _update_columns: ::std::vec::Vec<&'static str> =
+                        ::std::vec::Vec::with_capacity(fields.len());
+                    for &_f in fields {
+                        let _col: &'static str = match _f {
+                            #pk_col => {
+                                return ::core::result::Result::Err(
+                                    ::core::convert::Into::into(
+                                        #root::core::QueryError::BulkUpdatePrimaryKey {
+                                            model: _model_name,
+                                            field: ::std::string::ToString::to_string(_f),
+                                        }
+                                    )
+                                );
+                            }
+                            #( #col_arms )*
+                            _ => {
+                                return ::core::result::Result::Err(
+                                    ::core::convert::Into::into(
+                                        #root::core::QueryError::UnknownField {
+                                            model: _model_name,
+                                            field: ::std::string::ToString::to_string(_f),
+                                        }
+                                    )
+                                );
+                            }
+                        };
+                        _update_columns.push(_col);
+                    }
+                    let mut _rows: ::std::vec::Vec<
+                        ::std::vec::Vec<#root::core::SqlValue>,
+                    > = ::std::vec::Vec::with_capacity(objs.len());
+                    for _o in objs.iter() {
+                        let mut _row_vals: ::std::vec::Vec<#root::core::SqlValue> =
+                            ::std::vec::Vec::with_capacity(fields.len() + 1);
+                        // PK first — the writers expect `[pk, …update cols]`.
+                        _row_vals.push(
+                            ::core::convert::Into::<#root::core::SqlValue>::into(
+                                ::core::clone::Clone::clone(&_o.#pk_ident)
+                            )
+                        );
+                        for &_f in fields {
+                            match _f {
+                                #( #val_arms )*
+                                // Unreachable: every name was validated
+                                // against the same arm set above.
+                                _ => {}
+                            }
+                        }
+                        _rows.push(_row_vals);
+                    }
+                    let _query = #root::core::BulkUpdateQuery {
+                        model: <Self as #root::core::Model>::SCHEMA,
+                        update_columns: _update_columns,
+                        rows: _rows,
+                    };
+                    #root::sql::bulk_update_pool(pool, &_query).await
+                }
+            }
+        }
+    };
+
     let pk_value_helper = primary_key.map(|(pk_ident, _)| {
         quote! {
             /// Hidden runtime accessor for the primary-key value as a
@@ -7696,6 +7823,8 @@ fn inherent_impl_tokens(
             #bulk_insert_method
 
             #bulk_upsert_pool_method
+
+            #bulk_update_method
 
             #save_method
 

--- a/crates/rustango/src/core/error.rs
+++ b/crates/rustango/src/core/error.rs
@@ -8,6 +8,13 @@ pub enum QueryError {
     #[error("model `{model}` has no field `{field}`")]
     UnknownField { model: &'static str, field: String },
 
+    /// `bulk_update()` was asked to update the primary-key column, which
+    /// identifies each row in the `WHERE`/`CASE` join and so cannot be
+    /// reassigned. Mirrors Django's
+    /// `ValueError("bulk_update() cannot be used with primary key fields.")`.
+    #[error("`bulk_update` cannot update the primary-key field `{model}.{field}`")]
+    BulkUpdatePrimaryKey { model: &'static str, field: String },
+
     #[error("field `{model}.{field}` is type {expected}, but the bound value is type {actual}")]
     TypeMismatch {
         model: &'static str,

--- a/crates/rustango/tests/bulk_update_api_sqlite_live.rs
+++ b/crates/rustango/tests/bulk_update_api_sqlite_live.rs
@@ -1,0 +1,190 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for the ergonomic `Model::bulk_update(objs, fields)`
+//! API — Django's `QuerySet.bulk_update`.
+//!
+//! The SQL/IR/executor stack (`BulkUpdateQuery` + `bulk_update_pool` +
+//! the per-dialect `write_bulk_update_*` writers) already existed and is
+//! covered by `sqlite_bulk_update_live.rs` (it hand-builds the IR). This
+//! test covers the *new* per-model constructor: that `&[Self]` + a
+//! runtime column list lowers into the right `[pk, col_vals…]` rows,
+//! writes per-row-different values, leaves unnamed columns untouched,
+//! and rejects the PK / unknown columns with clear errors.
+//!
+//! `max_connections(1)` pins the seed + the update + the read-back to one
+//! in-memory database (a multi-connection `:memory:` pool would hand each
+//! query a fresh empty DB).
+
+use rustango::core::QueryError;
+use rustango::sql::{sqlx, ExecError, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "bua_widget")]
+#[allow(dead_code)]
+pub struct Widget {
+    #[rustango(primary_key)]
+    pub id: i64,
+    #[rustango(max_length = 40)]
+    pub name: String,
+    pub qty: i64,
+    #[rustango(max_length = 40)]
+    pub note: String,
+}
+
+async fn seeded_pool() -> Pool {
+    let p = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("sqlite");
+    sqlx::query(
+        "CREATE TABLE bua_widget (\
+            id INTEGER PRIMARY KEY, \
+            name TEXT NOT NULL, \
+            qty INTEGER NOT NULL, \
+            note TEXT NOT NULL)",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    for (id, name) in [(1, "alpha"), (2, "beta"), (3, "gamma")] {
+        sqlx::query("INSERT INTO bua_widget (id, name, qty, note) VALUES (?, ?, ?, ?)")
+            .bind(id)
+            .bind(name)
+            .bind(id * 10)
+            .bind("original")
+            .execute(&p)
+            .await
+            .unwrap();
+    }
+    p.into()
+}
+
+async fn row(pool: &Pool, id: i64) -> (String, i64, String) {
+    // Refutable under `--all-features` (Pool has PG/MySQL variants too);
+    // irrefutable under sqlite-only — keep the arm, silence the lint.
+    #[allow(irrefutable_let_patterns)]
+    let Pool::Sqlite(p) = pool
+    else {
+        unreachable!()
+    };
+    sqlx::query_as::<_, (String, i64, String)>(
+        "SELECT name, qty, note FROM bua_widget WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_one(p)
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn bulk_update_writes_per_row_values_and_leaves_unnamed_columns_alone() {
+    let pool = seeded_pool().await;
+
+    // Different new values per row. `note` is mutated in memory too, but
+    // we DON'T name it — it must stay `"original"` in the database.
+    let objs = vec![
+        Widget {
+            id: 1,
+            name: "alpha!".into(),
+            qty: 111,
+            note: "should-not-persist".into(),
+        },
+        Widget {
+            id: 2,
+            name: "beta!".into(),
+            qty: 222,
+            note: "should-not-persist".into(),
+        },
+        Widget {
+            id: 3,
+            name: "gamma!".into(),
+            qty: 333,
+            note: "should-not-persist".into(),
+        },
+    ];
+
+    let affected = Widget::bulk_update(&objs, &["name", "qty"], &pool)
+        .await
+        .expect("bulk_update");
+    assert_eq!(affected, 3, "all three rows updated in one statement");
+
+    for (id, name, qty) in [(1, "alpha!", 111), (2, "beta!", 222), (3, "gamma!", 333)] {
+        let (got_name, got_qty, got_note) = row(&pool, id).await;
+        assert_eq!(got_name, name, "row {id} name");
+        assert_eq!(got_qty, qty, "row {id} qty");
+        assert_eq!(
+            got_note, "original",
+            "row {id} note must be untouched — it wasn't named in `fields`"
+        );
+    }
+}
+
+#[tokio::test]
+async fn bulk_update_rejects_the_primary_key() {
+    let pool = seeded_pool().await;
+    let objs = vec![Widget {
+        id: 1,
+        name: "x".into(),
+        qty: 1,
+        note: "x".into(),
+    }];
+
+    let err = Widget::bulk_update(&objs, &["name", "id"], &pool)
+        .await
+        .expect_err("naming the PK must error");
+    match err {
+        ExecError::Query(QueryError::BulkUpdatePrimaryKey { field, .. }) => {
+            assert_eq!(field, "id");
+        }
+        other => panic!("expected BulkUpdatePrimaryKey, got {other:?}"),
+    }
+
+    // The rejection happens before any write — the row is unchanged.
+    assert_eq!(row(&pool, 1).await, ("alpha".into(), 10, "original".into()));
+}
+
+#[tokio::test]
+async fn bulk_update_rejects_unknown_columns() {
+    let pool = seeded_pool().await;
+    let objs = vec![Widget {
+        id: 1,
+        name: "x".into(),
+        qty: 1,
+        note: "x".into(),
+    }];
+
+    let err = Widget::bulk_update(&objs, &["nope"], &pool)
+        .await
+        .expect_err("unknown column must error");
+    match err {
+        ExecError::Query(QueryError::UnknownField { field, .. }) => {
+            assert_eq!(field, "nope");
+        }
+        other => panic!("expected UnknownField, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn bulk_update_empty_inputs_are_a_noop() {
+    let pool = seeded_pool().await;
+    let objs = vec![Widget {
+        id: 1,
+        name: "x".into(),
+        qty: 1,
+        note: "x".into(),
+    }];
+
+    assert_eq!(
+        Widget::bulk_update(&[], &["name"], &pool).await.unwrap(),
+        0,
+        "empty objs → 0"
+    );
+    assert_eq!(
+        Widget::bulk_update(&objs, &[], &pool).await.unwrap(),
+        0,
+        "empty fields → 0"
+    );
+    // Nothing was written.
+    assert_eq!(row(&pool, 1).await, ("alpha".into(), 10, "original".into()));
+}


### PR DESCRIPTION
## What

Adds the missing **ergonomic `Model::bulk_update(objs, fields)`** — Django's `QuerySet.bulk_update`. Write per-row-different values across many objects in a single statement, matched by primary key:

```rust
// before — hand-build the IR:
let q = BulkUpdateQuery {
    model: User::SCHEMA,
    update_columns: vec!["name", "age"],
    rows: vec![vec![pk.into(), name.into(), age.into()], /* … */],
};
bulk_update_pool(&pool, &q).await?;

// after:
User::bulk_update(&users, &["name", "age"], &pool).await?;  // -> rows affected
```

## Why

The SQL/IR/executor stack already existed — `BulkUpdateQuery`, `bulk_update_pool`, and the per-dialect `write_bulk_update_{pg,sqlite,mysql}` writers (the SQLite CTE path landed in #560). But the **only** way to call it was to hand-assemble `Vec<Vec<SqlValue>>` rows with the PK first and every field value `.into()`'d by hand. That's exactly the boilerplate a Django-shaped ORM should absorb.

## How

- `#[derive(Model)]` now emits `pub async fn bulk_update(objs: &[Self], fields: &[&str], pool: &Pool) -> Result<u64, ExecError>` for any model with a primary key. It maps `&[Self]` + a runtime column list into `[pk, col_vals…]` rows (PK first, as the writers expect) and lowers to one `BulkUpdateQuery`, dispatched per-backend. Mirrors the existing `bulk_upsert_pool` codegen (tri-dialect `&Pool`, no `postgres` gate).
- New `QueryError::BulkUpdatePrimaryKey` — naming the PK is rejected up front (it's the `CASE`/`WHERE` join key, mirroring Django's `ValueError`); an unknown column surfaces as `QueryError::UnknownField`. Both flow to `ExecError` via the existing `#[from]`.
- Unnamed columns are left untouched; empty `objs`/`fields` is a no-op returning `0`.

## Tests

New `bulk_update_api_sqlite_live.rs` (4 tests): per-row values written, **unnamed columns untouched**, PK rejection, unknown-column rejection, empty no-op. Wired into the `sqlite_live` job; also runs under `postgres_test --all-features`.

## Gates
- `cargo test … --test bulk_update_api_sqlite_live` — 4 pass
- `cargo test -p rustango --features sqlite,tenancy --lib` — 2263 pass
- `cargo test --workspace --all-features --no-run` — full workspace + all test binaries compile (method is emitted for every model under all feature combos)
- `cargo fmt --check` clean; clippy: no new warnings