### PR TITLE
docs(rest): correct serializer/viewset guides after #1069 + ORM-API fix

### DIFF
--- a/docs/serializers.md
+++ b/docs/serializers.md
@@ -63,7 +63,7 @@ pub struct PostSerializer {
 Use it:
 
 ```rust
-let post = Post::objects().get_pool(&pool, 42).await?;
+let post = Post::objects().find(42, &pool).await?.expect("post 42");
 
 let one  = PostSerializer::from_model(&post).to_value();   // a JSON object
 let many = PostSerializer::many_to_value(&posts);          // a JSON array
@@ -120,6 +120,11 @@ Everything is controlled by `#[serializer(...)]` on each field. The full set:
 
 **Mutually exclusive** (compile errors if combined): `read_only` + `write_only`;
 `method` + `source`; `slug` + any of `method` / `nested` / `many`.
+
+**Declarative validators.** `max_length = N`, `min_length = N`, `min = N`, and
+`max = N` add write-time validation to a field without changing its output shape
+(and a field with none of them inherits the model's bounds). See
+[Validation](#validation).
 
 `write_only` is for inbound-only data (a password, a one-time token): present in
 `writable_fields()`, absent from output. `skip` is the opposite escape hatch —
@@ -235,9 +240,34 @@ unloaded; it's display-only (not writable).
 
 ## Validation
 
-Two layers, both surfacing as `rustango::forms::FormErrors`.
+Three layers, all surfacing as `rustango::forms::FormErrors` (and, on a ViewSet
+write, a DRF-shape `400`). They run in this order: declarative constraints, then
+per-field validators, then the cross-field hook.
 
-**Per-field** — declare `validate = "fn"` and write
+**Declarative constraints (DRF `validators`, auto-inherited).** `max_length`,
+`min_length`, `min`, and `max` are field attributes — and when you omit them a
+field **inherits the model's** `max_length` / `min` / `max` / `choices`. So a
+`#[rustango(max_length = 200)]` column is length-checked with no serializer
+attribute at all (DRF `ModelSerializer` behaviour). They're checked on every
+writable field, turning would-be database-constraint `500`s into friendly `400`s:
+
+```rust
+#[serializer(model = Widget)]
+struct WidgetSerializer {
+    pub code: String,               // inherits the model's max_length
+    #[serializer(max_length = 4)]   // overrides the model's bound
+    pub note: String,
+    pub priority: i64,              // inherits the model's min / max
+    pub status: String,             // inherits the model's choices
+}
+```
+
+Messages match Django/DRF: `"Ensure this value has at most N characters."`,
+`"Ensure this value has at least N characters."`, `"Ensure this value is ≥ N."` /
+`"≤ N"`, and `"Select a valid choice."`. (`min_length` is serializer-only;
+`choices` is inherited from the model — there's no `choices` attribute.)
+
+**Per-field** (custom) — declare `validate = "fn"` and write
 `fn(value: &FieldType) -> Result<(), String>`:
 
 ```rust
@@ -282,11 +312,12 @@ impl PostSerializer {
 `FormErrors` separates **field** errors (`add(field, msg)`, a
 `HashMap<String, Vec<String>>`) from **non-field** errors
 (`add_non_field(msg)`). Inspect with `.fields()`, `.non_field()`, `.get(field)`,
-`.is_empty()`, and combine with `.merge(other)`. There are **no built-in
-validators** (no `max_length` / `email` magic) — every rule is a function you
-write, which keeps validation explicit and testable. The framework doesn't
-auto-render `FormErrors` to an HTTP body; map it to your 400 response (the
-field/non-field split lines up with DRF's error JSON).
+`.is_empty()`, and combine with `.merge(other)`. Beyond the declarative
+constraints above (`max_length` / `min_length` / `min` / `max` / inherited
+`choices`), custom rules are plain functions — there's no `email`/regex magic,
+which keeps custom validation explicit and testable. Outside a ViewSet the
+framework doesn't auto-render `FormErrors` to an HTTP body; map it to your 400
+response (the field/non-field split lines up with DRF's error JSON).
 
 ---
 
@@ -381,7 +412,7 @@ You can also use a serializer **standalone** — map a row and emit its JSON fro
 any handler:
 
 ```rust
-let post = Post::objects().get_pool(&pool, 42).await?;
+let post = Post::objects().find(42, &pool).await?.expect("post 42");
 let body = PostSerializer::from_model(&post).to_value();   // shaped JSON
 ```
 
@@ -448,8 +479,10 @@ A few sharp edges and escape hatches worth knowing:
   bespoke JSON object when the attributes aren't enough.
 - **Writable nested objects** aren't supported — `nested` / `many` / `slug`
   fields are output-only. Accept writes as scalar ids and resolve them yourself.
-- **No built-in validators** — `max_length`, `email`, regex, etc. are functions
-  you write (see [Validation](#validation)).
+- **Built-in validators are length/range/choice only** — `max_length` /
+  `min_length` / `min` / `max` (and inherited `choices`) are declarative; other
+  rules (`email`, regex, …) are functions you write (see
+  [Validation](#validation)).
 - **One per-field validator per field.** For multiple rules on a field, combine
   them in that field's function, or add a cross-field `validate(&self)`.
 - **The serializer doesn't persist.** Map → validate → hand the data to the ORM;

--- a/docs/viewsets.md
+++ b/docs/viewsets.md
@@ -166,7 +166,13 @@ impl PostSerializer {
 ```
 
 Register the module — add `pub mod post_serializer;` to `src/blog/mod.rs`.
-(See the [serializers guide](serializers.md) for every field attribute.)
+
+Note we only wrote one validator (`title_min_3`); the fields also **inherit the
+model's constraints** automatically — `title` is length-checked against the
+model's `max_length = 200`, and a `choices`/`min`/`max` column would be checked
+too, all returning friendly `400`s on write. Add `max_length` / `min_length` /
+`min` / `max` serializer attributes to override a field's bound. (See the
+[serializers guide](serializers.md#validation) for the full validation story.)
 
 ### Step 5 — Scaffold the ViewSet and wire the serializer
 
@@ -580,9 +586,18 @@ for very large tables. `?cursor=<token>&page_size=20`:
 ## Validation
 
 With a **serializer wired**, the create/update path runs the serializer's
-validators and returns DRF-shape `400`s — that's the recommended way to validate
-(see [the marriage](#the-serializer-marriage-input--output) and the
-[serializers guide](serializers.md)).
+validators and returns DRF-shape `400`s — the recommended way to validate (see
+[the marriage](#the-serializer-marriage-input--output) and the
+[serializers guide](serializers.md#validation)). Three layers run:
+
+- **Declarative constraints** — `max_length` / `min_length` / `min` / `max`, and
+  by default the field **inherits the model's** `max_length` / `min` / `max` /
+  `choices`. So a `#[rustango(max_length = 200)]` column is length-checked on the
+  API with no extra config (DRF `ModelSerializer` behaviour), turning would-be
+  DB-constraint `500`s into friendly `400`s like
+  `{"title":["Ensure this value has at most 200 characters."]}`.
+- **Per-field** `validate = "fn"` and a **cross-field** `validate` hook — your
+  custom rules (formats, cross-field, business logic).
 
 Independently of a serializer, the write path always enforces the **schema**:
 
@@ -590,11 +605,12 @@ Independently of a serializer, the write path always enforces the **schema**:
   value is a `400` naming the field.
 - **Required / NOT NULL** — a missing non-nullable field (or empty string for a
   non-nullable `String`) is a `400`; nullable fields accept empty → `NULL`.
-- **Database constraints** — unique, `VARCHAR(n)` length (PG/MySQL), foreign
-  keys and check constraints surface as a `400` on INSERT/UPDATE.
+- **Database constraints** — unique, foreign keys and check constraints surface
+  as a `400` on INSERT/UPDATE.
 
 So even without a serializer you get type + required + DB-constraint validation;
-add a serializer for application-level rules (formats, ranges, cross-field).
+wire a serializer to get declarative length/range/choice checks (auto-inherited)
+plus your own per-field and cross-field rules.
 
 ---
 


### PR DESCRIPTION
Re-review of the merged REST API guides (`serializers.md`, `viewsets.md`)
against current `develop` — which has advanced past my docs with **#1069**
(declarative serializer validators). Found and fixed two real inaccuracies;
re-verified the rest against source.

## Fixed
1. **Declarative validators (#1069) were undocumented / contradicted.** #1069
   added `max_length` / `min_length` / `min` / `max` serializer attributes, and
   **auto-inheritance** of `max_length` / `min` / `max` / `choices` from the
   model's `FieldSchema` (DRF `ModelSerializer` behaviour) — validated on the
   ViewSet write path as DRF-shape `400`s. The guides still said *"no built-in
   validators."* Now both Validation sections document a **declarative
   constraints** layer (with the exact Django messages), serializers.md gets a
   field-attribute note, and the blog tutorial notes that fields inherit the
   model's bounds.
2. **Wrong ORM call.** serializers.md used `Post::objects().get_pool(&pool, 42)`
   — `get_pool` is a foreign-key accessor, not a QuerySet terminal. Fixed to
   `Post::objects().find(42, &pool).await?.expect(…)` (pk-first; returns
   `Option<T>`).

## Re-verified accurate (no change)
- The list-endpoint **lookup set** (`ne`/`gt`/`gte`/`lt`/`lte`/`in`/`not_in`/
  `contains`/`icontains`/`startswith`/…/`isnull`) — matches `build_lookup_filter`.
- The **`TestClient`** API used in the tutorial test (`get/post/.json/.send`,
  `res.status`, `res.json_value()`).
- `router_pool`, `check_unique_together_pool`, `model.save(&pool)`, the CRUD
  response envelopes, and the `serializer = …` / `.serializer::<S>()` wiring.

Re-seeded the docs site locally — both pages render with the corrected content.
