### PR TITLE
feat(orm): StringAgg lowers to GROUP_CONCAT/group_concat — closes #1024

### DIFF
--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -940,20 +940,57 @@ fn write_aggregate_expr(
             delimiter,
             distinct,
         } => {
-            if b.d.name() != "postgres" {
-                return Err(SqlError::AggregateNotSupportedInDialect {
-                    aggregate: "string_agg",
-                    dialect: b.d.name(),
-                });
+            // Django 6.0 made StringAgg database-agnostic (#1024): PG
+            // `string_agg`, MySQL `GROUP_CONCAT`, SQLite `group_concat`.
+            match b.d.name() {
+                "mysql" => {
+                    // `SEPARATOR` does NOT accept a bound parameter — the
+                    // delimiter is inlined as a literal (single-quotes
+                    // doubled to stay injection-safe).
+                    b.sql.push_str("GROUP_CONCAT(");
+                    if *distinct {
+                        b.sql.push_str("DISTINCT ");
+                    }
+                    b.write_ident(column);
+                    b.sql.push_str(" SEPARATOR '");
+                    b.sql.push_str(&delimiter.replace('\'', "''"));
+                    b.sql.push_str("')");
+                }
+                "sqlite" => {
+                    // SQLite rejects `group_concat(DISTINCT col, sep)` —
+                    // DISTINCT aggregates take exactly one argument. Mirror
+                    // Django: allow DISTINCT only with the default ','
+                    // separator; reject DISTINCT + a custom delimiter.
+                    if *distinct {
+                        if delimiter.as_str() != "," {
+                            return Err(SqlError::AggregateNotSupportedInDialect {
+                                aggregate: "string_agg(DISTINCT) with a custom delimiter (SQLite group_concat DISTINCT takes one arg)",
+                                dialect: b.d.name(),
+                            });
+                        }
+                        b.sql.push_str("group_concat(DISTINCT ");
+                        b.write_ident(column);
+                        b.sql.push(')');
+                    } else {
+                        b.sql.push_str("group_concat(");
+                        b.write_ident(column);
+                        b.sql.push_str(", ");
+                        b.push_param(crate::core::SqlValue::String(delimiter.clone()));
+                        b.sql.push(')');
+                    }
+                }
+                // Postgres (+ any future dialect): the standard form.
+                _ => {
+                    b.sql.push_str("string_agg(");
+                    if *distinct {
+                        b.sql.push_str("DISTINCT ");
+                    }
+                    b.write_ident(column);
+                    b.sql.push_str(", ");
+                    b.push_param(crate::core::SqlValue::String(delimiter.clone()));
+                    b.sql.push(')');
+                }
             }
-            b.sql.push_str("string_agg(");
-            if *distinct {
-                b.sql.push_str("DISTINCT ");
-            }
-            b.write_ident(column);
-            b.sql.push_str(", ");
-            b.push_param(crate::core::SqlValue::String(delimiter.clone()));
-            b.sql.push(')');
             Ok(())
         }
         AggregateExpr::JsonbAgg { column } => {

--- a/crates/rustango/tests/django6_delta.rs
+++ b/crates/rustango/tests/django6_delta.rs
@@ -30,7 +30,7 @@
 #[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
 mod scenarios {
     use rustango::core::{AggregateExpr, SqlValue};
-    use rustango::sql::{raw_execute_pool, Auto, ExecError, FetcherPool as _, Pool, SqlError};
+    use rustango::sql::{raw_execute_pool, Auto, FetcherPool as _, Pool};
     use rustango::Model;
 
     #[derive(Model, Debug, Clone)]
@@ -68,51 +68,34 @@ mod scenarios {
         }
     }
 
-    /// Django 6.0: `StringAgg("name", delimiter=Value(","))` works on
-    /// every backend. rustango: PG-only — GAP-PIN on MySQL + SQLite
-    /// (both have native equivalents: GROUP_CONCAT / group_concat). Issue #1024.
+    /// Django 6.0: `StringAgg("name", delimiter=Value(","))` is
+    /// database-agnostic — PG `string_agg`, MySQL `GROUP_CONCAT`, SQLite
+    /// `group_concat` (#1024). Uniform assertion across all backends.
     pub async fn check_string_agg_dialect_matrix(pool: &Pool) {
-        let res = DeltaRow::objects()
+        let rows = DeltaRow::objects()
             .aggregate()
             .values(&[])
             .annotate("names", AggregateExpr::string_agg("name", ","))
             .fetch(pool)
-            .await;
-        if pool.dialect().name() == "postgres" {
-            let rows = res.expect("string_agg on PG");
-            let joined = match rows[0].get("names") {
-                Some(SqlValue::String(s)) => s.clone(),
-                other => panic!("expected string names, got {other:?}"),
-            };
-            // No order_by param exists on the aggregate (Django 6.0
-            // Aggregate.order_by gap) — element order is arbitrary,
-            // so sort before asserting.
-            let mut parts: Vec<&str> = joined.split(',').collect();
-            parts.sort_unstable();
-            assert_eq!(parts, vec!["alpha", "beta", "beta", "gamma"]);
-        } else {
-            let err = res.expect_err("string_agg must be rejected off-PG");
-            match err {
-                ExecError::Sql(SqlError::AggregateNotSupportedInDialect { aggregate, dialect }) => {
-                    assert_eq!(aggregate, "string_agg");
-                    assert_eq!(dialect, pool.dialect().name());
-                }
-                other => panic!(
-                    "expected AggregateNotSupportedInDialect, got {other:?} — if \
-                     string_agg now lowers to GROUP_CONCAT here (Django 6.0 made \
-                     StringAgg database-agnostic), update the audit + issue"
-                ),
-            }
-        }
+            .await
+            .expect("string_agg on every backend");
+        let joined = match rows[0].get("names") {
+            Some(SqlValue::String(s)) => s.clone(),
+            other => panic!("expected string names, got {other:?}"),
+        };
+        // No order_by param yet (#1026) — element order is arbitrary, so
+        // sort before asserting.
+        let mut parts: Vec<&str> = joined.split(',').collect();
+        parts.sort_unstable();
+        assert_eq!(parts, vec!["alpha", "beta", "beta", "gamma"]);
     }
 
-    /// `string_agg(DISTINCT name, ...)` on PG — the dedup variant.
-    /// Off-PG it is the same pinned gap as above, so only the PG arm
-    /// asserts content.
+    /// `string_agg(DISTINCT name, ",")` — the dedup variant. With the
+    /// default `,` delimiter this works on every backend (#1024): PG
+    /// `string_agg(DISTINCT …)`, MySQL `GROUP_CONCAT(DISTINCT …)`, SQLite
+    /// `group_concat(DISTINCT …)` (DISTINCT + a *custom* delimiter stays
+    /// rejected on SQLite — covered by the emission tests).
     pub async fn check_string_agg_distinct(pool: &Pool) {
-        if pool.dialect().name() != "postgres" {
-            return;
-        }
         let rows = DeltaRow::objects()
             .aggregate()
             .values(&[])

--- a/crates/rustango/tests/pg_aggregates.rs
+++ b/crates/rustango/tests/pg_aggregates.rs
@@ -1,6 +1,8 @@
 //! Tri-dialect emission tests for PG aggregate functions (issue #33):
-//! `array_agg`, `string_agg`, `jsonb_agg`. PG-only — non-PG backends
-//! must emit `SqlError::AggregateNotSupportedInDialect`.
+//! `array_agg`, `string_agg`, `jsonb_agg`. `array_agg` / `jsonb_agg`
+//! stay PG-only (non-PG emits `SqlError::AggregateNotSupportedInDialect`);
+//! `string_agg` is database-agnostic as of Django 6.0 (#1024) — it
+//! lowers to GROUP_CONCAT (MySQL) / group_concat (SQLite).
 
 use rustango::core::{AggregateExpr, AggregateQuery, SqlValue, WhereExpr};
 use rustango::sql::{Dialect, MySql, Postgres, SqlError, Sqlite};
@@ -111,22 +113,24 @@ fn string_agg_distinct_emits_distinct() {
 }
 
 #[test]
-fn string_agg_rejected_on_non_pg() {
+fn string_agg_lowers_on_mysql_and_sqlite() {
+    // #1024 — Django 6.0 made StringAgg database-agnostic. MySQL maps to
+    // GROUP_CONCAT (delimiter inlined into SEPARATOR), SQLite to
+    // group_concat (delimiter bound as a parameter).
     let q = aggregate_query(AggregateExpr::string_agg("tag", ", "), "tags");
-    assert!(matches!(
-        MySql.compile_aggregate(&q),
-        Err(SqlError::AggregateNotSupportedInDialect {
-            aggregate: "string_agg",
-            ..
-        })
-    ));
-    assert!(matches!(
-        Sqlite.compile_aggregate(&q),
-        Err(SqlError::AggregateNotSupportedInDialect {
-            aggregate: "string_agg",
-            ..
-        })
-    ));
+    let my = MySql.compile_aggregate(&q).unwrap();
+    assert!(
+        my.sql.contains("GROUP_CONCAT(`tag` SEPARATOR ', ')"),
+        "MySQL GROUP_CONCAT: {}",
+        my.sql
+    );
+    let sq = Sqlite.compile_aggregate(&q).unwrap();
+    assert!(
+        sq.sql.contains(r#"group_concat("tag", "#),
+        "SQLite group_concat: {}",
+        sq.sql
+    );
+    assert_eq!(sq.params, vec![SqlValue::String(", ".into())]);
 }
 
 // ---------- jsonb_agg ----------


### PR DESCRIPTION
## What
Django 6.0 promoted `StringAgg` from contrib.postgres to database-agnostic core. rustango's `AggregateExpr::StringAgg` was PG-only; now lowers per-dialect. Closes #1024.

## How (`write_aggregate_expr` arm)
- **PG**: `string_agg(col, $delim)` — unchanged (delimiter bound).
- **MySQL**: `GROUP_CONCAT([DISTINCT ]col SEPARATOR '<delim>')` — `SEPARATOR` can't take a bound param, so the delimiter is inlined as a literal (single-quotes doubled, injection-safe).
- **SQLite**: `group_concat(col, ?)` (delimiter bound). DISTINCT aggregates take one arg, so `DISTINCT + custom delimiter` is rejected (matches Django); `DISTINCT` with the default `,` → `group_concat(DISTINCT col)`.

`array_agg` / `jsonb_agg` stay PG-only.

## Tests
Flipped both pins: `pg_aggregates::string_agg_rejected_on_non_pg` → `string_agg_lowers_on_mysql_and_sqlite` (emission), and `django6_delta::check_string_agg_dialect_matrix` / `check_string_agg_distinct` to uniform cross-dialect assertions. **Verified on pg + mysql + sqlite.**

Follow-ups on this issue family: #1025 (AnyValue), #1026 (Aggregate `order_by`).