### PR TITLE
feat(orm): QuerySet::exclude() — closes #1030

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,7 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_filepath_field
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test serializer_cross_validate
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_none
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_exclude_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test sqlmigrate
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_set_ops
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test set_algebra_emission

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -143,6 +143,11 @@ enum PendingFilter {
     /// typed-column API). Already validated; contributes a whole
     /// sub-tree to the WHERE clause.
     Expr(WhereExpr),
+    /// Negated predicate — `NOT (<inner>)`. Backs
+    /// [`QuerySet::exclude`] (#1030). The inner entry is resolved
+    /// recursively then wrapped in [`WhereExpr::Not`], so `exclude`
+    /// inherits the full lookup grammar (`__gt`, `__icontains`, …).
+    Negated(Box<PendingFilter>),
     /// Deferred error surfaced at `compile()` time. Used by
     /// [`QuerySet::filter`] (issue #71) when the lookup-suffix
     /// parser fails — keeps the builder API non-Result while
@@ -1293,26 +1298,35 @@ impl<T: Model> QuerySet<T> {
     /// `prefetch_related`). v1 supports single-table fields only.
     #[must_use]
     pub fn filter(mut self, key: &str, value: impl Into<SqlValue>) -> Self {
-        let raw = value.into();
-        match parse_lookup(key, raw) {
-            Ok(ParsedLookup::Raw { field, op, value }) => self.filter_op(field, op, value),
-            Ok(ParsedLookup::DateTransform {
-                field,
-                transform,
-                op,
-                value,
-            }) => {
-                self.pending
-                    .push(PendingFilter::DateTransform(DateTransformFilter {
-                        field,
-                        transform,
-                        op,
-                        value,
-                    }));
-                self
-            }
-            Err(e) => self.with_pending_error(e),
-        }
+        self.pending.push(parse_to_pending(key, value.into()));
+        self
+    }
+
+    /// Django `.exclude(key, value)` — the negation of [`Self::filter`].
+    /// Each `exclude` call wraps **its own** predicate in `NOT (…)`;
+    /// chained excludes AND together (identical to Django for
+    /// single-kwarg excludes). The full `__lookup` suffix grammar works
+    /// through `exclude` exactly as through `filter` (shared parser).
+    ///
+    /// ```ignore
+    /// // Django: Post.objects.exclude(status="draft")
+    /// Post::objects().exclude("status", "draft").fetch_pool(&pool).await?;
+    /// // with a lookup suffix:
+    /// Post::objects().exclude("views__lt", 100_i64)
+    /// ```
+    ///
+    /// **NULL semantics:** `NOT (col = v)` excludes rows where `col IS
+    /// NULL` (SQL three-valued logic) — matching Django's emission for
+    /// the same shape. For Django's multi-kwarg `exclude(a=1, b=2)` (one
+    /// `NOT` over the whole group), compose `where_raw(!Q(...))`.
+    #[must_use]
+    pub fn exclude(mut self, key: &str, value: impl Into<SqlValue>) -> Self {
+        self.pending
+            .push(PendingFilter::Negated(Box::new(parse_to_pending(
+                key,
+                value.into(),
+            ))));
+        self
     }
 
     /// Stash a builder-time error to surface at `compile()` time.
@@ -3174,33 +3188,60 @@ fn never_match_clause(
     })
 }
 
+/// Parse a `key`/`value` pair through the lookup grammar into a single
+/// [`PendingFilter`]. Shared by [`QuerySet::filter`] and
+/// [`QuerySet::exclude`] (#1030) so the `__lookup` suffix grammar can
+/// never drift between the two.
+fn parse_to_pending(key: &str, value: SqlValue) -> PendingFilter {
+    match parse_lookup(key, value) {
+        Ok(ParsedLookup::Raw { field, op, value }) => {
+            PendingFilter::Raw(RawFilter { field, op, value })
+        }
+        Ok(ParsedLookup::DateTransform {
+            field,
+            transform,
+            op,
+            value,
+        }) => PendingFilter::DateTransform(DateTransformFilter {
+            field,
+            transform,
+            op,
+            value,
+        }),
+        Err(e) => PendingFilter::Error(e),
+    }
+}
+
 fn resolve_pending(
     model: &'static ModelSchema,
     pending: Vec<PendingFilter>,
 ) -> Result<WhereExpr, QueryError> {
     let mut nodes: Vec<WhereExpr> = Vec::with_capacity(pending.len());
     for entry in pending {
-        match entry {
-            PendingFilter::Raw(raw) => {
-                nodes.push(WhereExpr::Predicate(resolve_filter(model, raw)?));
-            }
-            PendingFilter::DateTransform(dt) => {
-                nodes.push(resolve_date_transform(model, dt)?);
-            }
-            PendingFilter::Resolved(filter) => {
-                nodes.push(WhereExpr::Predicate(filter));
-            }
-            PendingFilter::Expr(expr) => {
-                nodes.push(expr);
-            }
-            PendingFilter::Error(e) => {
-                // Issue #71 — bubble the deferred lookup-parse error
-                // up at the natural `compile()` checkpoint.
-                return Err(e);
-            }
-        }
+        nodes.push(resolve_one_pending(model, entry)?);
     }
     Ok(WhereExpr::And(nodes))
+}
+
+/// Lower a single [`PendingFilter`] to a [`WhereExpr`]. Split out of
+/// [`resolve_pending`]'s loop so [`PendingFilter::Negated`] can resolve
+/// its inner entry recursively (#1030).
+fn resolve_one_pending(
+    model: &'static ModelSchema,
+    entry: PendingFilter,
+) -> Result<WhereExpr, QueryError> {
+    Ok(match entry {
+        PendingFilter::Raw(raw) => WhereExpr::Predicate(resolve_filter(model, raw)?),
+        PendingFilter::DateTransform(dt) => resolve_date_transform(model, dt)?,
+        PendingFilter::Resolved(filter) => WhereExpr::Predicate(filter),
+        PendingFilter::Expr(expr) => expr,
+        PendingFilter::Negated(inner) => {
+            WhereExpr::Not(Box::new(resolve_one_pending(model, *inner)?))
+        }
+        // Issue #71 — bubble the deferred lookup-parse error up at the
+        // natural `compile()` checkpoint.
+        PendingFilter::Error(e) => return Err(e),
+    })
 }
 
 fn resolve_filter(model: &'static ModelSchema, raw: RawFilter) -> Result<Filter, QueryError> {

--- a/crates/rustango/tests/queryset_exclude_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_exclude_sqlite_live.rs
@@ -1,0 +1,108 @@
+//! Live SQLite test for `QuerySet::exclude` (Django `.exclude()`,
+//! #1030). Covers the filter/exclude inverse pair, `__lookup` suffixes
+//! through exclude, chained-excludes-AND, and the NULL-row semantics of
+//! `NOT (col = v)`.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+
+use rustango::core::Model as _;
+use rustango::sql::{raw_execute_pool, sqlx, FetcherPool as _, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "qex_post")]
+#[allow(dead_code)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: i64,
+    #[rustango(max_length = 20)]
+    pub status: String,
+    pub views: i64,
+    #[rustango(max_length = 20)]
+    pub category: Option<String>,
+}
+
+async fn seeded() -> Pool {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite");
+    raw_execute_pool(
+        &Pool::Sqlite(sq.clone()),
+        "CREATE TABLE qex_post (id INTEGER PRIMARY KEY AUTOINCREMENT, \
+         status TEXT NOT NULL, views INTEGER NOT NULL, category TEXT)",
+        vec![],
+    )
+    .await
+    .expect("create");
+    let pool = Pool::Sqlite(sq);
+    for sql in [
+        "INSERT INTO qex_post (id, status, views, category) VALUES (1, 'draft', 10, 'a')",
+        "INSERT INTO qex_post (id, status, views, category) VALUES (2, 'published', 200, 'b')",
+        "INSERT INTO qex_post (id, status, views, category) VALUES (3, 'archived', 50, NULL)",
+        "INSERT INTO qex_post (id, status, views, category) VALUES (4, 'published', 100, 'a')",
+    ] {
+        raw_execute_pool(&pool, sql, vec![]).await.expect("seed");
+    }
+    pool
+}
+
+async fn ids(pool: &Pool, qs: rustango::query::QuerySet<Post>) -> Vec<i64> {
+    let mut v: Vec<i64> = qs
+        .fetch_pool(pool)
+        .await
+        .expect("fetch")
+        .into_iter()
+        .map(|p| p.id)
+        .collect();
+    v.sort_unstable();
+    v
+}
+
+#[tokio::test]
+async fn exclude_is_the_inverse_of_filter() {
+    let pool = seeded().await;
+
+    let drafts = ids(&pool, Post::objects().filter("status", "draft")).await;
+    assert_eq!(drafts, vec![1]);
+
+    let non_drafts = ids(&pool, Post::objects().exclude("status", "draft")).await;
+    assert_eq!(non_drafts, vec![2, 3, 4]);
+
+    // filter ∪ exclude = every row (status is NOT NULL here).
+    let mut union = drafts;
+    union.extend(non_drafts);
+    union.sort_unstable();
+    assert_eq!(union, vec![1, 2, 3, 4]);
+}
+
+#[tokio::test]
+async fn exclude_supports_lookup_suffixes() {
+    let pool = seeded().await;
+    // NOT (views < 100) → views >= 100 → ids 2 (200) + 4 (100).
+    let got = ids(&pool, Post::objects().exclude("views__lt", 100_i64)).await;
+    assert_eq!(got, vec![2, 4]);
+}
+
+#[tokio::test]
+async fn chained_excludes_and_together() {
+    let pool = seeded().await;
+    // NOT draft AND NOT archived → published rows.
+    let got = ids(
+        &pool,
+        Post::objects()
+            .exclude("status", "draft")
+            .exclude("status", "archived"),
+    )
+    .await;
+    assert_eq!(got, vec![2, 4]);
+}
+
+#[tokio::test]
+async fn exclude_drops_null_rows() {
+    let pool = seeded().await;
+    // NOT (category = 'a') excludes the 'a' rows (1, 4) AND the NULL-row
+    // (3) — `NOT (NULL = 'a')` is NULL, which fails the WHERE. Matches
+    // Django's emission. Only the 'b' row (2) survives.
+    let got = ids(&pool, Post::objects().exclude("category", "a")).await;
+    assert_eq!(got, vec![2], "NULL category row excluded by NOT(=)");
+}


### PR DESCRIPTION
## What
The Django 6.0 parity audit marked `.exclude()` as shipped, but no `QuerySet::exclude` existed (the only `exclude` was the unrelated forms field-whitelist builder). Adds it as the negation of `filter`. Closes #1030.

## How
- `PendingFilter::Negated(Box<PendingFilter>)` variant.
- `exclude(key, value)` runs the **same** lookup grammar as `filter` via a shared `parse_to_pending` helper (so `__gt`/`__icontains`/… can't drift between filter and exclude), wrapping the parsed entry in `Negated`.
- `resolve_pending`'s loop is factored into `resolve_one_pending`; `Negated` resolves its inner entry recursively → `WhereExpr::Not`. `filter` re-expressed over the shared helper — **identical behavior** (existing filter tests unchanged).

Semantics match Django: each `exclude` negates its own predicate; chained excludes AND; `NOT (col = v)` drops NULL rows (three-valued logic). Multi-kwarg one-NOT-over-the-group → `where_raw(!Q(...))`.

## Tests
`queryset_exclude_sqlite_live`: filter/exclude inverse pair, `__lookup` through exclude, chained-excludes-AND, NULL-row exclusion. Verified on sqlite; `cargo test --workspace --all-features --no-run` green.