### PR TITLE
fix(admin): tenant-admin login layout + logout button (0.49.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.49.0"
+version = "0.49.1"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.49.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.49.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.49.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.49.1", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.49.1", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.49.1", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.49.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.49.1" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -405,7 +405,7 @@ runserver = ["dep:axum", "dep:tokio"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.49.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.49.1", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }

--- a/crates/rustango/src/admin/helpers.rs
+++ b/crates/rustango/src/admin/helpers.rs
@@ -111,6 +111,13 @@ pub(crate) fn chrome_context_with_session(
         // v0.28.2 (#77) — sidebar "Change password" link target.
         // Threaded from the tenant admin's RouteConfig.
         "change_password_url": &state.config.change_password_url,
+        // Sidebar Logout POST target. Defaults to `{admin_prefix}/logout`
+        // (the bare admin's own route); the tenant admin overrides it to
+        // its RouteConfig logout_url (handled at the tenancy layer), so
+        // the button doesn't POST to a non-existent `{prefix}/logout`.
+        "logout_url": state.config.logout_url.clone().unwrap_or_else(
+            || format!("{}/logout", state.config.admin_prefix)
+        ),
         // #253 — Logout button visibility. The bare admin's
         // session middleware redirects unauthenticated requests to
         // `/login`, so by the time chrome renders we know any

--- a/crates/rustango/src/admin/templates/_sidebar.html
+++ b/crates/rustango/src/admin/templates/_sidebar.html
@@ -39,7 +39,7 @@
        context only sets `session_user` when the session-auth
        middleware seated an `AdminSession` on the request. #}
     {% if session_user %}
-        <form method="post" action="{{ admin_prefix }}/logout" class="logout-form">
+        <form method="post" action="{{ logout_url | default(value=admin_prefix ~ '/logout') }}" class="logout-form">
             <p class="signed-in-as">
                 {% if session_user.username %}
                     Signed in as <strong>{{ session_user.username }}</strong>

--- a/crates/rustango/src/admin/urls.rs
+++ b/crates/rustango/src/admin/urls.rs
@@ -164,6 +164,13 @@ pub(crate) struct Config {
     /// `RouteConfig::change_password_url`. Standalone admins
     /// leave it `None` (no auth surface to wire it to).
     pub(crate) change_password_url: Option<String>,
+    /// Logout POST target for the sidebar button. Standalone admins
+    /// leave this `None` and the chrome falls back to
+    /// `{admin_prefix}/logout` (the bare admin's own logout route).
+    /// The tenant admin sets it to its `RouteConfig::logout_url`
+    /// (e.g. `/staff-logout`), which is handled at the tenancy layer
+    /// rather than under the admin prefix.
+    pub(crate) logout_url: Option<String>,
     /// URL suffix the audit-log view is mounted under (sibling
     /// to `admin_prefix`). The cross-row activity feed renders
     /// at `<admin_prefix><audit_url>` and the cleanup form at
@@ -429,6 +436,17 @@ impl Builder {
     #[must_use]
     pub fn change_password_url(mut self, url: impl Into<String>) -> Self {
         self.config.change_password_url = Some(url.into());
+        self
+    }
+
+    /// Set the sidebar Logout button's POST target. Standalone admins
+    /// omit this and the chrome defaults to `{admin_prefix}/logout`.
+    /// The tenant admin sets it to its `RouteConfig::logout_url` so the
+    /// button hits the tenancy-layer logout route (e.g. `/staff-logout`),
+    /// not a non-existent `{admin_prefix}/logout`.
+    #[must_use]
+    pub fn logout_url(mut self, url: impl Into<String>) -> Self {
+        self.config.logout_url = Some(url.into());
         self
     }
 

--- a/crates/rustango/src/tenancy/admin.rs
+++ b/crates/rustango/src/tenancy/admin.rs
@@ -410,6 +410,10 @@ where
     // still applies — every request goes straight to the inner admin.
     let mut user_perms: Option<std::collections::HashSet<String>> = None;
     let mut session_user_id: Option<i64> = None;
+    // Chrome session info threaded into the inner admin so the sidebar
+    // renders "Signed in as <username>" + the Logout button.
+    let mut session_username: Option<String> = None;
+    let mut session_is_superuser = false;
     // v0.27.8 (#78) — populated when the session was minted by
     // the operator console's impersonation flow. Threaded into
     // the chrome context for the impersonation banner + into
@@ -543,9 +547,12 @@ where
             SessionCheck::Authenticated {
                 is_superuser,
                 user_id,
+                username,
                 impersonated_by: imp_by,
             } => {
                 session_user_id = Some(user_id);
+                session_username = Some(username);
+                session_is_superuser = is_superuser;
                 impersonated_by = imp_by;
                 if !is_superuser {
                     // Fetch the user's effective codenames once per request
@@ -615,6 +622,7 @@ where
         impersonated_by,
         routes.admin_url.as_str(),
         routes.change_password_url.as_str(),
+        routes.logout_url.as_str(),
         routes.audit_url.as_str(),
         routes.static_url.as_str(),
     );
@@ -649,16 +657,36 @@ where
             Err(_infallible) => unreachable!("axum::Router service is Infallible"),
         }
     };
-    let response = if let Some(uid) = session_user_id {
-        crate::audit::with_source(
-            crate::audit::AuditSource::User {
-                id: uid.to_string(),
-            },
-            dispatch,
-        )
-        .await
-    } else {
-        dispatch.await
+    let audited = async {
+        if let Some(uid) = session_user_id {
+            crate::audit::with_source(
+                crate::audit::AuditSource::User {
+                    id: uid.to_string(),
+                },
+                dispatch,
+            )
+            .await
+        } else {
+            dispatch.await
+        }
+    };
+    // Install the request's session into the admin task-local the inner
+    // chrome reads (`admin::session::current()`), so the tenant admin
+    // sidebar renders "Signed in as <username>" + the Logout button —
+    // the bare admin gets this from its own `require_session` middleware,
+    // which the tenant admin path bypasses.
+    let response = match session_user_id {
+        Some(uid) => {
+            let sess = crate::admin::session::AdminSession {
+                user_id: uid,
+                username: session_username.clone().unwrap_or_default(),
+                is_superuser: session_is_superuser,
+            };
+            crate::admin::session::CURRENT_SESSION
+                .scope(sess, audited)
+                .await
+        }
+        None => audited.await,
     };
 
     // Schema-mode pool is dropped here when `pool` falls out of
@@ -678,6 +706,11 @@ enum SessionCheck {
         /// duration of the inner-router dispatch so any audited
         /// write picks up the user-attribution automatically.
         user_id: i64,
+        /// Username of the authenticated user (empty for an
+        /// operator-impersonation session, which has no tenant user).
+        /// Threaded into the inner admin's chrome session so the
+        /// sidebar renders "Signed in as <username>" + Logout.
+        username: String,
         /// `Some(operator_id)` when this session was minted by
         /// the operator console's "Open admin as superuser →"
         /// flow (#78). Drives the impersonation banner +
@@ -757,6 +790,7 @@ async fn validate_session(
             Some(op) if op.active => SessionCheck::Authenticated {
                 is_superuser: true,
                 user_id: 0,
+                username: String::new(),
                 impersonated_by: Some(operator_id),
             },
             // Operator gone or deactivated → drop the impersonation.
@@ -799,6 +833,7 @@ async fn validate_session(
     SessionCheck::Authenticated {
         is_superuser: user.is_superuser,
         user_id: payload.uid,
+        username: user.username.clone(),
         impersonated_by: None,
     }
 }
@@ -1444,6 +1479,7 @@ fn build_inner_admin_router(
     impersonated_by: Option<i64>,
     admin_url_prefix: &str,
     change_password_url: &str,
+    logout_url: &str,
     audit_url: &str,
     static_url: &str,
 ) -> Router {
@@ -1468,7 +1504,10 @@ fn build_inner_admin_router(
         .static_url(static_url)
         // v0.28.2 (#77) — surface the self-serve change-password
         // page in the sidebar.
-        .change_password_url(change_password_url);
+        .change_password_url(change_password_url)
+        // Sidebar Logout posts here (the tenancy-layer logout route),
+        // not the bare admin's `{prefix}/logout` which isn't mounted.
+        .logout_url(logout_url);
     // v0.27.8 (#78) — propagate the impersonation flag so chrome
     // renders the banner + audit-log emit picks it up.
     if let Some(operator_id) = impersonated_by {

--- a/crates/rustango/src/tenancy/templates/tenant_login.html
+++ b/crates/rustango/src/tenancy/templates/tenant_login.html
@@ -105,6 +105,7 @@
       color: var(--color-text, #222); font: inherit; text-decoration: none; cursor: pointer;
     }
     .sso-button:hover { background: var(--color-surface-hover, #f3f3f3); }
+    .sso-button + .sso-button { margin-top: var(--space-2, 0.5rem); }
     .error {
       color: var(--color-error-fg);
       background: var(--color-error-bg);
@@ -139,12 +140,12 @@
     <input type="password" id="password" name="password" autocomplete="current-password" required>
     <input type="hidden" name="next" value="{{ next }}">
     <button type="submit">Sign in</button>
+    {% if sso_enabled %}
+    <div class="sso-divider"><span>or</span></div>
+    {% for p in sso_providers %}
+    <a class="sso-button" href="{{ p.login_url }}">{{ p.label }}</a>
+    {% endfor %}
+    {% endif %}
   </form>
-  {% if sso_enabled %}
-  <div class="sso-divider"><span>or</span></div>
-  {% for p in sso_providers %}
-  <a class="sso-button" href="{{ p.login_url }}">{{ p.label }}</a>
-  {% endfor %}
-  {% endif %}
 </body>
 </html>


### PR DESCRIPTION
Tenant-admin login layout + logout button fix, bumping to **0.49.1**.

This commit existed only on the local `develop` (it was never pushed) — this PR brings it onto `origin/develop`, which was at 0.49.0 (#1173). Cherry-picked verbatim from the local `7ecfc3a`; applies cleanly on top of 0.49.0 (the two 0.49.0 lineages were content-identical).

Touches admin login/logout UI: `tenancy/admin.rs`, `admin/urls.rs`, `admin/helpers.rs`, `tenant_login.html`, `_sidebar.html`, + the 0.49.0→0.49.1 version bump.