### PR TITLE
fix(examples): revive cookbook_blog + CI-gate it + QUERY chapter (#1124, #1114)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,8 +486,13 @@ jobs:
           # The 16-chapter COOKBOOK.md example. Chapters manage their own
           # DB setup (reset/migrate per test), so migrate: false like
           # orm_cookbook. Gated here so it can't silently bit-rot (#1124).
+          # `--test-threads=1`: the chapters create/reset tables in the
+          # shared `public` schema, so they must run serially (as every
+          # chapter's doc comment already documents) — parallel DDL races
+          # on `pg_class`/`pg_type`.
           - example: cookbook_blog
             migrate: false
+            test_args: "-- --test-threads=1"
           - example: admin_demo
             migrate: true
           # Authentication deep-dive docs (docs/auth-*.md). `migrate: false` for
@@ -526,4 +531,4 @@ jobs:
         run: cargo run -- migrate
       - name: Test
         working-directory: crates/rustango/examples/${{ matrix.example }}
-        run: cargo test
+        run: cargo test ${{ matrix.test_args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,11 @@ jobs:
             migrate: true
           - example: orm_cookbook
             migrate: false
+          # The 16-chapter COOKBOOK.md example. Chapters manage their own
+          # DB setup (reset/migrate per test), so migrate: false like
+          # orm_cookbook. Gated here so it can't silently bit-rot (#1124).
+          - example: cookbook_blog
+            migrate: false
           - example: admin_demo
             migrate: true
           # Authentication deep-dive docs (docs/auth-*.md). `migrate: false` for

--- a/crates/rustango/examples/cookbook_blog/COOKBOOK.md
+++ b/crates/rustango/examples/cookbook_blog/COOKBOOK.md
@@ -2339,6 +2339,42 @@ gone.
 9.116b (typed permissions), 9.117 (OpenAPI auto-derive),
 9.118 (response shaping via `.fields(&[...])`) queued for Slice 9b.*
 
+## Chapter 9e — Searching with the HTTP `QUERY` method (RFC 10008)
+
+3 tests, **no DB** — one product-search handler serving both `GET` and
+`QUERY` from the same code. Run with
+`cargo test --test cookbook_chapter09e_query_search`.
+
+`QUERY` is the "safe GET with a body": safe + idempotent like `GET`, but
+the search criteria travel in the request body — so a search too big or
+too structured for a querystring (long filter lists, arrays, nested
+criteria) doesn't have to masquerade as a `POST`. Two pieces combine:
+`QueryRouterExt::query` routes `QUERY` alongside `GET` on one path, and
+the `Params<T>` extractor reads `T` from the querystring on `GET` and
+from the body on `QUERY`.
+
+```rust,ignore
+use rustango::params::Params;
+use rustango::http_query::QueryRouterExt;
+use axum::routing::get;
+
+async fn search(Params(q): Params<ProductQuery>) -> Json<Value> { /* filter */ }
+
+Router::new().route("/products", get(search).query(search));
+```
+
+* §9.119 — `GET /products?q=cable&max_price=15` and the same criteria in
+  a urlencoded `QUERY` body return identical results.
+  → `get_and_query_urlencoded_agree`
+* §9.119 — a `QUERY` JSON body carries a real array (`{"tags":["usb","hdmi"]}`)
+  — awkward in a querystring, natural in a body. → `query_json_body_matches_multiple_tags`
+* §9.119 — an empty `QUERY` body returns the whole catalog.
+  → `empty_query_returns_everything`
+
+See the [QUERY method guide](../../../../docs/query-method.md) for the
+full framework surface (routing, CSRF/CORS, caching, ViewSet `query`
+action, OpenAPI 3.2).
+
 ## Chapter 10 — Templates + static
 
 3 tests on the Tera template surface that the admin (Chapter 8) +

--- a/crates/rustango/examples/cookbook_blog/Cargo.toml
+++ b/crates/rustango/examples/cookbook_blog/Cargo.toml
@@ -20,6 +20,18 @@ path = "src/lib.rs"
 name = "cookbook_blog"
 path = "src/main.rs"
 
+# `#[derive(Model)]` emits backend-specific `sqlx::FromRow` impls gated on
+# THIS crate's feature flags (`#[cfg(feature = "postgres")]` etc.), so the
+# example must define matching features forwarding to rustango — otherwise
+# the FromRow impls compile out and models don't satisfy `MaybePgFromRow`.
+# `default = ["postgres"]` because the chapters run against Postgres.
+# Mirrors `orm_cookbook`.
+[features]
+default = ["postgres"]
+postgres = ["rustango/postgres"]
+mysql = ["rustango/mysql"]
+sqlite = ["rustango/sqlite"]
+
 [dependencies]
 rustango = { path = "../..", default-features = false, features = [
     "postgres", "mysql", "manage", "admin", "config", "forms", "serializer",

--- a/crates/rustango/examples/cookbook_blog/src/apps/blog/urls.rs
+++ b/crates/rustango/examples/cookbook_blog/src/apps/blog/urls.rs
@@ -213,7 +213,7 @@ fn edit_form(id: i64, a: &Author, error: Option<&str>) -> Html<String> {
 
 /// `GET /whoami` — demonstrates the [`SessionUser`] cookie extractor.
 ///
-/// Anonymous → 401. Logged-in (via the tenant `__login` cookie flow) →
+/// Anonymous → 401. Logged-in (via the tenant `/login` cookie flow) →
 /// 200 with `{ "username": ..., "is_superuser": ... }`. The extractor
 /// resolves the request's tenant via [`rustango::extractors::TenantContext`]
 /// and validates the cookie against that tenant's slug — a cookie minted

--- a/crates/rustango/examples/cookbook_blog/src/apps/blog/urls.rs
+++ b/crates/rustango/examples/cookbook_blog/src/apps/blog/urls.rs
@@ -12,7 +12,6 @@ use axum::response::{Html, IntoResponse, Json, Redirect};
 use axum::routing::get;
 use axum::Router;
 
-use rustango::core::Op;
 use rustango::extractors::{SessionUser, Tenant};
 use rustango::forms::ModelFormFor;
 use rustango::sql::Auto;

--- a/crates/rustango/examples/cookbook_blog/src/apps/blog/urls.rs
+++ b/crates/rustango/examples/cookbook_blog/src/apps/blog/urls.rs
@@ -37,7 +37,7 @@ async fn retrieve(
     Path(id): Path<i64>,
 ) -> Result<Json<AuthorOut>, (StatusCode, String)> {
     let row: Vec<Author> = Author::objects()
-        .filter("id", Op::Eq, id)
+        .filter("id", id)
         .fetch_on(tenant.conn())
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -136,7 +136,7 @@ async fn show_edit_form(
     Path(id): Path<i64>,
 ) -> Result<Html<String>, (StatusCode, String)> {
     let mut rows: Vec<Author> = Author::objects()
-        .filter("id", Op::Eq, id)
+        .filter("id", id)
         .fetch_on(tenant.conn())
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter02_models.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter02_models.rs
@@ -9,7 +9,7 @@
 //! drops + recreates its tables so reruns are deterministic.
 
 use cookbook_blog::apps::blog::models::*;
-use rustango::core::{Model as _, Op};
+use rustango::core::Op;
 use rustango::sql::{sqlx, Auto, };
 
 fn url() -> Option<String> {
@@ -559,8 +559,8 @@ async fn generic_fk_schema_and_content_type_lookup() {
 
     // ContentType lookup against an arbitrary registered model — Author
     // is registered by this binary's inventory.
-    rustango::contenttypes::ensure_seeded(&pool).await.expect("seed contenttypes");
-    let ct = rustango::contenttypes::ContentType::for_model::<Author>(&pool)
+    rustango::contenttypes::ensure_seeded(&pool.clone().into()).await.expect("seed contenttypes");
+    let ct = rustango::contenttypes::ContentType::for_model::<Author>(&pool.clone().into())
         .await
         .expect("ContentType lookup")
         .expect("ContentType row should exist after ensure_seeded");

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter02_models.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter02_models.rs
@@ -209,7 +209,7 @@ async fn option_field_round_trips_null() {
 
     let id = match a.id { Auto::Set(v) => v, Auto::Unset => unreachable!() };
     let row: Vec<Author> = Author::objects()
-        .filter("id", Op::Eq, id).fetch_on(&pool).await.unwrap();
+        .filter_op("id", Op::Eq, id).fetch_on(&pool).await.unwrap();
     assert_eq!(row.len(), 1);
     assert_eq!(row[0].bio, None, "Option<String>::None should round-trip as NULL");
 }
@@ -231,7 +231,7 @@ async fn auto_now_add_assigns_at_insert() {
     let id = match a.id { Auto::Set(v) => v, Auto::Unset => unreachable!() };
 
     let row: Vec<Author> = Author::objects()
-        .filter("id", Op::Eq, id).fetch_on(&pool).await.unwrap();
+        .filter_op("id", Op::Eq, id).fetch_on(&pool).await.unwrap();
     let joined = match row[0].joined_at {
         Auto::Set(t) => t,
         Auto::Unset => panic!("auto_now_add did not populate joined_at"),
@@ -321,7 +321,7 @@ async fn fk_column_round_trips() {
     p.save(&pool).await.unwrap();
 
     let posts: Vec<Post> = Post::objects()
-        .filter("author_id", Op::Eq, author_id).fetch_on(&pool).await.unwrap();
+        .filter_op("author_id", Op::Eq, author_id).fetch_on(&pool).await.unwrap();
     assert_eq!(posts.len(), 1);
     assert_eq!(posts[0].title, "first");
     assert_eq!(posts[0].metadata["tags"][0], "intro");
@@ -361,7 +361,7 @@ async fn jsonb_field_round_trips_structured_data() {
     p.save(&pool).await.unwrap();
 
     let posts: Vec<Post> = Post::objects()
-        .filter("slug", Op::Eq, "j").fetch_on(&pool).await.unwrap();
+        .filter_op("slug", Op::Eq, "j").fetch_on(&pool).await.unwrap();
     assert_eq!(posts[0].metadata, payload);
 }
 
@@ -406,9 +406,9 @@ async fn datetime_option_round_trips() {
     };
     p2.save(&pool).await.unwrap();
 
-    let now_back: Vec<Post> = Post::objects().filter("slug", Op::Eq, "now").fetch_on(&pool).await.unwrap();
+    let now_back: Vec<Post> = Post::objects().filter_op("slug", Op::Eq, "now").fetch_on(&pool).await.unwrap();
     assert!(now_back[0].published_at.is_some(), "Some(when) lost on round-trip");
-    let never_back: Vec<Post> = Post::objects().filter("slug", Op::Eq, "never").fetch_on(&pool).await.unwrap();
+    let never_back: Vec<Post> = Post::objects().filter_op("slug", Op::Eq, "never").fetch_on(&pool).await.unwrap();
     assert_eq!(never_back[0].published_at, None);
 }
 
@@ -585,7 +585,7 @@ async fn generic_fk_schema_and_content_type_lookup() {
     act.save(&pool).await.expect("activity insert");
 
     let rows: Vec<Activity> = Activity::objects()
-        .filter("target_object_pk", Op::Eq, author_id).fetch_on(&pool).await.unwrap();
+        .filter_op("target_object_pk", Op::Eq, author_id).fetch_on(&pool).await.unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].action, "viewed");
 }
@@ -605,7 +605,7 @@ async fn soft_delete_column_round_trips_and_deleted_at_defaults_null() {
     let id = match n.id { Auto::Set(v) => v, _ => unreachable!() };
 
     let rows: Vec<ArchiveNote> = ArchiveNote::objects()
-        .filter("id", Op::Eq, id).fetch_on(&pool).await.unwrap();
+        .filter_op("id", Op::Eq, id).fetch_on(&pool).await.unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].deleted_at, None, "fresh row deleted_at should be NULL");
 }

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter03_orm.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter03_orm.rs
@@ -87,7 +87,7 @@ async fn filter_eq_fetch_returns_matching_rows() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let published: Vec<Post> = Post::objects()
-        .filter("published", Op::Eq, true).fetch_on(&pool).await.unwrap();
+        .filter_op("published", Op::Eq, true).fetch_on(&pool).await.unwrap();
     assert_eq!(published.len(), 3, "3 of 5 posts are published");
     for p in &published { assert!(p.published, "filter must keep only published"); }
 }
@@ -100,7 +100,7 @@ async fn filter_with_gt_lt_op() {
     let popular: Vec<Post> = Post::objects()
         // Bind as i64 — the column is BIGINT, and `90` would otherwise
         // infer as i32 and trip rustango's TypeMismatch guard.
-        .filter("view_count", Op::Gt, 90i64).fetch_on(&pool).await.unwrap();
+        .filter_op("view_count", Op::Gt, 90i64).fetch_on(&pool).await.unwrap();
     assert_eq!(popular.len(), 2, "view_count>90: rust-orm(100) + django-shape(250)");
     let titles: Vec<&str> = popular.iter().map(|p| p.title.as_str()).collect();
     assert!(titles.contains(&"Rust ORM"));
@@ -113,7 +113,7 @@ async fn filter_with_ilike_case_insensitive() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let drafts: Vec<Post> = Post::objects()
-        .filter("title", Op::ILike, "%draft%").fetch_on(&pool).await.unwrap();
+        .filter_op("title", Op::ILike, "%draft%").fetch_on(&pool).await.unwrap();
     assert_eq!(drafts.len(), 2);
 }
 
@@ -124,7 +124,7 @@ async fn filter_with_in_list() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let picks: Vec<Post> = Post::objects()
-        .filter("slug", Op::In, SqlValue::List(vec![
+        .filter_op("slug", Op::In, SqlValue::List(vec![
             SqlValue::String("rust-orm".into()),
             SqlValue::String("axum-101".into()),
         ])).fetch_on(&pool).await.unwrap();
@@ -138,7 +138,7 @@ async fn filter_with_between_range() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let mid: Vec<Post> = Post::objects()
-        .filter("view_count", Op::Between, SqlValue::List(vec![
+        .filter_op("view_count", Op::Between, SqlValue::List(vec![
             SqlValue::I64(50), SqlValue::I64(150),
         ])).fetch_on(&pool).await.unwrap();
     assert_eq!(mid.len(), 2, "axum-101(80) + rust-orm(100) within [50, 150]");
@@ -151,7 +151,7 @@ async fn filter_with_is_null_unpublished() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let drafts: Vec<Post> = Post::objects()
-        .filter("published_at", Op::IsNull, SqlValue::Bool(true)).fetch_on(&pool).await.unwrap();
+        .filter_op("published_at", Op::IsNull, SqlValue::Bool(true)).fetch_on(&pool).await.unwrap();
     assert_eq!(drafts.len(), 2, "draft-1 + draft-2 have NULL published_at");
 }
 
@@ -161,7 +161,7 @@ async fn order_by_view_count_desc() {
     let Some(pool) = pool().await else { return };
     let _ = fresh_blog(&pool).await;
     let by_views: Vec<Post> = Post::objects()
-        .filter("published", Op::Eq, true)
+        .filter_op("published", Op::Eq, true)
         // QuerySet::order_by uses (column, desc): true = DESC, false = ASC.
         .order_by(&[("view_count", true)]).fetch_on(&pool).await.unwrap();
     assert_eq!(by_views[0].slug, "django-shape", "250 views first");
@@ -193,7 +193,7 @@ async fn aggregate_count_and_sum() {
     let _ = fresh_blog(&pool).await;
 
     let q = Post::objects()
-        .filter("published", Op::Eq, true)
+        .filter_op("published", Op::Eq, true)
         .aggregate()
         .annotate("total", AggregateExpr::Count(None))
         .annotate("views", AggregateExpr::Sum("view_count"))
@@ -234,7 +234,7 @@ async fn save_inserts_then_updates_in_place() {
     p.save(&pool).await.unwrap();
 
     let back: Vec<Post> = Post::objects()
-        .filter("id", Op::Eq, id).fetch_on(&pool).await.unwrap();
+        .filter_op("id", Op::Eq, id).fetch_on(&pool).await.unwrap();
     assert_eq!(back[0].body, "v2");
     assert!(back[0].published);
 }

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter03_orm.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter03_orm.rs
@@ -194,6 +194,10 @@ async fn aggregate_count_and_sum() {
     let q = Post::objects()
         .filter_op("published", Op::Eq, true)
         .aggregate()
+        // `.values(&[])` → a scalar aggregate that projects only the
+        // annotations (one summary row), rather than grouping by / emitting
+        // the base columns per row.
+        .values(&[])
         .annotate("total", AggregateExpr::Count(None))
         .annotate("views", AggregateExpr::Sum("view_count"))
         .compile()

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter03_orm.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter03_orm.rs
@@ -8,7 +8,6 @@
 use cookbook_blog::apps::blog::models::*;
 use rustango::core::Op;
 use rustango::sql::{sqlx, Auto, };
-use rustango::Model;
 
 fn url() -> Option<String> {
     std::env::var("DATABASE_URL").ok()
@@ -199,7 +198,7 @@ async fn aggregate_count_and_sum() {
         .annotate("views", AggregateExpr::Sum("view_count"))
         .compile()
         .unwrap();
-    let rows = fetch_aggregate(&q, &pool).await.unwrap();
+    let rows = fetch_aggregate_on(&q, &pool).await.unwrap();
     assert_eq!(rows.len(), 1, "no GROUP BY → one summary row");
     let row = &rows[0];
     match row.get("total") {
@@ -325,7 +324,7 @@ async fn where_expr_not_negates_predicate() {
     for p in &drafts { assert!(!p.published); }
 }
 
-// §3.43 — bulk_insert in one round-trip via BulkInsertQuery.
+// §3.43 — bulk_insert_on in one round-trip via BulkInsertQuery.
 #[tokio::test]
 async fn bulk_insert_writes_many_rows_in_one_round_trip() {
     use rustango::core::{BulkInsertQuery, SqlValue};
@@ -357,7 +356,7 @@ async fn bulk_insert_writes_many_rows_in_one_round_trip() {
         returning: vec!["id"],
         on_conflict: None,
     };
-    let returned = bulk_insert(&pool, &q).await.expect("bulk insert");
+    let returned = bulk_insert_on(&pool, &q).await.expect("bulk insert");
     assert_eq!(returned.len(), 4, "4 RETURNING rows");
 
     let count: i64 = sqlx::query_scalar(

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter04_migrations.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter04_migrations.rs
@@ -21,12 +21,21 @@ async fn pool() -> Option<sqlx::PgPool> {
 }
 
 // §4.56 — embed_migrations! covered in chapter01; here we re-assert
-// the const carries our 0001_initial.json so apps relying on it ship
-// migrations baked into the binary.
+// the const carries the cookbook's own tables migration so apps relying
+// on it ship migrations baked into the binary.
 #[test]
 fn embedded_migrations_const_is_loaded() {
     assert!(!cookbook_blog::EMBEDDED.is_empty());
-    assert!(cookbook_blog::EMBEDDED.iter().any(|(name, _)| *name == "0001_initial"));
+    assert!(
+        cookbook_blog::EMBEDDED
+            .iter()
+            .any(|(name, _)| *name == "0002_cookbook_tables"),
+        "embedded names: {:?}",
+        cookbook_blog::EMBEDDED
+            .iter()
+            .map(|(n, _)| *n)
+            .collect::<Vec<_>>()
+    );
 }
 
 // §4.55 / §4.57 / §4.58 — migration file format: serde_json round-trip

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter05_tenancy.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter05_tenancy.rs
@@ -67,7 +67,7 @@ async fn provision_two_tenants_then_resolve_and_lazy_pool() {
         let req = http::Request::get("http://cookbook_acme.cookbook-test.local/")
             .body(()).unwrap();
         let parts = req.into_parts().0;
-        let org = r.resolve(&parts, &registry).await.expect("resolve");
+        let org = r.resolve(&parts, &registry.clone().into()).await.expect("resolve");
         let org = org.expect("subdomain resolver should match seeded acme tenant");
         assert_eq!(org.slug, "cookbook_acme");
     }
@@ -78,7 +78,7 @@ async fn provision_two_tenants_then_resolve_and_lazy_pool() {
         let mut req = http::Request::get("http://localhost/").body(()).unwrap();
         req.headers_mut().insert("X-Org", "cookbook_globex".parse().unwrap());
         let parts = req.into_parts().0;
-        let org = r.resolve(&parts, &registry).await.expect("resolve");
+        let org = r.resolve(&parts, &registry.clone().into()).await.expect("resolve");
         let org = org.expect("X-Org should match seeded globex tenant");
         assert_eq!(org.slug, "cookbook_globex");
     }
@@ -92,7 +92,7 @@ async fn provision_two_tenants_then_resolve_and_lazy_pool() {
         let mut req = http::Request::get("http://localhost/").body(()).unwrap();
         req.headers_mut().insert("X-Org", "cookbook_acme".parse().unwrap());
         let parts = req.into_parts().0;
-        let org = r.resolve(&parts, &registry).await.expect("resolve");
+        let org = r.resolve(&parts, &registry.clone().into()).await.expect("resolve");
         let org = org.expect("chain should fall through to header arm");
         assert_eq!(org.slug, "cookbook_acme");
     }

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter06b_user_extractors.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter06b_user_extractors.rs
@@ -293,7 +293,7 @@ async fn session_user_resolves_browser_cookie_and_falls_back_to_anonymous() {
     }
     let app: Router = Router::new()
         .route("/profile", get(profile))
-        .require_auth(backends, pool.clone());
+        .require_auth(backends, pool.clone().into());
 
     // (a) No credentials → 401.
     let (status, _body) = oneshot(app.clone(), Method::GET, "/profile", None, None).await;

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter06b_user_extractors.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter06b_user_extractors.rs
@@ -4,7 +4,7 @@
 //!
 //! | Pattern | Identifies | When to reach for it |
 //! |---|---|---|
-//! | [`SessionUser`] extractor | The browser-cookie tenant user | Multi-tenant HTML / JSON routes that share the admin's `__login` cookie. Returns `None` for anonymous — never rejects. |
+//! | [`SessionUser`] extractor | The browser-cookie tenant user | Multi-tenant HTML / JSON routes that share the admin's `/login` cookie. Returns `None` for anonymous — never rejects. |
 //! | [`CurrentUser`] extractor + `RouterAuthExt::require_auth` | An [`AuthenticatedUser`] resolved by a backend chain | Single-pool API routes. Middleware short-circuits with 401 when no backend matches. |
 //! | [`ApiKeyBackend`] inside the chain | `Authorization: Bearer <prefix.secret>` | Headless clients (CI, scripts) that cannot present a cookie. |
 //!
@@ -103,7 +103,7 @@ async fn wait_ready() {
     let deadline = Instant::now() + Duration::from_secs(20);
     while Instant::now() < deadline {
         if reqwest::Client::new()
-            .get(format!("http://{BIND}/__login"))
+            .get(format!("http://{BIND}/login"))
             .header("Host", format!("{TENANT}.{APEX}"))
             .send()
             .await
@@ -201,9 +201,9 @@ async fn session_user_resolves_browser_cookie_and_falls_back_to_anonymous() {
         .unwrap();
     assert_eq!(resp.status().as_u16(), 401, "anonymous /whoami should be 401");
 
-    // Step 2 — log in via the tenant `__login` cookie route.
+    // Step 2 — log in via the tenant `/login` cookie route.
     let resp = client
-        .post(format!("http://{BIND}/__login"))
+        .post(format!("http://{BIND}/login"))
         .header("Host", &host)
         .form(&[("username", USERNAME), ("password", PASSWORD)])
         .send()

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter07e_unique_together_validator.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter07e_unique_together_validator.rs
@@ -5,7 +5,7 @@
 //! form re-render would carry the raw Postgres error (`duplicate
 //! key value violates unique constraint "..."`).
 //!
-//! `ModelFormFor::validate_unique_together(&pool, pk_value)` walks
+//! `ModelFormFor::validate_unique_together(&pool.clone().into(), pk_value)` walks
 //! every composite-unique index on the model and SELECTs the
 //! conflicting tuple before the INSERT/UPDATE. Hits become friendly
 //! per-field FormErrors keyed by every column in the conflict.
@@ -50,7 +50,7 @@ async fn validator_accepts_when_no_existing_pair() {
     fresh(&pool).await;
 
     let mf = ModelFormFor::<Membership>::parse(&payload("10", "20", "owner")).unwrap();
-    mf.validate_unique_together(&pool, None).await.expect("no conflict");
+    mf.validate_unique_together(&pool.clone().into(), None).await.expect("no conflict");
 }
 
 // §7e.2 — existing (org, user) → validator rejects with per-field
@@ -67,7 +67,7 @@ async fn validator_rejects_with_per_field_errors_on_create() {
     // Now a new form with the same (10, 20) pair must fail validation
     // BEFORE any INSERT.
     let mf = ModelFormFor::<Membership>::parse(&payload("10", "20", "viewer")).unwrap();
-    let err = mf.validate_unique_together(&pool, None).await
+    let err = mf.validate_unique_together(&pool.clone().into(), None).await
         .expect_err("validator must reject the duplicate pair");
     let s = format!("{err:?}");
     // Errors are keyed by both columns — DRF-shape per-field surface.
@@ -88,10 +88,10 @@ async fn validator_accepts_different_pair() {
 
     // (10, 99) is a different tuple — ok.
     let mf = ModelFormFor::<Membership>::parse(&payload("10", "99", "viewer")).unwrap();
-    mf.validate_unique_together(&pool, None).await.expect("(10,99) is unique vs (10,20)");
+    mf.validate_unique_together(&pool.clone().into(), None).await.expect("(10,99) is unique vs (10,20)");
     // (99, 20) likewise.
     let mf = ModelFormFor::<Membership>::parse(&payload("99", "20", "viewer")).unwrap();
-    mf.validate_unique_together(&pool, None).await.expect("(99,20) is unique vs (10,20)");
+    mf.validate_unique_together(&pool.clone().into(), None).await.expect("(99,20) is unique vs (10,20)");
 }
 
 // §7e.4 — UPDATE: pass the row's own PK so its existing tuple isn't
@@ -110,7 +110,7 @@ async fn validator_excludes_own_row_on_update() {
     // pk_value the validator would reject (the row's own tuple is its
     // own conflict). Passing pk_value skips it.
     let mf = ModelFormFor::<Membership>::parse(&payload("10", "20", "admin")).unwrap();
-    mf.validate_unique_together(&pool, Some(&SqlValue::I64(pk))).await
+    mf.validate_unique_together(&pool.clone().into(), Some(&SqlValue::I64(pk))).await
         .expect("own row excluded — UPDATE is fine");
 
     // But if we set a DIFFERENT row's tuple, validator still rejects.
@@ -120,6 +120,6 @@ async fn validator_excludes_own_row_on_update() {
 
     // Try to UPDATE row #2 to row #1's tuple → conflict.
     let mf = ModelFormFor::<Membership>::parse(&payload("10", "20", "viewer")).unwrap();
-    mf.validate_unique_together(&pool, Some(&SqlValue::I64(pk2))).await
+    mf.validate_unique_together(&pool.clone().into(), Some(&SqlValue::I64(pk2))).await
         .expect_err("conflicting pair on a different row must reject");
 }

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter08b_browser_forms.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter08b_browser_forms.rs
@@ -2,7 +2,7 @@
 //!
 //! Spins up the actual `cookbook_blog` binary against an isolated DB,
 //! provisions two tenants + a tenant user, drives the admin form
-//! through HTTP (login → POST /__admin/<table> → verify list), then
+//! through HTTP (login → POST /admin/<table> → verify list), then
 //! exercises the tenant-aware /api/authors ViewSet from both tenants
 //! to confirm data isolation.
 //!
@@ -32,6 +32,15 @@ async fn db_url() -> Option<String> {
 async fn reset_db() {
     let Some(base) = url() else { return };
     let admin_pool = sqlx::PgPool::connect(&base).await.expect("connect to admin db");
+    // Terminate any lingering connections to the test DB before DROP,
+    // otherwise Postgres rejects with 55006 ("being accessed by other
+    // users"). Matches chapter06b's reset_db.
+    let _ = sqlx::query(&format!(
+        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+         WHERE datname = '{DB_NAME}' AND pid <> pg_backend_pid()"
+    ))
+    .execute(&admin_pool)
+    .await;
     sqlx::query(&format!("DROP DATABASE IF EXISTS {DB_NAME}"))
         .execute(&admin_pool).await.unwrap();
     sqlx::query(&format!("CREATE DATABASE {DB_NAME}"))
@@ -120,7 +129,7 @@ async fn admin_form_creates_then_viewset_isolates_per_tenant() {
     // 1. Login as alice on acme tenant.
     let login_body = [("username", "alice"), ("password", "tenantpw")];
     let resp = client
-        .post(format!("http://{BIND}/__login"))
+        .post(format!("http://{BIND}/login"))
         .header("Host", "acme.localhost")
         .form(&login_body)
         .send().await.unwrap();
@@ -136,7 +145,7 @@ async fn admin_form_creates_then_viewset_isolates_per_tenant() {
         ("bio",   "first programmer"),
     ];
     let resp = client
-        .post(format!("http://{BIND}/__admin/cookbook_author"))
+        .post(format!("http://{BIND}/admin/cookbook_author"))
         .header("Host", "acme.localhost")
         .form(&create_body)
         .send().await.unwrap();

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter09c_template_views.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter09c_template_views.rs
@@ -98,30 +98,30 @@ fn router(pool: sqlx::PgPool, tera: Arc<Tera>) -> axum::Router {
                 .filter_fields(&["name"])
                 .search_fields(&["name", "email"])
                 .ordering_fields(&["name", "id"])
-                .router("/authors", tera.clone(), pool.clone()),
+                .router("/authors", tera.clone(), pool.clone().into()),
         )
         .merge(
             DetailView::for_model(Author::SCHEMA)
                 .template("cookbook_author_detail.html")
-                .router("/authors", tera.clone(), pool.clone()),
+                .router("/authors", tera.clone(), pool.clone().into()),
         )
         .merge(
             CreateView::for_model(Author::SCHEMA)
                 .template("cookbook_author_form.html")
                 .success_url("/authors/{pk}")
-                .router("/authors", tera.clone(), pool.clone()),
+                .router("/authors", tera.clone(), pool.clone().into()),
         )
         .merge(
             UpdateView::for_model(Author::SCHEMA)
                 .template("cookbook_author_form.html")
                 .success_url("/authors/{pk}")
-                .router("/authors", tera.clone(), pool.clone()),
+                .router("/authors", tera.clone(), pool.clone().into()),
         )
         .merge(
             DeleteView::for_model(Author::SCHEMA)
                 .template("cookbook_author_confirm_delete.html")
                 .success_url("/authors")
-                .router("/authors", tera, pool),
+                .router("/authors", tera, pool.into()),
         )
 }
 

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter09d_viewset_tenant_router.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter09d_viewset_tenant_router.rs
@@ -148,7 +148,8 @@ async fn fixture() -> Option<(String, sqlx::PgPool, axum::Router)> {
         resolver,
         session_secret: SessionSecret::from_bytes(b"a-test-secret-thirty-two-bytes-x".to_vec()),
         operator_secret: SessionSecret::from_bytes(b"a-test-secret-thirty-two-bytes-y".to_vec()),
-        registry: pool.clone(),
+        // v0.30 unification: the registry pool now lives inside `pools`
+        // (TenantPools); TenantContext no longer has a `registry` field.
     });
 
     // §9.116 / §9.116b — same builder chain that works for the static

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter09e_query_search.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter09e_query_search.rs
@@ -1,0 +1,163 @@
+//! Cookbook Chapter 9e — searching with the HTTP `QUERY` method (RFC 10008).
+//!
+//! `QUERY` is the "safe GET with a body": safe + idempotent like `GET`, but
+//! the search criteria travel in the request body. That lets a search
+//! endpoint accept criteria too big or too structured for a querystring
+//! (long filter lists, nested criteria) without pretending to be a `POST`.
+//!
+//! This chapter builds one product-search handler that serves **both**
+//! transports from the same code:
+//!
+//! - `GET /products?q=cable&max_price=20` — the flat, bookmarkable form.
+//! - `QUERY /products` with a JSON body `{"q":"cable","tags":["usb","hdmi"]}`
+//!   — arrays / structured criteria that a querystring can't express well.
+//!
+//! The trick is two rustango pieces working together:
+//!
+//! | Piece | Role |
+//! |---|---|
+//! | [`QueryRouterExt::query`] | routes `QUERY` alongside `GET` on one path |
+//! | [`Params<T>`] | reads `T` from the querystring on GET and from the body on QUERY |
+//!
+//! No database, no network — the handler filters an in-memory catalog and
+//! the test drives it with [`TestClient`], so this chapter runs anywhere.
+//!
+//! Run: `cargo test --test cookbook_chapter09e_query_search`
+//!
+//! [`QueryRouterExt::query`]: rustango::http_query::QueryRouterExt::query
+//! [`Params<T>`]: rustango::params::Params
+//! [`TestClient`]: rustango::test_client::TestClient
+
+use axum::routing::get;
+use axum::Router;
+use rustango::http_query::QueryRouterExt as _;
+use rustango::params::Params;
+use rustango::test_client::TestClient;
+use serde::Deserialize;
+
+// --------------------------------------------------------------------------
+// The catalog + the search criteria.
+// --------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct Product {
+    name: &'static str,
+    price: u32,
+    tags: &'static [&'static str],
+}
+
+fn catalog() -> Vec<Product> {
+    vec![
+        Product { name: "USB-C cable", price: 12, tags: &["usb", "cable"] },
+        Product { name: "HDMI cable", price: 18, tags: &["hdmi", "cable"] },
+        Product { name: "USB hub", price: 35, tags: &["usb", "hub"] },
+        Product { name: "Laptop stand", price: 40, tags: &["desk"] },
+    ]
+}
+
+/// Search criteria. The SAME struct deserializes from a GET querystring
+/// (`?q=cable&max_price=20`) and from a QUERY body — urlencoded (flat) or
+/// JSON (where `tags` can be a real array).
+#[derive(Debug, Default, Deserialize)]
+struct ProductQuery {
+    /// Case-insensitive substring match on the product name.
+    #[serde(default)]
+    q: Option<String>,
+    /// Upper price bound (inclusive).
+    #[serde(default)]
+    max_price: Option<u32>,
+    /// Match any of these tags. Expressible as a JSON array on QUERY;
+    /// urlencoded is single-value, so pass one tag or use a JSON body.
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
+/// One handler, both transports. `Params` sources the criteria from the
+/// querystring on GET/HEAD and from the request body on QUERY.
+async fn search(Params(query): Params<ProductQuery>) -> axum::Json<serde_json::Value> {
+    let names: Vec<&'static str> = catalog()
+        .into_iter()
+        .filter(|p| {
+            query
+                .q
+                .as_deref()
+                .is_none_or(|needle| p.name.to_lowercase().contains(&needle.to_lowercase()))
+        })
+        .filter(|p| query.max_price.is_none_or(|max| p.price <= max))
+        .filter(|p| query.tags.is_empty() || query.tags.iter().any(|t| p.tags.contains(&t.as_str())))
+        .map(|p| p.name)
+        .collect();
+    axum::Json(serde_json::json!({ "results": names }))
+}
+
+fn app() -> Router {
+    // `get(search).query(search)` mounts the same handler on GET and QUERY.
+    Router::new().route("/products", get(search).query(search))
+}
+
+fn names(v: &serde_json::Value) -> Vec<String> {
+    v["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .map(|n| n.as_str().unwrap().to_owned())
+        .collect()
+}
+
+// --------------------------------------------------------------------------
+// §9e.1 — GET and QUERY (urlencoded) are interchangeable.
+// --------------------------------------------------------------------------
+#[tokio::test]
+async fn get_and_query_urlencoded_agree() {
+    let client = TestClient::new(app());
+
+    // GET with a querystring.
+    let via_get = client.get("/products?q=cable&max_price=15").send().await;
+    assert_eq!(via_get.status, 200);
+    assert_eq!(names(&via_get.json_value()), vec!["USB-C cable"]);
+
+    // QUERY with the identical criteria in an urlencoded body — same rows.
+    let via_query = client
+        .query("/products")
+        .form(&[("q", "cable"), ("max_price", "15")])
+        .send()
+        .await;
+    assert_eq!(via_query.status, 200);
+    assert_eq!(
+        names(&via_query.json_value()),
+        names(&via_get.json_value()),
+        "GET and QUERY must return the same results for the same criteria"
+    );
+}
+
+// --------------------------------------------------------------------------
+// §9e.2 — QUERY unlocks a JSON body: arrays / structured criteria.
+// --------------------------------------------------------------------------
+#[tokio::test]
+async fn query_json_body_matches_multiple_tags() {
+    let client = TestClient::new(app());
+
+    // `tags` is a real array here — awkward to express in a querystring,
+    // natural in a QUERY JSON body.
+    let resp = client
+        .query("/products")
+        .json(&serde_json::json!({ "tags": ["usb", "hdmi"] }))
+        .send()
+        .await;
+    assert_eq!(resp.status, 200);
+    let mut got = names(&resp.json_value());
+    got.sort();
+    // Everything tagged usb OR hdmi: the two cables + the hub.
+    assert_eq!(got, vec!["HDMI cable", "USB hub", "USB-C cable"]);
+}
+
+// --------------------------------------------------------------------------
+// §9e.3 — an empty QUERY body returns the whole catalog (no criteria).
+// --------------------------------------------------------------------------
+#[tokio::test]
+async fn empty_query_returns_everything() {
+    let client = TestClient::new(app());
+    let resp = client.query("/products").json(&serde_json::json!({})).send().await;
+    assert_eq!(resp.status, 200);
+    assert_eq!(names(&resp.json_value()).len(), 4);
+}

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter12_bidialect.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter12_bidialect.rs
@@ -60,7 +60,7 @@ async fn cookbook_rating_round_trips_against_mysql() {
     assert!(id > 0, "MySQL AUTO_INCREMENT must assign positive id");
 
     let rows: Vec<Rating> = Rating::objects()
-        .filter("id", Op::Eq, id)
+        .filter_op("id", Op::Eq, id)
         .fetch(&p).await.expect("fetch against mysql");
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].score, 4);
@@ -95,7 +95,7 @@ async fn mysql_multi_auto_inserts_then_refetches_for_remaining_fields() {
     // path — same shape as Django apps that .refresh_from_db() after
     // save when they need server-set timestamps.
     let rows: Vec<Author> = Author::objects()
-        .filter("id", Op::Eq, id)
+        .filter_op("id", Op::Eq, id)
         .fetch(&p).await.unwrap();
     assert_eq!(rows.len(), 1);
     let loaded_joined_at = match rows[0].joined_at {

--- a/crates/rustango/src/forms/mod.rs
+++ b/crates/rustango/src/forms/mod.rs
@@ -1367,10 +1367,16 @@ impl<T: crate::core::Model> ModelFormFor<T> {
             if !all_present {
                 continue;
             }
-            // Build `SELECT 1 FROM <table> WHERE c1 = ? AND c2 = ? [...] [AND pk <> ?] LIMIT 1`
-            // with dialect-aware quoting + placeholders.
+            // Build `SELECT COUNT(*) FROM <table> WHERE c1 = ? AND c2 = ?
+            // [...] [AND pk <> ?]` with dialect-aware quoting + placeholders.
+            //
+            // `COUNT(*)` (not `SELECT 1 … LIMIT 1`) because the result is
+            // decoded as `(i64,)`: PG types the literal `1` as `INT4`, so
+            // `SELECT 1` fails to decode into `i64` on Postgres (the
+            // SQLite-only test never caught it). `COUNT(*)` is `bigint` on
+            // PG / MySQL / SQLite alike, so `(i64,)` decodes everywhere.
             let table_q = dialect.quote_ident(T::SCHEMA.table);
-            let mut sql = format!("SELECT 1 FROM {table_q} WHERE ");
+            let mut sql = format!("SELECT COUNT(*) FROM {table_q} WHERE ");
             let mut binds: Vec<crate::core::SqlValue> = Vec::new();
             let mut sep = "";
             for (i, (col, val)) in bound.iter().enumerate() {
@@ -1388,18 +1394,16 @@ impl<T: crate::core::Model> ModelFormFor<T> {
                 sql.push_str(&format!(" AND {pk_col} <> {ph}"));
                 binds.push(pk_v.clone());
             }
-            sql.push_str(" LIMIT 1");
             // #561 — was a 3-arm `match pool` each doing the same
             // bind-loop via per-backend `bind_sql_value_inline*` helpers
             // then `fetch_optional`. The executor's `raw_query_pool` plus
             // the canonical `bind_match!` macros already handle every
-            // backend's bind shape — collapse to one call. SELECT
-            // shape is `SELECT 1 FROM <table> WHERE ... LIMIT 1`, so
-            // `(i64,)` tuple decodes positionally and `is_empty()` on
-            // the returned Vec answers the existence check.
+            // backend's bind shape — collapse to one call. `SELECT COUNT(*)`
+            // returns exactly one row whose `(i64,)` count answers the
+            // existence check (`> 0`).
             let exists = crate::sql::raw_query_pool::<(i64,)>(&sql, binds, pool)
                 .await
-                .map(|rows| !rows.is_empty())
+                .map(|rows| rows.first().is_some_and(|(n,)| *n > 0))
                 .map_err(|e| match e {
                     crate::sql::ExecError::Driver(err) => err,
                     other => crate::sql::sqlx::Error::Protocol(format!("{other}")),


### PR DESCRIPTION
Closes #1124. Closes #1114.

The `cookbook_blog` example (the 16-chapter `COOKBOOK.md`) had silently bit-rotted — it didn't compile and **wasn't in CI**. This revives it, gates it in CI so it can't rot again, and adds the QUERY recipe chapter (#1114) that was blocked on it.

## Root cause + fix

`cookbook_blog/Cargo.toml` had **no `[features]` section**, so `#[derive(Model)]`'s `#[cfg(feature = "postgres")]`-gated `FromRow` impls compiled out and every model failed `MaybePgFromRow`. Added the section (`default = ["postgres"]` + forwards), mirroring `orm_cookbook`.

Then the usual API bit-rot (all compiler-verified):
- **filter API** — `.filter(k, Op::X, v)` (3-arg) → `.filter_op(k, Op::X, v)` (19 sites, ch02/03/12).
- **`PgPool` → `sql::Pool`** (v0.36 multi-backend) — `&pool.clone().into()` at rustango-API call sites, keeping raw `sqlx` uses on `&PgPool` (ch02/05/06b/07e/09c).
- `fetch_aggregate`→`fetch_aggregate_on`, `bulk_insert`→`bulk_insert_on` (ch03).
- dropped the removed `TenantContext.registry` field (ch09d — the registry pool lives in `pools` now).
- fixed a stale embedded-migration-name assertion (ch04: `0002_cookbook_tables`, not `0001_initial`).
- removed 3 now-unused imports.

## Durable fix

**Added `cookbook_blog` to the `doc_examples` CI matrix** (`migrate: false`; Postgres service already provided) — this is the part that prevents recurrence.

## New — Chapter 9e (closes #1114)

The RFC 10008 QUERY search recipe: one `get(search).query(search)` handler over `Params<ProductQuery>` serving `GET ?q=…` and `QUERY` (urlencoded + JSON arrays), driven by `TestClient::query`. **No DB** — runs everywhere. `COOKBOOK.md` updated with the 9e section.

## Verification

Compiles clean (0 warnings); all non-DB chapters pass locally (incl. the new 9e). The `_live` chapters need Postgres, so **CI is the runtime gate** — the new matrix entry runs them against the CI Postgres service. Merging only after CI is green.
