### PR TITLE
feat(openapi): QUERY operation (OpenAPI 3.2) + query-method docs page (#1114)

### DIFF
--- a/crates/rustango/src/openapi/mod.rs
+++ b/crates/rustango/src/openapi/mod.rs
@@ -1,4 +1,7 @@
-//! OpenAPI 3.1 spec builder + optional Swagger UI router.
+//! OpenAPI 3.1 spec builder + optional Swagger UI router. A spec that
+//! attaches a `QUERY` operation (RFC 10008) via [`PathItem::query`] is
+//! emitted as OpenAPI 3.2.0 (which added the `query` Path Item field);
+//! specs without one stay 3.1.0.
 //!
 //! Two flavors of usage:
 //!
@@ -117,6 +120,12 @@ impl OpenApiSpec {
 
     #[must_use]
     pub fn add_path(mut self, path: impl Into<String>, item: PathItem) -> Self {
+        // OpenAPI 3.2 introduced the `query` Path Item field (RFC 10008).
+        // A spec that uses one must declare 3.2.0; specs without QUERY
+        // stay 3.1.0 for maximum tooling compatibility.
+        if item.query.is_some() {
+            self.openapi = "3.2.0".into();
+        }
         self.paths.insert(path.into(), item);
         self
     }
@@ -253,6 +262,11 @@ pub struct PathItem {
     pub head: Option<Operation>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<Operation>,
+    /// RFC 10008 `QUERY` operation — a first-class Path Item field in
+    /// OpenAPI 3.2. A spec containing one is emitted as `openapi: 3.2.0`
+    /// (see [`OpenApiSpec::add_path`]).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query: Option<Operation>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub parameters: Vec<Parameter>,
 }
@@ -292,6 +306,13 @@ impl PathItem {
     #[must_use]
     pub fn delete(mut self, op: Operation) -> Self {
         self.delete = Some(op);
+        self
+    }
+    /// Attach the RFC 10008 `QUERY` operation (OpenAPI 3.2). Adding this
+    /// to a spec's path bumps the emitted `openapi` version to 3.2.0.
+    #[must_use]
+    pub fn query(mut self, op: Operation) -> Self {
+        self.query = Some(op);
         self
     }
     #[must_use]
@@ -1056,6 +1077,56 @@ mod tests {
                 ["schema"]["items"]["$ref"],
             "#/components/schemas/Post"
         );
+    }
+
+    #[test]
+    fn query_operation_serializes_and_bumps_version_to_3_2() {
+        // A path with a `query` operation (RFC 10008) is emitted under the
+        // `query` Path Item field and forces the spec version to 3.2.0.
+        let spec = OpenApiSpec::new("API", "1.0")
+            .add_schema("Post", Schema::object().property("title", Schema::string()))
+            .add_path(
+                "/posts",
+                PathItem::new()
+                    .get(
+                        Operation::new()
+                            .summary("List posts")
+                            .response("200", Response::new("OK")),
+                    )
+                    .query(
+                        Operation::new()
+                            .summary("Search posts")
+                            .operation_id("search_posts")
+                            .request_body(RequestBody::json(Schema::ref_("Post")))
+                            .response(
+                                "200",
+                                Response::new("OK")
+                                    .json_content(Schema::array_of(Schema::ref_("Post"))),
+                            ),
+                    ),
+            );
+        let v: serde_json::Value = serde_json::from_str(&spec.to_json()).unwrap();
+        assert_eq!(v["openapi"], "3.2.0", "QUERY op must bump the version");
+        assert_eq!(v["paths"]["/posts"]["query"]["summary"], "Search posts");
+        assert_eq!(v["paths"]["/posts"]["query"]["operationId"], "search_posts");
+        assert_eq!(
+            v["paths"]["/posts"]["query"]["requestBody"]["content"]["application/json"]["schema"]
+                ["$ref"],
+            "#/components/schemas/Post"
+        );
+        // GET on the same path is unaffected.
+        assert_eq!(v["paths"]["/posts"]["get"]["summary"], "List posts");
+    }
+
+    #[test]
+    fn spec_without_query_stays_3_1() {
+        let spec = OpenApiSpec::new("API", "1.0").add_path(
+            "/posts",
+            PathItem::new().get(Operation::new().response("200", Response::new("OK"))),
+        );
+        let v: serde_json::Value = serde_json::from_str(&spec.to_json()).unwrap();
+        assert_eq!(v["openapi"], "3.1.0");
+        assert!(v["paths"]["/posts"].get("query").is_none());
     }
 
     #[test]

--- a/docs/index.toml
+++ b/docs/index.toml
@@ -15,7 +15,7 @@ pages = ["getting-started.md", "scaffolding.md", "glossary.md"]
 [[section]]
 title = "Guides"
 slug = "guides"
-pages = ["models.md", "orm.md", "admin.md", "serializers.md", "viewsets.md", "html-views.md", "openapi.md", "mcp.md", "urls.md", "manage.md", "middleware.md", "jobs.md", "caching.md", "files.md", "i18n.md", "email.md", "testing.md", "security.md"]
+pages = ["models.md", "orm.md", "admin.md", "serializers.md", "viewsets.md", "html-views.md", "openapi.md", "query-method.md", "mcp.md", "urls.md", "manage.md", "middleware.md", "jobs.md", "caching.md", "files.md", "i18n.md", "email.md", "testing.md", "security.md"]
 
 [[section]]
 title = "Authentication"

--- a/docs/query-method.md
+++ b/docs/query-method.md
@@ -1,0 +1,171 @@
+# The QUERY method
+
+`QUERY` ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008), a Proposed Standard
+published in June 2026) is the "safe GET with a body." It's **safe** and
+**idempotent** like `GET`, but the query criteria travel in the request body
+instead of the URL — so a complex search doesn't have to be squeezed into a
+querystring, and there's no URL-length ceiling. **Rustango** routes `QUERY`
+alongside `GET` across the whole framework: routing, a method-adaptive
+extractor, CSRF/CORS/retry policy, per-view caching, ViewSets, the test client,
+and OpenAPI.
+
+> **Source:** `rustango::http_query` (`query`, `QueryRouterExt`, `QUERY`) and
+> `rustango::params` (`Params`) — behind the `admin` feature. Related surface:
+> `viewset::ViewSet`, `cache_page::CachePageLayer::cache_query`,
+> `forms::csrf::CsrfConfig::require_csrf_on_query`, `cors::CorsLayer`,
+> `test_client` / `http_client`.
+
+## When to reach for it
+
+Use `QUERY` instead of `GET` when the search criteria are big or structured:
+
+- Filter sets that would blow past a querystring (long `IN` lists, many facets).
+- Nested / structured criteria that don't map cleanly to `?key=value` pairs —
+  send them as a JSON body.
+- Anything you'd be tempted to model as a `POST /search` even though it reads no
+  state and changes nothing — `QUERY` says "this is a safe, cacheable read" in
+  the method itself.
+
+Use plain `GET` for simple, short, bookmarkable requests. `QUERY` is additive:
+the same handler can serve both.
+
+## Routing
+
+axum 0.8 can't route `QUERY` natively (its `MethodFilter` is a closed set —
+[tokio-rs/axum#3799](https://github.com/tokio-rs/axum/issues/3799)), so rustango
+provides `query()` and a `.query()` chain that mirror axum's own `get()` /
+`post()`:
+
+```rust
+use rustango::http_query::{query, QueryRouterExt};
+use axum::routing::get;
+
+let app = axum::Router::new()
+    // QUERY-only route.
+    .route("/search", query(search))
+    // GET + QUERY on one path — chain `.query()` last.
+    .route("/products", get(list_products).query(search_products));
+```
+
+A `405` on a mixed route reports the full method set, e.g.
+`Allow: GET,HEAD,QUERY`.
+
+## One handler, both transports
+
+`Params<T>` reads `T` from the querystring on `GET`/`HEAD` and from the request
+body on `QUERY`, so a single handler serves both with no branching:
+
+```rust
+use rustango::params::Params;
+use rustango::http_query::QueryRouterExt;
+use axum::routing::get;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Search { q: String, page: Option<u32> }
+
+async fn search(Params(s): Params<Search>) -> String {
+    format!("q={} page={:?}", s.q, s.page)
+}
+
+let app = axum::Router::new().route("/search", get(search).query(search));
+```
+
+`GET /search?q=hi` and `QUERY /search` with body `q=hi` reach `search` and
+deserialize identically. On `QUERY` the body is parsed by `Content-Type`:
+
+| `Content-Type` | Parsed as | Notes |
+|---|---|---|
+| `application/x-www-form-urlencoded` (or none) | `serde_urlencoded` | Same codepath as the querystring — flat, single-value per key. |
+| `application/json` (or a `…+json` suffix) | `serde_json` | Use this for arrays / nested criteria. |
+| anything else | — | `415 Unsupported Media Type` |
+
+Status codes match axum's conventions: a querystring parse error is `400`, a body
+parse error is `422`, and a method other than GET/HEAD/QUERY is `405`.
+
+```bash
+# urlencoded body
+curl -X QUERY http://localhost:8080/search \
+     -H 'Content-Type: application/x-www-form-urlencoded' \
+     --data 'q=hello&page=2'
+
+# JSON body (arrays / nesting)
+curl -X QUERY http://localhost:8080/search \
+     -H 'Content-Type: application/json' \
+     --data '{"q":"hello","tags":["rust","web"]}'
+```
+
+## ViewSets
+
+A `ViewSet` gets a `QUERY` collection action for free — `QUERY /things` returns
+the same filtered / ordered / paginated list as `GET /things?…`, but with the
+criteria in the body:
+
+```bash
+# identical results:
+curl 'http://localhost:8080/posts?status=draft&ordering=-rating'
+curl -X QUERY http://localhost:8080/posts \
+     -H 'Content-Type: application/x-www-form-urlencoded' \
+     --data 'status=draft&ordering=-rating'
+
+# arrays via JSON (comma-joined internally for __in lookups):
+curl -X QUERY http://localhost:8080/posts \
+     -H 'Content-Type: application/json' \
+     --data '{"status__in":["draft","published"],"rating__gte":2}'
+```
+
+Permissions and throttles reuse the `list` action's, and admin custom views
+declared with method `QUERY` route correctly too.
+
+## Framework guarantees
+
+- **CSRF.** `QUERY` is exempt from CSRF token enforcement by default, alongside
+  `GET`/`HEAD`/`OPTIONS`/`TRACE`. Browsers can't form-submit `QUERY`, and a
+  cross-origin `fetch` with method `QUERY` is never a CORS-safelisted "simple
+  request" — it always triggers a preflight — so there's no ambient-credential
+  CSRF vector. Set `CsrfConfig::require_csrf_on_query = true` for pure
+  defense-in-depth. Keep `QUERY` handlers side-effect-free, and never add
+  `QUERY` to the [method-override](middleware.md) allow-list.
+- **CORS.** `QUERY` is in the `permissive()` and settings-derived method lists.
+  Because every cross-origin `QUERY` preflights, it must be advertised in
+  `Access-Control-Allow-Methods` to work cross-origin.
+- **Retries.** The HTTP client (`http_client`) treats `QUERY` as idempotent, so
+  it's retried on transient failures like `GET`.
+- **Idempotency.** `QUERY` needs no `Idempotency-Key` — the method is
+  idempotent by definition.
+- **Caching.** `cache_page` can cache `QUERY` responses when you opt in with
+  `CachePageLayer::cache_query(true)`. The cache key folds in a digest of the
+  request body, and the response is marked `private` so shared caches (which
+  can't key on a body) never mis-serve it. See [Caching](caching.md).
+
+## Testing
+
+`TestClient` and `RequestFactory` have `.query()` builders, and the outbound
+`HttpClient` can send `QUERY`:
+
+```rust
+let resp = client.query("/search").json(&criteria).send().await;
+```
+
+## OpenAPI
+
+OpenAPI 3.1 has no `QUERY` operation; [OpenAPI 3.2](https://www.openapis.org/blog/2025/09/23/announcing-openapi-v3-2)
+added it as a first-class Path Item field. Rustango emits a `query` operation
+when you attach one, and bumps the spec to `openapi: 3.2.0` only for specs that
+use it (specs without `QUERY` stay `3.1.0` for maximum tooling compatibility):
+
+```rust
+use rustango::openapi::{OpenApiSpec, PathItem, Operation, RequestBody, Response, Schema};
+
+let spec = OpenApiSpec::new("API", "1.0").add_path(
+    "/posts",
+    PathItem::new()
+        .get(Operation::new().summary("List posts").response("200", Response::new("OK")))
+        .query(
+            Operation::new()
+                .summary("Search posts")
+                .request_body(RequestBody::json(Schema::ref_("SearchCriteria")))
+                .response("200", Response::new("OK")),
+        ),
+);
+```


### PR DESCRIPTION
Final slice of the HTTP QUERY epic (#1107) — OpenAPI 3.2 support + docs. Advances #1114.

## OpenAPI

- `PathItem::query(op)` — attach the RFC 10008 `QUERY` operation, a first-class Path Item field introduced in [OpenAPI 3.2](https://www.openapis.org/blog/2025/09/23/announcing-openapi-v3-2).
- A spec that uses a QUERY operation is emitted as `openapi: 3.2.0`; specs without one stay `3.1.0` (maximum tooling compatibility — the version bump is conditional, not unconditional).
- Tests: the serialized `query` op with a `requestBody`, and the conditional version bump (3.2.0 with QUERY, 3.1.0 without).

## Docs

New `docs/query-method.md` (registered in the Guides TOC), covering:
- What QUERY is (RFC 10008) and when to reach for it vs GET.
- Routing (`query()` / `.query()`), the `Params<T>` method-adaptive extractor, and the Content-Type → status-code table.
- ViewSet QUERY action with curl examples.
- Framework guarantees: CSRF exemption rationale, CORS preflight, retry/idempotency, and opt-in `cache_page`.
- Testing (`.query()` builders) and the OpenAPI 3.2 emission.

## Remaining

The runnable cookbook recipe chapter (the last item on #1114) is intentionally deferred — the docs page already carries thorough curl + Rust examples. #1114 stays open for that chapter.

Part of epic #1107 — this is the 7th and last slice's code + docs.
