### PR TITLE
feat(orm): refresh generated_as columns on save via RETURNING — closes #1028

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -1976,6 +1976,11 @@ struct CollectedFields {
     /// the bulk_insert codegen to rebuild assigns against `_row_mut`
     /// instead of `self`.
     auto_field_idents: Vec<(syn::Ident, String)>,
+    /// #1028 — `(ident, column)` for each `generated_as` field. Drives
+    /// the PG/SQLite RETURNING refresh that decodes the DB-computed value
+    /// back into the struct after insert (MySQL has no RETURNING → the
+    /// field stays at its placeholder, deferred, matching Django 6.0).
+    generated_field_idents: Vec<(syn::Ident, String)>,
     /// Inner `T` of the first `Auto<T>` field, for the MySQL
     /// `LAST_INSERT_ID()` assignment in `AssignAutoPkPool`.
     first_auto_value_ty: Option<Type>,
@@ -2071,6 +2076,7 @@ fn collect_fields(named: &syn::FieldsNamed, table: &str) -> syn::Result<Collecte
         returning_cols: Vec::new(),
         auto_assigns: Vec::new(),
         auto_field_idents: Vec::new(),
+        generated_field_idents: Vec::new(),
         first_auto_value_ty: None,
         bulk_pushes_no_auto: Vec::with_capacity(cap),
         bulk_pushes_all: Vec::with_capacity(cap),
@@ -2133,6 +2139,15 @@ fn collect_fields(named: &syn::FieldsNamed, table: &str) -> syn::Result<Collecte
                 column: info.column.clone(),
                 field_type_tokens: info.field_type_tokens,
             });
+            // #1028 — refresh the DB-computed value after insert on
+            // RETURNING-capable backends. The column joins `returning_cols`
+            // (so PG/SQLite `INSERT … RETURNING` includes it) and the
+            // ident is recorded so the `AssignAutoPkPool` impl decodes it
+            // back into the struct. MySQL has no `INSERT … RETURNING`, so
+            // it keeps the placeholder (deferred refresh, matching Django).
+            out.returning_cols.push(quote!(#column));
+            out.generated_field_idents
+                .push((ident.clone(), info.column.clone()));
             continue;
         }
         out.insert_columns.push(quote!(#column));
@@ -7676,6 +7691,29 @@ fn inherent_impl_tokens(
                 }
             })
             .collect();
+        // #1028 — decode each `generated_as` column from the same
+        // RETURNING row (PG/SQLite). Plain-typed fields, so the field's
+        // own type drives the decode (no `Auto<T>` wrapper).
+        let generated_assigns: Vec<TokenStream2> = fields
+            .generated_field_idents
+            .iter()
+            .map(|(ident, column)| {
+                quote! {
+                    self.#ident = #root::sql::try_get_returning(_returning_row, #column)?;
+                }
+            })
+            .collect();
+        let generated_assigns_sqlite: Vec<TokenStream2> = fields
+            .generated_field_idents
+            .iter()
+            .map(|(ident, column)| {
+                quote! {
+                    self.#ident = #root::sql::try_get_returning_sqlite(
+                        _returning_row, #column
+                    )?;
+                }
+            })
+            .collect();
         let mysql_body = if let Some(first) = fields.first_auto_ident.as_ref() {
             // The MySQL `LAST_INSERT_ID()` is always i64. Route through
             // `MysqlAutoIdSet` so Auto<i32> narrows safely and
@@ -7717,6 +7755,7 @@ fn inherent_impl_tokens(
                     _returning_row: &#root::sql::PgReturningRow,
                 ) -> ::core::result::Result<(), #root::sql::ExecError> {
                     #( #auto_assigns )*
+                    #( #generated_assigns )*
                     ::core::result::Result::Ok(())
                 }
                 fn __rustango_assign_from_mysql_id(
@@ -7730,6 +7769,7 @@ fn inherent_impl_tokens(
                     _returning_row: &#root::sql::SqliteReturningRow,
                 ) -> ::core::result::Result<(), #root::sql::ExecError> {
                     #( #auto_assigns_sqlite )*
+                    #( #generated_assigns_sqlite )*
                     ::core::result::Result::Ok(())
                 }
             }

--- a/crates/rustango/tests/django6_delta.rs
+++ b/crates/rustango/tests/django6_delta.rs
@@ -10,8 +10,8 @@
 //!   `ANY_VALUE()`, SQLite `min()` fallback (#1025)
 //! - `GeneratedField` values are refreshed from the database after
 //!   `save()` on RETURNING-capable backends (PG/SQLite) — rustango
-//!   never refreshes: PINNED DIVERGENCE (DB value correct, struct
-//!   stale)
+//!   decodes them from the `INSERT … RETURNING` row (#1028); MySQL
+//!   defers (no RETURNING), matching Django 6.0
 //! - `DEFAULT_AUTO_FIELD` now defaults to `BigAutoField` — rustango's
 //!   `Auto<i64>` ↔ BIGSERIAL/BIGINT AUTO_INCREMENT already matches
 //!
@@ -181,12 +181,9 @@ mod scenarios {
     }
 
     /// Django 6.0: after `save()`, `GeneratedField`s refresh from the
-    /// database via RETURNING (PG/SQLite; deferred on MySQL).
-    /// rustango DIVERGENCE PIN: the DB computes the column correctly
-    /// but the in-memory struct is never refreshed — on ANY backend. Issue #1028.
-    /// Goes red (flip the audit row) when save() starts returning
-    /// generated columns.
-    pub async fn check_generated_column_not_refreshed_on_save(pool: &Pool) {
+    /// database via RETURNING (PG/SQLite; deferred on MySQL, which has no
+    /// `INSERT … RETURNING`). #1028.
+    pub async fn check_generated_column_refreshed_on_save(pool: &Pool) {
         let mut inv = Invoice {
             id: Auto::default(),
             price: 3,
@@ -194,12 +191,18 @@ mod scenarios {
             total: 0, // placeholder — DB computes 12
         };
         inv.save_pool(pool).await.expect("insert");
-        assert_eq!(
-            inv.total, 0,
-            "PINNED DIVERGENCE: struct not refreshed after save — Django 6.0 \
-             refreshes GeneratedFields via RETURNING; if this is now 12, update \
-             the audit + issue"
-        );
+        if pool.dialect().name() == "mysql" {
+            // No `INSERT … RETURNING` on MySQL — the generated column
+            // stays at its placeholder (deferred refresh, matching Django).
+            assert_eq!(inv.total, 0, "MySQL: generated-column refresh deferred");
+        } else {
+            // PG / SQLite decode the DB-computed value from the RETURNING
+            // row straight back into the struct (3 * 4 = 12).
+            assert_eq!(
+                inv.total, 12,
+                "PG/SQLite: generated column refreshed via RETURNING"
+            );
+        }
         let fetched: Vec<Invoice> = Invoice::objects().fetch(pool).await.expect("re-fetch");
         assert_eq!(fetched.len(), 1);
         assert_eq!(fetched[0].total, 12, "the DB-side value IS computed");
@@ -279,7 +282,7 @@ mod pg_live {
     pg_case!(check_string_agg_distinct);
     pg_case!(check_any_value);
     pg_case!(check_string_agg_ordered);
-    pg_case!(check_generated_column_not_refreshed_on_save);
+    pg_case!(check_generated_column_refreshed_on_save);
     pg_case!(check_auto_pk_is_big_auto_field);
 }
 
@@ -327,7 +330,7 @@ mod sqlite_live {
     sqlite_case!(check_string_agg_distinct);
     sqlite_case!(check_any_value);
     sqlite_case!(check_string_agg_ordered);
-    sqlite_case!(check_generated_column_not_refreshed_on_save);
+    sqlite_case!(check_generated_column_refreshed_on_save);
     sqlite_case!(check_auto_pk_is_big_auto_field);
 }
 
@@ -388,6 +391,6 @@ mod mysql_live {
     mysql_case!(check_string_agg_distinct);
     mysql_case!(check_any_value);
     mysql_case!(check_string_agg_ordered);
-    mysql_case!(check_generated_column_not_refreshed_on_save);
+    mysql_case!(check_generated_column_refreshed_on_save);
     mysql_case!(check_auto_pk_is_big_auto_field);
 }

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -853,7 +853,7 @@ Run locally: `docker-compose up -d`, then per backend —
 | `AnyValue` aggregate (new) | SHIPPED 2026-06-13 — `AnyValue` aggregate variant, PR #1046 | compile-time presence | #1025 (closed) |
 | `Aggregate(order_by=...)` (new; deprecates PG `OrderableAggMixin`) | SHIPPED 2026-06-13 — ordered `StringAgg`, PR #1047 | `django6_aggregation.rs` | #1026 (closed) |
 | `JSONField` negative array index on SQLite (new) | SHIPPED 2026-06-13 — synthesized on SQLite, PR #1042 (MySQL N/A upstream — `$[N]` is non-negative-only) | `django6_json_dates.rs::check_negative_index_dialect_matrix` | #1027 (closed) |
-| `GeneratedField` auto-refresh after `save()` via RETURNING | PINNED DIVERGENCE — DB value correct, struct never refreshed (any backend) | `django6_delta.rs::check_generated_column_not_refreshed_on_save` | #1028 |
+| `GeneratedField` auto-refresh after `save()` via RETURNING | SHIPPED (PG/SQLite) — decoded from the `INSERT … RETURNING` row back into the struct; MySQL deferred (no RETURNING), matches Django | `django6_delta.rs::check_generated_column_refreshed_on_save` | #1028 (closed) |
 | `Model.NotUpdated` on forced 0-row update | DIVERGES — QuerySet `update_pool` surfaces rows-affected (0), instance `save_pool` silently `Ok(())` | `django6_writes.rs::check_zero_row_update_semantics` | #1029 |
 | `CompositePrimaryKey` in `raw()` / subquery lookups beyond `__in` | N/A BY ARCHITECTURE — composite-key idiom is surrogate `Auto<i64>` + `unique_together`; tuple-membership `(a,b) IN (SELECT…)` has no API (workaround: multi-predicate correlated EXISTS) | `django6_subquery.rs` header note | — |
 | `bulk_create(update_conflicts=True, unique_fields, update_fields)` | SHIPPED — verified incl. two-column composite conflict target + update-listed-columns-only | `django6_writes.rs::check_bulk_upsert_*` | — |
@@ -906,6 +906,7 @@ The 2026-06-12 pass (§26.1–§26.4) pinned a batch of gaps as live issues. PRs
 | #1025 | `AnyValue` aggregate | #1046 |
 | #1026 | `Aggregate(order_by=…)` — ordered `StringAgg` | #1047 |
 | #1027 | `JSONField` negative array index on SQLite | #1042 |
+| #1028 | `GeneratedField` refresh on save via RETURNING (PG/SQLite; MySQL deferred) | this PR |
 | #1030 | `QuerySet::exclude()` | #1044 |
 | #1032 | union per-branch aliased derived tables (MySQL 1248 fix) | #1048 |
 | #1033 | MySQL ranking windows decode losslessly (not `Bool`) | #1043 |
@@ -923,7 +924,6 @@ The 2026-06-12 pass (§26.1–§26.4) pinned a batch of gaps as live issues. PRs
 **Still open (the genuine parity gaps as of this refresh):**
 
 - [#1009](https://github.com/ujeenet/rustango/issues/1009) — GeoDjango geometry breadth beyond `Point` (LineString / Polygon / Multi*). `django-parity`.
-- [#1028](https://github.com/ujeenet/rustango/issues/1028) — refresh `generated_as` columns on `save()` via RETURNING (Django 6.0).
 - [#1029](https://github.com/ujeenet/rustango/issues/1029) — surface `rows_affected` from `Model::save` update path (Django 6.0 `Model.NotUpdated`).
 - [#1031](https://github.com/ujeenet/rustango/issues/1031) **Part 3** — `__in` / `__isnull` / `__between` on relation spans (`filter`/`exclude` Part 1 + `order_by` Part 2 shipped; the binary + LIKE-family ops work, these non-binary ops against an aliased column remain).
 - [#1035](https://github.com/ujeenet/rustango/issues/1035) **remaining** — windowed query as a subquery source (top-N-per-group); aggregate-as-window shipped in Part A.


### PR DESCRIPTION
Closes #1028. Django 6.0 refreshes `GeneratedField`s from the database after `save()` on RETURNING-capable backends — rustango now does too.

## What
After an insert, a `#[rustango(generated_as = "...")]` column is decoded from the `INSERT … RETURNING` row straight back into the struct (PG + SQLite), alongside the existing Auto-PK write-back — no extra round trip.

```rust
let mut inv = Invoice { id: Auto::default(), price: 3, qty: 4, total: 0 };
inv.save_pool(&pool).await?;
// PG/SQLite: inv.total == 12   (was a stale 0 placeholder)
// MySQL:     inv.total == 0    (deferred — no INSERT…RETURNING, matches Django)
```

## How
The macro pushes each generated column into `returning_cols` and records `(ident, column)` in a new `generated_field_idents`; the `AssignAutoPkPool` impl decodes them in its PG (`try_get_returning`) and SQLite (`try_get_returning_sqlite`) arms. The MySQL arm is untouched (no RETURNING → deferred, matching Django 6.0). Plain-typed generated fields decode via their own type (no `Auto<T>` wrapper).

## Tests
Flips `tests/django6_delta.rs::check_generated_column_not_refreshed_on_save` → `_refreshed_on_save`: PG/SQLite assert `inv.total == 12` post-save; MySQL asserts the deferred placeholder. Local: sqlite `django6_delta` 6/6; `cargo check --workspace --all-features --all-targets` clean (macro change recompiles every derive site). PG/MySQL validated by CI.

Audit §26.1 + §26.5 updated. (Note: §26.5 also touched by #1040 — whichever merges second will get a tiny doc rebase.)