### PR TITLE
feat(media): manage media tables via system migrations + 0.51.0 (#1174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 _Nothing yet — next development cycle._
 
+## [0.51.0] — 2026-08-06
+
+Headline: **the media subsystem is now managed by system migrations** — the
+last framework subsystem still relying on lazy `ensure_table` raw DDL now
+ships its schema like the rest of the framework's own tables.
+
+### Changed
+
+- **Media tables via system migrations** (#1174) — `Media`, `MediaCollection`,
+  and `MediaTag` are now managed `#[derive(Model)]`s on their `rustango_*`
+  tables, and a new `MediaTagLink` model backs the `rustango_media_tag_links`
+  junction. Their schema is emitted through the `#[cfg]`-aware system-migration
+  engine (present per-tenant when the `media` feature is on, absent when it is
+  off) instead of the lazy `ensure_table` layer. The hand-written per-dialect
+  DDL constants, the `ensure_*` functions, the manual per-backend row decoders,
+  and the `0.49.2` `ensure_media_tables` provisioning hook are all removed; the
+  derived `FromRow` decodes on every backend.
+
+### Fixed
+
+- **Empty-string defaults on MySQL LOB columns** (#1174) — a
+  `#[rustango(default = "")]` on a MySQL `TEXT`/`JSON`/`BLOB` column was emitted
+  as a literal `DEFAULT ''`, which MySQL rejects (error 1101). Empty-string
+  defaults are now routed through `translate_default_expr` in every CREATE /
+  ADD render path, so LOB columns get the parenthesized 8.0.13+ expression form
+  `DEFAULT ('')`; Postgres and SQLite keep the plain literal.
+
+### Upgrade note
+
+- Existing tenant databases provisioned before `0.51` created the media tables
+  via the retired `ensure_*` DDL, so those tables exist but are absent from the
+  system-migration ledger; the fresh `CREATE TABLE` will collide there. Fresh
+  provisioning is clean. A ledger backfill (fake-initial) for pre-existing
+  deployments is tracked separately (#1167).
+
 ## [0.50.0] — 2026-07-24
 
 Headline: **user-owned MCP keys** — a member mints a personal key and an LLM

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.50.0"
+version = "0.51.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.50.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.50.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.50.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.51.0", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.51.0", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.51.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.50.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.51.0" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -405,7 +405,7 @@ runserver = ["dep:axum", "dep:tokio"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.50.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.51.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }

--- a/crates/rustango/src/media/collection.rs
+++ b/crates/rustango/src/media/collection.rs
@@ -8,174 +8,32 @@
 //! orthogonal — Media has at most one collection FK and any number
 //! of tag M2M rows.
 //!
-//! Stored as a regular table, soft-deleted via `deleted_at`. `slug`
-//! is unique and path-friendly. v0.38 — tri-dialect via
-//! [`Self::ensure_table_pool`] + per-backend row decoders.
+//! Soft-deleted via `deleted_at`. `slug` is unique and path-friendly.
+//! A managed `#[derive(Model)]` on a `rustango_*` table, so its schema is
+//! emitted as an ordinary **system migration** — there is no lazy
+//! `ensure_*` creation layer.
 //!
 //! [`Media`]: crate::media::Media
-
-use chrono::{DateTime, Utc};
-#[cfg(feature = "postgres")]
-use sqlx::PgPool;
 
 use crate::sql::Auto;
 
 /// One folder. Cheap to clone.
-#[derive(Debug, Clone)]
+#[derive(crate::Model, Debug, Clone)]
+#[rustango(table = "rustango_media_collections")]
 pub struct MediaCollection {
+    #[rustango(primary_key)]
     pub id: Auto<i64>,
+    #[rustango(max_length = 255)]
     pub name: String,
     /// Path-friendly id, unique across the table.
+    #[rustango(max_length = 255, unique)]
     pub slug: String,
+    #[rustango(index)]
     pub parent_id: Option<i64>,
+    #[rustango(default = "")]
     pub description: String,
-    pub created_at: DateTime<Utc>,
-    pub deleted_at: Option<DateTime<Utc>>,
-}
-
-const CREATE_TABLE_SQL_PG: &str = "\
-CREATE TABLE IF NOT EXISTS rustango_media_collections (
-    id          BIGSERIAL PRIMARY KEY,
-    name        TEXT        NOT NULL,
-    slug        TEXT        NOT NULL UNIQUE,
-    parent_id   BIGINT,
-    description TEXT        NOT NULL DEFAULT '',
-    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    deleted_at  TIMESTAMPTZ
-);
-CREATE INDEX IF NOT EXISTS rustango_media_collections_parent_idx
-    ON rustango_media_collections (parent_id)
-    WHERE deleted_at IS NULL";
-
-const CREATE_TABLE_SQL_MYSQL: &str = "\
-CREATE TABLE IF NOT EXISTS `rustango_media_collections` (
-    `id`          BIGINT      NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    `name`        VARCHAR(255) NOT NULL,
-    `slug`        VARCHAR(255) NOT NULL UNIQUE,
-    `parent_id`   BIGINT,
-    `description` TEXT         NOT NULL,
-    `created_at`  DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-    `deleted_at`  DATETIME(6)
-);
-CREATE INDEX `rustango_media_collections_parent_idx`
-    ON `rustango_media_collections` (`parent_id`)";
-
-const CREATE_TABLE_SQL_SQLITE: &str = "\
-CREATE TABLE IF NOT EXISTS rustango_media_collections (
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    name        TEXT     NOT NULL,
-    slug        TEXT     NOT NULL UNIQUE,
-    parent_id   INTEGER,
-    description TEXT     NOT NULL DEFAULT '',
-    created_at  TEXT     NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-    deleted_at  TEXT
-);
-CREATE INDEX IF NOT EXISTS rustango_media_collections_parent_idx
-    ON rustango_media_collections (parent_id) WHERE deleted_at IS NULL";
-
-impl MediaCollection {
-    /// PG back-compat shim around [`Self::ensure_table_pool`].
-    ///
-    /// # Errors
-    /// Underlying sqlx DDL error.
-    #[cfg(feature = "postgres")]
-    pub async fn ensure_table(pool: &PgPool) -> Result<(), sqlx::Error> {
-        Self::ensure_table_pool(&crate::sql::Pool::Postgres(pool.clone())).await
-    }
-
-    /// Create the `rustango_media_collections` table + supporting
-    /// index if absent. Idempotent. Same pattern as
-    /// [`crate::media::Media::ensure_table_pool`]. v0.38 — tri-dialect.
-    ///
-    /// MySQL skips the partial index (`WHERE deleted_at IS NULL`) since
-    /// MySQL doesn't support partial indexes; the equivalent
-    /// full-column index is created instead. SQLite supports partial
-    /// indexes and uses the PG shape.
-    ///
-    /// # Errors
-    /// Underlying sqlx DDL error.
-    pub async fn ensure_table_pool(pool: &crate::sql::Pool) -> Result<(), sqlx::Error> {
-        let ddl = match pool.dialect().name() {
-            "postgres" => CREATE_TABLE_SQL_PG,
-            "mysql" => CREATE_TABLE_SQL_MYSQL,
-            "sqlite" => CREATE_TABLE_SQL_SQLITE,
-            _ => CREATE_TABLE_SQL_PG,
-        };
-        // #561 — shared split-+-dispatch-+-swallow-dup-index loop.
-        crate::sql::run_ddl_idempotent(pool, ddl).await
-    }
-
-    /// PG row decoder — kept for in-crate callers using `PgRow`.
-    /// Tri-dialect callers use the `sqlx::FromRow` impl below.
-    #[cfg(feature = "postgres")]
-    pub(super) fn decode_pg(row: &sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
-        use sqlx::Row;
-        let id: i64 = row.try_get("id")?;
-        Ok(Self {
-            id: Auto::Set(id),
-            name: row.try_get("name")?,
-            slug: row.try_get("slug")?,
-            parent_id: row.try_get("parent_id")?,
-            description: row.try_get("description")?,
-            created_at: row.try_get("created_at")?,
-            deleted_at: row.try_get("deleted_at")?,
-        })
-    }
-
-    /// MySQL row decoder.
-    #[cfg(feature = "mysql")]
-    pub(super) fn decode_my(row: &sqlx::mysql::MySqlRow) -> Result<Self, sqlx::Error> {
-        use sqlx::Row;
-        let id: i64 = row.try_get("id")?;
-        let created_at = super::tag::decode_my_datetime(row, "created_at")?;
-        let deleted_at = super::tag::decode_my_datetime_opt(row, "deleted_at")?;
-        Ok(Self {
-            id: Auto::Set(id),
-            name: row.try_get("name")?,
-            slug: row.try_get("slug")?,
-            parent_id: row.try_get("parent_id")?,
-            description: row.try_get("description")?,
-            created_at,
-            deleted_at,
-        })
-    }
-
-    /// SQLite row decoder.
-    #[cfg(feature = "sqlite")]
-    pub(super) fn decode_sq(row: &sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
-        use sqlx::Row;
-        let id: i64 = row.try_get("id")?;
-        let created_at = super::tag::decode_sqlite_datetime(row, "created_at")?;
-        let deleted_at = super::tag::decode_sqlite_datetime_opt(row, "deleted_at")?;
-        Ok(Self {
-            id: Auto::Set(id),
-            name: row.try_get("name")?,
-            slug: row.try_get("slug")?,
-            parent_id: row.try_get("parent_id")?,
-            description: row.try_get("description")?,
-            created_at,
-            deleted_at,
-        })
-    }
-}
-
-// v0.38 — FromRow impls so `raw_query_pool::<MediaCollection>` works
-// on every backend.
-#[cfg(feature = "postgres")]
-impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for MediaCollection {
-    fn from_row(row: &'r sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
-        Self::decode_pg(row)
-    }
-}
-#[cfg(feature = "mysql")]
-impl<'r> sqlx::FromRow<'r, sqlx::mysql::MySqlRow> for MediaCollection {
-    fn from_row(row: &'r sqlx::mysql::MySqlRow) -> Result<Self, sqlx::Error> {
-        Self::decode_my(row)
-    }
-}
-#[cfg(feature = "sqlite")]
-impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for MediaCollection {
-    fn from_row(row: &'r sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
-        Self::decode_sq(row)
-    }
+    /// Set on INSERT via the per-dialect `DEFAULT NOW()`.
+    #[rustango(auto_now_add)]
+    pub created_at: Auto<chrono::DateTime<chrono::Utc>>,
+    pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
 }

--- a/crates/rustango/src/media/mod.rs
+++ b/crates/rustango/src/media/mod.rs
@@ -14,8 +14,8 @@
 //! use rustango::storage::StorageRegistry;
 //! use std::sync::Arc;
 //!
-//! // Once at startup:
-//! Media::ensure_table(&pool).await?;
+//! // Tables come from the framework's system migrations (run during
+//! // provisioning / `migrate_framework`) — no per-boot table bootstrap.
 //!
 //! let registry = StorageRegistry::new()
 //!     .set("avatars", Arc::new(s3_storage))
@@ -44,25 +44,10 @@
 //!
 //! ## Schema
 //!
-//! ```sql
-//! CREATE TABLE rustango_media (
-//!     id                BIGSERIAL PRIMARY KEY,
-//!     disk              TEXT        NOT NULL,
-//!     storage_key       TEXT        NOT NULL,
-//!     mime              TEXT        NOT NULL,
-//!     size_bytes        BIGINT      NOT NULL,
-//!     original_filename TEXT        NOT NULL,
-//!     status            TEXT        NOT NULL,            -- pending/ready/failed
-//!     uploaded_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-//!     uploaded_by_id    BIGINT,                          -- soft FK to your User table
-//!     derived_from_id   BIGINT,                          -- self-FK for variants/thumbnails
-//!     metadata          JSONB       NOT NULL DEFAULT '{}'::JSONB,
-//!     deleted_at        TIMESTAMPTZ                      -- soft delete
-//! );
-//! CREATE INDEX rustango_media_disk_key_idx ON rustango_media (disk, storage_key);
-//! CREATE INDEX rustango_media_status_idx   ON rustango_media (status)
-//!     WHERE deleted_at IS NULL;
-//! ```
+//! The `rustango_media` table (and the collection / tag / tag-link
+//! tables) are managed `#[derive(Model)]`s, so their schema is emitted
+//! as ordinary **system migrations** rather than a per-boot `ensure_*`
+//! DDL bootstrap. See the [`Media`] struct for the column definitions.
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -75,117 +60,15 @@ use sqlx::PgPool;
 use crate::sql::Auto;
 use crate::storage::{StorageError, StorageRegistry};
 
-const CREATE_MEDIA_TABLE_SQL_PG: &str = "\
-CREATE TABLE IF NOT EXISTS rustango_media (
-    id                BIGSERIAL PRIMARY KEY,
-    disk              TEXT        NOT NULL,
-    storage_key       TEXT        NOT NULL,
-    mime              TEXT        NOT NULL,
-    size_bytes        BIGINT      NOT NULL,
-    original_filename TEXT        NOT NULL,
-    status            TEXT        NOT NULL,
-    uploaded_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    uploaded_by_id    BIGINT,
-    derived_from_id   BIGINT,
-    collection_id     BIGINT,
-    metadata          JSONB       NOT NULL DEFAULT '{}'::JSONB,
-    deleted_at        TIMESTAMPTZ
-);
-ALTER TABLE rustango_media ADD COLUMN IF NOT EXISTS collection_id BIGINT;
-CREATE INDEX IF NOT EXISTS rustango_media_disk_key_idx
-    ON rustango_media (disk, storage_key);
-CREATE INDEX IF NOT EXISTS rustango_media_status_idx
-    ON rustango_media (status)
-    WHERE deleted_at IS NULL;
-CREATE INDEX IF NOT EXISTS rustango_media_collection_idx
-    ON rustango_media (collection_id)
-    WHERE deleted_at IS NULL";
-
-const CREATE_MEDIA_TABLE_SQL_MYSQL: &str = "\
-CREATE TABLE IF NOT EXISTS `rustango_media` (
-    `id`                BIGINT      NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    `disk`              VARCHAR(255) NOT NULL,
-    `storage_key`       VARCHAR(512) NOT NULL,
-    `mime`              VARCHAR(255) NOT NULL,
-    `size_bytes`        BIGINT      NOT NULL,
-    `original_filename` VARCHAR(512) NOT NULL,
-    `status`            VARCHAR(32)  NOT NULL,
-    `uploaded_at`       DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-    `uploaded_by_id`    BIGINT,
-    `derived_from_id`   BIGINT,
-    `collection_id`     BIGINT,
-    `metadata`          JSON         NOT NULL,
-    `deleted_at`        DATETIME(6)
-);
-CREATE INDEX `rustango_media_disk_key_idx`
-    ON `rustango_media` (`disk`, `storage_key`);
-CREATE INDEX `rustango_media_status_idx`
-    ON `rustango_media` (`status`);
-CREATE INDEX `rustango_media_collection_idx`
-    ON `rustango_media` (`collection_id`)";
-
-const CREATE_MEDIA_TABLE_SQL_SQLITE: &str = "\
-CREATE TABLE IF NOT EXISTS rustango_media (
-    id                INTEGER PRIMARY KEY AUTOINCREMENT,
-    disk              TEXT     NOT NULL,
-    storage_key       TEXT     NOT NULL,
-    mime              TEXT     NOT NULL,
-    size_bytes        INTEGER  NOT NULL,
-    original_filename TEXT     NOT NULL,
-    status            TEXT     NOT NULL,
-    uploaded_at       TEXT     NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-    uploaded_by_id    INTEGER,
-    derived_from_id   INTEGER,
-    collection_id     INTEGER,
-    metadata          TEXT     NOT NULL DEFAULT '{}',
-    deleted_at        TEXT
-);
-CREATE INDEX IF NOT EXISTS rustango_media_disk_key_idx
-    ON rustango_media (disk, storage_key);
-CREATE INDEX IF NOT EXISTS rustango_media_status_idx
-    ON rustango_media (status) WHERE deleted_at IS NULL;
-CREATE INDEX IF NOT EXISTS rustango_media_collection_idx
-    ON rustango_media (collection_id) WHERE deleted_at IS NULL";
-
 pub mod collection;
 pub mod tag;
 pub use collection::MediaCollection;
-pub use tag::MediaTag;
+pub use tag::{MediaTag, MediaTagLink};
 
 #[cfg(feature = "admin")]
 pub mod router;
 
 const DEFAULT_DISK_NAME: &str = "default";
-
-/// One-call bootstrap for every table the `media` module needs:
-/// `rustango_media`, `rustango_media_collections`,
-/// `rustango_media_tags`, and the `rustango_media_tag_links`
-/// junction. Also runs the idempotent ALTER that adds
-/// `collection_id` to `rustango_media` for deployments that ran
-/// the v0.21.51 ensure_table before this column existed.
-///
-/// Safe to call on every boot. v0.38 — PG back-compat shim around
-/// [`ensure_all_tables_pool`].
-///
-/// # Errors
-/// Surfaces the underlying sqlx error if any DDL fails.
-#[cfg(feature = "postgres")]
-pub async fn ensure_all_tables(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
-    ensure_all_tables_pool(&crate::sql::Pool::Postgres(pool.clone())).await
-}
-
-/// Tri-dialect counterpart of [`ensure_all_tables`] (v0.38). Routes
-/// each `ensure_table_pool` through the unified [`crate::sql::Pool`]
-/// enum so the media bootstrap works on PG / SQLite / MySQL.
-///
-/// # Errors
-/// Surfaces the underlying sqlx error if any DDL fails.
-pub async fn ensure_all_tables_pool(pool: &crate::sql::Pool) -> Result<(), sqlx::Error> {
-    Media::ensure_table_pool(pool).await?;
-    MediaCollection::ensure_table_pool(pool).await?;
-    MediaTag::ensure_table_pool(pool).await?;
-    Ok(())
-}
 
 /// Lifecycle state of a Media row.
 ///
@@ -228,63 +111,49 @@ impl MediaStatus {
 
 /// First-class media row. Always referenced from user models via
 /// `Option<ForeignKey<Media>>` rather than embedded directly.
-#[derive(Debug, Clone)]
+///
+/// Managed `#[derive(Model)]` on the `rustango_media` table — its schema
+/// (and the `(disk, storage_key)` / `status` / `collection_id` indexes)
+/// is emitted via the framework's system migrations. The `status` and
+/// `collection_id` indexes are plain (non-partial) here; the retired
+/// hand-DDL made them partial `WHERE deleted_at IS NULL`, which the
+/// `#[rustango(index)]` attr can't express — behavior-equivalent for
+/// correctness.
+#[derive(crate::Model, Debug, Clone)]
+#[rustango(table = "rustango_media", index("disk, storage_key"))]
 pub struct Media {
+    #[rustango(primary_key)]
     pub id: Auto<i64>,
+    #[rustango(max_length = 255)]
     pub disk: String,
+    #[rustango(max_length = 512)]
     pub storage_key: String,
+    #[rustango(max_length = 255)]
     pub mime: String,
     pub size_bytes: i64,
+    #[rustango(max_length = 512)]
     pub original_filename: String,
-    pub status: String, // MediaStatus serialized as &str
-    pub uploaded_at: DateTime<Utc>,
+    /// MediaStatus serialized as &str (pending/ready/failed).
+    #[rustango(max_length = 32, index)]
+    pub status: String,
+    /// Set on INSERT via the per-dialect `DEFAULT NOW()`.
+    #[rustango(auto_now_add)]
+    pub uploaded_at: Auto<DateTime<Utc>>,
+    /// Soft FK to your User table.
     pub uploaded_by_id: Option<i64>,
+    /// Self-FK for variants / thumbnails.
     pub derived_from_id: Option<i64>,
     /// Optional FK to `rustango_media_collections.id` — the
     /// "where it lives" folder. NULL means "loose" (in the root).
+    #[rustango(index)]
     pub collection_id: Option<i64>,
+    #[rustango(default = "'{}'")]
     pub metadata: Value,
+    /// Soft delete.
     pub deleted_at: Option<DateTime<Utc>>,
 }
 
 impl Media {
-    /// Create the `rustango_media` table + supporting indexes if
-    /// they don't exist. Idempotent. Safe to call on every boot.
-    ///
-    /// We use raw DDL (matching the `PgJobQueue::ensure_table`
-    /// pattern shipped in v0.21.14) rather than threading through
-    /// the migration system, because Media is a framework-shipped
-    /// table rather than user-authored.
-    ///
-    /// # Errors
-    /// Underlying sqlx error if the DDL fails (insufficient
-    /// privileges, connection issue, etc.).
-    #[cfg(feature = "postgres")]
-    pub async fn ensure_table(pool: &PgPool) -> Result<(), sqlx::Error> {
-        Self::ensure_table_pool(&crate::sql::Pool::Postgres(pool.clone())).await
-    }
-
-    /// v0.38 — tri-dialect `rustango_media` table bootstrap. Dispatches
-    /// per-dialect DDL (BIGSERIAL/SERIAL/AUTOINCREMENT, TIMESTAMPTZ/
-    /// DATETIME(6)/TEXT-ISO-8601, JSONB/JSON/TEXT-as-JSON). PG + SQLite
-    /// keep the partial indexes (`WHERE deleted_at IS NULL`); MySQL
-    /// uses full-column indexes since it doesn't support partial
-    /// indexes.
-    ///
-    /// # Errors
-    /// Underlying sqlx DDL error.
-    pub async fn ensure_table_pool(pool: &crate::sql::Pool) -> Result<(), sqlx::Error> {
-        let ddl = match pool.dialect().name() {
-            "postgres" => CREATE_MEDIA_TABLE_SQL_PG,
-            "mysql" => CREATE_MEDIA_TABLE_SQL_MYSQL,
-            "sqlite" => CREATE_MEDIA_TABLE_SQL_SQLITE,
-            _ => CREATE_MEDIA_TABLE_SQL_PG,
-        };
-        // #561 — shared split-+-dispatch-+-swallow-dup-index loop
-        // lives in `crate::sql::run_ddl_idempotent`.
-        crate::sql::run_ddl_idempotent(pool, ddl).await
-    }
-
     /// Typed status accessor.
     #[must_use]
     pub fn status_enum(&self) -> Option<MediaStatus> {
@@ -295,100 +164,6 @@ impl Media {
     #[must_use]
     pub fn is_ready(&self) -> bool {
         self.status_enum() == Some(MediaStatus::Ready)
-    }
-
-    #[cfg(feature = "postgres")]
-    fn decode_pg(row: &sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
-        use sqlx::Row;
-        let id: i64 = row.try_get("id")?;
-        Ok(Self {
-            id: Auto::Set(id),
-            disk: row.try_get("disk")?,
-            storage_key: row.try_get("storage_key")?,
-            mime: row.try_get("mime")?,
-            size_bytes: row.try_get("size_bytes")?,
-            original_filename: row.try_get("original_filename")?,
-            status: row.try_get("status")?,
-            uploaded_at: row.try_get("uploaded_at")?,
-            uploaded_by_id: row.try_get("uploaded_by_id")?,
-            derived_from_id: row.try_get("derived_from_id")?,
-            collection_id: row.try_get("collection_id")?,
-            metadata: row.try_get("metadata")?,
-            deleted_at: row.try_get("deleted_at")?,
-        })
-    }
-
-    /// MySQL row decoder (v0.38).
-    #[cfg(feature = "mysql")]
-    fn decode_my(row: &sqlx::mysql::MySqlRow) -> Result<Self, sqlx::Error> {
-        use sqlx::Row;
-        let id: i64 = row.try_get("id")?;
-        let uploaded_at = crate::media::tag::decode_my_datetime(row, "uploaded_at")?;
-        let deleted_at = crate::media::tag::decode_my_datetime_opt(row, "deleted_at")?;
-        let metadata: sqlx::types::Json<Value> = row.try_get("metadata")?;
-        Ok(Self {
-            id: Auto::Set(id),
-            disk: row.try_get("disk")?,
-            storage_key: row.try_get("storage_key")?,
-            mime: row.try_get("mime")?,
-            size_bytes: row.try_get("size_bytes")?,
-            original_filename: row.try_get("original_filename")?,
-            status: row.try_get("status")?,
-            uploaded_at,
-            uploaded_by_id: row.try_get("uploaded_by_id")?,
-            derived_from_id: row.try_get("derived_from_id")?,
-            collection_id: row.try_get("collection_id")?,
-            metadata: metadata.0,
-            deleted_at,
-        })
-    }
-
-    /// SQLite row decoder (v0.38). `metadata` is stored as TEXT-as-JSON.
-    #[cfg(feature = "sqlite")]
-    fn decode_sq(row: &sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
-        use sqlx::Row;
-        let id: i64 = row.try_get("id")?;
-        let uploaded_at = crate::media::tag::decode_sqlite_datetime(row, "uploaded_at")?;
-        let deleted_at = crate::media::tag::decode_sqlite_datetime_opt(row, "deleted_at")?;
-        let meta_text: String = row.try_get("metadata")?;
-        let metadata: Value = serde_json::from_str(&meta_text).unwrap_or(Value::Null);
-        Ok(Self {
-            id: Auto::Set(id),
-            disk: row.try_get("disk")?,
-            storage_key: row.try_get("storage_key")?,
-            mime: row.try_get("mime")?,
-            size_bytes: row.try_get("size_bytes")?,
-            original_filename: row.try_get("original_filename")?,
-            status: row.try_get("status")?,
-            uploaded_at,
-            uploaded_by_id: row.try_get("uploaded_by_id")?,
-            derived_from_id: row.try_get("derived_from_id")?,
-            collection_id: row.try_get("collection_id")?,
-            metadata,
-            deleted_at,
-        })
-    }
-}
-
-// v0.38 — FromRow impls so `raw_query_pool::<Media>` dispatches via
-// the unified `crate::sql::Pool` enum. Each backend's FromRow forwards
-// to the corresponding inherent `decode_*` above.
-#[cfg(feature = "postgres")]
-impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for Media {
-    fn from_row(row: &'r sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
-        Self::decode_pg(row)
-    }
-}
-#[cfg(feature = "mysql")]
-impl<'r> sqlx::FromRow<'r, sqlx::mysql::MySqlRow> for Media {
-    fn from_row(row: &'r sqlx::mysql::MySqlRow) -> Result<Self, sqlx::Error> {
-        Self::decode_my(row)
-    }
-}
-#[cfg(feature = "sqlite")]
-impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for Media {
-    fn from_row(row: &'r sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
-        Self::decode_sq(row)
     }
 }
 
@@ -902,13 +677,12 @@ impl MediaManager {
                     .bind(&description)
                     .execute(&mut *tx)
                     .await?;
-                let row = sqlx::query(&format!(
+                let out: MediaCollection = sqlx::query_as(&format!(
                     "SELECT {select_cols} FROM `rustango_media_collections` \
                      WHERE id = LAST_INSERT_ID()"
                 ))
                 .fetch_one(&mut *tx)
                 .await?;
-                let out = MediaCollection::decode_my(&row)?;
                 tx.commit().await?;
                 return Ok(out);
             }
@@ -1157,13 +931,12 @@ impl MediaManager {
                 .bind(slug)
                 .execute(&mut *tx)
                 .await?;
-                let row = sqlx::query(
+                let out: MediaTag = sqlx::query_as(
                     "SELECT id, name, slug, created_at FROM `rustango_media_tags` WHERE slug = ?",
                 )
                 .bind(slug)
                 .fetch_one(&mut *tx)
                 .await?;
-                let out = MediaTag::decode_my(&row)?;
                 tx.commit().await?;
                 return Ok(out);
             }
@@ -1344,9 +1117,9 @@ impl MediaManager {
               LIMIT {p}"
         );
         // #561 — was three byte-similar `bind+fetch+decode` arms. The
-        // `use_count` aggregate column isn't part of MediaTag's schema,
-        // so the existing `MediaTag::decode_pg/my/sq` helpers can't be
-        // re-used directly. Factor per-backend pair decoders below.
+        // `use_count` aggregate column isn't part of MediaTag's schema, so
+        // per-backend pair decoders (below) pull `use_count` themselves and
+        // delegate the tag columns to the derived `sqlx::FromRow`.
         let lim = limit.max(1).min(1000);
         match &self.pool {
             #[cfg(feature = "postgres")]
@@ -1419,12 +1192,11 @@ impl MediaManager {
                     .bind(sqlx::types::Json(&r.metadata))
                     .execute(&mut *tx)
                     .await?;
-                let row = sqlx::query(&format!(
+                let out: Media = sqlx::query_as(&format!(
                     "SELECT {select_cols} FROM `rustango_media` WHERE id = LAST_INSERT_ID()"
                 ))
                 .fetch_one(&mut *tx)
                 .await?;
-                let out = Media::decode_my(&row)?;
                 tx.commit().await?;
                 return Ok(out);
             }
@@ -1476,31 +1248,31 @@ fn media_err_from_exec(e: crate::sql::ExecError) -> MediaError {
 
 /// #561 — per-backend MediaTag-with-`use_count` row decoder helpers.
 /// `popular_tags` does a single LEFT JOIN GROUP BY query whose row
-/// shape is `MediaTag::SCHEMA + use_count: i64`; the existing
-/// `MediaTag::decode_<backend>` family expects only the model's
-/// scalar columns. Three sibling free fns keep the per-backend
-/// arms tight without forcing a new schema column.
+/// shape is `MediaTag::SCHEMA + use_count: i64`. The derived
+/// `sqlx::FromRow` for `MediaTag` reads only the model's columns by
+/// name (ignoring the extra `use_count`), so we pull `use_count`
+/// ourselves and let `FromRow` decode the tag.
 #[cfg(feature = "postgres")]
 fn decode_tag_with_count_pg(row: &sqlx::postgres::PgRow) -> Result<(MediaTag, i64), MediaError> {
-    use sqlx::Row as _;
+    use sqlx::{FromRow as _, Row as _};
     let count: i64 = row.try_get("use_count").map_err(MediaError::Db)?;
-    let tag = MediaTag::decode_pg(row).map_err(MediaError::Db)?;
+    let tag = MediaTag::from_row(row).map_err(MediaError::Db)?;
     Ok((tag, count))
 }
 
 #[cfg(feature = "mysql")]
 fn decode_tag_with_count_my(row: &sqlx::mysql::MySqlRow) -> Result<(MediaTag, i64), MediaError> {
-    use sqlx::Row as _;
+    use sqlx::{FromRow as _, Row as _};
     let count: i64 = row.try_get("use_count").map_err(MediaError::Db)?;
-    let tag = MediaTag::decode_my(row).map_err(MediaError::Db)?;
+    let tag = MediaTag::from_row(row).map_err(MediaError::Db)?;
     Ok((tag, count))
 }
 
 #[cfg(feature = "sqlite")]
 fn decode_tag_with_count_sq(row: &sqlx::sqlite::SqliteRow) -> Result<(MediaTag, i64), MediaError> {
-    use sqlx::Row as _;
+    use sqlx::{FromRow as _, Row as _};
     let count: i64 = row.try_get("use_count").map_err(MediaError::Db)?;
-    let tag = MediaTag::decode_sq(row).map_err(MediaError::Db)?;
+    let tag = MediaTag::from_row(row).map_err(MediaError::Db)?;
     Ok((tag, count))
 }
 
@@ -1626,7 +1398,7 @@ mod tests {
             size_bytes: 0,
             original_filename: "x".into(),
             status: "ready".into(),
-            uploaded_at: Utc::now(),
+            uploaded_at: Auto::Set(Utc::now()),
             uploaded_by_id: None,
             derived_from_id: None,
             collection_id: None,

--- a/crates/rustango/src/media/router.rs
+++ b/crates/rustango/src/media/router.rs
@@ -31,8 +31,8 @@
 //! use rustango::media::{Media, MediaManager, router::media_router};
 //! use rustango::storage::StorageRegistry;
 //!
-//! Media::ensure_table(&pool).await?;
-//! rustango::media::ensure_all_tables(&pool).await?;
+//! // Tables come from the framework's system migrations (run during
+//! // provisioning / `migrate_framework`) — no per-boot bootstrap needed.
 //!
 //! let manager = MediaManager::new(pool.clone(), registry);
 //! let app = axum::Router::new()
@@ -166,7 +166,7 @@ impl MediaResponse {
             size_bytes: m.size_bytes,
             original_filename: m.original_filename,
             status: m.status,
-            uploaded_at: m.uploaded_at,
+            uploaded_at: m.uploaded_at.into_inner().unwrap_or_else(chrono::Utc::now),
             uploaded_by_id: m.uploaded_by_id,
             derived_from_id: m.derived_from_id,
             collection_id: m.collection_id,
@@ -220,7 +220,7 @@ impl From<MediaCollection> for CollectionResponse {
             slug: c.slug,
             parent_id: c.parent_id,
             description: c.description,
-            created_at: c.created_at,
+            created_at: c.created_at.into_inner().unwrap_or_else(chrono::Utc::now),
         }
     }
 }

--- a/crates/rustango/src/media/tag.rs
+++ b/crates/rustango/src/media/tag.rs
@@ -3,248 +3,57 @@
 //! Sibling to [`crate::media::collection::MediaCollection`]: tags
 //! express inclusive labels ("featured", "approved",
 //! "homepage-hero"); collections express exclusive location.
-//! M2M between Media and Tag via `rustango_media_tag_links`.
+//! M2M between Media and Tag via [`MediaTagLink`]
+//! (`rustango_media_tag_links`).
 //!
 //! Tags are cheap to recreate, so deletion is hard (not soft) — the
 //! junction rows cascade away with the FK.
 //!
-//! v0.38 — tri-dialect via [`Self::ensure_table_pool`] + per-backend
-//! [`Self::from_row`] dispatch. The PG-only `ensure_table(&PgPool)`
-//! stays as a documented back-compat shim.
+//! Both models are managed `#[derive(Model)]`s on `rustango_*` tables, so
+//! their schema is emitted as ordinary **system migrations** (and, in
+//! tests, materialized by [`crate::testkit::migrate_framework`]). There is
+//! no lazy `ensure_*` creation layer — the tables exist because migrations
+//! ran, exactly like the rest of the framework's own tables.
 //!
 //! [`Media`]: crate::media::Media
 
-use chrono::{DateTime, Utc};
-#[cfg(feature = "postgres")]
-use sqlx::PgPool;
-
 use crate::sql::Auto;
 
-#[derive(Debug, Clone)]
+/// One free-form label. Cheap to clone.
+#[derive(crate::Model, Debug, Clone)]
+#[rustango(table = "rustango_media_tags")]
 pub struct MediaTag {
+    #[rustango(primary_key)]
     pub id: Auto<i64>,
+    #[rustango(max_length = 255)]
     pub name: String,
     /// Path-friendly id, unique across the table.
+    #[rustango(max_length = 255, unique)]
     pub slug: String,
-    pub created_at: DateTime<Utc>,
+    /// Set on INSERT via the per-dialect `DEFAULT NOW()`.
+    #[rustango(auto_now_add)]
+    pub created_at: Auto<chrono::DateTime<chrono::Utc>>,
 }
 
-const CREATE_TABLE_SQL_PG: &str = "\
-CREATE TABLE IF NOT EXISTS rustango_media_tags (
-    id         BIGSERIAL PRIMARY KEY,
-    name       TEXT        NOT NULL,
-    slug       TEXT        NOT NULL UNIQUE,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-CREATE TABLE IF NOT EXISTS rustango_media_tag_links (
-    media_id BIGINT NOT NULL,
-    tag_id   BIGINT NOT NULL,
-    PRIMARY KEY (media_id, tag_id),
-    FOREIGN KEY (tag_id)
-        REFERENCES rustango_media_tags (id)
-        ON DELETE CASCADE
-);
-CREATE INDEX IF NOT EXISTS rustango_media_tag_links_tag_idx
-    ON rustango_media_tag_links (tag_id)";
-
-const CREATE_TABLE_SQL_MYSQL: &str = "\
-CREATE TABLE IF NOT EXISTS `rustango_media_tags` (
-    `id`         BIGINT      NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    `name`       VARCHAR(255) NOT NULL,
-    `slug`       VARCHAR(255) NOT NULL UNIQUE,
-    `created_at` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
-);
-CREATE TABLE IF NOT EXISTS `rustango_media_tag_links` (
-    `media_id` BIGINT NOT NULL,
-    `tag_id`   BIGINT NOT NULL,
-    PRIMARY KEY (`media_id`, `tag_id`),
-    FOREIGN KEY (`tag_id`)
-        REFERENCES `rustango_media_tags` (`id`)
-        ON DELETE CASCADE
-);
-CREATE INDEX `rustango_media_tag_links_tag_idx`
-    ON `rustango_media_tag_links` (`tag_id`)";
-
-const CREATE_TABLE_SQL_SQLITE: &str = "\
-CREATE TABLE IF NOT EXISTS rustango_media_tags (
-    id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    name       TEXT     NOT NULL,
-    slug       TEXT     NOT NULL UNIQUE,
-    created_at TEXT     NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-);
-CREATE TABLE IF NOT EXISTS rustango_media_tag_links (
-    media_id INTEGER NOT NULL,
-    tag_id   INTEGER NOT NULL,
-    PRIMARY KEY (media_id, tag_id),
-    FOREIGN KEY (tag_id)
-        REFERENCES rustango_media_tags (id)
-        ON DELETE CASCADE
-);
-CREATE INDEX IF NOT EXISTS rustango_media_tag_links_tag_idx
-    ON rustango_media_tag_links (tag_id)";
-
-impl MediaTag {
-    /// PG back-compat shim around [`Self::ensure_table_pool`].
-    ///
-    /// # Errors
-    /// Underlying sqlx DDL error.
-    #[cfg(feature = "postgres")]
-    pub async fn ensure_table(pool: &PgPool) -> Result<(), sqlx::Error> {
-        Self::ensure_table_pool(&crate::sql::Pool::Postgres(pool.clone())).await
-    }
-
-    /// Create the `rustango_media_tags` + `rustango_media_tag_links`
-    /// junction tables if absent. Idempotent. v0.38 — tri-dialect:
-    /// dispatches on `pool.dialect()` for PG / MySQL / SQLite DDL.
-    /// MySQL's `CREATE INDEX` raises 1061 if the index already
-    /// exists (no `IF NOT EXISTS` clause); that one error is swallowed
-    /// for idempotency, every other error surfaces.
-    ///
-    /// # Errors
-    /// Underlying sqlx DDL error.
-    pub async fn ensure_table_pool(pool: &crate::sql::Pool) -> Result<(), sqlx::Error> {
-        let ddl = match pool.dialect().name() {
-            "postgres" => CREATE_TABLE_SQL_PG,
-            "mysql" => CREATE_TABLE_SQL_MYSQL,
-            "sqlite" => CREATE_TABLE_SQL_SQLITE,
-            _ => CREATE_TABLE_SQL_PG,
-        };
-        // #561 — shared split-+-dispatch-+-swallow-dup-index loop.
-        crate::sql::run_ddl_idempotent(pool, ddl).await
-    }
-
-    /// PG row decoder — kept for in-crate callers that still acquire
-    /// a `PgRow` directly. Tri-dialect callers can use the
-    /// `sqlx::FromRow` trait impl below + `raw_query_pool::<MediaTag>`.
-    #[cfg(feature = "postgres")]
-    pub(super) fn decode_pg(row: &sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
-        use sqlx::Row;
-        let id: i64 = row.try_get("id")?;
-        Ok(Self {
-            id: Auto::Set(id),
-            name: row.try_get("name")?,
-            slug: row.try_get("slug")?,
-            created_at: row.try_get("created_at")?,
-        })
-    }
-
-    /// MySQL row decoder.
-    #[cfg(feature = "mysql")]
-    pub(super) fn decode_my(row: &sqlx::mysql::MySqlRow) -> Result<Self, sqlx::Error> {
-        use sqlx::Row;
-        let id: i64 = row.try_get("id")?;
-        let created_at: DateTime<Utc> = decode_my_datetime(row, "created_at")?;
-        Ok(Self {
-            id: Auto::Set(id),
-            name: row.try_get("name")?,
-            slug: row.try_get("slug")?,
-            created_at,
-        })
-    }
-
-    /// SQLite row decoder.
-    #[cfg(feature = "sqlite")]
-    pub(super) fn decode_sq(row: &sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
-        use sqlx::Row;
-        let id: i64 = row.try_get("id")?;
-        let created_at: DateTime<Utc> = decode_sqlite_datetime(row, "created_at")?;
-        Ok(Self {
-            id: Auto::Set(id),
-            name: row.try_get("name")?,
-            slug: row.try_get("slug")?,
-            created_at,
-        })
-    }
-}
-
-// v0.38 — FromRow impls dispatch per backend so `raw_query_pool::<MediaTag>`
-// works on every backend.
-#[cfg(feature = "postgres")]
-impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for MediaTag {
-    fn from_row(row: &'r sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
-        Self::decode_pg(row)
-    }
-}
-#[cfg(feature = "mysql")]
-impl<'r> sqlx::FromRow<'r, sqlx::mysql::MySqlRow> for MediaTag {
-    fn from_row(row: &'r sqlx::mysql::MySqlRow) -> Result<Self, sqlx::Error> {
-        Self::decode_my(row)
-    }
-}
-#[cfg(feature = "sqlite")]
-impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for MediaTag {
-    fn from_row(row: &'r sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
-        Self::decode_sq(row)
-    }
-}
-
-// #561 — the pub(super) `is_mysql_dup_index_error` re-export here
-// was a shim for media::mod + media::collection that reached
-// across modules to dodge a 5th copy of the predicate. Both of
-// those callers now route through `crate::sql::run_ddl_idempotent`
-// (the shared DDL runner already swallows MySQL's dup-index
-// error), so the re-export has no remaining consumers.
-
-/// MySQL DATETIME(6) decoder — sqlx returns `NaiveDateTime` by default
-/// for `DATETIME` (no TZ); promote to `DateTime<Utc>` assuming the
-/// column is stored in UTC (matches the DEFAULT CURRENT_TIMESTAMP and
-/// every framework-side write).
-#[cfg(feature = "mysql")]
-pub(super) fn decode_my_datetime(
-    row: &sqlx::mysql::MySqlRow,
-    col: &str,
-) -> Result<DateTime<Utc>, sqlx::Error> {
-    use chrono::TimeZone as _;
-    use sqlx::Row;
-    let naive: chrono::NaiveDateTime = row.try_get(col)?;
-    Ok(Utc.from_utc_datetime(&naive))
-}
-
-/// MySQL nullable DATETIME(6) decoder.
-#[cfg(feature = "mysql")]
-pub(super) fn decode_my_datetime_opt(
-    row: &sqlx::mysql::MySqlRow,
-    col: &str,
-) -> Result<Option<DateTime<Utc>>, sqlx::Error> {
-    use chrono::TimeZone as _;
-    use sqlx::Row;
-    let naive: Option<chrono::NaiveDateTime> = row.try_get(col)?;
-    Ok(naive.map(|n| Utc.from_utc_datetime(&n)))
-}
-
-/// SQLite TEXT-as-ISO-8601 decoder.
-#[cfg(feature = "sqlite")]
-pub(super) fn decode_sqlite_datetime(
-    row: &sqlx::sqlite::SqliteRow,
-    col: &str,
-) -> Result<DateTime<Utc>, sqlx::Error> {
-    use sqlx::Row;
-    let s: String = row.try_get(col)?;
-    parse_sqlite_dt(&s)
-}
-
-/// SQLite nullable TEXT-as-ISO-8601 decoder.
-#[cfg(feature = "sqlite")]
-pub(super) fn decode_sqlite_datetime_opt(
-    row: &sqlx::sqlite::SqliteRow,
-    col: &str,
-) -> Result<Option<DateTime<Utc>>, sqlx::Error> {
-    use sqlx::Row;
-    let s: Option<String> = row.try_get(col)?;
-    s.map(|s| parse_sqlite_dt(&s)).transpose()
-}
-
-#[cfg(feature = "sqlite")]
-fn parse_sqlite_dt(s: &str) -> Result<DateTime<Utc>, sqlx::Error> {
-    DateTime::parse_from_rfc3339(s)
-        .or_else(|_| {
-            // SQLite's `strftime('%Y-%m-%dT%H:%M:%fZ', 'now')` emits
-            // `2026-05-12T14:30:42.123Z` which RFC3339 accepts. Some
-            // older writes used the bare `YYYY-MM-DD HH:MM:SS` form;
-            // try that as a fallback.
-            chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
-                .map(|n| n.and_utc().fixed_offset())
-        })
-        .map(|d| d.with_timezone(&Utc))
-        .map_err(|e| sqlx::Error::Decode(format!("sqlite datetime parse: {e} (got `{s}`)").into()))
+/// Junction row linking a [`Media`] to a [`MediaTag`] (the M2M table).
+///
+/// Carries a surrogate `Auto<i64>` PK so it's an ordinary managed model;
+/// the logical key is the composite `UNIQUE(media_id, tag_id)`.
+/// `MediaManager` raw-inserts only `(media_id, tag_id)` (relying on the
+/// unique index for idempotency, never on a returned id), so the surrogate
+/// PK is harmless.
+///
+/// [`Media`]: crate::media::Media
+#[derive(crate::Model, Debug, Clone)]
+#[rustango(
+    table = "rustango_media_tag_links",
+    unique_together = "media_id, tag_id"
+)]
+pub struct MediaTagLink {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub media_id: i64,
+    #[rustango(fk = "rustango_media_tags", on = "id", on_delete = "cascade")]
+    #[rustango(index)]
+    pub tag_id: i64,
 }

--- a/crates/rustango/src/migrate/ddl.rs
+++ b/crates/rustango/src/migrate/ddl.rs
@@ -329,11 +329,14 @@ fn write_column_def(s: &mut String, dialect: &dyn Dialect, field: &FieldSchema) 
         // `''` rather than nothing, or we emit `DEFAULT  NOT NULL` which the
         // driver rejects with `near "NOT": syntax error` (#1161). `''` is a
         // valid empty-string literal in Postgres, MySQL, and SQLite.
-        let rendered = if expr.is_empty() {
-            "''".to_owned()
-        } else {
-            dialect.translate_default_expr(expr, ty_name, field.max_length)
-        };
+        //
+        // Still route the `''` literal through `translate_default_expr` so a
+        // LOB column (MySQL TEXT/JSON/BLOB) gets the parenthesized
+        // expression form `DEFAULT ('')` it requires — MySQL rejects a
+        // *literal* default on those types (error 1101), only the 8.0.13+
+        // expression form is legal. PG/SQLite leave `''` untouched (#1174).
+        let expr_to_render = if expr.is_empty() { "''" } else { expr };
+        let rendered = dialect.translate_default_expr(expr_to_render, ty_name, field.max_length);
         let _ = write!(s, " DEFAULT {rendered}");
     }
     if !field.nullable {
@@ -550,6 +553,31 @@ mod tests {
                 dialect.name()
             );
         }
+    }
+
+    #[test]
+    fn empty_string_default_on_lob_uses_mysql_expression_form() {
+        // #1174 — an empty-string default on a MySQL LOB column (TEXT/JSON/
+        // BLOB, i.e. `String` with no `max_length`) must emit the
+        // parenthesized expression form `DEFAULT ('')`; MySQL rejects a
+        // *literal* default on those types (error 1101). PG/SQLite still emit
+        // the plain `DEFAULT ''` (they accept literal defaults on TEXT).
+        let f = fld("body", FieldType::String, false, Some("")); // no max_length → TEXT
+        #[cfg(feature = "mysql")]
+        {
+            let mut s = String::new();
+            write_column_def(&mut s, &crate::sql::MySql, &f);
+            assert!(
+                s.contains("DEFAULT ('')"),
+                "[mysql] LOB empty default must be paren-wrapped: {s}"
+            );
+        }
+        let mut s = String::new();
+        write_column_def(&mut s, &crate::sql::Postgres, &f);
+        assert!(
+            s.contains("DEFAULT ''") && !s.contains("DEFAULT ('')"),
+            "[postgres] LOB empty default stays a literal: {s}"
+        );
     }
 
     #[test]

--- a/crates/rustango/src/migrate/diff.rs
+++ b/crates/rustango/src/migrate/diff.rs
@@ -1254,12 +1254,7 @@ fn create_table_sql_from_snapshot_with_dialect(
             continue;
         }
         if let Some(expr) = &f.default {
-            // Empty-string default → literal `''`, not a blank (#1161).
-            let rendered = if expr.is_empty() {
-                "''".to_owned()
-            } else {
-                dialect.translate_default_expr(expr, &f.ty, f.max_length)
-            };
+            let rendered = render_column_default(expr, &f.ty, f.max_length, dialect);
             let _ = write!(sql, " DEFAULT {rendered}");
         }
         if !f.nullable {
@@ -1373,6 +1368,26 @@ fn constraints_sql_from_snapshot(
     out
 }
 
+/// Render a column `DEFAULT` expression for CREATE TABLE / ADD COLUMN.
+///
+/// An empty-string default (`#[rustango(default = "")]`) means the literal
+/// empty string — render it as `''` rather than a blank, or we emit
+/// `DEFAULT  NOT NULL` which the driver rejects (#1161). The `''` literal is
+/// then routed through [`Dialect::translate_default_expr`] like any other
+/// expression so a MySQL LOB column (TEXT/JSON/BLOB) gets the parenthesized
+/// expression form `DEFAULT ('')` it requires — MySQL rejects a *literal*
+/// default on those types (error 1101), only the 8.0.13+ expression form is
+/// legal. PG/SQLite leave `''` untouched (#1174).
+fn render_column_default(
+    expr: &str,
+    ty: &str,
+    max_length: Option<u32>,
+    dialect: &dyn crate::sql::Dialect,
+) -> String {
+    let expr_to_render = if expr.is_empty() { "''" } else { expr };
+    dialect.translate_default_expr(expr_to_render, ty, max_length)
+}
+
 fn add_column_sql(table: &str, f: &FieldSnapshot, dialect: &dyn crate::sql::Dialect) -> String {
     let col_q = dialect.quote_ident(&f.column);
     let mut sql = format!(
@@ -1382,12 +1397,7 @@ fn add_column_sql(table: &str, f: &FieldSnapshot, dialect: &dyn crate::sql::Dial
         sql_type_with_dialect(f, dialect)
     );
     if let Some(expr) = &f.default {
-        // Empty-string default → literal `''`, not a blank (#1161).
-        let rendered = if expr.is_empty() {
-            "''".to_owned()
-        } else {
-            dialect.translate_default_expr(expr, &f.ty, f.max_length)
-        };
+        let rendered = render_column_default(expr, &f.ty, f.max_length, dialect);
         let _ = write!(sql, " DEFAULT {rendered}");
     }
     if !f.nullable {

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -804,14 +804,6 @@ async fn migrate<W: Write>(
         return Ok(());
     }
 
-    // Framework media tables (`rustango_media` + collections/tags/links):
-    // created BEFORE any user migrations are applied, so a user model that
-    // FKs `rustango_media` applies cleanly — the same behavior the tenant
-    // provisioning path gives per-tenant. Idempotent (`CREATE TABLE IF NOT
-    // EXISTS`); only when the `media` feature is enabled.
-    #[cfg(feature = "media")]
-    crate::media::ensure_all_tables_pool(pool).await?;
-
     if let Some(target) = positional {
         let touched = runner::migrate_to_pool(pool, dir, target).await?;
         if touched.is_empty() {

--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -1367,8 +1367,8 @@ pub async fn raw_execute_tx(
 ///
 /// This is the canonical "ensure-this-DDL-applied" primitive for
 /// modules that ship hand-written per-dialect schema constants
-/// (`audit::ensure_table_pool`, `media::*::ensure_table`, the
-/// JSON-side `jobs::pg::ensure_jobs_table`, etc.). The non-MySQL
+/// (`audit::ensure_table_pool`, the JSON-side
+/// `jobs::pg::ensure_jobs_table`, etc.). The non-MySQL
 /// errors surface as [`sqlx::Error`] verbatim (driver-level); only
 /// the dup-index case is swallowed.
 ///

--- a/crates/rustango/src/tenancy/migrate.rs
+++ b/crates/rustango/src/tenancy/migrate.rs
@@ -429,7 +429,6 @@ where
     // migrations, which may FK into them (issue #1171).
     let mut applied =
         apply_system_migrations(&inner_pool, dir, crate::core::ModelScope::Tenant).await?;
-    ensure_media_tables(&inner_pool).await?;
     applied.extend(migrate::migrate_pool(&inner_pool, dir).await?);
     // Data seeders (rows, not DDL — kept): the CRUD permission codenames
     // for every registered model (#61) + the content-type catalog (#89).
@@ -468,24 +467,6 @@ where
     migrate_tenants_db(pools, dir, registry_url).await
 }
 
-/// Ensure the framework `media` subsystem tables (`rustango_media`,
-/// `rustango_media_collections`, `rustango_media_tags`) exist in a
-/// tenant's storage. Media is not yet part of the migration engine
-/// (#1174) — it ships idempotent `CREATE TABLE IF NOT EXISTS` DDL via
-/// [`crate::media::ensure_all_tables_pool`]. We run it here, AFTER the
-/// system migrations and BEFORE the tenant's user migrations, so a tenant
-/// model that FKs `rustango_media` applies cleanly on a fresh tenant.
-/// No-op unless the `media` feature is enabled.
-async fn ensure_media_tables(pool: &crate::sql::Pool) -> Result<(), TenancyError> {
-    #[cfg(feature = "media")]
-    crate::media::ensure_all_tables_pool(pool)
-        .await
-        .map_err(|e| TenancyError::Validation(format!("media table ensure failed: {e}")))?;
-    #[cfg(not(feature = "media"))]
-    let _ = pool;
-    Ok(())
-}
-
 #[cfg(feature = "postgres")]
 async fn run_for_one_tenant(
     pools: &TenantPools,
@@ -511,7 +492,6 @@ async fn run_for_one_tenant(
             let dbpool: crate::sql::Pool = pool.clone().into();
             let mut applied =
                 apply_system_migrations(&dbpool, dir, crate::core::ModelScope::Tenant).await?;
-            ensure_media_tables(&dbpool).await?;
             applied.extend(migrate::migrate(&pool, dir).await?);
             // Data seeders (rows, not DDL — kept): CRUD permission
             // codenames for every registered model (#61) + the
@@ -531,7 +511,6 @@ async fn run_for_one_tenant(
             let dbpool: crate::sql::Pool = tenant_pool.pool().clone().into();
             let mut applied =
                 apply_system_migrations(&dbpool, dir, crate::core::ModelScope::Tenant).await?;
-            ensure_media_tables(&dbpool).await?;
             applied.extend(migrate::migrate(tenant_pool.pool(), dir).await?);
             // Data seeders (rows, not DDL — kept): #61 + #89.
             if let Err(e) = super::permissions::auto_create_permissions(tenant_pool.pool()).await {

--- a/crates/rustango/src/testkit.rs
+++ b/crates/rustango/src/testkit.rs
@@ -143,7 +143,10 @@ async fn emit_tables(pool: &Pool, models: &[&'static ModelSchema]) -> Result<(),
 ///
 /// # Errors
 /// Any generation or apply failure ([`MigrateError`]).
-#[cfg(feature = "tenancy")]
+///
+/// Available in any build (not just `tenancy`) — the `media` subsystem's
+/// tests use it to materialize the media tables from the migration render
+/// path with no `tenancy` feature.
 pub async fn migrate_framework(pool: &Pool) -> Result<(), MigrateError> {
     // Deduped snapshot of every framework (`rustango_*`) table — the
     // shared audit/content_types tables appear once — materialized in one

--- a/crates/rustango/tests/media_collections_tags_live.rs
+++ b/crates/rustango/tests/media_collections_tags_live.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "postgres")]
+#![cfg(all(feature = "postgres", feature = "media", feature = "testkit"))]
 //! Live integration tests for `MediaCollection` + `MediaTag` + the
 //! axum router. Same env-var contract as `media_live.rs` — skips
 //! silently when DATABASE_URL or RUSTANGO_S3_TEST_* are unset.
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use rustango::media::router::media_router;
-use rustango::media::{ensure_all_tables, MediaManager, SaveOpts};
+use rustango::media::{MediaManager, SaveOpts};
 use rustango::storage::s3::{S3Config, S3Storage};
 use rustango::storage::{BoxedStorage, StorageRegistry};
 use sqlx::PgPool;
@@ -25,7 +25,9 @@ async fn maybe_setup() -> Option<MediaManager> {
     let region = std::env::var("RUSTANGO_S3_TEST_REGION").unwrap_or_else(|_| "us-east-1".into());
 
     let pool = PgPool::connect(&url).await.expect("connect Postgres");
-    ensure_all_tables(&pool).await.expect("ensure_all_tables");
+    rustango::testkit::migrate_framework(&rustango::sql::Pool::Postgres(pool.clone()))
+        .await
+        .expect("migrate framework media tables");
     // Wipe between runs — every test gets a clean slate.
     sqlx::query("DELETE FROM rustango_media_tag_links")
         .execute(&pool)
@@ -751,19 +753,21 @@ async fn router_collection_contents_with_recursive_query() {
 }
 
 #[tokio::test]
-async fn ensure_all_tables_works_against_running_db() {
+async fn migrate_framework_is_idempotent_against_running_db() {
     let Some(_manager) = maybe_setup().await else {
         return;
     };
-    // The setup helper already calls ensure_all_tables; a second
-    // call must be a no-op (idempotent DDL).
+    // The setup helper already ran migrate_framework; a second call must be
+    // a no-op (it swallows "already exists" errors on a fresh-then-reapplied
+    // schema).
     let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
         .await
         .unwrap();
-    rustango::media::ensure_all_tables(&pool)
+    let pool_enum = rustango::sql::Pool::Postgres(pool);
+    rustango::testkit::migrate_framework(&pool_enum)
         .await
-        .expect("ensure_all_tables idempotent");
-    rustango::media::ensure_all_tables(&pool)
+        .expect("migrate_framework idempotent");
+    rustango::testkit::migrate_framework(&pool_enum)
         .await
-        .expect("ensure_all_tables called twice");
+        .expect("migrate_framework called twice");
 }

--- a/crates/rustango/tests/media_live.rs
+++ b/crates/rustango/tests/media_live.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "postgres")]
+#![cfg(all(feature = "postgres", feature = "media", feature = "testkit"))]
 //! Live integration tests for `MediaManager` against Postgres + an
 //! S3-compatible bucket.
 //!
@@ -20,7 +20,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use rustango::media::{Media, MediaManager, MediaStatus, SaveOpts, UploadIntent};
+use rustango::media::{MediaManager, MediaStatus, SaveOpts, UploadIntent};
 use rustango::storage::s3::{S3Config, S3Storage};
 use rustango::storage::{BoxedStorage, StorageRegistry};
 use sqlx::PgPool;
@@ -36,7 +36,9 @@ async fn maybe_setup() -> Option<MediaManager> {
     let region = std::env::var("RUSTANGO_S3_TEST_REGION").unwrap_or_else(|_| "us-east-1".into());
 
     let pool = PgPool::connect(&url).await.expect("connect Postgres");
-    Media::ensure_table(&pool).await.expect("ensure_table");
+    rustango::testkit::migrate_framework(&rustango::sql::Pool::Postgres(pool.clone()))
+        .await
+        .expect("migrate framework media tables");
     // Wipe between runs so each test sees a clean slate.
     sqlx::query("DELETE FROM rustango_media")
         .execute(&pool)

--- a/crates/rustango/tests/media_live_seed.rs
+++ b/crates/rustango/tests/media_live_seed.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "postgres")]
+#![cfg(all(feature = "postgres", feature = "media", feature = "testkit"))]
 //! `#[ignore]`-d helper that creates visible Media rows + S3
 //! objects via `MediaManager`, leaves everything behind for
 //! inspection.
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use rustango::media::{Media, MediaManager, SaveOpts, UploadIntent};
+use rustango::media::{MediaManager, SaveOpts, UploadIntent};
 use rustango::storage::s3::{S3Config, S3Storage};
 use rustango::storage::{BoxedStorage, StorageRegistry};
 use sqlx::PgPool;
@@ -31,7 +31,9 @@ async fn seed_media_rows_for_inspection() {
     let region = std::env::var("RUSTANGO_S3_TEST_REGION").unwrap_or_else(|_| "us-east-1".into());
 
     let pool = PgPool::connect(&url).await.expect("connect");
-    Media::ensure_table(&pool).await.expect("ensure_table");
+    rustango::testkit::migrate_framework(&rustango::sql::Pool::Postgres(pool.clone()))
+        .await
+        .expect("migrate framework media tables");
 
     let storage: BoxedStorage = Arc::new(S3Storage::new(S3Config {
         bucket,

--- a/crates/rustango/tests/media_sqlite_live.rs
+++ b/crates/rustango/tests/media_sqlite_live.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "sqlite", feature = "media"))]
+#![cfg(all(feature = "sqlite", feature = "media", feature = "testkit"))]
 //! Live integration test for the tri-dialect MediaManager on SQLite.
 //!
 //! v0.38 slice 29 — every MediaManager query is dispatched per
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use rustango::media::{ensure_all_tables_pool, MediaManager, SaveOpts};
+use rustango::media::{MediaManager, SaveOpts};
 use rustango::sql::Pool;
 use rustango::storage::{InMemoryStorage, StorageRegistry};
 
@@ -24,9 +24,9 @@ async fn manager() -> MediaManager {
         .await
         .expect("sqlite connect");
     let pool_enum = Pool::Sqlite(pool);
-    ensure_all_tables_pool(&pool_enum)
+    rustango::testkit::migrate_framework(&pool_enum)
         .await
-        .expect("ensure media tables");
+        .expect("migrate framework media tables");
     let registry = StorageRegistry::new()
         .set("default", Arc::new(InMemoryStorage::new()))
         .with_default("default");


### PR DESCRIPTION
Converts the media subsystem (`Media`/`MediaCollection`/`MediaTag` + the `rustango_media_tag_links` junction) from the legacy lazy `ensure_table` raw-DDL pattern to managed `#[derive(Model)]`s emitted through the `#[cfg]`-aware system-migration engine — the same transform as agents (#1178). Removes the ensure layer + the 0.49.2 `ensure_media_tables` hook; adds a `MediaTagLink` model.

Also fixes a latent framework bug this is the first to hit: empty-string defaults on MySQL LOB columns (`TEXT`/`JSON`) were emitted as literal `DEFAULT ''` (MySQL error 1101) — now routed through the LOB expression form `DEFAULT ('')`.

Includes the 0.51.0 version bump + CHANGELOG.

Verified: tri-dialect builds; media_sqlite_live; live MySQL migrate_framework round-trip; `--all-features --no-run`; MySQL DDL live suite; and live adoption by ironbar (with media), rcms-blog + rustangodocs (without media).

Carries the #1167 reconcile caveat for pre-existing ensure'd deployments.