### PR TITLE
feat(viewset): marry ViewSets + serializers — render + validate (tri-dialect)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -13021,9 +13021,21 @@ fn expand_serializer(input: &DeriveInput) -> syn::Result<TokenStream2> {
             }
         }
     });
-    let validate_method = if validator_calls.is_empty() && container.cross_validate.is_none() {
-        quote! {}
-    } else {
+    let has_validators = !validator_calls.is_empty() || container.cross_validate.is_some();
+    // Shared body: run per-field validators, then the cross-field hook.
+    let validate_body = quote! {
+        let mut __errors = #root::forms::FormErrors::default();
+        #( #validator_calls )*
+        #cross_validate_call
+        if __errors.is_empty() {
+            ::core::result::Result::Ok(())
+        } else {
+            ::core::result::Result::Err(__errors)
+        }
+    };
+    // Inherent `validate(&self)` — kept for back-compat with direct
+    // `serializer.validate()` calls that don't import `ModelSerializer`.
+    let validate_method = if has_validators {
         quote! {
             impl #struct_name {
                 /// Run every `#[serializer(validate = "...")]` per-field
@@ -13033,17 +13045,24 @@ fn expand_serializer(input: &DeriveInput) -> syn::Result<TokenStream2> {
                 /// non-field keys the cross-field method adds).
                 /// Returns `Ok(())` when all pass.
                 pub fn validate(&self) -> ::core::result::Result<(), #root::forms::FormErrors> {
-                    let mut __errors = #root::forms::FormErrors::default();
-                    #( #validator_calls )*
-                    #cross_validate_call
-                    if __errors.is_empty() {
-                        ::core::result::Result::Ok(())
-                    } else {
-                        ::core::result::Result::Err(__errors)
-                    }
+                    #validate_body
                 }
             }
         }
+    } else {
+        quote! {}
+    };
+    // Trait-method override so the type-erased ViewSet write path can
+    // dispatch `ModelSerializer::validate` generically. When there are
+    // no validators the trait's default no-op is used instead.
+    let trait_validate_override = if has_validators {
+        quote! {
+            fn validate(&self) -> ::core::result::Result<(), #root::forms::FormErrors> {
+                #validate_body
+            }
+        }
+    } else {
+        quote! {}
     };
 
     // For every `#[serializer(many = S)]` field, emit a
@@ -13107,17 +13126,68 @@ fn expand_serializer(input: &DeriveInput) -> syn::Result<TokenStream2> {
     // path accept those fields from the JSON body and try to bind
     // them to the SQL UPDATE — a silent no-op at best, a type
     // mismatch at worst.
+    let is_writable = |fi: &&FieldInfo| {
+        !fi.attrs.read_only
+            && !fi.attrs.skip
+            && fi.attrs.method.is_none()
+            && !fi.attrs.nested
+            && fi.attrs.many.is_none()
+            && fi.attrs.slug.is_none()
+    };
     let writable_lits: Vec<_> = fields_info
         .iter()
-        .filter(|fi| {
-            !fi.attrs.read_only
-                && !fi.attrs.skip
-                && fi.attrs.method.is_none()
-                && !fi.attrs.nested
-                && fi.attrs.many.is_none()
-                && fi.attrs.slug.is_none()
-        })
+        .filter(is_writable)
         .map(|fi| fi.ident.to_string())
+        .collect();
+
+    // `writable_source_fields`: the MODEL field names of writable
+    // serializer fields (source-resolved). The ViewSet write path skips
+    // every model column NOT in this set, so `read_only` / `method` /
+    // computed fields a client posts are ignored instead of written.
+    let writable_source_lits: Vec<String> = fields_info
+        .iter()
+        .filter(is_writable)
+        .map(|fi| {
+            fi.attrs
+                .source
+                .clone()
+                .unwrap_or_else(|| fi.ident.to_string())
+        })
+        .collect();
+
+    // `from_writable_json`: build a partial instance for input
+    // validation. Writable fields are parsed from the JSON body (keyed
+    // by serializer field name); every other field defaults. Per-field
+    // type errors collect into `FormErrors` keyed by the field name.
+    // Construction is field-by-field (not `Self::default()`) so it works
+    // for serializers regardless of a struct-level `Default`.
+    let from_writable_json_inits: Vec<_> = fields_info
+        .iter()
+        .map(|fi| {
+            let ident = &fi.ident;
+            let fname = ident.to_string();
+            let ty = &fi.ty;
+            if is_writable(&fi) {
+                quote! {
+                    #ident: match __obj.and_then(|__o| __o.get(#fname)) {
+                        ::core::option::Option::Some(__v) => {
+                            match #root::__serde_json::from_value::<#ty>(
+                                ::core::clone::Clone::clone(__v),
+                            ) {
+                                ::core::result::Result::Ok(__x) => __x,
+                                ::core::result::Result::Err(__e) => {
+                                    __errors.add(#fname.to_owned(), __e.to_string());
+                                    ::core::default::Default::default()
+                                }
+                            }
+                        }
+                        ::core::option::Option::None => ::core::default::Default::default(),
+                    }
+                }
+            } else {
+                quote! { #ident: ::core::default::Default::default() }
+            }
+        })
         .collect();
 
     // OpenAPI: emit `impl OpenApiSchema` when our `openapi` feature is on.
@@ -13177,6 +13247,27 @@ fn expand_serializer(input: &DeriveInput) -> syn::Result<TokenStream2> {
             fn writable_fields() -> &'static [&'static str] {
                 &[ #( #writable_lits ),* ]
             }
+
+            fn writable_source_fields() -> &'static [&'static str] {
+                &[ #( #writable_source_lits ),* ]
+            }
+
+            fn from_writable_json(
+                __body: &#root::__serde_json::Value,
+            ) -> ::core::result::Result<Self, #root::forms::FormErrors> {
+                let mut __errors = #root::forms::FormErrors::default();
+                let __obj = __body.as_object();
+                let __out = Self {
+                    #( #from_writable_json_inits ),*
+                };
+                if __errors.is_empty() {
+                    ::core::result::Result::Ok(__out)
+                } else {
+                    ::core::result::Result::Err(__errors)
+                }
+            }
+
+            #trait_validate_override
         }
 
         impl #root::__serde::Serialize for #struct_name {

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -85,6 +85,11 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
 /// * `ordering = "a, -b"` — default list ordering; prefix `-` for DESC.
 /// * `page_size = N` — default page size (default: 20, max: 1000).
 /// * `read_only` — flag; wires only `list` + `retrieve` (no mutations).
+/// * `serializer = SomeSerializer` — render list / retrieve / create
+///   responses through a `#[derive(Serializer)]` type instead of the
+///   default field-level projection (`read_only` / `source` / `method`
+///   / `write_only` overrides apply). Tri-dialect. Requires the
+///   `serializer` feature.
 /// * `permissions(list = "...", retrieve = "...", create = "...",
 ///   update = "...", destroy = "...")` — codenames required per action.
 #[proc_macro_derive(ViewSet, attributes(viewset))]
@@ -12414,6 +12419,11 @@ struct ViewSetAttrs {
     page_size: Option<usize>,
     read_only: bool,
     perms: ViewSetPermsAttrs,
+    /// `#[viewset(serializer = SomeSerializer)]` — render list /
+    /// retrieve / create responses through this `#[derive(Serializer)]`
+    /// type instead of the default field-level projection (requires the
+    /// `serializer` feature). Tri-dialect.
+    serializer: Option<syn::Path>,
 }
 
 #[derive(Default)]
@@ -12495,6 +12505,15 @@ fn expand_viewset(input: &DeriveInput) -> syn::Result<TokenStream2> {
         quote!()
     };
 
+    // `.serializer::<S>()` — reshape responses through a derived
+    // serializer. Requires the downstream crate to enable the
+    // `serializer` feature (the method is gated on it).
+    let serializer_call = if let Some(ref ser) = attrs.serializer {
+        quote!(.serializer::<#ser>())
+    } else {
+        quote!()
+    };
+
     let perms = &attrs.perms;
     let perms_call = if perms.list.is_empty()
         && perms.retrieve.is_empty()
@@ -12535,6 +12554,7 @@ fn expand_viewset(input: &DeriveInput) -> syn::Result<TokenStream2> {
                     #page_size_call
                     #perms_call
                     #read_only_call
+                    #serializer_call
                     .router(prefix, pool)
             }
         }
@@ -12550,6 +12570,7 @@ fn parse_viewset_attrs(input: &DeriveInput) -> syn::Result<ViewSetAttrs> {
     let mut page_size: Option<usize> = None;
     let mut read_only = false;
     let mut perms = ViewSetPermsAttrs::default();
+    let mut serializer: Option<syn::Path> = None;
 
     for attr in &input.attrs {
         if !attr.path().is_ident("viewset") {
@@ -12559,6 +12580,11 @@ fn parse_viewset_attrs(input: &DeriveInput) -> syn::Result<ViewSetAttrs> {
             if meta.path.is_ident("model") {
                 let path: syn::Path = meta.value()?.parse()?;
                 model = Some(path);
+                return Ok(());
+            }
+            if meta.path.is_ident("serializer") {
+                let path: syn::Path = meta.value()?.parse()?;
+                serializer = Some(path);
                 return Ok(());
             }
             if meta.path.is_ident("fields") {
@@ -12617,7 +12643,7 @@ fn parse_viewset_attrs(input: &DeriveInput) -> syn::Result<ViewSetAttrs> {
             }
             Err(meta.error(
                 "unknown viewset attribute (supported: model, fields, filter_fields, \
-                 search_fields, ordering, page_size, read_only, permissions(...))",
+                 search_fields, ordering, page_size, read_only, serializer, permissions(...))",
             ))
         })?;
     }
@@ -12635,6 +12661,7 @@ fn parse_viewset_attrs(input: &DeriveInput) -> syn::Result<ViewSetAttrs> {
         page_size,
         read_only,
         perms,
+        serializer,
     })
 }
 

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -988,10 +988,12 @@ pub mod extractors;
 ///
 /// v0.38 — fully tri-dialect. Internal queries route through
 /// `select_rows_as_json` + `insert_returning_pool` etc., so the
-/// same ViewSet body runs on PG / MySQL / SQLite. The `.serializer()`
-/// row-render extension stays PG-only because it decodes via
-/// `T::from_row(&PgRow)`; non-PG ViewSets use the default field-level
-/// JSON projection.
+/// same ViewSet body runs on PG / MySQL / SQLite. v0.45 — the
+/// `.serializer()` render extension is tri-dialect too: it fetches
+/// typed `Vec<S::Model>` via `select_rows_pool_with_related` (which
+/// decodes on every backend) and renders list / retrieve / create
+/// responses through `S::from_model`, so the serializer's shape
+/// applies on PG, MySQL **and** SQLite.
 ///
 /// The `router(prefix, &PgPool)` (static-pool) entry point keeps its
 /// PG-typed pool arg for source-compat; `tenant_router(prefix)`

--- a/crates/rustango/src/serializer/mod.rs
+++ b/crates/rustango/src/serializer/mod.rs
@@ -173,6 +173,47 @@ pub trait ModelSerializer: serde::Serialize + Sized {
     /// and `skip` fields). Used by the ViewSet write path to filter the
     /// incoming JSON body.
     fn writable_fields() -> &'static [&'static str];
+
+    /// The **model** field names of the writable serializer fields
+    /// (`source`-resolved). The ViewSet write path skips every model
+    /// column NOT in this set, so `read_only` / `method` / computed
+    /// fields a client posts are ignored instead of written.
+    ///
+    /// For a field with `#[serializer(source = "x")]` this is `"x"`; for
+    /// a plain field it's the field name. Defaults to
+    /// [`Self::writable_fields`] (correct when no `source` rename is in
+    /// play); the derive macro overrides it with the resolved names.
+    fn writable_source_fields() -> &'static [&'static str] {
+        Self::writable_fields()
+    }
+
+    /// Build a partial instance from a JSON request body for **input
+    /// validation**: writable fields are parsed (by serializer field
+    /// name); read-only / computed fields default. Per-field type errors
+    /// land in [`crate::forms::FormErrors`] keyed by the field name. The
+    /// derive macro generates this; the default errors out so a manual
+    /// impl that forgets it fails loudly rather than silently skipping
+    /// validation.
+    ///
+    /// # Errors
+    /// A `FormErrors` carrying every field that failed to parse.
+    fn from_writable_json(body: &Value) -> Result<Self, crate::forms::FormErrors> {
+        let _ = body;
+        let mut errors = crate::forms::FormErrors::default();
+        errors.add_non_field("from_writable_json not implemented for this serializer");
+        Err(errors)
+    }
+
+    /// Cross-field / per-field validation hook (DRF `validate`). The
+    /// derive macro overrides this when the serializer declares any
+    /// `#[serializer(validate = "...")]` field validator or a container
+    /// `validate = "..."` cross-field method. Default: no-op.
+    ///
+    /// # Errors
+    /// A [`crate::forms::FormErrors`] aggregating every failed rule.
+    fn validate(&self) -> Result<(), crate::forms::FormErrors> {
+        Ok(())
+    }
 }
 
 /// Django-shape `UniqueTogetherValidator` — pre-save check that a

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -290,6 +290,17 @@ trait SerializerBridge: Send + Sync {
         acq: &'a mut AcquiredConn,
         q: &'a SelectQuery,
     ) -> Pin<Box<dyn Future<Output = Result<Option<Value>, crate::sql::ExecError>> + Send + 'a>>;
+
+    /// Run the serializer's input validation against a JSON request body:
+    /// parse the writable fields (DRF read shape) then call the
+    /// serializer's `validate()` hook. `Err` carries DRF-shape field
+    /// errors for a 400 response.
+    fn validate_body(&self, body: &Value) -> Result<(), crate::forms::FormErrors>;
+
+    /// The **model** field names the serializer accepts on write
+    /// (`source`-resolved). The write path skips every other model column
+    /// so `read_only` / computed fields can't be set by a client.
+    fn writable_model_fields(&self) -> &'static [&'static str];
 }
 
 /// Zero-sized carrier that pins a concrete serializer type `S` so the
@@ -332,6 +343,17 @@ where
             let models = acq.select_rows_typed::<S::Model>(q).await?;
             Ok(models.first().map(|m| S::from_model(m).to_value()))
         })
+    }
+
+    fn validate_body(&self, body: &Value) -> Result<(), crate::forms::FormErrors> {
+        // Parse the writable fields into a partial serializer instance
+        // (surfacing per-field type errors), then run its validation hook.
+        let s = S::from_writable_json(body)?;
+        s.validate()
+    }
+
+    fn writable_model_fields(&self) -> &'static [&'static str] {
+        S::writable_source_fields()
     }
 }
 
@@ -999,6 +1021,49 @@ fn json_error(status: StatusCode, msg: &str) -> Response {
     json_with_status(status, json!({ "error": msg }))
 }
 
+/// `400` from serializer validation, DRF shape:
+/// `{"<field>": ["msg", …], …, "non_field_errors": [ … ]}`.
+fn json_form_errors(errs: &crate::forms::FormErrors) -> Response {
+    let mut map = serde_json::Map::new();
+    for (field, msgs) in errs.fields() {
+        map.insert(field.clone(), json!(msgs));
+    }
+    if !errs.non_field().is_empty() {
+        map.insert("non_field_errors".to_owned(), json!(errs.non_field()));
+    }
+    json_with_status(StatusCode::BAD_REQUEST, Value::Object(map))
+}
+
+/// When a serializer is registered, validate the JSON request body (if
+/// present) through it and compute the extra model fields to skip on
+/// write — every column the serializer doesn't accept (`read_only` /
+/// computed). Returns the 400 response on a validation failure so the
+/// caller can short-circuit. No-op (`Ok(vec![])`) without a serializer.
+fn serializer_write_prep(
+    state: &ViewSetState,
+    json: Option<&Value>,
+) -> Result<Vec<&'static str>, Response> {
+    match &state.vs.serializer {
+        Some(bridge) => {
+            if let Some(body) = json {
+                if let Err(errs) = bridge.validate_body(body) {
+                    return Err(json_form_errors(&errs));
+                }
+            }
+            let writable = bridge.writable_model_fields();
+            let extra_skip = state
+                .vs
+                .schema
+                .scalar_fields()
+                .map(|f| f.name)
+                .filter(|n| !writable.contains(n))
+                .collect();
+            Ok(extra_skip)
+        }
+        None => Ok(Vec::new()),
+    }
+}
+
 /// Unwrap-or-return-500. Collapses the `match expr { Ok(v) => v,
 /// Err(e) => return json_error(INTERNAL_SERVER_ERROR, &e.to_string()) }`
 /// shape that recurred ~5× in handler bodies. Issue #808 (item 4).
@@ -1628,7 +1693,9 @@ async fn handle_create(
     };
 
     match create_body {
-        CreateBody::Single(form) => create_one(&state, &mut acq, &form, &skip, pk_field).await,
+        CreateBody::Single(form, json) => {
+            create_one(&state, &mut acq, &form, json.as_ref(), &skip, pk_field).await
+        }
         CreateBody::Bulk(rows) => create_many(&state, &mut acq, &rows, &skip, pk_field).await,
     }
 }
@@ -1683,10 +1750,19 @@ async fn create_one(
     state: &Arc<ViewSetState>,
     acq: &mut AcquiredConn,
     form: &HashMap<String, String>,
+    json: Option<&Value>,
     skip: &[&str],
     pk_field: &'static crate::core::FieldSchema,
 ) -> Response {
-    let collected = or_400!(collect_values(state.vs.schema, form, skip));
+    // When a serializer is registered: run its input validation and
+    // skip every model column it doesn't accept (read_only / computed).
+    let extra_skip = match serializer_write_prep(state, json) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    let mut all_skip: Vec<&str> = skip.to_vec();
+    all_skip.extend(extra_skip);
+    let collected = or_400!(collect_values(state.vs.schema, form, &all_skip));
     let (columns, values): (Vec<_>, Vec<_>) = collected.into_iter().unzip();
     let fields = state.effective_fields();
     match insert_and_fetch_one(state, acq, columns, values, pk_field, &fields).await {
@@ -1706,7 +1782,7 @@ async fn create_one(
 async fn create_many(
     state: &Arc<ViewSetState>,
     acq: &mut AcquiredConn,
-    rows: &[HashMap<String, String>],
+    rows: &[(HashMap<String, String>, Option<Value>)],
     skip: &[&str],
     pk_field: &'static crate::core::FieldSchema,
 ) -> Response {
@@ -1719,8 +1795,15 @@ async fn create_many(
     // INSERTs committed. DRF's default ListSerializer.create has
     // the same shape — validate the whole list before any save.
     let mut prepared: Vec<(Vec<&'static str>, Vec<SqlValue>)> = Vec::with_capacity(rows.len());
-    for (i, row) in rows.iter().enumerate() {
-        let collected = match collect_values(state.vs.schema, row, skip) {
+    for (i, (row, json)) in rows.iter().enumerate() {
+        // Serializer validation + non-writable skip, per entry.
+        let extra_skip = match serializer_write_prep(state, json.as_ref()) {
+            Ok(s) => s,
+            Err(resp) => return resp,
+        };
+        let mut all_skip: Vec<&str> = skip.to_vec();
+        all_skip.extend(extra_skip);
+        let collected = match collect_values(state.vs.schema, row, &all_skip) {
             Ok(v) => v,
             Err(e) => {
                 return json_error(StatusCode::BAD_REQUEST, &format!("bulk entry {i}: {e}"));
@@ -1793,11 +1876,21 @@ async fn update_inner(
         Err(resp) => return resp,
     };
 
-    let form = or_400!(extract_form_body(parts, body).await);
+    let (form, json) = or_400!(extract_form_body(parts, body).await);
+
+    // Serializer (when set): validate the body + the set of model
+    // columns it doesn't accept (read_only / computed), which we skip.
+    let non_writable = match serializer_write_prep(&state, json.as_ref()) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
 
     let mut assignments: Vec<Assignment> = Vec::new();
     for field in state.vs.schema.scalar_fields() {
         if field.primary_key || field.auto {
+            continue;
+        }
+        if non_writable.contains(&field.name) {
             continue;
         }
         if partial && !form.contains_key(field.name) {
@@ -1928,9 +2021,9 @@ async fn render_single(
 async fn extract_form_body(
     parts: axum::http::request::Parts,
     body: Body,
-) -> Result<HashMap<String, String>, String> {
+) -> Result<(HashMap<String, String>, Option<Value>), String> {
     match extract_create_body(parts, body).await? {
-        CreateBody::Single(form) => Ok(form),
+        CreateBody::Single(form, json) => Ok((form, json)),
         CreateBody::Bulk(_) => Err("expected a JSON object; got an array".into()),
     }
 }
@@ -1944,8 +2037,11 @@ async fn extract_form_body(
 /// single records (multi-row form encoding doesn't have a portable
 /// shape).
 pub(crate) enum CreateBody {
-    Single(HashMap<String, String>),
-    Bulk(Vec<HashMap<String, String>>),
+    /// `(stringified form, raw JSON value)`. The JSON value is `Some`
+    /// for `application/json` bodies (used for typed serializer
+    /// validation) and `None` for form-urlencoded.
+    Single(HashMap<String, String>, Option<Value>),
+    Bulk(Vec<(HashMap<String, String>, Option<Value>)>),
 }
 
 pub(crate) async fn extract_create_body(
@@ -1967,25 +2063,28 @@ pub(crate) async fn extract_create_body(
     if content_type.contains("application/json") {
         let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|e| e.to_string())?;
         if let Some(array) = value.as_array() {
-            // Bulk shape: each element must be an object.
-            let mut bulk: Vec<HashMap<String, String>> = Vec::with_capacity(array.len());
+            // Bulk shape: each element must be an object. Keep the raw
+            // JSON entry alongside the stringified form for serializer
+            // validation.
+            let mut bulk: Vec<(HashMap<String, String>, Option<Value>)> =
+                Vec::with_capacity(array.len());
             for (i, entry) in array.iter().enumerate() {
                 let obj = entry
                     .as_object()
                     .ok_or_else(|| format!("bulk entry {i} is not a JSON object"))?;
-                bulk.push(json_object_to_form(obj));
+                bulk.push((json_object_to_form(obj), Some(entry.clone())));
             }
             return Ok(CreateBody::Bulk(bulk));
         }
         let obj = value
             .as_object()
             .ok_or("expected a JSON object or array of objects")?;
-        Ok(CreateBody::Single(json_object_to_form(obj)))
+        Ok(CreateBody::Single(json_object_to_form(obj), Some(value)))
     } else {
-        // form-urlencoded (default) — single only.
+        // form-urlencoded (default) — single only, no typed JSON value.
         let form = serde_urlencoded::from_bytes::<HashMap<String, String>>(&bytes)
             .map_err(|e| e.to_string())?;
-        Ok(CreateBody::Single(form))
+        Ok(CreateBody::Single(form, None))
     }
 }
 

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -98,6 +98,10 @@
 mod openapi;
 
 use std::collections::HashMap;
+use std::future::Future;
+#[cfg(feature = "serializer")]
+use std::marker::PhantomData;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -255,21 +259,81 @@ impl PaginationStyle {
     }
 }
 
-/// Optional per-row render callback installed via
-/// [`ViewSet::serializer`]. When present, list / retrieve responses
-/// route every row through it instead of the default `row_to_json`
-/// projection. The closure decodes the row into the model's struct
-/// (`T::from_row`) then runs it through the serializer's `from_model`
-/// + `to_value`, so SerializerMethodField / read_only / source /
-/// many overrides all apply to the JSON output.
+/// Type-erased bridge that lets a `dyn`-routed [`ViewSet`] render rows
+/// through a concrete [`crate::serializer::ModelSerializer`].
 ///
-/// v0.38 — gated to `cfg(postgres)` because the closure is bound to
-/// `&PgRow` via `T::from_row(row)`. The tri-dialect ViewSet
-/// (`tenant_router` on sqlite/mysql) skips the closure path and
-/// uses the dialect-aware `select_rows_as_json` default
-/// projection.
-#[cfg(feature = "postgres")]
-type RowRender = std::sync::Arc<dyn Fn(&crate::sql::sqlx::postgres::PgRow) -> Value + Send + Sync>;
+/// `ViewSet` is stored without its model/serializer type (so a router
+/// can hold many of them), so it can't name `S` directly. Instead
+/// [`ViewSet::serializer`] boxes a [`Bridge<S>`] behind this trait.
+/// When set, list / retrieve / create responses route through the
+/// bridge instead of the default field-level `select_rows_as_json`
+/// projection, so `method` / `read_only` / `source` / `write_only`
+/// overrides all shape the JSON output.
+///
+/// Tri-dialect (v0.45): the bridge fetches typed `Vec<S::Model>` via
+/// [`crate::sql::select_rows_pool_with_related`] — which decodes `T`
+/// on Postgres, MySQL **and** SQLite — then maps each model through
+/// `S::from_model` + `to_value`. The pre-v0.45 implementation was a
+/// `Fn(&PgRow) -> Value` closure, which pinned the feature to Postgres.
+trait SerializerBridge: Send + Sync {
+    /// Fetch every row matching `q` and render it through the
+    /// serializer (replaces the default field-level projection).
+    fn render_rows<'a>(
+        &'a self,
+        acq: &'a mut AcquiredConn,
+        q: &'a SelectQuery,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Value>, crate::sql::ExecError>> + Send + 'a>>;
+
+    /// Fetch the first row matching `q` and render it, or `None`.
+    fn render_one<'a>(
+        &'a self,
+        acq: &'a mut AcquiredConn,
+        q: &'a SelectQuery,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<Value>, crate::sql::ExecError>> + Send + 'a>>;
+}
+
+/// Zero-sized carrier that pins a concrete serializer type `S` so the
+/// type-erased [`SerializerBridge`] trait object can call back into
+/// `S::from_model` / `S::Model`'s tri-dialect row decode.
+#[cfg(feature = "serializer")]
+struct Bridge<S>(PhantomData<S>);
+
+#[cfg(feature = "serializer")]
+impl<S> SerializerBridge for Bridge<S>
+where
+    S: crate::serializer::ModelSerializer + Send + Sync + 'static,
+    S::Model: crate::sql::MaybePgFromRow
+        + crate::sql::MaybeMyFromRow
+        + crate::sql::MaybeSqliteFromRow
+        + crate::sql::LoadRelated
+        + crate::sql::MaybeMyLoadRelated
+        + crate::sql::MaybeSqliteLoadRelated
+        + Send
+        + Unpin,
+{
+    fn render_rows<'a>(
+        &'a self,
+        acq: &'a mut AcquiredConn,
+        q: &'a SelectQuery,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Value>, crate::sql::ExecError>> + Send + 'a>> {
+        Box::pin(async move {
+            let models = acq.select_rows_typed::<S::Model>(q).await?;
+            Ok(models.iter().map(|m| S::from_model(m).to_value()).collect())
+        })
+    }
+
+    fn render_one<'a>(
+        &'a self,
+        acq: &'a mut AcquiredConn,
+        q: &'a SelectQuery,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<Value>, crate::sql::ExecError>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            let models = acq.select_rows_typed::<S::Model>(q).await?;
+            Ok(models.first().map(|m| S::from_model(m).to_value()))
+        })
+    }
+}
 
 /// A pluggable filter backend (DRF `BaseFilterBackend` parity, #1010).
 ///
@@ -348,11 +412,11 @@ pub struct ViewSet {
     filter_backends: Vec<std::sync::Arc<dyn ViewSetFilter>>,
     /// Per-action request throttles (#1010). Default: unthrottled.
     throttle: ViewSetThrottle,
-    /// When set (PG only), list / retrieve responses run each row
-    /// through this callback instead of the default field-level
-    /// projection. Wired via [`Self::serializer`].
-    #[cfg(feature = "postgres")]
-    row_render: Option<RowRender>,
+    /// When set, list / retrieve / create responses render each row
+    /// through this serializer bridge instead of the default
+    /// field-level projection. Tri-dialect. Wired via
+    /// [`Self::serializer`].
+    serializer: Option<Arc<dyn SerializerBridge>>,
 }
 
 impl ViewSet {
@@ -371,46 +435,49 @@ impl ViewSet {
             pagination: PaginationStyle::PageNumber,
             filter_backends: Vec::new(),
             throttle: ViewSetThrottle::default(),
-            #[cfg(feature = "postgres")]
-            row_render: None,
+            serializer: None,
         }
     }
 
-    /// Render list / retrieve responses through `S` (a serializer
-    /// derived via `#[derive(Serializer)] #[serializer(model = T)]`)
-    /// instead of the default field-level projection.
+    /// Render list / retrieve / create responses through `S` (a
+    /// serializer derived via `#[derive(Serializer)]
+    /// #[serializer(model = T)]`) instead of the default field-level
+    /// projection.
     ///
     /// Apply when you want the ViewSet's JSON shape to match a typed
     /// serializer's `read_only` / `source` / `method` / `nested` /
-    /// `many` overrides. The serializer's `Model` associated type
-    /// must be the same model the ViewSet is built over.
+    /// `many` overrides. The serializer's `Model` associated type must
+    /// be the same model the ViewSet is built over.
     ///
-    /// Internally stores `Arc<dyn Fn(&PgRow) -> Value>` so the
-    /// ViewSet itself stays type-erased — non-breaking add-on.
+    /// Internally boxes a [`Bridge<S>`] behind a [`SerializerBridge`]
+    /// trait object so the `ViewSet` itself stays type-erased — a
+    /// non-breaking add-on.
     ///
-    /// v0.38 — PG-only because the serializer's `Model` requires
-    /// `FromRow<PgRow>`. Sqlite/MySQL ViewSets use the default
-    /// field-level JSON projection (no per-row callback); add a
-    /// tri-dialect serializer-like extension in v0.39 once
-    /// `T::from_row` is lifted to the backend-erasing trait.
-    #[cfg(all(feature = "serializer", feature = "postgres"))]
+    /// Tri-dialect (v0.45): works on Postgres, MySQL and SQLite. The
+    /// render path fetches typed `Vec<S::Model>` via the tri-dialect
+    /// `select_rows_pool_with_related` rather than a PG-only
+    /// `FromRow<PgRow>` closure.
+    ///
+    /// Note: `nested` / `many` fields need the related rows a flat
+    /// fetch doesn't load unless the ViewSet's query populated them via
+    /// `select_related`; those fields render as their `Default` value
+    /// otherwise. `method` / `read_only` / `source` / `write_only`
+    /// always apply because a real typed model is in hand.
+    #[cfg(feature = "serializer")]
     #[must_use]
     pub fn serializer<S>(mut self) -> Self
     where
-        S: crate::serializer::ModelSerializer + 'static,
-        S::Model:
-            for<'r> crate::sql::sqlx::FromRow<'r, crate::sql::sqlx::postgres::PgRow> + Send + Unpin,
+        S: crate::serializer::ModelSerializer + Send + Sync + 'static,
+        S::Model: crate::sql::MaybePgFromRow
+            + crate::sql::MaybeMyFromRow
+            + crate::sql::MaybeSqliteFromRow
+            + crate::sql::LoadRelated
+            + crate::sql::MaybeMyLoadRelated
+            + crate::sql::MaybeSqliteLoadRelated
+            + Send
+            + Unpin,
     {
-        let render: RowRender = std::sync::Arc::new(|row| {
-            match <S::Model as crate::sql::sqlx::FromRow<_>>::from_row(row) {
-                Ok(model) => {
-                    let s = S::from_model(&model);
-                    serde_json::to_value(&s).unwrap_or(Value::Null)
-                }
-                Err(_) => Value::Null,
-            }
-        });
-        self.row_render = Some(render);
+        self.serializer = Some(Arc::new(Bridge::<S>(PhantomData)));
         self
     }
 
@@ -723,6 +790,30 @@ impl AcquiredConn {
     ) -> Result<Option<Value>, crate::sql::ExecError> {
         let mut rows = crate::sql::select_rows_as_json(&self.pool, q, fields).await?;
         Ok(rows.pop())
+    }
+
+    /// Tri-dialect typed fetch — decode every row matching `q` into
+    /// `T` (the model struct) on Postgres, MySQL **or** SQLite. Used by
+    /// the serializer render path ([`SerializerBridge`]); mirrors
+    /// [`Self::select_rows_as_json`] but yields typed models instead of
+    /// the field-level JSON projection. Goes through `&self.pool`, so
+    /// it inherits the same tenant-scoping the JSON projection has.
+    #[cfg(feature = "serializer")]
+    async fn select_rows_typed<T>(
+        &mut self,
+        q: &SelectQuery,
+    ) -> Result<Vec<T>, crate::sql::ExecError>
+    where
+        T: crate::sql::MaybePgFromRow
+            + crate::sql::MaybeMyFromRow
+            + crate::sql::MaybeSqliteFromRow
+            + crate::sql::LoadRelated
+            + crate::sql::MaybeMyLoadRelated
+            + crate::sql::MaybeSqliteLoadRelated
+            + Send
+            + Unpin,
+    {
+        crate::sql::select_rows_pool_with_related::<T>(&self.pool, q).await
     }
 
     /// Insert a row and return the primary-key value of the new row
@@ -1291,15 +1382,11 @@ async fn handle_list(
             // keeps the handler simple — two short queries on the
             // same connection are typically faster than two pool
             // round-trips anyway.
-            // v0.38 — fetch as JSON directly via the tri-dialect
-            // `select_rows_as_json`; the optional row_render
-            // closure (PG-only, requires PgRow) is no longer applied
-            // here because the AcquiredConn is dialect-agnostic. PG
-            // projects that want the serializer extension can still
-            // mount the legacy `.serializer()` path under a separate
-            // builder if needed; default JSON projection is now
-            // tri-dialect.
-            let results = or_500!(acq.select_rows_as_json(&select_q, &fields).await);
+            // `render_list` renders through the registered serializer
+            // (typed tri-dialect fetch) when one is set, else falls
+            // back to the default field-level `select_rows_as_json`
+            // projection — both dialect-agnostic.
+            let results = or_500!(render_list(&state, &mut acq, &select_q, &fields).await);
             let count = or_500!(acq.count_rows(&count_q).await);
             let last_page = ((count - 1).max(0) / page_size) + 1;
             json_response(json!({
@@ -1355,7 +1442,7 @@ async fn handle_list(
                 where_clause,
                 search: search_clause,
             };
-            let results = or_500!(acq.select_rows_as_json(&select_q, &fields).await);
+            let results = or_500!(render_list(&state, &mut acq, &select_q, &fields).await);
             let count = or_500!(acq.count_rows(&count_q).await);
             json_response(json!({
                 "count": count,
@@ -1438,7 +1525,7 @@ async fn handle_list_cursor(
         limit: Some(page_size + 1),
         ..SelectQuery::new(state.vs.schema)
     };
-    let rows = or_500!(acq.select_rows_as_json(&select_q, &fields).await);
+    let rows = or_500!(render_list(state, acq, &select_q, &fields).await);
 
     let has_more = rows.len() as i64 > page_size;
     let page_rows: &[Value] = if has_more {
@@ -1508,7 +1595,7 @@ async fn handle_retrieve(
     let select_q = SelectQuery::by_pk(state.vs.schema, pk_field.column, pk_val);
 
     let fields = state.effective_fields();
-    match acq.select_one_as_json(&select_q, &fields).await {
+    match render_single(&state, &mut acq, &select_q, &fields).await {
         Ok(Some(row)) => json_response(row),
         Ok(None) => json_error(StatusCode::NOT_FOUND, "not found"),
         Err(e) => json_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
@@ -1799,11 +1886,41 @@ async fn fetch_by_pk(
 ) -> Option<Value> {
     // #562 — SelectQuery::by_pk replaces the 11-field literal.
     let select_q = SelectQuery::by_pk(state.vs.schema, pk_field.column, pk_val);
-    let _ = state;
-    acq.select_one_as_json(&select_q, fields)
+    render_single(state, acq, &select_q, fields)
         .await
         .ok()
         .flatten()
+}
+
+/// Render the rows matching `select_q` for a list response: through
+/// the registered [`SerializerBridge`] when one is set
+/// ([`ViewSet::serializer`]), else the default field-level JSON
+/// projection. Single source of truth for the three list shapes.
+async fn render_list(
+    state: &ViewSetState,
+    acq: &mut AcquiredConn,
+    select_q: &SelectQuery,
+    fields: &[&'static crate::core::FieldSchema],
+) -> Result<Vec<Value>, crate::sql::ExecError> {
+    match &state.vs.serializer {
+        Some(bridge) => bridge.render_rows(acq, select_q).await,
+        None => acq.select_rows_as_json(select_q, fields).await,
+    }
+}
+
+/// Render the single row matching `select_q` for a retrieve / create /
+/// update response: through the registered serializer when set, else
+/// the default field-level JSON projection.
+async fn render_single(
+    state: &ViewSetState,
+    acq: &mut AcquiredConn,
+    select_q: &SelectQuery,
+    fields: &[&'static crate::core::FieldSchema],
+) -> Result<Option<Value>, crate::sql::ExecError> {
+    match &state.vs.serializer {
+        Some(bridge) => bridge.render_one(acq, select_q).await,
+        None => acq.select_one_as_json(select_q, fields).await,
+    }
 }
 
 /// Extract form data from both `application/x-www-form-urlencoded` and

--- a/crates/rustango/tests/viewset_derive_serializer_compile.rs
+++ b/crates/rustango/tests/viewset_derive_serializer_compile.rs
@@ -1,0 +1,58 @@
+//! Compile-smoke for `#[derive(ViewSet)] #[viewset(serializer = S)]`.
+//!
+//! The derive's `router(prefix, PgPool)` is the PG static-pool entry
+//! point, so this only exercises that the macro emits a valid
+//! `.serializer::<S>()` call in the generated builder chain — it does
+//! not run (no live DB). Runtime rendering is covered tri-dialect by
+//! `viewset_serializer_render_sqlite_live.rs`. This test exists so a
+//! regression in `expand_viewset`'s serializer emit trips the
+//! `--all-features` build that CI runs.
+
+#![cfg(all(feature = "postgres", feature = "serializer"))]
+
+use rustango::sql::Auto;
+use rustango::{Model, Serializer, ViewSet};
+
+#[derive(Model, Clone)]
+#[rustango(table = "vs_derive_ser_post")]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 500)]
+    pub body: String,
+}
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+#[allow(dead_code)] // body is write-only by design.
+pub struct PostSerializer {
+    pub title: String,
+    #[serializer(method = "excerpt")]
+    pub excerpt: String,
+    #[serializer(write_only)]
+    pub body: String,
+}
+
+impl PostSerializer {
+    fn excerpt(p: &Post) -> String {
+        p.body.chars().take(10).collect()
+    }
+}
+
+#[derive(ViewSet)]
+#[viewset(
+    model = Post,
+    serializer = PostSerializer,
+    ordering = "-id",
+    page_size = 25,
+)]
+pub struct PostViewSet;
+
+/// Compile-only: the derive must emit a `router(prefix, PgPool)` that
+/// wires `.serializer::<PostSerializer>()`. Never called.
+#[allow(dead_code)]
+fn _router_signature_compiles(pool: rustango::sql::sqlx::PgPool) -> axum::Router {
+    PostViewSet::router("/api/posts", pool)
+}

--- a/crates/rustango/tests/viewset_serializer_input_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_serializer_input_sqlite_live.rs
@@ -1,0 +1,189 @@
+//! Live integration test for the serializer **input** path on a
+//! ViewSet (tri-dialect, here on SQLite):
+//!   * the serializer's `validate()` runs on create/update → 400 with
+//!     DRF-shape `{field: [msgs]}` field errors,
+//!   * `read_only` fields a client posts are ignored, not written.
+//!
+//! Pairs with `viewset_serializer_render_sqlite_live.rs` (the output
+//! half) to cover the full DRF marriage of ViewSets + serializers.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy", feature = "serializer"))]
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use rustango::core::Model as _;
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::{Model, Serializer};
+use tower::ServiceExt as _;
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "vs_in_item")]
+#[rustango(app = "vs_in_app")]
+pub struct Item {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 120)]
+    pub name: String,
+    #[rustango(max_length = 120)]
+    pub slug: String,
+    /// Server-controlled — clients must not be able to set it.
+    pub internal_score: i64,
+}
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Item)]
+struct ItemSerializer {
+    #[serializer(validate = "name_min_len")]
+    pub name: String,
+    pub slug: String,
+    /// In output, ignored on write.
+    #[serializer(read_only)]
+    pub internal_score: i64,
+}
+
+impl ItemSerializer {
+    fn name_min_len(n: &String) -> Result<(), String> {
+        if n.chars().count() < 3 {
+            Err("name must be at least 3 characters".to_owned())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+async fn router() -> axum::Router {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE vs_in_item (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            name TEXT NOT NULL, \
+            slug TEXT NOT NULL, \
+            internal_score INTEGER NOT NULL DEFAULT 0)",
+    )
+    .execute(&sq)
+    .await
+    .expect("create");
+    rustango::viewset::ViewSet::for_model(Item::SCHEMA)
+        .serializer::<ItemSerializer>()
+        .router_pool("/items", Pool::Sqlite(sq))
+}
+
+fn post(uri: &str, json: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(json.to_owned()))
+        .unwrap()
+}
+
+async fn json_body(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .expect("body bytes");
+    serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+}
+
+#[tokio::test]
+async fn create_runs_serializer_validate_and_400s_on_failure() {
+    let app = router().await;
+
+    // name "ab" is 2 chars → fails the field validator.
+    let resp = app
+        .clone()
+        .oneshot(post("/items", r#"{"name":"ab","slug":"thing"}"#))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "short name should 400"
+    );
+    let v = json_body(resp).await;
+    let name_errs = v["name"].as_array().expect("DRF field-error shape: {v}");
+    assert!(
+        name_errs
+            .iter()
+            .any(|m| m.as_str() == Some("name must be at least 3 characters")),
+        "validation message should surface under the `name` key: {v}"
+    );
+
+    // name "abc" passes.
+    let resp = app
+        .clone()
+        .oneshot(post("/items", r#"{"name":"abc","slug":"thing"}"#))
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "valid name should succeed, got {}",
+        resp.status()
+    );
+    let v = json_body(resp).await;
+    assert_eq!(v["name"], "abc");
+}
+
+#[tokio::test]
+async fn read_only_field_is_ignored_on_create() {
+    let app = router().await;
+
+    // Client tries to set the server-controlled `internal_score`.
+    let resp = app
+        .clone()
+        .oneshot(post(
+            "/items",
+            r#"{"name":"widget","slug":"w","internal_score":999}"#,
+        ))
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "create should succeed");
+
+    let v = json_body(resp).await;
+    assert_eq!(v["name"], "widget");
+    // read_only → not written → DB default 0, NOT the posted 999.
+    assert_eq!(
+        v["internal_score"], 0,
+        "read_only field must be ignored on write (DB default, not 999): {v}"
+    );
+}
+
+#[tokio::test]
+async fn partial_update_ignores_read_only_field() {
+    let app = router().await;
+
+    // Seed a row.
+    let resp = app
+        .clone()
+        .oneshot(post("/items", r#"{"name":"orig","slug":"o"}"#))
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    // PATCH attempts to bump internal_score (read_only) + rename.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::PATCH)
+                .uri("/items/1")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"name":"renamed","internal_score":777}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "patch should succeed, got {}",
+        resp.status()
+    );
+
+    let v = json_body(resp).await;
+    assert_eq!(v["name"], "renamed", "writable field updated: {v}");
+    assert_eq!(
+        v["internal_score"], 0,
+        "read_only field must stay at its server value: {v}"
+    );
+}

--- a/crates/rustango/tests/viewset_serializer_render_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_serializer_render_sqlite_live.rs
@@ -1,0 +1,206 @@
+//! Live integration test proving the ViewSet renders list / retrieve /
+//! create responses **through a registered serializer**, tri-dialect
+//! (here on SQLite). Before v0.45 `.serializer::<S>()` stored a dead
+//! PG-only `row_render` closure that was never invoked — output was
+//! always the default field-level projection. This test pins the new
+//! behavior: `method` fields appear, `write_only` fields are hidden,
+//! and the response shape is the serializer's, not the raw model's.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy", feature = "serializer"))]
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use rustango::core::Model as _;
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::{Model, Serializer};
+use tower::ServiceExt as _;
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "vs_ser_post")]
+#[rustango(app = "vs_ser_app")]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 500)]
+    pub body: String,
+}
+
+/// Serializer that reshapes `Post`:
+/// * `excerpt` is a computed `method` field (first 10 chars of body),
+/// * `body` is `write_only` — accepted on write, hidden from output.
+///
+/// So the rendered shape is `{ "title", "excerpt" }` — provably
+/// different from the raw model projection (which would include
+/// `id` + `body`).
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+#[allow(dead_code)] // `body` is write-only by design — never read directly.
+struct PostSerializer {
+    pub title: String,
+    #[serializer(method = "excerpt")]
+    pub excerpt: String,
+    #[serializer(write_only)]
+    pub body: String,
+}
+
+impl PostSerializer {
+    fn excerpt(p: &Post) -> String {
+        p.body.chars().take(10).collect::<String>()
+    }
+}
+
+async fn sqlite_pool() -> Pool {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE vs_ser_post (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            title TEXT NOT NULL, \
+            body TEXT NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .expect("create");
+    Pool::Sqlite(sq)
+}
+
+/// ViewSet with the serializer wired in.
+async fn serializer_router() -> axum::Router {
+    rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .serializer::<PostSerializer>()
+        .router_pool("/posts", sqlite_pool().await)
+}
+
+fn get(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn post_json(uri: &str, json: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(json.to_owned()))
+        .unwrap()
+}
+
+async fn json_body(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .expect("body bytes");
+    serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+}
+
+#[tokio::test]
+async fn create_response_renders_through_serializer() {
+    let app = serializer_router().await;
+
+    let resp = app
+        .clone()
+        .oneshot(post_json(
+            "/posts",
+            r#"{"title":"Hello","body":"the quick brown fox jumps"}"#,
+        ))
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "POST should succeed, got {}",
+        resp.status()
+    );
+
+    let v = json_body(resp).await;
+    // Serializer shape: title + computed excerpt, NO body, NO id.
+    assert_eq!(v["title"], "Hello", "title should be serialized: {v}");
+    assert_eq!(
+        v["excerpt"], "the quick ",
+        "method field `excerpt` (first 10 chars) should be rendered: {v}"
+    );
+    assert!(
+        v.get("body").is_none(),
+        "write_only `body` must be hidden from output: {v}"
+    );
+    assert!(
+        v.get("id").is_none(),
+        "serializer didn't declare `id`, so it must be absent: {v}"
+    );
+}
+
+#[tokio::test]
+async fn list_and_retrieve_render_through_serializer() {
+    let app = serializer_router().await;
+
+    // Seed two rows.
+    for (t, b) in [("First", "aaaaaaaaaaaa"), ("Second", "bbbbbbbbbbbb")] {
+        let resp = app
+            .clone()
+            .oneshot(post_json(
+                "/posts",
+                &format!(r#"{{"title":"{t}","body":"{b}"}}"#),
+            ))
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+    }
+
+    // LIST — each result is serializer-shaped.
+    let resp = app.clone().oneshot(get("/posts")).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = json_body(resp).await;
+    let results = v["results"].as_array().expect("results array");
+    assert_eq!(results.len(), 2, "two rows expected: {v}");
+    for row in results {
+        assert!(row.get("excerpt").is_some(), "excerpt rendered: {row}");
+        assert!(row.get("body").is_none(), "body hidden: {row}");
+    }
+    assert_eq!(results[0]["title"], "First");
+    assert_eq!(results[0]["excerpt"], "aaaaaaaaaa"); // first 10 of 12 a's
+
+    // RETRIEVE by pk — serializer-shaped too.
+    let resp = app.clone().oneshot(get("/posts/1")).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = json_body(resp).await;
+    assert_eq!(v["title"], "First", "retrieve renders serializer: {v}");
+    assert_eq!(v["excerpt"], "aaaaaaaaaa");
+    assert!(v.get("body").is_none(), "body hidden on retrieve: {v}");
+}
+
+#[tokio::test]
+async fn without_serializer_default_projection_is_unchanged() {
+    // Contrast: same model, no `.serializer()` — the default
+    // field-level projection still includes every column (id + body),
+    // confirming the serializer path is what reshapes the output.
+    let app = rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .router_pool("/posts", sqlite_pool().await);
+
+    let resp = app
+        .clone()
+        .oneshot(post_json(
+            "/posts",
+            r#"{"title":"Raw","body":"visible body"}"#,
+        ))
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    let v = json_body(resp).await;
+    assert_eq!(v["title"], "Raw");
+    assert_eq!(
+        v["body"], "visible body",
+        "default projection keeps body: {v}"
+    );
+    assert!(v.get("id").is_some(), "default projection keeps id: {v}");
+    assert!(
+        v.get("excerpt").is_none(),
+        "no serializer → no computed excerpt: {v}"
+    );
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -481,7 +481,19 @@ pub struct PostSerializer {
 
 Each serializer field's type mirrors the matching model field, so `id` and `published_at` keep their `Auto<…>` wrapper from the model (an `Auto<i64>` still serializes to a plain JSON integer). Then register the module by adding `mod post_serializer;` alongside the other `mod` declarations in `src/main.rs`.
 
-(Auto-wiring this into the ViewSet response shape is on the roadmap. For now, use the serializer manually in custom handlers.)
+Wire the serializer into the ViewSet with the `serializer` attribute — list, retrieve, and create responses are then rendered through it (the field-level `fields` projection is bypassed in favor of the serializer's shape):
+
+```rust
+#[derive(ViewSet)]
+#[viewset(
+    model = Post,
+    serializer = crate::post_serializer::PostSerializer,
+    ordering = "-published_at",
+)]
+pub struct PostViewSet;
+```
+
+This works identically on PostgreSQL, MySQL, and SQLite. `method` / `read_only` / `source` / `write_only` overrides all apply to the response. (Note: `nested` / `many` serializer fields need the related rows loaded via `select_related`; otherwise they render as their default. Request-body validation through the serializer is separate — for now, validate in a custom handler.)
 
 ---
 


### PR DESCRIPTION
Wires `ViewSet` ↔ `ModelSerializer` end-to-end (DRF-style), **tri-dialect** (Postgres + MySQL + SQLite). `.serializer::<S>()` was dead before: the v0.38 refactor stopped invoking the PG-only `row_render` closure, so output was always the raw field projection and the serializer governed neither responses nor input.

### Output — responses render through the serializer
- Replaces the dead `RowRender` closure with a type-erased `SerializerBridge` (`Bridge<S>`). List / retrieve / create / update responses fetch typed `Vec<S::Model>` via the already-tri-dialect `select_rows_pool_with_related` and render through `S::from_model`, so `method` / `read_only` / `source` / `write_only` shape the JSON on all three backends.
- `.serializer::<S>()` is no longer `cfg(postgres)`-gated; the old `FromRow<PgRow>` bound becomes the standard tri-dialect ORM fetch bounds (any `#[derive(Model)]` satisfies them).

### Input — serializer governs writes
- The serializer's **`validate()`** runs on create/update against the JSON body, returning a DRF-shape **400** (`{field: [msgs], …}`). Both per-field `#[serializer(validate = "fn")]` and container cross-field `validate` are surfaced.
- **`read_only` / computed fields are ignored on write** (`source`-resolved): every model column the serializer doesn't accept is skipped, so a client can't set server-controlled fields.
- `ModelSerializer` gains `validate` (default no-op), `writable_source_fields`, and `from_writable_json` (builds a partial instance field-by-field — no struct-`Default` dependency). The macro overrides all three; the inherent `validate` is kept for back-compat. The create/update handlers thread the raw JSON through `CreateBody` / `extract_form_body` and run `serializer_write_prep` before persisting. Form-urlencoded bodies skip `validate()` (no typed value) but still get writable-field filtering.

### Derive
`#[derive(ViewSet)] #[viewset(serializer = S)]` wires both halves in one attribute; getting-started doc updated.

### Limitations (documented)
`nested` / `many` serializer fields need related rows loaded via `select_related` or they render as their default. A `source`-renamed field validated under its serializer name requires the client to post that name.

### Tests
- `viewset_serializer_render_sqlite_live.rs` — output: method field rendered, write_only hidden, undeclared fields absent; no-serializer contrast.
- `viewset_serializer_input_sqlite_live.rs` — input: `validate()` → 400 field errors; `read_only` ignored on create + partial update.
- `viewset_derive_serializer_compile.rs` — PG-gated compile smoke for the derive attribute.
- Full `--all-features --no-run` gate + 3386 lib tests pass locally. Cookbook chapter 9b asserts the PG output behavior end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)