### PR TITLE
chore: back-merge 0.43.1 release into develop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.43.0"
+version = "0.43.1"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.43.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.43.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.43.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.43.1", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.43.1", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.43.1", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,9 +89,9 @@ chacha20poly1305 = "0.10"
 
 # Interactive manage CLI
 dotenvy   = "0.15"
-# 7.4+ uses `libc::__errno_location` which is Linux-only; pin to 7.3
-# until rpassword adopts a portable errno call.
-rpassword = "=7.5.0"
+# 7.4+ uses `libc::__errno_location` which is Linux-only (breaks macOS
+# builds); pin to 7.3 until rpassword adopts a portable errno call.
+rpassword = "=7.3.1"
 
 # Admin (HTTP)
 axum = { version = "0.8", default-features = false, features = ["tokio", "http1", "json", "form", "query", "original-uri"] }

--- a/crates/cargo-rustango/src/templates.rs
+++ b/crates/cargo-rustango/src/templates.rs
@@ -78,6 +78,20 @@ RUSTANGO_BIND=0.0.0.0:8080
 # Generate a real secret with: openssl rand -base64 32
 RUSTANGO_APEX_DOMAIN=localhost
 RUSTANGO_SESSION_SECRET=change-me-base64-encoded-32-bytes-or-more
+
+# ---------------- Logging (ujeenet/rustango-cms#305) ----------------
+# `#[rustango::main]` auto-installs a tracing_subscriber::fmt with
+# env-filter; the default is `info,sqlx=warn`. Uncomment to turn on
+# more verbose output without code changes. Standard `RUST_LOG`
+# syntax — per-target filtering is the easiest knob.
+#
+#   `debug` — everything DEBUG+ across every crate (very noisy)
+#   `info,my_app=debug` — INFO globally, DEBUG for one module
+#   `info,sqlx=warn,hyper=warn` — quiet down noisy upstreams
+#
+# Production deployments override this in the orchestrator (k8s env,
+# systemd unit, etc.) rather than editing this file.
+# RUST_LOG=info,sqlx=warn,hyper=warn
 "
     )
 }
@@ -263,6 +277,12 @@ const MAIN_RS_API: &str = "//! Project entrypoint — `Cli::run()` is the unifie
 //! that handles `cargo run` (runserver) AND `cargo run -- migrate` /
 //! `makemigrations` / `startapp` / etc. from one binary. No
 //! `src/bin/manage.rs` needed.
+//!
+//! Logging is auto-configured by `#[rustango::main]` —
+//! `tracing_subscriber::fmt` with env-filter, default
+//! `info,sqlx=warn`. Override with `RUST_LOG` (see `.env.example`)
+//! or replace the macro with a hand-rolled subscriber in front of
+//! `Cli::new()` for JSON / file-rotation / OTel export.
 
 mod models;
 mod urls;
@@ -285,6 +305,12 @@ const MAIN_RS_FULLSTACK: &str = "//! Project entrypoint — `Cli::run()` is the 
 //! `src/bin/manage.rs` needed. The auto-admin lives in
 //! `urls::admin_router(pool)`; nest it under `/admin` when you want
 //! it (see the getting-started guide).
+//!
+//! Logging is auto-configured by `#[rustango::main]` —
+//! `tracing_subscriber::fmt` with env-filter, default
+//! `info,sqlx=warn`. Override with `RUST_LOG` (see `.env.example`)
+//! or replace the macro with a hand-rolled subscriber in front of
+//! `Cli::new()` for JSON / file-rotation / OTel export.
 
 mod models;
 mod urls;
@@ -304,6 +330,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 const MAIN_RS_TENANT: &str = r##"//! Tenant project entrypoint — HTTP server serving both the operator
 //! console and per-tenant apps via subdomain routing.
+//!
+//! Logging is auto-configured by `#[rustango::main]` —
+//! `tracing_subscriber::fmt` with env-filter, default
+//! `info,sqlx=warn`. Override with `RUST_LOG` (see `.env.example`)
+//! or replace the macro with a hand-rolled subscriber in front of
+//! `Cli::new()` for JSON / file-rotation / OTel export.
 
 mod models;
 mod urls;

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -367,7 +367,7 @@ runserver = ["dep:axum", "dep:tokio"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.43.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.43.1", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }

--- a/crates/rustango/src/admin/urls.rs
+++ b/crates/rustango/src/admin/urls.rs
@@ -723,6 +723,21 @@ pub(crate) struct AppState {
 
 impl AppState {
     pub(crate) fn is_visible(&self, table: &str) -> bool {
+        // ujeenet/rustango-cms#291 — `rustango_admin_users` is the bare
+        // admin's standalone credential store. Its table is created
+        // only when a host opts into `Builder::with_session_auth`;
+        // tenancy hosts (anything mounting `tenancy::auth::User`'s
+        // `rustango_users` instead) never call that opt-in and so
+        // the table never exists. But the `#[derive(Model)]` on
+        // `AdminUser` unconditionally submits to the inventory, so
+        // the model index lists `rustango_admin_users` as if it
+        // were a real surface — clicking it on a tenancy host either
+        // 500'd (pre-#260) or showed the "table missing" placeholder
+        // (post-#260). Hide it entirely when session_auth isn't
+        // configured so tenancy hosts don't see a dead surface.
+        if table == "rustango_admin_users" && self.config.session_secret.is_none() {
+            return false;
+        }
         let allowlist_ok = self
             .config
             .allowed_tables
@@ -936,6 +951,38 @@ mod scope_filter_tests {
             .expect("connect_lazy never fails");
         let builder = Builder::new(pool).tenant_mode();
         assert!(builder.config.tenant_mode);
+    }
+
+    // ujeenet/rustango-cms#291 — `rustango_admin_users` is the bare
+    // admin's standalone credential store. The Model derive
+    // unconditionally registers it in the inventory, but the table
+    // is only created when a host opts into `with_session_auth`.
+    // Tenancy hosts (which mount `tenancy::auth::User`'s
+    // `rustango_users` instead) never call that opt-in, so they
+    // should never see `rustango_admin_users` in the model index
+    // either — clicking it would land on a dead surface.
+    #[tokio::test]
+    async fn admin_users_hidden_when_session_auth_not_configured() {
+        let state = state_with(false);
+        // session_secret stays None on the default Config — the
+        // host hasn't opted into the bare admin's session-auth
+        // flow. AdminUser's table must be hidden from the index.
+        assert!(state.config.session_secret.is_none());
+        assert!(!state.is_visible("rustango_admin_users"));
+        // Sanity: other tables still show through.
+        assert!(state.is_visible("rustango_users"));
+        assert!(state.is_visible("post"));
+    }
+
+    #[tokio::test]
+    async fn admin_users_visible_when_session_auth_configured() {
+        let mut cfg = Config::default();
+        cfg.session_secret = Some(crate::session::SessionSecret::from_bytes(vec![0u8; 32]));
+        let state = AppState {
+            pool: Pool::Postgres(lazy_pg_pool()),
+            config: Arc::new(cfg),
+        };
+        assert!(state.is_visible("rustango_admin_users"));
     }
 
     // v0.27.9 (#59) — admin_prefix template variable regression

--- a/crates/rustango/src/crypto.rs
+++ b/crates/rustango/src/crypto.rs
@@ -30,6 +30,10 @@ use sha2::{Digest, Sha256};
 /// implementation shared with the always-on call sites (`pagination`,
 /// `row_to_json`). Kept here so HMAC callers don't need to rewrite
 /// their import paths.
+// Conditionally used: the callers (storage::s3, hmac_auth) are
+// feature-gated, so this is dead in a build that pulls in `crypto` but
+// none of its consumers. Allow rather than delete — it's live elsewhere.
+#[allow(dead_code)]
 #[must_use]
 pub(crate) fn hex_encode(bytes: &[u8]) -> String {
     crate::hex::hex_encode(bytes)
@@ -37,6 +41,7 @@ pub(crate) fn hex_encode(bytes: &[u8]) -> String {
 
 /// `SHA-256(bytes)` rendered as a lowercase hex string. Used by the
 /// SigV4 canonical-request hash and HMAC auth body hash.
+#[allow(dead_code)] // see `hex_encode` above — live under s3/hmac, dead otherwise
 #[must_use]
 pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
     let mut h = Sha256::new();

--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -918,15 +918,6 @@ macro_rules! bind_match_sqlite {
     };
 }
 
-// Sibling-module access to the bind macros (values.rs and future
-// extractions need them at `super::` scope).
-#[cfg(feature = "postgres")]
-pub(super) use bind_match;
-#[cfg(feature = "mysql")]
-pub(super) use bind_match_mysql;
-#[cfg(feature = "sqlite")]
-pub(super) use bind_match_sqlite;
-
 #[cfg(feature = "postgres")]
 pub(super) fn bind_query_as<T>(
     q: QueryAs<'_, sqlx::Postgres, T, PgArguments>,

--- a/crates/rustango/src/sql/executor/values.rs
+++ b/crates/rustango/src/sql/executor/values.rs
@@ -31,11 +31,11 @@ use crate::sql::{
 };
 
 #[cfg(feature = "postgres")]
-use super::{bind_match, bind_query};
+use super::bind_query;
 #[cfg(feature = "mysql")]
-use super::{bind_match_mysql, bind_query_my};
+use super::bind_query_my;
 #[cfg(feature = "sqlite")]
-use super::{bind_match_sqlite, bind_query_sqlite};
+use super::bind_query_sqlite;
 
 /// Decode one per-dialect raw `SqlValue` from the i-th column of a row.
 /// Same probe order as the aggregate-row decoder so the two paths agree

--- a/crates/rustango/src/tenancy/pools.rs
+++ b/crates/rustango/src/tenancy/pools.rs
@@ -46,8 +46,15 @@ pub struct TenantPoolsConfig {
     /// count against this limit. Default: 64.
     pub max_cached_database_pools: usize,
     /// Per-pool `max_connections` for database-mode tenants. Keep
-    /// small so a tenant fan-out doesn't exhaust Postgres'
-    /// `max_connections`. Default: 4.
+    /// small enough that a fleet fan-out doesn't exhaust Postgres'
+    /// `max_connections`, but large enough that a single tenant's
+    /// concurrent admin traffic (page render + thumbnail fan-out
+    /// + background tasks) doesn't deadlock — the framework's
+    /// `Tenant` extractor pins one connection for the handler's
+    /// whole lifetime, so handlers that also call `fetch_pool(...)`
+    /// inside need at least one extra slot to make progress.
+    /// 4 is far too tight for that pattern; 16 leaves headroom
+    /// without flooding upstream PG. Default: 16.
     pub database_pool_max_connections: u32,
 
     // v0.27.7 — connection-time tuning (#60). Pre-fix, every tenant
@@ -97,7 +104,7 @@ impl Default for TenantPoolsConfig {
     fn default() -> Self {
         Self {
             max_cached_database_pools: 64,
-            database_pool_max_connections: 4,
+            database_pool_max_connections: 16,
             // Below: zeros / None preserve pre-0.27.7 behavior so
             // existing apps don't see surprise behavior on upgrade.
             // Apps that want hot pools opt in via `.config(...)`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,6 +75,25 @@ There is a single binary: `cargo run` boots the HTTP server, and every Django-st
 
 `Cargo.toml` is the dependency manifest (like `composer.json` or a `Gemfile`). Open it and confirm `rustango` is listed under `[dependencies]`.
 
+> **Confirm the `[features]` block — pick a database backend.** `#[derive(Model)]`
+> cfg-gates its generated `FromRow` / `LoadRelated` impls on **your** crate's
+> features (a `cfg` inside a derive macro resolves against the destination crate,
+> not rustango), so a backend feature must be enabled here or the first model
+> won't compile. A current scaffold includes:
+>
+> ```toml
+> [features]
+> default  = ["postgres"]            # the backend `cargo run` uses
+> postgres = ["rustango/postgres"]
+> sqlite   = ["rustango/sqlite"]
+> mysql    = ["rustango/mysql"]
+> ```
+>
+> If your generated `Cargo.toml` has **no** `[features]` block (an older
+> `cargo-rustango`), add the one above by hand — that always fixes it. Without it
+> the build fails with *"the trait bound `…: MaybePgFromRow` is not satisfied"*
+> plus a tell-tale `warning: unexpected cfg condition value: postgres`.
+
 ---
 
 ## Step 3: Set up your environment

--- a/docs/urls.md
+++ b/docs/urls.md
@@ -20,7 +20,8 @@ with `redirect_to_view(...)`. The API surface mirrors Django's
 - [Register a named URL](#register-a-named-url)
 - [Reverse in Rust](#reverse-in-rust) · [Reverse in templates](#reverse-in-templates)
 - [Redirect by name](#redirect-by-name) · [Namespacing](#namespacing)
-- [Inspect the URL map](#inspect-the-url-map) · [Errors](#errors) · [Notes & limits](#notes-and-limits)
+- [Inspect the URL map](#inspect-the-url-map) · [Errors](#errors)
+- [Regex & typed path patterns](#regex--typed-path-patterns) · [Notes & limits](#notes-and-limits)
 
 ---
 
@@ -200,6 +201,65 @@ rather than rendering a broken link.
 
 ---
 
+## Regex & typed path patterns
+
+**Rustango has no `re_path`, and no path converter is ever enforced.** A pattern
+segment is either a literal (`/posts/new`) or a `{name}` placeholder that captures
+exactly one segment; `{*name}` captures the rest of the path. That's the whole
+vocabulary — there is no `r'(?P<year>[0-9]{4})'`, and `{int:id}` does **not**
+constrain `id` to an integer.
+
+### Why — the matcher isn't a regex engine
+
+Routing *is* [axum](https://docs.rs/axum) 0.8, and axum matches paths with
+[`matchit`](https://docs.rs/matchit), a **radix-trie** router. It walks the URL
+one segment at a time down a prefix tree, so a match costs O(path length) and is
+independent of how many routes you've registered. A regex router does the
+opposite: Django evaluates `urlpatterns` top-to-bottom, running each entry's
+regex against the path until one matches. The trie buys constant-time matching
+and an unambiguous "most-specific literal wins" precedence — at the cost of not
+expressing character-class constraints *in the path itself*.
+
+Rustango inherits that matcher wholesale. There is **no second, regex-based
+resolver** layered on top, and `register_url!` deliberately records the *same*
+`{name}` strings the router already understands — it never compiles a regex. So
+regex paths aren't "turned off"; the routing layer was simply never a regex
+engine to begin with.
+
+The `{int:id}` form is accepted only as a **porting affordance** for `reverse()`:
+the builder splits the placeholder on `:` and keeps just the name, discarding the
+type prefix ([`urls.rs`](../crates/rustango/src/urls.rs)). That lets `reverse()`
+run on a pattern copied verbatim from a Django `path("<int:id>/", …)` — but
+nothing validates that the supplied value is actually an integer.
+
+### How to express a constrained route
+
+Match the segment with a plain `{placeholder}`, then enforce its shape where the
+value is used. Django's `re_path(r'^articles/(?P<year>[0-9]{4})/$', …)` becomes:
+
+```rust
+register_url!("article-by-year", "/articles/{year}");
+// router:
+.route("/articles/{year}", get(article_by_year))
+
+async fn article_by_year(Path(year): Path<String>) -> impl IntoResponse {
+    // the router accepted any single segment; enforce [0-9]{4} here
+    match year.parse::<u16>() {
+        Ok(y) if (1000..=9999).contains(&y) => render_year(y).await,
+        _ => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+```
+
+To reject *before* the handler runs (closer to Django's converter semantics), put
+the check in a custom axum extractor (`FromRequestParts`) and take that type as
+the handler argument instead of `Path<String>` — the framework doesn't ship one,
+but axum's extractor trait is the intended seam. The `regex` crate is already a
+dependency (the ORM uses it for `__regex` lookups), so a validating extractor can
+compile a `Regex` once and reuse it across requests.
+
+---
+
 ## Notes and limits
 
 - **Registration is link-time.** A `register_url!` only takes effect if its
@@ -212,4 +272,6 @@ rather than rendering a broken link.
 - **Values are percent-encoded** by `reverse`, so they're safe to drop into a
   `Location` header or an `href`.
 - **No regex/typed converters** in patterns (Django's `<int:pk>`); placeholders
-  are plain `{name}` and values are substituted as-is (after encoding).
+  are plain `{name}` and values are substituted as-is (after encoding). See
+  [Regex & typed path patterns](#regex--typed-path-patterns) for why, and how to
+  constrain a route instead.


### PR DESCRIPTION
Back-merges the 0.43.1 release commits from `main` into `develop` so the dev line isn't left behind after the release force-push.

Brings in (all already on main):
- `fix`: rpassword pinned to 7.3.1 (macOS build) + dead-code/unused-import warning cleanup
- `docs`: urls.md regex-path section + getting-started `[features]` note
- `chore`: release 0.43.1 (version bump)
- cherry-picked main-only hotfixes: tenancy pool 4→16, scaffold logging hint (#305), hide `rustango_admin_users` w/o session_auth (#291)

Fast-forward-clean (no conflicts) — develop is a direct ancestor of main's tip.