### PR TITLE
refactor(orm): drop `_pool` suffix from QuerySet terminals — fetch/count/exists

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -242,7 +242,7 @@ pub fn embed_migrations(input: TokenStream) -> TokenStream {
 ///         Q!(User.active = true)
 ///             .and(Q!(User.email__icontains = "alice"))
 ///     )
-///     .fetch_pool(&pool).await?;
+///     .fetch(&pool).await?;
 /// ```
 ///
 /// All emitted code routes through existing per-dialect writers — no new
@@ -1388,7 +1388,7 @@ fn reverse_helper_tokens(
                     let _pk: #root::core::SqlValue = self.__rustango_pk_value();
                     #root::query::QuerySet::<#child_ident>::new()
                         .filter_op(#fk_col, #root::core::Op::Eq, _pk)
-                        .fetch_pool(pool)
+                        .fetch(pool)
                         .await
                 }
             }
@@ -1639,7 +1639,7 @@ fn reverse_has_accessor_tokens(
              `{child_fk_column}` matches this `{struct_name}` \
              instance's primary key. **Chainable**: compose `.filter()` \
              / `.order_by()` / `.limit()` etc. on top, then call \
-             `.fetch_pool(&pool)` (the QuerySet trait method) when \
+             `.fetch(&pool)` (the QuerySet trait method) when \
              done. For the simple \"fetch all\" hot path with no \
              further composition, prefer the bare-name \
              `{name}_fetch(&pool)` companion.",
@@ -1647,7 +1647,7 @@ fn reverse_has_accessor_tokens(
         );
         let fetch_doc = format!(
             "Eloquent `$model->{name}->get()` — bare-name hot-path \
-             over `{name}(&self).fetch_pool(&pool)`. Use this when \
+             over `{name}(&self).fetch(&pool)`. Use this when \
              you don't need further `.filter()` / `.order_by()` \
              composition; falls back to the chainable accessor when \
              you do. Avoids the `_pool` suffix on the most common \
@@ -1670,7 +1670,7 @@ fn reverse_has_accessor_tokens(
                 #root::sql::ExecError,
             > {
                 use #root::sql::FetcherPool as _;
-                self.#accessor_ident().fetch_pool(pool).await
+                self.#accessor_ident().fetch(pool).await
             }
 
             /// Eloquent `$model->relation->first()` / `hasOne`
@@ -1757,7 +1757,7 @@ fn reverse_has_accessor_tokens(
                 use #root::sql::CounterPool as _;
                 #root::query::QuerySet::<#child>::new()
                     .filter(#child_fk_column, self.__rustango_pk_value())
-                    .count_pool(pool)
+                    .count(pool)
                     .await
             }
         }
@@ -1825,7 +1825,7 @@ fn through_accessor_tokens(
             "Eloquent `$model->{name}->count()` analog for the \
              through-relation — returns the number of `{far}` rows \
              reachable through `{intermediate}`. Equivalent to \
-             `self.{name}_through().count_pool(pool)` but spelled \
+             `self.{name}_through().count(pool)` but spelled \
              as a bare instance method for parity with the \
              `reverse_has` `<name>_count` shape.",
             name = rel.name,
@@ -1865,12 +1865,12 @@ fn through_accessor_tokens(
                 #root::sql::ExecError,
             > {
                 use #root::sql::CounterPool as _;
-                self.#method_ident().count_pool(pool).await
+                self.#method_ident().count(pool).await
             }
 
             /// Eloquent `$model->relation->get()` for the
             /// through-relation — bare-name hot-path over
-            /// `self.<name>_through().fetch_pool(&pool)`. Use this
+            /// `self.<name>_through().fetch(&pool)`. Use this
             /// when you don't need further `.filter()` /
             /// `.order_by()` composition; falls back to the
             /// chainable accessor when you do. Avoids the `_pool`
@@ -1883,7 +1883,7 @@ fn through_accessor_tokens(
                 #root::sql::ExecError,
             > {
                 use #root::sql::FetcherPool as _;
-                self.#method_ident().fetch_pool(pool).await
+                self.#method_ident().fetch(pool).await
             }
 
             /// Eloquent `hasOneThrough` analog — bare-name shortcut
@@ -3921,7 +3921,7 @@ fn inherent_impl_tokens(
         //
         // Drop the conflicting shortcut for that model. Callers can
         // still reach the same behavior via
-        // `QuerySet::<Model>::default().count_pool(&pool)`.
+        // `QuerySet::<Model>::default().count(&pool)`.
         let column_names: ::std::collections::HashSet<String> = fields
             .column_entries
             .iter()
@@ -3941,19 +3941,19 @@ fn inherent_impl_tokens(
                 /// <table>`. Eloquent `Model::count()` parity.
                 ///
                 /// Skipped on models that already declare a field named
-                /// `count`. Drop into `QuerySet::<Self>::default().count_pool(&pool)`
+                /// `count`. Drop into `QuerySet::<Self>::default().count(&pool)`
                 /// in that case.
                 ///
                 /// # Errors
-                /// As [`CounterPool::count_pool`].
+                /// As [`CounterPool::count`].
                 ///
-                /// [`CounterPool::count_pool`]: rustango::sql::CounterPool::count_pool
+                /// [`CounterPool::count`]: rustango::sql::CounterPool::count
                 pub async fn count(
                     pool: &#root::sql::Pool,
                 ) -> ::core::result::Result<i64, #root::sql::ExecError> {
                     use #root::sql::CounterPool as _;
                     #root::query::QuerySet::<Self>::default()
-                        .count_pool(pool)
+                        .count(pool)
                         .await
                 }
             },
@@ -4180,11 +4180,11 @@ fn inherent_impl_tokens(
             /// the row was deleted concurrently).
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`]; also `RowNotFound` when
+            /// As [`FetcherPool::fetch`]; also `RowNotFound` when
             /// the PK no longer exists.
             ///
             /// [`Model.refresh_from_db`]: https://docs.djangoproject.com/en/5.1/ref/models/instances/#django.db.models.Model.refresh_from_db
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn refresh_from_db(
                 &mut self,
                 pool: &#root::sql::Pool,
@@ -4197,7 +4197,7 @@ fn inherent_impl_tokens(
                     #root::query::QuerySet::<Self>::default()
                         .filter(::core::stringify!(#pk_ident), _pk_val)
                         .limit(1)
-                        .fetch_pool(pool)
+                        .fetch(pool)
                         .await?;
                 match _rows.into_iter().next() {
                     ::core::option::Option::Some(_fresh) => {
@@ -4361,9 +4361,9 @@ fn inherent_impl_tokens(
             /// reference you already hold.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn fresh(
                 &self,
                 pool: &#root::sql::Pool,
@@ -4379,7 +4379,7 @@ fn inherent_impl_tokens(
                     #root::query::QuerySet::<Self>::default()
                         .filter(::core::stringify!(#pk_ident), _pk_val)
                         .limit(1)
-                        .fetch_pool(pool)
+                        .fetch(pool)
                         .await?;
                 ::core::result::Result::Ok(_rows.into_iter().next())
             }
@@ -4503,7 +4503,7 @@ fn inherent_impl_tokens(
                             .order_by(&[(pk_col, false)])
                             .limit(n)
                             .offset(offset)
-                            .fetch_pool(pool)
+                            .fetch(pool)
                             .await?;
                     if rows.is_empty() {
                         return ::core::result::Result::Ok(());
@@ -4564,7 +4564,7 @@ fn inherent_impl_tokens(
                             .filter(key.as_str(), last_seen)
                             .order_by(&[(pk_col, false)])
                             .limit(n)
-                            .fetch_pool(pool)
+                            .fetch(pool)
                             .await?;
                     if rows.is_empty() {
                         return ::core::result::Result::Ok(());
@@ -4636,7 +4636,7 @@ fn inherent_impl_tokens(
                             .filter(key.as_str(), last_seen)
                             .order_by(&[(pk_col, false)])
                             .limit(batch)
-                            .fetch_pool(pool)
+                            .fetch(pool)
                             .await?;
                     if rows.is_empty() {
                         return ::core::result::Result::Ok(());
@@ -4746,7 +4746,7 @@ fn inherent_impl_tokens(
             /// `Model.objects.filter(col=val).all()` parity.
             ///
             /// Thin wrapper over `QuerySet::<Self>::default()
-            /// .filter(col, val).fetch_pool(pool)`. For one row,
+            /// .filter(col, val).fetch(pool)`. For one row,
             /// use [`Self::first_where_pool`]; for a chain that
             /// needs further `.filter()` / `.order_by()` /
             /// `.limit()`, drop down to `Self::query().filter(...)`
@@ -4756,9 +4756,9 @@ fn inherent_impl_tokens(
             /// strings, ints, UUIDs, etc. all work.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_(
                 col: &str,
                 val: impl ::core::convert::Into<#root::core::SqlValue>,
@@ -4770,7 +4770,7 @@ fn inherent_impl_tokens(
                 use #root::sql::FetcherPool as _;
                 #root::query::QuerySet::<Self>::default()
                     .filter(col, val)
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -4784,9 +4784,9 @@ fn inherent_impl_tokens(
             /// etc.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_in<V>(
                 col: &str,
                 vals: impl ::core::iter::IntoIterator<Item = V>,
@@ -4807,7 +4807,7 @@ fn inherent_impl_tokens(
                 let _key = ::std::format!("{}__in", col);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, #root::core::SqlValue::List(_values))
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -4817,9 +4817,9 @@ fn inherent_impl_tokens(
             /// semantics — vacuously true for every row).
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_not_in<V>(
                 col: &str,
                 vals: impl ::core::iter::IntoIterator<Item = V>,
@@ -4836,13 +4836,13 @@ fn inherent_impl_tokens(
                     vals.into_iter().map(::core::convert::Into::into).collect();
                 if _values.is_empty() {
                     return #root::query::QuerySet::<Self>::default()
-                        .fetch_pool(pool)
+                        .fetch(pool)
                         .await;
                 }
                 let _key = ::std::format!("{}__not_in", col);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, #root::core::SqlValue::List(_values))
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -4850,9 +4850,9 @@ fn inherent_impl_tokens(
             /// `Model::whereNull($col)->get()` parity.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_null(
                 col: &str,
                 pool: &#root::sql::Pool,
@@ -4864,7 +4864,7 @@ fn inherent_impl_tokens(
                 let _key = ::std::format!("{}__isnull", col);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, #root::core::SqlValue::Bool(true))
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -4872,9 +4872,9 @@ fn inherent_impl_tokens(
             /// `Model::whereNotNull($col)->get()` parity.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_not_null(
                 col: &str,
                 pool: &#root::sql::Pool,
@@ -4886,7 +4886,7 @@ fn inherent_impl_tokens(
                 let _key = ::std::format!("{}__isnull", col);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, #root::core::SqlValue::Bool(false))
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -4899,9 +4899,9 @@ fn inherent_impl_tokens(
             /// `pk >= rand_offset LIMIT N` walk for huge tables.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn random_n(
                 n: i64,
                 pool: &#root::sql::Pool,
@@ -4913,7 +4913,7 @@ fn inherent_impl_tokens(
                 #root::query::QuerySet::<Self>::default()
                     .order_random()
                     .limit(n)
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -4922,9 +4922,9 @@ fn inherent_impl_tokens(
             /// performance caveat as [`Self::random_n_pool`].
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn random(
                 pool: &#root::sql::Pool,
             ) -> ::core::result::Result<
@@ -4941,9 +4941,9 @@ fn inherent_impl_tokens(
             /// counterpart of [`Self::earliest_pool`].
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn oldest(
                 field: &str,
                 pool: &#root::sql::Pool,
@@ -4954,7 +4954,7 @@ fn inherent_impl_tokens(
                 use #root::sql::FetcherPool as _;
                 #root::query::QuerySet::<Self>::default()
                     .order_by(&[(field, false)])
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -4963,9 +4963,9 @@ fn inherent_impl_tokens(
             /// counterpart of [`Self::latest_pool`].
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn newest(
                 field: &str,
                 pool: &#root::sql::Pool,
@@ -4976,7 +4976,7 @@ fn inherent_impl_tokens(
                 use #root::sql::FetcherPool as _;
                 #root::query::QuerySet::<Self>::default()
                     .order_by(&[(field, true)])
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -4986,9 +4986,9 @@ fn inherent_impl_tokens(
             /// (issue #829).
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_year(
                 col: &str,
                 year: i64,
@@ -5001,7 +5001,7 @@ fn inherent_impl_tokens(
                 let _key = ::std::format!("{}__year", col);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, #root::core::SqlValue::I64(year))
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5010,9 +5010,9 @@ fn inherent_impl_tokens(
             /// `month` is 1–12.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_month(
                 col: &str,
                 month: i64,
@@ -5025,7 +5025,7 @@ fn inherent_impl_tokens(
                 let _key = ::std::format!("{}__month", col);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, #root::core::SqlValue::I64(month))
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5034,9 +5034,9 @@ fn inherent_impl_tokens(
             /// `day` is 1–31.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_day(
                 col: &str,
                 day: i64,
@@ -5049,7 +5049,7 @@ fn inherent_impl_tokens(
                 let _key = ::std::format!("{}__day", col);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, #root::core::SqlValue::I64(day))
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5058,9 +5058,9 @@ fn inherent_impl_tokens(
             /// `hour` is 0–23.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_hour(
                 col: &str,
                 hour: i64,
@@ -5073,7 +5073,7 @@ fn inherent_impl_tokens(
                 let _key = ::std::format!("{}__hour", col);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, #root::core::SqlValue::I64(hour))
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5082,9 +5082,9 @@ fn inherent_impl_tokens(
             /// `minute` is 0–59.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_minute(
                 col: &str,
                 minute: i64,
@@ -5097,7 +5097,7 @@ fn inherent_impl_tokens(
                 let _key = ::std::format!("{}__minute", col);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, #root::core::SqlValue::I64(minute))
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5107,9 +5107,9 @@ fn inherent_impl_tokens(
             /// parity.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_like(
                 col: &str,
                 pattern: impl ::core::convert::Into<::std::string::String>,
@@ -5125,7 +5125,7 @@ fn inherent_impl_tokens(
                         &_key,
                         #root::core::SqlValue::String(pattern.into()),
                     )
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5134,9 +5134,9 @@ fn inherent_impl_tokens(
             /// emulated via `LOWER(col) LIKE LOWER(pattern)`).
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_ilike(
                 col: &str,
                 pattern: impl ::core::convert::Into<::std::string::String>,
@@ -5152,7 +5152,7 @@ fn inherent_impl_tokens(
                         &_key,
                         #root::core::SqlValue::String(pattern.into()),
                     )
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5161,9 +5161,9 @@ fn inherent_impl_tokens(
             /// `whereLike("col", "$prefix%")` parity.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_starts_with(
                 col: &str,
                 prefix: impl ::core::convert::Into<::std::string::String>,
@@ -5179,7 +5179,7 @@ fn inherent_impl_tokens(
                         &_key,
                         #root::core::SqlValue::String(prefix.into()),
                     )
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5188,9 +5188,9 @@ fn inherent_impl_tokens(
             /// `whereLike("col", "%$suffix")` parity.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_ends_with(
                 col: &str,
                 suffix: impl ::core::convert::Into<::std::string::String>,
@@ -5206,7 +5206,7 @@ fn inherent_impl_tokens(
                         &_key,
                         #root::core::SqlValue::String(suffix.into()),
                     )
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5215,9 +5215,9 @@ fn inherent_impl_tokens(
             /// Eloquent `whereLike("col", "%$substr%")` parity.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_contains(
                 col: &str,
                 substr: impl ::core::convert::Into<::std::string::String>,
@@ -5233,7 +5233,7 @@ fn inherent_impl_tokens(
                         &_key,
                         #root::core::SqlValue::String(substr.into()),
                     )
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5241,9 +5241,9 @@ fn inherent_impl_tokens(
             /// `Model::where($col, ">", $val)->get()` parity.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_gt(
                 col: &str,
                 val: impl ::core::convert::Into<#root::core::SqlValue>,
@@ -5256,7 +5256,7 @@ fn inherent_impl_tokens(
                 let _key = ::std::format!("{}__gt", col);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, val)
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5264,9 +5264,9 @@ fn inherent_impl_tokens(
             /// `Model::where($col, ">=", $val)->get()` parity.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_gte(
                 col: &str,
                 val: impl ::core::convert::Into<#root::core::SqlValue>,
@@ -5279,7 +5279,7 @@ fn inherent_impl_tokens(
                 let _key = ::std::format!("{}__gte", col);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, val)
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5287,9 +5287,9 @@ fn inherent_impl_tokens(
             /// `Model::where($col, "<", $val)->get()` parity.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_lt(
                 col: &str,
                 val: impl ::core::convert::Into<#root::core::SqlValue>,
@@ -5302,7 +5302,7 @@ fn inherent_impl_tokens(
                 let _key = ::std::format!("{}__lt", col);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, val)
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5310,9 +5310,9 @@ fn inherent_impl_tokens(
             /// `Model::where($col, "<=", $val)->get()` parity.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_lte(
                 col: &str,
                 val: impl ::core::convert::Into<#root::core::SqlValue>,
@@ -5325,7 +5325,7 @@ fn inherent_impl_tokens(
                 let _key = ::std::format!("{}__lte", col);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, val)
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5333,9 +5333,9 @@ fn inherent_impl_tokens(
             /// `Model::where($col, "!=", $val)->get()` parity.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_ne(
                 col: &str,
                 val: impl ::core::convert::Into<#root::core::SqlValue>,
@@ -5348,7 +5348,7 @@ fn inherent_impl_tokens(
                 let _key = ::std::format!("{}__ne", col);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, val)
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5361,10 +5361,10 @@ fn inherent_impl_tokens(
             /// `Q` expression (`col1 = ? OR col2 = ? OR …`).
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`]; `QueryError::UnknownField`
+            /// As [`FetcherPool::fetch`]; `QueryError::UnknownField`
             /// when any column is not declared on the model.
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_any(
                 cols: &[&str],
                 val: impl ::core::convert::Into<#root::core::SqlValue>,
@@ -5416,9 +5416,9 @@ fn inherent_impl_tokens(
             /// drop into `Self::query()` for that.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn take(
                 n: i64,
                 pool: &#root::sql::Pool,
@@ -5429,7 +5429,7 @@ fn inherent_impl_tokens(
                 use #root::sql::FetcherPool as _;
                 #root::query::QuerySet::<Self>::default()
                     .limit(n)
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5441,9 +5441,9 @@ fn inherent_impl_tokens(
             /// prefer keyset pagination via PK on hot paths.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn for_page(
                 page: i64,
                 per_page: i64,
@@ -5457,7 +5457,7 @@ fn inherent_impl_tokens(
                 #root::query::QuerySet::<Self>::default()
                     .limit(per_page)
                     .offset(_offset)
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5492,7 +5492,7 @@ fn inherent_impl_tokens(
                 let total = {
                     use #root::sql::CounterPool as _;
                     #root::query::QuerySet::<Self>::default()
-                        .count_pool(pool)
+                        .count(pool)
                         .await?
                 };
                 let rows = Self::for_page(page, per_page, pool).await?;
@@ -5596,9 +5596,9 @@ fn inherent_impl_tokens(
             /// passed verbatim — caller controls `%` / `_`.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_not_like(
                 col: &str,
                 pattern: impl ::core::convert::Into<::std::string::String>,
@@ -5614,7 +5614,7 @@ fn inherent_impl_tokens(
                         &_key,
                         #root::core::SqlValue::String(pattern.into()),
                     )
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5623,9 +5623,9 @@ fn inherent_impl_tokens(
             /// SQLite emulated via `LOWER(col) NOT LIKE LOWER(pattern)`).
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_not_ilike(
                 col: &str,
                 pattern: impl ::core::convert::Into<::std::string::String>,
@@ -5641,7 +5641,7 @@ fn inherent_impl_tokens(
                         &_key,
                         #root::core::SqlValue::String(pattern.into()),
                     )
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5650,9 +5650,9 @@ fn inherent_impl_tokens(
             /// parity.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_not_between(
                 col: &str,
                 lo: impl ::core::convert::Into<#root::core::SqlValue>,
@@ -5670,7 +5670,7 @@ fn inherent_impl_tokens(
                 ]);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, _vals)
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5697,9 +5697,9 @@ fn inherent_impl_tokens(
             /// `Model::whereBetween($col, [$lo, $hi])->get()` parity.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn where_between(
                 col: &str,
                 lo: impl ::core::convert::Into<#root::core::SqlValue>,
@@ -5717,7 +5717,7 @@ fn inherent_impl_tokens(
                 ]);
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, _vals)
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5804,27 +5804,27 @@ fn inherent_impl_tokens(
             /// `true` when the table contains at least one row.
             /// Eloquent `Model::query()->exists()` / Django
             /// `Model.objects.exists()` parity. Thin wrapper over
-            /// `QuerySet::<Self>::default().exists_pool(pool)`.
+            /// `QuerySet::<Self>::default().exists(pool)`.
             ///
             /// # Errors
-            /// As [`ExistsPool::exists_pool`].
+            /// As [`ExistsPool::exists`].
             ///
-            /// [`ExistsPool::exists_pool`]: rustango::sql::ExistsPool::exists_pool
+            /// [`ExistsPool::exists`]: rustango::sql::ExistsPool::exists
             pub async fn exists(
                 pool: &#root::sql::Pool,
             ) -> ::core::result::Result<bool, #root::sql::ExecError> {
                 use #root::sql::ExistsPool as _;
                 #root::query::QuerySet::<Self>::default()
-                    .exists_pool(pool)
+                    .exists(pool)
                     .await
             }
 
-            /// Inverse of [`Self::exists_pool`] — returns `true` when
+            /// Inverse of [`Self::exists`] — returns `true` when
             /// the table has zero rows. Eloquent
             /// `Model::doesntExist()` parity.
             ///
             /// # Errors
-            /// As [`Self::exists_pool`].
+            /// As [`Self::exists`].
             pub async fn doesnt_exist(
                 pool: &#root::sql::Pool,
             ) -> ::core::result::Result<bool, #root::sql::ExecError> {
@@ -5884,26 +5884,26 @@ fn inherent_impl_tokens(
 
             /// Fetch every row of this model from `pool`. Eloquent
             /// `Model::all()` parity — a thin wrapper over
-            /// `QuerySet::<Self>::default().fetch_pool(pool)`.
+            /// `QuerySet::<Self>::default().fetch(pool)`.
             ///
             /// **Use with care on large tables** — there's no
             /// pagination or limit; the entire table is materialized
             /// into memory. For anything beyond fixture / lookup
             /// tables, page through `QuerySet::<Self>::default()
-            /// .order_by(...).limit(N).offset(M).fetch_pool(pool)`
+            /// .order_by(...).limit(N).offset(M).fetch(pool)`
             /// or stream via `.iterator(chunk_size)`.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn all(
                 pool: &#root::sql::Pool,
             ) -> ::core::result::Result<::std::vec::Vec<Self>, #root::sql::ExecError>
             {
                 use #root::sql::FetcherPool as _;
                 #root::query::QuerySet::<Self>::default()
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5915,7 +5915,7 @@ fn inherent_impl_tokens(
             /// parity.
             ///
             /// Thin wrapper over `QuerySet::<Self>::default()
-            /// .filter("<pk>__in", SqlValue::List([...])).fetch_pool(pool)`.
+            /// .filter("<pk>__in", SqlValue::List([...])).fetch(pool)`.
             /// Caller-supplied PKs that don't match a row are
             /// silently skipped (the returned vec is shorter than
             /// the input list). For an order-preserving / "fail
@@ -5927,9 +5927,9 @@ fn inherent_impl_tokens(
             /// `Vec<Uuid>`, etc.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn find_many<V>(
                 pks: impl ::core::iter::IntoIterator<Item = V>,
                 pool: &#root::sql::Pool,
@@ -5949,7 +5949,7 @@ fn inherent_impl_tokens(
                 let _key = ::std::format!("{}__in", ::core::stringify!(#pk_ident));
                 #root::query::QuerySet::<Self>::default()
                     .filter(&_key, #root::core::SqlValue::List(_values))
-                    .fetch_pool(pool)
+                    .fetch(pool)
                     .await
             }
 
@@ -5961,13 +5961,13 @@ fn inherent_impl_tokens(
             ///
             /// One-liner shortcut for the common
             /// `QuerySet::<Self>::default().filter("<pk_field>", pk)
-            /// .limit(1).fetch_pool(pool).await?.into_iter().next()`
+            /// .limit(1).fetch(pool).await?.into_iter().next()`
             /// dance.
             ///
             /// # Errors
-            /// As [`FetcherPool::fetch_pool`].
+            /// As [`FetcherPool::fetch`].
             ///
-            /// [`FetcherPool::fetch_pool`]: rustango::sql::FetcherPool::fetch_pool
+            /// [`FetcherPool::fetch`]: rustango::sql::FetcherPool::fetch
             pub async fn find(
                 pk: impl ::core::convert::Into<#root::core::SqlValue>,
                 pool: &#root::sql::Pool,
@@ -5979,7 +5979,7 @@ fn inherent_impl_tokens(
                     #root::query::QuerySet::<Self>::default()
                         .filter(::core::stringify!(#pk_ident), _pk_val)
                         .limit(1)
-                        .fetch_pool(pool)
+                        .fetch(pool)
                         .await?;
                 ::core::result::Result::Ok(_rows.into_iter().next())
             }
@@ -6910,10 +6910,10 @@ fn inherent_impl_tokens(
                 /// see issue #820 — so this is the explicit shortcut).
                 ///
                 /// One-liner over `QuerySet::<Self>::default()
-                /// .active().fetch_pool(pool)`. Closes #821 partial.
+                /// .active().fetch(pool)`. Closes #821 partial.
                 ///
                 /// # Errors
-                /// As [`#root::sql::FetcherPool::fetch_pool`].
+                /// As [`#root::sql::FetcherPool::fetch`].
                 pub async fn active(
                     pool: &#root::sql::Pool,
                 ) -> ::core::result::Result<
@@ -6923,7 +6923,7 @@ fn inherent_impl_tokens(
                     use #root::sql::FetcherPool as _;
                     #root::query::QuerySet::<Self>::default()
                         .active()
-                        .fetch_pool(pool)
+                        .fetch(pool)
                         .await
                 }
 
@@ -6933,11 +6933,11 @@ fn inherent_impl_tokens(
                 /// scans, etc.
                 ///
                 /// One-liner over `QuerySet::<Self>::default()
-                /// .only_trashed().fetch_pool(pool)`. Closes #821
+                /// .only_trashed().fetch(pool)`. Closes #821
                 /// partial.
                 ///
                 /// # Errors
-                /// As [`#root::sql::FetcherPool::fetch_pool`].
+                /// As [`#root::sql::FetcherPool::fetch`].
                 pub async fn only_trashed(
                     pool: &#root::sql::Pool,
                 ) -> ::core::result::Result<
@@ -6947,7 +6947,7 @@ fn inherent_impl_tokens(
                     use #root::sql::FetcherPool as _;
                     #root::query::QuerySet::<Self>::default()
                         .only_trashed()
-                        .fetch_pool(pool)
+                        .fetch(pool)
                         .await
                 }
 
@@ -6965,7 +6965,7 @@ fn inherent_impl_tokens(
                 /// Closes #821 partial.
                 ///
                 /// # Errors
-                /// As [`#root::sql::FetcherPool::fetch_pool`].
+                /// As [`#root::sql::FetcherPool::fetch`].
                 pub async fn with_trashed(
                     pool: &#root::sql::Pool,
                 ) -> ::core::result::Result<
@@ -6975,7 +6975,7 @@ fn inherent_impl_tokens(
                     use #root::sql::FetcherPool as _;
                     #root::query::QuerySet::<Self>::default()
                         .with_trashed()
-                        .fetch_pool(pool)
+                        .fetch(pool)
                         .await
                 }
 
@@ -8264,9 +8264,9 @@ struct ThroughAttr {
 ///
 /// ```ignore
 /// // Posts with at least one comment:
-/// Post::objects().where_raw(Post::comments_exists_expr()).fetch_pool(&pool)
+/// Post::objects().where_raw(Post::comments_exists_expr()).fetch(&pool)
 /// // Posts with no comments:
-/// Post::objects().where_raw(Post::comments_not_exists_expr()).fetch_pool(&pool)
+/// Post::objects().where_raw(Post::comments_not_exists_expr()).fetch(&pool)
 /// ```
 ///
 /// As with #817, all column / table identifiers are **SQL names**

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter12_bidialect.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter12_bidialect.rs
@@ -61,7 +61,7 @@ async fn cookbook_rating_round_trips_against_mysql() {
 
     let rows: Vec<Rating> = Rating::objects()
         .filter("id", Op::Eq, id)
-        .fetch_pool(&p).await.expect("fetch_pool against mysql");
+        .fetch(&p).await.expect("fetch against mysql");
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].score, 4);
 }
@@ -96,7 +96,7 @@ async fn mysql_multi_auto_inserts_then_refetches_for_remaining_fields() {
     // save when they need server-set timestamps.
     let rows: Vec<Author> = Author::objects()
         .filter("id", Op::Eq, id)
-        .fetch_pool(&p).await.unwrap();
+        .fetch(&p).await.unwrap();
     assert_eq!(rows.len(), 1);
     let loaded_joined_at = match rows[0].joined_at {
         Auto::Set(t) => t,
@@ -135,7 +135,7 @@ async fn mysql_decodes_multi_row_select() {
         r.save_pool(&p).await.unwrap();
     }
     let rows: Vec<Rating> = Rating::objects()
-        .fetch_pool(&p).await.expect("fetch_pool against mysql");
+        .fetch(&p).await.expect("fetch against mysql");
     assert_eq!(rows.len(), 5);
     let total: i64 = rows.iter().map(|r| r.score).sum();
     assert_eq!(total, 1 + 2 + 3 + 4 + 5);

--- a/crates/rustango/examples/gfk_demo/seed.rs
+++ b/crates/rustango/examples/gfk_demo/seed.rs
@@ -16,7 +16,7 @@ pub async fn run(pool: &Pool) -> Result<(), Box<dyn std::error::Error>> {
     // #253 — seed the admin user used by the session-login form.
     // Credentials default to `admin / admin`; override via the
     // `RUSTANGO_DEMO_USER` / `RUSTANGO_DEMO_PASS` env vars.
-    let existing_admin: Vec<AdminUser> = AdminUser::objects().fetch_pool(pool).await?;
+    let existing_admin: Vec<AdminUser> = AdminUser::objects().fetch(pool).await?;
     if existing_admin.is_empty() {
         let username = std::env::var("RUSTANGO_DEMO_USER").unwrap_or_else(|_| "admin".to_owned());
         let password = std::env::var("RUSTANGO_DEMO_PASS").unwrap_or_else(|_| "admin".to_owned());
@@ -27,7 +27,7 @@ pub async fn run(pool: &Pool) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Skip the rest if we've already populated.
-    let existing_posts: Vec<Post> = Post::objects().fetch_pool(pool).await?;
+    let existing_posts: Vec<Post> = Post::objects().fetch(pool).await?;
     if !existing_posts.is_empty() {
         println!("→ seed: demo data already present, skipping");
         return Ok(());

--- a/crates/rustango/examples/sqlite_app_demo.rs
+++ b/crates/rustango/examples/sqlite_app_demo.rs
@@ -80,7 +80,7 @@ fn routes() -> Router {
 async fn list_users(Extension(pool): Extension<Arc<Pool>>) -> Json<Vec<User>> {
     let users = User::objects()
         .order_by(&[("id", false)])
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("fetch users");
     Json(users)

--- a/crates/rustango/examples/sqlite_orm_demo.rs
+++ b/crates/rustango/examples/sqlite_orm_demo.rs
@@ -10,7 +10,7 @@
 //!   - Model derivation with `Auto<i64>` PK + `ForeignKey<T>`
 //!   - Schema bootstrap via the dialect-aware DDL emitter
 //!   - `insert_pool` (INSERT … RETURNING populating Auto PKs)
-//!   - `save_pool` / `delete_pool` / `count_pool` / `fetch_pool`
+//!   - `save_pool` / `delete_pool` / `count` / `fetch`
 //!   - QuerySet `filter` / `order_by` / `limit` / `offset`
 //!   - Filter operators: Eq, Gt, In, Like, ILike, Between
 //!   - `select_related` (FK join decoded via LoadRelatedSqlite)
@@ -132,12 +132,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     rustango::sql::bulk_insert_pool(&pool, &bulk_query).await?;
     println!("bulk_insert_pool inserted {} rows", post_seed.len());
 
-    println!("\n== 3. count_pool + fetch_pool ==");
-    let total = Post::objects().count_pool(&pool).await?;
+    println!("\n== 3. count + fetch ==");
+    let total = Post::objects().count(&pool).await?;
     println!("Post count: {total}");
     let all_posts: Vec<Post> = Post::objects()
         .order_by(&[("id", false)])
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?;
     for p in &all_posts {
         println!(
@@ -154,13 +154,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let alice_posts: Vec<Post> = Post::objects()
         .filter_op("author_id", Op::Eq, alice_id)
         .order_by(&[("title", false)])
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?;
     println!("Alice has {} post(s)", alice_posts.len());
 
     let popular: Vec<Post> = Post::objects()
         .filter_op("views", Op::Gt, 0_i64)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?;
     println!("posts with views > 0: {}", popular.len());
 
@@ -170,20 +170,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Op::In,
             SqlValue::List(vec![SqlValue::I64(alice_id), SqlValue::I64(bob_id)]),
         )
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?;
     println!("posts by Alice or Bob: {}", by_known_authors.len());
 
     let titles_with_pks: Vec<Post> = Post::objects()
         .filter_op("title", Op::Like, "%PKs%")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?;
     println!("LIKE '%PKs%': {}", titles_with_pks.len());
 
     // ILIKE — translated to LOWER(col) LIKE LOWER(?) on SQLite.
     let titles_ilike: Vec<Post> = Post::objects()
         .filter_op("title", Op::ILike, "%hello%")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?;
     println!("ILIKE '%hello%': {}", titles_ilike.len());
 
@@ -193,7 +193,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Op::Between,
             SqlValue::List(vec![SqlValue::I64(1), SqlValue::I64(50)]),
         )
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?;
     println!("BETWEEN 1 AND 50 views: {}", mid_views.len());
 
@@ -201,7 +201,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let newest_two: Vec<Post> = Post::objects()
         .order_by(&[("published_at", true)])
         .limit(2)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?;
     for p in &newest_two {
         println!("  newest: {}", p.title);
@@ -210,7 +210,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .order_by(&[("id", false)])
         .offset(1)
         .limit(2)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?;
     println!("skip 1 row, take 2: {}", skip_one.len());
 
@@ -218,7 +218,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut first = Post::objects()
         .order_by(&[("id", false)])
         .limit(1)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?
         .pop()
         .expect("at least one post");
@@ -226,7 +226,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     first.save_pool(&pool).await?;
     let refetched: Post = QuerySet::<Post>::new()
         .filter_op("id", Op::Eq, *first.id.get().unwrap())
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?
         .pop()
         .unwrap();
@@ -256,7 +256,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     let alice_after: Author = QuerySet::<Author>::new()
         .filter_op("id", Op::Eq, alice_id)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?
         .pop()
         .unwrap();
@@ -267,7 +267,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let joined: Vec<Post> = Post::objects()
         .select_related("author_id")
         .order_by(&[("id", false)])
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?;
     for p in &joined {
         let author_name = p
@@ -314,13 +314,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n== 12. delete_pool removes a row ==");
     let doomed = Post::objects()
         .filter_op("title", Op::Eq, "Draft")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?
         .pop()
         .expect("Draft post exists");
     let removed = doomed.delete_pool(&pool).await?;
     println!("delete_pool removed {removed} row");
-    let after = Post::objects().count_pool(&pool).await?;
+    let after = Post::objects().count(&pool).await?;
     println!("Post count after delete: {after}");
 
     println!("\n== ✓ All 12 sections completed against in-memory SQLite ==");

--- a/crates/rustango/src/admin/render.rs
+++ b/crates/rustango/src/admin/render.rs
@@ -71,7 +71,7 @@ pub(crate) fn coerce_form_to_json(field: &FieldSchema, raw: &str) -> serde_json:
 
 /// Backend-agnostic counterpart of [`render_value_for_input`]. Takes
 /// a `serde_json::Value` instead of a `PgRow` — call sites that fetch
-/// rows via the ORM (`Model::objects().fetch_pool` then
+/// rows via the ORM (`Model::objects().fetch` then
 /// `serde_json::to_value(&row)`) can render form inputs without
 /// pinning the registry to Postgres. Used by the v0.34 operator
 /// console.

--- a/crates/rustango/src/admin/totp_store.rs
+++ b/crates/rustango/src/admin/totp_store.rs
@@ -79,7 +79,7 @@ pub async fn device(pool: &Pool, user_id: i64) -> Option<AdminTotp> {
     use crate::sql::FetcherPool as _;
     AdminTotp::objects()
         .filter("user_id", user_id)
-        .fetch_pool(pool)
+        .fetch(pool)
         .await
         .ok()
         .and_then(|rows| rows.into_iter().next())

--- a/crates/rustango/src/contenttypes.rs
+++ b/crates/rustango/src/contenttypes.rs
@@ -78,7 +78,7 @@ pub struct ContentType {
 /// [`crate::sql::Pool`] enum carries.
 impl ContentType {
     /// Backend-agnostic counterpart of [`Self::by_natural_key`].
-    /// Routes through [`crate::sql::FetcherPool::fetch_pool`] so the
+    /// Routes through [`crate::sql::FetcherPool::fetch`] so the
     /// same call works against `Pool::Postgres` / `Pool::Mysql` /
     /// `Pool::Sqlite`.
     /// Prefer this in framework code so sqlite/mysql apps don't get
@@ -103,7 +103,7 @@ impl ContentType {
                 SqlValue::String(model_name.into()),
             )
             .limit(1)
-            .fetch_pool(pool)
+            .fetch(pool)
             .await?;
         Ok(rows.into_iter().next())
     }
@@ -117,7 +117,7 @@ impl ContentType {
         let rows: Vec<Self> = Self::objects()
             .filter_op("id", crate::core::Op::Eq, SqlValue::I64(id))
             .limit(1)
-            .fetch_pool(pool)
+            .fetch(pool)
             .await?;
         Ok(rows.into_iter().next())
     }
@@ -125,7 +125,7 @@ impl ContentType {
     /// Tri-dialect counterpart of [`Self::for_model`] (v0.38).
     /// Resolves `T`'s registered ContentType row via the natural
     /// `(app_label, model_name)` key — same lookup logic, but the
-    /// query goes through [`crate::sql::FetcherPool::fetch_pool`]
+    /// query goes through [`crate::sql::FetcherPool::fetch`]
     /// so the call works on PG / SQLite / MySQL.
     ///
     /// # Errors
@@ -213,7 +213,7 @@ impl ContentType {
     pub async fn all_ordered(pool: &crate::sql::Pool) -> Result<Vec<Self>, ExecError> {
         let rows: Vec<Self> = Self::objects()
             .order_by(&[("app_label", false), ("model_name", false)])
-            .fetch_pool(pool)
+            .fetch(pool)
             .await?;
         Ok(rows)
     }
@@ -598,7 +598,7 @@ pub async fn render_generic_fk_link(
 
 /// Tri-dialect counterpart of [`prefetch_soft`] (v0.38). Same shape
 /// — one batched SELECT against `target_fk_column`, grouped by
-/// parent PK — but routes through [`crate::sql::FetcherPool::fetch_pool`]
+/// parent PK — but routes through [`crate::sql::FetcherPool::fetch`]
 /// so the bound is `C: Model + MaybePgFromRow + MaybeMyFromRow +
 /// MaybeSqliteFromRow + …` (all auto-implemented by `#[derive(Model)]`).
 ///
@@ -641,7 +641,7 @@ where
             crate::core::Op::In,
             crate::core::SqlValue::List(pk_values),
         )
-        .fetch_pool(pool)
+        .fetch(pool)
         .await?;
     let mut grouped: ::std::collections::HashMap<i64, Vec<C>> = ::std::collections::HashMap::new();
     for child in children {
@@ -653,7 +653,7 @@ where
 
 /// Tri-dialect counterpart of [`prefetch_generic`] (v0.38). Routes the
 /// ContentType lookup through [`ContentType::for_model`] and the
-/// target SELECT through [`crate::sql::FetcherPool::fetch_pool`] so
+/// target SELECT through [`crate::sql::FetcherPool::fetch`] so
 /// the same body works on PG / SQLite / MySQL.
 ///
 /// # Errors
@@ -719,7 +719,7 @@ where
             crate::core::Op::In,
             crate::core::SqlValue::List(pk_values),
         )
-        .fetch_pool(pool)
+        .fetch(pool)
         .await?;
 
     let mut out: ::std::collections::HashMap<(i64, i64), C> =

--- a/crates/rustango/src/core/expr.rs
+++ b/crates/rustango/src/core/expr.rs
@@ -16,7 +16,7 @@
 //! // Column-vs-column filter.
 //! Reservation::objects()
 //!     .where_col(Reservation::start_date, Op::Lt, F("end_date"))
-//!     .fetch_pool(&pool).await?;
+//!     .fetch(&pool).await?;
 //! ```
 //!
 //! `Expr` carries three variants:

--- a/crates/rustango/src/core/fts.rs
+++ b/crates/rustango/src/core/fts.rs
@@ -29,7 +29,7 @@
 //!     .annotate("rank", SearchRank::new(&v, &q))
 //!     .where_raw(v.matches(&q))
 //!     .order_by_expr(SearchRank::new(&v, &q), true) // rank DESC
-//!     .fetch_pool(&pool).await?;
+//!     .fetch(&pool).await?;
 //! ```
 //!
 //! ## API surface

--- a/crates/rustango/src/databases.rs
+++ b/crates/rustango/src/databases.rs
@@ -2,7 +2,7 @@
 //! `QuerySet.using(alias)` (issues #332 / #400).
 //!
 //! rustango is single-pool-per-call by default: every terminal takes an
-//! explicit connection (`fetch_pool(&pool)` / `fetch_on(executor)`), so
+//! explicit connection (`fetch(&pool)` / `fetch_on(executor)`), so
 //! multi-DB routing is already possible by passing the right pool. This
 //! module adds the Django-shaped **named-alias** convenience on top: a
 //! process-wide registry of `alias → Pool` plus a `.using("alias")` verb
@@ -23,7 +23,7 @@
 //!     .await?;
 //! ```
 //!
-//! **Writes** still route through the explicit `fetch_pool(&pool)` family
+//! **Writes** still route through the explicit `fetch(&pool)` family
 //! on purpose — `.using` exposes only the read terminals so a write
 //! can't be silently sent to a read replica. Automatic per-model routing
 //! (Django's `DATABASE_ROUTERS`, #401) is a separate layer on top of this
@@ -215,7 +215,7 @@ impl<T: crate::core::Model> crate::query::QuerySet<T> {
     /// (`fetch` / `first` / `count` / `exists`) bound to the resolved
     /// pool. Panics at call time if `alias` isn't registered (see
     /// [`pool`]). Writes intentionally aren't routed here — use the
-    /// explicit `fetch_pool(&pool)` family for those.
+    /// explicit `fetch(&pool)` family for those.
     #[must_use]
     pub fn using(self, alias: &str) -> UsingQuerySet<T> {
         UsingQuerySet {
@@ -232,7 +232,7 @@ impl<T: crate::core::Model> crate::query::QuerySet<T> {
     ///
     /// Panics if the chosen alias isn't registered (see [`pool`]). Like
     /// [`Self::using`], this exposes only read terminals; for writes use
-    /// [`write_pool_for`] (`fetch_pool(&write_pool_for(T::SCHEMA))`) so a
+    /// [`write_pool_for`] (`fetch(&write_pool_for(T::SCHEMA))`) so a
     /// write is never silently sent to a read replica.
     #[must_use]
     pub fn routed(self) -> UsingQuerySet<T> {
@@ -262,13 +262,13 @@ where
         + Unpin,
 {
     /// Run the query against the chosen connection — like
-    /// `fetch_pool(&pool)` but routed by alias.
+    /// `fetch(&pool)` but routed by alias.
     ///
     /// # Errors
-    /// As [`crate::sql::FetcherPool::fetch_pool`].
+    /// As [`crate::sql::FetcherPool::fetch`].
     pub async fn fetch(self) -> Result<Vec<T>, crate::sql::ExecError> {
         use crate::sql::FetcherPool as _;
-        self.qs.fetch_pool(&self.pool).await
+        self.qs.fetch(&self.pool).await
     }
 
     /// The first matching row (applies `LIMIT 1`).
@@ -277,30 +277,24 @@ where
     /// As [`Self::fetch`].
     pub async fn first(self) -> Result<Option<T>, crate::sql::ExecError> {
         use crate::sql::FetcherPool as _;
-        Ok(self
-            .qs
-            .limit(1)
-            .fetch_pool(&self.pool)
-            .await?
-            .into_iter()
-            .next())
+        Ok(self.qs.limit(1).fetch(&self.pool).await?.into_iter().next())
     }
 
     /// `SELECT COUNT(*)` against the chosen connection.
     ///
     /// # Errors
-    /// As [`crate::sql::CounterPool::count_pool`].
+    /// As [`crate::sql::CounterPool::count`].
     pub async fn count(self) -> Result<i64, crate::sql::ExecError> {
         use crate::sql::CounterPool as _;
-        self.qs.count_pool(&self.pool).await
+        self.qs.count(&self.pool).await
     }
 
     /// `EXISTS` against the chosen connection.
     ///
     /// # Errors
-    /// As [`crate::sql::ExistsPool::exists_pool`].
+    /// As [`crate::sql::ExistsPool::exists`].
     pub async fn exists(self) -> Result<bool, crate::sql::ExecError> {
         use crate::sql::ExistsPool as _;
-        self.qs.exists_pool(&self.pool).await
+        self.qs.exists(&self.pool).await
     }
 }

--- a/crates/rustango/src/extractors/session_user.rs
+++ b/crates/rustango/src/extractors/session_user.rs
@@ -89,7 +89,7 @@ impl<S: Send + Sync> FromRequestParts<S> for SessionUser {
         // instead of acquiring a backend-specific TenantConn. This
         // lets `SessionUser` resolve on sqlite + mysql tenancy builds
         // the same way `SessionOperator` already does (via
-        // `fetch_pool` on the registry pool below).
+        // `fetch` on the registry pool below).
         let pool = match ctx.pools.scoped_pool_dyn(&org).await {
             Ok(p) => p,
             Err(_) => return Ok(SessionUser(None)),
@@ -99,7 +99,7 @@ impl<S: Send + Sync> FromRequestParts<S> for SessionUser {
         use crate::sql::FetcherPool as _;
         let users = User::objects()
             .where_(User::id.eq(payload.uid))
-            .fetch_pool(&pool)
+            .fetch(&pool)
             .await
             .unwrap_or_default();
 
@@ -147,7 +147,7 @@ impl<S: Send + Sync> FromRequestParts<S> for SessionOperator {
         use crate::sql::FetcherPool as _;
         let ops = Operator::objects()
             .where_(Operator::id.eq(payload.oid))
-            .fetch_pool(&ctx.pools.registry_pool())
+            .fetch(&ctx.pools.registry_pool())
             .await
             .unwrap_or_default();
 

--- a/crates/rustango/src/extractors/tenant.rs
+++ b/crates/rustango/src/extractors/tenant.rs
@@ -78,7 +78,7 @@ pub struct Tenant<DB: Database = DefaultTenantDb> {
     /// it would hit the `public` schema unless `SET search_path` is
     /// applied — for that path prefer [`Tenant::conn`]). On non-PG
     /// (and PG database-mode), this is the tenant's dedicated pool;
-    /// handlers can run `Model::objects().fetch_pool(&t.pool)` for
+    /// handlers can run `Model::objects().fetch(&t.pool)` for
     /// tri-dialect ORM queries.
     pool: crate::sql::Pool,
 }
@@ -135,7 +135,7 @@ impl<DB: Database> Tenant<DB> {
     }
 
     /// Borrow the tenant-scoped [`crate::sql::Pool`] enum. Use this
-    /// when routing through the tri-dialect ORM (`fetch_pool` /
+    /// when routing through the tri-dialect ORM (`fetch` /
     /// `insert_pool` / `save_pool`) — every backend works through the
     /// same code path.
     ///
@@ -251,7 +251,7 @@ where
             .map_err(|e| TenantRejection::Internal(e.to_string()))?;
         // v0.38 — also resolve the backend-erasing Pool enum so
         // `t.pool()` lets handlers use tri-dialect ORM helpers
-        // (fetch_pool / save_pool / etc.). Schema-mode picks the
+        // (fetch / save_pool / etc.). Schema-mode picks the
         // shared registry pool (which requires SET search_path);
         // database-mode resolves to the dedicated tenant pool.
         let pool = ctx

--- a/crates/rustango/src/i18n/db.rs
+++ b/crates/rustango/src/i18n/db.rs
@@ -112,7 +112,7 @@ pub async fn ensure_table_pool(pool: &Pool) -> Result<(), sqlx::Error> {
 /// As the ORM fetch path ([`ExecError`]).
 pub async fn all_pool(pool: &Pool) -> Result<Vec<Translation>, ExecError> {
     use crate::sql::FetcherPool as _;
-    Translation::objects().fetch_pool(pool).await
+    Translation::objects().fetch(pool).await
 }
 
 /// Insert-or-update the editable value for `(locale, key)` — the

--- a/crates/rustango/src/inheritance.rs
+++ b/crates/rustango/src/inheritance.rs
@@ -115,7 +115,7 @@
 //! }
 //!
 //! // Acts as a "PublishedArticle" proxy:
-//! Article::objects().only_published().fetch_pool(&pool).await?;
+//! Article::objects().only_published().fetch(&pool).await?;
 //! ```
 //!
 //! ## Summary table

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -1417,7 +1417,7 @@ pub use rustango_macros::embed_migrations;
 ///
 /// User::objects()
 ///     .where_(Q!(User.email__icontains = "alice"))
-///     .fetch_pool(&pool).await?;
+///     .fetch(&pool).await?;
 /// // → WHERE "email" ILIKE $1   ($1 = "%alice%")
 /// ```
 #[allow(non_upper_case_globals)]

--- a/crates/rustango/src/manager.rs
+++ b/crates/rustango/src/manager.rs
@@ -33,7 +33,7 @@
 //! Rust's **extension trait** idiom maps directly to Django's
 //! `as_manager()` — and it's strictly more flexible because the
 //! returned chained value is still a `QuerySet<T>`, so every existing
-//! method (`.where_`, `.order_by`, `.fetch_pool`) stays available
+//! method (`.where_`, `.order_by`, `.fetch`) stays available
 //! alongside the app-specific shortcuts. No subclassing, no method
 //! resolution surprises.
 //!
@@ -73,7 +73,7 @@
 //!         .published()                    // custom shortcut
 //!         .by_author(7)                   // another custom shortcut
 //!         .order_by("-id")                // framework method
-//!         .fetch_pool(pool).await.unwrap();
+//!         .fetch(pool).await.unwrap();
 //! }
 //! ```
 //!
@@ -98,12 +98,12 @@
 //! // Usage:
 //! let public_articles = Article::published_objects()
 //!     .order_by("-id")
-//!     .fetch_pool(&pool).await?;
+//!     .fetch(&pool).await?;
 //! ```
 //!
 //! Either shape composes with the rest of the QuerySet builder —
 //! you can call any framework method (`.where_`, `.limit`,
-//! `.select_related`, `.order_by`, `.fetch_pool`) on the result.
+//! `.select_related`, `.order_by`, `.fetch`) on the result.
 //!
 //! ## Why no `#[rustango(manager = "...")]` attribute?
 //!
@@ -134,4 +134,4 @@
 // machinery — no framework runtime to test. Worked examples live in
 // `tests/manager_pattern_live.rs`, which uses a real `#[derive(Model)]`
 // type to prove the shape compiles end-to-end and the chained QuerySet
-// still routes through `.fetch_pool()`.
+// still routes through `.fetch()`.

--- a/crates/rustango/src/pagination.rs
+++ b/crates/rustango/src/pagination.rs
@@ -21,19 +21,19 @@
 //! For server-side rendered list views (Tera / template_views), pure-
 //! metadata `Paginator` + `Page` types. The `Page` holds no rows — the
 //! caller computes `page.offset()` and `page.limit()` and feeds them
-//! into a `QuerySet` `.offset(...).limit(...).fetch_pool(...)` call.
+//! into a `QuerySet` `.offset(...).limit(...).fetch(...)` call.
 //!
 //! ```ignore
 //! use rustango::pagination::Paginator;
 //!
-//! let total = Post::objects().count_pool(&pool).await?;
+//! let total = Post::objects().count(&pool).await?;
 //! let paginator = Paginator::new(total as usize, 20);
 //! let page = paginator.get_page(requested_page_number); // never errors — clamps
 //! let rows = Post::objects()
 //!     .order_by(&[("id", false)])
 //!     .limit(page.limit() as i64)
 //!     .offset(page.offset() as i64)
-//!     .fetch_pool(&pool).await?;
+//!     .fetch(&pool).await?;
 //!
 //! // Template rendering — emit the 1, 2, …, 12, 13, 14, …, 49, 50 pager:
 //! for mark in paginator.get_elided_page_range(page.number, 3, 2) { … }
@@ -70,7 +70,7 @@
 //! if let Some(c) = &cursor {
 //!     q = q.filter("id__gt", c.position.id);
 //! }
-//! let rows = q.fetch_pool(&pool).await?;
+//! let rows = q.fetch(&pool).await?;
 //!
 //! let page = paginator.build_page(rows, |row| PostPos { id: row.id });
 //! // page.items — up to N rows
@@ -932,7 +932,7 @@ impl<'a> Page<'a> {
 
     /// Slice a fully-fetched item list for this page. Convenient for
     /// in-memory paging when you've already pulled everything via a
-    /// single `fetch_pool` and want to render one page at a time
+    /// single `fetch` and want to render one page at a time
     /// without round-trips. For DB-backed paging, prefer
     /// `.limit([page.limit()]).offset([page.offset()])` on the queryset.
     ///

--- a/crates/rustango/src/passkey/mod.rs
+++ b/crates/rustango/src/passkey/mod.rs
@@ -136,7 +136,7 @@ pub async fn for_user(
     use crate::sql::FetcherPool as _;
     WebauthnCredential::objects()
         .filter("user_id", user_id)
-        .fetch_pool(pool)
+        .fetch(pool)
         .await
 }
 
@@ -152,7 +152,7 @@ pub async fn by_credential_id(
     use crate::sql::FetcherPool as _;
     Ok(WebauthnCredential::objects()
         .filter("credential_id", credential_id.to_owned())
-        .fetch_pool(pool)
+        .fetch(pool)
         .await?
         .into_iter()
         .next())

--- a/crates/rustango/src/prunable.rs
+++ b/crates/rustango/src/prunable.rs
@@ -120,7 +120,7 @@ where
     T: Prunable + Send + 'static,
     QuerySet<T>: CounterPool<T>,
 {
-    Box::pin(async move { T::prune_queryset().count_pool(pool).await })
+    Box::pin(async move { T::prune_queryset().count(pool).await })
 }
 
 /// Internal helper invoked from [`register_prunable!`] to build the
@@ -241,7 +241,7 @@ pub async fn prune_pretend(
         let rows = (entry.count)(pool).await?;
         reports.push(PruneReport {
             table: entry.name.to_owned(),
-            // `count_pool` returns i64; clamp the negative-impossible
+            // `count` returns i64; clamp the negative-impossible
             // case to 0 so the reporting type stays positive.
             rows: u64::try_from(rows.max(0)).unwrap_or(0),
         });

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -683,7 +683,7 @@ impl<T: Model> QuerySet<T> {
     /// chainable form lives here under the explicit name.
     ///
     /// ```ignore
-    /// Post::objects().order_by_desc("created_at").fetch_pool(&pool).await?;
+    /// Post::objects().order_by_desc("created_at").fetch(&pool).await?;
     /// // SELECT ... FROM post ORDER BY created_at DESC
     /// ```
     #[must_use]
@@ -698,7 +698,7 @@ impl<T: Model> QuerySet<T> {
     /// `Builder::oldest($column)`.
     ///
     /// ```ignore
-    /// Post::objects().order_by_asc("created_at").fetch_pool(&pool).await?;
+    /// Post::objects().order_by_asc("created_at").fetch(&pool).await?;
     /// // SELECT ... FROM post ORDER BY created_at ASC
     /// ```
     #[must_use]
@@ -844,7 +844,7 @@ impl<T: Model> QuerySet<T> {
     /// let hits = Doc::objects()
     ///     .order_by_distance("embedding", query_embedding, VectorMetric::Cosine)
     ///     .limit(5)
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn order_by_distance(
@@ -869,7 +869,7 @@ impl<T: Model> QuerySet<T> {
     /// use rustango::core::VectorMetric;
     /// let top3 = Doc::objects()
     ///     .k_nearest("embedding", query_embedding, 3, VectorMetric::L2)
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn k_nearest(
@@ -893,7 +893,7 @@ impl<T: Model> QuerySet<T> {
     /// let near = Place::objects()
     ///     .order_by_distance_to("location", here)
     ///     .limit(5)
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn order_by_distance_to(self, column: &'static str, point: crate::sql::Point) -> Self {
@@ -910,7 +910,7 @@ impl<T: Model> QuerySet<T> {
     /// // Places within ~1km (in degrees) of `here`.
     /// let nearby = Place::objects()
     ///     .filter_dwithin("location", here, 0.01)
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn filter_dwithin(
@@ -986,7 +986,7 @@ impl<T: Model> QuerySet<T> {
     /// let five = Post::objects()
     ///     .in_random_order()
     ///     .take(5)
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn in_random_order(self) -> Self {
@@ -1162,7 +1162,7 @@ impl<T: Model> QuerySet<T> {
     ///         op: Op::Eq,
     ///         rhs: aliased("customer", "id"),
     ///     })
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn join_sub(self, sub: SelectQuery, alias: &'static str, on: WhereExpr) -> Self {
@@ -1354,7 +1354,7 @@ impl<T: Model> QuerySet<T> {
     ///
     /// ```ignore
     /// // Django: Post.objects.exclude(status="draft")
-    /// Post::objects().exclude("status", "draft").fetch_pool(&pool).await?;
+    /// Post::objects().exclude("status", "draft").fetch(&pool).await?;
     /// // with a lookup suffix:
     /// Post::objects().exclude("views__lt", 100_i64)
     /// ```
@@ -1422,7 +1422,7 @@ impl<T: Model> QuerySet<T> {
     /// // Eloquent: Post::query()->whereKeyNot(1)->get();
     /// let others = Post::objects()
     ///     .where_key_not(1_i64)
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     ///
     /// Errors as [`Self::where_key`] when the model carries no PK.
@@ -1456,7 +1456,7 @@ impl<T: Model> QuerySet<T> {
     ///     .compile()?;
     /// let authors = Author::objects()
     ///     .where_exists(with_books)
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     ///
     /// Sugar over `self.where_raw(subquery::exists(subquery))`.
@@ -1476,7 +1476,7 @@ impl<T: Model> QuerySet<T> {
     ///     .compile()?;
     /// let empty = Author::objects()
     ///     .where_not_exists(no_books)
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn where_not_exists(self, subquery: SelectQuery) -> Self {
@@ -1499,7 +1499,7 @@ impl<T: Model> QuerySet<T> {
     ///     .compile()?;
     /// let visible = Post::objects()
     ///     .where_in_subquery("category_id", public_cat_ids)
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn where_in_subquery(self, column: &'static str, subquery: SelectQuery) -> Self {
@@ -1539,7 +1539,7 @@ impl<T: Model> QuerySet<T> {
     /// // Authors with at least one book (reverse-FK relation "books").
     /// let with_books = Author::objects()
     ///     .where_has("books")
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn where_has(self, name: &str) -> Self {
@@ -1628,7 +1628,7 @@ impl<T: Model> QuerySet<T> {
     /// // Authors with zero books.
     /// let empty = Author::objects()
     ///     .where_doesnt_have("books")
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn where_doesnt_have(self, name: &str) -> Self {
@@ -1662,7 +1662,7 @@ impl<T: Model> QuerySet<T> {
     /// let inner = Book::objects().filter("published", true).compile()?;
     /// let authors = Author::objects()
     ///     .where_has_filter("books", inner)
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn where_has_filter(self, name: &str, inner: SelectQuery) -> Self {
@@ -1758,7 +1758,7 @@ impl<T: Model> QuerySet<T> {
     /// // Eloquent: Author::has('books', '>', 3)->get();
     /// let prolific = Author::objects()
     ///     .where_has_count("books", Op::Gt, 3)
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn where_has_count(self, name: &str, op: Op, n: i64) -> Self {
@@ -1799,7 +1799,7 @@ impl<T: Model> QuerySet<T> {
     /// // Eloquent: Author::withCount('books')->get();
     /// let rows = Author::objects()
     ///     .annotate_count("books")
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// // rows[0]["books_count"] => SqlValue::I64(n)
     /// ```
     #[must_use]
@@ -2006,7 +2006,7 @@ impl<T: Model> QuerySet<T> {
     /// // Eloquent: User::whereColumn('first_name', 'last_name');
     /// User::objects()
     ///     .where_column("first_name", "last_name")
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn where_column(self, col1: &'static str, col2: &'static str) -> Self {
@@ -2022,7 +2022,7 @@ impl<T: Model> QuerySet<T> {
     /// // start_date < end_date — Eloquent: whereColumn('start_date', '<', 'end_date')
     /// Reservation::objects()
     ///     .where_column_op("start_date", Op::Lt, "end_date")
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn where_column_op(self, col1: &'static str, op: Op, col2: &'static str) -> Self {
@@ -2116,7 +2116,7 @@ impl<T: Model> QuerySet<T> {
     /// let rows = Post::objects()
     ///     .filter("active", true)
     ///     .tap(|qs| tracing::debug!(?qs, "about to fetch"))
-    ///     .fetch_pool(&pool).await?;
+    ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
     pub fn tap<F>(self, f: F) -> Self
@@ -2339,7 +2339,7 @@ impl<T: Model> QuerySet<T> {
 
     /// Project to `Vec<HashMap<String, SqlValue>>` — Django's
     /// `.values('id', 'name')`. Issue #22. Returns a
-    /// [`ValuesQuerySet`] whose terminal `.fetch_pool(&pool)` decodes
+    /// [`ValuesQuerySet`] whose terminal `.fetch(&pool)` decodes
     /// rows into a `HashMap` keyed by column name.
     ///
     /// Skips the typed `Model` decode — useful when you only need a
@@ -2377,7 +2377,7 @@ impl<T: Model> QuerySet<T> {
 
     /// Single-column flat projection — Django's
     /// `.values_list('id', flat=True)`. Issue #22. Returns
-    /// [`ValuesFlatQuerySet`] whose terminal `.fetch_pool::<U>(&pool)`
+    /// [`ValuesFlatQuerySet`] whose terminal `.fetch::<U>(&pool)`
     /// decodes the single column into `Vec<U>` directly via sqlx's
     /// typed `query_scalar` path.
     ///
@@ -2448,7 +2448,7 @@ impl<T: Model> QuerySet<T> {
     pub fn compile_delete(mut self) -> Result<DeleteQuery, QueryError> {
         // Issue #820 — fold global scopes into the WHERE so a
         // `Post.objects().delete_pool(&pool)` honors the same
-        // auto-applied filter that `Post.objects().fetch_pool(&pool)`
+        // auto-applied filter that `Post.objects().fetch(&pool)`
         // does (e.g. a `published_only` scope means a wholesale delete
         // still won't reach unpublished rows).
         self.apply_global_scopes();
@@ -2669,7 +2669,7 @@ impl<T: Model> UpdateBuilder<T> {
     pub fn compile(mut self) -> Result<UpdateQuery, QueryError> {
         // Issue #820 — same rationale as the SELECT / DELETE paths:
         // an `.update().set(...)` shouldn't escape the model's global
-        // scopes any more than a plain `.fetch_pool` would.
+        // scopes any more than a plain `.fetch` would.
         self.qs.apply_global_scopes();
         let model: &'static ModelSchema = T::SCHEMA;
 
@@ -4051,7 +4051,7 @@ impl<T: Model> AggregateBuilder<T> {
             return Err(e);
         }
         // Issue #820 — fold global scopes into the WHERE so aggregates
-        // honor the same auto-applied filter (e.g. `.count_pool()`
+        // honor the same auto-applied filter (e.g. `.count()`
         // against a `published_only`-scoped model counts published
         // rows only, not the table's full row count).
         self.qs.apply_global_scopes();
@@ -4221,7 +4221,7 @@ fn validate_aggregate_expr_columns(
 /// Pure-projection queryset returned by [`QuerySet::values_dict`].
 /// Compiles to a `SELECT <cols> FROM …` with the WHERE / ORDER BY /
 /// LIMIT / OFFSET / set-algebra branches of the underlying queryset
-/// preserved. Terminal `fetch_pool` lives in
+/// preserved. Terminal `fetch` lives in
 /// [`crate::sql::fetch_values_dict_pool`].
 pub struct ValuesQuerySet<T: Model> {
     pub(crate) qs: QuerySet<T>,
@@ -4342,7 +4342,7 @@ impl DateKind {
 }
 
 /// Builder returned by [`QuerySet::dates`]. The terminal
-/// [`fetch_pool`](Self::fetch_pool) emits
+/// [`fetch`](Self::fetch) emits
 /// `SELECT DISTINCT <trunc(col)> AS d FROM (<inner-query>) sub ORDER BY d`
 /// — the wrap inherits the underlying queryset's WHERE / JOINs / LIMIT
 /// / ORDER BY so filters on the QuerySet pass through to `.dates()`.

--- a/crates/rustango/src/query/q.rs
+++ b/crates/rustango/src/query/q.rs
@@ -17,7 +17,7 @@
 //!         Q::startswith("name", "A")
 //!             | (Q::gt("age", 18_i64) & !Q::eq("banned", true))
 //!     )
-//!     .fetch_pool(&pool).await?;
+//!     .fetch(&pool).await?;
 //! ```
 //!
 //! ## When to reach for `Q()` vs `Q!()` macro vs typed methods

--- a/crates/rustango/src/shortcuts.rs
+++ b/crates/rustango/src/shortcuts.rs
@@ -178,7 +178,7 @@ where
         + MaybeMyLoadRelated
         + MaybeSqliteLoadRelated,
 {
-    let rows = qs.fetch_pool(pool).await?;
+    let rows = qs.fetch(pool).await?;
     if rows.is_empty() {
         Err(ShortcutError::not_found(format!(
             "no {} matches",

--- a/crates/rustango/src/sql/executor/get_or_create.rs
+++ b/crates/rustango/src/sql/executor/get_or_create.rs
@@ -1,7 +1,7 @@
 //! Django-shape `get_or_create` / `update_or_create` helpers.
 //!
 //! Extracted from `executor/mod.rs` as part of #116 step 2. Both
-//! helpers go through `FetcherPool::fetch_pool` then either return
+//! helpers go through `FetcherPool::fetch` then either return
 //! the existing row or invoke the caller's `create_fn` / `update_fn`
 //! closure.
 
@@ -51,7 +51,7 @@ use crate::sql::Pool;
 /// # Errors
 /// - [`ExecError::MultipleRowsReturned`] when the filter matches >1 row.
 /// - Whatever the `create_fn` closure returns when matching no rows.
-/// - Whatever [`FetcherPool::fetch_pool`] returns.
+/// - Whatever [`FetcherPool::fetch`] returns.
 pub async fn get_or_create<T, F, Fut>(
     qs: crate::query::QuerySet<T>,
     create_fn: F,
@@ -70,7 +70,7 @@ where
     F: FnOnce(Pool) -> Fut,
     Fut: std::future::Future<Output = Result<T, ExecError>>,
 {
-    let mut rows = qs.fetch_pool(pool).await?;
+    let mut rows = qs.fetch(pool).await?;
     match rows.len() {
         0 => Ok((create_fn(pool.clone()).await?, true)),
         1 => Ok((rows.remove(0), false)),
@@ -137,7 +137,7 @@ where
     CF: FnOnce(Pool) -> CFut,
     CFut: std::future::Future<Output = Result<T, ExecError>>,
 {
-    let mut rows = qs.fetch_pool(pool).await?;
+    let mut rows = qs.fetch(pool).await?;
     match rows.len() {
         0 => Ok((create_fn(pool.clone()).await?, true)),
         1 => {

--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -115,7 +115,7 @@ impl<T> QuerySet<T>
 where
     T: Model + for<'r> sqlx::FromRow<'r, PgRow> + Send + Unpin,
 {
-    /// Like [`Fetcher::fetch`] but takes any sqlx executor — `&PgPool`,
+    /// Like [`FetcherPool::fetch`] but takes any sqlx executor — `&PgPool`,
     /// `&mut PgConnection`, or a `Transaction`. The escape hatch for
     /// tenant-scoped queries: schema-mode tenants share the registry
     /// pool but rely on a per-checkout `SET search_path`, so passing
@@ -123,7 +123,7 @@ where
     /// connection via `TenantPools::acquire(&org)` and pass that here.
     ///
     /// # Errors
-    /// As [`Fetcher::fetch`].
+    /// As [`FetcherPool::fetch`].
     pub async fn fetch_on<'c, E>(self, executor: E) -> Result<Vec<T>, ExecError>
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
@@ -2102,7 +2102,7 @@ pub async fn fetch_datetimes_pool<T: crate::core::Model + Send>(
     Ok(rows.into_iter().map(|r| r.0).collect())
 }
 
-/// `Counter::count` against either backend — fills the QuerySet
+/// `CounterPool::count` against either backend — fills the QuerySet
 /// counter gap from batches 5/15. Counts rows matching the queryset's
 /// filters via `count_rows_pool`.
 ///
@@ -2111,15 +2111,13 @@ pub trait CounterPool<T: Model + Send> {
     /// Count rows matching the queryset's filters against either backend.
     ///
     /// # Errors
-    /// As [`Counter::count`].
-    fn count_pool(
-        self,
-        pool: &Pool,
-    ) -> impl std::future::Future<Output = Result<i64, ExecError>> + Send;
+    /// As [`CounterPool::count`].
+    fn count(self, pool: &Pool)
+        -> impl std::future::Future<Output = Result<i64, ExecError>> + Send;
 }
 
 impl<T: Model + Send> CounterPool<T> for QuerySet<T> {
-    async fn count_pool(self, pool: &Pool) -> Result<i64, ExecError> {
+    async fn count(self, pool: &Pool) -> Result<i64, ExecError> {
         let select = self.compile()?;
         count_rows_pool(
             pool,
@@ -2137,9 +2135,9 @@ impl<T: Model + Send> CounterPool<T> for QuerySet<T> {
 /// (issue #330) — boolean predicates on top of the existing count
 /// path.
 ///
-/// `exists_pool` returns `Ok(true)` when at least one row matches the
+/// `exists` returns `Ok(true)` when at least one row matches the
 /// queryset's filters, `Ok(false)` otherwise. Internally runs the
-/// same `COUNT(*)` as [`CounterPool::count_pool`] and compares to
+/// same `COUNT(*)` as [`CounterPool::count`] and compares to
 /// zero — simple + dialect-agnostic. Future optimization: emit
 /// `SELECT 1 FROM … LIMIT 1` instead of `COUNT(*)`, which doesn't
 /// scan all matching rows. Tracked as a follow-up; the count
@@ -2147,8 +2145,8 @@ impl<T: Model + Send> CounterPool<T> for QuerySet<T> {
 ///
 /// `contains_pk` adds the convenience of "is THIS pk in the
 /// queryset?" — looks up the model's primary key column from the
-/// schema, builds an `Eq` predicate, and forwards to `exists_pool`.
-/// Equivalent to `qs.filter("<pk_col>", pk).exists_pool(pool)` with
+/// schema, builds an `Eq` predicate, and forwards to `exists`.
+/// Equivalent to `qs.filter("<pk_col>", pk).exists(pool)` with
 /// the column lookup baked in.
 ///
 /// Pulled in via `use rustango::sql::ExistsPool;`.
@@ -2157,19 +2155,19 @@ pub trait ExistsPool<T: Model + Send> {
     /// filters, `Ok(false)` otherwise. #330.
     ///
     /// # Errors
-    /// As [`CounterPool::count_pool`].
-    fn exists_pool(
+    /// As [`CounterPool::count`].
+    fn exists(
         self,
         pool: &Pool,
     ) -> impl std::future::Future<Output = Result<bool, ExecError>> + Send;
 
     /// `Ok(true)` when the queryset matches zero rows, `Ok(false)`
-    /// otherwise — inverse of [`Self::exists_pool`]. Reads naturally
+    /// otherwise — inverse of [`Self::exists`]. Reads naturally
     /// in negation-flavored code (`if qs.is_empty(&pool).await? {
-    /// ... }`) where `!qs.exists_pool(...).await?` is awkward.
+    /// ... }`) where `!qs.exists(...).await?` is awkward.
     ///
     /// # Errors
-    /// As [`Self::exists_pool`].
+    /// As [`Self::exists`].
     fn is_empty(
         self,
         pool: &Pool,
@@ -2192,7 +2190,7 @@ pub trait ExistsPool<T: Model + Send> {
     /// models without an explicit `#[rustango(primary_key)]`).
     ///
     /// # Errors
-    /// As [`Self::exists_pool`], plus a model-without-PK error wrapped
+    /// As [`Self::exists`], plus a model-without-PK error wrapped
     /// in `ExecError::Query`.
     fn contains_pk(
         self,
@@ -2202,13 +2200,13 @@ pub trait ExistsPool<T: Model + Send> {
 }
 
 impl<T: Model + Send> ExistsPool<T> for QuerySet<T> {
-    async fn exists_pool(self, pool: &Pool) -> Result<bool, ExecError> {
-        let count = self.count_pool(pool).await?;
+    async fn exists(self, pool: &Pool) -> Result<bool, ExecError> {
+        let count = self.count(pool).await?;
         Ok(count > 0)
     }
 
     async fn is_empty(self, pool: &Pool) -> Result<bool, ExecError> {
-        let count = self.count_pool(pool).await?;
+        let count = self.count(pool).await?;
         Ok(count == 0)
     }
 
@@ -2228,7 +2226,7 @@ impl<T: Model + Send> ExistsPool<T> for QuerySet<T> {
             }));
         };
         self.filter_op(pk_field.column, crate::core::Op::Eq, pk_value.into())
-            .exists_pool(pool)
+            .exists(pool)
             .await
     }
 }
@@ -2488,8 +2486,8 @@ where
     /// declared any.
     ///
     /// # Errors
-    /// As [`Fetcher::fetch`].
-    fn fetch_pool(
+    /// As [`FetcherPool::fetch`].
+    fn fetch(
         self,
         pool: &Pool,
     ) -> impl std::future::Future<Output = Result<Vec<T>, ExecError>> + Send;
@@ -2507,7 +2505,7 @@ where
         + Send
         + Unpin,
 {
-    async fn fetch_pool(self, pool: &Pool) -> Result<Vec<T>, ExecError> {
+    async fn fetch(self, pool: &Pool) -> Result<Vec<T>, ExecError> {
         let select = self.compile()?;
         select_rows_pool_with_related(pool, &select).await
     }
@@ -2515,7 +2513,7 @@ where
 
 // v0.45 — single-row sugar on top of FetcherPool. Each method
 // applies the appropriate `order_by` + `limit(1)` then forwards to
-// `fetch_pool`. All four are inherent methods on `QuerySet<T>` (not
+// `fetch`. All four are inherent methods on `QuerySet<T>` (not
 // trait methods) because adding default methods to `FetcherPool`
 // would require RTN syntax against `Self::Future` and bound shuffling
 // we don't need — `QuerySet<T>` is the only Self that matters.
@@ -2540,10 +2538,10 @@ where
     /// way (it falls back to PK ordering for determinism).
     ///
     /// # Errors
-    /// As [`FetcherPool::fetch_pool`].
+    /// As [`FetcherPool::fetch`].
     pub async fn first(self, pool: &Pool) -> Result<Option<T>, ExecError> {
         let qs = ensure_pk_ordering(self, /*reverse=*/ false);
-        let rows = qs.limit(1).fetch_pool(pool).await?;
+        let rows = qs.limit(1).fetch(pool).await?;
         Ok(rows.into_iter().next())
     }
 
@@ -2555,10 +2553,10 @@ where
     /// If no `order_by` is set, sorts by PK DESC.
     ///
     /// # Errors
-    /// As [`FetcherPool::fetch_pool`].
+    /// As [`FetcherPool::fetch`].
     pub async fn last(self, pool: &Pool) -> Result<Option<T>, ExecError> {
         let qs = ensure_pk_ordering(self, /*reverse=*/ true);
-        let rows = qs.limit(1).fetch_pool(pool).await?;
+        let rows = qs.limit(1).fetch(pool).await?;
         Ok(rows.into_iter().next())
     }
 
@@ -2569,10 +2567,10 @@ where
     /// declares the sort itself.
     ///
     /// # Errors
-    /// As [`FetcherPool::fetch_pool`].
+    /// As [`FetcherPool::fetch`].
     pub async fn earliest(mut self, field: &str, pool: &Pool) -> Result<Option<T>, ExecError> {
         self = self.replace_order_by(&[(field, false)]);
-        let rows = self.limit(1).fetch_pool(pool).await?;
+        let rows = self.limit(1).fetch(pool).await?;
         Ok(rows.into_iter().next())
     }
 
@@ -2583,10 +2581,10 @@ where
     /// declares the sort itself.
     ///
     /// # Errors
-    /// As [`FetcherPool::fetch_pool`].
+    /// As [`FetcherPool::fetch`].
     pub async fn latest(mut self, field: &str, pool: &Pool) -> Result<Option<T>, ExecError> {
         self = self.replace_order_by(&[(field, true)]);
-        let rows = self.limit(1).fetch_pool(pool).await?;
+        let rows = self.limit(1).fetch(pool).await?;
         Ok(rows.into_iter().next())
     }
 
@@ -2614,7 +2612,7 @@ where
     /// via the deferred-error path.
     ///
     /// # Errors
-    /// As [`FetcherPool::fetch_pool`].
+    /// As [`FetcherPool::fetch`].
     pub async fn find(self, pk: impl Into<SqlValue>, pool: &Pool) -> Result<Option<T>, ExecError> {
         self.where_key(pk).first(pool).await
     }
@@ -2681,11 +2679,11 @@ where
     /// ```
     ///
     /// # Errors
-    /// As [`FetcherPool::fetch_pool`]; additionally
+    /// As [`FetcherPool::fetch`]; additionally
     /// [`ExecError::Driver(sqlx::Error::RowNotFound)`] on empty
     /// result, [`ExecError::MultipleRowsReturned`] on >1 matches.
     pub async fn sole(self, pool: &Pool) -> Result<T, ExecError> {
-        let mut rows = self.limit(2).fetch_pool(pool).await?;
+        let mut rows = self.limit(2).fetch(pool).await?;
         match rows.len() {
             0 => Err(ExecError::Driver(sqlx::Error::RowNotFound)),
             1 => Ok(rows.remove(0)),
@@ -2709,7 +2707,7 @@ where
     /// so a `get_latest_by = "-priority"` reverses the sort.
     ///
     /// # Errors
-    /// As [`FetcherPool::fetch_pool`]; also returns
+    /// As [`FetcherPool::fetch`]; also returns
     /// [`ExecError::Query`] when `Meta.get_latest_by` is unset.
     pub async fn latest_default(self, pool: &Pool) -> Result<Option<T>, ExecError> {
         let Some((field, attr_desc)) = T::SCHEMA.get_latest_by else {
@@ -2886,7 +2884,7 @@ where
     /// unique column to avoid surprises.
     ///
     /// # Errors
-    /// As [`FetcherPool::fetch_pool`].
+    /// As [`FetcherPool::fetch`].
     pub async fn in_bulk<C, K, I, F>(
         self,
         column: C,
@@ -2915,7 +2913,7 @@ where
                 crate::core::Op::In,
                 crate::core::SqlValue::List(id_values),
             )
-            .fetch_pool(pool)
+            .fetch(pool)
             .await?;
         let mut out = std::collections::HashMap::with_capacity(rows.len());
         for row in rows {
@@ -2980,7 +2978,7 @@ where
     /// transaction. Stitches `select_related` joins automatically.
     ///
     /// # Errors
-    /// As [`FetcherPool::fetch_pool`].
+    /// As [`FetcherPool::fetch`].
     fn fetch_tx(
         self,
         tx: &mut PoolTx<'_>,

--- a/crates/rustango/src/sql/executor/prefetch.rs
+++ b/crates/rustango/src/sql/executor/prefetch.rs
@@ -56,7 +56,7 @@ where
         + Send
         + Unpin,
 {
-    let parents: Vec<P> = parent_qs.fetch_pool(pool).await?;
+    let parents: Vec<P> = parent_qs.fetch(pool).await?;
     if parents.is_empty() {
         return Ok(Vec::new());
     }
@@ -89,7 +89,7 @@ where
             crate::core::Op::In,
             crate::core::SqlValue::List(parent_pks),
         )
-        .fetch_pool(pool)
+        .fetch(pool)
         .await?;
 
     let mut grouped: std::collections::HashMap<String, Vec<C>> = std::collections::HashMap::new();
@@ -175,7 +175,7 @@ where
         + Send
         + Unpin,
 {
-    let parents: Vec<P> = parent_qs.fetch_pool(pool).await?;
+    let parents: Vec<P> = parent_qs.fetch(pool).await?;
     if parents.is_empty() {
         return Ok(Vec::new());
     }
@@ -210,7 +210,7 @@ where
             crate::core::Op::In,
             crate::core::SqlValue::List(parent_pks),
         )
-        .fetch_pool(pool)
+        .fetch(pool)
         .await?;
 
     let mut grouped: std::collections::HashMap<String, Vec<C>> = std::collections::HashMap::new();

--- a/crates/rustango/src/sql/executor/traits.rs
+++ b/crates/rustango/src/sql/executor/traits.rs
@@ -18,7 +18,7 @@
 // `&Pool` FromRow dispatch — Phase B (v0.23.0-batch6)
 // ====================================================================
 //
-// `select_rows_pool` / `Fetcher::fetch` for `&Pool`. The trait bound on
+// `select_rows_pool` / `FetcherPool::fetch` for `&Pool`. The trait bound on
 // `T` needs to flex: when rustango is built with the `mysql` feature,
 // it must also include `FromRow<MySqlRow>`; without it, the MySql
 // variant doesn't exist and the bound shouldn't either. The

--- a/crates/rustango/src/sql/executor/values.rs
+++ b/crates/rustango/src/sql/executor/values.rs
@@ -702,7 +702,7 @@ impl<T: crate::core::Model> crate::query::QuerySet<T> {
     /// readable left-to-right.
     ///
     /// # Errors
-    /// As [`crate::sql::FetcherPool::fetch_pool`], plus per-cell
+    /// As [`crate::sql::FetcherPool::fetch`], plus per-cell
     /// type-mismatch errors when `K` / `V` don't match the columns'
     /// SQL types.
     pub async fn pluck_pairs<K, V>(
@@ -823,8 +823,8 @@ impl<T: crate::core::Model> crate::query::QuerySet<T> {
     /// Eloquent and `Model::for_page`.
     ///
     /// # Errors
-    /// As [`crate::sql::CounterPool::count_pool`] and
-    /// [`crate::sql::FetcherPool::fetch_pool`].
+    /// As [`crate::sql::CounterPool::count`] and
+    /// [`crate::sql::FetcherPool::fetch`].
     pub async fn paginate(
         self,
         page: i64,
@@ -844,10 +844,10 @@ impl<T: crate::core::Model> crate::query::QuerySet<T> {
     {
         use crate::sql::{CounterPool as _, FetcherPool as _};
         let total = <crate::query::QuerySet<T> as ::core::clone::Clone>::clone(&self)
-            .count_pool(pool)
+            .count(pool)
             .await?;
         let offset = if page > 1 { (page - 1) * per_page } else { 0 };
-        let rows = self.limit(per_page).offset(offset).fetch_pool(pool).await?;
+        let rows = self.limit(per_page).offset(offset).fetch(pool).await?;
         Ok((rows, total))
     }
 

--- a/crates/rustango/src/sql/foreign_key.rs
+++ b/crates/rustango/src/sql/foreign_key.rs
@@ -354,7 +354,7 @@ where
 {
     /// Resolve the parent row and cache it on the field. Backend-
     /// agnostic counterpart of [`Self::get`] — routes through
-    /// [`crate::sql::FetcherPool::fetch_pool`].
+    /// [`crate::sql::FetcherPool::fetch`].
     ///
     /// # Errors
     /// As [`Self::get`].
@@ -369,7 +369,7 @@ where
                 })?;
             let mut rows: Vec<T> = QuerySet::<T>::new()
                 .filter_op(pk_field.column, Op::Eq, pk.clone())
-                .fetch_pool(pool)
+                .fetch(pool)
                 .await?;
             let value = rows.pop().ok_or_else(|| {
                 let sv: SqlValue = pk.clone().into();

--- a/crates/rustango/src/sql/model_shortcuts.rs
+++ b/crates/rustango/src/sql/model_shortcuts.rs
@@ -172,7 +172,7 @@ where
 /// - `all = true`  → returns every row (vacuous AND is TRUE).
 ///
 /// # Errors
-/// As [`FetcherPool::fetch_pool`]; or
+/// As [`FetcherPool::fetch`]; or
 /// [`ExecError::Query(QueryError::UnknownField)`] when any
 /// column is not declared on the model.
 pub async fn where_multi_pool<T>(
@@ -194,7 +194,7 @@ where
 {
     if cols.is_empty() {
         return if all {
-            QuerySet::<T>::default().fetch_pool(pool).await
+            QuerySet::<T>::default().fetch(pool).await
         } else {
             Ok(Vec::new())
         };
@@ -217,6 +217,6 @@ where
     }
     QuerySet::<T>::default()
         .where_(q.expect("non-empty cols"))
-        .fetch_pool(pool)
+        .fetch(pool)
         .await
 }

--- a/crates/rustango/src/tenancy/admin.rs
+++ b/crates/rustango/src/tenancy/admin.rs
@@ -685,7 +685,7 @@ async fn validate_session(
     if let Some(operator_id) = payload.imp {
         let ops: Vec<super::auth::Operator> = match super::auth::Operator::objects()
             .where_(super::auth::Operator::id.eq(operator_id))
-            .fetch_pool(registry_pool)
+            .fetch(registry_pool)
             .await
         {
             Ok(v) => v,
@@ -709,12 +709,12 @@ async fn validate_session(
             _ => SessionCheck::Anonymous,
         };
     }
-    // v0.38 — route through ORM `User::objects().fetch_pool` so the
+    // v0.38 — route through ORM `User::objects().fetch` so the
     // same body runs on PG / MySQL / SQLite. Identifier quoting +
     // placeholders are handled by the dialect emitter.
     let users: Vec<super::auth::User> = match super::auth::User::objects()
         .where_(super::auth::User::id.eq(payload.uid))
-        .fetch_pool(tenant_pool)
+        .fetch(tenant_pool)
         .await
     {
         Ok(v) => v,
@@ -878,7 +878,7 @@ async fn login_submit(
     // is built with search_path baked in).
     let users: Vec<super::auth::User> = match super::auth::User::objects()
         .where_(super::auth::User::username.eq(form.username.clone()))
-        .fetch_pool(tenant_pool)
+        .fetch(tenant_pool)
         .await
     {
         Ok(v) => v,
@@ -1262,7 +1262,7 @@ async fn change_password_submit(
     // identifier quoting differences.
     let users: Vec<super::auth::User> = match super::auth::User::objects()
         .where_(super::auth::User::id.eq(user_id))
-        .fetch_pool(tenant_pool)
+        .fetch(tenant_pool)
         .await
     {
         Ok(v) => v,

--- a/crates/rustango/src/tenancy/auth.rs
+++ b/crates/rustango/src/tenancy/auth.rs
@@ -163,7 +163,7 @@ pub async fn authenticate_operator_pool(
     use crate::sql::FetcherPool as _;
     let rows: Vec<Operator> = Operator::objects()
         .where_(Operator::username.eq(username.to_owned()))
-        .fetch_pool(registry)
+        .fetch(registry)
         .await?;
     let Some(op) = rows.into_iter().next() else {
         // H1: spend a verify's worth of work on the unknown-user path
@@ -271,7 +271,7 @@ pub async fn authenticate_user_pool(
     use crate::sql::FetcherPool as _;
     let rows: Vec<User> = User::objects()
         .where_(User::username.eq(username.to_owned()))
-        .fetch_pool(pool)
+        .fetch(pool)
         .await?;
     let Some(user) = rows.into_iter().next() else {
         // H1: equalize timing for the unknown-user path.

--- a/crates/rustango/src/tenancy/auth_backends.rs
+++ b/crates/rustango/src/tenancy/auth_backends.rs
@@ -120,7 +120,7 @@ impl AuthBackend for ModelBackend {
 
         let users = super::auth::User::objects()
             .where_(super::auth::User::username.eq(username.clone()))
-            .fetch_pool(pool)
+            .fetch(pool)
             .await?;
 
         let Some(user) = users.into_iter().next() else {
@@ -329,7 +329,7 @@ impl AuthBackend for ApiKeyBackend {
         // total latency on the hot path is two index seeks.
         let keys = ApiKey::objects()
             .where_(ApiKey::key_prefix.eq(prefix.to_owned()))
-            .fetch_pool(pool)
+            .fetch(pool)
             .await?;
         let Some(key) = keys.into_iter().next() else {
             // Audit N4 — equalize timing on the unknown-prefix path so it
@@ -351,7 +351,7 @@ impl AuthBackend for ApiKeyBackend {
 
         let users = super::auth::User::objects()
             .where_(super::auth::User::id.eq(key.user_id))
-            .fetch_pool(pool)
+            .fetch(pool)
             .await?;
         let Some(user) = users.into_iter().next() else {
             return Ok(None);
@@ -542,7 +542,7 @@ impl AuthBackend for JwtBackend {
 
         let users = super::auth::User::objects()
             .where_(super::auth::User::id.eq(user_id))
-            .fetch_pool(pool)
+            .fetch(pool)
             .await?;
 
         let Some(user) = users.into_iter().next() else {

--- a/crates/rustango/src/tenancy/auth_routes.rs
+++ b/crates/rustango/src/tenancy/auth_routes.rs
@@ -230,7 +230,7 @@ async fn login(
 
     let users = User::objects()
         .where_(User::username.eq(body.username.clone()))
-        .fetch_pool(t.pool())
+        .fetch(t.pool())
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response())?;
 
@@ -367,7 +367,7 @@ async fn refresh(
         use crate::tenancy::auth::User;
         let users: Vec<User> = User::objects()
             .where_(User::id.eq(claims.sub))
-            .fetch_pool(t.pool())
+            .fetch(t.pool())
             .await
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response())?;
         let still_active = users.into_iter().next().is_some_and(|u| u.active);
@@ -468,7 +468,7 @@ async fn me(t: Tenant, bearer: Bearer) -> Result<Json<UserBrief>, Response> {
 
     let users = User::objects()
         .where_(User::id.eq(user_id))
-        .fetch_pool(t.pool())
+        .fetch(t.pool())
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response())?;
 

--- a/crates/rustango/src/tenancy/manage/api.rs
+++ b/crates/rustango/src/tenancy/manage/api.rs
@@ -75,7 +75,7 @@ where
 {
     let mut rows: Vec<Org> = Org::objects()
         .where_(Org::slug.eq(slug.to_owned()))
-        .fetch_pool(&pools.registry_pool())
+        .fetch(&pools.registry_pool())
         .await?;
     Ok(rows.pop())
 }
@@ -245,7 +245,7 @@ where
     let registry = pools.registry_pool();
     let mut existing: Vec<Operator> = Operator::objects()
         .where_(Operator::username.eq(username.to_owned()))
-        .fetch_pool(&registry)
+        .fetch(&registry)
         .await?;
     if let Some(op) = existing.pop() {
         return Ok(op);
@@ -291,7 +291,7 @@ where
 
     let mut existing: Vec<User> = User::objects()
         .where_(User::username.eq(username.to_owned()))
-        .fetch_pool(&scoped)
+        .fetch(&scoped)
         .await?;
     if let Some(u) = existing.pop() {
         return Ok(u);

--- a/crates/rustango/src/tenancy/manage/audit.rs
+++ b/crates/rustango/src/tenancy/manage/audit.rs
@@ -85,7 +85,7 @@ where
     let orgs: Vec<Org> = if let Some(ref slug) = tenant_slug {
         let found: Vec<Org> = Org::objects()
             .where_(Org::slug.eq(slug.as_str()))
-            .fetch_pool(&registry)
+            .fetch(&registry)
             .await?;
         if found.is_empty() {
             return Err(TenancyError::Validation(format!(
@@ -96,7 +96,7 @@ where
     } else {
         Org::objects()
             .where_(Org::active.eq(true))
-            .fetch_pool(&registry)
+            .fetch(&registry)
             .await?
     };
 

--- a/crates/rustango/src/tenancy/manage/roles.rs
+++ b/crates/rustango/src/tenancy/manage/roles.rs
@@ -73,7 +73,7 @@ where
     // unnoticeable, and the code stays tri-dialect without per-
     // dialect SQL.
     use crate::tenancy::permissions::{Role, RolePermission};
-    let roles: Vec<Role> = Role::objects().fetch_pool(&pool).await?;
+    let roles: Vec<Role> = Role::objects().fetch(&pool).await?;
     if roles.is_empty() {
         writeln!(w, "(no roles on tenant `{slug}`)")?;
         return Ok(());
@@ -84,7 +84,7 @@ where
         let id = role.id.get().copied().unwrap_or(0);
         let perms: Vec<RolePermission> = RolePermission::objects()
             .where_(RolePermission::role_id.eq(id))
-            .fetch_pool(&pool)
+            .fetch(&pool)
             .await?;
         writeln!(
             w,
@@ -346,7 +346,7 @@ where
     let targets: Vec<Org> = if let Some(s) = slug.as_deref() {
         let orgs: Vec<Org> = Org::objects()
             .where_(Org::slug.eq(s.to_owned()))
-            .fetch_pool(&registry)
+            .fetch(&registry)
             .await?;
         if orgs.is_empty() {
             return Err(TenancyError::Validation(format!("tenant `{s}` not found")));
@@ -355,7 +355,7 @@ where
     } else {
         Org::objects()
             .where_(Org::active.eq(true))
-            .fetch_pool(&registry)
+            .fetch(&registry)
             .await?
     };
 
@@ -387,7 +387,7 @@ where
 {
     let orgs: Vec<Org> = Org::objects()
         .where_(Org::slug.eq(slug.to_owned()))
-        .fetch_pool(&pools.registry_pool())
+        .fetch(&pools.registry_pool())
         .await?;
     let org = orgs
         .into_iter()
@@ -399,7 +399,7 @@ where
 async fn user_id_by_username(username: &str, pool: &crate::sql::Pool) -> Result<i64, TenancyError> {
     let rows = User::objects()
         .where_(User::username.eq(username.to_owned()))
-        .fetch_pool(pool)
+        .fetch(pool)
         .await?;
     rows.into_iter()
         .next()
@@ -411,7 +411,7 @@ async fn role_id_by_name(name: &str, pool: &crate::sql::Pool) -> Result<i64, Ten
     use crate::tenancy::permissions::Role;
     let rows = Role::objects()
         .where_(Role::name.eq(name.to_owned()))
-        .fetch_pool(pool)
+        .fetch(pool)
         .await?;
     rows.into_iter()
         .next()

--- a/crates/rustango/src/tenancy/manage/tenants.rs
+++ b/crates/rustango/src/tenancy/manage/tenants.rs
@@ -51,7 +51,7 @@ where
     let registry = pools.registry_pool();
     let existing: Vec<Org> = Org::objects()
         .where_(Org::slug.eq(parsed.slug.clone()))
-        .fetch_pool(&registry)
+        .fetch(&registry)
         .await?;
     if !existing.is_empty() {
         return Err(TenancyError::Validation(format!(
@@ -336,7 +336,7 @@ where
     let registry = pools.registry_pool();
     let existing: Vec<Org> = Org::objects()
         .where_(Org::slug.eq(slug.clone()))
-        .fetch_pool(&registry)
+        .fetch(&registry)
         .await?;
     let Some(org) = existing.into_iter().next() else {
         return Err(TenancyError::Validation(format!(
@@ -462,7 +462,7 @@ where
     let registry = pools.registry_pool();
     let existing: Vec<Org> = Org::objects()
         .where_(Org::slug.eq(slug.clone()))
-        .fetch_pool(&registry)
+        .fetch(&registry)
         .await?;
     let Some(org) = existing.into_iter().next() else {
         return Err(TenancyError::Validation(format!(
@@ -625,7 +625,7 @@ pub(super) async fn list_tenants<W: Write + Send, DB: Database>(
 where
     crate::sql::Pool: From<sqlx::Pool<DB>>,
 {
-    let orgs: Vec<Org> = Org::objects().fetch_pool(&pools.registry_pool()).await?;
+    let orgs: Vec<Org> = Org::objects().fetch(&pools.registry_pool()).await?;
     if orgs.is_empty() {
         writeln!(w, "(no tenants)")?;
         return Ok(());

--- a/crates/rustango/src/tenancy/manage/users.rs
+++ b/crates/rustango/src/tenancy/manage/users.rs
@@ -5,7 +5,7 @@
 //! The per-tenant verbs (create-user / set-superuser / reset-password)
 //! rely on `scoped_tenant_pool` which on PG dispatches through schema-
 //! mode + database-mode, and on sqlite/mysql resolves to database-mode
-//! only. The `_pool` ORM family (`fetch_pool`, `save_pool`,
+//! only. The `_pool` ORM family (`fetch`, `save_pool`,
 //! `update_pool`) drives every backend-uniform query path so the same
 //! verb body runs on PG / MySQL / SQLite.
 
@@ -96,7 +96,7 @@ where
     let registry = pools.registry_pool();
     let existing: Vec<crate::tenancy::Operator> = crate::tenancy::Operator::objects()
         .where_(crate::tenancy::Operator::username.eq(username.clone()))
-        .fetch_pool(&registry)
+        .fetch(&registry)
         .await?;
     if !existing.is_empty() {
         return Err(TenancyError::Validation(format!(
@@ -208,7 +208,7 @@ where
     let registry = pools.registry_pool();
     let orgs: Vec<crate::tenancy::Org> = crate::tenancy::Org::objects()
         .where_(crate::tenancy::Org::slug.eq(slug.clone()))
-        .fetch_pool(&registry)
+        .fetch(&registry)
         .await?;
     orgs.into_iter().next().ok_or_else(|| {
         TenancyError::Validation(format!("create-user: no tenant with slug `{slug}`"))
@@ -218,7 +218,7 @@ where
 
     // v0.38 — open a tenant-scoped Pool enum (handles schema-mode on
     // PG, database-mode on any backend). Then drive the read/write
-    // through the tri-dialect ORM (FetcherPool::fetch_pool +
+    // through the tri-dialect ORM (FetcherPool::fetch +
     // Model::save_pool) so the same code runs on PG / MySQL / SQLite.
     use crate::sql::FetcherPool as _;
     let scoped = scoped_tenant_pool(pools, registry_url, &slug).await?;
@@ -229,7 +229,7 @@ where
     let mut auto_promoted = false;
     if !is_superuser {
         let existing: Vec<crate::tenancy::User> = crate::tenancy::User::objects()
-            .fetch_pool(&scoped)
+            .fetch(&scoped)
             .await
             .unwrap_or_default();
         if existing.is_empty() {
@@ -553,7 +553,7 @@ where
     let registry = pools.registry_pool();
     let existing: Vec<crate::tenancy::Operator> = crate::tenancy::Operator::objects()
         .where_(crate::tenancy::Operator::username.eq(username.clone()))
-        .fetch_pool(&registry)
+        .fetch(&registry)
         .await?;
     let mut op = existing.into_iter().next().ok_or_else(|| {
         TenancyError::Validation(format!(
@@ -655,7 +655,7 @@ where
     use crate::sql::FetcherPool as _;
     let users: Vec<crate::tenancy::User> = crate::tenancy::User::objects()
         .where_(crate::tenancy::User::username.eq(username.clone()))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await?;
     let Some(mut user) = users.into_iter().next() else {
         return Err(TenancyError::Validation(format!(
@@ -758,7 +758,7 @@ where
     let registry = pools.registry_pool();
     let existing: Vec<crate::tenancy::Operator> = crate::tenancy::Operator::objects()
         .where_(crate::tenancy::Operator::username.eq(username.clone()))
-        .fetch_pool(&registry)
+        .fetch(&registry)
         .await?;
     let mut op = existing.into_iter().next().ok_or_else(|| {
         TenancyError::Validation(format!(
@@ -794,7 +794,7 @@ where
 {
     let orgs: Vec<crate::tenancy::Org> = crate::tenancy::Org::objects()
         .where_(crate::tenancy::Org::slug.eq(slug.to_owned()))
-        .fetch_pool(&pools.registry_pool())
+        .fetch(&pools.registry_pool())
         .await?;
     let org = orgs
         .into_iter()

--- a/crates/rustango/src/tenancy/migrate.rs
+++ b/crates/rustango/src/tenancy/migrate.rs
@@ -423,7 +423,7 @@ where
     let registry_pool = pools.registry_pool();
     let orgs: Vec<Org> = Org::objects()
         .where_(Org::active.eq(true))
-        .fetch_pool(&registry_pool)
+        .fetch(&registry_pool)
         .await?;
 
     info!(

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -41,7 +41,7 @@
 use crate::core::Column as _;
 // v0.34 — operator console no longer imports `PgPool` directly.
 // ConsoleState.registry is `crate::sql::Pool` (the backend-erasing
-// enum); all internal queries route through `fetch_pool` /
+// enum); all internal queries route through `fetch` /
 // `insert_pool` / `save_pool` / `update_pool`.
 use crate::sql::FetcherPool;
 use crate::storage::BoxedStorage;
@@ -75,7 +75,7 @@ const RUSTANGO_PNG: &[u8] = include_bytes!("../static/rustango.png");
 struct ConsoleState {
     /// Backend-erasing registry pool. PG / MySQL / SQLite all share
     /// one operator-console code path — every query inside the
-    /// console routes through `_pool` ORM helpers (`fetch_pool` /
+    /// console routes through `_pool` ORM helpers (`fetch` /
     /// `insert_pool` / `save_pool`) which dispatch per-backend.
     registry: crate::sql::Pool,
     /// Optional pool cache. When `Some`, the operator console exposes
@@ -500,7 +500,7 @@ async fn require_session(
     };
     match auth::Operator::objects()
         .where_(auth::Operator::id.eq(payload.oid))
-        .fetch_pool(&state.registry)
+        .fetch(&state.registry)
         .await
     {
         Ok(rows) => {
@@ -633,7 +633,7 @@ async fn login_submit(
         use crate::sql::FetcherPool as _;
         auth::Operator::objects()
             .where_(auth::Operator::username.eq(form.username.clone()))
-            .fetch_pool(&state.registry)
+            .fetch(&state.registry)
             .await
             .ok()
             .and_then(|rows: Vec<auth::Operator>| rows.into_iter().next())
@@ -854,7 +854,7 @@ async fn change_password_submit(
     // account.
     let mut op_row: auth::Operator = match auth::Operator::objects()
         .where_(auth::Operator::id.eq(op_id))
-        .fetch_pool(&state.registry)
+        .fetch(&state.registry)
         .await
     {
         Ok(rows) => match rows.into_iter().next() {
@@ -906,11 +906,10 @@ async fn operators_list(
     State(state): State<ConsoleState>,
     Extension(op): Extension<auth::Operator>,
 ) -> Response<Body> {
-    let rows: Vec<auth::Operator> =
-        match auth::Operator::objects().fetch_pool(&state.registry).await {
-            Ok(r) => r,
-            Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")).into_response(),
-        };
+    let rows: Vec<auth::Operator> = match auth::Operator::objects().fetch(&state.registry).await {
+        Ok(r) => r,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")).into_response(),
+    };
     let view: Vec<_> = rows
         .into_iter()
         .map(|o| {
@@ -940,7 +939,7 @@ async fn orgs_list(
     State(state): State<ConsoleState>,
     Extension(op): Extension<auth::Operator>,
 ) -> Response<Body> {
-    let rows: Vec<super::Org> = match super::Org::objects().fetch_pool(&state.registry).await {
+    let rows: Vec<super::Org> = match super::Org::objects().fetch(&state.registry).await {
         Ok(r) => r,
         Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")).into_response(),
     };
@@ -1034,7 +1033,7 @@ async fn org_edit_form(
     // Fetch via the ORM (bi-dialect) instead of `SELECT *` + PgRow.
     let rows: Vec<super::Org> = match super::Org::objects()
         .where_(super::Org::slug.eq(slug.clone()))
-        .fetch_pool(&state.registry)
+        .fetch(&state.registry)
         .await
     {
         Ok(r) => r,
@@ -1179,7 +1178,7 @@ async fn org_edit_submit(
     // ORM path so registry-backend stays plug-and-play.
     let existing_orgs: Vec<super::Org> = match super::Org::objects()
         .where_(super::Org::slug.eq(slug.clone()))
-        .fetch_pool(&state.registry)
+        .fetch(&state.registry)
         .await
     {
         Ok(rows) => rows,
@@ -1563,7 +1562,7 @@ async fn org_impersonate(
     // correct context.
     let orgs: Vec<super::Org> = match super::Org::objects()
         .where_(super::Org::slug.eq(slug.clone()))
-        .fetch_pool(&state.registry)
+        .fetch(&state.registry)
         .await
     {
         Ok(rows) => rows,

--- a/crates/rustango/src/tenancy/permissions.rs
+++ b/crates/rustango/src/tenancy/permissions.rs
@@ -751,7 +751,7 @@ pub async fn get_or_create_role_pool(
     let existing: Vec<Role> = Role::objects()
         .where_(Role::name.eq(name.to_owned()))
         .limit(1)
-        .fetch_pool(pool)
+        .fetch(pool)
         .await?;
     if let Some(r) = existing.into_iter().next() {
         return Ok(r.id.get().copied().unwrap_or(0));

--- a/crates/rustango/src/tenancy/pools.rs
+++ b/crates/rustango/src/tenancy/pools.rs
@@ -317,7 +317,7 @@ impl TenantPools<sqlx::Postgres> {
     /// Available only when the registry IS Postgres. For
     /// backend-agnostic access use [`Self::registry_pool`] (returns
     /// `&crate::sql::Pool` which dispatches per-backend through
-    /// `fetch_pool` / `insert_pool` / `save_pool`).
+    /// `fetch` / `insert_pool` / `save_pool`).
     #[must_use]
     pub fn registry(&self) -> &PgPool {
         &self.registry
@@ -332,7 +332,7 @@ where
     /// [`rustango::sql::Pool`] enum. Used by the v0.34 resolver
     /// chain which is generic across backends — keeps a single
     /// `TenantPools` API while letting the resolver implementations
-    /// route through `fetch_pool` / `insert_pool`.
+    /// route through `fetch` / `insert_pool`.
     ///
     /// Cheap: `Pool` is `Arc`-shaped under sqlx, so the clone is a
     /// reference bump.
@@ -608,7 +608,7 @@ where
         let orgs: Vec<Org> = Org::objects()
             .where_(Org::storage_mode.eq("database".to_owned()))
             .where_(Org::active.eq(true))
-            .fetch_pool(&registry_pool)
+            .fetch(&registry_pool)
             .await?;
         let total = orgs.len();
         let mut report = PrewarmReport {

--- a/crates/rustango/src/tenancy/resolver.rs
+++ b/crates/rustango/src/tenancy/resolver.rs
@@ -324,7 +324,7 @@ where
     let rows: Vec<Org> = Org::objects()
         .where_(typed)
         .where_(Org::active.eq(true))
-        .fetch_pool(registry)
+        .fetch(registry)
         .await
         .map_err(|e| TenancyError::Driver(driver_from_exec(e)))?;
     Ok(rows.into_iter().next())

--- a/crates/rustango/src/tenancy/server.rs
+++ b/crates/rustango/src/tenancy/server.rs
@@ -217,7 +217,7 @@ async fn no_operators_warn<W: Write + Send>(
     use crate::sql::FetcherPool;
     let active: Vec<super::auth::Operator> = super::auth::Operator::objects()
         .where_(super::auth::Operator::active.eq(true))
-        .fetch_pool(registry)
+        .fetch(registry)
         .await?;
     if active.is_empty() {
         writeln!(w, "WARNING: no active operators in `rustango_operators` —")?;

--- a/crates/rustango/tests/admin_totp_2fa_e2e.rs
+++ b/crates/rustango/tests/admin_totp_2fa_e2e.rs
@@ -58,7 +58,7 @@ async fn seed() -> (Pool, TotpSecret) {
     }
     let alice_id = AdminUser::objects()
         .filter("username", "alice")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .into_iter()

--- a/crates/rustango/tests/array_field_pg_live.rs
+++ b/crates/rustango/tests/array_field_pg_live.rs
@@ -122,7 +122,7 @@ async fn array_contains_operator_filters() {
     // `tags @> ARRAY['rust']` — only the first post.
     let mut titles: Vec<String> = Post::objects()
         .where_(Post::tags.array_contains(["rust".to_owned()]))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .into_iter()
@@ -134,7 +134,7 @@ async fn array_contains_operator_filters() {
     // `tags @> ARRAY['orm']` — both posts.
     let n = Post::objects()
         .where_(Post::tags.array_contains(["orm".to_owned()]))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .len();

--- a/crates/rustango/tests/assert_num_queries_sqlite_live.rs
+++ b/crates/rustango/tests/assert_num_queries_sqlite_live.rs
@@ -53,7 +53,7 @@ async fn assert_num_queries_counts_single_select() {
     }
 
     assert_num_queries(1, async {
-        let rows: Vec<Post> = Post::objects().fetch_pool(&pool).await.unwrap();
+        let rows: Vec<Post> = Post::objects().fetch(&pool).await.unwrap();
         assert_eq!(rows.len(), 3);
     })
     .await;
@@ -70,7 +70,7 @@ async fn assert_num_queries_counts_insert_then_select() {
         };
         p.insert_pool(&pool).await.unwrap();
 
-        let rows: Vec<Post> = Post::objects().fetch_pool(&pool).await.unwrap();
+        let rows: Vec<Post> = Post::objects().fetch(&pool).await.unwrap();
         assert_eq!(rows.len(), 1);
     })
     .await;
@@ -124,7 +124,7 @@ async fn outside_scope_bumps_are_silently_dropped() {
 
     // Now open a scope and run exactly 1 query — count must be 1, not 6.
     assert_num_queries(1, async {
-        let rows: Vec<Post> = Post::objects().fetch_pool(&pool).await.unwrap();
+        let rows: Vec<Post> = Post::objects().fetch(&pool).await.unwrap();
         assert_eq!(rows.len(), 5);
     })
     .await;
@@ -146,7 +146,7 @@ async fn scope_take_resets_mid_block() {
         assert_eq!(QueryCounter::take(), 2);
 
         // Second segment: 1 select
-        let rows: Vec<Post> = Post::objects().fetch_pool(&pool).await.unwrap();
+        let rows: Vec<Post> = Post::objects().fetch(&pool).await.unwrap();
         assert_eq!(rows.len(), 2);
         assert_eq!(QueryCounter::take(), 1);
     })
@@ -165,7 +165,7 @@ async fn fails_loudly_when_count_diverges() {
             title: "x".into(),
         };
         p.insert_pool(&pool).await.unwrap();
-        let _rows: Vec<Post> = Post::objects().fetch_pool(&pool).await.unwrap();
+        let _rows: Vec<Post> = Post::objects().fetch(&pool).await.unwrap();
     })
     .await;
 }

--- a/crates/rustango/tests/database_routers_sqlite_live.rs
+++ b/crates/rustango/tests/database_routers_sqlite_live.rs
@@ -86,7 +86,7 @@ async fn routed_reads_hit_the_replica_writes_hit_the_primary() {
 
     // `write_pool_for` resolves the primary — confirm by reading it back.
     let on_primary: Vec<String> = Widget::objects()
-        .fetch_pool(&databases::write_pool_for(Widget::SCHEMA))
+        .fetch(&databases::write_pool_for(Widget::SCHEMA))
         .await
         .unwrap()
         .into_iter()

--- a/crates/rustango/tests/default_uuid_v7_sqlite_live.rs
+++ b/crates/rustango/tests/default_uuid_v7_sqlite_live.rs
@@ -54,7 +54,7 @@ async fn insert_with_unset_pk_generates_uuid_v7() {
 
     // Read it back — it lives in the row.
     let rows: Vec<Post> = rustango::query::QuerySet::<Post>::default()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -118,7 +118,7 @@ async fn save_pool_after_insert_does_an_update() {
     post.save_pool(&pool).await.unwrap();
 
     let rows: Vec<Post> = rustango::query::QuerySet::<Post>::default()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1, "save_pool should UPDATE not re-INSERT");

--- a/crates/rustango/tests/django6_delta.rs
+++ b/crates/rustango/tests/django6_delta.rs
@@ -200,7 +200,7 @@ mod scenarios {
              refreshes GeneratedFields via RETURNING; if this is now 12, update \
              the audit + issue"
         );
-        let fetched: Vec<Invoice> = Invoice::objects().fetch_pool(pool).await.expect("re-fetch");
+        let fetched: Vec<Invoice> = Invoice::objects().fetch(pool).await.expect("re-fetch");
         assert_eq!(fetched.len(), 1);
         assert_eq!(fetched[0].total, 12, "the DB-side value IS computed");
     }

--- a/crates/rustango/tests/django6_joins.rs
+++ b/crates/rustango/tests/django6_joins.rs
@@ -131,7 +131,7 @@ mod scenarios {
         let posts: Vec<Post> = Post::objects()
             .select_related("author__profile__country")
             .order_by(&[("id", false)])
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("3-hop fetch");
         assert_eq!(posts.len(), 2);
@@ -152,7 +152,7 @@ mod scenarios {
         // Single hop: `author__name = "Ada"` → post 1 only.
         let rows: Vec<Post> = Post::objects()
             .filter("author__name", "Ada")
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("single-hop relation-spanning filter");
         assert_eq!(rows.len(), 1);
@@ -162,7 +162,7 @@ mod scenarios {
         // Ada's profile bio is "ada bio"; Bob's is "bob bio".
         let rows: Vec<Post> = Post::objects()
             .filter("author__profile__bio__icontains", "ADA")
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("two-hop relation-spanning filter with suffix");
         assert_eq!(rows.len(), 1);
@@ -174,7 +174,7 @@ mod scenarios {
         let rows: Vec<Post> = Post::objects()
             .select_related("author")
             .filter("author__name", "Bob")
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("span + select_related dedupe");
         assert_eq!(rows.len(), 1);
@@ -187,7 +187,7 @@ mod scenarios {
     pub async fn check_relation_spanning_order_by_is_rejected(pool: &Pool) {
         let err = Post::objects()
             .order_by(&[("author__name", false)])
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .map(|rows: Vec<Post>| rows.len())
             .expect_err("relation-spanning order_by must be rejected");
@@ -213,7 +213,7 @@ mod scenarios {
                 project: vec![],
             })
             .where_raw(col_filter("a", "name", Op::Eq, "Ada"))
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("cross-table filter via join");
         assert_eq!(posts.len(), 1);
@@ -242,7 +242,7 @@ mod scenarios {
                 rhs: aliased("p", "views"),
             })
             .order_by(&[("score", false)])
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("F across join");
         let scores: Vec<i64> = comments.into_iter().map(|c| c.score).collect();

--- a/crates/rustango/tests/django6_json_dates.rs
+++ b/crates/rustango/tests/django6_json_dates.rs
@@ -61,7 +61,7 @@ mod scenarios {
                 op: Op::Eq,
                 rhs: Expr::Literal(SqlValue::String("post".into())),
             })
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("nested key traversal");
         assert_eq!(ids(rows), vec![1, 3]);
@@ -83,7 +83,7 @@ mod scenarios {
                 op: Op::Eq,
                 rhs: Expr::Literal(SqlValue::String("x".into())),
             })
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("key+index traversal");
         assert_eq!(ids(rows), vec![1]);
@@ -97,7 +97,7 @@ mod scenarios {
                 op: Op::Gte,
                 rhs: Expr::Literal(SqlValue::I64(2)),
             })
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("json_array_length");
         assert_eq!(ids(rows), vec![1, 3]);
@@ -122,14 +122,14 @@ mod scenarios {
         let name = pool.dialect().name();
         if name == "postgres" || name == "sqlite" {
             let rows: Vec<Doc> = qs()
-                .fetch_pool(pool)
+                .fetch(pool)
                 .await
                 .expect("negative index (PG / SQLite)");
             assert_eq!(ids(rows), vec![1], "row 1's last tag is \"c\"");
         } else {
             // MySQL only — `$[N]` has no negative form upstream.
             let err = qs()
-                .fetch_pool(pool)
+                .fetch(pool)
                 .await
                 .map(|rows: Vec<Doc>| rows.len())
                 .expect_err("negative index must be rejected on MySQL");
@@ -152,14 +152,14 @@ mod scenarios {
     pub async fn check_date_transform_chains(pool: &Pool) {
         let rows: Vec<Doc> = Doc::objects()
             .filter("created__year__gte", 2025_i64)
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("__year__gte");
         assert_eq!(ids(rows), vec![3]);
 
         let rows: Vec<Doc> = Doc::objects()
             .filter("created__month", 3_i64)
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("__month");
         assert_eq!(ids(rows), vec![1, 2]);
@@ -173,7 +173,7 @@ mod scenarios {
         // March (rows 1+2) is Q1 on every backend.
         let q1 = Doc::objects()
             .filter("created__quarter", 1_i64)
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("__quarter Q1");
         assert_eq!(ids(q1), vec![1, 2], "March is Q1");
@@ -182,7 +182,7 @@ mod scenarios {
         // off-by-one in the SQLite synthesis.
         let q3 = Doc::objects()
             .filter("created__quarter", 3_i64)
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("__quarter Q3");
         assert_eq!(ids(q3), vec![3], "July is Q3");

--- a/crates/rustango/tests/django6_setops.rs
+++ b/crates/rustango/tests/django6_setops.rs
@@ -58,7 +58,7 @@ mod scenarios {
         let union: Vec<Item> = Item::objects()
             .filter("grp", "a")
             .union(Item::objects().filter("rnk__lte", 4_i64))
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("UNION fetch");
         assert_eq!(sorted_names(union), vec!["a1", "a2", "a3", "b1"]);
@@ -66,7 +66,7 @@ mod scenarios {
         let union_all: Vec<Item> = Item::objects()
             .filter("grp", "a")
             .union_all(Item::objects().filter("rnk__lte", 4_i64))
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("UNION ALL fetch");
         assert_eq!(union_all.len(), 7, "3 + 4 with duplicates kept");
@@ -93,7 +93,7 @@ mod scenarios {
                     .order_by(&[("rnk", true)])
                     .limit(1),
             )
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("other-branch order/limit fetch");
         assert_eq!(sorted_names(rows), vec!["a1", "a2", "a3", "b2"]);
@@ -106,7 +106,7 @@ mod scenarios {
             .order_by(&[("rnk", false)])
             .limit(2)
             .union_all(Item::objects().filter("grp", "b"))
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("first-queryset order/limit fetch");
         assert_eq!(
@@ -124,7 +124,7 @@ mod scenarios {
             .union(Item::objects().filter("grp", "b"))
             .order_by(&[("rnk", true)])
             .limit(3)
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("outer order/limit fetch");
         let ranks: Vec<i64> = rows.into_iter().map(|i| i.rnk).collect();
@@ -136,7 +136,7 @@ mod scenarios {
         let rows: Vec<Item> = Item::objects()
             .filter("grp", "a")
             .intersection(Item::objects().filter("rnk__lte", 1_i64))
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("INTERSECT fetch (MySQL needs 8.0.31+)");
         assert_eq!(sorted_names(rows), vec!["a1"]);
@@ -147,7 +147,7 @@ mod scenarios {
         let rows: Vec<Item> = Item::objects()
             .filter("grp", "a")
             .difference(Item::objects().filter("rnk__lte", 2_i64))
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("EXCEPT fetch (MySQL needs 8.0.31+)");
         assert_eq!(sorted_names(rows), vec!["a3"]);
@@ -162,7 +162,7 @@ mod scenarios {
         let rows: Vec<Item> = Item::objects()
             .filter("grp", "a")
             .with_compound(SetOp::Union, branch)
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("with_compound fetch");
         assert_eq!(rows.len(), 5);

--- a/crates/rustango/tests/django6_subquery.rs
+++ b/crates/rustango/tests/django6_subquery.rs
@@ -97,7 +97,7 @@ mod scenarios {
         let rows: Vec<Author> = Author::objects()
             .where_exists(inner)
             .order_by(&[("name", false)])
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("EXISTS fetch");
         assert_eq!(names(rows), vec!["Ada", "Bob", "Dan"]);
@@ -114,7 +114,7 @@ mod scenarios {
             .expect("inner compile");
         let rows: Vec<Author> = Author::objects()
             .where_not_exists(inner)
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("NOT EXISTS fetch");
         assert_eq!(names(rows), vec!["Cara"]);
@@ -140,7 +140,7 @@ mod scenarios {
         let has: Vec<Author> = Author::objects()
             .where_has_filter("books", unpublished())
             .order_by(&[("name", false)])
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("whereHas fetch");
         assert_eq!(names(has), vec!["Ada", "Dan"], "filter() direction");
@@ -148,7 +148,7 @@ mod scenarios {
         let doesnt: Vec<Author> = Author::objects()
             .where_doesnt_have_filter("books", unpublished())
             .order_by(&[("name", false)])
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("whereDoesntHave fetch");
         assert_eq!(
@@ -168,7 +168,7 @@ mod scenarios {
             .expect("inner compile");
         let rows: Vec<Book> = Book::objects()
             .where_in_subquery("author_id", active_ids)
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("IN subquery fetch");
         assert_eq!(rows.len(), 5, "Ada's 2 + Dan's 3 books");
@@ -180,7 +180,7 @@ mod scenarios {
             .expect("inner compile");
         let rows: Vec<Book> = Book::objects()
             .where_not_in_subquery("author_id", active_ids)
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("NOT IN subquery fetch");
         assert_eq!(rows.len(), 1, "only Bob's book");
@@ -192,7 +192,7 @@ mod scenarios {
         let rows: Vec<Author> = Author::objects()
             .where_has_count("books", Op::Gte, 2)
             .order_by(&[("name", false)])
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("has-count fetch");
         assert_eq!(names(rows), vec!["Ada", "Dan"]);
@@ -235,7 +235,7 @@ mod scenarios {
                 op: Op::Eq,
                 rhs: subquery(newest_author),
             })
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("scalar subquery fetch");
         assert_eq!(rows.len(), 3, "Dan's 3 books");
@@ -294,7 +294,7 @@ mod scenarios {
                 op: Op::Eq,
                 rhs: outer_ref("id"),
             })
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .map(|rows: Vec<Author>| rows.len())
             .expect_err("OuterRef outside a subquery must error");

--- a/crates/rustango/tests/django6_window.rs
+++ b/crates/rustango/tests/django6_window.rs
@@ -258,7 +258,7 @@ mod scenarios {
         let rows: Vec<Score> = Score::objects()
             .distinct_on(&["tenant_id"])
             .order_by(&[("tenant_id", false), ("points", true)])
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("distinct_on fetch");
         let players: Vec<(i64, String, i64)> = rows
@@ -298,11 +298,11 @@ mod scenarios {
                 })
         };
         if pool.dialect().name() == "postgres" {
-            let rows: Vec<Score> = qs().fetch_pool(pool).await.expect("PG DISTINCT ON + join");
+            let rows: Vec<Score> = qs().fetch(pool).await.expect("PG DISTINCT ON + join");
             assert_eq!(rows.len(), 2);
         } else {
             let err = qs()
-                .fetch_pool(pool)
+                .fetch(pool)
                 .await
                 .map(|rows: Vec<Score>| rows.len())
                 .expect_err("distinct_on + join must be rejected on the window fallback");
@@ -339,7 +339,7 @@ mod scenarios {
             .expect("inner compile");
         let res = Tenant::objects()
             .join_lateral(top2, "top", WhereExpr::And(vec![]))
-            .fetch_pool(pool)
+            .fetch(pool)
             .await;
         if pool.dialect().name() == "sqlite" {
             let err = res

--- a/crates/rustango/tests/django6_writes.rs
+++ b/crates/rustango/tests/django6_writes.rs
@@ -63,7 +63,7 @@ mod scenarios {
     async fn fetch_sku(pool: &Pool, code: &str) -> Sku {
         let rows: Vec<Sku> = Sku::objects()
             .filter("code", code)
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("fetch sku");
         assert_eq!(rows.len(), 1, "exactly one row for code {code}");
@@ -122,7 +122,7 @@ mod scenarios {
         assert_eq!(Stock::count(pool).await.unwrap(), 3);
         let east: Vec<Stock> = Stock::objects()
             .filter("warehouse", "east")
-            .fetch_pool(pool)
+            .fetch(pool)
             .await
             .expect("fetch east");
         assert_eq!(east[0].qty, 50);
@@ -206,7 +206,7 @@ mod scenarios {
         assert_eq!(
             Sku::objects()
                 .filter("code", "stale")
-                .fetch_pool(pool)
+                .fetch(pool)
                 .await
                 .map(|rows: Vec<Sku>| rows.len())
                 .unwrap(),

--- a/crates/rustango/tests/filter_date_lookup_sqlite_live.rs
+++ b/crates/rustango/tests/filter_date_lookup_sqlite_live.rs
@@ -73,7 +73,7 @@ async fn year_lookup_matches_only_target_year() {
 
     let rows: Vec<Event> = QuerySet::<Event>::default()
         .filter("created__year", 2025_i64)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1, "only y2025 should match: {rows:?}");
@@ -87,7 +87,7 @@ async fn year_lookup_gte_picks_recent_years() {
 
     let rows: Vec<Event> = QuerySet::<Event>::default()
         .filter("created__year__gte", 2025_i64)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 2);
@@ -103,7 +103,7 @@ async fn month_lookup_matches_by_month_only() {
 
     let rows: Vec<Event> = QuerySet::<Event>::default()
         .filter("created__month", 2_i64)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -117,7 +117,7 @@ async fn day_lookup_matches_by_day_of_month() {
 
     let rows: Vec<Event> = QuerySet::<Event>::default()
         .filter("created__day", 6_i64)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -131,7 +131,7 @@ async fn hour_lookup_matches_by_hour() {
 
     let rows: Vec<Event> = QuerySet::<Event>::default()
         .filter("created__hour", 14_i64)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -146,7 +146,7 @@ async fn date_lookup_matches_full_date() {
     let target = NaiveDate::from_ymd_opt(2026, 6, 6).unwrap();
     let rows: Vec<Event> = QuerySet::<Event>::default()
         .filter("created__date", target)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -163,7 +163,7 @@ async fn week_day_lookup_matches_normalized_dow() {
     // 2026-06-06 is a Saturday → '6'
     let rows: Vec<Event> = QuerySet::<Event>::default()
         .filter("created__week_day", 6_i64)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -179,7 +179,7 @@ async fn quarter_lookup_works_on_sqlite() {
     // (Apr–Jun) matches only the June row.
     let rows = QuerySet::<Event>::default()
         .filter("created__quarter", 2_i64)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("quarter lookup now works on SQLite");
     let labels: Vec<&str> = rows.iter().map(|e| e.label.as_str()).collect();

--- a/crates/rustango/tests/first_last_sqlite_live.rs
+++ b/crates/rustango/tests/first_last_sqlite_live.rs
@@ -1,7 +1,7 @@
 //! v0.45 — live SQLite coverage for `QuerySet::first`,
 //! `last`, `earliest`, `latest`.
 //!
-//! Builder sugar over `order_by + limit(1) + fetch_pool`. No DB-side
+//! Builder sugar over `order_by + limit(1) + fetch`. No DB-side
 //! ranking logic; this suite proves the ordering semantics match
 //! Django:
 //!

--- a/crates/rustango/tests/gis_geometry_postgis_live.rs
+++ b/crates/rustango/tests/gis_geometry_postgis_live.rs
@@ -69,7 +69,7 @@ async fn point_column_round_trips_through_postgis() {
     p.save_pool(&pool).await.expect("insert Point");
 
     // Typed decode — the stored geometry round-trips back to a `Point`.
-    let rows: Vec<Place> = Place::objects().fetch_pool(&pool).await.unwrap();
+    let rows: Vec<Place> = Place::objects().fetch(&pool).await.unwrap();
     assert_eq!(rows.len(), 1);
     let got = rows[0].location;
     assert_eq!(got.srid, 4326);

--- a/crates/rustango/tests/gis_spatial_queries_postgis_live.rs
+++ b/crates/rustango/tests/gis_spatial_queries_postgis_live.rs
@@ -67,7 +67,7 @@ async fn spatial_distance_dwithin_and_intersects() {
     // order_by_distance_to → ST_Distance ascending: nearest first.
     let ordered: Vec<String> = Place::objects()
         .order_by_distance_to("location", origin)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .into_iter()
@@ -84,7 +84,7 @@ async fn spatial_distance_dwithin_and_intersects() {
     let within: Vec<String> = Place::objects()
         .filter_dwithin("location", origin, 1.0)
         .order_by_distance_to("location", origin)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .into_iter()
@@ -101,7 +101,7 @@ async fn spatial_distance_dwithin_and_intersects() {
             op: Op::Eq,
             rhs: Expr::Literal(SqlValue::Bool(true)),
         })
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .into_iter()

--- a/crates/rustango/tests/json_array_length_sqlite_live.rs
+++ b/crates/rustango/tests/json_array_length_sqlite_live.rs
@@ -73,7 +73,7 @@ async fn where_json_length_gt_filters_correctly() {
         rhs: Expr::Literal(SqlValue::I64(1)),
     });
 
-    let rows: Vec<Doc> = q.fetch_pool(&pool).await.unwrap();
+    let rows: Vec<Doc> = q.fetch(&pool).await.unwrap();
     assert_eq!(
         rows.len(),
         2,
@@ -94,6 +94,6 @@ async fn where_json_length_eq_zero_finds_empty_arrays() {
         rhs: Expr::Literal(SqlValue::I64(0)),
     });
 
-    let rows: Vec<Doc> = q.fetch_pool(&pool).await.unwrap();
+    let rows: Vec<Doc> = q.fetch(&pool).await.unwrap();
     assert_eq!(rows.len(), 1, "expected 1 doc with empty tags array");
 }

--- a/crates/rustango/tests/model_count_exists_sqlite_live.rs
+++ b/crates/rustango/tests/model_count_exists_sqlite_live.rs
@@ -33,7 +33,7 @@ async fn make_pool() -> Pool {
 }
 
 #[tokio::test]
-async fn count_pool_returns_row_count() {
+async fn count_returns_row_count() {
     let pool = make_pool().await;
     assert_eq!(Post::count(&pool).await.unwrap(), 0);
 
@@ -48,13 +48,13 @@ async fn count_pool_returns_row_count() {
 }
 
 #[tokio::test]
-async fn exists_pool_returns_false_for_empty_table() {
+async fn exists_returns_false_for_empty_table() {
     let pool = make_pool().await;
     assert!(!Post::exists(&pool).await.unwrap());
 }
 
 #[tokio::test]
-async fn exists_pool_returns_true_after_insert() {
+async fn exists_returns_true_after_insert() {
     let pool = make_pool().await;
     let mut p = Post {
         id: Auto::default(),

--- a/crates/rustango/tests/model_destroy_pool_sqlite_live.rs
+++ b/crates/rustango/tests/model_destroy_pool_sqlite_live.rs
@@ -54,7 +54,7 @@ async fn destroy_pool_deletes_listed_rows() {
     let n = Post::destroy(to_delete, &pool).await.unwrap();
     assert_eq!(n, 3);
 
-    let remaining: Vec<Post> = QuerySet::<Post>::default().fetch_pool(&pool).await.unwrap();
+    let remaining: Vec<Post> = QuerySet::<Post>::default().fetch(&pool).await.unwrap();
     assert_eq!(remaining.len(), 2);
     let titles: Vec<&str> = remaining.iter().map(|p| p.title.as_str()).collect();
     assert!(titles.contains(&"b"));
@@ -68,7 +68,7 @@ async fn destroy_pool_empty_list_is_noop() {
     let n = Post::destroy(Vec::<i64>::new(), &pool).await.unwrap();
     assert_eq!(n, 0);
 
-    let remaining: Vec<Post> = QuerySet::<Post>::default().fetch_pool(&pool).await.unwrap();
+    let remaining: Vec<Post> = QuerySet::<Post>::default().fetch(&pool).await.unwrap();
     assert_eq!(remaining.len(), 5);
 }
 

--- a/crates/rustango/tests/model_global_scope_sqlite_live.rs
+++ b/crates/rustango/tests/model_global_scope_sqlite_live.rs
@@ -15,8 +15,8 @@
 //!    suppresses one scope; other scopes (if any) keep applying.
 //! 3. **Wholesale opt-out** — `qs.without_global_scopes()` returns the
 //!    same WHERE you'd get on a model with no scopes declared.
-//! 4. **Apply across query verbs** — SELECT (`fetch_pool` /
-//!    `Model::all`) and aggregate (`count_pool` / `Model::count`) both
+//! 4. **Apply across query verbs** — SELECT (`fetch` /
+//!    `Model::all`) and aggregate (`count` / `Model::count`) both
 //!    fold the scope in. DELETE is exercised via the free
 //!    `rustango::sql::delete_pool` to prove `compile_delete()` honors
 //!    the scope too.
@@ -108,7 +108,7 @@ async fn default_queryset_hides_inactive_rows() {
     let pool = make_pool().await;
     seed(&pool).await;
     // `Post::all(&pool)` is the macro-emitted shortcut over
-    // `Post::objects().fetch_pool(&pool)` — the scope should fold in
+    // `Post::objects().fetch(&pool)` — the scope should fold in
     // here just as in the explicit chain.
     let visible = Post::all(&pool).await.unwrap();
     assert_eq!(visible.len(), 3, "scope must filter to active rows only");
@@ -123,7 +123,7 @@ async fn without_global_scope_by_name_sees_every_row() {
     seed(&pool).await;
     let all = Post::objects()
         .without_global_scope("active")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(all.len(), 5);
@@ -135,7 +135,7 @@ async fn without_global_scopes_sees_every_row() {
     seed(&pool).await;
     let all = Post::objects()
         .without_global_scopes()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(all.len(), 5);
@@ -150,14 +150,14 @@ async fn unknown_scope_name_is_silently_ignored() {
     // robust against scope renames.
     let visible = Post::objects()
         .without_global_scope("nope")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(visible.len(), 3);
 }
 
 #[tokio::test]
-async fn count_pool_honors_global_scope() {
+async fn count_honors_global_scope() {
     let pool = make_pool().await;
     seed(&pool).await;
     let active_count = Post::count(&pool).await.unwrap();
@@ -165,7 +165,7 @@ async fn count_pool_honors_global_scope() {
 
     let total = Post::objects()
         .without_global_scopes()
-        .count_pool(&pool)
+        .count(&pool)
         .await
         .unwrap();
     assert_eq!(total, 5);
@@ -179,7 +179,7 @@ async fn user_filters_compose_with_global_scope() {
     // active row whose title equals "alpha".
     let rows = Post::objects()
         .filter("title", "alpha")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -189,14 +189,14 @@ async fn user_filters_compose_with_global_scope() {
     // empty (scope hides it); unscoped MUST find it.
     let beta_scoped = Post::objects()
         .filter("title", "beta")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert!(beta_scoped.is_empty(), "scope must hide inactive `beta`");
     let beta_unscoped = Post::objects()
         .without_global_scopes()
         .filter("title", "beta")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(beta_unscoped.len(), 1);
@@ -215,7 +215,7 @@ async fn compile_delete_honors_global_scope() {
 
     let survivors = Post::objects()
         .without_global_scopes()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(survivors.len(), 2);

--- a/crates/rustango/tests/model_reverse_has_sqlite_live.rs
+++ b/crates/rustango/tests/model_reverse_has_sqlite_live.rs
@@ -17,7 +17,7 @@
 //! ```ignore
 //! Post::objects()
 //!     .where_raw(Post::comments_exists_expr())
-//!     .fetch_pool(&pool).await?;
+//!     .fetch(&pool).await?;
 //! ```
 //!
 //! Tri-dialect: `EXISTS` is portable across PG / MySQL / SQLite —
@@ -117,7 +117,7 @@ async fn where_has_returns_only_posts_with_at_least_one_comment() {
 
     let mut posts = Post::objects()
         .where_raw(Post::comments_exists_expr())
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     posts.sort_by_key(|p| p.id.get().copied().unwrap());
@@ -134,7 +134,7 @@ async fn where_doesnt_have_returns_only_posts_with_zero_comments() {
 
     let posts = Post::objects()
         .where_raw(Post::comments_not_exists_expr())
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(posts.len(), 1);
@@ -152,7 +152,7 @@ async fn reverse_has_composes_with_user_filters() {
     let posts = Post::objects()
         .where_raw(Post::comments_exists_expr())
         .filter("title__startswith", "Has")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(posts.len(), 1);
@@ -165,7 +165,7 @@ async fn empty_child_table_returns_zero_via_where_has() {
     // No seeding — comment table is empty so EXISTS never matches.
     let posts = Post::objects()
         .where_raw(Post::comments_exists_expr())
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert!(posts.is_empty());
@@ -180,7 +180,7 @@ async fn comments_accessor_returns_chainable_queryset() {
     let (p1_id, _p2_id, _p3_id) = seed(&pool).await;
     let p1 = Post::find(p1_id, &pool).await.unwrap().unwrap();
 
-    let all = p1.comments().fetch_pool(&pool).await.unwrap();
+    let all = p1.comments().fetch(&pool).await.unwrap();
     assert_eq!(all.len(), 3);
     for c in &all {
         // Every fetched comment's FK matches this post's id.
@@ -191,7 +191,7 @@ async fn comments_accessor_returns_chainable_queryset() {
     let filtered = p1
         .comments()
         .filter("body", "comment-1")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(filtered.len(), 1);
@@ -229,7 +229,7 @@ async fn comments_first_returns_first_child_or_none() {
 #[tokio::test]
 async fn comments_fetch_bare_name_hot_path() {
     // Bare-name hot path — `post.comments_fetch(&pool)` is the
-    // suffix-free shortcut over `post.comments().fetch_pool(&pool)`.
+    // suffix-free shortcut over `post.comments().fetch(&pool)`.
     // Same rows, no `_pool` in the user-visible spelling.
     let pool = make_pool().await;
     let (p1_id, _, _) = seed(&pool).await;

--- a/crates/rustango/tests/model_through_relation_sqlite_live.rs
+++ b/crates/rustango/tests/model_through_relation_sqlite_live.rs
@@ -155,7 +155,7 @@ async fn posts_through_returns_only_far_model_rows_for_this_country() {
     let (a_id, b_id) = seed(&pool).await;
 
     let a = Country::find(a_id, &pool).await.unwrap().unwrap();
-    let posts = a.posts_through().fetch_pool(&pool).await.unwrap();
+    let posts = a.posts_through().fetch(&pool).await.unwrap();
     // Country A has 2 users × 3 posts each = 6 far-model rows.
     assert_eq!(posts.len(), 6);
     for p in &posts {
@@ -167,7 +167,7 @@ async fn posts_through_returns_only_far_model_rows_for_this_country() {
     }
 
     let b = Country::find(b_id, &pool).await.unwrap().unwrap();
-    let posts_b = b.posts_through().fetch_pool(&pool).await.unwrap();
+    let posts_b = b.posts_through().fetch(&pool).await.unwrap();
     // Country B has 3 users × 3 posts each = 9.
     assert_eq!(posts_b.len(), 9);
     for p in &posts_b {
@@ -193,7 +193,7 @@ async fn through_accessor_is_chainable_with_filter_and_limit() {
     let alice_posts = a
         .posts_through()
         .filter("title__startswith", "alice-")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(alice_posts.len(), 3);
@@ -207,7 +207,7 @@ async fn through_accessor_is_chainable_with_filter_and_limit() {
         .posts_through()
         .order_by(&[("id", false)])
         .limit(2)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(first_two.len(), 2);
@@ -222,7 +222,7 @@ async fn through_accessor_returns_empty_for_country_with_no_users() {
         name: "Empty".into(),
     };
     empty.save_pool(&pool).await.unwrap();
-    let posts = empty.posts_through().fetch_pool(&pool).await.unwrap();
+    let posts = empty.posts_through().fetch(&pool).await.unwrap();
     assert!(posts.is_empty());
 }
 
@@ -286,7 +286,7 @@ async fn posts_through_first_returns_first_far_or_none() {
 #[tokio::test]
 async fn posts_through_fetch_bare_name_hot_path() {
     // Bare-name hot path — `posts_through_fetch(&pool)` is the
-    // suffix-free shortcut over `posts_through().fetch_pool(&pool)`.
+    // suffix-free shortcut over `posts_through().fetch(&pool)`.
     let pool = make_pool().await;
     let (a_id, _b_id) = seed(&pool).await;
     let a = Country::find(a_id, &pool).await.unwrap().unwrap();

--- a/crates/rustango/tests/mysql_from_row.rs
+++ b/crates/rustango/tests/mysql_from_row.rs
@@ -64,7 +64,7 @@ fn user_model_also_implements_pg_from_row() {
 #[test]
 fn maybe_my_from_row_resolves_for_derived_model() {
     // The MaybeMyFromRow bound is what `select_rows_pool` and
-    // `FetcherPool::fetch_pool` use. Confirm derived models satisfy
+    // `FetcherPool::fetch` use. Confirm derived models satisfy
     // it under the mysql feature config.
     fn check<T: rustango::sql::MaybeMyFromRow>() {}
     check::<User>();
@@ -199,14 +199,14 @@ fn direction_aware_pool_runners_are_callable() {
 
 #[test]
 fn fetcher_pool_satisfies_join_bound() {
-    // batch 15 — FetcherPool::fetch_pool now requires LoadRelated +
+    // batch 15 — FetcherPool::fetch now requires LoadRelated +
     // MaybeMyLoadRelated alongside FromRow + MaybeMyFromRow. Every
     // derived Model satisfies all four bounds (FK-less models get
     // empty-arm impls), so this resolves at compile time.
     use rustango::sql::FetcherPool;
     fn _probe(pool: &rustango::sql::Pool) {
-        let _fut = User::objects().fetch_pool(pool);
-        let _fut = Post::objects().fetch_pool(pool);
+        let _fut = User::objects().fetch(pool);
+        let _fut = Post::objects().fetch(pool);
     }
 }
 
@@ -305,11 +305,11 @@ fn audited_auto_pk_model_gets_insert_pool() {
 }
 
 #[test]
-fn counter_pool_count_pool_is_callable() {
-    // batch 24 — QuerySet::count_pool fills the QuerySet counter gap.
+fn counter_pool_count_is_callable() {
+    // batch 24 — QuerySet::count fills the QuerySet counter gap.
     use rustango::sql::CounterPool;
     fn _probe(pool: &rustango::sql::Pool) {
-        let _fut = User::objects().count_pool(pool);
+        let _fut = User::objects().count(pool);
     }
 }
 

--- a/crates/rustango/tests/mysql_live.rs
+++ b/crates/rustango/tests/mysql_live.rs
@@ -115,15 +115,12 @@ async fn auto_pk_insert_pool_round_trips() {
     // LAST_INSERT_ID() — first row → 1.
     assert_eq!(u.id.get().copied(), Some(1));
 
-    let n = LiveUser::objects()
-        .count_pool(&pool)
-        .await
-        .expect("count_pool");
+    let n = LiveUser::objects().count(&pool).await.expect("count");
     assert_eq!(n, 1);
 }
 
 #[tokio::test]
-async fn fetch_pool_round_trips_decoded_row() {
+async fn fetch_round_trips_decoded_row() {
     let Some(pool) = pool_or_skip().await else {
         eprintln!("MYSQL_TEST_URL unset — skipping");
         return;
@@ -138,10 +135,7 @@ async fn fetch_pool_round_trips_decoded_row() {
     };
     u.insert_pool(&pool).await.expect("insert_pool");
 
-    let users: Vec<LiveUser> = LiveUser::objects()
-        .fetch_pool(&pool)
-        .await
-        .expect("fetch_pool");
+    let users: Vec<LiveUser> = LiveUser::objects().fetch(&pool).await.expect("fetch");
     assert_eq!(users.len(), 1);
     assert_eq!(users[0].name, "bob");
     assert!(!users[0].is_active);
@@ -166,7 +160,7 @@ async fn save_pool_updates_existing_row() {
     u.name = "Carol".into();
     u.save_pool(&pool).await.expect("save_pool");
 
-    let users: Vec<LiveUser> = LiveUser::objects().fetch_pool(&pool).await.expect("fetch");
+    let users: Vec<LiveUser> = LiveUser::objects().fetch(&pool).await.expect("fetch");
     assert_eq!(users[0].name, "Carol");
 }
 
@@ -187,7 +181,7 @@ async fn delete_pool_removes_row() {
     u.insert_pool(&pool).await.expect("insert");
     let affected = u.delete_pool(&pool).await.expect("delete_pool");
     assert_eq!(affected, 1);
-    let n = LiveUser::objects().count_pool(&pool).await.expect("count");
+    let n = LiveUser::objects().count(&pool).await.expect("count");
     assert_eq!(n, 0);
 }
 
@@ -264,7 +258,7 @@ async fn transaction_pool_commit_persists() {
         _ => unreachable!("test runs with mysql feature"),
     }
 
-    let n = LiveUser::objects().count_pool(&pool).await.expect("count");
+    let n = LiveUser::objects().count(&pool).await.expect("count");
     assert_eq!(n, 1);
 }
 

--- a/crates/rustango/tests/orm_advanced_sqlite_live.rs
+++ b/crates/rustango/tests/orm_advanced_sqlite_live.rs
@@ -1,6 +1,6 @@
 #![allow(irrefutable_let_patterns)] // Pool enum is single-variant in sqlite-only builds; pattern is refutable on multi-backend builds.
 //! Advanced ORM coverage on SQLite — closes the gap between the
-//! basic `save_pool` / `fetch_pool` round-trips in `sqlite_live.rs`
+//! basic `save_pool` / `fetch` round-trips in `sqlite_live.rs`
 //! and the full PG live suite (`save_live.rs`, `select_related_live.rs`,
 //! `where_expr_live.rs`, `order_by_annotate_live.rs`, `upsert_unique_*`,
 //! `prefetch_related_live.rs`).
@@ -9,7 +9,7 @@
 //!   * `select_related(&[Fk])` decodes the joined row correctly
 //!   * `where_(...)` with AND / OR / IN combinations compiles + matches
 //!   * `order_by(&[(col, asc)])` produces deterministic ordering
-//!   * `count_pool` matches `fetch_pool().len()` for the same QuerySet
+//!   * `count` matches `fetch().len()` for the same QuerySet
 //!   * `bulk_insert_pool` round-trips
 //!   * upsert via the ORM IR (`InsertQuery` with `ConflictClause::DoUpdate`)
 //!   * `prefetch_related` (FK-based) hydrates parents-then-children
@@ -110,7 +110,7 @@ async fn where_chain_with_and_filters_correctly_on_sqlite() {
     let posts: Vec<Post> = Post::objects()
         .where_(Post::author.eq(alice))
         .where_(Post::published.eq(true))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("fetch");
     assert_eq!(posts.len(), 2, "two published posts by alice");
@@ -129,7 +129,7 @@ async fn where_in_list_filters_on_sqlite() {
             rustango::core::Op::In,
             SqlValue::List(vec![SqlValue::I64(alice), SqlValue::I64(bob)]),
         )
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("fetch IN");
     assert_eq!(posts.len(), 2, "both authors' posts");
@@ -147,7 +147,7 @@ async fn order_by_desc_produces_deterministic_order_on_sqlite() {
     .await;
     let posts: Vec<Post> = Post::objects()
         .order_by(&[("title", false)])
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("fetch");
     let titles: Vec<&str> = posts.iter().map(|p| p.title.as_str()).collect();
@@ -155,7 +155,7 @@ async fn order_by_desc_produces_deterministic_order_on_sqlite() {
     // DESC.
     let posts: Vec<Post> = Post::objects()
         .order_by(&[("title", true)])
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("fetch desc");
     let titles: Vec<&str> = posts.iter().map(|p| p.title.as_str()).collect();
@@ -163,17 +163,17 @@ async fn order_by_desc_produces_deterministic_order_on_sqlite() {
 }
 
 #[tokio::test]
-async fn count_pool_matches_fetch_pool_len_on_sqlite() {
+async fn count_matches_fetch_len_on_sqlite() {
     let pool = fresh_pool().await;
     let (alice, _bob) = seed_basic(&pool).await;
     seed_posts(&pool, alice, &[("a", true), ("b", false), ("c", true)]).await;
     let qs = Post::objects().where_(Post::author.eq(alice));
     let qs2 = Post::objects().where_(Post::author.eq(alice));
-    let n_count = qs.count_pool(&pool).await.expect("count");
-    let n_fetch = qs2.fetch_pool(&pool).await.expect("fetch").len() as i64;
+    let n_count = qs.count(&pool).await.expect("count");
+    let n_fetch = qs2.fetch(&pool).await.expect("fetch").len() as i64;
     assert_eq!(
         n_count, n_fetch,
-        "count_pool should match fetch_pool().len() — got count={n_count}, fetch_len={n_fetch}"
+        "count should match fetch().len() — got count={n_count}, fetch_len={n_fetch}"
     );
 }
 
@@ -184,7 +184,7 @@ async fn foreign_key_get_pool_lazy_loads_author_on_sqlite() {
     seed_posts(&pool, alice, &[("hello", true)]).await;
     let mut posts: Vec<Post> = Post::objects()
         .where_(Post::published.eq(true))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("fetch");
     assert_eq!(posts.len(), 1);
@@ -262,7 +262,7 @@ async fn upsert_via_insert_query_with_do_update_works_on_sqlite() {
     // Verify there's still only one row + `published` is now true.
     let rows: Vec<Post> = Post::objects()
         .where_(Post::title.eq("unique-slot".to_owned()))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("fetch");
     assert_eq!(rows.len(), 1, "ON CONFLICT should keep one row");
@@ -289,7 +289,7 @@ async fn limit_offset_pagination_on_sqlite() {
         .order_by(&[("title", false)])
         .limit(2)
         .offset(0)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("page 1");
     assert_eq!(
@@ -300,7 +300,7 @@ async fn limit_offset_pagination_on_sqlite() {
         .order_by(&[("title", false)])
         .limit(2)
         .offset(2)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("page 2");
     assert_eq!(
@@ -311,7 +311,7 @@ async fn limit_offset_pagination_on_sqlite() {
         .order_by(&[("title", false)])
         .limit(2)
         .offset(4)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("page 3");
     assert_eq!(
@@ -326,7 +326,7 @@ async fn save_pool_updates_existing_row_on_sqlite() {
     let (alice, _) = seed_basic(&pool).await;
     seed_posts(&pool, alice, &[("draft", false)]).await;
     let mut row: Post = Post::objects()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("fetch")
         .into_iter()
@@ -336,7 +336,7 @@ async fn save_pool_updates_existing_row_on_sqlite() {
     row.title = "published".into();
     row.save_pool(&pool).await.expect("save update");
     let again: Post = Post::objects()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("fetch again")
         .into_iter()

--- a/crates/rustango/tests/per_fk_related_name_sqlite_live.rs
+++ b/crates/rustango/tests/per_fk_related_name_sqlite_live.rs
@@ -101,7 +101,7 @@ async fn per_fk_related_name_disambiguates_two_fks_to_same_parent() {
 
     let ada_db = QuerySet::<User>::default()
         .filter("id", ada_pk)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .pop()
@@ -122,7 +122,7 @@ async fn per_fk_related_name_disambiguates_two_fks_to_same_parent() {
 
     let grace_db = QuerySet::<User>::default()
         .filter("id", grace_pk)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .pop()

--- a/crates/rustango/tests/prunable_sqlite_live.rs
+++ b/crates/rustango/tests/prunable_sqlite_live.rs
@@ -136,7 +136,7 @@ async fn prune_pretend_counts_without_deleting() {
 
     // Nothing was deleted.
     let audits: Vec<AuditEntry> = QuerySet::<AuditEntry>::default()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(audits.len(), 4, "no rows actually deleted");
@@ -155,7 +155,7 @@ async fn prune_all_deletes_matching_rows() {
 
     // Survivors only.
     let audits: Vec<AuditEntry> = QuerySet::<AuditEntry>::default()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(audits.len(), 2);
@@ -168,7 +168,7 @@ async fn prune_all_deletes_matching_rows() {
         );
     }
     let sessions: Vec<StaleSession> = QuerySet::<StaleSession>::default()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(sessions.len(), 2);
@@ -189,7 +189,7 @@ async fn prune_only_restricts_to_listed_models() {
 
     // Session table untouched.
     let sessions: Vec<StaleSession> = QuerySet::<StaleSession>::default()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(sessions.len(), 3, "session prune was filtered out");
@@ -211,7 +211,7 @@ async fn prune_except_skips_listed_models() {
 
     // Audit table untouched.
     let audits: Vec<AuditEntry> = QuerySet::<AuditEntry>::default()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(audits.len(), 4, "audit prune was filtered out");

--- a/crates/rustango/tests/queryset_clone_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_clone_sqlite_live.rs
@@ -64,8 +64,8 @@ async fn cloning_a_queryset_lets_branches_diverge() {
     let drafts = base.clone().filter("status", "draft");
     let pub_only = base.filter("status", "published");
 
-    let drafts_rows = drafts.fetch_pool(&pool).await.unwrap();
-    let pub_rows = pub_only.fetch_pool(&pool).await.unwrap();
+    let drafts_rows = drafts.fetch(&pool).await.unwrap();
+    let pub_rows = pub_only.fetch(&pool).await.unwrap();
 
     assert_eq!(drafts_rows.len(), 2);
     assert!(drafts_rows.iter().all(|r| r.status == "draft"));
@@ -84,10 +84,10 @@ async fn clone_does_not_share_pending_state() {
     let with_filter = original.clone().filter("status", "draft");
 
     // Original is still unfiltered → returns all 5.
-    let all = original.fetch_pool(&pool).await.unwrap();
+    let all = original.fetch(&pool).await.unwrap();
     assert_eq!(all.len(), 5);
 
     // Cloned-then-filtered branch → returns only the 2 drafts.
-    let drafts = with_filter.fetch_pool(&pool).await.unwrap();
+    let drafts = with_filter.fetch(&pool).await.unwrap();
     assert_eq!(drafts.len(), 2);
 }

--- a/crates/rustango/tests/queryset_contains.rs
+++ b/crates/rustango/tests/queryset_contains.rs
@@ -50,35 +50,35 @@ async fn seed(pool: &Pool) -> Vec<i64> {
     ids
 }
 
-// ----- exists_pool
+// ----- exists
 
 #[tokio::test]
-async fn exists_pool_true_when_any_match() {
+async fn exists_true_when_any_match() {
     let pool = fresh_pool().await;
     seed(&pool).await;
-    assert!(Widget::objects().exists_pool(&pool).await.unwrap());
+    assert!(Widget::objects().exists(&pool).await.unwrap());
 }
 
 #[tokio::test]
-async fn exists_pool_false_on_empty_table() {
+async fn exists_false_on_empty_table() {
     let pool = fresh_pool().await;
-    assert!(!Widget::objects().exists_pool(&pool).await.unwrap());
+    assert!(!Widget::objects().exists(&pool).await.unwrap());
 }
 
 #[tokio::test]
-async fn exists_pool_false_when_filter_excludes_all() {
+async fn exists_false_when_filter_excludes_all() {
     let pool = fresh_pool().await;
     seed(&pool).await;
     let any_z: bool = Widget::objects()
         .where_(Widget::label.eq("z".to_owned()))
-        .exists_pool(&pool)
+        .exists(&pool)
         .await
         .unwrap();
     assert!(!any_z);
 }
 
 #[tokio::test]
-async fn exists_pool_honors_chained_filters() {
+async fn exists_honors_chained_filters() {
     let pool = fresh_pool().await;
     seed(&pool).await;
     // Both filters need to match — there ARE published rows, but
@@ -86,7 +86,7 @@ async fn exists_pool_honors_chained_filters() {
     let q = Widget::objects()
         .where_(Widget::published.eq(true))
         .where_(Widget::label.eq("b".to_owned()))
-        .exists_pool(&pool)
+        .exists(&pool)
         .await
         .unwrap();
     assert!(!q);
@@ -141,7 +141,7 @@ async fn contains_pk_after_delete_returns_false() {
     // contains_pk flips to false.
     let row: Widget = Widget::objects()
         .where_(Widget::id.eq(ids[0]))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .into_iter()

--- a/crates/rustango/tests/queryset_exclude_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_exclude_sqlite_live.rs
@@ -48,7 +48,7 @@ async fn seeded() -> Pool {
 
 async fn ids(pool: &Pool, qs: rustango::query::QuerySet<Post>) -> Vec<i64> {
     let mut v: Vec<i64> = qs
-        .fetch_pool(pool)
+        .fetch(pool)
         .await
         .expect("fetch")
         .into_iter()

--- a/crates/rustango/tests/queryset_in_random_order_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_in_random_order_sqlite_live.rs
@@ -42,7 +42,7 @@ async fn in_random_order_returns_every_row() {
     }
     let rows = Post::objects()
         .in_random_order()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 10);
@@ -64,7 +64,7 @@ async fn in_random_order_with_take_caps_result() {
     let rows = Post::objects()
         .in_random_order()
         .take(5)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 5);

--- a/crates/rustango/tests/queryset_increment_decrement_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_increment_decrement_sqlite_live.rs
@@ -59,7 +59,7 @@ async fn seed(pool: &Pool) -> (Vec<i64>, Vec<i64>) {
 async fn views_for(pool: &Pool, id: i64) -> i64 {
     Post::objects()
         .filter("id", id)
-        .fetch_pool(pool)
+        .fetch(pool)
         .await
         .unwrap()
         .pop()

--- a/crates/rustango/tests/queryset_is_empty_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_is_empty_sqlite_live.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "sqlite")]
 //! Live SQLite test for `QuerySet::is_empty(&pool)` — inverse of
-//! `exists_pool`, more readable in negation-flavored code.
+//! `exists`, more readable in negation-flavored code.
 
 use rustango::sql::{sqlx, Auto, ExistsPool as _, Pool};
 use rustango::Model;
@@ -49,11 +49,11 @@ async fn is_empty_returns_false_when_rows_match() {
 }
 
 #[tokio::test]
-async fn is_empty_is_inverse_of_exists_pool() {
+async fn is_empty_is_inverse_of_exists() {
     let pool = make_pool().await;
     // Empty table — exists=false, is_empty=true.
     assert_eq!(
-        Post::objects().exists_pool(&pool).await.unwrap(),
+        Post::objects().exists(&pool).await.unwrap(),
         !Post::objects().is_empty(&pool).await.unwrap()
     );
 
@@ -64,7 +64,7 @@ async fn is_empty_is_inverse_of_exists_pool() {
     };
     p.save_pool(&pool).await.unwrap();
     assert_eq!(
-        Post::objects().exists_pool(&pool).await.unwrap(),
+        Post::objects().exists(&pool).await.unwrap(),
         !Post::objects().is_empty(&pool).await.unwrap()
     );
 }

--- a/crates/rustango/tests/queryset_order_by_desc_asc_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_order_by_desc_asc_sqlite_live.rs
@@ -49,7 +49,7 @@ async fn order_by_desc_appends_descending_order() {
     seed(&pool, 5).await;
     let rows = Post::objects()
         .order_by_desc("seq")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     let ns: Vec<i64> = rows.iter().map(|r| r.seq).collect();
@@ -62,7 +62,7 @@ async fn order_by_asc_appends_ascending_order() {
     seed(&pool, 5).await;
     let rows = Post::objects()
         .order_by_asc("seq")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     let ns: Vec<i64> = rows.iter().map(|r| r.seq).collect();

--- a/crates/rustango/tests/queryset_rel_m2m_gfk_live.rs
+++ b/crates/rustango/tests/queryset_rel_m2m_gfk_live.rs
@@ -142,7 +142,7 @@ async fn assert_relations(pool: &rustango::sql::Pool) {
     // --- M2M where_has: A, B (not C) ---
     let mut has_tags: Vec<String> = Post::objects()
         .where_has("tags")
-        .fetch_pool(pool)
+        .fetch(pool)
         .await
         .unwrap()
         .into_iter()
@@ -193,7 +193,7 @@ async fn assert_relations(pool: &rustango::sql::Pool) {
     // --- GFK where_has: P, Q (not R) ---
     let mut commented: Vec<String> = Article::objects()
         .where_has("comments")
-        .fetch_pool(pool)
+        .fetch(pool)
         .await
         .unwrap()
         .into_iter()

--- a/crates/rustango/tests/queryset_reorder_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_reorder_sqlite_live.rs
@@ -53,7 +53,7 @@ async fn order_by_appends_secondary_sort_key() {
     let rows = Post::objects()
         .order_by(&[("title", false)])
         .order_by(&[("views", false)])
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     let titles: Vec<&str> = rows.iter().map(|r| r.title.as_str()).collect();
@@ -69,7 +69,7 @@ async fn reorder_replaces_prior_order_by_keys() {
     let rows = Post::objects()
         .with_default_order() // inherits `title ASC` from schema
         .reorder(&[("views", true)]) // replaces with views DESC
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     let views: Vec<i64> = rows.iter().map(|r| r.views).collect();
@@ -86,7 +86,7 @@ async fn reorder_with_empty_slice_clears_sort() {
         .order_by(&[("title", true)])
         .reorder(&[])
         .order_by(&[("id", false)])
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     // After reorder(&[]) the prior title-DESC is gone; only id-ASC

--- a/crates/rustango/tests/queryset_reverse.rs
+++ b/crates/rustango/tests/queryset_reverse.rs
@@ -53,7 +53,7 @@ async fn reverse_flips_single_column_ascending_to_descending() {
     // ASC by rating → [b(1), c(2), a(3)]
     let asc: Vec<Widget> = Widget::objects()
         .order_by(&[("rating", false)])
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(
@@ -65,7 +65,7 @@ async fn reverse_flips_single_column_ascending_to_descending() {
     let rev: Vec<Widget> = Widget::objects()
         .order_by(&[("rating", false)])
         .reverse()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(
@@ -83,7 +83,7 @@ async fn reverse_flips_descending_to_ascending() {
     let rev: Vec<Widget> = Widget::objects()
         .order_by(&[("rating", true)])
         .reverse()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(
@@ -118,7 +118,7 @@ async fn reverse_flips_each_field_of_a_multi_column_sort() {
     // ORDER BY rating ASC, label ASC → [(1,a), (1,b), (2,c)]
     let asc: Vec<Widget> = Widget::objects()
         .order_by(&[("rating", false), ("label", false)])
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(
@@ -130,7 +130,7 @@ async fn reverse_flips_each_field_of_a_multi_column_sort() {
     let rev: Vec<Widget> = Widget::objects()
         .order_by(&[("rating", false), ("label", false)])
         .reverse()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(
@@ -145,7 +145,7 @@ async fn reverse_no_op_when_no_ordering_set() {
     seed(&pool).await;
 
     // No order_by — .reverse() must not error and must return all rows.
-    let rows: Vec<Widget> = Widget::objects().reverse().fetch_pool(&pool).await.unwrap();
+    let rows: Vec<Widget> = Widget::objects().reverse().fetch(&pool).await.unwrap();
     assert_eq!(rows.len(), 3);
 }
 
@@ -156,14 +156,14 @@ async fn double_reverse_returns_to_original() {
 
     let original: Vec<Widget> = Widget::objects()
         .order_by(&[("rating", false)])
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     let twice_reversed: Vec<Widget> = Widget::objects()
         .order_by(&[("rating", false)])
         .reverse()
         .reverse()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(

--- a/crates/rustango/tests/queryset_skip_take_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_skip_take_sqlite_live.rs
@@ -49,7 +49,7 @@ async fn skip_take_chains_correctly() {
         .order_by(&[("n", false)])
         .skip(5)
         .take(3)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     let ns: Vec<i64> = rows.iter().map(|r| r.n).collect();
@@ -63,7 +63,7 @@ async fn take_alone_caps_result() {
     let rows = Post::objects()
         .order_by(&[("n", false)])
         .take(3)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 3);
@@ -80,7 +80,7 @@ async fn skip_alone_with_limit_returns_remainder() {
         .order_by(&[("n", false)])
         .skip(7)
         .take(100)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 3);

--- a/crates/rustango/tests/queryset_where_column_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_where_column_sqlite_live.rs
@@ -56,7 +56,7 @@ async fn where_column_eq_matches_rows_with_equal_columns() {
     insert(&pool, 7, 7, "same2").await;
     let mut got: Vec<String> = Reservation::objects()
         .where_column("start_day", "end_day")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .into_iter()
@@ -74,7 +74,7 @@ async fn where_column_op_lt_finds_rows_where_start_before_end() {
     insert(&pool, 9, 1, "reversed").await;
     let mut got: Vec<String> = Reservation::objects()
         .where_column_op("start_day", Op::Lt, "end_day")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .into_iter()

--- a/crates/rustango/tests/queryset_where_exists_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_where_exists_sqlite_live.rs
@@ -90,7 +90,7 @@ async fn where_exists_finds_authors_with_books() {
         .unwrap();
     let rows = Author::objects()
         .where_exists(inner)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -107,7 +107,7 @@ async fn where_not_exists_finds_authors_with_no_books() {
         .unwrap();
     let rows = Author::objects()
         .where_not_exists(inner)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);

--- a/crates/rustango/tests/queryset_where_has_count_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_where_has_count_sqlite_live.rs
@@ -91,7 +91,7 @@ async fn seed(pool: &Pool) {
 async fn names_for(pool: &Pool, op: Op, n: i64) -> Vec<String> {
     let mut names: Vec<String> = Author::objects()
         .where_has_count("books", op, n)
-        .fetch_pool(pool)
+        .fetch(pool)
         .await
         .unwrap()
         .into_iter()
@@ -156,7 +156,7 @@ async fn composes_with_other_filters() {
     let rows = Author::objects()
         .filter("name", "One")
         .where_has_count("books", Op::Gte, 1)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -169,7 +169,7 @@ async fn unknown_relation_errors_at_compile_time() {
     seed(&pool).await;
     let err = Author::objects()
         .where_has_count("nope", Op::Gt, 1)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap_err();
     assert!(format!("{err}").contains("nope"));

--- a/crates/rustango/tests/queryset_where_has_filter_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_where_has_filter_sqlite_live.rs
@@ -119,7 +119,7 @@ async fn where_has_filter_narrows_to_authors_with_matching_child_rows() {
     let inner = Book::objects().filter("published", true).compile().unwrap();
     let rows = Author::objects()
         .where_has_filter("books", inner)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -134,7 +134,7 @@ async fn where_doesnt_have_filter_finds_authors_without_matching_child_rows() {
     let inner = Book::objects().filter("published", true).compile().unwrap();
     let mut names: Vec<String> = Author::objects()
         .where_doesnt_have_filter("books", inner)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .into_iter()
@@ -151,7 +151,7 @@ async fn where_has_filter_with_unknown_relation_errors() {
     let inner = Book::objects().compile().unwrap();
     let err = Author::objects()
         .where_has_filter("nonexistent", inner)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap_err();
     assert!(format!("{err}").contains("nonexistent"));
@@ -166,7 +166,7 @@ async fn where_has_filter_with_wrong_child_model_errors() {
     let wrong_inner = Other::objects().compile().unwrap();
     let err = Author::objects()
         .where_has_filter("books", wrong_inner)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap_err();
     let msg = format!("{err}");

--- a/crates/rustango/tests/queryset_where_has_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_where_has_sqlite_live.rs
@@ -89,7 +89,7 @@ async fn where_has_resolves_relation_name_to_exists() {
     seed(&pool).await;
     let rows = Author::objects()
         .where_has("books")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -102,7 +102,7 @@ async fn where_doesnt_have_resolves_relation_name_to_not_exists() {
     seed(&pool).await;
     let rows = Author::objects()
         .where_doesnt_have("books")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -115,7 +115,7 @@ async fn where_has_unknown_relation_errors_at_compile_time() {
     seed(&pool).await;
     let err = Author::objects()
         .where_has("nonexistent")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap_err();
     let msg = format!("{err}");

--- a/crates/rustango/tests/queryset_where_in_subquery_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_where_in_subquery_sqlite_live.rs
@@ -93,7 +93,7 @@ async fn where_in_subquery_finds_posts_with_public_category() {
         .unwrap();
     let mut titles: Vec<String> = Post::objects()
         .where_in_subquery("category_id", public_ids)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .into_iter()
@@ -114,7 +114,7 @@ async fn where_not_in_subquery_finds_posts_outside_public_category() {
         .unwrap();
     let mut titles: Vec<String> = Post::objects()
         .where_not_in_subquery("category_id", public_ids)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .into_iter()

--- a/crates/rustango/tests/queryset_where_key_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_where_key_sqlite_live.rs
@@ -53,7 +53,7 @@ async fn where_key_filters_to_single_row() {
     let target = ids[2];
     let rows = Post::objects()
         .where_key(target)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 1);
@@ -68,7 +68,7 @@ async fn where_key_not_excludes_pk() {
     let excluded = ids[1];
     let mut got: Vec<i64> = Post::objects()
         .where_key_not(excluded)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .into_iter()
@@ -86,7 +86,7 @@ async fn where_key_no_match_returns_empty() {
     seed(&pool).await;
     let rows = Post::objects()
         .where_key(999_999_i64)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert!(rows.is_empty());

--- a/crates/rustango/tests/range_field_pg_live.rs
+++ b/crates/rustango/tests/range_field_pg_live.rs
@@ -159,7 +159,7 @@ async fn range_contains_operator_filters() {
     // `seats @> int4range(5,6)` — only "small" contains seat 5.
     let names: Vec<String> = Event::objects()
         .where_(Event::seats.range_contains("[5,6)"))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .into_iter()

--- a/crates/rustango/tests/refresh_replicate_sqlite_live.rs
+++ b/crates/rustango/tests/refresh_replicate_sqlite_live.rs
@@ -8,7 +8,7 @@
 //!   `Auto<T>` PKs so the next `save_pool` allocates a fresh
 //!   autoincrement.
 //!
-//! Backend-neutral (the methods route through `QuerySet::fetch_pool`
+//! Backend-neutral (the methods route through `QuerySet::fetch`
 //! + the existing `_pool` save family); SQLite proves the round-trip.
 
 use rustango::sql::{sqlx, Auto, FetcherPool, Pool};
@@ -134,7 +134,7 @@ async fn replicate_resets_auto_pk_and_clones_other_fields() {
 
     // Both rows live in the table.
     let rows: Vec<Post> = rustango::query::QuerySet::<Post>::default()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 2);

--- a/crates/rustango/tests/regex_live.rs
+++ b/crates/rustango/tests/regex_live.rs
@@ -73,7 +73,7 @@ async fn regex_case_sensitive_matches_lowercase_only() {
 
     let rows: Vec<User> = User::objects()
         .where_(User::name.regex("^al.*"))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
 
@@ -91,7 +91,7 @@ async fn iregex_case_insensitive_matches_both_cases() {
 
     let rows: Vec<User> = User::objects()
         .where_(User::name.iregex("^al.*"))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
 
@@ -112,7 +112,7 @@ async fn not_regex_excludes_case_sensitive_matches() {
 
     let rows: Vec<User> = User::objects()
         .where_(User::name.not_regex("^admin"))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
 
@@ -139,7 +139,7 @@ async fn not_iregex_excludes_both_cases() {
 
     let rows: Vec<User> = User::objects()
         .where_(User::name.not_iregex("^admin"))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
 
@@ -165,7 +165,7 @@ async fn filter_string_iregex_routes_at_runtime() {
 
     let rows: Vec<User> = User::objects()
         .filter("name__iregex", "^bob")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
 

--- a/crates/rustango/tests/regex_sqlite_live.rs
+++ b/crates/rustango/tests/regex_sqlite_live.rs
@@ -65,7 +65,7 @@ async fn regex_emission_parses_clean_runtime_error_on_missing_extension() {
 
     let err = User::objects()
         .where_(User::name.regex("^al.*"))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect_err("should error — regexp not registered");
 
@@ -92,7 +92,7 @@ async fn iregex_lower_wrap_parses_clean_runtime_error() {
 
     let err = User::objects()
         .where_(User::name.iregex("^al.*"))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect_err("should error — regexp not registered");
 

--- a/crates/rustango/tests/reverse_relation_sqlite_live.rs
+++ b/crates/rustango/tests/reverse_relation_sqlite_live.rs
@@ -128,7 +128,7 @@ async fn override_emits_custom_named_accessor() {
 
     let ada = QuerySet::<Author>::default()
         .filter("id", ada_pk)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .pop()
@@ -143,7 +143,7 @@ async fn override_emits_custom_named_accessor() {
 
     let grace = QuerySet::<Author>::default()
         .filter("id", grace_pk)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .pop()
@@ -160,7 +160,7 @@ async fn default_name_falls_back_to_child_snake_set() {
 
     let ada = QuerySet::<Author>::default()
         .filter("id", ada_pk)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .pop()

--- a/crates/rustango/tests/select_related_multihop.rs
+++ b/crates/rustango/tests/select_related_multihop.rs
@@ -296,7 +296,7 @@ mod sqlite_live {
         let pool = seeded_pool().await;
         let posts: Vec<Post> = Post::objects()
             .select_related("author__profile__country")
-            .fetch_pool(&pool)
+            .fetch(&pool)
             .await
             .expect("fetch");
         assert_eq!(posts.len(), 1);
@@ -322,7 +322,7 @@ mod sqlite_live {
         let pool = seeded_pool().await;
         let posts: Vec<Post> = Post::objects()
             .select_related("author")
-            .fetch_pool(&pool)
+            .fetch(&pool)
             .await
             .expect("fetch");
         let author = posts[0].author.value().expect("author stitched");
@@ -375,7 +375,7 @@ mod pg_live {
         let pool = Pool::Postgres(pg);
         let posts: Vec<Post> = Post::objects()
             .select_related("author__profile__country")
-            .fetch_pool(&pool)
+            .fetch(&pool)
             .await
             .expect("fetch");
         assert_eq!(posts.len(), 1);
@@ -420,7 +420,7 @@ mod my_live {
         let pool = Pool::Mysql(my);
         let posts: Vec<Post> = Post::objects()
             .select_related("author__profile__country")
-            .fetch_pool(&pool)
+            .fetch(&pool)
             .await
             .expect("fetch");
         assert_eq!(posts.len(), 1);

--- a/crates/rustango/tests/session_user_sqlite_live.rs
+++ b/crates/rustango/tests/session_user_sqlite_live.rs
@@ -5,7 +5,7 @@
 //! behind `#[cfg(feature = "postgres")]` because its inner
 //! User-fetch ran through `pools.acquire(&org)` + `fetch_on(&mut **conn)`,
 //! a PG-specific path. The tri-dialect lift swapped that for
-//! `scoped_pool_dyn` + `fetch_pool`, matching `SessionOperator`'s
+//! `scoped_pool_dyn` + `fetch`, matching `SessionOperator`'s
 //! shape and unblocking sqlite/mysql tenancy builds.
 //!
 //! This test proves the new path compiles + runs end-to-end on
@@ -19,7 +19,7 @@
 //! Anonymous-path validation is sufficient for the cfg-lift contract.
 //! The cookie-decode + user-fetch path goes through
 //! `tenant_console::decode` (dialect-agnostic HMAC) +
-//! `Model::objects().fetch_pool(&pool)` (the same primitive
+//! `Model::objects().fetch(&pool)` (the same primitive
 //! `SessionOperator` already uses successfully on sqlite). PG-specific
 //! regression of the cookie path is covered by the existing PG
 //! integration suite (`auth_live.rs`).

--- a/crates/rustango/tests/soft_delete_pool_instance_sqlite_live.rs
+++ b/crates/rustango/tests/soft_delete_pool_instance_sqlite_live.rs
@@ -68,7 +68,7 @@ async fn soft_delete_pool_marks_row_trashed_but_keeps_in_table() {
     // Row still exists in the table; `active()` excludes it.
     let all_with_trashed: Vec<Post> = QuerySet::<Post>::default()
         .with_trashed()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(all_with_trashed.len(), 1);
@@ -76,7 +76,7 @@ async fn soft_delete_pool_marks_row_trashed_but_keeps_in_table() {
 
     let actives: Vec<Post> = QuerySet::<Post>::default()
         .active()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert!(actives.is_empty(), "active() must hide trashed rows");
@@ -93,7 +93,7 @@ async fn restore_pool_clears_deleted_at_back_to_null() {
     // Re-fetch the trashed version, then restore.
     let trashed: Post = QuerySet::<Post>::default()
         .only_trashed()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .pop()
@@ -104,7 +104,7 @@ async fn restore_pool_clears_deleted_at_back_to_null() {
     // Back to active.
     let actives: Vec<Post> = QuerySet::<Post>::default()
         .active()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(actives.len(), 1);
@@ -123,7 +123,7 @@ async fn force_delete_pool_actually_removes_the_row() {
     // Row is gone for real — not even `with_trashed` brings it back.
     let all: Vec<Post> = QuerySet::<Post>::default()
         .with_trashed()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert!(all.is_empty(), "force_delete_pool removes the row entirely");

--- a/crates/rustango/tests/soft_delete_queryset_sqlite_live.rs
+++ b/crates/rustango/tests/soft_delete_queryset_sqlite_live.rs
@@ -89,7 +89,7 @@ async fn active_filters_to_non_trashed() {
 
     let rows: Vec<Post> = QuerySet::<Post>::default()
         .active()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 3, "expected 3 alive rows: {rows:?}");
@@ -105,7 +105,7 @@ async fn only_trashed_filters_to_trashed() {
 
     let rows: Vec<Post> = QuerySet::<Post>::default()
         .only_trashed()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 2, "expected 2 trashed rows: {rows:?}");
@@ -121,7 +121,7 @@ async fn with_trashed_is_no_op_returning_all_rows() {
 
     let rows: Vec<Post> = QuerySet::<Post>::default()
         .with_trashed()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 5, "with_trashed() should not filter anything");
@@ -138,7 +138,7 @@ async fn active_composes_with_other_filters() {
     let rows: Vec<Post> = QuerySet::<Post>::default()
         .active()
         .filter("title__startswith", "alive")
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 3);
@@ -160,14 +160,14 @@ async fn active_is_noop_on_model_without_soft_delete_column() {
 
     let rows: Vec<Plain> = QuerySet::<Plain>::default()
         .active()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 2);
 
     let rows: Vec<Plain> = QuerySet::<Plain>::default()
         .only_trashed()
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(rows.len(), 2, "only_trashed() no-op on non-SD model");

--- a/crates/rustango/tests/sqlite_live.rs
+++ b/crates/rustango/tests/sqlite_live.rs
@@ -2,8 +2,8 @@
 //!
 //! Runs against an anonymous in-memory SQLite database — no env var,
 //! no external service, no docker. Confirms the bi-dialect surface
-//! (`apply_all_pool` → `insert_pool` → `fetch_pool` → `save_pool` →
-//! `delete_pool` → `count_pool`) reaches the SQLite arms cleanly,
+//! (`apply_all_pool` → `insert_pool` → `fetch` → `save_pool` →
+//! `delete_pool` → `count`) reaches the SQLite arms cleanly,
 //! including `Auto<i64>` PK assignment via `INSERT … RETURNING`.
 
 #![cfg(feature = "sqlite")]
@@ -68,15 +68,12 @@ async fn auto_pk_insert_pool_round_trips() {
     let id = u.id.get().copied().unwrap();
     assert!(id >= 1);
 
-    let n = LiveUser::objects()
-        .count_pool(&pool)
-        .await
-        .expect("count_pool");
+    let n = LiveUser::objects().count(&pool).await.expect("count");
     assert_eq!(n, 1);
 }
 
 #[tokio::test]
-async fn fetch_pool_round_trips_decoded_row() {
+async fn fetch_round_trips_decoded_row() {
     let pool = fresh_pool().await;
 
     let mut u = LiveUser {
@@ -86,10 +83,7 @@ async fn fetch_pool_round_trips_decoded_row() {
     };
     u.insert_pool(&pool).await.expect("insert_pool");
 
-    let users: Vec<LiveUser> = LiveUser::objects()
-        .fetch_pool(&pool)
-        .await
-        .expect("fetch_pool");
+    let users: Vec<LiveUser> = LiveUser::objects().fetch(&pool).await.expect("fetch");
     assert_eq!(users.len(), 1);
     assert_eq!(users[0].name, "bob");
     assert!(!users[0].is_active);
@@ -109,7 +103,7 @@ async fn save_pool_updates_existing_row() {
     u.name = "Carol".into();
     u.save_pool(&pool).await.expect("save_pool");
 
-    let users: Vec<LiveUser> = LiveUser::objects().fetch_pool(&pool).await.expect("fetch");
+    let users: Vec<LiveUser> = LiveUser::objects().fetch(&pool).await.expect("fetch");
     assert_eq!(users.len(), 1);
     assert_eq!(users[0].name, "Carol");
 }
@@ -126,7 +120,7 @@ async fn delete_pool_removes_row() {
     u.insert_pool(&pool).await.expect("insert");
     let affected = u.delete_pool(&pool).await.expect("delete_pool");
     assert_eq!(affected, 1);
-    let n = LiveUser::objects().count_pool(&pool).await.expect("count");
+    let n = LiveUser::objects().count(&pool).await.expect("count");
     assert_eq!(n, 0);
 }
 

--- a/crates/rustango/tests/sqlite_registry_proof_live.rs
+++ b/crates/rustango/tests/sqlite_registry_proof_live.rs
@@ -7,7 +7,7 @@
 //!
 //! ✅ `Org::insert_pool(&Pool::Sqlite(...))` round-trips through
 //!    SQLite's `INSERT ... RETURNING id` (SQLite ≥ 3.35).
-//! ✅ `Org::objects().fetch_pool(&Pool::Sqlite(...))` reads rows back.
+//! ✅ `Org::objects().fetch(&Pool::Sqlite(...))` reads rows back.
 //! ✅ The new `Org.backend_kind` column persists via SQLite TEXT.
 //!
 //! ❌ `TenantPools::registry()` still returns `&PgPool` — apps wanting
@@ -111,7 +111,7 @@ async fn org_insert_and_fetch_against_sqlite_registry() {
     // FETCH through the QuerySet API.
     let rows: Vec<Org> = Org::objects()
         .order_by(&[("slug", false)])
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("fetch");
     assert_eq!(rows.len(), 2);
@@ -121,7 +121,7 @@ async fn org_insert_and_fetch_against_sqlite_registry() {
     // Filtered fetch — confirms WHERE generation lands sqlite syntax.
     let mut just_acme: Vec<Org> = Org::objects()
         .where_(Org::slug.eq("acme".to_owned()))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("filtered fetch");
     assert_eq!(just_acme.len(), 1);
@@ -144,7 +144,7 @@ async fn org_save_against_sqlite_registry() {
 
     let after: Vec<Org> = Org::objects()
         .where_(Org::slug.eq("acme".to_owned()))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .expect("refetch");
     assert_eq!(after.len(), 1);

--- a/crates/rustango/tests/subquery_join_lateral_pg_live.rs
+++ b/crates/rustango/tests/subquery_join_lateral_pg_live.rs
@@ -107,7 +107,7 @@ async fn join_lateral_correlates_to_outer_and_filters() {
 
     let rows = Customer::objects()
         .join_lateral(latest, "lo", WhereExpr::And(vec![]))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
 
@@ -148,7 +148,7 @@ async fn left_join_lateral_keeps_all_customers() {
 
     let rows = Customer::objects()
         .left_join_lateral(latest, "lo", WhereExpr::And(vec![]))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
 

--- a/crates/rustango/tests/subquery_join_sqlite_live.rs
+++ b/crates/rustango/tests/subquery_join_sqlite_live.rs
@@ -83,7 +83,7 @@ async fn join_sub_filters_to_customers_with_orders() {
                 rhs: aliased("sj_customer", "id"),
             },
         )
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
 
@@ -113,7 +113,7 @@ async fn left_join_sub_keeps_unmatched_rows() {
                 rhs: aliased("sj_customer", "id"),
             },
         )
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     // Alice matches her order; Bob is preserved by the LEFT JOIN.
@@ -129,7 +129,7 @@ async fn join_lateral_errors_on_sqlite() {
     let sub = Order::objects().compile().unwrap();
     let err = Customer::objects()
         .join_lateral(sub, "lo", WhereExpr::And(vec![]))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap_err();
     assert!(

--- a/crates/rustango/tests/tx_methods_sqlite_live.rs
+++ b/crates/rustango/tests/tx_methods_sqlite_live.rs
@@ -68,9 +68,9 @@ async fn tx_insert_save_delete_commit_round_trip() {
 
     let after: Vec<Widget> = Widget::objects()
         .where_(Widget::id.eq(id))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
-        .expect("post-commit fetch_pool");
+        .expect("post-commit fetch");
     assert_eq!(after.len(), 1);
     assert_eq!(after[0].count, 42);
 
@@ -81,9 +81,9 @@ async fn tx_insert_save_delete_commit_round_trip() {
 
     let gone: Vec<Widget> = Widget::objects()
         .where_(Widget::id.eq(id))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
-        .expect("post-delete fetch_pool");
+        .expect("post-delete fetch");
     assert!(gone.is_empty(), "row truly deleted");
 }
 
@@ -104,9 +104,9 @@ async fn tx_rollback_discards_writes() {
 
     let rows: Vec<Widget> = Widget::objects()
         .where_(Widget::id.eq(id))
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
-        .expect("post-rollback fetch_pool");
+        .expect("post-rollback fetch");
     assert!(rows.is_empty(), "rollback discarded the insert");
 }
 

--- a/crates/rustango/tests/vector_pgvector_pg_live.rs
+++ b/crates/rustango/tests/vector_pgvector_pg_live.rs
@@ -69,7 +69,7 @@ async fn vector_column_round_trip_and_knn() {
     use rustango::core::VectorMetric;
     let nearest: Vec<String> = Doc::objects()
         .k_nearest("embedding", vec![1.0, 0.0, 0.0], 2, VectorMetric::L2)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap()
         .into_iter()
@@ -80,7 +80,7 @@ async fn vector_column_round_trip_and_knn() {
     // Full ordering across all three, + typed decode of the embedding.
     let all: Vec<Doc> = Doc::objects()
         .order_by_distance("embedding", vec![1.0, 0.0, 0.0], VectorMetric::L2)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     let order: Vec<&str> = all.iter().map(|d| d.title.as_str()).collect();
@@ -95,7 +95,7 @@ async fn vector_column_round_trip_and_knn() {
     // Cosine ordering ranks A first too (identical direction → 0 distance).
     let cos_first = Doc::objects()
         .k_nearest("embedding", vec![1.0, 0.0, 0.0], 1, VectorMetric::Cosine)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .unwrap();
     assert_eq!(cos_first[0].title, "A");

--- a/examples/showcase/Cargo.lock
+++ b/examples/showcase/Cargo.lock
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.41.0"
+version = "0.43.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1855,6 +1855,7 @@ dependencies = [
  "subtle",
  "tera",
  "thiserror 1.0.69",
+ "time",
  "tokio",
  "toml",
  "tower",
@@ -1866,8 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.41.0"
+version = "0.43.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "serde_json",

--- a/examples/showcase/src/apps/accounts/urls.rs
+++ b/examples/showcase/src/apps/accounts/urls.rs
@@ -117,7 +117,7 @@ async fn register(
     };
     let mut rows: Vec<User> = User::objects()
         .filter_op("id", Op::Eq, id)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     let stored = rows.pop().ok_or((
@@ -146,7 +146,7 @@ async fn login(
     let pool = into_pool(&pool);
     let mut rows: Vec<User> = User::objects()
         .filter_op("username", Op::Eq, input.username.clone())
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     let user = rows
@@ -162,10 +162,7 @@ async fn login(
     let id = match user.id {
         Auto::Set(n) => n,
         Auto::Unset => {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "user has no PK".into(),
-            ));
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, "user has no PK".into()));
         }
     };
     let claims = Claims::new(id.to_string())
@@ -195,7 +192,8 @@ async fn me(
             "missing or malformed Authorization header".into(),
         ))?;
 
-    let claims = decode(token, &jwt_secret()).map_err(|e| (StatusCode::UNAUTHORIZED, e.to_string()))?;
+    let claims =
+        decode(token, &jwt_secret()).map_err(|e| (StatusCode::UNAUTHORIZED, e.to_string()))?;
     let id: i64 = claims
         .subject()
         .and_then(|s| s.parse().ok())
@@ -203,7 +201,7 @@ async fn me(
 
     let mut rows: Vec<User> = User::objects()
         .filter_op("id", Op::Eq, id)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     let user = rows

--- a/examples/showcase/src/apps/blog/urls.rs
+++ b/examples/showcase/src/apps/blog/urls.rs
@@ -85,7 +85,7 @@ async fn list_posts(
     let pool = into_pool(&pool);
     let posts: Vec<Post> = Post::objects()
         .order_by(&[("id", false)]) // ASC — natural list order
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(Json(posts.into_iter().map(PostOut::from).collect()))
@@ -98,7 +98,7 @@ async fn retrieve_post(
     let pool = into_pool(&pool);
     let mut rows: Vec<Post> = Post::objects()
         .filter_op("id", Op::Eq, id)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     if let Some(p) = rows.pop() {
@@ -140,7 +140,7 @@ async fn create_post(
     };
     let mut rows: Vec<Post> = Post::objects()
         .filter_op("id", Op::Eq, id)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     let stored = rows.pop().ok_or((

--- a/examples/showcase/src/apps/mod.rs
+++ b/examples/showcase/src/apps/mod.rs
@@ -27,10 +27,7 @@ pub fn api() -> Router {
 /// Smoke endpoint — used by the E2E playwright suite's readiness
 /// probe + by the matrix job to assert which backend it ran against.
 async fn info() -> Json<serde_json::Value> {
-    let backend = match std::env::var("DATABASE_URL")
-        .unwrap_or_default()
-        .as_str()
-    {
+    let backend = match std::env::var("DATABASE_URL").unwrap_or_default().as_str() {
         u if u.starts_with("postgres://") || u.starts_with("postgresql://") => "postgres",
         u if u.starts_with("mysql://") || u.starts_with("mariadb://") => "mysql",
         u if u.starts_with("sqlite:") => "sqlite",

--- a/examples/showcase/src/apps/shop/urls.rs
+++ b/examples/showcase/src/apps/shop/urls.rs
@@ -35,10 +35,7 @@ fn into_pool(p: &AttachedPool) -> Pool {
 #[must_use]
 pub fn api() -> Router {
     Router::new()
-        .route(
-            "/shop/products",
-            get(list_products).post(create_product),
-        )
+        .route("/shop/products", get(list_products).post(create_product))
         .route("/shop/products/{id}", get(retrieve_product))
 }
 
@@ -99,7 +96,7 @@ async fn list_products(
         qs = qs.filter_op("active", Op::Eq, want_active);
     }
     let rows: Vec<Product> = qs
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(Json(rows.into_iter().map(ProductOut::from).collect()))
@@ -112,7 +109,7 @@ async fn retrieve_product(
     let pool = into_pool(&pool);
     let mut rows: Vec<Product> = Product::objects()
         .filter_op("id", Op::Eq, id)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     if let Some(p) = rows.pop() {
@@ -151,7 +148,7 @@ async fn create_product(
     };
     let mut rows: Vec<Product> = Product::objects()
         .filter_op("id", Op::Eq, id)
-        .fetch_pool(&pool)
+        .fetch(&pool)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     let stored = rows.pop().ok_or((

--- a/examples/showcase/src/main.rs
+++ b/examples/showcase/src/main.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rustango::manage::Cli::new()
         .api(apps::api())
-        .migrations_dir(
-            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"),
-        )
+        .migrations_dir(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"))
         .run()
         .await
 }


### PR DESCRIPTION
## What

Removes the `_pool` suffix from the three QuerySet terminal methods where it was pure clutter:

| before | after |
|---|---|
| `FetcherPool::fetch_pool` | `fetch` |
| `CounterPool::count_pool` | `count` |
| `ExistsPool::exists_pool` | `exists` |

Each had a free bare name (the only sibling is the `_on` executor variant), and their doc-links pointed at nonexistent `Fetcher`/`Counter` traits (now fixed to the real `FetcherPool`/`CounterPool`). Trait names are unchanged. Updates all call sites, the `quote!` emissions in `rustango-macros` (relation accessors + managers), intra-doc links, and stale test names.

## Breaking

`fetch_pool` / `count_pool` / `exists_pool` are removed — use the bare names.

## Deliberately NOT changed

`save_pool` / `insert_pool` / `delete_pool` keep the suffix. Their bare siblings `save`/`insert`/`delete` are real, distinct, `#[cfg(feature = "postgres")]`-gated methods taking `&PgPool`, while the `_pool` versions take `&Pool` (multi-backend). The suffix discriminates PG-only vs all-backends here; retiring it is the separate v0.40 plug-and-play DB refactor.

## Verification

`cargo check --workspace --all-features --all-targets` clean. Pre-push hook: `cargo check --all-features` + clippy + `cargo test --lib` (3386 passed, 0 failed).