### PR TITLE
feat(orm): chain multiple relation aggregates in one query — closes #1038

### DIFF
--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1861,27 +1861,7 @@ impl<T: Model> QuerySet<T> {
     #[must_use]
     pub fn annotate_exists(self, name: &str) -> AggregateBuilder<T> {
         let mut builder = self.aggregate();
-        // Reuse the existence resolver (reverse-FK / M2M / GFK), then
-        // wrap whatever `[NOT ]EXISTS` it produced in a `CASE WHEN …
-        // THEN 1 ELSE 0` so it projects as an `I64(0|1)` column.
-        match Self::resolve_rel_exists(name, /*negated=*/ false) {
-            Some(exists) => {
-                let expr = AggregateExpr::RelatedAggregate(Box::new(
-                    crate::core::subquery::exists_as_int(exists),
-                ));
-                builder
-                    .aggregates
-                    .push((std::borrow::Cow::Owned(format!("{name}_exists")), expr));
-            }
-            None => {
-                builder
-                    .deferred_error
-                    .get_or_insert(QueryError::UnknownField {
-                        model: T::SCHEMA.name,
-                        field: name.to_owned(),
-                    });
-            }
-        }
+        builder.push_relation_exists(name);
         builder
     }
 
@@ -1904,91 +1884,11 @@ impl<T: Model> QuerySet<T> {
         agg: AggregateExpr,
         suffix: &str,
     ) -> AggregateBuilder<T> {
-        use crate::core::{subquery, RelAggKind};
+        // #1038 — the resolve-and-push worker lives on `AggregateBuilder`
+        // so it can be chained more than once (two relation aggregates in
+        // one query). QuerySet entry just opens a builder and delegates.
         let mut builder = self.aggregate();
-        // `<name>_count` (no column) or `<name>_<suffix>_<column>`.
-        let alias = || match column {
-            Some(col) => std::borrow::Cow::Owned(format!("{name}_{suffix}_{col}")),
-            None => std::borrow::Cow::Owned(format!("{name}_{suffix}")),
-        };
-        // Map the reverse-FK `AggregateExpr` onto the raw-table
-        // `RelAggKind` used by the M2M / GFK builders.
-        let rel_kind = |a: &AggregateExpr| match a {
-            AggregateExpr::Sum(_) => RelAggKind::Sum,
-            AggregateExpr::Avg(_) => RelAggKind::Avg,
-            AggregateExpr::Max(_) => RelAggKind::Max,
-            AggregateExpr::Min(_) => RelAggKind::Min,
-            _ => RelAggKind::Count,
-        };
-
-        // Reverse-FK relation — aggregate over the child table directly.
-        if let Some(rel) = T::reverse_relations().iter().find(|r| r.name == name) {
-            if let Some(col) = column {
-                if rel.child_schema.field_by_column(col).is_none() {
-                    builder
-                        .deferred_error
-                        .get_or_insert(QueryError::UnknownField {
-                            model: rel.child_schema.name,
-                            field: col.to_owned(),
-                        });
-                    return builder;
-                }
-            }
-            let expr = AggregateExpr::RelatedAggregate(Box::new(subquery::reverse_has_aggregate(
-                rel, agg,
-            )));
-            builder.aggregates.push((alias(), expr));
-            return builder;
-        }
-
-        // Many-to-many — `Count` over the junction; `Sum`/`Avg`/`Max`/
-        // `Min` over a target column reached through the junction. The
-        // target table has no `ModelSchema`, so `column` can't be
-        // validated here (a bad column surfaces at the database).
-        if let Some(m2m) = T::SCHEMA.m2m.iter().find(|m| m.name == name) {
-            let expr = AggregateExpr::RelatedAggregate(Box::new(subquery::m2m_has_aggregate(
-                m2m,
-                Self::self_pk_column(),
-                rel_kind(&agg),
-                column,
-            )));
-            builder.aggregates.push((alias(), expr));
-            return builder;
-        }
-
-        // Generic-FK — aggregate over the polymorphic child table,
-        // discriminated by content type.
-        if let Some(g) = T::generic_reverse_relations()
-            .iter()
-            .find(|g| g.name == name)
-        {
-            if let Some(col) = column {
-                if g.child_schema.field_by_column(col).is_none() {
-                    builder
-                        .deferred_error
-                        .get_or_insert(QueryError::UnknownField {
-                            model: g.child_schema.name,
-                            field: col.to_owned(),
-                        });
-                    return builder;
-                }
-            }
-            let expr = AggregateExpr::RelatedAggregate(Box::new(subquery::generic_has_aggregate(
-                g,
-                T::SCHEMA.table,
-                rel_kind(&agg),
-                column,
-            )));
-            builder.aggregates.push((alias(), expr));
-            return builder;
-        }
-
-        builder
-            .deferred_error
-            .get_or_insert(QueryError::UnknownField {
-                model: T::SCHEMA.name,
-                field: name.to_owned(),
-            });
+        builder.push_relation_aggregate(name, column, agg, suffix);
         builder
     }
 
@@ -3941,6 +3841,165 @@ impl<T: Model> AggregateBuilder<T> {
     #[must_use]
     pub fn annotate_subquery(self, alias: &'static str, inner: crate::core::SelectQuery) -> Self {
         self.annotate(alias, crate::core::subquery::scalar_subquery(inner))
+    }
+
+    /// #1038 — resolve a relation `name` (reverse-FK / M2M / generic-FK)
+    /// into a correlated `RelatedAggregate` and stage it on this builder.
+    /// Shared with [`QuerySet::annotate_count`] & co. so a relation
+    /// aggregate can be chained more than once in a single query. Errors
+    /// are deferred onto `self.deferred_error` to surface from `compile()`.
+    fn push_relation_aggregate(
+        &mut self,
+        name: &str,
+        column: Option<&'static str>,
+        agg: AggregateExpr,
+        suffix: &str,
+    ) {
+        use crate::core::{subquery, RelAggKind};
+        // `<name>_count` (no column) or `<name>_<suffix>_<column>`.
+        let alias = || match column {
+            Some(col) => std::borrow::Cow::Owned(format!("{name}_{suffix}_{col}")),
+            None => std::borrow::Cow::Owned(format!("{name}_{suffix}")),
+        };
+        let rel_kind = |a: &AggregateExpr| match a {
+            AggregateExpr::Sum(_) => RelAggKind::Sum,
+            AggregateExpr::Avg(_) => RelAggKind::Avg,
+            AggregateExpr::Max(_) => RelAggKind::Max,
+            AggregateExpr::Min(_) => RelAggKind::Min,
+            _ => RelAggKind::Count,
+        };
+
+        // Reverse-FK relation — aggregate over the child table directly.
+        if let Some(rel) = T::reverse_relations().iter().find(|r| r.name == name) {
+            if let Some(col) = column {
+                if rel.child_schema.field_by_column(col).is_none() {
+                    self.deferred_error.get_or_insert(QueryError::UnknownField {
+                        model: rel.child_schema.name,
+                        field: col.to_owned(),
+                    });
+                    return;
+                }
+            }
+            let expr = AggregateExpr::RelatedAggregate(Box::new(subquery::reverse_has_aggregate(
+                rel, agg,
+            )));
+            self.aggregates.push((alias(), expr));
+            return;
+        }
+
+        // Many-to-many — `Count` over the junction; `Sum`/`Avg`/`Max`/
+        // `Min` over a target column reached through the junction. The
+        // target table has no `ModelSchema`, so `column` can't be
+        // validated here (a bad column surfaces at the database).
+        if let Some(m2m) = T::SCHEMA.m2m.iter().find(|m| m.name == name) {
+            let pk = T::SCHEMA.primary_key().map_or("id", |f| f.column);
+            let expr = AggregateExpr::RelatedAggregate(Box::new(subquery::m2m_has_aggregate(
+                m2m,
+                pk,
+                rel_kind(&agg),
+                column,
+            )));
+            self.aggregates.push((alias(), expr));
+            return;
+        }
+
+        // Generic-FK — aggregate over the polymorphic child table,
+        // discriminated by content type.
+        if let Some(g) = T::generic_reverse_relations()
+            .iter()
+            .find(|g| g.name == name)
+        {
+            if let Some(col) = column {
+                if g.child_schema.field_by_column(col).is_none() {
+                    self.deferred_error.get_or_insert(QueryError::UnknownField {
+                        model: g.child_schema.name,
+                        field: col.to_owned(),
+                    });
+                    return;
+                }
+            }
+            let expr = AggregateExpr::RelatedAggregate(Box::new(subquery::generic_has_aggregate(
+                g,
+                T::SCHEMA.table,
+                rel_kind(&agg),
+                column,
+            )));
+            self.aggregates.push((alias(), expr));
+            return;
+        }
+
+        self.deferred_error.get_or_insert(QueryError::UnknownField {
+            model: T::SCHEMA.name,
+            field: name.to_owned(),
+        });
+    }
+
+    /// #1038 — `<name>_exists` companion of [`Self::push_relation_aggregate`]
+    /// (the `CASE WHEN EXISTS(...) THEN 1 ELSE 0` projection). Reuses the
+    /// `QuerySet` existence resolver so the reverse-FK / M2M / GFK logic
+    /// lives in one place.
+    fn push_relation_exists(&mut self, name: &str) {
+        match QuerySet::<T>::resolve_rel_exists(name, /*negated=*/ false) {
+            Some(exists) => {
+                let expr = AggregateExpr::RelatedAggregate(Box::new(
+                    crate::core::subquery::exists_as_int(exists),
+                ));
+                self.aggregates
+                    .push((std::borrow::Cow::Owned(format!("{name}_exists")), expr));
+            }
+            None => {
+                self.deferred_error.get_or_insert(QueryError::UnknownField {
+                    model: T::SCHEMA.name,
+                    field: name.to_owned(),
+                });
+            }
+        }
+    }
+
+    /// Chain a relation `COUNT` onto an existing aggregate builder
+    /// (#1038) — mirrors [`QuerySet::annotate_count`] so two relation
+    /// counts compose in ONE query:
+    /// `Post::objects().annotate_count("comments").annotate_count("likes")`.
+    #[must_use]
+    pub fn annotate_count(mut self, name: &str) -> Self {
+        self.push_relation_aggregate(name, None, AggregateExpr::Count(None), "count");
+        self
+    }
+
+    /// Chain a relation `SUM(<column>)` (#1038). See [`QuerySet::annotate_sum`].
+    #[must_use]
+    pub fn annotate_sum(mut self, name: &str, column: &'static str) -> Self {
+        self.push_relation_aggregate(name, Some(column), AggregateExpr::Sum(column), "sum");
+        self
+    }
+
+    /// Chain a relation `AVG(<column>)` (#1038). See [`QuerySet::annotate_avg`].
+    #[must_use]
+    pub fn annotate_avg(mut self, name: &str, column: &'static str) -> Self {
+        self.push_relation_aggregate(name, Some(column), AggregateExpr::Avg(column), "avg");
+        self
+    }
+
+    /// Chain a relation `MAX(<column>)` (#1038). See [`QuerySet::annotate_max`].
+    #[must_use]
+    pub fn annotate_max(mut self, name: &str, column: &'static str) -> Self {
+        self.push_relation_aggregate(name, Some(column), AggregateExpr::Max(column), "max");
+        self
+    }
+
+    /// Chain a relation `MIN(<column>)` (#1038). See [`QuerySet::annotate_min`].
+    #[must_use]
+    pub fn annotate_min(mut self, name: &str, column: &'static str) -> Self {
+        self.push_relation_aggregate(name, Some(column), AggregateExpr::Min(column), "min");
+        self
+    }
+
+    /// Chain a relation `<name>_exists` projection (#1038). See
+    /// [`QuerySet::annotate_exists`].
+    #[must_use]
+    pub fn annotate_exists(mut self, name: &str) -> Self {
+        self.push_relation_exists(name);
+        self
     }
 
     /// Django 3.2 `.alias()` — annotate without projecting. The expression

--- a/crates/rustango/tests/django6_joins.rs
+++ b/crates/rustango/tests/django6_joins.rs
@@ -19,10 +19,10 @@
 //!   so they can never inflate
 //!
 //! AUDIT NOTES:
-//! - Two relation-counts in ONE query (`annotate_count` twice) is not
-//!   expressible — `annotate_count` lives on `QuerySet` and returns an
-//!   `AggregateBuilder` with no further relation-annotate methods. One
-//!   relation aggregate per query today. Issue #1038.
+//! - Two relation aggregates in ONE query now compose —
+//!   `AggregateBuilder::annotate_count` / `annotate_sum` / … chain off
+//!   the first relation annotate (#1038, shipped). Each lowers to its own
+//!   correlated subquery, so neither inflates.
 //! - Ad-hoc `.join()` does not compose with `.aggregate()` —
 //!   `AggregateQuery` carries no joins, so Django's join+GROUP BY
 //!   aggregate shape (`values("author__name").annotate(Count)`) must
@@ -284,40 +284,48 @@ mod scenarios {
     }
 
     /// The Django join-duplication trap: `annotate(nc=Count("comments"),
-    /// nl=Count("likes"))` without `distinct=True` returns 6/6 for a
-    /// post with 3 comments × 2 likes. rustango's relation counts are
-    /// correlated subqueries — structurally immune. (One relation
-    /// aggregate per query — see AUDIT NOTES in the file header.)
+    /// nl=Count("likes"))` without `distinct=True` returns 6/6 for a post
+    /// with 3 comments × 2 likes. rustango lowers relation aggregates to
+    /// correlated subqueries — structurally immune — and #1038 lets two
+    /// of them chain in ONE query (`AggregateBuilder::annotate_count`).
     pub async fn check_relation_counts_never_inflate(pool: &Pool) {
-        let comment_rows = Post::objects()
+        // Two relation counts in ONE query (#1038). Post 1 has 3 comments
+        // + 2 likes, Post 2 has 0 comments + 1 like — never 6/6.
+        let rows = Post::objects()
             .annotate_count("comments")
-            .order_by(&[("id", false)])
-            .fetch(pool)
-            .await
-            .expect("comments_count");
-        let n_comments: Vec<i64> = comment_rows
-            .iter()
-            .map(|r| match r.get("comments_count") {
-                Some(SqlValue::I64(n)) => *n,
-                other => panic!("expected I64 comments_count, got {other:?}"),
-            })
-            .collect();
-        assert_eq!(n_comments, vec![3, 0], "never 6 — no JOIN duplication");
-
-        let like_rows = Post::objects()
             .annotate_count("likes")
             .order_by(&[("id", false)])
             .fetch(pool)
             .await
-            .expect("likes_count");
-        let n_likes: Vec<i64> = like_rows
+            .expect("two relation counts in one query");
+        let pair = |r: &std::collections::HashMap<String, SqlValue>, k: &str| match r.get(k) {
+            Some(SqlValue::I64(n)) => *n,
+            other => panic!("expected I64 {k}, got {other:?}"),
+        };
+        let counts: Vec<(i64, i64)> = rows
             .iter()
-            .map(|r| match r.get("likes_count") {
-                Some(SqlValue::I64(n)) => *n,
-                other => panic!("expected I64 likes_count, got {other:?}"),
-            })
+            .map(|r| (pair(r, "comments_count"), pair(r, "likes_count")))
             .collect();
-        assert_eq!(n_likes, vec![2, 1]);
+        assert_eq!(
+            counts,
+            vec![(3, 2), (0, 1)],
+            "correlated subqueries never inflate to 6/6"
+        );
+
+        // Mixed count + sum in one pass: Post 1's comment scores 5+12+20.
+        let rows = Post::objects()
+            .annotate_count("comments")
+            .annotate_sum("comments", "score")
+            .order_by(&[("id", false)])
+            .fetch(pool)
+            .await
+            .expect("count + sum in one query");
+        assert_eq!(pair(&rows[0], "comments_count"), 3);
+        assert_eq!(
+            pair(&rows[0], "comments_sum_score"),
+            37,
+            "sum of comment scores 5+12+20"
+        );
     }
 }
 

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -873,7 +873,7 @@ Status per scenario group (PG / SQLite / MySQL). ✓ = passes asserting Django-e
 | B. Correlated subqueries | `Exists`+`OuterRef` (raw + typed `eq_expr`), NOT EXISTS, exclude-on-relation semantics, `IN (SELECT…)`, has-count, `annotate_count`, scalar `Subquery` in WHERE | ✓ | ✓ | ✓ | `django6_subquery.rs` | `where_doesnt_have_filter` reproduces Django's exclude-NOT-EXISTS semantics exactly (bookless parents included). `OuterRef` misuse pinned (`OuterRefOutsideSubquery`). Scalar `Subquery` as projected annotation inexpressible — #1036. |
 | C. Window functions | rank/dense_rank/lag(default)/first_value+ROWS frame/ntile, partitioned | ✓ | ✓ | ✓* | `django6_window.rs` | *MySQL ranking outputs decode as `SqlValue::Bool` (#1033, pinned). Required shape: `.aggregate().group_by(<every projected col>)`. `Sum(...) OVER` + windowed-subquery missing (#1035); top-N-per-group via `join_lateral` works PG/MySQL, `LateralJoinNotSupported` pinned on SQLite. |
 | K. distinct_on | first-row-per-group, +join | ✓ | ✓ (window fallback) | ✓ (window fallback) | `django6_window.rs` | Fallback rejects joins — pinned `OpNotSupportedInDialect` on SQLite/MySQL (#1039); PG native handles joins. |
-| D. Multi-join | 3-hop `select_related` stitching, cross-table filter via `.join()`+`aliased`, F-across-join, relation-count inflation | ✓ | ✓ | ✓ | `django6_joins.rs` | Relation-spanning `filter("author__name",…)` (Part 1) + `order_by("author__name")` (Part 2) now resolve the FK chain into LEFT JOINs — #1031 (`__in`/`__isnull`/`__between` on spans remain, Part 3). `annotate_count` never inflates (correlated subquery ≡ Django `distinct=True`). One relation aggregate per query (#1038); `.join()` doesn't compose with `.aggregate()` — `values("author__name").annotate(Count)` shape inexpressible (#1040). |
+| D. Multi-join | 3-hop `select_related` stitching, cross-table filter via `.join()`+`aliased`, F-across-join, relation-count inflation | ✓ | ✓ | ✓ | `django6_joins.rs` | Relation-spanning `filter("author__name",…)` (Part 1) + `order_by("author__name")` (Part 2) now resolve the FK chain into LEFT JOINs — #1031 (`__in`/`__isnull`/`__between` on spans remain, Part 3). `annotate_count` never inflates (correlated subquery ≡ Django `distinct=True`), and two relation aggregates now chain in one query (#1038, shipped). Remaining: `.join()` doesn't compose with `.aggregate()` — `values("author__name").annotate(Count)` group-by-on-related-column shape inexpressible (#1040). |
 | E. Set operations | union dedup/all, per-branch + combined ORDER/LIMIT, intersection, difference, `with_compound` | ✓ | ✓ | ✓* | `django6_setops.rs` | *Ordered/limited branches broken on MySQL — alias-less derived table, error 1248 (#1032, pinned). First-queryset ORDER/LIMIT always combined-scoped (#1034, pinned). INTERSECT/EXCEPT floor: MySQL 8.0.31+. |
 | G. JSON lookups | nested keys, key+index, array length, negative index | ✓ | ✓ (neg. index pinned) | ✓ (neg. index pinned) | `django6_json_dates.rs` | Negative index PG-only — #1027 (Django 6.0 supports SQLite). |
 | H. Date transforms | `__year__gte` chains, `__month`, `__quarter`, `.dates()`, `.datetimes()` | ✓ | ✓ (`__quarter` pinned) | ✓ | `django6_json_dates.rs` | `__quarter` errors on SQLite — #1037. `.dates()/.datetimes()` truncation identical tri-dialect. |
@@ -891,7 +891,7 @@ Status per scenario group (PG / SQLite / MySQL). ✓ = passes asserting Django-e
 
 - `.values(cols)` + window-only annotate → `QueryError::ValuesRequiresAggregate`; explicit `group_by` per projected column is the canonical window shape.
 - Inside a `.join()` `on` predicate, bare `Expr::Column` qualifies to the **joined** alias — refer to the outer table via `joins::aliased("<outer_table>", col)`.
-- `annotate_count`/`annotate_sum`… live on `QuerySet` and return `AggregateBuilder` — two relation aggregates in one query is not expressible (#1038); grouping by a related column (`values("author__name").annotate(...)`) is also inexpressible since `AggregateQuery` carries no joins (#1040).
+- `annotate_count`/`annotate_sum`… also live on `AggregateBuilder` now, so two relation aggregates compose in one query (#1038, shipped). Grouping by a related column (`values("author__name").annotate(...)`) is still inexpressible since `AggregateQuery` carries no joins (#1040).
 - Aggregate `.filter()` builder + `WindowBuilder`/`StringAgg` wrappers reject nesting (`NestedAggregateWrapper`) — Django's `StringAgg(..., filter=...)` shape included.
 
 ### 26.5 Refresh 2026-06-15 — what shipped since the 2026-06-12 execution pass
@@ -913,7 +913,8 @@ The 2026-06-12 pass (§26.1–§26.4) pinned a batch of gaps as live issues. PRs
 | #1036 | scalar `Subquery` as a projected annotation | #1049 |
 | #1037 | `__quarter` synthesized on SQLite | #1041 |
 | #1031 **Part 1** | relation-spanning lookups in `filter()`/`exclude()` (`author__name__icontains`) | #1051 |
-| #1031 **Part 2** | relation-spanning `order_by("author__name")` (shared `resolve_span_chain` walk) | this PR |
+| #1031 **Part 2** | relation-spanning `order_by("author__name")` (shared `resolve_span_chain` walk) | #1057 |
+| #1038 | two relation aggregates in one query (chained `AggregateBuilder::annotate_count`/`_sum`/…) | this PR |
 | #1035 **Part A** | aggregate-as-window (`Sum/Avg/Min/Max/Count OVER`) | #1050 |
 | #1011 | in-admin model reference (admindocs) | #1023 |
 | #1010 | DRF epic — per-action throttling (#1022) + pluggable filter backends (#1021) | (epic closed) |
@@ -926,7 +927,6 @@ The 2026-06-12 pass (§26.1–§26.4) pinned a batch of gaps as live issues. PRs
 - [#1029](https://github.com/ujeenet/rustango/issues/1029) — surface `rows_affected` from `Model::save` update path (Django 6.0 `Model.NotUpdated`).
 - [#1031](https://github.com/ujeenet/rustango/issues/1031) **Part 3** — `__in` / `__isnull` / `__between` on relation spans (`filter`/`exclude` Part 1 + `order_by` Part 2 shipped; the binary + LIKE-family ops work, these non-binary ops against an aliased column remain).
 - [#1035](https://github.com/ujeenet/rustango/issues/1035) **remaining** — windowed query as a subquery source (top-N-per-group); aggregate-as-window shipped in Part A.
-- [#1038](https://github.com/ujeenet/rustango/issues/1038) — two relation-aggregate chains (`annotate_count` + `annotate_sum`) in one query.
 - [#1039](https://github.com/ujeenet/rustango/issues/1039) — `distinct_on` window fallback supporting joins on MySQL/SQLite.
 - [#1040](https://github.com/ujeenet/rustango/issues/1040) — `AggregateQuery` joins — `values("author__name").annotate(Count)` group-by-on-related-column shape.
 


### PR DESCRIPTION
Closes #1038. `Post::objects().annotate_count("comments").annotate_count("likes")` now works in **one query** — Djangos `annotate(Count("comments"), Count("likes"))` shape.

## What
`annotate_count` / `annotate_sum` / `annotate_avg` / `annotate_max` / `annotate_min` / `annotate_exists` now also exist on **`AggregateBuilder<T>`**, so a relation aggregate can be chained after the first one. Each lowers to its own correlated subquery, so two counts never inflate each other (the JOIN-duplication trap stays structurally impossible).

## How
- Factored the resolve-and-push worker out of `QuerySet::annotate_relation_aggregate` into **`AggregateBuilder::push_relation_aggregate`** (+ `push_relation_exists`); the QuerySet entry points and the new builder-chained variants now share one resolver — no duplication, cant drift.
- `self_pk_column()` inlined as `T::SCHEMA.primary_key()` on the builder side (it was pure type-level already).
- Purely additive — no breaking change.

## Tests
Flips `tests/django6_joins.rs::check_relation_counts_never_inflate` from two separate queries to **one** query asserting `[(comments=3, likes=2), (0, 1)]`, plus a mixed `count + sum` pass (sum of comment scores = 37) — tri-dialect (PG/MySQL/SQLite). Local: sqlite `django6_joins` 6/6; `cargo check --workspace --all-features --all-targets` clean.

## Scope
Parity audit §26.2-D / §26.4 / §26.5 updated. Sibling gap #1040 (group-by-on-related-column — `AggregateQuery` carries no joins) remains open and is the natural next step.