### PR TITLE
fix(migrate): empty-string default renders invalid DDL (#1161)

### DIFF
--- a/crates/rustango/src/migrate/ddl.rs
+++ b/crates/rustango/src/migrate/ddl.rs
@@ -324,11 +324,17 @@ fn write_column_def(s: &mut String, dialect: &dyn Dialect, field: &FieldSchema) 
     }
     if let Some(expr) = field.default {
         let ty_name = crate::migrate::snapshot::field_type_name(field.ty);
-        let _ = write!(
-            s,
-            " DEFAULT {}",
+        // An empty-string default (`#[rustango(default = "")]`) means the
+        // literal empty string, not an empty raw expression — render it as
+        // `''` rather than nothing, or we emit `DEFAULT  NOT NULL` which the
+        // driver rejects with `near "NOT": syntax error` (#1161). `''` is a
+        // valid empty-string literal in Postgres, MySQL, and SQLite.
+        let rendered = if expr.is_empty() {
+            "''".to_owned()
+        } else {
             dialect.translate_default_expr(expr, ty_name, field.max_length)
-        );
+        };
+        let _ = write!(s, " DEFAULT {rendered}");
     }
     if !field.nullable {
         s.push_str(" NOT NULL");
@@ -513,6 +519,46 @@ mod tests {
     fn auto_uuid_emits_uuid_not_bigserial() {
         let f = fld("id", FieldType::Uuid, true, Some("gen_random_uuid()"));
         assert_eq!(sql_type(&pg(), &f), "UUID");
+    }
+
+    #[test]
+    fn empty_string_default_renders_as_quoted_empty_literal() {
+        // #1161 — `#[rustango(default = "")]` must emit `DEFAULT ''`, not
+        // `DEFAULT ` (nothing), which collapses to `DEFAULT  NOT NULL` and the
+        // driver rejects with `near "NOT": syntax error`. `''` is a valid
+        // empty-string literal on Postgres, MySQL, and SQLite.
+        let mut f = fld("name", FieldType::String, false, Some(""));
+        f.max_length = Some(64);
+        // Postgres is always available in this build; MySQL/SQLite are
+        // feature-gated, so add them only when compiled in.
+        let mut dialects: Vec<&dyn Dialect> = vec![&crate::sql::Postgres];
+        #[cfg(feature = "mysql")]
+        dialects.push(&crate::sql::MySql);
+        #[cfg(feature = "sqlite")]
+        dialects.push(&crate::sql::Sqlite);
+        for dialect in dialects {
+            let mut s = String::new();
+            write_column_def(&mut s, dialect, &f);
+            assert!(
+                s.contains("DEFAULT ''"),
+                "[{}] expected DEFAULT '': {s}",
+                dialect.name()
+            );
+            assert!(
+                !s.contains("DEFAULT  "),
+                "[{}] empty default leaked a blank: {s}",
+                dialect.name()
+            );
+        }
+    }
+
+    #[test]
+    fn nonempty_string_default_is_unchanged() {
+        // A non-empty default is still a raw expression, untouched.
+        let f = fld("status", FieldType::String, false, Some("'active'"));
+        let mut s = String::new();
+        write_column_def(&mut s, &crate::sql::Postgres, &f);
+        assert!(s.contains("DEFAULT 'active'"), "got: {s}");
     }
 
     #[test]

--- a/crates/rustango/src/migrate/diff.rs
+++ b/crates/rustango/src/migrate/diff.rs
@@ -829,9 +829,14 @@ fn render_changes_split_inner(
             } => {
                 guard_alter_column_dialect(dialect, "AlterColumnDefault", table, column)?;
                 match to {
-                    Some(expr) => out.immediate.push(format!(
-                        r#"ALTER TABLE "{table}" ALTER COLUMN "{column}" SET DEFAULT {expr}"#,
-                    )),
+                    Some(expr) => {
+                        // Empty-string default → the literal `''`, not nothing
+                        // (#1161), so we don't emit `SET DEFAULT ` (invalid).
+                        let rendered: &str = if expr.is_empty() { "''" } else { expr };
+                        out.immediate.push(format!(
+                            r#"ALTER TABLE "{table}" ALTER COLUMN "{column}" SET DEFAULT {rendered}"#,
+                        ));
+                    }
                     None => out.immediate.push(format!(
                         r#"ALTER TABLE "{table}" ALTER COLUMN "{column}" DROP DEFAULT"#,
                     )),
@@ -1249,11 +1254,13 @@ fn create_table_sql_from_snapshot_with_dialect(
             continue;
         }
         if let Some(expr) = &f.default {
-            let _ = write!(
-                sql,
-                " DEFAULT {}",
+            // Empty-string default → literal `''`, not a blank (#1161).
+            let rendered = if expr.is_empty() {
+                "''".to_owned()
+            } else {
                 dialect.translate_default_expr(expr, &f.ty, f.max_length)
-            );
+            };
+            let _ = write!(sql, " DEFAULT {rendered}");
         }
         if !f.nullable {
             sql.push_str(" NOT NULL");
@@ -1375,11 +1382,13 @@ fn add_column_sql(table: &str, f: &FieldSnapshot, dialect: &dyn crate::sql::Dial
         sql_type_with_dialect(f, dialect)
     );
     if let Some(expr) = &f.default {
-        let _ = write!(
-            sql,
-            " DEFAULT {}",
+        // Empty-string default → literal `''`, not a blank (#1161).
+        let rendered = if expr.is_empty() {
+            "''".to_owned()
+        } else {
             dialect.translate_default_expr(expr, &f.ty, f.max_length)
-        );
+        };
+        let _ = write!(sql, " DEFAULT {rendered}");
     }
     if !f.nullable {
         sql.push_str(" NOT NULL");

--- a/crates/rustango/tests/empty_default_ddl.rs
+++ b/crates/rustango/tests/empty_default_ddl.rs
@@ -1,0 +1,69 @@
+//! Regression for #1161 — a field with `#[rustango(default = "")]` must
+//! produce **appliable** `CREATE TABLE` DDL: the empty-string default has to
+//! render as the quoted literal `''`, not as nothing (which collapses to
+//! `DEFAULT  NOT NULL` and the driver rejects with `near "NOT": syntax error`).
+#![cfg(feature = "sqlite")]
+
+use rustango::core::Model as _;
+use rustango::migrate::{detect_changes, render_changes_split_with_dialect, SchemaSnapshot};
+use rustango::sql::{raw_execute_pool, sqlx, Pool};
+
+// The issue's exact repro model.
+#[derive(rustango::Model, Debug, Clone)]
+#[rustango(table = "empty_default_demo")]
+#[allow(dead_code)]
+pub struct Demo {
+    #[rustango(primary_key)]
+    pub id: rustango::sql::Auto<i64>,
+    #[rustango(max_length = 64, default = "")]
+    pub name: String,
+}
+
+fn create_ddl(dialect: &dyn rustango::sql::Dialect) -> Vec<String> {
+    let snap = SchemaSnapshot::from_models(&[Demo::SCHEMA]);
+    let changes = detect_changes(&SchemaSnapshot::default(), &snap);
+    let batch =
+        render_changes_split_with_dialect(&changes, &snap, dialect).expect("render Demo DDL");
+    batch
+        .immediate
+        .into_iter()
+        .chain(batch.deferred_fks)
+        .collect()
+}
+
+#[test]
+fn empty_default_renders_quoted_literal() {
+    let ddl = create_ddl(&rustango::sql::Sqlite).join("\n");
+    assert!(ddl.contains("DEFAULT ''"), "expected DEFAULT '': {ddl}");
+    assert!(
+        !ddl.contains("DEFAULT  "),
+        "empty default leaked a blank: {ddl}"
+    );
+}
+
+#[tokio::test]
+async fn empty_default_applies_and_defaults_to_empty_string() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite:{}?mode=rwc", tmp.path().join("demo.db").display());
+    let pool = Pool::connect(&url).await.expect("sqlite connect");
+
+    for stmt in create_ddl(pool.dialect()) {
+        raw_execute_pool(&pool, &stmt, Vec::new())
+            .await
+            .expect("CREATE TABLE with an empty-string default must apply (#1161)");
+    }
+
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!()
+    };
+    // Insert without supplying `name` → the `DEFAULT ''` fills it.
+    sqlx::query("INSERT INTO empty_default_demo DEFAULT VALUES")
+        .execute(sq)
+        .await
+        .expect("insert using the default");
+    let name: String = sqlx::query_scalar("SELECT name FROM empty_default_demo")
+        .fetch_one(sq)
+        .await
+        .expect("read back");
+    assert_eq!(name, "", "the empty-string default should store `''`");
+}


### PR DESCRIPTION
Closes #1161.

## Bug
`#[rustango(default = "")]` rendered `DEFAULT ` (nothing), so the column came out
`… DEFAULT  NOT NULL` and drivers reject it — `near "NOT": syntax error`. Any
`String` / `Cast<C>` field with an empty-string default produced an un-appliable
`CREATE TABLE` (surfaced while adding `SsoProvider.client_secret: Cast<EncryptedString>`).

## Fix
An empty default now emits the quoted empty-string literal `''` (valid on Postgres,
MySQL, SQLite) across **all four** render paths a plain `write!(" DEFAULT {expr}")` missed:
- `ddl.rs::write_column_def` (inventory / ensure-table path)
- `diff.rs` CreateTable-from-snapshot + AddColumn-from-snapshot (the migration path — the one the issue hit)
- `diff.rs` AlterColumnDefault (`SET DEFAULT`)

Non-empty defaults remain raw expressions, untouched.

## Tests
- Tri-dialect unit tests in `ddl.rs` (empty → `DEFAULT ''`; non-empty unchanged).
- New `tests/empty_default_ddl.rs`: the issue's exact repro model — renders `DEFAULT ''` and **applies + inserts** on SQLite (row defaults to `''`).
- Verified `SsoProvider` (carries `default = ""`) applies on a real MySQL 8; migrate-engine + migrate integration unit tests unchanged (43 + 85 pass).