### PR TITLE
feat(viewset): scope a queryset to whoever the request authenticated as (#1183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,51 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
-_Nothing yet — next development cycle._
+Headline: **a `ViewSet` can finally be scoped to the caller** (#1183) — the
+authenticated identity is available to filter backends, backends apply to every
+action, and `OwnedBy` does the common case in one line.
+
+### Added
+
+- **`ViewSetFilter::filter_with(&Parts, params, schema)`** — a default-provided
+  companion to `filter` that receives the request `Parts`, so a backend can read
+  the authenticated principal out of the extensions. `filter` alone sees only
+  the query string, which means "only this user's rows" could not be written at
+  all — apps were pushing the owner column into `filter_fields` and trusting the
+  client to send `?owner_id=`, which is not authorization. The default delegates
+  to `filter`, so every existing backend — including the plain closure form —
+  compiles and behaves exactly as before.
+
+- **`tenancy::Principal`** — one identity type, resolved from whichever
+  middleware verified the request: an explicit `Principal`, an
+  `AuthenticatedUser` (session or Bearer), or an MCP agent token, which acts as
+  the user who minted it. Available as an extractor (401 when absent) and as
+  `OptionalPrincipal` where anonymous is a valid answer. It authenticates
+  nothing itself — it reads only what a verifying layer already proved.
+
+- **`viewset::OwnedBy`** — the shipped ownership backend:
+  `.filter_backend(OwnedBy::column("member_id"))`. Any column name works, since
+  it takes the name rather than assuming a convention, and it fails closed on
+  both ways it can be wrong — an unauthenticated request and a column the model
+  does not have each match **nothing**, so a typo at mount time cannot become
+  "no predicates, return the table". `.superuser_sees_all()` opts superusers in;
+  they are not special by default, because "admins see everything" is a product
+  decision.
+
+- **`auth_routes::require_bearer`** — middleware that turns a Bearer access
+  token into a `Principal`: verifies against the resolved tenant, then re-reads
+  the user row, so a deactivated account stops working on the next request
+  rather than when the token expires. `Bearer` is now public alongside it.
+
+### Fixed
+
+- **Filter backends now scope `retrieve` / `update` / `destroy`, not just
+  `list`** — DRF's `get_queryset()` contract. Scoping the collection alone is
+  worse than not scoping: it reads as safe while every row stays reachable by
+  id. A row excluded by a backend is now a **404** on those actions (not a 403,
+  which would confirm the id exists), an `UPDATE` that matches nothing returns
+  404 rather than reporting success, and the read-back after an update is
+  scoped too.
 
 ## [0.51.2] — 2026-08-08
 

--- a/crates/rustango/src/tenancy/auth_routes.rs
+++ b/crates/rustango/src/tenancy/auth_routes.rs
@@ -46,6 +46,7 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
 use crate::extractors::Tenant;
+use crate::sql::FetcherPool as _;
 use crate::tenancy::jwt_lifecycle::JwtLifecycle;
 
 // ---------------------------------------------------------------- Config
@@ -488,6 +489,99 @@ async fn me(t: Tenant, bearer: Bearer) -> Result<Json<UserBrief>, Response> {
     }))
 }
 
+// ------------------------------------------------- Bearer → Principal layer
+
+/// Require a valid, tenant-pinned access token, and publish who sent it.
+///
+/// This is the API counterpart of the session-cookie middleware: it turns
+/// `Authorization: Bearer …` into an [`AuthenticatedUser`] and a [`Principal`]
+/// in the request extensions, which is what every downstream consumer reads —
+/// `ViewSet` permission gates, [`OwnedBy`] scoping, handlers taking the
+/// `Principal` extractor.
+///
+/// What it checks, in order:
+/// 1. signature, expiry, `typ = access`, and the JTI revocation list, via
+///    [`verify_for_tenant`];
+/// 2. the token's `tenant` claim against the resolved tenant — all tenants
+///    share one signing key, so this is the only thing standing between a
+///    token minted on `acme.` and a request to `globex.`;
+/// 3. the user row, **read per request**, so deactivating an account takes
+///    effect immediately rather than whenever the access token happens to
+///    expire.
+///
+/// ```no_run
+/// use axum::{middleware, Router};
+/// use rustango::tenancy::auth_routes::require_bearer;
+///
+/// # fn api() -> Router { Router::new() }
+/// let protected = api().layer(middleware::from_fn(require_bearer));
+/// ```
+///
+/// Mount it on the routes that need a user, not on `/auth/login` or
+/// `/auth/refresh` — those are how a client gets a token in the first place.
+///
+/// [`AuthenticatedUser`]: crate::tenancy::AuthenticatedUser
+/// [`Principal`]: crate::tenancy::Principal
+/// [`OwnedBy`]: crate::viewset::OwnedBy
+pub async fn require_bearer(
+    t: Tenant,
+    mut req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    let Some(token) = req
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+    else {
+        return unauthorized("missing Bearer token");
+    };
+
+    let user_id = match verify_for_tenant(token, &t.org.slug) {
+        Ok(id) => id,
+        // The reason is deliberately not echoed: "expired" vs "wrong tenant"
+        // vs "revoked" tells a prober which of those they achieved.
+        Err(_) => return unauthorized("invalid or expired token"),
+    };
+
+    let user = match crate::tenancy::auth::User::objects()
+        .filter("id", user_id)
+        .fetch(t.pool())
+        .await
+    {
+        Ok(rows) => rows.into_iter().next(),
+        Err(e) => {
+            tracing::error!(error = %e, "bearer auth could not read the user row");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "authentication failed").into_response();
+        }
+    };
+    let Some(user) = user.filter(|u| u.active) else {
+        // Deleted or deactivated between mint and use. Same body as a bad
+        // token: whether an account exists is not a fact this endpoint owes.
+        return unauthorized("invalid or expired token");
+    };
+
+    let id = user.id.get().copied().unwrap_or(user_id);
+    req.extensions_mut()
+        .insert(crate::tenancy::AuthenticatedUser {
+            id,
+            username: user.username.clone(),
+            is_superuser: user.is_superuser,
+        });
+    req.extensions_mut().insert(crate::tenancy::Principal::user(
+        id,
+        user.is_superuser,
+        Some(t.org.slug.clone()),
+    ));
+    next.run(req).await
+}
+
+fn unauthorized(msg: &'static str) -> Response {
+    (StatusCode::UNAUTHORIZED, msg).into_response()
+}
+
 // ---------------------------------------------------------------- Bearer
 
 /// Extracts the raw bearer token from the `Authorization` header.
@@ -496,7 +590,7 @@ async fn me(t: Tenant, bearer: Bearer) -> Result<Json<UserBrief>, Response> {
 /// looks the user row up against a `PgPool` (single-tenant); this
 /// extractor just pulls the token string and lets handlers do the
 /// per-tenant lookup themselves via [`Tenant`].
-struct Bearer(String);
+pub struct Bearer(pub String);
 
 impl<S: Send + Sync> FromRequestParts<S> for Bearer {
     type Rejection = Response;

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -95,6 +95,9 @@ mod org;
 pub mod password;
 pub mod permissions;
 mod pools;
+/// Who a request is acting as, whatever authenticated it (session cookie,
+/// Bearer access token, MCP agent token).
+pub mod principal;
 mod resolver;
 pub mod routes;
 mod secrets;
@@ -134,6 +137,7 @@ pub use auth_backends::{
 };
 pub use bootstrap::{init_tenancy, init_tenancy_with, InitTenancyReport};
 pub use middleware::{AuthenticatedUser, CurrentUser, RouterAuthExt};
+pub use principal::{OptionalPrincipal, Principal, PrincipalKind, TenantSlug};
 // v0.38 — the PG-typed permission helpers stay PG-only re-exports;
 // the tri-dialect `_pool` variants are the cross-dialect entry points.
 #[cfg(feature = "postgres")]

--- a/crates/rustango/src/tenancy/principal.rs
+++ b/crates/rustango/src/tenancy/principal.rs
@@ -1,0 +1,234 @@
+//! Who a request is acting as — one type, whatever authenticated it.
+//!
+//! A request can arrive carrying a session cookie, a Bearer access token, or an
+//! MCP agent token, and each of those middlewares has historically left behind
+//! a different extension: [`AuthenticatedUser`], `CurrentMember`, `McpAgent`.
+//! Anything downstream that needs "which user is this" — a queryset scoped to
+//! its owner, an audit line, a permission check — then has to know which auth
+//! path ran, and gets it wrong for the paths nobody tested.
+//!
+//! [`Principal`] is that answer, resolved once from whatever is present. It is
+//! deliberately *not* another auth mechanism: it authenticates nothing, mints
+//! nothing, and reads only what a verifying middleware already proved.
+//!
+//! ```no_run
+//! use rustango::tenancy::Principal;
+//!
+//! async fn handler(principal: Principal) -> String {
+//!     format!("hello, user {}", principal.user_id)
+//! }
+//! ```
+
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+use super::middleware::AuthenticatedUser;
+
+/// How the request proved who it is. Kept because the answer sometimes
+/// matters: an agent token acts *for* a user but is not that user sitting at a
+/// browser, and an audit trail that cannot tell them apart is worth less.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrincipalKind {
+    /// A signed-in user — session cookie or a Bearer access token.
+    User,
+    /// A machine token acting on behalf of the user who minted it.
+    Agent,
+}
+
+/// The identity behind a request.
+///
+/// Populated by whichever middleware verified the request; see
+/// [`Principal::from_parts`] for the resolution order. Absence means
+/// unauthenticated — never "assume anonymous is fine".
+#[derive(Clone, Debug)]
+pub struct Principal {
+    /// `rustango_users.id`. For an agent token this is the **owner**, so work
+    /// done by a key scopes to the person who created it.
+    pub user_id: i64,
+    /// Authoritative only as of whenever the middleware last read the row.
+    pub is_superuser: bool,
+    /// Tenant slug the credential is pinned to, when it carries one. A token
+    /// without this cannot be checked against the resolved tenant.
+    pub tenant: Option<String>,
+    pub kind: PrincipalKind,
+    /// `rustango_agents.id` when [`PrincipalKind::Agent`].
+    pub agent_id: Option<i64>,
+}
+
+impl Principal {
+    /// A signed-in user.
+    #[must_use]
+    pub fn user(user_id: i64, is_superuser: bool, tenant: Option<String>) -> Self {
+        Self {
+            user_id,
+            is_superuser,
+            tenant,
+            kind: PrincipalKind::User,
+            agent_id: None,
+        }
+    }
+
+    /// A signed-in superuser. Convenience for tests and for middleware that
+    /// has already read the flag.
+    #[must_use]
+    pub fn admin(user_id: i64) -> Self {
+        Self {
+            is_superuser: true,
+            ..Self::user(user_id, true, None)
+        }
+    }
+
+    /// Resolve from whatever a verifying middleware left in the extensions.
+    ///
+    /// Order, most specific first:
+    /// 1. an explicit [`Principal`] — an app that resolved its own wins;
+    /// 2. [`AuthenticatedUser`] — `require_auth`, the Bearer middleware, any
+    ///    auth backend;
+    /// 3. an `McpAgent` **that owns a user** — the agent acts as that user. A
+    ///    standalone machine agent has no user to act as and yields `None`,
+    ///    which is what keeps an ownership filter from matching everyone's rows.
+    ///
+    /// Returns `None` when the request is unauthenticated. This function
+    /// verifies nothing on its own — a forged extension would be trusted, so
+    /// nothing may insert one without checking a credential first.
+    #[must_use]
+    pub fn from_parts(parts: &Parts) -> Option<Self> {
+        if let Some(p) = parts.extensions.get::<Self>() {
+            return Some(p.clone());
+        }
+        if let Some(u) = parts.extensions.get::<AuthenticatedUser>() {
+            return Some(Self {
+                user_id: u.id,
+                is_superuser: u.is_superuser,
+                tenant: parts
+                    .extensions
+                    .get::<TenantSlug>()
+                    .map(|TenantSlug(s)| s.clone()),
+                kind: PrincipalKind::User,
+                agent_id: None,
+            });
+        }
+        #[cfg(feature = "mcp")]
+        if let Some(agent) = parts.extensions.get::<crate::mcp::auth::McpAgent>() {
+            return agent.user_id.map(|uid| Self {
+                user_id: uid,
+                // An agent token carries no superuser bit; it is bounded by the
+                // skills its key was granted, not by the owner's admin rights.
+                is_superuser: false,
+                tenant: Some(agent.tenant.clone()),
+                kind: PrincipalKind::Agent,
+                agent_id: Some(agent.agent_id),
+            });
+        }
+        None
+    }
+
+    /// Whether this principal may act on a row owned by `owner_id`.
+    ///
+    /// Superusers pass only when the caller opts in, because "admins see
+    /// everything" is a product decision, not a framework one.
+    #[must_use]
+    pub fn may_access(&self, owner_id: i64, superuser_sees_all: bool) -> bool {
+        self.user_id == owner_id || (superuser_sees_all && self.is_superuser)
+    }
+}
+
+/// The resolved tenant's slug, for middleware that wants [`Principal::tenant`]
+/// populated from a cookie session (which carries no slug of its own).
+#[derive(Clone, Debug)]
+pub struct TenantSlug(pub String);
+
+/// Rejection for the [`Principal`] extractor: 401, never 403 — the request did
+/// not say who it is, which is a different failure from saying so and being
+/// refused.
+#[derive(Debug)]
+pub struct Unauthenticated;
+
+impl IntoResponse for Unauthenticated {
+    fn into_response(self) -> Response {
+        (StatusCode::UNAUTHORIZED, "authentication required").into_response()
+    }
+}
+
+impl<S: Send + Sync> FromRequestParts<S> for Principal {
+    type Rejection = Unauthenticated;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        Self::from_parts(parts).ok_or(Unauthenticated)
+    }
+}
+
+/// [`Principal`] where absence is a valid answer — a page that renders
+/// differently when signed in, rather than one that refuses.
+#[derive(Clone, Debug)]
+pub struct OptionalPrincipal(pub Option<Principal>);
+
+impl<S: Send + Sync> FromRequestParts<S> for OptionalPrincipal {
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(Self(Principal::from_parts(parts)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parts() -> Parts {
+        axum::http::Request::builder()
+            .body(())
+            .expect("request")
+            .into_parts()
+            .0
+    }
+
+    #[test]
+    fn unauthenticated_requests_have_no_principal() {
+        assert!(Principal::from_parts(&parts()).is_none());
+    }
+
+    #[test]
+    fn an_authenticated_user_becomes_a_user_principal() {
+        let mut p = parts();
+        p.extensions.insert(AuthenticatedUser {
+            id: 7,
+            username: "ada".into(),
+            is_superuser: true,
+        });
+        p.extensions.insert(TenantSlug("acme".into()));
+        let principal = Principal::from_parts(&p).expect("principal");
+        assert_eq!(principal.user_id, 7);
+        assert!(principal.is_superuser);
+        assert_eq!(principal.tenant.as_deref(), Some("acme"));
+        assert_eq!(principal.kind, PrincipalKind::User);
+    }
+
+    #[test]
+    fn an_explicit_principal_wins_over_a_derived_one() {
+        // An app that resolved its own identity — from a signed header, say —
+        // must not have it silently replaced by a lower-precedence source.
+        let mut p = parts();
+        p.extensions.insert(AuthenticatedUser {
+            id: 7,
+            username: "ada".into(),
+            is_superuser: false,
+        });
+        p.extensions
+            .insert(Principal::user(99, false, Some("acme".into())));
+        assert_eq!(Principal::from_parts(&p).expect("principal").user_id, 99);
+    }
+
+    #[test]
+    fn access_is_ownership_unless_superusers_are_let_through() {
+        let owner = Principal::user(7, false, None);
+        assert!(owner.may_access(7, false));
+        assert!(!owner.may_access(8, false));
+
+        let admin = Principal::user(1, true, None);
+        assert!(!admin.may_access(8, false), "opt-in, not automatic");
+        assert!(admin.may_access(8, true));
+    }
+}

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -398,14 +398,167 @@ where
 ///     .router_pool("/posts", pool);
 /// ```
 ///
-/// Backends run on the **list** action.
+/// Backends run on **every** action: they narrow the list query, and they
+/// scope `retrieve` / `update` / `destroy` so a row the backend excludes is a
+/// 404 rather than someone else's data. That is DRF's `get_queryset()`
+/// contract, and without it an ownership backend would guard the collection
+/// while leaving every row reachable by id.
 pub trait ViewSetFilter: Send + Sync + 'static {
-    /// Return `WHERE` predicates to AND into the list query for this request.
+    /// Return `WHERE` predicates to AND into the query for this request.
     fn filter(
         &self,
         params: &HashMap<String, String>,
         schema: &'static ModelSchema,
     ) -> Vec<WhereExpr>;
+
+    /// As [`Self::filter`], with the request's [`Parts`] in hand.
+    ///
+    /// The authenticated principal lives in the request extensions, not in the
+    /// query string, so "only this user's rows" cannot be written against
+    /// `filter` alone. Defaults to [`Self::filter`], so every existing backend
+    /// — including the plain closure form — keeps compiling and behaving
+    /// exactly as before.
+    ///
+    /// [`Parts`]: axum::http::request::Parts
+    fn filter_with(
+        &self,
+        _parts: &axum::http::request::Parts,
+        params: &HashMap<String, String>,
+        schema: &'static ModelSchema,
+    ) -> Vec<WhereExpr> {
+        self.filter(params, schema)
+    }
+}
+
+/// Scope every row to the principal that owns it.
+///
+/// The reusable half of ownership: name the column that holds the owner and
+/// mount it. It works on any model with such a column — `owner_id`,
+/// `member_id`, `user_id`, `created_by` — and applies to every action, so the
+/// collection and the item routes cannot disagree.
+///
+/// ```no_run
+/// # use rustango::viewset::{OwnedBy, ViewSet};
+/// # use rustango::core::Model as _;
+/// # #[derive(rustango::Model)] #[rustango(table = "note")]
+/// # pub struct Note { #[rustango(primary_key)] pub id: rustango::sql::Auto<i64>, pub owner_id: i64 }
+/// # fn main() {
+/// ViewSet::for_model(Note::SCHEMA)
+///     .filter_backend(OwnedBy::column("owner_id"))
+///     .tenant_router("/api/notes");
+/// # }
+/// ```
+///
+/// The owner comes from [`Principal`], which every auth path populates, so the
+/// same backend covers a cookie session, a Bearer token and an agent token
+/// without knowing which one ran. It is **never** read from the query string:
+/// a client that could name its own `owner_id` is not being authorized.
+///
+/// Fails closed. No principal ⇒ a contradiction, matching nothing — an
+/// unauthenticated request sees an empty list rather than the whole table.
+/// Pair it with an auth layer that rejects those requests outright; this is
+/// the second line, not the first.
+///
+/// [`Principal`]: crate::tenancy::Principal
+#[cfg(feature = "tenancy")]
+#[derive(Clone, Copy, Debug)]
+pub struct OwnedBy {
+    column: &'static str,
+    superuser_sees_all: bool,
+}
+
+#[cfg(feature = "tenancy")]
+impl OwnedBy {
+    /// Scope to `column = <principal's user id>`.
+    #[must_use]
+    pub const fn column(column: &'static str) -> Self {
+        Self {
+            column,
+            superuser_sees_all: false,
+        }
+    }
+
+    /// Let superusers read and write every row.
+    ///
+    /// Off by default: "admins see everything" is a product decision. A
+    /// support tool wants it; a gym app where the owner is also a member
+    /// emphatically does not.
+    #[must_use]
+    pub const fn superuser_sees_all(self) -> Self {
+        Self {
+            superuser_sees_all: true,
+            ..self
+        }
+    }
+}
+
+#[cfg(feature = "tenancy")]
+impl ViewSetFilter for OwnedBy {
+    fn filter(
+        &self,
+        _params: &HashMap<String, String>,
+        schema: &'static ModelSchema,
+    ) -> Vec<WhereExpr> {
+        // Reached only when something calls the params-only path — no request
+        // in hand means no principal, and no principal means no rows.
+        vec![match_nothing(schema)]
+    }
+
+    fn filter_with(
+        &self,
+        parts: &axum::http::request::Parts,
+        _params: &HashMap<String, String>,
+        schema: &'static ModelSchema,
+    ) -> Vec<WhereExpr> {
+        let Some(principal) = crate::tenancy::Principal::from_parts(parts) else {
+            return vec![match_nothing(schema)];
+        };
+        if self.superuser_sees_all && principal.is_superuser {
+            return Vec::new();
+        }
+        let Some(field) = schema.field(self.column) else {
+            // The column named at mount time is not on this model. Denying is
+            // the only safe reading of "scope to an owner I cannot find".
+            tracing::error!(
+                model = schema.table,
+                column = self.column,
+                "OwnedBy names a column this model does not have — denying every row"
+            );
+            return vec![match_nothing(schema)];
+        };
+        vec![WhereExpr::Predicate(Filter {
+            column: field.column,
+            op: Op::Eq,
+            value: SqlValue::from(principal.user_id),
+        })]
+    }
+}
+
+/// A predicate no row satisfies: `col IS NULL AND col IS NOT NULL`.
+///
+/// A contradiction rather than `1 = 0` because it binds no parameters and
+/// every dialect writes it the same way. Used wherever a scoping backend
+/// cannot determine the principal — returning *no* predicates there would
+/// widen the query to the whole table, which is the failure this exists to
+/// prevent.
+#[cfg(feature = "tenancy")]
+fn match_nothing(schema: &'static ModelSchema) -> WhereExpr {
+    let column = schema
+        .primary_key()
+        .or_else(|| schema.scalar_fields().next())
+        .map_or("id", |f| f.column);
+    WhereExpr::And(vec![
+        WhereExpr::Predicate(Filter {
+            column,
+            op: Op::IsNull,
+            value: SqlValue::Bool(true),
+        }),
+        WhereExpr::Predicate(Filter {
+            column,
+            op: Op::IsNull,
+            value: SqlValue::Bool(false),
+        }),
+    ])
 }
 
 impl<F> ViewSetFilter for F
@@ -1169,6 +1322,32 @@ macro_rules! or_400 {
 /// it; the helper still returns the body so write paths
 /// (`handle_create`, `update_inner`) can consume it after the
 /// permission gate.
+/// Predicates every backend contributes for this request, ANDed into
+/// whatever query the action is about to run.
+fn scope_filters(
+    state: &ViewSetState,
+    parts: &axum::http::request::Parts,
+    params: &HashMap<String, String>,
+) -> Vec<WhereExpr> {
+    state
+        .vs
+        .filter_backends
+        .iter()
+        .flat_map(|b| b.filter_with(parts, params, state.vs.schema))
+        .collect()
+}
+
+/// `expr` narrowed by `extra`. An empty `extra` returns `expr` untouched, so
+/// a ViewSet with no backends builds the same SQL it always did.
+fn narrow(expr: WhereExpr, extra: Vec<WhereExpr>) -> WhereExpr {
+    if extra.is_empty() {
+        return expr;
+    }
+    let mut all = vec![expr];
+    all.extend(extra);
+    WhereExpr::And(all)
+}
+
 async fn enter(
     state: &Arc<ViewSetState>,
     req: axum::extract::Request,
@@ -1371,11 +1550,11 @@ async fn handle_list(
     Query(params): Query<HashMap<String, String>>,
     req: axum::extract::Request,
 ) -> Response {
-    let (_parts, _body, acq) = match enter(&state, req, &state.vs.perms.list, "list").await {
+    let (parts, _body, acq) = match enter(&state, req, &state.vs.perms.list, "list").await {
         Ok(x) => x,
         Err(resp) => return resp,
     };
-    run_list(state, params, acq).await
+    run_list(state, params, acq, &parts).await
 }
 
 /// Core `list` logic shared by the GET `list` action and the RFC 10008
@@ -1387,6 +1566,7 @@ async fn run_list(
     state: Arc<ViewSetState>,
     params: HashMap<String, String>,
     mut acq: AcquiredConn,
+    parts: &axum::http::request::Parts,
 ) -> Response {
     let page_size: i64 = params
         .get("page_size")
@@ -1428,9 +1608,7 @@ async fn run_list(
 
     // #1010 — pluggable filter backends contribute extra predicates,
     // ANDed with the built-in filter_fields parsed above.
-    for backend in &state.vs.filter_backends {
-        filters.extend(backend.filter(&params, state.vs.schema));
-    }
+    filters.extend(scope_filters(&state, parts, &params));
 
     let where_clause = if filters.len() == 1 {
         filters.remove(0)
@@ -1608,7 +1786,7 @@ async fn handle_query(
         Ok(p) => p,
         Err(resp) => return resp,
     };
-    run_list(state, params, acq).await
+    run_list(state, params, acq, &parts).await
 }
 
 /// Parse a QUERY request body into the same `HashMap<String, String>`
@@ -1808,7 +1986,7 @@ async fn handle_retrieve(
     Path(pk_raw): Path<String>,
     req: axum::extract::Request,
 ) -> Response {
-    let (_parts, _body, mut acq) =
+    let (parts, _body, mut acq) =
         match enter(&state, req, &state.vs.perms.retrieve, "retrieve").await {
             Ok(x) => x,
             Err(resp) => return resp,
@@ -1825,7 +2003,11 @@ async fn handle_retrieve(
 
     // #562 — was 11-field struct literal; SelectQuery::by_pk constructs
     // the single-PK-lookup shape directly.
-    let select_q = SelectQuery::by_pk(state.vs.schema, pk_field.column, pk_val);
+    let mut select_q = SelectQuery::by_pk(state.vs.schema, pk_field.column, pk_val);
+    // …narrowed by the filter backends, so a row this principal may not see
+    // reads as absent rather than forbidden — a 403 would confirm the id.
+    let scope = scope_filters(&state, &parts, &HashMap::new());
+    select_q.where_clause = narrow(select_q.where_clause, scope);
 
     let fields = state.effective_fields();
     match render_single(&state, &mut acq, &select_q, &fields).await {
@@ -2040,6 +2222,8 @@ async fn update_inner(
         Ok(x) => x,
         Err(resp) => return resp,
     };
+    // Scope first: an update must not reach a row this principal cannot see.
+    let scope = scope_filters(&state, &parts, &HashMap::new());
 
     let pk_field = match pk_field_or_500(&state) {
         Ok(f) => f,
@@ -2093,19 +2277,26 @@ async fn update_inner(
     let query = UpdateQuery {
         model: state.vs.schema,
         set: assignments,
-        where_clause: WhereExpr::Predicate(Filter {
-            column: pk_field.column,
-            op: Op::Eq,
-            value: pk_val.clone(),
-        }),
+        where_clause: narrow(
+            WhereExpr::Predicate(Filter {
+                column: pk_field.column,
+                op: Op::Eq,
+                value: pk_val.clone(),
+            }),
+            scope.clone(),
+        ),
     };
 
-    if let Err(e) = acq.update(&query).await {
-        return json_error(StatusCode::BAD_REQUEST, &e.to_string());
+    match acq.update(&query).await {
+        // Nothing matched: either no such row, or one this principal is
+        // scoped out of. Both are a 404 — see `handle_retrieve`.
+        Ok(0) => return json_error(StatusCode::NOT_FOUND, "not found"),
+        Ok(_) => {}
+        Err(e) => return json_error(StatusCode::BAD_REQUEST, &e.to_string()),
     }
 
     let fields = state.effective_fields();
-    match fetch_by_pk(&state, &mut acq, pk_field, pk_val, &fields).await {
+    match fetch_by_pk_scoped(&state, &mut acq, pk_field, pk_val, &fields, scope).await {
         Some(obj) => json_response(obj),
         None => json_error(StatusCode::NOT_FOUND, "not found after update"),
     }
@@ -2116,11 +2307,12 @@ async fn handle_destroy(
     Path(pk_raw): Path<String>,
     req: axum::extract::Request,
 ) -> Response {
-    let (_parts, _body, mut acq) =
-        match enter(&state, req, &state.vs.perms.destroy, "destroy").await {
-            Ok(x) => x,
-            Err(resp) => return resp,
-        };
+    let (parts, _body, mut acq) = match enter(&state, req, &state.vs.perms.destroy, "destroy").await
+    {
+        Ok(x) => x,
+        Err(resp) => return resp,
+    };
+    let scope = scope_filters(&state, &parts, &HashMap::new());
 
     let pk_field = match pk_field_or_500(&state) {
         Ok(f) => f,
@@ -2133,11 +2325,14 @@ async fn handle_destroy(
 
     let query = DeleteQuery {
         model: state.vs.schema,
-        where_clause: WhereExpr::Predicate(Filter {
-            column: pk_field.column,
-            op: Op::Eq,
-            value: pk_val,
-        }),
+        where_clause: narrow(
+            WhereExpr::Predicate(Filter {
+                column: pk_field.column,
+                op: Op::Eq,
+                value: pk_val,
+            }),
+            scope,
+        ),
     };
 
     match acq.delete(&query).await {
@@ -2148,6 +2343,24 @@ async fn handle_destroy(
 }
 
 // ------------------------------------------------------------------ helpers
+
+/// [`fetch_by_pk`] narrowed by the filter backends — the read-back after an
+/// update, which must not return a row the principal is scoped out of.
+async fn fetch_by_pk_scoped(
+    state: &ViewSetState,
+    acq: &mut AcquiredConn,
+    pk_field: &'static crate::core::FieldSchema,
+    pk_val: SqlValue,
+    fields: &[&'static crate::core::FieldSchema],
+    scope: Vec<WhereExpr>,
+) -> Option<Value> {
+    let mut select_q = SelectQuery::by_pk(state.vs.schema, pk_field.column, pk_val);
+    select_q.where_clause = narrow(select_q.where_clause, scope);
+    render_single(state, acq, &select_q, fields)
+        .await
+        .ok()
+        .flatten()
+}
 
 async fn fetch_by_pk(
     state: &ViewSetState,

--- a/crates/rustango/tests/owned_by_bearer_sqlite_live.rs
+++ b/crates/rustango/tests/owned_by_bearer_sqlite_live.rs
@@ -1,0 +1,321 @@
+#![allow(irrefutable_let_patterns)] // Pool enum is single-variant in sqlite-only builds.
+//! The whole ownership path, end to end: a Bearer token arrives, the tenancy
+//! middleware turns it into a `Principal`, and `OwnedBy` narrows the SQL.
+//!
+//! Every piece has its own test elsewhere; this one exists because the seam
+//! between them is where a per-user API actually leaks. It asserts the two
+//! properties that matter and cannot be checked in isolation:
+//!
+//! * a token for member A never returns member B's rows, on **any** action;
+//! * a token minted for another tenant is refused even though both tenants
+//!   share one signing key.
+
+// `not(postgres)`: the `Tenant` extractor looks up `TenantContext<DefaultDb>`,
+// and enabling the postgres feature makes that Postgres — the sqlite context
+// this test hands it would simply not be found.
+#![cfg(all(
+    feature = "sqlite",
+    feature = "tenancy",
+    feature = "passwords",
+    feature = "admin",
+    not(feature = "postgres")
+))]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use axum::Router;
+use rustango::core::Model as _;
+use rustango::extractors::{Tenant, TenantContext};
+use rustango::sql::sqlx;
+use rustango::sql::{Auto, Pool};
+use rustango::tenancy::auth_routes::require_bearer;
+use rustango::tenancy::jwt_lifecycle::JwtLifecycle;
+use rustango::tenancy::{
+    session::SessionSecret, ChainResolver, Org, OrgResolver, TenancyError, TenantPools,
+};
+use rustango::viewset::{OwnedBy, ViewSet};
+use rustango::Model;
+use serde_json::Value;
+use tower::ServiceExt as _;
+
+/// Must match what `auth_routes` signs with — the middleware verifies through
+/// the same process-wide handle the login route mints from, and that handle
+/// reads `RUSTANGO_SESSION_SECRET`.
+const SECRET: &[u8] = b"owned_by_bearer_test_secret_32byte!!";
+
+/// Set the signing key before anything touches the JWT handle. It is a
+/// `OnceLock` inside `auth_routes`, so the first call in the process wins —
+/// every test has to go through here first.
+fn install_secret() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        std::env::set_var(
+            "RUSTANGO_SESSION_SECRET",
+            std::str::from_utf8(SECRET).expect("utf8 secret"),
+        );
+    });
+}
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "ob_note")]
+#[rustango(app = "ob_app")]
+pub struct Note {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    /// The ownership column `OwnedBy` is pointed at. Named `member_id` rather
+    /// than `owner_id` on purpose: the backend must not assume a convention.
+    pub member_id: i64,
+    #[rustango(max_length = 200)]
+    pub body: String,
+}
+
+#[derive(Clone)]
+struct FixedResolver(Org);
+
+#[async_trait::async_trait]
+impl OrgResolver for FixedResolver {
+    async fn resolve(
+        &self,
+        _parts: &axum::http::request::Parts,
+        _registry: &Pool,
+    ) -> Result<Option<Org>, TenancyError> {
+        Ok(Some(self.0.clone()))
+    }
+}
+
+/// Each test gets its own database file, so the parallel harness doesn't have
+/// them seeding over each other.
+///
+/// A file, not `:memory:`: the test seeds through one pool and the tenant
+/// extractor opens another, and two connections to a sqlite in-memory URL are
+/// two different databases — the seeded tables simply aren't there.
+fn db_path(name: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("rustango_owned_by_{name}.sqlite"))
+}
+
+fn db_url(name: &str) -> String {
+    format!("sqlite://{}?mode=rwc", db_path(name).display())
+}
+
+fn org(slug: &str, name: &str) -> Org {
+    Org {
+        slug: slug.to_owned(),
+        display_name: "Acme".into(),
+        storage_mode: "database".into(),
+        backend_kind: "sqlite".into(),
+        database_url: Some(db_url(name)),
+        ..rustango::testkit::org()
+    }
+}
+
+async fn seed_member(pool: &Pool, username: &str, active: bool) -> i64 {
+    let mut u = rustango::tenancy::User {
+        username: username.into(),
+        password_hash: rustango::tenancy::password::hash("irrelevant").expect("hash"),
+        active,
+        ..rustango::testkit::user()
+    };
+    u.insert_pool(pool).await.expect("seed user");
+    u.id.get().copied().expect("user id")
+}
+
+/// The app under test: notes scoped to their owner, behind Bearer auth.
+///
+/// `name` keys this test's private database; `slug` is the tenant the request
+/// resolves to.
+async fn app(slug: &str, name: &str) -> (Router, i64, i64, i64) {
+    install_secret();
+    // Fresh every run — a leftover file from a previous run would carry its
+    // rows into this one and quietly change what the assertions mean.
+    let _ = std::fs::remove_file(db_path(name));
+    let seeder = sqlx::SqlitePool::connect(&db_url(name))
+        .await
+        .expect("tenant db");
+    let pool = Pool::Sqlite(seeder);
+    rustango::testkit::create_tables_for::<rustango::tenancy::User>(&pool)
+        .await
+        .expect("users table");
+    rustango::testkit::create_tables_for::<Note>(&pool)
+        .await
+        .expect("notes table");
+
+    let alice = seed_member(&pool, "alice", true).await;
+    let bob = seed_member(&pool, "bob", true).await;
+    let ghost = seed_member(&pool, "ghost", false).await; // deactivated
+
+    for (member_id, body) in [(alice, "alice one"), (alice, "alice two"), (bob, "bob one")] {
+        let mut n = Note {
+            id: Auto::Unset,
+            member_id,
+            body: body.into(),
+        };
+        n.insert_pool(&pool).await.expect("seed note");
+    }
+
+    let registry = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("registry");
+    let ctx = Arc::new(TenantContext::<sqlx::Sqlite> {
+        pools: Arc::new(TenantPools::new(registry)),
+        resolver: ChainResolver::new().push(FixedResolver(org(slug, name))),
+        session_secret: SessionSecret::from_bytes(SECRET.to_vec()),
+        operator_secret: SessionSecret::from_bytes(SECRET.to_vec()),
+    });
+
+    let router = ViewSet::for_model(Note::SCHEMA)
+        .page_size(100)
+        .filter_backend(OwnedBy::column("member_id"))
+        .tenant_router("/notes")
+        .layer(axum::middleware::from_fn(require_bearer))
+        .layer(axum::middleware::from_fn(
+            move |mut req: Request<Body>, next: axum::middleware::Next| {
+                let ctx = ctx.clone();
+                async move {
+                    req.extensions_mut().insert(ctx);
+                    next.run(req).await
+                }
+            },
+        ));
+
+    (router, alice, bob, ghost)
+}
+
+/// An access token exactly as `/api/auth/login` mints one: tenant-pinned.
+fn token_for(user_id: i64, tenant: &str) -> String {
+    let jwt = JwtLifecycle::new(SECRET.to_vec());
+    let mut custom = serde_json::Map::new();
+    custom.insert("tenant".into(), Value::String(tenant.to_owned()));
+    jwt.issue_pair_with(user_id, custom).expect("issue").access
+}
+
+fn req(method: Method, uri: &str, token: Option<&str>) -> Request<Body> {
+    let mut b = Request::builder().method(method).uri(uri);
+    if let Some(t) = token {
+        b = b.header(header::AUTHORIZATION, format!("Bearer {t}"));
+    }
+    b.body(Body::empty()).expect("request")
+}
+
+async fn json(resp: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .expect("body");
+    serde_json::from_slice(&bytes).expect("json")
+}
+
+#[tokio::test]
+async fn a_token_sees_only_its_own_rows() {
+    let (app, alice, bob, _) = app("acme", "own_rows").await;
+
+    let body = json(
+        app.clone()
+            .oneshot(req(Method::GET, "/notes", Some(&token_for(alice, "acme"))))
+            .await
+            .expect("response"),
+    )
+    .await;
+    assert_eq!(body["count"], 2);
+    for row in body["results"].as_array().expect("results") {
+        assert_eq!(row["member_id"], alice);
+    }
+
+    let body = json(
+        app.oneshot(req(Method::GET, "/notes", Some(&token_for(bob, "acme"))))
+            .await
+            .expect("response"),
+    )
+    .await;
+    assert_eq!(body["count"], 1);
+    assert_eq!(body["results"][0]["body"], "bob one");
+}
+
+#[tokio::test]
+async fn another_members_row_is_not_found_by_id() {
+    let (app, alice, bob, _) = app("acme", "by_id").await;
+
+    // Bob reads his own row (id 3) …
+    let resp = app
+        .clone()
+        .oneshot(req(Method::GET, "/notes/3", Some(&token_for(bob, "acme"))))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // … and for Alice it does not exist. 404, not 403: a 403 would confirm it.
+    let resp = app
+        .clone()
+        .oneshot(req(
+            Method::GET,
+            "/notes/3",
+            Some(&token_for(alice, "acme")),
+        ))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    // Deleting it is refused the same way, and the row survives.
+    let resp = app
+        .clone()
+        .oneshot(req(
+            Method::DELETE,
+            "/notes/3",
+            Some(&token_for(alice, "acme")),
+        ))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    let resp = app
+        .oneshot(req(Method::GET, "/notes/3", Some(&token_for(bob, "acme"))))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn a_token_from_another_tenant_is_refused() {
+    // Both tenants sign with the same key — the `tenant` claim is the only
+    // thing that makes `sub: 1` mean a different person on each subdomain.
+    let (app, alice, _, _) = app("acme", "cross_tenant").await;
+    let resp = app
+        .oneshot(req(
+            Method::GET,
+            "/notes",
+            Some(&token_for(alice, "globex")),
+        ))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn a_deactivated_account_stops_working_immediately() {
+    // The token is still cryptographically valid; the account is not. The
+    // middleware re-reads the row per request precisely so this does not wait
+    // for the access token to expire.
+    let (app, _, _, ghost) = app("acme", "deactivated").await;
+    let resp = app
+        .oneshot(req(Method::GET, "/notes", Some(&token_for(ghost, "acme"))))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn no_token_is_401_and_never_reaches_the_query() {
+    let (app, _, _, _) = app("acme", "no_token").await;
+    let resp = app
+        .clone()
+        .oneshot(req(Method::GET, "/notes", None))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    let resp = app
+        .oneshot(req(Method::GET, "/notes", Some("not-a-token")))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}

--- a/crates/rustango/tests/viewset_principal_filter_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_principal_filter_sqlite_live.rs
@@ -1,0 +1,360 @@
+//! `ViewSetFilter::filter_with(&Parts, …)` — ownership scoping that holds on
+//! every action, not just `list`.
+//!
+//! The principal lives in the request extensions, so "only this user's rows"
+//! cannot be expressed against the params-only `filter`. And scoping `list`
+//! alone is worse than not scoping at all: it reads as safe while every row
+//! stays reachable by id. These tests pin both halves — the collection is
+//! narrowed, and `retrieve` / `update` / `destroy` of a row belonging to
+//! someone else is a **404**, because a 403 would confirm the id exists.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+
+use std::collections::HashMap;
+
+use axum::body::Body;
+use axum::http::request::Parts;
+use axum::http::{header, Method, Request, StatusCode};
+use rustango::core::{Filter, Model as _, ModelSchema, Op, SqlValue, WhereExpr};
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::viewset::{ViewSet, ViewSetFilter};
+use rustango::Model;
+use serde_json::Value;
+use tower::ServiceExt as _;
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "vs_pf_note")]
+#[rustango(app = "vs_pf_app")]
+pub struct Note {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub owner_id: i64,
+    #[rustango(max_length = 200)]
+    pub body: String,
+}
+
+use rustango::tenancy::Principal;
+
+/// Stands in for an authenticated principal, injected as an extension the way
+/// an auth middleware would.
+#[derive(Clone, Copy)]
+struct LocalPrincipal(i64);
+
+/// The backend an app writes: rows whose `owner_id` is the caller.
+struct OwnerFilter;
+
+impl ViewSetFilter for OwnerFilter {
+    fn filter(&self, _p: &HashMap<String, String>, schema: &'static ModelSchema) -> Vec<WhereExpr> {
+        // No principal in hand ⇒ match nothing. Fail closed: a backend that
+        // silently returns "no predicates" would widen the query to everyone.
+        deny(schema)
+    }
+
+    fn filter_with(
+        &self,
+        parts: &Parts,
+        _p: &HashMap<String, String>,
+        schema: &'static ModelSchema,
+    ) -> Vec<WhereExpr> {
+        let Some(LocalPrincipal(uid)) = parts.extensions.get::<LocalPrincipal>().copied() else {
+            return deny(schema);
+        };
+        schema.field("owner_id").map_or_else(Vec::new, |f| {
+            vec![WhereExpr::Predicate(Filter {
+                column: f.column,
+                op: Op::Eq,
+                value: SqlValue::from(uid),
+            })]
+        })
+    }
+}
+
+fn deny(schema: &'static ModelSchema) -> Vec<WhereExpr> {
+    schema.field("owner_id").map_or_else(Vec::new, |f| {
+        vec![WhereExpr::Predicate(Filter {
+            column: f.column,
+            op: Op::Eq,
+            value: SqlValue::from(-1_i64),
+        })]
+    })
+}
+
+async fn router() -> axum::Router {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite pool");
+    sqlx::query(
+        "CREATE TABLE vs_pf_note (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            owner_id INTEGER NOT NULL, \
+            body TEXT NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .expect("create");
+    for (owner, body) in [(1, "alice one"), (1, "alice two"), (2, "bob one")] {
+        sqlx::query("INSERT INTO vs_pf_note (owner_id, body) VALUES (?, ?)")
+            .bind(owner)
+            .bind(body)
+            .execute(&sq)
+            .await
+            .expect("seed");
+    }
+    ViewSet::for_model(Note::SCHEMA)
+        .page_size(100)
+        .filter_backend(OwnerFilter)
+        .router_pool("/notes", Pool::Sqlite(sq))
+}
+
+/// A request carrying `uid` as the authenticated principal.
+fn as_user(method: Method, uri: &str, uid: i64) -> Request<Body> {
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    req.extensions_mut().insert(LocalPrincipal(uid));
+    req.extensions_mut()
+        .insert(Principal::user(uid, false, None));
+    req
+}
+
+fn patch_as(uri: &str, uid: i64, form: &'static str) -> Request<Body> {
+    let mut req = Request::builder()
+        .method(Method::PATCH)
+        .uri(uri)
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(Body::from(form))
+        .unwrap();
+    req.extensions_mut().insert(LocalPrincipal(uid));
+    req.extensions_mut()
+        .insert(Principal::user(uid, false, None));
+    req
+}
+
+async fn json(resp: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .expect("body");
+    serde_json::from_slice(&bytes).expect("json")
+}
+
+#[tokio::test]
+async fn list_returns_only_the_principals_rows() {
+    let app = router().await;
+    let resp = app
+        .clone()
+        .oneshot(as_user(Method::GET, "/notes", 1))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = json(resp).await;
+    assert_eq!(body["count"], 2);
+    for row in body["results"].as_array().expect("results") {
+        assert_eq!(row["owner_id"], 1);
+    }
+
+    // The other member sees their own single row — not a filtered view of a
+    // shared list, a different list.
+    let resp = app
+        .oneshot(as_user(Method::GET, "/notes", 2))
+        .await
+        .unwrap();
+    let body = json(resp).await;
+    assert_eq!(body["count"], 1);
+    assert_eq!(body["results"][0]["body"], "bob one");
+}
+
+#[tokio::test]
+async fn retrieve_of_someone_elses_row_is_not_found() {
+    let app = router().await;
+    // Bob's row (id 3) is readable by Bob…
+    let resp = app
+        .clone()
+        .oneshot(as_user(Method::GET, "/notes/3", 2))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // …and simply does not exist for Alice. 404, not 403: a 403 would tell
+    // her the id is real.
+    let resp = app
+        .oneshot(as_user(Method::GET, "/notes/3", 1))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn update_cannot_reach_across_owners() {
+    let app = router().await;
+    let resp = app
+        .clone()
+        .oneshot(patch_as("/notes/3", 1, "body=owned+by+alice+now"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    // The row is untouched — the guard is the query, not the response code.
+    let resp = app
+        .clone()
+        .oneshot(as_user(Method::GET, "/notes/3", 2))
+        .await
+        .unwrap();
+    assert_eq!(json(resp).await["body"], "bob one");
+
+    // The owner's own update still works, and reads back.
+    let resp = app
+        .clone()
+        .oneshot(patch_as("/notes/3", 2, "body=edited"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(json(resp).await["body"], "edited");
+}
+
+#[tokio::test]
+async fn destroy_cannot_reach_across_owners() {
+    let app = router().await;
+    let resp = app
+        .clone()
+        .oneshot(as_user(Method::DELETE, "/notes/3", 1))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    let resp = app
+        .clone()
+        .oneshot(as_user(Method::GET, "/notes/3", 2))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "row survived the attempt");
+
+    let resp = app
+        .clone()
+        .oneshot(as_user(Method::DELETE, "/notes/3", 2))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let resp = app
+        .oneshot(as_user(Method::GET, "/notes/3", 2))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+/// The same table, scoped by the shipped [`OwnedBy`] backend instead of a
+/// hand-written one — the path an app actually takes.
+mod owned_by {
+    use super::{as_user, json, Note, Principal};
+    use axum::http::{Method, StatusCode};
+    use rustango::core::Model as _;
+    use rustango::sql::{sqlx, Pool};
+    use rustango::viewset::{OwnedBy, ViewSet};
+    use tower::ServiceExt as _;
+
+    async fn router(backend: OwnedBy) -> axum::Router {
+        let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite pool");
+        sqlx::query(
+            "CREATE TABLE vs_pf_note (\
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                owner_id INTEGER NOT NULL, \
+                body TEXT NOT NULL)",
+        )
+        .execute(&sq)
+        .await
+        .expect("create");
+        for (owner, body) in [(1, "alice one"), (1, "alice two"), (2, "bob one")] {
+            sqlx::query("INSERT INTO vs_pf_note (owner_id, body) VALUES (?, ?)")
+                .bind(owner)
+                .bind(body)
+                .execute(&sq)
+                .await
+                .expect("seed");
+        }
+        ViewSet::for_model(Note::SCHEMA)
+            .page_size(100)
+            .filter_backend(backend)
+            .router_pool("/notes", Pool::Sqlite(sq))
+    }
+
+    #[tokio::test]
+    async fn scopes_to_the_column_it_was_given() {
+        let app = router(OwnedBy::column("owner_id")).await;
+        let body = json(
+            app.oneshot(as_user(Method::GET, "/notes", 1))
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(body["count"], 2);
+    }
+
+    #[tokio::test]
+    async fn a_superuser_is_not_special_by_default() {
+        // Opt-in, because "admins see everything" is a product decision. Here
+        // the admin is also a member, and their list is their own.
+        let app = router(OwnedBy::column("owner_id")).await;
+        let mut req = as_user(Method::GET, "/notes", 2);
+        req.extensions_mut().insert(Principal::admin(2));
+        assert_eq!(json(app.oneshot(req).await.unwrap()).await["count"], 1);
+    }
+
+    #[tokio::test]
+    async fn a_superuser_sees_everything_when_asked_to() {
+        let app = router(OwnedBy::column("owner_id").superuser_sees_all()).await;
+        let mut req = as_user(Method::GET, "/notes", 2);
+        req.extensions_mut().insert(Principal::admin(2));
+        assert_eq!(json(app.oneshot(req).await.unwrap()).await["count"], 3);
+    }
+
+    #[tokio::test]
+    async fn an_unknown_column_denies_rather_than_widens() {
+        // A typo at mount time must not mean "no predicates, return the table".
+        let app = router(OwnedBy::column("no_such_column")).await;
+        let body = json(
+            app.oneshot(as_user(Method::GET, "/notes", 1))
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(body["count"], 0);
+    }
+
+    #[tokio::test]
+    async fn an_unauthenticated_request_sees_nothing() {
+        let app = router(OwnedBy::column("owner_id")).await;
+        let req = axum::http::Request::builder()
+            .method(Method::GET)
+            .uri("/notes")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        assert_eq!(json(app.oneshot(req).await.unwrap()).await["count"], 0);
+    }
+
+    #[tokio::test]
+    async fn item_routes_are_scoped_too() {
+        let app = router(OwnedBy::column("owner_id")).await;
+        let resp = app
+            .oneshot(as_user(Method::GET, "/notes/3", 1))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}
+
+#[tokio::test]
+async fn a_backend_without_a_principal_fails_closed() {
+    // No extension on the request: the default `filter` runs and denies.
+    let app = router().await;
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/notes")
+        .body(Body::empty())
+        .unwrap();
+    let body = json(app.oneshot(req).await.unwrap()).await;
+    assert_eq!(body["count"], 0);
+}

--- a/docs/viewsets.md
+++ b/docs/viewsets.md
@@ -715,8 +715,112 @@ let api = Router::new()
     .route("/api/posts/bulk_archive", post(bulk_archive));
 ```
 
-For per-list extra `WHERE` logic, `.filter_backend(…)` contributes predicates to
-the built-in list query without a separate route.
+For extra `WHERE` logic, `.filter_backend(…)` contributes predicates without a
+separate route.
+
+### Scoping rows to the authenticated principal
+
+A backend runs on **every** action — `list`, `retrieve`, `update`, `destroy` —
+so it behaves like DRF's `get_queryset()`. A row the backend excludes is a
+**404** on the item routes, not a 403: a 403 would confirm the id exists.
+
+Identity must come from the credential, never from the query string. A
+`?owner_id=` filter is not a scope — it is a parameter the caller chooses.
+
+#### `OwnedBy` — the shipped backend
+
+Most owned resources need exactly one rule: *rows whose ownership column is the
+caller*. Name the column and mount it.
+
+```rust
+use rustango::viewset::{OwnedBy, ViewSet};
+
+ViewSet::for_model(Note::SCHEMA)
+    .filter_backend(OwnedBy::column("member_id"))
+    .tenant_router("/api/notes")
+    .layer(axum::middleware::from_fn(
+        rustango::tenancy::auth_routes::require_bearer,
+    ))
+```
+
+Any column works — `owner_id`, `member_id`, `author_id` — because the backend
+takes the name rather than assuming a convention. It fails closed on the two
+ways it can be wrong: an unauthenticated request and a column the model does not
+have both match **nothing**, so a typo at mount time cannot turn into "no
+predicates, return the table".
+
+Superusers are not special by default; `.superuser_sees_all()` opts in, because
+"admins see everything" is a product decision, not a framework one.
+
+#### Where the identity comes from
+
+[`Principal`] is the one identity type, resolved from whatever verified the
+request — an explicit `Principal`, an `AuthenticatedUser` left by a session or
+Bearer middleware, or an MCP agent token (which acts as the user who minted it).
+It authenticates nothing itself; it only reads what a verifying middleware
+already proved, so nothing may insert one without checking a credential first.
+
+`require_bearer` is that middleware for a JSON API: it verifies the access token
+against the resolved tenant, re-reads the user row (a deactivated account stops
+working on the next request, not when the token expires), and inserts both
+`AuthenticatedUser` and `Principal`. Use it as an extractor anywhere:
+
+```rust
+use rustango::tenancy::{OptionalPrincipal, Principal};
+
+async fn mine(principal: Principal) -> String {          // 401 when absent
+    format!("user {}", principal.user_id)
+}
+
+async fn home(OptionalPrincipal(who): OptionalPrincipal) -> String {
+    who.map_or("anonymous".into(), |p| format!("user {}", p.user_id))
+}
+```
+
+#### Writing your own backend
+
+When ownership is not a single column — a shared team, a soft-deleted row, a
+window of dates — implement the trait and override `filter_with`, which receives
+the request `Parts`:
+
+```rust
+use axum::http::request::Parts;
+use rustango::tenancy::Principal;
+use rustango::viewset::ViewSetFilter;
+
+struct OwnerFilter;
+
+impl ViewSetFilter for OwnerFilter {
+    // No principal in hand — fail closed. Returning no predicates here would
+    // widen the query to every row in the table.
+    fn filter(&self, _p: &HashMap<String, String>, schema: &'static ModelSchema) -> Vec<WhereExpr> {
+        deny_all(schema)
+    }
+
+    fn filter_with(
+        &self,
+        parts: &Parts,
+        _p: &HashMap<String, String>,
+        schema: &'static ModelSchema,
+    ) -> Vec<WhereExpr> {
+        let Some(principal) = Principal::from_parts(parts) else {
+            return deny_all(schema);
+        };
+        vec![WhereExpr::Predicate(Filter {
+            column: schema.field("owner_id").expect("owner_id").column,
+            op: Op::Eq,
+            value: SqlValue::from(principal.user_id),
+        })]
+    }
+}
+
+ViewSet::for_model(Note::SCHEMA)
+    .filter_backend(OwnerFilter)
+    .tenant_router("/api/notes")
+```
+
+`filter_with` defaults to `filter`, so a backend that does not need the request
+— including the plain closure form — implements only `filter` as before.
 
 ---
 


### PR DESCRIPTION
Closes #1183.

## The problem

A `ViewSet` could not express the one predicate every per-user API needs: *rows belonging to the caller.*

`ViewSetFilter::filter` receives the query string and nothing else, while the authenticated identity lives in the request extensions. So the workaround apps reach for is putting the owner column in `filter_fields` and trusting the client to send `?owner_id=…` — which is not authorization at all. The client picks the value, and omitting the param returns every row in the table.

The second half reads safe and isn't: backends ran on `list` only. An app that correctly filters its collection is still one `GET /notes/3` away from another member's row, and one `PATCH` away from writing to it.

## The change

Three pieces, each usable on its own.

**`tenancy::Principal`** — the identity, resolved once from whatever verified the request: an explicit `Principal`, an `AuthenticatedUser` left by a session or Bearer layer, or an MCP agent token (which acts as the user who minted it — a standalone machine agent has no user to act as and yields `None`, which is what keeps an ownership filter from matching everyone's rows). It authenticates nothing itself; it reads only what a verifying layer already proved, so nothing may insert one without checking a credential first. Available as an extractor (401 when absent) and as `OptionalPrincipal` where anonymous is an answer rather than a refusal.

**`auth_routes::require_bearer`** — that verifying layer for a JSON API. Verifies the access token against the *resolved tenant*, then re-reads the user row, so a deactivated account stops working on the next request rather than when the token expires. Inserts both `AuthenticatedUser` (which unlocks the existing permission gates) and `Principal`.

**`viewset::OwnedBy`** — the backend:

```rust
ViewSet::for_model(Note::SCHEMA)
    .filter_backend(OwnedBy::column("member_id"))
    .tenant_router("/api/notes")
    .layer(axum::middleware::from_fn(require_bearer))
```

Any column name works, because it takes the name rather than assuming a convention. It fails closed on both ways it can be wrong — an unauthenticated request and a column the model does not have each match **nothing**, so a typo at mount time cannot quietly become "no predicates, return the table". `.superuser_sees_all()` opts superusers in; they are not special by default, because "admins see everything" is a product decision.

Underneath:

- **`ViewSetFilter::filter_with(&Parts, params, schema)`**, default-provided and delegating to `filter` — every existing backend, including the plain closure impl, compiles and behaves exactly as before.
- **Backends apply to `retrieve` / `update` / `destroy`**, which is DRF's `get_queryset()` contract. An excluded row is a **404**, not a 403 (a 403 confirms the id exists); an `UPDATE` matching nothing returns 404 rather than reporting success; the read-back after an update is scoped too.

## Compatibility

Additive to the trait. Behaviour changes only for code already calling `.filter_backend(…)`: the item routes start honouring the backend that was registered, which is the intent.

## Tests

16, all new.

`viewset_principal_filter_sqlite_live.rs` (11) — the trait and `OwnedBy` against sqlite: list scoped; `retrieve`/`update`/`destroy` across owners are 404 and leave the row intact; a backend with no principal fails closed; superuser off by default and on when asked; an unknown column denies rather than widens.

`owned_by_bearer_sqlite_live.rs` (5) — mint a token → `require_bearer` → `OwnedBy` → SQL, because the seam between them is where a per-user API actually leaks. A token sees only its own rows; another member's row is 404 by id and survives the delete attempt; a token minted for a different tenant is refused even though both tenants sign with the same key; a deactivated account is refused immediately; no token never reaches the query.

`cargo test --workspace --all-features` green; `cargo clippy -p rustango --features tenancy --lib --no-deps` adds no new warnings.

Found while building a JWT-authenticated REST API on a multi-tenant app: the tenant resolved per request, but "this member's routines" had no expressible form.