### PR TITLE
feat(mcp): user-owned keys with permission-driven capabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,6 +356,7 @@ jobs:
       - run: cargo test -p rustango --features mysql,tenancy --test tenancy_manage_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy,testkit --test permissions_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy,testkit --test database_pools_mysql_live
+      - run: cargo test -p rustango --features mysql,tenancy,mcp,testkit --test mcp_user_keys_mysql_live
       - run: cargo test -p rustango --features mysql --test audit_mysql_live
       - run: cargo test -p rustango --features mysql --test fixtures_mysql_live
       - run: cargo test -p rustango --features mysql --test inspectdb_mysql_live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,25 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
-_Nothing yet — next development cycle._
+### Added
+
+- **User-owned MCP keys + permission-driven capabilities** — a member can
+  generate a personal MCP key (a user-owned `Agent`, via a new nullable
+  `user_id` owner on `rustango_agents`) so an LLM acts on their behalf. Its
+  tools/prompts/resources are resolved from the tenant's existing **RBAC**
+  rather than pinned onto the key: map a skill to a permission codename with
+  `map_skill_to_permission_pool` (new `rustango_agent_skill_permissions`
+  table), and any key whose owner holds that permission is granted the skill
+  at token-issue (`resolve_user_agent_grants_pool` — the user's effective
+  permissions select the mapped skills, flattened into the JWT `skills`/`tools`
+  claims, so `tools/list`, `tools/call`, `prompts/get` and `resources/read`
+  are all RBAC-gated). The owner rides in the token's `uid` claim, surfaced as
+  `McpAgent.user_id` for tool handlers to scope work to the member. New
+  helpers `create_user_key_pool` / `list_user_keys_pool` /
+  `revoke_user_key_pool`. Backward compatible: standalone machine agents
+  (`user_id = None`) use their explicit grants only, and older `rustango_agents`
+  tables gain `user_id` transparently via an additive `ADD COLUMN`.
+  `issue_agent_token` gains a trailing `user_id: Option<i64>` argument.
 
 ## [0.48.0] — 2026-07-21
 

--- a/crates/rustango/src/mcp/auth.rs
+++ b/crates/rustango/src/mcp/auth.rs
@@ -236,6 +236,20 @@ pub(crate) async fn post_authed(
     let Some(agent) = verify_agent_token(jwt, token, &t.org.slug) else {
         return unauthorized(&headers, &uri);
     };
+    // Revocation immediacy: the JWT is stateless, so re-check at request time
+    // that the agent (and, for a user-owned key, its owner) still exists and is
+    // active. A revoked / deactivated key is refused straight away rather than
+    // lingering until the token expires.
+    match crate::tenancy::agent_token_still_valid_pool(t.pool(), agent.agent_id, agent.user_id)
+        .await
+    {
+        Ok(true) => {}
+        Ok(false) => return unauthorized(&headers, &uri),
+        Err(e) => {
+            tracing::warn!(error = %e, "mcp agent liveness re-check failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "auth check failed").into_response();
+        }
+    }
     // Agent verified + tenant-pinned: hand the tools layer the resolved
     // tenant pool + principal so `tools/call` runs against the right tenant.
     let ctx = super::tools::McpContext {

--- a/crates/rustango/src/mcp/auth.rs
+++ b/crates/rustango/src/mcp/auth.rs
@@ -40,6 +40,9 @@ pub const CLAIM_TENANT: &str = "tenant";
 pub const CLAIM_SKILLS: &str = "skills";
 /// Custom-claim key carrying the agent's flattened tool set (Slice 4).
 pub const CLAIM_TOOLS: &str = "tools";
+/// Custom-claim key carrying the owning `rustango_users.id` for a user-owned
+/// key. Absent for a standalone machine agent.
+pub const CLAIM_UID: &str = "uid";
 
 /// A verified agent principal, resolved from a tenant-pinned access token.
 #[derive(Debug, Clone)]
@@ -52,6 +55,10 @@ pub struct McpAgent {
     pub skills: Vec<String>,
     /// Flattened allowed tool set (empty until Slice 4).
     pub tools: Vec<String>,
+    /// Owning `rustango_users.id` for a user-owned key; `None` for a
+    /// standalone machine agent. Tool handlers scope work to this user via
+    /// `ctx.agent.user_id`.
+    pub user_id: Option<i64>,
     /// Unique token id — the revocation handle.
     pub jti: String,
 }
@@ -68,12 +75,16 @@ pub fn issue_agent_token(
     tenant: &str,
     skills: &[String],
     tools: &[String],
+    user_id: Option<i64>,
 ) -> Result<String, JwtIssueError> {
     let mut custom = serde_json::Map::new();
     custom.insert(CLAIM_KIND.into(), json!(KIND_AGENT));
     custom.insert(CLAIM_TENANT.into(), json!(tenant));
     custom.insert(CLAIM_SKILLS.into(), json!(skills));
     custom.insert(CLAIM_TOOLS.into(), json!(tools));
+    if let Some(uid) = user_id {
+        custom.insert(CLAIM_UID.into(), json!(uid));
+    }
     jwt.issue_access_with(agent_id, custom)
 }
 
@@ -103,6 +114,7 @@ pub fn verify_agent_token(
         tools: claims
             .get_custom::<Vec<String>>(CLAIM_TOOLS)
             .unwrap_or_default(),
+        user_id: claims.get_custom::<i64>(CLAIM_UID),
         jti: claims.jti,
     })
 }
@@ -157,16 +169,21 @@ pub(crate) async fn mint_agent_jwt(
         }
     };
     let agent_id = agent.id.get().copied().unwrap_or_default();
-    let (skills, tools) = crate::tenancy::resolve_agent_grants_pool(pool, agent_id)
-        .await
-        .map_err(|e| {
-            tracing::warn!(error = %e, "mcp grant resolution failed");
-            MintError::Internal
-        })?;
-    let token = issue_agent_token(jwt, agent_id, slug, &skills, &tools).map_err(|e| {
-        tracing::error!(error = %e, "mcp token issuance failed");
+    // A user-owned key resolves its capabilities from the owner's permissions
+    // (RBAC); a standalone machine agent uses its explicit grants only.
+    let grants = match agent.user_id {
+        Some(uid) => crate::tenancy::resolve_user_agent_grants_pool(pool, agent_id, uid).await,
+        None => crate::tenancy::resolve_agent_grants_pool(pool, agent_id).await,
+    };
+    let (skills, tools) = grants.map_err(|e| {
+        tracing::warn!(error = %e, "mcp grant resolution failed");
         MintError::Internal
     })?;
+    let token =
+        issue_agent_token(jwt, agent_id, slug, &skills, &tools, agent.user_id).map_err(|e| {
+            tracing::error!(error = %e, "mcp token issuance failed");
+            MintError::Internal
+        })?;
     Ok(MintedToken {
         token,
         expires_in: jwt.access_ttl_secs,
@@ -333,6 +350,36 @@ pub(crate) fn jwt_secret() -> Vec<u8> {
 mod tests {
     use super::*;
     use axum::http::Uri;
+
+    #[test]
+    fn token_round_trips_the_owning_user_id() {
+        use crate::tenancy::jwt_lifecycle::JwtLifecycle;
+        let jwt = JwtLifecycle::new(b"unit-secret-at-least-32-bytes-long!!".to_vec());
+
+        // A user-owned key carries `uid`.
+        let token = issue_agent_token(
+            &jwt,
+            5,
+            "acme",
+            &["coach".into()],
+            &["log".into()],
+            Some(99),
+        )
+        .expect("issue");
+        let agent = verify_agent_token(&jwt, &token, "acme").expect("verify");
+        assert_eq!(agent.agent_id, 5);
+        assert_eq!(agent.user_id, Some(99));
+        assert_eq!(agent.tools, vec!["log"]);
+
+        // A standalone machine agent has no `uid`.
+        let token = issue_agent_token(&jwt, 5, "acme", &[], &[], None).expect("issue");
+        assert_eq!(
+            verify_agent_token(&jwt, &token, "acme")
+                .expect("verify")
+                .user_id,
+            None
+        );
+    }
 
     fn headers(host: &str) -> HeaderMap {
         let mut h = HeaderMap::new();

--- a/crates/rustango/src/mcp/transport.rs
+++ b/crates/rustango/src/mcp/transport.rs
@@ -106,6 +106,18 @@ pub(crate) async fn sse_handler(
     let Some(agent) = super::auth::verify_agent_token(jwt, token, &t.org.slug) else {
         return super::auth::unauthorized(&headers, &uri);
     };
+    // Revocation immediacy: re-check the agent (and, for a user-owned key, its
+    // owner) still exists + is active before opening the notification stream.
+    match crate::tenancy::agent_token_still_valid_pool(t.pool(), agent.agent_id, agent.user_id)
+        .await
+    {
+        Ok(true) => {}
+        Ok(false) => return super::auth::unauthorized(&headers, &uri),
+        Err(e) => {
+            tracing::warn!(error = %e, "mcp agent liveness re-check failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "auth check failed").into_response();
+        }
+    }
     let tenant = agent.tenant.clone();
     let agent_id = agent.agent_id;
 

--- a/crates/rustango/src/tenancy/agents.rs
+++ b/crates/rustango/src/tenancy/agents.rs
@@ -609,11 +609,61 @@ pub async fn unmap_skill_from_permission_pool(
     Ok(())
 }
 
-/// Resolve a **user-owned** agent's effective `(skill codenames, tools)`:
-/// its explicit [`AgentGrant`]s (if any) unioned with every skill mapped to a
-/// permission the owning `user_id` currently holds. This is what
-/// [`crate::mcp`] bakes into the scoped JWT so `tools`, `prompts`, and
-/// `resources` are all gated by the tenant's RBAC.
+/// The skill ids the owning user is **entitled** to. `Ok(None)` means a
+/// superuser (entitled to every skill); `Ok(Some(ids))` is the set of skills
+/// mapped to a permission the user currently holds (may be empty).
+///
+/// # Errors
+/// Propagates DB / permission-lookup errors.
+async fn user_entitled_skill_ids(
+    pool: &Pool,
+    user_id: i64,
+) -> Result<Option<Vec<i64>>, AgentError> {
+    use crate::core::Column as _;
+    use crate::sql::FetcherPool as _;
+
+    let is_superuser = crate::tenancy::User::objects()
+        .filter("id", user_id)
+        .limit(1)
+        .fetch(pool)
+        .await?
+        .into_iter()
+        .next()
+        .is_some_and(|u| u.is_superuser);
+    if is_superuser {
+        return Ok(None);
+    }
+    let perms = super::user_permissions_pool(user_id, pool).await?;
+    if perms.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+    let mapped: Vec<AgentSkillPermission> = AgentSkillPermission::objects()
+        .where_(AgentSkillPermission::permission_codename.is_in(perms))
+        .fetch(pool)
+        .await?;
+    let mut ids: Vec<i64> = Vec::new();
+    for m in mapped {
+        if !ids.contains(&m.skill_id) {
+            ids.push(m.skill_id);
+        }
+    }
+    Ok(Some(ids))
+}
+
+/// Resolve a **user-owned** agent's effective `(skill codenames, tools)`,
+/// along two axes and always bounded by the owner's entitlement:
+///
+/// * **Entitlement** — which skills the owner may use: *every* skill for a
+///   superuser, otherwise the skills mapped (via [`AgentSkillPermission`]) to a
+///   permission the owner currently holds.
+/// * **Scope** — if the key was created with pinned skills ([`AgentGrant`]s via
+///   [`create_user_key_pool`]) it is limited to those; an unscoped key gets the
+///   owner's full entitlement.
+///
+/// Effective skills = `pinned ∩ entitled` for a scoped key, or the full
+/// entitlement for an unscoped one. A key can therefore never exceed the
+/// owner's permissions, and revoking a permission narrows every key at the next
+/// mint. [`crate::mcp`] bakes the resulting `tools` into the scoped JWT.
 ///
 /// # Errors
 /// Propagates DB / permission-lookup errors.
@@ -625,71 +675,52 @@ pub async fn resolve_user_agent_grants_pool(
     use crate::core::Column as _;
     use crate::sql::FetcherPool as _;
 
-    // Start from any explicit grants (an app may still pin a skill directly).
-    let (mut skills, mut tools) = resolve_agent_grants_pool(pool, agent_id).await?;
+    let entitled = user_entitled_skill_ids(pool, user_id).await?;
 
-    // A superuser owner is entitled to everything. `user_permissions_pool`
-    // returns only explicit/role perms and does NOT expand superusers, so
-    // resolve them here: union every skill codename + every tool in the tenant
-    // on top of the explicit grants, then return.
-    let owner_is_superuser = crate::tenancy::User::objects()
-        .filter("id", user_id)
-        .limit(1)
+    // Skills pinned onto THIS key at creation (the per-key scope).
+    let pinned: Vec<i64> = {
+        let grants: Vec<AgentGrant> = AgentGrant::objects()
+            .filter("agent_id", agent_id)
+            .fetch(pool)
+            .await?;
+        let mut ids = Vec::new();
+        for g in grants {
+            if !ids.contains(&g.skill_id) {
+                ids.push(g.skill_id);
+            }
+        }
+        ids
+    };
+
+    // Effective skill ids: pinned∩entitled (scoped) or the full entitlement.
+    let effective: Vec<i64> = match (&entitled, pinned.is_empty()) {
+        (None, true) => AgentSkill::objects()
+            .fetch(pool)
+            .await?
+            .into_iter()
+            .filter_map(|s| s.id.get().copied())
+            .collect(), // superuser, unscoped → every skill
+        (None, false) => pinned, // superuser, scoped → the pinned skills
+        (Some(ent), true) => ent.clone(), // non-superuser, unscoped → entitled
+        (Some(ent), false) => pinned.into_iter().filter(|id| ent.contains(id)).collect(),
+    };
+    if effective.is_empty() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+
+    let skills: Vec<String> = AgentSkill::objects()
+        .where_(AgentSkill::id.is_in(effective.clone()))
         .fetch(pool)
         .await?
         .into_iter()
-        .next()
-        .is_some_and(|u| u.is_superuser);
-    if owner_is_superuser {
-        let all_skills: Vec<AgentSkill> = AgentSkill::objects().fetch(pool).await?;
-        for s in all_skills {
-            if !skills.contains(&s.codename) {
-                skills.push(s.codename);
-            }
-        }
-        let all_tools: Vec<AgentSkillTool> = AgentSkillTool::objects().fetch(pool).await?;
-        for st in all_tools {
-            if !tools.contains(&st.tool_name) {
-                tools.push(st.tool_name);
-            }
-        }
-        return Ok((skills, tools));
-    }
-
-    // Skills the owning user is entitled to via their permissions.
-    let perms = super::user_permissions_pool(user_id, pool).await?;
-    if perms.is_empty() {
-        return Ok((skills, tools));
-    }
-
-    let mapped: Vec<AgentSkillPermission> = AgentSkillPermission::objects()
-        .where_(AgentSkillPermission::permission_codename.is_in(perms))
+        .map(|s| s.codename)
+        .collect();
+    let mut tools: Vec<String> = Vec::new();
+    for st in AgentSkillTool::objects()
+        .where_(AgentSkillTool::skill_id.is_in(effective))
         .fetch(pool)
-        .await?;
-    let mut skill_ids: Vec<i64> = Vec::new();
-    for m in mapped {
-        if !skill_ids.contains(&m.skill_id) {
-            skill_ids.push(m.skill_id);
-        }
-    }
-    if skill_ids.is_empty() {
-        return Ok((skills, tools));
-    }
-
-    let entitled: Vec<AgentSkill> = AgentSkill::objects()
-        .where_(AgentSkill::id.is_in(skill_ids.clone()))
-        .fetch(pool)
-        .await?;
-    for s in entitled {
-        if !skills.contains(&s.codename) {
-            skills.push(s.codename);
-        }
-    }
-    let entitled_tools: Vec<AgentSkillTool> = AgentSkillTool::objects()
-        .where_(AgentSkillTool::skill_id.is_in(skill_ids))
-        .fetch(pool)
-        .await?;
-    for st in entitled_tools {
+        .await?
+    {
         if !tools.contains(&st.tool_name) {
             tools.push(st.tool_name);
         }
@@ -728,16 +759,62 @@ async fn unique_key_name(pool: &Pool, user_id: i64) -> Result<String, AgentError
 }
 
 /// Create a personal, user-owned MCP key. The returned [`AgentSecret::token`]
-/// (`prefix.secret`) is shown once and never recoverable. Capabilities are
-/// resolved from the owner's permissions at token-issue — nothing to pin here.
+/// (`prefix.secret`) is shown once and never recoverable.
+///
+/// `skills` sets the key's scope:
+/// * **empty** → an *unscoped* key that can use everything the owner is
+///   entitled to (their full permission-derived skill set, or all skills for a
+///   superuser).
+/// * **non-empty** → a *scoped* key limited to exactly those skill codenames
+///   (a single skill or a skillset). Each must be a real skill the owner is
+///   entitled to; otherwise this fails — you can't mint a key more capable than
+///   yourself. Scoping pins [`AgentGrant`]s, and resolution always re-intersects
+///   with the owner's current entitlement at mint
+///   ([`resolve_user_agent_grants_pool`]).
 ///
 /// # Errors
-/// A DB / secret-generation error.
+/// [`AgentError::NotFound`] for an unknown skill codename;
+/// [`AgentError::Tenancy`] if the owner isn't entitled to a requested skill;
+/// a DB / secret-generation error otherwise.
 pub async fn create_user_key_pool(
     pool: &Pool,
     user_id: i64,
     label: &str,
+    skills: &[String],
 ) -> Result<AgentSecret, AgentError> {
+    use crate::core::Column as _;
+    use crate::sql::FetcherPool as _;
+
+    // Resolve + entitlement-check every requested skill up front, so an invalid
+    // request fails before any key row is written.
+    let mut skill_ids: Vec<i64> = Vec::new();
+    if !skills.is_empty() {
+        let entitled = user_entitled_skill_ids(pool, user_id).await?;
+        for codename in skills {
+            let skill = AgentSkill::objects()
+                .where_(AgentSkill::codename.eq(codename.clone()))
+                .limit(1)
+                .fetch(pool)
+                .await?
+                .into_iter()
+                .next()
+                .ok_or_else(|| AgentError::NotFound(codename.clone()))?;
+            let sid = skill.id.get().copied().unwrap_or_default();
+            let entitled_to_it = match &entitled {
+                None => true, // superuser
+                Some(ids) => ids.contains(&sid),
+            };
+            if !entitled_to_it {
+                return Err(AgentError::Tenancy(super::error::TenancyError::Validation(
+                    format!("owner is not entitled to skill `{codename}`"),
+                )));
+            }
+            if !skill_ids.contains(&sid) {
+                skill_ids.push(sid);
+            }
+        }
+    }
+
     let name = unique_key_name(pool, user_id).await?;
     let (token, prefix, hash) = generate_credential()?;
     let mut agent = Agent {
@@ -752,6 +829,18 @@ pub async fn create_user_key_pool(
         data: serde_json::json!({ "kind": "user_key", "label": label }),
     };
     agent.insert_pool(pool).await?;
+    let agent_id = agent.id.get().copied().unwrap_or_default();
+
+    // Pin the scoped skills as grants (the per-key scope).
+    for sid in skill_ids {
+        let mut grant = AgentGrant {
+            id: Auto::default(),
+            agent_id,
+            skill_id: sid,
+            data: serde_json::json!({}),
+        };
+        grant.insert_pool(pool).await?;
+    }
     Ok(AgentSecret { agent, token })
 }
 

--- a/crates/rustango/src/tenancy/agents.rs
+++ b/crates/rustango/src/tenancy/agents.rs
@@ -6,12 +6,12 @@
 //! verified by [`crate::api_keys`] — and exchanges it for a short-lived
 //! scoped JWT (see [`crate::mcp::auth`]).
 //!
-//! The table is created on demand by [`ensure_agents_table_pool`], exactly
-//! like `rustango_api_keys` (`tenancy::auth_backends::ensure_api_keys_table_pool`)
-//! — the bootstrap `forward` ops only create `rustango_users`; everything
-//! else is ensured per-dialect. `Agent::SCHEMA` is still listed in the
-//! tenant bootstrap snapshot so a downstream `make_migrations` sees a
-//! complete world.
+//! Every model here is `#[derive(Model)]`, `managed`, and lives on a
+//! `rustango_*` table, so all its tables are emitted as ordinary **system
+//! migrations** (and, in tests, materialized by
+//! [`crate::testkit::migrate_framework`]). There is no lazy `ensure_*`
+//! creation layer — the tables exist because migrations ran, exactly like
+//! the rest of the framework's own tables.
 
 use crate::sql::{Auto, ExecError, Pool};
 
@@ -54,116 +54,13 @@ pub struct Agent {
     /// member generates so an LLM can act on their behalf. The owner rides
     /// into the agent's scoped JWT (`uid` claim) so tool handlers can scope
     /// work to the member (`ctx.agent.user_id`). Logically references
-    /// `rustango_users`; the ensure-DDL owns the schema (like the rest of
-    /// this table) so no hard FK is declared.
+    /// `rustango_users`, but no hard FK is declared — that would couple the
+    /// `mcp` feature to `tenancy` and break mcp-without-tenancy builds. Orphan
+    /// cleanup on user deletion is explicit via [`delete_user_keys_pool`].
     pub user_id: Option<i64>,
     /// Flexible per-agent metadata. Never read by the framework.
     #[rustango(default = "'{}'")]
     pub data: serde_json::Value,
-}
-
-// --------------------------------------------------------------- ensure DDL
-// Per-dialect `CREATE TABLE IF NOT EXISTS`, mirroring
-// `tenancy::auth_backends`'s api-keys constants. No FK — an agent is its
-// own identity (not owned by a `rustango_users` row).
-
-const AGENT_ENSURE_SQL: &str = r#"
-CREATE TABLE IF NOT EXISTS "rustango_agents" (
-    "id"                BIGSERIAL    PRIMARY KEY,
-    "name"              VARCHAR(150) NOT NULL,
-    "secret_prefix"     VARCHAR(16)  NOT NULL,
-    "secret_hash"       VARCHAR(255) NOT NULL,
-    "active"            BOOLEAN      NOT NULL DEFAULT TRUE,
-    "created_at"        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
-    "secret_rotated_at" TIMESTAMPTZ,
-    "user_id"           BIGINT,
-    "data"              JSONB        NOT NULL DEFAULT '{}',
-    CONSTRAINT "rustango_agents_name_uq"   UNIQUE ("name"),
-    CONSTRAINT "rustango_agents_prefix_uq" UNIQUE ("secret_prefix")
-);"#;
-
-const AGENT_ENSURE_SQL_SQLITE: &str = r#"
-CREATE TABLE IF NOT EXISTS "rustango_agents" (
-    "id"                INTEGER PRIMARY KEY AUTOINCREMENT,
-    "name"              TEXT    NOT NULL,
-    "secret_prefix"     TEXT    NOT NULL,
-    "secret_hash"       TEXT    NOT NULL,
-    "active"            INTEGER NOT NULL DEFAULT 1,
-    "created_at"        TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "secret_rotated_at" TEXT,
-    "user_id"           INTEGER,
-    "data"              TEXT    NOT NULL DEFAULT '{}',
-    CONSTRAINT "rustango_agents_name_uq"   UNIQUE ("name"),
-    CONSTRAINT "rustango_agents_prefix_uq" UNIQUE ("secret_prefix")
-);"#;
-
-const AGENT_ENSURE_SQL_MYSQL: &str = r#"
-CREATE TABLE IF NOT EXISTS `rustango_agents` (
-    `id`                BIGINT AUTO_INCREMENT PRIMARY KEY,
-    `name`              VARCHAR(150) NOT NULL,
-    `secret_prefix`     VARCHAR(16)  NOT NULL,
-    `secret_hash`       VARCHAR(255) NOT NULL,
-    `active`            TINYINT(1)   NOT NULL DEFAULT 1,
-    `created_at`        DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-    `secret_rotated_at` DATETIME(6),
-    `user_id`           BIGINT,
-    `data`              JSON,
-    CONSTRAINT `rustango_agents_name_uq`   UNIQUE (`name`),
-    CONSTRAINT `rustango_agents_prefix_uq` UNIQUE (`secret_prefix`)
-);"#;
-
-/// Create the `rustango_agents` table if absent (idempotent, per-dialect).
-/// Mirrors `tenancy::auth_backends::ensure_api_keys_table_pool`.
-///
-/// # Errors
-/// Propagates the driver error if the `CREATE TABLE` fails.
-pub async fn ensure_agents_table_pool(pool: &Pool) -> Result<(), sqlx::Error> {
-    let ddl = match pool.dialect().name() {
-        "sqlite" => AGENT_ENSURE_SQL_SQLITE,
-        "mysql" => AGENT_ENSURE_SQL_MYSQL,
-        _ => AGENT_ENSURE_SQL,
-    };
-    for stmt in ddl.split(';').map(str::trim).filter(|s| !s.is_empty()) {
-        crate::sql::raw_execute_pool(pool, stmt, Vec::new())
-            .await
-            .map_err(|e| match e {
-                ExecError::Driver(err) => err,
-                other => sqlx::Error::Protocol(format!("{other}")),
-            })?;
-    }
-    // Additive: `CREATE TABLE IF NOT EXISTS` won't add `user_id` to a table
-    // created before this column existed. Probe for it and `ADD COLUMN` once
-    // if missing, so upgrading in place is transparent (no migration step).
-    ensure_user_id_column(pool).await?;
-    Ok(())
-}
-
-/// Add `rustango_agents.user_id` if an older table predates it. Probe with a
-/// cheap zero-row select (dialect-agnostic); only `ALTER` when the column is
-/// absent. The added column is nullable with no default, so it's a metadata-
-/// only change on every backend.
-async fn ensure_user_id_column(pool: &Pool) -> Result<(), sqlx::Error> {
-    // Identifier quoting differs by dialect (MySQL uses backticks).
-    let (tbl, col, col_type) = match pool.dialect().name() {
-        "mysql" => ("`rustango_agents`", "`user_id`", "BIGINT"),
-        "sqlite" => (r#""rustango_agents""#, r#""user_id""#, "INTEGER"),
-        _ => (r#""rustango_agents""#, r#""user_id""#, "BIGINT"),
-    };
-    let probe = format!("SELECT {col} FROM {tbl} LIMIT 0");
-    if crate::sql::raw_execute_pool(pool, &probe, Vec::new())
-        .await
-        .is_ok()
-    {
-        return Ok(()); // column already present
-    }
-    let alter = format!("ALTER TABLE {tbl} ADD COLUMN {col} {col_type}");
-    crate::sql::raw_execute_pool(pool, &alter, Vec::new())
-        .await
-        .map_err(|e| match e {
-            ExecError::Driver(err) => err,
-            other => sqlx::Error::Protocol(format!("{other}")),
-        })?;
-    Ok(())
 }
 
 // ------------------------------------------------------------- operations
@@ -228,8 +125,6 @@ pub async fn create_agent_pool(pool: &Pool, name: &str) -> Result<AgentSecret, A
     use crate::core::Column as _;
     use crate::sql::FetcherPool as _;
 
-    ensure_agents_table_pool(pool).await?;
-
     let existing: Vec<Agent> = Agent::objects()
         .where_(Agent::name.eq(name))
         .limit(1)
@@ -265,8 +160,6 @@ pub async fn rotate_agent_secret_pool(pool: &Pool, name: &str) -> Result<AgentSe
     use crate::core::Column as _;
     use crate::sql::FetcherPool as _;
 
-    ensure_agents_table_pool(pool).await?;
-
     let mut agent: Agent = Agent::objects()
         .where_(Agent::name.eq(name))
         .limit(1)
@@ -290,7 +183,6 @@ pub async fn rotate_agent_secret_pool(pool: &Pool, name: &str) -> Result<AgentSe
 /// Propagates DB errors.
 pub async fn list_agents_pool(pool: &Pool) -> Result<Vec<Agent>, AgentError> {
     use crate::sql::FetcherPool as _;
-    ensure_agents_table_pool(pool).await?;
     let agents = Agent::objects()
         .order_by(&[("name", false)])
         .fetch(pool)
@@ -313,8 +205,6 @@ pub async fn authenticate_agent_pool(
 ) -> Result<Option<Agent>, AgentError> {
     use crate::core::Column as _;
     use crate::sql::FetcherPool as _;
-
-    ensure_agents_table_pool(pool).await?;
 
     // Accept either `prefix.secret` or the bare secret half (secrets are
     // hex, so the part after the last `.` is the secret).
@@ -424,123 +314,6 @@ pub struct AgentSkillPermission {
     pub permission_codename: String,
 }
 
-const SKILLS_ENSURE_SQL: &str = r#"
-CREATE TABLE IF NOT EXISTS "rustango_agent_skills" (
-    "id"           BIGSERIAL    PRIMARY KEY,
-    "codename"     VARCHAR(100) NOT NULL,
-    "name"         VARCHAR(150) NOT NULL DEFAULT '',
-    "description"  VARCHAR(500) NOT NULL DEFAULT '',
-    "instructions" TEXT         NOT NULL DEFAULT '',
-    "data"         JSONB        NOT NULL DEFAULT '{}',
-    CONSTRAINT "rustango_agent_skills_codename_uq" UNIQUE ("codename")
-);
-CREATE TABLE IF NOT EXISTS "rustango_agent_skill_tools" (
-    "id"        BIGSERIAL    PRIMARY KEY,
-    "skill_id"  BIGINT       NOT NULL REFERENCES "rustango_agent_skills"("id") ON DELETE CASCADE,
-    "tool_name" VARCHAR(150) NOT NULL
-);
-CREATE TABLE IF NOT EXISTS "rustango_agent_grants" (
-    "id"       BIGSERIAL PRIMARY KEY,
-    "agent_id" BIGINT    NOT NULL REFERENCES "rustango_agents"("id")       ON DELETE CASCADE,
-    "skill_id" BIGINT    NOT NULL REFERENCES "rustango_agent_skills"("id") ON DELETE CASCADE,
-    "data"     JSONB     NOT NULL DEFAULT '{}',
-    CONSTRAINT "rustango_agent_grants_uq" UNIQUE ("agent_id", "skill_id")
-);
-CREATE TABLE IF NOT EXISTS "rustango_agent_skill_permissions" (
-    "id"                  BIGSERIAL    PRIMARY KEY,
-    "skill_id"            BIGINT       NOT NULL REFERENCES "rustango_agent_skills"("id") ON DELETE CASCADE,
-    "permission_codename" VARCHAR(150) NOT NULL,
-    CONSTRAINT "rustango_agent_skill_permissions_uq" UNIQUE ("skill_id", "permission_codename")
-);"#;
-
-const SKILLS_ENSURE_SQL_SQLITE: &str = r#"
-CREATE TABLE IF NOT EXISTS "rustango_agent_skills" (
-    "id"           INTEGER PRIMARY KEY AUTOINCREMENT,
-    "codename"     TEXT NOT NULL,
-    "name"         TEXT NOT NULL DEFAULT '',
-    "description"  TEXT NOT NULL DEFAULT '',
-    "instructions" TEXT NOT NULL DEFAULT '',
-    "data"         TEXT NOT NULL DEFAULT '{}',
-    CONSTRAINT "rustango_agent_skills_codename_uq" UNIQUE ("codename")
-);
-CREATE TABLE IF NOT EXISTS "rustango_agent_skill_tools" (
-    "id"        INTEGER PRIMARY KEY AUTOINCREMENT,
-    "skill_id"  INTEGER NOT NULL REFERENCES "rustango_agent_skills"("id") ON DELETE CASCADE,
-    "tool_name" TEXT    NOT NULL
-);
-CREATE TABLE IF NOT EXISTS "rustango_agent_grants" (
-    "id"       INTEGER PRIMARY KEY AUTOINCREMENT,
-    "agent_id" INTEGER NOT NULL REFERENCES "rustango_agents"("id")       ON DELETE CASCADE,
-    "skill_id" INTEGER NOT NULL REFERENCES "rustango_agent_skills"("id") ON DELETE CASCADE,
-    "data"     TEXT    NOT NULL DEFAULT '{}',
-    CONSTRAINT "rustango_agent_grants_uq" UNIQUE ("agent_id", "skill_id")
-);
-CREATE TABLE IF NOT EXISTS "rustango_agent_skill_permissions" (
-    "id"                  INTEGER PRIMARY KEY AUTOINCREMENT,
-    "skill_id"            INTEGER NOT NULL REFERENCES "rustango_agent_skills"("id") ON DELETE CASCADE,
-    "permission_codename" TEXT    NOT NULL,
-    CONSTRAINT "rustango_agent_skill_permissions_uq" UNIQUE ("skill_id", "permission_codename")
-);"#;
-
-const SKILLS_ENSURE_SQL_MYSQL: &str = r#"
-CREATE TABLE IF NOT EXISTS `rustango_agent_skills` (
-    `id`           BIGINT AUTO_INCREMENT PRIMARY KEY,
-    `codename`     VARCHAR(100) NOT NULL,
-    `name`         VARCHAR(150) NOT NULL DEFAULT '',
-    `description`  VARCHAR(500) NOT NULL DEFAULT '',
-    `instructions` TEXT         NOT NULL,
-    `data`         JSON,
-    CONSTRAINT `rustango_agent_skills_codename_uq` UNIQUE (`codename`)
-);
-CREATE TABLE IF NOT EXISTS `rustango_agent_skill_tools` (
-    `id`        BIGINT AUTO_INCREMENT PRIMARY KEY,
-    `skill_id`  BIGINT       NOT NULL,
-    `tool_name` VARCHAR(150) NOT NULL,
-    CONSTRAINT `rustango_agent_skill_tools_fk` FOREIGN KEY (`skill_id`)
-        REFERENCES `rustango_agent_skills`(`id`) ON DELETE CASCADE
-);
-CREATE TABLE IF NOT EXISTS `rustango_agent_grants` (
-    `id`       BIGINT AUTO_INCREMENT PRIMARY KEY,
-    `agent_id` BIGINT NOT NULL,
-    `skill_id` BIGINT NOT NULL,
-    `data`     JSON,
-    CONSTRAINT `rustango_agent_grants_uq` UNIQUE (`agent_id`, `skill_id`),
-    CONSTRAINT `rustango_agent_grants_fk_agent` FOREIGN KEY (`agent_id`)
-        REFERENCES `rustango_agents`(`id`) ON DELETE CASCADE,
-    CONSTRAINT `rustango_agent_grants_fk_skill` FOREIGN KEY (`skill_id`)
-        REFERENCES `rustango_agent_skills`(`id`) ON DELETE CASCADE
-);
-CREATE TABLE IF NOT EXISTS `rustango_agent_skill_permissions` (
-    `id`                  BIGINT AUTO_INCREMENT PRIMARY KEY,
-    `skill_id`            BIGINT       NOT NULL,
-    `permission_codename` VARCHAR(150) NOT NULL,
-    CONSTRAINT `rustango_agent_skill_permissions_uq` UNIQUE (`skill_id`, `permission_codename`),
-    CONSTRAINT `rustango_agent_skill_permissions_fk` FOREIGN KEY (`skill_id`)
-        REFERENCES `rustango_agent_skills`(`id`) ON DELETE CASCADE
-);"#;
-
-/// Create the skill / skill-tool / grant tables if absent (idempotent,
-/// per-dialect). Mirrors [`ensure_agents_table_pool`].
-///
-/// # Errors
-/// Propagates the driver error if a `CREATE TABLE` fails.
-pub async fn ensure_skill_tables_pool(pool: &Pool) -> Result<(), sqlx::Error> {
-    let ddl = match pool.dialect().name() {
-        "sqlite" => SKILLS_ENSURE_SQL_SQLITE,
-        "mysql" => SKILLS_ENSURE_SQL_MYSQL,
-        _ => SKILLS_ENSURE_SQL,
-    };
-    for stmt in ddl.split(';').map(str::trim).filter(|s| !s.is_empty()) {
-        crate::sql::raw_execute_pool(pool, stmt, Vec::new())
-            .await
-            .map_err(|e| match e {
-                ExecError::Driver(err) => err,
-                other => sqlx::Error::Protocol(format!("{other}")),
-            })?;
-    }
-    Ok(())
-}
-
 /// Create a skill bundling `tools` (by name). `name`/`description`/
 /// `instructions` are optional metadata.
 ///
@@ -557,7 +330,6 @@ pub async fn create_skill_pool(
     use crate::core::Column as _;
     use crate::sql::FetcherPool as _;
 
-    ensure_skill_tables_pool(pool).await?;
     let existing: Vec<AgentSkill> = AgentSkill::objects()
         .where_(AgentSkill::codename.eq(codename))
         .limit(1)
@@ -595,7 +367,6 @@ pub async fn create_skill_pool(
 /// Propagates DB errors.
 pub async fn list_skills_pool(pool: &Pool) -> Result<Vec<AgentSkill>, AgentError> {
     use crate::sql::FetcherPool as _;
-    ensure_skill_tables_pool(pool).await?;
     Ok(AgentSkill::objects()
         .order_by(&[("codename", false)])
         .fetch(pool)
@@ -615,9 +386,6 @@ pub async fn grant_skill_pool(
 ) -> Result<(), AgentError> {
     use crate::core::Column as _;
     use crate::sql::FetcherPool as _;
-
-    ensure_agents_table_pool(pool).await?;
-    ensure_skill_tables_pool(pool).await?;
 
     let (agent_id, skill_id) = resolve_ids(pool, agent_name, skill_codename).await?;
 
@@ -652,9 +420,6 @@ pub async fn revoke_skill_pool(
 ) -> Result<(), AgentError> {
     use crate::core::Column as _;
     use crate::sql::FetcherPool as _;
-
-    ensure_agents_table_pool(pool).await?;
-    ensure_skill_tables_pool(pool).await?;
 
     let (agent_id, skill_id) = resolve_ids(pool, agent_name, skill_codename).await?;
     let grants: Vec<AgentGrant> = AgentGrant::objects()
@@ -731,8 +496,6 @@ pub async fn resolve_agent_grants_pool(
     use crate::core::Column as _;
     use crate::sql::FetcherPool as _;
 
-    ensure_skill_tables_pool(pool).await?;
-
     let grants: Vec<AgentGrant> = AgentGrant::objects()
         .where_(AgentGrant::agent_id.eq(agent_id))
         .fetch(pool)
@@ -782,7 +545,6 @@ pub async fn map_skill_to_permission_pool(
     use crate::core::Column as _;
     use crate::sql::FetcherPool as _;
 
-    ensure_skill_tables_pool(pool).await?;
     let skill_id = AgentSkill::objects()
         .where_(AgentSkill::codename.eq(skill_codename))
         .limit(1)
@@ -825,7 +587,6 @@ pub async fn unmap_skill_from_permission_pool(
     use crate::core::Column as _;
     use crate::sql::FetcherPool as _;
 
-    ensure_skill_tables_pool(pool).await?;
     let Some(skill_id) = AgentSkill::objects()
         .where_(AgentSkill::codename.eq(skill_codename))
         .limit(1)
@@ -866,6 +627,34 @@ pub async fn resolve_user_agent_grants_pool(
 
     // Start from any explicit grants (an app may still pin a skill directly).
     let (mut skills, mut tools) = resolve_agent_grants_pool(pool, agent_id).await?;
+
+    // A superuser owner is entitled to everything. `user_permissions_pool`
+    // returns only explicit/role perms and does NOT expand superusers, so
+    // resolve them here: union every skill codename + every tool in the tenant
+    // on top of the explicit grants, then return.
+    let owner_is_superuser = crate::tenancy::User::objects()
+        .filter("id", user_id)
+        .limit(1)
+        .fetch(pool)
+        .await?
+        .into_iter()
+        .next()
+        .is_some_and(|u| u.is_superuser);
+    if owner_is_superuser {
+        let all_skills: Vec<AgentSkill> = AgentSkill::objects().fetch(pool).await?;
+        for s in all_skills {
+            if !skills.contains(&s.codename) {
+                skills.push(s.codename);
+            }
+        }
+        let all_tools: Vec<AgentSkillTool> = AgentSkillTool::objects().fetch(pool).await?;
+        for st in all_tools {
+            if !tools.contains(&st.tool_name) {
+                tools.push(st.tool_name);
+            }
+        }
+        return Ok((skills, tools));
+    }
 
     // Skills the owning user is entitled to via their permissions.
     let perms = super::user_permissions_pool(user_id, pool).await?;
@@ -949,7 +738,6 @@ pub async fn create_user_key_pool(
     user_id: i64,
     label: &str,
 ) -> Result<AgentSecret, AgentError> {
-    ensure_agents_table_pool(pool).await?;
     let name = unique_key_name(pool, user_id).await?;
     let (token, prefix, hash) = generate_credential()?;
     let mut agent = Agent {
@@ -973,7 +761,6 @@ pub async fn create_user_key_pool(
 /// Propagates DB errors.
 pub async fn list_user_keys_pool(pool: &Pool, user_id: i64) -> Result<Vec<Agent>, AgentError> {
     use crate::sql::FetcherPool as _;
-    ensure_agents_table_pool(pool).await?;
     Ok(Agent::objects()
         .filter("user_id", user_id)
         .order_by(&[("created_at", true)])
@@ -996,7 +783,6 @@ pub async fn revoke_user_key_pool(
 ) -> Result<(), AgentError> {
     use crate::sql::FetcherPool as _;
 
-    ensure_agents_table_pool(pool).await?;
     let agent = Agent::objects()
         .filter("id", agent_id)
         .limit(1)
@@ -1018,6 +804,87 @@ pub async fn revoke_user_key_pool(
     Ok(())
 }
 
+/// Delete **every** user-owned key belonging to `user_id` — all [`Agent`]
+/// rows with `user_id == Some(user_id)` — removing each agent's
+/// [`AgentGrant`]s first (not relying on FK cascade, which some SQLite
+/// connections don't enforce). Call this from a tenant user-deletion path so a
+/// departed member's personal MCP keys can't outlive them. There is no hard FK
+/// from `rustango_agents.user_id` to `rustango_users` (it would couple `mcp` →
+/// `tenancy`), so orphan cleanup is explicit.
+///
+/// # Errors
+/// Propagates DB errors.
+pub async fn delete_user_keys_pool(pool: &Pool, user_id: i64) -> Result<(), AgentError> {
+    use crate::sql::FetcherPool as _;
+
+    let agents: Vec<Agent> = Agent::objects()
+        .filter("user_id", user_id)
+        .fetch(pool)
+        .await?;
+    for agent in agents {
+        let agent_id = agent.id.get().copied().unwrap_or_default();
+        let grants: Vec<AgentGrant> = AgentGrant::objects()
+            .filter("agent_id", agent_id)
+            .fetch(pool)
+            .await?;
+        for g in grants {
+            g.delete_pool(pool).await?;
+        }
+        agent.delete_pool(pool).await?;
+    }
+    Ok(())
+}
+
+/// Request-time liveness re-check for a verified agent token. MCP agent JWTs
+/// are stateless — [`crate::mcp::verify_agent_token`] proves the token is
+/// well-formed and tenant-pinned but not that the agent still exists. Call
+/// this right after verification (where the tenant [`Pool`] is available) so
+/// that revoking / deactivating a key takes effect immediately instead of
+/// lingering until the token expires.
+///
+/// Returns `false` (reject) when the agent row is absent or `active == false`,
+/// and — for a user-owned key (`user_id.is_some()`) — when the owning user is
+/// missing or `active == false`. One cheap lookup per request.
+///
+/// # Errors
+/// Propagates DB errors.
+pub async fn agent_token_still_valid_pool(
+    pool: &Pool,
+    agent_id: i64,
+    user_id: Option<i64>,
+) -> Result<bool, AgentError> {
+    use crate::sql::FetcherPool as _;
+
+    let Some(agent) = Agent::objects()
+        .filter("id", agent_id)
+        .limit(1)
+        .fetch(pool)
+        .await?
+        .into_iter()
+        .next()
+    else {
+        return Ok(false);
+    };
+    if !agent.active {
+        return Ok(false);
+    }
+
+    if let Some(uid) = user_id {
+        let owner_active = crate::tenancy::User::objects()
+            .filter("id", uid)
+            .limit(1)
+            .fetch(pool)
+            .await?
+            .into_iter()
+            .next()
+            .is_some_and(|u| u.active);
+        if !owner_active {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 // ====================================================== resources (Slice 5)
 
 /// A resource attached to a skill (epic #1013, Slice 5 / #1018). The body is
@@ -1037,52 +904,6 @@ pub struct AgentSkillResource {
     pub data: serde_json::Value,
 }
 
-const RESOURCES_ENSURE_SQL: &str = r#"
-CREATE TABLE IF NOT EXISTS "rustango_agent_skill_resources" (
-    "id"           BIGSERIAL    PRIMARY KEY,
-    "skill_id"     BIGINT       NOT NULL REFERENCES "rustango_agent_skills"("id") ON DELETE CASCADE,
-    "resource_uri" VARCHAR(500) NOT NULL,
-    "mime"         VARCHAR(100) NOT NULL DEFAULT 'text/plain',
-    "data"         JSONB        NOT NULL DEFAULT '{}'
-);"#;
-
-const RESOURCES_ENSURE_SQL_SQLITE: &str = r#"
-CREATE TABLE IF NOT EXISTS "rustango_agent_skill_resources" (
-    "id"           INTEGER PRIMARY KEY AUTOINCREMENT,
-    "skill_id"     INTEGER NOT NULL REFERENCES "rustango_agent_skills"("id") ON DELETE CASCADE,
-    "resource_uri" TEXT    NOT NULL,
-    "mime"         TEXT    NOT NULL DEFAULT 'text/plain',
-    "data"         TEXT    NOT NULL DEFAULT '{}'
-);"#;
-
-const RESOURCES_ENSURE_SQL_MYSQL: &str = r#"
-CREATE TABLE IF NOT EXISTS `rustango_agent_skill_resources` (
-    `id`           BIGINT AUTO_INCREMENT PRIMARY KEY,
-    `skill_id`     BIGINT       NOT NULL,
-    `resource_uri` VARCHAR(500) NOT NULL,
-    `mime`         VARCHAR(100) NOT NULL DEFAULT 'text/plain',
-    `data`         JSON,
-    CONSTRAINT `rustango_agent_skill_resources_fk` FOREIGN KEY (`skill_id`)
-        REFERENCES `rustango_agent_skills`(`id`) ON DELETE CASCADE
-);"#;
-
-async fn ensure_resources_table_pool(pool: &Pool) -> Result<(), sqlx::Error> {
-    let ddl = match pool.dialect().name() {
-        "sqlite" => RESOURCES_ENSURE_SQL_SQLITE,
-        "mysql" => RESOURCES_ENSURE_SQL_MYSQL,
-        _ => RESOURCES_ENSURE_SQL,
-    };
-    for stmt in ddl.split(';').map(str::trim).filter(|s| !s.is_empty()) {
-        crate::sql::raw_execute_pool(pool, stmt, Vec::new())
-            .await
-            .map_err(|e| match e {
-                ExecError::Driver(err) => err,
-                other => sqlx::Error::Protocol(format!("{other}")),
-            })?;
-    }
-    Ok(())
-}
-
 /// Attach a resource (uri + mime + text body) to a skill.
 ///
 /// # Errors
@@ -1096,9 +917,6 @@ pub async fn add_skill_resource_pool(
 ) -> Result<AgentSkillResource, AgentError> {
     use crate::core::Column as _;
     use crate::sql::FetcherPool as _;
-
-    ensure_skill_tables_pool(pool).await?;
-    ensure_resources_table_pool(pool).await?;
 
     let skill_id = AgentSkill::objects()
         .where_(AgentSkill::codename.eq(skill_codename))
@@ -1135,7 +953,6 @@ pub async fn skills_by_codenames_pool(
 ) -> Result<Vec<AgentSkill>, AgentError> {
     use crate::core::Column as _;
     use crate::sql::FetcherPool as _;
-    ensure_skill_tables_pool(pool).await?;
     if codenames.is_empty() {
         return Ok(vec![]);
     }
@@ -1156,8 +973,6 @@ pub async fn resources_for_skills_pool(
 ) -> Result<Vec<AgentSkillResource>, AgentError> {
     use crate::core::Column as _;
     use crate::sql::FetcherPool as _;
-    ensure_skill_tables_pool(pool).await?;
-    ensure_resources_table_pool(pool).await?;
     if codenames.is_empty() {
         return Ok(vec![]);
     }

--- a/crates/rustango/src/tenancy/agents.rs
+++ b/crates/rustango/src/tenancy/agents.rs
@@ -49,6 +49,14 @@ pub struct Agent {
     pub created_at: Auto<chrono::DateTime<chrono::Utc>>,
     /// Timestamp of the last secret rotation. `None` until first rotated.
     pub secret_rotated_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Optional owning `rustango_users.id`. `None` for a standalone machine
+    /// agent; `Some(uid)` for a **user-owned key** — a personal credential a
+    /// member generates so an LLM can act on their behalf. The owner rides
+    /// into the agent's scoped JWT (`uid` claim) so tool handlers can scope
+    /// work to the member (`ctx.agent.user_id`). Logically references
+    /// `rustango_users`; the ensure-DDL owns the schema (like the rest of
+    /// this table) so no hard FK is declared.
+    pub user_id: Option<i64>,
     /// Flexible per-agent metadata. Never read by the framework.
     #[rustango(default = "'{}'")]
     pub data: serde_json::Value,
@@ -68,6 +76,7 @@ CREATE TABLE IF NOT EXISTS "rustango_agents" (
     "active"            BOOLEAN      NOT NULL DEFAULT TRUE,
     "created_at"        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
     "secret_rotated_at" TIMESTAMPTZ,
+    "user_id"           BIGINT,
     "data"              JSONB        NOT NULL DEFAULT '{}',
     CONSTRAINT "rustango_agents_name_uq"   UNIQUE ("name"),
     CONSTRAINT "rustango_agents_prefix_uq" UNIQUE ("secret_prefix")
@@ -82,6 +91,7 @@ CREATE TABLE IF NOT EXISTS "rustango_agents" (
     "active"            INTEGER NOT NULL DEFAULT 1,
     "created_at"        TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "secret_rotated_at" TEXT,
+    "user_id"           INTEGER,
     "data"              TEXT    NOT NULL DEFAULT '{}',
     CONSTRAINT "rustango_agents_name_uq"   UNIQUE ("name"),
     CONSTRAINT "rustango_agents_prefix_uq" UNIQUE ("secret_prefix")
@@ -96,6 +106,7 @@ CREATE TABLE IF NOT EXISTS `rustango_agents` (
     `active`            TINYINT(1)   NOT NULL DEFAULT 1,
     `created_at`        DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     `secret_rotated_at` DATETIME(6),
+    `user_id`           BIGINT,
     `data`              JSON,
     CONSTRAINT `rustango_agents_name_uq`   UNIQUE (`name`),
     CONSTRAINT `rustango_agents_prefix_uq` UNIQUE (`secret_prefix`)
@@ -120,6 +131,38 @@ pub async fn ensure_agents_table_pool(pool: &Pool) -> Result<(), sqlx::Error> {
                 other => sqlx::Error::Protocol(format!("{other}")),
             })?;
     }
+    // Additive: `CREATE TABLE IF NOT EXISTS` won't add `user_id` to a table
+    // created before this column existed. Probe for it and `ADD COLUMN` once
+    // if missing, so upgrading in place is transparent (no migration step).
+    ensure_user_id_column(pool).await?;
+    Ok(())
+}
+
+/// Add `rustango_agents.user_id` if an older table predates it. Probe with a
+/// cheap zero-row select (dialect-agnostic); only `ALTER` when the column is
+/// absent. The added column is nullable with no default, so it's a metadata-
+/// only change on every backend.
+async fn ensure_user_id_column(pool: &Pool) -> Result<(), sqlx::Error> {
+    // Identifier quoting differs by dialect (MySQL uses backticks).
+    let (tbl, col, col_type) = match pool.dialect().name() {
+        "mysql" => ("`rustango_agents`", "`user_id`", "BIGINT"),
+        "sqlite" => (r#""rustango_agents""#, r#""user_id""#, "INTEGER"),
+        _ => (r#""rustango_agents""#, r#""user_id""#, "BIGINT"),
+    };
+    let probe = format!("SELECT {col} FROM {tbl} LIMIT 0");
+    if crate::sql::raw_execute_pool(pool, &probe, Vec::new())
+        .await
+        .is_ok()
+    {
+        return Ok(()); // column already present
+    }
+    let alter = format!("ALTER TABLE {tbl} ADD COLUMN {col} {col_type}");
+    crate::sql::raw_execute_pool(pool, &alter, Vec::new())
+        .await
+        .map_err(|e| match e {
+            ExecError::Driver(err) => err,
+            other => sqlx::Error::Protocol(format!("{other}")),
+        })?;
     Ok(())
 }
 
@@ -147,6 +190,8 @@ pub enum AgentError {
     Db(#[from] ExecError),
     #[error(transparent)]
     Driver(#[from] sqlx::Error),
+    #[error(transparent)]
+    Tenancy(#[from] super::error::TenancyError),
 }
 
 /// Generate a fresh `prefix.secret` credential: returns
@@ -204,6 +249,7 @@ pub async fn create_agent_pool(pool: &Pool, name: &str) -> Result<AgentSecret, A
         active: true,
         created_at: Auto::default(),
         secret_rotated_at: None,
+        user_id: None,
         data: serde_json::json!({}),
     };
     agent.insert_pool(pool).await?;
@@ -358,6 +404,26 @@ pub struct AgentGrant {
     pub data: serde_json::Value,
 }
 
+/// Maps a skill to a user **permission codename**. A user-owned key is
+/// granted the skill (its tools + prompt + resources) when the owning user
+/// holds any mapped permission — so MCP capabilities follow the tenant's
+/// existing RBAC. Standalone (machine) agents ignore this; they use explicit
+/// [`AgentGrant`]s only.
+#[derive(crate::Model, Debug, Clone)]
+#[rustango(
+    table = "rustango_agent_skill_permissions",
+    admin(list_display = "skill_id, permission_codename", ordering = "skill_id")
+)]
+pub struct AgentSkillPermission {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(fk = "rustango_agent_skills", on = "id", on_delete = "cascade")]
+    pub skill_id: i64,
+    /// A `rustango_permissions` codename (e.g. `ib_member_profile.change`).
+    #[rustango(max_length = 150)]
+    pub permission_codename: String,
+}
+
 const SKILLS_ENSURE_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS "rustango_agent_skills" (
     "id"           BIGSERIAL    PRIMARY KEY,
@@ -379,6 +445,12 @@ CREATE TABLE IF NOT EXISTS "rustango_agent_grants" (
     "skill_id" BIGINT    NOT NULL REFERENCES "rustango_agent_skills"("id") ON DELETE CASCADE,
     "data"     JSONB     NOT NULL DEFAULT '{}',
     CONSTRAINT "rustango_agent_grants_uq" UNIQUE ("agent_id", "skill_id")
+);
+CREATE TABLE IF NOT EXISTS "rustango_agent_skill_permissions" (
+    "id"                  BIGSERIAL    PRIMARY KEY,
+    "skill_id"            BIGINT       NOT NULL REFERENCES "rustango_agent_skills"("id") ON DELETE CASCADE,
+    "permission_codename" VARCHAR(150) NOT NULL,
+    CONSTRAINT "rustango_agent_skill_permissions_uq" UNIQUE ("skill_id", "permission_codename")
 );"#;
 
 const SKILLS_ENSURE_SQL_SQLITE: &str = r#"
@@ -402,6 +474,12 @@ CREATE TABLE IF NOT EXISTS "rustango_agent_grants" (
     "skill_id" INTEGER NOT NULL REFERENCES "rustango_agent_skills"("id") ON DELETE CASCADE,
     "data"     TEXT    NOT NULL DEFAULT '{}',
     CONSTRAINT "rustango_agent_grants_uq" UNIQUE ("agent_id", "skill_id")
+);
+CREATE TABLE IF NOT EXISTS "rustango_agent_skill_permissions" (
+    "id"                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    "skill_id"            INTEGER NOT NULL REFERENCES "rustango_agent_skills"("id") ON DELETE CASCADE,
+    "permission_codename" TEXT    NOT NULL,
+    CONSTRAINT "rustango_agent_skill_permissions_uq" UNIQUE ("skill_id", "permission_codename")
 );"#;
 
 const SKILLS_ENSURE_SQL_MYSQL: &str = r#"
@@ -430,6 +508,14 @@ CREATE TABLE IF NOT EXISTS `rustango_agent_grants` (
     CONSTRAINT `rustango_agent_grants_fk_agent` FOREIGN KEY (`agent_id`)
         REFERENCES `rustango_agents`(`id`) ON DELETE CASCADE,
     CONSTRAINT `rustango_agent_grants_fk_skill` FOREIGN KEY (`skill_id`)
+        REFERENCES `rustango_agent_skills`(`id`) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS `rustango_agent_skill_permissions` (
+    `id`                  BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `skill_id`            BIGINT       NOT NULL,
+    `permission_codename` VARCHAR(150) NOT NULL,
+    CONSTRAINT `rustango_agent_skill_permissions_uq` UNIQUE (`skill_id`, `permission_codename`),
+    CONSTRAINT `rustango_agent_skill_permissions_fk` FOREIGN KEY (`skill_id`)
         REFERENCES `rustango_agent_skills`(`id`) ON DELETE CASCADE
 );"#;
 
@@ -673,6 +759,263 @@ pub async fn resolve_agent_grants_pool(
         }
     }
     Ok((skill_codenames, tools))
+}
+
+// =========================================== permission-driven capabilities
+// User-owned keys derive their MCP capabilities from the tenant's RBAC: a
+// skill is mapped to one or more permission codenames, and the key's owning
+// user is granted that skill (its tools + prompt + resources) when they hold
+// any mapped permission. Resolved fresh at token-mint so the JWT reflects the
+// user's current entitlements.
+
+/// Map `skill_codename` to a `permission_codename`. Idempotent — a duplicate
+/// mapping is a no-op. A user-owned key whose owner holds this permission is
+/// then granted the skill at token-issue.
+///
+/// # Errors
+/// [`AgentError::NotFound`] if the skill codename doesn't exist.
+pub async fn map_skill_to_permission_pool(
+    pool: &Pool,
+    skill_codename: &str,
+    permission_codename: &str,
+) -> Result<(), AgentError> {
+    use crate::core::Column as _;
+    use crate::sql::FetcherPool as _;
+
+    ensure_skill_tables_pool(pool).await?;
+    let skill_id = AgentSkill::objects()
+        .where_(AgentSkill::codename.eq(skill_codename))
+        .limit(1)
+        .fetch(pool)
+        .await?
+        .into_iter()
+        .next()
+        .ok_or_else(|| AgentError::NotFound(skill_codename.to_owned()))?
+        .id
+        .get()
+        .copied()
+        .unwrap_or_default();
+
+    let existing: Vec<AgentSkillPermission> = AgentSkillPermission::objects()
+        .where_(AgentSkillPermission::skill_id.eq(skill_id))
+        .where_(AgentSkillPermission::permission_codename.eq(permission_codename))
+        .limit(1)
+        .fetch(pool)
+        .await?;
+    if existing.is_empty() {
+        let mut row = AgentSkillPermission {
+            id: Auto::default(),
+            skill_id,
+            permission_codename: permission_codename.to_owned(),
+        };
+        row.insert_pool(pool).await?;
+    }
+    Ok(())
+}
+
+/// Remove a skill↔permission mapping. No-op if absent.
+///
+/// # Errors
+/// [`AgentError::NotFound`] if the skill codename doesn't exist.
+pub async fn unmap_skill_from_permission_pool(
+    pool: &Pool,
+    skill_codename: &str,
+    permission_codename: &str,
+) -> Result<(), AgentError> {
+    use crate::core::Column as _;
+    use crate::sql::FetcherPool as _;
+
+    ensure_skill_tables_pool(pool).await?;
+    let Some(skill_id) = AgentSkill::objects()
+        .where_(AgentSkill::codename.eq(skill_codename))
+        .limit(1)
+        .fetch(pool)
+        .await?
+        .into_iter()
+        .next()
+        .and_then(|s| s.id.get().copied())
+    else {
+        return Err(AgentError::NotFound(skill_codename.to_owned()));
+    };
+    let rows: Vec<AgentSkillPermission> = AgentSkillPermission::objects()
+        .where_(AgentSkillPermission::skill_id.eq(skill_id))
+        .where_(AgentSkillPermission::permission_codename.eq(permission_codename))
+        .fetch(pool)
+        .await?;
+    for row in rows {
+        row.delete_pool(pool).await?;
+    }
+    Ok(())
+}
+
+/// Resolve a **user-owned** agent's effective `(skill codenames, tools)`:
+/// its explicit [`AgentGrant`]s (if any) unioned with every skill mapped to a
+/// permission the owning `user_id` currently holds. This is what
+/// [`crate::mcp`] bakes into the scoped JWT so `tools`, `prompts`, and
+/// `resources` are all gated by the tenant's RBAC.
+///
+/// # Errors
+/// Propagates DB / permission-lookup errors.
+pub async fn resolve_user_agent_grants_pool(
+    pool: &Pool,
+    agent_id: i64,
+    user_id: i64,
+) -> Result<(Vec<String>, Vec<String>), AgentError> {
+    use crate::core::Column as _;
+    use crate::sql::FetcherPool as _;
+
+    // Start from any explicit grants (an app may still pin a skill directly).
+    let (mut skills, mut tools) = resolve_agent_grants_pool(pool, agent_id).await?;
+
+    // Skills the owning user is entitled to via their permissions.
+    let perms = super::user_permissions_pool(user_id, pool).await?;
+    if perms.is_empty() {
+        return Ok((skills, tools));
+    }
+
+    let mapped: Vec<AgentSkillPermission> = AgentSkillPermission::objects()
+        .where_(AgentSkillPermission::permission_codename.is_in(perms))
+        .fetch(pool)
+        .await?;
+    let mut skill_ids: Vec<i64> = Vec::new();
+    for m in mapped {
+        if !skill_ids.contains(&m.skill_id) {
+            skill_ids.push(m.skill_id);
+        }
+    }
+    if skill_ids.is_empty() {
+        return Ok((skills, tools));
+    }
+
+    let entitled: Vec<AgentSkill> = AgentSkill::objects()
+        .where_(AgentSkill::id.is_in(skill_ids.clone()))
+        .fetch(pool)
+        .await?;
+    for s in entitled {
+        if !skills.contains(&s.codename) {
+            skills.push(s.codename);
+        }
+    }
+    let entitled_tools: Vec<AgentSkillTool> = AgentSkillTool::objects()
+        .where_(AgentSkillTool::skill_id.is_in(skill_ids))
+        .fetch(pool)
+        .await?;
+    for st in entitled_tools {
+        if !tools.contains(&st.tool_name) {
+            tools.push(st.tool_name);
+        }
+    }
+    Ok((skills, tools))
+}
+
+// ================================================================ user keys
+// A "user key" is a personal, user-owned [`Agent`]: a member generates one so
+// an LLM/MCP client can act on their behalf. Its capabilities are entirely
+// permission-driven (see [`resolve_user_agent_grants_pool`]); the app never
+// pins tools onto it.
+
+/// Allocate a per-tenant-unique agent name for `user_id`'s new key.
+async fn unique_key_name(pool: &Pool, user_id: i64) -> Result<String, AgentError> {
+    use crate::sql::FetcherPool as _;
+    use rand::rngs::OsRng;
+    use rand::RngCore;
+
+    for _ in 0..6 {
+        let mut b = [0u8; 5];
+        OsRng.fill_bytes(&mut b);
+        let name = format!("uk_{user_id}_{}", to_hex(&b));
+        let taken: Vec<Agent> = Agent::objects()
+            .filter("name", name.clone())
+            .limit(1)
+            .fetch(pool)
+            .await?;
+        if taken.is_empty() {
+            return Ok(name);
+        }
+    }
+    Err(AgentError::Secret(
+        "could not allocate a unique key name".to_owned(),
+    ))
+}
+
+/// Create a personal, user-owned MCP key. The returned [`AgentSecret::token`]
+/// (`prefix.secret`) is shown once and never recoverable. Capabilities are
+/// resolved from the owner's permissions at token-issue — nothing to pin here.
+///
+/// # Errors
+/// A DB / secret-generation error.
+pub async fn create_user_key_pool(
+    pool: &Pool,
+    user_id: i64,
+    label: &str,
+) -> Result<AgentSecret, AgentError> {
+    ensure_agents_table_pool(pool).await?;
+    let name = unique_key_name(pool, user_id).await?;
+    let (token, prefix, hash) = generate_credential()?;
+    let mut agent = Agent {
+        id: Auto::default(),
+        name,
+        secret_prefix: prefix,
+        secret_hash: hash,
+        active: true,
+        created_at: Auto::default(),
+        secret_rotated_at: None,
+        user_id: Some(user_id),
+        data: serde_json::json!({ "kind": "user_key", "label": label }),
+    };
+    agent.insert_pool(pool).await?;
+    Ok(AgentSecret { agent, token })
+}
+
+/// List a user's personal keys, newest first.
+///
+/// # Errors
+/// Propagates DB errors.
+pub async fn list_user_keys_pool(pool: &Pool, user_id: i64) -> Result<Vec<Agent>, AgentError> {
+    use crate::sql::FetcherPool as _;
+    ensure_agents_table_pool(pool).await?;
+    Ok(Agent::objects()
+        .filter("user_id", user_id)
+        .order_by(&[("created_at", true)])
+        .fetch(pool)
+        .await?)
+}
+
+/// Revoke (delete) one of `user_id`'s keys by agent id. Verifies ownership —
+/// a key that isn't the user's is reported as [`AgentError::NotFound`], not
+/// deleted. Explicit grants are removed first (not relying on FK cascade,
+/// which some SQLite connections don't enforce).
+///
+/// # Errors
+/// [`AgentError::NotFound`] if the key doesn't exist or isn't owned by
+/// `user_id`.
+pub async fn revoke_user_key_pool(
+    pool: &Pool,
+    user_id: i64,
+    agent_id: i64,
+) -> Result<(), AgentError> {
+    use crate::sql::FetcherPool as _;
+
+    ensure_agents_table_pool(pool).await?;
+    let agent = Agent::objects()
+        .filter("id", agent_id)
+        .limit(1)
+        .fetch(pool)
+        .await?
+        .into_iter()
+        .next()
+        .filter(|a| a.user_id == Some(user_id))
+        .ok_or_else(|| AgentError::NotFound(format!("key #{agent_id}")))?;
+
+    let grants: Vec<AgentGrant> = AgentGrant::objects()
+        .filter("agent_id", agent_id)
+        .fetch(pool)
+        .await?;
+    for g in grants {
+        g.delete_pool(pool).await?;
+    }
+    agent.delete_pool(pool).await?;
+    Ok(())
 }
 
 // ====================================================== resources (Slice 5)

--- a/crates/rustango/src/tenancy/agents.rs
+++ b/crates/rustango/src/tenancy/agents.rs
@@ -23,7 +23,7 @@ use crate::sql::{Auto, ExecError, Pool};
     table = "rustango_agents",
     display = "name",
     admin(
-        list_display = "name, active, secret_prefix, created_at",
+        list_display = "name, user_id, active, secret_prefix, created_at",
         search_fields = "name",
         ordering = "name",
         readonly_fields = "secret_prefix, secret_hash, created_at, secret_rotated_at",

--- a/crates/rustango/src/tenancy/manage/agents.rs
+++ b/crates/rustango/src/tenancy/manage/agents.rs
@@ -22,7 +22,9 @@ const CREATE_SKILL_HELP: &str =
 const GRANT_HELP: &str = "grant-skill <slug> <agent> <skill>";
 const REVOKE_HELP: &str = "revoke-skill <slug> <agent> <skill>";
 const LIST_SKILLS_HELP: &str = "list-skills <slug>";
-const CREATE_USER_KEY_HELP: &str = "create-user-key <slug> <username> [label]";
+const CREATE_USER_KEY_HELP: &str =
+    "create-user-key <slug> <username> [--label <l>] [--skill <codename>]…  \
+     (repeat --skill to scope the key to a skillset; omit for a full key)";
 const LIST_USER_KEYS_HELP: &str = "list-user-keys <slug> <username>";
 const REVOKE_USER_KEY_HELP: &str = "revoke-user-key <slug> <username> <key_id>";
 const MAP_SKILL_PERM_HELP: &str = "map-skill-permission <slug> <skill> <permission>";
@@ -286,31 +288,58 @@ where
     crate::sql::Pool: From<sqlx::Pool<DB>>,
 {
     reject_leading_flag(args, "create-user-key", "slug", CREATE_USER_KEY_HELP)?;
-    let mut iter = args.iter();
-    let slug = iter
-        .next()
+    let slug = args
+        .first()
         .cloned()
         .ok_or_else(|| TenancyError::Validation(CREATE_USER_KEY_HELP.into()))?;
-    let username = iter
-        .next()
+    let username = args
+        .get(1)
         .cloned()
         .ok_or_else(|| TenancyError::Validation(CREATE_USER_KEY_HELP.into()))?;
-    let label = iter.next().cloned().unwrap_or_else(|| username.clone());
-    if let Some(extra) = iter.next() {
-        return Err(TenancyError::Validation(format!(
-            "create-user-key: unexpected argument `{extra}`"
-        )));
+
+    // Flags after the two positionals: --label <l>, --skill <codename> (repeat
+    // --skill for a skillset; none = a full-permission key).
+    let mut label: Option<String> = None;
+    let mut skills: Vec<String> = Vec::new();
+    let mut i = 2;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--label" => {
+                i += 1;
+                label = Some(args.get(i).cloned().ok_or_else(|| {
+                    TenancyError::Validation("create-user-key: --label needs a value".into())
+                })?);
+            }
+            "--skill" => {
+                i += 1;
+                skills.push(args.get(i).cloned().ok_or_else(|| {
+                    TenancyError::Validation("create-user-key: --skill needs a codename".into())
+                })?);
+            }
+            other => {
+                return Err(TenancyError::Validation(format!(
+                    "create-user-key: unexpected argument `{other}` ({CREATE_USER_KEY_HELP})"
+                )));
+            }
+        }
+        i += 1;
     }
+    let label = label.unwrap_or_else(|| username.clone());
 
     let scoped = scoped_tenant_pool(pools, registry_url, &slug).await?;
     let uid = resolve_user_id(&scoped, &username).await?;
-    let issued = crate::tenancy::create_user_key_pool(&scoped, uid, &label)
+    let issued = crate::tenancy::create_user_key_pool(&scoped, uid, &label, &skills)
         .await
         .map_err(|e| TenancyError::Validation(e.to_string()))?;
     let id = issued.agent.id.get().copied().unwrap_or_default();
+    let scope = if skills.is_empty() {
+        "full (owner's permissions)".to_owned()
+    } else {
+        format!("skills: {}", skills.join(", "))
+    };
     writeln!(
         w,
-        "created key #{id} for user `{username}` in tenant `{slug}` (label `{label}`)"
+        "created key #{id} for user `{username}` in tenant `{slug}` (label `{label}`, scope {scope})"
     )?;
     writeln!(w, "  token: {}", issued.token)?;
     writeln!(w, "  store this safely — it won't be shown again")?;

--- a/crates/rustango/src/tenancy/manage/agents.rs
+++ b/crates/rustango/src/tenancy/manage/agents.rs
@@ -7,6 +7,7 @@ use std::io::Write;
 
 use sqlx::Database;
 
+use crate::sql::Pool;
 use crate::tenancy::error::TenancyError;
 use crate::tenancy::manage::args::{next_value, reject_leading_flag};
 use crate::tenancy::pools::TenantPools;
@@ -21,6 +22,11 @@ const CREATE_SKILL_HELP: &str =
 const GRANT_HELP: &str = "grant-skill <slug> <agent> <skill>";
 const REVOKE_HELP: &str = "revoke-skill <slug> <agent> <skill>";
 const LIST_SKILLS_HELP: &str = "list-skills <slug>";
+const CREATE_USER_KEY_HELP: &str = "create-user-key <slug> <username> [label]";
+const LIST_USER_KEYS_HELP: &str = "list-user-keys <slug> <username>";
+const REVOKE_USER_KEY_HELP: &str = "revoke-user-key <slug> <username> <key_id>";
+const MAP_SKILL_PERM_HELP: &str = "map-skill-permission <slug> <skill> <permission>";
+const UNMAP_SKILL_PERM_HELP: &str = "unmap-skill-permission <slug> <skill> <permission>";
 
 /// `create-agent <slug> <name>` — provision a new MCP agent in the tenant
 /// and print its one-time `prefix.secret` credential.
@@ -265,6 +271,199 @@ where
         writeln!(w, "  {}  {}", s.codename, s.name)?;
     }
     Ok(())
+}
+
+/// `create-user-key <slug> <username> [label]` — provision a personal,
+/// user-owned MCP key for `<username>` and print its one-time credential.
+/// The default label is the username.
+pub(super) async fn create_user_key_cmd<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    registry_url: &str,
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    reject_leading_flag(args, "create-user-key", "slug", CREATE_USER_KEY_HELP)?;
+    let mut iter = args.iter();
+    let slug = iter
+        .next()
+        .cloned()
+        .ok_or_else(|| TenancyError::Validation(CREATE_USER_KEY_HELP.into()))?;
+    let username = iter
+        .next()
+        .cloned()
+        .ok_or_else(|| TenancyError::Validation(CREATE_USER_KEY_HELP.into()))?;
+    let label = iter.next().cloned().unwrap_or_else(|| username.clone());
+    if let Some(extra) = iter.next() {
+        return Err(TenancyError::Validation(format!(
+            "create-user-key: unexpected argument `{extra}`"
+        )));
+    }
+
+    let scoped = scoped_tenant_pool(pools, registry_url, &slug).await?;
+    let uid = resolve_user_id(&scoped, &username).await?;
+    let issued = crate::tenancy::create_user_key_pool(&scoped, uid, &label)
+        .await
+        .map_err(|e| TenancyError::Validation(e.to_string()))?;
+    let id = issued.agent.id.get().copied().unwrap_or_default();
+    writeln!(
+        w,
+        "created key #{id} for user `{username}` in tenant `{slug}` (label `{label}`)"
+    )?;
+    writeln!(w, "  token: {}", issued.token)?;
+    writeln!(w, "  store this safely — it won't be shown again")?;
+    Ok(())
+}
+
+/// `list-user-keys <slug> <username>` — print every personal key owned by
+/// `<username>`, newest first.
+pub(super) async fn list_user_keys_cmd<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    registry_url: &str,
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    reject_leading_flag(args, "list-user-keys", "slug", LIST_USER_KEYS_HELP)?;
+    let mut iter = args.iter();
+    let slug = iter
+        .next()
+        .cloned()
+        .ok_or_else(|| TenancyError::Validation(LIST_USER_KEYS_HELP.into()))?;
+    let username = iter
+        .next()
+        .cloned()
+        .ok_or_else(|| TenancyError::Validation(LIST_USER_KEYS_HELP.into()))?;
+
+    let scoped = scoped_tenant_pool(pools, registry_url, &slug).await?;
+    let uid = resolve_user_id(&scoped, &username).await?;
+    let keys = crate::tenancy::list_user_keys_pool(&scoped, uid)
+        .await
+        .map_err(|e| TenancyError::Validation(e.to_string()))?;
+    if keys.is_empty() {
+        writeln!(w, "no keys for user `{username}`")?;
+        return Ok(());
+    }
+    writeln!(w, "keys for user `{username}` in tenant `{slug}`:")?;
+    for k in &keys {
+        let id = k.id.get().copied().unwrap_or_default();
+        let label = k
+            .data
+            .get("label")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        let created = k
+            .created_at
+            .get()
+            .map(chrono::DateTime::to_rfc3339)
+            .unwrap_or_default();
+        writeln!(w, "  #{id}  {label}  {created}")?;
+    }
+    Ok(())
+}
+
+/// `revoke-user-key <slug> <username> <key_id>` — delete one of
+/// `<username>`'s personal keys by its id (ownership-verified).
+pub(super) async fn revoke_user_key_cmd<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    registry_url: &str,
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    reject_leading_flag(args, "revoke-user-key", "slug", REVOKE_USER_KEY_HELP)?;
+    let mut iter = args.iter();
+    let slug = iter
+        .next()
+        .cloned()
+        .ok_or_else(|| TenancyError::Validation(REVOKE_USER_KEY_HELP.into()))?;
+    let username = iter
+        .next()
+        .cloned()
+        .ok_or_else(|| TenancyError::Validation(REVOKE_USER_KEY_HELP.into()))?;
+    let key_id: i64 = iter
+        .next()
+        .ok_or_else(|| TenancyError::Validation(REVOKE_USER_KEY_HELP.into()))?
+        .parse()
+        .map_err(|_| {
+            TenancyError::Validation("revoke-user-key: <key_id> must be an integer".into())
+        })?;
+
+    let scoped = scoped_tenant_pool(pools, registry_url, &slug).await?;
+    let uid = resolve_user_id(&scoped, &username).await?;
+    crate::tenancy::revoke_user_key_pool(&scoped, uid, key_id)
+        .await
+        .map_err(|e| TenancyError::Validation(e.to_string()))?;
+    writeln!(w, "revoked key #{key_id} for user `{username}`")?;
+    Ok(())
+}
+
+/// `map-skill-permission <slug> <skill> <permission>` — grant everyone
+/// holding `<permission>` the `<skill>`'s tools on their user-owned keys.
+/// Idempotent.
+pub(super) async fn map_skill_permission_cmd<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    registry_url: &str,
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let (slug, skill, permission) =
+        three_positionals(args, "map-skill-permission", MAP_SKILL_PERM_HELP)?;
+    let scoped = scoped_tenant_pool(pools, registry_url, &slug).await?;
+    crate::tenancy::map_skill_to_permission_pool(&scoped, &skill, &permission)
+        .await
+        .map_err(|e| TenancyError::Validation(e.to_string()))?;
+    writeln!(
+        w,
+        "mapped skill `{skill}` → permission `{permission}` in tenant `{slug}`"
+    )?;
+    Ok(())
+}
+
+/// `unmap-skill-permission <slug> <skill> <permission>` — remove a
+/// skill↔permission mapping. No-op if absent.
+pub(super) async fn unmap_skill_permission_cmd<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    registry_url: &str,
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let (slug, skill, permission) =
+        three_positionals(args, "unmap-skill-permission", UNMAP_SKILL_PERM_HELP)?;
+    let scoped = scoped_tenant_pool(pools, registry_url, &slug).await?;
+    crate::tenancy::unmap_skill_from_permission_pool(&scoped, &skill, &permission)
+        .await
+        .map_err(|e| TenancyError::Validation(e.to_string()))?;
+    writeln!(w, "unmapped skill `{skill}` ✗ permission `{permission}`")?;
+    Ok(())
+}
+
+/// Resolve `username` to a `rustango_users.id` on the scoped tenant pool.
+/// Returns a `Validation` error naming the unknown user.
+async fn resolve_user_id(pool: &Pool, username: &str) -> Result<i64, TenancyError> {
+    use crate::sql::FetcherPool as _;
+    let user = crate::tenancy::User::objects()
+        .filter("username", username.to_owned())
+        .limit(1)
+        .fetch(pool)
+        .await
+        .map_err(|e| TenancyError::Validation(e.to_string()))?
+        .into_iter()
+        .next()
+        .ok_or_else(|| TenancyError::Validation(format!("unknown user `{username}`")))?;
+    Ok(user.id.get().copied().unwrap_or_default())
 }
 
 /// Parse exactly three positional args (`<slug> <a> <b>`) for the grant verbs.

--- a/crates/rustango/src/tenancy/manage/mod.rs
+++ b/crates/rustango/src/tenancy/manage/mod.rs
@@ -276,6 +276,26 @@ where
         "revoke-skill" => agents::revoke_skill_cmd(pools, registry_url, &args[1..], writer).await,
         #[cfg(feature = "mcp")]
         "list-skills" => agents::list_skills_cmd(pools, registry_url, &args[1..], writer).await,
+        #[cfg(feature = "mcp")]
+        "create-user-key" => {
+            agents::create_user_key_cmd(pools, registry_url, &args[1..], writer).await
+        }
+        #[cfg(feature = "mcp")]
+        "list-user-keys" => {
+            agents::list_user_keys_cmd(pools, registry_url, &args[1..], writer).await
+        }
+        #[cfg(feature = "mcp")]
+        "revoke-user-key" => {
+            agents::revoke_user_key_cmd(pools, registry_url, &args[1..], writer).await
+        }
+        #[cfg(feature = "mcp")]
+        "map-skill-permission" => {
+            agents::map_skill_permission_cmd(pools, registry_url, &args[1..], writer).await
+        }
+        #[cfg(feature = "mcp")]
+        "unmap-skill-permission" => {
+            agents::unmap_skill_permission_cmd(pools, registry_url, &args[1..], writer).await
+        }
         "seed-permissions" => roles::seed_permissions_cmd(pools, &args[1..], writer).await,
         "startapp" => scaffold::startapp_cmd(&args[1..], writer),
         // Plain `migrate` is scope-aware here — registry-scoped
@@ -543,6 +563,28 @@ pub fn write_help<W: Write>(w: &mut W) -> Result<(), TenancyError> {
         writeln!(w, "  revoke-skill <slug> <agent> <skill>")?;
         writeln!(w, "                       Revoke a skill from an agent.")?;
         writeln!(w, "  list-skills <slug>   List a tenant's MCP skills.")?;
+        writeln!(w, "  create-user-key <slug> <username> [label]")?;
+        writeln!(
+            w,
+            "                       Issue a personal, user-owned MCP key (prints its token once)."
+        )?;
+        writeln!(w, "  list-user-keys <slug> <username>")?;
+        writeln!(w, "                       List a user's personal MCP keys.")?;
+        writeln!(w, "  revoke-user-key <slug> <username> <key_id>")?;
+        writeln!(
+            w,
+            "                       Revoke one of a user's personal keys by id."
+        )?;
+        writeln!(w, "  map-skill-permission <slug> <skill> <permission>")?;
+        writeln!(
+            w,
+            "                       Grant a skill to any user holding <permission> (user keys)."
+        )?;
+        writeln!(w, "  unmap-skill-permission <slug> <skill> <permission>")?;
+        writeln!(
+            w,
+            "                       Remove a skill↔permission mapping."
+        )?;
     }
     writeln!(w, "  seed-permissions [--slug <s>]")?;
     writeln!(

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -113,10 +113,12 @@ pub mod tenant_console;
 #[cfg(feature = "mcp")]
 pub use agents::{
     add_skill_resource_pool, authenticate_agent_pool, create_agent_pool, create_skill_pool,
-    ensure_agents_table_pool, ensure_skill_tables_pool, grant_skill_pool, list_agents_pool,
-    list_skills_pool, resolve_agent_grants_pool, resources_for_skills_pool, revoke_skill_pool,
-    rotate_agent_secret_pool, skills_by_codenames_pool, Agent, AgentError, AgentGrant, AgentSecret,
-    AgentSkill, AgentSkillResource, AgentSkillTool,
+    create_user_key_pool, ensure_agents_table_pool, ensure_skill_tables_pool, grant_skill_pool,
+    list_agents_pool, list_skills_pool, list_user_keys_pool, map_skill_to_permission_pool,
+    resolve_agent_grants_pool, resolve_user_agent_grants_pool, resources_for_skills_pool,
+    revoke_skill_pool, revoke_user_key_pool, rotate_agent_secret_pool, skills_by_codenames_pool,
+    unmap_skill_from_permission_pool, Agent, AgentError, AgentGrant, AgentSecret, AgentSkill,
+    AgentSkillPermission, AgentSkillResource, AgentSkillTool,
 };
 #[cfg(feature = "postgres")]
 pub use auth::{authenticate_operator, authenticate_user};

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -112,13 +112,13 @@ pub mod tenant_console;
 
 #[cfg(feature = "mcp")]
 pub use agents::{
-    add_skill_resource_pool, authenticate_agent_pool, create_agent_pool, create_skill_pool,
-    create_user_key_pool, ensure_agents_table_pool, ensure_skill_tables_pool, grant_skill_pool,
-    list_agents_pool, list_skills_pool, list_user_keys_pool, map_skill_to_permission_pool,
-    resolve_agent_grants_pool, resolve_user_agent_grants_pool, resources_for_skills_pool,
-    revoke_skill_pool, revoke_user_key_pool, rotate_agent_secret_pool, skills_by_codenames_pool,
-    unmap_skill_from_permission_pool, Agent, AgentError, AgentGrant, AgentSecret, AgentSkill,
-    AgentSkillPermission, AgentSkillResource, AgentSkillTool,
+    add_skill_resource_pool, agent_token_still_valid_pool, authenticate_agent_pool,
+    create_agent_pool, create_skill_pool, create_user_key_pool, delete_user_keys_pool,
+    grant_skill_pool, list_agents_pool, list_skills_pool, list_user_keys_pool,
+    map_skill_to_permission_pool, resolve_agent_grants_pool, resolve_user_agent_grants_pool,
+    resources_for_skills_pool, revoke_skill_pool, revoke_user_key_pool, rotate_agent_secret_pool,
+    skills_by_codenames_pool, unmap_skill_from_permission_pool, Agent, AgentError, AgentGrant,
+    AgentSecret, AgentSkill, AgentSkillPermission, AgentSkillResource, AgentSkillTool,
 };
 #[cfg(feature = "postgres")]
 pub use auth::{authenticate_operator, authenticate_user};

--- a/crates/rustango/tests/mcp_doc.rs
+++ b/crates/rustango/tests/mcp_doc.rs
@@ -5,7 +5,7 @@
 //!
 //! Run: `cargo test -p rustango --features sqlite,mcp --test mcp_doc`
 
-#![cfg(all(feature = "sqlite", feature = "mcp"))]
+#![cfg(all(feature = "sqlite", feature = "mcp", feature = "testkit"))]
 #![allow(irrefutable_let_patterns)]
 
 use std::sync::Arc;
@@ -99,6 +99,9 @@ async fn initialize_handshake_over_http() {
 #[tokio::test]
 async fn agent_lists_and_calls_only_its_granted_tools() {
     let pool = Pool::Sqlite(sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap());
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("migrate framework");
 
     // Provision an agent (returns a one-time credential), define a skill that
     // bundles the `add` tool, and grant it to the agent in tenant "acme".
@@ -168,6 +171,9 @@ async fn agent_lists_and_calls_only_its_granted_tools() {
 #[tokio::test]
 async fn ungranted_agent_sees_nothing_and_is_refused() {
     let pool = Pool::Sqlite(sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap());
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("migrate framework");
 
     // An agent with NO grants — fail-closed: empty tool list, calls refused.
     let agent = McpAgent {

--- a/crates/rustango/tests/mcp_doc.rs
+++ b/crates/rustango/tests/mcp_doc.rs
@@ -139,7 +139,7 @@ async fn agent_lists_and_calls_only_its_granted_tools() {
     let jwt = Arc::new(JwtLifecycle::new(
         b"doc-secret-at-least-32-bytes-long!!".to_vec(),
     ));
-    let token = issue_agent_token(&jwt, agent_id, "acme", &skills, &tools).unwrap();
+    let token = issue_agent_token(&jwt, agent_id, "acme", &skills, &tools, None).unwrap();
 
     // The guarded endpoint verifies the token on every request (tenant-pinned).
     let agent = verify_agent_token(&jwt, &token, "acme").expect("valid agent token");
@@ -175,6 +175,7 @@ async fn ungranted_agent_sees_nothing_and_is_refused() {
         tenant: "acme".into(),
         skills: vec![],
         tools: vec![],
+        user_id: None,
         jti: "doc-jti".into(),
     };
 

--- a/crates/rustango/tests/mcp_e2e_sqlite_live.rs
+++ b/crates/rustango/tests/mcp_e2e_sqlite_live.rs
@@ -120,7 +120,7 @@ async fn full_agent_loop() {
     let jwt = Arc::new(JwtLifecycle::new(
         b"e2e-secret-at-least-32-bytes-long!!".to_vec(),
     ));
-    let token = issue_agent_token(&jwt, agent_id, "acme", &skills, &tools).expect("issue");
+    let token = issue_agent_token(&jwt, agent_id, "acme", &skills, &tools, None).expect("issue");
 
     // 6. Verify the token (what the guarded endpoint does each request).
     let agent = verify_agent_token(&jwt, &token, "acme").expect("verify");

--- a/crates/rustango/tests/mcp_e2e_sqlite_live.rs
+++ b/crates/rustango/tests/mcp_e2e_sqlite_live.rs
@@ -8,7 +8,7 @@
 //! This is the "full agent loop is green" acceptance. (The JSON-RPC
 //! transport itself — initialize/ping over HTTP — is covered in
 //! `mcp_slice1`.)
-#![cfg(all(feature = "sqlite", feature = "mcp"))]
+#![cfg(all(feature = "sqlite", feature = "mcp", feature = "testkit"))]
 #![allow(irrefutable_let_patterns)]
 
 use std::sync::Arc;
@@ -64,6 +64,10 @@ async fn full_agent_loop() {
             .await
             .expect("sqlite"),
     );
+    // Agent/skill/resource tables now come from system migrations.
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("migrate framework");
 
     // 1. Provision an agent (one-time secret).
     let issued = create_agent_pool(&pool, "e2e-bot").await.expect("agent");

--- a/crates/rustango/tests/mcp_manage_verbs_sqlite_live.rs
+++ b/crates/rustango/tests/mcp_manage_verbs_sqlite_live.rs
@@ -109,7 +109,7 @@ async fn user_key_and_skill_permission_verbs_round_trip_on_sqlite() {
         &pools,
         &url,
         dir,
-        &["create-user-key", "acme", "alice", "mylabel"],
+        &["create-user-key", "acme", "alice", "--label", "mylabel"],
     )
     .await;
     assert!(out.contains("token:"), "expected a token line, got:\n{out}");

--- a/crates/rustango/tests/mcp_manage_verbs_sqlite_live.rs
+++ b/crates/rustango/tests/mcp_manage_verbs_sqlite_live.rs
@@ -1,0 +1,201 @@
+//! Live integration test for the MCP **user-owned-keys** + **skill↔permission**
+//! `manage` verbs on SQLite (epic #1013 follow-up).
+//!
+//! Drives the full CLI dispatch — `migrate-registry` → `create-tenant`
+//! (database mode) → `create-user` → the new verbs:
+//!   `create-user-key`, `list-user-keys`, `revoke-user-key`,
+//!   `map-skill-permission`, `unmap-skill-permission`.
+//!
+//! Mirrors `tenancy_manage_sqlite_live.rs`'s setup so the verbs are
+//! exercised through exactly the code path `cargo run -- <verb>` uses.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy", feature = "mcp"))]
+
+use rustango::sql::sqlx;
+use rustango::tenancy::TenantPools;
+
+/// Build a sqlite tenant-pools handle backed by a tempfile DB (a real
+/// on-disk file so successive acquisitions see the same data).
+async fn sqlite_pools_in_tempfile() -> (TenantPools<sqlx::Sqlite>, String, tempfile::TempDir) {
+    let tmpdir = tempfile::tempdir().expect("tempdir");
+    let db_path = tmpdir.path().join("registry.db");
+    let url = format!("sqlite://{}?mode=rwc", db_path.display());
+    let pool = sqlx::SqlitePool::connect(&url)
+        .await
+        .expect("sqlite connect");
+    let pools = TenantPools::<sqlx::Sqlite>::new(pool);
+    (pools, url, tmpdir)
+}
+
+/// Run one manage verb, returning captured stdout. Panics on error.
+async fn run(
+    pools: &TenantPools<sqlx::Sqlite>,
+    url: &str,
+    dir: &std::path::Path,
+    argv: &[&str],
+) -> String {
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools,
+        url,
+        dir,
+        argv.iter().map(|s| (*s).to_owned()).collect::<Vec<_>>(),
+        &mut buf,
+    )
+    .await
+    .unwrap_or_else(|e| panic!("verb {argv:?} failed: {e}"));
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+/// Run one manage verb expecting an error; returns the error string.
+async fn run_err(
+    pools: &TenantPools<sqlx::Sqlite>,
+    url: &str,
+    dir: &std::path::Path,
+    argv: &[&str],
+) -> String {
+    let mut buf: Vec<u8> = Vec::new();
+    let err = rustango::tenancy::manage::run_with_writer(
+        pools,
+        url,
+        dir,
+        argv.iter().map(|s| (*s).to_owned()).collect::<Vec<_>>(),
+        &mut buf,
+    )
+    .await
+    .expect_err("verb should fail");
+    err.to_string()
+}
+
+#[tokio::test]
+async fn user_key_and_skill_permission_verbs_round_trip_on_sqlite() {
+    let (pools, url, tmpdir) = sqlite_pools_in_tempfile().await;
+    let migrations_dir = tempfile::tempdir().expect("migrations tempdir");
+    let dir = migrations_dir.path();
+
+    // Registry schema.
+    run(&pools, &url, dir, &["migrate-registry"]).await;
+
+    // A database-mode tenant (schema-mode is PG-only). Its DB is migrated
+    // with the framework tables (rustango_users, rustango_agents, …).
+    let tenant_db = tmpdir.path().join("acme.db");
+    let tenant_url = format!("sqlite://{}?mode=rwc", tenant_db.display());
+    run(
+        &pools,
+        &url,
+        dir,
+        &[
+            "create-tenant",
+            "acme",
+            "--mode",
+            "database",
+            "--database-url",
+            &tenant_url,
+        ],
+    )
+    .await;
+
+    // A tenant user to own the key.
+    run(
+        &pools,
+        &url,
+        dir,
+        &["create-user", "acme", "alice", "--password", "hunter2"],
+    )
+    .await;
+
+    // ---- create-user-key: prints a one-time token + key id ----
+    let out = run(
+        &pools,
+        &url,
+        dir,
+        &["create-user-key", "acme", "alice", "mylabel"],
+    )
+    .await;
+    assert!(out.contains("token:"), "expected a token line, got:\n{out}");
+    assert!(
+        out.contains("won't be shown again"),
+        "expected the one-time warning, got:\n{out}"
+    );
+    assert!(out.contains("mylabel"), "expected the label, got:\n{out}");
+    // Extract the key id from `created key #<id> for user ...`.
+    let key_id: i64 = out
+        .split_once('#')
+        .and_then(|(_, rest)| rest.split_whitespace().next())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| panic!("could not parse key id from:\n{out}"));
+
+    // ---- list-user-keys: shows the key + label ----
+    let listed = run(&pools, &url, dir, &["list-user-keys", "acme", "alice"]).await;
+    assert!(
+        listed.contains(&format!("#{key_id}")),
+        "expected key #{key_id} in list, got:\n{listed}"
+    );
+    assert!(
+        listed.contains("mylabel"),
+        "expected label in list, got:\n{listed}"
+    );
+
+    // ---- revoke-user-key: removes it ----
+    let revoked = run(
+        &pools,
+        &url,
+        dir,
+        &["revoke-user-key", "acme", "alice", &key_id.to_string()],
+    )
+    .await;
+    assert!(
+        revoked.contains(&format!("revoked key #{key_id}")),
+        "got:\n{revoked}"
+    );
+    let empty = run(&pools, &url, dir, &["list-user-keys", "acme", "alice"]).await;
+    assert!(
+        empty.contains("no keys for user `alice`"),
+        "expected empty listing, got:\n{empty}"
+    );
+
+    // ---- unknown user is a friendly validation error ----
+    let err = run_err(&pools, &url, dir, &["create-user-key", "acme", "nobody"]).await;
+    assert!(
+        err.contains("unknown user `nobody`"),
+        "expected unknown-user error, got: {err}"
+    );
+
+    // ---- map-skill-permission is idempotent ----
+    run(
+        &pools,
+        &url,
+        dir,
+        &["create-skill", "acme", "greeter", "--tools", "echo"],
+    )
+    .await;
+    let mapped = run(
+        &pools,
+        &url,
+        dir,
+        &["map-skill-permission", "acme", "greeter", "greeter.use"],
+    )
+    .await;
+    assert!(mapped.contains("mapped skill `greeter`"), "got:\n{mapped}");
+    // Second call is a no-op (must not error).
+    run(
+        &pools,
+        &url,
+        dir,
+        &["map-skill-permission", "acme", "greeter", "greeter.use"],
+    )
+    .await;
+
+    // ---- unmap-skill-permission removes it ----
+    let unmapped = run(
+        &pools,
+        &url,
+        dir,
+        &["unmap-skill-permission", "acme", "greeter", "greeter.use"],
+    )
+    .await;
+    assert!(
+        unmapped.contains("unmapped skill `greeter`"),
+        "got:\n{unmapped}"
+    );
+}

--- a/crates/rustango/tests/mcp_slice2.rs
+++ b/crates/rustango/tests/mcp_slice2.rs
@@ -9,7 +9,7 @@
 //! plus the `rustango_agents` data layer (create / authenticate / rotate).
 //!
 //! Run: `cargo test -p rustango --no-default-features --features sqlite,mcp --test mcp_slice2`.
-#![cfg(all(feature = "sqlite", feature = "mcp"))]
+#![cfg(all(feature = "sqlite", feature = "mcp", feature = "testkit"))]
 #![allow(irrefutable_let_patterns)] // Pool is single-variant in sqlite-only builds
 
 use std::sync::Arc;
@@ -22,10 +22,16 @@ use rustango::tenancy::{
 };
 
 async fn sqlite_pool() -> Pool {
-    let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+    let pool = Pool::Sqlite(
+        sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite memory pool"),
+    );
+    // Agent tables now come from system migrations, not a lazy ensure layer.
+    rustango::testkit::migrate_framework(&pool)
         .await
-        .expect("sqlite memory pool");
-    Pool::Sqlite(pool)
+        .expect("migrate framework");
+    pool
 }
 
 // ----------------------------------------------------------- data layer

--- a/crates/rustango/tests/mcp_slice2.rs
+++ b/crates/rustango/tests/mcp_slice2.rs
@@ -112,7 +112,7 @@ fn jwt() -> Arc<JwtLifecycle> {
 #[tokio::test]
 async fn token_issue_and_verify_within_tenant() {
     let jwt = jwt();
-    let token = rustango::mcp::issue_agent_token(&jwt, 42, "acme", &[], &[]).expect("issue");
+    let token = rustango::mcp::issue_agent_token(&jwt, 42, "acme", &[], &[], None).expect("issue");
     let agent = rustango::mcp::verify_agent_token(&jwt, &token, "acme").expect("verify");
     assert_eq!(agent.agent_id, 42);
     assert_eq!(agent.tenant, "acme");
@@ -122,7 +122,7 @@ async fn token_issue_and_verify_within_tenant() {
 #[tokio::test]
 async fn token_for_other_tenant_is_rejected() {
     let jwt = jwt();
-    let token = rustango::mcp::issue_agent_token(&jwt, 42, "acme", &[], &[]).expect("issue");
+    let token = rustango::mcp::issue_agent_token(&jwt, 42, "acme", &[], &[], None).expect("issue");
     // Same valid signature, wrong tenant → refused (cross-tenant replay).
     assert!(rustango::mcp::verify_agent_token(&jwt, &token, "evilcorp").is_none());
 }
@@ -130,7 +130,7 @@ async fn token_for_other_tenant_is_rejected() {
 #[tokio::test]
 async fn revoked_token_is_refused() {
     let jwt = jwt();
-    let token = rustango::mcp::issue_agent_token(&jwt, 7, "acme", &[], &[]).expect("issue");
+    let token = rustango::mcp::issue_agent_token(&jwt, 7, "acme", &[], &[], None).expect("issue");
     assert!(rustango::mcp::verify_agent_token(&jwt, &token, "acme").is_some());
     assert!(jwt.revoke(&token), "revoke decodes + blacklists the jti");
     assert!(rustango::mcp::verify_agent_token(&jwt, &token, "acme").is_none());

--- a/crates/rustango/tests/mcp_slice3.rs
+++ b/crates/rustango/tests/mcp_slice3.rs
@@ -80,6 +80,7 @@ async fn ctx_with_tools(tools: &[&str]) -> McpContext {
             tenant: "acme".into(),
             skills: vec![],
             tools: tools.iter().map(|s| s.to_string()).collect(),
+            user_id: None,
             jti: "test-jti".into(),
         },
         progress: rustango::mcp::ProgressReporter::disabled(),

--- a/crates/rustango/tests/mcp_slice4.rs
+++ b/crates/rustango/tests/mcp_slice4.rs
@@ -47,6 +47,7 @@ fn agent_with(tools: Vec<String>) -> McpAgent {
         tenant: "acme".into(),
         skills: vec![],
         tools,
+        user_id: None,
         jti: "t".into(),
     }
 }

--- a/crates/rustango/tests/mcp_slice4.rs
+++ b/crates/rustango/tests/mcp_slice4.rs
@@ -6,7 +6,7 @@
 //!   * revoking removes them;
 //!   * an agent with no grants resolves to an empty tool set (fail-closed) →
 //!     `list_tools` returns nothing.
-#![cfg(all(feature = "sqlite", feature = "mcp"))]
+#![cfg(all(feature = "sqlite", feature = "mcp", feature = "testkit"))]
 #![allow(irrefutable_let_patterns)]
 
 use rustango::mcp::{list_tools, McpAgent};
@@ -17,11 +17,16 @@ use rustango::tenancy::{
 };
 
 async fn pool() -> Pool {
-    Pool::Sqlite(
+    let pool = Pool::Sqlite(
         sqlx::SqlitePool::connect("sqlite::memory:")
             .await
             .expect("sqlite"),
-    )
+    );
+    // Agent/skill tables now come from system migrations, not a lazy ensure layer.
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("migrate framework");
+    pool
 }
 
 async fn agent_id(pool: &Pool, name: &str) -> i64 {

--- a/crates/rustango/tests/mcp_slice5.rs
+++ b/crates/rustango/tests/mcp_slice5.rs
@@ -34,6 +34,7 @@ fn ctx(pool: Pool, skills: &[&str]) -> McpContext {
             tenant: "acme".into(),
             skills: skills.iter().map(|s| s.to_string()).collect(),
             tools: vec![],
+            user_id: None,
             jti: "t".into(),
         },
         progress: rustango::mcp::ProgressReporter::disabled(),

--- a/crates/rustango/tests/mcp_slice5.rs
+++ b/crates/rustango/tests/mcp_slice5.rs
@@ -4,7 +4,7 @@
 //! `prompts/get` and its resources by `resources/read`; an ungranted
 //! skill's prompt/resources are neither listed nor readable (fail-closed);
 //! a `register_mcp_resource!` static resource is always available.
-#![cfg(all(feature = "sqlite", feature = "mcp"))]
+#![cfg(all(feature = "sqlite", feature = "mcp", feature = "testkit"))]
 #![allow(irrefutable_let_patterns)]
 
 use rustango::mcp::{
@@ -19,11 +19,16 @@ rustango::register_mcp_resource!("rustango://about", "About", "text/plain", || {
 },);
 
 async fn pool() -> Pool {
-    Pool::Sqlite(
+    let pool = Pool::Sqlite(
         sqlx::SqlitePool::connect("sqlite::memory:")
             .await
             .expect("sqlite"),
-    )
+    );
+    // Skill/resource tables now come from system migrations, not a lazy ensure layer.
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("migrate framework");
+    pool
 }
 
 fn ctx(pool: Pool, skills: &[&str]) -> McpContext {

--- a/crates/rustango/tests/mcp_slice_progress.rs
+++ b/crates/rustango/tests/mcp_slice_progress.rs
@@ -43,6 +43,7 @@ async fn ctx() -> McpContext {
             tenant: "acme".into(),
             skills: vec![],
             tools: vec!["work".into()],
+            user_id: None,
             jti: "t".into(),
         },
         progress: rustango::mcp::ProgressReporter::disabled(),

--- a/crates/rustango/tests/mcp_slice_utilities.rs
+++ b/crates/rustango/tests/mcp_slice_utilities.rs
@@ -1,5 +1,5 @@
 //! MCP follow-up #1091 — logging/setLevel + completion/complete.
-#![cfg(all(feature = "sqlite", feature = "mcp"))]
+#![cfg(all(feature = "sqlite", feature = "mcp", feature = "testkit"))]
 #![allow(irrefutable_let_patterns)]
 
 use rustango::mcp::utilities::{complete, set_log_level};
@@ -14,6 +14,10 @@ async fn ctx(skills: &[&str]) -> McpContext {
             .await
             .expect("sqlite"),
     );
+    // Skill/resource tables now come from system migrations, not a lazy ensure layer.
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("migrate framework");
     McpContext {
         pool,
         agent: McpAgent {

--- a/crates/rustango/tests/mcp_slice_utilities.rs
+++ b/crates/rustango/tests/mcp_slice_utilities.rs
@@ -21,6 +21,7 @@ async fn ctx(skills: &[&str]) -> McpContext {
             tenant: "acme".into(),
             skills: skills.iter().map(|s| s.to_string()).collect(),
             tools: vec![],
+            user_id: None,
             jti: "t".into(),
         },
         progress: rustango::mcp::ProgressReporter::disabled(),

--- a/crates/rustango/tests/mcp_user_keys_mysql_live.rs
+++ b/crates/rustango/tests/mcp_user_keys_mysql_live.rs
@@ -1,0 +1,134 @@
+//! MySQL mirror of `mcp_user_keys_sqlite_live` — validates the user-owned key
+//! + permission-driven capability resolver against **real MySQL** (the
+//! `user_id` column, the `rustango_agent_skill_permissions` table, and the
+//! `resolve_user_agent_grants_pool` join all rendered by the tri-dialect
+//! engine). Activated by `MYSQL_TEST_URL`; skips silently when unset.
+//!
+//!   export MYSQL_TEST_URL=mysql://rustango:rustango@127.0.0.1:3406/rustango_test
+//!   cargo test -p rustango --features mysql,tenancy,mcp,testkit --test mcp_user_keys_mysql_live
+
+#![cfg(all(feature = "mysql", feature = "mcp", feature = "testkit"))]
+
+use rustango::sql::{sqlx, Pool};
+use rustango::tenancy::permissions::set_user_perm_pool;
+use rustango::tenancy::{
+    create_skill_pool, create_user_key_pool, list_user_keys_pool, map_skill_to_permission_pool,
+    resolve_user_agent_grants_pool, revoke_user_key_pool,
+};
+use tokio::sync::Mutex;
+
+/// Suite-wide lock — every test shares the `MYSQL_TEST_URL` DB and resets the
+/// agent tables, so they must not run concurrently.
+fn live_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn pool() -> Option<Pool> {
+    let url = std::env::var("MYSQL_TEST_URL").ok()?;
+    let pool: Pool = sqlx::MySqlPool::connect(&url).await.ok()?.into();
+    let my = pool.as_mysql().unwrap();
+    // Clean slate for the agent tables (FK checks off so child-order doesn't
+    // matter). `migrate_framework` recreates them from the models each run.
+    sqlx::query("SET FOREIGN_KEY_CHECKS = 0")
+        .execute(my)
+        .await
+        .expect("fk off");
+    for tbl in [
+        "rustango_agent_skill_permissions",
+        "rustango_agent_skill_tools",
+        "rustango_agent_skill_resources",
+        "rustango_agent_grants",
+        "rustango_agent_skills",
+        "rustango_agents",
+    ] {
+        let _ = sqlx::query(&format!("DROP TABLE IF EXISTS `{tbl}`"))
+            .execute(my)
+            .await;
+    }
+    sqlx::query("SET FOREIGN_KEY_CHECKS = 1")
+        .execute(my)
+        .await
+        .expect("fk on");
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("framework schema");
+    Some(pool)
+}
+
+async fn make_user(pool: &Pool, name: &str) -> i64 {
+    let my = pool.as_mysql().unwrap();
+    sqlx::query("DELETE FROM `rustango_users` WHERE username = ?")
+        .bind(name)
+        .execute(my)
+        .await
+        .ok();
+    sqlx::query(
+        "INSERT INTO `rustango_users` (username, password_hash, is_superuser, active, created_at) \
+         VALUES (?, '', 0, 1, NOW())",
+    )
+    .bind(name)
+    .execute(my)
+    .await
+    .expect("insert user");
+    let (id,): (i64,) = sqlx::query_as("SELECT id FROM `rustango_users` WHERE username = ?")
+        .bind(name)
+        .fetch_one(my)
+        .await
+        .expect("fetch id");
+    id
+}
+
+#[tokio::test]
+async fn user_key_capabilities_follow_permissions_on_mysql() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return; // MYSQL_TEST_URL unset — skip offline.
+    };
+
+    let uid = make_user(&pool, "ukmy_alice").await;
+    set_user_perm_pool(uid, "ukmy.coach", true, &pool)
+        .await
+        .expect("perm");
+    create_skill_pool(&pool, "ukmy_coach", "Coach", "", "", &["coach_log".into()])
+        .await
+        .expect("skill");
+    map_skill_to_permission_pool(&pool, "ukmy_coach", "ukmy.coach")
+        .await
+        .expect("map");
+
+    let issued = create_user_key_pool(&pool, uid, "laptop")
+        .await
+        .expect("key");
+    assert_eq!(issued.agent.user_id, Some(uid));
+    let agent_id = issued.agent.id.get().copied().unwrap();
+    let (skills, tools) = resolve_user_agent_grants_pool(&pool, agent_id, uid)
+        .await
+        .expect("resolve");
+    assert_eq!(skills, vec!["ukmy_coach"]);
+    assert_eq!(tools, vec!["coach_log"]);
+
+    assert_eq!(
+        list_user_keys_pool(&pool, uid).await.expect("list").len(),
+        1
+    );
+    revoke_user_key_pool(&pool, uid, agent_id)
+        .await
+        .expect("revoke");
+    assert!(list_user_keys_pool(&pool, uid)
+        .await
+        .expect("list")
+        .is_empty());
+
+    // Negative: no permission → no capabilities (fail-closed).
+    let bob = make_user(&pool, "ukmy_bob").await;
+    let issued2 = create_user_key_pool(&pool, bob, "phone")
+        .await
+        .expect("key2");
+    let aid2 = issued2.agent.id.get().copied().unwrap();
+    let (s2, t2) = resolve_user_agent_grants_pool(&pool, aid2, bob)
+        .await
+        .expect("resolve2");
+    assert!(s2.is_empty() && t2.is_empty());
+}

--- a/crates/rustango/tests/mcp_user_keys_mysql_live.rs
+++ b/crates/rustango/tests/mcp_user_keys_mysql_live.rs
@@ -98,7 +98,7 @@ async fn user_key_capabilities_follow_permissions_on_mysql() {
         .await
         .expect("map");
 
-    let issued = create_user_key_pool(&pool, uid, "laptop")
+    let issued = create_user_key_pool(&pool, uid, "laptop", &[])
         .await
         .expect("key");
     assert_eq!(issued.agent.user_id, Some(uid));
@@ -123,7 +123,7 @@ async fn user_key_capabilities_follow_permissions_on_mysql() {
 
     // Negative: no permission → no capabilities (fail-closed).
     let bob = make_user(&pool, "ukmy_bob").await;
-    let issued2 = create_user_key_pool(&pool, bob, "phone")
+    let issued2 = create_user_key_pool(&pool, bob, "phone", &[])
         .await
         .expect("key2");
     let aid2 = issued2.agent.id.get().copied().unwrap();

--- a/crates/rustango/tests/mcp_user_keys_pg_live.rs
+++ b/crates/rustango/tests/mcp_user_keys_pg_live.rs
@@ -86,7 +86,7 @@ async fn user_key_capabilities_follow_permissions_on_pg() {
         .expect("map");
 
     // A personal key resolves its capabilities from the owner's permissions.
-    let issued = create_user_key_pool(&pool, uid, "laptop")
+    let issued = create_user_key_pool(&pool, uid, "laptop", &[])
         .await
         .expect("key");
     assert_eq!(issued.agent.user_id, Some(uid));
@@ -112,7 +112,7 @@ async fn user_key_capabilities_follow_permissions_on_pg() {
 
     // Negative: no permission → no capabilities (fail-closed).
     let bob = make_user(&pool, "ukpg_bob").await;
-    let issued2 = create_user_key_pool(&pool, bob, "phone")
+    let issued2 = create_user_key_pool(&pool, bob, "phone", &[])
         .await
         .expect("key2");
     let aid2 = issued2.agent.id.get().copied().unwrap();

--- a/crates/rustango/tests/mcp_user_keys_pg_live.rs
+++ b/crates/rustango/tests/mcp_user_keys_pg_live.rs
@@ -1,0 +1,123 @@
+//! Postgres mirror of `mcp_user_keys_sqlite_live` — validates the user-owned
+//! key + permission-driven capability resolver against **real Postgres** (the
+//! `user_id` column, the `rustango_agent_skill_permissions` table, and the
+//! `resolve_user_agent_grants_pool` join all rendered by the tri-dialect
+//! engine). Reads `DATABASE_URL`; every test returns silently when unset, so
+//! `cargo test` stays green offline. CI's `--all-features` Postgres job runs it.
+
+#![cfg(all(feature = "postgres", feature = "mcp", feature = "testkit"))]
+
+use rustango::sql::{sqlx, Pool};
+use rustango::tenancy::permissions::set_user_perm_pool;
+use rustango::tenancy::{
+    create_skill_pool, create_user_key_pool, list_user_keys_pool, map_skill_to_permission_pool,
+    resolve_user_agent_grants_pool, revoke_user_key_pool,
+};
+use tokio::sync::Mutex;
+
+/// Suite-wide lock — every test shares the `DATABASE_URL` DB and resets the
+/// agent tables, so they must not run concurrently.
+fn live_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn pool() -> Option<Pool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    let pool: Pool = sqlx::PgPool::connect(&url).await.ok()?.into();
+    let pg = pool.as_postgres().unwrap();
+    // Clean slate for the agent tables (child-first). `migrate_framework`
+    // recreates them from the models, so we get the current DDL each run.
+    for tbl in [
+        "rustango_agent_skill_permissions",
+        "rustango_agent_skill_tools",
+        "rustango_agent_skill_resources",
+        "rustango_agent_grants",
+        "rustango_agent_skills",
+        "rustango_agents",
+    ] {
+        sqlx::query(&format!(r#"DROP TABLE IF EXISTS "{tbl}" CASCADE"#))
+            .execute(pg)
+            .await
+            .expect("drop");
+    }
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("framework schema");
+    Some(pool)
+}
+
+async fn make_user(pool: &Pool, name: &str) -> i64 {
+    let pg = pool.as_postgres().unwrap();
+    sqlx::query(r#"DELETE FROM "rustango_users" WHERE username = $1"#)
+        .bind(name)
+        .execute(pg)
+        .await
+        .ok();
+    let (id,): (i64,) = sqlx::query_as(
+        r#"INSERT INTO "rustango_users" (username, password_hash, is_superuser, active, created_at)
+           VALUES ($1, '', false, true, NOW()) RETURNING id"#,
+    )
+    .bind(name)
+    .fetch_one(pg)
+    .await
+    .expect("insert user");
+    id
+}
+
+#[tokio::test]
+async fn user_key_capabilities_follow_permissions_on_pg() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return; // DATABASE_URL unset — skip offline.
+    };
+
+    // Owner holds the coaching permission; a mapped skill bundles the tool.
+    let uid = make_user(&pool, "ukpg_alice").await;
+    set_user_perm_pool(uid, "ukpg.coach", true, &pool)
+        .await
+        .expect("perm");
+    create_skill_pool(&pool, "ukpg_coach", "Coach", "", "", &["coach_log".into()])
+        .await
+        .expect("skill");
+    map_skill_to_permission_pool(&pool, "ukpg_coach", "ukpg.coach")
+        .await
+        .expect("map");
+
+    // A personal key resolves its capabilities from the owner's permissions.
+    let issued = create_user_key_pool(&pool, uid, "laptop")
+        .await
+        .expect("key");
+    assert_eq!(issued.agent.user_id, Some(uid));
+    let agent_id = issued.agent.id.get().copied().unwrap();
+    let (skills, tools) = resolve_user_agent_grants_pool(&pool, agent_id, uid)
+        .await
+        .expect("resolve");
+    assert_eq!(skills, vec!["ukpg_coach"]);
+    assert_eq!(tools, vec!["coach_log"]);
+
+    // Owner-scoped list + revoke.
+    assert_eq!(
+        list_user_keys_pool(&pool, uid).await.expect("list").len(),
+        1
+    );
+    revoke_user_key_pool(&pool, uid, agent_id)
+        .await
+        .expect("revoke");
+    assert!(list_user_keys_pool(&pool, uid)
+        .await
+        .expect("list")
+        .is_empty());
+
+    // Negative: no permission → no capabilities (fail-closed).
+    let bob = make_user(&pool, "ukpg_bob").await;
+    let issued2 = create_user_key_pool(&pool, bob, "phone")
+        .await
+        .expect("key2");
+    let aid2 = issued2.agent.id.get().copied().unwrap();
+    let (s2, t2) = resolve_user_agent_grants_pool(&pool, aid2, bob)
+        .await
+        .expect("resolve2");
+    assert!(s2.is_empty() && t2.is_empty());
+}

--- a/crates/rustango/tests/mcp_user_keys_sqlite_live.rs
+++ b/crates/rustango/tests/mcp_user_keys_sqlite_live.rs
@@ -1,0 +1,229 @@
+//! User-owned MCP keys + permission-driven capabilities (feat/mcp-user-keys).
+//!
+//! A member generates a personal key (a user-owned `Agent`); its MCP
+//! capabilities are resolved from the owner's RBAC permissions via
+//! skill↔permission mappings — not pinned onto the key. Exercised end-to-end
+//! on SQLite through the public API:
+//!
+//!   create user → grant permission → create skill(+tool) → map skill↔perm
+//!     → create_user_key → authenticate → resolve_user_agent_grants
+//!     → issue token (carries `uid`) → verify → tools/list → tools/call
+//!
+//! Plus the negative path (no permission → no tools) and list/revoke.
+
+#![cfg(all(feature = "sqlite", feature = "mcp", feature = "testkit"))]
+#![allow(irrefutable_let_patterns)]
+
+use std::sync::Arc;
+
+use rustango::mcp::{
+    call_tool, issue_agent_token, list_tools, verify_agent_token, McpContext, McpError,
+};
+use rustango::sql::{sqlx, Pool};
+use rustango::tenancy::jwt_lifecycle::JwtLifecycle;
+use rustango::tenancy::permissions::set_user_perm_pool;
+use rustango::tenancy::{
+    authenticate_agent_pool, create_skill_pool, create_user_key_pool, list_user_keys_pool,
+    map_skill_to_permission_pool, resolve_user_agent_grants_pool, revoke_user_key_pool,
+};
+use serde_json::json;
+
+rustango::register_mcp_tool!(
+    "coach_log",
+    "Record a coaching note",
+    NoteInput,
+    |_ctx: McpContext, input: NoteInput| async move {
+        Ok::<_, McpError>(json!({ "logged": input.note }))
+    },
+);
+
+#[derive(serde::Deserialize)]
+struct NoteInput {
+    note: String,
+}
+
+impl rustango::openapi::OpenApiSchema for NoteInput {
+    fn openapi_schema() -> rustango::openapi::Schema {
+        rustango::openapi::Schema::object()
+            .property("note", rustango::openapi::Schema::string())
+            .required(["note"])
+    }
+}
+
+async fn world() -> Pool {
+    let pool = Pool::Sqlite(
+        sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite"),
+    );
+    // rustango_users + roles/permissions + join tables, via the real path.
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("migrate framework");
+    pool
+}
+
+async fn make_user(pool: &Pool, name: &str) -> i64 {
+    let Pool::Sqlite(sq) = pool else {
+        unreachable!()
+    };
+    sqlx::query(
+        "INSERT INTO rustango_users (username, password_hash, is_superuser, active, created_at) \
+         VALUES (?, '', 0, 1, datetime('now'))",
+    )
+    .bind(name)
+    .execute(sq)
+    .await
+    .expect("insert user");
+    let (id,): (i64,) = sqlx::query_as("SELECT id FROM rustango_users WHERE username = ?")
+        .bind(name)
+        .fetch_one(sq)
+        .await
+        .expect("fetch id");
+    id
+}
+
+fn ctx(pool: &Pool, agent: &rustango::mcp::McpAgent) -> McpContext {
+    McpContext {
+        pool: pool.clone(),
+        agent: agent.clone(),
+        progress: rustango::mcp::ProgressReporter::disabled(),
+        cancel: rustango::mcp::CancelToken::never(),
+    }
+}
+
+/// Permission-holding owner: the key can list + call the mapped tool, and its
+/// token carries the owning `user_id`.
+#[tokio::test]
+async fn permission_grants_flow_into_a_user_key() {
+    let pool = world().await;
+    let uid = make_user(&pool, "alice").await;
+
+    // Owner holds the coaching permission (direct grant).
+    set_user_perm_pool(uid, "mcp.coach", true, &pool)
+        .await
+        .expect("grant perm");
+
+    // A skill bundling the tool, mapped to that permission.
+    create_skill_pool(
+        &pool,
+        "coach",
+        "Coach",
+        "logs coaching notes",
+        "You are the member's coach.",
+        &["coach_log".into()],
+    )
+    .await
+    .expect("skill");
+    map_skill_to_permission_pool(&pool, "coach", "mcp.coach")
+        .await
+        .expect("map");
+
+    // Member generates a personal key (shown-once secret).
+    let issued = create_user_key_pool(&pool, uid, "Alice's phone")
+        .await
+        .expect("key");
+    assert_eq!(issued.agent.user_id, Some(uid));
+    assert!(issued.token.contains('.'), "prefix.secret token");
+
+    // Credential → identity (what `/token` does).
+    let agent_row = authenticate_agent_pool(&pool, &issued.agent.name, &issued.token)
+        .await
+        .expect("auth")
+        .expect("valid credential");
+    let agent_id = agent_row.id.get().copied().unwrap();
+    assert_eq!(agent_row.user_id, Some(uid));
+
+    // Capabilities resolve from the owner's permissions.
+    let (skills, tools) = resolve_user_agent_grants_pool(&pool, agent_id, uid)
+        .await
+        .expect("resolve");
+    assert_eq!(skills, vec!["coach"]);
+    assert_eq!(tools, vec!["coach_log"]);
+
+    // Token carries the owner + the resolved tools.
+    let jwt = Arc::new(JwtLifecycle::new(
+        b"user-keys-secret-at-least-32-bytes!!".to_vec(),
+    ));
+    let token =
+        issue_agent_token(&jwt, agent_id, "acme", &skills, &tools, Some(uid)).expect("issue");
+    let agent = verify_agent_token(&jwt, &token, "acme").expect("verify");
+    assert_eq!(agent.user_id, Some(uid));
+    assert_eq!(agent.tools, vec!["coach_log"]);
+
+    // tools/list is gated to the granted tool; tools/call runs it.
+    let names: Vec<String> = list_tools(&agent)["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap().to_owned())
+        .collect();
+    assert_eq!(names, vec!["coach_log"]);
+    let out = call_tool(
+        ctx(&pool, &agent),
+        json!({ "name": "coach_log", "arguments": { "note": "great squat depth" } }),
+    )
+    .await
+    .expect("call");
+    assert_eq!(out["structuredContent"]["logged"], "great squat depth");
+}
+
+/// Without the permission, the same mapped skill yields no capabilities —
+/// fail-closed.
+#[tokio::test]
+async fn without_the_permission_a_key_gets_nothing() {
+    let pool = world().await;
+    let uid = make_user(&pool, "bob").await;
+
+    create_skill_pool(&pool, "coach", "Coach", "", "", &["coach_log".into()])
+        .await
+        .expect("skill");
+    map_skill_to_permission_pool(&pool, "coach", "mcp.coach")
+        .await
+        .expect("map");
+
+    let issued = create_user_key_pool(&pool, uid, "Bob's key")
+        .await
+        .expect("key");
+    let agent_id = issued.agent.id.get().copied().unwrap();
+
+    // Bob was never granted `mcp.coach`.
+    let (skills, tools) = resolve_user_agent_grants_pool(&pool, agent_id, uid)
+        .await
+        .expect("resolve");
+    assert!(skills.is_empty(), "no skills without the permission");
+    assert!(tools.is_empty(), "no tools without the permission");
+}
+
+/// Keys are listable and revocable by their owner; revoking a key that isn't
+/// yours is refused.
+#[tokio::test]
+async fn keys_list_and_revoke_by_owner() {
+    let pool = world().await;
+    let alice = make_user(&pool, "alice").await;
+    let mallory = make_user(&pool, "mallory").await;
+
+    let k1 = create_user_key_pool(&pool, alice, "laptop")
+        .await
+        .expect("k1");
+    let _k2 = create_user_key_pool(&pool, alice, "phone")
+        .await
+        .expect("k2");
+
+    let keys = list_user_keys_pool(&pool, alice).await.expect("list");
+    assert_eq!(keys.len(), 2);
+
+    // Another user cannot revoke Alice's key.
+    let k1_id = k1.agent.id.get().copied().unwrap();
+    assert!(
+        revoke_user_key_pool(&pool, mallory, k1_id).await.is_err(),
+        "cross-user revoke refused"
+    );
+
+    // The owner can.
+    revoke_user_key_pool(&pool, alice, k1_id)
+        .await
+        .expect("revoke");
+    let after = list_user_keys_pool(&pool, alice).await.expect("list");
+    assert_eq!(after.len(), 1);
+}

--- a/crates/rustango/tests/mcp_user_keys_sqlite_live.rs
+++ b/crates/rustango/tests/mcp_user_keys_sqlite_live.rs
@@ -23,8 +23,9 @@ use rustango::sql::{sqlx, Pool};
 use rustango::tenancy::jwt_lifecycle::JwtLifecycle;
 use rustango::tenancy::permissions::set_user_perm_pool;
 use rustango::tenancy::{
-    authenticate_agent_pool, create_skill_pool, create_user_key_pool, list_user_keys_pool,
-    map_skill_to_permission_pool, resolve_user_agent_grants_pool, revoke_user_key_pool,
+    agent_token_still_valid_pool, authenticate_agent_pool, create_skill_pool, create_user_key_pool,
+    delete_user_keys_pool, list_user_keys_pool, map_skill_to_permission_pool,
+    resolve_user_agent_grants_pool, revoke_user_key_pool,
 };
 use serde_json::json;
 
@@ -81,6 +82,37 @@ async fn make_user(pool: &Pool, name: &str) -> i64 {
         .await
         .expect("fetch id");
     id
+}
+
+async fn make_superuser(pool: &Pool, name: &str) -> i64 {
+    let Pool::Sqlite(sq) = pool else {
+        unreachable!()
+    };
+    sqlx::query(
+        "INSERT INTO rustango_users (username, password_hash, is_superuser, active, created_at) \
+         VALUES (?, '', 1, 1, datetime('now'))",
+    )
+    .bind(name)
+    .execute(sq)
+    .await
+    .expect("insert superuser");
+    let (id,): (i64,) = sqlx::query_as("SELECT id FROM rustango_users WHERE username = ?")
+        .bind(name)
+        .fetch_one(sq)
+        .await
+        .expect("fetch id");
+    id
+}
+
+async fn deactivate_user(pool: &Pool, user_id: i64) {
+    let Pool::Sqlite(sq) = pool else {
+        unreachable!()
+    };
+    sqlx::query("UPDATE rustango_users SET active = 0 WHERE id = ?")
+        .bind(user_id)
+        .execute(sq)
+        .await
+        .expect("deactivate user");
 }
 
 fn ctx(pool: &Pool, agent: &rustango::mcp::McpAgent) -> McpContext {
@@ -226,4 +258,109 @@ async fn keys_list_and_revoke_by_owner() {
         .expect("revoke");
     let after = list_user_keys_pool(&pool, alice).await.expect("list");
     assert_eq!(after.len(), 1);
+}
+
+/// A superuser owner's key resolves to EVERY skill + tool in the tenant, even
+/// with no explicit grants and no direct permissions — `user_permissions_pool`
+/// does not expand superusers, so `resolve_user_agent_grants_pool` does (#1).
+#[tokio::test]
+async fn superuser_user_key_resolves_to_all_skills_and_tools() {
+    let pool = world().await;
+    let root = make_superuser(&pool, "root").await;
+
+    // Two skills; neither mapped to any permission the user holds.
+    create_skill_pool(&pool, "coach", "Coach", "", "", &["coach_log".into()])
+        .await
+        .expect("skill a");
+    create_skill_pool(
+        &pool,
+        "billing",
+        "Billing",
+        "",
+        "",
+        &["invoice.create".into(), "invoice.void".into()],
+    )
+    .await
+    .expect("skill b");
+
+    let issued = create_user_key_pool(&pool, root, "root's key")
+        .await
+        .expect("key");
+    let agent_id = issued.agent.id.get().copied().unwrap();
+
+    let (mut skills, mut tools) = resolve_user_agent_grants_pool(&pool, agent_id, root)
+        .await
+        .expect("resolve");
+    skills.sort();
+    tools.sort();
+    assert_eq!(skills, vec!["billing", "coach"]);
+    assert_eq!(tools, vec!["coach_log", "invoice.create", "invoice.void"]);
+}
+
+/// Request-time re-check (#2): a token stays valid while the key + owner are
+/// live, and is refused as soon as the key is revoked or the owner is
+/// deactivated — the effect `post_authed` / `sse_handler` rely on for immediate
+/// revocation of stateless JWTs.
+#[tokio::test]
+async fn revoked_or_deactivated_key_is_refused_at_request_time() {
+    let pool = world().await;
+    let uid = make_user(&pool, "carol").await;
+
+    let issued = create_user_key_pool(&pool, uid, "carol's key")
+        .await
+        .expect("key");
+    let agent_id = issued.agent.id.get().copied().unwrap();
+
+    // Live key + live owner → accepted.
+    assert!(
+        agent_token_still_valid_pool(&pool, agent_id, Some(uid))
+            .await
+            .expect("check"),
+        "live key accepted"
+    );
+
+    // Deactivating the owner refuses the key even though the agent row remains.
+    deactivate_user(&pool, uid).await;
+    assert!(
+        !agent_token_still_valid_pool(&pool, agent_id, Some(uid))
+            .await
+            .expect("check"),
+        "inactive owner refused"
+    );
+
+    // Revoking (deleting) the key refuses the token — a missing agent row.
+    revoke_user_key_pool(&pool, uid, agent_id)
+        .await
+        .expect("revoke");
+    assert!(
+        !agent_token_still_valid_pool(&pool, agent_id, Some(uid))
+            .await
+            .expect("check"),
+        "deleted key refused"
+    );
+}
+
+/// Deleting a tenant user must remove their user-owned keys (#4). No framework
+/// user-deletion path exists yet, so the helper is exercised directly.
+#[tokio::test]
+async fn delete_user_keys_removes_only_that_users_keys() {
+    let pool = world().await;
+    let dave = make_user(&pool, "dave").await;
+    let erin = make_user(&pool, "erin").await;
+
+    create_user_key_pool(&pool, dave, "k1").await.expect("k1");
+    create_user_key_pool(&pool, dave, "k2").await.expect("k2");
+    create_user_key_pool(&pool, erin, "k3").await.expect("k3");
+
+    delete_user_keys_pool(&pool, dave).await.expect("delete");
+
+    assert!(
+        list_user_keys_pool(&pool, dave).await.unwrap().is_empty(),
+        "dave's keys removed"
+    );
+    assert_eq!(
+        list_user_keys_pool(&pool, erin).await.unwrap().len(),
+        1,
+        "erin's key untouched"
+    );
 }

--- a/crates/rustango/tests/mcp_user_keys_sqlite_live.rs
+++ b/crates/rustango/tests/mcp_user_keys_sqlite_live.rs
@@ -152,7 +152,7 @@ async fn permission_grants_flow_into_a_user_key() {
         .expect("map");
 
     // Member generates a personal key (shown-once secret).
-    let issued = create_user_key_pool(&pool, uid, "Alice's phone")
+    let issued = create_user_key_pool(&pool, uid, "Alice's phone", &[])
         .await
         .expect("key");
     assert_eq!(issued.agent.user_id, Some(uid));
@@ -214,7 +214,7 @@ async fn without_the_permission_a_key_gets_nothing() {
         .await
         .expect("map");
 
-    let issued = create_user_key_pool(&pool, uid, "Bob's key")
+    let issued = create_user_key_pool(&pool, uid, "Bob's key", &[])
         .await
         .expect("key");
     let agent_id = issued.agent.id.get().copied().unwrap();
@@ -235,10 +235,10 @@ async fn keys_list_and_revoke_by_owner() {
     let alice = make_user(&pool, "alice").await;
     let mallory = make_user(&pool, "mallory").await;
 
-    let k1 = create_user_key_pool(&pool, alice, "laptop")
+    let k1 = create_user_key_pool(&pool, alice, "laptop", &[])
         .await
         .expect("k1");
-    let _k2 = create_user_key_pool(&pool, alice, "phone")
+    let _k2 = create_user_key_pool(&pool, alice, "phone", &[])
         .await
         .expect("k2");
 
@@ -283,7 +283,7 @@ async fn superuser_user_key_resolves_to_all_skills_and_tools() {
     .await
     .expect("skill b");
 
-    let issued = create_user_key_pool(&pool, root, "root's key")
+    let issued = create_user_key_pool(&pool, root, "root's key", &[])
         .await
         .expect("key");
     let agent_id = issued.agent.id.get().copied().unwrap();
@@ -306,7 +306,7 @@ async fn revoked_or_deactivated_key_is_refused_at_request_time() {
     let pool = world().await;
     let uid = make_user(&pool, "carol").await;
 
-    let issued = create_user_key_pool(&pool, uid, "carol's key")
+    let issued = create_user_key_pool(&pool, uid, "carol's key", &[])
         .await
         .expect("key");
     let agent_id = issued.agent.id.get().copied().unwrap();
@@ -348,9 +348,15 @@ async fn delete_user_keys_removes_only_that_users_keys() {
     let dave = make_user(&pool, "dave").await;
     let erin = make_user(&pool, "erin").await;
 
-    create_user_key_pool(&pool, dave, "k1").await.expect("k1");
-    create_user_key_pool(&pool, dave, "k2").await.expect("k2");
-    create_user_key_pool(&pool, erin, "k3").await.expect("k3");
+    create_user_key_pool(&pool, dave, "k1", &[])
+        .await
+        .expect("k1");
+    create_user_key_pool(&pool, dave, "k2", &[])
+        .await
+        .expect("k2");
+    create_user_key_pool(&pool, erin, "k3", &[])
+        .await
+        .expect("k3");
 
     delete_user_keys_pool(&pool, dave).await.expect("delete");
 
@@ -362,5 +368,83 @@ async fn delete_user_keys_removes_only_that_users_keys() {
         list_user_keys_pool(&pool, erin).await.unwrap().len(),
         1,
         "erin's key untouched"
+    );
+}
+
+/// Per-key scope: a non-superuser entitled to two skills can mint a key scoped
+/// to ONE of them (or a skillset) — the key resolves to only those skills'
+/// tools, not the owner's full set — while an unscoped key gets everything the
+/// owner may use. Scoping to a skill the owner isn't entitled to is refused.
+#[tokio::test]
+async fn user_key_can_be_scoped_to_a_skillset() {
+    let pool = world().await;
+    let uid = make_user(&pool, "dana").await;
+
+    // Two entitled skills (each gated on a permission dana holds).
+    create_skill_pool(
+        &pool,
+        "coach",
+        "Coach",
+        "",
+        "",
+        &["log_set".into(), "view_progress".into()],
+    )
+    .await
+    .expect("coach");
+    create_skill_pool(
+        &pool,
+        "billing",
+        "Billing",
+        "",
+        "",
+        &["invoice.create".into()],
+    )
+    .await
+    .expect("billing");
+    map_skill_to_permission_pool(&pool, "coach", "mcp.coach")
+        .await
+        .expect("map coach");
+    map_skill_to_permission_pool(&pool, "billing", "mcp.billing")
+        .await
+        .expect("map billing");
+    set_user_perm_pool(uid, "mcp.coach", true, &pool)
+        .await
+        .expect("perm coach");
+    set_user_perm_pool(uid, "mcp.billing", true, &pool)
+        .await
+        .expect("perm billing");
+
+    // Unscoped key → both skills.
+    let full = create_user_key_pool(&pool, uid, "full", &[])
+        .await
+        .expect("full");
+    let (mut fs, _) =
+        resolve_user_agent_grants_pool(&pool, full.agent.id.get().copied().unwrap(), uid)
+            .await
+            .expect("resolve full");
+    fs.sort();
+    assert_eq!(fs, vec!["billing", "coach"]);
+
+    // Scoped to just `coach` → only coach's tools.
+    let scoped = create_user_key_pool(&pool, uid, "coach-only", &["coach".into()])
+        .await
+        .expect("scoped");
+    let (ss, mut st) =
+        resolve_user_agent_grants_pool(&pool, scoped.agent.id.get().copied().unwrap(), uid)
+            .await
+            .expect("resolve scoped");
+    st.sort();
+    assert_eq!(ss, vec!["coach"]);
+    assert_eq!(st, vec!["log_set", "view_progress"]);
+
+    // Scoping to a skill the owner isn't entitled to is refused (no key left).
+    create_skill_pool(&pool, "admin_ops", "Admin", "", "", &["nuke".into()])
+        .await
+        .expect("admin skill");
+    assert!(
+        create_user_key_pool(&pool, uid, "bad", &["admin_ops".into()])
+            .await
+            .is_err(),
+        "scoping to an un-entitled skill must be refused"
     );
 }

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -230,8 +230,11 @@ create_skill_pool(&pool, "coach", "Coach", "logs workouts",
 map_skill_to_permission_pool(&pool, "coach", "mcp.coach").await?;
 
 // 2. The member generates a key — a one-time `name`.`secret`, shown once.
-//    Nothing is pinned onto it; capabilities come from the owner's permissions.
-let issued = create_user_key_pool(&pool, user_id, "Alice's phone").await?;
+//    `&[]` = a FULL key: everything the owner is entitled to. Pass skill
+//    codenames to SCOPE the key to a single skill or a skillset instead —
+//    always bounded by the owner's entitlement (you can't exceed your perms):
+let issued = create_user_key_pool(&pool, user_id, "Alice's phone", &[]).await?;
+// scoped: create_user_key_pool(&pool, user_id, "coach bot", &["coach".into()]).await?;
 println!("copy once: {}", issued.token);
 ```
 
@@ -247,6 +250,15 @@ member. Revoke fresh capabilities by changing the user's permissions (they
 re-resolve on the next token); revoke the key itself with
 `revoke_user_key_pool(&pool, user_id, agent_id)`. List a member's keys with
 `list_user_keys_pool(&pool, user_id)`.
+
+**Per-key scope vs per-user entitlement.** Skills reach a key along two axes:
+the owner's **entitlement** (superuser → every skill; otherwise the skills
+mapped to a permission they hold) and the key's **scope** (skills pinned at
+creation). An unscoped key (`skills = &[]`) gets the owner's full entitlement;
+a scoped key (`skills = &["coach", …]`) is limited to those. Resolution always
+re-intersects scope with the *current* entitlement — so a key can never exceed
+the owner's permissions, and losing a permission narrows every key on the next
+mint. Scoping to a skill the owner isn't entitled to is refused at creation.
 
 Standalone agents are unaffected — a machine agent (`user_id = None`) still
 uses only its explicit `grant_skill_pool` grants.
@@ -266,7 +278,7 @@ tenant-scoped and takes a `<slug>`:
 | `grant-skill <slug> <agent> <skill>` | Grant a skill to an agent. |
 | `revoke-skill <slug> <agent> <skill>` | Revoke a skill from an agent. |
 | `list-skills <slug>` | List a tenant's skills. |
-| `create-user-key <slug> <username> [label]` | Issue a **user-owned key** for a tenant user; prints its token **once** (default label = username). |
+| `create-user-key <slug> <username> [--label <l>] [--skill <codename>]…` | Issue a **user-owned key**; prints its token **once**. Repeat `--skill` to scope the key to a single skill or a skillset; omit for a full key (default label = username). |
 | `list-user-keys <slug> <username>` | List a user's personal keys (id, label, created-at). |
 | `revoke-user-key <slug> <username> <key_id>` | Revoke one of a user's personal keys by id (ownership-verified). |
 | `map-skill-permission <slug> <skill> <permission>` | Map a skill to a permission codename. Idempotent — any user key whose owner holds `<permission>` gains the skill. |
@@ -282,10 +294,13 @@ $ cargo run -- map-skill-permission acme coach mcp.coach
 # 2. Grant the permission to the member (roles or direct — see grant-perm),
 #    then issue their personal key.
 $ cargo run -- grant-perm acme alice mcp.coach
-$ cargo run -- create-user-key acme alice "Alice's phone"
-created key #7 for user `alice` in tenant `acme` (label `Alice's phone`)
+$ cargo run -- create-user-key acme alice --label "Alice's phone"
+created key #7 for user `alice` in tenant `acme` (label `Alice's phone`, scope full (owner's permissions))
   token: 3f9c1a2b.7d…            # copy once — never shown again
   store this safely — it won't be shown again
+
+# …or scope the key to a single skill / skillset (repeat --skill):
+$ cargo run -- create-user-key acme alice --label "coach bot" --skill coach
 ```
 
 Alice's key now resolves the `coach` skill's tools at every token-issue because

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -211,6 +211,46 @@ assert_eq!(out["structuredContent"]["sum"], 5);
 Tokens are tenant-pinned: a token minted for `acme` is rejected against any other
 tenant (cross-tenant replay → 401). Revoke an agent and its JTI is blacklisted.
 
+### User-owned keys (permission-driven capabilities)
+
+The agents above are standalone machine identities. A member can instead
+generate a **personal key** — a user-owned agent — so an LLM acts *on their
+behalf*, with capabilities that follow the tenant's existing **RBAC** instead
+of a list pinned onto the key.
+
+Two pieces wire it up:
+
+```rust
+use rustango::tenancy::{create_user_key_pool, create_skill_pool, map_skill_to_permission_pool};
+
+// 1. Map a skill to a permission codename. Any user-owned key whose owner
+//    holds `mcp.coach` is then granted this skill's tools + prompt + resources.
+create_skill_pool(&pool, "coach", "Coach", "logs workouts",
+                  "You are the member's coach.", &["log_set".into()]).await?;
+map_skill_to_permission_pool(&pool, "coach", "mcp.coach").await?;
+
+// 2. The member generates a key — a one-time `name`.`secret`, shown once.
+//    Nothing is pinned onto it; capabilities come from the owner's permissions.
+let issued = create_user_key_pool(&pool, user_id, "Alice's phone").await?;
+println!("copy once: {}", issued.token);
+```
+
+At token-issue the server calls
+[`resolve_user_agent_grants_pool`](../crates/rustango/src/tenancy/agents.rs) —
+the owner's effective permissions (`user_permissions_pool`, i.e. roles + direct
+grants − denials) select the mapped skills, whose tools/prompts/resources are
+flattened into the JWT's `skills`/`tools` claims. So `tools/list`,
+`tools/call`, `prompts/get`, and `resources/read` are **all** gated by RBAC,
+with no change to those handlers. The owning user rides in the token's `uid`
+claim; a tool handler reads it as `ctx.agent.user_id` to scope work to that
+member. Revoke fresh capabilities by changing the user's permissions (they
+re-resolve on the next token); revoke the key itself with
+`revoke_user_key_pool(&pool, user_id, agent_id)`. List a member's keys with
+`list_user_keys_pool(&pool, user_id)`.
+
+Standalone agents are unaffected — a machine agent (`user_id = None`) still
+uses only its explicit `grant_skill_pool` grants.
+
 ---
 
 ## The protocol

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -251,6 +251,53 @@ re-resolve on the next token); revoke the key itself with
 Standalone agents are unaffected — a machine agent (`user_id = None`) still
 uses only its explicit `grant_skill_pool` grants.
 
+### From the CLI (`manage` verbs)
+
+Everything above is also available out of the box through the tenancy-aware
+`manage` dispatcher (these verbs compile in with the `mcp` feature). Each is
+tenant-scoped and takes a `<slug>`:
+
+| Verb | What it does |
+|---|---|
+| `create-agent <slug> <name>` | Provision a machine agent; prints its `prefix.secret` **once**. |
+| `rotate-agent-secret <slug> <name>` | Issue a fresh secret, invalidating the old one. |
+| `list-agents <slug>` | List a tenant's agents (id, name, status, prefix). |
+| `create-skill <slug> <codename> [--name ..] [--description ..] [--tools a,b] [--instructions ..]` | Define a skill (a bundle of tools + prompt). |
+| `grant-skill <slug> <agent> <skill>` | Grant a skill to an agent. |
+| `revoke-skill <slug> <agent> <skill>` | Revoke a skill from an agent. |
+| `list-skills <slug>` | List a tenant's skills. |
+| `create-user-key <slug> <username> [label]` | Issue a **user-owned key** for a tenant user; prints its token **once** (default label = username). |
+| `list-user-keys <slug> <username>` | List a user's personal keys (id, label, created-at). |
+| `revoke-user-key <slug> <username> <key_id>` | Revoke one of a user's personal keys by id (ownership-verified). |
+| `map-skill-permission <slug> <skill> <permission>` | Map a skill to a permission codename. Idempotent — any user key whose owner holds `<permission>` gains the skill. |
+| `unmap-skill-permission <slug> <skill> <permission>` | Remove a skill↔permission mapping. |
+
+The **permission → skill → tools** flow end to end:
+
+```console
+# 1. Define the skill and map it to a permission codename.
+$ cargo run -- create-skill acme coach --tools log_set --instructions "You are the member's coach."
+$ cargo run -- map-skill-permission acme coach mcp.coach
+
+# 2. Grant the permission to the member (roles or direct — see grant-perm),
+#    then issue their personal key.
+$ cargo run -- grant-perm acme alice mcp.coach
+$ cargo run -- create-user-key acme alice "Alice's phone"
+created key #7 for user `alice` in tenant `acme` (label `Alice's phone`)
+  token: 3f9c1a2b.7d…            # copy once — never shown again
+  store this safely — it won't be shown again
+```
+
+Alice's key now resolves the `coach` skill's tools at every token-issue because
+she holds `mcp.coach`. Change her permissions and the capabilities re-resolve on
+her next token; revoke the key itself with `revoke-user-key`. The same key id is
+distinguishable from machine agents in the tenant admin (the `Agent` list shows
+`user_id`).
+
+The auto-admin surfaces these too: `Agent`, `AgentSkill`, `AgentSkillPermission`
+(and `AgentGrant`) each render an auto-CRUD table in the tenant admin, so the
+skill↔permission mappings can be reviewed and edited without the CLI.
+
 ---
 
 ## The protocol


### PR DESCRIPTION
## What

Lets an application user generate a **personal MCP key** so an LLM can act on their behalf, with the key's capabilities governed by the tenant's existing **RBAC** — not a static list pinned onto the key.

A personal key is a **user-owned `Agent`**: `rustango_agents` gains a nullable `user_id` owner. Everything else reuses the existing MCP machinery (JWT, skills, OAuth token endpoint, router, audit).

## How capabilities are resolved (permission-driven)

1. Map a skill to a permission codename — new table `rustango_agent_skill_permissions` + `map_skill_to_permission_pool` / `unmap_skill_from_permission_pool`.
2. At token-issue for a user-owned key, `resolve_user_agent_grants_pool(pool, agent_id, user_id)` unions the key's explicit grants with **every skill the owner is entitled to** via `user_permissions_pool` (roles + direct grants − denials).
3. The entitled skills' tools/prompts/resources flatten into the JWT `skills`/`tools` claims — so `tools/list`, `tools/call`, `prompts/get`, and `resources/read` are all RBAC-gated **with no change to those handlers**.

The owner rides in the token's new `uid` claim, surfaced as `McpAgent.user_id` for tool handlers to scope work to the member (`ctx.agent.user_id`).

## API

- `Agent.user_id: Option<i64>` (owner).
- Helpers: `create_user_key_pool`, `list_user_keys_pool`, `revoke_user_key_pool`, `map_skill_to_permission_pool`, `unmap_skill_from_permission_pool`, `resolve_user_agent_grants_pool`; new model `AgentSkillPermission`.
- **Breaking (internal):** `issue_agent_token` gains a trailing `user_id: Option<i64>` argument. All in-repo callers (tests/examples) updated.

## Compatibility

- Standalone machine agents (`user_id = None`) are unaffected — they use their explicit `grant_skill_pool` grants only.
- Older `rustango_agents` tables gain `user_id` transparently via an additive, idempotent, dialect-aware `ADD COLUMN` in `ensure_agents_table_pool` (probe-then-alter; nullable, no default → metadata-only on every backend).
- Fresh tables carry `user_id` and the mapping table in the per-dialect ensure DDL (Postgres / SQLite / MySQL).

## Tests / docs

- New `tests/mcp_user_keys_sqlite_live.rs`: grant flows into a key (list + call), negative path (no permission → no tools, fail-closed), and owner-scoped list/revoke.
- Unit test: `uid` claim round-trips through `issue`/`verify`.
- Regression: existing `mcp_*`, `system_migrations_gen`, `permissions_sqlite_live` all green.
- `docs/mcp.md` gains a "User-owned keys (permission-driven capabilities)" section; CHANGELOG updated.