### PR TITLE
feat(orm): window/aggregate query as a derived-table source (#1035)

### DIFF
--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -26,9 +26,10 @@ pub use expr::{BinOp, CaseBranch, Expr, JsonPathStep, ScalarFn, VectorMetric, F}
 pub use field_type::{ArrayElem, FieldType, RangeElem};
 pub use query::{
     AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ColumnFilter,
-    CompoundBranch, ConflictClause, CountQuery, CtFilter, DeleteQuery, DistinctMode, Filter,
-    InsertQuery, Join, JoinKind, LockMode, NullsOrder, Op, OrderClause, OrderItem, RelAggKind,
-    RelCorrelation, SearchClause, SelectQuery, SetOp, SubqueryJoin, UpdateQuery, WhereExpr,
+    CompoundBranch, ConflictClause, CountQuery, CtFilter, DeleteQuery, DerivedSource, DistinctMode,
+    Filter, InsertQuery, Join, JoinKind, LockMode, NullsOrder, Op, OrderClause, OrderItem,
+    RelAggKind, RelCorrelation, SearchClause, SelectQuery, SetOp, SubqueryJoin, UpdateQuery,
+    WhereExpr,
 };
 pub use schema::{
     infer_app_label_from_module_path, AdminConfig, CheckConstraint, CompositeFkRelation,

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -1154,11 +1154,41 @@ pub struct Join {
 /// writer raises [`crate::sql::SqlError::LateralJoinNotSupported`] on
 /// SQLite.
 ///
+/// Source of a derived-table join (#828, #1035) — either a plain typed
+/// `SELECT` or an aggregate/window query. Window functions compile to an
+/// [`AggregateQuery`], so the [`DerivedSource::Aggregate`] variant lets a
+/// windowed result be joined as a derived table — the missing half of
+/// "filter on a window result" (e.g. keep rows where a per-group `rank`
+/// is `<= N`), which a subquery can express but a bare `WHERE` can't.
+///
+/// The four derived-table join builders
+/// ([`crate::query::QuerySet::join_sub`] et al.) take `impl Into<DerivedSource>`,
+/// so a `SelectQuery` or an `AggregateQuery` both work with no ceremony.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DerivedSource {
+    /// A plain typed `SELECT` derived table.
+    Select(Box<SelectQuery>),
+    /// An aggregate / window query derived table (#1035).
+    Aggregate(Box<AggregateQuery>),
+}
+
+impl From<SelectQuery> for DerivedSource {
+    fn from(q: SelectQuery) -> Self {
+        DerivedSource::Select(Box::new(q))
+    }
+}
+
+impl From<AggregateQuery> for DerivedSource {
+    fn from(q: AggregateQuery) -> Self {
+        DerivedSource::Aggregate(Box::new(q))
+    }
+}
+
 /// [`Expr::AliasedColumn`]: crate::core::Expr::AliasedColumn
 #[derive(Debug, Clone, PartialEq)]
 pub struct SubqueryJoin {
-    /// The derived table — a compiled `SELECT`.
-    pub subquery: Box<SelectQuery>,
+    /// The derived table — a plain `SELECT` or an aggregate/window query.
+    pub subquery: DerivedSource,
     /// Alias the derived table is exposed under (`AS "<alias>"`).
     pub alias: &'static str,
     /// `INNER` or `LEFT` (the only kinds meaningful for a derived-table

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -1165,7 +1165,12 @@ impl<T: Model> QuerySet<T> {
     ///     .fetch(&pool).await?;
     /// ```
     #[must_use]
-    pub fn join_sub(self, sub: SelectQuery, alias: &'static str, on: WhereExpr) -> Self {
+    pub fn join_sub(
+        self,
+        sub: impl Into<crate::core::DerivedSource>,
+        alias: &'static str,
+        on: WhereExpr,
+    ) -> Self {
         self.push_subquery_join(
             sub,
             alias,
@@ -1178,7 +1183,12 @@ impl<T: Model> QuerySet<T> {
     /// `LEFT JOIN (<subquery>) AS <alias> ON <on>` — left-join counterpart
     /// of [`Self::join_sub`] (Eloquent `leftJoinSub`). Issue #828.
     #[must_use]
-    pub fn left_join_sub(self, sub: SelectQuery, alias: &'static str, on: WhereExpr) -> Self {
+    pub fn left_join_sub(
+        self,
+        sub: impl Into<crate::core::DerivedSource>,
+        alias: &'static str,
+        on: WhereExpr,
+    ) -> Self {
         self.push_subquery_join(
             sub,
             alias,
@@ -1199,7 +1209,12 @@ impl<T: Model> QuerySet<T> {
     /// the writer raises [`crate::sql::SqlError::LateralJoinNotSupported`]
     /// at compile time.
     #[must_use]
-    pub fn join_lateral(self, sub: SelectQuery, alias: &'static str, on: WhereExpr) -> Self {
+    pub fn join_lateral(
+        self,
+        sub: impl Into<crate::core::DerivedSource>,
+        alias: &'static str,
+        on: WhereExpr,
+    ) -> Self {
         self.push_subquery_join(
             sub,
             alias,
@@ -1215,7 +1230,12 @@ impl<T: Model> QuerySet<T> {
     /// (the natural shape for "latest order per customer, customers
     /// without orders included"). **PG / MySQL only.** Issue #828.
     #[must_use]
-    pub fn left_join_lateral(self, sub: SelectQuery, alias: &'static str, on: WhereExpr) -> Self {
+    pub fn left_join_lateral(
+        self,
+        sub: impl Into<crate::core::DerivedSource>,
+        alias: &'static str,
+        on: WhereExpr,
+    ) -> Self {
         self.push_subquery_join(
             sub,
             alias,
@@ -1229,14 +1249,14 @@ impl<T: Model> QuerySet<T> {
     #[must_use]
     fn push_subquery_join(
         mut self,
-        sub: SelectQuery,
+        sub: impl Into<crate::core::DerivedSource>,
         alias: &'static str,
         kind: crate::core::JoinKind,
         on: WhereExpr,
         lateral: bool,
     ) -> Self {
         self.subquery_joins.push(crate::core::SubqueryJoin {
-            subquery: Box::new(sub),
+            subquery: sub.into(),
             alias,
             kind,
             on,

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -528,11 +528,16 @@ fn write_select_inner(b: &mut Sql<'_>, query: &SelectQuery) -> Result<(), SqlErr
             b.sql.push_str(" LATERAL");
         }
         b.sql.push_str(" (");
-        // `write_select` pushes/pops the subquery's own scope frame, so a
-        // correlated `OuterRef` inside a LATERAL subquery resolves to the
-        // enclosing query; explicit `AliasedColumn` refs to the outer
-        // table work regardless (LATERAL exposes earlier FROM items).
-        write_select(b, &sj.subquery)?;
+        // `write_select` / `write_aggregate` push/pop the subquery's own
+        // scope frame, so a correlated `OuterRef` inside a LATERAL subquery
+        // resolves to the enclosing query; explicit `AliasedColumn` refs to
+        // the outer table work regardless (LATERAL exposes earlier FROM
+        // items). The `Aggregate` variant (#1035) lets a window/aggregate
+        // query be joined as a derived table.
+        match &sj.subquery {
+            crate::core::DerivedSource::Select(s) => write_select(b, s)?,
+            crate::core::DerivedSource::Aggregate(a) => write_aggregate(b, a)?,
+        }
         b.sql.push_str(") AS ");
         b.write_ident(sj.alias);
         // Empty `on` → `ON true` (the LATERAL shape, where the

--- a/crates/rustango/tests/django6_window.rs
+++ b/crates/rustango/tests/django6_window.rs
@@ -19,12 +19,13 @@
 //!   `.aggregate().group_by(<every projected column>)` shape —
 //!   `.values(cols)` + window-only annotate is rejected with
 //!   `QueryError::ValuesRequiresAggregate`.
-//! - A windowed query cannot be re-embedded as a subquery source
-//!   (windows compile to `AggregateQuery`; `join_sub` takes
-//!   `SelectQuery`), so Django's `qs.annotate(rank=Window(...))` then
-//!   `.filter(rank__lte=N)` outer-wrap has no direct equivalent —
-//!   `join_lateral` is the workaround (see
-//!   `check_top_n_per_group_via_lateral`).
+//! - A windowed query can now be re-embedded as a subquery source (#1035):
+//!   `join_sub` / `left_join_sub` accept an `AggregateQuery` (what a window
+//!   compiles to) via `impl Into<DerivedSource>`, so Django's
+//!   `qs.annotate(rank=Window(...))` then `.filter(rank__lte=N)` outer-wrap
+//!   has a direct equivalent — see
+//!   `subquery_join_sqlite_live::window_derived_table_yields_top_n_per_group`.
+//!   `join_lateral` remains an alternative (PG/MySQL only).
 
 #[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
 mod scenarios {

--- a/crates/rustango/tests/subquery_join_emission.rs
+++ b/crates/rustango/tests/subquery_join_emission.rs
@@ -4,6 +4,7 @@
 //! `LATERAL` is PG / MySQL only and errors cleanly on SQLite.
 
 use rustango::core::joins::aliased;
+use rustango::core::window::row_number;
 use rustango::core::{Op, WhereExpr};
 use rustango::sql::{Dialect, MySql, Postgres, SqlError, Sqlite};
 use rustango::Model;
@@ -130,6 +131,105 @@ fn lateral_errors_cleanly_on_sqlite() {
         matches!(err, SqlError::LateralJoinNotSupported { dialect: "sqlite" }),
         "expected LateralJoinNotSupported, got: {err:?}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// #1035 — a window/aggregate query as a derived-table source. Window
+// functions compile to an `AggregateQuery`; `join_sub` now accepts one
+// (via `impl Into<DerivedSource>`), so the "filter on a window result"
+// idiom (rank ≤ N per group) is expressible as a derived table.
+// ---------------------------------------------------------------------------
+
+/// `row_number() OVER (PARTITION BY customer_id ORDER BY total DESC)`,
+/// projected alongside the grouped columns so the outer query can join +
+/// filter on it.
+fn ranked_orders() -> rustango::core::AggregateQuery {
+    Order::objects()
+        .aggregate()
+        .group_by("id")
+        .group_by("customer_id")
+        .annotate(
+            "rn",
+            row_number()
+                .partition_by("customer_id")
+                .order_by(&[("total", true)])
+                .into(),
+        )
+        .compile()
+        .unwrap()
+}
+
+#[test]
+fn join_sub_accepts_window_aggregate_on_pg() {
+    let q = Customer::objects()
+        .join_sub(
+            ranked_orders(),
+            "r",
+            WhereExpr::ExprCompare {
+                lhs: aliased("r", "customer_id"),
+                op: Op::Eq,
+                rhs: aliased("customer", "id"),
+            },
+        )
+        .compile()
+        .unwrap();
+    let sql = Postgres.compile_select(&q).unwrap().sql;
+    // The aggregate/window query is wrapped as a derived table, OVER clause
+    // and all, and joined on the projected group column.
+    assert!(
+        sql.contains(r#"INNER JOIN (SELECT "#),
+        "derived table: {sql}"
+    );
+    assert!(sql.contains("OVER ("), "window OVER inside subquery: {sql}");
+    assert!(
+        sql.contains(r#") AS "r" ON "r"."customer_id" = "customer"."id""#),
+        "alias + ON: {sql}"
+    );
+}
+
+#[test]
+fn window_aggregate_derived_table_is_tri_dialect() {
+    let q = Customer::objects()
+        .join_sub(
+            ranked_orders(),
+            "r",
+            WhereExpr::ExprCompare {
+                lhs: aliased("r", "customer_id"),
+                op: Op::Eq,
+                rhs: aliased("customer", "id"),
+            },
+        )
+        .compile()
+        .unwrap();
+    // Window functions are supported on all three backends, so a
+    // (non-lateral) windowed derived table emits cleanly everywhere.
+    for (name, sql) in [
+        ("sqlite", Sqlite.compile_select(&q).unwrap().sql),
+        ("mysql", MySql.compile_select(&q).unwrap().sql),
+    ] {
+        assert!(sql.contains("OVER ("), "{name}: window missing: {sql}");
+        assert!(
+            sql.to_lowercase().contains("inner join (select"),
+            "{name}: derived table missing: {sql}"
+        );
+    }
+}
+
+#[test]
+fn join_lateral_accepts_window_aggregate_on_pg() {
+    // The window/aggregate derived table also composes with LATERAL
+    // (PG / MySQL). Emits `JOIN LATERAL (SELECT … OVER … ) AS r ON true`.
+    let q = Customer::objects()
+        .join_lateral(ranked_orders(), "r", WhereExpr::And(vec![]))
+        .compile()
+        .unwrap();
+    let sql = Postgres.compile_select(&q).unwrap().sql;
+    assert!(
+        sql.contains("INNER JOIN LATERAL (SELECT "),
+        "lateral kw: {sql}"
+    );
+    assert!(sql.contains("OVER ("), "window inside lateral: {sql}");
+    assert!(sql.contains(r#") AS "r" ON true"#), "on true: {sql}");
 }
 
 #[test]

--- a/crates/rustango/tests/subquery_join_sqlite_live.rs
+++ b/crates/rustango/tests/subquery_join_sqlite_live.rs
@@ -5,7 +5,8 @@
 //! the base model.
 
 use rustango::core::joins::aliased;
-use rustango::core::{Model as _, Op, WhereExpr};
+use rustango::core::window::row_number;
+use rustango::core::{Expr, Model as _, Op, SqlValue, WhereExpr};
 use rustango::sql::{sqlx, Auto, FetcherPool as _, ForeignKey, Pool};
 use rustango::Model;
 
@@ -120,6 +121,72 @@ async fn left_join_sub_keeps_unmatched_rows() {
     let mut names: Vec<String> = rows.into_iter().map(|c| c.name).collect();
     names.sort();
     assert_eq!(names, vec!["Alice", "Bob"]);
+}
+
+/// #1035 — "top-N per group" via a window query joined as a derived
+/// table. The inner query ranks each customer's orders by `total` DESC
+/// with `ROW_NUMBER() OVER (PARTITION BY customer_id ...)`; the outer
+/// query joins that ranked derived table back to the base rows and keeps
+/// only rank ≤ 2. Django's `annotate(rank=Window(...)).filter(rank__lte=2)`
+/// idiom, which previously had no rustango equivalent (windows compile to
+/// an `AggregateQuery`, which `join_sub` didn't accept).
+#[tokio::test]
+async fn window_derived_table_yields_top_n_per_group() {
+    let pool = make_pool().await;
+    let alice = add_customer(&pool, "Alice").await;
+    let bob = add_customer(&pool, "Bob").await;
+    // Alice: 100, 80, 40 → top-2 are 100, 80.
+    add_order(&pool, alice, 100).await;
+    add_order(&pool, alice, 80).await;
+    add_order(&pool, alice, 40).await;
+    // Bob: 200, 50 → top-2 are both (only two orders).
+    add_order(&pool, bob, 200).await;
+    add_order(&pool, bob, 50).await;
+
+    // Inner: ROW_NUMBER() per customer, ordered by total DESC, projected
+    // alongside the id + total so the outer query can join + filter on it.
+    let ranked = Order::objects()
+        .aggregate()
+        .group_by("id")
+        .group_by("customer_id")
+        .group_by("total")
+        .annotate(
+            "rn",
+            row_number()
+                .partition_by("customer_id")
+                .order_by(&[("total", true)]) // DESC
+                .into(),
+        )
+        .compile()
+        .unwrap();
+
+    // Outer: join the ranked derived table back to the base orders on id,
+    // keeping only the top-2 per customer (rn <= 2).
+    let rows = Order::objects()
+        .join_sub(
+            ranked,
+            "r",
+            WhereExpr::And(vec![
+                WhereExpr::ExprCompare {
+                    lhs: aliased("r", "id"),
+                    op: Op::Eq,
+                    rhs: aliased("sj_order", "id"),
+                },
+                WhereExpr::ExprCompare {
+                    lhs: aliased("r", "rn"),
+                    op: Op::Lte,
+                    rhs: Expr::Literal(SqlValue::I64(2)),
+                },
+            ]),
+        )
+        .fetch(&pool)
+        .await
+        .unwrap();
+
+    // 2 (Alice's top-2) + 2 (all of Bob's) = 4 rows; Alice's 40 is dropped.
+    let mut totals: Vec<i64> = rows.iter().map(|o| o.total).collect();
+    totals.sort_unstable();
+    assert_eq!(totals, vec![50, 80, 100, 200], "top-2 per customer");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #1035 (remaining half). Aggregate-as-window (`SUM(...) OVER w`) shipped earlier; this adds the other half — **a window/aggregate query as a derived-table source**.

## Problem

Window functions compile to an `AggregateQuery`, but the derived-table join builders (`join_sub` / `left_join_sub` / `join_lateral` / `left_join_lateral`) only accepted a `SelectQuery`. So Django's "filter on a window result" idiom — `annotate(rank=Window(...)).filter(rank__lte=N)`, i.e. **top-N per group** — had no rustango equivalent. The codebase's own audit notes (`django6_window.rs`) flagged this as impossible.

## Change

- `SubqueryJoin.subquery` becomes a `DerivedSource` enum (`Select` | `Aggregate`) with `From<SelectQuery>` / `From<AggregateQuery>`.
- The four builders + `push_subquery_join` take `impl Into<DerivedSource>` — existing `SelectQuery` callers are **unchanged**; an `AggregateQuery` now works with no ceremony.
- The subquery-join writer dispatches the `Aggregate` variant to the existing `write_aggregate` (same parens / alias / `ON` wrapping, own scope frame). **No new SQL surface.**

Window functions are tri-dialect (PG / MySQL 8.0+ / SQLite 3.25+), so a non-lateral windowed derived table emits everywhere; LATERAL stays PG/MySQL-only (SQLite errors before emission, unchanged).

## Tests

- Emission (all three dialects): windowed aggregate wraps as a derived table with its `OVER (...)` clause; plus a lateral+aggregate case.
- Live SQLite: **top-2 orders per customer** via `ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY total DESC)` joined back and filtered `rn <= 2`.
- All 66 existing window/subquery tests still pass; all-features workspace compiles clean.

Reviewed by a correctness pass (scope-stack balance, PartialEq across variants, builder-widening back-compat, LATERAL+aggregate validity, `write_aggregate` wrap shape, tri-dialect emission) — all clean. Stale audit note in `django6_window.rs` updated.
