### PR TITLE
chore(release): 0.43.0 — version bump + CHANGELOG cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
-Post-v0.42 Django-parity follow-ups. Each item is a self-contained slice that landed as its own PR after the v0.42.0 release tag.
+_Nothing yet — next development cycle._
+
+## [0.43.0] — 2026-06-13
+
+Django-parity batch since the v0.42.0 tag — each item below landed as its own PR. Headlines: **relation-spanning lookups** in `filter()`/`exclude()` (`author__name__icontains`, #1031), **aggregate window functions** (`SUM`/`AVG`/`MIN`/`MAX`/`COUNT OVER`, #1035), scalar **`Subquery()` annotations** (#1036), **union component-queryset slicing** + aliased derived tables (#1032/#1034), and the full **Django 6.0 aggregate family** (`StringAgg`→`GROUP_CONCAT`, `AnyValue`, ordered aggregates, #1024–#1026) — plus i18n/RTL, `CITextField`, `DatabaseCache`, `managed=false`, and 50+ Eloquent query shortcuts.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.42.0"
+version = "0.43.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.42.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.42.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.42.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.43.0", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.43.0", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.43.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.42.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.43.0" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -367,7 +367,7 @@ runserver = ["dep:axum", "dep:tokio"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.42.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.43.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }


### PR DESCRIPTION
Release prep for **0.43.0**. No code changes — version bump + CHANGELOG cut only.

- Workspace `0.42.0 → 0.43.0` (root `[workspace.package]` + the `rustango` / `rustango-macros` / `rustango-orm-macros` dep pins + the `rustango-renamed-smoke` smoke pin).
- CHANGELOG `[Unreleased]` → `[0.43.0] — 2026-06-13`; fresh empty `[Unreleased]` on top.

## 0.43.0 = the Django-parity batch since v0.42.0
Headlines (each landed as its own PR):
- **Relation-spanning lookups** in `filter()`/`exclude()` — `author__name__icontains` (#1031 P1)
- **Aggregate window functions** — `SUM`/`AVG`/`MIN`/`MAX`/`COUNT OVER` (#1035 Part A)
- **Scalar `Subquery()` annotations** (#1036)
- **Union component-queryset slicing** + aliased derived tables (#1032/#1034)
- **Django 6.0 aggregate family** — `StringAgg`→`GROUP_CONCAT` (#1024), `AnyValue` (#1025), ordered aggregates (#1026)
- plus i18n/RTL, `CITextField`, `DatabaseCache`, `managed=false`, 50+ Eloquent shortcuts (see CHANGELOG)

## Release path after merge
1. Merge this → `develop`.
2. Open & merge `develop → main`.
3. `git tag v0.43.0` on `main`.
4. Run `/tmp/rustango-release-0.43.0.sh` (publish in dep order + yank all versions below 0.43.0) on a machine with crates.io access + token.