### PR TITLE
feat(gis): spatial query functions — ST_Distance/DWithin/Contains/Within/Intersects (closes #58)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.88
       - uses: Swatinem/rust-cache@v2
       - run: cargo test -p rustango --features postgres,tenancy --test gis_geometry_postgis_live
+      - run: cargo test -p rustango --features postgres,tenancy --test gis_spatial_queries_postgis_live
 
   # End-to-end playwright suite for the multi-app rustango showcase.
   # The showcase is a severed workspace under examples/showcase/ that

--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -607,6 +607,30 @@ pub enum ScalarFn {
     /// and dropping tsvector semantics). **PG-only**; MySQL / SQLite
     /// reject with `OpNotSupportedInDialect`. Variadic ≥ 2 args.
     TsConcat,
+
+    // --- PostGIS spatial functions (GeoDjango queries, issue #58) ---
+    /// `ST_Distance(a, b)` — distance between two geometries in the
+    /// column's SRID units (degrees for 4326). Returns `double
+    /// precision`; use for nearest-neighbour ordering. Arity 2.
+    /// **PG/PostGIS-only** — MySQL / SQLite reject with
+    /// `OpNotSupportedInDialect`. Pairs with the [`crate::sql::Point`]
+    /// type (#443).
+    StDistance,
+    /// `ST_DWithin(a, b, distance)` — `true` when `a` is within
+    /// `distance` (SRID units) of `b`. The index-friendly "within
+    /// radius" / geofence predicate. Returns `boolean`. Arity 3.
+    /// **PG/PostGIS-only**.
+    StDWithin,
+    /// `ST_Contains(a, b)` — `true` when geometry `a` completely
+    /// contains `b`. Returns `boolean`. Arity 2. **PG/PostGIS-only**.
+    StContains,
+    /// `ST_Within(a, b)` — `true` when geometry `a` is completely
+    /// inside `b` (the converse of [`Self::StContains`]). Returns
+    /// `boolean`. Arity 2. **PG/PostGIS-only**.
+    StWithin,
+    /// `ST_Intersects(a, b)` — `true` when the geometries share any
+    /// point. Returns `boolean`. Arity 2. **PG/PostGIS-only**.
+    StIntersects,
 }
 
 impl Expr {

--- a/crates/rustango/src/core/funcs.rs
+++ b/crates/rustango/src/core/funcs.rs
@@ -868,6 +868,61 @@ pub fn json_path_indexed(
     }
 }
 
+// ---- PostGIS spatial functions (GeoDjango queries, issue #58) -------
+//
+// All Postgres/PostGIS-only — they emit `OpNotSupportedInDialect` on
+// MySQL / SQLite. Pass a column via `F("col")` and a literal point as a
+// bare [`crate::sql::Point`] (which is `Into<Expr>`).
+
+/// `ST_Distance(a, b)` — distance between two geometries in SRID units.
+/// Returns `double precision`; use with `.order_by_expr(...)` for
+/// nearest-neighbour ordering (or [`crate::query::QuerySet::order_by_distance_to`]).
+#[must_use]
+pub fn st_distance(a: impl Into<Expr>, b: impl Into<Expr>) -> Expr {
+    Expr::Function {
+        kind: ScalarFn::StDistance,
+        args: vec![a.into(), b.into()],
+    }
+}
+
+/// `ST_DWithin(a, b, distance)` — boolean "within `distance` (SRID
+/// units)" predicate. Use with `.where_raw(...)` (or the
+/// [`crate::query::QuerySet::filter_dwithin`] shortcut).
+#[must_use]
+pub fn st_dwithin(a: impl Into<Expr>, b: impl Into<Expr>, distance: impl Into<Expr>) -> Expr {
+    Expr::Function {
+        kind: ScalarFn::StDWithin,
+        args: vec![a.into(), b.into(), distance.into()],
+    }
+}
+
+/// `ST_Contains(a, b)` — boolean "geometry `a` completely contains `b`".
+#[must_use]
+pub fn st_contains(a: impl Into<Expr>, b: impl Into<Expr>) -> Expr {
+    Expr::Function {
+        kind: ScalarFn::StContains,
+        args: vec![a.into(), b.into()],
+    }
+}
+
+/// `ST_Within(a, b)` — boolean "geometry `a` is completely inside `b`".
+#[must_use]
+pub fn st_within(a: impl Into<Expr>, b: impl Into<Expr>) -> Expr {
+    Expr::Function {
+        kind: ScalarFn::StWithin,
+        args: vec![a.into(), b.into()],
+    }
+}
+
+/// `ST_Intersects(a, b)` — boolean "the geometries share any point".
+#[must_use]
+pub fn st_intersects(a: impl Into<Expr>, b: impl Into<Expr>) -> Expr {
+    Expr::Function {
+        kind: ScalarFn::StIntersects,
+        args: vec![a.into(), b.into()],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -833,6 +833,55 @@ impl<T: Model> QuerySet<T> {
         self.order_by_distance(column, query, metric).limit(k)
     }
 
+    /// PostGIS nearest-first ordering (#58): `ORDER BY
+    /// ST_Distance(<column>, <point>)` ascending. Pair with `.limit(k)`
+    /// for a k-nearest query. `column` should be a `geometry(Point, …)`
+    /// / `#[rustango(geometry(...))]` field. **PG/PostGIS-only** — emits
+    /// `OpNotSupportedInDialect` at compile time on MySQL / SQLite.
+    ///
+    /// ```ignore
+    /// // The 5 places nearest to `here`.
+    /// let near = Place::objects()
+    ///     .order_by_distance_to("location", here)
+    ///     .limit(5)
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    #[must_use]
+    pub fn order_by_distance_to(self, column: &'static str, point: crate::sql::Point) -> Self {
+        let expr = crate::core::funcs::st_distance(crate::core::Expr::Column(column), point);
+        self.order_by_expr(expr, /*desc=*/ false)
+    }
+
+    /// PostGIS "within radius" filter (#58): `WHERE ST_DWithin(<column>,
+    /// <point>, <distance>)`. `distance` is in the column's SRID units
+    /// (degrees for SRID 4326 — cast to `::geography` in raw SQL when you
+    /// need metres). **PG/PostGIS-only.**
+    ///
+    /// ```ignore
+    /// // Places within ~1km (in degrees) of `here`.
+    /// let nearby = Place::objects()
+    ///     .filter_dwithin("location", here, 0.01)
+    ///     .fetch_pool(&pool).await?;
+    /// ```
+    #[must_use]
+    pub fn filter_dwithin(
+        self,
+        column: &'static str,
+        point: crate::sql::Point,
+        distance: f64,
+    ) -> Self {
+        let pred = WhereExpr::ExprCompare {
+            lhs: crate::core::funcs::st_dwithin(
+                crate::core::Expr::Column(column),
+                point,
+                crate::core::Expr::Literal(SqlValue::F64(distance)),
+            ),
+            op: Op::Eq,
+            rhs: crate::core::Expr::Literal(SqlValue::Bool(true)),
+        };
+        self.where_raw(pred)
+    }
+
     /// Same as [`Self::order_by_expr`] but with an explicit
     /// `NullsOrder`. Issue #76.
     #[must_use]

--- a/crates/rustango/src/sql/geometry.rs
+++ b/crates/rustango/src/sql/geometry.rs
@@ -99,6 +99,14 @@ impl From<Point> for crate::core::SqlValue {
     }
 }
 
+// A `Point` literal in an expression tree — lets the spatial function
+// builders (`st_distance(F("loc"), point)`, #58) accept a bare `Point`.
+impl From<Point> for crate::core::Expr {
+    fn from(p: Point) -> Self {
+        crate::core::Expr::Literal(p.into())
+    }
+}
+
 // ---- serde: a plain `{ "x", "y", "srid" }` object -------------------
 
 impl serde::Serialize for Point {

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -2299,7 +2299,53 @@ fn write_function(
         // -------- Full-text search builder (issue #295 / T2.4) --------
         F::SetWeight => write_setweight(b, args),
         F::TsConcat => write_ts_concat(b, args),
+
+        // -------- PostGIS spatial functions (#58) — PG-only --------
+        F::StDistance | F::StDWithin | F::StContains | F::StWithin | F::StIntersects => {
+            write_spatial_fn(b, kind, args)
+        }
     }
+}
+
+/// PostGIS `ST_*` spatial functions (#58). All are Postgres/PostGIS-only
+/// — MySQL / SQLite reject with `OpNotSupportedInDialect`, mirroring the
+/// pgvector distance operators and FTS functions. Arity is checked so a
+/// hand-built `Expr::Function` fails at emit-time rather than reaching
+/// the database malformed.
+fn write_spatial_fn(
+    b: &mut Sql<'_>,
+    kind: crate::core::ScalarFn,
+    args: &[crate::core::Expr],
+) -> Result<(), SqlError> {
+    use crate::core::ScalarFn as F;
+    let (name, arity): (&'static str, usize) = match kind {
+        F::StDistance => ("ST_Distance", 2),
+        F::StDWithin => ("ST_DWithin", 3),
+        F::StContains => ("ST_Contains", 2),
+        F::StWithin => ("ST_Within", 2),
+        F::StIntersects => ("ST_Intersects", 2),
+        _ => unreachable!("write_spatial_fn only handles ST_* variants"),
+    };
+    if args.len() != arity {
+        return Err(SqlError::FunctionArityMismatch {
+            func: name,
+            expected: if arity == 3 { "3" } else { "2" },
+            got: args.len(),
+        });
+    }
+    if b.d.name() != "postgres" {
+        return Err(SqlError::OpNotSupportedInDialect {
+            op: match kind {
+                F::StDistance => "ST_Distance (PostGIS) is Postgres-only",
+                F::StDWithin => "ST_DWithin (PostGIS) is Postgres-only",
+                F::StContains => "ST_Contains (PostGIS) is Postgres-only",
+                F::StWithin => "ST_Within (PostGIS) is Postgres-only",
+                _ => "ST_Intersects (PostGIS) is Postgres-only",
+            },
+            dialect: b.d.name(),
+        });
+    }
+    write_call(b, name, args)
 }
 
 /// `LPAD(s, len, fill)` / `RPAD(s, len, fill)` — PG/MySQL native;

--- a/crates/rustango/tests/gis_spatial_fns_emission.rs
+++ b/crates/rustango/tests/gis_spatial_fns_emission.rs
@@ -1,0 +1,166 @@
+//! Emission tests for PostGIS spatial functions (`ST_Distance`,
+//! `ST_DWithin`, `ST_Contains`, `ST_Within`, `ST_Intersects`) — issue
+//! #58, the query layer atop the #443 geometry type. PG emits the native
+//! `ST_*` calls; MySQL and SQLite reject at compile time with
+//! `OpNotSupportedInDialect`. No database needed — pure dialect compile.
+
+use rustango::core::funcs::{st_contains, st_distance, st_dwithin, st_intersects, st_within};
+use rustango::core::{
+    Assignment, Expr, Filter, Model as _, Op, ScalarFn, SqlValue, UpdateQuery, WhereExpr, F,
+};
+#[cfg(feature = "mysql")]
+use rustango::sql::MySql;
+#[cfg(feature = "sqlite")]
+use rustango::sql::Sqlite;
+use rustango::sql::{Dialect, Point, Postgres, SqlError};
+use rustango::Model;
+
+#[derive(Model)]
+#[rustango(table = "gis_emit_place")]
+#[allow(dead_code)]
+pub struct Place {
+    #[rustango(primary_key)]
+    id: i64,
+    #[rustango(geometry(srid = 4326))]
+    location: Point,
+    rank: f64,
+}
+
+// Park the spatial expr in a SET clause — we only inspect the emitted
+// SQL / params, never execute, so type-compatibility is irrelevant.
+fn update_set(value: Expr) -> UpdateQuery {
+    UpdateQuery {
+        model: Place::SCHEMA,
+        set: vec![Assignment {
+            column: "rank",
+            value,
+        }],
+        where_clause: WhereExpr::Predicate(Filter {
+            column: "id",
+            op: Op::Eq,
+            value: SqlValue::I64(1),
+        }),
+    }
+}
+
+// ---------- PG: native ST_* emission ----------
+
+#[test]
+fn pg_emits_st_distance() {
+    let q = update_set(st_distance(F("location"), Point::new(1.0, 2.0)));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"ST_Distance("location", $"#),
+        "PG ST_Distance: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.params
+            .iter()
+            .any(|p| matches!(p, SqlValue::Geometry { .. })),
+        "point bound as a Geometry param: {:?}",
+        stmt.params
+    );
+}
+
+#[test]
+fn pg_emits_st_dwithin() {
+    let q = update_set(st_dwithin(
+        F("location"),
+        Point::new(1.0, 2.0),
+        Expr::Literal(SqlValue::F64(0.5)),
+    ));
+    let stmt = Postgres.compile_update(&q).unwrap();
+    assert!(
+        stmt.sql.contains(r#"ST_DWithin("location", $"#),
+        "PG ST_DWithin: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn pg_emits_topological_predicates() {
+    for (build, label) in [
+        (
+            st_contains(F("location"), Point::new(0.0, 0.0)),
+            "ST_Contains(",
+        ),
+        (st_within(F("location"), Point::new(0.0, 0.0)), "ST_Within("),
+        (
+            st_intersects(F("location"), Point::new(0.0, 0.0)),
+            "ST_Intersects(",
+        ),
+    ] {
+        let stmt = Postgres.compile_update(&update_set(build)).unwrap();
+        assert!(stmt.sql.contains(label), "PG {label}: {}", stmt.sql);
+    }
+}
+
+// ---------- MySQL / SQLite rejection ----------
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn sqlite_rejects_st_distance() {
+    let q = update_set(st_distance(F("location"), Point::new(1.0, 2.0)));
+    let err = Sqlite.compile_update(&q).unwrap_err();
+    match err {
+        SqlError::OpNotSupportedInDialect { op, dialect } => {
+            assert!(op.contains("ST_Distance"), "op label: {op}");
+            assert_eq!(dialect, "sqlite");
+        }
+        other => panic!("expected OpNotSupportedInDialect, got: {other:?}"),
+    }
+}
+
+#[cfg(feature = "mysql")]
+#[test]
+fn mysql_rejects_st_dwithin() {
+    let q = update_set(st_dwithin(
+        F("location"),
+        Point::new(1.0, 2.0),
+        Expr::Literal(SqlValue::F64(0.5)),
+    ));
+    let err = MySql.compile_update(&q).unwrap_err();
+    assert!(matches!(
+        err,
+        SqlError::OpNotSupportedInDialect { op, .. } if op.contains("ST_DWithin")
+    ));
+}
+
+// ---------- Arity checks ----------
+
+#[test]
+fn st_dwithin_with_two_args_arity_mismatch() {
+    let bad = Expr::Function {
+        kind: ScalarFn::StDWithin,
+        args: vec![F("location").into(), Point::new(0.0, 0.0).into()],
+    };
+    let err = Postgres.compile_update(&update_set(bad)).unwrap_err();
+    assert!(matches!(
+        err,
+        SqlError::FunctionArityMismatch {
+            func: "ST_DWithin",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn st_distance_with_three_args_arity_mismatch() {
+    let bad = Expr::Function {
+        kind: ScalarFn::StDistance,
+        args: vec![
+            F("location").into(),
+            Point::new(0.0, 0.0).into(),
+            Expr::Literal(SqlValue::F64(1.0)),
+        ],
+    };
+    let err = Postgres.compile_update(&update_set(bad)).unwrap_err();
+    assert!(matches!(
+        err,
+        SqlError::FunctionArityMismatch {
+            func: "ST_Distance",
+            ..
+        }
+    ));
+}

--- a/crates/rustango/tests/gis_spatial_queries_postgis_live.rs
+++ b/crates/rustango/tests/gis_spatial_queries_postgis_live.rs
@@ -1,0 +1,116 @@
+#![cfg(feature = "postgres")]
+//! Live Postgres + PostGIS test for the spatial query layer — issue #58
+//! (GeoDjango queries/functions), the follow-up to the #443 geometry
+//! type. Requires a PostGIS-enabled Postgres (the `postgis_live` CI job);
+//! skips when `DATABASE_URL` is unset or `postgis` isn't installed.
+//!
+//! Exercises the ergonomic `QuerySet` helpers end-to-end against a real
+//! PostGIS: `order_by_distance_to` (ST_Distance nearest-first ordering)
+//! and `filter_dwithin` (ST_DWithin "within radius" predicate), plus a
+//! topological predicate via `where_raw` + the `st_intersects` builder.
+
+use rustango::core::funcs::st_intersects;
+use rustango::core::{Expr, Op, SqlValue, WhereExpr};
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Point, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gis_spatial_live")]
+#[allow(dead_code)]
+pub struct Place {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 40)]
+    pub name: String,
+    #[rustango(geometry(srid = 4326))]
+    pub location: Point,
+}
+
+#[tokio::test]
+async fn spatial_distance_dwithin_and_intersects() {
+    let Ok(url) = std::env::var("DATABASE_URL") else {
+        eprintln!("DATABASE_URL unset — skipping PostGIS spatial live test");
+        return;
+    };
+    let pg = sqlx::PgPool::connect(&url).await.expect("connect PG");
+    if sqlx::query("CREATE EXTENSION IF NOT EXISTS postgis")
+        .execute(&pg)
+        .await
+        .is_err()
+    {
+        eprintln!("`postgis` extension unavailable — skipping spatial live test");
+        return;
+    }
+    for ddl in [
+        "DROP TABLE IF EXISTS gis_spatial_live",
+        "CREATE TABLE gis_spatial_live (\
+            id BIGSERIAL PRIMARY KEY, \
+            name VARCHAR(40) NOT NULL, \
+            location geometry(Point,4326) NOT NULL)",
+    ] {
+        sqlx::query(ddl).execute(&pg).await.expect(ddl);
+    }
+    let pool: Pool = pg.clone().into();
+
+    // Three places along the prime meridian at increasing distance from
+    // the origin (0,0): near (0.0), mid (0.5°), far (5.0°).
+    for (name, lon) in [("near", 0.0), ("mid", 0.5), ("far", 5.0)] {
+        let mut place = Place {
+            id: Auto::default(),
+            name: name.to_owned(),
+            location: Point::with_srid(lon, 0.0, 4326),
+        };
+        place.save_pool(&pool).await.expect("insert place");
+    }
+    let origin = Point::with_srid(0.0, 0.0, 4326);
+
+    // order_by_distance_to → ST_Distance ascending: nearest first.
+    let ordered: Vec<String> = Place::objects()
+        .order_by_distance_to("location", origin)
+        .fetch_pool(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.name)
+        .collect();
+    assert_eq!(
+        ordered,
+        vec!["near", "mid", "far"],
+        "ST_Distance orders nearest-first"
+    );
+
+    // filter_dwithin(1.0°) → only `near` (0.0) and `mid` (0.5) qualify;
+    // `far` (5.0) is excluded.
+    let within: Vec<String> = Place::objects()
+        .filter_dwithin("location", origin, 1.0)
+        .order_by_distance_to("location", origin)
+        .fetch_pool(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.name)
+        .collect();
+    assert_eq!(within, vec!["near", "mid"], "ST_DWithin filters by radius");
+
+    // Topological predicate via where_raw + st_intersects: only the row
+    // whose geometry intersects the exact `mid` point (0.5, 0.0).
+    let mid = Point::with_srid(0.5, 0.0, 4326);
+    let hits: Vec<String> = Place::objects()
+        .where_raw(WhereExpr::ExprCompare {
+            lhs: st_intersects(Expr::Column("location"), mid),
+            op: Op::Eq,
+            rhs: Expr::Literal(SqlValue::Bool(true)),
+        })
+        .fetch_pool(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.name)
+        .collect();
+    assert_eq!(hits, vec!["mid"], "ST_Intersects matches the exact point");
+
+    sqlx::query("DROP TABLE IF EXISTS gis_spatial_live")
+        .execute(&pg)
+        .await
+        .ok();
+}


### PR DESCRIPTION
The GeoDjango **query layer** atop the #443 `Point` geometry type — the five most-used PostGIS predicates/functions as first-class IR, composable through the existing query API and wrapped in Django-shape shortcuts.

```rust
use rustango::core::funcs::st_distance;

// 5 nearest places to `here` (ST_Distance ascending):
Place::objects().order_by_distance_to("location", here).limit(5)

// places within ~1km of `here` (ST_DWithin):
Place::objects().filter_dwithin("location", here, 0.01)

// or compose any predicate via the existing where_raw / order_by_expr:
Place::objects().order_by_expr(st_distance(F("location"), here), false)
```

## What's in it
- **`ScalarFn::{StDistance, StDWithin, StContains, StWithin, StIntersects}`** emitted by a new `write_spatial_fn` — PG `ST_*` with arity checks; **MySQL/SQLite reject** with `OpNotSupportedInDialect` (PG/PostGIS-only by language semantics, mirroring the pgvector distance ops + FTS funcs).
- **`core::funcs::{st_distance, st_dwithin, st_contains, st_within, st_intersects}`** builders returning `Expr`.
- **`QuerySet::order_by_distance_to(col, point)`** (ST_Distance ordering) + **`filter_dwithin(col, point, distance)`** (ST_DWithin radius) — distinct names from the pgvector `order_by_distance`. Distances are in the column's SRID units (degrees for 4326; cast to `::geography` for metres).
- `From<Point> for Expr` so the builders take a bare `Point` literal.

## Scope
This closes the **queries/functions** half of the GeoDjango umbrella (#58); #443 shipped the geometry **type**. Point is the geometry subtype today — `ST_Contains`/`Within` become meaningfully testable once Polygon/LineString land (follow-up), but the predicates + emission are wired now.

## Tests
- `gis_spatial_fns_emission.rs` (7) — PG emits each `ST_*`; SQLite/MySQL reject; arity mismatches caught. Pure dialect-compile, runs under `postgres_test --all-features` (no DB).
- `gis_spatial_queries_postgis_live.rs` — **end-to-end vs real PostGIS**: `order_by_distance_to` nearest-first ordering, `filter_dwithin` radius filtering, `ST_Intersects` via `where_raw`. Added to the `postgis_live` CI job; verified locally against `postgis:16-3.4`.

## Gates
`sqlite,tenancy` + `postgres,tenancy` build; 7 emission tests (3 dialects); live test green vs local PostGIS; 2266 lib tests; `cargo test --workspace --all-features --no-run`; fmt clean.