### PR TITLE
feat(cache-page): opt-in caching for QUERY requests (#1111)

### DIFF
--- a/crates/rustango/src/cache_page.rs
+++ b/crates/rustango/src/cache_page.rs
@@ -6,7 +6,10 @@
 //! 1. [`CachePageLayer`] — a tower layer that caches successful GET
 //!    responses under a key derived from `(method, path, Vary-on
 //!    header values)`. Subsequent matching requests bypass the inner
-//!    service and return the cached response.
+//!    service and return the cached response. RFC 10008 `QUERY`
+//!    responses are cacheable too — opt in with
+//!    [`CachePageLayer::cache_query`], which folds a digest of the
+//!    request body into the key.
 //! 2. [`CacheControl`] — fluent builder for the `Cache-Control`
 //!    header (`max_age`, `public`, `private`, `no_cache`, `no_store`,
 //!    `must_revalidate`).
@@ -37,9 +40,13 @@
 //!
 //! ## Semantics
 //!
-//! - **GET-only.** POST / PUT / PATCH / DELETE / HEAD bypass the
-//!   cache (mutating methods invalidate semantics; HEAD is too rare
-//!   to be worth the body-stripping path).
+//! - **GET, and QUERY when opted in.** POST / PUT / PATCH / DELETE /
+//!   HEAD bypass the cache (mutating methods invalidate semantics; HEAD
+//!   is too rare to be worth the body-stripping path). RFC 10008 `QUERY`
+//!   is cached only when [`CachePageLayer::cache_query`] is enabled;
+//!   those responses are forced `private` so shared caches (which can't
+//!   key on the request body) never mis-serve them, and a QUERY body
+//!   over the 1 MiB cacheable cap gets `413`.
 //! - **Status 200-only.** Errors / redirects / 304s aren't cached so
 //!   transient failures don't poison the cache.
 //! - **`Cache-Control: no-store`** on the response disables caching
@@ -91,6 +98,7 @@ pub struct CachePageLayer {
     timeout: Duration,
     key_prefix: String,
     vary_on: Vec<HeaderName>,
+    cache_query: bool,
 }
 
 impl CachePageLayer {
@@ -103,6 +111,7 @@ impl CachePageLayer {
             timeout: Duration::from_secs(60),
             key_prefix: "rustango.cache_page".to_owned(),
             vary_on: Vec::new(),
+            cache_query: false,
         }
     }
 
@@ -144,6 +153,25 @@ impl CachePageLayer {
         }
         self
     }
+
+    /// Opt into caching RFC 10008 `QUERY` requests (default `false`).
+    ///
+    /// QUERY is safe + idempotent and its response is cacheable, keyed on
+    /// the request body (the query criteria). When enabled, a `QUERY`
+    /// request has its body buffered and a digest of it folded into the
+    /// cache key, so byte-identical query bodies hit the cache and
+    /// anything else misses. Off by default because buffering request
+    /// bodies has a cost and should be a deliberate choice.
+    ///
+    /// Buffering is capped at the cacheable limit (1 MiB); a QUERY body
+    /// larger than that is rejected with `413 Payload Too Large` (a
+    /// megabyte of search criteria is pathological). Pair with a request
+    /// body-limit layer to reject oversized bodies earlier and uniformly.
+    #[must_use]
+    pub fn cache_query(mut self, enabled: bool) -> Self {
+        self.cache_query = enabled;
+        self
+    }
 }
 
 impl<S> tower::Layer<S> for CachePageLayer {
@@ -155,6 +183,7 @@ impl<S> tower::Layer<S> for CachePageLayer {
             timeout: self.timeout,
             key_prefix: Arc::new(self.key_prefix.clone()),
             vary_on: Arc::new(self.vary_on.clone()),
+            cache_query: self.cache_query,
         }
     }
 }
@@ -167,6 +196,7 @@ pub struct CachePageService<S> {
     timeout: Duration,
     key_prefix: Arc<String>,
     vary_on: Arc<Vec<HeaderName>>,
+    cache_query: bool,
 }
 
 impl<S> Service<Request<Body>> for CachePageService<S>
@@ -191,21 +221,58 @@ where
         let timeout = self.timeout;
         let prefix = self.key_prefix.clone();
         let vary = self.vary_on.clone();
+        let cache_query = self.cache_query;
         let clone = self.inner.clone();
         let mut inner = std::mem::replace(&mut self.inner, clone);
 
         Box::pin(async move {
-            // Bypass non-GET methods entirely.
-            if req.method() != axum::http::Method::GET {
+            // GET is always cacheable. QUERY (RFC 10008) is cacheable only
+            // when opted in; every other method bypasses the cache.
+            let is_get = req.method() == axum::http::Method::GET;
+            let is_query = cache_query && req.method().as_str() == "QUERY";
+            if !is_get && !is_query {
                 return inner.call(req).await;
             }
 
-            let key = compute_cache_key(&prefix, &req, &vary);
+            // For QUERY, buffer the body so we can (a) fold its digest into
+            // the cache key and (b) hand a fresh body to the inner service.
+            // A body over the cacheable cap is forwarded uncached rather
+            // than truncated. Buffering is bounded by any upstream
+            // body-limit layer (documented on `cache_query`).
+            let (req, body_digest) = if is_query {
+                let (parts, body) = req.into_parts();
+                match to_bytes(body, MAX_CACHEABLE_BODY_BYTES).await {
+                    Ok(bytes) => {
+                        let digest = query_body_digest(&bytes);
+                        (Request::from_parts(parts, Body::from(bytes)), Some(digest))
+                    }
+                    Err(_) => {
+                        // QUERY body exceeds the cacheable cap (or a read
+                        // error). `to_bytes` has consumed it and won't hand
+                        // the bytes back, so we can't forward it to the
+                        // handler untouched. Reject cleanly with 413 rather
+                        // than run the handler against a truncated/empty
+                        // body and return silently-wrong results — enabling
+                        // `cache_query` caps QUERY bodies at the cacheable
+                        // limit (documented). `_parts` intentionally
+                        // dropped; the request is not forwarded.
+                        let _ = parts;
+                        return Ok(payload_too_large());
+                    }
+                }
+            } else {
+                (req, None)
+            };
+
+            let key = compute_cache_key(&prefix, &req, &vary, body_digest.as_deref());
 
             // Cache hit?
             if let Ok(Some(serialized)) = cache.get(&key).await {
                 if let Ok(stored) = serde_json::from_str::<CachedResponse>(&serialized) {
-                    if let Some(resp) = stored.into_response(&vary) {
+                    if let Some(mut resp) = stored.into_response(&vary) {
+                        if is_query {
+                            mark_query_response_private(resp.headers_mut());
+                        }
                         return Ok(resp);
                     }
                 }
@@ -279,6 +346,11 @@ where
             // specific request headers, downstream caches need to
             // know so they can repeat the partitioning.
             apply_vary_header(headers, &vary);
+            // QUERY partitions on the request body, which `Vary` can't
+            // express — keep these responses out of shared caches.
+            if is_query {
+                mark_query_response_private(headers);
+            }
             Ok(rebuilt)
         })
     }
@@ -304,7 +376,12 @@ const X_CACHE_STATUS: HeaderName = HeaderName::from_static("x-cache-status");
 /// The `Host` header is included by default — multi-tenant apps
 /// serving different content per Host would otherwise see
 /// cross-tenant cache hits.
-fn compute_cache_key(prefix: &str, req: &Request<Body>, vary_on: &[HeaderName]) -> String {
+fn compute_cache_key(
+    prefix: &str,
+    req: &Request<Body>,
+    vary_on: &[HeaderName],
+    body_digest: Option<&str>,
+) -> String {
     use std::fmt::Write as _;
     let mut k = String::with_capacity(prefix.len() + 128);
     let _ = write!(&mut k, "{prefix}|");
@@ -328,7 +405,57 @@ fn compute_cache_key(prefix: &str, req: &Request<Body>, vary_on: &[HeaderName]) 
         write_lp(&mut k, name.as_str());
         write_lp(&mut k, v);
     }
+    // QUERY (RFC 10008) carries its criteria in the body, so the body
+    // digest partitions the cache — GET keys stay unchanged (`None`).
+    if let Some(digest) = body_digest {
+        write_lp(&mut k, digest);
+    }
     k
+}
+
+/// Mark a QUERY response `private` so shared/downstream caches (CDNs,
+/// reverse proxies) never store it. This layer keys QUERY on the request
+/// body, but HTTP `Vary` can't reference a body, so a shared cache keying
+/// on URL + headers alone would serve one query's result for a different
+/// query. `private` keeps QUERY responses out of shared caches while this
+/// layer's own body-keyed cache keeps working; a stray `public` from the
+/// handler is downgraded for safety. Freshness directives (`max-age`, …)
+/// are preserved.
+fn mark_query_response_private(headers: &mut HeaderMap) {
+    use axum::http::header::CACHE_CONTROL;
+    let existing = headers
+        .get(CACHE_CONTROL)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let mut directives: Vec<String> = existing
+        .split(',')
+        .map(|d| d.trim().to_owned())
+        .filter(|d| {
+            !d.is_empty() && !d.eq_ignore_ascii_case("public") && !d.eq_ignore_ascii_case("private")
+        })
+        .collect();
+    directives.insert(0, "private".to_owned());
+    if let Ok(v) = HeaderValue::from_str(&directives.join(", ")) {
+        headers.insert(CACHE_CONTROL, v);
+    }
+}
+
+/// Base64 SHA-256 of a QUERY request body — the cache-key component that
+/// makes byte-identical query bodies hit and anything else miss.
+fn query_body_digest(body: &[u8]) -> String {
+    use base64::engine::general_purpose::STANDARD as B64;
+    use base64::Engine as _;
+    use sha2::{Digest, Sha256};
+    B64.encode(Sha256::digest(body))
+}
+
+/// `413 Payload Too Large` for a QUERY body over the cacheable cap.
+fn payload_too_large() -> Response<Body> {
+    let mut resp = Response::new(Body::from("QUERY body too large to cache"));
+    *resp.status_mut() = StatusCode::PAYLOAD_TOO_LARGE;
+    resp.headers_mut()
+        .insert(X_CACHE_STATUS, HeaderValue::from_static("BYPASS"));
+    resp
 }
 
 /// Length-prefixed append: writes `<len-in-bytes>:<bytes>|` so the

--- a/crates/rustango/tests/cache_page.rs
+++ b/crates/rustango/tests/cache_page.rs
@@ -570,3 +570,172 @@ async fn host_header_partitions_cache_by_default() {
     );
     assert_eq!(COUNTER.load(Ordering::SeqCst), 2);
 }
+
+// ---------------------------------------------------------------- QUERY (#1111)
+
+use rustango::http_query::QueryRouterExt as _;
+
+/// Build a `QUERY` request to `/page` with `body`.
+fn query_req(body: &'static str) -> Request<Body> {
+    Request::builder()
+        .method(Method::from_bytes(b"QUERY").unwrap())
+        .uri("/page")
+        .body(Body::from(body))
+        .unwrap()
+}
+
+fn query_app(counter: &'static AtomicU32, cache: Arc<InMemoryCache>, cache_query: bool) -> Router {
+    Router::new()
+        .route(
+            "/page",
+            get(|| async { "list" }).query(move |body: String| async move {
+                let n = counter.fetch_add(1, Ordering::SeqCst);
+                format!("q{n}:{body}")
+            }),
+        )
+        .layer(CachePageLayer::new(cache).cache_query(cache_query))
+}
+
+#[tokio::test]
+async fn query_caching_off_by_default() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+    let cache = Arc::new(InMemoryCache::new());
+    // cache_query defaults to false → QUERY bypasses the cache.
+    let app = query_app(&COUNTER, cache, false);
+
+    for _ in 0..2 {
+        let resp = app.clone().oneshot(query_req("q=x")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(resp.headers().get("x-cache-status").is_none());
+    }
+    assert_eq!(
+        COUNTER.load(Ordering::SeqCst),
+        2,
+        "both QUERYs reached the handler"
+    );
+}
+
+#[tokio::test]
+async fn query_same_body_hits_cache_when_enabled() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+    let cache = Arc::new(InMemoryCache::new());
+    let app = query_app(&COUNTER, cache, true);
+
+    let r1 = app.clone().oneshot(query_req("q=x")).await.unwrap();
+    assert_eq!(
+        r1.headers()
+            .get("x-cache-status")
+            .and_then(|h| h.to_str().ok()),
+        Some("MISS")
+    );
+    assert_eq!(body_to_string(r1.into_body()).await, "q0:q=x");
+
+    // Byte-identical body → HIT; handler does not run again.
+    let r2 = app.clone().oneshot(query_req("q=x")).await.unwrap();
+    assert_eq!(
+        r2.headers()
+            .get("x-cache-status")
+            .and_then(|h| h.to_str().ok()),
+        Some("HIT")
+    );
+    assert_eq!(body_to_string(r2.into_body()).await, "q0:q=x");
+    assert_eq!(COUNTER.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn query_different_body_misses() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+    let cache = Arc::new(InMemoryCache::new());
+    let app = query_app(&COUNTER, cache, true);
+
+    let r1 = app.clone().oneshot(query_req("q=x")).await.unwrap();
+    assert_eq!(body_to_string(r1.into_body()).await, "q0:q=x");
+    // Different body → different cache key → MISS, handler runs again.
+    let r2 = app.clone().oneshot(query_req("q=y")).await.unwrap();
+    assert_eq!(
+        r2.headers()
+            .get("x-cache-status")
+            .and_then(|h| h.to_str().ok()),
+        Some("MISS")
+    );
+    assert_eq!(body_to_string(r2.into_body()).await, "q1:q=y");
+    assert_eq!(COUNTER.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn query_response_forced_private() {
+    // A QUERY handler that (mistakenly) marks its result publicly
+    // cacheable must not leak into shared caches — the layer downgrades
+    // it to `private` while preserving freshness.
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route(
+            "/page",
+            get(|| async { "list" }).query(|_body: String| async move {
+                ([(header::CACHE_CONTROL, "public, max-age=60")], "results")
+            }),
+        )
+        .layer(CachePageLayer::new(cache).cache_query(true));
+
+    let resp = app.clone().oneshot(query_req("q=x")).await.unwrap();
+    let cc = resp
+        .headers()
+        .get(header::CACHE_CONTROL)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_ascii_lowercase();
+    assert!(cc.contains("private"), "must be private: {cc}");
+    assert!(!cc.contains("public"), "public must be stripped: {cc}");
+    assert!(cc.contains("max-age=60"), "freshness preserved: {cc}");
+}
+
+#[tokio::test]
+async fn query_body_over_cap_is_413() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+    let cache = Arc::new(InMemoryCache::new());
+    let app = query_app(&COUNTER, cache, true);
+
+    // 1 MiB + 1 byte QUERY body exceeds the cacheable cap.
+    let big = "a".repeat((1 << 20) + 1);
+    let req = Request::builder()
+        .method(Method::from_bytes(b"QUERY").unwrap())
+        .uri("/page")
+        .body(Body::from(big))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_eq!(
+        resp.headers()
+            .get("x-cache-status")
+            .and_then(|h| h.to_str().ok()),
+        Some("BYPASS")
+    );
+    // The handler never ran (body rejected before dispatch).
+    assert_eq!(COUNTER.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn get_and_query_do_not_collide() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+    let cache = Arc::new(InMemoryCache::new());
+    let app = query_app(&COUNTER, cache, true);
+
+    // GET and QUERY share the path but must not share a cache entry
+    // (method is in the key), so the GET handler's "list" is never
+    // served to a QUERY and vice versa.
+    let g = app
+        .clone()
+        .oneshot(Request::builder().uri("/page").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(body_to_string(g.into_body()).await, "list");
+
+    let q = app.clone().oneshot(query_req("q=x")).await.unwrap();
+    assert_eq!(body_to_string(q.into_body()).await, "q0:q=x");
+}


### PR DESCRIPTION
Opt-in QUERY response caching for the HTTP QUERY epic (#1107). Closes #1111. Builds on Slice 1.

## What

`CachePageLayer::cache_query(bool)` (default **off**). When enabled, an RFC 10008 `QUERY` request has its body buffered and a base64 SHA-256 digest of it folded into the cache key, so **byte-identical query bodies hit** and anything else misses. GET keys are byte-for-byte unchanged (digest = `None`).

## Safety

- **Shared-cache protection.** QUERY responses are forced `Cache-Control: private` (freshness directives preserved, a stray `public` downgraded). HTTP `Vary` can't reference a request body, so a downstream shared cache keying on URL+headers alone would mis-serve one query's result for another — `private` keeps QUERY responses out of shared caches while this layer's own body-keyed cache keeps working.
- **Bounded buffering.** A QUERY body over the 1 MiB cacheable cap gets `413 Payload Too Large` (a megabyte of search criteria is pathological). Pair with a body-limit layer to reject oversized bodies earlier.
- GET caching is byte-for-byte unchanged in both flag states.

## Tests

Off-by-default bypass, same-body HIT, different-body MISS, GET/QUERY non-collision, `public`→`private` downgrade (freshness preserved), and over-cap 413 + `X-Cache-Status: BYPASS`.

## Review

A correctness finder verified body reconstruction, GET key stability, GET/QUERY non-collision, and cached-QUERY replay. It surfaced the shared-cache `Vary` hazard (fixed here with forced `private`) and a stale doc bullet (fixed).

Part of epic #1107.
