### PR TITLE
release: 0.45.0 — version bump + CHANGELOG + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 _Nothing yet — next development cycle._
 
+## [0.45.0] — 2026-07-03
+
+Headline: **i18n depth** — CLDR plural-rules and a locale capability registry — plus a CSRF escape hatch for beacon/collector endpoints.
+
+### Added
+
+- **CLDR plural-rules** (#1103) — `plural_category(lang, n)` returns the CLDR plural category (`one` / `few` / `many` / `other` / …) for a count, and `translate_plural` selects the matching per-category message from a catalog. Language-specific rules for the common families (Slavic few/many, French 0-is-one, …); the generic one/other fallback covers the rest.
+- **Locale capability registry** — `locale_info(code) -> LocaleInfo` exposes core's static per-locale metadata (display + native name, text direction / RTL, whether an explicit CLDR plural rule is modeled, and a `known` flag), and `known_locales()` yields the English-named roster. Lets callers query what core supports instead of string-matching `"Unknown"`.
+- **`CsrfConfig::exempt_prefix`** — exempt URL path prefixes from CSRF enforcement on unsafe methods. Intended for `navigator.sendBeacon` collector endpoints (e.g. analytics) that cannot set an `X-CSRF-Token` header and — behind a CDN cache that strips `Set-Cookie` — may carry no CSRF cookie at all.
+
+### Changed
+
+- **Docs** — capitalize "Rustango" in prose, fix `cargo` command casing, refresh version references to 0.44+, document the locale capability registry and CLDR plural support, and link the live docs site from the README.
+
 ## [0.44.0] — 2026-06-25
 
 Headline: the **MCP server** — rustango can now expose its skills, tools, prompts, and resources to AI agents over the Model Context Protocol (Streamable HTTP transport, OAuth 2.1, scoped-JWT agent identity). Plus **ViewSets married to serializers** (declarative render + validate, tri-dialect), a batch of **Django-parity ORM** features (relation-spanning `order_by`, related-column `GROUP BY`, `distinct_on` on MySQL/SQLite, `generated_as` refresh on save), and a comprehensive documentation pass. Folds in the never-tagged v0.43.1 scaffolder/`rpassword` patch.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.44.0"
+version = "0.45.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.44.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.44.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.44.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.45.0", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.45.0", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.45.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/README.md
+++ b/README.md
@@ -10,25 +10,33 @@
 
 Every feature works on every supported backend out of the box. The only PG-specific surface is schema-mode tenancy, a connection-pool optimization for high-N SaaS — see the [storage modes table](#multi-tenancy) below for when it matters.
 
+📚 **Documentation:** full guides & tutorials at **[rustango.im-fullstack.dev](https://rustango.im-fullstack.dev)** · [getting started](docs/getting-started.md) · [all guides](docs/) · [CHANGELOG](CHANGELOG.md). API reference (published releases): [docs.rs/rustango](https://docs.rs/rustango).
+
 ```toml
 [dependencies]
 # Postgres (default)
-rustango = "0.42"
+rustango = "0.44"
 
 # SQLite — file-backed or in-memory, full tri-dialect framework
-rustango = { version = "0.42", default-features = false, features = ["sqlite", "tenancy", "admin", "manage"] }
+rustango = { version = "0.44", default-features = false, features = ["sqlite", "tenancy", "admin", "manage"] }
 
 # MySQL 8+
-rustango = { version = "0.42", default-features = false, features = ["mysql", "tenancy", "admin", "manage"] }
+rustango = { version = "0.44", default-features = false, features = ["mysql", "tenancy", "admin", "manage"] }
 
 # Multiple backends in one binary
-rustango = { version = "0.42", features = ["postgres", "sqlite"] }
+rustango = { version = "0.44", features = ["postgres", "sqlite"] }
 
 # Renaming the dep — `#[derive(Model)]` etc. resolve the crate root
 # via `proc-macro-crate` (issue #142), so importing under a custom
 # name works without any extra wiring.
-orm = { package = "rustango", version = "0.42" }
+orm = { package = "rustango", version = "0.44" }
 ```
+
+### What's new in v0.44.0 (June 2026) — MCP server + ViewSets↔serializers
+
+**Headline: the [MCP server](docs/mcp.md).** Rustango can expose its skills, tools, prompts, and resources to AI agents over the Model Context Protocol — JSON-RPC 2.0 over Streamable HTTP, OAuth 2.1 discovery, scoped-JWT agent identity — opt-in via the `mcp` feature. Plus **ViewSets married to serializers** (declarative render + validate, tri-dialect), a batch of **Django-parity ORM** features (relation-spanning `order_by`, related-column `GROUP BY`, `distinct_on` on MySQL/SQLite, `generated_as` refresh on save via `RETURNING`), and a comprehensive documentation pass. Full detail in the [CHANGELOG](CHANGELOG.md).
+
+_Landed since 0.44.0 (in `develop`, not yet tagged):_ CLDR plural-rules (`plural_category` / `translate_plural`, [#1103](https://github.com/ujeenet/rustango/pull/1103)), a locale capability registry (`locale_info` / `known_locales`), and `CsrfConfig::exempt_prefix` for beacon/collector endpoints.
 
 ### What's new in v0.42.0 (May 2026) — Django-parity gap-closure batch
 
@@ -3052,10 +3060,11 @@ Then verify your stack has:
 
 ## Documentation
 
-- **API docs**: <https://docs.rs/rustango>
-- **Tutorial**: see `docs/getting-started.md`
-- **CHANGELOG**: see `CHANGELOG.md`
-- **Source**: <https://github.com/cot-rs/rustango>
+- **Guides & tutorials (latest)**: <https://rustango.im-fullstack.dev> — getting started, ORM, auth, admin, jobs, MCP, i18n, and more.
+- **API reference**: <https://docs.rs/rustango> (published releases)
+- **In-repo guides**: [`docs/`](docs/) — e.g. [getting-started](docs/getting-started.md), [models](docs/models.md), [orm](docs/orm.md), [auth-flows](docs/auth-flows.md), [admin](docs/admin.md), [mcp](docs/mcp.md), [i18n](docs/i18n.md).
+- **CHANGELOG**: [`CHANGELOG.md`](CHANGELOG.md)
+- **Source**: <https://github.com/ujeenet/rustango>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@ rustango = { version = "0.44", features = ["postgres", "sqlite"] }
 orm = { package = "rustango", version = "0.44" }
 ```
 
+### What's new in v0.45.0 (July 2026) — i18n depth
+
+**CLDR plural-rules + a locale capability registry.** `plural_category(lang, n)` returns the CLDR category (`one` / `few` / `many` / `other` / …) and `translate_plural` picks the matching message ([#1103](https://github.com/ujeenet/rustango/pull/1103)); `locale_info(code)` / `known_locales()` expose core's static per-locale metadata (display + native name, direction / RTL, whether an explicit plural rule is modeled) so callers can query support instead of string-matching `"Unknown"`. Plus `CsrfConfig::exempt_prefix` — a narrow CSRF escape hatch for `sendBeacon` collector endpoints (e.g. analytics) that can't send a token header. See [docs/i18n.md](docs/i18n.md) and the [CHANGELOG](CHANGELOG.md).
+
 ### What's new in v0.44.0 (June 2026) — MCP server + ViewSets↔serializers
 
 **Headline: the [MCP server](docs/mcp.md).** Rustango can expose its skills, tools, prompts, and resources to AI agents over the Model Context Protocol — JSON-RPC 2.0 over Streamable HTTP, OAuth 2.1 discovery, scoped-JWT agent identity — opt-in via the `mcp` feature. Plus **ViewSets married to serializers** (declarative render + validate, tri-dialect), a batch of **Django-parity ORM** features (relation-spanning `order_by`, related-column `GROUP BY`, `distinct_on` on MySQL/SQLite, `generated_as` refresh on save via `RETURNING`), and a comprehensive documentation pass. Full detail in the [CHANGELOG](CHANGELOG.md).
-
-_Landed since 0.44.0 (in `develop`, not yet tagged):_ CLDR plural-rules (`plural_category` / `translate_plural`, [#1103](https://github.com/ujeenet/rustango/pull/1103)), a locale capability registry (`locale_info` / `known_locales`), and `CsrfConfig::exempt_prefix` for beacon/collector endpoints.
 
 ### What's new in v0.42.0 (May 2026) — Django-parity gap-closure batch
 

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.44.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.45.0" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -376,7 +376,7 @@ runserver = ["dep:axum", "dep:tokio"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.44.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.45.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -356,8 +356,10 @@ In Tera templates, `{{ csrf_token }}` gives the raw token and `{{ csrf_input }}`
 a ready-made hidden `<input name="_csrf">` — drop one in every form. Override
 the cookie/header names or the `Secure` flag with `csrf::with_config(CsrfConfig)`;
 for SPA setups, add `.with_trusted_origins([...])` to enable the Origin-header
-defense-in-depth check on top of the token. The auto-admin enables CSRF on
-every mutation with no opt-out.
+defense-in-depth check on top of the token. For append-only collector endpoints
+hit via `navigator.sendBeacon` (e.g. analytics) that can't send a token header,
+`CsrfConfig::exempt_prefix("/path")` skips enforcement for a narrow path prefix.
+The auto-admin enables CSRF on every mutation with no opt-out.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -220,6 +220,8 @@ let app = Router::new()
 
 `csrf::layer()` builds the layer with sensible defaults; `csrf::with_config(CsrfConfig)` lets you override the cookie/header names and the `Secure` flag. In templates, `{{ csrf_token }}` gives you the raw token and `{{ csrf_input }}` gives you a ready-made hidden `<input>` — drop one inside every form. It uses the double-submit cookie pattern: on unsafe methods (POST, PUT, PATCH, DELETE) the layer checks the `X-CSRF-Token` header (or the `_csrf` form field) against the `rustango_csrf` cookie; a mismatch returns `403 Forbidden`.
 
+**Exempting collector endpoints.** `CsrfConfig::exempt_prefix("/path")` (repeatable) skips CSRF enforcement for unsafe methods on requests whose path starts with the given prefix. This is for append-only, no-auth-state endpoints hit via `navigator.sendBeacon` — e.g. an analytics collector — which can't set an `X-CSRF-Token` header and, when the page is served from a CDN cache that strips `Set-Cookie`, may carry no CSRF cookie at all. Keep prefixes narrow and never exempt anything that reads or writes auth state.
+
 The auto-admin enables CSRF on every mutation by default, and there is no way to opt out.
 
 ---


### PR DESCRIPTION
Syncs `develop` with the **0.45.0** release. The crates are already published to crates.io (rustango, rustango-macros, rustango-orm-macros, cargo-rustango @ 0.45.0) and `v0.45.0` is tagged; this PR lands the release metadata on `develop`.

`develop` already carries the code features via prior PRs — CLDR plural-rules (#1103) and the locale capability registry + `CsrfConfig::exempt_prefix` (#1104). This PR adds only:

- **Version bump** 0.44.0 → 0.45.0 (workspace + internal dep pins).
- **CHANGELOG** — new `[0.45.0]` section (CLDR plurals, locale registry, `exempt_prefix`).
- **README** — live docs link (rustango.im-fullstack.dev) up top, "What's new in v0.45.0" section, install pins `→ 0.44`, and a fixed Documentation section (was pointing at the wrong repo `cot-rs/rustango`).
- **Docs** — document `CsrfConfig::exempt_prefix` in security.md + middleware.md (it had no coverage).

Merge unblocks nothing on crates.io (already live); it just keeps git in sync with the published release.