### PR TITLE
feat(orm): AnyValue aggregate (Django 6.0) — closes #1025

### DIFF
--- a/crates/rustango/src/core/aggregates.rs
+++ b/crates/rustango/src/core/aggregates.rs
@@ -170,6 +170,17 @@ pub fn min(column: &'static str) -> AggregateBuilder {
     AggregateBuilder::new(AggregateExpr::Min(column))
 }
 
+/// `ANY_VALUE(column)` — an arbitrary value from the group's non-null
+/// inputs (new in Django 6.0, #1025). Projects a functionally-dependent
+/// column without adding it to GROUP BY. PG 16+ `any_value()`, MySQL
+/// `ANY_VALUE()`, SQLite `min()` fallback. PG < 16 has no `any_value()`
+/// and the server errors at execution. Composes with `.filter()` /
+/// `.default()` via the existing wrappers.
+#[must_use]
+pub fn any_value(column: &'static str) -> AggregateBuilder {
+    AggregateBuilder::new(AggregateExpr::AnyValue(column))
+}
+
 /// `STDDEV_SAMP(column)` — sample standard deviation. Native on PG
 /// and MySQL 8+; SQLite has no built-in stddev and the writer raises
 /// `SqlError::AggregateNotSupported` (matches Django behavior).

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -1473,6 +1473,12 @@ pub enum AggregateExpr {
     Max(&'static str),
     /// `MIN(column)`.
     Min(&'static str),
+    /// `ANY_VALUE(column)` — an arbitrary value from the group's non-null
+    /// inputs (new in Django 6.0, #1025). Lets a functionally-dependent
+    /// column be projected without adding it to GROUP BY. PG 16+
+    /// `any_value()`, MySQL `ANY_VALUE()`, SQLite falls back to `min()`
+    /// (deterministic, satisfies the "arbitrary value" contract).
+    AnyValue(&'static str),
     /// `STDDEV_SAMP(column)` — sample standard deviation. Issue #6.
     /// Native on PG + MySQL 8+; the writer raises
     /// [`crate::sql::SqlError::AggregateNotSupported`] on SQLite,
@@ -1573,6 +1579,7 @@ impl AggregateExpr {
             | AggregateExpr::Avg(_)
             | AggregateExpr::Max(_)
             | AggregateExpr::Min(_)
+            | AggregateExpr::AnyValue(_)
             | AggregateExpr::StdDev(_)
             | AggregateExpr::StdDevPop(_)
             | AggregateExpr::Variance(_)

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -792,6 +792,17 @@ fn format_bare_aggregate(b: &Sql<'_>, expr: &AggregateExpr) -> Result<String, Sq
         AggregateExpr::Avg(col) => format!("AVG({})", b.d.quote_ident(col)),
         AggregateExpr::Max(col) => format!("MAX({})", b.d.quote_ident(col)),
         AggregateExpr::Min(col) => format!("MIN({})", b.d.quote_ident(col)),
+        AggregateExpr::AnyValue(col) => {
+            // Django 6.0 (#1025): PG 16+ `any_value()`, MySQL
+            // `ANY_VALUE()`, SQLite has neither — fall back to `min()`
+            // (deterministic, satisfies the "arbitrary value" contract).
+            let ident = b.d.quote_ident(col);
+            match b.d.name() {
+                "mysql" => format!("ANY_VALUE({ident})"),
+                "sqlite" => format!("min({ident})"),
+                _ => format!("any_value({ident})"),
+            }
+        }
         AggregateExpr::StdDev(col)
         | AggregateExpr::StdDevPop(col)
         | AggregateExpr::Variance(col)
@@ -1053,6 +1064,7 @@ fn write_aggregate_as_case_when(
         AggregateExpr::Avg(col) => ("AVG", Some(*col), ""),
         AggregateExpr::Max(col) => ("MAX", Some(*col), ""),
         AggregateExpr::Min(col) => ("MIN", Some(*col), ""),
+        AggregateExpr::AnyValue(col) => ("ANY_VALUE", Some(*col), ""),
         AggregateExpr::StdDev(col)
         | AggregateExpr::StdDevPop(col)
         | AggregateExpr::Variance(col)
@@ -1124,6 +1136,7 @@ fn aggregate_column(expr: &AggregateExpr) -> Option<&'static str> {
         | AggregateExpr::Avg(c)
         | AggregateExpr::Max(c)
         | AggregateExpr::Min(c)
+        | AggregateExpr::AnyValue(c)
         | AggregateExpr::StdDev(c)
         | AggregateExpr::StdDevPop(c)
         | AggregateExpr::Variance(c)

--- a/crates/rustango/tests/django6_delta.rs
+++ b/crates/rustango/tests/django6_delta.rs
@@ -4,8 +4,10 @@
 //!
 //! Release-note items covered here:
 //! - `StringAgg` is database-agnostic in Django 6.0 (was PG-only
-//!   contrib.postgres) — rustango is still PG-only: PINNED GAP on
-//!   MySQL (GROUP_CONCAT) + SQLite (group_concat)
+//!   contrib.postgres) — rustango lowers it to GROUP_CONCAT (MySQL) /
+//!   group_concat (SQLite) (#1024)
+//! - `AnyValue` aggregate (new in 6.0) — PG `any_value()`, MySQL
+//!   `ANY_VALUE()`, SQLite `min()` fallback (#1025)
 //! - `GeneratedField` values are refreshed from the database after
 //!   `save()` on RETURNING-capable backends (PG/SQLite) — rustango
 //!   never refreshes: PINNED DIVERGENCE (DB value correct, struct
@@ -15,7 +17,6 @@
 //!
 //! Release-note items that are compile-time API absences (no runtime
 //! pin possible — audit rows + issues only):
-//! - `AnyValue` aggregate (new in 6.0): no `AggregateExpr` variant. Issue #1025.
 //! - `Aggregate(order_by=...)` (new in 6.0, deprecates PG
 //!   `OrderableAggMixin`): `AggregateExpr::StringAgg` carries no
 //!   ordering (issue #1026) — element order in the joined string is
@@ -116,6 +117,44 @@ mod scenarios {
         );
     }
 
+    /// Django 6.0 `AnyValue` (#1025) — projects a value from each group
+    /// without adding the column to GROUP BY. Group by name, then take
+    /// `any_value(id)`: the returned id must be a member of that name's
+    /// group (PG/MySQL pick arbitrarily; SQLite's `min()` fallback picks
+    /// the lowest — both are valid group members).
+    pub async fn check_any_value(pool: &Pool) {
+        let rows = DeltaRow::objects()
+            .aggregate()
+            .group_by("name")
+            .annotate("anyid", AggregateExpr::AnyValue("id"))
+            .fetch(pool)
+            .await
+            .expect("any_value on every backend");
+        assert_eq!(rows.len(), 3, "three distinct names");
+        for row in &rows {
+            let name = match row.get("name") {
+                Some(SqlValue::String(s)) => s.as_str(),
+                other => panic!("expected name, got {other:?}"),
+            };
+            let anyid = match row.get("anyid") {
+                Some(SqlValue::I64(n)) => *n,
+                Some(SqlValue::I32(n)) => i64::from(*n),
+                other => panic!("expected integer anyid, got {other:?}"),
+            };
+            // Seed: alpha=id1, beta=id2+id4, gamma=id3.
+            let ok = match name {
+                "alpha" => anyid == 1,
+                "beta" => anyid == 2 || anyid == 4,
+                "gamma" => anyid == 3,
+                other => panic!("unexpected name {other}"),
+            };
+            assert!(
+                ok,
+                "any_value(id) for {name} returned {anyid}, not a group member"
+            );
+        }
+    }
+
     /// Django 6.0: after `save()`, `GeneratedField`s refresh from the
     /// database via RETURNING (PG/SQLite; deferred on MySQL).
     /// rustango DIVERGENCE PIN: the DB computes the column correctly
@@ -213,6 +252,7 @@ mod pg_live {
 
     pg_case!(check_string_agg_dialect_matrix);
     pg_case!(check_string_agg_distinct);
+    pg_case!(check_any_value);
     pg_case!(check_generated_column_not_refreshed_on_save);
     pg_case!(check_auto_pk_is_big_auto_field);
 }
@@ -259,6 +299,7 @@ mod sqlite_live {
 
     sqlite_case!(check_string_agg_dialect_matrix);
     sqlite_case!(check_string_agg_distinct);
+    sqlite_case!(check_any_value);
     sqlite_case!(check_generated_column_not_refreshed_on_save);
     sqlite_case!(check_auto_pk_is_big_auto_field);
 }
@@ -318,6 +359,7 @@ mod mysql_live {
 
     mysql_case!(check_string_agg_dialect_matrix);
     mysql_case!(check_string_agg_distinct);
+    mysql_case!(check_any_value);
     mysql_case!(check_generated_column_not_refreshed_on_save);
     mysql_case!(check_auto_pk_is_big_auto_field);
 }

--- a/crates/rustango/tests/pg_aggregates.rs
+++ b/crates/rustango/tests/pg_aggregates.rs
@@ -133,6 +133,39 @@ fn string_agg_lowers_on_mysql_and_sqlite() {
     assert_eq!(sq.params, vec![SqlValue::String(", ".into())]);
 }
 
+// ---------- any_value (#1025) ----------
+
+#[test]
+fn any_value_emits_per_dialect() {
+    // Django 6.0 AnyValue: PG `any_value()`, MySQL `ANY_VALUE()`, SQLite
+    // has neither so it falls back to `min()` (deterministic).
+    let q = aggregate_query(AggregateExpr::AnyValue("tag"), "any_tag");
+    assert!(
+        Postgres
+            .compile_aggregate(&q)
+            .unwrap()
+            .sql
+            .contains(r#"any_value("tag")"#),
+        "PG any_value"
+    );
+    assert!(
+        MySql
+            .compile_aggregate(&q)
+            .unwrap()
+            .sql
+            .contains("ANY_VALUE(`tag`)"),
+        "MySQL ANY_VALUE"
+    );
+    assert!(
+        Sqlite
+            .compile_aggregate(&q)
+            .unwrap()
+            .sql
+            .contains(r#"min("tag")"#),
+        "SQLite min() fallback"
+    );
+}
+
 // ---------- jsonb_agg ----------
 
 #[test]


### PR DESCRIPTION
## What
Django 6.0 added `AnyValue` — returns an arbitrary value from a group's non-null inputs (project a functionally-dependent column without adding it to GROUP BY). Closes #1025.

## How
- `AggregateExpr::AnyValue(col)` variant + `aggregates::any_value(col)` builder.
- Per-dialect emission: PG 16+ `any_value()`, MySQL `ANY_VALUE()`, SQLite `min()` fallback (deterministic — same trick Django uses on older SQLite). PG < 16 errors at execution (version-floor posture).
- Wired into the variant's required match sites: `is_aggregating` → true, `aggregate_column` → Some(col), and the MySQL FILTER `CASE WHEN` rewrite (`ANY_VALUE(CASE …)`) so it composes with `.filter()`/`.default()`.

## Tests
`pg_aggregates::any_value_emits_per_dialect` (emission, 3 dialects) + `django6_delta::check_any_value` (live: group by name, `any_value(id)` returns a group member). **Verified on pg + mysql + sqlite**; `cargo test --workspace --all-features --no-run` green.

Sibling: #1026 (`Aggregate(order_by=…)`) follows once this lands.