### PR TITLE
feat(viewset): pluggable filter backends — #1010 (DRF parity)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test auth_signals
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_cursor_pagination_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_limit_offset_pagination_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test viewset_filter_backend_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_db_comment
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_verbose_name
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_meta_verbose_name

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -203,6 +203,59 @@ impl PaginationStyle {
 #[cfg(feature = "postgres")]
 type RowRender = std::sync::Arc<dyn Fn(&crate::sql::sqlx::postgres::PgRow) -> Value + Send + Sync>;
 
+/// A pluggable filter backend (DRF `BaseFilterBackend` parity, #1010).
+///
+/// Registered on a [`ViewSet`] via [`ViewSet::filter_backend`], a backend
+/// contributes extra `WHERE` predicates from the list request's query
+/// params. Its predicates are `AND`-ed with the built-in exact / lookup
+/// filters — use it for what the `filter_fields` surface can't express
+/// (a geo-radius, a custom `?q=` DSL, request-scoped row visibility, …).
+///
+/// Any `Fn(&HashMap<String, String>, &'static ModelSchema) -> Vec<WhereExpr>`
+/// is a backend via the blanket impl below, so a closure works directly:
+///
+/// ```ignore
+/// use rustango::core::{Filter, Op, SqlValue, WhereExpr};
+/// ViewSet::for_model(Post::SCHEMA)
+///     .filter_backend(|params: &HashMap<String, String>, schema| {
+///         // hide drafts unless ?include_drafts=1
+///         if params.get("include_drafts").map(String::as_str) == Some("1") {
+///             return Vec::new();
+///         }
+///         schema.field("status").map_or_else(Vec::new, |f| {
+///             vec![WhereExpr::Predicate(Filter {
+///                 column: f.column,
+///                 op: Op::Eq,
+///                 value: SqlValue::from("published"),
+///             })]
+///         })
+///     })
+///     .router_pool("/posts", pool);
+/// ```
+///
+/// Backends run on the **list** action.
+pub trait ViewSetFilter: Send + Sync + 'static {
+    /// Return `WHERE` predicates to AND into the list query for this request.
+    fn filter(
+        &self,
+        params: &HashMap<String, String>,
+        schema: &'static ModelSchema,
+    ) -> Vec<WhereExpr>;
+}
+
+impl<F> ViewSetFilter for F
+where
+    F: Fn(&HashMap<String, String>, &'static ModelSchema) -> Vec<WhereExpr> + Send + Sync + 'static,
+{
+    fn filter(
+        &self,
+        params: &HashMap<String, String>,
+        schema: &'static ModelSchema,
+    ) -> Vec<WhereExpr> {
+        self(params, schema)
+    }
+}
+
 /// Builder for a set of REST CRUD endpoints over a single [`Model`] table.
 ///
 /// Call `.router(prefix, pool)` when done to get an `axum::Router`.
@@ -222,6 +275,9 @@ pub struct ViewSet {
     perms: ViewSetPerms,
     read_only: bool,
     pagination: PaginationStyle,
+    /// Pluggable filter backends (#1010) — each contributes extra `WHERE`
+    /// predicates on the list action, ANDed with the built-in filters.
+    filter_backends: Vec<std::sync::Arc<dyn ViewSetFilter>>,
     /// When set (PG only), list / retrieve responses run each row
     /// through this callback instead of the default field-level
     /// projection. Wired via [`Self::serializer`].
@@ -243,6 +299,7 @@ impl ViewSet {
             perms: ViewSetPerms::default(),
             read_only: false,
             pagination: PaginationStyle::PageNumber,
+            filter_backends: Vec::new(),
             #[cfg(feature = "postgres")]
             row_render: None,
         }
@@ -316,6 +373,17 @@ impl ViewSet {
     #[must_use]
     pub fn pagination(mut self, style: PaginationStyle) -> Self {
         self.pagination = style;
+        self
+    }
+
+    /// Register a pluggable filter backend (DRF `filter_backends` parity,
+    /// #1010). Each backend contributes extra `WHERE` predicates on the
+    /// list action, ANDed with the built-in `filter_fields`. Call
+    /// repeatedly to stack backends; any matching closure works (see
+    /// [`ViewSetFilter`]).
+    #[must_use]
+    pub fn filter_backend(mut self, backend: impl ViewSetFilter) -> Self {
+        self.filter_backends.push(std::sync::Arc::new(backend));
         self
     }
 
@@ -962,6 +1030,12 @@ async fn handle_list(
         if let Some(predicate) = build_lookup_filter(field, lookup, raw_val) {
             filters.push(predicate);
         }
+    }
+
+    // #1010 — pluggable filter backends contribute extra predicates,
+    // ANDed with the built-in filter_fields parsed above.
+    for backend in &state.vs.filter_backends {
+        filters.extend(backend.filter(&params, state.vs.schema));
     }
 
     let where_clause = if filters.len() == 1 {

--- a/crates/rustango/tests/viewset_filter_backend_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_filter_backend_sqlite_live.rs
@@ -1,0 +1,152 @@
+//! End-to-end live test for `ViewSet::filter_backend(...)` on SQLite
+//! (DRF `filter_backends` parity, #1010). A registered backend
+//! contributes extra `WHERE` predicates on the list action, ANDed with
+//! the built-in `filter_fields`.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy", feature = "serializer"))]
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use rustango::core::{Filter, Model as _, Op, SqlValue, WhereExpr};
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use serde_json::Value;
+use std::collections::HashMap;
+use tower::ServiceExt as _;
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "vs_fb_post")]
+#[rustango(app = "vs_fb_app")]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 20)]
+    pub status: String,
+}
+
+/// Backend: hide non-`published` rows unless `?include_drafts=1`.
+fn published_only(
+    params: &HashMap<String, String>,
+    schema: &'static rustango::core::ModelSchema,
+) -> Vec<WhereExpr> {
+    if params.get("include_drafts").map(String::as_str) == Some("1") {
+        return Vec::new();
+    }
+    schema.field("status").map_or_else(Vec::new, |f| {
+        vec![WhereExpr::Predicate(Filter {
+            column: f.column,
+            op: Op::Eq,
+            value: SqlValue::from("published"),
+        })]
+    })
+}
+
+async fn router() -> axum::Router {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE vs_fb_post (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            title TEXT NOT NULL, \
+            status TEXT NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .expect("create");
+    let pool = Pool::Sqlite(sq);
+    rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(100)
+        .filter_fields(&["title"])
+        .filter_backend(published_only)
+        .router_pool("/posts", pool)
+}
+
+async fn body_json(resp: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .expect("body bytes");
+    serde_json::from_slice(&bytes).expect("json")
+}
+
+fn get(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn seed(app: &axum::Router, title: &str, status: &str) {
+    let body = format!(r#"{{"title":"{title}","status":"{status}"}}"#);
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/posts")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "seed {title} failed");
+}
+
+fn count(body: &Value) -> usize {
+    body["results"].as_array().expect("results").len()
+}
+
+#[tokio::test]
+async fn filter_backend_constrains_list_by_default() {
+    let app = router().await;
+    seed(&app, "a", "published").await;
+    seed(&app, "b", "published").await;
+    seed(&app, "c", "published").await;
+    seed(&app, "d", "draft").await;
+    seed(&app, "e", "draft").await;
+
+    // Default: backend hides the 2 drafts → 3 published.
+    let body = body_json(app.clone().oneshot(get("/posts")).await.unwrap()).await;
+    assert_eq!(body["count"], 3, "backend should hide drafts: {body}");
+    assert_eq!(count(&body), 3);
+    assert!(body["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|r| r["status"] == "published"));
+
+    // Escape hatch: ?include_drafts=1 disables the backend → all 5.
+    let body = body_json(
+        app.clone()
+            .oneshot(get("/posts?include_drafts=1"))
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(body["count"], 5);
+}
+
+#[tokio::test]
+async fn filter_backend_ands_with_builtin_filter_fields() {
+    let app = router().await;
+    seed(&app, "shared", "published").await;
+    seed(&app, "shared", "draft").await;
+
+    // ?title=shared matches both rows, but the backend AND-s status=published.
+    let resp = app
+        .clone()
+        .oneshot(get("/posts?title=shared"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(
+        body["count"], 1,
+        "title filter AND status=published: {body}"
+    );
+    assert_eq!(body["results"][0]["status"], "published");
+}


### PR DESCRIPTION
## What

DRF `filter_backends` / `BaseFilterBackend` parity. Register backends on a ViewSet that contribute extra `WHERE` predicates on the **list** action, ANDed with the built-in `filter_fields`. For filtering the exact/lookup surface can't express — geo-radius, a custom `?q=` DSL, request-scoped row visibility, etc. Advances #1010.

## How

- **`ViewSetFilter` trait** — `filter(&params, schema) -> Vec<WhereExpr>`, with a **blanket impl for any matching closure**, so `.filter_backend(|p, s| …)` works directly with no wrapper type.
- **`ViewSet::filter_backend(impl ViewSetFilter)`** builder (stackable) + `filter_backends: Vec<Arc<dyn ViewSetFilter>>` on the struct (rides the existing `#[derive(Clone)]`).
- `handle_list` extends the built-in filter set with each backend's predicates before folding into the WHERE clause.

Mirrors the admin's `register_admin_queryset!` request-aware WHERE hook, but per-ViewSet-instance (the natural shape for the builder API). Tri-dialect (no new SQL).

## Tests

`viewset_filter_backend_sqlite_live`: a backend hides drafts by default + reveals them via `?include_drafts=1`; and ANDs correctly with a built-in `?title=` exact filter. Wired into `sqlite_live`. Gates: build, fmt, clippy, `cargo test --workspace --all-features --no-run`.

## #1010 status

- ✅ LimitOffset pagination (#1020, merged)
- ✅ Pluggable filter backends (this PR)
- ⏳ Per-action throttling (next PR)
- ℹ️ Serializer JSON-Schema export — **already shipped**: the macro derives `OpenApiSchema for <Serializer>` under the `openapi` feature, so `S::openapi_schema().to_json()` yields a JSON-Schema-2020-12-dialect document. Will note on #1010 rather than duplicate.