### PR TITLE
docs: French translation + 0.51 feature updates + rustango.com links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Rustango gives you the productivity of Django or Laravel with the speed and type-safety of Rust: a tri-dialect ORM, auto-migrations, an auto-generated admin, multi-tenancy, first-class auth, and every standard middleware — all shipped, all opt-out via cargo features, and all working on **Postgres, MySQL, and SQLite** out of the box.
 
-📚 **Docs:** [rustango.im-fullstack.dev](https://rustango.im-fullstack.dev) · [in-repo guides](docs/) · [API reference](https://docs.rs/rustango)
+📚 **Docs:** [rustango.com](https://rustango.com) · [in-repo guides](docs/) · [API reference](https://docs.rs/rustango)
 🍳 **Cookbook:** [`cookbook_blog/COOKBOOK.md`](crates/rustango/examples/cookbook_blog/COOKBOOK.md) — a runnable, test-backed recipe for every feature below.
 
 ---
@@ -317,7 +317,7 @@ A `TestClient` drives the router as a tower service (no socket), a `RequestFacto
 
 ## Documentation
 
-- **Guides & tutorials**: <https://rustango.im-fullstack.dev>
+- **Guides & tutorials**: <https://rustango.com>
 - **Runnable cookbook**: [`cookbook_blog/COOKBOOK.md`](crates/rustango/examples/cookbook_blog/COOKBOOK.md) — a test-backed recipe for every feature, on all three backends.
 - **In-repo guides** ([`docs/`](docs/)): [getting started](docs/getting-started.md) · [models](docs/models.md) · [ORM](docs/orm.md) · [migrations & CLI](docs/manage.md) · [admin](docs/admin.md) · [viewsets](docs/viewsets.md) · [serializers](docs/serializers.md) · [auth](docs/auth-flows.md) · [security](docs/security.md) · [middleware](docs/middleware.md) · [caching](docs/caching.md) · [email](docs/email.md) · [files](docs/files.md) · [jobs](docs/jobs.md) · [i18n](docs/i18n.md) · [MCP](docs/mcp.md) · [testing](docs/testing.md) · [glossary](docs/glossary.md)
 - **API reference**: <https://docs.rs/rustango>

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -404,6 +404,21 @@ one of two ways:
 - **Front it with your own auth.** Leave the admin open and put HTTP Basic auth,
   OAuth2, or corporate SSO in front of the nest path with your own middleware.
 
+When session auth is on, the sidebar footer shows a **"Signed in as _username_"**
+line and a **Logout** button (a `POST` form). Standalone admins post to
+`{admin_prefix}/logout` by default; a tenant admin sits behind the tenancy
+layer's own logout route, so point the button there with `Builder::logout_url`:
+
+```rust
+let admin = admin::Builder::new(pool)
+    .with_session_auth(session_secret)
+    .logout_url("/staff-logout")       // POST target for the sidebar Logout button
+    .build();
+```
+
+The tenant-admin builder wires this to its `RouteConfig::logout_url`
+automatically, so the button always hits a route that exists.
+
 ---
 
 ## Theming and branding
@@ -444,6 +459,7 @@ Every method on `admin::Builder` (each returns `Self` for chaining unless noted)
 | `with_user_perms([codenames])` | Gate tables on `{table}.view/add/change/delete`. |
 | `register_action(table, name, handler)` | Register a bulk-action handler. |
 | `with_session_auth(secret)` | Require cookie login (`/login` + `/logout`). |
+| `logout_url(u)` | POST target for the sidebar Logout button. Default `{admin_prefix}/logout`; tenant admins set it to their tenancy logout route. |
 | `secure_cookies(bool)` | Set the `Secure` (HTTPS-only) flag on the session cookie. |
 | `theme_mode(m)` | `"light"` / `"dark"` / `"auto"`. |
 | `brand_logo_url(url)` | Logo above the title. |

--- a/docs/fr/admin.md
+++ b/docs/fr/admin.md
@@ -1,0 +1,555 @@
+# L'admin
+
+**Rustango** génère une interface d'administration complète à partir de vos
+modèles — la même idée que l'admin de Django ou un panneau Laravel
+Nova/Filament, mais avec **zéro boilerplate par modèle**. Ajoutez
+`#[derive(Model)]`, montez l'admin une fois, et chaque modèle obtient une vue
+liste avec recherche, filtres, tri, pagination et actions groupées ; un
+formulaire de création/édition regroupé en fieldsets ; l'édition inline des
+enfants ; une piste d'audit par ligne ; et une référence de modèle en direct.
+Tout ce qui suit est configuré de manière déclarative dans un bloc
+`admin(...)` sur le derive, ou avec une poignée de méthodes `Builder` et de
+macros d'enregistrement au niveau du module.
+
+[![L'admin auto-généré : une liste de posts avec des facettes de filtre, la recherche, des actions groupées et la pagination — tout à partir d'un seul bloc `admin(...)`](img/admin.png)](img/admin.png)
+
+> **Source :** `rustango::admin` (les options du derive `admin(...)`, l'API
+> `Builder` et les macros d'enregistrement) — derrière la feature `admin`
+> (activée par défaut).
+>
+> **Version exécutable :** chaque fonctionnalité de cette page est illustrée
+> dans un exemple testé et compilable à
+> [`crates/rustango/examples/admin_demo`](../crates/rustango/examples/admin_demo).
+> Les captures d'écran de cette page proviennent de cet exemple. Si un extrait
+> semble incorrect, comparez-le à celui-ci.
+
+> **Un terme nouveau ici ?** *modèle*, *fieldset*, *piste d'audit* — voir le
+> [glossaire](glossary.md).
+
+---
+
+## Table des matières
+- [Le monter](#mount-it) · [La page d'accueil](#the-home-page)
+- [Configurer un modèle : le bloc `admin(...)`](#configure-a-model-the-admin-block)
+- [La vue liste](#the-list-view) — colonnes, recherche, filtres, hiérarchie de dates, tri, pagination
+- [Le formulaire de modification](#the-change-form) — fieldsets, widgets, édition des FK, champs prépeuplés et en lecture seule
+- [Inlines](#inlines) · [Actions groupées](#bulk-actions) · [Piste d'audit](#audit-trail)
+- [Colonnes calculées et filtres personnalisés](#computed-columns-and-custom-filters)
+- [Vues personnalisées, querysets et permissions](#custom-views-querysets-and-permissions)
+- [Authentification](#authentication) · [Thème et image de marque](#theming-and-branding)
+- [Référence `Builder`](#builder-reference) · [Référence des routes](#routes-reference)
+- [La référence de modèle (`__docs`)](#the-model-reference) · [Essayer l'exemple](#try-the-example)
+
+---
+
+## Le monter
+
+> **L'admin est ouvert par défaut.** Il découvre et sert automatiquement
+> *chaque* modèle — liste, création, édition, suppression — sans
+> authentification jusqu'à ce que vous l'ajoutiez. Ne l'exposez pas
+> publiquement avant d'avoir câblé la connexion : voir
+> [Authentification](#authentication) ci-dessous.
+
+L'admin est un `axum::Router` que vous construisez à partir d'un pool de base
+de données et que vous nichez (« nest ») sous un chemin :
+
+```rust
+use rustango::admin;
+
+let admin_router = admin::Builder::new(pool.clone())
+    .title("Admin Demo")
+    .subtitle("rustango auto-admin showcase")
+    .admin_prefix("/admin")          // MUST match the nest path below
+    .build();
+
+let api = axum::Router::new().nest("/admin", admin_router);
+```
+
+L'auto-admin découvre **automatiquement** chaque `#[derive(Model)]` de votre
+binaire via le registre `inventory` — vous n'enregistrez pas les modèles un
+par un. Ouvrez `http://localhost:8080/admin` et ils apparaissent regroupés
+dans la barre latérale.
+
+> **`admin_prefix` doit être égal au chemin de nesting.** L'admin construit
+> ses liens et les actions de formulaire à partir de `admin_prefix` (par
+> défaut `/__admin`). Si vous nichez sous `/admin` mais laissez le préfixe par
+> défaut, chaque lien renvoie une 404. Réglez-les de façon identique.
+
+> **Lier le registre.** L'enregistrement inventory n'est lié dans le binaire
+> final que si les types de modèles sont référencés quelque part. Un crate
+> bibliothèque dont les modèles ne sont pas utilisés ailleurs peut avoir
+> besoin d'un petit coup de pouce `let _ = std::any::type_name::<Post>();`
+> dans `main` (c'est ce que fait l'exemple) — sinon le linker les élimine et
+> ils n'apparaissent jamais.
+
+### La page d'accueil
+
+La racine de l'admin (`GET /<prefix>`) liste chaque modèle enregistré,
+regroupé par app, avec le nom de table et le nombre de champs de chaque
+modèle — plus un flux **Actions récentes** des derniers changements audités.
+
+[![La page d'accueil de l'admin : chaque modèle enregistré regroupé par app avec le nombre de tables et de champs, et un flux d'activité des actions récentes](img/admin-home.png)](img/admin-home.png)
+
+---
+
+## Configurer un modèle : le bloc `admin(...)`
+
+Tout ce qui concerne l'apparence d'un modèle est réglé dans un bloc
+`admin(...)` sur le derive. Voici le `Post` de démonstration de l'exemple, qui
+exerce presque tous les réglages :
+
+```rust
+#[derive(Model, Clone, Debug)]
+#[rustango(
+    table = "posts",
+    display = "title",
+    admin(
+        list_display       = "id, title, author_id, status, view_count, published_at",
+        list_display_links = "id, title",
+        list_filter        = "status, author_id",
+        search_fields      = "title, body",
+        search_help_text   = "Search posts by title or body",
+        ordering           = "-published_at",
+        list_per_page      = 10,
+        date_hierarchy     = "published_at",
+        fieldsets          = "Content: title, body, status | Publishing: author_id, published_at, view_count",
+        actions            = "publish, archive",
+    ),
+    audit(track = "title, body, status"),
+)]
+pub struct Post { /* … */ }
+```
+
+`display = "title"` (sur le modèle, en dehors de `admin(...)`) définit le
+libellé humain utilisé partout où une ligne est référencée — les colonnes FK
+dans les listes d'autres modèles, le fil d'Ariane, le titre de la page de
+détail.
+
+### Toutes les options `admin(...)`
+
+| Clé | Exemple | Ce que ça fait |
+|---|---|---|
+| `list_display` | `"id, title, status"` | Colonnes affichées dans la liste, dans l'ordre. Les colonnes FK affichent la valeur `display` de la cible. Les colonnes calculées (voir plus bas) peuvent être nommées ici. Vide = chaque champ scalaire. |
+| `list_display_links` | `"id, title"` | Quelles cellules de `list_display` renvoient vers la page de détail. Doit être un sous-ensemble de `list_display`. |
+| `list_filter` | `"status, author_id"` | Cartes de facettes dans la colonne de droite — valeurs distinctes + compteurs, cliquez pour filtrer. Fonctionne sur les colonnes scalaires et FK. |
+| `search_fields` | `"title, body"` | Champs que la boîte de recherche `?q=` compare (`ILIKE`/`LIKE` insensible à la casse). |
+| `search_help_text` | `"Search by title"` | Légende affichée à côté de la boîte de recherche. |
+| `ordering` | `"-published_at, id"` | Tri par défaut. Préfixe `-` = DESC ; nu = ASC. Plusieurs clés séparées par des virgules. |
+| `list_per_page` | `10` | Taille de page (par défaut 50). |
+| `date_hierarchy` | `"published_at"` | Bandeau de forage année → mois → jour au-dessus de la liste, sur une colonne Date/DateTime. |
+| `fieldsets` | `"Content: title, body \| Meta: status"` | Regroupe le formulaire de modification en sections titrées. La barre `\|` sépare les sections, la virgule sépare les champs ; la légende `Title:` est optionnelle. |
+| `actions` | `"publish, archive"` | Actions groupées proposées dans le sélecteur d'actions de la liste (chacune nécessite un gestionnaire enregistré — voir [Actions groupées](#bulk-actions)). |
+| `readonly_fields` | `"created_at"` | Champs affichés en texte (sans saisie) sur le formulaire de modification. |
+| `raw_id_fields` | `"author_id"` | Champs FK édités via une saisie d'id brut + un lien de recherche (bien adapté aux grandes tables cibles). |
+| `autocomplete_fields` | `"author_id"` | Champs FK édités via un typeahead Ajax adossé à l'endpoint `__autocomplete` de la cible. |
+| `prepopulated_fields` | `"slug:title"` | Remplit automatiquement un champ en slugifiant un autre au fur et à mesure de la saisie (`cible:source` ; combinez les sources avec `+`). |
+| `list_select_related` | `"all"` / `"none"` / `"author_id"` | Contrôle la JOIN automatique des colonnes FK dans la requête de liste. `"all"` (par défaut) joint chaque FK ; `"none"` désactive ; une liste CSV restreint aux FK nommées. |
+| `formfield_overrides` | `"status:textarea"` | Remplace le widget de formulaire d'un champ (`champ:widget`) — voir le [tableau des widgets](#form-widgets). |
+| `actions_on_top` | `true` | Affiche la barre d'actions groupées au-dessus de la liste (par défaut `true`). |
+| `actions_on_bottom` | `false` | Affiche une seconde barre d'actions sous la liste (par défaut `false`). |
+
+---
+
+## La vue liste
+
+`GET /<prefix>/<table>` affiche la liste. À partir du seul bloc `admin(...)`
+ci-dessus, vous obtenez des colonnes triables, une boîte de recherche avec son
+texte d'aide, les cartes de facettes statut/auteur avec des compteurs en
+direct, le forage par date, la pagination à 10 par page, et le sélecteur
+d'actions publier/archiver.
+
+**Filtrage.** Cliquez sur une valeur dans une carte de facette `list_filter`
+pour restreindre la liste ; le filtre actif s'affiche sous forme de puce avec
+un lien **effacer**, et le nombre de lignes ainsi que les compteurs de
+facettes se mettent à jour. Les filtres, la recherche, le tri et la hiérarchie
+de dates se combinent tous dans la chaîne de requête et peuvent être associés.
+
+[![La liste des posts filtrée par status=published : une puce de filtre actif, la facette correspondante mise en évidence, la boîte de recherche et le sélecteur d'actions groupées](img/admin-list-filtered.png)](img/admin-list-filtered.png)
+
+**Tri.** Cliquez sur l'en-tête d'une colonne pour trier ; cliquez à nouveau
+pour inverser le sens (`?sort=col&order=asc|desc`). La valeur par défaut vient
+de `ordering`.
+
+**Pagination.** `list_per_page` fixe la taille de page ; naviguez avec
+`?page=N`. Pour les très grandes tables, enregistrez-les avec
+`Builder::skip_count_for([...])` pour éviter le `SELECT COUNT(*)` (le
+pagineur affiche alors « Page N » sans total global) ; un `?count=skip` par
+requête fait la même chose ponctuellement.
+
+**Recherche.** Quand `search_fields` est défini, une boîte de recherche
+apparaît et fait correspondre ces champs avec `ILIKE` (PostgreSQL) / `LIKE`
+(MySQL, SQLite). `search_help_text` s'affiche comme légende.
+
+**Hiérarchie de dates.** Avec `date_hierarchy` défini, un fil d'Ariane
+année → mois → jour se place au-dessus du tableau ; forer dans cette
+hiérarchie ajoute des filtres de plage semi-ouverte sur cette colonne en
+utilisant l'extraction de date tri-dialecte (PostgreSQL `EXTRACT`, MySQL,
+SQLite `strftime`).
+
+---
+
+## Le formulaire de modification
+
+`GET /<prefix>/<table>/new` (création) et `GET /<prefix>/<table>/<pk>/edit`
+(édition) affichent le formulaire. `fieldsets` regroupe les saisies en
+sections titrées ; sans lui, tous les champs modifiables apparaissent en un
+seul bloc.
+
+[![Le formulaire de modification de Post regroupé en fieldsets Content et Publishing, chaque champ avec le widget de saisie adapté à son type](img/admin-fieldsets.png)](img/admin-fieldsets.png)
+
+Soumettre un formulaire valide la saisie, écrit la ligne, enregistre une
+entrée d'audit, et redirige vers la vue **détail** en lecture seule
+(`GET /<prefix>/<table>/<pk>`), qui affiche chaque champ ainsi que les
+inlines et la carte d'audit (ci-dessous). Les boutons **Éditer** et
+**Supprimer** de la page de détail mènent au formulaire et à la confirmation
+de suppression.
+
+### Widgets de formulaire
+
+Chaque champ affiche une saisie correspondant à son type par défaut —
+`<input type="number">` pour les entiers, `type="date"`/`datetime-local` pour
+les dates, `type="checkbox"` pour les booléens, un `<textarea>` pour les
+chaînes longues, un `<select>` pour les colonnes FK, et ainsi de suite.
+Remplacez-le par champ avec `formfield_overrides = "champ:widget"` :
+
+| Widget | S'applique à | Affiche |
+|---|---|---|
+| `textarea` | String | `<textarea>` multi-lignes |
+| `password` | String | `<input type="password">` |
+| `email` | String | `<input type="email">` |
+| `url` | String | `<input type="url">` |
+| `color` | String | `<input type="color">` |
+| `slug` | String | saisie texte avec un motif de slug |
+| `ipaddress` | String | saisie texte avec un motif d'IP |
+| `json` | Json | `<textarea>` monospace |
+| `hidden` | any | `<input type="hidden">` |
+
+### Éditer les clés étrangères
+
+Les colonnes FK ont trois modes d'édition :
+
+- **Par défaut** — un `<select>` peuplé à partir de la table cible, affichant
+  la valeur `display` de chaque ligne.
+- **`raw_id_fields`** — une simple saisie d'id plus un lien de recherche ;
+  préférable quand la table cible est trop grande pour être énumérée dans une
+  liste déroulante.
+- **`autocomplete_fields`** — un typeahead Ajax qui interroge les
+  `search_fields` du modèle cible via
+  `GET /<prefix>/<target>/__autocomplete?q=…`.
+
+### Champs prépeuplés et en lecture seule
+
+`prepopulated_fields = "slug:title"` émet du JS côté client qui slugifie le
+champ source vers la cible au fur et à mesure de la saisie (combinez
+plusieurs sources avec `+`, p. ex. `"slug:section+title"`).
+`readonly_fields` affiche les champs nommés en texte échappé sur le
+formulaire au lieu de saisies.
+
+---
+
+## Inlines
+
+Les inlines affichent les lignes d'un modèle enfant sur la page du parent
+(inlines Django). Enregistrez-en un au niveau du module :
+
+```rust
+rustango::register_admin_inline!(
+    parent = "posts",
+    child  = "comments",
+    fk     = "post_id",                                     // child column → parent PK
+    kind   = rustango::admin::inlines::InlineKind::Tabular, // or Stacked
+    label  = "Comments",
+    fields = &["author_name", "body", "created_at"],
+);
+```
+
+Sur la page **détail** du parent, les enfants s'affichent sous forme de
+tableau en lecture seule ; sur la page **édition**, ils deviennent un
+FormSet modifiable (ajouter / modifier / supprimer des lignes sur place).
+Options : `kind` (`Tabular` — une ligne de tableau par enfant, ou `Stacked` —
+un fieldset par enfant), `label`, `fields` (par défaut : chaque scalaire sauf
+la FK), `extra` (lignes vierges proposées pour l'ajout), `max_num`, et
+`readonly_fields`.
+
+[![La page de détail d'un post : champs en lecture seule, le tableau inline Comments, et la carte de piste d'audit montrant l'entrée de création sous forme de diff JSON](img/admin-detail.png)](img/admin-detail.png)
+
+Pour les lignes enfants rattachées par une clé étrangère générique (paire
+type-de-contenu + pk-d'objet) plutôt que par une seule colonne FK, utilisez
+`register_admin_inline_generic!(parent, child, ct = "content_type_id", pk =
+"object_pk", …)` — les mêmes options par ailleurs.
+
+---
+
+## Actions groupées
+
+Nommez les actions dans `admin(actions = "...")`, puis enregistrez un
+gestionnaire par action sur le `Builder`. Le gestionnaire reçoit le pool et
+les clés primaires des lignes sélectionnées :
+
+```rust
+use rustango::core::SqlValue;
+
+let admin_router = admin::Builder::new(pool)
+    .register_action("posts", "publish", |pool, pks| {
+        Box::pin(async move {
+            let ids: Vec<String> = pks.iter().filter_map(|v| match v {
+                SqlValue::I64(n) => Some(n.to_string()),
+                SqlValue::I32(n) => Some(n.to_string()),
+                _ => None,
+            }).collect();
+            if !ids.is_empty() {
+                let sql = format!("UPDATE posts SET status='published' WHERE id IN ({})", ids.join(","));
+                rustango::sql::raw_execute_pool(pool, &sql, Vec::new()).await?;
+            }
+            Ok(())
+        })
+    })
+    .register_action("posts", "archive", /* … */)
+    .build();
+```
+
+Choisissez les lignes avec les cases à cocher, sélectionnez l'action dans le
+sélecteur, et soumettez (`POST /<prefix>/<table>/__action`).
+`delete_selected` est intégré — vous ne l'enregistrez pas. Un nom d'action
+listé dans `admin(actions = ...)` sans gestionnaire enregistré n'apparaît
+simplement pas.
+
+---
+
+## Piste d'audit
+
+Ajoutez `audit(track = "field1, field2")` à un modèle et chaque création,
+mise à jour et suppression est enregistrée dans la table
+`rustango_audit_log` (créée pour vous lors de l'exécution de `migrate`).
+Seuls les modèles portant un attribut `audit(...)` sont journalisés ; `track`
+sélectionne les champs capturés dans le diff (omettez-le pour suivre tous les
+scalaires).
+
+```rust
+#[rustango(table = "posts", audit(track = "title, body, status"))]
+```
+
+Chaque entrée stocke la table, la clé primaire, l'opération, la source, un
+diff par champ (`{before, after}`) en JSON, l'acteur, un horodatage, et une
+empreinte inviolable. Deux endroits l'exposent :
+
+- La **page de détail** du modèle gagne une carte **Piste d'audit** listant
+  les changements récents (qui, quand, et le diff), avec un lien **Voir
+  l'historique complet** (visible dans la [capture de détail](#inlines)
+  ci-dessus).
+- La vue **Activité** de la barre latérale (`GET /<prefix>/__audit`) est un
+  flux transversal, du plus récent au plus ancien, avec des cartes de
+  facettes par entité / opération / source et un formulaire de nettoyage pour
+  purger les entrées plus anciennes que N jours (lui-même enregistré comme
+  une entrée d'audit).
+
+[![Le flux Activité : chaque changement audité à travers les modèles avec des diffs JSON, des cartes de facettes par table/opération/source, et un formulaire de nettoyage](img/admin-audit.png)](img/admin-audit.png)
+
+---
+
+## Colonnes calculées et filtres personnalisés
+
+Quand le bloc déclaratif ne suffit pas, deux macros au niveau du module
+étendent la vue liste :
+
+**Colonnes calculées** — une colonne dérivée, hors base de données :
+
+```rust
+rustango::register_admin_computed!(
+    "posts", "word_count", "Words",
+    |row| row.get("body").and_then(|v| v.as_str())
+             .unwrap_or_default().split_whitespace().count().to_string(),
+);
+// then add `word_count` to admin(list_display = "...").
+```
+
+La closure reçoit la ligne comme `serde_json::Value` et renvoie du HTML
+pré-échappé. Une forme à 5 arguments ajoute `link = |row| Option<String>`
+pour envelopper la cellule dans un `<a>`.
+
+**Filtres de liste personnalisés** — une logique de filtrage que les
+facettes automatiques ne peuvent pas exprimer :
+
+```rust
+fn by_status(value: &str) -> Vec<rustango::core::Filter> { /* map value → predicates */ }
+
+rustango::register_admin_list_filter!(
+    "posts", "status", "Status",
+    &[("draft", "Drafts"), ("published", "Published")],   // (value, label) choices
+    by_status,                                            // fn(&str) -> Vec<Filter>
+);
+```
+
+---
+
+## Vues personnalisées, querysets et permissions
+
+Trois macros d'enregistrement supplémentaires reflètent les hooks
+`ModelAdmin` de Django :
+
+- **Pages d'admin personnalisées** —
+  `register_admin_view!("posts", "duplicate", Method::POST, "Duplicate", handler)`
+  monte une page/action supplémentaire à `/<prefix>/posts/duplicate`. Le
+  gestionnaire est une `fn(Pool, Request) -> Response` asynchrone. (Les
+  suffixes réservés comme `new`, `__action`, `__autocomplete`, `{pk}`,
+  `{pk}/edit`, `{pk}/delete` sont ignorés avec un avertissement.)
+- **Restriction de queryset** —
+  `register_admin_queryset!("posts", hook)` où
+  `hook: fn(&Parts) -> Vec<Filter>` restreint ce qu'une requête peut voir
+  (p. ex. seulement les lignes de l'utilisateur courant). Plusieurs hooks sur
+  une table se combinent.
+- **Permissions au niveau de la ligne** —
+  `register_admin_object_permission!("posts", "change", check)` où
+  `check: fn(&Parts, Option<&Value>) -> bool` autorise ou refuse par ligne.
+  Les gestionnaires intégrés consultent les actions `add`, `change`,
+  `delete` et `view` ; plusieurs hooks se combinent avec un ET logique.
+
+Pour un contrôle d'accès plus grossier basé sur des codenames,
+`Builder::with_user_perms([...])` conditionne chaque table sur
+`{table}.view` / `.add` / `.change` / `.delete` : l'absence de `view` masque
+le modèle et renvoie une 404 sur les accès directs, l'absence de `change` le
+rend en lecture seule, et l'absence de `add` / `delete` retire ces boutons.
+
+---
+
+## Authentification
+
+Par défaut, l'admin est **ouvert** — quiconque peut y accéder peut l'utiliser.
+Verrouillez-le de l'une des deux façons suivantes :
+
+- **Authentification par session (intégrée).** `Builder::with_session_auth(secret)`
+  monte `/login` + `/logout` (et une page optionnelle de changement de mot de
+  passe `/account/password`) et enveloppe chaque autre route dans un
+  middleware qui redirige les requêtes anonymes vers le formulaire de
+  connexion. Les identifiants vivent dans la table
+  `rustango_admin_users` (`username`, `password_hash` argon2,
+  `is_superuser`, `active`, `created_at`) ; changer un mot de passe révoque
+  les autres sessions de cet utilisateur. Une double authentification TOTP
+  optionnelle est disponible derrière la feature `totp`, avec l'inscription
+  sous `/account/totp`.
+
+  ```rust
+  let admin = admin::Builder::new(pool)
+      .with_session_auth(session_secret)
+      .secure_cookies(true)              // HTTPS-only cookie in production
+      .build();
+  ```
+
+- **Le protéger avec votre propre authentification.** Laissez l'admin ouvert
+  et placez une authentification HTTP Basic, OAuth2, ou un SSO d'entreprise
+  devant le chemin de nesting avec votre propre middleware.
+
+---
+
+## Thème et image de marque
+
+| Méthode | Effet |
+|---|---|
+| `.theme_mode("light" \| "dark" \| "auto")` | Thème de couleur par défaut (définit `data-theme` sur `<html>`). |
+| `.title(s)` / `.subtitle(s)` | Texte d'en-tête de la barre latérale. |
+| `.brand_logo_url(url)` | Logo affiché au-dessus du titre. |
+| `.brand_name(s)` / `.brand_tagline(s)` | Surcharges par tenant du titre/sous-titre. |
+| `.tenant_brand_css(css)` | Un bloc CSS `:root{…}` de variables déjà construit, inliné pour des palettes par tenant. |
+| `.from_settings(pool, &settings)` | Construit l'image de marque + la visibilité à partir des sections `[admin]` / `[brand]` de votre fichier de configuration. |
+
+`from_settings` lit `admin.title`, `admin.subtitle`, `admin.logo_url`,
+`admin.theme_mode`, `admin.url_prefix`, `admin.allowed_tables`,
+`admin.read_only_tables`, en se repliant sur la section `[brand]`, et met
+`secure_cookies` à `true` par défaut. Les appels impératifs au `Builder`
+après cela l'emportent toujours.
+
+---
+
+## Référence `Builder`
+
+Chaque méthode de `admin::Builder` (chacune renvoie `Self` pour le chaînage
+sauf indication contraire) :
+
+| Méthode | Objet |
+|---|---|
+| `new(pool)` | Construit à partir de n'importe quel pool (PostgreSQL / MySQL / SQLite). Par défaut : préfixe `/__admin`, cookies de développement. |
+| `from_settings(pool, &settings)` | Construit à partir d'une configuration analysée (feature `config`). |
+| `title(s)` / `subtitle(s)` | En-tête / sous-en-tête de la barre latérale. |
+| `admin_prefix(p)` | Préfixe d'URL — **doit correspondre au chemin de nesting**. Par défaut `/__admin`. |
+| `audit_url(u)` | Chemin de la vue activité/audit. Par défaut `/__audit`. |
+| `static_url(u)` | Préfixe pour les ressources embarquées (favicon, logo). Par défaut `/__static__`. |
+| `change_password_url(u)` | Chemin de la page libre-service de changement de mot de passe (ajoute le lien dans la barre latérale). |
+| `show_only([tables])` | Liste blanche des tables qui apparaissent ; les autres renvoient une 404 et sont masquées. |
+| `read_only([tables])` | Affiche ces tables mais interdit la création/édition/suppression. |
+| `read_only_all()` | Marque **toutes** les tables en lecture seule. |
+| `skip_count_for([tables])` | Évite `COUNT(*)` sur les tables volumineuses (le pagineur affiche « Page N »). |
+| `with_user_perms([codenames])` | Conditionne les tables sur `{table}.view/add/change/delete`. |
+| `register_action(table, name, handler)` | Enregistre un gestionnaire d'action groupée. |
+| `with_session_auth(secret)` | Exige une connexion par cookie (`/login` + `/logout`). |
+| `secure_cookies(bool)` | Définit le drapeau `Secure` (HTTPS uniquement) sur le cookie de session. |
+| `theme_mode(m)` | `"light"` / `"dark"` / `"auto"`. |
+| `brand_logo_url(url)` | Logo au-dessus du titre. |
+| `brand_name(s)` / `brand_tagline(s)` | Surcharges de marque par tenant. |
+| `tenant_brand_css(css)` | Bloc CSS de variables par tenant. |
+| `impersonated_by(operator_id)` | Affiche une bannière d'emprunt d'identité (console opérateur). |
+| `tenant_mode()` | Masque les modèles à portée registre (défini automatiquement pour les admins de tenant). |
+| `build()` | Finalise et renvoie le `axum::Router`. |
+
+---
+
+## Référence des routes
+
+Tous les chemins sont relatifs à `admin_prefix` :
+
+| Chemin | Méthode | Quoi |
+|---|---|---|
+| `/` | GET | Accueil — index des modèles + actions récentes. |
+| `/<table>` | GET | Vue liste (recherche, filtres, tri, pagination). |
+| `/<table>` | POST | Soumission de création. |
+| `/<table>/new` | GET | Formulaire de création. |
+| `/<table>/<pk>` | GET | Vue détail (lecture seule), avec inlines + carte d'audit. |
+| `/<table>/<pk>` | POST | Soumission de mise à jour. |
+| `/<table>/<pk>/edit` | GET | Formulaire de modification. |
+| `/<table>/<pk>/delete` | POST | Suppression (après confirmation). |
+| `/<table>/__action` | POST | Exécute une action groupée sur les PK sélectionnées. |
+| `/<table>/__autocomplete` | GET | JSON du typeahead FK (`?q=`). |
+| `/__docs` | GET | Référence de modèle. |
+| `/__audit` (ou `audit_url`) | GET | Flux d'activité + nettoyage. |
+| `/login`, `/logout` | GET/POST | Authentification par session (si activée). |
+| `/account/password`, `/account/totp` | GET/POST | Changement de mot de passe libre-service / inscription TOTP. |
+
+Les routes personnalisées enregistrées avec `register_admin_view!` se
+montent à `/<table>/<suffix>`.
+
+---
+
+## La référence de modèle
+
+Chaque admin embarque une référence de modèle en direct (l'admindocs de
+Django) à `<prefix>/__docs` — un catalogue en lecture seule de chaque modèle
+enregistré avec ses champs, colonnes, types, drapeaux (PK, unique, …) et
+relations. Rien à configurer ; elle est générée à partir de vos modèles, donc
+elle ne dérive jamais du schéma.
+
+[![La référence de modèle : les champs de chaque modèle avec le nom de colonne, le type Rust, les drapeaux et les relations — générée à partir des modèles](img/admin-model-reference.png)](img/admin-model-reference.png)
+
+---
+
+## Essayer l'exemple
+
+```bash
+cd crates/rustango/examples/admin_demo
+export DATABASE_URL=postgres://rustango:rustango@localhost:5432/admin_demo
+cargo run -- migrate     # tables + the audit-log table
+cargo run                # seeds demo data, serves the admin at /admin
+```
+
+Puis ouvrez <http://localhost:8080/admin> et cliquez sur **Posts** pour voir
+les filtres, la recherche, la hiérarchie de dates, les actions, les
+fieldsets, les commentaires en inline, la piste d'audit, et la référence de
+modèle — chaque capture d'écran de cette page — au même endroit.
+
+
+---
+
+## Voir aussi
+
+- [Le cookbook de l'ORM](orm.md) — les modèles à partir desquels l'admin est généré (y compris la piste d'audit partagée).
+- [Vues HTML](html-views.md) — les vues génériques basées sur des classes sur lesquelles l'admin est construit.
+- [Backends d'authentification](auth-backends.md) · [Sessions](auth-sessions.md) — sécuriser l'admin derrière une connexion.
+- [Guide de sécurité](security.md) — durcir avant de l'exposer.

--- a/docs/fr/getting-started.md
+++ b/docs/fr/getting-started.md
@@ -1,0 +1,727 @@
+# Bien démarrer : construire un blog avec Rustango
+
+Ce guide vous accompagne depuis un répertoire vide jusqu'à un blog déployé : des articles, une interface d'administration, une API JSON, une authentification JWT et des tests. De bout en bout. Si vous avez déjà utilisé Django, Laravel ou Rails, la plupart des étapes vous sembleront familières ; nous soulignons les parallèles au fil du texte.
+
+> **Durée :** ~45 minutes pour la visite complète, ~10 minutes si vous voulez juste la voir fonctionner.
+>
+> **Version exécutable :** chaque étape ci-dessous est reproduite dans un exemple testé et compilable disponible dans [`crates/rustango/examples/getting_started_blog`](../crates/rustango/examples/getting_started_blog). Si une étape vous semble incorrecte, comparez-la à cet exemple.
+
+[![Construire un blog avec Rustango : générer la migration, l'appliquer, démarrer le serveur, et interroger l'API JSON — tout depuis un seul binaire](img/getting-started.png)](img/getting-started.png)
+
+---
+
+## Ce dont vous avez besoin d'abord
+
+| Outil | Pourquoi | Installation |
+|---|---|---|
+| Rust 1.88+ | Compilateur | <https://rustup.rs> |
+| Docker | Postgres local | <https://docker.com> |
+| `psql` (optionnel) | Inspecter la BDD | `brew install libpq` / `apt install postgresql-client` |
+
+Vérifiez les versions installées :
+
+```bash
+rustc --version    # should print 1.88+
+docker --version   # any recent version
+```
+
+---
+
+## Étape 1 : installer le générateur de squelette
+
+Le générateur de squelette (scaffolder) crée pour vous des squelettes de projet et d'application, comme `django-admin` ou `rails new`.
+
+```bash
+cargo install cargo-rustango
+```
+
+Ceci ajoute globalement la sous-commande `cargo rustango ...`. Vérifiez qu'elle est bien disponible :
+
+```bash
+cargo rustango --help
+```
+
+---
+
+## Étape 2 : créer le projet
+
+Ceci génère un nouveau projet, l'équivalent chez **Rustango** de `rails new` ou `composer create-project`.
+
+```bash
+cd ~/projects                                 # wherever you keep code
+cargo rustango new myblog                     # default = fullstack template
+cd myblog
+```
+
+Voici ce qui a été généré :
+
+```
+myblog/
+├── Cargo.toml                  # rustango + axum + sqlx + tokio
+├── .env.example                # template for DATABASE_URL etc.
+├── .gitignore
+├── docker-compose.yml          # Postgres in a container
+├── README.md                   # project-specific
+├── config/                     # tiered settings (default + dev/staging/prod)
+├── migrations/                 # empty — `cargo run -- makemigrations` populates
+└── src/
+    ├── main.rs                 # entry point: `Cli::new().api(urls::api()).run()`
+    ├── models.rs               # every #[derive(Model)] lives here
+    ├── views.rs                # axum request handlers
+    └── urls.rs                 # `pub fn api()` route aggregator + `admin_router(pool)`
+```
+
+Il n'y a qu'un seul binaire : `cargo run` démarre le serveur HTTP, et chaque verbe de style Django (`migrate`, `makemigrations`, `startapp`, `check`, …) passe par ce même binaire via `cargo run -- <verb>`. Il n'y a pas de binaire `manage` séparé.
+
+`Cargo.toml` est le manifeste de dépendances (comme un `composer.json` ou un `Gemfile`). Ouvrez-le et vérifiez que `rustango` figure bien dans `[dependencies]`.
+
+> **Vérifiez le bloc `[features]` — choisissez un backend de base de données.** `#[derive(Model)]`
+> conditionne (via `cfg`) ses implémentations générées de `FromRow` / `LoadRelated` aux
+> features de **votre** crate (un `cfg` à l'intérieur d'une macro derive se résout par rapport à la crate de destination,
+> pas celle de **Rustango**), donc une feature de backend doit être activée ici, sinon le premier modèle
+> ne compilera pas. Un squelette actuel inclut :
+>
+> ```toml
+> [features]
+> default  = ["postgres"]            # the backend `cargo run` uses
+> postgres = ["rustango/postgres"]
+> sqlite   = ["rustango/sqlite"]
+> mysql    = ["rustango/mysql"]
+> ```
+>
+> Si votre `Cargo.toml` généré n'a **aucun** bloc `[features]` (un `cargo-rustango`
+> plus ancien), ajoutez celui ci-dessus à la main — cela résout toujours le problème. Sans cela,
+> la compilation échoue avec *« the trait bound `…: MaybePgFromRow` is not satisfied »*
+> ainsi qu'un révélateur `warning: unexpected cfg condition value: postgres`.
+
+---
+
+## Étape 3 : configurer votre environnement
+
+La configuration se trouve dans un fichier `.env`, tout comme dans Django ou Laravel. Copiez le modèle :
+
+```bash
+cp .env.example .env
+```
+
+Le fichier `.env` généré est prêt à l'emploi avec Docker. Comme nous allons exécuter `cargo` sur la machine hôte (et non dans le conteneur de développement), changez l'hôte de la base de données de `postgres` à `localhost` :
+
+```bash
+DATABASE_URL=postgres://rustango:rustango@localhost:5432/myblog_dev
+RUSTANGO_BIND=0.0.0.0:8080
+RUSTANGO_APEX_DOMAIN=localhost
+RUSTANGO_SESSION_SECRET=change-me-base64-encoded-32-bytes-or-more
+```
+
+Les identifiants, le port et le nom de la base de données (`myblog_dev`) correspondent déjà au service Postgres du `docker-compose.yml`, donc vous n'avez pas besoin d'y toucher.
+
+`RUSTANGO_SESSION_SECRET` signe les sessions et les jetons, donc ne déployez pas la valeur d'exemple. Générez-en une vraie et collez-la :
+
+```bash
+openssl rand -base64 32     # paste output as RUSTANGO_SESSION_SECRET value
+```
+
+---
+
+## Étape 4 : démarrer Postgres
+
+Le projet inclut un `docker-compose.yml` qui exécute Postgres dans un conteneur, afin que vous n'ayez pas à installer une base de données à la main. Nous allons exécuter l'application elle-même avec `cargo` sur l'hôte, donc démarrez uniquement le service `postgres` en arrière-plan (le fichier compose définit aussi un conteneur de développement `rust` optionnel qui occuperait sinon le port 8080) :
+
+```bash
+docker compose up -d postgres
+```
+
+Vérifiez qu'il fonctionne :
+
+```bash
+docker compose ps
+psql "$DATABASE_URL" -c "SELECT version();"   # should print Postgres version
+```
+
+---
+
+## Étape 5 : exécuter les migrations intégrées
+
+Les migrations créent les tables de votre base de données, la même idée que `php artisan migrate` ou `rails db:migrate`. Exécutez-les une fois pour mettre en place les propres tables du framework :
+
+```bash
+cargo run -- migrate
+```
+
+La première compilation prend ~2 minutes (Rust compile tout depuis les sources). Un projet neuf n'expose encore aucun fichier de migration, donc vous verrez `nothing to migrate (already up to date)` — `migrate` met néanmoins en place la table de journal d'audit du framework afin que les modèles audités fonctionnent dès que vous les ajouterez. Vous générerez votre première vraie migration à l'étape 9.
+
+Vérifiez l'état des migrations :
+
+```bash
+cargo run -- showmigrations
+```
+
+Sur un projet neuf, ceci affiche `(no migrations in ./migrations)`. Une fois que vous aurez créé un modèle et exécuté `makemigrations` (étape 9), chaque migration appliquée affichera un `[X]` ici.
+
+---
+
+## Étape 6 : premier démarrage
+
+Démarrez le serveur pour vérifier que tout est correctement branché.
+
+```bash
+cargo run
+```
+
+Vous verrez :
+
+```
+listening on http://0.0.0.0:8080
+```
+
+Ouvrez <http://localhost:8080> dans votre navigateur. Le squelette fournit un gestionnaire racine simple (`views::index`) qui vous accueille avec **Hello from Rustango!** et un lien vers l'administration — ce qui confirme que **Rustango** fonctionne. (Les projets qui ne définissent pas leur propre route `/` reçoivent à la place une page d'accueil intégrée, via `Cli::with_welcome()`.)
+
+Appuyez sur Ctrl-C pour arrêter.
+
+---
+
+## Étape 7 : créer une application
+
+Une « application » est un module fonctionnel autonome, exactement comme une application Django. Votre application blog contiendra le modèle Post, ses routes et ses gabarits (templates).
+
+```bash
+cargo run -- startapp blog
+```
+
+Ceci écrit :
+
+```
+src/blog/
+├── mod.rs
+├── models.rs              # a starter model named after the app (you'll replace it)
+├── views.rs               # axum handlers
+├── urls.rs                # blog-specific routes (pub fn api())
+└── tests.rs               # in-process router + inventory smoke tests
+```
+
+`startapp` branche le nouveau module pour vous (de manière similaire à l'ajout d'une entrée dans `INSTALLED_APPS` de Django) : il déclare `mod blog;` dans `src/main.rs` et insère une ligne `.merge(crate::blog::urls::api())` dans l'agrégateur `api()` de `src/urls.rs`, si bien que les routes du blog s'intègrent automatiquement à l'application. Aucun enregistrement manuel de module n'est nécessaire.
+
+---
+
+## Étape 8 : définir un modèle
+
+Un modèle est une table de base de données décrite comme une structure Rust, comme un modèle Django ou une classe Eloquent/Active Record. Ouvrez `src/blog/models.rs` et définissez votre `Post`. (Pour la référence complète — chaque type de champ, les clés primaires personnalisées et tous les attributs — voir le [guide des modèles](models.md).)
+
+```rust
+use rustango::{Auto, Model};
+use chrono::{DateTime, Utc};
+
+#[derive(Model, Clone, Debug)]
+#[rustango(
+    table = "posts",
+    display = "title",
+    admin(
+        list_display  = "id, title, status, published_at",
+        search_fields = "title, body",
+        list_filter   = "status, author_id",
+        ordering      = "-published_at",
+    ),
+    audit(track = "title, body, status"),
+    index("status, published_at"),
+)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+
+    #[rustango(max_length = 200)]
+    pub title: String,
+
+    pub body: String,
+
+    #[rustango(max_length = 20, default = "'draft'")]
+    pub status: String,                  // draft | published
+
+    pub author_id: i64,
+
+    #[rustango(auto_now_add)]
+    pub published_at: Auto<DateTime<Utc>>,
+
+    #[rustango(soft_delete)]
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+```
+
+Quelques points Rust à noter :
+
+- `#[derive(Model, ...)]` est une **macro derive** : elle génère automatiquement du code pour la structure, à la manière d'un décorateur de classe ou d'une classe de base dans d'autres frameworks. Dériver `Model` est ce qui donne à la structure ses méthodes de requête.
+- `Auto<i64>` marque un champ que la base de données remplit pour vous (un entier `i64` auto-incrémenté), comme une clé primaire automatique.
+- `Option<...>` signifie « cette valeur peut être absente ». `Option<DateTime<Utc>>` est un horodatage qui peut être nul, donc `deleted_at` est vide jusqu'à ce que la ligne soit supprimée en douceur (soft-delete).
+- Les attributs `#[rustango(...)]` configurent chaque champ (longueur maximale, valeurs par défaut, index) et le bloc `admin(...)` définit les colonnes et filtres de l'interface d'administration.
+
+---
+
+## Étape 9 : créer et appliquer la migration
+
+Transformons maintenant ce modèle en une véritable table. Générez d'abord la migration à partir de votre modèle (comme `makemigrations` dans Django) :
+
+```bash
+cargo run -- makemigrations
+```
+
+Vous verrez quelque chose comme :
+
+```
+wrote ./migrations/0001_create_item_and_posts_and_rustango_admin_users_etc.json
+    + CreateTable("item")
+    + CreateTable("posts")
+    + CreateTable("rustango_admin_users")
+    + CreateTable("rustango_content_types")
+    + CreateIndex { table: "posts", columns: ["status", "published_at"], ... }
+```
+
+Cette première migration crée vos modèles — `posts`, ainsi que le modèle de démarrage `item` fourni par le squelette dans `src/models.rs` — en même temps que les propres tables d'administration et de types de contenu du framework. Ouvrez le fichier JSON si vous le souhaitez : il contient les opérations ainsi qu'un instantané complet du schéma.
+
+Appliquez-la à la base de données :
+
+```bash
+cargo run -- migrate
+```
+
+Vérifiez que la table existe :
+
+```bash
+psql "$DATABASE_URL" -c "\d posts"
+```
+
+---
+
+## Étape 10 : essayer l'ORM
+
+Lisons et écrivons des lignes depuis le code. L'ORM vous permet de manipuler les lignes de la base de données comme des structures Rust plutôt que du SQL brut, comme l'ORM de Django, Eloquent, ou Active Record.
+
+Modifiez temporairement `src/main.rs` pour exécuter un rapide test de création-et-lecture avant de démarrer le serveur. Remplacez le corps du `Cli` par un test ad hoc de l'ORM (conservez le `#[rustango::main]` du générateur de squelette ainsi que les déclarations `mod` en haut du fichier) :
+
+```rust
+mod blog;
+mod models;
+mod urls;
+mod views;
+
+use crate::blog::models::Post;
+use rustango::{Auto, Model};
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    let pool = rustango::sql::sqlx::PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
+
+    // CREATE
+    let mut p = Post {
+        id: Auto::default(),
+        title: "First post".into(),
+        body: "Hello, world.".into(),
+        status: "draft".into(),
+        author_id: 1,
+        published_at: Auto::default(),
+        deleted_at: None,
+    };
+    p.save(&pool).await?;
+    println!("created post id = {}", p.id.get().copied().unwrap());
+
+    // READ
+    let posts = Post::objects().fetch_on(&pool).await?;
+    for post in &posts {
+        println!("- {}", post.title);
+    }
+
+    Ok(())
+}
+```
+
+Ce qui se passe ici, en termes simples :
+
+- `pool` est le pool de connexions à la base de données partagé. Vous passez une référence à celui-ci (`&pool`) dans les appels de requête plutôt que d'ouvrir une nouvelle connexion chaque fois.
+- Les appels à la base de données sont asynchrones, donc chacun se termine par `.await` — cela met en pause jusqu'à ce que le résultat revienne, puis continue. Le `?` après un `.await` signifie « si ceci a échoué, arrête et renvoie l'erreur ».
+- `main` renvoie un `Result`, le type succès-ou-erreur de Rust, ce qui explique pourquoi `?` et le `Ok(())` final fonctionnent.
+- Pour enregistrer une ligne, appelez `.save(&pool)` sur celle-ci. Pour lire des lignes, construisez une requête avec `Post::objects()` et exécutez-la avec `.fetch_on(&pool)` — l'équivalent approximatif du `Post.objects.all()` de Django. (`.save(&pool)` / `.fetch_on(&pool)` prennent un `sqlx::PgPool` ; la variante nue `.fetch(&pool)` prend à la place un `rustango::sql::Pool` multi-backend — voir le [guide de l'ORM](orm.md).)
+
+Exécutez-le :
+
+```bash
+cargo run
+```
+
+Vous devriez voir l'identifiant de votre nouvel article ainsi que les lignes lues en retour. Restaurez `src/main.rs` à sa forme de serveur générée par le squelette une fois que vous avez confirmé que cela fonctionne — l'étape suivante s'appuie sur cette forme.
+
+---
+
+## Étape 11 : activer l'administration automatique
+
+**Rustango** fournit une interface d'administration générée pour vos modèles, tout comme l'administration Django. Le générateur de squelette vous a déjà donné un utilitaire `admin_router(pool)` dans `src/urls.rs` qui construit l'administration automatique à partir d'un pool — vous n'avez qu'à l'imbriquer sous `/admin` et à l'injecter dans le `Cli`.
+
+Donnez d'abord un titre à l'administration dans `src/urls.rs`. Le `admin_prefix` doit correspondre au chemin sous lequel vous l'imbriquerez à l'étape suivante (`/admin`) afin que les propres liens et actions de formulaire de l'administration se résolvent correctement :
+
+```rust
+pub fn admin_router(pool: PgPool) -> Router {
+    admin::Builder::new(pool)
+        .title("Myblog Admin")
+        .admin_prefix("/admin") // must match the `.nest("/admin", …)` below
+        .build()
+}
+```
+
+Ensuite, connectez un pool dans `src/main.rs` et imbriquez l'administration dans le routeur de l'API avant de la remettre au `Cli`. Conservez la ligne `mod blog;` de l'étape 7 — c'est elle qui enregistre votre modèle `Post` auprès de l'administration :
+
+```rust
+mod blog;
+mod models;
+mod urls;
+mod views;
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    let pool = rustango::sql::sqlx::PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
+
+    let api = urls::api().nest("/admin", urls::admin_router(pool));
+
+    rustango::manage::Cli::new()
+        .api(api)
+        .with_health() // /health + /ready endpoints
+        .run()
+        .await
+}
+```
+
+`Cli::new()...run()` est le même dispatcheur unifié généré par le squelette — il continue de servir chaque `cargo run -- <verb>` ; vous n'avez fait qu'enrichir le routeur qu'il sert au moment de `runserver`.
+
+Exécutez-le :
+
+```bash
+cargo run
+```
+
+Ouvrez <http://localhost:8080/admin> (sans barre oblique finale). Vous verrez l'accueil de l'administration avec un lien `posts`. Cliquez sur celui-ci pour voir votre article brouillon dans la liste, cliquez sur l'article pour ouvrir son formulaire d'édition, puis enregistrez. L'onglet de piste d'audit enregistre chaque écriture.
+
+---
+
+## Étape 12 : construire l'API JSON
+
+Un ViewSet expose un modèle comme une API REST avec des points de terminaison de liste, création, récupération, mise à jour et suppression, tout comme un ViewSet Django REST Framework ou un contrôleur de ressource API Laravel.
+
+### 12a. Générer le ViewSet
+
+Générez le fichier, puis renseignez les champs et comportements à exposer :
+
+```bash
+cargo run -- make:viewset PostViewSet --model Post
+```
+
+Modifiez `src/post_view_set.rs` :
+
+```rust
+use rustango::ViewSet;
+use crate::blog::models::Post;
+
+#[derive(ViewSet)]
+#[viewset(
+    model         = Post,
+    fields        = "id, title, body, status, author_id, published_at",
+    filter_fields = "author_id, status",
+    search_fields = "title, body",
+    ordering      = "-published_at",
+    page_size     = 20,
+)]
+pub struct PostViewSet;
+```
+
+Enregistrez le nouveau module en ajoutant `mod post_view_set;` avec les autres déclarations `mod` en haut de `src/main.rs`.
+
+### 12b. Monter les routes
+
+Attachez les routes du ViewSet au routeur de l'application (la version **Rustango** d'un fichier `urls.py` ou d'un `routes/api.php`). Le routeur du ViewSet a besoin du pool de base de données, construisez-le donc dans `src/main.rs`, là où vit le pool, et fusionnez-le dans l'agrégateur `urls::api()` :
+
+```rust
+let api = urls::api()
+    .nest("/admin", urls::admin_router(pool.clone()))
+    .merge(crate::post_view_set::PostViewSet::router("/api/posts", pool));
+
+rustango::manage::Cli::new()
+    .api(api)
+    .with_health()
+    .run()
+    .await
+```
+
+(`urls::api()` est l'agrégateur généré par le générateur de squelette ; `manage startapp` fusionne les routes de toute sous-application de la même façon.)
+
+### 12c. Essayer les points de terminaison
+
+Démarrez le serveur :
+
+```bash
+cargo run
+```
+
+Dans un autre terminal, interrogez l'API avec `curl` :
+
+```bash
+curl http://localhost:8080/api/posts                                    # list
+curl -X POST http://localhost:8080/api/posts \
+     -H "content-type: application/json" \
+     -d '{"title":"From API","body":"Yo","status":"published","author_id":1}'
+curl http://localhost:8080/api/posts/1                                   # retrieve
+curl "http://localhost:8080/api/posts?search=API&ordering=-id"            # search + sort
+curl "http://localhost:8080/api/posts?status__ne=draft"                   # lookup operator
+```
+
+---
+
+## Étape 13 : façonner la sortie avec un Serializer
+
+Par défaut, le ViewSet renvoie tous les champs du modèle. Un Serializer vous permet de contrôler la forme de la réponse : masquer des champs internes, les renommer, ou en marquer certains en lecture seule. Il joue le même rôle qu'un serializer DRF ou une ressource API Laravel.
+
+```bash
+cargo run -- make:serializer PostSerializer --model Post
+```
+
+Modifiez `src/post_serializer.rs` :
+
+```rust
+use rustango::{Auto, Serializer};
+use crate::blog::models::Post;
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: Auto<i64>,
+    pub title: String,
+
+    #[serializer(source = "body")]                      // rename in API
+    pub content: String,
+
+    #[serializer(read_only)]                            // include in GET, ignore in POST/PUT
+    pub published_at: Auto<chrono::DateTime<chrono::Utc>>,
+}
+```
+
+Le type de chaque champ du serializer reflète le champ correspondant du modèle, donc `id` et `published_at` conservent leur enveloppe `Auto<…>` héritée du modèle (un `Auto<i64>` se sérialise toujours en un simple entier JSON). Enregistrez ensuite le module en ajoutant `mod post_serializer;` avec les autres déclarations `mod` dans `src/main.rs`.
+
+Branchez le serializer dans le ViewSet avec l'attribut `serializer` — les réponses de liste, de récupération et de création sont alors rendues via celui-ci (la projection de champs `fields` est alors contournée au profit de la forme du serializer) :
+
+```rust
+#[derive(ViewSet)]
+#[viewset(
+    model = Post,
+    serializer = crate::post_serializer::PostSerializer,
+    ordering = "-published_at",
+)]
+pub struct PostViewSet;
+```
+
+Ceci fonctionne à l'identique sur PostgreSQL, MySQL et SQLite. Les redéfinitions `method` / `read_only` / `source` / `write_only` s'appliquent toutes à la réponse, et **les corps de requête sont eux aussi validés via le serializer** : `create` / `update` exécutent sa `validate()` (par champ et inter-champs), renvoyant un `400` de forme DRF (`{field: [messages]}`) en cas d'échec, et les champs en lecture seule / calculés qu'un client tenterait de poster sont ignorés. (Remarque : les champs de serializer `nested` / `many` nécessitent que les lignes liées soient chargées via `select_related` ; sinon ils s'affichent avec leur valeur par défaut.) Voir le [guide des ViewSets](viewsets.md) pour le comportement complet en entrée et en sortie.
+
+---
+
+## Étape 14 : ajouter l'authentification JWT
+
+Les JWT sont des jetons signés que vous remettez à un client après la connexion et que vous vérifiez à chaque requête, un schéma courant pour l'authentification d'API. Le module `rustango::jwt` de **Rustango** les émet et les vérifie (HS256), et il est actif par défaut — aucune feature supplémentaire à activer.
+
+### 14a. Émettre un jeton à la connexion
+
+Intégrez l'identifiant de l'utilisateur (le « sujet » du jeton) et toute revendication (claim) personnalisée, comme les rôles, dans un jeton signé, puis remettez-le au client :
+
+```rust
+use rustango::jwt::{encode, Claims};
+use std::time::Duration;
+
+// Derive the signing key from your session secret.
+let secret = std::env::var("RUSTANGO_SESSION_SECRET")?.into_bytes();
+
+let mut claims = Claims::new(user_id.to_string());   // subject = user id
+claims.set("roles", vec!["editor"]);
+let token = encode(&claims.ttl(Duration::from_secs(900)), &secret)?;
+
+// Send `token` to the client (e.g. in the login response body).
+```
+
+### 14b. Vérifier le jeton à chaque requête
+
+Décodez le jeton — ceci vérifie la signature et l'expiration — puis relisez les revendications (claims). S'il est absent ou invalide, rejetez la requête comme non autorisée :
+
+```rust
+use rustango::jwt::decode;
+
+let claims = decode(&access_token, &secret)
+    .map_err(|_| StatusCode::UNAUTHORIZED)?;
+
+let user_id = claims.subject().ok_or(StatusCode::UNAUTHORIZED)?;
+let roles: Vec<String> = claims.get("roles").unwrap_or_default();
+```
+
+### 14c. Cycle de vie accès + rafraîchissement
+
+`rustango::jwt` émet des jetons uniques sans état. Pour le schéma complet — des jetons d'**accès** de courte durée, un jeton de **rafraîchissement** de longue durée dans un cookie HttpOnly, la rotation, et une liste noire de JTI pour la révocation — activez la feature `tenancy` et utilisez `rustango::tenancy::jwt_lifecycle::JwtLifecycle`, dont les méthodes `issue_pair_with` / `verify_access` / `refresh` gèrent la paire pour vous.
+
+---
+
+## Étape 15 : ajouter le middleware de sécurité
+
+Le middleware englobe chaque requête pour y ajouter un comportement transversal. Ici, vous empilez les identifiants de requête, la journalisation des accès, la limitation de débit, le CORS et les en-têtes de sécurité en une seule chaîne. Chaque `.method(...)` ajoute une couche, de manière similaire au middleware Django ou à la pile de middleware de Laravel. Voir le [guide du middleware](middleware.md) pour le catalogue complet des couches et les règles d'ordonnancement.
+
+```rust
+use rustango::security_headers::{SecurityHeadersLayer, SecurityHeadersRouterExt, CspBuilder};
+use rustango::cors::{CorsLayer, CorsRouterExt};
+use rustango::rate_limit::{RateLimitLayer, RateLimitRouterExt};
+use rustango::access_log::{AccessLogLayer, AccessLogRouterExt};
+use rustango::request_id::{RequestIdLayer, RequestIdRouterExt};
+use rustango::health::health_router;
+use std::time::Duration;
+
+let app = urls::api()
+    .nest("/admin", urls::admin_router(pool.clone()))
+    .merge(crate::post_view_set::PostViewSet::router("/api/posts", pool.clone()))
+    .merge(health_router(pool.clone()))                        // /health, /ready
+    .request_id(RequestIdLayer::default())
+    .access_log(AccessLogLayer::default())                      // PII-redacted
+    .rate_limit(RateLimitLayer::per_ip(60, Duration::from_secs(60)))
+    .cors(CorsLayer::new()
+        .allow_origins(vec!["https://app.example.com"])
+        .allow_methods(vec!["GET", "POST", "PUT", "PATCH", "DELETE"]))
+    .security_headers(
+        SecurityHeadersLayer::strict()
+            .csp(CspBuilder::strict_starter().build()),
+    );
+```
+
+Remettez le `app` fini au `Cli` exactement comme avant — `rustango::manage::Cli::new().api(app).with_welcome().run().await` — et chaque requête passe désormais par la pile complète de middleware.
+
+---
+
+## Étape 16 : écrire des tests
+
+**Rustango** inclut un client de test qui pilote votre routeur en process, ce qui vous permet de faire des assertions sur de vraies réponses HTTP sans démarrer de serveur, tout comme le client de test de Django ou les tests HTTP de Laravel. Générez un fichier de test :
+
+```bash
+cargo run -- make:test PostSmoke      # generates tests/post_smoke.rs
+```
+
+Les générateurs `make:*` prennent un nom en PascalCase ; `PostSmoke` devient le fichier en snake_case `tests/post_smoke.rs`.
+
+Modifiez `tests/post_smoke.rs`. Les tests d'intégration vivent dans une crate séparée, donc ils construisent le routeur testé directement à partir du ViewSet (le même appel `router(...)` que celui monté à l'étape 12b) :
+
+```rust
+use rustango::test_client::TestClient;
+use myblog::post_view_set::PostViewSet;
+use rustango::sql::sqlx::PgPool;
+use serde_json::json;
+
+async fn app() -> axum::Router {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap()).await.unwrap();
+    PostViewSet::router("/api/posts", pool)
+}
+
+#[tokio::test]
+async fn list_posts_returns_200() {
+    let client = TestClient::new(app().await);
+    let response = client.get("/api/posts").send().await;
+    assert_eq!(response.status, 200);
+    let v = response.json_value();
+    assert!(v["results"].is_array());
+}
+
+#[tokio::test]
+async fn create_post_returns_the_new_object() {
+    let client = TestClient::new(app().await);
+    let response = client.post("/api/posts")
+        .json(&json!({
+            "title": "Test",
+            "body":  "x",
+            "status": "draft",
+            "author_id": 1,
+        }))
+        .send().await;
+    assert_eq!(response.status, 201);
+    let v: serde_json::Value = response.json();
+    assert_eq!(v["title"], "Test");
+}
+```
+
+> **Attention :** les tests d'intégration dans `tests/` ne peuvent faire `use myblog::…` que si la crate expose une cible de bibliothèque. Un squelette neuf n'est composé que d'un binaire (`src/main.rs`, sans `src/lib.rs`), donc ajoutez une simple ligne `src/lib.rs` qui réexporte les modules que vous voulez tester — `pub mod models; pub mod post_view_set; pub mod urls;` — et conservez les lignes `mod …;` correspondantes dans `src/main.rs`. (Si vous préférez ne pas ajouter de cible de bibliothèque, construisez plutôt le routeur entièrement en ligne dans le test, de la façon dont `make:test` génère sa fonction `app()`.)
+
+Exécutez les tests :
+
+```bash
+cargo test --test post_smoke
+```
+
+---
+
+## Étape 17 : exécuter la vérification système
+
+Avant de déployer, exécutez le vérificateur intégré. Il signale les erreurs de configuration courantes (comme un `RUSTANGO_SESSION_SECRET` trop faible ou une base de données inaccessible), de façon similaire au `check --deploy` de Django.
+
+```bash
+cargo run -- check --deploy
+```
+
+Dans votre environnement de développement local, vous verrez quelque chose comme :
+
+```
+running rustango system check (deploy mode)...
+  [info]    6 models registered via inventory
+  [info]    database reachable
+  [info]    1 migration(s) on disk
+  [info]    RUSTANGO_SESSION_SECRET length OK
+  [info]    config tier resolved to `dev`
+  [warning] RUSTANGO_ENV is unset — set to `prod` so config loaders pick the right tier
+  [warning] DATABASE_URL points at localhost / 127.0.0.1 — verify this is intended in production
+  [warning] RUSTANGO_APEX_DOMAIN is unset / `localhost` — set it for tenancy projects
+```
+
+(Le nombre exact de modèles/migrations dépend de votre projet.) Ces trois avertissements sont ceux attendus en environnement de développement. Dans une configuration de production — `RUSTANGO_ENV=prod`, un `DATABASE_URL` de base de données géré, un domaine apex défini — ils disparaissent et vous verrez `all checks passed`. Corrigez tout avertissement ou erreur restant avant de déployer en production.
+
+---
+
+## Étape 18 : déployer en production
+
+La façon de déployer dépend de votre plateforme (Fly, Railway, Kubernetes, ECS nu, et ainsi de suite). Les étapes côté framework sont les mêmes partout ; l'option `--release` construit un binaire optimisé :
+
+```bash
+# 1. Set production env
+export RUSTANGO_ENV=prod
+export DATABASE_URL=postgres://prod-host/myblog
+export RUSTANGO_SESSION_SECRET=$(openssl rand -base64 32)
+
+# 2. Run migrations
+cargo run --release -- migrate
+
+# 3. Audit
+cargo run --release -- check --deploy
+
+# 4. Build binary
+cargo build --release
+
+# 5. Run with a process supervisor (systemd / docker / k8s)
+./target/release/myblog
+```
+
+Assurez-vous que votre proxy inverse :
+- Termine le HTTPS
+- Transmet `X-Forwarded-For` pour des IP précises dans `AccessLogLayer`
+- Transmet `X-Forwarded-Host`, `X-Forwarded-Proto`
+- Utilise `axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())` afin que `ConnectInfo` soit renseigné pour la limitation de débit et le filtrage par IP
+
+---
+
+## Où aller ensuite
+
+| Sujet | Doc |
+|---|---|
+| Version exécutable de ce guide | [`examples/getting_started_blog`](../crates/rustango/examples/getting_started_blog) |
+| Chaque sous-commande `manage` | [`docs/manage.md`](manage.md) |
+| Recueil de recettes ORM (filtres avancés, agrégations, M2M, suppression douce) | [`docs/orm.md`](orm.md) |
+| Middleware (le catalogue complet des couches + ordonnancement) | [`docs/middleware.md`](middleware.md) |
+| Benchmarks de performance (vs Go) | [`docs/benchmarks.md`](benchmarks.md) |
+| Conventions d'API (nommage, patrons de construction, feature gates) | [`docs/api-conventions.md`](api-conventions.md) |
+| Fonctionnalités de sécurité en détail | [`docs/security.md`](security.md) |
+| Audit de parité avec Django | [`docs/django-parity-audit-2026-05-21.md`](django-parity-audit-2026-05-21.md) |
+| Multi-tenancy | [README — section Multi-tenancy](../README.md#multi-tenancy) |
+| Documentation de l'API | <https://docs.rs/rustango> |
+
+Si vous rencontrez quelque chose qui ne fonctionne pas ou qui n'est pas clair, ouvrez un ticket.

--- a/docs/fr/i18n.md
+++ b/docs/fr/i18n.md
@@ -1,0 +1,279 @@
+# Internationalisation (i18n)
+
+L'internationalisation consiste à servir votre application dans la langue de
+l'utilisateur. **Rustango** la divise en deux moitiés : **résoudre** la locale
+voulue par une requête (cookie →
+`Accept-Language` → valeur par défaut — traité dans [Middleware](middleware.md)), et
+**traduire** les chaînes vers cette locale, ce qui est l'objet de ce guide. Le `Translator`
+charge des catalogues de messages par locale, substitue les `{placeholders}`,
+gère les pluriels, et se replie avec élégance en cas d'absence — le `gettext` / `{% trans %}`
+de Django, en Rust.
+
+[![i18n dans Rustango : un Translator détient des catalogues par locale ; gettext recherche une clé avec repli (locale → langue de base → défaut → la clé elle-même), substitue les placeholders {name}, et ngettext choisit entre singulier et pluriel](img/i18n.png)](img/i18n.png)
+
+> **Nouveau ici ?** *locale*, *catalogue*, *Accept-Language*, *pluralisation*,
+> *RTL* — voir le [glossaire](glossary.md).
+
+> **Source :** `rustango::i18n` (`Translator`, `Locale`, `negotiate_language`,
+> `plural_category`, `is_rtl_language`, `language_native_name`, et les
+> liaisons de templates `tera_tags`) — toujours compilé. Le *middleware* de
+> locale/fuseau horaire par requête se trouve dans `rustango::i18n::middleware` /
+> `::timezone` (voir [Middleware](middleware.md)).
+>
+> **Version exécutable :** chaque extrait est copié depuis
+> [`i18n_doc.rs`](../crates/rustango/tests/i18n_doc.rs)
+> (`cargo test -p rustango --test i18n_doc`) ; les surcharges de traduction
+> adossées à la base de données sont testées en conditions réelles par
+> [`i18n_db_overrides_sqlite_live.rs`](../crates/rustango/tests/i18n_db_overrides_sqlite_live.rs).
+
+## Table des matières
+
+- [Les deux moitiés de l'i18n](#the-two-halves-of-i18n)
+- [Étape 1 — Construire un Translator](#step-1--build-a-translator)
+- [Étape 2 — Traduire des chaînes (gettext)](#step-2--translate-strings-gettext)
+- [Placeholders](#placeholders)
+- [Pluralisation](#pluralization)
+- [Ordre de repli](#fallback-order)
+- [Négocier la langue](#negotiating-the-language)
+- [Langues de droite à gauche](#right-to-left-languages)
+- [Traduire dans les templates (Tera)](#translating-in-templates-tera)
+- [Charger les catalogues + surcharges à l'exécution](#loading-catalogs--runtime-overrides)
+- [Voir aussi](#see-also)
+
+---
+
+## Les deux moitiés de l'i18n
+
+| Préoccupation | Où | Ce que ça fait |
+|---|---|---|
+| **Résoudre** la locale | [`i18n::middleware::LocaleMiddleware`](middleware.md#locale-aware-middleware) | choisit une locale par requête (cookie → Accept-Language → défaut) et expose l'extracteur `ActiveLocale` |
+| **Traduire** les chaînes | `i18n::Translator` (ce guide) | recherche une clé de message dans le catalogue de la locale active |
+| Afficher les dates dans le fuseau horaire de l'utilisateur | [`i18n::timezone`](middleware.md#timezone-aware-middleware) | le filtre `{{ ts \| localtime }}` |
+
+Vous branchez le middleware une seule fois, puis vous traduisez en utilisant la
+locale qu'il a résolue.
+
+---
+
+## Étape 1 — Construire un Translator
+
+Un `Translator` détient un **catalogue** (une table `clé → message`) par
+locale. Construisez-le avec une locale par défaut, puis ajoutez des
+catalogues :
+
+```rust
+use rustango::i18n::{Locale, Translator};
+use std::collections::HashMap;
+
+let mut en = HashMap::new();
+en.insert("greeting".to_owned(), "Hello".to_owned());
+en.insert("welcome".to_owned(), "Welcome, {name}!".to_owned());
+
+let mut fr = HashMap::new();
+fr.insert("greeting".to_owned(), "Bonjour".to_owned());
+
+let translator = Translator::new(Locale::new("en"))   // default locale
+    .add_locale(Locale::new("en"), en)
+    .add_locale(Locale::new("fr"), fr);
+```
+
+Conservez le `Translator` dans l'état de votre application (il est bon marché
+à cloner/partager) et recherchez les chaînes avec l'
+[`ActiveLocale`](middleware.md#locale-aware-middleware) résolue par le
+middleware.
+
+---
+
+## Étape 2 — Traduire des chaînes (gettext)
+
+`gettext(locale, key)` renvoie le message pour cette locale — et se dégrade
+sans risque quand quelque chose manque :
+
+```rust
+translator.gettext("en", "greeting");      // "Hello"
+translator.gettext("fr", "greeting");      // "Bonjour"
+
+translator.gettext("en", "missing.key");   // "missing.key"  — returns the key, never panics
+translator.gettext("de", "greeting");      // "Hello"        — unknown locale → default
+```
+
+Une clé manquante renvoie la clé elle-même, si bien qu'une chaîne non
+traduite apparaît visiblement plutôt que de faire planter la page.
+
+---
+
+## Placeholders
+
+Les messages peuvent contenir des placeholders `{name}` ; `translate` les
+substitue à partir de paires clé/valeur :
+
+```rust
+// catalog: "welcome" = "Welcome, {name}!"
+translator.translate("en", "welcome", &[("name", "Ada")]);   // "Welcome, Ada!"
+```
+
+`gettext` est le raccourci sans placeholder ; `translate` (et `gettext_fmt`)
+prennent des paramètres.
+
+---
+
+## Pluralisation
+
+Les pluriels diffèrent selon la langue *et* le nombre. `ngettext` est le
+raccourci à deux formes : il choisit la clé du singulier pour la catégorie
+CLDR `one` et celle du pluriel sinon, en liant automatiquement `{count}` :
+
+```rust
+// catalog: "cart.one" = "1 item",  "cart.other" = "{count} items"
+translator.ngettext("en", "cart.one", "cart.other", 1);   // "1 item"
+translator.ngettext("en", "cart.one", "cart.other", 5);   // "5 items"
+```
+
+Utilisez `ngettext_fmt` pour passer des placeholders supplémentaires en plus
+de `{count}`.
+
+### Langues à plus de deux formes
+
+Le polonais, l'ukrainien, le russe, l'arabe et d'autres ont des formes `few` /
+`many` qu'une paire singulier/pluriel ne peut pas exprimer. `plural_category(locale, n)`
+renvoie la catégorie CLDR (`one` / `few` / `many` / `other`), et
+`translate_plural` choisit la forme correspondante dans un **catalogue par
+catégorie** — une entrée par clé contenant toutes ses formes :
+
+```rust
+use rustango::i18n::plural_category;
+
+plural_category("en", 1);   // "one"
+plural_category("fr", 0);   // "one"   — French treats 0 as singular
+plural_category("pl", 2);   // "few"   — Polish 2–4
+plural_category("pl", 5);   // "many"
+
+// pl plural catalog: "deleted_pages" → { one, few, many }
+let n = 5;
+translator.translate_plural("pl", "deleted_pages", n, &[("count", &n.to_string())]);
+// → "Usunięto 5 stron."   (the `many` form)
+```
+
+Une forme manquante retombe sur `other`, puis sur la recherche scalaire (et
+enfin sur la clé), si bien qu'une langue non traduite s'affiche encore. Les
+langues d'Asie de l'Est (`zh`, `ja`, …) n'ont qu'une seule forme `other`.
+
+---
+
+## Ordre de repli
+
+Les recherches parcourent une chaîne pour qu'une traduction partielle ne
+laisse jamais un vide : la **locale demandée → sa langue de base → la chaîne
+de repli → la locale par défaut → la clé elle-même**. Ainsi, une requête en
+français canadien se résout dans le catalogue `fr` :
+
+```rust
+// only "fr" is registered, not "fr-CA"
+translator.gettext("fr-CA", "greeting");   // "Bonjour"  — base-language fallback
+```
+
+Définissez des repli supplémentaires avec
+`Translator::new(default).with_fallback_chain(&["en"])`.
+
+---
+
+## Négocier la langue
+
+Si vous résolvez la locale vous-même (en dehors du middleware),
+`negotiate_language` analyse un en-tête `Accept-Language` de navigateur et
+choisit la meilleure correspondance parmi les locales que vous prenez en
+charge :
+
+```rust
+use rustango::i18n::negotiate_language;
+
+negotiate_language("fr-FR,fr;q=0.9,en;q=0.8", &["en", "fr"]);   // Some("fr")
+negotiate_language("de,ja;q=0.5", &["en", "fr"]);               // None — fall back to default
+```
+
+C'est exactement ce que `LocaleMiddleware` utilise en interne.
+
+---
+
+## Langues de droite à gauche
+
+`is_rtl_language` (et `Locale::direction()`) vous indiquent s'il faut définir
+`dir="rtl"` sur la page — pour l'arabe, l'hébreu, le persan, etc. :
+
+```rust
+use rustango::i18n::is_rtl_language;
+
+is_rtl_language("ar");   // true
+is_rtl_language("en");   // false
+```
+
+Dans un template : `<html dir="{{ direction }}">`, alimenté depuis
+`ActiveLocale`. Voir la
+[note RTL dans Middleware](middleware.md#locale-aware-middleware).
+
+---
+
+## Traduire dans les templates (Tera)
+
+Tout ce qui précède est l'API Rust ; dans les templates Tera — vues HTML, et
+l'interface d'administration — le même `Translator` est exposé sous forme de
+filtres/fonctions. Enregistrez-les une seule fois auprès du translator, et la
+locale active (la variable de contexte `LANG` que le middleware définit)
+pilote chaque recherche :
+
+```rust
+rustango::i18n::tera_tags::register(&mut tera, translator.clone());
+```
+
+```jinja
+{{ "Save" | translate(locale=LANG) }}
+<button title="{{ "Delete" | translate(locale=LANG) }}">…</button>
+
+{# count-aware: pass the count both as the selector `n` and as a {count} arg #}
+{{ translate_plural(key="deleted_pages", n=num, locale=LANG, count=num) }}
+
+<html lang="{{ LANG }}" dir="{{ get_text_direction(locale=LANG) }}">
+```
+
+La **clé est la chaîne source en anglais** (à la manière de gettext), si bien
+qu'une chaîne non traduite s'affiche en anglais plutôt qu'en blanc — vous
+enveloppez d'abord une chaîne d'UI et la traduisez plus tard, sans registre de
+clés à maintenir.
+
+C'est exactement ainsi que **rustango-cms localise son administration** :
+chaque chaîne de l'habillage passe par `translate` / `translate_plural`, les
+catalogues sont livrés par locale sous `src/admin/locales/`, la locale active
+est résolue par la chaîne cookie → préférence par utilisateur →
+`Accept-Language` → défaut par tenant, et un sélecteur dans la barre latérale
+ainsi qu'un réglage **Préférences → Langue** par utilisateur permettent aux
+éditeurs de choisir. Les modifications d'un opérateur via la couche de
+surcharge en base de données (ci-dessous) prennent effet sans redéploiement.
+
+---
+
+## Charger les catalogues + surcharges à l'exécution
+
+Vous construisez rarement des tables à la main en production. Deux
+chargeurs :
+
+- **`Translator::from_directory(dir, default)`** — charge un fichier de
+  catalogue par locale depuis un répertoire au démarrage.
+- **`Translator::from_settings(&settings.i18n)`** — le branche depuis votre
+  configuration.
+
+Et les opérateurs peuvent modifier les traductions **à l'exécution** sans
+redéploiement : `set_override(locale, key, value)` (ou `load_overrides(rows)`
+depuis une table) se superposent aux catalogues de fichiers et l'emportent
+pour cette clé. Ce flux de surcharge en base de données alimente l'éditeur de
+traduction de l'administration et est testé en conditions réelles dans
+`i18n_db_overrides_sqlite_live.rs`.
+
+---
+
+## Voir aussi
+
+- [Middleware](middleware.md) — résoudre la locale par requête (`LocaleMiddleware`,
+  `ActiveLocale`) et le filtre de fuseau horaire `{{ ts | localtime }}`.
+- [Vues HTML](html-views.md) · [L'administration](admin.md) — où les chaînes
+  traduites et l'éditeur de traduction apparaissent.
+- [Glossaire](glossary.md) — locale, catalogue, RTL et compagnie en langage clair.

--- a/docs/fr/index.toml
+++ b/docs/fr/index.toml
@@ -1,0 +1,21 @@
+# Table des matières de la documentation.
+#
+# rustangodocs lit ce manifeste pour amorcer le site de documentation : chaque
+# [[section]] devient une section de navigation, et chaque page (un fichier
+# markdown de ce répertoire) devient une page de documentation, rendue dans
+# l'ordre indiqué ici. Les fichiers non listés ci-dessous ne sont pas publiés.
+
+[[section]]
+title = "Premiers pas"
+slug = "premiers-pas"
+pages = ["getting-started.md", "scaffolding.md"]
+
+[[section]]
+title = "Guides"
+slug = "guides"
+pages = ["models.md", "orm.md", "admin.md", "i18n.md", "manage.md"]
+
+[[section]]
+title = "Authentification"
+slug = "authentification"
+pages = ["sso.md"]

--- a/docs/fr/manage.md
+++ b/docs/fr/manage.md
@@ -1,0 +1,1261 @@
+# Référence CLI `manage`
+
+Ceci est l'outil en ligne de commande de **Rustango**, comme `manage.py` de
+Django, `artisan` de Laravel, ou la commande `rails` de Rails. Dans un projet
+généré via `cargo rustango new`, un seul binaire exécute chaque commande
+(« verbe ») :
+
+```bash
+cargo run                          # runserver (no args = boot the HTTP server)
+cargo run -- migrate               # any other verb
+cargo run -- --help                # full subcommand list
+```
+
+[![One binary runs every manage verb — server, migrations, scaffolders, database utilities, and system commands — like Django's manage.py or Laravel's artisan](img/manage.png)](img/manage.png)
+
+> **Source :** `rustango::manage` (`Cli`, le répartiteur de verbes) — derrière
+> la fonctionnalité `manage` (activée par défaut).
+>
+> **Version exécutable :** chaque verbe présenté ici s'exécute dans un projet
+> généré ; l'exemple
+> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog)
+> est piloté par `cargo run -- migrate` et consorts.
+
+> **Nouveau terme rencontré ici ?** *scaffold* (générateur de squelette),
+> *migration*, *tenant* (locataire) — voir le [glossaire](glossary.md).
+
+Le routeur de commandes se trouve dans [`rustango::manage::Cli`](https://docs.rs/rustango/latest/rustango/manage/struct.Cli.html) ;
+votre `src/main.rs` le branche ainsi :
+
+```rust
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    rustango::manage::Cli::new().api(urls::api()).run().await
+}
+```
+
+Les projets multi-tenant ajoutent `.tenancy()` à la chaîne. Cela fait basculer
+le routeur vers [`rustango::tenancy::manage`](https://docs.rs/rustango/latest/rustango/tenancy/manage/index.html)
+et débloque les commandes multi-tenant.
+
+> **Forme plus ancienne** — les projets générés par
+> `manage startapp --with-manage-bin` (ou datant d'avant la v0.16) livrent
+> encore un `src/bin/manage.rs`. Ceux-ci utilisent
+> `cargo run --bin manage -- <verb>`. Les deux formes acceptent les mêmes
+> verbes.
+
+Chaque commande affiche sa sortie sur stdout et se termine avec un code de
+retour non nul en cas d'erreur de validation ou d'E/S. Exécutez
+`cargo run -- --help` (ou `<verb> --help`) pour l'aide intégrée.
+
+---
+
+## Table des matières
+
+- [Migrations](#migrations)
+- [Migrations de données](#data-migrations)
+- [Générateurs de projet / d'app](#project--app-scaffolders)
+- [Générateurs de fichiers (`make:*`)](#file-generators-make)
+- [Utilitaires de base de données](#database-utilities)
+- [Commandes système](#system-commands)
+- [Commandes de tenancy](#tenancy-commands)
+- [Sous-commandes personnalisées](#custom-subcommands)
+- [Flux de travail courants](#common-workflows)
+
+---
+
+## Migrations
+
+### `makemigrations [name]`
+
+Génère un fichier de migration à partir des changements de vos modèles —
+comme le `makemigrations` de Django. Elle compare vos modèles enregistrés au
+dernier instantané de schéma sauvegardé dans `migrations/` et écrit un
+nouveau fichier JSON avec ce qui a changé.
+
+```bash
+cargo run -- makemigrations                          # auto-name (e.g. 0004_add_slug_to_posts)
+cargo run -- makemigrations rename_status_to_state   # custom suffix
+```
+
+**Changements détectés automatiquement :**
+- `CreateTable` / `DropTable`
+- `AddColumn` / `DropColumn`
+- `AlterColumnType` / `AlterColumnNullable` / `AlterColumnDefault` / `AlterColumnMaxLength`
+- `AlterColumnUnique`
+- `CreateIndex` / `DropIndex`
+- `AddCheckConstraint` / `DropCheckConstraint`
+- `CreateM2MTable` / `DropM2MTable`
+
+**NON détectés automatiquement** (renommage vs suppression+ajout est ambigu) :
+- `RenameTable`, `RenameColumn` — utilisez `--empty` et modifiez le JSON.
+
+### `makemigrations --app <app>`
+
+Limite la migration à une seule app. Elle écrit dans le répertoire
+`migrations/` propre à cette app, sous
+`<project_root>/<app>/migrations/`, et ne regarde que les modèles
+appartenant à cette app.
+
+```bash
+cargo run -- makemigrations --app blog
+cargo run -- makemigrations --app blog backfill_slugs
+```
+
+### `makemigrations --scope <registry|tenant>`
+
+Réservé au multi-tenant. Écrit une seule migration pour uniquement les
+modèles d'un scope donné — ceux dont l'attribut
+`#[rustango(scope = "...")]` correspond. (Les tables « registry » sont
+partagées entre tous les tenants ; les tables « tenant » vivent par
+tenant.) Sans ce drapeau, un simple `makemigrations` dans un projet de
+tenancy scinde automatiquement les changements en DEUX fichiers — un pour
+les modèles registry, un pour les modèles tenant — afin que les tables
+partagées du framework (`Org`, `Operator`) ne se retrouvent pas dans les
+migrations par tenant exécutées par `migrate-tenants`.
+
+```bash
+cargo run -- makemigrations                       # tenancy: writes 0NN_<auto>.json (registry) + 0MM_<auto>.json (tenant) as needed
+cargo run -- makemigrations --scope tenant        # explicit single-scope diff
+cargo run -- makemigrations --scope registry      # explicit single-scope diff
+```
+
+Pourquoi cette scission compte : avant la v0.24.2, un simple
+`makemigrations` sur un projet de tenancy regroupait les opérations sur
+`rustango_operators` (une table registry) dans une migration tenant.
+Lorsque `migrate-tenants` exécutait ce fichier, `rustango_operators` se
+résolvait via `search_path` vers la copie registry et entrait en conflit
+avec la contrainte déjà présente là-bas.
+
+### `makemigrations --empty <name>`
+
+Crée une migration vide (sans opérations `forward`) que vous remplissez
+vous-même à la main — comme `makemigrations --empty` de Django. Utilisez-la
+lorsque vous devez écrire des opérations de données ou de renommage que le
+détecteur automatique ne peut pas générer. Modifiez le JSON résultant
+vous-même.
+
+```bash
+cargo run -- makemigrations --empty rename_status_to_state
+# Then edit migrations/0005_rename_status_to_state.json:
+#   "forward": [
+#     {"schema": {"RenameColumn": {"table": "posts", "old_column": "status", "new_column": "state"}}}
+#   ]
+```
+
+### `makemigrations --merge`
+
+Corrige un historique de migrations qui s'est scindé en deux branches —
+même principe que le `makemigrations --merge` de Django (issue #346). Cela
+se produit quand deux personnes exécutent chacune `makemigrations` sur leur
+propre branche de fonctionnalité, de sorte que les deux nouveaux fichiers
+pointent vers le même parent. Une fois les deux branches fusionnées,
+l'historique compte deux « feuilles » (points de fin), et le prochain
+`makemigrations` en choisirait une arbitrairement comme parent.
+
+`--merge` détecte cette situation et écrit un `NNNN_merge.json` vide dont
+le parent pointe vers la dernière feuille par ordre alphabétique,
+réunissant l'historique en une seule chaîne. Son instantané de schéma
+reflète l'état combiné, lu depuis le registre de modèles en direct — les
+modèles des deux branches sont compilés à ce stade, donc l'instantané est
+exact.
+
+```bash
+cargo run -- makemigrations --merge
+# wrote migrations/0004_merge.json
+#     merge node — empty `forward`, anchors the chain after divergent leaves
+```
+
+- **Déjà une seule chaîne** → affiche `no merge needed` et se termine
+  proprement. Sûr à exécuter sur un historique sain.
+- **Historiques vraiment séparés** (pas une collision de branches) →
+  échoue au lieu d'inventer un parent. Même garde-fou que Django.
+- **Ne peut pas être combiné** avec `--empty`, `--app`, `--scope`, ou un
+  nom positionnel.
+
+### `migrate`
+
+Applique toutes les migrations en attente à la base de données, dans
+l'ordre — comme le `migrate` de Django ou le `php artisan migrate` de
+Laravel. C'est la commande à exécuter après `makemigrations` pour changer
+réellement votre schéma.
+
+```bash
+cargo run -- migrate
+cargo run -- migrate --dry-run                       # print SQL without writing
+```
+
+Chaque fichier s'exécute dans une transaction par défaut, donc un échec
+annule tout le fichier. Réglez `"atomic": false` dans le JSON pour
+désactiver ce comportement — nécessaire pour des instructions comme
+`CREATE INDEX CONCURRENTLY` qui ne peuvent pas s'exécuter dans une
+transaction.
+
+En **mode tenancy** (`Cli::tenancy()`), `migrate` connaît le scope : elle
+applique d'abord les migrations registry à la base de données registry
+partagée, puis applique les migrations tenant à travers chaque tenant
+actif. Pour un contrôle plus fin, utilisez
+[`migrate-registry`](#migrate-registry) /
+[`migrate-tenants`](#migrate-tenants).
+
+### `migrate <target>`
+
+Migre vers un point précis de l'historique, en avant ou en arrière —
+comme `migrate <app> <name>` de Django. Nommez une migration pour y
+accéder ; la cible spéciale `zero` défait tout.
+
+```bash
+cargo run -- migrate 0003_add_slug      # forward to 0003
+cargo run -- migrate 0001_initial       # roll back to 0001 (unapply 0002+)
+cargo run -- migrate zero               # unapply EVERY migration
+```
+
+### `migrate --squash`
+
+Regroupe chaque migration **en attente** (non appliquée) en un seul diff
+nouvellement généré — l'échappatoire pour l'itération de développement,
+utile quand une pile de migrations à moitié terminées est plus simple à
+régénérer qu'à corriger. Elle refuse de toucher à tout ce qui est déjà
+appliqué.
+
+```bash
+cargo run -- migrate --squash
+```
+
+Le fichier régénéré enregistre les noms qu'il a regroupés dans sa liste
+`replaces`. Cela compte dès qu'une autre base de données entre en jeu :
+le checkout de votre collègue, le staging, ou la CI ont peut-être déjà
+appliqué certains des fichiers que vous venez de supprimer. Sans
+`replaces`, le `CREATE TABLE` du nouveau fichier entrerait en conflit
+là-bas ; avec, le runner **réconcilie** au lieu de cela (voir ci-dessous).
+
+### Réconciliation du squash
+
+Un squash recrée l'état final des migrations qu'il remplace, donc ce que
+le runner doit faire dépend entièrement de ce que contient déjà la base
+de données cible. La décision est automatique :
+
+| état de la base de données | ce qui se passe |
+|---|---|
+| fraîche — aucun historique, aucune table | le squash s'exécute réellement |
+| chaque migration remplacée est dans le journal | enregistrée, prédécesseurs mis en sommeil, **aucun DDL** |
+| des tables existent mais le journal n'a aucun historique | enregistrée, **aucun DDL** (`--fake-initial` de Django) |
+| seulement *certaines* des lignes/tables remplacées sont présentes | **refusé**, en précisant ce qui manque |
+
+Le cas partiel est délibérément une erreur bloquante : aucun choix
+automatique n'y est sûr, donc le runner s'arrête et vous indique ce qu'il
+a trouvé plutôt que de deviner. Résolvez-le avec `migrate --fake`
+(ci-dessous).
+
+Les migrations remplacées par un squash appliqué sont considérées comme
+appliquées, donc vous pouvez laisser les anciens fichiers sur le disque
+pour une ou deux versions — les déploiements qui ne les ont jamais
+exécutés migrent tout de même correctement vers l'avant.
+
+Les migrations ordinaires (non-squash) ne sont pas affectées : une
+migration classique dont la table existe déjà échoue toujours
+bruyamment, car il s'agit d'un vrai conflit et non d'un historique
+équivalent connu.
+
+### `migrate --fake <name>`
+
+Marque une migration comme appliquée **sans exécuter son SQL** —
+l'échappatoire opérateur pour quand la base de données est déjà dans
+l'état cible mais que le journal ne le sait pas (une base de données
+configurée hors bande, une table de journal supprimée, une migration
+partiellement réussie, un squash partiel refusé). Répétez le drapeau
+pour réparer plusieurs lignes à la fois.
+
+```bash
+cargo run -- migrate --fake 0004_add_indexes
+cargo run -- migrate --fake 0004_add_indexes --system        # framework's own chain
+cargo run -- migrate --fake 0004_add_indexes --all-tenants   # every active tenant
+```
+
+Le nom est d'abord validé par rapport au répertoire de migrations, donc
+une faute de frappe ne peut pas créer une fausse ligne. Le marquage est
+idempotent.
+
+`--system` cible la propre chaîne de migrations du framework
+(`system/migrations/`, enregistrée dans
+`__rustango_system_migrations__`) plutôt que celle de votre projet.
+`--all-tenants` diffuse le marquage à travers chaque tenant actif, en
+rapportant chacun et en continuant malgré les échecs — les tables du
+framework vivent par tenant, donc les réparer est une tâche par tenant.
+
+### `downgrade [N]`
+
+Annule les N dernières migrations appliquées (par défaut 1) — le
+`migrate:rollback` de Laravel. Chaque migration doit être réversible :
+les changements de schéma s'annulent automatiquement, mais les
+opérations de données nécessitent un `reverse_sql` défini, sinon
+l'annulation échoue.
+
+```bash
+cargo run -- downgrade                  # one step
+cargo run -- downgrade 3                # three steps
+```
+
+### `showmigrations` / `status`
+
+Liste chaque migration et indique si elle a été appliquée — comme le
+`showmigrations` de Django. `[X]` signifie appliquée, `[ ]` signifie
+encore en attente.
+
+```bash
+cargo run -- showmigrations
+cargo run -- status                     # alias
+```
+
+Sortie :
+
+```
+[X] 0001_initial
+[X] 0002_add_status
+[ ] 0003_add_slug
+```
+
+---
+
+## Migrations de données
+
+### `add-data-op`
+
+Ajoute une étape de données en SQL brut à une migration sans modifier de
+JSON à la main. Utilisez-la quand vous devez transformer des lignes
+existantes — remplir rétroactivement une colonne, nettoyer des données —
+dans le cadre d'une migration. C'est l'équivalent de la migration de
+données `RunSQL` de Django, générée pour vous depuis la ligne de
+commande.
+
+```bash
+# New migration with up + down
+cargo run -- add-data-op \
+    --sql "UPDATE posts SET slug = lower(title)" \
+    --reverse-sql "UPDATE posts SET slug = NULL" \
+    --name backfill_post_slugs
+
+# Append to an existing migration
+cargo run -- add-data-op \
+    --to 0003_add_slug \
+    --sql "UPDATE posts SET slug = id::text"
+
+# Irreversible (no rollback)
+cargo run -- add-data-op \
+    --sql "DELETE FROM legacy_data" \
+    --name purge_legacy
+```
+
+| Flag | Requis | Description |
+|---|:-:|---|
+| `--sql <SQL>` | oui | SQL avant exécuté lors de `migrate` |
+| `--reverse-sql <SQL>` | non | SQL de retour en arrière lors de `unapply` ; omettez-le pour une opération irréversible |
+| `--name <name>` | non | Suffixe de nom pour la nouvelle migration ; par défaut `data_op` |
+| `--to <migration>` | non | Ajoute à une migration existante au lieu d'en créer une |
+
+Omettez `--reverse-sql` et l'étape est marquée `reversible: false` —
+toute tentative de l'annuler échoue immédiatement.
+
+---
+
+## Générateurs de projet / d'app
+
+### `cargo rustango new <name>` *(binaire séparé)*
+
+Crée un nouveau projet **Rustango** — comme `django-admin startproject`
+ou `laravel new`. C'est un outil séparé, donc installez-le d'abord avec
+`cargo install cargo-rustango`. Choisissez parmi trois modèles :
+
+```bash
+cargo rustango new myblog                          # default = fullstack (ORM + admin)
+cargo rustango new myapi --template api            # JSON-only, no admin
+cargo rustango new shop --template tenant          # multi-tenancy
+```
+
+Écrit :
+
+```
+<name>/
+  Cargo.toml
+  .env.example
+  .gitignore
+  rust-toolchain.toml
+  docker-compose.yml
+  README.md
+  migrations/                               (your app's migrations)
+  system/migrations/                        (tenant template — framework tables, generated)
+  src/{main,models,views,urls}.rs
+```
+
+Le modèle tenant fournit un dossier `system/migrations/` **vide**. Les
+propres tables du framework (`rustango_orgs`, `rustango_users`,
+rôles/permissions, …) sont générées dans ce dossier à partir des modèles
+compilés lors du premier `cargo run -- migrate` — il n'y a pas de JSON
+d'amorçage livré à la main. Voir [`migrate`](#migrate) /
+[`migrate-registry`](#migrate-registry).
+
+### `startapp <name> [flags]`
+
+Crée une nouvelle app (un module de fonctionnalité) sous `src/<name>/` —
+exactement comme le `startapp` de Django. Utilisez-la pour regrouper les
+modèles, vues et URLs d'une partie de votre projet.
+
+```bash
+cargo run -- startapp blog
+cargo run -- startapp shop --with-manage-bin             # also writes src/bin/manage.rs
+cargo run -- startapp shop --into apps                   # write under src/apps/shop/ instead
+```
+
+Crée :
+
+```
+src/<name>/
+  mod.rs
+  models.rs
+  views.rs
+  urls.rs
+```
+
+Sûr à réexécuter — les fichiers existants sont laissés intacts. Une
+étape manuelle : ajouter `pub mod <name>;` à `src/lib.rs` pour que Rust
+compile le nouveau module.
+
+---
+
+## Générateurs de fichiers (`make:*`)
+
+Ceux-ci créent des fichiers de démarrage pour des briques courantes —
+à l'image des commandes `make:*` de Laravel (`make:controller`,
+`make:model`, …). Chaque générateur écrit dans `src/<snake_name>.rs`
+(ou `tests/<snake_name>.rs` pour `make:test`) et :
+
+- Vérifie que le nom est valide (PascalCase, lettres/chiffres/underscore).
+- Le convertit en snake_case pour le nom de fichier (`PostViewSet` →
+  `post_view_set.rs`).
+- Ne remplace pas un fichier existant.
+- Vous rappelle d'ajouter `pub mod X;` à votre `lib.rs`.
+
+### `make:viewset <Name> [--model <Model>]`
+
+Génère une structure `#[derive(ViewSet)]` — un point d'accès REST pour
+un modèle, comme un ViewSet de Django REST Framework. Les listes de
+champs sont pré-ébauchées pour que vous les complétiez.
+
+```bash
+cargo run -- make:viewset PostViewSet --model Post
+```
+
+`src/post_view_set.rs` généré :
+
+```rust
+#[derive(ViewSet)]
+#[viewset(model = Post, fields = "id, ", filter_fields = "", search_fields = "", page_size = 20)]
+pub struct PostViewSet;
+```
+
+Montez-le avec : `.merge(PostViewSet::router("/api/posts", pool.clone()))`.
+
+### `make:serializer <Name> [--model <Model>]`
+
+Génère une structure `#[derive(Serializer)]` — contrôle la façon dont un
+modèle est converti vers et depuis JSON (comme un serializer DRF).
+
+```bash
+cargo run -- make:serializer PostSerializer --model Post
+```
+
+### `make:form <Name>`
+
+Génère une structure `#[derive(Form)]` pour valider et traiter une saisie
+de formulaire — comme un `Form` de Django.
+
+```bash
+cargo run -- make:form ContactForm
+```
+
+### `make:job <Name>`
+
+Génère un squelette de tâche en arrière-plan (travail qui s'exécute hors
+de la requête, comme une tâche Celery ou un job Laravel), avec un exemple
+commenté montrant comment la planifier.
+
+```bash
+cargo run -- make:job EmailDigestJob
+```
+
+### `make:notification <Name>`
+
+Génère une structure de notification qui construit un email — comme le
+`make:notification` de Laravel.
+
+```bash
+cargo run -- make:notification WelcomeEmail
+```
+
+### `make:middleware <Name>`
+
+Génère une fonction middleware — du code qui s'exécute avant et après
+chaque requête (vérifications d'authentification, journalisation, etc.).
+« axum » est le framework web sur lequel **Rustango** est construit, donc
+l'ébauche correspond à la forme du middleware d'axum.
+
+```bash
+cargo run -- make:middleware AuditLog
+```
+
+### `make:test <Name>`
+
+Génère un test d'intégration dans `tests/` qui utilise `TestClient` pour
+effectuer des requêtes contre votre app.
+
+```bash
+cargo run -- make:test post_smoke
+```
+
+---
+
+## Utilitaires de base de données
+
+### `db:info`
+
+Affiche à quelle base de données cette build est configurée pour parler,
+sans se connecter. Elle imprime la version du framework, les pilotes de
+base de données compilés (fonctionnalités Cargo `postgres`/`mysql`),
+l'URL de connexion avec le mot de passe masqué, et le backend détecté.
+Comme elle n'ouvre jamais de connexion, elle est pratique en CI ou dans
+des conteneurs où la base de données n'est pas encore prête mais où vous
+voulez confirmer que les réglages sont corrects.
+
+```bash
+cargo run -- db:info
+```
+
+### `db:dump [--out <path>] [--data-only|--schema-only] [--no-owner]`
+
+Sauvegarde votre base de données en exécutant `pg_dump` contre
+`DATABASE_URL` — comme `php artisan db:dump`. Par défaut, le SQL part
+sur stdout (pour pouvoir le rediriger dans un pipe) ; passez
+`--out <path>` (`-o`) pour écrire un fichier à la place. `--data-only`
+et `--schema-only` correspondent directement aux drapeaux de `pg_dump`,
+et `--no-owner` supprime les lignes OWNER. Vous devez avoir `pg_dump`
+installé et dans votre `PATH`.
+
+```bash
+cargo run -- db:dump > backups/before-migrate.sql    # stdout → file
+cargo run -- db:dump --out backups/before-migrate.sql
+```
+
+### `db:restore <path> [--clean]`
+
+Recharge un fichier de sauvegarde dans votre base de données — l'inverse
+de `db:dump`. Elle exécute le fichier via `psql` contre `DATABASE_URL`
+avec `ON_ERROR_STOP=1`, donc elle s'arrête à la première erreur. Ajoutez
+`--clean` pour effacer le schéma existant au préalable (elle préfixe
+`DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;`) afin que
+la restauration se fasse sur une base de données vide. Vous devez avoir
+`psql` dans votre `PATH`.
+
+```bash
+cargo run -- db:restore backups/before-migrate.sql
+cargo run -- db:restore backups/before-migrate.sql --clean
+```
+
+---
+
+## Commandes système
+
+### `version` / `--version`
+
+Affiche la version du framework **Rustango**.
+
+```bash
+$ cargo run -- version
+rustango 0.44.0
+```
+
+### `about`
+
+Affiche un instantané de votre environnement : version du framework,
+modèles et apps enregistrés, si la base de données est accessible, et
+les variables d'environnement clés. Utile à joindre aux tickets de
+support en cas de problème.
+
+```bash
+$ cargo run -- about
+rustango
+  version:        0.44.0
+  models:         3 registered
+  apps:           1 (blog)
+  RUSTANGO_ENV:   local
+  DATABASE_URL:   postgres://***@localhost:5433/myblog
+  db_connect:     ok
+```
+
+### `check [--deploy]`
+
+Exécute des vérifications de santé sur votre projet — comme le `check`
+de Django. Ajoutez `--deploy` pour les vérifications plus strictes de
+préparation à la production, de la même façon que fonctionne
+`check --deploy` de Django.
+
+**Vérifications toujours actives :**
+- ≥ 1 modèle enregistré via `inventory`
+- Base de données accessible (`SELECT 1`)
+- Nombre de migrations vs nombre de modèles
+
+**Avec `--deploy` :**
+- `RUSTANGO_ENV` vaut `prod` ou `production`
+- `RUSTANGO_SESSION_SECRET` défini et ≥ 32 octets (la clé HMAC pour les
+  cookies + JWT ; `SECRET_KEY` n'est jamais lu par le framework)
+- `DATABASE_URL` défini
+- `RUSTANGO_APEX_DOMAIN` défini (projets de tenancy)
+
+```bash
+$ cargo run -- check --deploy
+running rustango system check (deploy mode)...
+  [info]    3 models registered via inventory
+  [info]    database reachable
+  [info]    4 migration(s) on disk
+  [info]    RUSTANGO_SESSION_SECRET length OK
+all checks passed
+```
+
+Se termine avec un code non nul si une vérification de niveau erreur
+échoue. Les avertissements seuls ne provoquent pas d'échec.
+
+### `docs`
+
+Ouvre la documentation de **Rustango** (<https://docs.rs/rustango>) dans
+votre navigateur. Elle affiche toujours aussi l'URL, afin de rester
+utile sur un serveur sans interface graphique.
+
+```bash
+cargo run -- docs
+```
+
+### `--help` / `help`
+
+Liste chaque commande avec une description d'une ligne. En mode
+tenancy, les commandes multi-tenant listées ci-dessous sont ajoutées
+également.
+
+---
+
+## Commandes de tenancy
+
+Ces commandes n'existent que dans les projets multi-tenant (une
+application servant de nombreux clients/organisations isolés). Elles
+n'apparaissent que lorsque le projet est compilé avec
+`features = ["tenancy"]` ET que `Cli::new()` est chaîné avec
+`.tenancy()`.
+
+### `init-tenancy`
+
+**Ne fait rien — conservée pour compatibilité.** Le framework ne fournit
+plus de migrations d'amorçage écrites à la main. Ses propres tables
+(`rustango_orgs`, `rustango_operators`, `rustango_users`,
+rôles/permissions, …) sont générées dans `system/migrations/` à partir
+des modèles compilés — le flux Django habituel (modèles →
+`makemigrations` → `migrate`) — et appliquées par [`migrate`](#migrate) /
+[`migrate-registry`](#migrate-registry), qui les génèrent à la demande
+si les fichiers sont absents.
+
+```bash
+cargo run -- init-tenancy   # does nothing now; kept so old scripts don't break
+```
+
+Les anciennes versions écrivaient ici `0001_rustango_*_initial.json` ;
+ce flux figé a disparu. **Pour provisionner, exécutez simplement
+`cargo run -- migrate`.** Un modèle utilisateur personnalisé
+(`.user_model::<AppUser>()`) passe par le même `system/migrations/`
+généré — voir
+[Modèle utilisateur personnalisé](#custom-user-model-extra-columns-on-rustango_users).
+
+### `migrate-registry`
+
+Applique uniquement les migrations registry — les tables partagées,
+inter-tenant. Le registry contient `rustango_orgs` et
+`rustango_operators` plus toute table de scope registry que vous
+définissez. Les tables tenant ne sont pas touchées.
+
+```bash
+cargo run -- migrate-registry
+```
+
+### `migrate-tenants`
+
+Applique les migrations tenant à chaque tenant actif, l'un après
+l'autre. Chaque tenant utilise sa propre connexion (son propre schéma ou
+sa propre base de données), et si un tenant échoue, les autres
+continuent tout de même — la commande rapporte le résultat par tenant à
+la fin.
+
+```bash
+cargo run -- migrate-tenants
+```
+
+Pour le cas courant, un simple `migrate` fait déjà registry en premier,
+puis tenants — n'utilisez `migrate-tenants` que lorsque vous avez besoin
+de cette étape seule.
+
+### `runserver` / `run-server`
+
+Démarre le serveur web multi-tenant — le `runserver` de Django. Dans un
+projet de tenancy, c'est équivalent au simple `cargo run` ; la forme
+nommée existe pour que des binaires personnalisés qui analysent leurs
+propres arguments puissent tout de même la déclencher.
+
+```bash
+cargo run                        # implicit
+cargo run -- runserver           # explicit
+```
+
+### `create-tenant <slug> [options]`
+
+Met en place un nouveau tenant (client/organisation) et applique les
+migrations tenant à celui-ci. Le `<slug>` est son identifiant court.
+Sûr à réexécuter — l'appeler à nouveau sur un tenant existant ne
+duplique rien.
+
+```bash
+cargo run -- create-tenant acme --display-name "ACME Corp"
+cargo run -- create-tenant beta --mode database --database-url postgres://...
+```
+
+| Flag | Description |
+|---|---|
+| `--display-name <name>` | Libellé lisible affiché dans les barres latérales d'administration |
+| `--mode schema \| database` | Mode de stockage (par défaut : schema) |
+| `--database-url <url>` | URL de base de données propre au tenant (requise en mode database) |
+| `--host-pattern <pattern>` | Remplace le motif d'hôte utilisé par `SubdomainResolver` |
+| `--no-migrate` | Ignore l'application des migrations à scope tenant après le provisionnement |
+
+### `drop-tenant <slug> [--confirm <slug>]`
+
+Désactive un tenant en réglant `active = false`. C'est l'option souple
+et réversible — les données du tenant restent sur le disque, et
+réexécuter `create-tenant` les fait revenir. Quand vous n'êtes pas en
+mode interactif (aucun terminal attaché), vous devez passer
+`--confirm <slug>` avec le slug retapé pour confirmer.
+
+```bash
+cargo run -- drop-tenant acme --confirm acme
+```
+
+### `purge-tenant <slug> [--confirm <slug>] [--purge-database]`
+
+**Supprime définitivement un tenant.** Elle supprime le schéma du
+tenant et retire sa ligne de `rustango_orgs`, sans possibilité
+d'annulation. Quand vous n'êtes pas en mode interactif (aucun terminal
+attaché), vous devez passer `--confirm <slug>` avec le slug retapé.
+Pour les tenants en mode database, la base de données sous-jacente est
+laissée en place sauf si vous passez aussi `--purge-database`.
+
+```bash
+cargo run -- purge-tenant acme --confirm acme
+cargo run -- purge-tenant beta --confirm beta --purge-database   # database-mode: also DROP DATABASE
+```
+
+### `list-tenants`
+
+Liste chaque tenant avec son mode de stockage et son statut
+actif/inactif.
+
+```bash
+cargo run -- list-tenants
+```
+
+### `create-operator <username> --password <pwd>`
+
+Crée un opérateur — un administrateur global qui peut gérer chaque
+tenant depuis une console inter-tenant. Les opérateurs vivent dans le
+registry partagé, pas dans un tenant en particulier.
+
+```bash
+cargo run -- create-operator admin --password letmein
+```
+
+### `create-user <tenant> <username> --password <pwd> [--superuser]`
+
+Crée un utilisateur au sein d'un tenant — à peu près le
+`createsuperuser` de Django, mais limité à un seul tenant.
+
+```bash
+cargo run -- create-user acme alice --password hunter2 --superuser
+```
+
+`--superuser` règle `is_superuser = true` pour cet utilisateur au sein
+du tenant. Cela en fait un administrateur du tenant (accès en écriture
+complet dans l'admin du tenant), mais cela ne lui donne jamais accès à
+la console opérateur inter-tenant.
+
+### `create-role <tenant> <name>`
+
+Crée un rôle (un ensemble nommé de permissions, comme un groupe Django)
+au sein d'un tenant.
+
+```bash
+cargo run -- create-role acme editor
+```
+
+### `list-roles <tenant>`
+
+Liste les rôles définis dans un tenant donné.
+
+```bash
+cargo run -- list-roles acme
+```
+
+### `assign-role <tenant> <username> <role>`
+
+Donne à un utilisateur l'un des rôles du tenant.
+
+```bash
+cargo run -- assign-role acme alice editor
+```
+
+### `revoke-role <tenant> <username> <role>`
+
+Retire un rôle à un utilisateur — l'inverse d'`assign-role`.
+
+```bash
+cargo run -- revoke-role acme alice editor
+```
+
+### `grant-perm <tenant> <role-name|username> <codename> [--role]`
+
+Accorde une seule permission. Par défaut, le deuxième argument est un
+**nom d'utilisateur**, donc la permission va directement à cet
+utilisateur ; ajoutez `--role` pour l'accorder à un rôle à la place.
+Les noms de code de permission suivent le format `<app>.<action>_<model>`
+de Django (`blog.add_post`, `blog.change_post`, …). La fonctionnalité
+`auto_create_permissions` crée automatiquement les quatre noms de code
+CRUD standards pour tout modèle marqué `#[rustango(permissions)]`.
+
+```bash
+cargo run -- grant-perm acme alice blog.change_post           # grant to user alice
+cargo run -- grant-perm acme editor blog.change_post --role   # grant to role editor
+```
+
+### `revoke-perm <tenant> <role-name|username> <codename> [--role]`
+
+Retire une permission — l'inverse de `grant-perm`. Cible un utilisateur
+par défaut ; ajoutez `--role` pour la retirer à un rôle à la place.
+
+```bash
+cargo run -- revoke-perm acme alice blog.change_post
+cargo run -- revoke-perm acme editor blog.change_post --role
+```
+
+### `create-api-key <tenant> <username> [--label <s>]`
+
+Émet une clé API pour un utilisateur du tenant. Le jeton complet est
+affiché **une seule fois** et jamais plus — copiez-le maintenant, car
+seuls son préfixe et un hachage sont stockés.
+
+```bash
+cargo run -- create-api-key acme alice --label "ci-bot"
+```
+
+### `audit-cleanup`
+
+Élague les anciennes entrées du journal d'audit (`rustango_audit_log`)
+pour l'empêcher de grossir indéfiniment. Réduisez par âge (`--days`) ou
+par nombre (`--keep-last`), et limitez éventuellement à un seul tenant.
+
+```bash
+cargo run -- audit-cleanup --days 90                       # delete > 90 days old
+cargo run -- audit-cleanup --keep-last 50                  # keep most recent 50 per row
+cargo run -- audit-cleanup --keep-last 50 --tenant acme    # scoped
+```
+
+---
+
+## Modèle utilisateur personnalisé (colonnes supplémentaires sur `rustango_users`)
+
+C'est la version **Rustango** du « modèle utilisateur personnalisé » de
+Django — comment ajouter vos propres champs à la table utilisateur. Le
+`User` de tenant intégré possède sept colonnes fixes : `id`, `username`,
+`password_hash`, `is_superuser`, `active`, `created_at`, plus une
+colonne JSONB `data` (un blob JSON flexible) pour toute métadonnée
+supplémentaire par utilisateur. **Pour la plupart des apps, cette
+colonne JSONB est tout ce dont vous avez besoin** — pas de migration,
+pas de surcharge, pas de surprise.
+
+Quand vous voulez des colonnes **typées, indexables** sur
+`rustango_users` à la place, il existe deux approches. Elles ne sont pas
+interchangeables ; choisissez celle qui correspond à l'étape de vie de
+votre projet.
+
+### Option 1 — Modèle de profil compagnon avec clé étrangère *(fonctionne sur tout projet)*
+
+Idéale quand le projet existe déjà, ou quand vous préférez laisser la
+table `User` du framework comme source unique de vérité.
+
+```rust
+#[derive(rustango::Model)]
+pub struct UserProfile {
+    #[rustango(primary_key)] pub id: rustango::sql::Auto<i64>,
+    #[rustango(fk = "rustango_users")] pub user_id: i64,
+    #[rustango(max_length = 128, default = "''")] pub display_name: String,
+    #[rustango(max_length = 64, default = "'UTC'")] pub timezone: String,
+}
+```
+
+Exécutez `cargo run -- makemigrations` puis `cargo run -- migrate`, et
+vous avez une table d'extras typée liée à l'utilisateur par clé
+étrangère. Lisez-la avec l'ORM :
+
+```rust
+let profile = UserProfile::objects()
+    .where_(UserProfile::user_id.eq(user.id.get().copied().unwrap()))
+    .first(&pool).await?;            // Option<UserProfile>
+```
+
+Compromis : une ligne supplémentaire et une jointure à chaque accès.
+Avantage : zéro risque de casser l'authentification du framework.
+
+### Option 2 — `Cli::user_model::<AppUser>()` *(uniquement pour un projet neuf)*
+
+N'utilisez ceci que sur un projet neuf où vous voulez les champs
+supplémentaires directement sur la table `rustango_users` elle-même.
+Comme `AppUser` *est* le modèle `rustango_users`, ses colonnes passent
+par le moteur ordinaire `makemigrations` → `migrate` : les tables du
+framework sont générées dans `system/migrations/`, donc les colonnes
+d'`AppUser` se retrouvent dans le `CREATE TABLE rustango_users` généré.
+
+**Étape 1.** Définissez votre modèle. Il doit déclarer exactement chaque
+colonne requise par le framework (`id`, `username`, `password_hash`,
+`is_superuser`, `active`, `created_at`, `data`), plus vos extras. Chaque
+colonne supplémentaire doit soit autoriser `NULL`, soit avoir un
+`default = "…"`.
+
+```rust
+use rustango::sql::Auto;
+
+#[derive(rustango::Model, Debug, Clone)]
+#[rustango(table = "rustango_users")]
+pub struct AppUser {
+    #[rustango(primary_key)] pub id: Auto<i64>,
+    #[rustango(max_length = 64, unique)] pub username: String,
+    #[rustango(max_length = 255)] pub password_hash: String,
+    pub is_superuser: bool,
+    pub active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    #[rustango(default = "'{}'")] pub data: serde_json::Value,
+    // extras —
+    #[rustango(max_length = 128, default = "''")] pub display_name: String,
+    #[rustango(max_length = 64, default = "'UTC'")] pub timezone: String,
+}
+impl rustango::tenancy::TenantUserModel for AppUser {}
+```
+
+**Étape 2.** Branchez la surcharge dans `main.rs` :
+
+```rust
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    rustango::manage::Cli::new()
+        .api(my_app::urls::router())
+        .tenancy()
+        .user_model::<AppUser>()
+        .run().await
+}
+```
+
+**Étape 3.** Enregistrez `AppUser` **au lieu du** `User` du framework —
+un seul modèle peut revendiquer `table = "rustango_users"`. Le
+générateur de squelette ne livre aucun JSON d'amorçage statique
+(seulement un `system/migrations/` vide), donc il n'y a rien à
+supprimer ; il faut juste ne pas enregistrer aussi le `User` du
+framework.
+
+**Étape 4.** Générez + appliquez :
+
+```bash
+cargo run -- makemigrations       # generates system/migrations/ with AppUser's columns
+cargo run -- migrate              # creates rustango_users with your extras
+```
+
+**Mises en garde :**
+
+- Modifier `AppUser` plus tard est un changement de schéma ordinaire :
+  réexécutez `makemigrations` pour émettre la migration `AddColumn`,
+  puis `migrate`.
+- Un seul modèle peut correspondre à `rustango_users`. Enregistrer **à
+  la fois** le `User` du framework et votre `AppUser` rend
+  `makemigrations` ambigu — enregistrez `AppUser` seul. C'est la
+  raison principale pour laquelle l'option 2 est réservée aux projets
+  neufs ; sur un projet existant, l'option 1 évite le problème.
+- Le code d'authentification et d'administration du framework lit les
+  sept colonnes essentielles par leur nom ; vos colonnes
+  supplémentaires ne sont accessibles que via
+  `AppUser::objects().fetch(...)`.
+
+`Builder::user_model::<AppUser>()` fait la même chose pour le code qui
+construit directement le `Builder` du serveur, sans passer par `Cli`.
+
+---
+
+## Sous-commandes personnalisées
+
+Vous pouvez ajouter vos propres commandes — la version **Rustango** des
+commandes de gestion personnalisées de Django. L'astuce consiste à
+inspecter vous-même les arguments et à traiter votre commande avant de
+passer le reste à `Cli::run`. Deux façons de le faire :
+
+**En ligne dans `src/main.rs`** (pas de binaire supplémentaire) :
+
+```rust
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if matches!(args.first().map(String::as_str), Some("import-csv")) {
+        let url = std::env::var("DATABASE_URL")?;
+        let pool = rustango::sql::sqlx::PgPool::connect(&url).await?;
+        return my_csv_importer::run(&pool, &args[1..]).await;
+    }
+    rustango::manage::Cli::new().api(urls::api()).run().await
+}
+```
+
+**Via `--with-manage-bin`** (`src/bin/manage.rs` séparé) :
+
+```bash
+cargo run -- startapp app --with-manage-bin
+```
+
+Puis dans `src/bin/manage.rs` :
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let url = std::env::var("DATABASE_URL")?;
+    let pool = rustango::sql::sqlx::PgPool::connect(&url).await?;
+
+    match args.first().map(String::as_str) {
+        Some("import-csv") => my_csv_importer::run(&pool, &args[1..]).await,
+        _ => rustango::migrate::manage::run(&pool, "./migrations".as_ref(), args)
+            .await
+            .map_err(Into::into),
+    }
+}
+```
+
+Exécutez vos propres commandes exactement comme les commandes
+intégrées : `cargo run -- import-csv path/to/file.csv` (ou
+`cargo run --bin manage -- import-csv …` en utilisant
+`--with-manage-bin`).
+
+---
+
+## Flux de travail courants
+
+### Mise en place d'un projet pour la première fois (mono-tenant)
+
+```bash
+cargo rustango new myapp
+cd myapp
+cp .env.example .env             # edit DATABASE_URL
+docker compose up -d
+cargo run -- migrate
+cargo run                        # serve at :8080
+```
+
+### Mise en place d'un projet pour la première fois (tenancy)
+
+```bash
+cargo rustango new myapp --template tenant
+cd myapp
+cp .env.example .env             # edit DATABASE_URL + RUSTANGO_APEX_DOMAIN
+docker compose up -d
+cargo run -- migrate                                      # registry + tenants
+cargo run -- create-operator admin --password letmein
+cargo run -- create-tenant acme --display-name "ACME Inc" \
+                  --host-pattern acme.localhost
+cargo run -- create-user acme alice --password tenantpw --superuser
+cargo run                        # serve at :8080
+```
+
+### Ajout de tenants une fois l'app déjà en fonctionnement
+
+Une véritable application de tenancy accumule généralement des modèles
+et des migrations bien avant l'arrivée de son premier tenant. Ce flux
+fonctionne à n'importe quel moment de la vie du projet :
+
+```bash
+# 1. (any time) develop user models — define structs with #[derive(Model)],
+#    add `pub mod ...;` to src/lib.rs.
+# 2. Generate scope-aware migrations. In a tenancy project this writes
+#    up to TWO files: one tagged registry-scope (touches Org/Operator),
+#    one tagged tenant-scope (touches User + your models). Pre-v0.24.2
+#    this used to dump everything into one tenant-scoped file and
+#    crash on `create-tenant` — see the changelog.
+cargo run -- makemigrations
+
+# 3. Apply migrations. `migrate` is scope-aware: it runs registry-
+#    scoped files once against the registry pool first, then fans
+#    tenant-scoped files across every active tenant.
+cargo run -- migrate
+
+# 4. Provision a NEW tenant whenever (could be days, weeks, many
+#    migrations later). The tenancy code applies every accumulated
+#    tenant-scoped migration to the new tenant's schema in one pass —
+#    the new tenant arrives at the same schema state as existing ones.
+cargo run -- create-tenant acme --display-name "ACME Inc" \
+                  --host-pattern acme.localhost
+cargo run -- create-user acme alice --password tenantpw --superuser
+```
+
+Pourquoi c'est sûr :
+- `#[rustango(scope = "registry")]` sur `Org`/`Operator` maintient les
+  changements aux tables partagées hors des migrations par tenant.
+- `migrate-tenants` visite chaque tenant actif et applique uniquement
+  les migrations tenant — les fichiers registry sont ignorés.
+- `create-tenant` exécute ce même passage `migrate-tenants` contre le
+  schéma du nouveau tenant, qui démarre donc entièrement à jour sans
+  correctif manuel.
+
+### Ajouter un modèle
+
+```bash
+cargo run -- startapp blog        # if not done yet
+# Edit src/blog/models.rs — add #[derive(Model)]
+# Add `pub mod blog;` to src/lib.rs
+cargo run -- makemigrations
+cargo run -- migrate
+```
+
+### Ajouter une API JSON pour ce modèle
+
+```bash
+cargo run -- make:viewset PostViewSet --model Post
+# Edit src/post_view_set.rs — fill in field lists
+# Mount in src/urls.rs
+cargo run                        # GET /api/posts now works
+```
+
+### Ajouter un remplissage rétroactif de données
+
+```bash
+cargo run -- add-data-op \
+    --sql "UPDATE posts SET slug = lower(title) WHERE slug IS NULL" \
+    --reverse-sql "UPDATE posts SET slug = NULL" \
+    --name backfill_post_slugs
+cargo run -- migrate
+```
+
+### Audit avant déploiement
+
+```bash
+cargo run --release -- check --deploy
+```
+
+### Annuler la dernière migration
+
+```bash
+cargo run -- downgrade 1
+```
+
+### Appliquer une migration de tenancy à un scope spécifique
+
+```bash
+cargo run -- migrate-registry            # registry-scoped only
+cargo run -- migrate-tenants             # tenant-scoped, fan-out across orgs
+```
+
+### Décommissionner un tenant
+
+```bash
+cargo run -- drop-tenant acme            # soft (reversible)
+cargo run -- purge-tenant acme           # hard (drops schema/db)
+```
+
+---
+
+## Réglage du pool par tenant (v0.27.7+)
+
+Les tenants en mode database obtiennent leur propre pool de connexions
+(un `PgPool` — un ensemble de connexions de base de données réutilisées),
+mis en cache par slug dans
+[`TenantPools`](../crates/rustango/src/tenancy/pools.rs). Par défaut, un
+pool est construit **de façon paresseuse, à la première requête du
+tenant**, sauf si vous activez le préchauffage. Les réglages se trouvent
+sur `TenantPoolsConfig` :
+
+| Champ | Défaut | Objet |
+|---|---|---|
+| `max_cached_database_pools` | 64 | Plafond du cache de pools. Une fois plein, le prochain tenant non mis en cache échoue (pas d'éviction silencieuse). |
+| `database_pool_max_connections` | 4 | `max_connections` par pool. À garder petit pour qu'un éparpillement de tenants n'épuise pas le `max_connections` de PG. |
+| `database_pool_min_connections` | 0 | Garde N connexions chaudes en permanence. `≥1` réduit la latence de la première requête en payant l'aller-retour TCP/TLS/auth au démarrage. |
+| `database_pool_acquire_timeout` | 30s | Durée d'attente de `pool.acquire()` avant l'erreur `PoolTimedOut`. |
+| `database_pool_idle_timeout` | 10 min | Ferme les connexions inactives après cette durée. Protège contre les coupures dues à l'équilibreur de charge / à `idle_in_transaction_session_timeout`. |
+| `database_pool_max_lifetime` | 30 min | Force la rotation des connexions pour que les identifiants louvés via vault soient renouvelés. |
+| `prewarm_active_tenants` | false | Si vrai, `Server::Builder::serve` appelle `prewarm_database_tenants()` au démarrage. |
+
+### Préchauffage au démarrage
+
+Deux façons de le déclencher :
+
+1. **Automatique** — réglez `prewarm_active_tenants = true` sur le
+   `TenantPoolsConfig` que vous passez à
+   `TenantPools::new(...).config(...)`. `Server::Builder::serve`
+   exécute le préchauffage avant de se lier au port.
+
+2. **Verbe CLI** — `cargo run -- prewarm-pools` construit les pools
+   pour chaque tenant actif en mode database et se termine. Utile
+   comme hook post-déploiement (par exemple après une rotation
+   d'identifiants), ou pour vérifier que chaque tenant est accessible
+   avant de basculer un équilibreur de charge.
+
+Le préchauffage parcourt `Org::objects().where(active = true,
+storage_mode = "database")` et s'arrête court quand le plafond du
+cache est atteint (rapporté comme `skipped_cap` dans le
+[`PrewarmReport`]). Les échecs de construction par tenant journalisent
+un `tracing::warn!` mais n'interrompent pas la boucle.
+
+### Traçage
+
+`crate::tenancy::pools::tenant_pool_init` est un
+`tracing::info_span!` qui enveloppe la construction du pool sur le
+chemin froid. Abonnez-vous-y pour voir la latence de construction par
+tenant :
+
+```text
+INFO crate::tenancy::pools: tenant pool connected (database mode)
+     slug=acme elapsed_ms=42 min_conn=1 max_conn=4
+```
+
+### Piège de configuration — TLD `.local` sur macOS
+
+Si vous accédez à l'admin du tenant via
+`http://acme.local:8080/admin/` sur macOS et constatez une pause de 5
+secondes à chaque requête : c'est **Bonjour / mDNS**, pas
+**Rustango**. Le résolveur de macOS traite `.local` de façon spéciale
+et attend le délai complet de mDNS avant de retomber sur
+`/etc/hosts`. Deux corrections :
+
+1. **Utiliser un TLD différent** : `127.0.0.1 acme.localhost`
+   fonctionne sans délai. `localhost` est réservé (RFC 6761) et évite
+   mDNS.
+2. **Exécuter dnsmasq** avec une zone `.local` pointant vers 127.0.0.1
+   pour que l'OS obtienne une réponse immédiate.
+
+Confirmez avec `curl -w "%{time_connect}\n"` : si `time_connect`
+affiche environ 5s mais tombe à quelques millisecondes avec
+`--resolve acme.local:8080:127.0.0.1`, vous êtes bien confronté à mDNS.
+
+
+---
+
+## Voir aussi
+
+- [Recueil ORM](orm.md)
+- [Générateurs de squelette](scaffolding.md)
+- [ViewSets](viewsets.md)
+- [Serializers](serializers.md)
+- [Guide de sécurité](security.md)

--- a/docs/fr/models.md
+++ b/docs/fr/models.md
@@ -1,0 +1,449 @@
+# Modèles
+
+Un modèle est une struct Rust qui correspond à une table de base de données. Ajoutez `#[derive(Model)]`,
+annotez les champs, et **Rustango** génère le schéma, un point d'entrée de requête type-safe,
+et les méthodes `save`/`find`/`delete` — les modèles de Django ou l'Eloquent de Laravel,
+avec le compilateur qui vérifie vos colonnes. Ceci est la référence de **déclaration** :
+chaque type de champ, chaque option de clé primaire, et chaque
+attribut `#[rustango(...)]`. Pour *interroger* les modèles une fois déclarés, voir
+le [cookbook ORM](orm.md).
+
+[![Models in Rustango: a #[derive(Model)] struct maps Rust field types to per-dialect columns, the primary key can be an auto-increment Auto<i64> or a custom application-assigned key, and the derive generates SCHEMA + objects() + save/find](img/models.png)](img/models.png)
+
+> **Nouveau sur un terme ici ?** *modèle*, *clé primaire*, *clé étrangère*, *migration*,
+> *nullable* — voir le [glossaire](glossary.md).
+
+> **Source :** `rustango::Model` (`#[derive(Model)]`), `rustango::core`
+> (le trait `Model`, `ModelSchema`, `FieldType`, `Auto`, `ForeignKey`), et les
+> correspondances de types par dialecte dans `rustango::sql::{dialect, mysql, sqlite}` — toujours
+> compilées (choisissez une feature de backend : `postgres` / `mysql` / `sqlite`).
+>
+> **Version exécutable :** les allers-retours de types de champs, la PK personnalisée, et les
+> extraits SCHEMA sont copiés depuis
+> [`models_doc.rs`](../crates/rustango/tests/models_doc.rs)
+> (`cargo test -p rustango --features sqlite --test models_doc`).
+
+## Table des matières
+
+- [Anatomie d'un modèle](#anatomy-of-a-model)
+- [Types de champs](#field-types) · [Types spécifiques à PostgreSQL](#postgresql-only-types)
+- [Clés primaires](#primary-keys) — [PK personnalisées](#custom-primary-keys) · [composites](#composite-primary-keys)
+- [Relations](#relationships)
+- [Attributs de champ courants](#common-field-attributes)
+- [Index et contraintes](#indexes-and-constraints)
+- [Attributs de modèle courants](#common-model-attributes)
+- [L'API générée](#the-generated-api) — [save vs insert](#save-vs-insert)
+- [Référence complète des attributs](#full-attribute-reference)
+- [Voir aussi](#see-also)
+
+---
+
+## Anatomie d'un modèle
+
+```rust
+use rustango::{Auto, Model};
+use chrono::{DateTime, Utc};
+
+#[derive(Model, Clone, Debug)]
+#[rustango(table = "posts", display = "title")]   // model-level attributes
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,                            // field-level attributes
+
+    #[rustango(max_length = 200)]
+    pub title: String,
+
+    pub body: String,
+
+    #[rustango(fk = "authors", on = "id")]
+    pub author_id: i64,
+
+    #[rustango(auto_now_add)]
+    pub created_at: Auto<DateTime<Utc>>,
+}
+```
+
+À partir de cette seule déclaration, le derive génère :
+
+- le **schéma** (`Post::SCHEMA` — nom de la table, colonnes, types, la PK) que
+  les migrations et l'admin lisent ;
+- un point d'entrée de requête, **`Post::objects()`**, retournant un `QuerySet<Post>` ;
+- des **constantes de champ typées** (`Post::title`, `Post::author_id`) pour des
+  filtres vérifiés à la compilation — `Post::objects().where_(Post::author_id.eq(42))` ;
+- des méthodes de ligne — **`save`**, **`find`**, **`delete`**, et plus (voir
+  [l'API générée](#the-generated-api)).
+
+Le nom de la table prend par défaut le nom du modèle si vous omettez `table` ; les noms de colonnes
+prennent par défaut le nom du champ en snake_case sauf si vous définissez `column`.
+
+---
+
+## Types de champs
+
+Le type Rust du champ déterminele type de colonne en base de données. Rustango fait correspondre chaque
+type par dialecte, si bien que le même modèle fonctionne sur PostgreSQL, MySQL et SQLite :
+
+| Type Rust | PostgreSQL | MySQL | SQLite |
+|---|---|---|---|
+| `i16` | `SMALLINT` | `SMALLINT` | `INTEGER` |
+| `i32` | `INTEGER` | `INT` | `INTEGER` |
+| `i64` | `BIGINT` | `BIGINT` | `INTEGER` |
+| `f32` | `REAL` | `FLOAT` | `REAL` |
+| `f64` | `DOUBLE PRECISION` | `DOUBLE` | `REAL` |
+| `bool` | `BOOLEAN` | `TINYINT(1)` | `INTEGER` (0/1) |
+| `String` | `TEXT` | `TEXT` | `TEXT` |
+| `String` + `max_length = N` | `VARCHAR(N)` | `VARCHAR(N)` | `TEXT` |
+| `chrono::DateTime<Utc>` | `TIMESTAMPTZ` | `DATETIME(6)` | `TEXT` (ISO-8601) |
+| `chrono::NaiveDate` | `DATE` | `DATE` | `TEXT` |
+| `chrono::NaiveTime` | `TIME` | `TIME(6)` | `TEXT` |
+| `uuid::Uuid` | `UUID` | `CHAR(36)` | `TEXT` |
+| `serde_json::Value` | `JSONB` | `JSON` | `TEXT` |
+| `rust_decimal::Decimal` | `NUMERIC` | `DECIMAL(38,10)` | `NUMERIC` |
+| `Vec<u8>` | `BYTEA` | `LONGBLOB` | `BLOB` |
+| `Option<T>` | `T NULL` | `T NULL` | `T` (nullable) |
+
+`Option<T>` est le moyen de rendre une colonne **nullable** — un champ non-`Option` est
+`NOT NULL`. Tous ces types font l'aller-retour via `save` → `find`, vérifié de bout
+en bout :
+
+```rust
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gadget")]
+pub struct Gadget {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 100)]
+    pub name: String,
+    pub qty: i64,
+    pub active: bool,
+    pub note: Option<String>,        // nullable
+    pub made_at: DateTime<Utc>,
+    pub meta: serde_json::Value,     // JSON
+}
+```
+
+> **Précision décimale.** Le `NUMERIC` de PostgreSQL est à précision arbitraire ; MySQL utilise
+> `DECIMAL(38,10)` (38 chiffres, 10 décimales — l'ajustement portable le plus large) ; SQLite
+> utilise l'affinité `NUMERIC`. Utilisez `rust_decimal::Decimal` pour l'argent, jamais `f64`.
+
+### Types spécifiques à PostgreSQL
+
+Ceux-ci correspondent à des types de colonnes natifs de PostgreSQL et n'ont **aucun équivalent
+MySQL/SQLite** — le générateur de migrations émet `TEXT` sur ces backends pour rester valide, mais
+lire/écrire ces types provoque une erreur à l'exécution sur ces backends. Ne les utilisez que dans
+des déploiements PostgreSQL :
+
+| Type Rust | PostgreSQL | Notes |
+|---|---|---|
+| `Array<T>` | `text[]` / `integer[]` / `bigint[]` | tableaux natifs |
+| `Range<T>` | `int4range` / `int8range` / `numrange` / `daterange` / `tstzrange` | types de plage |
+| `HStore` | `hstore` | map plate chaîne→chaîne (nécessite l'extension) |
+| `Vector` + `#[rustango(vector(dims = N))]` | `vector(N)` | embeddings pgvector |
+| `Point` + `#[rustango(geometry(srid = N))]` | `geometry(Point, N)` | PostGIS |
+
+---
+
+## Clés primaires
+
+Chaque modèle a besoin d'une clé primaire. Marquez un champ `#[rustango(primary_key)]` ; si
+vous n'en marquez aucun, le schéma recherche une colonne nommée `id`.
+
+La PK **par défaut et la plus courante** est un entier 64 bits auto-incrémenté,
+déclaré comme `Auto<i64>` :
+
+```rust
+#[rustango(primary_key)]
+pub id: Auto<i64>,
+```
+
+**Sémantique de `Auto<T>`.** Un champ `Auto<T>` est soit `Unset` (la valeur que la base de données
+assignera) soit `Set(v)`. À l'insertion, une PK `Unset` est omise de la liste des colonnes
+pour que la base de données la génère, puis la valeur est relue (`RETURNING` sur
+PostgreSQL/SQLite, `LAST_INSERT_ID()` sur MySQL) et stockée sur votre struct :
+
+```rust
+let mut g = Gadget { id: Auto::default(), /* … */ };   // Unset
+g.save_pool(&pool).await?;                              // DB assigns the id
+let new_id = g.id.get().copied().unwrap();             // now populated
+```
+
+Les types internes de `Auto<T>` pris en charge sont `i32`, `i64` et `Uuid`.
+
+### Clés primaires personnalisées
+
+La PK n'a pas besoin d'être un entier auto-incrémenté. Tout type qui correspond à une
+colonne peut être la PK ; vous assignez la valeur vous-même :
+
+| Déclaration de PK | Type de colonne | Qui l'assigne |
+|---|---|---|
+| `Auto<i64>` *(par défaut)* | `BIGSERIAL` / `BIGINT AUTO_INCREMENT` / `INTEGER … AUTOINCREMENT` | la base de données |
+| `Auto<i32>` | `SERIAL` / `INT AUTO_INCREMENT` / `INTEGER …` | la base de données |
+| `Auto<Uuid>` + `auto_uuid` | `UUID` | côté Rust (`uuid v4`) |
+| `Auto<Uuid>` + `default_uuid_v7` | `UUID` | côté Rust (`uuid v7` triable) |
+| `String` + `primary_key` | `VARCHAR(N)` / `TEXT` | vous (l'application) |
+| `Uuid` + `primary_key` | `UUID` / `CHAR(36)` / `TEXT` | vous (l'application) |
+| `i64` / `i32` + `primary_key` | `BIGINT` / `INTEGER` | vous (l'application) |
+
+Une **clé de chaîne naturelle** (par ex. un code de coupon) — notez que vous fournissez la valeur et
+insérez avec [`insert_pool`](#save-vs-insert), puisqu'il n'y a pas d'`Auto::Unset` pour que
+`save` puisse le détecter :
+
+```rust
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "coupon")]
+pub struct Coupon {
+    #[rustango(primary_key, max_length = 32)]
+    pub code: String,        // you assign this
+    pub discount: i64,
+}
+
+let c = Coupon { code: "SAVE10".into(), discount: 10 };
+c.insert_pool(&pool).await?;                       // explicit INSERT
+let back = Coupon::find_or_fail("SAVE10".to_string(), &pool).await?;   // look up by the string PK
+```
+
+**Renommer la colonne de la PK** avec `column` (le champ Rust reste `number`, la colonne
+SQL est `account_no`) :
+
+```rust
+#[rustango(primary_key, column = "account_no")]
+pub number: i64,
+```
+
+```rust
+// Introspect it via the schema:
+let pk = Account::SCHEMA.primary_key().unwrap();
+assert_eq!(pk.name, "number");        // Rust field
+assert_eq!(pk.column, "account_no");  // SQL column
+```
+
+**Les clés primaires UUID** génèrent la valeur côté Rust : `auto_uuid` donne un v4
+aléatoire, `default_uuid_v7` un v7 triable dans le temps (meilleure localité d'index) :
+
+```rust
+#[rustango(primary_key, auto_uuid)]
+pub id: Auto<uuid::Uuid>,
+```
+
+### Clés primaires composites
+
+Les clés primaires multi-colonnes natives ne sont **pas prises en charge** — exactement un champ peut être
+`primary_key`. Le motif fourni est une PK `Auto<i64>` substitutive plus une
+contrainte d'unicité composite déclarée, ce qui est équivalent à un index :
+
+```rust
+#[derive(Model)]
+#[rustango(table = "line_item", unique_together = "invoice_id, line_no")]
+pub struct LineItem {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,        // surrogate PK
+    pub invoice_id: i64,
+    pub line_no: i32,         // (invoice_id, line_no) is unique together
+}
+```
+
+Recherchez les lignes avec `.where_(LineItem::invoice_id.eq(..)).where_(LineItem::line_no.eq(..))`.
+
+---
+
+## Relations
+
+Une clé étrangère est une colonne `_id` plus un accesseur typé optionnel :
+
+```rust
+// Plain FK column — store the parent's id:
+#[rustango(fk = "authors", on = "id")]
+pub author_id: i64,
+
+// Typed FK — lazy-loads the parent on demand:
+pub author: ForeignKey<Author>,
+```
+
+`ForeignKey<T>` prend par défaut `i64` comme type de clé ; si la PK du parent est d'un
+type différent, précisez-le : `ForeignKey<User, String>`. Le un-à-un utilise
+`#[rustango(o2o)]` ; le plusieurs-à-plusieurs est une table séparée — voir
+[cookbook ORM → Plusieurs-à-plusieurs](orm.md#many-to-many). Chargez les lignes liées de manière anticipée avec
+`select_related` (également dans le guide ORM).
+
+---
+
+## Attributs de champ courants
+
+`#[rustango(...)]` sur un champ. Ceux que vous utiliserez constamment :
+
+| Attribut | Exemple | Effet |
+|---|---|---|
+| `primary_key` | `#[rustango(primary_key)]` | marque la PK |
+| `max_length = N` | `#[rustango(max_length = 200)]` | `VARCHAR(N)` + vérification de longueur à l'écriture |
+| `default = "…"` | `#[rustango(default = "'draft'")]` | valeur par défaut de la colonne en base (littéral SQL) |
+| `unique` | `#[rustango(unique)]` | contrainte d'unicité sur la colonne |
+| `choices = "…"` | `#[rustango(choices = "draft:Draft, published:Published")]` | valeurs énumérées (`value:Label`) ; `<select>` de l'admin + validation |
+| `auto_now_add` | `#[rustango(auto_now_add)]` | réglé à l'heure actuelle à l'**insertion** (sur un `Auto<DateTime<Utc>>`) |
+| `auto_now` | `#[rustango(auto_now)]` | réglé à l'heure actuelle à **chaque save** |
+| `column = "…"` | `#[rustango(column = "account_no")]` | renomme la colonne SQL |
+| `null` / `Option<T>` | `pub note: Option<String>` | colonne nullable |
+| `min` / `max` | `#[rustango(min = 0, max = 100)]` | validation de plage à l'écriture |
+| `blank` / `editable` | `#[rustango(editable = false)]` | comportement formulaire/admin |
+| `db_comment = "…"` | `#[rustango(db_comment = "cents")]` | COMMENT de colonne |
+
+`choices`, `default`, `auto_now_add`, et la suppression logique ensemble (tous vérifiés) :
+
+```rust
+#[rustango(max_length = 20, default = "'draft'", choices = "draft:Draft, published:Published")]
+pub status: String,
+#[rustango(auto_now_add)]
+pub created_at: Auto<DateTime<Utc>>,
+#[rustango(soft_delete)]
+pub deleted_at: Option<DateTime<Utc>>,
+```
+
+---
+
+## Index et contraintes
+
+Déclarés sur le **modèle** :
+
+```rust
+#[rustango(
+    table = "posts",
+    index("status, published_at"),                 // composite btree index
+    unique_together = "author_id, slug",           // multi-column unique
+    check(name = "qty_nonneg", expr = "qty >= 0"), // CHECK constraint
+)]
+```
+
+- **`index(...)`** — un index btree par défaut ; choisissez une méthode pour PostgreSQL
+  avec `index(columns = "body", method = "gin")` (aussi `gist`, `brin`, `hash`,
+  `bloom`, `spgist`).
+- **`unique_together` / `index_together`** — unicité / index non unique multi-colonnes.
+- **Index partiels** — `unique_when(...)` / `index_when(...)` ajoutent une condition
+  `WHERE`.
+- **`check(name, expr)`** — une contrainte CHECK ; **`exclude(...)`** est une
+  contrainte EXCLUDE de PostgreSQL.
+
+---
+
+## Attributs de modèle courants
+
+`#[rustango(...)]` sur la struct :
+
+| Attribut | Exemple | Effet |
+|---|---|---|
+| `table = "…"` | `table = "posts"` | nom de la table (par défaut le nom de la struct) |
+| `display = "…"` | `display = "title"` | le champ affiché lorsqu'une ligne est référencée (libellés de FK, admin) |
+| `app = "…"` | `app = "blog"` | regroupe le modèle sous une app |
+| `default_order = "…"` | `default_order = "-created_at"` | tri par défaut pour les requêtes |
+| `default_permissions` | `default_permissions = "add, change"` | quelles auto-permissions créer |
+| `soft_delete` *(champ)* | `#[rustango(soft_delete)] deleted_at: Option<…>` | active la suppression logique (marquer, pas supprimer) |
+| `audit(track = "…")` | `audit(track = "title, status")` | enregistre l'historique des modifications par ligne |
+| `scope = "…"` | `scope = "tenant"` | portée multi-tenant (registre vs tenant) |
+| `admin(...)` | `admin(list_display = "…")` | configuration de l'UI admin — voir [l'admin](admin.md) |
+
+---
+
+## L'API générée
+
+`#[derive(Model)]` implémente le trait `Model` (`Post::SCHEMA`) et génère :
+
+- **`Post::objects()`** (alias `Post::query()`) → un `QuerySet<Post>` pour filtrer,
+  ordonner et récupérer (le [cookbook ORM](orm.md) couvre l'API de requête).
+- **Des constantes de champ typées** — `Post::title`, `Post::author_id` — utilisées dans
+  `.where_(Post::author_id.eq(42))` pour des filtres vérifiés à la compilation.
+- **Des chercheurs (finders)** — `find(pk, &pool)` → `Option<Self>` ; `find_or_fail(pk, &pool)` →
+  `Self` (erreur si absent) ; `find_many(pks, &pool)` ; `find_or_insert(...)`.
+- **Des écrivains (writers)** — `save`/`save_pool`, `save_partial(&["title"], &pool)` (met à jour
+  seulement certaines colonnes), `insert_pool` (insertion explicite), `delete`.
+- **La suppression logique** (si activée) — `soft_delete`, `restore`, `force_delete` ;
+  `QuerySet::active()` / `with_trashed()` / `only_trashed()`.
+
+### save vs insert
+
+Ceci embrouille souvent les gens, il vaut donc la peine de le dire clairement :
+
+| Méthode | Comportement |
+|---|---|
+| `save_pool(&mut self, &pool)` | **INSERT** si la PK `Auto` est `Unset`, sinon **UPDATE** |
+| `insert_pool(&self, &pool)` | toujours **INSERT** |
+
+Pour la PK `Auto<i64>` par défaut, `save_pool` fait ce qu'il faut automatiquement.
+Pour une **PK assignée par l'application** (un `String`/`Uuid` que vous définissez vous-même), il n'y a
+pas d'état `Unset` — `save_pool` ferait donc un UPDATE sur une ligne (peut-être inexistante).
+Utilisez **`insert_pool`** pour insérer une ligne toute neuve avec une PK personnalisée (vérifié dans le
+test associé).
+
+---
+
+## Référence complète des attributs
+
+Chaque clé `#[rustango(...)]` acceptée par le derive. Les plus courantes sont couvertes
+ci-dessus ; voici la liste complète, y compris les avancées/spécifiques à PostgreSQL.
+
+### Au niveau du modèle (sur la struct)
+
+| Attribut | Valeur | Effet |
+|---|---|---|
+| `table` | `"name"` | nom de la table |
+| `display` | `"field"` | libellé humain pour une ligne |
+| `app` | `"name"` | regroupement par app |
+| `default_order` | `"-field"` | tri par défaut |
+| `default_permissions` | `"add, change, delete, view"` | auto-permissions à créer |
+| `default_related_name` | `"posts"` | nom de l'accesseur inverse sur le parent |
+| `base_manager_name` | `"all_objects"` | nom du manager de base (non filtré) |
+| `manager(ext = "Trait")` | chemin de trait | génère un trait d'extension de manager personnalisé |
+| `manager_fn` | `"published"` | ajoute un accesseur de manager en plus de `objects()` |
+| `get_latest_by` | `"created_at"` | colonne par défaut pour `latest()`/`earliest()` |
+| `order_with_respect_to` | `"parent"` | ordre relatif au parent, à la manière de Django |
+| `index(...)` | `columns`, `method`, `name` | index secondaire (btree/gin/gist/brin/hash/bloom/spgist) |
+| `unique_together` | `"a, b"` | contrainte d'unicité composite |
+| `index_together` | `"a, b"` | index composite non unique |
+| `unique_when(...)` / `index_when(...)` | colonnes + `condition` | index partiel (conditionnel) |
+| `check(...)` | `name`, `expr` | contrainte CHECK |
+| `exclude(...)` | spécification d'opérateur | contrainte EXCLUDE de PostgreSQL |
+| `audit(track = "…")` | liste de champs | historique des modifications par ligne |
+| `scope` | `"tenant"` / `"registry"` | portée multi-tenant |
+| `proxy` | indicateur | modèle proxy (partage la table d'un autre) |
+| `global_scope(name, apply = fn)` | nom + fonction | filtre appliqué automatiquement à toutes les requêtes |
+| `through(...)` | spécification de relation | accesseur de relation « through » personnalisé |
+| `reverse_has(...)` / `generic_has(...)` | spécification de relation | accesseur has-many inverse / FK générique inverse |
+| `required_db_features` / `required_db_vendor` | liste / fournisseur | contraintes de validation de déploiement |
+| `db_table_comment` | `"…"` | COMMENT de table |
+| `admin(...)` | options admin | configuration de l'UI admin (voir [admin.md](admin.md)) |
+
+### Au niveau du champ (sur un champ)
+
+| Attribut | Valeur | Effet |
+|---|---|---|
+| `primary_key` | indicateur | marque la PK |
+| `column` | `"name"` | renomme la colonne SQL |
+| `max_length` | `N` | `VARCHAR(N)` + validation de longueur |
+| `default` | `"sql literal"` | DEFAULT de colonne |
+| `null` | indicateur | nullable (ou utilisez `Option<T>`) |
+| `unique` | indicateur | contrainte d'unicité |
+| `choices` | `"v:Label, …"` | valeurs énumérées |
+| `min` / `max` | nombre | validation de plage |
+| `blank` | indicateur | autorise le vide dans les formulaires/admin |
+| `editable` | `true`/`false` | éditabilité formulaire/admin |
+| `auto_now` | indicateur | réglé à l'heure actuelle à chaque save |
+| `auto_now_add` | indicateur | réglé à l'heure actuelle à l'insertion |
+| `auto_uuid` | indicateur | UUID v4 côté Rust (sur `Auto<Uuid>`) |
+| `default_uuid_v7` | indicateur | UUID v7 triable côté Rust |
+| `fk` + `on` | `"table"`, `"col"` | colonne de clé étrangère |
+| `cascade` | indicateur | `ON DELETE CASCADE` |
+| `o2o` | indicateur | relation un-à-un |
+| `fk_composite(...)` / `generic_fk(...)` | spécification | FK composite / FK générique (content-type) |
+| `generated_as` | `"expr"` | colonne calculée (générée) par la base de données |
+| `citext` | indicateur | texte insensible à la casse (CITEXT PostgreSQL) |
+| `vector(dims = N)` | `N` | dimension pgvector |
+| `geometry(srid = N)` | `N` | identifiant de référence spatiale PostGIS |
+| `db_comment` | `"…"` | COMMENT de colonne |
+
+---
+
+## Voir aussi
+
+- [Cookbook ORM](orm.md) — requêtes, filtres, agrégations, jointures, transactions
+  (que faire d'un modèle une fois qu'il est déclaré).
+- [Sérialiseurs](serializers.md) — transformer un modèle en JSON pour une API.
+- [L'admin](admin.md) — le bloc `admin(...)` et l'UI générée.
+- [Scaffolding](scaffolding.md) · [CLI `manage`](manage.md) — générer un modèle
+  et sa migration.

--- a/docs/fr/orm.md
+++ b/docs/fr/orm.md
@@ -1,0 +1,1800 @@
+# Cookbook de l'ORM
+
+Des patterns pour l'ORM de **Rustango** au-delà des bases. Si vous venez de l'ORM de Django, d'Eloquent (Laravel) ou d'ActiveRecord (Rails), les formes présentées ici vous sembleront familières. La plupart des exemples supposent que vous disposez déjà d'un modèle `Post` issu de `Getting Started`.
+
+[![Type-checked ORM queries: chained filters, ordering, limits, and aggregation — all without raw SQL](img/orm.png)](img/orm.png)
+
+> **Source :** `rustango::sql` (`QuerySet`, la macro `Q!` / le builder `Qb`) et l'API de requête
+> `#[derive(Model)]` — toujours compilée ; choisissez une feature de backend
+> (`postgres` / `mysql` / `sqlite`).
+>
+> **Version exécutable :** les patterns présentés ici s'exécutent dans l'exemple testé
+> [`orm_cookbook`](../crates/rustango/examples/orm_cookbook).
+>
+> **Nouveau sur un terme ici ?** Le [glossaire](glossary.md) définit *modèle*, *queryset*,
+> *pool* et *migration* en langage simple.
+
+Quelques termes Rust reviennent tout au long du texte. `&pool` est une référence partagée vers le pool de connexions à la base de données ; vous la passez aux méthodes qui exécutent réellement du SQL. `.await` exécute un appel asynchrone et attend le résultat. `Option<T>` est une valeur qui peut être présente (`Some`) ou absente (`None`) — le null de Rust. `Result` représente succès-ou-erreur ; le `?` final sur un appel retourne immédiatement en cas d'erreur. `Auto<i64>` est une clé primaire auto-incrémentée qui est soit `Set` (chargée depuis la base) soit `Unset` (pas encore insérée).
+
+## Nouveautés (v0.41 / v0.42)
+
+Les dernières versions ont ajouté un lot de fonctionnalités à parité avec Django qui ne sont pas encore intégrées dans chaque section ci-dessous. Repères rapides :
+
+- **Macro `Q!` + builder `Qb` au runtime** (#269, #263) — filtres de forme Django, sûrs à la compilation. `User::objects().where_(Q!(User.email__icontains = "alice"))` échoue à la compilation en cas de faute de frappe sur un nom de champ. Variante composable au runtime pour les puces de filtre de l'admin : `let q = Qb::eq("active", true) & Qb::gt("age", 18i64);`.
+- **`.distinct_on(&["author_id"])`** (#264) — natif PG ; repli portable par fonction fenêtrée sur MySQL / SQLite. Patterns « dernier par groupe ».
+- **`bulk_upsert_pool(rows, unique_fields, update_fields, &pool)`** (#267) — équivalent de `bulk_create(update_conflicts=True)` de Django. ON CONFLICT / ON DUPLICATE KEY UPDATE tri-dialecte.
+- **`explain_pool()`** (#272) — EXPLAIN tri-dialecte. PG `EXPLAIN (FORMAT JSON, ANALYZE, BUFFERS)` / MySQL `EXPLAIN ANALYZE` / SQLite `EXPLAIN QUERY PLAN`.
+- **Bibliothèque de fonctions DB** (#266) — `Cast`, `LPad`, `RPad`, `MD5`, `SHA1`, `SHA256`, `Position`, `Repeat`, `Reverse`, `Sign`, `Mod`, `Power`, `Sqrt`. Émission par dialecte avec des erreurs claires là où SQLite ne dispose pas de la fonction.
+- **Types de champs** — `rust_decimal::Decimal` (natif PG/MySQL, via un shim Decode sur SQLite), `chrono::NaiveTime`, `Vec<u8>` (`FieldType::Binary`) désormais acceptés par `#[derive(Model)]` (#524, v0.42).
+- **`ModelForm::prepare_save()` / `PreparedSave`** (#375, v0.42) — équivalent de `save(commit=False)` de Django. Validez maintenant, modifiez l'ensemble d'écriture préparé, validez (commit) quand vous êtes prêt.
+- **`#[rustango(unique_when(columns = "...", condition = "..."))]`** (#265) — contraintes d'unicité partielles. « Email unique par ligne non supprimée » / « Slug unique par tenant ».
+- **`#[rustango(manager(ext = "FooManagerExt"))]`** (#271) — trait d'extension de manager personnalisé de forme Django, émis à côté du modèle. (C'est aussi la forme Rust des modèles proxy de Django — même table physique, plusieurs « personnalités » via des méthodes par trait. Voir `inheritance.rs:98-127`.)
+- **`manage makemigrations --merge`** (#346, v0.42) — nœud de fusion de forme Django pour les chaînes de branches divergentes. Voir [`docs/manage.md`](manage.md#makemigrations---merge).
+
+Le CHANGELOG contient l'index complet des tickets pour chaque version.
+
+## Table des matières
+
+- [Requêtage](#querying)
+- [Valeurs calculées & fonctions de base de données](#computed-values--database-functions)
+- [Agrégations](#aggregations)
+- [Jointures & préchargement des lignes liées](#joins--preloading-related-rows)
+- [Opérations en masse](#bulk-operations)
+- [Insertion ou mise à jour (upsert)](#insert-or-update-upsert)
+- [Transactions](#transactions)
+- [Relations plusieurs-à-plusieurs](#many-to-many)
+- [JSON / JSONB](#json--jsonb)
+- [Suppression logique](#soft-delete)
+- [Piste d'audit](#audit-trail)
+- [Échappatoire SQL brut](#raw-sql-escape-hatch)
+- [Chargement paresseux des FK](#lazy-fk-loading)
+- [Quatre façons de filtrer](#four-ways-to-filter)
+- [Requêtes cloisonnées par tenant](#tenant-scoped-queries)
+- [Signaux](#signals)
+- [Conseils de performance](#performance-tips)
+
+---
+
+## Requêtage
+
+Lire des lignes depuis la base de données. `Post::objects()` démarre une requête (comme `Post.objects` de Django) ; vous enchaînez des filtres et un tri, puis appelez `.fetch(&pool).await?` pour l'exécuter et récupérer un `Vec<Post>`. `.where_(...)` ajoute une condition jointe par un AND.
+
+```rust
+use rustango::core::Column as _;
+use rustango::core::{Op, SqlValue, WhereExpr};   // for filter_op / where_raw below
+use rustango::sql::FetcherPool as _;
+
+// Simplest — fetch all
+let posts = Post::objects().fetch(&pool).await?;
+
+// Single equality filter
+let drafts = Post::objects()
+    .where_(Post::status.eq("draft"))
+    .fetch(&pool).await?;
+
+// Chained filters (AND)
+let recent_drafts = Post::objects()
+    .where_(Post::status.eq("draft"))
+    .where_(Post::author_id.eq(42))
+    .where_(Post::deleted_at.is_null())
+    .order_by(&[("created_at", true)])        // true = DESC
+    .limit(20)
+    .fetch(&pool).await?;
+
+// String-keyed filter (validated at compile of the queryset)
+let by_id = Post::objects()
+    .filter_op("id", Op::Eq, SqlValue::I64(42))
+    .fetch(&pool).await?;
+
+// OR / nested
+let qs = Post::objects().where_raw(WhereExpr::Or(vec![
+    Post::status.eq("draft").into(),
+    Post::status.eq("review").into(),
+]));
+
+// XOR — Django 4.1+ `Q(a) ^ Q(b)`. Matches rows where an odd number
+// of operands evaluate to true (binary case = "exactly one is true").
+// Issue #27.
+let either_but_not_both = Post::objects()
+    .where_(Post::status.eq("draft").xor(Post::author_id.eq(42)))
+    .fetch(&pool).await?;
+// Tri-dialect emission: native logical XOR exists on MySQL but not PG
+// or SQLite, so the writer emits a portable rewrite uniformly —
+// `(a AND NOT b) OR (NOT a AND b)` for the binary form, or a
+// CASE-WHEN-1/0 tally `% 2 = 1` for N-ary chains.
+```
+
+### Filtres de comparaison
+
+Les méthodes de filtre courantes, une par opérateur SQL. Ce sont les lookups de champs de Django (`__gt`, `__in`, `__icontains`, etc.) sous une forme typée.
+
+```rust
+Post::objects().where_(Post::view_count.gt(100)).fetch(&pool).await?;
+Post::objects().where_(Post::view_count.gte(100)).fetch(&pool).await?;
+Post::objects().where_(Post::view_count.lt(100)).fetch(&pool).await?;
+Post::objects().where_(Post::view_count.lte(100)).fetch(&pool).await?;
+Post::objects().where_(Post::status.ne("archived")).fetch(&pool).await?;
+Post::objects().where_(Post::id.is_in([1, 2, 3])).fetch(&pool).await?;
+Post::objects().where_(Post::status.not_in(["draft", "deleted"])).fetch(&pool).await?;
+Post::objects().where_(Post::title.like("%draft%")).fetch(&pool).await?;          // case-sensitive contains
+Post::objects().where_(Post::title.ilike("%draft%")).fetch(&pool).await?;         // case-insensitive contains
+Post::objects().where_(Post::title.ilike("Hello%")).fetch(&pool).await?;          // case-insensitive starts-with
+Post::objects().where_(Post::deleted_at.is_null()).fetch(&pool).await?;
+Post::objects().where_(Post::published_at.between(start, end)).fetch(&pool).await?;
+```
+
+### Tri des résultats
+
+Triez les lignes par une ou plusieurs colonnes, par une expression, ou avec un contrôle explicite de l'emplacement des NULL. Au-delà du `.order_by(&[("col", desc)])` basique, vous disposez de trois dimensions supplémentaires :
+
+```rust
+use rustango::core::funcs::lower;
+use rustango::core::{F, NullsOrder};
+
+// 1. Plain field + ASC/DESC (back-compat — implicit NULLS handling
+//    differs between dialects; see the dialect note below).
+Post::objects()
+    .order_by(&[("published_at", true), ("id", false)])
+    .fetch(&pool).await?;
+
+// 2. Explicit NULLS FIRST/LAST control — portable across PG, MySQL,
+//    and SQLite. MySQL has no native `NULLS …` keyword; the writer
+//    emulates with an `<col> IS NULL` pre-sort term so the on-wire
+//    ordering matches PG/SQLite.
+Post::objects()
+    .order_by_with_nulls(&[("score", true, NullsOrder::Last)])
+    .fetch(&pool).await?;
+
+// 3. Arbitrary Expr in the ORDER BY position — case-insensitive
+//    title sort via `LOWER(title)`, computed sort keys via
+//    `case() / when() / value()`, arithmetic via `F("a") + F("b")`.
+Post::objects()
+    .order_by_expr(lower(F("title")), false)
+    .order_by_expr_with_nulls(F("score") + 1_i64, true, NullsOrder::Last)
+    .fetch(&pool).await?;
+```
+
+**Gestion des NULL par dialecte (sans `NullsOrder` explicite) :**
+
+| Dialecte | Défaut ASC | Défaut DESC |
+|---|---|---|
+| PostgreSQL | NULLS LAST | NULLS FIRST |
+| SQLite | NULLS LAST | NULLS FIRST |
+| MySQL | NULL en premier (sémantique « plus petite valeur ») | NULL en dernier |
+
+Utilisez `.order_by_with_nulls(...)` / `.order_by_expr_with_nulls(...)` pour fixer le placement ; sinon c'est le comportement natif par défaut de la base qui s'applique. Sur MySQL, le writer émet `<col> IS NULL <asc|desc>` avant le tri réel pour l'émuler ; le SQL émis comporte deux termes ORDER BY par colonne épinglée, mais la sémantique correspond à PG/SQLite.
+
+**Composition de la chaîne.** `.order_by(...)`, `.order_by_with_nulls(...)` et `.order_by_expr(...)` s'accumulent dans une liste unifiée, **dans l'ordre d'enregistrement**. `.replace_order_by(&[...])` efface tous les appels order-by précédents. `.flip_order_by()` inverse chaque direction ET échange `NullsOrder::First` ↔ `NullsOrder::Last` afin que la sémantique « les NULL restent du même côté » survive à une inversion (pour `First` / `Last` explicites ; le comportement par défaut du dialecte sous `Default` continue de suivre la direction).
+
+### Tri aléatoire
+
+Retournez les lignes dans un ordre aléatoire — le `.order_by('?')` de Django. Utilisez `.order_random()`. Il émet `ORDER BY RANDOM()` sur PG et SQLite, `ORDER BY RAND()` sur MySQL. Pratique pour la rotation de bannières, l'échantillonnage, ou l'attribution de buckets de test A/B sans charger les lignes côté application pour les mélanger.
+
+```rust
+// Three random posts.
+Post::objects()
+    .order_random()
+    .limit(3)
+    .fetch(&pool).await?;
+
+// Random tie-breaker after a primary sort: posts ordered by score
+// descending, with ties shuffled.
+Post::objects()
+    .order_by(&[("score", true)])
+    .order_random()
+    .fetch(&pool).await?;
+```
+
+La variante IR ne porte aucune direction ni clause NULLS : un tri aléatoire est non ordonné par définition, et la clé aléatoire est calculée par ligne (non NULL).
+
+**Avertissement de performance.** `ORDER BY RANDOM()` force un **balayage complet de la table + un tri en mémoire par une clé aléatoire par ligne**. Le planificateur de requêtes ne peut pas utiliser d'index. Pour des tables bien plus grandes que la mémoire, préférez le pattern compatible index :
+
+```rust
+// Coin-flip offset; range-scans the PK index.
+let max_id: i64 = Post::objects().max::<i64>("id", &pool).await?.unwrap_or(0);
+let offset = rand::random::<u32>() as i64 % max_id.max(1);
+Post::objects()
+    .where_(Post::id.gte(offset))
+    .order_by(&[("id", false)])
+    .limit(1)
+    .fetch(&pool).await?;
+```
+
+Le compromis : l'adjacence dans les lignes du résultat reflète l'adjacence des PK, ce n'est donc pas « uniformément aléatoire » au sens strict — mais c'est exempt du coût d'un balayage complet de table.
+
+### Pagination
+
+Récupérez une page de résultats à la fois. `.limit(size).offset(...)` est la forme simple par numéro de page ; la forme par curseur (« tout ce qui vient après le dernier id vu ») s'adapte mieux sur les grandes tables.
+
+```rust
+// Page-number — page 2 of 50-row pages = LIMIT 50 OFFSET 50.
+let page = Post::objects().limit(50).offset(50).fetch(&pool).await?;
+
+// Cursor (manual — no auto-next-token from QuerySet)
+let next = Post::objects()
+    .where_(Post::id.gt(last_id))
+    .order_by(&[("id", false)])
+    .limit(50)
+    .fetch(&pool).await?;
+```
+
+Pour la pagination par curseur côté HTTP, utilisez plutôt `ViewSet::cursor_pagination("id")`.
+
+### Récupérer des lignes dans une map
+
+Recherchez plusieurs lignes à partir d'une liste de valeurs et récupérez-les sous forme de `HashMap` indexée par cette colonne. C'est le `in_bulk(ids, field_name=)` de Django. Utilisez `.in_bulk(...)` pour « récupérer ces N lignes en un aller-retour, indexées par id ». Un `HashMap<K, V>` est le dictionnaire / la table de hachage de Rust.
+
+```rust
+use std::collections::HashMap;
+use rustango::sql::Auto;
+
+// Default Django shape: keyed by the Auto<i64> PK.
+let books: HashMap<i64, Book> = Book::objects()
+    .in_bulk(Book::id, [1_i64, 2, 3], |b| match b.id {
+        Auto::Set(v) => v,
+        Auto::Unset  => unreachable!("fetched row has Auto::Set PK"),
+    }, &pool)
+    .await?;
+assert_eq!(books[&1].title, "The Rust Programming Language");
+
+// `field_name=` equivalent — key by any unique column.
+let by_isbn: HashMap<String, Book> = Book::objects()
+    .in_bulk(Book::isbn, ["isbn-1".to_string()], |b| b.isbn.clone(), &pool)
+    .await?;
+```
+
+Se compose avec les filtres `.where_()` précédents — la liste `IN` est jointe par un AND avec le WHERE existant. Un `ids` vide court-circuite avec une map vide (aucun SQL n'est émis). La closure gère explicitement le déballage `Auto<T>` / `ForeignKey<T, K>`, donnant à l'appelant le contrôle sur la façon dont la clé se matérialise.
+
+Pendant cloisonnée par tenant : `in_bulk_on(column, ids, extract, &executor)` prend n'importe quel executor sqlx — à combiner avec `tenant.conn()` pour les tenants en mode schéma.
+
+### Verrouiller des lignes pour mise à jour
+
+Verrouillez les lignes sélectionnées afin qu'aucune autre transaction ne puisse les modifier avant votre commit — la manière standard de réserver du travail ou d'éviter les mises à jour perdues. C'est le `select_for_update(skip_locked=, nowait=, of=, no_key=)` de Django. Appelez `.select_for_update()` ; cela ajoute `SELECT … FOR UPDATE` (ou une variante) et le verrou dure pendant toute la transaction englobante.
+
+```rust
+// Canonical "claim next available row" pattern. Worker A grabs the
+// lowest-priority pending job; concurrent worker B with SKIP LOCKED
+// skips A's row and grabs the next instead — no blocking.
+let mut tx = pool.begin().await?;
+let claim: Vec<Job> = Job::objects()
+    .where_(Job::status.eq("pending"))
+    .order_by(&[("priority", false)])
+    .limit(1)
+    .select_for_update()
+    .skip_locked()
+    .fetch_on(&mut *tx).await?;
+// ... mark claim[0] as in-progress, do work ...
+tx.commit().await?;
+```
+
+**Méthodes du builder** — à chaîner pour les activer :
+
+- `.select_for_update()` — simple `FOR UPDATE`.
+- `.skip_locked()` — ajoute `SKIP LOCKED` ; les lignes détenues par une autre transaction sont silencieusement écartées au lieu de bloquer.
+- `.nowait()` — ajoute `NOWAIT` ; remonte immédiatement une erreur du driver si une ligne correspondante est verrouillée. Mutuellement exclusif avec `skip_locked` (le writer choisit le plus permissif, `SKIP LOCKED`, si les deux sont définis).
+- `.no_key()` — émet `FOR NO KEY UPDATE` à la place (PG 9.3+). Verrou plus faible qui ne bloque pas les écrivains touchant uniquement des colonnes non-clé.
+- `.of(&["table_or_alias", …])` — restreint le verrou à des tables spécifiques quand la requête fait des JOIN.
+
+Appeler `.skip_locked()` / `.nowait()` / `.no_key()` / `.of(…)` sans `.select_for_update()` préalable active implicitement le verrou, ce qui correspond à l'ergonomie de Django.
+
+**Comportement tri-dialecte :**
+
+| Dialecte | Comportement |
+|---|---|
+| PostgreSQL | Support complet — chaque flag émet sa syntaxe native. |
+| MySQL 8.0.1+ | Prend tout en charge sauf `NO KEY` — ce flag retombe sur le simple `FOR UPDATE` (le verrou le plus strict). |
+| SQLite | Aucune syntaxe de verrou au niveau ligne. Le writer n'émet aucune clause ; les transactions détiennent un verrou d'écriture implicite pour la base entière. Utilisez une autre stratégie pour SQLite (typiquement une boucle d'attente active sur la transaction elle-même). |
+
+**Doit s'exécuter dans une transaction.** `FOR UPDATE` hors transaction est un no-op sur PostgreSQL (la transaction implicite à instruction unique libère le verrou immédiatement) et une erreur sur MySQL. À combiner avec `pool.begin()` (ou `rustango::sql::atomic`).
+
+### Combiner des requêtes (union, intersection, différence)
+
+Fusionnez deux requêtes ou plus sur le même modèle avec les opérateurs d'ensemble SQL. Ce sont les `.union()`, `.intersection()` et `.difference()` de Django.
+
+```rust
+// Posts that are EITHER drafts OR currently in review.
+let inbox: Vec<Post> = Post::objects()
+    .where_(Post::status.eq("draft"))
+    .union(Post::objects().where_(Post::status.eq("review")))
+    .order_by(&[("created_at", true)])
+    .limit(50)
+    .fetch(&pool).await?;
+```
+
+**Méthodes du builder** :
+
+| Méthode | SQL | Sémantique |
+|---|---|---|
+| `.union(other)` | `UNION` | Combine + déduplique |
+| `.union_all(other)` | `UNION ALL` | Combine, conserve les doublons (moins coûteux, pas de passe DISTINCT) |
+| `.intersection(other)` | `INTERSECT` | Lignes présentes dans les DEUX querysets |
+| `.difference(other)` | `EXCEPT` | Lignes du premier queryset mais PAS des autres |
+
+Chaque méthode prend un `QuerySet<T>` — les deux branches doivent cibler le même modèle `T`, de sorte que la forme des colonnes correspond par construction (vérifié à la compilation grâce aux génériques de Rust). Les appels s'accumulent ; mélanger des opérateurs dans une même chaîne est autorisé (`a.union(b).intersection(c)` s'évalue de gauche à droite conformément à la norme SQL).
+
+**Les modificateurs externes s'appliquent au résultat fusionné** :
+
+```rust
+// Outer .order_by() / .limit() / .offset() / .select_for_update()
+// set AFTER the union apply to the combined resultset, NOT per-branch.
+let page: Vec<Post> = qs_a
+    .union(qs_b)
+    .union(qs_c)
+    .order_by(&[("id", false)])    // sorts the merged rows
+    .limit(20)                     // caps the merged count
+    .offset(40)                    // skips into the merged result
+    .fetch(&pool).await?;
+
+// Per-branch ORDER BY / LIMIT stay INSIDE the branch's parens:
+let mixed = qs_a
+    .union(qs_b.order_by(&[("id", true)]).limit(5))   // branch picks its top 5
+    .fetch(&pool).await?;
+```
+
+**Tri-dialecte** : PostgreSQL + SQLite prennent en charge les quatre opérateurs sur chaque version que **Rustango** supporte. MySQL 8.0+ prend en charge `UNION`/`UNION ALL` ; `INTERSECT`/`EXCEPT` sont arrivés dans MySQL 8.0.31. Les versions plus anciennes de MySQL font remonter l'erreur de syntaxe du driver au moment du fetch — il n'y a pas de garde côté client.
+
+**Chemin d'erreur sur le builder typé** : `.union(other_qs)` (ainsi que `.intersection()` / `.difference()`) compile la branche de manière eager et panique si la branche échoue à compiler (colonne mal orthographiée, etc.). Pour une composition faillible où l'appelant veut un `Result`, compilez d'abord la branche et passez-la via `.with_compound(SetOp::Union, branch)` — un point d'entrée générique unique couvre chaque opérateur. La forme de la panique correspond à celle de Django : une mauvaise branche est une erreur de programmation, pas une condition de données au runtime.
+
+### Streamer de grands ensembles de résultats
+
+Traitez une table volumineuse sans la charger entièrement en mémoire. C'est le `.iterator(chunk_size=2000)` de Django. Appelez `.iterator(chunk_size)` ; il récupère `chunk_size` lignes à la fois (via `LIMIT N OFFSET M`) et ne met jamais en tampon l'ensemble du résultat. À utiliser pour les exports de millions de lignes, les pipelines ETL, et les jobs batch.
+
+```rust
+// 1. Whole-chunk loop — process N rows at a time.
+let mut iter = Post::objects()
+    .where_(Post::published.eq(true))
+    .order_by(&[("id", false)])
+    .iterator(2_000)?;
+while let Some(chunk) = iter.next_chunk(&pool).await? {
+    for post in chunk { /* … */ }
+}
+
+// 2. Row-by-row loop — buffer one chunk internally, yield one row.
+let mut iter = Post::objects().order_by(&[("id", false)]).iterator(2_000)?;
+while let Some(post) = iter.next_row(&pool).await? {
+    /* … */
+}
+```
+
+**Définissez un `order_by`.** `OFFSET` sur une requête sans tri stable retourne des lignes imprévisibles d'un chunk à l'autre — typiquement `.order_by(&[("pk", false)])` afin que chaque chunk reprenne proprement. La méthode n'impose pas de tri (certaines requêtes veulent légitimement aucun tri, par exemple une vidange en une seule fois), mais itérer sans tri est un piège classique.
+
+**Compromis vs curseurs côté serveur.** C'est un simple découpeur par LIMIT/OFFSET. Sur une colonne de tri indexée par btree, PostgreSQL balaie les N premières lignes avant de retourner la (N+1)-ième — donc une pagination profonde coûte `O(n²)` au total. Pour une vidange de 10M de lignes, cela compte ; pour 100k lignes, généralement pas. Le découpeur l'emporte sur la portabilité (fonctionne sur tous les backends sans surcharge de transaction) et la simplicité (aucune gestion de cycle de vie de curseur). Pour une lecture réellement en streaming sur PG, passez par `pool.begin()` + l'API Stream `sqlx::query(...).fetch(&mut *tx)` en SQL brut directement — le protocole étendu streame depuis le serveur sans re-cherche par offset.
+
+**Mélanger `next_chunk` et `next_row` sur le même itérateur est sûr.** Le tampon interne `VecDeque` se vide dans l'ordre des lignes avant tout nouveau fetch en base, donc `next_chunk` après un `next_row` partiel retourne d'abord les lignes déjà en tampon, puis continue avec des chunks frais.
+
+`.rows_seen()` (compteur cumulé) et `.is_exhausted()` (indicateur de fin de vidange) sont tous deux disponibles pour le suivi de progression et les vérifications de terminaison.
+
+**Risque d'écriture concurrente.** Chaque chunk est une requête séparée, donc des lignes insérées/supprimées entre les chunks peuvent être ignorées ou dupliquées (le classique problème de « fenêtrage » de la pagination par OFFSET). Pour des tables en lecture seule / uniquement en ajout — le cas d'usage typique de l'export — ce n'est pas un problème. Pour des tables écrites de manière concurrente, il vous faut une transaction en isolation snapshot afin que chaque chunk voie la même vue. **`ChunkedIter` prend un `&Pool`, pas une `&mut Transaction`, donc l'API du découpeur ne peut pas être utilisée directement dans la transaction** — codez à la main le SELECT découpé contre la transaction :
+
+```rust
+let mut tx = pool.begin().await?;
+sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+    .execute(&mut *tx).await?;
+
+// Hand-loop LIMIT/OFFSET chunks against the tx with `.fetch_on(&mut *tx)`,
+// so every chunk reads from the same snapshot.
+let chunk_size = 2_000_i64;
+let mut offset = 0_i64;
+loop {
+    let rows: Vec<Post> = Post::objects()
+        .order_by(&[("id", false)])
+        .limit(chunk_size)
+        .offset(offset)
+        .fetch_on(&mut *tx)
+        .await?;
+    if rows.is_empty() { break; }
+    for post in &rows { /* … */ }
+    if (rows.len() as i64) < chunk_size { break; }
+    offset += rows.len() as i64;
+}
+tx.commit().await?;
+```
+
+**`select_for_update()` ne se propage pas d'un chunk à l'autre.** Les verrous de ligne détenus par `.select_for_update()` sont relâchés à la fin de la transaction implicite de chaque chunk. Il n'existe pas de correctif au niveau du découpeur : le builder `.iterator()` prend un `&Pool`, les variantes de verrouillage ont besoin d'une `&mut Transaction`, et les deux ne se combinent pas. Pour une vidange verrouillée, vous avez deux options, chacune avec un compromis :
+
+- **`.fetch_on(&mut *tx)` sur tout le résultat** — un seul aller-retour, un `Vec<T>` complet en mémoire. Correct quand le résultat tient en mémoire.
+- **LIMIT/OFFSET codé à la main dans la transaction** — même forme que l'extrait en isolation snapshot ci-dessus ; les chunks restent streamés mais vous êtes hors de l'API `ChunkedIter`.
+
+Un futur compagnon `iterator_on(&mut *tx, chunk_size)` (suivi d'issue) comblerait cet écart. Hors périmètre pour l'issue #23.
+
+**`chunk_size` doit être > 0.** Les valeurs nulles ou négatives paniquent. Choisissez une valeur adaptée à votre budget de taille de ligne (le défaut de Django est `2000` ; raisonnable pour des lignes étroites, plus bas pour de larges colonnes TEXT/JSONB).
+
+### Sélectionner des colonnes spécifiques
+
+Récupérez seulement quelques colonnes au lieu de structs `Post` entières — les `.values('col')` et `.values_list('col', flat=True)` de Django. Utilisez-les quand vous n'avez besoin que de quelques colonnes d'une table large, ou quand le résultat alimente du code dynamique (templates, export CSV, JSON). Vous récupérez des maps, des tuples, ou une liste typée plate au lieu d'instances de modèle.
+
+```rust
+use rustango::core::SqlValue;
+use std::collections::HashMap;
+
+// 1. Column-keyed map per row — Django's `.values('id', 'title')`.
+let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+    .where_(Post::published.eq(true))
+    .order_by(&[("id", false)])
+    .values_dict(&["id", "title"])
+    .fetch(&pool).await?;
+
+// 2. Ordered tuple per row — Django's `.values_list('id', 'title')`.
+//    Cell ordering matches the column-list argument.
+let rows: Vec<Vec<SqlValue>> = Post::objects()
+    .values_list(&["title", "id"])  // title first, id second
+    .fetch(&pool).await?;
+
+// 3. Single-column typed scalar — Django's `.values_list('id', flat=True)`.
+//    Returns Vec<U> directly via sqlx's typed scalar path.
+let ids: Vec<i64> = Post::objects()
+    .where_(Post::published.eq(true))
+    .values_list_flat("id")
+    .fetch::<i64>(&pool).await?;
+```
+
+**Trois builders, une seule IR.** Les trois définissent `SelectQuery::projection` sur la liste de colonnes validée — le SQL est identique dans les trois formes terminales ; seul le décodage des lignes diffère :
+
+| Builder | Forme SQL | Retourne |
+|---|---|---|
+| `.values_dict(&[cols])` | `SELECT col1, col2 FROM …` | `Vec<HashMap<String, SqlValue>>` |
+| `.values_list(&[cols])` | `SELECT col1, col2 FROM …` | `Vec<Vec<SqlValue>>` (ordonné selon `cols`) |
+| `.values_list_flat(col)` | `SELECT col FROM …` | `Vec<U>` (typé, via `fetch::<U>(...)`) |
+
+**Fonctionne avec le reste de la chaîne de requête.** `.where_()`, `.filter()`, `.order_by()`, `.limit()`, `.offset()`, et les opérateurs d'ensemble (`.union()` / `.intersection()` / `.difference()`) — toute méthode appelée AVANT `.values_*` est conservée. Les builders values sont terminaux (rien ne s'enchaîne après eux), donc définissez la forme de la requête d'abord, puis exécutez le fetch.
+
+**Validation au moment de `.compile()` / `.fetch()` :**
+- Liste de colonnes vide (`.values_dict(&[])`) → [`QueryError::EmptyValuesProjection`].
+- Nom de colonne mal orthographié (`.values_dict(&["nope"])`) → [`QueryError::UnknownField`].
+
+**Tri-dialecte : émission de la projection identique sur PG / MySQL / SQLite** (seul le guillemetage des identifiants diffère). Pour `.values_list_flat::<U>(...)`, `U` doit implémenter `Decode + Type` de sqlx sur chaque backend ciblé par le binaire ; les choix courants (`i64`, `i32`, `String`, `bool`, `f64`) fonctionnent universellement.
+
+**Pourquoi ne pas changer le `.values()` existant pour faire une projection pure ?** `QuerySet::values(cols)` est déjà promu vers [`AggregateBuilder`] pour le chemin d'auto-inférence de GROUP BY (issue #75). Le renommer casserait ~20 sites d'appel existants. La nouvelle chaîne de méthodes `.values_dict()` / `.values_list()` / `.values_list_flat()` se place à côté, en laissant le chemin d'agrégation intact. L'erreur préexistante `QueryError::ValuesRequiresAggregate` se déclenche toujours pour `.values(cols).compile()` sans `.annotate(...)` ultérieur — son message oriente désormais les appelants vers les nouvelles méthodes de projection pure.
+
+### Inclure ou exclure des colonnes
+
+Même idée que la section précédente, mais dans la forme include/exclude de Django : `.only('id', 'name')` ne conserve que les colonnes nommées, `.defer('big_field')` conserve tout sauf elles. Utilisez-les sur des tables larges où de grandes colonnes TEXT / BLOB / JSONB rendent les vues de liste coûteuses à lire :
+
+```rust
+// .only(...) — fetch only the named columns.
+let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+    .where_(Post::published.eq(true))
+    .only(&["id", "title"])
+    .fetch(&pool).await?;
+
+// .defer(...) — fetch everything except the named columns.
+// Useful for "list view: skip body / metadata / large JSON".
+let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+    .defer(&["body", "raw_html"])
+    .fetch(&pool).await?;
+```
+
+**Sémantique** : `.only(&[cols])` est un synonyme de `.values_dict(cols)` — même IR, même forme de retour, point d'entrée séparé pour une lisibilité de forme Django. `.defer(&[cols])` calcule le complément par rapport au schéma du modèle (chaque colonne scalaire du modèle SAUF celles listées) et route vers le même chemin.
+
+**Avertissement — le type de retour diffère de Django.** Les `.only()` / `.defer()` de Django retournent des instances de `Model` partiellement hydratées où les champs différés se chargent paresseusement à l'accès à l'attribut. **Rustango** n'a pas d'équivalent à la magie des descripteurs de Python ; la forme de retour est `Vec<HashMap<String, SqlValue>>` (ou `Vec<Vec<SqlValue>>` si vous substituez `.values_list(...)` à la place). Le décodage de ligne partielle typé est prévu pour une future itération.
+
+**Sécurité vis-à-vis des fautes de frappe** : `.defer(&["nope_col"])` fait remonter `QueryError::UnknownField` au moment de `.compile()` — la faute de frappe ne se transforme pas silencieusement en « projeter toutes les colonnes ». `.only(&[])` fait remonter `QueryError::EmptyValuesProjection` ; `.defer(&[])` est un no-op sémantique (projette chaque colonne).
+
+### Filtrer avec des expressions régulières
+
+Comparez une colonne à un motif regex — les `__regex` / `__iregex` de Django. `.regex()` est sensible à la casse, `.iregex()` insensible à la casse, et `.not_regex()` / `.not_iregex()` en sont les formes négées.
+
+```rust
+use rustango::core::Column as _;
+
+// Names starting with "al" (case-sensitive).
+User::objects()
+    .where_(User::name.regex("^al.*"))
+    .fetch(&pool).await?;
+
+// Names starting with "al" — case-insensitive.
+User::objects()
+    .where_(User::name.iregex("^al.*"))
+    .fetch(&pool).await?;
+
+// Negated: exclude names starting with "admin" (case-sensitive).
+User::objects()
+    .where_(User::name.not_regex("^admin"))
+    .fetch(&pool).await?;
+
+// Django-shape lookup-suffix form.
+User::objects()
+    .filter("name__iregex", "^bob")
+    .fetch(&pool).await?;
+```
+
+**Émission tri-dialecte** :
+
+| Dialecte | Sensible à la casse | Insensible à la casse | Notes |
+|---|---|---|---|
+| PostgreSQL | `<col> ~ ?` / `<col> !~ ?` | `<col> ~* ?` / `<col> !~* ?` | Opérateurs POSIX natifs |
+| MySQL | `` `col` REGEXP ? `` / `` `col` NOT REGEXP ? `` | `LOWER(`col`) REGEXP LOWER(?)` (la forme négée enveloppe avec `NOT`) | Repli via LOWER() pour `i*` |
+| SQLite | `"col" REGEXP ?` / `"col" NOT REGEXP ?` | `LOWER("col") REGEXP LOWER(?)` (la forme négée enveloppe avec `NOT`) | Nécessite la fonction utilisateur `regexp` chargée sur la connexion |
+
+**SQLite exige une fonction utilisateur `regexp` enregistrée** — elle n'est pas intégrée. sqlx-sqlite 0.8 n'en enregistre **pas** une par défaut. Deux façons de l'activer :
+
+1. **Simple** — activez la feature cargo `regexp` de sqlx-sqlite, puis activez-la sur la connexion :
+   ```rust
+   use sqlx::sqlite::SqliteConnectOptions;
+   let opts = SqliteConnectOptions::new()
+       .filename("app.db")
+       .with_regexp();  // gated on sqlx-sqlite/regexp
+   ```
+2. **Manuelle** — enregistrez une closure Rust via `SqliteConnection::lock_handle()` + FFI brut (`sqlite3_create_function_v2`).
+
+Sans cela, la requête émet du SQL `REGEXP` valide que SQLite rejette à l'exécution avec `no such function: regexp` (propre à l'analyse syntaxique — `tests/regex_sqlite_live.rs` fixe ce comportement).
+
+**Le dialecte du motif diffère selon les backends.** PostgreSQL utilise les regex POSIX étendues ; MySQL utilise des regex basées sur ICU avec sa propre saveur ; SQLite délègue à ce que la fonction utilisateur implémente (typiquement la crate `regex` de Rust). Les motifs qui s'appuient sur une syntaxe spécifique à un dialecte (par exemple les frontières de mots `\m` / `\M` de PG) ne se transposent pas d'un dialecte à l'autre — restez sur le sous-ensemble portable (`^`, `$`, `.`, `*`, `+`, `?`, `[...]`, `()`, `|`) si le même modèle est interrogé depuis plusieurs backends.
+
+**Les valeurs non-chaîne sont rejetées au moment de `.compile()`** — passer `SqlValue::I64(42)` à `__regex` fait remonter `QueryError::InvalidLookupValue { suffix: "regex", expected: "SqlValue::String(<regex pattern>)", … }` plutôt qu'une conversion silencieuse.
+
+---
+
+## Valeurs calculées & fonctions de base de données
+
+Laissez la base de données calculer les choses au lieu de charger des lignes dans l'application, les modifier, puis les réécrire. `F("col")` référence une colonne par son nom (l'objet `F()` de Django), et les builders `funcs::*` enveloppent des fonctions SQL scalaires comme `LOWER` ou `COALESCE`. Ensemble, ils débloquent trois patterns que le simple `.set()` / `.where_()` basé sur des valeurs ne peut pas exprimer :
+
+### Incréments atomiques (pas de race lecture-modification-écriture)
+
+Le bug classique de compteur — récupérer une ligne, incrémenter un champ, sauvegarder — perd des mises à jour quand deux requêtes s'exécutent en même temps. `F("col") + 1` réduit l'aller-retour à un seul `UPDATE`, de sorte que la base détient le verrou de ligne pour vous :
+
+```rust
+use rustango::core::F;
+
+Post::objects()
+    .eq("id", post_id)
+    .update()
+    .set_expr("view_count", F("view_count") + 1_i64)
+    .execute(&pool).await?;
+```
+
+Tri-dialecte : émet `views = ("views" + $1)` sur PG, ``views = (`views` + ?)`` sur MySQL, identique sur SQLite. L'arithmétique est parenthésée afin que les opérations imbriquées restent non ambiguës : `F("a") + F("b") * 2`.
+
+Opérateurs pris en charge : `+ - * / %` plus `& | ^ << >>` (opérations sur bits ; le XOR sur SQLite émet une erreur claire `OpNotSupportedInDialect` puisque SQLite n'a pas de symbole XOR).
+
+### Comparer deux colonnes dans un filtre
+
+Filtrez une colonne par rapport à une autre, pas par rapport à un littéral — par exemple `Reservation start_date < end_date` pour vérifier la cohérence d'une ligne, ou `Inventory available > reserved` pour trouver les lignes disposant de capacité :
+
+```rust
+use rustango::core::Column as _;
+
+// `start_date < end_date` for every selected row.
+let valid = Reservation::objects()
+    .where_(Reservation::start_date.lt_expr(F("end_date")))
+    .fetch(&pool).await?;
+
+// Combine with literal predicates.
+let oversold = Inventory::objects()
+    .where_(Inventory::available.lt_expr(F("reserved")))
+    .where_(Inventory::active.eq(true))
+    .fetch(&pool).await?;
+```
+
+La famille `*_expr` — `eq_expr`, `ne_expr`, `lt_expr`, `lte_expr`, `gt_expr`, `gte_expr` — reflète les méthodes littérales `eq`, `ne`, … mais accepte n'importe quel `impl Into<Expr>` sur le côté droit : des références de colonne nues (`F("col")`), de l'arithmétique (`F("price") * 2`), ou des résultats de fonction (section suivante).
+
+### Fonctions scalaires — texte, mathématiques, gestion des NULL
+
+`rustango::core::funcs` fournit des builders pour les fonctions SQL les plus utilisées. Les 17 disponibles à ce jour :
+
+| Groupe | Builders |
+|---|---|
+| **Texte** | `lower`, `upper`, `length`, `trim`, `ltrim`, `rtrim`, `concat`, `substr`, `replace` |
+| **Mathématiques** | `abs`, `ceil`, `floor`, `round` (1 argument) / `round_to` (2 arguments, précision) |
+| **NULL** | `coalesce`, `greatest`, `least`, `nullif` |
+
+```rust
+use rustango::core::funcs::{lower, upper, concat, coalesce, trim, abs, round};
+use rustango::core::F;
+
+// Normalize on write.
+User::objects()
+    .eq("id", id)
+    .update()
+    .set_expr("email", lower(trim(F("email"))))
+    .execute(&pool).await?;
+
+// Build a derived column from two FKs + a literal.
+User::objects()
+    .update()
+    .set_expr(
+        "display_name",
+        concat([F("first").into(), " ".into(), F("last").into()]),
+    )
+    .execute(&pool).await?;
+
+// First non-NULL fallback.
+User::objects()
+    .update()
+    .set_expr(
+        "label",
+        coalesce([F("nickname").into(), F("username").into(), "anonymous".into()]),
+    )
+    .execute(&pool).await?;
+
+// Function on the WHERE rhs.
+User::objects()
+    .where_(User::email_norm.eq_expr(lower(F("email_norm"))))
+    .fetch(&pool).await?;
+
+// Functions compose freely — `abs(round(F("score") * 100))` is one Expr.
+Player::objects()
+    .update()
+    .set_expr("score_int", abs(round(F("score") * 100_f64)))
+    .execute(&pool).await?;
+```
+
+### Comportement tri-dialecte
+
+La plupart des fonctions émettent un SQL identique sur PG / MySQL / SQLite. Les formes divergentes sont gérées par dialecte, de manière transparente :
+
+| Builder | PG | MySQL | SQLite |
+|---|---|---|---|
+| `concat([a, b])` | `CONCAT(a, b)` | `CONCAT(a, b)` | `(a \|\| b)` |
+| `substr(s, 1, 3)` | `SUBSTRING(s FROM 1 FOR 3)` | `SUBSTRING(s, 1, 3)` | `SUBSTR(s, 1, 3)` |
+| `greatest([a, b])` | `GREATEST(a, b)` | `GREATEST(a, b)` | `MAX(a, b)` scalaire |
+| `least([a, b])` | `LEAST(a, b)` | `LEAST(a, b)` | `MIN(a, b)` scalaire |
+
+### Passer des arguments mixtes à une fonction
+
+Les fonctions qui prennent une liste d'arguments (comme `concat`) acceptent n'importe quel itérable d'`Expr`. Les tableaux Rust doivent contenir un seul type, donc un mélange de `F` (colonne) et `&str` (littéral) ne compile pas tel quel — appelez `.into()` une fois par élément pour élever chacun en `Expr` :
+
+```rust
+concat([F("first").into(), " ".into(), F("last").into()])
+//          ^^^^^^ each element lifted to Expr
+```
+
+Ou construisez un `Vec<Expr>` et passez-le directement — même forme, même résultat.
+
+### Avertissements
+
+- **`length` octets-vs-caractères** : PG retourne des caractères sur `TEXT`/`VARCHAR`, MySQL retourne des **octets** (utilisez le futur builder `CharLength` du framework ou enveloppez manuellement dans `CHAR_LENGTH` si vous avez besoin de comptages de caractères multi-dialecte).
+- **`round(x, n)` sur PG** : la forme à 2 arguments de PG exige un `numeric`, pas un `double`. Passez soit une colonne entière, soit convertissez d'abord le float ; MySQL et SQLite acceptent les deux types.
+- **`greatest([single_arg])` / `least([single_arg])` sur SQLite** : non pris en charge — le `MAX(x)` à un seul argument de SQLite est la forme *agrégat*, pas la forme scalaire. Le writer retourne `OpNotSupportedInDialect`. PG et MySQL acceptent la forme à un seul argument comme un no-op retournant `x`. Enveloppez avec au moins un littéral pour rester portable.
+- **`substr` avec un début négatif** : PG traite un négatif comme « commencer à la position de caractère N » (avec un effet de clamp à 0) ; MySQL et SQLite traitent un négatif comme « compter depuis la fin ». Évitez les débuts négatifs dans du code portable.
+
+### Fonctions de date & heure
+
+Les builders `now()`, `extract_*` et `trunc_*` fonctionnent sur les dates et timestamps. Utilisez-les pour les requêtes de cohortes, les agrégats par tranche temporelle, et l'estampillage de l'heure courante à l'écriture — tout cela dans la base de données, sans faire d'aller-retour de lignes vers l'application.
+
+```rust
+use rustango::core::funcs::{
+    now, trunc_date, trunc_month,
+    extract_year, extract_month, extract_weekday,
+};
+use rustango::core::F;
+
+// 1. Stamp server-side current time on write.
+Post::objects()
+    .eq("id", id)
+    .update()
+    .set_expr("published_at", now())
+    .execute(&pool).await?;
+
+// 2. Extract year / month / weekday into denormalized indexable
+// columns so cohort + day-of-week queries are cheap.
+Signup::objects()
+    .update()
+    .set_expr("bucket_year", extract_year(F("created_at")))
+    .set_expr("bucket_month", extract_month(F("created_at")))
+    .set_expr("weekday", extract_weekday(F("created_at")))
+    .execute(&pool).await?;
+
+// 3. Filter on the stored bucket — typed integer comparison, uses
+// the index, portable across all three dialects.
+let friday_signups = Signup::objects()
+    .where_(Signup::weekday.eq(5_i64))            // 5 = Friday (0=Sun)
+    .fetch(&pool).await?;
+
+// 4. For range filters where you'd be tempted to write
+// `created_at >= trunc_year(now())` directly: don't. The function
+// builders for `Trunc*` return text on MySQL/SQLite (see caveats
+// below), so a column-vs-trunc comparison in WHERE only behaves
+// well on PG. Compute the boundary in Rust instead and pass it as a
+// typed literal — works the same on every backend and uses the
+// index on `created_at`:
+use chrono::{Datelike, TimeZone};
+let this_year = chrono::Utc::now().year();
+let year_start = chrono::Utc.with_ymd_and_hms(this_year, 1, 1, 0, 0, 0).unwrap();
+
+let recent = Order::objects()
+    .where_(Order::created_at.gte(year_start))
+    .fetch(&pool).await?;
+
+// 5. `Trunc*` shines on the *write* side. `trunc_date` is the
+// one trunc-family builder with identical SQL on every dialect
+// (`DATE(x)`) — handy for grouping by day without the type-divergence
+// caveat the year/month variants carry.
+Order::objects()
+    .update()
+    .set_expr("day_bucket", trunc_date(F("created_at")))     // DATE column on every backend
+    .set_expr("month_bucket", trunc_month(F("created_at")))  // see caveat
+    .execute(&pool).await?;
+// `month_bucket` should be `TIMESTAMPTZ` on PG and `VARCHAR(10)` /
+// `TEXT` on MySQL/SQLite — parse client-side when reading if you
+// need a typed `chrono::NaiveDate`.
+```
+
+**Émission par dialecte :**
+
+| Builder | PG | MySQL | SQLite |
+|---|---|---|---|
+| `now()` | `NOW()` | `NOW()` | `CURRENT_TIMESTAMP` |
+| `extract_year(x)` | `CAST(EXTRACT(YEAR FROM x) AS INTEGER)` | `YEAR(x)` | `CAST(strftime('%Y', x) AS INTEGER)` |
+| `extract_week(x)` ⚠ | `EXTRACT(WEEK FROM x)` — ISO 8601, plage 1–53 | `WEEK(x)` — début dimanche, plage **0**–53 | `strftime('%W', x)` — début lundi, plage 00–53 |
+| `extract_weekday(x)` | `CAST(EXTRACT(DOW FROM x) AS INTEGER)` | `(DAYOFWEEK(x) - 1)` | `CAST(strftime('%w', x) AS INTEGER)` |
+| `extract_quarter(x)` | `EXTRACT(QUARTER FROM x)` | `QUARTER(x)` | **non pris en charge** — erreur |
+| `trunc_date(x)` | `DATE(x)` | `DATE(x)` | `DATE(x)` |
+| `trunc_year(x)` | `DATE_TRUNC('year', x)` → timestamp | `DATE_FORMAT(x, '%Y-01-01')` → **chaîne** | `strftime('%Y-01-01', x)` → **chaîne** |
+| `trunc_month(x)` | `DATE_TRUNC('month', x)` → timestamp | `DATE_FORMAT(x, '%Y-%m-01')` → **chaîne** | `strftime('%Y-%m-01', x)` → **chaîne** |
+| `trunc_day(x)` | `DATE_TRUNC('day', x)` → timestamp | `DATE(x)` → date | `date(x)` → texte |
+
+**Avertissements spécifiques aux dates/heures :**
+
+- **Le type de retour de `trunc_year/month` diverge** : timestamp sur PG, texte sur MySQL/SQLite. Effectuez la conversion côté application à la lecture si vous avez besoin d'un `chrono::NaiveDate` typé — ou stockez le bucket comme un simple entier (`extract_year` + `extract_month`) et reconstruisez-le dans le code.
+- **`extract_weekday` est normalisé à 0 = dimanche** sur les trois dialectes. Le `DAYOFWEEK()` natif de MySQL retourne 1=dimanche, donc le writer soustrait 1.
+- **⚠ `extract_week` n'est PAS portable.** PG retourne des numéros de semaine ISO 8601 (début lundi, plage 1–53) ; le `WEEK(x)` par défaut de MySQL débute le dimanche avec une plage **0**–53 ; le `strftime('%W')` de SQLite débute le lundi avec une plage 00–53. Pour le 2024-01-01 (un lundi), les trois backends retournent respectivement `1`, `0` et `01`. Le code mono-backend peut l'utiliser librement ; le code multi-dialecte devrait calculer la limite de semaine comme un `chrono::DateTime` typé en Rust et filtrer sur la colonne timestamp à la place.
+- **`extract_quarter` génère une erreur sur SQLite** avec `OpNotSupportedInDialect` — SQLite n'a pas de jeton trimestre natif. Soit protégez la fonctionnalité derrière `cfg(not(sqlite))`, soit calculez via `((extract_month - 1) / 3) + 1` côté application.
+- **Gestion des fuseaux horaires** : `EXTRACT` de PG opère dans le fuseau horaire de la colonne ; `YEAR()` de MySQL opère dans le fuseau horaire de la session (`SET time_zone = ...`) ; SQLite n'a pas de vrai support de fuseau horaire — traitez tout comme UTC. Utilisez `TIMESTAMPTZ` sur PG, `DATETIME` sur MySQL avec le fuseau horaire de session défini, des chaînes ISO-8601 sur SQLite.
+
+### Expressions CASE WHEN
+
+Construisez un `CASE WHEN … THEN … ELSE … END` SQL avec les builders `case()` / `.when()` / `value()` — le `Case`/`When` de Django. Utilisez-le pour des tris personnalisés, des colonnes dérivées dans `annotate`, des valeurs par défaut calculées dans `update`, et (combiné avec `Sum`) des agrégats conditionnels.
+
+```rust
+use rustango::core::case::{case, value};
+use rustango::core::{Column as _, F};
+use rustango::core::funcs::lower;
+
+// Custom ordering — published posts first, drafts last.
+Post::objects()
+    .update()
+    .set_expr(
+        "priority",
+        case()
+            .when(Post::status.eq("published"), 0_i64)
+            .when(Post::status.eq("review"), 1_i64)
+            .when(Post::status.eq("draft"), 2_i64)
+            .default(99_i64),
+    )
+    .execute(&pool).await?;
+
+let ordered = Post::objects()
+    .order_by(&[("priority", false), ("id", false)])
+    .fetch(&pool).await?;
+
+// Computed default on update — drafts get a lowercased title for
+// the label, everything else uses the title verbatim.
+Post::objects()
+    .update()
+    .set_expr(
+        "label",
+        case()
+            .when(Post::status.eq("draft"), lower(F("title")))
+            .default(F("title")),
+    )
+    .execute(&pool).await?;
+
+// AND / OR composition in the WHEN predicate.
+let viral = Post::status.eq("published").and(Post::views.gt(1_000_i64));
+Post::objects()
+    .update()
+    .set_expr(
+        "label",
+        case()
+            .when(viral, value("viral"))
+            .when(Post::status.eq("published"), value("live"))
+            .default(value("pending")),
+    )
+    .execute(&pool).await?;
+```
+
+**Forme du builder :**
+
+- `case()` — démarre un builder.
+- `.when(condition, then)` — ajoute une branche. `condition` est n'importe quoi implémentant `Into<WhereExpr>` (typiquement `Column::eq()`, `.and()`, `.or()`) ; `then` est n'importe quoi implémentant `Into<Expr>` (littéral, `F()`, appel de fonction, `case()` imbriqué).
+- `.default(expr)` — définit la branche `ELSE` optionnelle. L'omettre produit un `CASE` qui retourne `NULL` pour les lignes non appariées (norme SQL).
+- `.build()` ou `.into()` — finalise en un `Expr` pour `set_expr` / `eq_expr` / `annotate`.
+- `value(literal)` — sucre syntaxique de style Django pour `Expr::Literal(...)`. Optionnel — les littéraux nus se convertissent via `Into<Expr>`, mais `value("…")` se lit explicitement comme « c'est un littéral chaîne, pas une référence de colonne ».
+
+**Émission tri-dialecte :**
+
+`CASE WHEN … THEN … [ELSE …] END` fait partie de la norme SQL-92 — émis de manière identique sur PG, MySQL et SQLite. Aucune répartition par dialecte dans le writer.
+
+**Avertissements :**
+
+- **Branches vides** : `case().build()` sans appel `.when(...)` est rejeté à l'émission avec `SqlError::EmptyCaseBranches`. SQL exige au moins une clause `WHEN`. Une condition `WHEN` vide (par exemple `WhereExpr::And(vec![])`) est rejetée avec `SqlError::EmptyCaseWhenCondition` pour la même raison.
+- **Unification des types entre branches** : chaque dialecte choisit un type commun à partir des valeurs `THEN` et `ELSE`. Mélanger les types (`THEN 1_i64` + `ELSE "string"`) peut lever une erreur de conversion au runtime ou coercer de manière surprenante. Restez sur un seul type par `CASE`.
+- **Performance** : chaque ligne évalue les prédicats `WHEN` dans l'ordre jusqu'à ce qu'un corresponde (premier qui correspond gagne, par ligne). Le coût croît avec le nombre de branches et le coût des prédicats. Pour de nombreuses correspondances de chaînes fixes, une jointure avec une petite table de correspondance peut être moins coûteuse et plus lisible.
+
+### Sous-requêtes (EXISTS, IN, scalaire)
+
+Intégrez une requête dans une autre — les `Exists`, `Subquery` et `OuterRef` de Django. Ces builders couvrent la plupart des patterns « existe-t-il au moins une ligne liée ? » et « cette valeur est-elle dans cet ensemble ? » :
+
+| Builder | Forme | À utiliser pour |
+|---|---|---|
+| `exists(qs)` | `EXISTS (SELECT … FROM …)` | « Auteurs ayant au moins un livre » |
+| `not_exists(qs)` | `NOT EXISTS (SELECT …)` | « Auteurs sans aucun livre » (anti-jointure) |
+| `in_subquery(col, qs)` | `<col> IN (SELECT …)` | « Posts dans n'importe quelle catégorie publique » |
+| `not_in_subquery(col, qs)` | `<col> NOT IN (SELECT …)` | Inverse du précédent |
+| `subquery(qs)` | `(SELECT …)` en tant que scalaire | Valeur par défaut calculée dans `set_expr` |
+| `outer_ref(col)` | `"<outer_table>"."<col>"` | Référencer la ligne externe depuis l'intérieur de l'un des éléments ci-dessus |
+
+```rust
+use rustango::core::subquery::{exists, not_exists, in_subquery, outer_ref};
+use rustango::core::{Column as _, WhereExpr};
+
+// "Authors with no books" — the canonical anti-join. Build the inner
+// queryset first so its compile() catches typos; embed via not_exists.
+let no_books = Book::objects()
+    .where_(Book::author_id.eq_expr(outer_ref("id")))
+    .compile()?;
+let orphans = Author::objects()
+    .where_raw(not_exists(no_books))
+    .fetch(&pool).await?;
+
+// "Authors who have a published book of more than 100 pages" — the
+// inner predicate combines a correlation (outer_ref) with literal
+// filters in the same WHERE.
+let inner = Book::objects()
+    .where_(Book::author_id.eq_expr(outer_ref("id")))
+    .where_(Book::status.eq("published"))
+    .where_(Book::pages.gt(100_i64))
+    .compile()?;
+let long_writers = Author::objects()
+    .where_raw(exists(inner))
+    .fetch(&pool).await?;
+
+// Compose EXISTS with an OR.
+let inner = Book::objects()
+    .where_(Book::author_id.eq_expr(outer_ref("id")))
+    .compile()?;
+let featured = Author::objects()
+    .where_raw(WhereExpr::Or(vec![
+        Author::name.eq("Carol").into(),
+        exists(inner),
+    ]))
+    .fetch(&pool).await?;
+```
+
+**La corrélation imbriquée fonctionne.** Un OuterRef à l'intérieur d'une sous-requête doublement imbriquée se résout vers la portée englobante *immédiate* — le writer maintient une pile de portées au fur et à mesure qu'il descend, donc `EXISTS (Book WHERE id = outer.id AND EXISTS (Comment WHERE book_id = outer.id))` résout le `outer.id` interne vers `Book.id`, pas vers le `Author.id` le plus externe. Utilisez `outer_ref(...)` deux fois si vous avez réellement besoin d'atteindre deux portées plus haut.
+
+**Erreurs :**
+
+- **`OuterRefOutsideSubquery`** — émettre `outer_ref("col")` au niveau supérieur (pas à l'intérieur d'un wrapper de sous-requête) est une erreur de programmation. Le writer la signale bruyamment avec le nom de la colonne pour repérer facilement le site d'appel.
+
+**Avertissements :**
+
+- **Restriction de projection pour `IN (SELECT …)`** : PG exige strictement que le SELECT interne projette exactement une colonne pour la forme `<col> IN (…)`. **Rustango** ne fournit pas encore de restriction de projection de type `.values("col")` (issue #62), donc le queryset interne projette toujours chaque colonne du modèle — ce qui fait que `in_subquery` ne fonctionne aujourd'hui qu'avec des tables dont le modèle n'a qu'une seule colonne. Pour le cas multi-colonnes, utilisez plutôt `exists(inner.where_(<outer col>.eq_expr(outer_ref(...))))` — cela a la même sémantique et ne dépend pas de la forme de projection.
+- **Le `subquery(...)` scalaire exige un interne à une colonne-une ligne** : le SQL émis est `SET col = (SELECT …)` — si l'interne produit plus d'une ligne, la base lève une erreur au runtime. Contraignez via `.limit(1)` et soit restreignez la projection (une fois disponible), soit concevez l'interne autour d'un invariant d'unicité.
+- **La validation à la compilation des sous-requêtes vit sur le queryset interne** : les fautes de frappe sur les colonnes remontent à l'appel `queryset.compile()?` interne, pas à `compile()` de la requête externe. Construisez d'abord l'interne et propagez `?`.
+
+### Quand passer au SQL brut à la place
+
+Les builders ci-dessus couvrent les cas courants. Pour ce qu'ils n'expriment pas encore — `Cast`, la recherche plein texte, les opérateurs de chemin JSON, les fonctions de hachage, la trigonométrie, les fonctions fenêtrées — voir la section [Échappatoire SQL brut](#raw-sql-escape-hatch) ci-dessous, ou attendez les issues de suivi qui étendent le même arbre d'expressions.
+
+---
+
+## Agrégations
+
+Comptez, sommez, moyennez, et groupez des lignes. `.count()`, `.sum()`, `.avg()`, `.min()` et `.max()` retournent un seul nombre ; `.annotate(...)` combiné avec `.values(...)` construit des requêtes GROUP BY (l'`aggregate` / `annotate` de Django). Les résultats d'agrégation reviennent sous forme de `Vec<HashMap<String, SqlValue>>` plutôt que de structs typées, car la forme est dynamique.
+
+```rust
+use rustango::sql::CounterPool as _;
+
+// COUNT
+let n = Post::objects()
+    .where_(Post::status.eq("published"))
+    .count(&pool).await?;
+
+// SUM / AVG / MIN / MAX — string column name; each returns Option<U>
+// (None when the filtered result set is empty).
+let total_views = Post::objects().sum::<i64>("view_count", &pool).await?;
+let avg_views = Post::objects().avg::<f64>("view_count", &pool).await?;
+let max_views = Post::objects().max::<i64>("view_count", &pool).await?;
+
+// Annotate + GROUP BY (issue #75 — Django-shape auto-inference)
+use rustango::core::aggregates::{count_all, sum};
+
+// "Posts per author" — `.values()` lists the GROUP BY columns.
+let by_author = Sale::objects()
+    .values(&["author_id"])
+    .annotate("n", count_all().into())
+    .compile()?;
+let rows = rustango::sql::fetch_aggregate_dict(&pool, &by_author).await?;
+// rows: Vec<HashMap<String, SqlValue>> — { author_id: 1, n: 3 }, …
+```
+
+### Comment le GROUP BY est inféré
+
+Vous n'avez presque jamais besoin d'écrire vous-même `GROUP BY` — **Rustango** l'infère à partir de la forme de la requête, tout comme Django. Vous n'appelez `.group_by(...)` que pour surcharger cette inférence. Le tableau montre ce que chaque forme produit :
+
+| Forme | Builder | `GROUP BY` résultant |
+|---|---|---|
+| **2 — values + agrégat** | `.values(&["author_id"]).annotate("n", count_all().into())` | `GROUP BY "author_id"` |
+| **3 — agrégat nu** | `.annotate("n", count_all().into())` | `GROUP BY` chaque colonne scalaire non agrégée du modèle |
+| **Fenêtré uniquement** | `.aggregate().annotate("rn", row_number()…)` | (pas de `GROUP BY` — les fonctions fenêtrées sont par ligne) |
+| **Surcharge explicite** | `.aggregate().group_by("month").annotate(...)` | `GROUP BY "month"` — l'explicite gagne |
+
+Le classificateur `AggregateExpr::is_aggregating()` distingue les variantes qui réduisent les lignes (`Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` / `StdDev*` / `Variance*` — plus les wrappers récursifs `Filtered` / `Coalesced`) de `Window`, qui est par ligne. Seules les variantes agrégeantes déclenchent l'inférence de la Forme 3.
+
+```rust
+use rustango::core::aggregates::{count_all, sum};
+
+// Shape 2 — "monthly revenue per author".
+Sale::objects()
+    .where_(Sale::status.eq("paid"))
+    .values(&["author_id", "month"])
+    .annotate("total", sum("amount").into())
+    .compile()?;
+// → SELECT "author_id", "month", SUM("amount")::bigint AS "total"
+//   FROM "sale" WHERE "status" = $1
+//   GROUP BY "author_id", "month"
+
+// Shape 3 — a bare .annotate() with no .values(): rustango adds every
+// non-aggregate scalar column of the model to the GROUP BY.
+Post::objects()
+    .annotate("n", count_all().into())
+    .compile()?;
+// → SELECT <every Post column>, COUNT(*) AS "n"
+//   FROM "post" GROUP BY <every Post column>
+```
+
+**Avertissement sur la projection pure.** `.values(cols)` *seul* (sans annotation d'agrégat) n'est **pas** pris en charge en v0.40 — `compile()` retourne `QueryError::ValuesRequiresAggregate`. La projection pure sous forme de dicts nécessite un chemin de writer séparé (c'est un SELECT sans GROUP BY, décodé en `Vec<HashMap>`) et est prévue pour un suivi. Pour l'instant, utilisez le `QuerySet::fetch(...)` typé pour lire des lignes entières.
+
+### Agrégats conditionnels & statistiques
+
+Comptez ou sommez seulement les lignes qui correspondent à une condition, fournissez une valeur de repli pour les résultats vides, et calculez l'écart-type / la variance. Ils reflètent le `Count('id', filter=...)`, le `Sum('price', default=0)` et le `StdDev` de Django. Enchaînez `.filter(...)` et `.default(...)` sur n'importe quel builder d'agrégat.
+
+```rust
+use rustango::core::aggregates::{avg, count, count_all, stddev, sum};
+use rustango::core::Column as _;
+
+let rows = Post::objects()
+    .aggregate()
+    // COUNT(*) FILTER (WHERE is_active AND status = 'published')
+    .annotate(
+        "active_published",
+        count_all()
+            .filter(Post::is_active.eq(true).and(Post::status.eq("published")))
+            .into(),
+    )
+    // COALESCE(SUM(price) FILTER (WHERE status = 'published'), 0)
+    //   — returns 0 instead of NULL when the queryset is empty.
+    .annotate(
+        "revenue_or_zero",
+        sum("price")
+            .filter(Post::status.eq("published"))
+            .default(0_i64)
+            .into(),
+    )
+    .annotate("avg_pages", avg("pages").into())
+    .annotate("page_stddev", stddev("pages").into())
+    .compile()?;
+let result = rustango::sql::fetch_aggregate_dict(&pool, &rows).await?;
+```
+
+**Builders** dans `rustango::core::aggregates` :
+
+| Builder | SQL |
+|---|---|
+| `count(col)` | `COUNT(col)` |
+| `count_all()` | `COUNT(*)` |
+| `count_distinct(col)` | `COUNT(DISTINCT col)` |
+| `sum(col)` / `avg(col)` / `max(col)` / `min(col)` | l'habituel |
+| `stddev(col)` / `stddev_pop(col)` | `STDDEV_SAMP` / `STDDEV_POP` |
+| `variance(col)` / `variance_pop(col)` | `VAR_SAMP` / `VAR_POP` |
+
+Chacun retourne un `AggregateBuilder` avec deux modificateurs chaînables :
+
+- `.filter(predicate)` — enveloppe dans `FILTER (WHERE predicate)`. Le prédicat est n'importe quel `WhereExpr` (typé via `.eq()` / `.and()` / brut via `WhereExpr::Or(...)`), il se compose donc comme un WHERE normal.
+- `.default(value)` — enveloppe dans `COALESCE(..., value)` afin qu'un queryset vide retourne la valeur par défaut au lieu de `NULL`.
+
+En chaînant les deux, `Coalesced` enveloppe `Filtered` : `COALESCE(SUM(col) FILTER (WHERE p), 0)`. L'ordre de chaînage n'a pas d'importance — `.filter(p).default(0)` et `.default(0).filter(p)` produisent la même IR.
+
+**Émission tri-dialecte :**
+
+| Fonctionnalité | PG | MySQL | SQLite |
+|---|---|---|---|
+| `Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` | ✓ | ✓ | ✓ |
+| `StdDev` / `StdDevPop` / `Variance` / `VariancePop` | ✓ | ✓ (8.0+) | ✗ `SqlError::AggregateNotSupported` |
+| `.filter(...)` — `FILTER (WHERE …)` natif | ✓ | ✗ réécrit | ✓ (3.30+) |
+| `.filter(...)` — repli `CASE WHEN` | — | ✓ `<agg>(CASE WHEN … THEN <arg> END)` | — |
+| `.default(...)` — `COALESCE` | ✓ | ✓ | ✓ |
+
+Le writer applique la conversion int/float du dialecte (`::bigint`, `CAST(... AS SIGNED)`, etc.) autour de toute l'expression `FILTER` — `SUM(col)::bigint FILTER (...)` est une erreur d'analyse syntaxique sur PG, donc la forme émise est `(SUM(col) FILTER (...))::bigint`. Même forme pour `STDDEV_SAMP` / `VAR_SAMP` (ils retournent NUMERIC sur PG pour une entrée bigint).
+
+**SQLite + StdDev/Variance :** SQLite n'a pas d'agrégats statistiques intégrés, donc le writer rejette avec `SqlError::AggregateNotSupported { aggregate, dialect: "sqlite" }`. Calculez la formule de variance côté application si des statistiques portables sont nécessaires (même posture que Django).
+
+### Fonctions fenêtrées
+
+Calculez des totaux courants, des classements, et des deltas ligne-à-ligne sans réduire les lignes — le `Window(expression, partition_by=, order_by=, frame=)` de Django. Huit fonctions (`row_number`, `rank`, `dense_rank`, `lag`, `lead`, `first_value`, `last_value`, `ntile`) plus les frames ROWS/RANGE. Chaque backend supporté par **Rustango** (PG ≥ 9.0, MySQL ≥ 8.0, SQLite ≥ 3.25) fournit une syntaxe `OVER (…)` native, donc l'émission est uniforme.
+
+```rust
+use rustango::core::aggregates::max;
+use rustango::core::window::{lag, rank, row_number};
+
+// "Rank users by score within each tenant" — the canonical
+// integration target.
+let q = User::objects()
+    .aggregate()
+    .group_by("id")
+    .group_by("tenant_id")
+    .group_by("name")
+    .group_by("score")
+    .annotate("_a", max("id").into())  // satisfies GROUP BY on the projection
+    .annotate(
+        "tenant_rank",
+        rank().partition_by("tenant_id").order_by(&[("score", true)]).into(),
+    )
+    .order_by(&[("tenant_id", false), ("score", true)])
+    .compile()?;
+let rows = rustango::sql::fetch_aggregate_dict(&pool, &q).await?;
+
+// Day-over-day delta via LAG with a default for the first row.
+let q = Event::objects()
+    .aggregate()
+    .group_by("id")
+    .group_by("day")
+    .group_by("count")
+    .annotate("_a", max("id").into())
+    .annotate(
+        "prev_count",
+        lag("count", 1, Some(SqlValue::I64(0)))
+            .partition_by("user_id")
+            .order_by(&[("day", false)])
+            .into(),
+    )
+    .compile()?;
+
+// Stable row index per group for "show me row N" pagination.
+let q = Post::objects()
+    .aggregate()
+    .group_by("id")
+    .group_by("status")
+    .group_by("created_at")
+    .annotate("_a", max("id").into())
+    .annotate(
+        "rn",
+        row_number()
+            .partition_by("status")
+            .order_by(&[("created_at", true)])
+            .into(),
+    )
+    .compile()?;
+```
+
+**Builders** dans `rustango::core::window` :
+
+| Builder | SQL | Arguments |
+|---|---|---|
+| `row_number()` | `ROW_NUMBER()` | — |
+| `rank()` | `RANK()` | — |
+| `dense_rank()` | `DENSE_RANK()` | — |
+| `ntile(buckets)` | `NTILE(buckets)` | nombre de buckets |
+| `lag(col, offset, default)` | `LAG(col, offset, default?)` | colonne + offset + défaut optionnel |
+| `lead(col, offset, default)` | `LEAD(col, offset, default?)` | colonne + offset + défaut optionnel |
+| `first_value(col)` | `FIRST_VALUE(col)` | colonne |
+| `last_value(col)` | `LAST_VALUE(col)` | colonne |
+
+Chacun retourne un `WindowBuilder` avec trois modificateurs chaînables :
+
+- `.partition_by("col")` — ajoute une colonne `PARTITION BY`. Appelez-le plusieurs fois pour un partitionnement multi-colonnes.
+- `.order_by(&[("col", desc)])` — ajoute des colonnes `ORDER BY` (`desc = true` → DESC).
+- `.frame(WindowFrame { kind, start, end })` — définit la clause de frame `ROWS`/`RANGE` optionnelle. `FrameBoundary::UnboundedPreceding` / `Preceding(n)` / `CurrentRow` / `Following(n)` / `UnboundedFollowing`.
+
+Le builder se convertit via `Into<AggregateExpr>` afin que les fonctions fenêtrées se composent avec `annotate()`. `Into<Expr>` est aussi implémenté (le slot au niveau IR pour les expressions fenêtrées), mais **chaque backend supporté par Rustango restreint les fonctions fenêtrées à la liste `SELECT` et à la clause `ORDER BY` d'une requête** — elles ne peuvent pas apparaître dans `WHERE` / `HAVING` / `GROUP BY` / `UPDATE SET` / `JOIN ON` / `RETURNING`. Le writer ne verrouille pas l'émission sur ce point, donc `set_expr("col", row_number())` compile en SQL que la base rejette à l'exécution. Construisez les expressions fenêtrées via `annotate()` ; passez par une sous-requête si vous devez alimenter un résultat de fonction fenêtrée dans un filtre WHERE ou un UPDATE.
+
+**Le piège de la frame par défaut de `LAST_VALUE` :**
+
+Un `last_value(col).order_by(&[("x", false)])` nu émet `LAST_VALUE("col") OVER (ORDER BY "x")` et semble devoir retourner le dernier `col` de la partition. Ce n'est pas le cas — la frame de fenêtre *par défaut* de SQL est `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`, donc `LAST_VALUE` retourne la valeur **de la ligne courante**, pas de la dernière ligne de la partition. Pour obtenir le comportement intuitif « dernière ligne de la partition », passez une frame illimitée explicite :
+
+```rust
+use rustango::core::{FrameBoundary, FrameKind, WindowFrame};
+
+last_value("score")
+    .partition_by("tenant_id")
+    .order_by(&[("created_at", true)])
+    .frame(WindowFrame {
+        kind: FrameKind::Rows,
+        start: FrameBoundary::UnboundedPreceding,
+        end: Some(FrameBoundary::UnboundedFollowing),
+    })
+```
+
+`first_value` n'a pas ce piège — le début de la frame par défaut correspond au début de la partition, la réponse intuitive tombe donc naturellement.
+
+**Avertissement sur annotate (jusqu'à l'arrivée de l'issue #75) :**
+
+`annotate()` vit sur le builder d'agrégat qui exige `GROUP BY` pour projeter des colonnes scalaires par ligne à côté des agrégats. Pour projeter des résultats de fonction fenêtrée à côté de colonnes de ligne aujourd'hui, listez chaque colonne de ligne que vous voulez retourner dans des appels `.group_by(...)` et utilisez `annotate("_a", max("id").into())` comme espace réservé no-op pour garder l'identité de ligne stable. L'issue #75 (auto-inférence de GROUP BY) apportera une forme plus propre.
+
+**Clauses de frame :**
+
+```rust
+use rustango::core::{FrameBoundary, FrameKind, WindowFrame};
+
+// Running total over the last 7 rows:
+let frame = WindowFrame {
+    kind: FrameKind::Rows,
+    start: FrameBoundary::Preceding(6),
+    end: Some(FrameBoundary::CurrentRow),
+};
+
+// Centered 11-row window:
+let frame = WindowFrame {
+    kind: FrameKind::Rows,
+    start: FrameBoundary::Preceding(5),
+    end: Some(FrameBoundary::Following(5)),
+};
+```
+
+**Émission tri-dialecte :**
+
+`<fn>(args) OVER (PARTITION BY … ORDER BY … [frame])` fait partie de la norme SQL — identique sur PG, MySQL 8+ et SQLite 3.25+. La seule bizarrerie : `LAG` / `LEAD` / `NTILE` exigent des offsets/buckets entiers sur PG (les lier comme un paramètre bigint `$N` provoque `function lag(bigint, bigint, bigint) does not exist`). Le writer intègre directement des littéraux entiers dans le SQL pour ces emplacements ; les arguments de valeur par défaut se lient normalement.
+
+**Avertissements :**
+
+- **`FILTER` + `Window` pas encore pris en charge** : combiner `.filter(...)` avec une fonction fenêtrée lève `SqlError::NestedAggregateWrapper { wrapper: "Filtered(Window)" }` — la syntaxe sous-jacente varie selon le type de fonction (PG autorise `agg_fn() FILTER (WHERE …) OVER (…)` pour les fonctions fenêtrées agrégeantes mais pas pour les fonctions de classement), et le writer n'a pas encore été enseigné cette répartition. Consigné pour un suivi si la demande se manifeste.
+- **`PercentRank` / `CumeDist` / `NthValue`** ne sont pas dans la v1 — l'ensemble complet de Django est plus large. La v1 fournit les 8 variantes les plus utilisées ; les trois manquantes peuvent être ajoutées progressivement avec la même forme de builder.
+
+### Filtrer sur des agrégats (HAVING)
+
+Un appel `.filter(...)` après `.annotate(...)` atterrit soit dans `WHERE` soit dans `HAVING`, selon que le nom correspond à un alias d'agrégat — exactement le comportement de Django. Ainsi, filtrer sur une vraie colonne ajoute un `WHERE`, tandis que filtrer sur une annotation comme `post_count` ajoute un `HAVING` :
+
+```rust
+use rustango::core::aggregates::count_all;
+use rustango::core::Op;
+
+// "Authors with > 10 published posts" — the canonical pattern.
+// status='published' is on the model       → routes to WHERE.
+// post_count > 10 references the annotation → routes to HAVING.
+let q = Post::objects()
+    .aggregate()
+    .group_by("author_id")
+    .annotate("post_count", count_all().into())
+    .filter("status",     Op::Eq, "published")
+    .filter("post_count", Op::Gt, 10_i64)
+    .compile()?;
+let rows = rustango::sql::fetch_aggregate_dict(&pool, &q).await?;
+```
+
+Émet, sur PG :
+
+```sql
+SELECT "author_id", COUNT(*) AS "post_count"
+FROM "post"
+WHERE "status" = $1
+GROUP BY "author_id"
+HAVING COUNT(*) > $2
+```
+
+**L'expression d'agrégat est remontée dans HAVING, pas l'alias du SELECT.** PG interdit strictement les alias dans HAVING (seule l'expression se résout) ; MySQL + SQLite sont plus permissifs. Le writer émet la forme remontée de manière uniforme sur les trois afin que la même requête fonctionne partout.
+
+**L'ordre de la chaîne compte en v1.** Appelez `.annotate(alias, ...)` AVANT le `.filter(alias, ...)` correspondant. Si l'ordre est inversé, `filter()` consulte un registre d'annotations vide et route vers `WHERE` — et le validateur `resolve_pending` fait remonter `UnknownField` à `compile()` parce que l'alias n'est pas une vraie colonne du modèle. Django diffère cette résolution au moment de la construction de la requête ; un suivi v0.50 pourrait adopter cette posture.
+
+**Lacune du validateur (correspond à la posture existante des agrégats)** : les prédicats HAVING routés par alias ne parcourent pas le schéma du modèle. Les alias mal orthographiés remontent à la base de données, pas à `compile()`. Même lacune que `Sum("typo_col")` — préexistante et orthogonale.
+
+**Opérateurs pris en charge sur `.filter()` routé par alias** (issue #87) : l'ensemble des comparaisons binaires (`Op::Eq` / `Ne` / `Lt` / `Lte` / `Gt` / `Gte`) **plus** les prédicats standard SQL-92 qui se composent avec un LHS d'agrégat de manière uniforme sur chaque backend — `Op::In` / `NotIn`, `Between`, `IsNull`, `Like` / `NotLike`, `ILike` / `NotILike`. Chacun émet la forme prévisible :
+
+```rust
+use rustango::core::{Op, SqlValue};
+
+// HAVING COUNT(*) IN ($1, $2, $3)
+Post::objects()
+    .aggregate()
+    .group_by("author_id")
+    .annotate("post_count", count_all().into())
+    .filter("post_count", Op::In, SqlValue::List(vec![5_i64.into(), 10_i64.into(), 20_i64.into()]))
+    .compile()?;
+
+// HAVING COUNT(*) BETWEEN $1 AND $2
+.filter("post_count", Op::Between, SqlValue::List(vec![5_i64.into(), 10_i64.into()]))
+
+// HAVING COUNT(*) IS NULL  /  IS NOT NULL  (bool: true = IS NULL)
+.filter("post_count", Op::IsNull, SqlValue::Bool(false))
+
+// HAVING MAX("name") LIKE $1  /  ILIKE $1 (PG) / LOWER(MAX("name")) LIKE LOWER(?) (MySQL/SQLite)
+.filter("max_name", Op::ILike, "SMITH%")
+```
+
+Les opérateurs restants — la famille JSON (`JsonContains` / `JsonContainedBy` / `JsonHasKey` / `JsonHasAnyKey` / `JsonHasAllKeys`) et l'égalité null-safe (`IsDistinctFrom` / `IsNotDistinctFrom`) — nécessitent encore des writers spécifiques au dialecte prenant un `&str` pour le LHS, ils sont donc rejetés à `compile()` avec `QueryError::HavingOpNotSupported { alias, op }`. Pour ceux-là, passez par la forme typée `.having(<TypedExpr>)` avec un prédicat pré-construit.
+
+**Gonflement du vecteur de paramètres avec des agrégats non triviaux** : quand l'alias cible une annotation `Filtered { Count, filter: pred }` ou `Coalesced { Sum, default: 0 }`, le writer remonte l'**expression d'agrégat entière** dans HAVING — y compris ses prédicats internes et ses valeurs par défaut. Leurs littéraux liés obtiennent de nouveaux emplacements de paramètres dans HAVING, séparés de l'émission dans la liste SELECT. Concrètement :
+
+```text
+SELECT … COUNT(*) FILTER (WHERE "status" = $1) AS "published_count" …
+HAVING COUNT(*) FILTER (WHERE "status" = $2) > $3
+              -- "published" bound twice (once at $1, once at $2)
+```
+
+La sémantique SQL est inchangée (les mêmes nombres de lignes reviennent), mais `stmt.params.len()` croît à chaque appel `.filter()` ciblant un alias non trivial. Pour les alias `COUNT(*)` (aucun littéral interne), le gonflement est nul. À documenter si votre suite de tests fixe des comptes de paramètres.
+
+---
+
+## Jointures & préchargement des lignes liées
+
+Récupérez la cible d'une clé étrangère en même temps que la ligne principale, en une seule requête, afin de ne pas tirer une requête supplémentaire par ligne (le problème N+1). `.select_related("author")` est le `select_related` de Django / le chargement anticipé d'Eloquent. Un champ `ForeignKey<T>` arrive alors déjà rempli sans avoir besoin d'une recherche séparée.
+
+```rust
+let posts = Post::objects()
+    .select_related("author")              // JOIN posts.author -> authors.id
+    .fetch(&pool).await?;
+
+for post in &posts {
+    let author = post.author.value().unwrap();   // already loaded, no DB round-trip
+    println!("{} by {}", post.title, author.name);
+}
+```
+
+`select_related` résout les champs FK au moment de la compilation du queryset. Le champ `ForeignKey<T>` sur le parent passe de `Unloaded(pk)` à `Loaded { pk, value }`.
+
+Pour les FK inversées (parent.enfants), utilisez la méthode `_set` générée par la macro :
+
+```rust
+let author_posts = author.post_set(&pool).await?;
+```
+
+### Jointures personnalisées
+
+Quand la jointure n'est pas pilotée par une clé étrangère — un prédicat personnalisé, une jointure non-équi, INNER au lieu de LEFT, une auto-jointure, ou une jointure sur une colonne non-PK — utilisez `.join(Join { … })`. Son champ `on` accepte n'importe quel `WhereExpr`, donc `and()` / `or()` / `Not` / appels de fonction / colonne-vs-colonne / filtres littéraux se composent tous librement.
+
+```rust
+use rustango::core::joins::aliased;
+use rustango::core::{Join, JoinKind, Op, WhereExpr};
+
+// "Posts that have at least one APPROVED comment" — INNER JOIN with
+// an extra predicate inside the ON. Posts with no approved comment
+// drop out; LEFT JOIN would keep them.
+Post::objects()
+    .join(Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Inner,
+        on: WhereExpr::And(vec![
+            // Column-on-column condition — both sides aliased.
+            WhereExpr::ExprCompare {
+                lhs: aliased("c", "post_id"),
+                op: Op::Eq,
+                rhs: aliased("post", "id"),
+            },
+            // Bare Filter — unqualified columns inside `on` resolve
+            // to the joined alias ("c"), so this becomes
+            // `"c"."is_approved" = $N`.
+            Comment::is_approved.eq(true).into(),
+        ]),
+        project: vec![],
+    })
+    .fetch(&pool).await?;
+```
+
+**Règles de qualification des colonnes à l'intérieur de `on` :**
+
+- **Les colonnes `Filter` / `ColumnFilter` nues + les références de colonne `F()`** se résolvent vers l'alias joint (`<alias>` que vous avez passé). C'est la lecture naturelle car la majeure partie d'un prédicat ON concerne la table jointe.
+- **`aliased(alias, col)`** émet explicitement `"<alias>"."<col>"` — utilisez-le pour des références croisées vers la table externe (`aliased("<outer_table>", "<col>")`) ou vers un alias précédemment joint.
+- **`WhereExpr::ExprCompare { lhs, op, rhs }`** est la forme adéquate pour des comparaisons colonne-vs-colonne entre tables, puisque les deux côtés acceptent n'importe quel `Expr`.
+
+> ⚠️ **PATTERN DANGEREUX — filtres typés du modèle EXTERNE à l'intérieur de `on`.**
+> `Post::status.eq("draft").into()` produit un `WhereExpr::Predicate(Filter { column: "status", ... })` et **perd le tag du modèle `Post`** à la frontière `Into<WhereExpr>`. La règle d'auto-qualification ci-dessus route alors ce filtre par erreur vers l'**alias joint**, pas vers `Post`. Vous obtenez `"<joined_alias>"."status" = $N` — la mauvaise table — et le compilateur ne peut pas le détecter. **Utilisez [`joins::col_filter`] pour les prédicats portant sur une colonne dont la table n'est pas l'alias par défaut de la jointure :**
+>
+> ```rust
+> use rustango::core::joins::{aliased, col_filter};
+> use rustango::core::Op;
+>
+> // SAFE: explicit alias on the LHS.
+> col_filter("post", "status", Op::Eq, "draft")
+> ```
+>
+> Réservez les filtres typés nus (`Comment::is_approved.eq(true).into()`) aux colonnes du modèle JOINT uniquement — jamais pour les colonnes du modèle externe.
+
+**Support tri-dialecte de JoinKind :**
+
+| Type | PG | MySQL | SQLite |
+|---|---|---|---|
+| `Inner` | ✓ | ✓ | ✓ |
+| `Left` (par défaut) | ✓ | ✓ | ✓ |
+| `Right` | ✓ | ✓ | ✗ `SqlError::JoinKindNotSupported` |
+| `Full` | ✓ | ✗ | ✗ |
+
+`Right` est facile à contourner — échangez les opérandes et utilisez `Left`. `Full` sur MySQL est habituellement émulé avec `(LEFT JOIN) UNION (RIGHT JOIN)` si vous en avez vraiment besoin.
+
+**Autres erreurs à l'émission :**
+
+- **Prédicat `on` vide** (`WhereExpr::And(vec![])` ou aucun `ExprCompare`) est rejeté avec `SqlError::EmptyJoinOnCondition`. SQL exige au moins un prédicat booléen à l'intérieur de `ON` ; le raccourci auto-`true` du WHERE de premier niveau ne s'applique pas ici.
+
+**`project` est actuellement une donnée morte sur les jointures ad hoc.**
+
+Le champ `Join.project` indique au writer d'émettre des colonnes `<alias>"."<col>" AS "<alias>__<col>"` dans la liste SELECT. Aujourd'hui, seul `select_related` décode réellement ces colonnes (via le décodeur de ligne complète de la cible FK). Les jointures ad hoc émettent les colonnes mais le décodeur `Vec<MainModel>` les ignore, donc renseigner `project` sur une jointure ad hoc ne fait qu'ajouter des octets sur le fil. Laissez-le à `vec![]` jusqu'à ce que la restriction de projection + le décodage de tuples arrivent.
+
+**Quand utiliser des jointures ad hoc :**
+
+| Besoin | Outil |
+|---|---|
+| Récupérer les lignes liées avec la ligne principale | `select_related` (forme Django) |
+| Filtrer les lignes principales par un prédicat de table liée | `exists(...)` / `not_exists(...)` |
+| Filtrer via INNER au lieu de LEFT, ou avec des prédicats ON supplémentaires | `.join(...)` |
+| Auto-jointure (par exemple `employee.manager_id = manager.id`) | `.join(...)` |
+| Anti-jointure (lignes de A sans AUCUNE correspondance dans B) | `not_exists(...)` |
+
+`select_related` reste l'outil approprié quand la jointure consiste à « suivre cette FK et projeter toutes ses colonnes ». Les jointures ad hoc sont l'échappatoire quand vous avez besoin : d'une clé de jointure non-FK, d'INNER au lieu de LEFT, d'un prédicat supplémentaire à l'intérieur du ON, ou d'une auto-jointure.
+
+[`joins::col_filter`]: https://docs.rs/rustango/latest/rustango/core/joins/fn.col_filter.html
+
+[`WhereExpr`]: https://docs.rs/rustango/latest/rustango/core/enum.WhereExpr.html
+
+---
+
+## Sauvegarder seulement certains champs
+
+Écrivez uniquement les champs modifiés au lieu de toutes les colonnes — le `save(update_fields=[...])` de Django. Une sauvegarde normale réécrit toutes les colonnes non-PK ; `save_partial(&[...], &pool)` ne réécrit que celles que vous nommez.
+
+```rust
+let mut post = Post::objects().fetch(&pool).await?.pop().unwrap();
+post.title = "new title".into();
+post.save_partial(&["title"], &pool).await?;  // SET "title" = $1
+                                                  // — leaves body, status, views untouched
+```
+
+Deux motivations :
+
+* **Performance.** Les lignes larges avec des colonnes `TEXT` / `JSON` / `bytea` coûtent à re-lier et à réécrire à chaque `save()` même quand un seul champ a été modifié. `save_partial` limite la clause `SET` exactement à ce qui a changé.
+* **Sécurité de la concurrence.** Quand deux écrivains divergent après une lecture partagée, le perdant écrase silencieusement les modifications du gagnant sur les champs qu'il n'a pas touchés. Ne nommer que le champ réellement modifié préserve le travail de l'autre écrivain partout ailleurs.
+
+```rust
+// Writer A — flips title.
+a.title = "from-A".into();
+a.save_partial(&["title"], &pool).await?;
+
+// Writer B — started from the same read, flips status.
+// B's local `title` is stale, but it's not in the list, so A's
+// write survives.
+b.status = "from-B".into();
+b.save_partial(&["status"], &pool).await?;
+```
+
+**Les noms de champs sont des champs de struct côté Rust**, pas des colonnes SQL — `["author_id"]` (pas `["author"]` pour un champ typé FK). Les noms de champs inconnus retournent `ExecError::Query(QueryError::UnknownField)`. Une liste vide est un no-op (retourne `Ok(())` et journalise un `tracing::warn!`), ce qui correspond à la sémantique « rien à faire » de Django. Les modèles audités (`#[rustango(audit(...))]`) restreignent l'instantané du journal d'audit au même ensemble de colonnes — le journal reflète exactement ce qui a été écrit.
+
+**Note sur les PK auto.** `save_partial` est UPDATE uniquement ; l'appeler sur une PK `Auto::Unset` est une erreur utilisateur (utilisez `insert_pool` / `save_pool` pour ce cas). Contrairement à `save_pool` qui dispatche automatiquement `Unset → insert_pool`, cette méthode suppose que vous avez déjà inséré la ligne.
+
+### Liste de champs vérifiée à la compilation
+
+La forme à clés en chaînes ci-dessus convient aux listes de champs dynamiques (formulaires admin, payloads d'API). Quand la liste est fixe dans votre code, `save_partial_typed((Post::title, ...), &pool)` détecte les champs mal orthographiés ou renommés à la **compilation** plutôt qu'au runtime :
+
+```rust
+post.save_partial_typed((Post::title, Post::slug), &pool).await?;
+//                       ──────────  ──────────
+//                       title_col   slug_col   ← distinct ZSTs
+```
+
+Chaque `Post::<field>` est son propre type de taille zéro — une slice homogène (`&[Post::title, Post::slug]`) ne compile pas en Rust, donc l'API prend un **tuple** à la place. Les appels à un seul champ utilisent l'idiome de la virgule finale : `(Post::title,)`. Les tuples sont pris en charge de l'arité 1 jusqu'à 12 — au-delà, retombez sur `save_partial(&[&str], _)`.
+
+Les tuples entre modèles différents sont une **erreur de compilation** — `(Post::title, Author::name)` échoue à la contrainte de trait `TypedFieldList<Post>` car `Author::name` a `Column::Model = Author`. C'est l'apport principal par rapport à la forme à clés en chaînes : les refactorisations de renommage sur un nom de colonne remontent au site d'appel typé, pas au runtime.
+
+Se réduit en interne à `save_partial` — même restriction d'audit, même contrainte `Auto::Unset`, même sémantique de no-op sur liste vide.
+
+---
+
+## Opérations en masse
+
+> **Piège — les opérations en masse contournent les hooks par ligne.** `bulk_insert`, `.update().execute()` d'un queryset,
+> et `.delete()` s'exécutent comme du SQL orienté ensemble : ils ne déclenchent **pas**
+> les signaux, n'écrivent pas la piste d'audit, ne passent pas par la suppression logique, et n'exécutent pas
+> de validation par ligne. Utilisez-les pour la vitesse ; retombez sur le `save()` / `delete()` par ligne
+> quand vous avez besoin de ces effets de bord.
+
+Insérez, mettez à jour, ou supprimez de nombreuses lignes en une seule instruction plutôt qu'une par ligne — le `bulk_create`, `QuerySet.update()` et `QuerySet.delete()` de Django. L'import `as _` place les méthodes d'un trait dans la portée sans nommer le trait directement.
+
+```rust
+// Bulk INSERT — rows FIRST (a `&mut [Self]`), executor/pool second.
+let mut rows = [p1, p2, p3];
+Post::bulk_insert_on(&mut rows, &pool).await?;
+
+// Bulk UPDATE — applies the same set to every matched row. `.set`
+// takes a string column name.
+Post::objects()
+    .where_(Post::status.eq("draft"))
+    .where_(Post::created_at.lt(thirty_days_ago))
+    .update()
+    .set("status", "archived")
+    .execute_on(&pool).await?;
+
+// Bulk DELETE
+Post::objects()
+    .where_(Post::deleted_at.is_not_null())
+    .delete_on(&pool).await?;
+```
+
+---
+
+## Insertion ou mise à jour (upsert)
+
+Insérez une ligne, ou mettez-la à jour si une ligne avec la même clé existe déjà — le `update_or_create` de Django / l'`upsert` de Rails. Cela émet le `ON CONFLICT … DO UPDATE` natif de la base.
+
+Le `.upsert_on(executor)` sur une seule instance entre en conflit sur la **clé primaire** : avec une PK `Auto::Unset`, le serveur attribue une nouvelle clé (équivalent à `insert`) ; avec une PK `Auto::Set`, la ligne est insérée si absente ou toutes les colonnes non-PK sont écrasées si présente.
+
+```rust
+// Upsert on the PK — INSERT, or UPDATE every non-PK column if the
+// PK already exists.
+post.upsert_on(&pool).await?;
+```
+
+Pour faire un upsert sur une clé unique arbitraire (le `bulk_create(update_conflicts=True, unique_fields=…, update_fields=…)` de Django), utilisez le helper en masse — il prend les lignes, les colonnes cibles du conflit, les colonnes à mettre à jour en cas de conflit, et le pool EN DERNIER :
+
+```rust
+// ON CONFLICT (external_id) DO UPDATE SET title = EXCLUDED.title
+Post::bulk_upsert_pool(
+    &[post],
+    &["external_id"],          // conflict target (unique key)
+    &["title"],                // columns to overwrite on conflict
+    &pool,
+).await?;
+```
+
+---
+
+## Transactions
+
+> **Piège — ne mélangez pas les appels `&pool` à l'intérieur d'une transaction.** Chaque appel
+> entre `pool.begin()` et `commit` doit cibler le handle de transaction
+> (`&mut *tx`). Un `&pool` / `fetch()` / `save_on(&pool)` isolé récupère une
+> *deuxième* connexion et peut créer un deadlock du pool sous charge. Faites passer la `tx`
+> partout, ou utilisez `rustango::sql::atomic`.
+
+Exécutez plusieurs écritures comme une unité qui réussit entièrement ou est entièrement annulée — le `transaction.atomic()` de Django. Ouvrez-en une avec `pool.begin()` et exécutez chaque instruction sur la connexion de la transaction via les méthodes `_on` (`fetch_on`, `save_on`), afin que le travail atterrisse sur la transaction en cours plutôt que sur une connexion fraîchement tirée du pool.
+
+```rust
+let mut tx = pool.begin().await?;
+
+let mut a = Account::objects()
+    .where_(Account::id.eq(1))
+    .fetch_on(&mut *tx).await?
+    .pop().unwrap();
+let mut b = Account::objects()
+    .where_(Account::id.eq(2))
+    .fetch_on(&mut *tx).await?
+    .pop().unwrap();
+
+a.balance -= 100;
+b.balance += 100;
+a.save_on(&mut *tx).await?;
+b.save_on(&mut *tx).await?;
+
+tx.commit().await?;
+```
+
+Abandonnez la `tx` sans appeler `commit()` (par exemple lors d'un retour anticipé par `?`) et la transaction est annulée (rollback). Pour un hook après-commit (le `transaction.on_commit` de Django), utilisez le helper de style closure `rustango::sql::atomic(&pool, |tx| Box::pin(async move { … }))`, qui valide automatiquement (auto-commit) en cas de `Ok` et annule automatiquement en cas de `Err`.
+
+---
+
+## Relations plusieurs-à-plusieurs
+
+Reliez de nombreuses lignes à de nombreuses autres via une table de jonction — le `ManyToManyField` de Django. Déclarez la relation sur le modèle, puis utilisez l'accesseur généré pour ajouter, retirer, définir, ou lister les ids liés.
+
+```rust
+#[rustango(
+    table = "posts",
+    m2m(name = "tags", to = "tags", through = "post_tags",
+        src = "post_id", dst = "tag_id"),
+)]
+pub struct Post { ... }
+```
+
+Utilisez l'accesseur auto-généré :
+
+```rust
+let tag_ids: Vec<i64> = post.tags_m2m().all(&pool).await?;
+post.tags_m2m().add(42, &pool).await?;
+post.tags_m2m().remove(42, &pool).await?;
+post.tags_m2m().set(&[1, 2, 3], &pool).await?;        // replace all
+post.tags_m2m().clear(&pool).await?;
+let has = post.tags_m2m().contains(42, &pool).await?;
+```
+
+La table de jonction (`post_tags`) est auto-créée par `make_migrations` avec une PK composite + deux FK `ON DELETE CASCADE`. Actuellement, la jonction n'a que les deux colonnes FK — pour des colonnes supplémentaires (added_by, order, created_at), vous devrez définir un Model séparé et traverser manuellement jusqu'à ce que le « modèle through personnalisé » soit disponible.
+
+---
+
+## JSON / JSONB
+
+Stockez et interrogez un document JSON dans une colonne — le `JSONField` de Django. Déclarez le champ comme `serde_json::Value` (le type JSON générique), puis interrogez-le avec `json_contains` ou un filtre de chemin.
+
+```rust
+#[derive(Model)]
+pub struct Event {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(default = r#"'{}'::jsonb"#)]
+    pub data: serde_json::Value,
+}
+```
+
+Interroger le contenu JSON :
+
+```rust
+use rustango::core::{Expr, Op, SqlValue, WhereExpr};
+use rustango::core::funcs::json_path;
+use rustango::core::F;
+
+let with_email = Event::objects()
+    .where_(Event::data.json_contains(serde_json::json!({"email_set": true})))
+    .fetch(&pool).await?;
+
+// Path extract — `json_path(F("data"), &["type"], true)` builds the
+// `data ->> 'type'` text-extract LHS; compare it via `where_raw`.
+let typed = Event::objects()
+    .where_raw(WhereExpr::ExprCompare {
+        lhs: json_path(F("data"), &["type"], true),
+        op: Op::Eq,
+        rhs: Expr::Literal(SqlValue::String("user.created".into())),
+    })
+    .fetch(&pool).await?;
+```
+
+Lisez/écrivez des types Rust via `serde_json::from_value` / `to_value`.
+
+---
+
+## Suppression logique
+
+Marquez une ligne comme supprimée en définissant un timestamp au lieu de la retirer — comme `django-safedelete` de Django ou `SoftDeletes` de Laravel. Marquez la colonne de timestamp avec l'attribut `#[rustango(soft_delete)]` (une annotation de derive qui indique à la macro comment traiter le champ) :
+
+```rust
+#[derive(Model)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub title: String,
+    #[rustango(soft_delete)]
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+```
+
+Utilisation :
+
+```rust
+post.soft_delete_on(&pool).await?;     // sets deleted_at = NOW()
+post.restore_on(&pool).await?;          // sets deleted_at = NULL
+
+// Default queries DO include soft-deleted rows. Filter explicitly:
+let live = Post::objects().where_(Post::deleted_at.is_null()).fetch(&pool).await?;
+```
+
+Le bouton « Supprimer » de l'admin route automatiquement vers `soft_delete_on` pour tout modèle possédant la colonne. Le filtre automatique (exclusion par défaut) est sur la feuille de route de la v0.21.
+
+---
+
+## Piste d'audit
+
+Enregistrez qui a modifié quels champs et quand, automatiquement à chaque sauvegarde et suppression — comme `django-simple-history` de Django ou les paquets d'audit de Laravel. Annotez le modèle avec les champs à suivre :
+
+```rust
+#[derive(Model)]
+#[rustango(audit(track = "title, body, status"))]
+pub struct Post { ... }
+```
+
+Chaque sauvegarde/suppression écrit une ligne dans `rustango_audit_log` avec un diff JSONB `before / after` pour les champs listés. Définissez la source par requête :
+
+```rust
+use rustango::audit::{with_source, AuditSource};
+
+with_source(
+    AuditSource::User { id: user_id.to_string() },
+    async {
+        post.save_on(&pool).await
+    },
+).await?;
+```
+
+Le panneau d'historique par ligne de l'admin lit depuis cette table ; le flux inter-modèles se trouve sur `/__audit`.
+
+Nettoyage :
+
+```rust
+rustango::audit::cleanup_older_than(&pool, 90).await?;       // delete > 90 days
+rustango::audit::cleanup_keep_last_n(&pool, 50).await?;      // keep most recent 50/row
+
+// CLI
+manage audit-cleanup --days 90
+manage audit-cleanup --keep-last 50 --tenant acme
+```
+
+---
+
+## Échappatoire SQL brut
+
+Passez au SQL écrit à la main quand le query builder ne peut pas exprimer ce dont vous avez besoin — le `Model.objects.raw()` / `connection.cursor()` de Django. Les macros `sqlx` exécutent une requête et décodent le résultat en un tuple, un `Model` typé, ou rien :
+
+```rust
+use rustango::sql::sqlx;
+
+// Raw query → typed rows
+let rows = sqlx::query_as::<_, (i64, String)>("SELECT id, title FROM posts WHERE views > $1 ORDER BY views DESC")
+    .bind(1000)
+    .fetch_all(&pool)
+    .await?;
+
+// Raw with model decoding
+let posts: Vec<Post> = sqlx::query_as::<_, Post>("SELECT * FROM posts WHERE complicated_condition")
+    .fetch_all(&pool)
+    .await?;
+
+// Raw without rows (DDL / DML)
+sqlx::query("REINDEX TABLE posts").execute(&pool).await?;
+```
+
+Pour du SQL brut programmatique au sein de la couche de requête **Rustango** (tri-dialecte ; prend le SQL, un `Vec<SqlValue>` de valeurs liées, puis le pool EN DERNIER, et retourne `Vec<T>`) :
+
+```rust
+use rustango::sql::raw_query_pool;
+
+let rows = raw_query_pool::<(i64,)>(
+    "SELECT COUNT(*) FROM posts WHERE complicated",
+    vec![],
+    &pool,
+).await?;
+let count = rows.first().map(|r| r.0).unwrap_or(0);
+```
+
+---
+
+## Chargement paresseux des FK
+
+Une clé étrangère commence par ne détenir que l'id lié (`Unloaded`), et vous ne récupérez la ligne liée complète que lorsque vous la demandez — l'accès paresseux aux objets liés de Django. Faites un `match` sur la `ForeignKey` pour gérer les deux états, ou appelez `.get(&pool)` pour la charger à la demande. Pour un lot entier, utilisez `select_related` (ci-dessus) pour les précharger en une seule requête et éviter le fetch par ligne.
+
+```rust
+let mut post = Post::objects().find_or_fail(1, &pool).await?;
+
+// FK starts Unloaded — just the PK. `Loaded` is a struct variant
+// `{ pk, value }`; `value` is a `Box<Author>`.
+match &post.author {
+    ForeignKey::Unloaded(pk) => println!("author id = {pk}"),
+    ForeignKey::Loaded { pk, value } => println!("author = {}", value.name),
+}
+
+// Force-load
+let author = post.author.get(&pool).await?;          // fetches if Unloaded
+```
+
+Utilisez `select_related("author")` sur le queryset pour précharger un lot.
+
+---
+
+## Quatre façons de filtrer
+
+Il existe quatre façons d'exprimer un filtre ; choisissez selon le contexte. Les colonnes typées sont vérifiées à la compilation et sont les mieux adaptées au code applicatif ; la forme en chaîne `field__lookup` est la syntaxe familière de Django pour l'admin et le CRUD générique ; `filter_op` sert lorsque vous détenez déjà un `Op` ; la chaîne de requête HTTP pilote l'API publique.
+
+```rust
+// 1. HTTP query string (set via ViewSet filter_fields)
+//    GET /api/posts?author_id=42&status__ne=archived
+
+// 2. Django-shape string lookup (the same `field__lookup` grammar your
+//    URL parser uses, but inside Rust). Suffix decides the operator
+//    and value-shape; bare key is exact-eq. Field name is validated
+//    at `.compile()`.
+Post::objects()
+    .filter("status", "published")                 // exact-eq
+    .filter("title__icontains", "rust")            // ILIKE %rust%
+    .filter("views__gt", 100_i64);
+
+// 3. Explicit operator (legacy 3-arg shape — when you want to pass
+//    an Op directly without parsing a suffix)
+Post::objects().filter_op("author_id", Op::Eq, SqlValue::I64(42));
+
+// 4. Typed columns (compile-time field check; preferred in app code)
+Post::objects().where_(Post::author_id.eq(42));
+```
+
+**Convention :** typé dans le code applicatif, forme Django dans l'admin / le CRUD générique, `filter_op` seulement quand vous avez déjà calculé un `Op` (par exemple depuis un parseur de requête), la chaîne de requête HTTP pour la surface d'API publique.
+
+### Suffixes de lookup pris en charge
+
+| Suffixe | Opérateur SQL | Forme de la valeur | Notes |
+|---|---|---|---|
+| *(aucun)* / `__exact` | `=` | scalaire | la clé nue est exact-eq |
+| `__ne` | `<>` | scalaire | |
+| `__gt` / `__gte` / `__lt` / `__lte` | `>` `>=` `<` `<=` | scalaire | |
+| `__contains` | `LIKE` | chaîne | enveloppe la valeur en `%v%` |
+| `__icontains` | `ILIKE` | chaîne | enveloppe la valeur en `%v%` ; émulé sur MySQL via `LOWER()` |
+| `__startswith` | `LIKE` | chaîne | enveloppe en `v%` |
+| `__istartswith` | `ILIKE` | chaîne | enveloppe en `v%` |
+| `__endswith` | `LIKE` | chaîne | enveloppe en `%v` |
+| `__iendswith` | `ILIKE` | chaîne | enveloppe en `%v` |
+| `__iexact` | `ILIKE` | chaîne | pas d'enveloppement par joker — correspondance exacte insensible à la casse |
+| `__in` | `IN (…)` | `SqlValue::List` | rejette les valeurs non-liste |
+| `__isnull` | `IS NULL` / `IS NOT NULL` | `bool` | `true` → IS NULL, `false` → IS NOT NULL |
+| `__between` / `__range` | `BETWEEN … AND …` | `SqlValue::List` à 2 éléments | inclusif aux deux bornes |
+| `__regex` / `__iregex` | PG `~` / `~*`, MySQL/SQLite `REGEXP` | chaîne | insensibilité à la casse émulée sur MySQL/SQLite via `LOWER()` ; SQLite nécessite une fonction utilisateur `regexp` |
+
+**Les erreurs remontent à `.compile()`, pas au moment de l'appel `.filter()`** — les incohérences de forme de valeur (par exemple `__in` avec un scalaire, `__isnull` avec un non-bool, `__between` avec une arité incorrecte) et les suffixes inconnus (`status__nope`) retournent `QueryError::UnknownLookup` / `QueryError::InvalidLookupValue` depuis `.compile()` afin que la chaîne fluide reste propre côté types. Les traversées chaînées (`author__name__icontains`) ne sont **pas** prises en charge en v0.39 — le découpeur prend le suffixe après le premier `__`, donc toute la queue `name__icontains` est traitée comme un suffixe inconnu.
+
+Chaque appel de filtre se joint par un AND à ceux qui précèdent ; mélangez librement la forme Django, `filter_op`, et `where_` sur le même queryset.
+
+---
+
+## Requêtes cloisonnées par tenant
+
+Dans une application multi-tenant, exécutez chaque requête sur la connexion du tenant courant plutôt que sur le pool partagé. Récupérez une connexion par requête et passez-la à `fetch_on` (qui accepte n'importe quel executor de base de données) au lieu de `fetch` (qui utilise toujours `&pool`).
+
+```rust
+use rustango::extractors::Tenant;
+
+async fn handler(mut t: Tenant) -> Result<...> {
+    let conn = t.conn();        // &mut PgConnection for this tenant
+    let posts = Post::objects().fetch_on(&mut *conn).await?;
+    Ok(...)
+}
+```
+
+`fetch_on` fonctionne avec n'importe quel `sqlx::Executor` ; `fetch` est du sucre syntaxique pour `fetch_on(&pool)`.
+
+---
+
+## Signaux
+
+Exécutez un callback quand quelque chose se produit — les signaux de Django. Il existe deux registres indépendants : un pour les écritures de modèles, un pour les requêtes HTTP.
+
+### Cycle de vie du modèle
+
+Déclenchez un hook avant ou après qu'un modèle soit sauvegardé ou supprimé : `pre_save`, `post_save`, `pre_delete`, `post_delete`. Enregistrez-en un avec `connect_post_save::<Post, _, _>(...)`.
+
+```rust
+use rustango::signals::{connect_post_save, PostSaveContext};
+
+connect_post_save::<Post, _, _>(|post, ctx| async move {
+    if ctx.created {
+        tracing::info!("new post #{}", post.id.get().copied().unwrap_or(0));
+    }
+});
+```
+
+`T: Clone + 'static` est requis (le dispatcher remet à chaque récepteur un clone `Arc<T>`). Les récepteurs s'exécutent séquentiellement dans l'ordre d'enregistrement. Déconnectez via le `ReceiverId` retourné par `connect_*`. Les quatre types de signaux + leurs formes de contexte sont documentés en ligne dans `rustango::signals`.
+
+### Cycle de vie de la requête
+
+Déclenchez un hook autour de chaque requête HTTP : `request_started`, `request_finished`, `got_request_exception`. Ajoutez le middleware `RequestSignalsLayer` à votre routeur, puis connectez des callbacks. Utile pour le traçage, l'audit, les métriques de temps de requête, et le reporting d'erreurs de style Django.
+
+```rust
+use axum::Router;
+use rustango::signals::request::{
+    connect_request_started, connect_request_finished, RequestSignalsLayer,
+};
+
+connect_request_started(|ctx| Box::pin(async move {
+    tracing::info!(method = %ctx.method, path = %ctx.path, "started");
+}));
+connect_request_finished(|ctx| Box::pin(async move {
+    metrics::histogram!("http_request_ms").record(ctx.elapsed_ms);
+}));
+
+let app: Router = Router::new()
+    .route("/", get(home))
+    .layer(RequestSignalsLayer::new());  // outermost — sees request first / response last
+```
+
+| Signal | Champs de contexte |
+|---|---|
+| `request_started` | `method`, `path`, `query` |
+| `request_finished` | `method`, `path`, `status`, `elapsed_ms` |
+| `got_request_exception` | `method`, `path`, `error` |
+
+Les récepteurs s'exécutent séquentiellement dans l'ordre d'enregistrement ; enveloppez un corps dans `tokio::spawn` pour un fan-out parallèle ou une isolation des panics. Les registres de requêtes et de modèles sont indépendants — connecter / déconnecter / vider l'un ne touche pas l'autre.
+
+---
+
+## Conseils de performance
+
+Une checklist rapide pour garder les requêtes rapides à mesure que les données croissent :
+
+- **Utilisez toujours des index pour les colonnes `WHERE` et `ORDER BY`.** Déclarez-les via `#[rustango(index)]` afin qu'ils figurent dans les migrations.
+- **`select_related` pour l'affichage des FK dans les listes** — élimine le N+1 dans les vues de liste admin/publiques.
+- **`page` plutôt que `fetch().drain()`** — ne chargez jamais des tables entières.
+- **Pagination par curseur pour les tables volumineuses** — évite un `COUNT(*)` par page.
+- **`bulk_insert_on` pour les lots** — un seul aller-retour au lieu de N.
+- **`upsert_on` pour les imports idempotents** — `ON CONFLICT` est plus rapide qu'un SELECT-puis-INSERT.
+- **`transaction` pour les écritures liées** — réduit la surcharge de commit et préserve la cohérence.
+- **Mettez en cache les lectures fréquentes** avec `cache::get_or_set` — invalidez sur un gestionnaire de signal `connect_post_save<T>(...)`.
+
+---
+
+## Voir aussi
+
+- [Models](models.md) — déclarer un modèle : types de champs, clés primaires, chaque attribut (le complément à ce guide de requêtage).
+- [Serializers](serializers.md) — mettre en forme les lignes de modèle en JSON.
+- [ViewSets](viewsets.md) — transformer un modèle en une API CRUD JSON.
+- [The admin](admin.md) — une interface utilisateur auto-générée sur les mêmes modèles.
+- [`manage` CLI](manage.md) — `makemigrations` / `migrate` pour les changements de schéma.

--- a/docs/fr/scaffolding.md
+++ b/docs/fr/scaffolding.md
@@ -1,0 +1,184 @@
+# Scaffolding
+
+**Rustango** dispose de deux niveaux de génération de code, tous deux inspirés des générateurs que vous connaissez déjà avec Django et Laravel — de sorte que vous n'avez presque jamais à câbler de code répétitif à la main :
+
+1. **Le générateur de projet** — `cargo rustango new` crée un tout nouveau projet à partir d'un template.
+2. **Les générateurs internes au projet** — `manage startapp` et la famille `manage make:*` ajoutent des apps, des vues, des sérialiseurs, des jobs, et bien plus au sein d'un projet existant.
+
+[![`cargo rustango new` scaffolds a complete, ready-to-run project — Cargo manifest, config tiers, Docker, migrations, and src — in one command](img/scaffolding.png)](img/scaffolding.png)
+
+## Table des matières
+
+- [Installer le générateur](#install-the-generator)
+- [Créer un projet : `cargo rustango new`](#create-a-project-cargo-rustango-new)
+- [Ce qui est généré](#what-gets-generated)
+- [Ajouter un module fonctionnel : `manage startapp`](#add-a-feature-module-manage-startapp)
+- [Générer des fichiers individuels : les commandes `make:*`](#generate-single-files-the-make-commands)
+- [Un flux typique](#a-typical-flow)
+
+---
+
+## Installer le générateur
+
+`cargo rustango` est une sous-commande Cargo. Installez-la une fois, globalement :
+
+```sh
+cargo install cargo-rustango
+```
+
+Cela place un binaire `cargo-rustango` sur votre `PATH` ; Cargo l'expose alors comme `cargo rustango` (de la même manière que `django-admin` ou l'installeur `laravel` vous donnent une commande globale).
+
+---
+
+## Créer un projet : `cargo rustango new`
+
+```sh
+cargo rustango new <name> [--template api|fullstack|tenant]
+```
+
+- **`<name>`** — le nom du projet (et de la crate). Il doit s'agir d'un nom de crate Cargo valide (`[A-Za-z_][A-Za-z0-9_-]*`), et le répertoire cible ne doit pas déjà exister.
+- **`--template` / `-t`** — quel template utiliser pour l'échafaudage (par défaut : **fullstack**).
+- **`--help` / `-h`**, **`--version`** — usage et version.
+
+### Les trois templates
+
+Chacun correspond à une des trois formes d'application de **Rustango** :
+
+| Template | Ce que vous obtenez | À utiliser quand |
+|---|---|---|
+| `api` | ORM nu + Axum, **sans admin** | Services et microservices JSON uniquement |
+| `fullstack` *(par défaut)* | ORM + l'**admin automatique** | Une application web classique avec un back-office |
+| `tenant` | Multi-tenancy + console opérateur + apps par tenant | Hébergement SaaS avec de nombreux tenants isolés |
+
+```sh
+cargo rustango new myblog                      # fullstack (the default)
+cargo rustango new api_demo  --template api
+cargo rustango new shop      --template tenant
+```
+
+---
+
+## Ce qui est généré
+
+Chaque template écrit un projet Cargo autonome :
+
+```text
+<name>/
+  Cargo.toml            # the rustango dependency + features for this template
+  .env.example          # copy to .env (DATABASE_URL, RUSTANGO_SESSION_SECRET, …)
+  .gitignore
+  rust-toolchain.toml   # pins the Rust toolchain
+  docker-compose.yml    # a Postgres service to develop against
+  Dockerfile            # production image
+  README.md
+  config/
+    default.toml        # settings shared across every environment
+    dev_settings.toml   # per-tier overrides …
+    staging_settings.toml
+    prod_settings.toml
+  migrations/           # JSON migration files (committed to git)
+  src/
+    main.rs             # the single binary — HTTP server + every manage verb
+    models.rs           # your #[derive(Model)] structs
+    views.rs            # request handlers ("views")
+    urls.rs             # pub fn api() -> Router that aggregates your routes
+```
+
+### Un seul binaire pour tout
+
+`src/main.rs` est le seul point d'entrée. Il démarre le serveur HTTP **et** dispatche chaque verbe `manage` — il n'y a pas de `manage.py` séparé ni de `src/bin/manage.rs` :
+
+```rust
+mod models;
+mod urls;
+mod views;
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    rustango::manage::Cli::new()
+        .api(urls::api())
+        .with_welcome()  // friendly `/` page until you add a root handler
+        .with_health()   // /health + /ready endpoints (fullstack & tenant)
+        .run()
+        .await
+}
+```
+
+Ainsi, `cargo run` démarre le serveur, et `cargo run -- <verb>` exécute les migrations, les générateurs, et le reste.
+
+En quoi les templates diffèrent à l'intérieur de `main.rs` / `urls.rs` :
+
+- **api** — pas d'admin ; `urls::api()` se contente d'agréger vos propres routes.
+- **fullstack** — `urls.rs` expose également `admin_router(pool)` (construit à partir de `admin::Builder::new(pool).build()`) afin que l'admin automatique se monte sur `/admin`.
+- **tenant** — `main.rs` ajoute `.tenancy()`, servant la console opérateur sur le domaine apex et chaque tenant sous son propre sous-domaine. Les propres tables du framework sont générées dans un dossier **`system/migrations/`** à partir des modèles compilés (à la manière de Django) lors du premier `cargo run -- migrate` — aucun JSON de bootstrap livré à la main, donc le tout premier migrate fonctionne sans configuration supplémentaire.
+
+### Configuration en couches
+
+Les paramètres se chargent d'abord depuis `config/default.toml`, puis depuis `config/<RUSTANGO_ENV>_settings.toml` par-dessus. `RUSTANGO_ENV` vaut `dev` par défaut, si bien qu'un `cargo run` juste après l'échafaudage fonctionne sans aucune modification ; définissez `RUSTANGO_ENV=prod` en production pour prendre en compte `prod_settings.toml`.
+
+### Premier lancement
+
+```sh
+cd <name>
+cp .env.example .env
+docker compose up -d        # start Postgres
+cargo run -- migrate        # apply migrations
+cargo run                   # serve
+cargo run -- --help         # see every manage verb
+```
+
+---
+
+## Ajouter un module fonctionnel : `manage startapp`
+
+C'est l'équivalent du `startapp` de Django — il échafaude un module autonome regroupant des modèles, des vues et des routes liés entre eux :
+
+```sh
+cargo run -- startapp blog
+```
+
+Cela écrit `src/blog/` contenant `mod.rs`, `models.rs` (un modèle de départ nommé d'après l'app mise au singulier — `blog` → `Blog`), `views.rs`, `urls.rs`, et `tests.rs`, puis déclare le module dans `src/main.rs` et fusionne ses routes dans `urls::api()`.
+
+Options :
+
+- **`--into <dir>`** — échafaude sous un répertoire de base autre que `src/` (par exemple un membre de workspace).
+- **`--with-manage-bin`** — génère aussi un `bin/manage.rs` (pour les architectures qui préfèrent un binaire manage séparé).
+
+---
+
+## Générer des fichiers individuels : les commandes `make:*`
+
+Au sein d'un projet, les verbes `make:*` échafaudent un fichier à la fois. La référence complète, drapeau par drapeau, se trouve dans la [référence CLI manage](manage) ; les formes les plus courantes sont :
+
+| Commande | Génère | Comparable à |
+|---|---|---|
+| `make:viewset <Name> [--model <M>]` | Un ViewSet CRUD façon DRF | DRF `ViewSet` |
+| `make:serializer <Name> [--model <M>]` | Un sérialiseur pour la mise en forme des requêtes/réponses | Sérialiseur DRF |
+| `make:api_routes <app>` | Un agrégateur de routes API pour une app | — |
+| `make:form <Name>` | Un formulaire HTML avec validation | `Form` Django |
+| `make:job <Name>` | Un gestionnaire de job en arrière-plan | Job Laravel / Celery |
+| `make:notification <Name>` | Une notification multi-canal | Notification Laravel |
+| `make:middleware <Name>` | Un squelette de middleware | Middleware Django / Laravel |
+| `make:test <Name>` | Un module de test utilisant le client de test in-process | — |
+
+```sh
+cargo run -- make:viewset PostViewSet --model Post
+cargo run -- make:serializer PostSerializer --model Post
+cargo run -- make:test post_smoke
+```
+
+---
+
+## Un flux typique
+
+```sh
+cargo rustango new myblog                              # 1. scaffold the project
+cd myblog
+cargo run -- startapp blog                             # 2. add a feature module
+# …add fields to src/blog/models.rs…
+cargo run -- makemigrations                            # 3. generate a migration
+cargo run -- migrate                                   # 4. apply it
+cargo run -- make:viewset PostViewSet --model Post     # 5. expose a JSON API
+cargo run                                              # 6. serve
+```

--- a/docs/fr/sso.md
+++ b/docs/fr/sso.md
@@ -1,0 +1,141 @@
+# SSO admin (OpenID Connect / connexion sociale)
+
+Connectez-vous à l'admin rustango avec un fournisseur d'identité externe —
+Google, Microsoft / Azure AD, GitHub, GitLab, Discord, ou **n'importe quel
+fournisseur OpenID Connect** (Okta, Auth0, Keycloak, …) — au lieu d'un
+mot de passe local. Activez-le avec la fonctionnalité cargo `admin-sso`.
+
+Vous pouvez configurer **plusieurs providers**, chacun géré depuis
+l'interface d'admin comme une ligne (pas de fichier de configuration, pas
+de recompilation). Les points de terminaison d'un provider sont
+découverts automatiquement à partir de son URL d'émetteur (issuer) OIDC
+lors de la connexion ; les providers sociaux utilisent des préréglages
+intégrés.
+
+Le SSO fonctionne en **liaison à un compte existant** : l'email vérifié
+renvoyé par l'IdP doit correspondre à un utilisateur admin existant. Le
+SSO authentifie la personne ; il ne crée jamais de comptes et n'accorde
+jamais d'accès par lui-même. Un email inconnu ou non vérifié est refusé.
+
+```toml
+[dependencies]
+rustango = { version = "0.48", features = ["admin-sso"] }
+```
+
+## Comment ça fonctionne
+
+1. La page de connexion affiche un bouton **« Sign in with &lt;provider&gt; »**
+   par provider activé.
+2. Cliquer sur l'un d'eux (`GET <login>/sso/<slug>`) redirige vers l'IdP
+   avec un cookie de flux signé et à courte durée de vie (PKCE + `state`
+   CSRF).
+3. L'IdP renvoie l'utilisateur vers `<login>/sso/<slug>/callback`.
+4. rustango vérifie le flux, échange le code, lit `/userinfo`, et exige
+   **`email_verified`**.
+5. Il recherche un utilisateur admin par cet email. S'il en existe un et
+   qu'il est actif, rustango émet la **même session à cookie signé**
+   qu'une connexion par mot de passe produit, liée à cet utilisateur —
+   ainsi chaque garde-fou existant (superutilisateur / permissions,
+   invalidation en direct au changement de mot de passe) s'applique
+   toujours.
+6. Aucune correspondance → l'utilisateur est renvoyé vers la page de
+   connexion avec une erreur générique (les détails vont dans le journal
+   serveur, jamais dans le navigateur).
+
+Le secret client est **chiffré au repos** — la colonne `client_secret`
+est un cast [`EncryptedString`](#stockage-des-secrets), déchiffré en
+mémoire uniquement au moment de la connexion.
+
+## Les providers sont des lignes, gérées dans l'admin
+
+Chaque provider est une ligne `SsoProvider`. Il apparaît comme un modèle
+admin ordinaire — ajout/modification/activation depuis l'interface
+d'admin, sans redéploiement. Champs :
+
+| Champ | Signification |
+|---|---|
+| `slug` | Clé de route stable + id du bouton (`<login>/sso/<slug>`). Unique. |
+| `label` | Texte du bouton, ex. « Sign in with Google ». |
+| `kind` | Un préréglage — `google` / `microsoft` / `github` / `gitlab` / `discord` — ou `oidc` pour un provider OpenID Connect générique. |
+| `issuer_url` | URL de base de découverte OIDC (pour `kind = "oidc"`) ; rustango récupère `{issuer}/.well-known/openid-configuration`. Inutilisé pour les préréglages. |
+| `client_id` | L'identifiant client OAuth fourni par l'IdP. |
+| `client_secret` | Le secret client OAuth, **chiffré au repos** (jamais en clair dans la base de données). |
+| `enabled` | Indique si le bouton s'affiche sur la page de connexion. |
+| `sort_order` | Ordre d'affichage des boutons (croissant). |
+| `scopes` | Substitution optionnelle des scopes, séparés par des espaces (par défaut `openid email profile`). |
+
+Pour ajouter un provider : saisissez le `client_id` + `client_secret`,
+choisissez un `kind` (ou `oidc` + une `issuer_url`), et enregistrez. Les
+points de terminaison sont découverts au moment de la connexion — aucun
+câblage de points de terminaison par provider n'est nécessaire.
+
+## Où chaque surface gère les providers
+
+- **Admin autonome / mono-tenant** (`crate::admin`) : les lignes
+  `SsoProvider` forment une table globale simple, gérée depuis l'admin
+  nu. Nécessite `Builder::with_session_auth` (le SSO émet la même
+  session).
+- **Admin tenant** (multi-tenancy) : chaque tenant gère ses **propres**
+  lignes `SsoProvider` depuis son admin — granulaire, en libre-service,
+  isolé par tenant.
+- **Console opérateur** (multi-tenancy) : un opérateur définit un
+  **`SharedSsoProvider`** une seule fois, et il est proposé à **tous**
+  les tenants (un Google à l'échelle de l'entreprise, par exemple). Géré
+  depuis le panneau *Shared SSO* de la console.
+
+Sur la page de connexion d'un tenant, les deux ensembles fusionnent, et
+en cas de collision de slug, c'est le **propre provider du tenant qui
+l'emporte** sur le provider partagé — un tenant peut ainsi remplacer un
+provider partagé pour lui-même.
+
+L'URL de callback est dérivée par requête à partir de l'hôte + du slug
+(`https://<host><login>/sso/<slug>/callback`), c'est donc celle-là qu'il
+faut enregistrer auprès de l'IdP. Liez un utilisateur en définissant la
+colonne `email` sur sa ligne `rustango_users` (tenant) /
+`rustango_admin_users` (nu) à l'adresse renvoyée par l'IdP.
+
+## Stockage des secrets
+
+`client_secret` est stocké **chiffré au repos** avec XChaCha20-Poly1305
+(AEAD), la clé étant dérivée de la variable d'environnement
+**`RUSTANGO_SECRET_KEY`**. Il n'est déchiffré en mémoire qu'au moment de
+la connexion, pour s'authentifier auprès du point de terminaison de
+jetons de l'IdP. Ainsi, un dump de base de données divulgué n'expose
+jamais le secret, et chaque tenant conserve son propre secret sans
+variable d'environnement par provider.
+
+> Définissez `RUSTANGO_SECRET_KEY` dans le déploiement (n'importe quelle
+> longueur ; elle est hachée en SHA-256 vers une clé de 32 octets). Sans
+> elle, enregistrer ou utiliser un provider échoue immédiatement — la
+> même posture qu'une URL de base de données manquante.
+
+## Providers (préréglages)
+
+Préréglages intégrés : `google`, `microsoft` (Azure AD), `github`,
+`gitlab`, `discord`. Pour tout le reste, utilisez `kind = "oidc"` avec
+une `issuer_url` — rustango exécute la découverte OpenID Connect pour
+trouver les points de terminaison. (Sign in with Apple n'est pas un
+préréglage ; il nécessite une vérification id_token/JWKS.)
+
+## Notes de sécurité
+
+- **Email vérifié uniquement** — les emails non vérifiés de l'IdP sont
+  rejetés.
+- **Pas de provisionnement automatique** — un email inconnu ne peut pas
+  entrer ; créez d'abord l'utilisateur admin (et définissez son
+  `email`).
+- **Secrets chiffrés au repos** (`RUSTANGO_SECRET_KEY`), déchiffrés
+  uniquement en mémoire au moment de la connexion ; les formulaires
+  d'édition masquent le secret stocké.
+- Le cookie de flux a une courte durée de vie (10 min), `HttpOnly`,
+  `SameSite=Lax`, et `Secure` en HTTPS ; la poignée de main transporte
+  PKCE + un `state` signé.
+- Les sessions SSO sont la session admin ordinaire — faire tourner ou
+  désactiver l'utilisateur lié les invalide via le garde-fou en direct
+  existant.
+- Le modèle de confiance repose sur `/userinfo` via TLS (l'id_token n'est
+  pas vérifié indépendamment) ; placez l'admin derrière HTTPS.
+
+## Voir aussi
+
+- [Guide de sécurité](security.md) · [Authentification](auth-flows.md)

--- a/docs/index.toml
+++ b/docs/index.toml
@@ -5,7 +5,7 @@
 # becomes one documentation page, rendered in the order listed here. Files
 # not listed below are not published (e.g. internal audits / inventories).
 
-version = "0.44"
+version = "0.51"
 
 [[section]]
 title = "Getting started"
@@ -15,7 +15,7 @@ pages = ["getting-started.md", "scaffolding.md", "glossary.md"]
 [[section]]
 title = "Guides"
 slug = "guides"
-pages = ["models.md", "orm.md", "admin.md", "serializers.md", "viewsets.md", "html-views.md", "openapi.md", "query-method.md", "mcp.md", "urls.md", "manage.md", "middleware.md", "jobs.md", "websockets.md", "caching.md", "files.md", "i18n.md", "email.md", "testing.md", "security.md"]
+pages = ["models.md", "orm.md", "admin.md", "serializers.md", "viewsets.md", "html-views.md", "openapi.md", "query-method.md", "mcp.md", "urls.md", "manage.md", "migrations.md", "middleware.md", "jobs.md", "websockets.md", "caching.md", "files.md", "i18n.md", "email.md", "testing.md", "security.md"]
 
 [[section]]
 title = "Authentication"

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,190 @@
+# Migrations & the migration engine
+
+**Rustango** ships a Django-style migration engine: you edit your models,
+run `makemigrations` to generate a versioned JSON file describing the
+schema change, and `migrate` to apply it. Since **0.48** the framework
+even migrates **its own** `rustango_*` tables through the same engine —
+no hand-shipped bootstrap DDL. This page explains the moving parts that
+make an upgrade safe: the two migration chains, squash reconciliation,
+and the guarded fake-initial that lets a pre-existing database adopt the
+engine without collisions.
+
+> **New to migrations?** The day-to-day CLI verbs — `makemigrations`,
+> `migrate`, `migrate --squash`, `migrate --fake`, `downgrade`,
+> `showmigrations` — are covered command-by-command in the
+> [manage guide](manage.md#migrations). This page is the conceptual
+> model behind them.
+
+> **Source:** `rustango::migrate` (`runner`, `make`, `file`, `manage`)
+> and `rustango::tenancy::migrate` — the runner's reconciliation lives in
+> `migrate::runner::reconcile`.
+
+---
+
+## Two migration chains
+
+A migration belongs to one of two independent chains, each with its own
+ledger table (the row of applied names the runner consults to skip work):
+
+| Chain | What it manages | Ledger table |
+|---|---|---|
+| **Project** | your `#[derive(Model)]` tables, in `migrations/` | `__rustango_migrations__` |
+| **System** | the framework's own `rustango_*` tables (`Org`, `User`, roles/permissions, agents, media, …), in `system/migrations/` | `__rustango_system_migrations__` |
+
+The **system chain** is what makes framework schema self-describing.
+Its files are generated from the compiled framework models — and they're
+**`#[cfg(feature = …)]`-aware**: a feature-gated column or table is
+compiler-stripped when the feature is off, so enabling a feature makes
+`makemigrations` emit an `AddColumn` / `CreateTable` and disabling it
+emits a `DropColumn` / `DropTable`. Scaffolded tenant projects ship an
+**empty** `system/migrations/`; the first `cargo run -- migrate`
+generates and applies it (see [scaffolding](scaffolding.md)).
+
+`migrate` applies the system chain **before** your project's migrations.
+In tenancy mode the two scopes deliberately overlap on the shared
+framework tables, so the tenant-scope chain is the one that runs; the
+registry-only tables (`rustango_orgs`, `rustango_operators`) mean nothing
+without tenancy. Non-tenancy apps that use a framework subsystem (e.g.
+`media`) get the system chain applied too.
+
+---
+
+## Squash reconciliation — `Migration.replaces`
+
+A **squash** collapses a run of historical migrations into one freshly
+generated file that recreates the same end state — handy when a stack of
+half-finished migrations is easier to regenerate than to fix. The catch:
+the file's `CREATE TABLE`s would collide on any database that already
+applied the migrations it collapsed (a colleague's checkout, staging,
+CI).
+
+`migrate --squash` solves this by stamping the new file's **`replaces`**
+list with the names it collapsed:
+
+```jsonc
+{
+  "name": "0007_squashed_0001_0006",
+  "replaces": ["0001_initial", "0002_add_status", "0003_add_slug", "…"],
+  "forward": [ /* recreates the end state */ ]
+}
+```
+
+With `replaces` set, the runner **reconciles** the squash against the
+database's actual state instead of blindly running it. The decision is
+automatic and depends entirely on what's already there:
+
+| Database state | What the runner does |
+|---|---|
+| fresh — no history, no tables | runs the squash for real |
+| every replaced migration is in the ledger | records it, tombstones the predecessors, **no DDL** |
+| tables exist but the ledger has no history | records it, **no DDL** (Django's cross-ledger `--fake-initial`) |
+| only *some* replaced rows / tables present | **refused** — names what's missing, tells you to resolve by hand |
+
+The **partial** case is a hard error on purpose: no automatic choice is
+safe there, so the runner stops and reports what it found rather than
+guessing. Resolve it with `migrate --fake` (below).
+
+Migrations superseded by an applied squash count as applied, so you can
+leave the collapsed files on disk for a release or two — deployments that
+never ran them still migrate forward correctly. Ordinary (non-squash)
+migrations are unaffected: a plain migration whose table already exists
+still fails loudly, because that's a real conflict, not a
+known-equivalent history.
+
+---
+
+## The guarded fake-initial reconcile
+
+This is the mechanism that lets an **existing** database adopt the system
+chain seamlessly. Before 0.51 the framework built some of its tables via
+lazy `ensure_table` raw DDL; those tables exist but aren't recorded in
+the `__rustango_system_migrations__` ledger, so a fresh `CREATE TABLE`
+from the new system migration would collide (`relation "rustango_media"
+already exists`, MySQL 1050, …).
+
+The system chain reconciles this itself. A pending **system** migration is
+inspected: the operations that make up *creating its tables* —
+`CreateTable`, plus `CreateIndex` / `CreateM2MTable` targeting a table the
+same migration creates — are the accepted set. If **every** table it
+creates already exists, the migration is **recorded into the ledger
+without running any DDL**, and existing data is left untouched. If only
+*some* of its tables exist, the chain creates just the missing ones
+(`CREATE TABLE IF NOT EXISTS` semantics) and leaves the rest alone.
+
+The guard is deliberately narrow:
+
+- **Scoped to the framework's own system chain.** User migrations use the
+  plain runner and never auto-fake — table-existence faking is opt-in to
+  the system path only.
+- **Anything that isn't table-creation disqualifies faking** — an index
+  on a pre-existing table, an alter / drop / data op / callback falls
+  through to a real run, so genuine work is never skipped.
+- **Existence is asked of the current namespace only** — Postgres
+  `current_schema()`, MySQL `DATABASE()`, SQLite `sqlite_master` — not
+  through the `search_path`, so in schema-mode multi-tenancy a same-named
+  table in `public` can't fool a tenant into skipping its own tables.
+
+A squash's partial state is still refused (see above); only the
+framework's system chain does the piecemeal "create the missing ones"
+repair.
+
+---
+
+## Repairing drift by hand — `migrate --fake`
+
+When the database is already in the target state but the ledger doesn't
+know it (a DB set up out-of-band, a dropped ledger, a partially-succeeded
+migration, a refused partial squash), stamp a migration as applied
+**without running its SQL**:
+
+```bash
+cargo run -- migrate --fake 0004_add_indexes
+cargo run -- migrate --fake 0001_rustango_registry_initial --system       # framework's own chain
+cargo run -- migrate --fake 0001_rustango_registry_initial --all-tenants  # every active tenant
+```
+
+- `--system` stamps the framework's system chain
+  (`system/migrations/` → `__rustango_system_migrations__`) instead of
+  your project's.
+- `--all-tenants` fans the stamp across every active tenant, reporting
+  each and continuing past failures — the framework tables live per
+  tenant, so repairing them is a per-tenant job. Combine with `--system`
+  for the framework's tables across all tenants.
+
+The name is validated against the migration directory first, so a typo
+can't land a bogus row; stamping is idempotent, and the flag can be
+repeated to repair a stretch of rows in one command.
+
+---
+
+## Upgrading to 0.51.2
+
+> **0.51.0 and 0.51.1 were yanked** — the reconcile they promised never
+> actually fired against real 0.46–0.50 databases (0.51.0 moved the media
+> tables onto system migrations and collided; 0.51.1's guard demanded a
+> migration be *purely* `CreateTable`, which no generated migration is).
+> **Upgrade straight to 0.51.2**, which fixes both.
+
+For an existing deployment, the upgrade is a plain deploy — no
+reprovision, no manual DDL:
+
+```bash
+cargo run -- migrate
+```
+
+The guarded fake-initial handles the pre-existing framework tables: the
+first `migrate` records the system migration whose tables already exist
+into the ledger without touching them, creates only what's genuinely
+missing, and leaves your data alone. If a database is in a truly
+inconsistent partial state the runner stops and tells you what it found;
+resolve it with `migrate --fake` rather than forcing.
+
+---
+
+## See also
+
+- [`manage` guide](manage.md#migrations) — every migration CLI verb, with
+  examples.
+- [Scaffolding](scaffolding.md) — where `migrations/` and
+  `system/migrations/` come from.
+- [Models](models.md) — the derive the migrations are generated from.

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -1,24 +1,57 @@
-# Admin SSO (OpenID Connect / social login)
+# SSO (OpenID Connect / social login)
 
-Sign in to the rustango admin with an external identity provider —
-Google, Microsoft / Azure AD, GitHub, GitLab, Discord, or **any OpenID
-Connect provider** (Okta, Auth0, Keycloak, …) — instead of a local
-password. Enable it with the `admin-sso` cargo feature.
+Sign in with an external identity provider — Google, Microsoft / Azure
+AD, GitHub, GitLab, Discord, or **any OpenID Connect provider** (Okta,
+Auth0, Keycloak, …) — instead of a local password.
 
 You can configure **multiple providers**, each managed from the admin UI
 as a row (no config file, no rebuild). A provider's endpoints are
 auto-discovered from its OIDC issuer URL at login; social providers use
 built-in presets.
 
-SSO is **link-to-existing**: the verified email the IdP returns must
-match an existing admin user. SSO authenticates the person; it never
-creates accounts and never grants access on its own. An unknown or
-unverified email is refused.
+SSO is **link-to-existing** for the admin: the verified email the IdP
+returns must match an existing admin user. It authenticates the person;
+it never creates accounts and never grants access on its own. An unknown
+or unverified email is refused. (The member flow, below, may opt into
+auto-provisioning.)
+
+> **Source:** the admin-independent core `rustango::sso` (`SsoProvider`,
+> `build_provider`, `verified_email`, `ResolvedSso`, `SsoError`), the
+> bare-admin wiring `rustango::admin::sso`, per-tenant/console SSO
+> `rustango::tenancy::sso` (`SharedSsoProvider`), and member SSO
+> `rustango::tenancy::member_auth`.
+
+## Features & who uses them
+
+Since **0.49** the SSO core is its own feature, independent of the
+auto-admin, so an end-user (member) login can build without pulling in
+`crate::admin`:
+
+| Feature | Pulls in | Gives you |
+|---|---|---|
+| `sso` | `oauth2`, `casts` | The admin-independent core: `rustango::sso` — the OIDC / social OAuth handshake, the DB-backed `SsoProvider` model (secret encrypted at rest via `casts`), and the member flow (`tenancy::member_auth`, with `tenancy`). |
+| `admin-sso` | `admin`, `sso` | The above **plus** the bare-admin login wiring (`rustango::admin::sso`) — SSO buttons on the admin login page that mint the admin session. |
 
 ```toml
 [dependencies]
-rustango = { version = "0.48", features = ["admin-sso"] }
+# Admin login with SSO:
+rustango = { version = "0.51", features = ["admin-sso"] }
+# Member (end-user) SSO without the auto-admin:
+rustango = { version = "0.51", features = ["tenancy", "sso"] }
 ```
+
+`admin::sso_provider` and the historical `admin::sso::*` core paths are
+now **re-export shims** over `sso::provider` / `sso::*`, so existing
+`crate::admin::sso::{build_provider, ResolvedSso, …}` and
+`crate::admin::sso_provider::SsoProvider` imports keep resolving
+unchanged (the table name `rustango_sso_providers` and every field are
+untouched — migrations are unaffected).
+
+The email a user is linked on is the `email` column. On the tenant
+`User` model it is gated on the **`sso`** feature (moved off `admin-sso`
+in 0.49, so member-SSO-only builds still get the column); the bare
+`AdminUser.email` remains behind `admin-sso`. Enabling or disabling the
+feature emits an `AddColumn` / `DropColumn` migration for that column.
 
 ## How it works
 
@@ -83,6 +116,74 @@ The callback URL is derived per request from the host + slug
 IdP. Link a user by setting the `email` column on their
 `rustango_users` (tenant) / `rustango_admin_users` (bare) row to the
 address the IdP returns.
+
+## Member (end-user) SSO
+
+The surfaces above sign people in to an **admin**. `tenancy::member_auth`
+is the member-facing analogue: it logs an end-user into a tenant's own
+user pool (`rustango_users`) and mints a **member session**, so a gym
+member / SaaS customer can "Sign in with Google" without touching the
+admin. It reuses the exact same `rustango::sso` core and the tenant's own
+`SsoProvider` rows — only the session it mints differs, which is why it
+lives behind the `sso` feature (not `admin-sso`) and needs no auto-admin.
+
+Mount `member_sso_router` into a `tenancy::server::Builder` stack (it
+reads the resolved `Arc<TenantContext>` the builder injects):
+
+```rust
+use rustango::tenancy::member_auth::{member_sso_router, MemberAuthConfig};
+
+let members = member_sso_router(MemberAuthConfig {
+    login_base:     "/auth".into(),   // buttons link to /auth/sso/<slug>
+    landing_url:    "/".into(),       // post-login destination (honors a same-origin ?next)
+    auto_provision: true,             // create a user from a verified email on first sign-in
+    session_ttl:    7 * 24 * 60 * 60, // 7 days
+    ..Default::default()
+});
+```
+
+It mounts two per-slug routes off `login_base`:
+
+- `GET {login_base}/sso/{slug}` — begin the handshake, redirect to the IdP.
+- `GET {login_base}/sso/{slug}/callback` — complete it, find-or-provision
+  the member, mint the session cookie.
+
+Differences from the admin flow:
+
+- **Auto-provisioning.** With `auto_provision = true` (the default), a
+  verified IdP email with no matching `rustango_users` row **creates**
+  one — username from the email local-part (deduped on a clash), a real
+  but unusable random password hash (SSO users can't password-login).
+  Set it to `false` for admin-style link-to-existing (unknown email
+  refused).
+- **Its own session cookie.** The member cookie
+  (`rustango_member_session`) is **domain-separated** from the tenant /
+  admin session cookies: the signed message carries a per-domain tag and
+  an audience claim, so a member cookie can never validate as a
+  tenant/admin cookie (or vice-versa) even though both are signed with
+  `RUSTANGO_SESSION_SECRET`. It is slug-bound (a cookie minted for `acme`
+  never authenticates on `globex`) and invalidated by a password rotation
+  (parity with the admin session).
+
+Read the current member in a handler with the **`CurrentMember`**
+extractor — the member analogue of `SessionUser`. It's infallible
+(`None` for anonymous / expired / rotated-out / cross-tenant sessions),
+so it composes with public routes:
+
+```rust
+use rustango::tenancy::member_auth::CurrentMember;
+
+async fn dashboard(CurrentMember(member): CurrentMember) -> impl axum::response::IntoResponse {
+    match member {
+        Some(user) => format!("Hi, {}", user.username),
+        None => "Please sign in".to_owned(),
+    }
+}
+```
+
+> **v1 scope.** Member SSO resolves providers from the tenant's own
+> `SsoProvider` rows only — the registry-wide `SharedSsoProvider` merge
+> and a custom `provision` hook are follow-ups.
 
 ## Secret storage
 


### PR DESCRIPTION
Documentation-only branch that backs the live docs site (rustango.com seeds its `docs/` from here via the docs deploy).

- **French docs** (`docs/fr/`): getting-started, scaffolding, models, orm, admin, i18n, manage, sso — mirrored filenames so the docs site maps FR⇄EN per page.
- **0.51 feature updates**: `sso.md` rewrite (`rustango::sso` core + `tenancy::member_auth`), new `migrations.md` (squash/replaces, --fake, fake-initial reconcile), admin logout note, `index.toml` version 0.44→0.51.
- **README**: Docs links → rustango.com (was rustango.im-fullstack.dev).

No framework code changes.