### PR TITLE
feat(passkey): WebAuthn passkey support — credential store + ceremonies (#392)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_validators
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test got_request_exception_signal
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test migrate_signals_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,passkey --test passkey_store_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_reverse
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_contains
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test m2m_changed_signal_sqlite_live

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,11 @@ tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 serde_urlencoded = "0.7"
 base64 = "0.22"
+# Passkey / WebAuthn ceremony crypto (#392) — pure-Rust, no C dep.
+# `ciborium` parses CBOR (attestationObject / COSE keys); `p256` verifies
+# ES256 (P-256 ECDSA) assertion signatures.
+ciborium = "0.2"
+p256 = { version = "0.13", default-features = false, features = ["ecdsa", "std"] }
 tera = { version = "1.20", default-features = false }
 
 # Caching

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -226,7 +226,7 @@ totp = ["dep:hmac", "dep:sha1", "dep:rand", "dep:subtle"]
 # (no extra deps). The ceremony layer adds pure-Rust CBOR (`ciborium`) +
 # ES256 (`p256`) when it lands — keeping the all-RustCrypto, no-C-dep
 # stack (vs `webauthn-rs` → openssl).
-passkey = ["dep:rand", "dep:base64", "dep:sha2", "dep:subtle"]
+passkey = ["dep:rand", "dep:base64", "dep:sha2", "dep:subtle", "dep:ciborium", "dep:p256"]
 
 # Webhook signature verification (`rustango::webhook`) — HMAC-SHA256
 # constant-time verification for inbound webhooks (Stripe, GitHub, etc.).
@@ -387,6 +387,8 @@ toml = { workspace = true, optional = true }
 # `admin` feature deps — optional.
 axum           = { workspace = true, optional = true }
 base64         = { workspace = true, optional = true }
+ciborium       = { workspace = true, optional = true }
+p256           = { workspace = true, optional = true }
 http           = { workspace = true, optional = true }
 http-body-util = { workspace = true, optional = true }
 tera           = { workspace = true, optional = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -222,6 +222,11 @@ casts = ["dep:chacha20poly1305", "dep:base64", "dep:rand", "dep:sha2"]
 # TOTP / 2FA (`rustango::totp`) — RFC 6238 time-based one-time passwords
 # for second-factor authentication. SHA-1 (Google Authenticator default).
 totp = ["dep:hmac", "dep:sha1", "dep:rand", "dep:subtle"]
+# Passkey / WebAuthn (#392). Foundation slice = credential storage only
+# (no extra deps). The ceremony layer adds pure-Rust CBOR (`ciborium`) +
+# ES256 (`p256`) when it lands — keeping the all-RustCrypto, no-C-dep
+# stack (vs `webauthn-rs` → openssl).
+passkey = ["dep:rand", "dep:base64", "dep:sha2", "dep:subtle"]
 
 # Webhook signature verification (`rustango::webhook`) — HMAC-SHA256
 # constant-time verification for inbound webhooks (Stripe, GitHub, etc.).

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -885,6 +885,12 @@ pub mod api_keys;
 #[cfg(feature = "passwords")]
 pub mod passwords;
 
+/// Passkey / WebAuthn (#392). Foundation slice: credential storage
+/// ([`passkey::WebauthnCredential`] + the store API). Pure-Rust ceremony
+/// crypto (CBOR + ES256) lands in a follow-up slice.
+#[cfg(feature = "passkey")]
+pub mod passkey;
+
 /// Pagination helpers — RFC 5988 Link headers + cursor params.
 /// See [`pagination::LinkHeaderBuilder`].
 pub mod pagination;

--- a/crates/rustango/src/passkey/ceremony.rs
+++ b/crates/rustango/src/passkey/ceremony.rs
@@ -1,0 +1,391 @@
+//! WebAuthn registration + authentication ceremonies (#392).
+//!
+//! These orchestrate the [`super::verify`] primitives into the two
+//! server-side verification steps, plus the challenge + options helpers
+//! the browser's `navigator.credentials.create()/get()` need. The crypto
+//! is pure-Rust (`p256` / `ciborium`); see the module docs.
+//!
+//! Scope: **ES256** keys, **`none`/self attestation** (no cert-chain
+//! verification). The caller is responsible for storing the per-ceremony
+//! `challenge` (e.g. in the session) between the `*_options` and `verify_*`
+//! calls, and for persisting the credential via [`super::register`] /
+//! advancing the counter via [`super::update_sign_count`].
+
+use super::error::PasskeyError;
+use super::verify;
+
+/// A fresh 32-byte ceremony challenge. Stash it (session) between issuing
+/// the options and verifying the client's response.
+#[must_use]
+pub fn generate_challenge() -> Vec<u8> {
+    use rand::RngCore as _;
+    let mut buf = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut buf);
+    buf.to_vec()
+}
+
+/// What a verified registration yields — store these via
+/// [`super::register`].
+#[derive(Debug, Clone)]
+pub struct RegistrationOutcome {
+    /// base64url (no pad) of the raw credential id.
+    pub credential_id: String,
+    /// COSE-encoded public key bytes.
+    pub cose_public_key: Vec<u8>,
+    /// The authenticator's initial signature counter.
+    pub sign_count: i64,
+}
+
+/// Verify a registration response (WebAuthn §7.1, `none`/self attestation).
+///
+/// `challenge` is the value handed to [`registration_options_json`];
+/// `client_data_json` + `attestation_object` are the decoded
+/// `response.clientDataJSON` / `response.attestationObject` from the
+/// browser.
+///
+/// # Errors
+/// The matching [`PasskeyError`] for whichever check fails.
+pub fn verify_registration(
+    challenge: &[u8],
+    rp_id: &str,
+    allowed_origins: &[String],
+    client_data_json: &[u8],
+    attestation_object: &[u8],
+) -> Result<RegistrationOutcome, PasskeyError> {
+    // 1. clientDataJSON: type / challenge / origin.
+    verify::parse_and_verify_client_data(
+        client_data_json,
+        "webauthn.create",
+        challenge,
+        allowed_origins,
+    )?;
+
+    // 2. attestationObject CBOR → authData byte string.
+    let value: ciborium::value::Value = ciborium::de::from_reader(attestation_object)
+        .map_err(|e| PasskeyError::Cbor(e.to_string()))?;
+    let auth_data_bytes = extract_auth_data(&value)?;
+
+    // 3. authData: rpIdHash, UP flag, attested credential data.
+    let ad = verify::parse_authenticator_data(&auth_data_bytes)?;
+    verify::verify_rp_id(&ad, rp_id)?;
+    if !ad.user_present() {
+        return Err(PasskeyError::UserNotPresent);
+    }
+    let attested = ad.attested.ok_or_else(|| {
+        PasskeyError::AuthData("registration authData has no attested credential data".into())
+    })?;
+    // `none`/self attestation: trust the embedded key (no cert chain).
+    // The COSE key was already validated as a parseable P-256 ES256 key
+    // by `parse_authenticator_data` → `canonicalize_cose_key`; confirm it
+    // builds a verifying key so we never store an unusable credential.
+    verify::cose_es256_key(&attested.cose_public_key)?;
+
+    Ok(RegistrationOutcome {
+        credential_id: verify::b64url_encode(&attested.credential_id),
+        cose_public_key: attested.cose_public_key,
+        sign_count: i64::from(ad.sign_count),
+    })
+}
+
+/// Verify an authentication (assertion) response (WebAuthn §7.2).
+/// Returns the new signature counter to persist via
+/// [`super::update_sign_count`].
+///
+/// # Errors
+/// The matching [`PasskeyError`] for whichever check fails (including
+/// [`PasskeyError::CounterRegression`] on a non-advancing counter).
+#[allow(clippy::too_many_arguments)]
+pub fn verify_authentication(
+    challenge: &[u8],
+    rp_id: &str,
+    allowed_origins: &[String],
+    stored_cose_public_key: &[u8],
+    stored_sign_count: i64,
+    client_data_json: &[u8],
+    authenticator_data: &[u8],
+    signature_der: &[u8],
+) -> Result<i64, PasskeyError> {
+    verify::parse_and_verify_client_data(
+        client_data_json,
+        "webauthn.get",
+        challenge,
+        allowed_origins,
+    )?;
+    let ad = verify::parse_authenticator_data(authenticator_data)?;
+    verify::verify_rp_id(&ad, rp_id)?;
+    if !ad.user_present() {
+        return Err(PasskeyError::UserNotPresent);
+    }
+    verify::verify_es256_assertion(
+        stored_cose_public_key,
+        authenticator_data,
+        client_data_json,
+        signature_der,
+    )?;
+    // Clone/replay detection: a non-zero counter must strictly advance.
+    let new = i64::from(ad.sign_count);
+    if new != 0 && stored_sign_count != 0 && new <= stored_sign_count {
+        return Err(PasskeyError::CounterRegression);
+    }
+    Ok(new)
+}
+
+/// `PublicKeyCredentialCreationOptions` JSON for
+/// `navigator.credentials.create({ publicKey })`. `user_id` is encoded
+/// base64url; `exclude` lists the user's existing credential ids (their
+/// stored base64url form) so the authenticator won't double-register.
+#[must_use]
+pub fn registration_options_json(
+    rp_id: &str,
+    rp_name: &str,
+    user_id: &[u8],
+    user_name: &str,
+    challenge: &[u8],
+    exclude_credential_ids: &[String],
+) -> serde_json::Value {
+    let exclude: Vec<serde_json::Value> = exclude_credential_ids
+        .iter()
+        .map(|id| serde_json::json!({ "type": "public-key", "id": id }))
+        .collect();
+    serde_json::json!({
+        "challenge": verify::b64url_encode(challenge),
+        "rp": { "id": rp_id, "name": rp_name },
+        "user": {
+            "id": verify::b64url_encode(user_id),
+            "name": user_name,
+            "displayName": user_name,
+        },
+        // -7 = ES256 (the only algorithm this slice verifies).
+        "pubKeyCredParams": [ { "type": "public-key", "alg": -7 } ],
+        "timeout": 60000,
+        "attestation": "none",
+        "excludeCredentials": exclude,
+        "authenticatorSelection": { "userVerification": "preferred", "residentKey": "preferred" },
+    })
+}
+
+/// `PublicKeyCredentialRequestOptions` JSON for
+/// `navigator.credentials.get({ publicKey })`. `allow_credential_ids` are
+/// the user's stored base64url credential ids.
+#[must_use]
+pub fn authentication_options_json(
+    rp_id: &str,
+    challenge: &[u8],
+    allow_credential_ids: &[String],
+) -> serde_json::Value {
+    let allow: Vec<serde_json::Value> = allow_credential_ids
+        .iter()
+        .map(|id| serde_json::json!({ "type": "public-key", "id": id }))
+        .collect();
+    serde_json::json!({
+        "challenge": verify::b64url_encode(challenge),
+        "rpId": rp_id,
+        "timeout": 60000,
+        "userVerification": "preferred",
+        "allowCredentials": allow,
+    })
+}
+
+/// Pull the `authData` byte string out of an attestationObject CBOR map.
+fn extract_auth_data(value: &ciborium::value::Value) -> Result<Vec<u8>, PasskeyError> {
+    use ciborium::value::Value;
+    let Value::Map(entries) = value else {
+        return Err(PasskeyError::AuthData(
+            "attestationObject is not a CBOR map".into(),
+        ));
+    };
+    for (k, v) in entries {
+        if let Value::Text(key) = k {
+            if key == "authData" {
+                if let Value::Bytes(b) = v {
+                    return Ok(b.clone());
+                }
+                return Err(PasskeyError::AuthData(
+                    "authData is not a byte string".into(),
+                ));
+            }
+        }
+    }
+    Err(PasskeyError::AuthData(
+        "attestationObject has no authData".into(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ciborium::value::{Integer, Value};
+    use p256::ecdsa::{signature::Signer as _, Signature, SigningKey};
+    use sha2::{Digest, Sha256};
+
+    fn os_rng() -> p256::elliptic_curve::rand_core::OsRng {
+        p256::elliptic_curve::rand_core::OsRng
+    }
+
+    fn cose_key_of(vk: &p256::ecdsa::VerifyingKey) -> Vec<u8> {
+        let pt = vk.to_encoded_point(false);
+        let map = Value::Map(vec![
+            (
+                Value::Integer(Integer::from(1)),
+                Value::Integer(Integer::from(2)),
+            ),
+            (
+                Value::Integer(Integer::from(3)),
+                Value::Integer(Integer::from(-7)),
+            ),
+            (
+                Value::Integer(Integer::from(-1)),
+                Value::Integer(Integer::from(1)),
+            ),
+            (
+                Value::Integer(Integer::from(-2)),
+                Value::Bytes(pt.x().unwrap().to_vec()),
+            ),
+            (
+                Value::Integer(Integer::from(-3)),
+                Value::Bytes(pt.y().unwrap().to_vec()),
+            ),
+        ]);
+        let mut out = Vec::new();
+        ciborium::ser::into_writer(&map, &mut out).unwrap();
+        out
+    }
+
+    fn rp_hash(rp_id: &str) -> [u8; 32] {
+        let mut h = Sha256::new();
+        h.update(rp_id.as_bytes());
+        h.finalize().into()
+    }
+
+    /// Build registration authData with attested credential data.
+    fn reg_auth_data(rp_id: &str, cred_id: &[u8], cose: &[u8], count: u32) -> Vec<u8> {
+        let mut d = Vec::new();
+        d.extend_from_slice(&rp_hash(rp_id));
+        d.push(0b0100_0001); // UP | AT
+        d.extend_from_slice(&count.to_be_bytes());
+        d.extend_from_slice(&[0u8; 16]); // aaguid
+        #[allow(clippy::cast_possible_truncation)]
+        d.extend_from_slice(&(cred_id.len() as u16).to_be_bytes());
+        d.extend_from_slice(cred_id);
+        d.extend_from_slice(cose);
+        d
+    }
+
+    fn attestation_object(auth_data: &[u8]) -> Vec<u8> {
+        let map = Value::Map(vec![
+            (Value::Text("fmt".into()), Value::Text("none".into())),
+            (Value::Text("attStmt".into()), Value::Map(vec![])),
+            (
+                Value::Text("authData".into()),
+                Value::Bytes(auth_data.to_vec()),
+            ),
+        ]);
+        let mut out = Vec::new();
+        ciborium::ser::into_writer(&map, &mut out).unwrap();
+        out
+    }
+
+    fn client_data(ty: &str, challenge: &[u8], origin: &str) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "type": ty,
+            "challenge": verify::b64url_encode(challenge),
+            "origin": origin,
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn full_register_then_authenticate_round_trip() {
+        let rp_id = "example.com";
+        let origins = vec!["https://example.com".to_owned()];
+        let sk = SigningKey::random(&mut os_rng());
+        let cose = cose_key_of(sk.verifying_key());
+        let cred_id = b"credential-handle-1";
+
+        // ---- Registration ----
+        let reg_challenge = generate_challenge();
+        let reg_ad = reg_auth_data(rp_id, cred_id, &cose, 1);
+        let att_obj = attestation_object(&reg_ad);
+        let reg_client = client_data("webauthn.create", &reg_challenge, "https://example.com");
+
+        let outcome =
+            verify_registration(&reg_challenge, rp_id, &origins, &reg_client, &att_obj).unwrap();
+        assert_eq!(outcome.credential_id, verify::b64url_encode(cred_id));
+        assert_eq!(outcome.sign_count, 1);
+        // The stored key must verify a signature from `sk`.
+        verify::cose_es256_key(&outcome.cose_public_key).unwrap();
+
+        // ---- Authentication with the registered key ----
+        let auth_challenge = generate_challenge();
+        let auth_ad = {
+            let mut d = Vec::new();
+            d.extend_from_slice(&rp_hash(rp_id));
+            d.push(0b0000_0001); // UP only (no AT on assertions)
+            d.extend_from_slice(&2u32.to_be_bytes()); // count advanced 1 → 2
+            d
+        };
+        let auth_client = client_data("webauthn.get", &auth_challenge, "https://example.com");
+        let mut signed = auth_ad.clone();
+        let mut ch = Sha256::new();
+        ch.update(&auth_client);
+        signed.extend_from_slice(&ch.finalize());
+        let sig: Signature = sk.sign(&signed);
+
+        let new_count = verify_authentication(
+            &auth_challenge,
+            rp_id,
+            &origins,
+            &outcome.cose_public_key,
+            outcome.sign_count,
+            &auth_client,
+            &auth_ad,
+            sig.to_der().as_bytes(),
+        )
+        .unwrap();
+        assert_eq!(new_count, 2);
+    }
+
+    #[test]
+    fn counter_regression_is_rejected() {
+        let rp_id = "example.com";
+        let origins = vec!["https://example.com".to_owned()];
+        let sk = SigningKey::random(&mut os_rng());
+        let cose = cose_key_of(sk.verifying_key());
+
+        let challenge = generate_challenge();
+        let mut ad = Vec::new();
+        ad.extend_from_slice(&rp_hash(rp_id));
+        ad.push(0b0000_0001);
+        ad.extend_from_slice(&3u32.to_be_bytes()); // count 3
+        let client = client_data("webauthn.get", &challenge, "https://example.com");
+        let mut signed = ad.clone();
+        let mut h = Sha256::new();
+        h.update(&client);
+        signed.extend_from_slice(&h.finalize());
+        let sig: Signature = sk.sign(&signed);
+
+        // Stored count 5 > presented 3 → regression rejected.
+        let r = verify_authentication(
+            &challenge,
+            rp_id,
+            &origins,
+            &cose,
+            5,
+            &client,
+            &ad,
+            sig.to_der().as_bytes(),
+        );
+        assert!(matches!(r, Err(PasskeyError::CounterRegression)));
+    }
+
+    #[test]
+    fn options_json_has_required_shape() {
+        let reg =
+            registration_options_json("example.com", "Example", b"user1", "alice", b"chal", &[]);
+        assert_eq!(reg["rp"]["id"], "example.com");
+        assert_eq!(reg["pubKeyCredParams"][0]["alg"], -7);
+        let auth = authentication_options_json("example.com", b"chal", &["abc".to_owned()]);
+        assert_eq!(auth["rpId"], "example.com");
+        assert_eq!(auth["allowCredentials"][0]["id"], "abc");
+    }
+}

--- a/crates/rustango/src/passkey/error.rs
+++ b/crates/rustango/src/passkey/error.rs
@@ -1,0 +1,48 @@
+//! Passkey / WebAuthn ceremony errors (#392).
+
+/// What went wrong verifying a WebAuthn registration or assertion.
+/// Deliberately coarse on the *reason* surfaced to clients (a precise
+/// "challenge mismatch" vs "bad signature" can aid an attacker) — log
+/// the detail, return a generic "verification failed" to the user.
+#[derive(Debug, thiserror::Error)]
+pub enum PasskeyError {
+    /// `clientDataJSON` wasn't valid JSON, or a required field was missing.
+    #[error("malformed clientDataJSON: {0}")]
+    ClientData(String),
+    /// `clientDataJSON.type` wasn't the expected ceremony type
+    /// (`webauthn.create` for registration, `webauthn.get` for assertion).
+    #[error("unexpected clientData type: expected `{expected}`, got `{got}`")]
+    WrongType { expected: &'static str, got: String },
+    /// The challenge echoed by the client didn't match the server's.
+    #[error("challenge mismatch")]
+    ChallengeMismatch,
+    /// The `origin` in `clientDataJSON` isn't an allowed origin.
+    #[error("origin `{0}` is not allowed")]
+    BadOrigin(String),
+    /// The `rpIdHash` in `authenticatorData` ≠ SHA-256(rp_id).
+    #[error("rpIdHash does not match the configured rp_id")]
+    RpIdMismatch,
+    /// The User-Present flag wasn't set — the authenticator reported no
+    /// user interaction.
+    #[error("user-present flag not set")]
+    UserNotPresent,
+    /// `authenticatorData` / `attestationObject` was truncated or
+    /// otherwise structurally invalid.
+    #[error("malformed authenticator data: {0}")]
+    AuthData(String),
+    /// The COSE public key wasn't a supported algorithm (only ES256 /
+    /// ECDSA-P256 is supported in this slice).
+    #[error("unsupported or malformed COSE key: {0}")]
+    CoseKey(String),
+    /// The assertion signature failed ES256 verification.
+    #[error("signature verification failed")]
+    BadSignature,
+    /// The authenticator's signature counter didn't advance — a possible
+    /// cloned authenticator (or a buggy one). The WebAuthn spec lets the
+    /// RP decide; rustango rejects a regression when both counts are > 0.
+    #[error("signature counter did not increase (possible cloned authenticator)")]
+    CounterRegression,
+    /// CBOR decode failure.
+    #[error("CBOR decode error: {0}")]
+    Cbor(String),
+}

--- a/crates/rustango/src/passkey/mod.rs
+++ b/crates/rustango/src/passkey/mod.rs
@@ -1,0 +1,195 @@
+//! Passkey / WebAuthn support — issue #392.
+//!
+//! This is the **foundation slice**: credential storage. It defines the
+//! `rustango_webauthn_credentials` table + a small store API that the
+//! registration / authentication ceremonies (the next slice) build on.
+//!
+//! ## Design
+//!
+//! - **All-RustCrypto, no C dep.** The ceremony layer (CBOR attestation
+//!   parsing + ES256 assertion verification) will use pure-Rust
+//!   `ciborium` + `p256`, *not* `webauthn-rs` (which pulls `openssl`).
+//!   This keeps rustango's dependency story C-free, matching `argon2` /
+//!   `sha2` / `hmac`.
+//! - **Operator-managed table** (`#[rustango(managed = false)]`),
+//!   bootstrapped idempotently via [`ensure_table`] (the `audit` /
+//!   `totp_store` pattern), so it never enters the migration graph.
+//! - A user may register **several** passkeys (laptop, phone, security
+//!   key), so the PK is a surrogate `id`; lookups are by `user_id` (list)
+//!   or `credential_id` (the unique handle the authenticator returns at
+//!   assertion time).
+//!
+//! Gated behind the `passkey` feature; builds without it are unchanged.
+
+use crate::sql::{Auto, Pool};
+use crate::Model;
+
+/// One registered WebAuthn credential (passkey). `public_key` holds the
+/// COSE-encoded public key bytes captured at registration; `sign_count`
+/// is the authenticator's signature counter, bumped on each assertion to
+/// detect cloned authenticators.
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rustango_webauthn_credentials", managed = false)]
+#[allow(dead_code)]
+pub struct WebauthnCredential {
+    /// Surrogate primary key (a user may have many credentials).
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    /// The owning user's id.
+    pub user_id: i64,
+    /// Base64url (no padding) of the raw credential id the authenticator
+    /// returns — the unique handle used to look the credential up at
+    /// assertion time.
+    #[rustango(max_length = 255)]
+    pub credential_id: String,
+    /// COSE-encoded public key bytes captured at registration.
+    pub public_key: Vec<u8>,
+    /// Authenticator signature counter (replay / clone detection).
+    pub sign_count: i64,
+    /// Optional user-facing label ("MacBook Touch ID", "YubiKey 5").
+    #[rustango(max_length = 64, default = "")]
+    pub label: String,
+    /// When the credential was registered.
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+const CREATE_TABLE_PG: &str = r#"
+CREATE TABLE IF NOT EXISTS "rustango_webauthn_credentials" (
+    "id"            BIGSERIAL PRIMARY KEY,
+    "user_id"       BIGINT NOT NULL,
+    "credential_id" VARCHAR(255) NOT NULL,
+    "public_key"    BYTEA NOT NULL,
+    "sign_count"    BIGINT NOT NULL DEFAULT 0,
+    "label"         VARCHAR(64) NOT NULL DEFAULT '',
+    "created_at"    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT "rustango_webauthn_credentials_cred_uq" UNIQUE ("credential_id")
+);
+CREATE INDEX IF NOT EXISTS "rustango_webauthn_credentials_user_idx"
+    ON "rustango_webauthn_credentials" ("user_id");
+"#;
+
+const CREATE_TABLE_MYSQL: &str = r"
+CREATE TABLE IF NOT EXISTS `rustango_webauthn_credentials` (
+    `id`            BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `user_id`       BIGINT NOT NULL,
+    `credential_id` VARCHAR(255) NOT NULL,
+    `public_key`    LONGBLOB NOT NULL,
+    `sign_count`    BIGINT NOT NULL DEFAULT 0,
+    `label`         VARCHAR(64) NOT NULL DEFAULT '',
+    `created_at`    DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    CONSTRAINT `rustango_webauthn_credentials_cred_uq` UNIQUE (`credential_id`),
+    INDEX `rustango_webauthn_credentials_user_idx` (`user_id`)
+);
+";
+
+const CREATE_TABLE_SQLITE: &str = r#"
+CREATE TABLE IF NOT EXISTS "rustango_webauthn_credentials" (
+    "id"            INTEGER PRIMARY KEY AUTOINCREMENT,
+    "user_id"       INTEGER NOT NULL,
+    "credential_id" TEXT NOT NULL,
+    "public_key"    BLOB NOT NULL,
+    "sign_count"    INTEGER NOT NULL DEFAULT 0,
+    "label"         TEXT NOT NULL DEFAULT '',
+    "created_at"    TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "rustango_webauthn_credentials_cred_uq" UNIQUE ("credential_id")
+);
+CREATE INDEX IF NOT EXISTS "rustango_webauthn_credentials_user_idx"
+    ON "rustango_webauthn_credentials" ("user_id");
+"#;
+
+/// Idempotently create the `rustango_webauthn_credentials` table for the
+/// active backend.
+///
+/// # Errors
+/// Driver / SQL failures from `CREATE TABLE IF NOT EXISTS` (other than
+/// the duplicate-object errors `run_ddl_idempotent` swallows).
+pub async fn ensure_table(pool: &Pool) -> Result<(), sqlx::Error> {
+    let ddl = match pool.dialect().name() {
+        "mysql" => CREATE_TABLE_MYSQL,
+        "sqlite" => CREATE_TABLE_SQLITE,
+        _ => CREATE_TABLE_PG,
+    };
+    crate::sql::run_ddl_idempotent(pool, ddl).await
+}
+
+/// Every credential registered to `user_id` — the allow-list the
+/// authentication ceremony offers the authenticator.
+///
+/// # Errors
+/// As the ORM fetch path ([`crate::sql::ExecError`]).
+pub async fn for_user(
+    pool: &Pool,
+    user_id: i64,
+) -> Result<Vec<WebauthnCredential>, crate::sql::ExecError> {
+    use crate::sql::FetcherPool as _;
+    WebauthnCredential::objects()
+        .filter("user_id", user_id)
+        .fetch_pool(pool)
+        .await
+}
+
+/// Look a credential up by its (unique) base64url credential id — the
+/// handle the authenticator returns at assertion time.
+///
+/// # Errors
+/// As the ORM fetch path ([`crate::sql::ExecError`]).
+pub async fn by_credential_id(
+    pool: &Pool,
+    credential_id: &str,
+) -> Result<Option<WebauthnCredential>, crate::sql::ExecError> {
+    use crate::sql::FetcherPool as _;
+    Ok(WebauthnCredential::objects()
+        .filter("credential_id", credential_id.to_owned())
+        .fetch_pool(pool)
+        .await?
+        .into_iter()
+        .next())
+}
+
+/// Persist a freshly-registered credential. `public_key` is the
+/// COSE-encoded key bytes; `sign_count` is the authenticator's initial
+/// counter (often 0).
+///
+/// # Errors
+/// As the ORM insert path ([`crate::sql::ExecError`]).
+pub async fn register(
+    pool: &Pool,
+    user_id: i64,
+    credential_id: &str,
+    public_key: Vec<u8>,
+    sign_count: i64,
+    label: &str,
+) -> Result<(), crate::sql::ExecError> {
+    let mut row = WebauthnCredential {
+        id: Auto::Unset,
+        user_id,
+        credential_id: credential_id.to_owned(),
+        public_key,
+        sign_count,
+        label: label.to_owned(),
+        created_at: chrono::Utc::now(),
+    };
+    row.insert_pool(pool).await?;
+    Ok(())
+}
+
+/// Advance the stored signature counter for a credential after a
+/// successful assertion (clone detection: the new count must exceed the
+/// stored one). No-op if the credential id is unknown.
+///
+/// # Errors
+/// As the ORM update path ([`crate::sql::ExecError`]).
+pub async fn update_sign_count(
+    pool: &Pool,
+    credential_id: &str,
+    new_count: i64,
+) -> Result<(), crate::sql::ExecError> {
+    use crate::sql::UpdaterPool as _;
+    WebauthnCredential::objects()
+        .filter("credential_id", credential_id.to_owned())
+        .update()
+        .set("sign_count", new_count)
+        .execute_pool(pool)
+        .await?;
+    Ok(())
+}

--- a/crates/rustango/src/passkey/mod.rs
+++ b/crates/rustango/src/passkey/mod.rs
@@ -21,6 +21,16 @@
 //!
 //! Gated behind the `passkey` feature; builds without it are unchanged.
 
+pub mod ceremony;
+pub mod error;
+pub mod verify;
+
+pub use ceremony::{
+    authentication_options_json, generate_challenge, registration_options_json,
+    verify_authentication, verify_registration, RegistrationOutcome,
+};
+pub use error::PasskeyError;
+
 use crate::sql::{Auto, Pool};
 use crate::Model;
 

--- a/crates/rustango/src/passkey/verify.rs
+++ b/crates/rustango/src/passkey/verify.rs
@@ -1,0 +1,439 @@
+//! WebAuthn verification primitives (#392) — pure-Rust, no C dep.
+//!
+//! These are the security-critical building blocks the ceremonies use:
+//! parse `clientDataJSON` / `authenticatorData` / the `attestationObject`
+//! CBOR, decode a COSE ES256 public key, and verify an ES256 assertion
+//! signature with `p256`. All parsing is bounds-checked; all failures
+//! return a [`PasskeyError`] rather than panicking.
+//!
+//! Scope: **ES256 (ECDSA P-256)** keys and **`none`/self attestation**
+//! (the dominant passkey case). Attestation-statement certificate chains
+//! are not verified — for `none` attestation there are none, and for
+//! platform passkeys RPs typically trust-on-first-use anyway.
+
+use sha2::{Digest, Sha256};
+
+use super::error::PasskeyError;
+
+/// `authenticatorData` flag bits (WebAuthn §6.1).
+const FLAG_UP: u8 = 0b0000_0001; // User Present
+const FLAG_AT: u8 = 0b0100_0000; // Attested credential data included
+
+/// Parsed `authenticatorData`.
+#[derive(Debug, Clone)]
+pub struct AuthenticatorData {
+    /// SHA-256 of the RP ID.
+    pub rp_id_hash: [u8; 32],
+    /// Raw flags byte.
+    pub flags: u8,
+    /// Signature counter.
+    pub sign_count: u32,
+    /// Present only when the `AT` flag is set (registration).
+    pub attested: Option<AttestedCredentialData>,
+}
+
+impl AuthenticatorData {
+    /// `User Present` bit.
+    #[must_use]
+    pub fn user_present(&self) -> bool {
+        self.flags & FLAG_UP != 0
+    }
+}
+
+/// The attested credential data embedded in registration `authData`.
+#[derive(Debug, Clone)]
+pub struct AttestedCredentialData {
+    /// Authenticator AAGUID (16 bytes).
+    pub aaguid: [u8; 16],
+    /// Raw credential id.
+    pub credential_id: Vec<u8>,
+    /// COSE-encoded public key bytes (stored verbatim for later asserts).
+    pub cose_public_key: Vec<u8>,
+}
+
+/// Parse `authenticatorData` (WebAuthn §6.1). `expect_attested` controls
+/// whether the `AT` block must be present (true for registration).
+///
+/// # Errors
+/// [`PasskeyError::AuthData`] on truncation / structural problems.
+pub fn parse_authenticator_data(bytes: &[u8]) -> Result<AuthenticatorData, PasskeyError> {
+    if bytes.len() < 37 {
+        return Err(PasskeyError::AuthData(format!(
+            "too short ({} bytes, need ≥37)",
+            bytes.len()
+        )));
+    }
+    let mut rp_id_hash = [0u8; 32];
+    rp_id_hash.copy_from_slice(&bytes[0..32]);
+    let flags = bytes[32];
+    let sign_count = u32::from_be_bytes([bytes[33], bytes[34], bytes[35], bytes[36]]);
+
+    let attested = if flags & FLAG_AT != 0 {
+        // aaguid(16) || credIdLen(2 BE) || credId(L) || coseKey(rest, CBOR)
+        if bytes.len() < 55 {
+            return Err(PasskeyError::AuthData(
+                "AT flag set but attested credential data truncated".into(),
+            ));
+        }
+        let mut aaguid = [0u8; 16];
+        aaguid.copy_from_slice(&bytes[37..53]);
+        let cred_len = u16::from_be_bytes([bytes[53], bytes[54]]) as usize;
+        let cred_start = 55;
+        let cred_end = cred_start + cred_len;
+        if bytes.len() < cred_end {
+            return Err(PasskeyError::AuthData(format!(
+                "credential id length {cred_len} exceeds buffer"
+            )));
+        }
+        let credential_id = bytes[cred_start..cred_end].to_vec();
+        // The COSE key is the remainder — a single CBOR map. We re-encode
+        // exactly what we decode so the stored bytes are canonical and
+        // self-describing (length-prefixed extensions, if any, are
+        // dropped — we don't support extensions in this slice).
+        let cose_slice = &bytes[cred_end..];
+        let cose_public_key = canonicalize_cose_key(cose_slice)?;
+        Some(AttestedCredentialData {
+            aaguid,
+            credential_id,
+            cose_public_key,
+        })
+    } else {
+        None
+    };
+
+    Ok(AuthenticatorData {
+        rp_id_hash,
+        flags,
+        sign_count,
+        attested,
+    })
+}
+
+/// Decode the leading CBOR map from `bytes` and re-encode just that map,
+/// so trailing extension bytes don't bloat the stored key.
+fn canonicalize_cose_key(bytes: &[u8]) -> Result<Vec<u8>, PasskeyError> {
+    let value: ciborium::value::Value =
+        ciborium::de::from_reader(bytes).map_err(|e| PasskeyError::Cbor(e.to_string()))?;
+    if !value.is_map() {
+        return Err(PasskeyError::CoseKey("not a CBOR map".into()));
+    }
+    let mut out = Vec::new();
+    ciborium::ser::into_writer(&value, &mut out).map_err(|e| PasskeyError::Cbor(e.to_string()))?;
+    Ok(out)
+}
+
+/// Parsed + validated `clientDataJSON`.
+pub struct ClientData {
+    pub ty: String,
+    /// base64url-decoded challenge bytes.
+    pub challenge: Vec<u8>,
+    pub origin: String,
+}
+
+/// Parse and validate `clientDataJSON` (WebAuthn §5.8.1). Verifies the
+/// ceremony `type`, that the echoed `challenge` decodes to `expected_challenge`,
+/// and that `origin` is in `allowed_origins`.
+///
+/// # Errors
+/// The matching [`PasskeyError`] variant for whichever check fails.
+pub fn parse_and_verify_client_data(
+    json: &[u8],
+    expected_type: &'static str,
+    expected_challenge: &[u8],
+    allowed_origins: &[String],
+) -> Result<ClientData, PasskeyError> {
+    let v: serde_json::Value =
+        serde_json::from_slice(json).map_err(|e| PasskeyError::ClientData(e.to_string()))?;
+    let ty = v
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| PasskeyError::ClientData("missing `type`".into()))?
+        .to_owned();
+    if ty != expected_type {
+        return Err(PasskeyError::WrongType {
+            expected: expected_type,
+            got: ty,
+        });
+    }
+    let challenge_b64 = v
+        .get("challenge")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| PasskeyError::ClientData("missing `challenge`".into()))?;
+    let challenge = b64url_decode(challenge_b64)
+        .ok_or_else(|| PasskeyError::ClientData("challenge is not valid base64url".into()))?;
+    // Constant-time compare — the challenge is a secret nonce.
+    use subtle::ConstantTimeEq as _;
+    if challenge.len() != expected_challenge.len()
+        || challenge.ct_eq(expected_challenge).unwrap_u8() == 0
+    {
+        return Err(PasskeyError::ChallengeMismatch);
+    }
+    let origin = v
+        .get("origin")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| PasskeyError::ClientData("missing `origin`".into()))?
+        .to_owned();
+    if !allowed_origins.iter().any(|o| o == &origin) {
+        return Err(PasskeyError::BadOrigin(origin));
+    }
+    Ok(ClientData {
+        ty,
+        challenge,
+        origin,
+    })
+}
+
+/// Verify that `authenticatorData.rpIdHash == SHA-256(rp_id)`.
+///
+/// # Errors
+/// [`PasskeyError::RpIdMismatch`].
+pub fn verify_rp_id(auth_data: &AuthenticatorData, rp_id: &str) -> Result<(), PasskeyError> {
+    let mut h = Sha256::new();
+    h.update(rp_id.as_bytes());
+    let expected: [u8; 32] = h.finalize().into();
+    if auth_data.rp_id_hash == expected {
+        Ok(())
+    } else {
+        Err(PasskeyError::RpIdMismatch)
+    }
+}
+
+/// Build a `p256` verifying key from a COSE EC2/ES256 public key.
+///
+/// # Errors
+/// [`PasskeyError::CoseKey`] if the key isn't a P-256 ES256 EC2 key or is
+/// malformed.
+pub fn cose_es256_key(cose: &[u8]) -> Result<p256::ecdsa::VerifyingKey, PasskeyError> {
+    use ciborium::value::Value;
+    let v: Value =
+        ciborium::de::from_reader(cose).map_err(|e| PasskeyError::Cbor(e.to_string()))?;
+    let Value::Map(entries) = v else {
+        return Err(PasskeyError::CoseKey("not a CBOR map".into()));
+    };
+    // COSE labels: 1=kty, 3=alg, -1=crv, -2=x, -3=y.
+    let int_of = |val: &Value| -> Option<i128> {
+        if let Value::Integer(i) = val {
+            Some((*i).into())
+        } else {
+            None
+        }
+    };
+    let mut kty = None;
+    let mut alg = None;
+    let mut crv = None;
+    let mut x: Option<Vec<u8>> = None;
+    let mut y: Option<Vec<u8>> = None;
+    for (k, val) in &entries {
+        let Some(key) = int_of(k) else { continue };
+        match key {
+            1 => kty = int_of(val),
+            3 => alg = int_of(val),
+            -1 => crv = int_of(val),
+            -2 => {
+                if let Value::Bytes(b) = val {
+                    x = Some(b.clone());
+                }
+            }
+            -3 => {
+                if let Value::Bytes(b) = val {
+                    y = Some(b.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+    // kty 2 = EC2, alg -7 = ES256, crv 1 = P-256.
+    if kty != Some(2) {
+        return Err(PasskeyError::CoseKey(format!("kty {kty:?} != EC2 (2)")));
+    }
+    if alg != Some(-7) {
+        return Err(PasskeyError::CoseKey(format!("alg {alg:?} != ES256 (-7)")));
+    }
+    if crv != Some(1) {
+        return Err(PasskeyError::CoseKey(format!("crv {crv:?} != P-256 (1)")));
+    }
+    let (x, y) = match (x, y) {
+        (Some(x), Some(y)) if x.len() == 32 && y.len() == 32 => (x, y),
+        _ => {
+            return Err(PasskeyError::CoseKey(
+                "missing/short x or y coordinate".into(),
+            ))
+        }
+    };
+    // Uncompressed SEC1 point: 0x04 || X || Y.
+    let mut sec1 = Vec::with_capacity(65);
+    sec1.push(0x04);
+    sec1.extend_from_slice(&x);
+    sec1.extend_from_slice(&y);
+    p256::ecdsa::VerifyingKey::from_sec1_bytes(&sec1)
+        .map_err(|e| PasskeyError::CoseKey(format!("invalid P-256 point: {e}")))
+}
+
+/// Verify an ES256 assertion signature: the authenticator signs
+/// `authenticatorData || SHA-256(clientDataJSON)` (WebAuthn §6.3.3 step
+/// 19). `signature` is ASN.1 DER ECDSA.
+///
+/// # Errors
+/// [`PasskeyError::BadSignature`] on any verification failure.
+pub fn verify_es256_assertion(
+    cose_public_key: &[u8],
+    authenticator_data: &[u8],
+    client_data_json: &[u8],
+    signature_der: &[u8],
+) -> Result<(), PasskeyError> {
+    use p256::ecdsa::signature::Verifier as _;
+    let key = cose_es256_key(cose_public_key)?;
+    let mut client_hash = Sha256::new();
+    client_hash.update(client_data_json);
+    let client_hash: [u8; 32] = client_hash.finalize().into();
+
+    let mut signed = Vec::with_capacity(authenticator_data.len() + 32);
+    signed.extend_from_slice(authenticator_data);
+    signed.extend_from_slice(&client_hash);
+
+    let sig =
+        p256::ecdsa::Signature::from_der(signature_der).map_err(|_| PasskeyError::BadSignature)?;
+    key.verify(&signed, &sig)
+        .map_err(|_| PasskeyError::BadSignature)
+}
+
+/// Decode base64url (with or without padding). Returns `None` on invalid
+/// input.
+pub(super) fn b64url_decode(s: &str) -> Option<Vec<u8>> {
+    use base64::Engine as _;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(s.trim_end_matches('='))
+        .ok()
+}
+
+/// Encode bytes as base64url, no padding.
+pub(super) fn b64url_encode(bytes: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p256::ecdsa::{signature::Signer as _, Signature, SigningKey};
+
+    /// Build a COSE EC2/ES256 key from a p256 verifying key.
+    fn cose_key_of(vk: &p256::ecdsa::VerifyingKey) -> Vec<u8> {
+        use ciborium::value::{Integer, Value};
+        let pt = vk.to_encoded_point(false); // uncompressed 0x04||x||y
+        let x = pt.x().unwrap().to_vec();
+        let y = pt.y().unwrap().to_vec();
+        let map = Value::Map(vec![
+            (
+                Value::Integer(Integer::from(1)),
+                Value::Integer(Integer::from(2)),
+            ), // kty=EC2
+            (
+                Value::Integer(Integer::from(3)),
+                Value::Integer(Integer::from(-7)),
+            ), // alg=ES256
+            (
+                Value::Integer(Integer::from(-1)),
+                Value::Integer(Integer::from(1)),
+            ), // crv=P-256
+            (Value::Integer(Integer::from(-2)), Value::Bytes(x)),
+            (Value::Integer(Integer::from(-3)), Value::Bytes(y)),
+        ]);
+        let mut out = Vec::new();
+        ciborium::ser::into_writer(&map, &mut out).unwrap();
+        out
+    }
+
+    /// Build minimal authenticatorData: rpIdHash || flags || signCount.
+    fn auth_data(rp_id: &str, flags: u8, count: u32) -> Vec<u8> {
+        let mut h = Sha256::new();
+        h.update(rp_id.as_bytes());
+        let rp_hash: [u8; 32] = h.finalize().into();
+        let mut d = Vec::with_capacity(37);
+        d.extend_from_slice(&rp_hash);
+        d.push(flags);
+        d.extend_from_slice(&count.to_be_bytes());
+        d
+    }
+
+    #[test]
+    fn cose_key_round_trips_to_verifying_key() {
+        let sk = SigningKey::random(&mut rand_core_os());
+        let vk = *sk.verifying_key();
+        let cose = cose_key_of(&vk);
+        let parsed = cose_es256_key(&cose).expect("parse COSE key");
+        assert_eq!(parsed.to_encoded_point(false), vk.to_encoded_point(false));
+    }
+
+    #[test]
+    fn assertion_verifies_and_tamper_is_rejected() {
+        let sk = SigningKey::random(&mut rand_core_os());
+        let cose = cose_key_of(sk.verifying_key());
+
+        let ad = auth_data("example.com", FLAG_UP, 1);
+        let client =
+            br#"{"type":"webauthn.get","challenge":"AAAA","origin":"https://example.com"}"#;
+        let mut client_hash = Sha256::new();
+        client_hash.update(client);
+        let ch: [u8; 32] = client_hash.finalize().into();
+        let mut signed = ad.clone();
+        signed.extend_from_slice(&ch);
+        let sig: Signature = sk.sign(&signed);
+        let der = sig.to_der();
+
+        // Good signature verifies.
+        verify_es256_assertion(&cose, &ad, client, der.as_bytes()).expect("valid assertion");
+
+        // Tampered authenticatorData (bumped count) → rejected.
+        let mut tampered = ad.clone();
+        tampered[36] ^= 0xff;
+        assert!(matches!(
+            verify_es256_assertion(&cose, &tampered, client, der.as_bytes()),
+            Err(PasskeyError::BadSignature)
+        ));
+    }
+
+    #[test]
+    fn parse_authenticator_data_reads_header() {
+        let ad = auth_data("example.com", FLAG_UP, 42);
+        let parsed = parse_authenticator_data(&ad).unwrap();
+        assert!(parsed.user_present());
+        assert_eq!(parsed.sign_count, 42);
+        assert!(parsed.attested.is_none());
+        verify_rp_id(&parsed, "example.com").unwrap();
+        assert!(matches!(
+            verify_rp_id(&parsed, "evil.com"),
+            Err(PasskeyError::RpIdMismatch)
+        ));
+    }
+
+    #[test]
+    fn client_data_validation() {
+        let json = br#"{"type":"webauthn.get","challenge":"YWJj","origin":"https://example.com"}"#;
+        let origins = vec!["https://example.com".to_owned()];
+        // "YWJj" is base64url of "abc".
+        let cd = parse_and_verify_client_data(json, "webauthn.get", b"abc", &origins).unwrap();
+        assert_eq!(cd.origin, "https://example.com");
+        // Wrong challenge.
+        assert!(matches!(
+            parse_and_verify_client_data(json, "webauthn.get", b"xyz", &origins),
+            Err(PasskeyError::ChallengeMismatch)
+        ));
+        // Wrong type.
+        assert!(matches!(
+            parse_and_verify_client_data(json, "webauthn.create", b"abc", &origins),
+            Err(PasskeyError::WrongType { .. })
+        ));
+        // Disallowed origin.
+        assert!(matches!(
+            parse_and_verify_client_data(json, "webauthn.get", b"abc", &[]),
+            Err(PasskeyError::BadOrigin(_))
+        ));
+    }
+
+    // p256's `SigningKey::random` wants an `OsRng`; pull it from `rand`'s
+    // re-exported core to avoid a separate `rand_core` dep in tests.
+    fn rand_core_os() -> p256::elliptic_curve::rand_core::OsRng {
+        p256::elliptic_curve::rand_core::OsRng
+    }
+}

--- a/crates/rustango/tests/passkey_store_sqlite_live.rs
+++ b/crates/rustango/tests/passkey_store_sqlite_live.rs
@@ -1,0 +1,93 @@
+#![cfg(all(feature = "sqlite", feature = "passkey"))]
+//! Live SQLite test for the passkey credential store — issue #392
+//! (foundation slice). The store uses only standard column types
+//! (i64 / String / BLOB / timestamp), so it round-trips on SQLite with
+//! no PostGIS / crypto involved — that's the ceremony layer's concern.
+//!
+//! `max_connections(1)` keeps DDL + writes + reads on one in-memory DB.
+
+use rustango::passkey;
+use rustango::sql::{sqlx, Pool};
+
+async fn pool() -> Pool {
+    let p = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("sqlite");
+    let pool: Pool = p.into();
+    passkey::ensure_table(&pool).await.expect("ensure_table");
+    pool
+}
+
+#[tokio::test]
+async fn ensure_table_is_idempotent() {
+    let p = pool().await;
+    passkey::ensure_table(&p)
+        .await
+        .expect("second create is a no-op");
+    assert!(passkey::for_user(&p, 1).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn register_lookup_and_bump_sign_count() {
+    let p = pool().await;
+
+    // Two passkeys for user 7, one for user 9.
+    passkey::register(&p, 7, "cred-laptop", vec![1, 2, 3], 0, "Laptop")
+        .await
+        .unwrap();
+    passkey::register(&p, 7, "cred-phone", vec![4, 5, 6], 0, "Phone")
+        .await
+        .unwrap();
+    passkey::register(&p, 9, "cred-key", vec![7, 8, 9], 0, "YubiKey")
+        .await
+        .unwrap();
+
+    // for_user lists only that user's credentials.
+    let u7 = passkey::for_user(&p, 7).await.unwrap();
+    assert_eq!(u7.len(), 2, "user 7 has two passkeys");
+    assert_eq!(passkey::for_user(&p, 9).await.unwrap().len(), 1);
+    assert!(passkey::for_user(&p, 42).await.unwrap().is_empty());
+
+    // by_credential_id finds the exact credential + round-trips the key.
+    let found = passkey::by_credential_id(&p, "cred-phone")
+        .await
+        .unwrap()
+        .expect("cred-phone exists");
+    assert_eq!(found.user_id, 7);
+    assert_eq!(found.public_key, vec![4, 5, 6]);
+    assert_eq!(found.sign_count, 0);
+    assert_eq!(found.label, "Phone");
+    assert!(passkey::by_credential_id(&p, "nope")
+        .await
+        .unwrap()
+        .is_none());
+
+    // Sign-count bump (clone/replay tracking) persists.
+    passkey::update_sign_count(&p, "cred-phone", 5)
+        .await
+        .unwrap();
+    let bumped = passkey::by_credential_id(&p, "cred-phone")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(bumped.sign_count, 5);
+    // The other credential is untouched.
+    let laptop = passkey::by_credential_id(&p, "cred-laptop")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(laptop.sign_count, 0);
+}
+
+#[tokio::test]
+async fn credential_id_is_unique() {
+    let p = pool().await;
+    passkey::register(&p, 1, "dup", vec![0], 0, "first")
+        .await
+        .unwrap();
+    // Same credential_id again violates the UNIQUE constraint.
+    let err = passkey::register(&p, 2, "dup", vec![1], 0, "second").await;
+    assert!(err.is_err(), "duplicate credential_id must be rejected");
+}


### PR DESCRIPTION
Pure-Rust passkey / WebAuthn support (#392) — **no `webauthn-rs`/openssl**; uses `ciborium` (CBOR) + `p256` (ES256), consistent with rustango's all-RustCrypto stack. Behind an opt-in `passkey` feature (zero impact on default builds).

## Layers
**Credential store** (`passkey::WebauthnCredential`, `managed=false`, 3-dialect `ensure_table`): surrogate PK, `user_id`, unique base64url `credential_id`, COSE `public_key`, `sign_count`, `label`. Store API: `for_user` / `by_credential_id` / `register` / `update_sign_count`.

**Verification primitives** (`passkey::verify`, bounds-checked, never panic): `parse_authenticator_data`, `parse_and_verify_client_data` (type / **constant-time** challenge / origin allow-list), `verify_rp_id`, `cose_es256_key` (COSE EC2/P-256 → `p256::VerifyingKey`), `verify_es256_assertion`.

**Ceremonies** (`passkey::ceremony`): `verify_registration` (attestationObject CBOR, `none`/self attestation — extract + validate the key, no cert chain), `verify_authentication` (full assertion + **signature-counter clone detection**), `generate_challenge`, and `registration_options_json` / `authentication_options_json` for `navigator.credentials.create()/get()`.

## Scope
ES256 + `none`/self attestation — the dominant passkey case. Every failure path returns `PasskeyError`; malformed input never panics.

## Tests
- `passkey_store_sqlite_live.rs` (3): store round-trip + UNIQUE.
- Unit (7): COSE round-trip, ES256 verify + tamper-reject, authData parse, clientData validation, **full register→authenticate round-trip** (generated keypair simulating an authenticator), counter-regression rejection.

## Gates
`sqlite,tenancy,passkey` + `postgres,tenancy,passkey` build; 2273 lib tests; `cargo test --workspace --all-features --no-run` (with `ciborium`/`p256` in the tree); fmt clean. `managed=false` model correctly skipped by `apply_all` (verified via `migrate_signals`).

## Follow-up (thin)
HTTP router + `AuthBackend` wiring — callers can already wire these verification functions into their own endpoints today.