### PR TITLE
feat(migrate): auto-ensure media tables when the `media` feature is enabled

### DIFF
--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -804,6 +804,14 @@ async fn migrate<W: Write>(
         return Ok(());
     }
 
+    // Framework media tables (`rustango_media` + collections/tags/links):
+    // created BEFORE any user migrations are applied, so a user model that
+    // FKs `rustango_media` applies cleanly — the same behavior the tenant
+    // provisioning path gives per-tenant. Idempotent (`CREATE TABLE IF NOT
+    // EXISTS`); only when the `media` feature is enabled.
+    #[cfg(feature = "media")]
+    crate::media::ensure_all_tables_pool(pool).await?;
+
     if let Some(target) = positional {
         let touched = runner::migrate_to_pool(pool, dir, target).await?;
         if touched.is_empty() {

--- a/crates/rustango/src/tenancy/migrate.rs
+++ b/crates/rustango/src/tenancy/migrate.rs
@@ -429,6 +429,7 @@ where
     // migrations, which may FK into them (issue #1171).
     let mut applied =
         apply_system_migrations(&inner_pool, dir, crate::core::ModelScope::Tenant).await?;
+    ensure_media_tables(&inner_pool).await?;
     applied.extend(migrate::migrate_pool(&inner_pool, dir).await?);
     // Data seeders (rows, not DDL — kept): the CRUD permission codenames
     // for every registered model (#61) + the content-type catalog (#89).
@@ -467,6 +468,24 @@ where
     migrate_tenants_db(pools, dir, registry_url).await
 }
 
+/// Ensure the framework `media` subsystem tables (`rustango_media`,
+/// `rustango_media_collections`, `rustango_media_tags`) exist in a
+/// tenant's storage. Media is not yet part of the migration engine
+/// (#1174) — it ships idempotent `CREATE TABLE IF NOT EXISTS` DDL via
+/// [`crate::media::ensure_all_tables_pool`]. We run it here, AFTER the
+/// system migrations and BEFORE the tenant's user migrations, so a tenant
+/// model that FKs `rustango_media` applies cleanly on a fresh tenant.
+/// No-op unless the `media` feature is enabled.
+async fn ensure_media_tables(pool: &crate::sql::Pool) -> Result<(), TenancyError> {
+    #[cfg(feature = "media")]
+    crate::media::ensure_all_tables_pool(pool)
+        .await
+        .map_err(|e| TenancyError::Validation(format!("media table ensure failed: {e}")))?;
+    #[cfg(not(feature = "media"))]
+    let _ = pool;
+    Ok(())
+}
+
 #[cfg(feature = "postgres")]
 async fn run_for_one_tenant(
     pools: &TenantPools,
@@ -492,6 +511,7 @@ async fn run_for_one_tenant(
             let dbpool: crate::sql::Pool = pool.clone().into();
             let mut applied =
                 apply_system_migrations(&dbpool, dir, crate::core::ModelScope::Tenant).await?;
+            ensure_media_tables(&dbpool).await?;
             applied.extend(migrate::migrate(&pool, dir).await?);
             // Data seeders (rows, not DDL — kept): CRUD permission
             // codenames for every registered model (#61) + the
@@ -511,6 +531,7 @@ async fn run_for_one_tenant(
             let dbpool: crate::sql::Pool = tenant_pool.pool().clone().into();
             let mut applied =
                 apply_system_migrations(&dbpool, dir, crate::core::ModelScope::Tenant).await?;
+            ensure_media_tables(&dbpool).await?;
             applied.extend(migrate::migrate(tenant_pool.pool(), dir).await?);
             // Data seeders (rows, not DDL — kept): #61 + #89.
             if let Err(e) = super::permissions::auto_create_permissions(tenant_pool.pool()).await {


### PR DESCRIPTION
## What

When the `media` feature is enabled, the framework now creates the media subsystem tables (`rustango_media`, `rustango_media_collections`, `rustango_media_tags`, `rustango_media_tag_links`) automatically inside the `migrate` flow — **before** user migrations run — for **both** app shapes:

- **Tenant** provisioning (`tenancy::migrate` — schema-mode, database-mode, and the tri-dialect db-mode path): per tenant, *after* the system migrations and *before* the tenant's user migrations.
- **Non-tenant** single-DB `migrate` (`migrate::manage`): before user migrations.

## Why

The media tables are created via idempotent `CREATE TABLE IF NOT EXISTS` DDL (`media::ensure_all_tables_pool`), not the migration engine (see #1174). Consequences before this change:

- An app had to call `ensure_all_tables_pool` itself (the "trick").
- In tenancy, media tables were never created per-tenant, so a tenant model with a FK into `rustango_media` (e.g. an `EquipmentMedia` row) failed to provision on a fresh tenant: `relation "rustango_media" does not exist`. Same failure class as the system-before-user ordering fix already in 0.49.0.

## Details

- Gated `#[cfg(feature = "media")]` → a no-op for apps that don't use media (no new coupling).
- Runs before user migrations, so FKs into `rustango_media` apply cleanly.
- The tenant **registry** (`public`) is intentionally excluded — media is per-tenant / per-app data.
- Idempotent; safe to re-run on every `migrate`.

## Scope / follow-up

This makes media tables reliably *exist* when the feature is on, consistently across tenant and non-tenant apps. Turning the media models into first-class **migrated** (ledger-tracked) `#[derive(Model)]`s is the larger follow-up tracked in **#1174** (carries an existing-DB reconcile consideration, #1167).

## Build

`cargo build -p rustango` green for: `tenancy+media`, `tenancy` without media (cfg's out cleanly), and `default` (media, no tenancy).