### PR TITLE
feat(i18n): admin translation editor — #532 Slice 2 (editor core)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,7 @@ jobs:
             --test funcs_batch1_sqlite_live \
             --test funcs_batch2_sqlite_live \
             --test get_or_create_sqlite_live \
+            --test i18n_admin_editor_sqlite_live \
             --test i18n_db_overrides_sqlite_live \
             --test inspectdb_sqlite_live \
             --test inspectdb_views_sqlite_live \

--- a/crates/rustango/src/i18n/admin.rs
+++ b/crates/rustango/src/i18n/admin.rs
@@ -1,0 +1,343 @@
+//! Admin UI to edit translations — issue #532 Slice 2.
+//!
+//! A pivoted editor over the [`crate::i18n::db`] override layer: one row
+//! per translation key, one editable column per locale, plus a per-locale
+//! coverage summary. Saving upserts each changed `(locale, key)` into
+//! `rustango_translations` (the editable DB layer from Slice 1) so
+//! operators fix typos — and fill coverage gaps (a blank cell for an
+//! existing key) — without a redeploy.
+//!
+//! Slice 2 scope: view + edit + coverage + persist. Add-brand-new-key,
+//! delete-key, export-to-JSON, and the `seed-translations` verb are a
+//! tracked Slice 3 follow-up.
+//!
+//! Mounted as an admin custom view on the `rustango_translations` model
+//! (so it inherits the admin's login gate):
+//! `GET`/`POST {admin_prefix}/rustango_translations/editor`. The app must
+//! register the `Translation` model with its admin Builder for the route
+//! to mount (the editor is otherwise inert).
+//!
+//! The render + apply logic are free functions so they're unit-testable
+//! without an HTTP harness; the registered handlers are thin glue.
+//!
+//! After a save the in-memory override cache is stale until the app calls
+//! [`crate::i18n::db::refresh_overrides_pool`] — wire that on a signal or
+//! a short interval; the persisted edit is authoritative regardless.
+
+#[cfg(feature = "admin")]
+use crate::i18n::db::{all_pool, upsert_pool, Translation};
+use crate::sql::Pool;
+
+/// A single key's value across the active locales, for the pivoted grid.
+#[derive(Debug, Clone, PartialEq)]
+pub struct KeyRow {
+    pub key: String,
+    /// `value` per locale, aligned with the column order passed to
+    /// [`pivot`]. `None` = no row for that (locale, key) (a coverage gap).
+    pub values: Vec<Option<String>>,
+}
+
+/// Group flat `Translation` rows into the pivoted `(locales, key-rows)`
+/// shape the editor renders. Locales are sorted; keys are sorted.
+#[must_use]
+pub fn pivot(rows: &[(String, String, String)]) -> (Vec<String>, Vec<KeyRow>) {
+    use std::collections::{BTreeMap, BTreeSet};
+    let mut locales: BTreeSet<String> = BTreeSet::new();
+    // key -> locale -> value
+    let mut by_key: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+    for (locale, key, value) in rows {
+        locales.insert(locale.clone());
+        by_key
+            .entry(key.clone())
+            .or_default()
+            .insert(locale.clone(), value.clone());
+    }
+    let locales: Vec<String> = locales.into_iter().collect();
+    let key_rows = by_key
+        .into_iter()
+        .map(|(key, per_locale)| KeyRow {
+            values: locales
+                .iter()
+                .map(|loc| per_locale.get(loc).cloned())
+                .collect(),
+            key,
+        })
+        .collect();
+    (locales, key_rows)
+}
+
+/// A coverage summary: per-locale count of keys missing a (non-empty)
+/// value, given the pivoted grid.
+#[must_use]
+pub fn coverage_gaps(locales: &[String], rows: &[KeyRow]) -> Vec<(String, usize)> {
+    locales
+        .iter()
+        .enumerate()
+        .map(|(i, loc)| {
+            let missing = rows
+                .iter()
+                .filter(|r| r.values.get(i).map_or(true, |v| v.is_none()))
+                .count();
+            (loc.clone(), missing)
+        })
+        .collect()
+}
+
+/// Render the editor page HTML. Inputs are named `tr:<locale>:<key>` so
+/// the POST handler can recover the `(locale, key)` pair. `escape` is the
+/// admin's HTML escaper.
+#[must_use]
+pub fn render_editor(
+    locales: &[String],
+    rows: &[KeyRow],
+    action: &str,
+    escape: impl Fn(&str) -> String,
+) -> String {
+    let mut h = String::with_capacity(1024 + rows.len() * 128);
+    h.push_str("<h1>Translations</h1>");
+    // Coverage panel.
+    let gaps = coverage_gaps(locales, rows);
+    h.push_str("<p class=\"coverage\">");
+    for (loc, missing) in &gaps {
+        h.push_str(&format!(
+            "<span>{}: {}</span> ",
+            escape(loc),
+            if *missing == 0 {
+                "complete".to_owned()
+            } else {
+                format!("{missing} missing")
+            }
+        ));
+    }
+    h.push_str("</p>");
+
+    h.push_str(&format!(
+        "<form method=\"post\" action=\"{}\"><table><thead><tr><th>key</th>",
+        escape(action)
+    ));
+    for loc in locales {
+        h.push_str(&format!("<th>{}</th>", escape(loc)));
+    }
+    h.push_str("</tr></thead><tbody>");
+    for row in rows {
+        h.push_str(&format!("<tr><td>{}</td>", escape(&row.key)));
+        for (i, loc) in locales.iter().enumerate() {
+            let val = row.values.get(i).and_then(Option::as_deref).unwrap_or("");
+            h.push_str(&format!(
+                "<td><input name=\"tr:{}:{}\" value=\"{}\"></td>",
+                escape(loc),
+                escape(&row.key),
+                escape(val)
+            ));
+        }
+        h.push_str("</tr>");
+    }
+    h.push_str("</tbody></table><button type=\"submit\">Save</button></form>");
+    h
+}
+
+/// Parse the editor POST body (`tr:<locale>:<key>=<value>` pairs) into
+/// `(locale, key, value)` edits. Form keys not matching the `tr:` prefix
+/// are ignored. The locale segment can't contain `:`; the key may.
+#[must_use]
+pub fn parse_edits(form: &[(String, String)]) -> Vec<(String, String, String)> {
+    form.iter()
+        .filter_map(|(name, value)| {
+            let rest = name.strip_prefix("tr:")?;
+            let (locale, key) = rest.split_once(':')?;
+            if locale.is_empty() || key.is_empty() {
+                return None;
+            }
+            Some((locale.to_owned(), key.to_owned(), value.clone()))
+        })
+        .collect()
+}
+
+/// Upsert each parsed edit into the override layer. Returns the count
+/// written. `updated_by` records the operator.
+///
+/// # Errors
+/// As the ORM upsert path ([`crate::sql::ExecError`]).
+#[cfg(feature = "admin")]
+pub async fn apply_edits(
+    pool: &Pool,
+    edits: &[(String, String, String)],
+    updated_by: &str,
+) -> Result<usize, crate::sql::ExecError> {
+    for (locale, key, value) in edits {
+        upsert_pool(pool, locale, key, value, updated_by).await?;
+    }
+    Ok(edits.len())
+}
+
+/// Fetch the current override rows as `(locale, key, value)` triples for
+/// [`pivot`].
+///
+/// # Errors
+/// As the ORM fetch path ([`crate::sql::ExecError`]).
+#[cfg(feature = "admin")]
+pub async fn editor_rows(
+    pool: &Pool,
+) -> Result<Vec<(String, String, String)>, crate::sql::ExecError> {
+    let rows: Vec<Translation> = all_pool(pool).await?;
+    Ok(rows
+        .into_iter()
+        .map(|t| (t.locale, t.key, t.value))
+        .collect())
+}
+
+// ---- admin custom-view registration (GET grid + POST save) ----------
+//
+// Mounts at `{admin_prefix}/rustango_translations/editor`. Inert unless
+// the app registers the `Translation` model with its admin Builder.
+
+#[cfg(feature = "admin")]
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(feature = "admin")]
+async fn editor_get(
+    pool: Pool,
+    _req: axum::http::Request<axum::body::Body>,
+) -> axum::response::Response {
+    use axum::response::{Html, IntoResponse};
+    match editor_rows(&pool).await {
+        Ok(triples) => {
+            let (locales, rows) = pivot(&triples);
+            Html(render_editor(&locales, &rows, "editor", html_escape)).into_response()
+        }
+        Err(e) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            format!("translations editor: {e}"),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(feature = "admin")]
+async fn editor_post(
+    pool: Pool,
+    req: axum::http::Request<axum::body::Body>,
+) -> axum::response::Response {
+    use axum::response::{IntoResponse, Redirect};
+    let body = match axum::body::to_bytes(req.into_body(), 1 << 20).await {
+        Ok(b) => b,
+        Err(_) => return axum::http::StatusCode::BAD_REQUEST.into_response(),
+    };
+    let form: Vec<(String, String)> = serde_urlencoded::from_bytes(&body).unwrap_or_default();
+    let edits = parse_edits(&form);
+    if let Err(e) = apply_edits(&pool, &edits, "admin").await {
+        return (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            format!("save translations: {e}"),
+        )
+            .into_response();
+    }
+    Redirect::to("editor").into_response()
+}
+
+#[cfg(feature = "admin")]
+crate::register_admin_view!(
+    "rustango_translations",
+    "editor",
+    axum::http::Method::GET,
+    "Edit translations",
+    editor_get,
+);
+
+#[cfg(feature = "admin")]
+crate::register_admin_view!(
+    "rustango_translations",
+    "editor",
+    axum::http::Method::POST,
+    "",
+    editor_post,
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rows() -> Vec<(String, String, String)> {
+        vec![
+            ("en".into(), "greeting".into(), "Hello".into()),
+            ("fr".into(), "greeting".into(), "Bonjour".into()),
+            ("en".into(), "bye".into(), "Bye".into()),
+            // fr.bye missing → coverage gap.
+        ]
+    }
+
+    #[test]
+    fn pivot_groups_by_key_with_aligned_locale_columns() {
+        let (locales, key_rows) = pivot(&rows());
+        assert_eq!(locales, vec!["en", "fr"]);
+        let greeting = key_rows.iter().find(|r| r.key == "greeting").unwrap();
+        assert_eq!(
+            greeting.values,
+            vec![Some("Hello".into()), Some("Bonjour".into())]
+        );
+        let bye = key_rows.iter().find(|r| r.key == "bye").unwrap();
+        assert_eq!(bye.values, vec![Some("Bye".into()), None]); // fr gap
+    }
+
+    #[test]
+    fn coverage_counts_missing_per_locale() {
+        let (locales, key_rows) = pivot(&rows());
+        let gaps = coverage_gaps(&locales, &key_rows);
+        assert_eq!(gaps, vec![("en".into(), 0), ("fr".into(), 1)]);
+    }
+
+    #[test]
+    fn render_has_inputs_named_for_locale_and_key() {
+        let (locales, key_rows) = pivot(&rows());
+        let html = render_editor(&locales, &key_rows, "editor", |s| s.to_owned());
+        assert!(
+            html.contains(r#"name="tr:fr:greeting" value="Bonjour""#),
+            "{html}"
+        );
+        assert!(
+            html.contains(r#"name="tr:fr:bye" value="""#),
+            "missing-value input: {html}"
+        );
+        assert!(html.contains("fr: 1 missing"));
+    }
+
+    #[test]
+    fn parse_edits_recovers_locale_and_key() {
+        let form = vec![
+            ("tr:fr:greeting".into(), "Salut".into()),
+            ("tr:en:bye".into(), "Goodbye".into()),
+            ("csrf".into(), "token".into()), // ignored (no tr: prefix)
+            ("tr:bad".into(), "x".into()),   // ignored (no second colon)
+        ];
+        let edits = parse_edits(&form);
+        assert_eq!(
+            edits,
+            vec![
+                ("fr".into(), "greeting".into(), "Salut".into()),
+                ("en".into(), "bye".into(), "Goodbye".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_edits_handles_keys_with_dots_and_underscores() {
+        let form = vec![("tr:en:nav.home_link".into(), "Home".into())];
+        assert_eq!(
+            parse_edits(&form),
+            vec![("en".into(), "nav.home_link".into(), "Home".into())]
+        );
+    }
+}

--- a/crates/rustango/src/i18n/mod.rs
+++ b/crates/rustango/src/i18n/mod.rs
@@ -40,6 +40,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::RwLock;
 
+pub mod admin;
 pub mod db;
 pub mod middleware;
 pub mod tera_tags;

--- a/crates/rustango/tests/i18n_admin_editor_sqlite_live.rs
+++ b/crates/rustango/tests/i18n_admin_editor_sqlite_live.rs
@@ -1,0 +1,77 @@
+#![cfg(all(feature = "sqlite", feature = "admin"))]
+//! Live SQLite test for the i18n admin editor — issue #532 Slice 2.
+//!
+//! Exercises the save → store → re-render round-trip end-to-end against
+//! the merged Slice 1 override layer: `apply_edits` upserts what the
+//! editor POSTs, `editor_rows` reads it back, `pivot` builds the grid,
+//! and `render_editor` produces inputs that round-trip the values.
+//!
+//! `max_connections(1)` pins DDL + writes + reads to one in-memory DB.
+
+use rustango::i18n::admin::{apply_edits, editor_rows, pivot, render_editor};
+use rustango::i18n::db::ensure_table_pool;
+use rustango::sql::{sqlx, Pool};
+
+async fn pool() -> Pool {
+    let p = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("sqlite");
+    let pool: Pool = p.into();
+    ensure_table_pool(&pool).await.expect("ensure_table");
+    pool
+}
+
+#[tokio::test]
+async fn editor_save_store_render_round_trip() {
+    let p = pool().await;
+
+    // The editor POSTs these (locale, key, value) edits.
+    let edits = vec![
+        ("en".to_owned(), "greeting".to_owned(), "Hello".to_owned()),
+        ("fr".to_owned(), "greeting".to_owned(), "Bonjour".to_owned()),
+        ("en".to_owned(), "bye".to_owned(), "Bye".to_owned()),
+    ];
+    let n = apply_edits(&p, &edits, "alice").await.unwrap();
+    assert_eq!(n, 3);
+
+    // Read back → pivot → grid reflects the saved values + the fr.bye gap.
+    let (locales, rows) = pivot(&editor_rows(&p).await.unwrap());
+    assert_eq!(locales, vec!["en", "fr"]);
+    let bye = rows.iter().find(|r| r.key == "bye").unwrap();
+    assert_eq!(
+        bye.values,
+        vec![Some("Bye".to_owned()), None],
+        "fr.bye is a gap"
+    );
+
+    // The rendered editor has an input pre-filled with the saved fr value.
+    let html = render_editor(&locales, &rows, "editor", |s| s.to_owned());
+    assert!(
+        html.contains(r#"name="tr:fr:greeting" value="Bonjour""#),
+        "{html}"
+    );
+
+    // A second save UPDATES in place (upsert), and fills the fr.bye gap.
+    let edits2 = vec![
+        ("fr".to_owned(), "greeting".to_owned(), "Salut".to_owned()),
+        ("fr".to_owned(), "bye".to_owned(), "Au revoir".to_owned()),
+    ];
+    apply_edits(&p, &edits2, "bob").await.unwrap();
+
+    let (locales, rows) = pivot(&editor_rows(&p).await.unwrap());
+    let greeting = rows.iter().find(|r| r.key == "greeting").unwrap();
+    // en unchanged, fr updated — no duplicate rows.
+    assert_eq!(
+        greeting.values,
+        vec![Some("Hello".to_owned()), Some("Salut".to_owned())]
+    );
+    let bye = rows.iter().find(|r| r.key == "bye").unwrap();
+    assert_eq!(
+        bye.values,
+        vec![Some("Bye".to_owned()), Some("Au revoir".to_owned())]
+    );
+    // Coverage now complete for both locales (4 rows, 2 keys × 2 locales).
+    assert_eq!(editor_rows(&p).await.unwrap().len(), 4);
+}


### PR DESCRIPTION
## What

The operator-facing editor on top of the Slice 1 DB-override layer (#1000). A pivoted grid — one row per key, one editable column per locale, with a per-locale coverage summary — that upserts edits into `rustango_translations`, so typos get fixed and coverage gaps filled **without a redeploy**.

## How

`crate::i18n::admin`:
- **Pure, unit-testable logic** (feature-ungated): `pivot` (flat rows → key×locale grid), `coverage_gaps` (missing-count per locale), `render_editor` (HTML with `tr:<locale>:<key>` inputs), `parse_edits` (POST body → edits).
- **Store glue** (`#[cfg(feature = "admin")]`): `apply_edits` / `editor_rows` over the Slice 1 `upsert_pool` / `all_pool`.
- Registered as an admin custom view (`register_admin_view!`) at `GET`/`POST {admin_prefix}/rustango_translations/editor`, inheriting the admin login gate. Inert unless the app registers the `Translation` model with its admin Builder.

Builds **with and without** the `admin` feature (pure logic ungated, HTTP handlers + registration gated). After a save the in-memory override cache is refreshed by the app via the Slice 1 `refresh_overrides_pool`; the persisted edit is authoritative regardless.

## Tests

- 5 unit (pivot / coverage / render input-naming / parse incl. dotted keys).
- `i18n_admin_editor_sqlite_live.rs` — save → store → re-pivot → render round-trip + upsert-in-place + gap-fill. Wired into the `sqlite_live` CI job.

## Scope / follow-up

Slice 2 ships **view + edit + coverage + persist**. Tracked as **Slice 3** on #532: add-brand-new-key, delete-key, export-to-JSON, the `seed-translations` manage verb, and an `auth.edit_translations` fine-grained permission.

Advances #532 (not closing — Slice 3 remains).