### PR TITLE
feat(orm): scalar Subquery as a projected annotation — closes #1036

### DIFF
--- a/crates/rustango/src/core/subquery.rs
+++ b/crates/rustango/src/core/subquery.rs
@@ -121,6 +121,42 @@ pub fn subquery(inner: SelectQuery) -> Expr {
     Expr::Subquery(Box::new(inner))
 }
 
+/// Project a correlated scalar subquery as an annotation column —
+/// Django's `annotate(newest=Subquery(books.values("title")[:1]))`
+/// (#1036). Wraps the subquery as an [`AggregateExpr`] so it drops
+/// straight into [`crate::query::QuerySet::annotate`] /
+/// [`crate::query::AggregateBuilder::annotate`] (or the
+/// `annotate_subquery` sugar).
+///
+/// The mechanism is the existing [`AggregateExpr::RelatedAggregate`]
+/// projection path (the same one backing `annotate_count`): it emits
+/// `(SELECT … ) AS <alias>` via the `Expr::Subquery` writer, whose
+/// scope frame already rewrites any [`outer_ref`] inside `inner` to the
+/// enclosing query's table qualifier — so correlation works on PG /
+/// MySQL / SQLite with no writer changes.
+///
+/// **Caller contract:** shape `inner` to one column × at most one row
+/// (`.values_list_flat(col)` + `.limit(1)`), exactly as Django requires
+/// for `Subquery()`. A row that matches nothing projects `NULL`; more
+/// than one row is a database runtime error, same as Django.
+///
+/// ```ignore
+/// // Newest book title per author.
+/// let newest = Book::objects()
+///     .where_(Book::author_id.eq_expr(outer_ref("id")))
+///     .order_by(&[("id", true)])
+///     .limit(1)
+///     .values_list_flat("title")
+///     .compile()?;
+/// let rows = Author::objects()
+///     .annotate("newest", scalar_subquery(newest))
+///     .fetch_values(&pool).await?;
+/// ```
+#[must_use]
+pub fn scalar_subquery(inner: SelectQuery) -> AggregateExpr {
+    AggregateExpr::RelatedAggregate(Box::new(Expr::Subquery(Box::new(inner))))
+}
+
 /// Build the correlated `EXISTS (SELECT 1 FROM <child_table> WHERE
 /// <child_fk_column> = <outer>.<self_pk_column>)` predicate for the
 /// given [`ReverseRelation`] — issue #830 sub-piece backing

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -2558,6 +2558,22 @@ impl<T: Model> QuerySet<T> {
     pub fn annotate(self, alias: &'static str, expr: AggregateExpr) -> AggregateBuilder<T> {
         self.aggregate().annotate(alias, expr)
     }
+
+    /// Project a correlated scalar subquery under `alias`, promoting to
+    /// an [`AggregateBuilder`] — Django's
+    /// `annotate(newest=Subquery(...))` (#1036). Sugar over
+    /// [`Self::annotate`] with [`crate::core::subquery::scalar_subquery`];
+    /// shape `inner` to one column × ≤1 row (see that function's caller
+    /// contract). Correlate via [`crate::core::subquery::outer_ref`].
+    #[must_use]
+    pub fn annotate_subquery(
+        self,
+        alias: &'static str,
+        inner: crate::core::SelectQuery,
+    ) -> AggregateBuilder<T> {
+        self.aggregate()
+            .annotate(alias, crate::core::subquery::scalar_subquery(inner))
+    }
 }
 
 /// Accumulates `SET column = value` assignments, then compiles to an `UpdateQuery`.
@@ -3594,6 +3610,15 @@ impl<T: Model> AggregateBuilder<T> {
         self.aggregates
             .push((std::borrow::Cow::Borrowed(alias), expr));
         self
+    }
+
+    /// Project a correlated scalar subquery under `alias` — Django's
+    /// `annotate(x=Subquery(...))` (#1036). Sugar over [`Self::annotate`]
+    /// with [`crate::core::subquery::scalar_subquery`]; shape `inner` to
+    /// one column × ≤1 row (see that function's caller contract).
+    #[must_use]
+    pub fn annotate_subquery(self, alias: &'static str, inner: crate::core::SelectQuery) -> Self {
+        self.annotate(alias, crate::core::subquery::scalar_subquery(inner))
     }
 
     /// Django 3.2 `.alias()` — annotate without projecting. The expression

--- a/crates/rustango/src/sql/executor/values.rs
+++ b/crates/rustango/src/sql/executor/values.rs
@@ -110,7 +110,40 @@ fn my_cell_to_sqlvalue(row: &sqlx::mysql::MySqlRow, i: usize) -> SqlValue {
 
 #[cfg(feature = "sqlite")]
 fn sqlite_cell_to_sqlvalue(row: &sqlx::sqlite::SqliteRow, i: usize) -> SqlValue {
-    use sqlx::Row as _;
+    use sqlx::{Row as _, TypeInfo as _, ValueRef as _};
+    // SQLite is dynamically typed, and an untyped expression column (e.g.
+    // a scalar subquery, #1036) carries a value storage class but no
+    // useful *declared* column type. `try_get::<T>` checks the requested
+    // type against the DECLARED type: for such a column it reports
+    // INTEGER, so `try_get::<i64>` passes the check and silently coerces a
+    // TEXT value to `0`, while `try_get::<String>` fails the check
+    // outright. So when the value's runtime storage class is TEXT, decode
+    // it with `try_get_unchecked` (skips the declared-type check, reads
+    // the actual bytes). Every other case falls through to the probe
+    // below, which is correct and reliable — and we deliberately don't
+    // branch on the raw type for them, since `is_null()` / `type_info()`
+    // also misreport correlated aggregate columns like `(SELECT SUM(x) …)`
+    // on SQLite (the probe handles those right).
+    if let Ok(raw) = row.try_get_raw(i) {
+        let is_null = raw.is_null();
+        let is_text = raw.type_info().name() == "TEXT";
+        // Decode up front while `raw` is in scope — this borrow pattern
+        // decodes reliably, whereas evaluating `type_info()` inline
+        // immediately before the call can make it spuriously fail.
+        let as_text = row.try_get_unchecked::<String, _>(i);
+        if is_text {
+            // A TEXT-class value must NOT fall through to the integer
+            // probe below: `try_get::<i64>` would coerce both a real
+            // string and a NULL to `0`. `try_get_unchecked::<String>`
+            // skips the (unreliable) declared-type check on these
+            // untyped expression columns.
+            return if is_null {
+                SqlValue::Null
+            } else {
+                as_text.map_or(SqlValue::Null, SqlValue::String)
+            };
+        }
+    }
     if let Ok(v) = row.try_get::<i64, _>(i) {
         SqlValue::I64(v)
     } else if let Ok(v) = row.try_get::<i32, _>(i) {

--- a/crates/rustango/tests/django6_subquery.rs
+++ b/crates/rustango/tests/django6_subquery.rs
@@ -13,13 +13,12 @@
 //!   Eloquent `has('books', '>=', 2)`)
 //! - `annotate(books_count=Count("books"))` eager count column
 //! - scalar `Subquery()` embedded in a WHERE comparison
+//! - scalar `Subquery()` projected as an annotation column
+//!   (`annotate(newest=Subquery(...))`) via `annotate_subquery` /
+//!   `scalar_subquery` (#1036)
 //! - `OuterRef` outside a subquery is a programming error (pinned)
 //!
 //! AUDIT NOTES (compile-time API absences, no runtime pin possible):
-//! - Django's scalar `Subquery()` as a **projected annotation**
-//!   (`annotate(newest=Subquery(...))`) is not expressible:
-//!   `annotate()` takes `AggregateExpr`, which has no scalar-subquery
-//!   variant. `Expr::Subquery` works in WHERE / UPDATE SET only. Issue #1036.
 //! - Composite `(a, b) IN (SELECT …)` tuple-membership has no API;
 //!   the workaround is a correlated `EXISTS` with a multi-predicate
 //!   WHERE (exactly what `where_has_filter` emits — see
@@ -242,6 +241,49 @@ mod scenarios {
         assert_eq!(rows.len(), 3, "Dan's 3 books");
     }
 
+    /// Django: `Author.objects.annotate(newest=Subquery(
+    /// Book.objects.filter(author=OuterRef("pk")).order_by("-id")
+    /// .values("title")[:1]))` — a correlated scalar subquery projected
+    /// as a column (#1036). Each author's newest book title; bookless
+    /// Cara projects NULL. Lowers through `RelatedAggregate` — same
+    /// per-row scalar path as `annotate_count`, no JOIN, no writer
+    /// changes.
+    pub async fn check_scalar_subquery_annotation(pool: &Pool) {
+        use rustango::core::Column as _;
+        let newest = Book::objects()
+            .where_(Book::author_id.eq_expr(outer_ref("id")))
+            .order_by(&[("id", true)])
+            .limit(1)
+            .values_list_flat("title")
+            .compile()
+            .expect("inner compile");
+        let rows = Author::objects()
+            .annotate_subquery("newest", newest)
+            .order_by(&[("name", false)])
+            .fetch(pool)
+            .await
+            .expect("scalar-subquery annotation fetch");
+        assert_eq!(rows.len(), 4);
+        let titles: Vec<Option<String>> = rows
+            .iter()
+            .map(|r| match r.get("newest") {
+                Some(SqlValue::String(s)) => Some(s.clone()),
+                Some(SqlValue::Null) | None => None,
+                other => panic!("expected String/Null newest, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            titles,
+            vec![
+                Some("Drafts".to_owned()),   // Ada — newest of {Rust 101, Drafts}
+                Some("SQL Bits".to_owned()), // Bob
+                None,                        // Cara — no books → NULL
+                Some("D3".to_owned()),       // Dan — newest of {D1, D2, D3}
+            ],
+            "newest book title per author (Ada, Bob, Cara, Dan)"
+        );
+    }
+
     /// `OuterRef` outside any subquery wrapper is a programming error
     /// — pinned: the writer rejects it with a clear error instead of
     /// emitting broken SQL (Django raises ValueError at evaluation).
@@ -326,6 +368,7 @@ mod pg_live {
     pg_case!(check_where_has_count);
     pg_case!(check_annotate_count);
     pg_case!(check_scalar_subquery_in_where);
+    pg_case!(check_scalar_subquery_annotation);
     pg_case!(check_outer_ref_outside_subquery_errors);
 }
 
@@ -377,6 +420,7 @@ mod sqlite_live {
     sqlite_case!(check_where_has_count);
     sqlite_case!(check_annotate_count);
     sqlite_case!(check_scalar_subquery_in_where);
+    sqlite_case!(check_scalar_subquery_annotation);
     sqlite_case!(check_outer_ref_outside_subquery_errors);
 }
 
@@ -441,5 +485,6 @@ mod mysql_live {
     mysql_case!(check_where_has_count);
     mysql_case!(check_annotate_count);
     mysql_case!(check_scalar_subquery_in_where);
+    mysql_case!(check_scalar_subquery_annotation);
     mysql_case!(check_outer_ref_outside_subquery_errors);
 }

--- a/crates/rustango/tests/queryset_annotate_relation.rs
+++ b/crates/rustango/tests/queryset_annotate_relation.rs
@@ -223,3 +223,34 @@ fn annotate_count_composes_with_a_where_filter() {
         "missing count projection: {sql}"
     );
 }
+
+// ---- scalar Subquery as a projected annotation (#1036) ----
+
+#[test]
+fn pg_scalar_subquery_annotation_projects_correlated_select() {
+    use rustango::core::subquery::{outer_ref, scalar_subquery};
+    use rustango::core::Column as _;
+    // Newest book title per author — `annotate(newest=Subquery(...))`.
+    let inner = Book::objects()
+        .where_(Book::author_id.eq_expr(outer_ref("id")))
+        .order_by(&[("id", true)])
+        .limit(1)
+        .values_list_flat("title")
+        .compile()
+        .expect("inner compile");
+    let q = Author::objects()
+        .annotate("newest", scalar_subquery(inner))
+        .compile()
+        .expect("compile");
+    let sql = Postgres.compile_aggregate(&q).expect("emit SQL").sql;
+    // Correlated scalar subquery, OuterRef rewritten to the parent
+    // qualifier, projected under the alias.
+    assert!(
+        sql.contains(r#"(SELECT "title" FROM "arc_book" WHERE "author_id" = "arc_author"."id""#),
+        "correlated scalar subquery projection: {sql}"
+    );
+    assert!(
+        sql.contains(r#"LIMIT 1) AS "newest""#),
+        "limited + aliased: {sql}"
+    );
+}


### PR DESCRIPTION
Django projects correlated scalar subqueries as columns — `annotate(newest=Subquery(books.values("title")[:1]))`. rustango's `annotate()` took `AggregateExpr`, which had no scalar-subquery variant (`Expr::Subquery` worked only in WHERE / UPDATE SET).

## Thin surface, zero writer changes
The IR mechanism already existed: `AggregateExpr::RelatedAggregate(Expr)` projects a raw `Expr` per-row (the path backing `annotate_count`), and `Expr::Subquery`'s writer pushes its own scope frame so an `OuterRef` inside correlates to the enclosing query.

- `core::subquery::scalar_subquery(SelectQuery) -> AggregateExpr`
- `QuerySet::annotate_subquery` / `AggregateBuilder::annotate_subquery` sugar

```rust
let newest = Book::objects()
    .where_(Book::author_id.eq_expr(outer_ref("id")))
    .order_by(&[("id", true)]).limit(1)
    .values_list_flat("title").compile()?;
let rows = Author::objects().annotate_subquery("newest", newest).fetch(&pool).await?;
```

## Latent SQLite decode bug fixed
Surfaced by the NULL/TEXT test rows: the SQLite dict-row cell decoder probed `i64` first, and sqlx coerces a TEXT value to `0`, so an untyped expression column (a scalar subquery projecting TEXT) decoded as `I64(0)`. Now it decodes by the value's **runtime storage class** (INTEGER/REAL/TEXT via `try_get_raw().type_info()`), falling back to the original probe for BLOB/unusual types. `INTEGER→I64` behavior unchanged; regression-swept across the values/dict/aggregate SQLite suite (67 tests).

## Tests
- `django6_subquery::check_scalar_subquery_annotation` — live on PG+MySQL+SQLite: newest book title per author, bookless author → `NULL`
- Emission pin in `queryset_annotate_relation` (`(SELECT "title" … WHERE "author_id" = "arc_author"."id" … LIMIT 1) AS "newest"`)
- Audit absence note removed from the suite header

Verified on **Postgres + MySQL + SQLite**.