### PR TITLE
fix(viewset): apply serializer source rename on the write path (input)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,20 @@ env:
   # pre-push hook treats warnings as warnings; CI now does the
   # same. Real type errors / broken tests still fail the build.
   DATABASE_URL: postgres://rustango:rustango@localhost:5432/rustango_test
+  # Strip debuginfo from every build profile in CI. The `postgres_test`
+  # job links the full workspace `--all-features`, which is ~450
+  # statically-linked integration-test binaries; with the default
+  # `debug = true` on both `[profile.dev]` (dependency rlibs) and
+  # `[profile.test]` (the test crates), full DWARF dominates each binary
+  # and the cumulative `target/` blows past the runner's free disk at
+  # link time (`ld: final link failed: No space left on device`) — even
+  # after `jlumbroso/free-disk-space` reclaims ~35 GB. CI never debugs
+  # interactively, so dropping debuginfo is free here: panic messages +
+  # the failing test's name still surface; only backtrace line numbers
+  # go. Set on both profiles because `cargo test` builds the dependency
+  # graph with `dev` and the test targets with `test`.
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
 
 jobs:
   fmt:

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -301,6 +301,13 @@ trait SerializerBridge: Send + Sync {
     /// (`source`-resolved). The write path skips every other model column
     /// so `read_only` / computed fields can't be set by a client.
     fn writable_model_fields(&self) -> &'static [&'static str];
+
+    /// The **serializer** field names of the writable fields — the JSON
+    /// keys a client sends (DRF read/write shape). Parallel to
+    /// [`Self::writable_model_fields`]; the two differ only where a field
+    /// declares `#[serializer(source = "…")]`, which the write path uses
+    /// to translate the inbound key to its model column.
+    fn writable_field_names(&self) -> &'static [&'static str];
 }
 
 /// Zero-sized carrier that pins a concrete serializer type `S` so the
@@ -354,6 +361,10 @@ where
 
     fn writable_model_fields(&self) -> &'static [&'static str] {
         S::writable_source_fields()
+    }
+
+    fn writable_field_names(&self) -> &'static [&'static str] {
+        S::writable_fields()
     }
 }
 
@@ -1039,6 +1050,42 @@ fn json_form_errors(errs: &crate::forms::FormErrors) -> Response {
 /// write — every column the serializer doesn't accept (`read_only` /
 /// computed). Returns the 400 response on a validation failure so the
 /// caller can short-circuit. No-op (`Ok(vec![])`) without a serializer.
+/// Translate inbound form keys from serializer field names to model
+/// columns for any `#[serializer(source = "…")]`-renamed **writable**
+/// field, so a client POSTs the serializer field name (DRF shape) — e.g.
+/// `content` for a field declared `#[serializer(source = "body")]` — and
+/// the persist step (which reads model columns) still finds the value.
+///
+/// Returns `None` when nothing needs renaming (no serializer, or no
+/// renamed writable key present in the body) — the common case, so no
+/// allocation. Otherwise returns a remapped clone of the form.
+fn serializer_input_renamed_form(
+    state: &ViewSetState,
+    form: &HashMap<String, String>,
+) -> Option<HashMap<String, String>> {
+    let bridge = state.vs.serializer.as_ref()?;
+    // `writable_field_names()` (JSON keys) and `writable_model_fields()`
+    // (model columns) are parallel; they differ only at `source` renames.
+    let renames: Vec<(&'static str, &'static str)> = bridge
+        .writable_field_names()
+        .iter()
+        .zip(bridge.writable_model_fields().iter())
+        .filter(|(name, col)| name != col && form.contains_key(**name))
+        .map(|(name, col)| (*name, *col))
+        .collect();
+    if renames.is_empty() {
+        return None;
+    }
+    let mut out = form.clone();
+    for (name, col) in renames {
+        if let Some(v) = out.remove(name) {
+            // Don't clobber an explicit model-column key if a client sent both.
+            out.entry(col.to_owned()).or_insert(v);
+        }
+    }
+    Some(out)
+}
+
 fn serializer_write_prep(
     state: &ViewSetState,
     json: Option<&Value>,
@@ -1762,6 +1809,10 @@ async fn create_one(
     };
     let mut all_skip: Vec<&str> = skip.to_vec();
     all_skip.extend(extra_skip);
+    // Translate `source`-renamed writable keys (serializer field name →
+    // model column) so the client can POST the serializer field name.
+    let renamed = serializer_input_renamed_form(state, form);
+    let form = renamed.as_ref().unwrap_or(form);
     let collected = or_400!(collect_values(state.vs.schema, form, &all_skip));
     let (columns, values): (Vec<_>, Vec<_>) = collected.into_iter().unzip();
     let fields = state.effective_fields();
@@ -1803,6 +1854,8 @@ async fn create_many(
         };
         let mut all_skip: Vec<&str> = skip.to_vec();
         all_skip.extend(extra_skip);
+        let renamed = serializer_input_renamed_form(state, row);
+        let row = renamed.as_ref().unwrap_or(row);
         let collected = match collect_values(state.vs.schema, row, &all_skip) {
             Ok(v) => v,
             Err(e) => {
@@ -1884,6 +1937,11 @@ async fn update_inner(
         Ok(s) => s,
         Err(resp) => return resp,
     };
+
+    // Translate `source`-renamed writable keys (serializer field name →
+    // model column) before the per-column update loop reads the form.
+    let renamed = serializer_input_renamed_form(&state, &form);
+    let form = renamed.as_ref().unwrap_or(&form);
 
     let mut assignments: Vec<Assignment> = Vec::new();
     for field in state.vs.schema.scalar_fields() {

--- a/crates/rustango/tests/viewset_serializer_input_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_serializer_input_sqlite_live.rs
@@ -342,3 +342,111 @@ async fn valid_widget_passes_all_constraints() {
     assert_eq!(v["code"], "ok");
     assert_eq!(v["priority"], 2);
 }
+
+// ── source-renamed writable field: input uses the serializer field name ──
+//
+// Regression: a `#[serializer(source = "body")]` writable field renamed on
+// OUTPUT (`body` → `content`) must also accept the serializer field name
+// (`content`) on INPUT and persist it to the model column (`body`). Before the
+// fix the write path read the raw body by model column, so posting `content`
+// 400'd with "required field `body` missing".
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "vs_in_doc")]
+#[rustango(app = "vs_in_app")]
+pub struct Doc {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    pub body: String,
+}
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Doc)]
+struct DocSerializer {
+    pub id: Auto<i64>,
+    pub title: String,
+    /// JSON key `content`, model column `body`.
+    #[serializer(source = "body")]
+    pub content: String,
+}
+
+async fn doc_router() -> axum::Router {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE vs_in_doc (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            title TEXT NOT NULL, \
+            body TEXT NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .expect("create");
+    rustango::viewset::ViewSet::for_model(Doc::SCHEMA)
+        .serializer::<DocSerializer>()
+        .router_pool("/docs", Pool::Sqlite(sq))
+}
+
+#[tokio::test]
+async fn source_renamed_field_accepts_serializer_name_on_create() {
+    let app = doc_router().await;
+    // Client posts the SERIALIZER field name `content` (DRF shape), not `body`.
+    let resp = app
+        .clone()
+        .oneshot(post(
+            "/docs",
+            r#"{"title":"Hello","content":"the body text"}"#,
+        ))
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "posting the serializer field name should succeed, got {}",
+        resp.status()
+    );
+    let v = json_body(resp).await;
+    // The value round-trips: written to `body`, rendered back as `content`.
+    assert_eq!(
+        v["content"], "the body text",
+        "source-renamed field must persist on write + render on read: {v}"
+    );
+    assert_eq!(v["title"], "Hello");
+}
+
+#[tokio::test]
+async fn source_renamed_field_updates_on_partial_update() {
+    let app = doc_router().await;
+    let created = app
+        .clone()
+        .oneshot(post("/docs", r#"{"title":"Orig","content":"orig body"}"#))
+        .await
+        .unwrap();
+    assert!(created.status().is_success());
+
+    let patched = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::PATCH)
+                .uri("/docs/1")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"content":"patched body"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        patched.status().is_success(),
+        "PATCH with the serializer field name should succeed, got {}",
+        patched.status()
+    );
+    let v = json_body(patched).await;
+    assert_eq!(
+        v["content"], "patched body",
+        "PATCH on a source-renamed field must update the model column: {v}"
+    );
+    assert_eq!(v["title"], "Orig", "untouched field preserved");
+}


### PR DESCRIPTION
Found by dogfooding the REST-blog tutorial: a `#[serializer(source = "body")]`
**writable** field renamed its key on **output** (`body` → `content`) but the
write path read the raw body by **model column**, so a client posting the
serializer field name (`content`) — the DRF shape, and what the docs/tutorial
tell you to send — got:

```
HTTP 400  {"error":"required field `body` was missing from the form"}
```

Input and output were asymmetric, and the case was never tested (the input
test's writable fields had no `source`).

## Fix
Translate inbound form keys from the **serializer field name** to the **model
column** before persisting, on create and update (full + partial).
`writable_fields()` (the JSON keys) and `writable_source_fields()` (the model
columns) are parallel arrays, so the rename map is their zip where they differ;
a new `SerializerBridge::writable_field_names()` exposes the former. When no
`source` rename is present (the common case) there's no remap and no clone.
Posting the model column still works (back-compat).

## Tests
Adds two live cases to `viewset_serializer_input_sqlite_live`: a source-renamed
writable field accepts the serializer field name on **create** and on **partial
update**, and persists to the model column. Existing serializer input (10) +
render (3) tests pass.

## Verified end-to-end
Rebuilt a `cargo`-style app against this branch:
`POST /api/posts {"title":...,"content":"…"}` → **201**, value round-trips
(stored as `body`, rendered back as `content`). This also makes the
**viewsets.md "Build a REST blog" tutorial correct as written** — no doc change
needed.
