### PR TITLE
docs(cookbook): add Chapter 19 — Rate limiting (#1012)

### DIFF
--- a/crates/rustango/examples/cookbook_blog/COOKBOOK.md
+++ b/crates/rustango/examples/cookbook_blog/COOKBOOK.md
@@ -3424,3 +3424,31 @@ catalogs overridden per-tenant in the DB and edited live in the admin —
 and `Accept-Language` middleware are documented in
 [docs/i18n.md](../../../../docs/i18n.md); this chapter covers the
 in-process `Translator` core.
+
+## Chapter 19 — Rate limiting
+
+2 tests, **no DB** — `rustango::rate_limit::RateLimitLayer`, a token-bucket
+middleware. Run with `cargo test --test cookbook_chapter19_rate_limit`.
+
+Three keying strategies: `per_ip` (needs `ConnectInfo` — mount with
+`into_make_service_with_connect_info`), `per_header` (e.g. `x-api-key`,
+one bucket per value), and `global` (one bucket for the whole route).
+Under the limit the request passes through with `X-RateLimit-Limit` /
+`X-RateLimit-Remaining` headers; over it you get `429 Too Many Requests`
+with `Retry-After` and a JSON body — the handler never runs.
+
+```rust,ignore
+use std::time::Duration;
+use rustango::rate_limit::{RateLimitLayer, RateLimitRouterExt};
+
+let app = Router::new()
+    .route("/api", get(handler))
+    .rate_limit(RateLimitLayer::per_ip(5, Duration::from_secs(60))); // 5 req/min/IP
+```
+
+* §19.146 — a `global` bucket allows N then returns `429` + `Retry-After`;
+  success responses carry the `X-RateLimit-*` budget headers.
+  → `global_bucket_allows_then_blocks`
+* §19.147 — `per_header` buckets are independent — one client exhausting
+  its quota doesn't block another (`x-api-key` = `alice` vs `bob`).
+  → `per_header_buckets_are_independent`

--- a/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter19_rate_limit.rs
+++ b/crates/rustango/examples/cookbook_blog/tests/cookbook_chapter19_rate_limit.rs
@@ -1,0 +1,69 @@
+//! Cookbook Chapter 19 — Rate limiting.
+//!
+//! `rustango::rate_limit::RateLimitLayer` is a token-bucket middleware:
+//! `per_ip`, `per_header`, or `global`. Under the limit it passes the
+//! request through and stamps `X-RateLimit-Limit` / `X-RateLimit-Remaining`;
+//! over it, it returns `429 Too Many Requests` with `Retry-After` and a
+//! JSON body — no handler call. All **in-process, no DB**; driven by
+//! `TestClient`.
+//!
+//! Run: `cargo test --test cookbook_chapter19_rate_limit`
+
+use std::time::Duration;
+
+use axum::routing::get;
+use axum::Router;
+use rustango::rate_limit::{RateLimitLayer, RateLimitRouterExt};
+use rustango::test_client::TestClient;
+
+// §19.146 — a global bucket: the first N requests pass, the next is 429.
+#[tokio::test]
+async fn global_bucket_allows_then_blocks() {
+    // capacity 2 per (long) window → 2 pass, 3rd blocked.
+    let app: Router = Router::new()
+        .route("/ping", get(|| async { "pong" }))
+        .rate_limit(RateLimitLayer::global(2, Duration::from_secs(60)));
+    let client = TestClient::new(app);
+
+    let r1 = client.get("/ping").send().await;
+    assert_eq!(r1.status, 200);
+    // Success carries the rate-limit budget headers.
+    assert_eq!(r1.header("x-ratelimit-limit"), Some("2"));
+    assert_eq!(r1.header("x-ratelimit-remaining"), Some("1"));
+
+    let r2 = client.get("/ping").send().await;
+    assert_eq!(r2.status, 200);
+    assert_eq!(r2.header("x-ratelimit-remaining"), Some("0"));
+
+    // Bucket empty → 429 with Retry-After, handler never runs.
+    let r3 = client.get("/ping").send().await;
+    assert_eq!(r3.status, 429);
+    assert!(r3.header("retry-after").is_some(), "429 must carry Retry-After");
+    assert_eq!(r3.header("x-ratelimit-remaining"), Some("0"));
+    assert!(
+        r3.text().contains("rate limit exceeded"),
+        "JSON error body: {}",
+        r3.text()
+    );
+}
+
+// §19.147 — per-header buckets: different header values are independent,
+// so one client exhausting its quota doesn't block another.
+#[tokio::test]
+async fn per_header_buckets_are_independent() {
+    let app: Router = Router::new()
+        .route("/api", get(|| async { "ok" }))
+        .rate_limit(RateLimitLayer::per_header(
+            "x-api-key",
+            1,
+            Duration::from_secs(60),
+        ));
+    let client = TestClient::new(app);
+
+    // Key "alice": 1 allowed, 2nd blocked.
+    assert_eq!(client.get("/api").header("x-api-key", "alice").send().await.status, 200);
+    assert_eq!(client.get("/api").header("x-api-key", "alice").send().await.status, 429);
+
+    // Key "bob" has its own bucket — still allowed.
+    assert_eq!(client.get("/api").header("x-api-key", "bob").send().await.status, 200);
+}


### PR DESCRIPTION
Continues #1012 (rate limiting had no cookbook recipe — not even in the Ch11 queued list).

`cookbook_chapter19_rate_limit` — 2 **no-DB** tests over `RateLimitLayer` (TestClient-driven):
- §19.146 `global` bucket allows N then `429` + `Retry-After`; success responses carry `X-RateLimit-Limit` / `X-RateLimit-Remaining`.
- §19.147 `per_header` buckets are independent (per `x-api-key` value).

COOKBOOK.md gains the Chapter 19 section (per_ip / per_header / global keying, 429 shape). Runs everywhere (no DB). Part of #1012.