### PR TITLE
docs(auth): JWT (standalone + API) + access-decorator deep-dives + tests

### DIFF
--- a/crates/rustango/examples/auth_demo/tests/auth_decorators.rs
+++ b/crates/rustango/examples/auth_demo/tests/auth_decorators.rs
@@ -1,0 +1,78 @@
+//! Backing test for `docs/auth-decorators.md` — `login_required` & friends gate
+//! handlers by the request's session. The gating decisions (302 redirect / 401)
+//! need NO database: an anonymous `SessionUser` resolves to `None` without any
+//! session or tenant setup. The authenticated happy-path (200) needs a real
+//! session — see `docs/auth-sessions.md`.
+//!
+//! Run: `cargo test -p auth_demo --test auth_decorators`
+
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use axum::routing::get;
+use axum::Router;
+use rustango::auth_decorators::{login_required, safe_next, superuser_required_or_403};
+use tower::ServiceExt;
+
+async fn protected() -> &'static str {
+    "secret"
+}
+
+#[tokio::test]
+async fn login_required_redirects_anonymous_with_next_preserved() {
+    // Browser/HTML flow: anonymous users are 302'd to the login page, with the
+    // page they wanted preserved in ?next= so login can send them back.
+    let app = Router::new()
+        .route("/profile", get(protected))
+        .layer(login_required("/login"));
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/profile")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::FOUND);
+    let loc = res
+        .headers()
+        .get(header::LOCATION)
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert_eq!(loc, "/login?next=%2Fprofile");
+}
+
+#[tokio::test]
+async fn api_gate_returns_401_for_anonymous_not_a_redirect() {
+    // JSON-API flow: the `_or_403` family returns 401 (anonymous) / 403
+    // (authenticated-but-unauthorized) instead of a 302 to an HTML page a
+    // client can't render.
+    let app = Router::new()
+        .route("/api/admin", get(protected))
+        .layer(superuser_required_or_403());
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[test]
+fn safe_next_blocks_open_redirects() {
+    // The login handler MUST sanitize ?next= before redirecting back, or it
+    // becomes an open-redirect (phishing) vector.
+    assert_eq!(safe_next("/dashboard"), Some("/dashboard".to_owned()));
+    assert_eq!(safe_next("https://evil.example/x"), None); // absolute URL
+    assert_eq!(safe_next("//evil.example/x"), None); // scheme-relative
+    assert_eq!(safe_next("%2F%2Fevil.example/x"), None); // decodes to //evil
+}

--- a/crates/rustango/examples/auth_demo/tests/auth_jwt.rs
+++ b/crates/rustango/examples/auth_demo/tests/auth_jwt.rs
@@ -1,0 +1,66 @@
+//! Backing test for `docs/auth-jwt.md` — standalone HS256 JWTs. Pure, no DB.
+//!
+//! Run: `cargo test -p auth_demo --test auth_jwt`
+
+use std::time::Duration;
+
+use rustango::jwt::{decode, decode_at, encode, Claims, JwtError};
+
+// HS256 is symmetric: the same secret signs and verifies. Must be >= 32 bytes.
+const SECRET: &[u8] = b"a-shared-signing-secret-at-least-32-bytes!!";
+
+#[test]
+fn issue_and_verify_with_custom_claims() {
+    let mut claims = Claims::new("user-42")
+        .ttl(Duration::from_secs(900))
+        .issuer("api.example.com");
+    claims.set("roles", vec!["editor", "author"]);
+
+    let token = encode(&claims, SECRET).unwrap();
+    assert_eq!(token.matches('.').count(), 2, "header.payload.signature");
+
+    let v = decode(&token, SECRET).unwrap();
+    assert_eq!(v.subject(), Some("user-42"));
+    assert_eq!(
+        v.get::<Vec<String>>("roles").unwrap(),
+        vec!["editor".to_string(), "author".to_string()]
+    );
+    // IMPORTANT: decode() verifies signature + exp/nbf but does NOT check
+    // `iss`/`aud` — you must validate those yourself against expected values.
+    assert_eq!(v.get::<String>("iss").as_deref(), Some("api.example.com"));
+}
+
+#[test]
+fn wrong_secret_and_tampering_are_rejected() {
+    let token = encode(&Claims::new("alice"), SECRET).unwrap();
+
+    // A different secret fails the signature check.
+    assert!(matches!(
+        decode(&token, b"the-wrong-secret-also-32-bytes-long-xx!"),
+        Err(JwtError::BadSignature)
+    ));
+
+    // Flip a byte of the signature → tamper detected (no valid forgery).
+    let mut bytes = token.into_bytes();
+    let last = bytes.len() - 1;
+    bytes[last] ^= 0x01;
+    let tampered = String::from_utf8(bytes).unwrap();
+    assert!(decode(&tampered, SECRET).is_err());
+}
+
+#[test]
+fn expiry_is_enforced() {
+    // `decode_at` lets the test pin "now"; in real code use `decode`.
+    let token = encode(&Claims::new("x").expires_at(1000), SECRET).unwrap();
+    assert!(decode_at(&token, SECRET, 500).is_ok()); // before exp
+    assert!(matches!(
+        decode_at(&token, SECRET, 2000),
+        Err(JwtError::Expired(_))
+    )); // after exp
+}
+
+#[test]
+fn a_short_secret_is_refused_at_sign_time() {
+    // A sub-32-byte key is guessable/forgeable; encode refuses to sign with it.
+    assert!(encode(&Claims::new("x"), b"too-short").is_err());
+}

--- a/crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs
+++ b/crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs
@@ -1,0 +1,95 @@
+//! Backing test for `docs/auth-jwt-api.md` — the access+refresh token engine
+//! (`JwtLifecycle`) behind the built-in `/api/auth/{login,refresh,logout,me}`
+//! router. Pure (in-memory JTI store), no DB. The HTTP endpoints themselves are
+//! tenant-scoped and exercised end-to-end by the framework's
+//! `crates/rustango/tests/tenant_auth_live.rs`.
+//!
+//! Run: `cargo test -p auth_demo --test auth_jwt_api`
+
+use std::sync::Arc;
+
+use rustango::jti_store::{InMemoryJtiStore, JtiStore};
+use rustango::tenancy::jwt_lifecycle::JwtLifecycle;
+
+fn jwt() -> JwtLifecycle {
+    JwtLifecycle::new(b"a-signing-secret-at-least-32-bytes-long!!".to_vec())
+}
+
+#[test]
+fn login_issues_a_pair_and_the_token_types_are_distinct() {
+    let j = jwt();
+    let pair = j.issue_pair(42); // what POST /api/auth/login returns
+
+    let claims = j.verify_access(&pair.access).expect("access verifies");
+    assert_eq!(claims.sub, 42);
+    assert_eq!(claims.typ, "access");
+
+    // An access token is rejected where a refresh is required, and vice versa —
+    // so a stolen short-lived access token can't be used to mint new ones.
+    assert!(j.verify_refresh(&pair.access).is_none());
+    assert!(j.verify_access(&pair.refresh).is_none());
+}
+
+#[test]
+fn refresh_rotates_and_blacklists_the_old_refresh_token() {
+    let j = jwt();
+    let pair = j.issue_pair(7);
+
+    let rotated = j.refresh(&pair.refresh).expect("POST /api/auth/refresh");
+    assert_ne!(pair.access, rotated.access);
+    assert_eq!(j.verify_access(&rotated.access).unwrap().sub, 7);
+
+    // Sliding refresh: the old refresh token is single-use — replay is rejected.
+    assert!(j.refresh(&pair.refresh).is_none());
+}
+
+#[test]
+fn logout_revokes_the_token() {
+    let j = jwt();
+    let pair = j.issue_pair(1);
+    assert!(j.verify_access(&pair.access).is_some());
+
+    assert!(j.revoke(&pair.access)); // what POST /api/auth/logout does
+    assert!(j.verify_access(&pair.access).is_none());
+}
+
+#[test]
+fn custom_claims_ride_in_the_token_and_survive_refresh() {
+    let j = jwt();
+    let custom = serde_json::json!({ "roles": ["admin"], "tenant": "acme" })
+        .as_object()
+        .unwrap()
+        .clone();
+
+    let pair = j.issue_pair_with(99, custom).unwrap();
+    let claims = j.verify_access(&pair.access).unwrap();
+    assert_eq!(
+        claims.get_custom::<Vec<String>>("roles").unwrap(),
+        vec!["admin".to_string()]
+    );
+
+    // refresh() carries the same custom payload onto the new pair (use
+    // refresh_with() to re-evaluate permissions instead).
+    let rotated = j.refresh(&pair.refresh).unwrap();
+    let rc = j.verify_access(&rotated.access).unwrap();
+    assert_eq!(rc.get_custom::<String>("tenant").as_deref(), Some("acme"));
+}
+
+#[test]
+fn revocation_is_visible_across_handles_via_a_shared_store() {
+    // The default in-memory store is single-process. In production pass a
+    // Redis/DB-backed `JtiStore` so a logout on one replica is seen by all —
+    // here two handles share one in-memory store to prove the wiring.
+    let secret = b"shared-signing-secret-32-bytes-long-xx!!".to_vec();
+    let shared: Arc<dyn JtiStore> = Arc::new(InMemoryJtiStore::new());
+    let a = JwtLifecycle::new(secret.clone()).with_jti_store(Arc::clone(&shared));
+    let b = JwtLifecycle::new(secret).with_jti_store(Arc::clone(&shared));
+
+    let pair = a.issue_pair(5);
+    assert!(b.verify_access(&pair.access).is_some());
+    a.revoke(&pair.access);
+    assert!(
+        b.verify_access(&pair.access).is_none(),
+        "instance B must see the revocation made on instance A"
+    );
+}

--- a/crates/rustango/tests/oauth2_router_standalone.rs
+++ b/crates/rustango/tests/oauth2_router_standalone.rs
@@ -40,7 +40,12 @@ fn dummy_success() -> OnAuthSuccess {
 async fn login_redirects_with_secure_flow_cookie_without_admin() {
     let registry = OAuth2Registry::new();
     registry.register("acme", providers::google("cid", "csec", "https://app/cb"));
-    let app = oauth2_router(registry, b"flow-signing-secret".to_vec(), true, dummy_success());
+    let app = oauth2_router(
+        registry,
+        b"flow-signing-secret".to_vec(),
+        true,
+        dummy_success(),
+    );
 
     let resp = app
         .oneshot(
@@ -53,16 +58,34 @@ async fn login_redirects_with_secure_flow_cookie_without_admin() {
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::SEE_OTHER);
-    let loc = resp.headers().get(header::LOCATION).unwrap().to_str().unwrap();
-    assert!(loc.contains("accounts.google.com"), "redirects to provider: {loc}");
-    let cookie = resp.headers().get(header::SET_COOKIE).unwrap().to_str().unwrap();
+    let loc = resp
+        .headers()
+        .get(header::LOCATION)
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(
+        loc.contains("accounts.google.com"),
+        "redirects to provider: {loc}"
+    );
+    let cookie = resp
+        .headers()
+        .get(header::SET_COOKIE)
+        .unwrap()
+        .to_str()
+        .unwrap();
     assert!(cookie.contains("HttpOnly") && cookie.contains("Secure"));
 }
 
 #[tokio::test]
 async fn unknown_provider_is_404_without_admin() {
     let registry = OAuth2Registry::new();
-    let app = oauth2_router(registry, b"flow-signing-secret".to_vec(), true, dummy_success());
+    let app = oauth2_router(
+        registry,
+        b"flow-signing-secret".to_vec(),
+        true,
+        dummy_success(),
+    );
     let resp = app
         .oneshot(
             Request::builder()

--- a/docs/auth-decorators.md
+++ b/docs/auth-decorators.md
@@ -1,0 +1,178 @@
+# Access decorators
+
+Once a user is authenticated, you gate routes. **Rustango** ships Django's
+`@login_required` family as composable axum **layers**: attach one to a router
+and anonymous requests are turned away — 302'd to your login page (browser flow)
+or answered with 401/403 (API flow) — before they ever reach the handler.
+
+[![Access decorators: login_required 302s anonymous browsers to /login?next=, the _or_403 family returns 401/403 for APIs, superuser_required gates by role](/static/img/auth-decorators.png?v=1)](/static/img/auth-decorators.png?v=1)
+
+> **Source:** `rustango::auth_decorators` (`login_required`, `login_required_or_401`,
+> `user_passes_test`, `superuser_required`, `active_required`,
+> `permission_required` + `_or_403` variants; `safe_next`, `extract_next`) —
+> behind the `tenancy` feature (the gates read the `SessionUser` extractor).
+>
+> **Runnable version:** the gating behavior is covered by the tested
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_decorators.rs) —
+> `cargo test -p auth_demo --test auth_decorators`.
+
+> Deep dive companion to the [Security guide](security.md). The gates read the
+> session set at login — see [Sessions](auth-sessions.md).
+
+---
+
+## Contents
+
+- [Quick start](#quick-start) · [Browser vs API gates](#browser-vs-api-gates)
+- [The gate family](#the-gate-family) · [Predicate & role gates](#predicate-and-role-gates)
+- [Permission gates](#permission-gates) · [The `?next=` round-trip](#the-next-round-trip)
+- [Notes & limits](#notes-and-limits)
+
+---
+
+## Quick start
+
+```rust
+use rustango::auth_decorators::login_required;
+
+// Scope the gate to a sub-router (the idiomatic shape):
+let private = Router::new()
+    .route("/profile", get(profile))
+    .route("/settings", get(settings))
+    .layer(login_required("/login"));      // anonymous → 302 /login?next=...
+
+let app = Router::new()
+    .route("/", get(home))                 // public
+    .merge(private);
+```
+
+Anonymous requests to `/profile` are redirected to `/login?next=%2Fprofile`; an
+authenticated request passes through to the handler.
+
+---
+
+## Browser vs API gates
+
+The same gate comes in two response shapes. Pick by what the caller can do with
+the response:
+
+- **Browser / HTML** → the base gates **302-redirect** to your login page (a
+  human can follow it and log in).
+- **JSON API** → the `_or_403` family returns **status codes**: `401 Unauthorized`
+  for anonymous, `403 Forbidden` for authenticated-but-not-allowed (a client
+  can't render an HTML login page, and the 401/403 split lets it tell "log in"
+  from "you can't do that" apart).
+
+```rust
+// Browser: redirect to /login
+let app = Router::new().route("/dashboard", get(dash)).layer(login_required("/login"));
+
+// API: 401 for anonymous, never a redirect
+let api = Router::new().route("/api/me", get(me)).layer(login_required_or_401());
+```
+
+---
+
+## The gate family
+
+| Gate (browser, 302) | API variant (401/403) | Lets through |
+|---|---|---|
+| `login_required(url)` | `login_required_or_401()` | any logged-in user |
+| `active_required(url)` | `active_required_or_403()` | logged-in **and** `active` |
+| `superuser_required(url)` | `superuser_required_or_403()` | `is_superuser && active` |
+| `user_passes_test(url, pred)` | `user_passes_test_or_403(pred)` | predicate over the `User` row |
+| `permission_required(url, codename)` | `permission_required_or_403(codename)` | holds the permission codename |
+
+All are tower layers — `.layer(...)` them onto a router or sub-router.
+
+---
+
+## Predicate and role gates
+
+`user_passes_test` runs your closure against the resolved `User` row, so you can
+gate on any field:
+
+```rust
+use rustango::auth_decorators::{user_passes_test, superuser_required_or_403};
+
+// Staff-only sub-router (browser):
+let staff = Router::new()
+    .route("/admin/dashboard", get(dashboard))
+    .layer(user_passes_test("/login", |u| u.is_superuser));
+
+// Superuser-only JSON API → 401 anonymous / 403 non-superuser:
+let api = Router::new()
+    .route("/api/admin/stats", get(stats))
+    .layer(superuser_required_or_403());
+```
+
+`superuser_required` / `active_required` are pinned shortcuts for the common
+`is_superuser && active` / `active` predicates so call sites don't silently
+diverge on whether deactivated accounts still count.
+
+---
+
+## Permission gates
+
+`permission_required` checks a permission codename against the tenant's
+permission engine (superusers bypass automatically). It additionally resolves
+the `Tenant` extractor, so routes using it must be mounted under the tenant
+context:
+
+```rust
+use rustango::auth_decorators::permission_required;
+use rustango::tenancy::permissions::ACCESS_ADMIN_CODENAME;
+
+let admin = Router::new()
+    .route("/admin", get(dashboard))
+    .layer(permission_required("/login", ACCESS_ADMIN_CODENAME));
+```
+
+---
+
+## The `?next=` round-trip
+
+`login_required` preserves the originally-requested URL in `?next=` so your login
+handler can send the user back after authenticating. **You must sanitize that
+value** — echoing it into a redirect unchecked is a textbook open-redirect
+(phishing) hole. `safe_next` is the guard:
+
+```rust
+use rustango::auth_decorators::{extract_next, safe_next};
+
+async fn login_post(Query(q): Query<HashMap<String, String>>, /* … */) -> Response {
+    // … verify credentials, set the session …
+    let dest = extract_next(&q)
+        .and_then(|n| safe_next(&n))          // rejects open redirects
+        .unwrap_or_else(|| "/".to_owned());
+    Redirect::to(&dest).into_response()
+}
+```
+
+`safe_next` only accepts same-origin, root-relative paths — it rejects absolute
+URLs, scheme-relative `//host`, backslash variants, and their percent-encoded
+forms:
+
+```rust
+assert_eq!(safe_next("/dashboard"),            Some("/dashboard".to_owned()));
+assert_eq!(safe_next("https://evil.example/x"), None);
+assert_eq!(safe_next("//evil.example/x"),       None);   // scheme-relative
+assert_eq!(safe_next("%2F%2Fevil.example/x"),   None);   // decodes to //evil
+```
+
+---
+
+## Notes and limits
+
+- **These gates read the session.** "Logged in" means the [`SessionUser`](auth-sessions.md)
+  extractor resolved a user from the session cookie — so they're for
+  session/cookie auth. API token auth ([JWT](auth-jwt-api.md), [API
+  keys](auth-api-keys.md)) gates at the [backend chain](auth-backends.md) layer
+  instead, reading the `Authorization` header.
+- **Layer ordering matters.** `.layer(gate)` protects every route added to the
+  router *before* it; routes added after are public. Scoping the gate to a
+  dedicated sub-router (the quick-start shape) avoids that footgun.
+- **`permission_required` needs tenant context** (it queries the tenant perm
+  engine) — mount it under the tenant; an untenant'd route 500s.
+- The redirect's `?next=` is always percent-encoded, so CRLF / response-splitting
+  can't leak into the `Location` header.

--- a/docs/auth-jwt-api.md
+++ b/docs/auth-jwt-api.md
@@ -1,0 +1,203 @@
+# JWT auth API
+
+The [standalone JWT](auth-jwt.md) module signs and verifies one token. A real
+API needs the whole **lifecycle**: a short-lived *access* token, a long-lived
+*refresh* token, rotation on refresh, and **revocation** for logout. **Rustango**
+ships that as `JwtLifecycle` — and a batteries-included router that mounts
+`POST /api/auth/login`, `/refresh`, `/logout`, and `GET /me` for you.
+
+[![JWT auth API: login issues an access+refresh pair, refresh rotates and blacklists the old token, logout revokes via a JTI store](/static/img/auth-jwt-api.png?v=1)](/static/img/auth-jwt-api.png?v=1)
+
+> **Source:** `rustango::tenancy::jwt_lifecycle` (`JwtLifecycle`, `JwtTokenPair`,
+> `JwtClaims`) and `rustango::tenancy::auth_routes` (`jwt_router`, `Config`) +
+> `rustango::jti_store` (`JtiStore`, `InMemoryJtiStore`) — behind `jwt` +
+> `tenancy`.
+>
+> **Runnable version:** the token engine is covered by the tested
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs) —
+> `cargo test -p auth_demo --test auth_jwt_api`. The HTTP endpoints are
+> tenant-scoped and exercised end-to-end by the framework's own
+> `crates/rustango/tests/tenant_auth_live.rs`.
+
+> Deep dive companion to the [Security guide](security.md)'s "Issuing and
+> refreshing JWTs" section. For a single, manually-managed token instead, see
+> [JWT (standalone)](auth-jwt.md).
+
+---
+
+## Contents
+
+- [The built-in router](#the-built-in-router) · [Wiring it up](#wiring-it-up)
+- [The token engine](#the-token-engine-jwtlifecycle) · [Refresh & rotation](#refresh-and-rotation)
+- [Revocation & the JTI store](#revocation-and-the-jti-store) · [Custom claims](#custom-claims)
+- [Notes & limits](#notes-and-limits)
+
+---
+
+## The built-in router
+
+`jwt_router` mounts the standard four endpoints against the per-tenant
+`rustango_users` table — the ~50 lines of login boilerplate every project
+otherwise rewrites:
+
+| Method | Path | Body / Auth | Returns |
+|---|---|---|---|
+| POST | `/api/auth/login` | `{username, password}` | `{access, refresh, user}` |
+| POST | `/api/auth/refresh` | `{refresh}` | `{access, refresh}` |
+| POST | `/api/auth/logout` | `Authorization: Bearer <access>` | `204` (revokes the JTI) |
+| GET | `/api/auth/me` | `Authorization: Bearer <access>` | `{user_id, username, is_superuser}` |
+
+Login verifies the password with [argon2id](auth-passwords.md), then issues a
+pair. Paths, TTLs, and the signing key are configurable via `Config`.
+
+## Wiring it up
+
+```rust
+use rustango::tenancy::auth_routes::{jwt_router, Config};
+
+rustango::manage::Cli::new()
+    .tenancy()
+    .api(my_app::urls::api()
+        .merge(jwt_router(Config::default())))   // mounts /api/auth/*
+    .run()
+    .await
+```
+
+`Config::default()` signs with `RUSTANGO_SESSION_SECRET` (the same key as the
+admin session cookie) and uses 15-min access / 7-day refresh TTLs. Override
+`prefix`, `access_ttl_secs`, `refresh_ttl_secs`, or `session_secret` as needed.
+The endpoints run under the tenant context, so mount them in a tenancy app.
+
+```sh
+# Login → access + refresh
+curl -sX POST localhost:8080/api/auth/login \
+  -H 'content-type: application/json' \
+  -d '{"username":"alice","password":"hunter2hunter"}'
+
+# Call a protected endpoint
+curl localhost:8080/api/auth/me -H "Authorization: Bearer $ACCESS"
+```
+
+---
+
+## The token engine (`JwtLifecycle`)
+
+Under the router sits `JwtLifecycle` — usable directly if you want the lifecycle
+without the built-in HTTP shape:
+
+```rust
+use rustango::tenancy::jwt_lifecycle::JwtLifecycle;
+
+let jwt = JwtLifecycle::new(secret_32_bytes);
+
+// Login: issue the pair.
+let pair = jwt.issue_pair(user_id);
+// → pair.access  (short TTL, send in the Authorization header)
+// → pair.refresh (long TTL, store in an HttpOnly cookie / secure storage)
+
+// Authenticated request: verify the access token.
+match jwt.verify_access(&access) {
+    Some(claims) => { /* claims.sub is the user id */ }
+    None => { /* 401: invalid, expired, revoked, or wrong type */ }
+}
+```
+
+Access and refresh tokens are **not interchangeable** — `verify_access` rejects
+a refresh token and vice versa, so a stolen short-lived access token can't be
+used to mint new ones:
+
+```rust
+let pair = jwt.issue_pair(42);
+assert!(jwt.verify_refresh(&pair.access).is_none());
+assert!(jwt.verify_access(&pair.refresh).is_none());
+```
+
+---
+
+## Refresh and rotation
+
+`refresh` exchanges a valid refresh token for a **new pair** and blacklists the
+old refresh token's JTI — sliding expiry with single-use refresh tokens (replay
+of the old one is rejected):
+
+```rust
+let pair = jwt.issue_pair(7);
+let rotated = jwt.refresh(&pair.refresh).expect("refresh ok");
+assert_ne!(pair.access, rotated.access);
+assert!(jwt.refresh(&pair.refresh).is_none());   // old refresh is now dead
+```
+
+By default `refresh` **preserves** the token's custom claims. If permissions may
+have changed (role revoked, scope downgraded), use `refresh_with(token, new_claims)`
+to substitute a fresh payload while still blacklisting the old refresh JTI.
+
+---
+
+## Revocation and the JTI store
+
+Each token carries a unique `jti`. `revoke` adds it to a blacklist so subsequent
+`verify_*` calls fail until the token would have expired anyway — this is what
+`POST /api/auth/logout` calls:
+
+```rust
+let pair = jwt.issue_pair(1);
+assert!(jwt.revoke(&pair.access));
+assert!(jwt.verify_access(&pair.access).is_none());
+```
+
+The blacklist lives in a pluggable `JtiStore`. The default `InMemoryJtiStore` is
+**single-process and loses revocations on restart** — fine for one instance. Any
+multi-replica deployment MUST install a shared, durable store (Redis / DB) so a
+logout on one replica is honored by all:
+
+```rust
+use rustango::jti_store::{InMemoryJtiStore, JtiStore};
+use std::sync::Arc;
+
+let shared: Arc<dyn JtiStore> = Arc::new(InMemoryJtiStore::new()); // swap for Redis in prod
+let a = JwtLifecycle::new(secret.clone()).with_jti_store(Arc::clone(&shared));
+let b = JwtLifecycle::new(secret).with_jti_store(Arc::clone(&shared));
+
+let pair = a.issue_pair(5);
+a.revoke(&pair.access);
+assert!(b.verify_access(&pair.access).is_none());   // B sees A's revocation
+```
+
+> Without a shared store, `/logout` is best-effort: a revoked token may still be
+> accepted on another replica until its natural expiry. This is the single most
+> important production setting for JWT auth.
+
+---
+
+## Custom claims
+
+Embed `roles` / `tenant` / `scope` directly in the token so verification needs no
+DB lookup. Reserved names (`sub`, `exp`, `jti`, `typ`) are rejected:
+
+```rust
+let custom = serde_json::json!({ "roles": ["admin"], "tenant": "acme" })
+    .as_object().unwrap().clone();
+let pair = jwt.issue_pair_with(99, custom)?;
+
+let claims = jwt.verify_access(&pair.access).unwrap();
+let roles: Vec<String> = claims.get_custom("roles").unwrap();   // ["admin"]
+```
+
+Custom claims survive `refresh` (carried onto the new pair) unless you use
+`refresh_with`.
+
+---
+
+## Notes and limits
+
+- **Sessions vs JWT vs this:** a plain [JWT](auth-jwt.md) can't be revoked; a
+  [Session](auth-sessions.md) is revocable but needs a per-request store lookup;
+  `JwtLifecycle` is the middle path — stateless verify, plus a JTI blocklist for
+  the revocations you actually need (logout, rotation).
+- **HTTP endpoints are tenant-scoped.** `jwt_router` resolves users via the
+  tenant context + `rustango_users`; mount it in a `.tenancy()` app. The token
+  engine (`JwtLifecycle`) itself has no such requirement.
+- **Pair this with** the [auth backend chain](auth-backends.md)'s `JwtBackend`
+  to authenticate arbitrary routes from the `Authorization: Bearer` header.
+- **HS256 signing**, 32-byte key floor — same algorithm and constraints as
+  [standalone JWT](auth-jwt.md#security-model).

--- a/docs/auth-jwt.md
+++ b/docs/auth-jwt.md
@@ -1,0 +1,191 @@
+# JWT (standalone)
+
+A JSON Web Token is a **stateless** credential: a signed, self-contained string
+the client sends on every request, that your server verifies with a secret —
+no per-request database or cache lookup. **Rustango**'s `rustango::jwt` module is
+the minimal building block: `encode` to sign claims, `decode` to verify and read
+them back, HS256 under the hood.
+
+[![Standalone JWT in rustango: Claims carry sub/exp/custom fields, encode() signs with a shared secret, decode() verifies signature + expiry](/static/img/auth-jwt.png?v=1)](/static/img/auth-jwt.png?v=1)
+
+> **Source:** `rustango::jwt` (`Claims`, `encode`, `decode`, `decode_at`,
+> `decode_unverified`, `JwtError`) — behind the `jwt` feature (on by default).
+> For a batteries-included access+refresh **API** with revocation, see
+> [JWT auth API](auth-jwt-api.md).
+>
+> **Runnable version:** snippets are copied from the tested
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt.rs) —
+> `cargo test -p auth_demo --test auth_jwt`.
+
+> Deep dive companion to the [Security guide](security.md)'s "Issuing and
+> refreshing JWTs" section.
+
+---
+
+## Contents
+
+- [Quick start](#quick-start) · [When to use it](#when-to-use-standalone-jwt)
+- [Building claims](#building-claims) · [Verifying](#verifying-a-token)
+- [Security model](#security-model) — read this · [Inspecting without trust](#inspecting-without-verifying)
+- [Notes & limits](#notes-and-limits)
+
+---
+
+## Quick start
+
+```rust
+use rustango::jwt::{Claims, encode, decode};
+use std::time::Duration;
+
+// HS256 is symmetric — the same secret signs and verifies. Must be >= 32 bytes.
+let secret = b"a-shared-signing-secret-at-least-32-bytes!!";
+
+let mut claims = Claims::new("user-42").ttl(Duration::from_secs(900));
+claims.set("roles", vec!["editor", "author"]);
+
+let token = encode(&claims, secret)?;        // header.payload.signature
+
+let verified = decode(&token, secret)?;       // checks signature + exp/nbf
+assert_eq!(verified.subject(), Some("user-42"));
+let roles: Vec<String> = verified.get("roles").unwrap();
+```
+
+---
+
+## When to use standalone JWT
+
+Reach for `rustango::jwt` when you want a plain signed token and will handle the
+lifecycle yourself:
+
+- **Magic-link / one-time tokens** — a few claims (user id, purpose, short `exp`).
+  See [Magic links & auth flows](auth-flows.md).
+- **Service-to-service** bearer tokens (the JWT sibling of [HMAC request
+  signing](auth-hmac.md) — HMAC for AWS-style canonical requests, JWT for a
+  stateless bearer).
+- **SSO tokens** you hand to a third party.
+
+If you want a turnkey **login → access + refresh → refresh → logout** API with
+token revocation, don't build it on this — use [JWT auth API](auth-jwt-api.md),
+which wraps this module with rotation + a revocation store. And if you need to
+forcibly log a user out *now*, prefer a revocable [Session](auth-sessions.md):
+a plain JWT is valid until it expires.
+
+---
+
+## Building claims
+
+`Claims` wraps a JSON object, so standard claims and your own extension fields
+coexist:
+
+```rust
+let mut claims = Claims::new("user-42")     // sets `sub` + `iat=now`
+    .ttl(Duration::from_secs(3600))         // sets `iat`=now and `exp`=now+ttl
+    .issuer("api.example.com")              // `iss`
+    .audience("web-client")                 // `aud`
+    .jti("unique-token-id");                // `jti` (for your own blocklist)
+claims.set("role", "admin");                // any Serialize value
+claims.set("org_id", 7_i64);
+```
+
+| Builder / setter | Claim |
+|---|---|
+| `Claims::new(sub)` | `sub` + `iat` |
+| `Claims::empty()` | none (full control) |
+| `.ttl(Duration)` | `iat` (now) + `exp` (now+ttl) |
+| `.expires_at(secs)` / `.not_before(secs)` | absolute `exp` / `nbf` |
+| `.issuer(s)` / `.audience(s)` / `.jti(s)` | `iss` / `aud` / `jti` |
+| `.set(name, value)` | any custom claim |
+
+Read them back with `.subject()` and `.get::<T>(name)` (returns `None` for a
+missing or wrong-typed claim).
+
+---
+
+## Verifying a token
+
+```rust
+use rustango::jwt::{decode, JwtError};
+
+match decode(&token, secret) {
+    Ok(claims) => { /* trust claims.subject() etc. */ }
+    Err(JwtError::Expired(_))      => { /* 401 — token aged out */ }
+    Err(JwtError::BadSignature)    => { /* 401 — forged or wrong key */ }
+    Err(JwtError::NotYetValid(_))  => { /* nbf in the future */ }
+    Err(_)                         => { /* malformed / unsupported alg */ }
+}
+```
+
+`decode` verifies the **signature**, then `exp` and `nbf`. To test clock-window
+behavior (or add skew tolerance), `decode_at(token, secret, now)` lets you pin
+the "current" second:
+
+```rust
+let token = encode(&Claims::new("x").expires_at(1000), secret)?;
+assert!(decode_at(&token, secret, 500).is_ok());                     // before exp
+assert!(matches!(decode_at(&token, secret, 2000), Err(JwtError::Expired(_)))); // after
+```
+
+---
+
+## Security model
+
+This is auth-boundary code — three things you must know:
+
+1. **`decode` does NOT validate `iss` / `aud`.** A valid signature proves the
+   token was minted with your secret, not that it was minted *for your service*.
+   If you set `iss`/`aud` at issue time, **check them yourself** on the decoded
+   claims:
+
+   ```rust
+   let c = decode(&token, secret)?;
+   if c.get::<String>("aud").as_deref() != Some("web-client") {
+       return Err("wrong audience");
+   }
+   ```
+
+2. **The secret must be ≥ 32 bytes** — `encode` refuses to sign with a shorter
+   key (a short key is guessable, and a guessable HMAC key means forgeable
+   tokens). HS256 is symmetric: anyone with the verify secret can also *mint*
+   tokens, so it stays inside your trust boundary (single service / shared
+   backend). Cross-org token issuance wants asymmetric RS256/ES256, which this
+   module deliberately doesn't ship.
+
+3. **`alg=none` and tampering are rejected.** `decode` pins HS256 (the classic
+   "alg: none" forgery is refused), and any change to the header or payload
+   breaks the signature — verified by a constant-time comparison.
+
+There is **no clock-skew leeway**: `exp`/`nbf` compare against the exact current
+second. If issuer and verifier clocks drift, subtract a few seconds via
+`decode_at`.
+
+---
+
+## Inspecting without verifying
+
+`decode_unverified` reads the payload **without** checking the signature or
+expiry — useful only to peek at a claim (e.g. a key id) so you can pick the right
+secret, then call `decode` for real.
+
+```rust
+let peek = rustango::jwt::decode_unverified(&token)?;   // NOT trusted
+let kid = peek.get::<String>("kid");
+// ... look up the secret for `kid`, then verify properly:
+let claims = decode(&token, &resolved_secret)?;
+```
+
+**Never authorize on `decode_unverified` output** — it carries no integrity
+guarantee.
+
+---
+
+## Notes and limits
+
+- **HS256 only** — symmetric, single shared secret. No RS256/ES256 (keeps the
+  always-on dep tree small; most single-service apps use HS256 anyway).
+- **Stateless = not revocable.** A plain JWT is valid until `exp`. If you need
+  "log out now" / per-token revocation, use [JWT auth API](auth-jwt-api.md) (JTI
+  blocklist) or a [Session](auth-sessions.md) (delete the server entry).
+- **Keep `exp` short** for access tokens (minutes). Long-lived plain JWTs are a
+  liability precisely because they can't be revoked.
+- Pair issuance with [Passwords](auth-passwords.md) (verify, then issue) and
+  gate API routes via the [auth backend chain](auth-backends.md)'s `JwtBackend`.

--- a/docs/index.toml
+++ b/docs/index.toml
@@ -20,7 +20,7 @@ pages = ["admin.md", "orm.md", "serializers.md", "viewsets.md", "urls.md", "mana
 [[section]]
 title = "Authentication"
 slug = "authentication"
-pages = ["auth-passwords.md", "auth-sessions.md"]
+pages = ["auth-passwords.md", "auth-sessions.md", "auth-decorators.md", "auth-jwt.md", "auth-jwt-api.md"]
 
 [[section]]
 title = "Benchmarks"

--- a/docs/security.md
+++ b/docs/security.md
@@ -409,6 +409,8 @@ jwt.revoke(&refresh_token);
 
 The default in-memory blacklist (`InMemoryJtiStore`) cleans out expired entries on its own, but it lives in one process and forgets every revocation on restart. For multi-process deployments, install a shared, durable store via `JwtLifecycle::new(secret).with_jti_store(store)` — `store` is any `Arc<dyn JtiStore>` (for example a Redis- or DB-backed one). Without a shared store, a token you revoke on one replica can still be replayed on another until it expires.
 
+> **Deep dive:** [JWT auth API](auth-jwt-api.md) — the built-in `/api/auth/login|refresh|logout|me` router, sliding refresh, and the JTI revocation store. For a single self-managed token, see [JWT (standalone)](auth-jwt.md). To gate browser/API routes by login, see [access decorators](auth-decorators.md).
+
 ---
 
 ## Authenticating with API keys


### PR DESCRIPTION
Session 2 of the authentication deep-dive series (follows #1076 — passwords + sessions). Three dedicated, tested per-flow guides, each backed by a runnable test in the `auth_demo` example.

## Docs
- **`docs/auth-jwt.md`** — standalone HS256 (`rustango::jwt`): claims, verify, and the security model up front (decode doesn't check `iss`/`aud`; 32-byte key floor; `alg=none` rejected).
- **`docs/auth-jwt-api.md`** — `JwtLifecycle` (access + refresh + revoke + rotation) and the built-in `/api/auth/{login,refresh,logout,me}` router, plus the JTI-store production guidance.
- **`docs/auth-decorators.md`** — `login_required` & the `_or_403` family, browser-vs-API responses (302 vs 401/403), and `?next=` + `safe_next` open-redirect defense.

## Tests (in `crates/rustango/examples/auth_demo/`)
| File | Tests |
|---|--:|
| `tests/auth_jwt.rs` | 4 |
| `tests/auth_jwt_api.rs` | 5 |
| `tests/auth_decorators.rs` | 3 |

All 12 new tests pass (plus Session 1's 7) under **both** sqlite and the default **postgres** backend — the same `cargo test` the `doc_examples` CI matrix runs for `auth_demo`.

## Wiring
- `docs/index.toml` — Authentication section now lists 5 pages.
- `docs/security.md` — JWT section links out to the new deep-dives.

## Notes
- The `jwt_router` HTTP endpoints are **tenant-scoped** (need `rustango_users` + tenant context). This PR tests the token **engine** (`JwtLifecycle`, no DB); the HTTP+tenant path is covered by `tests/tenant_auth_live.rs`. A dedicated showcase `jwt-api.spec.ts` is deferred for that reason.
- Some docs forward-reference not-yet-written guides (`auth-flows`, `auth-hmac`, `auth-api-keys`, `auth-backends`); those links resolve as Sessions 3–5 land.