### PR TITLE
release: 0.48.0 — framework migrations + multi-provider SSO + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,63 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 _Nothing yet — next development cycle._
 
+## [0.48.0] — 2026-07-21
+
+Headline: **the framework migrates its own schema** — Django-style
+system migrations with no hardcoded DDL and plug-and-play features — plus
+**multi-provider admin SSO**, configured from the admin UI with secrets
+encrypted at rest.
+
+### Added
+
+- **Django-style framework migrations** (#1158) — the framework's own
+  `rustango_*` tables now flow through the same `makemigrations` /
+  `migrate` engine as your models. They're generated into a scaffolded
+  **`system/migrations/`** folder from the compiled models (registry +
+  tenant scope), applied under a dedicated `__rustango_system_migrations__`
+  ledger, and generated on demand at provisioning time. No hand-shipped
+  bootstrap JSON, no per-dialect DDL strings. **Features are
+  plug-and-play**: a `#[cfg(feature = …)]`-gated column or table is
+  compiler-stripped when off, so enabling a feature makes `makemigrations`
+  emit `AddColumn`/`CreateTable` and disabling emits `DropColumn`/`DropTable`.
+- **Admin SSO** (#1157) — sign in to the admin with an external IdP
+  (Google, Microsoft/Azure AD, GitHub, GitLab, Discord, or any OpenID
+  Connect provider) instead of a password. Link-to-existing (verified IdP
+  email must match an admin user; no auto-provisioning), single-tenant and
+  per-tenant, reusing the normal signed-cookie session. Gated behind the
+  `admin-sso` feature.
+- **Multi-provider, admin-managed SSO** (#1160) — SSO providers are now
+  DB rows managed from the admin UI: **many providers per surface**, a
+  per-tenant `SsoProvider` (tenant admin, granular self-service) plus a
+  registry-wide `SharedSsoProvider` (operator-defined, offered to every
+  tenant), merged on the login page with tenant-wins on a slug clash.
+  Endpoints are auto-discovered from an OIDC issuer URL; the client secret
+  is **encrypted at rest** (XChaCha20-Poly1305, `RUSTANGO_SECRET_KEY`).
+  The operator console gains a *Shared SSO* panel; routes are
+  `{login}/sso/{slug}[/callback]`.
+
+### Changed
+
+- **SSO config moved off the `Org` row** — replaced the flat
+  `Org.sso_*` columns and the `BareSsoConfig` / `Builder::with_sso` /
+  `[sso]` config path with the `SsoProvider` / `SharedSsoProvider` models
+  (breaking for the single-provider config added earlier in this cycle).
+- **`init-tenancy` is now a no-op** — the framework ships no hardcoded
+  bootstrap migrations; the tenant scaffold ships an empty
+  `system/migrations/` and `cargo run -- migrate` generates + applies the
+  framework tables. Docs updated (`sso.md`, `manage.md`, `scaffolding.md`,
+  `security.md`, README, cookbook).
+
+### Fixed
+
+- **Empty-string default renders invalid DDL** (#1161) —
+  `#[rustango(default = "")]` emitted `DEFAULT ` (nothing), collapsing to
+  `… DEFAULT  NOT NULL` which drivers reject (`near "NOT": syntax error`),
+  so any `String` / `Cast<C>` field with an empty-string default produced
+  an un-appliable `CREATE TABLE`. It now renders the quoted empty-string
+  literal `''` across all four DDL render paths (create-table + add-column,
+  both the inventory and migration paths, plus `SET DEFAULT`).
+
 ## [0.46.0] — 2026-07-12
 
 Headline: **HTTP QUERY method (RFC 10008)** — first-class support for the "safe GET with a body" across routing, extraction, safe-method policy, per-view caching, ViewSets, the client/test surfaces, and OpenAPI 3.2. Plus an ORM derived-table source and a documentation overhaul (feature-focused README, cleaned runnable cookbook, new WebSockets/SSE guide).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.46.0"
+version = "0.48.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.46.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.46.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.46.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.48.0", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.48.0", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.48.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cargo rustango new shop --template tenant    # multi-tenancy + operator console
 cd myblog
 cp .env.example .env                         # edit DATABASE_URL
 docker compose up -d                         # starts Postgres
-cargo run -- migrate                         # apply bootstrap migrations
+cargo run -- migrate                         # generate + apply migrations
 cargo run                                    # http://localhost:8080
 ```
 

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.46.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.48.0" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -392,7 +392,7 @@ runserver = ["dep:axum", "dep:tokio"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.46.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.48.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }

--- a/docs/manage.md
+++ b/docs/manage.md
@@ -294,15 +294,16 @@ Writes:
   rust-toolchain.toml
   docker-compose.yml
   README.md
-  migrations/                               (tenant template only — bootstrap JSONs)
+  migrations/                               (your app's migrations)
+  system/migrations/                        (tenant template — framework tables, generated)
   src/{main,models,views,urls}.rs
 ```
 
-The tenant template writes
-`migrations/0001_rustango_registry_initial.json` and
-`0001_rustango_tenant_initial.json` for you — see
-[`init-tenancy`](#init-tenancy) for what they contain and when to
-regenerate them.
+The tenant template ships an **empty** `system/migrations/` folder. The
+framework's own tables (`rustango_orgs`, `rustango_users`,
+roles/permissions, …) are generated into it from the compiled models on
+the first `cargo run -- migrate` — there's no hand-shipped bootstrap
+JSON. See [`migrate`](#migrate) / [`migrate-registry`](#migrate-registry).
 
 ### `startapp <name> [flags]`
 
@@ -313,7 +314,6 @@ of your project grouped together.
 ```bash
 cargo run -- startapp blog
 cargo run -- startapp shop --with-manage-bin             # also writes src/bin/manage.rs
-cargo run -- startapp shop --with-bootstrap-migration    # tenancy: also seed bootstrap migrations
 cargo run -- startapp shop --into apps                   # write under src/apps/shop/ instead
 ```
 
@@ -325,17 +325,10 @@ src/<name>/
   models.rs
   views.rs
   urls.rs
-  migrations/                               (when --with-bootstrap-migration on tenancy)
 ```
 
 Safe to re-run — existing files are left alone. One manual step: add
 `pub mod <name>;` to `src/lib.rs` so Rust compiles the new module.
-
-`--with-bootstrap-migration` is tenancy-only. It runs
-[`init-tenancy`](#init-tenancy) inside the new app's `migrations/`
-directory, writing the framework's registry and tenant bootstrap files
-there. Skip it if you already have those bootstrap files at the project
-root.
 
 ---
 
@@ -559,32 +552,23 @@ with `features = ["tenancy"]` AND `Cli::new()` is chained with
 
 ### `init-tenancy`
 
-Writes the framework's starter migrations for multi-tenancy into your
-migrations directory. It creates `0001_rustango_registry_initial.json`
-(which builds the shared `rustango_orgs` and `rustango_operators`
-tables) and `0001_rustango_tenant_initial.json` (which builds the
-per-tenant `rustango_users` table).
+**No-op — retained for compatibility.** The framework no longer ships
+hand-built bootstrap migrations. Its own tables (`rustango_orgs`,
+`rustango_operators`, `rustango_users`, roles/permissions, …) are
+generated into `system/migrations/` from the compiled models — the
+normal Django flow (models → `makemigrations` → `migrate`) — and applied
+by [`migrate`](#migrate) / [`migrate-registry`](#migrate-registry), which
+generate them on demand if the files are missing.
 
 ```bash
-cargo run -- init-tenancy
+cargo run -- init-tenancy   # does nothing now; kept so old scripts don't break
 ```
 
-**Safe to re-run**: if those files already exist, they're left alone.
-Most of the time this command runs for you indirectly:
-
-- `cargo rustango new --template tenant` writes the same JSONs from a
-  static template, so a freshly scaffolded project never needs
-  `init-tenancy`.
-- `startapp --with-bootstrap-migration` runs it against a per-app
-  migrations directory.
-- `Builder::migrate(project_root)` runs it implicitly before applying
-  pending migrations.
-
-If you've chained `.user_model::<AppUser>()` on `Cli`, this command
-builds the starter migration from your `AppUser` schema instead of the
-framework's `User`, so your extra columns end up in the `CREATE TABLE`.
-See [Custom user model](#custom-user-model-extra-columns-on-rustango_users)
-below.
+Older versions wrote `0001_rustango_*_initial.json` here; that hardcoded
+flow is gone. **To provision, just run `cargo run -- migrate`.** A custom
+user model (`.user_model::<AppUser>()`) flows through the same generated
+`system/migrations/` — see
+[Custom user model](#custom-user-model-extra-columns-on-rustango_users).
 
 ### `migrate-registry`
 
@@ -824,9 +808,11 @@ breaking framework auth.
 ### Option 2 — `Cli::user_model::<AppUser>()` *(greenfield only)*
 
 Use this only on a fresh project where you want the extra fields right
-on the `rustango_users` table itself. The `init-tenancy` command then
-generates a starter migration whose `CREATE TABLE rustango_users`
-includes your columns.
+on the `rustango_users` table itself. Because `AppUser` *is* the
+`rustango_users` model, its columns flow through the ordinary
+`makemigrations` → `migrate` engine: the framework's tables are generated
+into `system/migrations/`, so `AppUser`'s columns land in the generated
+`CREATE TABLE rustango_users`.
 
 **Step 1.** Define your model. It has to declare every framework-required
 column exactly (`id`, `username`, `password_hash`, `is_superuser`,
@@ -866,31 +852,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-**Step 3.** Make sure no starter migration exists yet. If you ran
-`cargo rustango new --template tenant`, the scaffolder already wrote
-`migrations/0001_rustango_{registry,tenant}_initial.json` from a static
-template — those use the framework's `User`, and `init-tenancy` won't
-overwrite them. So either:
-
-- delete both `0001_rustango_*_initial.json` files before continuing, or
-- start from a non-template `cargo new` and skip the scaffolder.
+**Step 3.** Register `AppUser` **instead of** the framework `User` — only
+one model may claim `table = "rustango_users"`. The scaffolder ships no
+static bootstrap JSON (just an empty `system/migrations/`), so there's
+nothing to delete; just don't also register the framework `User`.
 
 **Step 4.** Generate + apply:
 
 ```bash
-cargo run -- init-tenancy        # writes 0001_*.json using AppUser's schema
-cargo run -- migrate             # creates rustango_users with your extras
+cargo run -- makemigrations       # generates system/migrations/ with AppUser's columns
+cargo run -- migrate              # creates rustango_users with your extras
 ```
 
 **Caveats:**
 
-- `init-tenancy` won't rewrite the migration once it's on disk, so
-  changing `AppUser` later has no effect on it. To add columns after
-  the fact, write a normal `AddColumn` migration via `makemigrations`.
-- Both the framework's `User` and your `AppUser` register as models
-  (they share `table = "rustango_users"`). `makemigrations` may then
-  produce redundant operations on that table — review the generated
-  JSON before applying. This is the main reason Option 2 is for fresh
+- Changing `AppUser` later is a normal schema change: re-run
+  `makemigrations` to emit the `AddColumn` migration, then `migrate`.
+- Only one model may map to `rustango_users`. Registering **both** the
+  framework `User` and your `AppUser` makes `makemigrations` ambiguous —
+  register `AppUser` alone. This is the main reason Option 2 is for fresh
   projects only; on an existing project, Option 1 avoids the problem.
 - Framework auth and admin code reads the seven core columns by name;
   your extra columns are reachable only through

--- a/docs/scaffolding.md
+++ b/docs/scaffolding.md
@@ -111,7 +111,7 @@ How the templates differ inside `main.rs` / `urls.rs`:
 
 - **api** — no admin; `urls::api()` simply aggregates your own routes.
 - **fullstack** — `urls.rs` also exposes `admin_router(pool)` (built from `admin::Builder::new(pool).build()`) so the auto-admin mounts at `/admin`.
-- **tenant** — `main.rs` adds `.tenancy()`, serving the operator console at the apex domain and each tenant under its own subdomain. It also ships the registry + tenant **bootstrap migrations**, so the very first `cargo run -- migrate` works with no extra setup.
+- **tenant** — `main.rs` adds `.tenancy()`, serving the operator console at the apex domain and each tenant under its own subdomain. The framework's own tables are generated into a **`system/migrations/`** folder from the compiled models (Django-style) on the first `cargo run -- migrate` — no hand-shipped bootstrap JSON, so the very first migrate works with no extra setup.
 
 ### Layered configuration
 
@@ -144,7 +144,6 @@ Options:
 
 - **`--into <dir>`** — scaffold under a base directory other than `src/` (e.g. a workspace member).
 - **`--with-manage-bin`** — also emit a `bin/manage.rs` (for layouts that prefer a separate manage binary).
-- **`--with-bootstrap-migration`** — drop a starter migration alongside the new app.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -284,7 +284,7 @@ sqlx::query(&sql).bind(1).fetch_all(&pool).await?;
 
 Authentication is how you confirm who is making a request. **Rustango** ships three ready-made backends (Basic auth, API keys, and JWTs) and lets you write your own — much like Django's authentication backends. You attach them to routes, and requests without a recognized credential get a `401`.
 
-> **Admin SSO.** To let operators sign in to the admin with an external IdP (Google, Microsoft/Azure AD, GitHub, or any OpenID Connect provider) instead of a password, enable the `admin-sso` feature — see the [SSO guide](sso.md). It's link-to-existing (the verified IdP email must match an admin user; no auto-provisioning), works for the single-tenant admin (global `[sso]`) and per-tenant, and reuses the existing session.
+> **Admin SSO.** To let operators sign in to the admin with an external IdP (Google, Microsoft/Azure AD, GitHub, or any OpenID Connect provider) instead of a password, enable the `admin-sso` feature — see the [SSO guide](sso.md). Providers are **managed from the admin UI as rows** (multiple per surface; per-tenant, or a shared set across tenants), with the client secret **encrypted at rest**. It's link-to-existing (the verified IdP email must match an admin user; no auto-provisioning) and reuses the existing session.
 
 ### Three ready-made backends
 

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -5,6 +5,11 @@ Google, Microsoft / Azure AD, GitHub, GitLab, Discord, or **any OpenID
 Connect provider** (Okta, Auth0, Keycloak, …) — instead of a local
 password. Enable it with the `admin-sso` cargo feature.
 
+You can configure **multiple providers**, each managed from the admin UI
+as a row (no config file, no rebuild). A provider's endpoints are
+auto-discovered from its OIDC issuer URL at login; social providers use
+built-in presets.
+
 SSO is **link-to-existing**: the verified email the IdP returns must
 match an existing admin user. SSO authenticates the person; it never
 creates accounts and never grants access on its own. An unknown or
@@ -12,15 +17,16 @@ unverified email is refused.
 
 ```toml
 [dependencies]
-rustango = { version = "0.46", features = ["admin-sso"] }
+rustango = { version = "0.48", features = ["admin-sso"] }
 ```
 
 ## How it works
 
-1. The login page shows a **"Sign in with &lt;provider&gt;"** button.
-2. Clicking it (`GET <login>/sso`) redirects to the IdP with a signed,
-   short-lived flow cookie (PKCE + CSRF `state`).
-3. The IdP sends the user back to `<login>/sso/callback`.
+1. The login page shows one **"Sign in with &lt;provider&gt;"** button per
+   enabled provider.
+2. Clicking one (`GET <login>/sso/<slug>`) redirects to the IdP with a
+   signed, short-lived flow cookie (PKCE + CSRF `state`).
+3. The IdP sends the user back to `<login>/sso/<slug>/callback`.
 4. rustango verifies the flow, exchanges the code, reads `/userinfo`,
    and requires **`email_verified`**.
 5. It looks up an admin user by that email. If one exists and is active,
@@ -30,83 +36,80 @@ rustango = { version = "0.46", features = ["admin-sso"] }
 6. No match → the user is bounced back to the login page with a generic
    error (details go to the server log, never the browser).
 
-The client **secret is never stored in plaintext** — it's a reference
-(`env://…`) resolved at login time, the same way `Org.database_url` is.
+The client **secret is encrypted at rest** — the `client_secret` column
+is an [`EncryptedString`](#secret-storage) cast, decrypted in-memory only
+at login time.
 
-## Single-tenant (no multi-tenancy)
+## Providers are rows, managed in the admin
 
-Configure one global provider. Set the email column on the admin user
-you want to allow, then enable SSO.
+Each provider is a `SsoProvider` row. It shows up as an ordinary
+admin model — add/edit/enable from the admin UI, no redeploy. Fields:
 
-### Via code
-
-```rust
-use rustango::admin::{Builder, sso::BareSsoConfig};
-
-let admin = Builder::new(pool)
-    .with_session_auth(secret)          // SSO reuses this session
-    .with_sso(BareSsoConfig {
-        provider: "google".into(),      // or microsoft/github/gitlab/discord/oidc
-        issuer_url: None,               // required only for provider = "oidc"
-        client_id: std::env::var("SSO_CLIENT_ID")?,
-        client_secret: std::env::var("SSO_CLIENT_SECRET")?,
-        redirect_uri: "https://admin.example.com/login/sso/callback".into(),
-    })
-    .build();
-```
-
-### Via config
-
-```toml
-[sso]
-enabled = true
-provider = "oidc"                       # generic OpenID Connect
-issuer_url = "https://id.example.com"   # discovery: {issuer}/.well-known/openid-configuration
-client_id = "rustango-admin"
-# client_secret comes from RUSTANGO__SSO__CLIENT_SECRET (env overlay), not TOML
-redirect_uri = "https://admin.example.com/login/sso/callback"
-```
-
-`Builder::from_settings(pool, &settings)` wires this automatically.
-Incomplete config (missing provider / client_id / redirect_uri) logs a
-warning and leaves SSO off rather than half-wiring a broken button.
-
-Link an operator to their IdP identity by setting the `email` column on
-their `rustango_admin_users` row to the address the IdP returns.
-
-## Multi-tenant — per-tenant IdP
-
-Each tenant brings its own identity provider. The config lives on the
-`Org` row, editable in the operator console's org-edit form:
-
-| Column | Meaning |
+| Field | Meaning |
 |---|---|
-| `sso_enabled` | Turns the button on for this tenant. |
-| `sso_provider` | `google` / `microsoft` / `github` / `gitlab` / `discord` / `oidc`. |
-| `sso_issuer_url` | OIDC discovery base URL (for `provider = "oidc"`). |
-| `sso_client_id` | The tenant's OAuth client id. |
-| `sso_secret_ref` | **Reference** to the client secret — e.g. `env://ACME_SSO_SECRET` — resolved by the tenancy `SecretsResolver`. Never the raw secret. |
+| `slug` | Stable route key + button id (`<login>/sso/<slug>`). Unique. |
+| `label` | Button text, e.g. "Sign in with Google". |
+| `kind` | A preset — `google` / `microsoft` / `github` / `gitlab` / `discord` — or `oidc` for a generic OpenID Connect provider. |
+| `issuer_url` | OIDC discovery base URL (for `kind = "oidc"`); rustango fetches `{issuer}/.well-known/openid-configuration`. Unused for presets. |
+| `client_id` | The OAuth client id from the IdP. |
+| `client_secret` | The OAuth client secret, **encrypted at rest** (never plaintext in the DB). |
+| `enabled` | Whether the button shows on the login page. |
+| `sort_order` | Button ordering (ascending). |
+| `scopes` | Optional space-separated scope override (default `openid email profile`). |
 
-The callback URL is derived per tenant from the request host
-(`https://<tenant-host><login>/sso/callback`), so register that with
-each tenant's IdP. Link a tenant user by setting the `email` column on
-their `rustango_users` row.
+To add a provider: enter the `client_id` + `client_secret`, pick a
+`kind` (or `oidc` + an `issuer_url`), and save. The endpoints are
+discovered at login — no per-provider endpoint wiring.
 
-## Providers
+## Where each surface manages providers
+
+- **Single-tenant / standalone admin** (`crate::admin`): `SsoProvider`
+  rows are a plain global table, managed from the bare admin. Requires
+  `Builder::with_session_auth` (SSO mints the same session).
+- **Tenant admin** (multi-tenancy): each tenant manages its **own**
+  `SsoProvider` rows from its admin — granular, self-service, isolated
+  per tenant.
+- **Operator console** (multi-tenancy): an operator defines a
+  **`SharedSsoProvider`** once and it's offered to **every** tenant
+  (a company-wide Google, say). Managed from the console's *Shared SSO*
+  panel.
+
+On a tenant's login page the two sets merge, and on a slug clash the
+**tenant's own provider wins** over the shared one — so a tenant can
+override a shared provider for itself.
+
+The callback URL is derived per request from the host + slug
+(`https://<host><login>/sso/<slug>/callback`), so register that with the
+IdP. Link a user by setting the `email` column on their
+`rustango_users` (tenant) / `rustango_admin_users` (bare) row to the
+address the IdP returns.
+
+## Secret storage
+
+`client_secret` is stored **encrypted at rest** with XChaCha20-Poly1305
+(AEAD), the key derived from the **`RUSTANGO_SECRET_KEY`** environment
+variable. It's decrypted in memory only at login, to authenticate to the
+IdP's token endpoint. So a leaked DB dump never exposes the secret, and
+each tenant keeps its own secret with no per-provider env var.
+
+> Set `RUSTANGO_SECRET_KEY` in the deployment (any length; it's SHA-256'd
+> to a 32-byte key). Without it, saving or using a provider fails fast —
+> the same posture as a missing database URL.
+
+## Providers (presets)
 
 Built-in presets: `google`, `microsoft` (Azure AD), `github`, `gitlab`,
-`discord`. For anything else, use `provider = "oidc"` with an
-`issuer_url` — rustango runs OpenID Connect discovery to find the
-endpoints. (Sign in with Apple isn't a preset; it needs id_token/JWKS
-verification.)
+`discord`. For anything else, use `kind = "oidc"` with an `issuer_url` —
+rustango runs OpenID Connect discovery to find the endpoints. (Sign in
+with Apple isn't a preset; it needs id_token/JWKS verification.)
 
 ## Security notes
 
 - **Verified email only** — unverified IdP emails are rejected.
 - **No auto-provisioning** — an unknown email can't get in; create the
   admin user (and set its `email`) first.
-- **Secrets are references**, resolved at runtime; the operator console
-  masks `sso_secret_ref` like it masks `database_url`.
+- **Secrets encrypted at rest** (`RUSTANGO_SECRET_KEY`), decrypted only
+  in memory at login; edit forms mask the stored secret.
 - The flow cookie is short-lived (10 min), `HttpOnly`, `SameSite=Lax`,
   and `Secure` on HTTPS; the handshake carries PKCE + a signed `state`.
 - SSO sessions are the ordinary admin session — rotating or deactivating


### PR DESCRIPTION
Version bump **0.46.0 → 0.48.0**, CHANGELOG, and docs brought up to the current app.

> 0.47.0 exists only as a **dangling git tag** (never published to crates.io — the
> crate is at 0.46.0), so this release skips it and goes to 0.48.0. The `v0.48.0`
> tag (a WIP dev tag) will be force-moved onto the real release merge commit.

### Version
Workspace `[package] version` + internal dep pins → `0.48.0`. `cargo metadata` resolves.

### CHANGELOG `[0.48.0]`
- **Django-style framework migrations** (#1158) — framework tables flow through
  makemigrations/migrate into a scaffolded `system/migrations/`; no hardcoded DDL;
  features plug-and-play.
- **Admin SSO** (#1157) + **multi-provider, admin-managed SSO** (#1160) — DB-backed
  providers (per-tenant + registry-wide shared), OIDC auto-discovery, secrets encrypted
  at rest.
- **Fixed** empty-string-default DDL (#1161).

### Docs
`sso.md` rewritten (multi-provider / encrypted secrets); `manage.md` (`init-tenancy`
no-op, removed `--with-bootstrap-migration`, custom-user-model → `makemigrations`);
`scaffolding.md` / `security.md` / README wording.

Squash-merges into `develop`; then `develop → main` merge commit + tag `v0.48.0` +
crates.io publish.