### PR TITLE
fix(orm): JSON negative array index on SQLite — closes #1027

### DIFF
--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -273,10 +273,10 @@ pub enum Expr {
 /// lookups (`{"k": v}` → `JsonPathStep::Key("k")`); indices are array
 /// lookups (`[a, b, c]` → `JsonPathStep::Index(0)`).
 ///
-/// Negative indices follow PG's convention: PG's `->` accepts negative
-/// indices ("count from the end"); MySQL / SQLite emit `$[N]` which
-/// only accepts non-negative — the writer rejects negative indices on
-/// non-PG with a clear error.
+/// Negative indices ("count from the end") work on PG (native `->`) and
+/// SQLite (the `$[#-1]` from-the-end anchor, #1027). MySQL's `$[N]` path
+/// grammar has no negative form, so the writer rejects negative indices
+/// on MySQL with a clear error.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JsonPathStep {
     /// Object key lookup. The string is emitted as a quoted SQL

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -1600,14 +1600,24 @@ fn write_json_path(
             }
             JsonPathStep::Index(n) => {
                 if *n < 0 {
-                    return Err(SqlError::OpNotSupportedInDialect {
-                        op: "JsonPath negative indices are PG-only (MySQL/SQLite require non-negative)",
-                        dialect,
-                    });
+                    // SQLite 3.31+ has the `$[#-1]` "from the end" anchor;
+                    // `n` is already negative so it renders as `[#-1]`
+                    // (#1027). MySQL's `$[N]` grammar has no negative form.
+                    if dialect == "sqlite" {
+                        json_path.push_str("[#");
+                        json_path.push_str(&n.to_string());
+                        json_path.push(']');
+                    } else {
+                        return Err(SqlError::OpNotSupportedInDialect {
+                            op: "JsonPath negative indices are unsupported on MySQL (the $[N] path grammar has no negative form; PG + SQLite support them)",
+                            dialect,
+                        });
+                    }
+                } else {
+                    json_path.push('[');
+                    json_path.push_str(&n.to_string());
+                    json_path.push(']');
                 }
-                json_path.push('[');
-                json_path.push_str(&n.to_string());
-                json_path.push(']');
             }
         }
     }

--- a/crates/rustango/tests/django6_json_dates.rs
+++ b/crates/rustango/tests/django6_json_dates.rs
@@ -6,9 +6,9 @@
 //! - `filter(data__meta__kind="post")` nested key traversal
 //! - `filter(data__items__0__name="x")` key + array-index traversal
 //! - JSON array length lookup (`tags__len__gte` shape)
-//! - negative array indexing — NEW in Django 6.0 for SQLite; rustango
-//!   supports PG only (pinned gap on SQLite + MySQL — MySQL's
-//!   `$[N]` path syntax genuinely can't express it upstream)
+//! - negative array indexing — PG (native) + SQLite (`$[#-1]` anchor,
+//!   Django 6.0 + #1027); MySQL's `$[N]` path syntax genuinely can't
+//!   express it upstream (documented rejection)
 //! - `filter(created__year__gte=...)` / `__month` / `__quarter`
 //!   date-transform chains
 //! - `.dates("created", "month")` / `.datetimes("created", "hour")`
@@ -103,10 +103,10 @@ mod scenarios {
         assert_eq!(ids(rows), vec![1, 3]);
     }
 
-    /// Negative array index (`data__tags__-1`). Django 6.0 added
-    /// SQLite support; rustango emits PG's native negative `->` only.
-    /// GAP-PIN: SQLite (and MySQL, where `$[N]` genuinely can't
-    /// express it) reject with `OpNotSupportedInDialect`. Issue #1027.
+    /// Negative array index (`data__tags__-1`). PG (native `-> -1`) and
+    /// SQLite (the `$[#-1]` from-the-end anchor, Django 6.0 + #1027) both
+    /// resolve it; MySQL's `$[N]` path grammar has no negative form, so
+    /// it stays a documented rejection.
     pub async fn check_negative_index_dialect_matrix(pool: &Pool) {
         let qs = || {
             Doc::objects().where_raw(WhereExpr::ExprCompare {
@@ -119,28 +119,29 @@ mod scenarios {
                 rhs: Expr::Literal(SqlValue::String("c".into())),
             })
         };
-        if pool.dialect().name() == "postgres" {
-            let rows: Vec<Doc> = qs().fetch_pool(pool).await.expect("PG negative index");
-            assert_eq!(ids(rows), vec![1]);
+        let name = pool.dialect().name();
+        if name == "postgres" || name == "sqlite" {
+            let rows: Vec<Doc> = qs()
+                .fetch_pool(pool)
+                .await
+                .expect("negative index (PG / SQLite)");
+            assert_eq!(ids(rows), vec![1], "row 1's last tag is \"c\"");
         } else {
+            // MySQL only — `$[N]` has no negative form upstream.
             let err = qs()
                 .fetch_pool(pool)
                 .await
                 .map(|rows: Vec<Doc>| rows.len())
-                .expect_err("negative index must be rejected off-PG");
+                .expect_err("negative index must be rejected on MySQL");
             match err {
                 ExecError::Sql(SqlError::OpNotSupportedInDialect { op, dialect }) => {
                     assert!(
                         op.contains("negative"),
                         "error should mention negative indices: {op}"
                     );
-                    assert_eq!(dialect, pool.dialect().name());
+                    assert_eq!(dialect, "mysql");
                 }
-                other => panic!(
-                    "expected OpNotSupportedInDialect, got {other:?} — if negative \
-                     JSON indices now work here (Django 6.0 supports them on \
-                     SQLite), update the audit + issue"
-                ),
+                other => panic!("expected OpNotSupportedInDialect on MySQL, got {other:?}"),
             }
         }
     }

--- a/crates/rustango/tests/json_path_lookups.rs
+++ b/crates/rustango/tests/json_path_lookups.rs
@@ -131,15 +131,19 @@ fn array_index_step_emits_per_dialect_form() {
 }
 
 #[test]
-fn negative_index_is_pg_only() {
+fn negative_index_pg_and_sqlite() {
     let e = json_path_indexed(F("data"), [JsonPathStep::Index(-1)], false);
     // PG accepts negative indices natively.
     let pg = pg(&e).unwrap();
     assert!(pg.contains(r#""data" -> -1"#), "PG negative index: {pg}");
-    // MySQL and SQLite must error — their `$[N]` syntax requires non-negative.
-    for err in [my(&e).unwrap_err(), sqlite(&e).unwrap_err()] {
-        assert!(matches!(err, SqlError::OpNotSupportedInDialect { .. }));
-    }
+    // SQLite uses the `$[#-1]` from-the-end anchor (#1027).
+    let sq = sqlite(&e).unwrap();
+    assert!(sq.contains("[#-1]"), "SQLite from-end anchor: {sq}");
+    // MySQL's `$[N]` grammar has no negative form — still rejected.
+    assert!(matches!(
+        my(&e).unwrap_err(),
+        SqlError::OpNotSupportedInDialect { .. }
+    ));
 }
 
 // ---------- Safety guards ----------


### PR DESCRIPTION
## What
Django 6.0 added negative JSON array indexing on SQLite (`data__tags__-1`); rustango only emitted PG's native `-> -1`. Closes #1027.

## How
SQLite 3.31+ has the `$[#-1]` "from the end" anchor. In `write_json_path`'s MySQL/SQLite path builder, `JsonPathStep::Index(n)` with `n < 0` now renders `[#-1]` on SQLite (n is already negative). MySQL's `$[N]` grammar has no negative form upstream → narrowed rejection (names MySQL only). PG untouched. No IR change.

## Tests
Flipped `django6_json_dates::check_negative_index_dialect_matrix`: SQLite joins PG (last tag `"c"` → row 1); MySQL keeps the documented rejection. **Verified on sqlite + pg + mysql.** Doc notes in `expr.rs` + test header updated.