### PR TITLE
feat(serializer): declarative field validators, auto-inherited from the model

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -152,6 +152,9 @@ pub fn derive_form(input: TokenStream) -> TokenStream {
 /// - `#[serializer(many = ChildSerializer)]` — collection of nested serializers; populated via macro-emitted `set_<field>(&[Child::Model])`; excluded from `writable_fields()`
 /// - `#[serializer(slug = "name")]` — DRF `SlugRelatedField`: clones `model.<source>.value()?.name`; excluded from `writable_fields()` (v0.44)
 /// - `#[serializer(validate = "fn_name")]` — per-field validator surfaced by `Self::validate(&self)`
+/// - `#[serializer(max_length = N)]` / `min_length` / `min` / `max` — declarative bounds checked on
+///   write; auto-inherit from the model's `FieldSchema` (`max_length`/`min`/`max`/`choices`) when
+///   no attr is given, override it when given (`min_length` is serializer-only)
 ///
 /// The macro also emits a custom `impl serde::Serialize` — do **not** also `#[derive(Serialize)]`.
 #[proc_macro_derive(Serializer, attributes(serializer))]
@@ -12728,6 +12731,19 @@ struct SerializerFieldAttrs {
     /// `nested`. Source defaults to the field name; override with
     /// `source = "..."`. v0.44.
     slug: Option<String>,
+    /// `#[serializer(max_length = N)]` — DRF `MaxLengthValidator`. Caps
+    /// the character count of a string field on write. Overrides the
+    /// model's `max_length`; when absent the model value is inherited.
+    max_length: Option<u64>,
+    /// `#[serializer(min_length = N)]` — DRF `MinLengthValidator`.
+    /// Serializer-only (the model has no `min_length` column).
+    min_length: Option<u64>,
+    /// `#[serializer(min = N)]` — DRF `MinValueValidator`. Inclusive
+    /// integer lower bound; overrides the model's `min` when given.
+    min: Option<i64>,
+    /// `#[serializer(max = N)]` — DRF `MaxValueValidator`. Inclusive
+    /// integer upper bound; overrides the model's `max` when given.
+    max: Option<i64>,
 }
 
 fn parse_serializer_container_attrs(input: &DeriveInput) -> syn::Result<SerializerContainerAttrs> {
@@ -12829,10 +12845,31 @@ fn parse_serializer_field_attrs(field: &syn::Field) -> syn::Result<SerializerFie
                 out.slug = Some(s.value());
                 return Ok(());
             }
+            if meta.path.is_ident("max_length") {
+                let lit: syn::LitInt = meta.value()?.parse()?;
+                out.max_length = Some(lit.base10_parse::<u64>()?);
+                return Ok(());
+            }
+            if meta.path.is_ident("min_length") {
+                let lit: syn::LitInt = meta.value()?.parse()?;
+                out.min_length = Some(lit.base10_parse::<u64>()?);
+                return Ok(());
+            }
+            if meta.path.is_ident("min") {
+                let lit: syn::LitInt = meta.value()?.parse()?;
+                out.min = Some(lit.base10_parse::<i64>()?);
+                return Ok(());
+            }
+            if meta.path.is_ident("max") {
+                let lit: syn::LitInt = meta.value()?.parse()?;
+                out.max = Some(lit.base10_parse::<i64>()?);
+                return Ok(());
+            }
             Err(meta.error(
                 "unknown serializer field attribute (supported: \
                  `read_only`, `write_only`, `source`, `skip`, `method`, \
-                 `validate`, `nested`, `many`, `slug`)",
+                 `validate`, `nested`, `many`, `slug`, `max_length`, \
+                 `min_length`, `min`, `max`)",
             ))
         })?;
     }
@@ -12989,6 +13026,73 @@ fn expand_serializer(input: &DeriveInput) -> syn::Result<TokenStream2> {
         }
     });
 
+    // is_writable predicate (also used by writable_lits /
+    // writable_source_lits below).
+    let is_writable = |fi: &&FieldInfo| {
+        !fi.attrs.read_only
+            && !fi.attrs.skip
+            && fi.attrs.method.is_none()
+            && !fi.attrs.nested
+            && fi.attrs.many.is_none()
+            && fi.attrs.slug.is_none()
+    };
+
+    // Declarative field constraints (DRF `validators=[...]`): one block
+    // per writable field, run inside `validate()`. Each resolves its
+    // bounds as the serializer attr when given (`#[serializer(max_length
+    // = N)]`), else the model's `FieldSchema` (`max_length` / `min` /
+    // `max` / `choices`), then dispatches on the field's JSON value via
+    // `forms::validators::check_value` (string → length/choices, integer
+    // → min/max).
+    let opt_usize = |v: Option<u64>| match v {
+        Some(n) => {
+            let n = n as usize;
+            quote!(::core::option::Option::Some(#n))
+        }
+        None => quote!(::core::option::Option::None),
+    };
+    let opt_i64 = |v: Option<i64>| match v {
+        Some(n) => quote!(::core::option::Option::Some(#n)),
+        None => quote!(::core::option::Option::None),
+    };
+    let constraint_blocks: Vec<_> = fields_info
+        .iter()
+        .filter(is_writable)
+        .map(|fi| {
+            let ident = &fi.ident;
+            let fname = ident.to_string();
+            let mname = fi
+                .attrs
+                .source
+                .clone()
+                .unwrap_or_else(|| fi.ident.to_string());
+            let attr_max_len = opt_usize(fi.attrs.max_length);
+            let attr_min_len = opt_usize(fi.attrs.min_length);
+            let attr_min = opt_i64(fi.attrs.min);
+            let attr_max = opt_i64(fi.attrs.max);
+            quote! {
+                {
+                    let __sf = <#model_path as #root::core::Model>::SCHEMA.field(#mname);
+                    let __max_length: ::core::option::Option<usize> = #attr_max_len
+                        .or_else(|| __sf.and_then(|__f| __f.max_length).map(|__n| __n as usize));
+                    let __min_length: ::core::option::Option<usize> = #attr_min_len;
+                    let __min: ::core::option::Option<i64> =
+                        #attr_min.or_else(|| __sf.and_then(|__f| __f.min));
+                    let __max: ::core::option::Option<i64> =
+                        #attr_max.or_else(|| __sf.and_then(|__f| __f.max));
+                    let __choices = __sf.and_then(|__f| __f.choices);
+                    let __v = #root::__serde_json::to_value(&self.#ident)
+                        .unwrap_or(#root::__serde_json::Value::Null);
+                    #root::forms::validators::check_value(
+                        #fname, &__v, __max_length, __min_length, __min, __max, __choices,
+                        &mut __errors,
+                    );
+                }
+            }
+        })
+        .collect();
+    let has_constraints = !constraint_blocks.is_empty();
+
     // Per-field validators (DRF-shape `validators=[...]`). Emit a
     // `validate(&self)` method that runs each user-defined validator
     // and aggregates errors into `FormErrors`.
@@ -13022,9 +13126,15 @@ fn expand_serializer(input: &DeriveInput) -> syn::Result<TokenStream2> {
         }
     });
     let has_validators = !validator_calls.is_empty() || container.cross_validate.is_some();
-    // Shared body: run per-field validators, then the cross-field hook.
+    // Anything to run? Declarative constraints (for any writable field) +
+    // per-field validators + cross-field hook.
+    let has_run_validations = has_validators || has_constraints;
+    // Shared body: declarative field constraints first (length / range /
+    // choices, serializer-attr-or-model), then per-field validators, then
+    // the cross-field hook.
     let validate_body = quote! {
         let mut __errors = #root::forms::FormErrors::default();
+        #( #constraint_blocks )*
         #( #validator_calls )*
         #cross_validate_call
         if __errors.is_empty() {
@@ -13035,15 +13145,17 @@ fn expand_serializer(input: &DeriveInput) -> syn::Result<TokenStream2> {
     };
     // Inherent `validate(&self)` — kept for back-compat with direct
     // `serializer.validate()` calls that don't import `ModelSerializer`.
+    // Emitted only when the serializer declares per-field/cross-field
+    // validators (unchanged rule) so it never collides with a
+    // hand-written inherent `validate`.
     let validate_method = if has_validators {
         quote! {
             impl #struct_name {
-                /// Run every `#[serializer(validate = "...")]` per-field
-                /// validator and, when declared, the container-level
-                /// cross-field validator. Aggregates errors into
-                /// `FormErrors` keyed by the field name (plus any
-                /// non-field keys the cross-field method adds).
-                /// Returns `Ok(())` when all pass.
+                /// Run the declarative field constraints, every
+                /// `#[serializer(validate = "...")]` per-field validator,
+                /// and (when declared) the container-level cross-field
+                /// validator. Aggregates errors into `FormErrors` keyed by
+                /// the field name. Returns `Ok(())` when all pass.
                 pub fn validate(&self) -> ::core::result::Result<(), #root::forms::FormErrors> {
                     #validate_body
                 }
@@ -13053,9 +13165,10 @@ fn expand_serializer(input: &DeriveInput) -> syn::Result<TokenStream2> {
         quote! {}
     };
     // Trait-method override so the type-erased ViewSet write path can
-    // dispatch `ModelSerializer::validate` generically. When there are
-    // no validators the trait's default no-op is used instead.
-    let trait_validate_override = if has_validators {
+    // dispatch `ModelSerializer::validate` generically. Emitted whenever
+    // there's anything to run (declarative constraints inherited from the
+    // model count); otherwise the trait's default no-op is used.
+    let trait_validate_override = if has_run_validations {
         quote! {
             fn validate(&self) -> ::core::result::Result<(), #root::forms::FormErrors> {
                 #validate_body
@@ -13126,14 +13239,7 @@ fn expand_serializer(input: &DeriveInput) -> syn::Result<TokenStream2> {
     // path accept those fields from the JSON body and try to bind
     // them to the SQL UPDATE — a silent no-op at best, a type
     // mismatch at worst.
-    let is_writable = |fi: &&FieldInfo| {
-        !fi.attrs.read_only
-            && !fi.attrs.skip
-            && fi.attrs.method.is_none()
-            && !fi.attrs.nested
-            && fi.attrs.many.is_none()
-            && fi.attrs.slug.is_none()
-    };
+    // (`is_writable` is defined above, near the constraint codegen.)
     let writable_lits: Vec<_> = fields_info
         .iter()
         .filter(is_writable)

--- a/crates/rustango/src/forms/mod.rs
+++ b/crates/rustango/src/forms/mod.rs
@@ -66,6 +66,11 @@ pub mod csrf;
 /// HTTP request payload keyed `<prefix>-<N>-<field>`. Issue #49.
 pub mod formset;
 
+/// Reusable declarative field-constraint validators (`max_length` /
+/// `min_length` / `min` / `max` / `choices`), shared by the serializer
+/// write path. Messages match the admin `DynamicForm`.
+pub mod validators;
+
 // ------------------------------------------------------------------ FormErrors
 
 /// All validation errors collected from a form submission.

--- a/crates/rustango/src/forms/validators.rs
+++ b/crates/rustango/src/forms/validators.rs
@@ -1,0 +1,183 @@
+//! Reusable declarative field-constraint validators.
+//!
+//! Used by the `#[derive(Serializer)]` write path (DRF
+//! `validators=[…]`): each writable field is checked against the
+//! constraints resolved for it — the serializer-declared value when
+//! given (`#[serializer(max_length = …)]`), otherwise the model's
+//! [`crate::core::FieldSchema`] (`max_length` / `min` / `max` /
+//! `choices`). The messages match the admin `DynamicForm` so every
+//! validation surface speaks the same Django/DRF language.
+
+use super::FormErrors;
+use serde_json::Value;
+
+/// Validate a single field value against its resolved constraints,
+/// appending any failures to `errors` keyed by `field`.
+///
+/// Type dispatch is by the JSON value, so the macro needs no Rust-type
+/// introspection:
+/// * **strings** — `max_length`, `min_length`, `choices`,
+/// * **integers** — `min`, `max`.
+///
+/// `null` / arrays / objects are skipped. `min_length` and `choices`
+/// skip empty strings (an empty value means "not provided", caught by
+/// NOT-NULL handling rather than a length/choice error) — matching
+/// `DynamicForm`. String length is measured in characters
+/// (`chars().count()`), matching `FieldSchema::max_length`'s
+/// "characters" semantics.
+#[allow(clippy::too_many_arguments)]
+pub fn check_value(
+    field: &str,
+    value: &Value,
+    max_length: Option<usize>,
+    min_length: Option<usize>,
+    min: Option<i64>,
+    max: Option<i64>,
+    choices: Option<&[(&str, &str)]>,
+    errors: &mut FormErrors,
+) {
+    if let Some(s) = value.as_str() {
+        let len = s.chars().count();
+        if let Some(m) = max_length {
+            if len > m {
+                errors.add(
+                    field,
+                    format!("Ensure this value has at most {m} characters."),
+                );
+            }
+        }
+        if let Some(m) = min_length {
+            if !s.is_empty() && len < m {
+                errors.add(
+                    field,
+                    format!("Ensure this value has at least {m} characters."),
+                );
+            }
+        }
+        if let Some(cs) = choices {
+            if !s.is_empty() && !cs.iter().any(|(v, _)| *v == s) {
+                errors.add(field, "Select a valid choice.");
+            }
+        }
+    } else if let Some(n) = value.as_i64() {
+        if let Some(m) = min {
+            if n < m {
+                errors.add(field, format!("Ensure this value is ≥ {m}."));
+            }
+        }
+        if let Some(m) = max {
+            if n > m {
+                errors.add(field, format!("Ensure this value is ≤ {m}."));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn max_length_flags_too_long_string() {
+        let mut e = FormErrors::default();
+        check_value(
+            "name",
+            &json!("abcdef"),
+            Some(3),
+            None,
+            None,
+            None,
+            None,
+            &mut e,
+        );
+        assert_eq!(e.get("name").len(), 1);
+        assert!(e.get("name")[0].contains("at most 3 characters"));
+    }
+
+    #[test]
+    fn min_length_skips_empty_but_flags_short() {
+        let mut e = FormErrors::default();
+        check_value("name", &json!(""), None, Some(3), None, None, None, &mut e);
+        assert!(
+            e.is_empty(),
+            "empty string is 'not provided', not a length error"
+        );
+        check_value(
+            "name",
+            &json!("ab"),
+            None,
+            Some(3),
+            None,
+            None,
+            None,
+            &mut e,
+        );
+        assert!(e.get("name")[0].contains("at least 3 characters"));
+    }
+
+    #[test]
+    fn min_max_bound_integers() {
+        let mut e = FormErrors::default();
+        check_value("n", &json!(5), None, None, Some(0), Some(3), None, &mut e);
+        assert!(e.get("n")[0].contains("≤ 3"));
+        let mut e = FormErrors::default();
+        check_value("n", &json!(-1), None, None, Some(0), Some(3), None, &mut e);
+        assert!(e.get("n")[0].contains("≥ 0"));
+    }
+
+    #[test]
+    fn choices_rejects_value_not_in_set() {
+        let mut e = FormErrors::default();
+        let choices: &[(&str, &str)] = &[("draft", "Draft"), ("published", "Published")];
+        check_value(
+            "status",
+            &json!("archived"),
+            None,
+            None,
+            None,
+            None,
+            Some(choices),
+            &mut e,
+        );
+        assert!(e.get("status")[0].contains("valid choice"));
+        let mut e = FormErrors::default();
+        check_value(
+            "status",
+            &json!("draft"),
+            None,
+            None,
+            None,
+            None,
+            Some(choices),
+            &mut e,
+        );
+        assert!(e.is_empty());
+    }
+
+    #[test]
+    fn null_and_non_scalar_are_skipped() {
+        let mut e = FormErrors::default();
+        check_value(
+            "x",
+            &json!(null),
+            Some(1),
+            Some(1),
+            Some(1),
+            Some(1),
+            None,
+            &mut e,
+        );
+        check_value(
+            "x",
+            &json!({"a": 1}),
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+            &mut e,
+        );
+        assert!(e.is_empty());
+    }
+}

--- a/crates/rustango/src/serializer/mod.rs
+++ b/crates/rustango/src/serializer/mod.rs
@@ -48,6 +48,21 @@
 //! | `many = TagSerializer` | initializes to `Vec::new()`; populate via `set_<field>(&[Tag])` helper | included | no |
 //! | `slug = "name"` | clones `model.<source>.value()?.name` (DRF SlugRelatedField) | included | no |
 //! | `validate = "fn"` | per-field validator called by `Self::validate(&self)` | n/a | n/a |
+//! | `max_length = N` | caps string length on write (DRF `MaxLengthValidator`) | n/a | n/a |
+//! | `min_length = N` | min string length on write (DRF `MinLengthValidator`) | n/a | n/a |
+//! | `min = N` / `max = N` | inclusive integer bounds on write (DRF `Min/MaxValueValidator`) | n/a | n/a |
+//!
+//! ## Declarative field validators
+//!
+//! `max_length` / `min_length` / `min` / `max` are checked on **write**
+//! (create/update through a ViewSet) and surface DRF-shape `400`s. They
+//! **auto-inherit from the model**: every writable field is validated
+//! against the model's [`crate::core::FieldSchema`] (`max_length`, `min`,
+//! `max`, and `choices`) even with no attribute; a per-field attribute
+//! overrides the inherited value. `min_length` is serializer-only (no
+//! model column). `choices` is inherited from the model (no attribute).
+//! String length is measured in characters. For arbitrary rules, use
+//! `validate = "fn"` (per-field) or the container `validate` (cross-field).
 //!
 //! ## Nested serializers — auto-resolved via `#[serializer(nested)]`
 //!

--- a/crates/rustango/tests/serializer_derive.rs
+++ b/crates/rustango/tests/serializer_derive.rs
@@ -566,3 +566,71 @@ mod advanced_attrs {
         assert!(title_errs[0].contains("3 chars"));
     }
 }
+
+// ============================================================================
+// Declarative field validators (max_length / min_length / min / max), with
+// auto-inherit from the model's FieldSchema. No DB needed — `validate()` is
+// pure and reads `Model::SCHEMA` (a const).
+// ============================================================================
+
+mod declarative_validators {
+    use rustango::serializer::ModelSerializer;
+    use rustango::sql::Auto;
+    use rustango::Serializer;
+
+    #[derive(rustango::Model, Clone)]
+    #[rustango(table = "dv_widget")]
+    pub struct DvWidget {
+        #[rustango(primary_key)]
+        pub id: Auto<i64>,
+        #[rustango(max_length = 5)]
+        pub code: String,
+        #[rustango(min = 1, max = 3)]
+        pub level: i64,
+    }
+
+    #[derive(Serializer, serde::Deserialize, Default)]
+    #[serializer(model = DvWidget)]
+    struct DvWidgetSer {
+        pub code: String, // inherits max_length = 5
+        #[serializer(min = 0, max = 10)] // overrides the model's min/max
+        pub level: i64,
+    }
+
+    #[test]
+    fn inherits_model_max_length() {
+        let s = DvWidgetSer {
+            code: "toolong".into(), // 7 > model's 5
+            level: 5,
+        };
+        let err = s.validate().expect_err("should fail");
+        assert!(
+            err.get("code")[0].contains("at most 5 characters"),
+            "code inherits the model's max_length: {:?}",
+            err.fields()
+        );
+    }
+
+    #[test]
+    fn attr_overrides_model_min_max() {
+        let s = DvWidgetSer {
+            code: "ok".into(),
+            level: 20, // > the serializer attr max = 10 (model max is 3)
+        };
+        let err = s.validate().expect_err("should fail");
+        assert!(
+            err.get("level")[0].contains("≤ 10"),
+            "level uses the serializer attr bound, not the model's: {:?}",
+            err.fields()
+        );
+    }
+
+    #[test]
+    fn passes_within_all_bounds() {
+        let s = DvWidgetSer {
+            code: "ok".into(),
+            level: 7,
+        };
+        assert!(s.validate().is_ok());
+    }
+}

--- a/crates/rustango/tests/viewset_serializer_input_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_serializer_input_sqlite_live.rs
@@ -187,3 +187,158 @@ async fn partial_update_ignores_read_only_field() {
         "read_only field must stay at its server value: {v}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Declarative field validators: max_length / min / max / choices, inherited
+// from the model's FieldSchema unless a per-field attr overrides.
+// ---------------------------------------------------------------------------
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "vs_in_widget")]
+#[rustango(app = "vs_in_app")]
+pub struct Widget {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 8)]
+    pub code: String,
+    #[rustango(max_length = 50)]
+    pub note: String,
+    #[rustango(min = 1, max = 3)]
+    pub priority: i64,
+    #[rustango(max_length = 20, choices = "draft:Draft, live:Live")]
+    pub status: String,
+}
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Widget)]
+struct WidgetSerializer {
+    pub code: String, // inherits max_length = 8 from the model
+    #[serializer(max_length = 4)] // overrides the model's 50
+    pub note: String,
+    pub priority: i64,  // inherits min = 1, max = 3
+    pub status: String, // inherits choices
+}
+
+async fn widget_router() -> axum::Router {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE vs_in_widget (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            code TEXT NOT NULL, note TEXT NOT NULL, \
+            priority INTEGER NOT NULL, status TEXT NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .expect("create");
+    rustango::viewset::ViewSet::for_model(Widget::SCHEMA)
+        .serializer::<WidgetSerializer>()
+        .router_pool("/widgets", Pool::Sqlite(sq))
+}
+
+/// Helper: POST a widget body, return (status, body).
+async fn post_widget(app: &axum::Router, body: &str) -> (StatusCode, serde_json::Value) {
+    let resp = app.clone().oneshot(post("/widgets", body)).await.unwrap();
+    let status = resp.status();
+    (status, json_body(resp).await)
+}
+
+#[tokio::test]
+async fn max_length_inherited_from_model() {
+    let app = widget_router().await;
+    // code = 9 chars > the model's max_length = 8.
+    let (status, v) = post_widget(
+        &app,
+        r#"{"code":"abcdefghi","note":"ok","priority":1,"status":"draft"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "inherited max_length: {v}");
+    assert!(
+        v["code"][0]
+            .as_str()
+            .unwrap_or("")
+            .contains("at most 8 characters"),
+        "model max_length inherited: {v}"
+    );
+}
+
+#[tokio::test]
+async fn max_length_attr_overrides_model() {
+    let app = widget_router().await;
+    // note = 5 chars > the serializer attr max_length = 4 (model allows 50).
+    let (status, v) = post_widget(
+        &app,
+        r#"{"code":"ok","note":"toolong","priority":1,"status":"draft"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "override max_length: {v}");
+    assert!(
+        v["note"][0]
+            .as_str()
+            .unwrap_or("")
+            .contains("at most 4 characters"),
+        "serializer attr overrides model max_length: {v}"
+    );
+}
+
+#[tokio::test]
+async fn min_max_inherited_from_model() {
+    let app = widget_router().await;
+    // priority = 9 > model max = 3.
+    let (status, v) = post_widget(
+        &app,
+        r#"{"code":"ok","note":"ok","priority":9,"status":"draft"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        v["priority"][0].as_str().unwrap_or("").contains("≤ 3"),
+        "max inherited: {v}"
+    );
+    // priority = 0 < model min = 1.
+    let (status, v) = post_widget(
+        &app,
+        r#"{"code":"ok","note":"ok","priority":0,"status":"draft"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        v["priority"][0].as_str().unwrap_or("").contains("≥ 1"),
+        "min inherited: {v}"
+    );
+}
+
+#[tokio::test]
+async fn choices_inherited_from_model() {
+    let app = widget_router().await;
+    let (status, v) = post_widget(
+        &app,
+        r#"{"code":"ok","note":"ok","priority":1,"status":"bogus"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        v["status"][0]
+            .as_str()
+            .unwrap_or("")
+            .contains("valid choice"),
+        "model choices inherited: {v}"
+    );
+}
+
+#[tokio::test]
+async fn valid_widget_passes_all_constraints() {
+    let app = widget_router().await;
+    let (status, v) = post_widget(
+        &app,
+        r#"{"code":"ok","note":"abc","priority":2,"status":"live"}"#,
+    )
+    .await;
+    assert!(
+        status.is_success(),
+        "all constraints satisfied → success: {status} {v}"
+    );
+    assert_eq!(v["code"], "ok");
+    assert_eq!(v["priority"], 2);
+}


### PR DESCRIPTION
## What

Adds DRF `validators=[…]`-style declarative field validation to serializers, **auto-inherited from the model** (DRF `ModelSerializer` behavior). Builds on #1067 (serializer↔ViewSet marriage). A too-long string / out-of-range number / bad choice now returns a friendly DRF-shape **400** on write instead of an ugly DB-constraint 500.

## How it works

- New per-field attrs: `#[serializer(max_length = N)]`, `min_length`, `min`, `max`.
- **Auto-inherit:** every writable field is validated against the model's `FieldSchema` (`max_length` / `min` / `max` / `choices`) even with no attribute; a per-field attribute **overrides** the inherited value. `min_length` is serializer-only (no model column); `choices` is inherited from the model.
- `forms::validators::check_value` does the work, dispatching on the field's JSON value (string → `max_length`/`min_length`/`choices`; integer → `min`/`max`), reusing the **exact Django/DRF messages** already used by the admin `DynamicForm` — so the macro needs no Rust-type introspection and every validation surface speaks the same language.
- The generated `validate()` runs the per-field constraint blocks, then the existing `validate = "fn"` per-field + cross-field validators. The trait `ModelSerializer::validate` override is now emitted whenever there's anything to check (so auto-inherit runs through the ViewSet write path); the inherent `validate` emission rule is unchanged (no collision with hand-written `validate` methods).

## Behavior change

Serializer-backed ViewSets now enforce the model's `max_length`/`min`/`max`/`choices` on create/update. This is strictly safer (the DB enforced them anyway — now it's a 400 with a clear message instead of a 500). String length is measured in characters.

## Tests

- `forms::validators` unit (5).
- `serializer_derive` no-DB units: inherits model `max_length`; attr overrides model `min`/`max` (3).
- `viewset_serializer_input_sqlite_live` live: inherited `max_length`, attr override, inherited `min`/`max`, inherited `choices`, all-valid path (5).
- Full `--all-features --no-run` gate + 3186 lib tests + clippy clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)