### PR TITLE
feat(orm): group by a related column — AggregateQuery joins (closes #1040)

### DIFF
--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -1729,8 +1729,15 @@ impl AggregateExpr {
 #[derive(Debug, Clone)]
 pub struct AggregateQuery {
     pub model: &'static ModelSchema,
+    /// FK-chain / ad-hoc JOINs (#1040) — lets an aggregate group by a
+    /// *related* column (`values("author.name").annotate(Count)`). Empty
+    /// for the common single-table aggregate. Emitted between `FROM` and
+    /// `WHERE`, same shape as [`SelectQuery::joins`].
+    pub joins: Vec<Join>,
     pub where_clause: WhereExpr,
-    /// Columns to group by. Must be valid column names on `model`.
+    /// Columns to group by. A bare name (`"status"`) is a column on
+    /// `model`; a dotted name (`"author.name"`) references a JOINed
+    /// alias (#1040) and is emitted qualified + skips model validation.
     pub group_by: Vec<&'static str>,
     /// `(alias, expr)` pairs — the alias becomes the key in each result row.
     ///
@@ -1765,6 +1772,7 @@ pub struct AggregateQuery {
 impl PartialEq for AggregateQuery {
     fn eq(&self, other: &Self) -> bool {
         std::ptr::eq(self.model, other.model)
+            && self.joins == other.joins
             && self.where_clause == other.where_clause
             && self.group_by == other.group_by
             && self.aggregates == other.aggregates

--- a/crates/rustango/src/core/subquery.rs
+++ b/crates/rustango/src/core/subquery.rs
@@ -213,6 +213,7 @@ pub fn reverse_has_not_exists(rel: &ReverseRelation) -> WhereExpr {
 pub fn reverse_has_aggregate(rel: &ReverseRelation, agg: AggregateExpr) -> Expr {
     let inner = AggregateQuery {
         model: rel.child_schema,
+        joins: Vec::new(),
         where_clause: WhereExpr::ExprCompare {
             lhs: Expr::Column(rel.child_fk_column),
             op: Op::Eq,

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -4200,6 +4200,10 @@ impl<T: Model> AggregateBuilder<T> {
         // against a `published_only`-scoped model counts published
         // rows only, not the table's full row count).
         self.qs.apply_global_scopes();
+        // #1040 — carry the QuerySet's ad-hoc JOINs into the aggregate so
+        // it can group by a related column (`group_by("author.name")`).
+        // Empty for the common single-table aggregate.
+        let joins = std::mem::take(&mut self.qs.ad_hoc_joins);
         let model = T::SCHEMA;
         let where_clause = resolve_pending(model, self.qs.pending)?;
         // Walk each AggregateExpr for column-name typos. Today this
@@ -4248,7 +4252,9 @@ impl<T: Model> AggregateBuilder<T> {
             // belong to the model (caught early — typos otherwise
             // surface at the DB).
             for col in &self.group_by {
-                if model.field_by_column(col).is_none() {
+                // #1040 — a dotted `alias.col` references a JOINed table,
+                // validated by the JOIN's presence, not the base model.
+                if !col.contains('.') && model.field_by_column(col).is_none() {
                     return Err(QueryError::UnknownField {
                         model: model.name,
                         field: (*col).to_owned(),
@@ -4265,7 +4271,7 @@ impl<T: Model> AggregateBuilder<T> {
                 return Err(QueryError::ValuesRequiresAggregate { cols: cols.clone() });
             }
             for col in cols {
-                if model.field_by_column(col).is_none() {
+                if !col.contains('.') && model.field_by_column(col).is_none() {
                     return Err(QueryError::UnknownField {
                         model: model.name,
                         field: (*col).to_owned(),
@@ -4297,6 +4303,7 @@ impl<T: Model> AggregateBuilder<T> {
 
         Ok(AggregateQuery {
             model,
+            joins,
             where_clause,
             group_by,
             aggregates: self.aggregates,

--- a/crates/rustango/src/sql/executor/values.rs
+++ b/crates/rustango/src/sql/executor/values.rs
@@ -926,6 +926,9 @@ impl<T: crate::core::Model> crate::query::QuerySet<T> {
         let select_q = self.compile()?;
         let aggregate_q = crate::core::AggregateQuery {
             model: <T as crate::core::Model>::SCHEMA,
+            // Carry any ad-hoc JOINs from the queryset (#1040) so a scalar
+            // aggregate over a joined column still resolves.
+            joins: select_q.joins,
             where_clause: select_q.where_clause,
             group_by: Vec::new(),
             aggregates: vec![("v".into(), build(col_static))],

--- a/crates/rustango/src/sql/model_shortcuts.rs
+++ b/crates/rustango/src/sql/model_shortcuts.rs
@@ -150,6 +150,7 @@ where
     let col_static = resolve_col::<T>(col)?;
     let q = AggregateQuery {
         model: T::SCHEMA,
+        joins: Vec::new(),
         where_clause: WhereExpr::And(Vec::new()),
         group_by: Vec::new(),
         aggregates: vec![("v".into(), build(col_static))],

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -479,54 +479,7 @@ fn write_select_inner(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlErr
     b.sql.push_str(" FROM ");
     b.write_ident(query.model.table);
 
-    for join in &query.joins {
-        use crate::core::JoinKind;
-        // Reject dialect-incompatible kinds before emitting anything —
-        // gives users a clear error rather than a parse failure at the
-        // driver. PG supports all four; MySQL has no FULL OUTER JOIN;
-        // SQLite has neither RIGHT nor FULL.
-        let kind_kw = match (join.kind, b.d.name()) {
-            (JoinKind::Inner, _) => "INNER JOIN",
-            (JoinKind::Left, _) => "LEFT JOIN",
-            (JoinKind::Right, "sqlite") => {
-                return Err(SqlError::JoinKindNotSupported {
-                    kind: "RIGHT",
-                    dialect: b.d.name(),
-                });
-            }
-            (JoinKind::Right, _) => "RIGHT JOIN",
-            (JoinKind::Full, "postgres") => "FULL OUTER JOIN",
-            (JoinKind::Full, _) => {
-                return Err(SqlError::JoinKindNotSupported {
-                    kind: "FULL",
-                    dialect: b.d.name(),
-                });
-            }
-        };
-        // Empty `on` (e.g. `WhereExpr::And(vec![])`) is the legitimate
-        // "no WHERE filter" marker at the top of a SELECT/UPDATE, but
-        // inside an ON it would emit `ON ` with a literal hole — a
-        // parse error on every backend. Mirror of `EmptyCaseWhenCondition`.
-        if join.on.is_empty() {
-            return Err(SqlError::EmptyJoinOnCondition);
-        }
-        b.sql.push(' ');
-        b.sql.push_str(kind_kw);
-        b.sql.push(' ');
-        b.write_ident(join.target.table);
-        b.sql.push_str(" AS ");
-        b.write_ident(join.alias);
-        b.sql.push_str(" ON ");
-        // The ON predicate's unqualified `Filter` / `ColumnFilter`
-        // columns and bare `Expr::Column` refs (via `F()`) resolve
-        // to the joined alias for the duration of this write. Cross-
-        // references back to the outer (or to another joined alias)
-        // use `Expr::AliasedColumn` to escape the default.
-        let prior_qualify = b.current_qualify_alias.replace(join.alias);
-        let on_result = write_where_expr(b, &join.on, Some(join.alias), Some(join.target));
-        b.current_qualify_alias = prior_qualify;
-        on_result?;
-    }
+    write_model_joins(b, &query.joins)?;
 
     // Derived-table joins — `JOIN [LATERAL] (<subquery>) AS alias ON …`
     // (Eloquent joinSub / joinLateral, issue #828). Emitted after the
@@ -697,6 +650,61 @@ pub(super) fn write_count(b: &mut Sql<'_>, query: &CountQuery) -> Result<(), Sql
 // AGGREGATE
 // ====================================================================
 
+/// Emit the `KIND JOIN <target> AS <alias> ON <pred>` clauses shared by
+/// the SELECT writer and the aggregate writer (#1040 — group-by-on-a-
+/// joined-column). Rejects dialect-incompatible join kinds up front.
+fn write_model_joins(b: &mut Sql<'_>, joins: &[crate::core::Join]) -> Result<(), SqlError> {
+    use crate::core::JoinKind;
+    for join in joins {
+        // Reject dialect-incompatible kinds before emitting anything —
+        // gives users a clear error rather than a parse failure at the
+        // driver. PG supports all four; MySQL has no FULL OUTER JOIN;
+        // SQLite has neither RIGHT nor FULL.
+        let kind_kw = match (join.kind, b.d.name()) {
+            (JoinKind::Inner, _) => "INNER JOIN",
+            (JoinKind::Left, _) => "LEFT JOIN",
+            (JoinKind::Right, "sqlite") => {
+                return Err(SqlError::JoinKindNotSupported {
+                    kind: "RIGHT",
+                    dialect: b.d.name(),
+                });
+            }
+            (JoinKind::Right, _) => "RIGHT JOIN",
+            (JoinKind::Full, "postgres") => "FULL OUTER JOIN",
+            (JoinKind::Full, _) => {
+                return Err(SqlError::JoinKindNotSupported {
+                    kind: "FULL",
+                    dialect: b.d.name(),
+                });
+            }
+        };
+        // Empty `on` (e.g. `WhereExpr::And(vec![])`) is the legitimate
+        // "no WHERE filter" marker at the top of a SELECT/UPDATE, but
+        // inside an ON it would emit `ON ` with a literal hole — a
+        // parse error on every backend. Mirror of `EmptyCaseWhenCondition`.
+        if join.on.is_empty() {
+            return Err(SqlError::EmptyJoinOnCondition);
+        }
+        b.sql.push(' ');
+        b.sql.push_str(kind_kw);
+        b.sql.push(' ');
+        b.write_ident(join.target.table);
+        b.sql.push_str(" AS ");
+        b.write_ident(join.alias);
+        b.sql.push_str(" ON ");
+        // The ON predicate's unqualified `Filter` / `ColumnFilter`
+        // columns and bare `Expr::Column` refs (via `F()`) resolve
+        // to the joined alias for the duration of this write. Cross-
+        // references back to the outer (or to another joined alias)
+        // use `Expr::AliasedColumn` to escape the default.
+        let prior_qualify = b.current_qualify_alias.replace(join.alias);
+        let on_result = write_where_expr(b, &join.on, Some(join.alias), Some(join.target));
+        b.current_qualify_alias = prior_qualify;
+        on_result?;
+    }
+    Ok(())
+}
+
 pub(super) fn write_aggregate(b: &mut Sql<'_>, query: &AggregateQuery) -> Result<(), SqlError> {
     // Push the model onto the scope stack so any `Expr::Aggregate`
     // (issue #74) emitted inside the HAVING predicate has a model
@@ -708,14 +716,50 @@ pub(super) fn write_aggregate(b: &mut Sql<'_>, query: &AggregateQuery) -> Result
     r
 }
 
+/// Emit one group-by / projection column for the aggregate writer,
+/// qualified when JOINs are present (#1040). A dotted `alias.col` →
+/// `"alias"."col"`; a bare `col` with joins present → `"model_table"."col"`
+/// (disambiguates against joined tables); a bare `col` with no joins →
+/// `"col"` (the pre-#1040 shape). When `project` is set the SELECT-list
+/// form gets a stable `AS` label so the dict-row key is predictable:
+/// `alias__col` for a dotted ref, the bare column name otherwise.
+fn write_agg_group_col(
+    b: &mut Sql<'_>,
+    col: &str,
+    model_table: &str,
+    has_joins: bool,
+    project: bool,
+) {
+    if let Some((alias, c)) = col.split_once('.') {
+        b.write_ident(alias);
+        b.sql.push('.');
+        b.write_ident(c);
+        if project {
+            b.sql.push_str(" AS ");
+            b.write_ident(&format!("{alias}__{c}"));
+        }
+    } else if has_joins {
+        b.write_ident(model_table);
+        b.sql.push('.');
+        b.write_ident(col);
+        if project {
+            b.sql.push_str(" AS ");
+            b.write_ident(col);
+        }
+    } else {
+        b.write_ident(col);
+    }
+}
+
 fn write_aggregate_inner(b: &mut Sql<'_>, query: &AggregateQuery) -> Result<(), SqlError> {
     b.sql.push_str("SELECT ");
+    let has_joins = !query.joins.is_empty();
 
     for (i, col) in query.group_by.iter().enumerate() {
         if i > 0 {
             b.sql.push_str(", ");
         }
-        b.write_ident(col);
+        write_agg_group_col(b, col, query.model.table, has_joins, /*project=*/ true);
     }
     for (i, (alias, expr)) in query.aggregates.iter().enumerate() {
         if !query.group_by.is_empty() || i > 0 {
@@ -728,6 +772,9 @@ fn write_aggregate_inner(b: &mut Sql<'_>, query: &AggregateQuery) -> Result<(), 
 
     b.sql.push_str(" FROM ");
     b.write_ident(query.model.table);
+    // #1040 — JOINs for group-by-on-a-related-column. Emitted between
+    // FROM and WHERE, same position as the SELECT writer.
+    write_model_joins(b, &query.joins)?;
     write_where(b, &query.where_clause, Some(query.model))?;
 
     if !query.group_by.is_empty() {
@@ -736,7 +783,13 @@ fn write_aggregate_inner(b: &mut Sql<'_>, query: &AggregateQuery) -> Result<(), 
             if i > 0 {
                 b.sql.push_str(", ");
             }
-            b.write_ident(col);
+            write_agg_group_col(
+                b,
+                col,
+                query.model.table,
+                has_joins,
+                /*project=*/ false,
+            );
         }
     }
 

--- a/crates/rustango/tests/aggregate_filter.rs
+++ b/crates/rustango/tests/aggregate_filter.rs
@@ -30,6 +30,7 @@ pub struct Post {
 fn agg(expr: AggregateExpr) -> AggregateQuery {
     AggregateQuery {
         model: Post::SCHEMA,
+        joins: Vec::new(),
         where_clause: WhereExpr::And(vec![]),
         aggregates: vec![("agg".into(), expr)],
         aliases: vec![],

--- a/crates/rustango/tests/count_distinct_sqlite_live.rs
+++ b/crates/rustango/tests/count_distinct_sqlite_live.rs
@@ -51,6 +51,7 @@ async fn count_distinct_returns_unique_count_not_row_count() {
     // Total rows = 6
     let total_q = AggregateQuery {
         model: CdTag::SCHEMA,
+        joins: Vec::new(),
         where_clause: WhereExpr::And(vec![]),
         group_by: vec![],
         aggregates: vec![("total".into(), AggregateExpr::Count(None))],
@@ -66,6 +67,7 @@ async fn count_distinct_returns_unique_count_not_row_count() {
     // Distinct categories = 3 (rust, django, go)
     let distinct_q = AggregateQuery {
         model: CdTag::SCHEMA,
+        joins: Vec::new(),
         where_clause: WhereExpr::And(vec![]),
         group_by: vec![],
         aggregates: vec![("uniq".into(), AggregateExpr::CountDistinct("category"))],
@@ -88,6 +90,7 @@ async fn count_distinct_respects_where_clause() {
     // WHERE category = 'rust' → 3 matching rows, 1 distinct value.
     let q = AggregateQuery {
         model: CdTag::SCHEMA,
+        joins: Vec::new(),
         where_clause: WhereExpr::Predicate(Filter {
             column: "category",
             op: Op::Eq,

--- a/crates/rustango/tests/django6_joins.rs
+++ b/crates/rustango/tests/django6_joins.rs
@@ -23,10 +23,11 @@
 //!   `AggregateBuilder::annotate_count` / `annotate_sum` / … chain off
 //!   the first relation annotate (#1038, shipped). Each lowers to its own
 //!   correlated subquery, so neither inflates.
-//! - Ad-hoc `.join()` does not compose with `.aggregate()` —
-//!   `AggregateQuery` carries no joins, so Django's join+GROUP BY
-//!   aggregate shape (`values("author__name").annotate(Count)`) must
-//!   go through relation aggregates or raw SQL. Issue #1040.
+//! - Ad-hoc `.join()` now composes with `.aggregate()` —
+//!   `AggregateQuery` carries `joins`, so Django's join+GROUP BY shape
+//!   (`values("author.name").annotate(Count)`) works via an explicit
+//!   join + aliased `group_by` (#1040, shipped). The `author__name`
+//!   sugar will ride #1031's `resolve_span_chain`.
 
 #[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
 mod scenarios {
@@ -327,6 +328,53 @@ mod scenarios {
             "sum of comment scores 5+12+20"
         );
     }
+
+    /// Django's most common reporting shape — group by a RELATED column:
+    /// `Post.objects.values("author__name").annotate(n=Count("id"))`. #1040.
+    /// Explicit `.join()` + aliased `group_by("author.name")` (the
+    /// `__`-sugar will ride #1031's resolver later). Each author has one
+    /// post (Ada → "Hello", Bob → "World"), so the grouped counts are 1/1.
+    pub async fn check_group_by_related_column(pool: &Pool) {
+        let rows = Post::objects()
+            .join(Join {
+                target: Author::SCHEMA,
+                alias: "author",
+                kind: JoinKind::Inner,
+                on: WhereExpr::ExprCompare {
+                    lhs: aliased("author", "id"),
+                    op: Op::Eq,
+                    rhs: aliased("d6join_post", "author"),
+                },
+                project: vec![],
+            })
+            .aggregate()
+            .group_by("author.name")
+            .annotate("n", rustango::core::AggregateExpr::Count(None))
+            .fetch(pool)
+            .await
+            .expect("group by author.name");
+        // Grouped column projects under the `<alias>__<col>` key.
+        let mut pairs: Vec<(String, i64)> = rows
+            .iter()
+            .map(|r| {
+                let name = match r.get("author__name") {
+                    Some(SqlValue::String(s)) => s.clone(),
+                    other => panic!("expected String author__name, got {other:?}"),
+                };
+                let n = match r.get("n") {
+                    Some(SqlValue::I64(n)) => *n,
+                    other => panic!("expected I64 n, got {other:?}"),
+                };
+                (name, n)
+            })
+            .collect();
+        pairs.sort();
+        assert_eq!(
+            pairs,
+            vec![("Ada".to_string(), 1), ("Bob".to_string(), 1)],
+            "one post per author, grouped by the joined author.name"
+        );
+    }
 }
 
 // ------------------------------------------------------------- Postgres
@@ -388,6 +436,7 @@ mod pg_live {
     pg_case!(check_cross_table_filter_via_join);
     pg_case!(check_f_comparison_across_join);
     pg_case!(check_relation_counts_never_inflate);
+    pg_case!(check_group_by_related_column);
 }
 
 // --------------------------------------------------------------- SQLite
@@ -432,6 +481,7 @@ mod sqlite_live {
     sqlite_case!(check_cross_table_filter_via_join);
     sqlite_case!(check_f_comparison_across_join);
     sqlite_case!(check_relation_counts_never_inflate);
+    sqlite_case!(check_group_by_related_column);
 }
 
 // ---------------------------------------------------------------- MySQL
@@ -493,4 +543,5 @@ mod mysql_live {
     mysql_case!(check_cross_table_filter_via_join);
     mysql_case!(check_f_comparison_across_join);
     mysql_case!(check_relation_counts_never_inflate);
+    mysql_case!(check_group_by_related_column);
 }

--- a/crates/rustango/tests/mysql_from_row.rs
+++ b/crates/rustango/tests/mysql_from_row.rs
@@ -320,6 +320,7 @@ fn fetch_aggregate_pool_is_callable() {
     fn _probe(pool: &rustango::sql::Pool) {
         let q = AggregateQuery {
             model: <User as Model>::SCHEMA,
+            joins: Vec::new(),
             where_clause: WhereExpr::And(vec![]),
             group_by: vec![],
             aggregates: vec![],

--- a/crates/rustango/tests/pg_aggregates.rs
+++ b/crates/rustango/tests/pg_aggregates.rs
@@ -23,6 +23,7 @@ pub struct Post {
 fn aggregate_query(expr: AggregateExpr, alias: &'static str) -> AggregateQuery {
     AggregateQuery {
         model: <Post as rustango::core::Model>::SCHEMA,
+        joins: Vec::new(),
         where_clause: WhereExpr::And(vec![]),
         group_by: Vec::new(),
         aggregates: vec![(alias.into(), expr)],
@@ -267,6 +268,7 @@ fn jsonb_agg_rejected_on_non_pg() {
 fn array_agg_composes_with_group_by() {
     let q = AggregateQuery {
         model: <Post as rustango::core::Model>::SCHEMA,
+        joins: Vec::new(),
         where_clause: WhereExpr::And(vec![]),
         group_by: vec!["author"],
         aggregates: vec![("tags".into(), AggregateExpr::array_agg("tag"))],

--- a/crates/rustango/tests/pg_aggregates_live.rs
+++ b/crates/rustango/tests/pg_aggregates_live.rs
@@ -68,6 +68,7 @@ async fn cleanup(pool: &sqlx::PgPool) {
 fn agg_per_author(expr: AggregateExpr, alias: &'static str) -> AggregateQuery {
     AggregateQuery {
         model: <Post as rustango::core::Model>::SCHEMA,
+        joins: Vec::new(),
         where_clause: WhereExpr::And(vec![]),
         group_by: vec!["author"],
         aggregates: vec![(alias.into(), expr)],

--- a/crates/rustango/tests/window_functions.rs
+++ b/crates/rustango/tests/window_functions.rs
@@ -31,6 +31,7 @@ pub struct User {
 fn agg(expr: AggregateExpr) -> AggregateQuery {
     AggregateQuery {
         model: User::SCHEMA,
+        joins: Vec::new(),
         where_clause: WhereExpr::And(vec![]),
         aggregates: vec![("w".into(), expr)],
         aliases: vec![],

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -873,7 +873,7 @@ Status per scenario group (PG / SQLite / MySQL). ✓ = passes asserting Django-e
 | B. Correlated subqueries | `Exists`+`OuterRef` (raw + typed `eq_expr`), NOT EXISTS, exclude-on-relation semantics, `IN (SELECT…)`, has-count, `annotate_count`, scalar `Subquery` in WHERE | ✓ | ✓ | ✓ | `django6_subquery.rs` | `where_doesnt_have_filter` reproduces Django's exclude-NOT-EXISTS semantics exactly (bookless parents included). `OuterRef` misuse pinned (`OuterRefOutsideSubquery`). Scalar `Subquery` as projected annotation inexpressible — #1036. |
 | C. Window functions | rank/dense_rank/lag(default)/first_value+ROWS frame/ntile, partitioned | ✓ | ✓ | ✓* | `django6_window.rs` | *MySQL ranking outputs decode as `SqlValue::Bool` (#1033, pinned). Required shape: `.aggregate().group_by(<every projected col>)`. `Sum(...) OVER` + windowed-subquery missing (#1035); top-N-per-group via `join_lateral` works PG/MySQL, `LateralJoinNotSupported` pinned on SQLite. |
 | K. distinct_on | first-row-per-group, +join | ✓ | ✓ (window fallback) | ✓ (window fallback) | `django6_window.rs` | Fallback rejects joins — pinned `OpNotSupportedInDialect` on SQLite/MySQL (#1039); PG native handles joins. |
-| D. Multi-join | 3-hop `select_related` stitching, cross-table filter via `.join()`+`aliased`, F-across-join, relation-count inflation | ✓ | ✓ | ✓ | `django6_joins.rs` | Relation-spanning `filter("author__name",…)` (Part 1) + `order_by("author__name")` (Part 2) now resolve the FK chain into LEFT JOINs — #1031 (`__in`/`__isnull`/`__between` on spans remain, Part 3). `annotate_count` never inflates (correlated subquery ≡ Django `distinct=True`), and two relation aggregates now chain in one query (#1038, shipped). Remaining: `.join()` doesn't compose with `.aggregate()` — `values("author__name").annotate(Count)` group-by-on-related-column shape inexpressible (#1040). |
+| D. Multi-join | 3-hop `select_related` stitching, cross-table filter via `.join()`+`aliased`, F-across-join, relation-count inflation | ✓ | ✓ | ✓ | `django6_joins.rs` | Relation-spanning `filter("author__name",…)` (Part 1) + `order_by("author__name")` (Part 2) now resolve the FK chain into LEFT JOINs — #1031 (`__in`/`__isnull`/`__between` on spans remain, Part 3). `annotate_count` never inflates (correlated subquery ≡ Django `distinct=True`), two relation aggregates chain in one query (#1038), and `.join()` now composes with `.aggregate()` so a group-by-on-a-related-column (`group_by("author.name")`) emits JOIN + GROUP BY (#1040, shipped). |
 | E. Set operations | union dedup/all, per-branch + combined ORDER/LIMIT, intersection, difference, `with_compound` | ✓ | ✓ | ✓* | `django6_setops.rs` | *Ordered/limited branches broken on MySQL — alias-less derived table, error 1248 (#1032, pinned). First-queryset ORDER/LIMIT always combined-scoped (#1034, pinned). INTERSECT/EXCEPT floor: MySQL 8.0.31+. |
 | G. JSON lookups | nested keys, key+index, array length, negative index | ✓ | ✓ (neg. index pinned) | ✓ (neg. index pinned) | `django6_json_dates.rs` | Negative index PG-only — #1027 (Django 6.0 supports SQLite). |
 | H. Date transforms | `__year__gte` chains, `__month`, `__quarter`, `.dates()`, `.datetimes()` | ✓ | ✓ (`__quarter` pinned) | ✓ | `django6_json_dates.rs` | `__quarter` errors on SQLite — #1037. `.dates()/.datetimes()` truncation identical tri-dialect. |
@@ -891,7 +891,7 @@ Status per scenario group (PG / SQLite / MySQL). ✓ = passes asserting Django-e
 
 - `.values(cols)` + window-only annotate → `QueryError::ValuesRequiresAggregate`; explicit `group_by` per projected column is the canonical window shape.
 - Inside a `.join()` `on` predicate, bare `Expr::Column` qualifies to the **joined** alias — refer to the outer table via `joins::aliased("<outer_table>", col)`.
-- `annotate_count`/`annotate_sum`… also live on `AggregateBuilder` now, so two relation aggregates compose in one query (#1038, shipped). Grouping by a related column (`values("author__name").annotate(...)`) is still inexpressible since `AggregateQuery` carries no joins (#1040).
+- `annotate_count`/`annotate_sum`… also live on `AggregateBuilder` now, so two relation aggregates compose in one query (#1038). Grouping by a related column also works (#1040): `AggregateQuery` carries `joins`, so an explicit join + aliased `group_by("author.name")` emits `… JOIN … GROUP BY "author"."name"`. The `author__name` sugar (auto-join) will ride #1031's `resolve_span_chain`.
 - Aggregate `.filter()` builder + `WindowBuilder`/`StringAgg` wrappers reject nesting (`NestedAggregateWrapper`) — Django's `StringAgg(..., filter=...)` shape included.
 
 ### 26.5 Refresh 2026-06-15 — what shipped since the 2026-06-12 execution pass
@@ -914,7 +914,8 @@ The 2026-06-12 pass (§26.1–§26.4) pinned a batch of gaps as live issues. PRs
 | #1037 | `__quarter` synthesized on SQLite | #1041 |
 | #1031 **Part 1** | relation-spanning lookups in `filter()`/`exclude()` (`author__name__icontains`) | #1051 |
 | #1031 **Part 2** | relation-spanning `order_by("author__name")` (shared `resolve_span_chain` walk) | #1057 |
-| #1038 | two relation aggregates in one query (chained `AggregateBuilder::annotate_count`/`_sum`/…) | this PR |
+| #1038 | two relation aggregates in one query (chained `AggregateBuilder::annotate_count`/`_sum`/…) | #1058 |
+| #1040 | group-by-on-a-related-column — `AggregateQuery.joins` + aliased `group_by("author.name")` | this PR |
 | #1035 **Part A** | aggregate-as-window (`Sum/Avg/Min/Max/Count OVER`) | #1050 |
 | #1011 | in-admin model reference (admindocs) | #1023 |
 | #1010 | DRF epic — per-action throttling (#1022) + pluggable filter backends (#1021) | (epic closed) |
@@ -928,7 +929,6 @@ The 2026-06-12 pass (§26.1–§26.4) pinned a batch of gaps as live issues. PRs
 - [#1031](https://github.com/ujeenet/rustango/issues/1031) **Part 3** — `__in` / `__isnull` / `__between` on relation spans (`filter`/`exclude` Part 1 + `order_by` Part 2 shipped; the binary + LIKE-family ops work, these non-binary ops against an aliased column remain).
 - [#1035](https://github.com/ujeenet/rustango/issues/1035) **remaining** — windowed query as a subquery source (top-N-per-group); aggregate-as-window shipped in Part A.
 - [#1039](https://github.com/ujeenet/rustango/issues/1039) — `distinct_on` window fallback supporting joins on MySQL/SQLite.
-- [#1040](https://github.com/ujeenet/rustango/issues/1040) — `AggregateQuery` joins — `values("author__name").annotate(Count)` group-by-on-related-column shape.
 
 ---
 


### PR DESCRIPTION
Closes #1040. `AggregateQuery` now carries a `joins` field, so Django's most common reporting shape — **group by a related column** (`values("author__name").annotate(n=Count("id"))`) — is expressible.

```rust
Post::objects()
    .join(Join { target: Author::SCHEMA, alias: "author", kind: Inner, on: aliased("author","id").eq(aliased("post","author")), .. })
    .aggregate()
    .group_by("author.name")
    .annotate("n", AggregateExpr::Count(None))
    .fetch(&pool).await?;
// SELECT "author"."name" AS "author__name", COUNT(*) AS "n"
// FROM post JOIN author AS author ON ... GROUP BY "author"."name"
```

## Implementation
- **IR**: new `AggregateQuery.joins` (+ `PartialEq`). The ~17 construction sites get `Vec::new()`; the scalar-aggregate path (`values.rs`) carries the compiled SELECT's joins so a scalar aggregate over a joined queryset also resolves.
- **Writer**: extracted the SELECT path's JOIN loop into a shared `write_model_joins` (emitted between FROM and WHERE — no duplication). New `write_agg_group_col` qualifies group/projection columns: dotted `alias.col` → `"alias"."col" AS "alias__col"`; bare col with joins present → `"table"."col"`; bare col, no joins → unchanged.
- **Builder**: `AggregateBuilder::compile` threads `qs.ad_hoc_joins` into the query and skips base-model validation for dotted group keys.

No new public API — the existing `.join().aggregate().group_by("author.name").annotate(...)` chain flows through.

## Tests
New tri-dialect `tests/django6_joins.rs::check_group_by_related_column` → `[("Ada", 1), ("Bob", 1)]`. Local: sqlite `django6_joins` 7/7; `cargo check --workspace --all-features --all-targets` clean. PG/MySQL (incl. `ONLY_FULL_GROUP_BY` + per-dialect aliased-column quoting) validated by CI.

## Scope
The `values("author__name")` auto-join *sugar* is deferred — it will reuse #1031's `resolve_span_chain`. Audit §26.2-D / §26.4 / §26.5 updated.