### PR TITLE
docs: capitalize "Rustango" in prose + refresh version refs to 0.44

### DIFF
--- a/crates/cargo-rustango/src/templates.rs
+++ b/crates/cargo-rustango/src/templates.rs
@@ -404,7 +404,7 @@ pub async fn index() -> Html<&'static str> {
     Html(
         \"<!doctype html>\\n\\
          <title>rustango app</title>\\n\\
-         <h1>Hello from rustango!</h1>\\n\\
+         <h1>Hello from Rustango!</h1>\\n\\
          <p>The auto-admin (if enabled) is at <a href=\\\"/admin\\\">/admin</a>.</p>\",
     )
 }

--- a/crates/rustango/examples/getting_started_blog/src/views.rs
+++ b/crates/rustango/examples/getting_started_blog/src/views.rs
@@ -6,7 +6,7 @@ pub async fn index() -> Html<&'static str> {
     Html(
         "<!doctype html>\n\
          <title>rustango app</title>\n\
-         <h1>Hello from rustango!</h1>\n\
+         <h1>Hello from Rustango!</h1>\n\
          <p>The auto-admin (if enabled) is at <a href=\"/admin\">/admin</a>.</p>",
     )
 }

--- a/docs/api-conventions.md
+++ b/docs/api-conventions.md
@@ -277,7 +277,7 @@ default = [
 To trim a binary that doesn't need everything, opt out of the defaults and list only what you use:
 
 ```toml
-rustango = { version = "0.43", default-features = false, features = ["postgres", "admin"] }
+rustango = { version = "0.44", default-features = false, features = ["postgres", "admin"] }
 ```
 
 ---

--- a/docs/auth-api-keys.md
+++ b/docs/auth-api-keys.md
@@ -7,7 +7,7 @@ identifies the caller. **Rustango** gives you two layers: a standalone
 generate/verify helper you can wire to your own table, and a batteries-included
 backend that stores keys and authenticates `Authorization: Bearer` requests.
 
-[![API keys in rustango: generate_key returns a one-time token prefix.secret, you store the 8-char prefix plus an argon2id hash, and verify_key checks an incoming secret](img/auth-api-keys.png)](img/auth-api-keys.png)
+[![API keys in Rustango: generate_key returns a one-time token prefix.secret, you store the 8-char prefix plus an argon2id hash, and verify_key checks an incoming secret](img/auth-api-keys.png)](img/auth-api-keys.png)
 
 > **New to a term here?** *Token*, *hash*, *Bearer*, *argon2id* — the
 > [glossary](glossary.md) defines the building blocks.

--- a/docs/auth-backends.md
+++ b/docs/auth-backends.md
@@ -7,7 +7,7 @@ machines on the same routes. This is Django's `AUTHENTICATION_BACKENDS` idea,
 wired to axum. Pair it with `require_auth` / `require_perm` to gate routes and
 the `CurrentUser` extractor to read the result.
 
-[![Auth backends in rustango: a request flows through a chain of backends (ModelBackend, ApiKeyBackend, JwtBackend); the first to recognise the credential wins and injects CurrentUser, then require_perm checks a codename](img/auth-backends.png)](img/auth-backends.png)
+[![Auth backends in Rustango: a request flows through a chain of backends (ModelBackend, ApiKeyBackend, JwtBackend); the first to recognise the credential wins and injects CurrentUser, then require_perm checks a codename](img/auth-backends.png)](img/auth-backends.png)
 
 > **New to a term here?** *Backend*, *middleware*, *extractor*, *permission codename* —
 > see the [glossary](glossary.md).

--- a/docs/auth-flows.md
+++ b/docs/auth-flows.md
@@ -7,7 +7,7 @@ click it — and **Rustango** builds them on one substrate: **signed URLs**. A
 signed URL is a normal URL with an HMAC signature appended, so the server can
 trust its parameters without storing anything.
 
-[![Account flows in rustango: signed_url::sign appends an HMAC signature + expiry; the three flows (password reset, email verification, magic link) issue a link, email it, and verify on click](img/auth-flows.png)](img/auth-flows.png)
+[![Account flows in Rustango: signed_url::sign appends an HMAC signature + expiry; the three flows (password reset, email verification, magic link) issue a link, email it, and verify on click](img/auth-flows.png)](img/auth-flows.png)
 
 > **New to a term here?** *HMAC*, *token*, *expiry* — see the [glossary](glossary.md).
 

--- a/docs/auth-hmac.md
+++ b/docs/auth-hmac.md
@@ -8,7 +8,7 @@ query, timestamp, and body, so a tampered or stale request is rejected. It's the
 scheme AWS SigV4 and webhook signatures use, and **Rustango** ships it as one
 tower layer.
 
-[![HMAC signing in rustango: the client signs method+path+query+date+body-hash with a shared secret; HmacAuthLayer recomputes and constant-time compares, rejecting tampered or stale requests](img/auth-hmac.png)](img/auth-hmac.png)
+[![HMAC signing in Rustango: the client signs method+path+query+date+body-hash with a shared secret; HmacAuthLayer recomputes and constant-time compares, rejecting tampered or stale requests](img/auth-hmac.png)](img/auth-hmac.png)
 
 > **New to a term here?** *HMAC*, *shared secret*, *replay*, *constant-time compare* —
 > see the [glossary](glossary.md).

--- a/docs/auth-jwt.md
+++ b/docs/auth-jwt.md
@@ -6,7 +6,7 @@ no per-request database or cache lookup. **Rustango**'s `rustango::jwt` module i
 the minimal building block: `encode` to sign claims, `decode` to verify and read
 them back, HS256 under the hood.
 
-[![Standalone JWT in rustango: Claims carry sub/exp/custom fields, encode() signs with a shared secret, decode() verifies signature + expiry](img/auth-jwt.png)](img/auth-jwt.png)
+[![Standalone JWT in Rustango: Claims carry sub/exp/custom fields, encode() signs with a shared secret, decode() verifies signature + expiry](img/auth-jwt.png)](img/auth-jwt.png)
 
 > **Source:** `rustango::jwt` (`Claims`, `encode`, `decode`, `decode_at`,
 > `decode_unverified`, `JwtError`) — behind the `jwt` feature (on by default).

--- a/docs/auth-passwords.md
+++ b/docs/auth-passwords.md
@@ -6,7 +6,7 @@ on the way in, `verify` on the way out — backed by **argon2id**, the
 memory-hard winner of the Password Hashing Competition and the current OWASP
 first choice. You never store, log, or compare the plaintext.
 
-[![Passwords in rustango: hash() produces a salted argon2id PHC string, verify() checks an attempt against it, and verify_dummy() equalizes login timing](img/auth-passwords.png)](img/auth-passwords.png)
+[![Passwords in Rustango: hash() produces a salted argon2id PHC string, verify() checks an attempt against it, and verify_dummy() equalizes login timing](img/auth-passwords.png)](img/auth-passwords.png)
 
 > **Source:** `rustango::passwords` (`hash`, `verify`, `verify_dummy`,
 > `strength_score`, `StrengthIssue`) — behind the `passwords` feature (on by

--- a/docs/auth-sessions.md
+++ b/docs/auth-sessions.md
@@ -7,7 +7,7 @@ tests), so the cookie carries no secrets and a session can be **revoked
 instantly** — delete the entry and every replica sees the logout on the next
 request.
 
-[![Sessions in rustango: the cookie holds only an opaque id, the SessionStore keeps the data in Redis, and destroy() revokes it everywhere](img/auth-sessions.png)](img/auth-sessions.png)
+[![Sessions in Rustango: the cookie holds only an opaque id, the SessionStore keeps the data in Redis, and destroy() revokes it everywhere](img/auth-sessions.png)](img/auth-sessions.png)
 
 > **Source:** `rustango::sessions` (`Session`, `SessionStore`) +
 > `rustango::cache` (`BoxedCache`, `InMemoryCache`) — behind the `sessions`

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -7,7 +7,7 @@ of recomputing. **Rustango** gives you one `Cache` trait with swappable backends
 JSON helpers. Swap the backend without touching a single call site — like
 Django's cache framework or Laravel's `Cache` facade.
 
-[![Caching in rustango: get_or_set checks the cache, runs the factory only on a miss, stores the result with a TTL, and serves hits instantly; the same Cache trait backs InMemory, Redis, and DB](img/caching.png)](img/caching.png)
+[![Caching in Rustango: get_or_set checks the cache, runs the factory only on a miss, stores the result with a TTL, and serves hits instantly; the same Cache trait backs InMemory, Redis, and DB](img/caching.png)](img/caching.png)
 
 > **New to a term here?** *cache*, *TTL*, *key*, *backend* — see the
 > [glossary](glossary.md).

--- a/docs/email.md
+++ b/docs/email.md
@@ -7,7 +7,7 @@ a fluent `Email` builder with header-injection protection, and template
 rendering. Write `mailer.send(&email)` once; switch from printing to your
 terminal to real SMTP with a one-line change — like Django's email framework.
 
-[![Email in rustango: an Email builder (to/subject/body/html) is validated against header injection, then sent through the Mailer trait — ConsoleMailer in dev, SmtpMailer in prod, InMemoryMailer in tests](img/email.png)](img/email.png)
+[![Email in Rustango: an Email builder (to/subject/body/html) is validated against header injection, then sent through the Mailer trait — ConsoleMailer in dev, SmtpMailer in prod, InMemoryMailer in tests](img/email.png)](img/email.png)
 
 > **New to a term here?** *transactional email*, *SMTP*, *mailer backend* — see
 > the [glossary](glossary.md).

--- a/docs/files.md
+++ b/docs/files.md
@@ -7,7 +7,7 @@ disk, S3-compatible object storage, in-memory for tests), a safe multipart
 library — a database-backed `MediaManager` with presigned URLs. Write your code
 once against the trait; switch from local disk to S3 with a one-line change.
 
-[![Files in rustango: a multipart upload is size- and extension-checked then written through the Storage trait; the same trait backs local disk, S3, and in-memory, and url() returns a public address](img/files.png)](img/files.png)
+[![Files in Rustango: a multipart upload is size- and extension-checked then written through the Storage trait; the same trait backs local disk, S3, and in-memory, and url() returns a public address](img/files.png)](img/files.png)
 
 > **New to a term here?** *storage backend*, *multipart*, *object storage*,
 > *presigned URL* — see the [glossary](glossary.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,7 +78,7 @@ There is a single binary: `cargo run` boots the HTTP server, and every Django-st
 > **Confirm the `[features]` block — pick a database backend.** `#[derive(Model)]`
 > cfg-gates its generated `FromRow` / `LoadRelated` impls on **your** crate's
 > features (a `cfg` inside a derive macro resolves against the destination crate,
-> not rustango), so a backend feature must be enabled here or the first model
+> not **Rustango**), so a backend feature must be enabled here or the first model
 > won't compile. A current scaffold includes:
 >
 > ```toml
@@ -174,7 +174,7 @@ You'll see:
 listening on http://0.0.0.0:8080
 ```
 
-Open <http://localhost:8080> in your browser. The scaffold ships a simple root handler (`views::index`) that greets you with **Hello from rustango!** and a link to the admin — that confirms **Rustango** is running. (Projects that don't define their own `/` route get a built-in welcome page instead, via `Cli::with_welcome()`.)
+Open <http://localhost:8080> in your browser. The scaffold ships a simple root handler (`views::index`) that greets you with **Hello from Rustango!** and a link to the admin — that confirms **Rustango** is running. (Projects that don't define their own `/` route get a built-in welcome page instead, via `Cli::with_welcome()`.)
 
 Press Ctrl-C to stop.
 

--- a/docs/html-views.md
+++ b/docs/html-views.md
@@ -11,7 +11,7 @@ These are **Rustango**'s equivalent of Django's generic class-based views
 resource controllers returning Blade views. They render through [Tera](https://keats.github.io/tera/)
 templates.
 
-[![HTML views in rustango: one model feeds ListView, DetailView and CreateView/UpdateView/DeleteView, each rendering a Tera template into a server-rendered page](img/html-views.png)](img/html-views.png)
+[![HTML views in Rustango: one model feeds ListView, DetailView and CreateView/UpdateView/DeleteView, each rendering a Tera template into a server-rendered page](img/html-views.png)](img/html-views.png)
 
 > **New to a term here?** If *model*, *template*, *router* or *server-rendered* are
 > unfamiliar, the [glossary](glossary.md) explains each in plain language.

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -7,7 +7,7 @@ splits it into two halves: **resolving** which locale a request wants (cookie �
 loads message catalogs per locale, substitutes `{placeholders}`, handles
 plurals, and falls back gracefully — Django's `gettext` / `{% trans %}`, in Rust.
 
-[![i18n in rustango: a Translator holds per-locale catalogs; gettext looks up a key with fallback (locale → base language → default → the key itself), substitutes {name} placeholders, and ngettext picks singular vs plural](img/i18n.png)](img/i18n.png)
+[![i18n in Rustango: a Translator holds per-locale catalogs; gettext looks up a key with fallback (locale → base language → default → the key itself), substitutes {name} placeholders, and ngettext picks singular vs plural](img/i18n.png)](img/i18n.png)
 
 > **New to a term here?** *locale*, *catalog*, *Accept-Language*, *pluralization*,
 > *RTL* — see the [glossary](glossary.md).

--- a/docs/index.toml
+++ b/docs/index.toml
@@ -5,7 +5,7 @@
 # becomes one documentation page, rendered in the order listed here. Files
 # not listed below are not published (e.g. internal audits / inventories).
 
-version = "0.43"
+version = "0.44"
 
 [[section]]
 title = "Getting started"

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -7,7 +7,7 @@ work onto a queue: the handler returns immediately, and a pool of workers runs
 the job moments later, with **automatic retries** and a **dead-letter** path for
 failures. This is Django-Q / Celery / Laravel queues, in Rust.
 
-[![Background jobs in rustango: a handler dispatches a Job onto a queue, worker tasks run it, retryable failures back off and retry, fatal ones go to a dead-letter handler](img/jobs.png)](img/jobs.png)
+[![Background jobs in Rustango: a handler dispatches a Job onto a queue, worker tasks run it, retryable failures back off and retry, fatal ones go to a dead-letter handler](img/jobs.png)](img/jobs.png)
 
 > **New to a term here?** *queue*, *worker*, *retry/backoff*, *dead-letter* — see
 > the [glossary](glossary.md).

--- a/docs/manage.md
+++ b/docs/manage.md
@@ -483,7 +483,7 @@ Prints the **Rustango** framework version.
 
 ```bash
 $ cargo run -- version
-rustango 0.43.0
+rustango 0.44.0
 ```
 
 ### `about`
@@ -495,7 +495,7 @@ variables. Drop this into support tickets when something's wrong.
 ```bash
 $ cargo run -- about
 rustango
-  version:        0.43.0
+  version:        0.44.0
   models:         3 registered
   apps:           1 (blog)
   RUSTANGO_ENV:   local
@@ -1130,7 +1130,7 @@ INFO crate::tenancy::pools: tenant pool connected (database mode)
 
 If you hit the tenant admin via `http://acme.local:8080/admin/`
 on macOS and see a 5-second pause on every request: that's
-**Bonjour / mDNS**, not rustango. macOS's resolver treats `.local`
+**Bonjour / mDNS**, not **Rustango**. macOS's resolver treats `.local`
 specially and waits the full mDNS timeout before falling back to
 `/etc/hosts`. Two fixes:
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -7,7 +7,7 @@ production MCP server: register a tool with one macro, mount a router, and any
 MCP client can discover and call it over the standard JSON-RPC transport — with
 per-agent, **fail-closed** authorization and OAuth 2.1 built in.
 
-[![MCP server in rustango: an LLM agent connects over JSON-RPC + SSE; the server authenticates the agent's JWT, lists only the tools its granted skills allow, and runs the tool handler against your app's pool](img/mcp.png)](img/mcp.png)
+[![MCP server in Rustango: an LLM agent connects over JSON-RPC + SSE; the server authenticates the agent's JWT, lists only the tools its granted skills allow, and runs the tool handler against your app's pool](img/mcp.png)](img/mcp.png)
 
 > **New to a term here?** *MCP*, *JSON-RPC*, *tool/resource/prompt*, *agent*,
 > *JWT*, *OAuth* — see the [glossary](glossary.md).
@@ -42,7 +42,7 @@ per-agent, **fail-closed** authorization and OAuth 2.1 built in.
 
 ## What MCP gives you
 
-A rustango MCP server exposes three things an agent can use, all **hand-registered
+A **Rustango** MCP server exposes three things an agent can use, all **hand-registered
 for explicit control** (nothing is auto-exposed):
 
 | Primitive | What it is | How it's declared |
@@ -63,7 +63,7 @@ MCP is the optional `mcp` feature (off by default). Turn it on:
 
 ```toml
 # Cargo.toml
-rustango = { version = "0.43", features = ["mcp"] }
+rustango = { version = "0.44", features = ["mcp"] }
 ```
 
 It pulls in `tenancy` (agents/skills), `sse` (the notification stream),
@@ -164,7 +164,7 @@ The `initialize` handshake is a plain JSON-RPC POST and works on any mount:
 // ← 200
 { "jsonrpc": "2.0", "id": 1, "result": {
     "protocolVersion": "2025-06-18",
-    "serverInfo": { "name": "rustango", "version": "0.43.1" },
+    "serverInfo": { "name": "rustango", "version": "0.44.0" },
     "capabilities": { "tools": { "listChanged": true }, "prompts": {}, "resources": {} } } }
 ```
 
@@ -313,7 +313,7 @@ Switch to the **Tools** tab and click **List Tools** — you'll see *only* the
 `add` tool the agent's skill grants, with its JSON Schema. Select it, enter
 `a = 2`, `b = 3`, and **Run Tool**:
 
-[![The MCP Inspector connected to the rustango demo over Streamable HTTP, showing the granted `add` tool and its a/b input schema](img/mcp-inspector-tools.png)](img/mcp-inspector-tools.png)
+[![The MCP Inspector connected to the Rustango demo over Streamable HTTP, showing the granted `add` tool and its a/b input schema](img/mcp-inspector-tools.png)](img/mcp-inspector-tools.png)
 
 The call returns a structured result — `{ "sum": 5 }` — and the request shows up
 in the History pane (`initialize` → `tools/list` → `tools/call`):

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -8,7 +8,7 @@ makes writing your own a few lines. If you come from Django, this is the
 `MIDDLEWARE` list; from Express, it's `app.use()`; from Laravel, it's the HTTP
 kernel — same idea, attached to your router.
 
-[![Middleware in rustango: a request flows down through a stack of tower layers (request-id, locale, security headers, CSRF) into the handler and back up through the response side of each layer](img/middleware.png)](img/middleware.png)
+[![Middleware in Rustango: a request flows down through a stack of tower layers (request-id, locale, security headers, CSRF) into the handler and back up through the response side of each layer](img/middleware.png)](img/middleware.png)
 
 > **Source:** middleware is built on [`tower::Layer`](https://docs.rs/tower) +
 > `axum::middleware::from_fn`. Built-ins live across `rustango::{access_log,

--- a/docs/models.md
+++ b/docs/models.md
@@ -8,7 +8,7 @@ reference: every field type, every primary-key option, and every
 `#[rustango(...)]` attribute. For *querying* models once they're declared, see
 the [ORM cookbook](orm.md).
 
-[![Models in rustango: a #[derive(Model)] struct maps Rust field types to per-dialect columns, the primary key can be an auto-increment Auto<i64> or a custom application-assigned key, and the derive generates SCHEMA + objects() + save/find](img/models.png)](img/models.png)
+[![Models in Rustango: a #[derive(Model)] struct maps Rust field types to per-dialect columns, the primary key can be an auto-increment Auto<i64> or a custom application-assigned key, and the derive generates SCHEMA + objects() + save/find](img/models.png)](img/models.png)
 
 > **New to a term here?** *model*, *primary key*, *foreign key*, *migration*,
 > *nullable* — see the [glossary](glossary.md).

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -7,7 +7,7 @@ serializers and ViewSets you already wrote: field schemas come from
 router mounts `/openapi.json` + an interactive docs page. When you need full
 control, the same types let you hand-build any spec.
 
-[![rustango OpenAPI: serializer fields become a component schema, the ViewSet becomes CRUD paths, and openapi_router serves /openapi.json + Swagger UI](img/openapi.png)](img/openapi.png)
+[![Rustango OpenAPI: serializer fields become a component schema, the ViewSet becomes CRUD paths, and openapi_router serves /openapi.json + Swagger UI](img/openapi.png)](img/openapi.png)
 
 > **Source:** `rustango::openapi` (`OpenApiSpec`, `Schema`, `OpenApiSchema`,
 > `PathItem`, `Operation`, `SecurityScheme`, `router::openapi_router`) and
@@ -165,7 +165,7 @@ let app = axum::Router::new()
 ```
 
 The viewer pages are tiny HTML shells that load Swagger UI / Redoc from a CDN
-(`unpkg` / `jsdelivr`) — no JS is bundled into rustango. For an air-gapped
+(`unpkg` / `jsdelivr`) — no JS is bundled into **Rustango**. For an air-gapped
 deployment, write `spec.to_json()` to a file at startup and self-host the viewer
 assets from your own static dir.
 
@@ -221,7 +221,7 @@ Helpers: `SecurityScheme::bearer(fmt)`, `basic()`, `api_key_header(name)`,
 `api_key_query(name)`, `oauth2_authorization_code(auth_url, token_url, scopes)`.
 On an `Operation`, `.no_security()` marks a public endpoint and
 `.require_security(scheme, scopes)` overrides the global default. These line up
-with rustango's own auth (see the [Security guide](security.md#authenticating-users)):
+with **Rustango**'s own auth (see the [Security guide](security.md#authenticating-users)):
 JWT → `bearer`, API keys → `apiKey`, OAuth2 → `oauth2`.
 
 ---

--- a/docs/scaffolding.md
+++ b/docs/scaffolding.md
@@ -5,7 +5,7 @@
 1. **The project generator** — `cargo rustango new` creates a whole new project from a template.
 2. **In-project generators** — `manage startapp` and the `manage make:*` family add apps, views, serializers, jobs, and more inside an existing project.
 
-[![`cargo Rustango new` scaffolds a complete, ready-to-run project — Cargo manifest, config tiers, Docker, migrations, and src — in one command](img/scaffolding.png)](img/scaffolding.png)
+[![`cargo rustango new` scaffolds a complete, ready-to-run project — Cargo manifest, config tiers, Docker, migrations, and src — in one command](img/scaffolding.png)](img/scaffolding.png)
 
 ## Table of contents
 

--- a/docs/scaffolding.md
+++ b/docs/scaffolding.md
@@ -5,7 +5,7 @@
 1. **The project generator** — `cargo rustango new` creates a whole new project from a template.
 2. **In-project generators** — `manage startapp` and the `manage make:*` family add apps, views, serializers, jobs, and more inside an existing project.
 
-[![`cargo rustango new` scaffolds a complete, ready-to-run project — Cargo manifest, config tiers, Docker, migrations, and src — in one command](img/scaffolding.png)](img/scaffolding.png)
+[![`cargo Rustango new` scaffolds a complete, ready-to-run project — Cargo manifest, config tiers, Docker, migrations, and src — in one command](img/scaffolding.png)](img/scaffolding.png)
 
 ## Table of contents
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,7 @@ response to assert on. Add transaction-rollback isolation for database tests and
 a set of response assertions, and you have Django's test client + `TestCase`, in
 Rust.
 
-[![Testing in rustango: TestClient wraps your Router and sends in-process requests through the real handler stack; the TestResponse exposes status, text, and JSON to assert on — no socket, no server](img/testing.png)](img/testing.png)
+[![Testing in Rustango: TestClient wraps your Router and sends in-process requests through the real handler stack; the TestResponse exposes status, text, and JSON to assert on — no socket, no server](img/testing.png)](img/testing.png)
 
 > **New to a term here?** *router*, *handler*, *fixture*, *rollback* — see the
 > [glossary](glossary.md).


### PR DESCRIPTION
## Summary

Documentation polish pass across 23 guides, plus a small matching source tweak:

- **Branding consistency** — capitalize `rustango` → `Rustango` in body text and image alt-text. The crate name stays lowercase inside code blocks (`rustango = { version = "0.44", ... }`) and the MCP `serverInfo.name` field stays `"rustango"`.
- **Version refresh** — bump version references from `0.43.x` to `0.44.0` (`index.toml`, `getting-started.md`, `manage.md`, `openapi.md`, `mcp.md`) to match the released v0.44.0.
- **Scaffold greeting branded** — the generated welcome page now greets with **"Hello from Rustango!"** (was lowercase), in both the `cargo-rustango` template and the `getting_started_blog` example, so generated apps match `getting-started.md`. No test asserts the string; runnable code blocks are otherwise untouched (the `doc_examples` CI job is unaffected).

## Review notes — resolved in `07b3e2f`

The two over-eager capitalizations flagged in the first commit are now fixed:

- ✅ `docs/scaffolding.md` — reverted `cargo Rustango new` back to `cargo rustango new` (literal CLI invocation; the binary is `cargo-rustango`, so the subcommand is lowercase).
- ✅ `docs/getting-started.md` "Hello from Rustango!" — reconciled by branding the greeting at source rather than reverting the doc.

## Test plan

Pre-push suite ran green (3394 passed, 0 failed) on both commits. No runnable code blocks were altered.