### PR TITLE
feat(i18n): editor delete-key + add-key + export-JSON + superuser gate — #532 Slice 3

### DIFF
--- a/crates/rustango/src/i18n/admin.rs
+++ b/crates/rustango/src/i18n/admin.rs
@@ -1,4 +1,4 @@
-//! Admin UI to edit translations — issue #532 Slice 2.
+//! Admin UI to edit translations — issue #532 Slices 2 + 3.
 //!
 //! A pivoted editor over the [`crate::i18n::db`] override layer: one row
 //! per translation key, one editable column per locale, plus a per-locale
@@ -7,9 +7,19 @@
 //! operators fix typos — and fill coverage gaps (a blank cell for an
 //! existing key) — without a redeploy.
 //!
-//! Slice 2 scope: view + edit + coverage + persist. Add-brand-new-key,
-//! delete-key, export-to-JSON, and the `seed-translations` verb are a
-//! tracked Slice 3 follow-up.
+//! Slice 2 (#1006): view + edit + coverage + persist. Slice 3 (this
+//! change): add a brand-new key (footer row), delete a key (per-row
+//! checkbox → all locales), export the whole catalog as JSON
+//! (`…/export.json`), and gate **writes** on superuser — the POST handler
+//! reads the live [`crate::admin::AdminSession`] from request extensions,
+//! rejects non-superusers with 403, and records the operator's username
+//! as `updated_by`. Reads (the grid + export) stay at the admin login
+//! gate.
+//!
+//! Still tracked on #532: the `seed-translations` manage verb (needs a
+//! locales-dir wired into the `Cli`) and a fine-grained
+//! `auth.edit_translations` permission codename (superuser is the gate
+//! for now).
 //!
 //! Mounted as an admin custom view on the `rustango_translations` model
 //! (so it inherits the admin's login gate):
@@ -25,7 +35,7 @@
 //! a short interval; the persisted edit is authoritative regardless.
 
 #[cfg(feature = "admin")]
-use crate::i18n::db::{all_pool, upsert_pool, Translation};
+use crate::i18n::db::{all_pool, delete_key_pool, upsert_pool, Translation};
 use crate::sql::Pool;
 
 /// A single key's value across the active locales, for the pivoted grid.
@@ -110,6 +120,7 @@ pub fn render_editor(
         ));
     }
     h.push_str("</p>");
+    h.push_str(r#"<p class="export"><a href="export.json">Export JSON</a></p>"#);
 
     h.push_str(&format!(
         "<form method=\"post\" action=\"{}\"><table><thead><tr><th>key</th>",
@@ -118,7 +129,7 @@ pub fn render_editor(
     for loc in locales {
         h.push_str(&format!("<th>{}</th>", escape(loc)));
     }
-    h.push_str("</tr></thead><tbody>");
+    h.push_str("<th>delete</th></tr></thead><tbody>");
     for row in rows {
         h.push_str(&format!("<tr><td>{}</td>", escape(&row.key)));
         for (i, loc) in locales.iter().enumerate() {
@@ -130,9 +141,25 @@ pub fn render_editor(
                 escape(val)
             ));
         }
-        h.push_str("</tr>");
+        // Per-row "delete this key" (removes every locale's override).
+        h.push_str(&format!(
+            "<td><input type=\"checkbox\" name=\"delkey:{}\"></td></tr>",
+            escape(&row.key)
+        ));
     }
-    h.push_str("</tbody></table><button type=\"submit\">Save</button></form>");
+    h.push_str("</tbody>");
+    // Footer: add a brand-new key across the active locales. The key goes
+    // in `newkey`; each locale's value in `newval:<locale>`.
+    h.push_str("<tfoot><tr><td><input name=\"newkey\" placeholder=\"new key\"></td>");
+    for loc in locales {
+        h.push_str(&format!(
+            "<td><input name=\"newval:{}\" placeholder=\"{}\"></td>",
+            escape(loc),
+            escape(loc)
+        ));
+    }
+    h.push_str("<td></td></tr></tfoot>");
+    h.push_str("</table><button type=\"submit\">Save</button></form>");
     h
 }
 
@@ -153,6 +180,59 @@ pub fn parse_edits(form: &[(String, String)]) -> Vec<(String, String, String)> {
         .collect()
 }
 
+/// Parse the "add new key" footer of the editor POST body: `newkey` names
+/// the key, each `newval:<locale>` carries that locale's value. Returns
+/// one `(locale, key, value)` edit per **non-empty** `newval`. An empty
+/// `newkey` (or no non-empty values) yields nothing.
+#[must_use]
+pub fn parse_new_key(form: &[(String, String)]) -> Vec<(String, String, String)> {
+    let key = form
+        .iter()
+        .find(|(n, _)| n == "newkey")
+        .map_or("", |(_, v)| v.trim());
+    if key.is_empty() {
+        return Vec::new();
+    }
+    form.iter()
+        .filter_map(|(name, value)| {
+            let locale = name.strip_prefix("newval:")?;
+            if locale.is_empty() || value.is_empty() {
+                return None;
+            }
+            Some((locale.to_owned(), key.to_owned(), value.clone()))
+        })
+        .collect()
+}
+
+/// Parse the per-row delete checkboxes (`delkey:<key>`) from the editor
+/// POST body. An HTML checkbox only submits when ticked, so any present
+/// `delkey:<key>` marks that key for deletion (all locales). Returns the
+/// keys to drop.
+#[must_use]
+pub fn parse_deletes(form: &[(String, String)]) -> Vec<String> {
+    form.iter()
+        .filter_map(|(name, _)| name.strip_prefix("delkey:").map(str::to_owned))
+        .filter(|k| !k.is_empty())
+        .collect()
+}
+
+/// Render the override catalog as a locale-keyed JSON object —
+/// `{"<locale>": {"<key>": "<value>", …}, …}` — for the editor's
+/// "Export JSON" link / backup. Locales and keys are sorted (`BTreeMap`)
+/// so the output is deterministic; pretty-printed.
+#[must_use]
+pub fn export_json(rows: &[(String, String, String)]) -> String {
+    use std::collections::BTreeMap;
+    let mut by_locale: BTreeMap<&str, BTreeMap<&str, &str>> = BTreeMap::new();
+    for (locale, key, value) in rows {
+        by_locale
+            .entry(locale.as_str())
+            .or_default()
+            .insert(key.as_str(), value.as_str());
+    }
+    serde_json::to_string_pretty(&by_locale).unwrap_or_else(|_| "{}".to_owned())
+}
+
 /// Upsert each parsed edit into the override layer. Returns the count
 /// written. `updated_by` records the operator.
 ///
@@ -168,6 +248,20 @@ pub async fn apply_edits(
         upsert_pool(pool, locale, key, value, updated_by).await?;
     }
     Ok(edits.len())
+}
+
+/// Delete each listed key (all locales) from the override layer. Returns
+/// the total override rows removed.
+///
+/// # Errors
+/// As the ORM delete path ([`crate::sql::ExecError`]).
+#[cfg(feature = "admin")]
+pub async fn apply_deletes(pool: &Pool, keys: &[String]) -> Result<u64, crate::sql::ExecError> {
+    let mut removed = 0;
+    for key in keys {
+        removed += delete_key_pool(pool, key).await?;
+    }
+    Ok(removed)
 }
 
 /// Fetch the current override rows as `(locale, key, value)` triples for
@@ -231,21 +325,75 @@ async fn editor_post(
     pool: Pool,
     req: axum::http::Request<axum::body::Body>,
 ) -> axum::response::Response {
+    use axum::http::StatusCode;
     use axum::response::{IntoResponse, Redirect};
+    // Writes require a superuser. The admin login gate inserts the live
+    // `AdminSession` into request extensions (see `admin::login_view`);
+    // read it before consuming the body.
+    let Some(session) = req
+        .extensions()
+        .get::<crate::admin::AdminSession>()
+        .cloned()
+    else {
+        return (
+            StatusCode::FORBIDDEN,
+            "translations editor: no admin session",
+        )
+            .into_response();
+    };
+    if !session.is_superuser {
+        return (
+            StatusCode::FORBIDDEN,
+            "translations editor: editing requires a superuser",
+        )
+            .into_response();
+    }
+
     let body = match axum::body::to_bytes(req.into_body(), 1 << 20).await {
         Ok(b) => b,
-        Err(_) => return axum::http::StatusCode::BAD_REQUEST.into_response(),
+        Err(_) => return StatusCode::BAD_REQUEST.into_response(),
     };
     let form: Vec<(String, String)> = serde_urlencoded::from_bytes(&body).unwrap_or_default();
-    let edits = parse_edits(&form);
-    if let Err(e) = apply_edits(&pool, &edits, "admin").await {
+
+    // Edits + the new key are upserts; deletes run last so a key that's
+    // both edited and delete-checked in the same submit ends up deleted.
+    let mut edits = parse_edits(&form);
+    edits.extend(parse_new_key(&form));
+    let deletes = parse_deletes(&form);
+    let result = async {
+        apply_edits(&pool, &edits, &session.username).await?;
+        apply_deletes(&pool, &deletes).await
+    }
+    .await;
+    if let Err(e) = result {
         return (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::INTERNAL_SERVER_ERROR,
             format!("save translations: {e}"),
         )
             .into_response();
     }
     Redirect::to("editor").into_response()
+}
+
+#[cfg(feature = "admin")]
+async fn export_get(
+    pool: Pool,
+    _req: axum::http::Request<axum::body::Body>,
+) -> axum::response::Response {
+    use axum::http::{header, StatusCode};
+    use axum::response::IntoResponse;
+    match editor_rows(&pool).await {
+        Ok(triples) => (
+            [(header::CONTENT_TYPE, "application/json")],
+            export_json(&triples),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("export translations: {e}"),
+        )
+            .into_response(),
+    }
 }
 
 #[cfg(feature = "admin")]
@@ -264,6 +412,15 @@ crate::register_admin_view!(
     axum::http::Method::POST,
     "",
     editor_post,
+);
+
+#[cfg(feature = "admin")]
+crate::register_admin_view!(
+    "rustango_translations",
+    "export.json",
+    axum::http::Method::GET,
+    "Export translations (JSON)",
+    export_get,
 );
 
 #[cfg(test)]
@@ -339,5 +496,67 @@ mod tests {
             parse_edits(&form),
             vec![("en".into(), "nav.home_link".into(), "Home".into())]
         );
+    }
+
+    #[test]
+    fn render_includes_delete_export_and_add_key_controls() {
+        let (locales, key_rows) = pivot(&rows());
+        let html = render_editor(&locales, &key_rows, "editor", |s| s.to_owned());
+        assert!(
+            html.contains(r#"href="export.json""#),
+            "export link: {html}"
+        );
+        assert!(
+            html.contains(r#"name="delkey:greeting""#),
+            "per-row delete: {html}"
+        );
+        assert!(html.contains(r#"name="newkey""#), "add-key field: {html}");
+        assert!(
+            html.contains(r#"name="newval:fr""#),
+            "add-key per-locale: {html}"
+        );
+    }
+
+    #[test]
+    fn parse_new_key_builds_edits_for_nonempty_values_only() {
+        let form = vec![
+            ("newkey".into(), " farewell ".into()), // trimmed
+            ("newval:en".into(), "Goodbye".into()),
+            ("newval:fr".into(), String::new()), // empty → skipped
+            ("tr:en:greeting".into(), "Hi".into()), // not a newval
+        ];
+        assert_eq!(
+            parse_new_key(&form),
+            vec![("en".into(), "farewell".into(), "Goodbye".into())]
+        );
+    }
+
+    #[test]
+    fn parse_new_key_empty_key_yields_nothing() {
+        let form = vec![
+            ("newkey".into(), "   ".into()),
+            ("newval:en".into(), "x".into()),
+        ];
+        assert!(parse_new_key(&form).is_empty());
+    }
+
+    #[test]
+    fn parse_deletes_collects_checked_keys() {
+        let form = vec![
+            ("delkey:greeting".into(), "on".into()),
+            ("delkey:nav.home".into(), "on".into()),
+            ("tr:en:bye".into(), "Bye".into()), // ignored
+        ];
+        assert_eq!(parse_deletes(&form), vec!["greeting", "nav.home"]);
+    }
+
+    #[test]
+    fn export_json_is_locale_keyed_and_sorted() {
+        let json = export_json(&rows());
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["en"]["greeting"], "Hello");
+        assert_eq!(v["fr"]["greeting"], "Bonjour");
+        assert_eq!(v["en"]["bye"], "Bye");
+        assert!(v["fr"].get("bye").is_none(), "fr.bye absent (coverage gap)");
     }
 }

--- a/crates/rustango/src/i18n/db.rs
+++ b/crates/rustango/src/i18n/db.rs
@@ -172,6 +172,30 @@ pub async fn seed_from_translator_pool(
     Ok(n)
 }
 
+/// Delete every override row for `key` (all locales) — the Slice 2
+/// editor's "delete key" action. Returns the number of rows removed (0
+/// if the key had no overrides). The file-catalog default, if any, is
+/// untouched, so a deleted key falls back to its shipped value.
+///
+/// # Errors
+/// As the ORM delete path ([`ExecError`]).
+pub async fn delete_key_pool(pool: &Pool, key: &str) -> Result<u64, ExecError> {
+    use crate::core::Model as _; // brings `Translation::SCHEMA` into scope
+    use crate::core::{DeleteQuery, Filter, Op, SqlValue, WhereExpr};
+    crate::sql::delete_pool(
+        pool,
+        &DeleteQuery {
+            model: Translation::SCHEMA,
+            where_clause: WhereExpr::and_predicates(vec![Filter {
+                column: "key",
+                op: Op::Eq,
+                value: SqlValue::from(key),
+            }]),
+        },
+    )
+    .await
+}
+
 /// Reload `translator`'s override layer from the DB so subsequent
 /// `translate(...)` calls reflect persisted edits — call after seeding,
 /// on boot, and after each admin save. Returns the row count loaded.

--- a/crates/rustango/tests/i18n_admin_editor_sqlite_live.rs
+++ b/crates/rustango/tests/i18n_admin_editor_sqlite_live.rs
@@ -1,14 +1,19 @@
 #![cfg(all(feature = "sqlite", feature = "admin"))]
-//! Live SQLite test for the i18n admin editor — issue #532 Slice 2.
+//! Live SQLite tests for the i18n admin editor — issue #532 Slices 2 + 3.
 //!
-//! Exercises the save → store → re-render round-trip end-to-end against
-//! the merged Slice 1 override layer: `apply_edits` upserts what the
-//! editor POSTs, `editor_rows` reads it back, `pivot` builds the grid,
-//! and `render_editor` produces inputs that round-trip the values.
+//! Slice 2: the save → store → re-render round-trip end-to-end against
+//! the Slice 1 override layer — `apply_edits` upserts what the editor
+//! POSTs, `editor_rows` reads it back, `pivot` builds the grid, and
+//! `render_editor` produces inputs that round-trip the values.
+//!
+//! Slice 3: `apply_deletes` removes a key across all locales, and
+//! `export_json` renders the live catalog locale-keyed.
 //!
 //! `max_connections(1)` pins DDL + writes + reads to one in-memory DB.
 
-use rustango::i18n::admin::{apply_edits, editor_rows, pivot, render_editor};
+use rustango::i18n::admin::{
+    apply_deletes, apply_edits, editor_rows, export_json, pivot, render_editor,
+};
 use rustango::i18n::db::ensure_table_pool;
 use rustango::sql::{sqlx, Pool};
 
@@ -74,4 +79,34 @@ async fn editor_save_store_render_round_trip() {
     );
     // Coverage now complete for both locales (4 rows, 2 keys × 2 locales).
     assert_eq!(editor_rows(&p).await.unwrap().len(), 4);
+}
+
+#[tokio::test]
+async fn delete_key_and_export_round_trip() {
+    let p = pool().await;
+    let edits = vec![
+        ("en".to_owned(), "greeting".to_owned(), "Hello".to_owned()),
+        ("fr".to_owned(), "greeting".to_owned(), "Bonjour".to_owned()),
+        ("en".to_owned(), "bye".to_owned(), "Bye".to_owned()),
+    ];
+    apply_edits(&p, &edits, "alice").await.unwrap();
+
+    // Export renders the live catalog locale-keyed (deterministic JSON).
+    let json = export_json(&editor_rows(&p).await.unwrap());
+    assert!(json.contains("\"greeting\""), "{json}");
+    assert!(json.contains("Bonjour"), "{json}");
+    assert!(json.contains("Bye"), "{json}");
+
+    // Delete the "greeting" key → both locales' overrides removed.
+    let removed = apply_deletes(&p, &["greeting".to_owned()]).await.unwrap();
+    assert_eq!(removed, 2, "greeting had en + fr overrides");
+    let rows = editor_rows(&p).await.unwrap();
+    assert!(
+        rows.iter().all(|(_, k, _)| k != "greeting"),
+        "greeting gone: {rows:?}"
+    );
+    assert_eq!(rows.len(), 1, "only en.bye remains");
+
+    // Deleting an unknown key is a no-op (0 rows).
+    assert_eq!(apply_deletes(&p, &["nope".to_owned()]).await.unwrap(), 0);
 }


### PR DESCRIPTION
## What

Rounds out the Slice 2 editor (#1006) with the remaining edit operations and a write gate. Stacked on #1006 (merged) — this PR is the Slice 3 delta only.

## Changes

- **Delete a key** — a per-row checkbox (`delkey:<key>`) removes every locale's override for that key. `db::delete_key_pool` is the tri-dialect primitive (`DeleteQuery` WHERE key=?, via `crate::sql::delete_pool`); `admin::apply_deletes` loops it. The shipped file-catalog default is untouched, so a deleted key falls back to its file value.
- **Add a key** — an editor footer row (`newkey` + `newval:<locale>`) upserts a brand-new key across the active locales. `parse_new_key` trims the key and skips empty values.
- **Export JSON** — `export_json` renders the catalog locale-keyed (`{locale: {key: value}}`, `BTreeMap`-sorted → deterministic); served at `GET {admin_prefix}/rustango_translations/export.json`.
- **Write gate** — `editor_post` now requires a **superuser**: reads the live `AdminSession` from request extensions (inserted by the admin login gate), 403s non-superusers, and records the operator's username as `updated_by` (was hard-coded `"admin"`). Reads (grid + export) stay at the login gate.

POST applies edits + the new key (upserts), then deletes **last**, so a key both edited and delete-checked in one submit ends up deleted.

## Feature gating

Pure logic (`parse_new_key` / `parse_deletes` / `export_json`) stays feature-ungated and unit-tested; handlers + the export registration are `#[cfg(feature = "admin")]`. Builds **with and without** `admin` (verified `--features sqlite,tenancy` and `…,admin`).

## Tests

- 5 new unit tests (render controls present / `parse_new_key` incl. trim + empty-value skip / `parse_deletes` / `export_json` shape + gap).
- The live test (`i18n_admin_editor_sqlite_live`, already wired into `sqlite_live`) gains a delete + export round-trip: delete removes both locales, unknown-key delete is a no-op.
- Gates: 81 i18n lib tests, 2 live tests, fmt clean, `cargo test --workspace --all-features --no-run`.

## Still tracked on #532

The `seed-translations` manage verb (needs a locales-dir wired into the `Cli`) and a fine-grained `auth.edit_translations` permission codename (superuser is the gate for now).