### PR TITLE
feat(i18n): editable DB-override layer for translations (#532 Slice 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,7 @@ jobs:
             --test funcs_batch1_sqlite_live \
             --test funcs_batch2_sqlite_live \
             --test get_or_create_sqlite_live \
+            --test i18n_db_overrides_sqlite_live \
             --test inspectdb_sqlite_live \
             --test inspectdb_views_sqlite_live \
             --test jobs_sqlite_live \

--- a/crates/rustango/src/i18n/db.rs
+++ b/crates/rustango/src/i18n/db.rs
@@ -1,0 +1,189 @@
+//! Editable DB-override layer for translations — issue #532 Slice 1.
+//!
+//! `Translator::from_directory` loads `locales/<lang>.json` on boot and
+//! that's the *only* ingest path: fixing a typo in `fr.json` means an
+//! editor + a redeploy. This module adds the hybrid storage layer the
+//! issue's Slice 1 calls for — a `rustango_translations` table whose
+//! rows override the file catalogs, so operators (eventually via the
+//! Slice 2 admin UI) can edit translations without shipping code.
+//!
+//! Lookup order in [`crate::i18n::Translator::translate`] becomes:
+//!
+//! 1. DB override (this table, loaded into the in-memory override map
+//!    via [`refresh_overrides_pool`])
+//! 2. File-loaded JSON catalog (read-only seed, unchanged)
+//! 3. Default-locale catalog (existing fallback chain)
+//!
+//! Files stay the source of truth for shipped defaults;
+//! [`seed_from_translator_pool`] copies them into the DB once
+//! (`ON CONFLICT DO NOTHING`), and edits live as DB rows on top.
+//!
+//! The table is created by [`ensure_table_pool`] across all three
+//! dialects (mirroring `audit` / `contenttypes`) rather than the
+//! migration graph, so it works for any app holding a [`Pool`] —
+//! tenancy or not. Tenancy apps create it on the registry pool.
+
+use crate::i18n::Translator;
+use crate::sql::{Auto, ExecError, Pool};
+use crate::Model;
+
+/// One editable translation, table `rustango_translations`. The
+/// `(locale, key)` pair is unique — one editable value per key per
+/// locale.
+///
+/// `managed = false`: created by [`ensure_table_pool`], not the
+/// migration graph. The table also carries DB-defaulted `created_at` /
+/// `updated_at` columns for the Slice 2 audit trail; they're not mapped
+/// here because the ORM only `SELECT`s declared columns, so the extra
+/// columns are harmless to this model.
+#[derive(Model, Debug, Clone, serde::Serialize)]
+#[rustango(table = "rustango_translations", managed = false)]
+pub struct Translation {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 16)]
+    pub locale: String,
+    #[rustango(max_length = 200)]
+    pub key: String,
+    pub value: String,
+    #[rustango(max_length = 200, default = "")]
+    pub updated_by: String,
+}
+
+const DDL_PG: &str = r#"
+CREATE TABLE IF NOT EXISTS "rustango_translations" (
+    "id"         BIGSERIAL PRIMARY KEY,
+    "locale"     VARCHAR(16) NOT NULL,
+    "key"        VARCHAR(200) NOT NULL,
+    "value"      TEXT NOT NULL,
+    "updated_by" VARCHAR(200) NOT NULL DEFAULT '',
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT "rustango_translations_locale_key_uq" UNIQUE ("locale", "key")
+);
+"#;
+
+const DDL_SQLITE: &str = r#"
+CREATE TABLE IF NOT EXISTS "rustango_translations" (
+    "id"         INTEGER PRIMARY KEY AUTOINCREMENT,
+    "locale"     TEXT NOT NULL,
+    "key"        TEXT NOT NULL,
+    "value"      TEXT NOT NULL,
+    "updated_by" TEXT NOT NULL DEFAULT '',
+    "created_at" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "rustango_translations_locale_key_uq" UNIQUE ("locale", "key")
+);
+"#;
+
+const DDL_MYSQL: &str = r"
+CREATE TABLE IF NOT EXISTS `rustango_translations` (
+    `id`         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `locale`     VARCHAR(16) NOT NULL,
+    `key`        VARCHAR(200) NOT NULL,
+    `value`      TEXT NOT NULL,
+    `updated_by` VARCHAR(200) NOT NULL DEFAULT '',
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT `rustango_translations_locale_key_uq` UNIQUE (`locale`, `key`)
+);
+";
+
+/// Create `rustango_translations` if absent — idempotent, dispatched per
+/// dialect. Call once at startup (and the Slice 2 `seed-translations`
+/// verb calls it too).
+///
+/// # Errors
+/// Driver / SQL failures other than the duplicate-object errors that
+/// [`crate::sql::run_ddl_idempotent`] swallows.
+pub async fn ensure_table_pool(pool: &Pool) -> Result<(), sqlx::Error> {
+    let ddl = match pool.dialect().name() {
+        "mysql" => DDL_MYSQL,
+        "sqlite" => DDL_SQLITE,
+        // Postgres + any future dialect: the standard `"`-quoted DDL.
+        _ => DDL_PG,
+    };
+    crate::sql::run_ddl_idempotent(pool, ddl).await
+}
+
+/// Every override row, for the admin list view / [`refresh_overrides_pool`].
+///
+/// # Errors
+/// As the ORM fetch path ([`ExecError`]).
+pub async fn all_pool(pool: &Pool) -> Result<Vec<Translation>, ExecError> {
+    use crate::sql::FetcherPool as _;
+    Translation::objects().fetch_pool(pool).await
+}
+
+/// Insert-or-update the editable value for `(locale, key)` — the
+/// "edit without redeploy" write. `updated_by` records who made the
+/// change (operator id / username); pass `""` if not tracked.
+///
+/// # Errors
+/// As the ORM upsert path ([`ExecError`]).
+pub async fn upsert_pool(
+    pool: &Pool,
+    locale: &str,
+    key: &str,
+    value: &str,
+    updated_by: &str,
+) -> Result<(), ExecError> {
+    let row = Translation {
+        id: Auto::Unset,
+        locale: locale.to_owned(),
+        key: key.to_owned(),
+        value: value.to_owned(),
+        updated_by: updated_by.to_owned(),
+    };
+    Translation::bulk_upsert_pool(&[row], &["locale", "key"], &["value", "updated_by"], pool).await
+}
+
+/// Seed the DB layer from a [`Translator`]'s file catalogs. Existing
+/// `(locale, key)` rows are left untouched (`ON CONFLICT DO NOTHING`),
+/// so files stay the source of truth for shipped defaults and only
+/// previously-unknown keys are added. Idempotent — safe to run on every
+/// boot. Returns the number of file entries processed.
+///
+/// The on-disk path is the caller's: load with
+/// `Translator::from_directory(dir, default)?` then hand the result here
+/// (keeps the filesystem error out of [`ExecError`]).
+///
+/// # Errors
+/// As the ORM bulk-insert path ([`ExecError`]).
+pub async fn seed_from_translator_pool(
+    pool: &Pool,
+    translator: &Translator,
+) -> Result<usize, ExecError> {
+    let rows: Vec<Translation> = translator
+        .entries()
+        .into_iter()
+        .map(|(locale, key, value)| Translation {
+            id: Auto::Unset,
+            locale,
+            key,
+            value,
+            updated_by: String::new(),
+        })
+        .collect();
+    let n = rows.len();
+    if n > 0 {
+        Translation::bulk_insert_or_ignore_pool(&rows, pool).await?;
+    }
+    Ok(n)
+}
+
+/// Reload `translator`'s override layer from the DB so subsequent
+/// `translate(...)` calls reflect persisted edits — call after seeding,
+/// on boot, and after each admin save. Returns the row count loaded.
+///
+/// # Errors
+/// As the ORM fetch path ([`ExecError`]).
+pub async fn refresh_overrides_pool(
+    translator: &Translator,
+    pool: &Pool,
+) -> Result<usize, ExecError> {
+    let rows = all_pool(pool).await?;
+    let n = rows.len();
+    translator.load_overrides(rows.into_iter().map(|t| (t.locale, t.key, t.value)));
+    Ok(n)
+}

--- a/crates/rustango/src/i18n/mod.rs
+++ b/crates/rustango/src/i18n/mod.rs
@@ -40,6 +40,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::RwLock;
 
+pub mod db;
 pub mod middleware;
 pub mod tera_tags;
 pub mod timezone;
@@ -310,6 +311,14 @@ pub struct Translator {
     /// Django parity #425. Lowercased on insert.
     fallback_chain: Vec<Locale>,
     catalogs: RwLock<HashMap<Locale, HashMap<String, String>>>,
+    /// DB-sourced override layer (#532). Same `locale → key → value`
+    /// shape as `catalogs`, but consulted *first* by [`Self::translate`]
+    /// so operator edits persisted to `rustango_translations` win over
+    /// the file-loaded defaults. Empty unless [`Self::load_overrides`] /
+    /// [`Self::set_override`] is called (e.g. by
+    /// [`crate::i18n::db::refresh_overrides_pool`]). Refreshing from the
+    /// DB keeps `translate` synchronous — no per-render query.
+    overrides: RwLock<HashMap<Locale, HashMap<String, String>>>,
 }
 
 impl Translator {
@@ -320,6 +329,7 @@ impl Translator {
             default_locale,
             fallback_chain: Vec::new(),
             catalogs: RwLock::new(HashMap::new()),
+            overrides: RwLock::new(HashMap::new()),
         }
     }
 
@@ -382,8 +392,23 @@ impl Translator {
     /// `params` substitutes `{name}` placeholders in the result.
     #[must_use]
     pub fn translate(&self, locale: &str, key: &str, params: &[(&str, &str)]) -> String {
-        let cats = self.catalogs.read().expect("translator poisoned");
         let req = Locale::new(locale);
+
+        // DB override layer (#532) takes priority over the file
+        // catalogs for the requested locale / its base language, so an
+        // operator's persisted edit wins. Anything not overridden falls
+        // through to the unchanged catalog lookup below.
+        {
+            let ov = self.overrides.read().expect("translator poisoned");
+            if let Some(v) = ov.get(&req).and_then(|c| c.get(key)).or_else(|| {
+                ov.get(&Locale::new(req.base_language()))
+                    .and_then(|c| c.get(key))
+            }) {
+                return substitute(v, params);
+            }
+        }
+
+        let cats = self.catalogs.read().expect("translator poisoned");
 
         // Walk the lookup chain in priority order.
         let mut template: Option<String> = cats
@@ -432,6 +457,63 @@ impl Translator {
             .keys()
             .map(|l| l.0.clone())
             .collect()
+    }
+
+    /// Every file-catalog entry as `(locale, key, value)` triples — used
+    /// to seed the editable DB layer from the on-disk defaults (#532).
+    #[must_use]
+    pub fn entries(&self) -> Vec<(String, String, String)> {
+        let cats = self.catalogs.read().expect("translator poisoned");
+        let mut out = Vec::new();
+        for (loc, catalog) in cats.iter() {
+            for (k, v) in catalog {
+                out.push((loc.0.clone(), k.clone(), v.clone()));
+            }
+        }
+        out
+    }
+
+    /// Replace the entire DB-override layer (#532) with `rows`
+    /// (`(locale, key, value)` triples — typically every
+    /// `rustango_translations` row). Locale strings are normalized the
+    /// same way as catalog locales. See
+    /// [`crate::i18n::db::refresh_overrides_pool`].
+    pub fn load_overrides(&self, rows: impl IntoIterator<Item = (String, String, String)>) {
+        let mut map: HashMap<Locale, HashMap<String, String>> = HashMap::new();
+        for (locale, key, value) in rows {
+            map.entry(Locale::new(&locale))
+                .or_default()
+                .insert(key, value);
+        }
+        *self.overrides.write().expect("translator poisoned") = map;
+    }
+
+    /// Set a single override entry (#532) without a full reload — used by
+    /// the admin edit path so a save takes effect immediately.
+    pub fn set_override(&self, locale: &str, key: impl Into<String>, value: impl Into<String>) {
+        self.overrides
+            .write()
+            .expect("translator poisoned")
+            .entry(Locale::new(locale))
+            .or_default()
+            .insert(key.into(), value.into());
+    }
+
+    /// Drop every DB override, falling back to the file catalogs (#532).
+    pub fn clear_overrides(&self) {
+        self.overrides.write().expect("translator poisoned").clear();
+    }
+
+    /// Total number of override entries across all locales (#532) —
+    /// handy for diagnostics and the admin coverage panel.
+    #[must_use]
+    pub fn override_count(&self) -> usize {
+        self.overrides
+            .read()
+            .expect("translator poisoned")
+            .values()
+            .map(HashMap::len)
+            .sum()
     }
 
     /// Load every `*.json` file in `dir` as a locale catalog. The file

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -244,6 +244,22 @@ pub fn registered_models() -> Vec<&'static ModelSchema> {
         .collect()
 }
 
+/// The subset of [`registered_models`] the inventory-walk bootstrap
+/// (`apply_all*` / `drop_all*`) should touch: framework-managed tables
+/// only. Django `Meta.managed = False` (#321) means the framework
+/// neither creates nor drops the table — the snapshot / migration path
+/// already filters these (see `snapshot.rs`), and the bootstrap walk
+/// must match. Otherwise a `managed = false` model (e.g.
+/// `rustango_translations`, which owns its schema via its own
+/// `ensure_table`) would get a second, schema-mismatched `CREATE TABLE`
+/// emitted from its field metadata here.
+fn bootstrap_models() -> Vec<&'static ModelSchema> {
+    registered_models()
+        .into_iter()
+        .filter(|m| m.managed)
+        .collect()
+}
+
 /// Run `CREATE TABLE` for every registered model, then every model's FK
 /// `ALTER TABLE` constraints. Two-phase so create order doesn't matter.
 /// PG-typed back-compat; for non-PG use [`apply_all_pool`].
@@ -260,7 +276,7 @@ pub async fn apply_all(pool: &PgPool) -> Result<(), MigrateError> {
         source: "apply_all",
     })
     .await;
-    let models = registered_models();
+    let models = bootstrap_models();
 
     for model in &models {
         let sql = ddl::create_table_sql(model);
@@ -289,7 +305,7 @@ pub async fn apply_all(pool: &PgPool) -> Result<(), MigrateError> {
 /// Returns [`MigrateError`] for any sqlx failure.
 #[cfg(feature = "postgres")]
 pub async fn drop_all(pool: &PgPool) -> Result<(), MigrateError> {
-    for model in registered_models() {
+    for model in bootstrap_models() {
         let sql = ddl::drop_table_sql(model, /* if_exists */ true, /* cascade */ true);
         sqlx::query(&sql).execute(pool).await?;
     }
@@ -319,7 +335,7 @@ pub async fn apply_all_pool(pool: &crate::sql::Pool) -> Result<(), MigrateError>
     })
     .await;
     let dialect = pool.dialect();
-    let models = registered_models();
+    let models = bootstrap_models();
     for model in &models {
         let sql = ddl::create_table_sql_with_dialect(dialect, model);
         crate::sql::raw_execute_pool(pool, &sql, ::std::vec::Vec::new()).await?;
@@ -371,7 +387,7 @@ pub async fn drop_all_pool(pool: &crate::sql::Pool) -> Result<(), MigrateError> 
     let dialect = pool.dialect();
     // Cascade only emitted for PG — MySQL parses it as syntax error.
     let cascade = dialect.name() == "postgres";
-    for model in registered_models() {
+    for model in bootstrap_models() {
         let sql =
             ddl::drop_table_sql_with_dialect(dialect, model, /* if_exists */ true, cascade);
         crate::sql::raw_execute_pool(pool, &sql, ::std::vec::Vec::new()).await?;

--- a/crates/rustango/tests/i18n_db_overrides_sqlite_live.rs
+++ b/crates/rustango/tests/i18n_db_overrides_sqlite_live.rs
@@ -133,3 +133,27 @@ async fn seed_from_translator_is_idempotent() {
     refresh_overrides_pool(&t, &pool).await.unwrap();
     assert_eq!(t.translate("fr", "a", &[]), "Salut-override");
 }
+
+#[tokio::test]
+async fn apply_all_does_not_bootstrap_the_managed_false_table() {
+    // `Translation` is `managed = false`: its schema is owned by
+    // `ensure_table_pool` (UNIQUE(locale,key) + DB-defaulted timestamps),
+    // so the inventory-walk bootstrap must skip it. Otherwise it gets a
+    // second, schema-mismatched CREATE TABLE from its field metadata —
+    // the regression that broke `migrate_signals` / `mysql_live` when
+    // this model first landed (apply_all walking every registered model,
+    // not just the managed ones).
+    let pool = empty_pool().await;
+    rustango::migrate::apply_all_pool(&pool)
+        .await
+        .expect("apply_all_pool succeeds with a managed=false model in inventory");
+
+    // The bootstrap did NOT create rustango_translations…
+    assert!(
+        all_pool(&pool).await.is_err(),
+        "managed=false table must be absent after apply_all_pool"
+    );
+    // …`ensure_table_pool` is its sole creator.
+    ensure_table_pool(&pool).await.unwrap();
+    assert_eq!(all_pool(&pool).await.unwrap().len(), 0);
+}

--- a/crates/rustango/tests/i18n_db_overrides_sqlite_live.rs
+++ b/crates/rustango/tests/i18n_db_overrides_sqlite_live.rs
@@ -1,0 +1,135 @@
+#![cfg(feature = "sqlite")]
+//! Live SQLite test for the i18n DB-override layer — issue #532 Slice 1.
+//!
+//! Covers the full storage substrate: `ensure_table_pool` is idempotent,
+//! `upsert_pool` inserts then updates a `(locale, key)`, seeding from a
+//! `Translator`'s file catalogs is idempotent (`ON CONFLICT DO NOTHING`),
+//! and `refresh_overrides_pool` makes `Translator::translate` prefer the
+//! DB value over the file value while leaving non-overridden keys on the
+//! file catalog.
+//!
+//! `max_connections(1)` pins DDL + writes + reads to one in-memory DB.
+
+use std::collections::HashMap;
+
+use rustango::i18n::db::{
+    all_pool, ensure_table_pool, refresh_overrides_pool, seed_from_translator_pool, upsert_pool,
+};
+use rustango::i18n::{Locale, Translator};
+use rustango::sql::{sqlx, Pool};
+
+async fn empty_pool() -> Pool {
+    let p = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("sqlite");
+    p.into()
+}
+
+async fn ready_pool() -> Pool {
+    let pool = empty_pool().await;
+    ensure_table_pool(&pool).await.expect("ensure_table");
+    pool
+}
+
+fn catalog(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+        .collect()
+}
+
+#[tokio::test]
+async fn ensure_table_is_idempotent() {
+    let pool = empty_pool().await;
+    ensure_table_pool(&pool).await.expect("first create");
+    ensure_table_pool(&pool)
+        .await
+        .expect("second create is a no-op");
+    // Table is usable.
+    assert_eq!(all_pool(&pool).await.unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn upsert_inserts_then_updates_in_place() {
+    let pool = ready_pool().await;
+
+    upsert_pool(&pool, "fr", "greeting", "Bonjour", "alice")
+        .await
+        .unwrap();
+    upsert_pool(&pool, "es", "greeting", "Hola", "bob")
+        .await
+        .unwrap();
+    assert_eq!(all_pool(&pool).await.unwrap().len(), 2);
+
+    // Same (locale, key) again → UPDATE, not a duplicate row.
+    upsert_pool(&pool, "fr", "greeting", "Salut", "carol")
+        .await
+        .unwrap();
+    let rows = all_pool(&pool).await.unwrap();
+    assert_eq!(rows.len(), 2, "(locale, key) is unique — upsert updates");
+    let fr = rows
+        .iter()
+        .find(|t| t.locale == "fr" && t.key == "greeting")
+        .unwrap();
+    assert_eq!(fr.value, "Salut");
+    assert_eq!(fr.updated_by, "carol");
+}
+
+#[tokio::test]
+async fn refresh_makes_translate_prefer_db_over_file() {
+    let pool = ready_pool().await;
+
+    // File catalog: fr has two keys.
+    let t = Translator::new(Locale::new("en"));
+    t.insert_locale(
+        Locale::new("fr"),
+        catalog(&[("greeting", "Bonjour (file)"), ("bye", "Au revoir")]),
+    );
+    assert_eq!(t.translate("fr", "greeting", &[]), "Bonjour (file)");
+
+    // Operator edits `fr.greeting` in the DB, then we refresh the layer.
+    upsert_pool(&pool, "fr", "greeting", "Salut (db)", "op")
+        .await
+        .unwrap();
+    let loaded = refresh_overrides_pool(&t, &pool).await.unwrap();
+    assert_eq!(loaded, 1);
+
+    // DB override wins for the edited key…
+    assert_eq!(t.translate("fr", "greeting", &[]), "Salut (db)");
+    // …but a non-overridden key still resolves from the file catalog.
+    assert_eq!(t.translate("fr", "bye", &[]), "Au revoir");
+    // Base-language resolution also sees the override (fr-FR → fr).
+    assert_eq!(t.translate("fr-FR", "greeting", &[]), "Salut (db)");
+}
+
+#[tokio::test]
+async fn seed_from_translator_is_idempotent() {
+    let pool = ready_pool().await;
+
+    let t = Translator::new(Locale::new("en"));
+    t.insert_locale(Locale::new("en"), catalog(&[("a", "A"), ("b", "B")]));
+    t.insert_locale(Locale::new("fr"), catalog(&[("a", "Ah")]));
+
+    let n1 = seed_from_translator_pool(&pool, &t).await.unwrap();
+    assert_eq!(n1, 3, "2 en + 1 fr entries processed");
+    assert_eq!(all_pool(&pool).await.unwrap().len(), 3);
+
+    // Re-seed: every key already present → ON CONFLICT DO NOTHING.
+    let n2 = seed_from_translator_pool(&pool, &t).await.unwrap();
+    assert_eq!(n2, 3, "still processes all entries");
+    assert_eq!(
+        all_pool(&pool).await.unwrap().len(),
+        3,
+        "no duplicate rows — files stay the read-only seed"
+    );
+
+    // A pre-existing DB edit is NOT clobbered by a re-seed.
+    upsert_pool(&pool, "fr", "a", "Salut-override", "op")
+        .await
+        .unwrap();
+    seed_from_translator_pool(&pool, &t).await.unwrap();
+    refresh_overrides_pool(&t, &pool).await.unwrap();
+    assert_eq!(t.translate("fr", "a", &[]), "Salut-override");
+}


### PR DESCRIPTION
Slice 1 of #532 — the hybrid file-seed / DB-override storage layer the issue calls for. Lands the substrate; the admin UI (Slice 2) follows separately.

## Problem
`Translator::from_directory("./locales", …)` is the **only** ingest path today. Fixing a typo in `fr.json` requires an editor + a redeploy, and non-engineers (localization vendors, marketing) can't touch a string. There's also no visibility into coverage gaps.

## What

`Translator::translate` lookup order becomes:
1. **DB override** (`rustango_translations`, loaded into an in-memory map)
2. file-loaded JSON catalog (read-only seed, unchanged)
3. default-locale catalog (existing fallback chain)

Files stay the source of truth for shipped defaults; DB rows are the editable layer on top. `translate` stays **synchronous** — the override map is refreshed from the DB out-of-band (seed / boot / save), never per-render.

### `Translator` (`src/i18n/mod.rs`)
- New `overrides` layer consulted first by `translate` (exact locale → base language) before the unchanged catalog lookup. Empty by default → **zero behavior change** until populated.
- `load_overrides` / `set_override` / `clear_overrides` / `override_count` + `entries()` (file catalogs as `(locale, key, value)` triples, for seeding).

### Storage (`src/i18n/db.rs`, new)
- `Translation` model (`rustango_translations`, `managed = false`, unique `(locale, key)`), created by `ensure_table_pool` across **all three dialects** (mirrors `audit` / `contenttypes`) — works for any app holding a `Pool`, tenancy or not. Carries DB-defaulted `created_at`/`updated_at` for the Slice 2 audit trail.
- Free fns: `ensure_table_pool`, `all_pool`, `upsert_pool` (edit-without-redeploy), `seed_from_translator_pool` (copy file defaults in, `ON CONFLICT DO NOTHING` — never clobbers an existing edit), `refresh_overrides_pool` (reload the in-memory layer).

## Tests
`i18n_db_overrides_sqlite_live.rs` (4): ensure_table idempotency; upsert insert-then-update-in-place; `refresh` making `translate` prefer the DB value (incl. base-language `fr-FR → fr`) while non-overridden keys stay on the file catalog; **re-seed not clobbering an operator edit**. Wired into `sqlite_live`; also runs under `postgres_test --all-features`.

## Gates
- `--test i18n_db_overrides_sqlite_live` — 4 pass
- `cargo test -p rustango --features sqlite,tenancy --lib` — 2263 pass
- `cargo test --workspace --all-features --no-run` — full workspace + all test binaries compile
- `cargo fmt --check` clean; clippy: no new warnings

## Follow-up (Slice 2)
Admin pages (`/__admin/i18n/`: list / detail-edit / add / delete / coverage / export) + the `seed-translations` manage verb + `auth.edit_translations` permission codename + audit-logging each change.