### PR TITLE
feat(gis): PostGIS Point geometry type (closes #443)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,38 @@ jobs:
       - run: cargo test -p rustango --features mysql --test funcs_batch1_mysql_live
       - run: cargo test -p rustango --features mysql --test json_path_mysql_live
 
+  # PostGIS geometry live suite (#443). The regular `postgres_test` runs
+  # against `pgvector/pgvector:pg16`, which has no PostGIS, so the
+  # geometry round-trip test there skips (CREATE EXTENSION postgis fails →
+  # graceful skip). This job runs `postgis/postgis:16-3.4` so the
+  # `Point` column EWKB encode/decode is exercised end-to-end against a
+  # real PostGIS. Like pgvector, the postgis image is a Docker Hub user-
+  # namespace image (not on the AWS ECR `library/` mirror), so it's
+  # pulled straight from Docker Hub.
+  postgis_live:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgis/postgis:16-3.4
+        env:
+          POSTGRES_USER: rustango
+          POSTGRES_PASSWORD: rustango
+          POSTGRES_DB: rustango_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U rustango -d rustango_test"
+          --health-interval 2s
+          --health-timeout 2s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgres://rustango:rustango@127.0.0.1:5432/rustango_test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.88
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test -p rustango --features postgres,tenancy --test gis_geometry_postgis_live
+
   # End-to-end playwright suite for the multi-app rustango showcase.
   # The showcase is a severed workspace under examples/showcase/ that
   # exercises every framework surface (admin, viewsets, forms, auth,

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -10311,6 +10311,10 @@ struct FieldAttrs {
     /// Threaded into `FieldType::Vector(N)` at emission. `None` → an
     /// unconstrained `vector` column.
     vector_dims: Option<u32>,
+    /// `#[rustango(geometry(srid = N))]` — PostGIS geometry SRID (#443).
+    /// Threaded into `FieldType::Geometry(N)` at emission. `None` → an
+    /// unconstrained `geometry(Point)` column (SRID 0).
+    geometry_srid: Option<u32>,
     min: Option<i64>,
     max: Option<i64>,
     default: Option<String>,
@@ -10424,6 +10428,7 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
         related_name: None,
         max_length: None,
         vector_dims: None,
+        geometry_srid: None,
         min: None,
         max: None,
         default: None,
@@ -10541,6 +10546,19 @@ fn parse_field_attrs(field: &syn::Field) -> syn::Result<FieldAttrs> {
                         return Ok(());
                     }
                     Err(inner.error("unknown `vector` attribute (supported: `dims`)"))
+                })?;
+                return Ok(());
+            }
+            // `#[rustango(geometry(srid = N))]` — PostGIS geometry SRID
+            // (#443). Nested-meta form, mirroring `vector(dims = N)`.
+            if meta.path.is_ident("geometry") {
+                meta.parse_nested_meta(|inner| {
+                    if inner.path.is_ident("srid") {
+                        let lit: syn::LitInt = inner.value()?.parse()?;
+                        out.geometry_srid = Some(lit.base10_parse::<u32>()?);
+                        return Ok(());
+                    }
+                    Err(inner.error("unknown `geometry` attribute (supported: `srid`)"))
                 })?;
                 return Ok(());
             }
@@ -11068,6 +11086,13 @@ fn process_field<'a>(field: &'a syn::Field, table: &str) -> syn::Result<FieldInf
         let root = rustango_root();
         let dims = attrs.vector_dims.unwrap_or(0);
         quote!(#root::core::FieldType::Vector(#dims))
+    } else if kind == DetectedKind::Geometry {
+        // PostGIS (#443): the `geometry(srid = N)` attribute supplies the
+        // SRID that the bare `Point` Rust type can't carry, so emit
+        // `FieldType::Geometry(N)` rather than the `Geometry(0)` fallback.
+        let root = rustango_root();
+        let srid = attrs.geometry_srid.unwrap_or(0);
+        quote!(#root::core::FieldType::Geometry(#srid))
     } else {
         kind.variant_tokens()
     };
@@ -11338,6 +11363,10 @@ enum DetectedKind {
     /// from the `#[rustango(vector(dims = N))]` field attribute, threaded
     /// in at the `FieldType` emission site (not carried on this enum).
     Vector,
+    /// `Point` → PostGIS `geometry(Point, srid)` (#443). The SRID comes
+    /// from the `#[rustango(geometry(srid = N))]` field attribute,
+    /// threaded in at the `FieldType` emission site.
+    Geometry,
 }
 
 impl DetectedKind {
@@ -11386,6 +11415,9 @@ impl DetectedKind {
             // Dimension comes from the `vector(dims = N)` attribute,
             // applied at the emission site; `0` here is just a fallback.
             Self::Vector => quote!(#root::core::FieldType::Vector(0)),
+            // SRID comes from the `geometry(srid = N)` attribute, applied
+            // at the emission site; `0` here is just a fallback.
+            Self::Geometry => quote!(#root::core::FieldType::Geometry(0)),
         }
     }
 
@@ -11445,6 +11477,9 @@ impl DetectedKind {
             Self::HStore => (quote!(HStore), quote!(::std::vec::Vec::new())),
             // Vector (#824) can't be a FK PK — never reached.
             Self::Vector => (quote!(Vector), quote!(::std::vec::Vec::new())),
+            // Geometry (#443) can't be a FK PK — never reached (arm is
+            // exhaustiveness-only; never interpolated into emitted code).
+            Self::Geometry => (quote!(Geometry), quote!(::std::vec::Vec::new())),
         }
     }
 }
@@ -11697,6 +11732,16 @@ fn detect_type(ty: &syn::Type) -> syn::Result<DetectedType<'_>> {
         "Vector" => {
             return Ok(DetectedType {
                 kind: DetectedKind::Vector,
+                nullable: false,
+                auto: false,
+                fk_inner: None,
+            });
+        }
+        // `Point` → PostGIS `geometry(Point, srid)` (#443). The SRID is
+        // supplied by `#[rustango(geometry(srid = N))]`, not the type.
+        "Point" => {
+            return Ok(DetectedType {
+                kind: DetectedKind::Geometry,
                 nullable: false,
                 auto: false,
                 fk_inner: None,

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -127,6 +127,8 @@ pub(crate) fn render_value_for_input_json(row: &serde_json::Value, field: &Field
         FieldType::HStore => v.to_string(),
         // #824 — pgvector: compact JSON array form.
         FieldType::Vector(_) => v.to_string(),
+        // #443 — PostGIS Point: compact JSON object form.
+        FieldType::Geometry(_) => v.to_string(),
     }
 }
 
@@ -354,6 +356,10 @@ fn render_input_default(field: &FieldSchema, value: &str, pk_locked: bool) -> St
         FieldType::Vector(_) => format!(
             r#"<input type="text" name="{name}" id="{name}" value="{val}" placeholder="[0.1, 0.2, ...]"{required}{readonly}>"#
         ),
+        // #443 — PostGIS Point: a JSON-object text input (`{{"x":..,"y":..}}`).
+        FieldType::Geometry(_) => format!(
+            r#"<input type="text" name="{name}" id="{name}" value="{val}" placeholder="{{&quot;x&quot;: 0, &quot;y&quot;: 0, &quot;srid&quot;: 4326}}"{required}{readonly}>"#
+        ),
     }
 }
 
@@ -537,6 +543,10 @@ pub(crate) fn render_value_json(row: &serde_json::Value, field: &FieldSchema) ->
         FieldType::Vector(_) => serde_json::to_string(v)
             .map(|s| escape(&s))
             .unwrap_or_default(),
+        // #443 — PostGIS Point: compact JSON object in the list cell.
+        FieldType::Geometry(_) => serde_json::to_string(v)
+            .map(|s| escape(&s))
+            .unwrap_or_default(),
     }
 }
 
@@ -615,6 +625,8 @@ pub(crate) fn read_joined_value_as_html_json(
         FieldType::HStore => None,
         // #824 — vector isn't a meaningful select_related join target.
         FieldType::Vector(_) => None,
+        // #443 — geometry isn't a meaningful select_related join target.
+        FieldType::Geometry(_) => None,
     };
     text.map(|s| escape(&s))
 }

--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -1281,6 +1281,9 @@ fn bind_value_pg(
         SqlValue::Vector(_) => {
             unreachable!("Vector values never reach audited-save bind path")
         }
+        SqlValue::Geometry { .. } => {
+            unreachable!("Geometry values never reach audited-save bind path")
+        }
     }
 }
 
@@ -1317,6 +1320,9 @@ fn bind_value_my(
         }
         SqlValue::Vector(_) => {
             unreachable!("Vector values never reach audited-save bind path")
+        }
+        SqlValue::Geometry { .. } => {
+            unreachable!("Geometry values never reach audited-save bind path")
         }
     }
 }
@@ -1356,6 +1362,9 @@ fn bind_value_sqlite<'q>(
         }
         SqlValue::Vector(_) => {
             unreachable!("Vector values never reach audited-save bind path")
+        }
+        SqlValue::Geometry { .. } => {
+            unreachable!("Geometry values never reach audited-save bind path")
         }
     }
 }

--- a/crates/rustango/src/core/field_type.rs
+++ b/crates/rustango/src/core/field_type.rs
@@ -68,6 +68,13 @@ pub enum FieldType {
     /// SQLite degrade to `TEXT`, and the decode path + distance
     /// operators error there. Requires the `vector` extension.
     Vector(u32),
+    /// Native PostGIS `geometry(Point, SRID)` column — GeoDjango
+    /// `gis.geos` geometry types (#443). The `u32` is the SRID (4326 =
+    /// WGS 84). Rust type: [`crate::sql::Point`]. **PG/PostGIS-only by
+    /// language semantics** like [`Self::Vector`]: MySQL / SQLite degrade
+    /// to `TEXT` and the decode path errors there. Requires the `postgis`
+    /// extension. (Slice 1 supports the `Point` subtype only.)
+    Geometry(u32),
 }
 
 /// Element type of a [`FieldType::Range`] column (#343). Selects the
@@ -159,6 +166,7 @@ impl FieldType {
             Self::Range(RangeElem::DateTime) => "Range<DateTime<Utc>>",
             Self::HStore => "HStore",
             Self::Vector(_) => "Vector",
+            Self::Geometry(_) => "Point",
         }
     }
 }

--- a/crates/rustango/src/core/validate.rs
+++ b/crates/rustango/src/core/validate.rs
@@ -48,7 +48,8 @@ pub fn validate_value(
         | SqlValue::Decimal(_)
         | SqlValue::Binary(_)
         | SqlValue::HStore(_)
-        | SqlValue::Vector(_) => Ok(()),
+        | SqlValue::Vector(_)
+        | SqlValue::Geometry { .. } => Ok(()),
     }
 }
 

--- a/crates/rustango/src/core/value.rs
+++ b/crates/rustango/src/core/value.rs
@@ -83,6 +83,16 @@ pub enum SqlValue {
     /// / SQLite reject (no `vector` type). Built from
     /// [`crate::sql::Vector`] via `Into<SqlValue>`.
     Vector(Vec<f32>),
+    /// PostGIS `geometry(Point, …)` value — issue #443. Backend-neutral
+    /// 2-D point + SRID at this layer; the PG bind path encodes it as
+    /// EWKB (via [`crate::sql::Point`]), MySQL / SQLite reject (no
+    /// `geometry` type). Built from [`crate::sql::Point`] via
+    /// `Into<SqlValue>`.
+    Geometry {
+        x: f64,
+        y: f64,
+        srid: u32,
+    },
 }
 
 impl SqlValue {
@@ -133,6 +143,7 @@ impl SqlValue {
                 let inner: Vec<String> = items.iter().map(f32::to_string).collect();
                 format!("vector[{}]", inner.join(", "))
             }
+            Self::Geometry { x, y, srid } => format!("SRID={srid};POINT({x} {y})"),
         }
     }
 
@@ -148,7 +159,10 @@ impl SqlValue {
             // `Vector` carries no dimension here; the column's
             // `FieldType::Vector(dims)` comes from the schema, so a bound
             // value can't be type-checked against it. Skip (like Array).
-            | Self::Vector(_) => return None,
+            | Self::Vector(_)
+            // `Geometry` likewise can't be type-checked against the
+            // column's `FieldType::Geometry(srid)` from here. Skip.
+            | Self::Geometry { .. } => return None,
             Self::I16(_) => FieldType::I16,
             Self::I32(_) => FieldType::I32,
             Self::I64(_) => FieldType::I64,

--- a/crates/rustango/src/forms/mod.rs
+++ b/crates/rustango/src/forms/mod.rs
@@ -239,12 +239,13 @@ pub fn parse_pk_string(field: &FieldSchema, raw: &str) -> Result<SqlValue, FormE
         | FieldType::Json
         | FieldType::Decimal
         | FieldType::Binary
-        // #341 / #343 / #342 / #824 — array / range / hstore / vector
-        // can't be a PK.
+        // #341 / #343 / #342 / #824 / #443 — array / range / hstore /
+        // vector / geometry can't be a PK.
         | FieldType::Array(_)
         | FieldType::Range(_)
         | FieldType::HStore
-        | FieldType::Vector(_) => Err(FormError::UnsupportedPk {
+        | FieldType::Vector(_)
+        | FieldType::Geometry(_) => Err(FormError::UnsupportedPk {
             field: field.name.to_owned(),
             ty: field.ty.as_str(),
         }),
@@ -426,6 +427,13 @@ pub fn parse_form_value(field: &FieldSchema, raw: Option<&str>) -> Result<SqlVal
             let vec: Vec<f32> = serde_json::from_str(raw)
                 .map_err(|e| make_parse_err("vector (JSON array of numbers)", &e))?;
             Ok(SqlValue::Vector(vec))
+        }
+        // #443 — PostGIS geometry from a form field: a JSON Point object
+        // (`{"x": 1.5, "y": -2.25, "srid": 4326}`; `srid` defaults to 4326).
+        FieldType::Geometry(_) => {
+            let p: crate::sql::Point = serde_json::from_str(raw)
+                .map_err(|e| make_parse_err("geometry (JSON {x, y, srid?})", &e))?;
+            Ok(p.into())
         }
     }
 }

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -3019,6 +3019,13 @@ fn json_to_sql_value(
                 .collect::<Result<Vec<_>, _>>()?;
             Ok(SqlValue::Vector(items))
         }
+        // #443 — PostGIS geometry from a fixture: a JSON Point object
+        // (`{"x": .., "y": .., "srid": ..}`; `srid` defaults to 4326).
+        FieldType::Geometry(_) => {
+            let p: crate::sql::Point = serde_json::from_value(v.clone())
+                .map_err(|e| format!("expected JSON {{x, y, srid?}} for geometry column: {e}"))?;
+            Ok(p.into())
+        }
     }
 }
 

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -532,6 +532,9 @@ pub(crate) fn field_type_name(ty: FieldType) -> &'static str {
         // `&'static str`), so a dimension-only change (`vector(3)` →
         // `vector(4)`) isn't surfaced as a schema diff.
         FieldType::Vector(_) => "vector",
+        // #443 — PostGIS geometry. Like `vector`, the SRID isn't encoded
+        // in this `&'static str`, so an SRID-only change isn't diffed.
+        FieldType::Geometry(_) => "geometry",
     }
 }
 

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -368,6 +368,9 @@ pub trait Dialect {
             // has no `&'static` CAST spelling — casting to it isn't
             // supported through this path (#824).
             FieldType::Vector(_) => return None,
+            // PostGIS `geometry(Point, srid)` likewise has no `&'static`
+            // CAST spelling (#443).
+            FieldType::Geometry(_) => return None,
         })
     }
 
@@ -415,6 +418,10 @@ pub trait Dialect {
             // dimension. Requires the `vector` extension.
             FieldType::Vector(0) => "vector".into(),
             FieldType::Vector(dims) => format!("vector({dims})"),
+            // PostGIS `geometry(Point, srid)` column (#443). `0` = no
+            // SRID constraint (`geometry(Point)`). Requires `postgis`.
+            FieldType::Geometry(0) => "geometry(Point)".into(),
+            FieldType::Geometry(srid) => format!("geometry(Point,{srid})"),
         }
     }
 

--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -768,6 +768,12 @@ macro_rules! bind_match {
             // PG `Encode` (binary wire format); the column/param type is
             // `vector`, resolved by name.
             SqlValue::Vector(v) => $q.bind(crate::sql::Vector(v)),
+            // PostGIS geometry (#443) — bind via the `Point` newtype's
+            // PG `Encode` (EWKB binary); the column/param type is
+            // `geometry`, resolved by name.
+            SqlValue::Geometry { x, y, srid } => {
+                $q.bind(crate::sql::Point { x, y, srid })
+            }
             // PG single-parameter array (issue #30). v1 supports
             // I32/I64/String/Bool elements; other element kinds
             // panic at bind time. Homogeneous-element arrays are
@@ -855,6 +861,9 @@ macro_rules! bind_match_mysql {
             SqlValue::Vector(_) => unreachable!(
                 "MySQL has no vector type; pgvector distance operators are rejected before bind. Issue #824."
             ),
+            SqlValue::Geometry { .. } => unreachable!(
+                "MySQL has no geometry type; PostGIS `Point` columns are PG-only. Issue #443."
+            ),
         }
     };
 }
@@ -901,6 +910,9 @@ macro_rules! bind_match_sqlite {
             }
             SqlValue::Vector(_) => unreachable!(
                 "SQLite has no vector type; pgvector distance operators are rejected before bind. Issue #824."
+            ),
+            SqlValue::Geometry { .. } => unreachable!(
+                "SQLite has no geometry type; PostGIS `Point` columns are PG-only. Issue #443."
             ),
         }
     };

--- a/crates/rustango/src/sql/executor/row_to_json.rs
+++ b/crates/rustango/src/sql/executor/row_to_json.rs
@@ -146,6 +146,8 @@ where
             FieldType::HStore => Value::Null,
             // #824 — pgvector columns; typed fetch decodes via `Vector`.
             FieldType::Vector(_) => Value::Null,
+            // #443 — PostGIS geometry columns; typed fetch decodes via `Point`.
+            FieldType::Geometry(_) => Value::Null,
         };
         map.insert(field.name.to_owned(), value);
     }
@@ -289,6 +291,8 @@ pub fn row_to_json_sqlite(
             FieldType::HStore => Value::Null,
             // #824 — pgvector is PG-only; typed fetch decodes via `Vector`.
             FieldType::Vector(_) => Value::Null,
+            // #443 — PostGIS geometry is PG-only; never present on SQLite.
+            FieldType::Geometry(_) => Value::Null,
         };
         map.insert(field.name.to_owned(), value);
     }

--- a/crates/rustango/src/sql/geometry.rs
+++ b/crates/rustango/src/sql/geometry.rs
@@ -1,0 +1,359 @@
+//! `Point` — PostGIS `geometry(Point, SRID)` column wrapper (GeoDjango
+//! `gis.geos` geometry types, issue #443).
+//!
+//! Declare a `geometry(Point, …)` column on a model and round-trip it as
+//! a Rust `Point`:
+//!
+//! ```ignore
+//! #[derive(Model)]
+//! #[rustango(table = "place")]
+//! struct Place {
+//!     #[rustango(primary_key)]
+//!     id: Auto<i64>,
+//!     // → DDL `location geometry(Point, 4326)`; round-trips as a `Point`.
+//!     #[rustango(geometry(srid = 4326))]
+//!     location: Point,
+//! }
+//! ```
+//!
+//! ## PostgreSQL/PostGIS only, by language semantics
+//!
+//! `geometry` is a PostGIS extension type. Like `vector` / trigram /
+//! full-text / `Array<T>`, `Point` is **PG-only by language semantics**:
+//! the migration writer emits a degraded `TEXT` column on MySQL / SQLite,
+//! and the [`sqlx::Decode`] path raises a clear error on those backends
+//! rather than silently mis-storing. The type still *compiles* under
+//! every backend (the per-backend [`sqlx::Type`] / [`sqlx::Decode`] impls
+//! below are total), so the `sqlite,tenancy` litmus build keeps passing.
+//!
+//! Spatial *queries* (`ST_Distance` / `ST_DWithin` / `ST_Contains` …)
+//! are the separate GeoDjango query layer (issue #58); this issue (#443)
+//! is the geometry *type* + storage + DDL.
+//!
+//! ## Why a newtype rather than a bare `(f64, f64)`
+//!
+//! Same rationale as [`crate::sql::Vector`]: `#[derive(Model)]` emits one
+//! shared `FromRow` body reused across the PG / MySQL / SQLite decoders,
+//! so the column type needs total `Decode` / `Type` impls for all three
+//! backends (a real PostGIS EWKB codec on PG, erroring stubs elsewhere).
+
+/// The default spatial reference identifier — WGS 84 (GPS lat/long),
+/// PostGIS's most common SRID and GeoDjango's default.
+pub const SRID_WGS84: u32 = 4326;
+
+/// A 2-D point in a PostGIS `geometry(Point, SRID)` column — see the
+/// [module docs](self). Carries its SRID so it round-trips losslessly
+/// through the EWKB wire format.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Point {
+    /// X coordinate (longitude for SRID 4326).
+    pub x: f64,
+    /// Y coordinate (latitude for SRID 4326).
+    pub y: f64,
+    /// Spatial reference identifier (4326 = WGS 84).
+    pub srid: u32,
+}
+
+impl Point {
+    /// A point in WGS 84 (SRID 4326) — the GPS lat/long default. `x` is
+    /// longitude, `y` is latitude.
+    #[must_use]
+    pub fn new(x: f64, y: f64) -> Self {
+        Self {
+            x,
+            y,
+            srid: SRID_WGS84,
+        }
+    }
+
+    /// A point in an explicit spatial reference system.
+    #[must_use]
+    pub fn with_srid(x: f64, y: f64, srid: u32) -> Self {
+        Self { x, y, srid }
+    }
+
+    /// `POINT(x y)` well-known text — handy for diagnostics and the text
+    /// decode fallback. (Note: WKT carries no SRID; EWKT would prefix
+    /// `SRID=…;`.)
+    #[must_use]
+    pub fn to_wkt(&self) -> String {
+        format!("POINT({} {})", self.x, self.y)
+    }
+}
+
+impl Default for Point {
+    fn default() -> Self {
+        Self::new(0.0, 0.0)
+    }
+}
+
+// ---- `Point` → `SqlValue` (INSERT / UPDATE bind, via SqlValue::Geometry) ----
+
+impl From<Point> for crate::core::SqlValue {
+    fn from(p: Point) -> Self {
+        crate::core::SqlValue::Geometry {
+            x: p.x,
+            y: p.y,
+            srid: p.srid,
+        }
+    }
+}
+
+// ---- serde: a plain `{ "x", "y", "srid" }` object -------------------
+
+impl serde::Serialize for Point {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct as _;
+        let mut s = serializer.serialize_struct("Point", 3)?;
+        s.serialize_field("x", &self.x)?;
+        s.serialize_field("y", &self.y)?;
+        s.serialize_field("srid", &self.srid)?;
+        s.end()
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Point {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(serde::Deserialize)]
+        struct Raw {
+            x: f64,
+            y: f64,
+            #[serde(default = "default_srid")]
+            srid: u32,
+        }
+        fn default_srid() -> u32 {
+            SRID_WGS84
+        }
+        let r = Raw::deserialize(deserializer)?;
+        Ok(Self {
+            x: r.x,
+            y: r.y,
+            srid: r.srid,
+        })
+    }
+}
+
+// ---- PostGIS EWKB wire format ---------------------------------------
+//
+// A 2-D Point with SRID is 25 bytes, little-endian:
+//   [u8 byte-order = 0x01]
+//   [u32 type      = 0x20000001]  (Point type 0x01 | SRID flag 0x20000000)
+//   [u32 srid]
+//   [f64 x]
+//   [f64 y]
+// Verified against `ST_AsEWKB(ST_SetSRID(ST_MakePoint(x,y), srid))`.
+
+/// PostGIS geometry type code for a 2-D Point.
+#[cfg(feature = "postgres")]
+const WKB_POINT: u32 = 0x0000_0001;
+/// EWKB flag bit indicating an embedded SRID follows the type word.
+#[cfg(feature = "postgres")]
+const EWKB_SRID_FLAG: u32 = 0x2000_0000;
+
+#[cfg(feature = "postgres")]
+fn encode_ewkb_point(p: &Point, buf: &mut Vec<u8>) {
+    buf.push(0x01); // little-endian
+    buf.extend_from_slice(&(WKB_POINT | EWKB_SRID_FLAG).to_le_bytes());
+    buf.extend_from_slice(&p.srid.to_le_bytes());
+    buf.extend_from_slice(&p.x.to_le_bytes());
+    buf.extend_from_slice(&p.y.to_le_bytes());
+}
+
+#[cfg(feature = "postgres")]
+fn decode_ewkb_point(bytes: &[u8]) -> Result<Point, sqlx::error::BoxDynError> {
+    if bytes.len() < 5 {
+        return Err("EWKB geometry too short (missing byte-order + type)".into());
+    }
+    let little = match bytes[0] {
+        0x01 => true,
+        0x00 => false,
+        other => return Err(format!("EWKB: unknown byte-order marker {other:#x}").into()),
+    };
+    let rd_u32 = |b: &[u8]| -> u32 {
+        let a = [b[0], b[1], b[2], b[3]];
+        if little {
+            u32::from_le_bytes(a)
+        } else {
+            u32::from_be_bytes(a)
+        }
+    };
+    let rd_f64 = |b: &[u8]| -> f64 {
+        let a = [b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]];
+        if little {
+            f64::from_le_bytes(a)
+        } else {
+            f64::from_be_bytes(a)
+        }
+    };
+
+    let type_word = rd_u32(&bytes[1..5]);
+    if type_word & 0x0000_00ff != WKB_POINT {
+        return Err(format!(
+            "EWKB: expected a Point geometry, got type word {type_word:#x} (only Point is supported, issue #443)"
+        )
+        .into());
+    }
+    let has_srid = type_word & EWKB_SRID_FLAG != 0;
+    let mut off = 5;
+    let srid = if has_srid {
+        if bytes.len() < off + 4 {
+            return Err("EWKB: SRID flag set but value truncated".into());
+        }
+        let s = rd_u32(&bytes[off..off + 4]);
+        off += 4;
+        s
+    } else {
+        SRID_WGS84
+    };
+    if bytes.len() < off + 16 {
+        return Err("EWKB Point: coordinate payload truncated".into());
+    }
+    let x = rd_f64(&bytes[off..off + 8]);
+    let y = rd_f64(&bytes[off + 8..off + 16]);
+    Ok(Point { x, y, srid })
+}
+
+#[cfg(feature = "postgres")]
+impl sqlx::Type<sqlx::Postgres> for Point {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        // PostGIS's `geometry` is an extension type with a dynamic OID;
+        // resolve it by name.
+        sqlx::postgres::PgTypeInfo::with_name("geometry")
+    }
+
+    fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+        use sqlx::TypeInfo as _;
+        ty.name().eq_ignore_ascii_case("geometry")
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl sqlx::Encode<'_, sqlx::Postgres> for Point {
+    fn encode_by_ref(
+        &self,
+        buf: &mut sqlx::postgres::PgArgumentBuffer,
+    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+        let mut bytes = Vec::with_capacity(25);
+        encode_ewkb_point(self, &mut bytes);
+        buf.extend_from_slice(&bytes);
+        Ok(sqlx::encode::IsNull::No)
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl sqlx::Decode<'_, sqlx::Postgres> for Point {
+    fn decode(value: sqlx::postgres::PgValueRef<'_>) -> Result<Self, sqlx::error::BoxDynError> {
+        // PostGIS returns geometry in binary as EWKB. In text mode it's
+        // the hex-encoded EWKB (e.g. `0101000020E6100000…`).
+        match value.format() {
+            sqlx::postgres::PgValueFormat::Binary => decode_ewkb_point(value.as_bytes()?),
+            sqlx::postgres::PgValueFormat::Text => {
+                let hex = value.as_str()?.trim();
+                let raw = decode_hex(hex)?;
+                decode_ewkb_point(&raw)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn decode_hex(s: &str) -> Result<Vec<u8>, sqlx::error::BoxDynError> {
+    if s.len() % 2 != 0 {
+        return Err("EWKB hex: odd length".into());
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).map_err(Into::into))
+        .collect()
+}
+
+#[cfg(feature = "mysql")]
+impl sqlx::Type<sqlx::MySql> for Point {
+    fn type_info() -> sqlx::mysql::MySqlTypeInfo {
+        <Vec<u8> as sqlx::Type<sqlx::MySql>>::type_info()
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl sqlx::Decode<'_, sqlx::MySql> for Point {
+    fn decode(_value: sqlx::mysql::MySqlValueRef<'_>) -> Result<Self, sqlx::error::BoxDynError> {
+        Err(
+            "`Point` columns are PostgreSQL/PostGIS-only; cannot decode on MySQL (issue #443)"
+                .into(),
+        )
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl sqlx::Type<sqlx::Sqlite> for Point {
+    fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
+        <Vec<u8> as sqlx::Type<sqlx::Sqlite>>::type_info()
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl sqlx::Decode<'_, sqlx::Sqlite> for Point {
+    fn decode(_value: sqlx::sqlite::SqliteValueRef<'_>) -> Result<Self, sqlx::error::BoxDynError> {
+        Err(
+            "`Point` columns are PostgreSQL/PostGIS-only; cannot decode on SQLite (issue #443)"
+                .into(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_defaults_to_wgs84_and_wkt() {
+        let p = Point::new(1.5, -2.25);
+        assert_eq!(p.srid, SRID_WGS84);
+        assert_eq!(p.to_wkt(), "POINT(1.5 -2.25)");
+    }
+
+    #[test]
+    fn into_sqlvalue_geometry() {
+        let sv: crate::core::SqlValue = Point::with_srid(1.0, 2.0, 3857).into();
+        match sv {
+            crate::core::SqlValue::Geometry { x, y, srid } => {
+                assert_eq!((x, y, srid), (1.0, 2.0, 3857));
+            }
+            _ => panic!("expected SqlValue::Geometry"),
+        }
+    }
+
+    #[test]
+    fn serde_round_trips_as_object() {
+        let p = Point::with_srid(1.5, -2.25, 4326);
+        let json = serde_json::to_string(&p).unwrap();
+        let back: Point = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, p);
+        // srid defaults when omitted.
+        let p2: Point = serde_json::from_str(r#"{"x":1.0,"y":2.0}"#).unwrap();
+        assert_eq!(p2, Point::new(1.0, 2.0));
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn ewkb_round_trip_and_matches_postgis() {
+        let p = Point::with_srid(1.5, -2.25, 4326);
+        let mut buf = Vec::new();
+        encode_ewkb_point(&p, &mut buf);
+        // Byte-for-byte equal to PostGIS `ST_AsEWKB(ST_SetSRID(ST_MakePoint(1.5,-2.25),4326))`:
+        // 0101000020e6100000000000000000f83f00000000000002c0
+        let expected = decode_hex("0101000020e6100000000000000000f83f00000000000002c0").unwrap();
+        assert_eq!(buf, expected, "EWKB encoding must match PostGIS");
+        assert_eq!(decode_ewkb_point(&buf).unwrap(), p);
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn decode_rejects_non_point() {
+        // LineString (type 0x02) with SRID flag → rejected.
+        let mut bytes = vec![0x01];
+        bytes.extend_from_slice(&(0x0000_0002u32 | EWKB_SRID_FLAG).to_le_bytes());
+        bytes.extend_from_slice(&4326u32.to_le_bytes());
+        assert!(decode_ewkb_point(&bytes).is_err());
+    }
+}

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -14,6 +14,7 @@ mod dialect;
 mod error;
 mod executor;
 mod foreign_key;
+mod geometry;
 mod hstore;
 pub mod m2m;
 #[doc(hidden)]
@@ -37,6 +38,7 @@ pub use backend::{
 pub use compiled::CompiledStatement;
 pub use dialect::Dialect;
 pub use error::{is_mysql_dup_index_error, ExecError, SqlError};
+pub use geometry::{Point, SRID_WGS84};
 pub use hstore::HStore;
 pub use range::Range;
 pub use vector::Vector;

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -149,7 +149,8 @@ impl Dialect for MySql {
             | FieldType::Array(_)
             | FieldType::Range(_)
             | FieldType::HStore
-            | FieldType::Vector(_) => return None,
+            | FieldType::Vector(_)
+            | FieldType::Geometry(_) => return None,
         })
     }
 
@@ -205,6 +206,8 @@ impl Dialect for MySql {
             FieldType::HStore => "TEXT".into(),
             // Ditto for pgvector `vector` columns (#824).
             FieldType::Vector(_) => "TEXT".into(),
+            // Ditto for PostGIS `geometry` columns (#443).
+            FieldType::Geometry(_) => "TEXT".into(),
         }
     }
 

--- a/crates/rustango/src/sql/postgres.rs
+++ b/crates/rustango/src/sql/postgres.rs
@@ -125,6 +125,10 @@ impl Dialect for Postgres {
                 // `vector` extension to be installed/enabled.
                 | "pgvector"
                 | "vector"
+                // PostGIS geometry columns (#443). Requires the
+                // `postgis` extension to be installed/enabled.
+                | "postgis"
+                | "geometry"
         ) || self.default_supports(token)
     }
 

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -193,6 +193,8 @@ impl Dialect for Sqlite {
             FieldType::HStore => "TEXT",
             // Ditto for pgvector `vector` columns (#824).
             FieldType::Vector(_) => "TEXT",
+            // Ditto for PostGIS `geometry` columns (#443).
+            FieldType::Geometry(_) => "TEXT",
         })
     }
 
@@ -225,6 +227,8 @@ impl Dialect for Sqlite {
             FieldType::HStore => "TEXT".into(),
             // Ditto for pgvector `vector` columns (#824).
             FieldType::Vector(_) => "TEXT".into(),
+            // Ditto for PostGIS `geometry` columns (#443).
+            FieldType::Geometry(_) => "TEXT".into(),
         }
     }
 

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -1521,6 +1521,8 @@ fn field_type_label(ty: crate::core::FieldType) -> &'static str {
         T::HStore => "hstore",
         // #824 — pgvector columns.
         T::Vector(_) => "vector",
+        // #443 — PostGIS geometry columns.
+        T::Geometry(_) => "geometry",
     }
 }
 

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -285,6 +285,8 @@ fn field_type_to_schema(t: FieldType) -> Schema {
         },
         // #824 — pgvector embedding: a JSON array of numbers.
         FieldType::Vector(_) => Schema::array_of(Schema::number()),
+        // #443 — PostGIS Point: a JSON object `{ x, y, srid }`.
+        FieldType::Geometry(_) => Schema::object(),
     }
 }
 

--- a/crates/rustango/tests/gis_geometry_postgis_live.rs
+++ b/crates/rustango/tests/gis_geometry_postgis_live.rs
@@ -1,0 +1,117 @@
+#![cfg(feature = "postgres")]
+//! Live Postgres + PostGIS test for the `Point` geometry column — issue
+//! #443 (gis.geos geometry types). Requires a PostGIS-enabled Postgres
+//! (the `postgis_live` CI job runs `postgis/postgis:16-3.4`); skips when
+//! `DATABASE_URL` is unset or the `postgis` extension isn't installed
+//! (e.g. the plain `postgres_test` pgvector image), so it never breaks a
+//! non-PostGIS suite.
+//!
+//! Exercises the full round-trip: `CREATE EXTENSION postgis`, a
+//! `geometry(Point, 4326)` column, a typed insert (the `Point` PG EWKB
+//! `Encode`), typed decode back to a `Point`, and a cross-check that
+//! PostGIS itself reads our encoded bytes as a real `POINT(...)` via
+//! `ST_AsText` / `ST_Distance`.
+
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Point, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gis_place_live")]
+#[allow(dead_code)]
+pub struct Place {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 40)]
+    pub name: String,
+    #[rustango(geometry(srid = 4326))]
+    pub location: Point,
+}
+
+#[tokio::test]
+async fn point_column_round_trips_through_postgis() {
+    let Ok(url) = std::env::var("DATABASE_URL") else {
+        eprintln!("DATABASE_URL unset — skipping PostGIS live test");
+        return;
+    };
+    let pg = sqlx::PgPool::connect(&url).await.expect("connect PG");
+
+    // PostGIS must be enabled; the `postgis_live` image ships it. If it's
+    // unavailable (e.g. the plain pgvector test image), skip rather than
+    // fail so a non-PostGIS PG doesn't break the suite.
+    if sqlx::query("CREATE EXTENSION IF NOT EXISTS postgis")
+        .execute(&pg)
+        .await
+        .is_err()
+    {
+        eprintln!("`postgis` extension unavailable — skipping PostGIS live test");
+        return;
+    }
+    for ddl in [
+        "DROP TABLE IF EXISTS gis_place_live",
+        "CREATE TABLE gis_place_live (\
+            id BIGSERIAL PRIMARY KEY, \
+            name VARCHAR(40) NOT NULL, \
+            location geometry(Point,4326) NOT NULL)",
+    ] {
+        sqlx::query(ddl).execute(&pg).await.expect(ddl);
+    }
+    let pool: Pool = pg.clone().into();
+
+    // Typed insert — exercises the `Point` EWKB binary `Encode`. The
+    // column is constrained to SRID 4326, so PostGIS rejects the insert
+    // outright if our encoded bytes are malformed or carry a wrong SRID.
+    let cn_tower = Point::with_srid(-79.387_054, 43.642_566, 4326);
+    let mut p = Place {
+        id: Auto::default(),
+        name: "CN Tower".to_owned(),
+        location: cn_tower,
+    };
+    p.save_pool(&pool).await.expect("insert Point");
+
+    // Typed decode — the stored geometry round-trips back to a `Point`.
+    let rows: Vec<Place> = Place::objects().fetch_pool(&pool).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    let got = rows[0].location;
+    assert_eq!(got.srid, 4326);
+    assert!(
+        (got.x - cn_tower.x).abs() < 1e-9,
+        "x round-trips: {}",
+        got.x
+    );
+    assert!(
+        (got.y - cn_tower.y).abs() < 1e-9,
+        "y round-trips: {}",
+        got.y
+    );
+
+    // Cross-check: PostGIS itself parsed our encoded bytes as a real
+    // Point — `ST_AsText` reflects the coordinates back.
+    let wkt: String = sqlx::query_scalar("SELECT ST_AsText(location) FROM gis_place_live")
+        .fetch_one(&pg)
+        .await
+        .unwrap();
+    assert!(
+        wkt.starts_with("POINT(-79.387054 43.642566"),
+        "PostGIS reads our EWKB as a Point: {wkt}"
+    );
+
+    // And a spatial function works against the stored geometry, proving
+    // it's a usable PostGIS value (the broader ST_* query DSL is #58).
+    let dist_km: f64 = sqlx::query_scalar(
+        "SELECT ST_Distance(location::geography, \
+         ST_SetSRID(ST_MakePoint(-79.3871, 43.6426), 4326)::geography) / 1000.0 \
+         FROM gis_place_live",
+    )
+    .fetch_one(&pg)
+    .await
+    .unwrap();
+    assert!(
+        dist_km < 0.1,
+        "stored point is ~0 km from itself: {dist_km}"
+    );
+
+    sqlx::query("DROP TABLE IF EXISTS gis_place_live")
+        .execute(&pg)
+        .await
+        .ok();
+}


### PR DESCRIPTION
GeoDjango `gis.geos` geometry **types** — a `geometry(Point, SRID)` column that round-trips through the ORM as a Rust `Point`.

```rust
#[derive(Model)]
#[rustango(table = "place")]
struct Place {
    #[rustango(primary_key)] id: Auto<i64>,
    #[rustango(geometry(srid = 4326))] location: Point,   // → DDL: geometry(Point,4326)
}
// place.location = Point::with_srid(-79.387, 43.642, 4326);  round-trips losslessly
```

## Approach
Mirrors the merged pgvector `Vector` work (#824): a newtype with **total tri-backend sqlx impls** (a real PostGIS EWKB codec on Postgres, erroring `Decode` stubs on MySQL/SQLite) so the single shared `#[derive(Model)]` `FromRow` body compiles under every backend. **PG/PostGIS-only by language semantics** — MySQL/SQLite degrade the column to `TEXT`.

## What's in it
- **`crate::sql::Point { x, y, srid }`** (`sql/geometry.rs`) — PostGIS EWKB encode/decode for PG, **verified byte-for-byte** against `ST_AsEWKB(ST_SetSRID(ST_MakePoint(x,y),srid))`; serde as `{x,y,srid}`; `Into<SqlValue>`.
- **IR**: `FieldType::Geometry(srid)` + `SqlValue::Geometry { x, y, srid }`, threaded through every exhaustiveness site (dialect/DDL, executor bind, row_to_json, forms, admin render, openapi, fixtures, snapshot, validate, audit, template_views).
- **DDL**: PG `geometry(Point,srid)` (needs `postgis`); MySQL/SQLite → `TEXT`.
- **Macro**: `Point` field → `DetectedKind::Geometry`; `#[rustango(geometry(srid = N))]` supplies the SRID (mirrors `vector(dims = N)`).

## Scope
This is #443 — the geometry **type** + storage + DDL. Spatial **queries** (`ST_Distance`/`ST_DWithin`/`ST_Contains` …) are the separate GeoDjango query layer (**#58**) and are a clean follow-up via `ScalarFn` + `Expr::Function`.

## Tests
- 5 unit tests incl. the byte-for-byte EWKB-matches-PostGIS assertion + non-Point rejection.
- `gis_geometry_postgis_live.rs` — full round-trip against **real PostGIS**: typed insert via EWKB Encode → typed decode → `ST_AsText` cross-check that PostGIS reads our bytes as a real `POINT` → `ST_Distance` works.
- **New `postgis_live` CI job** (`postgis/postgis:16-3.4`) runs it; it skips gracefully under the pgvector `postgres_test` image (no postgis), so nothing else is disturbed.

## Gates (all green locally)
`sqlite,tenancy` + `postgres,tenancy` build; 2266 lib tests; `bulk_update`/geometry coexistence verified; live test green against a local PostGIS 16-3.4; `cargo test --workspace --all-features --no-run`; fmt clean.