### PR TITLE
feat(client): .query() builders for TestClient / RequestFactory / http_client (#1113)

### DIFF
--- a/crates/rustango/src/http_client.rs
+++ b/crates/rustango/src/http_client.rs
@@ -154,6 +154,14 @@ impl HttpClient {
     pub fn head(&self, url: impl IntoUrl) -> RequestBuilder {
         self.request(Method::HEAD, url)
     }
+    /// Build a `QUERY` request (RFC 10008) — a safe, idempotent read with
+    /// a body. Classified idempotent, so it's retried by default like GET.
+    pub fn query(&self, url: impl IntoUrl) -> RequestBuilder {
+        self.request(
+            Method::from_bytes(b"QUERY").expect("QUERY is a valid method token"),
+            url,
+        )
+    }
 
     pub fn request(&self, method: Method, url: impl IntoUrl) -> RequestBuilder {
         RequestBuilder {
@@ -481,6 +489,28 @@ mod tests {
         let resp = client.get(url).send().await.unwrap();
         assert_eq!(resp.status(), 200);
         assert_eq!(resp.text().await.unwrap(), "hello");
+        srv.abort();
+    }
+
+    #[tokio::test]
+    async fn query_method_and_body_go_over_the_wire() {
+        // `any` accepts the extension method; the handler echoes method +
+        // body so we can prove the connector sent QUERY with its body.
+        let app = Router::new().route(
+            "/",
+            axum::routing::any(|m: Method, body: String| async move { format!("{m}:{body}") }),
+        );
+        let (url, srv) = start(app).await;
+
+        let client = HttpClient::builder().build().unwrap();
+        let resp = client
+            .query(url)
+            .body(b"q=x".to_vec())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        assert_eq!(resp.text().await.unwrap(), "QUERY:q=x");
         srv.abort();
     }
 

--- a/crates/rustango/src/test_client/mod.rs
+++ b/crates/rustango/src/test_client/mod.rs
@@ -275,6 +275,14 @@ impl TestClient {
         self.request(Method::HEAD, path)
     }
 
+    /// Build a `QUERY` request to `path` (RFC 10008). Pair with
+    /// `.form(...)` or `.json(...)` to send the query criteria in the
+    /// body; see [`crate::http_query`] and [`crate::params::Params`].
+    #[must_use]
+    pub fn query(&self, path: impl Into<String>) -> RequestBuilder<'_> {
+        self.request(crate::http_query::QUERY.clone(), path)
+    }
+
     /// Build a request with the given method.
     #[must_use]
     pub fn request(&self, method: Method, path: impl Into<String>) -> RequestBuilder<'_> {
@@ -517,6 +525,12 @@ impl RequestFactory {
     pub fn options(self, path: &str) -> FactoryRequestBuilder {
         FactoryRequestBuilder::new(Method::OPTIONS, path)
     }
+
+    /// Build a `QUERY` request to `path` (RFC 10008).
+    #[must_use]
+    pub fn query(self, path: &str) -> FactoryRequestBuilder {
+        FactoryRequestBuilder::new(crate::http_query::QUERY.clone(), path)
+    }
 }
 
 /// Chained builder returned by [`RequestFactory`] verb methods. Finalize
@@ -701,6 +715,7 @@ fn url_encode(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::http_query::QueryRouterExt;
     use axum::routing::{get, post};
     use serde_json::json;
 
@@ -708,6 +723,10 @@ mod tests {
         Router::new()
             .route("/hello", get(|| async { "hi" }))
             .route("/echo", post(|body: String| async move { body }))
+            .route(
+                "/search",
+                get(|| async { "list" }).query(|body: String| async move { format!("q:{body}") }),
+            )
             .route(
                 "/json",
                 post(|body: axum::Json<serde_json::Value>| async move {
@@ -746,6 +765,25 @@ mod tests {
         let r = c.post("/echo").body("hello world").send().await;
         assert_eq!(r.status, 200);
         assert_eq!(r.text(), "hello world");
+    }
+
+    #[tokio::test]
+    async fn query_builder_sends_query_method_with_body() {
+        let c = TestClient::new(app());
+        // GET and QUERY share the path; the QUERY builder hits the QUERY
+        // handler and its body round-trips.
+        let g = c.get("/search").send().await;
+        assert_eq!(g.text(), "list");
+        let r = c.query("/search").form(&[("q", "x")]).send().await;
+        assert_eq!(r.status, 200);
+        assert_eq!(r.text(), "q:q=x");
+    }
+
+    #[tokio::test]
+    async fn request_factory_builds_query_request() {
+        let req = RequestFactory::new().query("/search").build();
+        assert_eq!(req.method().as_str(), "QUERY");
+        assert_eq!(req.uri().path(), "/search");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Client-side `.query()` builders for the HTTP QUERY epic (#1107). Closes #1113. Builds on Slices 1–2.

## What

Adds `QUERY` (RFC 10008) request builders wherever the framework builds requests:

- **TestClient::query(path)** — `client.query("/search").form(&[("q","x")]).send()`, alongside `get`/`post`/…
- **RequestFactory::query(path)** — for building `QUERY` requests in unit tests.
- **HttpClient::query(url)** — outbound server-to-server QUERY calls; retried by default (QUERY is classified idempotent, per Slice 3).

TestClient/RequestFactory reuse the `http_query::QUERY` constant (both `admin`-gated). HttpClient builds the method via `Method::from_bytes(b"QUERY")` so the `http-client` feature stays independent of the `admin`-gated `http_query` module.

## Tests

- `TestClient::query().form()` round-trips against a `get().query()` route (GET → list handler, QUERY → query handler + body).
- `RequestFactory::query()` builds a request with method `QUERY`.
- **Wire test**: `HttpClient::query()` against a live axum server proves the connector sends the `QUERY` method and body over HTTP/1.1.

Part of epic #1107.
