### PR TITLE
docs(auth): passwords + sessions guides + auth_demo; fix(oauth2): router gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,11 @@ jobs:
             migrate: false
           - example: admin_demo
             migrate: true
+          # Authentication deep-dive docs (docs/auth-*.md). `migrate: false` for
+          # now — the current flow tests (passwords, sessions) are pure /
+          # in-memory; flips to true once DB-backed flow tests land.
+          - example: auth_demo
+            migrate: false
     services:
       # See `postgres_test`'s comment for the AWS Public ECR mirror
       # rationale (CI Docker Hub timeouts after PR #848 / #866).

--- a/crates/rustango/examples/auth_demo/.gitignore
+++ b/crates/rustango/examples/auth_demo/.gitignore
@@ -1,0 +1,3 @@
+/target
+/.env
+*.log

--- a/crates/rustango/examples/auth_demo/Cargo.toml
+++ b/crates/rustango/examples/auth_demo/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "auth_demo"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# Standalone — severs from the parent workspace so it builds self-contained.
+# Companion to the docs/auth-*.md authentication deep-dives; each
+# tests/auth_<flow>.rs is the runnable, CI-tested backing for one doc.
+[workspace]
+
+[lib]
+name = "auth_demo"
+path = "src/lib.rs"
+
+[[bin]]
+name = "auth_demo"
+path = "src/main.rs"
+
+[dependencies]
+# Every auth feature is enabled BY NAME (not via rustango's default set) so the
+# crate is the source of truth for "which feature each flow needs" and is robust
+# to a future default-set trim. `passkey` + `tenancy` are the two auth features
+# not in rustango's defaults; the rest are listed for self-documentation.
+# `default-features = false` is required for the backend selector below.
+rustango = { path = "../..", default-features = false, features = [
+    "manage", "runserver", "admin", "config", "forms", "serializer",
+    "template_views", "cache", "signals", "email",
+    "passwords", "sessions", "jwt", "api_keys", "hmac-auth", "totp",
+    "oauth2", "passkey", "signed_url", "auth_flows", "csrf", "tenancy",
+] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }
+axum = { version = "0.8", default-features = false, features = ["tokio", "http1", "json", "form", "query"] }
+tower = { version = "0.5", features = ["util"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
+dotenvy = "0.15"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+# Backend selector — `#[derive(Model)]`'s FromRow impls are cfg-gated on THIS
+# crate's backend feature (a cfg inside a derive resolves against the
+# destination crate). postgres is default so `cargo run -- migrate` + `cargo
+# test` work with no flags; the CI matrix and local SQLite runs flip it.
+[features]
+default = ["postgres"]
+postgres = ["rustango/postgres"]
+sqlite = ["rustango/sqlite"]
+mysql = ["rustango/mysql"]

--- a/crates/rustango/examples/auth_demo/README.md
+++ b/crates/rustango/examples/auth_demo/README.md
@@ -1,0 +1,29 @@
+# auth_demo
+
+Companion example for the rustango **Authentication** docs (`docs/auth-*.md`).
+
+Every authentication flow has a dedicated deep-dive doc, and each doc's code
+snippets are copied from a compiled, CI-tested file here:
+
+| Doc | Backing test |
+|-----|--------------|
+| `docs/auth-passwords.md` | `tests/auth_passwords.rs` |
+| `docs/auth-sessions.md`  | `tests/auth_sessions.rs`  |
+
+More flows (JWT, API keys, OAuth2, TOTP, passkey, …) land in later batches.
+
+## Run
+
+```sh
+# one flow
+cargo test --test auth_passwords
+
+# everything (what CI runs)
+cargo run -- migrate        # apply migrations (needs DATABASE_URL → Postgres)
+cargo test
+
+# under SQLite (no server; pure/in-memory tests don't need a DB)
+cargo test --no-default-features --features sqlite --test auth_passwords --test auth_sessions
+```
+
+`DATABASE_URL` defaults to the project `.env`; copy `.env.example` if present.

--- a/crates/rustango/examples/auth_demo/src/lib.rs
+++ b/crates/rustango/examples/auth_demo/src/lib.rs
@@ -1,0 +1,10 @@
+//! `auth_demo` — companion crate for the rustango Authentication deep-dive docs
+//! (`docs/auth-*.md`).
+//!
+//! The library holds the shared app-level models; each authentication flow is
+//! exercised by an integration test under `tests/auth_<flow>.rs`, which is the
+//! runnable, CI-tested source the matching doc copies its snippets from.
+
+pub mod models;
+
+pub use models::User;

--- a/crates/rustango/examples/auth_demo/src/main.rs
+++ b/crates/rustango/examples/auth_demo/src/main.rs
@@ -1,0 +1,13 @@
+//! `auth_demo` entrypoint — the unified manage CLI (`cargo run -- migrate`,
+//! `makemigrations`, `runserver`, …). The authentication flows themselves are
+//! exercised by the integration tests in `tests/`; this binary just provides
+//! the migrate/runserver harness the docs' "Runnable version" commands point at.
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    // Link the lib's model inventory into the binary so `migrate` /
+    // `makemigrations` see the `auth_users` table.
+    let _ = std::any::type_name::<auth_demo::User>();
+    rustango::manage::Cli::new().with_health().run().await
+}

--- a/crates/rustango/examples/auth_demo/src/models.rs
+++ b/crates/rustango/examples/auth_demo/src/models.rs
@@ -1,0 +1,24 @@
+//! App-level authentication models.
+//!
+//! `User` is the kind of account table an application owns — distinct from the
+//! framework's admin-operator store (`rustango_admin_users`). The password is
+//! stored as an argon2id PHC hash (never plaintext); see
+//! [`docs/auth-passwords.md`](../../../../docs/auth-passwords.md).
+
+use rustango::{Auto, Model};
+
+#[derive(Model, Clone, Debug)]
+#[rustango(table = "auth_users", display = "username")]
+pub struct User {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 150, unique)]
+    pub username: String,
+    #[rustango(max_length = 254)]
+    pub email: String,
+    /// argon2id PHC string from `rustango::passwords::hash` — never plaintext.
+    #[rustango(max_length = 255)]
+    pub password_hash: String,
+    pub is_active: bool,
+    pub is_superuser: bool,
+}

--- a/crates/rustango/examples/auth_demo/tests/auth_passwords.rs
+++ b/crates/rustango/examples/auth_demo/tests/auth_passwords.rs
@@ -1,0 +1,42 @@
+//! Backing test for `docs/auth-passwords.md`. Pure functions — no DB needed.
+//!
+//! Run: `cargo test -p auth_demo --test auth_passwords`
+
+use rustango::passwords::{hash, strength_score, verify, verify_dummy, StrengthIssue};
+
+#[test]
+fn hash_is_argon2id_phc_and_verifies() {
+    let stored = hash("CorrectHorseBatteryStaple!42").unwrap();
+
+    // What you persist is an argon2id PHC string — never the plaintext.
+    assert!(stored.starts_with("$argon2id$"), "got: {stored}");
+    assert_ne!(stored, "CorrectHorseBatteryStaple!42");
+
+    // Login: verify the attempt against the stored hash.
+    assert!(verify("CorrectHorseBatteryStaple!42", &stored).unwrap());
+    assert!(!verify("wrong-password", &stored).unwrap());
+}
+
+#[test]
+fn each_hash_is_salted_so_two_hashes_of_one_password_differ() {
+    let a = hash("same-password-12345").unwrap();
+    let b = hash("same-password-12345").unwrap();
+    assert_ne!(a, b, "random per-hash salt → distinct PHC strings");
+    assert!(verify("same-password-12345", &a).unwrap());
+    assert!(verify("same-password-12345", &b).unwrap());
+}
+
+#[test]
+fn strength_score_flags_weak_and_passes_strong() {
+    assert!(strength_score("Tr0ub4dor&3-CorrectBattery").is_empty());
+    assert!(strength_score("password123").contains(&StrengthIssue::KnownWeak));
+    assert!(strength_score("short").contains(&StrengthIssue::TooShort));
+}
+
+#[test]
+fn verify_dummy_equalizes_timing_on_unknown_user() {
+    // Call this on the user-not-found (and inactive) branch of a login so the
+    // request takes ~the same time whether or not the account exists —
+    // otherwise the timing difference lets an attacker enumerate usernames.
+    verify_dummy("whatever-the-attacker-typed");
+}

--- a/crates/rustango/examples/auth_demo/tests/auth_sessions.rs
+++ b/crates/rustango/examples/auth_demo/tests/auth_sessions.rs
@@ -1,0 +1,47 @@
+//! Backing test for `docs/auth-sessions.md`. Uses an in-memory cache — no
+//! Redis or database needed. In production you pass a `RedisCache` so every
+//! replica sees the same sessions (and a logout on one is seen by all).
+//!
+//! Run: `cargo test -p auth_demo --test auth_sessions`
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rustango::cache::{BoxedCache, InMemoryCache};
+use rustango::sessions::{Session, SessionStore};
+
+fn store() -> SessionStore {
+    let cache: BoxedCache = Arc::new(InMemoryCache::new());
+    SessionStore::new(cache).ttl(Duration::from_secs(60 * 60))
+}
+
+#[tokio::test]
+async fn login_saves_a_session_and_the_id_loads_it_back() {
+    let store = store();
+
+    // After the password check, stash who the user is and save → opaque id.
+    let mut session = Session::new();
+    session.set("user_id", 42_i64);
+    let sid = store.save(&session).await.unwrap();
+
+    // The cookie carries only `sid`; the data lives server-side in the cache.
+    let loaded = store.load(&sid).await.unwrap().expect("session present");
+    assert_eq!(loaded.get::<i64>("user_id"), Some(42));
+}
+
+#[tokio::test]
+async fn logout_destroys_the_session_immediately() {
+    let store = store();
+    let sid = store.save(&Session::new()).await.unwrap();
+    assert!(store.load(&sid).await.unwrap().is_some());
+
+    store.destroy(&sid).await.unwrap();
+    // Revocable on the server: the cookie is now meaningless on every replica.
+    assert!(store.load(&sid).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn unknown_or_tampered_id_loads_as_none() {
+    let store = store();
+    assert!(store.load("not-a-real-session-id").await.unwrap().is_none());
+}

--- a/crates/rustango/src/oauth2/mod.rs
+++ b/crates/rustango/src/oauth2/mod.rs
@@ -67,7 +67,11 @@ use subtle::ConstantTimeEq;
 
 pub mod providers;
 pub mod registry;
-#[cfg(feature = "admin")]
+// The router only needs axum, which arrives via `manage` (and `admin`
+// implies `manage`, so existing admin builds keep it). Gating on `admin`
+// was a stale proxy for "axum present" that made `oauth2_router`
+// unreachable for non-admin apps that enable just `oauth2` + `manage`.
+#[cfg(feature = "manage")]
 pub mod router;
 
 pub use registry::OAuth2Registry;

--- a/crates/rustango/tests/oauth2_router_standalone.rs
+++ b/crates/rustango/tests/oauth2_router_standalone.rs
@@ -1,0 +1,76 @@
+//! Proves `oauth2::router::oauth2_router` is reachable **without** the `admin`
+//! feature — it only needs axum, which arrives via `manage`. Before the cfg fix
+//! in `oauth2/mod.rs`, `pub mod router` was gated on `admin`, so a non-admin app
+//! enabling just `oauth2` + `manage` could not mount social login at all.
+//!
+//! The `not(feature = "admin")` gate is the real proof: this file only compiles
+//! when admin is OFF, so a green run here means the standalone path works. It is
+//! excluded from every admin-on build (default, CI `postgres_test`,
+//! `doc_examples`), so it never breaks those jobs.
+//!
+//! KNOWN LIMITATION (pre-existing, unrelated to this fix): a *minimal* non-admin
+//! build of `rustango` currently fails to compile because several always-on
+//! modules (`template_extensions`, `i18n`, `template_views`) reference optional
+//! deps (tera, tower, serde_urlencoded, …) that only a larger feature bundle
+//! supplies — CI's minimal combos all enable `tenancy`, which pulls that bundle
+//! (and `admin`), so the gap is invisible there. Until those modules are gated
+//! tightly (or `manage` pulls what its always-on siblings need), the smallest
+//! combo that compiles this test is roughly:
+//!   cargo test -p rustango --no-default-features \
+//!     --features "oauth2 manage template_views csrf forms serializer sqlite" \
+//!     --test oauth2_router_standalone
+//! The A1 cfg fix itself is verified on the admin path: `auth_demo` builds green
+//! with `oauth2` + `manage` + `admin`, exercising `oauth2::router`.
+#![cfg(all(feature = "oauth2", feature = "manage", not(feature = "admin")))]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use axum::response::Redirect;
+use rustango::oauth2::router::{oauth2_router, OnAuthSuccess};
+use rustango::oauth2::{providers, OAuth2Registry};
+use tower::ServiceExt;
+
+fn dummy_success() -> OnAuthSuccess {
+    Arc::new(|_user, _tokens| Box::pin(async { Ok(Redirect::to("/dashboard")) }))
+}
+
+#[tokio::test]
+async fn login_redirects_with_secure_flow_cookie_without_admin() {
+    let registry = OAuth2Registry::new();
+    registry.register("acme", providers::google("cid", "csec", "https://app/cb"));
+    let app = oauth2_router(registry, b"flow-signing-secret".to_vec(), true, dummy_success());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/auth/acme/google/login")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    let loc = resp.headers().get(header::LOCATION).unwrap().to_str().unwrap();
+    assert!(loc.contains("accounts.google.com"), "redirects to provider: {loc}");
+    let cookie = resp.headers().get(header::SET_COOKIE).unwrap().to_str().unwrap();
+    assert!(cookie.contains("HttpOnly") && cookie.contains("Secure"));
+}
+
+#[tokio::test]
+async fn unknown_provider_is_404_without_admin() {
+    let registry = OAuth2Registry::new();
+    let app = oauth2_router(registry, b"flow-signing-secret".to_vec(), true, dummy_success());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/auth/acme/google/login")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}

--- a/docs/auth-passwords.md
+++ b/docs/auth-passwords.md
@@ -1,0 +1,205 @@
+# Passwords
+
+Storing a password means storing something an attacker can't reverse even with
+your whole database in hand. **Rustango** gives you that in two calls — `hash`
+on the way in, `verify` on the way out — backed by **argon2id**, the
+memory-hard winner of the Password Hashing Competition and the current OWASP
+first choice. You never store, log, or compare the plaintext.
+
+[![Passwords in rustango: hash() produces a salted argon2id PHC string, verify() checks an attempt against it, and verify_dummy() equalizes login timing](/static/img/auth-passwords.png?v=1)](/static/img/auth-passwords.png?v=1)
+
+> **Source:** `rustango::passwords` (`hash`, `verify`, `verify_dummy`,
+> `strength_score`, `StrengthIssue`) — behind the `passwords` feature (on by
+> default). For the tenancy-integrated user-password helpers see
+> `rustango::tenancy::password`.
+>
+> **Runnable version:** every snippet below is copied from the tested
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_passwords.rs)
+> example — `cargo test -p auth_demo --test auth_passwords`.
+
+> This is the deep dive for the [Security guide](security.md)'s "Hashing and
+> checking passwords" section.
+
+---
+
+## Contents
+
+- [Quick start](#quick-start) · [Why argon2id](#why-argon2id)
+- [Hashing on signup](#hashing-on-signup) · [Verifying on login](#verifying-on-login)
+- [Timing-safe logins](#timing-safe-logins-account-enumeration) · [Strength checks](#strength-checks)
+- [Where the hash lives](#where-the-hash-lives) · [Notes & limits](#notes-and-limits)
+
+---
+
+## Quick start
+
+```rust
+use rustango::passwords::{hash, verify};
+
+// Signup — store the returned PHC string, never the plaintext.
+let stored: String = hash("CorrectHorseBatteryStaple!42")?;
+
+// Login — check an attempt against the stored hash.
+if verify("CorrectHorseBatteryStaple!42", &stored)? {
+    // credentials good
+}
+```
+
+`hash` returns a [PHC string](https://github.com/P-H-C/phc-string-format) — a
+self-describing line that carries the algorithm, its cost parameters, the random
+salt, and the digest:
+
+```text
+$argon2id$v=19$m=19456,t=2,p=1$<base64 salt>$<base64 hash>
+```
+
+Because the salt and parameters travel *inside* the string, `verify` needs only
+the stored value and the attempt — there's no separate salt column to manage.
+
+---
+
+## Why argon2id
+
+`hash` uses **argon2id** with OWASP-recommended defaults (m=19 MiB, t=2, p=1).
+argon2id is *memory-hard*: each guess costs real RAM, which is what blunts the
+GPU/ASIC farms that make fast hashes (MD5, SHA-256, even bcrypt at low cost)
+brute-forceable. Two properties matter for correctness:
+
+- **Salting is automatic and per-hash.** Hashing the same password twice yields
+  two different PHC strings, so identical passwords don't collide in your table
+  and precomputed-rainbow-table attacks don't apply.
+
+  ```rust
+  let a = hash("same-password-12345")?;
+  let b = hash("same-password-12345")?;
+  assert_ne!(a, b);                 // different random salt each time
+  assert!(verify("same-password-12345", &a)?);
+  assert!(verify("same-password-12345", &b)?);
+  ```
+
+- **Verification is constant-time** in the digest comparison (argon2's own
+  `PasswordVerifier`), so a byte-by-byte timing leak can't reveal how much of a
+  guess was right.
+
+---
+
+## Hashing on signup
+
+```rust
+use rustango::passwords::{hash, strength_score};
+
+fn create_user(username: &str, plaintext: &str) -> Result<String, String> {
+    // Optional: nudge users away from weak choices (see below).
+    let issues = strength_score(plaintext);
+    if !issues.is_empty() {
+        return Err(format!("password too weak: {issues:?}"));
+    }
+    // Store the PHC string on the user row (e.g. auth_users.password_hash).
+    hash(plaintext).map_err(|e| e.to_string())
+}
+```
+
+---
+
+## Verifying on login
+
+```rust
+use rustango::passwords::verify;
+
+// `stored` is the PHC string you saved at signup.
+let ok = verify(attempt, &stored)?;
+```
+
+`verify` returns:
+- `Ok(true)` — the attempt matches.
+- `Ok(false)` — it doesn't.
+- `Err(PasswordError::Verify)` — `stored` wasn't a valid PHC string (a corrupt
+  or truncated column), so treat it as a failed login, not a 500.
+
+---
+
+## Timing-safe logins (account enumeration)
+
+If your login does the expensive `verify` **only** when the username exists, an
+unknown username returns noticeably faster than a real one — and that timing
+gap lets an attacker enumerate valid accounts. `verify_dummy` closes it: call it
+on the user-not-found (and inactive-account) branch so every login spends one
+argon2 verify's worth of work regardless.
+
+```rust
+use rustango::passwords::{verify, verify_dummy};
+
+let row = users::find_by_username(username).await?;
+let authenticated = match row {
+    Some(u) if u.is_active => verify(attempt, &u.password_hash)?,
+    _ => {
+        verify_dummy(attempt); // burn the same work, then fail
+        false
+    }
+};
+```
+
+---
+
+## Strength checks
+
+`strength_score` returns a `Vec<StrengthIssue>` — empty means "good enough". It's
+an intentionally light heuristic to *encourage* users, not a hard policy gate;
+pair it with a breach-list check (HIBP / pwned-passwords) for serious deployments.
+
+```rust
+use rustango::passwords::{strength_score, StrengthIssue};
+
+assert!(strength_score("Tr0ub4dor&3-CorrectBattery").is_empty());
+assert!(strength_score("password123").contains(&StrengthIssue::KnownWeak));
+assert!(strength_score("short").contains(&StrengthIssue::TooShort));
+```
+
+| `StrengthIssue` | Triggered when |
+|---|---|
+| `TooShort` | fewer than 12 characters |
+| `NoDigitsOrSymbols` | letters only — no digit or symbol |
+| `NoVariety` | only lowercase letters |
+| `KnownWeak` | matches the small built-in weak-password list (case-insensitive) |
+
+---
+
+## Where the hash lives
+
+The PHC string is just a `String` column on whatever account model you own. In
+the [`auth_demo`](../crates/rustango/examples/auth_demo/src/models.rs) example:
+
+```rust
+#[derive(Model, Clone, Debug)]
+#[rustango(table = "auth_users", display = "username")]
+pub struct User {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 150, unique)]
+    pub username: String,
+    #[rustango(max_length = 254)]
+    pub email: String,
+    #[rustango(max_length = 255)]      // PHC strings are ~95 chars at these params
+    pub password_hash: String,
+    pub is_active: bool,
+    pub is_superuser: bool,
+}
+```
+
+Once the user is authenticated, hand off to a [session](auth-sessions.md) (for
+browser apps) or issue a [JWT](auth-jwt.md) (for APIs).
+
+---
+
+## Notes and limits
+
+- **Never** store, log, or `==`-compare the plaintext. `hash` → store;
+  `verify` → check. That's the whole contract.
+- **Cost parameters are the OWASP defaults**, baked in. They're a sensible
+  floor; raising them later is safe — old hashes still verify (their params live
+  in the PHC string), and you can re-hash on next successful login to upgrade.
+- `strength_score` is a heuristic, not a policy engine — it won't catch
+  `Summer2024!`. Layer a breach-list lookup for real strength enforcement.
+- For multi-tenant apps with the framework's user store, prefer
+  `rustango::tenancy::password` (same argon2id, integrated with the tenant user
+  model). This module is the standalone version for apps that own their User table.

--- a/docs/auth-sessions.md
+++ b/docs/auth-sessions.md
@@ -1,0 +1,177 @@
+# Sessions
+
+A session keeps a user logged in across requests by handing the browser an
+**opaque ID** in a cookie and keeping everything else server-side. **Rustango**'s
+`SessionStore` puts that state in a cache (Redis in production, in-memory for
+tests), so the cookie carries no secrets and a session can be **revoked
+instantly** — delete the entry and every replica sees the logout on the next
+request.
+
+[![Sessions in rustango: the cookie holds only an opaque id, the SessionStore keeps the data in Redis, and destroy() revokes it everywhere](/static/img/auth-sessions.png?v=1)](/static/img/auth-sessions.png?v=1)
+
+> **Source:** `rustango::sessions` (`Session`, `SessionStore`) +
+> `rustango::cache` (`BoxedCache`, `InMemoryCache`, `RedisCache`) — behind the
+> `sessions` feature (on by default; pulls `cache`).
+>
+> **Runnable version:** snippets below are copied from the tested
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_sessions.rs)
+> example — `cargo test -p auth_demo --test auth_sessions`.
+
+> Deep dive companion to the [Security guide](security.md). Gating routes behind
+> a logged-in session is covered in [Auth decorators](auth-decorators.md); for
+> stateless API tokens instead, see [JWT](auth-jwt.md).
+
+---
+
+## Contents
+
+- [Quick start](#quick-start) · [Sessions vs JWT](#sessions-vs-jwt)
+- [The session bag](#the-session-bag) · [The cookie](#the-cookie)
+- [Picking a backend](#picking-a-backend) · [Expiry & sliding renewal](#expiry-and-sliding-renewal)
+- [Updating in place](#updating-a-session-in-place) · [Notes & limits](#notes-and-limits)
+
+---
+
+## Quick start
+
+```rust
+use rustango::sessions::{Session, SessionStore};
+use rustango::cache::{BoxedCache, RedisCache};
+use std::sync::Arc;
+
+let store = SessionStore::new(Arc::new(RedisCache::new("redis://localhost/0")?) as BoxedCache);
+
+// After the password check (see auth-passwords.md): stash who the user is,
+// save → an opaque id, and set that id as the cookie.
+let mut session = Session::new();
+session.set("user_id", user.id);
+let sid = store.save(&session).await?;
+// Set-Cookie: rustango_session={sid}; HttpOnly; SameSite=Lax; Secure; Path=/
+
+// On later requests: read the id from the cookie, load the session back.
+let session = store.load(&sid).await?.unwrap_or_default();
+let user_id: Option<i64> = session.get("user_id");
+
+// Logout: drop the server-side entry — the cookie is now meaningless.
+store.destroy(&sid).await?;
+```
+
+The id is 192 bits of OS-CSPRNG randomness, base64url-encoded to 32 chars — well
+above the 128-bit floor for session tokens, and unguessable.
+
+---
+
+## Sessions vs JWT
+
+Both answer "who is this request?", with opposite trade-offs:
+
+| | Session | [JWT](auth-jwt.md) |
+|---|---|---|
+| State | server-side (cache lookup per request) | stateless (self-contained token) |
+| Revocation | **instant** — `destroy()` the entry | hard — valid until expiry (needs a blocklist) |
+| Best for | browser apps, "log this user out NOW" | APIs, service-to-service, no shared store |
+
+Reach for sessions when you need to forcibly log someone out (password change,
+"sign out all devices", a banned account). Reach for JWT when you want zero
+per-request lookups and have no shared cache.
+
+---
+
+## The session bag
+
+`Session` is a typed key→value bag with a dirty bit (so the store can skip a
+write when nothing changed):
+
+```rust
+let mut s = Session::new();
+s.set("user_id", 42_i64);            // serialize any Serialize value
+s.set("role", "editor");
+let uid: Option<i64> = s.get("user_id");   // None if absent or wrong type
+s.remove("role");
+s.clear();                            // wipe everything (e.g. on logout)
+```
+
+`get` is **fail-soft**: a missing key *or* a value that doesn't deserialize as
+the requested type returns `None` rather than panicking — so a schema change
+never 500s a request.
+
+---
+
+## The cookie
+
+The cookie holds only `sid`. Set it with the security attributes a session
+cookie needs:
+
+- **`HttpOnly`** — JavaScript can't read it (blunts XSS token theft).
+- **`SameSite=Lax`** — not sent on cross-site sub-requests (CSRF defense; pair
+  with [CSRF tokens](security.md#protecting-against-csrf) for form posts).
+- **`Secure`** — HTTPS only (drop only for local HTTP dev).
+- **`Path=/`** — visible to the whole app.
+
+Nothing sensitive is in the cookie, so a leaked cookie is exactly as powerful as
+the session it points at — and you can revoke that server-side at any time.
+
+---
+
+## Picking a backend
+
+`SessionStore::new` takes any `BoxedCache`:
+
+- **`RedisCache`** — production. Shared across replicas, so a login on one
+  instance and a logout on another are both visible everywhere.
+- **`InMemoryCache`** — single process / tests. Fast, zero deps, but sessions
+  don't survive a restart and aren't shared between replicas.
+
+```rust
+use rustango::cache::{BoxedCache, InMemoryCache};
+use std::sync::Arc;
+
+// Tests / single-process:
+let store = SessionStore::new(Arc::new(InMemoryCache::new()) as BoxedCache);
+```
+
+---
+
+## Expiry and sliding renewal
+
+Sessions default to a **2-week** TTL. Override per store, and `touch` on each
+authenticated request for sliding expiration (active users stay logged in,
+idle ones age out):
+
+```rust
+use std::time::Duration;
+
+let store = SessionStore::new(cache).ttl(Duration::from_secs(60 * 60)); // 1 hour
+
+// On each request, after a successful load — extend without rewriting:
+store.touch(&sid).await?;   // Ok(false) if the session is already gone
+```
+
+---
+
+## Updating a session in place
+
+`save` always mints a fresh id (use it at login). To modify an existing session
+during a request, load → mutate → `save_with_id` under the same id:
+
+```rust
+let mut s = store.load(&sid).await?.unwrap_or_default();
+s.set("last_seen", chrono::Utc::now().to_rfc3339());
+store.save_with_id(&sid, &s).await?;
+```
+
+---
+
+## Notes and limits
+
+- **Revocation is the headline feature** — `destroy()` (logout) and TTL expiry
+  both take effect on the next request, on every replica sharing the cache.
+- **Corrupt or unknown ids load as `None`** (fail-open): a cache schema change
+  or a tampered cookie yields an empty session, not an error — the request is
+  simply unauthenticated.
+- **The store doesn't set the cookie for you** — it manages server-side state;
+  you attach/read the `sid` cookie in your handler (or via a layer). This keeps
+  it usable from any framework wiring.
+- **Mint a fresh session id on privilege change** (e.g. right after login) to
+  avoid session fixation — `save` already does this since it always generates a
+  new id.

--- a/docs/index.toml
+++ b/docs/index.toml
@@ -18,6 +18,11 @@ slug = "guides"
 pages = ["admin.md", "orm.md", "serializers.md", "viewsets.md", "urls.md", "manage.md", "security.md", "api-conventions.md"]
 
 [[section]]
+title = "Authentication"
+slug = "authentication"
+pages = ["auth-passwords.md", "auth-sessions.md"]
+
+[[section]]
 title = "Benchmarks"
 slug = "benchmarks"
 pages = ["benchmarks.md"]

--- a/docs/security.md
+++ b/docs/security.md
@@ -338,6 +338,8 @@ Hashing uses **argon2id** (the OWASP-recommended default since 2023 — it resis
 
 The built-in **strength check** is intentionally minimal. For serious deployments, also check passwords against the HIBP / pwned-passwords API to reject ones known to be leaked.
 
+> **Deep dive:** [Passwords](auth-passwords.md) — argon2id internals, automatic salting, timing-safe logins (`verify_dummy`), and where the hash lives. Once authenticated, hand off to a [Session](auth-sessions.md) (browser) or a [JWT](auth-jwt.md) (API).
+
 ---
 
 ## Issuing and refreshing JWTs


### PR DESCRIPTION
Two related pieces of work, all uncommitted changes from the auth pass.

## 1. Authentication deep-dive docs + runnable example
- **`docs/auth-passwords.md`** — argon2id `hash`/`verify`, per-hash salting, `verify_dummy` (timing-safe logins), `strength_score`/`StrengthIssue`, where the PHC hash lives.
- **`docs/auth-sessions.md`** — opaque-id cookie + server-side `SessionStore` (in-memory/Redis), instant revocation, expiry & sliding renewal, sessions-vs-JWT.
- **`crates/rustango/examples/auth_demo/`** — runnable backing example; every doc snippet is copied from its tests (`auth_passwords.rs`, `auth_sessions.rs`). Added to the `doc_examples` CI matrix. **Builds + all tests pass.**
- `docs/index.toml` (new Authentication section) + `docs/security.md` (deep-dive cross-link).

## 2. OAuth2 router gating fix
- **`crates/rustango/src/oauth2/mod.rs`** — gate `pub mod router` on `manage` (not `admin`); `oauth2_router` only needs axum (which `manage` provides), so non-admin apps with `oauth2`+`manage` can now mount social login.
- **`tests/oauth2_router_standalone.rs`** — proves the non-admin path; `cfg(not(admin))` so it's inert under `--all-features`/all CI jobs (admin path is covered by `auth_demo`).

## Pending doc follow-ups (not blockers — no CI check covers md links/images)
- ⚠️ Forward-links to **`auth-jwt.md`** (×3) and **`auth-decorators.md`** (×1) — planned siblings, not yet written.
- ⚠️ Header diagrams **`auth-passwords.png`** / **`auth-sessions.png`** not yet under `docs/img/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)