### PR TITLE
feat(orm): aggregate window functions (SUM/AVG/MIN/MAX/COUNT OVER) — #1035 Part A

### DIFF
--- a/crates/rustango/src/core/window.rs
+++ b/crates/rustango/src/core/window.rs
@@ -107,6 +107,18 @@ pub enum WindowFn {
     /// `LAST_VALUE(expr)` — value from the last row in the
     /// partition/frame.
     LastValue,
+    /// `SUM(expr)` used as a window — running / partitioned total
+    /// (Django 6.0 `Window(Sum(...))`, #1035).
+    Sum,
+    /// `AVG(expr)` used as a window — partitioned / running mean.
+    Avg,
+    /// `MIN(expr)` used as a window — partitioned / running minimum.
+    Min,
+    /// `MAX(expr)` used as a window — partitioned / running maximum.
+    Max,
+    /// `COUNT(expr)` / `COUNT(*)` used as a window — partitioned /
+    /// running count. Empty args render `COUNT(*)`.
+    Count,
 }
 
 /// `ROWS` vs `RANGE` frame mode.
@@ -291,6 +303,51 @@ pub fn first_value(column: &'static str) -> WindowBuilder {
 #[must_use]
 pub fn last_value(column: &'static str) -> WindowBuilder {
     WindowBuilder::new(WindowFn::LastValue, vec![Expr::Column(column)])
+}
+
+/// `SUM(<column>) OVER (…)` — aggregate used as a window function
+/// (Django 6.0 `Window(Sum("points"), …)`, #1035). With an `ORDER BY`
+/// and no explicit [`WindowBuilder::frame`], SQL defaults to `RANGE
+/// UNBOUNDED PRECEDING .. CURRENT ROW` — a running total where peer
+/// rows (equal ORDER BY keys) share the cumulative value. Add
+/// `.frame(...)` for `ROWS` framing. Tri-dialect native (PG / MySQL 8+
+/// / SQLite 3.25+); no dialect fork.
+#[must_use]
+pub fn sum_over(column: &'static str) -> WindowBuilder {
+    WindowBuilder::new(WindowFn::Sum, vec![Expr::Column(column)])
+}
+
+/// `AVG(<column>) OVER (…)` — partitioned / running mean. Same framing
+/// note as [`sum_over`].
+#[must_use]
+pub fn avg_over(column: &'static str) -> WindowBuilder {
+    WindowBuilder::new(WindowFn::Avg, vec![Expr::Column(column)])
+}
+
+/// `MIN(<column>) OVER (…)` — partitioned / running minimum.
+#[must_use]
+pub fn min_over(column: &'static str) -> WindowBuilder {
+    WindowBuilder::new(WindowFn::Min, vec![Expr::Column(column)])
+}
+
+/// `MAX(<column>) OVER (…)` — partitioned / running maximum.
+#[must_use]
+pub fn max_over(column: &'static str) -> WindowBuilder {
+    WindowBuilder::new(WindowFn::Max, vec![Expr::Column(column)])
+}
+
+/// `COUNT(*) OVER (…)` — partitioned / running row count. For
+/// `COUNT(<column>)` (non-NULL only), use [`count_column_over`].
+#[must_use]
+pub fn count_over() -> WindowBuilder {
+    WindowBuilder::new(WindowFn::Count, vec![])
+}
+
+/// `COUNT(<column>) OVER (…)` — partitioned / running count of
+/// non-NULL `column` values.
+#[must_use]
+pub fn count_column_over(column: &'static str) -> WindowBuilder {
+    WindowBuilder::new(WindowFn::Count, vec![Expr::Column(column)])
 }
 
 #[cfg(test)]

--- a/crates/rustango/src/sql/executor/values.rs
+++ b/crates/rustango/src/sql/executor/values.rs
@@ -53,6 +53,11 @@ fn pg_cell_to_sqlvalue(row: &PgRow, i: usize) -> SqlValue {
         SqlValue::F64(v)
     } else if let Ok(v) = row.try_get::<bool, _>(i) {
         SqlValue::Bool(v)
+    } else if let Ok(v) = row.try_get::<rust_decimal::Decimal, _>(i) {
+        // #1035 — PG `NUMERIC` (e.g. `SUM(bigint)` / `SUM(...) OVER (...)`,
+        // which PG widens to numeric). The i64/f64 probes don't decode
+        // numeric, so without this the value silently decoded to `Null`.
+        SqlValue::Decimal(v)
     } else if let Ok(v) = row.try_get::<String, _>(i) {
         SqlValue::String(v)
     } else if let Ok(v) = row.try_get::<serde_json::Value, _>(i) {
@@ -91,6 +96,11 @@ fn my_cell_to_sqlvalue(row: &sqlx::mysql::MySqlRow, i: usize) -> SqlValue {
         SqlValue::F64(v)
     } else if let Ok(v) = row.try_get::<bool, _>(i) {
         SqlValue::Bool(v)
+    } else if let Ok(v) = row.try_get::<rust_decimal::Decimal, _>(i) {
+        // #1035 — MySQL `DECIMAL` (e.g. `SUM(...)` / `SUM(...) OVER (...)`
+        // over an integer column). Without this the i64/f64 probes fail
+        // and the value silently decoded to `Null`.
+        SqlValue::Decimal(v)
     } else if let Ok(v) = row.try_get::<String, _>(i) {
         SqlValue::String(v)
     } else {

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -1775,9 +1775,19 @@ fn write_window_expr(b: &mut Sql<'_>, w: &crate::core::WindowExpr) -> Result<(),
         WindowFn::Lead => "LEAD",
         WindowFn::FirstValue => "FIRST_VALUE",
         WindowFn::LastValue => "LAST_VALUE",
+        WindowFn::Sum => "SUM",
+        WindowFn::Avg => "AVG",
+        WindowFn::Min => "MIN",
+        WindowFn::Max => "MAX",
+        WindowFn::Count => "COUNT",
     };
     b.sql.push_str(fn_name);
     b.sql.push('(');
+    // `COUNT()` is invalid SQL — a bare `count_over()` (no column
+    // argument) is the windowed `COUNT(*)` (#1035).
+    if matches!(w.kind, WindowFn::Count) && w.args.is_empty() {
+        b.sql.push('*');
+    }
     // PG's LAG/LEAD/NTILE require `offset`/`buckets` as `integer`, not
     // `bigint`. Binding `i64` as a parameter (which PG types as
     // `bigint`) makes function lookup fail with

--- a/crates/rustango/tests/django6_window.rs
+++ b/crates/rustango/tests/django6_window.rs
@@ -4,6 +4,8 @@
 //! Django scenarios covered (docs.djangoproject.com/en/6.0):
 //! - `Window(Rank(), partition_by=..., order_by=...)` (+ dense_rank,
 //!   ntile, lag-with-default, first_value with a ROWS frame)
+//! - aggregates as window expressions: `Window(Sum("points"), …)` —
+//!   partitioned running total via `sum_over` (#1035 Part A)
 //! - `.distinct("tenant_id")` first-row-per-group (PG `DISTINCT ON`
 //!   native; MySQL/SQLite via the ROW_NUMBER fallback)
 //! - top-N-per-group: Django filters on a window annotation via an
@@ -12,10 +14,6 @@
 //!   SQLite)
 //!
 //! AUDIT NOTES (compile-time API absences, no runtime pin possible):
-//! - Django allows *aggregates as window expressions*
-//!   (`Window(Sum("points"), ...)`); rustango's `WindowFn` has only
-//!   the 8 ranking/navigation variants — `SUM(...) OVER (...)` is not
-//!   expressible. Issue #1035 (also covers windowed-query-as-subquery).
 //! - ERGONOMICS DIVERGENCE (execution-verified): Django annotates a
 //!   window onto a plain queryset; rustango requires the explicit
 //!   `.aggregate().group_by(<every projected column>)` shape —
@@ -34,7 +32,7 @@ mod scenarios {
 
     use rustango::core::joins::aliased;
     use rustango::core::window::{
-        dense_rank, first_value, lag, ntile, rank, FrameBoundary, FrameKind, WindowFrame,
+        dense_rank, first_value, lag, ntile, rank, sum_over, FrameBoundary, FrameKind, WindowFrame,
     };
     use rustango::core::{Join, JoinKind, Model as _, Op, SqlValue, WhereExpr};
     use rustango::sql::{raw_execute_pool, Auto, ExecError, FetcherPool as _, Pool, SqlError};
@@ -89,6 +87,14 @@ mod scenarios {
         match row.get(key) {
             Some(SqlValue::I64(n)) => *n,
             Some(SqlValue::I32(n)) => i64::from(*n),
+            // SUM over a BIGINT column widens per dialect: PG → NUMERIC,
+            // MySQL → DECIMAL, SQLite → INTEGER. Normalize for assertions.
+            Some(SqlValue::F64(f)) => *f as i64,
+            Some(SqlValue::Decimal(d)) => d
+                .to_string()
+                .parse::<f64>()
+                .unwrap_or_else(|_| panic!("unparseable decimal at `{key}`: {d}"))
+                as i64,
             other => panic!("expected integer at `{key}`, got {other:?}"),
         }
     }
@@ -216,6 +222,33 @@ mod scenarios {
             .expect("ntile window");
         let buckets: Vec<i64> = rows.iter().map(|r| as_i64(r, "bucket")).collect();
         assert_eq!(buckets, vec![1, 1, 1, 2, 2]);
+    }
+
+    /// Django 6.0 `Window(Sum("points"), partition_by="player",
+    /// order_by="day")` — a partitioned running total (#1035 Part A).
+    /// Tenant 1, per player by day: the cumulative points carry the
+    /// default `RANGE UNBOUNDED PRECEDING .. CURRENT ROW` frame.
+    pub async fn check_sum_over_running_total(pool: &Pool) {
+        let rows = Score::objects()
+            .aggregate()
+            .group_by("player")
+            .group_by("day")
+            .group_by("points")
+            .annotate(
+                "running",
+                sum_over("points")
+                    .partition_by("player")
+                    .order_by(&[("day", false)])
+                    .into(),
+            )
+            .filter("tenant_id", Op::Eq, 1_i64)
+            .order_by(&[("player", false), ("day", false)])
+            .fetch(pool)
+            .await
+            .expect("sum-over running total");
+        let running: Vec<i64> = rows.iter().map(|r| as_i64(r, "running")).collect();
+        // alice 30→(30,65), bob 20→(20,35), carol 10→(10).
+        assert_eq!(running, vec![30, 65, 20, 35, 10]);
     }
 
     /// Django `.distinct("tenant_id")` + ordering — best score row per
@@ -388,6 +421,7 @@ mod pg_live {
     pg_case!(check_lag_with_default);
     pg_case!(check_first_value_rows_frame);
     pg_case!(check_ntile_buckets);
+    pg_case!(check_sum_over_running_total);
     pg_case!(check_distinct_on_first_row_per_tenant);
     pg_case!(check_distinct_on_with_join_dialect_matrix);
     pg_case!(check_top_n_per_group_via_lateral);
@@ -439,6 +473,7 @@ mod sqlite_live {
     sqlite_case!(check_lag_with_default);
     sqlite_case!(check_first_value_rows_frame);
     sqlite_case!(check_ntile_buckets);
+    sqlite_case!(check_sum_over_running_total);
     sqlite_case!(check_distinct_on_first_row_per_tenant);
     sqlite_case!(check_distinct_on_with_join_dialect_matrix);
     sqlite_case!(check_top_n_per_group_via_lateral);
@@ -503,6 +538,7 @@ mod mysql_live {
     mysql_case!(check_lag_with_default);
     mysql_case!(check_first_value_rows_frame);
     mysql_case!(check_ntile_buckets);
+    mysql_case!(check_sum_over_running_total);
     mysql_case!(check_distinct_on_first_row_per_tenant);
     mysql_case!(check_distinct_on_with_join_dialect_matrix);
     mysql_case!(check_top_n_per_group_via_lateral);

--- a/crates/rustango/tests/window_functions.rs
+++ b/crates/rustango/tests/window_functions.rs
@@ -5,7 +5,8 @@
 //! and the dialect-shape placeholders for each backend.
 
 use rustango::core::window::{
-    dense_rank, first_value, lag, last_value, lead, ntile, rank, row_number,
+    avg_over, count_column_over, count_over, dense_rank, first_value, lag, last_value, lead,
+    max_over, min_over, ntile, rank, row_number, sum_over,
 };
 use rustango::core::{
     AggregateExpr, AggregateQuery, Expr, FrameBoundary, FrameKind, Model as _, SqlValue, WhereExpr,
@@ -487,6 +488,89 @@ fn filtered_window_rejection_msg_consistent_across_dialects() {
                 }
             ),
             "{label}: expected wrapper=Filtered(Window), got {err:?}",
+        );
+    }
+}
+
+// ---------- Aggregate window functions (#1035 Part A) ----------
+
+#[test]
+fn pg_sum_over_emits_running_total_form() {
+    // Window(Sum("score"), partition_by=tenant_id, order_by=id) — a
+    // partitioned running total. SQL-standard `SUM(col) OVER (…)`.
+    let w = sum_over("score")
+        .partition_by("tenant_id")
+        .order_by(&[("id", false)]);
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"SUM("score") OVER (PARTITION BY "tenant_id" ORDER BY "id") AS "w""#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn sum_over_is_tri_dialect_identical_apart_from_quoting() {
+    let mk = || {
+        sum_over("score")
+            .partition_by("tenant_id")
+            .order_by(&[("id", false)])
+    };
+    assert!(MySql
+        .compile_aggregate(&agg(mk().into()))
+        .unwrap()
+        .sql
+        .contains("SUM(`score`) OVER (PARTITION BY `tenant_id` ORDER BY `id`)"));
+    assert!(Sqlite
+        .compile_aggregate(&agg(mk().into()))
+        .unwrap()
+        .sql
+        .contains(r#"SUM("score") OVER (PARTITION BY "tenant_id" ORDER BY "id")"#));
+}
+
+#[test]
+fn count_over_emits_count_star() {
+    // Bare `count_over()` is the windowed COUNT(*) — `COUNT()` would be
+    // invalid SQL.
+    let w = count_over().partition_by("tenant_id");
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql
+            .contains(r#"COUNT(*) OVER (PARTITION BY "tenant_id") AS "w""#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn count_column_over_emits_column_arg() {
+    let w = count_column_over("score").order_by(&[("id", false)]);
+    let stmt = Postgres.compile_aggregate(&agg(w.into())).unwrap();
+    assert!(
+        stmt.sql.contains(r#"COUNT("score") OVER (ORDER BY "id")"#),
+        "got: {}",
+        stmt.sql
+    );
+}
+
+#[test]
+fn avg_min_max_over_map_to_their_keywords() {
+    for (build, kw) in [
+        (avg_over("score").build(), "AVG"),
+        (min_over("score").build(), "MIN"),
+        (max_over("score").build(), "MAX"),
+    ] {
+        // `.build()` yields an Expr; wrap it back into the aggregate slot.
+        let expr = AggregateExpr::Window(match build {
+            Expr::Window(w) => w,
+            other => panic!("expected Expr::Window, got {other:?}"),
+        });
+        let stmt = Postgres.compile_aggregate(&agg(expr)).unwrap();
+        assert!(
+            stmt.sql.contains(&format!(r#"{kw}("score") OVER"#)),
+            "{kw}: got {}",
+            stmt.sql
         );
     }
 }


### PR DESCRIPTION
Django 6.0 allows aggregates as window expressions — `Window(Sum("points"), partition_by=…, order_by=…)` → `SUM(points) OVER (…)`. rustango's `WindowFn` had only the 8 ranking/navigation variants, so running totals were inexpressible. This is **Part A** of #1035 (the small, ship-first half).

## Changes — small, tri-dialect native (no dialect fork)
`WindowExpr.args` is already `Vec<Expr>` and the writer emits `<FN>(args) OVER (…)` generically:

- `WindowFn::{Sum, Avg, Min, Max, Count}` + name mappings
- builders: `sum_over` / `avg_over` / `min_over` / `max_over` / `count_over` (`COUNT(*)`, empty args) / `count_column_over` (`COUNT(col)`)
- writer special-cases empty-args `Count` as `COUNT(*)` (`COUNT()` is invalid SQL)

`is_aggregating` already returns `false` for `Window` (windows don't collapse rows → no GROUP BY), and `validate_aggregate_expr_columns` already validates `args` columns — no changes needed.

```rust
Score::objects().aggregate()
    .group_by("player").group_by("day").group_by("points")
    .annotate("running", sum_over("points").partition_by("player").order_by(&[("day", false)]).into())
    .fetch(&pool).await?;  // running total per player by day
```

## Latent numeric-decode gap fixed
Surfaced by the running-total test: `SUM` over a `BIGINT` column widens to `NUMERIC` (PG) / `DECIMAL` (MySQL), which the i64/f64 cell probes don't decode — the value silently became `SqlValue::Null`. Added a `rust_decimal::Decimal` probe (before the `String` arm) to `pg_cell_to_sqlvalue` + `my_cell_to_sqlvalue`. Regression-swept across 26 aggregate/values/decimal/cast test binaries — all green.

## Tests
- `window_functions` emission pins: `SUM`/`COUNT(*)`/`COUNT(col)`/`AVG`/`MIN`/`MAX`, tri-dialect quoting
- `django6_window::check_sum_over_running_total` — live on PG+MySQL+SQLite (alice 30→65 cumulative); audit absence note removed

**Part B** (a windowed query re-embedded as a subquery source — `DerivedSource` enum) remains and is tracked on #1035.

Verified on **Postgres + MySQL + SQLite**.