### PR TITLE
fix(orm): MySQL ranking windows decode losslessly (not Bool) — closes #1033

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,15 @@ jobs:
             --test unique_when_sqlite_live \
             --test viewset_sqlite_live \
             --test admin_totp_2fa_sqlite_live \
-            --test admin_totp_2fa_e2e
+            --test admin_totp_2fa_e2e \
+            --test django6_aggregation \
+            --test django6_subquery \
+            --test django6_window \
+            --test django6_joins \
+            --test django6_setops \
+            --test django6_json_dates \
+            --test django6_writes \
+            --test django6_delta
 
   # v0.41 MySQL parity — the marketing claim is tri-dialect end-to-end
   # since v0.38, but every MySQL `_live.rs` test was skipped silently
@@ -302,6 +310,17 @@ jobs:
       - run: cargo test -p rustango --features mysql --test inspectdb_mysql_live
       - run: cargo test -p rustango --features mysql --test funcs_batch1_mysql_live
       - run: cargo test -p rustango --features mysql --test json_path_mysql_live
+      # Django 6.0 ORM parity execution-verification suite (audit §26).
+      # Shared scenario bodies; the mysql cfg-mod runs here, PG mods
+      # skip (DATABASE_URL unset), sqlite mods are compiled out.
+      - run: cargo test -p rustango --features mysql --test django6_aggregation
+      - run: cargo test -p rustango --features mysql --test django6_subquery
+      - run: cargo test -p rustango --features mysql --test django6_window
+      - run: cargo test -p rustango --features mysql --test django6_joins
+      - run: cargo test -p rustango --features mysql --test django6_setops
+      - run: cargo test -p rustango --features mysql --test django6_json_dates
+      - run: cargo test -p rustango --features mysql --test django6_writes
+      - run: cargo test -p rustango --features mysql --test django6_delta
 
   # PostGIS geometry live suite (#443). The regular `postgres_test` runs
   # against `pgvector/pgvector:pg16`, which has no PostGIS, so the

--- a/crates/rustango/src/sql/executor/values.rs
+++ b/crates/rustango/src/sql/executor/values.rs
@@ -64,7 +64,25 @@ fn pg_cell_to_sqlvalue(row: &PgRow, i: usize) -> SqlValue {
 
 #[cfg(feature = "mysql")]
 fn my_cell_to_sqlvalue(row: &sqlx::mysql::MySqlRow, i: usize) -> SqlValue {
-    use sqlx::Row as _;
+    use sqlx::{Column as _, Row as _, TypeInfo as _};
+    // #1033 — MySQL window-ranking outputs (RANK/DENSE_RANK/NTILE) and
+    // COUNT(*) come back as BIGINT UNSIGNED, which the i64 probe below
+    // can't decode; sqlx's permissive bool decode would then swallow
+    // them as `SqlValue::Bool`, making the numeric rank unrecoverable.
+    // Branch on the column type FIRST so unsigned ints decode losslessly
+    // — real BOOLEAN / TINYINT(1) columns aren't UNSIGNED, so they still
+    // fall through to the bool probe below and decode as `Bool`.
+    if row.column(i).type_info().name().contains("UNSIGNED") {
+        if let Ok(v) = row.try_get::<u64, _>(i) {
+            // Ranks are tiny; the String fallback keeps a (theoretical)
+            // value > i64::MAX lossless rather than saturating.
+            return i64::try_from(v)
+                .map_or_else(|_| SqlValue::String(v.to_string()), SqlValue::I64);
+        }
+        if let Ok(v) = row.try_get::<u32, _>(i) {
+            return SqlValue::I64(i64::from(v));
+        }
+    }
     if let Ok(v) = row.try_get::<i64, _>(i) {
         SqlValue::I64(v)
     } else if let Ok(v) = row.try_get::<i32, _>(i) {

--- a/crates/rustango/tests/django6_aggregation.rs
+++ b/crates/rustango/tests/django6_aggregation.rs
@@ -1,0 +1,458 @@
+//! Django 6.0 ORM parity — execution-based verification.
+//! Scenario groups A (conditional aggregation) + F (grouping shapes).
+//!
+//! Each scenario body is shared across the three backends; the
+//! cfg-gated modules at the bottom own pool construction + DDL and
+//! call into `scenarios::check_*`. Where rustango diverges from
+//! Django 6.0 on a given dialect, the scenario pins the *current*
+//! error so the suite goes red the moment the gap is fixed (and the
+//! parity audit row must then be updated).
+//!
+//! Django scenarios covered (docs.djangoproject.com/en/6.0):
+//! - `aggregate(total=Count("id"), published=Count("id", filter=Q(...)))`
+//! - `Sum("price", filter=Q(...), default=0)`
+//! - `Count("category", distinct=True)`
+//! - compound `Q` trees inside `filter=`
+//! - `.values("category").annotate(n=Count("id"), max_price=Max("price"))`
+//! - filter-on-annotation → HAVING routing (WHERE vs HAVING split)
+//! - `.alias()` non-projected annotations
+//! - `StdDev` (sample) — dialect support matrix
+
+#[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
+mod scenarios {
+    use std::collections::HashMap;
+
+    use rustango::core::aggregates::{count, count_all, count_distinct, max, stddev, sum};
+    use rustango::core::{Column as _, Op, SqlValue};
+    use rustango::sql::{Auto, ExecError, Pool, SqlError};
+    use rustango::Model;
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6agg_post")]
+    #[allow(dead_code)]
+    pub struct Post {
+        #[rustango(primary_key)]
+        pub id: Auto<i64>,
+        #[rustango(max_length = 20)]
+        pub status: String,
+        pub is_active: bool,
+        pub price: i64,
+        #[rustango(max_length = 40)]
+        pub category: String,
+    }
+
+    /// (status, is_active, price, category) — 6 rows, 2 categories.
+    const SEED: [(&str, bool, i64, &str); 6] = [
+        ("published", true, 100, "tech"),
+        ("published", true, 200, "tech"),
+        ("draft", true, 50, "tech"),
+        ("published", false, 300, "life"),
+        ("draft", false, 80, "life"),
+        ("review", true, 120, "life"),
+    ];
+
+    pub async fn seed(pool: &Pool) {
+        for (status, active, price, cat) in SEED {
+            let mut p = Post {
+                id: Auto::default(),
+                status: status.into(),
+                is_active: active,
+                price,
+                category: cat.into(),
+            };
+            p.save_pool(pool).await.expect("seed row");
+        }
+    }
+
+    type Row = HashMap<String, SqlValue>;
+
+    /// Aggregate outputs vary in numeric type by backend (PG `SUM` on
+    /// BIGINT → NUMERIC/Decimal, MySQL → DECIMAL, SQLite → INTEGER) —
+    /// normalize for assertions.
+    fn as_i64(row: &Row, key: &str) -> i64 {
+        match row.get(key) {
+            Some(SqlValue::I64(n)) => *n,
+            Some(SqlValue::I32(n)) => i64::from(*n),
+            Some(SqlValue::F64(f)) => *f as i64,
+            Some(SqlValue::Decimal(d)) => d
+                .to_string()
+                .parse::<f64>()
+                .unwrap_or_else(|_| panic!("unparseable decimal at `{key}`: {d}"))
+                as i64,
+            other => panic!("expected numeric at `{key}`, got {other:?}"),
+        }
+    }
+
+    fn as_f64(row: &Row, key: &str) -> f64 {
+        match row.get(key) {
+            Some(SqlValue::F64(f)) => *f,
+            Some(SqlValue::I64(n)) => *n as f64,
+            Some(SqlValue::Decimal(d)) => d
+                .to_string()
+                .parse::<f64>()
+                .unwrap_or_else(|_| panic!("unparseable decimal at `{key}`: {d}")),
+            other => panic!("expected numeric at `{key}`, got {other:?}"),
+        }
+    }
+
+    fn as_str<'r>(row: &'r Row, key: &str) -> &'r str {
+        match row.get(key) {
+            Some(SqlValue::String(s)) => s,
+            other => panic!("expected string at `{key}`, got {other:?}"),
+        }
+    }
+
+    /// Django: `aggregate(total=Count("id"), published=Count("id",
+    /// filter=Q(status="published")))` — total + conditional count in
+    /// one round trip. PG/SQLite emit `FILTER (WHERE …)`; MySQL is
+    /// rewritten to `COUNT(CASE WHEN … THEN id END)`.
+    ///
+    /// DIVERGENCE NOTE (Django 6.0 audit §26): bare
+    /// `.aggregate().annotate(...)` is rustango's Shape-3 (GROUP BY
+    /// every scalar column → per-row results, i.e. Django's
+    /// `.annotate()`); Django's single-row `aggregate()` shape
+    /// requires the explicit `.values(&[])` empty projection.
+    pub async fn check_total_vs_filtered_count(pool: &Pool) {
+        let rows = Post::objects()
+            .aggregate()
+            .values(&[])
+            .annotate("total", count_all().into())
+            .annotate(
+                "published",
+                count("id").filter(Post::status.eq("published")).into(),
+            )
+            .fetch(pool)
+            .await
+            .expect("filtered-count aggregate");
+        assert_eq!(rows.len(), 1, "global aggregate is one row: {rows:?}");
+        assert_eq!(as_i64(&rows[0], "total"), 6);
+        assert_eq!(as_i64(&rows[0], "published"), 3);
+    }
+
+    /// Django: `Sum("price", filter=Q(status="archived"), default=0)`
+    /// — no row matches, so the COALESCE default must surface instead
+    /// of NULL. Pins the `COALESCE(SUM(...) FILTER (...), 0)` wrap
+    /// order.
+    pub async fn check_filtered_sum_default(pool: &Pool) {
+        let rows = Post::objects()
+            .aggregate()
+            .values(&[])
+            .annotate(
+                "archived_revenue",
+                sum("price")
+                    .filter(Post::status.eq("archived"))
+                    .default(0_i64)
+                    .into(),
+            )
+            .fetch(pool)
+            .await
+            .expect("filtered sum with default");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(as_i64(&rows[0], "archived_revenue"), 0);
+    }
+
+    /// Django: `Count("category", distinct=True)` — 6 rows over 2
+    /// distinct categories.
+    pub async fn check_count_distinct(pool: &Pool) {
+        let rows = Post::objects()
+            .aggregate()
+            .values(&[])
+            .annotate("cats", count_distinct("category").into())
+            .fetch(pool)
+            .await
+            .expect("count distinct");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(as_i64(&rows[0], "cats"), 2);
+    }
+
+    /// Compound boolean tree inside `filter=` — exercises the MySQL
+    /// CASE-WHEN rewrite with nested AND/OR. Active AND (published OR
+    /// review) → rows 1, 2, 6.
+    pub async fn check_compound_filter_predicate(pool: &Pool) {
+        let rows = Post::objects()
+            .aggregate()
+            .values(&[])
+            .annotate(
+                "n",
+                count("id")
+                    .filter(
+                        Post::is_active
+                            .eq(true)
+                            .and(Post::status.eq("published").or(Post::status.eq("review"))),
+                    )
+                    .into(),
+            )
+            .fetch(pool)
+            .await
+            .expect("compound FILTER predicate");
+        assert_eq!(as_i64(&rows[0], "n"), 3);
+    }
+
+    /// Django Shape 2: `.values("category").annotate(...)` → GROUP BY
+    /// category. Both groups have 3 rows; max prices differ.
+    pub async fn check_values_annotate_group_by(pool: &Pool) {
+        let rows = Post::objects()
+            .values(&["category"])
+            .annotate("n", count_all().into())
+            .annotate("max_price", max("price").into())
+            .order_by(&[("category", false)])
+            .fetch(pool)
+            .await
+            .expect("values().annotate() group by");
+        assert_eq!(rows.len(), 2, "two categories: {rows:?}");
+        assert_eq!(as_str(&rows[0], "category"), "life");
+        assert_eq!(as_i64(&rows[0], "n"), 3);
+        assert_eq!(as_i64(&rows[0], "max_price"), 300);
+        assert_eq!(as_str(&rows[1], "category"), "tech");
+        assert_eq!(as_i64(&rows[1], "n"), 3);
+        assert_eq!(as_i64(&rows[1], "max_price"), 200);
+    }
+
+    /// WHERE vs HAVING routing: a filter on a real column lands in
+    /// WHERE, a filter on the annotation alias lands in HAVING.
+    /// Published-only per category: tech=2, life=1 → HAVING n >= 2
+    /// keeps tech alone.
+    pub async fn check_filter_on_annotation_routes_to_having(pool: &Pool) {
+        let rows = Post::objects()
+            .values(&["category"])
+            .annotate("n", count_all().into())
+            .filter("status", Op::Eq, "published")
+            .filter("n", Op::Gte, 2_i64)
+            .fetch(pool)
+            .await
+            .expect("WHERE + HAVING split");
+        assert_eq!(rows.len(), 1, "only tech survives HAVING: {rows:?}");
+        assert_eq!(as_str(&rows[0], "category"), "tech");
+        assert_eq!(as_i64(&rows[0], "n"), 2);
+    }
+
+    /// Django 3.2+ `.alias()` — usable in filter/order_by but omitted
+    /// from the SELECT projection.
+    pub async fn check_alias_is_not_projected(pool: &Pool) {
+        let rows = Post::objects()
+            .values(&["category"])
+            .alias("c", count_all().into())
+            .filter("c", Op::Gte, 1_i64)
+            .order_by(&[("c", true)])
+            .fetch(pool)
+            .await
+            .expect("alias non-projected");
+        assert_eq!(rows.len(), 2);
+        for row in &rows {
+            assert!(
+                !row.contains_key("c"),
+                "alias must not be projected: {row:?}"
+            );
+        }
+    }
+
+    /// `StdDev` (sample) dialect matrix: native on PG + MySQL 8;
+    /// SQLite has no built-in stddev — rustango pins the documented
+    /// rejection (matches Django, which also errors on SQLite).
+    pub async fn check_stddev_dialect_matrix(pool: &Pool) {
+        let res = Post::objects()
+            .aggregate()
+            .values(&[])
+            .annotate("sd", stddev("price").into())
+            .fetch(pool)
+            .await;
+        if pool.dialect().name() == "sqlite" {
+            let err = res.expect_err("stddev must be rejected on sqlite");
+            match err {
+                ExecError::Sql(SqlError::AggregateNotSupported { aggregate, dialect }) => {
+                    assert!(
+                        aggregate.to_uppercase().contains("STDDEV"),
+                        "unexpected aggregate name: {aggregate}"
+                    );
+                    assert_eq!(dialect, "sqlite");
+                }
+                other => panic!(
+                    "expected AggregateNotSupported on sqlite, got {other:?} — \
+                     if stddev now works there, update the Django 6.0 parity audit"
+                ),
+            }
+        } else {
+            let rows = res.expect("stddev on PG/MySQL");
+            let sd = as_f64(&rows[0], "sd");
+            // prices 100,200,50,300,80,120 → sample stddev ≈ 92.61
+            assert!(
+                (sd - 92.61).abs() < 0.5,
+                "sample stddev of seed prices ≈ 92.61, got {sd}"
+            );
+        }
+    }
+}
+
+// ------------------------------------------------------------- Postgres
+
+#[cfg(feature = "postgres")]
+mod pg_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let pg = sqlx::PgPool::connect(&url).await.ok()?;
+        sqlx::query(r#"DROP TABLE IF EXISTS "d6agg_post" CASCADE"#)
+            .execute(&pg)
+            .await
+            .unwrap();
+        sqlx::query(
+            r#"CREATE TABLE "d6agg_post" (
+                "id" BIGSERIAL PRIMARY KEY,
+                "status" VARCHAR(20) NOT NULL,
+                "is_active" BOOLEAN NOT NULL,
+                "price" BIGINT NOT NULL,
+                "category" VARCHAR(40) NOT NULL
+            )"#,
+        )
+        .execute(&pg)
+        .await
+        .unwrap();
+        Some(Pool::Postgres(pg))
+    }
+
+    macro_rules! pg_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("DATABASE_URL unset — skipping PG django6 test");
+                    return;
+                };
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    pg_case!(check_total_vs_filtered_count);
+    pg_case!(check_filtered_sum_default);
+    pg_case!(check_count_distinct);
+    pg_case!(check_compound_filter_predicate);
+    pg_case!(check_values_annotate_group_by);
+    pg_case!(check_filter_on_annotation_routes_to_having);
+    pg_case!(check_alias_is_not_projected);
+    pg_case!(check_stddev_dialect_matrix);
+}
+
+// --------------------------------------------------------------- SQLite
+
+#[cfg(feature = "sqlite")]
+mod sqlite_live {
+    use rustango::sql::{sqlx, Pool};
+
+    use super::scenarios;
+
+    async fn fresh_pool() -> Pool {
+        let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite mem pool");
+        sqlx::query(
+            "CREATE TABLE d6agg_post (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                status TEXT NOT NULL,
+                is_active INTEGER NOT NULL,
+                price INTEGER NOT NULL,
+                category TEXT NOT NULL
+            )",
+        )
+        .execute(&sq)
+        .await
+        .expect("ddl");
+        Pool::Sqlite(sq)
+    }
+
+    macro_rules! sqlite_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let pool = fresh_pool().await;
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    sqlite_case!(check_total_vs_filtered_count);
+    sqlite_case!(check_filtered_sum_default);
+    sqlite_case!(check_count_distinct);
+    sqlite_case!(check_compound_filter_predicate);
+    sqlite_case!(check_values_annotate_group_by);
+    sqlite_case!(check_filter_on_annotation_routes_to_having);
+    sqlite_case!(check_alias_is_not_projected);
+    sqlite_case!(check_stddev_dialect_matrix);
+}
+
+// ---------------------------------------------------------------- MySQL
+
+#[cfg(feature = "mysql")]
+mod mysql_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("MYSQL_TEST_URL").ok()?;
+        let my = sqlx::MySqlPool::connect(&url).await.ok()?;
+        sqlx::query("DROP TABLE IF EXISTS d6agg_post")
+            .execute(&my)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE d6agg_post (
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                status VARCHAR(20) NOT NULL,
+                is_active BOOLEAN NOT NULL,
+                price BIGINT NOT NULL,
+                category VARCHAR(40) NOT NULL
+            )",
+        )
+        .execute(&my)
+        .await
+        .unwrap();
+        Some(Pool::Mysql(my))
+    }
+
+    macro_rules! mysql_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("MYSQL_TEST_URL unset — skipping MySQL django6 test");
+                    return;
+                };
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    mysql_case!(check_total_vs_filtered_count);
+    mysql_case!(check_filtered_sum_default);
+    mysql_case!(check_count_distinct);
+    mysql_case!(check_compound_filter_predicate);
+    mysql_case!(check_values_annotate_group_by);
+    mysql_case!(check_filter_on_annotation_routes_to_having);
+    mysql_case!(check_alias_is_not_projected);
+    mysql_case!(check_stddev_dialect_matrix);
+}

--- a/crates/rustango/tests/django6_delta.rs
+++ b/crates/rustango/tests/django6_delta.rs
@@ -1,0 +1,340 @@
+//! Django 6.0 ORM parity — execution-based verification.
+//! Scenario group J: the Django 6.0 release-note delta — features new
+//! or changed in 6.0, each verified or pinned against rustango.
+//!
+//! Release-note items covered here:
+//! - `StringAgg` is database-agnostic in Django 6.0 (was PG-only
+//!   contrib.postgres) — rustango is still PG-only: PINNED GAP on
+//!   MySQL (GROUP_CONCAT) + SQLite (group_concat)
+//! - `GeneratedField` values are refreshed from the database after
+//!   `save()` on RETURNING-capable backends (PG/SQLite) — rustango
+//!   never refreshes: PINNED DIVERGENCE (DB value correct, struct
+//!   stale)
+//! - `DEFAULT_AUTO_FIELD` now defaults to `BigAutoField` — rustango's
+//!   `Auto<i64>` ↔ BIGSERIAL/BIGINT AUTO_INCREMENT already matches
+//!
+//! Release-note items that are compile-time API absences (no runtime
+//! pin possible — audit rows + issues only):
+//! - `AnyValue` aggregate (new in 6.0): no `AggregateExpr` variant. Issue #1025.
+//! - `Aggregate(order_by=...)` (new in 6.0, deprecates PG
+//!   `OrderableAggMixin`): `AggregateExpr::StringAgg` carries no
+//!   ordering (issue #1026) — element order in the joined string is
+//!   backend-arbitrary (tests sort to compensate).
+//! - `Model.NotUpdated` on forced 0-row update — pinned in
+//!   django6_writes.rs::check_zero_row_update_semantics.
+//! - CompositePrimaryKey enhancements (raw(), subquery lookups) — N/A
+//!   by architecture: rustango's composite-key idiom is surrogate
+//!   `Auto<i64>` PK + `unique_together`, so the 6.0 enhancements have
+//!   no surface to land on.
+
+#[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
+mod scenarios {
+    use rustango::core::{AggregateExpr, SqlValue};
+    use rustango::sql::{raw_execute_pool, Auto, ExecError, FetcherPool as _, Pool, SqlError};
+    use rustango::Model;
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6delta_row")]
+    #[allow(dead_code)]
+    pub struct DeltaRow {
+        #[rustango(primary_key)]
+        pub id: i64,
+        #[rustango(max_length = 40)]
+        pub name: String,
+    }
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6delta_invoice")]
+    #[allow(dead_code)]
+    pub struct Invoice {
+        #[rustango(primary_key)]
+        pub id: Auto<i64>,
+        pub price: i64,
+        pub qty: i64,
+        /// Database-computed `price * qty` — the struct carries a
+        /// placeholder; the macro skips the column on INSERT/UPDATE.
+        #[rustango(generated_as = "price * qty")]
+        pub total: i64,
+    }
+
+    pub async fn seed(pool: &Pool) {
+        for sql in [
+            "INSERT INTO d6delta_row (id, name) VALUES (1, 'alpha')",
+            "INSERT INTO d6delta_row (id, name) VALUES (2, 'beta')",
+            "INSERT INTO d6delta_row (id, name) VALUES (3, 'gamma')",
+            "INSERT INTO d6delta_row (id, name) VALUES (4, 'beta')",
+        ] {
+            raw_execute_pool(pool, sql, vec![]).await.expect("seed");
+        }
+    }
+
+    /// Django 6.0: `StringAgg("name", delimiter=Value(","))` works on
+    /// every backend. rustango: PG-only — GAP-PIN on MySQL + SQLite
+    /// (both have native equivalents: GROUP_CONCAT / group_concat). Issue #1024.
+    pub async fn check_string_agg_dialect_matrix(pool: &Pool) {
+        let res = DeltaRow::objects()
+            .aggregate()
+            .values(&[])
+            .annotate("names", AggregateExpr::string_agg("name", ","))
+            .fetch(pool)
+            .await;
+        if pool.dialect().name() == "postgres" {
+            let rows = res.expect("string_agg on PG");
+            let joined = match rows[0].get("names") {
+                Some(SqlValue::String(s)) => s.clone(),
+                other => panic!("expected string names, got {other:?}"),
+            };
+            // No order_by param exists on the aggregate (Django 6.0
+            // Aggregate.order_by gap) — element order is arbitrary,
+            // so sort before asserting.
+            let mut parts: Vec<&str> = joined.split(',').collect();
+            parts.sort_unstable();
+            assert_eq!(parts, vec!["alpha", "beta", "beta", "gamma"]);
+        } else {
+            let err = res.expect_err("string_agg must be rejected off-PG");
+            match err {
+                ExecError::Sql(SqlError::AggregateNotSupportedInDialect { aggregate, dialect }) => {
+                    assert_eq!(aggregate, "string_agg");
+                    assert_eq!(dialect, pool.dialect().name());
+                }
+                other => panic!(
+                    "expected AggregateNotSupportedInDialect, got {other:?} — if \
+                     string_agg now lowers to GROUP_CONCAT here (Django 6.0 made \
+                     StringAgg database-agnostic), update the audit + issue"
+                ),
+            }
+        }
+    }
+
+    /// `string_agg(DISTINCT name, ...)` on PG — the dedup variant.
+    /// Off-PG it is the same pinned gap as above, so only the PG arm
+    /// asserts content.
+    pub async fn check_string_agg_distinct(pool: &Pool) {
+        if pool.dialect().name() != "postgres" {
+            return;
+        }
+        let rows = DeltaRow::objects()
+            .aggregate()
+            .values(&[])
+            .annotate("names", AggregateExpr::string_agg_distinct("name", ","))
+            .fetch(pool)
+            .await
+            .expect("string_agg_distinct on PG");
+        let joined = match rows[0].get("names") {
+            Some(SqlValue::String(s)) => s.clone(),
+            other => panic!("expected string names, got {other:?}"),
+        };
+        let mut parts: Vec<&str> = joined.split(',').collect();
+        parts.sort_unstable();
+        assert_eq!(
+            parts,
+            vec!["alpha", "beta", "gamma"],
+            "duplicate beta deduped"
+        );
+    }
+
+    /// Django 6.0: after `save()`, `GeneratedField`s refresh from the
+    /// database via RETURNING (PG/SQLite; deferred on MySQL).
+    /// rustango DIVERGENCE PIN: the DB computes the column correctly
+    /// but the in-memory struct is never refreshed — on ANY backend. Issue #1028.
+    /// Goes red (flip the audit row) when save() starts returning
+    /// generated columns.
+    pub async fn check_generated_column_not_refreshed_on_save(pool: &Pool) {
+        let mut inv = Invoice {
+            id: Auto::default(),
+            price: 3,
+            qty: 4,
+            total: 0, // placeholder — DB computes 12
+        };
+        inv.save_pool(pool).await.expect("insert");
+        assert_eq!(
+            inv.total, 0,
+            "PINNED DIVERGENCE: struct not refreshed after save — Django 6.0 \
+             refreshes GeneratedFields via RETURNING; if this is now 12, update \
+             the audit + issue"
+        );
+        let fetched: Vec<Invoice> = Invoice::objects().fetch_pool(pool).await.expect("re-fetch");
+        assert_eq!(fetched.len(), 1);
+        assert_eq!(fetched[0].total, 12, "the DB-side value IS computed");
+    }
+
+    /// Django 6.0: `DEFAULT_AUTO_FIELD` now defaults to
+    /// `BigAutoField`. rustango's `Auto<i64>` maps to
+    /// BIGSERIAL / BIGINT AUTO_INCREMENT / INTEGER PRIMARY KEY —
+    /// 64-bit on every backend, already matching.
+    pub async fn check_auto_pk_is_big_auto_field(pool: &Pool) {
+        let mut inv = Invoice {
+            id: Auto::default(),
+            price: 1,
+            qty: 1,
+            total: 0,
+        };
+        inv.save_pool(pool).await.expect("insert");
+        let pk: i64 = *inv.id.get().expect("Auto PK populated after save");
+        assert!(pk > 0, "64-bit auto PK assigned: {pk}");
+    }
+}
+
+// ------------------------------------------------------------- Postgres
+
+#[cfg(feature = "postgres")]
+mod pg_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let pg = sqlx::PgPool::connect(&url).await.ok()?;
+        for sql in [
+            r#"DROP TABLE IF EXISTS "d6delta_row" CASCADE"#,
+            r#"DROP TABLE IF EXISTS "d6delta_invoice" CASCADE"#,
+            r#"CREATE TABLE "d6delta_row" (
+                "id" BIGINT PRIMARY KEY,
+                "name" VARCHAR(40) NOT NULL
+            )"#,
+            r#"CREATE TABLE "d6delta_invoice" (
+                "id" BIGSERIAL PRIMARY KEY,
+                "price" BIGINT NOT NULL,
+                "qty" BIGINT NOT NULL,
+                "total" BIGINT GENERATED ALWAYS AS ("price" * "qty") STORED
+            )"#,
+        ] {
+            sqlx::query(sql).execute(&pg).await.unwrap();
+        }
+        Some(Pool::Postgres(pg))
+    }
+
+    macro_rules! pg_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("DATABASE_URL unset — skipping PG django6 test");
+                    return;
+                };
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    pg_case!(check_string_agg_dialect_matrix);
+    pg_case!(check_string_agg_distinct);
+    pg_case!(check_generated_column_not_refreshed_on_save);
+    pg_case!(check_auto_pk_is_big_auto_field);
+}
+
+// --------------------------------------------------------------- SQLite
+
+#[cfg(feature = "sqlite")]
+mod sqlite_live {
+    use rustango::sql::{sqlx, Pool};
+
+    use super::scenarios;
+
+    async fn fresh_pool() -> Pool {
+        let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite mem pool");
+        for sql in [
+            "CREATE TABLE d6delta_row (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL
+            )",
+            "CREATE TABLE d6delta_invoice (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                price INTEGER NOT NULL,
+                qty INTEGER NOT NULL,
+                total INTEGER GENERATED ALWAYS AS (price * qty) STORED
+            )",
+        ] {
+            sqlx::query(sql).execute(&sq).await.expect("ddl");
+        }
+        Pool::Sqlite(sq)
+    }
+
+    macro_rules! sqlite_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let pool = fresh_pool().await;
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    sqlite_case!(check_string_agg_dialect_matrix);
+    sqlite_case!(check_string_agg_distinct);
+    sqlite_case!(check_generated_column_not_refreshed_on_save);
+    sqlite_case!(check_auto_pk_is_big_auto_field);
+}
+
+// ---------------------------------------------------------------- MySQL
+
+#[cfg(feature = "mysql")]
+mod mysql_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("MYSQL_TEST_URL").ok()?;
+        let my = sqlx::MySqlPool::connect(&url).await.ok()?;
+        for sql in [
+            "DROP TABLE IF EXISTS d6delta_row",
+            "DROP TABLE IF EXISTS d6delta_invoice",
+            "CREATE TABLE d6delta_row (
+                id BIGINT PRIMARY KEY,
+                name VARCHAR(40) NOT NULL
+            )",
+            "CREATE TABLE d6delta_invoice (
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                price BIGINT NOT NULL,
+                qty BIGINT NOT NULL,
+                total BIGINT GENERATED ALWAYS AS (price * qty) STORED
+            )",
+        ] {
+            sqlx::query(sql).execute(&my).await.unwrap();
+        }
+        Some(Pool::Mysql(my))
+    }
+
+    macro_rules! mysql_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("MYSQL_TEST_URL unset — skipping MySQL django6 test");
+                    return;
+                };
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    mysql_case!(check_string_agg_dialect_matrix);
+    mysql_case!(check_string_agg_distinct);
+    mysql_case!(check_generated_column_not_refreshed_on_save);
+    mysql_case!(check_auto_pk_is_big_auto_field);
+}

--- a/crates/rustango/tests/django6_joins.rs
+++ b/crates/rustango/tests/django6_joins.rs
@@ -1,0 +1,438 @@
+//! Django 6.0 ORM parity — execution-based verification.
+//! Scenario group D: multi-join queries — `select_related` chains,
+//! cross-table predicates, F() across joins, and the classic
+//! join-duplication trap.
+//!
+//! Django scenarios covered (docs.djangoproject.com/en/6.0):
+//! - `select_related("author__profile__country")` nested stitching
+//! - `filter(author__name="Ada")` relation-spanning filter — Django
+//!   joins implicitly; rustango pins the documented rejection (the
+//!   workaround is an explicit `.join()` + aliased predicate, also
+//!   exercised here)
+//! - `order_by("author__name")` relation-spanning ordering — same
+//!   story as the filter
+//! - `filter(score__gt=F("post__views"))` — F() comparing columns
+//!   across a join
+//! - `annotate(nc=Count("comments"), nl=Count("likes"))` — Django
+//!   inflates counts without `distinct=True` (the JOIN-duplication
+//!   trap); rustango lowers relation counts to correlated subqueries
+//!   so they can never inflate
+//!
+//! AUDIT NOTES:
+//! - Two relation-counts in ONE query (`annotate_count` twice) is not
+//!   expressible — `annotate_count` lives on `QuerySet` and returns an
+//!   `AggregateBuilder` with no further relation-annotate methods. One
+//!   relation aggregate per query today. Issue #1038.
+//! - Ad-hoc `.join()` does not compose with `.aggregate()` —
+//!   `AggregateQuery` carries no joins, so Django's join+GROUP BY
+//!   aggregate shape (`values("author__name").annotate(Count)`) must
+//!   go through relation aggregates or raw SQL. Issue #1040.
+
+#[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
+mod scenarios {
+    use rustango::core::joins::{aliased, col_filter};
+    use rustango::core::{Expr, Join, JoinKind, Model as _, Op, SqlValue, WhereExpr};
+    use rustango::sql::{raw_execute_pool, ExecError, FetcherPool as _, ForeignKey, Pool};
+    use rustango::Model;
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6join_country")]
+    #[allow(dead_code)]
+    pub struct Country {
+        #[rustango(primary_key)]
+        pub id: i64,
+        #[rustango(max_length = 2)]
+        pub code: String,
+    }
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6join_profile")]
+    #[allow(dead_code)]
+    pub struct Profile {
+        #[rustango(primary_key)]
+        pub id: i64,
+        pub country: ForeignKey<Country>,
+        #[rustango(max_length = 100)]
+        pub bio: String,
+    }
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6join_author")]
+    #[allow(dead_code)]
+    pub struct Author {
+        #[rustango(primary_key)]
+        pub id: i64,
+        pub profile: ForeignKey<Profile>,
+        #[rustango(max_length = 60)]
+        pub name: String,
+    }
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(
+        table = "d6join_post",
+        reverse_has(name = "comments", child = "Comment", child_fk_column = "post_id",),
+        reverse_has(name = "likes", child = "Like", child_fk_column = "post_id",)
+    )]
+    #[allow(dead_code)]
+    pub struct Post {
+        #[rustango(primary_key)]
+        pub id: i64,
+        pub author: ForeignKey<Author>,
+        #[rustango(max_length = 120)]
+        pub title: String,
+        pub views: i64,
+    }
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6join_comment")]
+    #[allow(dead_code)]
+    pub struct Comment {
+        #[rustango(primary_key)]
+        pub id: i64,
+        pub post_id: ForeignKey<Post, i64>,
+        pub score: i64,
+    }
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6join_like")]
+    #[allow(dead_code)]
+    pub struct Like {
+        #[rustango(primary_key)]
+        pub id: i64,
+        pub post_id: ForeignKey<Post, i64>,
+    }
+
+    /// Post 1 "Hello" (Ada/US, 10 views): 3 comments (5, 12, 20) + 2
+    /// likes. Post 2 "World" (Bob/DE, 50 views): 0 comments + 1 like.
+    pub async fn seed(pool: &Pool) {
+        for sql in [
+            "INSERT INTO d6join_country (id, code) VALUES (1, 'US')",
+            "INSERT INTO d6join_country (id, code) VALUES (2, 'DE')",
+            "INSERT INTO d6join_profile (id, country, bio) VALUES (1, 1, 'ada bio')",
+            "INSERT INTO d6join_profile (id, country, bio) VALUES (2, 2, 'bob bio')",
+            "INSERT INTO d6join_author (id, profile, name) VALUES (1, 1, 'Ada')",
+            "INSERT INTO d6join_author (id, profile, name) VALUES (2, 2, 'Bob')",
+            "INSERT INTO d6join_post (id, author, title, views) VALUES (1, 1, 'Hello', 10)",
+            "INSERT INTO d6join_post (id, author, title, views) VALUES (2, 2, 'World', 50)",
+            "INSERT INTO d6join_comment (id, post_id, score) VALUES (1, 1, 5)",
+            "INSERT INTO d6join_comment (id, post_id, score) VALUES (2, 1, 12)",
+            "INSERT INTO d6join_comment (id, post_id, score) VALUES (3, 1, 20)",
+            "INSERT INTO d6join_like (id, post_id) VALUES (1, 1)",
+            "INSERT INTO d6join_like (id, post_id) VALUES (2, 1)",
+            "INSERT INTO d6join_like (id, post_id) VALUES (3, 2)",
+        ] {
+            raw_execute_pool(pool, sql, vec![]).await.expect("seed");
+        }
+    }
+
+    /// Django `select_related("author__profile__country")` — one
+    /// query, nested loaded objects on every hop.
+    pub async fn check_three_hop_select_related_stitching(pool: &Pool) {
+        let posts: Vec<Post> = Post::objects()
+            .select_related("author__profile__country")
+            .order_by(&[("id", false)])
+            .fetch_pool(pool)
+            .await
+            .expect("3-hop fetch");
+        assert_eq!(posts.len(), 2);
+        let author = posts[0].author.value().expect("hop 1 stitched");
+        assert_eq!(author.name, "Ada");
+        let profile = author.profile.value().expect("hop 2 stitched");
+        assert_eq!(profile.bio, "ada bio");
+        let country = profile.country.value().expect("hop 3 stitched");
+        assert_eq!(country.code, "US");
+    }
+
+    /// GAP-PIN: Django's `filter(author__name="Ada")` implicit-join
+    /// filter has no rustango equivalent — relation-spanning string
+    /// lookups are documented out-of-scope for `filter()` and error
+    /// at compile. The workaround is `check_cross_table_filter_via_join`.
+    /// Issue #1031.
+    pub async fn check_relation_spanning_filter_is_rejected(pool: &Pool) {
+        let err = Post::objects()
+            .filter("author__name", "Ada")
+            .fetch_pool(pool)
+            .await
+            .map(|rows: Vec<Post>| rows.len())
+            .expect_err("relation-spanning filter must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            matches!(err, ExecError::Query(_)),
+            "expected a compile-side QueryError, got {err:?}"
+        );
+        assert!(
+            msg.contains("name") || msg.contains("lookup") || msg.contains("author"),
+            "error should point at the bad lookup: {msg}"
+        );
+    }
+
+    /// GAP-PIN: `order_by("author__name")` relation-spanning ordering
+    /// — same out-of-scope story as the filter. Issue #1031.
+    pub async fn check_relation_spanning_order_by_is_rejected(pool: &Pool) {
+        let err = Post::objects()
+            .order_by(&[("author__name", false)])
+            .fetch_pool(pool)
+            .await
+            .map(|rows: Vec<Post>| rows.len())
+            .expect_err("relation-spanning order_by must be rejected");
+        assert!(
+            matches!(err, ExecError::Query(_)),
+            "expected a compile-side QueryError, got {err:?}"
+        );
+    }
+
+    /// The explicit-join workaround for `filter(author__name="Ada")`:
+    /// `.join()` + `col_filter` on the alias.
+    pub async fn check_cross_table_filter_via_join(pool: &Pool) {
+        let posts: Vec<Post> = Post::objects()
+            .join(Join {
+                target: Author::SCHEMA,
+                alias: "a",
+                kind: JoinKind::Inner,
+                on: WhereExpr::ExprCompare {
+                    lhs: aliased("a", "id"),
+                    op: Op::Eq,
+                    rhs: aliased("d6join_post", "author"),
+                },
+                project: vec![],
+            })
+            .where_raw(col_filter("a", "name", Op::Eq, "Ada"))
+            .fetch_pool(pool)
+            .await
+            .expect("cross-table filter via join");
+        assert_eq!(posts.len(), 1);
+        assert_eq!(posts[0].title, "Hello");
+    }
+
+    /// Django `filter(score__gt=F("post__views"))` — column-to-column
+    /// comparison across a join. Post 1 has 10 views → comments with
+    /// score 12 and 20 qualify.
+    pub async fn check_f_comparison_across_join(pool: &Pool) {
+        let comments: Vec<Comment> = Comment::objects()
+            .join(Join {
+                target: Post::SCHEMA,
+                alias: "p",
+                kind: JoinKind::Inner,
+                on: WhereExpr::ExprCompare {
+                    lhs: aliased("p", "id"),
+                    op: Op::Eq,
+                    rhs: aliased("d6join_comment", "post_id"),
+                },
+                project: vec![],
+            })
+            .where_raw(WhereExpr::ExprCompare {
+                lhs: Expr::Column("score"),
+                op: Op::Gt,
+                rhs: aliased("p", "views"),
+            })
+            .order_by(&[("score", false)])
+            .fetch_pool(pool)
+            .await
+            .expect("F across join");
+        let scores: Vec<i64> = comments.into_iter().map(|c| c.score).collect();
+        assert_eq!(scores, vec![12, 20]);
+    }
+
+    /// The Django join-duplication trap: `annotate(nc=Count("comments"),
+    /// nl=Count("likes"))` without `distinct=True` returns 6/6 for a
+    /// post with 3 comments × 2 likes. rustango's relation counts are
+    /// correlated subqueries — structurally immune. (One relation
+    /// aggregate per query — see AUDIT NOTES in the file header.)
+    pub async fn check_relation_counts_never_inflate(pool: &Pool) {
+        let comment_rows = Post::objects()
+            .annotate_count("comments")
+            .order_by(&[("id", false)])
+            .fetch(pool)
+            .await
+            .expect("comments_count");
+        let n_comments: Vec<i64> = comment_rows
+            .iter()
+            .map(|r| match r.get("comments_count") {
+                Some(SqlValue::I64(n)) => *n,
+                other => panic!("expected I64 comments_count, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(n_comments, vec![3, 0], "never 6 — no JOIN duplication");
+
+        let like_rows = Post::objects()
+            .annotate_count("likes")
+            .order_by(&[("id", false)])
+            .fetch(pool)
+            .await
+            .expect("likes_count");
+        let n_likes: Vec<i64> = like_rows
+            .iter()
+            .map(|r| match r.get("likes_count") {
+                Some(SqlValue::I64(n)) => *n,
+                other => panic!("expected I64 likes_count, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(n_likes, vec![2, 1]);
+    }
+}
+
+// ------------------------------------------------------------- Postgres
+
+#[cfg(feature = "postgres")]
+mod pg_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let pg = sqlx::PgPool::connect(&url).await.ok()?;
+        for sql in [
+            r#"DROP TABLE IF EXISTS "d6join_like" CASCADE"#,
+            r#"DROP TABLE IF EXISTS "d6join_comment" CASCADE"#,
+            r#"DROP TABLE IF EXISTS "d6join_post" CASCADE"#,
+            r#"DROP TABLE IF EXISTS "d6join_author" CASCADE"#,
+            r#"DROP TABLE IF EXISTS "d6join_profile" CASCADE"#,
+            r#"DROP TABLE IF EXISTS "d6join_country" CASCADE"#,
+            r#"CREATE TABLE "d6join_country" ("id" BIGINT PRIMARY KEY, "code" TEXT NOT NULL)"#,
+            r#"CREATE TABLE "d6join_profile" ("id" BIGINT PRIMARY KEY, "country" BIGINT NOT NULL, "bio" TEXT NOT NULL)"#,
+            r#"CREATE TABLE "d6join_author" ("id" BIGINT PRIMARY KEY, "profile" BIGINT NOT NULL, "name" TEXT NOT NULL)"#,
+            r#"CREATE TABLE "d6join_post" ("id" BIGINT PRIMARY KEY, "author" BIGINT NOT NULL, "title" TEXT NOT NULL, "views" BIGINT NOT NULL)"#,
+            r#"CREATE TABLE "d6join_comment" ("id" BIGINT PRIMARY KEY, "post_id" BIGINT NOT NULL, "score" BIGINT NOT NULL)"#,
+            r#"CREATE TABLE "d6join_like" ("id" BIGINT PRIMARY KEY, "post_id" BIGINT NOT NULL)"#,
+        ] {
+            sqlx::query(sql).execute(&pg).await.unwrap();
+        }
+        Some(Pool::Postgres(pg))
+    }
+
+    macro_rules! pg_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("DATABASE_URL unset — skipping PG django6 test");
+                    return;
+                };
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    pg_case!(check_three_hop_select_related_stitching);
+    pg_case!(check_relation_spanning_filter_is_rejected);
+    pg_case!(check_relation_spanning_order_by_is_rejected);
+    pg_case!(check_cross_table_filter_via_join);
+    pg_case!(check_f_comparison_across_join);
+    pg_case!(check_relation_counts_never_inflate);
+}
+
+// --------------------------------------------------------------- SQLite
+
+#[cfg(feature = "sqlite")]
+mod sqlite_live {
+    use rustango::sql::{sqlx, Pool};
+
+    use super::scenarios;
+
+    async fn fresh_pool() -> Pool {
+        let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite mem pool");
+        for sql in [
+            "CREATE TABLE d6join_country (id INTEGER PRIMARY KEY, code TEXT NOT NULL)",
+            "CREATE TABLE d6join_profile (id INTEGER PRIMARY KEY, country INTEGER NOT NULL, bio TEXT NOT NULL)",
+            "CREATE TABLE d6join_author (id INTEGER PRIMARY KEY, profile INTEGER NOT NULL, name TEXT NOT NULL)",
+            "CREATE TABLE d6join_post (id INTEGER PRIMARY KEY, author INTEGER NOT NULL, title TEXT NOT NULL, views INTEGER NOT NULL)",
+            "CREATE TABLE d6join_comment (id INTEGER PRIMARY KEY, post_id INTEGER NOT NULL, score INTEGER NOT NULL)",
+            "CREATE TABLE d6join_like (id INTEGER PRIMARY KEY, post_id INTEGER NOT NULL)",
+        ] {
+            sqlx::query(sql).execute(&sq).await.expect("ddl");
+        }
+        Pool::Sqlite(sq)
+    }
+
+    macro_rules! sqlite_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let pool = fresh_pool().await;
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    sqlite_case!(check_three_hop_select_related_stitching);
+    sqlite_case!(check_relation_spanning_filter_is_rejected);
+    sqlite_case!(check_relation_spanning_order_by_is_rejected);
+    sqlite_case!(check_cross_table_filter_via_join);
+    sqlite_case!(check_f_comparison_across_join);
+    sqlite_case!(check_relation_counts_never_inflate);
+}
+
+// ---------------------------------------------------------------- MySQL
+
+#[cfg(feature = "mysql")]
+mod mysql_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("MYSQL_TEST_URL").ok()?;
+        let my = sqlx::MySqlPool::connect(&url).await.ok()?;
+        for sql in [
+            "DROP TABLE IF EXISTS d6join_like",
+            "DROP TABLE IF EXISTS d6join_comment",
+            "DROP TABLE IF EXISTS d6join_post",
+            "DROP TABLE IF EXISTS d6join_author",
+            "DROP TABLE IF EXISTS d6join_profile",
+            "DROP TABLE IF EXISTS d6join_country",
+            "CREATE TABLE d6join_country (id BIGINT PRIMARY KEY, code VARCHAR(2) NOT NULL)",
+            "CREATE TABLE d6join_profile (id BIGINT PRIMARY KEY, country BIGINT NOT NULL, bio VARCHAR(100) NOT NULL)",
+            "CREATE TABLE d6join_author (id BIGINT PRIMARY KEY, profile BIGINT NOT NULL, name VARCHAR(60) NOT NULL)",
+            "CREATE TABLE d6join_post (id BIGINT PRIMARY KEY, author BIGINT NOT NULL, title VARCHAR(120) NOT NULL, views BIGINT NOT NULL)",
+            "CREATE TABLE d6join_comment (id BIGINT PRIMARY KEY, post_id BIGINT NOT NULL, score BIGINT NOT NULL)",
+            "CREATE TABLE d6join_like (id BIGINT PRIMARY KEY, post_id BIGINT NOT NULL)",
+        ] {
+            sqlx::query(sql).execute(&my).await.unwrap();
+        }
+        Some(Pool::Mysql(my))
+    }
+
+    macro_rules! mysql_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("MYSQL_TEST_URL unset — skipping MySQL django6 test");
+                    return;
+                };
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    mysql_case!(check_three_hop_select_related_stitching);
+    mysql_case!(check_relation_spanning_filter_is_rejected);
+    mysql_case!(check_relation_spanning_order_by_is_rejected);
+    mysql_case!(check_cross_table_filter_via_join);
+    mysql_case!(check_f_comparison_across_join);
+    mysql_case!(check_relation_counts_never_inflate);
+}

--- a/crates/rustango/tests/django6_json_dates.rs
+++ b/crates/rustango/tests/django6_json_dates.rs
@@ -1,0 +1,390 @@
+//! Django 6.0 ORM parity — execution-based verification.
+//! Scenario groups G (JSONField lookups) + H (date transforms,
+//! `.dates()` / `.datetimes()`).
+//!
+//! Django scenarios covered (docs.djangoproject.com/en/6.0):
+//! - `filter(data__meta__kind="post")` nested key traversal
+//! - `filter(data__items__0__name="x")` key + array-index traversal
+//! - JSON array length lookup (`tags__len__gte` shape)
+//! - negative array indexing — NEW in Django 6.0 for SQLite; rustango
+//!   supports PG only (pinned gap on SQLite + MySQL — MySQL's
+//!   `$[N]` path syntax genuinely can't express it upstream)
+//! - `filter(created__year__gte=...)` / `__month` / `__quarter`
+//!   date-transform chains
+//! - `.dates("created", "month")` / `.datetimes("created", "hour")`
+//!   truncation querysets
+
+#[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
+mod scenarios {
+    use rustango::core::funcs::{json_array_length, json_path, json_path_indexed};
+    use rustango::core::{Expr, JsonPathStep, Op, SqlValue, WhereExpr, F};
+    use rustango::query::{DateKind, DateTimeKind};
+    use rustango::sql::{
+        fetch_dates_pool, fetch_datetimes_pool, raw_execute_pool, ExecError, FetcherPool as _,
+        Pool, SqlError,
+    };
+    use rustango::Model;
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6jd_doc")]
+    #[allow(dead_code)]
+    pub struct Doc {
+        #[rustango(primary_key)]
+        pub id: i64,
+        pub data: serde_json::Value,
+        pub created: chrono::DateTime<chrono::Utc>,
+    }
+
+    pub async fn seed(pool: &Pool) {
+        for sql in [
+            r#"INSERT INTO d6jd_doc (id, data, created) VALUES (1, '{"meta":{"kind":"post"},"items":[{"name":"x"},{"name":"y"}],"tags":["a","b","c"]}', '2024-03-15 10:30:00')"#,
+            r#"INSERT INTO d6jd_doc (id, data, created) VALUES (2, '{"meta":{"kind":"page"},"items":[{"name":"z"}],"tags":["a"]}', '2024-03-15 14:00:00')"#,
+            r#"INSERT INTO d6jd_doc (id, data, created) VALUES (3, '{"meta":{"kind":"post"},"items":[{"name":"w"}],"tags":["a","b"]}', '2025-07-01 09:00:00')"#,
+        ] {
+            raw_execute_pool(pool, sql, vec![]).await.expect("seed");
+        }
+    }
+
+    fn ids(rows: Vec<Doc>) -> Vec<i64> {
+        let mut ids: Vec<i64> = rows.into_iter().map(|d| d.id).collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    /// Django `filter(data__meta__kind="post")` — nested object keys,
+    /// compared as text (`->>` / `JSON_UNQUOTE(JSON_EXTRACT(...))` /
+    /// `json_extract`).
+    pub async fn check_nested_key_traversal(pool: &Pool) {
+        let rows: Vec<Doc> = Doc::objects()
+            .where_raw(WhereExpr::ExprCompare {
+                lhs: json_path(F("data"), &["meta", "kind"], true),
+                op: Op::Eq,
+                rhs: Expr::Literal(SqlValue::String("post".into())),
+            })
+            .fetch_pool(pool)
+            .await
+            .expect("nested key traversal");
+        assert_eq!(ids(rows), vec![1, 3]);
+    }
+
+    /// Django `filter(data__items__0__name="x")` — key + array index.
+    pub async fn check_key_index_traversal(pool: &Pool) {
+        let rows: Vec<Doc> = Doc::objects()
+            .where_raw(WhereExpr::ExprCompare {
+                lhs: json_path_indexed(
+                    F("data"),
+                    [
+                        JsonPathStep::Key("items".into()),
+                        JsonPathStep::Index(0),
+                        JsonPathStep::Key("name".into()),
+                    ],
+                    true,
+                ),
+                op: Op::Eq,
+                rhs: Expr::Literal(SqlValue::String("x".into())),
+            })
+            .fetch_pool(pool)
+            .await
+            .expect("key+index traversal");
+        assert_eq!(ids(rows), vec![1]);
+    }
+
+    /// JSON array length — docs with at least two tags.
+    pub async fn check_json_array_length(pool: &Pool) {
+        let rows: Vec<Doc> = Doc::objects()
+            .where_raw(WhereExpr::ExprCompare {
+                lhs: json_array_length(json_path(F("data"), &["tags"], false)),
+                op: Op::Gte,
+                rhs: Expr::Literal(SqlValue::I64(2)),
+            })
+            .fetch_pool(pool)
+            .await
+            .expect("json_array_length");
+        assert_eq!(ids(rows), vec![1, 3]);
+    }
+
+    /// Negative array index (`data__tags__-1`). Django 6.0 added
+    /// SQLite support; rustango emits PG's native negative `->` only.
+    /// GAP-PIN: SQLite (and MySQL, where `$[N]` genuinely can't
+    /// express it) reject with `OpNotSupportedInDialect`. Issue #1027.
+    pub async fn check_negative_index_dialect_matrix(pool: &Pool) {
+        let qs = || {
+            Doc::objects().where_raw(WhereExpr::ExprCompare {
+                lhs: json_path_indexed(
+                    F("data"),
+                    [JsonPathStep::Key("tags".into()), JsonPathStep::Index(-1)],
+                    true,
+                ),
+                op: Op::Eq,
+                rhs: Expr::Literal(SqlValue::String("c".into())),
+            })
+        };
+        if pool.dialect().name() == "postgres" {
+            let rows: Vec<Doc> = qs().fetch_pool(pool).await.expect("PG negative index");
+            assert_eq!(ids(rows), vec![1]);
+        } else {
+            let err = qs()
+                .fetch_pool(pool)
+                .await
+                .map(|rows: Vec<Doc>| rows.len())
+                .expect_err("negative index must be rejected off-PG");
+            match err {
+                ExecError::Sql(SqlError::OpNotSupportedInDialect { op, dialect }) => {
+                    assert!(
+                        op.contains("negative"),
+                        "error should mention negative indices: {op}"
+                    );
+                    assert_eq!(dialect, pool.dialect().name());
+                }
+                other => panic!(
+                    "expected OpNotSupportedInDialect, got {other:?} — if negative \
+                     JSON indices now work here (Django 6.0 supports them on \
+                     SQLite), update the audit + issue"
+                ),
+            }
+        }
+    }
+
+    /// Django `filter(created__year__gte=2025)` and
+    /// `filter(created__month=3)` — date-transform lookups with and
+    /// without trailing comparisons.
+    pub async fn check_date_transform_chains(pool: &Pool) {
+        let rows: Vec<Doc> = Doc::objects()
+            .filter("created__year__gte", 2025_i64)
+            .fetch_pool(pool)
+            .await
+            .expect("__year__gte");
+        assert_eq!(ids(rows), vec![3]);
+
+        let rows: Vec<Doc> = Doc::objects()
+            .filter("created__month", 3_i64)
+            .fetch_pool(pool)
+            .await
+            .expect("__month");
+        assert_eq!(ids(rows), vec![1, 2]);
+    }
+
+    /// `filter(created__quarter=1)` — PG and MySQL have native
+    /// QUARTER extraction; SQLite's strftime has no quarter code.
+    /// GAP-PIN on SQLite (Django computes quarter on SQLite via a
+    /// CASE rewrite, so this is a real parity gap). Issue #1037.
+    pub async fn check_quarter_dialect_matrix(pool: &Pool) {
+        let res = Doc::objects()
+            .filter("created__quarter", 1_i64)
+            .fetch_pool(pool)
+            .await;
+        if pool.dialect().name() == "sqlite" {
+            let err = res
+                .map(|rows: Vec<Doc>| rows.len())
+                .expect_err("__quarter must error on sqlite");
+            assert!(
+                matches!(err, ExecError::Sql(_)),
+                "expected a writer-side SqlError, got {err:?} — if quarter now \
+                 works on sqlite, update the audit"
+            );
+        } else {
+            let rows = res.expect("__quarter on PG/MySQL");
+            assert_eq!(ids(rows), vec![1, 2], "March is Q1");
+        }
+    }
+
+    /// Django `.dates("created", "month")` — distinct truncated
+    /// dates, ascending, plus `order_desc` reversal.
+    pub async fn check_dates_truncation(pool: &Pool) {
+        let months = fetch_dates_pool(pool, Doc::objects().dates("created", DateKind::Month))
+            .await
+            .expect("dates(month)");
+        let rendered: Vec<String> = months.iter().map(|d| d.to_string()).collect();
+        assert_eq!(rendered, vec!["2024-03-01", "2025-07-01"]);
+
+        let desc = fetch_dates_pool(
+            pool,
+            Doc::objects()
+                .dates("created", DateKind::Month)
+                .order_desc(true),
+        )
+        .await
+        .expect("dates(month) desc");
+        let rendered_desc: Vec<String> = desc.iter().map(|d| d.to_string()).collect();
+        assert_eq!(rendered_desc, vec!["2025-07-01", "2024-03-01"]);
+    }
+
+    /// Django `.datetimes("created", "hour")` — distinct truncated
+    /// timestamps.
+    pub async fn check_datetimes_truncation(pool: &Pool) {
+        let hours = fetch_datetimes_pool(
+            pool,
+            Doc::objects().datetimes("created", DateTimeKind::Hour),
+        )
+        .await
+        .expect("datetimes(hour)");
+        let rendered: Vec<String> = hours
+            .iter()
+            .map(|d| d.format("%Y-%m-%d %H:%M").to_string())
+            .collect();
+        assert_eq!(
+            rendered,
+            vec!["2024-03-15 10:00", "2024-03-15 14:00", "2025-07-01 09:00"]
+        );
+    }
+}
+
+// ------------------------------------------------------------- Postgres
+
+#[cfg(feature = "postgres")]
+mod pg_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let pg = sqlx::PgPool::connect(&url).await.ok()?;
+        for sql in [
+            r#"DROP TABLE IF EXISTS "d6jd_doc" CASCADE"#,
+            r#"CREATE TABLE "d6jd_doc" (
+                "id" BIGINT PRIMARY KEY,
+                "data" JSONB NOT NULL,
+                "created" TIMESTAMPTZ NOT NULL
+            )"#,
+        ] {
+            sqlx::query(sql).execute(&pg).await.unwrap();
+        }
+        Some(Pool::Postgres(pg))
+    }
+
+    macro_rules! pg_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("DATABASE_URL unset — skipping PG django6 test");
+                    return;
+                };
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    pg_case!(check_nested_key_traversal);
+    pg_case!(check_key_index_traversal);
+    pg_case!(check_json_array_length);
+    pg_case!(check_negative_index_dialect_matrix);
+    pg_case!(check_date_transform_chains);
+    pg_case!(check_quarter_dialect_matrix);
+    pg_case!(check_dates_truncation);
+    pg_case!(check_datetimes_truncation);
+}
+
+// --------------------------------------------------------------- SQLite
+
+#[cfg(feature = "sqlite")]
+mod sqlite_live {
+    use rustango::sql::{sqlx, Pool};
+
+    use super::scenarios;
+
+    async fn fresh_pool() -> Pool {
+        let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite mem pool");
+        sqlx::query(
+            "CREATE TABLE d6jd_doc (
+                id INTEGER PRIMARY KEY,
+                data TEXT NOT NULL,
+                created TEXT NOT NULL
+            )",
+        )
+        .execute(&sq)
+        .await
+        .expect("ddl");
+        Pool::Sqlite(sq)
+    }
+
+    macro_rules! sqlite_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let pool = fresh_pool().await;
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    sqlite_case!(check_nested_key_traversal);
+    sqlite_case!(check_key_index_traversal);
+    sqlite_case!(check_json_array_length);
+    sqlite_case!(check_negative_index_dialect_matrix);
+    sqlite_case!(check_date_transform_chains);
+    sqlite_case!(check_quarter_dialect_matrix);
+    sqlite_case!(check_dates_truncation);
+    sqlite_case!(check_datetimes_truncation);
+}
+
+// ---------------------------------------------------------------- MySQL
+
+#[cfg(feature = "mysql")]
+mod mysql_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("MYSQL_TEST_URL").ok()?;
+        let my = sqlx::MySqlPool::connect(&url).await.ok()?;
+        for sql in [
+            "DROP TABLE IF EXISTS d6jd_doc",
+            "CREATE TABLE d6jd_doc (
+                id BIGINT PRIMARY KEY,
+                data JSON NOT NULL,
+                created TIMESTAMP NOT NULL
+            )",
+        ] {
+            sqlx::query(sql).execute(&my).await.unwrap();
+        }
+        Some(Pool::Mysql(my))
+    }
+
+    macro_rules! mysql_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("MYSQL_TEST_URL unset — skipping MySQL django6 test");
+                    return;
+                };
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    mysql_case!(check_nested_key_traversal);
+    mysql_case!(check_key_index_traversal);
+    mysql_case!(check_json_array_length);
+    mysql_case!(check_negative_index_dialect_matrix);
+    mysql_case!(check_date_transform_chains);
+    mysql_case!(check_quarter_dialect_matrix);
+    mysql_case!(check_dates_truncation);
+    mysql_case!(check_datetimes_truncation);
+}

--- a/crates/rustango/tests/django6_setops.rs
+++ b/crates/rustango/tests/django6_setops.rs
@@ -1,0 +1,347 @@
+//! Django 6.0 ORM parity — execution-based verification.
+//! Scenario group E: set operations — union / union_all /
+//! intersection / difference with per-branch and combined-result
+//! ordering.
+//!
+//! Django scenarios covered (docs.djangoproject.com/en/6.0):
+//! - `qs1.union(qs2)` dedups; `union(all=True)` keeps duplicates
+//! - per-branch `ORDER BY`/`LIMIT` (each branch wraps in parens)
+//! - `.order_by()/.limit()` AFTER `.union()` applies to the combined
+//!   result (Django's documented compound semantics)
+//! - `qs1.intersection(qs2)` / `qs1.difference(qs2)`
+//!
+//! Dialect floor: MySQL needs 8.0.31+ for native INTERSECT / EXCEPT
+//! (docker-compose pins `mysql:8.0`, currently ≥ 8.0.31 — older
+//! servers surface a driver syntax error; that floor is recorded in
+//! the parity audit rather than branch-handled here).
+
+#[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
+mod scenarios {
+    use rustango::core::SetOp;
+    use rustango::sql::{raw_execute_pool, FetcherPool as _, Pool};
+    use rustango::Model;
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6set_item")]
+    #[allow(dead_code)]
+    pub struct Item {
+        #[rustango(primary_key)]
+        pub id: i64,
+        #[rustango(max_length = 40)]
+        pub name: String,
+        pub rnk: i64,
+        #[rustango(max_length = 10)]
+        pub grp: String,
+    }
+
+    pub async fn seed(pool: &Pool) {
+        for sql in [
+            "INSERT INTO d6set_item (id, name, rnk, grp) VALUES (1, 'a1', 1, 'a')",
+            "INSERT INTO d6set_item (id, name, rnk, grp) VALUES (2, 'a2', 2, 'a')",
+            "INSERT INTO d6set_item (id, name, rnk, grp) VALUES (3, 'a3', 3, 'a')",
+            "INSERT INTO d6set_item (id, name, rnk, grp) VALUES (4, 'b1', 4, 'b')",
+            "INSERT INTO d6set_item (id, name, rnk, grp) VALUES (5, 'b2', 5, 'b')",
+        ] {
+            raw_execute_pool(pool, sql, vec![]).await.expect("seed");
+        }
+    }
+
+    fn sorted_names(rows: Vec<Item>) -> Vec<String> {
+        let mut names: Vec<String> = rows.into_iter().map(|i| i.name).collect();
+        names.sort();
+        names
+    }
+
+    /// Branches overlap on the three 'a' rows: UNION dedups them,
+    /// UNION ALL keeps both copies.
+    pub async fn check_union_dedups_vs_union_all(pool: &Pool) {
+        let union: Vec<Item> = Item::objects()
+            .filter("grp", "a")
+            .union(Item::objects().filter("rnk__lte", 4_i64))
+            .fetch_pool(pool)
+            .await
+            .expect("UNION fetch");
+        assert_eq!(sorted_names(union), vec!["a1", "a2", "a3", "b1"]);
+
+        let union_all: Vec<Item> = Item::objects()
+            .filter("grp", "a")
+            .union_all(Item::objects().filter("rnk__lte", 4_i64))
+            .fetch_pool(pool)
+            .await
+            .expect("UNION ALL fetch");
+        assert_eq!(union_all.len(), 7, "3 + 4 with duplicates kept");
+    }
+
+    /// Per-branch ORDER BY + LIMIT. DIVERGENCE (execution-verified):
+    /// only the *other* branch (the argument to `union_all`) gets the
+    /// parenthesized branch-scoped wrapping; ORDER BY/LIMIT on the
+    /// *first* queryset always apply to the COMBINED result — the
+    /// builder stores them in the same slots as post-union clauses, so
+    /// "before union" vs "after union" is indistinguishable. Django
+    /// 4.0+ supports slicing BOTH component querysets
+    /// (`qs1[:2].union(qs2[:1])`); rustango can slice only the
+    /// non-self branches.
+    pub async fn check_per_branch_order_and_limit(pool: &Pool) {
+        // Other-branch clauses ARE branch-scoped: all of 'a' + top-1
+        // of 'b' by rank desc.
+        //
+        // GAP-PIN (MySQL): the branch wrapper emits
+        // `SELECT * FROM (<branch>)` with NO alias — PG/SQLite accept
+        // that, MySQL rejects it with error 1248 ("Every derived
+        // table must have its own alias"). Ordered/limited union
+        // branches are therefore broken on MySQL until the writer
+        // appends an alias. Tracked in the gh issue filed from this
+        // suite (#1032).
+        let res = Item::objects()
+            .filter("grp", "a")
+            .union_all(
+                Item::objects()
+                    .filter("grp", "b")
+                    .order_by(&[("rnk", true)])
+                    .limit(1),
+            )
+            .fetch_pool(pool)
+            .await;
+        if pool.dialect().name() == "mysql" {
+            let err = res
+                .map(|rows: Vec<Item>| rows.len())
+                .expect_err("MySQL must reject the alias-less branch wrapper");
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("alias"),
+                "expected MySQL error 1248 (derived table alias), got: {msg} — \
+                 if branch wrappers now carry aliases, update the audit + issue"
+            );
+        } else {
+            let rows: Vec<Item> = res.expect("other-branch order/limit fetch");
+            assert_eq!(sorted_names(rows), vec!["a1", "a2", "a3", "b2"]);
+        }
+
+        // PINNED DIVERGENCE: first-queryset clauses leak to the
+        // combined result — top-2 of (a ∪ b) by rank asc, NOT
+        // "top-2 of 'a' plus all of 'b'". Goes red if branch-scoped
+        // first-queryset slicing ever ships (then update the audit). Issue #1034.
+        let rows: Vec<Item> = Item::objects()
+            .filter("grp", "a")
+            .order_by(&[("rnk", false)])
+            .limit(2)
+            .union_all(Item::objects().filter("grp", "b"))
+            .fetch_pool(pool)
+            .await
+            .expect("first-queryset order/limit fetch");
+        assert_eq!(
+            sorted_names(rows),
+            vec!["a1", "a2"],
+            "first-queryset LIMIT applies to the combined result"
+        );
+    }
+
+    /// Django: ordering/slicing applied AFTER `.union()` operates on
+    /// the combined resultset.
+    pub async fn check_outer_order_limit_on_combined(pool: &Pool) {
+        let rows: Vec<Item> = Item::objects()
+            .filter("grp", "a")
+            .union(Item::objects().filter("grp", "b"))
+            .order_by(&[("rnk", true)])
+            .limit(3)
+            .fetch_pool(pool)
+            .await
+            .expect("outer order/limit fetch");
+        let ranks: Vec<i64> = rows.into_iter().map(|i| i.rnk).collect();
+        assert_eq!(ranks, vec![5, 4, 3], "top-3 of the COMBINED set, desc");
+    }
+
+    /// `qs.intersection(other)` — rows in both branches.
+    pub async fn check_intersection(pool: &Pool) {
+        let rows: Vec<Item> = Item::objects()
+            .filter("grp", "a")
+            .intersection(Item::objects().filter("rnk__lte", 1_i64))
+            .fetch_pool(pool)
+            .await
+            .expect("INTERSECT fetch (MySQL needs 8.0.31+)");
+        assert_eq!(sorted_names(rows), vec!["a1"]);
+    }
+
+    /// `qs.difference(other)` — rows in the first branch only.
+    pub async fn check_difference(pool: &Pool) {
+        let rows: Vec<Item> = Item::objects()
+            .filter("grp", "a")
+            .difference(Item::objects().filter("rnk__lte", 2_i64))
+            .fetch_pool(pool)
+            .await
+            .expect("EXCEPT fetch (MySQL needs 8.0.31+)");
+        assert_eq!(sorted_names(rows), vec!["a3"]);
+    }
+
+    /// `with_compound` — the fallible pre-compiled-branch form.
+    pub async fn check_with_compound_precompiled_branch(pool: &Pool) {
+        let branch = Item::objects()
+            .filter("grp", "b")
+            .compile()
+            .expect("branch compile");
+        let rows: Vec<Item> = Item::objects()
+            .filter("grp", "a")
+            .with_compound(SetOp::Union, branch)
+            .fetch_pool(pool)
+            .await
+            .expect("with_compound fetch");
+        assert_eq!(rows.len(), 5);
+    }
+}
+
+// ------------------------------------------------------------- Postgres
+
+#[cfg(feature = "postgres")]
+mod pg_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let pg = sqlx::PgPool::connect(&url).await.ok()?;
+        for sql in [
+            r#"DROP TABLE IF EXISTS "d6set_item" CASCADE"#,
+            r#"CREATE TABLE "d6set_item" (
+                "id" BIGINT PRIMARY KEY,
+                "name" VARCHAR(40) NOT NULL,
+                "rnk" BIGINT NOT NULL,
+                "grp" VARCHAR(10) NOT NULL
+            )"#,
+        ] {
+            sqlx::query(sql).execute(&pg).await.unwrap();
+        }
+        Some(Pool::Postgres(pg))
+    }
+
+    macro_rules! pg_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("DATABASE_URL unset — skipping PG django6 test");
+                    return;
+                };
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    pg_case!(check_union_dedups_vs_union_all);
+    pg_case!(check_per_branch_order_and_limit);
+    pg_case!(check_outer_order_limit_on_combined);
+    pg_case!(check_intersection);
+    pg_case!(check_difference);
+    pg_case!(check_with_compound_precompiled_branch);
+}
+
+// --------------------------------------------------------------- SQLite
+
+#[cfg(feature = "sqlite")]
+mod sqlite_live {
+    use rustango::sql::{sqlx, Pool};
+
+    use super::scenarios;
+
+    async fn fresh_pool() -> Pool {
+        let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite mem pool");
+        sqlx::query(
+            "CREATE TABLE d6set_item (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                rnk INTEGER NOT NULL,
+                grp TEXT NOT NULL
+            )",
+        )
+        .execute(&sq)
+        .await
+        .expect("ddl");
+        Pool::Sqlite(sq)
+    }
+
+    macro_rules! sqlite_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let pool = fresh_pool().await;
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    sqlite_case!(check_union_dedups_vs_union_all);
+    sqlite_case!(check_per_branch_order_and_limit);
+    sqlite_case!(check_outer_order_limit_on_combined);
+    sqlite_case!(check_intersection);
+    sqlite_case!(check_difference);
+    sqlite_case!(check_with_compound_precompiled_branch);
+}
+
+// ---------------------------------------------------------------- MySQL
+
+#[cfg(feature = "mysql")]
+mod mysql_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("MYSQL_TEST_URL").ok()?;
+        let my = sqlx::MySqlPool::connect(&url).await.ok()?;
+        for sql in [
+            "DROP TABLE IF EXISTS d6set_item",
+            "CREATE TABLE d6set_item (
+                id BIGINT PRIMARY KEY,
+                name VARCHAR(40) NOT NULL,
+                rnk BIGINT NOT NULL,
+                grp VARCHAR(10) NOT NULL
+            )",
+        ] {
+            sqlx::query(sql).execute(&my).await.unwrap();
+        }
+        Some(Pool::Mysql(my))
+    }
+
+    macro_rules! mysql_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("MYSQL_TEST_URL unset — skipping MySQL django6 test");
+                    return;
+                };
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    mysql_case!(check_union_dedups_vs_union_all);
+    mysql_case!(check_per_branch_order_and_limit);
+    mysql_case!(check_outer_order_limit_on_combined);
+    mysql_case!(check_intersection);
+    mysql_case!(check_difference);
+    mysql_case!(check_with_compound_precompiled_branch);
+}

--- a/crates/rustango/tests/django6_subquery.rs
+++ b/crates/rustango/tests/django6_subquery.rs
@@ -1,0 +1,445 @@
+//! Django 6.0 ORM parity — execution-based verification.
+//! Scenario group B: correlated subqueries — `Exists` / `OuterRef` /
+//! `Subquery` / `IN (SELECT …)` and Django's exclude-on-multi-valued-
+//! relation semantics.
+//!
+//! Django scenarios covered (docs.djangoproject.com/en/6.0):
+//! - `filter(Exists(Book.objects.filter(author=OuterRef("pk"))))`
+//! - the relation-spanning exclude trap: `exclude(books__published=False)`
+//!   means "authors with NO unpublished book" (NOT EXISTS), not
+//!   "authors having some book that isn't unpublished"
+//! - `filter(author__in=Subquery(...))` → `where_in_subquery`
+//! - count comparator over a relation (`annotate(Count) + filter` /
+//!   Eloquent `has('books', '>=', 2)`)
+//! - `annotate(books_count=Count("books"))` eager count column
+//! - scalar `Subquery()` embedded in a WHERE comparison
+//! - `OuterRef` outside a subquery is a programming error (pinned)
+//!
+//! AUDIT NOTES (compile-time API absences, no runtime pin possible):
+//! - Django's scalar `Subquery()` as a **projected annotation**
+//!   (`annotate(newest=Subquery(...))`) is not expressible:
+//!   `annotate()` takes `AggregateExpr`, which has no scalar-subquery
+//!   variant. `Expr::Subquery` works in WHERE / UPDATE SET only. Issue #1036.
+//! - Composite `(a, b) IN (SELECT …)` tuple-membership has no API;
+//!   the workaround is a correlated `EXISTS` with a multi-predicate
+//!   WHERE (exactly what `where_has_filter` emits — see
+//!   `check_exclude_relation_spanning_semantics`).
+
+#[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
+mod scenarios {
+    use rustango::core::subquery::{outer_ref, subquery};
+    use rustango::core::{Expr, Op, SqlValue, WhereExpr};
+    use rustango::sql::{
+        raw_execute_pool, Auto, ExecError, FetcherPool as _, ForeignKey, Pool, SqlError,
+    };
+    use rustango::Model;
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(
+        table = "d6sub_author",
+        reverse_has(name = "books", child = "Book", child_fk_column = "author_id",)
+    )]
+    #[allow(dead_code)]
+    pub struct Author {
+        #[rustango(primary_key)]
+        pub id: Auto<i64>,
+        #[rustango(max_length = 60)]
+        pub name: String,
+        pub active: bool,
+    }
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6sub_book")]
+    #[allow(dead_code)]
+    pub struct Book {
+        #[rustango(primary_key)]
+        pub id: Auto<i64>,
+        pub author_id: ForeignKey<Author, i64>,
+        #[rustango(max_length = 120)]
+        pub title: String,
+        pub published: bool,
+    }
+
+    /// Ada(active): 1 published + 1 draft. Bob(inactive): 1 published.
+    /// Cara(active): no books. Dan(active): 2 drafts + 1 published.
+    pub async fn seed(pool: &Pool) {
+        for sql in [
+            "INSERT INTO d6sub_author (id, name, active) VALUES (1, 'Ada', TRUE)",
+            "INSERT INTO d6sub_author (id, name, active) VALUES (2, 'Bob', FALSE)",
+            "INSERT INTO d6sub_author (id, name, active) VALUES (3, 'Cara', TRUE)",
+            "INSERT INTO d6sub_author (id, name, active) VALUES (4, 'Dan', TRUE)",
+            "INSERT INTO d6sub_book (id, author_id, title, published) VALUES (1, 1, 'Rust 101', TRUE)",
+            "INSERT INTO d6sub_book (id, author_id, title, published) VALUES (2, 1, 'Drafts', FALSE)",
+            "INSERT INTO d6sub_book (id, author_id, title, published) VALUES (3, 2, 'SQL Bits', TRUE)",
+            "INSERT INTO d6sub_book (id, author_id, title, published) VALUES (4, 4, 'D1', FALSE)",
+            "INSERT INTO d6sub_book (id, author_id, title, published) VALUES (5, 4, 'D2', FALSE)",
+            "INSERT INTO d6sub_book (id, author_id, title, published) VALUES (6, 4, 'D3', TRUE)",
+        ] {
+            raw_execute_pool(pool, sql, vec![]).await.expect("seed");
+        }
+    }
+
+    fn names(rows: Vec<Author>) -> Vec<String> {
+        rows.into_iter().map(|a| a.name).collect()
+    }
+
+    /// Django: `Author.objects.filter(Exists(Book.objects.filter(
+    /// author=OuterRef("pk"))))` — hand-built correlated EXISTS via
+    /// `outer_ref` + `where_exists`.
+    pub async fn check_exists_with_outer_ref(pool: &Pool) {
+        let inner = Book::objects()
+            .where_raw(WhereExpr::ExprCompare {
+                lhs: Expr::Column("author_id"),
+                op: Op::Eq,
+                rhs: outer_ref("id"),
+            })
+            .compile()
+            .expect("inner compile");
+        let rows: Vec<Author> = Author::objects()
+            .where_exists(inner)
+            .order_by(&[("name", false)])
+            .fetch_pool(pool)
+            .await
+            .expect("EXISTS fetch");
+        assert_eq!(names(rows), vec!["Ada", "Bob", "Dan"]);
+    }
+
+    /// Same scenario through the typed-column form
+    /// (`Book::author_id.eq_expr(outer_ref("id"))`) and negated via
+    /// `where_not_exists` — Django `~Exists(...)`.
+    pub async fn check_not_exists_typed_outer_ref(pool: &Pool) {
+        use rustango::core::Column as _;
+        let inner = Book::objects()
+            .where_(Book::author_id.eq_expr(outer_ref("id")))
+            .compile()
+            .expect("inner compile");
+        let rows: Vec<Author> = Author::objects()
+            .where_not_exists(inner)
+            .fetch_pool(pool)
+            .await
+            .expect("NOT EXISTS fetch");
+        assert_eq!(names(rows), vec!["Cara"]);
+    }
+
+    /// The Django relation-spanning exclude trap. With Ada holding
+    /// BOTH a published and an unpublished book:
+    /// - `filter(books__published=False)` keeps authors with at least
+    ///   one unpublished book → Ada, Dan (rustango:
+    ///   `where_has_filter`).
+    /// - `exclude(books__published=False)` keeps authors with NO
+    ///   unpublished book at all → Bob, Cara — *including* bookless
+    ///   Cara (rustango: `where_doesnt_have_filter` emits the same
+    ///   NOT EXISTS Django lowers to). String-keyed `exclude()` itself
+    ///   is missing despite the audit claim — issue #1030.
+    pub async fn check_exclude_relation_spanning_semantics(pool: &Pool) {
+        let unpublished = || {
+            Book::objects()
+                .filter("published", false)
+                .compile()
+                .expect("inner compile")
+        };
+        let has: Vec<Author> = Author::objects()
+            .where_has_filter("books", unpublished())
+            .order_by(&[("name", false)])
+            .fetch_pool(pool)
+            .await
+            .expect("whereHas fetch");
+        assert_eq!(names(has), vec!["Ada", "Dan"], "filter() direction");
+
+        let doesnt: Vec<Author> = Author::objects()
+            .where_doesnt_have_filter("books", unpublished())
+            .order_by(&[("name", false)])
+            .fetch_pool(pool)
+            .await
+            .expect("whereDoesntHave fetch");
+        assert_eq!(
+            names(doesnt),
+            vec!["Bob", "Cara"],
+            "exclude() direction must be NOT EXISTS — bookless Cara included"
+        );
+    }
+
+    /// Django: `Book.objects.filter(author__in=Author.objects.filter(
+    /// active=True).values("id"))` → `IN (SELECT id FROM …)`.
+    pub async fn check_in_subquery(pool: &Pool) {
+        let active_ids = Author::objects()
+            .filter("active", true)
+            .values_list_flat("id")
+            .compile()
+            .expect("inner compile");
+        let rows: Vec<Book> = Book::objects()
+            .where_in_subquery("author_id", active_ids)
+            .fetch_pool(pool)
+            .await
+            .expect("IN subquery fetch");
+        assert_eq!(rows.len(), 5, "Ada's 2 + Dan's 3 books");
+
+        let active_ids = Author::objects()
+            .filter("active", true)
+            .values_list_flat("id")
+            .compile()
+            .expect("inner compile");
+        let rows: Vec<Book> = Book::objects()
+            .where_not_in_subquery("author_id", active_ids)
+            .fetch_pool(pool)
+            .await
+            .expect("NOT IN subquery fetch");
+        assert_eq!(rows.len(), 1, "only Bob's book");
+    }
+
+    /// Django: `annotate(n=Count("books")).filter(n__gte=2)` /
+    /// Eloquent `has('books', '>=', 2)` — correlated COUNT comparator.
+    pub async fn check_where_has_count(pool: &Pool) {
+        let rows: Vec<Author> = Author::objects()
+            .where_has_count("books", Op::Gte, 2)
+            .order_by(&[("name", false)])
+            .fetch_pool(pool)
+            .await
+            .expect("has-count fetch");
+        assert_eq!(names(rows), vec!["Ada", "Dan"]);
+    }
+
+    /// Django: `annotate(books_count=Count("books"))` — projected
+    /// eager count. rustango lowers to a correlated scalar subquery
+    /// (never a JOIN), so it can't double-count.
+    pub async fn check_annotate_count(pool: &Pool) {
+        let rows = Author::objects()
+            .annotate_count("books")
+            .order_by(&[("name", false)])
+            .fetch(pool)
+            .await
+            .expect("annotate_count fetch");
+        assert_eq!(rows.len(), 4);
+        let counts: Vec<i64> = rows
+            .iter()
+            .map(|r| match r.get("books_count") {
+                Some(SqlValue::I64(n)) => *n,
+                other => panic!("expected I64 books_count, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(counts, vec![2, 1, 0, 3], "Ada, Bob, Cara, Dan");
+    }
+
+    /// Django: `filter(author=Subquery(Author.objects.order_by(
+    /// "-id").values("id")[:1]))` — scalar subquery embedded in a
+    /// WHERE comparison. Newest author by id is Dan (id 4).
+    pub async fn check_scalar_subquery_in_where(pool: &Pool) {
+        let newest_author = Author::objects()
+            .order_by(&[("id", true)])
+            .limit(1)
+            .values_list_flat("id")
+            .compile()
+            .expect("inner compile");
+        let rows: Vec<Book> = Book::objects()
+            .where_raw(WhereExpr::ExprCompare {
+                lhs: Expr::Column("author_id"),
+                op: Op::Eq,
+                rhs: subquery(newest_author),
+            })
+            .fetch_pool(pool)
+            .await
+            .expect("scalar subquery fetch");
+        assert_eq!(rows.len(), 3, "Dan's 3 books");
+    }
+
+    /// `OuterRef` outside any subquery wrapper is a programming error
+    /// — pinned: the writer rejects it with a clear error instead of
+    /// emitting broken SQL (Django raises ValueError at evaluation).
+    pub async fn check_outer_ref_outside_subquery_errors(pool: &Pool) {
+        let err = Author::objects()
+            .where_raw(WhereExpr::ExprCompare {
+                lhs: Expr::Column("id"),
+                op: Op::Eq,
+                rhs: outer_ref("id"),
+            })
+            .fetch_pool(pool)
+            .await
+            .map(|rows: Vec<Author>| rows.len())
+            .expect_err("OuterRef outside a subquery must error");
+        match err {
+            ExecError::Sql(SqlError::OuterRefOutsideSubquery { column }) => {
+                assert_eq!(column, "id");
+            }
+            other => panic!("expected OuterRefOutsideSubquery, got {other:?}"),
+        }
+    }
+}
+
+// ------------------------------------------------------------- Postgres
+
+#[cfg(feature = "postgres")]
+mod pg_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let pg = sqlx::PgPool::connect(&url).await.ok()?;
+        for sql in [
+            r#"DROP TABLE IF EXISTS "d6sub_book" CASCADE"#,
+            r#"DROP TABLE IF EXISTS "d6sub_author" CASCADE"#,
+            r#"CREATE TABLE "d6sub_author" (
+                "id" BIGINT PRIMARY KEY,
+                "name" VARCHAR(60) NOT NULL,
+                "active" BOOLEAN NOT NULL
+            )"#,
+            r#"CREATE TABLE "d6sub_book" (
+                "id" BIGINT PRIMARY KEY,
+                "author_id" BIGINT NOT NULL,
+                "title" VARCHAR(120) NOT NULL,
+                "published" BOOLEAN NOT NULL
+            )"#,
+        ] {
+            sqlx::query(sql).execute(&pg).await.unwrap();
+        }
+        Some(Pool::Postgres(pg))
+    }
+
+    macro_rules! pg_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("DATABASE_URL unset — skipping PG django6 test");
+                    return;
+                };
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    pg_case!(check_exists_with_outer_ref);
+    pg_case!(check_not_exists_typed_outer_ref);
+    pg_case!(check_exclude_relation_spanning_semantics);
+    pg_case!(check_in_subquery);
+    pg_case!(check_where_has_count);
+    pg_case!(check_annotate_count);
+    pg_case!(check_scalar_subquery_in_where);
+    pg_case!(check_outer_ref_outside_subquery_errors);
+}
+
+// --------------------------------------------------------------- SQLite
+
+#[cfg(feature = "sqlite")]
+mod sqlite_live {
+    use rustango::sql::{sqlx, Pool};
+
+    use super::scenarios;
+
+    async fn fresh_pool() -> Pool {
+        let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite mem pool");
+        for sql in [
+            "CREATE TABLE d6sub_author (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                active INTEGER NOT NULL
+            )",
+            "CREATE TABLE d6sub_book (
+                id INTEGER PRIMARY KEY,
+                author_id INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                published INTEGER NOT NULL
+            )",
+        ] {
+            sqlx::query(sql).execute(&sq).await.expect("ddl");
+        }
+        Pool::Sqlite(sq)
+    }
+
+    macro_rules! sqlite_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let pool = fresh_pool().await;
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    sqlite_case!(check_exists_with_outer_ref);
+    sqlite_case!(check_not_exists_typed_outer_ref);
+    sqlite_case!(check_exclude_relation_spanning_semantics);
+    sqlite_case!(check_in_subquery);
+    sqlite_case!(check_where_has_count);
+    sqlite_case!(check_annotate_count);
+    sqlite_case!(check_scalar_subquery_in_where);
+    sqlite_case!(check_outer_ref_outside_subquery_errors);
+}
+
+// ---------------------------------------------------------------- MySQL
+
+#[cfg(feature = "mysql")]
+mod mysql_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("MYSQL_TEST_URL").ok()?;
+        let my = sqlx::MySqlPool::connect(&url).await.ok()?;
+        for sql in [
+            "DROP TABLE IF EXISTS d6sub_book",
+            "DROP TABLE IF EXISTS d6sub_author",
+            "CREATE TABLE d6sub_author (
+                id BIGINT PRIMARY KEY,
+                name VARCHAR(60) NOT NULL,
+                active BOOLEAN NOT NULL
+            )",
+            "CREATE TABLE d6sub_book (
+                id BIGINT PRIMARY KEY,
+                author_id BIGINT NOT NULL,
+                title VARCHAR(120) NOT NULL,
+                published BOOLEAN NOT NULL
+            )",
+        ] {
+            sqlx::query(sql).execute(&my).await.unwrap();
+        }
+        Some(Pool::Mysql(my))
+    }
+
+    macro_rules! mysql_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("MYSQL_TEST_URL unset — skipping MySQL django6 test");
+                    return;
+                };
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    mysql_case!(check_exists_with_outer_ref);
+    mysql_case!(check_not_exists_typed_outer_ref);
+    mysql_case!(check_exclude_relation_spanning_semantics);
+    mysql_case!(check_in_subquery);
+    mysql_case!(check_where_has_count);
+    mysql_case!(check_annotate_count);
+    mysql_case!(check_scalar_subquery_in_where);
+    mysql_case!(check_outer_ref_outside_subquery_errors);
+}

--- a/crates/rustango/tests/django6_window.rs
+++ b/crates/rustango/tests/django6_window.rs
@@ -36,7 +36,7 @@ mod scenarios {
     use rustango::core::window::{
         dense_rank, first_value, lag, ntile, rank, FrameBoundary, FrameKind, WindowFrame,
     };
-    use rustango::core::{Expr, Join, JoinKind, Model as _, Op, SqlValue, WhereExpr};
+    use rustango::core::{Join, JoinKind, Model as _, Op, SqlValue, WhereExpr};
     use rustango::sql::{raw_execute_pool, Auto, ExecError, FetcherPool as _, Pool, SqlError};
     use rustango::Model;
 
@@ -93,31 +93,6 @@ mod scenarios {
         }
     }
 
-    /// Whether this dialect's ranking-window outputs decode correctly
-    /// in dict rows. GAP-PIN (MySQL): `RANK()` / `DENSE_RANK()` /
-    /// `NTILE()` return BIGINT UNSIGNED on MySQL and the dict decoder
-    /// currently maps them to `SqlValue::Bool` — the numeric rank is
-    /// unrecoverable. LAG/FIRST_VALUE (which carry the source column's
-    /// signed type) are unaffected. Tracked in the Django 6.0 parity
-    /// audit; issue #1033.
-    fn ranking_decode_is_lossy(pool: &Pool) -> bool {
-        pool.dialect().name() == "mysql"
-    }
-
-    /// Pin the MySQL decode wart: every ranking value comes back as
-    /// `SqlValue::Bool`. Goes red the moment the decoder is fixed.
-    fn assert_lossy_ranking(rows: &[Row], key: &str) {
-        for row in rows {
-            match row.get(key) {
-                Some(SqlValue::Bool(_)) => {}
-                other => panic!(
-                    "expected the MySQL Bool-decode wart at `{key}`, got {other:?} — \
-                     if ranking windows now decode numerically, update the audit + issue"
-                ),
-            }
-        }
-    }
-
     /// `Window(Rank(), partition_by="tenant_id", order_by="-points")`
     /// — full table, both partitions in one pass.
     pub async fn check_rank_partitioned(pool: &Pool) {
@@ -138,10 +113,6 @@ mod scenarios {
             .await
             .expect("rank window");
         assert_eq!(rows.len(), 9);
-        if ranking_decode_is_lossy(pool) {
-            assert_lossy_ranking(&rows, "r");
-            return;
-        }
         let ranks: Vec<i64> = rows.iter().map(|r| as_i64(r, "r")).collect();
         // t1: 35,30,20,15,10 → 1..5; t2: 100,50,50,25 → 1,2,2,4 (RANK skips).
         assert_eq!(ranks, vec![1, 2, 3, 4, 5, 1, 2, 2, 4]);
@@ -159,10 +130,6 @@ mod scenarios {
             .fetch(pool)
             .await
             .expect("dense_rank window");
-        if ranking_decode_is_lossy(pool) {
-            assert_lossy_ranking(&rows, "d");
-            return;
-        }
         let dense: Vec<i64> = rows.iter().map(|r| as_i64(r, "d")).collect();
         assert_eq!(dense, vec![1, 2, 2, 3]);
     }
@@ -247,10 +214,6 @@ mod scenarios {
             .fetch(pool)
             .await
             .expect("ntile window");
-        if ranking_decode_is_lossy(pool) {
-            assert_lossy_ranking(&rows, "bucket");
-            return;
-        }
         let buckets: Vec<i64> = rows.iter().map(|r| as_i64(r, "bucket")).collect();
         assert_eq!(buckets, vec![1, 1, 1, 2, 2]);
     }

--- a/crates/rustango/tests/django6_window.rs
+++ b/crates/rustango/tests/django6_window.rs
@@ -1,0 +1,546 @@
+//! Django 6.0 ORM parity — execution-based verification.
+//! Scenario group C (window functions) + K (distinct_on interplay).
+//!
+//! Django scenarios covered (docs.djangoproject.com/en/6.0):
+//! - `Window(Rank(), partition_by=..., order_by=...)` (+ dense_rank,
+//!   ntile, lag-with-default, first_value with a ROWS frame)
+//! - `.distinct("tenant_id")` first-row-per-group (PG `DISTINCT ON`
+//!   native; MySQL/SQLite via the ROW_NUMBER fallback)
+//! - top-N-per-group: Django filters on a window annotation via an
+//!   outer queryset; rustango's equivalent is `join_lateral`
+//!   (PG + MySQL 8.0.14+ only — pinned `LateralJoinNotSupported` on
+//!   SQLite)
+//!
+//! AUDIT NOTES (compile-time API absences, no runtime pin possible):
+//! - Django allows *aggregates as window expressions*
+//!   (`Window(Sum("points"), ...)`); rustango's `WindowFn` has only
+//!   the 8 ranking/navigation variants — `SUM(...) OVER (...)` is not
+//!   expressible. Issue #1035 (also covers windowed-query-as-subquery).
+//! - ERGONOMICS DIVERGENCE (execution-verified): Django annotates a
+//!   window onto a plain queryset; rustango requires the explicit
+//!   `.aggregate().group_by(<every projected column>)` shape —
+//!   `.values(cols)` + window-only annotate is rejected with
+//!   `QueryError::ValuesRequiresAggregate`.
+//! - A windowed query cannot be re-embedded as a subquery source
+//!   (windows compile to `AggregateQuery`; `join_sub` takes
+//!   `SelectQuery`), so Django's `qs.annotate(rank=Window(...))` then
+//!   `.filter(rank__lte=N)` outer-wrap has no direct equivalent —
+//!   `join_lateral` is the workaround (see
+//!   `check_top_n_per_group_via_lateral`).
+
+#[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
+mod scenarios {
+    use std::collections::HashMap;
+
+    use rustango::core::joins::aliased;
+    use rustango::core::window::{
+        dense_rank, first_value, lag, ntile, rank, FrameBoundary, FrameKind, WindowFrame,
+    };
+    use rustango::core::{Expr, Join, JoinKind, Model as _, Op, SqlValue, WhereExpr};
+    use rustango::sql::{raw_execute_pool, Auto, ExecError, FetcherPool as _, Pool, SqlError};
+    use rustango::Model;
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6win_tenant")]
+    #[allow(dead_code)]
+    pub struct Tenant {
+        #[rustango(primary_key)]
+        pub id: Auto<i64>,
+        #[rustango(max_length = 40)]
+        pub name: String,
+    }
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6win_score")]
+    #[allow(dead_code)]
+    pub struct Score {
+        #[rustango(primary_key)]
+        pub id: Auto<i64>,
+        pub tenant_id: i64,
+        #[rustango(max_length = 40)]
+        pub player: String,
+        pub points: i64,
+        pub day: chrono::NaiveDate,
+    }
+
+    /// Tenant 1: alice 30→35 over two days, bob 20→15, carol 10.
+    /// Tenant 2: dave 100, eve 50, frank 50 (tie), gina 25.
+    pub async fn seed(pool: &Pool) {
+        for sql in [
+            "INSERT INTO d6win_tenant (id, name) VALUES (1, 'acme')",
+            "INSERT INTO d6win_tenant (id, name) VALUES (2, 'globex')",
+            "INSERT INTO d6win_score (id, tenant_id, player, points, day) VALUES (1, 1, 'alice', 30, '2026-01-01')",
+            "INSERT INTO d6win_score (id, tenant_id, player, points, day) VALUES (2, 1, 'alice', 35, '2026-01-02')",
+            "INSERT INTO d6win_score (id, tenant_id, player, points, day) VALUES (3, 1, 'bob', 20, '2026-01-01')",
+            "INSERT INTO d6win_score (id, tenant_id, player, points, day) VALUES (4, 1, 'bob', 15, '2026-01-02')",
+            "INSERT INTO d6win_score (id, tenant_id, player, points, day) VALUES (5, 1, 'carol', 10, '2026-01-01')",
+            "INSERT INTO d6win_score (id, tenant_id, player, points, day) VALUES (6, 2, 'dave', 100, '2026-01-01')",
+            "INSERT INTO d6win_score (id, tenant_id, player, points, day) VALUES (7, 2, 'eve', 50, '2026-01-01')",
+            "INSERT INTO d6win_score (id, tenant_id, player, points, day) VALUES (8, 2, 'frank', 50, '2026-01-01')",
+            "INSERT INTO d6win_score (id, tenant_id, player, points, day) VALUES (9, 2, 'gina', 25, '2026-01-01')",
+        ] {
+            raw_execute_pool(pool, sql, vec![]).await.expect("seed");
+        }
+    }
+
+    type Row = HashMap<String, SqlValue>;
+
+    fn as_i64(row: &Row, key: &str) -> i64 {
+        match row.get(key) {
+            Some(SqlValue::I64(n)) => *n,
+            Some(SqlValue::I32(n)) => i64::from(*n),
+            other => panic!("expected integer at `{key}`, got {other:?}"),
+        }
+    }
+
+    /// Whether this dialect's ranking-window outputs decode correctly
+    /// in dict rows. GAP-PIN (MySQL): `RANK()` / `DENSE_RANK()` /
+    /// `NTILE()` return BIGINT UNSIGNED on MySQL and the dict decoder
+    /// currently maps them to `SqlValue::Bool` — the numeric rank is
+    /// unrecoverable. LAG/FIRST_VALUE (which carry the source column's
+    /// signed type) are unaffected. Tracked in the Django 6.0 parity
+    /// audit; issue #1033.
+    fn ranking_decode_is_lossy(pool: &Pool) -> bool {
+        pool.dialect().name() == "mysql"
+    }
+
+    /// Pin the MySQL decode wart: every ranking value comes back as
+    /// `SqlValue::Bool`. Goes red the moment the decoder is fixed.
+    fn assert_lossy_ranking(rows: &[Row], key: &str) {
+        for row in rows {
+            match row.get(key) {
+                Some(SqlValue::Bool(_)) => {}
+                other => panic!(
+                    "expected the MySQL Bool-decode wart at `{key}`, got {other:?} — \
+                     if ranking windows now decode numerically, update the audit + issue"
+                ),
+            }
+        }
+    }
+
+    /// `Window(Rank(), partition_by="tenant_id", order_by="-points")`
+    /// — full table, both partitions in one pass.
+    pub async fn check_rank_partitioned(pool: &Pool) {
+        let rows = Score::objects()
+            .aggregate()
+            .group_by("tenant_id")
+            .group_by("player")
+            .group_by("points")
+            .annotate(
+                "r",
+                rank()
+                    .partition_by("tenant_id")
+                    .order_by(&[("points", true)])
+                    .into(),
+            )
+            .order_by(&[("tenant_id", false), ("points", true), ("player", false)])
+            .fetch(pool)
+            .await
+            .expect("rank window");
+        assert_eq!(rows.len(), 9);
+        if ranking_decode_is_lossy(pool) {
+            assert_lossy_ranking(&rows, "r");
+            return;
+        }
+        let ranks: Vec<i64> = rows.iter().map(|r| as_i64(r, "r")).collect();
+        // t1: 35,30,20,15,10 → 1..5; t2: 100,50,50,25 → 1,2,2,4 (RANK skips).
+        assert_eq!(ranks, vec![1, 2, 3, 4, 5, 1, 2, 2, 4]);
+    }
+
+    /// DENSE_RANK on the tied partition — no rank skipping (1,2,2,3).
+    pub async fn check_dense_rank_ties(pool: &Pool) {
+        let rows = Score::objects()
+            .aggregate()
+            .group_by("player")
+            .group_by("points")
+            .annotate("d", dense_rank().order_by(&[("points", true)]).into())
+            .filter("tenant_id", Op::Eq, 2_i64)
+            .order_by(&[("points", true), ("player", false)])
+            .fetch(pool)
+            .await
+            .expect("dense_rank window");
+        if ranking_decode_is_lossy(pool) {
+            assert_lossy_ranking(&rows, "d");
+            return;
+        }
+        let dense: Vec<i64> = rows.iter().map(|r| as_i64(r, "d")).collect();
+        assert_eq!(dense, vec![1, 2, 2, 3]);
+    }
+
+    /// `Lag("points", default=0)` partitioned per player — Django's
+    /// previous-row navigation with an out-of-range default.
+    pub async fn check_lag_with_default(pool: &Pool) {
+        let rows = Score::objects()
+            .aggregate()
+            .group_by("player")
+            .group_by("points")
+            .group_by("day")
+            .annotate(
+                "prev",
+                lag("points", 1, Some(SqlValue::I64(0)))
+                    .partition_by("player")
+                    .order_by(&[("day", false)])
+                    .into(),
+            )
+            .filter(
+                "player",
+                Op::In,
+                SqlValue::List(vec![
+                    SqlValue::String("alice".into()),
+                    SqlValue::String("bob".into()),
+                ]),
+            )
+            .order_by(&[("player", false), ("day", false)])
+            .fetch(pool)
+            .await
+            .expect("lag window");
+        let prev: Vec<i64> = rows.iter().map(|r| as_i64(r, "prev")).collect();
+        // alice d1 (no prev → 0), alice d2 (prev 30), bob d1 → 0, bob d2 → 20.
+        assert_eq!(prev, vec![0, 30, 0, 20]);
+    }
+
+    /// FIRST_VALUE with an explicit ROWS frame — every row sees its
+    /// player's first-day points.
+    pub async fn check_first_value_rows_frame(pool: &Pool) {
+        let rows = Score::objects()
+            .aggregate()
+            .group_by("player")
+            .group_by("points")
+            .group_by("day")
+            .annotate(
+                "first_pts",
+                first_value("points")
+                    .partition_by("player")
+                    .order_by(&[("day", false)])
+                    .frame(WindowFrame {
+                        kind: FrameKind::Rows,
+                        start: FrameBoundary::UnboundedPreceding,
+                        end: Some(FrameBoundary::CurrentRow),
+                    })
+                    .into(),
+            )
+            .filter(
+                "player",
+                Op::In,
+                SqlValue::List(vec![
+                    SqlValue::String("alice".into()),
+                    SqlValue::String("bob".into()),
+                ]),
+            )
+            .order_by(&[("player", false), ("day", false)])
+            .fetch(pool)
+            .await
+            .expect("first_value window");
+        let firsts: Vec<i64> = rows.iter().map(|r| as_i64(r, "first_pts")).collect();
+        assert_eq!(firsts, vec![30, 30, 20, 20]);
+    }
+
+    /// `Ntile(2)` halves tenant 1's five rows into buckets 1,1,1,2,2.
+    pub async fn check_ntile_buckets(pool: &Pool) {
+        let rows = Score::objects()
+            .aggregate()
+            .group_by("player")
+            .group_by("points")
+            .annotate("bucket", ntile(2).order_by(&[("points", true)]).into())
+            .filter("tenant_id", Op::Eq, 1_i64)
+            .order_by(&[("points", true)])
+            .fetch(pool)
+            .await
+            .expect("ntile window");
+        if ranking_decode_is_lossy(pool) {
+            assert_lossy_ranking(&rows, "bucket");
+            return;
+        }
+        let buckets: Vec<i64> = rows.iter().map(|r| as_i64(r, "bucket")).collect();
+        assert_eq!(buckets, vec![1, 1, 1, 2, 2]);
+    }
+
+    /// Django `.distinct("tenant_id")` + ordering — best score row per
+    /// tenant. PG runs native `DISTINCT ON`; MySQL/SQLite go through
+    /// the ROW_NUMBER fallback. Identical rows on all three.
+    pub async fn check_distinct_on_first_row_per_tenant(pool: &Pool) {
+        let rows: Vec<Score> = Score::objects()
+            .distinct_on(&["tenant_id"])
+            .order_by(&[("tenant_id", false), ("points", true)])
+            .fetch_pool(pool)
+            .await
+            .expect("distinct_on fetch");
+        let players: Vec<(i64, String, i64)> = rows
+            .into_iter()
+            .map(|s| (s.tenant_id, s.player, s.points))
+            .collect();
+        assert_eq!(
+            players,
+            vec![(1, "alice".into(), 35), (2, "dave".into(), 100)]
+        );
+    }
+
+    /// GAP-PIN: `distinct_on` + any join works on PG (native DISTINCT
+    /// ON) but the MySQL/SQLite ROW_NUMBER fallback rejects joins
+    /// (issue #1039).
+    /// Django supports `.distinct(*fields)` only on PG anyway, so the
+    /// PG-arm is the Django-parity surface — the pin documents the
+    /// fallback's limitation.
+    pub async fn check_distinct_on_with_join_dialect_matrix(pool: &Pool) {
+        let qs = || {
+            Score::objects()
+                .distinct_on(&["tenant_id"])
+                .order_by(&[("tenant_id", false), ("points", true)])
+                .join(Join {
+                    target: Tenant::SCHEMA,
+                    alias: "t",
+                    kind: JoinKind::Inner,
+                    // Inside an `on` predicate bare columns resolve to
+                    // the joined alias — the outer side must be
+                    // explicitly aliased by its table name.
+                    on: WhereExpr::ExprCompare {
+                        lhs: aliased("t", "id"),
+                        op: Op::Eq,
+                        rhs: aliased("d6win_score", "tenant_id"),
+                    },
+                    project: vec![],
+                })
+        };
+        if pool.dialect().name() == "postgres" {
+            let rows: Vec<Score> = qs().fetch_pool(pool).await.expect("PG DISTINCT ON + join");
+            assert_eq!(rows.len(), 2);
+        } else {
+            let err = qs()
+                .fetch_pool(pool)
+                .await
+                .map(|rows: Vec<Score>| rows.len())
+                .expect_err("distinct_on + join must be rejected on the window fallback");
+            match err {
+                ExecError::Sql(SqlError::OpNotSupportedInDialect { op, dialect }) => {
+                    assert!(
+                        op.starts_with("DISTINCT ON combined with joins"),
+                        "unexpected op: {op}"
+                    );
+                    assert_eq!(dialect, pool.dialect().name());
+                }
+                other => panic!(
+                    "expected OpNotSupportedInDialect, got {other:?} — if the \
+                     fallback now supports joins, update the Django 6.0 parity audit"
+                ),
+            }
+        }
+    }
+
+    /// Django top-N-per-group (`annotate(rank=Window(...))` +
+    /// outer-filter) — rustango's equivalent is a correlated LATERAL
+    /// join: top-2 scores for each tenant. PG + MySQL 8.0.14+ execute;
+    /// SQLite pins `LateralJoinNotSupported`.
+    pub async fn check_top_n_per_group_via_lateral(pool: &Pool) {
+        let top2 = Score::objects()
+            .where_raw(WhereExpr::ExprCompare {
+                lhs: aliased("d6win_score", "tenant_id"),
+                op: Op::Eq,
+                rhs: aliased("d6win_tenant", "id"),
+            })
+            .order_by(&[("points", true)])
+            .limit(2)
+            .compile()
+            .expect("inner compile");
+        let res = Tenant::objects()
+            .join_lateral(top2, "top", WhereExpr::And(vec![]))
+            .fetch_pool(pool)
+            .await;
+        if pool.dialect().name() == "sqlite" {
+            let err = res
+                .map(|rows: Vec<Tenant>| rows.len())
+                .expect_err("LATERAL must be rejected on sqlite");
+            match err {
+                ExecError::Sql(SqlError::LateralJoinNotSupported { dialect }) => {
+                    assert_eq!(dialect, "sqlite");
+                }
+                other => panic!(
+                    "expected LateralJoinNotSupported on sqlite, got {other:?} — \
+                     if LATERAL now works there, update the Django 6.0 parity audit"
+                ),
+            }
+        } else {
+            let rows: Vec<Tenant> = res.expect("LATERAL top-2 per tenant");
+            // 2 tenants × top-2 lateral rows each → 4 joined rows.
+            assert_eq!(rows.len(), 4, "top-2 per tenant via LATERAL");
+        }
+    }
+}
+
+// ------------------------------------------------------------- Postgres
+
+#[cfg(feature = "postgres")]
+mod pg_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let pg = sqlx::PgPool::connect(&url).await.ok()?;
+        for sql in [
+            r#"DROP TABLE IF EXISTS "d6win_score" CASCADE"#,
+            r#"DROP TABLE IF EXISTS "d6win_tenant" CASCADE"#,
+            r#"CREATE TABLE "d6win_tenant" (
+                "id" BIGINT PRIMARY KEY,
+                "name" VARCHAR(40) NOT NULL
+            )"#,
+            r#"CREATE TABLE "d6win_score" (
+                "id" BIGINT PRIMARY KEY,
+                "tenant_id" BIGINT NOT NULL,
+                "player" VARCHAR(40) NOT NULL,
+                "points" BIGINT NOT NULL,
+                "day" DATE NOT NULL
+            )"#,
+        ] {
+            sqlx::query(sql).execute(&pg).await.unwrap();
+        }
+        Some(Pool::Postgres(pg))
+    }
+
+    macro_rules! pg_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("DATABASE_URL unset — skipping PG django6 test");
+                    return;
+                };
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    pg_case!(check_rank_partitioned);
+    pg_case!(check_dense_rank_ties);
+    pg_case!(check_lag_with_default);
+    pg_case!(check_first_value_rows_frame);
+    pg_case!(check_ntile_buckets);
+    pg_case!(check_distinct_on_first_row_per_tenant);
+    pg_case!(check_distinct_on_with_join_dialect_matrix);
+    pg_case!(check_top_n_per_group_via_lateral);
+}
+
+// --------------------------------------------------------------- SQLite
+
+#[cfg(feature = "sqlite")]
+mod sqlite_live {
+    use rustango::sql::{sqlx, Pool};
+
+    use super::scenarios;
+
+    async fn fresh_pool() -> Pool {
+        let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite mem pool");
+        for sql in [
+            "CREATE TABLE d6win_tenant (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL
+            )",
+            "CREATE TABLE d6win_score (
+                id INTEGER PRIMARY KEY,
+                tenant_id INTEGER NOT NULL,
+                player TEXT NOT NULL,
+                points INTEGER NOT NULL,
+                day TEXT NOT NULL
+            )",
+        ] {
+            sqlx::query(sql).execute(&sq).await.expect("ddl");
+        }
+        Pool::Sqlite(sq)
+    }
+
+    macro_rules! sqlite_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let pool = fresh_pool().await;
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    sqlite_case!(check_rank_partitioned);
+    sqlite_case!(check_dense_rank_ties);
+    sqlite_case!(check_lag_with_default);
+    sqlite_case!(check_first_value_rows_frame);
+    sqlite_case!(check_ntile_buckets);
+    sqlite_case!(check_distinct_on_first_row_per_tenant);
+    sqlite_case!(check_distinct_on_with_join_dialect_matrix);
+    sqlite_case!(check_top_n_per_group_via_lateral);
+}
+
+// ---------------------------------------------------------------- MySQL
+
+#[cfg(feature = "mysql")]
+mod mysql_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("MYSQL_TEST_URL").ok()?;
+        let my = sqlx::MySqlPool::connect(&url).await.ok()?;
+        for sql in [
+            "DROP TABLE IF EXISTS d6win_score",
+            "DROP TABLE IF EXISTS d6win_tenant",
+            "CREATE TABLE d6win_tenant (
+                id BIGINT PRIMARY KEY,
+                name VARCHAR(40) NOT NULL
+            )",
+            "CREATE TABLE d6win_score (
+                id BIGINT PRIMARY KEY,
+                tenant_id BIGINT NOT NULL,
+                player VARCHAR(40) NOT NULL,
+                points BIGINT NOT NULL,
+                day DATE NOT NULL
+            )",
+        ] {
+            sqlx::query(sql).execute(&my).await.unwrap();
+        }
+        Some(Pool::Mysql(my))
+    }
+
+    macro_rules! mysql_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("MYSQL_TEST_URL unset — skipping MySQL django6 test");
+                    return;
+                };
+                scenarios::seed(&pool).await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    mysql_case!(check_rank_partitioned);
+    mysql_case!(check_dense_rank_ties);
+    mysql_case!(check_lag_with_default);
+    mysql_case!(check_first_value_rows_frame);
+    mysql_case!(check_ntile_buckets);
+    mysql_case!(check_distinct_on_first_row_per_tenant);
+    mysql_case!(check_distinct_on_with_join_dialect_matrix);
+    mysql_case!(check_top_n_per_group_via_lateral);
+}

--- a/crates/rustango/tests/django6_writes.rs
+++ b/crates/rustango/tests/django6_writes.rs
@@ -1,0 +1,464 @@
+//! Django 6.0 ORM parity — execution-based verification.
+//! Scenario group I: complex write paths — UPSERT, F-expression
+//! atomic updates, Case/When in UPDATE SET, zero-row update
+//! semantics (Django 6.0 `Model.NotUpdated`), get_or_create /
+//! update_or_create.
+//!
+//! Django scenarios covered (docs.djangoproject.com/en/6.0):
+//! - `bulk_create(objs, update_conflicts=True, unique_fields=...,
+//!   update_fields=...)` — single- and two-column conflict targets
+//! - `update(qty=F("qty") + 5)` atomic arithmetic, no
+//!   read-modify-write race
+//! - `update(status=Case(When(qty=0, then=Value("out")), ...))`
+//! - Django 6.0 NEW: `save(force_update=True)` affecting 0 rows now
+//!   raises `Model.NotUpdated` — rustango's divergence is pinned
+//!   (silent `Ok(())`, rows-affected discarded by the macro save
+//!   path; the QuerySet update path does surface the count)
+//! - `get_or_create()` / `update_or_create()`
+
+#[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
+mod scenarios {
+    use rustango::core::case::{case, value};
+    use rustango::core::{Column as _, F};
+    use rustango::sql::{raw_execute_pool, update_pool, Auto, FetcherPool as _, Pool};
+    use rustango::Model;
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6wr_sku")]
+    #[allow(dead_code)]
+    pub struct Sku {
+        #[rustango(primary_key)]
+        pub id: Auto<i64>,
+        #[rustango(max_length = 40, unique)]
+        pub code: String,
+        pub qty: i64,
+        pub price: i64,
+        #[rustango(max_length = 10)]
+        pub status: String,
+    }
+
+    #[derive(Model, Debug, Clone)]
+    #[rustango(table = "d6wr_stock", unique_together(columns = "warehouse, sku"))]
+    #[allow(dead_code)]
+    pub struct Stock {
+        #[rustango(primary_key)]
+        pub id: Auto<i64>,
+        #[rustango(max_length = 20)]
+        pub warehouse: String,
+        #[rustango(max_length = 40)]
+        pub sku: String,
+        pub qty: i64,
+    }
+
+    fn sku(code: &str, qty: i64, price: i64) -> Sku {
+        Sku {
+            id: Auto::default(),
+            code: code.into(),
+            qty,
+            price,
+            status: "new".into(),
+        }
+    }
+
+    async fn fetch_sku(pool: &Pool, code: &str) -> Sku {
+        let rows: Vec<Sku> = Sku::objects()
+            .filter("code", code)
+            .fetch_pool(pool)
+            .await
+            .expect("fetch sku");
+        assert_eq!(rows.len(), 1, "exactly one row for code {code}");
+        rows.into_iter().next().unwrap()
+    }
+
+    /// Django `bulk_create(update_conflicts=True, unique_fields=
+    /// ["code"], update_fields=["qty"])` — idempotent re-run updates
+    /// only the listed columns.
+    pub async fn check_bulk_upsert_idempotent(pool: &Pool) {
+        let first = vec![sku("a", 10, 100), sku("b", 20, 200)];
+        Sku::bulk_upsert_pool(&first, &["code"], &["qty", "price"], pool)
+            .await
+            .expect("first upsert");
+        assert_eq!(Sku::count(pool).await.unwrap(), 2);
+
+        // Re-run with conflicting codes: qty in the update set, price
+        // NOT — price must keep its original value.
+        let second = vec![sku("a", 11, 999), sku("c", 30, 300)];
+        Sku::bulk_upsert_pool(&second, &["code"], &["qty"], pool)
+            .await
+            .expect("second upsert");
+        assert_eq!(Sku::count(pool).await.unwrap(), 3, "a updated, c inserted");
+        let a = fetch_sku(pool, "a").await;
+        assert_eq!(a.qty, 11, "qty is in update_fields");
+        assert_eq!(a.price, 100, "price is NOT in update_fields");
+    }
+
+    /// Two-column conflict target — Django's `unique_fields=
+    /// ["warehouse", "sku"]` against a composite UNIQUE constraint.
+    pub async fn check_bulk_upsert_two_column_unique_target(pool: &Pool) {
+        let mk = |wh: &str, s: &str, qty: i64| Stock {
+            id: Auto::default(),
+            warehouse: wh.into(),
+            sku: s.into(),
+            qty,
+        };
+        Stock::bulk_upsert_pool(
+            &[mk("east", "w-1", 5), mk("west", "w-1", 7)],
+            &["warehouse", "sku"],
+            &["qty"],
+            pool,
+        )
+        .await
+        .expect("first upsert");
+        // Same (warehouse, sku) pair → update; same sku in a new
+        // warehouse → insert.
+        Stock::bulk_upsert_pool(
+            &[mk("east", "w-1", 50), mk("north", "w-1", 9)],
+            &["warehouse", "sku"],
+            &["qty"],
+            pool,
+        )
+        .await
+        .expect("second upsert");
+        assert_eq!(Stock::count(pool).await.unwrap(), 3);
+        let east: Vec<Stock> = Stock::objects()
+            .filter("warehouse", "east")
+            .fetch_pool(pool)
+            .await
+            .expect("fetch east");
+        assert_eq!(east[0].qty, 50);
+    }
+
+    /// Django `update(qty=F("qty") + 5)` — DB-side arithmetic.
+    pub async fn check_f_expression_atomic_update(pool: &Pool) {
+        Sku::bulk_upsert_pool(&[sku("f-test", 10, 1)], &["code"], &["qty"], pool)
+            .await
+            .expect("seed");
+        let q = Sku::objects()
+            .filter("code", "f-test")
+            .update()
+            .set_expr("qty", F("qty") + 5_i64)
+            .compile()
+            .expect("update compile");
+        let affected = update_pool(pool, &q).await.expect("update execute");
+        assert_eq!(affected, 1);
+        assert_eq!(fetch_sku(pool, "f-test").await.qty, 15);
+    }
+
+    /// Django `update(status=Case(When(qty=0, then=Value("out")),
+    /// default=Value("in")))` — conditional bulk update.
+    pub async fn check_case_when_in_update(pool: &Pool) {
+        Sku::bulk_upsert_pool(
+            &[sku("c-zero", 0, 1), sku("c-some", 4, 1)],
+            &["code"],
+            &["qty"],
+            pool,
+        )
+        .await
+        .expect("seed");
+        let q = Sku::objects()
+            .update()
+            .set_expr(
+                "status",
+                case()
+                    .when(Sku::qty.eq(0_i64), value("out"))
+                    .default(value("in")),
+            )
+            .compile()
+            .expect("update compile");
+        let affected = update_pool(pool, &q).await.expect("update execute");
+        assert!(affected >= 2);
+        assert_eq!(fetch_sku(pool, "c-zero").await.status, "out");
+        assert_eq!(fetch_sku(pool, "c-some").await.status, "in");
+    }
+
+    /// Django 6.0 NEW: a forced update affecting 0 rows raises
+    /// `Model.NotUpdated`. rustango: the QuerySet update path DOES
+    /// surface rows-affected (0 here), but the instance-level
+    /// `save_pool` on a stale row silently returns `Ok(())` — the
+    /// macro discards rows-affected. DIVERGENCE PIN: this goes red — issue #1029 —
+    /// (and the audit row flips) if save ever starts surfacing it.
+    pub async fn check_zero_row_update_semantics(pool: &Pool) {
+        // QuerySet path: no match → 0 affected, no error. Same as
+        // Django's `.update()` (which never raises NotUpdated).
+        let q = Sku::objects()
+            .filter("code", "ghost")
+            .update()
+            .set("qty", 1_i64)
+            .compile()
+            .expect("update compile");
+        let affected = update_pool(pool, &q).await.expect("update execute");
+        assert_eq!(affected, 0);
+
+        // Instance path: fetch a row, delete it out from under the
+        // instance, then save — the UPDATE matches nothing.
+        Sku::bulk_upsert_pool(&[sku("stale", 1, 1)], &["code"], &["qty"], pool)
+            .await
+            .expect("seed");
+        let mut stale = fetch_sku(pool, "stale").await;
+        raw_execute_pool(pool, "DELETE FROM d6wr_sku WHERE code = 'stale'", vec![])
+            .await
+            .expect("delete behind the instance's back");
+        stale.qty = 99;
+        stale
+            .save_pool(pool)
+            .await
+            .expect("PINNED DIVERGENCE: rustango save() is silent on 0-row update; Django 6.0 raises Model.NotUpdated");
+        assert_eq!(
+            Sku::objects()
+                .filter("code", "stale")
+                .fetch_pool(pool)
+                .await
+                .map(|rows: Vec<Sku>| rows.len())
+                .unwrap(),
+            0,
+            "the silent save really did update nothing"
+        );
+    }
+
+    /// Django `get_or_create(code="goc")` — create-then-find.
+    pub async fn check_get_or_create(pool: &Pool) {
+        let (created_sku, created) = Sku::objects()
+            .filter("code", "goc")
+            .get_or_create(
+                |pool| async move {
+                    let mut s = sku("goc", 1, 10);
+                    s.save_pool(&pool).await?;
+                    Ok(s)
+                },
+                pool,
+            )
+            .await
+            .expect("get_or_create #1");
+        assert!(created);
+        assert_eq!(created_sku.code, "goc");
+
+        let (found, created) = Sku::objects()
+            .filter("code", "goc")
+            .get_or_create(
+                |_pool| async move { panic!("row exists — create must not run") },
+                pool,
+            )
+            .await
+            .expect("get_or_create #2");
+        assert!(!created);
+        assert_eq!(found.qty, 1);
+    }
+
+    /// Django `update_or_create(code="uoc", defaults={"qty": 5})`.
+    pub async fn check_update_or_create(pool: &Pool) {
+        let (row, created) = Sku::objects()
+            .filter("code", "uoc")
+            .update_or_create(
+                |_pool, _row| async move { panic!("missing row — update must not run") },
+                |pool| async move {
+                    let mut s = sku("uoc", 1, 10);
+                    s.save_pool(&pool).await?;
+                    Ok(s)
+                },
+                pool,
+            )
+            .await
+            .expect("update_or_create create branch");
+        assert!(created);
+        assert_eq!(row.qty, 1);
+
+        let (row, created) = Sku::objects()
+            .filter("code", "uoc")
+            .update_or_create(
+                |pool, mut row| async move {
+                    row.qty = 5;
+                    row.save_pool(&pool).await?;
+                    Ok(row)
+                },
+                |_pool| async move { panic!("row exists — create must not run") },
+                pool,
+            )
+            .await
+            .expect("update_or_create update branch");
+        assert!(!created);
+        assert_eq!(row.qty, 5);
+        assert_eq!(fetch_sku(pool, "uoc").await.qty, 5);
+    }
+}
+
+// ------------------------------------------------------------- Postgres
+
+#[cfg(feature = "postgres")]
+mod pg_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let pg = sqlx::PgPool::connect(&url).await.ok()?;
+        for sql in [
+            r#"DROP TABLE IF EXISTS "d6wr_sku" CASCADE"#,
+            r#"DROP TABLE IF EXISTS "d6wr_stock" CASCADE"#,
+            r#"CREATE TABLE "d6wr_sku" (
+                "id" BIGSERIAL PRIMARY KEY,
+                "code" VARCHAR(40) NOT NULL UNIQUE,
+                "qty" BIGINT NOT NULL,
+                "price" BIGINT NOT NULL,
+                "status" VARCHAR(10) NOT NULL
+            )"#,
+            r#"CREATE TABLE "d6wr_stock" (
+                "id" BIGSERIAL PRIMARY KEY,
+                "warehouse" VARCHAR(20) NOT NULL,
+                "sku" VARCHAR(40) NOT NULL,
+                "qty" BIGINT NOT NULL,
+                UNIQUE ("warehouse", "sku")
+            )"#,
+        ] {
+            sqlx::query(sql).execute(&pg).await.unwrap();
+        }
+        Some(Pool::Postgres(pg))
+    }
+
+    macro_rules! pg_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("DATABASE_URL unset — skipping PG django6 test");
+                    return;
+                };
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    pg_case!(check_bulk_upsert_idempotent);
+    pg_case!(check_bulk_upsert_two_column_unique_target);
+    pg_case!(check_f_expression_atomic_update);
+    pg_case!(check_case_when_in_update);
+    pg_case!(check_zero_row_update_semantics);
+    pg_case!(check_get_or_create);
+    pg_case!(check_update_or_create);
+}
+
+// --------------------------------------------------------------- SQLite
+
+#[cfg(feature = "sqlite")]
+mod sqlite_live {
+    use rustango::sql::{sqlx, Pool};
+
+    use super::scenarios;
+
+    async fn fresh_pool() -> Pool {
+        let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite mem pool");
+        for sql in [
+            "CREATE TABLE d6wr_sku (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                code TEXT NOT NULL UNIQUE,
+                qty INTEGER NOT NULL,
+                price INTEGER NOT NULL,
+                status TEXT NOT NULL
+            )",
+            "CREATE TABLE d6wr_stock (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                warehouse TEXT NOT NULL,
+                sku TEXT NOT NULL,
+                qty INTEGER NOT NULL,
+                UNIQUE (warehouse, sku)
+            )",
+        ] {
+            sqlx::query(sql).execute(&sq).await.expect("ddl");
+        }
+        Pool::Sqlite(sq)
+    }
+
+    macro_rules! sqlite_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let pool = fresh_pool().await;
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    sqlite_case!(check_bulk_upsert_idempotent);
+    sqlite_case!(check_bulk_upsert_two_column_unique_target);
+    sqlite_case!(check_f_expression_atomic_update);
+    sqlite_case!(check_case_when_in_update);
+    sqlite_case!(check_zero_row_update_semantics);
+    sqlite_case!(check_get_or_create);
+    sqlite_case!(check_update_or_create);
+}
+
+// ---------------------------------------------------------------- MySQL
+
+#[cfg(feature = "mysql")]
+mod mysql_live {
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn fresh_pool() -> Option<Pool> {
+        let url = std::env::var("MYSQL_TEST_URL").ok()?;
+        let my = sqlx::MySqlPool::connect(&url).await.ok()?;
+        for sql in [
+            "DROP TABLE IF EXISTS d6wr_sku",
+            "DROP TABLE IF EXISTS d6wr_stock",
+            "CREATE TABLE d6wr_sku (
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                code VARCHAR(40) NOT NULL UNIQUE,
+                qty BIGINT NOT NULL,
+                price BIGINT NOT NULL,
+                status VARCHAR(10) NOT NULL
+            )",
+            "CREATE TABLE d6wr_stock (
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                warehouse VARCHAR(20) NOT NULL,
+                sku VARCHAR(40) NOT NULL,
+                qty BIGINT NOT NULL,
+                UNIQUE KEY uq_wh_sku (warehouse, sku)
+            )",
+        ] {
+            sqlx::query(sql).execute(&my).await.unwrap();
+        }
+        Some(Pool::Mysql(my))
+    }
+
+    macro_rules! mysql_case {
+        ($name:ident) => {
+            #[tokio::test]
+            async fn $name() {
+                let _g = live_lock().lock().await;
+                let Some(pool) = fresh_pool().await else {
+                    eprintln!("MYSQL_TEST_URL unset — skipping MySQL django6 test");
+                    return;
+                };
+                scenarios::$name(&pool).await;
+            }
+        };
+    }
+
+    mysql_case!(check_bulk_upsert_idempotent);
+    mysql_case!(check_bulk_upsert_two_column_unique_target);
+    mysql_case!(check_f_expression_atomic_update);
+    mysql_case!(check_case_when_in_update);
+    mysql_case!(check_zero_row_update_semantics);
+    mysql_case!(check_get_or_create);
+    mysql_case!(check_update_or_create);
+}

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -21,7 +21,7 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | Category | SHIPPED | PARTIAL | MISSING | N/A |
 |---|---:|---:|---:|---:|
 | 1. ORM — models / fields / Meta | 22 | 1 | 1 | 0 |
-| 2. QuerySet API | 38 | 1 | 1 | 0 |
+| 2. QuerySet API | 36 | 2 | 2 | 0 |
 | 3. Field types & options | 32 | 0 | 2 | 1 |
 | 4. Postgres-specific fields | 5 | 0 | 0 | 0 |
 | 5. Migrations | 15 | 0 | 0 | 1 |
@@ -45,9 +45,9 @@ This is a static snapshot — when in doubt about a row, `grep` the cited source
 | 23. DRF parity | 22 | 0 | 1 | 0 |
 | 24. contrib modules | 12 | 1 | 3 | 2 |
 | 25. `django.utils.*` helpers | 106 | 0 | 0 | 0 |
-| **Totals** | **481** | **11** | **21** | **19** |
+| **Totals** | **479** | **12** | **22** | **19** |
 
-Coverage = 481 / (481 + 11 + 21) = **94% full, 2% partial, 4% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **96%**.
+Coverage = 479 / (479 + 12 + 22) = **93% full, 2% partial, 4% missing** vs Django 6.0 surface (excluding 19 N/A rows). Partial+shipped = **96%**. (Two rows corrected by the 2026-06-12 execution-verification pass — see §26.3.)
 
 Snapshot date: 2026-06-06 (post-v0.42 plus 100+ Django `utils.*` + `template.defaultfilters` + `validators` parity helpers across PRs #619–#731 + the 2026-06-06 Laravel 13 / Eloquent parity sweep: date-transform lookups (#834 / #829), `refresh_from_db` + `replicate` (#835 / #825), `default_uuid_v7` (#836 / #823), `Observer<T>` + quiet writes (#837 / #827), reverse-FK accessor + per-FK `related_name` (#838 / #841, #816), `Prunable` + `manage prune` (#848 / #822), `manage clear-cache` / `createcachetable` (#849 / #850), `QuerySet::active()` / `only_trashed()` / `with_trashed()` (#851 / #821 partial), `whereJsonLength` (#853 / #826), `__not_in` (#854) / `__not_between` (#855) / raw-`__like` (#856), the full Eloquent Model-level CRUD-shortcut surface — `find_pool` / `find_or_fail_pool` / `find_many_pool` / `all_pool` / `first_pool` / `first_or_fail_pool` / `first_where_pool` / `count_pool` / `exists_pool` / `latest_pool` / `earliest_pool` / `destroy_pool` / `truncate_pool` / `pluck_pool` / `query` / `fresh_pool` (PRs #857–#873), and soft-delete instance `_pool` family (`soft_delete_pool` / `restore_pool` / `force_delete_pool`, PR #872, closing more of #821). CI Docker pull mirror migrated to `public.ecr.aws/docker/library/` (PR #868) — eliminates the intermittent `registry-1.docker.io` timeouts that were affecting earlier PRs.
 
@@ -91,13 +91,13 @@ Summary: **22 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-bas
 | Django method | Doc | Status | rustango pointer | Notes |
 |---|---|---|---|---|
 | `.filter(**kwargs)` (string keyed) | [filter](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#filter) | SHIPPED | [crates/rustango/src/query/mod.rs#QuerySet::filter](crates/rustango/src/query/mod.rs) | `__icontains`, `__in`, `__gte`, `__between` etc. via `parse_lookup`. |
-| `.exclude(**kwargs)` | [exclude](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#exclude) | SHIPPED | `.exclude(...)` | |
+| `.exclude(**kwargs)` | [exclude](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#exclude) | MISSING | n/a — no `QuerySet::exclude` exists (the only `exclude` is the unrelated forms field-whitelist builder). Negate via `Q::negate()` / `where_raw(WhereExpr::Not)` / `where_doesnt_have*`. | Disproven by execution 2026-06-12 (§26.3), #1030. Django's exclude-on-multi-valued-relation semantics ARE available via `where_doesnt_have_filter` — pinned in `tests/django6_subquery.rs`. |
 | `Q()` composable | [Q](https://docs.djangoproject.com/en/6.0/topics/db/queries/#complex-lookups-with-q-objects) | SHIPPED | `Q!()` compile-time macro + `core::query::Q` runtime (T1.1, T1.7) | |
 | `F()` expression | [F](https://docs.djangoproject.com/en/6.0/ref/models/expressions/#f) | SHIPPED | `F("col")` in [src/core/expr.rs](crates/rustango/src/core/expr.rs) | |
 | `.annotate(alias=expr)` | [annotate](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#annotate) | SHIPPED | `AggregateBuilder::annotate` + tri-dialect GROUP BY parity (T2.8 closed) | |
 | `.alias()` (non-projected) | [alias](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#alias) | SHIPPED | T1.6 closed | |
 | `.aggregate(**kwargs)` | [aggregate](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#aggregate) | SHIPPED | `aggregates::{count_all, sum, avg, min, max, ...}` | |
-| Window functions (`Window`, `RowNumber`, `Rank`, `Lag`, `Lead`) | [Window](https://docs.djangoproject.com/en/6.0/ref/models/expressions/#window-functions) | SHIPPED | `core::window::{row_number, rank, dense_rank, lag, lead, ntile}` | |
+| Window functions (`Window`, `RowNumber`, `Rank`, `Lag`, `Lead`) | [Window](https://docs.djangoproject.com/en/6.0/ref/models/expressions/#window-functions) | PARTIAL | `core::window::{row_number, rank, dense_rank, lag, lead, ntile, first_value, last_value}` | Downgraded 2026-06-12 (§26.2-C): only the 8 ranking/navigation fns — Django's aggregates-as-windows (`Window(Sum(...))`) inexpressible, windowed query can't be a subquery source (top-N-per-group needs `join_lateral`, PG/MySQL-only) — #1035. Required shape is `.aggregate().group_by(<every projected col>)` (`.values()`+window errors `ValuesRequiresAggregate`). MySQL: ranking outputs decode as `SqlValue::Bool` in dict rows — #1033. Pinned in `tests/django6_window.rs`. |
 | `Subquery()`, `OuterRef()`, `Exists()` | [Subquery](https://docs.djangoproject.com/en/6.0/ref/models/expressions/#subquery-expressions) | SHIPPED | `core::subquery::{Subquery, OuterRef, exists}` | |
 | `Case` / `When` | [Case](https://docs.djangoproject.com/en/6.0/ref/models/expressions/#case) | SHIPPED | `core::case::case()` builder | |
 | `.values(*fields)` (dict-shape projection) | [values](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#values) | SHIPPED | `.values_dict(&["col", ...])` + `.values(...).annotate(...)` Shape 2/3 (T2.8) | |
@@ -125,13 +125,13 @@ Summary: **22 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A**. Gaps: full abstract-bas
 | `.count()` / `.exists()` | [count](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#count) | SHIPPED | `.count_pool` / `.exists_pool`. Model-level shortcut: `Self::count_pool(&pool)` / `Self::exists_pool(&pool)` (PR #861). | |
 | Eloquent-shape Model-level CRUD shortcuts (`find` / `findOrFail` / `findMany` / `all` / `first` / `firstOrFail` / `firstWhere` / `count` / `exists` / `latest` / `oldest` / `destroy` / `truncate` / `pluck` / `query` / `fresh` / `refresh` / `replicate` / soft-delete trio) | n/a in Django core (verbs live on `objects.<x>`) | SHIPPED | Macro-emitted on every `#[derive(Model)]` struct with a PK across PRs #835 / #857–#873. Full surface: `Self::find_pool(pk, &pool) -> Option<Self>` (#857), `find_or_fail_pool` (#859), `find_many_pool(pks, &pool) -> Vec<Self>` (#871), `all_pool(&pool) -> Vec<Self>` (#858), `first_pool` / `first_or_fail_pool` (#860), `first_where_pool(col, val, &pool)` (#869), `count_pool(&pool) -> i64` / `exists_pool(&pool) -> bool` (#861), `latest_pool` / `earliest_pool(field, &pool)` (#862), `destroy_pool(pks, &pool) -> u64` (#863), `truncate_pool(&pool) -> u64` (#864), `pluck_pool::<U>(col, &pool) -> Vec<U>` (#865), `query()` Eloquent alias of `objects()` (#870), `fresh_pool(&pool) -> Option<Self>` (#873), `refresh_from_db_pool(&mut self, &pool)` + `replicate(&self) -> Self` (#835). For soft-delete-enabled models: `soft_delete_pool` / `restore_pool` / `force_delete_pool` (#872). Rustango ahead of Django here; matches Eloquent's Model-level surface. | |
 | `.get_or_create()` / `.update_or_create()` | [get_or_create](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#get-or-create) | SHIPPED | `sql::get_or_create` + `sql::update_or_create` | |
-| `.union()` / `.intersection()` / `.difference()` | [union](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#union) | SHIPPED | `QuerySet::{union, union_all, intersection, difference}` + `with_compound(SetOp, …)` (closed #329, v0.42). Writer emits the bare compound shape (`SELECT … UNION SELECT …`) — portable across PG / MySQL / SQLite. Branches with per-branch `ORDER BY` / `LIMIT` / `OFFSET` wrap in `SELECT * FROM (<branch>)` so those clauses scope to the branch instead of attaching to the outer compound. **MySQL caveat**: native `INTERSECT` / `EXCEPT` require 8.0.31+; pre-8.0.31 surfaces a driver syntax error. | |
+| `.union()` / `.intersection()` / `.difference()` | [union](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#union) | SHIPPED | `QuerySet::{union, union_all, intersection, difference}` + `with_compound(SetOp, …)` (closed #329, v0.42). Writer emits the bare compound shape (`SELECT … UNION SELECT …`) — portable across PG / MySQL / SQLite. Branches with per-branch `ORDER BY` / `LIMIT` / `OFFSET` wrap in `SELECT * FROM (<branch>)` so those clauses scope to the branch instead of attaching to the outer compound. **MySQL caveat**: native `INTERSECT` / `EXCEPT` require 8.0.31+; pre-8.0.31 surfaces a driver syntax error. Execution-verified 2026-06-12 (§26.2-E): per-branch wrapper emits NO derived-table alias → MySQL error 1248 on ordered/limited branches (#1032); ORDER BY/LIMIT on the FIRST queryset always apply to the combined result — Django 4.0+ slices both components (#1034). Pinned in `tests/django6_setops.rs`. | |
 | `.contains(obj)` / `.exists()` | [contains](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#contains) | SHIPPED | `ExistsPool::exists_pool(&pool)` + `ExistsPool::contains_pk(&pool, pk)` (#330, v0.42). `contains_pk` looks up the PK column from the schema; takes a typed pk value rather than the obj instance to keep the Rust API explicit. | |
 | `.none()` | [none](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#none) | SHIPPED | `QuerySet::none()` (closed #331, v0.42) — SELECT compiles to `LIMIT 0`; UPDATE / DELETE add an `<pk> IS NULL` guard against the (NOT NULL) primary key so every row is rejected. Chained filters / ordering are preserved alongside the marker (Django semantic). | |
-| `__lookup`s (`__icontains`, `__lt`, `__in`, `__between`, `__range`, `__isnull`, ...) | [Field lookups](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#field-lookups) | SHIPPED | `parse_lookup` in query/mod.rs | Django field-lookup coverage including date-transform chains: `__year` / `__month` / `__day` / `__hour` / `__minute` / `__second` / `__quarter` / `__week` / `__week_day` / `__date` + composition with trailing comparison ops (`created__year__gte`) shipped in PR #834 (#829). |
+| `__lookup`s (`__icontains`, `__lt`, `__in`, `__between`, `__range`, `__isnull`, ...) | [Field lookups](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#field-lookups) | SHIPPED | `parse_lookup` in query/mod.rs | Django field-lookup coverage including date-transform chains: `__year` / `__month` / `__day` / `__hour` / `__minute` / `__second` / `__quarter` / `__week` / `__week_day` / `__date` + composition with trailing comparison ops (`created__year__gte`) shipped in PR #834 (#829). `__quarter` errors on SQLite (Django lowers via CASE) — #1037, pinned in `tests/django6_json_dates.rs`. |
 | `.using(db_alias)` (multi-DB routing) | [using](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#using) | MISSING | n/a (#332) | rustango is single-pool-per-QuerySet (or tenant-scoped); multi-DB router missing. |
 
-Summary: **38 SHIPPED / 1 PARTIAL / 1 MISSING / 0 N/A** (post-#857–#865 Eloquent Model-shortcut surface added as one row). Gaps: multi-DB `.using()` (#332), plus a few esoteric Postgres lookups. `.dates/datetimes/contains/none` all shipped in v0.42; `__date` / `__year` / `__year__lte` and the full date-transform lookup grammar shipped post-v0.42 (PR #834, #829). Lookup-parser drift fixes for `__not_in` (PR #854), `__not_between` / `__not_range` (PR #855), and raw-pattern `__like` / `__ilike` / `__not_like` / `__not_ilike` (PR #856) closed the remaining Eloquent `whereNotIn` / `whereNotBetween` / `whereLike` / `whereNotLike` gaps. `whereJsonLength` shipped via `ScalarFn::JsonArrayLength` (PR #853).
+Summary: **36 SHIPPED / 2 PARTIAL / 2 MISSING / 0 N/A** (post-#857–#865 Eloquent Model-shortcut surface added as one row; `.exclude()` corrected to MISSING and Window downgraded to PARTIAL by the 2026-06-12 execution pass, §26.3). Gaps: multi-DB `.using()` (#332), `.exclude()` (#1030), relation-spanning lookups (#1031), plus a few esoteric Postgres lookups. `.dates/datetimes/contains/none` all shipped in v0.42; `__date` / `__year` / `__year__lte` and the full date-transform lookup grammar shipped post-v0.42 (PR #834, #829). Lookup-parser drift fixes for `__not_in` (PR #854), `__not_between` / `__not_range` (PR #855), and raw-pattern `__like` / `__ilike` / `__not_like` / `__not_ilike` (PR #856) closed the remaining Eloquent `whereNotIn` / `whereNotBetween` / `whereLike` / `whereNotLike` gaps. `whereJsonLength` shipped via `ScalarFn::JsonArrayLength` (PR #853).
 
 ---
 
@@ -831,6 +831,64 @@ Net effect of the 2026-06-04→06-06 batch:
 * **Companion DRY cleanup batch — PRs #777–#795 (#561 + #562)**: 19 PRs totaling ~1000 lines removed. Introduces `SelectQuery::new` + `::by_pk` constructors and migrates 40+ sites; collapses tri-dialect match-pool arms via `raw_query_pool::<(T,)>` + per-backend row-decoder helpers (`AuditEntry::from_my_row` / `from_sq_row`, `decode_role_*_row`, `decode_has_perm_*_row`, `decode_bucket_*_row`, `decode_facet_row<R: sqlx::Row>`); fixes the silent-loss snapshot bug where file-based migrations dropped `generated_as` and `db_comment` column attributes (#777).
 
 Bulk closure of Django `utils.*` API surface — the most-common helper functions a Django port reaches for during translation now have direct rustango equivalents. Outstanding gaps in this category: `regex_helper.normalize` (URL-conf regex normalization — niche), `formats.localize` (locale-aware value rendering — large lift, requires per-locale config wiring), `safestring.mark_safe` (N/A — Tera handles autoescape natively).
+
+---
+
+## 26. Django 6.0 delta + execution verification (2026-06-12)
+
+Everything above this section is claims-based (rows point at source). This section is **execution-based**: `tests/django6_*.rs` (8 files, ~165 test executions) run the scenarios below against live PG 16, SQLite (in-memory), and MySQL 8.0. Every PINNED GAP / DIVERGENCE row has a test that asserts the *current* behavior and goes red the moment the gap is fixed — fixing one means updating the test, the linked issue, and this table.
+
+Run locally: `docker-compose up -d`, then per backend —
+`DATABASE_URL=postgres://rustango:rustango@localhost:5432/rustango_test cargo test -p rustango --all-features --test django6_<x>` /
+`cargo test -p rustango --no-default-features --features sqlite,tenancy --test django6_<x>` /
+`MYSQL_TEST_URL=mysql://rustango:rustango@127.0.0.1:3406/rustango_test cargo test -p rustango --features mysql --test django6_<x>`.
+
+### 26.1 Django 6.0 release-note delta
+
+| Django 6.0 feature | Status | Evidence (test) | Issue |
+|---|---|---|---|
+| `StringAgg` database-agnostic (was contrib.postgres) | PG SHIPPED / MySQL + SQLite PINNED GAP (`AggregateNotSupportedInDialect`) | `django6_delta.rs::check_string_agg_dialect_matrix` | #1024 |
+| `AnyValue` aggregate (new) | MISSING — no `AggregateExpr` variant | compile-time absence | #1025 |
+| `Aggregate(order_by=...)` (new; deprecates PG `OrderableAggMixin`) | MISSING — `StringAgg` IR carries no ordering | compile-time absence | #1026 |
+| `JSONField` negative array index on SQLite (new) | PG SHIPPED / SQLite PINNED GAP (MySQL N/A upstream — `$[N]` is non-negative-only) | `django6_json_dates.rs::check_negative_index_dialect_matrix` | #1027 |
+| `GeneratedField` auto-refresh after `save()` via RETURNING | PINNED DIVERGENCE — DB value correct, struct never refreshed (any backend) | `django6_delta.rs::check_generated_column_not_refreshed_on_save` | #1028 |
+| `Model.NotUpdated` on forced 0-row update | DIVERGES — QuerySet `update_pool` surfaces rows-affected (0), instance `save_pool` silently `Ok(())` | `django6_writes.rs::check_zero_row_update_semantics` | #1029 |
+| `CompositePrimaryKey` in `raw()` / subquery lookups beyond `__in` | N/A BY ARCHITECTURE — composite-key idiom is surrogate `Auto<i64>` + `unique_together`; tuple-membership `(a,b) IN (SELECT…)` has no API (workaround: multi-predicate correlated EXISTS) | `django6_subquery.rs` header note | — |
+| `bulk_create(update_conflicts=True, unique_fields, update_fields)` | SHIPPED — verified incl. two-column composite conflict target + update-listed-columns-only | `django6_writes.rs::check_bulk_upsert_*` | — |
+| `DEFAULT_AUTO_FIELD` → `BigAutoField` default | SHIPPED — `Auto<i64>` ↔ BIGSERIAL / BIGINT AUTO_INCREMENT / INTEGER PK on all three | `django6_delta.rs::check_auto_pk_is_big_auto_field` | — |
+| `Model.save()` positional args removed / `as_sql()` tuple params / DB-backend method renames | N/A — Python-API internals with no rustango surface | — | — |
+
+### 26.2 Complex-query execution matrix
+
+Status per scenario group (PG / SQLite / MySQL). ✓ = passes asserting Django-equivalent semantics.
+
+| Group | Scenarios | PG | SQLite | MySQL | Test file | Findings |
+|---|---|---|---|---|---|---|
+| A. Conditional aggregation | `Count(filter=Q)`, `Sum(filter, default)`, `count_distinct`, compound predicates in FILTER | ✓ | ✓ | ✓ (CASE-WHEN rewrite) | `django6_aggregation.rs` | `stddev` on SQLite pinned `AggregateNotSupported` (matches Django). **Shape note**: bare `.aggregate().annotate()` is Django's `.annotate()` (Shape 3, GROUP BY every scalar column); Django's single-row `aggregate()` requires explicit `.values(&[])`. |
+| F. Grouping shapes | `values().annotate()` GROUP BY inference, filter-on-annotation → HAVING, `.alias()` non-projected | ✓ | ✓ | ✓ | `django6_aggregation.rs` | WHERE-vs-HAVING auto-routing verified live. |
+| B. Correlated subqueries | `Exists`+`OuterRef` (raw + typed `eq_expr`), NOT EXISTS, exclude-on-relation semantics, `IN (SELECT…)`, has-count, `annotate_count`, scalar `Subquery` in WHERE | ✓ | ✓ | ✓ | `django6_subquery.rs` | `where_doesnt_have_filter` reproduces Django's exclude-NOT-EXISTS semantics exactly (bookless parents included). `OuterRef` misuse pinned (`OuterRefOutsideSubquery`). Scalar `Subquery` as projected annotation inexpressible — #1036. |
+| C. Window functions | rank/dense_rank/lag(default)/first_value+ROWS frame/ntile, partitioned | ✓ | ✓ | ✓* | `django6_window.rs` | *MySQL ranking outputs decode as `SqlValue::Bool` (#1033, pinned). Required shape: `.aggregate().group_by(<every projected col>)`. `Sum(...) OVER` + windowed-subquery missing (#1035); top-N-per-group via `join_lateral` works PG/MySQL, `LateralJoinNotSupported` pinned on SQLite. |
+| K. distinct_on | first-row-per-group, +join | ✓ | ✓ (window fallback) | ✓ (window fallback) | `django6_window.rs` | Fallback rejects joins — pinned `OpNotSupportedInDialect` on SQLite/MySQL (#1039); PG native handles joins. |
+| D. Multi-join | 3-hop `select_related` stitching, cross-table filter via `.join()`+`aliased`, F-across-join, relation-count inflation | ✓ | ✓ | ✓ | `django6_joins.rs` | Relation-spanning `filter("author__name",…)` / `order_by("author__name")` rejected at compile — #1031 (workaround verified). `annotate_count` never inflates (correlated subquery ≡ Django `distinct=True`). One relation aggregate per query (#1038); `.join()` doesn't compose with `.aggregate()` — `values("author__name").annotate(Count)` shape inexpressible (#1040). |
+| E. Set operations | union dedup/all, per-branch + combined ORDER/LIMIT, intersection, difference, `with_compound` | ✓ | ✓ | ✓* | `django6_setops.rs` | *Ordered/limited branches broken on MySQL — alias-less derived table, error 1248 (#1032, pinned). First-queryset ORDER/LIMIT always combined-scoped (#1034, pinned). INTERSECT/EXCEPT floor: MySQL 8.0.31+. |
+| G. JSON lookups | nested keys, key+index, array length, negative index | ✓ | ✓ (neg. index pinned) | ✓ (neg. index pinned) | `django6_json_dates.rs` | Negative index PG-only — #1027 (Django 6.0 supports SQLite). |
+| H. Date transforms | `__year__gte` chains, `__month`, `__quarter`, `.dates()`, `.datetimes()` | ✓ | ✓ (`__quarter` pinned) | ✓ | `django6_json_dates.rs` | `__quarter` errors on SQLite — #1037. `.dates()/.datetimes()` truncation identical tri-dialect. |
+| I. Complex writes | bulk_upsert (single + composite target), F-expression update, Case-in-UPDATE, 0-row semantics, get/update_or_create | ✓ | ✓ | ✓ | `django6_writes.rs` | 0-row instance-save divergence pinned — #1029. |
+
+### 26.3 Corrections to earlier sections (claims disproven by execution)
+
+1. **§2 `.exclude(**kwargs)`: SHIPPED → MISSING** (#1030). No `QuerySet::exclude` exists — the audit pointer was wrong (`forms::exclude` is a field whitelist). Row edited in place.
+2. **§2 Window functions: SHIPPED → PARTIAL** (#1033, #1035). Ranking/navigation fns work tri-dialect, but aggregates-as-windows and filter-on-window-result are inexpressible, and MySQL dict-decode is lossy. Row edited in place.
+3. **§2 union row**: per-branch clause claims corrected — MySQL alias bug (#1032) + first-branch scoping (#1034) appended.
+4. **§2 lookups row**: `__quarter` SQLite caveat appended (#1037).
+5. Summary stats updated: section 2 now 36/2/2, totals 479/12/22 (93% full).
+
+### 26.4 New ergonomics/API notes (no Django-side equivalent claim broken, recorded for the next reader)
+
+- `.values(cols)` + window-only annotate → `QueryError::ValuesRequiresAggregate`; explicit `group_by` per projected column is the canonical window shape.
+- Inside a `.join()` `on` predicate, bare `Expr::Column` qualifies to the **joined** alias — refer to the outer table via `joins::aliased("<outer_table>", col)`.
+- `annotate_count`/`annotate_sum`… live on `QuerySet` and return `AggregateBuilder` — two relation aggregates in one query is not expressible (#1038); grouping by a related column (`values("author__name").annotate(...)`) is also inexpressible since `AggregateQuery` carries no joins (#1040).
+- Aggregate `.filter()` builder + `WindowBuilder`/`StringAgg` wrappers reject nesting (`NestedAggregateWrapper`) — Django's `StringAgg(..., filter=...)` shape included.
 
 ---
 


### PR DESCRIPTION
## What
`RANK()` / `DENSE_RANK()` / `NTILE()` (and `COUNT(*)`) return **BIGINT UNSIGNED** on MySQL. `my_cell_to_sqlvalue`'s probe chain had no unsigned arm, so the i64 probe failed and sqlx's permissive `bool` decode swallowed the value as `SqlValue::Bool` — the numeric rank was unrecoverable. Closes #1033.

## How
Branch on the column type **first** — `type_info().name().contains("UNSIGNED")` → decode `u64` (→ i64, with a `String` fallback for the theoretical `> i64::MAX`) or `u32`. The type-info guard is safer than reordering the probe chain: real `BOOLEAN` / `TINYINT(1)` columns aren't `UNSIGNED`, so they still fall through to the `bool` probe and decode as `Bool` — **no regression** to genuine booleans.

## Tests
Removed the `ranking_decode_is_lossy` / `assert_lossy_ranking` MySQL gap-pins; RANK/DENSE_RANK/NTILE now assert the same numeric ranks on MySQL as PG/SQLite. **Verified on mysql + sqlite.** (Also dropped a pre-existing unused `Expr` import in the touched test.)