### PR TITLE
feat(orm)!: save family returns rows-affected — closes #1029

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -3231,7 +3231,7 @@ fn inherent_impl_tokens(
                     pub async fn save_pool(
                         &mut self,
                         pool: &#root::sql::Pool,
-                    ) -> ::core::result::Result<(), #root::sql::ExecError> {
+                    ) -> ::core::result::Result<u64, #root::sql::ExecError> {
                         let _query = #root::core::UpdateQuery {
                             model: <Self as #root::core::Model>::SCHEMA,
                             set: ::std::vec![ #( #assignments ),* ],
@@ -3254,10 +3254,10 @@ fn inherent_impl_tokens(
                                 #( #pairs ),*
                             ]),
                         };
-                        let _ = #root::audit::save_one_with_audit(
+                        let _affected = #root::audit::save_one_with_audit(
                             pool, &_query, &_audit_entry,
                         ).await?;
-                        ::core::result::Result::Ok(())
+                        ::core::result::Result::Ok(_affected)
                     }
 
                     /// `save_pool` narrowed to a Rust-field allowlist — issue #66
@@ -3273,14 +3273,14 @@ fn inherent_impl_tokens(
                         &mut self,
                         fields: &[&str],
                         pool: &#root::sql::Pool,
-                    ) -> ::core::result::Result<(), #root::sql::ExecError> {
+                    ) -> ::core::result::Result<u64, #root::sql::ExecError> {
                         if fields.is_empty() {
                             #root::__tracing::warn!(
                                 target: "rustango::save_partial",
                                 model = <Self as #root::core::Model>::SCHEMA.name,
                                 "save_partial called with empty field list — no-op"
                             );
-                            return ::core::result::Result::Ok(());
+                            return ::core::result::Result::Ok(0);
                         }
                         let _schema = <Self as #root::core::Model>::SCHEMA;
                         let mut _wanted_cols: ::std::collections::HashSet<&'static str> =
@@ -3314,7 +3314,7 @@ fn inherent_impl_tokens(
                                 model = _schema.name,
                                 "save_partial: every named field maps to a non-assignable column — no-op"
                             );
-                            return ::core::result::Result::Ok(());
+                            return ::core::result::Result::Ok(0);
                         }
                         let _query = #root::core::UpdateQuery {
                             model: _schema,
@@ -3344,10 +3344,10 @@ fn inherent_impl_tokens(
                             source: #root::audit::current_source(),
                             changes: #root::audit::snapshot_changes(&_narrowed),
                         };
-                        let _ = #root::audit::save_one_with_audit(
+                        let _affected = #root::audit::save_one_with_audit(
                             pool, &_query, &_audit_entry,
                         ).await?;
-                        ::core::result::Result::Ok(())
+                        ::core::result::Result::Ok(_affected)
                     }
 
                     /// Typed-column counterpart of [`Self::save_partial`] —
@@ -3374,7 +3374,7 @@ fn inherent_impl_tokens(
                         &mut self,
                         fields: L,
                         pool: &#root::sql::Pool,
-                    ) -> ::core::result::Result<(), #root::sql::ExecError> {
+                    ) -> ::core::result::Result<u64, #root::sql::ExecError> {
                         let _names = fields.rust_field_names();
                         let _refs: ::std::vec::Vec<&str> =
                             _names.iter().copied().collect();
@@ -3386,7 +3386,7 @@ fn inherent_impl_tokens(
             let dispatch_unset = if fields.pk_is_auto {
                 quote! {
                     if matches!(self.#pk_ident, #root::sql::Auto::Unset) {
-                        return self.insert_pool(pool).await;
+                        return self.insert_pool(pool).await.map(|()| 1u64);
                     }
                 }
             } else {
@@ -3402,7 +3402,7 @@ fn inherent_impl_tokens(
                 pub async fn save_pool(
                     &mut self,
                     pool: &#root::sql::Pool,
-                ) -> ::core::result::Result<(), #root::sql::ExecError> {
+                ) -> ::core::result::Result<u64, #root::sql::ExecError> {
                     #dispatch_unset
                     let _query = #root::core::UpdateQuery {
                         model: <Self as #root::core::Model>::SCHEMA,
@@ -3417,8 +3417,8 @@ fn inherent_impl_tokens(
                             }
                         ),
                     };
-                    let _ = #root::sql::update_pool(pool, &_query).await?;
-                    ::core::result::Result::Ok(())
+                    let _affected = #root::sql::update_pool(pool, &_query).await?;
+                    ::core::result::Result::Ok(_affected)
                 }
 
                 /// Save (UPDATE) only the listed Rust-side fields,
@@ -3453,14 +3453,14 @@ fn inherent_impl_tokens(
                     &mut self,
                     fields: &[&str],
                     pool: &#root::sql::Pool,
-                ) -> ::core::result::Result<(), #root::sql::ExecError> {
+                ) -> ::core::result::Result<u64, #root::sql::ExecError> {
                     if fields.is_empty() {
                         #root::__tracing::warn!(
                             target: "rustango::save_partial",
                             model = <Self as #root::core::Model>::SCHEMA.name,
                             "save_partial called with empty field list — no-op"
                         );
-                        return ::core::result::Result::Ok(());
+                        return ::core::result::Result::Ok(0);
                     }
                     let _schema = <Self as #root::core::Model>::SCHEMA;
                     // Validate field names against the schema.
@@ -3501,7 +3501,7 @@ fn inherent_impl_tokens(
                             model = _schema.name,
                             "save_partial: every named field maps to a non-assignable column — no-op"
                         );
-                        return ::core::result::Result::Ok(());
+                        return ::core::result::Result::Ok(0);
                     }
                     let _query = #root::core::UpdateQuery {
                         model: _schema,
@@ -3516,8 +3516,8 @@ fn inherent_impl_tokens(
                             }
                         ),
                     };
-                    let _ = #root::sql::update_pool(pool, &_query).await?;
-                    ::core::result::Result::Ok(())
+                    let _affected = #root::sql::update_pool(pool, &_query).await?;
+                    ::core::result::Result::Ok(_affected)
                 }
 
                 /// Typed-column counterpart of [`Self::save_partial`] —
@@ -3545,7 +3545,7 @@ fn inherent_impl_tokens(
                     &mut self,
                     fields: L,
                     pool: &#root::sql::Pool,
-                ) -> ::core::result::Result<(), #root::sql::ExecError> {
+                ) -> ::core::result::Result<u64, #root::sql::ExecError> {
                     let _names = fields.rust_field_names();
                     let _refs: ::std::vec::Vec<&str> =
                         _names.iter().copied().collect();
@@ -3735,7 +3735,7 @@ fn inherent_impl_tokens(
             let unset_dispatch = if fields.has_auto {
                 quote! {
                     if matches!(self.#pk_ident, #root::sql::Auto::Unset) {
-                        return self.insert_pool(pool).await;
+                        return self.insert_pool(pool).await.map(|()| 1u64);
                     }
                 }
             } else {
@@ -3758,7 +3758,7 @@ fn inherent_impl_tokens(
                 pub async fn save_pool(
                     &mut self,
                     pool: &#root::sql::Pool,
-                ) -> ::core::result::Result<(), #root::sql::ExecError> {
+                ) -> ::core::result::Result<u64, #root::sql::ExecError> {
                     #unset_dispatch
                     let _query = #root::core::UpdateQuery {
                         model: <Self as #root::core::Model>::SCHEMA,
@@ -6318,7 +6318,7 @@ fn inherent_impl_tokens(
         let dispatch_unset = if fields.pk_is_auto {
             quote! {
                 if matches!(self.#pk_ident, #root::sql::Auto::Unset) {
-                    return self.insert_tx(tx).await;
+                    return self.insert_tx(tx).await.map(|()| 1u64);
                 }
             }
         } else {
@@ -6334,7 +6334,7 @@ fn inherent_impl_tokens(
             pub async fn save_tx(
                 &mut self,
                 tx: &mut #root::sql::PoolTx<'_>,
-            ) -> ::core::result::Result<(), #root::sql::ExecError> {
+            ) -> ::core::result::Result<u64, #root::sql::ExecError> {
                 #dispatch_unset
                 let _query = #root::core::UpdateQuery {
                     model: <Self as #root::core::Model>::SCHEMA,
@@ -6349,8 +6349,8 @@ fn inherent_impl_tokens(
                         }
                     ),
                 };
-                let _ = #root::sql::update_tx(tx, &_query).await?;
-                ::core::result::Result::Ok(())
+                let _affected = #root::sql::update_tx(tx, &_query).await?;
+                ::core::result::Result::Ok(_affected)
             }
         }
     } else {
@@ -6599,7 +6599,7 @@ fn inherent_impl_tokens(
             pub async fn save(
                 &mut self,
                 pool: &#root::sql::sqlx::PgPool,
-            ) -> ::core::result::Result<(), #root::sql::ExecError> {
+            ) -> ::core::result::Result<u64, #root::sql::ExecError> {
                 #pool_to_save_on
             }
 
@@ -6617,11 +6617,14 @@ fn inherent_impl_tokens(
             pub async fn save_on #executor_generics (
                 &mut self,
                 #executor_param,
-            ) -> ::core::result::Result<(), #root::sql::ExecError>
+            ) -> ::core::result::Result<u64, #root::sql::ExecError>
             #executor_where
             {
+                // #1029 — INSERT writes exactly one row → 1; UPDATE returns
+                // the rows-affected count (0 when the PK no longer exists,
+                // the Django 6.0 `Model.NotUpdated` signal).
                 if matches!(self.#pk_ident, #root::sql::Auto::Unset) {
-                    return self.insert_on(#executor_passes_to_data_write).await;
+                    return self.insert_on(#executor_passes_to_data_write).await.map(|()| 1u64);
                 }
                 #audit_update_pre
                 let _query = #root::core::UpdateQuery {
@@ -6637,12 +6640,12 @@ fn inherent_impl_tokens(
                         }
                     ),
                 };
-                let _ = #root::sql::__macro_internals::update_on(
+                let _affected = #root::sql::__macro_internals::update_on(
                     #executor_passes_to_data_write,
                     &_query,
                 ).await?;
                 #audit_update_post
-                ::core::result::Result::Ok(())
+                ::core::result::Result::Ok(_affected)
             }
 
             /// Per-call override for the audit source. Runs
@@ -6660,7 +6663,7 @@ fn inherent_impl_tokens(
                 &mut self,
                 #executor_param,
                 source: #root::audit::AuditSource,
-            ) -> ::core::result::Result<(), #root::sql::ExecError>
+            ) -> ::core::result::Result<u64, #root::sql::ExecError>
             #executor_where
             {
                 #root::audit::with_source(source, self.save_on(_executor)).await

--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -1407,7 +1407,7 @@ pub async fn save_one_with_diff<F1, F2, F3>(
     decode_before_pg: F1,
     decode_before_my: F2,
     decode_before_sqlite: F3,
-) -> Result<(), crate::sql::ExecError>
+) -> Result<u64, crate::sql::ExecError>
 where
     F1: FnOnce(&crate::sql::PgReturningRow) -> Vec<(&'static str, serde_json::Value)>,
     F2: FnOnce(&crate::sql::MyReturningRow) -> Vec<(&'static str, serde_json::Value)>,
@@ -1439,7 +1439,7 @@ where
                     _ => None,
                 };
             let mut wrapped = crate::sql::PoolTx::Postgres(tx);
-            finish_update_with_audit_diff(
+            let _affected = finish_update_with_audit_diff(
                 &mut wrapped,
                 &stmt,
                 before_pairs,
@@ -1449,7 +1449,7 @@ where
             )
             .await?;
             wrapped.commit().await?;
-            Ok(())
+            Ok(_affected)
         }
         #[cfg(feature = "mysql")]
         crate::sql::Pool::Mysql(my) => {
@@ -1466,7 +1466,7 @@ where
                     _ => None,
                 };
             let mut wrapped = crate::sql::PoolTx::Mysql(tx);
-            finish_update_with_audit_diff(
+            let _affected = finish_update_with_audit_diff(
                 &mut wrapped,
                 &stmt,
                 before_pairs,
@@ -1476,7 +1476,7 @@ where
             )
             .await?;
             wrapped.commit().await?;
-            Ok(())
+            Ok(_affected)
         }
         #[cfg(feature = "sqlite")]
         crate::sql::Pool::Sqlite(sq) => {
@@ -1493,7 +1493,7 @@ where
                     _ => None,
                 };
             let mut wrapped = crate::sql::PoolTx::Sqlite(tx);
-            finish_update_with_audit_diff(
+            let _affected = finish_update_with_audit_diff(
                 &mut wrapped,
                 &stmt,
                 before_pairs,
@@ -1503,7 +1503,7 @@ where
             )
             .await?;
             wrapped.commit().await?;
-            Ok(())
+            Ok(_affected)
         }
     }
 }
@@ -1520,8 +1520,10 @@ async fn finish_update_with_audit_diff(
     after_pairs: &[(&'static str, serde_json::Value)],
     entity_table: &'static str,
     entity_pk: &str,
-) -> Result<(), crate::sql::ExecError> {
-    crate::sql::raw_execute_tx(tx, &stmt.sql, stmt.params.clone()).await?;
+) -> Result<u64, crate::sql::ExecError> {
+    // #1029 — surface the UPDATE's rows-affected (0 when the PK no
+    // longer exists, the Django 6.0 `Model.NotUpdated` signal).
+    let _affected = crate::sql::raw_execute_tx(tx, &stmt.sql, stmt.params.clone()).await?;
     if let Some(before) = before_pairs {
         let entry = PendingEntry {
             entity_table,
@@ -1532,5 +1534,5 @@ async fn finish_update_with_audit_diff(
         };
         emit_one_tx(tx, &entry).await?;
     }
-    Ok(())
+    Ok(_affected)
 }

--- a/crates/rustango/tests/django6_writes.rs
+++ b/crates/rustango/tests/django6_writes.rs
@@ -172,11 +172,10 @@ mod scenarios {
     }
 
     /// Django 6.0 NEW: a forced update affecting 0 rows raises
-    /// `Model.NotUpdated`. rustango: the QuerySet update path DOES
-    /// surface rows-affected (0 here), but the instance-level
-    /// `save_pool` on a stale row silently returns `Ok(())` — the
-    /// macro discards rows-affected. DIVERGENCE PIN: this goes red — issue #1029 —
-    /// (and the audit row flips) if save ever starts surfacing it.
+    /// `Model.NotUpdated`. rustango's analogue (#1029): the whole save
+    /// family returns `Result<u64, _>` — a 0-row UPDATE surfaces as
+    /// `Ok(0)` and an INSERT as `Ok(1)`, so userland can `if n == 0 {…}`
+    /// (no exception, matching rustango's no-raise convention).
     pub async fn check_zero_row_update_semantics(pool: &Pool) {
         // QuerySet path: no match → 0 affected, no error. Same as
         // Django's `.update()` (which never raises NotUpdated).
@@ -199,10 +198,11 @@ mod scenarios {
             .await
             .expect("delete behind the instance's back");
         stale.qty = 99;
-        stale
-            .save_pool(pool)
-            .await
-            .expect("PINNED DIVERGENCE: rustango save() is silent on 0-row update; Django 6.0 raises Model.NotUpdated");
+        // #1029 — a 0-row UPDATE now surfaces as `Ok(0)` (rustango's
+        // analogue of Django 6.0's `Model.NotUpdated` — we return the
+        // count rather than raising) instead of a silent `Ok(())`.
+        let affected = stale.save_pool(pool).await.expect("save on a stale row");
+        assert_eq!(affected, 0, "stale-row save affected zero rows");
         assert_eq!(
             Sku::objects()
                 .filter("code", "stale")
@@ -211,8 +211,12 @@ mod scenarios {
                 .map(|rows: Vec<Sku>| rows.len())
                 .unwrap(),
             0,
-            "the silent save really did update nothing"
+            "the save really did update nothing"
         );
+        // A fresh row (Unset PK) inserts → exactly one row affected.
+        let mut fresh = sku("notupdated_fresh", 7, 7);
+        let inserted = fresh.save_pool(pool).await.expect("insert fresh");
+        assert_eq!(inserted, 1, "insert affects one row");
     }
 
     /// Django `get_or_create(code="goc")` — create-then-find.

--- a/docs/django-parity-audit-2026-05-21.md
+++ b/docs/django-parity-audit-2026-05-21.md
@@ -854,7 +854,7 @@ Run locally: `docker-compose up -d`, then per backend —
 | `Aggregate(order_by=...)` (new; deprecates PG `OrderableAggMixin`) | SHIPPED 2026-06-13 — ordered `StringAgg`, PR #1047 | `django6_aggregation.rs` | #1026 (closed) |
 | `JSONField` negative array index on SQLite (new) | SHIPPED 2026-06-13 — synthesized on SQLite, PR #1042 (MySQL N/A upstream — `$[N]` is non-negative-only) | `django6_json_dates.rs::check_negative_index_dialect_matrix` | #1027 (closed) |
 | `GeneratedField` auto-refresh after `save()` via RETURNING | SHIPPED (PG/SQLite) — decoded from the `INSERT … RETURNING` row back into the struct; MySQL deferred (no RETURNING), matches Django | `django6_delta.rs::check_generated_column_refreshed_on_save` | #1028 (closed) |
-| `Model.NotUpdated` on forced 0-row update | DIVERGES — QuerySet `update_pool` surfaces rows-affected (0), instance `save_pool` silently `Ok(())` | `django6_writes.rs::check_zero_row_update_semantics` | #1029 |
+| `Model.NotUpdated` on forced 0-row update | SHIPPED (analogue) — the whole save family returns `Result<u64, _>`: a 0-row UPDATE → `Ok(0)`, an INSERT → `Ok(1)`. No raise (rustango's no-exception convention); userland checks the count. | `django6_writes.rs::check_zero_row_update_semantics` | #1029 (closed) |
 | `CompositePrimaryKey` in `raw()` / subquery lookups beyond `__in` | N/A BY ARCHITECTURE — composite-key idiom is surrogate `Auto<i64>` + `unique_together`; tuple-membership `(a,b) IN (SELECT…)` has no API (workaround: multi-predicate correlated EXISTS) | `django6_subquery.rs` header note | — |
 | `bulk_create(update_conflicts=True, unique_fields, update_fields)` | SHIPPED — verified incl. two-column composite conflict target + update-listed-columns-only | `django6_writes.rs::check_bulk_upsert_*` | — |
 | `DEFAULT_AUTO_FIELD` → `BigAutoField` default | SHIPPED — `Auto<i64>` ↔ BIGSERIAL / BIGINT AUTO_INCREMENT / INTEGER PK on all three | `django6_delta.rs::check_auto_pk_is_big_auto_field` | — |
@@ -877,7 +877,7 @@ Status per scenario group (PG / SQLite / MySQL). ✓ = passes asserting Django-e
 | E. Set operations | union dedup/all, per-branch + combined ORDER/LIMIT, intersection, difference, `with_compound` | ✓ | ✓ | ✓* | `django6_setops.rs` | *Ordered/limited branches broken on MySQL — alias-less derived table, error 1248 (#1032, pinned). First-queryset ORDER/LIMIT always combined-scoped (#1034, pinned). INTERSECT/EXCEPT floor: MySQL 8.0.31+. |
 | G. JSON lookups | nested keys, key+index, array length, negative index | ✓ | ✓ (neg. index pinned) | ✓ (neg. index pinned) | `django6_json_dates.rs` | Negative index PG-only — #1027 (Django 6.0 supports SQLite). |
 | H. Date transforms | `__year__gte` chains, `__month`, `__quarter`, `.dates()`, `.datetimes()` | ✓ | ✓ (`__quarter` pinned) | ✓ | `django6_json_dates.rs` | `__quarter` errors on SQLite — #1037. `.dates()/.datetimes()` truncation identical tri-dialect. |
-| I. Complex writes | bulk_upsert (single + composite target), F-expression update, Case-in-UPDATE, 0-row semantics, get/update_or_create | ✓ | ✓ | ✓ | `django6_writes.rs` | 0-row instance-save divergence pinned — #1029. |
+| I. Complex writes | bulk_upsert (single + composite target), F-expression update, Case-in-UPDATE, 0-row semantics, get/update_or_create | ✓ | ✓ | ✓ | `django6_writes.rs` | save family returns rows-affected — 0-row UPDATE → `Ok(0)`, INSERT → `Ok(1)` (#1029, shipped). |
 
 ### 26.3 Corrections to earlier sections (claims disproven by execution)
 
@@ -922,12 +922,12 @@ The 2026-06-12 pass (§26.1–§26.4) pinned a batch of gaps as live issues. PRs
 | #1011 | in-admin model reference (admindocs) | #1023 |
 | #1010 | DRF epic — per-action throttling (#1022) + pluggable filter backends (#1021) | (epic closed) |
 | — | QuerySet terminals `fetch` / `count` / `exists` drop the `_pool` suffix | #1054 |
-| #1039 | `distinct_on` + join on MySQL/SQLite — fallback emits the join inside the windowed subquery | this PR |
+| #1039 | `distinct_on` + join on MySQL/SQLite — fallback emits the join inside the windowed subquery | #1062 |
+| #1029 | save family returns `Result<u64>` — 0-row UPDATE → `Ok(0)`, INSERT → `Ok(1)` (**breaking**) | this PR |
 
 **Still open (the genuine parity gaps as of this refresh):**
 
 - [#1009](https://github.com/ujeenet/rustango/issues/1009) — GeoDjango geometry breadth beyond `Point` (LineString / Polygon / Multi*). `django-parity`.
-- [#1029](https://github.com/ujeenet/rustango/issues/1029) — surface `rows_affected` from `Model::save` update path (Django 6.0 `Model.NotUpdated`).
 - [#1035](https://github.com/ujeenet/rustango/issues/1035) **remaining** — windowed query as a subquery source (top-N-per-group); aggregate-as-window shipped in Part A.
 
 ---


### PR DESCRIPTION
⚠️ **BREAKING** — closes #1029 (Django 6.0 `Model.NotUpdated` analogue).

## What
The whole instance save family now returns **`Result<u64, ExecError>`** instead of `Result<(), ExecError>`:
`save` / `save_on` / `save_on_with` / `save_tx` / `save_pool` / `save_partial` / `save_partial_typed`.
- INSERT → `Ok(1)`
- UPDATE → `Ok(rows_affected)` — **`Ok(0)` when the PK no longer exists** (the stale-row case Django 6.0 flags via `Model.NotUpdated`; rustango returns the count instead of raising, per its no-exception convention).

```rust
let n = post.save_pool(&pool).await?;
if n == 0 { /* row vanished — Django 6.0 Model.NotUpdated */ }
```

## ⚠️ Breaking impact
`?`-propagating callers are **unaffected** (the `u64` is just dropped). Callers that **bind or match `Ok(())`** from a `save*()` must change to `let _ = …` (or use the count). **This will hit `Ok(())` save-matchers in rustango-cms / Tango** — a one-line fix per site. All in-repo callers were verified clean (`cargo check --workspace --all-features --all-targets`).

## How
Threaded the count through every save method (INSERT arm `.map(|()| 1)`, UPDATE arm captures the executors rows-affected). The audited paths needed `audit::save_one_with_diff` + `finish_update_with_audit_diff` to also return the count (that missed `()` tail was breaking audited + Auto-PK models).

## Tests
Flips `tests/django6_writes.rs::check_zero_row_update_semantics`: stale-row save → `Ok(0)`, fresh insert → `Ok(1)`. Local: sqlite `django6_writes` 7/7; full `--all-features --all-targets` gate clean (the real check for a signature change). PG/MySQL validated by CI.

Audit §26.1 + §26.2-I + §26.5 updated. **This closes the parity sweep** — #1009 (GeoDjango breadth) is the only remaining open issue.