### PR TITLE
feat(orm): Aggregate order_by — ordered StringAgg (Django 6.0) — closes #1026

### DIFF
--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -1536,6 +1536,10 @@ pub enum AggregateExpr {
         column: &'static str,
         delimiter: String,
         distinct: bool,
+        /// `ORDER BY` inside the aggregate (Django 6.0 `Aggregate(order_by=…)`,
+        /// #1026). Empty = backend-arbitrary order. With `distinct`, every
+        /// clause must order by `column` itself (validated at emit).
+        order_by: Vec<OrderClause>,
     },
     /// PG: `jsonb_agg(column)` — collects column values into a JSONB
     /// array. Issue #33. **Postgres-only**.
@@ -1629,6 +1633,7 @@ impl AggregateExpr {
             column,
             delimiter: delimiter.into(),
             distinct: false,
+            order_by: Vec::new(),
         }
     }
 
@@ -1640,6 +1645,53 @@ impl AggregateExpr {
             column,
             delimiter: delimiter.into(),
             distinct: true,
+            order_by: Vec::new(),
+        }
+    }
+
+    /// `string_agg(column, delimiter ORDER BY …)` — ordered concatenation
+    /// (Django 6.0 `Aggregate(order_by=…)`, #1026). `order` is a slice of
+    /// `(column, desc)` pairs (the `WindowBuilder::order_by` convention).
+    #[must_use]
+    pub fn string_agg_ordered(
+        column: &'static str,
+        delimiter: impl Into<String>,
+        order: &[(&'static str, bool)],
+    ) -> Self {
+        Self::StringAgg {
+            column,
+            delimiter: delimiter.into(),
+            distinct: false,
+            order_by: order
+                .iter()
+                .map(|(c, desc)| OrderClause {
+                    column: c,
+                    desc: *desc,
+                })
+                .collect(),
+        }
+    }
+
+    /// `string_agg(DISTINCT column, delimiter ORDER BY …)` (#1026). With
+    /// DISTINCT, `order` may only reference `column` itself — enforced at
+    /// emit time (PG hard requirement; portable-safe everywhere).
+    #[must_use]
+    pub fn string_agg_distinct_ordered(
+        column: &'static str,
+        delimiter: impl Into<String>,
+        order: &[(&'static str, bool)],
+    ) -> Self {
+        Self::StringAgg {
+            column,
+            delimiter: delimiter.into(),
+            distinct: true,
+            order_by: order
+                .iter()
+                .map(|(c, desc)| OrderClause {
+                    column: c,
+                    desc: *desc,
+                })
+                .collect(),
         }
     }
 

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -781,6 +781,27 @@ fn apply_agg_cast(d: &dyn Dialect, kind: AggCast, inner: &str) -> String {
 /// of the flat variants. Doesn't write to `b.sql` — the caller
 /// composes it (optionally inside a FILTER clause, then post-wraps
 /// with `apply_agg_cast` for cast-needing kinds).
+/// Render an aggregate's inner `ORDER BY` clause (#1026) — e.g.
+/// `" ORDER BY \"name\" DESC"`, or `""` when there are no clauses. Used
+/// by `StringAgg`'s per-dialect emission (PG/MySQL/SQLite all spell the
+/// inner ORDER BY the same; only its position differs).
+fn render_agg_order_by(b: &Sql<'_>, order_by: &[crate::core::OrderClause]) -> String {
+    if order_by.is_empty() {
+        return String::new();
+    }
+    let mut s = String::from(" ORDER BY ");
+    for (i, o) in order_by.iter().enumerate() {
+        if i > 0 {
+            s.push_str(", ");
+        }
+        s.push_str(&b.d.quote_ident(o.column));
+        if o.desc {
+            s.push_str(" DESC");
+        }
+    }
+    s
+}
+
 fn format_bare_aggregate(b: &Sql<'_>, expr: &AggregateExpr) -> Result<String, SqlError> {
     Ok(match expr {
         AggregateExpr::Count(None) => "COUNT(*)".into(),
@@ -950,19 +971,32 @@ fn write_aggregate_expr(
             column,
             delimiter,
             distinct,
+            order_by,
         } => {
+            // #1026 — DISTINCT aggregates may only ORDER BY the aggregated
+            // column (PG hard requirement; kept portable-safe everywhere).
+            if *distinct && order_by.iter().any(|o| o.column != *column) {
+                return Err(SqlError::AggregateNotSupportedInDialect {
+                    aggregate: "string_agg(DISTINCT) ORDER BY a non-aggregated column",
+                    dialect: b.d.name(),
+                });
+            }
+            let order_sql = render_agg_order_by(b, order_by);
             // Django 6.0 made StringAgg database-agnostic (#1024): PG
             // `string_agg`, MySQL `GROUP_CONCAT`, SQLite `group_concat`.
+            // ORDER BY (#1026) sits at the dialect-correct position.
             match b.d.name() {
                 "mysql" => {
                     // `SEPARATOR` does NOT accept a bound parameter — the
                     // delimiter is inlined as a literal (single-quotes
-                    // doubled to stay injection-safe).
+                    // doubled to stay injection-safe). ORDER BY goes before
+                    // SEPARATOR.
                     b.sql.push_str("GROUP_CONCAT(");
                     if *distinct {
                         b.sql.push_str("DISTINCT ");
                     }
                     b.write_ident(column);
+                    b.sql.push_str(&order_sql);
                     b.sql.push_str(" SEPARATOR '");
                     b.sql.push_str(&delimiter.replace('\'', "''"));
                     b.sql.push_str("')");
@@ -972,6 +1006,7 @@ fn write_aggregate_expr(
                     // DISTINCT aggregates take exactly one argument. Mirror
                     // Django: allow DISTINCT only with the default ','
                     // separator; reject DISTINCT + a custom delimiter.
+                    // ORDER BY inside the aggregate needs SQLite 3.44+.
                     if *distinct {
                         if delimiter.as_str() != "," {
                             return Err(SqlError::AggregateNotSupportedInDialect {
@@ -981,16 +1016,19 @@ fn write_aggregate_expr(
                         }
                         b.sql.push_str("group_concat(DISTINCT ");
                         b.write_ident(column);
+                        b.sql.push_str(&order_sql);
                         b.sql.push(')');
                     } else {
                         b.sql.push_str("group_concat(");
                         b.write_ident(column);
                         b.sql.push_str(", ");
                         b.push_param(crate::core::SqlValue::String(delimiter.clone()));
+                        b.sql.push_str(&order_sql);
                         b.sql.push(')');
                     }
                 }
-                // Postgres (+ any future dialect): the standard form.
+                // Postgres (+ any future dialect): the standard form. ORDER
+                // BY goes after the delimiter, inside the parens.
                 _ => {
                     b.sql.push_str("string_agg(");
                     if *distinct {
@@ -999,6 +1037,7 @@ fn write_aggregate_expr(
                     b.write_ident(column);
                     b.sql.push_str(", ");
                     b.push_param(crate::core::SqlValue::String(delimiter.clone()));
+                    b.sql.push_str(&order_sql);
                     b.sql.push(')');
                 }
             }

--- a/crates/rustango/tests/django6_delta.rs
+++ b/crates/rustango/tests/django6_delta.rs
@@ -15,12 +15,12 @@
 //! - `DEFAULT_AUTO_FIELD` now defaults to `BigAutoField` — rustango's
 //!   `Auto<i64>` ↔ BIGSERIAL/BIGINT AUTO_INCREMENT already matches
 //!
+//! - `Aggregate(order_by=...)` (new in 6.0, deprecates PG
+//!   `OrderableAggMixin`) — `string_agg_ordered` / `_distinct_ordered`
+//!   emit `ORDER BY` inside the aggregate (#1026).
+//!
 //! Release-note items that are compile-time API absences (no runtime
 //! pin possible — audit rows + issues only):
-//! - `Aggregate(order_by=...)` (new in 6.0, deprecates PG
-//!   `OrderableAggMixin`): `AggregateExpr::StringAgg` carries no
-//!   ordering (issue #1026) — element order in the joined string is
-//!   backend-arbitrary (tests sort to compensate).
 //! - `Model.NotUpdated` on forced 0-row update — pinned in
 //!   django6_writes.rs::check_zero_row_update_semantics.
 //! - CompositePrimaryKey enhancements (raw(), subquery lookups) — N/A
@@ -84,8 +84,8 @@ mod scenarios {
             Some(SqlValue::String(s)) => s.clone(),
             other => panic!("expected string names, got {other:?}"),
         };
-        // No order_by param yet (#1026) — element order is arbitrary, so
-        // sort before asserting.
+        // Unordered form — element order is backend-arbitrary, so sort
+        // before asserting (the ordered form is `check_string_agg_ordered`).
         let mut parts: Vec<&str> = joined.split(',').collect();
         parts.sort_unstable();
         assert_eq!(parts, vec!["alpha", "beta", "beta", "gamma"]);
@@ -114,6 +114,31 @@ mod scenarios {
             parts,
             vec!["alpha", "beta", "gamma"],
             "duplicate beta deduped"
+        );
+    }
+
+    /// Django 6.0 `Aggregate(order_by=…)` (#1026) — ordered StringAgg.
+    /// With ORDER BY the joined string is deterministic, so we assert the
+    /// EXACT result (no sort-to-compensate). PG/MySQL native; SQLite needs
+    /// 3.44+ for ORDER BY inside an aggregate.
+    pub async fn check_string_agg_ordered(pool: &Pool) {
+        let rows = DeltaRow::objects()
+            .aggregate()
+            .values(&[])
+            .annotate(
+                "names",
+                AggregateExpr::string_agg_ordered("name", ",", &[("name", false)]),
+            )
+            .fetch(pool)
+            .await
+            .expect("ordered string_agg on every backend");
+        let joined = match rows[0].get("names") {
+            Some(SqlValue::String(s)) => s.clone(),
+            other => panic!("expected string names, got {other:?}"),
+        };
+        assert_eq!(
+            joined, "alpha,beta,beta,gamma",
+            "exact ascending-by-name order"
         );
     }
 
@@ -253,6 +278,7 @@ mod pg_live {
     pg_case!(check_string_agg_dialect_matrix);
     pg_case!(check_string_agg_distinct);
     pg_case!(check_any_value);
+    pg_case!(check_string_agg_ordered);
     pg_case!(check_generated_column_not_refreshed_on_save);
     pg_case!(check_auto_pk_is_big_auto_field);
 }
@@ -300,6 +326,7 @@ mod sqlite_live {
     sqlite_case!(check_string_agg_dialect_matrix);
     sqlite_case!(check_string_agg_distinct);
     sqlite_case!(check_any_value);
+    sqlite_case!(check_string_agg_ordered);
     sqlite_case!(check_generated_column_not_refreshed_on_save);
     sqlite_case!(check_auto_pk_is_big_auto_field);
 }
@@ -360,6 +387,7 @@ mod mysql_live {
     mysql_case!(check_string_agg_dialect_matrix);
     mysql_case!(check_string_agg_distinct);
     mysql_case!(check_any_value);
+    mysql_case!(check_string_agg_ordered);
     mysql_case!(check_generated_column_not_refreshed_on_save);
     mysql_case!(check_auto_pk_is_big_auto_field);
 }

--- a/crates/rustango/tests/pg_aggregates.rs
+++ b/crates/rustango/tests/pg_aggregates.rs
@@ -166,6 +166,64 @@ fn any_value_emits_per_dialect() {
     );
 }
 
+// ---------- string_agg ORDER BY (#1026) ----------
+
+#[test]
+fn string_agg_ordered_emits_per_dialect() {
+    let q = aggregate_query(
+        AggregateExpr::string_agg_ordered("tag", ", ", &[("tag", true)]),
+        "tag_list",
+    );
+    assert!(
+        Postgres
+            .compile_aggregate(&q)
+            .unwrap()
+            .sql
+            .contains(r#"string_agg("tag", $1 ORDER BY "tag" DESC)"#),
+        "PG ordered"
+    );
+    assert!(
+        MySql
+            .compile_aggregate(&q)
+            .unwrap()
+            .sql
+            .contains("GROUP_CONCAT(`tag` ORDER BY `tag` DESC SEPARATOR ', ')"),
+        "MySQL ordered (ORDER BY before SEPARATOR)"
+    );
+    // SQLite — ORDER BY inside group_concat (3.44+); ascending here.
+    let asc = aggregate_query(
+        AggregateExpr::string_agg_ordered("tag", ", ", &[("tag", false)]),
+        "tag_list",
+    );
+    assert!(
+        Sqlite
+            .compile_aggregate(&asc)
+            .unwrap()
+            .sql
+            .contains(r#"ORDER BY "tag")"#),
+        "SQLite ordered"
+    );
+}
+
+#[test]
+fn string_agg_distinct_ordered_by_non_agg_column_is_rejected() {
+    // DISTINCT aggregates may only ORDER BY the aggregated column.
+    let q = aggregate_query(
+        AggregateExpr::string_agg_distinct_ordered("tag", ",", &[("author", true)]),
+        "tag_list",
+    );
+    assert!(matches!(
+        Postgres.compile_aggregate(&q),
+        Err(SqlError::AggregateNotSupportedInDialect { .. })
+    ));
+    // Ordering by the agg column itself is fine.
+    let ok = aggregate_query(
+        AggregateExpr::string_agg_distinct_ordered("tag", ",", &[("tag", false)]),
+        "tag_list",
+    );
+    assert!(Postgres.compile_aggregate(&ok).is_ok());
+}
+
 // ---------- jsonb_agg ----------
 
 #[test]


### PR DESCRIPTION
## What
Django 6.0 added `Aggregate(order_by=…)` (deprecating PG `OrderableAggMixin`). `AggregateExpr::StringAgg` now carries `order_by: Vec<OrderClause>`, exposed via `string_agg_ordered` / `string_agg_distinct_ordered` (`&[(col, desc)]`). Closes #1026.

## How
Per-dialect ORDER-BY position (`render_agg_order_by` renders the shared inner clause):
- **PG**: `string_agg(col, $delim ORDER BY col [DESC])`
- **MySQL**: `GROUP_CONCAT(col ORDER BY col [DESC] SEPARATOR '<delim>')` — before `SEPARATOR`
- **SQLite**: `group_concat(col, ? ORDER BY col)` — needs 3.44+ (documented; the bundled sqlx SQLite supports it)

DISTINCT may only ORDER BY the aggregated column (PG hard requirement, kept portable-safe everywhere) — rejected at emit otherwise.

## Tests
`pg_aggregates::string_agg_ordered_emits_per_dialect` + `…_distinct_ordered_by_non_agg_column_is_rejected` (emission + validation); `django6_delta::check_string_agg_ordered` asserts the **exact** joined string (no sort-to-compensate). **Verified on pg + mysql + sqlite**; `cargo test --workspace --all-features --no-run` green.