### PR TITLE
feat(orm): distinct_on + join on MySQL/SQLite — closes #1039

### DIFF
--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -277,6 +277,20 @@ fn write_compound_select(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), Sql
     Ok(())
 }
 
+/// Write a model column for the distinct-on window fallback's inner
+/// SELECT — qualified with the model table when joins are present (#1039)
+/// so it can't collide with a joined table's same-named column. The outer
+/// SELECT reads from the `sub` derived table, so it always stays bare.
+fn write_distinct_inner_col(b: &mut Sql<'_>, table: &str, col: &str, qualify: bool) {
+    if qualify {
+        b.write_ident(table);
+        b.sql.push('.');
+        b.write_ident(col);
+    } else {
+        b.write_ident(col);
+    }
+}
+
 /// MySQL / SQLite portable fallback for PG's `SELECT DISTINCT ON (cols)`.
 /// Wraps the original SELECT in a subquery that adds
 /// `ROW_NUMBER() OVER (PARTITION BY cols ORDER BY <user_order>) AS __rn`
@@ -299,18 +313,11 @@ fn write_distinct_on_via_window(
     query: &SelectQuery,
     distinct_cols: &[&'static str],
 ) -> Result<(), SqlError> {
-    // v1 limitation: the window-function rewrite doesn't yet handle
-    // joins (`.select_related` / `.join`). Tracked as a follow-up;
-    // surface a clear error so users on MySQL/SQLite know the gap
-    // rather than seeing wrong-shape SQL.
-    if !query.joins.is_empty() {
-        return Err(SqlError::OpNotSupportedInDialect {
-            op: "DISTINCT ON combined with joins (workaround: pre-collapse \
-                 with a subquery, or run on Postgres which supports DISTINCT \
-                 ON natively)",
-            dialect: b.d.name(),
-        });
-    }
+    // #1039 — the inner SELECT below joins the related tables and
+    // qualifies the model's own columns with the model table so they
+    // can't collide with a joined column. The derived table `sub`
+    // re-exposes them by their bare names for the outer SELECT / ORDER BY.
+    let qualify = !query.joins.is_empty();
 
     // ---------- Outer SELECT — projection columns only (no __rn). ----------
     b.sql.push_str("SELECT ");
@@ -343,7 +350,7 @@ fn write_distinct_on_via_window(
                 b.sql.push_str(", ");
             }
             inner_first = false;
-            b.write_ident(col);
+            write_distinct_inner_col(b, query.model.table, col, qualify);
         }
     } else {
         for field in query.model.scalar_fields() {
@@ -351,7 +358,7 @@ fn write_distinct_on_via_window(
                 b.sql.push_str(", ");
             }
             inner_first = false;
-            b.write_ident(field.column);
+            write_distinct_inner_col(b, query.model.table, field.column, qualify);
         }
     }
     // ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...) AS __rn
@@ -360,7 +367,7 @@ fn write_distinct_on_via_window(
         if i > 0 {
             b.sql.push_str(", ");
         }
-        b.write_ident(col);
+        write_distinct_inner_col(b, query.model.table, col, qualify);
     }
     if !query.order_by.is_empty() {
         b.sql.push_str(" ORDER BY ");
@@ -370,7 +377,7 @@ fn write_distinct_on_via_window(
             }
             match item {
                 crate::core::OrderItem::Column { column, desc, .. } => {
-                    b.write_ident(column);
+                    write_distinct_inner_col(b, query.model.table, column, qualify);
                     if *desc {
                         b.sql.push_str(" DESC");
                     }
@@ -393,6 +400,10 @@ fn write_distinct_on_via_window(
     }
     b.sql.push_str(") AS __rn FROM ");
     b.write_ident(query.model.table);
+    // #1039 — the FK-chain / ad-hoc joins live in the inner SELECT next to
+    // the ROW_NUMBER() partition, so they filter/correlate the rows the
+    // window ranks. The outer SELECT reads the survivors from `sub`.
+    write_model_joins(b, &query.joins)?;
     write_where(b, &query.where_clause, Some(query.model))?;
 
     b.sql.push_str(") sub WHERE sub.__rn = 1");

--- a/crates/rustango/tests/django6_window.rs
+++ b/crates/rustango/tests/django6_window.rs
@@ -271,55 +271,41 @@ mod scenarios {
         );
     }
 
-    /// GAP-PIN: `distinct_on` + any join works on PG (native DISTINCT
-    /// ON) but the MySQL/SQLite ROW_NUMBER fallback rejects joins
-    /// (issue #1039).
-    /// Django supports `.distinct(*fields)` only on PG anyway, so the
-    /// PG-arm is the Django-parity surface — the pin documents the
-    /// fallback's limitation.
+    /// `distinct_on` + a join now works on every backend (#1039): PG runs
+    /// native `DISTINCT ON`; MySQL/SQLite go through the ROW_NUMBER
+    /// fallback, which emits the join inside the windowed subquery and
+    /// qualifies the model's own columns so they don't collide with the
+    /// joined table. Both tenants have a matching `Tenant`, so the INNER
+    /// JOIN drops nobody → same shape as the no-join distinct_on.
     pub async fn check_distinct_on_with_join_dialect_matrix(pool: &Pool) {
-        let qs = || {
-            Score::objects()
-                .distinct_on(&["tenant_id"])
-                .order_by(&[("tenant_id", false), ("points", true)])
-                .join(Join {
-                    target: Tenant::SCHEMA,
-                    alias: "t",
-                    kind: JoinKind::Inner,
-                    // Inside an `on` predicate bare columns resolve to
-                    // the joined alias — the outer side must be
-                    // explicitly aliased by its table name.
-                    on: WhereExpr::ExprCompare {
-                        lhs: aliased("t", "id"),
-                        op: Op::Eq,
-                        rhs: aliased("d6win_score", "tenant_id"),
-                    },
-                    project: vec![],
-                })
-        };
-        if pool.dialect().name() == "postgres" {
-            let rows: Vec<Score> = qs().fetch(pool).await.expect("PG DISTINCT ON + join");
-            assert_eq!(rows.len(), 2);
-        } else {
-            let err = qs()
-                .fetch(pool)
-                .await
-                .map(|rows: Vec<Score>| rows.len())
-                .expect_err("distinct_on + join must be rejected on the window fallback");
-            match err {
-                ExecError::Sql(SqlError::OpNotSupportedInDialect { op, dialect }) => {
-                    assert!(
-                        op.starts_with("DISTINCT ON combined with joins"),
-                        "unexpected op: {op}"
-                    );
-                    assert_eq!(dialect, pool.dialect().name());
-                }
-                other => panic!(
-                    "expected OpNotSupportedInDialect, got {other:?} — if the \
-                     fallback now supports joins, update the Django 6.0 parity audit"
-                ),
-            }
-        }
+        let rows: Vec<Score> = Score::objects()
+            .distinct_on(&["tenant_id"])
+            .order_by(&[("tenant_id", false), ("points", true)])
+            .join(Join {
+                target: Tenant::SCHEMA,
+                alias: "t",
+                // Inside an `on` predicate bare columns resolve to the
+                // joined alias — the outer side is explicitly aliased.
+                kind: JoinKind::Inner,
+                on: WhereExpr::ExprCompare {
+                    lhs: aliased("t", "id"),
+                    op: Op::Eq,
+                    rhs: aliased("d6win_score", "tenant_id"),
+                },
+                project: vec![],
+            })
+            .fetch(pool)
+            .await
+            .expect("distinct_on + join on every backend");
+        let got: Vec<(i64, String, i64)> = rows
+            .into_iter()
+            .map(|s| (s.tenant_id, s.player, s.points))
+            .collect();
+        assert_eq!(
+            got,
+            vec![(1, "alice".into(), 35), (2, "dave".into(), 100)],
+            "best-scoring row per tenant, with the tenant join applied"
+        );
     }
 
     /// Django top-N-per-group (`annotate(rank=Window(...))` +

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -872,7 +872,7 @@ Status per scenario group (PG / SQLite / MySQL). ✓ = passes asserting Django-e
 | F. Grouping shapes | `values().annotate()` GROUP BY inference, filter-on-annotation → HAVING, `.alias()` non-projected | ✓ | ✓ | ✓ | `django6_aggregation.rs` | WHERE-vs-HAVING auto-routing verified live. |
 | B. Correlated subqueries | `Exists`+`OuterRef` (raw + typed `eq_expr`), NOT EXISTS, exclude-on-relation semantics, `IN (SELECT…)`, has-count, `annotate_count`, scalar `Subquery` in WHERE | ✓ | ✓ | ✓ | `django6_subquery.rs` | `where_doesnt_have_filter` reproduces Django's exclude-NOT-EXISTS semantics exactly (bookless parents included). `OuterRef` misuse pinned (`OuterRefOutsideSubquery`). Scalar `Subquery` as projected annotation inexpressible — #1036. |
 | C. Window functions | rank/dense_rank/lag(default)/first_value+ROWS frame/ntile, partitioned | ✓ | ✓ | ✓* | `django6_window.rs` | *MySQL ranking outputs decode as `SqlValue::Bool` (#1033, pinned). Required shape: `.aggregate().group_by(<every projected col>)`. `Sum(...) OVER` + windowed-subquery missing (#1035); top-N-per-group via `join_lateral` works PG/MySQL, `LateralJoinNotSupported` pinned on SQLite. |
-| K. distinct_on | first-row-per-group, +join | ✓ | ✓ (window fallback) | ✓ (window fallback) | `django6_window.rs` | Fallback rejects joins — pinned `OpNotSupportedInDialect` on SQLite/MySQL (#1039); PG native handles joins. |
+| K. distinct_on | first-row-per-group, +join | ✓ | ✓ (window fallback) | ✓ (window fallback) | `django6_window.rs` | distinct_on + join works tri-dialect (#1039, shipped): PG native DISTINCT ON; the MySQL/SQLite ROW_NUMBER fallback now emits the join inside the windowed subquery and qualifies the model's columns. |
 | D. Multi-join | 3-hop `select_related` stitching, cross-table filter via `.join()`+`aliased`, F-across-join, relation-count inflation | ✓ | ✓ | ✓ | `django6_joins.rs` | Relation-spanning `filter("author__name",…)` (Part 1) + `order_by("author__name")` (Part 2) + `__in`/`__isnull`/`__between` on spans (Part 3) all resolve the FK chain into LEFT JOINs — #1031 fully shipped. `annotate_count` never inflates (correlated subquery ≡ Django `distinct=True`), two relation aggregates chain in one query (#1038), and `.join()` now composes with `.aggregate()` so a group-by-on-a-related-column (`group_by("author.name")`) emits JOIN + GROUP BY (#1040, shipped). |
 | E. Set operations | union dedup/all, per-branch + combined ORDER/LIMIT, intersection, difference, `with_compound` | ✓ | ✓ | ✓* | `django6_setops.rs` | *Ordered/limited branches broken on MySQL — alias-less derived table, error 1248 (#1032, pinned). First-queryset ORDER/LIMIT always combined-scoped (#1034, pinned). INTERSECT/EXCEPT floor: MySQL 8.0.31+. |
 | G. JSON lookups | nested keys, key+index, array length, negative index | ✓ | ✓ (neg. index pinned) | ✓ (neg. index pinned) | `django6_json_dates.rs` | Negative index PG-only — #1027 (Django 6.0 supports SQLite). |
@@ -915,20 +915,20 @@ The 2026-06-12 pass (§26.1–§26.4) pinned a batch of gaps as live issues. PRs
 | #1037 | `__quarter` synthesized on SQLite | #1041 |
 | #1031 **Part 1** | relation-spanning lookups in `filter()`/`exclude()` (`author__name__icontains`) | #1051 |
 | #1031 **Part 2** | relation-spanning `order_by("author__name")` (shared `resolve_span_chain` walk) | #1057 |
-| #1031 **Part 3** | `__in` / `__isnull` / `__between` on relation spans (aliased-LHS `ExprCompare` writer) | this PR |
+| #1031 **Part 3** | `__in` / `__isnull` / `__between` on relation spans (aliased-LHS `ExprCompare` writer) | #1061 |
 | #1038 | two relation aggregates in one query (chained `AggregateBuilder::annotate_count`/`_sum`/…) | #1058 |
 | #1040 | group-by-on-a-related-column — `AggregateQuery.joins` + aliased `group_by("author.name")` | #1059 |
 | #1035 **Part A** | aggregate-as-window (`Sum/Avg/Min/Max/Count OVER`) | #1050 |
 | #1011 | in-admin model reference (admindocs) | #1023 |
 | #1010 | DRF epic — per-action throttling (#1022) + pluggable filter backends (#1021) | (epic closed) |
 | — | QuerySet terminals `fetch` / `count` / `exists` drop the `_pool` suffix | #1054 |
+| #1039 | `distinct_on` + join on MySQL/SQLite — fallback emits the join inside the windowed subquery | this PR |
 
 **Still open (the genuine parity gaps as of this refresh):**
 
 - [#1009](https://github.com/ujeenet/rustango/issues/1009) — GeoDjango geometry breadth beyond `Point` (LineString / Polygon / Multi*). `django-parity`.
 - [#1029](https://github.com/ujeenet/rustango/issues/1029) — surface `rows_affected` from `Model::save` update path (Django 6.0 `Model.NotUpdated`).
 - [#1035](https://github.com/ujeenet/rustango/issues/1035) **remaining** — windowed query as a subquery source (top-N-per-group); aggregate-as-window shipped in Part A.
-- [#1039](https://github.com/ujeenet/rustango/issues/1039) — `distinct_on` window fallback supporting joins on MySQL/SQLite.
 
 ---
 


### PR DESCRIPTION
Closes #1039. `distinct_on(...)` combined with a join now works on **every** backend.

## What
The MySQL/SQLite `ROW_NUMBER() OVER (PARTITION BY …)` fallback for PG's `DISTINCT ON` used to reject joins (`OpNotSupportedInDialect`). It now emits the FK-chain / ad-hoc joins **inside the windowed subquery** and qualifies the model's own columns with the model table so they can't collide with a joined table's column. The derived table `sub` re-exposes them by their bare names for the outer SELECT / ORDER BY. PG keeps native `DISTINCT ON`.

```sql
SELECT <model cols> FROM (
  SELECT "score"."tenant_id", "score"."player", …,
         ROW_NUMBER() OVER (PARTITION BY "score"."tenant_id" ORDER BY …) AS __rn
  FROM "score" INNER JOIN "tenant" AS t ON t."id" = "score"."tenant_id"
) sub WHERE sub.__rn = 1 ORDER BY …
```

Reuses the shared `write_model_joins` helper added in #1040.

## Tests
Flips `tests/django6_window.rs::check_distinct_on_with_join_dialect_matrix` from a PG-only-passes / MySQL+SQLite-rejected pin to a **tri-dialect success** (best-scoring row per tenant, with the tenant INNER JOIN applied). Local: sqlite `django6_window` 9/9; `cargo check --workspace --all-features --all-targets` clean. PG/MySQL validated by CI.

Audit §26.2-K + §26.5 updated. (§26.5 also touched by in-flight #1061 — auto-merge or a tiny rebase.)