### PR TITLE
feat(viewset): QUERY collection action + admin custom-view QUERY (#1112)

### DIFF
--- a/crates/rustango/src/admin/urls.rs
+++ b/crates/rustango/src/admin/urls.rs
@@ -859,24 +859,6 @@ fn mount_custom_views(mut router: Router, state: AppState) -> Router {
             continue;
         }
 
-        let method_filter = match view.method {
-            Method::GET => MethodFilter::GET,
-            Method::POST => MethodFilter::POST,
-            Method::PUT => MethodFilter::PUT,
-            Method::DELETE => MethodFilter::DELETE,
-            Method::PATCH => MethodFilter::PATCH,
-            ref other => {
-                tracing::warn!(
-                    target: "rustango::admin",
-                    table = %view.table,
-                    suffix = %view.suffix,
-                    method = ?other,
-                    "custom admin view declared with an unsupported HTTP method — defaulting to GET"
-                );
-                MethodFilter::GET
-            }
-        };
-
         let table = view.table;
         let suffix = view.suffix.trim_start_matches('/');
         let path = format!("/{table}/{suffix}");
@@ -894,7 +876,33 @@ fn mount_custom_views(mut router: Router, state: AppState) -> Router {
             async move { handler(pool, req).await }
         };
 
-        router = router.route(&path, on(method_filter, mounted_handler));
+        // RFC 10008 QUERY can't be expressed as an axum `MethodFilter`
+        // (#1112), so route it through the `http_query` shim; every other
+        // method maps to a `MethodFilter` as before.
+        let route = if view.method.as_str() == "QUERY" {
+            crate::http_query::query(mounted_handler)
+        } else {
+            let method_filter = match view.method {
+                Method::GET => MethodFilter::GET,
+                Method::POST => MethodFilter::POST,
+                Method::PUT => MethodFilter::PUT,
+                Method::DELETE => MethodFilter::DELETE,
+                Method::PATCH => MethodFilter::PATCH,
+                ref other => {
+                    tracing::warn!(
+                        target: "rustango::admin",
+                        table = %view.table,
+                        suffix = %view.suffix,
+                        method = ?other,
+                        "custom admin view declared with an unsupported HTTP method — defaulting to GET"
+                    );
+                    MethodFilter::GET
+                }
+            };
+            on(method_filter, mounted_handler)
+        };
+
+        router = router.route(&path, route);
     }
 
     router

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -732,6 +732,15 @@ impl ViewSet {
         } else {
             get(handle_list).post(handle_create)
         };
+        // RFC 10008 QUERY collection action (#1112) — same filtered list as
+        // GET, criteria in the body. Gated on `admin` since the QUERY
+        // routing shim lives in the `admin`-gated `http_query` module; a
+        // `tenancy`-only ViewSet build keeps GET/POST without QUERY.
+        #[cfg(feature = "admin")]
+        let collection_route = {
+            use crate::http_query::QueryRouterExt as _;
+            collection_route.query(handle_query)
+        };
 
         let item_route = if self.read_only {
             axum::routing::MethodRouter::new().get(handle_retrieve)
@@ -1362,11 +1371,23 @@ async fn handle_list(
     Query(params): Query<HashMap<String, String>>,
     req: axum::extract::Request,
 ) -> Response {
-    let (_parts, _body, mut acq) = match enter(&state, req, &state.vs.perms.list, "list").await {
+    let (_parts, _body, acq) = match enter(&state, req, &state.vs.perms.list, "list").await {
         Ok(x) => x,
         Err(resp) => return resp,
     };
+    run_list(state, params, acq).await
+}
 
+/// Core `list` logic shared by the GET `list` action and the RFC 10008
+/// QUERY action (#1112): builds filters / search / ordering / pagination
+/// from `params` and renders the paginated envelope. `params` arrive from
+/// the querystring on GET and from the request body on QUERY, so the two
+/// transports return byte-identical results for equivalent criteria.
+async fn run_list(
+    state: Arc<ViewSetState>,
+    params: HashMap<String, String>,
+    mut acq: AcquiredConn,
+) -> Response {
     let page_size: i64 = params
         .get("page_size")
         .and_then(|p| p.parse().ok())
@@ -1563,6 +1584,106 @@ async fn handle_list(
                 "results": results,
             }))
         }
+    }
+}
+
+/// RFC 10008 QUERY action on the collection (#1112) — the same filtered,
+/// paginated `list`, but with the criteria in the request body instead of
+/// the querystring. A ViewSet gets this for free (no trait method to
+/// implement); `QUERY /things` with body `status=draft&ordering=-created`
+/// returns exactly what `GET /things?status=draft&ordering=-created`
+/// would. Permissions / throttles reuse the `list` codenames via `enter`.
+#[cfg(feature = "admin")]
+async fn handle_query(
+    State(state): State<Arc<ViewSetState>>,
+    req: axum::extract::Request,
+) -> Response {
+    // `enter` returns the body unconsumed (it only reads `parts` for
+    // throttle + permission checks), so we can parse params from it here.
+    let (parts, body, acq) = match enter(&state, req, &state.vs.perms.list, "query").await {
+        Ok(x) => x,
+        Err(resp) => return resp,
+    };
+    let params = match parse_query_body_params(&parts, body).await {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    run_list(state, params, acq).await
+}
+
+/// Parse a QUERY request body into the same `HashMap<String, String>`
+/// param shape `run_list` consumes for GET. Dispatches on `Content-Type`:
+/// urlencoded (or none) via the querystring codepath, JSON objects flattened
+/// to string values (scalars stringified, arrays comma-joined so
+/// `{"status__in":["a","b"]}` matches `status__in=a,b`), anything else 415.
+#[cfg(feature = "admin")]
+async fn parse_query_body_params(
+    parts: &axum::http::request::Parts,
+    body: Body,
+) -> Result<HashMap<String, String>, Response> {
+    const CAP: usize = 1 << 20;
+    let essence = parts
+        .headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    let bytes = match axum::body::to_bytes(body, CAP).await {
+        Ok(b) => b,
+        Err(_) => {
+            return Err(json_error(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "QUERY body too large",
+            ))
+        }
+    };
+
+    if essence == "application/json" || essence.ends_with("+json") {
+        let value: Value = serde_json::from_slice(&bytes).map_err(|e| {
+            json_error(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                &format!("invalid JSON QUERY body: {e}"),
+            )
+        })?;
+        let Value::Object(obj) = value else {
+            return Err(json_error(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "QUERY JSON body must be an object of criteria",
+            ));
+        };
+        Ok(obj
+            .iter()
+            .map(|(k, v)| (k.clone(), json_value_to_param(v)))
+            .collect())
+    } else if essence.is_empty() || essence == "application/x-www-form-urlencoded" {
+        serde_urlencoded::from_bytes::<HashMap<String, String>>(&bytes)
+            .map_err(|e| json_error(StatusCode::BAD_REQUEST, &format!("invalid QUERY body: {e}")))
+    } else {
+        Err(json_error(
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "QUERY body must be application/x-www-form-urlencoded or application/json",
+        ))
+    }
+}
+
+/// Flatten a JSON value to the string form `run_list`'s filter parser
+/// expects: strings verbatim, arrays comma-joined (for `__in` lookups),
+/// null → empty, numbers / bools via their JSON text.
+#[cfg(feature = "admin")]
+fn json_value_to_param(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Array(items) => items
+            .iter()
+            .map(json_value_to_param)
+            .collect::<Vec<_>>()
+            .join(","),
+        Value::Null => String::new(),
+        other => other.to_string(),
     }
 }
 

--- a/crates/rustango/tests/viewset_query_action_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_query_action_sqlite_live.rs
@@ -1,0 +1,195 @@
+//! End-to-end live test for the ViewSet RFC 10008 QUERY action (#1112,
+//! epic #1107) on SQLite.
+//!
+//! `QUERY /posts` returns the same filtered / ordered / paginated list as
+//! `GET /posts?…`, but with the criteria in the request body — urlencoded
+//! (identical to the querystring path) or JSON (arrays for `__in`). This
+//! is the DRF-beyond capability: complex search criteria that outgrow a
+//! querystring travel in a safe, idempotent request body.
+
+#![cfg(all(
+    feature = "admin",
+    feature = "sqlite",
+    feature = "tenancy",
+    feature = "serializer"
+))]
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use rustango::core::Model as _;
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use serde_json::Value;
+use tower::ServiceExt as _;
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "vs_query_post")]
+#[rustango(app = "vs_query_app")]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+    #[rustango(max_length = 50)]
+    pub status: String,
+    pub rating: i32,
+}
+
+async fn fresh_pool() -> Pool {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE vs_query_post (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            title TEXT NOT NULL, \
+            status TEXT NOT NULL, \
+            rating INTEGER NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .expect("create");
+    Pool::Sqlite(sq)
+}
+
+fn app(pool: Pool) -> axum::Router {
+    rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .filter_fields(&["status", "rating"])
+        .ordering_fields(&["rating", "title"])
+        .router_pool("/posts", pool)
+}
+
+async fn body_json(resp: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .expect("body bytes");
+    serde_json::from_slice(&bytes).expect("json")
+}
+
+fn ids(body: &Value) -> Vec<i64> {
+    body["results"]
+        .as_array()
+        .expect("results")
+        .iter()
+        .map(|r| r["id"].as_i64().expect("id i64"))
+        .collect()
+}
+
+async fn seed(app: &axum::Router) {
+    for (title, status, rating) in [
+        ("a", "draft", 3),
+        ("b", "published", 1),
+        ("c", "draft", 2),
+        ("d", "published", 5),
+    ] {
+        let payload =
+            serde_json::json!({ "title": title, "status": status, "rating": rating }).to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/posts")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(resp.status().is_success(), "seed {title} failed");
+    }
+}
+
+fn query_req(content_type: &str, body: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::from_bytes(b"QUERY").unwrap())
+        .uri("/posts")
+        .header(header::CONTENT_TYPE, content_type)
+        .body(Body::from(body.to_owned()))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn query_urlencoded_body_matches_get_querystring() {
+    let app = app(fresh_pool().await);
+    seed(&app).await;
+
+    let criteria = "status=draft&ordering=-rating";
+    let get = body_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(&format!("/posts?{criteria}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let query = body_json(
+        app.clone()
+            .oneshot(query_req("application/x-www-form-urlencoded", criteria))
+            .await
+            .unwrap(),
+    )
+    .await;
+
+    // draft rows are id 1 (rating 3) and id 3 (rating 2); -rating → [1, 3].
+    assert_eq!(ids(&get), vec![1, 3]);
+    assert_eq!(
+        ids(&get),
+        ids(&query),
+        "QUERY body and GET querystring must return the same rows"
+    );
+    assert_eq!(get["count"], query["count"]);
+}
+
+#[tokio::test]
+async fn query_json_body_with_in_array() {
+    let app = app(fresh_pool().await);
+    seed(&app).await;
+
+    // JSON body with an array for `status__in` — not expressible in a flat
+    // querystring value the same way; the array is comma-joined internally.
+    let resp = app
+        .clone()
+        .oneshot(query_req(
+            "application/json",
+            r#"{"status__in":["draft","published"],"rating__gte":2,"ordering":"rating"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    // rating >= 2 → ids 1(3), 3(2), 4(5); status in {draft,published} keeps
+    // all three; ordering=rating ASC → [3, 1, 4].
+    assert_eq!(ids(&body), vec![3, 1, 4]);
+}
+
+#[tokio::test]
+async fn query_unsupported_content_type_is_415() {
+    let app = app(fresh_pool().await);
+    seed(&app).await;
+    let resp = app
+        .oneshot(query_req("text/plain", "status=draft"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}
+
+#[tokio::test]
+async fn query_empty_body_lists_everything() {
+    let app = app(fresh_pool().await);
+    seed(&app).await;
+    // No criteria → full list, same as GET /posts.
+    let resp = app
+        .oneshot(query_req("application/x-www-form-urlencoded", ""))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["count"], 4);
+}


### PR DESCRIPTION
ViewSet QUERY action for the HTTP QUERY epic (#1107). Closes #1112. Builds on Slices 1–2.

## What

`QUERY /things` returns the **same** filtered / ordered / paginated list as `GET /things?…`, but with the criteria in the request body — so complex search that outgrows a querystring travels in a safe, idempotent body. DRF has no equivalent.

A ViewSet gets this for free — no trait method to implement:

```
QUERY /posts   body: status=draft&ordering=-rating           (urlencoded)
QUERY /posts   body: {"status__in":["draft","live"],"rating__gte":2}   (json)
```

## How

- Extracted the post-`enter` list logic into `run_list(state, params, acq)`, shared by the GET `list` handler (params from querystring) and the new `handle_query` (params from body). `enter()` returns the body unconsumed — it reads only `parts` for throttle + permission checks — so the QUERY path reuses the exact same permission codenames and throttles as `list`.
- Body dispatch by `Content-Type`: `application/x-www-form-urlencoded` (identical to the querystring codepath) or `application/json` (objects flattened to string params; arrays comma-joined so `{"status__in":["a","b"]}` matches `status__in=a,b`); other types → 415; over 1 MiB → 413.
- Admin custom views declared with method `QUERY` now route through the `http_query` shim instead of warning and defaulting to GET.

The QUERY additions are gated on `admin` (the routing shim lives in the `admin`-gated `http_query` module); a `tenancy`-only ViewSet build keeps GET/POST unchanged (verified against the `sqlite,tenancy` litmus).

## Tests

`viewset_query_action_sqlite_live`: GET/QUERY urlencoded parity (same rows + count), JSON `__in` array filtering, 415 on unsupported Content-Type, empty-body full list. All existing viewset tests still pass (the `run_list` extraction is behavior-preserving).

Part of epic #1107.
