### PR TITLE
feat(i18n): locale capability registry (locale_info / known_locales)

### DIFF
--- a/crates/rustango/src/forms/csrf.rs
+++ b/crates/rustango/src/forms/csrf.rs
@@ -118,6 +118,15 @@ pub struct CsrfConfig {
     /// attacker steals the cookie token, they can't submit from a
     /// different origin.
     pub trusted_origins: Vec<String>,
+    /// URL path prefixes exempt from CSRF enforcement on unsafe
+    /// methods. Default `[]`. Intended for `navigator.sendBeacon`
+    /// collector endpoints (e.g. analytics), which cannot set an
+    /// `X-CSRF-Token` header and — when the page is served from a CDN
+    /// cache that strips `Set-Cookie` — may have no CSRF cookie at all.
+    /// Each entry is matched with `req.uri().path().starts_with(prefix)`,
+    /// so keep prefixes narrow and only exempt append-only endpoints
+    /// that read/write no auth state.
+    pub exempt_prefixes: Vec<String>,
 }
 
 impl Default for CsrfConfig {
@@ -127,6 +136,7 @@ impl Default for CsrfConfig {
             header_name: CSRF_HEADER.to_owned(),
             secure: true,
             trusted_origins: Vec::new(),
+            exempt_prefixes: Vec::new(),
         }
     }
 }
@@ -161,6 +171,18 @@ impl CsrfConfig {
         S: Into<String>,
     {
         self.trusted_origins = origins.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Builder — exempt a URL path prefix from CSRF enforcement on
+    /// unsafe methods. For beacon/collector endpoints posted via
+    /// `navigator.sendBeacon` (which cannot set a custom header) and
+    /// reachable from CDN-cached pages that never received a CSRF
+    /// cookie. Only exempt append-only endpoints that touch no auth
+    /// state; keep the prefix narrow.
+    #[must_use]
+    pub fn exempt_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.exempt_prefixes.push(prefix.into());
         self
     }
 }
@@ -297,8 +319,11 @@ where
         Box::pin(async move {
             let cookie_value = read_csrf_cookie(&req, &cfg.cookie_name);
 
-            // Enforce on unsafe methods.
-            let req = if !is_safe_method(req.method()) {
+            // Enforce on unsafe methods — unless the path is exempt
+            // (beacon/collector endpoints; see `CsrfConfig::exempt_prefix`).
+            let req = if !is_safe_method(req.method())
+                && !path_is_exempt(req.uri().path(), &cfg.exempt_prefixes)
+            {
                 // Origin-header defense-in-depth. Skipped when
                 // `trusted_origins` is empty (back-compat default).
                 if !origin_allowed(&req, &cfg.trusted_origins) {
@@ -380,6 +405,12 @@ where
 /// — the middleware can't safely buffer megabyte-scale form
 /// payloads in memory just to verify a token.
 const BODY_BUFFER_LIMIT: usize = 64 * 1024;
+
+/// `true` when `path` starts with any configured exempt prefix. Used to
+/// skip CSRF enforcement for beacon/collector endpoints.
+fn path_is_exempt(path: &str, prefixes: &[String]) -> bool {
+    prefixes.iter().any(|p| path.starts_with(p.as_str()))
+}
 
 fn is_safe_method(m: &Method) -> bool {
     matches!(
@@ -702,6 +733,26 @@ mod tests {
         assert!(!is_safe_method(&Method::POST));
         assert!(!is_safe_method(&Method::PUT));
         assert!(!is_safe_method(&Method::DELETE));
+    }
+
+    #[test]
+    fn exempt_prefix_matches_only_configured_paths() {
+        let prefixes = vec!["/__cms__/collect".to_owned()];
+        // Exact + sub-path match (prefix semantics).
+        assert!(path_is_exempt("/__cms__/collect", &prefixes));
+        assert!(path_is_exempt("/__cms__/collect/extra", &prefixes));
+        // Unrelated paths still enforced.
+        assert!(!path_is_exempt("/__cms__/other", &prefixes));
+        assert!(!path_is_exempt("/forms/submit/1", &prefixes));
+        assert!(!path_is_exempt("/", &prefixes));
+        // Empty config exempts nothing (back-compat default).
+        assert!(!path_is_exempt("/__cms__/collect", &[]));
+    }
+
+    #[test]
+    fn exempt_prefix_builder_appends() {
+        let cfg = CsrfConfig::default().exempt_prefix("/__cms__/collect");
+        assert_eq!(cfg.exempt_prefixes, vec!["/__cms__/collect".to_owned()]);
     }
 
     #[test]

--- a/crates/rustango/src/i18n/mod.rs
+++ b/crates/rustango/src/i18n/mod.rs
@@ -154,113 +154,143 @@ impl Locale {
     }
 }
 
-/// English display name for a bare locale string — public so callers
-/// holding an `Accept-Language`-shaped `&str` can render it without
-/// constructing a [`Locale`].
-#[must_use]
-pub fn language_display_name(locale: &str) -> &'static str {
-    let lower = locale.to_ascii_lowercase();
-    let base = lower.split('-').next().unwrap_or(&lower);
+/// Canonical per-base-language display metadata: `(base code, English
+/// name, native name)`. Single source of truth for
+/// [`language_display_name`], [`language_native_name`], and
+/// [`known_locales`]. Retired / variant subtags (`iw`→`he`, `nb`/`nn`→
+/// `no`, `ji`→`yi`) resolve to their canonical row via `canonical_base`.
+const LANGUAGE_NAMES: &[(&str, &str, &str)] = &[
+    ("en", "English", "English"),
+    ("fr", "French", "français"),
+    ("de", "German", "Deutsch"),
+    ("es", "Spanish", "español"),
+    ("it", "Italian", "italiano"),
+    ("pt", "Portuguese", "português"),
+    ("nl", "Dutch", "Nederlands"),
+    ("ru", "Russian", "русский"),
+    ("ja", "Japanese", "日本語"),
+    ("zh", "Chinese", "中文"),
+    ("ko", "Korean", "한국어"),
+    ("ar", "Arabic", "العربية"),
+    ("he", "Hebrew", "עברית"),
+    ("fa", "Persian", "فارسی"),
+    ("ur", "Urdu", "اردو"),
+    ("tr", "Turkish", "Türkçe"),
+    ("pl", "Polish", "polski"),
+    ("uk", "Ukrainian", "українська"),
+    ("cs", "Czech", "čeština"),
+    ("sk", "Slovak", "slovenčina"),
+    ("hu", "Hungarian", "magyar"),
+    ("ro", "Romanian", "română"),
+    ("bg", "Bulgarian", "български"),
+    ("el", "Greek", "Ελληνικά"),
+    ("sv", "Swedish", "svenska"),
+    ("no", "Norwegian", "norsk"),
+    ("da", "Danish", "dansk"),
+    ("fi", "Finnish", "suomi"),
+    ("hi", "Hindi", "हिन्दी"),
+    ("bn", "Bengali", "বাংলা"),
+    ("ta", "Tamil", "தமிழ்"),
+    ("th", "Thai", "ไทย"),
+    ("vi", "Vietnamese", "Tiếng Việt"),
+    ("id", "Indonesian", "Bahasa Indonesia"),
+    ("ms", "Malay", "Bahasa Melayu"),
+    ("ps", "Pashto", "پښتو"),
+    ("yi", "Yiddish", "ייִדיש"),
+    ("dv", "Divehi", "ދިވެހި"),
+    ("ckb", "Sorani Kurdish", "کوردیی ناوەندی"),
+    ("ug", "Uyghur", "ئۇيغۇرچە"),
+    ("sd", "Sindhi", "سنڌي"),
+    ("syr", "Syriac", "ܠܫܢܐ ܣܘܪܝܝܐ"),
+];
+
+/// Resolve retired / variant language subtags to the canonical base code
+/// keyed in [`LANGUAGE_NAMES`].
+fn canonical_base(base: &str) -> &str {
     match base {
-        "en" => "English",
-        "fr" => "French",
-        "de" => "German",
-        "es" => "Spanish",
-        "it" => "Italian",
-        "pt" => "Portuguese",
-        "nl" => "Dutch",
-        "ru" => "Russian",
-        "ja" => "Japanese",
-        "zh" => "Chinese",
-        "ko" => "Korean",
-        "ar" => "Arabic",
-        "he" | "iw" => "Hebrew",
-        "fa" => "Persian",
-        "ur" => "Urdu",
-        "tr" => "Turkish",
-        "pl" => "Polish",
-        "uk" => "Ukrainian",
-        "cs" => "Czech",
-        "sk" => "Slovak",
-        "hu" => "Hungarian",
-        "ro" => "Romanian",
-        "bg" => "Bulgarian",
-        "el" => "Greek",
-        "sv" => "Swedish",
-        "no" | "nb" | "nn" => "Norwegian",
-        "da" => "Danish",
-        "fi" => "Finnish",
-        "hi" => "Hindi",
-        "bn" => "Bengali",
-        "ta" => "Tamil",
-        "th" => "Thai",
-        "vi" => "Vietnamese",
-        "id" => "Indonesian",
-        "ms" => "Malay",
-        "ps" => "Pashto",
-        "yi" | "ji" => "Yiddish",
-        "dv" => "Divehi",
-        "ckb" => "Sorani Kurdish",
-        "ug" => "Uyghur",
-        "sd" => "Sindhi",
-        "syr" => "Syriac",
-        // Unknown → return the input verbatim so the UI shows
-        // something. Static lifetime requires a tiny static fallback;
-        // leak the input on the cold path to satisfy &'static str.
-        _ => "Unknown",
+        "iw" => "he",        // retired Hebrew alias
+        "nb" | "nn" => "no", // Norwegian Bokmål / Nynorsk
+        "ji" => "yi",        // retired Yiddish alias
+        other => other,
     }
 }
 
+/// The [`LANGUAGE_NAMES`] row for a bare locale string (region-stripped,
+/// alias-resolved), or `None` when core has no metadata for the language.
+fn language_row(locale: &str) -> Option<&'static (&'static str, &'static str, &'static str)> {
+    let lower = locale.to_ascii_lowercase();
+    let base = canonical_base(lower.split('-').next().unwrap_or(&lower));
+    LANGUAGE_NAMES.iter().find(|(code, _, _)| *code == base)
+}
+
+/// English display name for a bare locale string — public so callers
+/// holding an `Accept-Language`-shaped `&str` can render it without
+/// constructing a [`Locale`]. Returns `"Unknown"` for locales core has
+/// no metadata for.
+#[must_use]
+pub fn language_display_name(locale: &str) -> &'static str {
+    language_row(locale).map_or("Unknown", |(_, en, _)| *en)
+}
+
 /// Native name for a bare locale string — sibling to
-/// [`language_display_name`].
+/// [`language_display_name`]. Returns `"Unknown"` for unknown locales.
 #[must_use]
 pub fn language_native_name(locale: &str) -> &'static str {
-    let lower = locale.to_ascii_lowercase();
-    let base = lower.split('-').next().unwrap_or(&lower);
-    match base {
-        "en" => "English",
-        "fr" => "français",
-        "de" => "Deutsch",
-        "es" => "español",
-        "it" => "italiano",
-        "pt" => "português",
-        "nl" => "Nederlands",
-        "ru" => "русский",
-        "ja" => "日本語",
-        "zh" => "中文",
-        "ko" => "한국어",
-        "ar" => "العربية",
-        "he" | "iw" => "עברית",
-        "fa" => "فارسی",
-        "ur" => "اردو",
-        "tr" => "Türkçe",
-        "pl" => "polski",
-        "uk" => "українська",
-        "cs" => "čeština",
-        "sk" => "slovenčina",
-        "hu" => "magyar",
-        "ro" => "română",
-        "bg" => "български",
-        "el" => "Ελληνικά",
-        "sv" => "svenska",
-        "no" | "nb" | "nn" => "norsk",
-        "da" => "dansk",
-        "fi" => "suomi",
-        "hi" => "हिन्दी",
-        "bn" => "বাংলা",
-        "ta" => "தமிழ்",
-        "th" => "ไทย",
-        "vi" => "Tiếng Việt",
-        "id" => "Bahasa Indonesia",
-        "ms" => "Bahasa Melayu",
-        "ps" => "پښتو",
-        "yi" | "ji" => "ייִדיש",
-        "dv" => "ދިވެހި",
-        "ckb" => "کوردیی ناوەندی",
-        "ug" => "ئۇيغۇرچە",
-        "sd" => "سنڌي",
-        "syr" => "ܠܫܢܐ ܣܘܪܝܝܐ",
-        _ => "Unknown",
+    language_row(locale).map_or("Unknown", |(_, _, native)| *native)
+}
+
+/// Every locale code core has display metadata for, as `(code, English
+/// name)` — canonical base codes only (retired aliases excluded). Powers
+/// "known locale" pickers / datalists so operators can pick codes core
+/// fully supports; free-text codes remain valid content locales, just
+/// without core metadata (see [`locale_info`]).
+pub fn known_locales() -> impl Iterator<Item = (&'static str, &'static str)> {
+    LANGUAGE_NAMES.iter().map(|(code, en, _)| (*code, *en))
+}
+
+/// Everything core statically knows about a locale, in one query — so a
+/// caller (e.g. a CMS managing its own DB locale roster) can decide how
+/// gracefully to degrade without string-comparing `"Unknown"` or
+/// re-implementing the metadata tables.
+///
+/// `known` is `true` when core has display metadata (name/RTL);
+/// `has_plural_rules` is `true` when the language hits a language-specific
+/// CLDR rule (see [`plural_category_is_explicit`] — note this is `false`
+/// for the generic English-style *one/other* rule, which is nonetheless
+/// *correct* for English/German/Spanish/etc.). A locale can be a perfectly
+/// usable content locale even when `known == false` — content translation
+/// is code-agnostic; only chrome/plural/RTL degrade.
+#[derive(Debug, Clone)]
+pub struct LocaleInfo {
+    /// The queried code, lowercased.
+    pub code: String,
+    /// Core has display/RTL metadata for this language.
+    pub known: bool,
+    /// English name, or `"Unknown"`.
+    pub display_name: &'static str,
+    /// Endonym, or `"Unknown"`.
+    pub native_name: &'static str,
+    /// `"ltr"` or `"rtl"`.
+    pub direction: &'static str,
+    /// Right-to-left script.
+    pub is_rtl: bool,
+    /// Core models a language-specific CLDR plural rule (not the generic
+    /// one/other fallback).
+    pub has_plural_rules: bool,
+}
+
+/// Query core's static knowledge of `code`. See [`LocaleInfo`].
+#[must_use]
+pub fn locale_info(code: &str) -> LocaleInfo {
+    let display_name = language_display_name(code);
+    LocaleInfo {
+        code: code.to_ascii_lowercase(),
+        known: display_name != "Unknown",
+        display_name,
+        native_name: language_native_name(code),
+        direction: text_direction(code),
+        is_rtl: is_rtl_language(code),
+        has_plural_rules: plural_category_is_explicit(code),
     }
 }
 
@@ -542,12 +572,20 @@ impl Translator {
         self.translate(locale, key, params)
     }
 
-    /// `true` when a catalog is registered for `locale` (or its base language).
+    /// `true` when strings are registered for `locale` (or its base
+    /// language) in **either** the file/programmatic catalogs or the DB
+    /// override layer (#532) — so a locale supplied only via
+    /// [`Self::load_overrides`] is reported as available too.
     #[must_use]
     pub fn has_locale(&self, locale: &str) -> bool {
-        let cats = self.catalogs.read().expect("translator poisoned");
         let req = Locale::new(locale);
-        cats.contains_key(&req) || cats.contains_key(&Locale::new(req.base_language()))
+        let base = Locale::new(req.base_language());
+        let cats = self.catalogs.read().expect("translator poisoned");
+        if cats.contains_key(&req) || cats.contains_key(&base) {
+            return true;
+        }
+        let ov = self.overrides.read().expect("translator poisoned");
+        ov.contains_key(&req) || ov.contains_key(&base)
     }
 
     /// All registered locale identifiers (for `negotiate_language`).
@@ -885,25 +923,50 @@ fn substitute(template: &str, params: &[(&str, &str)]) -> String {
 /// assert_eq!(plural_category("uk", 21), "one");       // Ukrainian: …1 (not 11)
 /// assert_eq!(plural_category("ja", 7), "other");      // no count distinction
 /// ```
+/// The CLDR plural *family* a base language belongs to, or `None` for the
+/// generic one/other rule (Germanic / Romance / everything unmodeled).
+/// Extracted so [`plural_category`] and [`plural_category_is_explicit`]
+/// share one classification and can't drift.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum PluralFamily {
+    /// No count-based form distinction (always `other`).
+    NoDistinction,
+    /// French / Brazilian-Portuguese: 0 and 1 are `one`.
+    FrenchStyle,
+    /// West-Slavic (Polish): one / few / many.
+    WestSlavic,
+    /// East-Slavic (Ukrainian, Russian, Belarusian): one / few / many.
+    EastSlavic,
+}
+
+fn plural_family(base: &str) -> Option<PluralFamily> {
+    match base {
+        "zh" | "ja" | "ko" | "th" | "vi" | "id" | "ms" | "lo" | "km" | "my" => {
+            Some(PluralFamily::NoDistinction)
+        }
+        "fr" | "pt" | "ff" | "hy" | "kab" => Some(PluralFamily::FrenchStyle),
+        "pl" => Some(PluralFamily::WestSlavic),
+        "uk" | "ru" | "be" => Some(PluralFamily::EastSlavic),
+        _ => None,
+    }
+}
+
 #[must_use]
 pub fn plural_category(locale: &str, n: i64) -> &'static str {
     let base = Locale::new(locale);
     let n = n.unsigned_abs();
     let r10 = n % 10;
     let r100 = n % 100;
-    match base.base_language() {
-        // East-Asian + others with no count-based form distinction.
-        "zh" | "ja" | "ko" | "th" | "vi" | "id" | "ms" | "lo" | "km" | "my" => "other",
-        // French / Brazilian-Portuguese style: 0 and 1 are "one".
-        "fr" | "pt" | "ff" | "hy" | "kab" => {
+    match plural_family(base.base_language()) {
+        Some(PluralFamily::NoDistinction) => "other",
+        Some(PluralFamily::FrenchStyle) => {
             if n == 0 || n == 1 {
                 "one"
             } else {
                 "other"
             }
         }
-        // West-Slavic (Polish): one / few / many.
-        "pl" => {
+        Some(PluralFamily::WestSlavic) => {
             if n == 1 {
                 "one"
             } else if (2..=4).contains(&r10) && !(12..=14).contains(&r100) {
@@ -912,8 +975,7 @@ pub fn plural_category(locale: &str, n: i64) -> &'static str {
                 "many"
             }
         }
-        // East-Slavic (Ukrainian, Russian, Belarusian): one / few / many.
-        "uk" | "ru" | "be" => {
+        Some(PluralFamily::EastSlavic) => {
             if r10 == 1 && r100 != 11 {
                 "one"
             } else if (2..=4).contains(&r10) && !(12..=14).contains(&r100) {
@@ -923,7 +985,7 @@ pub fn plural_category(locale: &str, n: i64) -> &'static str {
             }
         }
         // Germanic / Romance / default: one / other (n == 1 → one).
-        _ => {
+        None => {
             if n == 1 {
                 "one"
             } else {
@@ -931,6 +993,17 @@ pub fn plural_category(locale: &str, n: i64) -> &'static str {
             }
         }
     }
+}
+
+/// `true` when core models a *language-specific* CLDR plural rule for
+/// `locale` (French-style, West/East-Slavic, or no-distinction) — as
+/// opposed to the generic English one/other fallback. Note: this returns
+/// `false` for English/German/Spanish/etc., for which one/other is
+/// nonetheless correct; callers surfacing it should frame the fallback as
+/// "basic one/other", not an error. Backs [`LocaleInfo::has_plural_rules`].
+#[must_use]
+pub fn plural_category_is_explicit(locale: &str) -> bool {
+    plural_family(Locale::new(locale).base_language()).is_some()
 }
 
 // ------------------------------------------------------------------ Accept-Language negotiation
@@ -1188,6 +1261,48 @@ mod tests {
         for code in ["no", "nb", "nn", "nb-NO", "nn-NO"] {
             assert_eq!(Locale::new(code).display_name(), "Norwegian", "{code}");
             assert_eq!(Locale::new(code).native_name(), "norsk", "{code}");
+        }
+    }
+
+    #[test]
+    fn locale_info_summarizes_core_support() {
+        let fr = locale_info("fr-CA");
+        assert!(fr.known);
+        assert_eq!(fr.display_name, "French");
+        assert!(!fr.is_rtl && fr.direction == "ltr");
+        assert!(fr.has_plural_rules); // French-style family
+
+        let ar = locale_info("ar");
+        assert!(ar.known && ar.is_rtl && ar.direction == "rtl");
+
+        let en = locale_info("EN");
+        assert_eq!(en.code, "en"); // lowercased
+        assert!(en.known && !en.has_plural_rules); // generic one/other
+
+        let xx = locale_info("xx");
+        assert!(!xx.known && xx.display_name == "Unknown" && !xx.is_rtl && !xx.has_plural_rules);
+    }
+
+    #[test]
+    fn known_locales_lists_canonical_codes_only() {
+        let codes: Vec<&str> = known_locales().map(|(c, _)| c).collect();
+        assert!(codes.contains(&"en") && codes.contains(&"zh") && codes.contains(&"ar"));
+        // Retired / variant aliases are excluded from the picker set …
+        assert!(!codes.contains(&"iw") && !codes.contains(&"nb") && !codes.contains(&"ji"));
+        // … but still resolve through the name lookups.
+        assert_eq!(language_display_name("iw"), "Hebrew");
+    }
+
+    #[test]
+    fn plural_explicit_flag_matches_families() {
+        for c in ["pl", "uk", "ru", "zh-Hans", "fr", "pt-BR", "ja"] {
+            assert!(
+                plural_category_is_explicit(c),
+                "{c} has a language-specific rule"
+            );
+        }
+        for c in ["en", "de", "es", "xx"] {
+            assert!(!plural_category_is_explicit(c), "{c} uses the generic rule");
         }
     }
 

--- a/crates/rustango/src/manage.rs
+++ b/crates/rustango/src/manage.rs
@@ -1513,6 +1513,7 @@ mod tests {
             header_name: "X-Custom-CSRF".into(),
             secure: true,
             trusted_origins: Vec::new(),
+            exempt_prefixes: Vec::new(),
         });
         let csrf = cli.csrf.expect("with_csrf_config should set csrf");
         assert_eq!(csrf.cookie_name, "custom_csrf");


### PR DESCRIPTION
## Why
Downstream consumers (notably rustango-cms, which manages its own DB-backed
content-locale roster in `cms_locale`) need to reconcile their locale list
with the framework's **compile-time** locale support without re-implementing
core's metadata tables or brittly string-comparing `"Unknown"`. Today core's
"support" is spread across unsynchronized surfaces (catalogs, the negotiation
allowlist, and the hardcoded RTL/display-name/plural `match` tables) and an
unknown code degrades silently. This adds a single query for what core
statically knows, so a consumer can validate + surface the gap and degrade
gracefully.

## What
**`feat(i18n): locale capability registry`** (main commit)
- `locale_info(code) -> LocaleInfo { known, display_name, native_name, direction, is_rtl, has_plural_rules }`.
- `known_locales()` — iterator of `(code, English name)` for pickers/datalists.
- `plural_category_is_explicit(code)` — does core model a language-specific CLDR rule (vs the generic one/other fallback)?
- **De-dup refactor:** the two parallel ~41-arm `language_display_name` / `language_native_name` match tables collapse into one `LANGUAGE_NAMES` source (+ a `canonical_base` alias map preserving `iw`→he, `nb`/`nn`→no, `ji`→yi), and `plural_family()` is extracted so `plural_category` and the new flag share one classification and can't drift. **Behavior preserved** — existing display/native/plural tests still pass, plus 3 new tests.
- `has_locale()` now also consults the DB override layer (#532), so a locale supplied only via `load_overrides` is reported available.
- Fixes a pre-existing `CsrfConfig` test literal missing `exempt_prefixes` that broke the lib test build.

## Note
This branch also carries the previously-local, unpushed commit
**`feat(csrf): add CsrfConfig::exempt_prefix`** (the i18n test fix depends on
it). Both land on `develop` together.

## Test
`cargo test -p rustango --lib i18n::` → 93 passed (90 existing + 3 new:
`locale_info_summarizes_core_support`, `known_locales_lists_canonical_codes_only`,
`plural_explicit_flag_matches_families`). No public signature changes; all
additions are additive `pub`.