### PR TITLE
feat(orm): union component-queryset slicing + aliased derived tables — closes #1032 #1034

### DIFF
--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -649,6 +649,20 @@ pub struct SelectQuery {
     /// cols ORDER BY <order_by>) AS __rn` subquery with an outer
     /// `WHERE __rn = 1` so the "first row per group" semantics carry.
     pub distinct: Option<DistinctMode>,
+    /// #1034 — outer-compound `ORDER BY` that applies to the COMBINED
+    /// result of a set operation. Holds the clauses chained AFTER the
+    /// first `.union()` / `.intersection()` / `.difference()` call.
+    /// Empty when there is no compound, or when ordering was set
+    /// BEFORE the first set-op call (those scope to the head branch and
+    /// live in [`Self::order_by`], which the writer wraps). Emitted
+    /// after the last branch.
+    pub compound_order_by: Vec<OrderItem>,
+    /// #1034 — outer-compound `LIMIT` on the merged result (chained
+    /// after the first set-op call). See [`Self::compound_order_by`].
+    pub compound_limit: Option<i64>,
+    /// #1034 — outer-compound `OFFSET` on the merged result (chained
+    /// after the first set-op call). See [`Self::compound_order_by`].
+    pub compound_offset: Option<i64>,
 }
 
 impl SelectQuery {
@@ -690,6 +704,9 @@ impl SelectQuery {
             compound: Vec::new(),
             projection: None,
             distinct: None,
+            compound_order_by: Vec::new(),
+            compound_limit: None,
+            compound_offset: None,
         }
     }
 
@@ -892,6 +909,9 @@ impl PartialEq for SelectQuery {
             && self.lock_mode == other.lock_mode
             && self.compound == other.compound
             && self.projection == other.projection
+            && self.compound_order_by == other.compound_order_by
+            && self.compound_limit == other.compound_limit
+            && self.compound_offset == other.compound_offset
     }
 }
 

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -75,6 +75,20 @@ pub struct QuerySet<T: Model> {
     /// Each entry is a pre-compiled [`crate::core::CompoundBranch`].
     /// Empty (default) emits a plain SELECT.
     compound: Vec<crate::core::CompoundBranch>,
+    /// #1034 — head-branch `ORDER BY` frozen at the first `.union()` /
+    /// `.intersection()` / `.difference()` call. `order_by` / `limit` /
+    /// `offset` set BEFORE the first set-op scope to the FIRST
+    /// queryset (Django 4.0+ component-queryset slicing); the freeze
+    /// snapshots them here so clauses chained AFTER the set-op
+    /// accumulate fresh in the live slots and apply to the combined
+    /// result. Empty until the first set-op call.
+    head_order_by: Vec<PendingOrderItem>,
+    /// #1034 — head-branch `LIMIT` frozen at the first set-op call.
+    /// See [`Self::head_order_by`].
+    head_limit: Option<i64>,
+    /// #1034 — head-branch `OFFSET` frozen at the first set-op call.
+    /// See [`Self::head_order_by`].
+    head_offset: Option<i64>,
     /// Django `.none()` short-circuit — issue #331. When `true`, every
     /// terminal op compiles to a guaranteed-empty SQL statement: SELECT
     /// gets `LIMIT 0`, UPDATE / DELETE gain an `IS NULL` predicate
@@ -208,6 +222,9 @@ impl<T: Model> Clone for QuerySet<T> {
             order_by: self.order_by.clone(),
             lock_mode: self.lock_mode.clone(),
             compound: self.compound.clone(),
+            head_order_by: self.head_order_by.clone(),
+            head_limit: self.head_limit,
+            head_offset: self.head_offset,
             is_none: self.is_none,
             disabled_global_scopes: self.disabled_global_scopes.clone(),
             disable_all_global_scopes: self.disable_all_global_scopes,
@@ -230,6 +247,9 @@ impl<T: Model> QuerySet<T> {
             order_by: Vec::new(),
             lock_mode: None,
             compound: Vec::new(),
+            head_order_by: Vec::new(),
+            head_limit: None,
+            head_offset: None,
             is_none: false,
             disabled_global_scopes: Vec::new(),
             disable_all_global_scopes: false,
@@ -470,10 +490,14 @@ impl<T: Model> QuerySet<T> {
     /// or `difference` on the same chain is allowed but unusual; SQL
     /// evaluates them left-to-right.
     ///
-    /// Outer `.order_by()` / `.limit()` / `.offset()` set after
-    /// `.union()` apply to the COMBINED result (the merged
-    /// resultset). Each branch keeps its own per-branch ORDER BY /
-    /// LIMIT inside parens.
+    /// `.order_by()` / `.limit()` / `.offset()` set AFTER `.union()`
+    /// apply to the COMBINED result (the merged resultset); the same
+    /// methods called BEFORE `.union()` scope to the FIRST queryset —
+    /// Django 4.0+ component-queryset slicing (#1034). Each argument
+    /// branch likewise keeps its own per-branch ORDER BY / LIMIT. Every
+    /// such component wraps in an aliased derived table
+    /// (`SELECT * FROM (…) AS __rustango_bN`) so the clauses stay local
+    /// on all three backends.
     ///
     /// Tri-dialect availability: every supported backend.
     ///
@@ -565,6 +589,18 @@ impl<T: Model> QuerySet<T> {
         op: crate::core::SetOp,
         branch: crate::core::SelectQuery,
     ) -> Self {
+        // #1034 — the FIRST set-op call freezes the pre-union
+        // `ORDER BY` / `LIMIT` / `OFFSET` into the head-branch slots
+        // (those clauses scope to the first queryset, Django 4.0+
+        // component-slicing). Clearing the live slots means anything
+        // chained AFTER this point accumulates fresh and applies to
+        // the combined result. Subsequent set-op calls leave the
+        // already-frozen head untouched.
+        if self.compound.is_empty() {
+            self.head_order_by = std::mem::take(&mut self.order_by);
+            self.head_limit = self.limit.take();
+            self.head_offset = self.offset.take();
+        }
         self.compound.push(crate::core::CompoundBranch {
             op,
             query: Box::new(branch),
@@ -2168,11 +2204,41 @@ impl<T: Model> QuerySet<T> {
         // for legacy callers, and keeps user-driven joins next to the
         // user-driven WHERE.
         joins.extend(self.ad_hoc_joins);
+        // #1034 — split head-branch clauses from combined-result
+        // clauses. With a compound, the head-branch `ORDER BY` /
+        // `LIMIT` / `OFFSET` were frozen at the first set-op call
+        // (`head_*`); the live slots hold whatever was chained AFTER
+        // and apply to the merged result. Without a compound, the
+        // live slots are the query's own and `head_*` are empty.
+        let has_compound = !self.compound.is_empty();
+        let (head_pending, head_limit, head_offset, comb_pending, comb_limit, comb_offset) =
+            if has_compound {
+                (
+                    std::mem::take(&mut self.head_order_by),
+                    self.head_limit,
+                    self.head_offset,
+                    std::mem::take(&mut self.order_by),
+                    self.limit,
+                    self.offset,
+                )
+            } else {
+                (
+                    std::mem::take(&mut self.order_by),
+                    self.limit,
+                    self.offset,
+                    Vec::new(),
+                    None,
+                    None,
+                )
+            };
         // Lower the unified pending list to OrderItems. Insertion
         // order is preserved across legacy `.order_by(...)` and
         // issue-#76 `.order_by_with_nulls(...)` / `.order_by_expr(...)`
         // calls so a mixed chain emits in the order it was written.
-        let order_by = lower_order_items(model, self.order_by)?;
+        // `order_by` is the head-branch (or sole) ordering; the
+        // combined-result ordering lowers separately below.
+        let order_by = lower_order_items(model, head_pending)?;
+        let compound_order_by = lower_order_items(model, comb_pending)?;
         // Issue #264 / T1.2 — `.distinct_on(&[...])` requires the
         // listed columns to head the ORDER BY (Django enforces this
         // at runtime; we catch it at builder time). Empty list is
@@ -2220,8 +2286,18 @@ impl<T: Model> QuerySet<T> {
         // Cheap on every dialect (PG/MySQL/SQLite skip plan
         // materialization), and the other terminal ops (count, exists,
         // first) read off the same SelectQuery so they see the same
-        // empty result without further special-casing.
-        let limit = if self.is_none { Some(0) } else { self.limit };
+        // empty result without further special-casing. The `LIMIT 0`
+        // pins to the OUTERMOST slot — the combined result when a
+        // compound is present, else the head/sole query.
+        let (limit, compound_limit) = if self.is_none {
+            if has_compound {
+                (head_limit, Some(0))
+            } else {
+                (Some(0), comb_limit)
+            }
+        } else {
+            (head_limit, comb_limit)
+        };
         Ok(SelectQuery {
             model,
             where_clause,
@@ -2230,11 +2306,14 @@ impl<T: Model> QuerySet<T> {
             subquery_joins: self.subquery_joins,
             order_by,
             limit,
-            offset: self.offset,
+            offset: head_offset,
             lock_mode: self.lock_mode,
             compound: self.compound,
             projection: None,
             distinct: self.distinct,
+            compound_order_by,
+            compound_limit,
+            compound_offset: comb_offset,
         })
     }
 

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -968,6 +968,9 @@ mod tests {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert_eq!(
@@ -998,6 +1001,9 @@ mod tests {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("LOWER(`name`) NOT LIKE LOWER(?)"));
@@ -1024,6 +1030,9 @@ mod tests {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("NOT (`email` <=> ?)"));
@@ -1050,6 +1059,9 @@ mod tests {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         // No outer NOT; bare null-safe equality.
@@ -1078,6 +1090,9 @@ mod tests {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt.sql.contains("JSON_CONTAINS(`meta`, ?)"));
@@ -1105,6 +1120,9 @@ mod tests {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         // Argument order is swapped vs JSON_CONTAINS — value first.
@@ -1132,6 +1150,9 @@ mod tests {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -1163,6 +1184,9 @@ mod tests {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -1195,6 +1219,9 @@ mod tests {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert!(stmt
@@ -1285,6 +1312,9 @@ mod tests {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         };
         let stmt = MySql.compile_select(&q).unwrap();
         assert_eq!(

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -724,6 +724,9 @@ mod tests {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         };
         let stmt = Sqlite.compile_select(&q).unwrap();
         // SQLite emits ANSI-quoted identifiers and `?` placeholders.

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -173,34 +173,47 @@ pub(super) fn write_select(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), S
 /// apply to ITS branch (the first one in the compound, since the
 /// outer is itself a complete `SelectQuery`).
 fn write_compound_select(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlError> {
-    // First branch: the outer query itself. Build a copy with the
-    // compound stripped + the outer order_by / limit / offset /
-    // lock_mode stripped (those apply to the WHOLE compound, not
-    // the head branch).
+    // First branch: the outer query itself. Build a copy carrying its
+    // WHERE / search / joins AND its own `order_by` / `limit` /
+    // `offset` — #1034: those are the head-branch clauses (set BEFORE
+    // the first `.union()`), so they scope to the first queryset, not
+    // the merged result. The *combined-result* clauses live in
+    // `compound_order_by` / `compound_limit` / `compound_offset` and
+    // emit after the last branch (below).
     //
-    // No parens around branches: SQLite's `compound-select-stmt`
-    // grammar (`select-core (UNION select-core)*`) explicitly forbids
-    // parenthesizing the head select; PG / MySQL accept either shape
-    // identically. Per-branch `ORDER BY` / `LIMIT` are already
-    // stripped from the outer head (see fields cleared below); branch
-    // queries that *do* carry their own ORDER BY / LIMIT are
-    // surrounded by `SELECT * FROM (<sub>)` rather than naked parens
-    // (handled by the writer for nested subqueries — set ops with
-    // per-branch LIMIT remain a stretch goal).
-    // #562 — struct-update over SelectQuery::new; the head copies the
-    // outer query's WHERE / search / joins but explicitly clears the
-    // compound + outer-only fields (order_by / limit / offset /
-    // lock_mode / compound) since those apply to the merged result,
-    // not the head branch.
+    // Derived-table wrapping (`SELECT * FROM (<branch>) AS __rustango_bN`)
+    // is what keeps a branch's own ORDER BY / LIMIT local instead of
+    // attaching to the whole compound. #1032: every wrapper carries an
+    // alias — MySQL rejects an alias-less derived table (error 1248),
+    // and PG / SQLite accept the alias, so one code path serves all
+    // three. The head reserves `__rustango_b0`; branches start at 1.
+    // SQLite's `compound-select-stmt` grammar forbids bare parens
+    // around a select-core, hence the derived-table form over naked
+    // parens.
+    // #562 — struct-update over SelectQuery::new; the head clears
+    // `compound` (it's one branch, not the whole thing) and
+    // `lock_mode` (that applies to the merged result).
     let head = SelectQuery {
         where_clause: query.where_clause.clone(),
         search: query.search.clone(),
         joins: query.joins.clone(),
+        order_by: query.order_by.clone(),
+        limit: query.limit,
+        offset: query.offset,
         ..SelectQuery::new(query.model)
     };
-    write_select_inner(b, &head)?;
+    let head_scoped = !head.order_by.is_empty() || head.limit.is_some() || head.offset.is_some();
+    if head_scoped {
+        b.sql.push_str("SELECT * FROM (");
+        write_select_inner(b, &head)?;
+        b.sql.push(')');
+        b.sql.push_str(" AS ");
+        b.write_ident("__rustango_b0");
+    } else {
+        write_select_inner(b, &head)?;
+    }
 
-    for branch in &query.compound {
+    for (i, branch) in query.compound.iter().enumerate() {
         b.sql.push(' ');
         b.sql.push_str(branch.op.keyword());
         b.sql.push(' ');
@@ -210,13 +223,10 @@ fn write_compound_select(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), Sql
         // need their own frame.
         b.scope_stack.push(branch.query.model);
         // Branches that carry their own ORDER BY / LIMIT / OFFSET get
-        // wrapped in `SELECT * FROM (<branch>)` so those clauses scope
-        // to the branch instead of attaching to the outer compound.
-        // SQLite's `compound-select-stmt` grammar forbids bare
-        // parens around a select-core, so we use a derived-table
-        // wrap (portable across PG / MySQL / SQLite). Plain branches
-        // with no ORDER BY / LIMIT emit inline — `SELECT … UNION
-        // SELECT …` is the shortest valid form on every backend.
+        // wrapped in `SELECT * FROM (<branch>) AS __rustango_bN`. Plain
+        // branches with no ORDER BY / LIMIT emit inline — `SELECT …
+        // UNION SELECT …` is the shortest valid form on every backend
+        // and needs no alias.
         let scoped = !branch.query.order_by.is_empty()
             || branch.query.limit.is_some()
             || branch.query.offset.is_some();
@@ -225,6 +235,10 @@ fn write_compound_select(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), Sql
                 b.sql.push_str("SELECT * FROM (");
                 let r = write_select_inner(b, &branch.query);
                 b.sql.push(')');
+                if r.is_ok() {
+                    b.sql.push_str(" AS ");
+                    b.write_ident(&format!("__rustango_b{}", i + 1));
+                }
                 r
             } else {
                 write_select_inner(b, &branch.query)
@@ -235,16 +249,26 @@ fn write_compound_select(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), Sql
             b.sql.push_str("SELECT * FROM (");
             let r = write_compound_select(b, &branch.query);
             b.sql.push(')');
+            if r.is_ok() {
+                b.sql.push_str(" AS ");
+                b.write_ident(&format!("__rustango_b{}", i + 1));
+            }
             r
         };
         b.scope_stack.pop();
         r?;
     }
 
-    // Outer ORDER BY / LIMIT / OFFSET apply to the merged result.
-    // No qualify (the compound's "table" is the merged resultset, not
-    // a join target).
-    write_order_limit_offset(b, &query.order_by, query.limit, query.offset, None)?;
+    // Combined-result ORDER BY / LIMIT / OFFSET — the clauses chained
+    // AFTER the first set-op call (#1034). No qualify (the compound's
+    // "table" is the merged resultset, not a join target).
+    write_order_limit_offset(
+        b,
+        &query.compound_order_by,
+        query.compound_limit,
+        query.compound_offset,
+        None,
+    )?;
 
     if let Some(lock) = &query.lock_mode {
         write_lock_clause(b, lock);

--- a/crates/rustango/tests/django6_setops.rs
+++ b/crates/rustango/tests/django6_setops.rs
@@ -72,27 +72,20 @@ mod scenarios {
         assert_eq!(union_all.len(), 7, "3 + 4 with duplicates kept");
     }
 
-    /// Per-branch ORDER BY + LIMIT. DIVERGENCE (execution-verified):
-    /// only the *other* branch (the argument to `union_all`) gets the
-    /// parenthesized branch-scoped wrapping; ORDER BY/LIMIT on the
-    /// *first* queryset always apply to the COMBINED result — the
-    /// builder stores them in the same slots as post-union clauses, so
-    /// "before union" vs "after union" is indistinguishable. Django
-    /// 4.0+ supports slicing BOTH component querysets
-    /// (`qs1[:2].union(qs2[:1])`); rustango can slice only the
-    /// non-self branches.
+    /// Per-branch ORDER BY + LIMIT (Django 4.0+ component-queryset
+    /// slicing — `qs1[:2].union(qs2[:1])`). Both the head queryset and
+    /// the argument branches carry their OWN parenthesized
+    /// branch-scoped ORDER BY/LIMIT (#1032 + #1034):
+    /// - #1032: each derived-table wrapper carries an alias
+    ///   (`__rustango_bN`) so MySQL accepts it (error 1248 otherwise).
+    /// - #1034: clauses set BEFORE the first set-op call scope to the
+    ///   FIRST queryset; clauses set AFTER apply to the combined
+    ///   result (see `check_outer_order_limit_on_combined`).
     pub async fn check_per_branch_order_and_limit(pool: &Pool) {
-        // Other-branch clauses ARE branch-scoped: all of 'a' + top-1
-        // of 'b' by rank desc.
-        //
-        // GAP-PIN (MySQL): the branch wrapper emits
-        // `SELECT * FROM (<branch>)` with NO alias — PG/SQLite accept
-        // that, MySQL rejects it with error 1248 ("Every derived
-        // table must have its own alias"). Ordered/limited union
-        // branches are therefore broken on MySQL until the writer
-        // appends an alias. Tracked in the gh issue filed from this
-        // suite (#1032).
-        let res = Item::objects()
+        // Other-branch clauses are branch-scoped: all of 'a' + top-1
+        // of 'b' by rank desc. Works on every backend now that the
+        // wrapper carries an alias (#1032).
+        let rows: Vec<Item> = Item::objects()
             .filter("grp", "a")
             .union_all(
                 Item::objects()
@@ -101,26 +94,13 @@ mod scenarios {
                     .limit(1),
             )
             .fetch_pool(pool)
-            .await;
-        if pool.dialect().name() == "mysql" {
-            let err = res
-                .map(|rows: Vec<Item>| rows.len())
-                .expect_err("MySQL must reject the alias-less branch wrapper");
-            let msg = format!("{err}");
-            assert!(
-                msg.contains("alias"),
-                "expected MySQL error 1248 (derived table alias), got: {msg} — \
-                 if branch wrappers now carry aliases, update the audit + issue"
-            );
-        } else {
-            let rows: Vec<Item> = res.expect("other-branch order/limit fetch");
-            assert_eq!(sorted_names(rows), vec!["a1", "a2", "a3", "b2"]);
-        }
+            .await
+            .expect("other-branch order/limit fetch");
+        assert_eq!(sorted_names(rows), vec!["a1", "a2", "a3", "b2"]);
 
-        // PINNED DIVERGENCE: first-queryset clauses leak to the
-        // combined result — top-2 of (a ∪ b) by rank asc, NOT
-        // "top-2 of 'a' plus all of 'b'". Goes red if branch-scoped
-        // first-queryset slicing ever ships (then update the audit). Issue #1034.
+        // First-queryset clauses are now ALSO branch-scoped (#1034):
+        // top-2 of 'a' by rank asc (a1, a2) PLUS all of 'b' (b1, b2) —
+        // NOT "top-2 of the combined set".
         let rows: Vec<Item> = Item::objects()
             .filter("grp", "a")
             .order_by(&[("rnk", false)])
@@ -131,8 +111,8 @@ mod scenarios {
             .expect("first-queryset order/limit fetch");
         assert_eq!(
             sorted_names(rows),
-            vec!["a1", "a2"],
-            "first-queryset LIMIT applies to the combined result"
+            vec!["a1", "a2", "b1", "b2"],
+            "first-queryset LIMIT scopes to the FIRST branch (top-2 of 'a' + all of 'b')"
         );
     }
 

--- a/crates/rustango/tests/mysql_from_row.rs
+++ b/crates/rustango/tests/mysql_from_row.rs
@@ -229,6 +229,9 @@ fn select_rows_pool_with_related_is_callable() {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         };
         let _fut: _ = rustango::sql::select_rows_pool_with_related::<User>(pool, &q);
     }

--- a/crates/rustango/tests/q_xor_emission.rs
+++ b/crates/rustango/tests/q_xor_emission.rs
@@ -35,6 +35,9 @@ fn select(where_clause: WhereExpr) -> SelectQuery {
         compound: vec![],
         projection: None,
         distinct: None,
+        compound_order_by: vec![],
+        compound_limit: None,
+        compound_offset: None,
     }
 }
 

--- a/crates/rustango/tests/row_to_json_pool_sqlite_live.rs
+++ b/crates/rustango/tests/row_to_json_pool_sqlite_live.rs
@@ -84,6 +84,9 @@ async fn select_rows_as_json_pool_decodes_sqlite_rows() {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         },
         &fields,
     )
@@ -124,6 +127,9 @@ async fn select_one_row_as_json_pool_returns_none_for_miss() {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         },
         &fields,
     )
@@ -166,6 +172,9 @@ async fn select_one_row_as_json_pool_returns_decoded_row_for_hit() {
             compound: vec![],
             projection: None,
             distinct: None,
+            compound_order_by: vec![],
+            compound_limit: None,
+            compound_offset: None,
         },
         &fields,
     )

--- a/crates/rustango/tests/set_algebra_emission.rs
+++ b/crates/rustango/tests/set_algebra_emission.rs
@@ -159,6 +159,85 @@ fn branch_order_by_wraps_in_derived_table() {
         "branch LIMIT inside derived table: {}",
         stmt.sql
     );
+    // #1032 — the derived table carries an alias (MySQL error 1248
+    // otherwise; PG/SQLite accept it, so one code path serves all
+    // three). Branches start numbering at 1 (b0 reserved for the head).
+    assert!(
+        stmt.sql.contains(r#") AS "__rustango_b1""#),
+        "branch wrapper aliased: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn head_order_by_before_union_wraps_with_b0_alias() {
+    // #1034 — ORDER BY / LIMIT set BEFORE the first `.union()` scope to
+    // the FIRST queryset (Django 4.0+ component-slicing). The head is
+    // wrapped in its own aliased derived table; the clauses live inside
+    // the parens, NOT after the final branch.
+    let q = Post::objects()
+        .where_(Post::status.eq("draft"))
+        .order_by(&[("id", true)])
+        .limit(2)
+        .union(Post::objects().where_(Post::status.eq("review")))
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    // Statement opens with the wrapped head (SQLite forbids a leading
+    // bare paren, but `SELECT * FROM (` is a valid select-core head).
+    assert!(
+        stmt.sql.starts_with(r#"SELECT * FROM ("#),
+        "head wraps in derived table: {}",
+        stmt.sql
+    );
+    assert!(
+        stmt.sql.contains(r#") AS "__rustango_b0" UNION "#),
+        "head wrapper aliased b0, before UNION: {}",
+        stmt.sql
+    );
+    // The head's ORDER BY / LIMIT are INSIDE the b0 parens (before the
+    // UNION keyword), not trailing the whole compound.
+    let union_pos = stmt.sql.find(" UNION ").unwrap();
+    let order_pos = stmt.sql.find("ORDER BY").expect("head ORDER BY");
+    let limit_pos = stmt.sql.find("LIMIT").expect("head LIMIT");
+    assert!(
+        order_pos < union_pos,
+        "head ORDER BY before UNION: {}",
+        stmt.sql
+    );
+    assert!(
+        limit_pos < union_pos,
+        "head LIMIT before UNION: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn clauses_after_union_scope_to_combined_result() {
+    // #1034 — the SAME clauses set AFTER `.union()` route to the
+    // combined-result slots and emit after the last branch (the head
+    // is NOT wrapped). This is the Django-documented outer form.
+    let q = Post::objects()
+        .where_(Post::status.eq("draft"))
+        .union(Post::objects().where_(Post::status.eq("review")))
+        .order_by(&[("id", true)])
+        .limit(2)
+        .compile()
+        .unwrap();
+    let stmt = Postgres.compile_select(&q).unwrap();
+    // No head wrap, no b0 alias — ordering trails the final branch.
+    assert!(
+        !stmt.sql.contains("__rustango_b0"),
+        "head not wrapped when clauses set after union: {}",
+        stmt.sql
+    );
+    let union_pos = stmt.sql.rfind(" UNION ").unwrap();
+    let order_pos = stmt.sql.find("ORDER BY").expect("combined ORDER BY");
+    assert!(
+        order_pos > union_pos,
+        "combined ORDER BY after final UNION: {}",
+        stmt.sql
+    );
 }
 
 // ---------- Multiple branches accumulate ----------

--- a/crates/rustango/tests/sql.rs
+++ b/crates/rustango/tests/sql.rs
@@ -598,6 +598,9 @@ fn empty_select() -> SelectQuery {
         compound: vec![],
         projection: None,
         distinct: None,
+        compound_order_by: vec![],
+        compound_limit: None,
+        compound_offset: None,
     }
 }
 
@@ -830,6 +833,9 @@ fn empty_post_select() -> SelectQuery {
         compound: vec![],
         projection: None,
         distinct: None,
+        compound_order_by: vec![],
+        compound_limit: None,
+        compound_offset: None,
     }
 }
 

--- a/crates/rustango/tests/where_expr_live.rs
+++ b/crates/rustango/tests/where_expr_live.rs
@@ -195,6 +195,9 @@ async fn empty_or_branch_returns_named_writer_error() {
         compound: vec![],
         projection: None,
         distinct: None,
+        compound_order_by: vec![],
+        compound_limit: None,
+        compound_offset: None,
     };
     let err = Postgres.compile_select(&q).unwrap_err();
     assert!(matches!(err, SqlError::EmptyOrBranch));
@@ -217,6 +220,9 @@ async fn empty_or_branch_returns_named_writer_error() {
         compound: vec![],
         projection: None,
         distinct: None,
+        compound_order_by: vec![],
+        compound_limit: None,
+        compound_offset: None,
     };
     rustango::sql::__macro_internals::select_rows_on(&pool, &q2)
         .await


### PR DESCRIPTION
Two entangled set-operation gaps from the Django 6.0 parity audit, fixed together (#1034 sequences after #1032).

## #1032 — MySQL alias-less derived table (error 1248)
A branch carrying its own `ORDER BY`/`LIMIT`/`OFFSET` wraps in `SELECT * FROM (<branch>)`. PG/SQLite accept an unaliased derived table; MySQL rejects it (*"Every derived table must have its own alias"*). Every wrapper now emits `AS __rustango_bN` on **all three** dialects — one code path, no dialect fork.

## #1034 — first-queryset ORDER BY/LIMIT leaked to the combined result
`qs1.order_by(…).limit(2).union_all(qs2)` silently meant *"top-2 of the COMBINED set"* — the head's clauses lived in the same slots as post-union clauses, so before/after-union was indistinguishable. Django 4.0+ slices **both** component querysets (`qs1[:2].union(qs2[:1])`).

**Fix — snapshot-at-first-union:** the first `.union()`/`.intersection()`/`.difference()` call freezes the pre-union `order_by`/`limit`/`offset` into head-branch slots; the writer wraps the head as `SELECT * FROM (…) AS __rustango_b0`. Clauses chained *after* the set-op accumulate fresh and apply to the merged result (the Django-documented outer form, unchanged).

## Changes
- `core::SelectQuery`: `+ compound_order_by / compound_limit / compound_offset` (combined-result slots; head clauses stay in `order_by`/`limit`/`offset`)
- `QuerySet`: `+ head_*` slots frozen in `add_compound_compiled`; `compile()` routes head vs combined
- `writers::write_compound_select`: head-wrap + per-branch `__rustango_bN` alias + emit combined slots after the last branch
- `.union()` rustdoc updated (claim now fully true)

## Tests
- `django6_setops::check_per_branch_order_and_limit` flipped — both halves now pass on PG/MySQL/SQLite (`["a1","a2","a3","b2"]` + `["a1","a2","b1","b2"]`); removed the MySQL-1248 gap-pin
- `check_outer_order_limit_on_combined` unchanged + green (after-union path)
- New emission pins: branch wrapper alias, head-wrap `b0` alias, before/after-union clause routing

Verified on **Postgres + MySQL + SQLite** (django6_setops 18 = 6 checks × 3 dialects, set_algebra_live, queryset_set_ops, distinct/order/paginate regression sweep all green).