### PR TITLE
feat(http): treat QUERY as a safe, idempotent method across the sweep (#1110)

### DIFF
--- a/crates/rustango/src/cors.rs
+++ b/crates/rustango/src/cors.rs
@@ -22,7 +22,7 @@
 //!
 //! let cors = CorsLayer::new()
 //!     .allow_origins(vec!["https://app.example.com", "https://admin.example.com"])
-//!     .allow_methods(vec!["GET", "POST", "PUT", "PATCH", "DELETE"])
+//!     .allow_methods(vec!["GET", "POST", "PUT", "PATCH", "DELETE", "QUERY"])
 //!     .allow_headers(vec!["content-type", "authorization"])
 //!     .allow_credentials(true)
 //!     .max_age(Duration::from_secs(3600));
@@ -101,6 +101,10 @@ impl CorsLayer {
                 "DELETE".into(),
                 "HEAD".into(),
                 "OPTIONS".into(),
+                // RFC 10008 — QUERY always triggers a preflight (never
+                // CORS-safelisted), so it must be advertised here to work
+                // cross-origin.
+                "QUERY".into(),
             ],
             allow_headers: vec!["*".into()],
             expose_headers: Vec::new(),
@@ -175,7 +179,9 @@ impl CorsLayer {
         Some(
             Self::new()
                 .allow_origins(s.cors_allowed_origins.iter().cloned())
-                .allow_methods(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"])
+                .allow_methods([
+                    "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "QUERY",
+                ])
                 .allow_headers(["Content-Type", "Authorization"])
                 .max_age(Duration::from_secs(3600)),
         )
@@ -433,6 +439,18 @@ mod tests {
     fn permissive_allows_any() {
         let l = CorsLayer::permissive();
         assert!(l.resolve_origin(Some("https://anywhere.test")).is_some());
+    }
+
+    #[test]
+    fn permissive_advertises_query_method() {
+        // RFC 10008 QUERY always triggers a preflight, so it must be in
+        // Access-Control-Allow-Methods to work cross-origin.
+        let l = CorsLayer::permissive();
+        assert!(
+            l.allow_methods.iter().any(|m| m == "QUERY"),
+            "permissive CORS must allow QUERY: {:?}",
+            l.allow_methods
+        );
     }
 
     // ---- #87 wiring: from_settings ----

--- a/crates/rustango/src/forms/csrf.rs
+++ b/crates/rustango/src/forms/csrf.rs
@@ -127,6 +127,26 @@ pub struct CsrfConfig {
     /// so keep prefixes narrow and only exempt append-only endpoints
     /// that read/write no auth state.
     pub exempt_prefixes: Vec<String>,
+    /// Enforce CSRF on the HTTP `QUERY` method (RFC 10008). Default
+    /// `false` — QUERY is a *safe* method, browsers can't form-submit it,
+    /// and a cross-origin `fetch` with method `QUERY` is never a
+    /// CORS-safelisted "simple request", so it always triggers a preflight
+    /// and carries no ambient-credential CSRF vector. It is therefore
+    /// exempt like GET/HEAD/OPTIONS/TRACE. Set `true` for pure
+    /// defense-in-depth if you want a token required on QUERY anyway.
+    ///
+    /// The default exemption stays safe only while two things hold — both
+    /// true out of the box:
+    /// - **QUERY handlers are side-effect-free.** RFC 10008 defines QUERY
+    ///   as safe + idempotent; mount only read-only handlers on it (a
+    ///   mutation on QUERY would have no token check under the default).
+    /// - **`QUERY` is never added to the method-override allow-list**
+    ///   ([`crate::method_override`], default `[PUT, PATCH, DELETE]`).
+    ///   Allowing a form POST to be rewritten to QUERY would manufacture
+    ///   the ambient-credential request the exemption assumes can't exist.
+    ///
+    /// If you can't guarantee both, set this to `true`.
+    pub require_csrf_on_query: bool,
 }
 
 impl Default for CsrfConfig {
@@ -137,6 +157,7 @@ impl Default for CsrfConfig {
             secure: true,
             trusted_origins: Vec::new(),
             exempt_prefixes: Vec::new(),
+            require_csrf_on_query: false,
         }
     }
 }
@@ -321,7 +342,7 @@ where
 
             // Enforce on unsafe methods — unless the path is exempt
             // (beacon/collector endpoints; see `CsrfConfig::exempt_prefix`).
-            let req = if !is_safe_method(req.method())
+            let req = if !method_is_csrf_exempt(req.method(), &cfg)
                 && !path_is_exempt(req.uri().path(), &cfg.exempt_prefixes)
             {
                 // Origin-header defense-in-depth. Skipped when
@@ -417,6 +438,15 @@ fn is_safe_method(m: &Method) -> bool {
         *m,
         Method::GET | Method::HEAD | Method::OPTIONS | Method::TRACE
     )
+}
+
+/// Whether `m` is exempt from CSRF token enforcement. The classic safe
+/// methods always are; the RFC 10008 `QUERY` method is too (a safe method
+/// with no browser CSRF vector) unless [`CsrfConfig::require_csrf_on_query`]
+/// opts it back in. `QUERY` is matched by name so this stays independent
+/// of the `admin`-gated `http_query` module.
+fn method_is_csrf_exempt(m: &Method, cfg: &CsrfConfig) -> bool {
+    is_safe_method(m) || (!cfg.require_csrf_on_query && m.as_str() == "QUERY")
 }
 
 fn read_csrf_cookie(req: &Request<Body>, name: &str) -> Option<String> {
@@ -733,6 +763,28 @@ mod tests {
         assert!(!is_safe_method(&Method::POST));
         assert!(!is_safe_method(&Method::PUT));
         assert!(!is_safe_method(&Method::DELETE));
+    }
+
+    #[test]
+    fn query_method_is_csrf_exempt_by_default() {
+        let query = Method::from_bytes(b"QUERY").unwrap();
+        let cfg = CsrfConfig::default();
+        // QUERY exempt by default (safe method, no browser CSRF vector)…
+        assert!(method_is_csrf_exempt(&query, &cfg));
+        // …but still not a mutating method like POST.
+        assert!(!method_is_csrf_exempt(&Method::POST, &cfg));
+    }
+
+    #[test]
+    fn require_csrf_on_query_opts_query_back_in() {
+        let query = Method::from_bytes(b"QUERY").unwrap();
+        let cfg = CsrfConfig {
+            require_csrf_on_query: true,
+            ..CsrfConfig::default()
+        };
+        assert!(!method_is_csrf_exempt(&query, &cfg));
+        // Classic safe methods are unaffected by the knob.
+        assert!(method_is_csrf_exempt(&Method::GET, &cfg));
     }
 
     #[test]

--- a/crates/rustango/src/http_client.rs
+++ b/crates/rustango/src/http_client.rs
@@ -386,7 +386,10 @@ impl RequestBuilder {
 }
 
 fn is_method_idempotent(m: &Method) -> bool {
-    matches!(*m, Method::GET | Method::HEAD | Method::OPTIONS)
+    // QUERY (RFC 10008) is safe + idempotent, so it's retry-safe like GET.
+    // Matched by name to stay independent of the `admin`-gated `http_query`
+    // module.
+    matches!(*m, Method::GET | Method::HEAD | Method::OPTIONS) || m.as_str() == "QUERY"
 }
 
 fn is_status_retryable(s: StatusCode) -> bool {
@@ -434,6 +437,8 @@ mod tests {
         assert!(!is_method_idempotent(&Method::PUT));
         assert!(!is_method_idempotent(&Method::PATCH));
         assert!(!is_method_idempotent(&Method::DELETE));
+        // QUERY (RFC 10008) is safe + idempotent → retry-safe.
+        assert!(is_method_idempotent(&Method::from_bytes(b"QUERY").unwrap()));
     }
 
     #[test]

--- a/crates/rustango/src/idempotency.rs
+++ b/crates/rustango/src/idempotency.rs
@@ -12,6 +12,11 @@
 //!
 //! Requests without the header pass straight through unmodified.
 //!
+//! Note: the RFC 10008 `QUERY` method needs no `Idempotency-Key` — QUERY
+//! is idempotent by definition, so a retried QUERY is inherently safe.
+//! This middleware defaults to the mutating methods (POST/PUT/PATCH/DELETE)
+//! and deliberately does not cover QUERY.
+//!
 //! ## Quick start
 //!
 //! ```ignore

--- a/crates/rustango/src/manage.rs
+++ b/crates/rustango/src/manage.rs
@@ -1514,6 +1514,7 @@ mod tests {
             secure: true,
             trusted_origins: Vec::new(),
             exempt_prefixes: Vec::new(),
+            ..Default::default()
         });
         let csrf = cli.csrf.expect("with_csrf_config should set csrf");
         assert_eq!(csrf.cookie_name, "custom_csrf");


### PR DESCRIPTION
Third slice of the HTTP QUERY epic (#1107). Closes #1110. Independent of Slices 1–2 (different files).

## What

Teach the framework's "which methods are safe / idempotent" policies about RFC 10008 `QUERY` (safe + idempotent — a GET with a body).

- **CSRF** ([forms/csrf.rs]) — QUERY is exempt from token enforcement by default, alongside GET/HEAD/OPTIONS/TRACE. New `CsrfConfig::require_csrf_on_query` (default `false`) opts it back in.
- **http_client** — `is_method_idempotent` now includes QUERY, so it's retried on transient failures like GET.
- **CORS** — QUERY added to `permissive()` and the `from_settings` method list (QUERY always triggers a preflight, so it must be advertised to work cross-origin).
- **idempotency** — doc note that QUERY needs no `Idempotency-Key` (it's inherently idempotent).

QUERY is matched by name (`m.as_str() == "QUERY"`) in the `csrf` / `http-client` modules so they stay independent of the `admin`-gated `http_query` module (those features can build without `admin`).

## Why the CSRF exemption is safe

Verified by a dedicated security review:
- HTML `<form method>` only accepts get/post/dialog — a browser can't form-submit QUERY.
- QUERY is not a CORS-safelisted method ({GET, HEAD, POST}), so any cross-origin `fetch` with method QUERY **always** triggers a preflight; the browser won't send the credentialed request without server CORS opt-in.
- No preflight-free browser surface (img/script/link/beacon/navigation/WebSocket) can emit QUERY.

Residual risks are operator-misconfiguration only, and both are documented on the `require_csrf_on_query` field: QUERY handlers must stay side-effect-free, and QUERY must never be added to the method-override allow-list (which could rewrite a form POST into a QUERY). If either can't be guaranteed, set `require_csrf_on_query = true`.

## Tests

- CSRF: QUERY exempt by default; `require_csrf_on_query = true` re-enables enforcement; POST still requires a token.
- http_client: QUERY classified idempotent (retry-safe).
- CORS: `permissive()` advertises QUERY.

Audit-only middleware (`access_log`, `metrics`, `server_timing`) has no method allowlist — QUERY flows through unchanged (verified, no code change).

Part of epic #1107.
