### PR TITLE
fix(migrate): auto-reconcile pre-existing framework tables (fake-initial) + 0.51.1 (#1167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 _Nothing yet — next development cycle._
 
+## [0.51.1] — 2026-08-06
+
+Headline: **the media upgrade is now automatic** — the collision that 0.51.0's
+upgrade note warned about (existing `ensure_table`-era media tables vs the new
+system migration) is reconciled during provisioning, with no operator action.
+
+### Fixed
+
+- **Auto-reconcile pre-existing framework tables on provision** (#1167) — the
+  system-migration runner now performs a guarded **fake-initial**: a pending
+  migration that is _purely_ `CreateTable` operations whose tables **all
+  already exist** is recorded in the `__rustango_system_migrations__` ledger
+  _without_ running its `CREATE TABLE`, then the chain continues. This is the
+  upgrade path for a deployment whose media tables were built by the retired
+  `ensure_table` DDL (pre-0.51): the first `migrate` / tenant provision after
+  upgrading no longer fails with `relation already exists` (Postgres 42P07) /
+  `table already exists` (MySQL 1050) / `table … already exists` (SQLite), and
+  **existing data is left untouched**. The guard is narrow — it is scoped to
+  the framework's own system migrations (user migrations use the plain runner
+  and never auto-fake), a migration with any non-`CreateTable` operation is
+  never faked, and a _partial_ pre-existing state falls through to the runner
+  so a genuine inconsistency still surfaces loudly rather than being papered
+  over. Closes the reconcile follow-up from #1174 / #1178.
+
 ## [0.51.0] — 2026-08-06
 
 Headline: **the media subsystem is now managed by system migrations** — the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.51.0"
+version = "0.51.1"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.51.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.51.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.51.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.51.1", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.51.1", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.51.1", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.51.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.51.1" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -405,7 +405,7 @@ runserver = ["dep:axum", "dep:tokio"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.51.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.51.1", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }

--- a/crates/rustango/src/migrate/mod.rs
+++ b/crates/rustango/src/migrate/mod.rs
@@ -53,6 +53,7 @@ pub use make::{
 #[cfg(feature = "postgres")]
 pub use manage::{append_data_op, make_data_migration};
 pub use runner::migrate_pool_with_ledger;
+pub use runner::migrate_pool_with_ledger_fake_initial;
 // Always-on: tri-dialect entry points (work on PG / MySQL / SQLite via
 // the `Pool` enum), plus the inventory + builder surface.
 pub use runner::{

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -1406,6 +1406,47 @@ pub async fn migrate_pool_with_ledger(
     dir: &Path,
     ledger: &str,
 ) -> Result<Vec<Migration>, MigrateError> {
+    migrate_pool_with_ledger_opts(pool, dir, ledger, false).await
+}
+
+/// Like [`migrate_pool_with_ledger`], but with **guarded fake-initial**
+/// reconciliation (#1167): before applying, any pending migration that
+/// is *purely* table-creation (`CreateTable` ops only) whose tables
+/// **all already exist** is recorded in the ledger *without running its
+/// SQL*. This is the upgrade path for a subsystem that used to build
+/// its tables via the lazy `ensure_table` DDL and is now managed by a
+/// system migration: on the first `migrate` after the upgrade, the
+/// freshly-generated `CREATE TABLE` would otherwise collide with the
+/// already-present table. Faking it records the migration as applied so
+/// the chain moves on; existing data is untouched.
+///
+/// Scoped to the framework's own system-migration apply path (see
+/// [`crate::tenancy`] provisioning) — user migrations go through the
+/// plain [`migrate_pool_with_ledger`] and never auto-fake. The guard is
+/// deliberately narrow: a migration with *any* non-`CreateTable`
+/// operation (a column add, a data backfill, a callback) is never
+/// faked, and a create-migration is faked only when **every** table it
+/// creates is already present (a partial state falls through to the
+/// runner, which surfaces the collision loudly rather than papering
+/// over it).
+///
+/// # Errors
+/// As [`migrate_pool_with_ledger`], plus a ledger-insert failure while
+/// recording a faked migration.
+pub async fn migrate_pool_with_ledger_fake_initial(
+    pool: &crate::sql::Pool,
+    dir: &Path,
+    ledger: &str,
+) -> Result<Vec<Migration>, MigrateError> {
+    migrate_pool_with_ledger_opts(pool, dir, ledger, true).await
+}
+
+async fn migrate_pool_with_ledger_opts(
+    pool: &crate::sql::Pool,
+    dir: &Path,
+    ledger: &str,
+    fake_initial: bool,
+) -> Result<Vec<Migration>, MigrateError> {
     ensure_ledger_pool_with_ledger(pool, ledger).await?;
     with_migrate_lock_pool(pool, async {
         let all = file::list_dir(dir)?;
@@ -1417,6 +1458,25 @@ pub async fn migrate_pool_with_ledger(
 
         let mut newly = Vec::with_capacity(pending.len());
         for mig in pending {
+            // Fake-initial reconcile (#1167): a pure-`CreateTable`
+            // migration whose tables all already exist is recorded
+            // without running — the ensure→system-migration upgrade path.
+            if fake_initial {
+                if let Some(tables) = create_only_tables(&mig) {
+                    if all_tables_exist(pool, &tables).await {
+                        record_fake_applied(pool, &mig, ledger).await?;
+                        tracing::warn!(
+                            migration = %mig.name,
+                            tables = %tables.join(", "),
+                            "fake-initial: tables already exist (pre-migration \
+                             `ensure_table` era) — recorded as applied without \
+                             running its CREATE TABLE; existing data left intact"
+                        );
+                        newly.push(mig);
+                        continue;
+                    }
+                }
+            }
             if mig.atomic {
                 apply_atomic_pool(pool, &mig, ledger).await?;
             } else {
@@ -1427,6 +1487,70 @@ pub async fn migrate_pool_with_ledger(
         Ok(newly)
     })
     .await
+}
+
+/// If every operation in `mig` is a `CreateTable` schema change, return
+/// the tables it creates; otherwise `None`. Only such "initial"
+/// pure-table-creation migrations are eligible for fake-initial
+/// reconciliation — anything with a column add / data op / callback is
+/// excluded so we never skip a real side effect.
+fn create_only_tables(mig: &Migration) -> Option<Vec<String>> {
+    let mut tables = Vec::new();
+    for op in &mig.forward {
+        match op {
+            Operation::Schema(super::diff::SchemaChange::CreateTable(t)) => tables.push(t.clone()),
+            _ => return None,
+        }
+    }
+    (!tables.is_empty()).then_some(tables)
+}
+
+/// `true` when every table in `tables` already exists in `pool`. Uses
+/// `SELECT 1 FROM <t> LIMIT 1` so the name resolves through exactly the
+/// same search_path / current-database rules the migration's own
+/// `CREATE TABLE` would use (unqualified — correct for schema-mode
+/// tenants and single-DB alike).
+async fn all_tables_exist(pool: &crate::sql::Pool, tables: &[String]) -> bool {
+    let dialect = pool.dialect();
+    for t in tables {
+        let sql = format!("SELECT 1 FROM {} LIMIT 1", dialect.quote_ident(t));
+        if crate::sql::raw_execute_pool(pool, &sql, Vec::new())
+            .await
+            .is_err()
+        {
+            return false;
+        }
+    }
+    true
+}
+
+/// Insert a migration's name into `ledger` without running its SQL
+/// (idempotent — an existing row is left untouched). Mirrors the
+/// bookkeeping the normal apply path performs on success.
+async fn record_fake_applied(
+    pool: &crate::sql::Pool,
+    mig: &Migration,
+    ledger: &str,
+) -> Result<(), MigrateError> {
+    let dialect = pool.dialect();
+    let placeholder = dialect.placeholder(1);
+    let table = dialect.quote_ident(ledger);
+    let name_col = dialect.quote_ident("name");
+    let conflict_tail = dialect.insert_on_conflict_skip(&[&name_col]);
+    let sql = format!("INSERT INTO {table} ({name_col}) VALUES ({placeholder}) {conflict_tail}");
+    crate::sql::raw_execute_pool(
+        pool,
+        &sql,
+        vec![crate::core::SqlValue::String(mig.name.clone())],
+    )
+    .await
+    .map(|_| ())
+    .map_err(|e| {
+        MigrateError::Validation(format!(
+            "fake-initial: ledger insert for `{}` failed: {e}",
+            mig.name
+        ))
+    })
 }
 
 /// Hold the migrate session-scoped advisory lock while `body` runs,

--- a/crates/rustango/src/tenancy/migrate.rs
+++ b/crates/rustango/src/tenancy/migrate.rs
@@ -137,15 +137,28 @@ async fn apply_system_migrations(
         crate::core::ModelScope::Registry => MigrationScope::Registry,
         crate::core::ModelScope::Tenant => MigrationScope::Tenant,
     };
+    // Fake-initial reconcile (#1167): a subsystem that used to build its
+    // tables via lazy `ensure_table` DDL (e.g. media before 0.51) now ships
+    // them as a system migration. On the first `migrate` after the upgrade
+    // the freshly-generated `CREATE TABLE` would collide with the
+    // already-present table — so the system-migration runner records such a
+    // pure-`CreateTable`-of-existing-tables migration as applied without
+    // running it. Scoped to the framework's own tables; user migrations use
+    // the plain runner.
     let applied = match scoped_subset(&system_dir, migration_scope).await? {
         ScopedDir::Owned(temp) => {
-            let r =
-                crate::migrate::migrate_pool_with_ledger(pool, temp.path(), SYSTEM_LEDGER).await?;
+            let r = crate::migrate::migrate_pool_with_ledger_fake_initial(
+                pool,
+                temp.path(),
+                SYSTEM_LEDGER,
+            )
+            .await?;
             drop(temp);
             r
         }
         ScopedDir::Original => {
-            crate::migrate::migrate_pool_with_ledger(pool, &system_dir, SYSTEM_LEDGER).await?
+            crate::migrate::migrate_pool_with_ledger_fake_initial(pool, &system_dir, SYSTEM_LEDGER)
+                .await?
         }
     };
     Ok(applied)

--- a/crates/rustango/tests/migrate_fake_initial_mysql_live.rs
+++ b/crates/rustango/tests/migrate_fake_initial_mysql_live.rs
@@ -1,0 +1,98 @@
+#![cfg(all(feature = "mysql", feature = "tenancy"))]
+//! Fake-initial reconcile on live MySQL (#1167 / #1174).
+//!
+//! Reads `MYSQL_TEST_URL`; skips silently when unset. Proves the
+//! ensure→system-migration upgrade path on the strict dialect: a
+//! pre-existing (ensure-era) table is reconciled by recording the
+//! generated `CREATE TABLE` migration without running it — no collision,
+//! existing data intact.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use rustango::migrate::{self, file, Migration, Operation, SchemaChange, SchemaSnapshot, TableSnapshot};
+use rustango::sql::sqlx::{self, Row};
+use rustango::sql::Pool;
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+const LEDGER: &str = "__rustango_system_migrations__";
+
+fn snapshot_with_table(table: &str) -> SchemaSnapshot {
+    let t: TableSnapshot = serde_json::from_value(serde_json::json!({
+        "name": table,
+        "model": "T",
+        "fields": [
+            {"name": "id", "column": "id", "ty": "i64", "nullable": false, "primary_key": true}
+        ]
+    }))
+    .unwrap();
+    SchemaSnapshot { tables: vec![t], ..Default::default() }
+}
+
+fn write_dir(m: &Migration) -> PathBuf {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let mut dir = std::env::temp_dir();
+    dir.push(format!("rustango_fakeinit_my_{}_{n}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    file::write(&dir.join(format!("{}.json", m.name)), m).unwrap();
+    dir
+}
+
+#[tokio::test]
+async fn fake_initial_reconciles_existing_table_on_mysql() {
+    let Ok(url) = std::env::var("MYSQL_TEST_URL") else {
+        eprintln!("skipping — set MYSQL_TEST_URL");
+        return;
+    };
+    let my = sqlx::MySqlPool::connect(&url).await.expect("connect mysql");
+    let pool = Pool::Mysql(my.clone());
+
+    // Unique names so parallel/rerun don't collide on the shared DB + ledger.
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let table = format!("recon_media_{}_{n}", std::process::id());
+    let name = format!("9{n:03}_create_{table}");
+
+    // Clean slate.
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{table}`")).execute(&my).await.unwrap();
+    let _ = sqlx::query(&format!("DELETE FROM {LEDGER} WHERE name = ?")).bind(&name).execute(&my).await;
+
+    let m = Migration {
+        name: name.clone(),
+        created_at: "2026-08-06T00:00:00Z".into(),
+        prev: None,
+        atomic: true,
+        scope: migrate::MigrationScope::default(),
+        snapshot: snapshot_with_table(&table),
+        forward: vec![Operation::Schema(SchemaChange::CreateTable(table.clone()))],
+    };
+    let dir = write_dir(&m);
+
+    // Simulate the old ensure_table era: table already present, with data.
+    sqlx::query(&format!("CREATE TABLE `{table}` (id BIGINT PRIMARY KEY, note VARCHAR(64))"))
+        .execute(&my).await.unwrap();
+    sqlx::query(&format!("INSERT INTO `{table}` (id, note) VALUES (1, 'pre-existing')"))
+        .execute(&my).await.unwrap();
+
+    // The reconcile: no "table already exists" (MySQL 1050); faked instead.
+    let applied = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER)
+        .await
+        .expect("fake-initial must not collide on MySQL");
+    assert_eq!(applied.len(), 1);
+
+    // Recorded in the ledger.
+    let recorded: i64 = sqlx::query(&format!("SELECT COUNT(*) AS c FROM {LEDGER} WHERE name = ?"))
+        .bind(&name).fetch_one(&my).await.unwrap().try_get("c").unwrap();
+    assert_eq!(recorded, 1, "faked migration must be in the ledger");
+
+    // Data intact — the CREATE never ran.
+    let note: String = sqlx::query(&format!("SELECT note FROM `{table}` WHERE id = 1"))
+        .fetch_one(&my).await.unwrap().try_get("note").unwrap();
+    assert_eq!(note, "pre-existing");
+
+    // Cleanup.
+    let _ = sqlx::query(&format!("DROP TABLE IF EXISTS `{table}`")).execute(&my).await;
+    let _ = sqlx::query(&format!("DELETE FROM {LEDGER} WHERE name = ?")).bind(&name).execute(&my).await;
+    let _ = std::fs::remove_dir_all(&dir);
+    println!("MySQL fake-initial reconcile OK");
+}

--- a/crates/rustango/tests/migrate_fake_initial_sqlite_live.rs
+++ b/crates/rustango/tests/migrate_fake_initial_sqlite_live.rs
@@ -1,0 +1,187 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! Fake-initial reconcile for system migrations (#1167 / #1174).
+//!
+//! When a subsystem that used to build its tables via lazy `ensure_table`
+//! DDL becomes managed by a system migration, the first `migrate` after the
+//! upgrade must NOT fail on the freshly-generated `CREATE TABLE` colliding
+//! with the already-present table. `migrate_pool_with_ledger_fake_initial`
+//! records such a pure-`CreateTable`-of-existing-tables migration as applied
+//! without running it, leaving existing data intact.
+//!
+//! SQLite + a temp file (so every pool connection sees the same DB).
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use rustango::migrate::{self, file, Migration, Operation, SchemaChange, SchemaSnapshot, TableSnapshot};
+use rustango::sql::sqlx::{self, Row};
+use rustango::sql::Pool;
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+const LEDGER: &str = "__rustango_system_migrations__";
+
+async fn sqlite_pool() -> (Pool, PathBuf) {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let mut path = std::env::temp_dir();
+    path.push(format!("rustango_fakeinit_{}_{n}.db", std::process::id()));
+    let _ = std::fs::remove_file(&path);
+    let url = format!("sqlite:{}?mode=rwc", path.display());
+    let sq = sqlx::SqlitePool::connect(&url).await.expect("connect sqlite");
+    (Pool::Sqlite(sq), path)
+}
+
+fn snapshot_with_table(table: &str) -> SchemaSnapshot {
+    let t: TableSnapshot = serde_json::from_value(serde_json::json!({
+        "name": table,
+        "model": "T",
+        "fields": [
+            {"name": "id", "column": "id", "ty": "i64", "nullable": false, "primary_key": true}
+        ]
+    }))
+    .unwrap();
+    SchemaSnapshot { tables: vec![t], ..Default::default() }
+}
+
+fn snapshot_with_tables(tables: &[&str]) -> SchemaSnapshot {
+    let ts = tables
+        .iter()
+        .map(|table| {
+            serde_json::from_value(serde_json::json!({
+                "name": table,
+                "model": "T",
+                "fields": [
+                    {"name": "id", "column": "id", "ty": "i64", "nullable": false, "primary_key": true}
+                ]
+            }))
+            .unwrap()
+        })
+        .collect();
+    SchemaSnapshot { tables: ts, ..Default::default() }
+}
+
+fn mig(name: &str, snapshot: SchemaSnapshot, forward: Vec<Operation>) -> Migration {
+    Migration {
+        name: name.to_owned(),
+        created_at: "2026-08-06T00:00:00Z".into(),
+        prev: None,
+        atomic: true,
+        scope: migrate::MigrationScope::default(),
+        snapshot,
+        forward,
+    }
+}
+
+fn write_dir(mig: &Migration) -> PathBuf {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let mut dir = std::env::temp_dir();
+    dir.push(format!("rustango_fakeinit_dir_{}_{n}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    file::write(&dir.join(format!("{}.json", mig.name)), mig).unwrap();
+    dir
+}
+
+async fn ledger_has(pool: &Pool, name: &str) -> bool {
+    let Pool::Sqlite(sq) = pool else { unreachable!() };
+    let count: i64 = sqlx::query(&format!("SELECT COUNT(*) AS c FROM {LEDGER} WHERE name = ?"))
+        .bind(name)
+        .fetch_one(sq)
+        .await
+        .unwrap()
+        .try_get("c")
+        .unwrap();
+    count > 0
+}
+
+fn cleanup(pool: Pool, path: &Path, dir: &Path) {
+    drop(pool);
+    let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+/// The reconcile case: a pure-`CreateTable` migration whose table already
+/// exists (with data) is faked — recorded in the ledger, its `CREATE TABLE`
+/// never run, the existing row untouched.
+#[tokio::test]
+async fn fake_initial_records_without_running_when_table_exists() {
+    let (pool, path) = sqlite_pool().await;
+    let table = "recon_media";
+    let name = "0004_create_recon_media";
+    let m = mig(name, snapshot_with_table(table), vec![Operation::Schema(SchemaChange::CreateTable(table.into()))]);
+    let dir = write_dir(&m);
+
+    // Simulate the old `ensure_table` era: the table already exists, with data.
+    let Pool::Sqlite(sq) = &pool else { unreachable!() };
+    sqlx::query(&format!("CREATE TABLE {table} (id INTEGER PRIMARY KEY, note TEXT)"))
+        .execute(sq).await.unwrap();
+    sqlx::query(&format!("INSERT INTO {table} (id, note) VALUES (1, 'pre-existing')"))
+        .execute(sq).await.unwrap();
+
+    let applied = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER)
+        .await
+        .expect("fake-initial should succeed, not collide");
+    assert_eq!(applied.len(), 1, "migration should be resolved (faked)");
+    assert!(ledger_has(&pool, name).await, "faked migration must be recorded in the ledger");
+
+    // The pre-existing row survived — the CREATE never ran and no data was lost.
+    let note: String = sqlx::query(&format!("SELECT note FROM {table} WHERE id = 1"))
+        .fetch_one(sq).await.unwrap().try_get("note").unwrap();
+    assert_eq!(note, "pre-existing");
+
+    // Idempotent: a second run is a no-op (already in ledger).
+    let again = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER).await.unwrap();
+    assert!(again.is_empty(), "second run has nothing pending");
+
+    cleanup(pool, &path, &dir);
+}
+
+/// Control: a pure-`CreateTable` migration whose table does NOT exist runs
+/// normally (fake-initial doesn't suppress a genuine creation).
+#[tokio::test]
+async fn fake_initial_creates_normally_when_table_absent() {
+    let (pool, path) = sqlite_pool().await;
+    let table = "recon_fresh";
+    let name = "0001_create_recon_fresh";
+    let m = mig(name, snapshot_with_table(table), vec![Operation::Schema(SchemaChange::CreateTable(table.into()))]);
+    let dir = write_dir(&m);
+
+    let applied = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER).await.unwrap();
+    assert_eq!(applied.len(), 1);
+    assert!(ledger_has(&pool, name).await);
+
+    // The table was actually created (a real INSERT works).
+    let Pool::Sqlite(sq) = &pool else { unreachable!() };
+    sqlx::query(&format!("INSERT INTO {table} (id) VALUES (1)")).execute(sq).await
+        .expect("table should have been created by the runner");
+
+    cleanup(pool, &path, &dir);
+}
+
+/// Guard: a migration whose tables only PARTIALLY exist is NOT faked — it
+/// falls through to the runner and surfaces the collision loudly rather than
+/// silently skipping a table that still needs creating.
+#[tokio::test]
+async fn fake_initial_does_not_fake_partial_existence() {
+    let (pool, path) = sqlite_pool().await;
+    let (t1, t2) = ("recon_a", "recon_b");
+    let name = "0002_create_recon_a_and_recon_b";
+    let m = mig(
+        name,
+        snapshot_with_tables(&[t1, t2]),
+        vec![
+            Operation::Schema(SchemaChange::CreateTable(t1.into())),
+            Operation::Schema(SchemaChange::CreateTable(t2.into())),
+        ],
+    );
+    let dir = write_dir(&m);
+
+    // Only t1 pre-exists → not all tables exist → must not fake.
+    let Pool::Sqlite(sq) = &pool else { unreachable!() };
+    sqlx::query(&format!("CREATE TABLE {t1} (id INTEGER PRIMARY KEY)")).execute(sq).await.unwrap();
+
+    let res = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER).await;
+    assert!(res.is_err(), "partial existence must fall through to the runner and collide, not fake");
+    assert!(!ledger_has(&pool, name).await, "a non-faked, failed migration must not be recorded");
+
+    cleanup(pool, &path, &dir);
+}

--- a/docs/files.md
+++ b/docs/files.md
@@ -188,6 +188,24 @@ It also handles soft-delete and orphan purging. The full flow is dogfooded in
 `media_sqlite_live.rs`; the manager's presigned/direct-upload methods are
 PostgreSQL-oriented.
 
+### How the media tables are created
+
+The media tables (`rustango_media`, `rustango_media_collections`,
+`rustango_media_tags`, `rustango_media_tag_links`) are managed models. Their
+schema ships as a **system migration** and is created — per tenant, when the
+`media` feature is enabled — the same way as the rest of the framework's own
+tables, whenever you run `migrate` / provision a tenant. There is no lazy
+"create on first use" step; if the feature is off, the tables are never created.
+
+> **Upgrading from before 0.51.** Earlier versions created the media tables
+> lazily via an `ensure_table` DDL call rather than a migration. On the first
+> `migrate` (or tenant provision) after upgrading, the framework **auto-reconciles**:
+> because the tables already exist, the generated media migration is recorded in
+> the system-migration ledger *without* re-running its `CREATE TABLE`, and your
+> existing rows are left untouched. **No manual step is required** — the upgrade
+> that would otherwise fail with `relation already exists` / `table already exists`
+> now just works. (Introduced in 0.51.1; see the CHANGELOG.)
+
 ---
 
 ## Reference


### PR DESCRIPTION
Closes the #1174/#1178 upgrade follow-up (#1167). System-migration provisioning now records a pure-`CreateTable` migration whose tables **all already exist** in the ledger *without* running its `CREATE TABLE`, so a deployment whose media tables were built by the retired `ensure_table` DDL no longer collides on the first post-upgrade `migrate` (PG 42P07 / MySQL 1050 / SQLite). Existing data untouched.

Guard is narrow: scoped to the framework's own system migrations (user migrations use the plain runner); a migration with any non-`CreateTable` op is never faked; a partially-existing state falls through to the runner so real inconsistencies still surface.

Tests: 3 sqlite cases (reconcile / normal-create / partial-guard) + a live MySQL reconcile. Docs: CHANGELOG [0.51.1] + files.md upgrade notice.