### PR TITLE
ci: notify the docs site on release

### DIFF
--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -1,0 +1,36 @@
+name: Notify docs site of release
+
+# On every published release, ping the docs site (ujeenet/rustango-docs) so it
+# re-syncs its versioned docs. The docs site pulls each curated release tag's
+# docs/ straight from GitHub, so this just triggers its re-seed/redeploy.
+#
+# Requires a repo secret DOCS_DISPATCH_TOKEN: a (fine-grained) PAT allowed to
+# send repository_dispatch to ujeenet/rustango-docs (Contents: read + the
+# repo's "Dispatch" permission). Absent → the job no-ops with a warning.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: repository_dispatch → rustango-docs
+        env:
+          TOKEN: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::warning::DOCS_DISPATCH_TOKEN not set — skipping docs-site notification for $TAG."
+            exit 0
+          fi
+          curl -fsS -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/ujeenet/rustango-docs/dispatches \
+            -d "{\"event_type\":\"docs-release\",\"client_payload\":{\"tag\":\"${TAG}\"}}"
+          echo "Notified rustango-docs of release ${TAG}."

--- a/crates/rustango/src/forms/csrf.rs
+++ b/crates/rustango/src/forms/csrf.rs
@@ -118,6 +118,15 @@ pub struct CsrfConfig {
     /// attacker steals the cookie token, they can't submit from a
     /// different origin.
     pub trusted_origins: Vec<String>,
+    /// URL path prefixes exempt from CSRF enforcement on unsafe
+    /// methods. Default `[]`. Intended for `navigator.sendBeacon`
+    /// collector endpoints (e.g. analytics), which cannot set an
+    /// `X-CSRF-Token` header and — when the page is served from a CDN
+    /// cache that strips `Set-Cookie` — may have no CSRF cookie at all.
+    /// Each entry is matched with `req.uri().path().starts_with(prefix)`,
+    /// so keep prefixes narrow and only exempt append-only endpoints
+    /// that read/write no auth state.
+    pub exempt_prefixes: Vec<String>,
 }
 
 impl Default for CsrfConfig {
@@ -127,6 +136,7 @@ impl Default for CsrfConfig {
             header_name: CSRF_HEADER.to_owned(),
             secure: true,
             trusted_origins: Vec::new(),
+            exempt_prefixes: Vec::new(),
         }
     }
 }
@@ -161,6 +171,18 @@ impl CsrfConfig {
         S: Into<String>,
     {
         self.trusted_origins = origins.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Builder — exempt a URL path prefix from CSRF enforcement on
+    /// unsafe methods. For beacon/collector endpoints posted via
+    /// `navigator.sendBeacon` (which cannot set a custom header) and
+    /// reachable from CDN-cached pages that never received a CSRF
+    /// cookie. Only exempt append-only endpoints that touch no auth
+    /// state; keep the prefix narrow.
+    #[must_use]
+    pub fn exempt_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.exempt_prefixes.push(prefix.into());
         self
     }
 }
@@ -297,8 +319,11 @@ where
         Box::pin(async move {
             let cookie_value = read_csrf_cookie(&req, &cfg.cookie_name);
 
-            // Enforce on unsafe methods.
-            let req = if !is_safe_method(req.method()) {
+            // Enforce on unsafe methods — unless the path is exempt
+            // (beacon/collector endpoints; see `CsrfConfig::exempt_prefix`).
+            let req = if !is_safe_method(req.method())
+                && !path_is_exempt(req.uri().path(), &cfg.exempt_prefixes)
+            {
                 // Origin-header defense-in-depth. Skipped when
                 // `trusted_origins` is empty (back-compat default).
                 if !origin_allowed(&req, &cfg.trusted_origins) {
@@ -380,6 +405,12 @@ where
 /// — the middleware can't safely buffer megabyte-scale form
 /// payloads in memory just to verify a token.
 const BODY_BUFFER_LIMIT: usize = 64 * 1024;
+
+/// `true` when `path` starts with any configured exempt prefix. Used to
+/// skip CSRF enforcement for beacon/collector endpoints.
+fn path_is_exempt(path: &str, prefixes: &[String]) -> bool {
+    prefixes.iter().any(|p| path.starts_with(p.as_str()))
+}
 
 fn is_safe_method(m: &Method) -> bool {
     matches!(
@@ -702,6 +733,26 @@ mod tests {
         assert!(!is_safe_method(&Method::POST));
         assert!(!is_safe_method(&Method::PUT));
         assert!(!is_safe_method(&Method::DELETE));
+    }
+
+    #[test]
+    fn exempt_prefix_matches_only_configured_paths() {
+        let prefixes = vec!["/__cms__/collect".to_owned()];
+        // Exact + sub-path match (prefix semantics).
+        assert!(path_is_exempt("/__cms__/collect", &prefixes));
+        assert!(path_is_exempt("/__cms__/collect/extra", &prefixes));
+        // Unrelated paths still enforced.
+        assert!(!path_is_exempt("/__cms__/other", &prefixes));
+        assert!(!path_is_exempt("/forms/submit/1", &prefixes));
+        assert!(!path_is_exempt("/", &prefixes));
+        // Empty config exempts nothing (back-compat default).
+        assert!(!path_is_exempt("/__cms__/collect", &[]));
+    }
+
+    #[test]
+    fn exempt_prefix_builder_appends() {
+        let cfg = CsrfConfig::default().exempt_prefix("/__cms__/collect");
+        assert_eq!(cfg.exempt_prefixes, vec!["/__cms__/collect".to_owned()]);
     }
 
     #[test]


### PR DESCRIPTION
## Why
The docs site (`ujeenet/rustango-docs`) now publishes **one docs version per
framework release tag**, pulled straight from GitHub (rustango-docs PR #91).
This closes the loop: on every published release, ping the docs site so it
re-syncs.

## What
`.github/workflows/notify-docs.yml` — on `release: published`, sends a
`repository_dispatch` (`event_type: docs-release`, `client_payload.tag`) to
`ujeenet/rustango-docs`, whose `docs-sync.yml` triggers its redeploy/re-seed.

- Requires a repo secret **`DOCS_DISPATCH_TOKEN`** (a fine-grained PAT that
  can send `repository_dispatch` to `ujeenet/rustango-docs`). When the secret
  is absent the job no-ops with a warning, so it's safe to merge before the
  secret is configured.
- `permissions: contents: read` only; no write scope on this repo.

## Note
Publishing a *new* version's docs still requires adding its tag to the docs
site's curated `DOC_TAGS` allowlist (see rustango-docs PR #91); this workflow
triggers the re-sync, it doesn't auto-add versions.