### PR TITLE
ci: Trivy security scanning — vulnerability gate for releases + opt-in git hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,6 +11,7 @@
 #   PRECOMMIT_SKIP_SECRETS=1 skip secret-pattern scan
 #   PRECOMMIT_SKIP_DEBRIS=1  skip stray-debugger scan
 #   PRECOMMIT_TYPOS=1        opt-in `typos` if installed
+#   PRECOMMIT_TRIVY=1        opt-in trivy secret+misconfig scan if installed
 #
 # Install once per clone: `bin/install-hooks.sh` (or
 # `git config core.hooksPath .githooks`).
@@ -123,6 +124,21 @@ if [ "${PRECOMMIT_TYPOS:-0}" = "1" ] && command -v typos >/dev/null 2>&1; then
   if ! typos --quiet "${STAGED_FILES[@]}"; then
     red "[pre-commit] typos check failed"
     yellow "[pre-commit] auto-fix with: typos -w"
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------- trivy (opt-in)
+# Fast secret + IaC/misconfiguration scan. The heavier vulnerability
+# (Cargo.lock CVE) scan lives in pre-push (PREPUSH_TRIVY=1) and CI, so
+# commits stay snappy. `target/` is skipped so build artifacts don't
+# balloon the scan.
+if [ "${PRECOMMIT_TRIVY:-0}" = "1" ] && command -v trivy >/dev/null 2>&1; then
+  gray "[pre-commit] trivy fs --scanners secret,misconfig"
+  if ! trivy fs --scanners secret,misconfig --severity HIGH,CRITICAL \
+        --skip-dirs target --exit-code 1 --no-progress --quiet . 2>&1 | tail -20; then
+    red "[pre-commit] trivy found secrets or misconfigurations"
+    yellow "[pre-commit] triage the finding, or override with: git commit --no-verify"
     exit 1
   fi
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,6 +9,7 @@
 #   PREPUSH_SKIP_CLIPPY=1    skip cargo clippy
 #   PREPUSH_SKIP_TESTS=1     skip cargo test --lib
 #   PREPUSH_DENY=1           opt-in cargo deny check (heaviest)
+#   PREPUSH_TRIVY=1          opt-in trivy vulnerability scan if installed
 #
 # Install once per clone: `bin/install-hooks.sh`.
 
@@ -62,6 +63,19 @@ if [ "${PREPUSH_DENY:-0}" = "1" ] && command -v cargo-deny >/dev/null 2>&1; then
   gray "[pre-push] cargo deny check"
   if ! cargo deny check 2>&1 | tail -10; then
     red "[pre-push] cargo deny check failed"
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------- trivy vuln (opt-in)
+# Cargo.lock vulnerability (CVE) scan — the same gate CI enforces on
+# every PR. Blocks on HIGH/CRITICAL with a fix available.
+if [ "${PREPUSH_TRIVY:-0}" = "1" ] && command -v trivy >/dev/null 2>&1; then
+  gray "[pre-push] trivy fs --scanners vuln (Cargo.lock CVEs)"
+  if ! trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed \
+        --skip-dirs target --exit-code 1 --no-progress --quiet . 2>&1 | tail -20; then
+    red "[pre-push] trivy found HIGH/CRITICAL vulnerabilities"
+    yellow "[pre-push] triage/upgrade the dependency, or override with: PREPUSH_TRIVY=0 git push"
     exit 1
   fi
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,42 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
 
+  # Trivy security scan — the non-bypassable "detect vulnerabilities
+  # before releases" gate. Complements `deny` (RustSec advisories) with
+  # a broader vuln DB (GHSA), plus committed-secret and IaC/misconfig
+  # scanning. The git hooks run the same checks opt-in locally
+  # (PRECOMMIT_TRIVY / PREPUSH_TRIVY). Vulns + secrets block on
+  # HIGH/CRITICAL (fixable only); misconfig is report-only so a
+  # pre-existing finding never silently blocks a release.
+  trivy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Trivy
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+            | sudo sh -s -- -b /usr/local/bin
+          trivy --version
+      - name: Vulnerabilities + secrets (blocking)
+        run: |
+          trivy fs \
+            --scanners vuln,secret \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --exit-code 1 \
+            --skip-dirs target \
+            --no-progress \
+            .
+      - name: Misconfigurations (report-only)
+        run: |
+          trivy fs \
+            --scanners misconfig \
+            --severity HIGH,CRITICAL \
+            --exit-code 0 \
+            --skip-dirs target \
+            --no-progress \
+            .
+
   # v0.40 tri-dialect litmus — proves a non-PG build of rustango with
   # tenancy still compiles. Catches regressions where PG-only types,
   # bind syntax, or feature wiring leak into the bi/tri-dialect paths.


### PR DESCRIPTION
Adds Trivy scanning so vulnerabilities are detected **before releases**, and wires the same checks into the local git hooks (opt-in).

## What

- **CI `trivy` job** (non-bypassable release gate) — `trivy fs` over the repo:
  - **Blocks** on HIGH/CRITICAL **vulnerabilities** (Cargo.lock CVEs) and **committed secrets** (fixable only, `--ignore-unfixed`).
  - **Misconfigurations** (Dockerfile / compose / GH-Actions) run **report-only** so a pre-existing finding never silently blocks a release.
  - Complements the existing `deny` job: cargo-deny covers RustSec advisories; Trivy adds a broader vuln DB (GHSA), plus secret + IaC scanning.
- **`.githooks/pre-commit`** — opt-in `trivy fs --scanners secret,misconfig` via `PRECOMMIT_TRIVY=1` (fast, no vuln DB; only runs if `trivy` is installed). Keeps commits snappy.
- **`.githooks/pre-push`** — opt-in `trivy fs --scanners vuln` via `PREPUSH_TRIVY=1` (the same gate CI enforces, run locally before code leaves your machine).

Both hooks follow the existing opt-in convention (`command -v trivy` guard, documented env override, `--no-verify` bypass), so contributors without Trivy installed are unaffected.

## Notes

- Trivy is installed in CI via the official install script (latest), so there's no action-version pin to drift.
- Merging this to `develop` before the 0.46.0 release means the release is gated by the vuln scan.
