### PR TITLE
fix(deps): pin time < 0.3.48 (E0119 regression breaks all CI)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,13 @@ thiserror = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-appender = "0.2"
 
+# `time` 0.3.48 shipped an E0119 regression (conflicting `From` impl in
+# `format_description::parse`); the workspace gitignores Cargo.lock so CI
+# fresh-resolves and picks it up, breaking every build. `time` is pulled
+# transitively (cookie / tracing-appender / sqlx date types), so we pin it
+# here below 0.3.48. Unpin once a fixed release (0.3.49+) is verified.
+time = ">=0.3, <0.3.48"
+
 # Async-trait for dyn-dispatchable async traits (e.g. OrgResolver)
 async-trait = "0.1"
 

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -423,6 +423,10 @@ lettre = { version = "0.11", default-features = false, features = [
 # default tracing subscriber (env-filter) before the user body runs.
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "json"], optional = true }
 tracing-appender = { workspace = true, optional = true }
+# Not used directly — declared only to pin the transitive `time` away from
+# the broken 0.3.48 (see the workspace.dependencies note). `time` is
+# already pulled by cookie / tracing-appender / sqlx in every real build.
+time = { workspace = true }
 
 [dev-dependencies]
 tokio          = { workspace = true }


### PR DESCRIPTION
## Problem
`time` **0.3.48** (published today) regressed: it fails to compile with

```
error[E0119]: conflicting implementations of trait
`From<…HourBase>` for type `<…HourBase as ModifierValue>::Type`
```

The workspace **gitignores `Cargo.lock`** (`.gitignore:2`), so CI fresh-resolves every run and grabbed 0.3.48 the moment it published — **breaking every job** (clippy, doc, postgres_test, mysql_live, sqlite_litmus, sqlite_live, postgis_live) on `develop` and every open PR (#1002 et al.). Local builds with a cached `0.3.47` lock pass, which is why it surfaced only on CI.

## Fix
`time` is transitive (cookie / tracing-appender / sqlx date types), so it's pinned in `[workspace.dependencies]` (`>=0.3, <0.3.48`) and referenced from the `rustango` crate to constrain the resolver. Follows the repo's existing pin precedent (rusqlite 7.3 note in the same file).

Verified locally: `cargo update -p time` holds **0.3.47**; reproduced the 0.3.48 `E0119` and confirmed the pin clears it; `cargo check --no-default-features --features sqlite,tenancy` builds clean.

Unpin when a fixed `time` (0.3.49+) is out.