### PR TITLE
feat(viewset): principal-aware filter backends that scope every action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 _Nothing yet — next development cycle._
 
+## [0.51.1] — 2026-08-06
+
+Headline: **the media upgrade is now automatic** — the collision that 0.51.0's
+upgrade note warned about (existing `ensure_table`-era media tables vs the new
+system migration) is reconciled during provisioning, with no operator action.
+
+### Fixed
+
+- **Auto-reconcile pre-existing framework tables on provision** (#1167) — the
+  system-migration runner now performs a guarded **fake-initial**: a pending
+  migration that is _purely_ `CreateTable` operations whose tables **all
+  already exist** is recorded in the `__rustango_system_migrations__` ledger
+  _without_ running its `CREATE TABLE`, then the chain continues. This is the
+  upgrade path for a deployment whose media tables were built by the retired
+  `ensure_table` DDL (pre-0.51): the first `migrate` / tenant provision after
+  upgrading no longer fails with `relation already exists` (Postgres 42P07) /
+  `table already exists` (MySQL 1050) / `table … already exists` (SQLite), and
+  **existing data is left untouched**. The guard is narrow — it is scoped to
+  the framework's own system migrations (user migrations use the plain runner
+  and never auto-fake), a migration with any non-`CreateTable` operation is
+  never faked, and a _partial_ pre-existing state falls through to the runner
+  so a genuine inconsistency still surfaces loudly rather than being papered
+  over. Closes the reconcile follow-up from #1174 / #1178.
+
 ## [0.51.0] — 2026-08-06
 
 Headline: **the media subsystem is now managed by system migrations** — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 _Nothing yet — next development cycle._
 
+## [0.52.0] — 2026-08-08
+
+Headline: **filter backends are principal-aware, and they scope every action**
+— the two things standing between a `ViewSet` and a safe per-user API.
+
+### Added
+
+- **`ViewSetFilter::filter_with(&Parts, params, schema)`** — a default-provided
+  companion to `filter` that receives the request `Parts`, so a backend can read
+  the authenticated principal out of the extensions. `filter` alone sees only
+  the query string, which means "only this user's rows" could not be written at
+  all. The default delegates to `filter`, so every existing backend — including
+  the plain closure form — compiles and behaves exactly as before.
+
+### Fixed
+
+- **Filter backends now scope `retrieve` / `update` / `destroy`, not just
+  `list`** — DRF's `get_queryset()` contract. Scoping the collection alone is
+  worse than not scoping: it reads as safe while every row stays reachable by
+  id. A row excluded by a backend is now a **404** on those actions (not a 403,
+  which would confirm the id exists), an `UPDATE` that matches nothing returns
+  404 rather than reporting success, and the read-back after an update is
+  scoped too.
+
 ## [0.51.1] — 2026-08-06
 
 Headline: **the media upgrade is now automatic** — the collision that 0.51.0's

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.51.0"
+version = "0.51.1"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.51.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.51.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.51.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.51.1", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.51.1", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.51.1", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.51.1"
+version = "0.52.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.51.1", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.51.1", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.51.1", path = "crates/rustango" }
+rustango-macros     = { version = "0.52.0", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.52.0", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.52.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.51.1" }
+orm = { package = "rustango", path = "../rustango", version = "0.52.0" }
 chrono = { workspace = true }

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.51.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.51.1" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -405,7 +405,7 @@ runserver = ["dep:axum", "dep:tokio"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.51.1", path = "../rustango-macros" }
+rustango-macros = { version = "0.52.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -405,7 +405,7 @@ runserver = ["dep:axum", "dep:tokio"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.51.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.51.1", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }

--- a/crates/rustango/src/migrate/mod.rs
+++ b/crates/rustango/src/migrate/mod.rs
@@ -53,6 +53,7 @@ pub use make::{
 #[cfg(feature = "postgres")]
 pub use manage::{append_data_op, make_data_migration};
 pub use runner::migrate_pool_with_ledger;
+pub use runner::migrate_pool_with_ledger_fake_initial;
 // Always-on: tri-dialect entry points (work on PG / MySQL / SQLite via
 // the `Pool` enum), plus the inventory + builder surface.
 pub use runner::{

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -1406,6 +1406,47 @@ pub async fn migrate_pool_with_ledger(
     dir: &Path,
     ledger: &str,
 ) -> Result<Vec<Migration>, MigrateError> {
+    migrate_pool_with_ledger_opts(pool, dir, ledger, false).await
+}
+
+/// Like [`migrate_pool_with_ledger`], but with **guarded fake-initial**
+/// reconciliation (#1167): before applying, any pending migration that
+/// is *purely* table-creation (`CreateTable` ops only) whose tables
+/// **all already exist** is recorded in the ledger *without running its
+/// SQL*. This is the upgrade path for a subsystem that used to build
+/// its tables via the lazy `ensure_table` DDL and is now managed by a
+/// system migration: on the first `migrate` after the upgrade, the
+/// freshly-generated `CREATE TABLE` would otherwise collide with the
+/// already-present table. Faking it records the migration as applied so
+/// the chain moves on; existing data is untouched.
+///
+/// Scoped to the framework's own system-migration apply path (see
+/// [`crate::tenancy`] provisioning) — user migrations go through the
+/// plain [`migrate_pool_with_ledger`] and never auto-fake. The guard is
+/// deliberately narrow: a migration with *any* non-`CreateTable`
+/// operation (a column add, a data backfill, a callback) is never
+/// faked, and a create-migration is faked only when **every** table it
+/// creates is already present (a partial state falls through to the
+/// runner, which surfaces the collision loudly rather than papering
+/// over it).
+///
+/// # Errors
+/// As [`migrate_pool_with_ledger`], plus a ledger-insert failure while
+/// recording a faked migration.
+pub async fn migrate_pool_with_ledger_fake_initial(
+    pool: &crate::sql::Pool,
+    dir: &Path,
+    ledger: &str,
+) -> Result<Vec<Migration>, MigrateError> {
+    migrate_pool_with_ledger_opts(pool, dir, ledger, true).await
+}
+
+async fn migrate_pool_with_ledger_opts(
+    pool: &crate::sql::Pool,
+    dir: &Path,
+    ledger: &str,
+    fake_initial: bool,
+) -> Result<Vec<Migration>, MigrateError> {
     ensure_ledger_pool_with_ledger(pool, ledger).await?;
     with_migrate_lock_pool(pool, async {
         let all = file::list_dir(dir)?;
@@ -1417,6 +1458,25 @@ pub async fn migrate_pool_with_ledger(
 
         let mut newly = Vec::with_capacity(pending.len());
         for mig in pending {
+            // Fake-initial reconcile (#1167): a pure-`CreateTable`
+            // migration whose tables all already exist is recorded
+            // without running — the ensure→system-migration upgrade path.
+            if fake_initial {
+                if let Some(tables) = create_only_tables(&mig) {
+                    if all_tables_exist(pool, &tables).await {
+                        record_fake_applied(pool, &mig, ledger).await?;
+                        tracing::warn!(
+                            migration = %mig.name,
+                            tables = %tables.join(", "),
+                            "fake-initial: tables already exist (pre-migration \
+                             `ensure_table` era) — recorded as applied without \
+                             running its CREATE TABLE; existing data left intact"
+                        );
+                        newly.push(mig);
+                        continue;
+                    }
+                }
+            }
             if mig.atomic {
                 apply_atomic_pool(pool, &mig, ledger).await?;
             } else {
@@ -1427,6 +1487,70 @@ pub async fn migrate_pool_with_ledger(
         Ok(newly)
     })
     .await
+}
+
+/// If every operation in `mig` is a `CreateTable` schema change, return
+/// the tables it creates; otherwise `None`. Only such "initial"
+/// pure-table-creation migrations are eligible for fake-initial
+/// reconciliation — anything with a column add / data op / callback is
+/// excluded so we never skip a real side effect.
+fn create_only_tables(mig: &Migration) -> Option<Vec<String>> {
+    let mut tables = Vec::new();
+    for op in &mig.forward {
+        match op {
+            Operation::Schema(super::diff::SchemaChange::CreateTable(t)) => tables.push(t.clone()),
+            _ => return None,
+        }
+    }
+    (!tables.is_empty()).then_some(tables)
+}
+
+/// `true` when every table in `tables` already exists in `pool`. Uses
+/// `SELECT 1 FROM <t> LIMIT 1` so the name resolves through exactly the
+/// same search_path / current-database rules the migration's own
+/// `CREATE TABLE` would use (unqualified — correct for schema-mode
+/// tenants and single-DB alike).
+async fn all_tables_exist(pool: &crate::sql::Pool, tables: &[String]) -> bool {
+    let dialect = pool.dialect();
+    for t in tables {
+        let sql = format!("SELECT 1 FROM {} LIMIT 1", dialect.quote_ident(t));
+        if crate::sql::raw_execute_pool(pool, &sql, Vec::new())
+            .await
+            .is_err()
+        {
+            return false;
+        }
+    }
+    true
+}
+
+/// Insert a migration's name into `ledger` without running its SQL
+/// (idempotent — an existing row is left untouched). Mirrors the
+/// bookkeeping the normal apply path performs on success.
+async fn record_fake_applied(
+    pool: &crate::sql::Pool,
+    mig: &Migration,
+    ledger: &str,
+) -> Result<(), MigrateError> {
+    let dialect = pool.dialect();
+    let placeholder = dialect.placeholder(1);
+    let table = dialect.quote_ident(ledger);
+    let name_col = dialect.quote_ident("name");
+    let conflict_tail = dialect.insert_on_conflict_skip(&[&name_col]);
+    let sql = format!("INSERT INTO {table} ({name_col}) VALUES ({placeholder}) {conflict_tail}");
+    crate::sql::raw_execute_pool(
+        pool,
+        &sql,
+        vec![crate::core::SqlValue::String(mig.name.clone())],
+    )
+    .await
+    .map(|_| ())
+    .map_err(|e| {
+        MigrateError::Validation(format!(
+            "fake-initial: ledger insert for `{}` failed: {e}",
+            mig.name
+        ))
+    })
 }
 
 /// Hold the migrate session-scoped advisory lock while `body` runs,

--- a/crates/rustango/src/tenancy/migrate.rs
+++ b/crates/rustango/src/tenancy/migrate.rs
@@ -137,15 +137,28 @@ async fn apply_system_migrations(
         crate::core::ModelScope::Registry => MigrationScope::Registry,
         crate::core::ModelScope::Tenant => MigrationScope::Tenant,
     };
+    // Fake-initial reconcile (#1167): a subsystem that used to build its
+    // tables via lazy `ensure_table` DDL (e.g. media before 0.51) now ships
+    // them as a system migration. On the first `migrate` after the upgrade
+    // the freshly-generated `CREATE TABLE` would collide with the
+    // already-present table — so the system-migration runner records such a
+    // pure-`CreateTable`-of-existing-tables migration as applied without
+    // running it. Scoped to the framework's own tables; user migrations use
+    // the plain runner.
     let applied = match scoped_subset(&system_dir, migration_scope).await? {
         ScopedDir::Owned(temp) => {
-            let r =
-                crate::migrate::migrate_pool_with_ledger(pool, temp.path(), SYSTEM_LEDGER).await?;
+            let r = crate::migrate::migrate_pool_with_ledger_fake_initial(
+                pool,
+                temp.path(),
+                SYSTEM_LEDGER,
+            )
+            .await?;
             drop(temp);
             r
         }
         ScopedDir::Original => {
-            crate::migrate::migrate_pool_with_ledger(pool, &system_dir, SYSTEM_LEDGER).await?
+            crate::migrate::migrate_pool_with_ledger_fake_initial(pool, &system_dir, SYSTEM_LEDGER)
+                .await?
         }
     };
     Ok(applied)

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -398,14 +398,36 @@ where
 ///     .router_pool("/posts", pool);
 /// ```
 ///
-/// Backends run on the **list** action.
+/// Backends run on **every** action: they narrow the list query, and they
+/// scope `retrieve` / `update` / `destroy` so a row the backend excludes is a
+/// 404 rather than someone else's data. That is DRF's `get_queryset()`
+/// contract, and without it an ownership backend would guard the collection
+/// while leaving every row reachable by id.
 pub trait ViewSetFilter: Send + Sync + 'static {
-    /// Return `WHERE` predicates to AND into the list query for this request.
+    /// Return `WHERE` predicates to AND into the query for this request.
     fn filter(
         &self,
         params: &HashMap<String, String>,
         schema: &'static ModelSchema,
     ) -> Vec<WhereExpr>;
+
+    /// As [`Self::filter`], with the request's [`Parts`] in hand.
+    ///
+    /// The authenticated principal lives in the request extensions, not in the
+    /// query string, so "only this user's rows" cannot be written against
+    /// `filter` alone. Defaults to [`Self::filter`], so every existing backend
+    /// — including the plain closure form — keeps compiling and behaving
+    /// exactly as before.
+    ///
+    /// [`Parts`]: axum::http::request::Parts
+    fn filter_with(
+        &self,
+        _parts: &axum::http::request::Parts,
+        params: &HashMap<String, String>,
+        schema: &'static ModelSchema,
+    ) -> Vec<WhereExpr> {
+        self.filter(params, schema)
+    }
 }
 
 impl<F> ViewSetFilter for F
@@ -1169,6 +1191,32 @@ macro_rules! or_400 {
 /// it; the helper still returns the body so write paths
 /// (`handle_create`, `update_inner`) can consume it after the
 /// permission gate.
+/// Predicates every backend contributes for this request, ANDed into
+/// whatever query the action is about to run.
+fn scope_filters(
+    state: &ViewSetState,
+    parts: &axum::http::request::Parts,
+    params: &HashMap<String, String>,
+) -> Vec<WhereExpr> {
+    state
+        .vs
+        .filter_backends
+        .iter()
+        .flat_map(|b| b.filter_with(parts, params, state.vs.schema))
+        .collect()
+}
+
+/// `expr` narrowed by `extra`. An empty `extra` returns `expr` untouched, so
+/// a ViewSet with no backends builds the same SQL it always did.
+fn narrow(expr: WhereExpr, extra: Vec<WhereExpr>) -> WhereExpr {
+    if extra.is_empty() {
+        return expr;
+    }
+    let mut all = vec![expr];
+    all.extend(extra);
+    WhereExpr::And(all)
+}
+
 async fn enter(
     state: &Arc<ViewSetState>,
     req: axum::extract::Request,
@@ -1371,11 +1419,11 @@ async fn handle_list(
     Query(params): Query<HashMap<String, String>>,
     req: axum::extract::Request,
 ) -> Response {
-    let (_parts, _body, acq) = match enter(&state, req, &state.vs.perms.list, "list").await {
+    let (parts, _body, acq) = match enter(&state, req, &state.vs.perms.list, "list").await {
         Ok(x) => x,
         Err(resp) => return resp,
     };
-    run_list(state, params, acq).await
+    run_list(state, params, acq, &parts).await
 }
 
 /// Core `list` logic shared by the GET `list` action and the RFC 10008
@@ -1387,6 +1435,7 @@ async fn run_list(
     state: Arc<ViewSetState>,
     params: HashMap<String, String>,
     mut acq: AcquiredConn,
+    parts: &axum::http::request::Parts,
 ) -> Response {
     let page_size: i64 = params
         .get("page_size")
@@ -1428,9 +1477,7 @@ async fn run_list(
 
     // #1010 — pluggable filter backends contribute extra predicates,
     // ANDed with the built-in filter_fields parsed above.
-    for backend in &state.vs.filter_backends {
-        filters.extend(backend.filter(&params, state.vs.schema));
-    }
+    filters.extend(scope_filters(&state, parts, &params));
 
     let where_clause = if filters.len() == 1 {
         filters.remove(0)
@@ -1608,7 +1655,7 @@ async fn handle_query(
         Ok(p) => p,
         Err(resp) => return resp,
     };
-    run_list(state, params, acq).await
+    run_list(state, params, acq, &parts).await
 }
 
 /// Parse a QUERY request body into the same `HashMap<String, String>`
@@ -1808,7 +1855,7 @@ async fn handle_retrieve(
     Path(pk_raw): Path<String>,
     req: axum::extract::Request,
 ) -> Response {
-    let (_parts, _body, mut acq) =
+    let (parts, _body, mut acq) =
         match enter(&state, req, &state.vs.perms.retrieve, "retrieve").await {
             Ok(x) => x,
             Err(resp) => return resp,
@@ -1825,7 +1872,11 @@ async fn handle_retrieve(
 
     // #562 — was 11-field struct literal; SelectQuery::by_pk constructs
     // the single-PK-lookup shape directly.
-    let select_q = SelectQuery::by_pk(state.vs.schema, pk_field.column, pk_val);
+    let mut select_q = SelectQuery::by_pk(state.vs.schema, pk_field.column, pk_val);
+    // …narrowed by the filter backends, so a row this principal may not see
+    // reads as absent rather than forbidden — a 403 would confirm the id.
+    let scope = scope_filters(&state, &parts, &HashMap::new());
+    select_q.where_clause = narrow(select_q.where_clause, scope);
 
     let fields = state.effective_fields();
     match render_single(&state, &mut acq, &select_q, &fields).await {
@@ -2040,6 +2091,8 @@ async fn update_inner(
         Ok(x) => x,
         Err(resp) => return resp,
     };
+    // Scope first: an update must not reach a row this principal cannot see.
+    let scope = scope_filters(&state, &parts, &HashMap::new());
 
     let pk_field = match pk_field_or_500(&state) {
         Ok(f) => f,
@@ -2093,19 +2146,26 @@ async fn update_inner(
     let query = UpdateQuery {
         model: state.vs.schema,
         set: assignments,
-        where_clause: WhereExpr::Predicate(Filter {
-            column: pk_field.column,
-            op: Op::Eq,
-            value: pk_val.clone(),
-        }),
+        where_clause: narrow(
+            WhereExpr::Predicate(Filter {
+                column: pk_field.column,
+                op: Op::Eq,
+                value: pk_val.clone(),
+            }),
+            scope.clone(),
+        ),
     };
 
-    if let Err(e) = acq.update(&query).await {
-        return json_error(StatusCode::BAD_REQUEST, &e.to_string());
+    match acq.update(&query).await {
+        // Nothing matched: either no such row, or one this principal is
+        // scoped out of. Both are a 404 — see `handle_retrieve`.
+        Ok(0) => return json_error(StatusCode::NOT_FOUND, "not found"),
+        Ok(_) => {}
+        Err(e) => return json_error(StatusCode::BAD_REQUEST, &e.to_string()),
     }
 
     let fields = state.effective_fields();
-    match fetch_by_pk(&state, &mut acq, pk_field, pk_val, &fields).await {
+    match fetch_by_pk_scoped(&state, &mut acq, pk_field, pk_val, &fields, scope).await {
         Some(obj) => json_response(obj),
         None => json_error(StatusCode::NOT_FOUND, "not found after update"),
     }
@@ -2116,11 +2176,12 @@ async fn handle_destroy(
     Path(pk_raw): Path<String>,
     req: axum::extract::Request,
 ) -> Response {
-    let (_parts, _body, mut acq) =
-        match enter(&state, req, &state.vs.perms.destroy, "destroy").await {
-            Ok(x) => x,
-            Err(resp) => return resp,
-        };
+    let (parts, _body, mut acq) = match enter(&state, req, &state.vs.perms.destroy, "destroy").await
+    {
+        Ok(x) => x,
+        Err(resp) => return resp,
+    };
+    let scope = scope_filters(&state, &parts, &HashMap::new());
 
     let pk_field = match pk_field_or_500(&state) {
         Ok(f) => f,
@@ -2133,11 +2194,14 @@ async fn handle_destroy(
 
     let query = DeleteQuery {
         model: state.vs.schema,
-        where_clause: WhereExpr::Predicate(Filter {
-            column: pk_field.column,
-            op: Op::Eq,
-            value: pk_val,
-        }),
+        where_clause: narrow(
+            WhereExpr::Predicate(Filter {
+                column: pk_field.column,
+                op: Op::Eq,
+                value: pk_val,
+            }),
+            scope,
+        ),
     };
 
     match acq.delete(&query).await {
@@ -2148,6 +2212,24 @@ async fn handle_destroy(
 }
 
 // ------------------------------------------------------------------ helpers
+
+/// [`fetch_by_pk`] narrowed by the filter backends — the read-back after an
+/// update, which must not return a row the principal is scoped out of.
+async fn fetch_by_pk_scoped(
+    state: &ViewSetState,
+    acq: &mut AcquiredConn,
+    pk_field: &'static crate::core::FieldSchema,
+    pk_val: SqlValue,
+    fields: &[&'static crate::core::FieldSchema],
+    scope: Vec<WhereExpr>,
+) -> Option<Value> {
+    let mut select_q = SelectQuery::by_pk(state.vs.schema, pk_field.column, pk_val);
+    select_q.where_clause = narrow(select_q.where_clause, scope);
+    render_single(state, acq, &select_q, fields)
+        .await
+        .ok()
+        .flatten()
+}
 
 async fn fetch_by_pk(
     state: &ViewSetState,

--- a/crates/rustango/tests/migrate_fake_initial_mysql_live.rs
+++ b/crates/rustango/tests/migrate_fake_initial_mysql_live.rs
@@ -1,0 +1,98 @@
+#![cfg(all(feature = "mysql", feature = "tenancy"))]
+//! Fake-initial reconcile on live MySQL (#1167 / #1174).
+//!
+//! Reads `MYSQL_TEST_URL`; skips silently when unset. Proves the
+//! ensure→system-migration upgrade path on the strict dialect: a
+//! pre-existing (ensure-era) table is reconciled by recording the
+//! generated `CREATE TABLE` migration without running it — no collision,
+//! existing data intact.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use rustango::migrate::{self, file, Migration, Operation, SchemaChange, SchemaSnapshot, TableSnapshot};
+use rustango::sql::sqlx::{self, Row};
+use rustango::sql::Pool;
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+const LEDGER: &str = "__rustango_system_migrations__";
+
+fn snapshot_with_table(table: &str) -> SchemaSnapshot {
+    let t: TableSnapshot = serde_json::from_value(serde_json::json!({
+        "name": table,
+        "model": "T",
+        "fields": [
+            {"name": "id", "column": "id", "ty": "i64", "nullable": false, "primary_key": true}
+        ]
+    }))
+    .unwrap();
+    SchemaSnapshot { tables: vec![t], ..Default::default() }
+}
+
+fn write_dir(m: &Migration) -> PathBuf {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let mut dir = std::env::temp_dir();
+    dir.push(format!("rustango_fakeinit_my_{}_{n}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    file::write(&dir.join(format!("{}.json", m.name)), m).unwrap();
+    dir
+}
+
+#[tokio::test]
+async fn fake_initial_reconciles_existing_table_on_mysql() {
+    let Ok(url) = std::env::var("MYSQL_TEST_URL") else {
+        eprintln!("skipping — set MYSQL_TEST_URL");
+        return;
+    };
+    let my = sqlx::MySqlPool::connect(&url).await.expect("connect mysql");
+    let pool = Pool::Mysql(my.clone());
+
+    // Unique names so parallel/rerun don't collide on the shared DB + ledger.
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let table = format!("recon_media_{}_{n}", std::process::id());
+    let name = format!("9{n:03}_create_{table}");
+
+    // Clean slate.
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{table}`")).execute(&my).await.unwrap();
+    let _ = sqlx::query(&format!("DELETE FROM {LEDGER} WHERE name = ?")).bind(&name).execute(&my).await;
+
+    let m = Migration {
+        name: name.clone(),
+        created_at: "2026-08-06T00:00:00Z".into(),
+        prev: None,
+        atomic: true,
+        scope: migrate::MigrationScope::default(),
+        snapshot: snapshot_with_table(&table),
+        forward: vec![Operation::Schema(SchemaChange::CreateTable(table.clone()))],
+    };
+    let dir = write_dir(&m);
+
+    // Simulate the old ensure_table era: table already present, with data.
+    sqlx::query(&format!("CREATE TABLE `{table}` (id BIGINT PRIMARY KEY, note VARCHAR(64))"))
+        .execute(&my).await.unwrap();
+    sqlx::query(&format!("INSERT INTO `{table}` (id, note) VALUES (1, 'pre-existing')"))
+        .execute(&my).await.unwrap();
+
+    // The reconcile: no "table already exists" (MySQL 1050); faked instead.
+    let applied = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER)
+        .await
+        .expect("fake-initial must not collide on MySQL");
+    assert_eq!(applied.len(), 1);
+
+    // Recorded in the ledger.
+    let recorded: i64 = sqlx::query(&format!("SELECT COUNT(*) AS c FROM {LEDGER} WHERE name = ?"))
+        .bind(&name).fetch_one(&my).await.unwrap().try_get("c").unwrap();
+    assert_eq!(recorded, 1, "faked migration must be in the ledger");
+
+    // Data intact — the CREATE never ran.
+    let note: String = sqlx::query(&format!("SELECT note FROM `{table}` WHERE id = 1"))
+        .fetch_one(&my).await.unwrap().try_get("note").unwrap();
+    assert_eq!(note, "pre-existing");
+
+    // Cleanup.
+    let _ = sqlx::query(&format!("DROP TABLE IF EXISTS `{table}`")).execute(&my).await;
+    let _ = sqlx::query(&format!("DELETE FROM {LEDGER} WHERE name = ?")).bind(&name).execute(&my).await;
+    let _ = std::fs::remove_dir_all(&dir);
+    println!("MySQL fake-initial reconcile OK");
+}

--- a/crates/rustango/tests/migrate_fake_initial_mysql_live.rs
+++ b/crates/rustango/tests/migrate_fake_initial_mysql_live.rs
@@ -10,7 +10,9 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use rustango::migrate::{self, file, Migration, Operation, SchemaChange, SchemaSnapshot, TableSnapshot};
+use rustango::migrate::{
+    self, file, Migration, Operation, SchemaChange, SchemaSnapshot, TableSnapshot,
+};
 use rustango::sql::sqlx::{self, Row};
 use rustango::sql::Pool;
 
@@ -26,7 +28,10 @@ fn snapshot_with_table(table: &str) -> SchemaSnapshot {
         ]
     }))
     .unwrap();
-    SchemaSnapshot { tables: vec![t], ..Default::default() }
+    SchemaSnapshot {
+        tables: vec![t],
+        ..Default::default()
+    }
 }
 
 fn write_dir(m: &Migration) -> PathBuf {
@@ -54,8 +59,14 @@ async fn fake_initial_reconciles_existing_table_on_mysql() {
     let name = format!("9{n:03}_create_{table}");
 
     // Clean slate.
-    sqlx::query(&format!("DROP TABLE IF EXISTS `{table}`")).execute(&my).await.unwrap();
-    let _ = sqlx::query(&format!("DELETE FROM {LEDGER} WHERE name = ?")).bind(&name).execute(&my).await;
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{table}`"))
+        .execute(&my)
+        .await
+        .unwrap();
+    let _ = sqlx::query(&format!("DELETE FROM {LEDGER} WHERE name = ?"))
+        .bind(&name)
+        .execute(&my)
+        .await;
 
     let m = Migration {
         name: name.clone(),
@@ -69,10 +80,18 @@ async fn fake_initial_reconciles_existing_table_on_mysql() {
     let dir = write_dir(&m);
 
     // Simulate the old ensure_table era: table already present, with data.
-    sqlx::query(&format!("CREATE TABLE `{table}` (id BIGINT PRIMARY KEY, note VARCHAR(64))"))
-        .execute(&my).await.unwrap();
-    sqlx::query(&format!("INSERT INTO `{table}` (id, note) VALUES (1, 'pre-existing')"))
-        .execute(&my).await.unwrap();
+    sqlx::query(&format!(
+        "CREATE TABLE `{table}` (id BIGINT PRIMARY KEY, note VARCHAR(64))"
+    ))
+    .execute(&my)
+    .await
+    .unwrap();
+    sqlx::query(&format!(
+        "INSERT INTO `{table}` (id, note) VALUES (1, 'pre-existing')"
+    ))
+    .execute(&my)
+    .await
+    .unwrap();
 
     // The reconcile: no "table already exists" (MySQL 1050); faked instead.
     let applied = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER)
@@ -81,18 +100,34 @@ async fn fake_initial_reconciles_existing_table_on_mysql() {
     assert_eq!(applied.len(), 1);
 
     // Recorded in the ledger.
-    let recorded: i64 = sqlx::query(&format!("SELECT COUNT(*) AS c FROM {LEDGER} WHERE name = ?"))
-        .bind(&name).fetch_one(&my).await.unwrap().try_get("c").unwrap();
+    let recorded: i64 = sqlx::query(&format!(
+        "SELECT COUNT(*) AS c FROM {LEDGER} WHERE name = ?"
+    ))
+    .bind(&name)
+    .fetch_one(&my)
+    .await
+    .unwrap()
+    .try_get("c")
+    .unwrap();
     assert_eq!(recorded, 1, "faked migration must be in the ledger");
 
     // Data intact — the CREATE never ran.
     let note: String = sqlx::query(&format!("SELECT note FROM `{table}` WHERE id = 1"))
-        .fetch_one(&my).await.unwrap().try_get("note").unwrap();
+        .fetch_one(&my)
+        .await
+        .unwrap()
+        .try_get("note")
+        .unwrap();
     assert_eq!(note, "pre-existing");
 
     // Cleanup.
-    let _ = sqlx::query(&format!("DROP TABLE IF EXISTS `{table}`")).execute(&my).await;
-    let _ = sqlx::query(&format!("DELETE FROM {LEDGER} WHERE name = ?")).bind(&name).execute(&my).await;
+    let _ = sqlx::query(&format!("DROP TABLE IF EXISTS `{table}`"))
+        .execute(&my)
+        .await;
+    let _ = sqlx::query(&format!("DELETE FROM {LEDGER} WHERE name = ?"))
+        .bind(&name)
+        .execute(&my)
+        .await;
     let _ = std::fs::remove_dir_all(&dir);
     println!("MySQL fake-initial reconcile OK");
 }

--- a/crates/rustango/tests/migrate_fake_initial_sqlite_live.rs
+++ b/crates/rustango/tests/migrate_fake_initial_sqlite_live.rs
@@ -13,7 +13,9 @@
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use rustango::migrate::{self, file, Migration, Operation, SchemaChange, SchemaSnapshot, TableSnapshot};
+use rustango::migrate::{
+    self, file, Migration, Operation, SchemaChange, SchemaSnapshot, TableSnapshot,
+};
 use rustango::sql::sqlx::{self, Row};
 use rustango::sql::Pool;
 
@@ -26,7 +28,9 @@ async fn sqlite_pool() -> (Pool, PathBuf) {
     path.push(format!("rustango_fakeinit_{}_{n}.db", std::process::id()));
     let _ = std::fs::remove_file(&path);
     let url = format!("sqlite:{}?mode=rwc", path.display());
-    let sq = sqlx::SqlitePool::connect(&url).await.expect("connect sqlite");
+    let sq = sqlx::SqlitePool::connect(&url)
+        .await
+        .expect("connect sqlite");
     (Pool::Sqlite(sq), path)
 }
 
@@ -39,7 +43,10 @@ fn snapshot_with_table(table: &str) -> SchemaSnapshot {
         ]
     }))
     .unwrap();
-    SchemaSnapshot { tables: vec![t], ..Default::default() }
+    SchemaSnapshot {
+        tables: vec![t],
+        ..Default::default()
+    }
 }
 
 fn snapshot_with_tables(tables: &[&str]) -> SchemaSnapshot {
@@ -56,7 +63,10 @@ fn snapshot_with_tables(tables: &[&str]) -> SchemaSnapshot {
             .unwrap()
         })
         .collect();
-    SchemaSnapshot { tables: ts, ..Default::default() }
+    SchemaSnapshot {
+        tables: ts,
+        ..Default::default()
+    }
 }
 
 fn mig(name: &str, snapshot: SchemaSnapshot, forward: Vec<Operation>) -> Migration {
@@ -82,14 +92,18 @@ fn write_dir(mig: &Migration) -> PathBuf {
 }
 
 async fn ledger_has(pool: &Pool, name: &str) -> bool {
-    let Pool::Sqlite(sq) = pool else { unreachable!() };
-    let count: i64 = sqlx::query(&format!("SELECT COUNT(*) AS c FROM {LEDGER} WHERE name = ?"))
-        .bind(name)
-        .fetch_one(sq)
-        .await
-        .unwrap()
-        .try_get("c")
-        .unwrap();
+    let Pool::Sqlite(sq) = pool else {
+        unreachable!()
+    };
+    let count: i64 = sqlx::query(&format!(
+        "SELECT COUNT(*) AS c FROM {LEDGER} WHERE name = ?"
+    ))
+    .bind(name)
+    .fetch_one(sq)
+    .await
+    .unwrap()
+    .try_get("c")
+    .unwrap();
     count > 0
 }
 
@@ -107,29 +121,52 @@ async fn fake_initial_records_without_running_when_table_exists() {
     let (pool, path) = sqlite_pool().await;
     let table = "recon_media";
     let name = "0004_create_recon_media";
-    let m = mig(name, snapshot_with_table(table), vec![Operation::Schema(SchemaChange::CreateTable(table.into()))]);
+    let m = mig(
+        name,
+        snapshot_with_table(table),
+        vec![Operation::Schema(SchemaChange::CreateTable(table.into()))],
+    );
     let dir = write_dir(&m);
 
     // Simulate the old `ensure_table` era: the table already exists, with data.
-    let Pool::Sqlite(sq) = &pool else { unreachable!() };
-    sqlx::query(&format!("CREATE TABLE {table} (id INTEGER PRIMARY KEY, note TEXT)"))
-        .execute(sq).await.unwrap();
-    sqlx::query(&format!("INSERT INTO {table} (id, note) VALUES (1, 'pre-existing')"))
-        .execute(sq).await.unwrap();
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!()
+    };
+    sqlx::query(&format!(
+        "CREATE TABLE {table} (id INTEGER PRIMARY KEY, note TEXT)"
+    ))
+    .execute(sq)
+    .await
+    .unwrap();
+    sqlx::query(&format!(
+        "INSERT INTO {table} (id, note) VALUES (1, 'pre-existing')"
+    ))
+    .execute(sq)
+    .await
+    .unwrap();
 
     let applied = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER)
         .await
         .expect("fake-initial should succeed, not collide");
     assert_eq!(applied.len(), 1, "migration should be resolved (faked)");
-    assert!(ledger_has(&pool, name).await, "faked migration must be recorded in the ledger");
+    assert!(
+        ledger_has(&pool, name).await,
+        "faked migration must be recorded in the ledger"
+    );
 
     // The pre-existing row survived — the CREATE never ran and no data was lost.
     let note: String = sqlx::query(&format!("SELECT note FROM {table} WHERE id = 1"))
-        .fetch_one(sq).await.unwrap().try_get("note").unwrap();
+        .fetch_one(sq)
+        .await
+        .unwrap()
+        .try_get("note")
+        .unwrap();
     assert_eq!(note, "pre-existing");
 
     // Idempotent: a second run is a no-op (already in ledger).
-    let again = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER).await.unwrap();
+    let again = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER)
+        .await
+        .unwrap();
     assert!(again.is_empty(), "second run has nothing pending");
 
     cleanup(pool, &path, &dir);
@@ -142,16 +179,26 @@ async fn fake_initial_creates_normally_when_table_absent() {
     let (pool, path) = sqlite_pool().await;
     let table = "recon_fresh";
     let name = "0001_create_recon_fresh";
-    let m = mig(name, snapshot_with_table(table), vec![Operation::Schema(SchemaChange::CreateTable(table.into()))]);
+    let m = mig(
+        name,
+        snapshot_with_table(table),
+        vec![Operation::Schema(SchemaChange::CreateTable(table.into()))],
+    );
     let dir = write_dir(&m);
 
-    let applied = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER).await.unwrap();
+    let applied = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER)
+        .await
+        .unwrap();
     assert_eq!(applied.len(), 1);
     assert!(ledger_has(&pool, name).await);
 
     // The table was actually created (a real INSERT works).
-    let Pool::Sqlite(sq) = &pool else { unreachable!() };
-    sqlx::query(&format!("INSERT INTO {table} (id) VALUES (1)")).execute(sq).await
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!()
+    };
+    sqlx::query(&format!("INSERT INTO {table} (id) VALUES (1)"))
+        .execute(sq)
+        .await
         .expect("table should have been created by the runner");
 
     cleanup(pool, &path, &dir);
@@ -176,12 +223,23 @@ async fn fake_initial_does_not_fake_partial_existence() {
     let dir = write_dir(&m);
 
     // Only t1 pre-exists → not all tables exist → must not fake.
-    let Pool::Sqlite(sq) = &pool else { unreachable!() };
-    sqlx::query(&format!("CREATE TABLE {t1} (id INTEGER PRIMARY KEY)")).execute(sq).await.unwrap();
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!()
+    };
+    sqlx::query(&format!("CREATE TABLE {t1} (id INTEGER PRIMARY KEY)"))
+        .execute(sq)
+        .await
+        .unwrap();
 
     let res = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER).await;
-    assert!(res.is_err(), "partial existence must fall through to the runner and collide, not fake");
-    assert!(!ledger_has(&pool, name).await, "a non-faked, failed migration must not be recorded");
+    assert!(
+        res.is_err(),
+        "partial existence must fall through to the runner and collide, not fake"
+    );
+    assert!(
+        !ledger_has(&pool, name).await,
+        "a non-faked, failed migration must not be recorded"
+    );
 
     cleanup(pool, &path, &dir);
 }

--- a/crates/rustango/tests/migrate_fake_initial_sqlite_live.rs
+++ b/crates/rustango/tests/migrate_fake_initial_sqlite_live.rs
@@ -1,0 +1,187 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! Fake-initial reconcile for system migrations (#1167 / #1174).
+//!
+//! When a subsystem that used to build its tables via lazy `ensure_table`
+//! DDL becomes managed by a system migration, the first `migrate` after the
+//! upgrade must NOT fail on the freshly-generated `CREATE TABLE` colliding
+//! with the already-present table. `migrate_pool_with_ledger_fake_initial`
+//! records such a pure-`CreateTable`-of-existing-tables migration as applied
+//! without running it, leaving existing data intact.
+//!
+//! SQLite + a temp file (so every pool connection sees the same DB).
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use rustango::migrate::{self, file, Migration, Operation, SchemaChange, SchemaSnapshot, TableSnapshot};
+use rustango::sql::sqlx::{self, Row};
+use rustango::sql::Pool;
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+const LEDGER: &str = "__rustango_system_migrations__";
+
+async fn sqlite_pool() -> (Pool, PathBuf) {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let mut path = std::env::temp_dir();
+    path.push(format!("rustango_fakeinit_{}_{n}.db", std::process::id()));
+    let _ = std::fs::remove_file(&path);
+    let url = format!("sqlite:{}?mode=rwc", path.display());
+    let sq = sqlx::SqlitePool::connect(&url).await.expect("connect sqlite");
+    (Pool::Sqlite(sq), path)
+}
+
+fn snapshot_with_table(table: &str) -> SchemaSnapshot {
+    let t: TableSnapshot = serde_json::from_value(serde_json::json!({
+        "name": table,
+        "model": "T",
+        "fields": [
+            {"name": "id", "column": "id", "ty": "i64", "nullable": false, "primary_key": true}
+        ]
+    }))
+    .unwrap();
+    SchemaSnapshot { tables: vec![t], ..Default::default() }
+}
+
+fn snapshot_with_tables(tables: &[&str]) -> SchemaSnapshot {
+    let ts = tables
+        .iter()
+        .map(|table| {
+            serde_json::from_value(serde_json::json!({
+                "name": table,
+                "model": "T",
+                "fields": [
+                    {"name": "id", "column": "id", "ty": "i64", "nullable": false, "primary_key": true}
+                ]
+            }))
+            .unwrap()
+        })
+        .collect();
+    SchemaSnapshot { tables: ts, ..Default::default() }
+}
+
+fn mig(name: &str, snapshot: SchemaSnapshot, forward: Vec<Operation>) -> Migration {
+    Migration {
+        name: name.to_owned(),
+        created_at: "2026-08-06T00:00:00Z".into(),
+        prev: None,
+        atomic: true,
+        scope: migrate::MigrationScope::default(),
+        snapshot,
+        forward,
+    }
+}
+
+fn write_dir(mig: &Migration) -> PathBuf {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let mut dir = std::env::temp_dir();
+    dir.push(format!("rustango_fakeinit_dir_{}_{n}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    file::write(&dir.join(format!("{}.json", mig.name)), mig).unwrap();
+    dir
+}
+
+async fn ledger_has(pool: &Pool, name: &str) -> bool {
+    let Pool::Sqlite(sq) = pool else { unreachable!() };
+    let count: i64 = sqlx::query(&format!("SELECT COUNT(*) AS c FROM {LEDGER} WHERE name = ?"))
+        .bind(name)
+        .fetch_one(sq)
+        .await
+        .unwrap()
+        .try_get("c")
+        .unwrap();
+    count > 0
+}
+
+fn cleanup(pool: Pool, path: &Path, dir: &Path) {
+    drop(pool);
+    let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+/// The reconcile case: a pure-`CreateTable` migration whose table already
+/// exists (with data) is faked — recorded in the ledger, its `CREATE TABLE`
+/// never run, the existing row untouched.
+#[tokio::test]
+async fn fake_initial_records_without_running_when_table_exists() {
+    let (pool, path) = sqlite_pool().await;
+    let table = "recon_media";
+    let name = "0004_create_recon_media";
+    let m = mig(name, snapshot_with_table(table), vec![Operation::Schema(SchemaChange::CreateTable(table.into()))]);
+    let dir = write_dir(&m);
+
+    // Simulate the old `ensure_table` era: the table already exists, with data.
+    let Pool::Sqlite(sq) = &pool else { unreachable!() };
+    sqlx::query(&format!("CREATE TABLE {table} (id INTEGER PRIMARY KEY, note TEXT)"))
+        .execute(sq).await.unwrap();
+    sqlx::query(&format!("INSERT INTO {table} (id, note) VALUES (1, 'pre-existing')"))
+        .execute(sq).await.unwrap();
+
+    let applied = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER)
+        .await
+        .expect("fake-initial should succeed, not collide");
+    assert_eq!(applied.len(), 1, "migration should be resolved (faked)");
+    assert!(ledger_has(&pool, name).await, "faked migration must be recorded in the ledger");
+
+    // The pre-existing row survived — the CREATE never ran and no data was lost.
+    let note: String = sqlx::query(&format!("SELECT note FROM {table} WHERE id = 1"))
+        .fetch_one(sq).await.unwrap().try_get("note").unwrap();
+    assert_eq!(note, "pre-existing");
+
+    // Idempotent: a second run is a no-op (already in ledger).
+    let again = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER).await.unwrap();
+    assert!(again.is_empty(), "second run has nothing pending");
+
+    cleanup(pool, &path, &dir);
+}
+
+/// Control: a pure-`CreateTable` migration whose table does NOT exist runs
+/// normally (fake-initial doesn't suppress a genuine creation).
+#[tokio::test]
+async fn fake_initial_creates_normally_when_table_absent() {
+    let (pool, path) = sqlite_pool().await;
+    let table = "recon_fresh";
+    let name = "0001_create_recon_fresh";
+    let m = mig(name, snapshot_with_table(table), vec![Operation::Schema(SchemaChange::CreateTable(table.into()))]);
+    let dir = write_dir(&m);
+
+    let applied = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER).await.unwrap();
+    assert_eq!(applied.len(), 1);
+    assert!(ledger_has(&pool, name).await);
+
+    // The table was actually created (a real INSERT works).
+    let Pool::Sqlite(sq) = &pool else { unreachable!() };
+    sqlx::query(&format!("INSERT INTO {table} (id) VALUES (1)")).execute(sq).await
+        .expect("table should have been created by the runner");
+
+    cleanup(pool, &path, &dir);
+}
+
+/// Guard: a migration whose tables only PARTIALLY exist is NOT faked — it
+/// falls through to the runner and surfaces the collision loudly rather than
+/// silently skipping a table that still needs creating.
+#[tokio::test]
+async fn fake_initial_does_not_fake_partial_existence() {
+    let (pool, path) = sqlite_pool().await;
+    let (t1, t2) = ("recon_a", "recon_b");
+    let name = "0002_create_recon_a_and_recon_b";
+    let m = mig(
+        name,
+        snapshot_with_tables(&[t1, t2]),
+        vec![
+            Operation::Schema(SchemaChange::CreateTable(t1.into())),
+            Operation::Schema(SchemaChange::CreateTable(t2.into())),
+        ],
+    );
+    let dir = write_dir(&m);
+
+    // Only t1 pre-exists → not all tables exist → must not fake.
+    let Pool::Sqlite(sq) = &pool else { unreachable!() };
+    sqlx::query(&format!("CREATE TABLE {t1} (id INTEGER PRIMARY KEY)")).execute(sq).await.unwrap();
+
+    let res = migrate::migrate_pool_with_ledger_fake_initial(&pool, &dir, LEDGER).await;
+    assert!(res.is_err(), "partial existence must fall through to the runner and collide, not fake");
+    assert!(!ledger_has(&pool, name).await, "a non-faked, failed migration must not be recorded");
+
+    cleanup(pool, &path, &dir);
+}

--- a/crates/rustango/tests/viewset_principal_filter_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_principal_filter_sqlite_live.rs
@@ -1,0 +1,252 @@
+//! `ViewSetFilter::filter_with(&Parts, …)` — ownership scoping that holds on
+//! every action, not just `list`.
+//!
+//! The principal lives in the request extensions, so "only this user's rows"
+//! cannot be expressed against the params-only `filter`. And scoping `list`
+//! alone is worse than not scoping at all: it reads as safe while every row
+//! stays reachable by id. These tests pin both halves — the collection is
+//! narrowed, and `retrieve` / `update` / `destroy` of a row belonging to
+//! someone else is a **404**, because a 403 would confirm the id exists.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+
+use std::collections::HashMap;
+
+use axum::body::Body;
+use axum::http::request::Parts;
+use axum::http::{header, Method, Request, StatusCode};
+use rustango::core::{Filter, Model as _, ModelSchema, Op, SqlValue, WhereExpr};
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::viewset::{ViewSet, ViewSetFilter};
+use rustango::Model;
+use serde_json::Value;
+use tower::ServiceExt as _;
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "vs_pf_note")]
+#[rustango(app = "vs_pf_app")]
+pub struct Note {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub owner_id: i64,
+    #[rustango(max_length = 200)]
+    pub body: String,
+}
+
+/// Stands in for an authenticated principal, injected as an extension the way
+/// an auth middleware would.
+#[derive(Clone, Copy)]
+struct Principal(i64);
+
+/// The backend an app writes: rows whose `owner_id` is the caller.
+struct OwnerFilter;
+
+impl ViewSetFilter for OwnerFilter {
+    fn filter(&self, _p: &HashMap<String, String>, schema: &'static ModelSchema) -> Vec<WhereExpr> {
+        // No principal in hand ⇒ match nothing. Fail closed: a backend that
+        // silently returns "no predicates" would widen the query to everyone.
+        deny(schema)
+    }
+
+    fn filter_with(
+        &self,
+        parts: &Parts,
+        _p: &HashMap<String, String>,
+        schema: &'static ModelSchema,
+    ) -> Vec<WhereExpr> {
+        let Some(Principal(uid)) = parts.extensions.get::<Principal>().copied() else {
+            return deny(schema);
+        };
+        schema.field("owner_id").map_or_else(Vec::new, |f| {
+            vec![WhereExpr::Predicate(Filter {
+                column: f.column,
+                op: Op::Eq,
+                value: SqlValue::from(uid),
+            })]
+        })
+    }
+}
+
+fn deny(schema: &'static ModelSchema) -> Vec<WhereExpr> {
+    schema.field("owner_id").map_or_else(Vec::new, |f| {
+        vec![WhereExpr::Predicate(Filter {
+            column: f.column,
+            op: Op::Eq,
+            value: SqlValue::from(-1_i64),
+        })]
+    })
+}
+
+async fn router() -> axum::Router {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE vs_pf_note (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            owner_id INTEGER NOT NULL, \
+            body TEXT NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .expect("create");
+    for (owner, body) in [(1, "alice one"), (1, "alice two"), (2, "bob one")] {
+        sqlx::query("INSERT INTO vs_pf_note (owner_id, body) VALUES (?, ?)")
+            .bind(owner)
+            .bind(body)
+            .execute(&sq)
+            .await
+            .expect("seed");
+    }
+    ViewSet::for_model(Note::SCHEMA)
+        .page_size(100)
+        .filter_backend(OwnerFilter)
+        .router_pool("/notes", Pool::Sqlite(sq))
+}
+
+/// A request carrying `uid` as the authenticated principal.
+fn as_user(method: Method, uri: &str, uid: i64) -> Request<Body> {
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    req.extensions_mut().insert(Principal(uid));
+    req
+}
+
+fn patch_as(uri: &str, uid: i64, form: &'static str) -> Request<Body> {
+    let mut req = Request::builder()
+        .method(Method::PATCH)
+        .uri(uri)
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(Body::from(form))
+        .unwrap();
+    req.extensions_mut().insert(Principal(uid));
+    req
+}
+
+async fn json(resp: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .expect("body");
+    serde_json::from_slice(&bytes).expect("json")
+}
+
+#[tokio::test]
+async fn list_returns_only_the_principals_rows() {
+    let app = router().await;
+    let resp = app
+        .clone()
+        .oneshot(as_user(Method::GET, "/notes", 1))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = json(resp).await;
+    assert_eq!(body["count"], 2);
+    for row in body["results"].as_array().expect("results") {
+        assert_eq!(row["owner_id"], 1);
+    }
+
+    // The other member sees their own single row — not a filtered view of a
+    // shared list, a different list.
+    let resp = app
+        .oneshot(as_user(Method::GET, "/notes", 2))
+        .await
+        .unwrap();
+    let body = json(resp).await;
+    assert_eq!(body["count"], 1);
+    assert_eq!(body["results"][0]["body"], "bob one");
+}
+
+#[tokio::test]
+async fn retrieve_of_someone_elses_row_is_not_found() {
+    let app = router().await;
+    // Bob's row (id 3) is readable by Bob…
+    let resp = app
+        .clone()
+        .oneshot(as_user(Method::GET, "/notes/3", 2))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // …and simply does not exist for Alice. 404, not 403: a 403 would tell
+    // her the id is real.
+    let resp = app
+        .oneshot(as_user(Method::GET, "/notes/3", 1))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn update_cannot_reach_across_owners() {
+    let app = router().await;
+    let resp = app
+        .clone()
+        .oneshot(patch_as("/notes/3", 1, "body=owned+by+alice+now"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    // The row is untouched — the guard is the query, not the response code.
+    let resp = app
+        .clone()
+        .oneshot(as_user(Method::GET, "/notes/3", 2))
+        .await
+        .unwrap();
+    assert_eq!(json(resp).await["body"], "bob one");
+
+    // The owner's own update still works, and reads back.
+    let resp = app
+        .clone()
+        .oneshot(patch_as("/notes/3", 2, "body=edited"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(json(resp).await["body"], "edited");
+}
+
+#[tokio::test]
+async fn destroy_cannot_reach_across_owners() {
+    let app = router().await;
+    let resp = app
+        .clone()
+        .oneshot(as_user(Method::DELETE, "/notes/3", 1))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    let resp = app
+        .clone()
+        .oneshot(as_user(Method::GET, "/notes/3", 2))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "row survived the attempt");
+
+    let resp = app
+        .clone()
+        .oneshot(as_user(Method::DELETE, "/notes/3", 2))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let resp = app
+        .oneshot(as_user(Method::GET, "/notes/3", 2))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn a_backend_without_a_principal_fails_closed() {
+    // No extension on the request: the default `filter` runs and denies.
+    let app = router().await;
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/notes")
+        .body(Body::empty())
+        .unwrap();
+    let body = json(app.oneshot(req).await.unwrap()).await;
+    assert_eq!(body["count"], 0);
+}

--- a/docs/files.md
+++ b/docs/files.md
@@ -188,6 +188,24 @@ It also handles soft-delete and orphan purging. The full flow is dogfooded in
 `media_sqlite_live.rs`; the manager's presigned/direct-upload methods are
 PostgreSQL-oriented.
 
+### How the media tables are created
+
+The media tables (`rustango_media`, `rustango_media_collections`,
+`rustango_media_tags`, `rustango_media_tag_links`) are managed models. Their
+schema ships as a **system migration** and is created — per tenant, when the
+`media` feature is enabled — the same way as the rest of the framework's own
+tables, whenever you run `migrate` / provision a tenant. There is no lazy
+"create on first use" step; if the feature is off, the tables are never created.
+
+> **Upgrading from before 0.51.** Earlier versions created the media tables
+> lazily via an `ensure_table` DDL call rather than a migration. On the first
+> `migrate` (or tenant provision) after upgrading, the framework **auto-reconciles**:
+> because the tables already exist, the generated media migration is recorded in
+> the system-migration ledger *without* re-running its `CREATE TABLE`, and your
+> existing rows are left untouched. **No manual step is required** — the upgrade
+> that would otherwise fail with `relation already exists` / `table already exists`
+> now just works. (Introduced in 0.51.1; see the CHANGELOG.)
+
 ---
 
 ## Reference

--- a/docs/viewsets.md
+++ b/docs/viewsets.md
@@ -715,8 +715,56 @@ let api = Router::new()
     .route("/api/posts/bulk_archive", post(bulk_archive));
 ```
 
-For per-list extra `WHERE` logic, `.filter_backend(…)` contributes predicates to
-the built-in list query without a separate route.
+For extra `WHERE` logic, `.filter_backend(…)` contributes predicates without a
+separate route.
+
+### Scoping rows to the authenticated principal
+
+A backend runs on **every** action — `list`, `retrieve`, `update`, `destroy` —
+so it behaves like DRF's `get_queryset()`. A row the backend excludes is a
+**404** on the item routes, not a 403: a 403 would confirm the id exists.
+
+The principal lives in the request extensions, not the query string, so
+implement the trait and override `filter_with`, which receives the request
+`Parts`:
+
+```rust
+use axum::http::request::Parts;
+use rustango::viewset::ViewSetFilter;
+
+struct OwnerFilter;
+
+impl ViewSetFilter for OwnerFilter {
+    // No principal in hand — fail closed. Returning no predicates here would
+    // widen the query to every row in the table.
+    fn filter(&self, _p: &HashMap<String, String>, schema: &'static ModelSchema) -> Vec<WhereExpr> {
+        deny_all(schema)
+    }
+
+    fn filter_with(
+        &self,
+        parts: &Parts,
+        _p: &HashMap<String, String>,
+        schema: &'static ModelSchema,
+    ) -> Vec<WhereExpr> {
+        let Some(user) = parts.extensions.get::<AuthenticatedUser>() else {
+            return deny_all(schema);
+        };
+        vec![WhereExpr::Predicate(Filter {
+            column: schema.field("owner_id").expect("owner_id").column,
+            op: Op::Eq,
+            value: SqlValue::from(user.id),
+        })]
+    }
+}
+
+ViewSet::for_model(Note::SCHEMA)
+    .filter_backend(OwnerFilter)
+    .tenant_router("/api/notes")
+```
+
+`filter_with` defaults to `filter`, so a backend that does not need the request
+— including the plain closure form — implements only `filter` as before.
 
 ---
 


### PR DESCRIPTION
Two gaps that together make a per-user REST API impossible to build safely on `ViewSet`.

## 1. A backend cannot see who is asking

`ViewSetFilter::filter(params, schema)` receives only the query string. The authenticated principal lives in the request extensions, so the single predicate every per-user API needs — *rows belonging to the caller* — could not be expressed at all.

Added `filter_with(&Parts, params, schema)`, **defaulted to `filter`**, so every existing backend (including the plain closure form) compiles and behaves exactly as before.

## 2. Backends ran on `list` only

This is the worse half. Scoping the collection while leaving every row reachable by id reads as safe and isn't: an app that filtered its list was still one `GET /notes/3` away from another user's data.

Backends now narrow `retrieve`, `update` and `destroy` too — DRF's `get_queryset()` contract:

- an excluded row is **404**, not 403, on the item routes (a 403 confirms the id exists);
- an `UPDATE` matching nothing returns 404 instead of reporting success;
- the read-back after an update is scoped, so it cannot return a row the caller may not see.

## Tests

`crates/rustango/tests/viewset_principal_filter_sqlite_live.rs` — list narrows per principal; cross-owner retrieve/update/destroy are 404 **with the row asserted untouched**; the owner's own update still works and reads back; and a backend with no principal in hand fails closed rather than widening to every row.

`cargo test --workspace --all-features`: 494 test binaries, zero failures. `cargo clippy -p rustango --features tenancy --lib --no-deps` clean.

Version 0.52.0 — new public trait method, plus a behaviour change on the item routes for anyone already using `filter_backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)