### PR TITLE
feat(viewset): LimitOffset pagination — #1010 (DRF parity)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_choices
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test auth_signals
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_cursor_pagination_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_limit_offset_pagination_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_db_comment
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_verbose_name
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_meta_verbose_name

--- a/crates/rustango/src/list_params.rs
+++ b/crates/rustango/src/list_params.rs
@@ -37,7 +37,15 @@ use crate::core::{ModelSchema, OrderItem};
 /// Reserved query-string keys that NEVER match a model field — they
 /// drive pagination, sort, search, and cursor flow. List handlers
 /// must skip these when interpreting params as filter clauses.
-pub const RESERVED_LIST_KEYS: &[&str] = &["page", "page_size", "ordering", "search", "cursor"];
+pub const RESERVED_LIST_KEYS: &[&str] = &[
+    "page",
+    "page_size",
+    "ordering",
+    "search",
+    "cursor",
+    "limit",
+    "offset",
+];
 
 /// `true` when `key` is one of [`RESERVED_LIST_KEYS`]. Use to gate
 /// filter parsing:
@@ -126,7 +134,15 @@ mod tests {
 
     #[test]
     fn reserved_keys_match_documented_set() {
-        for k in ["page", "page_size", "ordering", "search", "cursor"] {
+        for k in [
+            "page",
+            "page_size",
+            "ordering",
+            "search",
+            "cursor",
+            "limit",
+            "offset",
+        ] {
             assert!(is_reserved_list_key(k), "{k} should be reserved");
         }
         assert!(!is_reserved_list_key("name"));

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -60,6 +60,23 @@
 //!
 //! Response: `{"page_size": S, "next": "<token>" \| null, "results": [...]}`
 //!
+//! ### Limit/offset pagination (opt-in)
+//!
+//! Enable via `.limit_offset_pagination()`. DRF-shape `?limit=&offset=`
+//! windowing — handy for tables/grids that page by row offset rather
+//! than page number. Runs `COUNT(*)` per request (same cost as
+//! page-number).
+//!
+//! | Parameter | Default | Description |
+//! |---|---|---|
+//! | `limit` | configured default | Items to return (capped at 1000) |
+//! | `offset` | 0 | Rows to skip before the window |
+//! | `ordering` | configured default | Comma-separated field names, prefix `-` for DESC |
+//! | `search` | — | Full-text search across `search_fields` |
+//! | `{field}` | — | Exact filter for any `filter_fields` |
+//!
+//! Response: `{"count": N, "limit": L, "offset": O, "results": [...]}`
+//!
 //! ## Permissions
 //!
 //! Pair with [`RouterAuthExt`](crate::tenancy::middleware::RouterAuthExt)
@@ -137,6 +154,11 @@ pub enum PaginationStyle {
         /// of `>`. Default ordering is set automatically to match.
         desc: bool,
     },
+    /// DRF-shape limit/offset windowing — `?limit=20&offset=40`. Returns
+    /// `count` + `limit` + `offset` in the response. Runs `COUNT(*)` per
+    /// request (same cost as [`PaginationStyle::PageNumber`]); pick it
+    /// when callers think in row offsets rather than page numbers.
+    LimitOffset,
 }
 
 impl PaginationStyle {
@@ -156,6 +178,12 @@ impl PaginationStyle {
     #[must_use]
     pub const fn cursor_desc(field: &'static str) -> Self {
         Self::Cursor { field, desc: true }
+    }
+
+    /// DRF-shape limit/offset pagination.
+    #[must_use]
+    pub const fn limit_offset() -> Self {
+        Self::LimitOffset
     }
 }
 
@@ -272,6 +300,15 @@ impl ViewSet {
     #[must_use]
     pub fn cursor_pagination_desc(mut self, field: &'static str) -> Self {
         self.pagination = PaginationStyle::Cursor { field, desc: true };
+        self
+    }
+
+    /// Switch to DRF-shape limit/offset pagination — `?limit=&offset=`.
+    /// Like page-number it runs `COUNT(*)` per request, but callers
+    /// window by row offset instead of page index.
+    #[must_use]
+    pub fn limit_offset_pagination(mut self) -> Self {
+        self.pagination = PaginationStyle::LimitOffset;
         self
     }
 
@@ -1045,6 +1082,43 @@ async fn handle_list(
                 *desc,
             )
             .await
+        }
+        PaginationStyle::LimitOffset => {
+            // `?limit=` overrides the default page size; `?offset=` skips
+            // rows. Same `COUNT(*)` cost as page-number pagination.
+            let limit: i64 = params
+                .get("limit")
+                .and_then(|p| p.parse().ok())
+                .unwrap_or(page_size)
+                .min(1000)
+                .max(1);
+            let offset: i64 = params
+                .get("offset")
+                .and_then(|p| p.parse().ok())
+                .unwrap_or(0)
+                .max(0);
+
+            let select_q = SelectQuery {
+                where_clause: where_clause.clone(),
+                search: search_clause.clone(),
+                order_by,
+                limit: Some(limit),
+                offset: Some(offset),
+                ..SelectQuery::new(state.vs.schema)
+            };
+            let count_q = CountQuery {
+                model: state.vs.schema,
+                where_clause,
+                search: search_clause,
+            };
+            let results = or_500!(acq.select_rows_as_json(&select_q, &fields).await);
+            let count = or_500!(acq.count_rows(&count_q).await);
+            json_response(json!({
+                "count": count,
+                "limit": limit,
+                "offset": offset,
+                "results": results,
+            }))
         }
     }
 }

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -165,6 +165,16 @@ impl ViewSet {
                         .description("Items per page (max 1000)"),
                 );
             }
+            PaginationStyle::LimitOffset => {
+                out.push(
+                    Parameter::query("limit", Schema::int32())
+                        .description("Items to return (max 1000)"),
+                );
+                out.push(
+                    Parameter::query("offset", Schema::int32())
+                        .description("Rows to skip before the window"),
+                );
+            }
         }
         // Search
         if !self.search_fields.is_empty() {
@@ -227,6 +237,12 @@ impl ViewSet {
                 .property("next", Schema::string().nullable())
                 .property("results", items)
                 .required(["page_size", "results"]),
+            PaginationStyle::LimitOffset => Schema::object()
+                .property("count", Schema::integer())
+                .property("limit", Schema::int32())
+                .property("offset", Schema::int32())
+                .property("results", items)
+                .required(["count", "limit", "offset", "results"]),
         }
     }
 }

--- a/crates/rustango/tests/viewset_limit_offset_pagination_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_limit_offset_pagination_sqlite_live.rs
@@ -1,0 +1,155 @@
+//! End-to-end live test for `ViewSet::limit_offset_pagination()` on
+//! SQLite (Django-parity #1010). DRF-shape `?limit=&offset=` windowing:
+//! asserts the window walks by offset, echoes `count`/`limit`/`offset`,
+//! defaults sensibly, and clamps hostile bounds.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy", feature = "serializer"))]
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use rustango::core::Model as _;
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use serde_json::Value;
+use tower::ServiceExt as _;
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "vs_lo_post")]
+#[rustango(app = "vs_lo_app")]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+async fn make_router_and_pool(page_size: usize) -> axum::Router {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE vs_lo_post (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            title TEXT NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .expect("create");
+    let pool = Pool::Sqlite(sq);
+    rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(page_size)
+        .limit_offset_pagination()
+        .router_pool("/posts", pool)
+}
+
+async fn body_json(resp: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .expect("body bytes");
+    serde_json::from_slice(&bytes).expect("json")
+}
+
+fn get(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn seed(app: &axum::Router, n: usize) {
+    for i in 1..=n {
+        let body = format!(r#"{{"title":"post-{i}"}}"#);
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/posts")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(resp.status().is_success(), "seed {i} failed");
+    }
+}
+
+fn ids(body: &Value) -> Vec<i64> {
+    body["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .map(|r| r["id"].as_i64().expect("id"))
+        .collect()
+}
+
+#[tokio::test]
+async fn limit_offset_windows_rows_by_offset() {
+    let app = make_router_and_pool(5).await;
+    seed(&app, 12).await;
+
+    // limit=5, offset=0 → ids 1..=5, total count 12.
+    let body = body_json(app.clone().oneshot(get("/posts?limit=5")).await.unwrap()).await;
+    assert_eq!(body["count"], 12);
+    assert_eq!(body["limit"], 5);
+    assert_eq!(body["offset"], 0);
+    assert_eq!(ids(&body), vec![1, 2, 3, 4, 5]);
+
+    // limit=5, offset=5 → ids 6..=10.
+    let body = body_json(
+        app.clone()
+            .oneshot(get("/posts?limit=5&offset=5"))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(body["count"], 12);
+    assert_eq!(body["offset"], 5);
+    assert_eq!(ids(&body), vec![6, 7, 8, 9, 10]);
+
+    // limit=5, offset=10 → partial tail ids 11..=12.
+    let body = body_json(
+        app.clone()
+            .oneshot(get("/posts?limit=5&offset=10"))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(body["count"], 12);
+    assert_eq!(ids(&body), vec![11, 12]);
+}
+
+#[tokio::test]
+async fn limit_offset_defaults_to_page_size_and_zero_offset() {
+    let app = make_router_and_pool(3).await;
+    seed(&app, 5).await;
+
+    // No params → limit defaults to the configured page_size (3), offset 0.
+    let resp = app.clone().oneshot(get("/posts")).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["count"], 5);
+    assert_eq!(body["limit"], 3);
+    assert_eq!(body["offset"], 0);
+    assert_eq!(ids(&body), vec![1, 2, 3]);
+}
+
+#[tokio::test]
+async fn limit_offset_clamps_hostile_bounds() {
+    let app = make_router_and_pool(10).await;
+    seed(&app, 4).await;
+
+    // limit above the 1000 cap clamps to 1000; offset below 0 clamps to 0.
+    let body = body_json(
+        app.clone()
+            .oneshot(get("/posts?limit=999999&offset=-5"))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(body["limit"], 1000);
+    assert_eq!(body["offset"], 0);
+    assert_eq!(ids(&body), vec![1, 2, 3, 4]);
+}


### PR DESCRIPTION
## What

Adds DRF-shape **limit/offset pagination** — the third pagination style alongside the existing PageNumber + Cursor. Advances #1010.

## How

- `PaginationStyle::LimitOffset` variant + `PaginationStyle::limit_offset()` + `ViewSet::limit_offset_pagination()` builder.
- New `handle_list` arm: `?limit=` (defaults to the configured `page_size`, capped at 1000, floored at 1) + `?offset=` (defaults 0, floored at 0). Response: `{"count": N, "limit": L, "offset": O, "results": [...]}`. Same `COUNT(*)` cost as PageNumber (mirrors that arm exactly bar the params + response keys).
- `limit` / `offset` added to `list_params::RESERVED_LIST_KEYS` so they're never treated as filter fields — single source of truth shared by ViewSet + the `ListView` CBV.
- OpenAPI: the two exhaustive matches in `viewset/openapi.rs` (`list_query_params` + `list_response_schema`) document the new params + response shape.

Tri-dialect — rides the existing `SelectQuery` `limit`/`offset` fields, no new SQL.

## Tests

- `viewset_limit_offset_pagination_sqlite_live`: window-walk by offset (12 rows, limit=5), default-to-page_size + zero-offset, and hostile-bound clamping (`?limit=999999&offset=-5` → 1000/0). Wired into the `sqlite_live` CI job.
- Extended the `list_params` reserved-keys unit test to cover `limit`/`offset`.
- Gates: lib tests, fmt, clippy, `cargo test --workspace --all-features --no-run`.

## Scope

One of four items in #1010. Remaining (separate PRs): per-action throttling, pluggable filter backends, serializer JSON-Schema export.