### PR TITLE
fix(orm): synthesize __quarter on SQLite — closes #1037

### DIFF
--- a/crates/rustango/src/core/funcs.rs
+++ b/crates/rustango/src/core/funcs.rs
@@ -64,8 +64,9 @@
 //!   MySQL's native `DAYOFWEEK()` returns 1=Sunday; the writer
 //!   subtracts 1 to align with PG's `EXTRACT(DOW)`. SQLite's
 //!   `strftime('%w')` already matches.
-//! - **`extract_quarter` errors on SQLite** — no native quarter
-//!   token; emitter returns `OpNotSupportedInDialect`.
+//! - **`extract_quarter` is cross-dialect** — PG/MySQL use native
+//!   QUARTER extraction; SQLite synthesizes it from the month
+//!   (`((month + 2) / 3)`), matching Django (#1037).
 //! - **⚠ `extract_week` is NOT cross-dialect**. Each backend uses a
 //!   different week-numbering convention (PG: ISO 8601; MySQL:
 //!   Sunday-start range 0–53; SQLite: Monday-start range 00–53). For
@@ -335,9 +336,9 @@ pub fn extract_weekday(arg: impl Into<Expr>) -> Expr {
     unary(ScalarFn::ExtractWeekDay, arg)
 }
 
-/// `EXTRACT(QUARTER FROM x)` — quarter (1–4) as integer.
-/// **Not supported on SQLite** (no native `strftime` token); emits
-/// `OpNotSupportedInDialect`.
+/// `EXTRACT(QUARTER FROM x)` — quarter (1–4) as integer. Cross-dialect:
+/// native on PG/MySQL; on SQLite synthesized from the month as
+/// `((month + 2) / 3)` (#1037).
 #[must_use]
 pub fn extract_quarter(arg: impl Into<Expr>) -> Expr {
     unary(ScalarFn::ExtractQuarter, arg)

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1270,7 +1270,7 @@ impl<T: Model> QuerySet<T> {
     /// | `__isnull` | `<col> IS NULL` / `IS NOT NULL` | value must be `bool` |
     /// | `__between` / `__range` | `<col> BETWEEN ? AND ?` | value must be 2-element `SqlValue::List` |
     /// | `__not_between` / `__not_range` | `<col> NOT BETWEEN ? AND ?` | value must be 2-element `SqlValue::List`. Eloquent `whereNotBetween` parity. |
-    /// | `__year` / `__month` / `__day` / `__hour` / `__minute` / `__second` / `__quarter` / `__week` / `__week_day` | `EXTRACT(<part> FROM <col>) = ?` | scalar value matches the date part (issue #829). Composes with trailing `__gte` / `__lt` / etc. SQLite-unsupported parts (e.g. quarter) error consistently with the underlying fn. |
+    /// | `__year` / `__month` / `__day` / `__hour` / `__minute` / `__second` / `__quarter` / `__week` / `__week_day` | `EXTRACT(<part> FROM <col>) = ?` | scalar value matches the date part (issue #829). Composes with trailing `__gte` / `__lt` / etc. `__quarter` is cross-dialect (SQLite synthesizes it from the month, #1037); `__week` numbering differs per backend. |
     /// | `__date` | `DATE(<col>) = ?` | value is a `chrono::NaiveDate`; strips the time component before comparison. |
     ///
     /// ```ignore

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -2013,15 +2013,13 @@ fn write_function(
                 });
             }
             if b.d.name() == "sqlite" {
-                // SQLite has no quarter token in strftime and no
-                // QUARTER() function. Surface a clear error rather
-                // than synthesize a multi-clause CASE expression.
-                return Err(SqlError::OpNotSupportedInDialect {
-                    op: "EXTRACT(QUARTER) (SQLite has no native quarter token)",
-                    dialect: "sqlite",
-                });
+                // SQLite has no quarter token in strftime; synthesize it
+                // from the month (#1037), matching how Django lowers
+                // `__quarter` on SQLite.
+                write_extract_quarter_sqlite(b, &args[0])
+            } else {
+                write_extract_int(b, kind, args)
             }
-            write_extract_int(b, kind, args)
         }
         F::TruncDate => {
             if args.len() != 1 {
@@ -2923,6 +2921,19 @@ fn write_ts_concat(b: &mut Sql<'_>, args: &[crate::core::Expr]) -> Result<(), Sq
 /// Emit an `EXTRACT(<field> FROM x)` family call. PG uses the SQL
 /// standard syntax + cast to integer; MySQL has direct per-field
 /// functions; SQLite routes through `strftime` + cast.
+/// SQLite quarter synthesis (#1037). SQLite's `strftime` has no quarter
+/// token, so derive it from the month via integer division:
+/// `((month + 2) / 3)` → months 1-3 = Q1, 4-6 = Q2, 7-9 = Q3, 10-12 = Q4.
+/// Mirrors how Django lowers `__quarter` on SQLite. Shared by the
+/// `filter("…__quarter", …)` lookup path and the `extract_quarter()`
+/// projection — both route through the `ExtractQuarter` writer arm.
+fn write_extract_quarter_sqlite(b: &mut Sql<'_>, expr: &crate::core::Expr) -> Result<(), SqlError> {
+    b.sql.push_str("((CAST(strftime('%m', ");
+    write_expr(b, expr, None)?;
+    b.sql.push_str(") AS INTEGER) + 2) / 3)");
+    Ok(())
+}
+
 fn write_extract_int(
     b: &mut Sql<'_>,
     kind: crate::core::ScalarFn,

--- a/crates/rustango/tests/date_functions.rs
+++ b/crates/rustango/tests/date_functions.rs
@@ -202,18 +202,14 @@ fn pg_mysql_extract_quarter_works() {
 }
 
 #[test]
-fn sqlite_extract_quarter_returns_op_not_supported() {
+fn sqlite_extract_quarter_synthesizes_from_month() {
+    // #1037 — SQLite has no quarter token in strftime, so quarter is
+    // synthesized from the month: ((month + 2) / 3).
     let q = update_set(extract_quarter(F("created_at")));
-    let err = Sqlite.compile_update(&q).unwrap_err();
+    let sql = Sqlite.compile_update(&q).unwrap().sql;
     assert!(
-        matches!(
-            err,
-            SqlError::OpNotSupportedInDialect {
-                dialect: "sqlite",
-                ..
-            }
-        ),
-        "expected OpNotSupportedInDialect, got {err:?}",
+        sql.contains("strftime('%m'") && sql.contains("+ 2) / 3"),
+        "expected month-synthesis for quarter, got {sql}",
     );
 }
 

--- a/crates/rustango/tests/django6_json_dates.rs
+++ b/crates/rustango/tests/django6_json_dates.rs
@@ -164,28 +164,27 @@ mod scenarios {
         assert_eq!(ids(rows), vec![1, 2]);
     }
 
-    /// `filter(created__quarter=1)` — PG and MySQL have native
-    /// QUARTER extraction; SQLite's strftime has no quarter code.
-    /// GAP-PIN on SQLite (Django computes quarter on SQLite via a
-    /// CASE rewrite, so this is a real parity gap). Issue #1037.
+    /// `filter(created__quarter=N)` across all three dialects. PG/MySQL
+    /// have native QUARTER extraction; SQLite synthesizes it from the
+    /// month (`((month + 2) / 3)`), matching Django. Issue #1037 — was a
+    /// SQLite gap-pin, now uniform.
     pub async fn check_quarter_dialect_matrix(pool: &Pool) {
-        let res = Doc::objects()
+        // March (rows 1+2) is Q1 on every backend.
+        let q1 = Doc::objects()
             .filter("created__quarter", 1_i64)
             .fetch_pool(pool)
-            .await;
-        if pool.dialect().name() == "sqlite" {
-            let err = res
-                .map(|rows: Vec<Doc>| rows.len())
-                .expect_err("__quarter must error on sqlite");
-            assert!(
-                matches!(err, ExecError::Sql(_)),
-                "expected a writer-side SqlError, got {err:?} — if quarter now \
-                 works on sqlite, update the audit"
-            );
-        } else {
-            let rows = res.expect("__quarter on PG/MySQL");
-            assert_eq!(ids(rows), vec![1, 2], "March is Q1");
-        }
+            .await
+            .expect("__quarter Q1");
+        assert_eq!(ids(q1), vec![1, 2], "March is Q1");
+
+        // July (row 3, seeded 2025-07-01) is Q3 — guards the arithmetic
+        // off-by-one in the SQLite synthesis.
+        let q3 = Doc::objects()
+            .filter("created__quarter", 3_i64)
+            .fetch_pool(pool)
+            .await
+            .expect("__quarter Q3");
+        assert_eq!(ids(q3), vec![3], "July is Q3");
     }
 
     /// Django `.dates("created", "month")` — distinct truncated

--- a/crates/rustango/tests/filter_date_lookup_sqlite_live.rs
+++ b/crates/rustango/tests/filter_date_lookup_sqlite_live.rs
@@ -171,18 +171,19 @@ async fn week_day_lookup_matches_normalized_dow() {
 }
 
 #[tokio::test]
-async fn quarter_lookup_errors_on_sqlite() {
+async fn quarter_lookup_works_on_sqlite() {
     let pool = make_pool().await;
     seed(&pool).await;
 
-    let result = QuerySet::<Event>::default()
+    // #1037 — quarter is synthesized from the month on SQLite. Q2
+    // (Apr–Jun) matches only the June row.
+    let rows = QuerySet::<Event>::default()
         .filter("created__quarter", 2_i64)
         .fetch_pool(&pool)
-        .await;
-    assert!(
-        result.is_err(),
-        "SQLite has no native quarter; should error consistently"
-    );
+        .await
+        .expect("quarter lookup now works on SQLite");
+    let labels: Vec<&str> = rows.iter().map(|e| e.label.as_str()).collect();
+    assert_eq!(labels, vec!["y2026-jun"], "Q2 = June");
 }
 
 // Smoke: keep an unused chrono ref so warnings stay clean if cfg


### PR DESCRIPTION
## What
`filter("…__quarter", N)` and `extract_quarter()` errored on SQLite (strftime has no quarter token). Now synthesized from the month, matching Django's SQLite lowering. Closes #1037.

## How
`ExtractQuarter` writer arm (SQLite branch) → `write_extract_quarter_sqlite`:
```
((CAST(strftime('%m', <expr>) AS INTEGER) + 2) / 3)
```
Integer division → months 1-3 = Q1 … 10-12 = Q4. Shared by the filter-lookup and projection paths. PG/MySQL unchanged (native QUARTER).

## Tests
Flipped `django6_json_dates::check_quarter_dialect_matrix` from a SQLite gap-pin to a uniform assertion on all three dialects (Q1 → [1,2], plus a Q3 → [3] case guarding the arithmetic). **Verified locally on sqlite + pg + mysql.** Doc notes in `funcs.rs` + the `filter()` table updated.