### PR TITLE
release: 0.46.0 — version bump + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 _Nothing yet — next development cycle._
 
+## [0.46.0] — 2026-07-12
+
+Headline: **HTTP QUERY method (RFC 10008)** — first-class support for the "safe GET with a body" across routing, extraction, safe-method policy, per-view caching, ViewSets, the client/test surfaces, and OpenAPI 3.2. Plus an ORM derived-table source and a documentation overhaul (feature-focused README, cleaned runnable cookbook, new WebSockets/SSE guide).
+
+### Added
+
+- **HTTP QUERY routing** (#1108) — `routing::query()` + `QueryRouterExt::query()` register a QUERY handler on a path (via a `MethodRouter` fallback shim until axum lands native QUERY routing — tokio-rs/axum#3799), fixing the 405 `Allow` set.
+- **Method-adaptive `Params<T>` extractor** (#1109) — GET reads the querystring, QUERY reads the body by content-type (urlencoded / JSON), with 400 / 422 / 415 / 405 handling and parity between `GET /x?a=1` and `QUERY /x` with body `a=1`.
+- **QUERY treated as safe + idempotent across the sweep** (#1110) — CSRF exempts QUERY by default (opt back in with `CsrfConfig::require_csrf_on_query`), the HTTP client retries it, and CORS advertises it.
+- **Per-view caching of QUERY** (#1111) — `CachePageLayer::cache_query(true)` keys on a request-body digest; QUERY responses are forced `private`; bodies over 1 MiB return 413.
+- **ViewSet QUERY collection action** (#1112) — a body-driven list alongside `GET list`, plus QUERY support on admin custom views.
+- **Client `.query()` builders** (#1113) — on `TestClient`, `RequestFactory`, and the HTTP client (+ an HTTP/1.1 wire test).
+- **OpenAPI 3.2 QUERY operation** (#1114) — `PathItem::query(op)`; the spec bumps to `3.2.0` only when a QUERY operation is present. New `docs/query-method.md` guide.
+- **ORM derived-table source** (#1035) — a window / aggregate query can be used as a derived-table (subquery) source.
+- **Security scanning** (#1154) — a Trivy CI job gates every PR/release on HIGH/CRITICAL vulnerabilities (Cargo.lock CVEs) and committed secrets, complementing the existing cargo-deny (RustSec) job; the git hooks add the same checks opt-in (`PRECOMMIT_TRIVY` / `PREPUSH_TRIVY`).
+
+### Changed
+
+- **Documentation overhaul.** Cookbook cleaned of version/PR/changelog noise across every chapter, release-numbered chapters reorganized into topics, with real admin screenshots, captured test output, and live-MySQL evidence (#1153, epic #1131). README rewritten to be feature-focused — the embedded per-release changelog and version clutter removed in favor of a feature tour, a docs index, and a link to the runnable cookbook. New **WebSockets & SSE** guide (#1151) and cookbook chapters for i18n, rate limiting, health checks, and secrets (#1126–#1129). `docs/security.md` corrected to reflect shipped OAuth2/OIDC social login.
+
+### Fixed
+
+- **`sqlite_orm_demo` scalar aggregate** (#1152) — the aggregate example used `.annotate()` without `.values(&[])` (Django "Shape 3" — group by every model column) and failed to decode into a scalar tuple; switched to `.values(&[])` so the example runs to completion on SQLite.
+
 ## [0.45.0] — 2026-07-03
 
 Headline: **i18n depth** — CLDR plural-rules and a locale capability registry — plus a CSRF escape hatch for beacon/collector endpoints.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.45.0"
+version = "0.46.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.45.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.45.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.45.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.46.0", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.46.0", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.46.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.45.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.46.0" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -376,7 +376,7 @@ runserver = ["dep:axum", "dep:tokio"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.45.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.46.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }


### PR DESCRIPTION
Version bump `0.45.0 → 0.46.0` across the 4 publishable crates + the CHANGELOG `[0.46.0]` entry. Follows the same flow as #1106 (0.45.0): this lands the bump on `develop`, then a `develop → main` PR is the actual release (tag + publish after that merges).

## What's in 0.46.0

- **HTTP QUERY method (RFC 10008)** — routing, method-adaptive `Params<T>`, CSRF/CORS/retry policy, `cache_page`, ViewSet action, client/test builders, OpenAPI 3.2 (#1108–#1114).
- **ORM derived-table source** — window/aggregate query as a subquery source (#1035).
- **Trivy security scanning** — CI vuln/secret release gate + opt-in git hooks (#1154).
- **Documentation overhaul** — cleaned cookbook (epic #1131 / #1153), feature-focused README, WebSockets/SSE guide (#1151), new cookbook chapters (#1126–#1129), security.md OAuth2 fix.
- **Fixed** — `sqlite_orm_demo` scalar aggregate (#1152).

Diff is Cargo.toml version pins + CHANGELOG only.
