### PR TITLE
feat(admin): in-admin model reference (admindocs) — closes #1011

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,7 @@ jobs:
             --test admin_search_help_text_sqlite_live \
             --test admin_actions_position_sqlite_live \
             --test admin_date_hierarchy_sqlite_live \
+            --test admin_docs_sqlite_live \
             --test admin_prepopulated_sqlite_live \
             --test admin_raw_id_fields_sqlite_live \
             --test admin_autocomplete_sqlite_live \

--- a/crates/rustango/src/admin/docs.rs
+++ b/crates/rustango/src/admin/docs.rs
@@ -1,0 +1,76 @@
+//! `GET <admin_prefix>/__docs` — in-admin model reference (Django
+//! `django.contrib.admindocs` parity, #1011).
+//!
+//! Renders a read-only reference of every registered, *visible* model
+//! grouped by Django-shape app label, with each field's column / type /
+//! key / nullability / relation. The data is what the admin registry
+//! already holds (the `ModelEntry` inventory + each `ModelSchema`), so
+//! this is pure presentation — no DB I/O.
+//!
+//! Scope: the **models** reference. Django's admindocs also documents
+//! views and template tags/filters; those are out of scope for v1
+//! (axum routes aren't enumerable at runtime the way Django's URLconf
+//! is, and the Tera filter/tag set isn't introspectable).
+
+use axum::extract::State;
+use axum::response::Html;
+use serde_json::json;
+
+use super::helpers::{chrome_context, inventory_entries_dedup_by_table};
+use super::templates::render_with_chrome;
+use super::urls::AppState;
+use crate::core::Relation;
+
+pub(crate) async fn docs_view(State(state): State<AppState>) -> Html<String> {
+    // Group registered models by app label — same grouping the sidebar
+    // uses — preserving registration order within each app.
+    let mut by_app: indexmap::IndexMap<String, Vec<serde_json::Value>> = indexmap::IndexMap::new();
+    for entry in inventory_entries_dedup_by_table() {
+        let schema = entry.schema;
+        // Respect the admin's table visibility allow/deny config so the
+        // docs page never reveals a model the operator hid.
+        if !state.is_visible(schema.table) {
+            continue;
+        }
+        let app = entry.resolved_app_label().unwrap_or("(project)").to_owned();
+        let fields: Vec<serde_json::Value> = schema
+            .fields
+            .iter()
+            .map(|f| {
+                let relation = match &f.relation {
+                    Some(Relation::Fk { to, on }) => format!("FK → {to}.{on}"),
+                    Some(Relation::O2O { to, on }) => format!("O2O → {to}.{on}"),
+                    None => String::new(),
+                };
+                json!({
+                    "name": f.name,
+                    "column": f.column,
+                    "type": f.ty.to_string(),
+                    "pk": f.primary_key,
+                    "nullable": f.nullable,
+                    "unique": f.unique,
+                    "relation": relation,
+                })
+            })
+            .collect();
+        by_app.entry(app).or_default().push(json!({
+            "model": schema.name,
+            "table": schema.table,
+            "fields": fields,
+        }));
+    }
+
+    let apps: Vec<serde_json::Value> = by_app
+        .into_iter()
+        .map(|(app, models)| json!({ "app": app, "models": models }))
+        .collect();
+
+    let mut ctx = json!({ "apps": apps });
+    Html(render_with_chrome(
+        "docs.html",
+        &mut ctx,
+        // `__docs` highlights the sidebar "Model reference" link and
+        // matches no real table, so no model row is falsely activated.
+        chrome_context(&state, Some("__docs")),
+    ))
+}

--- a/crates/rustango/src/admin/mod.rs
+++ b/crates/rustango/src/admin/mod.rs
@@ -44,6 +44,7 @@ mod auth;
 pub mod computed_fields;
 pub mod custom_views;
 mod date_hierarchy;
+mod docs;
 mod errors;
 mod forms;
 mod helpers;

--- a/crates/rustango/src/admin/templates.rs
+++ b/crates/rustango/src/admin/templates.rs
@@ -40,6 +40,7 @@ fn templates() -> &'static tera::Tera {
                 include_str!("templates/change_password.html"),
             ),
             ("audit_log.html", include_str!("templates/audit_log.html")),
+            ("docs.html", include_str!("templates/docs.html")),
             // Issue #367 — TOTP two-factor enrollment page.
             (
                 "totp_enroll.html",

--- a/crates/rustango/src/admin/templates/_sidebar.html
+++ b/crates/rustango/src/admin/templates/_sidebar.html
@@ -10,6 +10,11 @@
         <a href="{{ admin_prefix }}{{ audit_url }}"
            class="{% if active_table == '__audit' %}active{% endif %}">Activity</a>
     </p>
+    <p>
+        {# #1011 — in-admin model reference (Django admindocs). #}
+        <a href="{{ admin_prefix }}/__docs"
+           class="{% if active_table == '__docs' %}active{% endif %}">Model reference</a>
+    </p>
     {# #253 follow-up — Change-password link moved into the
        Logout form at the bottom of the sidebar to keep all
        account actions in one place. The old standalone <p>

--- a/crates/rustango/src/admin/templates/docs.html
+++ b/crates/rustango/src/admin/templates/docs.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}Model reference — {{ admin_title }}{% endblock title %}
+{% block body %}
+<nav class="breadcrumb" aria-label="breadcrumb">
+  <ol>
+    <li><a href="{{ admin_prefix }}/">{{ admin_title }}</a></li>
+    <li><strong>Model reference</strong></li>
+  </ol>
+</nav>
+<h1>Model reference</h1>
+<p>{{ apps | length }} app{% if apps | length != 1 %}s{% endif %} &middot; every registered model and its fields.</p>
+
+{% for app in apps %}
+<section class="docs-app">
+  <h2>{{ app.app }}</h2>
+  {% for m in app.models %}
+  <h3><code>{{ m.model }}</code> <span class="docs-table">{{ m.table }}</span></h3>
+  <table class="docs-fields">
+    <thead>
+      <tr><th>field</th><th>column</th><th>type</th><th>flags</th><th>relation</th></tr>
+    </thead>
+    <tbody>
+    {% for f in m.fields %}
+      <tr>
+        <td><code>{{ f.name }}</code></td>
+        <td><code>{{ f.column }}</code></td>
+        <td>{{ f.type }}</td>
+        <td>{% if f.pk %}PK {% endif %}{% if f.unique %}unique {% endif %}{% if f.nullable %}nullable{% endif %}</td>
+        <td>{{ f.relation }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  {% endfor %}
+</section>
+{% endfor %}
+{% endblock body %}

--- a/crates/rustango/src/admin/urls.rs
+++ b/crates/rustango/src/admin/urls.rs
@@ -647,6 +647,8 @@ impl Builder {
                 &audit_cleanup_path,
                 post(super::audit::audit_cleanup_submit),
             )
+            // #1011 — in-admin model reference (Django admindocs).
+            .route("/__docs", get(super::docs::docs_view))
             .route(
                 "/{table}",
                 get(views::table_view).post(views::create_submit),

--- a/crates/rustango/tests/admin_docs_sqlite_live.rs
+++ b/crates/rustango/tests/admin_docs_sqlite_live.rs
@@ -1,0 +1,79 @@
+//! End-to-end live test for the in-admin model reference (`/__docs`,
+//! Django `admindocs` parity, #1011). Builds an admin (no session auth →
+//! open routes), hits `/__docs`, and asserts the registered models +
+//! their fields / types / key-flags / relations render.
+
+#![cfg(all(feature = "sqlite", feature = "admin", feature = "tenancy"))]
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use http_body_util::BodyExt;
+use rustango::sql::Pool;
+use rustango::Model;
+use tower::ServiceExt as _;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(
+    table = "adoc_category",
+    app = "adoc_app",
+    admin(list_display = "name")
+)]
+pub struct AdocCategory {
+    #[rustango(primary_key)]
+    id: rustango::Auto<i64>,
+    #[rustango(max_length = 100)]
+    name: String,
+}
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "adoc_post", app = "adoc_app", admin(list_display = "title"))]
+pub struct AdocPost {
+    #[rustango(primary_key)]
+    id: rustango::Auto<i64>,
+    #[rustango(max_length = 200)]
+    title: String,
+    #[rustango(fk = "adoc_category", on = "id")]
+    category_id: i64,
+}
+
+async fn docs_html() -> String {
+    let pool = Pool::connect("sqlite::memory:").await.expect("sqlite pool");
+    let app = rustango::admin::Builder::new(pool).admin_prefix("").build();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/__docs")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "/__docs should render");
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    String::from_utf8(bytes.to_vec()).expect("utf8")
+}
+
+#[tokio::test]
+async fn docs_lists_models_fields_and_relations() {
+    let html = docs_html().await;
+
+    // App grouping + both models present.
+    assert!(html.contains("adoc_app"), "app label missing: {html}");
+    assert!(html.contains("AdocPost"), "model name missing");
+    assert!(html.contains("adoc_post"), "table name missing");
+    assert!(html.contains("AdocCategory"), "second model missing");
+
+    // Fields + their rendered types.
+    assert!(html.contains("title"), "field name missing");
+    assert!(html.contains("String"), "field type missing");
+
+    // PK flag on the id column.
+    assert!(html.contains("PK"), "primary-key flag missing");
+
+    // FK relation rendered (category_id → adoc_category.id).
+    assert!(
+        html.contains("FK → adoc_category.id"),
+        "FK relation missing: {html}"
+    );
+}


### PR DESCRIPTION
## What

Django `django.contrib.admindocs` parity — a read-only **`/__docs`** page in the admin that lists every registered, visible model grouped by app, with each field's column / type / key-flags / relation. Closes #1011.

Pure presentation over the `ModelEntry` inventory the admin already holds — **no DB I/O**.

## How

- **`admin/docs.rs::docs_view`** — walks `inventory_entries_dedup_by_table()`, respects the admin's table-visibility config (hidden models don't appear), groups by `resolved_app_label()`, and renders each field's type (`FieldType: Display`), PK/unique/nullable flags, and `FK →`/`O2O →` relation target.
- **`admin/templates/docs.html`** — extends the admin chrome; mounted at `<admin_prefix>/__docs` on the protected (login-gated) router, beside `/__audit`.
- **Sidebar** gets a "Model reference" link (highlights via `active_table == "__docs"`).

## Scope

The **models** reference. Django's admindocs also documents views + template tags/filters — deferred for v1 (axum routes aren't runtime-enumerable like Django's URLconf, and the Tera filter set isn't introspectable). Noted in the module docs.

## Tests

`admin_docs_sqlite_live` (wired into `sqlite_live`): builds an admin (no session auth → open routes), hits `/__docs`, asserts models + fields + types + PK flag + an FK relation (`FK → adoc_category.id`) render. Gates: build, fmt, clippy, `cargo test --workspace --all-features --no-run`.