### PR TITLE
docs: full FR/DE/ES translations + README rustango.com

### DIFF
--- a/docs/de/admin.md
+++ b/docs/de/admin.md
@@ -1,0 +1,546 @@
+# Die Administrationsoberfläche
+
+**Rustango** erzeugt eine vollständige Admin-Oberfläche aus deinen Modellen — dieselbe
+Idee wie das Admin von Django oder ein Nova/Filament-Panel von Laravel, aber mit
+**null Boilerplate pro Modell**. Füge `#[derive(Model)]` hinzu, binde das Admin einmal
+ein, und jedes Modell erhält eine Listenansicht mit Suche, Filtern, Sortierung,
+Paginierung und Massenaktionen; ein nach Feldgruppen gegliedertes Erstellen-/Bearbeiten-
+Formular; inline-Bearbeitung von Kindobjekten; einen Prüfpfad pro Zeile; und eine
+Live-Modellreferenz. Alles Folgende wird deklarativ in einem `admin(...)`-Block am
+Derive konfiguriert, oder mit einer Handvoll `Builder`-Methoden und Registrierungsmakros
+auf Modulebene.
+
+[![Das automatisch generierte Admin: eine Beitragsliste mit Filter-Facetten, Suche, Massenaktionen und Paginierung — alles aus einem einzigen `admin(...)`-Block](img/admin.png)](img/admin.png)
+
+> **Quelle:** `rustango::admin` (die `admin(...)`-Derive-Optionen, die `Builder`-
+> API und die Registrierungsmakros) — hinter dem `admin`-Feature (standardmäßig
+> aktiviert).
+>
+> **Lauffähige Version:** jedes Feature auf dieser Seite wird in einem getesteten,
+> kompilierbaren Beispiel unter
+> [`crates/rustango/examples/admin_demo`](../crates/rustango/examples/admin_demo)
+> ausgeführt. Die Screenshots auf dieser Seite stammen aus diesem Beispiel. Wenn ein
+> Snippet seltsam aussieht, vergleiche es damit.
+
+> **Ein Begriff hier ist neu für dich?** *model*, *fieldset*, *audit trail* — siehe das
+> [Glossar](glossary.md).
+
+---
+
+## Inhaltsverzeichnis
+- [Einbinden](#mount-it) · [Die Startseite](#the-home-page)
+- [Ein Modell konfigurieren: der `admin(...)`-Block](#configure-a-model-the-admin-block)
+- [Die Listenansicht](#the-list-view) — Spalten, Suche, Filter, Datumshierarchie, Sortierung, Paginierung
+- [Das Änderungsformular](#the-change-form) — Feldgruppen, Widgets, FK-Bearbeitung, vorbefüllte & schreibgeschützte Felder
+- [Inlines](#inlines) · [Massenaktionen](#bulk-actions) · [Prüfpfad](#audit-trail)
+- [Berechnete Spalten & benutzerdefinierte Filter](#computed-columns-and-custom-filters)
+- [Benutzerdefinierte Views, Querysets & Berechtigungen](#custom-views-querysets-and-permissions)
+- [Authentifizierung](#authentication) · [Theming & Branding](#theming-and-branding)
+- [`Builder`-Referenz](#builder-reference) · [Routen-Referenz](#routes-reference)
+- [Die Modellreferenz (`__docs`)](#the-model-reference) · [Das Beispiel ausprobieren](#try-the-example)
+
+---
+
+## Einbinden
+
+> **Das Admin ist standardmäßig offen.** Es erkennt und liefert *jedes* Modell
+> automatisch — auflisten, erstellen, bearbeiten, löschen — ohne Authentifizierung,
+> bis du sie hinzufügst. Mache es nicht öffentlich zugänglich, bevor du das Login
+> verdrahtet hast: siehe [Authentifizierung](#authentication) weiter unten.
+
+Das Admin ist ein `axum::Router`, den du aus einem Datenbank-Pool baust und unter
+einen Pfad einhängst:
+
+```rust
+use rustango::admin;
+
+let admin_router = admin::Builder::new(pool.clone())
+    .title("Admin Demo")
+    .subtitle("rustango auto-admin showcase")
+    .admin_prefix("/admin")          // MUST match the nest path below
+    .build();
+
+let api = axum::Router::new().nest("/admin", admin_router);
+```
+
+Das Auto-Admin erkennt jedes `#[derive(Model)]` in deiner Binärdatei **automatisch**
+über die `inventory`-Registry — du registrierst Modelle nicht einzeln. Öffne
+`http://localhost:8080/admin`, und sie erscheinen gruppiert in der Seitenleiste.
+
+> **`admin_prefix` muss dem Einhängepfad entsprechen.** Das Admin baut seine Links und
+> Formularaktionen aus `admin_prefix` (Standard `/__admin`). Wenn du unter `/admin`
+> einhängst, aber den Standard-Präfix belässt, liefert jeder Link einen 404. Setze sie
+> gleich.
+
+> **Die Registry einbinden.** Die Inventory-Registrierung wird nur dann in die finale
+> Binärdatei eingebunden, wenn die Modelltypen irgendwo referenziert werden. Ein
+> Bibliotheks-Crate, dessen Modelle nicht anderweitig verwendet werden, benötigt
+> eventuell einen Anstoß per `let _ = std::any::type_name::<Post>();` in `main` (das
+> Beispiel macht das) — andernfalls verwirft der Linker sie und sie erscheinen nie.
+
+### Die Startseite
+
+Die Admin-Wurzel (`GET /<prefix>`) listet jedes registrierte Modell auf, gruppiert nach
+App, mit Tabellennamen und Feldanzahl jedes Modells — plus einem **Recent actions**-
+Feed der neuesten geprüften Änderungen.
+
+[![Die Admin-Startseite: jedes registrierte Modell nach App gruppiert mit Tabellen- und Feldanzahl sowie ein Aktivitäts-Feed der letzten Aktionen](img/admin-home.png)](img/admin-home.png)
+
+---
+
+## Ein Modell konfigurieren: der `admin(...)`-Block
+
+Alles darüber, wie ein Modell erscheint, wird in einem `admin(...)`-Block am Derive
+festgelegt. Hier der Vorzeige-`Post` aus dem Beispiel, der fast jeden Stellhebel
+ausübt:
+
+```rust
+#[derive(Model, Clone, Debug)]
+#[rustango(
+    table = "posts",
+    display = "title",
+    admin(
+        list_display       = "id, title, author_id, status, view_count, published_at",
+        list_display_links = "id, title",
+        list_filter        = "status, author_id",
+        search_fields      = "title, body",
+        search_help_text   = "Search posts by title or body",
+        ordering           = "-published_at",
+        list_per_page      = 10,
+        date_hierarchy     = "published_at",
+        fieldsets          = "Content: title, body, status | Publishing: author_id, published_at, view_count",
+        actions            = "publish, archive",
+    ),
+    audit(track = "title, body, status"),
+)]
+pub struct Post { /* … */ }
+```
+
+`display = "title"` (am Modell, außerhalb von `admin(...)`) legt das menschenlesbare
+Label fest, das überall verwendet wird, wo eine Zeile referenziert wird — FK-Spalten in
+den Listen anderer Modelle, der Breadcrumb, der Titel der Detailseite.
+
+### Jede `admin(...)`-Option
+
+| Schlüssel | Beispiel | Was es bewirkt |
+|---|---|---|
+| `list_display` | `"id, title, status"` | In der Liste angezeigte Spalten, in Reihenfolge. FK-Spalten rendern den `display`-Wert des Ziels. Berechnete Spalten (siehe unten) können hier benannt werden. Leer = jedes skalare Feld. |
+| `list_display_links` | `"id, title"` | Welche `list_display`-Zellen zur Detailseite verlinken. Muss eine Teilmenge von `list_display` sein. |
+| `list_filter` | `"status, author_id"` | Facetten-Karten in der rechten Leiste — eindeutige Werte + Anzahlen, zum Filtern anklicken. Funktioniert bei skalaren und FK-Spalten. |
+| `search_fields` | `"title, body"` | Felder, die das `?q=`-Suchfeld abgleicht (Groß-/Kleinschreibung-unabhängig `ILIKE`/`LIKE`). |
+| `search_help_text` | `"Search by title"` | Beschriftung, die neben dem Suchfeld gerendert wird. |
+| `ordering` | `"-published_at, id"` | Standardsortierung. `-`-Präfix = DESC; ohne = ASC. Mehrere Schlüssel durch Komma getrennt. |
+| `list_per_page` | `10` | Seitengröße (Standard 50). |
+| `date_hierarchy` | `"published_at"` | Aufschlüsselungsleiste Jahr → Monat → Tag über der Liste, auf einer Date-/DateTime-Spalte. |
+| `fieldsets` | `"Content: title, body \| Meta: status"` | Gliedert das Änderungsformular in benannte Abschnitte. Pipe `\|` trennt Abschnitte, Komma trennt Felder; die `Title:`-Legende ist optional. |
+| `actions` | `"publish, archive"` | Massenaktionen, die im Aktionsauswähler der Liste angeboten werden (jede benötigt einen registrierten Handler — siehe [Massenaktionen](#bulk-actions)). |
+| `readonly_fields` | `"created_at"` | Felder, die im Änderungsformular als Text (ohne Eingabe) gerendert werden. |
+| `raw_id_fields` | `"author_id"` | FK-Felder, die über eine reine ID-Eingabe + Nachschlage-Link bearbeitet werden (gut für große Zieltabellen). |
+| `autocomplete_fields` | `"author_id"` | FK-Felder, die über eine Ajax-Vervollständigung bearbeitet werden, gestützt auf den `__autocomplete`-Endpunkt des Ziels. |
+| `prepopulated_fields` | `"slug:title"` | Ein Feld automatisch befüllen, indem ein anderes beim Tippen sluggifiziert wird (`target:source`; kombiniere Quellen mit `+`). |
+| `list_select_related` | `"all"` / `"none"` / `"author_id"` | Steuert das automatische JOIN von FK-Spalten in der Listenabfrage. `"all"` (Standard) joint jeden FK; `"none"` deaktiviert; ein CSV beschränkt auf benannte FKs. |
+| `formfield_overrides` | `"status:textarea"` | Überschreibt das Formular-Widget eines Feldes (`field:widget`) — siehe die [Widget-Tabelle](#form-widgets). |
+| `actions_on_top` | `true` | Rendert die Massenaktionsleiste über der Liste (Standard `true`). |
+| `actions_on_bottom` | `false` | Rendert eine zweite Aktionsleiste unter der Liste (Standard `false`). |
+
+---
+
+## Die Listenansicht
+
+`GET /<prefix>/<table>` rendert die Liste. Aus dem einzelnen `admin(...)`-Block oben
+erhältst du sortierbare Spalten, ein Suchfeld mit Hilfetext, die Status-/Autor-Facetten-
+Karten mit Live-Anzahlen, die Datumsaufschlüsselung, Paginierung mit 10/Seite und den
+publish/archive-Aktionsauswähler.
+
+**Filtern.** Klicke auf einen beliebigen Wert in einer `list_filter`-Facetten-Karte, um
+die Liste einzuschränken; der aktive Filter erscheint als Chip mit einem **clear**-Link,
+und Zeilenanzahl sowie Facetten-Anzahlen aktualisieren sich. Filter, Suche, Sortierung
+und die Datumshierarchie fügen sich alle in der Query-Zeichenkette zusammen und lassen
+sich kombinieren.
+
+[![Die nach status=published gefilterte Beitragsliste: ein aktiver Filter-Chip, die passende hervorgehobene Facette, das Suchfeld und der Massenaktionsauswähler](img/admin-list-filtered.png)](img/admin-list-filtered.png)
+
+**Sortieren.** Klicke auf einen Spaltenkopf zum Sortieren; erneut klicken, um die
+Richtung umzukehren (`?sort=col&order=asc|desc`). Der Standard kommt aus `ordering`.
+
+**Paginierung.** `list_per_page` legt die Seitengröße fest; navigiere mit `?page=N`.
+Registriere sehr große Tabellen mit `Builder::skip_count_for([...])`, um das
+`SELECT COUNT(*)` zu überspringen (der Pager zeigt dann "Page N" ohne Gesamtsumme); ein
+`?count=skip` pro Anfrage bewirkt dasselbe ad hoc.
+
+**Suche.** Wenn `search_fields` gesetzt ist, erscheint ein Suchfeld und gleicht diese
+Felder mit `ILIKE` (PostgreSQL) / `LIKE` (MySQL, SQLite) ab. `search_help_text` wird als
+dessen Beschriftung gerendert.
+
+**Datumshierarchie.** Mit gesetztem `date_hierarchy` sitzt ein Breadcrumb Jahr → Monat →
+Tag über der Tabelle; das Hineinnavigieren fügt halboffene Bereichsfilter auf dieser
+Spalte hinzu, unter Verwendung der tri-dialektalen Datumsextraktion (PostgreSQL
+`EXTRACT`, MySQL, SQLite `strftime`).
+
+---
+
+## Das Änderungsformular
+
+`GET /<prefix>/<table>/new` (erstellen) und `GET /<prefix>/<table>/<pk>/edit`
+(bearbeiten) rendern das Formular. `fieldsets` gruppiert die Eingaben in benannte
+Abschnitte; ohne es erscheinen alle bearbeitbaren Felder in einem Block.
+
+[![Das Post-Änderungsformular gegliedert in die Feldgruppen Content und Publishing, jedes Feld mit dem passenden Eingabe-Widget für seinen Typ](img/admin-fieldsets.png)](img/admin-fieldsets.png)
+
+Das Absenden eines Formulars validiert die Eingabe, schreibt die Zeile, erfasst einen
+Prüfpfad-Eintrag und leitet zur schreibgeschützten **Detail**-Ansicht
+(`GET /<prefix>/<table>/<pk>`) weiter, die jedes Feld plus Inlines und die Prüfpfad-Karte
+(unten) zeigt. Die **Edit**- und **Delete**-Schaltflächen der Detailseite führen zum
+Formular und zur Löschbestätigung.
+
+### Formular-Widgets
+
+Jedes Feld rendert standardmäßig eine seinem Typ entsprechende Eingabe —
+`<input type="number">` für Ganzzahlen, `type="date"`/`datetime-local` für Datumsangaben,
+`type="checkbox"` für Booleans, ein `<textarea>` für lange Zeichenketten, ein `<select>`
+für FK-Spalten und so weiter. Überschreibe pro Feld mit
+`formfield_overrides = "field:widget"`:
+
+| Widget | Gilt für | Rendert |
+|---|---|---|
+| `textarea` | String | mehrzeiliges `<textarea>` |
+| `password` | String | `<input type="password">` |
+| `email` | String | `<input type="email">` |
+| `url` | String | `<input type="url">` |
+| `color` | String | `<input type="color">` |
+| `slug` | String | Texteingabe mit Slug-Muster |
+| `ipaddress` | String | Texteingabe mit IP-Muster |
+| `json` | Json | monospaced `<textarea>` |
+| `hidden` | beliebig | `<input type="hidden">` |
+
+### Fremdschlüssel bearbeiten
+
+FK-Spalten haben drei Bearbeitungsmodi:
+
+- **Standard** — ein `<select>`, befüllt aus der Zieltabelle, das den `display`-Wert
+  jeder Zeile anzeigt.
+- **`raw_id_fields`** — eine reine ID-Eingabe plus ein Nachschlage-Link; am besten, wenn
+  die Zieltabelle zu groß ist, um sie in einem Dropdown aufzuzählen.
+- **`autocomplete_fields`** — eine Ajax-Vervollständigung, die die `search_fields` des
+  Zielmodells über `GET /<prefix>/<target>/__autocomplete?q=…` abfragt.
+
+### Vorbefüllte & schreibgeschützte Felder
+
+`prepopulated_fields = "slug:title"` gibt clientseitiges JS aus, das das Quellfeld beim
+Tippen in das Zielfeld sluggifiziert (kombiniere mehrere Quellen mit `+`, z. B.
+`"slug:section+title"`). `readonly_fields` rendert die benannten Felder als maskierten
+Text im Formular statt als Eingaben.
+
+---
+
+## Inlines
+
+Inlines zeigen die Zeilen eines Kindmodells auf der Seite des Elternobjekts (Django-
+Inlines). Registriere eines auf Modulebene:
+
+```rust
+rustango::register_admin_inline!(
+    parent = "posts",
+    child  = "comments",
+    fk     = "post_id",                                     // child column → parent PK
+    kind   = rustango::admin::inlines::InlineKind::Tabular, // or Stacked
+    label  = "Comments",
+    fields = &["author_name", "body", "created_at"],
+);
+```
+
+Auf der **Detail**-Seite des Elternobjekts rendern die Kinder als schreibgeschützte
+Tabelle; auf der **Edit**-Seite werden sie zu einem bearbeitbaren FormSet (Zeilen
+hinzufügen / ändern / löschen an Ort und Stelle). Optionen: `kind` (`Tabular` — eine
+Tabellenzeile pro Kind, oder `Stacked` — eine Feldgruppe pro Kind), `label`, `fields`
+(Standard: jedes Skalar außer dem FK), `extra` (leere Zeilen zum Hinzufügen angeboten),
+`max_num` und `readonly_fields`.
+
+[![Die Detailseite eines Beitrags: schreibgeschützte Felder, die Comments-Inline-Tabelle und die Prüfpfad-Karte, die den Erstellungs-Eintrag als JSON-Diff zeigt](img/admin-detail.png)](img/admin-detail.png)
+
+Für Kindzeilen, die über einen generischen Fremdschlüssel (Paar aus Content-Type +
+Objekt-PK) statt über eine einzelne FK-Spalte angehängt sind, verwende
+`register_admin_inline_generic!(parent, child, ct = "content_type_id", pk = "object_pk",
+…)` — ansonsten dieselben Optionen.
+
+---
+
+## Massenaktionen
+
+Benenne die Aktionen in `admin(actions = "...")` und registriere dann einen Handler pro
+Aktion am `Builder`. Der Handler erhält den Pool und die Primärschlüssel der
+ausgewählten Zeilen:
+
+```rust
+use rustango::core::SqlValue;
+
+let admin_router = admin::Builder::new(pool)
+    .register_action("posts", "publish", |pool, pks| {
+        Box::pin(async move {
+            let ids: Vec<String> = pks.iter().filter_map(|v| match v {
+                SqlValue::I64(n) => Some(n.to_string()),
+                SqlValue::I32(n) => Some(n.to_string()),
+                _ => None,
+            }).collect();
+            if !ids.is_empty() {
+                let sql = format!("UPDATE posts SET status='published' WHERE id IN ({})", ids.join(","));
+                rustango::sql::raw_execute_pool(pool, &sql, Vec::new()).await?;
+            }
+            Ok(())
+        })
+    })
+    .register_action("posts", "archive", /* … */)
+    .build();
+```
+
+Wähle Zeilen mit den Kontrollkästchen aus, wähle die Aktion im Auswähler und sende ab
+(`POST /<prefix>/<table>/__action`). `delete_selected` ist eingebaut — du registrierst es
+nicht. Ein in `admin(actions = ...)` gelisteter Aktionsname ohne registrierten Handler
+erscheint schlicht nicht.
+
+---
+
+## Prüfpfad
+
+Füge `audit(track = "field1, field2")` zu einem Modell hinzu, und jedes Erstellen,
+Aktualisieren und Löschen wird in der Tabelle `rustango_audit_log` erfasst (für dich
+erstellt, wenn du `migrate` ausführst). Nur Modelle mit einem `audit(...)`-Attribut
+werden protokolliert; `track` wählt aus, welche Felder im Diff erfasst werden (lasse es
+weg, um alle Skalare zu verfolgen).
+
+```rust
+#[rustango(table = "posts", audit(track = "title, body, status"))]
+```
+
+Jeder Eintrag speichert die Tabelle, den Primärschlüssel, die Operation, die Quelle, ein
+Diff pro Feld (`{before, after}`) als JSON, den Akteur, einen Zeitstempel und einen
+manipulationssicheren Fingerabdruck. Zwei Stellen zeigen es an:
+
+- Die **Detailseite** des Modells erhält eine **Audit trail**-Karte, die aktuelle
+  Änderungen auflistet (wer, wann und das Diff), mit einem **View full history**-Link
+  (im [Detail-Screenshot](#inlines) oben gezeigt).
+- Die **Activity**-Ansicht der Seitenleiste (`GET /<prefix>/__audit`) ist ein
+  zeilenübergreifender Feed, neueste zuerst, mit Facetten-Karten für Entität / Operation
+  / Quelle und einem Aufräumformular, um Einträge älter als N Tage zu bereinigen (was
+  selbst als Prüfpfad-Eintrag erfasst wird).
+
+[![Der Activity-Feed: jede geprüfte Änderung über Modelle hinweg mit JSON-Diffs, Facetten-Karten nach Tabelle/Operation/Quelle und einem Aufräumformular](img/admin-audit.png)](img/admin-audit.png)
+
+---
+
+## Berechnete Spalten und benutzerdefinierte Filter
+
+Wenn der deklarative Block nicht ausreicht, erweitern zwei Makros auf Modulebene die
+Listenansicht:
+
+**Berechnete Spalten** — eine abgeleitete Spalte, nicht aus der Datenbank:
+
+```rust
+rustango::register_admin_computed!(
+    "posts", "word_count", "Words",
+    |row| row.get("body").and_then(|v| v.as_str())
+             .unwrap_or_default().split_whitespace().count().to_string(),
+);
+// then add `word_count` to admin(list_display = "...").
+```
+
+Der Closure erhält die Zeile als `serde_json::Value` und gibt vorab maskiertes HTML
+zurück. Eine Form mit 5 Argumenten fügt `link = |row| Option<String>` hinzu, um die
+Zelle in ein `<a>` einzuschließen.
+
+**Benutzerdefinierte Listenfilter** — Filterlogik, die die Auto-Facetten nicht ausdrücken
+können:
+
+```rust
+fn by_status(value: &str) -> Vec<rustango::core::Filter> { /* map value → predicates */ }
+
+rustango::register_admin_list_filter!(
+    "posts", "status", "Status",
+    &[("draft", "Drafts"), ("published", "Published")],   // (value, label) choices
+    by_status,                                            // fn(&str) -> Vec<Filter>
+);
+```
+
+---
+
+## Benutzerdefinierte Views, Querysets und Berechtigungen
+
+Drei weitere Registrierungsmakros spiegeln die `ModelAdmin`-Hooks von Django wider:
+
+- **Benutzerdefinierte Admin-Seiten** —
+  `register_admin_view!("posts", "duplicate", Method::POST, "Duplicate", handler)`
+  bindet eine zusätzliche Seite/Aktion unter `/<prefix>/posts/duplicate` ein. Der
+  Handler ist ein asynchrones `fn(Pool, Request) -> Response`. (Reservierte Suffixe wie
+  `new`, `__action`, `__autocomplete`, `{pk}`, `{pk}/edit`, `{pk}/delete` werden mit
+  einer Warnung übersprungen.)
+- **Queryset-Einschränkung** —
+  `register_admin_queryset!("posts", hook)`, wobei `hook: fn(&Parts) -> Vec<Filter>`
+  einschränkt, was eine Anfrage sehen kann (z. B. nur die Zeilen des aktuellen
+  Benutzers). Mehrere Hooks auf einer Tabelle fügen sich zusammen.
+- **Berechtigungen auf Zeilenebene** —
+  `register_admin_object_permission!("posts", "change", check)`, wobei
+  `check: fn(&Parts, Option<&Value>) -> bool` pro Zeile erlaubt oder verweigert.
+  Eingebaute Handler konsultieren die Aktionen `add`, `change`, `delete` und `view`;
+  mehrere Hooks werden mit UND verknüpft.
+
+Für gröbere, codename-basierte Zugriffskontrolle sperrt `Builder::with_user_perms([...])`
+jede Tabelle auf `{table}.view` / `.add` / `.change` / `.delete`: fehlendes `view`
+verbirgt das Modell und liefert bei direkten Treffern 404, fehlendes `change` rendert es
+schreibgeschützt, und fehlendes `add` / `delete` entfernt diese Schaltflächen.
+
+---
+
+## Authentifizierung
+
+Standardmäßig ist das Admin **offen** — jeder, der es erreichen kann, kann es benutzen.
+Sperre es auf eine von zwei Arten:
+
+- **Session-Auth (eingebaut).** `Builder::with_session_auth(secret)` bindet
+  `/login` + `/logout` (und eine optionale `/account/password`-Änderungsseite) ein und
+  umgibt jede andere Route mit Middleware, die anonyme Anfragen auf das Login-Formular
+  umleitet. Anmeldedaten liegen in der Tabelle `rustango_admin_users`
+  (`username`, argon2 `password_hash`, `is_superuser`, `active`, `created_at`); das
+  Ändern eines Passworts widerruft die anderen Sitzungen dieses Benutzers. Optionale
+  TOTP-Zweifaktor-Authentifizierung ist hinter dem `totp`-Feature verfügbar, mit
+  Registrierung unter `/account/totp`.
+
+  ```rust
+  let admin = admin::Builder::new(pool)
+      .with_session_auth(session_secret)
+      .secure_cookies(true)              // HTTPS-only cookie in production
+      .build();
+  ```
+
+- **Setze deine eigene Auth davor.** Lasse das Admin offen und setze HTTP-Basic-Auth,
+  OAuth2 oder unternehmensweites SSO mit deiner eigenen Middleware vor den Einhängepfad.
+
+Wenn die Session-Auth aktiv ist, zeigt die Fußzeile der Seitenleiste eine Zeile
+**"Signed in as _username_"** und eine **Logout**-Schaltfläche (ein `POST`-Formular).
+Eigenständige Admins posten standardmäßig an `{admin_prefix}/logout`; ein Mandanten-Admin
+sitzt hinter der eigenen Logout-Route der Mandanten-Schicht, also verweise die
+Schaltfläche dorthin mit `Builder::logout_url`:
+
+```rust
+let admin = admin::Builder::new(pool)
+    .with_session_auth(session_secret)
+    .logout_url("/staff-logout")       // POST target for the sidebar Logout button
+    .build();
+```
+
+Der Mandanten-Admin-Builder verdrahtet dies automatisch mit seiner
+`RouteConfig::logout_url`, sodass die Schaltfläche immer eine Route trifft, die
+existiert.
+
+---
+
+## Theming und Branding
+
+| Methode | Wirkung |
+|---|---|
+| `.theme_mode("light" \| "dark" \| "auto")` | Standard-Farbthema (setzt `data-theme` auf `<html>`). |
+| `.title(s)` / `.subtitle(s)` | Kopftext der Seitenleiste. |
+| `.brand_logo_url(url)` | Über dem Titel gerendertes Logo. |
+| `.brand_name(s)` / `.brand_tagline(s)` | Mandantenspezifische Überschreibungen von Titel/Untertitel. |
+| `.tenant_brand_css(css)` | Ein vorgefertigter `:root{…}`-CSS-Variablen-Block, inline eingebettet für mandantenspezifische Paletten. |
+| `.from_settings(pool, &settings)` | Baut Branding + Sichtbarkeit aus den Abschnitten `[admin]` / `[brand]` deiner Konfigurationsdatei. |
+
+`from_settings` liest `admin.title`, `admin.subtitle`, `admin.logo_url`,
+`admin.theme_mode`, `admin.url_prefix`, `admin.allowed_tables`,
+`admin.read_only_tables`, greift auf den `[brand]`-Abschnitt zurück und setzt
+`secure_cookies` standardmäßig auf `true`. Imperative `Builder`-Aufrufe danach gewinnen
+weiterhin.
+
+---
+
+## `Builder`-Referenz
+
+Jede Methode auf `admin::Builder` (jede gibt `Self` zur Verkettung zurück, sofern nicht
+anders angegeben):
+
+| Methode | Zweck |
+|---|---|
+| `new(pool)` | Aus einem beliebigen Pool konstruieren (PostgreSQL / MySQL / SQLite). Standardwerte: Präfix `/__admin`, Dev-Cookies. |
+| `from_settings(pool, &settings)` | Aus geparster Konfiguration konstruieren (`config`-Feature). |
+| `title(s)` / `subtitle(s)` | Kopf- / Unterüberschrift der Seitenleiste. |
+| `admin_prefix(p)` | URL-Präfix — **muss dem Einhängepfad entsprechen**. Standard `/__admin`. |
+| `audit_url(u)` | Pfad der Aktivitäts-/Prüfpfad-Ansicht. Standard `/__audit`. |
+| `static_url(u)` | Präfix für eingebettete Assets (Favicon, Logo). Standard `/__static__`. |
+| `change_password_url(u)` | Pfad der Selbstbedienungs-Passwortänderungsseite (fügt den Seitenleisten-Link hinzu). |
+| `show_only([tables])` | Whitelist, welche Tabellen erscheinen; andere liefern 404 und sind verborgen. |
+| `read_only([tables])` | Diese Tabellen rendern, aber Erstellen/Bearbeiten/Löschen verbieten. |
+| `read_only_all()` | Markiert **jede** Tabelle als schreibgeschützt. |
+| `skip_count_for([tables])` | Überspringt `COUNT(*)` auf riesigen Tabellen (Pager zeigt "Page N"). |
+| `with_user_perms([codenames])` | Sperrt Tabellen auf `{table}.view/add/change/delete`. |
+| `register_action(table, name, handler)` | Registriert einen Massenaktions-Handler. |
+| `with_session_auth(secret)` | Erfordert Cookie-Login (`/login` + `/logout`). |
+| `logout_url(u)` | POST-Ziel für die Logout-Schaltfläche der Seitenleiste. Standard `{admin_prefix}/logout`; Mandanten-Admins setzen es auf ihre Mandanten-Logout-Route. |
+| `secure_cookies(bool)` | Setzt das `Secure`-Flag (HTTPS-only) auf dem Session-Cookie. |
+| `theme_mode(m)` | `"light"` / `"dark"` / `"auto"`. |
+| `brand_logo_url(url)` | Logo über dem Titel. |
+| `brand_name(s)` / `brand_tagline(s)` | Mandantenspezifische Marken-Überschreibungen. |
+| `tenant_brand_css(css)` | Mandantenspezifischer CSS-Variablen-Block. |
+| `impersonated_by(operator_id)` | Rendert ein Impersonations-Banner (Operator-Konsole). |
+| `tenant_mode()` | Verbirgt registry-scoped Modelle (automatisch für Mandanten-Admins gesetzt). |
+| `build()` | Finalisiert und gibt den `axum::Router` zurück. |
+
+---
+
+## Routen-Referenz
+
+Alle Pfade sind relativ zu `admin_prefix`:
+
+| Pfad | Methode | Was |
+|---|---|---|
+| `/` | GET | Startseite — Modellindex + aktuelle Aktionen. |
+| `/<table>` | GET | Listenansicht (Suche, Filter, Sortierung, Paginierung). |
+| `/<table>` | POST | Erstellen-Absenden. |
+| `/<table>/new` | GET | Erstellungsformular. |
+| `/<table>/<pk>` | GET | Detailansicht (schreibgeschützt), mit Inlines + Prüfpfad-Karte. |
+| `/<table>/<pk>` | POST | Aktualisieren-Absenden. |
+| `/<table>/<pk>/edit` | GET | Bearbeitungsformular. |
+| `/<table>/<pk>/delete` | POST | Löschen (nach Bestätigung). |
+| `/<table>/__action` | POST | Führt eine Massenaktion auf ausgewählten PKs aus. |
+| `/<table>/__autocomplete` | GET | FK-Vervollständigungs-JSON (`?q=`). |
+| `/__docs` | GET | Modellreferenz. |
+| `/__audit` (oder `audit_url`) | GET | Aktivitäts-Feed + Aufräumen. |
+| `/login`, `/logout` | GET/POST | Session-Auth (wenn aktiviert). |
+| `/account/password`, `/account/totp` | GET/POST | Selbstbedienungs-Passwortänderung / TOTP-Registrierung. |
+
+Mit `register_admin_view!` registrierte benutzerdefinierte Routen binden unter
+`/<table>/<suffix>` ein.
+
+---
+
+## Die Modellreferenz
+
+Jedes Admin liefert eine Live-Modellreferenz (Djangos admindocs) unter
+`<prefix>/__docs` — ein schreibgeschützter Katalog jedes registrierten Modells mit seinen
+Feldern, Spalten, Typen, Flags (PK, unique, …) und Beziehungen. Nichts zu konfigurieren;
+es wird aus deinen Modellen generiert, also weicht es nie vom Schema ab.
+
+[![Die Modellreferenz: die Felder jedes Modells mit Spaltenname, Rust-Typ, Flags und Beziehungen — aus den Modellen generiert](img/admin-model-reference.png)](img/admin-model-reference.png)
+
+---
+
+## Das Beispiel ausprobieren
+
+```bash
+cd crates/rustango/examples/admin_demo
+export DATABASE_URL=postgres://rustango:rustango@localhost:5432/admin_demo
+cargo run -- migrate     # tables + the audit-log table
+cargo run                # seeds demo data, serves the admin at /admin
+```
+
+Öffne dann <http://localhost:8080/admin> und klicke in **Posts** hinein, um die Filter,
+Suche, Datumshierarchie, Aktionen, Feldgruppen, Inline-Kommentare, den Prüfpfad und die
+Modellreferenz zu sehen — jeden Screenshot auf dieser Seite — an einem Ort.
+
+
+---
+
+## Siehe auch
+
+- [Das ORM-Kochbuch](orm.md) — die Modelle, aus denen das Admin generiert wird (inkl. des geteilten Prüfpfads).
+- [HTML-Views](html-views.md) — die generischen klassenbasierten Views, auf denen das Admin aufbaut.
+- [Auth-Backends](auth-backends.md) · [Sessions](auth-sessions.md) — das Admin hinter einem Login absichern.
+- [Sicherheitsleitfaden](security.md) — Härtung, bevor du es öffentlich zugänglich machst.

--- a/docs/de/api-conventions.md
+++ b/docs/de/api-conventions.md
@@ -1,0 +1,321 @@
+# API-Konventionen
+
+> **Für wen diese Seite gedacht ist.** Dies ist eine **fortgeschrittene Referenz für Rust-Entwickler**, die *mit* oder *am* Code des Frameworks arbeiten — sie erklärt die Namens-, Rückgabetyp- und Modulkonventionen hinter der Rust-API von Rustango. Sie ist **keine** Anleitung zum *Aufrufen* der REST-API einer Rustango-Anwendung über HTTP. Wenn Sie das suchen, beginnen Sie mit den [ViewSets](viewsets.md) (eine REST-API bauen) und dem [Glossar](glossary.md) (Begriffe in Klartext); kommen Sie hierher zurück, sobald Sie Rust gegen das Framework schreiben.
+
+Diese Seite erklärt die Muster, denen die API von **Rustango** folgt, damit Sie das Verhalten jeder Methode vorhersagen können, bevor Sie deren Dokumentation lesen. Wenn Sie zu einem Feature beitragen oder es auditieren, sind dies die Regeln.
+
+[![Namenskonvention von Rustango: das Methodensuffix sagt Ihnen, was sie entgegennimmt — `*_on` für einen typisierten Pool, blank für den Multi-Backend-Pool und pool-freie Signale](img/api-conventions.png)](img/api-conventions.png)
+
+## Inhaltsverzeichnis
+
+- [Naming](#naming)
+- [Constructors](#constructors)
+- [Return types](#return-types)
+- [Async vs sync](#async-vs-sync)
+- [The pool argument](#the-pool-argument)
+- [Filtering](#filtering)
+- [Errors](#errors)
+- [Module naming](#module-naming)
+- [Builders vs config structs](#builders-vs-config-structs)
+- [Feature flags](#feature-flags)
+- [Macros vs runtime](#macros-vs-runtime)
+- [Contributing](#contributing)
+
+---
+
+## Namensgebung
+
+Der Name einer Methode sagt Ihnen, was sie tut. Sobald Sie diese Suffixe gelernt haben, können Sie den Großteil der API erraten.
+
+### Funktionen
+
+- **`save_on(executor)`, `delete_on(executor)`** — Schreibmethoden nehmen einen *Executor* entgegen (einen Pool, eine Verbindung oder eine Transaktion — das, was mit der Datenbank spricht). Das Suffix `_on` bedeutet „führe dies gegen den Executor aus, den ich dir übergebe“.
+- **`fetch_on(executor)`, `count_on(executor)`** — dasselbe `_on`-Suffix, für Lesevorgänge.
+- **`save()`, `fetch()`, `count()`** ohne `_on` — Kurzform, die die `_on`-Variante mit einem Standard-`&pool` aufruft. Funktioniert nur dort, wo das Queryset oder Modell bereits eine Pool-Referenz hält (selten im Anwendungscode).
+- **`from_X(value)`** — konvertiert AUS einem anderen Wert (z. B. `from_model(post)`, `from_base32(s)`).
+- **`with_X(value)`** — eine Builder-Methode, die eine Option setzt und das Objekt zurückgibt, sodass Sie Aufrufe verketten können (z. B. `with_default_ttl(d)`, `with_access_ttl(secs)`).
+- **`new()`** — der minimale Konstruktor. Alle Argumente, die er entgegennimmt, sind erforderliche Abhängigkeiten (z. B. `RedisCache::new(url)` — Sie können den Cache nicht ohne URL bauen).
+
+### Typen
+
+Diese folgen der Standard-Groß-/Kleinschreibung von Rust, genau wie die Aufteilung von Pythons PEP 8 zwischen Klassen und Funktionen:
+
+- **`PascalCase`** — Typen, Traits und Enum-Varianten (wie Python-Klassen).
+- **`snake_case`** — Module, Funktionen, Felder und lokale Variablen.
+- **`SCREAMING_SNAKE_CASE`** — Konstanten, dazu die Konstante `Model::SCHEMA`, die das Derive-Makro für jedes Modell generiert.
+- **`Boxed*`** — ein Alias für `Arc<dyn Trait>`, ein thread-sicherer geteilter Zeiger auf ein Trait-Objekt (die Rust-Art, „irgendeine Implementierung dieser Schnittstelle“ zu halten). Zum Beispiel `BoxedCache = Arc<dyn Cache>`. Dies ist der Standardtyp für ein austauschbares Backend, das Sie ersetzen können.
+
+### Module
+
+- **Singular**, wenn das Modul EINEN Haupttyp oder ein Hauptkonzept enthält: `cache`, `email`, `storage`, `signed_url`, `request_id`.
+- **Plural**, wenn das Modul eine SAMMLUNG von Elementen enthält: `bulk_actions`, `api_keys`, `passwords`, `forms`, `signals`.
+
+---
+
+## Konstruktoren
+
+Wie Sie ein Objekt bauen, hängt davon ab, was es benötigt. Es gibt einige Standardformen:
+
+| Muster | Wann | Beispiel |
+|---|---|---|
+| `T::new()` | Minimal — keine erforderlichen Abhängigkeiten | `InMemoryCache::new()`, `Validator::new()` |
+| `T::new(arg)` | Eine erforderliche Abhängigkeit | `EnvSecrets::with_prefix(s)`, `RedisCache::new(url)` |
+| `T::with_X(arg)` | Builder-artige Überschreibung nach `new()` | `InMemoryCache::with_default_ttl(d)`, `JwtLifecycle::new(s).with_access_ttl(60)` |
+| `T::from_X(arg)` | Konvertieren AUS Y | `TotpSecret::from_base32(s)`, `Locale::new(s)` (manchmal `from_str`) |
+| `T::for_Y(arg)` | Ein auf ein bestimmtes Y beschränktes T bauen | `ViewSet::for_model(schema)` |
+
+**Vermeiden Sie dies:** `T::with_X_and_Y_and_Z(a, b, c)` — ein Konstruktor, der alles entgegennimmt. Teilen Sie ihn stattdessen in `new(...)` plus verkettete `.with_*()`-Aufrufe auf.
+
+---
+
+## Rückgabetypen
+
+Der Rückgabetyp einer Methode sagt Ihnen, wie sie fehlschlagen kann. Rust hat keine Exceptions, daher ist der Fehlschlag Teil des Rückgabewerts. Es gibt drei Formen.
+
+**`Result<T, E>`** — wie eine Funktion, die entweder einen Wert zurückgibt oder eine Exception wirft. Sie erhalten entweder den Wert `T` oder einen Fehler `E` mit Details. Verwenden Sie es für Operationen, die fehlschlagen können und bei denen das *Warum* zählt:
+- I/O: `pool.fetch(...).await -> Result<_, sqlx::Error>`
+- Validierung: `Form::parse(data) -> Result<Self, FormErrors>`
+- Ausstellung: `JwtLifecycle::issue_pair_with(uid, claims) -> Result<_, JwtIssueError>`
+
+**`Option<T>`** — entweder ein Wert (`Some`) oder nichts (`None`), wie ein nullbares Feld. Verwenden Sie es, wenn „nichts gefunden“ ein normales Ergebnis ist und Sie keine Fehlermeldung benötigen, die erklärt, warum:
+- Nachschlagen: `cache.get(k) -> Result<Option<String>, _>` (das `Result` deckt den I/O-Fehler ab; die `Option` deckt „Schlüssel nicht vorhanden“ ab)
+- Verifizierung: `JwtLifecycle::verify_access(token) -> Option<Claims>` („abgelaufen oder ungültig“ ist ein erwartetes Ergebnis, also genügt `None`)
+- Optionale Config-Lesevorgänge: `env::optional("FOO") -> Result<Option<T>, _>`
+
+**`bool`** — ein schlichtes Ja/Nein, wenn kein weiteres Detail benötigt wird:
+- `cache.exists(k) -> Result<bool, _>` (das `Result` deckt das I/O ab; der `bool` ist die Antwort)
+- `JwtLifecycle::revoke(token) -> bool` (true = zur Blacklist hinzugefügt)
+- `disconnect_pre_save(id) -> bool` (true = ein Eintrag wurde entfernt)
+
+**`Result<Option<T>>` oder `Result<T>` mit einem `NotFound`-Fehler?** Beide können „Nachschlagen fehlgeschlagen“ ausdrücken, wählen Sie also danach, wie außergewöhnlich „nicht gefunden“ ist:
+- Verwenden Sie `Result<Option<T>>`, wenn „nicht gefunden“ die Regel ist — Ihr Code verzweigt ohnehin fast immer auf `Some`/`None`.
+- Verwenden Sie `Result<T>` mit einer `NotFound`-Fehlervariante, wenn „nicht gefunden“ außergewöhnlich ist — etwas, das Sie als Warnung protokollieren oder in ein 404 verwandeln würden.
+
+---
+
+## Async vs sync
+
+Die Faustregel: Wenn eine Methode auf etwas wartet (die Datenbank, das Netzwerk oder die Festplatte), ist sie `async` und Sie müssen sie `.await`en. Wenn sie nur rechnet, ist es ein normaler synchroner Aufruf. Diese Tabelle buchstabiert es aus.
+
+| Operation | Sync oder async? |
+|---|---|
+| Trait-Methode, die I/O berührt (DB, Netzwerk, Datei) | **async** |
+| Trait-Methode, die reine Berechnung ist (`hash`, `verify`, `encode`) | **sync** |
+| Builder-Methoden (`with_X`, verkettbare Setter) | **sync** |
+| Makros (`derive(Model)`, `derive(Serializer)`) | **N/A** (zur Kompilierzeit) |
+| Signal `connect_*` (registriert einen Empfänger) | **sync** |
+| Signal `send_*` (dispatcht an async-Empfänger) | **async** |
+
+**Ausnahme:** `Cache::set` ist `async`, obwohl die In-Memory-Variante (`InMemoryCache::set`) niemals tatsächlich wartet. Der Trait ist für den Redis-Fall geformt, der es tut. Das ist beabsichtigt: eine Trait-Methode sollte `async` sein, wenn *irgendeine* sinnvolle Implementierung warten muss, damit alle Backends eine Signatur teilen.
+
+---
+
+## Das Pool-Argument
+
+Jeder ORM-Aufruf nimmt einen Pool oder Executor (das Datenbank-Handle) als **letztes** Argument entgegen. Sie übergeben die Verbindung jedes Mal, anstatt sich auf einen versteckten globalen Zustand zu verlassen:
+
+```rust
+post.save_on(&pool).await?
+Post::objects().filter(...).fetch_on(&pool).await?
+send_post_save(&post, ctx).await                  // ⚠️ no pool — signals are pool-free
+```
+
+**Eine Ausnahme:** Signale nehmen keinen Pool entgegen, weil sie die Datenbank niemals berühren. Die Regel hält: Alles, was die DB erreicht, nimmt den Pool; alles, was das nicht tut, nicht.
+
+**Warum jedes Mal übergeben?** Rust bevorzugt sichtbare Abhängigkeiten gegenüber verstecktem globalem Zustand. Django hält die Verbindung im Thread-Local-Speicher, aber das bricht in Rusts async-Welt zusammen, wo eine Task mitten in einer Anfrage zwischen Threads springen kann. Der Nachteil ist mehr Tipparbeit; der Vorteil ist, dass Sie nach jeder Stelle greppen können, die die Datenbank berührt.
+
+Wenn Sie feststellen, dass Sie `&pool` durch zehn Schichten von Funktionsaufrufen durchreichen, akzeptieren Sie einmal `impl Executor` am öffentlichen Einstiegspunkt und lassen Sie die internen Helfer diese eine Verbindung teilen.
+
+---
+
+## Filtern
+
+Es gibt drei Möglichkeiten, ein Queryset zu filtern, und sie kombinieren sich alle in einer Abfrage. Wählen Sie danach, woher der Filter kommt.
+
+```rust
+// 1. HTTP query string (set via ViewSet filter_fields, parsed at request time)
+//    GET /api/posts?author_id=42&status__ne=archived
+
+// 2. String-keyed (lookup at compile of the queryset; runtime field name resolution)
+Post::objects().filter("author_id", Op::Eq, SqlValue::I64(42));
+
+// 3. Typed columns (compile-time field check)
+Post::objects().where_(Post::author_id.eq(42));
+```
+
+| Syntax | Verwenden, wenn |
+|---|---|
+| HTTP-Query | Öffentliche API-Endpunkte — das ViewSet parst diese für Sie, wie die Filter-Backends von DRF |
+| String-basiertes `.filter` | Generischer CRUD- oder Admin-Code, wo Feldnamen aus der Config stammen und zur Kompilierzeit nicht bekannt sind |
+| Typisiertes `.where_` | Ihr Anwendungscode — der bevorzugte Standard. Der Compiler prüft, dass das Feld existiert und die Typen übereinstimmen |
+
+Sie können **alle drei mischen** in einem einzigen Queryset.
+
+---
+
+## Fehler
+
+**Rustango** hat **über 20 Fehlertypen** — einen pro Modul — anstelle einer einzigen Auffang-Exception-Klasse. Sie bilden eine lose Hierarchie, und ein Typ auf oberster Ebene verbindet sie, sodass Sie selten einzeln mit ihnen umgehen.
+
+| Schicht | Modul | Fehlertyp |
+|---|---|---|
+| ORM-I/O | `sql::*` | `ExecError` |
+| ORM-SQL-Writer | `sql::*` | `SqlError` (Variante von `ExecError::Sql`) |
+| Migrationen | `migrate::*` | `MigrateError` |
+| Formulare | `forms::*` | `FormError` (einzeln) + `FormErrors` (mehrfach) + `ModelFormError` |
+| Cache | `cache::*` | `CacheError` |
+| E-Mail | `email::*` | `MailError` |
+| Speicher | `storage::*` | `StorageError` |
+| Auth-Backends | `tenancy::auth_backends` | `AuthError` |
+| JWT | `tenancy::jwt_lifecycle` | `JwtIssueError` |
+| API-Schlüssel | `api_keys::*` | `ApiKeyError` |
+| Passwörter | `passwords::*` | `PasswordError` |
+| Webhooks | `webhook::*` | (gibt bool zurück, kein dedizierter Fehler) |
+| Signierte URLs | `signed_url::*` | `SignedUrlError` |
+| Bulk-Aktionen | `bulk_actions::*` | `BulkActionError` |
+| Fixtures | `fixtures::*` | `FixtureError` |
+| IP-Filter | `ip_filter::*` | `IpFilterError` |
+| i18n | `i18n::*` | `I18nError` |
+| Env | `env::*` | `EnvError` |
+| Secrets | `secrets::*` | `SecretsError` |
+| API-Antworten | `api_errors::*` | `ApiError` (HTTP-geformt, nicht intern) |
+
+**Der eine für Handler:** Es gibt eine `RustangoError`-Enum auf oberster Ebene (aus `lib.rs` exportiert, zusammen mit dem Alias `RustangoResult<T> = Result<T, RustangoError>`). Sie umschließt jeden der obigen Fehler mit `From`-Konvertierungen, sodass der `?`-Operator jeden Modulfehler automatisch in sie hochstuft. Sie implementiert außerdem `IntoResponse`, was bedeutet, dass jede Variante auf einen sinnvollen HTTP-Status abgebildet wird, wenn sie aus einem Handler zurückgegeben wird. Die Aufteilung ist einfach: Verwenden Sie die spezifischen Fehler pro Modul tief in Ihrem Code und `RustangoError` / `RustangoResult` an der Handler-Grenze. Für Fehler aus Drittanbieter-Crates umschließen `RustangoError::other(msg)` / `RustangoError::other_from(e)` jeden `std::error::Error + Send + Sync + 'static`.
+
+**Ein Handler-Beispiel:**
+
+```rust
+use rustango::api_errors::ApiError;
+
+async fn handler() -> Result<Json<X>, ApiError> {
+    let post = Post::objects().get(&pool, 1).await
+        .map_err(|e| ApiError::internal(e.to_string()))?;
+    Ok(Json(post))
+}
+```
+
+`ApiError` implementiert `IntoResponse`, sodass die Rückgabe automatisch die standardmäßige JSON-Fehlerform erzeugt.
+
+---
+
+## Modul-Namensgebung
+
+Der Name eines Moduls sollte Sie **die darin enthaltenen Typnamen erraten** lassen, ohne die Datei zu öffnen.
+
+| Modul | Beherbergt | Nachschlage-Zuversicht |
+|---|---|---|
+| `cache` | den `Cache`-Trait, die `*Cache`-Impls | hoch |
+| `email` | den `Mailer`-Trait, `Email`, die `*Mailer`-Impls | hoch |
+| `storage` | den `Storage`-Trait, die `*Storage`-Impls | hoch |
+| `signed_url` | die freien Funktionen `sign`, `verify` | mittel |
+| `text` | die freien Funktionen `slugify`, `html_escape`, `truncate` | mittel |
+| `bulk_actions` | `BulkActionRegistry`, `BulkAction`, die `Bulk*Action`-Impls | hoch |
+| `api_keys` | die freien Funktionen `generate_key`, `verify_key`, `split_token` | mittel |
+
+**Vermeiden Sie dies:** ein Modul, das ein zusammenhangloses Sammelsurium enthält (`utils`, `helpers`, `common`). Wenn Sie das einzige Konzept, das es abdeckt, nicht benennen können, sollte es kein Modul sein.
+
+---
+
+## Builder vs Config-Structs
+
+Es gibt zwei Möglichkeiten, ein konfiguriertes Objekt zu übergeben. Wählen Sie danach, wie Benutzer es einrichten werden.
+
+### Builder: verkettete Setter, kein `Default`
+
+```rust
+let l = SecurityHeadersLayer::strict()
+    .csp(...)
+    .header("x-extra", "v");
+```
+
+Verwenden, wenn:
+- Die meisten Benutzer von einem Preset ausgehen und es anpassen
+- Setter Absicht ausdrücken (z. B. liest sich `.errors_only()` besser als `.log_success(false)`)
+- Das Struct viele optionale Felder hat (10+)
+
+### Config-Struct: Felder direkt setzen, auf `Default` zurückfallen
+
+```rust
+let l = AccessLogLayer {
+    log_success: false,
+    include_ip: true,
+    slow_threshold_ms: 500,
+    ..Default::default()
+};
+```
+
+Verwenden, wenn:
+- Benutzer bei jedem Feld explizit sein möchten
+- Reflection / Serialisierung von Bedeutung ist
+- In-Place-Aktualisierung üblich ist (`config.field = ...`)
+
+**Als Regel verwendet **Rustango** Builder** für HTTP-Middleware (`security_headers`, `cors`, `rate_limit` und so weiter) und Config-Structs für einfache Datenträger (`Email`, `AccessLogLayer`, den internen Zustand von `RateLimitLayer`).
+
+---
+
+## Feature-Flags
+
+Ein *Feature* ist ein Cargo-Build-Flag (das `[features]` von `Cargo.toml`), das einen Teil des Crates ein- oder ausschaltet — ähnlich der Package-Discovery von Laravel oder den `INSTALLED_APPS` von Django, aber zur Kompilierzeit aufgelöst. Jedes Modul, das eine zusätzliche Abhängigkeit hereinzieht, sitzt hinter einem. Der Standardsatz lautet „die wollen Sie mit ziemlicher Sicherheit“:
+
+```toml
+default = [
+    "postgres", "manage", "admin", "config", "forms", "serializer",
+    "cache", "signals", "email", "storage", "scheduler", "secrets", "totp",
+    "webhook", "webhook-delivery", "api_keys", "passwords", "signed_url",
+    "notifications", "casts", "jobs", "jobs-postgres", "auth_flows", "sse",
+    "websocket", "oauth2", "http-client", "compression", "openapi",
+    "csp-nonce", "sessions", "hmac-auth", "jwt", "uploads", "storage-s3",
+    "media", "runserver", "template_views",
+]
+```
+
+**Standardmäßig aus:** Features, die schwere Abhängigkeiten oder externe Dienste hereinziehen:
+- `tenancy` — fügt `argon2`, `hmac`, `sha2`, `cookie`, `tower` hinzu (die meisten Anwendungen brauchen es nicht)
+- `cache-redis` — fügt die `redis`-Crate hinzu (die meisten Anwendungen kommen mit dem In-Memory-Cache aus)
+- `csrf` — wird von `admin` automatisch eingeschaltet, ist aber auch einzeln verfügbar
+
+Um ein Binary zu verschlanken, das nicht alles braucht, deaktivieren Sie die Standardwerte und listen Sie nur auf, was Sie verwenden:
+
+```toml
+rustango = { version = "0.44", default-features = false, features = ["postgres", "admin"] }
+```
+
+---
+
+## Makros vs Laufzeit
+
+Ein *Makro* ist Code, der zur Kompilierzeit Code generiert (`#[derive(Model)]` und Verwandte) — ungefähr das, was ein Rails-Generator tut, außer dass es bei jedem Build läuft und der Compiler das Ergebnis prüft. Die Aufteilung unten entscheidet, was von einem Makro versus schlichtem Laufzeitcode erledigt wird.
+
+| Anliegen | Makro oder Laufzeit? |
+|---|---|
+| Schema-Metadaten für `inventory` | Makro (`#[derive(Model)]`) |
+| Schema-gesteuerter Abfragebau | Laufzeit (nutzt das `&'static ModelSchema` aus dem Makro) |
+| Formular-Parsing | Makro für das Struct (`#[derive(Form)]`); Laufzeit für die Parsing-Logik |
+| Serializer-Feldauswahl | Makro (`#[derive(Serializer)]`) — erzeugt ein `from_model` + eine eigene `Serialize`-Impl |
+| Migrations-Operationen | Laufzeit (`SchemaSnapshot`-Diff) |
+| Signal-Dispatch | Laufzeit (`TypeId`-basiertes Registry, kein Makro pro Modell) |
+| Pattern-Matching der Auth-Backends | Laufzeit (`#[async_trait]` auf `AuthBackend`) |
+
+**Regel:** Verwenden Sie ein Makro für alles, was der Compiler vorab verifizieren kann (Feldnamen müssen existieren, Typen müssen übereinstimmen). Verwenden Sie Laufzeitcode für alles, was pro Anfrage oder pro Deployment variiert.
+
+---
+
+## Mitwirken
+
+Wenn Sie ein neues Feature hinzufügen, befolgen Sie diese Schritte:
+
+1. **Ein Modul pro Konzept**, in `crates/rustango/src/<name>.rs` oder `<name>/mod.rs`.
+2. **Fügen Sie Rustdoc auf Modulebene hinzu** mit einem „Quick start“-Beispiel in einem `// ignore`-Block.
+3. **Fügen Sie ein Feature-Flag hinzu, wenn Sie eine neue Abhängigkeit hereinziehen** — benennen Sie es nach dem Modul (`feature = "<name>"`).
+4. **Re-exportieren Sie das Modul aus `lib.rs`** mit einer einzeiligen Rustdoc.
+5. **Platzieren Sie Unit-Tests in derselben Datei**, hinter `#[cfg(test)] mod tests` — keine Datenbank, es sei denn, Sie brauchen wirklich eine.
+6. **Platzieren Sie Integrationstests in `crates/rustango/tests/<name>.rs`** für die End-to-End-Geschichte.
+7. **Fügen Sie keinen neuen Fehlertyp hinzu, es sei denn, die bestehenden passen nicht** — erweitern Sie zuerst eine bestehende Enum.
+8. **Folgen Sie dem [Rückgabetyp-Leitfaden](#return-types)** bei der Wahl zwischen `Result`, `Option` oder `bool`.
+9. **Fügen Sie einen `manage`-Unterbefehl hinzu?** Verdrahten Sie ihn in den `match cmd`-Dispatcher und `print_help`, fügen Sie einen Test in `crates/rustango/tests/migrate_manage.rs` hinzu und dokumentieren Sie eine Zeile in `docs/manage.md`.
+10. **Aktualisieren Sie `CHANGELOG.md`** mit einem `Added`-Eintrag unter der nächsten Version.
+
+Wenn Sie die API brechen:
+- Markieren Sie das alte Element mit `#[deprecated(since = "...", note = "use X instead")]` und behalten Sie es eine volle Minor-Version lang, bevor Sie es entfernen.
+- Halten Sie es in `CHANGELOG.md` unter `Breaking changes` fest.
+- Verlinken Sie den Migrationspfad aus den Release Notes.

--- a/docs/de/auth-api-keys.md
+++ b/docs/de/auth-api-keys.md
@@ -1,0 +1,214 @@
+# API-Schlüssel
+
+Ein API-Schlüssel ist ein **langlebiges Credential für Maschinen** — CI-Jobs,
+Skripte, Server-zu-Server-Aufrufe — die kein Anmeldeformular vorlegen oder kein
+Session-Cookie tragen können. Der Client sendet den Schlüssel bei jeder Anfrage;
+der Server schlägt ihn nach und identifiziert den Aufrufer. **Rustango** gibt
+Ihnen zwei Ebenen: einen eigenständigen Erzeugungs-/Verifizierungshelfer, den
+Sie an Ihre eigene Tabelle anbinden können, und ein schlüsselfertiges Backend,
+das Schlüssel speichert und `Authorization: Bearer`-Anfragen authentifiziert.
+
+[![API-Schlüssel in Rustango: generate_key liefert einen Einmal-Token prefix.secret, Sie speichern das 8-stellige Präfix plus einen argon2id-Hash, und verify_key prüft ein eingehendes Secret](img/auth-api-keys.png)](img/auth-api-keys.png)
+
+> **Ein Begriff hier neu für Sie?** *Token*, *Hash*, *Bearer*, *argon2id* — das
+> [Glossar](glossary.md) definiert die Bausteine.
+
+> **Quelle:** `rustango::api_keys` (`generate_key`, `hash_secret`, `verify_key`,
+> `split_token`, `ApiKeyError`) — der eigenständige Helfer, hinter dem Feature
+> `api_keys` (standardmäßig aktiviert). Das speichernde Backend ist
+> `rustango::tenancy::auth_backends` (`create_api_key`, `ApiKeyBackend`,
+> `ensure_api_keys_table_pool`) — hinter dem Feature `tenancy`.
+>
+> **Lauffähige Version:** Die Helfer-Snippets sind aus
+> [`auth_api_keys_doc.rs`](../crates/rustango/tests/auth_api_keys_doc.rs) kopiert
+> (`cargo test -p rustango --test auth_api_keys_doc`); der Middleware-Ablauf des
+> `ApiKeyBackend` aus
+> [`auth_backends_doc.rs`](../crates/rustango/tests/auth_backends_doc.rs)
+> (`cargo test -p rustango --features sqlite,tenancy --test auth_backends_doc`).
+
+## Inhaltsverzeichnis
+
+- [Wie ein API-Schlüssel funktioniert](#how-an-api-key-works)
+- [Der eigenständige Helfer](#the-standalone-helper)
+- [Das speichernde Backend](#the-stored-backend)
+- [Einen Schlüssel ausstellen (CLI + Code)](#issuing-a-key)
+- [Anfragen authentifizieren](#authenticating-requests)
+- [Sicherheitshinweise](#security-notes)
+- [Siehe auch](#see-also)
+
+---
+
+## Wie ein API-Schlüssel funktioniert
+
+Ein Schlüssel hat zwei durch einen Punkt verbundene Teile:
+**`{prefix}.{secret}`**.
+
+- Das **Präfix** hat 8 Zeichen — im Klartext gespeichert und als schneller,
+  eindeutiger Nachschlage-Index verwendet („welcher Schlüssel ist das?“).
+- Das **Secret** ist das eigentliche Credential. Sie speichern nur einen
+  **argon2id-Hash** davon, niemals das Secret selbst.
+
+Der vollständige Token wird dem Benutzer **genau einmal** angezeigt, bei der
+Erstellung. Verlieren Sie ihn, stellen Sie ihn neu aus — es gibt keine
+Möglichkeit, ihn wiederherzustellen, da nur der Hash aufbewahrt wird. Das ist
+dieselbe „hashen, nicht speichern“-Disziplin wie bei
+[Passwörtern](auth-passwords.md), angewandt auf Maschinen-Credentials.
+
+---
+
+## Der eigenständige Helfer
+
+`rustango::api_keys` ist ein abhängigkeitsfreies Toolkit (keine Datenbank, keine
+Tabellen) — verwenden Sie es, wenn Sie Schlüssel in Ihrem eigenen Schema
+speichern wollen.
+
+```rust
+use rustango::api_keys::{generate_key, split_token, verify_key};
+
+// Bei der Erstellung: liefert (full_token, prefix, hash).
+let (token, prefix, hash) = generate_key()?;
+// → token  = "a1b2c3d4.<secret>"   dem Benutzer EINMAL zeigen
+// → prefix = "a1b2c3d4"            als Nachschlage-Schlüssel speichern
+// → hash   = "$argon2id$v=19$..."  statt des Secrets speichern
+
+// Bei einer eingehenden Anfrage: Token abrufen, Zeile per Präfix finden, verifizieren.
+let (prefix, secret) = split_token(&token).expect("well-formed token");
+let stored_hash = lookup_hash_by_prefix(prefix);     // Ihre Abfrage
+if verify_key(secret, &stored_hash)? {
+    // authentifiziert
+}
+```
+
+`split_token` ist strikt — es liefert `None`, es sei denn, das Präfix hat genau
+8 Zeichen und das Secret ist nicht leer, sodass fehlerhafte Eingaben abgelehnt
+werden, bevor Sie die Datenbank berühren:
+
+```rust
+assert!(split_token("no-dot-here").is_none());
+assert!(split_token("short.secret").is_none()); // Präfix muss 8 Zeichen haben
+assert!(split_token("a1b2c3d4.").is_none());     // leeres Secret
+```
+
+`hash_secret` und `verify_key` verwenden argon2id mit einem zufälligen Salt pro
+Hash, sodass das zweimalige Hashen desselben Secrets unterschiedliche Zeichenketten
+ergibt — und beide verifizieren sich. `verify_key` liefert `Ok(false)` bei einer
+Nichtübereinstimmung und `Err(ApiKeyError)` nur dann, wenn die gespeicherte
+Zeichenkette kein gültiger Hash ist.
+
+---
+
+## Das speichernde Backend
+
+Wenn Sie bereits auf der `tenancy`-Ebene sind, brauchen Sie keine eigene Tabelle.
+`rustango::tenancy::auth_backends` liefert ein `ApiKey`-Modell (Tabelle
+`rustango_api_keys`), einen Ersteller und ein Auth-Backend, das sich in die
+[Backend-Kette](auth-backends.md) einklinkt.
+
+Initialisieren Sie die Tabelle einmalig (tri-dialektfähig, idempotent):
+
+```rust
+use rustango::tenancy::auth_backends::ensure_api_keys_table_pool;
+
+ensure_api_keys_table_pool(&pool).await?;   // CREATE TABLE IF NOT EXISTS
+```
+
+Die `ApiKey`-Zeile speichert `user_id` (FK auf `rustango_users`), das
+8-stellige `key_prefix` (eindeutig), den argon2id-`key_hash`, ein `label` und
+ein optionales `expires_at`.
+
+---
+
+## Einen Schlüssel ausstellen
+
+`create_api_key` erzeugt den Token, hasht das Secret, fügt die Zeile ein und
+liefert den **Klartext-Token einmalig**:
+
+```rust
+use rustango::tenancy::auth_backends::create_api_key;
+
+// Einen nicht ablaufenden Schlüssel für Benutzer 42 ausstellen, mit "ci-key" beschriftet.
+let token = create_api_key(42, "ci-key", None, &pool).await?;
+println!("Store this — it won't be shown again: {token}");
+
+// Oder mit einem Ablauf:
+use chrono::{Duration, Utc};
+let token = create_api_key(42, "tmp", Some(Utc::now() + Duration::days(30)), &pool).await?;
+```
+
+Von der Kommandozeile aus umhüllt die `manage`-CLI denselben Aufruf:
+
+```bash
+cargo run -- create-api-key <tenant> <username> --label "ci-key" --expires-days 30
+```
+
+---
+
+## Anfragen authentifizieren
+
+Registrieren Sie `ApiKeyBackend` in Ihrer
+[Auth-Backend-Kette](auth-backends.md), und die Middleware authentifiziert jede
+`Authorization: Bearer {prefix}.{secret}`-Anfrage:
+
+```rust
+use std::sync::Arc;
+use rustango::tenancy::auth_backends::{ApiKeyBackend, AuthBackend, ModelBackend};
+use rustango::tenancy::RouterAuthExt;
+
+let backends: Vec<Arc<dyn AuthBackend>> = vec![
+    Arc::new(ModelBackend),   // HTTP Basic (Menschen)
+    Arc::new(ApiKeyBackend),  // Bearer-Schlüssel  (Maschinen)
+];
+
+let app = Router::new()
+    .route("/api/data", get(handler))
+    .require_auth(backends, pool);
+```
+
+Ein Client ruft dann auf:
+
+```bash
+curl https://api.example.com/api/data \
+  -H "Authorization: Bearer a1b2c3d4.the-secret-half"
+```
+
+Das Backend findet den `ApiKey` anhand seines 8-stelligen Präfixes, prüft
+`expires_at`, verifiziert das Secret gegen den gespeicherten Hash, lädt den
+besitzenden Benutzer und injiziert ihn, damit Ihre Handler ihn über
+[`CurrentUser`](auth-backends.md) lesen können. Ein falsches Secret oder ein
+unbekanntes Präfix ist ein `401`; ein abgelaufener Schlüssel wird abgelehnt; ein
+deaktivierter Besitzer ist ein `403`.
+
+---
+
+## Sicherheitshinweise
+
+- **Das Secret wird einmal angezeigt.** Nur das Präfix + der argon2id-Hash werden
+  persistiert — es gibt keine Wiederherstellung, nur eine Neuausstellung.
+- **Das Präfix wird absichtlich im Klartext gespeichert** — es ist der
+  O(1)-Nachschlage-Index. Ein Datenbankleck verrät, welche Präfixe existieren,
+  niemals die Secrets.
+- **Das Timing ist ausgeglichen.** Ein unbekanntes Präfix führt trotzdem eine
+  Dummy-Verifizierung durch, sodass ein fehlender Schlüssel etwa gleich lang
+  braucht wie ein echter — keine Aufzählung über das Antwort-Timing.
+- **Beschränken Sie Schlüssel auf einen Benutzer, setzen Sie einen Ablauf und
+  rotieren Sie.** Stellen Sie pro Integration einen aus, damit Sie einen
+  widerrufen können, ohne die anderen zu stören; bevorzugen Sie kurze
+  `expires_at`-Fenster für temporären Zugriff.
+- **Abgrenzung von JWTs:** Das Backend behandelt einen Bearer-Wert nur dann als
+  API-Schlüssel, wenn sein erstes Punkt-Segment genau 8 Zeichen hat — so können
+  sich API-Schlüssel und [JWTs](auth-jwt.md) den
+  `Authorization: Bearer`-Header teilen.
+
+---
+
+## Siehe auch
+
+- [Auth-Backends](auth-backends.md) — die Kette, in die sich `ApiKeyBackend`
+  einklinkt, sowie der `CurrentUser`-Extraktor + die
+  `require_auth`/`require_perm`-Middleware.
+- [HMAC-Anfragesignierung](auth-hmac.md) — für Maschinen-Aufrufer, die
+  Integrität pro Anfrage benötigen, nicht nur ein Bearer-Credential.
+- [Passwörter](auth-passwords.md) — dieselbe „hashen, nicht speichern“-Disziplin
+  für menschliche Anmeldungen.
+- [JWT](auth-jwt.md) — kurzlebige zustandslose Tokens, die andere
+  Maschinen-Option.

--- a/docs/de/auth-backends.md
+++ b/docs/de/auth-backends.md
@@ -1,0 +1,221 @@
+# Auth-Backends
+
+Ein **Auth-Backend** beantwortet eine einzige Frage: *wer ist der Benutzer bei
+einer eingehenden Anfrage?* **Rustango** lässt Sie mehrere davon stapeln — HTTP
+Basic, API-Schlüssel, JWT — zu einer Kette, die die Auth-Middleware der Reihe
+nach durchprobiert, sodass eine Anwendung Menschen und Maschinen auf denselben
+Routen akzeptieren kann. Das ist Djangos `AUTHENTICATION_BACKENDS`-Idee, an axum
+verdrahtet. Kombinieren Sie es mit `require_auth` / `require_perm`, um Routen
+abzusichern, und dem `CurrentUser`-Extraktor, um das Ergebnis zu lesen.
+
+[![Auth-Backends in Rustango: eine Anfrage durchläuft eine Kette von Backends (ModelBackend, ApiKeyBackend, JwtBackend); das erste, das den Anmeldenachweis erkennt, gewinnt und injiziert CurrentUser, dann prüft require_perm einen Codename](img/auth-backends.png)](img/auth-backends.png)
+
+> **Ein Begriff hier neu?** *Backend*, *Middleware*, *Extraktor*,
+> *Berechtigungs-Codename* — siehe das [Glossar](glossary.md).
+
+> **Quelle:** `rustango::tenancy::auth_backends` (`AuthBackend`, `ModelBackend`,
+> `ApiKeyBackend`, `JwtBackend`, `AuthUser`, `AuthError`) und
+> `rustango::tenancy::{RouterAuthExt, CurrentUser}` — hinter dem Feature
+> `tenancy`. Eine portable, datenbankunabhängige Registry lebt auch unter
+> `rustango::auth_backends` (immer kompiliert).
+>
+> **Ausführbare Version:** jeder Ausschnitt ist aus
+> [`auth_backends_doc.rs`](../crates/rustango/tests/auth_backends_doc.rs)
+> kopiert (`cargo test -p rustango --features sqlite,tenancy --test auth_backends_doc`).
+
+## Inhaltsverzeichnis
+
+- [Die Kette](#the-chain) · [Die eingebauten Backends](#the-built-in-backends)
+- [Routen absichern: require_auth](#gating-routes-require_auth)
+- [Den Benutzer lesen: CurrentUser](#reading-the-user-currentuser)
+- [Berechtigungen: require_perm](#permissions-require_perm)
+- [Die portable Registry](#the-portable-registry)
+- [Siehe auch](#see-also)
+
+---
+
+## Die Kette
+
+Sie übergeben `require_auth` einen `Vec<Arc<dyn AuthBackend>>`. Bei jeder Anfrage
+probiert die Middleware sie **der Reihe nach** durch:
+
+- das **erste** Backend, das den Anmeldenachweis erkennt, gewinnt (gibt den
+  Benutzer zurück);
+- ein Backend, das ihn nicht erkennt, gibt „keiner" zurück, und das nächste wird
+  probiert;
+- wenn ein Backend hart fehlschlägt (z. B. ein inaktives Konto bei einem
+  *gültigen* Token), stoppt die Kette mit diesem Fehler;
+- wenn keines passt, erhält die Anfrage `401` (mit `require_auth`) oder fährt
+  anonym fort (mit `optional_auth`).
+
+```rust
+use std::sync::Arc;
+use rustango::tenancy::auth_backends::{ApiKeyBackend, AuthBackend, ModelBackend};
+
+let backends: Vec<Arc<dyn AuthBackend>> = vec![
+    Arc::new(ModelBackend),    // HTTP Basic  → humans
+    Arc::new(ApiKeyBackend),   // Bearer key  → machines
+];
+```
+
+---
+
+## Die eingebauten Backends
+
+| Backend | Anmeldenachweis, den es liest | Identifiziert einen Benutzer über |
+|---|---|---|
+| `ModelBackend` | `Authorization: Basic <base64(user:pass)>` | Benutzername + argon2id-Passwortprüfung gegen `rustango_users` |
+| `ApiKeyBackend` | `Authorization: Bearer <prefix.secret>` | die Tabelle `rustango_api_keys` (siehe [API-Schlüssel](auth-api-keys.md)) |
+| `JwtBackend` | `Authorization: Bearer <jwt>` | ein signiertes HS256-Token (siehe [JWT](auth-jwt.md)) |
+
+`ApiKeyBackend` und `JwtBackend` lesen beide `Bearer` und unterscheiden anhand der
+Form (das erste Punkt-Segment eines API-Schlüssels ist genau 8 Zeichen lang).
+Konstruieren Sie `JwtBackend` mit einem Geheimnis von **mindestens 32 Byte**
+(`JwtBackend::new(secret)` panikt andernfalls):
+
+```rust
+use rustango::tenancy::auth_backends::JwtBackend;
+
+let backends: Vec<Arc<dyn AuthBackend>> = vec![
+    Arc::new(ModelBackend),
+    Arc::new(JwtBackend::new(jwt_secret_at_least_32_bytes.to_vec())),
+];
+```
+
+Schreiben Sie ein eigenes Backend, indem Sie den Trait implementieren (eine
+einzige async-Methode, die die `Parts` der Anfrage inspiziert und
+`Option<AuthUser>` zurückgibt):
+
+```rust
+use async_trait::async_trait;   // add `async-trait` to your Cargo.toml
+use axum::http::request::Parts;
+use rustango::sql::Pool;
+use rustango::tenancy::auth_backends::{AuthBackend, AuthError, AuthUser};
+
+struct HeaderBackend;
+
+#[async_trait]
+impl AuthBackend for HeaderBackend {
+    async fn authenticate(&self, parts: &Parts, _pool: &Pool)
+        -> Result<Option<AuthUser>, AuthError>
+    {
+        // ...inspect parts.headers, return Some(AuthUser{..}) or Ok(None)
+        Ok(None)
+    }
+}
+```
+
+---
+
+## Routen absichern: require_auth
+
+`RouterAuthExt` fügt die Middleware hinzu. `require_auth` weist anonyme Anfragen
+mit `401` ab; `optional_auth` lässt sie durch (sodass ein Handler auf angemeldet
+vs. nicht verzweigen kann):
+
+```rust
+use rustango::tenancy::RouterAuthExt;
+
+let app = Router::new()
+    .route("/profile", get(profile))
+    .require_auth(backends, pool);     // 401 if no backend matches
+```
+
+Verifiziertes Verhalten:
+
+```rust
+// no credentials               → 401
+// Basic alice:<correct>        → 200
+// Basic alice:<wrong>          → 401   (no backend accepted; no enumeration)
+// Bearer <valid api key>       → 200
+```
+
+---
+
+## Den Benutzer lesen: CurrentUser
+
+Handler lesen den authentifizierten Benutzer mit dem `CurrentUser`-Extraktor. Er
+ist unfehlbar — `Some(user)`, wenn ein Backend einen aufgelöst hat, sonst `None`:
+
+```rust
+use rustango::tenancy::CurrentUser;
+
+async fn profile(CurrentUser(user): CurrentUser) -> Response {
+    match user {
+        Some(u) => format!("hello {}", u.username).into_response(),
+        None    => StatusCode::UNAUTHORIZED.into_response(),
+    }
+}
+```
+
+> **Fallstrick:** weil `CurrentUser` unfehlbar ist, führt das Vergessen von
+> `require_auth` nicht zu einem Kompilierfehler — jede Anfrage sieht einfach
+> `None`. Hinter `require_auth` erhalten anonyme Anfragen bereits `401`, sodass
+> `user` dort stets `Some` ist.
+
+---
+
+## Berechtigungen: require_perm
+
+`require_perm` sichert eine Route über einen Berechtigungs-**Codename** ab
+(`{table}.{action}`, z. B. `post.add`). Wenden Sie es auf den inneren Sub-Router
+an und `require_auth` auf den äußeren, sodass der Benutzer aufgelöst wird,
+*bevor* die Berechtigung geprüft wird:
+
+```rust
+let admin = Router::new()
+    .route("/admin", get(admin_only))
+    .require_perm("post.add", pool.clone());   // inner: needs the codename
+
+let app = Router::new()
+    .route("/profile", get(profile))
+    .merge(admin)
+    .require_auth(backends, pool);             // outer: resolves the user first
+```
+
+```rust
+// alice (granted post.add)   → /admin 200
+// bob   (authed, no grant)   → /admin 403
+// anonymous                  → /admin 401   (auth runs first)
+```
+
+Auflösung: ein (aktiver) **Superuser** passiert alles; ein **deaktivierter**
+Benutzer wird selbst mit Erteilungen abgelehnt; eine explizite Überschreibung pro
+Benutzer gewinnt über Rollen-Erteilungen; andernfalls passiert jede Rolle, die
+der Benutzer hält und die den Codename erteilt. Erteilen Sie mit
+`set_user_perm_pool` / Rollen über `create_role_pool` + `assign_role_pool` (die
+Berechtigungstabellen werden von `ensure_tables_pool` erstellt).
+
+---
+
+## Die portable Registry
+
+Separat davon ist `rustango::auth_backends` (Achtung: Crate-Wurzel, **nicht**
+`tenancy`) eine kleine **framework-unabhängige** Registry — eine
+`Credentials` → `Principal`-Kette mit ihrem eigenen `AuthBackend`-Trait. Sie hat
+keinerlei HTTP/axum-Verklebung; verwenden Sie sie, wenn Sie Django-artige
+Backend-Steckbarkeit innerhalb Ihres eigenen Auth-Codes wünschen:
+
+```rust
+use rustango::auth_backends::{AuthBackendChain, Credentials, RemoteUserBackend};
+
+let chain = AuthBackendChain::new().with(Arc::new(RemoteUserBackend::trust_username()));
+let principal = chain.authenticate(&Credentials::remote("alice")).await?;
+```
+
+Dieselbe Semantik „erster Erfolg gewinnt / erster Fehler stoppt" wie die
+HTTP-Kette. Zum Absichern echter Routen verwenden Sie die `tenancy`-Middleware
+oben.
+
+---
+
+## Siehe auch
+
+- [API-Schlüssel](auth-api-keys.md) und [JWT](auth-jwt.md) — die
+  Anmeldenachweise, die `ApiKeyBackend` / `JwtBackend` konsumieren.
+- [Passwörter](auth-passwords.md) — das Hashing, gegen das `ModelBackend`
+  verifiziert.
+- [Zugriffs-Dekoratoren](auth-decorators.md) — Absicherung pro Handler mit
+  `login_required` / `permission_required`, die dekorator-artige Alternative zu
+  `require_auth`/`require_perm`.
+- [Sessions](auth-sessions.md) — cookie-basierte Authentifizierung für Browser.

--- a/docs/de/auth-decorators.md
+++ b/docs/de/auth-decorators.md
@@ -1,0 +1,195 @@
+# Zugriffs-Dekoratoren
+
+Sobald ein Benutzer authentifiziert ist, sichern Sie Routen ab. **Rustango**
+liefert Djangos `@login_required`-Familie als komponierbare axum-**Layer**:
+hängen Sie einen an einen Router, und anonyme Anfragen werden abgewiesen — per
+302 auf Ihre Anmeldeseite umgeleitet (Browser-Ablauf) oder mit 401/403
+beantwortet (API-Ablauf) —, bevor sie je den Handler erreichen.
+
+[![Zugriffs-Dekoratoren: login_required leitet anonyme Browser per 302 auf /login?next= um, die _or_403-Familie gibt 401/403 für APIs zurück, superuser_required sichert nach Rolle ab](img/auth-decorators.png)](img/auth-decorators.png)
+
+> **Quelle:** `rustango::auth_decorators` (`login_required`, `login_required_or_401`,
+> `user_passes_test`, `superuser_required`, `active_required`,
+> `permission_required` + die `_or_403`-Varianten; `safe_next`, `extract_next`) —
+> hinter dem Feature `tenancy` (die Gatter lesen den `SessionUser`-Extraktor).
+>
+> **Ausführbare Version:** das Absicherungsverhalten wird vom getesteten
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_decorators.rs)
+> abgedeckt — `cargo test -p auth_demo --test auth_decorators`.
+
+> **Ein Begriff hier neu?** *Middleware/Layer*, *Extraktor*, *401/403* — siehe das
+> [Glossar](glossary.md).
+
+> Vertiefungsbegleiter zum [Sicherheitsleitfaden](security.md). Die Gatter lesen
+> die bei der Anmeldung gesetzte Session — siehe [Sessions](auth-sessions.md).
+
+---
+
+## Inhaltsverzeichnis
+- [Schnellstart](#quick-start) · [Browser- vs. API-Gatter](#browser-vs-api-gates)
+- [Die Gatter-Familie](#the-gate-family) · [Prädikat- und Rollen-Gatter](#predicate-and-role-gates)
+- [Berechtigungs-Gatter](#permission-gates) · [Der `?next=`-Umlauf](#the-next-round-trip)
+- [Hinweise und Grenzen](#notes-and-limits)
+
+---
+
+## Schnellstart
+
+```rust
+use rustango::auth_decorators::login_required;
+
+// Scope the gate to a sub-router (the idiomatic shape):
+let private = Router::new()
+    .route("/profile", get(profile))
+    .route("/settings", get(settings))
+    .layer(login_required("/login"));      // anonymous → 302 /login?next=...
+
+let app = Router::new()
+    .route("/", get(home))                 // public
+    .merge(private);
+```
+
+Anonyme Anfragen an `/profile` werden auf `/login?next=%2Fprofile` umgeleitet;
+eine authentifizierte Anfrage geht bis zum Handler durch.
+
+---
+
+## Browser- vs. API-Gatter
+
+Dasselbe Gatter kommt in zwei Antwortformen. Wählen Sie danach, was der Aufrufer
+mit der Antwort anfangen kann:
+
+- **Browser / HTML** → die Basis-Gatter **leiten per 302** auf Ihre Anmeldeseite
+  um (ein Mensch kann ihr folgen und sich anmelden).
+- **JSON-API** → die `_or_403`-Familie gibt **Statuscodes** zurück:
+  `401 Unauthorized` für anonym, `403 Forbidden` für authentifiziert-aber-nicht-erlaubt
+  (ein Client kann keine HTML-Anmeldeseite rendern, und die 401/403-Aufteilung
+  lässt ihn „anmelden" von „das darfst du nicht" unterscheiden).
+
+```rust
+// Browser: redirect to /login
+let app = Router::new().route("/dashboard", get(dash)).layer(login_required("/login"));
+
+// API: 401 for anonymous, never a redirect
+let api = Router::new().route("/api/me", get(me)).layer(login_required_or_401());
+```
+
+---
+
+## Die Gatter-Familie
+
+| Gatter (Browser, 302) | API-Variante (401/403) | Lässt durch |
+|---|---|---|
+| `login_required(url)` | `login_required_or_401()` | jeden angemeldeten Benutzer |
+| `active_required(url)` | `active_required_or_403()` | angemeldet **und** `active` |
+| `superuser_required(url)` | `superuser_required_or_403()` | `is_superuser && active` |
+| `user_passes_test(url, pred)` | `user_passes_test_or_403(pred)` | Prädikat über die `User`-Zeile |
+| `permission_required(url, codename)` | `permission_required_or_403(codename)` | hält den Berechtigungs-Codename |
+
+Alle sind tower-Layer — `.layer(...)` sie auf einen Router oder Sub-Router.
+
+---
+
+## Prädikat- und Rollen-Gatter
+
+`user_passes_test` führt Ihre Closure gegen die aufgelöste `User`-Zeile aus,
+sodass Sie über jedes Feld absichern können:
+
+```rust
+use rustango::auth_decorators::{user_passes_test, superuser_required_or_403};
+
+// Staff-only sub-router (browser):
+let staff = Router::new()
+    .route("/admin/dashboard", get(dashboard))
+    .layer(user_passes_test("/login", |u| u.is_superuser));
+
+// Superuser-only JSON API → 401 anonymous / 403 non-superuser:
+let api = Router::new()
+    .route("/api/admin/stats", get(stats))
+    .layer(superuser_required_or_403());
+```
+
+`superuser_required` / `active_required` sind fest verdrahtete Abkürzungen für
+die gängigen Prädikate `is_superuser && active` / `active`, damit Aufrufstellen
+nicht stillschweigend darüber auseinanderdriften, ob deaktivierte Konten noch
+zählen.
+
+---
+
+## Berechtigungs-Gatter
+
+`permission_required` prüft einen Berechtigungs-Codename gegen die
+Berechtigungs-Engine des Mandanten (Superuser umgehen sie automatisch). Es löst
+zusätzlich den `Tenant`-Extraktor auf, sodass Routen, die es verwenden, unter dem
+Mandantenkontext eingehängt werden müssen:
+
+```rust
+use rustango::auth_decorators::permission_required;
+use rustango::tenancy::permissions::ACCESS_ADMIN_CODENAME;
+
+let admin = Router::new()
+    .route("/admin", get(dashboard))
+    .layer(permission_required("/login", ACCESS_ADMIN_CODENAME));
+```
+
+---
+
+## Der `?next=`-Umlauf
+
+`login_required` bewahrt die ursprünglich angeforderte URL in `?next=` auf,
+sodass Ihr Anmelde-Handler den Benutzer nach der Authentifizierung zurückschicken
+kann. **Sie müssen diesen Wert bereinigen** — ihn ungeprüft in eine Umleitung zu
+spiegeln, ist ein lehrbuchmäßiges Open-Redirect-Loch (Phishing). `safe_next` ist
+der Schutz:
+
+```rust
+use rustango::auth_decorators::{extract_next, safe_next};
+
+async fn login_post(Query(q): Query<HashMap<String, String>>, /* … */) -> Response {
+    // … verify credentials, set the session …
+    let dest = extract_next(&q)
+        .and_then(|n| safe_next(&n))          // rejects open redirects
+        .unwrap_or_else(|| "/".to_owned());
+    Redirect::to(&dest).into_response()
+}
+```
+
+`safe_next` akzeptiert nur gleichherkünftige, wurzelrelative Pfade — es weist
+absolute URLs, schema-relative `//host`, Backslash-Varianten und deren
+prozentkodierte Formen zurück:
+
+```rust
+assert_eq!(safe_next("/dashboard"),            Some("/dashboard".to_owned()));
+assert_eq!(safe_next("https://evil.example/x"), None);
+assert_eq!(safe_next("//evil.example/x"),       None);   // scheme-relative
+assert_eq!(safe_next("%2F%2Fevil.example/x"),   None);   // decodes to //evil
+```
+
+---
+
+## Hinweise und Grenzen
+
+- **Diese Gatter lesen die Session.** „Angemeldet" bedeutet, dass der
+  [`SessionUser`](auth-sessions.md)-Extraktor einen Benutzer aus dem
+  Session-Cookie aufgelöst hat — sie sind also für Session-/Cookie-Auth gedacht.
+  API-Token-Auth ([JWT](auth-jwt-api.md), [API-Schlüssel](auth-api-keys.md))
+  sichert stattdessen auf der Ebene der [Backend-Kette](auth-backends.md) ab und
+  liest den `Authorization`-Header.
+- **Die Layer-Reihenfolge ist wichtig.** `.layer(gate)` schützt jede Route, die
+  dem Router *vor* ihm hinzugefügt wurde; danach hinzugefügte Routen sind
+  öffentlich. Das Gatter auf einen dedizierten Sub-Router zu beschränken (die
+  Schnellstart-Form) vermeidet diesen Fallstrick.
+- **`permission_required` benötigt Mandantenkontext** (es fragt die
+  Mandanten-Berechtigungs-Engine ab) — hängen Sie es unter den Mandanten ein;
+  eine Route ohne Mandant quittiert mit 500.
+- Das `?next=` der Umleitung ist stets prozentkodiert, sodass
+  CRLF / Response-Splitting nicht in den `Location`-Header durchsickern kann.
+
+
+---
+
+## Siehe auch
+
+- [Auth-Backends](auth-backends.md)
+- [Sessions](auth-sessions.md)
+- [Sicherheitsleitfaden](security.md)

--- a/docs/de/auth-flows.md
+++ b/docs/de/auth-flows.md
@@ -1,0 +1,192 @@
+# Konto-Abläufe (Zurücksetzen, Verifizieren, Magic Link)
+
+Die Abläufe, die jede Anwendung am Rande der Anmeldung braucht: **Passwort-Zurücksetzung**,
+**E-Mail-Verifizierung** und **Magic-Link-Anmeldung (passwortlos)**. Alle drei haben dieselbe
+Form — dem Benutzer einen manipulationssicheren, zeitlich begrenzten Link per E-Mail schicken und
+dann handeln, wenn er darauf klickt — und **Rustango** baut sie auf einem einzigen Fundament auf:
+**signierten URLs**. Eine signierte URL ist eine normale URL mit angehängter HMAC-Signatur, sodass
+der Server ihren Parametern vertrauen kann, ohne irgendetwas zu speichern.
+
+[![Konto-Abläufe in Rustango: signed_url::sign hängt eine HMAC-Signatur + Ablauf an; die drei Abläufe (Passwort-Zurücksetzung, E-Mail-Verifizierung, Magic Link) stellen einen Link aus, versenden ihn per E-Mail und verifizieren ihn beim Klick](img/auth-flows.png)](img/auth-flows.png)
+
+> **Ein Begriff hier neu für Sie?** *HMAC*, *Token*, *Ablauf* — siehe das [Glossar](glossary.md).
+
+> **Quelle:** `rustango::signed_url` (`sign`, `verify`, `SignedUrlError`) und
+> `rustango::auth_flows` (`PasswordReset`, `EmailVerification`, `MagicLink`,
+> `confirm_password_reset_pool_into`) — hinter den Features `signed_url` / `auth_flows`
+> (standardmäßig aktiv; die Reset-Bestätigung braucht zusätzlich `passwords` + ein DB-Backend).
+>
+> **Ausführbare Version:** jeder Ausschnitt ist aus
+> [`auth_flows_doc.rs`](../crates/rustango/tests/auth_flows_doc.rs) kopiert
+> (`cargo test -p rustango --features sqlite --test auth_flows_doc`).
+
+## Inhaltsverzeichnis
+
+- [Signierte URLs: das Fundament](#signed-urls-the-substrate)
+- [Passwort-Zurücksetzung](#password-reset)
+- [E-Mail-Verifizierung](#email-verification)
+- [Magic-Link-Anmeldung](#magic-link-login)
+- [Einmal-Tokens](#single-use-tokens)
+- [Was Sie bereitstellen](#what-you-provide)
+- [Siehe auch](#see-also)
+
+---
+
+## Signierte URLs: das Fundament
+
+`sign` hängt eine HMAC-SHA256-Signatur (und einen optionalen Ablauf) über den Pfad + die Query der
+URL an. `verify` berechnet sie neu: Manipulieren Sie irgendeinen Parameter, verwenden Sie das
+falsche Secret oder lassen Sie sie ablaufen, und sie schlägt fehl.
+
+```rust
+use rustango::signed_url::{sign, verify, SignedUrlError};
+
+let url = "https://app.example.com/files/42?user_id=7";
+let signed = sign(url, secret, None);     // None = never expires
+assert!(verify(&signed, secret).is_ok());
+
+// Flip any signed byte → InvalidSignature.
+let tampered = signed.replace("user_id=7", "user_id=8");
+assert_eq!(verify(&tampered, secret), Err(SignedUrlError::InvalidSignature));
+```
+
+Fügen Sie eine TTL hinzu, und ein abgelaufener Link wird abgewiesen (`sign_at` / `verify_at`
+nehmen explizite Unix-Sekunden für deterministische Tests):
+
+```rust
+use rustango::signed_url::{sign_at, verify_at, SignedUrlError};
+
+let signed = sign_at(url, secret, Some(100));         // expires at t=100
+assert!(verify_at(&signed, secret, 50).is_ok());      // before → ok
+assert_eq!(verify_at(&signed, secret, 1000), Err(SignedUrlError::Expired));
+```
+
+Die Query wird vor dem Signieren sortiert, die Reihenfolge der Parameter spielt also keine Rolle.
+Die Fehler sind `MissingSignature`, `MalformedSignature`, `InvalidSignature`, `Expired`.
+
+---
+
+## Passwort-Zurücksetzung
+
+Die `auth_flows`-Helfer umhüllen signierte URLs mit einer **Zweck-Markierung** (damit ein
+Reset-Token nicht als Magic Link wiederverwendet werden kann) und kodieren die Benutzer-ID.
+`PasswordReset` liefert außerdem einen Bestätigungshelfer, der das Token verifiziert und den
+**gespeicherten Hash rotiert** — in einem einzigen Aufruf.
+
+```rust
+use std::time::Duration;
+use rustango::auth_flows::{PasswordReset, confirm_password_reset_pool_into};
+
+// 1. User asks to reset → look them up → issue a link → email it.
+let url = PasswordReset::issue(
+    "https://app.example.com/auth/reset",   // your callback route
+    user_id,                                // encoded in the token
+    secret,
+    Duration::from_secs(3600),              // 1-hour TTL
+);
+mailer.send(&Email::new().to(addr).subject("Reset your password").body(&url)).await?;
+
+// 2. User clicks + submits a new password → verify + rotate the hash.
+let user_id = confirm_password_reset_pool_into(
+    &pool, &url, "a-brand-new-strong-password", secret,
+    "rustango_users", "id", "password_hash",  // table, pk col, password col
+).await?;
+```
+
+Der Bestätigungshelfer erzwingt eine Mindestlänge, hasht das neue Passwort mit argon2id und
+schreibt es — wobei er schwache, abgelaufene, manipulierte oder mit falschem Secret versehene
+Eingaben abweist, ohne die Zeile anzurühren:
+
+```rust
+// valid token + strong pw → hash rotated (starts "$argon2…")
+// "short"                  → Err(WeakPassword), nothing written
+// user_id tampered         → Err(InvalidSignature), nothing written
+```
+
+> `confirm_password_reset_pool` ist die bequeme Form, die die Standardwerte
+> `rustango_users` / `id` / `password_hash` annimmt; verwenden Sie `_into`, um auf Ihre eigene
+> Tabelle/Spalten zu verweisen.
+
+---
+
+## E-Mail-Verifizierung
+
+`EmailVerification` kodiert sowohl die Benutzer-ID **als auch** die E-Mail, sodass Sie bei der
+Verifizierung beide zurückerhalten und bestätigen können, dass die Adresse immer noch übereinstimmt
+(um Links abzufangen, die vor einer E-Mail-Änderung versendet wurden). Hier gibt es keinen
+integrierten DB-Schreibvorgang — Sie setzen Ihre eigene Spalte „verifiziert“:
+
+```rust
+use rustango::auth_flows::EmailVerification;
+
+// On signup:
+let url = EmailVerification::issue(callback, user_id, &email, secret, Duration::from_secs(86_400));
+mailer.send(&Email::new().to(&email).subject("Confirm your email").body(&url)).await?;
+
+// On click:
+let (user_id, email) = EmailVerification::verify(&url, secret)?;
+// → if email still matches the user's current address, mark them verified
+```
+
+---
+
+## Magic-Link-Anmeldung
+
+`MagicLink` kodiert nur die E-Mail — der Benutzer klickt, Sie schlagen das Konto nach und prägen
+eine [Session](auth-sessions.md). Halten Sie die TTL kurz (10–30 Min) und machen Sie ihn
+**einmalig nutzbar** (nächster Abschnitt), denn der Link *ist* die Zugangsberechtigung:
+
+```rust
+use rustango::auth_flows::MagicLink;
+
+let url = MagicLink::issue(callback, &email, secret, Duration::from_secs(900));
+mailer.send(&Email::new().to(&email).subject("Your sign-in link").body(&url)).await?;
+
+// On click:
+let email = MagicLink::verify_single_use(&url, secret, &cache).await?;
+// → look up the user by email, create a session
+```
+
+---
+
+## Einmal-Tokens
+
+`verify` allein prüft nur Signatur + Ablauf, ein durchgesickerter Link ist also bis zum Ablauf
+wiederholbar. Für Anmeldung und Zurücksetzung bevorzugen Sie `verify_single_use(url, secret,
+&cache)` — es hält die Signatur des Tokens in einem `Cache` fest und verweigert eine zweite
+Nutzung:
+
+```rust
+// first click  → Ok(email)
+// same link reused → Err(AuthFlowError::AlreadyUsed)
+```
+
+Untermauern Sie es in der Produktion mit einem **gemeinsam genutzten** Cache (Redis), damit ein
+Token nicht gegen ein anderes Replikat wiederholt werden kann. Die Prüfung schlägt geschlossen fehl
+(ein Cache-Fehler verweigert, statt einen Wiederholungsangriff zu riskieren).
+
+---
+
+## Was Sie bereitstellen
+
+Das Framework stellt Tokens aus/verifiziert sie und schreibt (beim Zurücksetzen) den Hash; Ihre
+Anwendung liefert den Rest:
+
+- Ein **Secret** (ein stabiler App-Schlüssel; per Konvention 32 Byte).
+- Ein **Mailer** zum Versenden der Links — `rustango::email` liefert `ConsoleMailer`,
+  `SmtpMailer` und `InMemoryMailer` (praktisch in Tests).
+- Eine **Benutzertabelle** mit den Spalten, die jeder Ablauf braucht (E-Mail für die
+  Verifizierungs-/Magic-Link-Suche; eine Passwort-Hash-Spalte für die Zurücksetzung; eine Spalte
+  „verifiziert“, die Ihnen gehört).
+- Die **Callback-Routen**, die den Klick empfangen, und die Session-Prägung für die
+  Magic-Link-Anmeldung.
+
+---
+
+## Siehe auch
+
+- [Passwörter](auth-passwords.md) — das Hashing, das die Zurücksetzung rotiert.
+- [Sessions](auth-sessions.md) — was die Magic-Link-Anmeldung bei Erfolg erzeugt.
+- [HMAC-Request-Signierung](auth-hmac.md) — dieselbe HMAC-Primitive, angewandt auf API-Requests
+  statt auf URLs.
+- [Sicherheitsleitfaden](security.md) — die umfassendere Härtungs-Checkliste.

--- a/docs/de/auth-hmac.md
+++ b/docs/de/auth-hmac.md
@@ -1,0 +1,189 @@
+# HMAC-Anfragesignierung
+
+Die HMAC-Signierung beweist **sowohl, wer eine Anfrage gesendet hat, als auch,
+dass sie unterwegs nicht verändert wurde**. Der Client signiert jede Anfrage mit
+einem gemeinsamen Secret; der Server berechnet die Signatur neu und vergleicht.
+Anders als ein Bearer-[API-Schlüssel](auth-api-keys.md) — der bei Abfangen
+wiederholbar ist — deckt eine HMAC-Signatur die Methode, den Pfad, den
+Query-String, den Zeitstempel und den Body ab, sodass eine manipulierte oder
+veraltete Anfrage abgelehnt wird. Es ist das Schema, das AWS SigV4 und
+Webhook-Signaturen verwenden, und **Rustango** liefert es als einen einzigen
+Tower-Layer.
+
+[![HMAC-Signierung in Rustango: der Client signiert Methode+Pfad+Query+Datum+Body-Hash mit einem gemeinsamen Secret; HmacAuthLayer berechnet neu und vergleicht in konstanter Zeit, manipulierte oder veraltete Anfragen werden abgelehnt](img/auth-hmac.png)](img/auth-hmac.png)
+
+> **Ein Begriff hier neu für Sie?** *HMAC*, *gemeinsames Secret*, *Replay*, *Vergleich in konstanter Zeit* —
+> siehe das [Glossar](glossary.md).
+
+> **Quelle:** `rustango::hmac_auth` (`HmacAuthLayer`, `KeyResolver`, `sign_now`,
+> `sign_request`) — hinter dem Feature `hmac-auth` (standardmäßig aktiviert; der
+> Replay-Schutz benötigt zusätzlich `cache`).
+>
+> **Lauffähige Version:** Jedes Snippet ist aus
+> [`auth_hmac_doc.rs`](../crates/rustango/tests/auth_hmac_doc.rs) kopiert
+> (`cargo test -p rustango --test auth_hmac_doc`).
+
+## Inhaltsverzeichnis
+
+- [Wann einsetzen](#when-to-use-it)
+- [Was signiert wird](#what-gets-signed)
+- [Server: mit dem Layer verifizieren](#server-verify-with-the-layer)
+- [Client: eine Anfrage signieren](#client-sign-a-request)
+- [Uhren-Skew und Replay](#clock-skew-and-replay)
+- [Grenzen](#limits)
+- [Siehe auch](#see-also)
+
+---
+
+## Wann einsetzen
+
+| Verwenden Sie… | Wann |
+|---|---|
+| [API-Schlüssel](auth-api-keys.md) (Bearer) | Einfache Maschinen-Auth; Abfangrisiko ist akzeptabel (TLS, kurze Rotation). |
+| **HMAC-Signierung** | Sie benötigen **Integrität pro Anfrage + Replay-Resistenz** — Webhooks, Partner-APIs, alles, wo eine abgefangene Anfrage nicht wiederverwendbar oder modifizierbar sein darf. |
+| [JWT](auth-jwt.md) | Zustandslose, selbstbeschreibende Benutzer-Tokens mit Claims. |
+
+HMAC erfordert, dass beide Seiten dasselbe Secret out-of-band halten (Sie stellen
+es bereit) und einigermaßen synchronisierte Uhren.
+
+---
+
+## Was signiert wird
+
+Der Client baut eine kanonische Zeichenkette und wendet HMAC-SHA256 mit dem
+gemeinsamen Secret darauf an:
+
+```text
+<UPPERCASE-METHOD>\n
+<PATH>\n
+<SORTED-QUERY>\n
+<X-DATE>\n
+<HEX-SHA256(BODY)>
+```
+
+Zwei Anfrage-Header tragen das Ergebnis:
+
+- `X-Date` — ein RFC-3339-Zeitstempel (ebenfalls Teil der signierten
+  Zeichenkette).
+- `Authorization: HMAC-SHA256 keyId=<id>,signature=<base64>`
+
+Weil der Query-String auf beiden Seiten **sortiert** wird, erzeugen `?b=2&a=1`
+und `?a=1&b=2` dieselbe Signatur. Weil der Body in die Zeichenkette gehasht wird,
+macht das Ändern eines einzigen Bytes sie ungültig.
+
+---
+
+## Server: mit dem Layer verifizieren
+
+`HmacAuthLayer::new` nimmt einen **`KeyResolver`** — eine Closure, die eine
+`keyId` auf ihr Secret abbildet (`None` ⇒ unbekannter Schlüssel ⇒ 401). Hängen
+Sie ihn als normalen Tower-Layer vor die Routen, die Sie schützen wollen:
+
+```rust
+use std::sync::Arc;
+use rustango::hmac_auth::{HmacAuthLayer, KeyResolver};
+use tower::Layer;
+
+// Schlüssel-IDs auf Secrets auflösen — hinterlegen Sie dies mit Ihrer DB / Ihrem Secret-Store.
+let resolver: KeyResolver = Arc::new(|key_id: &str| {
+    (key_id == "k_demo").then(|| b"shared-secret-at-least-32-bytes-long!!".to_vec())
+});
+
+let layer = HmacAuthLayer::new(resolver)
+    .tolerance_secs(300);                 // ±5-Min-Uhren-Skew-Fenster (Standard)
+
+let app = protected_router.layer(layer);
+```
+
+Eine korrekt signierte Anfrage passiert; manipulieren Sie den Body, lassen Sie
+`X-Date` weg oder signieren Sie mit einem unbekannten Schlüssel, und es ist ein
+`401`:
+
+```rust
+// korrekt signiert            → 200
+// Body nach dem Signieren geändert → 401  (Signatur stimmt nicht überein)
+// fehlender X-Date-Header      → 401
+// keyId, die der Resolver ablehnt → 401
+```
+
+> **Kein Identitäts-Extraktor.** Der Layer verifiziert die Signatur, **injiziert
+> aber nicht**, welche `keyId` signiert hat, in die Anfrage — es gibt keinen
+> `HmacUser`-Extraktor. Wenn ein Handler die Aufrufer-Identität benötigt, umhüllen
+> Sie den Layer oder führen Sie sie selbst mit. Ablehnungen sind schlichte
+> `401`/`413`-Antworten, kein typisierter Fehler, auf den Sie matchen.
+
+---
+
+## Client: eine Anfrage signieren
+
+`sign_now` signiert mit der aktuellen Zeit und liefert die beiden anzuhängenden
+Header-Werte (`sign_request` ist die Variante, die ein explizites
+RFC-3339-Datum nimmt):
+
+```rust
+use rustango::hmac_auth::sign_now;
+
+let body = br#"{"amount": 100}"#;
+let (x_date, authorization) =
+    sign_now("k_demo", b"shared-secret-at-least-32-bytes-long!!",
+             "POST", "/api/charge", "", body);
+
+// Hängen Sie beide Header an und senden Sie den EXAKTEN Body, den Sie signiert haben:
+let req = http::Request::post("/api/charge")
+    .header("x-date", x_date)
+    .header("authorization", authorization)
+    .body(body.to_vec())?;
+```
+
+Die Signatur ist base64; der Body-Hash innerhalb der kanonischen Zeichenkette ist
+hex. Senden Sie den Body Byte für Byte wie signiert — jeder Proxy, der ihn
+umschreibt (Neukomprimierung, JSON-Neuserialisierung), bricht die Verifizierung.
+
+---
+
+## Uhren-Skew und Replay
+
+Der `X-Date`-Zeitstempel begrenzt Replay: Eine Anfrage, deren Datum außerhalb von
+`tolerance_secs` (Standard ±300 s) liegt, wird abgelehnt, sodass eine abgefangene
+Anfrage nur innerhalb dieses kurzen Fensters wiederverwendbar ist. Um es ganz zu
+schließen, hängen Sie einen **Nonce-Store** an (irgendeinen `cache::Cache`), und
+jede Signatur kann innerhalb des Fensters nur einmal ausgegeben werden:
+
+```rust
+use rustango::cache::InMemoryCache;
+
+let layer = HmacAuthLayer::new(resolver)
+    .tolerance_secs(120)
+    .nonce_store(Arc::new(InMemoryCache::new()));  // Replays ablehnen
+```
+
+Verwenden Sie in der Produktion einen **gemeinsamen** Store (Redis), damit der
+Schutz über Replicas hinweg hält — ein In-Process-Cache schützt nur eine
+Instanz. Die Replay-Prüfung schlägt bei einem Cache-Fehler „fail open“ fehl
+(Verfügbarkeit vor dem engen In-Fenster-Risiko).
+
+---
+
+## Grenzen
+
+- **Symmetrischer ±Skew, RFC-3339-Daten.** Beide Uhren müssen ungefähr
+  synchronisiert sein; der Client muss denselben Zeitstempel senden, den er
+  signiert hat (`sign_now` liefert ihn für Sie).
+- **Vollständige Body-Pufferung.** Der Body wird zum Hashen in den Speicher
+  gelesen (Standardobergrenze 10 MiB → `413`; anheben mit `.body_limit(n)`, aber
+  auf den Speicher achten). Streaming-Bodies werden nicht unterstützt.
+- **Die Signatur ist base64 auf dem Draht, der Body-Hash ist hex** — leicht zu
+  verwechseln, wenn man einen Client in einer anderen Sprache schreibt.
+- **Halten Sie den Layer am äußersten** relativ zu allem, was den Body mutiert.
+
+---
+
+## Siehe auch
+
+- [API-Schlüssel](auth-api-keys.md) — einfacheres Bearer-Credential, wenn
+  Integrität/Replay keine Rolle spielen.
+- [Auth-Backends](auth-backends.md) — zum Identifizieren eines *Benutzers* pro
+  Anfrage (HMAC beweist die Nachrichtenintegrität, nicht eine Session-Identität).
+- [Webhooks](security.md) — das eingehende Gegenstück: Signaturen auf Ereignissen
+  verifizieren, die Sie empfangen.
+- [Middleware](middleware.md) — wie sich Tower-Layer anhängen und ordnen.

--- a/docs/de/auth-jwt-api.md
+++ b/docs/de/auth-jwt-api.md
@@ -1,0 +1,227 @@
+# JWT-Auth-API
+
+Das Modul [eigenständiges JWT](auth-jwt.md) signiert und verifiziert einen
+einzelnen Token. Eine echte API braucht den ganzen **Lebenszyklus**: einen
+kurzlebigen *Access*-Token, einen langlebigen *Refresh*-Token, Rotation beim
+Refresh und **Widerruf** für das Abmelden. **Rustango** liefert das als
+`JwtLifecycle` — und einen schlüsselfertigen Router, der `POST /api/auth/login`,
+`/refresh`, `/logout` und `GET /me` für Sie einhängt.
+
+[![JWT-Auth-API: login stellt ein Access+Refresh-Paar aus, refresh rotiert und setzt den alten Token auf die Sperrliste, logout widerruft über einen JTI-Speicher](img/auth-jwt-api.png)](img/auth-jwt-api.png)
+
+> **Quelle:** `rustango::tenancy::jwt_lifecycle` (`JwtLifecycle`, `JwtTokenPair`,
+> `JwtClaims`) und `rustango::tenancy::auth_routes` (`jwt_router`, `Config`) +
+> `rustango::jti_store` (`JtiStore`, `InMemoryJtiStore`) — hinter `jwt` +
+> `tenancy`.
+>
+> **Lauffähige Version:** Die Token-Engine wird durch den getesteten
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs)
+> abgedeckt — `cargo test -p auth_demo --test auth_jwt_api`. Die HTTP-Endpunkte
+> sind tenant-bezogen und werden durchgängig durch das eigene
+> `crates/rustango/tests/tenant_auth_live.rs` des Frameworks geprüft.
+
+> **Ein Begriff hier neu für Sie?** *Access-/Refresh-Token*, *Rotation*,
+> *Widerruf* — siehe das [Glossar](glossary.md).
+
+> Vertiefende Ergänzung zum Abschnitt „JWTs ausstellen und erneuern“ des
+> [Sicherheitsleitfadens](security.md). Für einen einzelnen, manuell verwalteten
+> Token siehe stattdessen [JWT (eigenständig)](auth-jwt.md).
+
+---
+
+## Inhaltsverzeichnis
+- [Der eingebaute Router](#the-built-in-router) · [Die Verdrahtung](#wiring-it-up)
+- [Die Token-Engine](#the-token-engine-jwtlifecycle) · [Refresh & Rotation](#refresh-and-rotation)
+- [Widerruf & der JTI-Speicher](#revocation-and-the-jti-store) · [Benutzerdefinierte Claims](#custom-claims)
+- [Hinweise und Grenzen](#notes-and-limits)
+
+---
+
+## Der eingebaute Router
+
+`jwt_router` hängt die vier Standard-Endpunkte gegen die tenant-spezifische
+Tabelle `rustango_users` ein — die ~50 Zeilen Login-Boilerplate, die jedes
+Projekt sonst neu schreibt:
+
+| Methode | Pfad | Body / Auth | Liefert |
+|---|---|---|---|
+| POST | `/api/auth/login` | `{username, password}` | `{access, refresh, user}` |
+| POST | `/api/auth/refresh` | `{refresh}` | `{access, refresh}` |
+| POST | `/api/auth/logout` | `Authorization: Bearer <access>` | `204` (widerruft die JTI) |
+| GET | `/api/auth/me` | `Authorization: Bearer <access>` | `{user_id, username, is_superuser}` |
+
+Login verifiziert das Passwort mit [argon2id](auth-passwords.md) und stellt dann
+ein Paar aus. Pfade, TTLs und der Signierschlüssel sind über `Config`
+konfigurierbar.
+
+## Die Verdrahtung
+
+```rust
+use rustango::tenancy::auth_routes::{jwt_router, Config};
+
+rustango::manage::Cli::new()
+    .tenancy()
+    .api(my_app::urls::api()
+        .merge(jwt_router(Config::default())))   // hängt /api/auth/* ein
+    .run()
+    .await
+```
+
+`Config::default()` signiert mit `RUSTANGO_SESSION_SECRET` (demselben Schlüssel
+wie das Admin-Session-Cookie) und verwendet TTLs von 15 Min. Access / 7 Tage
+Refresh. Überschreiben Sie `prefix`, `access_ttl_secs`, `refresh_ttl_secs` oder
+`session_secret` nach Bedarf. Die Endpunkte laufen im Tenant-Kontext, hängen Sie
+sie also in einer Tenancy-App ein.
+
+```sh
+# Login → access + refresh
+curl -sX POST localhost:8080/api/auth/login \
+  -H 'content-type: application/json' \
+  -d '{"username":"alice","password":"hunter2hunter"}'
+
+# Einen geschützten Endpunkt aufrufen
+curl localhost:8080/api/auth/me -H "Authorization: Bearer $ACCESS"
+```
+
+---
+
+## Die Token-Engine (`JwtLifecycle`)
+
+Unter dem Router sitzt `JwtLifecycle` — direkt nutzbar, wenn Sie den
+Lebenszyklus ohne die eingebaute HTTP-Form wollen:
+
+```rust
+use rustango::tenancy::jwt_lifecycle::JwtLifecycle;
+
+let jwt = JwtLifecycle::new(secret_32_bytes);
+
+// Login: das Paar ausstellen.
+let pair = jwt.issue_pair(user_id);
+// → pair.access  (kurze TTL, im Authorization-Header senden)
+// → pair.refresh (lange TTL, in einem HttpOnly-Cookie / sicheren Speicher ablegen)
+
+// Authentifizierte Anfrage: den Access-Token verifizieren.
+match jwt.verify_access(&access) {
+    Some(claims) => { /* claims.sub ist die Benutzer-ID */ }
+    None => { /* 401: ungültig, abgelaufen, widerrufen oder falscher Typ */ }
+}
+```
+
+Access- und Refresh-Tokens sind **nicht austauschbar** — `verify_access` lehnt
+einen Refresh-Token ab und umgekehrt, sodass ein gestohlener kurzlebiger
+Access-Token nicht zum Erzeugen neuer Tokens verwendet werden kann:
+
+```rust
+let pair = jwt.issue_pair(42);
+assert!(jwt.verify_refresh(&pair.access).is_none());
+assert!(jwt.verify_access(&pair.refresh).is_none());
+```
+
+---
+
+## Refresh und Rotation
+
+`refresh` tauscht einen gültigen Refresh-Token gegen ein **neues Paar** und setzt
+die JTI des alten Refresh-Tokens auf die Sperrliste — gleitender Ablauf mit
+Refresh-Tokens für den einmaligen Gebrauch (das Wiedereinspielen des alten wird
+abgelehnt):
+
+```rust
+let pair = jwt.issue_pair(7);
+let rotated = jwt.refresh(&pair.refresh).expect("refresh ok");
+assert_ne!(pair.access, rotated.access);
+assert!(jwt.refresh(&pair.refresh).is_none());   // der alte Refresh ist jetzt tot
+```
+
+Standardmäßig **bewahrt** `refresh` die benutzerdefinierten Claims des Tokens.
+Wenn sich Berechtigungen geändert haben könnten (Rolle widerrufen, Scope
+herabgestuft), verwenden Sie `refresh_with(token, new_claims)`, um ein frisches
+Payload einzusetzen, während die alte Refresh-JTI dennoch auf die Sperrliste
+gesetzt wird.
+
+---
+
+## Widerruf und der JTI-Speicher
+
+Jeder Token trägt eine eindeutige `jti`. `revoke` fügt sie einer Sperrliste
+hinzu, sodass nachfolgende `verify_*`-Aufrufe fehlschlagen, bis der Token ohnehin
+abgelaufen wäre — genau das ruft `POST /api/auth/logout` auf:
+
+```rust
+let pair = jwt.issue_pair(1);
+assert!(jwt.revoke(&pair.access));
+assert!(jwt.verify_access(&pair.access).is_none());
+```
+
+Die Sperrliste liegt in einem austauschbaren `JtiStore`. Der Standard
+`InMemoryJtiStore` ist **einprozessig und verliert Widerrufe beim Neustart** —
+in Ordnung für eine einzelne Instanz. Jede Multi-Replica-Bereitstellung MUSS
+einen gemeinsamen, dauerhaften Speicher (Redis / DB) installieren, damit ein
+Logout auf einer Replica von allen respektiert wird:
+
+```rust
+use rustango::jti_store::{InMemoryJtiStore, JtiStore};
+use std::sync::Arc;
+
+let shared: Arc<dyn JtiStore> = Arc::new(InMemoryJtiStore::new()); // in Prod durch Redis ersetzen
+let a = JwtLifecycle::new(secret.clone()).with_jti_store(Arc::clone(&shared));
+let b = JwtLifecycle::new(secret).with_jti_store(Arc::clone(&shared));
+
+let pair = a.issue_pair(5);
+a.revoke(&pair.access);
+assert!(b.verify_access(&pair.access).is_none());   // B sieht As Widerruf
+```
+
+> Ohne gemeinsamen Speicher ist `/logout` bestenfalls „best-effort“: Ein
+> widerrufener Token kann auf einer anderen Replica bis zu seinem natürlichen
+> Ablauf noch akzeptiert werden. Dies ist die einzelne wichtigste
+> Produktionseinstellung für JWT-Auth.
+
+---
+
+## Benutzerdefinierte Claims
+
+Betten Sie `roles` / `tenant` / `scope` direkt in den Token ein, sodass die
+Verifizierung keine DB-Abfrage benötigt. Reservierte Namen (`sub`, `exp`, `jti`,
+`typ`) werden abgelehnt:
+
+```rust
+let custom = serde_json::json!({ "roles": ["admin"], "tenant": "acme" })
+    .as_object().unwrap().clone();
+let pair = jwt.issue_pair_with(99, custom)?;
+
+let claims = jwt.verify_access(&pair.access).unwrap();
+let roles: Vec<String> = claims.get_custom("roles").unwrap();   // ["admin"]
+```
+
+Benutzerdefinierte Claims überleben `refresh` (werden auf das neue Paar
+übertragen), es sei denn, Sie verwenden `refresh_with`.
+
+---
+
+## Hinweise und Grenzen
+
+- **Sessions vs. JWT vs. dies:** Ein einfaches [JWT](auth-jwt.md) kann nicht
+  widerrufen werden; eine [Session](auth-sessions.md) ist widerrufbar, braucht
+  aber eine Speicherabfrage pro Anfrage; `JwtLifecycle` ist der Mittelweg —
+  zustandslose Verifizierung, plus eine JTI-Sperrliste für die Widerrufe, die Sie
+  tatsächlich brauchen (Logout, Rotation).
+- **HTTP-Endpunkte sind tenant-bezogen.** `jwt_router` löst Benutzer über den
+  Tenant-Kontext + `rustango_users` auf; hängen Sie ihn in einer
+  `.tenancy()`-App ein. Die Token-Engine (`JwtLifecycle`) selbst hat diese
+  Anforderung nicht.
+- **Kombinieren Sie dies** mit dem `JwtBackend` der
+  [Auth-Backend-Kette](auth-backends.md), um beliebige Routen aus dem
+  `Authorization: Bearer`-Header zu authentifizieren.
+- **HS256-Signierung**, 32-Byte-Schlüssel-Untergrenze — derselbe Algorithmus und
+  dieselben Einschränkungen wie beim [eigenständigen JWT](auth-jwt.md#security-model).
+
+
+---
+
+## Siehe auch
+
+- [JWT (eigenständig)](auth-jwt.md)
+- [Auth-Backends](auth-backends.md)
+- [Sessions](auth-sessions.md)
+- [Sicherheitsleitfaden](security.md)

--- a/docs/de/auth-jwt.md
+++ b/docs/de/auth-jwt.md
@@ -1,0 +1,211 @@
+# JWT (eigenständig)
+
+Ein JSON Web Token ist ein **zustandsloses** Credential: eine signierte,
+in sich geschlossene Zeichenkette, die der Client bei jeder Anfrage sendet und
+die Ihr Server mit einem Secret verifiziert — ohne Datenbank- oder
+Cache-Abfrage pro Anfrage. Das Modul `rustango::jwt` von **Rustango** ist der
+minimale Baustein: `encode` zum Signieren von Claims, `decode` zum Verifizieren
+und Zurücklesen, HS256 unter der Haube.
+
+[![Eigenständiges JWT in Rustango: Claims tragen sub-/exp-/benutzerdefinierte Felder, encode() signiert mit einem gemeinsamen Secret, decode() verifiziert Signatur + Ablauf](img/auth-jwt.png)](img/auth-jwt.png)
+
+> **Quelle:** `rustango::jwt` (`Claims`, `encode`, `decode`, `decode_at`,
+> `decode_unverified`, `JwtError`) — hinter dem Feature `jwt` (standardmäßig
+> aktiviert). Für eine schlüsselfertige Access+Refresh-**API** mit Widerruf siehe
+> [JWT-Auth-API](auth-jwt-api.md).
+>
+> **Lauffähige Version:** Die Snippets sind aus dem getesteten
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt.rs) kopiert —
+> `cargo test -p auth_demo --test auth_jwt`.
+
+> **Ein Begriff hier neu für Sie?** *JWT*, *Claims*, *zustandslos*, *Secret* —
+> siehe das [Glossar](glossary.md).
+
+> Vertiefende Ergänzung zum Abschnitt „JWTs ausstellen und erneuern“ des
+> [Sicherheitsleitfadens](security.md).
+
+---
+
+## Inhaltsverzeichnis
+- [Schnellstart](#quick-start) · [Wann einsetzen](#when-to-use-standalone-jwt)
+- [Claims erstellen](#building-claims) · [Verifizieren](#verifying-a-token)
+- [Sicherheitsmodell](#security-model) — unbedingt lesen · [Inspizieren ohne Vertrauen](#inspecting-without-verifying)
+- [Hinweise und Grenzen](#notes-and-limits)
+
+---
+
+## Schnellstart
+
+```rust
+use rustango::jwt::{Claims, encode, decode};
+use std::time::Duration;
+
+// HS256 ist symmetrisch — dasselbe Secret signiert und verifiziert. Muss >= 32 Bytes sein.
+let secret = b"a-shared-signing-secret-at-least-32-bytes!!";
+
+let mut claims = Claims::new("user-42").ttl(Duration::from_secs(900));
+claims.set("roles", vec!["editor", "author"]);
+
+let token = encode(&claims, secret)?;        // header.payload.signature
+
+let verified = decode(&token, secret)?;       // prüft Signatur + exp/nbf
+assert_eq!(verified.subject(), Some("user-42"));
+let roles: Vec<String> = verified.get("roles").unwrap();
+```
+
+---
+
+## Wann ein eigenständiges JWT einsetzen
+
+Greifen Sie zu `rustango::jwt`, wenn Sie einen schlichten signierten Token wollen
+und den Lebenszyklus selbst verwalten:
+
+- **Magic-Link- / Einmal-Tokens** — wenige Claims (Benutzer-ID, Zweck, kurzes
+  `exp`).
+  Siehe [Magic Links & Auth-Abläufe](auth-flows.md).
+- **Service-zu-Service**-Bearer-Tokens (das JWT-Gegenstück zur [HMAC-
+  Anfragesignierung](auth-hmac.md) — HMAC für kanonische Anfragen im AWS-Stil,
+  JWT für einen zustandslosen Bearer).
+- **SSO-Tokens**, die Sie an einen Dritten übergeben.
+
+Wenn Sie eine schlüsselfertige **login → access + refresh → refresh →
+logout**-API mit Token-Widerruf wollen, bauen Sie sie nicht darauf auf —
+verwenden Sie die [JWT-Auth-API](auth-jwt-api.md), die dieses Modul mit Rotation +
+einem Widerrufsspeicher umhüllt. Und wenn Sie einen Benutzer *jetzt* zwangsweise
+abmelden müssen, bevorzugen Sie eine widerrufbare [Session](auth-sessions.md):
+Ein einfaches JWT ist gültig, bis es abläuft.
+
+---
+
+## Claims erstellen
+
+`Claims` umhüllt ein JSON-Objekt, sodass Standard-Claims und Ihre eigenen
+Erweiterungsfelder koexistieren:
+
+```rust
+let mut claims = Claims::new("user-42")     // setzt `sub` + `iat=now`
+    .ttl(Duration::from_secs(3600))         // setzt `iat`=now und `exp`=now+ttl
+    .issuer("api.example.com")              // `iss`
+    .audience("web-client")                 // `aud`
+    .jti("unique-token-id");                // `jti` (für Ihre eigene Sperrliste)
+claims.set("role", "admin");                // beliebiger Serialize-Wert
+claims.set("org_id", 7_i64);
+```
+
+| Builder / Setter | Claim |
+|---|---|
+| `Claims::new(sub)` | `sub` + `iat` |
+| `Claims::empty()` | keine (volle Kontrolle) |
+| `.ttl(Duration)` | `iat` (now) + `exp` (now+ttl) |
+| `.expires_at(secs)` / `.not_before(secs)` | absolutes `exp` / `nbf` |
+| `.issuer(s)` / `.audience(s)` / `.jti(s)` | `iss` / `aud` / `jti` |
+| `.set(name, value)` | beliebiger benutzerdefinierter Claim |
+
+Lesen Sie sie mit `.subject()` und `.get::<T>(name)` zurück (liefert `None` für
+einen fehlenden oder falsch typisierten Claim).
+
+---
+
+## Einen Token verifizieren
+
+```rust
+use rustango::jwt::{decode, JwtError};
+
+match decode(&token, secret) {
+    Ok(claims) => { /* claims.subject() usw. vertrauen */ }
+    Err(JwtError::Expired(_))      => { /* 401 — Token abgelaufen */ }
+    Err(JwtError::BadSignature)    => { /* 401 — gefälscht oder falscher Schlüssel */ }
+    Err(JwtError::NotYetValid(_))  => { /* nbf in der Zukunft */ }
+    Err(_)                         => { /* fehlerhaft / nicht unterstützter alg */ }
+}
+```
+
+`decode` verifiziert die **Signatur**, dann `exp` und `nbf`. Um das Verhalten des
+Zeitfensters zu testen (oder eine Skew-Toleranz hinzuzufügen), lässt
+`decode_at(token, secret, now)` Sie die „aktuelle“ Sekunde festlegen:
+
+```rust
+let token = encode(&Claims::new("x").expires_at(1000), secret)?;
+assert!(decode_at(&token, secret, 500).is_ok());                     // vor exp
+assert!(matches!(decode_at(&token, secret, 2000), Err(JwtError::Expired(_)))); // danach
+```
+
+---
+
+## Sicherheitsmodell
+
+Dies ist Code an der Auth-Grenze — drei Dinge, die Sie wissen müssen:
+
+1. **`decode` validiert `iss` / `aud` NICHT.** Eine gültige Signatur beweist,
+   dass der Token mit Ihrem Secret erzeugt wurde, nicht dass er *für Ihren
+   Dienst* erzeugt wurde. Wenn Sie `iss`/`aud` bei der Ausstellung setzen,
+   **prüfen Sie sie selbst** an den decodierten Claims:
+
+   ```rust
+   let c = decode(&token, secret)?;
+   if c.get::<String>("aud").as_deref() != Some("web-client") {
+       return Err("wrong audience");
+   }
+   ```
+
+2. **Das Secret muss ≥ 32 Bytes sein** — `encode` weigert sich, mit einem
+   kürzeren Schlüssel zu signieren (ein kurzer Schlüssel ist erratbar, und ein
+   erratbarer HMAC-Schlüssel bedeutet fälschbare Tokens). HS256 ist symmetrisch:
+   Wer das Verifizierungs-Secret besitzt, kann auch Tokens *erzeugen*, es bleibt
+   also innerhalb Ihrer Vertrauensgrenze (einzelner Dienst / gemeinsames
+   Backend). Die organisationsübergreifende Token-Ausstellung verlangt
+   asymmetrisches RS256/ES256, das dieses Modul bewusst nicht mitbringt.
+
+3. **`alg=none` und Manipulation werden abgelehnt.** `decode` fixiert HS256 (die
+   klassische „alg: none“-Fälschung wird verweigert), und jede Änderung an
+   Header oder Payload bricht die Signatur — verifiziert durch einen Vergleich
+   in konstanter Zeit.
+
+Es gibt **keinen Spielraum für Uhren-Skew**: `exp`/`nbf` vergleichen mit der
+exakten aktuellen Sekunde. Wenn die Uhren von Aussteller und Verifizierer
+auseinanderdriften, ziehen Sie ein paar Sekunden über `decode_at` ab.
+
+---
+
+## Inspizieren ohne Verifizieren
+
+`decode_unverified` liest das Payload, **ohne** Signatur oder Ablauf zu prüfen —
+nützlich nur, um einen Blick auf einen Claim zu werfen (z. B. eine Schlüssel-ID),
+damit Sie das richtige Secret wählen können, und rufen Sie dann `decode` echt auf.
+
+```rust
+let peek = rustango::jwt::decode_unverified(&token)?;   // NICHT vertrauenswürdig
+let kid = peek.get::<String>("kid");
+// ... das Secret für `kid` nachschlagen, dann korrekt verifizieren:
+let claims = decode(&token, &resolved_secret)?;
+```
+
+**Autorisieren Sie niemals auf Basis der Ausgabe von `decode_unverified`** — sie
+trägt keine Integritätsgarantie.
+
+---
+
+## Hinweise und Grenzen
+
+- **Nur HS256** — symmetrisch, ein einziges gemeinsames Secret. Kein RS256/ES256
+  (hält den stets aktiven Abhängigkeitsbaum klein; die meisten
+  Einzeldienst-Apps verwenden ohnehin HS256).
+- **Zustandslos = nicht widerrufbar.** Ein einfaches JWT ist gültig bis `exp`.
+  Wenn Sie „jetzt abmelden“ / Widerruf pro Token benötigen, verwenden Sie die
+  [JWT-Auth-API](auth-jwt-api.md) (JTI-Sperrliste) oder eine
+  [Session](auth-sessions.md) (löschen Sie den Servereintrag).
+- **Halten Sie `exp` kurz** für Access-Tokens (Minuten). Langlebige einfache
+  JWTs sind gerade deshalb ein Risiko, weil sie nicht widerrufen werden können.
+- Verbinden Sie die Ausstellung mit [Passwörtern](auth-passwords.md)
+  (verifizieren, dann ausstellen) und schützen Sie API-Routen über das
+  `JwtBackend` der [Auth-Backend-Kette](auth-backends.md).
+
+
+---
+
+## Siehe auch
+
+- [JWT-Auth-API](auth-jwt-api.md)
+- [Auth-Backends](auth-backends.md)
+- [API-Schlüssel](auth-api-keys.md)
+- [Sessions](auth-sessions.md)

--- a/docs/de/auth-passwords.md
+++ b/docs/de/auth-passwords.md
@@ -1,0 +1,230 @@
+# Passwörter
+
+Ein Passwort zu speichern bedeutet, etwas zu speichern, das ein Angreifer selbst
+mit Ihrer gesamten Datenbank in der Hand nicht umkehren kann. **Rustango** liefert
+Ihnen das in zwei Aufrufen — `hash` beim Eingang, `verify` beim Ausgang —
+gestützt auf **argon2id**, den *memory-hard* Gewinner der Password Hashing
+Competition und die aktuelle Erstwahl der OWASP. Sie speichern, protokollieren
+oder vergleichen den Klartext niemals.
+
+[![Passwörter in Rustango: hash() erzeugt eine gesalzene argon2id-PHC-Zeichenkette, verify() prüft einen Versuch dagegen, und verify_dummy() gleicht die Anmelde-Timing an](img/auth-passwords.png)](img/auth-passwords.png)
+
+> **Quelle:** `rustango::passwords` (`hash`, `verify`, `verify_dummy`,
+> `strength_score`, `StrengthIssue`) — hinter dem Feature `passwords`
+> (standardmäßig aktiviert). Für die in die Mandantenfähigkeit integrierten
+> Passwort-Hilfsfunktionen siehe `rustango::tenancy::password`.
+>
+> **Ausführbare Version:** jeder Ausschnitt unten ist aus dem getesteten Beispiel
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_passwords.rs)
+> kopiert — `cargo test -p auth_demo --test auth_passwords`.
+
+> **Ein Begriff hier neu?** *hash*, *salt*, *argon2id*, *PHC-Zeichenkette* — siehe
+> das [Glossar](glossary.md).
+
+> Dies ist die Vertiefung zum Abschnitt „Passwörter hashen und prüfen" des
+> [Sicherheitsleitfadens](security.md).
+
+---
+
+## Inhaltsverzeichnis
+- [Schnellstart](#quick-start) · [Warum argon2id](#why-argon2id)
+- [Hashen bei der Registrierung](#hashing-on-signup) · [Prüfen bei der Anmeldung](#verifying-on-login)
+- [Timing-sichere Anmeldungen](#timing-safe-logins-account-enumeration) · [Stärkeprüfungen](#strength-checks)
+- [Wo der Hash lebt](#where-the-hash-lives) · [Hinweise und Grenzen](#notes-and-limits)
+
+---
+
+## Schnellstart
+
+```rust
+use rustango::passwords::{hash, verify};
+
+// Signup — store the returned PHC string, never the plaintext.
+let stored: String = hash("CorrectHorseBatteryStaple!42")?;
+
+// Login — check an attempt against the stored hash.
+if verify("CorrectHorseBatteryStaple!42", &stored)? {
+    // credentials good
+}
+```
+
+`hash` gibt eine [PHC-Zeichenkette](https://github.com/P-H-C/phc-string-format)
+zurück — eine selbstbeschreibende Zeile, die den Algorithmus, seine
+Kostenparameter, das zufällige Salt und den Digest trägt:
+
+```text
+$argon2id$v=19$m=19456,t=2,p=1$<base64 salt>$<base64 hash>
+```
+
+Da Salt und Parameter *innerhalb* der Zeichenkette mitreisen, benötigt `verify`
+nur den gespeicherten Wert und den Versuch — es gibt keine separate Salt-Spalte
+zu verwalten.
+
+---
+
+## Warum argon2id
+
+`hash` verwendet **argon2id** mit den von der OWASP empfohlenen Standardwerten
+(m=19 MiB, t=2, p=1). argon2id ist *memory-hard*: jeder Rateversuch kostet echten
+RAM, und genau das stumpft die GPU/ASIC-Farmen ab, die schnelle Hashes (MD5,
+SHA-256, sogar bcrypt bei niedrigen Kosten) per Brute-Force angreifbar machen.
+Zwei Eigenschaften sind für die Korrektheit wichtig:
+
+- **Das Salting ist automatisch und pro Hash.** Dasselbe Passwort zweimal zu
+  hashen ergibt zwei verschiedene PHC-Zeichenketten, sodass identische Passwörter
+  in Ihrer Tabelle nicht kollidieren und Angriffe mit vorberechneten
+  Rainbow-Tables nicht greifen.
+
+  ```rust
+  let a = hash("same-password-12345")?;
+  let b = hash("same-password-12345")?;
+  assert_ne!(a, b);                 // different random salt each time
+  assert!(verify("same-password-12345", &a)?);
+  assert!(verify("same-password-12345", &b)?);
+  ```
+
+- **Die Prüfung erfolgt in konstanter Zeit** beim Digest-Vergleich (argon2s
+  eigener `PasswordVerifier`), sodass ein Byte-für-Byte-Timing-Leak nicht
+  verraten kann, wie viel eines Versuchs richtig war.
+
+---
+
+## Hashen bei der Registrierung
+
+```rust
+use rustango::passwords::{hash, strength_score};
+
+fn create_user(username: &str, plaintext: &str) -> Result<String, String> {
+    // Optional: nudge users away from weak choices (see below).
+    let issues = strength_score(plaintext);
+    if !issues.is_empty() {
+        return Err(format!("password too weak: {issues:?}"));
+    }
+    // Store the PHC string on the user row (e.g. auth_users.password_hash).
+    hash(plaintext).map_err(|e| e.to_string())
+}
+```
+
+---
+
+## Prüfen bei der Anmeldung
+
+```rust
+use rustango::passwords::verify;
+
+// `stored` is the PHC string you saved at signup.
+let ok = verify(attempt, &stored)?;
+```
+
+`verify` gibt zurück:
+- `Ok(true)` — der Versuch stimmt überein.
+- `Ok(false)` — er stimmt nicht.
+- `Err(PasswordError::Verify)` — `stored` war keine gültige PHC-Zeichenkette
+  (eine beschädigte oder abgeschnittene Spalte), behandeln Sie es also als
+  fehlgeschlagene Anmeldung, nicht als 500.
+
+---
+
+## Timing-sichere Anmeldungen (Kontoaufzählung)
+
+Wenn Ihre Anmeldung das teure `verify` **nur** ausführt, wenn der Benutzername
+existiert, kehrt ein unbekannter Benutzername merklich schneller zurück als ein
+echter — und diese Zeitlücke lässt einen Angreifer gültige Konten aufzählen.
+`verify_dummy` schließt sie: rufen Sie es im Zweig Benutzer-nicht-gefunden (und
+Konto-inaktiv) auf, damit jede Anmeldung unabhängig davon die Arbeit eines
+argon2-verify aufwendet.
+
+```rust
+use rustango::passwords::{verify, verify_dummy};
+
+let row = users::find_by_username(username).await?;
+let authenticated = match row {
+    Some(u) if u.is_active => verify(attempt, &u.password_hash)?,
+    _ => {
+        verify_dummy(attempt); // burn the same work, then fail
+        false
+    }
+};
+```
+
+---
+
+## Stärkeprüfungen
+
+`strength_score` gibt einen `Vec<StrengthIssue>` zurück — leer bedeutet „gut
+genug". Es ist eine bewusst leichtgewichtige Heuristik, um Benutzer zu
+*ermutigen*, kein hartes Richtlinien-Gatter; kombinieren Sie sie für ernsthafte
+Deployments mit einer Prüfung gegen eine Leak-Liste (HIBP / pwned-passwords).
+
+```rust
+use rustango::passwords::{strength_score, StrengthIssue};
+
+assert!(strength_score("Tr0ub4dor&3-CorrectBattery").is_empty());
+assert!(strength_score("password123").contains(&StrengthIssue::KnownWeak));
+assert!(strength_score("short").contains(&StrengthIssue::TooShort));
+```
+
+| `StrengthIssue` | Ausgelöst, wenn |
+|---|---|
+| `TooShort` | weniger als 12 Zeichen |
+| `NoDigitsOrSymbols` | nur Buchstaben — keine Ziffer oder kein Symbol |
+| `NoVariety` | nur Kleinbuchstaben |
+| `KnownWeak` | stimmt mit der kleinen eingebauten Liste schwacher Passwörter überein (ohne Berücksichtigung der Groß-/Kleinschreibung) |
+
+---
+
+## Wo der Hash lebt
+
+Die PHC-Zeichenkette ist lediglich eine `String`-Spalte auf dem beliebigen
+Kontomodell, das Ihnen gehört. Im Beispiel
+[`auth_demo`](../crates/rustango/examples/auth_demo/src/models.rs):
+
+```rust
+#[derive(Model, Clone, Debug)]
+#[rustango(table = "auth_users", display = "username")]
+pub struct User {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 150, unique)]
+    pub username: String,
+    #[rustango(max_length = 254)]
+    pub email: String,
+    #[rustango(max_length = 255)]      // PHC strings are ~95 chars at these params
+    pub password_hash: String,
+    pub is_active: bool,
+    pub is_superuser: bool,
+}
+```
+
+Sobald der Benutzer authentifiziert ist, übergeben Sie an eine
+[Session](auth-sessions.md) (für Browser-Anwendungen) oder stellen Sie ein
+[JWT](auth-jwt.md) aus (für APIs).
+
+---
+
+## Hinweise und Grenzen
+
+- **Niemals** den Klartext speichern, protokollieren oder mit `==` vergleichen.
+  `hash` → speichern; `verify` → prüfen. Das ist der ganze Vertrag.
+- **Die Kostenparameter sind die OWASP-Standardwerte**, fest eingebaut. Sie sind
+  eine vernünftige Untergrenze; sie später anzuheben ist sicher — alte Hashes
+  verifizieren weiterhin (ihre Parameter leben in der PHC-Zeichenkette), und Sie
+  können bei der nächsten erfolgreichen Anmeldung neu hashen, um sie zu
+  aktualisieren.
+- `strength_score` ist eine Heuristik, keine Richtlinien-Engine — es wird
+  `Summer2024!` nicht erkennen. Legen Sie für echte Stärkedurchsetzung eine
+  Leak-Listen-Abfrage darüber.
+- Für mandantenfähige Anwendungen mit dem Benutzerspeicher des Frameworks
+  bevorzugen Sie `rustango::tenancy::password` (dasselbe argon2id, integriert in
+  das Benutzermodell des Mandanten). Dieses Modul ist die eigenständige Version
+  für Anwendungen, die ihre eigene User-Tabelle besitzen.
+
+
+---
+
+## Siehe auch
+
+- [Sessions](auth-sessions.md)
+- [Konto-Abläufe](auth-flows.md)
+- [Auth-Backends](auth-backends.md)
+- [Sicherheitsleitfaden](security.md)

--- a/docs/de/auth-sessions.md
+++ b/docs/de/auth-sessions.md
@@ -1,0 +1,204 @@
+# Sessions
+
+Eine Session hält einen Benutzer über Anfragen hinweg angemeldet, indem sie dem
+Browser eine **opake ID** in einem Cookie übergibt und alles andere serverseitig
+behält. Der `SessionStore` von **Rustango** legt diesen Zustand in einen Cache
+(Redis in Produktion, im Speicher für Tests), sodass das Cookie keine Geheimnisse
+trägt und eine Session **sofort widerrufen** werden kann — löschen Sie den
+Eintrag, und jede Replik sieht das Abmelden bei der nächsten Anfrage.
+
+[![Sessions in Rustango: das Cookie enthält nur eine opake ID, der SessionStore hält die Daten in Redis, und destroy() widerruft sie überall](img/auth-sessions.png)](img/auth-sessions.png)
+
+> **Quelle:** `rustango::sessions` (`Session`, `SessionStore`) +
+> `rustango::cache` (`BoxedCache`, `InMemoryCache`) — hinter dem Feature
+> `sessions` (standardmäßig aktiviert; zieht `cache` nach). Für einen
+> Redis-gestützten Speicher in Produktion fügen Sie das Feature `cache-redis`
+> hinzu (standardmäßig deaktiviert), um `RedisCache` zu erhalten.
+>
+> **Ausführbare Version:** die Ausschnitte unten sind aus dem getesteten Beispiel
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_sessions.rs)
+> kopiert — `cargo test -p auth_demo --test auth_sessions`.
+
+> **Ein Begriff hier neu?** *Session*, *opake ID*, *Cookie*, *Cache* — siehe das
+> [Glossar](glossary.md).
+
+> Vertiefungsbegleiter zum [Sicherheitsleitfaden](security.md). Das Absichern von
+> Routen hinter einer angemeldeten Session wird in
+> [Auth-Dekoratoren](auth-decorators.md) behandelt; für zustandslose API-Tokens
+> stattdessen siehe [JWT](auth-jwt.md).
+
+---
+
+## Inhaltsverzeichnis
+- [Schnellstart](#quick-start) · [Sessions vs. JWT](#sessions-vs-jwt)
+- [Die Session-Tasche](#the-session-bag) · [Das Cookie](#the-cookie)
+- [Ein Backend wählen](#picking-a-backend) · [Ablauf und gleitende Erneuerung](#expiry-and-sliding-renewal)
+- [An Ort und Stelle aktualisieren](#updating-a-session-in-place) · [Hinweise und Grenzen](#notes-and-limits)
+
+---
+
+## Schnellstart
+
+```rust
+use rustango::sessions::{Session, SessionStore};
+use rustango::cache::{BoxedCache, RedisCache};
+use std::sync::Arc;
+
+let store = SessionStore::new(Arc::new(RedisCache::new("redis://localhost/0")?) as BoxedCache);
+
+// After the password check (see auth-passwords.md): stash who the user is,
+// save → an opaque id, and set that id as the cookie.
+let mut session = Session::new();
+session.set("user_id", user.id);
+let sid = store.save(&session).await?;
+// Set-Cookie: rustango_session={sid}; HttpOnly; SameSite=Lax; Secure; Path=/
+
+// On later requests: read the id from the cookie, load the session back.
+let session = store.load(&sid).await?.unwrap_or_default();
+let user_id: Option<i64> = session.get("user_id");
+
+// Logout: drop the server-side entry — the cookie is now meaningless.
+store.destroy(&sid).await?;
+```
+
+Die ID besteht aus 192 Bit OS-CSPRNG-Zufälligkeit, base64url-kodiert auf 32
+Zeichen — weit über der 128-Bit-Untergrenze für Session-Tokens und nicht
+erratbar.
+
+---
+
+## Sessions vs. JWT
+
+Beide beantworten „wer ist diese Anfrage?", mit gegensätzlichen Kompromissen:
+
+| | Session | [JWT](auth-jwt.md) |
+|---|---|---|
+| Zustand | serverseitig (Cache-Abfrage pro Anfrage) | zustandslos (selbstenthaltenes Token) |
+| Widerruf | **sofort** — den Eintrag `destroy()` | schwierig — gültig bis zum Ablauf (benötigt eine Sperrliste) |
+| Am besten für | Browser-Anwendungen, „diesen Benutzer JETZT abmelden" | APIs, Service-zu-Service, kein gemeinsamer Speicher |
+
+Greifen Sie zu Sessions, wenn Sie jemanden zwangsweise abmelden müssen
+(Passwortänderung, „von allen Geräten abmelden", ein gesperrtes Konto). Greifen
+Sie zu JWT, wenn Sie null Abfragen pro Anfrage wünschen und keinen gemeinsamen
+Cache haben.
+
+---
+
+## Die Session-Tasche
+
+`Session` ist eine typisierte Schlüssel→Wert-Tasche mit einem Dirty-Bit (sodass
+der Speicher einen Schreibvorgang überspringen kann, wenn sich nichts geändert
+hat):
+
+```rust
+let mut s = Session::new();
+s.set("user_id", 42_i64);            // serialize any Serialize value
+s.set("role", "editor");
+let uid: Option<i64> = s.get("user_id");   // None if absent or wrong type
+s.remove("role");
+s.clear();                            // wipe everything (e.g. on logout)
+```
+
+`get` ist **fehlertolerant**: ein fehlender Schlüssel *oder* ein Wert, der sich
+nicht in den angeforderten Typ deserialisieren lässt, gibt `None` zurück, statt
+zu paniken — sodass eine Schemaänderung nie eine Anfrage mit 500 quittiert.
+
+---
+
+## Das Cookie
+
+Das Cookie enthält nur `sid`. Setzen Sie es mit den Sicherheitsattributen, die
+ein Session-Cookie benötigt:
+
+- **`HttpOnly`** — JavaScript kann es nicht lesen (stumpft Token-Diebstahl per
+  XSS ab).
+- **`SameSite=Lax`** — wird bei seitenübergreifenden Unteranfragen nicht gesendet
+  (CSRF-Abwehr; kombinieren Sie es mit [CSRF-Tokens](security.md#protecting-against-csrf)
+  für Formular-Posts).
+- **`Secure`** — nur HTTPS (nur für lokale HTTP-Entwicklung weglassen).
+- **`Path=/`** — für die gesamte Anwendung sichtbar.
+
+Nichts Sensibles steckt im Cookie, sodass ein durchgesickertes Cookie genau so
+mächtig ist wie die Session, auf die es verweist — und Sie können diese jederzeit
+serverseitig widerrufen.
+
+---
+
+## Ein Backend wählen
+
+`SessionStore::new` nimmt jeden `BoxedCache`:
+
+- **`RedisCache`** — Produktion. Über Repliken hinweg geteilt, sodass eine
+  Anmeldung auf einer Instanz und eine Abmeldung auf einer anderen beide überall
+  sichtbar sind.
+- **`InMemoryCache`** — Einzelprozess / Tests. Schnell, keine Abhängigkeiten,
+  aber Sessions überleben keinen Neustart und werden nicht zwischen Repliken
+  geteilt.
+
+```rust
+use rustango::cache::{BoxedCache, InMemoryCache};
+use std::sync::Arc;
+
+// Tests / single-process:
+let store = SessionStore::new(Arc::new(InMemoryCache::new()) as BoxedCache);
+```
+
+---
+
+## Ablauf und gleitende Erneuerung
+
+Sessions haben standardmäßig eine TTL von **2 Wochen**. Überschreiben Sie sie pro
+Speicher und rufen Sie bei jeder authentifizierten Anfrage `touch` auf, um eine
+gleitende Ablaufzeit zu erhalten (aktive Benutzer bleiben angemeldet, untätige
+laufen aus):
+
+```rust
+use std::time::Duration;
+
+let store = SessionStore::new(cache).ttl(Duration::from_secs(60 * 60)); // 1 hour
+
+// On each request, after a successful load — extend without rewriting:
+store.touch(&sid).await?;   // Ok(false) if the session is already gone
+```
+
+---
+
+## Eine Session an Ort und Stelle aktualisieren
+
+`save` prägt stets eine frische ID (verwenden Sie es bei der Anmeldung). Um eine
+bestehende Session während einer Anfrage zu ändern, laden → mutieren →
+`save_with_id` unter derselben ID:
+
+```rust
+let mut s = store.load(&sid).await?.unwrap_or_default();
+s.set("last_seen", chrono::Utc::now().to_rfc3339());
+store.save_with_id(&sid, &s).await?;
+```
+
+---
+
+## Hinweise und Grenzen
+
+- **Der Widerruf ist das Hauptmerkmal** — `destroy()` (Abmeldung) und der
+  TTL-Ablauf treten beide bei der nächsten Anfrage in Kraft, auf jeder Replik,
+  die sich den Cache teilt.
+- **Beschädigte oder unbekannte IDs laden als `None`** (*fail-open*): eine
+  Cache-Schemaänderung oder ein manipuliertes Cookie ergibt eine leere Session,
+  keinen Fehler — die Anfrage ist einfach nicht authentifiziert.
+- **Der Speicher setzt das Cookie nicht für Sie** — er verwaltet den
+  serverseitigen Zustand; Sie hängen das `sid`-Cookie in Ihrem Handler an bzw.
+  lesen es (oder über einen Layer). Das macht ihn aus jeder Framework-Verdrahtung
+  heraus nutzbar.
+- **Prägen Sie bei einer Rechteänderung eine frische Session-ID** (z. B. direkt
+  nach der Anmeldung), um Session-Fixierung zu vermeiden — `save` tut dies
+  bereits, da es stets eine neue ID erzeugt.
+
+
+---
+
+## Siehe auch
+
+- [Auth-Dekoratoren](auth-decorators.md)
+- [JWT](auth-jwt.md)
+- [Auth-Backends](auth-backends.md)
+- [Sicherheitsleitfaden](security.md)

--- a/docs/de/benchmarks.md
+++ b/docs/de/benchmarks.md
@@ -1,0 +1,271 @@
+# Benchmarks: Rustango vs Django vs Laravel vs Go
+
+Wie schnell ist **Rustango** wirklich? Diese Seite berichtet über einen direkten Benchmark
+gegen die beiden Frameworks, denen **Rustango** nachempfunden ist — Django und Laravel — und
+gegen eine **Go**-Basislinie (das `net/http` der Standardbibliothek), die verankert, was eine
+zweite kompilierte, native Laufzeit bei derselben Arbeitslast erreicht. Alle verwenden
+*funktional identische* Blog-Sites: dieselben Daten, dasselbe Schema, dieselben Endpunkte,
+dasselbe Hardware-Budget — die einzige Variable ist die Laufzeit. Django und Laravel werden
+jeweils in **beiden** Varianten gemessen: ihrem konventionellen Produktions-Deployment *und* einer
+robusteren Laufzeit: **Django** auf **gunicorn** (WSGI) und auf **Hypercorn**
+(ASGI); **Laravel** auf **php-fpm + nginx** und auf **Octane** (Swoole). Rustango
+und Go sind jeweils ein einziges residentes Binary, also gibt es von jedem eines.
+
+Jede Zahl unten ist **gemessen und reproduzierbar**, aus einem konsistenten Durchlauf eines
+Ein-Kommando-Harness (siehe [Reproduce](#reproduce)). Nichts hier ist mit Handbewegungen weggeredet.
+
+> **Kurzfassung.** Auf identischer Hardware, die identisch gerenderte HTML-Seiten ausliefert, lassen die beiden
+> **kompilierten, nativen** Laufzeiten — **Rustango** und **Go** — die interpretierten
+> Frameworks **um das 5- bis 30-Fache hinter sich** und wechseln sich untereinander in der Führung ab. Beim
+> nicht gecachten Index führte **Go** mit **6.651 Req/s** und **Rustango** folgte mit
+> **4.781** — **5,6×** Django (gunicorn) und **11,7×** Laravel (php-fpm). Gos
+> Vorsprung ist auf der nicht gecachten Detailseite am größten (**13.921 vs 6.538**, 2,1×).
+> **Rustango** erobert die Führung dort zurück, wo es für ausgelieferten Traffic zählt: den
+> **Redis-gecachten** Pfaden (**25.546** vs Gos 20.929 beim Index; 35.781 vs
+> 29.470 beim Detail) und **reiner Berechnung** (14.341 vs 11.573). Es hielt außerdem den
+> **geringsten RAM unter Last** (18,5 MiB, kein GC) und — anders als die Go-stdlib-Anwendung —
+> liefert ein vollständiges, batteries-included Framework. Selbst das schnellste nicht kompilierte
+> Ergebnis, **Laravel auf Octane**, liegt um das 4- bis 7-Fache hinter beiden Binaries.
+
+[![Requests/Sek. auf dem nicht gecachten Blog-Index über alle sechs Laufzeiten — Go 6.651, Rustango 4.781, Laravel+Octane 1.238, Django+Hypercorn 910, Django+gunicorn 850, Laravel+php-fpm 408](img/benchmarks.png)](img/benchmarks.png)
+
+---
+
+## Der Aufbau
+
+Vier Blog-Anwendungen — **Autoren, Beiträge, Tags (Viele-zu-Viele) und Kommentare** —
+die HTML-Seiten rendern:
+
+| Route | Rendert | Gecacht? |
+|---|---|---|
+| `GET /` | die neuesten 20 Beiträge, jeder mit Autor, Tags, Kommentaranzahl | nein |
+| `GET /cached` | dasselbe wie `/` | Redis, 60 s |
+| `GET /post/{slug}` | Beitragsrumpf + Autor + Tags + jeder Kommentar | nein |
+| `GET /post/{slug}/cached` | dasselbe wie Detail | Redis, 60 s |
+| `GET /tag/{slug}` | Beiträge, die einen Tag tragen | nein |
+| `GET /compute` | Summe aller Primzahlen unter 20.000 (CPU-gebunden; keine DB, kein Cache) | nein |
+
+Die ersten fünf sind I/O- + Render-gebunden; `/compute` ist eine reine CPU-Arbeitslast — der
+identische Algorithmus der Probedivision in jeder Sprache — um die rohe Laufzeit-Geschwindigkeit
+zu isolieren. Jede Anwendung lädt ihre Relationen **eifrig** (kein N+1): **Rustango** bündelt die
+Abfragen explizit, Django verwendet `select_related` / `prefetch_related` /
+`annotate(Count)`, Laravel verwendet `with()` + `withCount()`, **Go** lädt im Batch
+mit `= ANY($1)`-Abfragen. Die Templates sind bewusst winzig und äquivalent (Tera,
+Django-Templates, Blade, Gos `html/template`), sodass wir das *Framework* messen, nicht den
+Template-Aufwand.
+
+### Was es zu einem fairen Kampf macht
+
+- **Identische Daten.** Ein PostgreSQL-Schema und ein deterministischer Seed, geteilt von allen
+  vier Anwendungen — sie lesen dieselben *Tabellen*: 10 Autoren, 30 Tags, **1.000 Beiträge**,
+  2.600 Beitrag-Tag-Verknüpfungen, **10.000 Kommentare**. Der Index zeigt dieselben 20 Beiträge in
+  derselben Reihenfolge auf jedem Framework, und das gerenderte HTML ist byte-identisch
+  (abgesehen vom Entity-Escaping-Stil jeder Engine).
+- **Identisches Hardware-Budget.** Jede Anwendung läuft in einem Container, gedeckelt auf
+  **4 CPUs / 2 GB RAM**. PostgreSQL und Redis werden geteilt und sind identisch.
+- **Eine nach der anderen.** Die Anwendungen werden sequenziell lastgetestet, sodass sie nie um den
+  Host konkurrieren (eine 12-Kern- / 18-GB-Maschine). Lastgenerator:
+  [`oha`](https://github.com/hatoo/oha), 50 gleichzeitige Verbindungen, 10 s pro
+  Endpunkt, HTTP-Keep-Alive an. Jeder Durchlauf meldete **100 % Erfolg**.
+- **Alles im Produktionsmodus.** Das zählt sehr (siehe unten).
+
+### Produktionskonfiguration
+
+| | Laufzeit | Produktionshärtung |
+|---|---|---|
+| **Rustango** | ein `--release`-Binary (axum + Tokio, async, alle Kerne) | `opt-level=3` + LTO; Redis-Seiten-Cache via `CachePageLayer` |
+| **Go** | ein statisches Binary (stdlib `net/http`, Goroutinen, alle Kerne) | `pgx`-Pool + `go-redis`-Seiten-Cache; Templates eingebettet; ausgeliefert auf `scratch` |
+| **Django 5.2** · gunicorn | gthread-Worker + Keep-Alive (WSGI) | `DEBUG=False`; integrierter Redis-Cache + `@cache_page`; persistente DB-Verbindungen |
+| **Django 5.2** · Hypercorn | ASGI-Server, 4 Worker, Keep-Alive | dieselbe Anwendung, über ASGI ausgeliefert; die synchronen Views laufen in einem Threadpool |
+| **Laravel 13** · php-fpm | php-fpm + nginx, OPcache **an**, 16 Worker | `APP_ENV=production`; `composer install --no-dev --optimize-autoloader`; Blade gecacht; `Cache::remember` auf Redis |
+| **Laravel 13** · Octane | Octane + **Swoole**, persistente Worker | dieselbe Anwendung auf einer speicherresidenten Laufzeit — kein Framework-Bootstrap pro Anfrage |
+
+> Der Produktionsmodus ist keine Fußnote. Laravels erster (ungetunter) Durchlauf schaffte nur
+> ~53 Req/s; das Aktivieren von OPcache, dem optimierten Autoloader und einem ordentlichen Worker-
+> Pool brachte ihn auf ~408 Req/s — ein **7,7-facher Ausschlag** allein durch Konfiguration. Die
+> Zahlen unten stammen alle aus der Produktionskonfiguration.
+
+---
+
+## Ergebnisse
+
+### Durchsatz — Requests pro Sekunde (höher ist besser)
+
+Die beiden kompilierten Binaries, dann jedes interpretierte Framework in seiner konventionellen
+Laufzeit **und** seiner robusten Laufzeit:
+
+| Endpunkt | **Rustango** | **Go** | Django · gunicorn | Django · Hypercorn | Laravel · php-fpm | Laravel · Octane |
+|---|--:|--:|--:|--:|--:|--:|
+| Index, nicht gecacht | 4 781 | **6 651** | 850 | 910 | 408 | 1 238 |
+| Index, **gecacht** | **25 546** | 20 929 | 4 841 | 1 537 | 1 224 | 5 777 |
+| Detail, nicht gecacht | 6 538 | **13 921** | 1 983 | 916 | 464 | 1 790 |
+| Detail, **gecacht** | **35 781** | 29 470 | 4 843 | 1 320 | 793 | 5 811 |
+| Tag, nicht gecacht | 3 926 | **4 353** | 1 129 | 1 033 | 398 | 1 179 |
+| **compute** (CPU-gebunden) | **14 341** | 11 573 | 452 | 400 | 716 | 1 504 |
+
+Drei Geschichten stechen hervor. Erstens **gruppieren sich Go und Rustango weit über allen
+anderen** — die Kluft zwischen den beiden nativen Binaries (zehn Prozent, mit Go vorn
+bei nicht gecachtem I/O und Rustango vorn bei gecachten Treffern + Berechnung) ist klein neben der
+5- bis 30-fachen Kluft zu den interpretierten Laufzeiten. Zweitens ist **Laravel + Octane** (Swoole)
+ein **3- bis 7-facher Sprung** gegenüber php-fpm — ein residenter Worker, der Laravels Framework-
+Bootstrap pro Anfrage überspringt — und das schnellste nicht kompilierte Ergebnis auf jeder Seite.
+Drittens ist **Django + Hypercorn** (ASGI) grob **flach und langsamer auf den gecachten
+Pfaden**: die Views des Blogs sind *synchron*, sodass ASGI nur einen Threadpool-Sprung hinzufügt
+ohne einen der Nebenläufigkeitsgewinne, die *async*-Views bringen würden. Selbst das Beste
+dieses Felds (Octane, 1.238 Req/s nicht gecachter Index; 5.811 bei gecachtem Detail) liegt
+um das 4- bis 7-Fache hinter beiden Binaries.
+
+### Latenz — p50 in Millisekunden (niedriger ist besser)
+
+| Endpunkt | **Rustango** | **Go** | Django · gunicorn | Django · Hypercorn | Laravel · php-fpm | Laravel · Octane |
+|---|--:|--:|--:|--:|--:|--:|
+| Index, nicht gecacht | 10.2 | **7.2** | 56.9 | 43.2 | 114.7 | 39.9 |
+| Index, gecacht | **1.8** | 2.1 | 9.3 | 5.0 | 20.2 | 7.6 |
+| Detail, gecacht | **1.3** | 1.5 | 5.8 | 32.1 | 81.8 | 7.6 |
+| compute (CPU-gebunden) | 3.5 | **2.5** | 70.8 | 130.0 | 87.4 | 32.9 |
+
+(Mediane gezeigt; die vollständigen p50 / p95 / p99 für jeden Endpunkt und jede Laufzeit stehen in
+`bench/results/summary.tsv`.) Die Mediane von **Rustango** und **Go** auf dem
+nicht gecachten Index (10,2 / 7,2 ms) liegen unter denen jedes interpretierten Konkurrenten, und
+ihre gecachten Mediane (1,3–2,1 ms) sind eine Größenordnung unter selbst der
+schnellsten Framework-Laufzeit. Ein Vorbehalt zu Gos Gunsten *und* zu seinen Ungunsten: sein
+Compute-p50 (2,5 ms) schlägt Rustangos, aber sein Compute-p99 springt auf ~47 ms bei einer GC-
+Pause — ein Schwanz, den das GC-lose Rust-Binary nicht hat.
+
+### Fußabdruck — Image-Größe, Speicher, CPU
+
+| | **Rustango** | **Go** | Django · gunicorn | Django · Hypercorn | Laravel · php-fpm | Laravel · Octane |
+|---|--:|--:|--:|--:|--:|--:|
+| Container-Image (unkomprimiert) | 164 MB | **18.5 MB** | 293 MB | 293 MB | 959 MB | 1.01 GB |
+| RAM, im Leerlauf | 12.1 MiB | **5.2 MiB** | 128 MiB | 173 MiB | 92 MiB | 248 MiB |
+| RAM, unter Last | **18.5 MiB** | 34.7 MiB | 218 MiB | 277 MiB | 133 MiB | 267 MiB |
+| CPU unter Last (von 400 %-Deckel) | 295 % | 366 % | 356 % | 408 % | 406 % | 335 % |
+
+**Go** liefert das kleinste Image — ein statisches Binary auf `scratch`, **18,5 MB** — und
+läuft im Leerlauf bei nur **5,2 MiB**. Aber unter Last wächst sein GC-Heap auf **34,7 MiB**,
+~1,9× die konstanten **18,5 MiB** von **Rustango**: ohne Garbage Collector und ohne
+Allokation pro Anfrage passt das Rust-Binary unter Volllast in weniger RAM, als Go
+benutzt, und unter das, was jede interpretierte Laufzeit *im Leerlauf* verbraucht. Die robusten
+Laufzeiten kosten *mehr* Speicher, nicht weniger: Octane hält ein residentes Laravel in jedem
+Worker; Hypercorn legt den ASGI-Stack obendrauf auf Django.
+
+### Effizienz — geleistete Arbeit pro Ressource (die eigentliche Geschichte)
+
+Roher Durchsatz ist eine Sache; **Durchsatz pro Ressourceneinheit** ist das, was Ihre
+Cloud-Rechnung tatsächlich verfolgt (nicht gecachter Index):
+
+| Metrik | **Rustango** | **Go** | Django · gunicorn | Django · Hypercorn | Laravel · php-fpm | Laravel · Octane |
+|---|--:|--:|--:|--:|--:|--:|
+| Requests/Sek. **pro MiB RAM** | **258** | 192 | 3.9 | 3.3 | 3.1 | 4.6 |
+| Requests/Sek. **pro CPU-%** | 16.2 | **18.2** | 2.4 | 2.2 | 1.0 | 3.7 |
+
+Pro Megabyte Speicher leistet **Rustango** die meiste Arbeit aller Laufzeiten hier —
+~35× das beste interpretierte Ergebnis und ~1,3× Gos, weil sein Fußabdruck unter Last flach
+bleibt. Pro CPU-Prozent zieht **Go** knapp vorbei (es wandelt die zusätzlichen Kerne, die es
+hochfährt, in etwas mehr Durchsatz um). So oder so: um den Index-Durchsatz eines einzigen kompilierten
+Binaries zu erreichen, müssten Sie ~4 Octane-Laravels oder ~6 gunicorn-Djangos betreiben — jedes
+mit seinem eigenen mehrhundert-MB-Fußabdruck.
+
+---
+
+## Was der Cache verändert
+
+Jede Laufzeit ist am schnellsten, wenn ein Redis-Seiten-Cache es ihr erlaubt, die Datenbank und
+das Rendern gänzlich zu überspringen — nicht gecachte → **gecachte** Index-Req/s:
+
+- **Rustango**: 4 781 → **25 546** (5,3× durch Caching) — erobert den ersten Platz zurück.
+- **Go**: 6 651 → **20 929** (3,1×) — führt ungecacht, zweiter gecacht.
+- **Laravel · Octane**: 1 238 → **5 777** (4,7×) — das Beste des interpretierten Feldes.
+- **Django · gunicorn**: 850 → **4 841** (5,7×).
+- **Django · Hypercorn**: 910 → **1 537** (1,7×) — der Overhead des ASGI-Threadpools
+  deckelt den Gewinn selbst bei Cache-Treffern.
+- **Laravel · php-fpm**: 408 → **1 224** (3,0×).
+
+Caching hilft allen, aber es tilgt die Kluft nicht — und hier trennen sich die beiden
+kompilierten Binaries: ohne laufenden Anwendungscode ist der
+HTTP-Accept → Cache-Read → Response-Pfad alles, was übrig bleibt, und der
+allokationsfreie `CachePageLayer` von **Rustango** (25.546 Req/s) zieht am `go-redis`-
+Pfad von Go (20.929) vorbei, beide bei ~4× der besten Framework-Laufzeit.
+
+---
+
+## Rohe Berechnung: kompiliert vs interpretiert (und kompiliert vs kompiliert)
+
+Die fünf Seitenrouten werden von der Datenbank und der Template-Engine dominiert. Die
+`/compute`-Route entfernt diese — sie summiert jede Primzahl unter 20.000 per Probedivision,
+der *identische* Algorithmus in Rust, Go, Python und PHP. Alle vier geben
+dieselbe Antwort zurück (`21171191`); nur die Geschwindigkeit unterscheidet sich:
+
+| | **Rustango** | **Go** | Django | Laravel |
+|---|--:|--:|--:|--:|
+| Durchsatz | **14 341 req/s** | 11 573 | 452 | 716 |
+| p50-Latenz | 3.5 ms | **2.5 ms** | 70.8 ms | 87.4 ms |
+
+Die beiden nativen Binaries durchlaufen die Schleife **~26- bis 32-mal** schneller als Django und
+**~16- bis 20-mal** schneller als Laravel — die Kluft zwischen kompiliertem Maschinencode und einem
+Bytecode-Interpreter. Zwischen Rust und Go holt sich Rusts LTO-optimierte `--release`-Schleife die
+Durchsatz-Krone, während Gos Median-Latenz tatsächlich niedriger ist; Gos GC zeigt sich
+dann als Schwanz-Latenz (p99 ~47 ms), die das Rust-Binary nie zahlt. Interessanterweise übertrifft PHP 8.3
+(mit OPcache) CPython bei dieser engen Integer-Schleife rechnerisch, sodass Laravel Django hier
+*rechnerisch übertrifft*, obwohl es auf jeder I/O-gebundenen Seite verliert. Dies ist
+die Arbeitslast, bei der die Sprache, nicht das Framework, dominiert — und wo das Verlagern
+heißer Logik nach **Rustango** sich am meisten auszahlt.
+
+---
+
+## Ehrliche Vorbehalte
+
+Ein Benchmark, in den man keine Löcher bohren kann, ist die Veröffentlichung nicht wert. Also:
+
+- Die Zahlen stammen von **einem** 12-Kern- / 18-GB-Host (macOS + Docker). Absolute
+  Werte verschieben sich auf anderer Hardware; das **relative** Bild ist es, was Bestand hat.
+- Dies ist eine **lese-lastige, serverseitig gerenderte** Arbeitslast — die häufigste Blog-
+  Form. Sie misst keine Schreibvorgänge, Auth-Flows, Websockets oder schwere
+  Geschäftslogik.
+- **Go ist hier die Standardbibliothek, kein ebenbürtiges Framework.** Rustango, Django
+  und Laravel sind batteries-included Frameworks (ORM, Admin, Migrationen, Routing,
+  Templating, Multi-Tenancy); die Go-Anwendung ist handgeschriebenes `net/http` + rohes SQL —
+  die schlankeste, schnellste Basislinie, die ein Go-Dienst realistisch erreicht, und
+  die fairste Repräsentation der Sprache. Dass sie Rustango beim rohen ungecachten
+  Durchsatz erreicht oder schlägt, ist genau der Punkt: **Rustango liefert Go-Klasse-Leistung
+  mit einer Entwicklererfahrung der Django/Laravel-Klasse.** Gos Vorsprung bei den ungecachten
+  Endpunkten wird damit erkauft, SQL, Mapping und Verdrahtung selbst zu schreiben.
+- Die Laufzeiten sind grundlegend verschieden: Rustango und Go sind jeweils ein Binary,
+  das alle Kerne mit billigen Tasks nutzt; Django und Laravel verwenden feste Pools von Worker-
+  Prozessen/Threads. Dieser Unterschied *ist* Teil des Ergebnisses, und die
+  Worker-Anzahlen wurden auf sinnvolle Pro-CPU-Werte gesetzt, nicht getunt, um irgendjemanden zu bevorzugen.
+- Django und Laravel werden jeweils in **beiden** Laufzeiten gezeigt — konventionell
+  (gunicorn, php-fpm) und robust (Hypercorn, Octane). **Laravel auf Octane ist
+  3- bis 7-mal schneller** als php-fpm; **Django auf Hypercorn** (synchrone Views) ist grob
+  flach. Beide verengen die Kluft zu den kompilierten Binaries; keines schließt sie.
+
+Der Punkt ist nicht, dass Django oder Laravel langsam sind — sie treiben einen riesigen Teil des
+Webs an. Der Punkt ist, dass **Rustango** Ihnen dieselbe batteries-included Entwicklererfahrung mit
+der Leistung und dem Fußabdruck von kompiliertem Rust gibt — auf Augenhöhe mit einem handgetunten
+Go-Dienst, während es Ihnen das Framework in die Hand gibt, das Go Sie bauen lässt.
+
+---
+
+## Reproduzieren
+
+Das vollständige Harness — die vier Anwendungen, das geteilte PostgreSQL-Schema + der deterministische
+Seed, das Docker-Compose-Setup und der Runner — ist ein eigenständiges Projekt
+(`rustango-bench`). Aus seinem Verzeichnis:
+
+```sh
+bench/vendor.sh                       # vendor the framework into the build
+docker compose build                  # build all six images
+DURATION=10s CONCURRENCY=50 bench/run.sh
+```
+
+Voraussetzungen: Docker + Compose und Rust (für `cargo install oha`). Passen Sie den
+Hardware-Deckel in `.env` (`CAP_CPUS`, `CAP_MEM`) und die Last mit `DURATION` /
+`CONCURRENCY` an. Die rohe Ausgabe pro Durchlauf landet in `bench/results/`.
+
+
+---
+
+## Siehe auch
+
+- [Getting started](getting-started.md)
+- [ORM cookbook](orm.md)

--- a/docs/de/caching.md
+++ b/docs/de/caching.md
@@ -1,0 +1,199 @@
+# Caching
+
+Caching speichert das Ergebnis teurer Arbeit — eine schwere Query, ein
+gerendertes Fragment, einen Drittanbieter-API-Aufruf — sodass der nächste
+Request es sofort erhält, statt es neu zu berechnen. **Rustango** gibt dir einen
+`Cache`-Trait mit austauschbaren Backends (In-Memory, Redis, Datenbank), einen
+Compute-on-Miss-Helfer (`get_or_set`) und typisierte JSON-Helfer. Tausche das
+Backend, ohne eine einzige Aufrufstelle anzufassen — wie Djangos Cache-Framework
+oder Laravels `Cache`-Fassade.
+
+[![Caching in Rustango: get_or_set checks the cache, runs the factory only on a miss, stores the result with a TTL, and serves hits instantly; the same Cache trait backs InMemory, Redis, and DB](img/caching.png)](img/caching.png)
+
+> **Ein Begriff hier neu für dich?** *Cache*, *TTL*, *Key*, *Backend* — siehe
+> das [Glossar](glossary.md).
+
+> **Quelle:** `rustango::cache` (`Cache`, `InMemoryCache`, `NullCache`,
+> `get_or_set`, `get_json`, `set_json`, `BoxedCache`, `from_settings`) — hinter
+> der `cache`-Feature (standardmäßig aktiv). `RedisCache` benötigt die
+> `cache-redis`-Feature (standardmäßig aus).
+>
+> **Ausführbare Version:** jeder Codeausschnitt ist aus
+> [`cache_doc.rs`](../crates/rustango/tests/cache_doc.rs) kopiert
+> (`cargo test -p rustango --test cache_doc`); das Datenbank-Backend wird per
+> Dogfooding auf SQLite durch
+> [`cache_db_backend_sqlite_live.rs`](../crates/rustango/tests/cache_db_backend_sqlite_live.rs)
+> erprobt.
+
+## Inhaltsverzeichnis
+
+- [Schritt 1 — Ein Backend wählen](#step-1--pick-a-backend)
+- [Schritt 2 — get / set / delete](#step-2--get--set--delete)
+- [Schritt 3 — get_or_set (Cache-Aside)](#step-3--get_or_set-cache-aside)
+- [Typisierte JSON-Werte](#typed-json-values)
+- [TTL und Ablauf](#ttl-and-expiry)
+- [Backends tauschen](#swapping-backends)
+- [Referenz](#reference)
+- [Siehe auch](#see-also)
+
+---
+
+## Schritt 1 — Ein Backend wählen
+
+Jedes Backend implementiert denselben `Cache`-Trait, dein Code ist also
+identisch, welches du auch wählst. Der App-Code hält einen **`BoxedCache`**
+(`Arc<dyn Cache>`) und nennt nie den konkreten Typ:
+
+```rust
+use rustango::cache::{BoxedCache, InMemoryCache};
+use std::sync::Arc;
+
+let cache: BoxedCache = Arc::new(InMemoryCache::new());
+```
+
+| Backend | Feature | Verwenden für |
+|---|---|---|
+| `InMemoryCache` | `cache` | Dev, Tests, Einzelprozess (HashMap pro Prozess + TTL) |
+| `RedisCache` | `cache-redis` | Produktion; über Replicas geteilt |
+| `DbCache` | `cache` | Produktion ohne Redis; eine `rustango_cache`-Tabelle |
+| `NullCache` | `cache` | Caching deaktivieren (jeder Read verfehlt) — praktisch in Tests |
+
+---
+
+## Schritt 2 — get / set / delete
+
+Der Kern des Traits sind vier async-Methoden. `set` nimmt ein optionales TTL
+(`None` = kein Ablauf); `get` gibt `Option<String>` zurück (`None` bei einem
+Miss):
+
+```rust
+use rustango::cache::{Cache, InMemoryCache};
+
+let cache = InMemoryCache::new();
+
+assert_eq!(cache.get("greeting").await?, None);     // miss
+cache.set("greeting", "hello", None).await?;        // store, no expiry
+assert_eq!(cache.get("greeting").await?.as_deref(), Some("hello"));
+assert!(cache.exists("greeting").await?);
+
+cache.delete("greeting").await?;                    // gone
+```
+
+Es gibt auch Batch-Varianten — `get_many` / `set_many` / `delete_many`.
+
+---
+
+## Schritt 3 — get_or_set (Cache-Aside)
+
+Das ist die, zu der du am häufigsten greifst. `get_or_set` gibt den gecachten
+Wert zurück, oder — bei einem Miss — führt deine Factory aus, speichert das
+Ergebnis mit einem TTL und gibt es zurück. Die Factory **läuft nur bei einem
+Miss**:
+
+```rust
+use rustango::cache::get_or_set;
+use std::time::Duration;
+
+let stats: HomeStats = get_or_set(
+    &*cache,                       // &dyn Cache
+    "home:stats",
+    || async { compute_home_stats(&pool).await },   // runs only on a miss
+    Some(Duration::from_secs(60)),                   // cache for 60s
+).await?;
+```
+
+Der zugrunde liegende Test ruft `get_or_set` zweimal für denselben Key auf und
+stellt sicher, dass die Factory **genau einmal** lief — der zweite Aufruf wird
+aus dem Cache bedient.
+
+> **Bei Schreibvorgängen invalidieren.** Cache-Aside bedeutet veraltete Daten,
+> bis das TTL abläuft. Für Daten, die sich ändern, mache auch `delete(key)`, wenn
+> du sie schreibst — z. B. aus einem [`post_save`-Signal](orm.md) — damit der
+> nächste Read neu berechnet.
+
+---
+
+## Typisierte JSON-Werte
+
+`get_json` / `set_json` serialisieren jeden `Serialize`/`Deserialize`-Typ nach
+JSON, sodass du Structs und Listen cachst, nicht nur Strings:
+
+```rust
+use rustango::cache::{get_json, set_json};
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Profile { id: i64, name: String }
+
+set_json(&*cache, "profile:7", &profile, None).await?;
+let back: Option<Profile> = get_json(&*cache, "profile:7").await?;   // None on a miss
+```
+
+(`get_or_set` verwendet diese unter der Haube, weshalb sein Werttyp
+`Serialize + Deserialize` sein muss.)
+
+---
+
+## TTL und Ablauf
+
+Übergib eine `Duration` an `set` (oder `get_or_set`) und der Eintrag verschwindet
+danach. Verifiziert: ein 50-ms-Eintrag ist sofort lesbar und nach 80 ms weg.
+
+```rust
+cache.set("flash", "x", Some(Duration::from_millis(50))).await?;
+// ...50ms later...
+assert_eq!(cache.get("flash").await?, None);   // expired
+```
+
+`InMemoryCache::with_default_ttl(d)` setzt ein Standard-TTL, das angewendet wird,
+wenn du `None` übergibst.
+
+---
+
+## Backends tauschen
+
+Weil alles der `Cache`-Trait ist, ist der Wechsel von In-Memory zu Redis eine
+einzeilige Änderung beim Start — meist von der Konfiguration gesteuert, sodass sie
+sich pro Umgebung unterscheidet:
+
+```rust
+// Build the cache from `[cache]` settings (backend = "memory" | "redis" | "db" | "null").
+let cache: BoxedCache = rustango::cache::from_settings(&settings.cache);
+```
+
+In der Produktion richtest du es auf Redis (über alle deine Replicas geteilt):
+
+```rust
+use rustango::cache::RedisCache;   // needs the `cache-redis` feature
+let cache: BoxedCache = std::sync::Arc::new(RedisCache::new("redis://localhost").await?);
+```
+
+Dieselben `get` / `set` / `get_or_set`-Aufrufe — nur der Konstruktor hat sich
+geändert.
+
+---
+
+## Referenz
+
+**`Cache`-Trait:** `get` · `set(key, value, ttl)` · `delete` · `exists` ·
+`get_many` / `set_many` / `delete_many` · `get_or(key, default)`.
+
+**Freie Helfer:** `get_or_set(cache, key, factory, ttl)` ·
+`get_json` / `set_json` · `from_settings(&CacheSettings)`.
+
+**Was auf dem Cache aufbaut:** serverseitige [Sessions](auth-sessions.md),
+verteiltes [Rate Limiting](middleware.md) (`CacheRateLimitLayer`),
+Idempotenz-Schlüssel und Feature-Flags nehmen alle einen `BoxedCache` — sodass
+eine einzige Redis-Instanz sie alle stützt.
+
+---
+
+## Siehe auch
+
+- [Hintergrund-Jobs](jobs.md) — die andere Hälfte, um Requests schnell zu halten
+  (Arbeit aufschieben, statt ihr Ergebnis zu cachen).
+- [Sessions](auth-sessions.md) — ein serverseitiger Store, der auf `Cache`
+  aufbaut.
+- [Middleware](middleware.md) — `CacheRateLimitLayer` teilt einen Zähler über
+  Replicas hinweg via Cache.
+- [ORM-Cookbook](orm.md) — gecachte Reads aus einem `post_save`-Signal
+  invalidieren.

--- a/docs/de/email.md
+++ b/docs/de/email.md
@@ -1,0 +1,196 @@
+# E-Mails versenden
+
+Willkommensnachrichten, Passwort-Resets, Belege, Alerts — die meisten Apps versenden
+transaktionale E-Mails. **Rustango** gibt dir ein `Mailer`-Trait mit austauschbaren
+Backends (Konsole für die Entwicklung, SMTP für die Produktion, ein In-Memory-Recorder für Tests),
+einen flüssigen `Email`-Builder mit Schutz vor Header-Injection und
+Template-Rendering. Schreibe `mailer.send(&email)` einmal; wechsle vom Drucken
+in dein Terminal zu echtem SMTP mit einer einzeiligen Änderung — wie Djangos E-Mail-Framework.
+
+[![E-Mail in Rustango: Ein Email-Builder (to/subject/body/html) wird gegen Header-Injection validiert und dann durch das Mailer-Trait versendet — ConsoleMailer in dev, SmtpMailer in prod, InMemoryMailer in Tests](img/email.png)](img/email.png)
+
+> **Neu bei einem Begriff hier?** *transaktionale E-Mail*, *SMTP*, *Mailer-Backend* — siehe
+> das [Glossar](glossary.md).
+
+> **Quelle:** `rustango::email` (`Mailer`, `Email`, `ConsoleMailer`,
+> `InMemoryMailer`, `NullMailer`, `SmtpMailer`, `BoxedMailer`, `send_mail`,
+> `MailError`) — hinter dem `email`-Feature (standardmäßig aktiviert). SMTP benötigt das
+> `email-smtp`-Feature.
+>
+> **Lauffähige Version:** Jedes Snippet ist kopiert aus
+> [`email_doc.rs`](../crates/rustango/tests/email_doc.rs)
+> (`cargo test -p rustango --test email_doc`); die Send-Helfer und Anhänge
+> werden von `email_send_helpers.rs` und `email_attachments.rs` selbst erprobt.
+
+## Inhaltsverzeichnis
+
+- [Schritt 1 — Eine E-Mail bauen](#step-1--build-an-email)
+- [Schritt 2 — Einen Mailer wählen](#step-2--pick-a-mailer)
+- [Schritt 3 — Sie versenden](#step-3--send-it)
+- [Validierung und Schutz vor Header-Injection](#validation-and-header-injection-safety)
+- [E-Mails testen](#testing-email)
+- [Templates](#templates)
+- [Sie außerhalb des Requests versenden](#send-it-off-the-request)
+- [Referenz](#reference)
+- [Siehe auch](#see-also)
+
+---
+
+## Schritt 1 — Eine E-Mail bauen
+
+`Email` ist ein flüssiger Builder. Setze Empfänger, Betreff und einen Text- und/oder HTML-Body:
+
+```rust
+use rustango::email::Email;
+
+let email = Email::new()
+    .to("ada@example.com")
+    .from("noreply@example.com")
+    .subject("Welcome")
+    .body("Thanks for signing up.")              // plain-text part
+    .html_body("<p>Thanks for signing up.</p>"); // optional HTML part
+```
+
+`.cc(...)`, `.reply_to(...)` und Anhänge sind ebenfalls verfügbar.
+
+---
+
+## Schritt 2 — Einen Mailer wählen
+
+Jedes Backend implementiert `Mailer`, sodass dein Code den konkreten Typ nie benennt —
+halte ein **`BoxedMailer`** (`Arc<dyn Mailer>`):
+
+| Backend | Feature | Verwenden für |
+|---|---|---|
+| `ConsoleMailer` | `email` | dev — druckt die Nachricht auf stdout |
+| `SmtpMailer` | `email-smtp` | Produktion — echte Zustellung über SMTP |
+| `InMemoryMailer` | `email` | Tests — zeichnet Nachrichten auf, sendet nichts |
+| `FileMailer` | `email` | dev/CI — schreibt jede Nachricht in eine Datei |
+| `NullMailer` | `email` | E-Mail vollständig deaktivieren |
+
+Baue ihn aus der Konfiguration, damit er sich je Umgebung unterscheidet (`ConsoleMailer`
+lokal, `SmtpMailer` in prod) über `email::from_settings(&settings.email)`.
+
+---
+
+## Schritt 3 — Sie versenden
+
+`Email::send` nimmt jedes `&dyn Mailer`:
+
+```rust
+email.send(&mailer).await?;
+```
+
+Für einen schnellen Einzelfall überspringt `send_mail` den Builder:
+
+```rust
+use rustango::email::send_mail;
+
+send_mail(
+    &mailer,
+    "Your report is ready",                  // subject
+    "Download it from your dashboard.",      // body
+    Some("noreply@example.com"),             // from (or None for the default)
+    &["ops@example.com", "qa@example.com"],  // recipients
+).await?;
+```
+
+`send_many` versendet einen Batch in einem Aufruf.
+
+---
+
+## Validierung und Schutz vor Header-Injection
+
+`Email::validate()` läuft vor dem Versand (und du kannst es selbst aufrufen). Es
+lehnt unvollständige Nachrichten ab **und** verteidigt gegen Header-Injection — ein in einen
+Header eingeschmuggelter Zeilenumbruch ist die Art, wie Angreifer ein verstecktes `Bcc` hinzufügen:
+
+```rust
+// Missing recipients or an empty subject → MailError::InvalidMessage
+Email::new().subject("hi").validate()?;          // Err: no recipients
+
+// A CRLF in any header field → MailError::BadHeader (Django's BadHeaderError)
+Email::new()
+    .to("a@example.com")
+    .subject("Hello\r\nBcc: victim@example.com")  // injection attempt
+    .body("x")
+    .validate()?;                                  // Err: BadHeader
+```
+
+Beide werden im zugrunde liegenden Test verifiziert.
+
+---
+
+## E-Mails testen
+
+Verwende `InMemoryMailer` — es zeichnet jede Nachricht auf, statt zu senden, sodass Tests
+darauf prüfen, was *hinausgegangen wäre*, ohne Netzwerk:
+
+```rust
+use rustango::email::InMemoryMailer;
+
+let mailer = InMemoryMailer::new();
+welcome_flow(&mailer).await?;          // your code under test
+
+let sent = mailer.sent();              // Vec<Email>
+assert_eq!(sent.len(), 1);
+assert_eq!(sent[0].to, vec!["ada@example.com".to_string()]);
+assert_eq!(sent[0].subject, "Welcome");
+```
+
+---
+
+## Templates
+
+Für alles jenseits einer Textzeile rendere den Body aus einem [Tera](html-views.md)-Template,
+statt HTML inline zu setzen. Der `EmailRenderer` des `email_templates`-Features
+folgt einer `name.subject.txt` / `name.txt` / `name.html`-Konvention — ein Template-Satz
+produziert den Betreff, den Klartextteil und den HTML-Teil zusammen, sodass die
+drei nie auseinanderdriften. Das `Mailable`-Trait verpackt „ein Ding, das weiß, wie es sich
+selbst in eine `Email` verwandelt" für wiederverwendbare Nachrichten.
+
+---
+
+## Sie außerhalb des Requests versenden
+
+E-Mail inline zu versenden lässt den Nutzer auf deinen SMTP-Server warten und koppelt die
+Antwort an dessen Verfügbarkeit. Versende sie stattdessen aus einem [Hintergrundjob](jobs.md) —
+der Handler kehrt sofort zurück und ein Worker stellt sie zu (mit Retries, falls SMTP
+ausgefallen ist):
+
+```rust
+// in the handler: enqueue, don't send inline
+queue.dispatch(&SendWelcomeEmail { user_id }).await?;
+
+// the job (see the Background jobs guide):
+async fn run(&self) -> Result<(), JobError> {
+    let email = Email::new().to(/* ... */).subject("Welcome").body("...");
+    email.send(&*mailer).await.map_err(|e| JobError::Retryable(e.to_string()))?;
+    Ok(())
+}
+```
+
+Das `email_jobs`-Feature verdrahtet dies für dich.
+
+---
+
+## Referenz
+
+**`Email`-Builder:** `to` · `cc` · `from` · `reply_to` · `subject` · `body` ·
+`html_body` · Anhänge · `validate()` · `send(&mailer)`.
+
+**Helfer:** `send_mail(mailer, subject, body, from, &recipients)` ·
+`send_many(mailer, &emails)` · `from_settings(&EmailSettings)`.
+
+**`MailError`:** `InvalidMessage` (unvollständig) · `BadHeader` (CRLF-Injection) ·
+`Transport` (Backend-/Zustellungsfehler).
+
+---
+
+## Siehe auch
+
+- [Hintergrundjobs](jobs.md) — E-Mail außerhalb des Requests mit Retries zustellen.
+- [Konto-Abläufe](auth-flows.md) — Passwort-Reset- / Verifizierungs- / Magic-Link-E-Mails,
+  die darauf aufbauen.
+- [HTML-Views](html-views.md) — die Tera-Engine, die auch E-Mail-Templates verwenden.
+- [Caching](caching.md) — dasselbe Muster „Backend-austauschen" per Trait.

--- a/docs/de/files.md
+++ b/docs/de/files.md
@@ -1,0 +1,231 @@
+# Dateien, Uploads & Medien
+
+Fast jede App speichert Nutzerdateien — Avatare, Anhänge, exportierte Berichte,
+Bilder. **Rustango** gibt dir ein `Storage`-Trait mit austauschbaren Backends (lokale
+Festplatte, S3-kompatibler Objektspeicher, In-Memory für Tests), einen sicheren Multipart-**Upload**-Helfer
+mit Größen-/Typ-Schutzvorkehrungen und — wenn du eine nachverfolgte Mediathek brauchst — einen
+datenbankgestützten `MediaManager` mit vorsignierten URLs. Schreibe deinen Code
+einmal gegen das Trait; wechsle von lokaler Festplatte zu S3 mit einer einzeiligen Änderung.
+
+[![Dateien in Rustango: Ein Multipart-Upload wird größen- und erweiterungsgeprüft und dann durch das Storage-Trait geschrieben; dasselbe Trait unterlegt lokale Festplatte, S3 und In-Memory, und url() gibt eine öffentliche Adresse zurück](img/files.png)](img/files.png)
+
+> **Neu bei einem Begriff hier?** *Storage-Backend*, *Multipart*, *Objektspeicher*,
+> *vorsignierte URL* — siehe das [Glossar](glossary.md).
+
+> **Quelle:** `rustango::storage` (`Storage`, `LocalStorage`, `InMemoryStorage`,
+> `s3::S3Storage`, `BoxedStorage`), `rustango::uploads` (`save_uploads`,
+> `UploadConfig`, `sanitize_filename`) und `rustango::media`
+> (`Media`, `MediaManager`) — hinter den Features `storage` / `uploads` / `storage-s3` /
+> `media` (alle standardmäßig aktiviert).
+>
+> **Lauffähige Version:** Die Storage- + Upload-Schutzvorkehrungs-Snippets sind kopiert aus
+> [`files_doc.rs`](../crates/rustango/tests/files_doc.rs)
+> (`cargo test -p rustango --test files_doc`); der End-to-End-Multipart-`save_uploads`-Ablauf
+> wird von den In-File-Tests in
+> `crates/rustango/src/uploads.rs` selbst erprobt, und die Mediathek von
+> [`media_sqlite_live.rs`](../crates/rustango/tests/media_sqlite_live.rs).
+
+## Inhaltsverzeichnis
+
+- [Schritt 1 — Ein Storage-Backend wählen](#step-1--pick-a-storage-backend)
+- [Schritt 2 — Dateien speichern, laden und ausliefern](#step-2--save-load-and-serve-files)
+- [Schritt 3 — Einen Upload annehmen](#step-3--accept-an-upload)
+- [Sichere Dateinamen](#safe-filenames)
+- [Produktion: S3-kompatibler Speicher](#production-s3-compatible-storage)
+- [Die Mediathek](#the-media-library)
+- [Referenz](#reference)
+- [Siehe auch](#see-also)
+
+---
+
+## Schritt 1 — Ein Storage-Backend wählen
+
+Jedes Backend implementiert dasselbe `Storage`-Trait, sodass dein Code den konkreten Typ nie
+benennt — er hält ein **`BoxedStorage`** (`Arc<dyn Storage>`):
+
+```rust
+use rustango::storage::{BoxedStorage, LocalStorage};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+let storage: BoxedStorage = Arc::new(LocalStorage::new(PathBuf::from("./uploads")));
+```
+
+| Backend | Feature | Verwenden für |
+|---|---|---|
+| `LocalStorage` | `storage` | Ein-Server-Deployments — Dateien auf lokaler Festplatte |
+| `S3Storage` | `storage-s3` | Produktion — S3 / R2 / B2 / MinIO Objektspeicher |
+| `InMemoryStorage` | `storage` | Tests — eine `HashMap`, berührt nie die Festplatte |
+
+---
+
+## Schritt 2 — Dateien speichern, laden und ausliefern
+
+Das Trait besteht aus vier async-Methoden, indiziert durch einen String-Pfad. `save` schreibt
+Bytes, `load` liest sie zurück, dazu `exists` / `delete`:
+
+```rust
+use rustango::storage::{Storage, InMemoryStorage};
+
+let store = InMemoryStorage::new();
+store.save("avatars/7.png", &png_bytes).await?;
+assert!(store.exists("avatars/7.png").await?);
+let bytes = store.load("avatars/7.png").await?;
+store.delete("avatars/7.png").await?;
+```
+
+**Die Datei ausliefern.** Hänge eine Basis-URL an (dein CDN oder statischer Host) und `url(key)`
+baut die öffentliche Adresse, die du am Modell speicherst und dem Browser übergibst:
+
+```rust
+let store = LocalStorage::new("./uploads".into())
+    .with_base_url("https://cdn.example.com/uploads");
+
+store.url("docs/report.pdf");   // Some("https://cdn.example.com/uploads/docs/report.pdf")
+```
+
+Ohne Basis-URL gibt `url()` `None` zurück — du würdest die Bytes stattdessen durch einen
+Handler streamen. `LocalStorage` schützt außerdem vor Path-Traversal in Keys.
+
+---
+
+## Schritt 3 — Einen Upload annehmen
+
+`save_uploads` konsumiert einen axum-`Multipart`-Body, validiert jede Datei gegen eine
+`UploadConfig` und schreibt die Überlebenden in dein `Storage` — als Stream, sodass eine
+überdimensionierte Datei mitten in der Übertragung abgelehnt wird, statt zuerst in den Speicher
+gepuffert zu werden.
+
+```rust
+use rustango::uploads::{save_uploads, UploadConfig};
+use axum::extract::Multipart;
+
+async fn upload(mp: Multipart) -> Result<impl IntoResponse, UploadError> {
+    let cfg = UploadConfig::new("avatars/")          // key prefix
+        .max_bytes(2 * 1024 * 1024)                  // reject files over 2 MiB
+        .allowed_extensions(&["png", "jpg", "jpeg", "webp"])
+        .randomize_filename(true);                   // avoid collisions
+
+    let saved = save_uploads(mp, &cfg, &storage).await?;   // Vec<SavedUpload>
+    Ok(Json(saved))
+}
+```
+
+Die Schutzvorkehrungen werden erzwungen (und verifiziert): `allowed_extensions` ist
+**case-insensitiv** (`"PNG"` und `"png"` sind dasselbe), und `max_bytes` bricht den Stream ab,
+sobald die Größe überschritten wird. Die In-File-`uploads`-Tests treiben echte Multipart-Bodies an
+und behaupten, dass Dateien im Speicher landen, überdimensionierte Dateien abgelehnt und
+nicht erlaubte Erweiterungen verweigert werden.
+
+```rust
+let cfg = UploadConfig::new("avatars/").allowed_extensions(&["PNG", "Jpg"]);
+assert!(cfg.allowed_extensions.contains("png"));   // normalized to lowercase
+assert!(cfg.allowed_extensions.contains("jpg"));
+```
+
+---
+
+## Sichere Dateinamen
+
+Vertraue nie einem vom Client gelieferten Dateinamen. `sanitize_filename` reduziert ihn auf einen
+sicheren Basenamen — es entfernt Verzeichniskomponenten (Path-Traversal) und ersetzt unsichere
+Zeichen:
+
+```rust
+use rustango::uploads::sanitize_filename;
+
+sanitize_filename("../../etc/passwd");   // "passwd"   — no traversal
+sanitize_filename("my photo!.png");      // "my_photo_.png"
+sanitize_filename("");                    // "upload"   — never empty
+```
+
+`save_uploads` wendet dies für dich an; rufe es nur direkt auf, wenn du Keys von Hand baust.
+
+---
+
+## Produktion: S3-kompatibler Speicher
+
+Für Multi-Server-Deployments tausche `LocalStorage` gegen `S3Storage` (hinter dem
+`storage-s3`-Feature). Es spricht die S3-API mit einem selbstgebauten SigV4-Signierer, sodass es
+mit **AWS S3, Cloudflare R2, Backblaze B2 und MinIO** funktioniert. Das Trait ist
+identisch — nur der Konstruktor ändert sich:
+
+```rust
+use rustango::storage::s3::S3Storage;   // needs the `storage-s3` feature
+
+let storage: BoxedStorage = Arc::new(
+    S3Storage::new(/* bucket, region, endpoint, credentials */)
+);
+// save / load / delete / url — exactly the same calls as LocalStorage
+```
+
+Deine Handler und Modelle ändern sich nicht; nur die Verdrahtung beim Start.
+
+---
+
+## Die Mediathek
+
+Wenn Dateien erstklassige Datensätze sind — in der Datenbank nachverfolgt, im Admin durchstöberbar,
+mit Thumbnails und CDN-/vorsignierter Auslieferung — greife zu `rustango::media` statt zu rohem
+`Storage`. `MediaManager` persistiert eine `Media`-Zeile pro Datei und
+unterstützt zwei Upload-Abläufe:
+
+- **Serverseitig:** `manager.save_bytes(...)` speichert die Bytes und die Zeile in einem
+  Aufruf.
+- **Direkt-in-den-Speicher:** `manager.begin_upload(...)` gibt eine **vorsignierte PUT**-URL
+  zurück, zu der der Browser direkt hochlädt (dein Server proxyt die Bytes nie),
+  dann bestätigst du die Zeile.
+
+```rust
+use rustango::media::{Media, MediaManager};
+
+let manager = MediaManager::new_pool(pool.clone(), registry);
+// Hand the browser a short-lived download link:
+let url = manager.presigned_get(&media, Duration::from_secs(3600)).await?;
+```
+
+Er kümmert sich außerdem um Soft-Delete und das Bereinigen von Waisen. Der vollständige Ablauf wird
+in `media_sqlite_live.rs` erprobt; die vorsignierten/Direct-Upload-Methoden des Managers sind
+PostgreSQL-orientiert.
+
+### Wie die Medientabellen angelegt werden
+
+Die Medientabellen (`rustango_media`, `rustango_media_collections`,
+`rustango_media_tags`, `rustango_media_tag_links`) sind verwaltete Modelle. Ihr
+Schema wird als **System-Migration** ausgeliefert und angelegt — pro Tenant, wenn das
+`media`-Feature aktiviert ist — auf dieselbe Weise wie die übrigen frameworkeigenen
+Tabellen, immer wenn du `migrate` ausführst / einen Tenant provisionierst. Es gibt keinen faulen
+Schritt „beim ersten Gebrauch anlegen"; ist das Feature aus, werden die Tabellen nie angelegt.
+
+> **Upgrade von vor 0.51.** Frühere Versionen legten die Medientabellen faul über einen
+> `ensure_table`-DDL-Aufruf statt über eine Migration an. Beim ersten
+> `migrate` (oder Tenant-Provisionierung) nach dem Upgrade **rekonziliert** das Framework
+> **automatisch**:
+> Weil die Tabellen bereits existieren, wird die generierte Medien-Migration im
+> System-Migrations-Ledger verzeichnet, *ohne* ihr `CREATE TABLE` erneut auszuführen, und deine
+> bestehenden Zeilen bleiben unberührt. **Kein manueller Schritt ist erforderlich** — das Upgrade,
+> das andernfalls mit `relation already exists` / `table already exists` fehlschlagen würde,
+> funktioniert jetzt einfach. (Eingeführt in 0.51.1; siehe das CHANGELOG.)
+
+---
+
+## Referenz
+
+**`Storage`-Trait:** `save(key, &bytes)` · `load(key)` · `delete(key)` ·
+`exists(key)` · `url(key) -> Option<String>`.
+
+**`UploadConfig`:** `new(prefix)` · `.max_bytes(n)` · `.allowed_extensions(&[..])`
+(case-insensitiv) · `.randomize_filename(bool)`. Verwendet von
+`save_uploads(multipart, &cfg, &storage)`.
+
+**Backends:** `LocalStorage` (Festplatte) · `S3Storage` (Objektspeicher, `storage-s3`)
+· `InMemoryStorage` (Tests). Alle geben ein `BoxedStorage` zurück.
+
+---
+
+## Siehe auch
+
+- [Der Admin](admin.md) — Medien- und FK-Widgets bringen hochgeladene Dateien in der UI zur Anzeige.
+- [Hintergrundjobs](jobs.md) — skaliere/transcodiere einen Upload außerhalb des Requests.
+- [Caching](caching.md) — dasselbe Muster „Backend-austauschen" per Trait.
+- [Sicherheitsleitfaden](security.md) — Validieren nicht vertrauenswürdiger Upload-Eingaben.

--- a/docs/de/getting-started.md
+++ b/docs/de/getting-started.md
@@ -1,0 +1,727 @@
+# Erste Schritte: einen Blog mit Rustango bauen
+
+Diese Anleitung führt dich von einem leeren Verzeichnis bis zu einem deployten Blog: Beiträge, eine Admin-Oberfläche, eine JSON-API, JWT-Authentifizierung und Tests. Von Anfang bis Ende. Wenn du schon einmal Django, Laravel oder Rails verwendet hast, werden dir die meisten Schritte vertraut vorkommen; wir weisen unterwegs auf die Parallelen hin.
+
+> **Dauer:** ~45 Minuten für die komplette Tour, ~10 Minuten, wenn du es nur laufen sehen willst.
+>
+> **Lauffähige Version:** Jeder Schritt unten ist in einem getesteten, kompilierbaren Beispiel unter [`crates/rustango/examples/getting_started_blog`](../crates/rustango/examples/getting_started_blog) nachgebildet. Falls ein Schritt jemals seltsam aussieht, vergleiche ihn damit.
+
+[![Einen Blog mit Rustango bauen: die Migration generieren, sie anwenden, den Server starten und die JSON-API abfragen — alles aus einem einzigen Binary](img/getting-started.png)](img/getting-started.png)
+
+---
+
+## Was du zuerst brauchst
+
+| Werkzeug | Wofür | Installation |
+|---|---|---|
+| Rust 1.88+ | Compiler | <https://rustup.rs> |
+| Docker | Lokales Postgres | <https://docker.com> |
+| `psql` (optional) | DB inspizieren | `brew install libpq` / `apt install postgresql-client` |
+
+Prüfe die installierten Versionen:
+
+```bash
+rustc --version    # should print 1.88+
+docker --version   # any recent version
+```
+
+---
+
+## Schritt 1: Den Scaffolder installieren
+
+Der Scaffolder generiert für dich Projekt- und App-Gerüste, ähnlich wie `django-admin` oder `rails new`.
+
+```bash
+cargo install cargo-rustango
+```
+
+Das ergänzt den `cargo rustango ...`-Unterbefehl global. Bestätige, dass er vorhanden ist:
+
+```bash
+cargo rustango --help
+```
+
+---
+
+## Schritt 2: Das Projekt erstellen
+
+Das erzeugt ein frisches Projekt, das **Rustango**-Äquivalent zu `rails new` oder `composer create-project`.
+
+```bash
+cd ~/projects                                 # wherever you keep code
+cargo rustango new myblog                     # default = fullstack template
+cd myblog
+```
+
+Das wurde generiert:
+
+```
+myblog/
+├── Cargo.toml                  # rustango + axum + sqlx + tokio
+├── .env.example                # template for DATABASE_URL etc.
+├── .gitignore
+├── docker-compose.yml          # Postgres in a container
+├── README.md                   # project-specific
+├── config/                     # tiered settings (default + dev/staging/prod)
+├── migrations/                 # empty — `cargo run -- makemigrations` populates
+└── src/
+    ├── main.rs                 # entry point: `Cli::new().api(urls::api()).run()`
+    ├── models.rs               # every #[derive(Model)] lives here
+    ├── views.rs                # axum request handlers
+    └── urls.rs                 # `pub fn api()` route aggregator + `admin_router(pool)`
+```
+
+Es gibt ein einziges Binary: `cargo run` startet den HTTP-Server, und jedes Django-artige Verb (`migrate`, `makemigrations`, `startapp`, `check`, …) läuft über dasselbe Binary via `cargo run -- <verb>`. Es gibt kein separates `manage`-Binary.
+
+`Cargo.toml` ist das Abhängigkeits-Manifest (wie `composer.json` oder ein `Gemfile`). Öffne es und bestätige, dass `rustango` unter `[dependencies]` aufgeführt ist.
+
+> **Bestätige den `[features]`-Block — wähle ein Datenbank-Backend.** `#[derive(Model)]`
+> cfg-gated seine generierten `FromRow`- / `LoadRelated`-Impls anhand der Features
+> **deiner** Crate (ein `cfg` innerhalb eines Derive-Makros wird gegen die Ziel-Crate
+> aufgelöst, nicht gegen **Rustango**), also muss hier ein Backend-Feature aktiviert sein,
+> sonst kompiliert das erste Modell nicht. Ein aktuelles Gerüst enthält:
+>
+> ```toml
+> [features]
+> default  = ["postgres"]            # the backend `cargo run` uses
+> postgres = ["rustango/postgres"]
+> sqlite   = ["rustango/sqlite"]
+> mysql    = ["rustango/mysql"]
+> ```
+>
+> Wenn deine generierte `Cargo.toml` **keinen** `[features]`-Block hat (ein älteres
+> `cargo-rustango`), füge den obigen von Hand hinzu — das behebt es immer. Ohne ihn
+> schlägt der Build fehl mit *"the trait bound `…: MaybePgFromRow` is not satisfied"*
+> plus einem verräterischen `warning: unexpected cfg condition value: postgres`.
+
+---
+
+## Schritt 3: Deine Umgebung einrichten
+
+Die Konfiguration liegt in einer `.env`-Datei, genau wie bei Django oder Laravel. Kopiere die Vorlage:
+
+```bash
+cp .env.example .env
+```
+
+Die generierte `.env` ist von Haus aus Docker-freundlich. Da wir `cargo` auf dem Host ausführen (nicht im Dev-Container), ändere den Datenbank-Host von `postgres` auf `localhost`:
+
+```bash
+DATABASE_URL=postgres://rustango:rustango@localhost:5432/myblog_dev
+RUSTANGO_BIND=0.0.0.0:8080
+RUSTANGO_APEX_DOMAIN=localhost
+RUSTANGO_SESSION_SECRET=change-me-base64-encoded-32-bytes-or-more
+```
+
+Die Zugangsdaten, der Port und der Datenbankname (`myblog_dev`) passen bereits zum Postgres-Dienst aus der `docker-compose.yml`, du musst sie also nicht anfassen.
+
+`RUSTANGO_SESSION_SECRET` signiert Sessions und Tokens, also liefere nicht den Platzhalter aus. Generiere ein echtes und füge es ein:
+
+```bash
+openssl rand -base64 32     # paste output as RUSTANGO_SESSION_SECRET value
+```
+
+---
+
+## Schritt 4: Postgres starten
+
+Das Projekt bringt eine `docker-compose.yml` mit, die Postgres in einem Container ausführt, sodass du keine Datenbank von Hand installieren musst. Die App selbst führen wir mit `cargo` auf dem Host aus, also starte nur den `postgres`-Dienst im Hintergrund (die Compose-Datei definiert außerdem einen optionalen `rust`-Dev-Container, der andernfalls Port 8080 belegen würde):
+
+```bash
+docker compose up -d postgres
+```
+
+Bestätige, dass er läuft:
+
+```bash
+docker compose ps
+psql "$DATABASE_URL" -c "SELECT version();"   # should print Postgres version
+```
+
+---
+
+## Schritt 5: Die integrierten Migrationen ausführen
+
+Migrationen erstellen deine Datenbanktabellen, dieselbe Idee wie `php artisan migrate` oder `rails db:migrate`. Führe sie einmal aus, um die eigenen Tabellen des Frameworks einzurichten:
+
+```bash
+cargo run -- migrate
+```
+
+Der erste Kompiliervorgang dauert ~2 Minuten (Rust baut alles aus dem Quellcode). Ein frisches Projekt bringt noch keine Migrationsdateien mit, du siehst also `nothing to migrate (already up to date)` — `migrate` richtet dennoch die Audit-Log-Tabelle des Frameworks ein, damit auditierte Modelle sofort funktionieren, sobald du sie hinzufügst. Deine erste echte Migration generierst du in Schritt 9.
+
+Prüfe den Migrationsstatus:
+
+```bash
+cargo run -- showmigrations
+```
+
+Bei einem frischen Projekt gibt das `(no migrations in ./migrations)` aus. Sobald du ein Modell erstellst und `makemigrations` ausführst (Schritt 9), erscheint hier für jede angewendete Migration ein `[X]`.
+
+---
+
+## Schritt 6: Erster Start
+
+Starte den Server, um sicherzustellen, dass alles verdrahtet ist.
+
+```bash
+cargo run
+```
+
+Du siehst:
+
+```
+listening on http://0.0.0.0:8080
+```
+
+Öffne <http://localhost:8080> in deinem Browser. Das Gerüst bringt einen einfachen Root-Handler (`views::index`) mit, der dich mit **Hello from Rustango!** und einem Link zum Admin begrüßt — das bestätigt, dass **Rustango** läuft. (Projekte, die keine eigene `/`-Route definieren, bekommen stattdessen eine integrierte Willkommensseite über `Cli::with_welcome()`.)
+
+Drücke Strg-C zum Stoppen.
+
+---
+
+## Schritt 7: Eine App erstellen
+
+Eine „App" ist ein in sich geschlossenes Feature-Modul, genau wie eine Django-App. Deine Blog-App wird das Post-Modell, seine Routen und seine Templates enthalten.
+
+```bash
+cargo run -- startapp blog
+```
+
+Das schreibt:
+
+```
+src/blog/
+├── mod.rs
+├── models.rs              # a starter model named after the app (you'll replace it)
+├── views.rs               # axum handlers
+├── urls.rs                # blog-specific routes (pub fn api())
+└── tests.rs               # in-process router + inventory smoke tests
+```
+
+`startapp` verdrahtet das neue Modul für dich (ähnlich wie das Hinzufügen zu Djangos `INSTALLED_APPS`): Es deklariert `mod blog;` in `src/main.rs` und fügt eine `.merge(crate::blog::urls::api())`-Zeile in den `api()`-Aggregator in `src/urls.rs` ein, sodass sich die Routen des Blogs automatisch in die App einfügen. Keine manuelle Modulregistrierung nötig.
+
+---
+
+## Schritt 8: Ein Modell definieren
+
+Ein Modell ist eine Datenbanktabelle, beschrieben als Rust-Struct, wie ein Django-Modell oder eine Eloquent-/Active-Record-Klasse. Öffne `src/blog/models.rs` und definiere deinen `Post`. (Für die vollständige Referenz — jeden Feldtyp, benutzerdefinierte Primärschlüssel und alle Attribute — siehe den [Modelle-Leitfaden](models.md).)
+
+```rust
+use rustango::{Auto, Model};
+use chrono::{DateTime, Utc};
+
+#[derive(Model, Clone, Debug)]
+#[rustango(
+    table = "posts",
+    display = "title",
+    admin(
+        list_display  = "id, title, status, published_at",
+        search_fields = "title, body",
+        list_filter   = "status, author_id",
+        ordering      = "-published_at",
+    ),
+    audit(track = "title, body, status"),
+    index("status, published_at"),
+)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+
+    #[rustango(max_length = 200)]
+    pub title: String,
+
+    pub body: String,
+
+    #[rustango(max_length = 20, default = "'draft'")]
+    pub status: String,                  // draft | published
+
+    pub author_id: i64,
+
+    #[rustango(auto_now_add)]
+    pub published_at: Auto<DateTime<Utc>>,
+
+    #[rustango(soft_delete)]
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+```
+
+Ein paar Rust-Dinge, die zu beachten sind:
+
+- `#[derive(Model, ...)]` ist ein **Derive-Makro**: Es generiert automatisch Code für das Struct, so wie es ein Klassendekorator oder eine Basisklasse in anderen Frameworks täte. Das Ableiten von `Model` verleiht dem Struct seine Abfragemethoden.
+- `Auto<i64>` markiert ein Feld, das die Datenbank für dich befüllt (ein automatisch hochzählender `i64`-Integer), wie ein Auto-Primärschlüssel.
+- `Option<...>` bedeutet „dieser Wert kann fehlen". `Option<DateTime<Utc>>` ist ein Zeitstempel, der null sein kann, sodass `deleted_at` leer ist, bis die Zeile per Soft-Delete gelöscht wird.
+- Die `#[rustango(...)]`-Attribute konfigurieren jedes Feld (maximale Länge, Defaults, Indizes), und der `admin(...)`-Block richtet die Spalten und Filter der Admin-Oberfläche ein.
+
+---
+
+## Schritt 9: Die Migration erstellen und anwenden
+
+Verwandle dieses Modell nun in eine echte Tabelle. Generiere zunächst die Migration aus deinem Modell (wie `makemigrations` in Django):
+
+```bash
+cargo run -- makemigrations
+```
+
+Du siehst etwa Folgendes:
+
+```
+wrote ./migrations/0001_create_item_and_posts_and_rustango_admin_users_etc.json
+    + CreateTable("item")
+    + CreateTable("posts")
+    + CreateTable("rustango_admin_users")
+    + CreateTable("rustango_content_types")
+    + CreateIndex { table: "posts", columns: ["status", "published_at"], ... }
+```
+
+Diese erste Migration erstellt deine Modelle — `posts`, plus das Starter-Modell `item`, das das Gerüst in `src/models.rs` mitgeliefert hat — zusammen mit den Admin- und Content-Type-Tabellen des Frameworks. Öffne die JSON, wenn du willst: Sie enthält die Operationen plus einen vollständigen Schema-Snapshot.
+
+Wende sie auf die Datenbank an:
+
+```bash
+cargo run -- migrate
+```
+
+Bestätige, dass die Tabelle existiert:
+
+```bash
+psql "$DATABASE_URL" -c "\d posts"
+```
+
+---
+
+## Schritt 10: Das ORM ausprobieren
+
+Lass uns Zeilen aus dem Code lesen und schreiben. Das ORM lässt dich mit Datenbankzeilen als Rust-Structs arbeiten statt mit rohem SQL, wie Djangos ORM, Eloquent oder Active Record.
+
+Bearbeite `src/main.rs` vorübergehend, um vor dem Serverstart einen schnellen Erstellen-und-Lesen-Test auszuführen. Ersetze den `Cli`-Rumpf durch einen Ad-hoc-ORM-Smoke-Test (behalte das `#[rustango::main]` des Scaffolders und die `mod`-Deklarationen am Anfang der Datei):
+
+```rust
+mod blog;
+mod models;
+mod urls;
+mod views;
+
+use crate::blog::models::Post;
+use rustango::{Auto, Model};
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    let pool = rustango::sql::sqlx::PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
+
+    // CREATE
+    let mut p = Post {
+        id: Auto::default(),
+        title: "First post".into(),
+        body: "Hello, world.".into(),
+        status: "draft".into(),
+        author_id: 1,
+        published_at: Auto::default(),
+        deleted_at: None,
+    };
+    p.save(&pool).await?;
+    println!("created post id = {}", p.id.get().copied().unwrap());
+
+    // READ
+    let posts = Post::objects().fetch_on(&pool).await?;
+    for post in &posts {
+        println!("- {}", post.title);
+    }
+
+    Ok(())
+}
+```
+
+Was hier geschieht, in einfachen Worten:
+
+- `pool` ist der gemeinsam genutzte Datenbank-Verbindungspool. Du übergibst eine Referenz darauf (`&pool`) an Abfrageaufrufe, statt jedes Mal eine neue Verbindung zu öffnen.
+- Datenbankaufrufe sind asynchron, daher endet jeder mit `.await` — das pausiert, bis das Ergebnis zurückkommt, und macht dann weiter. Das `?` nach einem `.await` sagt „falls das einen Fehler ergab, halte an und gib den Fehler zurück".
+- `main` gibt ein `Result` zurück, Rusts Erfolg-oder-Fehler-Typ, weshalb `?` und das abschließende `Ok(())` funktionieren.
+- Um eine Zeile zu speichern, rufe `.save(&pool)` darauf auf. Um Zeilen zu lesen, baue eine Abfrage mit `Post::objects()` und führe sie mit `.fetch_on(&pool)` aus — das grobe Äquivalent zu Djangos `Post.objects.all()`. (`.save(&pool)` / `.fetch_on(&pool)` nehmen einen `sqlx::PgPool`; die schlichte `.fetch(&pool)`-Variante nimmt stattdessen einen Multi-Backend-`rustango::sql::Pool` — siehe den [ORM-Leitfaden](orm.md).)
+
+Führe es aus:
+
+```bash
+cargo run
+```
+
+Du solltest die ID deines neuen Beitrags und die zurückgelesenen Zeilen sehen. Stelle `src/main.rs` wieder in seine gescaffoldete Server-Form zurück, sobald du bestätigt hast, dass es funktioniert — der nächste Schritt baut darauf auf.
+
+---
+
+## Schritt 11: Den Auto-Admin einschalten
+
+**Rustango** bringt eine generierte Admin-Oberfläche für deine Modelle mit, genau wie Djangos Admin. Der Scaffolder hat dir bereits einen `admin_router(pool)`-Helfer in `src/urls.rs` gegeben, der den Auto-Admin aus einem Pool baut — du musst ihn nur unter `/admin` einhängen und in das `Cli` einspeisen.
+
+Gib dem Admin zunächst einen Titel in `src/urls.rs`. Das `admin_prefix` muss zu dem Pfad passen, unter dem du ihn im nächsten Schritt einhängst (`/admin`), damit die eigenen Links und Formularaktionen des Admins aufgelöst werden:
+
+```rust
+pub fn admin_router(pool: PgPool) -> Router {
+    admin::Builder::new(pool)
+        .title("Myblog Admin")
+        .admin_prefix("/admin") // must match the `.nest("/admin", …)` below
+        .build()
+}
+```
+
+Verbinde dann einen Pool in `src/main.rs` und hänge den Admin in den API-Router ein, bevor du ihn an das `Cli` übergibst. Behalte die `mod blog;`-Zeile aus Schritt 7 — die registriert dein `Post`-Modell beim Admin:
+
+```rust
+mod blog;
+mod models;
+mod urls;
+mod views;
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    let pool = rustango::sql::sqlx::PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
+
+    let api = urls::api().nest("/admin", urls::admin_router(pool));
+
+    rustango::manage::Cli::new()
+        .api(api)
+        .with_health() // /health + /ready endpoints
+        .run()
+        .await
+}
+```
+
+`Cli::new()...run()` ist derselbe vereinheitlichte Dispatcher, den der Scaffolder generiert hat — er bedient weiterhin jedes `cargo run -- <verb>`; du hast nur den Router angereichert, den er zur Runserver-Zeit bedient.
+
+Führe es aus:
+
+```bash
+cargo run
+```
+
+Öffne <http://localhost:8080/admin> (kein abschließender Schrägstrich). Du siehst die Admin-Startseite mit einem `posts`-Link. Klicke ihn an, um deinen Entwurfsbeitrag in der Liste zu sehen, klicke den Beitrag an, um sein Bearbeitungsformular zu öffnen, und speichere. Der Audit-Trail-Tab zeichnet jeden Schreibvorgang auf.
+
+---
+
+## Schritt 12: Die JSON-API bauen
+
+Ein ViewSet stellt ein Modell als REST-API mit List-, Create-, Retrieve-, Update- und Delete-Endpunkten bereit, ganz ähnlich einem ViewSet des Django REST Framework oder einem API-Resource-Controller von Laravel.
+
+### 12a. Das ViewSet generieren
+
+Erstelle das Gerüst der Datei, fülle dann aus, welche Felder und Verhaltensweisen exponiert werden sollen:
+
+```bash
+cargo run -- make:viewset PostViewSet --model Post
+```
+
+Bearbeite `src/post_view_set.rs`:
+
+```rust
+use rustango::ViewSet;
+use crate::blog::models::Post;
+
+#[derive(ViewSet)]
+#[viewset(
+    model         = Post,
+    fields        = "id, title, body, status, author_id, published_at",
+    filter_fields = "author_id, status",
+    search_fields = "title, body",
+    ordering      = "-published_at",
+    page_size     = 20,
+)]
+pub struct PostViewSet;
+```
+
+Registriere das neue Modul, indem du `mod post_view_set;` zu den anderen `mod`-Deklarationen am Anfang von `src/main.rs` hinzufügst.
+
+### 12b. Die Routen einhängen
+
+Hänge die Routen des ViewSet an den Router der App an (die **Rustango**-Version einer `urls.py`- oder `routes/api.php`-Datei). Der ViewSet-Router braucht den Datenbankpool, also baue ihn in `src/main.rs`, wo der Pool lebt, und merge ihn in den `urls::api()`-Aggregator:
+
+```rust
+let api = urls::api()
+    .nest("/admin", urls::admin_router(pool.clone()))
+    .merge(crate::post_view_set::PostViewSet::router("/api/posts", pool));
+
+rustango::manage::Cli::new()
+    .api(api)
+    .with_health()
+    .run()
+    .await
+```
+
+(`urls::api()` ist der Aggregator, den der Scaffolder generiert hat; `manage startapp` merged die Routen jeder Unter-App auf dieselbe Weise hinein.)
+
+### 12c. Die Endpunkte ausprobieren
+
+Starte den Server:
+
+```bash
+cargo run
+```
+
+In einem anderen Terminal rufe die API mit `curl` auf:
+
+```bash
+curl http://localhost:8080/api/posts                                    # list
+curl -X POST http://localhost:8080/api/posts \
+     -H "content-type: application/json" \
+     -d '{"title":"From API","body":"Yo","status":"published","author_id":1}'
+curl http://localhost:8080/api/posts/1                                   # retrieve
+curl "http://localhost:8080/api/posts?search=API&ordering=-id"            # search + sort
+curl "http://localhost:8080/api/posts?status__ne=draft"                   # lookup operator
+```
+
+---
+
+## Schritt 13: Die Ausgabe mit einem Serializer formen
+
+Standardmäßig gibt das ViewSet jedes Modellfeld zurück. Ein Serializer lässt dich die Form der Antwort steuern: interne Felder verbergen, sie umbenennen oder einige als read-only markieren. Es ist dieselbe Rolle wie ein DRF-Serializer oder eine API-Resource von Laravel.
+
+```bash
+cargo run -- make:serializer PostSerializer --model Post
+```
+
+Bearbeite `src/post_serializer.rs`:
+
+```rust
+use rustango::{Auto, Serializer};
+use crate::blog::models::Post;
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: Auto<i64>,
+    pub title: String,
+
+    #[serializer(source = "body")]                      // rename in API
+    pub content: String,
+
+    #[serializer(read_only)]                            // include in GET, ignore in POST/PUT
+    pub published_at: Auto<chrono::DateTime<chrono::Utc>>,
+}
+```
+
+Der Typ jedes Serializer-Felds spiegelt das passende Modellfeld wider, sodass `id` und `published_at` ihren `Auto<…>`-Wrapper vom Modell behalten (ein `Auto<i64>` serialisiert weiterhin zu einem schlichten JSON-Integer). Registriere dann das Modul, indem du `mod post_serializer;` zu den anderen `mod`-Deklarationen in `src/main.rs` hinzufügst.
+
+Verdrahte den Serializer mit dem ViewSet über das `serializer`-Attribut — List-, Retrieve- und Create-Antworten werden dann durch ihn gerendert (die feldbasierte `fields`-Projektion wird zugunsten der Form des Serializers umgangen):
+
+```rust
+#[derive(ViewSet)]
+#[viewset(
+    model = Post,
+    serializer = crate::post_serializer::PostSerializer,
+    ordering = "-published_at",
+)]
+pub struct PostViewSet;
+```
+
+Das funktioniert identisch auf PostgreSQL, MySQL und SQLite. `method`- / `read_only`- / `source`- / `write_only`-Overrides gelten alle für die Antwort, und **Request-Bodies werden ebenfalls durch den Serializer validiert**: `create` / `update` führen sein `validate()` aus (pro Feld und feldübergreifend) und geben bei Fehlschlag einen `400` in DRF-Form zurück (`{field: [messages]}`), und read-only- / berechnete Felder, die ein Client postet, werden ignoriert. (Hinweis: `nested`- / `many`-Serializer-Felder brauchen die zugehörigen Zeilen, geladen via `select_related`; andernfalls werden sie als ihr Default gerendert.) Siehe den [ViewSets-Leitfaden](viewsets.md) für das vollständige Eingabe- und Ausgabeverhalten.
+
+---
+
+## Schritt 14: JWT-Authentifizierung hinzufügen
+
+JWTs sind signierte Tokens, die du einem Client nach dem Login übergibst und bei jeder Anfrage prüfst, ein gängiges Muster für API-Auth. Das `rustango::jwt`-Modul von **Rustango** stellt sie aus und verifiziert sie (HS256) und ist standardmäßig aktiv — kein zusätzliches Feature-Flag.
+
+### 14a. Beim Login ein Token ausstellen
+
+Backe die Benutzer-ID (das „Subject" des Tokens) und beliebige benutzerdefinierte Claims, wie Rollen, in ein signiertes Token und übergib es dann dem Client:
+
+```rust
+use rustango::jwt::{encode, Claims};
+use std::time::Duration;
+
+// Derive the signing key from your session secret.
+let secret = std::env::var("RUSTANGO_SESSION_SECRET")?.into_bytes();
+
+let mut claims = Claims::new(user_id.to_string());   // subject = user id
+claims.set("roles", vec!["editor"]);
+let token = encode(&claims.ttl(Duration::from_secs(900)), &secret)?;
+
+// Send `token` to the client (e.g. in the login response body).
+```
+
+### 14b. Das Token bei jeder Anfrage verifizieren
+
+Dekodiere das Token — das prüft die Signatur und die Ablaufzeit — und lies dann die Claims zurück. Falls es fehlt oder ungültig ist, weise die Anfrage als nicht autorisiert ab:
+
+```rust
+use rustango::jwt::decode;
+
+let claims = decode(&access_token, &secret)
+    .map_err(|_| StatusCode::UNAUTHORIZED)?;
+
+let user_id = claims.subject().ok_or(StatusCode::UNAUTHORIZED)?;
+let roles: Vec<String> = claims.get("roles").unwrap_or_default();
+```
+
+### 14c. Access- + Refresh-Lebenszyklus
+
+`rustango::jwt` stellt zustandslose Einzeltokens aus. Für das vollständige Muster — kurzlebige **Access**-Tokens, ein langlebiges **Refresh**-Token in einem HttpOnly-Cookie, Rotation und eine JTI-Blacklist zum Widerruf — aktiviere das `tenancy`-Feature und verwende `rustango::tenancy::jwt_lifecycle::JwtLifecycle`, dessen Methoden `issue_pair_with` / `verify_access` / `refresh` das Paar für dich verwalten.
+
+---
+
+## Schritt 15: Security-Middleware hinzufügen
+
+Middleware umschließt jede Anfrage, um querschnittliches Verhalten zu ergänzen. Hier stapelst du Request-IDs, Access-Logging, Rate-Limiting, CORS und Security-Header in einer Kette. Jedes `.method(...)` fügt eine Schicht hinzu, ähnlich wie Django-Middleware oder Laravels Middleware-Stack. Siehe den [Middleware-Leitfaden](middleware.md) für den vollständigen Schichtenkatalog und die Reihenfolgeregeln.
+
+```rust
+use rustango::security_headers::{SecurityHeadersLayer, SecurityHeadersRouterExt, CspBuilder};
+use rustango::cors::{CorsLayer, CorsRouterExt};
+use rustango::rate_limit::{RateLimitLayer, RateLimitRouterExt};
+use rustango::access_log::{AccessLogLayer, AccessLogRouterExt};
+use rustango::request_id::{RequestIdLayer, RequestIdRouterExt};
+use rustango::health::health_router;
+use std::time::Duration;
+
+let app = urls::api()
+    .nest("/admin", urls::admin_router(pool.clone()))
+    .merge(crate::post_view_set::PostViewSet::router("/api/posts", pool.clone()))
+    .merge(health_router(pool.clone()))                        // /health, /ready
+    .request_id(RequestIdLayer::default())
+    .access_log(AccessLogLayer::default())                      // PII-redacted
+    .rate_limit(RateLimitLayer::per_ip(60, Duration::from_secs(60)))
+    .cors(CorsLayer::new()
+        .allow_origins(vec!["https://app.example.com"])
+        .allow_methods(vec!["GET", "POST", "PUT", "PATCH", "DELETE"]))
+    .security_headers(
+        SecurityHeadersLayer::strict()
+            .csp(CspBuilder::strict_starter().build()),
+    );
+```
+
+Übergib die fertige `app` genau wie zuvor an das `Cli` — `rustango::manage::Cli::new().api(app).with_welcome().run().await` — und jede Anfrage fließt nun durch den vollständigen Middleware-Stack.
+
+---
+
+## Schritt 16: Tests schreiben
+
+**Rustango** enthält einen Testclient, der deinen Router in-process ansteuert, sodass du reale HTTP-Antworten prüfen kannst, ohne einen Server zu starten, ganz ähnlich Djangos Testclient oder Laravels HTTP-Tests. Erstelle das Gerüst einer Testdatei:
+
+```bash
+cargo run -- make:test PostSmoke      # generates tests/post_smoke.rs
+```
+
+Die `make:*`-Generatoren nehmen einen PascalCase-Namen; `PostSmoke` wird zur snake_case-Datei `tests/post_smoke.rs`.
+
+Bearbeite `tests/post_smoke.rs`. Integrationstests leben in einer separaten Crate, daher bauen sie den zu testenden Router direkt aus dem ViewSet (derselbe `router(...)`-Aufruf, den du in Schritt 12b eingehängt hast):
+
+```rust
+use rustango::test_client::TestClient;
+use myblog::post_view_set::PostViewSet;
+use rustango::sql::sqlx::PgPool;
+use serde_json::json;
+
+async fn app() -> axum::Router {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap()).await.unwrap();
+    PostViewSet::router("/api/posts", pool)
+}
+
+#[tokio::test]
+async fn list_posts_returns_200() {
+    let client = TestClient::new(app().await);
+    let response = client.get("/api/posts").send().await;
+    assert_eq!(response.status, 200);
+    let v = response.json_value();
+    assert!(v["results"].is_array());
+}
+
+#[tokio::test]
+async fn create_post_returns_the_new_object() {
+    let client = TestClient::new(app().await);
+    let response = client.post("/api/posts")
+        .json(&json!({
+            "title": "Test",
+            "body":  "x",
+            "status": "draft",
+            "author_id": 1,
+        }))
+        .send().await;
+    assert_eq!(response.status, 201);
+    let v: serde_json::Value = response.json();
+    assert_eq!(v["title"], "Test");
+}
+```
+
+> **Achtung:** Integrationstests in `tests/` können nur dann `use myblog::…`, wenn die Crate ein Library-Target bereitstellt. Ein frisches Gerüst ist reines Binary (`src/main.rs`, kein `src/lib.rs`), also füge eine einzeilige `src/lib.rs` hinzu, die die Module re-exportiert, die du testen willst — `pub mod models; pub mod post_view_set; pub mod urls;` — und behalte die passenden `mod …;`-Zeilen in `src/main.rs`. (Wenn du lieber kein Library-Target hinzufügen möchtest, baue den Router stattdessen vollständig inline im Test, so wie `make:test` sein `app()` scaffoldet.)
+
+Führe die Tests aus:
+
+```bash
+cargo test --test post_smoke
+```
+
+---
+
+## Schritt 17: Den Systemcheck ausführen
+
+Bevor du deployst, führe den integrierten Prüfer aus. Er meldet gängige Fehlkonfigurationen (wie ein schwaches `RUSTANGO_SESSION_SECRET` oder eine nicht erreichbare Datenbank), ähnlich Djangos `check --deploy`.
+
+```bash
+cargo run -- check --deploy
+```
+
+In deiner lokalen Dev-Umgebung siehst du etwa Folgendes:
+
+```
+running rustango system check (deploy mode)...
+  [info]    6 models registered via inventory
+  [info]    database reachable
+  [info]    1 migration(s) on disk
+  [info]    RUSTANGO_SESSION_SECRET length OK
+  [info]    config tier resolved to `dev`
+  [warning] RUSTANGO_ENV is unset — set to `prod` so config loaders pick the right tier
+  [warning] DATABASE_URL points at localhost / 127.0.0.1 — verify this is intended in production
+  [warning] RUSTANGO_APEX_DOMAIN is unset / `localhost` — set it for tenancy projects
+```
+
+(Die genauen Modell-/Migrationszahlen hängen von deinem Projekt ab.) Diese drei Warnungen sind die erwarteten Dev-Umgebungs-Warnungen. In einem Produktions-Setup — `RUSTANGO_ENV=prod`, eine managed-Database-`DATABASE_URL`, eine gesetzte Apex-Domain — verschwinden sie und du siehst `all checks passed`. Behebe verbleibende Warnungen oder Fehler, bevor du in die Produktion pushst.
+
+---
+
+## Schritt 18: In die Produktion deployen
+
+Wie du deployst, hängt von deiner Plattform ab (Fly, Railway, Kubernetes, blankes ECS usw.). Die framework-seitigen Schritte sind überall gleich; das `--release`-Flag baut ein optimiertes Binary:
+
+```bash
+# 1. Set production env
+export RUSTANGO_ENV=prod
+export DATABASE_URL=postgres://prod-host/myblog
+export RUSTANGO_SESSION_SECRET=$(openssl rand -base64 32)
+
+# 2. Run migrations
+cargo run --release -- migrate
+
+# 3. Audit
+cargo run --release -- check --deploy
+
+# 4. Build binary
+cargo build --release
+
+# 5. Run with a process supervisor (systemd / docker / k8s)
+./target/release/myblog
+```
+
+Stelle sicher, dass dein Reverse-Proxy:
+- HTTPS terminiert
+- `X-Forwarded-For` weiterleitet für akkurate IPs im `AccessLogLayer`
+- `X-Forwarded-Host`, `X-Forwarded-Proto` weiterleitet
+- `axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())` verwendet, damit `ConnectInfo` für Rate-Limiting + IP-Filterung befüllt ist
+
+---
+
+## Wie es weitergeht
+
+| Thema | Doku |
+|---|---|
+| Lauffähige Version dieses Leitfadens | [`examples/getting_started_blog`](../crates/rustango/examples/getting_started_blog) |
+| Jeder `manage`-Unterbefehl | [`docs/manage.md`](manage.md) |
+| ORM-Kochbuch (fortgeschrittene Filter, Aggregationen, M2M, Soft-Delete) | [`docs/orm.md`](orm.md) |
+| Middleware (der vollständige Schichtenkatalog + Reihenfolge) | [`docs/middleware.md`](middleware.md) |
+| Performance-Benchmarks (vs. Go) | [`docs/benchmarks.md`](benchmarks.md) |
+| API-Konventionen (Benennung, Builder-Muster, Feature-Gates) | [`docs/api-conventions.md`](api-conventions.md) |
+| Security-Features im Detail | [`docs/security.md`](security.md) |
+| Django-Parity-Audit | [`docs/django-parity-audit-2026-05-21.md`](django-parity-audit-2026-05-21.md) |
+| Multi-Tenancy | [README — Abschnitt Multi-tenancy](../README.md#multi-tenancy) |
+| API-Doku | <https://docs.rs/rustango> |
+
+Wenn du auf etwas stößt, das nicht funktioniert oder unklar ist, öffne ein Issue.

--- a/docs/de/glossary.md
+++ b/docs/de/glossary.md
@@ -1,0 +1,206 @@
+# Glossar
+
+Eine Referenz in einfacher Sprache für die in dieser Dokumentation verwendeten Wörter. Wenn dir ein
+Begriff in einem Leitfaden unbekannt ist, schlage ihn zuerst hier nach. Die Definitionen sind
+bewusst informell — die vertiefenden Leitfäden liefern die genauen Details.
+
+Wenn du noch nie zuvor eine Web-API gebaut hast, lies [Grundlagen der Web-APIs](#web-api-basics)
+von oben bis unten; es ist eine fünfminütige Einführung. Alles andere ist zum Nachschlagen
+gedacht, während du vorankommst.
+
+## Inhaltsverzeichnis
+
+- [Grundlagen der Web-APIs](#web-api-basics) — was eine API ist, in alltäglichen Worten
+- [Rustango-Bausteine](#rustango-building-blocks) — die Teile, die du zusammensetzt
+- [Daten und die Datenbank](#data-and-the-database)
+- [Ein paar Rust-Wörter](#a-few-rust-words) — damit die Codeblöcke nicht angsteinflößend sind
+- [Frameworks, mit denen wir vergleichen](#frameworks-we-compare-to)
+
+---
+
+## Grundlagen der Web-APIs
+
+**API** — *Application Programming Interface* (Programmierschnittstelle). Ein Weg für ein Programm, mit
+einem anderen zu sprechen. Eine **Web-API** tut das über das Internet: Deine App sendet eine Nachricht, der
+Server sendet eine zurück. Stell sie dir wie einen Kellner vor — du bestellst von einer Speisekarte, die
+Küche schickt das Essen zurück.
+
+**REST-API** — der gängigste Stil von Web-API. „REST" ist einfach eine Reihe von
+Konventionen: Du wirkst auf **Ressourcen** (wie „posts" oder „users") mit standardisierten
+Web-Verben ein. Du musst die Theorie nicht kennen — in der Praxis bedeutet es *vorhersehbare
+URLs und eine Handvoll Verben*, wie als Nächstes beschrieben.
+
+**Endpoint** — eine bestimmte URL, auf die deine API antwortet, wie `/api/posts` (alle Posts)
+oder `/api/posts/42` (der Post mit der id 42). Eine API ist eine Sammlung von Endpoints.
+
+**HTTP-Verb (oder Methode)** — *was* du an einem Endpoint tun willst. Es gibt fünf,
+die dir ständig begegnen:
+
+| Verb | Bedeutet | Beispiel |
+|---|---|---|
+| `GET` | lesen / abrufen | „gib mir alle Posts" |
+| `POST` | erstellen | „füge einen neuen Post hinzu" |
+| `PUT` | ersetzen | „überschreibe Post 42 vollständig" |
+| `PATCH` | teilweise aktualisieren | „ändere nur den Titel von Post 42" |
+| `DELETE` | entfernen | „lösche Post 42" |
+
+**Request / Response** — ein Request ist die Nachricht, die du sendest (ein Verb + ein Endpoint
++ optional ein Datenkörper). Die Response ist das, was zurückkommt (ein Statuscode +
+üblicherweise ein Datenkörper).
+
+**JSON** — das Textformat, das APIs zum Transport von Daten verwenden. Es sieht aus wie
+`{"title": "Hello", "published": true}` — beschriftete Werte, menschenlesbar. Sowohl
+Requests als auch Responses sind üblicherweise JSON.
+
+**Statuscode** — eine dreistellige Zahl in jeder Response, die angibt, wie es gelaufen ist:
+
+| Code | Bedeutung |
+|---|---|
+| `200` | OK — hier sind deine Daten |
+| `201` | Created — dein neues Ding wurde gespeichert |
+| `204` | Done — nichts zurückzusenden (z. B. nach einem Löschen) |
+| `400` | Bad request — du hast etwas Ungültiges gesendet (der Körper sagt was) |
+| `401` / `403` | Nicht eingeloggt / nicht erlaubt |
+| `404` | Not found (nicht gefunden) |
+| `429` | Too many requests — mach langsamer |
+| `500` | Der Server ist auf einen Fehler gestoßen |
+
+**CRUD** — *Create, Read, Update, Delete* (erstellen, lesen, aktualisieren, löschen). Die vier grundlegenden Dinge, die du mit Daten tust.
+Eine „CRUD-API" bedeutet einfach eine API, die dich alle vier tun lässt. Siehe
+[ViewSets](viewsets.md), die eine vollständige CRUD-API aus einer einzigen Deklaration bauen.
+
+**Query-String / Query-Parameter** — der `?key=value`-Teil am Ende einer URL,
+verwendet, um Ergebnisse zu filtern, zu durchsuchen, zu sortieren oder zu paginieren — z. B.
+`/api/posts?status=published&page=2`. Jedes `key=value` ist ein Parameter.
+
+**Pagination (Seitennummerierung)** — das Aufteilen einer langen Ergebnisliste in Seiten, damit eine Response nicht
+riesig ist. Der **Envelope** ist die Hülle um die Seite, die dir auch die
+Gesamtwerte nennt — z. B. `{"count": 137, "page": 2, "results": [ … ]}`. Siehe
+[Pagination](viewsets.md#pagination).
+
+**`curl`** — ein Kommandozeilen-Werkzeug zum manuellen Senden von API-Requests. Die
+`curl ...`-Beispiele in dieser Dokumentation lassen dich einen Endpoint aus einem Terminal ausprobieren,
+ohne Code zu schreiben.
+
+---
+
+## Rustango-Bausteine
+
+Das sind die Teile, die du zusammensetzt, um eine App zu bauen. Jeder verlinkt auf seinen vollständigen Leitfaden.
+
+**Model (Modell)** — eine Beschreibung einer Art von Ding, die deine App speichert, wie ein `Post` oder
+ein `User`. Du schreibst es als Rust-`struct`; Rustango verwandelt es in eine
+Datenbanktabelle. Siehe den [ORM-Leitfaden](orm.md).
+
+**Migration** — eine aufgezeichnete Änderung der Form deiner Datenbank (Hinzufügen einer Tabelle,
+einer Spalte…). Du generierst eine mit `makemigrations` und wendest sie mit `migrate` an,
+sodass jede Umgebung mit derselben Datenbankstruktur endet.
+
+**Serializer** — der Übersetzer zwischen deinen Datenbankzeilen und dem JSON, das deine API
+sendet und empfängt. Er entscheidet, welche Felder sichtbar sind, benennt Felder um oder berechnet sie
+für die Ausgabe und validiert eingehende Daten. Er *formt* Daten; er speichert sie
+nicht (das tut das Modell). Siehe den [Serializer-Leitfaden](serializers.md).
+
+**ViewSet** — nimmt ein Modell und einen Serializer und erzeugt automatisch eine vollständige CRUD-**JSON-API**
+(alle fünf Verben oben), sodass du nicht jeden Endpoint von Hand schreibst.
+Die *API-View*. Siehe den [ViewSets-Leitfaden](viewsets.md).
+
+**HTML-View (Template-View, klassenbasierte View)** — das serverseitig gerenderte
+Gegenstück zu einem ViewSet: verwandelt ein Modell in HTML-**Seiten** — eine Listenseite, eine
+Detailseite und Erstellen-/Bearbeiten-/Löschen-Formulare — gerendert durch Tera-Templates,
+statt JSON. Die *HTML-View*. Siehe [HTML-Views](html-views.md).
+
+**Template** — eine Datei mit Platzhaltern (Rustango verwendet [Tera](https://keats.github.io/tera/),
+sehr ähnlich zu Django-Templates oder Jinja), die der Server mit Daten füllt, um eine
+HTML-Seite zu erzeugen. `{{ post.title }}` fügt einen Wert ein; `{% for … %}` schleift.
+
+**Router / Mount (Einhängen)** — der Router bildet eingehende URLs auf den Code ab, der sie
+verarbeitet. Ein ViewSet zu *mounten* bedeutet „seine Endpoints an einem gegebenen Pfad an deine
+App anhängen", z. B. die Posts-API unter `/api/posts` mounten. Siehe [URLs & Routing](urls.md).
+
+**Middleware (eine „Layer"/Schicht)** — Code, der *um* jeden Request herum läuft — vor deinem
+Handler und danach — für querschnittliche Belange wie Logging, Rate-Limiting,
+Security-Header oder CSRF. „Layer" ist Rustangos Wort für ein Stück
+Middleware. Siehe den [Middleware-Leitfaden](middleware.md).
+
+**Pool (oder Executor)** — die Datenbankverbindung, die dein Code zum Lesen und
+Schreiben verwendet. Rustango bittet dich, den Pool bei jedem Datenbankaufruf explizit zu übergeben
+(statt ihn in einem Global zu verstecken), sodass immer klar ist, was die
+Datenbank berührt. Du wirst `&pool` als letztes Argument von ORM-Aufrufen sehen.
+
+**QuerySet** — eine Datenbankabfrage, die du Schritt für Schritt in Rust aufbaust
+(`Post::objects().filter(...).order_by(...)`), bevor du sie ausführst. Sie ist lazy:
+Nichts trifft die Datenbank, bis du sie `fetch`st.
+
+**Feature-Flag** — ein An/Aus-Schalter, gesetzt in `Cargo.toml`, der ein Stück des Frameworks zur
+Buildzeit einschließt oder ausschließt. Er lässt dich deine App klein halten,
+indem nur kompiliert wird, was du verwendest. Die meisten Features sind standardmäßig an.
+
+**Scaffolding (Gerüstbau)** — Generator-Befehle (`startapp`, `make:serializer`,
+`make:viewset`…), die Startdateien für dich schreiben, damit du nicht von einer
+leeren Seite beginnst. Siehe [Scaffolding](scaffolding.md).
+
+---
+
+## Daten und die Datenbank
+
+**Feld / Spalte (field / column)** — ein Stück Daten an einem Modell, wie der `title` oder
+das `published_at` eines Posts. „Feld" ist die Rust-Seite; „Spalte" ist die Datenbankseite; sie
+entsprechen einander eins zu eins.
+
+**Primärschlüssel (primary key)** — die eindeutige id, die eine Zeile identifiziert, üblicherweise eine
+automatisch hochzählende Zahl namens `id`.
+
+**Fremdschlüssel (foreign key, FK)** — ein Feld an einem Modell, das auf die Zeile eines anderen Modells zeigt
+und eine Beziehung modelliert — z. B. hat ein `Post` einen Fremdschlüssel `author_id`, der
+auf einen `Author` zeigt. So referenzieren sich Zeilen gegenseitig.
+
+**NULL / nullable** — `NULL` ist das Wort der Datenbank für „kein Wert / leer". Ein
+**nullable** Feld darf leer sein; ein nicht-nullable Feld ist erforderlich.
+
+**Tri-Dialekt (tri-dialect)** — „funktioniert gleich auf allen drei unterstützten Datenbanken" —
+PostgreSQL, MySQL und SQLite. Wenn ein Feature tri-dialektfähig ist, kannst du die
+Datenbank wechseln, ohne deinen Code zu ändern.
+
+---
+
+## Ein paar Rust-Wörter
+
+Du musst kein Rust können, um die meisten Beispiele zu *lesen*, aber diese vier Wörter tauchen
+überall auf.
+
+**`struct`** — ein benanntes Bündel von Feldern, wie ein Datensatz oder eine Klasse mit nur
+Daten. Modelle und Serializer sind Structs.
+
+**Derive-Makro (`#[derive(Model)]`, `#[derive(Serializer)]`…)** — eine einzeilige
+Annotation über einem Struct, die dem Compiler sagt, einen Haufen
+Code für dich automatisch zu generieren (das Datenbank-Mapping, die JSON-Konvertierung, …). Es ist die Magie, die
+ein einfaches Struct in ein funktionierendes Modell oder Serializer verwandelt.
+
+**`async` / `.await`** — Rusts Art, mit Arbeit umzugehen, die Warten beinhaltet (eine
+Datenbankabfrage, ein Netzwerkaufruf). Eine mit `async` markierte Funktion ist „awaitable"; das
+`.await` nach einem Aufruf bedeutet „warte hier auf das Ergebnis". Alles, was die
+Datenbank berührt, ist `async`.
+
+**`Result` / `Option`** — wie Rust Ergebnisse meldet, statt Ausnahmen zu
+werfen. Ein `Result` ist „Erfolg *oder* ein Fehler"; ein `Option` ist „ein Wert *oder*
+nichts". Das `?`, das du nach manchen Aufrufen siehst, bedeutet „falls dies fehlgeschlagen ist, halte an und
+gib den Fehler zurück".
+
+---
+
+## Frameworks, mit denen wir vergleichen
+
+Diese Dokumentation sagt gelegentlich „wie X", um Leser zu unterstützen, die aus anderen
+Ökosystemen kommen. Die Vergleiche sind ein Bonus — du brauchst sie nie, um einem Leitfaden zu folgen.
+
+**Django** — ein populäres Python-Webframework. Rustango übernimmt viel von seiner Form
+(Modelle, Migrationen, eine Admin-Oberfläche, die `manage`-Befehle).
+
+**DRF (Django REST Framework)** — Djangos Erweiterung zum Bauen von REST-APIs.
+Rustangos Serializer und ViewSets sind daran modelliert, also bedeutet „DRF-Form"
+„so angeordnet, wie DRF es tut" — z. B. Validierungsfehler, die als JSON-Objekt
+mit Feldnamen als Schlüsseln zurückgegeben werden.
+
+**Laravel / Rails** — populäre PHP- und Ruby-Webframeworks, aus demselben
+Grund „wenn du dies verwendet hast, wird sich das vertraut anfühlen" erwähnt.

--- a/docs/de/html-views.md
+++ b/docs/de/html-views.md
@@ -1,0 +1,331 @@
+# HTML-Views — serverseitig gerenderte Seiten
+
+Ein HTML-View verwandelt ein Modell in **serverseitig gerenderte Webseiten** — eine
+Listenseite, eine Detailseite sowie Erstellungs-/Bearbeitungs-/Löschformulare — aus einer
+einzigen Deklaration. Es ist das **Gegenstück zu [ViewSets](viewsets.md)**: Während ein ViewSet
+JSON für API-Clients ausgibt, gibt ein HTML-View eine gerenderte Seite für einen Browser aus. Beide
+werden aus demselben `#[derive(Model)]` gebaut, und du kannst ein Modell *beides* zugleich
+ausliefern.
+
+Dies sind das Äquivalent von **Rustango** zu Djangos generischen klassenbasierten Views
+(`ListView`, `DetailView`, `CreateView`, `UpdateView`, `DeleteView`) oder Laravels
+Resource-Controllern, die Blade-Views zurückgeben. Sie rendern über [Tera](https://keats.github.io/tera/)-Templates.
+
+[![HTML-Views in Rustango: Ein Modell speist ListView, DetailView und CreateView/UpdateView/DeleteView, die jeweils ein Tera-Template zu einer serverseitig gerenderten Seite rendern](img/html-views.png)](img/html-views.png)
+
+> **Neu bei einem Begriff hier?** Falls *Modell*, *Template*, *Router* oder *serverseitig gerendert*
+> unbekannt sind, erklärt das [Glossar](glossary.md) jeden in einfacher Sprache.
+
+> **Quelle:** `rustango::template_views` (`ListView`, `DetailView`, `CreateView`,
+> `UpdateView`, `DeleteView`, `TemplateView`, `RedirectView`) — hinter dem
+> `template_views`-Feature (standardmäßig aktiviert).
+>
+> **Lauffähige Version:** Das API-vs-HTML-Beispiel unten ist durch den
+> Framework-Test
+> [`html_and_api_contrast_sqlite_live.rs`](../crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
+> festgeschrieben (`cargo test -p rustango --features sqlite --test html_and_api_contrast_sqlite_live`).
+> Die einzelnen Views werden von `template_view.rs` und
+> `template_views_context_object_name_sqlite_live.rs` abgedeckt.
+
+## Inhaltsverzeichnis
+
+- [API-Views vs HTML-Views — welche willst du?](#api-views-vs-html-views--which-do-you-want)
+- [Die fünf Modell-Views](#the-five-model-views)
+- [ListView](#listview) · [DetailView](#detailview)
+- [CreateView, UpdateView, DeleteView](#createview-updateview-deleteview)
+- [Der Tera-Kontext](#the-tera-context)
+- [TemplateView und RedirectView](#templateview-and-redirectview)
+- [Single-Tenant vs Multi-Tenant](#single-tenant-vs-multi-tenant)
+- [Ein Modell auf beide Arten ausliefern](#serving-one-model-both-ways)
+- [Siehe auch](#see-also)
+
+---
+
+## API-Views vs HTML-Views — welche willst du?
+
+Das ist die erste Entscheidung. Beide verwandeln ein Modell in Endpunkte; sie unterscheiden sich
+darin, *was herauskommt* und *wer aufruft*.
+
+| | **API-View** — [ViewSet](viewsets.md) | **HTML-View** — dieser Leitfaden |
+|---|---|---|
+| Modul | `rustango::viewset` | `rustango::template_views` |
+| Gibt zurück | **JSON-Daten** | eine **serverseitig gerenderte HTML-Seite** |
+| Gebaut für | SPAs, Mobile-Apps, andere Services | Browser, serverseitig gerenderte Sites, CRUD im Admin-Stil |
+| Ein „Erstellen" | `POST` JSON → `201` + das neue Objekt | `POST` eines Formulars → `303`-Redirect zu einer Erfolgsseite |
+| Bei fehlerhafter Eingabe | `400` + eine feldbasierte JSON-Fehlerkarte | rendert das Formular mit den angezeigten Fehlern neu |
+| Liest eine Liste als | eine paginierte JSON-Hülle | eine `<table>`/Schleife in deinem Template |
+| Üblicherweise authentifiziert per | Tokens / JWT / API-Keys | Session-Cookies |
+| Django-Analogon | DRF `ModelViewSet` | generische klassenbasierte Views |
+
+Du musst nicht global wählen — wähle pro Ressource, und du kannst **beide auf demselben Modell**
+einhängen (siehe [unten](#serving-one-model-both-ways)). Faustregeln:
+
+- Du baust ein **JSON-Backend** für ein Frontend-Framework oder eine Mobile-App → ViewSet.
+- Du baust eine **serverseitig gerenderte Site** (der Server gibt HTML-Seiten zurück) → HTML-Views.
+- Du brauchst beides (eine öffentliche API *und* interne CRUD-Seiten) → hänge beide ein.
+
+> Suchst du die JSON-Seite? Sie hat ihre eigene Vertiefung: [ViewSets — CRUD-REST-APIs](viewsets.md).
+
+---
+
+## Die fünf Modell-Views
+
+Jeder View ist `for_model(SCHEMA)` plus ein `.router(prefix, tera, pool)`. Sie am selben
+`prefix` (sagen wir `/posts`) einzuhängen, ergibt den klassischen CRUD-URL-Satz:
+
+| View | Rendert | Eingehängte Routen | Standard-Template |
+|---|---|---|---|
+| [`ListView`](#listview) | eine paginierte Liste | `GET <prefix>` | `<table>_list.html` |
+| [`DetailView`](#detailview) | eine Zeile | `GET <prefix>/{pk}` | `<table>_detail.html` |
+| [`CreateView`](#createview-updateview-deleteview) | ein Formular für einen neuen Datensatz | `GET`/`POST <prefix>/new` | `<table>_form.html` |
+| [`UpdateView`](#createview-updateview-deleteview) | ein vorausgefülltes Bearbeitungsformular | `GET`/`POST <prefix>/{pk}/edit` | `<table>_form.html` |
+| [`DeleteView`](#createview-updateview-deleteview) | eine Bestätigungsseite | `GET`/`POST <prefix>/{pk}/delete` | `<table>_confirm_delete.html` |
+
+`<table>` ist der Tabellenname des Modells, ein `Post` (Tabelle `posts`) sucht also nach
+`posts_list.html`, `posts_detail.html` und so weiter. Überschreibe jedes davon mit
+`.template("my_name.html")`.
+
+---
+
+## ListView
+
+Eine paginierte Listenseite. Du stellst ein Template bereit, das über `object_list` iteriert;
+der View übernimmt Paginierung, Sortierung, Filterung und Suche aus den Query-Parametern.
+
+```rust
+use rustango::template_views::ListView;
+use std::sync::Arc;
+use tera::Tera;
+
+let app = ListView::for_model(Post::SCHEMA)
+    .page_size(20)                       // rows per page (?page=N to navigate)
+    .order_by("published_at", true)      // default sort, true = DESC
+    .filter_fields(&["status", "author_id"])  // ?status=published
+    .search_fields(&["title", "body"])        // ?search=rust
+    .router("/posts", Arc::new(tera), pool);
+```
+
+Ein passendes `posts_list.html` — beachte `object_list` und die Paginierungsvariablen,
+die der View für dich einstempelt:
+
+```html
+<h1>Posts ({{ total }})</h1>
+{% for post in object_list %}
+  <article>
+    <h2><a href="/posts/{{ post.id }}">{{ post.title }}</a></h2>
+    <p>{{ post.body }}</p>
+  </article>
+{% endfor %}
+
+{% if has_prev %}<a href="?page={{ page - 1 }}">← prev</a>{% endif %}
+page {{ page }} / {{ total_pages }}
+{% if has_next %}<a href="?page={{ page + 1 }}">next →</a>{% endif %}
+```
+
+`?page=`, `?status=`, `?search=` und `?ordering=` funktionieren genauso wie bei einer
+ViewSet-Liste — der Unterschied liegt allein darin, dass das Ergebnis eine gerenderte Seite statt
+einer JSON-Hülle ist. Verwende `.context_object_name("posts")`, falls du lieber über `posts` als
+über `object_list` im Template iterierst.
+
+---
+
+## DetailView
+
+Eine Zeile, anhand der URL nachgeschlagen. Standardmäßig passt sie zum Primärschlüssel
+(`/posts/42`); richte sie mit `.lookup_field("slug")` auf eine andere Spalte aus, um schöne URLs zu
+erhalten (`/posts/my-first-post`). Eine fehlende Zeile ist ein `404`.
+
+```rust
+use rustango::template_views::DetailView;
+
+let app = DetailView::for_model(Post::SCHEMA)
+    .lookup_field("slug")          // GET /posts/{slug} instead of /posts/{id}
+    .router("/posts", Arc::new(tera), pool);
+```
+
+Das Template erhält die Zeile als `object`:
+
+```html
+<h1>{{ object.title }}</h1>
+<p>{{ object.body }}</p>
+<small>by author #{{ object.author_id }}</small>
+```
+
+---
+
+## CreateView, UpdateView, DeleteView
+
+Die Schreibseite. Jeder verarbeitet ein `GET` (ein Formular / eine Bestätigungsseite rendern) und
+ein `POST` (die Arbeit erledigen, dann **weiterleiten**). Die Weiterleitung-nach-POST ist das
+Standardmuster **Post/Redirect/Get** — es verhindert, dass ein Browser-Refresh erneut absendet.
+
+**CreateView** — `GET /posts/new` rendert ein leeres Formular; `POST /posts/new`
+fügt die Zeile ein und `303`t zu `success_url`:
+
+```rust
+use rustango::template_views::CreateView;
+
+let app = CreateView::for_model(Post::SCHEMA)
+    .success_url("/posts")         // where to send the browser after a save
+    .router("/posts", Arc::new(tera), pool);
+```
+
+Das Formular-Template (`posts_form.html`) wird mit UpdateView geteilt. `is_update`
+unterscheidet die beiden, und `errors` trägt etwaige Validierungsmeldungen zurück:
+
+```html
+<form method="post">
+  <input name="title" value="{{ object.title | default(value='') }}">
+  <textarea name="body">{{ object.body | default(value='') }}</textarea>
+  {% for field, msgs in errors %}
+    <p class="error">{{ field }}: {{ msgs | join(sep=', ') }}</p>
+  {% endfor %}
+  <button>{% if is_update %}Save{% else %}Create{% endif %}</button>
+</form>
+```
+
+**Validierung.** Schema-Regeln (Typ, `max_length`, NOT NULL…) werden automatisch
+erzwungen. Füge mit einem Closure-Validator eigene hinzu — bei `Err` wird das Formular
+mit den Meldungen und einem `422`-Status neu gerendert statt gespeichert:
+
+```rust
+use rustango::forms::FormErrors;
+
+CreateView::for_model(Post::SCHEMA)
+    .validator(|data| {
+        let mut errs = FormErrors::default();
+        if data.get("title").map_or(true, |t| t.len() < 5) {
+            errs.add("title", "must be at least 5 characters");
+        }
+        if errs.is_empty() { Ok(()) } else { Err(errs) }
+    })
+    .success_url("/posts")
+    .router("/posts", Arc::new(tera), pool);
+```
+
+Du kannst auch die Validatoren einer `#[derive(Form)]`-Struktur mit `.form::<F>()` wiederverwenden
+(vorerst nur Validierung — siehe die API-Dokumentation).
+
+**UpdateView** — `GET /posts/{pk}/edit` rendert dasselbe Formular, vorausgefüllt aus der
+Zeile (`object` ist befüllt, `is_update` ist `true`); `POST` aktualisiert und `303`t.
+
+```rust
+use rustango::template_views::UpdateView;
+
+UpdateView::for_model(Post::SCHEMA)
+    .success_url("/posts")
+    .router("/posts", Arc::new(tera), pool);
+```
+
+**DeleteView** — `GET /posts/{pk}/delete` rendert eine Bestätigungsseite
+(`posts_confirm_delete.html`, mit `object`); `POST` löscht und `303`t.
+
+```rust
+use rustango::template_views::DeleteView;
+
+DeleteView::for_model(Post::SCHEMA)
+    .success_url("/posts")
+    .router("/posts", Arc::new(tera), pool);
+```
+
+Hänge alle fünf am selben Präfix ein und du hast vollständiges HTML-CRUD:
+
+```rust
+let app = axum::Router::new()
+    .merge(ListView::for_model(Post::SCHEMA).router("/posts", tera.clone(), pool.clone()))
+    .merge(DetailView::for_model(Post::SCHEMA).router("/posts", tera.clone(), pool.clone()))
+    .merge(CreateView::for_model(Post::SCHEMA).success_url("/posts").router("/posts", tera.clone(), pool.clone()))
+    .merge(UpdateView::for_model(Post::SCHEMA).success_url("/posts").router("/posts", tera.clone(), pool.clone()))
+    .merge(DeleteView::for_model(Post::SCHEMA).success_url("/posts").router("/posts", tera, pool));
+```
+
+---
+
+## Der Tera-Kontext
+
+Jeder View stempelt einen konsistenten Kontext ein, damit Templates sauber zwischen ihnen portieren:
+
+| View | Im Template verfügbare Variablen |
+|---|---|
+| `ListView` | `object_list` (die Zeilen der Seite), `page`, `page_size`, `total`, `total_pages`, `has_next`, `has_prev` |
+| `DetailView` | `object` (die Zeile) |
+| `CreateView` / `UpdateView` | `object` (leer beim Erstellen, vorausgefüllt beim Aktualisieren), `is_update` (bool), `errors`, `values` |
+| `DeleteView` | `object` (die zu bestätigende Zeile) |
+
+Zeilen werden als schlichte, nach Spaltennamen indizierte Maps bereitgestellt (`{{ post.title }}`),
+wobei SQL-`NULL` als `null` gerendert wird. Verwende `.context_object_name("posts" / "post")`, um
+neben `object_list` / `object` einen freundlicheren Alias hinzuzufügen.
+
+---
+
+## TemplateView und RedirectView
+
+Zwei modellfreie Helfer für die Seiten, die jede Site hat:
+
+**TemplateView** — rendert ein statisches Template mit einem festen Kontext (eine „Über uns"-Seite,
+eine Landingpage). Kein Modell, keine Datenbank:
+
+```rust
+use rustango::template_views::TemplateView;
+
+let app = TemplateView::new("about.html")
+    .context_value("title", "About us")
+    .router("/about", Arc::new(tera));
+```
+
+**RedirectView** — eine permanente oder temporäre Weiterleitung an einer URL (für verschobene Seiten):
+
+```rust
+use rustango::template_views::RedirectView;
+
+let app = RedirectView::to("/posts").router("/old-posts");
+```
+
+---
+
+## Single-Tenant vs Multi-Tenant
+
+Jeder Modell-View bringt zwei Router-Konstruktoren mit — derselbe Builder, wähle den, der dazu
+passt, wie deine App Datenbankverbindungen verwaltet:
+
+- **`.router(prefix, tera, pool)`** — Single-Tenant; erfasst zur Einhängezeit einen Pool.
+  Das nutzen die Beispiele oben.
+- **`.tenant_router(prefix, tera)`** — Multi-Tenant; löst eine Verbindung pro Request aus dem
+  [`Tenant`](https://docs.rs)-Extractor auf. Verfügbar mit den Features
+  `template_views` + `tenancy`. Templates portieren unverändert zwischen beiden.
+
+Das spiegelt die ViewSet-Aufteilung (`router` / `router_pool` vs `tenant_router`).
+
+---
+
+## Ein Modell auf beide Arten ausliefern
+
+Du bist nicht auf eine Eingangstür beschränkt. Hänge eine JSON-API *und* HTML-Seiten über dasselbe
+Modell und denselben Pool ein — eine öffentliche API für Clients, serverseitig gerenderte Seiten
+für Menschen:
+
+```rust
+use rustango::viewset::ViewSet;
+use rustango::template_views::{ListView, DetailView};
+
+let app = axum::Router::new()
+    // JSON for API clients:
+    .merge(ViewSet::for_model(Post::SCHEMA).router_pool("/api/posts", pool.clone()))
+    // HTML pages for browsers:
+    .merge(ListView::for_model(Post::SCHEMA).router("/posts", tera.clone(), pool.clone()))
+    .merge(DetailView::for_model(Post::SCHEMA).router("/posts", tera, pool));
+```
+
+Jetzt gibt `GET /api/posts` die paginierte JSON-Hülle zurück und `GET /posts`
+gibt eine gerenderte HTML-Liste zurück — dieselben Zeilen, derselbe Pool, zwei Formen. Genau dieses
+Setup ist es, was der [zugrunde liegende Test](../crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
+behauptet.
+
+---
+
+## Siehe auch
+
+- [ViewSets — CRUD-REST-APIs](viewsets.md) — das JSON/API-Gegenstück, ausführlich.
+- [Admin](admin.md) — der automatisch generierte Admin baut auf denselben Views auf.
+- [URLs & Routing](urls.md) — wie du diese Router zu deiner App zusammensetzt.
+- [Serializer](serializers.md) — forme das JSON, wenn du den API-Weg gehst.

--- a/docs/de/i18n.md
+++ b/docs/de/i18n.md
@@ -1,0 +1,272 @@
+# Internationalisierung (i18n)
+
+Internationalisierung bedeutet, Ihre App in der Sprache des Nutzers auszuliefern.
+**Rustango** teilt sie in zwei Hälften: das **Auflösen**, welche Locale eine
+Anfrage möchte (Cookie → `Accept-Language` → Standard — behandelt in
+[Middleware](middleware.md)), und das **Übersetzen** von Strings in diese Locale,
+worum es in diesem Leitfaden geht. Der `Translator` lädt Nachrichtenkataloge pro
+Locale, ersetzt `{placeholders}`, behandelt Pluralformen und fällt elegant zurück
+— Djangos `gettext` / `{% trans %}`, in Rust.
+
+[![i18n in Rustango: Ein Translator hält Kataloge pro Locale; gettext schlägt einen Schlüssel mit Fallback nach (Locale → Basissprache → Standard → der Schlüssel selbst), ersetzt {name}-Platzhalter, und ngettext wählt Singular vs. Plural](img/i18n.png)](img/i18n.png)
+
+> **Ein Begriff hier neu?** *Locale*, *Katalog*, *Accept-Language*,
+> *Pluralisierung*, *RTL* — siehe das [Glossar](glossary.md).
+
+> **Quelle:** `rustango::i18n` (`Translator`, `Locale`, `negotiate_language`,
+> `plural_category`, `is_rtl_language`, `language_native_name` und die
+> `tera_tags`-Template-Bindings) — immer kompiliert. Die *Middleware* für
+> Locale/Zeitzone pro Anfrage liegt in `rustango::i18n::middleware` / `::timezone`
+> (siehe [Middleware](middleware.md)).
+>
+> **Lauffähige Version:** Jeder Ausschnitt ist aus
+> [`i18n_doc.rs`](../crates/rustango/tests/i18n_doc.rs) kopiert
+> (`cargo test -p rustango --test i18n_doc`); DB-gestützte Übersetzungs-Overrides
+> werden im Realbetrieb von
+> [`i18n_db_overrides_sqlite_live.rs`](../crates/rustango/tests/i18n_db_overrides_sqlite_live.rs)
+> erprobt.
+
+## Inhaltsverzeichnis
+
+- [Die zwei Hälften von i18n](#the-two-halves-of-i18n)
+- [Schritt 1 — Einen Translator bauen](#step-1--build-a-translator)
+- [Schritt 2 — Strings übersetzen (gettext)](#step-2--translate-strings-gettext)
+- [Platzhalter](#placeholders)
+- [Pluralisierung](#pluralization)
+- [Fallback-Reihenfolge](#fallback-order)
+- [Die Sprache aushandeln](#negotiating-the-language)
+- [Rechts-nach-links-Sprachen](#right-to-left-languages)
+- [In Templates übersetzen (Tera)](#translating-in-templates-tera)
+- [Kataloge laden + Laufzeit-Overrides](#loading-catalogs--runtime-overrides)
+- [Siehe auch](#see-also)
+
+---
+
+## Die zwei Hälften von i18n
+
+| Anliegen | Wo | Was es tut |
+|---|---|---|
+| Die Locale **auflösen** | [`i18n::middleware::LocaleMiddleware`](middleware.md#locale-aware-middleware) | wählt eine Locale pro Anfrage (Cookie → Accept-Language → Standard) und stellt den `ActiveLocale`-Extractor bereit |
+| Strings **übersetzen** | `i18n::Translator` (dieser Leitfaden) | schlägt einen Nachrichtenschlüssel im Katalog der aktiven Locale nach |
+| Daten in der TZ des Nutzers rendern | [`i18n::timezone`](middleware.md#timezone-aware-middleware) | der `{{ ts \| localtime }}`-Filter |
+
+Sie verdrahten die Middleware einmal und übersetzen dann mit der von ihr
+aufgelösten Locale.
+
+---
+
+## Schritt 1 — Einen Translator bauen
+
+Ein `Translator` hält einen **Katalog** (eine `key → message`-Map) pro Locale.
+Bauen Sie ihn mit einer Standard-Locale und fügen Sie dann Kataloge hinzu:
+
+```rust
+use rustango::i18n::{Locale, Translator};
+use std::collections::HashMap;
+
+let mut en = HashMap::new();
+en.insert("greeting".to_owned(), "Hello".to_owned());
+en.insert("welcome".to_owned(), "Welcome, {name}!".to_owned());
+
+let mut fr = HashMap::new();
+fr.insert("greeting".to_owned(), "Bonjour".to_owned());
+
+let translator = Translator::new(Locale::new("en"))   // default locale
+    .add_locale(Locale::new("en"), en)
+    .add_locale(Locale::new("fr"), fr);
+```
+
+Halten Sie den `Translator` in Ihrem App-State (er ist günstig zum Clone-Teilen)
+und schlagen Sie Strings mit der von der Middleware aufgelösten
+[`ActiveLocale`](middleware.md#locale-aware-middleware) nach.
+
+---
+
+## Schritt 2 — Strings übersetzen (gettext)
+
+`gettext(locale, key)` gibt die Nachricht für diese Locale zurück — und degradiert
+sicher, wenn etwas fehlt:
+
+```rust
+translator.gettext("en", "greeting");      // "Hello"
+translator.gettext("fr", "greeting");      // "Bonjour"
+
+translator.gettext("en", "missing.key");   // "missing.key"  — returns the key, never panics
+translator.gettext("de", "greeting");      // "Hello"        — unknown locale → default
+```
+
+Ein fehlender Schlüssel gibt den Schlüssel selbst zurück, sodass ein nicht
+übersetzter String sichtbar auftaucht, statt die Seite zum Absturz zu bringen.
+
+---
+
+## Platzhalter
+
+Nachrichten können `{name}`-Platzhalter tragen; `translate` ersetzt sie aus
+Schlüssel/Wert-Paaren:
+
+```rust
+// catalog: "welcome" = "Welcome, {name}!"
+translator.translate("en", "welcome", &[("name", "Ada")]);   // "Welcome, Ada!"
+```
+
+`gettext` ist die Kurzform ohne Platzhalter; `translate` (und `gettext_fmt`)
+nehmen Parameter.
+
+---
+
+## Pluralisierung
+
+Pluralformen unterscheiden sich nach Sprache *und* Anzahl. `ngettext` ist die
+Zwei-Formen-Kurzform: Sie wählt den Singular-Schlüssel für die CLDR-Kategorie
+`one` und ansonsten den Plural-Schlüssel und bindet `{count}` automatisch:
+
+```rust
+// catalog: "cart.one" = "1 item",  "cart.other" = "{count} items"
+translator.ngettext("en", "cart.one", "cart.other", 1);   // "1 item"
+translator.ngettext("en", "cart.one", "cart.other", 5);   // "5 items"
+```
+
+Verwenden Sie `ngettext_fmt`, um zusätzliche Platzhalter neben `{count}` zu
+übergeben.
+
+### Sprachen mit mehr als zwei Formen
+
+Polnisch, Ukrainisch, Russisch, Arabisch und andere haben `few` / `many`-Formen,
+die ein Singular/Plural-Paar nicht ausdrücken kann. `plural_category(locale, n)`
+gibt die CLDR-Kategorie zurück (`one` / `few` / `many` / `other`), und
+`translate_plural` wählt die passende Form aus einem **Katalog pro Kategorie** —
+ein Eintrag pro Schlüssel, der alle seine Formen hält:
+
+```rust
+use rustango::i18n::plural_category;
+
+plural_category("en", 1);   // "one"
+plural_category("fr", 0);   // "one"   — French treats 0 as singular
+plural_category("pl", 2);   // "few"   — Polish 2–4
+plural_category("pl", 5);   // "many"
+
+// pl plural catalog: "deleted_pages" → { one, few, many }
+let n = 5;
+translator.translate_plural("pl", "deleted_pages", n, &[("count", &n.to_string())]);
+// → "Usunięto 5 stron."   (the `many` form)
+```
+
+Eine fehlende Form fällt auf `other` zurück, dann auf den skalaren Lookup (und
+schließlich den Schlüssel), sodass eine nicht übersetzte Sprache dennoch rendert.
+Ostasiatische Sprachen (`zh`, `ja`, …) haben eine einzige `other`-Form.
+
+---
+
+## Fallback-Reihenfolge
+
+Lookups laufen eine Kette entlang, sodass eine partielle Übersetzung nie eine
+Lücke lässt: die **angefragte Locale → ihre Basissprache → die Fallback-Kette →
+die Standard-Locale → der Schlüssel selbst**. So löst eine
+frankokanadische Anfrage gegen den `fr`-Katalog auf:
+
+```rust
+// only "fr" is registered, not "fr-CA"
+translator.gettext("fr-CA", "greeting");   // "Bonjour"  — base-language fallback
+```
+
+Setzen Sie zusätzliche Fallbacks mit
+`Translator::new(default).with_fallback_chain(&["en"])`.
+
+---
+
+## Die Sprache aushandeln
+
+Wenn Sie die Locale selbst auflösen (außerhalb der Middleware), parst
+`negotiate_language` einen Browser-`Accept-Language`-Header und wählt die beste
+Übereinstimmung aus den von Ihnen unterstützten Locales:
+
+```rust
+use rustango::i18n::negotiate_language;
+
+negotiate_language("fr-FR,fr;q=0.9,en;q=0.8", &["en", "fr"]);   // Some("fr")
+negotiate_language("de,ja;q=0.5", &["en", "fr"]);               // None — fall back to default
+```
+
+Genau das nutzt `LocaleMiddleware` unter der Haube.
+
+---
+
+## Rechts-nach-links-Sprachen
+
+`is_rtl_language` (und `Locale::direction()`) sagen Ihnen, ob Sie `dir="rtl"` auf
+der Seite setzen sollten — für Arabisch, Hebräisch, Persisch usw.:
+
+```rust
+use rustango::i18n::is_rtl_language;
+
+is_rtl_language("ar");   // true
+is_rtl_language("en");   // false
+```
+
+In einem Template: `<html dir="{{ direction }}">`, gespeist aus der
+`ActiveLocale`. Siehe die [RTL-Notiz in Middleware](middleware.md#locale-aware-middleware).
+
+---
+
+## In Templates übersetzen (Tera)
+
+Alles Obige ist die Rust-API; in Tera-Templates — HTML-Views und die Admin-UI —
+wird derselbe `Translator` als Filter/Funktionen bereitgestellt. Registrieren Sie
+sie einmal gegen den Translator, und die aktive Locale (die von der Middleware
+gesetzte Kontextvariable `LANG`) treibt jeden Lookup:
+
+```rust
+rustango::i18n::tera_tags::register(&mut tera, translator.clone());
+```
+
+```jinja
+{{ "Save" | translate(locale=LANG) }}
+<button title="{{ "Delete" | translate(locale=LANG) }}">…</button>
+
+{# count-aware: pass the count both as the selector `n` and as a {count} arg #}
+{{ translate_plural(key="deleted_pages", n=num, locale=LANG, count=num) }}
+
+<html lang="{{ LANG }}" dir="{{ get_text_direction(locale=LANG) }}">
+```
+
+Der **Schlüssel ist der englische Ausgangs-String** (gettext-Stil), sodass ein
+nicht übersetzter String auf Englisch rendert statt leer — Sie umschließen einen
+UI-String zuerst und übersetzen ihn später, ohne eine Schlüssel-Registry zu
+pflegen.
+
+Genau so **lokalisiert rustango-cms seinen Admin**: Jeder Chrome-String läuft
+durch `translate` / `translate_plural`, Kataloge werden pro Locale unter
+`src/admin/locales/` ausgeliefert, die aktive Locale wird über die Kette Cookie →
+Nutzerpräferenz → `Accept-Language` → Tenant-Standard aufgelöst, und ein
+Seitenleisten-Umschalter plus eine Nutzer-Einstellung **Preferences → Language**
+lassen Redakteure wählen. Betreiber-Änderungen über die DB-Override-Schicht (unten)
+wirken ohne Redeploy.
+
+---
+
+## Kataloge laden + Laufzeit-Overrides
+
+In der Produktion bauen Sie selten Maps von Hand. Zwei Loader:
+
+- **`Translator::from_directory(dir, default)`** — lädt beim Start eine
+  Katalogdatei pro Locale aus einem Verzeichnis.
+- **`Translator::from_settings(&settings.i18n)`** — verdrahtet ihn aus Ihrer
+  Konfiguration.
+
+Und Betreiber können Übersetzungen **zur Laufzeit** ohne Redeploy bearbeiten:
+`set_override(locale, key, value)` (oder `load_overrides(rows)` aus einer Tabelle)
+legen sich über die Datei-Kataloge und gewinnen für diesen Schlüssel. Dieser
+DB-Override-Fluss treibt den Admin-Übersetzungseditor und wird in
+`i18n_db_overrides_sqlite_live.rs` im Realbetrieb erprobt.
+
+---
+
+## Siehe auch
+
+- [Middleware](middleware.md) — das Auflösen der Locale pro Anfrage
+  (`LocaleMiddleware`, `ActiveLocale`) und der Zeitzonenfilter
+  `{{ ts | localtime }}`.
+- [HTML-Views](html-views.md) · [Der Admin](admin.md) — wo übersetzte Strings und
+  der Übersetzungseditor auftauchen.
+- [Glossar](glossary.md) — Locale, Katalog, RTL und Verwandte in klarer Sprache.

--- a/docs/de/index.toml
+++ b/docs/de/index.toml
@@ -1,19 +1,19 @@
-# Table des matières de la documentation (français).
+# Inhaltsverzeichnis der Dokumentation (Deutsch).
 # Mirrors docs/index.toml; filenames match English so the site maps pages 1:1.
 
 [[section]]
-title = "Premiers pas"
-slug = "premiers-pas"
+title = "Erste Schritte"
+slug = "erste-schritte"
 pages = ["getting-started.md", "scaffolding.md", "glossary.md"]
 
 [[section]]
-title = "Guides"
-slug = "guides"
+title = "Anleitungen"
+slug = "anleitungen"
 pages = ["models.md", "orm.md", "admin.md", "serializers.md", "viewsets.md", "html-views.md", "openapi.md", "query-method.md", "mcp.md", "urls.md", "manage.md", "migrations.md", "middleware.md", "jobs.md", "websockets.md", "caching.md", "files.md", "i18n.md", "email.md", "testing.md", "security.md"]
 
 [[section]]
-title = "Authentification"
-slug = "authentification"
+title = "Authentifizierung"
+slug = "authentifizierung"
 pages = ["auth-passwords.md", "auth-sessions.md", "auth-backends.md", "auth-decorators.md", "auth-jwt.md", "auth-jwt-api.md", "auth-api-keys.md", "auth-hmac.md", "auth-flows.md", "sso.md"]
 
 [[section]]
@@ -22,6 +22,6 @@ slug = "benchmarks"
 pages = ["benchmarks.md"]
 
 [[section]]
-title = "Référence"
-slug = "reference"
+title = "Referenz"
+slug = "referenz"
 pages = ["api-conventions.md"]

--- a/docs/de/jobs.md
+++ b/docs/de/jobs.md
@@ -1,0 +1,379 @@
+# Hintergrund-Jobs
+
+Manche Arbeit sollte nicht während eines Requests passieren — eine
+Willkommens-E-Mail senden, einen Upload skalieren, eine Drittanbieter-API
+synchronisieren. Es inline zu tun lässt den Benutzer warten und koppelt die
+Response an einen unzuverlässigen externen Aufruf. Ein **Hintergrund-Job**
+verschiebt diese Arbeit auf eine Queue: der Handler kehrt sofort zurück, und ein
+Pool von Workern führt den Job Augenblicke später aus, mit **automatischen
+Retries** und einem **Dead-Letter**-Pfad für Fehlschläge. Das ist Django-Q /
+Celery / Laravel-Queues, in Rust.
+
+[![Background jobs in Rustango: a handler dispatches a Job onto a queue, worker tasks run it, retryable failures back off and retry, fatal ones go to a dead-letter handler](img/jobs.png)](img/jobs.png)
+
+> **Ein Begriff hier neu für dich?** *Queue*, *Worker*, *Retry/Backoff*,
+> *Dead-Letter* — siehe das [Glossar](glossary.md).
+
+> **Quelle:** `rustango::jobs` (`Job`, `JobQueue`, `InMemoryJobQueue`,
+> `JobError`, `JobDeadLetter`) und `rustango::jobs::DatabaseJobQueue` (die
+> tabellengestützte Queue, Alias von `pg::PgJobQueue`) — hinter der
+> `jobs`-Feature (standardmäßig aktiv).
+>
+> **Ausführbare Version:** die In-Memory-, Retry- und Dead-Letter-Snippets sind
+> aus [`jobs_doc.rs`](../crates/rustango/tests/jobs_doc.rs) kopiert
+> (`cargo test -p rustango --test jobs_doc`); die persistente Queue wird per
+> Dogfooding auf SQLite durch
+> [`jobs_sqlite_live.rs`](../crates/rustango/tests/jobs_sqlite_live.rs)
+> erprobt (`cargo test -p rustango --features sqlite,jobs-postgres --test jobs_sqlite_live`).
+
+## Inhaltsverzeichnis
+
+- [Schritt 1 — Einen Job definieren](#step-1--define-a-job)
+- [Schritt 2 — Eine Queue starten](#step-2--start-a-queue)
+- [Schritt 3 — Aus einem Handler dispatchen](#step-3--dispatch-from-a-handler)
+- [Schritt 4 — In deine App verdrahten](#step-4--wire-it-into-your-app) — das vollständige Beispiel
+- [Die Worker laufen lassen (CLI + Produktion)](#running-the-workers-cli--production)
+- [Retries und Backoff](#retries-and-backoff)
+- [Der Dead-Letter-Handler](#the-dead-letter-handler)
+- [Die persistente Queue (Produktion)](#the-persistent-queue-production)
+- [Referenz](#reference)
+- [Siehe auch](#see-also)
+
+---
+
+## Schritt 1 — Einen Job definieren
+
+Ein Job ist ein serialisierbares Struct, das `Job` implementiert. Die Payload
+ist das, was in die Queue gestellt wird (nach JSON serialisiert); `run()` ist
+die Arbeit. `NAME` routet eine in die Queue gestellte Payload zurück zu ihrem
+Handler, er muss also eindeutig sein.
+
+Erzeuge ein Gerüst mit der CLI — `cargo run -- make:job WelcomeEmail` — oder
+schreibe es von Hand:
+
+```rust
+use rustango::jobs::{Job, JobError};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct WelcomeEmail {
+    user_id: i64,
+}
+
+#[async_trait::async_trait]   // add `async-trait` to your Cargo.toml
+impl Job for WelcomeEmail {
+    const NAME: &'static str = "welcome_email";
+
+    async fn run(&self) -> Result<(), JobError> {
+        // ... look up the user and send the email
+        Ok(())
+    }
+}
+```
+
+`run()` gibt zurück:
+
+- `Ok(())` — erledigt.
+- `Err(JobError::Retryable(msg))` — transient; der Worker wiederholt mit
+  Backoff.
+- `Err(JobError::Fatal(msg))` — permanent; überspringe Retries, Dead-Letter es
+  sofort.
+
+Überschreibe `const MAX_ATTEMPTS: u32 = 3;` auf dem Impl, um die
+Retry-Obergrenze zu ändern (Standard 5).
+
+---
+
+## Schritt 2 — Eine Queue starten
+
+Für einen einzelnen Prozess (und für Dev und Tests) führt `InMemoryJobQueue`
+Jobs auf tokio-Worker-Tasks aus — ohne Datenbank. **Registriere jeden Job-Typ,
+dann `start()` die Worker** (Jobs werden nicht aufgenommen, bis du es tust):
+
+```rust
+use rustango::jobs::{InMemoryJobQueue, JobQueue};
+use std::sync::Arc;
+
+let queue = Arc::new(InMemoryJobQueue::with_workers(4));   // 4 worker tasks
+queue.register::<WelcomeEmail>().await;                    // before start/dispatch
+queue.start().await;
+
+// ... app runs ...
+
+queue.shutdown().await;   // on shutdown: drain in-flight jobs, then stop
+```
+
+Behalte den `Arc<InMemoryJobQueue>` in deinem App-State, damit Handler ihn
+erreichen können.
+
+> **In-Memory bedeutet In-Memory.** In der Queue stehende oder in Bearbeitung
+> befindliche Jobs gehen **beim Neustart verloren**. Für alles, dessen Verlust
+> du dir nicht leisten kannst, verwende die [persistente
+> Queue](#the-persistent-queue-production).
+
+---
+
+## Schritt 3 — Aus einem Handler dispatchen
+
+Sobald die Queue läuft, ist das Dispatchen ein einziger Aufruf — er stellt in
+die Queue und kehrt sofort zurück, sodass der Request nicht auf die Arbeit
+wartet:
+
+```rust
+queue.dispatch(&WelcomeEmail { user_id: 42 }).await?;
+```
+
+Ein Worker nimmt ihn auf und führt `run()` Augenblicke später aus. Durchgängig
+verifiziert: alle drei dispatchten Jobs laufen auf den Workern.
+
+```rust
+for user_id in 1..=3 {
+    queue.dispatch(&WelcomeEmail { user_id }).await.unwrap();
+}
+// → all three WelcomeEmail::run() calls execute on the worker pool
+```
+
+---
+
+## Schritt 4 — In deine App verdrahten
+
+Die Schritte 1–3 zusammengesetzt: baue die Queue und registriere jeden Job
+**einmalig beim Boot**, starte die Worker, übergib die Queue an deine Routen,
+damit Handler sie erreichen können, und drain dann beim Shutdown. Die Queue lebt
+in deiner `main.rs`:
+
+```rust
+// src/main.rs
+use std::sync::Arc;
+use rustango::jobs::{InMemoryJobQueue, JobQueue};
+use rustango::manage::Cli;
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Build the queue + register every job type BEFORE starting workers.
+    let queue = Arc::new(InMemoryJobQueue::with_workers(4));
+    queue.register::<WelcomeEmail>().await;
+    queue
+        .on_dead_letter(|dl| async move {
+            tracing::error!(job = dl.name, attempts = dl.attempts, error = %dl.error,
+                            "job dead-lettered");
+        })
+        .await;
+
+    // 2. Start the workers — tokio tasks that run inside THIS process.
+    queue.start().await;
+
+    // 3. Share the queue with handlers (axum extension/state).
+    let app = urls::api().layer(axum::Extension(queue.clone()));
+
+    // 4. Boot the server. Cli::run() blocks until Ctrl-C / SIGTERM.
+    Cli::new().api(app).with_health().run().await?;
+
+    // 5. On shutdown: drain in-flight jobs, then stop.
+    queue.shutdown().await;
+    Ok(())
+}
+```
+
+Ein Handler dispatcht, indem er die Queue aus dem Request wieder ausliest:
+
+```rust
+use axum::Extension;
+use std::sync::Arc;
+use rustango::jobs::{InMemoryJobQueue, JobQueue};
+
+async fn signup(Extension(queue): Extension<Arc<InMemoryJobQueue>>) -> StatusCode {
+    // ... create the user ...
+    queue.dispatch(&WelcomeEmail { user_id: 42 }).await.ok();  // returns instantly
+    StatusCode::CREATED
+}
+```
+
+> **Speichere den konkreten Queue-Typ.** Der `JobQueue`-Trait ist **nicht
+> object-safe** (seine `register`/`dispatch` sind generisch), du kannst also
+> nicht `Arc<dyn JobQueue>` im State halten — behalte den konkreten
+> `Arc<InMemoryJobQueue>` (oder `Arc<DatabaseJobQueue>`).
+
+---
+
+## Die Worker laufen lassen (CLI + Produktion)
+
+`start()` spawnt die Worker als **tokio-Tasks innerhalb des aktuellen
+Prozesses**. Wenn du also deine App mit der CLI startest — `cargo run` (das den
+Server ausführt) — laufen die Worker direkt daneben. Für die meisten Apps ist
+das alles, was du brauchst: **ein Prozess bedient Requests *und* leert die
+Queue**; es gibt keinen separaten Worker-Befehl.
+
+```bash
+cargo run                 # starts the server AND the in-process workers
+cargo run -- make:job WelcomeEmail   # scaffold a new job type
+```
+
+### Ein dedizierter Worker-Prozess (Produktion)
+
+Im großen Maßstab willst du die Worker oft **getrennt** von der Web-Ebene — damit
+ein Traffic-Spike keine Jobs aushungern kann und du beide unabhängig skalierst.
+Mit der [persistenten Queue](#the-persistent-queue-production) zieht jeder Prozess
+aus derselben `rustango_jobs`-Tabelle, führe also einfach ein zweites,
+serverloses Binary aus, das die Queue baut, startet und bis zu einem Signal
+blockiert:
+
+```rust
+// src/bin/worker.rs — run with `cargo run --bin worker`
+use std::sync::Arc;
+use rustango::jobs::{DatabaseJobQueue, JobQueue};
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pool = /* connect your tri-dialect Pool */;
+    DatabaseJobQueue::ensure_table_pool(&pool).await?;
+
+    let queue = Arc::new(DatabaseJobQueue::with_workers_pool(pool, 8));
+    queue.register::<WelcomeEmail>().await;   // register the SAME job types
+    queue.start().await;
+
+    tokio::signal::ctrl_c().await?;            // block until Ctrl-C / SIGTERM
+    queue.shutdown().await;                     // drain in-flight, then exit
+    Ok(())
+}
+```
+
+Deploye es als eigenen Container/Service und skaliere auf **N Replicas** — sie
+ziehen alle sicher aus der geteilten Tabelle. Der Web-Prozess muss dann nur noch
+`dispatch` (er muss keine Worker `start()`). Kopple den Worker mit einem
+periodischen [`reclaim_stuck_jobs_pool`](#the-persistent-queue-production)-Sweep,
+um Jobs eines abgestürzten Workers zurückzuholen.
+
+---
+
+## Retries und Backoff
+
+Ein Job, der `Retryable` zurückgibt, wird mit **exponentiellem Backoff** (1s, 2s,
+4s, 8s, …) bis zu `MAX_ATTEMPTS` erneut in die Queue gestellt. Verwende es für
+transiente Fehler — einen Timeout, eine rate-limitierte API, einen Deadlock:
+
+```rust
+#[async_trait::async_trait]
+impl Job for FlakyImport {
+    const NAME: &'static str = "flaky_import";
+    async fn run(&self) -> Result<(), JobError> {
+        match call_external_api().await {
+            Ok(_)  => Ok(()),
+            Err(e) => Err(JobError::Retryable(e.to_string())),   // try again later
+        }
+    }
+}
+```
+
+Der zugrunde liegende Test dispatcht einen Job, der einmal fehlschlägt und dann
+gelingt, und stellt sicher, dass er **mehr als einmal lief und schließlich
+gelang** — das Retry findet tatsächlich statt.
+
+---
+
+## Der Dead-Letter-Handler
+
+Wenn ein Job seine Retries erschöpft — oder sofort `Fatal` zurückgibt — wird er
+an den **Dead-Letter**-Callback übergeben, statt zu verschwinden. Registriere
+einen (vor `start`), um den Fehlschlag zu loggen, zu alarmieren oder zu
+persistieren:
+
+```rust
+queue
+    .on_dead_letter(|dl| async move {
+        // dl: JobDeadLetter { name, payload, attempts, error }
+        tracing::error!(job = dl.name, attempts = dl.attempts, error = %dl.error,
+                        "job dead-lettered");
+    })
+    .await;
+```
+
+Ein `Fatal`-Fehler überspringt Retries und landet hier beim ersten Versuch:
+
+```rust
+async fn run(&self) -> Result<(), JobError> {
+    Err(JobError::Fatal("unprocessable payload".into()))   // → dead-letter now
+}
+```
+
+Der Test bestätigt, dass der Callback für einen `Fatal`-Job genau einmal
+feuert, mit intaktem `name` und `error` des Jobs.
+
+---
+
+## Die persistente Queue (Produktion)
+
+`InMemoryJobQueue` ist Einzelprozess und vergisst beim Neustart. Für echte
+Deployments — mehrere Worker, mehrere Replicas, Jobs, die einen Absturz
+überstehen müssen — verwende **`DatabaseJobQueue`** (derselbe Typ wie
+`PgJobQueue`). Jobs leben in einer `rustango_jobs`-Tabelle; Worker nehmen sie
+mit einem transaktionsbegrenzten `UPDATE … RETURNING` auf, es ist also über
+Prozesse hinweg sicher. Sie ist **tri-dialektisch** (PostgreSQL, MySQL, SQLite).
+Die `Job`-Definitionen aus Schritt 1 bleiben unverändert.
+
+```rust
+use rustango::jobs::DatabaseJobQueue;   // = rustango::jobs::pg::PgJobQueue
+use rustango::jobs::JobQueue;
+use std::sync::Arc;
+use std::time::Duration;
+
+// 1. Create the jobs table once at boot (idempotent, tri-dialect).
+DatabaseJobQueue::ensure_table_pool(&pool).await?;
+
+// 2. Build the queue over your pool + N workers, and start it.
+let queue = Arc::new(
+    DatabaseJobQueue::with_workers_pool(pool.clone(), 4)
+        .poll_interval(Duration::from_millis(50)),
+);
+queue.register::<WelcomeEmail>().await;
+queue.start().await;
+
+// 3. Dispatch exactly as before — now it's durable.
+queue.dispatch(&WelcomeEmail { user_id: 42 }).await?;
+```
+
+**Abgestürzte Worker wiederherstellen.** Stirbt ein Worker mitten im Job, bleibt
+die Zeile gesperrt. Führe einen periodischen Sweep aus, um Sperren älter als eine
+Schwelle freizugeben, damit ein anderer Worker den Job wieder aufnimmt:
+
+```rust
+// e.g. from a scheduled task every few minutes:
+let reclaimed = DatabaseJobQueue::reclaim_stuck_jobs_pool(&pool, Duration::from_secs(300)).await?;
+```
+
+Sowohl der Dispatch-and-Run-Fluss als auch `reclaim_stuck_jobs_pool` werden per
+Dogfooding gegen SQLite in `jobs_sqlite_live.rs` erprobt.
+
+---
+
+## Referenz
+
+**Backends**
+
+| Backend | Verwenden für | Übersteht Neustart? |
+|---|---|---|
+| `InMemoryJobQueue` | Einzelprozess, Dev, Tests | nein |
+| `DatabaseJobQueue` (`PgJobQueue`) | Produktion; Multi-Worker / Multi-Replica | ja (`rustango_jobs`-Tabelle) |
+
+**`JobError`**
+
+| Variante | Wirkung |
+|---|---|
+| `Retryable(String)` | erneut in die Queue mit exponentiellem Backoff, bis zu `MAX_ATTEMPTS` |
+| `Fatal(String)` | Retries überspringen → sofort Dead-Letter |
+| `Queue(String)` | interner Queue-Fehler (Serialisierung/Registrierung) |
+
+**`JobQueue`-Methoden:** `register::<T>()` · `dispatch(&payload)` · `start()` ·
+`shutdown()` · `pending_count()`. `DatabaseJobQueue` ergänzt
+`ensure_table_pool`, `with_workers_pool`, `poll_interval` und
+`reclaim_stuck_jobs_pool`.
+
+---
+
+## Siehe auch
+
+- [Scheduler](manage.md) — für *zeitbasierte* wiederkehrende Arbeit (cron-artig),
+  im Gegensatz zu On-Demand-Jobs.
+- [E-Mail](email.md) — die kanonische „mach es in einem Job"-Workload.
+- [Caching](caching.md) — der andere Weg, Request-Handler schnell zu halten.
+- [Signals](orm.md) — Fire-and-Forget-Hooks, die oft einen Job *dispatchen*.

--- a/docs/de/manage.md
+++ b/docs/de/manage.md
@@ -1,0 +1,1226 @@
+# `manage`-CLI-Referenz
+
+Dies ist **Rustango**s Kommandozeilenwerkzeug, wie Djangos `manage.py`, Laravels
+`artisan` oder Rails' `rails`-Befehl. In einem via `cargo rustango new`
+generierten Projekt führt ein einziges Binary jeden Befehl aus („Verb"):
+
+```bash
+cargo run                          # runserver (no args = boot the HTTP server)
+cargo run -- migrate               # any other verb
+cargo run -- --help                # full subcommand list
+```
+
+[![One binary runs every manage verb — server, migrations, scaffolders, database utilities, and system commands — like Django's manage.py or Laravel's artisan](img/manage.png)](img/manage.png)
+
+> **Quelle:** `rustango::manage` (`Cli`, der Verb-Dispatcher) — hinter dem
+> `manage`-Feature (standardmäßig aktiviert).
+>
+> **Ausführbare Version:** jedes Verb hier läuft in einem generierten Projekt;
+> das Beispiel
+> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog)
+> wird von `cargo run -- migrate` und Konsorten angetrieben.
+
+> **Neu bei einem Begriff hier?** *scaffold*, *migration*, *tenant* — siehe das
+> [Glossar](glossary.md).
+
+Der Befehls-Router liegt in [`rustango::manage::Cli`](https://docs.rs/rustango/latest/rustango/manage/struct.Cli.html);
+Ihre `src/main.rs` verdrahtet ihn so:
+
+```rust
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    rustango::manage::Cli::new().api(urls::api()).run().await
+}
+```
+
+Multi-Tenant-Projekte fügen der Kette `.tenancy()` hinzu. Das schaltet den
+Router auf [`rustango::tenancy::manage`](https://docs.rs/rustango/latest/rustango/tenancy/manage/index.html)
+um und schaltet die Multi-Tenant-Befehle frei.
+
+> **Ältere Form** — Projekte, die von `manage startapp --with-manage-bin`
+> (oder vor v0.16) generiert wurden, liefern weiterhin `src/bin/manage.rs`.
+> Diese verwenden `cargo run --bin manage -- <verb>`. Beide Formen akzeptieren
+> dieselben Verben.
+
+Jeder Befehl gibt auf stdout aus und beendet sich bei Validierungs- oder
+E/A-Fehlern mit einem Exit-Code ungleich null. Führen Sie
+`cargo run -- --help` (oder `<verb> --help`) für die eingebaute
+Nutzungshilfe aus.
+
+---
+
+## Inhaltsverzeichnis
+
+- [Migrationen](#migrations)
+- [Datenmigrationen](#data-migrations)
+- [Projekt-/App-Scaffolder](#project--app-scaffolders)
+- [Dateigeneratoren (`make:*`)](#file-generators-make)
+- [Datenbank-Werkzeuge](#database-utilities)
+- [Systembefehle](#system-commands)
+- [Tenancy-Befehle](#tenancy-commands)
+- [Eigene Unterbefehle](#custom-subcommands)
+- [Häufige Arbeitsabläufe](#common-workflows)
+
+---
+
+## Migrationen
+
+### `makemigrations [name]`
+
+Generiert eine Migrationsdatei aus Änderungen an Ihren Modellen — wie Djangos
+`makemigrations`. Es vergleicht Ihre registrierten Modelle mit dem letzten
+gespeicherten Schema-Snapshot in `migrations/` und schreibt eine neue
+JSON-Datei mit allen Änderungen.
+
+```bash
+cargo run -- makemigrations                          # auto-name (e.g. 0004_add_slug_to_posts)
+cargo run -- makemigrations rename_status_to_state   # custom suffix
+```
+
+**Automatisch erkannte Änderungen:**
+- `CreateTable` / `DropTable`
+- `AddColumn` / `DropColumn`
+- `AlterColumnType` / `AlterColumnNullable` / `AlterColumnDefault` / `AlterColumnMaxLength`
+- `AlterColumnUnique`
+- `CreateIndex` / `DropIndex`
+- `AddCheckConstraint` / `DropCheckConstraint`
+- `CreateM2MTable` / `DropM2MTable`
+
+**NICHT automatisch erkannt** (Umbenennen vs. Löschen+Hinzufügen ist mehrdeutig):
+- `RenameTable`, `RenameColumn` — verwenden Sie `--empty` und bearbeiten Sie das JSON.
+
+### `makemigrations --app <app>`
+
+Beschränkt die Migration auf eine einzelne App. Sie schreibt in das eigene
+Verzeichnis `<project_root>/<app>/migrations/` dieser App und betrachtet nur
+Modelle, die zu dieser App gehören.
+
+```bash
+cargo run -- makemigrations --app blog
+cargo run -- makemigrations --app blog backfill_slugs
+```
+
+### `makemigrations --scope <registry|tenant>`
+
+Nur Multi-Tenant. Schreibt eine einzige Migration für nur die Modelle in einem
+Scope — jene, deren `#[rustango(scope = "...")]`-Attribut übereinstimmt.
+(„Registry"-Tabellen werden von allen Tenants gemeinsam genutzt;
+„Tenant"-Tabellen leben pro Tenant.) Ohne dieses Flag teilt ein einfaches
+`makemigrations` in einem Tenancy-Projekt die Änderungen automatisch in ZWEI
+Dateien auf — eine für Registry-Modelle, eine für Tenant-Modelle — damit
+gemeinsame Framework-Tabellen (`Org`, `Operator`) nicht in die
+Per-Tenant-Migrationen durchsickern, die `migrate-tenants` ausführt.
+
+```bash
+cargo run -- makemigrations                       # tenancy: writes 0NN_<auto>.json (registry) + 0MM_<auto>.json (tenant) as needed
+cargo run -- makemigrations --scope tenant        # explicit single-scope diff
+cargo run -- makemigrations --scope registry      # explicit single-scope diff
+```
+
+Warum die Aufteilung wichtig ist: vor v0.24.2 bündelte ein einfaches
+`makemigrations` in einem Tenancy-Projekt Operationen auf
+`rustango_operators` (einer Registry-Tabelle) in eine Tenant-Migration. Als
+`migrate-tenants` diese Datei ausführte, wurde `rustango_operators` über den
+`search_path` auf die Registry-Kopie aufgelöst und kollidierte mit dem dort
+bereits vorhandenen Constraint.
+
+### `makemigrations --empty <name>`
+
+Erstellt eine leere Migration (keine `forward`-Operationen), die Sie von Hand
+ausfüllen — wie Djangos `makemigrations --empty`. Verwenden Sie sie, wenn Sie
+Datenoperationen oder Umbenennungsoperationen schreiben müssen, die der
+Auto-Detektor nicht generieren kann. Bearbeiten Sie das resultierende JSON
+selbst.
+
+```bash
+cargo run -- makemigrations --empty rename_status_to_state
+# Then edit migrations/0005_rename_status_to_state.json:
+#   "forward": [
+#     {"schema": {"RenameColumn": {"table": "posts", "old_column": "status", "new_column": "state"}}}
+#   ]
+```
+
+### `makemigrations --merge`
+
+Repariert eine Migrationshistorie, die sich in zwei Zweige aufgeteilt hat —
+dieselbe Idee wie Djangos `makemigrations --merge` (Issue #346). Das passiert,
+wenn zwei Personen jeweils `makemigrations` auf ihrem eigenen Feature-Branch
+ausführen, sodass beide neuen Dateien auf denselben Elternknoten zeigen.
+Nachdem beide Branches gemergt sind, hat die Historie zwei „Blätter"
+(Endpunkte), und das nächste `makemigrations` würde willkürlich eines davon
+als Elternknoten wählen.
+
+`--merge` erkennt dies und schreibt eine leere `NNNN_merge.json`, deren
+Elternknoten auf das alphabetisch letzte Blatt zeigt und die Historie wieder
+zu einer einzigen Kette vereint. Ihr Schema-Snapshot spiegelt den kombinierten
+Zustand wider, gelesen aus der lebendigen Modell-Registry — die Modelle beider
+Branches sind zu diesem Zeitpunkt einkompiliert, sodass der Snapshot genau ist.
+
+```bash
+cargo run -- makemigrations --merge
+# wrote migrations/0004_merge.json
+#     merge node — empty `forward`, anchors the chain after divergent leaves
+```
+
+- **Bereits eine einzelne Kette** → gibt `no merge needed` aus und beendet sich
+  sauber. Sicher auf einer gesunden Historie auszuführen.
+- **Wirklich getrennte Historien** (keine Branch-Kollision) → bricht mit einem
+  Fehler ab, statt einen Elternknoten zu erfinden. Dieselbe Absicherung, die
+  Django verwendet.
+- **Nicht kombinierbar** mit `--empty`, `--app`, `--scope` oder einem
+  positionalen Namen.
+
+### `migrate`
+
+Wendet alle ausstehenden Migrationen der Reihe nach auf die Datenbank an — wie
+Djangos `migrate` oder Laravels `php artisan migrate`. Dies ist der Befehl, den
+Sie nach `makemigrations` ausführen, um Ihr Schema tatsächlich zu ändern.
+
+```bash
+cargo run -- migrate
+cargo run -- migrate --dry-run                       # print SQL without writing
+```
+
+Jede Datei läuft standardmäßig innerhalb einer Transaktion, sodass ein Fehler
+die gesamte Datei zurückrollt. Setzen Sie `"atomic": false` im JSON, um sich
+abzumelden — das brauchen Sie für Anweisungen wie
+`CREATE INDEX CONCURRENTLY`, die nicht in einer Transaktion laufen können.
+
+Im **Tenancy-Modus** (`Cli::tenancy()`) ist `migrate` scope-bewusst: es wendet
+zuerst Registry-Migrationen auf die gemeinsame Registry-Datenbank an, dann
+Tenant-Migrationen über jeden aktiven Tenant. Für feinere Kontrolle verwenden
+Sie [`migrate-registry`](#migrate-registry) /
+[`migrate-tenants`](#migrate-tenants).
+
+### `migrate <target>`
+
+Migriert zu einem bestimmten Punkt in der Historie, vorwärts oder rückwärts —
+wie Djangos `migrate <app> <name>`. Nennen Sie eine Migration, um zu ihr zu
+wechseln; das spezielle Ziel `zero` macht alles rückgängig.
+
+```bash
+cargo run -- migrate 0003_add_slug      # forward to 0003
+cargo run -- migrate 0001_initial       # roll back to 0001 (unapply 0002+)
+cargo run -- migrate zero               # unapply EVERY migration
+```
+
+### `migrate --squash`
+
+Fasst jede **ausstehende** (nicht angewendete) Migration in einem frisch
+generierten Diff zusammen — der Dev-Iterations-Notausgang, wenn ein Stapel
+halbfertiger Migrationen leichter neu zu generieren als zu reparieren ist. Es
+weigert sich, an bereits Angewendetem etwas zu ändern.
+
+```bash
+cargo run -- migrate --squash
+```
+
+Die neu generierte Datei zeichnet die Namen, die sie zusammengefasst hat, in
+ihrer `replaces`-Liste auf. Das ist in dem Moment wichtig, in dem eine andere
+Datenbank beteiligt ist: der Checkout Ihres Kollegen, Staging oder CI hat
+möglicherweise bereits einige der Dateien angewendet, die Sie gerade gelöscht
+haben. Ohne `replaces` würde das `CREATE TABLE` der neuen Datei dort
+kollidieren; mit ihr **versöhnt** der Runner stattdessen (siehe unten).
+
+### Squash-Versöhnung
+
+Ein Squash stellt den Endzustand der Migrationen wieder her, die er ersetzt,
+sodass das, was der Runner tun sollte, vollständig davon abhängt, was die
+Zieldatenbank bereits enthält. Er entscheidet automatisch:
+
+| Datenbankzustand | was passiert |
+|---|---|
+| frisch — keine Historie, keine Tabellen | der Squash läuft echt |
+| jede ersetzte Migration steht im Ledger | verzeichnet, Vorgänger als erledigt markiert, **kein DDL** |
+| Tabellen existieren, aber das Ledger hat keine Historie | verzeichnet, **kein DDL** (Djangos `--fake-initial`) |
+| nur *einige* ersetzte Zeilen / Tabellen vorhanden | **verweigert**, benennt, was fehlt |
+
+Der partielle Fall ist bewusst ein harter Fehler: keine automatische Wahl ist
+dort sicher, also stoppt der Runner und sagt Ihnen, was er gefunden hat, statt
+zu raten. Lösen Sie ihn mit `migrate --fake` (unten).
+
+Migrationen, die von einem angewendeten Squash abgelöst wurden, werden als
+angewendet behandelt, sodass Sie die alten Dateien für ein oder zwei Releases
+auf der Platte lassen können — Deployments, die sie nie ausgeführt haben,
+migrieren trotzdem korrekt vorwärts.
+
+Gewöhnliche (Nicht-Squash-)Migrationen bleiben unberührt: eine einfache
+Migration, deren Tabelle bereits existiert, scheitert weiterhin lautstark,
+denn das ist ein echter Konflikt und keine bekannt-äquivalente Historie.
+
+### `migrate --fake <name>`
+
+Stempelt eine Migration als angewendet **ohne ihr SQL auszuführen** — der
+Betreiber-Notausgang, wenn die Datenbank bereits im Zielzustand ist, das
+Ledger es aber nicht weiß (eine außerhalb des Kanals eingerichtete DB, eine
+gelöschte Ledger-Tabelle, eine teilweise gelungene Migration, ein verweigerter
+partieller Squash). Wiederholen Sie das Flag, um mehrere Zeilen auf einmal zu
+reparieren.
+
+```bash
+cargo run -- migrate --fake 0004_add_indexes
+cargo run -- migrate --fake 0004_add_indexes --system        # framework's own chain
+cargo run -- migrate --fake 0004_add_indexes --all-tenants   # every active tenant
+```
+
+Der Name wird zuerst gegen das Migrationsverzeichnis validiert, sodass ein
+Tippfehler keine unechte Zeile einschleusen kann. Das Stempeln ist idempotent.
+
+`--system` zielt auf die eigene Migrationskette des Frameworks
+(`system/migrations/`, verzeichnet in `__rustango_system_migrations__`) statt
+auf die Ihres Projekts. `--all-tenants` fächert den Stempel über jeden aktiven
+Tenant auf, berichtet über jeden einzelnen und fährt über Fehler hinweg fort —
+die Tabellen des Frameworks leben pro Tenant, ihre Reparatur ist also eine
+Per-Tenant-Aufgabe.
+
+### `downgrade [N]`
+
+Rollt die letzten N angewendeten Migrationen zurück (Standard 1) — Laravels
+`migrate:rollback`. Jede Migration muss reversibel sein: Schemaänderungen
+kehren sich automatisch um, aber Datenoperationen brauchen ein definiertes
+`reverse_sql`, sonst scheitert der Rollback.
+
+```bash
+cargo run -- downgrade                  # one step
+cargo run -- downgrade 3                # three steps
+```
+
+### `showmigrations` / `status`
+
+Listet jede Migration und ob sie angewendet wurde — wie Djangos
+`showmigrations`. `[X]` bedeutet angewendet, `[ ]` bedeutet noch ausstehend.
+
+```bash
+cargo run -- showmigrations
+cargo run -- status                     # alias
+```
+
+Ausgabe:
+
+```
+[X] 0001_initial
+[X] 0002_add_status
+[ ] 0003_add_slug
+```
+
+---
+
+## Datenmigrationen
+
+### `add-data-op`
+
+Fügt einer Migration einen Roh-SQL-Datenschritt hinzu, ohne das JSON von Hand
+zu bearbeiten. Greifen Sie dazu, wenn Sie vorhandene Zeilen transformieren
+müssen — eine Spalte nachfüllen, Daten bereinigen — als Teil einer Migration.
+Es ist das Äquivalent zu Djangos `RunSQL`-Datenmigration, für Sie von der
+Kommandozeile aus generiert.
+
+```bash
+# New migration with up + down
+cargo run -- add-data-op \
+    --sql "UPDATE posts SET slug = lower(title)" \
+    --reverse-sql "UPDATE posts SET slug = NULL" \
+    --name backfill_post_slugs
+
+# Append to an existing migration
+cargo run -- add-data-op \
+    --to 0003_add_slug \
+    --sql "UPDATE posts SET slug = id::text"
+
+# Irreversible (no rollback)
+cargo run -- add-data-op \
+    --sql "DELETE FROM legacy_data" \
+    --name purge_legacy
+```
+
+| Flag | Erforderlich | Beschreibung |
+|---|:-:|---|
+| `--sql <SQL>` | ja | Vorwärts-SQL, das bei `migrate` läuft |
+| `--reverse-sql <SQL>` | nein | Rollback-SQL bei `unapply`; weglassen für irreversibel |
+| `--name <name>` | nein | Namenssuffix der neuen Migration; Standard ist `data_op` |
+| `--to <migration>` | nein | An eine bestehende Migration anhängen, statt eine neue zu erstellen |
+
+Lassen Sie `--reverse-sql` weg, und der Schritt wird als `reversible: false`
+markiert — jeder Versuch, ihn zurückzurollen, scheitert sofort.
+
+---
+
+## Projekt-/App-Scaffolder
+
+### `cargo rustango new <name>` *(separates Binary)*
+
+Erstellt ein brandneues **Rustango**-Projekt — wie `django-admin startproject`
+oder `laravel new`. Dies ist ein separates Werkzeug, installieren Sie es also
+zuerst mit `cargo install cargo-rustango`. Wählen Sie aus drei Vorlagen:
+
+```bash
+cargo rustango new myblog                          # default = fullstack (ORM + admin)
+cargo rustango new myapi --template api            # JSON-only, no admin
+cargo rustango new shop --template tenant          # multi-tenancy
+```
+
+Schreibt:
+
+```
+<name>/
+  Cargo.toml
+  .env.example
+  .gitignore
+  rust-toolchain.toml
+  docker-compose.yml
+  README.md
+  migrations/                               (your app's migrations)
+  system/migrations/                        (tenant template — framework tables, generated)
+  src/{main,models,views,urls}.rs
+```
+
+Die Tenant-Vorlage liefert einen **leeren** `system/migrations/`-Ordner. Die
+eigenen Tabellen des Frameworks (`rustango_orgs`, `rustango_users`,
+Rollen/Berechtigungen, …) werden beim ersten `cargo run -- migrate` aus den
+kompilierten Modellen dorthin generiert — es gibt kein handgeliefertes
+Bootstrap-JSON. Siehe [`migrate`](#migrate) /
+[`migrate-registry`](#migrate-registry).
+
+### `startapp <name> [flags]`
+
+Erstellt eine neue App (ein Feature-Modul) unter `src/<name>/` — genau wie
+Djangos `startapp`. Verwenden Sie es, um Modelle, Views und URLs für einen Teil
+Ihres Projekts gruppiert zu halten.
+
+```bash
+cargo run -- startapp blog
+cargo run -- startapp shop --with-manage-bin             # also writes src/bin/manage.rs
+cargo run -- startapp shop --into apps                   # write under src/apps/shop/ instead
+```
+
+Erstellt:
+
+```
+src/<name>/
+  mod.rs
+  models.rs
+  views.rs
+  urls.rs
+```
+
+Sicher erneut ausführbar — bestehende Dateien bleiben unberührt. Ein manueller
+Schritt: fügen Sie `pub mod <name>;` zu `src/lib.rs` hinzu, damit Rust das neue
+Modul kompiliert.
+
+---
+
+## Dateigeneratoren (`make:*`)
+
+Diese erstellen Startdateien für gängige Bausteine — sehr ähnlich zu Laravels
+`make:*`-Befehlen (`make:controller`, `make:model`, …). Jeder Generator
+schreibt nach `src/<snake_name>.rs` (oder `tests/<snake_name>.rs` für
+`make:test`) und:
+
+- Prüft, ob der Name gültig ist (PascalCase, Buchstaben/Ziffern/Unterstrich).
+- Wandelt ihn für den Dateinamen in snake_case um (`PostViewSet` →
+  `post_view_set.rs`).
+- Überschreibt keine bestehende Datei.
+- Erinnert Sie daran, `pub mod X;` zu Ihrer `lib.rs` hinzuzufügen.
+
+### `make:viewset <Name> [--model <Model>]`
+
+Generiert eine `#[derive(ViewSet)]`-Struktur — einen REST-Endpunkt für ein
+Modell, wie ein Django-REST-Framework-ViewSet. Die Feldlisten kommen für Sie
+vorgestubbt zum Ausfüllen.
+
+```bash
+cargo run -- make:viewset PostViewSet --model Post
+```
+
+Generierte `src/post_view_set.rs`:
+
+```rust
+#[derive(ViewSet)]
+#[viewset(model = Post, fields = "id, ", filter_fields = "", search_fields = "", page_size = 20)]
+pub struct PostViewSet;
+```
+
+Einbinden mit: `.merge(PostViewSet::router("/api/posts", pool.clone()))`.
+
+### `make:serializer <Name> [--model <Model>]`
+
+Generiert eine `#[derive(Serializer)]`-Struktur — steuert, wie ein Modell nach
+und von JSON konvertiert wird (wie ein DRF-Serializer).
+
+```bash
+cargo run -- make:serializer PostSerializer --model Post
+```
+
+### `make:form <Name>`
+
+Generiert eine `#[derive(Form)]`-Struktur zum Validieren und Verarbeiten von
+Formular-Eingaben — wie ein Django-`Form`.
+
+```bash
+cargo run -- make:form ContactForm
+```
+
+### `make:job <Name>`
+
+Generiert ein Hintergrund-Job-Gerüst (Arbeit, die außerhalb des Requests läuft,
+wie eine Celery-Task oder ein Laravel-Job), mit einem auskommentierten Beispiel,
+wie man es einplant.
+
+```bash
+cargo run -- make:job EmailDigestJob
+```
+
+### `make:notification <Name>`
+
+Generiert eine Notification-Struktur, die eine E-Mail aufbaut — wie Laravels
+`make:notification`.
+
+```bash
+cargo run -- make:notification WelcomeEmail
+```
+
+### `make:middleware <Name>`
+
+Generiert eine Middleware-Funktion — Code, der vor und nach jedem Request läuft
+(Auth-Prüfungen, Logging und so weiter). „axum" ist das Web-Framework, auf dem
+**Rustango** aufbaut, sodass der Stub der Middleware-Form von axum entspricht.
+
+```bash
+cargo run -- make:middleware AuditLog
+```
+
+### `make:test <Name>`
+
+Generiert einen Integrationstest in `tests/`, der `TestClient` verwendet, um
+Requests gegen Ihre App zu stellen.
+
+```bash
+cargo run -- make:test post_smoke
+```
+
+---
+
+## Datenbank-Werkzeuge
+
+### `db:info`
+
+Zeigt, mit welcher Datenbank dieser Build zu sprechen konfiguriert ist, ohne
+sich zu verbinden. Es gibt die Framework-Version aus, welche
+Datenbanktreiber (`postgres`/`mysql` Cargo-Features) einkompiliert sind, die
+Verbindungs-URL mit verstecktem Passwort und das erkannte Backend. Da es nie
+eine Verbindung öffnet, ist es praktisch in CI oder Containern, in denen die
+Datenbank noch nicht läuft, Sie aber bestätigen wollen, dass die Einstellungen
+stimmen.
+
+```bash
+cargo run -- db:info
+```
+
+### `db:dump [--out <path>] [--data-only|--schema-only] [--no-owner]`
+
+Sichert Ihre Datenbank, indem `pg_dump` gegen `DATABASE_URL` ausgeführt wird —
+wie `php artisan db:dump`. Standardmäßig geht das SQL nach stdout (damit Sie es
+pipen können); übergeben Sie `--out <path>` (`-o`), um stattdessen eine Datei
+zu schreiben. `--data-only` und `--schema-only` bilden direkt auf die Flags von
+`pg_dump` ab, und `--no-owner` lässt die OWNER-Zeilen weg. Sie brauchen
+`pg_dump` installiert und in Ihrem `PATH`.
+
+```bash
+cargo run -- db:dump > backups/before-migrate.sql    # stdout → file
+cargo run -- db:dump --out backups/before-migrate.sql
+```
+
+### `db:restore <path> [--clean]`
+
+Lädt eine Dump-Datei zurück in Ihre Datenbank — das Gegenstück zu `db:dump`. Es
+lässt die Datei durch `psql` gegen `DATABASE_URL` mit `ON_ERROR_STOP=1` laufen,
+sodass es beim ersten Fehler stoppt. Fügen Sie `--clean` hinzu, um zuerst das
+bestehende Schema zu löschen (es stellt
+`DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;` voran), damit die
+Wiederherstellung auf einer leeren Datenbank landet. Sie brauchen `psql` in
+Ihrem `PATH`.
+
+```bash
+cargo run -- db:restore backups/before-migrate.sql
+cargo run -- db:restore backups/before-migrate.sql --clean
+```
+
+---
+
+## Systembefehle
+
+### `version` / `--version`
+
+Gibt die Version des **Rustango**-Frameworks aus.
+
+```bash
+$ cargo run -- version
+rustango 0.44.0
+```
+
+### `about`
+
+Gibt eine Momentaufnahme Ihrer Umgebung aus: Framework-Version, registrierte
+Modelle und Apps, ob die Datenbank erreichbar ist, und wichtige
+Umgebungsvariablen. Legen Sie dies in Support-Tickets, wenn etwas nicht stimmt.
+
+```bash
+$ cargo run -- about
+rustango
+  version:        0.44.0
+  models:         3 registered
+  apps:           1 (blog)
+  RUSTANGO_ENV:   local
+  DATABASE_URL:   postgres://***@localhost:5433/myblog
+  db_connect:     ok
+```
+
+### `check [--deploy]`
+
+Führt Gesundheitsprüfungen an Ihrem Projekt durch — wie Djangos `check`. Fügen
+Sie `--deploy` für die strengeren Produktionsreife-Prüfungen hinzu, genau wie
+Djangos `check --deploy` funktioniert.
+
+**Immer aktive Prüfungen:**
+- ≥ 1 Modell via `inventory` registriert
+- DB erreichbar (`SELECT 1`)
+- Migrationsanzahl vs. Modellanzahl
+
+**Mit `--deploy`:**
+- `RUSTANGO_ENV` ist `prod` oder `production`
+- `RUSTANGO_SESSION_SECRET` gesetzt und ≥ 32 Byte (der HMAC-Schlüssel für
+  Cookies + JWTs; `SECRET_KEY` wird vom Framework nie gelesen)
+- `DATABASE_URL` gesetzt
+- `RUSTANGO_APEX_DOMAIN` gesetzt (Tenancy-Projekte)
+
+```bash
+$ cargo run -- check --deploy
+running rustango system check (deploy mode)...
+  [info]    3 models registered via inventory
+  [info]    database reachable
+  [info]    4 migration(s) on disk
+  [info]    RUSTANGO_SESSION_SECRET length OK
+all checks passed
+```
+
+Beendet sich mit Exit-Code ungleich null, wenn eine Prüfung auf Fehler-Ebene
+scheitert. Warnungen allein verursachen kein Scheitern.
+
+### `docs`
+
+Öffnet die **Rustango**-Dokumentation (<https://docs.rs/rustango>) in Ihrem
+Browser. Es gibt immer auch die URL aus, sodass es auch auf einem Headless-Server
+funktioniert.
+
+```bash
+cargo run -- docs
+```
+
+### `--help` / `help`
+
+Listet jeden Befehl mit einer einzeiligen Beschreibung. Im Tenancy-Modus werden
+auch die unten aufgeführten Multi-Tenant-Befehle hinzugefügt.
+
+---
+
+## Tenancy-Befehle
+
+Diese Befehle existieren nur in Multi-Tenant-Projekten (eine App, die viele
+isolierte Kunden/Orgs bedient). Sie erscheinen nur, wenn das Projekt mit
+`features = ["tenancy"]` gebaut wird UND `Cli::new()` mit `.tenancy()`
+verkettet ist.
+
+### `init-tenancy`
+
+**No-op — aus Kompatibilitätsgründen beibehalten.** Das Framework liefert keine
+handgebauten Bootstrap-Migrationen mehr. Seine eigenen Tabellen
+(`rustango_orgs`, `rustango_operators`, `rustango_users`, Rollen/Berechtigungen,
+…) werden aus den kompilierten Modellen in `system/migrations/` generiert — der
+normale Django-Fluss (Modelle → `makemigrations` → `migrate`) — und von
+[`migrate`](#migrate) / [`migrate-registry`](#migrate-registry) angewendet, die
+sie bei Bedarf generieren, falls die Dateien fehlen.
+
+```bash
+cargo run -- init-tenancy   # does nothing now; kept so old scripts don't break
+```
+
+Ältere Versionen schrieben hier `0001_rustango_*_initial.json`; dieser
+hartkodierte Fluss ist verschwunden. **Zum Bereitstellen führen Sie einfach
+`cargo run -- migrate` aus.** Ein eigenes Benutzermodell
+(`.user_model::<AppUser>()`) fließt durch dieselben generierten
+`system/migrations/` — siehe
+[Eigenes Benutzermodell](#custom-user-model-extra-columns-on-rustango_users).
+
+### `migrate-registry`
+
+Wendet nur die Registry-Migrationen an — die gemeinsamen, tenant-übergreifenden
+Tabellen. Die Registry hält `rustango_orgs` und `rustango_operators` sowie alle
+registry-scoped Tabellen, die Sie definieren. Tenant-Tabellen bleiben unberührt.
+
+```bash
+cargo run -- migrate-registry
+```
+
+### `migrate-tenants`
+
+Wendet Tenant-Migrationen auf jeden aktiven Tenant nacheinander an. Jeder Tenant
+verwendet seine eigene Verbindung (sein eigenes Schema oder seine eigene
+Datenbank), und wenn ein Tenant scheitert, laufen die übrigen trotzdem weiter —
+der Befehl berichtet am Ende das Ergebnis pro Tenant.
+
+```bash
+cargo run -- migrate-tenants
+```
+
+Für den häufigen Fall macht ein einfaches `migrate` bereits zuerst die Registry,
+dann die Tenants — greifen Sie zu `migrate-tenants` nur, wenn Sie diesen Schritt
+für sich allein brauchen.
+
+### `runserver` / `run-server`
+
+Startet den Multi-Tenant-Webserver — Djangos `runserver`. In einem
+Tenancy-Projekt ist dies dasselbe wie ein nacktes `cargo run`; die benannte Form
+existiert, damit eigene Binaries, die ihre eigenen Argumente parsen, es trotzdem
+auslösen können.
+
+```bash
+cargo run                        # implicit
+cargo run -- runserver           # explicit
+```
+
+### `create-tenant <slug> [options]`
+
+Richtet einen neuen Tenant (Kunde/Org) ein und wendet die Tenant-Migrationen
+darauf an. Der `<slug>` ist sein kurzer Bezeichner. Sicher erneut ausführbar —
+ein erneuter Aufruf auf einem bestehenden Tenant dupliziert nichts.
+
+```bash
+cargo run -- create-tenant acme --display-name "ACME Corp"
+cargo run -- create-tenant beta --mode database --database-url postgres://...
+```
+
+| Flag | Beschreibung |
+|---|---|
+| `--display-name <name>` | Menschenlesbares Label, das in Admin-Seitenleisten angezeigt wird |
+| `--mode schema \| database` | Speichermodus (Standard: schema) |
+| `--database-url <url>` | Tenant-spezifische DB-URL (erforderlich für den database-Modus) |
+| `--host-pattern <pattern>` | Überschreibt das vom `SubdomainResolver` verwendete Host-Muster |
+| `--no-migrate` | Überspringt das Anwenden tenant-scoped Migrationen nach dem Provisioning |
+
+### `drop-tenant <slug> [--confirm <slug>]`
+
+Deaktiviert einen Tenant, indem `active = false` gesetzt wird. Dies ist die
+weiche, umkehrbare Option — die Daten des Tenants bleiben auf der Platte, und
+ein erneutes Ausführen von `create-tenant` bringt ihn zurück. Wenn Sie nicht
+interaktiv laufen (kein Terminal angehängt), müssen Sie `--confirm <slug>` mit
+dem erneut getippten Slug zur Bestätigung übergeben.
+
+```bash
+cargo run -- drop-tenant acme --confirm acme
+```
+
+### `purge-tenant <slug> [--confirm <slug>] [--purge-database]`
+
+**Löscht einen Tenant dauerhaft.** Es löscht das Schema des Tenants und entfernt
+seine Zeile aus `rustango_orgs`, ohne Rückgängig-Machen. Wenn Sie nicht
+interaktiv laufen (kein Terminal angehängt), müssen Sie `--confirm <slug>` mit
+dem erneut getippten Slug übergeben. Bei Tenants im database-Modus bleibt die
+zugrunde liegende Datenbank an Ort und Stelle, es sei denn, Sie übergeben
+zusätzlich `--purge-database`.
+
+```bash
+cargo run -- purge-tenant acme --confirm acme
+cargo run -- purge-tenant beta --confirm beta --purge-database   # database-mode: also DROP DATABASE
+```
+
+### `list-tenants`
+
+Listet jeden Tenant mit seinem Speichermodus und aktiv/inaktiv-Status.
+
+```bash
+cargo run -- list-tenants
+```
+
+### `create-operator <username> --password <pwd>`
+
+Erstellt einen Operator — einen globalen Admin, der jeden Tenant von einer
+tenant-übergreifenden Konsole aus verwalten kann. Operatoren leben in der
+gemeinsamen Registry, nicht innerhalb eines einzelnen Tenants.
+
+```bash
+cargo run -- create-operator admin --password letmein
+```
+
+### `create-user <tenant> <username> --password <pwd> [--superuser]`
+
+Erstellt einen Benutzer innerhalb eines Tenants — ungefähr Djangos
+`createsuperuser`, aber auf einen einzelnen Tenant beschränkt.
+
+```bash
+cargo run -- create-user acme alice --password hunter2 --superuser
+```
+
+`--superuser` setzt `is_superuser = true` für diesen Benutzer innerhalb des
+Tenants. Das macht ihn zu einem Admin des Tenants (voller Schreibzugriff im
+Tenant-Admin), gewährt aber nie Zugang zur tenant-übergreifenden
+Operator-Konsole.
+
+### `create-role <tenant> <name>`
+
+Erstellt eine Rolle (ein benanntes Bündel von Berechtigungen, wie eine
+Django-Gruppe) innerhalb eines Tenants.
+
+```bash
+cargo run -- create-role acme editor
+```
+
+### `list-roles <tenant>`
+
+Listet die in einem bestimmten Tenant definierten Rollen.
+
+```bash
+cargo run -- list-roles acme
+```
+
+### `assign-role <tenant> <username> <role>`
+
+Gibt einem Benutzer eine der Rollen des Tenants.
+
+```bash
+cargo run -- assign-role acme alice editor
+```
+
+### `revoke-role <tenant> <username> <role>`
+
+Entfernt eine Rolle von einem Benutzer — die Umkehrung von `assign-role`.
+
+```bash
+cargo run -- revoke-role acme alice editor
+```
+
+### `grant-perm <tenant> <role-name|username> <codename> [--role]`
+
+Gewährt eine einzelne Berechtigung. Standardmäßig ist das zweite Argument ein
+**Benutzername**, sodass die Berechtigung direkt an diesen Benutzer geht; fügen
+Sie `--role` hinzu, um sie stattdessen einer Rolle zu gewähren.
+Berechtigungs-Codenames verwenden Djangos Format `<app>.<action>_<model>`
+(`blog.add_post`, `blog.change_post`, …). Das Feature
+`auto_create_permissions` erstellt die vier standardmäßigen CRUD-Codenames
+automatisch für jedes Modell, das mit `#[rustango(permissions)]` markiert ist.
+
+```bash
+cargo run -- grant-perm acme alice blog.change_post           # grant to user alice
+cargo run -- grant-perm acme editor blog.change_post --role   # grant to role editor
+```
+
+### `revoke-perm <tenant> <role-name|username> <codename> [--role]`
+
+Entfernt eine Berechtigung — die Umkehrung von `grant-perm`. Zielt standardmäßig
+auf einen Benutzer; fügen Sie `--role` hinzu, um sie stattdessen von einer Rolle
+zu entziehen.
+
+```bash
+cargo run -- revoke-perm acme alice blog.change_post
+cargo run -- revoke-perm acme editor blog.change_post --role
+```
+
+### `create-api-key <tenant> <username> [--label <s>]`
+
+Stellt einen API-Schlüssel für einen Tenant-Benutzer aus. Das vollständige Token
+wird **einmal** ausgegeben und nie wieder — kopieren Sie es jetzt, denn nur sein
+Präfix und ein Hash werden gespeichert.
+
+```bash
+cargo run -- create-api-key acme alice --label "ci-bot"
+```
+
+### `audit-cleanup`
+
+Beschneidet alte Einträge aus dem Audit-Log (`rustango_audit_log`), damit es
+nicht ewig wächst. Kürzen Sie nach Alter (`--days`) oder nach Anzahl
+(`--keep-last`), und optional auf einen Tenant beschränkt.
+
+```bash
+cargo run -- audit-cleanup --days 90                       # delete > 90 days old
+cargo run -- audit-cleanup --keep-last 50                  # keep most recent 50 per row
+cargo run -- audit-cleanup --keep-last 50 --tenant acme    # scoped
+```
+
+---
+
+## Eigenes Benutzermodell (zusätzliche Spalten auf `rustango_users`)
+
+Dies ist **Rustango**s Version von Djangos „custom user model" — wie Sie Ihre
+eigenen Felder zur Benutzertabelle hinzufügen. Der eingebaute Tenant-`User` hat
+sieben feste Spalten: `id`, `username`, `password_hash`, `is_superuser`,
+`active`, `created_at`, plus eine `data`-JSONB-Spalte (ein flexibler JSON-Blob)
+für beliebige zusätzliche Metadaten pro Benutzer. **Für die meisten Apps ist
+diese JSONB-Spalte alles, was Sie brauchen** — keine Migration, kein Override,
+keine Überraschungen.
+
+Wenn Sie stattdessen **typisierte, indexierbare** Spalten auf `rustango_users`
+wollen, gibt es zwei Ansätze. Sie sind nicht austauschbar; wählen Sie den, der
+dazu passt, wo Ihr Projekt in seinem Leben steht.
+
+### Option 1 — Geschwister-Profilmodell mit FK *(funktioniert bei jedem Projekt)*
+
+Am besten, wenn das Projekt bereits existiert, oder wenn Sie die `User`-Tabelle
+des Frameworks lieber als einzige Quelle der Wahrheit belassen möchten.
+
+```rust
+#[derive(rustango::Model)]
+pub struct UserProfile {
+    #[rustango(primary_key)] pub id: rustango::sql::Auto<i64>,
+    #[rustango(fk = "rustango_users")] pub user_id: i64,
+    #[rustango(max_length = 128, default = "''")] pub display_name: String,
+    #[rustango(max_length = 64, default = "'UTC'")] pub timezone: String,
+}
+```
+
+Führen Sie `cargo run -- makemigrations` dann `cargo run -- migrate` aus, und
+Sie haben eine typisierte Extra-Tabelle, die per Fremdschlüssel mit dem Benutzer
+verknüpft ist. Lesen Sie sie mit dem ORM:
+
+```rust
+let profile = UserProfile::objects()
+    .where_(UserProfile::user_id.eq(user.id.get().copied().unwrap()))
+    .first(&pool).await?;            // Option<UserProfile>
+```
+
+Kompromiss: eine zusätzliche Zeile und ein JOIN bei jedem Zugriff. Vorteil: null
+Risiko, die Framework-Auth zu brechen.
+
+### Option 2 — `Cli::user_model::<AppUser>()` *(nur auf der grünen Wiese)*
+
+Verwenden Sie dies nur auf einem frischen Projekt, bei dem Sie die
+zusätzlichen Felder direkt auf der `rustango_users`-Tabelle selbst wollen. Da
+`AppUser` das `rustango_users`-Modell *ist*, fließen seine Spalten durch die
+gewöhnliche `makemigrations` → `migrate`-Engine: die Tabellen des Frameworks
+werden in `system/migrations/` generiert, sodass die Spalten von `AppUser` im
+generierten `CREATE TABLE rustango_users` landen.
+
+**Schritt 1.** Definieren Sie Ihr Modell. Es muss jede vom Framework geforderte
+Spalte exakt deklarieren (`id`, `username`, `password_hash`, `is_superuser`,
+`active`, `created_at`, `data`), plus Ihre Extras. Jede zusätzliche Spalte muss
+entweder `NULL` erlauben oder einen `default = "…"` haben.
+
+```rust
+use rustango::sql::Auto;
+
+#[derive(rustango::Model, Debug, Clone)]
+#[rustango(table = "rustango_users")]
+pub struct AppUser {
+    #[rustango(primary_key)] pub id: Auto<i64>,
+    #[rustango(max_length = 64, unique)] pub username: String,
+    #[rustango(max_length = 255)] pub password_hash: String,
+    pub is_superuser: bool,
+    pub active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    #[rustango(default = "'{}'")] pub data: serde_json::Value,
+    // extras —
+    #[rustango(max_length = 128, default = "''")] pub display_name: String,
+    #[rustango(max_length = 64, default = "'UTC'")] pub timezone: String,
+}
+impl rustango::tenancy::TenantUserModel for AppUser {}
+```
+
+**Schritt 2.** Verdrahten Sie den Override in `main.rs`:
+
+```rust
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    rustango::manage::Cli::new()
+        .api(my_app::urls::router())
+        .tenancy()
+        .user_model::<AppUser>()
+        .run().await
+}
+```
+
+**Schritt 3.** Registrieren Sie `AppUser` **anstelle** des Framework-`User` —
+nur ein Modell darf `table = "rustango_users"` beanspruchen. Der Scaffolder
+liefert kein statisches Bootstrap-JSON (nur ein leeres `system/migrations/`),
+es gibt also nichts zu löschen; registrieren Sie einfach nicht auch den
+Framework-`User`.
+
+**Schritt 4.** Generieren + anwenden:
+
+```bash
+cargo run -- makemigrations       # generates system/migrations/ with AppUser's columns
+cargo run -- migrate              # creates rustango_users with your extras
+```
+
+**Vorbehalte:**
+
+- `AppUser` später zu ändern ist eine normale Schemaänderung: führen Sie
+  `makemigrations` erneut aus, um die `AddColumn`-Migration zu emittieren, dann
+  `migrate`.
+- Nur ein Modell darf auf `rustango_users` abbilden. Das Registrieren **beider**,
+  des Framework-`User` und Ihres `AppUser`, macht `makemigrations` mehrdeutig —
+  registrieren Sie `AppUser` allein. Das ist der Hauptgrund, warum Option 2 nur
+  für frische Projekte ist; bei einem bestehenden Projekt vermeidet Option 1 das
+  Problem.
+- Framework-Auth- und Admin-Code liest die sieben Kernspalten namentlich; Ihre
+  zusätzlichen Spalten sind nur über `AppUser::objects().fetch(...)` erreichbar.
+
+`Builder::user_model::<AppUser>()` macht dasselbe für Code, der den
+Server-`Builder` direkt baut, ohne über `Cli` zu gehen.
+
+---
+
+## Eigene Unterbefehle
+
+Sie können Ihre eigenen Befehle hinzufügen — **Rustango**s Interpretation von
+Djangos eigenen Management-Befehlen. Der Trick besteht darin, die Argumente
+selbst zu inspizieren und Ihren Befehl zu behandeln, bevor Sie den Rest an
+`Cli::run` weitergeben. Zwei Wege, es zu tun:
+
+**Inline in `src/main.rs`** (kein zusätzliches Binary):
+
+```rust
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if matches!(args.first().map(String::as_str), Some("import-csv")) {
+        let url = std::env::var("DATABASE_URL")?;
+        let pool = rustango::sql::sqlx::PgPool::connect(&url).await?;
+        return my_csv_importer::run(&pool, &args[1..]).await;
+    }
+    rustango::manage::Cli::new().api(urls::api()).run().await
+}
+```
+
+**Via `--with-manage-bin`** (separates `src/bin/manage.rs`):
+
+```bash
+cargo run -- startapp app --with-manage-bin
+```
+
+Dann in `src/bin/manage.rs`:
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let url = std::env::var("DATABASE_URL")?;
+    let pool = rustango::sql::sqlx::PgPool::connect(&url).await?;
+
+    match args.first().map(String::as_str) {
+        Some("import-csv") => my_csv_importer::run(&pool, &args[1..]).await,
+        _ => rustango::migrate::manage::run(&pool, "./migrations".as_ref(), args)
+            .await
+            .map_err(Into::into),
+    }
+}
+```
+
+Führen Sie Ihre eigenen Befehle genau wie die eingebauten aus:
+`cargo run -- import-csv path/to/file.csv` (oder
+`cargo run --bin manage -- import-csv …` bei Verwendung von
+`--with-manage-bin`).
+
+---
+
+## Häufige Arbeitsabläufe
+
+### Erstmalige Projekteinrichtung (single-tenant)
+
+```bash
+cargo rustango new myapp
+cd myapp
+cp .env.example .env             # edit DATABASE_URL
+docker compose up -d
+cargo run -- migrate
+cargo run                        # serve at :8080
+```
+
+### Erstmalige Projekteinrichtung (tenancy)
+
+```bash
+cargo rustango new myapp --template tenant
+cd myapp
+cp .env.example .env             # edit DATABASE_URL + RUSTANGO_APEX_DOMAIN
+docker compose up -d
+cargo run -- migrate                                      # registry + tenants
+cargo run -- create-operator admin --password letmein
+cargo run -- create-tenant acme --display-name "ACME Inc" \
+                  --host-pattern acme.localhost
+cargo run -- create-user acme alice --password tenantpw --superuser
+cargo run                        # serve at :8080
+```
+
+### Tenants hinzufügen, nachdem die App bereits läuft
+
+Eine echte Tenancy-App baut in der Regel lange vor der Anmeldung ihres ersten
+Tenants Modelle und Migrationen auf. Dieser Ablauf funktioniert zu jedem
+Zeitpunkt im Leben des Projekts:
+
+```bash
+# 1. (any time) develop user models — define structs with #[derive(Model)],
+#    add `pub mod ...;` to src/lib.rs.
+# 2. Generate scope-aware migrations. In a tenancy project this writes
+#    up to TWO files: one tagged registry-scope (touches Org/Operator),
+#    one tagged tenant-scope (touches User + your models). Pre-v0.24.2
+#    this used to dump everything into one tenant-scoped file and
+#    crash on `create-tenant` — see the changelog.
+cargo run -- makemigrations
+
+# 3. Apply migrations. `migrate` is scope-aware: it runs registry-
+#    scoped files once against the registry pool first, then fans
+#    tenant-scoped files across every active tenant.
+cargo run -- migrate
+
+# 4. Provision a NEW tenant whenever (could be days, weeks, many
+#    migrations later). The tenancy code applies every accumulated
+#    tenant-scoped migration to the new tenant's schema in one pass —
+#    the new tenant arrives at the same schema state as existing ones.
+cargo run -- create-tenant acme --display-name "ACME Inc" \
+                  --host-pattern acme.localhost
+cargo run -- create-user acme alice --password tenantpw --superuser
+```
+
+Warum das sicher ist:
+- `#[rustango(scope = "registry")]` auf `Org`/`Operator` hält Änderungen an
+  gemeinsamen Tabellen aus den Per-Tenant-Migrationen heraus.
+- `migrate-tenants` besucht jeden aktiven Tenant und wendet nur die
+  Tenant-Migrationen an — Registry-Dateien werden übersprungen.
+- `create-tenant` führt denselben `migrate-tenants`-Durchlauf gegen das Schema
+  des neuen Tenants aus, sodass er vollständig auf dem neuesten Stand startet,
+  ohne manuelle Nachbesserung.
+
+### Ein Modell hinzufügen
+
+```bash
+cargo run -- startapp blog        # if not done yet
+# Edit src/blog/models.rs — add #[derive(Model)]
+# Add `pub mod blog;` to src/lib.rs
+cargo run -- makemigrations
+cargo run -- migrate
+```
+
+### Eine JSON-API für dieses Modell hinzufügen
+
+```bash
+cargo run -- make:viewset PostViewSet --model Post
+# Edit src/post_view_set.rs — fill in field lists
+# Mount in src/urls.rs
+cargo run                        # GET /api/posts now works
+```
+
+### Ein Daten-Backfill hinzufügen
+
+```bash
+cargo run -- add-data-op \
+    --sql "UPDATE posts SET slug = lower(title) WHERE slug IS NULL" \
+    --reverse-sql "UPDATE posts SET slug = NULL" \
+    --name backfill_post_slugs
+cargo run -- migrate
+```
+
+### Pre-Deploy-Audit
+
+```bash
+cargo run --release -- check --deploy
+```
+
+### Die letzte Migration zurückrollen
+
+```bash
+cargo run -- downgrade 1
+```
+
+### Eine Tenancy-Migration auf einen bestimmten Scope anwenden
+
+```bash
+cargo run -- migrate-registry            # registry-scoped only
+cargo run -- migrate-tenants             # tenant-scoped, fan-out across orgs
+```
+
+### Einen Tenant außer Betrieb nehmen
+
+```bash
+cargo run -- drop-tenant acme            # soft (reversible)
+cargo run -- purge-tenant acme           # hard (drops schema/db)
+```
+
+---
+
+## Tenant-Pool-Feinabstimmung (v0.27.7+)
+
+Tenants im database-Modus erhalten ihren eigenen Verbindungspool (einen
+`PgPool` — eine Menge wiederverwendeter Datenbankverbindungen), zwischengespeichert
+nach Slug in [`TenantPools`](../crates/rustango/src/tenancy/pools.rs).
+Standardmäßig wird ein Pool **faul, beim ersten Request des Tenants** gebaut, es
+sei denn, Sie schalten das Pre-Warming ein. Die Einstellungen leben auf
+`TenantPoolsConfig`:
+
+| Feld | Standard | Zweck |
+|---|---|---|
+| `max_cached_database_pools` | 64 | Obergrenze für den Pool-Cache. Ist er voll, scheitert der nächste nicht-gecachte Tenant (keine stille Verdrängung). |
+| `database_pool_max_connections` | 4 | `max_connections` pro Pool. Halten Sie es klein, damit ein Tenant-Fan-out PGs `max_connections` nicht erschöpft. |
+| `database_pool_min_connections` | 0 | Hält jederzeit N Verbindungen warm. `≥1` senkt die Latenz des ersten Requests, indem der TCP/TLS/Auth-Roundtrip beim Boot bezahlt wird. |
+| `database_pool_acquire_timeout` | 30s | Wie lange `pool.acquire()` wartet, bevor es mit `PoolTimedOut` scheitert. |
+| `database_pool_idle_timeout` | 10 min | Schließt untätige Verbindungen nach dieser Dauer. Wehrt Kappungen durch Load-Balancer / `idle_in_transaction_session_timeout` ab. |
+| `database_pool_max_lifetime` | 30 min | Erzwingt das Rotieren von Verbindungen, damit vault-geleaste Anmeldedaten aufgefrischt werden. |
+| `prewarm_active_tenants` | false | Wenn true, ruft `Server::Builder::serve` beim Boot `prewarm_database_tenants()` auf. |
+
+### Beim Boot vorwärmen
+
+Zwei Wege zum Auslösen:
+
+1. **Automatisch** — setzen Sie `prewarm_active_tenants = true` auf der
+   `TenantPoolsConfig`, die Sie `TenantPools::new(...).config(...)` übergeben.
+   `Server::Builder::serve` führt das Pre-Warming vor dem Binden aus.
+
+2. **CLI-Verb** — `cargo run -- prewarm-pools` baut Pools für jeden aktiven
+   Tenant im database-Modus und beendet sich. Nützlich als Post-Deploy-Hook
+   (z. B. nach einer Anmeldedaten-Rotation) oder um zu validieren, dass jeder
+   Tenant erreichbar ist, bevor ein Load-Balancer umgeschaltet wird.
+
+Das Pre-Warming durchläuft `Org::objects().where(active = true, storage_mode =
+"database")` und bricht kurz, wenn die Cache-Obergrenze erreicht ist (gemeldet
+als `skipped_cap` im [`PrewarmReport`]). Per-Tenant-Build-Fehler loggen ein
+`tracing::warn!`, brechen die Schleife aber nicht ab.
+
+### Tracing
+
+`crate::tenancy::pools::tenant_pool_init` ist ein `tracing::info_span!`, der den
+Cold-Path-Pool-Build umschließt. Abonnieren Sie ihn, um die Per-Tenant-Build-
+Latenz zu sehen:
+
+```text
+INFO crate::tenancy::pools: tenant pool connected (database mode)
+     slug=acme elapsed_ms=42 min_conn=1 max_conn=4
+```
+
+### Einrichtungs-Falle — macOS `.local`-TLDs
+
+Wenn Sie den Tenant-Admin über `http://acme.local:8080/admin/` auf macOS
+erreichen und bei jedem Request eine 5-Sekunden-Pause sehen: das ist
+**Bonjour / mDNS**, nicht **Rustango**. Der Resolver von macOS behandelt
+`.local` speziell und wartet den vollen mDNS-Timeout ab, bevor er auf
+`/etc/hosts` zurückfällt. Zwei Lösungen:
+
+1. **Verwenden Sie eine andere TLD**: `127.0.0.1 acme.localhost` funktioniert
+   ohne Verzögerung. `localhost` ist reserviert (RFC 6761) und überspringt
+   mDNS.
+2. **Betreiben Sie dnsmasq** mit einer `.local`-Zone, die auf 127.0.0.1 zeigt,
+   damit das OS eine sofortige Antwort erhält.
+
+Bestätigen Sie mit `curl -w "%{time_connect}\n"`: wenn `time_connect` ~5s zeigt,
+aber mit `--resolve acme.local:8080:127.0.0.1` auf Millisekunden fällt, treffen
+Sie auf mDNS.
+
+
+---
+
+## Siehe auch
+
+- [ORM-Kochbuch](orm.md)
+- [Scaffolding](scaffolding.md)
+- [ViewSets](viewsets.md)
+- [Serializer](serializers.md)
+- [Sicherheitsleitfaden](security.md)

--- a/docs/de/mcp.md
+++ b/docs/de/mcp.md
@@ -1,0 +1,486 @@
+# MCP-Server
+
+Das **Model Context Protocol (MCP)** ist der offene Standard, der es einem
+KI-Agenten — Claude, einem IDE-Assistenten, Ihrer eigenen LLM-App — erlaubt,
+sicher die **Tools** *Ihrer* Anwendung aufzurufen, ihre **Resources** zu lesen
+und ihre **Prompts** zu nutzen. **Rustango** liefert einen produktionsreifen
+MCP-Server: Registrieren Sie ein Tool mit einem einzigen Makro, mounten Sie einen
+Router, und jeder MCP-Client kann es über den standardmäßigen JSON-RPC-Transport
+entdecken und aufrufen — mit pro-Agent, **fail-closed** Autorisierung und
+eingebautem OAuth 2.1.
+
+[![MCP-Server in Rustango: Ein LLM-Agent verbindet sich über JSON-RPC + SSE; der Server authentifiziert das JWT des Agenten, listet nur die Tools auf, die seine gewährten Skills erlauben, und führt den Tool-Handler gegen den Pool Ihrer App aus](img/mcp.png)](img/mcp.png)
+
+> **Ein Begriff hier neu?** *MCP*, *JSON-RPC*, *Tool/Resource/Prompt*, *Agent*,
+> *JWT*, *OAuth* — siehe das [Glossar](glossary.md).
+
+> **Quelle:** `rustango::mcp` (`router`, `tenant_router`, `secure_tenant_router`,
+> `secure_tenant_router_from_settings`, `register_mcp_tool!`,
+> `register_mcp_resource!`, `McpContext`, `issue_agent_token`) und die
+> Agent/Skill-Helfer aus `rustango::tenancy` — hinter dem **`mcp`-Feature**
+> (standardmäßig AUS; zieht `tenancy, sse, serializer, openapi, jwt` mit).
+>
+> **Lauffähige Version:** Jeder Ausschnitt ist aus
+> [`mcp_doc.rs`](../crates/rustango/tests/mcp_doc.rs) kopiert
+> (`cargo test -p rustango --features sqlite,mcp --test mcp_doc`); die gesamte
+> Protokolloberfläche wird von der Suite `crates/rustango/tests/mcp_*.rs` im
+> Realbetrieb erprobt, und ein lauffähiger Server liegt in
+> [`examples/mcp_demo`](../crates/rustango/examples/mcp_demo).
+
+## Inhaltsverzeichnis
+
+- [Was MCP Ihnen bietet](#what-mcp-gives-you)
+- [Schritt 1 — Das Feature aktivieren](#step-1--enable-the-feature)
+- [Schritt 2 — Ein Tool definieren](#step-2--define-a-tool)
+- [Schritt 3 — Den Server mounten](#step-3--mount-the-server)
+- [Schritt 4 — Agenten autorisieren](#step-4--authorize-agents)
+- [Das Protokoll](#the-protocol)
+- [Einstellungen](#settings)
+- [Wie man testet](#how-to-test) — [die Suite](#a-the-test-suite) · [curl](#b-curl-the-json-rpc) · [der visuelle MCP Inspector](#c-test-it-visually-with-the-mcp-inspector) · [ein echter Client](#d-connect-a-real-mcp-client)
+- [Optionaler vs. Standard-Build](#optional-vs-default-build)
+- [Siehe auch](#see-also)
+
+---
+
+## Was MCP Ihnen bietet
+
+Ein **Rustango**-MCP-Server stellt drei Dinge bereit, die ein Agent nutzen kann,
+alle **von Hand registriert für explizite Kontrolle** (nichts wird automatisch
+freigegeben):
+
+| Primitiv | Was es ist | Wie es deklariert wird |
+|---|---|---|
+| **Tool** | eine Funktion, die der Agent aufruft (mit typisierten JSON-Argumenten) | `register_mcp_tool!` |
+| **Resource** | lesbarer Inhalt, den der Agent per URI abruft | `register_mcp_resource!` + skill-gebunden |
+| **Prompt** | eine wiederverwendbare Instruktionsvorlage | abgeleitet aus einem gewährten **Skill** |
+
+Jeder Aufruf ist **pro Agent autorisiert**: Das JWT eines Agenten trägt die
+**Skills** (und die Tools, die sie freischalten), die ihm gewährt wurden, und
+`tools/list` / `tools/call` **schlagen fail-closed fehl** — ein Agent sieht oder
+führt niemals ein Tool aus, das ihm nicht gewährt wurde.
+
+---
+
+## Schritt 1 — Das Feature aktivieren
+
+MCP ist das optionale `mcp`-Feature (standardmäßig aus). Schalten Sie es ein:
+
+```toml
+# Cargo.toml
+rustango = { version = "0.44", features = ["mcp"] }
+```
+
+Es zieht `tenancy` (Agenten/Skills), `sse` (den Benachrichtigungsstrom),
+`serializer` + `openapi` (die Tool-Eingabeschemata) und `jwt` (Agenten-Tokens)
+mit. Ein Build **ohne** das Feature kompiliert nichts vom MCP-Modul — siehe
+[Optionaler vs. Standard-Build](#optional-vs-default-build).
+
+---
+
+## Schritt 2 — Ein Tool definieren
+
+Ein Tool ist eine typisierte Eingabe-Struct + ein async Handler, zur
+Kompilierzeit mit `register_mcp_tool!` registriert. Der Eingabetyp leitet
+`serde::Deserialize` ab und implementiert `OpenApiSchema` (was zum veröffentlichten
+JSON Schema des Tools wird):
+
+```rust
+use rustango::mcp::{McpContext, McpError};
+use serde_json::json;
+
+rustango::register_mcp_tool!(
+    "add",
+    "Add two integers",
+    AddInput,
+    |_ctx: McpContext, input: AddInput| async move {
+        Ok::<_, McpError>(json!({ "sum": input.a + input.b }))
+    },
+);
+
+#[derive(serde::Deserialize)]
+struct AddInput { a: i64, b: i64 }
+
+impl rustango::openapi::OpenApiSchema for AddInput {
+    fn openapi_schema() -> rustango::openapi::Schema {
+        rustango::openapi::Schema::object()
+            .property("a", rustango::openapi::Schema::integer())
+            .property("b", rustango::openapi::Schema::integer())
+            .required(["a", "b"])
+    }
+}
+```
+
+Der Handler erhält einen `McpContext { pool, agent, progress, cancel }` — den
+Tenant-DB-Pool, den authentifizierten Agenten, einen Fortschrittsmelder und ein
+Cancellation-Token — sodass ein Tool Ihre Modelle abfragen, den Fortschritt
+langer Arbeit melden und bei Abbruch aussteigen kann. Geben Sie einen beliebigen
+`serde_json::Value` zurück (er wird als `structuredContent` des Tools
+präsentiert) oder einen `McpError`.
+
+**Resources** sind statischer Inhalt, auf dieselbe Weise registriert:
+
+```rust
+rustango::register_mcp_resource!(
+    "rustango://about", "About", "text/plain",
+    || "This server exposes the demo tools.".to_string(),
+);
+```
+
+**Prompts** stammen aus **Skills** (nächster Schritt) — die Instruktionen eines
+Skills werden zu einem Prompt, den der Agent abrufen kann.
+
+---
+
+## Schritt 3 — Den Server mounten
+
+Wählen Sie ein Mount passend zu Ihrem Deployment; alle geben einen `axum::Router`
+zurück, den Sie unter einem Präfix verschachteln (konventionell `/mcp`):
+
+| Mount | Tenancy | Auth | Verwenden für |
+|---|---|---|---|
+| `mcp::router(pool)` | single-tenant | keine | nur Transport (`initialize`/`ping`) |
+| `mcp::tenant_router()` | multi-tenant | keine | nur Transport (Pool pro Anfrage) |
+| `mcp::secure_tenant_router()` | multi-tenant | **Agenten-JWT** | die echte Sache |
+| `mcp::secure_tenant_router_from_settings(&s)` | multi-tenant | Agenten-JWT | Produktion (CORS, Rate-Limit, SSE, Body-Cap aus `[mcp]`) |
+
+Tools benötigen den **authentifizierten** Pfad (einen Agenten-Kontext), daher
+verwenden Produktionsserver `secure_tenant_router*`:
+
+```rust
+use rustango::mcp;
+
+let api = axum::Router::new()
+    .nest("/mcp", mcp::secure_tenant_router_from_settings(&settings.mcp));
+// hand `api` to your tenancy Cli/Builder as usual
+```
+
+Der authentifizierte Router mountet: `POST {prefix}` (JSON-RPC), `GET {prefix}`
+(SSE-Benachrichtigungen), `POST {prefix}/token` (Credential → JWT),
+`POST {prefix}/oauth/token` (OAuth 2.1) und die beiden `.well-known/*`
+Discovery-Dokumente. Er signiert Agenten-Tokens mit `RUSTANGO_SESSION_SECRET`.
+
+Der `initialize`-Handshake ist ein einfacher JSON-RPC-POST und funktioniert auf
+jedem Mount:
+
+```json
+// → POST /mcp
+{ "jsonrpc": "2.0", "id": 1, "method": "initialize",
+  "params": { "protocolVersion": "2025-06-18", "capabilities": {},
+              "clientInfo": { "name": "my-client", "version": "0" } } }
+
+// ← 200
+{ "jsonrpc": "2.0", "id": 1, "result": {
+    "protocolVersion": "2025-06-18",
+    "serverInfo": { "name": "rustango", "version": "0.44.0" },
+    "capabilities": { "tools": { "listChanged": true }, "prompts": {}, "resources": {} } } }
+```
+
+---
+
+## Schritt 4 — Agenten autorisieren
+
+Die Autorisierung ist **skill-basiert und fail-closed**. Sie provisionieren einen
+**Agenten** (der ein einmaliges Secret erhält), definieren einen **Skill**, der
+Tools (und Resources/einen Prompt) bündelt, und **gewähren** dann den Skill dem
+Agenten in einem Tenant:
+
+```rust
+use rustango::tenancy::{create_agent_pool, create_skill_pool, grant_skill_pool};
+
+// 1. Provision an agent — returns a one-time `name`.`secret` credential.
+let issued = create_agent_pool(&pool, "calc-bot").await?;
+
+// 2. A skill bundles tools (here, the `add` tool) + a prompt body.
+create_skill_pool(&pool, "calculator", "Calculator", "does arithmetic",
+                  "You are a precise calculator.", &["add".into()]).await?;
+
+// 3. Grant it to the agent in tenant "acme".
+grant_skill_pool(&pool, "acme", "calc-bot", "calculator").await?;
+```
+
+Der Client tauscht sein Credential gegen ein **tenant-gepinntes, scoped JWT** an
+`POST /mcp/token` (oder über den OAuth-`client_credentials`-Flow an
+`/mcp/oauth/token`). Der Server löst die Gewährung in die `skills` + `tools`
+Claims des Tokens auf; jede Anfrage verifiziert es erneut. Der Effekt, von Ende
+zu Ende verifiziert:
+
+```rust
+// tools/list returns ONLY the granted tool, with its JSON Schema:
+let listed = list_tools(&agent);                       // → { "tools": [ { "name": "add", … } ] }
+
+// tools/call runs the handler and returns a structured result:
+let out = call_tool(ctx, json!({ "name": "add", "arguments": { "a": 2, "b": 3 } })).await?;
+assert_eq!(out["structuredContent"]["sum"], 5);
+
+// An agent WITHOUT the grant sees an empty list and is refused:
+//   list_tools(&ungranted) → { "tools": [] }
+//   call_tool(ungranted, "add") → Err(code = TOOL_FORBIDDEN)
+```
+
+Tokens sind tenant-gepinnt: Ein für `acme` ausgestelltes Token wird gegen jeden
+anderen Tenant abgelehnt (Cross-Tenant-Replay → 401). Widerrufen Sie einen
+Agenten, und seine JTI wird auf die Blacklist gesetzt.
+
+### Nutzereigene Keys (berechtigungsgesteuerte Capabilities)
+
+Die obigen Agenten sind eigenständige Maschinenidentitäten. Ein Mitglied kann
+stattdessen einen **persönlichen Key** generieren — einen nutzereigenen Agenten —
+sodass ein LLM *in seinem Namen* handelt, mit Capabilities, die dem bestehenden
+**RBAC** des Tenants folgen, statt einer auf den Key gepinnten Liste.
+
+Zwei Teile verdrahten es:
+
+```rust
+use rustango::tenancy::{create_user_key_pool, create_skill_pool, map_skill_to_permission_pool};
+
+// 1. Map a skill to a permission codename. Any user-owned key whose owner
+//    holds `mcp.coach` is then granted this skill's tools + prompt + resources.
+create_skill_pool(&pool, "coach", "Coach", "logs workouts",
+                  "You are the member's coach.", &["log_set".into()]).await?;
+map_skill_to_permission_pool(&pool, "coach", "mcp.coach").await?;
+
+// 2. The member generates a key — a one-time `name`.`secret`, shown once.
+//    `&[]` = a FULL key: everything the owner is entitled to. Pass skill
+//    codenames to SCOPE the key to a single skill or a skillset instead —
+//    always bounded by the owner's entitlement (you can't exceed your perms):
+let issued = create_user_key_pool(&pool, user_id, "Alice's phone", &[]).await?;
+// scoped: create_user_key_pool(&pool, user_id, "coach bot", &["coach".into()]).await?;
+println!("copy once: {}", issued.token);
+```
+
+Bei der Token-Ausstellung ruft der Server
+[`resolve_user_agent_grants_pool`](../crates/rustango/src/tenancy/agents.rs) auf —
+die effektiven Berechtigungen des Eigentümers (`user_permissions_pool`, d. h.
+Rollen + direkte Gewährungen − Verweigerungen) wählen die gemappten Skills, deren
+Tools/Prompts/Resources in die `skills`/`tools` Claims des JWT eingeebnet werden.
+So sind `tools/list`, `tools/call`, `prompts/get` und `resources/read` **alle**
+durch RBAC abgesichert, ohne Änderung an diesen Handlern. Der besitzende Nutzer
+reist im `uid`-Claim des Tokens mit; ein Tool-Handler liest ihn als
+`ctx.agent.user_id`, um die Arbeit auf dieses Mitglied zu beschränken. Widerrufen
+Sie frische Capabilities, indem Sie die Berechtigungen des Nutzers ändern (sie
+werden beim nächsten Token neu aufgelöst); widerrufen Sie den Key selbst mit
+`revoke_user_key_pool(&pool, user_id, agent_id)`. Listen Sie die Keys eines
+Mitglieds mit `list_user_keys_pool(&pool, user_id)` auf.
+
+**Scope pro Key vs. Berechtigung pro Nutzer.** Skills erreichen einen Key entlang
+zweier Achsen: die **Berechtigung** des Eigentümers (Superuser → jeder Skill;
+sonst die einer von ihm gehaltenen Permission zugeordneten Skills) und der
+**Scope** des Keys (bei der Erstellung gepinnte Skills). Ein Key ohne Scope
+(`skills = &[]`) erhält die volle Berechtigung des Eigentümers; ein gescopeter Key
+(`skills = &["coach", …]`) ist auf diese beschränkt. Die Auflösung schneidet den
+Scope stets erneut mit der *aktuellen* Berechtigung — sodass ein Key niemals die
+Berechtigungen des Eigentümers überschreiten kann, und der Verlust einer
+Permission jeden Key bei der nächsten Ausstellung einengt. Ein Scope auf einen
+Skill, zu dem der Eigentümer nicht berechtigt ist, wird bei der Erstellung
+abgelehnt.
+
+Eigenständige Agenten sind unberührt — ein Maschinenagent (`user_id = None`)
+verwendet weiterhin nur seine expliziten `grant_skill_pool`-Gewährungen.
+
+### Über die CLI (`manage`-Verben)
+
+Alles Obige ist auch out of the box über den tenancy-bewussten `manage`-Dispatcher
+verfügbar (diese Verben kompilieren mit dem `mcp`-Feature). Jedes ist
+tenant-scoped und nimmt ein `<slug>`:
+
+| Verb | Was es tut |
+|---|---|
+| `create-agent <slug> <name>` | Provisioniert einen Maschinenagenten; druckt sein `prefix.secret` **einmalig**. |
+| `rotate-agent-secret <slug> <name>` | Stellt ein frisches Secret aus und macht das alte ungültig. |
+| `list-agents <slug>` | Listet die Agenten eines Tenants (id, name, status, prefix). |
+| `create-skill <slug> <codename> [--name ..] [--description ..] [--tools a,b] [--instructions ..]` | Definiert einen Skill (ein Bündel aus Tools + Prompt). |
+| `grant-skill <slug> <agent> <skill>` | Gewährt einem Agenten einen Skill. |
+| `revoke-skill <slug> <agent> <skill>` | Widerruft einem Agenten einen Skill. |
+| `list-skills <slug>` | Listet die Skills eines Tenants. |
+| `create-user-key <slug> <username> [--label <l>] [--skill <codename>]…` | Stellt einen **nutzereigenen Key** aus; druckt sein Token **einmalig**. Wiederholen Sie `--skill`, um den Key auf einen einzelnen Skill oder ein Skillset zu scopen; weglassen für einen vollständigen Key (Standard-Label = username). |
+| `list-user-keys <slug> <username>` | Listet die persönlichen Keys eines Nutzers (id, label, created-at). |
+| `revoke-user-key <slug> <username> <key_id>` | Widerruft einen der persönlichen Keys eines Nutzers per id (eigentumsgeprüft). |
+| `map-skill-permission <slug> <skill> <permission>` | Mappt einen Skill auf einen Permission-Codename. Idempotent — jeder Nutzer-Key, dessen Eigentümer `<permission>` hält, gewinnt den Skill. |
+| `unmap-skill-permission <slug> <skill> <permission>` | Entfernt ein Skill↔Permission-Mapping. |
+
+Der **Permission → Skill → Tools** Fluss von Ende zu Ende:
+
+```console
+# 1. Define the skill and map it to a permission codename.
+$ cargo run -- create-skill acme coach --tools log_set --instructions "You are the member's coach."
+$ cargo run -- map-skill-permission acme coach mcp.coach
+
+# 2. Grant the permission to the member (roles or direct — see grant-perm),
+#    then issue their personal key.
+$ cargo run -- grant-perm acme alice mcp.coach
+$ cargo run -- create-user-key acme alice --label "Alice's phone"
+created key #7 for user `alice` in tenant `acme` (label `Alice's phone`, scope full (owner's permissions))
+  token: 3f9c1a2b.7d…            # copy once — never shown again
+  store this safely — it won't be shown again
+
+# …or scope the key to a single skill / skillset (repeat --skill):
+$ cargo run -- create-user-key acme alice --label "coach bot" --skill coach
+```
+
+Alices Key löst nun bei jeder Token-Ausstellung die Tools des `coach`-Skills auf,
+weil sie `mcp.coach` hält. Ändern Sie ihre Berechtigungen und die Capabilities
+werden bei ihrem nächsten Token neu aufgelöst; widerrufen Sie den Key selbst mit
+`revoke-user-key`. Dieselbe Key-id ist von Maschinenagenten im Tenant-Admin
+unterscheidbar (die `Agent`-Liste zeigt `user_id`).
+
+Der Auto-Admin stellt diese ebenfalls dar: `Agent`, `AgentSkill`,
+`AgentSkillPermission` (und `AgentGrant`) rendern jeweils eine Auto-CRUD-Tabelle
+im Tenant-Admin, sodass die Skill↔Permission-Mappings ohne die CLI überprüft und
+bearbeitet werden können.
+
+---
+
+## Das Protokoll
+
+JSON-RPC 2.0 (Protokollversion `2025-06-18`) über HTTP POST, mit einem optionalen
+SSE-Strom (`GET {prefix}`) für Server→Client-Benachrichtigungen. Methoden:
+
+| Methode | Auth | Zweck |
+|---|---|---|
+| `initialize` · `ping` | nein | Handshake + Liveness |
+| `tools/list` · `tools/call` | ja | Tools entdecken + aufrufen (nur gewährte) |
+| `prompts/list` · `prompts/get` | ja | skill-abgeleitete Prompts |
+| `resources/list` · `resources/read` · `resources/templates/list` | ja | statische + Skill-Resources |
+| `logging/setLevel` · `completion/complete` | ja | Log-Level + Präfix-Vervollständigung |
+| `notifications/progress` · `notifications/*/list_changed` | — | Server→Client über SSE |
+| `notifications/cancelled` | — | Client bricht einen laufenden Aufruf ab |
+
+Ein fehlgeschlagener Tool-*Handler* gibt ein normales Ergebnis mit `isError: true`
+zurück (der Agent kann reagieren); Probleme auf Protokollebene (unbekanntes/
+verbotenes Tool, ungültige Params) geben einen JSON-RPC-`error` mit Codes wie
+`-32002` (`TOOL_NOT_FOUND`), `-32003` (`TOOL_FORBIDDEN`), `-32602`
+(`INVALID_PARAMS`) zurück. Lange Tools melden Fortschritt und honorieren
+Abbrüche über den `McpContext`.
+
+---
+
+## Einstellungen
+
+Der Abschnitt `[mcp]` (gelesen von `secure_tenant_router_from_settings`):
+
+```toml
+[mcp]
+prefix                = "/mcp"   # URL prefix the router mounts under
+token_ttl_secs        = 900      # agent access-token lifetime (15 min)
+enable_sse            = true     # serve the GET {prefix} SSE stream
+allowed_origins       = []       # CORS allow-list (empty = same-origin only)
+rate_limit_per_minute = 0        # per-IP cap (0/unset = unlimited)
+max_tools_listed      = 0        # tools/list page size (0/unset = unlimited)
+```
+
+---
+
+## Wie man testet
+
+### (a) Die Test-Suite
+
+Das gesamte Protokoll wird von `crates/rustango/tests/mcp_*.rs` + dem
+untermauernden Test der Doku abgedeckt. Führen Sie sie mit aktiviertem Feature
+aus:
+
+```bash
+# The doc's headline flow (register → initialize → grant → list → call → fail-closed):
+cargo test -p rustango --features sqlite,mcp --test mcp_doc
+
+# Slices + end-to-end + OAuth + settings:
+cargo test -p rustango --features sqlite,mcp,config --test 'mcp_*'
+```
+
+### (b) curl das JSON-RPC
+
+Booten Sie die Demo (nächster Abschnitt) und sprechen Sie direkt mit ihr. Die
+Demo sichert **jede** Methode hinter einem Agenten-Token (ein nicht
+authentifizierter Aufruf gibt `401` zurück), also prägen Sie zuerst eines — die
+Demo druckt das Agenten-Secret beim Booten:
+
+```bash
+TOKEN=$(curl -sX POST http://localhost:8090/mcp/token \
+  -H 'content-type: application/json' -d '{"name":"demo-bot","secret":"<printed-secret>"}' \
+  | jq -r .access_token)
+
+# initialize:
+curl -sX POST http://localhost:8090/mcp -H "authorization: Bearer $TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
+
+# tools/call — only the granted `add` tool is callable:
+curl -sX POST http://localhost:8090/mcp -H "authorization: Bearer $TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"add","arguments":{"a":2,"b":3}}}'
+# → { ... "result": { "structuredContent": { "sum": 5 }, "isError": false } }
+```
+
+### (c) Testen Sie es visuell mit dem MCP Inspector
+
+Der [MCP Inspector](https://github.com/modelcontextprotocol/inspector) ist der
+offizielle visuelle Client — verbinden Sie ihn mit Ihrem Server und klicken Sie
+sich durch Tools, Resources und Prompts. Starten Sie die Demo, dann den
+Inspector:
+
+```bash
+# 1. Start the demo MCP server (seeds an `acme` tenant + `demo-bot` agent + the `add` tool):
+cd crates/rustango/examples/mcp_demo && cargo run   # serves on http://localhost:8090/mcp
+
+# 2. Launch the Inspector (opens a browser UI on http://localhost:6274):
+npx @modelcontextprotocol/inspector
+```
+
+Im Inspector: Stellen Sie den Transport auf **Streamable HTTP** und die URL auf
+`http://localhost:8090/mcp`. Öffnen Sie **Authentication → Custom Headers**, fügen
+Sie einen Header `Authorization` mit dem Wert `Bearer <token>` hinzu (prägen Sie
+das Token mit dem obigen `/mcp/token`-Aufruf), schalten Sie die Zeile ein, dann
+**Connect**.
+
+Wechseln Sie zum **Tools**-Tab und klicken Sie **List Tools** — Sie sehen *nur*
+das `add`-Tool, das der Skill des Agenten gewährt, mit seinem JSON Schema. Wählen
+Sie es aus, geben Sie `a = 2`, `b = 3` ein und **Run Tool**:
+
+[![Der MCP Inspector über Streamable HTTP mit der Rustango-Demo verbunden, zeigt das gewährte `add`-Tool und sein a/b-Eingabeschema](img/mcp-inspector-tools.png)](img/mcp-inspector-tools.png)
+
+Der Aufruf gibt ein strukturiertes Ergebnis zurück — `{ "sum": 5 }` — und die
+Anfrage erscheint im History-Panel (`initialize` → `tools/list` → `tools/call`):
+
+[![Derselbe Inspector nach der Tool-Ausführung: Tool Result Success mit strukturiertem Inhalt { sum: 5 } und die JSON-RPC-Aufrufhistorie](img/mcp-inspector-call.png)](img/mcp-inspector-call.png)
+
+### (d) Einen echten MCP-Client verbinden
+
+Richten Sie Claude Code (oder einen beliebigen MCP-Client) auf den laufenden
+Server, indem Sie das Agenten-Token als Header übergeben (prägen Sie es mit dem
+obigen `/mcp/token`-Aufruf):
+
+```bash
+claude mcp add --transport http rustango-demo http://localhost:8090/mcp \
+  --header "Authorization: Bearer $TOKEN"
+```
+
+Bitten Sie dann den Agenten, zwei Zahlen zu addieren — er entdeckt und ruft das
+`add`-Tool über dasselbe Protokoll auf, das der Inspector verwendet hat.
+
+---
+
+## Optionaler vs. Standard-Build
+
+Das Feature ist vollständig gated — das gesamte `rustango::mcp`-Modul liegt
+hinter `#[cfg(feature = "mcp")]`, sodass es niemals Apps betrifft, die sich nicht
+einschreiben:
+
+```bash
+cargo build -p rustango                 # default — MCP module NOT compiled
+cargo build -p rustango --features mcp  # MCP server compiled + linked
+```
+
+Eine Standard-App trägt keinerlei MCP-Code, -Abhängigkeiten oder -Routen; das
+Aktivieren des Features ist das Einzige, was es einschaltet.
+
+---
+
+## Siehe auch
+
+- [OpenAPI](openapi.md) — die JSON-Schema-Maschinerie, die die Eingabe eines
+  Tools wiederverwendet.
+- [JWT-Auth-API](auth-jwt-api.md) · [Auth-Backends](auth-backends.md) — der
+  Token-Lebenszyklus, auf dem die Agenten-Auth aufgebaut ist.
+- [Sicherheitsleitfaden](security.md) — fail-closed Autorisierung, Secrets,
+  Rate-Limits.
+- [Hintergrund-Jobs](jobs.md) — die Arbeit eines langen Tools außerhalb der
+  Anfrage ausführen.

--- a/docs/de/middleware.md
+++ b/docs/de/middleware.md
@@ -1,0 +1,435 @@
+# Middleware
+
+Middleware ist Code, der **rund um** jeden Request läuft — bevor ihn dein
+Handler sieht und nachdem er eine Response erzeugt hat. Hier leben die
+Querschnittsthemen: Logging, Rate Limiting, Security-Header, CSRF, Auflösung von
+Locale und Zeitzone. **Rustango** liefert einen umfangreichen Katalog
+gebrauchsfertiger Middleware und macht das Schreiben eigener zu einer Sache
+weniger Zeilen. Wenn du von Django kommst, ist das die `MIDDLEWARE`-Liste; von
+Express `app.use()`; von Laravel der HTTP-Kernel — dieselbe Idee, an deinen
+Router angehängt.
+
+[![Middleware in Rustango: a request flows down through a stack of tower layers (request-id, locale, security headers, CSRF) into the handler and back up through the response side of each layer](img/middleware.png)](img/middleware.png)
+
+> **Quelle:** Middleware baut auf [`tower::Layer`](https://docs.rs/tower) +
+> `axum::middleware::from_fn` auf. Die eingebauten Bausteine verteilen sich über
+> `rustango::{access_log, rate_limit, cors, security_headers, request_id, …}`,
+> plus `rustango::forms::csrf` (die `csrf`-Feature) und `rustango::i18n`
+> (`middleware::LocaleMiddleware`, `timezone`). Die meisten sind standardmäßig
+> aktiv.
+>
+> **Ausführbare Version:** jeder Codeausschnitt unten ist aus dem getesteten
+> Beispiel unter
+> `crates/rustango/examples/getting_started_blog/tests/middleware.rs`
+> kopiert (Locale, Zeitzone, Security-Header, CSRF — alle ohne Datenbank).
+> Führe es mit `cargo test -p getting_started_blog --test middleware` aus.
+
+> **Ein Begriff hier neu für dich?** *Middleware*, *Layer*, *CSRF*, *Locale* —
+> das [Glossar](glossary.md) erklärt sie in einfachen Worten.
+
+## Inhaltsverzeichnis
+
+- [Wie Middleware in Rustango funktioniert](#how-middleware-works-in-rustango)
+- [Die Reihenfolge zählt](#ordering-matters)
+- [Der eingebaute Katalog](#the-built-in-catalog)
+- [Locale-bewusste Middleware](#locale-aware-middleware)
+- [Zeitzonen-bewusste Middleware](#timezone-aware-middleware)
+- [Security-Header](#security-headers)
+- [CSRF-Schutz](#csrf-protection)
+- [Eigene Middleware schreiben](#writing-your-own-middleware)
+- [Siehe auch](#see-also)
+
+---
+
+## Wie Middleware in Rustango funktioniert
+
+Es gibt zwei Formen, und du wirst beide verwenden:
+
+1. **Ein `tower::Layer`** — ein wiederverwendbares, konfigurierbares
+   Middleware-Struct. Jeder eingebaute Baustein ist einer
+   (`SecurityHeadersLayer`, `RateLimitLayer`, …). Du hängst einen Layer mit
+   axums `.layer(...)` an, oder — für die meisten Bausteine — mit einem
+   **Einzeiler über einen Extension-Trait**, der sich besser liest:
+
+   ```rust
+   use rustango::security_headers::{SecurityHeadersLayer, SecurityHeadersRouterExt};
+
+   // These two are equivalent; the second is the ergonomic form.
+   let app = router.layer(SecurityHeadersLayer::strict());
+   let app = router.security_headers(SecurityHeadersLayer::strict());
+   ```
+
+   Jedes eingebaute Modul exportiert einen `…RouterExt`-Trait
+   (`SecurityHeadersRouterExt`, `RateLimitRouterExt`, …). Bring ihn in den
+   Scope und du erhältst eine Methode `.security_headers()` / `.rate_limit()` /
+   `.cors()` direkt auf `Router`. Das ist der idiomatische Weg, einen Stack zu
+   verdrahten:
+
+   ```rust
+   let app = router
+       .request_id(RequestIdLayer::default())
+       .access_log(AccessLogLayer::default())
+       .rate_limit(RateLimitLayer::per_ip(60, Duration::from_secs(60)))
+       .cors(CorsLayer::new().allow_origins(vec!["https://app.example.com"]))
+       .security_headers(SecurityHeadersLayer::strict());
+   ```
+
+2. **Eine Funktion über `axum::middleware::from_fn`** — der schnellste Weg, eine
+   einmalige zu schreiben. Du erhältst den `Request` und ein `Next`; du rufst
+   `next.run(req)` auf, um fortzufahren, und du kannst auf beiden Seiten dieses
+   Aufrufs arbeiten. Das [Zeitzonen-Beispiel](#timezone-aware-middleware) unten
+   ist genau das.
+
+Beide lassen sich frei komponieren — eine `from_fn`-Middleware *ist* ein Layer,
+sie stapelt sich also mit den eingebauten Bausteinen in derselben
+`.layer(...)`-Kette.
+
+---
+
+## Die Reihenfolge zählt
+
+Ein Layer umschließt alles, was **vor** ihm hinzugefügt wurde, daher ist der
+**zuletzt** angehängte Layer der **äußerste** — er läuft auf dem Weg hinein
+zuerst und auf dem Weg hinaus zuletzt. Stell dir den Stack als Zwiebel vor; der
+Request wandert hinab zum Handler und die Response wandert wieder hinauf:
+
+```text
+            ┌──────────────────────────────────────┐
+request  →  │ security_headers   (added last = top) │  → response
+            │   ┌────────────────────────────────┐  │
+            │   │ rate_limit                     │  │
+            │   │   ┌──────────────────────────┐ │  │
+            │   │   │ request_id (added first) │ │  │
+            │   │   │      → handler →         │ │  │
+            │   │   └──────────────────────────┘ │  │
+            │   └────────────────────────────────┘  │
+            └──────────────────────────────────────┘
+```
+
+Praktische Konsequenzen:
+
+- **Platziere `request_id` / `access_log` nahe am Boden** (zuerst hinzugefügt),
+  damit die Korrelations-ID und der Log-Span alles abdecken, was nach ihnen
+  läuft.
+- **Platziere abweisungsgünstige Guards nahe der Spitze** (zuletzt hinzugefügt)
+  — `allowed_hosts`, `rate_limit`, `body_limit` — damit ein blockierter Request
+  verworfen wird, bevor er die teuren inneren Layer erreicht.
+- **`security_headers` am äußersten**, damit die Header auf *jede* Response
+  gestempelt werden, auch auf solche, die von einem inneren Layer
+  kurzgeschlossen werden (ein 429, ein 403).
+
+---
+
+## Der eingebaute Katalog
+
+Jeder Eintrag ist ein `tower::Layer` mit einem passenden
+`…RouterExt`-Einzeiler, sofern nicht anders vermerkt. Bring den
+`…RouterExt`-Trait des Moduls in den Scope, um die Methode zu erhalten.
+
+| Thema | Layer | Verdrahten mit |
+| --- | --- | --- |
+| **Sicherheit & Zugriff** | | |
+| Security-Header (HSTS, XFO, CSP…) | `SecurityHeadersLayer` | `.security_headers(..)` |
+| CSRF (Double-Submit-Cookie) | `CsrfLayer` | `.layer(csrf::layer())` |
+| CORS | `CorsLayer` | `.cors(..)` |
+| Host-Allowlist | `AllowedHostsLayer` | `.allowed_hosts(..)` |
+| IP zulassen/blockieren | `IpFilterLayer` | `.ip_filter(..)` |
+| HTTPS erzwingen | `SslRedirectLayer` | `.ssl_redirect(..)` |
+| CSP-Nonce pro Request | `CspNonceLayer` | `.csp_nonce(..)` |
+| HMAC-Request-Signierung | `HmacAuthLayer` | `.layer(..)` |
+| **Traffic & Resilienz** | | |
+| Rate Limit (pro IP/global) | `RateLimitLayer` | `.rate_limit(..)` |
+| Verteiltes Rate Limit (Cache-gestützt) | `CacheRateLimitLayer` | `.cache_rate_limit(..)` |
+| Request-Timeout | `RequestTimeoutLayer` | `.request_timeout(..)` |
+| Maximale Body-Größe | `BodyLimitLayer` | `.body_limit(..)` |
+| Wartungsmodus (503) | `MaintenanceLayer` | `.maintenance(..)` |
+| Idempotenz-Schlüssel | `IdempotencyLayer` | `.idempotency(..)` |
+| HTTP-Methoden einschränken | `MethodRestrictLayer` | `.require_get()` / `.require_post()` / `.require_safe()` |
+| **Observability** | | |
+| Request-ID (`X-Request-Id`) | `RequestIdLayer` | `.request_id(..)` |
+| Access-Log (PII-redigiert) | `AccessLogLayer` | `.access_log(..)` |
+| `tracing`-Spans | `TracingLayer` | `.layer(..)` |
+| `Server-Timing`-Header | `ServerTimingLayer` | `.server_timing(..)` |
+| Echte Client-IP (hinter Proxys) | `RealIpLayer` | `.real_ip(..)` |
+| **Inhalt & Response** | | |
+| gzip/br-Kompression | `CompressionLayer` | `.compression(..)` |
+| ETag / bedingtes GET | `EtagLayer` | `.etag(..)` |
+| Trailing-Slash-Redirect | `TrailingSlashLayer` | `.trailing_slash(..)` |
+| Page-Caching | `CachePageLayer` | `.layer(..)` |
+| **Lokalisierung** | | |
+| Locale-Aushandlung | `LocaleMiddleware` | `.layer(..)` (+ `ActiveLocale`-Extractor) |
+| Aktive Zeitzone | *(mit `from_fn` komponieren)* | siehe [unten](#timezone-aware-middleware) |
+| **Entwicklung** | | |
+| Live-Reload | `LiveReloadLayer` | `.livereload(..)` |
+| Debug-Panel | `DebugPanelLayer` | `.debug_panel(..)` |
+
+Die nächsten Abschnitte gehen die im Detail durch, nach denen der Request
+gefragt hat.
+
+---
+
+## Locale-bewusste Middleware
+
+`LocaleMiddleware` löst eine Locale pro Request auf und injiziert sie in den
+Request, damit jeder Handler sie lesen kann. Die Auswahlreihenfolge ist die von
+Django: **Cookie → `Accept-Language` → Standard**. Die erste Locale, die du
+auflistest, ist der Standard, sofern du ihn nicht überschreibst.
+
+```rust
+use rustango::i18n::middleware::{ActiveLocale, LocaleMiddleware};
+
+// First entry is the default; `.default("en")` is explicit here. `ar`
+// (Arabic) is included so we can prove the RTL convenience too.
+let layer = LocaleMiddleware::new(&["en", "fr", "ar"]).default("en");
+
+let app = Router::new()
+    .route(
+        "/",
+        // The extractor pulls the locale the layer chose for THIS request.
+        get(|loc: ActiveLocale| async move { format!("{} {}", loc.0, loc.direction()) }),
+    )
+    .layer(layer);
+```
+
+Handler lesen das Ergebnis mit dem `ActiveLocale`-Extractor. Er ist
+`Infallible` — wenn keine Middleware lief, fällt er auf `"en"` zurück — und er
+trägt RTL-Helfer, damit Templates nach Bidirektionalität verzweigen können:
+
+```rust
+loc.0            // the picked locale, e.g. "fr"
+loc.direction()  // "ltr" / "rtl" — feed straight into <html dir="…">
+loc.is_rtl()     // true for ar, he, fa, …
+```
+
+Der Cookie-Name ist standardmäßig `django_language` (Django-kompatibel); ändere
+ihn mit `.cookie_name("…")`, oder übergib `None`, um das Cookie-Lookup ganz zu
+deaktivieren. Die Auflösungsreihenfolge, durchgängig verifiziert:
+
+```rust
+// Cookie says fr, Accept-Language says ar → the cookie wins.
+//   Cookie: django_language=fr ; Accept-Language: ar   → "fr ltr"
+//
+// No cookie → negotiate Accept-Language (ar is RTL).
+//   Accept-Language: ar,en;q=0.5                        → "ar rtl"
+//
+// Neither cookie nor a supported language → the default locale.
+//   (no headers)                                        → "en ltr"
+```
+
+Für URL-Präfix-Locales (`/en/about`, `/fr/about`) statt Header-Aushandlung
+montiere einen Sub-Router pro Locale mit `Router::nest("/fr", …)` und injiziere
+die Locale dort.
+
+---
+
+## Zeitzonen-bewusste Middleware
+
+Es gibt bewusst **keinen Zeitzonen-Layer**. Stattdessen gibt dir das Framework
+einen task-lokalen aktiven Offset (`rustango::i18n::timezone`) und einen
+Header-/Cookie-Decoder, und du komponierst eine einzeilige Middleware, die ihn
+aktiviert — das kanonische „Schreib deine eigene"-Beispiel. Das spiegelt Djangos
+`USE_TZ=True`: speichere in UTC, rendere in der lokalen Uhr des Benutzers.
+
+```rust
+use axum::middleware::{from_fn, Next};
+use rustango::i18n::timezone::{current_offset, from_request_headers, with_offset};
+
+/// Per-request middleware: decode the client's UTC offset from the
+/// `tz_offset` cookie (or a `Time-Zone:` header), then run the rest of the
+/// stack with that offset active so `current_offset()` / the `localtime`
+/// Tera filter see it. Falls back to UTC when nothing parseable is sent.
+async fn timezone_mw(req: Request<Body>, next: Next) -> Response {
+    match from_request_headers(req.headers(), "tz_offset") {
+        Some(offset) => with_offset(offset, next.run(req)).await,
+        None => next.run(req).await,
+    }
+}
+
+let app = Router::new()
+    .route(
+        "/now",
+        // The handler runs inside the activated scope, so the task-local
+        // offset is visible here (and inside any `.await` it makes).
+        get(|| async { current_offset().local_minus_utc().to_string() }),
+    )
+    .layer(from_fn(timezone_mw));
+```
+
+`with_offset` installiert den Offset in einem **`tokio::task_local`**, sodass er
+`.await`-Punkte und Thread-Wechsel innerhalb des Requests überlebt — anders als
+ein Thread-Local verschwindet er nicht, wenn tokio den Task neu einplant.
+Innerhalb des Scopes:
+
+- `current_offset()` liefert den aktiven `FixedOffset` (UTC außerhalb jedes
+  Scopes),
+- `localtime(utc_dt)` konvertiert ein gespeichertes UTC-`DateTime` dorthin,
+- der `{{ ts | localtime }}` Tera-Filter (registriert mit
+  `timezone::register_filters`) rendert automatisch darin.
+
+`from_request_headers` akzeptiert zuerst das `tz_offset`-Cookie, dann einen
+`Time-Zone:`- (oder `X-Timezone:`-)Header. Die akzeptierten Formate sind
+flexibel — `"+05:30"`, `"+0530"`, `"Z"`/`"UTC"`, oder **vorzeichenbehaftete
+ganze Minuten** (`"330"`, `"-300"`), die Form, die JS' `Date.getTimezoneOffset()`
+erzeugt. Das Cookie wird typischerweise von einem winzigen Snippet beim Laden der
+Seite gesetzt:
+
+```html
+<script>
+  // getTimezoneOffset() is positive west-of-UTC, so flip the sign.
+  const minutes = -new Date().getTimezoneOffset();
+  document.cookie = `tz_offset=${minutes};path=/;max-age=31536000`;
+</script>
+```
+
+Verhalten, verifiziert:
+
+```rust
+// Cookie: tz_offset=330  (UTC+05:30)   → current_offset() = +19800s
+// Header: Time-Zone: -300 (UTC-05:00)  → current_offset() = -18000s
+// nothing sent                          → current_offset() = 0 (UTC)
+```
+
+> **Hinweis — `FixedOffset`, nicht IANA.** Das modelliert die aktive Zeitzone
+> als festen Offset, was alles ist, was ein *einzelner Zeitpunkt* braucht, und
+> vermeidet die rund 3 MB große `chrono-tz`-Datenbank. Es behandelt **keine**
+> Sommerzeit-Übergänge. Für vollständige IANA-Unterstützung parse die `Tz` des
+> Benutzers zur Request-Zeit mit `chrono-tz` und übergib
+> `tz.offset_from_utc_datetime(...)` an `with_offset` — die Middleware-Form oben
+> bleibt unverändert.
+
+---
+
+## Security-Header
+
+`SecurityHeadersLayer` stempelt die standardmäßigen Browser-Härtungs-Header —
+HSTS, `X-Frame-Options`, `X-Content-Type-Options`, Referrer-Policy und eine
+optionale Content-Security-Policy — auf jede Response, in einer Zeile.
+
+```rust
+use rustango::security_headers::{CspBuilder, SecurityHeadersLayer, SecurityHeadersRouterExt};
+
+let app = Router::new()
+    .route("/", get(|| async { "ok" }))
+    .security_headers(SecurityHeadersLayer::strict().csp(CspBuilder::strict_starter().build()));
+```
+
+Das härtet jede Response:
+
+```rust
+// strict-transport-security: max-age=31536000; includeSubDomains; preload
+// x-content-type-options:     nosniff
+// x-frame-options:            DENY
+// content-security-policy:    <built from CspBuilder::strict_starter()>
+```
+
+Drei Presets decken die häufigen Fälle ab:
+
+| Preset | Verwenden für | HSTS | `X-Frame-Options` |
+| --- | --- | --- | --- |
+| `strict()` | Produktion | 1 Jahr + preload | `DENY` |
+| `relaxed()` | einbettbare Seiten | 1 Jahr | `SAMEORIGIN` |
+| `dev()` | lokale Entwicklung | *(weggelassen)* | — |
+
+Verwende lokal `dev()` — HSTS würde deinen Browser sonst ein Jahr lang auf
+`localhost` an HTTPS binden. Baue eine CSP flüssig mit `CspBuilder`
+(`.default_src(..)`, `.script_src(..)`, …, `.build()`), und rolle sie sicher mit
+`.csp_report_only(true)` + `.csp_report_uri("/csp-report")` aus, bevor du sie
+durchsetzt.
+
+---
+
+## CSRF-Schutz
+
+CSRF (Cross-Site Request Forgery) ist, wenn eine andere Website den Browser eines
+angemeldeten Benutzers dazu bringt, an deine App zu senden. **Rustango**
+verteidigt sich mit dem **Double-Submit-Cookie**-Muster, in
+`rustango::forms::csrf` (hinter der `csrf`-Feature, die automatisch von `admin`
+eingeschaltet wird).
+
+```rust
+use rustango::forms::csrf;
+
+let app = Router::new()
+    .route("/form", get(|| async { "render form" }))
+    .route("/submit", post(|| async { "accepted" }))
+    .layer(csrf::layer());
+```
+
+Eine sichere Methode (GET/HEAD/OPTIONS) prägt ein `rustango_csrf`-Cookie. Eine
+unsichere Methode (POST/PUT/PATCH/DELETE) muss den Wert dieses Cookies
+zurückgeben, entweder im `X-CSRF-Token`-Header oder im `_csrf`-Formularfeld; eine
+Abweichung ergibt `403 Forbidden`:
+
+```rust
+// GET /form                            → 200 + Set-Cookie: rustango_csrf=…
+//
+// POST /submit  (no token)             → 403 Forbidden
+//
+// POST /submit  with both:
+//   Cookie:        rustango_csrf=<t>
+//   X-CSRF-Token:  <t>                 → 200 OK   (double-submit matches)
+```
+
+In Tera-Templates liefert `{{ csrf_token }}` das rohe Token und
+`{{ csrf_input }}` ein fertiges verstecktes `<input name="_csrf">` — leg eines in
+jedes Formular. Überschreibe die Cookie-/Header-Namen oder das `Secure`-Flag mit
+`csrf::with_config(CsrfConfig)`; für SPA-Setups füge
+`.with_trusted_origins([...])` hinzu, um die Defense-in-Depth-Prüfung des
+Origin-Headers zusätzlich zum Token zu aktivieren. Für Append-only-Collector-
+Endpoints, die über `navigator.sendBeacon` (z. B. Analytics) angesprochen werden
+und keinen Token-Header senden können, überspringt
+`CsrfConfig::exempt_prefix("/path")` die Durchsetzung für ein schmales
+Pfad-Präfix. Der Auto-Admin aktiviert CSRF bei jeder Mutation ohne Opt-out.
+
+---
+
+## Eigene Middleware schreiben
+
+Die schnelle Form hast du schon gesehen — die [Zeitzonen-
+Middleware](#timezone-aware-middleware) ist ein vollständiges
+`from_fn`-Beispiel. Greife zu `from_fn`, wann immer die Logik anwendungs-
+spezifisch ist und du sie nicht konfigurieren musst:
+
+```rust
+use axum::middleware::{from_fn, Next};
+
+async fn add_app_version(req: Request<Body>, next: Next) -> Response {
+    let mut resp = next.run(req).await;          // run the rest of the stack
+    resp.headers_mut()
+        .insert("X-App-Version", HeaderValue::from_static(env!("CARGO_PKG_VERSION")));
+    resp                                          // …then touch the response
+}
+
+let app = router.layer(from_fn(add_app_version));
+```
+
+Greife zu einem vollständigen **`tower::Layer`**, wenn die Middleware
+wiederverwendbar und konfigurierbar ist — wenn du sie als Teil einer Bibliothek
+ausliefern würdest. Das Muster ist ein kleines `Layer`-Struct, das einen
+`Service` baut, plus (per Konvention) einen `…RouterExt`-Extension-Trait für den
+Einzeiler. `rustango::request_id` ist die kleinste vollständige Referenz zum
+Kopieren:
+
+- `RequestIdLayer` — der konfigurierbare Layer (`::default()`,
+  `.always_generate()`),
+- `RequestIdService<S>` — umschließt den inneren Service; liest/setzt den
+  `X-Request-Id`-Header innerhalb von `call`,
+- `RequestId` — ein `FromRequestParts`-Extractor, damit Handler die ID lesen
+  können,
+- `RequestIdRouterExt` — liefert `Router::request_id(layer)`.
+
+`LocaleMiddleware` (nachzulesen in `crates/rustango/src/i18n/middleware.rs`) ist
+ein zweites ausgearbeitetes Beispiel — dieselben vier Teile, plus eine reine
+`.pick(&req)`-Methode, die sich unit-testen lässt, ohne einen Server
+hochzufahren. Modelliere neue Layer nach dem einen oder dem anderen.
+
+---
+
+## Siehe auch
+
+- [Security-Leitfaden](security.md) — der vollständige Defense-in-Depth-Stack
+  und eine Checkliste für den Deploy-Zeitpunkt (`manage check --deploy`).
+- [Authentifizierung](auth-sessions.md) — die Auth-Backends und die
+  `CurrentUser`-Middleware bauen auf demselben Layer-Mechanismus auf.
+- [URLs & Routing](urls.md) — wo Layer an Router und Sub-Router angehängt
+  werden.

--- a/docs/de/migrations.md
+++ b/docs/de/migrations.md
@@ -1,0 +1,189 @@
+# Migrationen & die Migrations-Engine
+
+**Rustango** liefert eine Migrations-Engine im Django-Stil: Sie bearbeiten Ihre Modelle,
+führen `makemigrations` aus, um eine versionierte JSON-Datei zu generieren, die die
+Schemaänderung beschreibt, und `migrate`, um sie anzuwenden. Seit **0.48** migriert das Framework
+sogar **seine eigenen** `rustango_*`-Tabellen über dieselbe Engine —
+kein handausgeliefertes Bootstrap-DDL. Diese Seite erklärt die beweglichen Teile, die
+ein Upgrade sicher machen: die beiden Migrationsketten, die Squash-Reconciliation
+und das abgesicherte Fake-Initial, das einer vorbestehenden Datenbank erlaubt, die
+Engine ohne Kollisionen zu übernehmen.
+
+> **Neu bei Migrationen?** Die alltäglichen CLI-Verben — `makemigrations`,
+> `migrate`, `migrate --squash`, `migrate --fake`, `downgrade`,
+> `showmigrations` — werden Befehl für Befehl im
+> [manage-Leitfaden](manage.md#migrations) behandelt. Diese Seite ist das konzeptionelle
+> Modell dahinter.
+
+> **Quelle:** `rustango::migrate` (`runner`, `make`, `file`, `manage`)
+> und `rustango::tenancy::migrate` — die Reconciliation des Runners lebt in
+> `migrate::runner::reconcile`.
+
+---
+
+## Zwei Migrationsketten
+
+Eine Migration gehört zu einer von zwei unabhängigen Ketten, jede mit ihrer eigenen
+Ledger-Tabelle (der Zeile angewandter Namen, die der Runner konsultiert, um Arbeit zu überspringen):
+
+| Kette | Was sie verwaltet | Ledger-Tabelle |
+|---|---|---|
+| **Project** | Ihre `#[derive(Model)]`-Tabellen, in `migrations/` | `__rustango_migrations__` |
+| **System** | die eigenen `rustango_*`-Tabellen des Frameworks (`Org`, `User`, Rollen/Berechtigungen, Agenten, Media, …), in `system/migrations/` | `__rustango_system_migrations__` |
+
+Die **System-Kette** ist das, was das Framework-Schema selbstbeschreibend macht.
+Ihre Dateien werden aus den kompilierten Framework-Modellen generiert — und sie sind
+**`#[cfg(feature = …)]`-bewusst**: eine feature-gegatete Spalte oder Tabelle wird vom
+Compiler entfernt, wenn das Feature aus ist, sodass das Aktivieren eines Features
+`makemigrations` ein `AddColumn` / `CreateTable` emittieren lässt und das Deaktivieren
+ein `DropColumn` / `DropTable` emittiert. Aufgescaffoldete Tenant-Projekte liefern ein
+**leeres** `system/migrations/`; das erste `cargo run -- migrate`
+generiert und wendet es an (siehe [Scaffolding](scaffolding.md)).
+
+`migrate` wendet die System-Kette **vor** den Migrationen Ihres Projekts an.
+Im Tenancy-Modus überlappen sich die beiden Scopes absichtlich bei den geteilten
+Framework-Tabellen, sodass die Tenant-Scope-Kette diejenige ist, die läuft; die
+reinen Registry-Tabellen (`rustango_orgs`, `rustango_operators`) bedeuten nichts
+ohne Tenancy. Nicht-Tenancy-Anwendungen, die ein Framework-Subsystem verwenden (z. B.
+`media`), erhalten die System-Kette ebenfalls angewandt.
+
+---
+
+## Squash-Reconciliation — `Migration.replaces`
+
+Ein **Squash** kollabiert eine Reihe historischer Migrationen in eine einzige frisch
+generierte Datei, die denselben Endzustand nachbildet — praktisch, wenn ein Stapel
+halbfertiger Migrationen leichter neu zu generieren als zu reparieren ist. Der Haken:
+die `CREATE TABLE`s der Datei würden auf jeder Datenbank kollidieren, die die Migrationen,
+die sie kollabiert hat, bereits angewandt hat (der Checkout eines Kollegen, Staging,
+CI).
+
+`migrate --squash` löst das, indem es die **`replaces`**-Liste der neuen Datei mit
+den Namen stempelt, die sie kollabiert hat:
+
+```jsonc
+{
+  "name": "0007_squashed_0001_0006",
+  "replaces": ["0001_initial", "0002_add_status", "0003_add_slug", "…"],
+  "forward": [ /* recreates the end state */ ]
+}
+```
+
+Mit gesetztem `replaces` **reconciliiert** der Runner den Squash gegen den tatsächlichen
+Zustand der Datenbank, anstatt ihn blind auszuführen. Die Entscheidung ist
+automatisch und hängt ganz davon ab, was bereits vorhanden ist:
+
+| Datenbankzustand | Was der Runner tut |
+|---|---|
+| frisch — keine Historie, keine Tabellen | führt den Squash tatsächlich aus |
+| jede ersetzte Migration ist im Ledger | verzeichnet ihn, setzt Tombstones auf die Vorgänger, **kein DDL** |
+| Tabellen existieren, aber das Ledger hat keine Historie | verzeichnet ihn, **kein DDL** (Djangos kettenübergreifendes `--fake-initial`) |
+| nur *einige* ersetzte Zeilen / Tabellen vorhanden | **verweigert** — benennt, was fehlt, weist Sie an, von Hand aufzulösen |
+
+Der **partielle** Fall ist absichtlich ein harter Fehler: keine automatische Wahl ist
+dort sicher, also stoppt der Runner und meldet, was er gefunden hat, statt zu
+raten. Lösen Sie ihn mit `migrate --fake` (unten) auf.
+
+Migrationen, die von einem angewandten Squash abgelöst werden, zählen als angewandt, sodass Sie
+die kollabierten Dateien für ein oder zwei Releases auf der Platte lassen können — Deployments, die
+sie nie ausgeführt haben, migrieren trotzdem korrekt vorwärts. Gewöhnliche (Nicht-Squash-)
+Migrationen sind unberührt: eine schlichte Migration, deren Tabelle bereits existiert,
+schlägt trotzdem lautstark fehl, weil das ein echter Konflikt ist, keine
+bekannt-äquivalente Historie.
+
+---
+
+## Die abgesicherte Fake-Initial-Reconciliation
+
+Dies ist der Mechanismus, der einer **bestehenden** Datenbank erlaubt, die System-
+Kette nahtlos zu übernehmen. Vor 0.51 baute das Framework einige seiner Tabellen über
+faules `ensure_table`-Roh-DDL; diese Tabellen existieren, sind aber nicht im
+`__rustango_system_migrations__`-Ledger verzeichnet, sodass ein frisches `CREATE TABLE`
+aus der neuen System-Migration kollidieren würde (`relation "rustango_media"
+already exists`, MySQL 1050, …).
+
+Die System-Kette reconciliiert das selbst. Eine ausstehende **System**-Migration wird
+inspiziert: die Operationen, die *das Erstellen ihrer Tabellen* ausmachen —
+`CreateTable`, plus `CreateIndex` / `CreateM2MTable`, die auf eine Tabelle zielen, die
+dieselbe Migration erstellt — sind die akzeptierte Menge. Wenn **jede** Tabelle, die sie
+erstellt, bereits existiert, wird die Migration **ins Ledger verzeichnet, ohne
+irgendein DDL auszuführen**, und bestehende Daten bleiben unberührt. Wenn nur
+*einige* ihrer Tabellen existieren, erstellt die Kette nur die fehlenden
+(`CREATE TABLE IF NOT EXISTS`-Semantik) und lässt den Rest in Ruhe.
+
+Der Schutz ist bewusst eng:
+
+- **Auf die eigene System-Kette des Frameworks beschränkt.** Benutzermigrationen verwenden den
+  schlichten Runner und faken niemals automatisch — Tabellen-Existenz-Faking ist opt-in
+  ausschließlich für den System-Pfad.
+- **Alles, was keine Tabellenerstellung ist, disqualifiziert das Faken** — ein Index
+  auf einer vorbestehenden Tabelle, ein Alter / Drop / Datenop / Callback fällt
+  durch zu einem echten Lauf, sodass echte Arbeit nie übersprungen wird.
+- **Existenz wird nur im aktuellen Namespace abgefragt** — Postgres
+  `current_schema()`, MySQL `DATABASE()`, SQLite `sqlite_master` — nicht
+  über den `search_path`, sodass in schema-modus-Multi-Tenancy eine gleichnamige
+  Tabelle in `public` einen Tenant nicht dazu verleiten kann, seine eigenen Tabellen zu überspringen.
+
+Der partielle Zustand eines Squash wird weiterhin verweigert (siehe oben); nur die
+System-Kette des Frameworks führt die stückweise „erstelle die fehlenden“-Reparatur durch.
+
+---
+
+## Drift von Hand reparieren — `migrate --fake`
+
+Wenn die Datenbank bereits im Zielzustand ist, aber das Ledger es nicht
+weiß (eine außerhalb der Reihe aufgesetzte DB, ein gelöschtes Ledger, eine teilweise
+erfolgreiche Migration, ein verweigerter partieller Squash), stempeln Sie eine Migration als angewandt
+**ohne ihr SQL auszuführen**:
+
+```bash
+cargo run -- migrate --fake 0004_add_indexes
+cargo run -- migrate --fake 0001_rustango_registry_initial --system       # framework's own chain
+cargo run -- migrate --fake 0001_rustango_registry_initial --all-tenants  # every active tenant
+```
+
+- `--system` stempelt die System-Kette des Frameworks
+  (`system/migrations/` → `__rustango_system_migrations__`) statt
+  der Ihres Projekts.
+- `--all-tenants` fächert den Stempel über jeden aktiven Tenant auf, meldet
+  jeden und fährt über Fehlschläge hinweg fort — die Framework-Tabellen leben pro
+  Tenant, sodass ihre Reparatur eine Aufgabe pro Tenant ist. Kombinieren Sie mit `--system`
+  für die Framework-Tabellen über alle Tenants.
+
+Der Name wird zuerst gegen das Migrationsverzeichnis validiert, sodass ein Tippfehler
+keine falsche Zeile landen kann; das Stempeln ist idempotent, und das Flag kann
+wiederholt werden, um eine Reihe von Zeilen in einem Befehl zu reparieren.
+
+---
+
+## Upgrade auf 0.51.2
+
+> **0.51.0 und 0.51.1 wurden zurückgezogen (yanked)** — die Reconciliation, die sie versprachen, feuerte nie
+> tatsächlich gegen echte 0.46–0.50-Datenbanken (0.51.0 verlagerte die Media-
+> Tabellen auf System-Migrationen und kollidierte; der Schutz von 0.51.1 verlangte, dass eine
+> Migration *rein* `CreateTable` sei, was keine generierte Migration ist).
+> **Upgraden Sie direkt auf 0.51.2**, das beides behebt.
+
+Für ein bestehendes Deployment ist das Upgrade ein schlichtes Deploy — kein
+Reprovisionieren, kein manuelles DDL:
+
+```bash
+cargo run -- migrate
+```
+
+Das abgesicherte Fake-Initial handhabt die vorbestehenden Framework-Tabellen: das
+erste `migrate` verzeichnet die System-Migration, deren Tabellen bereits existieren,
+ins Ledger, ohne sie zu berühren, erstellt nur das, was wirklich fehlt,
+und lässt Ihre Daten in Ruhe. Wenn eine Datenbank in einem wahrhaft
+inkonsistenten partiellen Zustand ist, stoppt der Runner und sagt Ihnen, was er gefunden hat;
+lösen Sie es mit `migrate --fake` auf, statt zu erzwingen.
+
+---
+
+## Siehe auch
+
+- [`manage`-Leitfaden](manage.md#migrations) — jedes Migrations-CLI-Verb, mit
+  Beispielen.
+- [Scaffolding](scaffolding.md) — woher `migrations/` und
+  `system/migrations/` kommen.
+- [Models](models.md) — das Derive, aus dem die Migrationen generiert werden.

--- a/docs/de/models.md
+++ b/docs/de/models.md
@@ -1,0 +1,456 @@
+# Modelle
+
+Ein Modell ist ein Rust-Struct, das auf eine Datenbanktabelle abgebildet wird. Füge
+`#[derive(Model)]` hinzu, annotiere die Felder, und **Rustango** generiert das Schema,
+einen typsicheren Abfrage-Einstiegspunkt sowie `save`/`find`/`delete`-Methoden — Djangos
+Modelle oder Laravels Eloquent, mit dem Compiler, der deine Spalten prüft. Dies ist die
+**Deklarations**-Referenz: jeder Feldtyp, jede Primärschlüssel-Option und jedes
+`#[rustango(...)]`-Attribut. Für das *Abfragen* von Modellen, sobald sie deklariert sind,
+siehe das [ORM-Kochbuch](orm.md).
+
+[![Modelle in Rustango: ein #[derive(Model)]-Struct bildet Rust-Feldtypen auf dialektspezifische Spalten ab, der Primärschlüssel kann ein auto-inkrementierender Auto<i64> oder ein benutzerdefinierter, anwendungsseitig zugewiesener Schlüssel sein, und das Derive generiert SCHEMA + objects() + save/find](img/models.png)](img/models.png)
+
+> **Ein Begriff hier ist neu für dich?** *model*, *primary key*, *foreign key*,
+> *migration*, *nullable* — siehe das [Glossar](glossary.md).
+
+> **Quelle:** `rustango::Model` (`#[derive(Model)]`), `rustango::core`
+> (`Model`-Trait, `ModelSchema`, `FieldType`, `Auto`, `ForeignKey`) und die
+> Dialekt-Typabbildungen in `rustango::sql::{dialect, mysql, sqlite}` — immer
+> kompiliert (wähle ein Backend-Feature: `postgres` / `mysql` / `sqlite`).
+>
+> **Lauffähige Version:** die Feldtyp-Round-Trips, der benutzerdefinierte PK und die
+> SCHEMA-Snippets sind aus
+> [`models_doc.rs`](../crates/rustango/tests/models_doc.rs) kopiert
+> (`cargo test -p rustango --features sqlite --test models_doc`).
+
+## Inhaltsverzeichnis
+
+- [Anatomie eines Modells](#anatomy-of-a-model)
+- [Feldtypen](#field-types) · [Nur-PostgreSQL-Typen](#postgresql-only-types)
+- [Primärschlüssel](#primary-keys) — [benutzerdefinierte PKs](#custom-primary-keys) · [zusammengesetzte](#composite-primary-keys)
+- [Beziehungen](#relationships)
+- [Übliche Feldattribute](#common-field-attributes)
+- [Indizes & Constraints](#indexes-and-constraints)
+- [Übliche Modellattribute](#common-model-attributes)
+- [Die generierte API](#the-generated-api) — [save vs insert](#save-vs-insert)
+- [Vollständige Attributreferenz](#full-attribute-reference)
+- [Siehe auch](#see-also)
+
+---
+
+## Anatomie eines Modells
+
+```rust
+use rustango::{Auto, Model};
+use chrono::{DateTime, Utc};
+
+#[derive(Model, Clone, Debug)]
+#[rustango(table = "posts", display = "title")]   // model-level attributes
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,                            // field-level attributes
+
+    #[rustango(max_length = 200)]
+    pub title: String,
+
+    pub body: String,
+
+    #[rustango(fk = "authors", on = "id")]
+    pub author_id: i64,
+
+    #[rustango(auto_now_add)]
+    pub created_at: Auto<DateTime<Utc>>,
+}
+```
+
+Aus dieser einen Deklaration generiert das Derive:
+
+- das **Schema** (`Post::SCHEMA` — Tabellenname, Spalten, Typen, den PK), das
+  Migrationen und das Admin lesen;
+- einen Abfrage-Einstiegspunkt, **`Post::objects()`**, der ein `QuerySet<Post>`
+  zurückgibt;
+- **typisierte Feldkonstanten** (`Post::title`, `Post::author_id`) für
+  compilergeprüfte Filter — `Post::objects().where_(Post::author_id.eq(42))`;
+- Zeilenmethoden — **`save`**, **`find`**, **`delete`** und mehr (siehe
+  [die generierte API](#the-generated-api)).
+
+Der Tabellenname ist standardmäßig der Modellname, wenn du `table` weglässt;
+Spaltennamen sind standardmäßig der snake_case-Feldname, sofern du nicht `column`
+setzt.
+
+---
+
+## Feldtypen
+
+Der Rust-Typ des Feldes bestimmt seinen Datenbank-Spaltentyp. Rustango bildet jeden Typ
+pro Dialekt ab, sodass dasselbe Modell auf PostgreSQL, MySQL und SQLite funktioniert:
+
+| Rust-Typ | PostgreSQL | MySQL | SQLite |
+|---|---|---|---|
+| `i16` | `SMALLINT` | `SMALLINT` | `INTEGER` |
+| `i32` | `INTEGER` | `INT` | `INTEGER` |
+| `i64` | `BIGINT` | `BIGINT` | `INTEGER` |
+| `f32` | `REAL` | `FLOAT` | `REAL` |
+| `f64` | `DOUBLE PRECISION` | `DOUBLE` | `REAL` |
+| `bool` | `BOOLEAN` | `TINYINT(1)` | `INTEGER` (0/1) |
+| `String` | `TEXT` | `TEXT` | `TEXT` |
+| `String` + `max_length = N` | `VARCHAR(N)` | `VARCHAR(N)` | `TEXT` |
+| `chrono::DateTime<Utc>` | `TIMESTAMPTZ` | `DATETIME(6)` | `TEXT` (ISO-8601) |
+| `chrono::NaiveDate` | `DATE` | `DATE` | `TEXT` |
+| `chrono::NaiveTime` | `TIME` | `TIME(6)` | `TEXT` |
+| `uuid::Uuid` | `UUID` | `CHAR(36)` | `TEXT` |
+| `serde_json::Value` | `JSONB` | `JSON` | `TEXT` |
+| `rust_decimal::Decimal` | `NUMERIC` | `DECIMAL(38,10)` | `NUMERIC` |
+| `Vec<u8>` | `BYTEA` | `LONGBLOB` | `BLOB` |
+| `Option<T>` | `T NULL` | `T NULL` | `T` (nullable) |
+
+`Option<T>` ist die Art, eine Spalte **nullable** zu machen — ein Feld ohne `Option` ist
+`NOT NULL`. All diese durchlaufen einen Round-Trip über `save` → `find`, durchgängig
+verifiziert:
+
+```rust
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gadget")]
+pub struct Gadget {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 100)]
+    pub name: String,
+    pub qty: i64,
+    pub active: bool,
+    pub note: Option<String>,        // nullable
+    pub made_at: DateTime<Utc>,
+    pub meta: serde_json::Value,     // JSON
+}
+```
+
+> **Dezimalpräzision.** PostgreSQL `NUMERIC` ist beliebig genau; MySQL verwendet
+> `DECIMAL(38,10)` (38 Stellen, 10 Nachkommastellen — die breiteste portable Passung);
+> SQLite verwendet `NUMERIC`-Affinität. Verwende `rust_decimal::Decimal` für Geld,
+> niemals `f64`.
+
+### Nur-PostgreSQL-Typen
+
+Diese bilden auf native PostgreSQL-Spaltentypen ab und haben **kein MySQL/SQLite-
+Äquivalent** — der Migrations-Writer gibt dort `TEXT` aus, um gültig zu bleiben, aber das
+Lesen/Schreiben davon schlägt zur Laufzeit auf jenen Backends mit einem Fehler fehl.
+Verwende sie nur in PostgreSQL-Deployments:
+
+| Rust-Typ | PostgreSQL | Anmerkungen |
+|---|---|---|
+| `Array<T>` | `text[]` / `integer[]` / `bigint[]` | native Arrays |
+| `Range<T>` | `int4range` / `int8range` / `numrange` / `daterange` / `tstzrange` | Range-Typen |
+| `HStore` | `hstore` | flache String→String-Map (benötigt die Extension) |
+| `Vector` + `#[rustango(vector(dims = N))]` | `vector(N)` | pgvector-Embeddings |
+| `Point` + `#[rustango(geometry(srid = N))]` | `geometry(Point, N)` | PostGIS |
+
+---
+
+## Primärschlüssel
+
+Jedes Modell braucht einen Primärschlüssel. Markiere ein Feld mit
+`#[rustango(primary_key)]`; wenn du keines markierst, sucht das Schema nach einer Spalte
+namens `id`.
+
+Der **Standard und häufigste** PK ist eine auto-inkrementierende 64-Bit-Ganzzahl,
+deklariert als `Auto<i64>`:
+
+```rust
+#[rustango(primary_key)]
+pub id: Auto<i64>,
+```
+
+**`Auto<T>`-Semantik.** Ein `Auto<T>`-Feld ist entweder `Unset` (der Wert, den die DB
+zuweisen wird) oder `Set(v)`. Beim Einfügen wird ein `Unset`-PK aus der Spaltenliste
+ausgelassen, sodass die Datenbank ihn generiert, dann wird der Wert zurückgelesen
+(`RETURNING` auf PostgreSQL/SQLite, `LAST_INSERT_ID()` auf MySQL) und auf deinem Struct
+gespeichert:
+
+```rust
+let mut g = Gadget { id: Auto::default(), /* … */ };   // Unset
+g.save_pool(&pool).await?;                              // DB assigns the id
+let new_id = g.id.get().copied().unwrap();             // now populated
+```
+
+Unterstützte innere `Auto<T>`-Typen sind `i32`, `i64` und `Uuid`.
+
+### Benutzerdefinierte Primärschlüssel
+
+Der PK muss keine auto-inkrementierende Ganzzahl sein. Jeder Typ, der auf eine Spalte
+abgebildet wird, kann der PK sein; du weist den Wert selbst zu:
+
+| PK-Deklaration | Spaltentyp | Wer weist ihn zu |
+|---|---|---|
+| `Auto<i64>` *(Standard)* | `BIGSERIAL` / `BIGINT AUTO_INCREMENT` / `INTEGER … AUTOINCREMENT` | Datenbank |
+| `Auto<i32>` | `SERIAL` / `INT AUTO_INCREMENT` / `INTEGER …` | Datenbank |
+| `Auto<Uuid>` + `auto_uuid` | `UUID` | Rust-seitig (`uuid v4`) |
+| `Auto<Uuid>` + `default_uuid_v7` | `UUID` | Rust-seitig (sortierbares `uuid v7`) |
+| `String` + `primary_key` | `VARCHAR(N)` / `TEXT` | du (Anwendung) |
+| `Uuid` + `primary_key` | `UUID` / `CHAR(36)` / `TEXT` | du (Anwendung) |
+| `i64` / `i32` + `primary_key` | `BIGINT` / `INTEGER` | du (Anwendung) |
+
+Ein **natürlicher String-Schlüssel** (z. B. ein Gutscheincode) — beachte, dass du den
+Wert selbst bereitstellst und mit [`insert_pool`](#save-vs-insert) einfügst, da es kein
+`Auto::Unset` gibt, das `save` erkennen könnte:
+
+```rust
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "coupon")]
+pub struct Coupon {
+    #[rustango(primary_key, max_length = 32)]
+    pub code: String,        // you assign this
+    pub discount: i64,
+}
+
+let c = Coupon { code: "SAVE10".into(), discount: 10 };
+c.insert_pool(&pool).await?;                       // explicit INSERT
+let back = Coupon::find_or_fail("SAVE10".to_string(), &pool).await?;   // look up by the string PK
+```
+
+**Benenne die PK-Spalte um** mit `column` (das Rust-Feld bleibt `number`, die SQL-Spalte
+ist `account_no`):
+
+```rust
+#[rustango(primary_key, column = "account_no")]
+pub number: i64,
+```
+
+```rust
+// Introspect it via the schema:
+let pk = Account::SCHEMA.primary_key().unwrap();
+assert_eq!(pk.name, "number");        // Rust field
+assert_eq!(pk.column, "account_no");  // SQL column
+```
+
+**UUID-Primärschlüssel** generieren den Wert Rust-seitig: `auto_uuid` gibt ein zufälliges
+v4, `default_uuid_v7` ein zeitlich sortierbares v7 (besser für Index-Lokalität):
+
+```rust
+#[rustango(primary_key, auto_uuid)]
+pub id: Auto<uuid::Uuid>,
+```
+
+### Zusammengesetzte Primärschlüssel
+
+Native mehrspaltige Primärschlüssel werden **nicht unterstützt** — genau ein Feld darf
+`primary_key` sein. Das ausgelieferte Muster ist ein Surrogat-`Auto<i64>`-PK plus ein
+deklarierter zusammengesetzter Unique-Constraint, was index-äquivalent ist:
+
+```rust
+#[derive(Model)]
+#[rustango(table = "line_item", unique_together = "invoice_id, line_no")]
+pub struct LineItem {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,        // surrogate PK
+    pub invoice_id: i64,
+    pub line_no: i32,         // (invoice_id, line_no) is unique together
+}
+```
+
+Schlage Zeilen nach mit
+`.where_(LineItem::invoice_id.eq(..)).where_(LineItem::line_no.eq(..))`.
+
+---
+
+## Beziehungen
+
+Ein Fremdschlüssel ist eine `_id`-Spalte plus ein optionaler typisierter Accessor:
+
+```rust
+// Plain FK column — store the parent's id:
+#[rustango(fk = "authors", on = "id")]
+pub author_id: i64,
+
+// Typed FK — lazy-loads the parent on demand:
+pub author: ForeignKey<Author>,
+```
+
+`ForeignKey<T>` setzt seinen Schlüsseltyp standardmäßig auf `i64`; wenn der PK des
+Elternobjekts einen anderen Typ hat, benenne ihn: `ForeignKey<User, String>`.
+Eins-zu-eins verwendet `#[rustango(o2o)]`; viele-zu-viele ist eine separate Tabelle —
+siehe [ORM-Kochbuch → Viele-zu-viele](orm.md#many-to-many). Lade verwandte Zeilen eager
+mit `select_related` (ebenfalls im ORM-Leitfaden).
+
+---
+
+## Übliche Feldattribute
+
+`#[rustango(...)]` auf einem Feld. Die, die du ständig verwenden wirst:
+
+| Attribut | Beispiel | Wirkung |
+|---|---|---|
+| `primary_key` | `#[rustango(primary_key)]` | markiert den PK |
+| `max_length = N` | `#[rustango(max_length = 200)]` | `VARCHAR(N)` + Längenprüfung beim Schreiben |
+| `default = "…"` | `#[rustango(default = "'draft'")]` | DB-Spaltenstandard (SQL-Literal) |
+| `unique` | `#[rustango(unique)]` | Unique-Constraint auf der Spalte |
+| `choices = "…"` | `#[rustango(choices = "draft:Draft, published:Published")]` | aufgezählte Werte (`value:Label`); Admin-`<select>` + Validierung |
+| `auto_now_add` | `#[rustango(auto_now_add)]` | beim **Einfügen** auf jetzt setzen (auf einem `Auto<DateTime<Utc>>`) |
+| `auto_now` | `#[rustango(auto_now)]` | bei **jedem Speichern** auf jetzt setzen |
+| `column = "…"` | `#[rustango(column = "account_no")]` | die SQL-Spalte umbenennen |
+| `null` / `Option<T>` | `pub note: Option<String>` | nullable Spalte |
+| `min` / `max` | `#[rustango(min = 0, max = 100)]` | Bereichsvalidierung beim Schreiben |
+| `blank` / `editable` | `#[rustango(editable = false)]` | Formular-/Admin-Verhalten |
+| `db_comment = "…"` | `#[rustango(db_comment = "cents")]` | Spalten-COMMENT |
+
+`choices`, `default`, `auto_now_add` und Soft-Delete zusammen (alle verifiziert):
+
+```rust
+#[rustango(max_length = 20, default = "'draft'", choices = "draft:Draft, published:Published")]
+pub status: String,
+#[rustango(auto_now_add)]
+pub created_at: Auto<DateTime<Utc>>,
+#[rustango(soft_delete)]
+pub deleted_at: Option<DateTime<Utc>>,
+```
+
+---
+
+## Indizes und Constraints
+
+Auf dem **Modell** deklariert:
+
+```rust
+#[rustango(
+    table = "posts",
+    index("status, published_at"),                 // composite btree index
+    unique_together = "author_id, slug",           // multi-column unique
+    check(name = "qty_nonneg", expr = "qty >= 0"), // CHECK constraint
+)]
+```
+
+- **`index(...)`** — standardmäßig ein Btree-Index; wähle für PostgreSQL eine Methode
+  mit `index(columns = "body", method = "gin")` (auch `gist`, `brin`, `hash`, `bloom`,
+  `spgist`).
+- **`unique_together` / `index_together`** — mehrspaltig unique / nicht-unique.
+- **Partielle Indizes** — `unique_when(...)` / `index_when(...)` fügen eine `WHERE`-
+  Bedingung hinzu.
+- **`check(name, expr)`** — ein CHECK-Constraint; **`exclude(...)`** ist ein
+  PostgreSQL-EXCLUDE-Constraint.
+
+---
+
+## Übliche Modellattribute
+
+`#[rustango(...)]` auf dem Struct:
+
+| Attribut | Beispiel | Wirkung |
+|---|---|---|
+| `table = "…"` | `table = "posts"` | Tabellenname (standardmäßig der Struct-Name) |
+| `display = "…"` | `display = "title"` | das Feld, das angezeigt wird, wenn eine Zeile referenziert wird (FK-Labels, Admin) |
+| `app = "…"` | `app = "blog"` | gruppiert das Modell unter einer App |
+| `default_order = "…"` | `default_order = "-created_at"` | Standardsortierung für Abfragen |
+| `default_permissions` | `default_permissions = "add, change"` | welche Auto-Berechtigungen erstellt werden |
+| `soft_delete` *(Feld)* | `#[rustango(soft_delete)] deleted_at: Option<…>` | Soft-Delete aktivieren (markieren, nicht entfernen) |
+| `audit(track = "…")` | `audit(track = "title, status")` | Änderungshistorie pro Zeile aufzeichnen |
+| `scope = "…"` | `scope = "tenant"` | Multi-Tenancy-Scope (Registry vs. Mandant) |
+| `admin(...)` | `admin(list_display = "…")` | Admin-UI-Konfiguration — siehe [das Admin](admin.md) |
+
+---
+
+## Die generierte API
+
+`#[derive(Model)]` implementiert das `Model`-Trait (`Post::SCHEMA`) und generiert:
+
+- **`Post::objects()`** (Alias `Post::query()`) → ein `QuerySet<Post>` zum Filtern,
+  Ordnen und Abrufen (das [ORM-Kochbuch](orm.md) deckt die Abfrage-API ab).
+- **Typisierte Feldkonstanten** — `Post::title`, `Post::author_id` — verwendet in
+  `.where_(Post::author_id.eq(42))` für compilergeprüfte Filter.
+- **Finder** — `find(pk, &pool)` → `Option<Self>`; `find_or_fail(pk, &pool)` →
+  `Self` (Fehler, wenn nicht vorhanden); `find_many(pks, &pool)`; `find_or_insert(...)`.
+- **Writer** — `save`/`save_pool`, `save_partial(&["title"], &pool)` (nur einige Spalten
+  aktualisieren), `insert_pool` (explizites Einfügen), `delete`.
+- **Soft-Delete** (wenn aktiviert) — `soft_delete`, `restore`, `force_delete`;
+  `QuerySet::active()` / `with_trashed()` / `only_trashed()`.
+
+### save vs insert
+
+Das bringt Leute durcheinander, daher ist es die klare Aussage wert:
+
+| Methode | Verhalten |
+|---|---|
+| `save_pool(&mut self, &pool)` | **INSERT**, wenn der `Auto`-PK `Unset` ist, andernfalls **UPDATE** |
+| `insert_pool(&self, &pool)` | immer **INSERT** |
+
+Für den Standard-`Auto<i64>`-PK macht `save_pool` automatisch das Richtige. Für einen
+**anwendungsseitig zugewiesenen PK** (ein `String`/`Uuid`, den du selbst setzt) gibt es
+keinen `Unset`-Zustand — daher würde `save_pool` eine (möglicherweise nicht existierende)
+Zeile UPDATEn. Verwende **`insert_pool`**, um eine brandneue Zeile mit einem
+benutzerdefinierten PK einzufügen (im begleitenden Test verifiziert).
+
+---
+
+## Vollständige Attributreferenz
+
+Jeder `#[rustango(...)]`-Schlüssel, den das Derive akzeptiert. Die üblichen sind oben
+behandelt; dies ist die vollständige Liste, einschließlich fortgeschrittener/PostgreSQL-
+spezifischer.
+
+### Auf Modellebene (auf dem Struct)
+
+| Attribut | Wert | Wirkung |
+|---|---|---|
+| `table` | `"name"` | Tabellenname |
+| `display` | `"field"` | menschenlesbares Label für eine Zeile |
+| `app` | `"name"` | App-Gruppierung |
+| `default_order` | `"-field"` | Standardsortierung |
+| `default_permissions` | `"add, change, delete, view"` | zu erstellende Auto-Berechtigungen |
+| `default_related_name` | `"posts"` | Name des Rückwärts-Accessors auf dem Elternobjekt |
+| `base_manager_name` | `"all_objects"` | Name des Basis- (ungefilterten) Managers |
+| `manager(ext = "Trait")` | Trait-Pfad | ein benutzerdefiniertes Manager-Erweiterungs-Trait generieren |
+| `manager_fn` | `"published"` | einen Manager-Accessor über `objects()` hinaus hinzufügen |
+| `get_latest_by` | `"created_at"` | Standardspalte für `latest()`/`earliest()` |
+| `order_with_respect_to` | `"parent"` | Django elternrelative Ordnung |
+| `index(...)` | `columns`, `method`, `name` | Sekundärindex (btree/gin/gist/brin/hash/bloom/spgist) |
+| `unique_together` | `"a, b"` | zusammengesetzter Unique-Constraint |
+| `index_together` | `"a, b"` | zusammengesetzter Nicht-Unique-Index |
+| `unique_when(...)` / `index_when(...)` | Spalten + `condition` | partieller (bedingter) Index |
+| `check(...)` | `name`, `expr` | CHECK-Constraint |
+| `exclude(...)` | Operator-Spezifikation | PostgreSQL-EXCLUDE-Constraint |
+| `audit(track = "…")` | Feldliste | Änderungshistorie pro Zeile |
+| `scope` | `"tenant"` / `"registry"` | Multi-Tenancy-Scope |
+| `proxy` | Flag | Proxy-Modell (teilt sich die Tabelle eines anderen) |
+| `global_scope(name, apply = fn)` | Name + fn | Filter, der automatisch auf alle Abfragen angewendet wird |
+| `through(...)` | Relationsspezifikation | benutzerdefinierter Through-Relation-Accessor |
+| `reverse_has(...)` / `generic_has(...)` | Relationsspezifikation | Rückwärts-has-many / Rückwärts-generischer-FK-Accessor |
+| `required_db_features` / `required_db_vendor` | Liste / Vendor | Deployment-Validierungs-Constraints |
+| `db_table_comment` | `"…"` | Tabellen-COMMENT |
+| `admin(...)` | Admin-Optionen | Admin-UI-Konfiguration (siehe [admin.md](admin.md)) |
+
+### Auf Feldebene (auf einem Feld)
+
+| Attribut | Wert | Wirkung |
+|---|---|---|
+| `primary_key` | Flag | markiert den PK |
+| `column` | `"name"` | die SQL-Spalte umbenennen |
+| `max_length` | `N` | `VARCHAR(N)` + Längenvalidierung |
+| `default` | `"sql literal"` | Spalten-DEFAULT |
+| `null` | Flag | nullable (oder verwende `Option<T>`) |
+| `unique` | Flag | Unique-Constraint |
+| `choices` | `"v:Label, …"` | aufgezählte Werte |
+| `min` / `max` | Zahl | Bereichsvalidierung |
+| `blank` | Flag | Leereingabe in Formularen/Admin erlauben |
+| `editable` | `true`/`false` | Bearbeitbarkeit in Formular/Admin |
+| `auto_now` | Flag | bei jedem Speichern auf jetzt setzen |
+| `auto_now_add` | Flag | beim Einfügen auf jetzt setzen |
+| `auto_uuid` | Flag | Rust-seitiges UUID v4 (auf `Auto<Uuid>`) |
+| `default_uuid_v7` | Flag | Rust-seitiges sortierbares UUID v7 |
+| `fk` + `on` | `"table"`, `"col"` | Fremdschlüsselspalte |
+| `cascade` | Flag | `ON DELETE CASCADE` |
+| `o2o` | Flag | Eins-zu-eins-Beziehung |
+| `fk_composite(...)` / `generic_fk(...)` | Spezifikation | zusammengesetzter FK / generischer (Content-Type-) FK |
+| `generated_as` | `"expr"` | DB-berechnete (generierte) Spalte |
+| `citext` | Flag | case-insensitiver Text (PostgreSQL CITEXT) |
+| `vector(dims = N)` | `N` | pgvector-Dimension |
+| `geometry(srid = N)` | `N` | PostGIS-Raumbezugs-ID |
+| `db_comment` | `"…"` | Spalten-COMMENT |
+
+---
+
+## Siehe auch
+
+- [ORM-Kochbuch](orm.md) — Abfragen, Filter, Aggregationen, Joins, Transaktionen
+  (was mit einem Modell zu tun ist, sobald es deklariert ist).
+- [Serializer](serializers.md) — ein Modell für eine API in JSON formen.
+- [Das Admin](admin.md) — der `admin(...)`-Block und die generierte UI.
+- [Scaffolding](scaffolding.md) · [`manage`-CLI](manage.md) — ein Modell und seine
+  Migration generieren.

--- a/docs/de/openapi.md
+++ b/docs/de/openapi.md
@@ -1,0 +1,271 @@
+# OpenAPI
+
+**Rustango** generiert eine **OpenAPI-3.1**-Spec für deine API und liefert sie
+mit Swagger UI / Redoc aus — keine von Hand zu pflegenden Annotationen. Richte
+den Generator auf die Serializer und ViewSets, die du bereits geschrieben hast:
+die Feldschemata kommen aus `#[derive(Serializer)]`, die CRUD-Pfade kommen aus
+deinem ViewSet, und ein einzeiliger Router hängt `/openapi.json` + eine
+interaktive Docs-Seite ein. Wenn du volle Kontrolle brauchst, lassen dich
+dieselben Typen jede beliebige Spec von Hand bauen.
+
+[![Rustango OpenAPI: Serializer-Felder werden zu einem Component-Schema, das ViewSet wird zu CRUD-Pfaden, und openapi_router liefert /openapi.json + Swagger UI aus](img/openapi.png)](img/openapi.png)
+
+> **Quelle:** `rustango::openapi` (`OpenApiSpec`, `Schema`, `OpenApiSchema`,
+> `PathItem`, `Operation`, `SecurityScheme`, `router::openapi_router`) und
+> `ViewSet::openapi_paths` — hinter dem `openapi`-Feature (standardmäßig aktiv;
+> der Viewer-Router benötigt zusätzlich `admin`).
+>
+> **Lauffähige Version:** jedes Snippet unten ist aus dem getesteten
+> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog/tests/openapi.rs)-Beispiel
+> kopiert — `cargo test -p getting_started_blog --test openapi`. Die Builder-,
+> Schema- und Router-Typen werden zusätzlich durch die eigenen Unit-Tests des
+> Frameworks abgedeckt (`crates/rustango/src/openapi/`).
+
+> **Neu bei einem Begriff hier?** *OpenAPI*, *schema*, *serializer*, *ViewSet* —
+> siehe das [Glossar](glossary.md).
+
+---
+
+## Inhaltsverzeichnis
+- [Schnellstart](#quick-start) — generieren + ausliefern auf einem Bildschirm
+- [Schemata aus Serializern](#schemas-from-serializers) · [Pfade aus ViewSets](#paths-from-viewsets)
+- [Ausliefern](#serving-the-spec-swagger-ui--redoc) · [Eine Spec von Hand bauen](#hand-building-a-spec)
+- [Security-Schemata](#security-schemes) · [Der `Schema`-Builder](#the-schema-builder)
+- [Anmerkungen & Grenzen](#notes-and-limits)
+
+---
+
+## Schnellstart
+
+Generiere ein Component-Schema aus einem Serializer, CRUD-Pfade aus einem
+ViewSet und hänge dann den Viewer ein:
+
+```rust
+use rustango::core::Model;                  // brings `Post::SCHEMA` into scope
+use rustango::openapi::{OpenApiSpec, OpenApiSchema, SecurityScheme};
+use rustango::openapi::router::openapi_router;
+use rustango::viewset::ViewSet;
+
+let mut spec = OpenApiSpec::new("Blog API", "1.0.0")
+    .description("Demo of rustango's OpenAPI generation")
+    .server("https://api.example.com", "Production")
+    .add_security_scheme("bearerAuth", SecurityScheme::bearer("JWT"))
+    .require_security("bearerAuth", [])                  // global default
+    .add_schema("Post", PostSerializer::openapi_schema()); // from #[derive(Serializer)]
+
+// CRUD path items straight off the ViewSet:
+for (path, item) in ViewSet::for_model(Post::SCHEMA).openapi_paths("/api/posts", "Post") {
+    spec = spec.add_path(path, item);
+}
+
+// Mount /openapi.json + /docs (Swagger UI) + /redoc:
+let app = axum::Router::new().merge(openapi_router(spec));
+```
+
+Rufe `/docs` für Swagger UI auf, `/redoc` für Redoc, oder hole das rohe
+`/openapi.json` für die Codegenerierung (`openapi-generator`, `oapi-codegen`
+usw.).
+
+---
+
+## Schemata aus Serializern
+
+Mit aktivem `openapi`-Feature emittiert `#[derive(Serializer)]` zusätzlich eine
+[`OpenApiSchema`]-Impl, sodass jeder Serializer zu einem Component-Schema wird:
+
+```rust
+use rustango::openapi::OpenApiSchema;
+
+let schema = PostSerializer::openapi_schema();   // -> rustango::openapi::Schema
+spec = spec.add_schema("Post", schema);
+```
+
+Das Schema spiegelt die **API-Form** wider, nicht die rohe Tabelle: umbenannte
+Felder (`#[serializer(source = "body")]` → `content`), `read_only`- /
+`write_only`-Sichtbarkeit, berechnete Methodenfelder und verschachtelte
+Serializer tragen sich alle durch. Feldtypen bilden automatisch ab:
+
+| Rust-Feld | OpenAPI |
+|---|---|
+| `i32` / `i64` | `integer` (`int32` / `int64`) |
+| `f32` / `f64` | `number` (`float` / `double`) |
+| `String`, `&str` | `string` |
+| `bool` | `boolean` |
+| `Vec<T>` / `[T; N]` | `array` von `T` |
+| `Option<T>` | `T`, als `nullable` markiert |
+| `chrono::DateTime<Utc>` | `string` / `date-time` |
+| `chrono::NaiveDate` | `string` / `date` |
+| `uuid::Uuid` | `string` / `uuid` |
+| `Auto<T>` | wie `T` (serverseitig zugewiesen) |
+| `HashMap<String, V>` | `object` mit `additionalProperties` |
+| `serde_json::Value` | frei geformt (beliebig) |
+
+Für einen **benutzerdefinierten Feldtyp** implementiere `OpenApiSchema` einmal,
+und es funktioniert überall dort, wo dieser Typ auftaucht:
+
+```rust
+struct Money { cents: i64 }
+
+impl rustango::openapi::OpenApiSchema for Money {
+    fn openapi_schema() -> rustango::openapi::Schema {
+        rustango::openapi::Schema::integer().description("amount in cents")
+    }
+}
+```
+
+> Siehe den [Serializer-Leitfaden](serializers.md#openapi-schemas) für die
+> Feldattribute, die die Ausgabe formen.
+
+---
+
+## Pfade aus ViewSets
+
+`ViewSet::openapi_paths(prefix, schema_ref)` gibt die `(path, PathItem)`-Paare
+für die fünf standardmäßigen CRUD-Routen zurück — list, create, retrieve,
+update, partial update, delete — verdrahtet, um auf ein registriertes
+Component-Schema zu verweisen:
+
+```rust
+for (path, item) in ViewSet::for_model(Post::SCHEMA)
+    .filter_fields(&["author_id", "status"])
+    .search_fields(&["title", "body"])
+    .openapi_paths("/api/posts", "Post")
+{
+    spec = spec.add_path(path, item);
+}
+```
+
+Es erzeugt `/api/posts` (GET list, POST create) und `/api/posts/{pk}` (GET, PUT,
+PATCH, DELETE), und es bleibt mit der Konfiguration des ViewSet synchron:
+
+- **Pagination** → die passenden Query-Parameter + der Umschlag der
+  Listenantwort für den konfigurierten Stil (`page`/`page_size`, `cursor` oder
+  `limit`/`offset`).
+- **Filtering / Suche / Sortierung** → ein `?field=`-Query-Parameter pro
+  `filter_fields` (mit den verfügbaren `__gt`/`__in`/…-Lookups beschrieben) plus
+  `?search=` und `?ordering=`, wenn konfiguriert.
+- **`read_only()`** → die Schreiboperationen (POST/PUT/PATCH/DELETE) werden
+  weggelassen.
+- **Pfadparameter** → `{pk}`, typisiert aus dem Primärschlüssel des Modells.
+- **`operationId`** → `list_post`, `create_post`, … (pro Aktion in snake_case).
+
+> Das ViewSet selbst wird im [ViewSets-Leitfaden](viewsets.md) dokumentiert.
+
+---
+
+## Die Spec ausliefern (Swagger UI / Redoc)
+
+`openapi_router(spec)` hängt drei Routen ein:
+
+| Route | Liefert |
+|---|---|
+| `GET /openapi.json` | die Spec als JSON (`application/json`) |
+| `GET /docs` | Swagger UI (interaktives „try-it-out“) |
+| `GET /redoc` | Redoc (saubere Drei-Panel-Referenz) |
+
+```rust
+let app = axum::Router::new()
+    .merge(PostViewSet::router("/api/posts", pool.clone()))
+    .merge(openapi_router(spec));        // adds /openapi.json, /docs, /redoc
+```
+
+Die Viewer-Seiten sind winzige HTML-Hüllen, die Swagger UI / Redoc von einem CDN
+laden (`unpkg` / `jsdelivr`) — es wird kein JS in **Rustango** gebündelt. Für
+ein Air-Gapped-Deployment schreibe `spec.to_json()` beim Start in eine Datei und
+hoste die Viewer-Assets aus deinem eigenen Static-Verzeichnis selbst.
+
+---
+
+## Eine Spec von Hand bauen
+
+Wenn deine API nicht ViewSet-förmig ist, baue die Spec direkt — dieselben Typen,
+volle OpenAPI-3.1-Treue:
+
+```rust
+use rustango::openapi::{OpenApiSpec, PathItem, Operation, Response, Parameter, Schema};
+
+let spec = OpenApiSpec::new("My API", "1.0.0")
+    .description("Customer-facing public API")
+    .add_schema("Post", Schema::object()
+        .property("id", Schema::integer())
+        .property("title", Schema::string())
+        .required(["id", "title"]))
+    .add_path("/posts/{id}", PathItem::new()
+        .parameter(Parameter::path("id", Schema::integer()))
+        .get(Operation::new()
+            .summary("Get a post")
+            .operation_id("get_post")
+            .tag("posts")
+            .response("200", Response::new("OK")
+                .json_content(Schema::ref_("Post")))
+            .response("404", Response::new("not found"))));
+
+let json = spec.to_json();   // pretty-printed OpenAPI 3.1
+```
+
+`OpenApiSpec` nimmt außerdem `.contact(...)`, `.license(...)`, `.add_tag(...)`
+und mehrere `.server(...)`-Einträge entgegen.
+
+---
+
+## Security-Schemata
+
+Deklariere, wie sich die API authentifiziert, und fordere dann ein Schema global
+(Overrides pro Operation gewinnen):
+
+```rust
+use rustango::openapi::SecurityScheme;
+
+let spec = OpenApiSpec::new("API", "1.0")
+    .add_security_scheme("bearerAuth", SecurityScheme::bearer("JWT"))
+    .add_security_scheme("apiKey", SecurityScheme::api_key_header("X-API-Key"))
+    .require_security("bearerAuth", []);     // default for every operation
+```
+
+Helfer: `SecurityScheme::bearer(fmt)`, `basic()`, `api_key_header(name)`,
+`api_key_query(name)`, `oauth2_authorization_code(auth_url, token_url, scopes)`.
+An einer `Operation` markiert `.no_security()` einen öffentlichen Endpunkt und
+`.require_security(scheme, scopes)` überschreibt den globalen Default. Diese
+passen zu **Rustango**s eigener Auth (siehe den
+[Security-Leitfaden](security.md#authenticating-users)): JWT → `bearer`,
+API-Keys → `apiKey`, OAuth2 → `oauth2`.
+
+---
+
+## Der `Schema`-Builder
+
+`Schema` ist ein flüssiger JSON-Schema-Builder (OpenAPI-3.1-Teilmenge):
+
+```rust
+Schema::object()
+    .property("id", Schema::integer())                       // int64
+    .property("email", Schema::email())                      // string/email
+    .property("status", Schema::string().enum_(["draft", "published"]))
+    .property("tags", Schema::array_of(Schema::string()))
+    .property("created", Schema::datetime().nullable())
+    .required(["id", "email"]);
+```
+
+Typkonstruktoren: `string` · `integer` / `int32` · `number` · `boolean` ·
+`object` · `array_of(..)` · `any_object` · `datetime` / `date` / `time` · `uuid`
+· `decimal` · `binary` · `email` · `uri` · `ref_("Name")`. Modifikatoren:
+`.property`, `.required`, `.nullable`, `.enum_`, `.format`, `.description`,
+`.example`, `.default_value`, `.min_length` / `.max_length`, `.minimum` /
+`.maximum`.
+
+---
+
+## Anmerkungen und Grenzen
+
+- **Es ist OpenAPI 3.1** (`"openapi": "3.1.0"`), was sich an JSON Schema 2020-12
+  ausrichtet — die meisten modernen Werkzeuge konsumieren es direkt.
+- **Der Viewer-Router benötigt das `admin`-Feature** (für axum); `openapi`
+  allein reicht, um eine Spec zu *bauen* und zu serialisieren
+  (`spec.to_json()`).
+- **Viewer laden von einem CDN** — in Ordnung für interne/Dev-Docs; hoste die
+  Assets selbst für Offline- oder CSP-gesperrte Deployments.
+- **`openapi_paths` deckt die Standard-CRUD-Form ab.** Benutzerdefinierte
+  Aktionen oder von Hand gebaute Endpunkte fügst du mit `add_path` hinzu (Abschnitt
+  „Von Hand bauen“ oben).
+- Regeneriere Client-SDKs aus `/openapi.json` in der CI, damit sie nie vom Server
+  abdriften.

--- a/docs/de/orm.md
+++ b/docs/de/orm.md
@@ -1,0 +1,1800 @@
+# ORM-Kochbuch
+
+Muster für das **Rustango**-ORM jenseits der Grundlagen. Wenn du von Djangos ORM, Laravel Eloquent oder Rails ActiveRecord kommst, werden dir die Formen hier vertraut vorkommen. Die meisten Beispiele setzen voraus, dass du bereits ein `Post`-Model aus `Getting Started` hast.
+
+[![Typgeprüfte ORM-Abfragen: verkettete Filter, Sortierung, Limits und Aggregation — alles ohne rohes SQL](img/orm.png)](img/orm.png)
+
+> **Quelle:** `rustango::sql` (`QuerySet`, das `Q!`-Makro / der `Qb`-Builder) und die
+> `#[derive(Model)]`-Query-API — immer kompiliert; wähle ein Backend-Feature
+> (`postgres` / `mysql` / `sqlite`).
+>
+> **Lauffähige Version:** die Muster hier laufen im getesteten
+> [`orm_cookbook`](../crates/rustango/examples/orm_cookbook)-Beispiel.
+>
+> **Neu bei einem Begriff hier?** Das [Glossar](glossary.md) definiert *model*, *queryset*,
+> *pool* und *migration* in einfacher Sprache.
+
+Ein paar Rust-Begriffe tauchen durchgehend auf. `&pool` ist eine geteilte Referenz auf den Datenbank-Verbindungspool; du übergibst sie an die Methoden, die tatsächlich SQL ausführen. `.await` führt einen asynchronen Aufruf aus und wartet auf das Ergebnis. `Option<T>` ist ein Wert, der vorhanden (`Some`) oder abwesend (`None`) sein kann — Rusts Null. `Result` ist Erfolg-oder-Fehler; das nachgestellte `?` an einem Aufruf kehrt bei einem Fehler früh zurück. `Auto<i64>` ist ein automatisch hochzählender Primärschlüssel, der entweder `Set` (aus der DB geladen) oder `Unset` (noch nicht eingefügt) ist.
+
+## Was ist neu (v0.41 / v0.42)
+
+Jüngste Releases haben eine Reihe von Django-Paritäts-Features hinzugefügt, die noch nicht in jeden Abschnitt weiter unten eingearbeitet sind. Kurze Hinweise:
+
+- **`Q!`-Makro + `Qb`-Laufzeit-Builder** (#269, #263) — kompilierzeitsichere Filter in Django-Form. `User::objects().where_(Q!(User.email__icontains = "alice"))` lässt sich bei einem falsch geschriebenen Feldnamen nicht bauen. Laufzeit-komponierbare Variante für Admin-Filter-Chips: `let q = Qb::eq("active", true) & Qb::gt("age", 18i64);`.
+- **`.distinct_on(&["author_id"])`** (#264) — PG-nativ; portabler Fallback per Fensterfunktion auf MySQL / SQLite. Muster nach dem Schema "Neuestes pro Gruppe".
+- **`bulk_upsert_pool(rows, unique_fields, update_fields, &pool)`** (#267) — Djangos `bulk_create(update_conflicts=True)`. Tri-dialektisches ON CONFLICT / ON DUPLICATE KEY UPDATE.
+- **`explain_pool()`** (#272) — tri-dialektisches EXPLAIN. PG `EXPLAIN (FORMAT JSON, ANALYZE, BUFFERS)` / MySQL `EXPLAIN ANALYZE` / SQLite `EXPLAIN QUERY PLAN`.
+- **DB-Funktionsbibliothek** (#266) — `Cast`, `LPad`, `RPad`, `MD5`, `SHA1`, `SHA256`, `Position`, `Repeat`, `Reverse`, `Sign`, `Mod`, `Power`, `Sqrt`. Emission pro Dialekt mit klaren Fehlern dort, wo SQLite die Funktion nicht hat.
+- **Feldtypen** — `rust_decimal::Decimal` (PG/MySQL-nativ, SQLite über einen Decode-Shim), `chrono::NaiveTime`, `Vec<u8>` (`FieldType::Binary`) werden jetzt von `#[derive(Model)]` akzeptiert (#524, v0.42).
+- **`ModelForm::prepare_save()` / `PreparedSave`** (#375, v0.42) — Djangos `save(commit=False)`. Jetzt validieren, das vorbereitete Schreib-Set mutieren, committen, wenn bereit.
+- **`#[rustango(unique_when(columns = "...", condition = "..."))]`** (#265) — partielle Unique-Constraints. "Eindeutige E-Mail pro nicht-gelöschter Zeile" / "Eindeutiger Slug pro Mandant".
+- **`#[rustango(manager(ext = "FooManagerExt"))]`** (#271) — Erweiterungs-Trait für benutzerdefinierte Manager in Django-Form, emittiert neben dem Model. (Auch die Rust-Form von Djangos Proxy-Models — dieselbe physische Tabelle, mehrere "Persönlichkeiten" über per-Trait-Methoden. Siehe `inheritance.rs:98-127`.)
+- **`manage makemigrations --merge`** (#346, v0.42) — Merge-Knoten in Django-Form für divergente Branch-Ketten. Siehe [`docs/manage.md`](manage.md#makemigrations---merge).
+
+Das CHANGELOG führt den vollständigen Ticket-Index für jedes Release.
+
+## Inhaltsverzeichnis
+
+- [Abfragen](#querying)
+- [Berechnete Werte & Datenbankfunktionen](#computed-values--database-functions)
+- [Aggregationen](#aggregations)
+- [Joins & Vorladen verwandter Zeilen](#joins--preloading-related-rows)
+- [Massenoperationen](#bulk-operations)
+- [Einfügen oder aktualisieren (Upsert)](#insert-or-update-upsert)
+- [Transaktionen](#transactions)
+- [Many-to-many](#many-to-many)
+- [JSON / JSONB](#json--jsonb)
+- [Soft Delete](#soft-delete)
+- [Audit-Trail](#audit-trail)
+- [Raw-SQL-Notausstieg](#raw-sql-escape-hatch)
+- [Lazy-FK-Laden](#lazy-fk-loading)
+- [Vier Wege zu filtern](#four-ways-to-filter)
+- [Mandantengebundene Abfragen](#tenant-scoped-queries)
+- [Signale](#signals)
+- [Performance-Tipps](#performance-tips)
+
+---
+
+## Abfragen
+
+Zeilen aus der Datenbank lesen. `Post::objects()` startet eine Abfrage (wie Djangos `Post.objects`); du verkettest Filter und Sortierung und rufst dann `.fetch(&pool).await?` auf, um sie auszuführen und ein `Vec<Post>` zurückzubekommen. `.where_(...)` fügt eine per-AND verknüpfte Bedingung hinzu.
+
+```rust
+use rustango::core::Column as _;
+use rustango::core::{Op, SqlValue, WhereExpr};   // for filter_op / where_raw below
+use rustango::sql::FetcherPool as _;
+
+// Simplest — fetch all
+let posts = Post::objects().fetch(&pool).await?;
+
+// Single equality filter
+let drafts = Post::objects()
+    .where_(Post::status.eq("draft"))
+    .fetch(&pool).await?;
+
+// Chained filters (AND)
+let recent_drafts = Post::objects()
+    .where_(Post::status.eq("draft"))
+    .where_(Post::author_id.eq(42))
+    .where_(Post::deleted_at.is_null())
+    .order_by(&[("created_at", true)])        // true = DESC
+    .limit(20)
+    .fetch(&pool).await?;
+
+// String-keyed filter (validated at compile of the queryset)
+let by_id = Post::objects()
+    .filter_op("id", Op::Eq, SqlValue::I64(42))
+    .fetch(&pool).await?;
+
+// OR / nested
+let qs = Post::objects().where_raw(WhereExpr::Or(vec![
+    Post::status.eq("draft").into(),
+    Post::status.eq("review").into(),
+]));
+
+// XOR — Django 4.1+ `Q(a) ^ Q(b)`. Matches rows where an odd number
+// of operands evaluate to true (binary case = "exactly one is true").
+// Issue #27.
+let either_but_not_both = Post::objects()
+    .where_(Post::status.eq("draft").xor(Post::author_id.eq(42)))
+    .fetch(&pool).await?;
+// Tri-dialect emission: native logical XOR exists on MySQL but not PG
+// or SQLite, so the writer emits a portable rewrite uniformly —
+// `(a AND NOT b) OR (NOT a AND b)` for the binary form, or a
+// CASE-WHEN-1/0 tally `% 2 = 1` for N-ary chains.
+```
+
+### Vergleichsfilter
+
+Die alltäglichen Filtermethoden, eine pro SQL-Operator. Das sind Djangos Feld-Lookups (`__gt`, `__in`, `__icontains` und so weiter) in typisierter Form.
+
+```rust
+Post::objects().where_(Post::view_count.gt(100)).fetch(&pool).await?;
+Post::objects().where_(Post::view_count.gte(100)).fetch(&pool).await?;
+Post::objects().where_(Post::view_count.lt(100)).fetch(&pool).await?;
+Post::objects().where_(Post::view_count.lte(100)).fetch(&pool).await?;
+Post::objects().where_(Post::status.ne("archived")).fetch(&pool).await?;
+Post::objects().where_(Post::id.is_in([1, 2, 3])).fetch(&pool).await?;
+Post::objects().where_(Post::status.not_in(["draft", "deleted"])).fetch(&pool).await?;
+Post::objects().where_(Post::title.like("%draft%")).fetch(&pool).await?;          // case-sensitive contains
+Post::objects().where_(Post::title.ilike("%draft%")).fetch(&pool).await?;         // case-insensitive contains
+Post::objects().where_(Post::title.ilike("Hello%")).fetch(&pool).await?;          // case-insensitive starts-with
+Post::objects().where_(Post::deleted_at.is_null()).fetch(&pool).await?;
+Post::objects().where_(Post::published_at.between(start, end)).fetch(&pool).await?;
+```
+
+### Ergebnisse sortieren
+
+Sortiere Zeilen nach einer oder mehreren Spalten, nach einem Ausdruck oder mit expliziter Kontrolle darüber, wo NULLs landen. Über das grundlegende `.order_by(&[("col", desc)])` hinaus bekommst du drei zusätzliche Dimensionen:
+
+```rust
+use rustango::core::funcs::lower;
+use rustango::core::{F, NullsOrder};
+
+// 1. Plain field + ASC/DESC (back-compat — implicit NULLS handling
+//    differs between dialects; see the dialect note below).
+Post::objects()
+    .order_by(&[("published_at", true), ("id", false)])
+    .fetch(&pool).await?;
+
+// 2. Explicit NULLS FIRST/LAST control — portable across PG, MySQL,
+//    and SQLite. MySQL has no native `NULLS …` keyword; the writer
+//    emulates with an `<col> IS NULL` pre-sort term so the on-wire
+//    ordering matches PG/SQLite.
+Post::objects()
+    .order_by_with_nulls(&[("score", true, NullsOrder::Last)])
+    .fetch(&pool).await?;
+
+// 3. Arbitrary Expr in the ORDER BY position — case-insensitive
+//    title sort via `LOWER(title)`, computed sort keys via
+//    `case() / when() / value()`, arithmetic via `F("a") + F("b")`.
+Post::objects()
+    .order_by_expr(lower(F("title")), false)
+    .order_by_expr_with_nulls(F("score") + 1_i64, true, NullsOrder::Last)
+    .fetch(&pool).await?;
+```
+
+**NULLS-Behandlung pro Dialekt (kein explizites `NullsOrder` gesetzt):**
+
+| Dialekt | ASC-Standard | DESC-Standard |
+|---|---|---|
+| PostgreSQL | NULLS LAST | NULLS FIRST |
+| SQLite | NULLS LAST | NULLS FIRST |
+| MySQL | NULLs zuerst (Semantik des kleinsten Werts) | NULLs zuletzt |
+
+Verwende `.order_by_with_nulls(...)` / `.order_by_expr_with_nulls(...)`, um die Platzierung festzunageln; andernfalls gilt der native Standard der Datenbank. Auf MySQL emittiert der Writer `<col> IS NULL <asc|desc>` vor der eigentlichen Sortierung, um das nachzubilden; das emittierte SQL hat zwei ORDER-BY-Terme pro festgenagelter Spalte, aber die Semantik entspricht PG/SQLite.
+
+**Kettenkomposition.** `.order_by(...)`, `.order_by_with_nulls(...)` und `.order_by_expr(...)` sammeln sich in **Registrierungsreihenfolge** zu einer einheitlichen Liste. `.replace_order_by(&[...])` löscht jeden vorherigen Order-by-Aufruf. `.flip_order_by()` invertiert jede Richtung UND tauscht `NullsOrder::First` ↔ `NullsOrder::Last`, sodass die Semantik "NULLs am selben Ende" eine Invertierung übersteht (für explizites `First` / `Last`; das Dialekt-Standardverhalten unter `Default` folgt weiterhin der Richtung).
+
+### Zufällige Sortierung
+
+Gib Zeilen in zufälliger Reihenfolge zurück — Djangos `.order_by('?')`. Verwende `.order_random()`. Es emittiert `ORDER BY RANDOM()` auf PG und SQLite, `ORDER BY RAND()` auf MySQL. Praktisch für Banner-Rotation, Sampling oder A/B-Test-Bucket-Zuweisung, ohne Zeilen in die App zu ziehen, um sie zu mischen.
+
+```rust
+// Three random posts.
+Post::objects()
+    .order_random()
+    .limit(3)
+    .fetch(&pool).await?;
+
+// Random tie-breaker after a primary sort: posts ordered by score
+// descending, with ties shuffled.
+Post::objects()
+    .order_by(&[("score", true)])
+    .order_random()
+    .fetch(&pool).await?;
+```
+
+Die IR-Variante trägt keine Richtungs- oder NULLS-Klausel: zufällige Sortierung ist per Definition ungeordnet, und der Zufallsschlüssel wird pro Zeile berechnet (non-NULL).
+
+**Performance-Vorbehalt.** `ORDER BY RANDOM()` erzwingt einen **vollständigen Tabellenscan + In-Memory-Sortierung nach einem Zufallsschlüssel pro Zeile**. Der Query-Planer kann keinen Index nutzen. Für Tabellen, die deutlich größer als der Speicher sind, bevorzuge das indexfreundliche Muster:
+
+```rust
+// Coin-flip offset; range-scans the PK index.
+let max_id: i64 = Post::objects().max::<i64>("id", &pool).await?.unwrap_or(0);
+let offset = rand::random::<u32>() as i64 % max_id.max(1);
+Post::objects()
+    .where_(Post::id.gte(offset))
+    .order_by(&[("id", false)])
+    .limit(1)
+    .fetch(&pool).await?;
+```
+
+Der Kompromiss: die Nachbarschaft in den Ergebniszeilen spiegelt die PK-Nachbarschaft wider, ist also nicht "gleichverteilt zufällig" im strengen Sinn — dafür entgeht sie den Kosten des vollständigen Tabellenscans.
+
+### Paginierung
+
+Hol dir jeweils eine Ergebnisseite auf einmal. `.limit(size).offset(...)` ist die einfache Seitennummern-Form; die Cursor-Form ("alles nach der letzten ID, die ich gesehen habe") skaliert bei großen Tabellen besser.
+
+```rust
+// Page-number — page 2 of 50-row pages = LIMIT 50 OFFSET 50.
+let page = Post::objects().limit(50).offset(50).fetch(&pool).await?;
+
+// Cursor (manual — no auto-next-token from QuerySet)
+let next = Post::objects()
+    .where_(Post::id.gt(last_id))
+    .order_by(&[("id", false)])
+    .limit(50)
+    .fetch(&pool).await?;
+```
+
+Für Cursor-Paginierung auf HTTP-Seite verwende stattdessen `ViewSet::cursor_pagination("id")`.
+
+### Zeilen in eine Map laden
+
+Schlag viele Zeilen anhand einer Werteliste nach und bekomme sie als `HashMap` zurück, geschlüsselt nach dieser Spalte. Das ist Djangos `in_bulk(ids, field_name=)`. Verwende `.in_bulk(...)` für "hol diese N Zeilen in einem Roundtrip, indiziert nach ID". Eine `HashMap<K, V>` ist Rusts Dictionary/Hash-Tabelle.
+
+```rust
+use std::collections::HashMap;
+use rustango::sql::Auto;
+
+// Default Django shape: keyed by the Auto<i64> PK.
+let books: HashMap<i64, Book> = Book::objects()
+    .in_bulk(Book::id, [1_i64, 2, 3], |b| match b.id {
+        Auto::Set(v) => v,
+        Auto::Unset  => unreachable!("fetched row has Auto::Set PK"),
+    }, &pool)
+    .await?;
+assert_eq!(books[&1].title, "The Rust Programming Language");
+
+// `field_name=` equivalent — key by any unique column.
+let by_isbn: HashMap<String, Book> = Book::objects()
+    .in_bulk(Book::isbn, ["isbn-1".to_string()], |b| b.isbn.clone(), &pool)
+    .await?;
+```
+
+Komponiert mit vorherigen `.where_()`-Filtern — die `IN`-Liste wird per AND mit dem bestehenden WHERE verknüpft. Ein leeres `ids` schließt kurz mit einer leeren Map (es wird kein SQL abgesetzt). Der Closure behandelt das `Auto<T>` / `ForeignKey<T, K>`-Auspacken explizit und gibt den Aufrufern Kontrolle darüber, wie der Schlüssel materialisiert wird.
+
+Mandantengebundenes Geschwister: `in_bulk_on(column, ids, extract, &executor)` nimmt jeden sqlx-Executor — kombiniere es mit `tenant.conn()` für Schema-Modus-Mandanten.
+
+### Zeilen zum Aktualisieren sperren
+
+Sperre die Zeilen, die du auswählst, sodass keine andere Transaktion sie ändern kann, bis du committest — der Standardweg, um Arbeit zu beanspruchen oder verlorene Updates zu verhindern. Das ist Djangos `select_for_update(skip_locked=, nowait=, of=, no_key=)`. Rufe `.select_for_update()` auf; es hängt `SELECT … FOR UPDATE` (oder eine Variante) an, und die Sperre dauert für die umgebende Transaktion.
+
+```rust
+// Canonical "claim next available row" pattern. Worker A grabs the
+// lowest-priority pending job; concurrent worker B with SKIP LOCKED
+// skips A's row and grabs the next instead — no blocking.
+let mut tx = pool.begin().await?;
+let claim: Vec<Job> = Job::objects()
+    .where_(Job::status.eq("pending"))
+    .order_by(&[("priority", false)])
+    .limit(1)
+    .select_for_update()
+    .skip_locked()
+    .fetch_on(&mut *tx).await?;
+// ... mark claim[0] as in-progress, do work ...
+tx.commit().await?;
+```
+
+**Builder-Methoden** — verkette sie, um sie zu aktivieren:
+
+- `.select_for_update()` — schlichtes `FOR UPDATE`.
+- `.skip_locked()` — hängt `SKIP LOCKED` an; Zeilen, die von einer anderen Transaktion gehalten werden, werden stillschweigend herausgefiltert, statt zu blockieren.
+- `.nowait()` — hängt `NOWAIT` an; liefert sofort einen Treiber-Fehler, wenn irgendeine passende Zeile gesperrt ist. Schließt sich gegenseitig mit `skip_locked` aus (der Writer wählt das permissivere `SKIP LOCKED`, wenn beide gesetzt sind).
+- `.no_key()` — emittiert stattdessen `FOR NO KEY UPDATE` (PG 9.3+). Schwächere Sperre, die Schreiber nicht blockiert, die nur Nicht-Schlüsselspalten anfassen.
+- `.of(&["table_or_alias", …])` — beschränke die Sperre auf bestimmte Tabellen, wenn die Abfrage JOINt.
+
+`.skip_locked()` / `.nowait()` / `.no_key()` / `.of(…)` ohne ein vorheriges `.select_for_update()` aufzurufen, aktiviert die Sperre implizit — passend zu Djangos Ergonomie.
+
+**Tri-dialektisches Verhalten:**
+
+| Dialekt | Verhalten |
+|---|---|
+| PostgreSQL | Volle Unterstützung — jedes Flag emittiert seine native Syntax. |
+| MySQL 8.0.1+ | Unterstützt alles außer `NO KEY` — dieses Flag fällt auf schlichtes `FOR UPDATE` zurück (die strengere Sperre). |
+| SQLite | Keine Syntax für Sperren auf Zeilenebene. Der Writer emittiert überhaupt keine Klausel; Transaktionen halten eine implizite Schreibsperre für die gesamte Datenbank. Verwende für SQLite eine andere Strategie (typischerweise eine Busy-Wait-Schleife auf der Transaktion selbst). |
+
+**Muss innerhalb einer Transaktion laufen.** `FOR UPDATE` außerhalb einer Transaktion ist auf PostgreSQL eine No-op (die implizite Ein-Statement-Transaktion gibt die Sperre sofort frei) und auf MySQL ein Fehler. Kombiniere mit `pool.begin()` (oder `rustango::sql::atomic`).
+
+### Abfragen kombinieren (Vereinigung, Schnitt, Differenz)
+
+Führe zwei oder mehr Abfragen über dasselbe Model mit SQL-Mengenoperatoren zusammen. Das sind Djangos `.union()`, `.intersection()` und `.difference()`.
+
+```rust
+// Posts that are EITHER drafts OR currently in review.
+let inbox: Vec<Post> = Post::objects()
+    .where_(Post::status.eq("draft"))
+    .union(Post::objects().where_(Post::status.eq("review")))
+    .order_by(&[("created_at", true)])
+    .limit(50)
+    .fetch(&pool).await?;
+```
+
+**Builder-Methoden**:
+
+| Methode | SQL | Semantik |
+|---|---|---|
+| `.union(other)` | `UNION` | Kombinieren + deduplizieren |
+| `.union_all(other)` | `UNION ALL` | Kombinieren, Duplikate behalten (günstiger, kein DISTINCT-Durchlauf) |
+| `.intersection(other)` | `INTERSECT` | Zeilen in BEIDEN Querysets |
+| `.difference(other)` | `EXCEPT` | Zeilen im ersten Queryset, aber NICHT in den anderen |
+
+Jede Methode nimmt `QuerySet<T>` — beide Zweige müssen auf dasselbe Model `T` zielen, sodass die Spaltenform per Konstruktion passt (zur Kompilierzeit durch Rusts Generics geprüft). Aufrufe sammeln sich an; das Mischen von Operatoren in einer Kette ist erlaubt (`a.union(b).intersection(c)` wertet gemäß SQL-Standard von links nach rechts aus).
+
+**Äußere Modifikatoren gelten für das zusammengeführte Ergebnis**:
+
+```rust
+// Outer .order_by() / .limit() / .offset() / .select_for_update()
+// set AFTER the union apply to the combined resultset, NOT per-branch.
+let page: Vec<Post> = qs_a
+    .union(qs_b)
+    .union(qs_c)
+    .order_by(&[("id", false)])    // sorts the merged rows
+    .limit(20)                     // caps the merged count
+    .offset(40)                    // skips into the merged result
+    .fetch(&pool).await?;
+
+// Per-branch ORDER BY / LIMIT stay INSIDE the branch's parens:
+let mixed = qs_a
+    .union(qs_b.order_by(&[("id", true)]).limit(5))   // branch picks its top 5
+    .fetch(&pool).await?;
+```
+
+**Tri-dialektisch**: PostgreSQL + SQLite unterstützen alle vier Operatoren auf jeder Version, die **Rustango** unterstützt. MySQL 8.0+ unterstützt `UNION`/`UNION ALL`; `INTERSECT`/`EXCEPT` kamen in MySQL 8.0.31 dazu. Ältere MySQL-Versionen liefern den Syntaxfehler des Treibers zur Fetch-Zeit — es gibt kein clientseitiges Gate.
+
+**Fehlerpfad auf dem typisierten Builder**: `.union(other_qs)` (und `.intersection()` / `.difference()`) kompiliert den Zweig sofort und panickt, wenn der Zweig sich nicht kompilieren lässt (falsch geschriebene Spalte etc.). Für fehlbare Komposition, bei der der Aufrufer ein `Result` will, kompiliere den Zweig zuerst und übergib ihn per `.with_compound(SetOp::Union, branch)` — ein generischer Einstiegspunkt deckt jeden Operator ab. Die Panic-Form entspricht Djangos: ein fehlerhafter Zweig ist ein Programmierfehler, keine Laufzeit-Datenbedingung.
+
+### Große Ergebnismengen streamen
+
+Verarbeite eine riesige Tabelle, ohne sie komplett in den Speicher zu laden. Das ist Djangos `.iterator(chunk_size=2000)`. Rufe `.iterator(chunk_size)` auf; es holt `chunk_size` Zeilen auf einmal (per `LIMIT N OFFSET M`) und puffert nie die gesamte Ergebnismenge. Greif danach bei Millionen-Zeilen-Exporten, ETL-Pipelines und Batch-Jobs.
+
+```rust
+// 1. Whole-chunk loop — process N rows at a time.
+let mut iter = Post::objects()
+    .where_(Post::published.eq(true))
+    .order_by(&[("id", false)])
+    .iterator(2_000)?;
+while let Some(chunk) = iter.next_chunk(&pool).await? {
+    for post in chunk { /* … */ }
+}
+
+// 2. Row-by-row loop — buffer one chunk internally, yield one row.
+let mut iter = Post::objects().order_by(&[("id", false)]).iterator(2_000)?;
+while let Some(post) = iter.next_row(&pool).await? {
+    /* … */
+}
+```
+
+**Setze ein `order_by`.** `OFFSET` gegen eine Abfrage ohne stabile Sortierung liefert über Chunks hinweg unvorhersehbare Zeilen — typischerweise `.order_by(&[("pk", false)])`, sodass jeder Chunk sauber weitermacht. Die Methode erzwingt keine Sortierung (manche Abfragen wollen legitimerweise keine Sortierung, z. B. ein einmaliges Leeren), aber unsortierte Iteration ist eine Fußfalle.
+
+**Kompromiss gegenüber serverseitigen Cursorn.** Das ist ein einfacher LIMIT/OFFSET-Chunker. Auf einer btree-indizierten Sortierspalte scannt PostgreSQL die ersten N Zeilen, bevor es die (N+1)-te zurückgibt — tiefe Paginierung ist also `O(n²)` Gesamtarbeit. Für ein 10M-Zeilen-Leeren ist das relevant; für 100k Zeilen meistens nicht. Der Chunker gewinnt bei Portabilität (funktioniert auf allen Backends ohne Transaktions-Overhead) und Einfachheit (kein Verwalten eines Cursor-Lebenszyklus). Für wirklich streamende Reads auf PG steig direkt in `pool.begin()` + rohes `sqlx::query(...).fetch(&mut *tx)` Stream-API ein — das erweiterte Protokoll streamt vom Server ohne Offset-Reseek.
+
+**`next_chunk` und `next_row` auf demselben Iterator zu mischen ist sicher.** Der interne `VecDeque`-Puffer leert sich in Zeilenreihenfolge vor jedem neuen DB-Fetch, sodass `next_chunk` nach einem partiellen `next_row`-Leeren zuerst die verbleibenden gepufferten Zeilen liefert und dann mit frischen Chunks fortfährt.
+
+Sowohl `.rows_seen()` (kumulierter Zähler) als auch `.is_exhausted()` (Post-Drain-Flag) sind für Fortschrittsmeldung und Terminierungsprüfungen verfügbar.
+
+**Gefahr bei gleichzeitigem Schreiben.** Jeder Chunk ist eine separate Abfrage, sodass zwischen Chunks eingefügte/gelöschte Zeilen übersprungen oder dupliziert werden können (das klassische "Windowing"-Problem der OFFSET-Paginierung). Für nur-lesbare / nur-anfügende Tabellen — den typischen Export-Anwendungsfall — ist das kein Thema. Für Tabellen, die gleichzeitig beschrieben werden, brauchst du eine Snapshot-Isolation-Transaktion, damit jeder Chunk dieselbe Sicht sieht. **`ChunkedIter` nimmt `&Pool`, nicht `&mut Transaction`, sodass die Chunker-API nicht direkt innerhalb der Transaktion verwendet werden kann** — rolle stattdessen den gechunkten SELECT gegen die Transaktion von Hand aus:
+
+```rust
+let mut tx = pool.begin().await?;
+sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+    .execute(&mut *tx).await?;
+
+// Hand-loop LIMIT/OFFSET chunks against the tx with `.fetch_on(&mut *tx)`,
+// so every chunk reads from the same snapshot.
+let chunk_size = 2_000_i64;
+let mut offset = 0_i64;
+loop {
+    let rows: Vec<Post> = Post::objects()
+        .order_by(&[("id", false)])
+        .limit(chunk_size)
+        .offset(offset)
+        .fetch_on(&mut *tx)
+        .await?;
+    if rows.is_empty() { break; }
+    for post in &rows { /* … */ }
+    if (rows.len() as i64) < chunk_size { break; }
+    offset += rows.len() as i64;
+}
+tx.commit().await?;
+```
+
+**`select_for_update()` propagiert nicht über Chunks hinweg.** Zeilensperren, die von `.select_for_update()` gehalten werden, werden am Ende der impliziten Transaktion jedes Chunks freigegeben. Es gibt keine chunker-förmige Lösung: der `.iterator()`-Builder nimmt `&Pool`, die sperrenden Varianten brauchen ein `&mut Transaction`, und die beiden komponieren nicht. Für ein gesperrtes Leeren hast du zwei Wege, jeder mit einem Kompromiss:
+
+- **Ganzes-Ergebnis `.fetch_on(&mut *tx)`** — ein einziger Roundtrip, volles `Vec<T>` im Speicher. In Ordnung, wenn das Ergebnis passt.
+- **Handgerolltes LIMIT/OFFSET innerhalb der Transaktion** — dieselbe Form wie das Snapshot-Isolation-Snippet oben; Chunks bleiben gestreamt, aber du bist außerhalb der `ChunkedIter`-API.
+
+Ein zukünftiges `iterator_on(&mut *tx, chunk_size)`-Gegenstück (Issue-Nachfolge) würde diese Lücke schließen. Nicht im Umfang von Issue #23.
+
+**`chunk_size` muss > 0 sein.** Null oder negative Werte panicken. Wähle einen Wert, der zu deinem Zeilengrößen-Budget passt (Djangos Standard ist `2000`; sinnvoll für schmale Zeilen, niedriger für breite TEXT/JSONB-Spalten).
+
+### Bestimmte Spalten auswählen
+
+Hol nur ein paar Spalten statt ganzer `Post`-Structs — Djangos `.values('col')` und `.values_list('col', flat=True)`. Verwende diese, wenn du nur ein paar Spalten aus einer breiten Tabelle brauchst, oder wenn das Ergebnis dynamischen Code speist (Templates, CSV-Export, JSON). Du bekommst Maps, Tupel oder eine flache typisierte Liste zurück statt Model-Instanzen.
+
+```rust
+use rustango::core::SqlValue;
+use std::collections::HashMap;
+
+// 1. Column-keyed map per row — Django's `.values('id', 'title')`.
+let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+    .where_(Post::published.eq(true))
+    .order_by(&[("id", false)])
+    .values_dict(&["id", "title"])
+    .fetch(&pool).await?;
+
+// 2. Ordered tuple per row — Django's `.values_list('id', 'title')`.
+//    Cell ordering matches the column-list argument.
+let rows: Vec<Vec<SqlValue>> = Post::objects()
+    .values_list(&["title", "id"])  // title first, id second
+    .fetch(&pool).await?;
+
+// 3. Single-column typed scalar — Django's `.values_list('id', flat=True)`.
+//    Returns Vec<U> directly via sqlx's typed scalar path.
+let ids: Vec<i64> = Post::objects()
+    .where_(Post::published.eq(true))
+    .values_list_flat("id")
+    .fetch::<i64>(&pool).await?;
+```
+
+**Drei Builder, eine IR.** Alle drei setzen `SelectQuery::projection` auf die validierte Spaltenliste — das SQL ist über die drei terminalen Formen identisch; nur das Zeilen-Decode unterscheidet sich:
+
+| Builder | SQL-Form | Gibt zurück |
+|---|---|---|
+| `.values_dict(&[cols])` | `SELECT col1, col2 FROM …` | `Vec<HashMap<String, SqlValue>>` |
+| `.values_list(&[cols])` | `SELECT col1, col2 FROM …` | `Vec<Vec<SqlValue>>` (geordnet nach `cols`) |
+| `.values_list_flat(col)` | `SELECT col FROM …` | `Vec<U>` (typisiert, über `fetch::<U>(...)`) |
+
+**Funktioniert mit dem Rest der Query-Kette.** `.where_()`, `.filter()`, `.order_by()`, `.limit()`, `.offset()` und die Mengenoperatoren (`.union()` / `.intersection()` / `.difference()`) — jede Methode, die VOR `.values_*` aufgerufen wird, wird übernommen. Die Values-Builder sind terminal (nichts verkettet danach), also setze zuerst die Query-Form und fetche dann.
+
+**Validierung zur `.compile()`- / `.fetch()`-Zeit:**
+- Leere Spaltenliste (`.values_dict(&[])`) → [`QueryError::EmptyValuesProjection`].
+- Falsch geschriebener Spaltenname (`.values_dict(&["nope"])`) → [`QueryError::UnknownField`].
+
+**Tri-dialektisch: identische Projektions-Emission über PG / MySQL / SQLite** (nur das Identifier-Quoting unterscheidet sich). Für `.values_list_flat::<U>(...)` muss `U` sqlx' `Decode + Type` auf jedem Backend implementieren, das die Binary anvisiert — gängige Auswahlen (`i64`, `i32`, `String`, `bool`, `f64`) funktionieren universell.
+
+**Warum das bestehende `.values()` nicht auf reine Projektion umstellen?** `QuerySet::values(cols)` befördert bereits zum [`AggregateBuilder`] für den GROUP-BY-Auto-Inferenzpfad (Issue #75). Ein Umbenennen würde ~20 bestehende Aufrufstellen brechen. Die neuen `.values_dict()` / `.values_list()` / `.values_list_flat()`-Ketten-Methoden stehen daneben und lassen den Aggregatpfad unangetastet. Der vorbestehende `QueryError::ValuesRequiresAggregate`-Fehler feuert weiterhin für `.values(cols).compile()` ohne ein nachfolgendes `.annotate(...)` — seine Meldung verweist Aufrufer jetzt auf die neuen Reine-Projektion-Methoden.
+
+### Spalten einschließen oder ausschließen
+
+Dieselbe Idee wie im vorherigen Abschnitt, aber in Djangos include/exclude-Form: `.only('id', 'name')` behält nur die genannten Spalten, `.defer('big_field')` behält alles außer ihnen. Verwende diese bei breiten Tabellen, wo große TEXT / BLOB / JSONB-Spalten Listenansichten teuer im Lesen machen:
+
+```rust
+// .only(...) — fetch only the named columns.
+let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+    .where_(Post::published.eq(true))
+    .only(&["id", "title"])
+    .fetch(&pool).await?;
+
+// .defer(...) — fetch everything except the named columns.
+// Useful for "list view: skip body / metadata / large JSON".
+let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+    .defer(&["body", "raw_html"])
+    .fetch(&pool).await?;
+```
+
+**Semantik**: `.only(&[cols])` ist ein Synonym für `.values_dict(cols)` — gleiche IR, gleiche Rückgabeform, separater Einstiegspunkt für Lesbarkeit in Django-Form. `.defer(&[cols])` berechnet das Komplement gegen das Model-Schema (jede Skalarspalte des Models AUSSER den aufgelisteten) und leitet auf denselben Pfad.
+
+**Vorbehalt — Rückgabetyp unterscheidet sich von Django.** Djangos `.only()` / `.defer()` geben teilweise hydrierte `Model`-Instanzen zurück, bei denen die aufgeschobenen Felder beim Attributzugriff lazy geladen werden. **Rustango** hat kein Äquivalent zu Pythons Descriptor-Magie; die Rückgabeform ist `Vec<HashMap<String, SqlValue>>` (oder `Vec<Vec<SqlValue>>`, wenn du stattdessen `.values_list(...)` einwechselst). Typisiertes Teilzeilen-Decode ist für eine zukünftige Iteration vorgemerkt.
+
+**Tippfehlersicherheit**: `.defer(&["nope_col"])` liefert `QueryError::UnknownField` zur `.compile()`-Zeit — der Tippfehler verwandelt sich nicht stillschweigend in "alle Spalten projizieren". `.only(&[])` liefert `QueryError::EmptyValuesProjection`; `.defer(&[])` ist eine semantische No-op (projiziert jede Spalte).
+
+### Mit regulären Ausdrücken abgleichen
+
+Gleiche eine Spalte gegen ein Regex-Muster ab — Djangos `__regex` / `__iregex`. `.regex()` ist case-sensitiv, `.iregex()` case-insensitiv, und `.not_regex()` / `.not_iregex()` sind die negierten Formen.
+
+```rust
+use rustango::core::Column as _;
+
+// Names starting with "al" (case-sensitive).
+User::objects()
+    .where_(User::name.regex("^al.*"))
+    .fetch(&pool).await?;
+
+// Names starting with "al" — case-insensitive.
+User::objects()
+    .where_(User::name.iregex("^al.*"))
+    .fetch(&pool).await?;
+
+// Negated: exclude names starting with "admin" (case-sensitive).
+User::objects()
+    .where_(User::name.not_regex("^admin"))
+    .fetch(&pool).await?;
+
+// Django-shape lookup-suffix form.
+User::objects()
+    .filter("name__iregex", "^bob")
+    .fetch(&pool).await?;
+```
+
+**Tri-dialektische Emission**:
+
+| Dialekt | Case-sensitiv | Case-insensitiv | Hinweise |
+|---|---|---|---|
+| PostgreSQL | `<col> ~ ?` / `<col> !~ ?` | `<col> ~* ?` / `<col> !~* ?` | Native POSIX-Operatoren |
+| MySQL | `` `col` REGEXP ? `` / `` `col` NOT REGEXP ? `` | `LOWER(`col`) REGEXP LOWER(?)` (Negation umschließt mit `NOT`) | LOWER()-Fallback für `i*` |
+| SQLite | `"col" REGEXP ?` / `"col" NOT REGEXP ?` | `LOWER("col") REGEXP LOWER(?)` (Negation umschließt mit `NOT`) | Braucht die `regexp`-User-Funktion auf der Verbindung geladen |
+
+**SQLite benötigt eine registrierte `regexp`-User-Funktion** — sie ist nicht eingebaut. sqlx-sqlite 0.8 registriert standardmäßig **keine**. Zwei Wege, sie zu aktivieren:
+
+1. **Einfach** — aktiviere sqlx-sqlites `regexp`-Cargo-Feature, dann opte die Verbindung ein:
+   ```rust
+   use sqlx::sqlite::SqliteConnectOptions;
+   let opts = SqliteConnectOptions::new()
+       .filename("app.db")
+       .with_regexp();  // gated on sqlx-sqlite/regexp
+   ```
+2. **Manuell** — registriere einen Rust-Closure über `SqliteConnection::lock_handle()` + rohes FFI (`sqlite3_create_function_v2`).
+
+Ohne eine solche emittiert die Abfrage valides `REGEXP`-SQL, das SQLite bei der Ausführung mit `no such function: regexp` ablehnt (parser-sauber — `tests/regex_sqlite_live.rs` nagelt das fest).
+
+**Der Muster-Dialekt unterscheidet sich zwischen Backends.** PostgreSQL verwendet POSIX-Extended-Regex; MySQL verwendet ICU-basiertes Regex mit eigenem Geschmack; SQLite delegiert an das, was die User-Funktion implementiert (typischerweise Rusts `regex`-Crate). Muster, die auf dialektspezifische Syntax setzen (z. B. PGs `\m` / `\M` Wortgrenzen), sind nicht rundlauffähig — halte dich an die portable Teilmenge (`^`, `$`, `.`, `*`, `+`, `?`, `[...]`, `()`, `|`), wenn dasselbe Model von mehreren Backends abgefragt wird.
+
+**Nicht-String-Werte werden bei `.compile()` abgelehnt** — das Übergeben von `SqlValue::I64(42)` an `__regex` liefert `QueryError::InvalidLookupValue { suffix: "regex", expected: "SqlValue::String(<regex pattern>)", … }` statt stillschweigend zu casten.
+
+---
+
+## Berechnete Werte & Datenbankfunktionen
+
+Lass die Datenbank Dinge berechnen, statt Zeilen in die App zu ziehen, sie zu mutieren und zurückzuschreiben. `F("col")` verweist auf eine Spalte per Name (Djangos `F()`-Objekt), und die `funcs::*`-Builder umschließen skalare SQL-Funktionen wie `LOWER` oder `COALESCE`. Zusammen schalten sie drei Muster frei, die reines wertbasiertes `.set()` / `.where_()` nicht ausdrücken kann:
+
+### Atomare Inkremente (kein Read-Modify-Write-Race)
+
+Der klassische Zähler-Bug — eine Zeile holen, ein Feld hochzählen, speichern — verliert Updates, wenn zwei Requests gleichzeitig laufen. `F("col") + 1` fasst den Roundtrip zu einem einzigen `UPDATE` zusammen, sodass die Datenbank die Zeilensperre für dich hält:
+
+```rust
+use rustango::core::F;
+
+Post::objects()
+    .eq("id", post_id)
+    .update()
+    .set_expr("view_count", F("view_count") + 1_i64)
+    .execute(&pool).await?;
+```
+
+Tri-dialektisch: emittiert `views = ("views" + $1)` auf PG, ``views = (`views` + ?)`` auf MySQL, identisch auf SQLite. Die Arithmetik wird geklammert, damit verschachtelte Operationen eindeutig bleiben: `F("a") + F("b") * 2`.
+
+Unterstützte Operatoren: `+ - * / %` plus `& | ^ << >>` (bitweise; XOR auf SQLite emittiert ein klares `OpNotSupportedInDialect`, da SQLite kein XOR-Symbol hat).
+
+### Zwei Spalten in einem Filter vergleichen
+
+Filtere eine Spalte gegen eine andere, nicht gegen ein Literal — z. B. `Reservation start_date < end_date`, um eine Zeile auf Plausibilität zu prüfen, oder `Inventory available > reserved`, um Zeilen mit Kapazität zu finden:
+
+```rust
+use rustango::core::Column as _;
+
+// `start_date < end_date` for every selected row.
+let valid = Reservation::objects()
+    .where_(Reservation::start_date.lt_expr(F("end_date")))
+    .fetch(&pool).await?;
+
+// Combine with literal predicates.
+let oversold = Inventory::objects()
+    .where_(Inventory::available.lt_expr(F("reserved")))
+    .where_(Inventory::active.eq(true))
+    .fetch(&pool).await?;
+```
+
+Die `*_expr`-Familie — `eq_expr`, `ne_expr`, `lt_expr`, `lte_expr`, `gt_expr`, `gte_expr` — spiegelt die literalen `eq`, `ne`, …-Methoden, nimmt aber auf der rechten Seite jedes `impl Into<Expr>`: nackte Spaltenreferenzen (`F("col")`), Arithmetik (`F("price") * 2`) oder Funktionsergebnisse (nächster Abschnitt).
+
+### Skalare Funktionen — Text, Mathematik, NULL-Behandlung
+
+`rustango::core::funcs` liefert Builder für die meistgenutzten SQL-Funktionen. Die 17 bisher verfügbaren:
+
+| Gruppe | Builder |
+|---|---|
+| **Text** | `lower`, `upper`, `length`, `trim`, `ltrim`, `rtrim`, `concat`, `substr`, `replace` |
+| **Mathematik** | `abs`, `ceil`, `floor`, `round` (1-arg) / `round_to` (2-arg-Präzision) |
+| **NULL** | `coalesce`, `greatest`, `least`, `nullif` |
+
+```rust
+use rustango::core::funcs::{lower, upper, concat, coalesce, trim, abs, round};
+use rustango::core::F;
+
+// Normalize on write.
+User::objects()
+    .eq("id", id)
+    .update()
+    .set_expr("email", lower(trim(F("email"))))
+    .execute(&pool).await?;
+
+// Build a derived column from two FKs + a literal.
+User::objects()
+    .update()
+    .set_expr(
+        "display_name",
+        concat([F("first").into(), " ".into(), F("last").into()]),
+    )
+    .execute(&pool).await?;
+
+// First non-NULL fallback.
+User::objects()
+    .update()
+    .set_expr(
+        "label",
+        coalesce([F("nickname").into(), F("username").into(), "anonymous".into()]),
+    )
+    .execute(&pool).await?;
+
+// Function on the WHERE rhs.
+User::objects()
+    .where_(User::email_norm.eq_expr(lower(F("email_norm"))))
+    .fetch(&pool).await?;
+
+// Functions compose freely — `abs(round(F("score") * 100))` is one Expr.
+Player::objects()
+    .update()
+    .set_expr("score_int", abs(round(F("score") * 100_f64)))
+    .execute(&pool).await?;
+```
+
+### Tri-dialektisches Verhalten
+
+Die meisten Funktionen emittieren über PG / MySQL / SQLite identisches SQL. Die divergierenden Formen werden pro Dialekt transparent behandelt:
+
+| Builder | PG | MySQL | SQLite |
+|---|---|---|---|
+| `concat([a, b])` | `CONCAT(a, b)` | `CONCAT(a, b)` | `(a \|\| b)` |
+| `substr(s, 1, 3)` | `SUBSTRING(s FROM 1 FOR 3)` | `SUBSTRING(s, 1, 3)` | `SUBSTR(s, 1, 3)` |
+| `greatest([a, b])` | `GREATEST(a, b)` | `GREATEST(a, b)` | `MAX(a, b)` skalar |
+| `least([a, b])` | `LEAST(a, b)` | `LEAST(a, b)` | `MIN(a, b)` skalar |
+
+### Gemischte Argumente an eine Funktion übergeben
+
+Funktionen, die eine Liste von Argumenten nehmen (wie `concat`), akzeptieren jedes iterierbare von `Expr`. Rust-Arrays müssen einen Typ enthalten, sodass ein Mix aus `F` (Spalte) und `&str` (Literal) allein nicht typprüfen wird — rufe `.into()` einmal pro Element auf, um jedes in ein `Expr` zu heben:
+
+```rust
+concat([F("first").into(), " ".into(), F("last").into()])
+//          ^^^^^^ each element lifted to Expr
+```
+
+Oder baue ein `Vec<Expr>` und übergib es direkt — gleiche Form, gleiches Ergebnis.
+
+### Vorbehalte
+
+- **`length` Byte-vs-Zeichen**: PG gibt Zeichen bei `TEXT`/`VARCHAR` zurück, MySQL gibt **Bytes** zurück (verwende den zukünftigen `CharLength`-Builder des Frameworks oder umschließe manuell mit `CHAR_LENGTH`, wenn du dialektübergreifende Zeichenzählungen brauchst).
+- **`round(x, n)` auf PG**: PGs 2-arg-Form erfordert `numeric`, nicht `double`. Übergib entweder eine Integer-Spalte oder caste den Float zuerst; MySQL und SQLite akzeptieren beide Typen.
+- **`greatest([single_arg])` / `least([single_arg])` auf SQLite**: nicht unterstützt — SQLites `MAX(x)` mit einem Argument ist die *Aggregat*-, nicht die skalare Form. Der Writer gibt `OpNotSupportedInDialect` zurück. PG und MySQL akzeptieren die Ein-Argument-Form als No-op, die `x` zurückgibt. Umschließe mit mindestens einem Literal, um portabel zu bleiben.
+- **`substr` mit negativem Start**: PG behandelt negativ als "starte ab Zeichenposition N" (klemmt effektiv auf 0); MySQL und SQLite behandeln negativ als "zähle vom Ende". Vermeide negative Starts in portablem Code.
+
+### Datums- & Zeitfunktionen
+
+Die `now()`-, `extract_*`- und `trunc_*`-Builder arbeiten auf Daten und Zeitstempeln. Verwende sie für Kohortenabfragen, Zeitbucket-Aggregate und das Stempeln der aktuellen Zeit beim Schreiben — alles in der Datenbank, ohne Zeilen durch die App zu roundtrippen.
+
+```rust
+use rustango::core::funcs::{
+    now, trunc_date, trunc_month,
+    extract_year, extract_month, extract_weekday,
+};
+use rustango::core::F;
+
+// 1. Stamp server-side current time on write.
+Post::objects()
+    .eq("id", id)
+    .update()
+    .set_expr("published_at", now())
+    .execute(&pool).await?;
+
+// 2. Extract year / month / weekday into denormalized indexable
+// columns so cohort + day-of-week queries are cheap.
+Signup::objects()
+    .update()
+    .set_expr("bucket_year", extract_year(F("created_at")))
+    .set_expr("bucket_month", extract_month(F("created_at")))
+    .set_expr("weekday", extract_weekday(F("created_at")))
+    .execute(&pool).await?;
+
+// 3. Filter on the stored bucket — typed integer comparison, uses
+// the index, portable across all three dialects.
+let friday_signups = Signup::objects()
+    .where_(Signup::weekday.eq(5_i64))            // 5 = Friday (0=Sun)
+    .fetch(&pool).await?;
+
+// 4. For range filters where you'd be tempted to write
+// `created_at >= trunc_year(now())` directly: don't. The function
+// builders for `Trunc*` return text on MySQL/SQLite (see caveats
+// below), so a column-vs-trunc comparison in WHERE only behaves
+// well on PG. Compute the boundary in Rust instead and pass it as a
+// typed literal — works the same on every backend and uses the
+// index on `created_at`:
+use chrono::{Datelike, TimeZone};
+let this_year = chrono::Utc::now().year();
+let year_start = chrono::Utc.with_ymd_and_hms(this_year, 1, 1, 0, 0, 0).unwrap();
+
+let recent = Order::objects()
+    .where_(Order::created_at.gte(year_start))
+    .fetch(&pool).await?;
+
+// 5. `Trunc*` shines on the *write* side. `trunc_date` is the
+// one trunc-family builder with identical SQL on every dialect
+// (`DATE(x)`) — handy for grouping by day without the type-divergence
+// caveat the year/month variants carry.
+Order::objects()
+    .update()
+    .set_expr("day_bucket", trunc_date(F("created_at")))     // DATE column on every backend
+    .set_expr("month_bucket", trunc_month(F("created_at")))  // see caveat
+    .execute(&pool).await?;
+// `month_bucket` should be `TIMESTAMPTZ` on PG and `VARCHAR(10)` /
+// `TEXT` on MySQL/SQLite — parse client-side when reading if you
+// need a typed `chrono::NaiveDate`.
+```
+
+**Emission pro Dialekt:**
+
+| Builder | PG | MySQL | SQLite |
+|---|---|---|---|
+| `now()` | `NOW()` | `NOW()` | `CURRENT_TIMESTAMP` |
+| `extract_year(x)` | `CAST(EXTRACT(YEAR FROM x) AS INTEGER)` | `YEAR(x)` | `CAST(strftime('%Y', x) AS INTEGER)` |
+| `extract_week(x)` ⚠ | `EXTRACT(WEEK FROM x)` — ISO 8601, Bereich 1–53 | `WEEK(x)` — sonntagsbeginnend, Bereich **0**–53 | `strftime('%W', x)` — montagsbeginnend, Bereich 00–53 |
+| `extract_weekday(x)` | `CAST(EXTRACT(DOW FROM x) AS INTEGER)` | `(DAYOFWEEK(x) - 1)` | `CAST(strftime('%w', x) AS INTEGER)` |
+| `extract_quarter(x)` | `EXTRACT(QUARTER FROM x)` | `QUARTER(x)` | **nicht unterstützt** — Fehler |
+| `trunc_date(x)` | `DATE(x)` | `DATE(x)` | `DATE(x)` |
+| `trunc_year(x)` | `DATE_TRUNC('year', x)` → Zeitstempel | `DATE_FORMAT(x, '%Y-01-01')` → **String** | `strftime('%Y-01-01', x)` → **String** |
+| `trunc_month(x)` | `DATE_TRUNC('month', x)` → Zeitstempel | `DATE_FORMAT(x, '%Y-%m-01')` → **String** | `strftime('%Y-%m-01', x)` → **String** |
+| `trunc_day(x)` | `DATE_TRUNC('day', x)` → Zeitstempel | `DATE(x)` → Datum | `date(x)` → Text |
+
+**Vorbehalte speziell für Datum/Zeit:**
+
+- **`trunc_year/month`-Rückgabetyp divergiert**: Zeitstempel auf PG, Text auf MySQL/SQLite. Caste auf App-Seite beim Lesen, wenn du ein typisiertes `chrono::NaiveDate` brauchst — oder speichere den Bucket als schlichten Integer (`extract_year` + `extract_month`) und rekonstruiere im Code.
+- **`extract_weekday` ist auf 0 = Sonntag normalisiert** über alle drei Dialekte. MySQLs natives `DAYOFWEEK()` gibt 1=Sonntag zurück, also subtrahiert der Writer 1.
+- **⚠ `extract_week` ist NICHT portabel.** PG gibt ISO-8601-Wochennummern zurück (montagsbeginnend, Bereich 1–53); MySQLs Standard-`WEEK(x)` ist sonntagsbeginnend mit Bereich **0**–53; SQLites `strftime('%W')` ist montagsbeginnend mit Bereich 00–53. Für 2024-01-01 (ein Montag) geben die drei Backends jeweils `1`, `0` und `01` zurück. Single-Backend-Code kann es frei verwenden; dialektübergreifender Code sollte die Wochengrenze als typisiertes `chrono::DateTime` in Rust berechnen und stattdessen auf der Zeitstempel-Spalte filtern.
+- **`extract_quarter` auf SQLite wirft einen Fehler** mit `OpNotSupportedInDialect` — SQLite hat kein natives Quartals-Token. Gate das Feature entweder hinter `cfg(not(sqlite))` oder berechne per `((extract_month - 1) / 3) + 1` im App-Code.
+- **Zeitzonen-Behandlung**: PG `EXTRACT` operiert in der Zeitzone der Spalte; MySQL `YEAR()` operiert in der Sitzungs-Zeitzone (`SET time_zone = ...`); SQLite hat keine echte TZ-Unterstützung — behandle alles als UTC. Verwende `TIMESTAMPTZ` auf PG, `DATETIME` auf MySQL mit gesetzter Sitzungs-TZ, ISO-8601-Strings auf SQLite.
+
+### CASE-WHEN-Ausdrücke
+
+Baue ein SQL `CASE WHEN … THEN … ELSE … END` mit den `case()` / `.when()` / `value()`-Buildern — Djangos `Case`/`When`. Verwende es für benutzerdefinierte Sortierungen, abgeleitete Spalten in `annotate`, berechnete Defaults in `update` und (gepaart mit `Sum`) bedingte Aggregate.
+
+```rust
+use rustango::core::case::{case, value};
+use rustango::core::{Column as _, F};
+use rustango::core::funcs::lower;
+
+// Custom ordering — published posts first, drafts last.
+Post::objects()
+    .update()
+    .set_expr(
+        "priority",
+        case()
+            .when(Post::status.eq("published"), 0_i64)
+            .when(Post::status.eq("review"), 1_i64)
+            .when(Post::status.eq("draft"), 2_i64)
+            .default(99_i64),
+    )
+    .execute(&pool).await?;
+
+let ordered = Post::objects()
+    .order_by(&[("priority", false), ("id", false)])
+    .fetch(&pool).await?;
+
+// Computed default on update — drafts get a lowercased title for
+// the label, everything else uses the title verbatim.
+Post::objects()
+    .update()
+    .set_expr(
+        "label",
+        case()
+            .when(Post::status.eq("draft"), lower(F("title")))
+            .default(F("title")),
+    )
+    .execute(&pool).await?;
+
+// AND / OR composition in the WHEN predicate.
+let viral = Post::status.eq("published").and(Post::views.gt(1_000_i64));
+Post::objects()
+    .update()
+    .set_expr(
+        "label",
+        case()
+            .when(viral, value("viral"))
+            .when(Post::status.eq("published"), value("live"))
+            .default(value("pending")),
+    )
+    .execute(&pool).await?;
+```
+
+**Builder-Form:**
+
+- `case()` — startet einen Builder.
+- `.when(condition, then)` — hängt einen Zweig an. `condition` ist alles `Into<WhereExpr>` (typischerweise `Column::eq()`, `.and()`, `.or()`); `then` ist alles `Into<Expr>` (Literal, `F()`, Funktionsaufruf, verschachteltes `case()`).
+- `.default(expr)` — setzt den optionalen `ELSE`-Zweig. Ihn wegzulassen erzeugt ein `CASE`, das `NULL` für nicht passende Zeilen zurückgibt (SQL-Standard).
+- `.build()` oder `.into()` — finalisiert zu einem `Expr` für `set_expr` / `eq_expr` / `annotate`.
+- `value(literal)` — Zucker im Django-Stil für `Expr::Literal(...)`. Optional — nackte Literale werden per `Into<Expr>` gecoerct, aber `value("…")` liest sich explizit als "das ist ein String-Literal, keine Spaltenreferenz".
+
+**Tri-dialektische Emission:**
+
+`CASE WHEN … THEN … [ELSE …] END` ist SQL-92-Standard — über PG, MySQL und SQLite identisch emittiert. Kein Dialekt-Dispatch im Writer.
+
+**Vorbehalte:**
+
+- **Leere Zweige**: `case().build()` ohne `.when(...)`-Aufrufe wird zur Emit-Zeit mit `SqlError::EmptyCaseBranches` abgelehnt. SQL erfordert mindestens eine `WHEN`-Klausel. Eine leere `WHEN`-Bedingung (z. B. `WhereExpr::And(vec![])`) wird aus demselben Grund mit `SqlError::EmptyCaseWhenCondition` abgelehnt.
+- **Typvereinheitlichung über Zweige**: jeder Dialekt wählt einen gemeinsamen Typ aus den `THEN`- und `ELSE`-Werten. Das Mischen von Typen (`THEN 1_i64` + `ELSE "string"`) kann einen Laufzeit-Cast-Fehler werfen oder überraschend coercen. Halte dich an einen Typ pro `CASE`.
+- **Performance**: jede Zeile wertet `WHEN`-Prädikate der Reihe nach aus, bis eines passt (First-Match-Wins, pro Zeile). Die Kosten wachsen mit der Anzahl der Zweige und den Kosten der Prädikate. Für viele feste String-Mappings kann ein Join gegen eine kleine Lookup-Tabelle günstiger und lesbarer sein.
+
+### Unterabfragen (EXISTS, IN, skalar)
+
+Bette eine Abfrage in eine andere ein — Djangos `Exists`, `Subquery` und `OuterRef`. Diese Builder decken die meisten "existiert eine verwandte Zeile?"- und "ist dieser Wert in dieser Menge?"-Muster ab:
+
+| Builder | Form | Verwende es für |
+|---|---|---|
+| `exists(qs)` | `EXISTS (SELECT … FROM …)` | "Autoren, die mindestens ein Buch haben" |
+| `not_exists(qs)` | `NOT EXISTS (SELECT …)` | "Autoren ohne Bücher" (Anti-Join) |
+| `in_subquery(col, qs)` | `<col> IN (SELECT …)` | "Posts in irgendeiner öffentlichen Kategorie" |
+| `not_in_subquery(col, qs)` | `<col> NOT IN (SELECT …)` | Umkehrung des obigen |
+| `subquery(qs)` | `(SELECT …)` als Skalar | Berechneter Default in `set_expr` |
+| `outer_ref(col)` | `"<outer_table>"."<col>"` | Verweise auf die äußere Zeile von innerhalb jedes der obigen |
+
+```rust
+use rustango::core::subquery::{exists, not_exists, in_subquery, outer_ref};
+use rustango::core::{Column as _, WhereExpr};
+
+// "Authors with no books" — the canonical anti-join. Build the inner
+// queryset first so its compile() catches typos; embed via not_exists.
+let no_books = Book::objects()
+    .where_(Book::author_id.eq_expr(outer_ref("id")))
+    .compile()?;
+let orphans = Author::objects()
+    .where_raw(not_exists(no_books))
+    .fetch(&pool).await?;
+
+// "Authors who have a published book of more than 100 pages" — the
+// inner predicate combines a correlation (outer_ref) with literal
+// filters in the same WHERE.
+let inner = Book::objects()
+    .where_(Book::author_id.eq_expr(outer_ref("id")))
+    .where_(Book::status.eq("published"))
+    .where_(Book::pages.gt(100_i64))
+    .compile()?;
+let long_writers = Author::objects()
+    .where_raw(exists(inner))
+    .fetch(&pool).await?;
+
+// Compose EXISTS with an OR.
+let inner = Book::objects()
+    .where_(Book::author_id.eq_expr(outer_ref("id")))
+    .compile()?;
+let featured = Author::objects()
+    .where_raw(WhereExpr::Or(vec![
+        Author::name.eq("Carol").into(),
+        exists(inner),
+    ]))
+    .fetch(&pool).await?;
+```
+
+**Verschachtelte Korrelation funktioniert.** Ein OuterRef innerhalb einer doppelt verschachtelten Unterabfrage löst zum *unmittelbar* umschließenden Scope auf — der Writer pflegt beim Absteigen einen Scope-Stack, sodass `EXISTS (Book WHERE id = outer.id AND EXISTS (Comment WHERE book_id = outer.id))` das innere `outer.id` zu `Book.id` auflöst, nicht zum äußersten `Author.id`. Verwende `outer_ref(...)` zweimal, wenn du wirklich zwei Scopes nach oben reichen musst.
+
+**Fehler:**
+
+- **`OuterRefOutsideSubquery`** — `outer_ref("col")` auf oberster Ebene zu emittieren (nicht innerhalb eines Unterabfrage-Wrappers) ist ein Programmierfehler. Der Writer wirft das laut mit dem Spaltennamen, sodass die Aufrufstelle leicht zu finden ist.
+
+**Vorbehalte:**
+
+- **`IN (SELECT …)`-Projektionsverengung**: PG erfordert strikt, dass der innere SELECT genau eine Spalte für die `<col> IN (…)`-Form projiziert. **Rustango** liefert noch keine `.values("col")`-artige Projektionsverengung (Issue #62), sodass das innere Queryset immer jede Model-Spalte projiziert — was `in_subquery` heute nur gegen Tabellen funktionieren lässt, deren Model eine einzige Spalte hat. Für den Mehr-Spalten-Fall greif zu `exists(inner.where_(<outer col>.eq_expr(outer_ref(...))))` — es hat dieselbe Semantik und hängt nicht von der Projektionsform ab.
+- **Skalares `subquery(...)` erfordert ein Ein-Spalte-eine-Zeile-Inneres**: das emittierte SQL ist `SET col = (SELECT …)` — produziert das Innere mehr als eine Zeile, wirft die Datenbank zur Laufzeit einen Fehler. Beschränke per `.limit(1)` und entweder verenge die Projektion (sobald sie landet) oder gestalte das Innere um eine Eindeutigkeits-Invariante.
+- **Kompilierzeit-Validierung der Unterabfrage lebt auf dem inneren Queryset**: Spalten-Tippfehler tauchen beim inneren `queryset.compile()?`-Aufruf auf, nicht beim `compile()` der äußeren Abfrage. Baue das Innere zuerst und propagiere `?`.
+
+### Wann man stattdessen auf rohes SQL zurückfällt
+
+Die obigen Builder decken die häufigen Fälle ab. Für Dinge, die sie noch nicht ausdrücken — `Cast`, Volltextsuche, JSON-Pfad-Operatoren, Hash-Funktionen, Trigonometrie, Fensterfunktionen — siehe den Abschnitt [Raw-SQL-Notausstieg](#raw-sql-escape-hatch) weiter unten, oder warte auf die Nachfolge-Issues, die denselben Ausdrucksbaum erweitern.
+
+---
+
+## Aggregationen
+
+Zeilen zählen, summieren, mitteln und gruppieren. `.count()`, `.sum()`, `.avg()`, `.min()` und `.max()` geben eine einzelne Zahl zurück; `.annotate(...)` plus `.values(...)` baut GROUP-BY-Abfragen (Djangos `aggregate` / `annotate`). Aggregatergebnisse kommen als `Vec<HashMap<String, SqlValue>>` zurück statt als typisierte Structs, da die Form dynamisch ist.
+
+```rust
+use rustango::sql::CounterPool as _;
+
+// COUNT
+let n = Post::objects()
+    .where_(Post::status.eq("published"))
+    .count(&pool).await?;
+
+// SUM / AVG / MIN / MAX — string column name; each returns Option<U>
+// (None when the filtered result set is empty).
+let total_views = Post::objects().sum::<i64>("view_count", &pool).await?;
+let avg_views = Post::objects().avg::<f64>("view_count", &pool).await?;
+let max_views = Post::objects().max::<i64>("view_count", &pool).await?;
+
+// Annotate + GROUP BY (issue #75 — Django-shape auto-inference)
+use rustango::core::aggregates::{count_all, sum};
+
+// "Posts per author" — `.values()` lists the GROUP BY columns.
+let by_author = Sale::objects()
+    .values(&["author_id"])
+    .annotate("n", count_all().into())
+    .compile()?;
+let rows = rustango::sql::fetch_aggregate_dict(&pool, &by_author).await?;
+// rows: Vec<HashMap<String, SqlValue>> — { author_id: 1, n: 3 }, …
+```
+
+### Wie GROUP BY inferiert wird
+
+Du schreibst `GROUP BY` selten selbst — **Rustango** inferiert es aus der Form der Abfrage, genau wie Django. Du rufst `.group_by(...)` nur auf, um diese Inferenz zu überschreiben. Die Tabelle zeigt, was jede Form erzeugt:
+
+| Form | Builder | Resultierendes `GROUP BY` |
+|---|---|---|
+| **2 — values + Aggregat** | `.values(&["author_id"]).annotate("n", count_all().into())` | `GROUP BY "author_id"` |
+| **3 — nacktes Aggregat** | `.annotate("n", count_all().into())` | `GROUP BY` jede nicht-aggregierende Skalarspalte des Models |
+| **Nur Fenster** | `.aggregate().annotate("rn", row_number()…)` | (kein `GROUP BY` — Fensterfunktionen sind pro Zeile) |
+| **Explizite Überschreibung** | `.aggregate().group_by("month").annotate(...)` | `GROUP BY "month"` — explizit gewinnt |
+
+Der Klassifizierer `AggregateExpr::is_aggregating()` unterscheidet die zeilen-kollabierenden Varianten (`Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` / `StdDev*` / `Variance*` — plus rekursive `Filtered` / `Coalesced`-Wrapper) von `Window`, das pro Zeile ist. Nur die aggregierenden Varianten lösen die Form-3-Inferenz aus.
+
+```rust
+use rustango::core::aggregates::{count_all, sum};
+
+// Shape 2 — "monthly revenue per author".
+Sale::objects()
+    .where_(Sale::status.eq("paid"))
+    .values(&["author_id", "month"])
+    .annotate("total", sum("amount").into())
+    .compile()?;
+// → SELECT "author_id", "month", SUM("amount")::bigint AS "total"
+//   FROM "sale" WHERE "status" = $1
+//   GROUP BY "author_id", "month"
+
+// Shape 3 — a bare .annotate() with no .values(): rustango adds every
+// non-aggregate scalar column of the model to the GROUP BY.
+Post::objects()
+    .annotate("n", count_all().into())
+    .compile()?;
+// → SELECT <every Post column>, COUNT(*) AS "n"
+//   FROM "post" GROUP BY <every Post column>
+```
+
+**Vorbehalt zur reinen Projektion.** `.values(cols)` *allein* (keine Aggregat-Annotation) wird in v0.40 **nicht** unterstützt — `compile()` gibt `QueryError::ValuesRequiresAggregate` zurück. Reine Projektion-als-Dicts braucht einen separaten Writer-Pfad (es ist ein SELECT ohne GROUP BY, dekodiert in `Vec<HashMap>`) und ist für eine Nachfolge vorgemerkt. Verwende vorerst das typisierte `QuerySet::fetch(...)`, um ganze Zeilen zu lesen.
+
+### Bedingte & statistische Aggregate
+
+Zähle oder summiere nur die Zeilen, die eine Bedingung erfüllen, liefere einen Fallback für leere Ergebnisse und berechne Standardabweichung / Varianz. Diese spiegeln Djangos `Count('id', filter=...)`, `Sum('price', default=0)` und `StdDev`. Verkette `.filter(...)` und `.default(...)` an jeden Aggregat-Builder.
+
+```rust
+use rustango::core::aggregates::{avg, count, count_all, stddev, sum};
+use rustango::core::Column as _;
+
+let rows = Post::objects()
+    .aggregate()
+    // COUNT(*) FILTER (WHERE is_active AND status = 'published')
+    .annotate(
+        "active_published",
+        count_all()
+            .filter(Post::is_active.eq(true).and(Post::status.eq("published")))
+            .into(),
+    )
+    // COALESCE(SUM(price) FILTER (WHERE status = 'published'), 0)
+    //   — returns 0 instead of NULL when the queryset is empty.
+    .annotate(
+        "revenue_or_zero",
+        sum("price")
+            .filter(Post::status.eq("published"))
+            .default(0_i64)
+            .into(),
+    )
+    .annotate("avg_pages", avg("pages").into())
+    .annotate("page_stddev", stddev("pages").into())
+    .compile()?;
+let result = rustango::sql::fetch_aggregate_dict(&pool, &rows).await?;
+```
+
+**Builder** in `rustango::core::aggregates`:
+
+| Builder | SQL |
+|---|---|
+| `count(col)` | `COUNT(col)` |
+| `count_all()` | `COUNT(*)` |
+| `count_distinct(col)` | `COUNT(DISTINCT col)` |
+| `sum(col)` / `avg(col)` / `max(col)` / `min(col)` | das Übliche |
+| `stddev(col)` / `stddev_pop(col)` | `STDDEV_SAMP` / `STDDEV_POP` |
+| `variance(col)` / `variance_pop(col)` | `VAR_SAMP` / `VAR_POP` |
+
+Jedes gibt einen `AggregateBuilder` mit zwei verkettbaren Modifikatoren zurück:
+
+- `.filter(predicate)` — umschließe mit `FILTER (WHERE predicate)`. Das Prädikat ist jedes `WhereExpr` (typisiertes `.eq()` / `.and()` / rohes `WhereExpr::Or(...)`), sodass es sich genauso komponiert wie ein normales WHERE.
+- `.default(value)` — umschließe mit `COALESCE(..., value)`, sodass ein leeres Queryset den Default statt `NULL` zurückgibt.
+
+Beide Ketten als `Coalesced` außerhalb `Filtered` aufzurufen: `COALESCE(SUM(col) FILTER (WHERE p), 0)`. Die Kettenreihenfolge spielt keine Rolle — `.filter(p).default(0)` und `.default(0).filter(p)` erzeugen dieselbe IR.
+
+**Tri-dialektische Emission:**
+
+| Feature | PG | MySQL | SQLite |
+|---|---|---|---|
+| `Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` | ✓ | ✓ | ✓ |
+| `StdDev` / `StdDevPop` / `Variance` / `VariancePop` | ✓ | ✓ (8.0+) | ✗ `SqlError::AggregateNotSupported` |
+| `.filter(...)` — natives `FILTER (WHERE …)` | ✓ | ✗ umgeschrieben | ✓ (3.30+) |
+| `.filter(...)` — `CASE WHEN`-Fallback | — | ✓ `<agg>(CASE WHEN … THEN <arg> END)` | — |
+| `.default(...)` — `COALESCE` | ✓ | ✓ | ✓ |
+
+Der Writer wendet den Int/Float-Cast des Dialekts (`::bigint`, `CAST(... AS SIGNED)` etc.) um den gesamten `FILTER`-Ausdruck an — `SUM(col)::bigint FILTER (...)` ist ein PG-Parse-Fehler, sodass die emittierte Form `(SUM(col) FILTER (...))::bigint` ist. Gleiche Form für `STDDEV_SAMP` / `VAR_SAMP` (sie geben NUMERIC auf PG für bigint-Input zurück).
+
+**SQLite + StdDev/Variance:** SQLite hat keine eingebauten statistischen Aggregate, sodass der Writer mit `SqlError::AggregateNotSupported { aggregate, dialect: "sqlite" }` ablehnt. Berechne die Varianzformel im App-Code, wenn portable Statistik benötigt wird (dieselbe Haltung, die Django einnimmt).
+
+### Fensterfunktionen
+
+Berechne laufende Summen, Rankings und Zeile-über-Zeile-Deltas, ohne Zeilen zu kollabieren — Djangos `Window(expression, partition_by=, order_by=, frame=)`. Acht Funktionen (`row_number`, `rank`, `dense_rank`, `lag`, `lead`, `first_value`, `last_value`, `ntile`) plus ROWS/RANGE-Frames. Jedes Backend, das **Rustango** unterstützt (PG ≥ 9.0, MySQL ≥ 8.0, SQLite ≥ 3.25), liefert native `OVER (…)`-Syntax, sodass die Emission uniform ist.
+
+```rust
+use rustango::core::aggregates::max;
+use rustango::core::window::{lag, rank, row_number};
+
+// "Rank users by score within each tenant" — the canonical
+// integration target.
+let q = User::objects()
+    .aggregate()
+    .group_by("id")
+    .group_by("tenant_id")
+    .group_by("name")
+    .group_by("score")
+    .annotate("_a", max("id").into())  // satisfies GROUP BY on the projection
+    .annotate(
+        "tenant_rank",
+        rank().partition_by("tenant_id").order_by(&[("score", true)]).into(),
+    )
+    .order_by(&[("tenant_id", false), ("score", true)])
+    .compile()?;
+let rows = rustango::sql::fetch_aggregate_dict(&pool, &q).await?;
+
+// Day-over-day delta via LAG with a default for the first row.
+let q = Event::objects()
+    .aggregate()
+    .group_by("id")
+    .group_by("day")
+    .group_by("count")
+    .annotate("_a", max("id").into())
+    .annotate(
+        "prev_count",
+        lag("count", 1, Some(SqlValue::I64(0)))
+            .partition_by("user_id")
+            .order_by(&[("day", false)])
+            .into(),
+    )
+    .compile()?;
+
+// Stable row index per group for "show me row N" pagination.
+let q = Post::objects()
+    .aggregate()
+    .group_by("id")
+    .group_by("status")
+    .group_by("created_at")
+    .annotate("_a", max("id").into())
+    .annotate(
+        "rn",
+        row_number()
+            .partition_by("status")
+            .order_by(&[("created_at", true)])
+            .into(),
+    )
+    .compile()?;
+```
+
+**Builder** in `rustango::core::window`:
+
+| Builder | SQL | Argumente |
+|---|---|---|
+| `row_number()` | `ROW_NUMBER()` | — |
+| `rank()` | `RANK()` | — |
+| `dense_rank()` | `DENSE_RANK()` | — |
+| `ntile(buckets)` | `NTILE(buckets)` | Bucket-Anzahl |
+| `lag(col, offset, default)` | `LAG(col, offset, default?)` | Spalte + Offset + optionaler Default |
+| `lead(col, offset, default)` | `LEAD(col, offset, default?)` | Spalte + Offset + optionaler Default |
+| `first_value(col)` | `FIRST_VALUE(col)` | Spalte |
+| `last_value(col)` | `LAST_VALUE(col)` | Spalte |
+
+Jedes gibt einen `WindowBuilder` mit drei verkettbaren Modifikatoren zurück:
+
+- `.partition_by("col")` — hängt eine `PARTITION BY`-Spalte an. Rufe es mehrmals auf für Mehr-Spalten-Partitionierung.
+- `.order_by(&[("col", desc)])` — hängt `ORDER BY`-Spalten an (`desc = true` → DESC).
+- `.frame(WindowFrame { kind, start, end })` — setzt die optionale `ROWS`/`RANGE`-Frame-Klausel. `FrameBoundary::UnboundedPreceding` / `Preceding(n)` / `CurrentRow` / `Following(n)` / `UnboundedFollowing`.
+
+Der Builder senkt per `Into<AggregateExpr>` ab, sodass Fensterfunktionen mit `annotate()` komponieren. `Into<Expr>` ist ebenfalls implementiert (der IR-Level-Slot für Fensterausdrücke), aber **jedes Backend, das **Rustango** unterstützt, beschränkt Fensterfunktionen auf die `SELECT`-Liste und die `ORDER BY`-Klausel einer Abfrage** — sie können nicht in `WHERE` / `HAVING` / `GROUP BY` / `UPDATE SET` / `JOIN ON` / `RETURNING` erscheinen. Der Writer gatet die Emission nicht darauf, sodass `set_expr("col", row_number())` zu SQL kompiliert, das die Datenbank bei der Ausführung ablehnt. Baue Fensterausdrücke über `annotate()`; greif zu einer Unterabfrage, wenn du ein Fensterergebnis in einen WHERE-Filter oder ein UPDATE einspeisen musst.
+
+**`LAST_VALUE`-Default-Frame-Falle:**
+
+Ein nacktes `last_value(col).order_by(&[("x", false)])` emittiert `LAST_VALUE("col") OVER (ORDER BY "x")` und sieht aus, als sollte es das letzte `col` der Partition zurückgeben. Tut es nicht — SQLs *Default*-Fensterframe ist `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`, sodass `LAST_VALUE` den Wert der **aktuellen Zeile** zurückgibt, nicht der letzten Zeile der Partition. Um das intuitive "letzte Zeile der Partition"-Verhalten zu erhalten, übergib einen expliziten unbegrenzten Frame:
+
+```rust
+use rustango::core::{FrameBoundary, FrameKind, WindowFrame};
+
+last_value("score")
+    .partition_by("tenant_id")
+    .order_by(&[("created_at", true)])
+    .frame(WindowFrame {
+        kind: FrameKind::Rows,
+        start: FrameBoundary::UnboundedPreceding,
+        end: Some(FrameBoundary::UnboundedFollowing),
+    })
+```
+
+`first_value` hat diese Falle nicht — der Start des Default-Frames stimmt mit dem Partitionsstart überein, sodass die intuitive Antwort herausfällt.
+
+**Annotate-Vorbehalt (bis Issue #75 landet):**
+
+`annotate()` lebt auf dem Aggregat-Builder, der `GROUP BY` erfordert, um pro-Zeile-Skalarspalten neben Aggregaten zu projizieren. Um Fensterfunktions-Ergebnisse heute neben Zeilenspalten zu projizieren, liste jede Zeilenspalte, die du zurückgeben willst, in `.group_by(...)`-Aufrufen auf und `annotate("_a", max("id").into())` als No-op-Platzhalter, um die Zeilenidentität stabil zu halten. Issue #75 (GROUP-BY-Auto-Inferenz) bringt eine sauberere Form.
+
+**Frame-Klauseln:**
+
+```rust
+use rustango::core::{FrameBoundary, FrameKind, WindowFrame};
+
+// Running total over the last 7 rows:
+let frame = WindowFrame {
+    kind: FrameKind::Rows,
+    start: FrameBoundary::Preceding(6),
+    end: Some(FrameBoundary::CurrentRow),
+};
+
+// Centered 11-row window:
+let frame = WindowFrame {
+    kind: FrameKind::Rows,
+    start: FrameBoundary::Preceding(5),
+    end: Some(FrameBoundary::Following(5)),
+};
+```
+
+**Tri-dialektische Emission:**
+
+`<fn>(args) OVER (PARTITION BY … ORDER BY … [frame])` ist SQL-Standard — identisch über PG, MySQL 8+ und SQLite 3.25+. Die eine Eigenart: `LAG` / `LEAD` / `NTILE` erfordern Integer-Offsets/-Buckets auf PG (das Binden als bigint-`$N`-Parameter verursacht `function lag(bigint, bigint, bigint) does not exist`). Der Writer inlint Integer-Literale für diese Slots direkt ins SQL; Default-Wert-Argumente werden normal gebunden.
+
+**Vorbehalte:**
+
+- **`FILTER` + `Window` noch nicht unterstützt**: das Kombinieren von `.filter(...)` mit einer Fensterfunktion wirft `SqlError::NestedAggregateWrapper { wrapper: "Filtered(Window)" }` — die zugrunde liegende Syntax variiert je nach Funktionsart (PG erlaubt `agg_fn() FILTER (WHERE …) OVER (…)` für Aggregat-Fensterfunktionen, aber nicht für Ranking-Funktionen), und dem Writer wurde der Dispatch noch nicht beigebracht. Für eine Nachfolge vorgemerkt, falls Nachfrage aufkommt.
+- **`PercentRank` / `CumeDist` / `NthValue`** sind nicht in v1 — Djangos vollständige Menge ist größer. v1 liefert die 8 meistgenutzten Varianten; die fehlenden drei können inkrementell mit derselben Builder-Form hinzugefügt werden.
+
+### Auf Aggregaten filtern (HAVING)
+
+Ein `.filter(...)`-Aufruf nach `.annotate(...)` landet entweder in `WHERE` oder `HAVING`, je nachdem, ob der Name einem Aggregat-Alias entspricht — genau Djangos Verhalten. So fügt das Filtern auf einer echten Spalte ein `WHERE` hinzu, während das Filtern auf einer Annotation wie `post_count` ein `HAVING` hinzufügt:
+
+```rust
+use rustango::core::aggregates::count_all;
+use rustango::core::Op;
+
+// "Authors with > 10 published posts" — the canonical pattern.
+// status='published' is on the model       → routes to WHERE.
+// post_count > 10 references the annotation → routes to HAVING.
+let q = Post::objects()
+    .aggregate()
+    .group_by("author_id")
+    .annotate("post_count", count_all().into())
+    .filter("status",     Op::Eq, "published")
+    .filter("post_count", Op::Gt, 10_i64)
+    .compile()?;
+let rows = rustango::sql::fetch_aggregate_dict(&pool, &q).await?;
+```
+
+Emittiert, auf PG:
+
+```sql
+SELECT "author_id", COUNT(*) AS "post_count"
+FROM "post"
+WHERE "status" = $1
+GROUP BY "author_id"
+HAVING COUNT(*) > $2
+```
+
+**Der Aggregatausdruck wird in HAVING gehoben, nicht der SELECT-Alias.** PG verbietet Aliase in HAVING strikt (nur der Ausdruck löst auf); MySQL + SQLite sind nachsichtiger. Der Writer emittiert die gehobene Form uniform über alle drei, sodass dieselbe Abfrage überall funktioniert.
+
+**Die Kettenreihenfolge ist in v1 wichtig.** Rufe `.annotate(alias, ...)` VOR dem entsprechenden `.filter(alias, ...)` auf. Ist die Reihenfolge umgekehrt, schlägt `filter()` eine leere Annotationsregistrierung nach und leitet auf `WHERE` — und der `resolve_pending`-Validator liefert `UnknownField` bei `compile()`, weil der Alias keine echte Model-Spalte ist. Django schiebt diese Auflösung auf die Query-Konstruktionszeit; eine v0.50-Nachfolge könnte dieser Haltung entsprechen.
+
+**Validator-Lücke (entspricht der bestehenden Aggregat-Haltung)**: alias-geroutete HAVING-Prädikate überspringen den Model-Schema-Spaltendurchlauf. Falsch geschriebene Aliase tauchen bei der Datenbank auf, nicht bei `compile()`. Gleiche Lücke wie `Sum("typo_col")` — vorbestehend und orthogonal.
+
+**Unterstützte Ops auf alias-geroutetem `.filter()`** (Issue #87): die Binärvergleichs-Menge (`Op::Eq` / `Ne` / `Lt` / `Lte` / `Gt` / `Gte`) **plus** die SQL-92-Standard-Prädikate, die gegen einen Aggregat-LHS uniform über jedes Backend komponieren — `Op::In` / `NotIn`, `Between`, `IsNull`, `Like` / `NotLike`, `ILike` / `NotILike`. Jedes emittiert die vorhersehbare Form:
+
+```rust
+use rustango::core::{Op, SqlValue};
+
+// HAVING COUNT(*) IN ($1, $2, $3)
+Post::objects()
+    .aggregate()
+    .group_by("author_id")
+    .annotate("post_count", count_all().into())
+    .filter("post_count", Op::In, SqlValue::List(vec![5_i64.into(), 10_i64.into(), 20_i64.into()]))
+    .compile()?;
+
+// HAVING COUNT(*) BETWEEN $1 AND $2
+.filter("post_count", Op::Between, SqlValue::List(vec![5_i64.into(), 10_i64.into()]))
+
+// HAVING COUNT(*) IS NULL  /  IS NOT NULL  (bool: true = IS NULL)
+.filter("post_count", Op::IsNull, SqlValue::Bool(false))
+
+// HAVING MAX("name") LIKE $1  /  ILIKE $1 (PG) / LOWER(MAX("name")) LIKE LOWER(?) (MySQL/SQLite)
+.filter("max_name", Op::ILike, "SMITH%")
+```
+
+Die verbleibenden Ops — die JSON-Op-Familie (`JsonContains` / `JsonContainedBy` / `JsonHasKey` / `JsonHasAnyKey` / `JsonHasAllKeys`) und die null-sichere Gleichheit (`IsDistinctFrom` / `IsNotDistinctFrom`) — brauchen weiterhin dialektspezifische Writer, die ein `&str` für den LHS nehmen, sodass sie bei `compile()` mit `QueryError::HavingOpNotSupported { alias, op }` ablehnen. Für die steig in die typisierte `.having(<TypedExpr>)`-Form mit einem vorgebauten Prädikat ein.
+
+**Param-Vektor-Aufblähung mit nicht-trivialen Aggregaten**: wenn der Alias eine `Filtered { Count, filter: pred }`- oder `Coalesced { Sum, default: 0 }`-Annotation anvisiert, hebt der Writer den **gesamten Aggregatausdruck** in HAVING — inklusive seiner inneren Prädikate und Defaults. Ihre gebundenen Literale bekommen frische Parameter-Slots in HAVING, getrennt von der SELECT-Listen-Emission. Konkret:
+
+```text
+SELECT … COUNT(*) FILTER (WHERE "status" = $1) AS "published_count" …
+HAVING COUNT(*) FILTER (WHERE "status" = $2) > $3
+              -- "published" bound twice (once at $1, once at $2)
+```
+
+Die SQL-Semantik ist unverändert (dieselben Zeilenzahlen kommen zurück), aber `stmt.params.len()` wächst pro `.filter()`-Aufruf, der einen nicht-trivialen Alias anvisiert. Für `COUNT(*)`-Aliase (keine inneren Literale) ist die Aufblähung null. Dokumentiere das, wenn deine Testsuite Parameterzählungen festnagelt.
+
+---
+
+## Joins & Vorladen verwandter Zeilen
+
+Zieh ein Foreign-Key-Ziel zusammen mit der Hauptzeile in einer einzigen Abfrage, sodass du nicht eine zusätzliche Abfrage pro Zeile abfeuerst (das N+1-Problem). `.select_related("author")` ist Djangos `select_related` / Eloquents Eager Loading. Ein `ForeignKey<T>`-Feld kommt dann bereits befüllt an, statt einen separaten Lookup zu brauchen.
+
+```rust
+let posts = Post::objects()
+    .select_related("author")              // JOIN posts.author -> authors.id
+    .fetch(&pool).await?;
+
+for post in &posts {
+    let author = post.author.value().unwrap();   // already loaded, no DB round-trip
+    println!("{} by {}", post.title, author.name);
+}
+```
+
+`select_related` löst FK-Felder zur Kompilierzeit des Querysets auf. Das `ForeignKey<T>`-Feld auf dem Elternteil geht von `Unloaded(pk)` zu `Loaded { pk, value }`.
+
+Für Reverse-FKs (parent.children) verwende die makro-generierte `_set`-Methode:
+
+```rust
+let author_posts = author.post_set(&pool).await?;
+```
+
+### Benutzerdefinierte Joins
+
+Wenn der Join nicht von einem Foreign Key getrieben wird — ein benutzerdefiniertes Prädikat, ein Non-Equi-Join, INNER statt LEFT, ein Self-Join oder ein Join auf einer Nicht-PK-Spalte — verwende `.join(Join { … })`. Sein `on`-Feld nimmt jedes `WhereExpr`, sodass `and()` / `or()` / `Not` / Funktionsaufrufe / Spalte-gegen-Spalte / Literalfilter alle frei komponieren.
+
+```rust
+use rustango::core::joins::aliased;
+use rustango::core::{Join, JoinKind, Op, WhereExpr};
+
+// "Posts that have at least one APPROVED comment" — INNER JOIN with
+// an extra predicate inside the ON. Posts with no approved comment
+// drop out; LEFT JOIN would keep them.
+Post::objects()
+    .join(Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Inner,
+        on: WhereExpr::And(vec![
+            // Column-on-column condition — both sides aliased.
+            WhereExpr::ExprCompare {
+                lhs: aliased("c", "post_id"),
+                op: Op::Eq,
+                rhs: aliased("post", "id"),
+            },
+            // Bare Filter — unqualified columns inside `on` resolve
+            // to the joined alias ("c"), so this becomes
+            // `"c"."is_approved" = $N`.
+            Comment::is_approved.eq(true).into(),
+        ]),
+        project: vec![],
+    })
+    .fetch(&pool).await?;
+```
+
+**Spaltenqualifizierungsregeln innerhalb `on`:**
+
+- **Nackte `Filter` / `ColumnFilter`-Spalten + `F()`-Spaltenreferenzen** lösen zum gejointen Alias auf (`<alias>`, den du übergeben hast). Das ist die natürliche Lesart, weil der Großteil eines ON-Prädikats über die gejointe Tabelle geht.
+- **`aliased(alias, col)`** emittiert `"<alias>"."<col>"` explizit — verwende das für Querverweise zurück auf die äußere Tabelle (`aliased("<outer_table>", "<col>")`) oder auf einen zuvor gejointen Alias.
+- **`WhereExpr::ExprCompare { lhs, op, rhs }`** ist die richtige Form für Spalte-gegen-Spalte-Vergleiche über Tabellen, da beide Seiten jedes `Expr` nehmen.
+
+> ⚠️ **GEFÄHRLICHES MUSTER — typisierte Filter vom ÄUSSEREN Model innerhalb `on`.**
+> `Post::status.eq("draft").into()` erzeugt ein `WhereExpr::Predicate(Filter { column: "status", ... })` und **verwirft das `Post`-Model-Tag** an der `Into<WhereExpr>`-Grenze. Die Auto-Qualifizierungsregel oben leitet diesen Filter dann fälschlich zum **gejointen Alias**, nicht zu `Post`. Du bekommst `"<joined_alias>"."status" = $N` — falsche Tabelle — und der Compiler kann es nicht fangen. **Verwende [`joins::col_filter`] für Prädikate gegen jede Spalte, deren Tabelle nicht der Default-Alias des Joins ist:**
+>
+> ```rust
+> use rustango::core::joins::{aliased, col_filter};
+> use rustango::core::Op;
+>
+> // SAFE: explicit alias on the LHS.
+> col_filter("post", "status", Op::Eq, "draft")
+> ```
+>
+> Reserviere nackte typisierte Filter (`Comment::is_approved.eq(true).into()`) nur für Spalten auf dem GEJOINTEN Model — niemals für Spalten des äußeren Models.
+
+**JoinKind-Tri-Dialekt-Unterstützung:**
+
+| Art | PG | MySQL | SQLite |
+|---|---|---|---|
+| `Inner` | ✓ | ✓ | ✓ |
+| `Left` (Standard) | ✓ | ✓ | ✓ |
+| `Right` | ✓ | ✓ | ✗ `SqlError::JoinKindNotSupported` |
+| `Full` | ✓ | ✗ | ✗ |
+
+`Right` ist leicht zu umgehen — tausche die Operanden und verwende `Left`. `Full` auf MySQL wird üblicherweise mit `(LEFT JOIN) UNION (RIGHT JOIN)` emuliert, wenn du es wirklich brauchst.
+
+**Andere Fehler zur Emit-Zeit:**
+
+- **Leeres `on`-Prädikat** (`WhereExpr::And(vec![])` oder keine `ExprCompare`s) wird mit `SqlError::EmptyJoinOnCondition` abgelehnt. SQL erfordert mindestens ein boolesches Prädikat innerhalb `ON`; die Auto-`true`-Kurzform vom Top-Level-WHERE gilt hier nicht.
+
+**`project` ist derzeit tote Daten bei Ad-hoc-Joins.**
+
+Das `Join.project`-Feld weist den Writer an, `<alias>"."<col>" AS "<alias>__<col>"`-Spalten in der SELECT-Liste zu emittieren. Heute dekodiert nur `select_related` diese tatsächlich (über den Voll-Zeilen-Decoder des FK-Ziels); Ad-hoc-Joins emittieren die Spalten, aber der `Vec<MainModel>`-Decoder ignoriert sie, sodass das Befüllen von `project` bei einem Ad-hoc-Join nur Bytes an die Leitung anfügt. Lass es als `vec![]`, bis Projektionsverengung + Tupel-Decoding landen.
+
+**Wann man zu Ad-hoc-Joins greift:**
+
+| Bedarf | Werkzeug |
+|---|---|
+| Verwandte Zeilen zusammen mit der Hauptzeile ziehen | `select_related` (Django-Form) |
+| Hauptzeilen nach einem Prädikat der verwandten Tabelle filtern | `exists(...)` / `not_exists(...)` |
+| Per INNER statt LEFT filtern oder mit zusätzlichen ON-Prädikaten | `.join(...)` |
+| Self-Join (z. B. `employee.manager_id = manager.id`) | `.join(...)` |
+| Anti-Join (Zeilen in A mit KEINEM Treffer in B) | `not_exists(...)` |
+
+`select_related` bleibt das richtige Werkzeug, wenn der Join "folge diesem FK und projiziere alle seine Spalten" ist. Ad-hoc-Joins sind der Notausstieg, wenn du brauchst: einen Nicht-FK-Join-Schlüssel, INNER statt LEFT, ein zusätzliches Prädikat innerhalb des ON oder einen Self-Join.
+
+[`joins::col_filter`]: https://docs.rs/rustango/latest/rustango/core/joins/fn.col_filter.html
+
+[`WhereExpr`]: https://docs.rs/rustango/latest/rustango/core/enum.WhereExpr.html
+
+---
+
+## Nur einige Felder speichern
+
+Schreib nur die Felder, die du geändert hast, statt jeder Spalte — Djangos `save(update_fields=[...])`. Ein normales Speichern überschreibt jede Nicht-PK-Spalte; `save_partial(&[...], &pool)` überschreibt nur die, die du benennst.
+
+```rust
+let mut post = Post::objects().fetch(&pool).await?.pop().unwrap();
+post.title = "new title".into();
+post.save_partial(&["title"], &pool).await?;  // SET "title" = $1
+                                                  // — leaves body, status, views untouched
+```
+
+Zwei Motivationen:
+
+* **Performance.** Breite Zeilen mit `TEXT` / `JSON` / `bytea`-Spalten zahlen dafür, jedes Feld bei jedem `save()` neu zu binden und neu zu schreiben, selbst wenn nur eines mutierte. `save_partial` hält die `SET`-Klausel auf genau das, was sich geändert hat.
+* **Nebenläufigkeitssicherheit.** Wenn zwei Schreiber nach einem gemeinsamen Read auseinanderlaufen, überschreibt der Verlierer stillschweigend die Edits des Gewinners auf Feldern, die er nicht angefasst hat. Nur das Feld zu benennen, das du tatsächlich geändert hast, bewahrt die Arbeit des anderen Schreibers überall sonst.
+
+```rust
+// Writer A — flips title.
+a.title = "from-A".into();
+a.save_partial(&["title"], &pool).await?;
+
+// Writer B — started from the same read, flips status.
+// B's local `title` is stale, but it's not in the list, so A's
+// write survives.
+b.status = "from-B".into();
+b.save_partial(&["status"], &pool).await?;
+```
+
+**Feldnamen sind Struct-Felder auf Rust-Seite**, keine SQL-Spalten — `["author_id"]` (nicht `["author"]` für ein FK-typisiertes Feld). Unbekannte Feldnamen geben `ExecError::Query(QueryError::UnknownField)` zurück. Eine leere Liste ist eine No-op (gibt `Ok(())` zurück und loggt ein `tracing::warn!`), passend zu Djangos "nichts zu tun"-Semantik. Auditierte Models (`#[rustango(audit(...))]`) verengen den Audit-Log-Snapshot auf dieselbe Spaltenmenge — das Log spiegelt genau das wider, was geschrieben wurde.
+
+**Auto-PK-Hinweis.** `save_partial` ist nur UPDATE; es auf einem `Auto::Unset`-PK aufzurufen ist ein Benutzerfehler (verwende dafür `insert_pool` / `save_pool`). Anders als `save_pool`, das automatisch `Unset → insert_pool` dispatcht, nimmt diese Methode an, dass du bereits eingefügt hast.
+
+### Kompilierzeit-geprüfte Feldliste
+
+Die string-geschlüsselte Form oben passt für dynamische Feldlisten (Admin-Formulare, API-Payloads). Wenn die Liste in deinem Code fest ist, fängt `save_partial_typed((Post::title, ...), &pool)` falsch geschriebene oder umbenannte Felder zur **Kompilierzeit** statt zur Laufzeit:
+
+```rust
+post.save_partial_typed((Post::title, Post::slug), &pool).await?;
+//                       ──────────  ──────────
+//                       title_col   slug_col   ← distinct ZSTs
+```
+
+Jedes `Post::<field>` ist sein eigener Zero-Sized Type — ein homogener Slice (`&[Post::title, Post::slug]`) typprüft in Rust nicht, sodass die API stattdessen ein **Tupel** nimmt. Ein-Feld-Aufrufe verwenden das Nachlaufkomma-Idiom: `(Post::title,)`. Tupel werden von Stelligkeit 1 bis 12 unterstützt — darüber hinaus wechsle zu `save_partial(&[&str], _)`.
+
+Modellübergreifende Tupel sind ein **Kompilierfehler** — `(Post::title, Author::name)` scheitert an der `TypedFieldList<Post>`-Trait-Schranke, weil `Author::name`s `Column::Model = Author` ist. Das ist der Kernvorteil gegenüber der string-geschlüsselten Form: Rename-Refactorings auf einem Spaltennamen tauchen an der typisierten Aufrufstelle auf, nicht zur Laufzeit.
+
+Senkt intern zu `save_partial` ab — gleiche Audit-Verengung, gleiche `Auto::Unset`-Beschränkung, gleiche Leere-Liste-No-op-Semantik.
+
+---
+
+## Massenoperationen
+
+> **Fallstrick — Massenoperationen überspringen Per-Zeile-Hooks.** `bulk_insert`, Queryset
+> `.update().execute()` und `.delete()` laufen als mengenbasiertes SQL: sie feuern **keine**
+> Signale, schreiben nicht den Audit-Trail, routen nicht durch Soft-Delete und führen
+> keine Per-Zeile-Validierung aus. Verwende sie für Geschwindigkeit; wechsle zu Per-Zeile-`save()` / `delete()`,
+> wenn du diese Seiteneffekte brauchst.
+
+Füge viele Zeilen in einem Statement ein, aktualisiere oder lösche sie, statt eine pro Zeile — Djangos `bulk_create`, `QuerySet.update()` und `QuerySet.delete()`. Der `as _`-Import bringt die Methoden eines Traits in Scope, ohne den Trait direkt zu benennen.
+
+```rust
+// Bulk INSERT — rows FIRST (a `&mut [Self]`), executor/pool second.
+let mut rows = [p1, p2, p3];
+Post::bulk_insert_on(&mut rows, &pool).await?;
+
+// Bulk UPDATE — applies the same set to every matched row. `.set`
+// takes a string column name.
+Post::objects()
+    .where_(Post::status.eq("draft"))
+    .where_(Post::created_at.lt(thirty_days_ago))
+    .update()
+    .set("status", "archived")
+    .execute_on(&pool).await?;
+
+// Bulk DELETE
+Post::objects()
+    .where_(Post::deleted_at.is_not_null())
+    .delete_on(&pool).await?;
+```
+
+---
+
+## Einfügen oder aktualisieren (Upsert)
+
+Füge eine Zeile ein oder aktualisiere sie, wenn eine Zeile mit demselben Schlüssel bereits existiert — Djangos `update_or_create` / Rails' `upsert`. Es emittiert das native `ON CONFLICT … DO UPDATE` der Datenbank.
+
+Das Einzelinstanz-`.upsert_on(executor)` kollidiert auf dem **Primärschlüssel**: mit einem `Auto::Unset`-PK weist der Server einen neuen Schlüssel zu (äquivalent zu `insert`); mit einem `Auto::Set`-PK wird die Zeile eingefügt, wenn abwesend, oder alle Nicht-PK-Spalten werden überschrieben, wenn vorhanden.
+
+```rust
+// Upsert on the PK — INSERT, or UPDATE every non-PK column if the
+// PK already exists.
+post.upsert_on(&pool).await?;
+```
+
+Um auf einem beliebigen Unique-Schlüssel zu upserten (Django `bulk_create(update_conflicts=True, unique_fields=…, update_fields=…)`), verwende den Bulk-Helper — er nimmt die Zeilen, die Konfliktziel-Spalten, die bei Konflikt zu aktualisierenden Spalten und den Pool ZULETZT:
+
+```rust
+// ON CONFLICT (external_id) DO UPDATE SET title = EXCLUDED.title
+Post::bulk_upsert_pool(
+    &[post],
+    &["external_id"],          // conflict target (unique key)
+    &["title"],                // columns to overwrite on conflict
+    &pool,
+).await?;
+```
+
+---
+
+## Transaktionen
+
+> **Fallstrick — mische keine `&pool`-Aufrufe innerhalb einer Transaktion.** Jeder Aufruf
+> zwischen `pool.begin()` und `commit` muss das Transaktions-Handle
+> (`&mut *tx`) anvisieren. Ein verirrtes `&pool` / `fetch()` / `save_on(&pool)` checkt eine
+> *zweite* Verbindung aus und kann den Pool unter Last deadlocken. Fädle die `tx`
+> durch, oder verwende `rustango::sql::atomic`.
+
+Führe mehrere Schreibvorgänge als eine Einheit aus, die entweder alle gelingen oder alle zurückrollen — Djangos `transaction.atomic()`. Öffne eine mit `pool.begin()` und führe jedes Statement gegen die Verbindung der Transaktion über die `_on`-Methoden (`fetch_on`, `save_on`) aus, sodass die Arbeit auf der laufenden Transaktion landet statt auf einer frischen gepoolten Verbindung.
+
+```rust
+let mut tx = pool.begin().await?;
+
+let mut a = Account::objects()
+    .where_(Account::id.eq(1))
+    .fetch_on(&mut *tx).await?
+    .pop().unwrap();
+let mut b = Account::objects()
+    .where_(Account::id.eq(2))
+    .fetch_on(&mut *tx).await?
+    .pop().unwrap();
+
+a.balance -= 100;
+b.balance += 100;
+a.save_on(&mut *tx).await?;
+b.save_on(&mut *tx).await?;
+
+tx.commit().await?;
+```
+
+Verwirf die `tx`, ohne `commit()` aufzurufen (z. B. bei einem frühen `?`-Return), und die Transaktion rollt zurück. Für einen Nach-Commit-Hook (Djangos `transaction.on_commit`) greif zum closure-artigen `rustango::sql::atomic(&pool, |tx| Box::pin(async move { … }))`-Helper, der bei `Ok` automatisch committet und bei `Err` automatisch zurückrollt.
+
+---
+
+## Many-to-many
+
+Verknüpfe viele Zeilen mit vielen anderen über eine Verknüpfungstabelle — Djangos `ManyToManyField`. Deklariere die Relation auf dem Model, verwende dann den generierten Accessor, um die verknüpften IDs hinzuzufügen, zu entfernen, zu setzen oder aufzulisten.
+
+```rust
+#[rustango(
+    table = "posts",
+    m2m(name = "tags", to = "tags", through = "post_tags",
+        src = "post_id", dst = "tag_id"),
+)]
+pub struct Post { ... }
+```
+
+Verwende den auto-generierten Accessor:
+
+```rust
+let tag_ids: Vec<i64> = post.tags_m2m().all(&pool).await?;
+post.tags_m2m().add(42, &pool).await?;
+post.tags_m2m().remove(42, &pool).await?;
+post.tags_m2m().set(&[1, 2, 3], &pool).await?;        // replace all
+post.tags_m2m().clear(&pool).await?;
+let has = post.tags_m2m().contains(42, &pool).await?;
+```
+
+Die Verknüpfungstabelle (`post_tags`) wird von `make_migrations` automatisch erstellt mit zusammengesetztem PK + zwei FKs `ON DELETE CASCADE`. Derzeit hat die Verknüpfungstabelle nur die zwei FK-Spalten — für zusätzliche Spalten (added_by, order, created_at) definierst du ein separates Model und traversierst manuell, bis "custom through model" landet.
+
+---
+
+## JSON / JSONB
+
+Speichere und frage ein JSON-Dokument in einer Spalte ab — Djangos `JSONField`. Deklariere das Feld als `serde_json::Value` (den generischen JSON-Typ), frage es dann mit `json_contains` oder einem Pfadfilter ab.
+
+```rust
+#[derive(Model)]
+pub struct Event {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(default = r#"'{}'::jsonb"#)]
+    pub data: serde_json::Value,
+}
+```
+
+JSON-Inhalte abfragen:
+
+```rust
+use rustango::core::{Expr, Op, SqlValue, WhereExpr};
+use rustango::core::funcs::json_path;
+use rustango::core::F;
+
+let with_email = Event::objects()
+    .where_(Event::data.json_contains(serde_json::json!({"email_set": true})))
+    .fetch(&pool).await?;
+
+// Path extract — `json_path(F("data"), &["type"], true)` builds the
+// `data ->> 'type'` text-extract LHS; compare it via `where_raw`.
+let typed = Event::objects()
+    .where_raw(WhereExpr::ExprCompare {
+        lhs: json_path(F("data"), &["type"], true),
+        op: Op::Eq,
+        rhs: Expr::Literal(SqlValue::String("user.created".into())),
+    })
+    .fetch(&pool).await?;
+```
+
+Lies/schreibe Rust-Typen über `serde_json::from_value` / `to_value`.
+
+---
+
+## Soft Delete
+
+Markiere eine Zeile als gelöscht, indem du einen Zeitstempel setzt, statt sie zu entfernen — wie Djangos `django-safedelete` oder Laravels `SoftDeletes`. Markiere die Zeitstempel-Spalte mit dem `#[rustango(soft_delete)]`-Attribut (eine Derive-Annotation, die dem Makro sagt, wie das Feld zu behandeln ist):
+
+```rust
+#[derive(Model)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub title: String,
+    #[rustango(soft_delete)]
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+```
+
+Verwendung:
+
+```rust
+post.soft_delete_on(&pool).await?;     // sets deleted_at = NOW()
+post.restore_on(&pool).await?;          // sets deleted_at = NULL
+
+// Default queries DO include soft-deleted rows. Filter explicitly:
+let live = Post::objects().where_(Post::deleted_at.is_null()).fetch(&pool).await?;
+```
+
+Der "Löschen"-Button des Admins routet automatisch zu `soft_delete_on` für jedes Model, das die Spalte hat. Der Auto-Filter (Default-Ausschluss) steht auf der v0.21-Roadmap.
+
+---
+
+## Audit-Trail
+
+Zeichne auf, wer welche Felder wann geändert hat, automatisch bei jedem Speichern und Löschen — wie Djangos `django-simple-history` oder Laravels Auditing-Pakete. Annotiere das Model mit den zu verfolgenden Feldern:
+
+```rust
+#[derive(Model)]
+#[rustango(audit(track = "title, body, status"))]
+pub struct Post { ... }
+```
+
+Jedes Speichern/Löschen schreibt eine Zeile in `rustango_audit_log` mit einem `before / after` JSONB-Diff für die aufgelisteten Felder. Setze die Quelle pro Request:
+
+```rust
+use rustango::audit::{with_source, AuditSource};
+
+with_source(
+    AuditSource::User { id: user_id.to_string() },
+    async {
+        post.save_on(&pool).await
+    },
+).await?;
+```
+
+Das Per-Zeile-Verlaufspanel des Admins liest aus dieser Tabelle; der modellübergreifende Feed ist unter `/__audit`.
+
+Bereinigung:
+
+```rust
+rustango::audit::cleanup_older_than(&pool, 90).await?;       // delete > 90 days
+rustango::audit::cleanup_keep_last_n(&pool, 50).await?;      // keep most recent 50/row
+
+// CLI
+manage audit-cleanup --days 90
+manage audit-cleanup --keep-last 50 --tenant acme
+```
+
+---
+
+## Raw-SQL-Notausstieg
+
+Steig auf handgeschriebenes SQL um, wenn der Query-Builder nicht ausdrücken kann, was du brauchst — Djangos `Model.objects.raw()` / `connection.cursor()`. Die `sqlx`-Makros führen eine Abfrage aus und dekodieren das Ergebnis in ein Tupel, ein typisiertes `Model` oder nichts:
+
+```rust
+use rustango::sql::sqlx;
+
+// Raw query → typed rows
+let rows = sqlx::query_as::<_, (i64, String)>("SELECT id, title FROM posts WHERE views > $1 ORDER BY views DESC")
+    .bind(1000)
+    .fetch_all(&pool)
+    .await?;
+
+// Raw with model decoding
+let posts: Vec<Post> = sqlx::query_as::<_, Post>("SELECT * FROM posts WHERE complicated_condition")
+    .fetch_all(&pool)
+    .await?;
+
+// Raw without rows (DDL / DML)
+sqlx::query("REINDEX TABLE posts").execute(&pool).await?;
+```
+
+Für programmatisches rohes SQL innerhalb der **Rustango**-Query-Schicht (tri-dialektisch; nimmt das SQL, ein `Vec<SqlValue>` von Binds, dann den Pool ZULETZT, und gibt `Vec<T>` zurück):
+
+```rust
+use rustango::sql::raw_query_pool;
+
+let rows = raw_query_pool::<(i64,)>(
+    "SELECT COUNT(*) FROM posts WHERE complicated",
+    vec![],
+    &pool,
+).await?;
+let count = rows.first().map(|r| r.0).unwrap_or(0);
+```
+
+---
+
+## Lazy-FK-Laden
+
+Ein Foreign Key hält anfangs nur die verwandte ID (`Unloaded`), und du holst die volle verwandte Zeile erst, wenn du danach fragst — Djangos Lazy-Zugriff auf verwandte Objekte. `match` auf den `ForeignKey`, um beide Zustände zu behandeln, oder rufe `.get(&pool)` auf, um ihn bei Bedarf zu laden. Für einen ganzen Batch verwende `select_related` (oben), um sie in einer Abfrage vorzuladen und den Per-Zeile-Fetch zu überspringen.
+
+```rust
+let mut post = Post::objects().find_or_fail(1, &pool).await?;
+
+// FK starts Unloaded — just the PK. `Loaded` is a struct variant
+// `{ pk, value }`; `value` is a `Box<Author>`.
+match &post.author {
+    ForeignKey::Unloaded(pk) => println!("author id = {pk}"),
+    ForeignKey::Loaded { pk, value } => println!("author = {}", value.name),
+}
+
+// Force-load
+let author = post.author.get(&pool).await?;          // fetches if Unloaded
+```
+
+Verwende `select_related("author")` auf dem Queryset, um einen Batch vorzuladen.
+
+---
+
+## Vier Wege zu filtern
+
+Es gibt vier Wege, einen Filter auszudrücken; wähle nach Kontext. Typisierte Spalten werden zur Kompilierzeit geprüft und sind am besten für App-Code; die `field__lookup`-String-Form ist Djangos vertraute Syntax für Admin und generisches CRUD; `filter_op` ist dafür, wenn du bereits ein `Op` hältst; der HTTP-Query-String treibt die öffentliche API.
+
+```rust
+// 1. HTTP query string (set via ViewSet filter_fields)
+//    GET /api/posts?author_id=42&status__ne=archived
+
+// 2. Django-shape string lookup (the same `field__lookup` grammar your
+//    URL parser uses, but inside Rust). Suffix decides the operator
+//    and value-shape; bare key is exact-eq. Field name is validated
+//    at `.compile()`.
+Post::objects()
+    .filter("status", "published")                 // exact-eq
+    .filter("title__icontains", "rust")            // ILIKE %rust%
+    .filter("views__gt", 100_i64);
+
+// 3. Explicit operator (legacy 3-arg shape — when you want to pass
+//    an Op directly without parsing a suffix)
+Post::objects().filter_op("author_id", Op::Eq, SqlValue::I64(42));
+
+// 4. Typed columns (compile-time field check; preferred in app code)
+Post::objects().where_(Post::author_id.eq(42));
+```
+
+**Konvention:** typisiert im App-Code, Django-Form in Admin- / generischem CRUD-Code, `filter_op` nur, wenn du bereits ein `Op` berechnet hast (z. B. aus einem Request-Parser), HTTP-Query für die öffentliche API-Oberfläche.
+
+### Unterstützte Lookup-Suffixe
+
+| Suffix | SQL-Operator | Wertform | Hinweise |
+|---|---|---|---|
+| *(keins)* / `__exact` | `=` | Skalar | nackter Schlüssel ist exact-eq |
+| `__ne` | `<>` | Skalar | |
+| `__gt` / `__gte` / `__lt` / `__lte` | `>` `>=` `<` `<=` | Skalar | |
+| `__contains` | `LIKE` | String | umschließt den Wert als `%v%` |
+| `__icontains` | `ILIKE` | String | umschließt den Wert als `%v%`; MySQL emuliert über `LOWER()` |
+| `__startswith` | `LIKE` | String | umschließt als `v%` |
+| `__istartswith` | `ILIKE` | String | umschließt als `v%` |
+| `__endswith` | `LIKE` | String | umschließt als `%v` |
+| `__iendswith` | `ILIKE` | String | umschließt als `%v` |
+| `__iexact` | `ILIKE` | String | kein Wildcard-Umschließen — exakter case-insensitiver Treffer |
+| `__in` | `IN (…)` | `SqlValue::List` | lehnt Nicht-Listen-Werte ab |
+| `__isnull` | `IS NULL` / `IS NOT NULL` | `bool` | `true` → IS NULL, `false` → IS NOT NULL |
+| `__between` / `__range` | `BETWEEN … AND …` | 2-elementige `SqlValue::List` | an beiden Enden inklusiv |
+| `__regex` / `__iregex` | PG `~` / `~*`, MySQL/SQLite `REGEXP` | String | case-insensitiv emuliert auf MySQL/SQLite über `LOWER()`-Umschließung; SQLite braucht eine `regexp`-User-Funktion |
+
+**Fehler tauchen bei `.compile()` auf, nicht zur `.filter()`-Aufrufzeit** — Wertform-Diskrepanzen (z. B. `__in` mit einem Skalar, `__isnull` mit einem Nicht-Bool, `__between` mit falscher Stelligkeit) und unbekannte Suffixe (`status__nope`) geben `QueryError::UnknownLookup` / `QueryError::InvalidLookupValue` von `.compile()` zurück, sodass die fluente Kette typsauber bleibt. Verkettete Traversierungen (`author__name__icontains`) werden in v0.39 **nicht** unterstützt — der Splitter nimmt das Suffix nach dem ersten `__`, sodass der ganze Schwanz `name__icontains` als unbekanntes Suffix behandelt wird.
+
+Jeder Filteraufruf wird per AND mit allen vorhergehenden verknüpft; mische Django-Form, `filter_op` und `where_` frei auf demselben Queryset.
+
+---
+
+## Mandantengebundene Abfragen
+
+In einer Multi-Tenant-App führe jede Abfrage gegen die Verbindung des aktuellen Mandanten aus statt gegen den geteilten Pool. Hol dir eine Per-Request-Verbindung und übergib sie an `fetch_on` (das jeden Datenbank-Executor akzeptiert) statt an `fetch` (das immer `&pool` verwendet).
+
+```rust
+use rustango::extractors::Tenant;
+
+async fn handler(mut t: Tenant) -> Result<...> {
+    let conn = t.conn();        // &mut PgConnection for this tenant
+    let posts = Post::objects().fetch_on(&mut *conn).await?;
+    Ok(...)
+}
+```
+
+`fetch_on` funktioniert mit jedem `sqlx::Executor`; `fetch` ist Zucker für `fetch_on(&pool)`.
+
+---
+
+## Signale
+
+Führe einen Callback aus, wenn etwas passiert — Djangos Signale. Es gibt zwei unabhängige Registrierungen: eine für Model-Schreibvorgänge, eine für HTTP-Requests.
+
+### Model-Lebenszyklus
+
+Feure einen Hook vor oder nach dem Speichern oder Löschen eines Models: `pre_save`, `post_save`, `pre_delete`, `post_delete`. Registriere einen mit `connect_post_save::<Post, _, _>(...)`.
+
+```rust
+use rustango::signals::{connect_post_save, PostSaveContext};
+
+connect_post_save::<Post, _, _>(|post, ctx| async move {
+    if ctx.created {
+        tracing::info!("new post #{}", post.id.get().copied().unwrap_or(0));
+    }
+});
+```
+
+`T: Clone + 'static` ist erforderlich (der Dispatcher übergibt jedem Empfänger einen `Arc<T>`-Klon). Empfänger laufen sequenziell in Registrierungsreihenfolge. Trenne über die `ReceiverId`, die `connect_*` zurückgibt. Die vier Signalarten + ihre Kontextformen sind inline in `rustango::signals` dokumentiert.
+
+### Request-Lebenszyklus
+
+Feure einen Hook um jeden HTTP-Request: `request_started`, `request_finished`, `got_request_exception`. Füge die `RequestSignalsLayer`-Middleware zu deinem Router hinzu, verbinde dann Callbacks. Nützlich für Tracing, Audit, Request-Zeit-Metriken und Fehlerberichterstattung im Django-Stil.
+
+```rust
+use axum::Router;
+use rustango::signals::request::{
+    connect_request_started, connect_request_finished, RequestSignalsLayer,
+};
+
+connect_request_started(|ctx| Box::pin(async move {
+    tracing::info!(method = %ctx.method, path = %ctx.path, "started");
+}));
+connect_request_finished(|ctx| Box::pin(async move {
+    metrics::histogram!("http_request_ms").record(ctx.elapsed_ms);
+}));
+
+let app: Router = Router::new()
+    .route("/", get(home))
+    .layer(RequestSignalsLayer::new());  // outermost — sees request first / response last
+```
+
+| Signal | Kontextfelder |
+|---|---|
+| `request_started` | `method`, `path`, `query` |
+| `request_finished` | `method`, `path`, `status`, `elapsed_ms` |
+| `got_request_exception` | `method`, `path`, `error` |
+
+Empfänger laufen sequenziell in Registrierungsreihenfolge; umschließe einen Körper in `tokio::spawn` für parallelen Fanout oder Panic-Isolation. Die Request- und Model-Registrierungen sind unabhängig — das Verbinden / Trennen / Leeren der einen berührt die andere nicht.
+
+---
+
+## Performance-Tipps
+
+Eine schnelle Checkliste, um Abfragen schnell zu halten, während die Daten wachsen:
+
+- **Verwende immer Indizes für `WHERE`- und `ORDER BY`-Spalten.** Deklariere über `#[rustango(index)]`, damit sie in den Migrationen sind.
+- **`select_related` für FK-Anzeige in Listen** — eliminiert N+1 in Admin-/Listenansichten.
+- **`page` statt `fetch().drain()`** — lade niemals ganze Tabellen.
+- **Cursor-Paginierung für riesige Tabellen** — überspringt `COUNT(*)` pro Seite.
+- **`bulk_insert_on` für Batches** — ein einziger Roundtrip statt N.
+- **`upsert_on` für idempotente Importe** — `ON CONFLICT` ist schneller als SELECT-dann-INSERT.
+- **`transaction` für zusammenhängende Schreibvorgänge** — reduziert Commit-Overhead und wahrt Konsistenz.
+- **Cache heiße Reads** mit `cache::get_or_set` — invalidiere im `connect_post_save<T>(...)`-Signalhandler.
+
+---
+
+## Siehe auch
+
+- [Models](models.md) — ein Model deklarieren: Feldtypen, Primärschlüssel, jedes Attribut (der Begleiter zu diesem Query-Leitfaden).
+- [Serializer](serializers.md) — Model-Zeilen in JSON formen.
+- [ViewSets](viewsets.md) — ein Model in eine JSON-CRUD-API verwandeln.
+- [Der Admin](admin.md) — eine auto-generierte UI über denselben Models.
+- [`manage`-CLI](manage.md) — `makemigrations` / `migrate` für Schemaänderungen.

--- a/docs/de/query-method.md
+++ b/docs/de/query-method.md
@@ -1,0 +1,179 @@
+# Die QUERY-Methode
+
+`QUERY` ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008), ein im Juni 2026
+veröffentlichter Proposed Standard) ist das „sichere GET mit Body". Sie ist
+**sicher** und **idempotent** wie `GET`, doch die Suchkriterien reisen im
+Anfrage-Body statt in der URL — so muss eine komplexe Suche nicht in einen
+Querystring gepresst werden, und es gibt keine URL-Längenobergrenze. **Rustango**
+routet `QUERY` neben `GET` im gesamten Framework: Routing, einen
+methodenadaptiven Extraktor, CSRF-/CORS-/Retry-Policy, Caching pro View, ViewSets,
+den Testclient und OpenAPI.
+
+> **Quelle:** `rustango::http_query` (`query`, `QueryRouterExt`, `QUERY`) und
+> `rustango::params` (`Params`) — hinter dem `admin`-Feature. Verwandte Oberfläche:
+> `viewset::ViewSet`, `cache_page::CachePageLayer::cache_query`,
+> `forms::csrf::CsrfConfig::require_csrf_on_query`, `cors::CorsLayer`,
+> `test_client` / `http_client`.
+
+## Wann man dazu greift
+
+Verwenden Sie `QUERY` anstelle von `GET`, wenn die Suchkriterien groß oder
+strukturiert sind:
+
+- Filtermengen, die einen Querystring sprengen würden (lange `IN`-Listen, viele
+  Facetten).
+- Verschachtelte / strukturierte Kriterien, die sich nicht sauber auf
+  `?key=value`-Paare abbilden lassen — senden Sie sie als JSON-Body.
+- Alles, was Sie versucht wären als `POST /search` zu modellieren, obwohl es keinen
+  Zustand liest und nichts ändert — `QUERY` sagt „dies ist ein sicherer,
+  cachebarer Lesevorgang" bereits in der Methode selbst.
+
+Verwenden Sie ein einfaches `GET` für einfache, kurze, mit Lesezeichen versehbare
+Anfragen. `QUERY` ist additiv: Derselbe Handler kann beide bedienen.
+
+## Routing
+
+axum 0.8 kann `QUERY` nicht nativ routen (sein `MethodFilter` ist eine geschlossene
+Menge — [tokio-rs/axum#3799](https://github.com/tokio-rs/axum/issues/3799)), daher
+stellt rustango `query()` und eine `.query()`-Kette bereit, die axums eigene
+`get()` / `post()` widerspiegeln:
+
+```rust
+use rustango::http_query::{query, QueryRouterExt};
+use axum::routing::get;
+
+let app = axum::Router::new()
+    // QUERY-only route.
+    .route("/search", query(search))
+    // GET + QUERY on one path — chain `.query()` last.
+    .route("/products", get(list_products).query(search_products));
+```
+
+Ein `405` auf einer gemischten Route meldet die vollständige Methodenmenge, z. B.
+`Allow: GET,HEAD,QUERY`.
+
+## Ein Handler, beide Transporte
+
+`Params<T>` liest `T` bei `GET`/`HEAD` aus dem Querystring und bei `QUERY` aus dem
+Anfrage-Body, sodass ein einziger Handler beide ohne Verzweigung bedient:
+
+```rust
+use rustango::params::Params;
+use rustango::http_query::QueryRouterExt;
+use axum::routing::get;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Search { q: String, page: Option<u32> }
+
+async fn search(Params(s): Params<Search>) -> String {
+    format!("q={} page={:?}", s.q, s.page)
+}
+
+let app = axum::Router::new().route("/search", get(search).query(search));
+```
+
+`GET /search?q=hi` und `QUERY /search` mit dem Body `q=hi` erreichen `search` und
+deserialisieren identisch. Bei `QUERY` wird der Body nach `Content-Type` geparst:
+
+| `Content-Type` | Geparst als | Anmerkungen |
+|---|---|---|
+| `application/x-www-form-urlencoded` (oder keiner) | `serde_urlencoded` | Derselbe Codepfad wie der Querystring — flach, ein einzelner Wert pro Schlüssel. |
+| `application/json` (oder ein `…+json`-Suffix) | `serde_json` | Für Arrays / verschachtelte Kriterien verwenden. |
+| alles andere | — | `415 Unsupported Media Type` |
+
+Die Statuscodes entsprechen axums Konventionen: Ein Parsefehler des Querystrings
+ist ein `400`, ein Parsefehler des Bodys ein `422`, und eine andere Methode als
+GET/HEAD/QUERY ein `405`.
+
+```bash
+# urlencoded body
+curl -X QUERY http://localhost:8080/search \
+     -H 'Content-Type: application/x-www-form-urlencoded' \
+     --data 'q=hello&page=2'
+
+# JSON body (arrays / nesting)
+curl -X QUERY http://localhost:8080/search \
+     -H 'Content-Type: application/json' \
+     --data '{"q":"hello","tags":["rust","web"]}'
+```
+
+## ViewSets
+
+Ein `ViewSet` erhält kostenlos eine `QUERY`-Sammlungsaktion — `QUERY /things` liefert
+dieselbe gefilterte / geordnete / paginierte Liste wie `GET /things?…`, aber mit den
+Kriterien im Body:
+
+```bash
+# identical results:
+curl 'http://localhost:8080/posts?status=draft&ordering=-rating'
+curl -X QUERY http://localhost:8080/posts \
+     -H 'Content-Type: application/x-www-form-urlencoded' \
+     --data 'status=draft&ordering=-rating'
+
+# arrays via JSON (comma-joined internally for __in lookups):
+curl -X QUERY http://localhost:8080/posts \
+     -H 'Content-Type: application/json' \
+     --data '{"status__in":["draft","published"],"rating__gte":2}'
+```
+
+Berechtigungen und Throttles nutzen die der `list`-Aktion wieder, und
+benutzerdefinierte Admin-Views, die mit der Methode `QUERY` deklariert sind, routen
+ebenfalls korrekt.
+
+## Framework-Garantien
+
+- **CSRF.** `QUERY` ist standardmäßig von der CSRF-Token-Durchsetzung befreit,
+  neben `GET`/`HEAD`/`OPTIONS`/`TRACE`. Browser können `QUERY` nicht per Formular
+  absenden, und ein cross-origin `fetch` mit der Methode `QUERY` ist niemals eine
+  CORS-safelisted „einfache Anfrage" — sie löst immer einen Preflight aus — es gibt
+  also keinen CSRF-Vektor über Ambient-Credentials. Setzen Sie
+  `CsrfConfig::require_csrf_on_query = true` für reine Defense-in-Depth. Halten Sie
+  `QUERY`-Handler nebenwirkungsfrei, und fügen Sie `QUERY` niemals zur Allow-List
+  des [Method-Overrides](middleware.md) hinzu.
+- **CORS.** `QUERY` ist in den `permissive()`- und aus den Einstellungen
+  abgeleiteten Methodenlisten enthalten. Da jedes cross-origin `QUERY` einen
+  Preflight durchläuft, muss es in `Access-Control-Allow-Methods` beworben werden,
+  um cross-origin zu funktionieren.
+- **Retries.** Der HTTP-Client (`http_client`) behandelt `QUERY` als idempotent, es
+  wird also bei transienten Fehlern wie `GET` erneut versucht.
+- **Idempotenz.** `QUERY` benötigt keinen `Idempotency-Key` — die Methode ist
+  per Definition idempotent.
+- **Caching.** `cache_page` kann `QUERY`-Antworten cachen, wenn Sie dies mit
+  `CachePageLayer::cache_query(true)` aktivieren. Der Cache-Schlüssel bezieht einen
+  Digest des Anfrage-Bodys mit ein, und die Antwort wird als `private` markiert,
+  damit geteilte Caches (die nicht auf einem Body basieren können) sie niemals
+  fehlerhaft ausliefern. Siehe [Caching](caching.md).
+
+## Testing
+
+`TestClient` und `RequestFactory` verfügen über `.query()`-Builder, und der
+ausgehende `HttpClient` kann `QUERY` senden:
+
+```rust
+let resp = client.query("/search").json(&criteria).send().await;
+```
+
+## OpenAPI
+
+OpenAPI 3.1 hat keine `QUERY`-Operation; [OpenAPI 3.2](https://www.openapis.org/blog/2025/09/23/announcing-openapi-v3-2)
+hat sie als erstklassiges Path-Item-Feld hinzugefügt. Rustango gibt eine
+`query`-Operation aus, wenn Sie eine anhängen, und hebt die Spezifikation nur für
+Spezifikationen, die sie verwenden, auf `openapi: 3.2.0` an (Spezifikationen ohne
+`QUERY` bleiben auf `3.1.0` für maximale Tooling-Kompatibilität):
+
+```rust
+use rustango::openapi::{OpenApiSpec, PathItem, Operation, RequestBody, Response, Schema};
+
+let spec = OpenApiSpec::new("API", "1.0").add_path(
+    "/posts",
+    PathItem::new()
+        .get(Operation::new().summary("List posts").response("200", Response::new("OK")))
+        .query(
+            Operation::new()
+                .summary("Search posts")
+                .request_body(RequestBody::json(Schema::ref_("SearchCriteria")))
+                .response("200", Response::new("OK")),
+        ),
+);
+```

--- a/docs/de/scaffolding.md
+++ b/docs/de/scaffolding.md
@@ -1,0 +1,184 @@
+# Scaffolding
+
+**Rustango** hat zwei Ebenen der Codegenerierung, beide nach den Generatoren modelliert, die du von Django und Laravel kennst — sodass du selten Boilerplate von Hand verdrahtest:
+
+1. **Der Projektgenerator** — `cargo rustango new` erstellt ein komplett neues Projekt aus einer Vorlage.
+2. **Projektinterne Generatoren** — `manage startapp` und die `manage make:*`-Familie fügen Apps, Views, Serializer, Jobs und mehr in einem bestehenden Projekt hinzu.
+
+[![`cargo rustango new` scaffoldet ein komplettes, sofort lauffähiges Projekt — Cargo-Manifest, Config-Tiers, Docker, Migrationen und src — mit einem einzigen Befehl](img/scaffolding.png)](img/scaffolding.png)
+
+## Inhaltsverzeichnis
+
+- [Den Generator installieren](#install-the-generator)
+- [Ein Projekt erstellen: `cargo rustango new`](#create-a-project-cargo-rustango-new)
+- [Was generiert wird](#what-gets-generated)
+- [Ein Feature-Modul hinzufügen: `manage startapp`](#add-a-feature-module-manage-startapp)
+- [Einzelne Dateien generieren: die `make:*`-Befehle](#generate-single-files-the-make-commands)
+- [Ein typischer Ablauf](#a-typical-flow)
+
+---
+
+## Den Generator installieren
+
+`cargo rustango` ist ein Cargo-Unterbefehl. Installiere ihn einmal, global:
+
+```sh
+cargo install cargo-rustango
+```
+
+Das legt ein `cargo-rustango`-Binary in deinem `PATH` ab; Cargo stellt es dann als `cargo rustango` bereit (auf dieselbe Weise, wie `django-admin` oder der `laravel`-Installer dir einen globalen Befehl geben).
+
+---
+
+## Ein Projekt erstellen: `cargo rustango new`
+
+```sh
+cargo rustango new <name> [--template api|fullstack|tenant]
+```
+
+- **`<name>`** — der Projekt- (und Crate-)Name. Er muss ein gültiger Cargo-Crate-Name sein (`[A-Za-z_][A-Za-z0-9_-]*`), und das Zielverzeichnis darf noch nicht existieren.
+- **`--template` / `-t`** — welcher Starter gescaffoldet wird (Default: **fullstack**).
+- **`--help` / `-h`**, **`--version`** — Verwendung und Version.
+
+### Die drei Vorlagen
+
+Jede entspricht einer der drei App-Formen von **Rustango**:
+
+| Vorlage | Was du bekommst | Wähle sie, wenn |
+|---|---|---|
+| `api` | Blankes ORM + Axum, **kein Admin** | JSON-only-Dienste und Microservices |
+| `fullstack` *(Default)* | ORM + der **Auto-Admin** | Eine typische Webapp mit Backoffice |
+| `tenant` | Multi-Tenancy + Operator-Konsole + Apps pro Tenant | SaaS, das viele isolierte Tenants hostet |
+
+```sh
+cargo rustango new myblog                      # fullstack (the default)
+cargo rustango new api_demo  --template api
+cargo rustango new shop      --template tenant
+```
+
+---
+
+## Was generiert wird
+
+Jede Vorlage schreibt ein in sich geschlossenes Cargo-Projekt:
+
+```text
+<name>/
+  Cargo.toml            # the rustango dependency + features for this template
+  .env.example          # copy to .env (DATABASE_URL, RUSTANGO_SESSION_SECRET, …)
+  .gitignore
+  rust-toolchain.toml   # pins the Rust toolchain
+  docker-compose.yml    # a Postgres service to develop against
+  Dockerfile            # production image
+  README.md
+  config/
+    default.toml        # settings shared across every environment
+    dev_settings.toml   # per-tier overrides …
+    staging_settings.toml
+    prod_settings.toml
+  migrations/           # JSON migration files (committed to git)
+  src/
+    main.rs             # the single binary — HTTP server + every manage verb
+    models.rs           # your #[derive(Model)] structs
+    views.rs            # request handlers ("views")
+    urls.rs             # pub fn api() -> Router that aggregates your routes
+```
+
+### Ein Binary für alles
+
+`src/main.rs` ist der einzige Einstiegspunkt. Es startet den HTTP-Server **und** dispatcht jedes `manage`-Verb — es gibt keine separate `manage.py` oder `src/bin/manage.rs`:
+
+```rust
+mod models;
+mod urls;
+mod views;
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    rustango::manage::Cli::new()
+        .api(urls::api())
+        .with_welcome()  // friendly `/` page until you add a root handler
+        .with_health()   // /health + /ready endpoints (fullstack & tenant)
+        .run()
+        .await
+}
+```
+
+Also startet `cargo run` den Server, und `cargo run -- <verb>` führt Migrationen, Generatoren und den Rest aus.
+
+Wie sich die Vorlagen innerhalb von `main.rs` / `urls.rs` unterscheiden:
+
+- **api** — kein Admin; `urls::api()` aggregiert schlicht deine eigenen Routen.
+- **fullstack** — `urls.rs` exponiert zusätzlich `admin_router(pool)` (gebaut aus `admin::Builder::new(pool).build()`), sodass der Auto-Admin unter `/admin` eingehängt wird.
+- **tenant** — `main.rs` ergänzt `.tenancy()`, bedient die Operator-Konsole auf der Apex-Domain und jeden Tenant unter seiner eigenen Subdomain. Die eigenen Tabellen des Frameworks werden beim ersten `cargo run -- migrate` aus den kompilierten Modellen (Django-Stil) in einen **`system/migrations/`**-Ordner generiert — kein handgeliefertes Bootstrap-JSON, sodass das allererste migrate ohne zusätzliche Einrichtung funktioniert.
+
+### Geschichtete Konfiguration
+
+Die Einstellungen laden zuerst `config/default.toml`, dann `config/<RUSTANGO_ENV>_settings.toml` darüber. `RUSTANGO_ENV` ist standardmäßig `dev`, sodass ein frisch gescaffoldetes `cargo run` ohne Änderungen funktioniert; setze `RUSTANGO_ENV=prod` in der Produktion, um `prod_settings.toml` aufzunehmen.
+
+### Erster Lauf
+
+```sh
+cd <name>
+cp .env.example .env
+docker compose up -d        # start Postgres
+cargo run -- migrate        # apply migrations
+cargo run                   # serve
+cargo run -- --help         # see every manage verb
+```
+
+---
+
+## Ein Feature-Modul hinzufügen: `manage startapp`
+
+Das ist Djangos `startapp` — scaffolde ein in sich geschlossenes Modul aus zusammengehörigen Modellen, Views und Routen:
+
+```sh
+cargo run -- startapp blog
+```
+
+Es schreibt `src/blog/` mit `mod.rs`, `models.rs` (ein Starter-Modell, benannt nach der Singular-Form der App — `blog` → `Blog`), `views.rs`, `urls.rs` und `tests.rs`, deklariert dann das Modul in `src/main.rs` und merged seine Routen in `urls::api()`.
+
+Optionen:
+
+- **`--into <dir>`** — scaffolde unter einem anderen Basisverzeichnis als `src/` (z. B. einem Workspace-Member).
+- **`--with-manage-bin`** — gib zusätzlich eine `bin/manage.rs` aus (für Layouts, die ein separates manage-Binary bevorzugen).
+
+---
+
+## Einzelne Dateien generieren: die `make:*`-Befehle
+
+Innerhalb eines Projekts scaffolden die `make:*`-Verben jeweils eine Datei. Die vollständige Referenz pro Flag findest du in der [manage-CLI-Referenz](manage); die gängigen Formen sind:
+
+| Befehl | Generiert | Vergleichbar mit |
+|---|---|---|
+| `make:viewset <Name> [--model <M>]` | Ein DRF-artiges CRUD-ViewSet | DRF `ViewSet` |
+| `make:serializer <Name> [--model <M>]` | Ein Serializer zum Formen von Request/Response | DRF-Serializer |
+| `make:api_routes <app>` | Ein API-Routen-Aggregator für eine App | — |
+| `make:form <Name>` | Ein HTML-Formular mit Validierung | Django `Form` |
+| `make:job <Name>` | Ein Handler für einen Hintergrund-Job | Laravel-/Celery-Job |
+| `make:notification <Name>` | Eine Mehrkanal-Benachrichtigung | Laravel-Notification |
+| `make:middleware <Name>` | Ein Middleware-Gerüst | Django-/Laravel-Middleware |
+| `make:test <Name>` | Ein Testmodul mit dem In-process-Testclient | — |
+
+```sh
+cargo run -- make:viewset PostViewSet --model Post
+cargo run -- make:serializer PostSerializer --model Post
+cargo run -- make:test post_smoke
+```
+
+---
+
+## Ein typischer Ablauf
+
+```sh
+cargo rustango new myblog                              # 1. scaffold the project
+cd myblog
+cargo run -- startapp blog                             # 2. add a feature module
+# …add fields to src/blog/models.rs…
+cargo run -- makemigrations                            # 3. generate a migration
+cargo run -- migrate                                   # 4. apply it
+cargo run -- make:viewset PostViewSet --model Post     # 5. expose a JSON API
+cargo run                                              # 6. serve
+```

--- a/docs/de/security.md
+++ b/docs/de/security.md
@@ -1,0 +1,671 @@
+# Sicherheitsleitfaden
+
+Dieser Leitfaden behandelt jede Sicherheitsfunktion, die **Rustango** mitbringt, und wie man sie kombiniert. Wenn du von Django, Laravel oder Rails kommst, werden dir die meisten davon vertraut vorkommen — die Namen unterscheiden sich, aber die Ideen sind dieselben. Jede der folgenden Funktionen benötigt in der Regel eine Zeile Setup. Wenn du bereit bist, in Produktion zu gehen, führe `manage check --deploy` für ein automatisiertes Audit aus.
+
+[![Der gehärtete Middleware-Stack in einer Kette verdrahtet: Request-IDs, Zugriffsprotokollierung, Rate Limiting, CORS und Security-Header](img/security.png)](img/security.png)
+
+## Inhaltsverzeichnis
+
+- [Die Defense-in-Depth-Checkliste](#the-defense-in-depth-checklist)
+- [Security-Header setzen](#setting-security-headers)
+- [Cross-Origin-Anfragen erlauben (CORS)](#allowing-cross-origin-requests-cors)
+- [Anfragen per Rate Limiting drosseln](#rate-limiting-requests)
+- [IPs erlauben oder blockieren](#allowing-or-blocking-ips)
+- [Schutz vor CSRF](#protecting-against-csrf)
+- [XSS verhindern](#preventing-xss)
+- [SQL-Injection verhindern](#preventing-sql-injection)
+- [Benutzer authentifizieren](#authenticating-users)
+- [Passwörter hashen und prüfen](#hashing-and-checking-passwords)
+- [JWTs ausstellen und erneuern](#issuing-and-refreshing-jwts)
+- [Mit API-Keys authentifizieren](#authenticating-with-api-keys)
+- [Zwei-Faktor-Authentifizierung hinzufügen (TOTP)](#adding-two-factor-auth-totp)
+- [Signierte URLs versenden (Magic Links)](#sending-signed-urls-magic-links)
+- [Eingehende Webhooks verifizieren](#verifying-incoming-webhooks)
+- [Secrets aus deinen Logs heraushalten](#keeping-secrets-out-of-your-logs)
+- [Anfragen über Services hinweg nachverfolgen](#tracing-requests-across-services)
+- [Secrets verwalten](#managing-secrets)
+- [Vor dem Deploy auditieren](#auditing-before-you-deploy)
+
+---
+
+## Die Defense-in-Depth-Checkliste
+
+Gute Sicherheit entsteht aus vielen kleinen Schichten, nicht aus einer großen Mauer. Eine produktive **Rustango**-App sollte die folgenden Schichten stapeln — die meisten davon sind jeweils eine Zeile. Der Rest dieses Leitfadens erklärt jede einzelne.
+
+```rust
+let app = Router::new()
+    .route("/...", ...)
+    .merge(health::health_router(pool.clone()))         // /health, /ready
+    .request_id(RequestIdLayer::default())              // log correlation
+    .access_log(AccessLogLayer::default())              // PII-redacted by default
+    .rate_limit(RateLimitLayer::per_ip(60, ONE_MIN))    // 60 req/min/IP
+    .cors(CorsLayer::new().allow_origins(vec!["..."])) // explicit allowlist
+    .security_headers(                                   // HSTS + XFO + nosniff + Referrer + CSP
+        SecurityHeadersLayer::strict()
+            .csp(CspBuilder::strict_starter().build()),
+    );
+// Plus: TLS termination at reverse proxy.
+// Plus: argon2 for passwords, JWT lifecycle for tokens, TOTP for MFA.
+```
+
+---
+
+## Security-Header setzen
+
+Security-Header teilen dem Browser mit, wie er deine Benutzer schützen soll (Clickjacking blockieren, HTTPS erzwingen, Content-Type-Sniffing unterbinden). `SecurityHeadersLayer` setzt das Standardset mit einer Zeile — dieselben Header, die Django standardmäßig mitbringt. (Ein „Layer" ist **Rustango**s Begriff für Middleware; du hängst sie an deinen Router an.)
+
+> Vertiefung: [Middleware](middleware.md) behandelt, wie Layer funktionieren, ihre Reihenfolge, den vollständigen eingebauten Katalog und das Schreiben eigener Layer (locale-, zeitzonenbewusst, Header, CSRF).
+
+```rust
+use rustango::security_headers::{SecurityHeadersLayer, SecurityHeadersRouterExt, CspBuilder};
+
+let app = router.security_headers(SecurityHeadersLayer::strict());
+```
+
+### Presets
+
+| Preset | Wann verwenden |
+|---|---|
+| `strict()` | Produktion: HSTS preload + XFO=DENY + nosniff + Referrer-Policy=no-referrer + COOP=same-origin + Permissions-Policy gesperrt |
+| `relaxed()` | Einbettbar in iframes: SAMEORIGIN + 1 Jahr HSTS |
+| `dev()` | Lokal: nur nosniff (kein HSTS, um localhost nicht für immer in HTTPS zu sperren) |
+| `empty()` | Von Grund auf aufbauen |
+
+### Benutzerdefinierte CSP
+
+```rust
+let csp = CspBuilder::new()
+    .default_src(&["'self'"])
+    .script_src(&["'self'", "https://cdn.example.com"])
+    .style_src(&["'self'", "'unsafe-inline'"])    // for inline <style>
+    .img_src(&["'self'", "data:", "https:"])
+    .font_src(&["'self'", "data:"])
+    .connect_src(&["'self'", "wss://realtime.example.com"])
+    .frame_ancestors(&["'none'"])                 // disallow embedding (clickjacking)
+    .object_src(&["'none'"])
+    .directive("base-uri", &["'self'"])
+    .build();
+
+let layer = SecurityHeadersLayer::strict().csp(csp);
+```
+
+### Gestaffelter CSP-Rollout
+
+Nutze `csp_report_only`, um zu überwachen, ohne die Produktion zu brechen:
+
+```rust
+let layer = SecurityHeadersLayer::strict()
+    .csp(CspBuilder::strict_starter().build())
+    .csp_report_only(true);                       // sends Content-Security-Policy-Report-Only
+```
+
+Nachdem du verifiziert hast, dass keine Konsolenfehler auftreten → schalte `csp_report_only(false)`, um zu erzwingen.
+
+---
+
+## Cross-Origin-Anfragen erlauben (CORS)
+
+CORS steuert, welche anderen Websites deine API aus einem Browser heraus aufrufen dürfen. Standardmäßig blockieren Browser diese Aufrufe; du lässt bestimmte Origins gezielt wieder zu. Liste in Produktion deine echten Frontend-Domains auf und öffne es niemals für alle.
+
+```rust
+use rustango::cors::{CorsLayer, CorsRouterExt};
+
+// Production
+let layer = CorsLayer::new()
+    .allow_origins(vec!["https://app.example.com", "https://admin.example.com"])
+    .allow_methods(vec!["GET", "POST", "PUT", "PATCH", "DELETE"])
+    .allow_headers(vec!["content-type", "authorization"])
+    .allow_credentials(true)
+    .max_age(Duration::from_secs(3600));
+
+// Dev only
+let layer = CorsLayer::permissive();              // any origin, common methods
+```
+
+**Sicherheitshinweis:** Kombiniere niemals `allow_credentials(true)` mit `allow_any_origin()` — der Browser wird die Antwort ablehnen. Mit Credentials MUSST du explizite Origins auflisten.
+
+---
+
+## Anfragen per Rate Limiting drosseln
+
+Rate Limiting begrenzt, wie viele Anfragen ein Client in einem Zeitfenster stellen kann. Nutze es, um Brute-Force-Logins, Scraping und Missbrauch auszubremsen. Du kannst pro IP, pro API-Key oder global für einen teuren Endpunkt begrenzen.
+
+```rust
+use rustango::rate_limit::{RateLimitLayer, RateLimitRouterExt};
+
+// Per-IP
+router.rate_limit(RateLimitLayer::per_ip(60, Duration::from_secs(60)));
+
+// Per-API-key (header)
+router.rate_limit(RateLimitLayer::per_header("authorization", 1000, Duration::from_secs(3600)));
+
+// Global ceiling for an expensive endpoint
+router.rate_limit(RateLimitLayer::global(10, Duration::from_secs(1)));
+```
+
+Bei Erschöpfung: `429 Too Many Requests` mit `Retry-After`-Header. Jede erfolgreiche Antwort enthält `X-RateLimit-Limit` + `X-RateLimit-Remaining`.
+
+> **Hinter einem Reverse Proxy: kombiniere `per_ip` mit `real_ip`.** `RateLimitLayer::per_ip` schlüsselt auf den verbindenden Socket (`ConnectInfo`), was hinter einem Proxy die IP des *Proxys* ist — also teilen sich alle Clients einen Bucket und das Limit ist nutzlos. Setze `real_ip::RealIpLayer` (liest `X-Forwarded-For` / `X-Real-IP`) davor, damit die echte Client-IP verwendet wird.
+
+`RateLimitLayer` ist **prozesslokal** — es zählt Anfragen nur innerhalb einer laufenden Instanz, was in Ordnung ist, wenn du eine einzelne Instanz betreibst. Wenn du mehrere Instanzen (Replicas) hinter einem Load Balancer betreibst, würde jede ihre eigene Zählung führen, sodass sich das reale Limit vervielfacht. Um eine Zählung über alle Replicas hinweg zu teilen, nutze `rate_limit_cache::CacheRateLimitLayer`, das an eine beliebige `cache::Cache`-Implementierung delegiert (kombiniere es mit `cache::RedisCache` für einen gemeinsamen Zähler, der atomar per Redis `INCRBY` inkrementiert wird):
+
+```rust
+use rustango::cache::RedisCache;
+use rustango::rate_limit::KeyBy;
+use rustango::rate_limit_cache::{CacheRateLimitLayer, CacheRateLimitRouterExt};
+
+let cache: rustango::cache::BoxedCache =
+    std::sync::Arc::new(RedisCache::new("redis://localhost").await?);
+
+let app = axum::Router::new()
+    .route("/api/login", axum::routing::post(login))
+    .cache_rate_limit(
+        CacheRateLimitLayer::new(cache, 5, Duration::from_secs(60))
+            .key_by(KeyBy::Ip)
+            .key_prefix("login"),
+    );
+```
+
+---
+
+## IPs erlauben oder blockieren
+
+Sperre sensible Routen (wie dein Admin) auf eine bekannte Menge von IP-Adressen ein oder blockiere bestimmte Missbraucher. Eine Allowlist erlaubt nur die aufgeführten Netzwerke; eine Blocklist verweigert die aufgeführten.
+
+```rust
+use rustango::ip_filter::{IpFilterLayer, IpFilterRouterExt};
+
+// Internal admin only
+let admin_router = admin_router
+    .ip_filter(IpFilterLayer::allow_only(vec![
+        "10.0.0.0/8",
+        "192.168.0.0/16",
+        "203.0.113.0/24",
+    ])?);
+
+// Block known abusers
+let public_router = public_router
+    .ip_filter(IpFilterLayer::block(vec!["203.0.113.42"])?);
+```
+
+**IPv4 + IPv6 werden unterstützt.** Familienübergreifend sicher (ein IPv4-CIDR matcht keine IPv6-Adressen). Gibt bei Ablehnung `403 Forbidden` zurück.
+
+**Wichtig:** **Rustango** liest die Client-IP aus `ConnectInfo<SocketAddr>`. Mounte mit:
+
+```rust
+axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await?;
+```
+
+Wenn dein Reverse Proxy `X-Forwarded-For` weiterleitet, konfiguriere ihn so, dass er `RemoteAddr` setzt — `ip_filter` liest den verbindenden Peer, nicht die Header.
+
+---
+
+## Schutz vor CSRF
+
+> **CSRF und Token-APIs.** CSRF schützt **Cookie-authentifizierte** Anfragen. Eine
+> reine Token- / Bearer- / [JWT](auth-jwt.md)-API ist kein CSRF-Ziel — wende
+> den CSRF-Layer nicht darauf an (sonst gibst du legitimen Clients ein 403). Für eine SPA, die
+> *tatsächlich* Cookies verwendet, lies das `rustango_csrf`-Cookie und gib es im `X-CSRF-Token`-
+> Header zurück.
+
+CSRF (Cross-Site Request Forgery) liegt vor, wenn eine andere Website den Browser eines eingeloggten Benutzers dazu bringt, eine Anfrage an deine App zu senden. Die Verteidigung ist ein geheimes Token in jedem Formular, genau wie Djangos `{% csrf_token %}`. Die CSRF-Middleware liegt in `rustango::forms::csrf` (hinter dem `csrf`-Feature, das durch das `admin`-Feature automatisch aktiviert wird):
+
+```rust
+use rustango::forms::csrf;
+
+let app = Router::new()
+    .route("/contact", get(form).post(submit))
+    .layer(csrf::layer());
+```
+
+`csrf::layer()` baut den Layer mit sinnvollen Standardwerten; `csrf::with_config(CsrfConfig)` erlaubt dir, die Cookie-/Header-Namen und das `Secure`-Flag zu überschreiben. In Templates gibt `{{ csrf_token }}` das rohe Token und `{{ csrf_input }}` ein fertiges verstecktes `<input>` — platziere eines in jedem Formular. Es verwendet das Double-Submit-Cookie-Muster: bei unsicheren Methoden (POST, PUT, PATCH, DELETE) prüft der Layer den `X-CSRF-Token`-Header (oder das `_csrf`-Formularfeld) gegen das `rustango_csrf`-Cookie; eine Nichtübereinstimmung gibt `403 Forbidden` zurück.
+
+**Collector-Endpunkte ausnehmen.** `CsrfConfig::exempt_prefix("/path")` (wiederholbar) überspringt die CSRF-Durchsetzung für unsichere Methoden bei Anfragen, deren Pfad mit dem angegebenen Präfix beginnt. Das ist für Append-only-, zustandslose Endpunkte gedacht, die per `navigator.sendBeacon` angesprochen werden — z. B. ein Analytics-Collector — die keinen `X-CSRF-Token`-Header setzen können und, wenn die Seite aus einem CDN-Cache ausgeliefert wird, der `Set-Cookie` entfernt, möglicherweise gar kein CSRF-Cookie mitführen. Halte Präfixe eng und nimm niemals etwas aus, das Auth-Zustand liest oder schreibt.
+
+Der Auto-Admin aktiviert CSRF standardmäßig bei jeder Mutation, und es gibt keine Möglichkeit, sich davon abzumelden.
+
+---
+
+## XSS verhindern
+
+XSS (Cross-Site Scripting) tritt auf, wenn Benutzereingaben als HTML gerendert werden und als Code im Browser einer anderen Person laufen. Die Lösung ist, jede Benutzereingabe zu escapen, bevor sie die Seite erreicht. **Rustango** löst das auf zwei Wegen:
+
+**1. Tera-Template-Auto-Escape** — Tera ist **Rustango**s Template-Engine (wie Django-Templates oder Blade). Jedes `{{ var }}` wird automatisch HTML-escapt. Verwende `{{ var | safe }}`, um dich abzumelden — selten und gefährlich, also tue das nur für HTML, dem du vollständig vertraust.
+
+**2. Manueller Escape-Helper** — für den Fall, dass du HTML in Rust-Code statt in einem Template baust:
+
+```rust
+use rustango::text::html_escape;
+
+let safe = html_escape(user_input);
+// "<script>" → "&lt;script&gt;"
+// "a & b" → "a &amp; b"
+```
+
+Ersetzt `&`, `<`, `>`, `"`, `'`. Geeignet für HTML-Elementinhalte + doppelt-quotierte Attribute.
+
+Für CSP-basierte XSS-Verteidigung siehe [Security-Header setzen](#setting-security-headers).
+
+---
+
+## SQL-Injection verhindern
+
+SQL-Injection tritt auf, wenn Benutzereingaben direkt in einen SQL-String eingefügt werden und die Query verändern. **Rustango**s ORM verhindert das durch Design: es verwendet überall sqlx-Parameter-Binding — jeder Wert wird als `$1, $2, ...`-Platzhalter gesendet, niemals in den Query-Text eingeklebt. (sqlx ist die zugrunde liegende Datenbankbibliothek.) **Du kannst über die ORM-API nicht versehentlich Benutzereingaben in SQL konkatenieren.**
+
+Es gibt zwei Stellen, bei denen du weiterhin vorsichtig sein solltest:
+
+**1. Tabellen- und Spaltennamen in `bulk_actions`:**
+
+Platzhalter schützen Werte, können aber keinen Bezeichner (einen Tabellen- oder Spaltennamen) tragen, also benötigen diese ihren eigenen Schutz. Der Bulk-Action-Runner klebt niemals rohe, benutzergelieferte Tabellen-/Spaltennamen in SQL. Intern validiert er jeden Bezeichner (ein crate-privates
+`validate_ident`, das `"`, `` ` ``, `\0`, `\n`, `\r`, `\`, `;`,
+Leerzeichen und Steuerzeichen ablehnt) und quotet ihn dann per `dialect.quote_ident()`,
+bevor die Anweisung gebaut wird. Dieser Schutz läuft für dich — du rufst ihn nicht
+selbst auf.
+
+**2. Der Raw-SQL-Notausgang:**
+
+Wenn du auf rohes `sqlx` heruntergehst, binde jeden *Wert* als Parameter und
+füge niemals einen *Bezeichner* (Tabellen- oder Spaltenname), der aus
+Benutzereingaben stammte, in den Query-String ein — Platzhalter können keine Bezeichner tragen:
+
+```rust
+// ✅ values go through bound placeholders
+sqlx::query("SELECT * FROM posts WHERE id = $1")
+    .bind(1).fetch_all(&pool).await?;
+
+// ❌ NEVER interpolate a user-supplied identifier into the SQL string
+let sql = format!("SELECT * FROM \"{user_table}\" WHERE id = $1");
+sqlx::query(&sql).bind(1).fetch_all(&pool).await?;
+```
+
+---
+
+## Benutzer authentifizieren
+
+Authentifizierung ist die Art, wie du bestätigst, wer eine Anfrage stellt. **Rustango** bringt drei fertige Backends mit (Basic Auth, API-Keys und JWTs) und lässt dich eigene schreiben — ganz ähnlich wie Djangos Authentifizierungs-Backends. Du hängst sie an Routen an, und Anfragen ohne ein erkanntes Credential erhalten ein `401`.
+
+> **Admin-SSO.** Um Betreibern zu erlauben, sich mit einem externen IdP (Google, Microsoft/Azure AD, GitHub oder einem beliebigen OpenID-Connect-Provider) statt mit einem Passwort im Admin anzumelden, aktiviere das `admin-sso`-Feature — siehe den [SSO-Leitfaden](sso.md). Provider werden **im Admin-UI als Zeilen verwaltet** (mehrere pro Surface; pro Tenant oder ein gemeinsames Set über Tenants hinweg), wobei das Client-Secret **verschlüsselt gespeichert** wird. Es ist Link-to-existing (die verifizierte IdP-E-Mail muss mit einem Admin-Benutzer übereinstimmen; kein Auto-Provisioning) und verwendet die bestehende Session wieder.
+
+### Drei fertige Backends
+
+```rust
+use rustango::tenancy::auth_backends::{ModelBackend, ApiKeyBackend, JwtBackend};
+use rustango::tenancy::middleware::{RouterAuthExt, CurrentUser};
+use std::sync::Arc;
+
+let backends = vec![
+    Arc::new(ModelBackend) as _,                   // Authorization: Basic <b64>
+    Arc::new(ApiKeyBackend) as _,                   // Authorization: Bearer <prefix>.<secret>
+    Arc::new(JwtBackend::new(secret)) as _,         // Authorization: Bearer <jwt>
+];
+
+let app = Router::new()
+    .route("/me", get(profile))
+    .require_auth(backends.clone(), pool.clone())   // 401 if no backend recognizes
+    .route("/posts/new", post(create_post))
+    .require_perm("post.add", pool.clone())         // gate by codename
+    .require_auth(backends, pool);
+```
+
+Die Middleware probiert jedes Backend der Reihe nach. Das erste, das erfolgreich ist, gewinnt; das erste, das einen harten Fehler zurückgibt, stoppt die Kette.
+
+### Ein eigenes Backend schreiben
+
+```rust
+use rustango::tenancy::auth_backends::{AuthBackend, AuthUser, AuthError};
+use async_trait::async_trait;
+
+pub struct OAuthBackend { /* ... */ }
+
+#[async_trait]
+impl AuthBackend for OAuthBackend {
+    async fn authenticate(&self, parts: &Parts, pool: &rustango::sql::Pool)
+        -> Result<Option<AuthUser>, AuthError>
+    {
+        // Read your custom header, validate, look up the user
+        Ok(None)  // means: not my request, try next backend
+    }
+}
+```
+
+---
+
+## Passwörter hashen und prüfen
+
+Speichere Passwörter niemals als Klartext. Hashe sie bei der Registrierung mit `hash` und vergleiche beim Login den Versuch mit `verify`. Nutze `strength_score`, um schwache Passwörter abzulehnen, bevor du sie überhaupt hashst.
+
+```rust
+use rustango::passwords::{hash, verify, strength_score, StrengthIssue};
+
+// Signup
+let issues = strength_score(&new_password);
+if !issues.is_empty() {
+    return Err(format!("password too weak: {issues:?}"));
+}
+let hashed = hash(&new_password)?;
+
+// Login
+let ok = verify(&attempted, &user.password_hash)?;
+```
+
+Das Hashing verwendet **argon2id** (der von OWASP empfohlene Standard seit 2023 — es widersteht GPU-Cracking besser als bcrypt). Hashes werden im PHC-String-Format gespeichert, sodass du Parameter später ändern kannst, ohne alte Hashes zu brechen.
+
+Die eingebaute **Stärkeprüfung** ist bewusst minimal. Für ernsthafte Deployments prüfe Passwörter zusätzlich gegen die HIBP- / pwned-passwords-API, um bekanntermaßen geleakte abzulehnen.
+
+> **Vertiefung:** [Passwörter](auth-passwords.md) — argon2id-Interna, automatisches Salting, timing-sichere Logins (`verify_dummy`) und wo der Hash liegt. Sobald authentifiziert, übergib an eine [Session](auth-sessions.md) (Browser) oder ein [JWT](auth-jwt.md) (API).
+
+---
+
+## JWTs ausstellen und erneuern
+
+Ein JWT (JSON Web Token) ist ein signiertes Token, das ein Client sendet, anstatt sich jedes Mal einzuloggen. `JwtLifecycle` handhabt den gesamten Ablauf: ein kurzlebiges Access-Token plus ein länger lebendes Refresh-Token, mit eingebautem Verify, Refresh und Revoke.
+
+```rust
+use rustango::tenancy::jwt_lifecycle::{JwtLifecycle, JwtTokenPair, JwtIssueError};
+use serde_json::json;
+
+let jwt = JwtLifecycle::new(secret)
+    .with_access_ttl(900)                         // 15 min
+    .with_refresh_ttl(7 * 86400);                 // 7 days
+```
+
+### Ein Token mit benutzerdefinierten Claims ausstellen (kein DB-Lookup beim Verify)
+
+```rust
+let pair = jwt.issue_pair_with(user_id, json!({
+    "roles":  ["admin", "editor"],
+    "tenant": "acme",
+    "scope":  "read:posts write:posts",
+    "email":  "alice@example.com",
+}).as_object().unwrap().clone())?;
+```
+
+„Claims" sind die Schlüssel/Wert-Fakten, die du in das Token einbettest (Rollen, Tenant und so weiter); der Client sendet sie zurück und du liest sie, ohne die Datenbank anzusprechen. Reservierte Claim-Namen (`sub`, `exp`, `jti`, `typ`) werden vom Framework verwendet und dürfen nicht in deinen benutzerdefinierten Claims auftauchen — der Versuch gibt `JwtIssueError::ReservedClaim` zurück.
+
+### Ein Token verifizieren
+
+```rust
+let claims = jwt.verify_access(&access_token)
+    .ok_or(StatusCode::UNAUTHORIZED)?;
+
+let roles: Vec<String> = claims.get_custom("roles").unwrap_or_default();
+let tenant: String = claims.get_custom("tenant").unwrap_or_default();
+```
+
+### Ein Token erneuern (behält deine benutzerdefinierten Claims)
+
+```rust
+let new_pair = jwt.refresh(&refresh_token)
+    .ok_or(StatusCode::UNAUTHORIZED)?;
+// new_pair has the same roles + scope + tenant
+```
+
+Die JTI des alten Refresh-Tokens (seine eindeutige ID) wird zu einer Blacklist hinzugefügt, sodass es nicht wiederverwendet werden kann — das blockiert Replay-Angriffe, bei denen ein gestohlenes altes Token erneut gesendet wird.
+
+### Erneuern mit neu geprüften Berechtigungen
+
+```rust
+// returns Result<Option<JwtTokenPair>, JwtIssueError>:
+// Err on a reserved-claim collision, Ok(None) on an invalid/expired refresh.
+let new_pair = jwt.refresh_with(&refresh_token, json!({
+    "roles": ["viewer"],     // role was demoted since login
+    "tenant": "acme",
+}).as_object().unwrap().clone())?
+    .ok_or(StatusCode::UNAUTHORIZED)?;
+```
+
+### Ein Token widerrufen
+
+```rust
+jwt.revoke(&access_token);     // adds JTI to blacklist
+jwt.revoke(&refresh_token);
+```
+
+Die standardmäßige In-Memory-Blacklist (`InMemoryJtiStore`) räumt abgelaufene Einträge von selbst aus, aber sie lebt in einem Prozess und vergisst bei jedem Neustart jeden Widerruf. Für Multi-Prozess-Deployments installiere einen gemeinsamen, dauerhaften Store über `JwtLifecycle::new(secret).with_jti_store(store)` — `store` ist ein beliebiger `Arc<dyn JtiStore>` (zum Beispiel ein Redis- oder DB-gestützter). Ohne einen gemeinsamen Store kann ein Token, das du auf einer Replica widerrufst, auf einer anderen weiterhin abgespielt werden, bis es abläuft.
+
+> **Vertiefung:** [JWT-Auth-API](auth-jwt-api.md) — der eingebaute `/api/auth/login|refresh|logout|me`-Router, gleitendes Refresh und der JTI-Widerrufs-Store. Für ein einzelnes selbstverwaltetes Token siehe [JWT (standalone)](auth-jwt.md). Um Browser-/API-Routen per Login zu gaten, siehe [Access-Decorators](auth-decorators.md).
+
+---
+
+## Mit API-Keys authentifizieren
+
+API-Keys erlauben Skripten und Services die Authentifizierung ohne Benutzername, Passwort oder Session — praktisch für Machine-to-Machine-Zugriff. Du generierst einen Key, zeigst ihn dem Benutzer einmal und speicherst nur seinen Präfix und Hash.
+
+```rust
+use rustango::api_keys::{generate_key, verify_key, split_token};
+
+// Issuance
+let (full_token, prefix, hash) = generate_key()?;
+// Format: {8-char hex prefix}.{32-char hex secret}
+// Show full_token to the user once. Store prefix + hash in your DB.
+
+// Verification on each request
+let (prefix, secret) = split_token(&inbound_header)
+    .ok_or(StatusCode::UNAUTHORIZED)?;
+let row = lookup_by_prefix(prefix).await?;
+if !verify_key(secret, &row.hash)? {
+    return Err(StatusCode::UNAUTHORIZED);
+}
+```
+
+Diese Keys funktionieren direkt mit dem Multi-Tenancy-`ApiKeyBackend` — beide verwenden dasselbe `{prefix}.{secret}`-Format mit argon2id-gehashten Secrets, sodass ein hier ausgestellter Key dort ohne zusätzliche Arbeit authentifiziert.
+
+---
+
+## Zwei-Faktor-Authentifizierung hinzufügen (TOTP)
+
+TOTP ist der 6-stellige Code aus einer Authenticator-App — ein zweiter Faktor zusätzlich zum Passwort. Du generierst pro Benutzer ein Secret, zeigst es als QR-Code zum Einrichten an und verifizierst dann bei jedem Login den eingetippten Code. Es folgt dem RFC-6238-Standard.
+
+```rust
+use rustango::totp::{TotpSecret, otpauth_url, verify};
+
+// Enrollment
+let secret = TotpSecret::generate();                           // 20 random bytes
+user.totp_secret = secret.to_base32();                          // store in DB
+let qr_url = otpauth_url("MyApp", &user.email, &secret);        // encode as QR
+
+// Verification on login
+let secret = TotpSecret::from_base32(&user.totp_secret).unwrap();
+if !verify(&secret, &user_supplied_code, 30, 6, 1) {            // 6 digits, ±30s drift
+    return Err("bad TOTP code");
+}
+```
+
+Funktioniert mit Google Authenticator, Authy, 1Password, Bitwarden und anderen Standard-Authenticator-Apps.
+
+**Recovery-Codes** (einmalige Backup-Codes für den Fall, dass ein Benutzer sein Telefon verliert) werden noch nicht mitgeliefert. Das gängige Muster ist, 8–10 gehashte Codes pro Benutzer zu speichern und einen bei jeder Verwendung zu verbrauchen.
+
+---
+
+## Signierte URLs versenden (Magic Links)
+
+Eine signierte URL trägt eine manipulationssichere Signatur, sodass du ihr ohne Session vertrauen kannst — perfekt für Magic-Link-Logins, Passwort-Resets und zeitlich begrenzte Download-Links. Du `sign`st eine URL (optional mit einem Ablaufdatum) und `verify`st sie, wenn der Benutzer klickt. (Laravel nennt diese „signed routes".)
+
+```rust
+use rustango::signed_url::{sign, verify, SignedUrlError};
+use std::time::Duration;
+
+// Issue a 1-hour magic-link login URL
+let url = sign(
+    "https://app.example.com/auth/login?email=alice@x.com",
+    secret,
+    Some(Duration::from_secs(3600)),
+);
+// Send via email...
+
+// On the callback handler
+match verify(&incoming_url, secret) {
+    Ok(()) => { /* identity confirmed */ }
+    Err(SignedUrlError::Expired) => { /* prompt to request a new link */ }
+    Err(SignedUrlError::InvalidSignature) => { /* tampered — log + 401 */ }
+    Err(_) => { /* malformed */ }
+}
+```
+
+Häufige Einsatzzwecke:
+- Magic-Link-Login (eine einmalige URL per E-Mail versenden, statt nach einem Passwort zu fragen)
+- Passwort-Reset-Bestätigung
+- Zeitlich begrenzte Datei-Downloads
+- „Hier klicken, um deine E-Mail zu verifizieren"-Links
+- Abmelde-Links (keine Auth nötig; die URL selbst beweist die Absicht)
+
+Vor dem Signieren werden die Query-Parameter in eine feste Reihenfolge sortiert, sodass ein Angreifer sie nicht umordnen kann (zum Beispiel durch Verschieben von `?expires=...`), um zu ändern, was die Signatur abdeckt, und einen gültig aussehenden Link zu fälschen.
+
+> Vertiefung: [Account-Flows](auth-flows.md) baut Passwort-Reset, E-Mail-Verifizierung und Magic-Link-Login auf diesem Signed-URL-Primitive auf.
+
+---
+
+## Eingehende Webhooks verifizieren
+
+Ein Webhook ist ein HTTP-Callback, den ein anderer Service dir sendet (eine Zahlung war erfolgreich, ein Push ist passiert). Prüfe immer seine Signatur, damit du weißt, dass er wirklich von diesem Service kam und der Body nicht verändert wurde. `verify_signature` handhabt die gängigen Formate.
+
+```rust
+use rustango::webhook::{verify_signature, SignatureFormat};
+
+async fn handle_stripe_webhook(headers: HeaderMap, body: Bytes) -> impl IntoResponse {
+    let signature = headers.get("stripe-signature")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    if !verify_signature(SignatureFormat::HexSha256, secret, &body, signature) {
+        return StatusCode::UNAUTHORIZED;
+    }
+    // ... process the verified payload
+    StatusCode::OK
+}
+```
+
+| Format | Verwendet von |
+|---|---|
+| `HexSha256WithPrefix` | GitHub (`sha256=<hex>`) |
+| `HexSha256` | Slack, rohe HMAC-Provider |
+| `Base64Sha256` | Stripe, AWS SNS |
+
+Der Signaturvergleich ist konstant-zeitlich, das heißt, er dauert immer gleich lang, egal ob die Vermutung richtig oder falsch ist. Das stoppt Timing-Angriffe, bei denen ein Angreifer winzige Antwortzeit-Unterschiede misst, um das Secret Zeichen für Zeichen zu erraten.
+
+---
+
+## Secrets aus deinen Logs heraushalten
+
+Geloggte URLs können Passwörter und Tokens leaken, die in Query-Strings auftauchen. `AccessLogLayer` maskiert automatisch bekannte Credential-Parameter, bevor die Log-Zeile geschrieben wird (PII = personenbezogene Daten).
+
+```rust
+let app = router.access_log(AccessLogLayer::default());
+```
+
+Standardmäßig werden Werte für diese Query-Parameter durch `[redacted]` ersetzt:
+`password`, `passwd`, `token`, `secret`, `api_key`, `apikey`, `access_token`, `refresh_token`, `signature`, `auth`.
+
+Zur Liste hinzufügen:
+
+```rust
+let layer = AccessLogLayer::default()
+    .redact_additional("session_id")
+    .redact_additional("private_key");
+```
+
+Die gesamte Liste ersetzen:
+
+```rust
+let layer = AccessLogLayer::default()
+    .redact(vec!["only_this".into()]);
+```
+
+Hinweis: Dies redaktiert nur **Query-Strings**. Um Request-Bodies oder Header zu bereinigen, filtere an der Quelle mit `tracing::Subscriber`.
+
+---
+
+## Anfragen über Services hinweg nachverfolgen
+
+Eine Request-ID versieht jede Log-Zeile für eine Anfrage mit derselben ID, sodass du dieser Anfrage über Handler hinweg — und über Services hinweg — folgen kannst. `RequestIdLayer` fügt jeder Anfrage eine hinzu.
+
+```rust
+let app = router.request_id(RequestIdLayer::default());
+```
+
+Es verwendet eine eingehende `X-Request-Id` wieder (sodass verkettete Services eine ID teilen) oder generiert eine frische 22-Zeichen-Base64-ID. Eingehende IDs werden zuerst validiert — alles mit Steuerzeichen, Zeilenumbrüchen, Null-Bytes oder länger als 128 Zeichen wird abgelehnt, was Header-Injection-Angriffe blockiert.
+
+In Handlern:
+
+```rust
+async fn handler(id: rustango::request_id::RequestId) -> String {
+    tracing::info!(req_id = %id.0, "handling /me");
+    format!("req {}", id.0)
+}
+```
+
+In einem Zero-Trust-Setup, in dem du IDs, die von Upstream-Services gesendet werden, nicht vertraust, erstelle immer deine eigene:
+
+```rust
+router.request_id(RequestIdLayer::always_generate());
+```
+
+---
+
+## Secrets verwalten
+
+Hardcode Secrets (Datenbank-Passwörter, API-Keys) niemals in deinem Quellcode. Lies sie zur Laufzeit über das `Secrets`-Trait, das darüber abstrahiert, wo sie tatsächlich liegen. (Ein „Trait" ist Rusts Version eines Interface.) Das eingebaute `EnvSecrets` liest aus Umgebungsvariablen.
+
+```rust
+use rustango::secrets::{Secrets, EnvSecrets, BoxedSecrets};
+use std::sync::Arc;
+
+// Env vars (with optional prefix)
+let secrets: BoxedSecrets = Arc::new(EnvSecrets::with_prefix("MYAPP_"));
+
+let db_pwd = secrets.require("DB_PASSWORD").await?;       // reads MYAPP_DB_PASSWORD
+let redis_url = secrets.get("REDIS_URL").await?;          // None when unset
+```
+
+Um Secrets aus Vault, AWS Secrets Manager oder GCP Secret Manager zu ziehen, implementiere das Trait selbst — es ist nur eine async Methode.
+
+---
+
+## Vor dem Deploy auditieren
+
+Bevor du in Produktion gehst, führe das eingebaute Audit aus. Es fängt häufige Fehlkonfigurationen ab — wie ein fehlendes oder zu kurzes Signing-Secret — die du nicht in der Produktion entdecken möchtest.
+
+```bash
+manage check --deploy
+```
+
+Immer aktive Prüfungen (laufen mit oder ohne `--deploy`):
+- ✅ Modelle im Inventory registriert
+- ✅ DB erreichbar (`SELECT 1`)
+- ✅ Migrationen auf der Platte für registrierte Modelle
+
+Zusätzliche `--deploy`-Prüfungen (Produktionshärtung):
+- ✅ `RUSTANGO_ENV` ist `prod` oder `production`
+- ✅ `RUSTANGO_SESSION_SECRET` gesetzt und ≥ 32 Bytes (der HMAC-Schlüssel für Cookie- + JWT-Signierung — `SECRET_KEY` wird vom Framework **nicht** gelesen), ohne verbliebenen Scaffolder-Platzhalter
+- ✅ `DATABASE_URL` gesetzt (und warnt, wenn es auf localhost zeigt)
+- ⚠️ `RUSTANGO_APEX_DOMAIN` / `RUSTANGO_BIND` Plausibilitätswarnungen für Tenancy + Nicht-Loopback-Binding
+
+Gibt bei jedem Befund auf **Error-Level** einen Exit-Code ungleich null zurück (gut für CI-Gates). Warnungen lösen kein Fehlschlagen aus, erscheinen aber in der Ausgabe.
+
+Für Prüfungen jenseits des Mitgelieferten erweitere mit benutzerdefiniertem Code in deinem `manage`-Binary, bevor du an `manage::run` weiterleitest.
+
+---
+
+## Was NOCH nicht mitgeliefert wird
+
+Ein paar End-to-End-Flows müssen noch aus den untenstehenden Primitiven zusammengeklebt werden:
+
+- **Passwort-Reset + E-Mail-Verifizierung** — die Token-Issue-/Verify-Helper existieren (`auth_flows::confirm_password_reset_pool`, plus E-Mail-Verifizierungs-Round-Trips) und die E-Mail-Pipeline wird separat mitgeliefert, aber es gibt keinen einzelnen vorgefertigten View- + E-Mail- + Validate-Zyklus, der für dich verdrahtet ist.
+- **PII-Redaktion von Request-Body / Headern** in `access_log` — feldbasierte Log-Redaktion existiert (siehe [Secrets aus deinen Logs heraushalten](#keeping-secrets-out-of-your-logs)), aber keine automatische Bereinigung des Request-Bodys oder der Header.
+
+Bereits mitgeliefert (greife nicht zu einem Workaround):
+
+- **OAuth2 / OIDC Social Login** — `oauth2::providers` bringt Google-, GitHub-, Microsoft-, GitLab- und Discord-Helper mit (plus `OAuth2Provider::from_discovery` für jeden OIDC-Provider), und `oauth2::router::oauth2_router` mountet die Login- + Callback-Routen, erstellt den Benutzerdatensatz und setzt das Session-Cookie.
+- **Sperre pro Account** — `rustango::account_lockout::Lockout` (cache-gestützt; `is_locked` / `record_failure` / `clear`, konfigurierbare `max_attempts` + `lockout_duration`).
+- **CSP-Report-Endpunkt** — `security_headers::csp_report_router(path)` + `SecurityHeadersLayer::csp_report_uri(uri)`.
+- **Verteiltes Rate Limiting** — `rate_limit_cache::CacheRateLimitLayer` (siehe [Anfragen per Rate Limiting drosseln](#rate-limiting-requests)).
+
+Bis die nicht mitgelieferten Flows landen, klebe sie aus den obigen Primitiven zusammen (`signed_url::sign` für Passwort-Reset-Tokens, die E-Mail-Pipeline für die Zustellung usw.).
+
+---
+
+## Siehe auch
+
+- [Middleware](middleware.md) — wie die Sicherheits-Layer angehängt werden, ihre Reihenfolge und der vollständige Katalog.
+- [Authentifizierung](auth-passwords.md) — Passwörter, Sessions, JWTs, API-Keys, HMAC, Auth-Backends und Account-Flows, jeweils in der Tiefe.
+- [API-Konventionen](api-conventions.md) — die Fehlertyp- und Rückgabetyp-Regeln hinter diesen APIs.

--- a/docs/de/serializers.md
+++ b/docs/de/serializers.md
@@ -1,0 +1,558 @@
+# Serializer
+
+Ein Serializer verwandelt eine Modellinstanz in eine typisierte, JSON-fertige
+Form — und auf dem Rückweg wieder zurück. Er ist **Rustango**s Antwort auf einen
+`ModelSerializer` des Django REST Framework oder eine Laravel-API-Resource:
+Deklariere ein Struct, annotiere seine Felder, und du bekommst kontrollierte
+Ausgabe (umbenennen, verbergen, berechnen, verschachteln), Validierung auf Feld-
+und Objektebene sowie eine saubere Anbindung an ViewSets.
+
+Eine Sache solltest du dir gleich zu Beginn einprägen, denn sie unterscheidet
+sich von DRF: ein Rustango-Serializer **formt Daten, er persistiert sie nicht**.
+Es gibt kein `serializer.save()`, das in die Datenbank schreibt — das erledigt
+das ORM. Der Serializer bildet ein Modell auf JSON ab (`from_model` →
+`to_value`), deklariert, welche Felder schreibbar sind, und validiert. Du
+kombinierst ihn mit dem ORM und den ViewSets, statt Schreibvorgänge *durch* ihn
+zu leiten.
+
+> **Neu bei einem Begriff hier?** — *serializer*, *model*, *ORM*, *DRF*? Das
+> [Glossar](glossary.md) erklärt jeden Begriff in klarer Sprache.
+
+[![Ein Rustango-Serializer: read_only, source-Umbenennung, ein berechnetes Methodenfeld, ein verschachtelter FK und ein write_only-Feld — deklariert auf einem einzigen Struct](img/serializers.png)](img/serializers.png)
+
+> **Quelle:** `rustango::serializer` (`ModelSerializer`, `#[derive(Serializer)]`,
+> die `#[serializer(...)]`-Feldattribute) — hinter dem `serializer`-Feature
+> (standardmäßig aktiv).
+>
+> **Lauffähige Versionen:** der minimale Serializer ist Teil des getesteten
+> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog/src/post_serializer.rs)-Beispiels,
+> und das vollständige Verhalten des Derive wird durch die eigenen Unit-Tests des
+> Frameworks abgedeckt — `crates/rustango/tests/serializer_derive.rs` und
+> `serializer_cross_validate.rs`. Wenn ein Snippet seltsam aussieht, vergleiche
+> es damit.
+
+---
+
+## Inhaltsverzeichnis
+- [Schnellstart](#quick-start) · [Der `ModelSerializer`-Trait](#the-modelserializer-trait)
+- [Feldattribute](#field-attributes) — die vollständige Referenz
+- [Berechnete Felder](#computed-fields) · [Verschachtelte Serializer](#nested-serializers) · [Sammlungen](#collections-many) · [Slug-Felder](#slug-related-fields)
+- [Validierung](#validation) · [Unique-together-Validierung](#unique-together-validation)
+- [Hyperlink-Ausgabe](#hyperlinked-output) · [Listen serialisieren](#serializing-lists)
+- [Einen Serializer mit einem ViewSet verwenden](#using-a-serializer-with-a-viewset) · [Validierung in einem eigenen Handler](#validating-in-a-custom-handler)
+- [OpenAPI](#openapi-schemas) · [Scaffolding](#scaffolding) · [Feinheiten & Grenzen](#tweaks-and-current-limits)
+
+---
+
+## Schnellstart
+
+Ein Serializer ist ein einfaches Struct mit `#[derive(Serializer)]` und einem
+`#[serializer(model = …)]`, das auf das Modell zeigt, von dem es abbildet. Es
+benötigt zwei begleitende Derives: `serde::Deserialize` (damit es auch
+eingehendes JSON parsen kann) und `Default` (damit ausgeschlossene/optionale
+Felder initialisiert werden können).
+
+```rust
+use rustango::Serializer;
+use rustango::serializer::ModelSerializer;
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: Auto<i64>,
+    pub title: String,
+
+    #[serializer(source = "body")]      // JSON key `content`, read from model.body
+    pub content: String,
+
+    #[serializer(read_only)]            // in output, never accepted on write
+    pub published_at: Auto<DateTime<Utc>>,
+}
+```
+
+Verwende ihn:
+
+```rust
+let post = Post::objects().find(42, &pool).await?.expect("post 42");
+
+let one  = PostSerializer::from_model(&post).to_value();   // a JSON object
+let many = PostSerializer::many_to_value(&posts);          // a JSON array
+```
+
+`from_model` klont die Felder des Modells in das Struct (unter Beachtung der
+Attribute weiter unten); `to_value` serialisiert es (überspringt
+`write_only`-Felder). Das ist die gesamte Kernschleife.
+
+---
+
+## Der `ModelSerializer`-Trait
+
+`#[derive(Serializer)]` implementiert `ModelSerializer` (plus ein
+`serde::Serialize`, das `write_only` respektiert, und eine `OpenApiSchema`-Impl
+unter dem `openapi`-Feature). Die Trait-Oberfläche:
+
+| Methode | Signatur | Anmerkungen |
+|---|---|---|
+| `from_model` | `fn(model: &Self::Model) -> Self` | Bildet ein Modell → Serializer ab. Generiert; nicht überschreibbar. |
+| `to_value` | `fn(&self) -> serde_json::Value` | Serialisiert zu JSON (überspringt `write_only`). Überschreibbar. |
+| `many` | `fn(&[Self::Model]) -> Vec<Self>` | Batch-`from_model`. Überschreibbar. |
+| `many_to_value` | `fn(&[Self::Model]) -> serde_json::Value` | Batch → JSON-Array. Überschreibbar. |
+| `writable_fields` | `fn() -> &'static [&'static str]` | Serializer-Feldnamen, die beim Schreiben akzeptiert werden (schließt `read_only`, `skip`, `method`, `nested`, `many`, `slug` aus). |
+| `writable_source_fields` | `fn() -> &'static [&'static str]` | Die **Modellspalten** der schreibbaren Felder (`source`-aufgelöst). Der Schreibpfad des ViewSet persistiert nur diese. Generiert. |
+| `from_writable_json` | `fn(&Value) -> Result<Self, FormErrors>` | Baut eine Instanz aus einem Request-Body und nutzt dabei nur die schreibbaren Felder (der Rest bekommt Default-Werte); Parse-Fehler pro Feld → `FormErrors`. Generiert. |
+| `validate` | `fn(&self) -> Result<(), FormErrors>` | Führt die deklarierten Validatoren pro Feld + feldübergreifend aus. No-op, wenn keine deklariert sind; überschreibbar. |
+
+Es gibt bewusst **kein** `create` / `update` / `save` auf dem Trait —
+Schreibvorgänge laufen über das ORM (`model.save(&pool)`). Wenn ein Serializer
+in ein [ViewSet](viewsets.md) eingebunden ist, nutzt der Create-/Update-Pfad
+`from_writable_json()` + `validate()` + `writable_source_fields()`, um den
+Request zu validieren und zu filtern, bevor gespeichert wird.
+
+---
+
+## Feldattribute
+
+Alles wird über `#[serializer(...)]` an jedem Feld gesteuert. Der vollständige
+Satz:
+
+| Attribut | `from_model` tut | In JSON-Ausgabe? | Schreibbar? |
+|---|---|---|---|
+| *(keins)* | bildet vom Modell ab | ja | ja |
+| `read_only` | bildet vom Modell ab | ja | **nein** |
+| `write_only` | `Default::default()` | **nein** | ja |
+| `source = "x"` | bildet von `model.x` ab (benennt um) | ja | ja |
+| `skip` | `Default::default()` — setze es selbst | ja | nein |
+| `method = "fn"` | ruft `Self::fn(&model)` auf | ja | nein |
+| `nested` | folgt einem FK → `Child::from_model(parent)` | ja | nein |
+| `nested(strict)` | dasselbe, panickt aber, wenn der FK nicht geladen wurde | ja | nein |
+| `many = ChildSer` | initialisiert `Vec::new()`; füllt via `set_<field>(&[Child])` | ja | nein |
+| `slug = "name"` | klont `model.<source>.value()?.name` | ja | nein |
+| `validate = "fn"` | Validator pro Feld, ausgeführt von `validate(&self)` | n. v. | n. v. |
+
+**Gegenseitig ausschließend** (Compile-Fehler bei Kombination): `read_only` +
+`write_only`; `method` + `source`; `slug` + eines von `method` / `nested` /
+`many`.
+
+**Deklarative Validatoren.** `max_length = N`, `min_length = N`, `min = N` und
+`max = N` fügen einem Feld Schreibzeit-Validierung hinzu, ohne dessen
+Ausgabeform zu ändern (und ein Feld ohne diese erbt die Grenzen des Modells).
+Siehe [Validierung](#validation).
+
+`write_only` ist für rein eingehende Daten (ein Passwort, ein Einmal-Token):
+vorhanden in `writable_fields()`, fehlt in der Ausgabe. `skip` ist das
+gegenteilige Schlupfloch — das Feld wird nicht aus dem Modell gelesen und ist
+nicht schreibbar, du befüllst es also nach `from_model` von Hand (z. B. eine
+Liste von Tag-IDs, die du separat holst).
+
+> **`write_only` transformiert den Wert nicht.** Ein `write_only`-Feld wird beim
+> Schreiben akzeptiert und **wortwörtlich** persistiert — der Serializer hasht
+> oder verschlüsselt es nie. Bei einem Passwort hashe es selbst (siehe
+> [Passwörter](auth-passwords.md)) vor `save()`; `read_only`-Felder werden
+> umgekehrt beim Schreiben stillschweigend ignoriert statt abgelehnt.
+
+---
+
+## Berechnete Felder
+
+`method = "fn"` ist DRFs `SerializerMethodField`. Deklariere das Feld und
+schreibe dann eine zugehörige Funktion `fn(&Model) -> FieldType`; sie wird
+während `from_model` aufgerufen:
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub title: String,
+    #[serializer(method = "excerpt")]
+    pub excerpt: String,
+}
+
+impl PostSerializer {
+    fn excerpt(model: &Post) -> String {
+        model.body.chars().take(80).collect::<String>() + "…"
+    }
+}
+```
+
+Berechnete Felder sind ausgabeseitig (ausgeschlossen aus `writable_fields()`).
+
+---
+
+## Verschachtelte Serializer
+
+`nested` bettet einen weiteren Serializer ein, indem es einem geladenen
+Fremdschlüssel folgt. Der Typ des Feldes ist der Kind-Serializer:
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Comment)]
+pub struct CommentSerializer {
+    pub id: Auto<i64>,
+    pub body: String,
+    #[serializer(nested)]               // reads the loaded `author` FK
+    pub author: AuthorBrief,
+}
+```
+
+Der FK muss bereits geladen sein (via `select_related` / ein Eager-Fetch). Wenn
+er **nicht** geladen wurde, fällt das Feld auf `Default::default()` zurück,
+statt zu panicken — die Produktion degradiert bei einem fehlenden Prefetch
+elegant. In Tests nutze `#[serializer(nested(strict))]`, um diesen Fallback in
+ein Panic zu verwandeln, damit ein weggelassener Prefetch erkannt wird. Zeige mit
+`source` auf einen anders benannten FK:
+
+```rust
+#[serializer(nested, source = "owner")]
+pub author: AuthorBrief,
+```
+
+Verschachtelte Felder sind in der Ausgabeform **schreibgeschützt** —
+schreibbare verschachtelte Objekte werden noch nicht unterstützt (siehe
+[Grenzen](#tweaks-and-current-limits)).
+
+---
+
+## Sammlungen (`many`)
+
+Für 1:n- oder M2M-Kinder deklariert `many = ChildSerializer` ein `Vec<…>`-Feld.
+Da der M2M-/Related-Accessor asynchron ist, kann das Makro ihn nicht automatisch
+laden; es initialisiert den Vec leer und emittiert einen
+`set_<field>(&[ChildModel])`-Helfer, den du nach dem Laden der Kinder aufrufst:
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostWithTags {
+    pub id: Auto<i64>,
+    pub title: String,
+    #[serializer(many = TagBrief)]
+    pub tags: Vec<TagBrief>,
+}
+
+// usage
+let tags = post.tags_m2m().all(&pool).await?;
+let mut s = PostWithTags::from_model(&post);
+s.set_tags(&tags);                       // generated setter, named set_<field>
+let json = s.to_value();
+```
+
+---
+
+## Slug-Related-Felder
+
+`slug = "name"` ist DRFs `SlugRelatedField`: statt einer FK-ID oder eines
+vollständigen verschachtelten Objekts wird ein einzelnes benanntes Feld
+ausgegeben, das aus dem geladenen Elternobjekt gezogen wird.
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: Auto<i64>,
+    pub title: String,
+    #[serializer(slug = "name", source = "author")]   // author.name as a flat field
+    pub author_name: String,
+}
+```
+
+Wie nested liest es von einem geladenen FK und fällt auf den Default zurück, wenn
+nicht geladen; es dient nur der Anzeige (nicht schreibbar).
+
+---
+
+## Validierung
+
+Drei Schichten, die alle als `rustango::forms::FormErrors` erscheinen (und bei
+einem ViewSet-Schreibvorgang als `400` in DRF-Form). Sie laufen in dieser
+Reihenfolge: deklarative Constraints, dann Validatoren pro Feld, dann der
+feldübergreifende Hook.
+
+**Deklarative Constraints (DRF `validators`, automatisch geerbt).**
+`max_length`, `min_length`, `min` und `max` sind Feldattribute — und wenn du sie
+weglässt, **erbt ein Feld die** `max_length` / `min` / `max` / `choices` **des
+Modells**. So wird eine `#[rustango(max_length = 200)]`-Spalte längengeprüft ganz
+ohne Serializer-Attribut (Verhalten von DRFs `ModelSerializer`). Sie werden bei
+jedem schreibbaren Feld geprüft und verwandeln potenzielle
+Datenbank-Constraint-`500`s in freundliche `400`s:
+
+```rust
+#[serializer(model = Widget)]
+struct WidgetSerializer {
+    pub code: String,               // inherits the model's max_length
+    #[serializer(max_length = 4)]   // overrides the model's bound
+    pub note: String,
+    pub priority: i64,              // inherits the model's min / max
+    pub status: String,             // inherits the model's choices
+}
+```
+
+Die Meldungen entsprechen Django/DRF: `"Ensure this value has at most N
+characters."`, `"Ensure this value has at least N characters."`, `"Ensure this
+value is ≥ N."` / `"≤ N"` und `"Select a valid choice."`. (`min_length` gibt es
+nur im Serializer; `choices` wird vom Modell geerbt — es gibt kein
+`choices`-Attribut.)
+
+**Pro Feld** (benutzerdefiniert) — deklariere `validate = "fn"` und schreibe
+`fn(value: &FieldType) -> Result<(), String>`:
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    #[serializer(validate = "title_min_3")]
+    pub title: String,
+    pub body: String,
+}
+
+impl PostSerializer {
+    fn title_min_3(t: &String) -> Result<(), String> {
+        if t.chars().count() < 3 { Err("title must be at least 3 chars".into()) } else { Ok(()) }
+    }
+}
+```
+
+Das Derive generiert ein `validate(&self)`, das jeden Validator pro Feld
+ausführt und Fehlschläge in einer nach Feldnamen indizierten `FormErrors`
+sammelt.
+
+**Feldübergreifend** — deklariere einen Hook auf Struct-Ebene, und die
+Validatoren verschmelzen. Füge entweder `#[serializer(validate =
+"cross_validate")]` am Struct hinzu (das `Result<(), FormErrors>` zurückgibt),
+oder implementiere schlicht selbst `validate(&self)`, wenn es keine Validatoren
+pro Feld gibt, die es generieren würden:
+
+```rust
+impl PostSerializer {
+    pub fn validate(&self) -> Result<(), rustango::forms::FormErrors> {
+        let mut errors = rustango::forms::FormErrors::default();
+        if self.title.is_empty() {
+            errors.add("title", "title cannot be empty");          // field error
+        }
+        if self.body.starts_with(&self.title) {
+            errors.add_non_field("body must not repeat the title"); // object-level error
+        }
+        if errors.is_empty() { Ok(()) } else { Err(errors) }
+    }
+}
+```
+
+`FormErrors` trennt **Feld**-Fehler (`add(field, msg)`, eine
+`HashMap<String, Vec<String>>`) von **Nicht-Feld**-Fehlern
+(`add_non_field(msg)`). Untersuche sie mit `.fields()`, `.non_field()`,
+`.get(field)`, `.is_empty()` und kombiniere mit `.merge(other)`. Jenseits der
+deklarativen Constraints oben (`max_length` / `min_length` / `min` / `max` /
+geerbte `choices`) sind benutzerdefinierte Regeln einfache Funktionen — es gibt
+keine `email`-/Regex-Magie, was die benutzerdefinierte Validierung explizit und
+testbar hält. Außerhalb eines ViewSet rendert das Framework `FormErrors` nicht
+automatisch in einen HTTP-Body; bilde es selbst auf deine 400-Antwort ab (die
+Trennung von Feld/Nicht-Feld passt zu DRFs Fehler-JSON).
+
+---
+
+## Unique-together-Validierung
+
+Für Djangos `UniqueTogetherValidator` — eine Prüfung vor dem Speichern, dass eine
+Kandidatenzeile nicht mit einem Unique-Index über mehrere Spalten kollidiert —
+rufe `check_unique_together_pool` vor dem Speichern auf:
+
+```rust
+use std::collections::HashMap;
+use rustango::core::SqlValue;
+use rustango::serializer::check_unique_together_pool;
+
+let mut values: HashMap<&'static str, SqlValue> = HashMap::new();
+values.insert("org_id",  SqlValue::I64(self.org_id));
+values.insert("user_id", SqlValue::I64(self.user_id));
+
+// None on insert; Some(&pk) on update so the row doesn't clash with itself.
+check_unique_together_pool(&pool, Membership::SCHEMA, &values, None).await?;
+```
+
+Es durchläuft die deklarierten Unique-Indexe des Modells über mehrere Spalten
+und gibt `Err(FormErrors)` mit einem Nicht-Feld-Fehler pro Kollision zurück
+(`"The fields a, b must be unique together."`). Einspaltiges `unique` wird der
+Konfliktbehandlung des Inserts überlassen; partielle
+(`unique_when`)-Indexe werden übersprungen.
+
+---
+
+## Hyperlink-Ausgabe
+
+Für eine Form im Stil eines `HyperlinkedModelSerializer` (Ressourcen-URLs statt
+nackter IDs) nachbearbeiten zwei Helfer das JSON:
+
+```rust
+use rustango::serializer::{hyperlink_url, hyperlinked_to_value};
+use std::collections::HashMap;
+
+let base = PostSerializer::from_model(&post).to_value();
+
+let mut fk_templates = HashMap::new();
+fk_templates.insert("author_id", "/api/users/{pk}");
+
+let out = hyperlinked_to_value(base, "/api/posts/{pk}", "id", &fk_templates);
+// → { "url": "/api/posts/42", "author_id_url": "/api/users/7", "id": 42, ... }
+```
+
+`hyperlink_url(template, &pk)` führt eine einmalige `{pk}`-Ersetzung durch;
+`hyperlinked_to_value` fügt ein `url` auf oberster Ebene plus ein `<fk>_url` pro
+Template hinzu (Null-FK → Null-URL). Die ursprünglichen `id`/`<fk>_id`-Schlüssel
+bleiben erhalten (entferne sie danach, wenn du sie loswerden willst).
+
+---
+
+## Listen serialisieren
+
+`many_to_value(&models)` gibt ein JSON-Array serialisierter Objekte zurück.
+ViewSets verpacken eine Seite davon in den Standard-Umschlag:
+
+```json
+{ "count": 100, "page": 1, "page_size": 20, "last_page": 5, "results": [ { … }, { … } ] }
+```
+
+(Das ist der Standard-Umschlag mit Seitennummern; siehe
+[Pagination](viewsets.md#pagination) für die Cursor- und
+Limit/Offset-Formen.)
+
+---
+
+## Einen Serializer mit einem ViewSet verwenden
+
+Binde einen Serializer in ein [ViewSet](viewsets.md) ein, und er steuert die
+gesamte REST-Ressource — **Ausgabe und Eingabe**, auf jedem Backend
+(PostgreSQL, MySQL, SQLite):
+
+```rust
+#[derive(ViewSet)]
+#[viewset(model = Post, serializer = crate::PostSerializer, ordering = "-published_at")]
+pub struct PostViewSet;
+// or, on the builder: ViewSet::for_model(Post::SCHEMA).serializer::<PostSerializer>()…
+```
+
+- **Ausgabe** — `list` / `retrieve` / `create` / `update`-Antworten rendern
+  über `from_model`, sodass `source` / `method` / `read_only` / `write_only`
+  das JSON formen.
+- **Eingabe** — `create` / `update` führen das `validate()` des Serializers aus
+  (ein Fehlschlag ist ein `400` in DRF-Form, `{field: [msgs]}`), und nur
+  schreibbare Felder werden geschrieben — `read_only`-/berechnete Felder, die
+  ein Client postet, werden ignoriert, `source`-aufgelöst auf die Modellspalte.
+
+Das ViewSet steuert dies über drei `ModelSerializer`-Methoden, die das Derive
+generiert: `validate()`, `writable_source_fields()` und `from_writable_json()`.
+Siehe den [ViewSets-Leitfaden](viewsets.md#the-serializer-marriage-input--output)
+für das vollständige Verhalten und ein durchgearbeitetes Beispiel.
+
+Du kannst einen Serializer auch **eigenständig** verwenden — bilde eine Zeile ab
+und gib ihr JSON aus jedem beliebigen Handler aus:
+
+```rust
+let post = Post::objects().find(42, &pool).await?.expect("post 42");
+let body = PostSerializer::from_model(&post).to_value();   // shaped JSON
+```
+
+---
+
+## Validierung in einem eigenen Handler
+
+Außerhalb eines ViewSet leitet der Serializer `serde::Deserialize` ab, sodass du
+einen Request-Body in ihn parsen, `.validate()` ausführen und — bei Erfolg — die
+Daten auf ein Modell abbilden und `save(&pool)` kannst. `from_writable_json()`
+baut eine Instanz nur aus den schreibbaren Schlüsseln (schreibgeschützte /
+berechnete Felder bekommen Default-Werte), und `writable_fields()` /
+`writable_source_fields()` sagen dir, welche Schlüssel akzeptiert werden — dieselbe
+Maschinerie, die das ViewSet intern nutzt.
+
+---
+
+## OpenAPI-Schemata
+
+Mit aktivem `openapi`-Feature emittiert das Derive zusätzlich eine
+`OpenApiSchema`-Impl: Feldtypen bilden auf JSON-Schema-Typen ab, `Option<T>` wird
+nullable-und-nicht-erforderlich, und `write_only`-Felder werden aus dem
+Antwortschema ausgeschlossen. Das speist die generierten API-Docs — kein
+separates Schema zu pflegen.
+
+> **Vertiefung:** [OpenAPI](openapi.md) — verwandle dieses Schema (plus die
+> CRUD-Pfade deines ViewSet) in eine vollständige OpenAPI-3.1-Spec, die mit
+> Swagger UI / Redoc ausgeliefert wird.
+
+---
+
+## Scaffolding
+
+Generiere ein Serializer-Gerüst mit der manage-CLI:
+
+```bash
+cargo run -- make:serializer PostSerializer --model Post
+```
+
+Es schreibt ein Startmodul, das du ausfüllst:
+
+```rust
+//! Auto-scaffolded by `manage make:serializer PostSerializer`.
+
+use rustango::Serializer;
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: i64,
+    // pub title: String,
+    // #[serializer(read_only)]
+    // pub created_at: chrono::DateTime<chrono::Utc>,
+}
+```
+
+Registriere dann das Modul (`mod post_serializer;`) neben deinen anderen.
+
+---
+
+## Feinheiten und aktuelle Grenzen
+
+Ein paar scharfe Kanten und Schlupflöcher, die man kennen sollte:
+
+- **Bedingte Felder.** Es gibt keine Feldauswahl zur Laufzeit (Felder sind zur
+  Compile-Zeit fixiert). Für „nur einbeziehen, wenn vorhanden“ nutze `Option<T>`
+  plus `#[serde(skip_serializing_if = "Option::is_none")]` am Feld — die
+  benutzerdefinierte `Serialize`-Impl respektiert serde-Attribute.
+- **Benutzerdefinierte Ausgabeform.** Überschreibe `to_value(&self)` an deinem
+  Struct für ein vollständig maßgeschneidertes JSON-Objekt, wenn die Attribute
+  nicht ausreichen.
+- **Schreibbare verschachtelte Objekte** werden nicht unterstützt — `nested` /
+  `many` / `slug`-Felder sind ausgabeseitig. Nimm Schreibvorgänge als skalare
+  IDs entgegen und löse sie selbst auf.
+- **Eingebaute Validatoren sind nur Länge/Bereich/Auswahl** — `max_length` /
+  `min_length` / `min` / `max` (und geerbte `choices`) sind deklarativ; andere
+  Regeln (`email`, Regex, …) sind Funktionen, die du schreibst (siehe
+  [Validierung](#validation)).
+- **Ein Validator pro Feld je Feld.** Für mehrere Regeln an einem Feld
+  kombiniere sie in der Funktion dieses Feldes, oder füge ein feldübergreifendes
+  `validate(&self)` hinzu.
+- **Der Serializer persistiert nicht.** Abbilden → validieren → die Daten an das
+  ORM übergeben; es gibt kein `serializer.save()`.
+
+---
+
+## Probier es aus
+
+Der minimale Serializer ist Teil des
+[`getting_started_blog`](../crates/rustango/examples/getting_started_blog/src/post_serializer.rs)-Beispiels
+(Schritt 13 des Getting-Started-Leitfadens). Das vollständige Verhalten des
+Derive — die Feldattribute, berechnete/verschachtelte/many-Felder und beide
+Validierungsschichten — wird durch die eigenen Unit-Tests des Frameworks
+abgedeckt (keine Datenbank nötig):
+
+```bash
+cd crates/rustango
+cargo test --test serializer_derive          # field attrs, method, nested, many, slug, OpenAPI
+cargo test --test serializer_cross_validate  # per-field + cross-field validation aggregation
+```
+
+---
+
+## Siehe auch
+
+- [ViewSets](viewsets.md) — binde einen Serializer in eine JSON-CRUD-API ein.
+- [HTML-Views](html-views.md) — die serverseitig gerenderte Alternative zu einer JSON-API.
+- [OpenAPI](openapi.md) — die Felder eines Serializers werden zu einem Component-Schema.
+- [ORM-Kochbuch](orm.md) — die Modelle, von denen Serializer abbilden.

--- a/docs/de/sso.md
+++ b/docs/de/sso.md
@@ -1,0 +1,231 @@
+# SSO (OpenID Connect / Social Login)
+
+Melden Sie sich mit einem externen Identitätsanbieter an — Google, Microsoft / Azure
+AD, GitHub, GitLab, Discord oder **jedem beliebigen OpenID-Connect-Anbieter** (Okta,
+Auth0, Keycloak, …) — statt mit einem lokalen Passwort.
+
+Sie können **mehrere Anbieter** konfigurieren, jeder als Zeile über die Admin-UI
+verwaltet (keine Konfigurationsdatei, kein Neubau). Die Endpunkte eines Anbieters
+werden bei der Anmeldung automatisch aus seiner OIDC-Issuer-URL ermittelt;
+Social-Anbieter verwenden eingebaute Presets.
+
+SSO ist für den Admin **Verknüpfung mit einem bestehenden Konto**: die verifizierte
+E-Mail, die der IdP zurückgibt, muss mit einem bestehenden Admin-Benutzer
+übereinstimmen. Es authentifiziert die Person; es erstellt niemals Konten und
+gewährt niemals von sich aus Zugriff. Eine unbekannte oder unverifizierte E-Mail
+wird abgewiesen. (Der Member-Ablauf, weiter unten, kann sich für
+Auto-Provisionierung entscheiden.)
+
+> **Quelle:** der admin-unabhängige Kern `rustango::sso` (`SsoProvider`,
+> `build_provider`, `verified_email`, `ResolvedSso`, `SsoError`), die
+> Bare-Admin-Verdrahtung `rustango::admin::sso`, das SSO pro Tenant/Konsole
+> `rustango::tenancy::sso` (`SharedSsoProvider`) und das Member-SSO
+> `rustango::tenancy::member_auth`.
+
+## Features & wer sie nutzt
+
+Seit **0.49** ist der SSO-Kern ein eigenes Feature, unabhängig vom
+Auto-Admin, sodass eine Endbenutzer-Anmeldung (Member) gebaut werden kann, ohne
+`crate::admin` hereinzuziehen:
+
+| Feature | Zieht herein | Gibt Ihnen |
+|---|---|---|
+| `sso` | `oauth2`, `casts` | Den admin-unabhängigen Kern: `rustango::sso` — den OIDC- / Social-OAuth-Handshake, das DB-gestützte `SsoProvider`-Modell (Secret im Ruhezustand über `casts` verschlüsselt) und den Member-Ablauf (`tenancy::member_auth`, mit `tenancy`). |
+| `admin-sso` | `admin`, `sso` | Das Obige **plus** die Bare-Admin-Login-Verdrahtung (`rustango::admin::sso`) — SSO-Buttons auf der Admin-Anmeldeseite, die die Admin-Session prägen. |
+
+```toml
+[dependencies]
+# Admin login with SSO:
+rustango = { version = "0.51", features = ["admin-sso"] }
+# Member (end-user) SSO without the auto-admin:
+rustango = { version = "0.51", features = ["tenancy", "sso"] }
+```
+
+`admin::sso_provider` und die historischen `admin::sso::*`-Kernpfade sind
+nun **Re-Export-Shims** über `sso::provider` / `sso::*`, sodass bestehende
+Imports von `crate::admin::sso::{build_provider, ResolvedSso, …}` und
+`crate::admin::sso_provider::SsoProvider` unverändert weiter aufgelöst
+werden (der Tabellenname `rustango_sso_providers` und jedes Feld bleiben
+unangetastet — Migrationen sind nicht betroffen).
+
+Die E-Mail, über die ein Benutzer verknüpft wird, ist die `email`-Spalte. Beim
+Tenant-`User`-Modell hängt sie am Feature **`sso`** (in 0.49 von `admin-sso`
+weggezogen, sodass reine Member-SSO-Builds die Spalte trotzdem erhalten); das
+nackte `AdminUser.email` bleibt hinter `admin-sso`. Das Aktivieren oder
+Deaktivieren des Features gibt eine `AddColumn` / `DropColumn`-Migration für
+diese Spalte aus.
+
+## Wie es funktioniert
+
+1. Die Anmeldeseite zeigt einen **„Mit &lt;Anbieter&gt; anmelden“**-Button pro
+   aktiviertem Anbieter.
+2. Ein Klick darauf (`GET <login>/sso/<slug>`) leitet zum IdP weiter, mit einem
+   signierten, kurzlebigen Flow-Cookie (PKCE + CSRF-`state`).
+3. Der IdP schickt den Benutzer zurück an `<login>/sso/<slug>/callback`.
+4. rustango verifiziert den Flow, tauscht den Code ein, liest `/userinfo`
+   und verlangt **`email_verified`**.
+5. Es sucht einen Admin-Benutzer über diese E-Mail. Existiert einer und ist aktiv,
+   prägt es **dieselbe signierte Cookie-Session**, die eine Passwort-Anmeldung
+   erzeugt, gebunden an diesen Benutzer — sodass jedes bestehende Gate (Superuser /
+   Berechtigungen, Live-Passwortänderungs-Invalidierung) weiterhin gilt.
+6. Keine Übereinstimmung → der Benutzer wird mit einem generischen Fehler zur
+   Anmeldeseite zurückgeschickt (Details gehen ins Server-Log, nie in den Browser).
+
+Das Client-**Secret ist im Ruhezustand verschlüsselt** — die `client_secret`-Spalte
+ist ein [`EncryptedString`](#secret-storage)-Cast, erst zur Anmeldezeit im Speicher
+entschlüsselt.
+
+## Anbieter sind Zeilen, verwaltet im Admin
+
+Jeder Anbieter ist eine `SsoProvider`-Zeile. Sie erscheint als gewöhnliches
+Admin-Modell — hinzufügen/bearbeiten/aktivieren über die Admin-UI, kein Redeploy.
+Felder:
+
+| Feld | Bedeutung |
+|---|---|
+| `slug` | Stabiler Routen-Schlüssel + Button-ID (`<login>/sso/<slug>`). Eindeutig. |
+| `label` | Button-Text, z. B. „Mit Google anmelden“. |
+| `kind` | Ein Preset — `google` / `microsoft` / `github` / `gitlab` / `discord` — oder `oidc` für einen generischen OpenID-Connect-Anbieter. |
+| `issuer_url` | OIDC-Discovery-Basis-URL (für `kind = "oidc"`); rustango holt `{issuer}/.well-known/openid-configuration`. Bei Presets ungenutzt. |
+| `client_id` | Die OAuth-Client-ID vom IdP. |
+| `client_secret` | Das OAuth-Client-Secret, **im Ruhezustand verschlüsselt** (nie im Klartext in der DB). |
+| `enabled` | Ob der Button auf der Anmeldeseite erscheint. |
+| `sort_order` | Button-Reihenfolge (aufsteigend). |
+| `scopes` | Optionale, durch Leerzeichen getrennte Scope-Überschreibung (Standard `openid email profile`). |
+
+Um einen Anbieter hinzuzufügen: geben Sie `client_id` + `client_secret` ein, wählen
+Sie ein `kind` (oder `oidc` + eine `issuer_url`) und speichern Sie. Die Endpunkte
+werden bei der Anmeldung ermittelt — keine Endpunkt-Verdrahtung pro Anbieter.
+
+## Wo jede Oberfläche Anbieter verwaltet
+
+- **Single-Tenant / Standalone-Admin** (`crate::admin`): `SsoProvider`-Zeilen
+  sind eine schlichte globale Tabelle, verwaltet vom nackten Admin. Erfordert
+  `Builder::with_session_auth` (SSO prägt dieselbe Session).
+- **Tenant-Admin** (Multi-Tenancy): jeder Tenant verwaltet seine **eigenen**
+  `SsoProvider`-Zeilen aus seinem Admin — granular, self-service, pro Tenant
+  isoliert.
+- **Operator-Konsole** (Multi-Tenancy): ein Operator definiert einmal einen
+  **`SharedSsoProvider`**, und er wird **jedem** Tenant angeboten
+  (etwa ein unternehmensweites Google). Verwaltet über das *Shared SSO*-Panel
+  der Konsole.
+
+Auf der Anmeldeseite eines Tenants verschmelzen die beiden Mengen, und bei einer
+Slug-Kollision **gewinnt der eigene Anbieter des Tenants** gegenüber dem geteilten
+— ein Tenant kann also einen geteilten Anbieter für sich selbst überschreiben.
+
+Die Callback-URL wird pro Anfrage aus Host + Slug abgeleitet
+(`https://<host><login>/sso/<slug>/callback`), registrieren Sie diese also beim
+IdP. Verknüpfen Sie einen Benutzer, indem Sie die `email`-Spalte in seiner
+`rustango_users`- (Tenant) / `rustango_admin_users`- (bare) Zeile auf die vom IdP
+zurückgegebene Adresse setzen.
+
+## Member (Endbenutzer) SSO
+
+Die obigen Oberflächen melden Personen bei einem **Admin** an.
+`tenancy::member_auth` ist das member-seitige Gegenstück: es meldet einen
+Endbenutzer in den eigenen Benutzerpool eines Tenants an (`rustango_users`) und
+prägt eine **Member-Session**, sodass ein Fitnessstudio-Mitglied / SaaS-Kunde
+„Mit Google anmelden“ kann, ohne den Admin zu berühren. Es verwendet exakt
+denselben `rustango::sso`-Kern und die eigenen `SsoProvider`-Zeilen des Tenants —
+nur die Session, die es prägt, unterscheidet sich, weshalb es hinter dem
+`sso`-Feature (nicht `admin-sso`) lebt und keinen Auto-Admin braucht.
+
+Hängen Sie `member_sso_router` in einen `tenancy::server::Builder`-Stack ein (es
+liest den aufgelösten `Arc<TenantContext>`, den der Builder injiziert):
+
+```rust
+use rustango::tenancy::member_auth::{member_sso_router, MemberAuthConfig};
+
+let members = member_sso_router(MemberAuthConfig {
+    login_base:     "/auth".into(),   // buttons link to /auth/sso/<slug>
+    landing_url:    "/".into(),       // post-login destination (honors a same-origin ?next)
+    auto_provision: true,             // create a user from a verified email on first sign-in
+    session_ttl:    7 * 24 * 60 * 60, // 7 days
+    ..Default::default()
+});
+```
+
+Es hängt zwei Routen pro Slug an `login_base` an:
+
+- `GET {login_base}/sso/{slug}` — den Handshake beginnen, zum IdP weiterleiten.
+- `GET {login_base}/sso/{slug}/callback` — ihn abschließen, den Member
+  finden-oder-provisionieren, das Session-Cookie prägen.
+
+Unterschiede zum Admin-Ablauf:
+
+- **Auto-Provisionierung.** Mit `auto_provision = true` (dem Standard) **erstellt**
+  eine verifizierte IdP-E-Mail ohne passende `rustango_users`-Zeile eine solche
+  — Benutzername aus dem lokalen Teil der E-Mail (bei Kollision entdupliziert),
+  ein echter, aber unbrauchbarer zufälliger Passwort-Hash (SSO-Benutzer können
+  sich nicht per Passwort anmelden). Setzen Sie es auf `false` für die
+  admin-artige Verknüpfung-mit-Bestehendem (unbekannte E-Mail abgewiesen).
+- **Ein eigenes Session-Cookie.** Das Member-Cookie
+  (`rustango_member_session`) ist von den Tenant- / Admin-Session-Cookies
+  **domänengetrennt**: die signierte Nachricht trägt einen Tag pro Domäne und
+  einen Audience-Claim, sodass ein Member-Cookie niemals als Tenant-/Admin-Cookie
+  validieren kann (oder umgekehrt), obwohl beide mit
+  `RUSTANGO_SESSION_SECRET` signiert sind. Es ist slug-gebunden (ein für `acme`
+  geprägtes Cookie authentifiziert niemals auf `globex`) und wird durch eine
+  Passwort-Rotation invalidiert (analog zur Admin-Session).
+
+Lesen Sie den aktuellen Member in einem Handler mit dem **`CurrentMember`**-
+Extraktor — dem Member-Gegenstück zu `SessionUser`. Er ist unfehlbar
+(`None` für anonyme / abgelaufene / rotierte / tenant-fremde Sessions),
+sodass er sich mit öffentlichen Routen komponieren lässt:
+
+```rust
+use rustango::tenancy::member_auth::CurrentMember;
+
+async fn dashboard(CurrentMember(member): CurrentMember) -> impl axum::response::IntoResponse {
+    match member {
+        Some(user) => format!("Hi, {}", user.username),
+        None => "Please sign in".to_owned(),
+    }
+}
+```
+
+> **v1-Umfang.** Member-SSO löst Anbieter nur aus den eigenen
+> `SsoProvider`-Zeilen des Tenants auf — der registry-weite
+> `SharedSsoProvider`-Merge und ein eigener `provision`-Hook sind Folgeaufgaben.
+
+## Secret-Speicherung
+
+`client_secret` wird **im Ruhezustand verschlüsselt** mit XChaCha20-Poly1305
+(AEAD) gespeichert, der Schlüssel abgeleitet aus der Umgebungsvariable
+**`RUSTANGO_SECRET_KEY`**. Es wird nur zur Anmeldezeit im Speicher entschlüsselt,
+um sich am Token-Endpunkt des IdP zu authentifizieren. So legt ein durchgesickerter
+DB-Dump das Secret nie offen, und jeder Tenant behält sein eigenes Secret ohne
+Umgebungsvariable pro Anbieter.
+
+> Setzen Sie `RUSTANGO_SECRET_KEY` im Deployment (beliebige Länge; es wird per
+> SHA-256 zu einem 32-Byte-Schlüssel gehasht). Ohne sie schlägt das Speichern oder
+> Verwenden eines Anbieters schnell fehl — dieselbe Haltung wie bei einer
+> fehlenden Datenbank-URL.
+
+## Anbieter (Presets)
+
+Eingebaute Presets: `google`, `microsoft` (Azure AD), `github`, `gitlab`,
+`discord`. Für alles andere verwenden Sie `kind = "oidc"` mit einer `issuer_url` —
+rustango führt OpenID-Connect-Discovery aus, um die Endpunkte zu finden. (Sign in
+with Apple ist kein Preset; es benötigt id_token/JWKS-Verifizierung.)
+
+## Sicherheitshinweise
+
+- **Nur verifizierte E-Mail** — unverifizierte IdP-E-Mails werden abgewiesen.
+- **Keine Auto-Provisionierung** — eine unbekannte E-Mail kommt nicht hinein;
+  erstellen Sie den Admin-Benutzer (und setzen Sie seine `email`) zuerst.
+- **Secrets im Ruhezustand verschlüsselt** (`RUSTANGO_SECRET_KEY`), nur zur
+  Anmeldezeit im Speicher entschlüsselt; Bearbeitungsformulare maskieren das
+  gespeicherte Secret.
+- Das Flow-Cookie ist kurzlebig (10 Min), `HttpOnly`, `SameSite=Lax`
+  und `Secure` über HTTPS; der Handshake trägt PKCE + ein signiertes `state`.
+- SSO-Sessions sind die gewöhnliche Admin-Session — das Rotieren oder
+  Deaktivieren des verknüpften Benutzers invalidiert sie über das bestehende
+  Live-Gate.
+- Das Vertrauensmodell ist `/userinfo` über TLS (das id_token wird nicht
+  unabhängig verifiziert); stellen Sie dem Admin HTTPS voran.
+
+## Siehe auch
+
+- [Sicherheitsleitfaden](security.md) · [Authentifizierung](auth-flows.md)

--- a/docs/de/testing.md
+++ b/docs/de/testing.md
@@ -1,0 +1,179 @@
+# Testen
+
+Schnelle, zuverlässige Tests müssen deine App so ansteuern, wie es ein Client tut — ohne
+einen Server zu booten oder das Netzwerk zu berühren. **Rustango**s `TestClient` führt deinen
+Router **in-process** aus: du rufst `client.get("/path")` auf, es routet die Anfrage
+durch den echten Stack (Extractors, Middleware, Handler) und gibt dir die
+Antwort zum Assertieren zurück. Füge Transaction-Rollback-Isolation für Datenbanktests und
+ein Set von Response-Assertions hinzu, und du hast Djangos Test-Client + `TestCase`, in
+Rust.
+
+[![Testen in Rustango: TestClient umschließt deinen Router und sendet In-process-Anfragen durch den echten Handler-Stack; die TestResponse macht Status, Text und JSON zum Assertieren verfügbar — kein Socket, kein Server](img/testing.png)](img/testing.png)
+
+> **Neu bei einem Begriff hier?** *router*, *handler*, *fixture*, *rollback* — siehe das
+> [Glossar](glossary.md).
+
+> **Quelle:** `rustango::test_client` (`TestClient`, `TestResponse`),
+> `rustango::test_assertions` (`assert_status_2xx`, `assert_redirects`,
+> `assert_cookie_set`, …) und `rustango::test_db` (`with_rollback`) — immer
+> kompiliert.
+>
+> **Lauffähige Version:** die untenstehenden Snippets *sind* ein bestehender Test —
+> [`testing_doc.rs`](../crates/rustango/tests/testing_doc.rs)
+> (`cargo test -p rustango --test testing_doc`). Nahezu jede andere `*_doc.rs`
+> in diesem Repo verwendet `TestClient` auf dieselbe Weise.
+
+## Inhaltsverzeichnis
+
+- [Schritt 1 — Steuere deine App mit TestClient an](#step-1--drive-your-app-with-testclient)
+- [Schritt 2 — Assertiere auf die Response](#step-2--assert-on-the-response)
+- [JSON, Header und Bodies senden](#sending-json-headers-and-bodies)
+- [Eine echte API testen](#testing-a-real-api)
+- [Datenbanktests mit Rollback](#database-tests-with-rollback)
+- [Response-Assertion-Helper](#response-assertion-helpers)
+- [Siehe auch](#see-also)
+
+---
+
+## Schritt 1 — Steuere deine App mit TestClient an
+
+Umschließe einen beliebigen `axum::Router` in einem `TestClient` und sende Anfragen — kein Socket wird gebunden,
+kein Server-Task gestartet. Die Anfrage fließt durch deine echte Middleware und
+Handler:
+
+```rust
+use rustango::test_client::TestClient;
+
+let client = TestClient::new(app());          // app() returns your Router
+
+let res = client.get("/ping").send().await;   // routed in-process
+assert_eq!(res.status, 200);
+```
+
+`TestClient` hat `get` / `post` / `put` / `patch` / `delete` / `head`, jeweils
+einen Builder zurückgebend, den du mit `.send().await` abschließt.
+
+---
+
+## Schritt 2 — Assertiere auf die Response
+
+`TestResponse` macht den Status und Body in jeder Form verfügbar, die du brauchst:
+
+```rust
+let res = client.get("/ping").send().await;
+
+res.status;                 // u16 — e.g. 200
+res.text();                 // body as a String
+res.header("content-type"); // Option<&str>
+```
+
+```rust
+// JSON, two ways:
+let res = client.post("/echo").json(&json!({ "name": "Ada" })).send().await;
+assert_eq!(res.json_value()["name"], "Ada");   // untyped
+
+#[derive(serde::Deserialize)]
+struct Out { name: String }
+let out: Out = res.json();                       // typed
+assert_eq!(out.name, "Ada");
+```
+
+---
+
+## JSON, Header und Bodies senden
+
+Der Request-Builder verkettet alles vor `.send()`:
+
+```rust
+let res = client
+    .post("/api/posts")
+    .header("authorization", "Bearer <token>")   // auth, content negotiation, …
+    .json(&json!({ "title": "Hello", "body": "..." }))
+    .send()
+    .await;
+assert_eq!(res.status, 201);
+```
+
+Nutze `.body(...)` für rohe (Nicht-JSON-)Bodies, und eine fehlende Route gibt ein echtes
+`404` zurück — verifiziert im zugrunde liegenden Test.
+
+---
+
+## Eine echte API testen
+
+`app()` in deinen Tests ist einfach dein Router. Für eine DB-gestützte API baue ihn genau
+so, wie es `main.rs` tut, aber mit einem Test-Pool — das Muster, das die meisten `*_doc.rs`-Tests verwenden:
+
+```rust
+async fn app() -> axum::Router {
+    let pool = test_pool().await;                 // a sqlite::memory: or test DB pool
+    PostViewSet::router("/api/posts", pool)
+}
+
+#[tokio::test]
+async fn create_then_list() {
+    let client = TestClient::new(app().await);
+    let created = client.post("/api/posts")
+        .json(&json!({ "title": "Hi", "body": "b" }))
+        .send().await;
+    assert_eq!(created.status, 201);
+
+    let list = client.get("/api/posts").send().await;
+    assert!(list.json_value()["results"].is_array());
+}
+```
+
+Dies ist der [ViewSets](viewsets.md)-Test aus jenem Leitfaden — derselbe `TestClient`.
+
+---
+
+## Datenbanktests mit Rollback
+
+Tests, die in eine Datenbank schreiben, dürfen keinen Zustand ineinander lecken lassen.
+`test_db::with_rollback` führt deinen Test innerhalb einer Transaktion aus und **rollt sie zurück**
+am Ende, sodass jeder Test vom selben sauberen Zustand startet und nichts persistiert wird:
+
+```rust
+use rustango::test_db::with_rollback;
+
+#[tokio::test]
+async fn creating_a_post_persists_it() {
+    with_rollback(&pool, |tx| async move {
+        // ... insert + assert against `tx` ...
+        // everything here is rolled back when the closure returns
+    }).await;
+}
+```
+
+Für SQLite verwenden die `*_sqlite_live.rs`-Tests überall in diesem Repo stattdessen eine In-Memory-
+Datenbank pro Test — ebenfalls vollständig isoliert, mit null externem Setup.
+
+---
+
+## Response-Assertion-Helper
+
+Für rohe `axum::Response`-Werte (z. B. aus `tower::oneshot`) liest sich `test_assertions`
+wie Djangos `assertContains` / `assertRedirects`:
+
+```rust
+use rustango::test_assertions::{assert_status_2xx, assert_redirects, assert_cookie_set};
+
+assert_status_2xx(&res);
+assert_redirects(&res, "/login?next=/dashboard");
+assert_cookie_set(&res, "rustango_session", None);
+```
+
+Ebenfalls verfügbar: `assert_status` / `assert_status_in` / `assert_status_4xx` /
+`assert_status_5xx`, `assert_header`, `assert_content_type`,
+`assert_redirect_chain`, `assert_cookie_not_set` und `assert_messages`.
+
+---
+
+## Siehe auch
+
+- [ViewSets](viewsets.md) · [HTML-Views](html-views.md) — worauf du den
+  `TestClient` richtest.
+- [Middleware](middleware.md) — `TestClient` übt auch die Layer aus (DB-frei,
+  via `tower::oneshot` in `middleware.rs`).
+- [Erste Schritte](getting-started.md) — Schritt 16 schreibt den ersten Test.
+- [`manage` CLI](manage.md) — `make:test` scaffoldet ein Test-Modul.

--- a/docs/de/urls.md
+++ b/docs/de/urls.md
@@ -1,0 +1,296 @@
+# URL-Namen & Reverse
+
+URLs (`/posts/42`) überall in Handlern und Templates fest zu verdrahten ist fragil
+— ändern Sie eine Route und jedes Literal bricht stillschweigend. **Rustango**
+gibt Ihnen Djangos Antwort: **benennen Sie ein URL-Muster einmal, dann bauen Sie
+die URL überall über den Namen** — in Rust mit `reverse(...)`, in Templates mit
+`{{ url(...) }}` und in Redirects mit `redirect_to_view(...)`. Die API-Oberfläche
+spiegelt Djangos `reverse()` / `{% url %}` / `resolve_url()` / `redirect()`.
+
+[![Reverse-URLs im Django-Stil: register_url! benennt ein Muster, reverse() baut die URL in Rust, und {{ url(...) }} baut die URL in einem Template](img/urls.png)](img/urls.png)
+
+> **Quelle:** `rustango::urls` (`register_url!`, `reverse`, `reverse_owned`,
+> `all_routes`, `duplicates`, `register_url_tag`) und `rustango::shortcuts`
+> (`resolve_url`, `redirect_to_view`).
+
+> **Ein Begriff hier neu?** *Route*, *Reverse*, *Namespacing* — siehe das
+> [Glossar](glossary.md).
+
+---
+
+## Inhaltsverzeichnis
+- [Eine benannte URL registrieren](#register-a-named-url)
+- [Reverse in Rust](#reverse-in-rust) · [Reverse in Templates](#reverse-in-templates)
+- [Redirect per Name](#redirect-by-name) · [Namespacing](#namespacing)
+- [Die URL-Map inspizieren](#inspect-the-url-map) · [Fehler](#errors)
+- [Regex & typisierte Pfadmuster](#regex--typed-path-patterns) · [Hinweise & Grenzen](#notes-and-limits)
+
+---
+
+## Eine benannte URL registrieren
+
+`register_url!("name", "/pattern")` registriert ein Mapping Name → Muster. Es läuft
+beim Laden des Moduls (via `inventory`), sodass die Route in einer globalen
+Registry landet, sobald ihr Modul gelinkt ist — keine zentrale `urls.py` zu
+bearbeiten und kein `include()` zu verdrahten.
+
+```rust
+use rustango::register_url;
+
+register_url!("post-detail", "/posts/{id}");
+register_url!("user-posts",  "/users/{user_id}/posts/{post_id}");
+register_url!("home",        "/");
+```
+
+Platzhalter nutzen axums `{name}`-Pfadsyntax. Das Muster ist derselbe String, an
+dem Sie den Handler mounten — halten Sie sie synchron (registrieren Sie den Namen
+dort, wo Sie die Route bauen).
+
+---
+
+## Reverse in Rust
+
+`reverse(name, &params)` ersetzt die `{placeholders}` des Musters durch die
+gegebenen Werte (jeden prozentkodiert) und gibt die URL zurück:
+
+```rust
+use std::collections::HashMap;
+use rustango::urls::reverse;
+
+let mut params = HashMap::new();
+params.insert("id", "42".to_string());
+
+let url = reverse("post-detail", &params)?;   // → "/posts/42"
+```
+
+Für dynamische Schlüssel (z. B. aus einer Anfrage zusammengesetzte Werte) nimmt
+`reverse_owned` `HashMap<String, String>` statt `HashMap<&str, String>`:
+
+```rust
+use rustango::urls::reverse_owned;
+let url = reverse_owned("post-detail", &owned_params)?;
+```
+
+`reverse` ist **strikt**: ein fehlender Platzhalter oder ein zusätzlicher
+`params`-Schlüssel, den das Muster nicht hat, ist ein Fehler (kein stiller
+Fehlabgleich) — siehe [Fehler](#errors).
+
+---
+
+## Reverse in Templates
+
+Templates erhalten Djangos `{% url %}` als Tera-Funktion. Registrieren Sie sie
+einmalig auf Ihrer `Tera`-Instanz beim Setup (sie liegt hinter dem
+`template_views`-Feature):
+
+```rust
+rustango::urls::register_url_tag(&mut tera);
+```
+
+Rufen Sie dann `url(name=..., <param>=...)` in einem beliebigen Template auf —
+`name` ist erforderlich, und jedes weitere Schlüsselwort-Argument ist ein
+Pfadparameter (Strings, Zahlen und Booleans werden akzeptiert):
+
+```jinja
+<a href="{{ url(name='post-detail', id=42) }}">View post</a>
+<a href="{{ url(name='user-posts', user_id=7, post_id=42) }}">…</a>
+```
+
+Das entspricht Djangos `{% url 'post-detail' id=42 %}`. Für das Capture-Muster
+`{% url 'x' as var %}` verwenden Sie Teras `{% set %}`:
+
+```jinja
+{% set post_url = url(name='post-detail', id=post.id) %}
+<a href="{{ post_url }}">{{ post.title }}</a>
+```
+
+Ein `null`-Argument (meist eine undefinierte Template-Variable) schlägt lautstark
+fehl, statt stillschweigend eine kaputte URL zu erzeugen.
+
+---
+
+## Redirect per Name
+
+`rustango::shortcuts` spiegelt Djangos View-Namen-Redirect-Helfer, sodass Handler
+niemals ein `Location` fest verdrahten:
+
+```rust
+use std::collections::HashMap;
+use rustango::shortcuts::{redirect_to_view, resolve_url};
+
+// redirect('post-detail', id=42) → 302 Location: /posts/42
+let mut params = HashMap::new();
+params.insert("id", "42".to_string());
+let response = redirect_to_view("post-detail", &params)?;
+```
+
+`resolve_url(spec, &params)` ist Djangos `resolve_url`: Wenn `spec` bereits wie
+eine URL aussieht (`/…`, `http://`, `https://`, `./`, `../`), wird es unverändert
+zurückgegeben; sonst wird es als Routenname behandelt und per Reverse aufgelöst.
+Praktisch für einen `?next=`-Parameter oder eine Einstellung, die *entweder* einen
+Pfad *oder* einen Namen halten kann:
+
+```rust
+let url = resolve_url("post-detail", &params)?;  // name  → "/posts/42"
+let url = resolve_url("/dashboard", &params)?;   // path  → "/dashboard" (as-is)
+```
+
+(Für rohe Redirects zu einer bekannten URL gibt `rustango::shortcuts::redirect(url)`
+ein schlichtes `302` zurück.)
+
+---
+
+## Namespacing
+
+Es gibt kein `include()` und keinen automatisch angewandten App-Namespace — jedes
+`register_url!` landet in einer globalen Registry. Namespacing ist eine
+**Konvention im Namen selbst**: mit `app:` präfixieren, genau wie Sie Djangos
+`reverse("app:detail")` aufrufen würden.
+
+```rust
+register_url!("blog:post-detail", "/blog/posts/{id}");
+register_url!("shop:product",     "/shop/products/{slug}");
+```
+
+```rust
+reverse("blog:post-detail", &params)?;   // "/blog/posts/42"
+```
+
+Der Doppelpunkt ist einfach Teil des registrierten Strings — wählen Sie ein
+konsistentes Präfix pro App, um Kollisionen zu vermeiden.
+
+---
+
+## Die URL-Map inspizieren
+
+Listen Sie jede registrierte Route über die CLI auf — nützlich für ein schnelles
+Audit oder zum Skripten:
+
+```bash
+cargo run -- showurls                  # plain table of name → pattern
+cargo run -- showurls --format json    # machine-readable
+```
+
+Im Code gibt `all_routes()` die gesamte Registry zurück, und `duplicates()` gibt
+jeden Namen zurück, der mehr als einmal registriert wurde (ansonsten gilt
+„erster gewinnt“ — beim Booten wert zu asserten):
+
+```rust
+use rustango::urls::{all_routes, duplicates};
+
+for route in all_routes() {
+    println!("{} → {}", route.name, route.pattern);
+}
+
+let dups = duplicates();
+assert!(dups.is_empty(), "duplicate URL names: {dups:?}");
+```
+
+---
+
+## Fehler
+
+`reverse` / `reverse_owned` / `resolve_url` / `redirect_to_view` geben
+`Result<_, rustango::urls::ReverseError>` zurück:
+
+| Variante | Wann |
+|---|---|
+| `UnknownName(name)` | Kein `register_url!` lief für diesen Namen (Tippfehler, oder sein Modul wurde nicht gelinkt). |
+| `MissingParam { name, param }` | Das Muster hat `{param}`, aber `params` lieferte es nicht. |
+| `UnexpectedParam { name, param }` | `params` trug einen Schlüssel, den das Muster nicht hat (fängt Tippfehler). |
+| `MalformedPattern { name, detail }` | Das registrierte Muster ist fehlerhaft (z. B. eine nicht geschlossene `{`). |
+
+In Templates tauchen sie als Tera-Render-Fehler auf (ein 500 via
+`shortcuts::render` / `template_views`), sodass ein fehlerhaftes `{{ url(...) }}`
+sichtbar fehlschlägt, statt einen kaputten Link zu rendern.
+
+---
+
+## Regex & typisierte Pfadmuster
+
+**Rustango hat kein `re_path` und erzwingt niemals einen Pfad-Konverter.** Ein
+Mustersegment ist entweder ein Literal (`/posts/new`) oder ein
+`{name}`-Platzhalter, der genau ein Segment erfasst; `{*name}` erfasst den Rest des
+Pfades. Das ist das gesamte Vokabular — es gibt kein `r'(?P<year>[0-9]{4})'`, und
+`{int:id}` schränkt `id` **nicht** auf eine Ganzzahl ein.
+
+### Warum — der Matcher ist keine Regex-Engine
+
+Das Routing *ist* [axum](https://docs.rs/axum) 0.8, und axum matcht Pfade mit
+[`matchit`](https://docs.rs/matchit), einem **Radix-Trie**-Router. Er läuft die URL
+segmentweise einen Präfixbaum hinunter, sodass ein Match O(Pfadlänge) kostet und
+unabhängig davon ist, wie viele Routen Sie registriert haben. Ein Regex-Router
+macht das Gegenteil: Django wertet `urlpatterns` von oben nach unten aus und führt
+die Regex jedes Eintrags gegen den Pfad aus, bis eine passt. Der Trie erkauft
+Matching in konstanter Zeit und eine eindeutige „spezifischstes Literal
+gewinnt“-Präzedenz — zum Preis, Zeichenklassen-Beschränkungen nicht *im Pfad
+selbst* auszudrücken.
+
+Rustango erbt diesen Matcher komplett. Es gibt **keinen zweiten, regex-basierten
+Resolver** obendrauf, und `register_url!` erfasst bewusst *dieselben*
+`{name}`-Strings, die der Router bereits versteht — es kompiliert nie eine Regex.
+Regex-Pfade sind also nicht „abgeschaltet“; die Routing-Schicht war schlicht nie
+eine Regex-Engine.
+
+Die Form `{int:id}` wird nur als **Portierungshilfe** für `reverse()` akzeptiert:
+Der Builder teilt den Platzhalter an `:` und behält nur den Namen, verwirft das
+Typpräfix ([`urls.rs`](../crates/rustango/src/urls.rs)). Das lässt `reverse()` auf
+einem Muster laufen, das wortwörtlich aus einem Django-`path("<int:id>/", …)`
+kopiert wurde — aber nichts validiert, dass der gelieferte Wert tatsächlich eine
+Ganzzahl ist.
+
+### Wie man eine eingeschränkte Route ausdrückt
+
+Matchen Sie das Segment mit einem schlichten `{placeholder}`, dann erzwingen Sie
+seine Form dort, wo der Wert verwendet wird. Djangos
+`re_path(r'^articles/(?P<year>[0-9]{4})/$', …)` wird zu:
+
+```rust
+register_url!("article-by-year", "/articles/{year}");
+// router:
+.route("/articles/{year}", get(article_by_year))
+
+async fn article_by_year(Path(year): Path<String>) -> impl IntoResponse {
+    // the router accepted any single segment; enforce [0-9]{4} here
+    match year.parse::<u16>() {
+        Ok(y) if (1000..=9999).contains(&y) => render_year(y).await,
+        _ => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+```
+
+Um *bevor* der Handler läuft abzulehnen (näher an Djangos Konverter-Semantik),
+legen Sie die Prüfung in einen eigenen axum-Extractor (`FromRequestParts`) und
+nehmen Sie diesen Typ statt `Path<String>` als Handler-Argument — das Framework
+liefert keinen mit, aber axums Extractor-Trait ist die vorgesehene Nahtstelle. Der
+`regex`-Crate ist bereits eine Abhängigkeit (das ORM nutzt ihn für
+`__regex`-Lookups), sodass ein validierender Extractor eine `Regex` einmal
+kompilieren und über Anfragen hinweg wiederverwenden kann.
+
+---
+
+## Hinweise und Grenzen
+
+- **Registrierung erfolgt zur Link-Zeit.** Ein `register_url!` wirkt nur, wenn sein
+  Modul in das Binary kompiliert ist. Ein `UnknownName`-Fehler bedeutet meist, dass
+  der Name ein Tippfehler ist *oder* sein Modul nirgends referenziert wird (der
+  Linker hat es also fallen gelassen).
+- **Muster werden nicht gegen Ihre echten Routen validiert.** `register_url!`
+  erfasst ein Mapping Name → String; es prüft nicht, ob tatsächlich ein Handler an
+  diesem Muster gemountet ist. Registrieren Sie den Namen dort, wo Sie die Route
+  mounten, damit sie synchron bleiben.
+- **Werte werden prozentkodiert** von `reverse`, sodass sie sicher in einen
+  `Location`-Header oder ein `href` fallengelassen werden können.
+- **Keine Regex-/typisierten Konverter** in Mustern (Djangos `<int:pk>`);
+  Platzhalter sind schlichte `{name}`, und Werte werden unverändert eingesetzt
+  (nach der Kodierung). Siehe [Regex & typisierte Pfadmuster](#regex--typed-path-patterns)
+  für das Warum und wie man eine Route stattdessen einschränkt.
+
+
+---
+
+## Siehe auch
+
+- [HTML-Views](html-views.md)
+- [ViewSets](viewsets.md)
+- [Middleware](middleware.md)

--- a/docs/de/viewsets.md
+++ b/docs/de/viewsets.md
@@ -1,0 +1,884 @@
+# ViewSets — CRUD-REST-APIs
+
+Ein ViewSet verwandelt ein Model in eine vollständige REST-Ressource — Endpunkte zum **Auflisten,
+Erstellen, Lesen, Aktualisieren und Löschen** von Datensätzen — aus einer einzigen Deklaration. (Es ist
+das **Rustango**-Äquivalent zu einem `ModelViewSet` des Django REST Framework oder einem Laravel-
+API-Resource-Controller, falls du diese schon einmal verwendet hast.)
+
+> **Neu bei REST-APIs?** Diese Anleitung setzt voraus, dass du weißt, was ein *Endpunkt*, ein *HTTP-
+> Verb* (GET / POST / …) und eine *JSON-Anfrage und -Antwort* sind. Falls dir davon etwas
+> unklar ist, ist das [Glossar](glossary.md#web-api-basics) eine Fünf-Minuten-Einführung —
+> lies es zuerst und komm dann hierher zurück.
+
+Kombiniere ein ViewSet mit einem [Serializer](serializers.md) — dem Baustein, der dein
+JSON formt — und es schützt **beide Richtungen** auf einmal: Der Serializer formatiert jede
+**Antwort** (Felder umbenennen, verbergen, berechnen oder verschachteln) *und* regelt jede
+**Anfrage** (er validiert eingehende Daten und ignoriert stillschweigend Felder, die ein Client
+nicht setzen dürfen sollte). Abgelehnte Eingaben kommen in der vertrauten DRF-
+Form zurück — ein JSON-Objekt mit dem Feldnamen als Schlüssel. Das funktioniert überall gleich auf PostgreSQL,
+MySQL und SQLite.
+
+Diese Anleitung ist tutorial-orientiert: Wir **bauen eine vollständige REST-Blog-API** von Anfang bis Ende —
+Gerüst, Models, ein Serializer, das ViewSet, alle sechs CRUD-Endpunkte, Eingabe-
+validierung, Filterung/Suche/Paginierung und Tests — und der Rest der Seite
+ist eine Referenz für jede Stellschraube.
+
+[![Ein Rustango-ViewSet, verdrahtet mit einem Serializer: Ein einziger #[viewset(serializer = …)]-Block liefert typisierte JSON-Ausgabe und validierte Eingabe über die sechs CRUD-Routen hinweg](img/viewsets.png)](img/viewsets.png)
+
+> **Quelle:** `rustango::viewset` (`ViewSet`, `#[derive(ViewSet)]`, die
+> `#[viewset(...)]`-Optionen + der `for_model`-Builder) — immer kompiliert.
+>
+> **Lauffähige Version:** Der hier gebaute Blog spiegelt das getestete, kompilierbare
+> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog)-
+> Beispiel (dessen `Post` / `PostSerializer` / `PostViewSet`), und jedes Verhalten ist
+> durch die eigenen Live-Tests des Frameworks abgesichert — `crates/rustango/tests/viewset_*.rs`
+> (insbesondere `viewset_serializer_render_sqlite_live` und
+> `viewset_serializer_input_sqlite_live`).
+
+---
+
+## Inhaltsverzeichnis
+- [API-Views vs. HTML-Views](#api-views-vs-html-views) — JSON für Clients oder HTML-Seiten?
+- [Eine REST-Blog-API bauen](#build-a-rest-blog-api) — die vollständige Anleitung
+- [Die Serializer-Ehe: Eingabe + Ausgabe](#the-serializer-marriage-input--output)
+- [Die zwei Wege, ein ViewSet zu definieren](#the-two-ways-to-define-a-viewset)
+- [Die CRUD-Endpunkte](#the-crud-endpoints) · [Auswahl, welche exponiert werden](#choosing-which-operations-to-expose)
+- [`#[viewset(...)]`-Referenz](#viewset-attribute-reference) · [Builder-Referenz](#builder-reference)
+- [Filterung, Suche & Sortierung](#filtering-search-and-ordering) · [Paginierung](#pagination)
+- [Validierung](#validation) · [Berechtigungen & Drosselung](#permissions-and-throttling) · [Eigene Aktionen](#custom-actions-beyond-crud)
+- [Einbinden](#mounting) · [Backends](#backend-support)
+
+---
+
+## API-Views vs. HTML-Views
+
+Vor dem Tutorial noch eine Weggabelung. **Rustango** hat zwei Wege, ein
+Model in Endpunkte zu verwandeln, und ein ViewSet ist einer davon:
+
+- Ein **ViewSet** (diese Anleitung) ist ein **API-View** — es spricht **JSON**, für
+  Frontend-Frameworks, mobile Apps und andere Dienste.
+- Ein **Template-View** ([HTML-Views](html-views.md)) ist ein **HTML-View** — es
+  rendert **serverseitige Seiten** über Tera, für Browser und servergerenderte
+  Websites.
+
+Darunter dasselbe Model; was sich unterscheidet, ist, was herauskommt und wer aufruft.
+
+| | **API-View** — ViewSet (hier) | **HTML-View** — [Template-Views](html-views.md) |
+|---|---|---|
+| Modul | `rustango::viewset` | `rustango::template_views` |
+| Sendet zurück | **JSON-Daten** | eine **servergerenderte HTML-Seite** |
+| Gebaut für | SPAs, Mobile, andere Dienste | Browser, servergerenderte Websites, admin-artiges CRUD |
+| Ein „Erstellen" | `POST` JSON → `201` + das Objekt | `POST` eines Formulars → `303`-Weiterleitung (Post/Redirect/Get) |
+| Bei ungültiger Eingabe | `400` + eine feldbasierte JSON-Fehlerabbildung | das Formular mit angezeigten Fehlern neu rendern |
+| Eine „Liste" ist | ein paginierter JSON-Umschlag | eine Schleife über Zeilen in deinem Template |
+| Üblicherweise authentifiziert per | Tokens / JWT / API-Keys | Session-Cookies |
+| Django-Entsprechung | DRF `ModelViewSet` | generische klassenbasierte Views |
+
+Wähle pro Ressource — und du kannst **beide auf demselben Model** einbinden (eine öffentliche JSON-
+API *und* interne CRUD-Seiten). Der Rest dieser Anleitung ist die JSON-/API-Seite; für
+die HTML-Seite siehe [HTML-Views — servergerenderte Seiten](html-views.md).
+
+---
+
+## Eine REST-Blog-API bauen
+
+Wir bauen einen Blog mit zwei Models — `Author` und `Post` — und exponieren `Post` als
+REST-Ressource unter `/api/posts`, deren JSON-Form und Validierung von einem
+Serializer gesteuert werden. Am Ende kannst du jedes CRUD-Verb per `curl` aufrufen und beobachten, wie der Serializer
+die Ausgabe formt und ungültige Eingaben ablehnt.
+
+Diese Anleitung setzt ein mit `cargo rustango new myblog` erstelltes Projekt voraus
+(siehe [Erste Schritte](getting-started.md) für Projekteinrichtung und Datenbank).
+Jeder Schritt ist ein echter Befehl oder eine echte Datei.
+
+### Schritt 1 — Die Blog-App erstellen
+
+Apps sind eigenständige Feature-Module (Djangos `startapp`):
+
+```bash
+cargo run -- startapp blog
+```
+
+Das schreibt `src/blog/{mod,models,views,urls,tests}.rs` und bindet das Modul
+in `main.rs` + den `urls::api()`-Aggregator ein.
+
+### Schritt 2 — Die Models definieren
+
+`src/blog/models.rs` — ein `Author` und ein `Post` (ein Fremdschlüssel verknüpft sie):
+
+```rust
+use rustango::{Auto, Model};
+use chrono::{DateTime, Utc};
+
+#[derive(Model, Clone, Debug)]
+#[rustango(table = "authors", display = "name")]
+pub struct Author {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 120)]
+    pub name: String,
+    #[rustango(max_length = 200)]
+    pub email: String,
+}
+
+#[derive(Model, Clone, Debug)]
+#[rustango(table = "posts", display = "title", index("status, published_at"))]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+
+    #[rustango(max_length = 200)]
+    pub title: String,
+
+    pub body: String,
+
+    #[rustango(max_length = 20, default = "'draft'")]
+    pub status: String,                       // draft | published | archived
+
+    #[rustango(fk = "authors", on = "id")]
+    pub author_id: i64,
+
+    #[rustango(auto_now_add)]
+    pub published_at: Auto<DateTime<Utc>>,
+}
+```
+
+### Schritt 3 — Migrieren
+
+Migration generieren und anwenden (wie `makemigrations` + `migrate`):
+
+```bash
+cargo run -- makemigrations
+cargo run -- migrate
+```
+
+### Schritt 4 — Den Serializer gerüsten
+
+Der Serializer ist das, was daraus eine *DRF*-API macht — er definiert den Anfrage-/Antwort-
+Kontrakt. Generiere das Grundgerüst:
+
+```bash
+cargo run -- make:serializer PostSerializer --model Post
+```
+
+Dann fülle es aus. Dieses hier nutzt die gesamte Eingabe-+-Ausgabe-Oberfläche — eine Umbenennung,
+ein berechnetes schreibgeschütztes Feld, ein schreibgeschütztes Server-Feld und einen Feld-Validator:
+
+```rust
+// src/blog/post_serializer.rs
+use rustango::{Auto, Serializer};
+use chrono::{DateTime, Utc};
+use crate::blog::models::Post;
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: Auto<i64>,
+
+    #[serializer(validate = "title_min_3")]   // input: reject titles < 3 chars
+    pub title: String,
+
+    #[serializer(source = "body")]            // JSON key `content`, column `body`
+    pub content: String,
+
+    pub status: String,
+    pub author_id: i64,
+
+    #[serializer(method = "summary")]         // output: computed, never written
+    pub summary: String,
+
+    #[serializer(read_only)]                  // output: shown, ignored on write
+    pub published_at: Auto<DateTime<Utc>>,
+}
+
+impl PostSerializer {
+    fn title_min_3(t: &String) -> Result<(), String> {
+        if t.chars().count() < 3 {
+            Err("title must be at least 3 characters".into())
+        } else {
+            Ok(())
+        }
+    }
+    fn summary(p: &Post) -> String {
+        p.body.chars().take(80).collect::<String>()
+    }
+}
+```
+
+Registriere das Modul — füge `pub mod post_serializer;` zu `src/blog/mod.rs` hinzu.
+
+Beachte, dass wir nur einen Validator geschrieben haben (`title_min_3`); die Felder **erben** zudem
+automatisch **die Constraints des Models** — `title` wird gegen die Längenvorgabe des Models
+`max_length = 200` geprüft, und eine `choices`/`min`/`max`-Spalte würde ebenfalls geprüft,
+wobei alle beim Schreiben freundliche `400`er zurückgeben. Füge `max_length` / `min_length` /
+`min` / `max` als Serializer-Attribute hinzu, um die Grenze eines Feldes zu überschreiben. (Siehe die
+[Serializer-Anleitung](serializers.md#validation) für die vollständige Validierungsgeschichte.)
+
+### Schritt 5 — Das ViewSet gerüsten und den Serializer verdrahten
+
+```bash
+cargo run -- make:viewset PostViewSet --model Post
+```
+
+Bearbeite es, um die Ressource zu deklarieren und **den Serializer mit dem `serializer`-
+Attribut zu verdrahten** — diese eine Zeile schaltet serializer-gesteuerte Ausgabe *und* Eingabe ein:
+
+```rust
+// src/blog/post_view_set.rs
+use rustango::ViewSet;
+
+#[derive(ViewSet)]
+#[viewset(
+    model         = Post,
+    serializer    = crate::blog::post_serializer::PostSerializer,
+    filter_fields = "author_id, status",
+    search_fields = "title, body",
+    ordering      = "-published_at",
+    page_size     = 20,
+)]
+pub struct PostViewSet;
+```
+
+Füge `pub mod post_view_set;` zu `src/blog/mod.rs` hinzu.
+
+> Mit einem verdrahteten Serializer brauchst du kein `fields = "..."` — der Serializer ist
+> die Projektion. Verwende `fields` nur, wenn du stattdessen die standardmäßige (serializer-freie)
+> Feldprojektion möchtest.
+
+### Schritt 6 — Die Routen einbinden
+
+In einem Single-Tenant-Projekt verschachtelst du den Router des ViewSets unter einem Pfad und übergibst
+den Pool:
+
+```rust
+// src/blog/urls.rs (or your urls::api aggregator)
+use axum::Router;
+use rustango::sql::sqlx::PgPool;
+use crate::blog::post_view_set::PostViewSet;
+
+pub fn api(pool: PgPool) -> Router {
+    Router::new()
+        .merge(PostViewSet::router("/api/posts", pool))
+}
+```
+
+`make:api_routes blog` gerüstet genau diesen Aggregator, falls du ihn lieber
+generieren möchtest. Binde `blog::urls::api(pool)` in deine oberste `urls.rs` ein.
+
+### Schritt 7 — Ausführen und jeden Endpunkt durchprobieren
+
+```bash
+cargo run            # listening on http://0.0.0.0:8080
+```
+
+**Erstellen** (`POST`). Der Serializer validiert zuerst und schreibt dann nur die
+Felder, die er akzeptiert:
+
+```bash
+# happy path — note `content` (the renamed `body`) on the way in
+curl -X POST localhost:8080/api/posts \
+  -H 'content-type: application/json' \
+  -d '{"title":"Hello Rustango","content":"First post body.","status":"published","author_id":1}'
+```
+```json
+{
+  "id": 1,
+  "title": "Hello Rustango",
+  "content": "First post body.",
+  "status": "published",
+  "author_id": 1,
+  "summary": "First post body.",
+  "published_at": "2026-01-02T12:00:00Z"
+}
+```
+Die Antwort hat die Form des **Serializers**: `body` kam als `content` zurück, das
+berechnete `summary` erschien, und `published_at` (schreibgeschützt, servergesetzt) ist
+vorhanden.
+
+**Die Validierung lehnt ungültige Eingaben** mit einem `400` in DRF-Form ab — feldbasierte Arrays von
+Meldungen:
+
+```bash
+curl -i -X POST localhost:8080/api/posts \
+  -H 'content-type: application/json' \
+  -d '{"title":"hi","content":"x","author_id":1}'
+# HTTP/1.1 400 Bad Request
+# {"title":["title must be at least 3 characters"]}
+```
+
+**Schreibgeschützte / berechnete Felder, die ein Client postet, werden ignoriert** — sie können weder
+`published_at` noch `summary` unterschieben:
+
+```bash
+curl -X POST localhost:8080/api/posts \
+  -H 'content-type: application/json' \
+  -d '{"title":"Sneaky","content":"x","author_id":1,"published_at":"1999-01-01T00:00:00Z","summary":"hax"}'
+# → published_at is the server value, not 1999; summary is recomputed from body.
+```
+
+**Auflisten** (`GET`) — paginiert, jede Zeile in der Form des Serializers:
+
+```bash
+curl localhost:8080/api/posts
+```
+```json
+{ "count": 1, "page": 1, "page_size": 20, "last_page": 1, "results": [ { "id": 1, "title": "Hello Rustango", … } ] }
+```
+
+**Abrufen / Aktualisieren / Teilaktualisieren / Löschen:**
+
+```bash
+curl localhost:8080/api/posts/1                       # retrieve  → 200
+curl -X PUT   localhost:8080/api/posts/1 -H 'content-type: application/json' \
+     -d '{"title":"Edited","content":"new body","status":"published","author_id":1}'   # full update → 200
+curl -X PATCH localhost:8080/api/posts/1 -H 'content-type: application/json' \
+     -d '{"title":"Just the title"}'                   # partial update → 200 (other fields untouched)
+curl -X DELETE localhost:8080/api/posts/1              # destroy → 204
+```
+
+Die `PATCH`-Validierung läuft über das, was du sendest; schreibgeschützte Felder behalten ihren Server-
+Wert, selbst wenn sie gepostet werden.
+
+### Schritt 8 — Filtern, suchen, sortieren, paginieren
+
+Alles am Listen-Endpunkt, ohne zusätzlichen Code (du hast die Felder in Schritt 5 deklariert):
+
+```bash
+curl 'localhost:8080/api/posts?status=published&author_id=1'      # filter
+curl 'localhost:8080/api/posts?status__in=published,archived'     # lookup
+curl 'localhost:8080/api/posts?search=rustango'                   # search title+body
+curl 'localhost:8080/api/posts?ordering=title'                    # sort (asc)
+curl 'localhost:8080/api/posts?page=2&page_size=10'               # paginate
+```
+
+### Schritt 9 — Testen
+
+Das Framework liefert einen In-Process-Testclient — prüfe echte HTTP-Antworten
+ab, ohne einen Server hochzufahren:
+
+```rust
+// tests/post_api.rs
+use rustango::test_client::TestClient;
+use myblog::blog::post_view_set::PostViewSet;
+use rustango::sql::sqlx::PgPool;
+use serde_json::json;
+
+async fn app() -> axum::Router {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap()).await.unwrap();
+    PostViewSet::router("/api/posts", pool)
+}
+
+#[tokio::test]
+async fn rejects_short_title() {
+    let client = TestClient::new(app().await);
+    let res = client.post("/api/posts")
+        .json(&json!({"title":"hi","content":"x","author_id":1}))
+        .send().await;
+    assert_eq!(res.status, 400);
+    assert!(res.json_value()["title"].is_array());   // DRF field-error shape
+}
+
+#[tokio::test]
+async fn create_then_list() {
+    let client = TestClient::new(app().await);
+    let created = client.post("/api/posts")
+        .json(&json!({"title":"Hello","content":"b","status":"published","author_id":1}))
+        .send().await;
+    assert_eq!(created.status, 201);
+    let list = client.get("/api/posts").send().await;
+    assert!(list.json_value()["results"].is_array());
+}
+```
+
+```bash
+cargo test --test post_api
+```
+
+Das ist eine vollständige, validierte REST-Ressource. Der Rest dieser Seite ist die
+Referenz hinter jedem Schritt.
+
+---
+
+## Die Serializer-Ehe: Eingabe + Ausgabe
+
+Das Verdrahten eines Serializers (über `serializer = …` an der Derive oder `.serializer::<S>()`
+am Builder) verändert **beide** Richtungen. Es funktioniert auf PostgreSQL, MySQL und
+SQLite gleichermaßen.
+
+### Ausgabe — Antworten werden durch den Serializer gerendert
+
+`list`-, `retrieve`-, `create`- und `update`-Antworten werden durch
+`S::from_model(&row)` erzeugt, sodass die Overrides des Serializers das JSON formen:
+
+| Serializer-Feld | Wirkung auf die Antwort |
+|---|---|
+| `#[serializer(source = "body")]` | Spalte `body` wird unter dem Namen des Feldes ausgegeben (z. B. `content`) |
+| `#[serializer(method = "fn")]` | ein berechnetes Feld erscheint (aus `Self::fn(&model)`) |
+| `#[serializer(read_only)]` | in der Ausgabe enthalten |
+| `#[serializer(write_only)]` | **weggelassen** aus der Ausgabe |
+
+> **`nested` / `many`-Vorbehalt.** Verschachtelte und Sammlungs-Serializer-Felder werden
+> nur gerendert, wenn die verwandten Zeilen geladen wurden (über `select_related` / ein Eager-
+> Fetch); andernfalls fallen sie auf ihren Standardwert zurück. Die automatische ViewSet-Listen-
+> Abfrage lädt die Basiszeile — verdrahte Beziehungen explizit, wenn ein verschachteltes Feld befüllt
+> werden muss.
+
+### Eingabe — Anfragen werden validiert und gefiltert
+
+Bei `create` und `update`, wenn ein Serializer registriert ist:
+
+1. **Die Validierung läuft.** Das `validate()` des Serializers — jedes einzelne
+   `#[serializer(validate = "fn")]` pro Feld plus das feldübergreifende `validate` auf Container-
+   Ebene — läuft gegen den JSON-Body. Bei Fehlschlag wird die Anfrage abgelehnt
+   mit `400 Bad Request` in der DRF-Fehlerform: ein JSON-Objekt mit dem Feldnamen als Schlüssel
+   und Arrays von Meldungen, z. B. `{"title":["title must be at least 3 characters"]}`.
+2. **Filterung schreibbarer Felder.** Nur die schreibbaren Felder des Serializers werden
+   gespeichert; `read_only`- und `method`-/berechnete Felder, die ein Client postet, werden
+   **ignoriert** (nicht geschrieben), und `source`-Umbenennungen werden auf die Model-
+   Spalte aufgelöst. So kann ein Client kein servergesteuertes Feld setzen, indem er es in den
+   Body einschließt.
+
+> **Form-urlencoded-Bodies** (vs. JSON) überspringen `validate()` — es gibt keinen typisierten
+> Wert zu validieren — bekommen aber trotzdem die Filterung schreibbarer Felder.
+
+Unter der Haube sind dies die Methoden `validate()`, `writable_source_fields()`
+und `from_writable_json()` des `ModelSerializer`-Traits, alle generiert von
+`#[derive(Serializer)]`. Siehe die [Serializer-Anleitung](serializers.md) dazu, wie man
+die Validatoren schreibt.
+
+---
+
+## Die zwei Wege, ein ViewSet zu definieren
+
+Beide erzeugen einen `axum::Router` mit denselben CRUD-Routen.
+
+**1. Das Derive-Makro** — deklarativ, Single-Tenant; verdrahte einen Serializer mit
+`serializer = …`:
+
+```rust
+#[derive(ViewSet)]
+#[viewset(
+    model         = Post,
+    serializer    = crate::blog::post_serializer::PostSerializer,
+    filter_fields = "author_id, status",
+    search_fields = "title, body",
+    ordering      = "-published_at",
+    page_size     = 20,
+)]
+pub struct PostViewSet;
+
+let router = PostViewSet::router("/api/posts", pool);
+```
+
+**2. Der Builder** — `ViewSet::for_model(...)`, programmatisch, tri-dialektfähig
+(PostgreSQL / SQLite / MySQL) und mandantenfähig; verdrahte einen Serializer mit
+`.serializer::<S>()`:
+
+```rust
+use rustango::viewset::ViewSet;
+use rustango::core::Model as _;
+
+let router = ViewSet::for_model(Post::SCHEMA)
+    .serializer::<PostSerializer>()
+    .filter_fields(&["author_id", "status"])
+    .search_fields(&["title", "body"])
+    .ordering(&[("published_at", true)])    // true = DESC
+    .page_size(20)
+    .router_pool("/api/posts", pool);       // tri-dialect Pool
+```
+
+Greife zum Builder, wenn du SQLite/MySQL, Mandantenfähigkeit, eine zur Laufzeit erstellte
+Konfiguration oder die Extras (Drosselung, eigene Filter-Backends, Cursor-Paginierung) brauchst.
+
+---
+
+## Die CRUD-Endpunkte
+
+Das Einbinden unter `/api/posts` verdrahtet alle sechs REST-Operationen:
+
+| Verb | Pfad | Aktion | Erfolg | Body |
+|---|---|---|---|---|
+| `GET` | `/api/posts` | **list** | 200 | paginierter Umschlag (siehe [Paginierung](#pagination)) |
+| `POST` | `/api/posts` | **create** | 201 | das erstellte Objekt — *oder ein Array bei Bulk-Create* |
+| `GET` | `/api/posts/{pk}` | **retrieve** | 200 | das Objekt |
+| `PUT` | `/api/posts/{pk}` | **update** (vollständig) | 200 | das aktualisierte Objekt |
+| `PATCH` | `/api/posts/{pk}` | **partial update** | 200 | das aktualisierte Objekt (nur gelieferte Felder ändern sich) |
+| `DELETE` | `/api/posts/{pk}` | **destroy** | 204 | leer |
+
+Ein abschließender Schrägstrich am Mount-Präfix ist optional. Nur diese sechs Verben werden
+verdrahtet — kein automatisches `HEAD`/`OPTIONS`. **Bulk-Create** gibt es gratis: `POST` ein JSON-
+*Array*, und jedes Element wird der Reihe nach eingefügt, atomar validiert (ein fehlerhaftes
+Element lehnt die ganze Charge ab).
+
+---
+
+## Auswahl, welche Operationen exponiert werden
+
+Für eine **schreibgeschützte** Ressource (nur list + retrieve) füge `read_only` hinzu:
+
+```rust
+#[viewset(model = Post, read_only)]            // macro
+ViewSet::for_model(Post::SCHEMA).read_only()   // builder
+```
+
+Es gibt keinen Umschalter pro Verb außer read_only. Für „alles außer Löschen"
+binde das ViewSet ein und überschreibe die eine Route mit deinem eigenen Handler (siehe
+[Eigene Aktionen](#custom-actions-beyond-crud)).
+
+---
+
+## `#[viewset(...)]`-Attributreferenz
+
+| Schlüssel | Beispiel | Standard | Was er tut |
+|---|---|---|---|
+| `model` | `model = Post` | **erforderlich** | Das Model, auf dem die Ressource aufbaut. |
+| `serializer` | `serializer = path::To::S` | keiner | Einen Serializer für typisierte **Ausgabe + Eingabe** verdrahten (siehe [oben](#the-serializer-marriage-input--output)). |
+| `fields` | `"id, title, body"` | alle Skalarfelder | Whitelist für die standardmäßige (serializer-freie) Projektion + schreibbare Felder. |
+| `filter_fields` | `"author_id, status"` | keiner | Über `?field=value` filterbare Felder (+ Lookups). |
+| `search_fields` | `"title, body"` | keiner | Felder, die die `?search=`-Box durchsucht (Groß-/Kleinschreibung-unabhängiges ODER). |
+| `ordering` | `"-published_at, id"` | keiner | Standardsortierung (`-` = DESC). |
+| `page_size` | `20` | 20 | Zeilen pro Seite (Client-`?page_size=` gedeckelt bei 1000). |
+| `read_only` | *(Flag)* | aus | Nur GET (list + retrieve) exponieren. |
+| `permissions(...)` | `permissions(create = "post.add")` | keiner | Berechtigungs-Codenamen pro Aktion. |
+
+---
+
+## Builder-Referenz
+
+Jede Methode auf `ViewSet::for_model(SCHEMA)` (jede gibt `Self` zurück):
+
+| Methode | Zweck |
+|---|---|
+| `serializer::<S>()` | Einen Serializer für typisierte Ausgabe + Eingabe verdrahten (tri-dialektfähig). |
+| `fields(&["…"])` | Standardprojektion + Whitelist schreibbarer Felder (wenn kein Serializer). |
+| `filter_fields(&["…"])` | `?field=value`-Filterung aktivieren. |
+| `search_fields(&["…"])` | `?search=` aktivieren. |
+| `ordering(&[("field", desc)])` | Standardsortierreihenfolge. |
+| `ordering_fields(&["…"])` | Festlegen, welche Felder `?ordering=` verwenden darf. |
+| `page_size(n)` | Standard-Seitengröße (≤ 1000). |
+| `read_only()` | Nur GET. |
+| `permissions(ViewSetPerms{…})` / `permissions_for_model::<T>()` | Codename-Gates pro Aktion (letzteres bei Mandantenfähigkeit). |
+| `cursor_pagination("id")` / `cursor_pagination_desc("id")` | Keyset-Paginierung (überspringt `COUNT(*)`). |
+| `limit_offset_pagination()` | `?limit=&offset=`-Fensterung. |
+| `pagination(PaginationStyle::…)` | Den Stil explizit setzen. |
+| `filter_backend(closure)` | Eigene `WHERE`-Prädikate über `filter_fields` hinaus hinzufügen. |
+| `throttle(…)` / `throttle_all(max, secs)` | Rate-Limits pro Aktion mit festem Zeitfenster. |
+| `router(prefix, pgpool)` | Einbinden (Postgres, statischer Pool). |
+| `router_pool(prefix, pool)` | Tri-dialektfähig einbinden (PG / SQLite / MySQL). |
+| `tenant_router(prefix)` | *(Mandantenfähigkeit)* mit Mandantenauflösung pro Anfrage einbinden. |
+
+---
+
+## Filterung, Suche und Sortierung
+
+Alles gesteuert über Query-Parameter am **Listen**-Endpunkt.
+
+**Filterung** — jeder `filter_fields`-Eintrag akzeptiert `?field=value` (exakt) plus
+Django-artige Lookups über ein `__suffix`:
+
+```
+?status=published
+?author_id__in=1,2,3
+?published_at__gte=2026-01-01
+?title__icontains=rust
+?body__isnull=false
+```
+
+Unterstützte Lookups: `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `not_in`, `contains`,
+`icontains`, `startswith`, `istartswith`, `endswith`, `iendswith`, `isnull`
+(kein Suffix = exakt). Felder, die nicht in `filter_fields` stehen, werden ignoriert.
+
+**Suche** — `?search=term` durchsucht `search_fields` mit einem Groß-/Kleinschreibung-unabhängigen ODER.
+
+**Sortierung** — `?ordering=field,-other` (`-` = DESC). Jedes Feld ist sortierbar,
+sofern du es nicht mit `.ordering_fields([...])` einschränkst. Ohne Parameter gilt der
+`ordering`-Standard. Alle lassen sich kombinieren.
+
+---
+
+## Paginierung
+
+> **Fallstrick — paginiere über eine deterministische Reihenfolge.** Seitenzahl- und
+> Limit/Offset-Paginierung setzen eine stabile Sortierung voraus; das Sortieren über eine nicht-eindeutige Spalte
+> (oder gar keine) lässt Zeilen zwischen den Seiten verrutschen — dupliziert oder übersprungen. Füge immer
+> einen eindeutigen Tiebreaker hinzu, z. B. `ordering = "-published_at, id"`. (Beide führen zudem
+> `COUNT(*)` pro Aufruf aus; Cursor-Paginierung überspringt das bei großen Tabellen.)
+
+Drei Stile; Seitenzahl ist der Standard. Der Listen-Umschlag unterscheidet sich je Stil:
+
+**Seitenzahl** (Standard) — `?page=2&page_size=20`:
+
+```json
+{ "count": 137, "page": 2, "page_size": 20, "last_page": 7, "results": [ … ] }
+```
+
+**Cursor** — `.cursor_pagination("id")` (oder `_desc`); überspringt `COUNT(*)`, ideal
+für sehr große Tabellen. `?cursor=<token>&page_size=20`:
+
+```json
+{ "page_size": 20, "next": "<opaque-cursor-or-null>", "results": [ … ] }
+```
+
+**Limit/Offset** — `.limit_offset_pagination()`. `?limit=20&offset=40`:
+
+```json
+{ "count": 137, "limit": 20, "offset": 40, "results": [ … ] }
+```
+
+`page_size` / `limit` werden auf 1000 begrenzt.
+
+---
+
+## Validierung
+
+Mit einem **verdrahteten Serializer** führt der Create-/Update-Pfad die Validatoren des Serializers
+aus und gibt `400`er in DRF-Form zurück — der empfohlene Weg zu validieren (siehe
+[die Ehe](#the-serializer-marriage-input--output) und die
+[Serializer-Anleitung](serializers.md#validation)). Drei Schichten laufen:
+
+- **Deklarative Constraints** — `max_length` / `min_length` / `min` / `max`, und
+  standardmäßig **erbt** das Feld das `max_length` / `min` / `max` /
+  `choices` **des Models**. So wird eine `#[rustango(max_length = 200)]`-Spalte an der
+  API längengeprüft, ohne zusätzliche Konfiguration (Verhalten des DRF-`ModelSerializer`), wodurch
+  potenzielle `500`er aus DB-Constraints in freundliche `400`er verwandelt werden wie
+  `{"title":["Ensure this value has at most 200 characters."]}`.
+- **Pro-Feld-** `validate = "fn"` und ein **feldübergreifender** `validate`-Hook — deine
+  eigenen Regeln (Formate, feldübergreifend, Geschäftslogik).
+
+Unabhängig von einem Serializer erzwingt der Schreibpfad immer das **Schema**:
+
+- **Typen werden konvertiert und geprüft** — ein ungültiger `i64`- / `DateTime`- / `Uuid`- / `bool`-
+  Wert ergibt einen `400`, der das Feld nennt.
+- **Erforderlich / NOT NULL** — ein fehlendes nicht-nullbares Feld (oder ein leerer String für einen
+  nicht-nullbaren `String`) ergibt einen `400`; nullbare Felder akzeptieren leer → `NULL`.
+- **Datenbank-Constraints** — Unique, Fremdschlüssel und Check-Constraints tauchen
+  als `400` beim INSERT/UPDATE auf.
+
+Also bekommst du selbst ohne Serializer Typ- + Erforderlich- + DB-Constraint-Validierung;
+verdrahte einen Serializer, um deklarative Längen-/Bereichs-/Auswahl-Prüfungen (automatisch geerbt)
+plus deine eigenen Pro-Feld- und feldübergreifenden Regeln zu erhalten.
+
+---
+
+## Berechtigungen und Drosselung
+
+> **Ein ViewSet ist standardmäßig öffentlich.** Das Einbinden eines solchen exponiert alle sechs CRUD-Verben
+> für jedermann — es gibt keine eingebaute Authentifizierung. Sichere es mit `permissions(...)`
+> (unten), stelle es hinter die [Auth-Middleware](auth-backends.md) (`require_auth`)
+> oder beides, bevor du Schreibzugriffe exponierst.
+
+**Berechtigungen** sichern jede Aktion über Codenamen (ODER innerhalb einer Aktion):
+
+```rust
+use rustango::viewset::{ViewSet, ViewSetPerms};
+
+ViewSet::for_model(Post::SCHEMA)
+    .permissions(ViewSetPerms {
+        list:     vec!["post.view".into()],
+        retrieve: vec!["post.view".into()],
+        create:   vec!["post.add".into()],
+        update:   vec!["post.change".into()],
+        destroy:  vec!["post.delete".into()],
+    })
+    .router_pool("/api/posts", pool);
+```
+
+Eine leere Aktionsliste = keine Prüfung. Die Durchsetzung liest einen authentifizierten Benutzer aus
+der Anfrage (die `tenancy`-Auth-Integration); Superuser umgehen sie, ein fehlender Benutzer
+wird abgelehnt. `.permissions_for_model::<Post>()` füllt automatisch die Standard-
+Codenamen `post.view`/`add`/`change`/`delete`.
+
+**Drosselung** wendet Limits pro Client mit festem Zeitfenster an, pro Aktion:
+
+```rust
+ViewSet::for_model(Post::SCHEMA)
+    .throttle_all(60, 60)              // 60 requests / 60s per client, every action
+    .router_pool("/api/posts", pool);
+```
+
+Über dem Limit → `429 Too Many Requests` + `Retry-After`. Die Zähler sind pro Prozess;
+der Client-Schlüssel ist die Verbindungs-IP (oder `X-Forwarded-For` / `X-Real-IP`).
+
+---
+
+## Eigene Aktionen jenseits von CRUD
+
+Es gibt keinen DRF-`@action`-Decorator — das ViewSet ist strikt auf die sechs CRUD-
+Routen beschränkt. Für zusätzliche Endpunkte binde deine eigenen Handler neben dem ViewSet ein:
+
+```rust
+use axum::{Router, routing::{get, post}};
+
+let api = Router::new()
+    .merge(ViewSet::for_model(Post::SCHEMA).router_pool("/api/posts", pool.clone()))
+    .route("/api/posts/stats", get(post_stats))
+    .route("/api/posts/bulk_archive", post(bulk_archive));
+```
+
+Für zusätzliche `WHERE`-Logik trägt `.filter_backend(…)` Prädikate ohne eine
+separate Route bei.
+
+### Zeilen auf den authentifizierten Principal beschränken
+
+Ein Backend läuft bei **jeder** Aktion — `list`, `retrieve`, `update`, `destroy` —
+verhält sich also wie DRFs `get_queryset()`. Eine vom Backend ausgeschlossene Zeile ergibt einen
+**404** auf den Item-Routen, keinen 403: Ein 403 würde bestätigen, dass die ID existiert.
+
+Die Identität muss aus der Credential kommen, niemals aus dem Query-String. Ein
+`?owner_id=`-Filter ist kein Scope — er ist ein Parameter, den der Aufrufer wählt.
+
+#### `OwnedBy` — das mitgelieferte Backend
+
+Die meisten besitzgebundenen Ressourcen brauchen genau eine Regel: *Zeilen, deren Besitzspalte der
+Aufrufer ist*. Benenne die Spalte und binde es ein.
+
+```rust
+use rustango::viewset::{OwnedBy, ViewSet};
+
+ViewSet::for_model(Note::SCHEMA)
+    .filter_backend(OwnedBy::column("member_id"))
+    .tenant_router("/api/notes")
+    .layer(axum::middleware::from_fn(
+        rustango::tenancy::auth_routes::require_bearer,
+    ))
+```
+
+Jede Spalte funktioniert — `owner_id`, `member_id`, `author_id` — weil das Backend
+den Namen entgegennimmt, statt eine Konvention anzunehmen. Es scheitert geschlossen bei den beiden
+Arten, wie es falsch sein kann: Eine unauthentifizierte Anfrage und eine Spalte, die das Model nicht
+hat, treffen beide auf **nichts**, sodass ein Tippfehler beim Einbinden nicht zu „keine
+Prädikate, gib die Tabelle zurück" werden kann.
+
+Superuser sind standardmäßig nicht besonders; `.superuser_sees_all()` schaltet das frei, denn
+„Admins sehen alles" ist eine Produktentscheidung, keine des Frameworks.
+
+#### Woher die Identität kommt
+
+[`Principal`] ist der eine Identitätstyp, aufgelöst aus dem, was die Anfrage
+verifiziert hat — ein expliziter `Principal`, ein von einer Session- oder Bearer-Middleware hinterlassener
+`AuthenticatedUser` oder ein MCP-Agent-Token (der als der Benutzer agiert, der ihn ausgestellt hat).
+Er authentifiziert selbst nichts; er liest nur, was eine verifizierende Middleware
+bereits nachgewiesen hat, sodass niemand einen einfügen darf, ohne zuerst eine Credential zu prüfen.
+
+`require_bearer` ist diese Middleware für eine JSON-API: Sie verifiziert das Access-Token
+gegen den aufgelösten Mandanten, liest die Benutzerzeile erneut (ein deaktiviertes Konto hört
+bei der nächsten Anfrage auf zu funktionieren, nicht erst wenn das Token abläuft), und fügt sowohl
+`AuthenticatedUser` als auch `Principal` ein. Verwende sie überall als Extraktor:
+
+```rust
+use rustango::tenancy::{OptionalPrincipal, Principal};
+
+async fn mine(principal: Principal) -> String {          // 401 when absent
+    format!("user {}", principal.user_id)
+}
+
+async fn home(OptionalPrincipal(who): OptionalPrincipal) -> String {
+    who.map_or("anonymous".into(), |p| format!("user {}", p.user_id))
+}
+```
+
+#### Ein eigenes Backend schreiben
+
+Wenn Besitz keine einzelne Spalte ist — ein geteiltes Team, eine soft-gelöschte Zeile, ein
+Zeitfenster von Daten — implementiere das Trait und überschreibe `filter_with`, das
+die Anfrage-`Parts` erhält:
+
+```rust
+use axum::http::request::Parts;
+use rustango::tenancy::Principal;
+use rustango::viewset::ViewSetFilter;
+
+struct OwnerFilter;
+
+impl ViewSetFilter for OwnerFilter {
+    // No principal in hand — fail closed. Returning no predicates here would
+    // widen the query to every row in the table.
+    fn filter(&self, _p: &HashMap<String, String>, schema: &'static ModelSchema) -> Vec<WhereExpr> {
+        deny_all(schema)
+    }
+
+    fn filter_with(
+        &self,
+        parts: &Parts,
+        _p: &HashMap<String, String>,
+        schema: &'static ModelSchema,
+    ) -> Vec<WhereExpr> {
+        let Some(principal) = Principal::from_parts(parts) else {
+            return deny_all(schema);
+        };
+        vec![WhereExpr::Predicate(Filter {
+            column: schema.field("owner_id").expect("owner_id").column,
+            op: Op::Eq,
+            value: SqlValue::from(principal.user_id),
+        })]
+    }
+}
+
+ViewSet::for_model(Note::SCHEMA)
+    .filter_backend(OwnerFilter)
+    .tenant_router("/api/notes")
+```
+
+`filter_with` fällt standardmäßig auf `filter` zurück, sodass ein Backend, das die Anfrage nicht braucht
+— einschließlich der schlichten Closure-Form — nur `filter` wie zuvor implementiert.
+
+---
+
+## Einbinden
+
+Setze den Router des ViewSets in deine App ein. Single-Tenant, statischer Pool:
+
+```rust
+let api = urls::api()
+    .merge(PostViewSet::router("/api/posts", pool.clone()))                          // macro
+    .merge(ViewSet::for_model(Author::SCHEMA).router_pool("/api/authors", pool.clone())); // builder
+```
+
+Multi-Tenant (kein Pool erfasst — jede Anfrage löst ihre Mandantenverbindung auf):
+
+```rust
+let api = urls::api()
+    .merge(ViewSet::for_model(Post::SCHEMA).tenant_router("/api/posts"));
+```
+
+`make:api_routes <app>` generiert eine `api()` pro App, die diese
+`.merge(...)`-Zeilen sammelt; binde sie in deine oberste `urls.rs` ein.
+
+---
+
+## Backend-Unterstützung
+
+- **Builder + `router_pool` / `tenant_router`** ist **tri-dialektfähig** — PostgreSQL,
+  SQLite und MySQL — und ist der empfohlene Weg.
+- **Das `router(prefix, PgPool)` des Derive-Makros** erfasst einen `PgPool` (PostgreSQL).
+- **Serializer-Eingabe + -Ausgabe** funktioniert jetzt auf **allen drei Backends** (das
+  Rendern pro Zeile ist tri-dialektfähig; das alte PG-only-Gate ist weg).
+- Filterung, Suche, Sortierung, die drei Paginierungsmodi, Berechtigungen,
+  Drosselung und Bulk-Create funktionieren alle über die unterstützten Backends hinweg auf dem
+  Builder-Pfad.
+
+---
+
+## Probier es aus
+
+Der obige End-to-End-Ablauf spiegelt das kompilierbare `getting_started_blog`-Beispiel
+(Schritte 12–13 der [Erste-Schritte-Anleitung](getting-started.md)). Die
+eigenen Live-Tests des Frameworks unter `crates/rustango/tests/viewset_*.rs` sind die
+vollständigste lauffähige Referenz — einschließlich der Serializer-Eingabe-/Ausgabe-Tests.
+Sie laufen auf In-Memory-SQLite, brauchen aber die passenden Feature-Flags, z. B.:
+
+```bash
+cd crates/rustango
+cargo test --features sqlite,tenancy --test viewset_serializer_render_sqlite_live
+cargo test --features sqlite,tenancy --test viewset_serializer_input_sqlite_live
+cargo test --features sqlite,tenancy --test viewset_sqlite_live
+```
+
+---
+
+## Siehe auch
+
+- [Serializer](serializers.md) — forme das JSON, das ein ViewSet sendet und validiert.
+- [HTML-Views](html-views.md) — das servergerenderte Gegenstück zu dieser JSON-API.
+- [OpenAPI](openapi.md) — generiere eine Spezifikation + Swagger-UI aus deinen ViewSets.
+- [URLs & Routing](urls.md) — setze ViewSet-Router in deine App ein.

--- a/docs/de/websockets.md
+++ b/docs/de/websockets.md
@@ -1,0 +1,217 @@
+# WebSockets & SSE
+
+Die meisten Requests sind einmalig: fragen, antworten, fertig. **Echtzeit**-Features sind die
+Ausnahme — eine Live-Benachrichtigung, ein Fortschrittsbalken, ein Dashboard, das sich
+selbst aktualisiert, ein Chat. Der Server muss zum Browser *pushen*, ohne gefragt zu werden.
+**Rustango** gibt dir beide Push-Transporte auf einer Grundlage:
+
+- **SSE (Server-Sent Events)** — ein Einweg-Stream, Server → Browser, über schlichtes
+  HTTP. Die eingebaute `EventSource` des Browsers verbindet sich automatisch neu. Das Einfachste,
+  was funktioniert; verwende es für Benachrichtigungen, Fortschritt, Live-Zähler, Feeds.
+- **WebSockets** — ein Vollduplex-Kanal, beide Richtungen. Verwende ihn, wenn der
+  Client auch sendet (Chat, kollaboratives Editieren, Präsenz).
+
+Beide fächern sich über denselben In-Process-**Broadcast-Bus** ([`EventBus`]) auf, sodass
+„sende dies an jeden verbundenen Client" ein einziger Aufruf ist, unabhängig vom Transport. Wenn du
+von Django kommst, ist das Channels; von Laravel, Echo/Reverb; von Node,
+`ws` + `EventSource` — dieselben Ideen, ein Bus dahinter.
+
+> **Quelle:** `rustango::sse` (`EventBus`) — hinter dem **`sse`**-Feature; und
+> `rustango::ws` (`WsHub`, `WsConfig`, `ws_handler`) — hinter dem
+> **`websocket`**-Feature (impliziert `admin` + `sse` + `axum/ws`). Beide sind im
+> Standard-Feature-Set. Der Server→Client-Kanal des MCP-Servers
+> (`rustango::mcp::transport`) ist ein Produktionskonsument der SSE-Seite.
+>
+> **Lauffähige Referenz:** Die maßgeblichen, aktuellen Snippets sind die
+> Modul-Schnellstarts in `src/sse.rs` und `src/ws.rs`; das Auffächern des
+> `EventBus` wird von den Unit-Tests in `src/sse.rs` abgedeckt.
+
+> **Neu bei einem Begriff hier?** *SSE*, *WebSocket*, *broadcast*, *keep-alive/ping*,
+> *back-pressure* — siehe das [Glossar](glossary.md).
+
+## Inhaltsverzeichnis
+
+- [SSE oder WebSocket — welches?](#sse-or-websocket--which)
+- [Der Broadcast-Bus](#the-broadcast-bus)
+- [Server-Sent Events](#server-sent-events)
+- [WebSockets](#websockets)
+- [Von anderswo senden](#sending-from-elsewhere)
+- [Auth & Mandantenfähigkeit](#auth--tenancy)
+- [Skalierungshinweise](#scaling-notes)
+- [Feature-Flags](#feature-flags)
+
+---
+
+## SSE oder WebSocket — welches?
+
+| | **SSE** | **WebSocket** |
+|---|---|---|
+| Richtung | nur Server → Client | bidirektional |
+| Transport | schlichtes HTTP (`text/event-stream`) | `ws://` / `wss://` Upgrade |
+| Reconnect | automatisch (in `EventSource` eingebaut) | du übernimmst es (oder eine Client-Bibliothek tut es) |
+| Proxys / Infra | nur HTTP — trivial proxybar | benötigt upgrade-fähige Proxys |
+| Client-API | `new EventSource(url)` | `new WebSocket(url)` |
+| Verwende es für | Benachrichtigungen, Fortschritt, Live-Zähler, Feeds | Chat, Präsenz, kollaboratives Editieren, alles, was der Client auch *sendet* |
+
+**Faustregel:** Wenn der Client nur *empfängt*, verwende SSE — es ist weniger Code, verbindet sich automatisch neu und läuft über gewöhnliches HTTP. Greife nur dann zu einem WebSocket, wenn der Client auch *sendet*.
+
+## Der Broadcast-Bus
+
+Beide Transporte sitzen auf [`EventBus<T>`] — einem günstig zu klonenden Auffächer-Kanal. Ein
+`send` erreicht jeden Abonnenten; langsame Abonnenten hinken hinterher, statt die
+anderen zu blockieren. `T` ist dein eigener `Clone`-Nachrichtentyp.
+
+```rust
+use rustango::sse::EventBus;
+use serde::{Serialize, Deserialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+struct Notification { kind: String, message: String }
+
+// capacity = per-subscriber buffer; older messages drop for a lagging client.
+let bus: EventBus<Notification> = EventBus::new(100);
+
+// share `bus` via router state (it's Clone). Then from anywhere:
+let delivered = bus.send(Notification { kind: "info".into(), message: "Saved".into() });
+//  `delivered` = how many connected clients received it (0 = no-op).
+```
+
+`EventBus`-API: `new(capacity)`, `send(event) -> usize`, `subscribe() ->
+broadcast::Receiver<T>`, `receiver_count() -> usize`.
+
+## Server-Sent Events
+
+Verdrahte den Bus mit einem SSE-Endpunkt über axums `Sse`-Response + einen
+`async_stream::stream!`, der jede Broadcast-Nachricht als Event weiterleitet. Füge
+`async-stream` und `futures` zu deiner `Cargo.toml` hinzu.
+
+```rust
+use std::convert::Infallible;
+use axum::{extract::State, response::sse::{Event, KeepAlive, Sse}, routing::get, Router};
+use futures::Stream;
+use rustango::sse::EventBus;
+
+async fn events(
+    State(bus): State<EventBus<Notification>>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let mut rx = bus.subscribe();
+    let stream = async_stream::stream! {
+        while let Ok(msg) = rx.recv().await {
+            let json = serde_json::to_string(&msg).unwrap_or_default();
+            yield Ok(Event::default().event("notification").data(json));
+        }
+    };
+    // keep-alive comments stop idle connections being reaped by proxies.
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+let app = Router::new()
+    .route("/events", get(events))
+    .with_state(bus.clone());
+```
+
+Browser — die eingebaute `EventSource` verbindet sich und reconnectet automatisch:
+
+```js
+const es = new EventSource('/events');
+es.addEventListener('notification', (e) => {
+  const n = JSON.parse(e.data);
+  console.log(n.kind, n.message);
+});
+es.onerror = () => {/* EventSource retries automatically */};
+```
+
+## WebSockets
+
+Für bidirektionalen Verkehr verwende [`WsHub`] + [`ws_handler`]. Der Hub umhüllt einen
+`EventBus` und ergänzt Keep-Alive-Pings, JSON-(De-)Serialisierung und die Behandlung langsamer
+Konsumenten; `ws_handler` betreibt eine Verbindung, bis der Client sich trennt.
+
+```rust
+use std::time::Duration;
+use axum::{extract::{State, WebSocketUpgrade}, response::Response, routing::get, Router};
+use rustango::{sse::EventBus, ws::{ws_handler, WsHub}};
+use serde::{Serialize, Deserialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+struct Tick { value: i64 }
+
+let bus: EventBus<Tick> = EventBus::new(100);
+let hub = WsHub::new(bus).keepalive(Duration::from_secs(20));
+
+async fn ws_route(ws: WebSocketUpgrade, State(hub): State<WsHub<Tick>>) -> Response {
+    ws.on_upgrade(move |socket| ws_handler(socket, hub.clone()))
+}
+
+let app = Router::new()
+    .route("/ws", get(ws_route))
+    .with_state(hub.clone());
+
+// From anywhere — one call fans out to every connected socket:
+hub.broadcast(Tick { value: 42 });
+```
+
+```js
+const ws = new WebSocket(`${location.origin.replace('http', 'ws')}/ws`);
+ws.onmessage = (e) => { const t = JSON.parse(e.data); console.log('tick', t.value); };
+```
+
+**Tuning** über [`WsConfig`] (Builder-Methoden auf `WsHub`):
+
+| Stellschraube | Standard | Wirkung |
+|---|---|---|
+| `.keepalive(Duration)` | 30 s | Intervall des Leerlauf-`Ping` — niedriger erkennt tote Verbindungen früher |
+| `.on_message(fn(&str) -> Option<String>)` | keine | verarbeitet Client→Server-Text; gib `Some(reply)` zurück, um ein Echo **nur an diesen Client** zu senden (rufe `hub.broadcast(..)` für das Auffächern auf) |
+| `.max_message_bytes(n)` | 1 MiB | schließt die Verbindung, wenn eine Client-Nachricht dies überschreitet |
+
+**Langsame Konsumenten** werden nicht stillschweigend verworfen: einem hinterherhinkenden Client
+wird mitgeteilt, dass er `n` Nachrichten verpasst hat (`Lagged(n)`), sodass er neu synchronisieren
+oder weitermachen kann.
+
+## Von anderswo senden
+
+Der Bus/Hub ist `Clone` und lebt im Router-State, sodass jeder Teil deiner
+App — ein Request-Handler, ein [Hintergrundjob](jobs.md), ein [Signal](models.md)-Empfänger —
+zu jedem verbundenen Client pushen kann, indem er einen Klon hält und
+`bus.send(..)` / `hub.broadcast(..)` aufruft. Ein häufiges Muster: Ein Job endet → er broadcastet eine
+„erledigt"-Benachrichtigung → der offene SSE-Stream des Browsers aktualisiert die UI.
+
+Ein `EventBus` kann **sowohl** eine SSE-Route als auch eine WebSocket-Route zugleich unterlegen —
+`WsHub::bus()` reicht dir den zugrunde liegenden Bus, um ihn mit einem SSE-Handler zu teilen, sodass
+Clients auf beiden Transporten denselben Stream sehen.
+
+## Auth & Mandantenfähigkeit
+
+Die SSE/WS-Routen sind gewöhnliche axum-Routen — lege deine übliche Auth darüber
+(Session, [JWT](auth-jwt-api.md), [API-Key](auth-api-keys.md)) genauso, wie du es
+bei jedem Handler tätest; füge den Extractor zur Route hinzu und lehne ab, bevor
+abonniert wird. In einer mandantenfähigen App löse den Mandanten auf der Verbindung auf und verwende
+einen **Bus pro Mandant** (oder filtere Nachrichten nach Mandant), sodass die Events eines
+Mandanten nie die Clients eines anderen erreichen. Der [MCP-Server](mcp.md) tut genau
+dies — sein authentifizierter, agentenbezogener SSE-Kanal baut auf dieser selben `sse`-Grundlage auf.
+
+## Skalierungshinweise
+
+`EventBus` ist ein **In-Process**-`tokio::sync::broadcast` — das Auffächern ist sofortig
+und sperrleicht, aber es erreicht nur Clients, die mit *diesem* Prozess verbunden sind. Du betreibst
+mehrere App-Instanzen hinter einem Load Balancer? Ein mit Knoten A verbundener Client
+sieht kein Event, das auf Knoten B gesendet wurde. Um über Knoten hinweg aufzufächern, überbrücke
+den Bus zu einem externen Pub/Sub (z. B. Redis) — veröffentliche Domänen-Events dort und lass den
+Abonnenten jedes Knotens sie erneut auf seinen lokalen `EventBus` `send`en. Der Ein-Knoten-Fall
+(der häufige Fall) braucht nichts davon.
+
+Bemesse außerdem `EventBus::new(capacity)` für deine Spitzenrate: es ist der Puffer pro
+Abonnent, und ein Client, der weiter als `capacity` zurückfällt, erhält ein
+`Lagged`-Signal statt unbeschränkten Speicherwachstums.
+
+## Feature-Flags
+
+```toml
+# Cargo.toml — both are in Rustango's default set; list them if you slim features.
+rustango = { version = "*", features = ["sse", "websocket"] }
+```
+
+- **`sse`** — der `EventBus`-Broadcast-Bus (zieht `tokio` nach). Ausreichend für SSE, da
+  das SSE-Drahtformat aus axums eigenem `response::sse` stammt.
+- **`websocket`** — das `WsHub` / `ws_handler`-Gerüst; impliziert `admin` (axum)
+  + `sse` + `axum/ws`.

--- a/docs/es/admin.md
+++ b/docs/es/admin.md
@@ -1,0 +1,545 @@
+# El panel de administración
+
+**Rustango** genera una interfaz de administración completa a partir de tus modelos —
+la misma idea que el admin de Django o un panel Nova/Filament de Laravel, pero con
+**cero código repetitivo por modelo**. Añade `#[derive(Model)]`, monta el admin una
+vez, y cada modelo obtiene una vista de lista con búsqueda, filtros, ordenación,
+paginación y acciones masivas; un formulario de creación/edición agrupado en conjuntos
+de campos; edición inline de hijos; un registro de auditoría por fila; y una referencia
+de modelos en vivo. Todo lo que sigue se configura de forma declarativa en un bloque
+`admin(...)` sobre el derive, o con un puñado de métodos del `Builder` y macros de
+registro a nivel de módulo.
+
+[![El admin autogenerado: una lista de entradas con facetas de filtro, búsqueda, acciones masivas y paginación — todo desde un solo bloque `admin(...)`](img/admin.png)](img/admin.png)
+
+> **Fuente:** `rustango::admin` (las opciones del derive `admin(...)`, la API del
+> `Builder` y las macros de registro) — tras la característica `admin` (activada por
+> defecto).
+>
+> **Versión ejecutable:** cada característica de esta página se ejercita en un ejemplo
+> probado y compilable en
+> [`crates/rustango/examples/admin_demo`](../crates/rustango/examples/admin_demo).
+> Las capturas de esta página provienen de ese ejemplo. Si un fragmento parece extraño,
+> compáralo con él.
+
+> **¿Un término aquí es nuevo para ti?** *model*, *fieldset*, *audit trail* — consulta el
+> [glosario](glossary.md).
+
+---
+
+## Tabla de contenidos
+- [Montarlo](#mount-it) · [La página de inicio](#the-home-page)
+- [Configurar un modelo: el bloque `admin(...)`](#configure-a-model-the-admin-block)
+- [La vista de lista](#the-list-view) — columnas, búsqueda, filtros, jerarquía de fechas, ordenación, paginación
+- [El formulario de cambio](#the-change-form) — conjuntos de campos, widgets, edición de FK, campos precompletados y de solo lectura
+- [Inlines](#inlines) · [Acciones masivas](#bulk-actions) · [Registro de auditoría](#audit-trail)
+- [Columnas calculadas y filtros personalizados](#computed-columns-and-custom-filters)
+- [Vistas, querysets y permisos personalizados](#custom-views-querysets-and-permissions)
+- [Autenticación](#authentication) · [Temas y marca](#theming-and-branding)
+- [Referencia del `Builder`](#builder-reference) · [Referencia de rutas](#routes-reference)
+- [La referencia de modelos (`__docs`)](#the-model-reference) · [Prueba el ejemplo](#try-the-example)
+
+---
+
+## Montarlo
+
+> **El admin está abierto por defecto.** Descubre y sirve *todos* los modelos
+> automáticamente — listar, crear, editar, eliminar — sin autenticación hasta que la
+> añadas. No lo expongas públicamente antes de conectar el inicio de sesión: consulta
+> [Autenticación](#authentication) más abajo.
+
+El admin es un `axum::Router` que construyes a partir de un pool de base de datos y
+anidas bajo una ruta:
+
+```rust
+use rustango::admin;
+
+let admin_router = admin::Builder::new(pool.clone())
+    .title("Admin Demo")
+    .subtitle("rustango auto-admin showcase")
+    .admin_prefix("/admin")          // MUST match the nest path below
+    .build();
+
+let api = axum::Router::new().nest("/admin", admin_router);
+```
+
+El auto-admin descubre cada `#[derive(Model)]` de tu binario **automáticamente** a
+través del registro `inventory` — no registras los modelos uno por uno. Abre
+`http://localhost:8080/admin` y aparecen agrupados en la barra lateral.
+
+> **`admin_prefix` debe coincidir con la ruta de anidamiento.** El admin construye sus
+> enlaces y acciones de formulario a partir de `admin_prefix` (por defecto `/__admin`).
+> Si anidas en `/admin` pero dejas el prefijo por defecto, cada enlace devuelve 404.
+> Ajústalos al mismo valor.
+
+> **Vincular el registro.** El registro de inventory solo se vincula al binario final si
+> los tipos de modelo se referencian en algún lugar. Un crate de biblioteca cuyos
+> modelos no se usan de otro modo puede necesitar un empujón con
+> `let _ = std::any::type_name::<Post>();` en `main` (el ejemplo lo hace) — de lo
+> contrario el enlazador los descarta y nunca aparecen.
+
+### La página de inicio
+
+La raíz del admin (`GET /<prefix>`) lista cada modelo registrado, agrupado por app, con
+el nombre de tabla y el recuento de campos de cada modelo — más un feed de **Recent
+actions** con los cambios auditados más recientes.
+
+[![La página de inicio del admin: cada modelo registrado agrupado por app con recuentos de tabla y campos, y un feed de actividad de acciones recientes](img/admin-home.png)](img/admin-home.png)
+
+---
+
+## Configurar un modelo: el bloque `admin(...)`
+
+Todo lo relativo a cómo aparece un modelo se establece en un bloque `admin(...)` sobre
+el derive. Aquí tienes el `Post` de exhibición del ejemplo, que ejercita casi todos los
+controles:
+
+```rust
+#[derive(Model, Clone, Debug)]
+#[rustango(
+    table = "posts",
+    display = "title",
+    admin(
+        list_display       = "id, title, author_id, status, view_count, published_at",
+        list_display_links = "id, title",
+        list_filter        = "status, author_id",
+        search_fields      = "title, body",
+        search_help_text   = "Search posts by title or body",
+        ordering           = "-published_at",
+        list_per_page      = 10,
+        date_hierarchy     = "published_at",
+        fieldsets          = "Content: title, body, status | Publishing: author_id, published_at, view_count",
+        actions            = "publish, archive",
+    ),
+    audit(track = "title, body, status"),
+)]
+pub struct Post { /* … */ }
+```
+
+`display = "title"` (en el modelo, fuera de `admin(...)`) establece la etiqueta legible
+que se usa allí donde se referencia una fila — columnas FK en las listas de otros
+modelos, la miga de pan, el título de la página de detalle.
+
+### Cada opción de `admin(...)`
+
+| Clave | Ejemplo | Qué hace |
+|---|---|---|
+| `list_display` | `"id, title, status"` | Columnas mostradas en la lista, en orden. Las columnas FK renderizan el valor `display` del objetivo. Las columnas calculadas (ver abajo) pueden nombrarse aquí. Vacío = cada campo escalar. |
+| `list_display_links` | `"id, title"` | Qué celdas de `list_display` enlazan a la página de detalle. Debe ser un subconjunto de `list_display`. |
+| `list_filter` | `"status, author_id"` | Tarjetas de faceta en el panel derecho — valores distintos + recuentos, clic para filtrar. Funciona en columnas escalares y FK. |
+| `search_fields` | `"title, body"` | Campos que coincide el cuadro de búsqueda `?q=` (`ILIKE`/`LIKE` insensible a mayúsculas). |
+| `search_help_text` | `"Search by title"` | Leyenda renderizada junto al cuadro de búsqueda. |
+| `ordering` | `"-published_at, id"` | Orden por defecto. Prefijo `-` = DESC; sin él = ASC. Varias claves separadas por comas. |
+| `list_per_page` | `10` | Tamaño de página (por defecto 50). |
+| `date_hierarchy` | `"published_at"` | Franja de desglose año → mes → día sobre la lista, en una columna Date/DateTime. |
+| `fieldsets` | `"Content: title, body \| Meta: status"` | Agrupa el formulario de cambio en secciones con título. La barra vertical `\|` separa secciones, la coma separa campos; la leyenda `Title:` es opcional. |
+| `actions` | `"publish, archive"` | Acciones masivas ofrecidas en el selector de acciones de la lista (cada una necesita un manejador registrado — ver [Acciones masivas](#bulk-actions)). |
+| `readonly_fields` | `"created_at"` | Campos renderizados como texto (sin entrada) en el formulario de cambio. |
+| `raw_id_fields` | `"author_id"` | Campos FK editados mediante una entrada de id sin procesar + un enlace de búsqueda (bueno para tablas objetivo grandes). |
+| `autocomplete_fields` | `"author_id"` | Campos FK editados mediante un autocompletado Ajax respaldado por el endpoint `__autocomplete` del objetivo. |
+| `prepopulated_fields` | `"slug:title"` | Autocompleta un campo sluggificando otro mientras escribes (`target:source`; combina fuentes con `+`). |
+| `list_select_related` | `"all"` / `"none"` / `"author_id"` | Controla el JOIN automático de columnas FK en la consulta de lista. `"all"` (por defecto) une cada FK; `"none"` lo desactiva; un CSV lo restringe a los FK nombrados. |
+| `formfield_overrides` | `"status:textarea"` | Sobrescribe el widget de formulario de un campo (`field:widget`) — ver la [tabla de widgets](#form-widgets). |
+| `actions_on_top` | `true` | Renderiza la barra de acciones masivas sobre la lista (por defecto `true`). |
+| `actions_on_bottom` | `false` | Renderiza una segunda barra de acciones bajo la lista (por defecto `false`). |
+
+---
+
+## La vista de lista
+
+`GET /<prefix>/<table>` renderiza la lista. A partir del único bloque `admin(...)` de
+arriba obtienes columnas ordenables, un cuadro de búsqueda con texto de ayuda, las
+tarjetas de faceta de estado/autor con recuentos en vivo, el desglose de fechas,
+paginación a 10/página y el selector de acciones publish/archive.
+
+**Filtrado.** Haz clic en cualquier valor de una tarjeta de faceta `list_filter` para
+acotar la lista; el filtro activo se muestra como un chip con un enlace **clear**, y el
+recuento de filas y los recuentos de facetas se actualizan. Los filtros, la búsqueda, la
+ordenación y la jerarquía de fechas se componen todos en la cadena de consulta y pueden
+combinarse.
+
+[![La lista de entradas filtrada por status=published: un chip de filtro activo, la faceta coincidente resaltada, el cuadro de búsqueda y el selector de acciones masivas](img/admin-list-filtered.png)](img/admin-list-filtered.png)
+
+**Ordenación.** Haz clic en un encabezado de columna para ordenar; clic de nuevo para
+invertir la dirección (`?sort=col&order=asc|desc`). El valor por defecto proviene de
+`ordering`.
+
+**Paginación.** `list_per_page` establece el tamaño de página; navega con `?page=N`.
+Para tablas muy grandes, regístralas con `Builder::skip_count_for([...])` para omitir el
+`SELECT COUNT(*)` (el paginador muestra entonces "Page N" sin un total general); un
+`?count=skip` por petición hace lo mismo de forma ad hoc.
+
+**Búsqueda.** Cuando `search_fields` está configurado, aparece un cuadro de búsqueda y
+coincide esos campos con `ILIKE` (PostgreSQL) / `LIKE` (MySQL, SQLite).
+`search_help_text` se renderiza como su leyenda.
+
+**Jerarquía de fechas.** Con `date_hierarchy` configurado, una miga de pan año → mes →
+día se sitúa sobre la tabla; profundizar añade filtros de rango semiabierto en esa
+columna usando extracción de fechas tri-dialecto (PostgreSQL `EXTRACT`, MySQL, SQLite
+`strftime`).
+
+---
+
+## El formulario de cambio
+
+`GET /<prefix>/<table>/new` (crear) y `GET /<prefix>/<table>/<pk>/edit` (editar)
+renderizan el formulario. `fieldsets` agrupa las entradas en secciones con título; sin
+él, todos los campos editables aparecen en un solo bloque.
+
+[![El formulario de cambio de Post agrupado en los conjuntos de campos Content y Publishing, cada campo con el widget de entrada adecuado para su tipo](img/admin-fieldsets.png)](img/admin-fieldsets.png)
+
+Enviar un formulario valida la entrada, escribe la fila, registra una entrada de
+auditoría y redirige a la vista de **detalle** de solo lectura
+(`GET /<prefix>/<table>/<pk>`), que muestra cada campo más los inlines y la tarjeta de
+auditoría (abajo). Los botones **Edit** y **Delete** de la página de detalle llevan al
+formulario y a la confirmación de eliminación.
+
+### Widgets de formulario
+
+Cada campo renderiza por defecto una entrada que coincide con su tipo —
+`<input type="number">` para enteros, `type="date"`/`datetime-local` para fechas,
+`type="checkbox"` para booleanos, un `<textarea>` para cadenas largas, un `<select>`
+para columnas FK, y así sucesivamente. Sobrescribe por campo con
+`formfield_overrides = "field:widget"`:
+
+| Widget | Se aplica a | Renderiza |
+|---|---|---|
+| `textarea` | String | `<textarea>` multilínea |
+| `password` | String | `<input type="password">` |
+| `email` | String | `<input type="email">` |
+| `url` | String | `<input type="url">` |
+| `color` | String | `<input type="color">` |
+| `slug` | String | entrada de texto con patrón de slug |
+| `ipaddress` | String | entrada de texto con patrón de IP |
+| `json` | Json | `<textarea>` monoespaciado |
+| `hidden` | cualquiera | `<input type="hidden">` |
+
+### Editar claves foráneas
+
+Las columnas FK tienen tres modos de edición:
+
+- **Por defecto** — un `<select>` poblado desde la tabla objetivo, que muestra el valor
+  `display` de cada fila.
+- **`raw_id_fields`** — una entrada de id simple más un enlace de búsqueda; ideal cuando
+  la tabla objetivo es demasiado grande para enumerarla en un desplegable.
+- **`autocomplete_fields`** — un autocompletado Ajax que consulta los `search_fields` del
+  modelo objetivo mediante `GET /<prefix>/<target>/__autocomplete?q=…`.
+
+### Campos precompletados y de solo lectura
+
+`prepopulated_fields = "slug:title"` emite JS del lado del cliente que sluggifica el
+campo fuente en el destino mientras escribes (combina varias fuentes con `+`, por
+ejemplo `"slug:section+title"`). `readonly_fields` renderiza los campos nombrados como
+texto escapado en el formulario en lugar de como entradas.
+
+---
+
+## Inlines
+
+Los inlines muestran las filas de un modelo hijo en la página del padre (inlines de
+Django). Registra uno a nivel de módulo:
+
+```rust
+rustango::register_admin_inline!(
+    parent = "posts",
+    child  = "comments",
+    fk     = "post_id",                                     // child column → parent PK
+    kind   = rustango::admin::inlines::InlineKind::Tabular, // or Stacked
+    label  = "Comments",
+    fields = &["author_name", "body", "created_at"],
+);
+```
+
+En la página de **detalle** del padre los hijos se renderizan como una tabla de solo
+lectura; en la página de **edición** se convierten en un FormSet editable (añadir /
+cambiar / eliminar filas en el sitio). Opciones: `kind` (`Tabular` — una fila de tabla
+por hijo, o `Stacked` — un conjunto de campos por hijo), `label`, `fields` (por defecto:
+cada escalar excepto el FK), `extra` (filas en blanco ofrecidas para añadir), `max_num`
+y `readonly_fields`.
+
+[![La página de detalle de una entrada: campos de solo lectura, la tabla inline de Comments y la tarjeta de registro de auditoría que muestra la entrada de creación como un diff JSON](img/admin-detail.png)](img/admin-detail.png)
+
+Para filas hijas adjuntadas mediante una clave foránea genérica (par content-type +
+object-pk) en lugar de una única columna FK, usa
+`register_admin_inline_generic!(parent, child, ct = "content_type_id", pk = "object_pk",
+…)` — con las mismas opciones por lo demás.
+
+---
+
+## Acciones masivas
+
+Nombra las acciones en `admin(actions = "...")`, luego registra un manejador por acción
+en el `Builder`. El manejador recibe el pool y las claves primarias de las filas
+seleccionadas:
+
+```rust
+use rustango::core::SqlValue;
+
+let admin_router = admin::Builder::new(pool)
+    .register_action("posts", "publish", |pool, pks| {
+        Box::pin(async move {
+            let ids: Vec<String> = pks.iter().filter_map(|v| match v {
+                SqlValue::I64(n) => Some(n.to_string()),
+                SqlValue::I32(n) => Some(n.to_string()),
+                _ => None,
+            }).collect();
+            if !ids.is_empty() {
+                let sql = format!("UPDATE posts SET status='published' WHERE id IN ({})", ids.join(","));
+                rustango::sql::raw_execute_pool(pool, &sql, Vec::new()).await?;
+            }
+            Ok(())
+        })
+    })
+    .register_action("posts", "archive", /* … */)
+    .build();
+```
+
+Selecciona filas con las casillas, elige la acción en el selector y envía
+(`POST /<prefix>/<table>/__action`). `delete_selected` está incorporada — no la
+registras. Un nombre de acción listado en `admin(actions = ...)` sin un manejador
+registrado simplemente no aparecerá.
+
+---
+
+## Registro de auditoría
+
+Añade `audit(track = "field1, field2")` a un modelo y cada creación, actualización y
+eliminación se registra en la tabla `rustango_audit_log` (creada por ti cuando ejecutas
+`migrate`). Solo se registran los modelos con un atributo `audit(...)`; `track`
+selecciona qué campos se capturan en el diff (omítelo para rastrear todos los escalares).
+
+```rust
+#[rustango(table = "posts", audit(track = "title, body, status"))]
+```
+
+Cada entrada almacena la tabla, la clave primaria, la operación, la fuente, un diff por
+campo (`{before, after}`) como JSON, el actor, una marca de tiempo y una huella
+resistente a manipulaciones. Dos lugares lo exponen:
+
+- La **página de detalle** del modelo gana una tarjeta **Audit trail** que lista los
+  cambios recientes (quién, cuándo y el diff), con un enlace **View full history**
+  (mostrado en la [captura de detalle](#inlines) de arriba).
+- La vista **Activity** de la barra lateral (`GET /<prefix>/__audit`) es un feed que
+  cruza filas, del más reciente al más antiguo, con tarjetas de faceta para entidad /
+  operación / fuente y un formulario de limpieza para purgar entradas de más de N días
+  (lo cual se registra a su vez como una entrada de auditoría).
+
+[![El feed de Activity: cada cambio auditado a través de los modelos con diffs JSON, tarjetas de faceta por tabla/operación/fuente y un formulario de limpieza](img/admin-audit.png)](img/admin-audit.png)
+
+---
+
+## Columnas calculadas y filtros personalizados
+
+Cuando el bloque declarativo no es suficiente, dos macros a nivel de módulo extienden la
+vista de lista:
+
+**Columnas calculadas** — una columna derivada, no de base de datos:
+
+```rust
+rustango::register_admin_computed!(
+    "posts", "word_count", "Words",
+    |row| row.get("body").and_then(|v| v.as_str())
+             .unwrap_or_default().split_whitespace().count().to_string(),
+);
+// then add `word_count` to admin(list_display = "...").
+```
+
+El closure recibe la fila como `serde_json::Value` y devuelve HTML preescapado. Una forma
+de 5 argumentos añade `link = |row| Option<String>` para envolver la celda en un `<a>`.
+
+**Filtros de lista personalizados** — lógica de filtrado que las autofacetas no pueden
+expresar:
+
+```rust
+fn by_status(value: &str) -> Vec<rustango::core::Filter> { /* map value → predicates */ }
+
+rustango::register_admin_list_filter!(
+    "posts", "status", "Status",
+    &[("draft", "Drafts"), ("published", "Published")],   // (value, label) choices
+    by_status,                                            // fn(&str) -> Vec<Filter>
+);
+```
+
+---
+
+## Vistas, querysets y permisos personalizados
+
+Tres macros de registro más reflejan los hooks de `ModelAdmin` de Django:
+
+- **Páginas de admin personalizadas** —
+  `register_admin_view!("posts", "duplicate", Method::POST, "Duplicate", handler)`
+  monta una página/acción adicional en `/<prefix>/posts/duplicate`. El manejador es un
+  `fn(Pool, Request) -> Response` asíncrono. (Los sufijos reservados como `new`,
+  `__action`, `__autocomplete`, `{pk}`, `{pk}/edit`, `{pk}/delete` se omiten con una
+  advertencia.)
+- **Acotación de querysets** —
+  `register_admin_queryset!("posts", hook)` donde `hook: fn(&Parts) -> Vec<Filter>`
+  restringe lo que una petición puede ver (por ejemplo, solo las filas del usuario
+  actual). Varios hooks sobre una tabla se componen.
+- **Permisos a nivel de fila** —
+  `register_admin_object_permission!("posts", "change", check)` donde
+  `check: fn(&Parts, Option<&Value>) -> bool` permite o deniega por fila. Los manejadores
+  incorporados consultan las acciones `add`, `change`, `delete` y `view`; varios hooks se
+  combinan con Y (AND).
+
+Para un control de acceso más grueso basado en codename, `Builder::with_user_perms([...])`
+condiciona cada tabla a `{table}.view` / `.add` / `.change` / `.delete`: la ausencia de
+`view` oculta el modelo y devuelve 404 en accesos directos, la ausencia de `change` lo
+renderiza de solo lectura, y la ausencia de `add` / `delete` elimina esos botones.
+
+---
+
+## Autenticación
+
+Por defecto el admin está **abierto** — cualquiera que pueda alcanzarlo puede usarlo.
+Restríngelo de una de dos maneras:
+
+- **Auth de sesión (incorporada).** `Builder::with_session_auth(secret)` monta
+  `/login` + `/logout` (y una página opcional de cambio en `/account/password`) y
+  envuelve cada otra ruta en middleware que redirige las peticiones anónimas al
+  formulario de inicio de sesión. Las credenciales viven en la tabla
+  `rustango_admin_users` (`username`, `password_hash` argon2, `is_superuser`, `active`,
+  `created_at`); cambiar una contraseña revoca las demás sesiones de ese usuario. La
+  autenticación de dos factores TOTP opcional está disponible tras la característica
+  `totp`, con inscripción en `/account/totp`.
+
+  ```rust
+  let admin = admin::Builder::new(pool)
+      .with_session_auth(session_secret)
+      .secure_cookies(true)              // HTTPS-only cookie in production
+      .build();
+  ```
+
+- **Ponle tu propia auth por delante.** Deja el admin abierto y coloca HTTP Basic auth,
+  OAuth2 o SSO corporativo delante de la ruta de anidamiento con tu propio middleware.
+
+Cuando la auth de sesión está activa, el pie de la barra lateral muestra una línea
+**"Signed in as _username_"** y un botón **Logout** (un formulario `POST`). Los admins
+independientes hacen POST a `{admin_prefix}/logout` por defecto; un admin de inquilino se
+sitúa tras la propia ruta de logout de la capa de tenancy, así que apunta el botón allí
+con `Builder::logout_url`:
+
+```rust
+let admin = admin::Builder::new(pool)
+    .with_session_auth(session_secret)
+    .logout_url("/staff-logout")       // POST target for the sidebar Logout button
+    .build();
+```
+
+El builder del admin de inquilino conecta esto a su `RouteConfig::logout_url`
+automáticamente, de modo que el botón siempre alcanza una ruta que existe.
+
+---
+
+## Temas y marca
+
+| Método | Efecto |
+|---|---|
+| `.theme_mode("light" \| "dark" \| "auto")` | Tema de color por defecto (establece `data-theme` en `<html>`). |
+| `.title(s)` / `.subtitle(s)` | Texto de cabecera de la barra lateral. |
+| `.brand_logo_url(url)` | Logo renderizado sobre el título. |
+| `.brand_name(s)` / `.brand_tagline(s)` | Sobrescrituras por inquilino del título/subtítulo. |
+| `.tenant_brand_css(css)` | Un bloque de variables CSS `:root{…}` prefabricado, incrustado inline para paletas por inquilino. |
+| `.from_settings(pool, &settings)` | Construye la marca + visibilidad a partir de las secciones `[admin]` / `[brand]` de tu archivo de configuración. |
+
+`from_settings` lee `admin.title`, `admin.subtitle`, `admin.logo_url`,
+`admin.theme_mode`, `admin.url_prefix`, `admin.allowed_tables`,
+`admin.read_only_tables`, recurriendo a la sección `[brand]`, y establece
+`secure_cookies` por defecto en `true`. Las llamadas imperativas al `Builder` posteriores
+siguen prevaleciendo.
+
+---
+
+## Referencia del `Builder`
+
+Cada método de `admin::Builder` (cada uno devuelve `Self` para encadenar salvo que se
+indique lo contrario):
+
+| Método | Propósito |
+|---|---|
+| `new(pool)` | Construir a partir de cualquier pool (PostgreSQL / MySQL / SQLite). Valores por defecto: prefijo `/__admin`, cookies de desarrollo. |
+| `from_settings(pool, &settings)` | Construir a partir de configuración parseada (característica `config`). |
+| `title(s)` / `subtitle(s)` | Cabecera / subcabecera de la barra lateral. |
+| `admin_prefix(p)` | Prefijo de URL — **debe coincidir con la ruta de anidamiento**. Por defecto `/__admin`. |
+| `audit_url(u)` | Ruta de la vista de actividad/auditoría. Por defecto `/__audit`. |
+| `static_url(u)` | Prefijo para los assets incrustados (favicon, logo). Por defecto `/__static__`. |
+| `change_password_url(u)` | Ruta de la página de autoservicio de cambio de contraseña (añade el enlace en la barra lateral). |
+| `show_only([tables])` | Lista blanca de qué tablas aparecen; las demás devuelven 404 y quedan ocultas. |
+| `read_only([tables])` | Renderiza esas tablas pero prohíbe crear/editar/eliminar. |
+| `read_only_all()` | Marca **cada** tabla como de solo lectura. |
+| `skip_count_for([tables])` | Omite `COUNT(*)` en tablas enormes (el paginador muestra "Page N"). |
+| `with_user_perms([codenames])` | Condiciona tablas a `{table}.view/add/change/delete`. |
+| `register_action(table, name, handler)` | Registra un manejador de acción masiva. |
+| `with_session_auth(secret)` | Requiere inicio de sesión por cookie (`/login` + `/logout`). |
+| `logout_url(u)` | Destino POST del botón Logout de la barra lateral. Por defecto `{admin_prefix}/logout`; los admins de inquilino lo ajustan a su ruta de logout de tenancy. |
+| `secure_cookies(bool)` | Establece el flag `Secure` (solo HTTPS) en la cookie de sesión. |
+| `theme_mode(m)` | `"light"` / `"dark"` / `"auto"`. |
+| `brand_logo_url(url)` | Logo sobre el título. |
+| `brand_name(s)` / `brand_tagline(s)` | Sobrescrituras de marca por inquilino. |
+| `tenant_brand_css(css)` | Bloque de variables CSS por inquilino. |
+| `impersonated_by(operator_id)` | Renderiza un banner de suplantación (consola de operador). |
+| `tenant_mode()` | Oculta los modelos con ámbito de registro (se establece automáticamente para los admins de inquilino). |
+| `build()` | Finaliza y devuelve el `axum::Router`. |
+
+---
+
+## Referencia de rutas
+
+Todas las rutas son relativas a `admin_prefix`:
+
+| Ruta | Método | Qué |
+|---|---|---|
+| `/` | GET | Inicio — índice de modelos + acciones recientes. |
+| `/<table>` | GET | Vista de lista (búsqueda, filtros, ordenación, paginación). |
+| `/<table>` | POST | Envío de creación. |
+| `/<table>/new` | GET | Formulario de creación. |
+| `/<table>/<pk>` | GET | Vista de detalle (solo lectura), con inlines + tarjeta de auditoría. |
+| `/<table>/<pk>` | POST | Envío de actualización. |
+| `/<table>/<pk>/edit` | GET | Formulario de edición. |
+| `/<table>/<pk>/delete` | POST | Eliminación (tras confirmación). |
+| `/<table>/__action` | POST | Ejecuta una acción masiva sobre los PK seleccionados. |
+| `/<table>/__autocomplete` | GET | JSON de autocompletado de FK (`?q=`). |
+| `/__docs` | GET | Referencia de modelos. |
+| `/__audit` (o `audit_url`) | GET | Feed de actividad + limpieza. |
+| `/login`, `/logout` | GET/POST | Auth de sesión (cuando está activada). |
+| `/account/password`, `/account/totp` | GET/POST | Autoservicio de cambio de contraseña / inscripción TOTP. |
+
+Las rutas personalizadas registradas con `register_admin_view!` se montan en
+`/<table>/<suffix>`.
+
+---
+
+## La referencia de modelos
+
+Cada admin incluye una referencia de modelos en vivo (los admindocs de Django) en
+`<prefix>/__docs` — un catálogo de solo lectura de cada modelo registrado con sus campos,
+columnas, tipos, flags (PK, unique, …) y relaciones. Nada que configurar; se genera a
+partir de tus modelos, así que nunca se desvía del esquema.
+
+[![La referencia de modelos: los campos de cada modelo con nombre de columna, tipo Rust, flags y relaciones — generados a partir de los modelos](img/admin-model-reference.png)](img/admin-model-reference.png)
+
+---
+
+## Prueba el ejemplo
+
+```bash
+cd crates/rustango/examples/admin_demo
+export DATABASE_URL=postgres://rustango:rustango@localhost:5432/admin_demo
+cargo run -- migrate     # tables + the audit-log table
+cargo run                # seeds demo data, serves the admin at /admin
+```
+
+Luego abre <http://localhost:8080/admin> y entra en **Posts** para ver los filtros, la
+búsqueda, la jerarquía de fechas, las acciones, los conjuntos de campos, los comentarios
+inline, el registro de auditoría y la referencia de modelos — cada captura de esta
+página — en un solo lugar.
+
+
+---
+
+## Véase también
+
+- [El recetario del ORM](orm.md) — los modelos a partir de los cuales se genera el admin (incl. el registro de auditoría compartido).
+- [Vistas HTML](html-views.md) — las vistas genéricas basadas en clases sobre las que se construye el admin.
+- [Backends de autenticación](auth-backends.md) · [Sesiones](auth-sessions.md) — asegurar el admin tras un inicio de sesión.
+- [Guía de seguridad](security.md) — endurecimiento antes de exponerlo.

--- a/docs/es/api-conventions.md
+++ b/docs/es/api-conventions.md
@@ -1,0 +1,321 @@
+# Convenciones de la API
+
+> **Para quién es esta página.** Esta es una **referencia avanzada para desarrolladores de Rust** que trabajan *con* o *en* el código del framework — explica las convenciones de nombres, tipos de retorno y módulos detrás de la API de Rust de Rustango. **No** es una guía para *llamar* a la API REST de una aplicación Rustango por HTTP. Si eso es lo que buscas, empieza por los [ViewSets](viewsets.md) (construir una API REST) y el [glosario](glossary.md) (términos en lenguaje llano); vuelve aquí cuando estés escribiendo Rust contra el framework.
+
+Esta página explica los patrones que sigue la API de **Rustango**, para que puedas predecir cómo se comporta cualquier método antes de leer su documentación. Si estás contribuyendo o auditando una funcionalidad, estas son las reglas.
+
+[![Convención de nombres de Rustango: el sufijo del método te dice qué recibe — `*_on` para un pool tipado, sin sufijo para el pool multi-backend, y señales sin pool](img/api-conventions.png)](img/api-conventions.png)
+
+## Tabla de contenidos
+
+- [Naming](#naming)
+- [Constructors](#constructors)
+- [Return types](#return-types)
+- [Async vs sync](#async-vs-sync)
+- [The pool argument](#the-pool-argument)
+- [Filtering](#filtering)
+- [Errors](#errors)
+- [Module naming](#module-naming)
+- [Builders vs config structs](#builders-vs-config-structs)
+- [Feature flags](#feature-flags)
+- [Macros vs runtime](#macros-vs-runtime)
+- [Contributing](#contributing)
+
+---
+
+## Nombres
+
+El nombre de un método te dice lo que hace. Una vez que aprendes estos sufijos, puedes adivinar la mayor parte de la API.
+
+### Funciones
+
+- **`save_on(executor)`, `delete_on(executor)`** — los métodos de escritura reciben un *executor* (un pool, una conexión o una transacción — lo que habla con la base de datos). El sufijo `_on` significa «ejecuta esto contra el executor que te entrego».
+- **`fetch_on(executor)`, `count_on(executor)`** — el mismo sufijo `_on`, para las lecturas.
+- **`save()`, `fetch()`, `count()`** sin `_on` — atajo que llama a la versión `_on` con un `&pool` por defecto. Solo funciona donde el queryset o el modelo ya guardan una referencia al pool (raro en código de aplicación).
+- **`from_X(value)`** — convierte DESDE otro valor (p. ej. `from_model(post)`, `from_base32(s)`).
+- **`with_X(value)`** — un método de builder que establece una opción y devuelve el objeto, de modo que puedes encadenar llamadas (p. ej. `with_default_ttl(d)`, `with_access_ttl(secs)`).
+- **`new()`** — el constructor mínimo. Cualquier argumento que reciba es una dependencia obligatoria (p. ej. `RedisCache::new(url)` — no puedes construir la caché sin una URL).
+
+### Tipos
+
+Estos siguen la convención de mayúsculas estándar de Rust, la misma división de PEP 8 de Python entre clases y funciones:
+
+- **`PascalCase`** — tipos, traits y variantes de enum (como las clases de Python).
+- **`snake_case`** — módulos, funciones, campos y variables locales.
+- **`SCREAMING_SNAKE_CASE`** — constantes, más la constante `Model::SCHEMA` que la macro derive genera para cada modelo.
+- **`Boxed*`** — un alias de `Arc<dyn Trait>`, un puntero compartido thread-safe a un objeto de trait (la forma en Rust de sostener «cualquier implementación de esta interfaz»). Por ejemplo `BoxedCache = Arc<dyn Cache>`. Este es el tipo estándar para un backend intercambiable que puedes sustituir.
+
+### Módulos
+
+- **Singular** cuando el módulo alberga UN tipo o concepto principal: `cache`, `email`, `storage`, `signed_url`, `request_id`.
+- **Plural** cuando el módulo alberga una COLECCIÓN de elementos: `bulk_actions`, `api_keys`, `passwords`, `forms`, `signals`.
+
+---
+
+## Constructores
+
+Cómo construyes un objeto depende de lo que necesita. Hay unas pocas formas estándar:
+
+| Patrón | Cuándo | Ejemplo |
+|---|---|---|
+| `T::new()` | Mínimo — sin dependencias obligatorias | `InMemoryCache::new()`, `Validator::new()` |
+| `T::new(arg)` | Una dependencia obligatoria | `EnvSecrets::with_prefix(s)`, `RedisCache::new(url)` |
+| `T::with_X(arg)` | Sobrescritura estilo builder tras `new()` | `InMemoryCache::with_default_ttl(d)`, `JwtLifecycle::new(s).with_access_ttl(60)` |
+| `T::from_X(arg)` | Convertir DESDE Y | `TotpSecret::from_base32(s)`, `Locale::new(s)` (a veces `from_str`) |
+| `T::for_Y(arg)` | Construir un T acotado a un Y específico | `ViewSet::for_model(schema)` |
+
+**Evita esto:** `T::with_X_and_Y_and_Z(a, b, c)` — un único constructor que recibe todo. Divídelo en `new(...)` más llamadas encadenadas `.with_*()`.
+
+---
+
+## Tipos de retorno
+
+El tipo de retorno de un método te dice cómo puede fallar. Rust no tiene excepciones, así que el fallo forma parte del valor de retorno. Hay tres formas.
+
+**`Result<T, E>`** — como una función que o bien devuelve un valor o bien lanza una excepción. Obtienes o el valor `T` o un error `E` con detalles. Úsalo para operaciones que pueden fallar y donde el *porqué* importa:
+- E/S: `pool.fetch(...).await -> Result<_, sqlx::Error>`
+- Validación: `Form::parse(data) -> Result<Self, FormErrors>`
+- Emisión: `JwtLifecycle::issue_pair_with(uid, claims) -> Result<_, JwtIssueError>`
+
+**`Option<T>`** — o un valor (`Some`) o nada (`None`), como un campo anulable. Úsalo cuando «no se encontró nada» es un resultado normal y no necesitas un mensaje de error que explique por qué:
+- Búsquedas: `cache.get(k) -> Result<Option<String>, _>` (el `Result` cubre el fallo de E/S; el `Option` cubre «clave ausente»)
+- Verificación: `JwtLifecycle::verify_access(token) -> Option<Claims>` («expirado o inválido» es un resultado esperado, así que `None` basta)
+- Lecturas de configuración opcionales: `env::optional("FOO") -> Result<Option<T>, _>`
+
+**`bool`** — un simple sí/no cuando no se necesita más detalle:
+- `cache.exists(k) -> Result<bool, _>` (el `Result` cubre la E/S; el `bool` es la respuesta)
+- `JwtLifecycle::revoke(token) -> bool` (true = añadido a la lista negra)
+- `disconnect_pre_save(id) -> bool` (true = se eliminó una entrada)
+
+**¿`Result<Option<T>>` o `Result<T>` con un error `NotFound`?** Ambos pueden expresar «la búsqueda falló», así que elige según lo excepcional que sea «no encontrado»:
+- Usa `Result<Option<T>>` cuando «no encontrado» es rutinario — tu código casi siempre se ramifica sobre `Some`/`None` de todos modos.
+- Usa `Result<T>` con una variante de error `NotFound` cuando «no encontrado» es excepcional — algo que registrarías como una advertencia o convertirías en un 404.
+
+---
+
+## Async vs sync
+
+La regla general: si un método espera algo (la base de datos, la red o el disco), es `async` y debes hacerle `.await`. Si solo calcula, es una llamada síncrona normal. Esta tabla lo detalla.
+
+| Operación | ¿Sync o async? |
+|---|---|
+| Método de trait que toca E/S (BD, red, archivo) | **async** |
+| Método de trait de puro cómputo (`hash`, `verify`, `encode`) | **sync** |
+| Métodos de builder (`with_X`, setters encadenables) | **sync** |
+| Macros (`derive(Model)`, `derive(Serializer)`) | **N/A** (en tiempo de compilación) |
+| Señal `connect_*` (registra un receptor) | **sync** |
+| Señal `send_*` (despacha a receptores async) | **async** |
+
+**Excepción:** `Cache::set` es `async` aunque la versión en memoria (`InMemoryCache::set`) nunca espera realmente. El trait está modelado para el caso de Redis, que sí lo hace. Es intencional: un método de trait debería ser `async` si *cualquier* implementación razonable necesita esperar, de modo que todos los backends compartan una misma firma.
+
+---
+
+## El argumento pool
+
+Cada llamada al ORM recibe un pool o executor (el handle de base de datos) como **último** argumento. Pasas la conexión cada vez, en lugar de depender de un estado global oculto:
+
+```rust
+post.save_on(&pool).await?
+Post::objects().filter(...).fetch_on(&pool).await?
+send_post_save(&post, ctx).await                  // ⚠️ no pool — signals are pool-free
+```
+
+**Una excepción:** las señales no reciben un pool, porque nunca tocan la base de datos. La regla se mantiene: todo lo que llega a la BD recibe el pool; todo lo que no, no.
+
+**¿Por qué pasarlo cada vez?** Rust prefiere las dependencias que puedes ver sobre el estado global oculto. Django mantiene la conexión en almacenamiento thread-local, pero eso se desmorona en el mundo async de Rust, donde una tarea puede saltar entre hilos a mitad de una petición. La desventaja es más tecleo; la ventaja es que puedes hacer grep de cada lugar que toca la base de datos.
+
+Si te encuentras pasando `&pool` a través de diez capas de llamadas a funciones, acepta `impl Executor` una sola vez en el punto de entrada público y deja que los helpers internos compartan esa única conexión.
+
+---
+
+## Filtrado
+
+Hay tres maneras de filtrar un queryset, y todas se combinan en una misma consulta. Elige según de dónde venga el filtro.
+
+```rust
+// 1. HTTP query string (set via ViewSet filter_fields, parsed at request time)
+//    GET /api/posts?author_id=42&status__ne=archived
+
+// 2. String-keyed (lookup at compile of the queryset; runtime field name resolution)
+Post::objects().filter("author_id", Op::Eq, SqlValue::I64(42));
+
+// 3. Typed columns (compile-time field check)
+Post::objects().where_(Post::author_id.eq(42));
+```
+
+| Sintaxis | Úsala cuando |
+|---|---|
+| Query HTTP | Endpoints de API públicos — el ViewSet los analiza por ti, como los backends de filtro de DRF |
+| `.filter` por clave-cadena | Código CRUD genérico o de admin, donde los nombres de campos vienen de la configuración y no se conocen en tiempo de compilación |
+| `.where_` tipado | El código de tu aplicación — la opción por defecto recomendada. El compilador comprueba que el campo existe y que los tipos coinciden |
+
+Puedes **mezclar las tres** en un mismo queryset.
+
+---
+
+## Errores
+
+**Rustango** tiene **más de 20 tipos de error** — uno por módulo — en lugar de una única clase de excepción para todo. Forman una jerarquía laxa, y un tipo de nivel superior los une de modo que rara vez lidias con ellos individualmente.
+
+| Capa | Módulo | Tipo de error |
+|---|---|---|
+| E/S del ORM | `sql::*` | `ExecError` |
+| Escritor SQL del ORM | `sql::*` | `SqlError` (variante de `ExecError::Sql`) |
+| Migraciones | `migrate::*` | `MigrateError` |
+| Formularios | `forms::*` | `FormError` (único) + `FormErrors` (múltiple) + `ModelFormError` |
+| Caché | `cache::*` | `CacheError` |
+| Email | `email::*` | `MailError` |
+| Almacenamiento | `storage::*` | `StorageError` |
+| Backends de autenticación | `tenancy::auth_backends` | `AuthError` |
+| JWT | `tenancy::jwt_lifecycle` | `JwtIssueError` |
+| Claves de API | `api_keys::*` | `ApiKeyError` |
+| Contraseñas | `passwords::*` | `PasswordError` |
+| Webhooks | `webhook::*` | (devuelve bool, sin error dedicado) |
+| URLs firmadas | `signed_url::*` | `SignedUrlError` |
+| Acciones masivas | `bulk_actions::*` | `BulkActionError` |
+| Fixtures | `fixtures::*` | `FixtureError` |
+| Filtro de IP | `ip_filter::*` | `IpFilterError` |
+| i18n | `i18n::*` | `I18nError` |
+| Env | `env::*` | `EnvError` |
+| Secrets | `secrets::*` | `SecretsError` |
+| Respuestas de API | `api_errors::*` | `ApiError` (con forma HTTP, no interno) |
+
+**El que hay que usar en los handlers:** existe un enum `RustangoError` de nivel superior (exportado desde `lib.rs`, junto con el alias `RustangoResult<T> = Result<T, RustangoError>`). Envuelve cada uno de los errores anteriores con conversiones `From`, de modo que el operador `?` promueve automáticamente cualquier error de módulo hacia él. También implementa `IntoResponse`, lo que significa que cada variante se mapea a un estado HTTP sensato cuando se devuelve desde un handler. La división es simple: usa los errores específicos por módulo en lo profundo de tu código, y `RustangoError` / `RustangoResult` en la frontera del handler. Para errores de crates de terceros, `RustangoError::other(msg)` / `RustangoError::other_from(e)` envuelven cualquier `std::error::Error + Send + Sync + 'static`.
+
+**Un ejemplo de handler:**
+
+```rust
+use rustango::api_errors::ApiError;
+
+async fn handler() -> Result<Json<X>, ApiError> {
+    let post = Post::objects().get(&pool, 1).await
+        .map_err(|e| ApiError::internal(e.to_string()))?;
+    Ok(Json(post))
+}
+```
+
+`ApiError` implementa `IntoResponse`, así que devolverlo produce automáticamente la forma JSON de error estándar.
+
+---
+
+## Nombres de módulos
+
+El nombre de un módulo debería permitirte **adivinar los nombres de los tipos que contiene** sin abrir el archivo.
+
+| Módulo | Alberga | Confianza de búsqueda |
+|---|---|---|
+| `cache` | el trait `Cache`, las impls `*Cache` | alta |
+| `email` | el trait `Mailer`, `Email`, las impls `*Mailer` | alta |
+| `storage` | el trait `Storage`, las impls `*Storage` | alta |
+| `signed_url` | las funciones libres `sign`, `verify` | media |
+| `text` | las funciones libres `slugify`, `html_escape`, `truncate` | media |
+| `bulk_actions` | `BulkActionRegistry`, `BulkAction`, las impls `Bulk*Action` | alta |
+| `api_keys` | las funciones libres `generate_key`, `verify_key`, `split_token` | media |
+
+**Evita esto:** un módulo que alberga un cajón de sastre heterogéneo (`utils`, `helpers`, `common`). Si no puedes nombrar el único concepto que cubre, no debería ser un módulo.
+
+---
+
+## Builders vs structs de configuración
+
+Hay dos maneras de entregar un objeto configurado. Elige según cómo lo configurarán los usuarios.
+
+### Builder: setters encadenados, sin `Default`
+
+```rust
+let l = SecurityHeadersLayer::strict()
+    .csp(...)
+    .header("x-extra", "v");
+```
+
+Úsalo cuando:
+- La mayoría de los usuarios parten de un preajuste y lo modifican
+- Los setters expresan intención (p. ej. `.errors_only()` se lee mejor que `.log_success(false)`)
+- El struct tiene muchos campos opcionales (10+)
+
+### Struct de configuración: establecer campos directamente, recurrir a `Default`
+
+```rust
+let l = AccessLogLayer {
+    log_success: false,
+    include_ip: true,
+    slow_threshold_ms: 500,
+    ..Default::default()
+};
+```
+
+Úsalo cuando:
+- Los usuarios quieren ser explícitos sobre cada campo
+- La reflexión / serialización importa
+- Actualizar en el sitio es común (`config.field = ...`)
+
+**Como regla, **Rustango** usa builders** para el middleware HTTP (`security_headers`, `cors`, `rate_limit`, etc.) y structs de configuración para los simples portadores de datos (`Email`, `AccessLogLayer`, el estado interno de `RateLimitLayer`).
+
+---
+
+## Feature flags
+
+Un *feature* es un flag de compilación de Cargo (el `[features]` de `Cargo.toml`) que activa o desactiva una parte del crate — similar al package discovery de Laravel o a los `INSTALLED_APPS` de Django, pero resuelto en tiempo de compilación. Cada módulo que arrastra una dependencia extra queda detrás de uno. El conjunto por defecto es «casi seguro que quieres estos»:
+
+```toml
+default = [
+    "postgres", "manage", "admin", "config", "forms", "serializer",
+    "cache", "signals", "email", "storage", "scheduler", "secrets", "totp",
+    "webhook", "webhook-delivery", "api_keys", "passwords", "signed_url",
+    "notifications", "casts", "jobs", "jobs-postgres", "auth_flows", "sse",
+    "websocket", "oauth2", "http-client", "compression", "openapi",
+    "csp-nonce", "sessions", "hmac-auth", "jwt", "uploads", "storage-s3",
+    "media", "runserver", "template_views",
+]
+```
+
+**Desactivados por defecto:** los features que arrastran dependencias pesadas o servicios externos:
+- `tenancy` — añade `argon2`, `hmac`, `sha2`, `cookie`, `tower` (la mayoría de las aplicaciones no lo necesitan)
+- `cache-redis` — añade el crate `redis` (a la mayoría de las aplicaciones les basta con la caché en memoria)
+- `csrf` — se activa automáticamente con `admin`, pero también está disponible por su cuenta
+
+Para adelgazar un binario que no necesita todo, desactiva los valores por defecto y lista solo lo que uses:
+
+```toml
+rustango = { version = "0.44", default-features = false, features = ["postgres", "admin"] }
+```
+
+---
+
+## Macros vs runtime
+
+Una *macro* es código que genera código en tiempo de compilación (`#[derive(Model)]` y compañía) — aproximadamente lo que hace un generador de Rails, salvo que se ejecuta en cada compilación y el compilador comprueba el resultado. La división de abajo decide qué hace una macro frente a código de runtime plano.
+
+| Aspecto | ¿Macro o runtime? |
+|---|---|
+| Metadatos de esquema para `inventory` | macro (`#[derive(Model)]`) |
+| Construcción de consultas guiada por el esquema | runtime (usa el `&'static ModelSchema` de la macro) |
+| Parseo de formularios | macro para el struct (`#[derive(Form)]`); runtime para la lógica de parseo |
+| Selección de campos del serializer | macro (`#[derive(Serializer)]`) — emite un `from_model` + una impl `Serialize` personalizada |
+| Operaciones de migración | runtime (diff de `SchemaSnapshot`) |
+| Despacho de señales | runtime (registro indexado por `TypeId`, sin macro por modelo) |
+| Coincidencia de patrones de los backends de autenticación | runtime (`#[async_trait]` sobre `AuthBackend`) |
+
+**Regla:** usa una macro para todo lo que el compilador pueda verificar de antemano (los nombres de campos deben existir, los tipos deben coincidir). Usa código de runtime para todo lo que varíe por petición o por despliegue.
+
+---
+
+## Contribuir
+
+Cuando añadas una nueva funcionalidad, sigue estos pasos:
+
+1. **Un módulo por concepto**, en `crates/rustango/src/<name>.rs` o `<name>/mod.rs`.
+2. **Añade rustdoc a nivel de módulo** con un ejemplo «Quick start» en un bloque `// ignore`.
+3. **Añade un feature flag si arrastras una nueva dependencia** — nómbralo según el módulo (`feature = "<name>"`).
+4. **Reexporta el módulo desde `lib.rs`** con una rustdoc de una línea.
+5. **Pon los tests unitarios en el mismo archivo**, tras `#[cfg(test)] mod tests` — sin base de datos a menos que realmente necesites una.
+6. **Pon los tests de integración en `crates/rustango/tests/<name>.rs`** para la historia de extremo a extremo.
+7. **No añadas un nuevo tipo de error a menos que los existentes no encajen** — extiende primero un enum existente.
+8. **Sigue la [guía de tipos de retorno](#return-types)** al elegir entre `Result`, `Option` o `bool`.
+9. **¿Añades un subcomando de `manage`?** Conéctalo en el dispatcher `match cmd` y en `print_help`, añade un test en `crates/rustango/tests/migrate_manage.rs`, y documenta una fila en `docs/manage.md`.
+10. **Actualiza `CHANGELOG.md`** con una entrada `Added` bajo la próxima versión.
+
+Cuando rompas la API:
+- Marca el elemento antiguo con `#[deprecated(since = "...", note = "use X instead")]` y consérvalo durante una versión minor completa antes de retirarlo.
+- Regístralo en `CHANGELOG.md` bajo `Breaking changes`.
+- Enlaza la ruta de migración desde las notas de la versión.

--- a/docs/es/auth-api-keys.md
+++ b/docs/es/auth-api-keys.md
@@ -1,0 +1,210 @@
+# Claves de API
+
+Una clave de API es una **credencial de larga duración para máquinas** — trabajos
+de CI, scripts, llamadas de servidor a servidor — que no pueden presentar un
+formulario de inicio de sesión ni llevar una cookie de sesión. El cliente envía
+la clave en cada petición; el servidor la busca e identifica al llamante.
+**Rustango** te ofrece dos capas: un ayudante autónomo de generación/verificación
+que puedes conectar a tu propia tabla, y un backend listo para usar que almacena
+las claves y autentica las peticiones `Authorization: Bearer`.
+
+[![Claves de API en Rustango: generate_key devuelve un token de un solo uso prefix.secret, almacenas el prefijo de 8 caracteres más un hash argon2id, y verify_key comprueba un secreto entrante](img/auth-api-keys.png)](img/auth-api-keys.png)
+
+> **¿Algún término te resulta nuevo?** *Token*, *hash*, *Bearer*, *argon2id* — el
+> [glosario](glossary.md) define los bloques de construcción.
+
+> **Fuente:** `rustango::api_keys` (`generate_key`, `hash_secret`, `verify_key`,
+> `split_token`, `ApiKeyError`) — el ayudante autónomo, tras la característica
+> `api_keys` (activada por defecto). El backend con almacenamiento es
+> `rustango::tenancy::auth_backends` (`create_api_key`, `ApiKeyBackend`,
+> `ensure_api_keys_table_pool`) — tras la característica `tenancy`.
+>
+> **Versión ejecutable:** los fragmentos del ayudante están copiados de
+> [`auth_api_keys_doc.rs`](../crates/rustango/tests/auth_api_keys_doc.rs)
+> (`cargo test -p rustango --test auth_api_keys_doc`); el flujo del middleware
+> `ApiKeyBackend` de
+> [`auth_backends_doc.rs`](../crates/rustango/tests/auth_backends_doc.rs)
+> (`cargo test -p rustango --features sqlite,tenancy --test auth_backends_doc`).
+
+## Tabla de contenidos
+
+- [Cómo funciona una clave de API](#how-an-api-key-works)
+- [El ayudante autónomo](#the-standalone-helper)
+- [El backend con almacenamiento](#the-stored-backend)
+- [Emitir una clave (CLI + código)](#issuing-a-key)
+- [Autenticar peticiones](#authenticating-requests)
+- [Notas de seguridad](#security-notes)
+- [Véase también](#see-also)
+
+---
+
+## Cómo funciona una clave de API
+
+Una clave tiene dos partes unidas por un punto: **`{prefix}.{secret}`**.
+
+- El **prefijo** tiene 8 caracteres — se almacena en texto claro y se usa como
+  índice de búsqueda rápido y único («¿qué clave es esta?»).
+- El **secreto** es la credencial real. Solo almacenas un **hash argon2id** del
+  mismo, nunca el secreto en sí.
+
+El token completo se muestra al usuario **exactamente una vez**, en la creación.
+Piérdelo y lo reemites — no hay forma de recuperarlo, porque solo se conserva el
+hash. Es la misma disciplina de «hashea, no almacenes» que en las
+[contraseñas](auth-passwords.md), aplicada a las credenciales de máquina.
+
+---
+
+## El ayudante autónomo
+
+`rustango::api_keys` es un conjunto de herramientas sin dependencias (sin base de
+datos, sin tablas) — úsalo cuando quieras almacenar las claves en tu propio
+esquema.
+
+```rust
+use rustango::api_keys::{generate_key, split_token, verify_key};
+
+// En la creación: devuelve (full_token, prefix, hash).
+let (token, prefix, hash) = generate_key()?;
+// → token  = "a1b2c3d4.<secret>"   mostrar al usuario UNA VEZ
+// → prefix = "a1b2c3d4"            almacenar como clave de búsqueda
+// → hash   = "$argon2id$v=19$..."  almacenar en lugar del secreto
+
+// En una petición entrante: extraer el token, encontrar la fila por prefijo, verificar.
+let (prefix, secret) = split_token(&token).expect("well-formed token");
+let stored_hash = lookup_hash_by_prefix(prefix);     // tu consulta
+if verify_key(secret, &stored_hash)? {
+    // autenticado
+}
+```
+
+`split_token` es estricto — devuelve `None` a menos que el prefijo tenga
+exactamente 8 caracteres y el secreto no esté vacío, de modo que una entrada
+malformada se rechaza antes de que toques la base de datos:
+
+```rust
+assert!(split_token("no-dot-here").is_none());
+assert!(split_token("short.secret").is_none()); // el prefijo debe tener 8 caracteres
+assert!(split_token("a1b2c3d4.").is_none());     // secreto vacío
+```
+
+`hash_secret` y `verify_key` usan argon2id con una sal aleatoria por hash, de
+modo que hashear el mismo secreto dos veces produce cadenas distintas — y ambas
+se verifican. `verify_key` devuelve `Ok(false)` en caso de discrepancia y
+`Err(ApiKeyError)` solo cuando la cadena almacenada no es un hash válido.
+
+---
+
+## El backend con almacenamiento
+
+Si ya estás en la capa `tenancy`, no necesitas tu propia tabla.
+`rustango::tenancy::auth_backends` incluye un modelo `ApiKey` (tabla
+`rustango_api_keys`), un creador, y un backend de autenticación que se conecta a
+la [cadena de backends](auth-backends.md).
+
+Inicializa la tabla una vez (tri-dialecto, idempotente):
+
+```rust
+use rustango::tenancy::auth_backends::ensure_api_keys_table_pool;
+
+ensure_api_keys_table_pool(&pool).await?;   // CREATE TABLE IF NOT EXISTS
+```
+
+La fila `ApiKey` almacena `user_id` (FK a `rustango_users`), el `key_prefix` de
+8 caracteres (único), el `key_hash` argon2id, una `label`, y un `expires_at`
+opcional.
+
+---
+
+## Emitir una clave
+
+`create_api_key` genera el token, hashea el secreto, inserta la fila, y devuelve
+el **token en texto claro una sola vez**:
+
+```rust
+use rustango::tenancy::auth_backends::create_api_key;
+
+// Emitir una clave sin expiración para el usuario 42, etiquetada "ci-key".
+let token = create_api_key(42, "ci-key", None, &pool).await?;
+println!("Store this — it won't be shown again: {token}");
+
+// O con una expiración:
+use chrono::{Duration, Utc};
+let token = create_api_key(42, "tmp", Some(Utc::now() + Duration::days(30)), &pool).await?;
+```
+
+Desde la línea de comandos, la CLI `manage` envuelve la misma llamada:
+
+```bash
+cargo run -- create-api-key <tenant> <username> --label "ci-key" --expires-days 30
+```
+
+---
+
+## Autenticar peticiones
+
+Registra `ApiKeyBackend` en tu [cadena de backends de
+autenticación](auth-backends.md) y el middleware autentica cualquier petición
+`Authorization: Bearer {prefix}.{secret}`:
+
+```rust
+use std::sync::Arc;
+use rustango::tenancy::auth_backends::{ApiKeyBackend, AuthBackend, ModelBackend};
+use rustango::tenancy::RouterAuthExt;
+
+let backends: Vec<Arc<dyn AuthBackend>> = vec![
+    Arc::new(ModelBackend),   // HTTP Basic (humanos)
+    Arc::new(ApiKeyBackend),  // clave Bearer  (máquinas)
+];
+
+let app = Router::new()
+    .route("/api/data", get(handler))
+    .require_auth(backends, pool);
+```
+
+Un cliente entonces llama:
+
+```bash
+curl https://api.example.com/api/data \
+  -H "Authorization: Bearer a1b2c3d4.the-secret-half"
+```
+
+El backend encuentra la `ApiKey` por su prefijo de 8 caracteres, comprueba
+`expires_at`, verifica el secreto contra el hash almacenado, carga al usuario
+propietario, y lo inyecta para que tus handlers lo lean mediante
+[`CurrentUser`](auth-backends.md). Un secreto incorrecto o un prefijo
+desconocido es un `401`; una clave caducada se rechaza; un propietario
+deshabilitado es un `403`.
+
+---
+
+## Notas de seguridad
+
+- **El secreto se muestra una vez.** Solo se persisten el prefijo + el hash
+  argon2id — no hay recuperación, solo reemisión.
+- **El prefijo se almacena en texto claro a propósito** — es el índice de
+  búsqueda O(1). Una fuga de base de datos revela qué prefijos existen, nunca los
+  secretos.
+- **El tiempo está igualado.** Un prefijo desconocido igualmente ejecuta una
+  verificación ficticia, de modo que una clave ausente tarda más o menos lo mismo
+  que una real — sin enumeración a través del tiempo de respuesta.
+- **Limita las claves a un usuario, establece una expiración, y rótalas.** Emite
+  una por integración para poder revocar una sin perturbar las demás; prefiere
+  ventanas `expires_at` cortas para acceso temporal.
+- **Desambiguación de los JWT:** el backend trata un valor Bearer como una clave
+  de API solo cuando su primer segmento separado por puntos tiene exactamente 8
+  caracteres — así las claves de API y los [JWT](auth-jwt.md) pueden compartir la
+  cabecera `Authorization: Bearer`.
+
+---
+
+## Véase también
+
+- [Backends de autenticación](auth-backends.md) — la cadena a la que se conecta
+  `ApiKeyBackend`, y el extractor `CurrentUser` + el middleware
+  `require_auth`/`require_perm`.
+- [Firma de peticiones HMAC](auth-hmac.md) — para llamantes de máquina que
+  necesitan integridad por petición, no solo una credencial bearer.
+- [Contraseñas](auth-passwords.md) — la misma disciplina de «hashea, no
+  almacenes» para los inicios de sesión humanos.
+- [JWT](auth-jwt.md) — tokens sin estado de corta duración, la otra opción de
+  máquina.

--- a/docs/es/auth-backends.md
+++ b/docs/es/auth-backends.md
@@ -1,0 +1,219 @@
+# Backends de autenticación
+
+Un **backend de autenticación** responde a una única pregunta: *dada una petición
+entrante, ¿quién es el usuario?* **Rustango** te permite apilar varios — HTTP
+Basic, clave de API, JWT — en una cadena que el middleware de autenticación
+prueba en orden, de modo que una misma aplicación puede aceptar humanos y
+máquinas en las mismas rutas. Es la idea de `AUTHENTICATION_BACKENDS` de Django,
+cableada a axum. Combínalo con `require_auth` / `require_perm` para restringir
+rutas y el extractor `CurrentUser` para leer el resultado.
+
+[![Backends de autenticación en Rustango: una petición fluye por una cadena de backends (ModelBackend, ApiKeyBackend, JwtBackend); el primero que reconoce la credencial gana e inyecta CurrentUser, luego require_perm comprueba un codename](img/auth-backends.png)](img/auth-backends.png)
+
+> **¿Algún término aquí es nuevo para ti?** *Backend*, *middleware*, *extractor*,
+> *codename de permiso* — consulta el [glosario](glossary.md).
+
+> **Fuente:** `rustango::tenancy::auth_backends` (`AuthBackend`, `ModelBackend`,
+> `ApiKeyBackend`, `JwtBackend`, `AuthUser`, `AuthError`) y
+> `rustango::tenancy::{RouterAuthExt, CurrentUser}` — detrás de la característica
+> `tenancy`. Un registro portable e independiente de la base de datos también
+> vive en `rustango::auth_backends` (siempre compilado).
+>
+> **Versión ejecutable:** cada fragmento está copiado de
+> [`auth_backends_doc.rs`](../crates/rustango/tests/auth_backends_doc.rs)
+> (`cargo test -p rustango --features sqlite,tenancy --test auth_backends_doc`).
+
+## Tabla de contenidos
+
+- [La cadena](#the-chain) · [Los backends integrados](#the-built-in-backends)
+- [Restringir rutas: require_auth](#gating-routes-require_auth)
+- [Leer el usuario: CurrentUser](#reading-the-user-currentuser)
+- [Permisos: require_perm](#permissions-require_perm)
+- [El registro portable](#the-portable-registry)
+- [Véase también](#see-also)
+
+---
+
+## La cadena
+
+Pasas a `require_auth` un `Vec<Arc<dyn AuthBackend>>`. En cada petición, el
+middleware los prueba **en orden**:
+
+- el **primer** backend que reconoce la credencial gana (devuelve el usuario);
+- un backend que no la reconoce devuelve «ninguno» y se prueba el siguiente;
+- si un backend falla de forma dura (p. ej. una cuenta inactiva con un token
+  *válido*), la cadena se detiene con ese error;
+- si ninguno coincide, la petición recibe `401` (con `require_auth`) o continúa
+  de forma anónima (con `optional_auth`).
+
+```rust
+use std::sync::Arc;
+use rustango::tenancy::auth_backends::{ApiKeyBackend, AuthBackend, ModelBackend};
+
+let backends: Vec<Arc<dyn AuthBackend>> = vec![
+    Arc::new(ModelBackend),    // HTTP Basic  → humans
+    Arc::new(ApiKeyBackend),   // Bearer key  → machines
+];
+```
+
+---
+
+## Los backends integrados
+
+| Backend | Credencial que lee | Identifica a un usuario por |
+|---|---|---|
+| `ModelBackend` | `Authorization: Basic <base64(user:pass)>` | nombre de usuario + verificación de contraseña argon2id contra `rustango_users` |
+| `ApiKeyBackend` | `Authorization: Bearer <prefix.secret>` | la tabla `rustango_api_keys` (véase [Claves de API](auth-api-keys.md)) |
+| `JwtBackend` | `Authorization: Bearer <jwt>` | un token HS256 firmado (véase [JWT](auth-jwt.md)) |
+
+`ApiKeyBackend` y `JwtBackend` leen ambos `Bearer` y desambiguan por la forma (el
+primer segmento separado por punto de una clave de API tiene exactamente 8
+caracteres). Construye `JwtBackend` con un secreto de **al menos 32 bytes**
+(`JwtBackend::new(secret)` entra en pánico en caso contrario):
+
+```rust
+use rustango::tenancy::auth_backends::JwtBackend;
+
+let backends: Vec<Arc<dyn AuthBackend>> = vec![
+    Arc::new(ModelBackend),
+    Arc::new(JwtBackend::new(jwt_secret_at_least_32_bytes.to_vec())),
+];
+```
+
+Escribe un backend personalizado implementando el trait (un único método async
+que inspecciona los `Parts` de la petición y devuelve `Option<AuthUser>`):
+
+```rust
+use async_trait::async_trait;   // add `async-trait` to your Cargo.toml
+use axum::http::request::Parts;
+use rustango::sql::Pool;
+use rustango::tenancy::auth_backends::{AuthBackend, AuthError, AuthUser};
+
+struct HeaderBackend;
+
+#[async_trait]
+impl AuthBackend for HeaderBackend {
+    async fn authenticate(&self, parts: &Parts, _pool: &Pool)
+        -> Result<Option<AuthUser>, AuthError>
+    {
+        // ...inspect parts.headers, return Some(AuthUser{..}) or Ok(None)
+        Ok(None)
+    }
+}
+```
+
+---
+
+## Restringir rutas: require_auth
+
+`RouterAuthExt` añade el middleware. `require_auth` rechaza las peticiones
+anónimas con `401`; `optional_auth` las deja pasar (de modo que un handler puede
+ramificar según con sesión iniciada o no):
+
+```rust
+use rustango::tenancy::RouterAuthExt;
+
+let app = Router::new()
+    .route("/profile", get(profile))
+    .require_auth(backends, pool);     // 401 if no backend matches
+```
+
+Comportamiento verificado:
+
+```rust
+// no credentials               → 401
+// Basic alice:<correct>        → 200
+// Basic alice:<wrong>          → 401   (no backend accepted; no enumeration)
+// Bearer <valid api key>       → 200
+```
+
+---
+
+## Leer el usuario: CurrentUser
+
+Los handlers leen el usuario autenticado con el extractor `CurrentUser`. Es
+infalible — `Some(user)` cuando un backend resolvió uno, `None` en caso
+contrario:
+
+```rust
+use rustango::tenancy::CurrentUser;
+
+async fn profile(CurrentUser(user): CurrentUser) -> Response {
+    match user {
+        Some(u) => format!("hello {}", u.username).into_response(),
+        None    => StatusCode::UNAUTHORIZED.into_response(),
+    }
+}
+```
+
+> **Trampa:** como `CurrentUser` es infalible, olvidar `require_auth` no provoca
+> un fallo de compilación — cada petición simplemente ve `None`. Detrás de
+> `require_auth`, las peticiones anónimas ya reciben `401`, así que `user`
+> siempre es `Some` ahí.
+
+---
+
+## Permisos: require_perm
+
+`require_perm` restringe una ruta a un **codename** de permiso
+(`{table}.{action}`, p. ej. `post.add`). Aplícalo al subrouter interno y
+`require_auth` al externo, de modo que el usuario se resuelva *antes* de
+comprobar el permiso:
+
+```rust
+let admin = Router::new()
+    .route("/admin", get(admin_only))
+    .require_perm("post.add", pool.clone());   // inner: needs the codename
+
+let app = Router::new()
+    .route("/profile", get(profile))
+    .merge(admin)
+    .require_auth(backends, pool);             // outer: resolves the user first
+```
+
+```rust
+// alice (granted post.add)   → /admin 200
+// bob   (authed, no grant)   → /admin 403
+// anonymous                  → /admin 401   (auth runs first)
+```
+
+Resolución: un **superusuario** (activo) pasa todo; un usuario **desactivado** es
+denegado incluso con concesiones; una anulación explícita por usuario prevalece
+sobre las concesiones de rol; en caso contrario, cualquier rol que el usuario
+posea que conceda el codename pasa. Concede con
+`set_user_perm_pool` / los roles mediante `create_role_pool` + `assign_role_pool`
+(las tablas de permisos las crea `ensure_tables_pool`).
+
+---
+
+## El registro portable
+
+Por separado, `rustango::auth_backends` (nota: raíz del crate, **no** `tenancy`)
+es un pequeño registro **independiente del framework** — una cadena
+`Credentials` → `Principal` con su propio trait `AuthBackend`. No tiene ningún
+pegamento HTTP/axum; úsalo cuando quieras una capacidad de conexión de backends
+al estilo Django dentro de tu propio código de autenticación:
+
+```rust
+use rustango::auth_backends::{AuthBackendChain, Credentials, RemoteUserBackend};
+
+let chain = AuthBackendChain::new().with(Arc::new(RemoteUserBackend::trust_username()));
+let principal = chain.authenticate(&Credentials::remote("alice")).await?;
+```
+
+La misma semántica «el primer éxito gana / el primer error detiene» que la cadena
+HTTP. Para restringir rutas reales, usa el middleware de `tenancy` de arriba.
+
+---
+
+## Véase también
+
+- [Claves de API](auth-api-keys.md) y [JWT](auth-jwt.md) — las credenciales que
+  `ApiKeyBackend` / `JwtBackend` consumen.
+- [Contraseñas](auth-passwords.md) — el hashing contra el que `ModelBackend`
+  verifica.
+- [Decoradores de acceso](auth-decorators.md) — restricción por handler con
+  `login_required` / `permission_required`, la alternativa de estilo decorador a
+  `require_auth`/`require_perm`.
+- [Sesiones](auth-sessions.md) — autenticación basada en cookies para
+  navegadores.

--- a/docs/es/auth-decorators.md
+++ b/docs/es/auth-decorators.md
@@ -1,0 +1,196 @@
+# Decoradores de acceso
+
+Una vez que un usuario está autenticado, restringes rutas. **Rustango** entrega
+la familia `@login_required` de Django como **capas** de axum componibles: adjunta
+una a un router y las peticiones anónimas son rechazadas — redirigidas con 302 a
+tu página de inicio de sesión (flujo de navegador) o respondidas con 401/403
+(flujo de API) — antes de que lleguen siquiera al handler.
+
+[![Decoradores de acceso: login_required redirige con 302 a los navegadores anónimos a /login?next=, la familia _or_403 devuelve 401/403 para APIs, superuser_required restringe por rol](img/auth-decorators.png)](img/auth-decorators.png)
+
+> **Fuente:** `rustango::auth_decorators` (`login_required`, `login_required_or_401`,
+> `user_passes_test`, `superuser_required`, `active_required`,
+> `permission_required` + las variantes `_or_403`; `safe_next`, `extract_next`) —
+> detrás de la característica `tenancy` (las barreras leen el extractor
+> `SessionUser`).
+>
+> **Versión ejecutable:** el comportamiento de restricción está cubierto por el
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_decorators.rs)
+> probado — `cargo test -p auth_demo --test auth_decorators`.
+
+> **¿Algún término aquí es nuevo para ti?** *middleware/capa*, *extractor*,
+> *401/403* — consulta el [glosario](glossary.md).
+
+> Compañero de inmersión profunda de la [guía de seguridad](security.md). Las
+> barreras leen la sesión establecida al iniciar sesión — consulta
+> [Sesiones](auth-sessions.md).
+
+---
+
+## Tabla de contenidos
+- [Inicio rápido](#quick-start) · [Barreras de navegador vs. API](#browser-vs-api-gates)
+- [La familia de barreras](#the-gate-family) · [Barreras por predicado y por rol](#predicate-and-role-gates)
+- [Barreras de permiso](#permission-gates) · [El viaje de ida y vuelta de `?next=`](#the-next-round-trip)
+- [Notas y límites](#notes-and-limits)
+
+---
+
+## Inicio rápido
+
+```rust
+use rustango::auth_decorators::login_required;
+
+// Scope the gate to a sub-router (the idiomatic shape):
+let private = Router::new()
+    .route("/profile", get(profile))
+    .route("/settings", get(settings))
+    .layer(login_required("/login"));      // anonymous → 302 /login?next=...
+
+let app = Router::new()
+    .route("/", get(home))                 // public
+    .merge(private);
+```
+
+Las peticiones anónimas a `/profile` se redirigen a `/login?next=%2Fprofile`; una
+petición autenticada pasa hasta el handler.
+
+---
+
+## Barreras de navegador vs. API
+
+La misma barrera viene en dos formas de respuesta. Elige según lo que el llamante
+puede hacer con la respuesta:
+
+- **Navegador / HTML** → las barreras base **redirigen con 302** a tu página de
+  inicio de sesión (un humano puede seguirla e iniciar sesión).
+- **API JSON** → la familia `_or_403` devuelve **códigos de estado**:
+  `401 Unauthorized` para anónimo, `403 Forbidden` para autenticado-pero-no-permitido
+  (un cliente no puede renderizar una página de inicio de sesión HTML, y la
+  división 401/403 le permite distinguir «inicia sesión» de «no puedes hacer
+  eso»).
+
+```rust
+// Browser: redirect to /login
+let app = Router::new().route("/dashboard", get(dash)).layer(login_required("/login"));
+
+// API: 401 for anonymous, never a redirect
+let api = Router::new().route("/api/me", get(me)).layer(login_required_or_401());
+```
+
+---
+
+## La familia de barreras
+
+| Barrera (navegador, 302) | Variante de API (401/403) | Deja pasar |
+|---|---|---|
+| `login_required(url)` | `login_required_or_401()` | cualquier usuario con sesión iniciada |
+| `active_required(url)` | `active_required_or_403()` | con sesión iniciada **y** `active` |
+| `superuser_required(url)` | `superuser_required_or_403()` | `is_superuser && active` |
+| `user_passes_test(url, pred)` | `user_passes_test_or_403(pred)` | predicado sobre la fila `User` |
+| `permission_required(url, codename)` | `permission_required_or_403(codename)` | posee el codename de permiso |
+
+Todas son capas tower — `.layer(...)`-las sobre un router o subrouter.
+
+---
+
+## Barreras por predicado y por rol
+
+`user_passes_test` ejecuta tu closure contra la fila `User` resuelta, de modo que
+puedes restringir por cualquier campo:
+
+```rust
+use rustango::auth_decorators::{user_passes_test, superuser_required_or_403};
+
+// Staff-only sub-router (browser):
+let staff = Router::new()
+    .route("/admin/dashboard", get(dashboard))
+    .layer(user_passes_test("/login", |u| u.is_superuser));
+
+// Superuser-only JSON API → 401 anonymous / 403 non-superuser:
+let api = Router::new()
+    .route("/api/admin/stats", get(stats))
+    .layer(superuser_required_or_403());
+```
+
+`superuser_required` / `active_required` son atajos fijados para los predicados
+comunes `is_superuser && active` / `active`, de modo que los puntos de llamada no
+divergen silenciosamente en si las cuentas desactivadas siguen contando.
+
+---
+
+## Barreras de permiso
+
+`permission_required` comprueba un codename de permiso contra el motor de
+permisos del inquilino (los superusuarios lo eluden automáticamente). Además
+resuelve el extractor `Tenant`, así que las rutas que lo usan deben montarse bajo
+el contexto del inquilino:
+
+```rust
+use rustango::auth_decorators::permission_required;
+use rustango::tenancy::permissions::ACCESS_ADMIN_CODENAME;
+
+let admin = Router::new()
+    .route("/admin", get(dashboard))
+    .layer(permission_required("/login", ACCESS_ADMIN_CODENAME));
+```
+
+---
+
+## El viaje de ida y vuelta de `?next=`
+
+`login_required` conserva la URL solicitada originalmente en `?next=` para que tu
+handler de inicio de sesión pueda devolver al usuario tras autenticarse. **Debes
+sanear ese valor** — reflejarlo en una redirección sin comprobarlo es un agujero
+de redirección abierta (phishing) de manual. `safe_next` es la salvaguarda:
+
+```rust
+use rustango::auth_decorators::{extract_next, safe_next};
+
+async fn login_post(Query(q): Query<HashMap<String, String>>, /* … */) -> Response {
+    // … verify credentials, set the session …
+    let dest = extract_next(&q)
+        .and_then(|n| safe_next(&n))          // rejects open redirects
+        .unwrap_or_else(|| "/".to_owned());
+    Redirect::to(&dest).into_response()
+}
+```
+
+`safe_next` solo acepta rutas del mismo origen, relativas a la raíz — rechaza las
+URL absolutas, las `//host` relativas al esquema, las variantes con barra
+invertida y sus formas codificadas en porcentaje:
+
+```rust
+assert_eq!(safe_next("/dashboard"),            Some("/dashboard".to_owned()));
+assert_eq!(safe_next("https://evil.example/x"), None);
+assert_eq!(safe_next("//evil.example/x"),       None);   // scheme-relative
+assert_eq!(safe_next("%2F%2Fevil.example/x"),   None);   // decodes to //evil
+```
+
+---
+
+## Notas y límites
+
+- **Estas barreras leen la sesión.** «Con sesión iniciada» significa que el
+  extractor [`SessionUser`](auth-sessions.md) resolvió un usuario a partir de la
+  cookie de sesión — así que son para autenticación por sesión/cookie. La
+  autenticación por token de API ([JWT](auth-jwt-api.md), [claves de
+  API](auth-api-keys.md)) se restringe en su lugar en la capa de la [cadena de
+  backends](auth-backends.md), leyendo la cabecera `Authorization`.
+- **El orden de las capas importa.** `.layer(gate)` protege cada ruta añadida al
+  router *antes* de ella; las rutas añadidas después son públicas. Acotar la
+  barrera a un subrouter dedicado (la forma del inicio rápido) evita esa trampa.
+- **`permission_required` necesita contexto de inquilino** (consulta el motor de
+  permisos del inquilino) — móntalo bajo el inquilino; una ruta sin inquilino
+  provoca un 500.
+- El `?next=` de la redirección siempre está codificado en porcentaje, de modo
+  que CRLF / división de respuestas no puede filtrarse en la cabecera
+  `Location`.
+
+
+---
+
+## Véase también
+
+- [Backends de autenticación](auth-backends.md)
+- [Sesiones](auth-sessions.md)
+- [Guía de seguridad](security.md)

--- a/docs/es/auth-flows.md
+++ b/docs/es/auth-flows.md
@@ -1,0 +1,192 @@
+# Flujos de cuenta (restablecimiento, verificación, enlace mágico)
+
+Los flujos que toda aplicación necesita en los márgenes del inicio de sesión: **restablecimiento
+de contraseña**, **verificación de correo electrónico** e **inicio de sesión por enlace mágico (sin
+contraseña)**. Los tres tienen la misma forma — enviar por correo al usuario un enlace a prueba de
+manipulaciones y con tiempo limitado, y luego actuar cuando hace clic en él — y **Rustango** los
+construye sobre un mismo sustrato: las **URL firmadas**. Una URL firmada es una URL normal con una
+firma HMAC añadida, de modo que el servidor puede confiar en sus parámetros sin almacenar nada.
+
+[![Flujos de cuenta en Rustango: signed_url::sign añade una firma HMAC + caducidad; los tres flujos (restablecimiento de contraseña, verificación de correo, enlace mágico) emiten un enlace, lo envían por correo y lo verifican al hacer clic](img/auth-flows.png)](img/auth-flows.png)
+
+> **¿Algún término aquí es nuevo para ti?** *HMAC*, *token*, *caducidad* — consulta el [glosario](glossary.md).
+
+> **Fuente:** `rustango::signed_url` (`sign`, `verify`, `SignedUrlError`) y
+> `rustango::auth_flows` (`PasswordReset`, `EmailVerification`, `MagicLink`,
+> `confirm_password_reset_pool_into`) — tras las funcionalidades `signed_url` / `auth_flows`
+> (activadas por defecto; la confirmación de restablecimiento también necesita `passwords` + un backend de BD).
+>
+> **Versión ejecutable:** cada fragmento está copiado de
+> [`auth_flows_doc.rs`](../crates/rustango/tests/auth_flows_doc.rs)
+> (`cargo test -p rustango --features sqlite --test auth_flows_doc`).
+
+## Tabla de contenidos
+
+- [URL firmadas: el sustrato](#signed-urls-the-substrate)
+- [Restablecimiento de contraseña](#password-reset)
+- [Verificación de correo electrónico](#email-verification)
+- [Inicio de sesión por enlace mágico](#magic-link-login)
+- [Tokens de un solo uso](#single-use-tokens)
+- [Lo que aportas tú](#what-you-provide)
+- [Véase también](#see-also)
+
+---
+
+## URL firmadas: el sustrato
+
+`sign` añade una firma HMAC-SHA256 (y una caducidad opcional) sobre la ruta + la query de la URL.
+`verify` la vuelve a calcular: manipula cualquier parámetro, usa el secreto equivocado o deja que
+caduque, y falla.
+
+```rust
+use rustango::signed_url::{sign, verify, SignedUrlError};
+
+let url = "https://app.example.com/files/42?user_id=7";
+let signed = sign(url, secret, None);     // None = never expires
+assert!(verify(&signed, secret).is_ok());
+
+// Flip any signed byte → InvalidSignature.
+let tampered = signed.replace("user_id=7", "user_id=8");
+assert_eq!(verify(&tampered, secret), Err(SignedUrlError::InvalidSignature));
+```
+
+Añade un TTL y un enlace caducado se rechaza (`sign_at` / `verify_at` toman segundos unix
+explícitos para pruebas deterministas):
+
+```rust
+use rustango::signed_url::{sign_at, verify_at, SignedUrlError};
+
+let signed = sign_at(url, secret, Some(100));         // expires at t=100
+assert!(verify_at(&signed, secret, 50).is_ok());      // before → ok
+assert_eq!(verify_at(&signed, secret, 1000), Err(SignedUrlError::Expired));
+```
+
+La query se ordena antes de firmar, así que el orden de los parámetros no importa. Los errores son
+`MissingSignature`, `MalformedSignature`, `InvalidSignature`, `Expired`.
+
+---
+
+## Restablecimiento de contraseña
+
+Los asistentes de `auth_flows` envuelven las URL firmadas con una **etiqueta de propósito** (para
+que un token de restablecimiento no pueda reproducirse como un enlace mágico) y codifican el
+identificador del usuario. `PasswordReset` también incluye un asistente de confirmación que
+verifica el token y **rota el hash almacenado** en una sola llamada.
+
+```rust
+use std::time::Duration;
+use rustango::auth_flows::{PasswordReset, confirm_password_reset_pool_into};
+
+// 1. User asks to reset → look them up → issue a link → email it.
+let url = PasswordReset::issue(
+    "https://app.example.com/auth/reset",   // your callback route
+    user_id,                                // encoded in the token
+    secret,
+    Duration::from_secs(3600),              // 1-hour TTL
+);
+mailer.send(&Email::new().to(addr).subject("Reset your password").body(&url)).await?;
+
+// 2. User clicks + submits a new password → verify + rotate the hash.
+let user_id = confirm_password_reset_pool_into(
+    &pool, &url, "a-brand-new-strong-password", secret,
+    "rustango_users", "id", "password_hash",  // table, pk col, password col
+).await?;
+```
+
+El asistente de confirmación exige una longitud mínima, aplica argon2id al nuevo password y lo
+escribe — rechazando entradas débiles, caducadas, manipuladas o con el secreto equivocado sin tocar
+la fila:
+
+```rust
+// valid token + strong pw → hash rotated (starts "$argon2…")
+// "short"                  → Err(WeakPassword), nothing written
+// user_id tampered         → Err(InvalidSignature), nothing written
+```
+
+> `confirm_password_reset_pool` es la forma cómoda que asume los valores por defecto
+> `rustango_users` / `id` / `password_hash`; usa `_into` para apuntar a tu propia
+> tabla/columnas.
+
+---
+
+## Verificación de correo electrónico
+
+`EmailVerification` codifica tanto el identificador del usuario **como** el correo electrónico, de
+modo que al verificar recuperas ambos y puedes confirmar que la dirección sigue coincidiendo
+(atrapando enlaces enviados antes de un cambio de correo). Aquí no hay ninguna escritura en BD
+integrada — tú defines tu propia columna «verificado»:
+
+```rust
+use rustango::auth_flows::EmailVerification;
+
+// On signup:
+let url = EmailVerification::issue(callback, user_id, &email, secret, Duration::from_secs(86_400));
+mailer.send(&Email::new().to(&email).subject("Confirm your email").body(&url)).await?;
+
+// On click:
+let (user_id, email) = EmailVerification::verify(&url, secret)?;
+// → if email still matches the user's current address, mark them verified
+```
+
+---
+
+## Inicio de sesión por enlace mágico
+
+`MagicLink` codifica solo el correo electrónico — el usuario hace clic, tú buscas la cuenta y
+acuñas una [sesión](auth-sessions.md). Mantén el TTL corto (10–30 min) y hazlo **de un solo uso**
+(siguiente sección), ya que el enlace *es* la credencial:
+
+```rust
+use rustango::auth_flows::MagicLink;
+
+let url = MagicLink::issue(callback, &email, secret, Duration::from_secs(900));
+mailer.send(&Email::new().to(&email).subject("Your sign-in link").body(&url)).await?;
+
+// On click:
+let email = MagicLink::verify_single_use(&url, secret, &cache).await?;
+// → look up the user by email, create a session
+```
+
+---
+
+## Tokens de un solo uso
+
+`verify` por sí solo únicamente comprueba firma + caducidad, así que un enlace filtrado es
+reproducible hasta que caduca. Para el inicio de sesión y el restablecimiento, prefiere
+`verify_single_use(url, secret, &cache)` — registra la firma del token en un `Cache` y rechaza un
+segundo uso:
+
+```rust
+// first click  → Ok(email)
+// same link reused → Err(AuthFlowError::AlreadyUsed)
+```
+
+Respáldalo con un caché **compartido** (Redis) en producción para que un token no pueda
+reproducirse contra una réplica distinta. La comprobación falla en modo cerrado (un error de caché
+rechaza en lugar de arriesgar una reproducción).
+
+---
+
+## Lo que aportas tú
+
+El framework emite/verifica los tokens y (para el restablecimiento) escribe el hash; tu aplicación
+aporta el resto:
+
+- Un **secreto** (una clave de aplicación estable; 32 bytes por convención).
+- Un **mailer** para enviar los enlaces — `rustango::email` incluye `ConsoleMailer`,
+  `SmtpMailer` e `InMemoryMailer` (útil en pruebas).
+- Una **tabla de usuarios** con las columnas que cada flujo necesita (correo para la búsqueda de
+  verificación/enlace mágico; una columna de hash de contraseña para el restablecimiento; una
+  columna «verificado» que es tuya).
+- Las **rutas de callback** que reciben el clic y la acuñación de sesión para el inicio de sesión
+  por enlace mágico.
+
+---
+
+## Véase también
+
+- [Contraseñas](auth-passwords.md) — el hashing que rota el restablecimiento.
+- [Sesiones](auth-sessions.md) — lo que el inicio de sesión por enlace mágico crea al tener éxito.
+- [Firma de peticiones HMAC](auth-hmac.md) — la misma primitiva HMAC, aplicada a peticiones de API
+  en lugar de a URL.
+- [Guía de seguridad](security.md) — la lista de endurecimiento más amplia.

--- a/docs/es/auth-hmac.md
+++ b/docs/es/auth-hmac.md
@@ -1,0 +1,188 @@
+# Firma de solicitudes con HMAC
+
+La firma HMAC demuestra **tanto quién envió una solicitud como que no fue
+alterada en tránsito**. El cliente firma cada solicitud con un secreto
+compartido; el servidor recalcula la firma y las compara. A diferencia de una
+[clave de API](auth-api-keys.md) de tipo bearer — que es reproducible si se
+captura — una firma HMAC cubre el método, la ruta, la query, la marca temporal
+y el cuerpo, de modo que una solicitud manipulada o caducada se rechaza. Es el
+esquema que usan AWS SigV4 y las firmas de webhooks, y **Rustango** lo incluye
+como una única capa tower.
+
+[![Firma HMAC en Rustango: el cliente firma method+path+query+date+body-hash con un secreto compartido; HmacAuthLayer recalcula y compara en tiempo constante, rechazando solicitudes manipuladas o caducadas](img/auth-hmac.png)](img/auth-hmac.png)
+
+> **¿Nuevo en algún término de aquí?** *HMAC*, *secreto compartido*, *replay*,
+> *comparación en tiempo constante* — consulta el [glosario](glossary.md).
+
+> **Fuente:** `rustango::hmac_auth` (`HmacAuthLayer`, `KeyResolver`, `sign_now`,
+> `sign_request`) — detrás de la feature `hmac-auth` (activa por defecto; la
+> protección contra replay además necesita `cache`).
+>
+> **Versión ejecutable:** cada fragmento está copiado de
+> [`auth_hmac_doc.rs`](../crates/rustango/tests/auth_hmac_doc.rs)
+> (`cargo test -p rustango --test auth_hmac_doc`).
+
+## Tabla de contenidos
+
+- [Cuándo usarlo](#when-to-use-it)
+- [Qué se firma](#what-gets-signed)
+- [Servidor: verificar con la capa](#server-verify-with-the-layer)
+- [Cliente: firmar una solicitud](#client-sign-a-request)
+- [Desfase de reloj y replay](#clock-skew-and-replay)
+- [Límites](#limits)
+- [Véase también](#see-also)
+
+---
+
+## Cuándo usarlo
+
+| Usa… | Cuándo |
+|---|---|
+| [Clave de API](auth-api-keys.md) (Bearer) | Autenticación de máquina sencilla; el riesgo de captura es aceptable (TLS, rotación corta). |
+| **Firma HMAC** | Necesitas **integridad por solicitud + resistencia a replay** — webhooks, APIs de socios, cualquier cosa donde una solicitud capturada no deba ser reutilizable ni modificable. |
+| [JWT](auth-jwt.md) | Tokens de usuario sin estado y autodescriptivos con claims. |
+
+HMAC requiere que ambos lados tengan el mismo secreto fuera de banda (tú lo
+aprovisionas), y relojes razonablemente sincronizados.
+
+---
+
+## Qué se firma
+
+El cliente construye una cadena canónica y le aplica HMAC-SHA256 con el secreto
+compartido:
+
+```text
+<UPPERCASE-METHOD>\n
+<PATH>\n
+<SORTED-QUERY>\n
+<X-DATE>\n
+<HEX-SHA256(BODY)>
+```
+
+Dos cabeceras de la solicitud llevan el resultado:
+
+- `X-Date` — una marca temporal RFC 3339 (también parte de la cadena firmada).
+- `Authorization: HMAC-SHA256 keyId=<id>,signature=<base64>`
+
+Como la query se **ordena** en ambos extremos, `?b=2&a=1` y `?a=1&b=2` producen
+la misma firma. Como el cuerpo se hashea dentro de la cadena, cambiar un solo
+byte la invalida.
+
+---
+
+## Servidor: verificar con la capa
+
+`HmacAuthLayer::new` recibe un **`KeyResolver`** — un closure que mapea un
+`keyId` a su secreto (`None` ⇒ clave desconocida ⇒ 401). Adjúntalo como una
+capa tower normal delante de las rutas que quieras proteger:
+
+```rust
+use std::sync::Arc;
+use rustango::hmac_auth::{HmacAuthLayer, KeyResolver};
+use tower::Layer;
+
+// Resolve key ids to secrets — back this with your DB / secret store.
+let resolver: KeyResolver = Arc::new(|key_id: &str| {
+    (key_id == "k_demo").then(|| b"shared-secret-at-least-32-bytes-long!!".to_vec())
+});
+
+let layer = HmacAuthLayer::new(resolver)
+    .tolerance_secs(300);                 // ±5 min clock-skew window (default)
+
+let app = protected_router.layer(layer);
+```
+
+Una solicitud firmada correctamente pasa; manipula el cuerpo, quita `X-Date`, o
+firma con una clave desconocida y será un `401`:
+
+```rust
+// correctly signed            → 200
+// body changed after signing  → 401  (signature mismatch)
+// missing X-Date header       → 401
+// keyId the resolver rejects  → 401
+```
+
+> **Sin extractor de identidad.** La capa verifica la firma pero **no** inyecta
+> qué `keyId` firmó en la solicitud — no hay un extractor `HmacUser`. Si un
+> handler necesita la identidad del llamante, envuelve la capa o transpórtala tú
+> mismo. Los rechazos son respuestas `401`/`413` planas, no un error tipado
+> sobre el que hagas match.
+
+---
+
+## Cliente: firmar una solicitud
+
+`sign_now` firma con la hora actual y devuelve los dos valores de cabecera para
+adjuntar (`sign_request` es la variante que toma una fecha RFC 3339 explícita):
+
+```rust
+use rustango::hmac_auth::sign_now;
+
+let body = br#"{"amount": 100}"#;
+let (x_date, authorization) =
+    sign_now("k_demo", b"shared-secret-at-least-32-bytes-long!!",
+             "POST", "/api/charge", "", body);
+
+// Attach both headers and send the EXACT body you signed:
+let req = http::Request::post("/api/charge")
+    .header("x-date", x_date)
+    .header("authorization", authorization)
+    .body(body.to_vec())?;
+```
+
+La firma es base64; el hash del cuerpo dentro de la cadena canónica es hex. Envía
+el cuerpo byte por byte tal como lo firmaste — cualquier proxy que lo reescriba
+(recompresión, reserialización de JSON) rompe la verificación.
+
+---
+
+## Desfase de reloj y replay
+
+La marca temporal `X-Date` acota el replay: una solicitud cuya fecha esté fuera
+de `tolerance_secs` (por defecto ±300 s) se rechaza, de modo que una solicitud
+capturada solo es reutilizable dentro de esa ventana corta. Para cerrarla por
+completo, adjunta un **almacén de nonce** (cualquier `cache::Cache`) y cada firma
+podrá gastarse una sola vez dentro de la ventana:
+
+```rust
+use rustango::cache::InMemoryCache;
+
+let layer = HmacAuthLayer::new(resolver)
+    .tolerance_secs(120)
+    .nonce_store(Arc::new(InMemoryCache::new()));  // reject replays
+```
+
+En producción usa un almacén **compartido** (Redis) para que la protección se
+mantenga a través de las réplicas — una caché en proceso solo protege una
+instancia. La comprobación de replay falla en modo abierto (fail-open) ante un
+error de caché (disponibilidad por encima del estrecho riesgo dentro de la
+ventana).
+
+---
+
+## Límites
+
+- **±desfase simétrico, fechas RFC 3339.** Ambos relojes deben estar más o menos
+  sincronizados; el cliente debe enviar la misma marca temporal que firmó
+  (`sign_now` te la devuelve).
+- **Almacenamiento completo del cuerpo en búfer.** El cuerpo se lee en memoria
+  para hashearlo (límite por defecto 10 MiB → `413`; súbelo con `.body_limit(n)`
+  pero cuida la memoria). Los cuerpos en streaming no están soportados.
+- **La firma va en base64 en el cable, el hash del cuerpo va en hex** — fácil de
+  confundir al escribir un cliente en otro lenguaje.
+- **Mantén la capa lo más externa posible** respecto a cualquier cosa que mute
+  el cuerpo.
+
+---
+
+## Véase también
+
+- [Claves de API](auth-api-keys.md) — credencial bearer más sencilla cuando la
+  integridad/replay no son una preocupación.
+- [Backends de autenticación](auth-backends.md) — para identificar a un *usuario*
+  por solicitud (HMAC demuestra la integridad del mensaje, no una identidad de
+  sesión).
+- [Webhooks](security.md) — la contraparte entrante: verificar firmas en los
+  eventos que recibes.
+- [Middleware](middleware.md) — cómo se adjuntan y ordenan las capas tower.

--- a/docs/es/auth-jwt-api.md
+++ b/docs/es/auth-jwt-api.md
@@ -1,0 +1,224 @@
+# API de autenticación JWT
+
+El módulo [JWT independiente](auth-jwt.md) firma y verifica un solo token. Una
+API real necesita todo el **ciclo de vida**: un token de *acceso* de corta
+duración, un token de *refresco* de larga duración, rotación en el refresco, y
+**revocación** para el cierre de sesión. **Rustango** lo entrega como
+`JwtLifecycle` — y un router listo para usar que monta por ti
+`POST /api/auth/login`, `/refresh`, `/logout`, y `GET /me`.
+
+[![API de autenticación JWT: login emite un par access+refresh, refresh rota y pone en lista negra el token antiguo, logout revoca a través de un almacén de JTI](img/auth-jwt-api.png)](img/auth-jwt-api.png)
+
+> **Fuente:** `rustango::tenancy::jwt_lifecycle` (`JwtLifecycle`, `JwtTokenPair`,
+> `JwtClaims`) y `rustango::tenancy::auth_routes` (`jwt_router`, `Config`) +
+> `rustango::jti_store` (`JtiStore`, `InMemoryJtiStore`) — tras `jwt` +
+> `tenancy`.
+>
+> **Versión ejecutable:** el motor de tokens está cubierto por el test
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs) —
+> `cargo test -p auth_demo --test auth_jwt_api`. Los endpoints HTTP están
+> delimitados por tenant y se ejercitan de extremo a extremo por el propio
+> `crates/rustango/tests/tenant_auth_live.rs` del framework.
+
+> **¿Algún término te resulta nuevo?** *token de acceso/de refresco*,
+> *rotación*, *revocación* — consulta el [glosario](glossary.md).
+
+> Complemento en profundidad de la sección «Emitir y renovar JWT» de la
+> [Guía de seguridad](security.md). Para un solo token gestionado manualmente,
+> consulta en su lugar [JWT (independiente)](auth-jwt.md).
+
+---
+
+## Tabla de contenidos
+- [El router integrado](#the-built-in-router) · [El cableado](#wiring-it-up)
+- [El motor de tokens](#the-token-engine-jwtlifecycle) · [Refresco y rotación](#refresh-and-rotation)
+- [Revocación y el almacén de JTI](#revocation-and-the-jti-store) · [Claims personalizados](#custom-claims)
+- [Notas y límites](#notes-and-limits)
+
+---
+
+## El router integrado
+
+`jwt_router` monta los cuatro endpoints estándar contra la tabla
+`rustango_users` propia de cada tenant — las ~50 líneas de boilerplate de login
+que todo proyecto reescribe de otro modo:
+
+| Método | Ruta | Cuerpo / Auth | Devuelve |
+|---|---|---|---|
+| POST | `/api/auth/login` | `{username, password}` | `{access, refresh, user}` |
+| POST | `/api/auth/refresh` | `{refresh}` | `{access, refresh}` |
+| POST | `/api/auth/logout` | `Authorization: Bearer <access>` | `204` (revoca el JTI) |
+| GET | `/api/auth/me` | `Authorization: Bearer <access>` | `{user_id, username, is_superuser}` |
+
+Login verifica la contraseña con [argon2id](auth-passwords.md), luego emite un
+par. Las rutas, los TTL y la clave de firma son configurables mediante `Config`.
+
+## El cableado
+
+```rust
+use rustango::tenancy::auth_routes::{jwt_router, Config};
+
+rustango::manage::Cli::new()
+    .tenancy()
+    .api(my_app::urls::api()
+        .merge(jwt_router(Config::default())))   // monta /api/auth/*
+    .run()
+    .await
+```
+
+`Config::default()` firma con `RUSTANGO_SESSION_SECRET` (la misma clave que la
+cookie de sesión del admin) y usa TTL de 15 min de acceso / 7 días de refresco.
+Sobrescribe `prefix`, `access_ttl_secs`, `refresh_ttl_secs`, o `session_secret`
+según necesites. Los endpoints se ejecutan bajo el contexto del tenant, así que
+móntalos en una aplicación tenancy.
+
+```sh
+# Login → access + refresh
+curl -sX POST localhost:8080/api/auth/login \
+  -H 'content-type: application/json' \
+  -d '{"username":"alice","password":"hunter2hunter"}'
+
+# Llamar a un endpoint protegido
+curl localhost:8080/api/auth/me -H "Authorization: Bearer $ACCESS"
+```
+
+---
+
+## El motor de tokens (`JwtLifecycle`)
+
+Bajo el router se encuentra `JwtLifecycle` — utilizable directamente si quieres
+el ciclo de vida sin la forma HTTP integrada:
+
+```rust
+use rustango::tenancy::jwt_lifecycle::JwtLifecycle;
+
+let jwt = JwtLifecycle::new(secret_32_bytes);
+
+// Login: emitir el par.
+let pair = jwt.issue_pair(user_id);
+// → pair.access  (TTL corto, enviar en la cabecera Authorization)
+// → pair.refresh (TTL largo, almacenar en una cookie HttpOnly / almacenamiento seguro)
+
+// Petición autenticada: verificar el token de acceso.
+match jwt.verify_access(&access) {
+    Some(claims) => { /* claims.sub es el id de usuario */ }
+    None => { /* 401: inválido, caducado, revocado, o tipo incorrecto */ }
+}
+```
+
+Los tokens de acceso y de refresco **no son intercambiables** — `verify_access`
+rechaza un token de refresco y viceversa, de modo que un token de acceso de corta
+duración robado no puede usarse para acuñar nuevos:
+
+```rust
+let pair = jwt.issue_pair(42);
+assert!(jwt.verify_refresh(&pair.access).is_none());
+assert!(jwt.verify_access(&pair.refresh).is_none());
+```
+
+---
+
+## Refresco y rotación
+
+`refresh` intercambia un token de refresco válido por un **nuevo par** y pone en
+lista negra el JTI del token de refresco antiguo — expiración deslizante con
+tokens de refresco de un solo uso (la reproducción del antiguo se rechaza):
+
+```rust
+let pair = jwt.issue_pair(7);
+let rotated = jwt.refresh(&pair.refresh).expect("refresh ok");
+assert_ne!(pair.access, rotated.access);
+assert!(jwt.refresh(&pair.refresh).is_none());   // el refresh antiguo ya está muerto
+```
+
+Por defecto, `refresh` **preserva** los claims personalizados del token. Si los
+permisos pueden haber cambiado (rol revocado, alcance degradado), usa
+`refresh_with(token, new_claims)` para sustituir un payload nuevo mientras se
+sigue poniendo en lista negra el JTI de refresco antiguo.
+
+---
+
+## Revocación y el almacén de JTI
+
+Cada token lleva un `jti` único. `revoke` lo añade a una lista negra para que las
+llamadas `verify_*` posteriores fallen hasta que el token hubiera expirado de
+todos modos — esto es lo que llama `POST /api/auth/logout`:
+
+```rust
+let pair = jwt.issue_pair(1);
+assert!(jwt.revoke(&pair.access));
+assert!(jwt.verify_access(&pair.access).is_none());
+```
+
+La lista negra reside en un `JtiStore` intercambiable. El `InMemoryJtiStore` por
+defecto es **de un solo proceso y pierde las revocaciones al reiniciar** — bien
+para una sola instancia. Cualquier despliegue con múltiples réplicas DEBE
+instalar un almacén compartido y duradero (Redis / BD) para que un cierre de
+sesión en una réplica sea respetado por todas:
+
+```rust
+use rustango::jti_store::{InMemoryJtiStore, JtiStore};
+use std::sync::Arc;
+
+let shared: Arc<dyn JtiStore> = Arc::new(InMemoryJtiStore::new()); // sustituir por Redis en prod
+let a = JwtLifecycle::new(secret.clone()).with_jti_store(Arc::clone(&shared));
+let b = JwtLifecycle::new(secret).with_jti_store(Arc::clone(&shared));
+
+let pair = a.issue_pair(5);
+a.revoke(&pair.access);
+assert!(b.verify_access(&pair.access).is_none());   // B ve la revocación de A
+```
+
+> Sin un almacén compartido, `/logout` es, en el mejor de los casos, «best-effort»:
+> un token revocado puede seguir siendo aceptado en otra réplica hasta su
+> expiración natural. Este es el ajuste de producción más importante para la
+> autenticación JWT.
+
+---
+
+## Claims personalizados
+
+Incrusta `roles` / `tenant` / `scope` directamente en el token para que la
+verificación no necesite ninguna consulta a la BD. Los nombres reservados
+(`sub`, `exp`, `jti`, `typ`) se rechazan:
+
+```rust
+let custom = serde_json::json!({ "roles": ["admin"], "tenant": "acme" })
+    .as_object().unwrap().clone();
+let pair = jwt.issue_pair_with(99, custom)?;
+
+let claims = jwt.verify_access(&pair.access).unwrap();
+let roles: Vec<String> = claims.get_custom("roles").unwrap();   // ["admin"]
+```
+
+Los claims personalizados sobreviven a `refresh` (se trasladan al nuevo par) a
+menos que uses `refresh_with`.
+
+---
+
+## Notas y límites
+
+- **Sesiones vs JWT vs esto:** un [JWT](auth-jwt.md) simple no se puede revocar;
+  una [Sesión](auth-sessions.md) es revocable pero necesita una consulta al
+  almacén por petición; `JwtLifecycle` es el camino intermedio — verificación
+  sin estado, más una lista de bloqueo JTI para las revocaciones que realmente
+  necesitas (logout, rotación).
+- **Los endpoints HTTP están delimitados por tenant.** `jwt_router` resuelve los
+  usuarios mediante el contexto del tenant + `rustango_users`; móntalo en una
+  aplicación `.tenancy()`. El motor de tokens (`JwtLifecycle`) en sí no tiene tal
+  requisito.
+- **Combina esto** con el `JwtBackend` de la [cadena de backends de
+  autenticación](auth-backends.md) para autenticar rutas arbitrarias a partir de
+  la cabecera `Authorization: Bearer`.
+- **Firma HS256**, suelo de clave de 32 bytes — mismo algoritmo y mismas
+  restricciones que el [JWT independiente](auth-jwt.md#security-model).
+
+
+---
+
+## Véase también
+
+- [JWT (independiente)](auth-jwt.md)
+- [Backends de autenticación](auth-backends.md)
+- [Sesiones](auth-sessions.md)
+- [Guía de seguridad](security.md)

--- a/docs/es/auth-jwt.md
+++ b/docs/es/auth-jwt.md
@@ -1,0 +1,211 @@
+# JWT (independiente)
+
+Un JSON Web Token es una credencial **sin estado**: una cadena firmada y
+autónoma que el cliente envía en cada petición, y que tu servidor verifica con
+un secreto — sin consultas a base de datos ni a caché por petición. El módulo
+`rustango::jwt` de **Rustango** es el bloque mínimo: `encode` para firmar
+claims, `decode` para verificarlos y volver a leerlos, HS256 por debajo.
+
+[![JWT independiente en Rustango: los Claims llevan campos sub/exp/personalizados, encode() firma con un secreto compartido, decode() verifica la firma + la expiración](img/auth-jwt.png)](img/auth-jwt.png)
+
+> **Fuente:** `rustango::jwt` (`Claims`, `encode`, `decode`, `decode_at`,
+> `decode_unverified`, `JwtError`) — tras la característica `jwt` (activada por
+> defecto). Para una **API** access+refresh lista para usar con revocación, consulta
+> [API de autenticación JWT](auth-jwt-api.md).
+>
+> **Versión ejecutable:** los fragmentos están copiados del test
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt.rs) —
+> `cargo test -p auth_demo --test auth_jwt`.
+
+> **¿Algún término te resulta nuevo?** *JWT*, *claims*, *sin estado*, *secreto* — consulta el
+> [glosario](glossary.md).
+
+> Complemento en profundidad de la sección «Emitir y renovar JWT» de la
+> [Guía de seguridad](security.md).
+
+---
+
+## Tabla de contenidos
+- [Inicio rápido](#quick-start) · [Cuándo usarlo](#when-to-use-standalone-jwt)
+- [Construir claims](#building-claims) · [Verificar](#verifying-a-token)
+- [Modelo de seguridad](#security-model) — léelo · [Inspeccionar sin confiar](#inspecting-without-verifying)
+- [Notas y límites](#notes-and-limits)
+
+---
+
+## Inicio rápido
+
+```rust
+use rustango::jwt::{Claims, encode, decode};
+use std::time::Duration;
+
+// HS256 es simétrico — el mismo secreto firma y verifica. Debe tener >= 32 bytes.
+let secret = b"a-shared-signing-secret-at-least-32-bytes!!";
+
+let mut claims = Claims::new("user-42").ttl(Duration::from_secs(900));
+claims.set("roles", vec!["editor", "author"]);
+
+let token = encode(&claims, secret)?;        // header.payload.signature
+
+let verified = decode(&token, secret)?;       // comprueba la firma + exp/nbf
+assert_eq!(verified.subject(), Some("user-42"));
+let roles: Vec<String> = verified.get("roles").unwrap();
+```
+
+---
+
+## Cuándo usar un JWT independiente
+
+Recurre a `rustango::jwt` cuando quieras un simple token firmado y vayas a
+gestionar el ciclo de vida tú mismo:
+
+- **Enlaces mágicos / tokens de un solo uso** — unos pocos claims (id de
+  usuario, propósito, `exp` corto).
+  Consulta [Enlaces mágicos y flujos de autenticación](auth-flows.md).
+- **Tokens bearer de servicio a servicio** (el hermano JWT de la [firma de
+  peticiones HMAC](auth-hmac.md) — HMAC para peticiones canónicas al estilo AWS,
+  JWT para un bearer sin estado).
+- **Tokens SSO** que entregas a un tercero.
+
+Si quieres una API llave en mano **login → access + refresh → refresh →
+logout** con revocación de tokens, no la construyas sobre esto — usa la
+[API de autenticación JWT](auth-jwt-api.md), que envuelve este módulo con
+rotación + un almacén de revocación. Y si necesitas cerrar la sesión de un
+usuario a la fuerza *ahora mismo*, prefiere una [Sesión](auth-sessions.md)
+revocable: un JWT simple es válido hasta que expire.
+
+---
+
+## Construir claims
+
+`Claims` envuelve un objeto JSON, de modo que los claims estándar y tus propios
+campos de extensión coexisten:
+
+```rust
+let mut claims = Claims::new("user-42")     // establece `sub` + `iat=now`
+    .ttl(Duration::from_secs(3600))         // establece `iat`=now y `exp`=now+ttl
+    .issuer("api.example.com")              // `iss`
+    .audience("web-client")                 // `aud`
+    .jti("unique-token-id");                // `jti` (para tu propia lista de bloqueo)
+claims.set("role", "admin");                // cualquier valor Serialize
+claims.set("org_id", 7_i64);
+```
+
+| Builder / setter | Claim |
+|---|---|
+| `Claims::new(sub)` | `sub` + `iat` |
+| `Claims::empty()` | ninguno (control total) |
+| `.ttl(Duration)` | `iat` (now) + `exp` (now+ttl) |
+| `.expires_at(secs)` / `.not_before(secs)` | `exp` / `nbf` absolutos |
+| `.issuer(s)` / `.audience(s)` / `.jti(s)` | `iss` / `aud` / `jti` |
+| `.set(name, value)` | cualquier claim personalizado |
+
+Léelos de vuelta con `.subject()` y `.get::<T>(name)` (devuelve `None` para un
+claim ausente o con tipo incorrecto).
+
+---
+
+## Verificar un token
+
+```rust
+use rustango::jwt::{decode, JwtError};
+
+match decode(&token, secret) {
+    Ok(claims) => { /* confiar en claims.subject() etc. */ }
+    Err(JwtError::Expired(_))      => { /* 401 — token caducado */ }
+    Err(JwtError::BadSignature)    => { /* 401 — falsificado o clave incorrecta */ }
+    Err(JwtError::NotYetValid(_))  => { /* nbf en el futuro */ }
+    Err(_)                         => { /* malformado / alg no soportado */ }
+}
+```
+
+`decode` verifica la **firma**, luego `exp` y `nbf`. Para probar el
+comportamiento de la ventana temporal (o añadir tolerancia de desfase),
+`decode_at(token, secret, now)` te permite fijar el segundo «actual»:
+
+```rust
+let token = encode(&Claims::new("x").expires_at(1000), secret)?;
+assert!(decode_at(&token, secret, 500).is_ok());                     // antes de exp
+assert!(matches!(decode_at(&token, secret, 2000), Err(JwtError::Expired(_)))); // después
+```
+
+---
+
+## Modelo de seguridad
+
+Esto es código de frontera de autenticación — tres cosas que debes saber
+obligatoriamente:
+
+1. **`decode` NO valida `iss` / `aud`.** Una firma válida prueba que el token se
+   acuñó con tu secreto, no que se acuñó *para tu servicio*. Si estableces
+   `iss`/`aud` en el momento de la emisión, **compruébalos tú mismo** sobre los
+   claims decodificados:
+
+   ```rust
+   let c = decode(&token, secret)?;
+   if c.get::<String>("aud").as_deref() != Some("web-client") {
+       return Err("wrong audience");
+   }
+   ```
+
+2. **El secreto debe tener ≥ 32 bytes** — `encode` se niega a firmar con una
+   clave más corta (una clave corta es adivinable, y una clave HMAC adivinable
+   significa tokens falsificables). HS256 es simétrico: cualquiera que tenga el
+   secreto de verificación también puede *acuñar* tokens, así que permanece
+   dentro de tu frontera de confianza (servicio único / backend compartido). La
+   emisión de tokens entre organizaciones requiere RS256/ES256 asimétrico, que
+   este módulo deliberadamente no incluye.
+
+3. **`alg=none` y la manipulación se rechazan.** `decode` fija HS256 (la
+   falsificación clásica «alg: none» se rechaza), y cualquier cambio en la
+   cabecera o el payload rompe la firma — verificada por una comparación de
+   tiempo constante.
+
+No hay **ninguna holgura para el desfase de reloj**: `exp`/`nbf` se comparan con
+el segundo actual exacto. Si los relojes del emisor y del verificador se
+desvían, resta unos segundos mediante `decode_at`.
+
+---
+
+## Inspeccionar sin verificar
+
+`decode_unverified` lee el payload **sin** comprobar la firma ni la expiración —
+útil solo para echar un vistazo a un claim (p. ej. un id de clave) para poder
+elegir el secreto correcto, y luego llamar a `decode` de verdad.
+
+```rust
+let peek = rustango::jwt::decode_unverified(&token)?;   // NO fiable
+let kid = peek.get::<String>("kid");
+// ... busca el secreto para `kid`, luego verifica correctamente:
+let claims = decode(&token, &resolved_secret)?;
+```
+
+**Nunca autorices sobre la salida de `decode_unverified`** — no lleva ninguna
+garantía de integridad.
+
+---
+
+## Notas y límites
+
+- **Solo HS256** — simétrico, un único secreto compartido. Sin RS256/ES256
+  (mantiene pequeño el árbol de dependencias siempre activo; la mayoría de las
+  aplicaciones de un solo servicio usan HS256 de todos modos).
+- **Sin estado = no revocable.** Un JWT simple es válido hasta `exp`. Si
+  necesitas «cerrar sesión ahora» / revocación por token, usa la
+  [API de autenticación JWT](auth-jwt-api.md) (lista de bloqueo JTI) o una
+  [Sesión](auth-sessions.md) (elimina la entrada del servidor).
+- **Mantén `exp` corto** para los access tokens (minutos). Los JWT simples de
+  larga duración son un riesgo precisamente porque no se pueden revocar.
+- Combina la emisión con [Contraseñas](auth-passwords.md) (verificar, luego
+  emitir) y protege las rutas de la API mediante el `JwtBackend` de la [cadena de
+  backends de autenticación](auth-backends.md).
+
+
+---
+
+## Véase también
+
+- [API de autenticación JWT](auth-jwt-api.md)
+- [Backends de autenticación](auth-backends.md)
+- [Claves de API](auth-api-keys.md)
+- [Sesiones](auth-sessions.md)

--- a/docs/es/auth-passwords.md
+++ b/docs/es/auth-passwords.md
@@ -1,0 +1,229 @@
+# Contraseñas
+
+Almacenar una contraseña significa almacenar algo que un atacante no puede
+revertir ni siquiera con toda tu base de datos en la mano. **Rustango** te ofrece
+eso en dos llamadas — `hash` a la entrada, `verify` a la salida — respaldadas por
+**argon2id**, el ganador *memory-hard* de la Password Hashing Competition y la
+primera opción actual de OWASP. Nunca almacenas, registras ni comparas el texto
+plano.
+
+[![Contraseñas en Rustango: hash() produce una cadena PHC argon2id con sal, verify() comprueba un intento contra ella, y verify_dummy() iguala los tiempos de inicio de sesión](img/auth-passwords.png)](img/auth-passwords.png)
+
+> **Fuente:** `rustango::passwords` (`hash`, `verify`, `verify_dummy`,
+> `strength_score`, `StrengthIssue`) — detrás de la característica `passwords`
+> (activada por defecto). Para las utilidades de contraseña de usuario integradas
+> con la multitenencia, consulta `rustango::tenancy::password`.
+>
+> **Versión ejecutable:** cada fragmento a continuación está copiado del ejemplo
+> probado [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_passwords.rs)
+> — `cargo test -p auth_demo --test auth_passwords`.
+
+> **¿Algún término aquí es nuevo para ti?** *hash*, *sal*, *argon2id*, *cadena
+> PHC* — consulta el [glosario](glossary.md).
+
+> Esta es la inmersión profunda de la sección «Hashear y verificar contraseñas»
+> de la [guía de seguridad](security.md).
+
+---
+
+## Tabla de contenidos
+- [Inicio rápido](#quick-start) · [Por qué argon2id](#why-argon2id)
+- [Hashear al registrarse](#hashing-on-signup) · [Verificar al iniciar sesión](#verifying-on-login)
+- [Inicios de sesión con tiempos seguros](#timing-safe-logins-account-enumeration) · [Comprobaciones de robustez](#strength-checks)
+- [Dónde vive el hash](#where-the-hash-lives) · [Notas y límites](#notes-and-limits)
+
+---
+
+## Inicio rápido
+
+```rust
+use rustango::passwords::{hash, verify};
+
+// Signup — store the returned PHC string, never the plaintext.
+let stored: String = hash("CorrectHorseBatteryStaple!42")?;
+
+// Login — check an attempt against the stored hash.
+if verify("CorrectHorseBatteryStaple!42", &stored)? {
+    // credentials good
+}
+```
+
+`hash` devuelve una [cadena PHC](https://github.com/P-H-C/phc-string-format) — una
+línea autodescriptiva que lleva el algoritmo, sus parámetros de coste, la sal
+aleatoria y el digest:
+
+```text
+$argon2id$v=19$m=19456,t=2,p=1$<base64 salt>$<base64 hash>
+```
+
+Como la sal y los parámetros viajan *dentro* de la cadena, `verify` solo necesita
+el valor almacenado y el intento — no hay una columna de sal separada que
+gestionar.
+
+---
+
+## Por qué argon2id
+
+`hash` usa **argon2id** con los valores por defecto recomendados por OWASP (m=19
+MiB, t=2, p=1). argon2id es *memory-hard*: cada intento cuesta RAM real, que es lo
+que embota las granjas de GPU/ASIC que hacen que los hashes rápidos (MD5,
+SHA-256, incluso bcrypt a bajo coste) sean vulnerables a la fuerza bruta. Dos
+propiedades importan para la corrección:
+
+- **El salado es automático y por hash.** Hashear la misma contraseña dos veces
+  produce dos cadenas PHC diferentes, de modo que contraseñas idénticas no
+  colisionan en tu tabla y los ataques con tablas arcoíris precalculadas no
+  aplican.
+
+  ```rust
+  let a = hash("same-password-12345")?;
+  let b = hash("same-password-12345")?;
+  assert_ne!(a, b);                 // different random salt each time
+  assert!(verify("same-password-12345", &a)?);
+  assert!(verify("same-password-12345", &b)?);
+  ```
+
+- **La verificación es de tiempo constante** en la comparación del digest (el
+  propio `PasswordVerifier` de argon2), de modo que una fuga de tiempo byte a
+  byte no puede revelar qué parte de un intento era correcta.
+
+---
+
+## Hashear al registrarse
+
+```rust
+use rustango::passwords::{hash, strength_score};
+
+fn create_user(username: &str, plaintext: &str) -> Result<String, String> {
+    // Optional: nudge users away from weak choices (see below).
+    let issues = strength_score(plaintext);
+    if !issues.is_empty() {
+        return Err(format!("password too weak: {issues:?}"));
+    }
+    // Store the PHC string on the user row (e.g. auth_users.password_hash).
+    hash(plaintext).map_err(|e| e.to_string())
+}
+```
+
+---
+
+## Verificar al iniciar sesión
+
+```rust
+use rustango::passwords::verify;
+
+// `stored` is the PHC string you saved at signup.
+let ok = verify(attempt, &stored)?;
+```
+
+`verify` devuelve:
+- `Ok(true)` — el intento coincide.
+- `Ok(false)` — no coincide.
+- `Err(PasswordError::Verify)` — `stored` no era una cadena PHC válida (una
+  columna corrupta o truncada), así que trátalo como un inicio de sesión fallido,
+  no como un 500.
+
+---
+
+## Inicios de sesión con tiempos seguros (enumeración de cuentas)
+
+Si tu inicio de sesión ejecuta el costoso `verify` **solo** cuando el nombre de
+usuario existe, un nombre de usuario desconocido responde notablemente más rápido
+que uno real — y esa brecha de tiempo permite a un atacante enumerar las cuentas
+válidas. `verify_dummy` la cierra: llámalo en la rama de usuario-no-encontrado (y
+cuenta-inactiva) para que cada inicio de sesión invierta el trabajo de un `verify`
+de argon2 sin importar el caso.
+
+```rust
+use rustango::passwords::{verify, verify_dummy};
+
+let row = users::find_by_username(username).await?;
+let authenticated = match row {
+    Some(u) if u.is_active => verify(attempt, &u.password_hash)?,
+    _ => {
+        verify_dummy(attempt); // burn the same work, then fail
+        false
+    }
+};
+```
+
+---
+
+## Comprobaciones de robustez
+
+`strength_score` devuelve un `Vec<StrengthIssue>` — vacío significa «lo bastante
+bueno». Es una heurística intencionadamente ligera para *animar* a los usuarios,
+no una barrera de política estricta; combínala con una comprobación contra listas
+de filtraciones (HIBP / pwned-passwords) para despliegues serios.
+
+```rust
+use rustango::passwords::{strength_score, StrengthIssue};
+
+assert!(strength_score("Tr0ub4dor&3-CorrectBattery").is_empty());
+assert!(strength_score("password123").contains(&StrengthIssue::KnownWeak));
+assert!(strength_score("short").contains(&StrengthIssue::TooShort));
+```
+
+| `StrengthIssue` | Se activa cuando |
+|---|---|
+| `TooShort` | menos de 12 caracteres |
+| `NoDigitsOrSymbols` | solo letras — sin dígito ni símbolo |
+| `NoVariety` | solo letras minúsculas |
+| `KnownWeak` | coincide con la pequeña lista integrada de contraseñas débiles (sin distinguir mayúsculas y minúsculas) |
+
+---
+
+## Dónde vive el hash
+
+La cadena PHC no es más que una columna `String` en el modelo de cuenta que sea
+tuyo. En el ejemplo
+[`auth_demo`](../crates/rustango/examples/auth_demo/src/models.rs):
+
+```rust
+#[derive(Model, Clone, Debug)]
+#[rustango(table = "auth_users", display = "username")]
+pub struct User {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 150, unique)]
+    pub username: String,
+    #[rustango(max_length = 254)]
+    pub email: String,
+    #[rustango(max_length = 255)]      // PHC strings are ~95 chars at these params
+    pub password_hash: String,
+    pub is_active: bool,
+    pub is_superuser: bool,
+}
+```
+
+Una vez que el usuario está autenticado, pasa el testigo a una
+[sesión](auth-sessions.md) (para aplicaciones de navegador) o emite un
+[JWT](auth-jwt.md) (para APIs).
+
+---
+
+## Notas y límites
+
+- **Nunca** almacenes, registres ni compares con `==` el texto plano. `hash` →
+  almacenar; `verify` → comprobar. Ese es todo el contrato.
+- **Los parámetros de coste son los valores por defecto de OWASP**, integrados de
+  serie. Son un suelo razonable; elevarlos más adelante es seguro — los hashes
+  antiguos siguen verificándose (sus parámetros viven en la cadena PHC), y puedes
+  volver a hashear en el siguiente inicio de sesión con éxito para actualizarlos.
+- `strength_score` es una heurística, no un motor de políticas — no detectará
+  `Summer2024!`. Superpón una búsqueda en listas de filtraciones para una
+  aplicación real de la robustez.
+- Para aplicaciones multitenencia con el almacén de usuarios del framework,
+  prefiere `rustango::tenancy::password` (el mismo argon2id, integrado con el
+  modelo de usuario del inquilino). Este módulo es la versión autónoma para
+  aplicaciones que poseen su propia tabla User.
+
+
+---
+
+## Véase también
+
+- [Sesiones](auth-sessions.md)
+- [Flujos de cuenta](auth-flows.md)
+- [Backends de autenticación](auth-backends.md)
+- [Guía de seguridad](security.md)

--- a/docs/es/auth-sessions.md
+++ b/docs/es/auth-sessions.md
@@ -1,0 +1,202 @@
+# Sesiones
+
+Una sesión mantiene a un usuario con la sesión iniciada a través de las
+peticiones entregando al navegador un **ID opaco** en una cookie y guardando todo
+lo demás en el servidor. El `SessionStore` de **Rustango** coloca ese estado en
+una caché (Redis en producción, en memoria para las pruebas), de modo que la
+cookie no lleva ningún secreto y una sesión puede **revocarse al instante** —
+elimina la entrada y cada réplica ve el cierre de sesión en la siguiente
+petición.
+
+[![Sesiones en Rustango: la cookie solo contiene un id opaco, el SessionStore guarda los datos en Redis, y destroy() la revoca en todas partes](img/auth-sessions.png)](img/auth-sessions.png)
+
+> **Fuente:** `rustango::sessions` (`Session`, `SessionStore`) +
+> `rustango::cache` (`BoxedCache`, `InMemoryCache`) — detrás de la característica
+> `sessions` (activada por defecto; arrastra `cache`). Para un almacén respaldado
+> por Redis en producción, añade la característica `cache-redis` (desactivada por
+> defecto) para obtener `RedisCache`.
+>
+> **Versión ejecutable:** los fragmentos a continuación están copiados del
+> ejemplo probado
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_sessions.rs) —
+> `cargo test -p auth_demo --test auth_sessions`.
+
+> **¿Algún término aquí es nuevo para ti?** *sesión*, *id opaco*, *cookie*,
+> *caché* — consulta el [glosario](glossary.md).
+
+> Compañero de inmersión profunda de la [guía de seguridad](security.md).
+> Restringir rutas tras una sesión iniciada se trata en [Decoradores de
+> autenticación](auth-decorators.md); para tokens de API sin estado en su lugar,
+> consulta [JWT](auth-jwt.md).
+
+---
+
+## Tabla de contenidos
+- [Inicio rápido](#quick-start) · [Sesiones vs. JWT](#sessions-vs-jwt)
+- [La bolsa de sesión](#the-session-bag) · [La cookie](#the-cookie)
+- [Elegir un backend](#picking-a-backend) · [Caducidad y renovación deslizante](#expiry-and-sliding-renewal)
+- [Actualizar in situ](#updating-a-session-in-place) · [Notas y límites](#notes-and-limits)
+
+---
+
+## Inicio rápido
+
+```rust
+use rustango::sessions::{Session, SessionStore};
+use rustango::cache::{BoxedCache, RedisCache};
+use std::sync::Arc;
+
+let store = SessionStore::new(Arc::new(RedisCache::new("redis://localhost/0")?) as BoxedCache);
+
+// After the password check (see auth-passwords.md): stash who the user is,
+// save → an opaque id, and set that id as the cookie.
+let mut session = Session::new();
+session.set("user_id", user.id);
+let sid = store.save(&session).await?;
+// Set-Cookie: rustango_session={sid}; HttpOnly; SameSite=Lax; Secure; Path=/
+
+// On later requests: read the id from the cookie, load the session back.
+let session = store.load(&sid).await?.unwrap_or_default();
+let user_id: Option<i64> = session.get("user_id");
+
+// Logout: drop the server-side entry — the cookie is now meaningless.
+store.destroy(&sid).await?;
+```
+
+El id son 192 bits de aleatoriedad OS-CSPRNG, codificados en base64url a 32
+caracteres — muy por encima del suelo de 128 bits para tokens de sesión, e
+inadivinable.
+
+---
+
+## Sesiones vs. JWT
+
+Ambos responden a «¿quién es esta petición?», con compensaciones opuestas:
+
+| | Sesión | [JWT](auth-jwt.md) |
+|---|---|---|
+| Estado | del lado del servidor (búsqueda en caché por petición) | sin estado (token autocontenido) |
+| Revocación | **instantánea** — `destroy()` la entrada | difícil — válido hasta la caducidad (necesita una lista de bloqueo) |
+| Mejor para | aplicaciones de navegador, «cerrar la sesión de este usuario AHORA» | APIs, servicio a servicio, sin almacén compartido |
+
+Recurre a las sesiones cuando necesites forzar el cierre de sesión de alguien
+(cambio de contraseña, «cerrar sesión en todos los dispositivos», una cuenta
+baneada). Recurre a JWT cuando quieras cero búsquedas por petición y no tengas
+una caché compartida.
+
+---
+
+## La bolsa de sesión
+
+`Session` es una bolsa tipada clave→valor con un bit de suciedad (*dirty bit*)
+(para que el almacén pueda omitir una escritura cuando nada ha cambiado):
+
+```rust
+let mut s = Session::new();
+s.set("user_id", 42_i64);            // serialize any Serialize value
+s.set("role", "editor");
+let uid: Option<i64> = s.get("user_id");   // None if absent or wrong type
+s.remove("role");
+s.clear();                            // wipe everything (e.g. on logout)
+```
+
+`get` es **tolerante a fallos**: una clave ausente *o* un valor que no se
+deserializa al tipo solicitado devuelve `None` en lugar de entrar en pánico — de
+modo que un cambio de esquema nunca provoca un 500 en una petición.
+
+---
+
+## La cookie
+
+La cookie solo contiene `sid`. Configúrala con los atributos de seguridad que una
+cookie de sesión necesita:
+
+- **`HttpOnly`** — JavaScript no puede leerla (embota el robo de tokens por XSS).
+- **`SameSite=Lax`** — no se envía en subpeticiones entre sitios (defensa CSRF;
+  combínala con [tokens CSRF](security.md#protecting-against-csrf) para los envíos
+  de formularios).
+- **`Secure`** — solo HTTPS (omítelo únicamente para el desarrollo HTTP local).
+- **`Path=/`** — visible para toda la aplicación.
+
+Nada sensible hay en la cookie, así que una cookie filtrada es exactamente tan
+poderosa como la sesión a la que apunta — y puedes revocar esa en el servidor en
+cualquier momento.
+
+---
+
+## Elegir un backend
+
+`SessionStore::new` acepta cualquier `BoxedCache`:
+
+- **`RedisCache`** — producción. Compartida entre réplicas, de modo que un inicio
+  de sesión en una instancia y un cierre de sesión en otra son ambos visibles en
+  todas partes.
+- **`InMemoryCache`** — proceso único / pruebas. Rápida, sin dependencias, pero
+  las sesiones no sobreviven a un reinicio y no se comparten entre réplicas.
+
+```rust
+use rustango::cache::{BoxedCache, InMemoryCache};
+use std::sync::Arc;
+
+// Tests / single-process:
+let store = SessionStore::new(Arc::new(InMemoryCache::new()) as BoxedCache);
+```
+
+---
+
+## Caducidad y renovación deslizante
+
+Las sesiones tienen por defecto un TTL de **2 semanas**. Sobrescríbelo por
+almacén, y llama a `touch` en cada petición autenticada para una caducidad
+deslizante (los usuarios activos siguen con la sesión iniciada, los inactivos
+caducan):
+
+```rust
+use std::time::Duration;
+
+let store = SessionStore::new(cache).ttl(Duration::from_secs(60 * 60)); // 1 hour
+
+// On each request, after a successful load — extend without rewriting:
+store.touch(&sid).await?;   // Ok(false) if the session is already gone
+```
+
+---
+
+## Actualizar una sesión in situ
+
+`save` siempre acuña un id nuevo (úsalo al iniciar sesión). Para modificar una
+sesión existente durante una petición, carga → muta → `save_with_id` bajo el
+mismo id:
+
+```rust
+let mut s = store.load(&sid).await?.unwrap_or_default();
+s.set("last_seen", chrono::Utc::now().to_rfc3339());
+store.save_with_id(&sid, &s).await?;
+```
+
+---
+
+## Notas y límites
+
+- **La revocación es la característica estrella** — `destroy()` (cierre de sesión)
+  y la caducidad por TTL surten efecto ambas en la siguiente petición, en cada
+  réplica que comparte la caché.
+- **Los ids corruptos o desconocidos se cargan como `None`** (*fail-open*): un
+  cambio de esquema de caché o una cookie manipulada produce una sesión vacía, no
+  un error — la petición simplemente no está autenticada.
+- **El almacén no establece la cookie por ti** — gestiona el estado del lado del
+  servidor; tú adjuntas/lees la cookie `sid` en tu handler (o mediante una capa).
+  Esto lo hace utilizable desde cualquier cableado de framework.
+- **Acuña un id de sesión nuevo al cambiar de privilegio** (p. ej. justo después
+  de iniciar sesión) para evitar la fijación de sesión — `save` ya lo hace,
+  puesto que siempre genera un id nuevo.
+
+
+---
+
+## Véase también
+
+- [Decoradores de autenticación](auth-decorators.md)
+- [JWT](auth-jwt.md)
+- [Backends de autenticación](auth-backends.md)
+- [Guía de seguridad](security.md)

--- a/docs/es/benchmarks.md
+++ b/docs/es/benchmarks.md
@@ -1,0 +1,290 @@
+# Benchmarks: Rustango vs Django vs Laravel vs Go
+
+¿Qué tan rápido es **Rustango**, de verdad? Esta página reporta un benchmark
+cara a cara contra los dos frameworks en los que se inspira **Rustango** —
+Django y Laravel — y contra una línea base de **Go** (la `net/http` de la
+biblioteca estándar) que ancla lo que consigue un segundo runtime compilado y
+nativo sobre la misma carga de trabajo. Todos usan sitios de blog
+*funcionalmente idénticos*: mismos datos, mismo esquema, mismos endpoints, mismo
+presupuesto de hardware — la única variable es el runtime. Django y Laravel se
+benchmarkean cada uno en **ambos** su despliegue de producción convencional *y*
+un runtime más robusto: **Django** sobre **gunicorn** (WSGI) y sobre
+**Hypercorn** (ASGI); **Laravel** sobre **php-fpm + nginx** y sobre **Octane**
+(Swoole). Rustango y Go son cada uno un único binario residente, así que hay uno
+de cada.
+
+Cada número de abajo es **medido y reproducible**, de una ejecución consistente
+de un arnés de un solo comando (ver [Reproducir](#reproduce)). Nada aquí es
+palabrería.
+
+> **TL;DR.** Sobre hardware idéntico sirviendo páginas HTML renderizadas
+> idénticas, los dos runtimes **compilados y nativos** — **Rustango** y **Go** —
+> dejan a los frameworks interpretados **5–30× atrás** y se intercambian el
+> liderazgo entre ellos. En el índice sin caché **Go** lideró con **6.651 req/s**
+> y **Rustango** le siguió con **4.781** — **5,6×** Django (gunicorn) y **11,7×**
+> Laravel (php-fpm). La ventaja de Go es más amplia en la página de detalle sin
+> caché (**13.921 vs 6.538**, 2,1×). **Rustango** recupera el liderazgo donde
+> importa para el tráfico servido: las rutas **cacheadas en Redis** (**25.546**
+> vs 20.929 de Go en el índice; 35.781 vs 29.470 en detalle) y el **cómputo puro**
+> (14.341 vs 11.573). También mantuvo la **menor RAM bajo carga** (18,5 MiB, sin
+> GC) y — a diferencia de la app de la stdlib de Go — incluye un framework
+> completo con todo incluido. Incluso el resultado no compilado más rápido,
+> **Laravel sobre Octane**, va 4–7× por detrás de ambos binarios.
+
+[![Solicitudes/s en el índice del blog sin caché a través de los seis runtimes — Go 6.651, Rustango 4.781, Laravel+Octane 1.238, Django+Hypercorn 910, Django+gunicorn 850, Laravel+php-fpm 408](img/benchmarks.png)](img/benchmarks.png)
+
+---
+
+## La configuración
+
+Cuatro apps de blog — **autores, posts, tags (muchos-a-muchos) y comentarios** —
+renderizando páginas HTML:
+
+| Ruta | Renderiza | ¿Cacheada? |
+|---|---|---|
+| `GET /` | los últimos 20 posts, cada uno con autor, tags, recuento de comentarios | no |
+| `GET /cached` | igual que `/` | Redis, 60 s |
+| `GET /post/{slug}` | cuerpo del post + autor + tags + todos los comentarios | no |
+| `GET /post/{slug}/cached` | igual que detalle | Redis, 60 s |
+| `GET /tag/{slug}` | posts que llevan un tag | no |
+| `GET /compute` | suma de todos los primos por debajo de 20.000 (ligado a CPU; sin BD, sin caché) | no |
+
+Los primeros cinco están ligados a E/S + render; `/compute` es una carga de
+trabajo puramente de CPU — el idéntico algoritmo de división por tentativa en
+cada lenguaje — para aislar la velocidad bruta del runtime. Cada app carga sus
+relaciones de forma **eager** (sin N+1): **Rustango** agrupa las consultas
+explícitamente, Django usa `select_related` / `prefetch_related` /
+`annotate(Count)`, Laravel usa `with()` + `withCount()`, **Go** hace carga por
+lotes con consultas `= ANY($1)`. Las plantillas son deliberadamente diminutas y
+equivalentes (Tera, plantillas de Django, Blade, `html/template` de Go) para que
+midamos el *framework*, no el esfuerzo de la plantilla.
+
+### Qué lo convierte en una pelea justa
+
+- **Datos idénticos.** Un esquema de PostgreSQL y una semilla determinista
+  compartida por las cuatro apps — leen las *mismas tablas*: 10 autores, 30 tags,
+  **1.000 posts**, 2.600 enlaces post-tag, **10.000 comentarios**. El índice
+  muestra los mismos 20 posts en el mismo orden en cada framework, y el HTML
+  renderizado es idéntico byte a byte (salvo el estilo de escape de entidades de
+  cada motor).
+- **Presupuesto de hardware idéntico.** Cada app corre en un contenedor limitado
+  a **4 CPUs / 2 GB de RAM**. PostgreSQL y Redis son compartidos e idénticos.
+- **Uno a la vez.** Las apps se prueban de carga secuencialmente para que nunca
+  compitan por el host (una máquina de 12 núcleos / 18 GB). Generador de carga:
+  [`oha`](https://github.com/hatoo/oha), 50 conexiones concurrentes, 10 s por
+  endpoint, keep-alive HTTP activado. Cada ejecución reportó **100 % de éxito**.
+- **Todo en modo producción.** Esto importa mucho (ver más abajo).
+
+### Configuración de producción
+
+| | Runtime | Endurecimiento de producción |
+|---|---|---|
+| **Rustango** | un binario `--release` (axum + Tokio, async, todos los núcleos) | `opt-level=3` + LTO; caché de página en Redis vía `CachePageLayer` |
+| **Go** | un binario estático (stdlib `net/http`, goroutines, todos los núcleos) | pool `pgx` + caché de página `go-redis`; plantillas embebidas; se distribuye sobre `scratch` |
+| **Django 5.2** · gunicorn | workers gthread + keep-alive (WSGI) | `DEBUG=False`; caché Redis integrada + `@cache_page`; conexiones de BD persistentes |
+| **Django 5.2** · Hypercorn | servidor ASGI, 4 workers, keep-alive | la misma app, servida sobre ASGI; las vistas síncronas corren en un threadpool |
+| **Laravel 13** · php-fpm | php-fpm + nginx, OPcache **activado**, 16 workers | `APP_ENV=production`; `composer install --no-dev --optimize-autoloader`; Blade cacheado; `Cache::remember` sobre Redis |
+| **Laravel 13** · Octane | Octane + **Swoole**, workers persistentes | la misma app sobre un runtime residente en memoria — sin arranque del framework por solicitud |
+
+> El modo producción no es una nota al pie. La primera ejecución (sin ajustar) de
+> Laravel apenas logró ~53 req/s; activar OPcache, el autoloader optimizado y un
+> pool de workers adecuado la llevó a ~408 req/s — un **cambio de 7,7×** solo por
+> configuración. Los números de abajo son todos de la configuración de producción.
+
+---
+
+## Resultados
+
+### Rendimiento (throughput) — solicitudes por segundo (más alto es mejor)
+
+Los dos binarios compilados, luego cada framework interpretado en su runtime
+convencional **y** su runtime robusto:
+
+| Endpoint | **Rustango** | **Go** | Django · gunicorn | Django · Hypercorn | Laravel · php-fpm | Laravel · Octane |
+|---|--:|--:|--:|--:|--:|--:|
+| índice, sin caché | 4 781 | **6 651** | 850 | 910 | 408 | 1 238 |
+| índice, **cacheado** | **25 546** | 20 929 | 4 841 | 1 537 | 1 224 | 5 777 |
+| detalle, sin caché | 6 538 | **13 921** | 1 983 | 916 | 464 | 1 790 |
+| detalle, **cacheado** | **35 781** | 29 470 | 4 843 | 1 320 | 793 | 5 811 |
+| tag, sin caché | 3 926 | **4 353** | 1 129 | 1 033 | 398 | 1 179 |
+| **compute** (ligado a CPU) | **14 341** | 11 573 | 452 | 400 | 716 | 1 504 |
+
+Saltan a la vista tres historias. Primero, **Go y Rustango se agrupan muy por
+encima de todos los demás** — la diferencia entre los dos binarios nativos
+(decenas de por ciento, con Go por delante en E/S sin caché y Rustango por
+delante en aciertos de caché + cómputo) es pequeña al lado del abismo de 5–30×
+hasta los runtimes interpretados. Segundo, **Laravel + Octane** (Swoole) es un
+**salto de 3–7×** sobre php-fpm — un worker residente que se salta el arranque
+del framework de Laravel por solicitud — y es el resultado no compilado más
+rápido en cada página. Tercero, **Django + Hypercorn** (ASGI) está más o menos
+**plano, y más lento en las rutas cacheadas**: las vistas del blog son
+*síncronas*, así que ASGI solo añade un salto de threadpool sin nada del beneficio
+de concurrencia que traerían las vistas *async*. Incluso lo mejor de ese campo
+(Octane, 1.238 req/s en el índice sin caché; 5.811 en el detalle cacheado) va por
+detrás de ambos binarios en 4–7×.
+
+### Latencia — p50 en milisegundos (más bajo es mejor)
+
+| Endpoint | **Rustango** | **Go** | Django · gunicorn | Django · Hypercorn | Laravel · php-fpm | Laravel · Octane |
+|---|--:|--:|--:|--:|--:|--:|
+| índice, sin caché | 10.2 | **7.2** | 56.9 | 43.2 | 114.7 | 39.9 |
+| índice, cacheado | **1.8** | 2.1 | 9.3 | 5.0 | 20.2 | 7.6 |
+| detalle, cacheado | **1.3** | 1.5 | 5.8 | 32.1 | 81.8 | 7.6 |
+| compute (ligado a CPU) | 3.5 | **2.5** | 70.8 | 130.0 | 87.4 | 32.9 |
+
+(Se muestran las medianas; el p50 / p95 / p99 completo para cada endpoint y
+runtime está en `bench/results/summary.tsv`.) Las medianas de **Rustango** y de
+**Go** en el índice sin caché (10,2 / 7,2 ms) están por debajo de las de cada
+competidor interpretado, y sus medianas cacheadas (1,3–2,1 ms) son un orden de
+magnitud menores que incluso el runtime de framework más rápido. Una salvedad a
+favor de Go *y* en su contra: su p50 de compute (2,5 ms) supera al de Rustango,
+pero su p99 de compute se dispara a ~47 ms en una pausa de GC — una cola que el
+binario de Rust sin GC no tiene.
+
+### Huella — tamaño de imagen, memoria, CPU
+
+| | **Rustango** | **Go** | Django · gunicorn | Django · Hypercorn | Laravel · php-fpm | Laravel · Octane |
+|---|--:|--:|--:|--:|--:|--:|
+| Imagen de contenedor (sin comprimir) | 164 MB | **18.5 MB** | 293 MB | 293 MB | 959 MB | 1.01 GB |
+| RAM, en reposo | 12.1 MiB | **5.2 MiB** | 128 MiB | 173 MiB | 92 MiB | 248 MiB |
+| RAM, bajo carga | **18.5 MiB** | 34.7 MiB | 218 MiB | 277 MiB | 133 MiB | 267 MiB |
+| CPU bajo carga (del tope de 400 %) | 295 % | 366 % | 356 % | 408 % | 406 % | 335 % |
+
+**Go** distribuye la imagen más pequeña — un binario estático sobre `scratch`,
+**18,5 MB** — y en reposo consume apenas **5,2 MiB**. Pero bajo carga su heap de
+GC crece hasta **34,7 MiB**, ~1,9× los **18,5 MiB** planos de **Rustango**: sin
+recolector de basura y sin asignación por solicitud, el binario de Rust a plena
+carga cabe en menos RAM que Go, y por debajo de lo que usa cualquier runtime
+interpretado en *reposo*. Los runtimes robustos cuestan *más* memoria, no menos:
+Octane mantiene un Laravel residente en cada worker; Hypercorn añade la pila ASGI
+encima de Django.
+
+### Eficiencia — trabajo hecho por recurso (la verdadera historia)
+
+El throughput bruto es una cosa; el **throughput por unidad de recurso** es lo
+que tu factura de la nube realmente rastrea (índice sin caché):
+
+| Métrica | **Rustango** | **Go** | Django · gunicorn | Django · Hypercorn | Laravel · php-fpm | Laravel · Octane |
+|---|--:|--:|--:|--:|--:|--:|
+| Solicitudes/s **por MiB de RAM** | **258** | 192 | 3.9 | 3.3 | 3.1 | 4.6 |
+| Solicitudes/s **por % de CPU** | 16.2 | **18.2** | 2.4 | 2.2 | 1.0 | 3.7 |
+
+Por megabyte de memoria, **Rustango** hace el mayor trabajo de cualquier runtime
+aquí — ~35× el mejor resultado interpretado y ~1,3× el de Go, porque su huella se
+mantiene plana bajo carga. Por porcentaje de CPU, **Go** se adelanta (convierte
+los núcleos extra que arranca en un poco más de throughput). En cualquier caso,
+para igualar el throughput del índice de un binario compilado tendrías que
+ejecutar ~4 Laravel con Octane o ~6 Django con gunicorn — cada uno cargando su
+propia huella de varios cientos de MB.
+
+---
+
+## Qué cambia la caché
+
+Cada runtime es más rápido cuando una caché de página en Redis le permite
+saltarse por completo la base de datos y el render — req/s del índice sin caché →
+**cacheado**:
+
+- **Rustango**: 4.781 → **25.546** (5,3× por el caché) — recupera el primer puesto.
+- **Go**: 6.651 → **20.929** (3,1×) — lidera sin caché, segundo cacheado.
+- **Laravel · Octane**: 1.238 → **5.777** (4,7×) — lo mejor del campo interpretado.
+- **Django · gunicorn**: 850 → **4.841** (5,7×).
+- **Django · Hypercorn**: 910 → **1.537** (1,7×) — la sobrecarga del threadpool
+  de ASGI limita la ganancia incluso en aciertos de caché.
+- **Laravel · php-fpm**: 408 → **1.224** (3,0×).
+
+El caché ayuda a todos, pero no borra la diferencia — y es donde los dos binarios
+compilados se separan: sin código de aplicación ejecutándose, la ruta
+HTTP-accept → lectura-de-caché → respuesta es todo lo que queda, y el
+`CachePageLayer` sin asignaciones de **Rustango** (25.546 req/s) se adelanta a la
+ruta `go-redis` de Go (20.929), con ambos ~4× el mejor runtime de framework.
+
+---
+
+## Cómputo puro: compilado vs interpretado (y compilado vs compilado)
+
+Las cinco rutas de página están dominadas por la base de datos y el motor de
+plantillas. La ruta `/compute` las quita de en medio — suma todos los primos por
+debajo de 20.000 mediante división por tentativa, el algoritmo *idéntico* en
+Rust, Go, Python y PHP. Los cuatro devuelven la misma respuesta (`21171191`);
+solo difiere la velocidad:
+
+| | **Rustango** | **Go** | Django | Laravel |
+|---|--:|--:|--:|--:|
+| Throughput | **14 341 req/s** | 11 573 | 452 | 716 |
+| latencia p50 | 3.5 ms | **2.5 ms** | 70.8 ms | 87.4 ms |
+
+Los dos binarios nativos corren el bucle **~26–32×** más rápido que Django y
+**~16–20×** más rápido que Laravel — la diferencia entre código máquina compilado
+y un intérprete de bytecode. Entre Rust y Go, el bucle `--release` con LTO de Rust
+se lleva la corona del throughput mientras que la latencia mediana de Go es en
+realidad más baja; el GC de Go entonces aparece como latencia de cola (p99 ~47 ms)
+que el binario de Rust nunca paga. Curiosamente PHP 8.3 (con OPcache) supera en
+cómputo a CPython en este bucle entero apretado, así que Laravel *supera en
+cómputo* a Django aquí aunque pierda en cada página ligada a E/S. Esta es la carga
+de trabajo donde domina el lenguaje, no el framework — y donde llevar la lógica
+caliente a **Rustango** rinde más.
+
+---
+
+## Salvedades honestas
+
+Un benchmark en el que no puedes encontrar fallos no vale la pena publicarlo. Así
+que:
+
+- Los números son de **un** host de 12 núcleos / 18 GB (macOS + Docker). Los
+  valores absolutos cambian en otro hardware; lo que se traslada es el panorama
+  **relativo**.
+- Esta es una carga de trabajo **intensiva en lecturas y renderizada en el
+  servidor** — la forma de blog más común. No mide escrituras, flujos de
+  autenticación, websockets ni lógica de negocio pesada.
+- **Go aquí es la biblioteca estándar, no un framework par.** Rustango, Django y
+  Laravel son frameworks con todo incluido (ORM, admin, migraciones, enrutamiento,
+  plantillas, multi-tenancy); la app de Go es `net/http` + SQL en crudo escrita a
+  mano — la línea base más ligera y rápida que un servicio Go alcanza de forma
+  realista, y la representación más justa del lenguaje. Que empate o supere a
+  Rustango en throughput bruto sin caché es exactamente el punto: **Rustango
+  entrega rendimiento de clase Go con una experiencia de desarrollador de clase
+  Django/Laravel.** La ventaja de Go en los endpoints sin caché se paga
+  escribiendo tú mismo el SQL, el mapeo y el cableado.
+- Los runtimes son fundamentalmente distintos: Rustango y Go son cada uno un
+  binario que usa todos los núcleos con tareas baratas; Django y Laravel usan
+  pools fijos de procesos/hilos worker. Esa diferencia *es* parte del resultado, y
+  los recuentos de workers se fijaron en valores sensatos por CPU, no ajustados
+  para favorecer a nadie.
+- Django y Laravel se muestran cada uno en **ambos** runtimes — convencional
+  (gunicorn, php-fpm) y robusto (Hypercorn, Octane). **Laravel sobre Octane es
+  3–7× más rápido** que php-fpm; **Django sobre Hypercorn** (vistas síncronas)
+  está más o menos plano. Ambos estrechan la diferencia con los binarios
+  compilados; ninguno la cierra.
+
+El punto no es que Django o Laravel sean lentos — mueven una porción enorme de la
+web. Es que **Rustango** te da esa misma experiencia de desarrollador con todo
+incluido con el rendimiento y la huella de Rust compilado — igualando un servicio
+Go ajustado a mano mientras te entrega el framework que Go te obliga a construir.
+
+---
+
+## Reproducir
+
+El arnés completo — las cuatro apps, el esquema de PostgreSQL compartido + la
+semilla determinista, la configuración de Docker Compose y el runner — es un
+proyecto autocontenido (`rustango-bench`). Desde su directorio:
+
+```sh
+bench/vendor.sh                       # vendor the framework into the build
+docker compose build                  # build all six images
+DURATION=10s CONCURRENCY=50 bench/run.sh
+```
+
+Requisitos: Docker + Compose y Rust (para `cargo install oha`). Ajusta el tope de
+hardware en `.env` (`CAP_CPUS`, `CAP_MEM`) y la carga con `DURATION` /
+`CONCURRENCY`. La salida en crudo por ejecución aterriza en `bench/results/`.
+
+
+---
+
+## Véase también
+
+- [Primeros pasos](getting-started.md)
+- [Recetario del ORM](orm.md)

--- a/docs/es/caching.md
+++ b/docs/es/caching.md
@@ -1,0 +1,197 @@
+# Caché
+
+La caché almacena el resultado de un trabajo costoso — una consulta pesada, un
+fragmento renderizado, una llamada a una API de terceros — para que la siguiente
+petición lo obtenga al instante en lugar de recalcularlo. **Rustango** te da un
+único trait `Cache` con backends intercambiables (in-memory, Redis, base de
+datos), un helper de cálculo-al-fallar (`get_or_set`) y helpers JSON tipados.
+Cambia el backend sin tocar un solo sitio de llamada — como el framework de caché
+de Django o la fachada `Cache` de Laravel.
+
+[![Caching in Rustango: get_or_set checks the cache, runs the factory only on a miss, stores the result with a TTL, and serves hits instantly; the same Cache trait backs InMemory, Redis, and DB](img/caching.png)](img/caching.png)
+
+> **¿Un término nuevo aquí?** *caché*, *TTL*, *clave*, *backend* — ver el
+> [glosario](glossary.md).
+
+> **Fuente:** `rustango::cache` (`Cache`, `InMemoryCache`, `NullCache`,
+> `get_or_set`, `get_json`, `set_json`, `BoxedCache`, `from_settings`) — tras la
+> feature `cache` (activa por defecto). `RedisCache` requiere la feature
+> `cache-redis` (desactivada por defecto).
+>
+> **Versión ejecutable:** cada fragmento está copiado de
+> [`cache_doc.rs`](../crates/rustango/tests/cache_doc.rs)
+> (`cargo test -p rustango --test cache_doc`); el backend de base de datos se
+> prueba con dogfooding sobre SQLite mediante
+> [`cache_db_backend_sqlite_live.rs`](../crates/rustango/tests/cache_db_backend_sqlite_live.rs).
+
+## Tabla de contenidos
+
+- [Paso 1 — Elegir un backend](#step-1--pick-a-backend)
+- [Paso 2 — get / set / delete](#step-2--get--set--delete)
+- [Paso 3 — get_or_set (cache-aside)](#step-3--get_or_set-cache-aside)
+- [Valores JSON tipados](#typed-json-values)
+- [TTL y expiración](#ttl-and-expiry)
+- [Cambiar de backend](#swapping-backends)
+- [Referencia](#reference)
+- [Véase también](#see-also)
+
+---
+
+## Paso 1 — Elegir un backend
+
+Cada backend implementa el mismo trait `Cache`, así que tu código es idéntico sea
+cual sea el que elijas. El código de la aplicación mantiene un **`BoxedCache`**
+(`Arc<dyn Cache>`) y nunca nombra el tipo concreto:
+
+```rust
+use rustango::cache::{BoxedCache, InMemoryCache};
+use std::sync::Arc;
+
+let cache: BoxedCache = Arc::new(InMemoryCache::new());
+```
+
+| Backend | Feature | Usar para |
+|---|---|---|
+| `InMemoryCache` | `cache` | dev, tests, un solo proceso (HashMap por proceso + TTL) |
+| `RedisCache` | `cache-redis` | producción; compartido entre réplicas |
+| `DbCache` | `cache` | producción sin Redis; una tabla `rustango_cache` |
+| `NullCache` | `cache` | deshabilitar la caché (cada lectura falla) — práctico en tests |
+
+---
+
+## Paso 2 — get / set / delete
+
+El núcleo del trait son cuatro métodos async. `set` toma un TTL opcional
+(`None` = sin expiración); `get` retorna `Option<String>` (`None` en un fallo):
+
+```rust
+use rustango::cache::{Cache, InMemoryCache};
+
+let cache = InMemoryCache::new();
+
+assert_eq!(cache.get("greeting").await?, None);     // miss
+cache.set("greeting", "hello", None).await?;        // store, no expiry
+assert_eq!(cache.get("greeting").await?.as_deref(), Some("hello"));
+assert!(cache.exists("greeting").await?);
+
+cache.delete("greeting").await?;                    // gone
+```
+
+También hay variantes por lotes — `get_many` / `set_many` / `delete_many`.
+
+---
+
+## Paso 3 — get_or_set (cache-aside)
+
+Esta es la que usarás más. `get_or_set` retorna el valor cacheado, o — en un
+fallo — ejecuta tu factory, almacena el resultado con un TTL y lo retorna. La
+factory **solo se ejecuta en un fallo**:
+
+```rust
+use rustango::cache::get_or_set;
+use std::time::Duration;
+
+let stats: HomeStats = get_or_set(
+    &*cache,                       // &dyn Cache
+    "home:stats",
+    || async { compute_home_stats(&pool).await },   // runs only on a miss
+    Some(Duration::from_secs(60)),                   // cache for 60s
+).await?;
+```
+
+El test que lo respalda llama a `get_or_set` dos veces para la misma clave y
+afirma que la factory se ejecutó **exactamente una vez** — la segunda llamada se
+sirve desde la caché.
+
+> **Invalida al escribir.** Cache-aside significa datos obsoletos hasta que
+> expira el TTL. Para datos que cambian, haz también `delete(key)` cuando los
+> escribes — p. ej. desde una [señal `post_save`](orm.md) — para que la siguiente
+> lectura recalcule.
+
+---
+
+## Valores JSON tipados
+
+`get_json` / `set_json` serializan cualquier tipo `Serialize`/`Deserialize` a
+JSON, de modo que cacheas structs y listas, no solo strings:
+
+```rust
+use rustango::cache::{get_json, set_json};
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Profile { id: i64, name: String }
+
+set_json(&*cache, "profile:7", &profile, None).await?;
+let back: Option<Profile> = get_json(&*cache, "profile:7").await?;   // None on a miss
+```
+
+(`get_or_set` los usa por debajo, por lo que su tipo de valor debe ser
+`Serialize + Deserialize`.)
+
+---
+
+## TTL y expiración
+
+Pasa una `Duration` a `set` (o `get_or_set`) y la entrada desaparece después de
+ella. Verificado: una entrada de 50 ms es legible de inmediato y desaparece tras
+80 ms.
+
+```rust
+cache.set("flash", "x", Some(Duration::from_millis(50))).await?;
+// ...50ms later...
+assert_eq!(cache.get("flash").await?, None);   // expired
+```
+
+`InMemoryCache::with_default_ttl(d)` fija un TTL por defecto que se aplica cuando
+pasas `None`.
+
+---
+
+## Cambiar de backend
+
+Como todo es el trait `Cache`, cambiar de in-memory a Redis es un cambio de una
+línea en el arranque — normalmente impulsado por la configuración para que
+difiera según el entorno:
+
+```rust
+// Build the cache from `[cache]` settings (backend = "memory" | "redis" | "db" | "null").
+let cache: BoxedCache = rustango::cache::from_settings(&settings.cache);
+```
+
+En producción, apúntalo a Redis (compartido entre todas tus réplicas):
+
+```rust
+use rustango::cache::RedisCache;   // needs the `cache-redis` feature
+let cache: BoxedCache = std::sync::Arc::new(RedisCache::new("redis://localhost").await?);
+```
+
+Las mismas llamadas `get` / `set` / `get_or_set` — solo cambió el constructor.
+
+---
+
+## Referencia
+
+**Trait `Cache`:** `get` · `set(key, value, ttl)` · `delete` · `exists` ·
+`get_many` / `set_many` / `delete_many` · `get_or(key, default)`.
+
+**Helpers libres:** `get_or_set(cache, key, factory, ttl)` ·
+`get_json` / `set_json` · `from_settings(&CacheSettings)`.
+
+**Qué está construido sobre la caché:** las [sesiones](auth-sessions.md) del lado
+del servidor, la [limitación de tasa](middleware.md) distribuida
+(`CacheRateLimitLayer`), las claves de idempotencia y los feature flags toman
+todos un `BoxedCache` — de modo que una sola instancia de Redis los respalda a
+todos.
+
+---
+
+## Véase también
+
+- [Trabajos en segundo plano](jobs.md) — la otra mitad de mantener rápidas las
+  peticiones (diferir el trabajo en lugar de cachear su resultado).
+- [Sesiones](auth-sessions.md) — un almacén del lado del servidor construido
+  sobre `Cache`.
+- [Middleware](middleware.md) — `CacheRateLimitLayer` comparte un contador entre
+  réplicas vía la caché.
+- [Cookbook del ORM](orm.md) — invalidar lecturas cacheadas desde una señal
+  `post_save`.

--- a/docs/es/email.md
+++ b/docs/es/email.md
@@ -1,0 +1,197 @@
+# Enviar correo electrónico
+
+Mensajes de bienvenida, restablecimientos de contraseña, recibos, alertas — la mayoría de las
+aplicaciones envían correo transaccional. **Rustango** te ofrece un trait `Mailer` con
+backends intercambiables (consola para desarrollo, SMTP para producción, un grabador en memoria
+para pruebas), un builder `Email` fluido con protección contra inyección de cabeceras, y el
+renderizado de plantillas. Escribe `mailer.send(&email)` una vez; cambia de imprimir
+en tu terminal a SMTP real con un cambio de una línea — como el framework de correo de Django.
+
+[![Correo en Rustango: un builder Email (to/subject/body/html) se valida contra la inyección de cabeceras, luego se envía a través del trait Mailer — ConsoleMailer en dev, SmtpMailer en prod, InMemoryMailer en pruebas](img/email.png)](img/email.png)
+
+> **¿Nuevo con algún término aquí?** *correo transaccional*, *SMTP*, *backend de correo* — ver
+> el [glosario](glossary.md).
+
+> **Fuente:** `rustango::email` (`Mailer`, `Email`, `ConsoleMailer`,
+> `InMemoryMailer`, `NullMailer`, `SmtpMailer`, `BoxedMailer`, `send_mail`,
+> `MailError`) — tras la característica `email` (activada por defecto). SMTP necesita la
+> característica `email-smtp`.
+>
+> **Versión ejecutable:** cada snippet se copia de
+> [`email_doc.rs`](../crates/rustango/tests/email_doc.rs)
+> (`cargo test -p rustango --test email_doc`); los ayudantes de envío y los adjuntos
+> se someten a prueba mediante `email_send_helpers.rs` y `email_attachments.rs`.
+
+## Tabla de contenidos
+
+- [Paso 1 — Construye un correo](#step-1--build-an-email)
+- [Paso 2 — Elige un mailer](#step-2--pick-a-mailer)
+- [Paso 3 — Envíalo](#step-3--send-it)
+- [Validación y protección contra inyección de cabeceras](#validation-and-header-injection-safety)
+- [Probar el correo](#testing-email)
+- [Plantillas](#templates)
+- [Envíalo fuera de la petición](#send-it-off-the-request)
+- [Referencia](#reference)
+- [Véase también](#see-also)
+
+---
+
+## Paso 1 — Construye un correo
+
+`Email` es un builder fluido. Establece los destinatarios, el asunto, y un cuerpo de texto y/o
+HTML:
+
+```rust
+use rustango::email::Email;
+
+let email = Email::new()
+    .to("ada@example.com")
+    .from("noreply@example.com")
+    .subject("Welcome")
+    .body("Thanks for signing up.")              // plain-text part
+    .html_body("<p>Thanks for signing up.</p>"); // optional HTML part
+```
+
+`.cc(...)`, `.reply_to(...)`, y los adjuntos también están disponibles.
+
+---
+
+## Paso 2 — Elige un mailer
+
+Cada backend implementa `Mailer`, de modo que tu código nunca nombra el tipo concreto —
+sostén un **`BoxedMailer`** (`Arc<dyn Mailer>`):
+
+| Backend | Característica | Úsalo para |
+|---|---|---|
+| `ConsoleMailer` | `email` | dev — imprime el mensaje en stdout |
+| `SmtpMailer` | `email-smtp` | producción — entrega real por SMTP |
+| `InMemoryMailer` | `email` | pruebas — graba los mensajes, no envía nada |
+| `FileMailer` | `email` | dev/CI — escribe cada mensaje en un archivo |
+| `NullMailer` | `email` | deshabilitar el correo por completo |
+
+Constrúyelo a partir de la configuración para que difiera por entorno (`ConsoleMailer`
+en local, `SmtpMailer` en prod) mediante `email::from_settings(&settings.email)`.
+
+---
+
+## Paso 3 — Envíalo
+
+`Email::send` toma cualquier `&dyn Mailer`:
+
+```rust
+email.send(&mailer).await?;
+```
+
+Para un envío rápido y puntual, `send_mail` se salta el builder:
+
+```rust
+use rustango::email::send_mail;
+
+send_mail(
+    &mailer,
+    "Your report is ready",                  // subject
+    "Download it from your dashboard.",      // body
+    Some("noreply@example.com"),             // from (or None for the default)
+    &["ops@example.com", "qa@example.com"],  // recipients
+).await?;
+```
+
+`send_many` envía un lote en una sola llamada.
+
+---
+
+## Validación y protección contra inyección de cabeceras
+
+`Email::validate()` se ejecuta antes de enviar (y puedes llamarlo tú mismo). Rechaza
+mensajes incompletos **y** defiende contra la inyección de cabeceras — un salto de línea
+introducido a escondidas en una cabecera es la forma en que los atacantes añaden un `Bcc` oculto:
+
+```rust
+// Missing recipients or an empty subject → MailError::InvalidMessage
+Email::new().subject("hi").validate()?;          // Err: no recipients
+
+// A CRLF in any header field → MailError::BadHeader (Django's BadHeaderError)
+Email::new()
+    .to("a@example.com")
+    .subject("Hello\r\nBcc: victim@example.com")  // injection attempt
+    .body("x")
+    .validate()?;                                  // Err: BadHeader
+```
+
+Ambos se verifican en el test de respaldo.
+
+---
+
+## Probar el correo
+
+Usa `InMemoryMailer` — graba cada mensaje en lugar de enviarlo, de modo que las pruebas
+afirman sobre lo que *se habría* enviado, sin red:
+
+```rust
+use rustango::email::InMemoryMailer;
+
+let mailer = InMemoryMailer::new();
+welcome_flow(&mailer).await?;          // your code under test
+
+let sent = mailer.sent();              // Vec<Email>
+assert_eq!(sent.len(), 1);
+assert_eq!(sent[0].to, vec!["ada@example.com".to_string()]);
+assert_eq!(sent[0].subject, "Welcome");
+```
+
+---
+
+## Plantillas
+
+Para cualquier cosa más allá de una línea de texto, renderiza el cuerpo a partir de una plantilla
+[Tera](html-views.md) en lugar de incrustar HTML. El `EmailRenderer` de la característica
+`email_templates` sigue una convención `name.subject.txt` / `name.txt` / `name.html` — un solo
+conjunto de plantillas produce el asunto, la parte de texto plano y la parte HTML juntos, de modo
+que las tres nunca divergen. El trait `Mailable` empaqueta «algo que sabe convertirse
+a sí mismo en un `Email`» para mensajes reutilizables.
+
+---
+
+## Envíalo fuera de la petición
+
+Enviar el correo en línea hace que el usuario espere a tu servidor SMTP y acopla la
+respuesta a su disponibilidad. Envíalo en su lugar desde un [trabajo en segundo plano](jobs.md) —
+el handler retorna de inmediato y un worker lo entrega (con reintentos si el SMTP está
+caído):
+
+```rust
+// in the handler: enqueue, don't send inline
+queue.dispatch(&SendWelcomeEmail { user_id }).await?;
+
+// the job (see the Background jobs guide):
+async fn run(&self) -> Result<(), JobError> {
+    let email = Email::new().to(/* ... */).subject("Welcome").body("...");
+    email.send(&*mailer).await.map_err(|e| JobError::Retryable(e.to_string()))?;
+    Ok(())
+}
+```
+
+La característica `email_jobs` cablea esto por ti.
+
+---
+
+## Referencia
+
+**Builder `Email`:** `to` · `cc` · `from` · `reply_to` · `subject` · `body` ·
+`html_body` · adjuntos · `validate()` · `send(&mailer)`.
+
+**Ayudantes:** `send_mail(mailer, subject, body, from, &recipients)` ·
+`send_many(mailer, &emails)` · `from_settings(&EmailSettings)`.
+
+**`MailError`:** `InvalidMessage` (incompleto) · `BadHeader` (inyección CRLF) ·
+`Transport` (fallo de backend/entrega).
+
+---
+
+## Véase también
+
+- [Trabajos en segundo plano](jobs.md) — entregar el correo fuera de la petición con reintentos.
+- [Flujos de cuenta](auth-flows.md) — correos de restablecimiento de contraseña / verificación /
+  enlace mágico construidos sobre esto.
+- [Vistas HTML](html-views.md) — el motor Tera que también usan las plantillas de correo.
+- [Caché](caching.md) — el mismo patrón de trait «cambia-el-backend».

--- a/docs/es/files.md
+++ b/docs/es/files.md
@@ -1,0 +1,231 @@
+# Archivos, subidas y medios
+
+Casi toda aplicación almacena archivos de usuario — avatares, adjuntos, informes exportados,
+imágenes. **Rustango** te ofrece un trait `Storage` con backends intercambiables (disco
+local, almacenamiento de objetos compatible con S3, en memoria para pruebas), un ayudante de
+**subida** multipart seguro con guardas de tamaño/tipo, y — cuando necesitas una
+biblioteca de medios rastreada — un `MediaManager` respaldado por base de datos con URLs
+prefirmadas. Escribe tu código una sola vez contra el trait; cambia de disco local a S3 con un
+cambio de una línea.
+
+[![Archivos en Rustango: una subida multipart se comprueba en tamaño y extensión y luego se escribe a través del trait Storage; el mismo trait respalda disco local, S3 y memoria, y url() devuelve una dirección pública](img/files.png)](img/files.png)
+
+> **¿Nuevo con algún término aquí?** *backend de almacenamiento*, *multipart*, *almacenamiento de
+> objetos*, *URL prefirmada* — ver el [glosario](glossary.md).
+
+> **Fuente:** `rustango::storage` (`Storage`, `LocalStorage`, `InMemoryStorage`,
+> `s3::S3Storage`, `BoxedStorage`), `rustango::uploads` (`save_uploads`,
+> `UploadConfig`, `sanitize_filename`), y `rustango::media`
+> (`Media`, `MediaManager`) — tras las características `storage` / `uploads` / `storage-s3` /
+> `media` (todas activadas por defecto).
+>
+> **Versión ejecutable:** los snippets de Storage + guardas de subida se copian de
+> [`files_doc.rs`](../crates/rustango/tests/files_doc.rs)
+> (`cargo test -p rustango --test files_doc`); el flujo multipart `save_uploads` de
+> extremo a extremo se somete a prueba mediante los tests internos en
+> `crates/rustango/src/uploads.rs`, y la biblioteca de medios mediante
+> [`media_sqlite_live.rs`](../crates/rustango/tests/media_sqlite_live.rs).
+
+## Tabla de contenidos
+
+- [Paso 1 — Elige un backend de almacenamiento](#step-1--pick-a-storage-backend)
+- [Paso 2 — Guarda, carga y sirve archivos](#step-2--save-load-and-serve-files)
+- [Paso 3 — Acepta una subida](#step-3--accept-an-upload)
+- [Nombres de archivo seguros](#safe-filenames)
+- [Producción: almacenamiento compatible con S3](#production-s3-compatible-storage)
+- [La biblioteca de medios](#the-media-library)
+- [Referencia](#reference)
+- [Véase también](#see-also)
+
+---
+
+## Paso 1 — Elige un backend de almacenamiento
+
+Cada backend implementa el mismo trait `Storage`, de modo que tu código nunca nombra el tipo
+concreto — sostiene un **`BoxedStorage`** (`Arc<dyn Storage>`):
+
+```rust
+use rustango::storage::{BoxedStorage, LocalStorage};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+let storage: BoxedStorage = Arc::new(LocalStorage::new(PathBuf::from("./uploads")));
+```
+
+| Backend | Característica | Úsalo para |
+|---|---|---|
+| `LocalStorage` | `storage` | despliegues de un solo servidor — archivos en disco local |
+| `S3Storage` | `storage-s3` | producción — almacenamiento de objetos S3 / R2 / B2 / MinIO |
+| `InMemoryStorage` | `storage` | pruebas — un `HashMap`, nunca toca el disco |
+
+---
+
+## Paso 2 — Guarda, carga y sirve archivos
+
+El trait son cuatro métodos async, indexados por una ruta en forma de cadena. `save` escribe
+bytes, `load` los vuelve a leer, más `exists` / `delete`:
+
+```rust
+use rustango::storage::{Storage, InMemoryStorage};
+
+let store = InMemoryStorage::new();
+store.save("avatars/7.png", &png_bytes).await?;
+assert!(store.exists("avatars/7.png").await?);
+let bytes = store.load("avatars/7.png").await?;
+store.delete("avatars/7.png").await?;
+```
+
+**Servir el archivo.** Adjunta una URL base (tu CDN o host estático) y `url(key)`
+construye la dirección pública que almacenas en el modelo y entregas al navegador:
+
+```rust
+let store = LocalStorage::new("./uploads".into())
+    .with_base_url("https://cdn.example.com/uploads");
+
+store.url("docs/report.pdf");   // Some("https://cdn.example.com/uploads/docs/report.pdf")
+```
+
+Sin una URL base, `url()` devuelve `None` — en su lugar transmitirías los bytes a través de un
+handler. `LocalStorage` también protege contra el path traversal en las claves.
+
+---
+
+## Paso 3 — Acepta una subida
+
+`save_uploads` consume un cuerpo `Multipart` de axum, valida cada archivo contra un
+`UploadConfig`, y escribe los supervivientes en tu `Storage` — en streaming, de modo que un archivo
+sobredimensionado se rechaza a mitad de transferencia en lugar de almacenarse primero en memoria.
+
+```rust
+use rustango::uploads::{save_uploads, UploadConfig};
+use axum::extract::Multipart;
+
+async fn upload(mp: Multipart) -> Result<impl IntoResponse, UploadError> {
+    let cfg = UploadConfig::new("avatars/")          // key prefix
+        .max_bytes(2 * 1024 * 1024)                  // reject files over 2 MiB
+        .allowed_extensions(&["png", "jpg", "jpeg", "webp"])
+        .randomize_filename(true);                   // avoid collisions
+
+    let saved = save_uploads(mp, &cfg, &storage).await?;   // Vec<SavedUpload>
+    Ok(Json(saved))
+}
+```
+
+Las guardas se aplican (y se verifican): `allowed_extensions` es **insensible a mayúsculas y
+minúsculas** (`"PNG"` y `"png"` son lo mismo), y `max_bytes` aborta el stream en cuanto se
+excede el tamaño. Los tests internos de `uploads` conducen cuerpos multipart reales y
+afirman que los archivos aterrizan en el almacenamiento, que los archivos sobredimensionados se
+rechazan y que las extensiones no permitidas se deniegan.
+
+```rust
+let cfg = UploadConfig::new("avatars/").allowed_extensions(&["PNG", "Jpg"]);
+assert!(cfg.allowed_extensions.contains("png"));   // normalized to lowercase
+assert!(cfg.allowed_extensions.contains("jpg"));
+```
+
+---
+
+## Nombres de archivo seguros
+
+Nunca confíes en un nombre de archivo suministrado por el cliente. `sanitize_filename` lo reduce a
+un basename seguro — eliminando componentes de directorio (path traversal) y reemplazando
+caracteres inseguros:
+
+```rust
+use rustango::uploads::sanitize_filename;
+
+sanitize_filename("../../etc/passwd");   // "passwd"   — no traversal
+sanitize_filename("my photo!.png");      // "my_photo_.png"
+sanitize_filename("");                    // "upload"   — never empty
+```
+
+`save_uploads` lo aplica por ti; llámalo directamente solo si construyes claves a mano.
+
+---
+
+## Producción: almacenamiento compatible con S3
+
+Para despliegues multi-servidor, cambia `LocalStorage` por `S3Storage` (tras la
+característica `storage-s3`). Habla la API de S3 con un firmante SigV4 hecho a mano, de modo que
+funciona con **AWS S3, Cloudflare R2, Backblaze B2 y MinIO**. El trait es
+idéntico — solo cambia el constructor:
+
+```rust
+use rustango::storage::s3::S3Storage;   // needs the `storage-s3` feature
+
+let storage: BoxedStorage = Arc::new(
+    S3Storage::new(/* bucket, region, endpoint, credentials */)
+);
+// save / load / delete / url — exactly the same calls as LocalStorage
+```
+
+Tus handlers y modelos no cambian; solo cambia el cableado en el arranque.
+
+---
+
+## La biblioteca de medios
+
+Cuando los archivos son registros de primera clase — rastreados en la base de datos, navegables en
+el admin, con miniaturas y entrega por CDN/prefirmada — recurre a `rustango::media` en lugar de a
+`Storage` en bruto. `MediaManager` persiste una fila `Media` por archivo y
+admite dos flujos de subida:
+
+- **Del lado del servidor:** `manager.save_bytes(...)` almacena los bytes y la fila en una sola
+  llamada.
+- **Directo al almacenamiento:** `manager.begin_upload(...)` devuelve una URL de **PUT
+  prefirmado** a la que el navegador sube directamente (tu servidor nunca hace de proxy de los
+  bytes), luego confirmas la fila.
+
+```rust
+use rustango::media::{Media, MediaManager};
+
+let manager = MediaManager::new_pool(pool.clone(), registry);
+// Hand the browser a short-lived download link:
+let url = manager.presigned_get(&media, Duration::from_secs(3600)).await?;
+```
+
+También gestiona el borrado lógico y la purga de huérfanos. El flujo completo se somete a prueba
+en `media_sqlite_live.rs`; los métodos prefirmados/de subida directa del manager están
+orientados a PostgreSQL.
+
+### Cómo se crean las tablas de medios
+
+Las tablas de medios (`rustango_media`, `rustango_media_collections`,
+`rustango_media_tags`, `rustango_media_tag_links`) son modelos gestionados. Su
+esquema se envía como una **migración de sistema** y se crea — por inquilino, cuando la
+característica `media` está activada — de la misma forma que el resto de las propias tablas del
+framework, cada vez que ejecutas `migrate` / aprovisionas un inquilino. No hay un paso perezoso de
+«crear en el primer uso»; si la característica está desactivada, las tablas nunca se crean.
+
+> **Actualización desde antes de 0.51.** Las versiones anteriores creaban las tablas de medios de
+> forma perezosa mediante una llamada DDL `ensure_table` en lugar de una migración. En el primer
+> `migrate` (o aprovisionamiento de inquilino) tras la actualización, el framework **reconcilia
+> automáticamente**:
+> como las tablas ya existen, la migración de medios generada se registra en
+> el libro mayor de migraciones de sistema *sin* volver a ejecutar su `CREATE TABLE`, y tus
+> filas existentes quedan intactas. **No se requiere ningún paso manual** — la actualización
+> que de otro modo fallaría con `relation already exists` / `table already exists`
+> ahora simplemente funciona. (Introducido en 0.51.1; ver el CHANGELOG.)
+
+---
+
+## Referencia
+
+**Trait `Storage`:** `save(key, &bytes)` · `load(key)` · `delete(key)` ·
+`exists(key)` · `url(key) -> Option<String>`.
+
+**`UploadConfig`:** `new(prefix)` · `.max_bytes(n)` · `.allowed_extensions(&[..])`
+(insensible a mayúsculas/minúsculas) · `.randomize_filename(bool)`. Usado por
+`save_uploads(multipart, &cfg, &storage)`.
+
+**Backends:** `LocalStorage` (disco) · `S3Storage` (almacenamiento de objetos, `storage-s3`)
+· `InMemoryStorage` (pruebas). Todos devuelven un `BoxedStorage`.
+
+---
+
+## Véase también
+
+- [El admin](admin.md) — los medios y los widgets de FK muestran los archivos subidos en la UI.
+- [Trabajos en segundo plano](jobs.md) — redimensiona/transcodifica una subida fuera de la petición.
+- [Caché](caching.md) — el mismo patrón de trait «cambia-el-backend».
+- [Guía de seguridad](security.md) — validar entradas de subida no confiables.

--- a/docs/es/getting-started.md
+++ b/docs/es/getting-started.md
@@ -1,0 +1,727 @@
+# Primeros pasos: construir un blog con Rustango
+
+Este recorrido te lleva desde un directorio vacío hasta un blog desplegado: publicaciones, una interfaz de administración, una API JSON, autenticación JWT y pruebas. De principio a fin. Si has usado Django, Laravel o Rails, la mayoría de los pasos te resultarán familiares; señalamos los paralelismos sobre la marcha.
+
+> **Tiempo:** ~45 minutos para el recorrido completo, ~10 minutos si solo quieres verlo funcionar.
+>
+> **Versión ejecutable:** cada paso a continuación está replicado en un ejemplo probado y compilable en [`crates/rustango/examples/getting_started_blog`](../crates/rustango/examples/getting_started_blog). Si algún paso parece estar mal, compáralo con ese ejemplo.
+
+[![Construir un blog con Rustango: generar la migración, aplicarla, arrancar el servidor y consultar la API JSON — todo desde un único binario](img/getting-started.png)](img/getting-started.png)
+
+---
+
+## Qué necesitas primero
+
+| Herramienta | Para qué | Instalación |
+|---|---|---|
+| Rust 1.88+ | Compilador | <https://rustup.rs> |
+| Docker | Postgres local | <https://docker.com> |
+| `psql` (opcional) | Inspeccionar la BD | `brew install libpq` / `apt install postgresql-client` |
+
+Comprueba las versiones que tienes instaladas:
+
+```bash
+rustc --version    # should print 1.88+
+docker --version   # any recent version
+```
+
+---
+
+## Paso 1: Instalar el generador de andamiaje
+
+El generador de andamiaje crea esqueletos de proyectos y apps por ti, como `django-admin` o `rails new`.
+
+```bash
+cargo install cargo-rustango
+```
+
+Esto añade el subcomando `cargo rustango ...` de forma global. Confirma que está ahí:
+
+```bash
+cargo rustango --help
+```
+
+---
+
+## Paso 2: Crear el proyecto
+
+Esto genera el andamiaje de un proyecto nuevo, el equivalente en **Rustango** de `rails new` o `composer create-project`.
+
+```bash
+cd ~/projects                                 # wherever you keep code
+cargo rustango new myblog                     # default = fullstack template
+cd myblog
+```
+
+Esto es lo que se generó:
+
+```
+myblog/
+├── Cargo.toml                  # rustango + axum + sqlx + tokio
+├── .env.example                # template for DATABASE_URL etc.
+├── .gitignore
+├── docker-compose.yml          # Postgres in a container
+├── README.md                   # project-specific
+├── config/                     # tiered settings (default + dev/staging/prod)
+├── migrations/                 # empty — `cargo run -- makemigrations` populates
+└── src/
+    ├── main.rs                 # entry point: `Cli::new().api(urls::api()).run()`
+    ├── models.rs               # every #[derive(Model)] lives here
+    ├── views.rs                # axum request handlers
+    └── urls.rs                 # `pub fn api()` route aggregator + `admin_router(pool)`
+```
+
+Hay un único binario: `cargo run` arranca el servidor HTTP, y cada verbo al estilo de Django (`migrate`, `makemigrations`, `startapp`, `check`, …) pasa por el mismo binario mediante `cargo run -- <verb>`. No hay un binario `manage` aparte.
+
+`Cargo.toml` es el manifiesto de dependencias (como `composer.json` o un `Gemfile`). Ábrelo y confirma que `rustango` aparece bajo `[dependencies]`.
+
+> **Confirma el bloque `[features]` — elige un backend de base de datos.** `#[derive(Model)]`
+> aplica cfg-gates a sus impls `FromRow` / `LoadRelated` generadas según las features
+> de **tu** crate (un `cfg` dentro de una macro derive se resuelve contra la crate de
+> destino, no contra **Rustango**), así que aquí debe estar habilitada una feature de
+> backend o el primer modelo no compilará. Un andamiaje actual incluye:
+>
+> ```toml
+> [features]
+> default  = ["postgres"]            # the backend `cargo run` uses
+> postgres = ["rustango/postgres"]
+> sqlite   = ["rustango/sqlite"]
+> mysql    = ["rustango/mysql"]
+> ```
+>
+> Si tu `Cargo.toml` generado **no** tiene un bloque `[features]` (un `cargo-rustango`
+> más antiguo), añade el de arriba a mano — eso siempre lo arregla. Sin él, la
+> compilación falla con *"the trait bound `…: MaybePgFromRow` is not satisfied"*
+> más un revelador `warning: unexpected cfg condition value: postgres`.
+
+---
+
+## Paso 3: Configurar tu entorno
+
+La configuración vive en un archivo `.env`, igual que en Django o Laravel. Copia la plantilla:
+
+```bash
+cp .env.example .env
+```
+
+El `.env` generado es compatible con Docker de fábrica. Como vamos a ejecutar `cargo` en el host (no dentro del contenedor de desarrollo), cambia el host de la base de datos de `postgres` a `localhost`:
+
+```bash
+DATABASE_URL=postgres://rustango:rustango@localhost:5432/myblog_dev
+RUSTANGO_BIND=0.0.0.0:8080
+RUSTANGO_APEX_DOMAIN=localhost
+RUSTANGO_SESSION_SECRET=change-me-base64-encoded-32-bytes-or-more
+```
+
+Las credenciales, el puerto y el nombre de la base de datos (`myblog_dev`) ya coinciden con el servicio Postgres del `docker-compose.yml`, así que no necesitas tocarlos.
+
+`RUSTANGO_SESSION_SECRET` firma sesiones y tokens, así que no despliegues el marcador de posición. Genera uno real y pégalo:
+
+```bash
+openssl rand -base64 32     # paste output as RUSTANGO_SESSION_SECRET value
+```
+
+---
+
+## Paso 4: Arrancar Postgres
+
+El proyecto incluye un `docker-compose.yml` que ejecuta Postgres en un contenedor, para que no instales una base de datos a mano. La app en sí la ejecutaremos con `cargo` en el host, así que arranca solo el servicio `postgres` en segundo plano (el archivo de compose también define un contenedor de desarrollo `rust` opcional que, de lo contrario, ocuparía el puerto 8080):
+
+```bash
+docker compose up -d postgres
+```
+
+Confirma que está en marcha:
+
+```bash
+docker compose ps
+psql "$DATABASE_URL" -c "SELECT version();"   # should print Postgres version
+```
+
+---
+
+## Paso 5: Ejecutar las migraciones integradas
+
+Las migraciones crean las tablas de tu base de datos, la misma idea que `php artisan migrate` o `rails db:migrate`. Ejecútalas una vez para preparar las propias tablas del framework:
+
+```bash
+cargo run -- migrate
+```
+
+La primera compilación tarda ~2 minutos (Rust compila todo desde el código fuente). Un proyecto nuevo aún no incluye archivos de migración, así que verás `nothing to migrate (already up to date)` — `migrate` igualmente prepara la tabla de registro de auditoría del framework para que los modelos auditados funcionen en cuanto los añadas. Generarás tu primera migración real en el Paso 9.
+
+Comprueba el estado de las migraciones:
+
+```bash
+cargo run -- showmigrations
+```
+
+En un proyecto nuevo esto imprime `(no migrations in ./migrations)`. Una vez que crees un modelo y ejecutes `makemigrations` (Paso 9), cada migración aplicada muestra aquí una `[X]`.
+
+---
+
+## Paso 6: Primer arranque
+
+Arranca el servidor para asegurarte de que todo está conectado.
+
+```bash
+cargo run
+```
+
+Verás:
+
+```
+listening on http://0.0.0.0:8080
+```
+
+Abre <http://localhost:8080> en tu navegador. El andamiaje incluye un handler raíz sencillo (`views::index`) que te saluda con **Hello from Rustango!** y un enlace al admin — eso confirma que **Rustango** está funcionando. (Los proyectos que no definen su propia ruta `/` obtienen en su lugar una página de bienvenida integrada, mediante `Cli::with_welcome()`.)
+
+Pulsa Ctrl-C para detenerlo.
+
+---
+
+## Paso 7: Crear una app
+
+Una "app" es un módulo de funcionalidad autocontenido, exactamente como una app de Django. Tu app de blog contendrá el modelo Post, sus rutas y sus plantillas.
+
+```bash
+cargo run -- startapp blog
+```
+
+Esto escribe:
+
+```
+src/blog/
+├── mod.rs
+├── models.rs              # a starter model named after the app (you'll replace it)
+├── views.rs               # axum handlers
+├── urls.rs                # blog-specific routes (pub fn api())
+└── tests.rs               # in-process router + inventory smoke tests
+```
+
+`startapp` conecta el nuevo módulo por ti (similar a añadirlo a `INSTALLED_APPS` de Django): declara `mod blog;` en `src/main.rs` e inserta una línea `.merge(crate::blog::urls::api())` en el agregador `api()` de `src/urls.rs`, de modo que las rutas del blog se componen en la app automáticamente. No hace falta registrar el módulo manualmente.
+
+---
+
+## Paso 8: Definir un modelo
+
+Un modelo es una tabla de base de datos descrita como un struct de Rust, como un modelo de Django o una clase de Eloquent/Active Record. Abre `src/blog/models.rs` y define tu `Post`. (Para la referencia completa — cada tipo de campo, claves primarias personalizadas y todos los atributos — consulta la [guía de Modelos](models.md).)
+
+```rust
+use rustango::{Auto, Model};
+use chrono::{DateTime, Utc};
+
+#[derive(Model, Clone, Debug)]
+#[rustango(
+    table = "posts",
+    display = "title",
+    admin(
+        list_display  = "id, title, status, published_at",
+        search_fields = "title, body",
+        list_filter   = "status, author_id",
+        ordering      = "-published_at",
+    ),
+    audit(track = "title, body, status"),
+    index("status, published_at"),
+)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+
+    #[rustango(max_length = 200)]
+    pub title: String,
+
+    pub body: String,
+
+    #[rustango(max_length = 20, default = "'draft'")]
+    pub status: String,                  // draft | published
+
+    pub author_id: i64,
+
+    #[rustango(auto_now_add)]
+    pub published_at: Auto<DateTime<Utc>>,
+
+    #[rustango(soft_delete)]
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+```
+
+Algunas cosas de Rust a tener en cuenta:
+
+- `#[derive(Model, ...)]` es una **macro derive**: genera código automáticamente para el struct, del mismo modo que lo haría un decorador de clase o una clase base en otros frameworks. Derivar `Model` es lo que le da al struct sus métodos de consulta.
+- `Auto<i64>` marca un campo que la base de datos rellena por ti (un entero `i64` autoincremental), como una clave primaria automática.
+- `Option<...>` significa "este valor puede estar ausente". `Option<DateTime<Utc>>` es una marca de tiempo que puede ser nula, así que `deleted_at` está vacío hasta que la fila se elimina de forma lógica (soft-delete).
+- Los atributos `#[rustango(...)]` configuran cada campo (longitud máxima, valores por defecto, índices) y el bloque `admin(...)` prepara las columnas y filtros de la interfaz de administración.
+
+---
+
+## Paso 9: Crear y aplicar la migración
+
+Ahora convierte ese modelo en una tabla real. Primero, genera la migración a partir de tu modelo (como `makemigrations` en Django):
+
+```bash
+cargo run -- makemigrations
+```
+
+Verás algo como:
+
+```
+wrote ./migrations/0001_create_item_and_posts_and_rustango_admin_users_etc.json
+    + CreateTable("item")
+    + CreateTable("posts")
+    + CreateTable("rustango_admin_users")
+    + CreateTable("rustango_content_types")
+    + CreateIndex { table: "posts", columns: ["status", "published_at"], ... }
+```
+
+Esta primera migración crea tus modelos — `posts`, además del modelo inicial `item` que el andamiaje incluyó en `src/models.rs` — junto con las propias tablas de admin y de tipos de contenido del framework. Abre el JSON si quieres: contiene las operaciones más una instantánea completa del esquema.
+
+Aplícala a la base de datos:
+
+```bash
+cargo run -- migrate
+```
+
+Confirma que la tabla existe:
+
+```bash
+psql "$DATABASE_URL" -c "\d posts"
+```
+
+---
+
+## Paso 10: Probar el ORM
+
+Vamos a leer y escribir filas desde el código. El ORM te permite trabajar con las filas de la base de datos como structs de Rust en lugar de SQL en crudo, como el ORM de Django, Eloquent o Active Record.
+
+Edita temporalmente `src/main.rs` para ejecutar una prueba rápida de crear-y-leer antes de arrancar el servidor. Reemplaza el cuerpo del `Cli` con una prueba de humo del ORM improvisada (conserva el `#[rustango::main]` del generador de andamiaje y las declaraciones `mod` al principio del archivo):
+
+```rust
+mod blog;
+mod models;
+mod urls;
+mod views;
+
+use crate::blog::models::Post;
+use rustango::{Auto, Model};
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    let pool = rustango::sql::sqlx::PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
+
+    // CREATE
+    let mut p = Post {
+        id: Auto::default(),
+        title: "First post".into(),
+        body: "Hello, world.".into(),
+        status: "draft".into(),
+        author_id: 1,
+        published_at: Auto::default(),
+        deleted_at: None,
+    };
+    p.save(&pool).await?;
+    println!("created post id = {}", p.id.get().copied().unwrap());
+
+    // READ
+    let posts = Post::objects().fetch_on(&pool).await?;
+    for post in &posts {
+        println!("- {}", post.title);
+    }
+
+    Ok(())
+}
+```
+
+Qué está pasando aquí, en términos sencillos:
+
+- `pool` es el pool de conexiones a la base de datos compartido. Le pasas una referencia (`&pool`) a las llamadas de consulta en lugar de abrir una conexión nueva cada vez.
+- Las llamadas a la base de datos son asíncronas, así que cada una termina en `.await` — eso pausa hasta que llega el resultado y luego continúa. El `?` tras un `.await` dice "si esto dio error, detente y devuelve el error".
+- `main` devuelve un `Result`, el tipo éxito-o-error de Rust, que es por lo que funcionan `?` y el `Ok(())` de cierre.
+- Para guardar una fila, llama a `.save(&pool)` sobre ella. Para leer filas, construye una consulta con `Post::objects()` y ejecútala con `.fetch_on(&pool)` — el equivalente aproximado de `Post.objects.all()` de Django. (`.save(&pool)` / `.fetch_on(&pool)` reciben un `sqlx::PgPool`; la variante escueta `.fetch(&pool)` recibe en su lugar un `rustango::sql::Pool` multi-backend — consulta la [guía del ORM](orm.md).)
+
+Ejecútalo:
+
+```bash
+cargo run
+```
+
+Deberías ver el id de tu nueva publicación y las filas leídas de vuelta. Restaura `src/main.rs` a su forma de servidor andamiada una vez que hayas confirmado que funciona — el siguiente paso parte de ahí.
+
+---
+
+## Paso 11: Activar el auto-admin
+
+**Rustango** incluye una interfaz de administración generada para tus modelos, igual que el admin de Django. El generador de andamiaje ya te dio un helper `admin_router(pool)` en `src/urls.rs` que construye el auto-admin a partir de un pool — solo tienes que anidarlo bajo `/admin` y pasarlo al `Cli`.
+
+Primero, dale un título al admin en `src/urls.rs`. El `admin_prefix` debe coincidir con la ruta bajo la que lo anidarás en el siguiente paso (`/admin`) para que los propios enlaces y las acciones de formulario del admin se resuelvan:
+
+```rust
+pub fn admin_router(pool: PgPool) -> Router {
+    admin::Builder::new(pool)
+        .title("Myblog Admin")
+        .admin_prefix("/admin") // must match the `.nest("/admin", …)` below
+        .build()
+}
+```
+
+Luego conecta un pool en `src/main.rs` y anida el admin en el router de la API antes de entregárselo al `Cli`. Conserva la línea `mod blog;` del Paso 7 — eso es lo que registra tu modelo `Post` con el admin:
+
+```rust
+mod blog;
+mod models;
+mod urls;
+mod views;
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    let pool = rustango::sql::sqlx::PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
+
+    let api = urls::api().nest("/admin", urls::admin_router(pool));
+
+    rustango::manage::Cli::new()
+        .api(api)
+        .with_health() // /health + /ready endpoints
+        .run()
+        .await
+}
+```
+
+`Cli::new()...run()` es el mismo despachador unificado que generó el generador de andamiaje — sigue sirviendo cada `cargo run -- <verb>`; solo has enriquecido el router que sirve en tiempo de runserver.
+
+Ejecútalo:
+
+```bash
+cargo run
+```
+
+Abre <http://localhost:8080/admin> (sin barra final). Verás la página de inicio del admin con un enlace `posts`. Haz clic en él para ver tu publicación en borrador en la lista, haz clic en la publicación para abrir su formulario de edición y guarda. La pestaña de rastro de auditoría registra cada escritura.
+
+---
+
+## Paso 12: Construir la API JSON
+
+Un ViewSet expone un modelo como una API REST con endpoints de listar, crear, recuperar, actualizar y eliminar, muy parecido a un ViewSet de Django REST Framework o a un controlador de recursos de API de Laravel.
+
+### 12a. Generar el ViewSet
+
+Genera el andamiaje del archivo y luego rellena qué campos y comportamientos exponer:
+
+```bash
+cargo run -- make:viewset PostViewSet --model Post
+```
+
+Edita `src/post_view_set.rs`:
+
+```rust
+use rustango::ViewSet;
+use crate::blog::models::Post;
+
+#[derive(ViewSet)]
+#[viewset(
+    model         = Post,
+    fields        = "id, title, body, status, author_id, published_at",
+    filter_fields = "author_id, status",
+    search_fields = "title, body",
+    ordering      = "-published_at",
+    page_size     = 20,
+)]
+pub struct PostViewSet;
+```
+
+Registra el nuevo módulo añadiendo `mod post_view_set;` junto a las otras declaraciones `mod` al principio de `src/main.rs`.
+
+### 12b. Montar las rutas
+
+Conecta las rutas del ViewSet al router de la app (la versión de **Rustango** de un archivo `urls.py` o `routes/api.php`). El router del ViewSet necesita el pool de la base de datos, así que constrúyelo en `src/main.rs`, donde vive el pool, y fusiónalo en el agregador `urls::api()`:
+
+```rust
+let api = urls::api()
+    .nest("/admin", urls::admin_router(pool.clone()))
+    .merge(crate::post_view_set::PostViewSet::router("/api/posts", pool));
+
+rustango::manage::Cli::new()
+    .api(api)
+    .with_health()
+    .run()
+    .await
+```
+
+(`urls::api()` es el agregador que generó el generador de andamiaje; `manage startapp` fusiona las rutas de cualquier sub-app de la misma manera.)
+
+### 12c. Probar los endpoints
+
+Arranca el servidor:
+
+```bash
+cargo run
+```
+
+En otra terminal, consulta la API con `curl`:
+
+```bash
+curl http://localhost:8080/api/posts                                    # list
+curl -X POST http://localhost:8080/api/posts \
+     -H "content-type: application/json" \
+     -d '{"title":"From API","body":"Yo","status":"published","author_id":1}'
+curl http://localhost:8080/api/posts/1                                   # retrieve
+curl "http://localhost:8080/api/posts?search=API&ordering=-id"            # search + sort
+curl "http://localhost:8080/api/posts?status__ne=draft"                   # lookup operator
+```
+
+---
+
+## Paso 13: Dar forma a la salida con un Serializer
+
+Por defecto, el ViewSet devuelve todos los campos del modelo. Un Serializer te permite controlar la forma de la respuesta: ocultar campos internos, renombrarlos o marcar algunos como de solo lectura. Es el mismo papel que un serializer de DRF o un recurso de API de Laravel.
+
+```bash
+cargo run -- make:serializer PostSerializer --model Post
+```
+
+Edita `src/post_serializer.rs`:
+
+```rust
+use rustango::{Auto, Serializer};
+use crate::blog::models::Post;
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: Auto<i64>,
+    pub title: String,
+
+    #[serializer(source = "body")]                      // rename in API
+    pub content: String,
+
+    #[serializer(read_only)]                            // include in GET, ignore in POST/PUT
+    pub published_at: Auto<chrono::DateTime<chrono::Utc>>,
+}
+```
+
+El tipo de cada campo del serializer refleja el campo correspondiente del modelo, así que `id` y `published_at` conservan su envoltorio `Auto<…>` del modelo (un `Auto<i64>` sigue serializándose a un entero JSON plano). Luego registra el módulo añadiendo `mod post_serializer;` junto a las otras declaraciones `mod` en `src/main.rs`.
+
+Conecta el serializer al ViewSet con el atributo `serializer` — las respuestas de listar, recuperar y crear se renderizan entonces a través de él (la proyección `fields` a nivel de campo se omite en favor de la forma del serializer):
+
+```rust
+#[derive(ViewSet)]
+#[viewset(
+    model = Post,
+    serializer = crate::post_serializer::PostSerializer,
+    ordering = "-published_at",
+)]
+pub struct PostViewSet;
+```
+
+Esto funciona de forma idéntica en PostgreSQL, MySQL y SQLite. Los overrides `method` / `read_only` / `source` / `write_only` se aplican todos a la respuesta, y **los cuerpos de las peticiones también se validan a través del serializer**: `create` / `update` ejecutan su `validate()` (por campo y entre campos), devolviendo un `400` con forma de DRF (`{field: [messages]}`) en caso de fallo, y los campos de solo lectura / calculados que un cliente envíe se ignoran. (Nota: los campos de serializer `nested` / `many` necesitan que las filas relacionadas se carguen mediante `select_related`; de lo contrario se renderizan como su valor por defecto.) Consulta la [guía de ViewSets](viewsets.md) para el comportamiento completo de entrada + salida.
+
+---
+
+## Paso 14: Añadir autenticación JWT
+
+Los JWT son tokens firmados que le entregas a un cliente tras el login y compruebas en cada petición, un patrón común para la autenticación de APIs. El módulo `rustango::jwt` de **Rustango** los emite y los verifica (HS256) y está activo por defecto — sin ningún feature flag adicional.
+
+### 14a. Emitir un token en el login
+
+Incorpora el id del usuario (el "subject" del token) y cualquier claim personalizado, como roles, en un token firmado, y luego entrégaselo al cliente:
+
+```rust
+use rustango::jwt::{encode, Claims};
+use std::time::Duration;
+
+// Derive the signing key from your session secret.
+let secret = std::env::var("RUSTANGO_SESSION_SECRET")?.into_bytes();
+
+let mut claims = Claims::new(user_id.to_string());   // subject = user id
+claims.set("roles", vec!["editor"]);
+let token = encode(&claims.ttl(Duration::from_secs(900)), &secret)?;
+
+// Send `token` to the client (e.g. in the login response body).
+```
+
+### 14b. Verificar el token en cada petición
+
+Decodifica el token — esto comprueba la firma y la caducidad — y luego vuelve a leer los claims. Si falta o es inválido, rechaza la petición como no autorizada:
+
+```rust
+use rustango::jwt::decode;
+
+let claims = decode(&access_token, &secret)
+    .map_err(|_| StatusCode::UNAUTHORIZED)?;
+
+let user_id = claims.subject().ok_or(StatusCode::UNAUTHORIZED)?;
+let roles: Vec<String> = claims.get("roles").unwrap_or_default();
+```
+
+### 14c. Ciclo de vida de access + refresh
+
+`rustango::jwt` emite tokens únicos sin estado. Para el patrón completo — tokens de **access** de corta duración, un token de **refresh** de larga duración en una cookie HttpOnly, rotación y una lista negra de JTI para la revocación — habilita la feature `tenancy` y usa `rustango::tenancy::jwt_lifecycle::JwtLifecycle`, cuyos métodos `issue_pair_with` / `verify_access` / `refresh` gestionan el par por ti.
+
+---
+
+## Paso 15: Añadir middleware de seguridad
+
+El middleware envuelve cada petición para añadir comportamiento transversal. Aquí apilas IDs de petición, registro de acceso, límite de tasa, CORS y cabeceras de seguridad en una cadena. Cada `.method(...)` añade una capa, similar al middleware de Django o a la pila de middleware de Laravel. Consulta la [guía de Middleware](middleware.md) para el catálogo completo de capas y las reglas de ordenamiento.
+
+```rust
+use rustango::security_headers::{SecurityHeadersLayer, SecurityHeadersRouterExt, CspBuilder};
+use rustango::cors::{CorsLayer, CorsRouterExt};
+use rustango::rate_limit::{RateLimitLayer, RateLimitRouterExt};
+use rustango::access_log::{AccessLogLayer, AccessLogRouterExt};
+use rustango::request_id::{RequestIdLayer, RequestIdRouterExt};
+use rustango::health::health_router;
+use std::time::Duration;
+
+let app = urls::api()
+    .nest("/admin", urls::admin_router(pool.clone()))
+    .merge(crate::post_view_set::PostViewSet::router("/api/posts", pool.clone()))
+    .merge(health_router(pool.clone()))                        // /health, /ready
+    .request_id(RequestIdLayer::default())
+    .access_log(AccessLogLayer::default())                      // PII-redacted
+    .rate_limit(RateLimitLayer::per_ip(60, Duration::from_secs(60)))
+    .cors(CorsLayer::new()
+        .allow_origins(vec!["https://app.example.com"])
+        .allow_methods(vec!["GET", "POST", "PUT", "PATCH", "DELETE"]))
+    .security_headers(
+        SecurityHeadersLayer::strict()
+            .csp(CspBuilder::strict_starter().build()),
+    );
+```
+
+Entrega la `app` terminada al `Cli` exactamente como antes — `rustango::manage::Cli::new().api(app).with_welcome().run().await` — y cada petición fluye ahora a través de la pila de middleware completa.
+
+---
+
+## Paso 16: Escribir pruebas
+
+**Rustango** incluye un cliente de pruebas que dirige tu router en el mismo proceso, para que puedas hacer aserciones sobre respuestas HTTP reales sin arrancar un servidor, muy parecido al cliente de pruebas de Django o a las pruebas HTTP de Laravel. Genera el andamiaje de un archivo de pruebas:
+
+```bash
+cargo run -- make:test PostSmoke      # generates tests/post_smoke.rs
+```
+
+Los generadores `make:*` toman un nombre en PascalCase; `PostSmoke` se convierte en el archivo en snake_case `tests/post_smoke.rs`.
+
+Edita `tests/post_smoke.rs`. Las pruebas de integración viven en una crate separada, así que construyen el router bajo prueba directamente a partir del ViewSet (la misma llamada `router(...)` que montaste en el Paso 12b):
+
+```rust
+use rustango::test_client::TestClient;
+use myblog::post_view_set::PostViewSet;
+use rustango::sql::sqlx::PgPool;
+use serde_json::json;
+
+async fn app() -> axum::Router {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap()).await.unwrap();
+    PostViewSet::router("/api/posts", pool)
+}
+
+#[tokio::test]
+async fn list_posts_returns_200() {
+    let client = TestClient::new(app().await);
+    let response = client.get("/api/posts").send().await;
+    assert_eq!(response.status, 200);
+    let v = response.json_value();
+    assert!(v["results"].is_array());
+}
+
+#[tokio::test]
+async fn create_post_returns_the_new_object() {
+    let client = TestClient::new(app().await);
+    let response = client.post("/api/posts")
+        .json(&json!({
+            "title": "Test",
+            "body":  "x",
+            "status": "draft",
+            "author_id": 1,
+        }))
+        .send().await;
+    assert_eq!(response.status, 201);
+    let v: serde_json::Value = response.json();
+    assert_eq!(v["title"], "Test");
+}
+```
+
+> **Atención:** las pruebas de integración en `tests/` solo pueden hacer `use myblog::…` si la crate expone un target de librería. Un andamiaje nuevo es solo binario (`src/main.rs`, sin `src/lib.rs`), así que añade un `src/lib.rs` de una línea que reexporte los módulos que quieras probar — `pub mod models; pub mod post_view_set; pub mod urls;` — y conserva las líneas `mod …;` correspondientes en `src/main.rs`. (Si prefieres no añadir un target de librería, construye el router completamente en línea dentro de la prueba, tal como `make:test` genera su `app()`.)
+
+Ejecuta las pruebas:
+
+```bash
+cargo test --test post_smoke
+```
+
+---
+
+## Paso 17: Ejecutar la comprobación del sistema
+
+Antes de desplegar, ejecuta el comprobador integrado. Señala malas configuraciones comunes (como un `RUSTANGO_SESSION_SECRET` débil o una base de datos inalcanzable), similar a `check --deploy` de Django.
+
+```bash
+cargo run -- check --deploy
+```
+
+En tu entorno de desarrollo local verás algo como:
+
+```
+running rustango system check (deploy mode)...
+  [info]    6 models registered via inventory
+  [info]    database reachable
+  [info]    1 migration(s) on disk
+  [info]    RUSTANGO_SESSION_SECRET length OK
+  [info]    config tier resolved to `dev`
+  [warning] RUSTANGO_ENV is unset — set to `prod` so config loaders pick the right tier
+  [warning] DATABASE_URL points at localhost / 127.0.0.1 — verify this is intended in production
+  [warning] RUSTANGO_APEX_DOMAIN is unset / `localhost` — set it for tenancy projects
+```
+
+(Los recuentos exactos de modelos/migraciones dependen de tu proyecto.) Esas tres advertencias son las esperadas para el entorno de desarrollo. En una configuración de producción — `RUSTANGO_ENV=prod`, una `DATABASE_URL` de base de datos gestionada, un dominio ápice configurado — desaparecen y verás `all checks passed`. Corrige cualquier advertencia o error restante antes de hacer push a producción.
+
+---
+
+## Paso 18: Desplegar a producción
+
+Cómo despliegas depende de tu plataforma (Fly, Railway, Kubernetes, ECS a secas, etc.). Los pasos del lado del framework son los mismos en todas partes; el flag `--release` compila un binario optimizado:
+
+```bash
+# 1. Set production env
+export RUSTANGO_ENV=prod
+export DATABASE_URL=postgres://prod-host/myblog
+export RUSTANGO_SESSION_SECRET=$(openssl rand -base64 32)
+
+# 2. Run migrations
+cargo run --release -- migrate
+
+# 3. Audit
+cargo run --release -- check --deploy
+
+# 4. Build binary
+cargo build --release
+
+# 5. Run with a process supervisor (systemd / docker / k8s)
+./target/release/myblog
+```
+
+Asegúrate de que tu proxy inverso:
+- Termine HTTPS
+- Reenvíe `X-Forwarded-For` para obtener IPs precisas en `AccessLogLayer`
+- Reenvíe `X-Forwarded-Host`, `X-Forwarded-Proto`
+- Use `axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())` para que `ConnectInfo` quede poblado para el límite de tasa + el filtrado de IP
+
+---
+
+## Adónde ir a continuación
+
+| Tema | Doc |
+|---|---|
+| Versión ejecutable de esta guía | [`examples/getting_started_blog`](../crates/rustango/examples/getting_started_blog) |
+| Cada subcomando de `manage` | [`docs/manage.md`](manage.md) |
+| Recetario del ORM (filtros avanzados, agregaciones, M2M, soft delete) | [`docs/orm.md`](orm.md) |
+| Middleware (el catálogo completo de capas + ordenamiento) | [`docs/middleware.md`](middleware.md) |
+| Benchmarks de rendimiento (vs. Go) | [`docs/benchmarks.md`](benchmarks.md) |
+| Convenciones de la API (nomenclatura, patrones builder, feature gates) | [`docs/api-conventions.md`](api-conventions.md) |
+| Funciones de seguridad en profundidad | [`docs/security.md`](security.md) |
+| Auditoría de paridad con Django | [`docs/django-parity-audit-2026-05-21.md`](django-parity-audit-2026-05-21.md) |
+| Multi-tenancy | [README — sección Multi-tenancy](../README.md#multi-tenancy) |
+| Documentación de la API | <https://docs.rs/rustango> |
+
+Si te topas con algo que no funciona o no queda claro, abre un issue.

--- a/docs/es/glossary.md
+++ b/docs/es/glossary.md
@@ -1,0 +1,206 @@
+# Glosario
+
+Una referencia en lenguaje sencillo de las palabras usadas en esta documentación. Si un
+término de una guía te resulta desconocido, búscalo aquí primero. Las definiciones son
+deliberadamente informales — las guías en profundidad tienen los detalles precisos.
+
+Si nunca has construido una API web antes, lee [Fundamentos de las API web](#web-api-basics)
+de principio a fin; es una introducción de cinco minutos. Todo lo demás está pensado para
+consultarse sobre la marcha.
+
+## Tabla de contenidos
+
+- [Fundamentos de las API web](#web-api-basics) — qué es una API, en términos cotidianos
+- [Bloques de construcción de Rustango](#rustango-building-blocks) — las piezas que ensamblas
+- [Los datos y la base de datos](#data-and-the-database)
+- [Unas pocas palabras de Rust](#a-few-rust-words) — para que los bloques de código no den miedo
+- [Frameworks con los que comparamos](#frameworks-we-compare-to)
+
+---
+
+## Fundamentos de las API web
+
+**API** — *Application Programming Interface* (interfaz de programación de aplicaciones). Una forma de que un programa hable con
+otro. Una **API web** lo hace por internet: tu app envía un mensaje, el
+servidor envía uno de vuelta. Piénsalo como un camarero — pides de un menú, la
+cocina te devuelve comida.
+
+**API REST** — el estilo más común de API web. "REST" es solo un conjunto de
+convenciones: actúas sobre **recursos** (como "posts" o "users") usando verbos
+web estándar. No necesitas conocer la teoría — en la práctica significa *URL
+predecibles y un puñado de verbos*, descritos a continuación.
+
+**Endpoint** — una URL específica a la que responde tu API, como `/api/posts` (todos los posts)
+o `/api/posts/42` (el post con id 42). Una API es una colección de endpoints.
+
+**Verbo HTTP (o método)** — *qué* quieres hacer en un endpoint. Hay cinco
+que verás constantemente:
+
+| Verbo | Significa | Ejemplo |
+|---|---|---|
+| `GET` | leer / obtener | "dame todos los posts" |
+| `POST` | crear | "añade un post nuevo" |
+| `PUT` | reemplazar | "sobrescribe el post 42 por completo" |
+| `PATCH` | actualizar parcialmente | "cambia solo el título del post 42" |
+| `DELETE` | eliminar | "elimina el post 42" |
+
+**Petición / Respuesta (request / response)** — una petición es el mensaje que envías (un verbo + un endpoint
++ opcionalmente un cuerpo de datos). La respuesta es lo que vuelve (un código de estado +
+normalmente un cuerpo de datos).
+
+**JSON** — el formato de texto que las API usan para transportar datos. Se ve como
+`{"title": "Hello", "published": true}` — valores etiquetados, legibles por humanos. Tanto
+las peticiones como las respuestas suelen ser JSON.
+
+**Código de estado (status code)** — un número de tres dígitos en cada respuesta que indica cómo fue:
+
+| Código | Significado |
+|---|---|
+| `200` | OK — aquí están tus datos |
+| `201` | Created — tu cosa nueva se guardó |
+| `204` | Done — nada que devolver (p. ej. tras un borrado) |
+| `400` | Bad request — enviaste algo inválido (el cuerpo dice qué) |
+| `401` / `403` | No autenticado / no permitido |
+| `404` | Not found (no encontrado) |
+| `429` | Too many requests — ve más despacio |
+| `500` | El servidor topó con un error |
+
+**CRUD** — *Create, Read, Update, Delete* (crear, leer, actualizar, eliminar). Las cuatro cosas básicas que haces con los datos.
+Una "API CRUD" simplemente significa una API que te permite hacer las cuatro. Consulta
+[ViewSets](viewsets.md), que construyen una API CRUD completa a partir de una sola declaración.
+
+**Cadena de consulta / parámetro de consulta (query string / query parameter)** — la parte `?key=value` al final de una URL,
+usada para filtrar, buscar, ordenar o paginar los resultados — p. ej.
+`/api/posts?status=published&page=2`. Cada `key=value` es un parámetro.
+
+**Paginación** — dividir una lista larga de resultados en páginas para que una respuesta no sea
+enorme. El **envelope (envoltorio)** es lo que rodea a la página y también te indica los
+totales — p. ej. `{"count": 137, "page": 2, "results": [ … ]}`. Consulta
+[Paginación](viewsets.md#pagination).
+
+**`curl`** — una herramienta de línea de comandos para enviar peticiones a la API a mano. Los
+ejemplos `curl ...` de esta documentación te permiten probar un endpoint desde una terminal
+sin escribir nada de código.
+
+---
+
+## Bloques de construcción de Rustango
+
+Estas son las piezas que ensamblas para construir una app. Cada una enlaza a su guía completa.
+
+**Modelo (Model)** — una descripción de un tipo de cosa que tu app almacena, como un `Post` o
+un `User`. Lo escribes como un `struct` de Rust; Rustango lo convierte en una tabla de base de
+datos. Consulta la [guía del ORM](orm.md).
+
+**Migración (Migration)** — un cambio registrado en la forma de tu base de datos (añadir una tabla,
+una columna…). Generas una con `makemigrations` y la aplicas con `migrate`,
+para que cada entorno acabe con la misma estructura de base de datos.
+
+**Serializer** — el traductor entre las filas de tu base de datos y el JSON que tu API
+envía y recibe. Decide qué campos son visibles, renombra o calcula
+campos para la salida, y valida los datos entrantes. *Da forma* a los datos; no los
+guarda (eso lo hace el modelo). Consulta la [guía de Serializers](serializers.md).
+
+**ViewSet** — toma un modelo y un serializer y produce una **API JSON** CRUD
+completa (los cinco verbos de arriba) automáticamente, para que no escribas cada
+endpoint a mano. La *vista de API*. Consulta la [guía de ViewSets](viewsets.md).
+
+**Vista HTML (template view, class-based view)** — la contraparte renderizada en el servidor
+de un ViewSet: convierte un modelo en **páginas** HTML — una página de lista, una
+página de detalle, y formularios de crear/editar/eliminar — renderizadas mediante plantillas Tera,
+en lugar de JSON. La *vista HTML*. Consulta [Vistas HTML](html-views.md).
+
+**Plantilla (Template)** — un archivo con marcadores de posición (Rustango usa [Tera](https://keats.github.io/tera/),
+muy parecido a las plantillas de Django o a Jinja) que el servidor rellena con datos para producir
+una página HTML. `{{ post.title }}` inserta un valor; `{% for … %}` itera.
+
+**Router / montaje (mount)** — el router mapea las URL entrantes al código que las
+maneja. *Montar* un ViewSet significa "adjuntar sus endpoints a tu app en una ruta
+dada", p. ej. montar la API de posts en `/api/posts`. Consulta [URLs y enrutamiento](urls.md).
+
+**Middleware (una "capa" / layer)** — código que se ejecuta *alrededor* de cada petición — antes de tu
+handler y después de él — para preocupaciones transversales como el registro, el límite de tasa, las
+cabeceras de seguridad o el CSRF. "Layer" es la palabra de Rustango para una pieza de
+middleware. Consulta la [guía de Middleware](middleware.md).
+
+**Pool (o executor)** — la conexión a la base de datos que tu código usa para leer y
+escribir. Rustango te pide pasar el pool explícitamente a cada llamada a la base de datos
+(en vez de ocultarlo en un global), para que siempre quede claro qué toca la
+base de datos. Verás `&pool` como último argumento de las llamadas del ORM.
+
+**QuerySet** — una consulta a la base de datos que construyes paso a paso en Rust
+(`Post::objects().filter(...).order_by(...)`) antes de ejecutarla. Es perezosa (lazy):
+nada llega a la base de datos hasta que la `fetch`eas.
+
+**Feature flag (bandera de funcionalidad)** — un interruptor de encendido/apagado, definido en `Cargo.toml`, que incluye o
+excluye una parte del framework en tiempo de compilación. Te permite mantener tu app pequeña
+compilando solo lo que usas. La mayoría de las features están activadas por defecto.
+
+**Andamiaje (Scaffolding)** — comandos generadores (`startapp`, `make:serializer`,
+`make:viewset`…) que escriben archivos iniciales por ti para que no empieces desde una
+página en blanco. Consulta [Andamiaje](scaffolding.md).
+
+---
+
+## Los datos y la base de datos
+
+**Campo / columna (field / column)** — un dato de un modelo, como el `title` o el
+`published_at` de un post. "Campo" es el lado Rust; "columna" es el lado de la base de datos; se
+corresponden uno a uno.
+
+**Clave primaria (primary key)** — el id único que identifica una fila, normalmente un
+número autoincremental llamado `id`.
+
+**Clave foránea (foreign key, FK)** — un campo de un modelo que apunta a la fila de otro modelo,
+modelando una relación — p. ej. un `Post` tiene una clave foránea `author_id` que apunta
+a un `Author`. Es como las filas se referencian entre sí.
+
+**NULL / nullable** — `NULL` es la palabra de la base de datos para "sin valor / vacío". Un
+campo **nullable** puede estar vacío; uno no-nullable es obligatorio.
+
+**Tri-dialecto (tri-dialect)** — "funciona igual en las tres bases de datos soportadas" —
+PostgreSQL, MySQL y SQLite. Cuando una feature es tri-dialecto, puedes cambiar de
+base de datos sin cambiar tu código.
+
+---
+
+## Unas pocas palabras de Rust
+
+No necesitas saber Rust para *leer* la mayoría de los ejemplos, pero estas cuatro palabras aparecen
+por todas partes.
+
+**`struct`** — un paquete con nombre de campos, como un registro o una clase que solo tiene
+datos. Los modelos y los serializers son structs.
+
+**Macro derive (`#[derive(Model)]`, `#[derive(Serializer)]`…)** — una anotación de una
+línea encima de un struct que le dice al compilador que auto-genere un montón de
+código por ti (el mapeo de la base de datos, la conversión a JSON, …). Es la magia que
+convierte un simple struct en un modelo o serializer funcional.
+
+**`async` / `.await`** — la forma en que Rust maneja el trabajo que implica esperar (una
+consulta a la base de datos, una llamada de red). Una función marcada como `async` es "awaitable"; el
+`.await` tras una llamada significa "espera aquí el resultado". Todo lo que toca la
+base de datos es `async`.
+
+**`Result` / `Option`** — cómo Rust reporta resultados en lugar de lanzar
+excepciones. Un `Result` es "éxito *o* un error"; una `Option` es "un valor *o*
+nada". El `?` que ves tras algunas llamadas significa "si esto falló, detente y
+devuelve el error".
+
+---
+
+## Frameworks con los que comparamos
+
+Esta documentación dice de vez en cuando "como X" para ayudar a los lectores que vienen de otros
+ecosistemas. Las comparaciones son un extra — nunca las necesitas para seguir una guía.
+
+**Django** — un framework web de Python popular. Rustango toma prestada buena parte de su forma
+(modelos, migraciones, una interfaz de administración, los comandos `manage`).
+
+**DRF (Django REST Framework)** — el complemento de Django para construir API REST.
+Los serializers y ViewSets de Rustango están inspirados en él, así que "forma DRF" significa
+"dispuesto tal como lo hace DRF" — p. ej. errores de validación devueltos como un objeto JSON
+indexado por nombre de campo.
+
+**Laravel / Rails** — frameworks web populares de PHP y Ruby, mencionados por la misma
+razón de "si has usado esto, esto te resultará familiar".

--- a/docs/es/html-views.md
+++ b/docs/es/html-views.md
@@ -1,0 +1,336 @@
+# Vistas HTML — páginas renderizadas en el servidor
+
+Una vista HTML convierte un modelo en **páginas web renderizadas en el servidor** — una
+página de listado, una página de detalle y formularios de creación/edición/borrado — a partir de
+una sola declaración. Es la **hermana de los [ViewSets](viewsets.md)**: donde un ViewSet emite JSON
+para clientes de API, una vista HTML emite una página renderizada para un navegador. Ambas se
+construyen a partir del mismo `#[derive(Model)]`, y puedes servir un modelo de *ambas* formas a la
+vez.
+
+Son el equivalente en **Rustango** de las vistas genéricas basadas en clases de Django
+(`ListView`, `DetailView`, `CreateView`, `UpdateView`, `DeleteView`) o de los controladores de
+recursos de Laravel que devuelven vistas Blade. Renderizan mediante plantillas
+[Tera](https://keats.github.io/tera/).
+
+[![Vistas HTML en Rustango: un modelo alimenta ListView, DetailView y CreateView/UpdateView/DeleteView, cada una renderizando una plantilla Tera en una página renderizada en el servidor](img/html-views.png)](img/html-views.png)
+
+> **¿Nuevo con algún término aquí?** Si *modelo*, *plantilla*, *router* o *renderizado en el
+> servidor* no te resultan familiares, el [glosario](glossary.md) explica cada uno en lenguaje
+> sencillo.
+
+> **Fuente:** `rustango::template_views` (`ListView`, `DetailView`, `CreateView`,
+> `UpdateView`, `DeleteView`, `TemplateView`, `RedirectView`) — tras la
+> característica `template_views` (activada por defecto).
+>
+> **Versión ejecutable:** el ejemplo API-vs-HTML de abajo está fijado por el
+> test del framework
+> [`html_and_api_contrast_sqlite_live.rs`](../crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
+> (`cargo test -p rustango --features sqlite --test html_and_api_contrast_sqlite_live`).
+> Las vistas individuales están cubiertas por `template_view.rs` y
+> `template_views_context_object_name_sqlite_live.rs`.
+
+## Tabla de contenidos
+
+- [Vistas de API vs vistas HTML — ¿cuál quieres?](#api-views-vs-html-views--which-do-you-want)
+- [Las cinco vistas de modelo](#the-five-model-views)
+- [ListView](#listview) · [DetailView](#detailview)
+- [CreateView, UpdateView, DeleteView](#createview-updateview-deleteview)
+- [El contexto de Tera](#the-tera-context)
+- [TemplateView y RedirectView](#templateview-and-redirectview)
+- [Mono-inquilino vs multi-inquilino](#single-tenant-vs-multi-tenant)
+- [Servir un modelo de ambas formas](#serving-one-model-both-ways)
+- [Véase también](#see-also)
+
+---
+
+## Vistas de API vs vistas HTML — ¿cuál quieres?
+
+Esta es la primera decisión. Ambas convierten un modelo en endpoints; difieren en
+*qué sale* y *quién llama*.
+
+| | **Vista de API** — [ViewSet](viewsets.md) | **Vista HTML** — esta guía |
+|---|---|---|
+| Módulo | `rustango::viewset` | `rustango::template_views` |
+| Devuelve | **datos JSON** | una **página HTML renderizada en el servidor** |
+| Pensada para | SPAs, apps móviles, otros servicios | navegadores, sitios renderizados en el servidor, CRUD tipo admin |
+| Una «creación» | `POST` JSON → `201` + el nuevo objeto | `POST` de un formulario → redirección `303` a una página de éxito |
+| Ante una entrada inválida | `400` + un mapa de errores JSON indexado por campo | vuelve a renderizar el formulario con los errores mostrados |
+| Lee un listado como | un sobre JSON paginado | una `<table>`/bucle en tu plantilla |
+| Habitualmente autenticada con | tokens / JWT / claves de API | cookies de sesión |
+| Análogo en Django | DRF `ModelViewSet` | vistas genéricas basadas en clases |
+
+No tienes que elegir globalmente — elige por recurso, y puedes montar **ambas
+sobre el mismo modelo** (ver [abajo](#serving-one-model-both-ways)). Reglas generales:
+
+- Construyes un **backend JSON** para un framework de frontend o app móvil → ViewSet.
+- Construyes un **sitio renderizado en el servidor** (el servidor devuelve páginas HTML) → vistas
+  HTML.
+- Necesitas ambas (una API pública *y* páginas CRUD internas) → monta ambas.
+
+> ¿Buscas el lado JSON? Tiene su propia inmersión: [ViewSets — APIs REST
+> CRUD](viewsets.md).
+
+---
+
+## Las cinco vistas de modelo
+
+Cada vista es `for_model(SCHEMA)` más un `.router(prefix, tera, pool)`. Montarlas en el mismo
+`prefix` (digamos `/posts`) da el conjunto clásico de URLs CRUD:
+
+| Vista | Renderiza | Rutas montadas | Plantilla por defecto |
+|---|---|---|---|
+| [`ListView`](#listview) | un listado paginado | `GET <prefix>` | `<table>_list.html` |
+| [`DetailView`](#detailview) | una fila | `GET <prefix>/{pk}` | `<table>_detail.html` |
+| [`CreateView`](#createview-updateview-deleteview) | un formulario de nuevo registro | `GET`/`POST <prefix>/new` | `<table>_form.html` |
+| [`UpdateView`](#createview-updateview-deleteview) | un formulario de edición rellenado | `GET`/`POST <prefix>/{pk}/edit` | `<table>_form.html` |
+| [`DeleteView`](#createview-updateview-deleteview) | una página de confirmación | `GET`/`POST <prefix>/{pk}/delete` | `<table>_confirm_delete.html` |
+
+`<table>` es el nombre de la tabla del modelo, así que un `Post` (tabla `posts`) busca
+`posts_list.html`, `posts_detail.html`, y así sucesivamente. Reemplaza cualquiera de ellas con
+`.template("my_name.html")`.
+
+---
+
+## ListView
+
+Una página de listado paginado. Tú proporcionas una plantilla que itera sobre `object_list`;
+la vista gestiona la paginación, el orden, el filtrado y la búsqueda a partir de los parámetros de
+consulta.
+
+```rust
+use rustango::template_views::ListView;
+use std::sync::Arc;
+use tera::Tera;
+
+let app = ListView::for_model(Post::SCHEMA)
+    .page_size(20)                       // rows per page (?page=N to navigate)
+    .order_by("published_at", true)      // default sort, true = DESC
+    .filter_fields(&["status", "author_id"])  // ?status=published
+    .search_fields(&["title", "body"])        // ?search=rust
+    .router("/posts", Arc::new(tera), pool);
+```
+
+Un `posts_list.html` correspondiente — fíjate en `object_list` y en las variables de paginación
+que la vista estampa por ti:
+
+```html
+<h1>Posts ({{ total }})</h1>
+{% for post in object_list %}
+  <article>
+    <h2><a href="/posts/{{ post.id }}">{{ post.title }}</a></h2>
+    <p>{{ post.body }}</p>
+  </article>
+{% endfor %}
+
+{% if has_prev %}<a href="?page={{ page - 1 }}">← prev</a>{% endif %}
+page {{ page }} / {{ total_pages }}
+{% if has_next %}<a href="?page={{ page + 1 }}">next →</a>{% endif %}
+```
+
+`?page=`, `?status=`, `?search=` y `?ordering=` funcionan igual que en un listado
+ViewSet — la diferencia es puramente que el resultado es una página renderizada en lugar de un
+sobre JSON. Usa `.context_object_name("posts")` si prefieres iterar sobre `posts` en vez de sobre
+`object_list` en la plantilla.
+
+---
+
+## DetailView
+
+Una fila, buscada a partir de la URL. Por defecto coincide con la clave primaria
+(`/posts/42`); apúntala a otra columna con `.lookup_field("slug")` para URLs bonitas
+(`/posts/my-first-post`). Una fila ausente es un `404`.
+
+```rust
+use rustango::template_views::DetailView;
+
+let app = DetailView::for_model(Post::SCHEMA)
+    .lookup_field("slug")          // GET /posts/{slug} instead of /posts/{id}
+    .router("/posts", Arc::new(tera), pool);
+```
+
+La plantilla recibe la fila como `object`:
+
+```html
+<h1>{{ object.title }}</h1>
+<p>{{ object.body }}</p>
+<small>by author #{{ object.author_id }}</small>
+```
+
+---
+
+## CreateView, UpdateView, DeleteView
+
+El lado de escritura. Cada una gestiona un `GET` (renderizar un formulario / página de
+confirmación) y un `POST` (hacer el trabajo, luego **redirigir**). La redirección-tras-POST es el
+patrón estándar **Post/Redirect/Get** — evita que un refresco del navegador vuelva a enviar.
+
+**CreateView** — `GET /posts/new` renderiza un formulario vacío; `POST /posts/new`
+inserta la fila y hace un `303` a `success_url`:
+
+```rust
+use rustango::template_views::CreateView;
+
+let app = CreateView::for_model(Post::SCHEMA)
+    .success_url("/posts")         // where to send the browser after a save
+    .router("/posts", Arc::new(tera), pool);
+```
+
+La plantilla del formulario (`posts_form.html`) se comparte con UpdateView. `is_update`
+distingue las dos, y `errors` transporta de vuelta cualquier mensaje de validación:
+
+```html
+<form method="post">
+  <input name="title" value="{{ object.title | default(value='') }}">
+  <textarea name="body">{{ object.body | default(value='') }}</textarea>
+  {% for field, msgs in errors %}
+    <p class="error">{{ field }}: {{ msgs | join(sep=', ') }}</p>
+  {% endfor %}
+  <button>{% if is_update %}Save{% else %}Create{% endif %}</button>
+</form>
+```
+
+**Validación.** Las reglas del esquema (tipo, `max_length`, NOT NULL…) se aplican
+automáticamente. Añade las tuyas con un validador de closure — ante un `Err`, el formulario
+se vuelve a renderizar con los mensajes y un estado `422` en lugar de guardar:
+
+```rust
+use rustango::forms::FormErrors;
+
+CreateView::for_model(Post::SCHEMA)
+    .validator(|data| {
+        let mut errs = FormErrors::default();
+        if data.get("title").map_or(true, |t| t.len() < 5) {
+            errs.add("title", "must be at least 5 characters");
+        }
+        if errs.is_empty() { Ok(()) } else { Err(errs) }
+    })
+    .success_url("/posts")
+    .router("/posts", Arc::new(tera), pool);
+```
+
+También puedes reutilizar los validadores de una estructura `#[derive(Form)]` con `.form::<F>()`
+(solo validación por ahora — ver la documentación de la API).
+
+**UpdateView** — `GET /posts/{pk}/edit` renderiza el mismo formulario rellenado desde la
+fila (`object` está poblado, `is_update` es `true`); `POST` actualiza y hace un `303`.
+
+```rust
+use rustango::template_views::UpdateView;
+
+UpdateView::for_model(Post::SCHEMA)
+    .success_url("/posts")
+    .router("/posts", Arc::new(tera), pool);
+```
+
+**DeleteView** — `GET /posts/{pk}/delete` renderiza una página de confirmación
+(`posts_confirm_delete.html`, con `object`); `POST` borra y hace un `303`.
+
+```rust
+use rustango::template_views::DeleteView;
+
+DeleteView::for_model(Post::SCHEMA)
+    .success_url("/posts")
+    .router("/posts", Arc::new(tera), pool);
+```
+
+Monta las cinco en el mismo prefijo y tienes un CRUD HTML completo:
+
+```rust
+let app = axum::Router::new()
+    .merge(ListView::for_model(Post::SCHEMA).router("/posts", tera.clone(), pool.clone()))
+    .merge(DetailView::for_model(Post::SCHEMA).router("/posts", tera.clone(), pool.clone()))
+    .merge(CreateView::for_model(Post::SCHEMA).success_url("/posts").router("/posts", tera.clone(), pool.clone()))
+    .merge(UpdateView::for_model(Post::SCHEMA).success_url("/posts").router("/posts", tera.clone(), pool.clone()))
+    .merge(DeleteView::for_model(Post::SCHEMA).success_url("/posts").router("/posts", tera, pool));
+```
+
+---
+
+## El contexto de Tera
+
+Cada vista estampa un contexto consistente para que las plantillas se porten limpiamente entre
+ellas:
+
+| Vista | Variables disponibles en la plantilla |
+|---|---|
+| `ListView` | `object_list` (las filas de la página), `page`, `page_size`, `total`, `total_pages`, `has_next`, `has_prev` |
+| `DetailView` | `object` (la fila) |
+| `CreateView` / `UpdateView` | `object` (vacío al crear, rellenado al actualizar), `is_update` (bool), `errors`, `values` |
+| `DeleteView` | `object` (la fila a confirmar) |
+
+Las filas se exponen como mapas planos indexados por nombre de columna (`{{ post.title }}`), con
+el `NULL` de SQL renderizado como `null`. Usa `.context_object_name("posts" / "post")` para
+añadir un alias más amigable junto a `object_list` / `object`.
+
+---
+
+## TemplateView y RedirectView
+
+Dos ayudantes sin modelo para las páginas que todo sitio tiene:
+
+**TemplateView** — renderiza una plantilla estática con un contexto fijo (una página «acerca de»,
+una landing page). Sin modelo, sin base de datos:
+
+```rust
+use rustango::template_views::TemplateView;
+
+let app = TemplateView::new("about.html")
+    .context_value("title", "About us")
+    .router("/about", Arc::new(tera));
+```
+
+**RedirectView** — una redirección permanente o temporal en una URL (para páginas movidas):
+
+```rust
+use rustango::template_views::RedirectView;
+
+let app = RedirectView::to("/posts").router("/old-posts");
+```
+
+---
+
+## Mono-inquilino vs multi-inquilino
+
+Cada vista de modelo trae dos constructores de router — el mismo builder, elige el que
+coincida con cómo tu app gestiona las conexiones a la base de datos:
+
+- **`.router(prefix, tera, pool)`** — mono-inquilino; captura un pool en el momento del montaje.
+  Esto es lo que usan los ejemplos de arriba.
+- **`.tenant_router(prefix, tera)`** — multi-inquilino; resuelve una conexión por petición desde
+  el extractor [`Tenant`](https://docs.rs). Disponible con las características
+  `template_views` + `tenancy`. Las plantillas se portan sin cambios entre ambos.
+
+Esto refleja la división de ViewSet (`router` / `router_pool` vs `tenant_router`).
+
+---
+
+## Servir un modelo de ambas formas
+
+No estás limitado a una sola puerta de entrada. Monta una API JSON *y* páginas HTML sobre el
+mismo modelo y pool — una API pública para clientes, páginas renderizadas en el servidor para
+personas:
+
+```rust
+use rustango::viewset::ViewSet;
+use rustango::template_views::{ListView, DetailView};
+
+let app = axum::Router::new()
+    // JSON for API clients:
+    .merge(ViewSet::for_model(Post::SCHEMA).router_pool("/api/posts", pool.clone()))
+    // HTML pages for browsers:
+    .merge(ListView::for_model(Post::SCHEMA).router("/posts", tera.clone(), pool.clone()))
+    .merge(DetailView::for_model(Post::SCHEMA).router("/posts", tera, pool));
+```
+
+Ahora `GET /api/posts` devuelve el sobre JSON paginado y `GET /posts`
+devuelve un listado HTML renderizado — las mismas filas, el mismo pool, dos formas. Esta
+configuración exacta es lo que afirma el [test de respaldo](../crates/rustango/tests/html_and_api_contrast_sqlite_live.rs).
+
+---
+
+## Véase también
+
+- [ViewSets — APIs REST CRUD](viewsets.md) — la contraparte JSON/API, en profundidad.
+- [Admin](admin.md) — el admin autogenerado se construye sobre estas mismas vistas.
+- [URLs y enrutamiento](urls.md) — cómo componer estos routers en tu app.
+- [Serializadores](serializers.md) — da forma al JSON cuando tomas la ruta de la API.

--- a/docs/es/i18n.md
+++ b/docs/es/i18n.md
@@ -1,0 +1,266 @@
+# Internacionalización (i18n)
+
+La internacionalización consiste en servir tu app en el idioma del usuario.
+**Rustango** la divide en dos mitades: **resolver** qué locale quiere una petición
+(cookie → `Accept-Language` → valor por defecto — tratado en
+[Middleware](middleware.md)), y **traducir** cadenas a ese locale, que es el objeto
+de esta guía. El `Translator` carga catálogos de mensajes por locale, sustituye
+`{placeholders}`, gestiona plurales y hace un fallback elegante — el `gettext` /
+`{% trans %}` de Django, en Rust.
+
+[![i18n en Rustango: un Translator mantiene catálogos por locale; gettext busca una clave con fallback (locale → idioma base → por defecto → la clave misma), sustituye placeholders {name}, y ngettext elige singular vs. plural](img/i18n.png)](img/i18n.png)
+
+> **¿Nuevo con algún término aquí?** *locale*, *catálogo*, *Accept-Language*,
+> *pluralización*, *RTL* — consulta el [glosario](glossary.md).
+
+> **Fuente:** `rustango::i18n` (`Translator`, `Locale`, `negotiate_language`,
+> `plural_category`, `is_rtl_language`, `language_native_name`, y los bindings de
+> template `tera_tags`) — siempre compilado. El *middleware* de locale/zona horaria
+> por petición vive en `rustango::i18n::middleware` / `::timezone` (consulta
+> [Middleware](middleware.md)).
+>
+> **Versión ejecutable:** cada fragmento está copiado de
+> [`i18n_doc.rs`](../crates/rustango/tests/i18n_doc.rs)
+> (`cargo test -p rustango --test i18n_doc`); las sobrescrituras de traducción
+> respaldadas por base de datos se prueban en condiciones reales con
+> [`i18n_db_overrides_sqlite_live.rs`](../crates/rustango/tests/i18n_db_overrides_sqlite_live.rs).
+
+## Tabla de contenidos
+
+- [Las dos mitades de la i18n](#the-two-halves-of-i18n)
+- [Paso 1 — Construir un Translator](#step-1--build-a-translator)
+- [Paso 2 — Traducir cadenas (gettext)](#step-2--translate-strings-gettext)
+- [Placeholders](#placeholders)
+- [Pluralización](#pluralization)
+- [Orden de fallback](#fallback-order)
+- [Negociar el idioma](#negotiating-the-language)
+- [Idiomas de derecha a izquierda](#right-to-left-languages)
+- [Traducir en templates (Tera)](#translating-in-templates-tera)
+- [Cargar catálogos + sobrescrituras en tiempo de ejecución](#loading-catalogs--runtime-overrides)
+- [Véase también](#see-also)
+
+---
+
+## Las dos mitades de la i18n
+
+| Preocupación | Dónde | Qué hace |
+|---|---|---|
+| **Resolver** el locale | [`i18n::middleware::LocaleMiddleware`](middleware.md#locale-aware-middleware) | elige un locale por petición (cookie → Accept-Language → por defecto) y expone el extractor `ActiveLocale` |
+| **Traducir** cadenas | `i18n::Translator` (esta guía) | busca una clave de mensaje en el catálogo del locale activo |
+| Renderizar fechas en la TZ del usuario | [`i18n::timezone`](middleware.md#timezone-aware-middleware) | el filtro `{{ ts \| localtime }}` |
+
+Cableas el middleware una vez, luego traduces usando el locale que resolvió.
+
+---
+
+## Paso 1 — Construir un Translator
+
+Un `Translator` mantiene un **catálogo** (un mapa `key → message`) por locale.
+Constrúyelo con un locale por defecto, luego añade catálogos:
+
+```rust
+use rustango::i18n::{Locale, Translator};
+use std::collections::HashMap;
+
+let mut en = HashMap::new();
+en.insert("greeting".to_owned(), "Hello".to_owned());
+en.insert("welcome".to_owned(), "Welcome, {name}!".to_owned());
+
+let mut fr = HashMap::new();
+fr.insert("greeting".to_owned(), "Bonjour".to_owned());
+
+let translator = Translator::new(Locale::new("en"))   // default locale
+    .add_locale(Locale::new("en"), en)
+    .add_locale(Locale::new("fr"), fr);
+```
+
+Mantén el `Translator` en el estado de tu app (es barato de clonar-compartir) y
+busca cadenas con el [`ActiveLocale`](middleware.md#locale-aware-middleware) que
+resolvió el middleware.
+
+---
+
+## Paso 2 — Traducir cadenas (gettext)
+
+`gettext(locale, key)` devuelve el mensaje para ese locale — y degrada de forma
+segura cuando falta algo:
+
+```rust
+translator.gettext("en", "greeting");      // "Hello"
+translator.gettext("fr", "greeting");      // "Bonjour"
+
+translator.gettext("en", "missing.key");   // "missing.key"  — returns the key, never panics
+translator.gettext("de", "greeting");      // "Hello"        — unknown locale → default
+```
+
+Una clave faltante devuelve la clave misma, así que una cadena sin traducir aparece
+de forma visible en lugar de tumbar la página.
+
+---
+
+## Placeholders
+
+Los mensajes pueden llevar placeholders `{name}`; `translate` los sustituye a
+partir de pares clave/valor:
+
+```rust
+// catalog: "welcome" = "Welcome, {name}!"
+translator.translate("en", "welcome", &[("name", "Ada")]);   // "Welcome, Ada!"
+```
+
+`gettext` es el atajo sin placeholders; `translate` (y `gettext_fmt`) toman
+parámetros.
+
+---
+
+## Pluralización
+
+Los plurales difieren según el idioma *y* el conteo. `ngettext` es el atajo de dos
+formas: elige la clave singular para la categoría CLDR `one` y la clave plural en
+caso contrario, enlazando `{count}` automáticamente:
+
+```rust
+// catalog: "cart.one" = "1 item",  "cart.other" = "{count} items"
+translator.ngettext("en", "cart.one", "cart.other", 1);   // "1 item"
+translator.ngettext("en", "cart.one", "cart.other", 5);   // "5 items"
+```
+
+Usa `ngettext_fmt` para pasar placeholders adicionales junto a `{count}`.
+
+### Idiomas con más de dos formas
+
+El polaco, el ucraniano, el ruso, el árabe y otros tienen formas `few` / `many`
+que un par singular/plural no puede expresar. `plural_category(locale, n)` devuelve
+la categoría CLDR (`one` / `few` / `many` / `other`), y `translate_plural` elige la
+forma que coincide de un **catálogo por categoría** — una entrada por clave que
+contiene todas sus formas:
+
+```rust
+use rustango::i18n::plural_category;
+
+plural_category("en", 1);   // "one"
+plural_category("fr", 0);   // "one"   — French treats 0 as singular
+plural_category("pl", 2);   // "few"   — Polish 2–4
+plural_category("pl", 5);   // "many"
+
+// pl plural catalog: "deleted_pages" → { one, few, many }
+let n = 5;
+translator.translate_plural("pl", "deleted_pages", n, &[("count", &n.to_string())]);
+// → "Usunięto 5 stron."   (the `many` form)
+```
+
+Una forma faltante cae de vuelta a `other`, luego al lookup escalar (y finalmente a
+la clave), así que un idioma sin traducir aún se renderiza. Los idiomas del este
+asiático (`zh`, `ja`, …) tienen una única forma `other`.
+
+---
+
+## Orden de fallback
+
+Los lookups recorren una cadena para que una traducción parcial nunca deje un
+hueco: el **locale solicitado → su idioma base → la cadena de fallback → el locale
+por defecto → la clave misma**. Así una petición franco-canadiense se resuelve
+contra el catálogo `fr`:
+
+```rust
+// only "fr" is registered, not "fr-CA"
+translator.gettext("fr-CA", "greeting");   // "Bonjour"  — base-language fallback
+```
+
+Establece fallbacks adicionales con
+`Translator::new(default).with_fallback_chain(&["en"])`.
+
+---
+
+## Negociar el idioma
+
+Si resuelves el locale por tu cuenta (fuera del middleware), `negotiate_language`
+parsea un header `Accept-Language` del navegador y elige la mejor coincidencia
+entre los locales que soportas:
+
+```rust
+use rustango::i18n::negotiate_language;
+
+negotiate_language("fr-FR,fr;q=0.9,en;q=0.8", &["en", "fr"]);   // Some("fr")
+negotiate_language("de,ja;q=0.5", &["en", "fr"]);               // None — fall back to default
+```
+
+Esto es exactamente lo que usa `LocaleMiddleware` por debajo.
+
+---
+
+## Idiomas de derecha a izquierda
+
+`is_rtl_language` (y `Locale::direction()`) te dicen si debes poner `dir="rtl"` en
+la página — para el árabe, el hebreo, el persa, etc.:
+
+```rust
+use rustango::i18n::is_rtl_language;
+
+is_rtl_language("ar");   // true
+is_rtl_language("en");   // false
+```
+
+En un template: `<html dir="{{ direction }}">`, alimentado desde el `ActiveLocale`.
+Consulta la [nota RTL en Middleware](middleware.md#locale-aware-middleware).
+
+---
+
+## Traducir en templates (Tera)
+
+Todo lo anterior es la API de Rust; en los templates Tera — vistas HTML y la UI del
+admin — el mismo `Translator` se expone como filtros/funciones. Regístralos una vez
+contra el translator, y el locale activo (la variable de contexto `LANG` que fija
+el middleware) dirige cada lookup:
+
+```rust
+rustango::i18n::tera_tags::register(&mut tera, translator.clone());
+```
+
+```jinja
+{{ "Save" | translate(locale=LANG) }}
+<button title="{{ "Delete" | translate(locale=LANG) }}">…</button>
+
+{# count-aware: pass the count both as the selector `n` and as a {count} arg #}
+{{ translate_plural(key="deleted_pages", n=num, locale=LANG, count=num) }}
+
+<html lang="{{ LANG }}" dir="{{ get_text_direction(locale=LANG) }}">
+```
+
+La **clave es la cadena fuente en inglés** (estilo gettext), así que una cadena sin
+traducir se renderiza en inglés en lugar de en blanco — envuelves una cadena de UI
+primero y la traduces después, sin un registro de claves que mantener.
+
+Así es exactamente como **rustango-cms localiza su admin**: cada cadena del chrome
+pasa por `translate` / `translate_plural`, los catálogos se envían por locale bajo
+`src/admin/locales/`, el locale activo se resuelve por la cadena cookie →
+preferencia por usuario → `Accept-Language` → por defecto por tenant, y un
+conmutador en la barra lateral más un ajuste **Preferences → Language** por usuario
+permiten que los editores elijan. Las ediciones del operador vía la capa de
+sobrescritura en BD (abajo) surten efecto sin un redeploy.
+
+---
+
+## Cargar catálogos + sobrescrituras en tiempo de ejecución
+
+Rara vez construyes mapas a mano en producción. Dos cargadores:
+
+- **`Translator::from_directory(dir, default)`** — carga un archivo de catálogo por
+  locale desde un directorio al arrancar.
+- **`Translator::from_settings(&settings.i18n)`** — lo cablea desde tu config.
+
+Y los operadores pueden editar traducciones **en tiempo de ejecución** sin un
+redeploy: `set_override(locale, key, value)` (o `load_overrides(rows)` desde una
+tabla) se superponen a los catálogos de archivo y ganan para esa clave. Este flujo
+de sobrescritura en BD impulsa el editor de traducciones del admin y se prueba en
+condiciones reales en `i18n_db_overrides_sqlite_live.rs`.
+
+---
+
+## Véase también
+
+- [Middleware](middleware.md) — resolver el locale por petición (`LocaleMiddleware`,
+  `ActiveLocale`) y el filtro de zona horaria `{{ ts | localtime }}`.
+- [Vistas HTML](html-views.md) · [El admin](admin.md) — dónde afloran las cadenas
+  traducidas y el editor de traducciones.
+- [Glosario](glossary.md) — locale, catálogo, RTL y compañía en lenguaje llano.

--- a/docs/es/index.toml
+++ b/docs/es/index.toml
@@ -1,19 +1,19 @@
-# Table des matières de la documentation (français).
+# Tabla de contenidos de la documentación (español).
 # Mirrors docs/index.toml; filenames match English so the site maps pages 1:1.
 
 [[section]]
-title = "Premiers pas"
-slug = "premiers-pas"
+title = "Primeros pasos"
+slug = "primeros-pasos"
 pages = ["getting-started.md", "scaffolding.md", "glossary.md"]
 
 [[section]]
-title = "Guides"
-slug = "guides"
+title = "Guías"
+slug = "guias"
 pages = ["models.md", "orm.md", "admin.md", "serializers.md", "viewsets.md", "html-views.md", "openapi.md", "query-method.md", "mcp.md", "urls.md", "manage.md", "migrations.md", "middleware.md", "jobs.md", "websockets.md", "caching.md", "files.md", "i18n.md", "email.md", "testing.md", "security.md"]
 
 [[section]]
-title = "Authentification"
-slug = "authentification"
+title = "Autenticación"
+slug = "autenticacion"
 pages = ["auth-passwords.md", "auth-sessions.md", "auth-backends.md", "auth-decorators.md", "auth-jwt.md", "auth-jwt-api.md", "auth-api-keys.md", "auth-hmac.md", "auth-flows.md", "sso.md"]
 
 [[section]]
@@ -22,6 +22,6 @@ slug = "benchmarks"
 pages = ["benchmarks.md"]
 
 [[section]]
-title = "Référence"
-slug = "reference"
+title = "Referencia"
+slug = "referencia"
 pages = ["api-conventions.md"]

--- a/docs/es/jobs.md
+++ b/docs/es/jobs.md
@@ -1,0 +1,377 @@
+# Trabajos en segundo plano
+
+Cierto trabajo no debería suceder durante una petición — enviar un correo de
+bienvenida, redimensionar una subida, sincronizar una API de terceros. Hacerlo en
+línea hace esperar al usuario y acopla la respuesta a una llamada externa poco
+fiable. Un **trabajo en segundo plano** mueve ese trabajo a una cola: el handler
+retorna de inmediato, y un pool de workers ejecuta el trabajo momentos después,
+con **reintentos automáticos** y una ruta **dead-letter** para los fallos. Esto
+es Django-Q / Celery / las colas de Laravel, en Rust.
+
+[![Background jobs in Rustango: a handler dispatches a Job onto a queue, worker tasks run it, retryable failures back off and retry, fatal ones go to a dead-letter handler](img/jobs.png)](img/jobs.png)
+
+> **¿Un término nuevo aquí?** *cola*, *worker*, *reintento/backoff*,
+> *dead-letter* — ver el [glosario](glossary.md).
+
+> **Fuente:** `rustango::jobs` (`Job`, `JobQueue`, `InMemoryJobQueue`,
+> `JobError`, `JobDeadLetter`) y `rustango::jobs::DatabaseJobQueue` (la cola
+> respaldada por tabla, alias de `pg::PgJobQueue`) — tras la feature `jobs`
+> (activa por defecto).
+>
+> **Versión ejecutable:** los fragmentos in-memory, de reintento y de
+> dead-letter están copiados de
+> [`jobs_doc.rs`](../crates/rustango/tests/jobs_doc.rs)
+> (`cargo test -p rustango --test jobs_doc`); la cola persistente se prueba con
+> dogfooding sobre SQLite mediante
+> [`jobs_sqlite_live.rs`](../crates/rustango/tests/jobs_sqlite_live.rs)
+> (`cargo test -p rustango --features sqlite,jobs-postgres --test jobs_sqlite_live`).
+
+## Tabla de contenidos
+
+- [Paso 1 — Definir un trabajo](#step-1--define-a-job)
+- [Paso 2 — Iniciar una cola](#step-2--start-a-queue)
+- [Paso 3 — Despachar desde un handler](#step-3--dispatch-from-a-handler)
+- [Paso 4 — Cablearlo en tu aplicación](#step-4--wire-it-into-your-app) — el ejemplo completo
+- [Ejecutar los workers (CLI + producción)](#running-the-workers-cli--production)
+- [Reintentos y backoff](#retries-and-backoff)
+- [El handler dead-letter](#the-dead-letter-handler)
+- [La cola persistente (producción)](#the-persistent-queue-production)
+- [Referencia](#reference)
+- [Véase también](#see-also)
+
+---
+
+## Paso 1 — Definir un trabajo
+
+Un trabajo es una struct serializable que implementa `Job`. El payload es lo que
+se encola (serializado a JSON); `run()` es el trabajo. `NAME` enruta un payload
+encolado de vuelta a su handler, así que debe ser único.
+
+Genera un esqueleto con la CLI — `cargo run -- make:job WelcomeEmail` — o
+escríbelo a mano:
+
+```rust
+use rustango::jobs::{Job, JobError};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct WelcomeEmail {
+    user_id: i64,
+}
+
+#[async_trait::async_trait]   // add `async-trait` to your Cargo.toml
+impl Job for WelcomeEmail {
+    const NAME: &'static str = "welcome_email";
+
+    async fn run(&self) -> Result<(), JobError> {
+        // ... look up the user and send the email
+        Ok(())
+    }
+}
+```
+
+`run()` retorna:
+
+- `Ok(())` — hecho.
+- `Err(JobError::Retryable(msg))` — transitorio; el worker reintenta con backoff.
+- `Err(JobError::Fatal(msg))` — permanente; omite reintentos, dead-letter
+  inmediato.
+
+Sobrescribe `const MAX_ATTEMPTS: u32 = 3;` en la impl para cambiar el tope de
+reintentos (5 por defecto).
+
+---
+
+## Paso 2 — Iniciar una cola
+
+Para un único proceso (y para dev y tests), `InMemoryJobQueue` ejecuta los
+trabajos en tareas worker de tokio — sin base de datos. **Registra cada tipo de
+trabajo, luego `start()` los workers** (los trabajos no se recogen hasta que lo
+hagas):
+
+```rust
+use rustango::jobs::{InMemoryJobQueue, JobQueue};
+use std::sync::Arc;
+
+let queue = Arc::new(InMemoryJobQueue::with_workers(4));   // 4 worker tasks
+queue.register::<WelcomeEmail>().await;                    // before start/dispatch
+queue.start().await;
+
+// ... app runs ...
+
+queue.shutdown().await;   // on shutdown: drain in-flight jobs, then stop
+```
+
+Mantén el `Arc<InMemoryJobQueue>` en el estado de tu aplicación para que los
+handlers puedan alcanzarlo.
+
+> **In-memory significa in-memory.** Los trabajos encolados o en curso se
+> **pierden al reiniciar**. Para todo lo que no puedas permitirte perder, usa la
+> [cola persistente](#the-persistent-queue-production).
+
+---
+
+## Paso 3 — Despachar desde un handler
+
+Una vez la cola está en marcha, despachar es una sola llamada — encola y retorna
+de inmediato, así que la petición no espera al trabajo:
+
+```rust
+queue.dispatch(&WelcomeEmail { user_id: 42 }).await?;
+```
+
+Un worker lo recoge y ejecuta `run()` momentos después. Verificado de extremo a
+extremo: los tres trabajos despachados se ejecutan todos en los workers.
+
+```rust
+for user_id in 1..=3 {
+    queue.dispatch(&WelcomeEmail { user_id }).await.unwrap();
+}
+// → all three WelcomeEmail::run() calls execute on the worker pool
+```
+
+---
+
+## Paso 4 — Cablearlo en tu aplicación
+
+Juntando los pasos 1–3: construye la cola y registra cada trabajo **una sola vez
+en el arranque**, inicia los workers, entrega la cola a tus rutas para que los
+handlers puedan alcanzarla, y luego drena al apagar. La cola vive en tu
+`main.rs`:
+
+```rust
+// src/main.rs
+use std::sync::Arc;
+use rustango::jobs::{InMemoryJobQueue, JobQueue};
+use rustango::manage::Cli;
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Build the queue + register every job type BEFORE starting workers.
+    let queue = Arc::new(InMemoryJobQueue::with_workers(4));
+    queue.register::<WelcomeEmail>().await;
+    queue
+        .on_dead_letter(|dl| async move {
+            tracing::error!(job = dl.name, attempts = dl.attempts, error = %dl.error,
+                            "job dead-lettered");
+        })
+        .await;
+
+    // 2. Start the workers — tokio tasks that run inside THIS process.
+    queue.start().await;
+
+    // 3. Share the queue with handlers (axum extension/state).
+    let app = urls::api().layer(axum::Extension(queue.clone()));
+
+    // 4. Boot the server. Cli::run() blocks until Ctrl-C / SIGTERM.
+    Cli::new().api(app).with_health().run().await?;
+
+    // 5. On shutdown: drain in-flight jobs, then stop.
+    queue.shutdown().await;
+    Ok(())
+}
+```
+
+Un handler despacha releyendo la cola desde la petición:
+
+```rust
+use axum::Extension;
+use std::sync::Arc;
+use rustango::jobs::{InMemoryJobQueue, JobQueue};
+
+async fn signup(Extension(queue): Extension<Arc<InMemoryJobQueue>>) -> StatusCode {
+    // ... create the user ...
+    queue.dispatch(&WelcomeEmail { user_id: 42 }).await.ok();  // returns instantly
+    StatusCode::CREATED
+}
+```
+
+> **Almacena el tipo de cola concreto.** El trait `JobQueue` **no es
+> object-safe** (sus `register`/`dispatch` son genéricos), así que no puedes
+> mantener `Arc<dyn JobQueue>` en el estado — conserva el `Arc<InMemoryJobQueue>`
+> concreto (o `Arc<DatabaseJobQueue>`).
+
+---
+
+## Ejecutar los workers (CLI + producción)
+
+`start()` lanza los workers como **tareas de tokio dentro del proceso actual**.
+Así que cuando arrancas tu aplicación con la CLI — `cargo run` (que ejecuta el
+servidor) — los workers corren justo a su lado. Para la mayoría de las
+aplicaciones eso es todo lo que necesitas: **un proceso sirve peticiones *y*
+drena la cola**; no hay un comando worker aparte.
+
+```bash
+cargo run                 # starts the server AND the in-process workers
+cargo run -- make:job WelcomeEmail   # scaffold a new job type
+```
+
+### Un proceso worker dedicado (producción)
+
+A escala, a menudo quieres los workers **separados** del nivel web — para que un
+pico de tráfico no pueda dejar sin recursos a los trabajos, y para escalar cada
+uno de forma independiente. Con la [cola
+persistente](#the-persistent-queue-production) cada proceso extrae de la misma
+tabla `rustango_jobs`, así que simplemente ejecuta un segundo binario, sin
+servidor, que construye la cola, la inicia y bloquea hasta una señal:
+
+```rust
+// src/bin/worker.rs — run with `cargo run --bin worker`
+use std::sync::Arc;
+use rustango::jobs::{DatabaseJobQueue, JobQueue};
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pool = /* connect your tri-dialect Pool */;
+    DatabaseJobQueue::ensure_table_pool(&pool).await?;
+
+    let queue = Arc::new(DatabaseJobQueue::with_workers_pool(pool, 8));
+    queue.register::<WelcomeEmail>().await;   // register the SAME job types
+    queue.start().await;
+
+    tokio::signal::ctrl_c().await?;            // block until Ctrl-C / SIGTERM
+    queue.shutdown().await;                     // drain in-flight, then exit
+    Ok(())
+}
+```
+
+Despliégalo como su propio contenedor/servicio y escálalo a **N réplicas** —
+todas extraen de la tabla compartida de forma segura. El proceso web entonces
+solo necesita `dispatch` (no tiene que `start()` los workers). Empareja el worker
+con un barrido periódico
+[`reclaim_stuck_jobs_pool`](#the-persistent-queue-production) para recuperar
+trabajos de un worker que se ha caído.
+
+---
+
+## Reintentos y backoff
+
+Un trabajo que retorna `Retryable` se reencola con **backoff exponencial** (1s,
+2s, 4s, 8s, …) hasta `MAX_ATTEMPTS`. Úsalo para fallos transitorios — un timeout,
+una API con límite de tasa, un deadlock:
+
+```rust
+#[async_trait::async_trait]
+impl Job for FlakyImport {
+    const NAME: &'static str = "flaky_import";
+    async fn run(&self) -> Result<(), JobError> {
+        match call_external_api().await {
+            Ok(_)  => Ok(()),
+            Err(e) => Err(JobError::Retryable(e.to_string())),   // try again later
+        }
+    }
+}
+```
+
+El test que lo respalda despacha un trabajo que falla una vez y luego tiene
+éxito, y afirma que **se ejecutó más de una vez y finalmente tuvo éxito** — el
+reintento realmente ocurre.
+
+---
+
+## El handler dead-letter
+
+Cuando un trabajo agota sus reintentos — o retorna `Fatal` de inmediato — se
+entrega al callback **dead-letter** en lugar de desvanecerse. Registra uno (antes
+de `start`) para registrar, alertar o persistir el fallo:
+
+```rust
+queue
+    .on_dead_letter(|dl| async move {
+        // dl: JobDeadLetter { name, payload, attempts, error }
+        tracing::error!(job = dl.name, attempts = dl.attempts, error = %dl.error,
+                        "job dead-lettered");
+    })
+    .await;
+```
+
+Un error `Fatal` omite los reintentos y aterriza aquí en el primer intento:
+
+```rust
+async fn run(&self) -> Result<(), JobError> {
+    Err(JobError::Fatal("unprocessable payload".into()))   // → dead-letter now
+}
+```
+
+El test confirma que el callback se dispara exactamente una vez para un trabajo
+`Fatal`, con el `name` y el `error` del trabajo intactos.
+
+---
+
+## La cola persistente (producción)
+
+`InMemoryJobQueue` es de un solo proceso y olvida al reiniciar. Para despliegues
+reales — múltiples workers, múltiples réplicas, trabajos que deben sobrevivir a
+una caída — usa **`DatabaseJobQueue`** (el mismo tipo que `PgJobQueue`). Los
+trabajos viven en una tabla `rustango_jobs`; los workers los recogen con un
+`UPDATE … RETURNING` acotado por transacción, así que es seguro entre procesos.
+Es **tri-dialecto** (PostgreSQL, MySQL, SQLite). Las definiciones `Job` del paso
+1 no cambian.
+
+```rust
+use rustango::jobs::DatabaseJobQueue;   // = rustango::jobs::pg::PgJobQueue
+use rustango::jobs::JobQueue;
+use std::sync::Arc;
+use std::time::Duration;
+
+// 1. Create the jobs table once at boot (idempotent, tri-dialect).
+DatabaseJobQueue::ensure_table_pool(&pool).await?;
+
+// 2. Build the queue over your pool + N workers, and start it.
+let queue = Arc::new(
+    DatabaseJobQueue::with_workers_pool(pool.clone(), 4)
+        .poll_interval(Duration::from_millis(50)),
+);
+queue.register::<WelcomeEmail>().await;
+queue.start().await;
+
+// 3. Dispatch exactly as before — now it's durable.
+queue.dispatch(&WelcomeEmail { user_id: 42 }).await?;
+```
+
+**Recuperar workers caídos.** Si un worker muere a mitad de un trabajo, la fila
+queda bloqueada. Ejecuta un barrido periódico para liberar los bloqueos más
+antiguos que un umbral, de modo que otro worker retome el trabajo:
+
+```rust
+// e.g. from a scheduled task every few minutes:
+let reclaimed = DatabaseJobQueue::reclaim_stuck_jobs_pool(&pool, Duration::from_secs(300)).await?;
+```
+
+Tanto el flujo dispatch-and-run como `reclaim_stuck_jobs_pool` se prueban con
+dogfooding contra SQLite en `jobs_sqlite_live.rs`.
+
+---
+
+## Referencia
+
+**Backends**
+
+| Backend | Usar para | ¿Sobrevive al reinicio? |
+|---|---|---|
+| `InMemoryJobQueue` | un solo proceso, dev, tests | no |
+| `DatabaseJobQueue` (`PgJobQueue`) | producción; multi-worker / multi-réplica | sí (tabla `rustango_jobs`) |
+
+**`JobError`**
+
+| Variante | Efecto |
+|---|---|
+| `Retryable(String)` | reencolar con backoff exponencial, hasta `MAX_ATTEMPTS` |
+| `Fatal(String)` | omitir reintentos → dead-letter de inmediato |
+| `Queue(String)` | error interno de la cola (serialización/registro) |
+
+**Métodos de `JobQueue`:** `register::<T>()` · `dispatch(&payload)` · `start()` ·
+`shutdown()` · `pending_count()`. `DatabaseJobQueue` añade
+`ensure_table_pool`, `with_workers_pool`, `poll_interval` y
+`reclaim_stuck_jobs_pool`.
+
+---
+
+## Véase también
+
+- [Planificador](manage.md) — para trabajo recurrente *basado en el tiempo*
+  (estilo cron), en contraste con los trabajos bajo demanda.
+- [Correo](email.md) — la carga de trabajo canónica del «hazlo en un trabajo».
+- [Caché](caching.md) — la otra manera de mantener rápidos los handlers de
+  peticiones.
+- [Signals](orm.md) — hooks fire-and-forget que a menudo *despachan* un trabajo.

--- a/docs/es/manage.md
+++ b/docs/es/manage.md
@@ -1,0 +1,1204 @@
+# Referencia de la CLI `manage`
+
+Esta es la herramienta de línea de comandos de **Rustango**, como el `manage.py`
+de Django, el `artisan` de Laravel o el comando `rails` de Rails. En un proyecto
+generado mediante `cargo rustango new`, un único binario ejecuta cada comando
+(«verbo»):
+
+```bash
+cargo run                          # runserver (no args = boot the HTTP server)
+cargo run -- migrate               # any other verb
+cargo run -- --help                # full subcommand list
+```
+
+[![One binary runs every manage verb — server, migrations, scaffolders, database utilities, and system commands — like Django's manage.py or Laravel's artisan](img/manage.png)](img/manage.png)
+
+> **Fuente:** `rustango::manage` (`Cli`, el despachador de verbos) — detrás de
+> la característica `manage` (activada por defecto).
+>
+> **Versión ejecutable:** cada verbo aquí se ejecuta en un proyecto generado; el
+> ejemplo [`getting_started_blog`](../crates/rustango/examples/getting_started_blog)
+> se maneja con `cargo run -- migrate` y compañía.
+
+> **¿Nuevo con algún término aquí?** *scaffold*, *migration*, *tenant* — consulta
+> el [glosario](glossary.md).
+
+El enrutador de comandos vive en [`rustango::manage::Cli`](https://docs.rs/rustango/latest/rustango/manage/struct.Cli.html);
+tu `src/main.rs` lo conecta así:
+
+```rust
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    rustango::manage::Cli::new().api(urls::api()).run().await
+}
+```
+
+Los proyectos multi-tenant añaden `.tenancy()` a la cadena. Eso cambia el
+enrutador a [`rustango::tenancy::manage`](https://docs.rs/rustango/latest/rustango/tenancy/manage/index.html)
+y desbloquea los comandos multi-tenant.
+
+> **Forma más antigua** — los proyectos generados por
+> `manage startapp --with-manage-bin` (o los anteriores a v0.16) todavía
+> incluyen `src/bin/manage.rs`. Estos usan
+> `cargo run --bin manage -- <verb>`. Ambas formas aceptan los mismos verbos.
+
+Cada comando imprime en stdout y termina con un código distinto de cero ante
+errores de validación o de E/S. Ejecuta `cargo run -- --help` (o
+`<verb> --help`) para obtener la ayuda de uso en línea.
+
+---
+
+## Tabla de contenidos
+
+- [Migraciones](#migrations)
+- [Migraciones de datos](#data-migrations)
+- [Generadores de proyecto / app](#project--app-scaffolders)
+- [Generadores de archivos (`make:*`)](#file-generators-make)
+- [Utilidades de base de datos](#database-utilities)
+- [Comandos del sistema](#system-commands)
+- [Comandos de tenancy](#tenancy-commands)
+- [Subcomandos personalizados](#custom-subcommands)
+- [Flujos de trabajo comunes](#common-workflows)
+
+---
+
+## Migraciones
+
+### `makemigrations [name]`
+
+Genera un archivo de migración a partir de los cambios en tus modelos — como el
+`makemigrations` de Django. Compara tus modelos registrados con la última
+instantánea de esquema guardada en `migrations/` y escribe un nuevo archivo JSON
+con lo que haya cambiado.
+
+```bash
+cargo run -- makemigrations                          # auto-name (e.g. 0004_add_slug_to_posts)
+cargo run -- makemigrations rename_status_to_state   # custom suffix
+```
+
+**Cambios detectados automáticamente:**
+- `CreateTable` / `DropTable`
+- `AddColumn` / `DropColumn`
+- `AlterColumnType` / `AlterColumnNullable` / `AlterColumnDefault` / `AlterColumnMaxLength`
+- `AlterColumnUnique`
+- `CreateIndex` / `DropIndex`
+- `AddCheckConstraint` / `DropCheckConstraint`
+- `CreateM2MTable` / `DropM2MTable`
+
+**NO detectados automáticamente** (renombrar vs. eliminar+añadir es ambiguo):
+- `RenameTable`, `RenameColumn` — usa `--empty` y edita el JSON.
+
+### `makemigrations --app <app>`
+
+Limita la migración a una sola app. Escribe en el propio directorio
+`<project_root>/<app>/migrations/` de esa app y solo mira los modelos que
+pertenecen a ella.
+
+```bash
+cargo run -- makemigrations --app blog
+cargo run -- makemigrations --app blog backfill_slugs
+```
+
+### `makemigrations --scope <registry|tenant>`
+
+Solo multi-tenant. Escribe una única migración solo para los modelos de un
+scope — aquellos cuyo atributo `#[rustango(scope = "...")]` coincide. (Las
+tablas «registry» se comparten entre todos los tenants; las tablas «tenant»
+viven por tenant.) Sin este flag, un `makemigrations` simple en un proyecto de
+tenancy divide automáticamente los cambios en DOS archivos — uno para los
+modelos de registry, otro para los modelos de tenant — de modo que las tablas
+compartidas del framework (`Org`, `Operator`) no se filtren en las migraciones
+por tenant que ejecuta `migrate-tenants`.
+
+```bash
+cargo run -- makemigrations                       # tenancy: writes 0NN_<auto>.json (registry) + 0MM_<auto>.json (tenant) as needed
+cargo run -- makemigrations --scope tenant        # explicit single-scope diff
+cargo run -- makemigrations --scope registry      # explicit single-scope diff
+```
+
+Por qué importa la división: antes de v0.24.2, un `makemigrations` simple en un
+proyecto de tenancy agrupaba operaciones sobre `rustango_operators` (una tabla
+de registry) dentro de una migración de tenant. Cuando `migrate-tenants`
+ejecutaba ese archivo, `rustango_operators` se resolvía vía `search_path` a la
+copia de registry y chocaba con la restricción que ya estaba allí.
+
+### `makemigrations --empty <name>`
+
+Crea una migración en blanco (sin operaciones `forward`) para que la rellenes a
+mano — como el `makemigrations --empty` de Django. Úsala cuando necesites
+escribir operaciones de datos u operaciones de renombrado que el autodetector no
+puede generar. Edita el JSON resultante tú mismo.
+
+```bash
+cargo run -- makemigrations --empty rename_status_to_state
+# Then edit migrations/0005_rename_status_to_state.json:
+#   "forward": [
+#     {"schema": {"RenameColumn": {"table": "posts", "old_column": "status", "new_column": "state"}}}
+#   ]
+```
+
+### `makemigrations --merge`
+
+Corrige un historial de migraciones que se ha dividido en dos ramas — la misma
+idea que el `makemigrations --merge` de Django (issue #346). Esto ocurre cuando
+dos personas ejecutan cada una `makemigrations` en su propia rama de
+característica, de modo que ambos archivos nuevos apuntan al mismo padre. Tras
+fusionar ambas ramas, el historial tiene dos «hojas» (puntos finales), y el
+siguiente `makemigrations` elegiría arbitrariamente una como su padre.
+
+`--merge` detecta esto y escribe un `NNNN_merge.json` vacío cuyo padre apunta a
+la última hoja en orden alfabético, reunificando el historial en una sola
+cadena. Su instantánea de esquema refleja el estado combinado, leído del
+registro de modelos vivo — los modelos de ambas ramas están compilados en este
+punto, así que la instantánea es precisa.
+
+```bash
+cargo run -- makemigrations --merge
+# wrote migrations/0004_merge.json
+#     merge node — empty `forward`, anchors the chain after divergent leaves
+```
+
+- **Ya es una sola cadena** → imprime `no merge needed` y termina limpiamente.
+  Seguro de ejecutar en un historial sano.
+- **Historiales realmente separados** (no una colisión de ramas) → da un error
+  en lugar de inventar un padre. La misma salvaguarda que usa Django.
+- **No se puede combinar** con `--empty`, `--app`, `--scope` ni un nombre
+  posicional.
+
+### `migrate`
+
+Aplica todas las migraciones pendientes a la base de datos, en orden — como el
+`migrate` de Django o el `php artisan migrate` de Laravel. Este es el comando
+que ejecutas después de `makemigrations` para cambiar realmente tu esquema.
+
+```bash
+cargo run -- migrate
+cargo run -- migrate --dry-run                       # print SQL without writing
+```
+
+Cada archivo se ejecuta dentro de una transacción por defecto, de modo que un
+fallo revierte todo el archivo. Establece `"atomic": false` en el JSON para no
+usarla — la necesitas para sentencias como `CREATE INDEX CONCURRENTLY` que no
+pueden ejecutarse dentro de una transacción.
+
+En **modo tenancy** (`Cli::tenancy()`), `migrate` es consciente del scope:
+primero aplica las migraciones de registry a la base de datos de registry
+compartida, luego aplica las migraciones de tenant a través de cada tenant
+activo. Para un control más fino, usa [`migrate-registry`](#migrate-registry) /
+[`migrate-tenants`](#migrate-tenants).
+
+### `migrate <target>`
+
+Migra a un punto concreto del historial, hacia adelante o hacia atrás — como el
+`migrate <app> <name>` de Django. Nombra una migración para moverte a ella; el
+objetivo especial `zero` deshace todo.
+
+```bash
+cargo run -- migrate 0003_add_slug      # forward to 0003
+cargo run -- migrate 0001_initial       # roll back to 0001 (unapply 0002+)
+cargo run -- migrate zero               # unapply EVERY migration
+```
+
+### `migrate --squash`
+
+Colapsa cada migración **pendiente** (sin aplicar) en un único diff recién
+generado — la escotilla de escape para la iteración de desarrollo, para cuando
+una pila de migraciones a medio terminar es más fácil de regenerar que de
+arreglar. Se niega a tocar cualquier cosa ya aplicada.
+
+```bash
+cargo run -- migrate --squash
+```
+
+El archivo regenerado registra los nombres que colapsó en su lista `replaces`.
+Eso importa en el momento en que hay otra base de datos involucrada: el checkout
+de tu colega, staging o CI puede que ya hayan aplicado algunos de los archivos
+que acabas de borrar. Sin `replaces`, el `CREATE TABLE` del archivo nuevo
+chocaría allí; con él, el runner **reconcilia** en su lugar (ver más abajo).
+
+### Reconciliación de squash
+
+Un squash recrea el estado final de las migraciones que reemplaza, así que lo
+que el runner debería hacer depende por completo de lo que la base de datos de
+destino ya contenga. Lo decide automáticamente:
+
+| estado de la base de datos | qué ocurre |
+|---|---|
+| nueva — sin historial, sin tablas | el squash se ejecuta de verdad |
+| cada migración reemplazada está en el ledger | registrado, predecesores marcados como obsoletos, **sin DDL** |
+| las tablas existen pero el ledger no tiene historial | registrado, **sin DDL** (`--fake-initial` de Django) |
+| solo están presentes *algunas* filas / tablas reemplazadas | **rechazado**, nombrando lo que falta |
+
+El caso parcial es deliberadamente un error rotundo: ninguna elección automática
+es segura ahí, así que el runner se detiene y te dice lo que encontró en lugar
+de adivinar. Resuélvelo con `migrate --fake` (abajo).
+
+Las migraciones sustituidas por un squash aplicado se tratan como aplicadas, así
+que puedes dejar los archivos viejos en disco durante una o dos releases — los
+despliegues que nunca las ejecutaron migran hacia adelante correctamente de
+todas formas.
+
+Las migraciones ordinarias (que no son squash) no se ven afectadas: una
+migración simple cuya tabla ya existe sigue fallando ruidosamente, porque eso es
+un conflicto real y no un historial conocido-equivalente.
+
+### `migrate --fake <name>`
+
+Marca una migración como aplicada **sin ejecutar su SQL** — la escotilla de
+escape del operador para cuando la base de datos ya está en el estado de destino
+pero el ledger no lo sabe (una BD configurada fuera de banda, una tabla de
+ledger eliminada, una migración parcialmente exitosa, un squash parcial
+rechazado). Repite el flag para reparar varias filas de una vez.
+
+```bash
+cargo run -- migrate --fake 0004_add_indexes
+cargo run -- migrate --fake 0004_add_indexes --system        # framework's own chain
+cargo run -- migrate --fake 0004_add_indexes --all-tenants   # every active tenant
+```
+
+El nombre se valida primero contra el directorio de migraciones, de modo que un
+error de tipeo no puede colar una fila falsa. Marcar es idempotente.
+
+`--system` apunta a la propia cadena de migraciones del framework
+(`system/migrations/`, registrada en `__rustango_system_migrations__`) en lugar
+de la de tu proyecto. `--all-tenants` extiende la marca a través de cada tenant
+activo, informando de cada uno y continuando más allá de los fallos — las tablas
+del framework viven por tenant, así que repararlas es un trabajo por tenant.
+
+### `downgrade [N]`
+
+Revierte las últimas N migraciones aplicadas (por defecto 1) — el
+`migrate:rollback` de Laravel. Cada migración debe ser reversible: los cambios
+de esquema se revierten automáticamente, pero las operaciones de datos necesitan
+un `reverse_sql` definido o el rollback falla.
+
+```bash
+cargo run -- downgrade                  # one step
+cargo run -- downgrade 3                # three steps
+```
+
+### `showmigrations` / `status`
+
+Lista cada migración y si se ha aplicado — como el `showmigrations` de Django.
+`[X]` significa aplicada, `[ ]` significa aún pendiente.
+
+```bash
+cargo run -- showmigrations
+cargo run -- status                     # alias
+```
+
+Salida:
+
+```
+[X] 0001_initial
+[X] 0002_add_status
+[ ] 0003_add_slug
+```
+
+---
+
+## Migraciones de datos
+
+### `add-data-op`
+
+Añade un paso de datos en SQL crudo a una migración sin editar el JSON a mano.
+Recurre a esto cuando necesites transformar filas existentes — rellenar una
+columna, limpiar datos — como parte de una migración. Es el equivalente a la
+migración de datos `RunSQL` de Django, generada para ti desde la línea de
+comandos.
+
+```bash
+# New migration with up + down
+cargo run -- add-data-op \
+    --sql "UPDATE posts SET slug = lower(title)" \
+    --reverse-sql "UPDATE posts SET slug = NULL" \
+    --name backfill_post_slugs
+
+# Append to an existing migration
+cargo run -- add-data-op \
+    --to 0003_add_slug \
+    --sql "UPDATE posts SET slug = id::text"
+
+# Irreversible (no rollback)
+cargo run -- add-data-op \
+    --sql "DELETE FROM legacy_data" \
+    --name purge_legacy
+```
+
+| Flag | Requerido | Descripción |
+|---|:-:|---|
+| `--sql <SQL>` | sí | SQL hacia adelante que se ejecuta en `migrate` |
+| `--reverse-sql <SQL>` | no | SQL de rollback en `unapply`; omítelo para hacerla irreversible |
+| `--name <name>` | no | Sufijo del nombre de la nueva migración; por defecto `data_op` |
+| `--to <migration>` | no | Añadir a una migración existente en lugar de crear una |
+
+Omite `--reverse-sql` y el paso se marca como `reversible: false` — cualquier
+intento de revertirlo falla de inmediato.
+
+---
+
+## Generadores de proyecto / app
+
+### `cargo rustango new <name>` *(binario aparte)*
+
+Crea un proyecto **Rustango** completamente nuevo — como `django-admin
+startproject` o `laravel new`. Esta es una herramienta aparte, así que instálala
+primero con `cargo install cargo-rustango`. Elige entre tres plantillas:
+
+```bash
+cargo rustango new myblog                          # default = fullstack (ORM + admin)
+cargo rustango new myapi --template api            # JSON-only, no admin
+cargo rustango new shop --template tenant          # multi-tenancy
+```
+
+Escribe:
+
+```
+<name>/
+  Cargo.toml
+  .env.example
+  .gitignore
+  rust-toolchain.toml
+  docker-compose.yml
+  README.md
+  migrations/                               (your app's migrations)
+  system/migrations/                        (tenant template — framework tables, generated)
+  src/{main,models,views,urls}.rs
+```
+
+La plantilla de tenant incluye una carpeta `system/migrations/` **vacía**. Las
+propias tablas del framework (`rustango_orgs`, `rustango_users`,
+roles/permisos, …) se generan en ella a partir de los modelos compilados en el
+primer `cargo run -- migrate` — no hay un JSON de bootstrap incluido a mano.
+Consulta [`migrate`](#migrate) / [`migrate-registry`](#migrate-registry).
+
+### `startapp <name> [flags]`
+
+Crea una nueva app (un módulo de característica) bajo `src/<name>/` — exactamente
+como el `startapp` de Django. Úsalo para mantener agrupados los modelos, vistas
+y URLs de una parte de tu proyecto.
+
+```bash
+cargo run -- startapp blog
+cargo run -- startapp shop --with-manage-bin             # also writes src/bin/manage.rs
+cargo run -- startapp shop --into apps                   # write under src/apps/shop/ instead
+```
+
+Crea:
+
+```
+src/<name>/
+  mod.rs
+  models.rs
+  views.rs
+  urls.rs
+```
+
+Seguro de volver a ejecutar — los archivos existentes se dejan intactos. Un paso
+manual: añade `pub mod <name>;` a `src/lib.rs` para que Rust compile el nuevo
+módulo.
+
+---
+
+## Generadores de archivos (`make:*`)
+
+Estos crean archivos de inicio para bloques de construcción comunes — muy
+parecido a los comandos `make:*` de Laravel (`make:controller`, `make:model`,
+…). Cada generador escribe en `src/<snake_name>.rs` (o `tests/<snake_name>.rs`
+para `make:test`) y:
+
+- Comprueba que el nombre es válido (PascalCase, letras/dígitos/guion bajo).
+- Lo convierte a snake_case para el nombre del archivo (`PostViewSet` →
+  `post_view_set.rs`).
+- No sobrescribe un archivo existente.
+- Te recuerda que añadas `pub mod X;` a tu `lib.rs`.
+
+### `make:viewset <Name> [--model <Model>]`
+
+Genera una estructura `#[derive(ViewSet)]` — un endpoint REST para un modelo,
+como un ViewSet de Django REST Framework. Las listas de campos vienen
+pre-esbozadas para que las rellenes.
+
+```bash
+cargo run -- make:viewset PostViewSet --model Post
+```
+
+`src/post_view_set.rs` generado:
+
+```rust
+#[derive(ViewSet)]
+#[viewset(model = Post, fields = "id, ", filter_fields = "", search_fields = "", page_size = 20)]
+pub struct PostViewSet;
+```
+
+Móntalo con: `.merge(PostViewSet::router("/api/posts", pool.clone()))`.
+
+### `make:serializer <Name> [--model <Model>]`
+
+Genera una estructura `#[derive(Serializer)]` — controla cómo un modelo se
+convierte hacia y desde JSON (como un serializer de DRF).
+
+```bash
+cargo run -- make:serializer PostSerializer --model Post
+```
+
+### `make:form <Name>`
+
+Genera una estructura `#[derive(Form)]` para validar y procesar la entrada de un
+formulario — como un `Form` de Django.
+
+```bash
+cargo run -- make:form ContactForm
+```
+
+### `make:job <Name>`
+
+Genera un esqueleto de trabajo en segundo plano (trabajo que se ejecuta fuera
+del request, como una tarea de Celery o un job de Laravel), con un ejemplo
+comentado de cómo programarlo.
+
+```bash
+cargo run -- make:job EmailDigestJob
+```
+
+### `make:notification <Name>`
+
+Genera una estructura de notificación que construye un correo electrónico — como
+el `make:notification` de Laravel.
+
+```bash
+cargo run -- make:notification WelcomeEmail
+```
+
+### `make:middleware <Name>`
+
+Genera una función de middleware — código que se ejecuta antes y después de cada
+request (comprobaciones de auth, logging, etc.). «axum» es el framework web
+sobre el que está construido **Rustango**, así que el stub coincide con la forma
+del middleware de axum.
+
+```bash
+cargo run -- make:middleware AuditLog
+```
+
+### `make:test <Name>`
+
+Genera un test de integración en `tests/` que usa `TestClient` para hacer
+requests contra tu app.
+
+```bash
+cargo run -- make:test post_smoke
+```
+
+---
+
+## Utilidades de base de datos
+
+### `db:info`
+
+Muestra con qué base de datos está configurada esta build para hablar, sin
+conectarse. Imprime la versión del framework, qué drivers de base de datos
+(características de Cargo `postgres`/`mysql`) están compilados, la URL de conexión
+con la contraseña oculta y el backend detectado. Como nunca abre una conexión,
+resulta práctico en CI o contenedores donde la base de datos aún no está
+levantada pero quieres confirmar que la configuración es correcta.
+
+```bash
+cargo run -- db:info
+```
+
+### `db:dump [--out <path>] [--data-only|--schema-only] [--no-owner]`
+
+Respalda tu base de datos ejecutando `pg_dump` contra `DATABASE_URL` — como
+`php artisan db:dump`. Por defecto el SQL va a stdout (para que puedas
+canalizarlo); pasa `--out <path>` (`-o`) para escribir un archivo en su lugar.
+`--data-only` y `--schema-only` se corresponden directamente con los flags de
+`pg_dump`, y `--no-owner` omite las líneas OWNER. Necesitas `pg_dump` instalado
+y en tu `PATH`.
+
+```bash
+cargo run -- db:dump > backups/before-migrate.sql    # stdout → file
+cargo run -- db:dump --out backups/before-migrate.sql
+```
+
+### `db:restore <path> [--clean]`
+
+Carga un archivo de dump de vuelta en tu base de datos — la contraparte de
+`db:dump`. Pasa el archivo por `psql` contra `DATABASE_URL` con
+`ON_ERROR_STOP=1`, de modo que se detiene ante el primer error. Añade `--clean`
+para borrar primero el esquema existente (antepone
+`DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;`) para que la
+restauración aterrice en una base de datos vacía. Necesitas `psql` en tu `PATH`.
+
+```bash
+cargo run -- db:restore backups/before-migrate.sql
+cargo run -- db:restore backups/before-migrate.sql --clean
+```
+
+---
+
+## Comandos del sistema
+
+### `version` / `--version`
+
+Imprime la versión del framework **Rustango**.
+
+```bash
+$ cargo run -- version
+rustango 0.44.0
+```
+
+### `about`
+
+Imprime una instantánea de tu entorno: versión del framework, modelos y apps
+registrados, si la base de datos es accesible, y variables de entorno clave.
+Incluye esto en los tickets de soporte cuando algo va mal.
+
+```bash
+$ cargo run -- about
+rustango
+  version:        0.44.0
+  models:         3 registered
+  apps:           1 (blog)
+  RUSTANGO_ENV:   local
+  DATABASE_URL:   postgres://***@localhost:5433/myblog
+  db_connect:     ok
+```
+
+### `check [--deploy]`
+
+Ejecuta comprobaciones de salud en tu proyecto — como el `check` de Django.
+Añade `--deploy` para las comprobaciones más estrictas de preparación para
+producción, del mismo modo que funciona el `check --deploy` de Django.
+
+**Comprobaciones siempre activas:**
+- ≥ 1 modelo registrado vía `inventory`
+- BD accesible (`SELECT 1`)
+- Recuento de migraciones vs. recuento de modelos
+
+**Con `--deploy`:**
+- `RUSTANGO_ENV` es `prod` o `production`
+- `RUSTANGO_SESSION_SECRET` establecido y ≥ 32 bytes (la clave HMAC para
+  cookies + JWTs; el framework nunca lee `SECRET_KEY`)
+- `DATABASE_URL` establecido
+- `RUSTANGO_APEX_DOMAIN` establecido (proyectos de tenancy)
+
+```bash
+$ cargo run -- check --deploy
+running rustango system check (deploy mode)...
+  [info]    3 models registered via inventory
+  [info]    database reachable
+  [info]    4 migration(s) on disk
+  [info]    RUSTANGO_SESSION_SECRET length OK
+all checks passed
+```
+
+Termina con un código distinto de cero si falla cualquier comprobación de nivel
+de error. Las advertencias por sí solas no provocan un fallo.
+
+### `docs`
+
+Abre la documentación de **Rustango** (<https://docs.rs/rustango>) en tu
+navegador. Siempre imprime también la URL, de modo que sigue funcionando en un
+servidor sin interfaz gráfica.
+
+```bash
+cargo run -- docs
+```
+
+### `--help` / `help`
+
+Lista cada comando con una descripción de una línea. En modo tenancy, también se
+añaden los comandos multi-tenant listados abajo.
+
+---
+
+## Comandos de tenancy
+
+Estos comandos existen solo en proyectos multi-tenant (una app que sirve a
+muchos clientes/orgs aislados). Aparecen solo cuando el proyecto se compila con
+`features = ["tenancy"]` Y `Cli::new()` se encadena con `.tenancy()`.
+
+### `init-tenancy`
+
+**No-op — conservado por compatibilidad.** El framework ya no incluye
+migraciones de bootstrap construidas a mano. Sus propias tablas
+(`rustango_orgs`, `rustango_operators`, `rustango_users`, roles/permisos, …) se
+generan en `system/migrations/` a partir de los modelos compilados — el flujo
+normal de Django (modelos → `makemigrations` → `migrate`) — y las aplica
+[`migrate`](#migrate) / [`migrate-registry`](#migrate-registry), que las generan
+bajo demanda si los archivos faltan.
+
+```bash
+cargo run -- init-tenancy   # does nothing now; kept so old scripts don't break
+```
+
+Las versiones más antiguas escribían aquí `0001_rustango_*_initial.json`; ese
+flujo codificado a mano ya no existe. **Para aprovisionar, simplemente ejecuta
+`cargo run -- migrate`.** Un modelo de usuario personalizado
+(`.user_model::<AppUser>()`) fluye por las mismas `system/migrations/` generadas
+— consulta [Modelo de usuario personalizado](#custom-user-model-extra-columns-on-rustango_users).
+
+### `migrate-registry`
+
+Aplica solo las migraciones de registry — las tablas compartidas entre tenants.
+El registry contiene `rustango_orgs` y `rustango_operators` más cualquier tabla
+con scope de registry que definas. Las tablas de tenant quedan intactas.
+
+```bash
+cargo run -- migrate-registry
+```
+
+### `migrate-tenants`
+
+Aplica las migraciones de tenant a cada tenant activo, uno tras otro. Cada
+tenant usa su propia conexión (su propio esquema o base de datos), y si un tenant
+falla, el resto se ejecuta igualmente — el comando informa del resultado por
+tenant al final.
+
+```bash
+cargo run -- migrate-tenants
+```
+
+Para el caso común, un `migrate` simple ya hace primero el registry, luego los
+tenants — recurre a `migrate-tenants` solo cuando necesites ese paso por sí solo.
+
+### `runserver` / `run-server`
+
+Arranca el servidor web multi-tenant — el `runserver` de Django. En un proyecto
+de tenancy esto es lo mismo que un `cargo run` pelado; la forma con nombre existe
+para que los binarios personalizados que parsean sus propios argumentos aún
+puedan activarlo.
+
+```bash
+cargo run                        # implicit
+cargo run -- runserver           # explicit
+```
+
+### `create-tenant <slug> [options]`
+
+Configura un nuevo tenant (cliente/org) y le aplica las migraciones de tenant. El
+`<slug>` es su identificador corto. Seguro de volver a ejecutar — llamarlo de
+nuevo sobre un tenant existente no duplicará nada.
+
+```bash
+cargo run -- create-tenant acme --display-name "ACME Corp"
+cargo run -- create-tenant beta --mode database --database-url postgres://...
+```
+
+| Flag | Descripción |
+|---|---|
+| `--display-name <name>` | Etiqueta legible por humanos que se muestra en las barras laterales del admin |
+| `--mode schema \| database` | Modo de almacenamiento (por defecto: schema) |
+| `--database-url <url>` | URL de BD específica del tenant (requerida para el modo database) |
+| `--host-pattern <pattern>` | Anula el patrón de host usado por `SubdomainResolver` |
+| `--no-migrate` | Omite aplicar las migraciones con scope de tenant tras el aprovisionamiento |
+
+### `drop-tenant <slug> [--confirm <slug>]`
+
+Desactiva un tenant estableciendo `active = false`. Esta es la opción suave y
+reversible — los datos del tenant permanecen en disco, y volver a ejecutar
+`create-tenant` lo trae de vuelta. Cuando no estás ejecutando de forma
+interactiva (sin terminal adjunto), debes pasar `--confirm <slug>` con el slug
+tecleado de nuevo para confirmar.
+
+```bash
+cargo run -- drop-tenant acme --confirm acme
+```
+
+### `purge-tenant <slug> [--confirm <slug>] [--purge-database]`
+
+**Elimina un tenant permanentemente.** Borra el esquema del tenant y elimina su
+fila de `rustango_orgs`, sin deshacer posible. Cuando no estás ejecutando de
+forma interactiva (sin terminal adjunto), debes pasar `--confirm <slug>` con el
+slug tecleado de nuevo. Para los tenants en modo database, la base de datos
+subyacente se deja en su sitio a menos que también pases `--purge-database`.
+
+```bash
+cargo run -- purge-tenant acme --confirm acme
+cargo run -- purge-tenant beta --confirm beta --purge-database   # database-mode: also DROP DATABASE
+```
+
+### `list-tenants`
+
+Lista cada tenant con su modo de almacenamiento y su estado activo/inactivo.
+
+```bash
+cargo run -- list-tenants
+```
+
+### `create-operator <username> --password <pwd>`
+
+Crea un operador — un admin global que puede gestionar cada tenant desde una
+consola entre tenants. Los operadores viven en el registry compartido, no dentro
+de un tenant concreto.
+
+```bash
+cargo run -- create-operator admin --password letmein
+```
+
+### `create-user <tenant> <username> --password <pwd> [--superuser]`
+
+Crea un usuario dentro de un tenant — aproximadamente el `createsuperuser` de
+Django, pero limitado a un solo tenant.
+
+```bash
+cargo run -- create-user acme alice --password hunter2 --superuser
+```
+
+`--superuser` establece `is_superuser = true` para ese usuario dentro del
+tenant. Eso lo convierte en admin del tenant (acceso de escritura completo en el
+admin del tenant), pero nunca otorga acceso a la consola de operador entre
+tenants.
+
+### `create-role <tenant> <name>`
+
+Crea un rol (un paquete con nombre de permisos, como un grupo de Django) dentro
+de un tenant.
+
+```bash
+cargo run -- create-role acme editor
+```
+
+### `list-roles <tenant>`
+
+Lista los roles definidos en un tenant dado.
+
+```bash
+cargo run -- list-roles acme
+```
+
+### `assign-role <tenant> <username> <role>`
+
+Otorga a un usuario uno de los roles del tenant.
+
+```bash
+cargo run -- assign-role acme alice editor
+```
+
+### `revoke-role <tenant> <username> <role>`
+
+Elimina un rol de un usuario — lo inverso de `assign-role`.
+
+```bash
+cargo run -- revoke-role acme alice editor
+```
+
+### `grant-perm <tenant> <role-name|username> <codename> [--role]`
+
+Otorga un único permiso. Por defecto, el segundo argumento es un **nombre de
+usuario**, así que el permiso va directamente a ese usuario; añade `--role` para
+otorgarlo a un rol en su lugar. Los codenames de permisos usan el formato
+`<app>.<action>_<model>` de Django (`blog.add_post`, `blog.change_post`, …). La
+característica `auto_create_permissions` crea automáticamente los cuatro
+codenames CRUD estándar para cualquier modelo marcado con
+`#[rustango(permissions)]`.
+
+```bash
+cargo run -- grant-perm acme alice blog.change_post           # grant to user alice
+cargo run -- grant-perm acme editor blog.change_post --role   # grant to role editor
+```
+
+### `revoke-perm <tenant> <role-name|username> <codename> [--role]`
+
+Elimina un permiso — lo inverso de `grant-perm`. Apunta a un usuario por
+defecto; añade `--role` para revocarlo de un rol en su lugar.
+
+```bash
+cargo run -- revoke-perm acme alice blog.change_post
+cargo run -- revoke-perm acme editor blog.change_post --role
+```
+
+### `create-api-key <tenant> <username> [--label <s>]`
+
+Emite una clave de API para un usuario de tenant. El token completo se imprime
+**una vez** y nunca más — cópialo ahora, porque solo se almacenan su prefijo y
+un hash.
+
+```bash
+cargo run -- create-api-key acme alice --label "ci-bot"
+```
+
+### `audit-cleanup`
+
+Poda las entradas antiguas del registro de auditoría (`rustango_audit_log`) para
+que no crezca indefinidamente. Recorta por antigüedad (`--days`) o por cantidad
+(`--keep-last`), y opcionalmente limítalo a un tenant.
+
+```bash
+cargo run -- audit-cleanup --days 90                       # delete > 90 days old
+cargo run -- audit-cleanup --keep-last 50                  # keep most recent 50 per row
+cargo run -- audit-cleanup --keep-last 50 --tenant acme    # scoped
+```
+
+---
+
+## Modelo de usuario personalizado (columnas extra en `rustango_users`)
+
+Esta es la versión de **Rustango** del «custom user model» de Django — cómo
+añades tus propios campos a la tabla de usuarios. El `User` de tenant integrado
+tiene siete columnas fijas: `id`, `username`, `password_hash`, `is_superuser`,
+`active`, `created_at`, más una columna `data` JSONB (un blob JSON flexible) para
+cualquier metadato extra por usuario. **Para la mayoría de las apps esa columna
+JSONB es todo lo que necesitas** — sin migración, sin override, sin sorpresas.
+
+Cuando quieras columnas **tipadas e indexables** en `rustango_users` en su lugar,
+hay dos enfoques. No son intercambiables; elige el que encaje con dónde está tu
+proyecto en su vida.
+
+### Opción 1 — Modelo de perfil hermano con FK *(funciona en cualquier proyecto)*
+
+Lo mejor cuando el proyecto ya existe, o cuando prefieres dejar la tabla `User`
+del framework como única fuente de verdad.
+
+```rust
+#[derive(rustango::Model)]
+pub struct UserProfile {
+    #[rustango(primary_key)] pub id: rustango::sql::Auto<i64>,
+    #[rustango(fk = "rustango_users")] pub user_id: i64,
+    #[rustango(max_length = 128, default = "''")] pub display_name: String,
+    #[rustango(max_length = 64, default = "'UTC'")] pub timezone: String,
+}
+```
+
+Ejecuta `cargo run -- makemigrations` y luego `cargo run -- migrate`, y tendrás
+una tabla de extras tipada enlazada al usuario por clave foránea. Léela con el
+ORM:
+
+```rust
+let profile = UserProfile::objects()
+    .where_(UserProfile::user_id.eq(user.id.get().copied().unwrap()))
+    .first(&pool).await?;            // Option<UserProfile>
+```
+
+Contrapartida: una fila extra y un JOIN en cada acceso. Ventaja: cero riesgo de
+romper la auth del framework.
+
+### Opción 2 — `Cli::user_model::<AppUser>()` *(solo greenfield)*
+
+Usa esto solo en un proyecto nuevo donde quieras los campos extra directamente
+en la propia tabla `rustango_users`. Como `AppUser` *es* el modelo
+`rustango_users`, sus columnas fluyen por el motor ordinario de `makemigrations`
+→ `migrate`: las tablas del framework se generan en `system/migrations/`, así
+que las columnas de `AppUser` aterrizan en el `CREATE TABLE rustango_users`
+generado.
+
+**Paso 1.** Define tu modelo. Tiene que declarar cada columna requerida por el
+framework exactamente (`id`, `username`, `password_hash`, `is_superuser`,
+`active`, `created_at`, `data`), más tus extras. Cada columna extra debe permitir
+`NULL` o tener un `default = "…"`.
+
+```rust
+use rustango::sql::Auto;
+
+#[derive(rustango::Model, Debug, Clone)]
+#[rustango(table = "rustango_users")]
+pub struct AppUser {
+    #[rustango(primary_key)] pub id: Auto<i64>,
+    #[rustango(max_length = 64, unique)] pub username: String,
+    #[rustango(max_length = 255)] pub password_hash: String,
+    pub is_superuser: bool,
+    pub active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    #[rustango(default = "'{}'")] pub data: serde_json::Value,
+    // extras —
+    #[rustango(max_length = 128, default = "''")] pub display_name: String,
+    #[rustango(max_length = 64, default = "'UTC'")] pub timezone: String,
+}
+impl rustango::tenancy::TenantUserModel for AppUser {}
+```
+
+**Paso 2.** Conecta el override en `main.rs`:
+
+```rust
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    rustango::manage::Cli::new()
+        .api(my_app::urls::router())
+        .tenancy()
+        .user_model::<AppUser>()
+        .run().await
+}
+```
+
+**Paso 3.** Registra `AppUser` **en lugar del** `User` del framework — solo un
+modelo puede reclamar `table = "rustango_users"`. El scaffolder no incluye JSON
+de bootstrap estático (solo un `system/migrations/` vacío), así que no hay nada
+que borrar; simplemente no registres también el `User` del framework.
+
+**Paso 4.** Genera + aplica:
+
+```bash
+cargo run -- makemigrations       # generates system/migrations/ with AppUser's columns
+cargo run -- migrate              # creates rustango_users with your extras
+```
+
+**Advertencias:**
+
+- Cambiar `AppUser` más adelante es un cambio de esquema normal: vuelve a
+  ejecutar `makemigrations` para emitir la migración `AddColumn`, luego
+  `migrate`.
+- Solo un modelo puede mapear a `rustango_users`. Registrar **ambos**, el `User`
+  del framework y tu `AppUser`, hace que `makemigrations` sea ambiguo — registra
+  `AppUser` solo. Esta es la razón principal por la que la Opción 2 es solo para
+  proyectos nuevos; en un proyecto existente, la Opción 1 evita el problema.
+- El código de auth y admin del framework lee las siete columnas núcleo por
+  nombre; tus columnas extra solo son accesibles a través de
+  `AppUser::objects().fetch(...)`.
+
+`Builder::user_model::<AppUser>()` hace lo mismo para el código que construye el
+`Builder` del servidor directamente, sin pasar por `Cli`.
+
+---
+
+## Subcomandos personalizados
+
+Puedes añadir tus propios comandos — la versión de **Rustango** de los comandos
+de gestión personalizados de Django. El truco es inspeccionar los argumentos tú
+mismo y manejar tu comando antes de pasar el resto a `Cli::run`. Dos formas de
+hacerlo:
+
+**En línea en `src/main.rs`** (sin binario extra):
+
+```rust
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if matches!(args.first().map(String::as_str), Some("import-csv")) {
+        let url = std::env::var("DATABASE_URL")?;
+        let pool = rustango::sql::sqlx::PgPool::connect(&url).await?;
+        return my_csv_importer::run(&pool, &args[1..]).await;
+    }
+    rustango::manage::Cli::new().api(urls::api()).run().await
+}
+```
+
+**Vía `--with-manage-bin`** (`src/bin/manage.rs` aparte):
+
+```bash
+cargo run -- startapp app --with-manage-bin
+```
+
+Luego en `src/bin/manage.rs`:
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let url = std::env::var("DATABASE_URL")?;
+    let pool = rustango::sql::sqlx::PgPool::connect(&url).await?;
+
+    match args.first().map(String::as_str) {
+        Some("import-csv") => my_csv_importer::run(&pool, &args[1..]).await,
+        _ => rustango::migrate::manage::run(&pool, "./migrations".as_ref(), args)
+            .await
+            .map_err(Into::into),
+    }
+}
+```
+
+Ejecuta tus propios comandos igual que los integrados:
+`cargo run -- import-csv path/to/file.csv` (o
+`cargo run --bin manage -- import-csv …` cuando uses `--with-manage-bin`).
+
+---
+
+## Flujos de trabajo comunes
+
+### Configuración inicial del proyecto (single-tenant)
+
+```bash
+cargo rustango new myapp
+cd myapp
+cp .env.example .env             # edit DATABASE_URL
+docker compose up -d
+cargo run -- migrate
+cargo run                        # serve at :8080
+```
+
+### Configuración inicial del proyecto (tenancy)
+
+```bash
+cargo rustango new myapp --template tenant
+cd myapp
+cp .env.example .env             # edit DATABASE_URL + RUSTANGO_APEX_DOMAIN
+docker compose up -d
+cargo run -- migrate                                      # registry + tenants
+cargo run -- create-operator admin --password letmein
+cargo run -- create-tenant acme --display-name "ACME Inc" \
+                  --host-pattern acme.localhost
+cargo run -- create-user acme alice --password tenantpw --superuser
+cargo run                        # serve at :8080
+```
+
+### Añadir tenants después de que la app ya está en marcha
+
+Una app de tenancy real normalmente acumula modelos y migraciones mucho antes de
+que se registre su primer tenant. Este flujo funciona en cualquier punto de la
+vida del proyecto:
+
+```bash
+# 1. (any time) develop user models — define structs with #[derive(Model)],
+#    add `pub mod ...;` to src/lib.rs.
+# 2. Generate scope-aware migrations. In a tenancy project this writes
+#    up to TWO files: one tagged registry-scope (touches Org/Operator),
+#    one tagged tenant-scope (touches User + your models). Pre-v0.24.2
+#    this used to dump everything into one tenant-scoped file and
+#    crash on `create-tenant` — see the changelog.
+cargo run -- makemigrations
+
+# 3. Apply migrations. `migrate` is scope-aware: it runs registry-
+#    scoped files once against the registry pool first, then fans
+#    tenant-scoped files across every active tenant.
+cargo run -- migrate
+
+# 4. Provision a NEW tenant whenever (could be days, weeks, many
+#    migrations later). The tenancy code applies every accumulated
+#    tenant-scoped migration to the new tenant's schema in one pass —
+#    the new tenant arrives at the same schema state as existing ones.
+cargo run -- create-tenant acme --display-name "ACME Inc" \
+                  --host-pattern acme.localhost
+cargo run -- create-user acme alice --password tenantpw --superuser
+```
+
+Por qué esto es seguro:
+- `#[rustango(scope = "registry")]` en `Org`/`Operator` mantiene los cambios en
+  las tablas compartidas fuera de las migraciones por tenant.
+- `migrate-tenants` visita cada tenant activo y aplica solo las migraciones de
+  tenant — los archivos de registry se omiten.
+- `create-tenant` ejecuta ese mismo paso de `migrate-tenants` contra el esquema
+  del nuevo tenant, así que arranca completamente al día sin arreglos manuales.
+
+### Añadir un modelo
+
+```bash
+cargo run -- startapp blog        # if not done yet
+# Edit src/blog/models.rs — add #[derive(Model)]
+# Add `pub mod blog;` to src/lib.rs
+cargo run -- makemigrations
+cargo run -- migrate
+```
+
+### Añadir una API JSON para ese modelo
+
+```bash
+cargo run -- make:viewset PostViewSet --model Post
+# Edit src/post_view_set.rs — fill in field lists
+# Mount in src/urls.rs
+cargo run                        # GET /api/posts now works
+```
+
+### Añadir un backfill de datos
+
+```bash
+cargo run -- add-data-op \
+    --sql "UPDATE posts SET slug = lower(title) WHERE slug IS NULL" \
+    --reverse-sql "UPDATE posts SET slug = NULL" \
+    --name backfill_post_slugs
+cargo run -- migrate
+```
+
+### Auditoría previa al despliegue
+
+```bash
+cargo run --release -- check --deploy
+```
+
+### Revertir la última migración
+
+```bash
+cargo run -- downgrade 1
+```
+
+### Aplicar una migración de tenancy a un scope específico
+
+```bash
+cargo run -- migrate-registry            # registry-scoped only
+cargo run -- migrate-tenants             # tenant-scoped, fan-out across orgs
+```
+
+### Dar de baja un tenant
+
+```bash
+cargo run -- drop-tenant acme            # soft (reversible)
+cargo run -- purge-tenant acme           # hard (drops schema/db)
+```
+
+---
+
+## Ajuste fino del pool de tenants (v0.27.7+)
+
+Los tenants en modo database obtienen su propio pool de conexiones (un `PgPool`
+— un conjunto de conexiones de base de datos reutilizadas), cacheado por slug en
+[`TenantPools`](../crates/rustango/src/tenancy/pools.rs). Por defecto un pool se
+construye **de forma perezosa, en el primer request del tenant**, a menos que
+actives el pre-calentamiento. Los ajustes viven en `TenantPoolsConfig`:
+
+| Campo | Por defecto | Propósito |
+|---|---|---|
+| `max_cached_database_pools` | 64 | Tope de la caché de pools. Una vez llena, el siguiente tenant no cacheado da error (sin desalojo silencioso). |
+| `database_pool_max_connections` | 4 | `max_connections` por pool. Mantenlo pequeño para que un fan-out de tenants no agote el `max_connections` de PG. |
+| `database_pool_min_connections` | 0 | Mantiene N conexiones calientes en todo momento. `≥1` reduce la latencia del primer request al pagar el round-trip de TCP/TLS/auth en el arranque. |
+| `database_pool_acquire_timeout` | 30s | Cuánto espera `pool.acquire()` antes de dar error `PoolTimedOut`. |
+| `database_pool_idle_timeout` | 10 min | Cierra las conexiones inactivas tras esta duración. Se defiende de los cortes por load-balancer / `idle_in_transaction_session_timeout`. |
+| `database_pool_max_lifetime` | 30 min | Fuerza la rotación de conexiones para que las credenciales arrendadas por vault se refresquen. |
+| `prewarm_active_tenants` | false | Cuando es true, `Server::Builder::serve` llama a `prewarm_database_tenants()` en el arranque. |
+
+### Pre-calentar en el arranque
+
+Dos formas de activarlo:
+
+1. **Automática** — establece `prewarm_active_tenants = true` en el
+   `TenantPoolsConfig` que le pasas a `TenantPools::new(...).config(...)`.
+   `Server::Builder::serve` ejecuta el pre-calentamiento antes de hacer el bind.
+
+2. **Verbo de CLI** — `cargo run -- prewarm-pools` construye pools para cada
+   tenant activo en modo database y termina. Útil como hook posterior al
+   despliegue (p. ej., tras una rotación de credenciales), o para validar que
+   cada tenant es accesible antes de conmutar un load-balancer.
+
+El pre-calentamiento recorre `Org::objects().where(active = true, storage_mode =
+"database")` y hace corto-circuito cuando se alcanza el tope de la caché
+(reportado como `skipped_cap` en el [`PrewarmReport`]). Los fallos de
+construcción por tenant registran un `tracing::warn!` pero no abortan el bucle.
+
+### Tracing
+
+`crate::tenancy::pools::tenant_pool_init` es un `tracing::info_span!` que envuelve
+la construcción del pool en la ruta fría. Suscríbete a él para ver la latencia de
+construcción por tenant:
+
+```text
+INFO crate::tenancy::pools: tenant pool connected (database mode)
+     slug=acme elapsed_ms=42 min_conn=1 max_conn=4
+```
+
+### Trampa de configuración — TLDs `.local` de macOS
+
+Si accedes al admin del tenant vía `http://acme.local:8080/admin/` en macOS y ves
+una pausa de 5 segundos en cada request: eso es **Bonjour / mDNS**, no
+**Rustango**. El resolver de macOS trata `.local` de forma especial y espera el
+timeout completo de mDNS antes de recurrir a `/etc/hosts`. Dos soluciones:
+
+1. **Usa un TLD diferente**: `127.0.0.1 acme.localhost` funciona sin retraso.
+   `localhost` está reservado (RFC 6761) y omite mDNS.
+2. **Ejecuta dnsmasq** con una zona `.local` que apunte a 127.0.0.1 para que el
+   SO obtenga una respuesta inmediata.
+
+Confírmalo con `curl -w "%{time_connect}\n"`: si `time_connect` muestra ~5s pero
+cae a milisegundos con `--resolve acme.local:8080:127.0.0.1`, estás topándote con
+mDNS.
+
+
+---
+
+## Véase también
+
+- [Recetario del ORM](orm.md)
+- [Scaffolding](scaffolding.md)
+- [ViewSets](viewsets.md)
+- [Serializers](serializers.md)
+- [Guía de seguridad](security.md)

--- a/docs/es/mcp.md
+++ b/docs/es/mcp.md
@@ -1,0 +1,477 @@
+# Servidor MCP
+
+El **Model Context Protocol (MCP)** es el estándar abierto que permite a un agente
+de IA — Claude, un asistente de IDE, tu propia app LLM — llamar de forma segura a
+las **tools** de *tu* aplicación, leer sus **resources** y usar sus **prompts**.
+**Rustango** incluye un servidor MCP listo para producción: registra una tool con
+una sola macro, monta un router, y cualquier cliente MCP puede descubrirla y
+llamarla sobre el transporte JSON-RPC estándar — con autorización **fail-closed**
+por agente y OAuth 2.1 integrados.
+
+[![Servidor MCP en Rustango: un agente LLM se conecta sobre JSON-RPC + SSE; el servidor autentica el JWT del agente, lista solo las tools que sus skills concedidos permiten, y ejecuta el handler de la tool contra el pool de tu app](img/mcp.png)](img/mcp.png)
+
+> **¿Nuevo con algún término aquí?** *MCP*, *JSON-RPC*, *tool/resource/prompt*,
+> *agente*, *JWT*, *OAuth* — consulta el [glosario](glossary.md).
+
+> **Fuente:** `rustango::mcp` (`router`, `tenant_router`, `secure_tenant_router`,
+> `secure_tenant_router_from_settings`, `register_mcp_tool!`,
+> `register_mcp_resource!`, `McpContext`, `issue_agent_token`) y los helpers de
+> agente/skill de `rustango::tenancy` — detrás del **feature `mcp`** (DESACTIVADO
+> por defecto; arrastra `tenancy, sse, serializer, openapi, jwt`).
+>
+> **Versión ejecutable:** cada fragmento está copiado de
+> [`mcp_doc.rs`](../crates/rustango/tests/mcp_doc.rs)
+> (`cargo test -p rustango --features sqlite,mcp --test mcp_doc`); toda la
+> superficie del protocolo se prueba en condiciones reales con la suite
+> `crates/rustango/tests/mcp_*.rs`, y un servidor ejecutable vive en
+> [`examples/mcp_demo`](../crates/rustango/examples/mcp_demo).
+
+## Tabla de contenidos
+
+- [Qué te aporta MCP](#what-mcp-gives-you)
+- [Paso 1 — Activar el feature](#step-1--enable-the-feature)
+- [Paso 2 — Definir una tool](#step-2--define-a-tool)
+- [Paso 3 — Montar el servidor](#step-3--mount-the-server)
+- [Paso 4 — Autorizar agentes](#step-4--authorize-agents)
+- [El protocolo](#the-protocol)
+- [Ajustes](#settings)
+- [Cómo probar](#how-to-test) — [la suite](#a-the-test-suite) · [curl](#b-curl-the-json-rpc) · [el MCP Inspector visual](#c-test-it-visually-with-the-mcp-inspector) · [un cliente real](#d-connect-a-real-mcp-client)
+- [Build opcional vs. por defecto](#optional-vs-default-build)
+- [Véase también](#see-also)
+
+---
+
+## Qué te aporta MCP
+
+Un servidor MCP de **Rustango** expone tres cosas que un agente puede usar, todas
+**registradas a mano para un control explícito** (nada se auto-expone):
+
+| Primitiva | Qué es | Cómo se declara |
+|---|---|---|
+| **Tool** | una función que el agente llama (con argumentos JSON tipados) | `register_mcp_tool!` |
+| **Resource** | contenido legible que el agente obtiene por URI | `register_mcp_resource!` + adjunto a un skill |
+| **Prompt** | una plantilla de instrucción reutilizable | derivada de un **skill** concedido |
+
+Cada llamada está **autorizada por agente**: el JWT de un agente lleva los
+**skills** (y las tools que desbloquean) que se le concedieron, y `tools/list` /
+`tools/call` **fallan de forma cerrada** — un agente nunca ve ni ejecuta una tool
+que no se le concedió.
+
+---
+
+## Paso 1 — Activar el feature
+
+MCP es el feature opcional `mcp` (desactivado por defecto). Actívalo:
+
+```toml
+# Cargo.toml
+rustango = { version = "0.44", features = ["mcp"] }
+```
+
+Arrastra `tenancy` (agentes/skills), `sse` (el flujo de notificaciones),
+`serializer` + `openapi` (los esquemas de entrada de las tools) y `jwt` (los
+tokens de agente). Un build **sin** el feature no compila nada del módulo MCP —
+consulta [Build opcional vs. por defecto](#optional-vs-default-build).
+
+---
+
+## Paso 2 — Definir una tool
+
+Una tool es una struct de entrada tipada + un handler async, registrado en tiempo
+de compilación con `register_mcp_tool!`. El tipo de entrada deriva
+`serde::Deserialize` e implementa `OpenApiSchema` (que se convierte en el JSON
+Schema publicado de la tool):
+
+```rust
+use rustango::mcp::{McpContext, McpError};
+use serde_json::json;
+
+rustango::register_mcp_tool!(
+    "add",
+    "Add two integers",
+    AddInput,
+    |_ctx: McpContext, input: AddInput| async move {
+        Ok::<_, McpError>(json!({ "sum": input.a + input.b }))
+    },
+);
+
+#[derive(serde::Deserialize)]
+struct AddInput { a: i64, b: i64 }
+
+impl rustango::openapi::OpenApiSchema for AddInput {
+    fn openapi_schema() -> rustango::openapi::Schema {
+        rustango::openapi::Schema::object()
+            .property("a", rustango::openapi::Schema::integer())
+            .property("b", rustango::openapi::Schema::integer())
+            .required(["a", "b"])
+    }
+}
+```
+
+El handler recibe un `McpContext { pool, agent, progress, cancel }` — el pool de
+BD del tenant, el agente autenticado, un reportero de progreso y un token de
+cancelación — de modo que una tool puede consultar tus modelos, reportar el
+progreso de un trabajo largo y abortar al cancelar. Devuelve cualquier
+`serde_json::Value` (se presenta como el `structuredContent` de la tool) o un
+`McpError`.
+
+Los **resources** son contenido estático registrado del mismo modo:
+
+```rust
+rustango::register_mcp_resource!(
+    "rustango://about", "About", "text/plain",
+    || "This server exposes the demo tools.".to_string(),
+);
+```
+
+Los **prompts** provienen de los **skills** (siguiente paso) — las instrucciones
+de un skill se convierten en un prompt que el agente puede obtener.
+
+---
+
+## Paso 3 — Montar el servidor
+
+Elige un montaje acorde a tu despliegue; todos devuelven un `axum::Router` que
+anidas bajo un prefijo (por convención `/mcp`):
+
+| Montaje | Tenancy | Auth | Usar para |
+|---|---|---|---|
+| `mcp::router(pool)` | single-tenant | ninguna | solo transporte (`initialize`/`ping`) |
+| `mcp::tenant_router()` | multi-tenant | ninguna | solo transporte (pool por petición) |
+| `mcp::secure_tenant_router()` | multi-tenant | **JWT de agente** | lo de verdad |
+| `mcp::secure_tenant_router_from_settings(&s)` | multi-tenant | JWT de agente | producción (CORS, rate-limit, SSE, tope de cuerpo desde `[mcp]`) |
+
+Las tools requieren la ruta **autenticada** (un contexto de agente), así que los
+servidores de producción usan `secure_tenant_router*`:
+
+```rust
+use rustango::mcp;
+
+let api = axum::Router::new()
+    .nest("/mcp", mcp::secure_tenant_router_from_settings(&settings.mcp));
+// hand `api` to your tenancy Cli/Builder as usual
+```
+
+El router autenticado monta: `POST {prefix}` (JSON-RPC), `GET {prefix}`
+(notificaciones SSE), `POST {prefix}/token` (credencial → JWT),
+`POST {prefix}/oauth/token` (OAuth 2.1), y los dos documentos de descubrimiento
+`.well-known/*`. Firma los tokens de agente con `RUSTANGO_SESSION_SECRET`.
+
+El handshake `initialize` es un simple POST JSON-RPC y funciona en cualquier
+montaje:
+
+```json
+// → POST /mcp
+{ "jsonrpc": "2.0", "id": 1, "method": "initialize",
+  "params": { "protocolVersion": "2025-06-18", "capabilities": {},
+              "clientInfo": { "name": "my-client", "version": "0" } } }
+
+// ← 200
+{ "jsonrpc": "2.0", "id": 1, "result": {
+    "protocolVersion": "2025-06-18",
+    "serverInfo": { "name": "rustango", "version": "0.44.0" },
+    "capabilities": { "tools": { "listChanged": true }, "prompts": {}, "resources": {} } } }
+```
+
+---
+
+## Paso 4 — Autorizar agentes
+
+La autorización es **basada en skills y fail-closed**. Aprovisionas un **agente**
+(que obtiene un secreto de un solo uso), defines un **skill** que agrupa tools (y
+resources/un prompt), y luego **concedes** el skill al agente en un tenant:
+
+```rust
+use rustango::tenancy::{create_agent_pool, create_skill_pool, grant_skill_pool};
+
+// 1. Provision an agent — returns a one-time `name`.`secret` credential.
+let issued = create_agent_pool(&pool, "calc-bot").await?;
+
+// 2. A skill bundles tools (here, the `add` tool) + a prompt body.
+create_skill_pool(&pool, "calculator", "Calculator", "does arithmetic",
+                  "You are a precise calculator.", &["add".into()]).await?;
+
+// 3. Grant it to the agent in tenant "acme".
+grant_skill_pool(&pool, "acme", "calc-bot", "calculator").await?;
+```
+
+El cliente intercambia su credencial por un **JWT fijado al tenant y con alcance
+limitado** en `POST /mcp/token` (o mediante el flujo OAuth `client_credentials` en
+`/mcp/oauth/token`). El servidor resuelve la concesión en los claims `skills` +
+`tools` del token; cada petición lo reverifica. El efecto, verificado de extremo
+a extremo:
+
+```rust
+// tools/list returns ONLY the granted tool, with its JSON Schema:
+let listed = list_tools(&agent);                       // → { "tools": [ { "name": "add", … } ] }
+
+// tools/call runs the handler and returns a structured result:
+let out = call_tool(ctx, json!({ "name": "add", "arguments": { "a": 2, "b": 3 } })).await?;
+assert_eq!(out["structuredContent"]["sum"], 5);
+
+// An agent WITHOUT the grant sees an empty list and is refused:
+//   list_tools(&ungranted) → { "tools": [] }
+//   call_tool(ungranted, "add") → Err(code = TOOL_FORBIDDEN)
+```
+
+Los tokens están fijados al tenant: un token emitido para `acme` se rechaza contra
+cualquier otro tenant (replay entre tenants → 401). Revoca un agente y su JTI
+queda en la lista negra.
+
+### Claves propiedad del usuario (capacidades dirigidas por permisos)
+
+Los agentes anteriores son identidades de máquina independientes. Un miembro puede
+en cambio generar una **clave personal** — un agente propiedad del usuario — para
+que un LLM actúe *en su nombre*, con capacidades que siguen el **RBAC** existente
+del tenant en lugar de una lista fijada en la clave.
+
+Dos piezas lo cablean:
+
+```rust
+use rustango::tenancy::{create_user_key_pool, create_skill_pool, map_skill_to_permission_pool};
+
+// 1. Map a skill to a permission codename. Any user-owned key whose owner
+//    holds `mcp.coach` is then granted this skill's tools + prompt + resources.
+create_skill_pool(&pool, "coach", "Coach", "logs workouts",
+                  "You are the member's coach.", &["log_set".into()]).await?;
+map_skill_to_permission_pool(&pool, "coach", "mcp.coach").await?;
+
+// 2. The member generates a key — a one-time `name`.`secret`, shown once.
+//    `&[]` = a FULL key: everything the owner is entitled to. Pass skill
+//    codenames to SCOPE the key to a single skill or a skillset instead —
+//    always bounded by the owner's entitlement (you can't exceed your perms):
+let issued = create_user_key_pool(&pool, user_id, "Alice's phone", &[]).await?;
+// scoped: create_user_key_pool(&pool, user_id, "coach bot", &["coach".into()]).await?;
+println!("copy once: {}", issued.token);
+```
+
+En la emisión del token, el servidor llama a
+[`resolve_user_agent_grants_pool`](../crates/rustango/src/tenancy/agents.rs) —
+los permisos efectivos del propietario (`user_permissions_pool`, es decir, roles +
+concesiones directas − denegaciones) seleccionan los skills mapeados, cuyos
+tools/prompts/resources se aplanan en los claims `skills`/`tools` del JWT. Así
+`tools/list`, `tools/call`, `prompts/get` y `resources/read` están **todos**
+protegidos por RBAC, sin cambio alguno en esos handlers. El usuario propietario
+viaja en el claim `uid` del token; un handler de tool lo lee como
+`ctx.agent.user_id` para acotar el trabajo a ese miembro. Revoca capacidades
+recién otorgadas cambiando los permisos del usuario (se re-resuelven en el
+siguiente token); revoca la clave misma con
+`revoke_user_key_pool(&pool, user_id, agent_id)`. Lista las claves de un miembro
+con `list_user_keys_pool(&pool, user_id)`.
+
+**Alcance por clave vs. derechos por usuario.** Los skills alcanzan una clave por
+dos ejes: los **derechos** del propietario (superusuario → todos los skills; de lo
+contrario los skills mapeados a un permiso que posee) y el **alcance** de la clave
+(los skills fijados en la creación). Una clave sin alcance (`skills = &[]`) obtiene
+la totalidad de los derechos del propietario; una clave con alcance
+(`skills = &["coach", …]`) se limita a esos. La resolución siempre reintersecta el
+alcance con los derechos *actuales* — de modo que una clave nunca puede exceder
+los permisos del propietario, y perder un permiso estrecha cada clave en la
+siguiente emisión. Acotar a un skill al que el propietario no tiene derecho se
+rechaza en la creación.
+
+Los agentes independientes no se ven afectados — un agente de máquina
+(`user_id = None`) sigue usando solo sus concesiones explícitas
+`grant_skill_pool`.
+
+### Desde la CLI (verbos `manage`)
+
+Todo lo anterior también está disponible de fábrica a través del dispatcher
+`manage` consciente de la multi-tenancy (estos verbos se compilan con el feature
+`mcp`). Cada uno tiene alcance de tenant y toma un `<slug>`:
+
+| Verbo | Qué hace |
+|---|---|
+| `create-agent <slug> <name>` | Aprovisiona un agente de máquina; imprime su `prefix.secret` **una sola vez**. |
+| `rotate-agent-secret <slug> <name>` | Emite un secreto nuevo, invalidando el anterior. |
+| `list-agents <slug>` | Lista los agentes de un tenant (id, name, status, prefix). |
+| `create-skill <slug> <codename> [--name ..] [--description ..] [--tools a,b] [--instructions ..]` | Define un skill (un paquete de tools + prompt). |
+| `grant-skill <slug> <agent> <skill>` | Concede un skill a un agente. |
+| `revoke-skill <slug> <agent> <skill>` | Revoca un skill a un agente. |
+| `list-skills <slug>` | Lista los skills de un tenant. |
+| `create-user-key <slug> <username> [--label <l>] [--skill <codename>]…` | Emite una **clave propiedad del usuario**; imprime su token **una sola vez**. Repite `--skill` para acotar la clave a un solo skill o a un conjunto de skills; omítelo para una clave completa (label por defecto = username). |
+| `list-user-keys <slug> <username>` | Lista las claves personales de un usuario (id, label, created-at). |
+| `revoke-user-key <slug> <username> <key_id>` | Revoca una de las claves personales de un usuario por id (propiedad verificada). |
+| `map-skill-permission <slug> <skill> <permission>` | Mapea un skill a un codename de permiso. Idempotente — cualquier clave de usuario cuyo propietario posea `<permission>` gana el skill. |
+| `unmap-skill-permission <slug> <skill> <permission>` | Elimina un mapeo skill↔permission. |
+
+El flujo **permiso → skill → tools** de extremo a extremo:
+
+```console
+# 1. Define the skill and map it to a permission codename.
+$ cargo run -- create-skill acme coach --tools log_set --instructions "You are the member's coach."
+$ cargo run -- map-skill-permission acme coach mcp.coach
+
+# 2. Grant the permission to the member (roles or direct — see grant-perm),
+#    then issue their personal key.
+$ cargo run -- grant-perm acme alice mcp.coach
+$ cargo run -- create-user-key acme alice --label "Alice's phone"
+created key #7 for user `alice` in tenant `acme` (label `Alice's phone`, scope full (owner's permissions))
+  token: 3f9c1a2b.7d…            # copy once — never shown again
+  store this safely — it won't be shown again
+
+# …or scope the key to a single skill / skillset (repeat --skill):
+$ cargo run -- create-user-key acme alice --label "coach bot" --skill coach
+```
+
+La clave de Alice ahora resuelve las tools del skill `coach` en cada emisión de
+token porque ella posee `mcp.coach`. Cambia sus permisos y las capacidades se
+re-resuelven en su siguiente token; revoca la clave misma con `revoke-user-key`.
+El mismo id de clave se distingue de los agentes de máquina en el admin del tenant
+(la lista `Agent` muestra `user_id`).
+
+El auto-admin también los expone: `Agent`, `AgentSkill`, `AgentSkillPermission`
+(y `AgentGrant`) renderizan cada uno una tabla auto-CRUD en el admin del tenant,
+de modo que los mapeos skill↔permission pueden revisarse y editarse sin la CLI.
+
+---
+
+## El protocolo
+
+JSON-RPC 2.0 (versión de protocolo `2025-06-18`) sobre HTTP POST, con un flujo SSE
+opcional (`GET {prefix}`) para notificaciones servidor→cliente. Métodos:
+
+| Método | Auth | Propósito |
+|---|---|---|
+| `initialize` · `ping` | no | handshake + liveness |
+| `tools/list` · `tools/call` | sí | descubrir + invocar tools (solo las concedidas) |
+| `prompts/list` · `prompts/get` | sí | prompts derivados de skills |
+| `resources/list` · `resources/read` · `resources/templates/list` | sí | resources estáticos + de skill |
+| `logging/setLevel` · `completion/complete` | sí | nivel de log + completado de prefijo |
+| `notifications/progress` · `notifications/*/list_changed` | — | servidor→cliente sobre SSE |
+| `notifications/cancelled` | — | el cliente cancela una llamada en curso |
+
+Un *handler* de tool fallido devuelve un resultado normal con `isError: true` (el
+agente puede reaccionar); los problemas a nivel de protocolo (tool
+desconocida/prohibida, params inválidos) devuelven un `error` JSON-RPC con códigos
+como `-32002` (`TOOL_NOT_FOUND`), `-32003` (`TOOL_FORBIDDEN`), `-32602`
+(`INVALID_PARAMS`). Las tools largas reportan progreso y honran la cancelación a
+través del `McpContext`.
+
+---
+
+## Ajustes
+
+La sección `[mcp]` (leída por `secure_tenant_router_from_settings`):
+
+```toml
+[mcp]
+prefix                = "/mcp"   # URL prefix the router mounts under
+token_ttl_secs        = 900      # agent access-token lifetime (15 min)
+enable_sse            = true     # serve the GET {prefix} SSE stream
+allowed_origins       = []       # CORS allow-list (empty = same-origin only)
+rate_limit_per_minute = 0        # per-IP cap (0/unset = unlimited)
+max_tools_listed      = 0        # tools/list page size (0/unset = unlimited)
+```
+
+---
+
+## Cómo probar
+
+### (a) La suite de tests
+
+Todo el protocolo está cubierto por `crates/rustango/tests/mcp_*.rs` + el test que
+respalda esta doc. Ejecútalos con el feature activado:
+
+```bash
+# The doc's headline flow (register → initialize → grant → list → call → fail-closed):
+cargo test -p rustango --features sqlite,mcp --test mcp_doc
+
+# Slices + end-to-end + OAuth + settings:
+cargo test -p rustango --features sqlite,mcp,config --test 'mcp_*'
+```
+
+### (b) curl al JSON-RPC
+
+Arranca la demo (siguiente sección) y háblale directamente. La demo protege
+**cada** método detrás de un token de agente (una llamada sin autenticar devuelve
+`401`), así que emite uno primero — la demo imprime el secreto del agente al
+arrancar:
+
+```bash
+TOKEN=$(curl -sX POST http://localhost:8090/mcp/token \
+  -H 'content-type: application/json' -d '{"name":"demo-bot","secret":"<printed-secret>"}' \
+  | jq -r .access_token)
+
+# initialize:
+curl -sX POST http://localhost:8090/mcp -H "authorization: Bearer $TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
+
+# tools/call — only the granted `add` tool is callable:
+curl -sX POST http://localhost:8090/mcp -H "authorization: Bearer $TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"add","arguments":{"a":2,"b":3}}}'
+# → { ... "result": { "structuredContent": { "sum": 5 }, "isError": false } }
+```
+
+### (c) Pruébalo visualmente con el MCP Inspector
+
+El [MCP Inspector](https://github.com/modelcontextprotocol/inspector) es el
+cliente visual oficial — conéctalo a tu servidor y navega por tools, resources y
+prompts. Ejecuta la demo, luego el Inspector:
+
+```bash
+# 1. Start the demo MCP server (seeds an `acme` tenant + `demo-bot` agent + the `add` tool):
+cd crates/rustango/examples/mcp_demo && cargo run   # serves on http://localhost:8090/mcp
+
+# 2. Launch the Inspector (opens a browser UI on http://localhost:6274):
+npx @modelcontextprotocol/inspector
+```
+
+En el Inspector: pon el transporte en **Streamable HTTP** y la URL en
+`http://localhost:8090/mcp`. Abre **Authentication → Custom Headers**, añade un
+header `Authorization` con valor `Bearer <token>` (emite el token con la llamada
+`/mcp/token` de arriba), activa la fila, luego **Connect**.
+
+Cambia a la pestaña **Tools** y haz clic en **List Tools** — verás *solo* la tool
+`add` que concede el skill del agente, con su JSON Schema. Selecciónala, introduce
+`a = 2`, `b = 3`, y **Run Tool**:
+
+[![El MCP Inspector conectado a la demo de Rustango sobre Streamable HTTP, mostrando la tool `add` concedida y su esquema de entrada a/b](img/mcp-inspector-tools.png)](img/mcp-inspector-tools.png)
+
+La llamada devuelve un resultado estructurado — `{ "sum": 5 }` — y la petición
+aparece en el panel History (`initialize` → `tools/list` → `tools/call`):
+
+[![El mismo Inspector tras ejecutar la tool: Tool Result Success con contenido estructurado { sum: 5 }, y el historial de llamadas JSON-RPC](img/mcp-inspector-call.png)](img/mcp-inspector-call.png)
+
+### (d) Conecta un cliente MCP real
+
+Apunta Claude Code (o cualquier cliente MCP) al servidor en ejecución, pasando el
+token de agente como header (emítelo con la llamada `/mcp/token` de arriba):
+
+```bash
+claude mcp add --transport http rustango-demo http://localhost:8090/mcp \
+  --header "Authorization: Bearer $TOKEN"
+```
+
+Luego pídele al agente que sume dos números — descubre y llama a la tool `add`
+sobre el mismo protocolo que usó el Inspector.
+
+---
+
+## Build opcional vs. por defecto
+
+El feature está totalmente gated — todo el módulo `rustango::mcp` está detrás de
+`#[cfg(feature = "mcp")]`, de modo que nunca afecta a apps que no se inscriben:
+
+```bash
+cargo build -p rustango                 # default — MCP module NOT compiled
+cargo build -p rustango --features mcp  # MCP server compiled + linked
+```
+
+Una app por defecto no lleva nada de código, dependencias ni rutas de MCP;
+activar el feature es lo único que lo enciende.
+
+---
+
+## Véase también
+
+- [OpenAPI](openapi.md) — la maquinaria de JSON Schema que reutiliza la entrada de
+  una tool.
+- [API de auth JWT](auth-jwt-api.md) · [Backends de auth](auth-backends.md) — el
+  ciclo de vida de tokens sobre el que se construye la auth de agente.
+- [Guía de seguridad](security.md) — autorización fail-closed, secretos, límites
+  de tasa.
+- [Jobs en segundo plano](jobs.md) — ejecutar el trabajo de una tool larga fuera
+  de la petición.

--- a/docs/es/middleware.md
+++ b/docs/es/middleware.md
@@ -1,0 +1,429 @@
+# Middleware
+
+El middleware es código que se ejecuta **alrededor** de cada petición — antes de
+que tu handler la vea y después de que produce una respuesta. Ahí es donde viven
+las preocupaciones transversales: logging, limitación de tasa, cabeceras de
+seguridad, CSRF, resolución de locale y zona horaria. **Rustango** incluye un
+catálogo amplio de middleware listo para usar y hace que escribir el tuyo propio
+sea cuestión de unas pocas líneas. Si vienes de Django, esto es la lista
+`MIDDLEWARE`; de Express, es `app.use()`; de Laravel, es el kernel HTTP — la
+misma idea, adjunta a tu router.
+
+[![Middleware in Rustango: a request flows down through a stack of tower layers (request-id, locale, security headers, CSRF) into the handler and back up through the response side of each layer](img/middleware.png)](img/middleware.png)
+
+> **Fuente:** el middleware está construido sobre
+> [`tower::Layer`](https://docs.rs/tower) + `axum::middleware::from_fn`. Los
+> componentes integrados se reparten entre
+> `rustango::{access_log, rate_limit, cors, security_headers, request_id, …}`,
+> más `rustango::forms::csrf` (la feature `csrf`) y `rustango::i18n`
+> (`middleware::LocaleMiddleware`, `timezone`). La mayoría están activos por
+> defecto.
+>
+> **Versión ejecutable:** cada fragmento a continuación está copiado del ejemplo
+> probado en
+> `crates/rustango/examples/getting_started_blog/tests/middleware.rs`
+> (locale, zona horaria, cabeceras de seguridad, CSRF — todos sin base de datos).
+> Ejecútalo con `cargo test -p getting_started_blog --test middleware`.
+
+> **¿Un término nuevo aquí?** *Middleware*, *layer*, *CSRF*, *locale* — el
+> [glosario](glossary.md) los explica en lenguaje sencillo.
+
+## Tabla de contenidos
+
+- [Cómo funciona el middleware en Rustango](#how-middleware-works-in-rustango)
+- [El orden importa](#ordering-matters)
+- [El catálogo integrado](#the-built-in-catalog)
+- [Middleware consciente del locale](#locale-aware-middleware)
+- [Middleware consciente de la zona horaria](#timezone-aware-middleware)
+- [Cabeceras de seguridad](#security-headers)
+- [Protección CSRF](#csrf-protection)
+- [Escribir tu propio middleware](#writing-your-own-middleware)
+- [Véase también](#see-also)
+
+---
+
+## Cómo funciona el middleware en Rustango
+
+Hay dos formas, y usarás ambas:
+
+1. **Un `tower::Layer`** — una struct de middleware reutilizable y configurable.
+   Cada componente integrado es uno (`SecurityHeadersLayer`, `RateLimitLayer`,
+   …). Adjuntas un layer con el `.layer(...)` de axum, o — para la mayoría de
+   los integrados — con un **one-liner de trait de extensión** que se lee mejor:
+
+   ```rust
+   use rustango::security_headers::{SecurityHeadersLayer, SecurityHeadersRouterExt};
+
+   // These two are equivalent; the second is the ergonomic form.
+   let app = router.layer(SecurityHeadersLayer::strict());
+   let app = router.security_headers(SecurityHeadersLayer::strict());
+   ```
+
+   Cada módulo integrado exporta un trait `…RouterExt` (`SecurityHeadersRouterExt`,
+   `RateLimitRouterExt`, …). Tráelo al scope y obtienes un método
+   `.security_headers()` / `.rate_limit()` / `.cors()` directamente sobre
+   `Router`. Esa es la forma idiomática de cablear una pila:
+
+   ```rust
+   let app = router
+       .request_id(RequestIdLayer::default())
+       .access_log(AccessLogLayer::default())
+       .rate_limit(RateLimitLayer::per_ip(60, Duration::from_secs(60)))
+       .cors(CorsLayer::new().allow_origins(vec!["https://app.example.com"]))
+       .security_headers(SecurityHeadersLayer::strict());
+   ```
+
+2. **Una función mediante `axum::middleware::from_fn`** — la forma más rápida de
+   escribir uno puntual. Recibes la `Request` y un `Next`; llamas a
+   `next.run(req)` para continuar, y puedes hacer trabajo a ambos lados de esa
+   llamada. El [ejemplo de zona horaria](#timezone-aware-middleware) más abajo es
+   exactamente esto.
+
+Ambos se componen libremente — un middleware `from_fn` *es* un layer, así que se
+apila con los integrados en la misma cadena `.layer(...)`.
+
+---
+
+## El orden importa
+
+Un layer envuelve todo lo añadido **antes** que él, así que el **último** layer
+que adjuntas es el **más externo** — se ejecuta primero a la entrada y último a
+la salida. Imagina la pila como una cebolla; la petición viaja hacia abajo hasta
+el handler y la respuesta viaja de vuelta hacia arriba:
+
+```text
+            ┌──────────────────────────────────────┐
+request  →  │ security_headers   (added last = top) │  → response
+            │   ┌────────────────────────────────┐  │
+            │   │ rate_limit                     │  │
+            │   │   ┌──────────────────────────┐ │  │
+            │   │   │ request_id (added first) │ │  │
+            │   │   │      → handler →         │ │  │
+            │   │   └──────────────────────────┘ │  │
+            │   └────────────────────────────────┘  │
+            └──────────────────────────────────────┘
+```
+
+Consecuencias prácticas:
+
+- **Coloca `request_id` / `access_log` cerca del fondo** (añadidos primero) para
+  que el id de correlación y el span de log cubran todo lo que se ejecuta después
+  de ellos.
+- **Coloca las guardas de rechazo barato cerca de la cima** (añadidas último) —
+  `allowed_hosts`, `rate_limit`, `body_limit` — para que una petición bloqueada
+  se descarte antes de alcanzar los layers internos costosos.
+- **`security_headers` en el nivel más externo** para que las cabeceras se
+  estampen en *cada* respuesta, incluidas las cortocircuitadas por un layer
+  interno (un 429, un 403).
+
+---
+
+## El catálogo integrado
+
+Cada entrada es un `tower::Layer` con un one-liner `…RouterExt` correspondiente,
+salvo que se indique lo contrario. Trae el trait `…RouterExt` del módulo al scope
+para obtener el método.
+
+| Preocupación | Layer | Cablealo con |
+| --- | --- | --- |
+| **Seguridad y acceso** | | |
+| Cabeceras de seguridad (HSTS, XFO, CSP…) | `SecurityHeadersLayer` | `.security_headers(..)` |
+| CSRF (cookie double-submit) | `CsrfLayer` | `.layer(csrf::layer())` |
+| CORS | `CorsLayer` | `.cors(..)` |
+| Lista de hosts permitidos | `AllowedHostsLayer` | `.allowed_hosts(..)` |
+| Permitir/bloquear IP | `IpFilterLayer` | `.ip_filter(..)` |
+| Forzar HTTPS | `SslRedirectLayer` | `.ssl_redirect(..)` |
+| Nonce CSP por petición | `CspNonceLayer` | `.csp_nonce(..)` |
+| Firma de petición HMAC | `HmacAuthLayer` | `.layer(..)` |
+| **Tráfico y resiliencia** | | |
+| Límite de tasa (por IP/global) | `RateLimitLayer` | `.rate_limit(..)` |
+| Límite de tasa distribuido (respaldado por caché) | `CacheRateLimitLayer` | `.cache_rate_limit(..)` |
+| Timeout de petición | `RequestTimeoutLayer` | `.request_timeout(..)` |
+| Tamaño máximo de cuerpo | `BodyLimitLayer` | `.body_limit(..)` |
+| Modo mantenimiento (503) | `MaintenanceLayer` | `.maintenance(..)` |
+| Claves de idempotencia | `IdempotencyLayer` | `.idempotency(..)` |
+| Restringir métodos HTTP | `MethodRestrictLayer` | `.require_get()` / `.require_post()` / `.require_safe()` |
+| **Observabilidad** | | |
+| Id de petición (`X-Request-Id`) | `RequestIdLayer` | `.request_id(..)` |
+| Log de acceso (PII redactada) | `AccessLogLayer` | `.access_log(..)` |
+| Spans de `tracing` | `TracingLayer` | `.layer(..)` |
+| Cabecera `Server-Timing` | `ServerTimingLayer` | `.server_timing(..)` |
+| IP real del cliente (tras proxies) | `RealIpLayer` | `.real_ip(..)` |
+| **Contenido y respuesta** | | |
+| Compresión gzip/br | `CompressionLayer` | `.compression(..)` |
+| ETag / GET condicional | `EtagLayer` | `.etag(..)` |
+| Redirección de barra final | `TrailingSlashLayer` | `.trailing_slash(..)` |
+| Caché de página | `CachePageLayer` | `.layer(..)` |
+| **Localización** | | |
+| Negociación de locale | `LocaleMiddleware` | `.layer(..)` (+ extractor `ActiveLocale`) |
+| Zona horaria activa | *(componer con `from_fn`)* | ver [más abajo](#timezone-aware-middleware) |
+| **Desarrollo** | | |
+| Recarga en vivo | `LiveReloadLayer` | `.livereload(..)` |
+| Panel de depuración | `DebugPanelLayer` | `.debug_panel(..)` |
+
+Las siguientes secciones recorren en detalle las que pidió la petición.
+
+---
+
+## Middleware consciente del locale
+
+`LocaleMiddleware` resuelve un locale por petición y lo inyecta en la petición
+para que cualquier handler pueda leerlo. El orden de selección es el de Django:
+**cookie → `Accept-Language` → valor por defecto**. El primer locale que listes
+es el valor por defecto salvo que lo sobrescribas.
+
+```rust
+use rustango::i18n::middleware::{ActiveLocale, LocaleMiddleware};
+
+// First entry is the default; `.default("en")` is explicit here. `ar`
+// (Arabic) is included so we can prove the RTL convenience too.
+let layer = LocaleMiddleware::new(&["en", "fr", "ar"]).default("en");
+
+let app = Router::new()
+    .route(
+        "/",
+        // The extractor pulls the locale the layer chose for THIS request.
+        get(|loc: ActiveLocale| async move { format!("{} {}", loc.0, loc.direction()) }),
+    )
+    .layer(layer);
+```
+
+Los handlers leen el resultado con el extractor `ActiveLocale`. Es `Infallible`
+— si no se ejecutó ningún middleware, recae en `"en"` — y lleva helpers RTL para
+que las plantillas puedan ramificar según la bidireccionalidad:
+
+```rust
+loc.0            // the picked locale, e.g. "fr"
+loc.direction()  // "ltr" / "rtl" — feed straight into <html dir="…">
+loc.is_rtl()     // true for ar, he, fa, …
+```
+
+El nombre de la cookie es por defecto `django_language` (compatible con Django);
+cámbialo con `.cookie_name("…")`, o pasa `None` para deshabilitar por completo la
+búsqueda por cookie. El orden de precedencia de resolución, verificado de
+extremo a extremo:
+
+```rust
+// Cookie says fr, Accept-Language says ar → the cookie wins.
+//   Cookie: django_language=fr ; Accept-Language: ar   → "fr ltr"
+//
+// No cookie → negotiate Accept-Language (ar is RTL).
+//   Accept-Language: ar,en;q=0.5                        → "ar rtl"
+//
+// Neither cookie nor a supported language → the default locale.
+//   (no headers)                                        → "en ltr"
+```
+
+Para locales en prefijo de URL (`/en/about`, `/fr/about`) en lugar de la
+negociación por cabecera, monta un sub-router por locale con
+`Router::nest("/fr", …)` e inyecta el locale ahí.
+
+---
+
+## Middleware consciente de la zona horaria
+
+Deliberadamente **no hay layer de zona horaria**. En su lugar, el framework te da
+un offset activo task-local (`rustango::i18n::timezone`) y un decodificador de
+cabecera/cookie, y compones un middleware de una línea que lo activa — el ejemplo
+canónico de «escribe el tuyo». Esto refleja el `USE_TZ=True` de Django: almacena
+en UTC, renderiza en el reloj local del usuario.
+
+```rust
+use axum::middleware::{from_fn, Next};
+use rustango::i18n::timezone::{current_offset, from_request_headers, with_offset};
+
+/// Per-request middleware: decode the client's UTC offset from the
+/// `tz_offset` cookie (or a `Time-Zone:` header), then run the rest of the
+/// stack with that offset active so `current_offset()` / the `localtime`
+/// Tera filter see it. Falls back to UTC when nothing parseable is sent.
+async fn timezone_mw(req: Request<Body>, next: Next) -> Response {
+    match from_request_headers(req.headers(), "tz_offset") {
+        Some(offset) => with_offset(offset, next.run(req)).await,
+        None => next.run(req).await,
+    }
+}
+
+let app = Router::new()
+    .route(
+        "/now",
+        // The handler runs inside the activated scope, so the task-local
+        // offset is visible here (and inside any `.await` it makes).
+        get(|| async { current_offset().local_minus_utc().to_string() }),
+    )
+    .layer(from_fn(timezone_mw));
+```
+
+`with_offset` instala el offset en un **`tokio::task_local`**, de modo que
+sobrevive a los puntos `.await` y a los saltos de hilo dentro de la petición — a
+diferencia de un thread-local, no se desvanece cuando tokio reprograma la tarea.
+Dentro del scope:
+
+- `current_offset()` devuelve el `FixedOffset` activo (UTC fuera de cualquier
+  scope),
+- `localtime(utc_dt)` convierte un `DateTime` UTC almacenado a él,
+- el filtro Tera `{{ ts | localtime }}` (registrado con
+  `timezone::register_filters`) lo renderiza automáticamente.
+
+`from_request_headers` acepta primero la cookie `tz_offset`, luego una cabecera
+`Time-Zone:` (o `X-Timezone:`). Los formatos aceptados son flexibles —
+`"+05:30"`, `"+0530"`, `"Z"`/`"UTC"`, o **minutos enteros con signo** (`"330"`,
+`"-300"`), la forma que produce `Date.getTimezoneOffset()` de JS. La cookie la
+suele fijar un pequeño fragmento al cargar la página:
+
+```html
+<script>
+  // getTimezoneOffset() is positive west-of-UTC, so flip the sign.
+  const minutes = -new Date().getTimezoneOffset();
+  document.cookie = `tz_offset=${minutes};path=/;max-age=31536000`;
+</script>
+```
+
+Comportamiento, verificado:
+
+```rust
+// Cookie: tz_offset=330  (UTC+05:30)   → current_offset() = +19800s
+// Header: Time-Zone: -300 (UTC-05:00)  → current_offset() = -18000s
+// nothing sent                          → current_offset() = 0 (UTC)
+```
+
+> **Nota — `FixedOffset`, no IANA.** Esto modela la zona horaria activa como un
+> offset fijo, que es todo lo que necesita un *único instante en el tiempo* y
+> evita la base de datos `chrono-tz` de unos 3 MB. **No** maneja las transiciones
+> de horario de verano. Para soporte IANA completo, parsea el `Tz` del usuario
+> con `chrono-tz` en tiempo de petición y pasa
+> `tz.offset_from_utc_datetime(...)` a `with_offset` — la forma del middleware de
+> arriba no cambia.
+
+---
+
+## Cabeceras de seguridad
+
+`SecurityHeadersLayer` estampa las cabeceras estándar de endurecimiento del
+navegador — HSTS, `X-Frame-Options`, `X-Content-Type-Options`, Referrer-Policy y
+una Content-Security-Policy opcional — en cada respuesta, en una línea.
+
+```rust
+use rustango::security_headers::{CspBuilder, SecurityHeadersLayer, SecurityHeadersRouterExt};
+
+let app = Router::new()
+    .route("/", get(|| async { "ok" }))
+    .security_headers(SecurityHeadersLayer::strict().csp(CspBuilder::strict_starter().build()));
+```
+
+Eso endurece cada respuesta:
+
+```rust
+// strict-transport-security: max-age=31536000; includeSubDomains; preload
+// x-content-type-options:     nosniff
+// x-frame-options:            DENY
+// content-security-policy:    <built from CspBuilder::strict_starter()>
+```
+
+Tres presets cubren los casos comunes:
+
+| Preset | Usar para | HSTS | `X-Frame-Options` |
+| --- | --- | --- | --- |
+| `strict()` | producción | 1 año + preload | `DENY` |
+| `relaxed()` | páginas embebibles | 1 año | `SAMEORIGIN` |
+| `dev()` | dev local | *(omitido)* | — |
+
+Usa `dev()` en local — de lo contrario HSTS fijaría tu navegador a HTTPS durante
+un año en `localhost`. Construye una CSP de forma fluida con `CspBuilder`
+(`.default_src(..)`, `.script_src(..)`, …, `.build()`), y despliégala de forma
+segura con `.csp_report_only(true)` + `.csp_report_uri("/csp-report")` antes de
+aplicarla.
+
+---
+
+## Protección CSRF
+
+CSRF (cross-site request forgery) es cuando otro sitio engaña al navegador de un
+usuario autenticado para que envíe a tu aplicación. **Rustango** se defiende con
+el patrón **double-submit-cookie**, en `rustango::forms::csrf` (tras la feature
+`csrf`, activada automáticamente por `admin`).
+
+```rust
+use rustango::forms::csrf;
+
+let app = Router::new()
+    .route("/form", get(|| async { "render form" }))
+    .route("/submit", post(|| async { "accepted" }))
+    .layer(csrf::layer());
+```
+
+Un método seguro (GET/HEAD/OPTIONS) emite una cookie `rustango_csrf`. Un método
+no seguro (POST/PUT/PATCH/DELETE) debe devolver el valor de esa cookie, ya sea en
+la cabecera `X-CSRF-Token` o en el campo de formulario `_csrf`; una discrepancia
+es `403 Forbidden`:
+
+```rust
+// GET /form                            → 200 + Set-Cookie: rustango_csrf=…
+//
+// POST /submit  (no token)             → 403 Forbidden
+//
+// POST /submit  with both:
+//   Cookie:        rustango_csrf=<t>
+//   X-CSRF-Token:  <t>                 → 200 OK   (double-submit matches)
+```
+
+En plantillas Tera, `{{ csrf_token }}` da el token en bruto y `{{ csrf_input }}`
+un `<input name="_csrf">` oculto listo para usar — coloca uno en cada
+formulario. Sobrescribe los nombres de cookie/cabecera o el flag `Secure` con
+`csrf::with_config(CsrfConfig)`; para configuraciones SPA, añade
+`.with_trusted_origins([...])` para habilitar la comprobación de defensa en
+profundidad de la cabecera Origin además del token. Para endpoints colectores
+append-only alcanzados vía `navigator.sendBeacon` (p. ej. analítica) que no
+pueden enviar una cabecera de token, `CsrfConfig::exempt_prefix("/path")` omite la
+aplicación para un prefijo de ruta estrecho. El auto-admin habilita CSRF en cada
+mutación sin opción de desactivarlo.
+
+---
+
+## Escribir tu propio middleware
+
+Ya viste la forma rápida — el [middleware de zona
+horaria](#timezone-aware-middleware) es un ejemplo `from_fn` completo. Recurre a
+`from_fn` siempre que la lógica sea específica de la aplicación y no necesites
+configurarla:
+
+```rust
+use axum::middleware::{from_fn, Next};
+
+async fn add_app_version(req: Request<Body>, next: Next) -> Response {
+    let mut resp = next.run(req).await;          // run the rest of the stack
+    resp.headers_mut()
+        .insert("X-App-Version", HeaderValue::from_static(env!("CARGO_PKG_VERSION")));
+    resp                                          // …then touch the response
+}
+
+let app = router.layer(from_fn(add_app_version));
+```
+
+Recurre a un **`tower::Layer`** completo cuando el middleware es reutilizable y
+configurable — cuando lo distribuirías como parte de una biblioteca. El patrón es
+una pequeña struct `Layer` que construye un `Service`, más (por convención) un
+trait de extensión `…RouterExt` para el one-liner. `rustango::request_id` es la
+referencia completa más pequeña para copiar:
+
+- `RequestIdLayer` — el layer configurable (`::default()`, `.always_generate()`),
+- `RequestIdService<S>` — envuelve el servicio interno; lee/fija la cabecera
+  `X-Request-Id` dentro de `call`,
+- `RequestId` — un extractor `FromRequestParts` para que los handlers puedan leer
+  el id,
+- `RequestIdRouterExt` — proporciona `Router::request_id(layer)`.
+
+`LocaleMiddleware` (léelo en `crates/rustango/src/i18n/middleware.rs`) es un
+segundo ejemplo trabajado — las mismas cuatro piezas, más un método puro
+`.pick(&req)` que se puede testear unitariamente sin levantar un servidor.
+Modela los nuevos layers sobre uno u otro.
+
+---
+
+## Véase también
+
+- [Guía de seguridad](security.md) — la pila completa de defensa en profundidad y
+  una checklist para el momento del despliegue (`manage check --deploy`).
+- [Autenticación](auth-sessions.md) — los backends de auth y el middleware
+  `CurrentUser` se apoyan en el mismo mecanismo de layer.
+- [URLs y enrutamiento](urls.md) — dónde se adjuntan los layers a los routers y
+  sub-routers.

--- a/docs/es/migrations.md
+++ b/docs/es/migrations.md
@@ -1,0 +1,196 @@
+# Migraciones y el motor de migraciones
+
+**Rustango** incluye un motor de migraciones al estilo de Django: editas tus
+modelos, ejecutas `makemigrations` para generar un archivo JSON versionado que
+describe el cambio de esquema, y `migrate` para aplicarlo. Desde la **0.48** el
+framework incluso migra **sus propias** tablas `rustango_*` a través del mismo
+motor — sin DDL de arranque escrito a mano. Esta página explica las piezas
+móviles que hacen que una actualización sea segura: las dos cadenas de
+migración, la reconciliación de squash y el fake-initial protegido que permite
+que una base de datos preexistente adopte el motor sin colisiones.
+
+> **¿Nuevo en las migraciones?** Los verbos de la CLI del día a día —
+> `makemigrations`, `migrate`, `migrate --squash`, `migrate --fake`,
+> `downgrade`, `showmigrations` — se tratan comando por comando en la
+> [guía de manage](manage.md#migrations). Esta página es el modelo conceptual
+> que hay detrás de ellos.
+
+> **Fuente:** `rustango::migrate` (`runner`, `make`, `file`, `manage`)
+> y `rustango::tenancy::migrate` — la reconciliación del runner vive en
+> `migrate::runner::reconcile`.
+
+---
+
+## Dos cadenas de migración
+
+Una migración pertenece a una de dos cadenas independientes, cada una con su
+propia tabla de registro (la fila de nombres aplicados que el runner consulta
+para omitir trabajo):
+
+| Cadena | Qué gestiona | Tabla de registro |
+|---|---|---|
+| **Proyecto** | tus tablas `#[derive(Model)]`, en `migrations/` | `__rustango_migrations__` |
+| **Sistema** | las tablas `rustango_*` propias del framework (`Org`, `User`, roles/permisos, agents, media, …), en `system/migrations/` | `__rustango_system_migrations__` |
+
+La **cadena del sistema** es lo que hace que el esquema del framework sea
+autodescriptivo. Sus archivos se generan a partir de los modelos compilados del
+framework — y son **conscientes de `#[cfg(feature = …)]`**: una columna o tabla
+protegida por una feature es eliminada por el compilador cuando la feature está
+desactivada, de modo que activar una feature hace que `makemigrations` emita un
+`AddColumn` / `CreateTable` y desactivarla emite un `DropColumn` / `DropTable`.
+Los proyectos de tenant generados por scaffolding incluyen un `system/migrations/`
+**vacío**; el primer `cargo run -- migrate` lo genera y aplica (consulta
+[scaffolding](scaffolding.md)).
+
+`migrate` aplica la cadena del sistema **antes** que las migraciones de tu
+proyecto. En modo de tenancy, los dos ámbitos se solapan deliberadamente en las
+tablas compartidas del framework, por lo que la cadena de ámbito de tenant es la
+que se ejecuta; las tablas exclusivas del registro (`rustango_orgs`,
+`rustango_operators`) no significan nada sin tenancy. Las aplicaciones sin
+tenancy que usan un subsistema del framework (por ejemplo `media`) también
+reciben la aplicación de la cadena del sistema.
+
+---
+
+## Reconciliación de squash — `Migration.replaces`
+
+Un **squash** colapsa una serie de migraciones históricas en un único archivo
+recién generado que recrea el mismo estado final — útil cuando una pila de
+migraciones a medio terminar es más fácil de regenerar que de arreglar. El
+inconveniente: los `CREATE TABLE` del archivo colisionarían en cualquier base de
+datos que ya aplicó las migraciones que colapsó (el checkout de un colega,
+staging, CI).
+
+`migrate --squash` resuelve esto estampando la lista **`replaces`** del nuevo
+archivo con los nombres que colapsó:
+
+```jsonc
+{
+  "name": "0007_squashed_0001_0006",
+  "replaces": ["0001_initial", "0002_add_status", "0003_add_slug", "…"],
+  "forward": [ /* recreates the end state */ ]
+}
+```
+
+Con `replaces` definido, el runner **reconcilia** el squash contra el estado
+real de la base de datos en lugar de ejecutarlo a ciegas. La decisión es
+automática y depende por completo de lo que ya esté presente:
+
+| Estado de la base de datos | Qué hace el runner |
+|---|---|
+| nueva — sin historial, sin tablas | ejecuta el squash de verdad |
+| todas las migraciones reemplazadas están en el registro | lo registra, marca como tombstone a las predecesoras, **sin DDL** |
+| las tablas existen pero el registro no tiene historial | lo registra, **sin DDL** (el `--fake-initial` entre registros de Django) |
+| solo *algunas* de las filas/tablas reemplazadas presentes | **rechazado** — indica qué falta y te dice que lo resuelvas a mano |
+
+El caso **parcial** es un error grave a propósito: ninguna elección automática
+es segura ahí, así que el runner se detiene y reporta lo que encontró en lugar
+de adivinar. Resuélvelo con `migrate --fake` (más abajo).
+
+Las migraciones sustituidas por un squash aplicado cuentan como aplicadas, así
+que puedes dejar los archivos colapsados en disco durante una o dos releases —
+los despliegues que nunca las ejecutaron migran hacia adelante correctamente de
+todos modos. Las migraciones ordinarias (que no son squash) no se ven afectadas:
+una migración corriente cuya tabla ya existe sigue fallando ruidosamente, porque
+eso es un conflicto real, no un historial equivalente conocido.
+
+---
+
+## El fake-initial protegido de reconciliación
+
+Este es el mecanismo que permite que una base de datos **existente** adopte la
+cadena del sistema sin problemas. Antes de la 0.51 el framework construía
+algunas de sus tablas mediante DDL en crudo con `ensure_table` de forma
+perezosa; esas tablas existen pero no están registradas en el registro
+`__rustango_system_migrations__`, así que un nuevo `CREATE TABLE` de la nueva
+migración de sistema colisionaría (`relation "rustango_media" already exists`,
+MySQL 1050, …).
+
+La cadena del sistema reconcilia esto por sí misma. Se inspecciona una migración
+de **sistema** pendiente: las operaciones que componen *la creación de sus
+tablas* — `CreateTable`, más `CreateIndex` / `CreateM2MTable` que apuntan a una
+tabla que la misma migración crea — son el conjunto aceptado. Si **todas** las
+tablas que crea ya existen, la migración se **registra en el registro sin
+ejecutar ningún DDL**, y los datos existentes se dejan intactos. Si solo
+*algunas* de sus tablas existen, la cadena crea únicamente las que faltan
+(semántica `CREATE TABLE IF NOT EXISTS`) y deja las demás en paz.
+
+La protección es deliberadamente estrecha:
+
+- **Limitada a la propia cadena del sistema del framework.** Las migraciones de
+  usuario usan el runner corriente y nunca hacen auto-fake — el faking por
+  existencia de tabla es opt-in solo para la ruta del sistema.
+- **Cualquier cosa que no sea creación de tablas descalifica el faking** — un
+  índice sobre una tabla preexistente, un alter / drop / operación de datos /
+  callback recae en una ejecución real, así que nunca se omite trabajo genuino.
+- **La existencia se pregunta únicamente al namespace actual** — `current_schema()`
+  en Postgres, `DATABASE()` en MySQL, `sqlite_master` en SQLite — no a través del
+  `search_path`, de modo que en la multi-tenancy de modo esquema una tabla con el
+  mismo nombre en `public` no puede engañar a un tenant para que omita sus propias
+  tablas.
+
+El estado parcial de un squash sigue siendo rechazado (ver arriba); solo la
+cadena del sistema del framework hace la reparación por partes de "crear las que
+faltan".
+
+---
+
+## Reparar drift a mano — `migrate --fake`
+
+Cuando la base de datos ya está en el estado objetivo pero el registro no lo
+sabe (una BD configurada fuera de banda, un registro eliminado, una migración
+parcialmente exitosa, un squash parcial rechazado), estampa una migración como
+aplicada **sin ejecutar su SQL**:
+
+```bash
+cargo run -- migrate --fake 0004_add_indexes
+cargo run -- migrate --fake 0001_rustango_registry_initial --system       # framework's own chain
+cargo run -- migrate --fake 0001_rustango_registry_initial --all-tenants  # every active tenant
+```
+
+- `--system` estampa la cadena del sistema del framework
+  (`system/migrations/` → `__rustango_system_migrations__`) en lugar de la de tu
+  proyecto.
+- `--all-tenants` propaga el sello a través de cada tenant activo, reportando
+  cada uno y continuando tras los fallos — las tablas del framework viven por
+  tenant, así que repararlas es un trabajo por tenant. Combínalo con `--system`
+  para las tablas del framework en todos los tenants.
+
+El nombre se valida primero contra el directorio de migraciones, así que un
+error tipográfico no puede colar una fila falsa; el estampado es idempotente, y
+la opción puede repetirse para reparar una serie de filas en un solo comando.
+
+---
+
+## Actualizar a la 0.51.2
+
+> **La 0.51.0 y la 0.51.1 fueron retiradas (yanked)** — la reconciliación que
+> prometían nunca llegó a dispararse de verdad contra bases de datos reales de la
+> 0.46–0.50 (la 0.51.0 movió las tablas de media a las migraciones de sistema y
+> colisionó; la protección de la 0.51.1 exigía que una migración fuera
+> *puramente* `CreateTable`, cosa que ninguna migración generada es).
+> **Actualiza directamente a la 0.51.2**, que corrige ambos.
+
+Para un despliegue existente, la actualización es un despliegue corriente — sin
+reaprovisionamiento, sin DDL manual:
+
+```bash
+cargo run -- migrate
+```
+
+El fake-initial protegido gestiona las tablas preexistentes del framework: el
+primer `migrate` registra en el registro la migración de sistema cuyas tablas ya
+existen sin tocarlas, crea únicamente lo que realmente falta, y deja tus datos en
+paz. Si una base de datos está en un estado parcial verdaderamente inconsistente,
+el runner se detiene y te dice lo que encontró; resuélvelo con `migrate --fake`
+en lugar de forzarlo.
+
+---
+
+## Véase también
+
+- [Guía de `manage`](manage.md#migrations) — cada verbo de la CLI de migración,
+  con ejemplos.
+- [Scaffolding](scaffolding.md) — de dónde vienen `migrations/` y
+  `system/migrations/`.
+- [Modelos](models.md) — el derive a partir del cual se generan las migraciones.

--- a/docs/es/models.md
+++ b/docs/es/models.md
@@ -1,0 +1,456 @@
+# Modelos
+
+Un modelo es una struct de Rust que se asigna a una tabla de base de datos. Añade
+`#[derive(Model)]`, anota los campos, y **Rustango** genera el esquema, un punto de
+entrada de consultas con tipos seguros y los métodos `save`/`find`/`delete` — los modelos
+de Django o el Eloquent de Laravel, con el compilador verificando tus columnas. Esta es
+la referencia de **declaración**: cada tipo de campo, cada opción de clave primaria y
+cada atributo `#[rustango(...)]`. Para *consultar* los modelos una vez declarados,
+consulta el [recetario del ORM](orm.md).
+
+[![Modelos en Rustango: una struct #[derive(Model)] asigna tipos de campo Rust a columnas por dialecto, la clave primaria puede ser un Auto<i64> autoincremental o una clave personalizada asignada por la aplicación, y el derive genera SCHEMA + objects() + save/find](img/models.png)](img/models.png)
+
+> **¿Un término aquí es nuevo para ti?** *model*, *primary key*, *foreign key*,
+> *migration*, *nullable* — consulta el [glosario](glossary.md).
+
+> **Fuente:** `rustango::Model` (`#[derive(Model)]`), `rustango::core`
+> (el trait `Model`, `ModelSchema`, `FieldType`, `Auto`, `ForeignKey`), y las
+> asignaciones de tipos por dialecto en `rustango::sql::{dialect, mysql, sqlite}` —
+> siempre compilados (elige una característica de backend: `postgres` / `mysql` /
+> `sqlite`).
+>
+> **Versión ejecutable:** los round-trips de tipos de campo, la PK personalizada y los
+> fragmentos de SCHEMA están copiados de
+> [`models_doc.rs`](../crates/rustango/tests/models_doc.rs)
+> (`cargo test -p rustango --features sqlite --test models_doc`).
+
+## Tabla de contenidos
+
+- [Anatomía de un modelo](#anatomy-of-a-model)
+- [Tipos de campo](#field-types) · [Tipos exclusivos de PostgreSQL](#postgresql-only-types)
+- [Claves primarias](#primary-keys) — [PKs personalizadas](#custom-primary-keys) · [compuestas](#composite-primary-keys)
+- [Relaciones](#relationships)
+- [Atributos de campo comunes](#common-field-attributes)
+- [Índices y restricciones](#indexes-and-constraints)
+- [Atributos de modelo comunes](#common-model-attributes)
+- [La API generada](#the-generated-api) — [save vs insert](#save-vs-insert)
+- [Referencia completa de atributos](#full-attribute-reference)
+- [Véase también](#see-also)
+
+---
+
+## Anatomía de un modelo
+
+```rust
+use rustango::{Auto, Model};
+use chrono::{DateTime, Utc};
+
+#[derive(Model, Clone, Debug)]
+#[rustango(table = "posts", display = "title")]   // model-level attributes
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,                            // field-level attributes
+
+    #[rustango(max_length = 200)]
+    pub title: String,
+
+    pub body: String,
+
+    #[rustango(fk = "authors", on = "id")]
+    pub author_id: i64,
+
+    #[rustango(auto_now_add)]
+    pub created_at: Auto<DateTime<Utc>>,
+}
+```
+
+A partir de esa única declaración el derive genera:
+
+- el **esquema** (`Post::SCHEMA` — nombre de tabla, columnas, tipos, la PK) que leen las
+  migraciones y el admin;
+- un punto de entrada de consultas, **`Post::objects()`**, que devuelve un
+  `QuerySet<Post>`;
+- **constantes de campo tipadas** (`Post::title`, `Post::author_id`) para filtros
+  verificados en compilación — `Post::objects().where_(Post::author_id.eq(42))`;
+- métodos de fila — **`save`**, **`find`**, **`delete`** y más (consulta
+  [la API generada](#the-generated-api)).
+
+El nombre de la tabla toma por defecto el nombre del modelo si omites `table`; los
+nombres de columna toman por defecto el nombre del campo en snake_case a menos que
+establezcas `column`.
+
+---
+
+## Tipos de campo
+
+El tipo Rust del campo determina su tipo de columna en la base de datos. Rustango asigna
+cada tipo por dialecto, de modo que el mismo modelo funciona en PostgreSQL, MySQL y
+SQLite:
+
+| Tipo Rust | PostgreSQL | MySQL | SQLite |
+|---|---|---|---|
+| `i16` | `SMALLINT` | `SMALLINT` | `INTEGER` |
+| `i32` | `INTEGER` | `INT` | `INTEGER` |
+| `i64` | `BIGINT` | `BIGINT` | `INTEGER` |
+| `f32` | `REAL` | `FLOAT` | `REAL` |
+| `f64` | `DOUBLE PRECISION` | `DOUBLE` | `REAL` |
+| `bool` | `BOOLEAN` | `TINYINT(1)` | `INTEGER` (0/1) |
+| `String` | `TEXT` | `TEXT` | `TEXT` |
+| `String` + `max_length = N` | `VARCHAR(N)` | `VARCHAR(N)` | `TEXT` |
+| `chrono::DateTime<Utc>` | `TIMESTAMPTZ` | `DATETIME(6)` | `TEXT` (ISO-8601) |
+| `chrono::NaiveDate` | `DATE` | `DATE` | `TEXT` |
+| `chrono::NaiveTime` | `TIME` | `TIME(6)` | `TEXT` |
+| `uuid::Uuid` | `UUID` | `CHAR(36)` | `TEXT` |
+| `serde_json::Value` | `JSONB` | `JSON` | `TEXT` |
+| `rust_decimal::Decimal` | `NUMERIC` | `DECIMAL(38,10)` | `NUMERIC` |
+| `Vec<u8>` | `BYTEA` | `LONGBLOB` | `BLOB` |
+| `Option<T>` | `T NULL` | `T NULL` | `T` (nullable) |
+
+`Option<T>` es la forma de hacer que una columna sea **nullable** — un campo que no es
+`Option` es `NOT NULL`. Todos estos hacen un round-trip a través de `save` → `find`,
+verificado de extremo a extremo:
+
+```rust
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "gadget")]
+pub struct Gadget {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 100)]
+    pub name: String,
+    pub qty: i64,
+    pub active: bool,
+    pub note: Option<String>,        // nullable
+    pub made_at: DateTime<Utc>,
+    pub meta: serde_json::Value,     // JSON
+}
+```
+
+> **Precisión decimal.** El `NUMERIC` de PostgreSQL es de precisión arbitraria; MySQL usa
+> `DECIMAL(38,10)` (38 dígitos, 10 fraccionarios — el ajuste portable más amplio); SQLite
+> usa afinidad `NUMERIC`. Usa `rust_decimal::Decimal` para dinero, nunca `f64`.
+
+### Tipos exclusivos de PostgreSQL
+
+Estos se asignan a tipos de columna nativos de PostgreSQL y **no tienen equivalente en
+MySQL/SQLite** — el escritor de migraciones emite `TEXT` allí para mantener la validez,
+pero leerlos/escribirlos produce un error en tiempo de ejecución en esos backends. Úsalos
+solo en despliegues de PostgreSQL:
+
+| Tipo Rust | PostgreSQL | Notas |
+|---|---|---|
+| `Array<T>` | `text[]` / `integer[]` / `bigint[]` | arrays nativos |
+| `Range<T>` | `int4range` / `int8range` / `numrange` / `daterange` / `tstzrange` | tipos de rango |
+| `HStore` | `hstore` | mapa plano string→string (necesita la extensión) |
+| `Vector` + `#[rustango(vector(dims = N))]` | `vector(N)` | embeddings de pgvector |
+| `Point` + `#[rustango(geometry(srid = N))]` | `geometry(Point, N)` | PostGIS |
+
+---
+
+## Claves primarias
+
+Cada modelo necesita una clave primaria. Marca un campo con
+`#[rustango(primary_key)]`; si no marcas ninguno, el esquema busca una columna llamada
+`id`.
+
+La PK **por defecto y más común** es un entero de 64 bits autoincremental, declarado como
+`Auto<i64>`:
+
+```rust
+#[rustango(primary_key)]
+pub id: Auto<i64>,
+```
+
+**Semántica de `Auto<T>`.** Un campo `Auto<T>` es o bien `Unset` (el valor que asignará
+la BD) o `Set(v)`. Al insertar, una PK `Unset` se omite de la lista de columnas para que
+la base de datos la genere, luego el valor se vuelve a leer (`RETURNING` en
+PostgreSQL/SQLite, `LAST_INSERT_ID()` en MySQL) y se almacena en tu struct:
+
+```rust
+let mut g = Gadget { id: Auto::default(), /* … */ };   // Unset
+g.save_pool(&pool).await?;                              // DB assigns the id
+let new_id = g.id.get().copied().unwrap();             // now populated
+```
+
+Los tipos internos de `Auto<T>` admitidos son `i32`, `i64` y `Uuid`.
+
+### Claves primarias personalizadas
+
+La PK no tiene por qué ser un entero autoincremental. Cualquier tipo que se asigne a una
+columna puede ser la PK; tú mismo asignas el valor:
+
+| Declaración de PK | Tipo de columna | Quién la asigna |
+|---|---|---|
+| `Auto<i64>` *(por defecto)* | `BIGSERIAL` / `BIGINT AUTO_INCREMENT` / `INTEGER … AUTOINCREMENT` | base de datos |
+| `Auto<i32>` | `SERIAL` / `INT AUTO_INCREMENT` / `INTEGER …` | base de datos |
+| `Auto<Uuid>` + `auto_uuid` | `UUID` | lado Rust (`uuid v4`) |
+| `Auto<Uuid>` + `default_uuid_v7` | `UUID` | lado Rust (`uuid v7` ordenable) |
+| `String` + `primary_key` | `VARCHAR(N)` / `TEXT` | tú (aplicación) |
+| `Uuid` + `primary_key` | `UUID` / `CHAR(36)` / `TEXT` | tú (aplicación) |
+| `i64` / `i32` + `primary_key` | `BIGINT` / `INTEGER` | tú (aplicación) |
+
+Una **clave natural de tipo string** (por ejemplo, un código de cupón) — ten en cuenta
+que proporcionas el valor e insertas con [`insert_pool`](#save-vs-insert), ya que no hay
+un `Auto::Unset` que `save` pueda detectar:
+
+```rust
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "coupon")]
+pub struct Coupon {
+    #[rustango(primary_key, max_length = 32)]
+    pub code: String,        // you assign this
+    pub discount: i64,
+}
+
+let c = Coupon { code: "SAVE10".into(), discount: 10 };
+c.insert_pool(&pool).await?;                       // explicit INSERT
+let back = Coupon::find_or_fail("SAVE10".to_string(), &pool).await?;   // look up by the string PK
+```
+
+**Renombra la columna de la PK** con `column` (el campo Rust sigue siendo `number`, la
+columna SQL es `account_no`):
+
+```rust
+#[rustango(primary_key, column = "account_no")]
+pub number: i64,
+```
+
+```rust
+// Introspect it via the schema:
+let pk = Account::SCHEMA.primary_key().unwrap();
+assert_eq!(pk.name, "number");        // Rust field
+assert_eq!(pk.column, "account_no");  // SQL column
+```
+
+**Las claves primarias UUID** generan el valor en el lado Rust: `auto_uuid` da un v4
+aleatorio, `default_uuid_v7` un v7 ordenable por tiempo (mejor para la localidad de
+índice):
+
+```rust
+#[rustango(primary_key, auto_uuid)]
+pub id: Auto<uuid::Uuid>,
+```
+
+### Claves primarias compuestas
+
+Las claves primarias nativas de varias columnas **no están soportadas** — exactamente un
+campo puede ser `primary_key`. El patrón provisto es una PK subrogada `Auto<i64>` más una
+restricción de unicidad compuesta declarada, que es equivalente en términos de índice:
+
+```rust
+#[derive(Model)]
+#[rustango(table = "line_item", unique_together = "invoice_id, line_no")]
+pub struct LineItem {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,        // surrogate PK
+    pub invoice_id: i64,
+    pub line_no: i32,         // (invoice_id, line_no) is unique together
+}
+```
+
+Busca las filas con
+`.where_(LineItem::invoice_id.eq(..)).where_(LineItem::line_no.eq(..))`.
+
+---
+
+## Relaciones
+
+Una clave foránea es una columna `_id` más un accesor tipado opcional:
+
+```rust
+// Plain FK column — store the parent's id:
+#[rustango(fk = "authors", on = "id")]
+pub author_id: i64,
+
+// Typed FK — lazy-loads the parent on demand:
+pub author: ForeignKey<Author>,
+```
+
+`ForeignKey<T>` toma por defecto `i64` como tipo de clave; si la PK del padre es de un
+tipo distinto, nómbralo: `ForeignKey<User, String>`. Uno-a-uno usa `#[rustango(o2o)]`;
+muchos-a-muchos es una tabla separada — consulta
+[Recetario del ORM → Muchos-a-muchos](orm.md#many-to-many). Carga de forma anticipada las
+filas relacionadas con `select_related` (también en la guía del ORM).
+
+---
+
+## Atributos de campo comunes
+
+`#[rustango(...)]` sobre un campo. Los que usarás constantemente:
+
+| Atributo | Ejemplo | Efecto |
+|---|---|---|
+| `primary_key` | `#[rustango(primary_key)]` | marca la PK |
+| `max_length = N` | `#[rustango(max_length = 200)]` | `VARCHAR(N)` + comprobación de longitud en escritura |
+| `default = "…"` | `#[rustango(default = "'draft'")]` | valor por defecto de columna en la BD (literal SQL) |
+| `unique` | `#[rustango(unique)]` | restricción de unicidad sobre la columna |
+| `choices = "…"` | `#[rustango(choices = "draft:Draft, published:Published")]` | valores enumerados (`value:Label`); `<select>` del admin + validación |
+| `auto_now_add` | `#[rustango(auto_now_add)]` | establecer a ahora en la **inserción** (en un `Auto<DateTime<Utc>>`) |
+| `auto_now` | `#[rustango(auto_now)]` | establecer a ahora en **cada guardado** |
+| `column = "…"` | `#[rustango(column = "account_no")]` | renombrar la columna SQL |
+| `null` / `Option<T>` | `pub note: Option<String>` | columna nullable |
+| `min` / `max` | `#[rustango(min = 0, max = 100)]` | validación de rango en escritura |
+| `blank` / `editable` | `#[rustango(editable = false)]` | comportamiento en formulario/admin |
+| `db_comment = "…"` | `#[rustango(db_comment = "cents")]` | COMMENT de columna |
+
+`choices`, `default`, `auto_now_add` y borrado lógico juntos (todos verificados):
+
+```rust
+#[rustango(max_length = 20, default = "'draft'", choices = "draft:Draft, published:Published")]
+pub status: String,
+#[rustango(auto_now_add)]
+pub created_at: Auto<DateTime<Utc>>,
+#[rustango(soft_delete)]
+pub deleted_at: Option<DateTime<Utc>>,
+```
+
+---
+
+## Índices y restricciones
+
+Declarados sobre el **modelo**:
+
+```rust
+#[rustango(
+    table = "posts",
+    index("status, published_at"),                 // composite btree index
+    unique_together = "author_id, slug",           // multi-column unique
+    check(name = "qty_nonneg", expr = "qty >= 0"), // CHECK constraint
+)]
+```
+
+- **`index(...)`** — un índice btree por defecto; elige un método para PostgreSQL con
+  `index(columns = "body", method = "gin")` (también `gist`, `brin`, `hash`, `bloom`,
+  `spgist`).
+- **`unique_together` / `index_together`** — de varias columnas único / no único.
+- **Índices parciales** — `unique_when(...)` / `index_when(...)` añaden una condición
+  `WHERE`.
+- **`check(name, expr)`** — una restricción CHECK; **`exclude(...)`** es una restricción
+  EXCLUDE de PostgreSQL.
+
+---
+
+## Atributos de modelo comunes
+
+`#[rustango(...)]` sobre la struct:
+
+| Atributo | Ejemplo | Efecto |
+|---|---|---|
+| `table = "…"` | `table = "posts"` | nombre de tabla (por defecto el nombre de la struct) |
+| `display = "…"` | `display = "title"` | el campo mostrado cuando se referencia una fila (etiquetas FK, admin) |
+| `app = "…"` | `app = "blog"` | agrupa el modelo bajo una app |
+| `default_order = "…"` | `default_order = "-created_at"` | orden por defecto para las consultas |
+| `default_permissions` | `default_permissions = "add, change"` | qué autopermisos crear |
+| `soft_delete` *(campo)* | `#[rustango(soft_delete)] deleted_at: Option<…>` | habilitar borrado lógico (marcar, no eliminar) |
+| `audit(track = "…")` | `audit(track = "title, status")` | registrar el historial de cambios por fila |
+| `scope = "…"` | `scope = "tenant"` | ámbito de multi-tenancy (registro vs inquilino) |
+| `admin(...)` | `admin(list_display = "…")` | configuración de la UI del admin — consulta [el admin](admin.md) |
+
+---
+
+## La API generada
+
+`#[derive(Model)]` implementa el trait `Model` (`Post::SCHEMA`) y genera:
+
+- **`Post::objects()`** (alias `Post::query()`) → un `QuerySet<Post>` para filtrar,
+  ordenar y obtener (el [recetario del ORM](orm.md) cubre la API de consultas).
+- **Constantes de campo tipadas** — `Post::title`, `Post::author_id` — usadas en
+  `.where_(Post::author_id.eq(42))` para filtros verificados en compilación.
+- **Buscadores** — `find(pk, &pool)` → `Option<Self>`; `find_or_fail(pk, &pool)` →
+  `Self` (error si no existe); `find_many(pks, &pool)`; `find_or_insert(...)`.
+- **Escritores** — `save`/`save_pool`, `save_partial(&["title"], &pool)` (actualiza solo
+  algunas columnas), `insert_pool` (inserción explícita), `delete`.
+- **Borrado lógico** (cuando está habilitado) — `soft_delete`, `restore`,
+  `force_delete`; `QuerySet::active()` / `with_trashed()` / `only_trashed()`.
+
+### save vs insert
+
+Esto confunde a la gente, así que vale la pena decirlo con claridad:
+
+| Método | Comportamiento |
+|---|---|
+| `save_pool(&mut self, &pool)` | **INSERT** si la PK `Auto` está `Unset`, de lo contrario **UPDATE** |
+| `insert_pool(&self, &pool)` | siempre **INSERT** |
+
+Para la PK `Auto<i64>` por defecto, `save_pool` hace lo correcto automáticamente. Para una
+**PK asignada por la aplicación** (un `String`/`Uuid` que estableces tú mismo), no hay un
+estado `Unset` — así que `save_pool` haría un UPDATE de una fila (posiblemente
+inexistente). Usa **`insert_pool`** para insertar una fila totalmente nueva con una PK
+personalizada (verificado en el test de respaldo).
+
+---
+
+## Referencia completa de atributos
+
+Cada clave `#[rustango(...)]` que acepta el derive. Las comunes se cubren arriba; esta es
+la lista completa, incluyendo las avanzadas/específicas de PostgreSQL.
+
+### A nivel de modelo (sobre la struct)
+
+| Atributo | Valor | Efecto |
+|---|---|---|
+| `table` | `"name"` | nombre de tabla |
+| `display` | `"field"` | etiqueta legible para una fila |
+| `app` | `"name"` | agrupación por app |
+| `default_order` | `"-field"` | orden por defecto |
+| `default_permissions` | `"add, change, delete, view"` | autopermisos a crear |
+| `default_related_name` | `"posts"` | nombre del accesor inverso en el padre |
+| `base_manager_name` | `"all_objects"` | nombre del manager base (sin filtrar) |
+| `manager(ext = "Trait")` | ruta del trait | generar un trait de extensión de manager personalizado |
+| `manager_fn` | `"published"` | añadir un accesor de manager más allá de `objects()` |
+| `get_latest_by` | `"created_at"` | columna por defecto para `latest()`/`earliest()` |
+| `order_with_respect_to` | `"parent"` | ordenación relativa al padre de Django |
+| `index(...)` | `columns`, `method`, `name` | índice secundario (btree/gin/gist/brin/hash/bloom/spgist) |
+| `unique_together` | `"a, b"` | restricción de unicidad compuesta |
+| `index_together` | `"a, b"` | índice no único compuesto |
+| `unique_when(...)` / `index_when(...)` | columnas + `condition` | índice parcial (condicional) |
+| `check(...)` | `name`, `expr` | restricción CHECK |
+| `exclude(...)` | especificación de operador | restricción EXCLUDE de PostgreSQL |
+| `audit(track = "…")` | lista de campos | historial de cambios por fila |
+| `scope` | `"tenant"` / `"registry"` | ámbito de multi-tenancy |
+| `proxy` | flag | modelo proxy (comparte la tabla de otro) |
+| `global_scope(name, apply = fn)` | nombre + fn | filtro aplicado automáticamente a todas las consultas |
+| `through(...)` | especificación de relación | accesor de relación through personalizado |
+| `reverse_has(...)` / `generic_has(...)` | especificación de relación | accesor inverso has-many / inverso de FK genérica |
+| `required_db_features` / `required_db_vendor` | lista / proveedor | restricciones de validación de despliegue |
+| `db_table_comment` | `"…"` | COMMENT de tabla |
+| `admin(...)` | opciones de admin | configuración de la UI del admin (consulta [admin.md](admin.md)) |
+
+### A nivel de campo (sobre un campo)
+
+| Atributo | Valor | Efecto |
+|---|---|---|
+| `primary_key` | flag | marca la PK |
+| `column` | `"name"` | renombrar la columna SQL |
+| `max_length` | `N` | `VARCHAR(N)` + validación de longitud |
+| `default` | `"sql literal"` | DEFAULT de columna |
+| `null` | flag | nullable (o usa `Option<T>`) |
+| `unique` | flag | restricción de unicidad |
+| `choices` | `"v:Label, …"` | valores enumerados |
+| `min` / `max` | número | validación de rango |
+| `blank` | flag | permitir vacío en formularios/admin |
+| `editable` | `true`/`false` | editabilidad en formulario/admin |
+| `auto_now` | flag | establecer a ahora en cada guardado |
+| `auto_now_add` | flag | establecer a ahora en la inserción |
+| `auto_uuid` | flag | UUID v4 del lado Rust (en `Auto<Uuid>`) |
+| `default_uuid_v7` | flag | UUID v7 ordenable del lado Rust |
+| `fk` + `on` | `"table"`, `"col"` | columna de clave foránea |
+| `cascade` | flag | `ON DELETE CASCADE` |
+| `o2o` | flag | relación uno-a-uno |
+| `fk_composite(...)` / `generic_fk(...)` | especificación | FK compuesta / FK genérica (content-type) |
+| `generated_as` | `"expr"` | columna computada (generada) por la BD |
+| `citext` | flag | texto insensible a mayúsculas (CITEXT de PostgreSQL) |
+| `vector(dims = N)` | `N` | dimensión de pgvector |
+| `geometry(srid = N)` | `N` | id de referencia espacial de PostGIS |
+| `db_comment` | `"…"` | COMMENT de columna |
+
+---
+
+## Véase también
+
+- [Recetario del ORM](orm.md) — consultas, filtros, agregaciones, joins, transacciones
+  (qué hacer con un modelo una vez declarado).
+- [Serializadores](serializers.md) — dar forma a un modelo en JSON para una API.
+- [El admin](admin.md) — el bloque `admin(...)` y la UI generada.
+- [Scaffolding](scaffolding.md) · [CLI `manage`](manage.md) — generar un modelo y su
+  migración.

--- a/docs/es/openapi.md
+++ b/docs/es/openapi.md
@@ -1,0 +1,267 @@
+# OpenAPI
+
+**Rustango** genera una especificación **OpenAPI 3.1** para tu API y la sirve con
+Swagger UI / Redoc — sin anotaciones que mantener a mano. Apunta el generador a los
+serializadores y ViewSets que ya escribiste: los esquemas de campo vienen de
+`#[derive(Serializer)]`, las rutas CRUD vienen de tu ViewSet, y un router de una línea
+monta `/openapi.json` + una página de documentación interactiva. Cuando necesitas
+control total, los mismos tipos te permiten construir a mano cualquier especificación.
+
+[![OpenAPI de Rustango: los campos del serializador se convierten en un esquema de componente, el ViewSet se convierte en rutas CRUD, y openapi_router sirve /openapi.json + Swagger UI](img/openapi.png)](img/openapi.png)
+
+> **Fuente:** `rustango::openapi` (`OpenApiSpec`, `Schema`, `OpenApiSchema`,
+> `PathItem`, `Operation`, `SecurityScheme`, `router::openapi_router`) y
+> `ViewSet::openapi_paths` — tras la característica `openapi` (activada por defecto; el
+> router del visor también necesita `admin`).
+>
+> **Versión ejecutable:** cada fragmento de abajo está copiado del ejemplo probado
+> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog/tests/openapi.rs)
+> — `cargo test -p getting_started_blog --test openapi`. Los tipos del builder, del
+> esquema y del router están cubiertos además por las propias pruebas unitarias del
+> framework (`crates/rustango/src/openapi/`).
+
+> **¿Algún término nuevo aquí?** *OpenAPI*, *schema*, *serializer*, *ViewSet* — consulta
+> el [glosario](glossary.md).
+
+---
+
+## Tabla de contenidos
+- [Inicio rápido](#quick-start) — genera + sirve en una sola pantalla
+- [Esquemas desde serializadores](#schemas-from-serializers) · [Rutas desde ViewSets](#paths-from-viewsets)
+- [Servirlo](#serving-the-spec-swagger-ui--redoc) · [Construir una especificación a mano](#hand-building-a-spec)
+- [Esquemas de seguridad](#security-schemes) · [El builder `Schema`](#the-schema-builder)
+- [Notas y límites](#notes-and-limits)
+
+---
+
+## Inicio rápido
+
+Genera un esquema de componente desde un serializador, rutas CRUD desde un ViewSet, y
+luego monta el visor:
+
+```rust
+use rustango::core::Model;                  // brings `Post::SCHEMA` into scope
+use rustango::openapi::{OpenApiSpec, OpenApiSchema, SecurityScheme};
+use rustango::openapi::router::openapi_router;
+use rustango::viewset::ViewSet;
+
+let mut spec = OpenApiSpec::new("Blog API", "1.0.0")
+    .description("Demo of rustango's OpenAPI generation")
+    .server("https://api.example.com", "Production")
+    .add_security_scheme("bearerAuth", SecurityScheme::bearer("JWT"))
+    .require_security("bearerAuth", [])                  // global default
+    .add_schema("Post", PostSerializer::openapi_schema()); // from #[derive(Serializer)]
+
+// CRUD path items straight off the ViewSet:
+for (path, item) in ViewSet::for_model(Post::SCHEMA).openapi_paths("/api/posts", "Post") {
+    spec = spec.add_path(path, item);
+}
+
+// Mount /openapi.json + /docs (Swagger UI) + /redoc:
+let app = axum::Router::new().merge(openapi_router(spec));
+```
+
+Visita `/docs` para Swagger UI, `/redoc` para Redoc, u obtén el `/openapi.json` crudo
+para codegen (`openapi-generator`, `oapi-codegen`, etc.).
+
+---
+
+## Esquemas desde serializadores
+
+Con la característica `openapi` activada, `#[derive(Serializer)]` también emite una
+impl de [`OpenApiSchema`], de modo que cualquier serializador se convierte en un
+esquema de componente:
+
+```rust
+use rustango::openapi::OpenApiSchema;
+
+let schema = PostSerializer::openapi_schema();   // -> rustango::openapi::Schema
+spec = spec.add_schema("Post", schema);
+```
+
+El esquema refleja la **forma de la API**, no la tabla cruda: los campos renombrados
+(`#[serializer(source = "body")]` → `content`), la visibilidad `read_only` /
+`write_only`, los campos de método calculados y los serializadores anidados se
+trasladan todos. Los tipos de campo se mapean automáticamente:
+
+| Campo Rust | OpenAPI |
+|---|---|
+| `i32` / `i64` | `integer` (`int32` / `int64`) |
+| `f32` / `f64` | `number` (`float` / `double`) |
+| `String`, `&str` | `string` |
+| `bool` | `boolean` |
+| `Vec<T>` / `[T; N]` | `array` of `T` |
+| `Option<T>` | `T`, marcado `nullable` |
+| `chrono::DateTime<Utc>` | `string` / `date-time` |
+| `chrono::NaiveDate` | `string` / `date` |
+| `uuid::Uuid` | `string` / `uuid` |
+| `Auto<T>` | igual que `T` (asignado por el servidor) |
+| `HashMap<String, V>` | `object` con `additionalProperties` |
+| `serde_json::Value` | libre (cualquiera) |
+
+Para un **tipo de campo personalizado**, implementa `OpenApiSchema` una vez y funciona
+en todas partes donde aparezca ese tipo:
+
+```rust
+struct Money { cents: i64 }
+
+impl rustango::openapi::OpenApiSchema for Money {
+    fn openapi_schema() -> rustango::openapi::Schema {
+        rustango::openapi::Schema::integer().description("amount in cents")
+    }
+}
+```
+
+> Consulta la [guía de Serializadores](serializers.md#openapi-schemas) para los
+> atributos de campo que dan forma a la salida.
+
+---
+
+## Rutas desde ViewSets
+
+`ViewSet::openapi_paths(prefix, schema_ref)` devuelve los pares `(path, PathItem)` para
+las cinco rutas CRUD estándar — list, create, retrieve, update, partial update,
+delete — conectadas para referenciar un esquema de componente registrado:
+
+```rust
+for (path, item) in ViewSet::for_model(Post::SCHEMA)
+    .filter_fields(&["author_id", "status"])
+    .search_fields(&["title", "body"])
+    .openapi_paths("/api/posts", "Post")
+{
+    spec = spec.add_path(path, item);
+}
+```
+
+Produce `/api/posts` (GET list, POST create) y `/api/posts/{pk}` (GET, PUT, PATCH,
+DELETE), y se mantiene sincronizado con la configuración del ViewSet:
+
+- **Paginación** → los parámetros de consulta correctos + el envoltorio de respuesta
+  de lista para el estilo configurado (`page`/`page_size`, `cursor`, o
+  `limit`/`offset`).
+- **Filtrado / búsqueda / ordenación** → un parámetro de consulta `?field=` por cada
+  `filter_fields` (con los lookups disponibles `__gt`/`__in`/… descritos), más
+  `?search=` y `?ordering=` cuando están configurados.
+- **`read_only()`** → las operaciones de escritura (POST/PUT/PATCH/DELETE) se omiten.
+- **Parámetro de ruta** → `{pk}` tipado a partir de la clave primaria del modelo.
+- **`operationId`** → `list_post`, `create_post`, … (en snake-case por acción).
+
+> El ViewSet en sí está documentado en la [guía de ViewSets](viewsets.md).
+
+---
+
+## Servir la especificación (Swagger UI / Redoc)
+
+`openapi_router(spec)` monta tres rutas:
+
+| Ruta | Sirve |
+|---|---|
+| `GET /openapi.json` | la especificación como JSON (`application/json`) |
+| `GET /docs` | Swagger UI (probar interactivamente) |
+| `GET /redoc` | Redoc (referencia limpia de tres paneles) |
+
+```rust
+let app = axum::Router::new()
+    .merge(PostViewSet::router("/api/posts", pool.clone()))
+    .merge(openapi_router(spec));        // adds /openapi.json, /docs, /redoc
+```
+
+Las páginas del visor son diminutas cáscaras HTML que cargan Swagger UI / Redoc desde
+un CDN (`unpkg` / `jsdelivr`) — no se empaqueta ningún JS en **Rustango**. Para un
+despliegue aislado (air-gapped), escribe `spec.to_json()` en un archivo al arrancar y
+auto-hospeda los assets del visor desde tu propio directorio estático.
+
+---
+
+## Construir una especificación a mano
+
+Cuando tu API no tiene forma de ViewSet, construye la especificación directamente — los
+mismos tipos, fidelidad completa a OpenAPI 3.1:
+
+```rust
+use rustango::openapi::{OpenApiSpec, PathItem, Operation, Response, Parameter, Schema};
+
+let spec = OpenApiSpec::new("My API", "1.0.0")
+    .description("Customer-facing public API")
+    .add_schema("Post", Schema::object()
+        .property("id", Schema::integer())
+        .property("title", Schema::string())
+        .required(["id", "title"]))
+    .add_path("/posts/{id}", PathItem::new()
+        .parameter(Parameter::path("id", Schema::integer()))
+        .get(Operation::new()
+            .summary("Get a post")
+            .operation_id("get_post")
+            .tag("posts")
+            .response("200", Response::new("OK")
+                .json_content(Schema::ref_("Post")))
+            .response("404", Response::new("not found"))));
+
+let json = spec.to_json();   // pretty-printed OpenAPI 3.1
+```
+
+`OpenApiSpec` también acepta `.contact(...)`, `.license(...)`, `.add_tag(...)` y
+múltiples entradas `.server(...)`.
+
+---
+
+## Esquemas de seguridad
+
+Declara cómo se autentica la API, luego exige un esquema globalmente (los overrides
+por operación ganan):
+
+```rust
+use rustango::openapi::SecurityScheme;
+
+let spec = OpenApiSpec::new("API", "1.0")
+    .add_security_scheme("bearerAuth", SecurityScheme::bearer("JWT"))
+    .add_security_scheme("apiKey", SecurityScheme::api_key_header("X-API-Key"))
+    .require_security("bearerAuth", []);     // default for every operation
+```
+
+Helpers: `SecurityScheme::bearer(fmt)`, `basic()`, `api_key_header(name)`,
+`api_key_query(name)`, `oauth2_authorization_code(auth_url, token_url, scopes)`. En una
+`Operation`, `.no_security()` marca un endpoint público y
+`.require_security(scheme, scopes)` sobrescribe el valor global por defecto. Estos se
+alinean con la propia autenticación de **Rustango** (consulta la
+[guía de Seguridad](security.md#authenticating-users)): JWT → `bearer`, API keys →
+`apiKey`, OAuth2 → `oauth2`.
+
+---
+
+## El builder `Schema`
+
+`Schema` es un builder fluido de JSON-Schema (subconjunto de OpenAPI 3.1):
+
+```rust
+Schema::object()
+    .property("id", Schema::integer())                       // int64
+    .property("email", Schema::email())                      // string/email
+    .property("status", Schema::string().enum_(["draft", "published"]))
+    .property("tags", Schema::array_of(Schema::string()))
+    .property("created", Schema::datetime().nullable())
+    .required(["id", "email"]);
+```
+
+Constructores de tipos: `string` · `integer` / `int32` · `number` · `boolean` ·
+`object` · `array_of(..)` · `any_object` · `datetime` / `date` / `time` · `uuid` ·
+`decimal` · `binary` · `email` · `uri` · `ref_("Name")`. Modificadores:
+`.property`, `.required`, `.nullable`, `.enum_`, `.format`, `.description`,
+`.example`, `.default_value`, `.min_length` / `.max_length`, `.minimum` /
+`.maximum`.
+
+---
+
+## Notas y límites
+
+- **Es OpenAPI 3.1** (`"openapi": "3.1.0"`), que se alinea con JSON Schema 2020-12 — la
+  mayoría del tooling moderno lo consume directamente.
+- **El router del visor necesita la característica `admin`** (para axum); `openapi` por
+  sí solo basta para *construir* y serializar una especificación (`spec.to_json()`).
+- **Los visores cargan desde un CDN** — está bien para documentación interna/de
+  desarrollo; auto-hospeda los assets para despliegues offline o bloqueados por CSP.
+- **`openapi_paths` cubre la forma CRUD estándar.** Las acciones personalizadas, o los
+  endpoints hechos a mano, los añades con `add_path` (sección de construir a mano de
+  arriba).
+- Regenera los SDKs de cliente desde `/openapi.json` en CI para que nunca se
+  desincronicen del servidor.

--- a/docs/es/orm.md
+++ b/docs/es/orm.md
@@ -1,0 +1,1800 @@
+# Recetario del ORM
+
+Patrones para el ORM de **Rustango** más allá de lo básico. Si vienes del ORM de Django, de Eloquent de Laravel o de ActiveRecord de Rails, las formas que verás aquí te resultarán familiares. La mayoría de los ejemplos asumen que ya tienes un modelo `Post` de `Getting Started`.
+
+[![Consultas del ORM verificadas por tipos: filtros encadenados, ordenamiento, límites y agregación — todo sin SQL crudo](img/orm.png)](img/orm.png)
+
+> **Fuente:** `rustango::sql` (`QuerySet`, la macro `Q!` / el builder `Qb`) y la
+> API de consulta de `#[derive(Model)]` — siempre compilada; elige una característica de backend
+> (`postgres` / `mysql` / `sqlite`).
+>
+> **Versión ejecutable:** los patrones aquí se ejecutan en el ejemplo probado
+> [`orm_cookbook`](../crates/rustango/examples/orm_cookbook).
+>
+> **¿Nuevo con algún término de aquí?** El [glosario](glossary.md) define *model*, *queryset*,
+> *pool* y *migración* en lenguaje sencillo.
+
+Algunos términos de Rust se repiten a lo largo del documento. `&pool` es una referencia compartida al pool de conexiones de la base de datos; se la pasas a los métodos que realmente ejecutan SQL. `.await` ejecuta una llamada asíncrona y espera el resultado. `Option<T>` es un valor que puede estar presente (`Some`) o ausente (`None`) — el null de Rust. `Result` es éxito-o-error; el `?` al final de una llamada retorna anticipadamente ante un error. `Auto<i64>` es una primary key autoincremental que está o bien `Set` (cargada desde la BD) o bien `Unset` (aún no insertada).
+
+## Novedades (v0.41 / v0.42)
+
+Las versiones recientes añadieron un lote de características con paridad con Django que aún no están integradas en cada una de las secciones de abajo. Referencias rápidas:
+
+- **Macro `Q!` + builder en tiempo de ejecución `Qb`** (#269, #263) — filtros con forma de Django, seguros en tiempo de compilación. `User::objects().where_(Q!(User.email__icontains = "alice"))` no compila si el nombre del campo tiene una errata. Variante componible en tiempo de ejecución para chips de filtro del admin: `let q = Qb::eq("active", true) & Qb::gt("age", 18i64);`.
+- **`.distinct_on(&["author_id"])`** (#264) — nativo en PG; fallback portable con funciones de ventana en MySQL / SQLite. Patrones de "el más reciente por grupo".
+- **`bulk_upsert_pool(rows, unique_fields, update_fields, &pool)`** (#267) — el `bulk_create(update_conflicts=True)` de Django. `ON CONFLICT` / `ON DUPLICATE KEY UPDATE` tri-dialecto.
+- **`explain_pool()`** (#272) — `EXPLAIN` tri-dialecto. PG `EXPLAIN (FORMAT JSON, ANALYZE, BUFFERS)` / MySQL `EXPLAIN ANALYZE` / SQLite `EXPLAIN QUERY PLAN`.
+- **Biblioteca de funciones de BD** (#266) — `Cast`, `LPad`, `RPad`, `MD5`, `SHA1`, `SHA256`, `Position`, `Repeat`, `Reverse`, `Sign`, `Mod`, `Power`, `Sqrt`. Emisión por dialecto con errores claros donde SQLite carece de la función.
+- **Tipos de campo** — `rust_decimal::Decimal` (nativo en PG/MySQL, en SQLite vía shim de Decode), `chrono::NaiveTime`, `Vec<u8>` (`FieldType::Binary`) ahora aceptados por `#[derive(Model)]` (#524, v0.42).
+- **`ModelForm::prepare_save()` / `PreparedSave`** (#375, v0.42) — el `save(commit=False)` de Django. Valida ahora, muta el conjunto de escritura preparado, confirma cuando estés listo.
+- **`#[rustango(unique_when(columns = "...", condition = "..."))]`** (#265) — restricciones únicas parciales. "Email único por fila no eliminada" / "Slug único por tenant".
+- **`#[rustango(manager(ext = "FooManagerExt"))]`** (#271) — trait de extensión de manager personalizado con forma de Django, emitido junto al modelo. (También es la forma en Rust de los proxy models de Django — misma tabla física, múltiples "personalidades" vía métodos por trait. Ver `inheritance.rs:98-127`.)
+- **`manage makemigrations --merge`** (#346, v0.42) — nodo de fusión con forma de Django para cadenas de ramas divergentes. Ver [`docs/manage.md`](manage.md#makemigrations---merge).
+
+El CHANGELOG contiene el índice completo de tickets de cada versión.
+
+## Tabla de contenidos
+
+- [Consultas](#querying)
+- [Valores calculados y funciones de base de datos](#computed-values--database-functions)
+- [Agregaciones](#aggregations)
+- [Joins y precarga de filas relacionadas](#joins--preloading-related-rows)
+- [Operaciones en lote](#bulk-operations)
+- [Insertar o actualizar (upsert)](#insert-or-update-upsert)
+- [Transacciones](#transactions)
+- [Muchos-a-muchos](#many-to-many)
+- [JSON / JSONB](#json--jsonb)
+- [Borrado lógico (soft delete)](#soft-delete)
+- [Rastro de auditoría](#audit-trail)
+- [Válvula de escape a SQL crudo](#raw-sql-escape-hatch)
+- [Carga perezosa de FK](#lazy-fk-loading)
+- [Cuatro maneras de filtrar](#four-ways-to-filter)
+- [Consultas acotadas por tenant](#tenant-scoped-queries)
+- [Señales](#signals)
+- [Consejos de rendimiento](#performance-tips)
+
+---
+
+## Consultas
+
+Lee filas de la base de datos. `Post::objects()` inicia una consulta (como `Post.objects` de Django); encadenas filtros y ordenamiento, luego llamas a `.fetch(&pool).await?` para ejecutarla y recuperar un `Vec<Post>`. `.where_(...)` añade una condición unida con AND.
+
+```rust
+use rustango::core::Column as _;
+use rustango::core::{Op, SqlValue, WhereExpr};   // for filter_op / where_raw below
+use rustango::sql::FetcherPool as _;
+
+// Simplest — fetch all
+let posts = Post::objects().fetch(&pool).await?;
+
+// Single equality filter
+let drafts = Post::objects()
+    .where_(Post::status.eq("draft"))
+    .fetch(&pool).await?;
+
+// Chained filters (AND)
+let recent_drafts = Post::objects()
+    .where_(Post::status.eq("draft"))
+    .where_(Post::author_id.eq(42))
+    .where_(Post::deleted_at.is_null())
+    .order_by(&[("created_at", true)])        // true = DESC
+    .limit(20)
+    .fetch(&pool).await?;
+
+// String-keyed filter (validated at compile of the queryset)
+let by_id = Post::objects()
+    .filter_op("id", Op::Eq, SqlValue::I64(42))
+    .fetch(&pool).await?;
+
+// OR / nested
+let qs = Post::objects().where_raw(WhereExpr::Or(vec![
+    Post::status.eq("draft").into(),
+    Post::status.eq("review").into(),
+]));
+
+// XOR — Django 4.1+ `Q(a) ^ Q(b)`. Matches rows where an odd number
+// of operands evaluate to true (binary case = "exactly one is true").
+// Issue #27.
+let either_but_not_both = Post::objects()
+    .where_(Post::status.eq("draft").xor(Post::author_id.eq(42)))
+    .fetch(&pool).await?;
+// Tri-dialect emission: native logical XOR exists on MySQL but not PG
+// or SQLite, so the writer emits a portable rewrite uniformly —
+// `(a AND NOT b) OR (NOT a AND b)` for the binary form, or a
+// CASE-WHEN-1/0 tally `% 2 = 1` for N-ary chains.
+```
+
+### Filtros de comparación
+
+Los métodos de filtro cotidianos, uno por cada operador SQL. Estos son los field lookups de Django (`__gt`, `__in`, `__icontains`, etc.) en forma tipada.
+
+```rust
+Post::objects().where_(Post::view_count.gt(100)).fetch(&pool).await?;
+Post::objects().where_(Post::view_count.gte(100)).fetch(&pool).await?;
+Post::objects().where_(Post::view_count.lt(100)).fetch(&pool).await?;
+Post::objects().where_(Post::view_count.lte(100)).fetch(&pool).await?;
+Post::objects().where_(Post::status.ne("archived")).fetch(&pool).await?;
+Post::objects().where_(Post::id.is_in([1, 2, 3])).fetch(&pool).await?;
+Post::objects().where_(Post::status.not_in(["draft", "deleted"])).fetch(&pool).await?;
+Post::objects().where_(Post::title.like("%draft%")).fetch(&pool).await?;          // case-sensitive contains
+Post::objects().where_(Post::title.ilike("%draft%")).fetch(&pool).await?;         // case-insensitive contains
+Post::objects().where_(Post::title.ilike("Hello%")).fetch(&pool).await?;          // case-insensitive starts-with
+Post::objects().where_(Post::deleted_at.is_null()).fetch(&pool).await?;
+Post::objects().where_(Post::published_at.between(start, end)).fetch(&pool).await?;
+```
+
+### Ordenar resultados
+
+Ordena filas por una o más columnas, por una expresión, o con control explícito sobre dónde caen los NULL. Más allá del `.order_by(&[("col", desc)])` básico, obtienes tres dimensiones extra:
+
+```rust
+use rustango::core::funcs::lower;
+use rustango::core::{F, NullsOrder};
+
+// 1. Plain field + ASC/DESC (back-compat — implicit NULLS handling
+//    differs between dialects; see the dialect note below).
+Post::objects()
+    .order_by(&[("published_at", true), ("id", false)])
+    .fetch(&pool).await?;
+
+// 2. Explicit NULLS FIRST/LAST control — portable across PG, MySQL,
+//    and SQLite. MySQL has no native `NULLS …` keyword; the writer
+//    emulates with an `<col> IS NULL` pre-sort term so the on-wire
+//    ordering matches PG/SQLite.
+Post::objects()
+    .order_by_with_nulls(&[("score", true, NullsOrder::Last)])
+    .fetch(&pool).await?;
+
+// 3. Arbitrary Expr in the ORDER BY position — case-insensitive
+//    title sort via `LOWER(title)`, computed sort keys via
+//    `case() / when() / value()`, arithmetic via `F("a") + F("b")`.
+Post::objects()
+    .order_by_expr(lower(F("title")), false)
+    .order_by_expr_with_nulls(F("score") + 1_i64, true, NullsOrder::Last)
+    .fetch(&pool).await?;
+```
+
+**Manejo de NULL por dialecto (sin `NullsOrder` explícito establecido):**
+
+| Dialecto | Predeterminado ASC | Predeterminado DESC |
+|---|---|---|
+| PostgreSQL | NULLS LAST | NULLS FIRST |
+| SQLite | NULLS LAST | NULLS FIRST |
+| MySQL | NULLs primero (semántica de valor-más-pequeño) | NULLs al final |
+
+Usa `.order_by_with_nulls(...)` / `.order_by_expr_with_nulls(...)` para fijar la ubicación; de lo contrario se aplica el valor predeterminado nativo de la base de datos. En MySQL el writer emite `<col> IS NULL <asc|desc>` por delante del ordenamiento real para emular; el SQL emitido tiene dos términos ORDER BY por columna fijada, pero la semántica coincide con PG/SQLite.
+
+**Composición de la cadena.** `.order_by(...)`, `.order_by_with_nulls(...)` y `.order_by_expr(...)` se acumulan en una lista unificada en **orden de registro**. `.replace_order_by(&[...])` limpia toda llamada de order-by previa. `.flip_order_by()` invierte cada dirección Y también intercambia `NullsOrder::First` ↔ `NullsOrder::Last` para que la semántica de "NULLs en el mismo extremo" sobreviva a una inversión (para `First` / `Last` explícitos; el comportamiento predeterminado del dialecto bajo `Default` sigue rastreando la dirección).
+
+### Ordenamiento aleatorio
+
+Devuelve las filas en orden aleatorio — el `.order_by('?')` de Django. Usa `.order_random()`. Emite `ORDER BY RANDOM()` en PG y SQLite, `ORDER BY RAND()` en MySQL. Práctico para rotación de banners, muestreo o asignación de buckets de tests A/B sin traer las filas a la aplicación para barajarlas.
+
+```rust
+// Three random posts.
+Post::objects()
+    .order_random()
+    .limit(3)
+    .fetch(&pool).await?;
+
+// Random tie-breaker after a primary sort: posts ordered by score
+// descending, with ties shuffled.
+Post::objects()
+    .order_by(&[("score", true)])
+    .order_random()
+    .fetch(&pool).await?;
+```
+
+La variante de IR no lleva dirección ni cláusula NULLS: el ordenamiento aleatorio es no-ordenado por definición, y la clave aleatoria se calcula por fila (no-NULL).
+
+**Advertencia de rendimiento.** `ORDER BY RANDOM()` fuerza un **escaneo completo de tabla + ordenamiento en memoria por una clave aleatoria por fila**. El planificador de consultas no puede usar un índice. Para tablas mucho más grandes que la memoria, prefiere el patrón amigable con los índices:
+
+```rust
+// Coin-flip offset; range-scans the PK index.
+let max_id: i64 = Post::objects().max::<i64>("id", &pool).await?.unwrap_or(0);
+let offset = rand::random::<u32>() as i64 % max_id.max(1);
+Post::objects()
+    .where_(Post::id.gte(offset))
+    .order_by(&[("id", false)])
+    .limit(1)
+    .fetch(&pool).await?;
+```
+
+La contrapartida: la adyacencia en las filas del resultado refleja la adyacencia de la PK, así que no es "uniformemente aleatorio" en sentido estricto — pero está libre del costo del escaneo completo de tabla.
+
+### Paginación
+
+Trae una página de resultados a la vez. `.limit(size).offset(...)` es la forma simple por número de página; la forma con cursor ("todo lo que sigue al último id que vi") escala mejor en tablas grandes.
+
+```rust
+// Page-number — page 2 of 50-row pages = LIMIT 50 OFFSET 50.
+let page = Post::objects().limit(50).offset(50).fetch(&pool).await?;
+
+// Cursor (manual — no auto-next-token from QuerySet)
+let next = Post::objects()
+    .where_(Post::id.gt(last_id))
+    .order_by(&[("id", false)])
+    .limit(50)
+    .fetch(&pool).await?;
+```
+
+Para paginación con cursor del lado HTTP, usa `ViewSet::cursor_pagination("id")` en su lugar.
+
+### Traer filas a un mapa
+
+Busca muchas filas por una lista de valores y recupéralas como un `HashMap` indexado por esa columna. Este es el `in_bulk(ids, field_name=)` de Django. Usa `.in_bulk(...)` para "trae estas N filas en un solo viaje de ida y vuelta, indexadas por id". Un `HashMap<K, V>` es el diccionario / tabla hash de Rust.
+
+```rust
+use std::collections::HashMap;
+use rustango::sql::Auto;
+
+// Default Django shape: keyed by the Auto<i64> PK.
+let books: HashMap<i64, Book> = Book::objects()
+    .in_bulk(Book::id, [1_i64, 2, 3], |b| match b.id {
+        Auto::Set(v) => v,
+        Auto::Unset  => unreachable!("fetched row has Auto::Set PK"),
+    }, &pool)
+    .await?;
+assert_eq!(books[&1].title, "The Rust Programming Language");
+
+// `field_name=` equivalent — key by any unique column.
+let by_isbn: HashMap<String, Book> = Book::objects()
+    .in_bulk(Book::isbn, ["isbn-1".to_string()], |b| b.isbn.clone(), &pool)
+    .await?;
+```
+
+Se compone con filtros `.where_()` previos — la lista `IN` se une con AND al WHERE existente. Un `ids` vacío hace un corto-circuito con un mapa vacío (no se emite SQL). El closure maneja el desempaquetado de `Auto<T>` / `ForeignKey<T, K>` explícitamente, dando a quien llama control sobre cómo se materializa la clave.
+
+Hermano acotado por tenant: `in_bulk_on(column, ids, extract, &executor)` acepta cualquier executor de sqlx — combínalo con `tenant.conn()` para tenants en modo schema.
+
+### Bloquear filas para actualización
+
+Bloquea las filas que seleccionas para que ninguna otra transacción pueda cambiarlas hasta que confirmes — la forma estándar de reclamar trabajo o prevenir actualizaciones perdidas. Este es el `select_for_update(skip_locked=, nowait=, of=, no_key=)` de Django. Llama a `.select_for_update()`; añade `SELECT … FOR UPDATE` (o una variante) y el bloqueo dura mientras dure la transacción circundante.
+
+```rust
+// Canonical "claim next available row" pattern. Worker A grabs the
+// lowest-priority pending job; concurrent worker B with SKIP LOCKED
+// skips A's row and grabs the next instead — no blocking.
+let mut tx = pool.begin().await?;
+let claim: Vec<Job> = Job::objects()
+    .where_(Job::status.eq("pending"))
+    .order_by(&[("priority", false)])
+    .limit(1)
+    .select_for_update()
+    .skip_locked()
+    .fetch_on(&mut *tx).await?;
+// ... mark claim[0] as in-progress, do work ...
+tx.commit().await?;
+```
+
+**Métodos del builder** — encadena para optar por ellos:
+
+- `.select_for_update()` — `FOR UPDATE` simple.
+- `.skip_locked()` — añade `SKIP LOCKED`; las filas retenidas por otra tx se filtran silenciosamente en lugar de bloquear.
+- `.nowait()` — añade `NOWAIT`; expone un error del driver de inmediato si cualquier fila coincidente está bloqueada. Mutuamente excluyente con `skip_locked` (el writer elige el más permisivo `SKIP LOCKED` si ambos están establecidos).
+- `.no_key()` — emite `FOR NO KEY UPDATE` en su lugar (PG 9.3+). Bloqueo más débil que no bloquea a escritores que tocan solo columnas que no son clave.
+- `.of(&["table_or_alias", …])` — restringe el bloqueo a tablas específicas cuando la consulta hace JOIN.
+
+Llamar a `.skip_locked()` / `.nowait()` / `.no_key()` / `.of(…)` sin un `.select_for_update()` previo habilita el bloqueo implícitamente, coincidiendo con la ergonomía de Django.
+
+**Comportamiento tri-dialecto:**
+
+| Dialecto | Comportamiento |
+|---|---|
+| PostgreSQL | Soporte completo — cada flag emite su sintaxis nativa. |
+| MySQL 8.0.1+ | Soporta todo excepto `NO KEY` — ese flag recae en `FOR UPDATE` simple (el bloqueo más estricto). |
+| SQLite | Sin sintaxis de bloqueo a nivel de fila. El writer no emite ninguna cláusula; las transacciones mantienen un bloqueo de escritura implícito sobre toda la base de datos. Usa una estrategia distinta para SQLite (típicamente un bucle busy-wait sobre la transacción misma). |
+
+**Debe ejecutarse dentro de una transacción.** `FOR UPDATE` fuera de una tx es un no-op en PostgreSQL (la tx implícita de una sola sentencia libera el bloqueo de inmediato) y un error en MySQL. Combínalo con `pool.begin()` (o `rustango::sql::atomic`).
+
+### Combinar consultas (unión, intersección, diferencia)
+
+Fusiona dos o más consultas sobre el mismo modelo con operadores de conjunto de SQL. Estos son `.union()`, `.intersection()` y `.difference()` de Django.
+
+```rust
+// Posts that are EITHER drafts OR currently in review.
+let inbox: Vec<Post> = Post::objects()
+    .where_(Post::status.eq("draft"))
+    .union(Post::objects().where_(Post::status.eq("review")))
+    .order_by(&[("created_at", true)])
+    .limit(50)
+    .fetch(&pool).await?;
+```
+
+**Métodos del builder**:
+
+| Método | SQL | Semántica |
+|---|---|---|
+| `.union(other)` | `UNION` | Combinar + deduplicar |
+| `.union_all(other)` | `UNION ALL` | Combinar, conservar duplicados (más barato, sin pasada DISTINCT) |
+| `.intersection(other)` | `INTERSECT` | Filas en AMBOS querysets |
+| `.difference(other)` | `EXCEPT` | Filas en el primer queryset pero NO en los otros |
+
+Cada método toma un `QuerySet<T>` — ambas ramas deben apuntar al mismo modelo `T`, así que la forma de columnas coincide por construcción (verificado en tiempo de compilación por los genéricos de Rust). Las llamadas se acumulan; mezclar operadores en una sola cadena está permitido (`a.union(b).intersection(c)` se evalúa de izquierda a derecha según el estándar SQL).
+
+**Los modificadores externos se aplican al resultado fusionado**:
+
+```rust
+// Outer .order_by() / .limit() / .offset() / .select_for_update()
+// set AFTER the union apply to the combined resultset, NOT per-branch.
+let page: Vec<Post> = qs_a
+    .union(qs_b)
+    .union(qs_c)
+    .order_by(&[("id", false)])    // sorts the merged rows
+    .limit(20)                     // caps the merged count
+    .offset(40)                    // skips into the merged result
+    .fetch(&pool).await?;
+
+// Per-branch ORDER BY / LIMIT stay INSIDE the branch's parens:
+let mixed = qs_a
+    .union(qs_b.order_by(&[("id", true)]).limit(5))   // branch picks its top 5
+    .fetch(&pool).await?;
+```
+
+**Tri-dialecto**: PostgreSQL + SQLite soportan los cuatro operadores en todas las versiones que **Rustango** soporta. MySQL 8.0+ soporta `UNION`/`UNION ALL`; `INTERSECT`/`EXCEPT` llegaron en MySQL 8.0.31. Las versiones más antiguas de MySQL exponen el error de sintaxis del driver en el momento del fetch — no hay un gate del lado del cliente.
+
+**Camino de error en el builder tipado**: `.union(other_qs)` (y `.intersection()` / `.difference()`) compila la rama de forma anticipada y hace panic si la rama no compila (columna con errata, etc.). Para composición falible donde quien llama quiere un `Result`, compila la rama primero y pásala vía `.with_compound(SetOp::Union, branch)` — un único punto de entrada genérico cubre todos los operadores. La forma del panic coincide con la de Django: una rama incorrecta es un error de programador, no una condición de datos en tiempo de ejecución.
+
+### Streaming de conjuntos de resultados grandes
+
+Procesa una tabla enorme sin cargarla toda en memoria. Este es el `.iterator(chunk_size=2000)` de Django. Llama a `.iterator(chunk_size)`; trae `chunk_size` filas a la vez (vía `LIMIT N OFFSET M`) y nunca almacena en búfer el conjunto de resultados completo. Recurre a ella en exportaciones de millones de filas, pipelines de ETL y trabajos por lotes.
+
+```rust
+// 1. Whole-chunk loop — process N rows at a time.
+let mut iter = Post::objects()
+    .where_(Post::published.eq(true))
+    .order_by(&[("id", false)])
+    .iterator(2_000)?;
+while let Some(chunk) = iter.next_chunk(&pool).await? {
+    for post in chunk { /* … */ }
+}
+
+// 2. Row-by-row loop — buffer one chunk internally, yield one row.
+let mut iter = Post::objects().order_by(&[("id", false)]).iterator(2_000)?;
+while let Some(post) = iter.next_row(&pool).await? {
+    /* … */
+}
+```
+
+**Establece un `order_by`.** `OFFSET` contra una consulta sin un ordenamiento estable devuelve filas impredecibles entre chunks — típicamente `.order_by(&[("pk", false)])` para que cada chunk se recoja limpiamente. El método no impone el ordenamiento (algunas consultas legítimamente no quieren ordenamiento, p. ej. un vaciado de un solo tiro), pero iterar sin ordenar es un peligro latente.
+
+**Contrapartida frente a los cursores del lado del servidor.** Esto es un simple fragmentador con LIMIT/OFFSET. Sobre una columna de ordenamiento indexada con btree, PostgreSQL escanea las primeras N filas antes de devolver la (N+1)-ésima — así que la paginación profunda es un trabajo total de `O(n²)`. Para un vaciado de 10M filas esto importa; para 100k filas normalmente no. El fragmentador gana en portabilidad (funciona en todos los backends sin sobrecarga de transacciones) y simplicidad (sin gestión del ciclo de vida del cursor). Para lecturas verdaderamente en streaming en PG, baja a `pool.begin()` + la API Stream cruda `sqlx::query(...).fetch(&mut *tx)` directamente — el protocolo extendido hace streaming desde el servidor sin re-búsqueda por offset.
+
+**Mezclar `next_chunk` y `next_row` en el mismo iterador es seguro.** El búfer interno `VecDeque` se drena en orden de fila antes de cualquier nuevo fetch de BD, así que `next_chunk` tras un vaciado parcial de `next_row` produce primero las filas restantes en búfer, y luego continúa con chunks nuevos.
+
+Tanto `.rows_seen()` (conteo acumulado) como `.is_exhausted()` (bandera post-vaciado) están disponibles para reportar progreso y para comprobaciones de terminación.
+
+**Peligro de escritura concurrente.** Cada chunk es una consulta separada, así que las filas insertadas/eliminadas entre chunks pueden omitirse o duplicarse (el clásico problema de "ventanas" de la paginación con OFFSET). Para tablas de solo-lectura / solo-append — el caso de uso típico de exportación — esto no es una preocupación. Para tablas que se escriben de forma concurrente necesitas una transacción con aislamiento de snapshot para que cada chunk vea la misma vista. **`ChunkedIter` toma `&Pool`, no un `&mut Transaction`, así que la API del fragmentador no se puede usar dentro de la tx directamente** — en su lugar, haz a mano el SELECT fragmentado contra la tx:
+
+```rust
+let mut tx = pool.begin().await?;
+sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+    .execute(&mut *tx).await?;
+
+// Hand-loop LIMIT/OFFSET chunks against the tx with `.fetch_on(&mut *tx)`,
+// so every chunk reads from the same snapshot.
+let chunk_size = 2_000_i64;
+let mut offset = 0_i64;
+loop {
+    let rows: Vec<Post> = Post::objects()
+        .order_by(&[("id", false)])
+        .limit(chunk_size)
+        .offset(offset)
+        .fetch_on(&mut *tx)
+        .await?;
+    if rows.is_empty() { break; }
+    for post in &rows { /* … */ }
+    if (rows.len() as i64) < chunk_size { break; }
+    offset += rows.len() as i64;
+}
+tx.commit().await?;
+```
+
+**`select_for_update()` no se propaga entre chunks.** Los bloqueos de fila retenidos por `.select_for_update()` se liberan al final de la transacción implícita de cada chunk. No hay un arreglo con forma de fragmentador: el builder `.iterator()` toma `&Pool`, las variantes de bloqueo necesitan un `&mut Transaction`, y los dos no se componen. Para un vaciado con bloqueo tienes dos caminos, cada uno con una contrapartida:
+
+- **`.fetch_on(&mut *tx)` de todo el resultado** — un solo viaje de ida y vuelta, el `Vec<T>` completo en memoria. Está bien cuando el resultado cabe.
+- **LIMIT/OFFSET a mano dentro de la tx** — la misma forma que el fragmento de aislamiento de snapshot de arriba; los chunks se mantienen en streaming pero estás fuera de la API `ChunkedIter`.
+
+Un futuro compañero `iterator_on(&mut *tx, chunk_size)` (seguimiento en un issue) cerraría esta brecha. Fuera de alcance para el issue #23.
+
+**`chunk_size` debe ser > 0.** Los valores cero o negativos hacen panic. Elige un valor que quepa en tu presupuesto de tamaño de fila (el predeterminado de Django es `2000`; razonable para filas estrechas, más bajo para columnas anchas TEXT/JSONB).
+
+### Seleccionar columnas específicas
+
+Trae solo unas pocas columnas en lugar de structs `Post` completos — los `.values('col')` y `.values_list('col', flat=True)` de Django. Úsalos cuando solo necesitas un par de columnas de una tabla ancha, o cuando el resultado alimenta código dinámico (plantillas, exportación a CSV, JSON). Recuperas mapas, tuplas o una lista tipada plana en lugar de instancias del modelo.
+
+```rust
+use rustango::core::SqlValue;
+use std::collections::HashMap;
+
+// 1. Column-keyed map per row — Django's `.values('id', 'title')`.
+let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+    .where_(Post::published.eq(true))
+    .order_by(&[("id", false)])
+    .values_dict(&["id", "title"])
+    .fetch(&pool).await?;
+
+// 2. Ordered tuple per row — Django's `.values_list('id', 'title')`.
+//    Cell ordering matches the column-list argument.
+let rows: Vec<Vec<SqlValue>> = Post::objects()
+    .values_list(&["title", "id"])  // title first, id second
+    .fetch(&pool).await?;
+
+// 3. Single-column typed scalar — Django's `.values_list('id', flat=True)`.
+//    Returns Vec<U> directly via sqlx's typed scalar path.
+let ids: Vec<i64> = Post::objects()
+    .where_(Post::published.eq(true))
+    .values_list_flat("id")
+    .fetch::<i64>(&pool).await?;
+```
+
+**Tres builders, un IR.** Los tres establecen `SelectQuery::projection` a la lista de columnas validada — el SQL es idéntico entre las tres formas terminales; solo difiere la decodificación de fila:
+
+| Builder | Forma SQL | Devuelve |
+|---|---|---|
+| `.values_dict(&[cols])` | `SELECT col1, col2 FROM …` | `Vec<HashMap<String, SqlValue>>` |
+| `.values_list(&[cols])` | `SELECT col1, col2 FROM …` | `Vec<Vec<SqlValue>>` (ordenado por `cols`) |
+| `.values_list_flat(col)` | `SELECT col FROM …` | `Vec<U>` (tipado, vía `fetch::<U>(...)`) |
+
+**Funciona con el resto de la cadena de consulta.** `.where_()`, `.filter()`, `.order_by()`, `.limit()`, `.offset()` y los operadores de conjunto (`.union()` / `.intersection()` / `.difference()`) — cada método llamado ANTES de `.values_*` se propaga. Los builders de values son terminales (nada se encadena después de ellos), así que establece la forma de la consulta primero y luego trae.
+
+**Validación en el momento de `.compile()` / `.fetch()`:**
+- Lista de columnas vacía (`.values_dict(&[])`) → [`QueryError::EmptyValuesProjection`].
+- Nombre de columna con errata (`.values_dict(&["nope"])`) → [`QueryError::UnknownField`].
+
+**Tri-dialecto: emisión de proyección idéntica entre PG / MySQL / SQLite** (solo difiere el entrecomillado de identificadores). Para `.values_list_flat::<U>(...)`, `U` debe implementar `Decode + Type` de sqlx en cada backend que el binario tenga como objetivo — las opciones comunes (`i64`, `i32`, `String`, `bool`, `f64`) funcionan universalmente.
+
+**¿Por qué no cambiar el `.values()` existente para hacer proyección pura?** `QuerySet::values(cols)` ya asciende a [`AggregateBuilder`] para el camino de auto-inferencia de GROUP BY (issue #75). Renombrarlo rompería ~20 sitios de llamada existentes. Los nuevos métodos de cadena `.values_dict()` / `.values_list()` / `.values_list_flat()` conviven junto a él, dejando el camino de agregación intacto. El error preexistente `QueryError::ValuesRequiresAggregate` sigue disparándose para `.values(cols).compile()` sin un `.annotate(...)` posterior — su mensaje ahora dirige a quien llama hacia los nuevos métodos de proyección pura.
+
+### Incluir o excluir columnas
+
+Misma idea que la sección anterior, pero en la forma include/exclude de Django: `.only('id', 'name')` conserva solo las columnas nombradas, `.defer('big_field')` conserva todo excepto esas. Úsalos en tablas anchas donde columnas grandes TEXT / BLOB / JSONB hacen que las vistas de lista sean caras de leer:
+
+```rust
+// .only(...) — fetch only the named columns.
+let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+    .where_(Post::published.eq(true))
+    .only(&["id", "title"])
+    .fetch(&pool).await?;
+
+// .defer(...) — fetch everything except the named columns.
+// Useful for "list view: skip body / metadata / large JSON".
+let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
+    .defer(&["body", "raw_html"])
+    .fetch(&pool).await?;
+```
+
+**Semántica**: `.only(&[cols])` es un sinónimo de `.values_dict(cols)` — mismo IR, misma forma de retorno, punto de entrada separado para legibilidad con forma de Django. `.defer(&[cols])` calcula el complemento contra el schema del modelo (cada columna escalar del modelo EXCEPTO las listadas) y encamina al mismo camino.
+
+**Salvedad — el tipo de retorno difiere del de Django.** Los `.only()` / `.defer()` de Django devuelven instancias `Model` parcialmente hidratadas donde los campos diferidos se cargan de forma perezosa al acceder al atributo. **Rustango** no tiene equivalente de la magia de descriptores de Python; la forma de retorno es `Vec<HashMap<String, SqlValue>>` (o `Vec<Vec<SqlValue>>` si intercambias por `.values_list(...)` en su lugar). La decodificación tipada de fila parcial está en cola para una futura entrega.
+
+**Seguridad ante erratas**: `.defer(&["nope_col"])` expone `QueryError::UnknownField` en el momento de `.compile()` — la errata no se convierte silenciosamente en "proyecta todas las columnas". `.only(&[])` expone `QueryError::EmptyValuesProjection`; `.defer(&[])` es un no-op semántico (proyecta todas las columnas).
+
+### Coincidencia con expresiones regulares
+
+Compara una columna contra un patrón regex — los `__regex` / `__iregex` de Django. `.regex()` distingue mayúsculas/minúsculas, `.iregex()` no las distingue, y `.not_regex()` / `.not_iregex()` son las formas negadas.
+
+```rust
+use rustango::core::Column as _;
+
+// Names starting with "al" (case-sensitive).
+User::objects()
+    .where_(User::name.regex("^al.*"))
+    .fetch(&pool).await?;
+
+// Names starting with "al" — case-insensitive.
+User::objects()
+    .where_(User::name.iregex("^al.*"))
+    .fetch(&pool).await?;
+
+// Negated: exclude names starting with "admin" (case-sensitive).
+User::objects()
+    .where_(User::name.not_regex("^admin"))
+    .fetch(&pool).await?;
+
+// Django-shape lookup-suffix form.
+User::objects()
+    .filter("name__iregex", "^bob")
+    .fetch(&pool).await?;
+```
+
+**Emisión tri-dialecto**:
+
+| Dialecto | Sensible a mayúsculas | Insensible a mayúsculas | Notas |
+|---|---|---|---|
+| PostgreSQL | `<col> ~ ?` / `<col> !~ ?` | `<col> ~* ?` / `<col> !~* ?` | Operadores POSIX nativos |
+| MySQL | `` `col` REGEXP ? `` / `` `col` NOT REGEXP ? `` | `LOWER(`col`) REGEXP LOWER(?)` (negado envuelve en `NOT`) | Fallback con LOWER() para `i*` |
+| SQLite | `"col" REGEXP ?` / `"col" NOT REGEXP ?` | `LOWER("col") REGEXP LOWER(?)` (negado envuelve en `NOT`) | Necesita la función de usuario `regexp` cargada en la conexión |
+
+**SQLite requiere una función de usuario `regexp` registrada** — no está incorporada. sqlx-sqlite 0.8 **no** registra una por defecto. Dos caminos para habilitarla:
+
+1. **Fácil** — habilita la característica cargo `regexp` de sqlx-sqlite, luego opta por ella en la conexión:
+   ```rust
+   use sqlx::sqlite::SqliteConnectOptions;
+   let opts = SqliteConnectOptions::new()
+       .filename("app.db")
+       .with_regexp();  // gated on sqlx-sqlite/regexp
+   ```
+2. **Manual** — registra un closure de Rust vía `SqliteConnection::lock_handle()` + FFI cruda (`sqlite3_create_function_v2`).
+
+Sin una, la consulta emite SQL `REGEXP` válido que SQLite rechaza en ejecución con `no such function: regexp` (limpio para el parser — `tests/regex_sqlite_live.rs` fija esto).
+
+**El dialecto de patrón difiere entre backends.** PostgreSQL usa regex extendida POSIX; MySQL usa regex basada en ICU con su propio sabor; SQLite delega a lo que sea que implemente la función de usuario (típicamente el crate `regex` de Rust). Los patrones que se apoyan en sintaxis específica del dialecto (p. ej. los límites de palabra `\m` / `\M` de PG) no son intercambiables — mantente en el subconjunto portable (`^`, `$`, `.`, `*`, `+`, `?`, `[...]`, `()`, `|`) si el mismo modelo se consulta desde múltiples backends.
+
+**Los valores no-string se rechazan en `.compile()`** — pasar `SqlValue::I64(42)` a `__regex` expone `QueryError::InvalidLookupValue { suffix: "regex", expected: "SqlValue::String(<regex pattern>)", … }` en lugar de convertir silenciosamente.
+
+---
+
+## Valores calculados y funciones de base de datos
+
+Deja que la base de datos calcule cosas en lugar de traer filas a la aplicación, mutarlas y escribirlas de vuelta. `F("col")` se refiere a una columna por nombre (el objeto `F()` de Django), y los builders `funcs::*` envuelven funciones SQL escalares como `LOWER` o `COALESCE`. Juntos desbloquean tres patrones que el `.set()` / `.where_()` basado en valores simples no puede expresar:
+
+### Incrementos atómicos (sin carrera de leer-modificar-escribir)
+
+El clásico bug del contador — traer una fila, incrementar un campo, guardar — pierde actualizaciones cuando dos peticiones se ejecutan a la vez. `F("col") + 1` colapsa el viaje de ida y vuelta en un solo `UPDATE`, así que la base de datos mantiene el bloqueo de fila por ti:
+
+```rust
+use rustango::core::F;
+
+Post::objects()
+    .eq("id", post_id)
+    .update()
+    .set_expr("view_count", F("view_count") + 1_i64)
+    .execute(&pool).await?;
+```
+
+Tri-dialecto: emite `views = ("views" + $1)` en PG, ``views = (`views` + ?)`` en MySQL, idéntico en SQLite. La aritmética se pone entre paréntesis para que las operaciones anidadas se mantengan sin ambigüedad: `F("a") + F("b") * 2`.
+
+Operadores soportados: `+ - * / %` más `& | ^ << >>` (a nivel de bits; XOR en SQLite emite un claro `OpNotSupportedInDialect` ya que SQLite no tiene símbolo XOR).
+
+### Comparar dos columnas en un filtro
+
+Filtra una columna contra otra, no contra un literal — p. ej. `Reservation start_date < end_date` para validar la coherencia de una fila, o `Inventory available > reserved` para encontrar filas con capacidad:
+
+```rust
+use rustango::core::Column as _;
+
+// `start_date < end_date` for every selected row.
+let valid = Reservation::objects()
+    .where_(Reservation::start_date.lt_expr(F("end_date")))
+    .fetch(&pool).await?;
+
+// Combine with literal predicates.
+let oversold = Inventory::objects()
+    .where_(Inventory::available.lt_expr(F("reserved")))
+    .where_(Inventory::active.eq(true))
+    .fetch(&pool).await?;
+```
+
+La familia `*_expr` — `eq_expr`, `ne_expr`, `lt_expr`, `lte_expr`, `gt_expr`, `gte_expr` — refleja los métodos literales `eq`, `ne`, … pero toma cualquier `impl Into<Expr>` en el lado derecho: referencias de columna simples (`F("col")`), aritmética (`F("price") * 2`), o resultados de función (siguiente sección).
+
+### Funciones escalares — texto, matemáticas, manejo de NULL
+
+`rustango::core::funcs` incluye builders para las funciones SQL más usadas. Las 17 disponibles hasta ahora:
+
+| Grupo | Builders |
+|---|---|
+| **Texto** | `lower`, `upper`, `length`, `trim`, `ltrim`, `rtrim`, `concat`, `substr`, `replace` |
+| **Matemáticas** | `abs`, `ceil`, `floor`, `round` (1 arg) / `round_to` (precisión de 2 args) |
+| **NULL** | `coalesce`, `greatest`, `least`, `nullif` |
+
+```rust
+use rustango::core::funcs::{lower, upper, concat, coalesce, trim, abs, round};
+use rustango::core::F;
+
+// Normalize on write.
+User::objects()
+    .eq("id", id)
+    .update()
+    .set_expr("email", lower(trim(F("email"))))
+    .execute(&pool).await?;
+
+// Build a derived column from two FKs + a literal.
+User::objects()
+    .update()
+    .set_expr(
+        "display_name",
+        concat([F("first").into(), " ".into(), F("last").into()]),
+    )
+    .execute(&pool).await?;
+
+// First non-NULL fallback.
+User::objects()
+    .update()
+    .set_expr(
+        "label",
+        coalesce([F("nickname").into(), F("username").into(), "anonymous".into()]),
+    )
+    .execute(&pool).await?;
+
+// Function on the WHERE rhs.
+User::objects()
+    .where_(User::email_norm.eq_expr(lower(F("email_norm"))))
+    .fetch(&pool).await?;
+
+// Functions compose freely — `abs(round(F("score") * 100))` is one Expr.
+Player::objects()
+    .update()
+    .set_expr("score_int", abs(round(F("score") * 100_f64)))
+    .execute(&pool).await?;
+```
+
+### Comportamiento tri-dialecto
+
+La mayoría de las funciones emiten SQL idéntico entre PG / MySQL / SQLite. Las formas divergentes se manejan por dialecto de forma transparente:
+
+| Builder | PG | MySQL | SQLite |
+|---|---|---|---|
+| `concat([a, b])` | `CONCAT(a, b)` | `CONCAT(a, b)` | `(a \|\| b)` |
+| `substr(s, 1, 3)` | `SUBSTRING(s FROM 1 FOR 3)` | `SUBSTRING(s, 1, 3)` | `SUBSTR(s, 1, 3)` |
+| `greatest([a, b])` | `GREATEST(a, b)` | `GREATEST(a, b)` | `MAX(a, b)` escalar |
+| `least([a, b])` | `LEAST(a, b)` | `LEAST(a, b)` | `MIN(a, b)` escalar |
+
+### Pasar argumentos mixtos a una función
+
+Las funciones que toman una lista de argumentos (como `concat`) aceptan cualquier iterable de `Expr`. Los arrays de Rust deben contener un solo tipo, así que una mezcla de `F` (columna) y `&str` (literal) no verificará por sí sola — llama a `.into()` una vez por elemento para elevar cada uno a un `Expr`:
+
+```rust
+concat([F("first").into(), " ".into(), F("last").into()])
+//          ^^^^^^ each element lifted to Expr
+```
+
+O construye un `Vec<Expr>` y pásalo directamente — misma forma, mismo resultado.
+
+### Salvedades
+
+- **`length` byte-vs-carácter**: PG devuelve caracteres en `TEXT`/`VARCHAR`, MySQL devuelve **bytes** (usa el futuro builder `CharLength` del framework o envuelve en `CHAR_LENGTH` manualmente si necesitas conteos de caracteres entre dialectos).
+- **`round(x, n)` en PG**: la forma de 2 args de PG requiere `numeric`, no `double`. O pasa una columna entera o castea el float primero; MySQL y SQLite aceptan cualquiera de los tipos.
+- **`greatest([single_arg])` / `least([single_arg])` en SQLite**: no soportado — el `MAX(x)` de SQLite con un argumento es la forma *agregada*, no la escalar. El writer devuelve `OpNotSupportedInDialect`. PG y MySQL aceptan la forma de un solo argumento como un no-op que devuelve `x`. Envuelve con al menos un literal para mantenerte portable.
+- **`substr` con inicio negativo**: PG trata un negativo como "empieza desde la posición de carácter N" (efectivamente lo limita a 0); MySQL y SQLite tratan el negativo como "cuenta desde el final". Evita inicios negativos en código portable.
+
+### Funciones de fecha y hora
+
+Los builders `now()`, `extract_*` y `trunc_*` trabajan sobre fechas y timestamps. Úsalos para consultas de cohortes, agregados por bucket de tiempo y estampar la hora actual en la escritura — todo en la base de datos, sin hacer viajes de ida y vuelta de filas a través de la aplicación.
+
+```rust
+use rustango::core::funcs::{
+    now, trunc_date, trunc_month,
+    extract_year, extract_month, extract_weekday,
+};
+use rustango::core::F;
+
+// 1. Stamp server-side current time on write.
+Post::objects()
+    .eq("id", id)
+    .update()
+    .set_expr("published_at", now())
+    .execute(&pool).await?;
+
+// 2. Extract year / month / weekday into denormalized indexable
+// columns so cohort + day-of-week queries are cheap.
+Signup::objects()
+    .update()
+    .set_expr("bucket_year", extract_year(F("created_at")))
+    .set_expr("bucket_month", extract_month(F("created_at")))
+    .set_expr("weekday", extract_weekday(F("created_at")))
+    .execute(&pool).await?;
+
+// 3. Filter on the stored bucket — typed integer comparison, uses
+// the index, portable across all three dialects.
+let friday_signups = Signup::objects()
+    .where_(Signup::weekday.eq(5_i64))            // 5 = Friday (0=Sun)
+    .fetch(&pool).await?;
+
+// 4. For range filters where you'd be tempted to write
+// `created_at >= trunc_year(now())` directly: don't. The function
+// builders for `Trunc*` return text on MySQL/SQLite (see caveats
+// below), so a column-vs-trunc comparison in WHERE only behaves
+// well on PG. Compute the boundary in Rust instead and pass it as a
+// typed literal — works the same on every backend and uses the
+// index on `created_at`:
+use chrono::{Datelike, TimeZone};
+let this_year = chrono::Utc::now().year();
+let year_start = chrono::Utc.with_ymd_and_hms(this_year, 1, 1, 0, 0, 0).unwrap();
+
+let recent = Order::objects()
+    .where_(Order::created_at.gte(year_start))
+    .fetch(&pool).await?;
+
+// 5. `Trunc*` shines on the *write* side. `trunc_date` is the
+// one trunc-family builder with identical SQL on every dialect
+// (`DATE(x)`) — handy for grouping by day without the type-divergence
+// caveat the year/month variants carry.
+Order::objects()
+    .update()
+    .set_expr("day_bucket", trunc_date(F("created_at")))     // DATE column on every backend
+    .set_expr("month_bucket", trunc_month(F("created_at")))  // see caveat
+    .execute(&pool).await?;
+// `month_bucket` should be `TIMESTAMPTZ` on PG and `VARCHAR(10)` /
+// `TEXT` on MySQL/SQLite — parse client-side when reading if you
+// need a typed `chrono::NaiveDate`.
+```
+
+**Emisión por dialecto:**
+
+| Builder | PG | MySQL | SQLite |
+|---|---|---|---|
+| `now()` | `NOW()` | `NOW()` | `CURRENT_TIMESTAMP` |
+| `extract_year(x)` | `CAST(EXTRACT(YEAR FROM x) AS INTEGER)` | `YEAR(x)` | `CAST(strftime('%Y', x) AS INTEGER)` |
+| `extract_week(x)` ⚠ | `EXTRACT(WEEK FROM x)` — ISO 8601, rango 1–53 | `WEEK(x)` — inicio en domingo, rango **0**–53 | `strftime('%W', x)` — inicio en lunes, rango 00–53 |
+| `extract_weekday(x)` | `CAST(EXTRACT(DOW FROM x) AS INTEGER)` | `(DAYOFWEEK(x) - 1)` | `CAST(strftime('%w', x) AS INTEGER)` |
+| `extract_quarter(x)` | `EXTRACT(QUARTER FROM x)` | `QUARTER(x)` | **no soportado** — error |
+| `trunc_date(x)` | `DATE(x)` | `DATE(x)` | `DATE(x)` |
+| `trunc_year(x)` | `DATE_TRUNC('year', x)` → timestamp | `DATE_FORMAT(x, '%Y-01-01')` → **string** | `strftime('%Y-01-01', x)` → **string** |
+| `trunc_month(x)` | `DATE_TRUNC('month', x)` → timestamp | `DATE_FORMAT(x, '%Y-%m-01')` → **string** | `strftime('%Y-%m-01', x)` → **string** |
+| `trunc_day(x)` | `DATE_TRUNC('day', x)` → timestamp | `DATE(x)` → date | `date(x)` → text |
+
+**Salvedades específicas de fecha/hora:**
+
+- **El tipo de retorno de `trunc_year/month` diverge**: timestamp en PG, texto en MySQL/SQLite. Castea del lado de la aplicación al leer si necesitas un `chrono::NaiveDate` tipado — o guarda el bucket como un entero simple (`extract_year` + `extract_month`) y reconstrúyelo en código.
+- **`extract_weekday` está normalizado a 0 = domingo** en los tres dialectos. El `DAYOFWEEK()` nativo de MySQL devuelve 1=domingo, así que el writer resta 1.
+- **⚠ `extract_week` NO es portable.** PG devuelve números de semana ISO 8601 (inicio en lunes, rango 1–53); el `WEEK(x)` predeterminado de MySQL es inicio en domingo con rango **0**–53; el `strftime('%W')` de SQLite es inicio en lunes con rango 00–53. Para 2024-01-01 (un lunes), los tres backends devuelven `1`, `0` y `01` respectivamente. El código de un solo backend puede usarlo libremente; el código entre dialectos debería calcular el límite de la semana como un `chrono::DateTime` tipado en Rust y filtrar sobre la columna de timestamp en su lugar.
+- **`extract_quarter` en SQLite da error** con `OpNotSupportedInDialect` — SQLite no tiene un token nativo de trimestre. O bien pon la característica detrás de un `cfg(not(sqlite))` o calcula vía `((extract_month - 1) / 3) + 1` en código de aplicación.
+- **Manejo de zona horaria**: el `EXTRACT` de PG opera en la zona horaria de la columna; el `YEAR()` de MySQL opera en la zona horaria de la sesión (`SET time_zone = ...`); SQLite no tiene soporte real de TZ — trata todo como UTC. Usa `TIMESTAMPTZ` en PG, `DATETIME` en MySQL con la TZ de sesión establecida, strings ISO-8601 en SQLite.
+
+### Expresiones CASE WHEN
+
+Construye un `CASE WHEN … THEN … ELSE … END` de SQL con los builders `case()` / `.when()` / `value()` — los `Case`/`When` de Django. Úsalo para ordenamientos personalizados, columnas derivadas en `annotate`, valores predeterminados calculados en `update` y (combinado con `Sum`) agregados condicionales.
+
+```rust
+use rustango::core::case::{case, value};
+use rustango::core::{Column as _, F};
+use rustango::core::funcs::lower;
+
+// Custom ordering — published posts first, drafts last.
+Post::objects()
+    .update()
+    .set_expr(
+        "priority",
+        case()
+            .when(Post::status.eq("published"), 0_i64)
+            .when(Post::status.eq("review"), 1_i64)
+            .when(Post::status.eq("draft"), 2_i64)
+            .default(99_i64),
+    )
+    .execute(&pool).await?;
+
+let ordered = Post::objects()
+    .order_by(&[("priority", false), ("id", false)])
+    .fetch(&pool).await?;
+
+// Computed default on update — drafts get a lowercased title for
+// the label, everything else uses the title verbatim.
+Post::objects()
+    .update()
+    .set_expr(
+        "label",
+        case()
+            .when(Post::status.eq("draft"), lower(F("title")))
+            .default(F("title")),
+    )
+    .execute(&pool).await?;
+
+// AND / OR composition in the WHEN predicate.
+let viral = Post::status.eq("published").and(Post::views.gt(1_000_i64));
+Post::objects()
+    .update()
+    .set_expr(
+        "label",
+        case()
+            .when(viral, value("viral"))
+            .when(Post::status.eq("published"), value("live"))
+            .default(value("pending")),
+    )
+    .execute(&pool).await?;
+```
+
+**Forma del builder:**
+
+- `case()` — inicia un builder.
+- `.when(condition, then)` — añade una rama. `condition` es cualquier cosa `Into<WhereExpr>` (típicamente `Column::eq()`, `.and()`, `.or()`); `then` es cualquier cosa `Into<Expr>` (literal, `F()`, llamada de función, `case()` anidado).
+- `.default(expr)` — establece la rama opcional `ELSE`. Omitirla produce un `CASE` que devuelve `NULL` para las filas sin coincidencia (estándar SQL).
+- `.build()` o `.into()` — finaliza en un `Expr` para `set_expr` / `eq_expr` / `annotate`.
+- `value(literal)` — azúcar al estilo Django para `Expr::Literal(...)`. Opcional — los literales simples se convierten vía `Into<Expr>`, pero `value("…")` se lee explícitamente como "esto es un literal de string, no una referencia de columna".
+
+**Emisión tri-dialecto:**
+
+`CASE WHEN … THEN … [ELSE …] END` es estándar SQL-92 — emitido de forma idéntica entre PG, MySQL y SQLite. Sin despacho por dialecto en el writer.
+
+**Salvedades:**
+
+- **Ramas vacías**: `case().build()` sin llamadas a `.when(...)` se rechaza en el momento de emisión con `SqlError::EmptyCaseBranches`. SQL requiere al menos una cláusula `WHEN`. Una condición `WHEN` vacía (p. ej. `WhereExpr::And(vec![])`) se rechaza con `SqlError::EmptyCaseWhenCondition` por la misma razón.
+- **Unificación de tipos entre ramas**: cada dialecto elige un tipo común de los valores `THEN` y `ELSE`. Mezclar tipos (`THEN 1_i64` + `ELSE "string"`) puede lanzar un error de cast en tiempo de ejecución o convertir de forma sorprendente. Mantente en un solo tipo por `CASE`.
+- **Rendimiento**: cada fila evalúa los predicados `WHEN` en orden hasta que uno coincide (gana la primera coincidencia, por fila). El costo crece con el número de ramas y el costo de los predicados. Para muchos mapeos de string fijos, un join contra una pequeña tabla de búsqueda puede ser más barato y legible.
+
+### Subconsultas (EXISTS, IN, escalar)
+
+Incrusta una consulta dentro de otra — los `Exists`, `Subquery` y `OuterRef` de Django. Estos builders cubren la mayoría de los patrones de "¿existe una fila relacionada?" y "¿está este valor en ese conjunto?":
+
+| Builder | Forma | Úsalo para |
+|---|---|---|
+| `exists(qs)` | `EXISTS (SELECT … FROM …)` | "Autores que tienen al menos un libro" |
+| `not_exists(qs)` | `NOT EXISTS (SELECT …)` | "Autores sin libros" (anti-join) |
+| `in_subquery(col, qs)` | `<col> IN (SELECT …)` | "Posts en cualquier categoría pública" |
+| `not_in_subquery(col, qs)` | `<col> NOT IN (SELECT …)` | Inverso del anterior |
+| `subquery(qs)` | `(SELECT …)` como escalar | Valor predeterminado calculado en `set_expr` |
+| `outer_ref(col)` | `"<outer_table>"."<col>"` | Referenciar la fila externa desde dentro de cualquiera de los anteriores |
+
+```rust
+use rustango::core::subquery::{exists, not_exists, in_subquery, outer_ref};
+use rustango::core::{Column as _, WhereExpr};
+
+// "Authors with no books" — the canonical anti-join. Build the inner
+// queryset first so its compile() catches typos; embed via not_exists.
+let no_books = Book::objects()
+    .where_(Book::author_id.eq_expr(outer_ref("id")))
+    .compile()?;
+let orphans = Author::objects()
+    .where_raw(not_exists(no_books))
+    .fetch(&pool).await?;
+
+// "Authors who have a published book of more than 100 pages" — the
+// inner predicate combines a correlation (outer_ref) with literal
+// filters in the same WHERE.
+let inner = Book::objects()
+    .where_(Book::author_id.eq_expr(outer_ref("id")))
+    .where_(Book::status.eq("published"))
+    .where_(Book::pages.gt(100_i64))
+    .compile()?;
+let long_writers = Author::objects()
+    .where_raw(exists(inner))
+    .fetch(&pool).await?;
+
+// Compose EXISTS with an OR.
+let inner = Book::objects()
+    .where_(Book::author_id.eq_expr(outer_ref("id")))
+    .compile()?;
+let featured = Author::objects()
+    .where_raw(WhereExpr::Or(vec![
+        Author::name.eq("Carol").into(),
+        exists(inner),
+    ]))
+    .fetch(&pool).await?;
+```
+
+**La correlación anidada funciona.** OuterRef dentro de una subconsulta doblemente anidada se resuelve al ámbito envolvente *inmediato* — el writer mantiene una pila de ámbitos a medida que desciende, así que `EXISTS (Book WHERE id = outer.id AND EXISTS (Comment WHERE book_id = outer.id))` resuelve el `outer.id` interno a `Book.id`, no al `Author.id` más externo. Usa `outer_ref(...)` dos veces si realmente necesitas alcanzar dos ámbitos hacia arriba.
+
+**Errores:**
+
+- **`OuterRefOutsideSubquery`** — emitir `outer_ref("col")` en el nivel superior (no dentro de ningún envoltorio de subconsulta) es un error de programación. El writer lo señala ruidosamente con el nombre de la columna para que el sitio de llamada sea fácil de encontrar.
+
+**Salvedades:**
+
+- **Estrechamiento de proyección de `IN (SELECT …)`**: PG requiere estrictamente que el SELECT interno proyecte exactamente una columna para la forma `<col> IN (…)`. **Rustango** aún no incluye estrechamiento de proyección al estilo `.values("col")` (issue #62), así que el queryset interno siempre proyecta todas las columnas del modelo — lo que hace que `in_subquery` solo funcione hoy contra tablas cuyo modelo tiene una sola columna. Para el caso multi-columna, recurre a `exists(inner.where_(<outer col>.eq_expr(outer_ref(...))))` — tiene la misma semántica y no depende de la forma de la proyección.
+- **El `subquery(...)` escalar requiere un interno de una columna y una fila**: el SQL emitido es `SET col = (SELECT …)` — si el interno produce más de una fila, la base de datos da error en tiempo de ejecución. Restríngelo vía `.limit(1)` y o bien estrecha la proyección (una vez que llegue) o diseña el interno en torno a una invariante de unicidad.
+- **La validación en tiempo de compilación de la subconsulta vive en el queryset interno**: las erratas de columna se exponen en la llamada interna `queryset.compile()?`, no en el `compile()` de la consulta externa. Construye el interno primero y propaga `?`.
+
+### Cuándo bajar a SQL crudo en su lugar
+
+Los builders de arriba cubren los casos comunes. Para cosas que aún no expresan — `Cast`, búsqueda de texto completo, operadores de path de JSON, funciones de hash, trigonometría, funciones de ventana — ver la sección [Válvula de escape a SQL crudo](#raw-sql-escape-hatch) más abajo, o espera a los issues de seguimiento que extienden el mismo árbol de expresiones.
+
+---
+
+## Agregaciones
+
+Cuenta, suma, promedia y agrupa filas. `.count()`, `.sum()`, `.avg()`, `.min()` y `.max()` devuelven un solo número; `.annotate(...)` más `.values(...)` construye consultas GROUP BY (los `aggregate` / `annotate` de Django). Los resultados de agregación vuelven como `Vec<HashMap<String, SqlValue>>` en lugar de structs tipados, ya que la forma es dinámica.
+
+```rust
+use rustango::sql::CounterPool as _;
+
+// COUNT
+let n = Post::objects()
+    .where_(Post::status.eq("published"))
+    .count(&pool).await?;
+
+// SUM / AVG / MIN / MAX — string column name; each returns Option<U>
+// (None when the filtered result set is empty).
+let total_views = Post::objects().sum::<i64>("view_count", &pool).await?;
+let avg_views = Post::objects().avg::<f64>("view_count", &pool).await?;
+let max_views = Post::objects().max::<i64>("view_count", &pool).await?;
+
+// Annotate + GROUP BY (issue #75 — Django-shape auto-inference)
+use rustango::core::aggregates::{count_all, sum};
+
+// "Posts per author" — `.values()` lists the GROUP BY columns.
+let by_author = Sale::objects()
+    .values(&["author_id"])
+    .annotate("n", count_all().into())
+    .compile()?;
+let rows = rustango::sql::fetch_aggregate_dict(&pool, &by_author).await?;
+// rows: Vec<HashMap<String, SqlValue>> — { author_id: 1, n: 3 }, …
+```
+
+### Cómo se infiere el GROUP BY
+
+Rara vez escribes `GROUP BY` tú mismo — **Rustango** lo infiere de la forma de la consulta, igual que Django. Solo llamas a `.group_by(...)` para sobrescribir esa inferencia. La tabla muestra qué produce cada forma:
+
+| Forma | Builder | `GROUP BY` resultante |
+|---|---|---|
+| **2 — values + agregado** | `.values(&["author_id"]).annotate("n", count_all().into())` | `GROUP BY "author_id"` |
+| **3 — agregado suelto** | `.annotate("n", count_all().into())` | `GROUP BY` cada columna escalar no-agregada del modelo |
+| **Solo ventana** | `.aggregate().annotate("rn", row_number()…)` | (sin `GROUP BY` — las funciones de ventana son por fila) |
+| **Sobrescritura explícita** | `.aggregate().group_by("month").annotate(...)` | `GROUP BY "month"` — lo explícito gana |
+
+El clasificador `AggregateExpr::is_aggregating()` distingue las variantes que colapsan filas (`Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` / `StdDev*` / `Variance*` — más los envoltorios recursivos `Filtered` / `Coalesced`) de `Window`, que es por fila. Solo las variantes que agregan disparan la inferencia de Forma 3.
+
+```rust
+use rustango::core::aggregates::{count_all, sum};
+
+// Shape 2 — "monthly revenue per author".
+Sale::objects()
+    .where_(Sale::status.eq("paid"))
+    .values(&["author_id", "month"])
+    .annotate("total", sum("amount").into())
+    .compile()?;
+// → SELECT "author_id", "month", SUM("amount")::bigint AS "total"
+//   FROM "sale" WHERE "status" = $1
+//   GROUP BY "author_id", "month"
+
+// Shape 3 — a bare .annotate() with no .values(): rustango adds every
+// non-aggregate scalar column of the model to the GROUP BY.
+Post::objects()
+    .annotate("n", count_all().into())
+    .compile()?;
+// → SELECT <every Post column>, COUNT(*) AS "n"
+//   FROM "post" GROUP BY <every Post column>
+```
+
+**Salvedad de proyección pura.** `.values(cols)` *por sí solo* (sin anotación de agregado) **no** está soportado en v0.40 — `compile()` devuelve `QueryError::ValuesRequiresAggregate`. La proyección pura como dicts necesita un camino de writer separado (es un SELECT sin GROUP BY, decodificado en `Vec<HashMap>`) y está en cola para un seguimiento. Por ahora, usa el `QuerySet::fetch(...)` tipado para leer filas completas.
+
+### Agregados condicionales y estadísticos
+
+Cuenta o suma solo las filas que coinciden con una condición, provee un fallback para resultados vacíos, y calcula desviación estándar / varianza. Estos reflejan los `Count('id', filter=...)`, `Sum('price', default=0)` y `StdDev` de Django. Encadena `.filter(...)` y `.default(...)` a cualquier builder de agregado.
+
+```rust
+use rustango::core::aggregates::{avg, count, count_all, stddev, sum};
+use rustango::core::Column as _;
+
+let rows = Post::objects()
+    .aggregate()
+    // COUNT(*) FILTER (WHERE is_active AND status = 'published')
+    .annotate(
+        "active_published",
+        count_all()
+            .filter(Post::is_active.eq(true).and(Post::status.eq("published")))
+            .into(),
+    )
+    // COALESCE(SUM(price) FILTER (WHERE status = 'published'), 0)
+    //   — returns 0 instead of NULL when the queryset is empty.
+    .annotate(
+        "revenue_or_zero",
+        sum("price")
+            .filter(Post::status.eq("published"))
+            .default(0_i64)
+            .into(),
+    )
+    .annotate("avg_pages", avg("pages").into())
+    .annotate("page_stddev", stddev("pages").into())
+    .compile()?;
+let result = rustango::sql::fetch_aggregate_dict(&pool, &rows).await?;
+```
+
+**Builders** en `rustango::core::aggregates`:
+
+| Builder | SQL |
+|---|---|
+| `count(col)` | `COUNT(col)` |
+| `count_all()` | `COUNT(*)` |
+| `count_distinct(col)` | `COUNT(DISTINCT col)` |
+| `sum(col)` / `avg(col)` / `max(col)` / `min(col)` | los de siempre |
+| `stddev(col)` / `stddev_pop(col)` | `STDDEV_SAMP` / `STDDEV_POP` |
+| `variance(col)` / `variance_pop(col)` | `VAR_SAMP` / `VAR_POP` |
+
+Cada uno devuelve un `AggregateBuilder` con dos modificadores encadenables:
+
+- `.filter(predicate)` — envuelve en `FILTER (WHERE predicate)`. El predicado es cualquier `WhereExpr` (`.eq()` / `.and()` tipado / `WhereExpr::Or(...)` crudo), así que se compone de la misma manera que un WHERE normal.
+- `.default(value)` — envuelve en `COALESCE(..., value)` para que un queryset vacío devuelva el valor predeterminado en lugar de `NULL`.
+
+Llamar a ambas cadenas como `Coalesced` fuera de `Filtered`: `COALESCE(SUM(col) FILTER (WHERE p), 0)`. El orden de la cadena no importa — `.filter(p).default(0)` y `.default(0).filter(p)` producen el mismo IR.
+
+**Emisión tri-dialecto:**
+
+| Característica | PG | MySQL | SQLite |
+|---|---|---|---|
+| `Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` | ✓ | ✓ | ✓ |
+| `StdDev` / `StdDevPop` / `Variance` / `VariancePop` | ✓ | ✓ (8.0+) | ✗ `SqlError::AggregateNotSupported` |
+| `.filter(...)` — `FILTER (WHERE …)` nativo | ✓ | ✗ reescrito | ✓ (3.30+) |
+| `.filter(...)` — fallback con `CASE WHEN` | — | ✓ `<agg>(CASE WHEN … THEN <arg> END)` | — |
+| `.default(...)` — `COALESCE` | ✓ | ✓ | ✓ |
+
+El writer aplica el cast int/float del dialecto (`::bigint`, `CAST(... AS SIGNED)`, etc.) alrededor de toda la expresión `FILTER` — `SUM(col)::bigint FILTER (...)` es un error de parseo de PG, así que la forma emitida es `(SUM(col) FILTER (...))::bigint`. La misma forma para `STDDEV_SAMP` / `VAR_SAMP` (devuelven NUMERIC en PG para entrada bigint).
+
+**SQLite + StdDev/Variance:** SQLite no tiene agregados estadísticos incorporados, así que el writer rechaza con `SqlError::AggregateNotSupported { aggregate, dialect: "sqlite" }`. Calcula la fórmula de varianza en código de aplicación si se necesitan estadísticas portables (la misma postura que toma Django).
+
+### Funciones de ventana
+
+Calcula totales acumulados, rankings y deltas fila-sobre-fila sin colapsar filas — el `Window(expression, partition_by=, order_by=, frame=)` de Django. Ocho funciones (`row_number`, `rank`, `dense_rank`, `lag`, `lead`, `first_value`, `last_value`, `ntile`) más frames ROWS/RANGE. Cada backend que **Rustango** soporta (PG ≥ 9.0, MySQL ≥ 8.0, SQLite ≥ 3.25) incluye sintaxis nativa `OVER (…)`, así que la emisión es uniforme.
+
+```rust
+use rustango::core::aggregates::max;
+use rustango::core::window::{lag, rank, row_number};
+
+// "Rank users by score within each tenant" — the canonical
+// integration target.
+let q = User::objects()
+    .aggregate()
+    .group_by("id")
+    .group_by("tenant_id")
+    .group_by("name")
+    .group_by("score")
+    .annotate("_a", max("id").into())  // satisfies GROUP BY on the projection
+    .annotate(
+        "tenant_rank",
+        rank().partition_by("tenant_id").order_by(&[("score", true)]).into(),
+    )
+    .order_by(&[("tenant_id", false), ("score", true)])
+    .compile()?;
+let rows = rustango::sql::fetch_aggregate_dict(&pool, &q).await?;
+
+// Day-over-day delta via LAG with a default for the first row.
+let q = Event::objects()
+    .aggregate()
+    .group_by("id")
+    .group_by("day")
+    .group_by("count")
+    .annotate("_a", max("id").into())
+    .annotate(
+        "prev_count",
+        lag("count", 1, Some(SqlValue::I64(0)))
+            .partition_by("user_id")
+            .order_by(&[("day", false)])
+            .into(),
+    )
+    .compile()?;
+
+// Stable row index per group for "show me row N" pagination.
+let q = Post::objects()
+    .aggregate()
+    .group_by("id")
+    .group_by("status")
+    .group_by("created_at")
+    .annotate("_a", max("id").into())
+    .annotate(
+        "rn",
+        row_number()
+            .partition_by("status")
+            .order_by(&[("created_at", true)])
+            .into(),
+    )
+    .compile()?;
+```
+
+**Builders** en `rustango::core::window`:
+
+| Builder | SQL | Args |
+|---|---|---|
+| `row_number()` | `ROW_NUMBER()` | — |
+| `rank()` | `RANK()` | — |
+| `dense_rank()` | `DENSE_RANK()` | — |
+| `ntile(buckets)` | `NTILE(buckets)` | conteo de buckets |
+| `lag(col, offset, default)` | `LAG(col, offset, default?)` | columna + offset + default opcional |
+| `lead(col, offset, default)` | `LEAD(col, offset, default?)` | columna + offset + default opcional |
+| `first_value(col)` | `FIRST_VALUE(col)` | columna |
+| `last_value(col)` | `LAST_VALUE(col)` | columna |
+
+Cada uno devuelve un `WindowBuilder` con tres modificadores encadenables:
+
+- `.partition_by("col")` — añade una columna `PARTITION BY`. Llama varias veces para particionamiento multi-columna.
+- `.order_by(&[("col", desc)])` — añade columnas `ORDER BY` (`desc = true` → DESC).
+- `.frame(WindowFrame { kind, start, end })` — establece la cláusula de frame `ROWS`/`RANGE` opcional. `FrameBoundary::UnboundedPreceding` / `Preceding(n)` / `CurrentRow` / `Following(n)` / `UnboundedFollowing`.
+
+El builder desciende vía `Into<AggregateExpr>` para que las funciones de ventana se compongan con `annotate()`. `Into<Expr>` también está implementado (el slot a nivel de IR para expresiones de ventana), pero **cada backend que **Rustango** soporta restringe las funciones de ventana a la lista `SELECT` y a la cláusula `ORDER BY` de una consulta** — no pueden aparecer en `WHERE` / `HAVING` / `GROUP BY` / `UPDATE SET` / `JOIN ON` / `RETURNING`. El writer no bloquea la emisión por esto, así que `set_expr("col", row_number())` compila a un SQL que la base de datos rechaza en ejecución. Construye las expresiones de ventana a través de `annotate()`; recurre a una subconsulta si necesitas alimentar un resultado de ventana a un filtro WHERE o a un UPDATE.
+
+**Trampa del frame predeterminado de `LAST_VALUE`:**
+
+Un `last_value(col).order_by(&[("x", false)])` simple emite `LAST_VALUE("col") OVER (ORDER BY "x")` y parece que debería devolver el último `col` de la partición. No lo hace — el frame de ventana *predeterminado* de SQL es `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`, así que `LAST_VALUE` devuelve el valor de la **fila actual**, no la última fila de la partición. Para obtener el comportamiento intuitivo de "última fila de la partición", pasa un frame no acotado explícito:
+
+```rust
+use rustango::core::{FrameBoundary, FrameKind, WindowFrame};
+
+last_value("score")
+    .partition_by("tenant_id")
+    .order_by(&[("created_at", true)])
+    .frame(WindowFrame {
+        kind: FrameKind::Rows,
+        start: FrameBoundary::UnboundedPreceding,
+        end: Some(FrameBoundary::UnboundedFollowing),
+    })
+```
+
+`first_value` no tiene esta trampa — el inicio del frame predeterminado coincide con el inicio de la partición, así que la respuesta intuitiva sale sola.
+
+**Salvedad de annotate (hasta que llegue el issue #75):**
+
+`annotate()` vive en el aggregate-builder que requiere `GROUP BY` para proyectar columnas escalares por fila junto a los agregados. Para proyectar resultados de función de ventana junto a columnas de fila hoy, lista cada columna de fila que quieras devolver en llamadas `.group_by(...)` y `annotate("_a", max("id").into())` como un placeholder no-op para mantener estable la identidad de la fila. El issue #75 (auto-inferencia de GROUP BY) trae una forma más limpia.
+
+**Cláusulas de frame:**
+
+```rust
+use rustango::core::{FrameBoundary, FrameKind, WindowFrame};
+
+// Running total over the last 7 rows:
+let frame = WindowFrame {
+    kind: FrameKind::Rows,
+    start: FrameBoundary::Preceding(6),
+    end: Some(FrameBoundary::CurrentRow),
+};
+
+// Centered 11-row window:
+let frame = WindowFrame {
+    kind: FrameKind::Rows,
+    start: FrameBoundary::Preceding(5),
+    end: Some(FrameBoundary::Following(5)),
+};
+```
+
+**Emisión tri-dialecto:**
+
+`<fn>(args) OVER (PARTITION BY … ORDER BY … [frame])` es estándar SQL — idéntico entre PG, MySQL 8+ y SQLite 3.25+. La única peculiaridad: `LAG` / `LEAD` / `NTILE` requieren offsets/buckets enteros en PG (vincularlos como un parámetro bigint `$N` causa `function lag(bigint, bigint, bigint) does not exist`). El writer incrusta los literales enteros directamente en el SQL para esos slots; los argumentos de valor predeterminado se vinculan normalmente.
+
+**Salvedades:**
+
+- **`FILTER` + `Window` aún no soportado**: combinar `.filter(...)` con una función de ventana levanta `SqlError::NestedAggregateWrapper { wrapper: "Filtered(Window)" }` — la sintaxis subyacente varía según el tipo de función (PG permite `agg_fn() FILTER (WHERE …) OVER (…)` para funciones agregadas-de-ventana pero no para las de ranking), y al writer no se le ha enseñado el despacho. Registrado para un seguimiento si surge demanda.
+- **`PercentRank` / `CumeDist` / `NthValue`** no están en v1 — el conjunto completo de Django es más grande. v1 incluye las 8 variantes más usadas; las tres faltantes pueden añadirse incrementalmente con la misma forma de builder.
+
+### Filtrar sobre agregados (HAVING)
+
+Una llamada `.filter(...)` después de `.annotate(...)` cae en `WHERE` o en `HAVING`, dependiendo de si el nombre coincide con un alias de agregado — exactamente el comportamiento de Django. Así que filtrar sobre una columna real añade un `WHERE`, mientras que filtrar sobre una anotación como `post_count` añade un `HAVING`:
+
+```rust
+use rustango::core::aggregates::count_all;
+use rustango::core::Op;
+
+// "Authors with > 10 published posts" — the canonical pattern.
+// status='published' is on the model       → routes to WHERE.
+// post_count > 10 references the annotation → routes to HAVING.
+let q = Post::objects()
+    .aggregate()
+    .group_by("author_id")
+    .annotate("post_count", count_all().into())
+    .filter("status",     Op::Eq, "published")
+    .filter("post_count", Op::Gt, 10_i64)
+    .compile()?;
+let rows = rustango::sql::fetch_aggregate_dict(&pool, &q).await?;
+```
+
+Emite, en PG:
+
+```sql
+SELECT "author_id", COUNT(*) AS "post_count"
+FROM "post"
+WHERE "status" = $1
+GROUP BY "author_id"
+HAVING COUNT(*) > $2
+```
+
+**La expresión de agregado se eleva a HAVING, no al alias del SELECT.** PG prohíbe estrictamente los alias en HAVING (solo se resuelve la expresión); MySQL + SQLite son más permisivos. El writer emite la forma elevada de manera uniforme en los tres para que la misma consulta funcione en todas partes.
+
+**El orden de la cadena importa en v1.** Llama a `.annotate(alias, ...)` ANTES del correspondiente `.filter(alias, ...)`. Si el orden se invierte, `filter()` busca en un registro de anotaciones vacío y encamina a `WHERE` — y el validador `resolve_pending` expone `UnknownField` en `compile()` porque el alias no es una columna real del modelo. Django difiere esta resolución al momento de construcción de la consulta; un seguimiento en v0.50 podría igualar esa postura.
+
+**Brecha del validador (coincide con la postura existente de agregados)**: los predicados HAVING encaminados por alias omiten el recorrido de columnas del schema del modelo. Los alias con errata se exponen en la base de datos, no en `compile()`. La misma brecha que `Sum("typo_col")` — preexistente y ortogonal.
+
+**Ops soportadas en `.filter()` encaminado por alias** (issue #87): el conjunto de comparación binaria (`Op::Eq` / `Ne` / `Lt` / `Lte` / `Gt` / `Gte`) **más** los predicados estándar SQL-92 que se componen contra un LHS de agregado de manera uniforme en todos los backends — `Op::In` / `NotIn`, `Between`, `IsNull`, `Like` / `NotLike`, `ILike` / `NotILike`. Cada uno emite la forma predecible:
+
+```rust
+use rustango::core::{Op, SqlValue};
+
+// HAVING COUNT(*) IN ($1, $2, $3)
+Post::objects()
+    .aggregate()
+    .group_by("author_id")
+    .annotate("post_count", count_all().into())
+    .filter("post_count", Op::In, SqlValue::List(vec![5_i64.into(), 10_i64.into(), 20_i64.into()]))
+    .compile()?;
+
+// HAVING COUNT(*) BETWEEN $1 AND $2
+.filter("post_count", Op::Between, SqlValue::List(vec![5_i64.into(), 10_i64.into()]))
+
+// HAVING COUNT(*) IS NULL  /  IS NOT NULL  (bool: true = IS NULL)
+.filter("post_count", Op::IsNull, SqlValue::Bool(false))
+
+// HAVING MAX("name") LIKE $1  /  ILIKE $1 (PG) / LOWER(MAX("name")) LIKE LOWER(?) (MySQL/SQLite)
+.filter("max_name", Op::ILike, "SMITH%")
+```
+
+Las ops restantes — la familia de ops JSON (`JsonContains` / `JsonContainedBy` / `JsonHasKey` / `JsonHasAnyKey` / `JsonHasAllKeys`) y la igualdad null-safe (`IsDistinctFrom` / `IsNotDistinctFrom`) — aún necesitan writers específicos de dialecto que tomen un `&str` para el LHS, así que rechazan en `.compile()` con `QueryError::HavingOpNotSupported { alias, op }`. Para esas, baja a la forma tipada `.having(<TypedExpr>)` con un predicado pre-construido.
+
+**Inflado del vector de parámetros con agregados no triviales**: cuando el alias apunta a una anotación `Filtered { Count, filter: pred }` o `Coalesced { Sum, default: 0 }`, el writer eleva la **expresión de agregado completa** a HAVING — incluyendo sus predicados internos y valores predeterminados. Sus literales vinculados obtienen slots de parámetro nuevos en HAVING, separados de la emisión en la lista SELECT. Concretamente:
+
+```text
+SELECT … COUNT(*) FILTER (WHERE "status" = $1) AS "published_count" …
+HAVING COUNT(*) FILTER (WHERE "status" = $2) > $3
+              -- "published" bound twice (once at $1, once at $2)
+```
+
+La semántica SQL no cambia (vuelven los mismos conteos de filas), pero `stmt.params.len()` crece por cada llamada `.filter()` que apunte a un alias no trivial. Para alias `COUNT(*)` (sin literales internos) el inflado es cero. Documéntalo si tu suite de tests fija conteos de parámetros.
+
+---
+
+## Joins y precarga de filas relacionadas
+
+Trae el objetivo de una foreign key junto con la fila principal en una sola consulta, para no disparar una consulta extra por fila (el problema N+1). `.select_related("author")` es el `select_related` de Django / la carga anticipada de Eloquent. Un campo `ForeignKey<T>` entonces llega ya poblado en lugar de necesitar una búsqueda separada.
+
+```rust
+let posts = Post::objects()
+    .select_related("author")              // JOIN posts.author -> authors.id
+    .fetch(&pool).await?;
+
+for post in &posts {
+    let author = post.author.value().unwrap();   // already loaded, no DB round-trip
+    println!("{} by {}", post.title, author.name);
+}
+```
+
+`select_related` resuelve los campos FK en el momento de compilación del queryset. El campo `ForeignKey<T>` del padre pasa de `Unloaded(pk)` a `Loaded { pk, value }`.
+
+Para FKs inversas (parent.children), usa el método `_set` generado por la macro:
+
+```rust
+let author_posts = author.post_set(&pool).await?;
+```
+
+### Joins personalizados
+
+Cuando el join no está impulsado por una foreign key — un predicado personalizado, un join no-equi, INNER en lugar de LEFT, un self-join, o unir por una columna que no es PK — usa `.join(Join { … })`. Su campo `on` toma cualquier `WhereExpr`, así que `and()` / `or()` / `Not` / llamadas de función / columna-vs-columna / filtros literales se componen todos libremente.
+
+```rust
+use rustango::core::joins::aliased;
+use rustango::core::{Join, JoinKind, Op, WhereExpr};
+
+// "Posts that have at least one APPROVED comment" — INNER JOIN with
+// an extra predicate inside the ON. Posts with no approved comment
+// drop out; LEFT JOIN would keep them.
+Post::objects()
+    .join(Join {
+        target: Comment::SCHEMA,
+        alias: "c",
+        kind: JoinKind::Inner,
+        on: WhereExpr::And(vec![
+            // Column-on-column condition — both sides aliased.
+            WhereExpr::ExprCompare {
+                lhs: aliased("c", "post_id"),
+                op: Op::Eq,
+                rhs: aliased("post", "id"),
+            },
+            // Bare Filter — unqualified columns inside `on` resolve
+            // to the joined alias ("c"), so this becomes
+            // `"c"."is_approved" = $N`.
+            Comment::is_approved.eq(true).into(),
+        ]),
+        project: vec![],
+    })
+    .fetch(&pool).await?;
+```
+
+**Reglas de calificación de columna dentro de `on`:**
+
+- **Columnas `Filter` / `ColumnFilter` simples + referencias de columna `F()`** se resuelven al alias del join (`<alias>` que pasaste). Esa es la lectura natural porque la mayor parte de un predicado ON trata sobre la tabla unida.
+- **`aliased(alias, col)`** emite `"<alias>"."<col>"` explícitamente — usa esto para referencias cruzadas de vuelta a la tabla externa (`aliased("<outer_table>", "<col>")`) o a un alias previamente unido.
+- **`WhereExpr::ExprCompare { lhs, op, rhs }`** es la forma correcta para comparaciones columna-vs-columna entre tablas, ya que ambos lados toman cualquier `Expr`.
+
+> ⚠️ **PATRÓN PELIGROSO — filtros tipados del modelo EXTERNO dentro de `on`.**
+> `Post::status.eq("draft").into()` produce un `WhereExpr::Predicate(Filter { column: "status", ... })` y **descarta la etiqueta del modelo `Post`** en el límite `Into<WhereExpr>`. La regla de auto-calificación de arriba entonces encamina mal ese filtro al **alias del join**, no a `Post`. Obtienes `"<joined_alias>"."status" = $N` — tabla equivocada — y el compilador no puede detectarlo. **Usa [`joins::col_filter`] para predicados contra cualquier columna cuya tabla no sea el alias predeterminado del join:**
+>
+> ```rust
+> use rustango::core::joins::{aliased, col_filter};
+> use rustango::core::Op;
+>
+> // SAFE: explicit alias on the LHS.
+> col_filter("post", "status", Op::Eq, "draft")
+> ```
+>
+> Reserva los filtros tipados simples (`Comment::is_approved.eq(true).into()`) solo para columnas del modelo UNIDO — nunca para columnas del modelo externo.
+
+**Soporte tri-dialecto de JoinKind:**
+
+| Tipo | PG | MySQL | SQLite |
+|---|---|---|---|
+| `Inner` | ✓ | ✓ | ✓ |
+| `Left` (predeterminado) | ✓ | ✓ | ✓ |
+| `Right` | ✓ | ✓ | ✗ `SqlError::JoinKindNotSupported` |
+| `Full` | ✓ | ✗ | ✗ |
+
+`Right` es fácil de sortear — intercambia los operandos y usa `Left`. `Full` en MySQL se emula normalmente con `(LEFT JOIN) UNION (RIGHT JOIN)` si realmente lo necesitas.
+
+**Otros errores en tiempo de emisión:**
+
+- **Predicado `on` vacío** (`WhereExpr::And(vec![])` o sin `ExprCompare`s) se rechaza con `SqlError::EmptyJoinOnCondition`. SQL requiere al menos un predicado booleano dentro de `ON`; la abreviatura auto-`true` del WHERE de nivel superior no aplica aquí.
+
+**`project` es actualmente dato muerto en joins ad-hoc.**
+
+El campo `Join.project` le dice al writer que emita columnas `<alias>"."<col>" AS "<alias>__<col>"` en la lista SELECT. Hoy solo `select_related` realmente las decodifica (vía el decoder de fila completa del objetivo de la FK); los joins ad-hoc emiten las columnas pero el decoder `Vec<MainModel>` las ignora, así que poblar `project` en un join ad-hoc solo añade bytes al cable. Déjalo como `vec![]` hasta que lleguen el estrechamiento de proyección + la decodificación de tuplas.
+
+**Cuándo recurrir a joins ad-hoc:**
+
+| Necesidad | Herramienta |
+|---|---|
+| Traer filas relacionadas junto con la fila principal | `select_related` (forma de Django) |
+| Filtrar filas principales por un predicado de tabla relacionada | `exists(...)` / `not_exists(...)` |
+| Filtrar vía INNER en lugar de LEFT, o con predicados ON extra | `.join(...)` |
+| Self-join (p. ej. `employee.manager_id = manager.id`) | `.join(...)` |
+| Anti-join (filas en A SIN coincidencia en B) | `not_exists(...)` |
+
+`select_related` sigue siendo la herramienta correcta cuando el join es "sigue esta FK y proyecta todas sus columnas". Los joins ad-hoc son la válvula de escape cuando necesitas: clave de join que no es FK, INNER en lugar de LEFT, un predicado extra dentro del ON, o un self-join.
+
+[`joins::col_filter`]: https://docs.rs/rustango/latest/rustango/core/joins/fn.col_filter.html
+
+[`WhereExpr`]: https://docs.rs/rustango/latest/rustango/core/enum.WhereExpr.html
+
+---
+
+## Guardar solo algunos campos
+
+Escribe solo los campos que cambiaste en lugar de cada columna — el `save(update_fields=[...])` de Django. Un save normal reescribe cada columna que no es PK; `save_partial(&[...], &pool)` reescribe solo las que nombras.
+
+```rust
+let mut post = Post::objects().fetch(&pool).await?.pop().unwrap();
+post.title = "new title".into();
+post.save_partial(&["title"], &pool).await?;  // SET "title" = $1
+                                                  // — leaves body, status, views untouched
+```
+
+Dos motivaciones:
+
+* **Rendimiento.** Las filas anchas con columnas `TEXT` / `JSON` / `bytea` pagan por revincular y reescribir cada campo en cada `save()` incluso cuando solo uno mutó. `save_partial` mantiene la cláusula `SET` en exactamente lo que cambió.
+* **Seguridad ante concurrencia.** Cuando dos escritores divergen tras una lectura compartida, el perdedor sobrescribe silenciosamente las ediciones del ganador en los campos que no tocó. Nombrar solo el campo que realmente cambiaste preserva el trabajo del otro escritor en todo lo demás.
+
+```rust
+// Writer A — flips title.
+a.title = "from-A".into();
+a.save_partial(&["title"], &pool).await?;
+
+// Writer B — started from the same read, flips status.
+// B's local `title` is stale, but it's not in the list, so A's
+// write survives.
+b.status = "from-B".into();
+b.save_partial(&["status"], &pool).await?;
+```
+
+**Los nombres de campo son campos del struct del lado de Rust**, no columnas SQL — `["author_id"]` (no `["author"]` para un campo tipo FK). Los nombres de campo desconocidos devuelven `ExecError::Query(QueryError::UnknownField)`. Una lista vacía es un no-op (devuelve `Ok(())` y registra un `tracing::warn!`), coincidiendo con la semántica de "nada que hacer" de Django. Los modelos auditados (`#[rustango(audit(...))]`) estrechan la instantánea del log de auditoría al mismo conjunto de columnas — el log refleja exactamente lo que se escribió.
+
+**Nota sobre auto-PK.** `save_partial` es solo-UPDATE; llamarlo sobre una PK `Auto::Unset` es un error de usuario (usa `insert_pool` / `save_pool` para ese caso). A diferencia de `save_pool` que auto-despacha `Unset → insert_pool`, este método asume que ya has insertado.
+
+### Lista de campos verificada en tiempo de compilación
+
+La forma con claves de string de arriba se adapta a listas de campos dinámicas (formularios de admin, payloads de API). Cuando la lista es fija en tu código, `save_partial_typed((Post::title, ...), &pool)` detecta campos mal escritos o renombrados en **tiempo de compilación** en lugar de en tiempo de ejecución:
+
+```rust
+post.save_partial_typed((Post::title, Post::slug), &pool).await?;
+//                       ──────────  ──────────
+//                       title_col   slug_col   ← distinct ZSTs
+```
+
+Cada `Post::<field>` es su propio tipo de tamaño cero — un slice homogéneo (`&[Post::title, Post::slug]`) no verifica en Rust, así que la API toma una **tupla** en su lugar. Las llamadas de un solo campo usan el idioma de la coma final: `(Post::title,)`. Las tuplas se soportan desde aridad 1 hasta 12 — más allá de eso, baja a `save_partial(&[&str], _)`.
+
+Las tuplas entre modelos son un **error de compilación** — `(Post::title, Author::name)` falla la cota de trait `TypedFieldList<Post>` porque el `Column::Model` de `Author::name` es `Author`. Este es el valor principal sobre la forma con claves de string: los refactors de renombrado sobre un nombre de columna se exponen en el sitio de llamada tipado, no en tiempo de ejecución.
+
+Internamente desciende a `save_partial` — mismo estrechamiento de auditoría, misma restricción `Auto::Unset`, misma semántica de no-op para lista vacía.
+
+---
+
+## Operaciones en lote
+
+> **Trampa — las ops en lote omiten los hooks por fila.** `bulk_insert`, el
+> `.update().execute()` de queryset, y `.delete()` se ejecutan como SQL basado en conjuntos: **no**
+> disparan señales, no escriben el rastro de auditoría, no encaminan a través del borrado lógico, ni ejecutan
+> validación por fila. Úsalas por velocidad; baja a `save()` / `delete()` por fila
+> cuando necesites esos efectos secundarios.
+
+Inserta, actualiza o elimina muchas filas en una sentencia en lugar de una por fila — los `bulk_create`, `QuerySet.update()` y `QuerySet.delete()` de Django. El import `as _` trae los métodos de un trait al ámbito sin nombrar el trait directamente.
+
+```rust
+// Bulk INSERT — rows FIRST (a `&mut [Self]`), executor/pool second.
+let mut rows = [p1, p2, p3];
+Post::bulk_insert_on(&mut rows, &pool).await?;
+
+// Bulk UPDATE — applies the same set to every matched row. `.set`
+// takes a string column name.
+Post::objects()
+    .where_(Post::status.eq("draft"))
+    .where_(Post::created_at.lt(thirty_days_ago))
+    .update()
+    .set("status", "archived")
+    .execute_on(&pool).await?;
+
+// Bulk DELETE
+Post::objects()
+    .where_(Post::deleted_at.is_not_null())
+    .delete_on(&pool).await?;
+```
+
+---
+
+## Insertar o actualizar (upsert)
+
+Inserta una fila, o actualízala si ya existe una fila con la misma clave — el `update_or_create` de Django / el `upsert` de Rails. Emite el `ON CONFLICT … DO UPDATE` nativo de la base de datos.
+
+El `.upsert_on(executor)` de instancia única entra en conflicto sobre la **primary key**: con una PK `Auto::Unset` el servidor asigna una clave nueva (equivalente a `insert`); con una PK `Auto::Set` la fila se inserta si está ausente o se sobrescriben todas las columnas que no son PK si está presente.
+
+```rust
+// Upsert on the PK — INSERT, or UPDATE every non-PK column if the
+// PK already exists.
+post.upsert_on(&pool).await?;
+```
+
+Para hacer upsert sobre una clave única arbitraria (el `bulk_create(update_conflicts=True, unique_fields=…, update_fields=…)` de Django), usa el helper en lote — toma las filas, las columnas objetivo del conflicto, las columnas a actualizar en conflicto, y el pool AL FINAL:
+
+```rust
+// ON CONFLICT (external_id) DO UPDATE SET title = EXCLUDED.title
+Post::bulk_upsert_pool(
+    &[post],
+    &["external_id"],          // conflict target (unique key)
+    &["title"],                // columns to overwrite on conflict
+    &pool,
+).await?;
+```
+
+---
+
+## Transacciones
+
+> **Trampa — no mezcles llamadas `&pool` dentro de una transacción.** Cada llamada
+> entre `pool.begin()` y `commit` debe apuntar al handle de la transacción
+> (`&mut *tx`). Un `&pool` / `fetch()` / `save_on(&pool)` perdido saca una
+> *segunda* conexión y puede provocar un deadlock del pool bajo carga. Enhebra la `tx`
+> por todo, o usa `rustango::sql::atomic`.
+
+Ejecuta varias escrituras como una unidad que o bien todas tienen éxito o todas hacen rollback — el `transaction.atomic()` de Django. Abre una con `pool.begin()` y ejecuta cada sentencia contra la conexión de la transacción vía los métodos `_on` (`fetch_on`, `save_on`), para que el trabajo caiga en la transacción en curso en lugar de una nueva conexión del pool.
+
+```rust
+let mut tx = pool.begin().await?;
+
+let mut a = Account::objects()
+    .where_(Account::id.eq(1))
+    .fetch_on(&mut *tx).await?
+    .pop().unwrap();
+let mut b = Account::objects()
+    .where_(Account::id.eq(2))
+    .fetch_on(&mut *tx).await?
+    .pop().unwrap();
+
+a.balance -= 100;
+b.balance += 100;
+a.save_on(&mut *tx).await?;
+b.save_on(&mut *tx).await?;
+
+tx.commit().await?;
+```
+
+Descarta la `tx` sin llamar a `commit()` (p. ej. en un retorno anticipado con `?`) y la transacción hace rollback. Para un hook post-commit (el `transaction.on_commit` de Django) recurre al helper de estilo closure `rustango::sql::atomic(&pool, |tx| Box::pin(async move { … }))`, que auto-confirma en `Ok` y auto-hace-rollback en `Err`.
+
+---
+
+## Muchos-a-muchos
+
+Relaciona muchas filas con muchas otras a través de una tabla de unión — el `ManyToManyField` de Django. Declara la relación en el modelo, luego usa el accessor generado para añadir, quitar, establecer o listar los ids enlazados.
+
+```rust
+#[rustango(
+    table = "posts",
+    m2m(name = "tags", to = "tags", through = "post_tags",
+        src = "post_id", dst = "tag_id"),
+)]
+pub struct Post { ... }
+```
+
+Usa el accessor auto-generado:
+
+```rust
+let tag_ids: Vec<i64> = post.tags_m2m().all(&pool).await?;
+post.tags_m2m().add(42, &pool).await?;
+post.tags_m2m().remove(42, &pool).await?;
+post.tags_m2m().set(&[1, 2, 3], &pool).await?;        // replace all
+post.tags_m2m().clear(&pool).await?;
+let has = post.tags_m2m().contains(42, &pool).await?;
+```
+
+La tabla de unión (`post_tags`) es auto-creada por `make_migrations` con una PK compuesta + dos FKs `ON DELETE CASCADE`. Actualmente la tabla de unión tiene solo las dos columnas FK — para columnas extra (added_by, order, created_at) definirás un Model separado y lo recorrerás manualmente hasta que llegue el "custom through model".
+
+---
+
+## JSON / JSONB
+
+Almacena y consulta un documento JSON en una columna — el `JSONField` de Django. Declara el campo como `serde_json::Value` (el tipo JSON genérico), luego consulta dentro de él con `json_contains` o un filtro de path.
+
+```rust
+#[derive(Model)]
+pub struct Event {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(default = r#"'{}'::jsonb"#)]
+    pub data: serde_json::Value,
+}
+```
+
+Consulta el contenido JSON:
+
+```rust
+use rustango::core::{Expr, Op, SqlValue, WhereExpr};
+use rustango::core::funcs::json_path;
+use rustango::core::F;
+
+let with_email = Event::objects()
+    .where_(Event::data.json_contains(serde_json::json!({"email_set": true})))
+    .fetch(&pool).await?;
+
+// Path extract — `json_path(F("data"), &["type"], true)` builds the
+// `data ->> 'type'` text-extract LHS; compare it via `where_raw`.
+let typed = Event::objects()
+    .where_raw(WhereExpr::ExprCompare {
+        lhs: json_path(F("data"), &["type"], true),
+        op: Op::Eq,
+        rhs: Expr::Literal(SqlValue::String("user.created".into())),
+    })
+    .fetch(&pool).await?;
+```
+
+Lee/escribe tipos de Rust vía `serde_json::from_value` / `to_value`.
+
+---
+
+## Borrado lógico (soft delete)
+
+Marca una fila como eliminada estableciendo un timestamp en lugar de removerla — como el `django-safedelete` de Django o los `SoftDeletes` de Laravel. Marca la columna de timestamp con el atributo `#[rustango(soft_delete)]` (una anotación de derive que le dice a la macro cómo tratar el campo):
+
+```rust
+#[derive(Model)]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub title: String,
+    #[rustango(soft_delete)]
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+```
+
+Uso:
+
+```rust
+post.soft_delete_on(&pool).await?;     // sets deleted_at = NOW()
+post.restore_on(&pool).await?;          // sets deleted_at = NULL
+
+// Default queries DO include soft-deleted rows. Filter explicitly:
+let live = Post::objects().where_(Post::deleted_at.is_null()).fetch(&pool).await?;
+```
+
+El botón "Delete" del admin encamina automáticamente a `soft_delete_on` para cualquier modelo que tenga la columna. El auto-filtro (exclusión predeterminada) está en la hoja de ruta de la v0.21.
+
+---
+
+## Rastro de auditoría
+
+Registra quién cambió qué campos y cuándo, automáticamente en cada save y delete — como el `django-simple-history` de Django o los paquetes de auditing de Laravel. Anota el modelo con los campos a rastrear:
+
+```rust
+#[derive(Model)]
+#[rustango(audit(track = "title, body, status"))]
+pub struct Post { ... }
+```
+
+Cada save/delete escribe una fila en `rustango_audit_log` con un diff JSONB `before / after` para los campos listados. Establece la fuente por petición:
+
+```rust
+use rustango::audit::{with_source, AuditSource};
+
+with_source(
+    AuditSource::User { id: user_id.to_string() },
+    async {
+        post.save_on(&pool).await
+    },
+).await?;
+```
+
+El panel de historial por fila del admin lee de esta tabla; el feed entre modelos está en `/__audit`.
+
+Limpieza:
+
+```rust
+rustango::audit::cleanup_older_than(&pool, 90).await?;       // delete > 90 days
+rustango::audit::cleanup_keep_last_n(&pool, 50).await?;      // keep most recent 50/row
+
+// CLI
+manage audit-cleanup --days 90
+manage audit-cleanup --keep-last 50 --tenant acme
+```
+
+---
+
+## Válvula de escape a SQL crudo
+
+Baja a SQL escrito a mano cuando el query builder no puede expresar lo que necesitas — el `Model.objects.raw()` / `connection.cursor()` de Django. Las macros de `sqlx` ejecutan una consulta y decodifican el resultado en una tupla, un `Model` tipado, o nada:
+
+```rust
+use rustango::sql::sqlx;
+
+// Raw query → typed rows
+let rows = sqlx::query_as::<_, (i64, String)>("SELECT id, title FROM posts WHERE views > $1 ORDER BY views DESC")
+    .bind(1000)
+    .fetch_all(&pool)
+    .await?;
+
+// Raw with model decoding
+let posts: Vec<Post> = sqlx::query_as::<_, Post>("SELECT * FROM posts WHERE complicated_condition")
+    .fetch_all(&pool)
+    .await?;
+
+// Raw without rows (DDL / DML)
+sqlx::query("REINDEX TABLE posts").execute(&pool).await?;
+```
+
+Para SQL crudo programático dentro de la capa de consulta de **Rustango** (tri-dialecto; toma el SQL, un `Vec<SqlValue>` de binds, y luego el pool AL FINAL, y devuelve `Vec<T>`):
+
+```rust
+use rustango::sql::raw_query_pool;
+
+let rows = raw_query_pool::<(i64,)>(
+    "SELECT COUNT(*) FROM posts WHERE complicated",
+    vec![],
+    &pool,
+).await?;
+let count = rows.first().map(|r| r.0).unwrap_or(0);
+```
+
+---
+
+## Carga perezosa de FK
+
+Una foreign key empieza conteniendo solo el id relacionado (`Unloaded`), y traes la fila relacionada completa solo cuando la pides — el acceso perezoso a objetos relacionados de Django. Haz `match` sobre el `ForeignKey` para manejar ambos estados, o llama a `.get(&pool)` para cargarlo bajo demanda. Para un lote entero, usa `select_related` (arriba) para precargarlos en una consulta y saltarte el fetch por fila.
+
+```rust
+let mut post = Post::objects().find_or_fail(1, &pool).await?;
+
+// FK starts Unloaded — just the PK. `Loaded` is a struct variant
+// `{ pk, value }`; `value` is a `Box<Author>`.
+match &post.author {
+    ForeignKey::Unloaded(pk) => println!("author id = {pk}"),
+    ForeignKey::Loaded { pk, value } => println!("author = {}", value.name),
+}
+
+// Force-load
+let author = post.author.get(&pool).await?;          // fetches if Unloaded
+```
+
+Usa `select_related("author")` sobre el queryset para precargar un lote.
+
+---
+
+## Cuatro maneras de filtrar
+
+Hay cuatro maneras de expresar un filtro; elige según el contexto. Las columnas tipadas se verifican en tiempo de compilación y son las mejores para el código de aplicación; la forma de string `field__lookup` es la sintaxis familiar de Django para el admin y CRUD genérico; `filter_op` es para cuando ya tienes un `Op` en la mano; la query string de HTTP impulsa la API pública.
+
+```rust
+// 1. HTTP query string (set via ViewSet filter_fields)
+//    GET /api/posts?author_id=42&status__ne=archived
+
+// 2. Django-shape string lookup (the same `field__lookup` grammar your
+//    URL parser uses, but inside Rust). Suffix decides the operator
+//    and value-shape; bare key is exact-eq. Field name is validated
+//    at `.compile()`.
+Post::objects()
+    .filter("status", "published")                 // exact-eq
+    .filter("title__icontains", "rust")            // ILIKE %rust%
+    .filter("views__gt", 100_i64);
+
+// 3. Explicit operator (legacy 3-arg shape — when you want to pass
+//    an Op directly without parsing a suffix)
+Post::objects().filter_op("author_id", Op::Eq, SqlValue::I64(42));
+
+// 4. Typed columns (compile-time field check; preferred in app code)
+Post::objects().where_(Post::author_id.eq(42));
+```
+
+**Convención:** tipado en código de aplicación, forma de Django en código de admin / CRUD genérico, `filter_op` solo cuando ya has calculado un `Op` (p. ej. de un parser de peticiones), query HTTP para la superficie de API pública.
+
+### Sufijos de lookup soportados
+
+| Sufijo | Operador SQL | Forma del valor | Notas |
+|---|---|---|---|
+| *(ninguno)* / `__exact` | `=` | escalar | la clave simple es exact-eq |
+| `__ne` | `<>` | escalar | |
+| `__gt` / `__gte` / `__lt` / `__lte` | `>` `>=` `<` `<=` | escalar | |
+| `__contains` | `LIKE` | string | envuelve el valor como `%v%` |
+| `__icontains` | `ILIKE` | string | envuelve el valor como `%v%`; emulado en MySQL vía `LOWER()` |
+| `__startswith` | `LIKE` | string | envuelve como `v%` |
+| `__istartswith` | `ILIKE` | string | envuelve como `v%` |
+| `__endswith` | `LIKE` | string | envuelve como `%v` |
+| `__iendswith` | `ILIKE` | string | envuelve como `%v` |
+| `__iexact` | `ILIKE` | string | sin envoltura de comodines — coincidencia exacta insensible a mayúsculas |
+| `__in` | `IN (…)` | `SqlValue::List` | rechaza valores que no son listas |
+| `__isnull` | `IS NULL` / `IS NOT NULL` | `bool` | `true` → IS NULL, `false` → IS NOT NULL |
+| `__between` / `__range` | `BETWEEN … AND …` | `SqlValue::List` de 2 elementos | inclusivo en ambos extremos |
+| `__regex` / `__iregex` | PG `~` / `~*`, MySQL/SQLite `REGEXP` | string | insensible a mayúsculas emulado en MySQL/SQLite vía envoltura `LOWER()`; SQLite necesita una función de usuario `regexp` |
+
+**Los errores se exponen en `.compile()`, no en el momento de la llamada a `.filter()`** — los desajustes de forma de valor (p. ej. `__in` con un escalar, `__isnull` con un no-bool, `__between` con la aridad equivocada) y los sufijos desconocidos (`status__nope`) devuelven `QueryError::UnknownLookup` / `QueryError::InvalidLookupValue` desde `.compile()` para que la cadena fluida se mantenga limpia de tipos. Los recorridos encadenados (`author__name__icontains`) **no** están soportados en v0.39 — el splitter toma el sufijo después del primer `__`, así que toda la cola `name__icontains` se trata como un sufijo desconocido.
+
+Cada llamada de filtro se une con AND a cualquier anterior; mezcla la forma de Django, `filter_op` y `where_` libremente en el mismo queryset.
+
+---
+
+## Consultas acotadas por tenant
+
+En una app multi-tenant, ejecuta cada consulta contra la conexión del tenant actual en lugar del pool compartido. Toma una conexión por petición y pásala a `fetch_on` (que acepta cualquier executor de base de datos) en lugar de `fetch` (que siempre usa `&pool`).
+
+```rust
+use rustango::extractors::Tenant;
+
+async fn handler(mut t: Tenant) -> Result<...> {
+    let conn = t.conn();        // &mut PgConnection for this tenant
+    let posts = Post::objects().fetch_on(&mut *conn).await?;
+    Ok(...)
+}
+```
+
+`fetch_on` funciona con cualquier `sqlx::Executor`; `fetch` es azúcar para `fetch_on(&pool)`.
+
+---
+
+## Señales
+
+Ejecuta un callback cuando algo ocurre — las señales de Django. Hay dos registros independientes: uno para escrituras de modelo, otro para peticiones HTTP.
+
+### Ciclo de vida del modelo
+
+Dispara un hook antes o después de que un modelo se guarde o elimine: `pre_save`, `post_save`, `pre_delete`, `post_delete`. Registra uno con `connect_post_save::<Post, _, _>(...)`.
+
+```rust
+use rustango::signals::{connect_post_save, PostSaveContext};
+
+connect_post_save::<Post, _, _>(|post, ctx| async move {
+    if ctx.created {
+        tracing::info!("new post #{}", post.id.get().copied().unwrap_or(0));
+    }
+});
+```
+
+Se requiere `T: Clone + 'static` (el dispatcher entrega a cada receptor un clon `Arc<T>`). Los receptores se ejecutan secuencialmente en orden de registro. Desconecta vía el `ReceiverId` devuelto por `connect_*`. Los cuatro tipos de señal + sus formas de contexto están documentados inline en `rustango::signals`.
+
+### Ciclo de vida de la petición
+
+Dispara un hook alrededor de cada petición HTTP: `request_started`, `request_finished`, `got_request_exception`. Añade el middleware `RequestSignalsLayer` a tu router, luego conecta callbacks. Útil para tracing, auditoría, métricas en tiempo de petición y reporte de errores al estilo de Django.
+
+```rust
+use axum::Router;
+use rustango::signals::request::{
+    connect_request_started, connect_request_finished, RequestSignalsLayer,
+};
+
+connect_request_started(|ctx| Box::pin(async move {
+    tracing::info!(method = %ctx.method, path = %ctx.path, "started");
+}));
+connect_request_finished(|ctx| Box::pin(async move {
+    metrics::histogram!("http_request_ms").record(ctx.elapsed_ms);
+}));
+
+let app: Router = Router::new()
+    .route("/", get(home))
+    .layer(RequestSignalsLayer::new());  // outermost — sees request first / response last
+```
+
+| Señal | Campos de contexto |
+|---|---|
+| `request_started` | `method`, `path`, `query` |
+| `request_finished` | `method`, `path`, `status`, `elapsed_ms` |
+| `got_request_exception` | `method`, `path`, `error` |
+
+Los receptores se ejecutan secuencialmente en orden de registro; envuelve un cuerpo en `tokio::spawn` para fanout paralelo o aislamiento de panics. Los registros de petición y de modelo son independientes — conectar / desconectar / limpiar uno no toca el otro.
+
+---
+
+## Consejos de rendimiento
+
+Una lista de verificación rápida para mantener las consultas veloces a medida que los datos crecen:
+
+- **Usa siempre índices para las columnas de `WHERE` y `ORDER BY`.** Decláralos vía `#[rustango(index)]` para que estén en las migraciones.
+- **`select_related` para mostrar FK en listas** — elimina el N+1 en las vistas de admin/lista.
+- **`page` en lugar de `fetch().drain()`** — nunca cargues tablas enteras.
+- **Paginación con cursor para tablas enormes** — se salta el `COUNT(*)` por página.
+- **`bulk_insert_on` para lotes** — un solo viaje de ida y vuelta en lugar de N.
+- **`upsert_on` para importaciones idempotentes** — `ON CONFLICT` es más rápido que SELECT-luego-INSERT.
+- **`transaction` para escrituras relacionadas** — reduce la sobrecarga de commit y mantiene la consistencia.
+- **Cachea lecturas calientes** con `cache::get_or_set` — invalida en el handler de la señal `connect_post_save<T>(...)`.
+
+---
+
+## Ver también
+
+- [Models](models.md) — declarar un modelo: tipos de campo, primary keys, cada atributo (el complemento de esta guía de consultas).
+- [Serializers](serializers.md) — dar forma a las filas del modelo como JSON.
+- [ViewSets](viewsets.md) — convertir un modelo en una API CRUD JSON.
+- [The admin](admin.md) — una UI auto-generada sobre los mismos modelos.
+- [`manage` CLI](manage.md) — `makemigrations` / `migrate` para cambios de schema.

--- a/docs/es/query-method.md
+++ b/docs/es/query-method.md
@@ -1,0 +1,179 @@
+# El método QUERY
+
+`QUERY` ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008), un Proposed Standard
+publicado en junio de 2026) es el «GET seguro con cuerpo». Es **seguro** e
+**idempotente** como `GET`, pero los criterios de búsqueda viajan en el cuerpo de
+la petición en lugar de en la URL — así una búsqueda compleja no tiene que
+comprimirse en una cadena de consulta, y no hay un límite de longitud de URL.
+**Rustango** enruta `QUERY` junto a `GET` en todo el framework: el enrutamiento, un
+extractor adaptativo al método, la política de CSRF/CORS/reintentos, el caché por
+vista, los ViewSets, el cliente de pruebas y OpenAPI.
+
+> **Fuente:** `rustango::http_query` (`query`, `QueryRouterExt`, `QUERY`) y
+> `rustango::params` (`Params`) — detrás de la característica `admin`. Superficie
+> relacionada: `viewset::ViewSet`, `cache_page::CachePageLayer::cache_query`,
+> `forms::csrf::CsrfConfig::require_csrf_on_query`, `cors::CorsLayer`,
+> `test_client` / `http_client`.
+
+## Cuándo recurrir a él
+
+Usa `QUERY` en lugar de `GET` cuando los criterios de búsqueda sean grandes o
+estructurados:
+
+- Conjuntos de filtros que rebasarían una cadena de consulta (listas `IN` largas,
+  muchas facetas).
+- Criterios anidados / estructurados que no se mapean limpiamente a pares
+  `?key=value` — envíalos como un cuerpo JSON.
+- Cualquier cosa que estarías tentado a modelar como un `POST /search` aunque no
+  lea ningún estado ni cambie nada — `QUERY` dice «esta es una lectura segura y
+  cacheable» en el propio método.
+
+Usa un `GET` simple para peticiones sencillas, cortas y guardables en marcadores.
+`QUERY` es aditivo: el mismo handler puede servir ambos.
+
+## Enrutamiento
+
+axum 0.8 no puede enrutar `QUERY` de forma nativa (su `MethodFilter` es un conjunto
+cerrado — [tokio-rs/axum#3799](https://github.com/tokio-rs/axum/issues/3799)), así
+que rustango proporciona `query()` y una cadena `.query()` que reflejan los propios
+`get()` / `post()` de axum:
+
+```rust
+use rustango::http_query::{query, QueryRouterExt};
+use axum::routing::get;
+
+let app = axum::Router::new()
+    // QUERY-only route.
+    .route("/search", query(search))
+    // GET + QUERY on one path — chain `.query()` last.
+    .route("/products", get(list_products).query(search_products));
+```
+
+Un `405` en una ruta mixta reporta el conjunto completo de métodos, p. ej.
+`Allow: GET,HEAD,QUERY`.
+
+## Un handler, ambos transportes
+
+`Params<T>` lee `T` desde la cadena de consulta en `GET`/`HEAD` y desde el cuerpo de
+la petición en `QUERY`, de modo que un único handler sirve ambos sin ramificación:
+
+```rust
+use rustango::params::Params;
+use rustango::http_query::QueryRouterExt;
+use axum::routing::get;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Search { q: String, page: Option<u32> }
+
+async fn search(Params(s): Params<Search>) -> String {
+    format!("q={} page={:?}", s.q, s.page)
+}
+
+let app = axum::Router::new().route("/search", get(search).query(search));
+```
+
+`GET /search?q=hi` y `QUERY /search` con el cuerpo `q=hi` alcanzan `search` y se
+deserializan de forma idéntica. En `QUERY` el cuerpo se analiza según el
+`Content-Type`:
+
+| `Content-Type` | Analizado como | Notas |
+|---|---|---|
+| `application/x-www-form-urlencoded` (o ninguno) | `serde_urlencoded` | Mismo codepath que la cadena de consulta — plano, un único valor por clave. |
+| `application/json` (o un sufijo `…+json`) | `serde_json` | Úsalo para arrays / criterios anidados. |
+| cualquier otra cosa | — | `415 Unsupported Media Type` |
+
+Los códigos de estado coinciden con las convenciones de axum: un error de análisis
+de la cadena de consulta es un `400`, un error de análisis del cuerpo es un `422`, y
+un método distinto de GET/HEAD/QUERY es un `405`.
+
+```bash
+# urlencoded body
+curl -X QUERY http://localhost:8080/search \
+     -H 'Content-Type: application/x-www-form-urlencoded' \
+     --data 'q=hello&page=2'
+
+# JSON body (arrays / nesting)
+curl -X QUERY http://localhost:8080/search \
+     -H 'Content-Type: application/json' \
+     --data '{"q":"hello","tags":["rust","web"]}'
+```
+
+## ViewSets
+
+Un `ViewSet` obtiene gratis una acción de colección `QUERY` — `QUERY /things` devuelve
+la misma lista filtrada / ordenada / paginada que `GET /things?…`, pero con los
+criterios en el cuerpo:
+
+```bash
+# identical results:
+curl 'http://localhost:8080/posts?status=draft&ordering=-rating'
+curl -X QUERY http://localhost:8080/posts \
+     -H 'Content-Type: application/x-www-form-urlencoded' \
+     --data 'status=draft&ordering=-rating'
+
+# arrays via JSON (comma-joined internally for __in lookups):
+curl -X QUERY http://localhost:8080/posts \
+     -H 'Content-Type: application/json' \
+     --data '{"status__in":["draft","published"],"rating__gte":2}'
+```
+
+Los permisos y throttles reutilizan los de la acción `list`, y las vistas de
+administración personalizadas declaradas con el método `QUERY` también se enrutan
+correctamente.
+
+## Garantías del framework
+
+- **CSRF.** `QUERY` está exento por defecto de la aplicación de tokens CSRF, junto a
+  `GET`/`HEAD`/`OPTIONS`/`TRACE`. Los navegadores no pueden enviar `QUERY` mediante
+  formulario, y un `fetch` de origen cruzado con el método `QUERY` nunca es una
+  «petición simple» de la lista blanca de CORS — siempre desencadena un preflight —
+  por lo que no hay un vector CSRF por credenciales ambientales. Establece
+  `CsrfConfig::require_csrf_on_query = true` para pura defensa en profundidad. Mantén
+  los handlers `QUERY` sin efectos secundarios, y nunca añadas `QUERY` a la lista de
+  permitidos de la [sobrescritura de método](middleware.md).
+- **CORS.** `QUERY` está en las listas de métodos `permissive()` y derivadas de la
+  configuración. Como cada `QUERY` de origen cruzado hace un preflight, debe
+  anunciarse en `Access-Control-Allow-Methods` para funcionar en origen cruzado.
+- **Reintentos.** El cliente HTTP (`http_client`) trata `QUERY` como idempotente,
+  así que se reintenta ante fallos transitorios como `GET`.
+- **Idempotencia.** `QUERY` no necesita ningún `Idempotency-Key` — el método es
+  idempotente por definición.
+- **Caché.** `cache_page` puede cachear las respuestas `QUERY` cuando lo habilitas
+  con `CachePageLayer::cache_query(true)`. La clave de caché incorpora un resumen del
+  cuerpo de la petición, y la respuesta se marca como `private` para que los cachés
+  compartidos (que no pueden basarse en un cuerpo) nunca la sirvan erróneamente. Ver
+  [Caché](caching.md).
+
+## Pruebas
+
+`TestClient` y `RequestFactory` tienen constructores `.query()`, y el `HttpClient`
+saliente puede enviar `QUERY`:
+
+```rust
+let resp = client.query("/search").json(&criteria).send().await;
+```
+
+## OpenAPI
+
+OpenAPI 3.1 no tiene una operación `QUERY`; [OpenAPI 3.2](https://www.openapis.org/blog/2025/09/23/announcing-openapi-v3-2)
+la añadió como un campo Path Item de primera clase. Rustango emite una operación
+`query` cuando adjuntas una, y sube la especificación a `openapi: 3.2.0` solo para
+las especificaciones que la usan (las especificaciones sin `QUERY` permanecen en
+`3.1.0` para máxima compatibilidad con las herramientas):
+
+```rust
+use rustango::openapi::{OpenApiSpec, PathItem, Operation, RequestBody, Response, Schema};
+
+let spec = OpenApiSpec::new("API", "1.0").add_path(
+    "/posts",
+    PathItem::new()
+        .get(Operation::new().summary("List posts").response("200", Response::new("OK")))
+        .query(
+            Operation::new()
+                .summary("Search posts")
+                .request_body(RequestBody::json(Schema::ref_("SearchCriteria")))
+                .response("200", Response::new("OK")),
+        ),
+);
+```

--- a/docs/es/scaffolding.md
+++ b/docs/es/scaffolding.md
@@ -1,0 +1,184 @@
+# Andamiaje
+
+**Rustango** tiene dos capas de generación de código, ambas inspiradas en los generadores que conoces de Django y Laravel — así rara vez conectas boilerplate a mano:
+
+1. **El generador de proyectos** — `cargo rustango new` crea un proyecto entero nuevo a partir de una plantilla.
+2. **Generadores dentro del proyecto** — `manage startapp` y la familia `manage make:*` añaden apps, vistas, serializers, jobs y más dentro de un proyecto existente.
+
+[![`cargo rustango new` genera un proyecto completo y listo para ejecutar — manifiesto de Cargo, niveles de configuración, Docker, migraciones y src — en un solo comando](img/scaffolding.png)](img/scaffolding.png)
+
+## Tabla de contenidos
+
+- [Instalar el generador](#install-the-generator)
+- [Crear un proyecto: `cargo rustango new`](#create-a-project-cargo-rustango-new)
+- [Qué se genera](#what-gets-generated)
+- [Añadir un módulo de funcionalidad: `manage startapp`](#add-a-feature-module-manage-startapp)
+- [Generar archivos sueltos: los comandos `make:*`](#generate-single-files-the-make-commands)
+- [Un flujo típico](#a-typical-flow)
+
+---
+
+## Instalar el generador
+
+`cargo rustango` es un subcomando de Cargo. Instálalo una vez, de forma global:
+
+```sh
+cargo install cargo-rustango
+```
+
+Eso coloca un binario `cargo-rustango` en tu `PATH`; Cargo lo expone entonces como `cargo rustango` (del mismo modo que `django-admin` o el instalador `laravel` te dan un comando global).
+
+---
+
+## Crear un proyecto: `cargo rustango new`
+
+```sh
+cargo rustango new <name> [--template api|fullstack|tenant]
+```
+
+- **`<name>`** — el nombre del proyecto (y de la crate). Debe ser un nombre de crate de Cargo válido (`[A-Za-z_][A-Za-z0-9_-]*`), y el directorio de destino no debe existir ya.
+- **`--template` / `-t`** — qué plantilla inicial generar (por defecto: **fullstack**).
+- **`--help` / `-h`**, **`--version`** — uso y versión.
+
+### Las tres plantillas
+
+Cada una se corresponde con una de las tres formas de app de **Rustango**:
+
+| Plantilla | Lo que obtienes | Recurre a ella cuando |
+|---|---|---|
+| `api` | ORM + Axum a secas, **sin admin** | Servicios solo-JSON y microservicios |
+| `fullstack` *(por defecto)* | ORM + el **auto-admin** | Una app web típica con back-office |
+| `tenant` | Multi-tenancy + consola de operador + apps por tenant | SaaS que aloja muchos tenants aislados |
+
+```sh
+cargo rustango new myblog                      # fullstack (the default)
+cargo rustango new api_demo  --template api
+cargo rustango new shop      --template tenant
+```
+
+---
+
+## Qué se genera
+
+Cada plantilla escribe un proyecto de Cargo autocontenido:
+
+```text
+<name>/
+  Cargo.toml            # the rustango dependency + features for this template
+  .env.example          # copy to .env (DATABASE_URL, RUSTANGO_SESSION_SECRET, …)
+  .gitignore
+  rust-toolchain.toml   # pins the Rust toolchain
+  docker-compose.yml    # a Postgres service to develop against
+  Dockerfile            # production image
+  README.md
+  config/
+    default.toml        # settings shared across every environment
+    dev_settings.toml   # per-tier overrides …
+    staging_settings.toml
+    prod_settings.toml
+  migrations/           # JSON migration files (committed to git)
+  src/
+    main.rs             # the single binary — HTTP server + every manage verb
+    models.rs           # your #[derive(Model)] structs
+    views.rs            # request handlers ("views")
+    urls.rs             # pub fn api() -> Router that aggregates your routes
+```
+
+### Un binario para todo
+
+`src/main.rs` es el único punto de entrada. Arranca el servidor HTTP **y** despacha cada verbo de `manage` — no hay un `manage.py` ni un `src/bin/manage.rs` aparte:
+
+```rust
+mod models;
+mod urls;
+mod views;
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = dotenvy::dotenv();
+    rustango::manage::Cli::new()
+        .api(urls::api())
+        .with_welcome()  // friendly `/` page until you add a root handler
+        .with_health()   // /health + /ready endpoints (fullstack & tenant)
+        .run()
+        .await
+}
+```
+
+Así que `cargo run` arranca el servidor, y `cargo run -- <verb>` ejecuta migraciones, generadores y lo demás.
+
+Cómo difieren las plantillas dentro de `main.rs` / `urls.rs`:
+
+- **api** — sin admin; `urls::api()` simplemente agrega tus propias rutas.
+- **fullstack** — `urls.rs` también expone `admin_router(pool)` (construido a partir de `admin::Builder::new(pool).build()`) para que el auto-admin se monte en `/admin`.
+- **tenant** — `main.rs` añade `.tenancy()`, sirviendo la consola de operador en el dominio ápice y cada tenant bajo su propio subdominio. Las propias tablas del framework se generan en una carpeta **`system/migrations/`** a partir de los modelos compilados (al estilo de Django) en el primer `cargo run -- migrate` — sin JSON de bootstrap entregado a mano, así que la primerísima migración funciona sin configuración adicional.
+
+### Configuración por capas
+
+Los ajustes cargan primero `config/default.toml`, luego `config/<RUSTANGO_ENV>_settings.toml` encima. `RUSTANGO_ENV` es `dev` por defecto, así que un `cargo run` recién generado funciona sin ediciones; establece `RUSTANGO_ENV=prod` en producción para recoger `prod_settings.toml`.
+
+### Primera ejecución
+
+```sh
+cd <name>
+cp .env.example .env
+docker compose up -d        # start Postgres
+cargo run -- migrate        # apply migrations
+cargo run                   # serve
+cargo run -- --help         # see every manage verb
+```
+
+---
+
+## Añadir un módulo de funcionalidad: `manage startapp`
+
+Este es el `startapp` de Django — genera un módulo autocontenido de modelos, vistas y rutas relacionados:
+
+```sh
+cargo run -- startapp blog
+```
+
+Escribe `src/blog/` conteniendo `mod.rs`, `models.rs` (un modelo inicial nombrado según la forma singular de la app — `blog` → `Blog`), `views.rs`, `urls.rs` y `tests.rs`, luego declara el módulo en `src/main.rs` y fusiona sus rutas en `urls::api()`.
+
+Opciones:
+
+- **`--into <dir>`** — genera el andamiaje bajo un directorio base distinto de `src/` (p. ej. un miembro del workspace).
+- **`--with-manage-bin`** — emite además un `bin/manage.rs` (para diseños que prefieren un binario de manage aparte).
+
+---
+
+## Generar archivos sueltos: los comandos `make:*`
+
+Dentro de un proyecto, los verbos `make:*` generan el andamiaje de un archivo cada vez. La referencia completa por flag vive en la [referencia de la CLI de manage](manage); las formas comunes son:
+
+| Comando | Genera | Comparable a |
+|---|---|---|
+| `make:viewset <Name> [--model <M>]` | Un ViewSet CRUD al estilo de DRF | `ViewSet` de DRF |
+| `make:serializer <Name> [--model <M>]` | Un serializer para dar forma a request/response | serializer de DRF |
+| `make:api_routes <app>` | Un agregador de rutas de API para una app | — |
+| `make:form <Name>` | Un formulario HTML con validación | `Form` de Django |
+| `make:job <Name>` | Un handler de job en segundo plano | job de Laravel / Celery |
+| `make:notification <Name>` | Una notificación multicanal | notificación de Laravel |
+| `make:middleware <Name>` | Un esqueleto de middleware | middleware de Django / Laravel |
+| `make:test <Name>` | Un módulo de pruebas usando el cliente de pruebas en el mismo proceso | — |
+
+```sh
+cargo run -- make:viewset PostViewSet --model Post
+cargo run -- make:serializer PostSerializer --model Post
+cargo run -- make:test post_smoke
+```
+
+---
+
+## Un flujo típico
+
+```sh
+cargo rustango new myblog                              # 1. scaffold the project
+cd myblog
+cargo run -- startapp blog                             # 2. add a feature module
+# …add fields to src/blog/models.rs…
+cargo run -- makemigrations                            # 3. generate a migration
+cargo run -- migrate                                   # 4. apply it
+cargo run -- make:viewset PostViewSet --model Post     # 5. expose a JSON API
+cargo run                                              # 6. serve
+```

--- a/docs/es/security.md
+++ b/docs/es/security.md
@@ -1,0 +1,672 @@
+# Guía de seguridad
+
+Esta guía cubre todas las funciones de seguridad que incluye **Rustango** y cómo combinarlas. Si vienes de Django, Laravel o Rails, la mayoría te resultarán familiares — los nombres difieren, pero las ideas son las mismas. Cada función de abajo suele ser una sola línea de configuración. Cuando estés listo para desplegar, ejecuta `manage check --deploy` para una auditoría automatizada.
+
+[![La pila de middleware endurecida conectada en una sola cadena: identificadores de petición, registro de accesos, limitación de tasa, CORS y cabeceras de seguridad](img/security.png)](img/security.png)
+
+## Tabla de contenidos
+
+- [La lista de comprobación de defensa en profundidad](#the-defense-in-depth-checklist)
+- [Establecer cabeceras de seguridad](#setting-security-headers)
+- [Permitir peticiones de origen cruzado (CORS)](#allowing-cross-origin-requests-cors)
+- [Limitar la tasa de peticiones](#rate-limiting-requests)
+- [Permitir o bloquear IPs](#allowing-or-blocking-ips)
+- [Protección contra CSRF](#protecting-against-csrf)
+- [Prevenir XSS](#preventing-xss)
+- [Prevenir la inyección SQL](#preventing-sql-injection)
+- [Autenticar usuarios](#authenticating-users)
+- [Hashear y verificar contraseñas](#hashing-and-checking-passwords)
+- [Emitir y refrescar JWTs](#issuing-and-refreshing-jwts)
+- [Autenticar con claves de API](#authenticating-with-api-keys)
+- [Añadir autenticación de dos factores (TOTP)](#adding-two-factor-auth-totp)
+- [Enviar URLs firmadas (enlaces mágicos)](#sending-signed-urls-magic-links)
+- [Verificar webhooks entrantes](#verifying-incoming-webhooks)
+- [Mantener los secretos fuera de tus registros](#keeping-secrets-out-of-your-logs)
+- [Rastrear peticiones a través de servicios](#tracing-requests-across-services)
+- [Gestionar secretos](#managing-secrets)
+- [Auditar antes de desplegar](#auditing-before-you-deploy)
+
+---
+
+## La lista de comprobación de defensa en profundidad
+
+La buena seguridad surge de muchas capas pequeñas, no de un único gran muro. Una aplicación **Rustango** en producción debería apilar las capas de abajo — la mayoría son una línea cada una. El resto de esta guía explica cada una.
+
+```rust
+let app = Router::new()
+    .route("/...", ...)
+    .merge(health::health_router(pool.clone()))         // /health, /ready
+    .request_id(RequestIdLayer::default())              // log correlation
+    .access_log(AccessLogLayer::default())              // PII-redacted by default
+    .rate_limit(RateLimitLayer::per_ip(60, ONE_MIN))    // 60 req/min/IP
+    .cors(CorsLayer::new().allow_origins(vec!["..."])) // explicit allowlist
+    .security_headers(                                   // HSTS + XFO + nosniff + Referrer + CSP
+        SecurityHeadersLayer::strict()
+            .csp(CspBuilder::strict_starter().build()),
+    );
+// Plus: TLS termination at reverse proxy.
+// Plus: argon2 for passwords, JWT lifecycle for tokens, TOTP for MFA.
+```
+
+---
+
+## Establecer cabeceras de seguridad
+
+Las cabeceras de seguridad le indican al navegador cómo proteger a tus usuarios (bloquear el clickjacking, forzar HTTPS, detener el sniffing del tipo de contenido). `SecurityHeadersLayer` establece el conjunto estándar con una sola línea — las mismas cabeceras que Django incluye por defecto. (Una "capa" es el término de **Rustango** para el middleware; la adjuntas a tu router.)
+
+> Análisis en profundidad: [Middleware](middleware.md) cubre cómo funcionan las capas, el orden, el catálogo completo de las incorporadas, y cómo escribir la tuya propia (locale, zona horaria, cabeceras, CSRF).
+
+```rust
+use rustango::security_headers::{SecurityHeadersLayer, SecurityHeadersRouterExt, CspBuilder};
+
+let app = router.security_headers(SecurityHeadersLayer::strict());
+```
+
+### Preajustes
+
+| Preajuste | Cuándo usarlo |
+|---|---|
+| `strict()` | Producción: HSTS preload + XFO=DENY + nosniff + Referrer-Policy=no-referrer + COOP=same-origin + Permissions-Policy restringida |
+| `relaxed()` | Incrustable en iframes: SAMEORIGIN + HSTS de 1 año |
+| `dev()` | Local: solo nosniff (sin HSTS para evitar bloquear localhost en HTTPS para siempre) |
+| `empty()` | Construir desde cero |
+
+### CSP personalizada
+
+```rust
+let csp = CspBuilder::new()
+    .default_src(&["'self'"])
+    .script_src(&["'self'", "https://cdn.example.com"])
+    .style_src(&["'self'", "'unsafe-inline'"])    // for inline <style>
+    .img_src(&["'self'", "data:", "https:"])
+    .font_src(&["'self'", "data:"])
+    .connect_src(&["'self'", "wss://realtime.example.com"])
+    .frame_ancestors(&["'none'"])                 // disallow embedding (clickjacking)
+    .object_src(&["'none'"])
+    .directive("base-uri", &["'self'"])
+    .build();
+
+let layer = SecurityHeadersLayer::strict().csp(csp);
+```
+
+### Despliegue gradual de CSP
+
+Usa `csp_report_only` para monitorizar sin romper producción:
+
+```rust
+let layer = SecurityHeadersLayer::strict()
+    .csp(CspBuilder::strict_starter().build())
+    .csp_report_only(true);                       // sends Content-Security-Policy-Report-Only
+```
+
+Tras verificar que no hay errores de consola → cambia a `csp_report_only(false)` para aplicarla.
+
+---
+
+## Permitir peticiones de origen cruzado (CORS)
+
+CORS controla qué otros sitios web tienen permiso para llamar a tu API desde un navegador. Por defecto los navegadores bloquean estas llamadas; tú vuelves a habilitar orígenes específicos. Enumera tus dominios front-end reales en producción y nunca lo abras a todo el mundo.
+
+```rust
+use rustango::cors::{CorsLayer, CorsRouterExt};
+
+// Production
+let layer = CorsLayer::new()
+    .allow_origins(vec!["https://app.example.com", "https://admin.example.com"])
+    .allow_methods(vec!["GET", "POST", "PUT", "PATCH", "DELETE"])
+    .allow_headers(vec!["content-type", "authorization"])
+    .allow_credentials(true)
+    .max_age(Duration::from_secs(3600));
+
+// Dev only
+let layer = CorsLayer::permissive();              // any origin, common methods
+```
+
+**Nota de seguridad:** nunca combines `allow_credentials(true)` con `allow_any_origin()` — el navegador rechazará la respuesta. Con credenciales, DEBES enumerar orígenes explícitos.
+
+---
+
+## Limitar la tasa de peticiones
+
+La limitación de tasa restringe cuántas peticiones puede hacer un cliente en una ventana de tiempo. Úsala para frenar los inicios de sesión por fuerza bruta, el scraping y el abuso. Puedes limitar por IP, por clave de API o globalmente para un endpoint costoso.
+
+```rust
+use rustango::rate_limit::{RateLimitLayer, RateLimitRouterExt};
+
+// Per-IP
+router.rate_limit(RateLimitLayer::per_ip(60, Duration::from_secs(60)));
+
+// Per-API-key (header)
+router.rate_limit(RateLimitLayer::per_header("authorization", 1000, Duration::from_secs(3600)));
+
+// Global ceiling for an expensive endpoint
+router.rate_limit(RateLimitLayer::global(10, Duration::from_secs(1)));
+```
+
+Cuando se agota: `429 Too Many Requests` con la cabecera `Retry-After`. Cada respuesta exitosa incluye `X-RateLimit-Limit` + `X-RateLimit-Remaining`.
+
+> **Detrás de un proxy inverso, empareja `per_ip` con `real_ip`.** `RateLimitLayer::per_ip` se basa en el socket de conexión (`ConnectInfo`), que detrás de un proxy es la IP del *proxy* — de modo que todos los clientes comparten un único cubo y el límite resulta inútil. Coloca `real_ip::RealIpLayer` (lee `X-Forwarded-For` / `X-Real-IP`) delante de él para que se use la IP real del cliente.
+
+`RateLimitLayer` es **local al proceso** — cuenta las peticiones solo dentro de una instancia en ejecución, lo cual está bien si ejecutas una sola instancia. Si ejecutas varias instancias (réplicas) detrás de un balanceador de carga, cada una mantendría su propio recuento, de modo que el límite real se multiplica. Para compartir un único recuento entre todas las réplicas, usa `rate_limit_cache::CacheRateLimitLayer`, que delega en cualquier implementación de `cache::Cache` (empareja con `cache::RedisCache` para un contador compartido incrementado atómicamente por el `INCRBY` de Redis):
+
+```rust
+use rustango::cache::RedisCache;
+use rustango::rate_limit::KeyBy;
+use rustango::rate_limit_cache::{CacheRateLimitLayer, CacheRateLimitRouterExt};
+
+let cache: rustango::cache::BoxedCache =
+    std::sync::Arc::new(RedisCache::new("redis://localhost").await?);
+
+let app = axum::Router::new()
+    .route("/api/login", axum::routing::post(login))
+    .cache_rate_limit(
+        CacheRateLimitLayer::new(cache, 5, Duration::from_secs(60))
+            .key_by(KeyBy::Ip)
+            .key_prefix("login"),
+    );
+```
+
+---
+
+## Permitir o bloquear IPs
+
+Restringe las rutas sensibles (como tu admin) a un conjunto conocido de direcciones IP, o bloquea a abusadores concretos. Una lista de permitidos autoriza solo las redes enumeradas; una lista de bloqueo deniega las enumeradas.
+
+```rust
+use rustango::ip_filter::{IpFilterLayer, IpFilterRouterExt};
+
+// Internal admin only
+let admin_router = admin_router
+    .ip_filter(IpFilterLayer::allow_only(vec![
+        "10.0.0.0/8",
+        "192.168.0.0/16",
+        "203.0.113.0/24",
+    ])?);
+
+// Block known abusers
+let public_router = public_router
+    .ip_filter(IpFilterLayer::block(vec!["203.0.113.42"])?);
+```
+
+**IPv4 + IPv6 soportados.** Seguro entre familias (un CIDR IPv4 no coincide con direcciones IPv6). Devuelve `403 Forbidden` al rechazar.
+
+**Importante:** **Rustango** lee la IP del cliente desde `ConnectInfo<SocketAddr>`. Monta con:
+
+```rust
+axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await?;
+```
+
+Si tu proxy inverso reenvía `X-Forwarded-For`, configúralo para que establezca `RemoteAddr` — `ip_filter` lee el par de conexión, no las cabeceras.
+
+---
+
+## Protección contra CSRF
+
+> **CSRF y las APIs de token.** CSRF protege las peticiones **autenticadas por
+> cookie**. Una API puramente de token / Bearer / [JWT](auth-jwt.md) no es un
+> objetivo de CSRF — no le apliques la capa CSRF (o darás un 403 a clientes
+> legítimos). Para una SPA que *sí* usa cookies, lee la cookie `rustango_csrf`
+> y reenvíala en la cabecera `X-CSRF-Token`.
+
+CSRF (falsificación de petición en sitios cruzados) es cuando otro sitio engaña al navegador de un usuario que ha iniciado sesión para que envíe una petición a tu aplicación. La defensa es un token secreto en cada formulario, igual que el `{% csrf_token %}` de Django. El middleware CSRF vive en `rustango::forms::csrf` (detrás de la función `csrf`, que se activa automáticamente con la función `admin`):
+
+```rust
+use rustango::forms::csrf;
+
+let app = Router::new()
+    .route("/contact", get(form).post(submit))
+    .layer(csrf::layer());
+```
+
+`csrf::layer()` construye la capa con valores predeterminados sensatos; `csrf::with_config(CsrfConfig)` te permite sobrescribir los nombres de la cookie/cabecera y el flag `Secure`. En las plantillas, `{{ csrf_token }}` te da el token en bruto y `{{ csrf_input }}` te da un `<input>` oculto listo para usar — coloca uno dentro de cada formulario. Usa el patrón de cookie de doble envío: en los métodos inseguros (POST, PUT, PATCH, DELETE) la capa comprueba la cabecera `X-CSRF-Token` (o el campo de formulario `_csrf`) contra la cookie `rustango_csrf`; una discrepancia devuelve `403 Forbidden`.
+
+**Eximir endpoints recolectores.** `CsrfConfig::exempt_prefix("/path")` (repetible) omite la aplicación de CSRF para los métodos inseguros en peticiones cuya ruta comienza con el prefijo dado. Esto es para endpoints de solo anexado, sin estado de autenticación, alcanzados vía `navigator.sendBeacon` — por ejemplo, un recolector de analíticas — que no pueden establecer una cabecera `X-CSRF-Token` y, cuando la página se sirve desde una caché de CDN que elimina `Set-Cookie`, puede que no lleven ninguna cookie CSRF en absoluto. Mantén los prefijos estrechos y nunca eximas nada que lea o escriba estado de autenticación.
+
+El auto-admin habilita CSRF en cada mutación por defecto, y no hay forma de desactivarlo.
+
+---
+
+## Prevenir XSS
+
+XSS (scripting entre sitios) ocurre cuando la entrada del usuario se renderiza como HTML y se ejecuta como código en el navegador de otra persona. La solución es escapar cualquier entrada del usuario antes de que llegue a la página. **Rustango** maneja esto de dos maneras:
+
+**1. Auto-escape de plantillas Tera** — Tera es el motor de plantillas de **Rustango** (como las plantillas de Django o Blade). Cada `{{ var }}` se escapa como HTML automáticamente. Usa `{{ var | safe }}` para desactivarlo — raro, y peligroso, así que hazlo solo con HTML en el que confíes plenamente.
+
+**2. Ayudante de escape manual** — para cuando construyes HTML en código Rust en lugar de en una plantilla:
+
+```rust
+use rustango::text::html_escape;
+
+let safe = html_escape(user_input);
+// "<script>" → "&lt;script&gt;"
+// "a & b" → "a &amp; b"
+```
+
+Reemplaza `&`, `<`, `>`, `"`, `'`. Adecuado para el contenido de elementos HTML + atributos entre comillas dobles.
+
+Para la defensa XSS basada en CSP, consulta [Establecer cabeceras de seguridad](#setting-security-headers).
+
+---
+
+## Prevenir la inyección SQL
+
+La inyección SQL ocurre cuando la entrada del usuario se pega directamente en una cadena SQL y cambia la consulta. El ORM de **Rustango** detiene esto por diseño: usa el enlace de parámetros de sqlx en todas partes — cada valor se envía como un marcador de posición `$1, $2, ...`, nunca pegado en el texto de la consulta. (sqlx es la biblioteca de base de datos subyacente.) **No puedes concatenar accidentalmente la entrada del usuario en SQL a través de la API del ORM.**
+
+Hay dos puntos en los que hay que tener cuidado:
+
+**1. Nombres de tabla y columna en `bulk_actions`:**
+
+Los marcadores de posición protegen los valores, pero no pueden llevar un identificador (un nombre de tabla o columna), así que esos necesitan su propia protección. El ejecutor de acciones masivas nunca pega nombres de tabla/columna suministrados por el usuario en bruto dentro del SQL. Internamente valida cada identificador (un `validate_ident` privado al crate que rechaza `"`, `` ` ``, `\0`, `\n`, `\r`, `\`, `;`, espacios y caracteres de control) y luego lo entrecomilla mediante `dialect.quote_ident()` antes de construir la sentencia. Esta protección se ejecuta por ti — no la llamas tú mismo.
+
+**2. La salida de emergencia de SQL en bruto:**
+
+Si desciendes a `sqlx` en bruto, enlaza cada *valor* como un parámetro y nunca pegues un *identificador* (nombre de tabla o columna) que provenga de la entrada del usuario en la cadena de la consulta — los marcadores de posición no pueden llevar identificadores:
+
+```rust
+// ✅ values go through bound placeholders
+sqlx::query("SELECT * FROM posts WHERE id = $1")
+    .bind(1).fetch_all(&pool).await?;
+
+// ❌ NEVER interpolate a user-supplied identifier into the SQL string
+let sql = format!("SELECT * FROM \"{user_table}\" WHERE id = $1");
+sqlx::query(&sql).bind(1).fetch_all(&pool).await?;
+```
+
+---
+
+## Autenticar usuarios
+
+La autenticación es cómo confirmas quién está haciendo una petición. **Rustango** incluye tres backends listos para usar (autenticación Basic, claves de API y JWTs) y te permite escribir el tuyo propio — muy parecido a los backends de autenticación de Django. Los adjuntas a las rutas, y las peticiones sin una credencial reconocida obtienen un `401`.
+
+> **SSO del admin.** Para permitir que los operadores inicien sesión en el admin con
+> un IdP externo (Google, Microsoft/Azure AD, GitHub, o cualquier proveedor
+> OpenID Connect) en lugar de una contraseña, habilita la función `admin-sso` —
+> consulta la [guía de SSO](sso.md). Los proveedores se **gestionan desde la UI
+> del admin como filas** (varios por superficie; por inquilino, o un conjunto
+> compartido entre inquilinos), con el secreto de cliente **cifrado en reposo**.
+> Es enlace-a-existente (el email verificado del IdP debe coincidir con un usuario
+> del admin; sin auto-aprovisionamiento) y reutiliza la sesión existente.
+
+### Tres backends listos para usar
+
+```rust
+use rustango::tenancy::auth_backends::{ModelBackend, ApiKeyBackend, JwtBackend};
+use rustango::tenancy::middleware::{RouterAuthExt, CurrentUser};
+use std::sync::Arc;
+
+let backends = vec![
+    Arc::new(ModelBackend) as _,                   // Authorization: Basic <b64>
+    Arc::new(ApiKeyBackend) as _,                   // Authorization: Bearer <prefix>.<secret>
+    Arc::new(JwtBackend::new(secret)) as _,         // Authorization: Bearer <jwt>
+];
+
+let app = Router::new()
+    .route("/me", get(profile))
+    .require_auth(backends.clone(), pool.clone())   // 401 if no backend recognizes
+    .route("/posts/new", post(create_post))
+    .require_perm("post.add", pool.clone())         // gate by codename
+    .require_auth(backends, pool);
+```
+
+El middleware prueba cada backend en orden. El primero que tiene éxito gana; el primero que devuelve un error duro detiene la cadena.
+
+### Escribir tu propio backend
+
+```rust
+use rustango::tenancy::auth_backends::{AuthBackend, AuthUser, AuthError};
+use async_trait::async_trait;
+
+pub struct OAuthBackend { /* ... */ }
+
+#[async_trait]
+impl AuthBackend for OAuthBackend {
+    async fn authenticate(&self, parts: &Parts, pool: &rustango::sql::Pool)
+        -> Result<Option<AuthUser>, AuthError>
+    {
+        // Read your custom header, validate, look up the user
+        Ok(None)  // means: not my request, try next backend
+    }
+}
+```
+
+---
+
+## Hashear y verificar contraseñas
+
+Nunca almacenes las contraseñas como texto plano. Hashéalas al registrarse con `hash`, y al iniciar sesión compara el intento con `verify`. Usa `strength_score` para rechazar contraseñas débiles antes siquiera de hashearlas.
+
+```rust
+use rustango::passwords::{hash, verify, strength_score, StrengthIssue};
+
+// Signup
+let issues = strength_score(&new_password);
+if !issues.is_empty() {
+    return Err(format!("password too weak: {issues:?}"));
+}
+let hashed = hash(&new_password)?;
+
+// Login
+let ok = verify(&attempted, &user.password_hash)?;
+```
+
+El hasheo usa **argon2id** (el valor predeterminado recomendado por OWASP desde 2023 — resiste mejor el crackeo por GPU que bcrypt). Los hashes se almacenan en formato de cadena PHC, así que puedes cambiar los parámetros más tarde sin romper los hashes antiguos.
+
+La **comprobación de fortaleza** incorporada es intencionadamente mínima. Para despliegues serios, comprueba también las contraseñas contra la API HIBP / pwned-passwords para rechazar las que se sabe que se han filtrado.
+
+> **Análisis en profundidad:** [Contraseñas](auth-passwords.md) — internos de argon2id, salado automático, inicios de sesión seguros ante el tiempo (`verify_dummy`), y dónde vive el hash. Una vez autenticado, delega en una [Sesión](auth-sessions.md) (navegador) o un [JWT](auth-jwt.md) (API).
+
+---
+
+## Emitir y refrescar JWTs
+
+Un JWT (JSON Web Token) es un token firmado que un cliente envía en lugar de iniciar sesión cada vez. `JwtLifecycle` maneja todo el flujo: un token de acceso de corta duración más un token de refresco de mayor duración, con verificación, refresco y revocación incorporados.
+
+```rust
+use rustango::tenancy::jwt_lifecycle::{JwtLifecycle, JwtTokenPair, JwtIssueError};
+use serde_json::json;
+
+let jwt = JwtLifecycle::new(secret)
+    .with_access_ttl(900)                         // 15 min
+    .with_refresh_ttl(7 * 86400);                 // 7 days
+```
+
+### Emitir un token con claims personalizados (sin consulta a la BD al verificar)
+
+```rust
+let pair = jwt.issue_pair_with(user_id, json!({
+    "roles":  ["admin", "editor"],
+    "tenant": "acme",
+    "scope":  "read:posts write:posts",
+    "email":  "alice@example.com",
+}).as_object().unwrap().clone())?;
+```
+
+Los "claims" son los hechos clave/valor que incrustas en el token (roles, inquilino, etc.); el cliente los devuelve y tú los lees sin tocar la base de datos. Los nombres de claim reservados (`sub`, `exp`, `jti`, `typ`) son usados por el framework y no pueden aparecer en tus claims personalizados — intentarlo devuelve `JwtIssueError::ReservedClaim`.
+
+### Verificar un token
+
+```rust
+let claims = jwt.verify_access(&access_token)
+    .ok_or(StatusCode::UNAUTHORIZED)?;
+
+let roles: Vec<String> = claims.get_custom("roles").unwrap_or_default();
+let tenant: String = claims.get_custom("tenant").unwrap_or_default();
+```
+
+### Refrescar un token (mantiene tus claims personalizados)
+
+```rust
+let new_pair = jwt.refresh(&refresh_token)
+    .ok_or(StatusCode::UNAUTHORIZED)?;
+// new_pair has the same roles + scope + tenant
+```
+
+El JTI (su ID único) del antiguo token de refresco se añade a una lista negra para que no pueda reutilizarse — esto bloquea los ataques de repetición donde se reenvía un token antiguo robado.
+
+### Refrescar con permisos revisados de nuevo
+
+```rust
+// returns Result<Option<JwtTokenPair>, JwtIssueError>:
+// Err on a reserved-claim collision, Ok(None) on an invalid/expired refresh.
+let new_pair = jwt.refresh_with(&refresh_token, json!({
+    "roles": ["viewer"],     // role was demoted since login
+    "tenant": "acme",
+}).as_object().unwrap().clone())?
+    .ok_or(StatusCode::UNAUTHORIZED)?;
+```
+
+### Revocar un token
+
+```rust
+jwt.revoke(&access_token);     // adds JTI to blacklist
+jwt.revoke(&refresh_token);
+```
+
+La lista negra en memoria por defecto (`InMemoryJtiStore`) limpia por sí sola las entradas caducadas, pero vive en un único proceso y olvida cada revocación al reiniciar. Para despliegues multiproceso, instala un almacén compartido y duradero vía `JwtLifecycle::new(secret).with_jti_store(store)` — `store` es cualquier `Arc<dyn JtiStore>` (por ejemplo uno respaldado por Redis o por BD). Sin un almacén compartido, un token que revocas en una réplica todavía puede repetirse en otra hasta que caduque.
+
+> **Análisis en profundidad:** [API de auth JWT](auth-jwt-api.md) — el router incorporado `/api/auth/login|refresh|logout|me`, el refresco deslizante, y el almacén de revocación de JTI. Para un único token autogestionado, consulta [JWT (independiente)](auth-jwt.md). Para restringir rutas de navegador/API por inicio de sesión, consulta los [decoradores de acceso](auth-decorators.md).
+
+---
+
+## Autenticar con claves de API
+
+Las claves de API permiten que scripts y servicios se autentiquen sin nombre de usuario, contraseña o sesión — útil para el acceso máquina a máquina. Generas una clave, se la muestras al usuario una vez, y almacenas solo su prefijo y su hash.
+
+```rust
+use rustango::api_keys::{generate_key, verify_key, split_token};
+
+// Issuance
+let (full_token, prefix, hash) = generate_key()?;
+// Format: {8-char hex prefix}.{32-char hex secret}
+// Show full_token to the user once. Store prefix + hash in your DB.
+
+// Verification on each request
+let (prefix, secret) = split_token(&inbound_header)
+    .ok_or(StatusCode::UNAUTHORIZED)?;
+let row = lookup_by_prefix(prefix).await?;
+if !verify_key(secret, &row.hash)? {
+    return Err(StatusCode::UNAUTHORIZED);
+}
+```
+
+Estas claves funcionan directamente con el `ApiKeyBackend` de multi-tenencia — ambos usan el mismo formato `{prefix}.{secret}` con secretos hasheados con argon2id, así que una clave emitida aquí autentica allí sin trabajo adicional.
+
+---
+
+## Añadir autenticación de dos factores (TOTP)
+
+TOTP es el código de 6 dígitos de una aplicación autenticadora — un segundo factor sobre la contraseña. Generas un secreto por usuario, lo muestras como un código QR para inscribirse, y luego verificas el código que teclean en cada inicio de sesión. Sigue el estándar RFC 6238.
+
+```rust
+use rustango::totp::{TotpSecret, otpauth_url, verify};
+
+// Enrollment
+let secret = TotpSecret::generate();                           // 20 random bytes
+user.totp_secret = secret.to_base32();                          // store in DB
+let qr_url = otpauth_url("MyApp", &user.email, &secret);        // encode as QR
+
+// Verification on login
+let secret = TotpSecret::from_base32(&user.totp_secret).unwrap();
+if !verify(&secret, &user_supplied_code, 30, 6, 1) {            // 6 digits, ±30s drift
+    return Err("bad TOTP code");
+}
+```
+
+Funciona con Google Authenticator, Authy, 1Password, Bitwarden y otras aplicaciones autenticadoras estándar.
+
+**Códigos de recuperación** (códigos de respaldo de un solo uso para cuando un usuario pierde su teléfono) todavía no se incluyen. El patrón común es almacenar de 8 a 10 códigos hasheados por usuario y consumir uno cada vez que se usa.
+
+---
+
+## Enviar URLs firmadas (enlaces mágicos)
+
+Una URL firmada lleva una firma a prueba de manipulaciones, de modo que puedes confiar en ella sin una sesión — perfecta para inicios de sesión con enlace mágico, restablecimientos de contraseña y enlaces de descarga de tiempo limitado. Firmas una URL con `sign` (opcionalmente con una caducidad) y la verificas con `verify` cuando el usuario hace clic. (Laravel las llama "rutas firmadas".)
+
+```rust
+use rustango::signed_url::{sign, verify, SignedUrlError};
+use std::time::Duration;
+
+// Issue a 1-hour magic-link login URL
+let url = sign(
+    "https://app.example.com/auth/login?email=alice@x.com",
+    secret,
+    Some(Duration::from_secs(3600)),
+);
+// Send via email...
+
+// On the callback handler
+match verify(&incoming_url, secret) {
+    Ok(()) => { /* identity confirmed */ }
+    Err(SignedUrlError::Expired) => { /* prompt to request a new link */ }
+    Err(SignedUrlError::InvalidSignature) => { /* tampered — log + 401 */ }
+    Err(_) => { /* malformed */ }
+}
+```
+
+Usos comunes:
+- Inicio de sesión con enlace mágico (envía por email una URL de un solo uso en lugar de pedir la contraseña)
+- Confirmación de restablecimiento de contraseña
+- Descargas de archivos de tiempo limitado
+- Enlaces de "Haz clic aquí para verificar tu email"
+- Enlaces de baja de suscripción (sin necesidad de auth; la propia URL prueba la intención)
+
+Antes de firmar, los parámetros de consulta se ordenan en un orden fijo, así que un atacante no puede reordenarlos (por ejemplo moviendo `?expires=...`) para cambiar lo que cubre la firma y falsificar un enlace de aspecto válido.
+
+> Análisis en profundidad: [Flujos de cuenta](auth-flows.md) construye el restablecimiento de contraseña, la verificación de email y el inicio de sesión con enlace mágico sobre esta primitiva de URL firmada.
+
+---
+
+## Verificar webhooks entrantes
+
+Un webhook es una llamada de retorno HTTP que otro servicio te envía (un pago tuvo éxito, ocurrió un push). Comprueba siempre su firma para saber que realmente vino de ese servicio y que el cuerpo no fue modificado. `verify_signature` maneja los formatos comunes.
+
+```rust
+use rustango::webhook::{verify_signature, SignatureFormat};
+
+async fn handle_stripe_webhook(headers: HeaderMap, body: Bytes) -> impl IntoResponse {
+    let signature = headers.get("stripe-signature")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    if !verify_signature(SignatureFormat::HexSha256, secret, &body, signature) {
+        return StatusCode::UNAUTHORIZED;
+    }
+    // ... process the verified payload
+    StatusCode::OK
+}
+```
+
+| Formato | Usado por |
+|---|---|
+| `HexSha256WithPrefix` | GitHub (`sha256=<hex>`) |
+| `HexSha256` | Slack, proveedores HMAC en bruto |
+| `Base64Sha256` | Stripe, AWS SNS |
+
+La comparación de la firma es de tiempo constante, lo que significa que siempre tarda la misma cantidad de tiempo tanto si la conjetura es correcta como si es incorrecta. Eso detiene los ataques de temporización, donde un atacante mide diminutas diferencias en el tiempo de respuesta para adivinar el secreto un carácter a la vez.
+
+---
+
+## Mantener los secretos fuera de tus registros
+
+Las URLs registradas pueden filtrar contraseñas y tokens que aparecen en las cadenas de consulta. `AccessLogLayer` enmascara automáticamente los parámetros de credenciales conocidos antes de escribir la línea de registro (PII = información de identificación personal).
+
+```rust
+let app = router.access_log(AccessLogLayer::default());
+```
+
+Por defecto, los valores de estos parámetros de consulta se reemplazan por `[redacted]`:
+`password`, `passwd`, `token`, `secret`, `api_key`, `apikey`, `access_token`, `refresh_token`, `signature`, `auth`.
+
+Añadir a la lista:
+
+```rust
+let layer = AccessLogLayer::default()
+    .redact_additional("session_id")
+    .redact_additional("private_key");
+```
+
+Reemplazar la lista completa:
+
+```rust
+let layer = AccessLogLayer::default()
+    .redact(vec!["only_this".into()]);
+```
+
+Nota: esto solo redacta las **cadenas de consulta**. Para depurar los cuerpos o las cabeceras de las peticiones, filtra en el origen con `tracing::Subscriber`.
+
+---
+
+## Rastrear peticiones a través de servicios
+
+Un ID de petición etiqueta cada línea de registro de una petición con el mismo ID, de modo que puedes seguir esa petición a través de los manejadores — y a través de los servicios. `RequestIdLayer` añade uno a cada petición.
+
+```rust
+let app = router.request_id(RequestIdLayer::default());
+```
+
+Reutiliza un `X-Request-Id` entrante (para que los servicios encadenados compartan un ID) o genera un ID base64 de 22 caracteres nuevo. Los IDs entrantes se validan primero — cualquiera con caracteres de control, saltos de línea, bytes nulos, o de más de 128 caracteres se rechaza, lo que bloquea los ataques de inyección de cabeceras.
+
+En los manejadores:
+
+```rust
+async fn handler(id: rustango::request_id::RequestId) -> String {
+    tracing::info!(req_id = %id.0, "handling /me");
+    format!("req {}", id.0)
+}
+```
+
+En una configuración de confianza cero, donde no confías en los IDs enviados por los servicios upstream, genera siempre el tuyo propio:
+
+```rust
+router.request_id(RequestIdLayer::always_generate());
+```
+
+---
+
+## Gestionar secretos
+
+Nunca codifiques secretos (contraseñas de base de datos, claves de API) directamente en tu código fuente. Léelos en tiempo de ejecución a través del trait `Secrets`, que abstrae dónde viven realmente. (Un "trait" es la versión de Rust de una interfaz.) El `EnvSecrets` incorporado lee de las variables de entorno.
+
+```rust
+use rustango::secrets::{Secrets, EnvSecrets, BoxedSecrets};
+use std::sync::Arc;
+
+// Env vars (with optional prefix)
+let secrets: BoxedSecrets = Arc::new(EnvSecrets::with_prefix("MYAPP_"));
+
+let db_pwd = secrets.require("DB_PASSWORD").await?;       // reads MYAPP_DB_PASSWORD
+let redis_url = secrets.get("REDIS_URL").await?;          // None when unset
+```
+
+Para obtener secretos de Vault, AWS Secrets Manager o GCP Secret Manager, implementa el trait tú mismo — es solo un método asíncrono.
+
+---
+
+## Auditar antes de desplegar
+
+Antes de ir a producción, ejecuta la auditoría incorporada. Detecta configuraciones erróneas comunes — como un secreto de firma ausente o demasiado corto — que no quieres descubrir en producción.
+
+```bash
+manage check --deploy
+```
+
+Comprobaciones siempre activas (se ejecutan con o sin `--deploy`):
+- ✅ Modelos registrados en el inventario
+- ✅ BD accesible (`SELECT 1`)
+- ✅ Migraciones en disco para los modelos registrados
+
+Comprobaciones adicionales de `--deploy` (endurecimiento para producción):
+- ✅ `RUSTANGO_ENV` es `prod` o `production`
+- ✅ `RUSTANGO_SESSION_SECRET` establecida y ≥ 32 bytes (la clave HMAC para la firma de cookies + JWT — `SECRET_KEY` **no** la lee el framework), sin ningún marcador de posición del scaffolder dejado dentro
+- ✅ `DATABASE_URL` establecida (y advierte si apunta a localhost)
+- ⚠️ Advertencias de coherencia de `RUSTANGO_APEX_DOMAIN` / `RUSTANGO_BIND` para la tenencia + el enlace no de loopback
+
+Devuelve un código de salida distinto de cero ante cualquier hallazgo de **nivel de error** (bueno para las puertas de CI). Las advertencias no provocan un fallo pero aparecen en la salida.
+
+Para comprobaciones más allá de las que se incluyen, extiende con código personalizado en tu binario `manage` antes de reenviar a `manage::run`.
+
+---
+
+## Lo que TODAVÍA NO se incluye
+
+Un par de flujos de extremo a extremo todavía necesitan ensamblarse a partir de las primitivas de abajo:
+
+- **Restablecimiento de contraseña + verificación de email** — los ayudantes de emisión/verificación de tokens existen (`auth_flows::confirm_password_reset_pool`, además de los viajes de ida y vuelta de verificación de email) y la canalización de email se incluye por separado, pero no hay un único ciclo prefabricado de vista + email + validación conectado para ti.
+- **Redacción de PII del cuerpo / las cabeceras de la petición** en `access_log` — existe la redacción de registros a nivel de campo (consulta [Mantener los secretos fuera de tus registros](#keeping-secrets-out-of-your-logs)), pero no la depuración automática del cuerpo o las cabeceras de la petición.
+
+Ya incluido (no recurras a un apaño):
+
+- **Inicio de sesión social OAuth2 / OIDC** — `oauth2::providers` incluye ayudantes para Google, GitHub, Microsoft, GitLab y Discord (además de `OAuth2Provider::from_discovery` para cualquier proveedor OIDC), y `oauth2::router::oauth2_router` monta las rutas de inicio de sesión + callback, crea el registro de usuario y establece la cookie de sesión.
+- **Bloqueo por cuenta** — `rustango::account_lockout::Lockout` (respaldado por caché; `is_locked` / `record_failure` / `clear`, con `max_attempts` + `lockout_duration` configurables).
+- **Endpoint de informe de CSP** — `security_headers::csp_report_router(path)` + `SecurityHeadersLayer::csp_report_uri(uri)`.
+- **Limitación de tasa distribuida** — `rate_limit_cache::CacheRateLimitLayer` (consulta [Limitar la tasa de peticiones](#rate-limiting-requests)).
+
+Hasta que aterricen los flujos no incluidos, ensámblalos a partir de las primitivas de arriba (`signed_url::sign` para los tokens de restablecimiento de contraseña, la canalización de email para la entrega, etc.).
+
+---
+
+## Véase también
+
+- [Middleware](middleware.md) — cómo se adjuntan las capas de seguridad, su orden, y el catálogo completo.
+- [Autenticación](auth-passwords.md) — contraseñas, sesiones, JWTs, claves de API, HMAC, backends de auth, y flujos de cuenta, cada uno en profundidad.
+- [Convenciones de API](api-conventions.md) — las reglas de tipo de error y tipo de retorno detrás de estas APIs.

--- a/docs/es/serializers.md
+++ b/docs/es/serializers.md
@@ -1,0 +1,545 @@
+# Serializadores
+
+Un serializador convierte una instancia de modelo en una forma tipada, lista para
+JSON — y de vuelta a la entrada. Es la respuesta de **Rustango** a un
+`ModelSerializer` de Django REST Framework o a un API Resource de Laravel: declara
+una struct, anota sus campos y obtienes una salida controlada (renombrar, ocultar,
+calcular, anidar), validación a nivel de campo y de objeto, y un enganche limpio
+con los ViewSets.
+
+Una cosa que conviene interiorizar de entrada, porque difiere de DRF: un
+serializador de Rustango **da forma a los datos, no los persiste**. No hay ningún
+`serializer.save()` que escriba en la base de datos — de eso se encarga el ORM. El
+serializador mapea un modelo a JSON (`from_model` → `to_value`), declara qué campos
+son escribibles y valida. Lo compones con el ORM y los ViewSets en lugar de enrutar
+escrituras *a través* de él.
+
+> **¿Algún término nuevo aquí?** — *serializer*, *model*, *ORM*, *DRF*? El
+> [glosario](glossary.md) define cada uno en lenguaje llano.
+
+[![Un serializador de Rustango: read_only, renombrado con source, un campo de método calculado, una FK anidada y un campo write_only — declarados en una sola struct](img/serializers.png)](img/serializers.png)
+
+> **Fuente:** `rustango::serializer` (`ModelSerializer`, `#[derive(Serializer)]`,
+> los atributos de campo `#[serializer(...)]`) — tras la característica `serializer`
+> (activada por defecto).
+>
+> **Versiones ejecutables:** el serializador mínimo se incluye en el ejemplo probado
+> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog/src/post_serializer.rs),
+> y el comportamiento completo del derive está cubierto por las propias pruebas
+> unitarias del framework — `crates/rustango/tests/serializer_derive.rs` y
+> `serializer_cross_validate.rs`. Si algún fragmento parece desalineado, compáralo
+> con ellas.
+
+---
+
+## Tabla de contenidos
+- [Inicio rápido](#quick-start) · [El trait `ModelSerializer`](#the-modelserializer-trait)
+- [Atributos de campo](#field-attributes) — la referencia completa
+- [Campos calculados](#computed-fields) · [Serializadores anidados](#nested-serializers) · [Colecciones](#collections-many) · [Campos slug](#slug-related-fields)
+- [Validación](#validation) · [Validación unique-together](#unique-together-validation)
+- [Salida con hipervínculos](#hyperlinked-output) · [Serializar listas](#serializing-lists)
+- [Usar un serializador con un ViewSet](#using-a-serializer-with-a-viewset) · [Validar en un handler personalizado](#validating-in-a-custom-handler)
+- [OpenAPI](#openapi-schemas) · [Scaffolding](#scaffolding) · [Ajustes y límites](#tweaks-and-current-limits)
+
+---
+
+## Inicio rápido
+
+Un serializador es una struct simple con `#[derive(Serializer)]` y un
+`#[serializer(model = …)]` que apunta al modelo del que mapea. Necesita dos derives
+acompañantes: `serde::Deserialize` (para que también pueda parsear el JSON entrante)
+y `Default` (para que los campos excluidos/opcionales puedan inicializarse).
+
+```rust
+use rustango::Serializer;
+use rustango::serializer::ModelSerializer;
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: Auto<i64>,
+    pub title: String,
+
+    #[serializer(source = "body")]      // JSON key `content`, read from model.body
+    pub content: String,
+
+    #[serializer(read_only)]            // in output, never accepted on write
+    pub published_at: Auto<DateTime<Utc>>,
+}
+```
+
+Úsalo:
+
+```rust
+let post = Post::objects().find(42, &pool).await?.expect("post 42");
+
+let one  = PostSerializer::from_model(&post).to_value();   // a JSON object
+let many = PostSerializer::many_to_value(&posts);          // a JSON array
+```
+
+`from_model` clona los campos del modelo dentro de la struct (respetando los
+atributos de más abajo); `to_value` la serializa (omitiendo los campos
+`write_only`). Ese es todo el bucle central.
+
+---
+
+## El trait `ModelSerializer`
+
+`#[derive(Serializer)]` implementa `ModelSerializer` (más un `serde::Serialize`
+que respeta `write_only`, y una impl de `OpenApiSchema` bajo la característica
+`openapi`). La superficie del trait:
+
+| Método | Firma | Notas |
+|---|---|---|
+| `from_model` | `fn(model: &Self::Model) -> Self` | Mapea un modelo → serializador. Generado; no sobrescribible. |
+| `to_value` | `fn(&self) -> serde_json::Value` | Serializa a JSON (omite `write_only`). Sobrescribible. |
+| `many` | `fn(&[Self::Model]) -> Vec<Self>` | `from_model` por lotes. Sobrescribible. |
+| `many_to_value` | `fn(&[Self::Model]) -> serde_json::Value` | Lote → array JSON. Sobrescribible. |
+| `writable_fields` | `fn() -> &'static [&'static str]` | Nombres de campo del serializador aceptados en escritura (excluye `read_only`, `skip`, `method`, `nested`, `many`, `slug`). |
+| `writable_source_fields` | `fn() -> &'static [&'static str]` | Las **columnas del modelo** de los campos escribibles (resueltas por `source`). La ruta de escritura del ViewSet persiste solo estas. Generado. |
+| `from_writable_json` | `fn(&Value) -> Result<Self, FormErrors>` | Construye una instancia a partir del cuerpo de una petición usando solo los campos escribibles (el resto toma su valor por defecto); los errores de parseo por campo → `FormErrors`. Generado. |
+| `validate` | `fn(&self) -> Result<(), FormErrors>` | Ejecuta los validadores declarados por campo + entre campos. No hace nada cuando no se declara ninguno; sobrescribible. |
+
+Deliberadamente **no** hay `create` / `update` / `save` en el trait — las
+escrituras pasan por el ORM (`model.save(&pool)`). Cuando un serializador se conecta
+a un [ViewSet](viewsets.md), la ruta de create/update usa `from_writable_json()` +
+`validate()` + `writable_source_fields()` para validar y filtrar la petición antes
+de guardar.
+
+---
+
+## Atributos de campo
+
+Todo se controla con `#[serializer(...)]` en cada campo. El conjunto completo:
+
+| Atributo | `from_model` hace | ¿En la salida JSON? | ¿Escribible? |
+|---|---|---|---|
+| *(ninguno)* | mapea desde el modelo | sí | sí |
+| `read_only` | mapea desde el modelo | sí | **no** |
+| `write_only` | `Default::default()` | **no** | sí |
+| `source = "x"` | mapea desde `model.x` (renombra) | sí | sí |
+| `skip` | `Default::default()` — lo asignas tú mismo | sí | no |
+| `method = "fn"` | llama a `Self::fn(&model)` | sí | no |
+| `nested` | recorre una FK → `Child::from_model(parent)` | sí | no |
+| `nested(strict)` | igual, pero entra en pánico si la FK no fue cargada | sí | no |
+| `many = ChildSer` | inicializa `Vec::new()`; rellena vía `set_<field>(&[Child])` | sí | no |
+| `slug = "name"` | clona `model.<source>.value()?.name` | sí | no |
+| `validate = "fn"` | validador por campo ejecutado por `validate(&self)` | n/a | n/a |
+
+**Mutuamente excluyentes** (errores de compilación si se combinan): `read_only` +
+`write_only`; `method` + `source`; `slug` + cualquiera de `method` / `nested` /
+`many`.
+
+**Validadores declarativos.** `max_length = N`, `min_length = N`, `min = N` y
+`max = N` añaden validación en tiempo de escritura a un campo sin cambiar su forma de
+salida (y un campo sin ninguno de ellos hereda los límites del modelo). Consulta
+[Validación](#validation).
+
+`write_only` es para datos solo de entrada (una contraseña, un token de un solo uso):
+presente en `writable_fields()`, ausente de la salida. `skip` es la escotilla de
+escape opuesta — el campo no se lee del modelo y no es escribible, así que lo pueblas
+a mano tras `from_model` (p. ej. una lista de ids de etiquetas que obtienes por
+separado).
+
+> **`write_only` no transforma el valor.** Un campo `write_only` se acepta en
+> escritura y se persiste **tal cual** — el serializador nunca lo hashea ni lo cifra.
+> Para una contraseña, hashéala tú mismo (consulta [Contraseñas](auth-passwords.md))
+> antes de `save()`; los campos `read_only`, en cambio, se ignoran silenciosamente en
+> escritura en lugar de rechazarse.
+
+---
+
+## Campos calculados
+
+`method = "fn"` es el `SerializerMethodField` de DRF. Declara el campo, luego escribe
+una función asociada `fn(&Model) -> FieldType`; se llama durante `from_model`:
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub title: String,
+    #[serializer(method = "excerpt")]
+    pub excerpt: String,
+}
+
+impl PostSerializer {
+    fn excerpt(model: &Post) -> String {
+        model.body.chars().take(80).collect::<String>() + "…"
+    }
+}
+```
+
+Los campos calculados son solo de salida (excluidos de `writable_fields()`).
+
+---
+
+## Serializadores anidados
+
+`nested` incrusta otro serializador recorriendo una clave foránea cargada. El tipo
+del campo es el serializador hijo:
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Comment)]
+pub struct CommentSerializer {
+    pub id: Auto<i64>,
+    pub body: String,
+    #[serializer(nested)]               // reads the loaded `author` FK
+    pub author: AuthorBrief,
+}
+```
+
+La FK ya debe estar cargada (vía `select_related` / una obtención eager). Si **no**
+fue cargada, el campo recurre a `Default::default()` en lugar de entrar en pánico —
+en producción se degrada con elegancia ante un prefetch faltante. En pruebas, usa
+`#[serializer(nested(strict))]` para convertir ese fallback en un pánico, de modo que
+un prefetch olvidado se detecte. Apunta a una FK con otro nombre con `source`:
+
+```rust
+#[serializer(nested, source = "owner")]
+pub author: AuthorBrief,
+```
+
+Los campos anidados son **de solo lectura** en la forma de salida — los objetos
+anidados escribibles todavía no están soportados (consulta
+[límites](#tweaks-and-current-limits)).
+
+---
+
+## Colecciones (`many`)
+
+Para hijos uno-a-muchos o M2M, `many = ChildSerializer` declara un campo `Vec<…>`.
+Como el accesor M2M/relacionado es async, la macro no puede cargarlo automáticamente;
+inicializa el vec vacío y emite un helper `set_<field>(&[ChildModel])` que llamas tras
+obtener los hijos:
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostWithTags {
+    pub id: Auto<i64>,
+    pub title: String,
+    #[serializer(many = TagBrief)]
+    pub tags: Vec<TagBrief>,
+}
+
+// usage
+let tags = post.tags_m2m().all(&pool).await?;
+let mut s = PostWithTags::from_model(&post);
+s.set_tags(&tags);                       // generated setter, named set_<field>
+let json = s.to_value();
+```
+
+---
+
+## Campos slug relacionados
+
+`slug = "name"` es el `SlugRelatedField` de DRF: en lugar de un id de FK o un objeto
+anidado completo, emite un único campo con nombre extraído del padre cargado.
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: Auto<i64>,
+    pub title: String,
+    #[serializer(slug = "name", source = "author")]   // author.name as a flat field
+    pub author_name: String,
+}
+```
+
+Como nested, lee de una FK cargada y recurre al valor por defecto cuando no está
+cargada; es solo para visualización (no escribible).
+
+---
+
+## Validación
+
+Tres capas, todas aflorando como `rustango::forms::FormErrors` (y, en una escritura
+de ViewSet, un `400` con forma de DRF). Se ejecutan en este orden: restricciones
+declarativas, luego validadores por campo, luego el enganche entre campos.
+
+**Restricciones declarativas (los `validators` de DRF, auto-heredadas).**
+`max_length`, `min_length`, `min` y `max` son atributos de campo — y cuando los
+omites un campo **hereda del modelo** su `max_length` / `min` / `max` / `choices`.
+Así que una columna `#[rustango(max_length = 200)]` recibe la comprobación de
+longitud sin ningún atributo de serializador en absoluto (comportamiento del
+`ModelSerializer` de DRF). Se comprueban en cada campo escribible, convirtiendo los
+`500` de restricción de base de datos que habría en `400` amables:
+
+```rust
+#[serializer(model = Widget)]
+struct WidgetSerializer {
+    pub code: String,               // inherits the model's max_length
+    #[serializer(max_length = 4)]   // overrides the model's bound
+    pub note: String,
+    pub priority: i64,              // inherits the model's min / max
+    pub status: String,             // inherits the model's choices
+}
+```
+
+Los mensajes coinciden con Django/DRF: `"Ensure this value has at most N characters."`,
+`"Ensure this value has at least N characters."`, `"Ensure this value is ≥ N."` /
+`"≤ N"`, y `"Select a valid choice."`. (`min_length` es solo de serializador;
+`choices` se hereda del modelo — no existe un atributo `choices`.)
+
+**Por campo** (personalizado) — declara `validate = "fn"` y escribe
+`fn(value: &FieldType) -> Result<(), String>`:
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    #[serializer(validate = "title_min_3")]
+    pub title: String,
+    pub body: String,
+}
+
+impl PostSerializer {
+    fn title_min_3(t: &String) -> Result<(), String> {
+        if t.chars().count() < 3 { Err("title must be at least 3 chars".into()) } else { Ok(()) }
+    }
+}
+```
+
+El derive genera un `validate(&self)` que ejecuta cada validador por campo y recoge
+los fallos en un `FormErrors` indexado por nombre de campo.
+
+**Entre campos** — declara un enganche a nivel de struct y los validadores se
+fusionan. O bien añade `#[serializer(validate = "cross_validate")]` en la struct
+(devolviendo `Result<(), FormErrors>`), o simplemente implementa `validate(&self)` tú
+mismo cuando no hay validadores por campo que lo generen:
+
+```rust
+impl PostSerializer {
+    pub fn validate(&self) -> Result<(), rustango::forms::FormErrors> {
+        let mut errors = rustango::forms::FormErrors::default();
+        if self.title.is_empty() {
+            errors.add("title", "title cannot be empty");          // field error
+        }
+        if self.body.starts_with(&self.title) {
+            errors.add_non_field("body must not repeat the title"); // object-level error
+        }
+        if errors.is_empty() { Ok(()) } else { Err(errors) }
+    }
+}
+```
+
+`FormErrors` separa los errores de **campo** (`add(field, msg)`, un
+`HashMap<String, Vec<String>>`) de los errores **no de campo**
+(`add_non_field(msg)`). Inspecciónalos con `.fields()`, `.non_field()`,
+`.get(field)`, `.is_empty()`, y combínalos con `.merge(other)`. Más allá de las
+restricciones declarativas de arriba (`max_length` / `min_length` / `min` / `max` /
+`choices` heredados), las reglas personalizadas son funciones simples — no hay magia
+de `email`/regex, lo que mantiene la validación personalizada explícita y verificable.
+Fuera de un ViewSet, el framework no renderiza automáticamente `FormErrors` a un
+cuerpo HTTP; mapéalo a tu respuesta 400 (la separación campo/no-campo coincide con el
+JSON de errores de DRF).
+
+---
+
+## Validación unique-together
+
+Para el `UniqueTogetherValidator` de Django — una comprobación previa al guardado de
+que una fila candidata no colisionará en un índice único multicolumna — llama a
+`check_unique_together_pool` antes de guardar:
+
+```rust
+use std::collections::HashMap;
+use rustango::core::SqlValue;
+use rustango::serializer::check_unique_together_pool;
+
+let mut values: HashMap<&'static str, SqlValue> = HashMap::new();
+values.insert("org_id",  SqlValue::I64(self.org_id));
+values.insert("user_id", SqlValue::I64(self.user_id));
+
+// None on insert; Some(&pk) on update so the row doesn't clash with itself.
+check_unique_together_pool(&pool, Membership::SCHEMA, &values, None).await?;
+```
+
+Recorre los índices únicos multicolumna declarados del modelo y devuelve
+`Err(FormErrors)` con un error no de campo por colisión
+(`"The fields a, b must be unique together."`). El `unique` de una sola columna se
+deja al manejo de conflictos del insert; los índices parciales (`unique_when`) se
+omiten.
+
+---
+
+## Salida con hipervínculos
+
+Para una forma al estilo `HyperlinkedModelSerializer` (URLs de recursos en lugar de
+ids desnudos), dos helpers post-procesan el JSON:
+
+```rust
+use rustango::serializer::{hyperlink_url, hyperlinked_to_value};
+use std::collections::HashMap;
+
+let base = PostSerializer::from_model(&post).to_value();
+
+let mut fk_templates = HashMap::new();
+fk_templates.insert("author_id", "/api/users/{pk}");
+
+let out = hyperlinked_to_value(base, "/api/posts/{pk}", "id", &fk_templates);
+// → { "url": "/api/posts/42", "author_id_url": "/api/users/7", "id": 42, ... }
+```
+
+`hyperlink_url(template, &pk)` hace una sustitución puntual de `{pk}`;
+`hyperlinked_to_value` añade una `url` de nivel superior más un `<fk>_url` por
+plantilla (FK null → URL null). Las claves originales id/`<fk>_id` se conservan
+(elimínalas después si quieres que desaparezcan).
+
+---
+
+## Serializar listas
+
+`many_to_value(&models)` devuelve un array JSON de objetos serializados. Los ViewSets
+envuelven una página de ellos en el envoltorio estándar:
+
+```json
+{ "count": 100, "page": 1, "page_size": 20, "last_page": 5, "results": [ { … }, { … } ] }
+```
+
+(Ese es el envoltorio de número de página por defecto; consulta
+[Paginación](viewsets.md#pagination) para las formas de cursor y limit/offset.)
+
+---
+
+## Usar un serializador con un ViewSet
+
+Conecta un serializador a un [ViewSet](viewsets.md) y dirige todo el recurso REST —
+**salida y entrada**, en cada backend (PostgreSQL, MySQL, SQLite):
+
+```rust
+#[derive(ViewSet)]
+#[viewset(model = Post, serializer = crate::PostSerializer, ordering = "-published_at")]
+pub struct PostViewSet;
+// or, on the builder: ViewSet::for_model(Post::SCHEMA).serializer::<PostSerializer>()…
+```
+
+- **Salida** — las respuestas de `list` / `retrieve` / `create` / `update` se
+  renderizan a través de `from_model`, así que `source` / `method` / `read_only` /
+  `write_only` dan forma al JSON.
+- **Entrada** — `create` / `update` ejecutan el `validate()` del serializador (un
+  fallo es un `400` con forma de DRF, `{field: [msgs]}`), y solo se escriben los
+  campos escribibles — los campos `read_only` / calculados que un cliente envíe se
+  ignoran, resueltos por `source` a la columna del modelo.
+
+El ViewSet dirige esto a través de tres métodos de `ModelSerializer` que el derive
+genera: `validate()`, `writable_source_fields()` y `from_writable_json()`. Consulta la
+[guía de ViewSets](viewsets.md#the-serializer-marriage-input--output) para el
+comportamiento completo y un ejemplo trabajado.
+
+También puedes usar un serializador **de forma independiente** — mapea una fila y
+emite su JSON desde cualquier handler:
+
+```rust
+let post = Post::objects().find(42, &pool).await?.expect("post 42");
+let body = PostSerializer::from_model(&post).to_value();   // shaped JSON
+```
+
+---
+
+## Validar en un handler personalizado
+
+Fuera de un ViewSet, el serializador deriva `serde::Deserialize`, así que puedes
+parsear el cuerpo de una petición dentro de él, ejecutar `.validate()` y — en caso de
+éxito — mapear los datos sobre un modelo y `save(&pool)`. `from_writable_json()`
+construye una instancia solo a partir de las claves escribibles (los campos de solo
+lectura / calculados toman su valor por defecto), y `writable_fields()` /
+`writable_source_fields()` te dicen qué claves se aceptan — la misma maquinaria que el
+ViewSet usa internamente.
+
+---
+
+## Esquemas OpenAPI
+
+Con la característica `openapi` activada, el derive también emite una impl de
+`OpenApiSchema`: los tipos de campo se mapean a tipos de JSON-schema, `Option<T>` pasa
+a ser nullable-y-no-requerido, y los campos `write_only` se excluyen del esquema de
+respuesta. Esto es lo que alimenta la documentación de API generada — sin ningún
+esquema separado que mantener.
+
+> **Análisis en profundidad:** [OpenAPI](openapi.md) — convierte este esquema (más las
+> rutas CRUD de tu ViewSet) en una especificación OpenAPI 3.1 completa servida con
+> Swagger UI / Redoc.
+
+---
+
+## Scaffolding
+
+Genera un esqueleto de serializador con la CLI de manage:
+
+```bash
+cargo run -- make:serializer PostSerializer --model Post
+```
+
+Escribe un módulo inicial que rellenas:
+
+```rust
+//! Auto-scaffolded by `manage make:serializer PostSerializer`.
+
+use rustango::Serializer;
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: i64,
+    // pub title: String,
+    // #[serializer(read_only)]
+    // pub created_at: chrono::DateTime<chrono::Utc>,
+}
+```
+
+Luego registra el módulo (`mod post_serializer;`) junto a los demás.
+
+---
+
+## Ajustes y límites actuales
+
+Unos cuantos filos afilados y escotillas de escape que conviene conocer:
+
+- **Campos condicionales.** No hay selección de campos en tiempo de ejecución (los
+  campos están fijados en tiempo de compilación). Para "incluir solo cuando esté
+  presente", usa `Option<T>` más
+  `#[serde(skip_serializing_if = "Option::is_none")]` en el campo — la impl de
+  `Serialize` personalizada respeta los atributos de serde.
+- **Forma de salida personalizada.** Sobrescribe `to_value(&self)` en tu struct para
+  un objeto JSON totalmente a medida cuando los atributos no basten.
+- **Los objetos anidados escribibles** no están soportados — los campos `nested` /
+  `many` / `slug` son solo de salida. Acepta las escrituras como ids escalares y
+  resuélvelas tú mismo.
+- **Los validadores integrados son solo de longitud/rango/opción** — `max_length` /
+  `min_length` / `min` / `max` (y `choices` heredados) son declarativos; otras reglas
+  (`email`, regex, …) son funciones que escribes tú (consulta
+  [Validación](#validation)).
+- **Un validador por campo por cada campo.** Para varias reglas en un campo,
+  combínalas en la función de ese campo, o añade un `validate(&self)` entre campos.
+- **El serializador no persiste.** Mapea → valida → entrega los datos al ORM; no hay
+  `serializer.save()`.
+
+---
+
+## Pruébalo
+
+El serializador mínimo se incluye en el ejemplo
+[`getting_started_blog`](../crates/rustango/examples/getting_started_blog/src/post_serializer.rs)
+(Paso 13 de la guía de primeros pasos). El comportamiento completo del derive — los
+atributos de campo, los campos calculados/anidados/many, y ambas capas de validación —
+está cubierto por las propias pruebas unitarias del framework (sin necesidad de base
+de datos):
+
+```bash
+cd crates/rustango
+cargo test --test serializer_derive          # field attrs, method, nested, many, slug, OpenAPI
+cargo test --test serializer_cross_validate  # per-field + cross-field validation aggregation
+```
+
+---
+
+## Véase también
+
+- [ViewSets](viewsets.md) — conecta un serializador a una API CRUD JSON.
+- [Vistas HTML](html-views.md) — la alternativa renderizada en el servidor a una API JSON.
+- [OpenAPI](openapi.md) — los campos de un serializador se convierten en un esquema de componente.
+- [Recetario del ORM](orm.md) — los modelos desde los que mapean los serializadores.

--- a/docs/es/sso.md
+++ b/docs/es/sso.md
@@ -1,0 +1,231 @@
+# SSO (OpenID Connect / inicio de sesión social)
+
+Inicia sesión con un proveedor de identidad externo — Google, Microsoft / Azure
+AD, GitHub, GitLab, Discord o **cualquier proveedor OpenID Connect** (Okta,
+Auth0, Keycloak, …) — en lugar de con una contraseña local.
+
+Puedes configurar **múltiples proveedores**, cada uno gestionado desde la interfaz
+de administración como una fila (sin archivo de configuración, sin recompilar). Los
+endpoints de un proveedor se autodescubren a partir de su URL de emisor OIDC al
+iniciar sesión; los proveedores sociales usan presets integrados.
+
+El SSO es **vinculación con existente** para el administrador: el correo verificado
+que devuelve el IdP debe coincidir con un usuario administrador existente. Autentica
+a la persona; nunca crea cuentas ni concede acceso por sí solo. Un correo
+desconocido o no verificado se rechaza. (El flujo de miembro, más abajo, puede optar
+por el aprovisionamiento automático.)
+
+> **Fuente:** el núcleo independiente del admin `rustango::sso` (`SsoProvider`,
+> `build_provider`, `verified_email`, `ResolvedSso`, `SsoError`), el cableado del
+> bare-admin `rustango::admin::sso`, el SSO por tenant/consola
+> `rustango::tenancy::sso` (`SharedSsoProvider`) y el SSO de miembro
+> `rustango::tenancy::member_auth`.
+
+## Funcionalidades y quién las usa
+
+Desde **0.49** el núcleo de SSO es su propia funcionalidad, independiente del
+auto-admin, de modo que un inicio de sesión de usuario final (miembro) puede
+compilarse sin arrastrar `crate::admin`:
+
+| Funcionalidad | Arrastra | Te da |
+|---|---|---|
+| `sso` | `oauth2`, `casts` | El núcleo independiente del admin: `rustango::sso` — el handshake OIDC / OAuth social, el modelo `SsoProvider` respaldado por BD (secreto cifrado en reposo vía `casts`) y el flujo de miembro (`tenancy::member_auth`, con `tenancy`). |
+| `admin-sso` | `admin`, `sso` | Lo anterior **más** el cableado de inicio de sesión del bare-admin (`rustango::admin::sso`) — botones de SSO en la página de inicio de sesión del admin que acuñan la sesión de administrador. |
+
+```toml
+[dependencies]
+# Admin login with SSO:
+rustango = { version = "0.51", features = ["admin-sso"] }
+# Member (end-user) SSO without the auto-admin:
+rustango = { version = "0.51", features = ["tenancy", "sso"] }
+```
+
+`admin::sso_provider` y las rutas históricas del núcleo `admin::sso::*` son
+ahora **shims de reexportación** sobre `sso::provider` / `sso::*`, de modo que
+los imports existentes de `crate::admin::sso::{build_provider, ResolvedSso, …}` y
+`crate::admin::sso_provider::SsoProvider` siguen resolviéndose sin cambios
+(el nombre de tabla `rustango_sso_providers` y cada campo quedan intactos — las
+migraciones no se ven afectadas).
+
+El correo por el que se vincula a un usuario es la columna `email`. En el modelo
+`User` del tenant está condicionado por la funcionalidad **`sso`** (movida fuera de
+`admin-sso` en 0.49, de modo que las compilaciones solo con SSO de miembro siguen
+obteniendo la columna); el `AdminUser.email` escueto permanece tras `admin-sso`.
+Activar o desactivar la funcionalidad emite una migración `AddColumn` / `DropColumn`
+para esa columna.
+
+## Cómo funciona
+
+1. La página de inicio de sesión muestra un botón **«Iniciar sesión con
+   &lt;proveedor&gt;»** por cada proveedor habilitado.
+2. Al hacer clic en uno (`GET <login>/sso/<slug>`) se redirige al IdP con una
+   cookie de flujo firmada y de vida corta (PKCE + `state` CSRF).
+3. El IdP devuelve al usuario a `<login>/sso/<slug>/callback`.
+4. rustango verifica el flujo, intercambia el código, lee `/userinfo`
+   y exige **`email_verified`**.
+5. Busca un usuario administrador por ese correo. Si existe uno y está activo,
+   acuña la **misma sesión de cookie firmada** que produce un inicio de sesión con
+   contraseña, vinculada a ese usuario — de modo que cada control existente
+   (superusuario / permisos, invalidación en vivo por cambio de contraseña) sigue
+   aplicándose.
+6. Sin coincidencia → el usuario es devuelto a la página de inicio de sesión con un
+   error genérico (los detalles van al log del servidor, nunca al navegador).
+
+El **secreto** del cliente está **cifrado en reposo** — la columna `client_secret`
+es un cast [`EncryptedString`](#secret-storage), descifrado en memoria solo en el
+momento del inicio de sesión.
+
+## Los proveedores son filas, gestionadas en el admin
+
+Cada proveedor es una fila `SsoProvider`. Aparece como un modelo de administración
+corriente — añadir/editar/habilitar desde la interfaz de administración, sin
+redespliegue. Campos:
+
+| Campo | Significado |
+|---|---|
+| `slug` | Clave de ruta estable + id del botón (`<login>/sso/<slug>`). Única. |
+| `label` | Texto del botón, p. ej. «Iniciar sesión con Google». |
+| `kind` | Un preset — `google` / `microsoft` / `github` / `gitlab` / `discord` — o `oidc` para un proveedor OpenID Connect genérico. |
+| `issuer_url` | URL base de descubrimiento OIDC (para `kind = "oidc"`); rustango obtiene `{issuer}/.well-known/openid-configuration`. No se usa en los presets. |
+| `client_id` | El id de cliente OAuth del IdP. |
+| `client_secret` | El secreto de cliente OAuth, **cifrado en reposo** (nunca en texto plano en la BD). |
+| `enabled` | Si el botón aparece en la página de inicio de sesión. |
+| `sort_order` | Orden de los botones (ascendente). |
+| `scopes` | Anulación opcional de scopes separados por espacios (por defecto `openid email profile`). |
+
+Para añadir un proveedor: introduce el `client_id` + `client_secret`, elige un
+`kind` (o `oidc` + un `issuer_url`) y guarda. Los endpoints se descubren al iniciar
+sesión — sin cableado de endpoints por proveedor.
+
+## Dónde gestiona los proveedores cada superficie
+
+- **Admin de un solo tenant / independiente** (`crate::admin`): las filas
+  `SsoProvider` son una tabla global sencilla, gestionada desde el bare-admin.
+  Requiere `Builder::with_session_auth` (el SSO acuña la misma sesión).
+- **Admin de tenant** (multi-tenancy): cada tenant gestiona sus **propias**
+  filas `SsoProvider` desde su admin — granular, autoservicio, aislado por
+  tenant.
+- **Consola de operador** (multi-tenancy): un operador define un
+  **`SharedSsoProvider`** una vez y se ofrece a **todos** los tenants
+  (un Google a nivel de empresa, por ejemplo). Gestionado desde el panel
+  *Shared SSO* de la consola.
+
+En la página de inicio de sesión de un tenant los dos conjuntos se fusionan, y ante
+un choque de slug **gana el propio proveedor del tenant** sobre el compartido — así
+un tenant puede anular un proveedor compartido para sí mismo.
+
+La URL de callback se deriva por petición a partir del host + slug
+(`https://<host><login>/sso/<slug>/callback`), así que regístrala con el
+IdP. Vincula a un usuario estableciendo la columna `email` en su fila de
+`rustango_users` (tenant) / `rustango_admin_users` (bare) con la dirección que
+devuelve el IdP.
+
+## SSO de miembro (usuario final)
+
+Las superficies anteriores inician sesión a las personas en un **admin**.
+`tenancy::member_auth` es el análogo orientado a miembros: inicia la sesión de un
+usuario final en el propio pool de usuarios de un tenant (`rustango_users`) y
+acuña una **sesión de miembro**, de modo que un socio de gimnasio / cliente SaaS
+puede «Iniciar sesión con Google» sin tocar el admin. Reutiliza exactamente el mismo
+núcleo `rustango::sso` y las propias filas `SsoProvider` del tenant — solo difiere
+la sesión que acuña, razón por la cual vive tras la funcionalidad `sso` (no
+`admin-sso`) y no necesita auto-admin.
+
+Monta `member_sso_router` en una pila `tenancy::server::Builder` (lee el
+`Arc<TenantContext>` resuelto que el builder inyecta):
+
+```rust
+use rustango::tenancy::member_auth::{member_sso_router, MemberAuthConfig};
+
+let members = member_sso_router(MemberAuthConfig {
+    login_base:     "/auth".into(),   // buttons link to /auth/sso/<slug>
+    landing_url:    "/".into(),       // post-login destination (honors a same-origin ?next)
+    auto_provision: true,             // create a user from a verified email on first sign-in
+    session_ttl:    7 * 24 * 60 * 60, // 7 days
+    ..Default::default()
+});
+```
+
+Monta dos rutas por slug a partir de `login_base`:
+
+- `GET {login_base}/sso/{slug}` — inicia el handshake, redirige al IdP.
+- `GET {login_base}/sso/{slug}/callback` — lo completa, encuentra-o-aprovisiona
+  al miembro, acuña la cookie de sesión.
+
+Diferencias respecto al flujo del admin:
+
+- **Aprovisionamiento automático.** Con `auto_provision = true` (el valor por
+  defecto), un correo de IdP verificado sin una fila `rustango_users` coincidente
+  **crea** una — nombre de usuario a partir de la parte local del correo (deduplicado
+  ante un choque), un hash de contraseña aleatorio real pero inutilizable (los
+  usuarios de SSO no pueden iniciar sesión con contraseña).
+  Ponlo a `false` para la vinculación-con-existente al estilo admin (correo
+  desconocido rechazado).
+- **Su propia cookie de sesión.** La cookie de miembro
+  (`rustango_member_session`) está **separada por dominio** de las cookies de
+  sesión de tenant / admin: el mensaje firmado lleva una etiqueta por dominio y
+  un claim de audiencia, de modo que una cookie de miembro nunca puede validarse
+  como una cookie de tenant/admin (o viceversa) aunque ambas estén firmadas con
+  `RUSTANGO_SESSION_SECRET`. Está ligada al slug (una cookie acuñada para `acme`
+  nunca autentica en `globex`) y se invalida con una rotación de contraseña
+  (a la par que la sesión del admin).
+
+Lee el miembro actual en un handler con el extractor **`CurrentMember`** — el
+análogo de miembro de `SessionUser`. Es infalible
+(`None` para sesiones anónimas / caducadas / rotadas / entre tenants),
+así que se compone con rutas públicas:
+
+```rust
+use rustango::tenancy::member_auth::CurrentMember;
+
+async fn dashboard(CurrentMember(member): CurrentMember) -> impl axum::response::IntoResponse {
+    match member {
+        Some(user) => format!("Hi, {}", user.username),
+        None => "Please sign in".to_owned(),
+    }
+}
+```
+
+> **Alcance v1.** El SSO de miembro resuelve proveedores únicamente a partir de las
+> propias filas `SsoProvider` del tenant — la fusión de `SharedSsoProvider` a nivel
+> de registro y un hook `provision` personalizado son seguimientos futuros.
+
+## Almacenamiento de secretos
+
+`client_secret` se almacena **cifrado en reposo** con XChaCha20-Poly1305
+(AEAD), con la clave derivada de la variable de entorno
+**`RUSTANGO_SECRET_KEY`**. Se descifra en memoria solo al iniciar sesión, para
+autenticarse ante el endpoint de token del IdP. Así, un volcado de BD filtrado nunca
+expone el secreto, y cada tenant conserva su propio secreto sin una variable de
+entorno por proveedor.
+
+> Establece `RUSTANGO_SECRET_KEY` en el despliegue (cualquier longitud; se le aplica
+> SHA-256 para obtener una clave de 32 bytes). Sin ella, guardar o usar un proveedor
+> falla de inmediato — la misma postura que ante una URL de base de datos ausente.
+
+## Proveedores (presets)
+
+Presets integrados: `google`, `microsoft` (Azure AD), `github`, `gitlab`,
+`discord`. Para cualquier otra cosa, usa `kind = "oidc"` con un `issuer_url` —
+rustango ejecuta el descubrimiento de OpenID Connect para encontrar los endpoints.
+(Sign in with Apple no es un preset; necesita verificación de id_token/JWKS.)
+
+## Notas de seguridad
+
+- **Solo correo verificado** — los correos de IdP no verificados se rechazan.
+- **Sin aprovisionamiento automático** — un correo desconocido no puede entrar;
+  crea el usuario administrador (y establece su `email`) primero.
+- **Secretos cifrados en reposo** (`RUSTANGO_SECRET_KEY`), descifrados solo en
+  memoria al iniciar sesión; los formularios de edición enmascaran el secreto
+  almacenado.
+- La cookie de flujo es de vida corta (10 min), `HttpOnly`, `SameSite=Lax`
+  y `Secure` sobre HTTPS; el handshake lleva PKCE + un `state` firmado.
+- Las sesiones de SSO son la sesión de administrador corriente — rotar o
+  desactivar al usuario vinculado las invalida a través del control en vivo
+  existente.
+- El modelo de confianza es `/userinfo` sobre TLS (el id_token no se verifica de
+  forma independiente); antepón HTTPS al admin.
+
+## Véase también
+
+- [Guía de seguridad](security.md) · [Autenticación](auth-flows.md)

--- a/docs/es/testing.md
+++ b/docs/es/testing.md
@@ -1,0 +1,182 @@
+# Pruebas
+
+Las pruebas rápidas y fiables necesitan controlar tu aplicación igual que lo hace
+un cliente: sin arrancar un servidor ni tocar la red. El `TestClient` de
+**Rustango** ejecuta tu router **en proceso**: llamas a `client.get("/path")`, la
+petición se enruta a través de la pila real (extractores, middleware, manejadores)
+y te devuelve la respuesta para hacer aserciones. Añade el aislamiento por
+reversión de transacción para las pruebas de base de datos y un conjunto de
+aserciones de respuesta, y tienes el cliente de pruebas de Django + `TestCase`, en
+Rust.
+
+[![Pruebas en Rustango: TestClient envuelve tu Router y envía peticiones en proceso a través de la pila real de manejadores; el TestResponse expone el estado, el texto y el JSON para hacer aserciones — sin socket, sin servidor](img/testing.png)](img/testing.png)
+
+> **¿Hay algún término nuevo para ti aquí?** *router*, *handler*, *fixture*, *rollback* — consulta el
+> [glosario](glossary.md).
+
+> **Fuente:** `rustango::test_client` (`TestClient`, `TestResponse`),
+> `rustango::test_assertions` (`assert_status_2xx`, `assert_redirects`,
+> `assert_cookie_set`, …), y `rustango::test_db` (`with_rollback`) — siempre
+> compilados.
+>
+> **Versión ejecutable:** los fragmentos de abajo *son* una prueba que pasa —
+> [`testing_doc.rs`](../crates/rustango/tests/testing_doc.rs)
+> (`cargo test -p rustango --test testing_doc`). Casi cualquier otro `*_doc.rs`
+> de este repositorio usa `TestClient` de la misma manera.
+
+## Tabla de contenidos
+
+- [Paso 1 — Controla tu aplicación con TestClient](#step-1--drive-your-app-with-testclient)
+- [Paso 2 — Haz aserciones sobre la respuesta](#step-2--assert-on-the-response)
+- [Enviar JSON, cabeceras y cuerpos](#sending-json-headers-and-bodies)
+- [Probar una API real](#testing-a-real-api)
+- [Pruebas de base de datos con reversión](#database-tests-with-rollback)
+- [Ayudantes de aserción de respuesta](#response-assertion-helpers)
+- [Véase también](#see-also)
+
+---
+
+## Paso 1 — Controla tu aplicación con TestClient
+
+Envuelve cualquier `axum::Router` en un `TestClient` y envía peticiones — no se
+enlaza ningún socket, no se genera ninguna tarea de servidor. La petición fluye a
+través de tu middleware y tus manejadores reales:
+
+```rust
+use rustango::test_client::TestClient;
+
+let client = TestClient::new(app());          // app() returns your Router
+
+let res = client.get("/ping").send().await;   // routed in-process
+assert_eq!(res.status, 200);
+```
+
+`TestClient` tiene `get` / `post` / `put` / `patch` / `delete` / `head`, cada uno
+devolviendo un constructor que finalizas con `.send().await`.
+
+---
+
+## Paso 2 — Haz aserciones sobre la respuesta
+
+`TestResponse` expone el estado y el cuerpo en la forma que necesites:
+
+```rust
+let res = client.get("/ping").send().await;
+
+res.status;                 // u16 — e.g. 200
+res.text();                 // body as a String
+res.header("content-type"); // Option<&str>
+```
+
+```rust
+// JSON, two ways:
+let res = client.post("/echo").json(&json!({ "name": "Ada" })).send().await;
+assert_eq!(res.json_value()["name"], "Ada");   // untyped
+
+#[derive(serde::Deserialize)]
+struct Out { name: String }
+let out: Out = res.json();                       // typed
+assert_eq!(out.name, "Ada");
+```
+
+---
+
+## Enviar JSON, cabeceras y cuerpos
+
+El constructor de peticiones encadena todo antes de `.send()`:
+
+```rust
+let res = client
+    .post("/api/posts")
+    .header("authorization", "Bearer <token>")   // auth, content negotiation, …
+    .json(&json!({ "title": "Hello", "body": "..." }))
+    .send()
+    .await;
+assert_eq!(res.status, 201);
+```
+
+Usa `.body(...)` para cuerpos sin procesar (que no sean JSON), y una ruta
+inexistente devuelve un `404` real — verificado en la prueba de respaldo.
+
+---
+
+## Probar una API real
+
+`app()` en tus pruebas no es más que tu router. Para una API respaldada por base de
+datos, constrúyela exactamente como lo hace `main.rs` pero con un pool de pruebas —
+el patrón que usa la mayoría de las pruebas `*_doc.rs`:
+
+```rust
+async fn app() -> axum::Router {
+    let pool = test_pool().await;                 // a sqlite::memory: or test DB pool
+    PostViewSet::router("/api/posts", pool)
+}
+
+#[tokio::test]
+async fn create_then_list() {
+    let client = TestClient::new(app().await);
+    let created = client.post("/api/posts")
+        .json(&json!({ "title": "Hi", "body": "b" }))
+        .send().await;
+    assert_eq!(created.status, 201);
+
+    let list = client.get("/api/posts").send().await;
+    assert!(list.json_value()["results"].is_array());
+}
+```
+
+Esta es la prueba de [ViewSets](viewsets.md) de aquella guía — el mismo `TestClient`.
+
+---
+
+## Pruebas de base de datos con reversión
+
+Las pruebas que escriben en una base de datos no deben filtrar estado entre sí.
+`test_db::with_rollback` ejecuta tu prueba dentro de una transacción y **la revierte**
+al final, de modo que cada prueba parte del mismo estado limpio y nada persiste:
+
+```rust
+use rustango::test_db::with_rollback;
+
+#[tokio::test]
+async fn creating_a_post_persists_it() {
+    with_rollback(&pool, |tx| async move {
+        // ... insert + assert against `tx` ...
+        // everything here is rolled back when the closure returns
+    }).await;
+}
+```
+
+Para SQLite, las pruebas `*_sqlite_live.rs` repartidas por este repositorio usan en
+su lugar una base de datos en memoria por prueba — también totalmente aislada, con
+cero configuración externa.
+
+---
+
+## Ayudantes de aserción de respuesta
+
+Para valores `axum::Response` sin procesar (por ejemplo, de `tower::oneshot`),
+`test_assertions` se lee como los `assertContains` / `assertRedirects` de Django:
+
+```rust
+use rustango::test_assertions::{assert_status_2xx, assert_redirects, assert_cookie_set};
+
+assert_status_2xx(&res);
+assert_redirects(&res, "/login?next=/dashboard");
+assert_cookie_set(&res, "rustango_session", None);
+```
+
+También disponibles: `assert_status` / `assert_status_in` / `assert_status_4xx` /
+`assert_status_5xx`, `assert_header`, `assert_content_type`,
+`assert_redirect_chain`, `assert_cookie_not_set`, y `assert_messages`.
+
+---
+
+## Véase también
+
+- [ViewSets](viewsets.md) · [Vistas HTML](html-views.md) — a qué apuntas el
+  `TestClient`.
+- [Middleware](middleware.md) — `TestClient` también ejercita las capas (sin base
+  de datos, mediante `tower::oneshot` en `middleware.rs`).
+- [Primeros pasos](getting-started.md) — el Paso 16 escribe la primera prueba.
+- [CLI `manage`](manage.md) — `make:test` genera un módulo de pruebas.

--- a/docs/es/urls.md
+++ b/docs/es/urls.md
@@ -1,0 +1,298 @@
+# Nombres de URL y reverse
+
+Codificar URLs a mano (`/posts/42`) por todos los handlers y templates es frágil —
+cambia una ruta y cada literal se rompe en silencio. **Rustango** te da la
+respuesta de Django: **nombra un patrón de URL una vez, luego construye la URL por
+su nombre en todas partes** — en Rust con `reverse(...)`, en templates con
+`{{ url(...) }}`, y en redirecciones con `redirect_to_view(...)`. La superficie de
+la API refleja los `reverse()` / `{% url %}` / `resolve_url()` / `redirect()` de
+Django.
+
+[![URLs reverse al estilo Django: register_url! nombra un patrón, reverse() construye la URL en Rust, y {{ url(...) }} construye la URL en un template](img/urls.png)](img/urls.png)
+
+> **Fuente:** `rustango::urls` (`register_url!`, `reverse`, `reverse_owned`,
+> `all_routes`, `duplicates`, `register_url_tag`) y `rustango::shortcuts`
+> (`resolve_url`, `redirect_to_view`).
+
+> **¿Nuevo con algún término aquí?** *ruta*, *reverse*, *namespacing* — consulta
+> el [glosario](glossary.md).
+
+---
+
+## Tabla de contenidos
+- [Registrar una URL con nombre](#register-a-named-url)
+- [Reverse en Rust](#reverse-in-rust) · [Reverse en templates](#reverse-in-templates)
+- [Redirigir por nombre](#redirect-by-name) · [Namespacing](#namespacing)
+- [Inspeccionar el mapa de URLs](#inspect-the-url-map) · [Errores](#errors)
+- [Patrones regex y de ruta tipados](#regex--typed-path-patterns) · [Notas y límites](#notes-and-limits)
+
+---
+
+## Registrar una URL con nombre
+
+`register_url!("name", "/pattern")` registra un mapeo nombre → patrón. Se ejecuta
+al cargar el módulo (vía `inventory`), así que la ruta aterriza en un registro
+global en el momento en que su módulo se enlaza — sin `urls.py` central que editar,
+y sin `include()` que cablear.
+
+```rust
+use rustango::register_url;
+
+register_url!("post-detail", "/posts/{id}");
+register_url!("user-posts",  "/users/{user_id}/posts/{post_id}");
+register_url!("home",        "/");
+```
+
+Los placeholders usan la sintaxis de ruta `{name}` de axum. El patrón es la misma
+cadena en la que montas el handler — mantenlos sincronizados (registra el nombre
+junto a donde construyes la ruta).
+
+---
+
+## Reverse en Rust
+
+`reverse(name, &params)` sustituye los `{placeholders}` del patrón por los valores
+dados (percent-encodando cada uno) y devuelve la URL:
+
+```rust
+use std::collections::HashMap;
+use rustango::urls::reverse;
+
+let mut params = HashMap::new();
+params.insert("id", "42".to_string());
+
+let url = reverse("post-detail", &params)?;   // → "/posts/42"
+```
+
+Para claves dinámicas (p. ej. valores ensamblados a partir de una petición),
+`reverse_owned` toma `HashMap<String, String>` en lugar de
+`HashMap<&str, String>`:
+
+```rust
+use rustango::urls::reverse_owned;
+let url = reverse_owned("post-detail", &owned_params)?;
+```
+
+`reverse` es **estricto**: un placeholder faltante, o una clave `params` extra que
+el patrón no tiene, es un error (no un desajuste silencioso) — consulta
+[Errores](#errors).
+
+---
+
+## Reverse en templates
+
+Los templates obtienen el `{% url %}` de Django como función Tera. Regístrala una
+vez en tu instancia `Tera` durante el setup (está detrás del feature
+`template_views`):
+
+```rust
+rustango::urls::register_url_tag(&mut tera);
+```
+
+Luego llama a `url(name=..., <param>=...)` en cualquier template — `name` es
+obligatorio, y cada otro argumento con nombre es un parámetro de ruta (se aceptan
+cadenas, números y booleanos):
+
+```jinja
+<a href="{{ url(name='post-detail', id=42) }}">View post</a>
+<a href="{{ url(name='user-posts', user_id=7, post_id=42) }}">…</a>
+```
+
+Ese es el equivalente del `{% url 'post-detail' id=42 %}` de Django. Para el patrón
+de captura `{% url 'x' as var %}`, usa el `{% set %}` de Tera:
+
+```jinja
+{% set post_url = url(name='post-detail', id=post.id) %}
+<a href="{{ post_url }}">{{ post.title }}</a>
+```
+
+Un argumento `null` (normalmente una variable de template no definida) falla
+ruidosamente en lugar de producir en silencio una URL rota.
+
+---
+
+## Redirigir por nombre
+
+`rustango::shortcuts` refleja los helpers de redirección por nombre de vista de
+Django, de modo que los handlers nunca codifican un `Location` a mano:
+
+```rust
+use std::collections::HashMap;
+use rustango::shortcuts::{redirect_to_view, resolve_url};
+
+// redirect('post-detail', id=42) → 302 Location: /posts/42
+let mut params = HashMap::new();
+params.insert("id", "42".to_string());
+let response = redirect_to_view("post-detail", &params)?;
+```
+
+`resolve_url(spec, &params)` es el `resolve_url` de Django: si `spec` ya parece una
+URL (`/…`, `http://`, `https://`, `./`, `../`) se devuelve sin cambios; en caso
+contrario se trata como un nombre de ruta y se resuelve por reverse. Útil para un
+parámetro `?next=` o un ajuste que pueda contener *o bien* una ruta *o bien* un
+nombre:
+
+```rust
+let url = resolve_url("post-detail", &params)?;  // name  → "/posts/42"
+let url = resolve_url("/dashboard", &params)?;   // path  → "/dashboard" (as-is)
+```
+
+(Para redirecciones crudas a una URL conocida, `rustango::shortcuts::redirect(url)`
+devuelve un simple `302`.)
+
+---
+
+## Namespacing
+
+No hay `include()` ni un namespace de app auto-aplicado — cada `register_url!`
+aterriza en un único registro global. El namespacing es una **convención en el
+nombre mismo**: prefija con `app:`, exactamente como llamarías al
+`reverse("app:detail")` de Django.
+
+```rust
+register_url!("blog:post-detail", "/blog/posts/{id}");
+register_url!("shop:product",     "/shop/products/{slug}");
+```
+
+```rust
+reverse("blog:post-detail", &params)?;   // "/blog/posts/42"
+```
+
+Los dos puntos son simplemente parte de la cadena registrada — elige un prefijo
+consistente por app para evitar colisiones.
+
+---
+
+## Inspeccionar el mapa de URLs
+
+Lista cada ruta registrada desde la CLI — útil para una auditoría rápida o para
+scriptear:
+
+```bash
+cargo run -- showurls                  # plain table of name → pattern
+cargo run -- showurls --format json    # machine-readable
+```
+
+En código, `all_routes()` devuelve todo el registro, y `duplicates()` devuelve
+cualquier nombre registrado más de una vez (gana el primero en caso contrario —
+conviene aseverarlo al arrancar):
+
+```rust
+use rustango::urls::{all_routes, duplicates};
+
+for route in all_routes() {
+    println!("{} → {}", route.name, route.pattern);
+}
+
+let dups = duplicates();
+assert!(dups.is_empty(), "duplicate URL names: {dups:?}");
+```
+
+---
+
+## Errores
+
+`reverse` / `reverse_owned` / `resolve_url` / `redirect_to_view` devuelven
+`Result<_, rustango::urls::ReverseError>`:
+
+| Variante | Cuándo |
+|---|---|
+| `UnknownName(name)` | Ningún `register_url!` se ejecutó para ese nombre (errata, o su módulo no se enlazó). |
+| `MissingParam { name, param }` | El patrón tiene `{param}` pero `params` no lo proporcionó. |
+| `UnexpectedParam { name, param }` | `params` llevaba una clave que el patrón no tiene (atrapa erratas). |
+| `MalformedPattern { name, detail }` | El patrón registrado está malformado (p. ej. una `{` sin cerrar). |
+
+En los templates estos afloran como errores de render de Tera (un 500 vía
+`shortcuts::render` / `template_views`), así que un `{{ url(...) }}` erróneo falla
+de forma visible en lugar de renderizar un enlace roto.
+
+---
+
+## Patrones regex y de ruta tipados
+
+**Rustango no tiene `re_path`, y nunca se aplica ningún convertidor de ruta.** Un
+segmento de patrón es o bien un literal (`/posts/new`) o un placeholder `{name}`
+que captura exactamente un segmento; `{*name}` captura el resto de la ruta. Ese es
+todo el vocabulario — no hay `r'(?P<year>[0-9]{4})'`, y `{int:id}` **no** restringe
+`id` a un entero.
+
+### Por qué — el matcher no es un motor de regex
+
+El enrutamiento *es* [axum](https://docs.rs/axum) 0.8, y axum empareja rutas con
+[`matchit`](https://docs.rs/matchit), un router de **radix-trie (árbol radix)**.
+Recorre la URL un segmento a la vez por un árbol de prefijos, de modo que un match
+cuesta O(longitud de la ruta) y es independiente de cuántas rutas hayas registrado.
+Un router de regex hace lo contrario: Django evalúa `urlpatterns` de arriba abajo,
+ejecutando la regex de cada entrada contra la ruta hasta que una coincide. El trie
+compra emparejamiento en tiempo constante y una precedencia inequívoca de «gana el
+literal más específico» — a costa de no expresar restricciones de clase de
+caracteres *en la ruta misma*.
+
+Rustango hereda ese matcher por completo. **No hay un segundo resolvedor basado en
+regex** superpuesto, y `register_url!` registra deliberadamente las *mismas*
+cadenas `{name}` que el router ya entiende — nunca compila una regex. Así que las
+rutas regex no están «apagadas»; la capa de enrutamiento simplemente nunca fue un
+motor de regex de entrada.
+
+La forma `{int:id}` se acepta solo como **facilidad de portado** para `reverse()`:
+el constructor divide el placeholder por `:` y conserva solo el nombre, descartando
+el prefijo de tipo ([`urls.rs`](../crates/rustango/src/urls.rs)). Eso permite que
+`reverse()` funcione sobre un patrón copiado literalmente de un
+`path("<int:id>/", …)` de Django — pero nada valida que el valor suministrado sea
+realmente un entero.
+
+### Cómo expresar una ruta restringida
+
+Empareja el segmento con un simple `{placeholder}`, luego impón su forma donde se
+usa el valor. El `re_path(r'^articles/(?P<year>[0-9]{4})/$', …)` de Django se
+convierte en:
+
+```rust
+register_url!("article-by-year", "/articles/{year}");
+// router:
+.route("/articles/{year}", get(article_by_year))
+
+async fn article_by_year(Path(year): Path<String>) -> impl IntoResponse {
+    // the router accepted any single segment; enforce [0-9]{4} here
+    match year.parse::<u16>() {
+        Ok(y) if (1000..=9999).contains(&y) => render_year(y).await,
+        _ => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+```
+
+Para rechazar *antes* de que el handler se ejecute (más cerca de la semántica de
+convertidores de Django), pon la comprobación en un extractor axum personalizado
+(`FromRequestParts`) y toma ese tipo como argumento del handler en lugar de
+`Path<String>` — el framework no incluye ninguno, pero el trait de extractor de
+axum es la costura prevista. El crate `regex` ya es una dependencia (el ORM lo usa
+para los lookups `__regex`), así que un extractor validador puede compilar una
+`Regex` una vez y reutilizarla entre peticiones.
+
+---
+
+## Notas y límites
+
+- **El registro es en tiempo de enlace.** Un `register_url!` solo surte efecto si su
+  módulo se compila en el binario. Un error `UnknownName` normalmente significa que
+  el nombre es una errata *o* que su módulo no se referencia en ningún sitio (así
+  que el linker lo descartó).
+- **Los patrones no se validan contra tus rutas reales.** `register_url!` registra
+  un mapeo nombre → cadena; no comprueba que haya realmente un handler montado en
+  ese patrón. Registra el nombre junto a donde montas la ruta para que se mantengan
+  sincronizados.
+- **Los valores se percent-encodan** con `reverse`, así que son seguros para
+  colocar en un header `Location` o un `href`.
+- **Sin convertidores regex/tipados** en los patrones (el `<int:pk>` de Django);
+  los placeholders son simples `{name}` y los valores se sustituyen tal cual
+  (después de codificar). Consulta [Patrones regex y de ruta tipados](#regex--typed-path-patterns)
+  para el porqué, y cómo restringir una ruta en su lugar.
+
+
+---
+
+## Véase también
+
+- [Vistas HTML](html-views.md)
+- [ViewSets](viewsets.md)
+- [Middleware](middleware.md)

--- a/docs/es/viewsets.md
+++ b/docs/es/viewsets.md
@@ -1,0 +1,909 @@
+# ViewSets — APIs REST CRUD
+
+Un ViewSet convierte un modelo en un recurso REST completo — endpoints para
+**listar, crear, leer, actualizar y eliminar** registros — a partir de una sola
+declaración. (Es el equivalente en **Rustango** de un `ModelViewSet` de Django
+REST Framework o de un controlador de recurso de API de Laravel, si has usado
+alguno de esos.)
+
+> **¿Nuevo en las APIs REST?** Esta guía asume que sabes qué es un *endpoint*, un
+> *verbo HTTP* (GET / POST / …) y una *petición y respuesta JSON*. Si algo de eso
+> te resulta confuso, el [glosario](glossary.md#web-api-basics) es una
+> introducción de cinco minutos — léelo primero y luego vuelve aquí.
+
+Empareja un ViewSet con un [serializador](serializers.md) — la pieza que da forma
+a tu JSON — y protege **ambas direcciones** a la vez: el serializador formatea
+cada **respuesta** (renombra, oculta, calcula o anida campos) *y* gobierna cada
+**petición** (valida los datos entrantes e ignora silenciosamente los campos que
+un cliente no debería poder establecer). La entrada rechazada regresa con la
+forma familiar de DRF — un objeto JSON indexado por nombre de campo. Todo
+funciona igual en PostgreSQL, MySQL y SQLite.
+
+Esta guía es ante todo un tutorial: **construimos una API REST de blog completa**
+de principio a fin — scaffolding, modelos, un serializador, el ViewSet, los seis
+endpoints CRUD, validación de entrada, filtrado/búsqueda/paginación y pruebas —
+y luego el resto de la página es una referencia de cada perilla.
+
+[![Un ViewSet de Rustango conectado a un serializador: un solo bloque #[viewset(serializer = …)] da salida JSON tipada y entrada validada en las seis rutas CRUD](img/viewsets.png)](img/viewsets.png)
+
+> **Fuente:** `rustango::viewset` (`ViewSet`, `#[derive(ViewSet)]`, las opciones
+> `#[viewset(...)]` + el builder `for_model`) — siempre compilado.
+>
+> **Versión ejecutable:** el blog construido aquí refleja el ejemplo probado y
+> compilable [`getting_started_blog`](../crates/rustango/examples/getting_started_blog)
+> (sus `Post` / `PostSerializer` / `PostViewSet`), y cada comportamiento está
+> fijado por las propias pruebas en vivo del framework — `crates/rustango/tests/viewset_*.rs`
+> (en particular `viewset_serializer_render_sqlite_live` y
+> `viewset_serializer_input_sqlite_live`).
+
+---
+
+## Table of contents
+- [Vistas de API vs vistas HTML](#api-views-vs-html-views) — ¿JSON para clientes o páginas HTML?
+- [Construir una API REST de blog](#build-a-rest-blog-api) — el recorrido completo
+- [El matrimonio con el serializador: entrada + salida](#the-serializer-marriage-input--output)
+- [Las dos formas de definir un ViewSet](#the-two-ways-to-define-a-viewset)
+- [Los endpoints CRUD](#the-crud-endpoints) · [Elegir cuáles exponer](#choosing-which-operations-to-expose)
+- [Referencia de `#[viewset(...)]`](#viewset-attribute-reference) · [Referencia del builder](#builder-reference)
+- [Filtrado, búsqueda y ordenación](#filtering-search-and-ordering) · [Paginación](#pagination)
+- [Validación](#validation) · [Permisos y throttling](#permissions-and-throttling) · [Acciones personalizadas](#custom-actions-beyond-crud)
+- [Montaje](#mounting) · [Backends](#backend-support)
+
+---
+
+## API views vs HTML views
+
+Antes del tutorial, una bifurcación en el camino. **Rustango** tiene dos formas
+de convertir un modelo en endpoints, y un ViewSet es una de ellas:
+
+- Un **ViewSet** (esta guía) es una **vista de API** — habla **JSON**, para
+  frameworks de frontend, apps móviles y otros servicios.
+- Una **vista de plantilla** ([vistas HTML](html-views.md)) es una **vista HTML** —
+  renderiza **páginas del lado del servidor** a través de Tera, para navegadores
+  y sitios renderizados en el servidor.
+
+El mismo modelo por debajo; lo que difiere es qué sale y quién llama.
+
+| | **Vista de API** — ViewSet (aquí) | **Vista HTML** — [vistas de plantilla](html-views.md) |
+|---|---|---|
+| Módulo | `rustango::viewset` | `rustango::template_views` |
+| Devuelve | **datos JSON** | una **página HTML renderizada en el servidor** |
+| Diseñado para | SPAs, móvil, otros servicios | navegadores, sitios renderizados en el servidor, CRUD estilo admin |
+| Un "crear" | `POST` JSON → `201` + el objeto | `POST` de un formulario → redirección `303` (Post/Redirect/Get) |
+| Ante entrada inválida | `400` + un mapa de errores JSON indexado por campo | re-renderiza el formulario con los errores mostrados |
+| Un "listar" es | un sobre JSON paginado | un bucle sobre filas en tu plantilla |
+| Normalmente autenticado por | tokens / JWT / claves de API | cookies de sesión |
+| Análogo en Django | `ModelViewSet` de DRF | vistas genéricas basadas en clases |
+
+Elige por recurso — y puedes montar **ambos sobre el mismo modelo** (una API JSON
+pública *y* páginas CRUD internas). El resto de esta guía es el lado JSON/API;
+para el lado HTML consulta [Vistas HTML — páginas renderizadas en el servidor](html-views.md).
+
+---
+
+## Build a REST blog API
+
+Construiremos un blog con dos modelos — `Author` y `Post` — y expondremos `Post`
+como un recurso REST en `/api/posts` cuya forma JSON y validación están
+gobernadas por un serializador. Al final podrás hacer `curl` a cada verbo CRUD y
+ver cómo el serializador da forma a la salida y rechaza la entrada inválida.
+
+Este recorrido asume un proyecto creado con `cargo rustango new myblog`
+(consulta [Primeros pasos](getting-started.md) para la configuración del proyecto
+y la base de datos). Cada paso es un comando o archivo real.
+
+### Step 1 — Create the blog app
+
+Las apps son módulos de funcionalidad autocontenidos (el `startapp` de Django):
+
+```bash
+cargo run -- startapp blog
+```
+
+Eso escribe `src/blog/{mod,models,views,urls,tests}.rs` y conecta el módulo
+dentro de `main.rs` + el agregador `urls::api()`.
+
+### Step 2 — Define the models
+
+`src/blog/models.rs` — un `Author` y un `Post` (una clave foránea los enlaza):
+
+```rust
+use rustango::{Auto, Model};
+use chrono::{DateTime, Utc};
+
+#[derive(Model, Clone, Debug)]
+#[rustango(table = "authors", display = "name")]
+pub struct Author {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 120)]
+    pub name: String,
+    #[rustango(max_length = 200)]
+    pub email: String,
+}
+
+#[derive(Model, Clone, Debug)]
+#[rustango(table = "posts", display = "title", index("status, published_at"))]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+
+    #[rustango(max_length = 200)]
+    pub title: String,
+
+    pub body: String,
+
+    #[rustango(max_length = 20, default = "'draft'")]
+    pub status: String,                       // draft | published | archived
+
+    #[rustango(fk = "authors", on = "id")]
+    pub author_id: i64,
+
+    #[rustango(auto_now_add)]
+    pub published_at: Auto<DateTime<Utc>>,
+}
+```
+
+### Step 3 — Migrate
+
+Genera y aplica la migración (igual que `makemigrations` + `migrate`):
+
+```bash
+cargo run -- makemigrations
+cargo run -- migrate
+```
+
+### Step 4 — Scaffold the serializer
+
+El serializador es lo que hace de esto una API *DRF* — define el contrato de
+petición/respuesta. Genera el esqueleto:
+
+```bash
+cargo run -- make:serializer PostSerializer --model Post
+```
+
+Luego complétalo. Este ejercita toda la superficie de entrada+salida — un
+renombrado, un campo calculado de solo lectura, un campo de servidor de solo
+lectura y un validador de campo:
+
+```rust
+// src/blog/post_serializer.rs
+use rustango::{Auto, Serializer};
+use chrono::{DateTime, Utc};
+use crate::blog::models::Post;
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: Auto<i64>,
+
+    #[serializer(validate = "title_min_3")]   // input: reject titles < 3 chars
+    pub title: String,
+
+    #[serializer(source = "body")]            // JSON key `content`, column `body`
+    pub content: String,
+
+    pub status: String,
+    pub author_id: i64,
+
+    #[serializer(method = "summary")]         // output: computed, never written
+    pub summary: String,
+
+    #[serializer(read_only)]                  // output: shown, ignored on write
+    pub published_at: Auto<DateTime<Utc>>,
+}
+
+impl PostSerializer {
+    fn title_min_3(t: &String) -> Result<(), String> {
+        if t.chars().count() < 3 {
+            Err("title must be at least 3 characters".into())
+        } else {
+            Ok(())
+        }
+    }
+    fn summary(p: &Post) -> String {
+        p.body.chars().take(80).collect::<String>()
+    }
+}
+```
+
+Registra el módulo — añade `pub mod post_serializer;` a `src/blog/mod.rs`.
+
+Nota que solo escribimos un validador (`title_min_3`); los campos también
+**heredan las restricciones del modelo** automáticamente — a `title` se le
+verifica la longitud contra el `max_length = 200` del modelo, y una columna con
+`choices`/`min`/`max` también se verificaría, todo devolviendo `400`s amigables
+en la escritura. Añade los atributos de serializador `max_length` / `min_length` /
+`min` / `max` para sobrescribir el límite de un campo. (Consulta la
+[guía de serializadores](serializers.md#validation) para la historia completa de
+validación.)
+
+### Step 5 — Scaffold the ViewSet and wire the serializer
+
+```bash
+cargo run -- make:viewset PostViewSet --model Post
+```
+
+Edítalo para declarar el recurso y **conectar el serializador con el atributo
+`serializer`** — esa única línea activa la salida *y* la entrada gobernadas por
+el serializador:
+
+```rust
+// src/blog/post_view_set.rs
+use rustango::ViewSet;
+
+#[derive(ViewSet)]
+#[viewset(
+    model         = Post,
+    serializer    = crate::blog::post_serializer::PostSerializer,
+    filter_fields = "author_id, status",
+    search_fields = "title, body",
+    ordering      = "-published_at",
+    page_size     = 20,
+)]
+pub struct PostViewSet;
+```
+
+Añade `pub mod post_view_set;` a `src/blog/mod.rs`.
+
+> Con un serializador conectado no necesitas `fields = "..."` — el serializador
+> es la proyección. Usa `fields` solo cuando quieras la proyección de campos por
+> defecto (sin serializador) en su lugar.
+
+### Step 6 — Mount the routes
+
+En un proyecto de un solo inquilino, anida el router del ViewSet bajo una ruta,
+pasando el pool:
+
+```rust
+// src/blog/urls.rs (or your urls::api aggregator)
+use axum::Router;
+use rustango::sql::sqlx::PgPool;
+use crate::blog::post_view_set::PostViewSet;
+
+pub fn api(pool: PgPool) -> Router {
+    Router::new()
+        .merge(PostViewSet::router("/api/posts", pool))
+}
+```
+
+`make:api_routes blog` genera exactamente este agregador si prefieres
+generarlo. Conecta `blog::urls::api(pool)` en tu `urls.rs` de nivel superior.
+
+### Step 7 — Run it and exercise every endpoint
+
+```bash
+cargo run            # listening on http://0.0.0.0:8080
+```
+
+**Crear** (`POST`). El serializador valida primero, luego escribe solo los campos
+que acepta:
+
+```bash
+# happy path — note `content` (the renamed `body`) on the way in
+curl -X POST localhost:8080/api/posts \
+  -H 'content-type: application/json' \
+  -d '{"title":"Hello Rustango","content":"First post body.","status":"published","author_id":1}'
+```
+```json
+{
+  "id": 1,
+  "title": "Hello Rustango",
+  "content": "First post body.",
+  "status": "published",
+  "author_id": 1,
+  "summary": "First post body.",
+  "published_at": "2026-01-02T12:00:00Z"
+}
+```
+La respuesta tiene la forma del **serializador**: `body` regresó como `content`,
+apareció el `summary` calculado, y `published_at` (de solo lectura, establecido
+por el servidor) está presente.
+
+**La validación rechaza la entrada inválida** con un `400` con forma de DRF —
+arreglos de mensajes indexados por campo:
+
+```bash
+curl -i -X POST localhost:8080/api/posts \
+  -H 'content-type: application/json' \
+  -d '{"title":"hi","content":"x","author_id":1}'
+# HTTP/1.1 400 Bad Request
+# {"title":["title must be at least 3 characters"]}
+```
+
+**Los campos de solo lectura / calculados que un cliente envía se ignoran** — no
+pueden inyectar `published_at` ni `summary`:
+
+```bash
+curl -X POST localhost:8080/api/posts \
+  -H 'content-type: application/json' \
+  -d '{"title":"Sneaky","content":"x","author_id":1,"published_at":"1999-01-01T00:00:00Z","summary":"hax"}'
+# → published_at is the server value, not 1999; summary is recomputed from body.
+```
+
+**Listar** (`GET`) — paginado, cada fila con la forma del serializador:
+
+```bash
+curl localhost:8080/api/posts
+```
+```json
+{ "count": 1, "page": 1, "page_size": 20, "last_page": 1, "results": [ { "id": 1, "title": "Hello Rustango", … } ] }
+```
+
+**Recuperar / actualizar / actualización parcial / eliminar:**
+
+```bash
+curl localhost:8080/api/posts/1                       # retrieve  → 200
+curl -X PUT   localhost:8080/api/posts/1 -H 'content-type: application/json' \
+     -d '{"title":"Edited","content":"new body","status":"published","author_id":1}'   # full update → 200
+curl -X PATCH localhost:8080/api/posts/1 -H 'content-type: application/json' \
+     -d '{"title":"Just the title"}'                   # partial update → 200 (other fields untouched)
+curl -X DELETE localhost:8080/api/posts/1              # destroy → 204
+```
+
+La validación de `PATCH` corre sobre lo que envías; los campos de solo lectura se
+mantienen en su valor de servidor incluso si se envían.
+
+### Step 8 — Filter, search, order, paginate
+
+Todo en el endpoint de listado, sin código adicional (declaraste los campos en el
+Paso 5):
+
+```bash
+curl 'localhost:8080/api/posts?status=published&author_id=1'      # filter
+curl 'localhost:8080/api/posts?status__in=published,archived'     # lookup
+curl 'localhost:8080/api/posts?search=rustango'                   # search title+body
+curl 'localhost:8080/api/posts?ordering=title'                    # sort (asc)
+curl 'localhost:8080/api/posts?page=2&page_size=10'               # paginate
+```
+
+### Step 9 — Test it
+
+El framework incluye un cliente de pruebas en proceso — haz aserciones sobre
+respuestas HTTP reales sin arrancar un servidor:
+
+```rust
+// tests/post_api.rs
+use rustango::test_client::TestClient;
+use myblog::blog::post_view_set::PostViewSet;
+use rustango::sql::sqlx::PgPool;
+use serde_json::json;
+
+async fn app() -> axum::Router {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap()).await.unwrap();
+    PostViewSet::router("/api/posts", pool)
+}
+
+#[tokio::test]
+async fn rejects_short_title() {
+    let client = TestClient::new(app().await);
+    let res = client.post("/api/posts")
+        .json(&json!({"title":"hi","content":"x","author_id":1}))
+        .send().await;
+    assert_eq!(res.status, 400);
+    assert!(res.json_value()["title"].is_array());   // DRF field-error shape
+}
+
+#[tokio::test]
+async fn create_then_list() {
+    let client = TestClient::new(app().await);
+    let created = client.post("/api/posts")
+        .json(&json!({"title":"Hello","content":"b","status":"published","author_id":1}))
+        .send().await;
+    assert_eq!(created.status, 201);
+    let list = client.get("/api/posts").send().await;
+    assert!(list.json_value()["results"].is_array());
+}
+```
+
+```bash
+cargo test --test post_api
+```
+
+Ese es un recurso REST completo y validado. El resto de esta página es la
+referencia detrás de cada paso.
+
+---
+
+## The serializer marriage: input + output
+
+Conectar un serializador (vía `serializer = …` en el derive, o `.serializer::<S>()`
+en el builder) cambia **ambas** direcciones. Funciona igual en PostgreSQL, MySQL
+y SQLite.
+
+### Output — responses render through the serializer
+
+Las respuestas de `list`, `retrieve`, `create` y `update` se producen mediante
+`S::from_model(&row)`, de modo que las sobrescrituras del serializador dan forma
+al JSON:
+
+| Campo del serializador | Efecto en la respuesta |
+|---|---|
+| `#[serializer(source = "body")]` | la columna `body` se emite bajo el nombre del campo (p. ej. `content`) |
+| `#[serializer(method = "fn")]` | aparece un campo calculado (a partir de `Self::fn(&model)`) |
+| `#[serializer(read_only)]` | incluido en la salida |
+| `#[serializer(write_only)]` | **omitido** de la salida |
+
+> **Advertencia sobre `nested` / `many`.** Los campos de serializador anidados y
+> de colección se renderizan solo cuando las filas relacionadas fueron cargadas
+> (vía `select_related` / una carga anticipada); de lo contrario recurren a su
+> valor por defecto. La consulta de listado del ViewSet automático carga la fila
+> base — conecta las relaciones explícitamente si un campo anidado debe
+> poblarse.
+
+### Input — requests are validated and filtered
+
+En `create` y `update`, cuando hay un serializador registrado:
+
+1. **Se ejecuta la validación.** El `validate()` del serializador — cada
+   `#[serializer(validate = "fn")]` por campo más el `validate` cruzado a nivel
+   de contenedor — corre contra el cuerpo JSON. Ante un fallo, la petición se
+   rechaza con `400 Bad Request` con la forma de error de DRF: un objeto JSON
+   indexado por nombre de campo con arreglos de mensajes, p. ej.
+   `{"title":["title must be at least 3 characters"]}`.
+2. **Filtrado de campos escribibles.** Solo se persisten los campos escribibles
+   del serializador; los campos `read_only` y `method`/calculados que un cliente
+   envía se **ignoran** (no se escriben), y los renombrados de `source` se
+   resuelven a la columna del modelo. Así, un cliente no puede establecer un
+   campo controlado por el servidor incluyéndolo en el cuerpo.
+
+> **Los cuerpos form-urlencoded** (frente a JSON) omiten `validate()` — no hay un
+> valor tipado que validar — pero aún reciben el filtrado de campos escribibles.
+
+Por debajo, esto son los métodos `validate()`, `writable_source_fields()` y
+`from_writable_json()` del trait `ModelSerializer`, todos generados por
+`#[derive(Serializer)]`. Consulta la [guía de serializadores](serializers.md) para
+saber cómo escribir los validadores.
+
+---
+
+## The two ways to define a ViewSet
+
+Ambas producen un `axum::Router` con las mismas rutas CRUD.
+
+**1. La macro derive** — declarativa, de un solo inquilino; conecta un
+serializador con `serializer = …`:
+
+```rust
+#[derive(ViewSet)]
+#[viewset(
+    model         = Post,
+    serializer    = crate::blog::post_serializer::PostSerializer,
+    filter_fields = "author_id, status",
+    search_fields = "title, body",
+    ordering      = "-published_at",
+    page_size     = 20,
+)]
+pub struct PostViewSet;
+
+let router = PostViewSet::router("/api/posts", pool);
+```
+
+**2. El builder** — `ViewSet::for_model(...)`, programático, tri-dialecto
+(PostgreSQL / SQLite / MySQL) y consciente de la tenencia; conecta un serializador
+con `.serializer::<S>()`:
+
+```rust
+use rustango::viewset::ViewSet;
+use rustango::core::Model as _;
+
+let router = ViewSet::for_model(Post::SCHEMA)
+    .serializer::<PostSerializer>()
+    .filter_fields(&["author_id", "status"])
+    .search_fields(&["title", "body"])
+    .ordering(&[("published_at", true)])    // true = DESC
+    .page_size(20)
+    .router_pool("/api/posts", pool);       // tri-dialect Pool
+```
+
+Recurre al builder cuando necesites SQLite/MySQL, multi-tenencia, una
+configuración construida en tiempo de ejecución, o los extras (throttling,
+backends de filtro personalizados, paginación por cursor).
+
+---
+
+## The CRUD endpoints
+
+Montar en `/api/posts` conecta las seis operaciones REST:
+
+| Verbo | Ruta | Acción | Éxito | Cuerpo |
+|---|---|---|---|---|
+| `GET` | `/api/posts` | **list** | 200 | sobre paginado (ver [Paginación](#pagination)) |
+| `POST` | `/api/posts` | **create** | 201 | el objeto creado — *o un arreglo, para creación masiva* |
+| `GET` | `/api/posts/{pk}` | **retrieve** | 200 | el objeto |
+| `PUT` | `/api/posts/{pk}` | **update** (completa) | 200 | el objeto actualizado |
+| `PATCH` | `/api/posts/{pk}` | **partial update** | 200 | el objeto actualizado (solo cambian los campos suministrados) |
+| `DELETE` | `/api/posts/{pk}` | **destroy** | 204 | vacío |
+
+Una barra final en el prefijo de montaje es opcional. Solo se conectan estos seis
+verbos — sin `HEAD`/`OPTIONS` automáticos. La **creación masiva** viene gratis:
+haz `POST` de un *arreglo* JSON y cada elemento se inserta en orden, validado
+atómicamente (un elemento inválido rechaza todo el lote).
+
+---
+
+## Choosing which operations to expose
+
+Para un recurso de **solo lectura** (solo list + retrieve), añade `read_only`:
+
+```rust
+#[viewset(model = Post, read_only)]            // macro
+ViewSet::for_model(Post::SCHEMA).read_only()   // builder
+```
+
+No hay un interruptor por verbo más allá de read-only. Para "todo excepto
+eliminar", monta el ViewSet y sobrescribe la única ruta con tu propio handler
+(ver [Acciones personalizadas](#custom-actions-beyond-crud)).
+
+---
+
+## `#[viewset(...)]` attribute reference
+
+| Clave | Ejemplo | Por defecto | Qué hace |
+|---|---|---|---|
+| `model` | `model = Post` | **requerido** | El modelo sobre el que se construye el recurso. |
+| `serializer` | `serializer = path::To::S` | ninguno | Conecta un serializador para **salida + entrada** tipadas (ver [arriba](#the-serializer-marriage-input--output)). |
+| `fields` | `"id, title, body"` | todos los campos escalares | Lista blanca para la proyección por defecto (sin serializador) + campos escribibles. |
+| `filter_fields` | `"author_id, status"` | ninguno | Campos filtrables vía `?field=value` (+ lookups). |
+| `search_fields` | `"title, body"` | ninguno | Campos con los que coincide la caja `?search=` (OR sin distinción de mayúsculas). |
+| `ordering` | `"-published_at, id"` | ninguno | Orden por defecto (`-` = DESC). |
+| `page_size` | `20` | 20 | Filas por página (el `?page_size=` del cliente se limita a 1000). |
+| `read_only` | *(flag)* | apagado | Expone solo GET (list + retrieve). |
+| `permissions(...)` | `permissions(create = "post.add")` | ninguno | Codenames de permiso por acción. |
+
+---
+
+## Builder reference
+
+Cada método de `ViewSet::for_model(SCHEMA)` (cada uno devuelve `Self`):
+
+| Método | Propósito |
+|---|---|
+| `serializer::<S>()` | Conecta un serializador para salida + entrada tipadas (tri-dialecto). |
+| `fields(&["…"])` | Lista blanca de proyección por defecto + campos escribibles (cuando no hay serializador). |
+| `filter_fields(&["…"])` | Habilita el filtrado `?field=value`. |
+| `search_fields(&["…"])` | Habilita `?search=`. |
+| `ordering(&[("field", desc)])` | Orden de clasificación por defecto. |
+| `ordering_fields(&["…"])` | Lista blanca de qué campos puede usar `?ordering=`. |
+| `page_size(n)` | Tamaño de página por defecto (≤ 1000). |
+| `read_only()` | Solo GET. |
+| `permissions(ViewSetPerms{…})` / `permissions_for_model::<T>()` | Compuertas de codename por acción (la última sobre tenencia). |
+| `cursor_pagination("id")` / `cursor_pagination_desc("id")` | Paginación por keyset (omite `COUNT(*)`). |
+| `limit_offset_pagination()` | Ventaneo `?limit=&offset=`. |
+| `pagination(PaginationStyle::…)` | Establece el estilo explícitamente. |
+| `filter_backend(closure)` | Añade predicados `WHERE` personalizados más allá de `filter_fields`. |
+| `throttle(…)` / `throttle_all(max, secs)` | Límites de tasa de ventana fija por acción. |
+| `router(prefix, pgpool)` | Monta (Postgres, pool estático). |
+| `router_pool(prefix, pool)` | Monta tri-dialecto (PG / SQLite / MySQL). |
+| `tenant_router(prefix)` | *(tenencia)* monta con resolución de inquilino por petición. |
+
+---
+
+## Filtering, search and ordering
+
+Todo gobernado por parámetros de consulta en el endpoint de **listado**.
+
+**Filtrado** — cada entrada de `filter_fields` acepta `?field=value` (exacto) más
+lookups estilo Django vía un sufijo `__`:
+
+```
+?status=published
+?author_id__in=1,2,3
+?published_at__gte=2026-01-01
+?title__icontains=rust
+?body__isnull=false
+```
+
+Lookups soportados: `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `not_in`, `contains`,
+`icontains`, `startswith`, `istartswith`, `endswith`, `iendswith`, `isnull`
+(sin sufijo = exacto). Los campos que no están en `filter_fields` se ignoran.
+
+**Búsqueda** — `?search=term` coincide con `search_fields` mediante un OR sin
+distinción de mayúsculas.
+
+**Ordenación** — `?ordering=field,-other` (`-` = DESC). Cualquier campo es
+ordenable a menos que establezcas `.ordering_fields([...])` para restringirlo. Sin
+un parámetro, se aplica el `ordering` por defecto. Todos se componen.
+
+---
+
+## Pagination
+
+> **Trampa — pagina sobre un orden determinista.** La paginación por número de
+> página y por limit/offset asume una clasificación estable; ordenar por una
+> columna no única (o por ninguna) permite que las filas se desplacen entre
+> páginas — duplicadas u omitidas. Añade siempre un desempate único, p. ej.
+> `ordering = "-published_at, id"`. (Ambas también ejecutan `COUNT(*)` por
+> llamada; la paginación por cursor lo omite para tablas grandes.)
+
+Tres estilos; el de número de página es el predeterminado. El sobre de listado
+difiere según el estilo:
+
+**Número de página** (por defecto) — `?page=2&page_size=20`:
+
+```json
+{ "count": 137, "page": 2, "page_size": 20, "last_page": 7, "results": [ … ] }
+```
+
+**Cursor** — `.cursor_pagination("id")` (o `_desc`); omite `COUNT(*)`, ideal para
+tablas muy grandes. `?cursor=<token>&page_size=20`:
+
+```json
+{ "page_size": 20, "next": "<opaque-cursor-or-null>", "results": [ … ] }
+```
+
+**Limit/offset** — `.limit_offset_pagination()`. `?limit=20&offset=40`:
+
+```json
+{ "count": 137, "limit": 20, "offset": 40, "results": [ … ] }
+```
+
+`page_size` / `limit` se limitan a 1000.
+
+---
+
+## Validation
+
+Con un **serializador conectado**, la ruta de create/update ejecuta los
+validadores del serializador y devuelve `400`s con forma de DRF — la forma
+recomendada de validar (ver [el matrimonio](#the-serializer-marriage-input--output)
+y la [guía de serializadores](serializers.md#validation)). Se ejecutan tres capas:
+
+- **Restricciones declarativas** — `max_length` / `min_length` / `min` / `max`, y
+  por defecto el campo **hereda del modelo** `max_length` / `min` / `max` /
+  `choices`. Así, una columna `#[rustango(max_length = 200)]` se verifica en
+  longitud en la API sin configuración extra (comportamiento del `ModelSerializer`
+  de DRF), convirtiendo los `500`s que serían por restricción de BD en `400`s
+  amigables como `{"title":["Ensure this value has at most 200 characters."]}`.
+- **Por campo** `validate = "fn"` y un hook `validate` **cruzado** — tus reglas
+  personalizadas (formatos, entre campos, lógica de negocio).
+
+Independientemente de un serializador, la ruta de escritura siempre aplica el
+**esquema**:
+
+- **Los tipos se coaccionan y verifican** — un valor `i64` / `DateTime` / `Uuid` /
+  `bool` inválido es un `400` que nombra el campo.
+- **Requerido / NOT NULL** — un campo no anulable faltante (o cadena vacía para un
+  `String` no anulable) es un `400`; los campos anulables aceptan vacío → `NULL`.
+- **Restricciones de base de datos** — únicos, claves foráneas y restricciones
+  check afloran como un `400` en INSERT/UPDATE.
+
+Así que incluso sin un serializador obtienes validación de tipo + requerido +
+restricción de BD; conecta un serializador para obtener verificaciones
+declarativas de longitud/rango/choice (heredadas automáticamente) más tus propias
+reglas por campo y entre campos.
+
+---
+
+## Permissions and throttling
+
+> **Un ViewSet es público por defecto.** Montar uno expone los seis verbos CRUD a
+> cualquiera — no hay autenticación integrada. Protégelo con `permissions(...)`
+> (abajo), ponlo detrás del [middleware de autenticación](auth-backends.md)
+> (`require_auth`), o ambos, antes de exponer escrituras.
+
+**Los permisos** protegen cada acción con codenames (OR dentro de una acción):
+
+```rust
+use rustango::viewset::{ViewSet, ViewSetPerms};
+
+ViewSet::for_model(Post::SCHEMA)
+    .permissions(ViewSetPerms {
+        list:     vec!["post.view".into()],
+        retrieve: vec!["post.view".into()],
+        create:   vec!["post.add".into()],
+        update:   vec!["post.change".into()],
+        destroy:  vec!["post.delete".into()],
+    })
+    .router_pool("/api/posts", pool);
+```
+
+Una lista de acción vacía = sin verificación. La aplicación lee un usuario
+autenticado de la petición (la integración de autenticación de `tenancy`); los
+superusuarios la eluden, un usuario ausente se deniega. `.permissions_for_model::<Post>()`
+autocompleta los codenames estándar `post.view`/`add`/`change`/`delete`.
+
+**El throttling** aplica límites de ventana fija por cliente, por acción:
+
+```rust
+ViewSet::for_model(Post::SCHEMA)
+    .throttle_all(60, 60)              // 60 requests / 60s per client, every action
+    .router_pool("/api/posts", pool);
+```
+
+Sobre el límite → `429 Too Many Requests` + `Retry-After`. Los contadores son por
+proceso; la clave del cliente es la IP de conexión (o `X-Forwarded-For` /
+`X-Real-IP`).
+
+---
+
+## Custom actions beyond CRUD
+
+No hay un decorador `@action` de DRF — el ViewSet es estrictamente las seis rutas
+CRUD. Para endpoints adicionales, monta tus propios handlers junto al ViewSet:
+
+```rust
+use axum::{Router, routing::{get, post}};
+
+let api = Router::new()
+    .merge(ViewSet::for_model(Post::SCHEMA).router_pool("/api/posts", pool.clone()))
+    .route("/api/posts/stats", get(post_stats))
+    .route("/api/posts/bulk_archive", post(bulk_archive));
+```
+
+Para lógica `WHERE` adicional, `.filter_backend(…)` aporta predicados sin una ruta
+separada.
+
+### Scoping rows to the authenticated principal
+
+Un backend se ejecuta en **cada** acción — `list`, `retrieve`, `update`,
+`destroy` — de modo que se comporta como el `get_queryset()` de DRF. Una fila que
+el backend excluye es un **404** en las rutas de ítem, no un 403: un 403
+confirmaría que el id existe.
+
+La identidad debe provenir de la credencial, nunca de la cadena de consulta. Un
+filtro `?owner_id=` no es un ámbito — es un parámetro que el llamador elige.
+
+#### `OwnedBy` — the shipped backend
+
+La mayoría de los recursos con dueño necesitan exactamente una regla: *filas cuya
+columna de propiedad es el llamador*. Nombra la columna y móntala.
+
+```rust
+use rustango::viewset::{OwnedBy, ViewSet};
+
+ViewSet::for_model(Note::SCHEMA)
+    .filter_backend(OwnedBy::column("member_id"))
+    .tenant_router("/api/notes")
+    .layer(axum::middleware::from_fn(
+        rustango::tenancy::auth_routes::require_bearer,
+    ))
+```
+
+Cualquier columna funciona — `owner_id`, `member_id`, `author_id` — porque el
+backend toma el nombre en lugar de asumir una convención. Falla cerrado en las dos
+formas en que puede estar mal: una petición no autenticada y una columna que el
+modelo no tiene coinciden ambas con **nada**, de modo que un error tipográfico al
+montar no puede convertirse en "sin predicados, devuelve la tabla".
+
+Los superusuarios no son especiales por defecto; `.superuser_sees_all()` lo
+habilita, porque "los admins ven todo" es una decisión de producto, no del
+framework.
+
+#### Where the identity comes from
+
+[`Principal`] es el único tipo de identidad, resuelto a partir de lo que sea que
+verificó la petición — un `Principal` explícito, un `AuthenticatedUser` dejado por
+un middleware de sesión o Bearer, o un token de agente MCP (que actúa como el
+usuario que lo acuñó). No autentica nada por sí mismo; solo lee lo que un
+middleware verificador ya demostró, de modo que nada puede insertar uno sin
+verificar primero una credencial.
+
+`require_bearer` es ese middleware para una API JSON: verifica el token de acceso
+contra el inquilino resuelto, vuelve a leer la fila del usuario (una cuenta
+desactivada deja de funcionar en la siguiente petición, no cuando el token
+expira), e inserta tanto `AuthenticatedUser` como `Principal`. Úsalo como
+extractor en cualquier lugar:
+
+```rust
+use rustango::tenancy::{OptionalPrincipal, Principal};
+
+async fn mine(principal: Principal) -> String {          // 401 when absent
+    format!("user {}", principal.user_id)
+}
+
+async fn home(OptionalPrincipal(who): OptionalPrincipal) -> String {
+    who.map_or("anonymous".into(), |p| format!("user {}", p.user_id))
+}
+```
+
+#### Writing your own backend
+
+Cuando la propiedad no es una sola columna — un equipo compartido, una fila con
+borrado lógico, una ventana de fechas — implementa el trait y sobrescribe
+`filter_with`, que recibe los `Parts` de la petición:
+
+```rust
+use axum::http::request::Parts;
+use rustango::tenancy::Principal;
+use rustango::viewset::ViewSetFilter;
+
+struct OwnerFilter;
+
+impl ViewSetFilter for OwnerFilter {
+    // No principal in hand — fail closed. Returning no predicates here would
+    // widen the query to every row in the table.
+    fn filter(&self, _p: &HashMap<String, String>, schema: &'static ModelSchema) -> Vec<WhereExpr> {
+        deny_all(schema)
+    }
+
+    fn filter_with(
+        &self,
+        parts: &Parts,
+        _p: &HashMap<String, String>,
+        schema: &'static ModelSchema,
+    ) -> Vec<WhereExpr> {
+        let Some(principal) = Principal::from_parts(parts) else {
+            return deny_all(schema);
+        };
+        vec![WhereExpr::Predicate(Filter {
+            column: schema.field("owner_id").expect("owner_id").column,
+            op: Op::Eq,
+            value: SqlValue::from(principal.user_id),
+        })]
+    }
+}
+
+ViewSet::for_model(Note::SCHEMA)
+    .filter_backend(OwnerFilter)
+    .tenant_router("/api/notes")
+```
+
+`filter_with` recae por defecto en `filter`, de modo que un backend que no
+necesita la petición — incluida la forma de closure simple — implementa solo
+`filter` como antes.
+
+---
+
+## Mounting
+
+Compón el router del ViewSet en tu app. Un solo inquilino, pool estático:
+
+```rust
+let api = urls::api()
+    .merge(PostViewSet::router("/api/posts", pool.clone()))                          // macro
+    .merge(ViewSet::for_model(Author::SCHEMA).router_pool("/api/authors", pool.clone())); // builder
+```
+
+Multi-inquilino (sin pool capturado — cada petición resuelve su conexión de
+inquilino):
+
+```rust
+let api = urls::api()
+    .merge(ViewSet::for_model(Post::SCHEMA).tenant_router("/api/posts"));
+```
+
+`make:api_routes <app>` genera una `api()` por app que reúne estas líneas
+`.merge(...)`; conéctala en tu `urls.rs` de nivel superior.
+
+---
+
+## Backend support
+
+- **El builder + `router_pool` / `tenant_router`** es **tri-dialecto** —
+  PostgreSQL, SQLite y MySQL — y es la ruta recomendada.
+- **El `router(prefix, PgPool)` de la macro derive** captura un `PgPool`
+  (PostgreSQL).
+- **La entrada + salida del serializador** ahora funciona en **los tres backends**
+  (el renderizado por fila es tri-dialecto; la antigua compuerta solo-PG
+  desapareció).
+- El filtrado, la búsqueda, la ordenación, los tres modos de paginación, los
+  permisos, el throttling y la creación masiva funcionan todos en los backends
+  soportados en la ruta del builder.
+
+---
+
+## Try it
+
+El flujo de principio a fin de arriba refleja el ejemplo compilable
+`getting_started_blog` (Pasos 12–13 de la [guía de primeros pasos](getting-started.md)).
+Las propias pruebas en vivo del framework bajo `crates/rustango/tests/viewset_*.rs`
+son la referencia ejecutable más completa — incluidas las pruebas de
+entrada/salida del serializador. Corren sobre SQLite en memoria pero necesitan los
+feature flags correspondientes, p. ej.:
+
+```bash
+cd crates/rustango
+cargo test --features sqlite,tenancy --test viewset_serializer_render_sqlite_live
+cargo test --features sqlite,tenancy --test viewset_serializer_input_sqlite_live
+cargo test --features sqlite,tenancy --test viewset_sqlite_live
+```
+
+---
+
+## See also
+
+- [Serializadores](serializers.md) — da forma al JSON que un ViewSet envía y valida.
+- [Vistas HTML](html-views.md) — la contraparte renderizada en el servidor de esta API JSON.
+- [OpenAPI](openapi.md) — genera una especificación + Swagger UI a partir de tus ViewSets.
+- [URLs y enrutamiento](urls.md) — compón routers de ViewSet en tu app.

--- a/docs/es/websockets.md
+++ b/docs/es/websockets.md
@@ -1,0 +1,216 @@
+# WebSockets y SSE
+
+La mayoría de las peticiones son de un solo disparo: pregunta, respuesta, listo. Las
+características **en tiempo real** son la excepción — una notificación en vivo, una barra de
+progreso, un panel que se actualiza solo, un chat. El servidor necesita *empujar* al navegador sin
+que se lo pidan. **Rustango** te ofrece ambos transportes de push sobre una sola base:
+
+- **SSE (Server-Sent Events)** — un flujo unidireccional, servidor → navegador, sobre HTTP
+  simple. El `EventSource` integrado del navegador se reconecta automáticamente. Lo más simple que
+  funciona; úsalo para notificaciones, progreso, contadores en vivo, feeds.
+- **WebSockets** — un canal full-duplex, en ambas direcciones. Úsalo cuando el
+  cliente también envía (chat, edición colaborativa, presencia).
+
+Ambos se difunden a través del mismo **bus de difusión** en proceso ([`EventBus`]), de modo que
+«envía esto a cada cliente conectado» es una sola llamada independientemente del transporte. Si
+vienes de Django, esto es Channels; de Laravel, Echo/Reverb; de Node,
+`ws` + `EventSource` — las mismas ideas, un solo bus detrás de ellas.
+
+> **Fuente:** `rustango::sse` (`EventBus`) — tras la característica **`sse`**; y
+> `rustango::ws` (`WsHub`, `WsConfig`, `ws_handler`) — tras la
+> característica **`websocket`** (implica `admin` + `sse` + `axum/ws`). Ambas están en
+> el conjunto de características por defecto. El canal servidor→cliente del servidor MCP
+> (`rustango::mcp::transport`) es un consumidor de producción del lado SSE.
+>
+> **Referencia ejecutable:** los snippets autorizados y actualizados son las
+> guías de inicio rápido de los módulos en `src/sse.rs` y `src/ws.rs`; la difusión del
+> `EventBus` está cubierta por los tests unitarios en `src/sse.rs`.
+
+> **¿Nuevo con algún término aquí?** *SSE*, *WebSocket*, *broadcast*, *keep-alive/ping*,
+> *back-pressure* — ver el [glosario](glossary.md).
+
+## Tabla de contenidos
+
+- [¿SSE o WebSocket — cuál?](#sse-or-websocket--which)
+- [El bus de difusión](#the-broadcast-bus)
+- [Server-Sent Events](#server-sent-events)
+- [WebSockets](#websockets)
+- [Enviar desde otro sitio](#sending-from-elsewhere)
+- [Auth y multi-inquilino](#auth--tenancy)
+- [Notas de escalado](#scaling-notes)
+- [Flags de características](#feature-flags)
+
+---
+
+## ¿SSE o WebSocket — cuál?
+
+| | **SSE** | **WebSocket** |
+|---|---|---|
+| Dirección | solo servidor → cliente | bidireccional |
+| Transporte | HTTP simple (`text/event-stream`) | upgrade `ws://` / `wss://` |
+| Reconexión | automática (integrada en `EventSource`) | la gestionas tú (o lo hace una biblioteca cliente) |
+| Proxies / infra | solo HTTP — trivialmente proxeable | necesita proxies conscientes del upgrade |
+| API del cliente | `new EventSource(url)` | `new WebSocket(url)` |
+| Úsalo para | notificaciones, progreso, contadores en vivo, feeds | chat, presencia, edición colaborativa, cualquier cosa que el cliente también *envíe* |
+
+**Regla general:** si el cliente solo *recibe*, usa SSE — es menos código, se reconecta automáticamente y viaja sobre HTTP ordinario. Recurre a un WebSocket solo cuando el cliente también *envía*.
+
+## El bus de difusión
+
+Ambos transportes se apoyan en [`EventBus<T>`] — un canal de difusión barato de clonar. Un
+solo `send` alcanza a cada suscriptor; los suscriptores lentos se rezagan en lugar de bloquear a
+los demás. `T` es tu propio tipo de mensaje `Clone`.
+
+```rust
+use rustango::sse::EventBus;
+use serde::{Serialize, Deserialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+struct Notification { kind: String, message: String }
+
+// capacity = per-subscriber buffer; older messages drop for a lagging client.
+let bus: EventBus<Notification> = EventBus::new(100);
+
+// share `bus` via router state (it's Clone). Then from anywhere:
+let delivered = bus.send(Notification { kind: "info".into(), message: "Saved".into() });
+//  `delivered` = how many connected clients received it (0 = no-op).
+```
+
+API de `EventBus`: `new(capacity)`, `send(event) -> usize`, `subscribe() ->
+broadcast::Receiver<T>`, `receiver_count() -> usize`.
+
+## Server-Sent Events
+
+Cablea el bus a un endpoint SSE con la respuesta `Sse` de axum + un
+`async_stream::stream!` que reenvía cada mensaje de difusión como un evento. Añade
+`async-stream` y `futures` a tu `Cargo.toml`.
+
+```rust
+use std::convert::Infallible;
+use axum::{extract::State, response::sse::{Event, KeepAlive, Sse}, routing::get, Router};
+use futures::Stream;
+use rustango::sse::EventBus;
+
+async fn events(
+    State(bus): State<EventBus<Notification>>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let mut rx = bus.subscribe();
+    let stream = async_stream::stream! {
+        while let Ok(msg) = rx.recv().await {
+            let json = serde_json::to_string(&msg).unwrap_or_default();
+            yield Ok(Event::default().event("notification").data(json));
+        }
+    };
+    // keep-alive comments stop idle connections being reaped by proxies.
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+let app = Router::new()
+    .route("/events", get(events))
+    .with_state(bus.clone());
+```
+
+Navegador — el `EventSource` integrado se conecta y se reconecta automáticamente:
+
+```js
+const es = new EventSource('/events');
+es.addEventListener('notification', (e) => {
+  const n = JSON.parse(e.data);
+  console.log(n.kind, n.message);
+});
+es.onerror = () => {/* EventSource retries automatically */};
+```
+
+## WebSockets
+
+Para tráfico bidireccional, usa [`WsHub`] + [`ws_handler`]. El hub envuelve un
+`EventBus` y añade pings keep-alive, (de)serialización JSON y el manejo de consumidores
+lentos; `ws_handler` ejecuta una conexión hasta que el cliente se desconecta.
+
+```rust
+use std::time::Duration;
+use axum::{extract::{State, WebSocketUpgrade}, response::Response, routing::get, Router};
+use rustango::{sse::EventBus, ws::{ws_handler, WsHub}};
+use serde::{Serialize, Deserialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+struct Tick { value: i64 }
+
+let bus: EventBus<Tick> = EventBus::new(100);
+let hub = WsHub::new(bus).keepalive(Duration::from_secs(20));
+
+async fn ws_route(ws: WebSocketUpgrade, State(hub): State<WsHub<Tick>>) -> Response {
+    ws.on_upgrade(move |socket| ws_handler(socket, hub.clone()))
+}
+
+let app = Router::new()
+    .route("/ws", get(ws_route))
+    .with_state(hub.clone());
+
+// From anywhere — one call fans out to every connected socket:
+hub.broadcast(Tick { value: 42 });
+```
+
+```js
+const ws = new WebSocket(`${location.origin.replace('http', 'ws')}/ws`);
+ws.onmessage = (e) => { const t = JSON.parse(e.data); console.log('tick', t.value); };
+```
+
+**Ajuste** mediante [`WsConfig`] (métodos de builder en `WsHub`):
+
+| Perilla | Por defecto | Efecto |
+|---|---|---|
+| `.keepalive(Duration)` | 30 s | intervalo de `Ping` en reposo — más bajo detecta conexiones muertas antes |
+| `.on_message(fn(&str) -> Option<String>)` | ninguno | maneja texto cliente→servidor; devuelve `Some(reply)` para responder con eco **solo a ese cliente** (llama a `hub.broadcast(..)` para la difusión) |
+| `.max_message_bytes(n)` | 1 MiB | cierra la conexión si un mensaje del cliente excede esto |
+
+**Los consumidores lentos** no se descartan en silencio: a un cliente rezagado se le indica que
+se perdió `n` mensajes (`Lagged(n)`) para que pueda resincronizarse o continuar.
+
+## Enviar desde otro sitio
+
+El bus/hub es `Clone` y vive en el state del router, de modo que cualquier parte de tu
+aplicación — un handler de petición, un [trabajo en segundo plano](jobs.md), un receptor de
+[señal](models.md) — puede empujar a cada cliente conectado sosteniendo un clon y llamando a
+`bus.send(..)` / `hub.broadcast(..)`. Un patrón común: un trabajo termina → difunde una
+notificación de «hecho» → el flujo SSE abierto del navegador actualiza la UI.
+
+Un solo `EventBus` puede respaldar **tanto** una ruta SSE como una ruta WebSocket a la vez —
+`WsHub::bus()` te entrega el bus subyacente para compartirlo con un handler SSE, de modo que los
+clientes de cualquiera de los dos transportes ven el mismo flujo.
+
+## Auth y multi-inquilino
+
+Las rutas SSE/WS son rutas axum ordinarias — superpón tu auth habitual sobre ellas
+(sesión, [JWT](auth-jwt-api.md), [clave de API](auth-api-keys.md)) exactamente como lo
+harías con cualquier handler; añade el extractor a la ruta y rechaza antes de
+suscribir. En una aplicación multi-inquilino, resuelve el inquilino en la conexión y usa un
+**bus por inquilino** (o filtra los mensajes por inquilino) para que los eventos de un
+inquilino nunca alcancen a los clientes de otro. El [servidor MCP](mcp.md) hace exactamente
+esto — su canal SSE autenticado y por agente se construye sobre esta misma base `sse`.
+
+## Notas de escalado
+
+`EventBus` es un `tokio::sync::broadcast` **en proceso** — la difusión es instantánea
+y ligera en bloqueos, pero solo alcanza a los clientes conectados a *este* proceso. ¿Ejecutas
+varias instancias de la aplicación detrás de un balanceador de carga? Un cliente conectado al nodo A
+no verá un evento enviado en el nodo B. Para difundir entre nodos, tiende un puente entre el bus y
+un pub/sub externo (p. ej. Redis) — publica ahí los eventos de dominio y haz que el
+suscriptor de cada nodo los vuelva a `send` a su `EventBus` local. El caso de un solo nodo
+(el caso común) no necesita nada de esto.
+
+Dimensiona también `EventBus::new(capacity)` para tu tasa de ráfaga: es el búfer por
+suscriptor, y un cliente que se rezaga más allá de `capacity` recibe una
+señal `Lagged` en lugar de un crecimiento de memoria ilimitado.
+
+## Flags de características
+
+```toml
+# Cargo.toml — both are in Rustango's default set; list them if you slim features.
+rustango = { version = "*", features = ["sse", "websocket"] }
+```
+
+- **`sse`** — el bus de difusión `EventBus` (arrastra `tokio`). Suficiente para SSE, ya que
+  el formato de cable SSE proviene del propio `response::sse` de axum.
+- **`websocket`** — el andamiaje `WsHub` / `ws_handler`; implica `admin` (axum)
+  + `sse` + `axum/ws`.

--- a/docs/fr/api-conventions.md
+++ b/docs/fr/api-conventions.md
@@ -1,0 +1,321 @@
+# Conventions d'API
+
+> **À qui s'adresse cette page.** Il s'agit d'une **référence avancée destinée aux développeurs Rust** qui travaillent *avec* ou *sur* le code du framework — elle explique les conventions de nommage, de types de retour et de modules derrière l'API Rust de Rustango. Ce **n'est pas** un guide pour *appeler* l'API REST d'une application Rustango via HTTP. Si c'est ce que vous cherchez, commencez par les [ViewSets](viewsets.md) (construire une API REST) et le [glossaire](glossary.md) (termes en langage clair) ; revenez ici une fois que vous écrirez du Rust contre le framework.
+
+Cette page explique les patterns que suit l'API de **Rustango**, afin que vous puissiez prédire le comportement de n'importe quelle méthode avant même d'en lire la documentation. Si vous contribuez ou auditez une fonctionnalité, ce sont les règles à connaître.
+
+[![Convention de nommage de Rustango : le suffixe de la méthode indique ce qu'elle attend — `*_on` pour un pool typé, forme nue pour le pool multi-backend, et signaux sans pool](img/api-conventions.png)](img/api-conventions.png)
+
+## Table des matières
+
+- [Naming](#naming)
+- [Constructors](#constructors)
+- [Return types](#return-types)
+- [Async vs sync](#async-vs-sync)
+- [The pool argument](#the-pool-argument)
+- [Filtering](#filtering)
+- [Errors](#errors)
+- [Module naming](#module-naming)
+- [Builders vs config structs](#builders-vs-config-structs)
+- [Feature flags](#feature-flags)
+- [Macros vs runtime](#macros-vs-runtime)
+- [Contributing](#contributing)
+
+---
+
+## Nommage
+
+Le nom d'une méthode indique ce qu'elle fait. Une fois ces suffixes assimilés, vous pouvez deviner la majeure partie de l'API.
+
+### Fonctions
+
+- **`save_on(executor)`, `delete_on(executor)`** — les méthodes d'écriture prennent un *executor* (un pool, une connexion ou une transaction — la chose qui dialogue avec la base de données). Le suffixe `_on` signifie « exécute ceci contre l'executor que je te fournis ».
+- **`fetch_on(executor)`, `count_on(executor)`** — même suffixe `_on`, pour les lectures.
+- **`save()`, `fetch()`, `count()`** sans `_on` — raccourci qui appelle la version `_on` avec un `&pool` par défaut. Ne fonctionne que là où le queryset ou le modèle détient déjà une référence de pool (rare dans le code applicatif).
+- **`from_X(value)`** — convertit DEPUIS une autre valeur (par ex. `from_model(post)`, `from_base32(s)`).
+- **`with_X(value)`** — une méthode de builder qui définit une option et retourne l'objet, ce qui permet d'enchaîner les appels (par ex. `with_default_ttl(d)`, `with_access_ttl(secs)`).
+- **`new()`** — le constructeur minimal. Les arguments qu'il prend sont des dépendances obligatoires (par ex. `RedisCache::new(url)` — vous ne pouvez pas construire le cache sans une URL).
+
+### Types
+
+Ils suivent la casse standard de Rust, la même que la distinction de PEP 8 en Python entre classes et fonctions :
+
+- **`PascalCase`** — types, traits et variantes d'enum (comme les classes Python).
+- **`snake_case`** — modules, fonctions, champs et variables locales.
+- **`SCREAMING_SNAKE_CASE`** — constantes, plus la constante `Model::SCHEMA` que la macro derive génère pour chaque modèle.
+- **`Boxed*`** — un alias pour `Arc<dyn Trait>`, un pointeur partagé thread-safe vers un objet-trait (la façon Rust de conserver « n'importe quelle implémentation de cette interface »). Par exemple `BoxedCache = Arc<dyn Cache>`. C'est le type standard pour un backend interchangeable que vous pouvez remplacer.
+
+### Modules
+
+- **Singulier** lorsque le module contient UN seul type ou concept principal : `cache`, `email`, `storage`, `signed_url`, `request_id`.
+- **Pluriel** lorsque le module contient une COLLECTION d'éléments : `bulk_actions`, `api_keys`, `passwords`, `forms`, `signals`.
+
+---
+
+## Constructeurs
+
+La façon de construire un objet dépend de ce dont il a besoin. Il existe quelques formes standard :
+
+| Pattern | Quand | Exemple |
+|---|---|---|
+| `T::new()` | Minimal — aucune dépendance obligatoire | `InMemoryCache::new()`, `Validator::new()` |
+| `T::new(arg)` | Une dépendance obligatoire | `EnvSecrets::with_prefix(s)`, `RedisCache::new(url)` |
+| `T::with_X(arg)` | Surcharge de style builder après `new()` | `InMemoryCache::with_default_ttl(d)`, `JwtLifecycle::new(s).with_access_ttl(60)` |
+| `T::from_X(arg)` | Convertir DEPUIS Y | `TotpSecret::from_base32(s)`, `Locale::new(s)` (parfois `from_str`) |
+| `T::for_Y(arg)` | Construire un T restreint à un Y spécifique | `ViewSet::for_model(schema)` |
+
+**À éviter :** `T::with_X_and_Y_and_Z(a, b, c)` — un seul constructeur qui prend tout. Découpez-le plutôt en `new(...)` plus des appels chaînés `.with_*()`.
+
+---
+
+## Types de retour
+
+Le type de retour d'une méthode indique comment elle peut échouer. Rust n'a pas d'exceptions, donc l'échec fait partie de la valeur de retour. Il existe trois formes.
+
+**`Result<T, E>`** — comme une fonction qui soit retourne une valeur, soit lève une exception. Vous obtenez soit la valeur `T`, soit une erreur `E` avec des détails. À utiliser pour les opérations qui peuvent échouer et où le *pourquoi* importe :
+- E/S : `pool.fetch(...).await -> Result<_, sqlx::Error>`
+- Validation : `Form::parse(data) -> Result<Self, FormErrors>`
+- Émission : `JwtLifecycle::issue_pair_with(uid, claims) -> Result<_, JwtIssueError>`
+
+**`Option<T>`** — soit une valeur (`Some`), soit rien (`None`), comme un champ nullable. À utiliser quand « rien trouvé » est un résultat normal et que vous n'avez pas besoin d'un message d'erreur expliquant pourquoi :
+- Recherches : `cache.get(k) -> Result<Option<String>, _>` (le `Result` couvre l'échec d'E/S ; l'`Option` couvre « clé absente »)
+- Vérification : `JwtLifecycle::verify_access(token) -> Option<Claims>` (« expiré ou invalide » est un résultat attendu, donc `None` suffit)
+- Lectures de config optionnelles : `env::optional("FOO") -> Result<Option<T>, _>`
+
+**`bool`** — un simple oui/non quand aucun détail supplémentaire n'est nécessaire :
+- `cache.exists(k) -> Result<bool, _>` (le `Result` couvre l'E/S ; le `bool` est la réponse)
+- `JwtLifecycle::revoke(token) -> bool` (true = ajouté à la liste noire)
+- `disconnect_pre_save(id) -> bool` (true = une entrée a été retirée)
+
+**`Result<Option<T>>` ou `Result<T>` avec une erreur `NotFound` ?** Les deux peuvent exprimer « la recherche a échoué », alors choisissez selon le caractère exceptionnel de « non trouvé » :
+- Utilisez `Result<Option<T>>` quand « non trouvé » est courant — votre code se ramifie de toute façon presque toujours sur `Some`/`None`.
+- Utilisez `Result<T>` avec une variante d'erreur `NotFound` quand « non trouvé » est exceptionnel — quelque chose que vous consigneriez en avertissement ou transformeriez en 404.
+
+---
+
+## Async vs sync
+
+La règle générale : si une méthode attend quelque chose (la base de données, le réseau ou le disque), elle est `async` et vous devez la `.await`. Si elle ne fait que calculer, c'est un appel sync normal. Ce tableau le détaille.
+
+| Opération | Sync ou async ? |
+|---|---|
+| Méthode de trait qui touche l'E/S (BDD, réseau, fichier) | **async** |
+| Méthode de trait purement calculatoire (`hash`, `verify`, `encode`) | **sync** |
+| Méthodes de builder (`with_X`, setters chaînables) | **sync** |
+| Macros (`derive(Model)`, `derive(Serializer)`) | **N/A** (à la compilation) |
+| Signal `connect_*` (enregistre un récepteur) | **sync** |
+| Signal `send_*` (dispatche vers des récepteurs async) | **async** |
+
+**Exception :** `Cache::set` est `async` même si la version en mémoire (`InMemoryCache::set`) n'attend jamais réellement. Le trait est modelé pour le cas Redis, qui, lui, attend. C'est intentionnel : une méthode de trait devrait être `async` si *une seule* implémentation raisonnable a besoin d'attendre, afin que tous les backends partagent une même signature.
+
+---
+
+## L'argument pool
+
+Chaque appel ORM prend un pool ou un executor (le handle de base de données) comme **dernier** argument. Vous passez la connexion à chaque fois, plutôt que de vous appuyer sur un état global caché :
+
+```rust
+post.save_on(&pool).await?
+Post::objects().filter(...).fetch_on(&pool).await?
+send_post_save(&post, ctx).await                  // ⚠️ no pool — signals are pool-free
+```
+
+**Une seule exception :** les signaux ne prennent pas de pool, car ils ne touchent jamais la base de données. La règle tient : tout ce qui atteint la BDD prend le pool ; tout ce qui ne l'atteint pas, non.
+
+**Pourquoi le passer à chaque fois ?** Rust préfère les dépendances visibles à un état global caché. Django conserve la connexion dans un stockage thread-local, mais cela s'effondre dans le monde async de Rust, où une tâche peut sauter d'un thread à l'autre en plein milieu d'une requête. L'inconvénient, c'est plus de saisie ; l'avantage, c'est que vous pouvez faire un grep sur chaque endroit qui touche la base de données.
+
+Si vous vous retrouvez à faire transiter `&pool` à travers dix couches d'appels de fonctions, acceptez `impl Executor` une seule fois au point d'entrée public et laissez les helpers internes partager cette unique connexion.
+
+---
+
+## Filtrage
+
+Il y a trois façons de filtrer un queryset, et elles se combinent toutes dans une même requête. Choisissez selon la provenance du filtre.
+
+```rust
+// 1. HTTP query string (set via ViewSet filter_fields, parsed at request time)
+//    GET /api/posts?author_id=42&status__ne=archived
+
+// 2. String-keyed (lookup at compile of the queryset; runtime field name resolution)
+Post::objects().filter("author_id", Op::Eq, SqlValue::I64(42));
+
+// 3. Typed columns (compile-time field check)
+Post::objects().where_(Post::author_id.eq(42));
+```
+
+| Syntaxe | À utiliser quand |
+|---|---|
+| Requête HTTP | Endpoints d'API publics — le ViewSet les analyse pour vous, comme les backends de filtre de DRF |
+| `.filter` par clé-chaîne | Code CRUD générique ou d'admin, où les noms de champs viennent de la config et ne sont pas connus à la compilation |
+| `.where_` typé | Le code de votre application — le choix par défaut recommandé. Le compilateur vérifie que le champ existe et que les types correspondent |
+
+Vous pouvez **mélanger les trois** dans un même queryset.
+
+---
+
+## Erreurs
+
+**Rustango** compte **plus de 20 types d'erreur** — un par module — au lieu d'une unique classe d'exception fourre-tout. Ils forment une hiérarchie souple, et un type de plus haut niveau les relie de sorte que vous les manipulez rarement individuellement.
+
+| Couche | Module | Type d'erreur |
+|---|---|---|
+| E/S ORM | `sql::*` | `ExecError` |
+| Écrivain SQL de l'ORM | `sql::*` | `SqlError` (variante de `ExecError::Sql`) |
+| Migrations | `migrate::*` | `MigrateError` |
+| Formulaires | `forms::*` | `FormError` (simple) + `FormErrors` (multiple) + `ModelFormError` |
+| Cache | `cache::*` | `CacheError` |
+| Email | `email::*` | `MailError` |
+| Stockage | `storage::*` | `StorageError` |
+| Backends d'authentification | `tenancy::auth_backends` | `AuthError` |
+| JWT | `tenancy::jwt_lifecycle` | `JwtIssueError` |
+| Clés d'API | `api_keys::*` | `ApiKeyError` |
+| Mots de passe | `passwords::*` | `PasswordError` |
+| Webhooks | `webhook::*` | (retourne un bool, pas d'erreur dédiée) |
+| URLs signées | `signed_url::*` | `SignedUrlError` |
+| Actions en masse | `bulk_actions::*` | `BulkActionError` |
+| Fixtures | `fixtures::*` | `FixtureError` |
+| Filtre IP | `ip_filter::*` | `IpFilterError` |
+| i18n | `i18n::*` | `I18nError` |
+| Env | `env::*` | `EnvError` |
+| Secrets | `secrets::*` | `SecretsError` |
+| Réponses d'API | `api_errors::*` | `ApiError` (forme HTTP, pas interne) |
+
+**Celle à utiliser dans les handlers :** il existe une enum `RustangoError` de plus haut niveau (exportée depuis `lib.rs`, avec l'alias `RustangoResult<T> = Result<T, RustangoError>`). Elle enveloppe chacune des erreurs ci-dessus via des conversions `From`, si bien que l'opérateur `?` promeut automatiquement toute erreur de module vers elle. Elle implémente aussi `IntoResponse`, ce qui signifie que chaque variante est mappée vers un statut HTTP sensé lorsqu'elle est retournée depuis un handler. La répartition est simple : utilisez les erreurs spécifiques par module au plus profond de votre code, et `RustangoError` / `RustangoResult` à la frontière du handler. Pour les erreurs provenant de crates tierces, `RustangoError::other(msg)` / `RustangoError::other_from(e)` enveloppent n'importe quel `std::error::Error + Send + Sync + 'static`.
+
+**Un exemple de handler :**
+
+```rust
+use rustango::api_errors::ApiError;
+
+async fn handler() -> Result<Json<X>, ApiError> {
+    let post = Post::objects().get(&pool, 1).await
+        .map_err(|e| ApiError::internal(e.to_string()))?;
+    Ok(Json(post))
+}
+```
+
+`ApiError` implémente `IntoResponse`, si bien que le retourner produit automatiquement la forme JSON d'erreur standard.
+
+---
+
+## Nommage des modules
+
+Le nom d'un module devrait vous permettre de **deviner les noms des types qu'il contient** sans ouvrir le fichier.
+
+| Module | Héberge | Confiance de recherche |
+|---|---|---|
+| `cache` | le trait `Cache`, les impls `*Cache` | élevée |
+| `email` | le trait `Mailer`, `Email`, les impls `*Mailer` | élevée |
+| `storage` | le trait `Storage`, les impls `*Storage` | élevée |
+| `signed_url` | les fonctions libres `sign`, `verify` | moyenne |
+| `text` | les fonctions libres `slugify`, `html_escape`, `truncate` | moyenne |
+| `bulk_actions` | `BulkActionRegistry`, `BulkAction`, les impls `Bulk*Action` | élevée |
+| `api_keys` | les fonctions libres `generate_key`, `verify_key`, `split_token` | moyenne |
+
+**À éviter :** un module qui contient un fourre-tout hétéroclite (`utils`, `helpers`, `common`). Si vous ne pouvez pas nommer le concept unique qu'il couvre, il ne devrait pas être un module.
+
+---
+
+## Builders vs structs de config
+
+Il y a deux façons de fournir un objet configuré. Choisissez selon la manière dont les utilisateurs le paramétreront.
+
+### Builder : setters chaînés, pas de `Default`
+
+```rust
+let l = SecurityHeadersLayer::strict()
+    .csp(...)
+    .header("x-extra", "v");
+```
+
+À utiliser quand :
+- La plupart des utilisateurs partent d'un préréglage et l'ajustent
+- Les setters expriment une intention (par ex. `.errors_only()` se lit mieux que `.log_success(false)`)
+- Le struct a de nombreux champs optionnels (10+)
+
+### Struct de config : définir les champs directement, se rabattre sur `Default`
+
+```rust
+let l = AccessLogLayer {
+    log_success: false,
+    include_ip: true,
+    slow_threshold_ms: 500,
+    ..Default::default()
+};
+```
+
+À utiliser quand :
+- Les utilisateurs veulent être explicites sur chaque champ
+- La réflexion / sérialisation importe
+- La mise à jour sur place est courante (`config.field = ...`)
+
+**En règle générale, **Rustango** utilise des builders** pour les middlewares HTTP (`security_headers`, `cors`, `rate_limit`, et ainsi de suite) et des structs de config pour les simples porteurs de données (`Email`, `AccessLogLayer`, l'état interne de `RateLimitLayer`).
+
+---
+
+## Feature flags
+
+Une *feature* est un flag de build Cargo (le `[features]` de `Cargo.toml`) qui active ou désactive un pan du crate — comparable à la découverte de paquets de Laravel ou aux `INSTALLED_APPS` de Django, mais résolu à la compilation. Chaque module qui tire une dépendance supplémentaire se trouve derrière l'une d'elles. L'ensemble par défaut, c'est « vous en voulez presque certainement » :
+
+```toml
+default = [
+    "postgres", "manage", "admin", "config", "forms", "serializer",
+    "cache", "signals", "email", "storage", "scheduler", "secrets", "totp",
+    "webhook", "webhook-delivery", "api_keys", "passwords", "signed_url",
+    "notifications", "casts", "jobs", "jobs-postgres", "auth_flows", "sse",
+    "websocket", "oauth2", "http-client", "compression", "openapi",
+    "csp-nonce", "sessions", "hmac-auth", "jwt", "uploads", "storage-s3",
+    "media", "runserver", "template_views",
+]
+```
+
+**Désactivées par défaut :** les features qui tirent de lourdes dépendances ou des services externes :
+- `tenancy` — ajoute `argon2`, `hmac`, `sha2`, `cookie`, `tower` (la plupart des applications n'en ont pas besoin)
+- `cache-redis` — ajoute la crate `redis` (la plupart des applications se contentent du cache en mémoire)
+- `csrf` — activée automatiquement par `admin`, mais aussi disponible seule
+
+Pour réduire un binaire qui n'a pas besoin de tout, désactivez les valeurs par défaut et ne listez que ce que vous utilisez :
+
+```toml
+rustango = { version = "0.44", default-features = false, features = ["postgres", "admin"] }
+```
+
+---
+
+## Macros vs runtime
+
+Une *macro* est du code qui génère du code à la compilation (`#[derive(Model)]` et consorts) — à peu près ce que fait un générateur Rails, sauf qu'elle s'exécute à chaque build et que le compilateur vérifie le résultat. La répartition ci-dessous décide de ce qui est fait par une macro versus du simple code au runtime.
+
+| Préoccupation | Macro ou runtime ? |
+|---|---|
+| Métadonnées de schéma pour `inventory` | macro (`#[derive(Model)]`) |
+| Construction de requêtes pilotée par le schéma | runtime (utilise le `&'static ModelSchema` issu de la macro) |
+| Parsing de formulaire | macro pour le struct (`#[derive(Form)]`) ; runtime pour la logique de parsing |
+| Sélection des champs du serializer | macro (`#[derive(Serializer)]`) — émet un `from_model` + une impl `Serialize` personnalisée |
+| Opérations de migration | runtime (diff de `SchemaSnapshot`) |
+| Dispatch de signal | runtime (registre indexé par `TypeId`, pas de macro par modèle) |
+| Filtrage par pattern des backends d'authentification | runtime (`#[async_trait]` sur `AuthBackend`) |
+
+**Règle :** utilisez une macro pour tout ce que le compilateur peut vérifier d'emblée (les noms de champs doivent exister, les types doivent correspondre). Utilisez du code au runtime pour tout ce qui varie par requête ou par déploiement.
+
+---
+
+## Contribuer
+
+Lorsque vous ajoutez une nouvelle fonctionnalité, suivez ces étapes :
+
+1. **Un module par concept**, dans `crates/rustango/src/<name>.rs` ou `<name>/mod.rs`.
+2. **Ajoutez de la rustdoc au niveau du module** avec un exemple « Quick start » dans un bloc `// ignore`.
+3. **Ajoutez un feature flag si vous tirez une nouvelle dépendance** — nommez-le d'après le module (`feature = "<name>"`).
+4. **Ré-exportez le module depuis `lib.rs`** avec une rustdoc d'une ligne.
+5. **Placez les tests unitaires dans le même fichier**, derrière `#[cfg(test)] mod tests` — pas de base de données à moins d'en avoir vraiment besoin.
+6. **Placez les tests d'intégration dans `crates/rustango/tests/<name>.rs`** pour le scénario de bout en bout.
+7. **N'ajoutez pas de nouveau type d'erreur à moins que les existants ne conviennent pas** — étendez d'abord une enum existante.
+8. **Suivez le [guide des types de retour](#return-types)** au moment de choisir entre `Result`, `Option` ou `bool`.
+9. **Vous ajoutez une sous-commande `manage` ?** Câblez-la dans le dispatcher `match cmd` et `print_help`, ajoutez un test dans `crates/rustango/tests/migrate_manage.rs`, et documentez une ligne dans `docs/manage.md`.
+10. **Mettez à jour `CHANGELOG.md`** avec une entrée `Added` sous la prochaine version.
+
+Lorsque vous cassez l'API :
+- Marquez l'ancien élément `#[deprecated(since = "...", note = "use X instead")]` et conservez-le pendant une version mineure complète avant de le retirer.
+- Consignez-le dans `CHANGELOG.md` sous `Breaking changes`.
+- Faites le lien vers le chemin de migration depuis les notes de version.

--- a/docs/fr/auth-api-keys.md
+++ b/docs/fr/auth-api-keys.md
@@ -1,0 +1,213 @@
+# Clés d'API
+
+Une clé d'API est un **identifiant à longue durée de vie pour les machines** —
+tâches CI, scripts, appels de serveur à serveur — qui ne peuvent pas présenter
+de formulaire de connexion ni porter de cookie de session. Le client envoie la
+clé à chaque requête ; le serveur la recherche et identifie l'appelant.
+**Rustango** vous offre deux couches : un utilitaire autonome de
+génération/vérification que vous pouvez brancher sur votre propre table, et un
+backend clé en main qui stocke les clés et authentifie les requêtes
+`Authorization: Bearer`.
+
+[![Clés d'API dans Rustango : generate_key renvoie un token à usage unique prefix.secret, vous stockez le préfixe de 8 caractères plus un hash argon2id, et verify_key vérifie un secret entrant](img/auth-api-keys.png)](img/auth-api-keys.png)
+
+> **Un terme vous est inconnu ?** *Token*, *hash*, *Bearer*, *argon2id* — le
+> [glossaire](glossary.md) définit les briques de base.
+
+> **Source :** `rustango::api_keys` (`generate_key`, `hash_secret`, `verify_key`,
+> `split_token`, `ApiKeyError`) — l'utilitaire autonome, derrière la
+> fonctionnalité `api_keys` (activée par défaut). Le backend avec stockage est
+> `rustango::tenancy::auth_backends` (`create_api_key`, `ApiKeyBackend`,
+> `ensure_api_keys_table_pool`) — derrière la fonctionnalité `tenancy`.
+>
+> **Version exécutable :** les extraits de l'utilitaire sont copiés depuis
+> [`auth_api_keys_doc.rs`](../crates/rustango/tests/auth_api_keys_doc.rs)
+> (`cargo test -p rustango --test auth_api_keys_doc`) ; le flux du middleware
+> `ApiKeyBackend` depuis
+> [`auth_backends_doc.rs`](../crates/rustango/tests/auth_backends_doc.rs)
+> (`cargo test -p rustango --features sqlite,tenancy --test auth_backends_doc`).
+
+## Table des matières
+
+- [Comment fonctionne une clé d'API](#how-an-api-key-works)
+- [L'utilitaire autonome](#the-standalone-helper)
+- [Le backend avec stockage](#the-stored-backend)
+- [Émettre une clé (CLI + code)](#issuing-a-key)
+- [Authentifier les requêtes](#authenticating-requests)
+- [Notes de sécurité](#security-notes)
+- [Voir aussi](#see-also)
+
+---
+
+## Comment fonctionne une clé d'API
+
+Une clé a deux parties jointes par un point : **`{prefix}.{secret}`**.
+
+- Le **préfixe** fait 8 caractères — stocké en clair et utilisé comme index de
+  recherche rapide et unique (« quelle clé est-ce ? »).
+- Le **secret** est l'identifiant réel. Vous ne stockez qu'un **hash argon2id**
+  de celui-ci, jamais le secret lui-même.
+
+Le token complet est montré à l'utilisateur **exactement une fois**, à la
+création. Perdez-le et vous le réémettez — il n'y a aucun moyen de le récupérer,
+car seul le hash est conservé. C'est la même discipline « hasher, ne pas
+stocker » que pour les [mots de passe](auth-passwords.md), appliquée aux
+identifiants machine.
+
+---
+
+## L'utilitaire autonome
+
+`rustango::api_keys` est une boîte à outils sans dépendance (pas de base de
+données, pas de tables) — utilisez-le quand vous voulez stocker les clés dans
+votre propre schéma.
+
+```rust
+use rustango::api_keys::{generate_key, split_token, verify_key};
+
+// À la création : renvoie (full_token, prefix, hash).
+let (token, prefix, hash) = generate_key()?;
+// → token  = "a1b2c3d4.<secret>"   à montrer à l'utilisateur UNE FOIS
+// → prefix = "a1b2c3d4"            à stocker comme clé de recherche
+// → hash   = "$argon2id$v=19$..."  à stocker au lieu du secret
+
+// Sur une requête entrante : extraire le token, trouver la ligne par préfixe, vérifier.
+let (prefix, secret) = split_token(&token).expect("well-formed token");
+let stored_hash = lookup_hash_by_prefix(prefix);     // votre requête
+if verify_key(secret, &stored_hash)? {
+    // authentifié
+}
+```
+
+`split_token` est strict — il renvoie `None` sauf si le préfixe fait exactement
+8 caractères et que le secret est non vide, de sorte qu'une entrée malformée est
+rejetée avant que vous ne touchiez à la base de données :
+
+```rust
+assert!(split_token("no-dot-here").is_none());
+assert!(split_token("short.secret").is_none()); // le préfixe doit faire 8 caractères
+assert!(split_token("a1b2c3d4.").is_none());     // secret vide
+```
+
+`hash_secret` et `verify_key` utilisent argon2id avec un sel aléatoire par hash,
+de sorte que hasher deux fois le même secret produit des chaînes différentes —
+et les deux se vérifient. `verify_key` renvoie `Ok(false)` en cas de non-
+correspondance et `Err(ApiKeyError)` uniquement quand la chaîne stockée n'est pas
+un hash valide.
+
+---
+
+## Le backend avec stockage
+
+Si vous êtes déjà sur la couche `tenancy`, vous n'avez pas besoin de votre propre
+table. `rustango::tenancy::auth_backends` fournit un modèle `ApiKey` (table
+`rustango_api_keys`), un créateur, et un backend d'authentification qui se
+branche sur la [chaîne de backends](auth-backends.md).
+
+Amorcez la table une fois (tri-dialecte, idempotent) :
+
+```rust
+use rustango::tenancy::auth_backends::ensure_api_keys_table_pool;
+
+ensure_api_keys_table_pool(&pool).await?;   // CREATE TABLE IF NOT EXISTS
+```
+
+La ligne `ApiKey` stocke `user_id` (FK vers `rustango_users`), le `key_prefix`
+de 8 caractères (unique), le `key_hash` argon2id, un `label`, et un `expires_at`
+optionnel.
+
+---
+
+## Émettre une clé
+
+`create_api_key` génère le token, hashe le secret, insère la ligne, et renvoie le
+**token en clair une seule fois** :
+
+```rust
+use rustango::tenancy::auth_backends::create_api_key;
+
+// Émettre une clé sans expiration pour l'utilisateur 42, étiquetée "ci-key".
+let token = create_api_key(42, "ci-key", None, &pool).await?;
+println!("Store this — it won't be shown again: {token}");
+
+// Ou avec une expiration :
+use chrono::{Duration, Utc};
+let token = create_api_key(42, "tmp", Some(Utc::now() + Duration::days(30)), &pool).await?;
+```
+
+Depuis la ligne de commande, la CLI `manage` enveloppe le même appel :
+
+```bash
+cargo run -- create-api-key <tenant> <username> --label "ci-key" --expires-days 30
+```
+
+---
+
+## Authentifier les requêtes
+
+Enregistrez `ApiKeyBackend` dans votre [chaîne de backends
+d'authentification](auth-backends.md) et le middleware authentifie toute requête
+`Authorization: Bearer {prefix}.{secret}` :
+
+```rust
+use std::sync::Arc;
+use rustango::tenancy::auth_backends::{ApiKeyBackend, AuthBackend, ModelBackend};
+use rustango::tenancy::RouterAuthExt;
+
+let backends: Vec<Arc<dyn AuthBackend>> = vec![
+    Arc::new(ModelBackend),   // HTTP Basic (humains)
+    Arc::new(ApiKeyBackend),  // clé Bearer  (machines)
+];
+
+let app = Router::new()
+    .route("/api/data", get(handler))
+    .require_auth(backends, pool);
+```
+
+Un client appelle alors :
+
+```bash
+curl https://api.example.com/api/data \
+  -H "Authorization: Bearer a1b2c3d4.the-secret-half"
+```
+
+Le backend trouve l'`ApiKey` par son préfixe de 8 caractères, vérifie
+`expires_at`, vérifie le secret contre le hash stocké, charge l'utilisateur
+propriétaire, et l'injecte pour que vos handlers le lisent via
+[`CurrentUser`](auth-backends.md). Un mauvais secret ou un préfixe inconnu est un
+`401` ; une clé expirée est rejetée ; un propriétaire désactivé est un `403`.
+
+---
+
+## Notes de sécurité
+
+- **Le secret est montré une fois.** Seuls le préfixe + le hash argon2id sont
+  persistés — il n'y a pas de récupération, seulement une réémission.
+- **Le préfixe est stocké en clair à dessein** — c'est l'index de recherche en
+  O(1). Une fuite de base de données révèle quels préfixes existent, jamais les
+  secrets.
+- **Le timing est égalisé.** Un préfixe inconnu exécute quand même une
+  vérification factice, de sorte qu'une clé manquante prend à peu près le même
+  temps qu'une vraie — pas d'énumération via le timing de réponse.
+- **Cantonnez les clés à un utilisateur, définissez une expiration, et faites-les
+  tourner.** Émettez-en une par intégration afin de pouvoir en révoquer une sans
+  perturber les autres ; préférez des fenêtres `expires_at` courtes pour un accès
+  temporaire.
+- **Distinction des JWT :** le backend traite une valeur Bearer comme une clé
+  d'API uniquement quand son premier segment séparé par un point fait exactement
+  8 caractères — ainsi les clés d'API et les [JWT](auth-jwt.md) peuvent partager
+  l'en-tête `Authorization: Bearer`.
+
+---
+
+## Voir aussi
+
+- [Backends d'authentification](auth-backends.md) — la chaîne sur laquelle se
+  branche `ApiKeyBackend`, et l'extracteur `CurrentUser` + le middleware
+  `require_auth`/`require_perm`.
+- [Signature de requêtes HMAC](auth-hmac.md) — pour les appelants machine qui ont
+  besoin d'intégrité par requête, pas seulement d'un identifiant bearer.
+- [Mots de passe](auth-passwords.md) — la même discipline « hasher, ne pas
+  stocker » pour les connexions humaines.
+- [JWT](auth-jwt.md) — tokens sans état à courte durée de vie, l'autre option
+  machine.

--- a/docs/fr/auth-backends.md
+++ b/docs/fr/auth-backends.md
@@ -1,0 +1,221 @@
+# Backends d'authentification
+
+Un **backend d'authentification** répond à une seule question : *étant donné une
+requête entrante, qui est l'utilisateur ?* **Rustango** vous permet d'en empiler
+plusieurs — HTTP Basic, clé d'API, JWT — dans une chaîne que le middleware
+d'authentification essaie dans l'ordre, de sorte qu'une même application peut
+accepter humains et machines sur les mêmes routes. C'est l'idée
+`AUTHENTICATION_BACKENDS` de Django, câblée à axum. Associez-la à
+`require_auth` / `require_perm` pour verrouiller les routes et à l'extracteur
+`CurrentUser` pour lire le résultat.
+
+[![Les backends d'authentification dans Rustango : une requête traverse une chaîne de backends (ModelBackend, ApiKeyBackend, JwtBackend) ; le premier à reconnaître l'identifiant l'emporte et injecte CurrentUser, puis require_perm vérifie un codename](img/auth-backends.png)](img/auth-backends.png)
+
+> **Un terme vous est inconnu ici ?** *Backend*, *middleware*, *extracteur*,
+> *codename de permission* — voir le [glossaire](glossary.md).
+
+> **Source :** `rustango::tenancy::auth_backends` (`AuthBackend`, `ModelBackend`,
+> `ApiKeyBackend`, `JwtBackend`, `AuthUser`, `AuthError`) et
+> `rustango::tenancy::{RouterAuthExt, CurrentUser}` — derrière la fonctionnalité
+> `tenancy`. Un registre portable et indépendant de la base de données vit aussi
+> à `rustango::auth_backends` (toujours compilé).
+>
+> **Version exécutable :** chaque extrait est copié depuis
+> [`auth_backends_doc.rs`](../crates/rustango/tests/auth_backends_doc.rs)
+> (`cargo test -p rustango --features sqlite,tenancy --test auth_backends_doc`).
+
+## Table des matières
+
+- [La chaîne](#the-chain) · [Les backends intégrés](#the-built-in-backends)
+- [Verrouiller les routes : require_auth](#gating-routes-require_auth)
+- [Lire l'utilisateur : CurrentUser](#reading-the-user-currentuser)
+- [Permissions : require_perm](#permissions-require_perm)
+- [Le registre portable](#the-portable-registry)
+- [Voir aussi](#see-also)
+
+---
+
+## La chaîne
+
+Vous passez à `require_auth` un `Vec<Arc<dyn AuthBackend>>`. À chaque requête, le
+middleware les essaie **dans l'ordre** :
+
+- le **premier** backend qui reconnaît l'identifiant l'emporte (renvoie
+  l'utilisateur) ;
+- un backend qui ne le reconnaît pas renvoie « aucun » et le suivant est essayé ;
+- si un backend échoue durement (par ex. un compte inactif sur un jeton
+  *valide*), la chaîne s'arrête avec cette erreur ;
+- si aucun ne correspond, la requête reçoit un `401` (avec `require_auth`) ou
+  poursuit de manière anonyme (avec `optional_auth`).
+
+```rust
+use std::sync::Arc;
+use rustango::tenancy::auth_backends::{ApiKeyBackend, AuthBackend, ModelBackend};
+
+let backends: Vec<Arc<dyn AuthBackend>> = vec![
+    Arc::new(ModelBackend),    // HTTP Basic  → humans
+    Arc::new(ApiKeyBackend),   // Bearer key  → machines
+];
+```
+
+---
+
+## Les backends intégrés
+
+| Backend | Identifiant qu'il lit | Identifie un utilisateur par |
+|---|---|---|
+| `ModelBackend` | `Authorization: Basic <base64(user:pass)>` | nom d'utilisateur + vérification du mot de passe argon2id contre `rustango_users` |
+| `ApiKeyBackend` | `Authorization: Bearer <prefix.secret>` | la table `rustango_api_keys` (voir [Clés d'API](auth-api-keys.md)) |
+| `JwtBackend` | `Authorization: Bearer <jwt>` | un jeton HS256 signé (voir [JWT](auth-jwt.md)) |
+
+`ApiKeyBackend` et `JwtBackend` lisent tous deux `Bearer` et lèvent l'ambiguïté
+par la forme (le premier segment séparé par un point d'une clé d'API fait
+exactement 8 caractères). Construisez `JwtBackend` avec un secret d'**au moins 32
+octets** (`JwtBackend::new(secret)` panique sinon) :
+
+```rust
+use rustango::tenancy::auth_backends::JwtBackend;
+
+let backends: Vec<Arc<dyn AuthBackend>> = vec![
+    Arc::new(ModelBackend),
+    Arc::new(JwtBackend::new(jwt_secret_at_least_32_bytes.to_vec())),
+];
+```
+
+Écrivez un backend personnalisé en implémentant le trait (une seule méthode async
+qui inspecte les `Parts` de la requête et renvoie `Option<AuthUser>`) :
+
+```rust
+use async_trait::async_trait;   // add `async-trait` to your Cargo.toml
+use axum::http::request::Parts;
+use rustango::sql::Pool;
+use rustango::tenancy::auth_backends::{AuthBackend, AuthError, AuthUser};
+
+struct HeaderBackend;
+
+#[async_trait]
+impl AuthBackend for HeaderBackend {
+    async fn authenticate(&self, parts: &Parts, _pool: &Pool)
+        -> Result<Option<AuthUser>, AuthError>
+    {
+        // ...inspect parts.headers, return Some(AuthUser{..}) or Ok(None)
+        Ok(None)
+    }
+}
+```
+
+---
+
+## Verrouiller les routes : require_auth
+
+`RouterAuthExt` ajoute le middleware. `require_auth` rejette les requêtes
+anonymes avec un `401` ; `optional_auth` les laisse passer (de sorte qu'un
+handler peut se ramifier selon connecté ou non) :
+
+```rust
+use rustango::tenancy::RouterAuthExt;
+
+let app = Router::new()
+    .route("/profile", get(profile))
+    .require_auth(backends, pool);     // 401 if no backend matches
+```
+
+Comportement vérifié :
+
+```rust
+// no credentials               → 401
+// Basic alice:<correct>        → 200
+// Basic alice:<wrong>          → 401   (no backend accepted; no enumeration)
+// Bearer <valid api key>       → 200
+```
+
+---
+
+## Lire l'utilisateur : CurrentUser
+
+Les handlers lisent l'utilisateur authentifié avec l'extracteur `CurrentUser`.
+Il est infaillible — `Some(user)` lorsqu'un backend en a résolu un, `None` sinon :
+
+```rust
+use rustango::tenancy::CurrentUser;
+
+async fn profile(CurrentUser(user): CurrentUser) -> Response {
+    match user {
+        Some(u) => format!("hello {}", u.username).into_response(),
+        None    => StatusCode::UNAUTHORIZED.into_response(),
+    }
+}
+```
+
+> **Piège :** parce que `CurrentUser` est infaillible, oublier `require_auth` ne
+> provoque pas d'échec de compilation — chaque requête voit simplement `None`.
+> Derrière `require_auth`, les requêtes anonymes reçoivent déjà un `401`, donc
+> `user` y est toujours `Some`.
+
+---
+
+## Permissions : require_perm
+
+`require_perm` verrouille une route sur un **codename** de permission
+(`{table}.{action}`, par ex. `post.add`). Appliquez-le au sous-routeur interne et
+`require_auth` à l'externe, afin que l'utilisateur soit résolu *avant* que la
+permission ne soit vérifiée :
+
+```rust
+let admin = Router::new()
+    .route("/admin", get(admin_only))
+    .require_perm("post.add", pool.clone());   // inner: needs the codename
+
+let app = Router::new()
+    .route("/profile", get(profile))
+    .merge(admin)
+    .require_auth(backends, pool);             // outer: resolves the user first
+```
+
+```rust
+// alice (granted post.add)   → /admin 200
+// bob   (authed, no grant)   → /admin 403
+// anonymous                  → /admin 401   (auth runs first)
+```
+
+Résolution : un **superutilisateur** (actif) passe tout ; un utilisateur
+**désactivé** est refusé même avec des octrois ; une surcharge explicite par
+utilisateur l'emporte sur les octrois de rôle ; sinon, tout rôle détenu par
+l'utilisateur qui octroie le codename passe. Octroyez avec
+`set_user_perm_pool` / les rôles via `create_role_pool` + `assign_role_pool` (les
+tables de permissions sont créées par `ensure_tables_pool`).
+
+---
+
+## Le registre portable
+
+Séparément, `rustango::auth_backends` (à noter : racine de crate, **et non**
+`tenancy`) est un petit registre **indépendant du framework** — une chaîne
+`Credentials` → `Principal` dotée de son propre trait `AuthBackend`. Il n'a aucune
+glu HTTP/axum ; utilisez-le lorsque vous voulez une pluggabilité de backend à la
+Django au sein de votre propre code d'authentification :
+
+```rust
+use rustango::auth_backends::{AuthBackendChain, Credentials, RemoteUserBackend};
+
+let chain = AuthBackendChain::new().with(Arc::new(RemoteUserBackend::trust_username()));
+let principal = chain.authenticate(&Credentials::remote("alice")).await?;
+```
+
+Mêmes sémantiques « le premier succès l'emporte / la première erreur arrête » que
+la chaîne HTTP. Pour verrouiller de vraies routes, utilisez le middleware
+`tenancy` ci-dessus.
+
+---
+
+## Voir aussi
+
+- [Clés d'API](auth-api-keys.md) et [JWT](auth-jwt.md) — les identifiants que
+  `ApiKeyBackend` / `JwtBackend` consomment.
+- [Mots de passe](auth-passwords.md) — le hachage contre lequel `ModelBackend`
+  vérifie.
+- [Décorateurs d'accès](auth-decorators.md) — verrouillage par handler
+  `login_required` / `permission_required`, l'alternative de style décorateur à
+  `require_auth`/`require_perm`.
+- [Sessions](auth-sessions.md) — authentification par cookie pour les
+  navigateurs.

--- a/docs/fr/auth-decorators.md
+++ b/docs/fr/auth-decorators.md
@@ -1,0 +1,198 @@
+# Décorateurs d'accès
+
+Une fois qu'un utilisateur est authentifié, vous verrouillez les routes.
+**Rustango** livre la famille `@login_required` de Django sous forme de **couches**
+axum composables : attachez-en une à un routeur et les requêtes anonymes sont
+refoulées — redirigées par 302 vers votre page de connexion (flux navigateur) ou
+répondues par 401/403 (flux API) — avant même d'atteindre le handler.
+
+[![Décorateurs d'accès : login_required redirige par 302 les navigateurs anonymes vers /login?next=, la famille _or_403 renvoie 401/403 pour les API, superuser_required verrouille par rôle](img/auth-decorators.png)](img/auth-decorators.png)
+
+> **Source :** `rustango::auth_decorators` (`login_required`, `login_required_or_401`,
+> `user_passes_test`, `superuser_required`, `active_required`,
+> `permission_required` + les variantes `_or_403` ; `safe_next`, `extract_next`) —
+> derrière la fonctionnalité `tenancy` (les verrous lisent l'extracteur
+> `SessionUser`).
+>
+> **Version exécutable :** le comportement de verrouillage est couvert par le
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_decorators.rs)
+> testé — `cargo test -p auth_demo --test auth_decorators`.
+
+> **Un terme vous est inconnu ici ?** *middleware/couche*, *extracteur*,
+> *401/403* — voir le [glossaire](glossary.md).
+
+> Compagnon d'approfondissement du [guide de sécurité](security.md). Les verrous
+> lisent la session posée à la connexion — voir [Sessions](auth-sessions.md).
+
+---
+
+## Table des matières
+- [Démarrage rapide](#quick-start) · [Verrous navigateur vs API](#browser-vs-api-gates)
+- [La famille de verrous](#the-gate-family) · [Verrous par prédicat et par rôle](#predicate-and-role-gates)
+- [Verrous de permission](#permission-gates) · [L'aller-retour `?next=`](#the-next-round-trip)
+- [Remarques et limites](#notes-and-limits)
+
+---
+
+## Démarrage rapide
+
+```rust
+use rustango::auth_decorators::login_required;
+
+// Scope the gate to a sub-router (the idiomatic shape):
+let private = Router::new()
+    .route("/profile", get(profile))
+    .route("/settings", get(settings))
+    .layer(login_required("/login"));      // anonymous → 302 /login?next=...
+
+let app = Router::new()
+    .route("/", get(home))                 // public
+    .merge(private);
+```
+
+Les requêtes anonymes vers `/profile` sont redirigées vers
+`/login?next=%2Fprofile` ; une requête authentifiée passe jusqu'au handler.
+
+---
+
+## Verrous navigateur vs API
+
+Le même verrou se présente sous deux formes de réponse. Choisissez selon ce que
+l'appelant peut faire de la réponse :
+
+- **Navigateur / HTML** → les verrous de base **redirigent par 302** vers votre
+  page de connexion (un humain peut la suivre et se connecter).
+- **API JSON** → la famille `_or_403` renvoie des **codes de statut** :
+  `401 Unauthorized` pour l'anonyme, `403 Forbidden` pour l'authentifié-mais-non-autorisé
+  (un client ne peut pas afficher une page de connexion HTML, et la distinction
+  401/403 lui permet de différencier « connectez-vous » de « vous ne pouvez pas
+  faire cela »).
+
+```rust
+// Browser: redirect to /login
+let app = Router::new().route("/dashboard", get(dash)).layer(login_required("/login"));
+
+// API: 401 for anonymous, never a redirect
+let api = Router::new().route("/api/me", get(me)).layer(login_required_or_401());
+```
+
+---
+
+## La famille de verrous
+
+| Verrou (navigateur, 302) | Variante API (401/403) | Laisse passer |
+|---|---|---|
+| `login_required(url)` | `login_required_or_401()` | tout utilisateur connecté |
+| `active_required(url)` | `active_required_or_403()` | connecté **et** `active` |
+| `superuser_required(url)` | `superuser_required_or_403()` | `is_superuser && active` |
+| `user_passes_test(url, pred)` | `user_passes_test_or_403(pred)` | prédicat sur le modèle `User` |
+| `permission_required(url, codename)` | `permission_required_or_403(codename)` | détient le codename de permission |
+
+Ce sont toutes des couches tower — `.layer(...)`-les sur un routeur ou un
+sous-routeur.
+
+---
+
+## Verrous par prédicat et par rôle
+
+`user_passes_test` exécute votre closure contre le modèle `User` résolu, de sorte
+que vous pouvez verrouiller sur n'importe quel champ :
+
+```rust
+use rustango::auth_decorators::{user_passes_test, superuser_required_or_403};
+
+// Staff-only sub-router (browser):
+let staff = Router::new()
+    .route("/admin/dashboard", get(dashboard))
+    .layer(user_passes_test("/login", |u| u.is_superuser));
+
+// Superuser-only JSON API → 401 anonymous / 403 non-superuser:
+let api = Router::new()
+    .route("/api/admin/stats", get(stats))
+    .layer(superuser_required_or_403());
+```
+
+`superuser_required` / `active_required` sont des raccourcis figés pour les
+prédicats courants `is_superuser && active` / `active`, afin que les sites
+d'appel ne divergent pas silencieusement sur la question de savoir si les comptes
+désactivés comptent encore.
+
+---
+
+## Verrous de permission
+
+`permission_required` vérifie un codename de permission contre le moteur de
+permissions du locataire (les superutilisateurs le contournent automatiquement).
+Il résout en plus l'extracteur `Tenant`, si bien que les routes qui l'utilisent
+doivent être montées sous le contexte du locataire :
+
+```rust
+use rustango::auth_decorators::permission_required;
+use rustango::tenancy::permissions::ACCESS_ADMIN_CODENAME;
+
+let admin = Router::new()
+    .route("/admin", get(dashboard))
+    .layer(permission_required("/login", ACCESS_ADMIN_CODENAME));
+```
+
+---
+
+## L'aller-retour `?next=`
+
+`login_required` préserve l'URL initialement demandée dans `?next=` afin que votre
+handler de connexion puisse renvoyer l'utilisateur après authentification. **Vous
+devez assainir cette valeur** — la réinjecter dans une redirection sans contrôle
+est un trou de redirection ouverte (hameçonnage) classique. `safe_next` est le
+garde-fou :
+
+```rust
+use rustango::auth_decorators::{extract_next, safe_next};
+
+async fn login_post(Query(q): Query<HashMap<String, String>>, /* … */) -> Response {
+    // … verify credentials, set the session …
+    let dest = extract_next(&q)
+        .and_then(|n| safe_next(&n))          // rejects open redirects
+        .unwrap_or_else(|| "/".to_owned());
+    Redirect::to(&dest).into_response()
+}
+```
+
+`safe_next` n'accepte que les chemins de même origine, relatifs à la racine — il
+rejette les URL absolues, les `//host` relatifs au schéma, les variantes à
+barre oblique inverse, et leurs formes encodées en pourcentage :
+
+```rust
+assert_eq!(safe_next("/dashboard"),            Some("/dashboard".to_owned()));
+assert_eq!(safe_next("https://evil.example/x"), None);
+assert_eq!(safe_next("//evil.example/x"),       None);   // scheme-relative
+assert_eq!(safe_next("%2F%2Fevil.example/x"),   None);   // decodes to //evil
+```
+
+---
+
+## Remarques et limites
+
+- **Ces verrous lisent la session.** « Connecté » signifie que l'extracteur
+  [`SessionUser`](auth-sessions.md) a résolu un utilisateur depuis le cookie de
+  session — ils sont donc destinés à l'authentification par session/cookie.
+  L'authentification par jeton d'API ([JWT](auth-jwt-api.md), [clés
+  d'API](auth-api-keys.md)) se verrouille plutôt au niveau de la [chaîne de
+  backends](auth-backends.md), en lisant l'en-tête `Authorization`.
+- **L'ordre des couches compte.** `.layer(gate)` protège chaque route ajoutée au
+  routeur *avant* elle ; les routes ajoutées après sont publiques. Cantonner le
+  verrou à un sous-routeur dédié (la forme du démarrage rapide) évite ce piège.
+- **`permission_required` a besoin du contexte du locataire** (il interroge le
+  moteur de permissions du locataire) — montez-le sous le locataire ; une route
+  sans locataire renvoie une erreur 500.
+- Le `?next=` de la redirection est toujours encodé en pourcentage, de sorte que
+  le CRLF / fractionnement de réponse ne peut pas fuiter dans l'en-tête
+  `Location`.
+
+
+---
+
+## Voir aussi
+
+- [Backends d'authentification](auth-backends.md)
+- [Sessions](auth-sessions.md)
+- [Guide de sécurité](security.md)

--- a/docs/fr/auth-flows.md
+++ b/docs/fr/auth-flows.md
@@ -1,0 +1,192 @@
+# Flux de compte (réinitialisation, vérification, lien magique)
+
+Les flux dont chaque application a besoin en périphérie de la connexion : **réinitialisation
+du mot de passe**, **vérification de l'e-mail** et **connexion par lien magique (sans mot de passe)**.
+Tous les trois ont la même forme — envoyer par e-mail à l'utilisateur un lien inviolable et à durée
+limitée, puis agir lorsqu'il clique dessus — et **Rustango** les construit sur un même socle :
+les **URL signées**. Une URL signée est une URL normale à laquelle est ajoutée une signature HMAC,
+de sorte que le serveur peut faire confiance à ses paramètres sans rien stocker.
+
+[![Flux de compte dans Rustango : signed_url::sign ajoute une signature HMAC + une expiration ; les trois flux (réinitialisation du mot de passe, vérification de l'e-mail, lien magique) émettent un lien, l'envoient par e-mail et le vérifient au clic](img/auth-flows.png)](img/auth-flows.png)
+
+> **Un terme vous est inconnu ?** *HMAC*, *token*, *expiration* — voir le [glossaire](glossary.md).
+
+> **Source :** `rustango::signed_url` (`sign`, `verify`, `SignedUrlError`) et
+> `rustango::auth_flows` (`PasswordReset`, `EmailVerification`, `MagicLink`,
+> `confirm_password_reset_pool_into`) — derrière les fonctionnalités `signed_url` / `auth_flows`
+> (activées par défaut ; la confirmation de réinitialisation nécessite en plus `passwords` + un backend BD).
+>
+> **Version exécutable :** chaque extrait est copié depuis
+> [`auth_flows_doc.rs`](../crates/rustango/tests/auth_flows_doc.rs)
+> (`cargo test -p rustango --features sqlite --test auth_flows_doc`).
+
+## Table des matières
+
+- [Les URL signées : le socle](#signed-urls-the-substrate)
+- [Réinitialisation du mot de passe](#password-reset)
+- [Vérification de l'e-mail](#email-verification)
+- [Connexion par lien magique](#magic-link-login)
+- [Tokens à usage unique](#single-use-tokens)
+- [Ce que vous fournissez](#what-you-provide)
+- [Voir aussi](#see-also)
+
+---
+
+## Les URL signées : le socle
+
+`sign` ajoute une signature HMAC-SHA256 (et une expiration facultative) sur le chemin + la
+requête de l'URL. `verify` la recalcule : altérez un paramètre quelconque, utilisez le mauvais
+secret ou laissez-la expirer, et elle échoue.
+
+```rust
+use rustango::signed_url::{sign, verify, SignedUrlError};
+
+let url = "https://app.example.com/files/42?user_id=7";
+let signed = sign(url, secret, None);     // None = never expires
+assert!(verify(&signed, secret).is_ok());
+
+// Flip any signed byte → InvalidSignature.
+let tampered = signed.replace("user_id=7", "user_id=8");
+assert_eq!(verify(&tampered, secret), Err(SignedUrlError::InvalidSignature));
+```
+
+Ajoutez une TTL et un lien expiré est rejeté (`sign_at` / `verify_at` prennent des secondes unix
+explicites pour des tests déterministes) :
+
+```rust
+use rustango::signed_url::{sign_at, verify_at, SignedUrlError};
+
+let signed = sign_at(url, secret, Some(100));         // expires at t=100
+assert!(verify_at(&signed, secret, 50).is_ok());      // before → ok
+assert_eq!(verify_at(&signed, secret, 1000), Err(SignedUrlError::Expired));
+```
+
+La requête est triée avant la signature, l'ordre des paramètres n'a donc pas d'importance. Les
+erreurs sont `MissingSignature`, `MalformedSignature`, `InvalidSignature`, `Expired`.
+
+---
+
+## Réinitialisation du mot de passe
+
+Les assistants `auth_flows` enveloppent les URL signées avec une **étiquette de finalité** (pour
+qu'un token de réinitialisation ne puisse pas être rejoué comme un lien magique) et encodent
+l'identifiant de l'utilisateur. `PasswordReset` fournit aussi un assistant de confirmation qui
+vérifie le token et **fait tourner le hash stocké** en un seul appel.
+
+```rust
+use std::time::Duration;
+use rustango::auth_flows::{PasswordReset, confirm_password_reset_pool_into};
+
+// 1. User asks to reset → look them up → issue a link → email it.
+let url = PasswordReset::issue(
+    "https://app.example.com/auth/reset",   // your callback route
+    user_id,                                // encoded in the token
+    secret,
+    Duration::from_secs(3600),              // 1-hour TTL
+);
+mailer.send(&Email::new().to(addr).subject("Reset your password").body(&url)).await?;
+
+// 2. User clicks + submits a new password → verify + rotate the hash.
+let user_id = confirm_password_reset_pool_into(
+    &pool, &url, "a-brand-new-strong-password", secret,
+    "rustango_users", "id", "password_hash",  // table, pk col, password col
+).await?;
+```
+
+L'assistant de confirmation impose une longueur minimale, hache le nouveau mot de passe avec
+argon2id et l'écrit — en rejetant les entrées faibles, expirées, altérées ou au mauvais secret sans
+toucher à la ligne :
+
+```rust
+// valid token + strong pw → hash rotated (starts "$argon2…")
+// "short"                  → Err(WeakPassword), nothing written
+// user_id tampered         → Err(InvalidSignature), nothing written
+```
+
+> `confirm_password_reset_pool` est la forme pratique qui suppose les valeurs par défaut
+> `rustango_users` / `id` / `password_hash` ; utilisez `_into` pour pointer vers votre propre
+> table/colonnes.
+
+---
+
+## Vérification de l'e-mail
+
+`EmailVerification` encode à la fois l'identifiant de l'utilisateur **et** l'e-mail, de sorte qu'à
+la vérification vous récupérez les deux et pouvez confirmer que l'adresse correspond toujours
+(pour attraper les liens envoyés avant un changement d'e-mail). Il n'y a pas d'écriture BD intégrée
+ici — vous définissez votre propre colonne « vérifié » :
+
+```rust
+use rustango::auth_flows::EmailVerification;
+
+// On signup:
+let url = EmailVerification::issue(callback, user_id, &email, secret, Duration::from_secs(86_400));
+mailer.send(&Email::new().to(&email).subject("Confirm your email").body(&url)).await?;
+
+// On click:
+let (user_id, email) = EmailVerification::verify(&url, secret)?;
+// → if email still matches the user's current address, mark them verified
+```
+
+---
+
+## Connexion par lien magique
+
+`MagicLink` encode uniquement l'e-mail — l'utilisateur clique, vous recherchez le compte et
+émettez une [session](auth-sessions.md). Gardez une TTL courte (10–30 min) et rendez-le
+**à usage unique** (section suivante), car le lien *est* l'identifiant :
+
+```rust
+use rustango::auth_flows::MagicLink;
+
+let url = MagicLink::issue(callback, &email, secret, Duration::from_secs(900));
+mailer.send(&Email::new().to(&email).subject("Your sign-in link").body(&url)).await?;
+
+// On click:
+let email = MagicLink::verify_single_use(&url, secret, &cache).await?;
+// → look up the user by email, create a session
+```
+
+---
+
+## Tokens à usage unique
+
+`verify` seul ne vérifie que la signature + l'expiration, donc un lien divulgué est rejouable
+jusqu'à son expiration. Pour la connexion et la réinitialisation, préférez `verify_single_use(url, secret,
+&cache)` — il enregistre la signature du token dans un `Cache` et refuse une deuxième
+utilisation :
+
+```rust
+// first click  → Ok(email)
+// same link reused → Err(AuthFlowError::AlreadyUsed)
+```
+
+Adossez-le à un cache **partagé** (Redis) en production, pour qu'un token ne puisse pas être rejoué
+contre un réplica différent. La vérification échoue en mode fermé (une erreur de cache refuse plutôt
+que de risquer un rejeu).
+
+---
+
+## Ce que vous fournissez
+
+Le framework émet/vérifie les tokens et (pour la réinitialisation) écrit le hash ; votre application
+fournit le reste :
+
+- Un **secret** (une clé d'application stable ; 32 octets par convention).
+- Un **mailer** pour envoyer les liens — `rustango::email` fournit `ConsoleMailer`,
+  `SmtpMailer` et `InMemoryMailer` (pratique dans les tests).
+- Une **table utilisateur** avec les colonnes dont chaque flux a besoin (e-mail pour la recherche
+  vérification/lien magique ; une colonne de hash de mot de passe pour la réinitialisation ; une
+  colonne « vérifié » qui vous appartient).
+- Les **routes de rappel** qui reçoivent le clic et l'émission de session pour la connexion par
+  lien magique.
+
+---
+
+## Voir aussi
+
+- [Mots de passe](auth-passwords.md) — le hachage que la réinitialisation fait tourner.
+- [Sessions](auth-sessions.md) — ce que la connexion par lien magique crée en cas de succès.
+- [Signature de requête HMAC](auth-hmac.md) — la même primitive HMAC, appliquée aux requêtes API
+  plutôt qu'aux URL.
+- [Guide de sécurité](security.md) — la liste de durcissement plus large.

--- a/docs/fr/auth-hmac.md
+++ b/docs/fr/auth-hmac.md
@@ -1,0 +1,188 @@
+# Signature de requêtes HMAC
+
+La signature HMAC prouve **à la fois qui a envoyé une requête et qu'elle n'a pas
+été altérée en transit**. Le client signe chaque requête avec un secret partagé ;
+le serveur recalcule la signature et compare. Contrairement à une [clé
+d'API](auth-api-keys.md) bearer — rejouable si elle est interceptée — une
+signature HMAC couvre la méthode, le chemin, la requête, l'horodatage et le
+corps, de sorte qu'une requête altérée ou périmée est rejetée. C'est le schéma
+utilisé par AWS SigV4 et les signatures de webhooks, et **Rustango** le fournit
+sous la forme d'une seule couche tower.
+
+[![Signature HMAC dans Rustango : le client signe méthode+chemin+requête+date+hash-du-corps avec un secret partagé ; HmacAuthLayer recalcule et compare en temps constant, rejetant les requêtes altérées ou périmées](img/auth-hmac.png)](img/auth-hmac.png)
+
+> **Un terme vous est inconnu ?** *HMAC*, *secret partagé*, *rejeu*, *comparaison en temps constant* —
+> voir le [glossaire](glossary.md).
+
+> **Source :** `rustango::hmac_auth` (`HmacAuthLayer`, `KeyResolver`, `sign_now`,
+> `sign_request`) — derrière la fonctionnalité `hmac-auth` (activée par défaut ;
+> la protection contre le rejeu nécessite en plus `cache`).
+>
+> **Version exécutable :** chaque extrait est copié depuis
+> [`auth_hmac_doc.rs`](../crates/rustango/tests/auth_hmac_doc.rs)
+> (`cargo test -p rustango --test auth_hmac_doc`).
+
+## Table des matières
+
+- [Quand l'utiliser](#when-to-use-it)
+- [Ce qui est signé](#what-gets-signed)
+- [Serveur : vérifier avec la couche](#server-verify-with-the-layer)
+- [Client : signer une requête](#client-sign-a-request)
+- [Dérive d'horloge et rejeu](#clock-skew-and-replay)
+- [Limites](#limits)
+- [Voir aussi](#see-also)
+
+---
+
+## Quand l'utiliser
+
+| Utilisez… | Quand |
+|---|---|
+| [Clé d'API](auth-api-keys.md) (Bearer) | Authentification machine simple ; le risque de capture est acceptable (TLS, rotation courte). |
+| **Signature HMAC** | Vous avez besoin d'**intégrité par requête + résistance au rejeu** — webhooks, API partenaires, tout ce où une requête capturée ne doit pas être réutilisable ou modifiable. |
+| [JWT](auth-jwt.md) | Tokens utilisateur sans état et auto-descriptifs avec claims. |
+
+HMAC nécessite que les deux côtés détiennent le même secret hors bande (vous le
+provisionnez), et des horloges raisonnablement synchronisées.
+
+---
+
+## Ce qui est signé
+
+Le client construit une chaîne canonique et lui applique HMAC-SHA256 avec le
+secret partagé :
+
+```text
+<UPPERCASE-METHOD>\n
+<PATH>\n
+<SORTED-QUERY>\n
+<X-DATE>\n
+<HEX-SHA256(BODY)>
+```
+
+Deux en-têtes de requête portent le résultat :
+
+- `X-Date` — un horodatage RFC 3339 (également partie de la chaîne signée).
+- `Authorization: HMAC-SHA256 keyId=<id>,signature=<base64>`
+
+Parce que la requête est **triée** des deux côtés, `?b=2&a=1` et `?a=1&b=2`
+produisent la même signature. Parce que le corps est haché dans la chaîne,
+changer un seul octet l'invalide.
+
+---
+
+## Serveur : vérifier avec la couche
+
+`HmacAuthLayer::new` prend un **`KeyResolver`** — une closure qui mappe un
+`keyId` à son secret (`None` ⇒ clé inconnue ⇒ 401). Attachez-le comme une couche
+tower normale devant les routes que vous voulez protéger :
+
+```rust
+use std::sync::Arc;
+use rustango::hmac_auth::{HmacAuthLayer, KeyResolver};
+use tower::Layer;
+
+// Résoudre les identifiants de clé en secrets — adossez ceci à votre BD / magasin de secrets.
+let resolver: KeyResolver = Arc::new(|key_id: &str| {
+    (key_id == "k_demo").then(|| b"shared-secret-at-least-32-bytes-long!!".to_vec())
+});
+
+let layer = HmacAuthLayer::new(resolver)
+    .tolerance_secs(300);                 // fenêtre de dérive d'horloge ±5 min (défaut)
+
+let app = protected_router.layer(layer);
+```
+
+Une requête correctement signée passe ; altérez le corps, supprimez `X-Date`, ou
+signez avec une clé inconnue et c'est un `401` :
+
+```rust
+// correctement signée         → 200
+// corps modifié après signature → 401  (non-correspondance de signature)
+// en-tête X-Date manquant      → 401
+// keyId rejeté par le resolver → 401
+```
+
+> **Pas d'extracteur d'identité.** La couche vérifie la signature mais n'**injecte
+> pas** quel `keyId` a signé dans la requête — il n'y a pas d'extracteur
+> `HmacUser`. Si un handler a besoin de l'identité de l'appelant, enveloppez la
+> couche ou portez-la vous-même. Les rejets sont de simples réponses `401`/`413`,
+> pas une erreur typée que vous filtrez.
+
+---
+
+## Client : signer une requête
+
+`sign_now` signe avec l'heure actuelle et renvoie les deux valeurs d'en-tête à
+attacher (`sign_request` est la variante qui prend une date RFC 3339 explicite) :
+
+```rust
+use rustango::hmac_auth::sign_now;
+
+let body = br#"{"amount": 100}"#;
+let (x_date, authorization) =
+    sign_now("k_demo", b"shared-secret-at-least-32-bytes-long!!",
+             "POST", "/api/charge", "", body);
+
+// Attachez les deux en-têtes et envoyez le corps EXACT que vous avez signé :
+let req = http::Request::post("/api/charge")
+    .header("x-date", x_date)
+    .header("authorization", authorization)
+    .body(body.to_vec())?;
+```
+
+La signature est en base64 ; le hash du corps à l'intérieur de la chaîne
+canonique est en hexadécimal. Envoyez le corps octet pour octet tel qu'il a été
+signé — tout proxy qui le réécrit (recompression, re-sérialisation JSON) casse la
+vérification.
+
+---
+
+## Dérive d'horloge et rejeu
+
+L'horodatage `X-Date` borne le rejeu : une requête dont la date est en dehors de
+`tolerance_secs` (défaut ±300 s) est rejetée, de sorte qu'une requête capturée
+n'est réutilisable que dans cette courte fenêtre. Pour la fermer entièrement,
+attachez un **magasin de nonces** (n'importe quel `cache::Cache`) et chaque
+signature ne peut être dépensée qu'une seule fois dans la fenêtre :
+
+```rust
+use rustango::cache::InMemoryCache;
+
+let layer = HmacAuthLayer::new(resolver)
+    .tolerance_secs(120)
+    .nonce_store(Arc::new(InMemoryCache::new()));  // rejeter les rejeux
+```
+
+En production, utilisez un magasin **partagé** (Redis) pour que la protection
+tienne à travers les réplicas — un cache en processus ne garde qu'une seule
+instance. La vérification de rejeu échoue en mode ouvert sur une erreur de cache
+(disponibilité plutôt que le risque étroit dans la fenêtre).
+
+---
+
+## Limites
+
+- **±dérive symétrique, dates RFC 3339.** Les deux horloges doivent être à peu
+  près synchronisées ; le client doit envoyer le même horodatage qu'il a signé
+  (`sign_now` vous le renvoie).
+- **Bufférisation complète du corps.** Le corps est lu en mémoire pour le hacher
+  (plafond par défaut 10 MiB → `413` ; augmentez avec `.body_limit(n)` mais
+  attention à la mémoire). Les corps en streaming ne sont pas supportés.
+- **La signature est en base64 sur le fil, le hash du corps est en hexadécimal**
+  — facile à confondre lors de l'écriture d'un client dans un autre langage.
+- **Gardez la couche la plus externe** par rapport à tout ce qui mute le corps.
+
+---
+
+## Voir aussi
+
+- [Clés d'API](auth-api-keys.md) — identifiant bearer plus simple quand
+  l'intégrité/le rejeu ne sont pas une préoccupation.
+- [Backends d'authentification](auth-backends.md) — pour identifier un
+  *utilisateur* par requête (HMAC prouve l'intégrité du message, pas une identité
+  de session).
+- [Webhooks](security.md) — le pendant entrant : vérifier les signatures sur les
+  événements que vous recevez.
+- [Middleware](middleware.md) — comment les couches tower s'attachent et
+  s'ordonnent.

--- a/docs/fr/auth-jwt-api.md
+++ b/docs/fr/auth-jwt-api.md
@@ -1,0 +1,227 @@
+# API d'authentification JWT
+
+Le module [JWT autonome](auth-jwt.md) signe et vérifie un seul token. Une vraie
+API a besoin de tout le **cycle de vie** : un token d'*accès* à courte durée, un
+token de *rafraîchissement* à longue durée, la rotation au rafraîchissement, et
+la **révocation** pour la déconnexion. **Rustango** fournit tout cela sous la
+forme de `JwtLifecycle` — et un routeur clé en main qui monte pour vous
+`POST /api/auth/login`, `/refresh`, `/logout`, et `GET /me`.
+
+[![API d'authentification JWT : login émet une paire access+refresh, refresh effectue une rotation et met en liste noire l'ancien token, logout révoque via un magasin de JTI](img/auth-jwt-api.png)](img/auth-jwt-api.png)
+
+> **Source :** `rustango::tenancy::jwt_lifecycle` (`JwtLifecycle`, `JwtTokenPair`,
+> `JwtClaims`) et `rustango::tenancy::auth_routes` (`jwt_router`, `Config`) +
+> `rustango::jti_store` (`JtiStore`, `InMemoryJtiStore`) — derrière `jwt` +
+> `tenancy`.
+>
+> **Version exécutable :** le moteur de tokens est couvert par le test
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs) —
+> `cargo test -p auth_demo --test auth_jwt_api`. Les endpoints HTTP sont
+> cloisonnés par tenant et éprouvés de bout en bout par le propre
+> `crates/rustango/tests/tenant_auth_live.rs` du framework.
+
+> **Un terme vous est inconnu ?** *token d'accès/de rafraîchissement*,
+> *rotation*, *révocation* — voir le [glossaire](glossary.md).
+
+> Complément approfondi de la section « Émettre et rafraîchir des JWT » du
+> [Guide de sécurité](security.md). Pour un token unique géré manuellement, voir
+> plutôt [JWT (autonome)](auth-jwt.md).
+
+---
+
+## Table des matières
+- [Le routeur intégré](#the-built-in-router) · [Le câblage](#wiring-it-up)
+- [Le moteur de tokens](#the-token-engine-jwtlifecycle) · [Rafraîchissement et rotation](#refresh-and-rotation)
+- [Révocation et le magasin de JTI](#revocation-and-the-jti-store) · [Claims personnalisés](#custom-claims)
+- [Notes et limites](#notes-and-limits)
+
+---
+
+## Le routeur intégré
+
+`jwt_router` monte les quatre endpoints standard sur la table `rustango_users`
+propre à chaque tenant — les ~50 lignes de boilerplate de login que tout projet
+réécrit sinon :
+
+| Méthode | Chemin | Corps / Auth | Renvoie |
+|---|---|---|---|
+| POST | `/api/auth/login` | `{username, password}` | `{access, refresh, user}` |
+| POST | `/api/auth/refresh` | `{refresh}` | `{access, refresh}` |
+| POST | `/api/auth/logout` | `Authorization: Bearer <access>` | `204` (révoque le JTI) |
+| GET | `/api/auth/me` | `Authorization: Bearer <access>` | `{user_id, username, is_superuser}` |
+
+Login vérifie le mot de passe avec [argon2id](auth-passwords.md), puis émet une
+paire. Les chemins, TTL et la clé de signature sont configurables via `Config`.
+
+## Le câblage
+
+```rust
+use rustango::tenancy::auth_routes::{jwt_router, Config};
+
+rustango::manage::Cli::new()
+    .tenancy()
+    .api(my_app::urls::api()
+        .merge(jwt_router(Config::default())))   // monte /api/auth/*
+    .run()
+    .await
+```
+
+`Config::default()` signe avec `RUSTANGO_SESSION_SECRET` (la même clé que le
+cookie de session admin) et utilise des TTL de 15 min pour l'accès / 7 jours pour
+le rafraîchissement. Redéfinissez `prefix`, `access_ttl_secs`,
+`refresh_ttl_secs`, ou `session_secret` selon vos besoins. Les endpoints
+s'exécutent dans le contexte du tenant, montez-les donc dans une application
+tenancy.
+
+```sh
+# Login → access + refresh
+curl -sX POST localhost:8080/api/auth/login \
+  -H 'content-type: application/json' \
+  -d '{"username":"alice","password":"hunter2hunter"}'
+
+# Appeler un endpoint protégé
+curl localhost:8080/api/auth/me -H "Authorization: Bearer $ACCESS"
+```
+
+---
+
+## Le moteur de tokens (`JwtLifecycle`)
+
+Sous le routeur se trouve `JwtLifecycle` — utilisable directement si vous voulez
+le cycle de vie sans la forme HTTP intégrée :
+
+```rust
+use rustango::tenancy::jwt_lifecycle::JwtLifecycle;
+
+let jwt = JwtLifecycle::new(secret_32_bytes);
+
+// Login : émettre la paire.
+let pair = jwt.issue_pair(user_id);
+// → pair.access  (TTL court, à envoyer dans l'en-tête Authorization)
+// → pair.refresh (TTL long, à stocker dans un cookie HttpOnly / stockage sécurisé)
+
+// Requête authentifiée : vérifier le token d'accès.
+match jwt.verify_access(&access) {
+    Some(claims) => { /* claims.sub est l'id utilisateur */ }
+    None => { /* 401 : invalide, expiré, révoqué, ou mauvais type */ }
+}
+```
+
+Les tokens d'accès et de rafraîchissement ne sont **pas interchangeables** —
+`verify_access` rejette un token de rafraîchissement et vice versa, de sorte
+qu'un token d'accès à courte durée volé ne peut pas servir à en forger de
+nouveaux :
+
+```rust
+let pair = jwt.issue_pair(42);
+assert!(jwt.verify_refresh(&pair.access).is_none());
+assert!(jwt.verify_access(&pair.refresh).is_none());
+```
+
+---
+
+## Rafraîchissement et rotation
+
+`refresh` échange un token de rafraîchissement valide contre une **nouvelle
+paire** et met en liste noire le JTI de l'ancien token de rafraîchissement —
+expiration glissante avec des tokens de rafraîchissement à usage unique (le
+rejeu de l'ancien est refusé) :
+
+```rust
+let pair = jwt.issue_pair(7);
+let rotated = jwt.refresh(&pair.refresh).expect("refresh ok");
+assert_ne!(pair.access, rotated.access);
+assert!(jwt.refresh(&pair.refresh).is_none());   // l'ancien refresh est maintenant mort
+```
+
+Par défaut, `refresh` **préserve** les claims personnalisés du token. Si les
+permissions ont pu changer (rôle révoqué, portée réduite), utilisez
+`refresh_with(token, new_claims)` pour substituer un payload frais tout en
+mettant quand même en liste noire l'ancien JTI de rafraîchissement.
+
+---
+
+## Révocation et le magasin de JTI
+
+Chaque token porte un `jti` unique. `revoke` l'ajoute à une liste noire de sorte
+que les appels `verify_*` suivants échouent jusqu'à ce que le token ait de toute
+façon expiré — c'est ce qu'appelle `POST /api/auth/logout` :
+
+```rust
+let pair = jwt.issue_pair(1);
+assert!(jwt.revoke(&pair.access));
+assert!(jwt.verify_access(&pair.access).is_none());
+```
+
+La liste noire réside dans un `JtiStore` interchangeable. Le `InMemoryJtiStore`
+par défaut est **mono-processus et perd les révocations au redémarrage** —
+convient pour une seule instance. Tout déploiement multi-réplica DOIT installer
+un magasin partagé et durable (Redis / BD) pour qu'une déconnexion sur une
+réplica soit honorée par toutes :
+
+```rust
+use rustango::jti_store::{InMemoryJtiStore, JtiStore};
+use std::sync::Arc;
+
+let shared: Arc<dyn JtiStore> = Arc::new(InMemoryJtiStore::new()); // à remplacer par Redis en prod
+let a = JwtLifecycle::new(secret.clone()).with_jti_store(Arc::clone(&shared));
+let b = JwtLifecycle::new(secret).with_jti_store(Arc::clone(&shared));
+
+let pair = a.issue_pair(5);
+a.revoke(&pair.access);
+assert!(b.verify_access(&pair.access).is_none());   // B voit la révocation de A
+```
+
+> Sans magasin partagé, `/logout` est au mieux « best-effort » : un token révoqué
+> peut encore être accepté sur une autre réplica jusqu'à son expiration
+> naturelle. C'est le paramètre de production le plus important pour
+> l'authentification JWT.
+
+---
+
+## Claims personnalisés
+
+Intégrez `roles` / `tenant` / `scope` directement dans le token pour que la
+vérification ne nécessite aucune consultation de BD. Les noms réservés (`sub`,
+`exp`, `jti`, `typ`) sont rejetés :
+
+```rust
+let custom = serde_json::json!({ "roles": ["admin"], "tenant": "acme" })
+    .as_object().unwrap().clone();
+let pair = jwt.issue_pair_with(99, custom)?;
+
+let claims = jwt.verify_access(&pair.access).unwrap();
+let roles: Vec<String> = claims.get_custom("roles").unwrap();   // ["admin"]
+```
+
+Les claims personnalisés survivent à `refresh` (reportés sur la nouvelle paire)
+sauf si vous utilisez `refresh_with`.
+
+---
+
+## Notes et limites
+
+- **Sessions vs JWT vs ceci :** un [JWT](auth-jwt.md) simple ne peut pas être
+  révoqué ; une [Session](auth-sessions.md) est révocable mais nécessite une
+  consultation du magasin à chaque requête ; `JwtLifecycle` est la voie
+  intermédiaire — vérification sans état, plus une liste de blocage JTI pour les
+  révocations dont vous avez réellement besoin (déconnexion, rotation).
+- **Les endpoints HTTP sont cloisonnés par tenant.** `jwt_router` résout les
+  utilisateurs via le contexte du tenant + `rustango_users` ; montez-le dans une
+  application `.tenancy()`. Le moteur de tokens (`JwtLifecycle`) lui-même n'a pas
+  cette exigence.
+- **Associez ceci** au `JwtBackend` de la [chaîne de backends
+  d'authentification](auth-backends.md) pour authentifier des routes arbitraires
+  à partir de l'en-tête `Authorization: Bearer`.
+- **Signature HS256**, plancher de clé de 32 octets — même algorithme et mêmes
+  contraintes que le [JWT autonome](auth-jwt.md#security-model).
+
+
+---
+
+## Voir aussi
+
+- [JWT (autonome)](auth-jwt.md)
+- [Backends d'authentification](auth-backends.md)
+- [Sessions](auth-sessions.md)
+- [Guide de sécurité](security.md)

--- a/docs/fr/auth-jwt.md
+++ b/docs/fr/auth-jwt.md
@@ -1,0 +1,213 @@
+# JWT (autonome)
+
+Un JSON Web Token est un identifiant **sans état** : une chaîne signée et
+autonome que le client envoie à chaque requête, et que votre serveur vérifie
+avec un secret — sans consultation de base de données ni de cache à chaque
+requête. Le module `rustango::jwt` de **Rustango** est la brique minimale :
+`encode` pour signer des claims, `decode` pour les vérifier et les relire,
+HS256 en interne.
+
+[![JWT autonome dans Rustango : les Claims portent des champs sub/exp/personnalisés, encode() signe avec un secret partagé, decode() vérifie la signature + l'expiration](img/auth-jwt.png)](img/auth-jwt.png)
+
+> **Source :** `rustango::jwt` (`Claims`, `encode`, `decode`, `decode_at`,
+> `decode_unverified`, `JwtError`) — derrière la fonctionnalité `jwt` (activée
+> par défaut). Pour une **API** access+refresh clé en main avec révocation, voir
+> [API d'authentification JWT](auth-jwt-api.md).
+>
+> **Version exécutable :** les extraits sont copiés depuis le test
+> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt.rs) —
+> `cargo test -p auth_demo --test auth_jwt`.
+
+> **Un terme vous est inconnu ?** *JWT*, *claims*, *sans état*, *secret* — voir le
+> [glossaire](glossary.md).
+
+> Complément approfondi de la section « Émettre et rafraîchir des JWT » du
+> [Guide de sécurité](security.md).
+
+---
+
+## Table des matières
+- [Démarrage rapide](#quick-start) · [Quand l'utiliser](#when-to-use-standalone-jwt)
+- [Construire des claims](#building-claims) · [Vérifier](#verifying-a-token)
+- [Modèle de sécurité](#security-model) — à lire · [Inspecter sans faire confiance](#inspecting-without-verifying)
+- [Notes et limites](#notes-and-limits)
+
+---
+
+## Démarrage rapide
+
+```rust
+use rustango::jwt::{Claims, encode, decode};
+use std::time::Duration;
+
+// HS256 est symétrique — le même secret signe et vérifie. Doit faire >= 32 octets.
+let secret = b"a-shared-signing-secret-at-least-32-bytes!!";
+
+let mut claims = Claims::new("user-42").ttl(Duration::from_secs(900));
+claims.set("roles", vec!["editor", "author"]);
+
+let token = encode(&claims, secret)?;        // header.payload.signature
+
+let verified = decode(&token, secret)?;       // vérifie la signature + exp/nbf
+assert_eq!(verified.subject(), Some("user-42"));
+let roles: Vec<String> = verified.get("roles").unwrap();
+```
+
+---
+
+## Quand utiliser un JWT autonome
+
+Optez pour `rustango::jwt` quand vous voulez un simple token signé et que vous
+gérerez le cycle de vie vous-même :
+
+- **Liens magiques / tokens à usage unique** — quelques claims (id utilisateur,
+  finalité, `exp` court).
+  Voir [Liens magiques et flux d'authentification](auth-flows.md).
+- **Tokens bearer de service à service** (le pendant JWT de la [signature de
+  requêtes HMAC](auth-hmac.md) — HMAC pour les requêtes canoniques façon AWS,
+  JWT pour un bearer sans état).
+- **Tokens SSO** que vous remettez à un tiers.
+
+Si vous voulez une API clé en main **login → access + refresh → refresh →
+logout** avec révocation de tokens, ne la construisez pas là-dessus — utilisez
+l'[API d'authentification JWT](auth-jwt-api.md), qui enveloppe ce module avec
+rotation + un magasin de révocation. Et si vous devez déconnecter un utilisateur
+de force *maintenant*, préférez une [Session](auth-sessions.md) révocable : un
+JWT simple reste valide jusqu'à son expiration.
+
+---
+
+## Construire des claims
+
+`Claims` enveloppe un objet JSON, de sorte que les claims standard et vos propres
+champs d'extension coexistent :
+
+```rust
+let mut claims = Claims::new("user-42")     // définit `sub` + `iat=now`
+    .ttl(Duration::from_secs(3600))         // définit `iat`=now et `exp`=now+ttl
+    .issuer("api.example.com")              // `iss`
+    .audience("web-client")                 // `aud`
+    .jti("unique-token-id");                // `jti` (pour votre propre liste de blocage)
+claims.set("role", "admin");                // toute valeur Serialize
+claims.set("org_id", 7_i64);
+```
+
+| Builder / setter | Claim |
+|---|---|
+| `Claims::new(sub)` | `sub` + `iat` |
+| `Claims::empty()` | aucune (contrôle total) |
+| `.ttl(Duration)` | `iat` (now) + `exp` (now+ttl) |
+| `.expires_at(secs)` / `.not_before(secs)` | `exp` / `nbf` absolus |
+| `.issuer(s)` / `.audience(s)` / `.jti(s)` | `iss` / `aud` / `jti` |
+| `.set(name, value)` | tout claim personnalisé |
+
+Relisez-les avec `.subject()` et `.get::<T>(name)` (renvoie `None` pour un claim
+absent ou du mauvais type).
+
+---
+
+## Vérifier un token
+
+```rust
+use rustango::jwt::{decode, JwtError};
+
+match decode(&token, secret) {
+    Ok(claims) => { /* faire confiance à claims.subject() etc. */ }
+    Err(JwtError::Expired(_))      => { /* 401 — token périmé */ }
+    Err(JwtError::BadSignature)    => { /* 401 — falsifié ou mauvaise clé */ }
+    Err(JwtError::NotYetValid(_))  => { /* nbf dans le futur */ }
+    Err(_)                         => { /* malformé / alg non supporté */ }
+}
+```
+
+`decode` vérifie la **signature**, puis `exp` et `nbf`. Pour tester le
+comportement de la fenêtre temporelle (ou ajouter une tolérance de dérive),
+`decode_at(token, secret, now)` vous permet de fixer la seconde « courante » :
+
+```rust
+let token = encode(&Claims::new("x").expires_at(1000), secret)?;
+assert!(decode_at(&token, secret, 500).is_ok());                     // avant exp
+assert!(matches!(decode_at(&token, secret, 2000), Err(JwtError::Expired(_)))); // après
+```
+
+---
+
+## Modèle de sécurité
+
+C'est du code de frontière d'authentification — trois choses à savoir
+impérativement :
+
+1. **`decode` ne valide PAS `iss` / `aud`.** Une signature valide prouve que le
+   token a été forgé avec votre secret, pas qu'il a été forgé *pour votre
+   service*. Si vous définissez `iss`/`aud` à l'émission, **vérifiez-les
+   vous-même** sur les claims décodés :
+
+   ```rust
+   let c = decode(&token, secret)?;
+   if c.get::<String>("aud").as_deref() != Some("web-client") {
+       return Err("wrong audience");
+   }
+   ```
+
+2. **Le secret doit faire ≥ 32 octets** — `encode` refuse de signer avec une clé
+   plus courte (une clé courte est devinable, et une clé HMAC devinable signifie
+   des tokens falsifiables). HS256 est symétrique : quiconque possède le secret
+   de vérification peut aussi *forger* des tokens, il reste donc à l'intérieur de
+   votre frontière de confiance (service unique / backend partagé). L'émission de
+   tokens inter-organisations demande du RS256/ES256 asymétrique, que ce module
+   ne fournit délibérément pas.
+
+3. **`alg=none` et la falsification sont rejetés.** `decode` fige HS256 (la
+   falsification classique « alg: none » est refusée), et toute modification de
+   l'en-tête ou du payload casse la signature — vérifiée par une comparaison à
+   temps constant.
+
+Il n'y a **aucune tolérance de dérive d'horloge** : `exp`/`nbf` se comparent à la
+seconde courante exacte. Si les horloges de l'émetteur et du vérificateur
+dérivent, soustrayez quelques secondes via `decode_at`.
+
+---
+
+## Inspecter sans vérifier
+
+`decode_unverified` lit le payload **sans** vérifier la signature ni
+l'expiration — utile uniquement pour jeter un œil à un claim (p. ex. un id de
+clé) afin de choisir le bon secret, puis d'appeler `decode` pour de vrai.
+
+```rust
+let peek = rustango::jwt::decode_unverified(&token)?;   // PAS de confiance
+let kid = peek.get::<String>("kid");
+// ... rechercher le secret pour `kid`, puis vérifier correctement :
+let claims = decode(&token, &resolved_secret)?;
+```
+
+**N'autorisez jamais sur la sortie de `decode_unverified`** — elle ne porte
+aucune garantie d'intégrité.
+
+---
+
+## Notes et limites
+
+- **HS256 uniquement** — symétrique, un seul secret partagé. Pas de RS256/ES256
+  (garde l'arbre de dépendances toujours actif réduit ; la plupart des
+  applications mono-service utilisent HS256 de toute façon).
+- **Sans état = non révocable.** Un JWT simple est valide jusqu'à `exp`. Si vous
+  avez besoin de « déconnexion immédiate » / de révocation par token, utilisez
+  l'[API d'authentification JWT](auth-jwt-api.md) (liste de blocage JTI) ou une
+  [Session](auth-sessions.md) (supprimez l'entrée côté serveur).
+- **Gardez `exp` court** pour les access tokens (quelques minutes). Les JWT
+  simples à longue durée de vie sont un risque précisément parce qu'ils ne
+  peuvent pas être révoqués.
+- Associez l'émission aux [Mots de passe](auth-passwords.md) (vérifier, puis
+  émettre) et protégez les routes d'API via le `JwtBackend` de la [chaîne de
+  backends d'authentification](auth-backends.md).
+
+
+---
+
+## Voir aussi
+
+- [API d'authentification JWT](auth-jwt-api.md)
+- [Backends d'authentification](auth-backends.md)
+- [Clés d'API](auth-api-keys.md)
+- [Sessions](auth-sessions.md)

--- a/docs/fr/auth-passwords.md
+++ b/docs/fr/auth-passwords.md
@@ -1,0 +1,230 @@
+# Mots de passe
+
+Stocker un mot de passe, c'est stocker quelque chose qu'un attaquant ne peut pas
+inverser même avec toute votre base de données en main. **Rustango** vous offre
+cela en deux appels — `hash` à l'entrée, `verify` à la sortie — reposant sur
+**argon2id**, le lauréat *memory-hard* de la Password Hashing Competition et le
+premier choix actuel de l'OWASP. Vous ne stockez, ne journalisez et ne comparez
+jamais le texte en clair.
+
+[![Les mots de passe dans Rustango : hash() produit une chaîne PHC argon2id salée, verify() vérifie une tentative par rapport à celle-ci, et verify_dummy() égalise le temps de connexion](img/auth-passwords.png)](img/auth-passwords.png)
+
+> **Source :** `rustango::passwords` (`hash`, `verify`, `verify_dummy`,
+> `strength_score`, `StrengthIssue`) — derrière la fonctionnalité `passwords`
+> (activée par défaut). Pour les utilitaires de mot de passe utilisateur
+> intégrés à la tenancy, voir `rustango::tenancy::password`.
+>
+> **Version exécutable :** chaque extrait ci-dessous est copié depuis l'exemple
+> testé [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_passwords.rs)
+> — `cargo test -p auth_demo --test auth_passwords`.
+
+> **Un terme vous est inconnu ici ?** *hash*, *salt*, *argon2id*, *chaîne PHC* —
+> voir le [glossaire](glossary.md).
+
+> Ceci est l'approfondissement de la section « Hachage et vérification des mots
+> de passe » du [guide de sécurité](security.md).
+
+---
+
+## Table des matières
+- [Démarrage rapide](#quick-start) · [Pourquoi argon2id](#why-argon2id)
+- [Hachage à l'inscription](#hashing-on-signup) · [Vérification à la connexion](#verifying-on-login)
+- [Connexions à temps constant](#timing-safe-logins-account-enumeration) · [Contrôles de robustesse](#strength-checks)
+- [Où vit le hash](#where-the-hash-lives) · [Remarques et limites](#notes-and-limits)
+
+---
+
+## Démarrage rapide
+
+```rust
+use rustango::passwords::{hash, verify};
+
+// Signup — store the returned PHC string, never the plaintext.
+let stored: String = hash("CorrectHorseBatteryStaple!42")?;
+
+// Login — check an attempt against the stored hash.
+if verify("CorrectHorseBatteryStaple!42", &stored)? {
+    // credentials good
+}
+```
+
+`hash` renvoie une [chaîne PHC](https://github.com/P-H-C/phc-string-format) — une
+ligne auto-descriptive qui embarque l'algorithme, ses paramètres de coût, le sel
+aléatoire et l'empreinte :
+
+```text
+$argon2id$v=19$m=19456,t=2,p=1$<base64 salt>$<base64 hash>
+```
+
+Comme le sel et les paramètres voyagent *à l'intérieur* de la chaîne, `verify` n'a
+besoin que de la valeur stockée et de la tentative — il n'y a pas de colonne de
+sel séparée à gérer.
+
+---
+
+## Pourquoi argon2id
+
+`hash` utilise **argon2id** avec les valeurs par défaut recommandées par l'OWASP
+(m=19 Mio, t=2, p=1). argon2id est *memory-hard* : chaque tentative coûte de la
+RAM réelle, ce qui est précisément ce qui émousse les fermes de GPU/ASIC rendant
+les hachages rapides (MD5, SHA-256, et même bcrypt à faible coût) vulnérables au
+force brute. Deux propriétés comptent pour l'exactitude :
+
+- **Le salage est automatique et propre à chaque hash.** Hacher deux fois le même
+  mot de passe produit deux chaînes PHC différentes, si bien que des mots de
+  passe identiques n'entrent pas en collision dans votre table et que les
+  attaques par tables arc-en-ciel précalculées ne s'appliquent pas.
+
+  ```rust
+  let a = hash("same-password-12345")?;
+  let b = hash("same-password-12345")?;
+  assert_ne!(a, b);                 // different random salt each time
+  assert!(verify("same-password-12345", &a)?);
+  assert!(verify("same-password-12345", &b)?);
+  ```
+
+- **La vérification est à temps constant** dans la comparaison de l'empreinte (le
+  `PasswordVerifier` propre à argon2), de sorte qu'une fuite de temps octet par
+  octet ne peut pas révéler quelle part d'une tentative était correcte.
+
+---
+
+## Hachage à l'inscription
+
+```rust
+use rustango::passwords::{hash, strength_score};
+
+fn create_user(username: &str, plaintext: &str) -> Result<String, String> {
+    // Optional: nudge users away from weak choices (see below).
+    let issues = strength_score(plaintext);
+    if !issues.is_empty() {
+        return Err(format!("password too weak: {issues:?}"));
+    }
+    // Store the PHC string on the user row (e.g. auth_users.password_hash).
+    hash(plaintext).map_err(|e| e.to_string())
+}
+```
+
+---
+
+## Vérification à la connexion
+
+```rust
+use rustango::passwords::verify;
+
+// `stored` is the PHC string you saved at signup.
+let ok = verify(attempt, &stored)?;
+```
+
+`verify` renvoie :
+- `Ok(true)` — la tentative correspond.
+- `Ok(false)` — elle ne correspond pas.
+- `Err(PasswordError::Verify)` — `stored` n'était pas une chaîne PHC valide (une
+  colonne corrompue ou tronquée) ; traitez-la comme un échec de connexion, pas
+  comme une erreur 500.
+
+---
+
+## Connexions à temps constant (énumération de comptes)
+
+Si votre connexion n'exécute le coûteux `verify` **que** lorsque le nom
+d'utilisateur existe, un nom d'utilisateur inconnu renvoie une réponse
+sensiblement plus rapide qu'un vrai — et cet écart de temps permet à un attaquant
+d'énumérer les comptes valides. `verify_dummy` le comble : appelez-le sur la
+branche utilisateur-introuvable (et compte-inactif) pour que chaque connexion
+consacre le travail d'un `verify` argon2, quoi qu'il arrive.
+
+```rust
+use rustango::passwords::{verify, verify_dummy};
+
+let row = users::find_by_username(username).await?;
+let authenticated = match row {
+    Some(u) if u.is_active => verify(attempt, &u.password_hash)?,
+    _ => {
+        verify_dummy(attempt); // burn the same work, then fail
+        false
+    }
+};
+```
+
+---
+
+## Contrôles de robustesse
+
+`strength_score` renvoie un `Vec<StrengthIssue>` — vide signifie « suffisamment
+bon ». C'est une heuristique intentionnellement légère destinée à *encourager*
+les utilisateurs, et non un verrou de politique stricte ; associez-la à une
+vérification par liste de fuites (HIBP / pwned-passwords) pour les déploiements
+sérieux.
+
+```rust
+use rustango::passwords::{strength_score, StrengthIssue};
+
+assert!(strength_score("Tr0ub4dor&3-CorrectBattery").is_empty());
+assert!(strength_score("password123").contains(&StrengthIssue::KnownWeak));
+assert!(strength_score("short").contains(&StrengthIssue::TooShort));
+```
+
+| `StrengthIssue` | Déclenché quand |
+|---|---|
+| `TooShort` | moins de 12 caractères |
+| `NoDigitsOrSymbols` | lettres uniquement — aucun chiffre ni symbole |
+| `NoVariety` | uniquement des lettres minuscules |
+| `KnownWeak` | correspond à la petite liste intégrée de mots de passe faibles (insensible à la casse) |
+
+---
+
+## Où vit le hash
+
+La chaîne PHC n'est qu'une colonne `String` sur le modèle de compte que vous
+possédez. Dans l'exemple [`auth_demo`](../crates/rustango/examples/auth_demo/src/models.rs) :
+
+```rust
+#[derive(Model, Clone, Debug)]
+#[rustango(table = "auth_users", display = "username")]
+pub struct User {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 150, unique)]
+    pub username: String,
+    #[rustango(max_length = 254)]
+    pub email: String,
+    #[rustango(max_length = 255)]      // PHC strings are ~95 chars at these params
+    pub password_hash: String,
+    pub is_active: bool,
+    pub is_superuser: bool,
+}
+```
+
+Une fois l'utilisateur authentifié, passez le relais à une
+[session](auth-sessions.md) (pour les applications navigateur) ou émettez un
+[JWT](auth-jwt.md) (pour les API).
+
+---
+
+## Remarques et limites
+
+- **Ne jamais** stocker, journaliser ni comparer avec `==` le texte en clair.
+  `hash` → stocker ; `verify` → vérifier. C'est tout le contrat.
+- **Les paramètres de coût sont les valeurs par défaut de l'OWASP**, intégrées.
+  Ils constituent un plancher raisonnable ; les augmenter plus tard est sûr — les
+  anciens hachages se vérifient toujours (leurs paramètres vivent dans la chaîne
+  PHC), et vous pouvez re-hacher à la prochaine connexion réussie pour les mettre
+  à niveau.
+- `strength_score` est une heuristique, pas un moteur de politique — elle ne
+  détectera pas `Summer2024!`. Superposez une recherche par liste de fuites pour
+  une vraie application de la robustesse.
+- Pour les applications multi-locataires utilisant le magasin d'utilisateurs du
+  framework, préférez `rustango::tenancy::password` (même argon2id, intégré au
+  modèle d'utilisateur du locataire). Ce module est la version autonome pour les
+  applications qui possèdent leur propre table User.
+
+
+---
+
+## Voir aussi
+
+- [Sessions](auth-sessions.md)
+- [Flux de compte](auth-flows.md)
+- [Backends d'authentification](auth-backends.md)
+- [Guide de sécurité](security.md)

--- a/docs/fr/auth-sessions.md
+++ b/docs/fr/auth-sessions.md
@@ -1,0 +1,203 @@
+# Sessions
+
+Une session maintient un utilisateur connecté à travers les requêtes en
+remettant au navigateur un **identifiant opaque** dans un cookie et en conservant
+tout le reste côté serveur. Le `SessionStore` de **Rustango** place cet état dans
+un cache (Redis en production, en mémoire pour les tests), de sorte que le cookie
+ne transporte aucun secret et qu'une session peut être **révoquée
+instantanément** — supprimez l'entrée et chaque réplique voit la déconnexion à la
+requête suivante.
+
+[![Les sessions dans Rustango : le cookie ne contient qu'un identifiant opaque, le SessionStore conserve les données dans Redis, et destroy() les révoque partout](img/auth-sessions.png)](img/auth-sessions.png)
+
+> **Source :** `rustango::sessions` (`Session`, `SessionStore`) +
+> `rustango::cache` (`BoxedCache`, `InMemoryCache`) — derrière la fonctionnalité
+> `sessions` (activée par défaut ; tire `cache`). Pour un magasin adossé à Redis
+> en production, ajoutez la fonctionnalité `cache-redis` (désactivée par défaut)
+> pour obtenir `RedisCache`.
+>
+> **Version exécutable :** les extraits ci-dessous sont copiés depuis l'exemple
+> testé [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_sessions.rs)
+> — `cargo test -p auth_demo --test auth_sessions`.
+
+> **Un terme vous est inconnu ici ?** *session*, *identifiant opaque*, *cookie*,
+> *cache* — voir le [glossaire](glossary.md).
+
+> Compagnon d'approfondissement du [guide de sécurité](security.md). Le
+> verrouillage des routes derrière une session connectée est traité dans
+> [Décorateurs d'authentification](auth-decorators.md) ; pour des jetons d'API
+> sans état à la place, voir [JWT](auth-jwt.md).
+
+---
+
+## Table des matières
+- [Démarrage rapide](#quick-start) · [Sessions vs JWT](#sessions-vs-jwt)
+- [Le sac de session](#the-session-bag) · [Le cookie](#the-cookie)
+- [Choisir un backend](#picking-a-backend) · [Expiration et renouvellement glissant](#expiry-and-sliding-renewal)
+- [Modification en place](#updating-a-session-in-place) · [Remarques et limites](#notes-and-limits)
+
+---
+
+## Démarrage rapide
+
+```rust
+use rustango::sessions::{Session, SessionStore};
+use rustango::cache::{BoxedCache, RedisCache};
+use std::sync::Arc;
+
+let store = SessionStore::new(Arc::new(RedisCache::new("redis://localhost/0")?) as BoxedCache);
+
+// After the password check (see auth-passwords.md): stash who the user is,
+// save → an opaque id, and set that id as the cookie.
+let mut session = Session::new();
+session.set("user_id", user.id);
+let sid = store.save(&session).await?;
+// Set-Cookie: rustango_session={sid}; HttpOnly; SameSite=Lax; Secure; Path=/
+
+// On later requests: read the id from the cookie, load the session back.
+let session = store.load(&sid).await?.unwrap_or_default();
+let user_id: Option<i64> = session.get("user_id");
+
+// Logout: drop the server-side entry — the cookie is now meaningless.
+store.destroy(&sid).await?;
+```
+
+L'identifiant représente 192 bits d'aléa OS-CSPRNG, encodés en base64url sur 32
+caractères — bien au-dessus du plancher de 128 bits pour les jetons de session,
+et impossible à deviner.
+
+---
+
+## Sessions vs JWT
+
+Les deux répondent à « qui est cette requête ? », avec des compromis opposés :
+
+| | Session | [JWT](auth-jwt.md) |
+|---|---|---|
+| État | côté serveur (recherche dans le cache par requête) | sans état (jeton auto-contenu) |
+| Révocation | **instantanée** — `destroy()` l'entrée | difficile — valide jusqu'à expiration (nécessite une liste de blocage) |
+| Idéal pour | applications navigateur, « déconnecter cet utilisateur MAINTENANT » | API, service à service, pas de magasin partagé |
+
+Optez pour les sessions lorsque vous devez déconnecter de force quelqu'un
+(changement de mot de passe, « déconnecter tous les appareils », un compte banni).
+Optez pour le JWT lorsque vous voulez zéro recherche par requête et que vous
+n'avez pas de cache partagé.
+
+---
+
+## Le sac de session
+
+`Session` est un sac typé clé→valeur doté d'un bit d'altération (*dirty bit*), de
+sorte que le magasin peut sauter une écriture lorsque rien n'a changé :
+
+```rust
+let mut s = Session::new();
+s.set("user_id", 42_i64);            // serialize any Serialize value
+s.set("role", "editor");
+let uid: Option<i64> = s.get("user_id");   // None if absent or wrong type
+s.remove("role");
+s.clear();                            // wipe everything (e.g. on logout)
+```
+
+`get` est **tolérant aux erreurs** : une clé manquante *ou* une valeur qui ne se
+désérialise pas dans le type demandé renvoie `None` plutôt que de paniquer — de
+sorte qu'un changement de schéma ne provoque jamais d'erreur 500 sur une requête.
+
+---
+
+## Le cookie
+
+Le cookie ne contient que `sid`. Configurez-le avec les attributs de sécurité
+dont un cookie de session a besoin :
+
+- **`HttpOnly`** — JavaScript ne peut pas le lire (émousse le vol de jeton par
+  XSS).
+- **`SameSite=Lax`** — non envoyé sur les sous-requêtes intersites (défense CSRF ;
+  associez-le aux [jetons CSRF](security.md#protecting-against-csrf) pour les
+  envois de formulaire).
+- **`Secure`** — HTTPS uniquement (à retirer seulement pour le développement HTTP
+  local).
+- **`Path=/`** — visible pour toute l'application.
+
+Rien de sensible n'est dans le cookie ; un cookie divulgué est donc exactement
+aussi puissant que la session qu'il désigne — et vous pouvez révoquer celle-ci
+côté serveur à tout moment.
+
+---
+
+## Choisir un backend
+
+`SessionStore::new` accepte n'importe quel `BoxedCache` :
+
+- **`RedisCache`** — production. Partagé entre les répliques, de sorte qu'une
+  connexion sur une instance et une déconnexion sur une autre sont toutes deux
+  visibles partout.
+- **`InMemoryCache`** — processus unique / tests. Rapide, sans dépendances, mais
+  les sessions ne survivent pas à un redémarrage et ne sont pas partagées entre
+  les répliques.
+
+```rust
+use rustango::cache::{BoxedCache, InMemoryCache};
+use std::sync::Arc;
+
+// Tests / single-process:
+let store = SessionStore::new(Arc::new(InMemoryCache::new()) as BoxedCache);
+```
+
+---
+
+## Expiration et renouvellement glissant
+
+Les sessions ont par défaut une TTL de **2 semaines**. Remplacez-la par magasin,
+et appelez `touch` à chaque requête authentifiée pour une expiration glissante
+(les utilisateurs actifs restent connectés, les inactifs finissent par expirer) :
+
+```rust
+use std::time::Duration;
+
+let store = SessionStore::new(cache).ttl(Duration::from_secs(60 * 60)); // 1 hour
+
+// On each request, after a successful load — extend without rewriting:
+store.touch(&sid).await?;   // Ok(false) if the session is already gone
+```
+
+---
+
+## Modification d'une session en place
+
+`save` frappe toujours un nouvel identifiant (utilisez-le à la connexion). Pour
+modifier une session existante pendant une requête, chargez → mutez →
+`save_with_id` sous le même identifiant :
+
+```rust
+let mut s = store.load(&sid).await?.unwrap_or_default();
+s.set("last_seen", chrono::Utc::now().to_rfc3339());
+store.save_with_id(&sid, &s).await?;
+```
+
+---
+
+## Remarques et limites
+
+- **La révocation est la fonctionnalité phare** — `destroy()` (déconnexion) et
+  l'expiration par TTL prennent toutes deux effet à la requête suivante, sur
+  chaque réplique partageant le cache.
+- **Les identifiants corrompus ou inconnus se chargent comme `None`**
+  (*fail-open*) : un changement de schéma de cache ou un cookie falsifié produit
+  une session vide, pas une erreur — la requête est simplement non authentifiée.
+- **Le magasin ne pose pas le cookie à votre place** — il gère l'état côté
+  serveur ; vous attachez/lisez le cookie `sid` dans votre handler (ou via une
+  couche). Cela le rend utilisable depuis n'importe quel câblage de framework.
+- **Frappez un nouvel identifiant de session lors d'un changement de privilège**
+  (par ex. juste après la connexion) pour éviter la fixation de session — `save`
+  le fait déjà puisqu'il génère toujours un nouvel identifiant.
+
+
+---
+
+## Voir aussi
+
+- [Décorateurs d'authentification](auth-decorators.md)
+- [JWT](auth-jwt.md)
+- [Backends d'authentification](auth-backends.md)
+- [Guide de sécurité](security.md)

--- a/docs/fr/benchmarks.md
+++ b/docs/fr/benchmarks.md
@@ -1,0 +1,271 @@
+# Benchmarks : Rustango vs Django vs Laravel vs Go
+
+À quel point **Rustango** est-il rapide, vraiment ? Cette page présente un benchmark
+en tête-à-tête face aux deux frameworks dont **Rustango** s'inspire — Django et Laravel — et
+face à une référence **Go** (le `net/http` de la bibliothèque standard) qui ancre ce qu'un
+second runtime compilé et natif atteint sur la même charge de travail. Tous utilisent
+des sites de blog *fonctionnellement identiques* : mêmes données, même schéma, mêmes endpoints,
+même budget matériel — la seule variable est le runtime. Django et Laravel sont
+chacun mesurés dans **les deux** cas : leur déploiement de production conventionnel *et* un
+runtime plus robuste : **Django** sur **gunicorn** (WSGI) et sur **Hypercorn**
+(ASGI) ; **Laravel** sur **php-fpm + nginx** et sur **Octane** (Swoole). Rustango
+et Go sont chacun un unique binaire résident, il n'y en a donc qu'un de chaque.
+
+Chaque chiffre ci-dessous est **mesuré et reproductible**, issu d'une exécution cohérente d'un
+harnais en une seule commande (voir [Reproduce](#reproduce)). Rien ici n'est esquivé à la légère.
+
+> **En bref.** Sur un matériel identique servant des pages HTML rendues identiques, les deux
+> runtimes **compilés et natifs** — **Rustango** et **Go** — laissent les
+> frameworks interprétés **5 à 30× derrière** et se disputent la tête entre eux. Sur
+> l'index non caché, **Go** menait à **6 651 req/s** et **Rustango** suivait à
+> **4 781** — **5,6×** Django (gunicorn) et **11,7×** Laravel (php-fpm). L'avance
+> de Go est la plus large sur la page de détail non cachée (**13 921 vs 6 538**, 2,1×).
+> **Rustango** reprend la tête là où cela compte pour le trafic servi : les
+> chemins **cachés en Redis** (**25 546** vs 20 929 de Go sur l'index ; 35 781 vs
+> 29 470 sur le détail) et le **pur calcul** (14 341 vs 11 573). Il a aussi conservé la
+> **plus faible RAM sous charge** (18,5 Mio, sans GC) et — contrairement à l'application Go stdlib —
+> livre un framework complet et tout compris. Même le résultat non compilé le plus rapide,
+> **Laravel sur Octane**, reste 4 à 7× derrière les deux binaires.
+
+[![Requêtes/s sur l'index de blog non caché pour les six runtimes — Go 6 651, Rustango 4 781, Laravel+Octane 1 238, Django+Hypercorn 910, Django+gunicorn 850, Laravel+php-fpm 408](img/benchmarks.png)](img/benchmarks.png)
+
+---
+
+## Le dispositif
+
+Quatre applications de blog — **auteurs, articles, tags (plusieurs-à-plusieurs) et commentaires** —
+rendant des pages HTML :
+
+| Route | Rend | Caché ? |
+|---|---|---|
+| `GET /` | les 20 derniers articles, chacun avec auteur, tags, nombre de commentaires | non |
+| `GET /cached` | identique à `/` | Redis, 60 s |
+| `GET /post/{slug}` | corps de l'article + auteur + tags + tous les commentaires | non |
+| `GET /post/{slug}/cached` | identique au détail | Redis, 60 s |
+| `GET /tag/{slug}` | les articles portant un tag | non |
+| `GET /compute` | somme de tous les nombres premiers en dessous de 20 000 (borné CPU ; sans BDD, sans cache) | non |
+
+Les cinq premières sont bornées par l'E/S + le rendu ; `/compute` est une charge de travail purement CPU — le
+même algorithme de division d'essai dans chaque langage — pour isoler la vitesse brute
+du runtime. Chaque application charge ses relations **de manière avide** (pas de N+1) : **Rustango** regroupe les
+requêtes explicitement, Django utilise `select_related` / `prefetch_related` /
+`annotate(Count)`, Laravel utilise `with()` + `withCount()`, **Go** charge par lots
+avec des requêtes `= ANY($1)`. Les templates sont délibérément minuscules et équivalents (Tera,
+templates Django, Blade, `html/template` de Go), afin que nous mesurions le *framework*, et non
+l'effort de template.
+
+### Ce qui en fait un combat équitable
+
+- **Données identiques.** Un schéma PostgreSQL et un seed déterministe partagés par les
+  quatre applications — elles lisent les *mêmes tables* : 10 auteurs, 30 tags, **1 000 articles**,
+  2 600 liens article-tag, **10 000 commentaires**. L'index affiche les 20 mêmes articles dans
+  le même ordre sur chaque framework, et le HTML rendu est octet-pour-octet identique
+  (au style d'échappement d'entités de chaque moteur près).
+- **Budget matériel identique.** Chaque application tourne dans un conteneur plafonné à
+  **4 CPU / 2 Go de RAM**. PostgreSQL et Redis sont partagés et identiques.
+- **Une à la fois.** Les applications sont testées en charge séquentiellement afin qu'elles ne se disputent jamais
+  l'hôte (une machine 12 cœurs / 18 Go). Générateur de charge :
+  [`oha`](https://github.com/hatoo/oha), 50 connexions concurrentes, 10 s par
+  endpoint, keep-alive HTTP activé. Chaque exécution a rapporté **100 % de succès**.
+- **Tout en mode production.** Cela compte énormément (voir ci-dessous).
+
+### Configuration de production
+
+| | Runtime | Durcissement de production |
+|---|---|---|
+| **Rustango** | un binaire `--release` (axum + Tokio, async, tous les cœurs) | `opt-level=3` + LTO ; cache de page Redis via `CachePageLayer` |
+| **Go** | un binaire statique (`net/http` stdlib, goroutines, tous les cœurs) | pool `pgx` + cache de page `go-redis` ; templates embarqués ; livré sur `scratch` |
+| **Django 5.2** · gunicorn | workers gthread + keep-alive (WSGI) | `DEBUG=False` ; cache Redis intégré + `@cache_page` ; connexions BDD persistantes |
+| **Django 5.2** · Hypercorn | serveur ASGI, 4 workers, keep-alive | même application, servie via ASGI ; les vues synchrones tournent dans un threadpool |
+| **Laravel 13** · php-fpm | php-fpm + nginx, OPcache **activé**, 16 workers | `APP_ENV=production` ; `composer install --no-dev --optimize-autoloader` ; Blade caché ; `Cache::remember` sur Redis |
+| **Laravel 13** · Octane | Octane + **Swoole**, workers persistants | même application sur un runtime résident en mémoire — pas de bootstrap du framework par requête |
+
+> Le mode production n'est pas une note de bas de page. La première exécution (non tunée) de Laravel n'a atteint
+> que ~53 req/s ; activer OPcache, l'autoloader optimisé et un vrai pool de
+> workers l'a porté à ~408 req/s — un **écart de 7,7×** dû à la seule configuration. Les
+> chiffres ci-dessous proviennent tous de la configuration de production.
+
+---
+
+## Résultats
+
+### Débit — requêtes par seconde (plus haut est meilleur)
+
+Les deux binaires compilés, puis chaque framework interprété dans son runtime
+conventionnel **et** son runtime robuste :
+
+| Endpoint | **Rustango** | **Go** | Django · gunicorn | Django · Hypercorn | Laravel · php-fpm | Laravel · Octane |
+|---|--:|--:|--:|--:|--:|--:|
+| index, non caché | 4 781 | **6 651** | 850 | 910 | 408 | 1 238 |
+| index, **caché** | **25 546** | 20 929 | 4 841 | 1 537 | 1 224 | 5 777 |
+| détail, non caché | 6 538 | **13 921** | 1 983 | 916 | 464 | 1 790 |
+| détail, **caché** | **35 781** | 29 470 | 4 843 | 1 320 | 793 | 5 811 |
+| tag, non caché | 3 926 | **4 353** | 1 129 | 1 033 | 398 | 1 179 |
+| **compute** (borné CPU) | **14 341** | 11 573 | 452 | 400 | 716 | 1 504 |
+
+Trois enseignements sautent aux yeux. Premièrement, **Go et Rustango se regroupent loin au-dessus de tous les
+autres** — l'écart entre les deux binaires natifs (des dizaines de pour cent, avec Go en tête
+sur l'E/S non cachée et Rustango en tête sur les hits cachés + le calcul) est faible face au
+gouffre de 5 à 30× vers les runtimes interprétés. Deuxièmement, **Laravel + Octane** (Swoole) est
+un **bond de 3 à 7×** par rapport à php-fpm — un worker résident qui évite le bootstrap
+du framework Laravel à chaque requête — et c'est le résultat non compilé le plus rapide sur chaque page.
+Troisièmement, **Django + Hypercorn** (ASGI) est à peu près **plat, et plus lent sur les chemins
+cachés** : les vues du blog sont *synchrones*, donc l'ASGI ne fait qu'ajouter un saut vers un threadpool
+sans aucun des gains de concurrence que des vues *async* apporteraient. Même le meilleur de
+ce peloton (Octane, 1 238 req/s sur l'index non caché ; 5 811 sur le détail caché) accuse
+un retard de 4 à 7× sur les deux binaires.
+
+### Latence — p50 en millisecondes (plus bas est meilleur)
+
+| Endpoint | **Rustango** | **Go** | Django · gunicorn | Django · Hypercorn | Laravel · php-fpm | Laravel · Octane |
+|---|--:|--:|--:|--:|--:|--:|
+| index, non caché | 10.2 | **7.2** | 56.9 | 43.2 | 114.7 | 39.9 |
+| index, caché | **1.8** | 2.1 | 9.3 | 5.0 | 20.2 | 7.6 |
+| détail, caché | **1.3** | 1.5 | 5.8 | 32.1 | 81.8 | 7.6 |
+| compute (borné CPU) | 3.5 | **2.5** | 70.8 | 130.0 | 87.4 | 32.9 |
+
+(Médianes indiquées ; les p50 / p95 / p99 complets pour chaque endpoint et runtime sont dans
+`bench/results/summary.tsv`.) Les médianes de **Rustango** et de **Go** sur l'index
+non caché (10,2 / 7,2 ms) sont inférieures à celles de tous les concurrents interprétés, et
+leurs médianes cachées (1,3 à 2,1 ms) sont un ordre de grandeur en dessous même du
+runtime de framework le plus rapide. Un bémol en faveur de Go *et* contre lui : son p50 de
+calcul (2,5 ms) bat celui de Rustango, mais son p99 de calcul grimpe à ~47 ms sur une pause
+GC — une traîne que le binaire Rust sans GC n'a pas.
+
+### Empreinte — taille d'image, mémoire, CPU
+
+| | **Rustango** | **Go** | Django · gunicorn | Django · Hypercorn | Laravel · php-fpm | Laravel · Octane |
+|---|--:|--:|--:|--:|--:|--:|
+| Image de conteneur (non compressée) | 164 MB | **18.5 MB** | 293 MB | 293 MB | 959 MB | 1.01 GB |
+| RAM, au repos | 12.1 MiB | **5.2 MiB** | 128 MiB | 173 MiB | 92 MiB | 248 MiB |
+| RAM, sous charge | **18.5 MiB** | 34.7 MiB | 218 MiB | 277 MiB | 133 MiB | 267 MiB |
+| CPU sous charge (sur un plafond de 400 %) | 295 % | 366 % | 356 % | 408 % | 406 % | 335 % |
+
+**Go** livre l'image la plus petite — un binaire statique sur `scratch`, **18,5 MB** — et
+tourne au repos à seulement **5,2 Mio**. Mais sous charge, son tas GC croît jusqu'à **34,7 Mio**,
+~1,9× les **18,5 Mio** stables de **Rustango** : sans ramasse-miettes et sans
+allocation par requête, le binaire Rust sous pleine charge tient dans moins de RAM que Go n'en
+utilise, et en deçà de ce que n'importe quel runtime interprété consomme *au repos*. Les runtimes
+robustes coûtent *plus* de mémoire, pas moins : Octane conserve un Laravel résident dans chaque
+worker ; Hypercorn ajoute la pile ASGI par-dessus Django.
+
+### Efficacité — travail accompli par ressource (la vraie histoire)
+
+Le débit brut est une chose ; le **débit par unité de ressource** est ce que votre
+facture cloud suit réellement (index non caché) :
+
+| Métrique | **Rustango** | **Go** | Django · gunicorn | Django · Hypercorn | Laravel · php-fpm | Laravel · Octane |
+|---|--:|--:|--:|--:|--:|--:|
+| Requêtes/s **par Mio de RAM** | **258** | 192 | 3.9 | 3.3 | 3.1 | 4.6 |
+| Requêtes/s **par % de CPU** | 16.2 | **18.2** | 2.4 | 2.2 | 1.0 | 3.7 |
+
+Par mégaoctet de mémoire, **Rustango** accomplit le plus de travail de tous les runtimes ici —
+~35× le meilleur résultat interprété et ~1,3× celui de Go, parce que son empreinte reste plate
+sous charge. Par pourcentage de CPU, **Go** prend légèrement l'avantage (il convertit les cœurs
+supplémentaires qu'il mobilise en un débit un peu plus élevé). Dans tous les cas, pour égaler le
+débit d'index d'un seul binaire compilé, il vous faudrait faire tourner ~4 Laravel sous Octane ou ~6
+Django sous gunicorn — chacun portant sa propre empreinte de plusieurs centaines de Mo.
+
+---
+
+## Ce que change le cache
+
+Chaque runtime est le plus rapide lorsqu'un cache de page Redis lui permet de sauter la base de données et
+le rendu entièrement — req/s de l'index non caché → **caché** :
+
+- **Rustango** : 4 781 → **25 546** (5,3× grâce au cache) — reprend la première place.
+- **Go** : 6 651 → **20 929** (3,1×) — en tête sans cache, deuxième avec cache.
+- **Laravel · Octane** : 1 238 → **5 777** (4,7×) — le meilleur du peloton interprété.
+- **Django · gunicorn** : 850 → **4 841** (5,7×).
+- **Django · Hypercorn** : 910 → **1 537** (1,7×) — la surcharge du threadpool ASGI
+  plafonne le gain même sur les hits de cache.
+- **Laravel · php-fpm** : 408 → **1 224** (3,0×).
+
+Le cache aide tout le monde, mais il n'efface pas l'écart — et c'est là que les deux
+binaires compilés se séparent : sans aucun code applicatif en exécution, le
+chemin accept HTTP → lecture de cache → réponse est tout ce qui reste, et le
+`CachePageLayer` sans allocation de **Rustango** (25 546 req/s) devance le chemin `go-redis` de Go
+(20 929), les deux à ~4× le meilleur runtime de framework.
+
+---
+
+## Calcul brut : compilé vs interprété (et compilé vs compilé)
+
+Les cinq routes de page sont dominées par la base de données et le moteur de template. La
+route `/compute` les évacue — elle somme tous les nombres premiers en dessous de 20 000 par division
+d'essai, le *même* algorithme en Rust, Go, Python et PHP. Tous les quatre retournent
+la même réponse (`21171191`) ; seule la vitesse diffère :
+
+| | **Rustango** | **Go** | Django | Laravel |
+|---|--:|--:|--:|--:|
+| Débit | **14 341 req/s** | 11 573 | 452 | 716 |
+| Latence p50 | 3.5 ms | **2.5 ms** | 70.8 ms | 87.4 ms |
+
+Les deux binaires natifs exécutent la boucle **~26 à 32×** plus vite que Django et
+**~16 à 20×** plus vite que Laravel — l'écart entre du code machine compilé et un
+interpréteur de bytecode. Entre Rust et Go, la boucle `--release` avec LTO de Rust s'empare de la
+couronne du débit tandis que la latence médiane de Go est en réalité plus basse ; le GC de Go se
+manifeste alors en latence de traîne (p99 ~47 ms) que le binaire Rust ne paie jamais. Fait intéressant, PHP 8.3
+(avec OPcache) surpasse CPython en calcul sur cette boucle d'entiers serrée, si bien que Laravel
+*surpasse en calcul* Django ici, même s'il perd sur chaque page bornée par l'E/S. C'est
+la charge de travail où le langage, et non le framework, domine — et où pousser
+la logique chaude dans **Rustango** rapporte le plus.
+
+---
+
+## Réserves honnêtes
+
+Un benchmark que vous ne pouvez pas critiquer ne vaut pas la peine d'être publié. Donc :
+
+- Les chiffres proviennent d'**un** hôte 12 cœurs / 18 Go (macOS + Docker). Les valeurs
+  absolues varient sur d'autres matériels ; c'est le tableau **relatif** qui voyage.
+- Il s'agit d'une charge de travail **à forte lecture, rendue côté serveur** — la forme de blog
+  la plus courante. Elle ne mesure pas les écritures, les flux d'authentification, les websockets ou une
+  logique métier lourde.
+- **Go ici est la bibliothèque standard, pas un framework pair.** Rustango, Django,
+  et Laravel sont des frameworks tout compris (ORM, admin, migrations, routage,
+  templating, multi-tenancy) ; l'application Go est du `net/http` écrit à la main + du SQL brut —
+  la référence la plus dépouillée et la plus rapide qu'un service Go atteint réalistement, et
+  la représentation la plus équitable du langage. Qu'il fasse jeu égal ou batte Rustango sur le
+  débit brut non caché est exactement là où réside le propos : **Rustango offre des performances
+  de classe Go avec une expérience développeur de classe Django/Laravel.** L'avance de Go sur les
+  endpoints non cachés s'achète en écrivant soi-même le SQL, le mappage et le câblage.
+- Les runtimes sont fondamentalement différents : Rustango et Go sont chacun un seul binaire
+  utilisant tous les cœurs avec des tâches bon marché ; Django et Laravel utilisent des pools fixes de
+  processus/threads worker. Cette différence *fait* partie du résultat, et les
+  nombres de workers ont été réglés à des valeurs par CPU sensées, non tunées pour favoriser quiconque.
+- Django et Laravel sont chacun présentés dans **les deux** runtimes — conventionnel
+  (gunicorn, php-fpm) et robuste (Hypercorn, Octane). **Laravel sur Octane est
+  3 à 7× plus rapide** que php-fpm ; **Django sur Hypercorn** (vues synchrones) est à peu près
+  plat. Les deux réduisent l'écart avec les binaires compilés ; aucun ne le comble.
+
+Le propos n'est pas que Django ou Laravel soient lents — ils propulsent une immense part du
+web. C'est que **Rustango** vous offre cette même expérience développeur tout compris avec
+les performances et l'empreinte de Rust compilé — égalant un service Go réglé à la main tout en
+vous livrant le framework que Go vous oblige à construire.
+
+---
+
+## Reproduire
+
+Le harnais complet — les quatre applications, le schéma PostgreSQL partagé + le seed
+déterministe, la configuration Docker Compose et le runner — est un projet autonome
+(`rustango-bench`). Depuis son répertoire :
+
+```sh
+bench/vendor.sh                       # vendor the framework into the build
+docker compose build                  # build all six images
+DURATION=10s CONCURRENCY=50 bench/run.sh
+```
+
+Prérequis : Docker + Compose et Rust (pour `cargo install oha`). Ajustez le
+plafond matériel dans `.env` (`CAP_CPUS`, `CAP_MEM`) et la charge avec `DURATION` /
+`CONCURRENCY`. La sortie brute par exécution atterrit dans `bench/results/`.
+
+
+---
+
+## Voir aussi
+
+- [Getting started](getting-started.md)
+- [ORM cookbook](orm.md)

--- a/docs/fr/caching.md
+++ b/docs/fr/caching.md
@@ -1,0 +1,198 @@
+# Mise en cache
+
+La mise en cache stocke le résultat d'un travail coûteux — une requête lourde,
+un fragment rendu, un appel d'API tierce — afin que la requête suivante l'obtienne
+instantanément au lieu de le recalculer. **Rustango** vous donne un unique trait
+`Cache` avec des backends interchangeables (in-memory, Redis, base de données),
+un helper de calcul-au-miss (`get_or_set`), et des helpers JSON typés. Changez de
+backend sans toucher à un seul site d'appel — comme le framework de cache de
+Django ou la façade `Cache` de Laravel.
+
+[![Caching in Rustango: get_or_set checks the cache, runs the factory only on a miss, stores the result with a TTL, and serves hits instantly; the same Cache trait backs InMemory, Redis, and DB](img/caching.png)](img/caching.png)
+
+> **Un terme vous est inconnu ?** *cache*, *TTL*, *clé*, *backend* — voir le
+> [glossaire](glossary.md).
+
+> **Source :** `rustango::cache` (`Cache`, `InMemoryCache`, `NullCache`,
+> `get_or_set`, `get_json`, `set_json`, `BoxedCache`, `from_settings`) — derrière
+> la feature `cache` (activée par défaut). `RedisCache` requiert la feature
+> `cache-redis` (désactivée par défaut).
+>
+> **Version exécutable :** chaque extrait est copié depuis
+> [`cache_doc.rs`](../crates/rustango/tests/cache_doc.rs)
+> (`cargo test -p rustango --test cache_doc`) ; le backend base de données est
+> éprouvé en dogfooding sur SQLite par
+> [`cache_db_backend_sqlite_live.rs`](../crates/rustango/tests/cache_db_backend_sqlite_live.rs).
+
+## Table des matières
+
+- [Étape 1 — Choisir un backend](#step-1--pick-a-backend)
+- [Étape 2 — get / set / delete](#step-2--get--set--delete)
+- [Étape 3 — get_or_set (cache-aside)](#step-3--get_or_set-cache-aside)
+- [Valeurs JSON typées](#typed-json-values)
+- [TTL et expiration](#ttl-and-expiry)
+- [Changer de backend](#swapping-backends)
+- [Référence](#reference)
+- [Voir aussi](#see-also)
+
+---
+
+## Étape 1 — Choisir un backend
+
+Chaque backend implémente le même trait `Cache`, donc votre code est identique
+quel que soit celui que vous choisissez. Le code applicatif détient un
+**`BoxedCache`** (`Arc<dyn Cache>`) et ne nomme jamais le type concret :
+
+```rust
+use rustango::cache::{BoxedCache, InMemoryCache};
+use std::sync::Arc;
+
+let cache: BoxedCache = Arc::new(InMemoryCache::new());
+```
+
+| Backend | Feature | À utiliser pour |
+|---|---|---|
+| `InMemoryCache` | `cache` | dev, tests, processus unique (HashMap par processus + TTL) |
+| `RedisCache` | `cache-redis` | production ; partagé entre réplicas |
+| `DbCache` | `cache` | production sans Redis ; une table `rustango_cache` |
+| `NullCache` | `cache` | désactiver la mise en cache (chaque lecture rate) — pratique en tests |
+
+---
+
+## Étape 2 — get / set / delete
+
+Le cœur du trait est quatre méthodes async. `set` prend un TTL optionnel
+(`None` = pas d'expiration) ; `get` retourne `Option<String>` (`None` sur un
+miss) :
+
+```rust
+use rustango::cache::{Cache, InMemoryCache};
+
+let cache = InMemoryCache::new();
+
+assert_eq!(cache.get("greeting").await?, None);     // miss
+cache.set("greeting", "hello", None).await?;        // store, no expiry
+assert_eq!(cache.get("greeting").await?.as_deref(), Some("hello"));
+assert!(cache.exists("greeting").await?);
+
+cache.delete("greeting").await?;                    // gone
+```
+
+Il existe aussi des variantes par lots — `get_many` / `set_many` /
+`delete_many`.
+
+---
+
+## Étape 3 — get_or_set (cache-aside)
+
+C'est celle que vous utiliserez le plus. `get_or_set` retourne la valeur en
+cache, ou — sur un miss — exécute votre factory, stocke le résultat avec un TTL,
+et le retourne. La factory **ne s'exécute que sur un miss** :
+
+```rust
+use rustango::cache::get_or_set;
+use std::time::Duration;
+
+let stats: HomeStats = get_or_set(
+    &*cache,                       // &dyn Cache
+    "home:stats",
+    || async { compute_home_stats(&pool).await },   // runs only on a miss
+    Some(Duration::from_secs(60)),                   // cache for 60s
+).await?;
+```
+
+Le test sous-jacent appelle `get_or_set` deux fois pour la même clé et affirme
+que la factory s'est exécutée **exactement une fois** — le second appel est
+servi depuis le cache.
+
+> **Invalidez à l'écriture.** Le cache-aside signifie des données périmées
+> jusqu'à ce que le TTL expire. Pour des données qui changent, faites aussi
+> `delete(key)` quand vous les écrivez — p. ex. depuis un [signal
+> `post_save`](orm.md) — pour que la lecture suivante recalcule.
+
+---
+
+## Valeurs JSON typées
+
+`get_json` / `set_json` sérialisent n'importe quel type
+`Serialize`/`Deserialize` en JSON, de sorte que vous mettez en cache des
+structs et des listes, pas seulement des chaînes :
+
+```rust
+use rustango::cache::{get_json, set_json};
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Profile { id: i64, name: String }
+
+set_json(&*cache, "profile:7", &profile, None).await?;
+let back: Option<Profile> = get_json(&*cache, "profile:7").await?;   // None on a miss
+```
+
+(`get_or_set` les utilise en interne, c'est pourquoi son type de valeur doit
+être `Serialize + Deserialize`.)
+
+---
+
+## TTL et expiration
+
+Passez une `Duration` à `set` (ou `get_or_set`) et l'entrée disparaît après
+elle. Vérifié : une entrée de 50 ms est lisible immédiatement et disparue après
+80 ms.
+
+```rust
+cache.set("flash", "x", Some(Duration::from_millis(50))).await?;
+// ...50ms later...
+assert_eq!(cache.get("flash").await?, None);   // expired
+```
+
+`InMemoryCache::with_default_ttl(d)` définit un TTL par défaut appliqué lorsque
+vous passez `None`.
+
+---
+
+## Changer de backend
+
+Parce que tout repose sur le trait `Cache`, passer de l'in-memory à Redis est un
+changement d'une ligne au démarrage — habituellement piloté par la config afin
+qu'il diffère selon l'environnement :
+
+```rust
+// Build the cache from `[cache]` settings (backend = "memory" | "redis" | "db" | "null").
+let cache: BoxedCache = rustango::cache::from_settings(&settings.cache);
+```
+
+En production, pointez-le vers Redis (partagé entre tous vos réplicas) :
+
+```rust
+use rustango::cache::RedisCache;   // needs the `cache-redis` feature
+let cache: BoxedCache = std::sync::Arc::new(RedisCache::new("redis://localhost").await?);
+```
+
+Les mêmes appels `get` / `set` / `get_or_set` — seul le constructeur a changé.
+
+---
+
+## Référence
+
+**Trait `Cache` :** `get` · `set(key, value, ttl)` · `delete` · `exists` ·
+`get_many` / `set_many` / `delete_many` · `get_or(key, default)`.
+
+**Helpers libres :** `get_or_set(cache, key, factory, ttl)` ·
+`get_json` / `set_json` · `from_settings(&CacheSettings)`.
+
+**Ce qui est bâti sur le cache :** les [sessions](auth-sessions.md) côté
+serveur, la [limitation de débit](middleware.md) distribuée
+(`CacheRateLimitLayer`), les clés d'idempotence, et les feature flags prennent
+tous un `BoxedCache` — de sorte qu'une seule instance Redis les adosse tous.
+
+---
+
+## Voir aussi
+
+- [Tâches d'arrière-plan](jobs.md) — l'autre moitié pour garder les requêtes
+  rapides (différer le travail au lieu de mettre en cache son résultat).
+- [Sessions](auth-sessions.md) — un stockage côté serveur bâti sur `Cache`.
+- [Middleware](middleware.md) — `CacheRateLimitLayer` partage un compteur entre
+  réplicas via le cache.
+- [Cookbook de l'ORM](orm.md) — invalider les lectures en cache depuis un signal
+  `post_save`.

--- a/docs/fr/email.md
+++ b/docs/fr/email.md
@@ -1,0 +1,198 @@
+# Envoyer des e-mails
+
+Messages de bienvenue, réinitialisations de mot de passe, reçus, alertes — la plupart des
+applications envoient des e-mails transactionnels. **Rustango** vous offre un trait `Mailer` avec
+des backends interchangeables (console pour le développement, SMTP pour la production, un
+enregistreur en mémoire pour les tests), un builder `Email` fluide avec protection contre
+l'injection d'en-têtes, et le rendu de templates. Écrivez `mailer.send(&email)` une seule fois ;
+passez de l'impression dans votre terminal à un vrai SMTP avec un changement d'une ligne — comme le
+framework d'e-mail de Django.
+
+[![L'e-mail dans Rustango : un builder Email (to/subject/body/html) est validé contre l'injection d'en-têtes, puis envoyé à travers le trait Mailer — ConsoleMailer en dev, SmtpMailer en prod, InMemoryMailer en test](img/email.png)](img/email.png)
+
+> **Un terme vous est inconnu ?** *e-mail transactionnel*, *SMTP*, *backend de messagerie* — voir
+> le [glossaire](glossary.md).
+
+> **Source :** `rustango::email` (`Mailer`, `Email`, `ConsoleMailer`,
+> `InMemoryMailer`, `NullMailer`, `SmtpMailer`, `BoxedMailer`, `send_mail`,
+> `MailError`) — derrière la fonctionnalité `email` (activée par défaut). SMTP nécessite la
+> fonctionnalité `email-smtp`.
+>
+> **Version exécutable :** chaque snippet est copié depuis
+> [`email_doc.rs`](../crates/rustango/tests/email_doc.rs)
+> (`cargo test -p rustango --test email_doc`) ; les helpers d'envoi et les pièces jointes
+> sont mis à l'épreuve par `email_send_helpers.rs` et `email_attachments.rs`.
+
+## Table des matières
+
+- [Étape 1 — Construire un e-mail](#step-1--build-an-email)
+- [Étape 2 — Choisir un mailer](#step-2--pick-a-mailer)
+- [Étape 3 — L'envoyer](#step-3--send-it)
+- [Validation et protection contre l'injection d'en-têtes](#validation-and-header-injection-safety)
+- [Tester les e-mails](#testing-email)
+- [Templates](#templates)
+- [L'envoyer en dehors de la requête](#send-it-off-the-request)
+- [Référence](#reference)
+- [Voir aussi](#see-also)
+
+---
+
+## Étape 1 — Construire un e-mail
+
+`Email` est un builder fluide. Définissez les destinataires, l'objet, et un corps texte et/ou
+HTML :
+
+```rust
+use rustango::email::Email;
+
+let email = Email::new()
+    .to("ada@example.com")
+    .from("noreply@example.com")
+    .subject("Welcome")
+    .body("Thanks for signing up.")              // plain-text part
+    .html_body("<p>Thanks for signing up.</p>"); // optional HTML part
+```
+
+`.cc(...)`, `.reply_to(...)`, et les pièces jointes sont également disponibles.
+
+---
+
+## Étape 2 — Choisir un mailer
+
+Chaque backend implémente `Mailer`, si bien que votre code ne nomme jamais le type concret —
+tenez un **`BoxedMailer`** (`Arc<dyn Mailer>`) :
+
+| Backend | Fonctionnalité | À utiliser pour |
+|---|---|---|
+| `ConsoleMailer` | `email` | dev — imprime le message sur stdout |
+| `SmtpMailer` | `email-smtp` | production — livraison réelle par SMTP |
+| `InMemoryMailer` | `email` | tests — enregistre les messages, n'envoie rien |
+| `FileMailer` | `email` | dev/CI — écrit chaque message dans un fichier |
+| `NullMailer` | `email` | désactive complètement l'e-mail |
+
+Construisez-le à partir de la configuration afin qu'il diffère selon l'environnement (`ConsoleMailer`
+en local, `SmtpMailer` en prod) via `email::from_settings(&settings.email)`.
+
+---
+
+## Étape 3 — L'envoyer
+
+`Email::send` prend n'importe quel `&dyn Mailer` :
+
+```rust
+email.send(&mailer).await?;
+```
+
+Pour un envoi ponctuel rapide, `send_mail` évite le builder :
+
+```rust
+use rustango::email::send_mail;
+
+send_mail(
+    &mailer,
+    "Your report is ready",                  // subject
+    "Download it from your dashboard.",      // body
+    Some("noreply@example.com"),             // from (or None for the default)
+    &["ops@example.com", "qa@example.com"],  // recipients
+).await?;
+```
+
+`send_many` envoie un lot en un seul appel.
+
+---
+
+## Validation et protection contre l'injection d'en-têtes
+
+`Email::validate()` s'exécute avant l'envoi (et vous pouvez l'appeler vous-même). Elle
+rejette les messages incomplets **et** défend contre l'injection d'en-têtes — un saut de ligne
+introduit subrepticement dans un en-tête est la façon dont les attaquants ajoutent un `Bcc` caché :
+
+```rust
+// Missing recipients or an empty subject → MailError::InvalidMessage
+Email::new().subject("hi").validate()?;          // Err: no recipients
+
+// A CRLF in any header field → MailError::BadHeader (Django's BadHeaderError)
+Email::new()
+    .to("a@example.com")
+    .subject("Hello\r\nBcc: victim@example.com")  // injection attempt
+    .body("x")
+    .validate()?;                                  // Err: BadHeader
+```
+
+Les deux sont vérifiés dans le test de support.
+
+---
+
+## Tester les e-mails
+
+Utilisez `InMemoryMailer` — il enregistre chaque message au lieu d'envoyer, si bien que les tests
+affirment sur ce qui *serait* parti, sans réseau :
+
+```rust
+use rustango::email::InMemoryMailer;
+
+let mailer = InMemoryMailer::new();
+welcome_flow(&mailer).await?;          // your code under test
+
+let sent = mailer.sent();              // Vec<Email>
+assert_eq!(sent.len(), 1);
+assert_eq!(sent[0].to, vec!["ada@example.com".to_string()]);
+assert_eq!(sent[0].subject, "Welcome");
+```
+
+---
+
+## Templates
+
+Pour tout ce qui va au-delà d'une ligne de texte, rendez le corps à partir d'un template
+[Tera](html-views.md) plutôt que d'inliner du HTML. L'`EmailRenderer` de la fonctionnalité
+`email_templates` suit une convention `name.subject.txt` / `name.txt` / `name.html` — un seul
+ensemble de templates produit l'objet, la partie texte brut et la partie HTML ensemble, si bien que
+les trois ne divergent jamais. Le trait `Mailable` empaquette « une chose qui sait se transformer
+elle-même en `Email` » pour des messages réutilisables.
+
+---
+
+## L'envoyer en dehors de la requête
+
+Envoyer l'e-mail en ligne fait attendre l'utilisateur après votre serveur SMTP et couple la
+réponse à sa disponibilité. Envoyez-le plutôt depuis une [tâche d'arrière-plan](jobs.md) —
+le handler renvoie immédiatement et un worker le livre (avec des relances si le SMTP est
+indisponible) :
+
+```rust
+// in the handler: enqueue, don't send inline
+queue.dispatch(&SendWelcomeEmail { user_id }).await?;
+
+// the job (see the Background jobs guide):
+async fn run(&self) -> Result<(), JobError> {
+    let email = Email::new().to(/* ... */).subject("Welcome").body("...");
+    email.send(&*mailer).await.map_err(|e| JobError::Retryable(e.to_string()))?;
+    Ok(())
+}
+```
+
+La fonctionnalité `email_jobs` câble cela pour vous.
+
+---
+
+## Référence
+
+**Builder `Email` :** `to` · `cc` · `from` · `reply_to` · `subject` · `body` ·
+`html_body` · pièces jointes · `validate()` · `send(&mailer)`.
+
+**Helpers :** `send_mail(mailer, subject, body, from, &recipients)` ·
+`send_many(mailer, &emails)` · `from_settings(&EmailSettings)`.
+
+**`MailError` :** `InvalidMessage` (incomplet) · `BadHeader` (injection CRLF) ·
+`Transport` (échec de backend/livraison).
+
+---
+
+## Voir aussi
+
+- [Tâches d'arrière-plan](jobs.md) — livrer l'e-mail en dehors de la requête avec des relances.
+- [Flux de compte](auth-flows.md) — e-mails de réinitialisation de mot de passe / vérification /
+  lien magique construits là-dessus.
+- [Vues HTML](html-views.md) — le moteur Tera qu'utilisent aussi les templates d'e-mail.
+- [Mise en cache](caching.md) — le même motif de trait « change-le-backend ».

--- a/docs/fr/files.md
+++ b/docs/fr/files.md
@@ -1,0 +1,233 @@
+# Fichiers, téléversements et médias
+
+Presque toutes les applications stockent des fichiers utilisateur — avatars, pièces jointes,
+rapports exportés, images. **Rustango** vous offre un trait `Storage` avec des backends
+interchangeables (disque local, stockage objet compatible S3, en mémoire pour les tests), un helper
+de **téléversement** multipart sûr avec des garde-fous de taille/type, et — lorsque vous avez besoin
+d'une médiathèque suivie — un `MediaManager` adossé à une base de données avec des URL présignées.
+Écrivez votre code une seule fois contre le trait ; passez du disque local à S3 avec un changement
+d'une ligne.
+
+[![Les fichiers dans Rustango : un téléversement multipart est vérifié en taille et en extension puis écrit à travers le trait Storage ; le même trait alimente le disque local, S3 et en mémoire, et url() renvoie une adresse publique](img/files.png)](img/files.png)
+
+> **Un terme vous est inconnu ?** *backend de stockage*, *multipart*, *stockage objet*,
+> *URL présignée* — voir le [glossaire](glossary.md).
+
+> **Source :** `rustango::storage` (`Storage`, `LocalStorage`, `InMemoryStorage`,
+> `s3::S3Storage`, `BoxedStorage`), `rustango::uploads` (`save_uploads`,
+> `UploadConfig`, `sanitize_filename`), et `rustango::media`
+> (`Media`, `MediaManager`) — derrière les fonctionnalités `storage` / `uploads` / `storage-s3` /
+> `media` (toutes activées par défaut).
+>
+> **Version exécutable :** les snippets Storage + garde-fous de téléversement sont copiés depuis
+> [`files_doc.rs`](../crates/rustango/tests/files_doc.rs)
+> (`cargo test -p rustango --test files_doc`) ; le flux multipart `save_uploads` de bout
+> en bout est mis à l'épreuve par les tests intégrés dans
+> `crates/rustango/src/uploads.rs`, et la médiathèque par
+> [`media_sqlite_live.rs`](../crates/rustango/tests/media_sqlite_live.rs).
+
+## Table des matières
+
+- [Étape 1 — Choisir un backend de stockage](#step-1--pick-a-storage-backend)
+- [Étape 2 — Enregistrer, charger et servir des fichiers](#step-2--save-load-and-serve-files)
+- [Étape 3 — Accepter un téléversement](#step-3--accept-an-upload)
+- [Noms de fichiers sûrs](#safe-filenames)
+- [Production : stockage compatible S3](#production-s3-compatible-storage)
+- [La médiathèque](#the-media-library)
+- [Référence](#reference)
+- [Voir aussi](#see-also)
+
+---
+
+## Étape 1 — Choisir un backend de stockage
+
+Chaque backend implémente le même trait `Storage`, si bien que votre code ne nomme jamais le type
+concret — il tient un **`BoxedStorage`** (`Arc<dyn Storage>`) :
+
+```rust
+use rustango::storage::{BoxedStorage, LocalStorage};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+let storage: BoxedStorage = Arc::new(LocalStorage::new(PathBuf::from("./uploads")));
+```
+
+| Backend | Fonctionnalité | À utiliser pour |
+|---|---|---|
+| `LocalStorage` | `storage` | déploiements mono-serveur — fichiers sur disque local |
+| `S3Storage` | `storage-s3` | production — stockage objet S3 / R2 / B2 / MinIO |
+| `InMemoryStorage` | `storage` | tests — un `HashMap`, ne touche jamais au disque |
+
+---
+
+## Étape 2 — Enregistrer, charger et servir des fichiers
+
+Le trait tient en quatre méthodes async, indexées par un chemin sous forme de chaîne. `save` écrit
+des octets, `load` les relit, plus `exists` / `delete` :
+
+```rust
+use rustango::storage::{Storage, InMemoryStorage};
+
+let store = InMemoryStorage::new();
+store.save("avatars/7.png", &png_bytes).await?;
+assert!(store.exists("avatars/7.png").await?);
+let bytes = store.load("avatars/7.png").await?;
+store.delete("avatars/7.png").await?;
+```
+
+**Servir le fichier.** Attachez une URL de base (votre CDN ou hôte statique) et `url(key)`
+construit l'adresse publique que vous stockez sur le modèle et remettez au navigateur :
+
+```rust
+let store = LocalStorage::new("./uploads".into())
+    .with_base_url("https://cdn.example.com/uploads");
+
+store.url("docs/report.pdf");   // Some("https://cdn.example.com/uploads/docs/report.pdf")
+```
+
+Sans URL de base, `url()` renvoie `None` — vous streameriez plutôt les octets à travers un
+handler. `LocalStorage` protège aussi contre la traversée de chemin dans les clés.
+
+---
+
+## Étape 3 — Accepter un téléversement
+
+`save_uploads` consomme un corps `Multipart` axum, valide chaque fichier contre un
+`UploadConfig`, et écrit les survivants dans votre `Storage` — en streaming, si bien qu'un fichier
+surdimensionné est rejeté en cours de transfert au lieu d'être mis en tampon en mémoire d'abord.
+
+```rust
+use rustango::uploads::{save_uploads, UploadConfig};
+use axum::extract::Multipart;
+
+async fn upload(mp: Multipart) -> Result<impl IntoResponse, UploadError> {
+    let cfg = UploadConfig::new("avatars/")          // key prefix
+        .max_bytes(2 * 1024 * 1024)                  // reject files over 2 MiB
+        .allowed_extensions(&["png", "jpg", "jpeg", "webp"])
+        .randomize_filename(true);                   // avoid collisions
+
+    let saved = save_uploads(mp, &cfg, &storage).await?;   // Vec<SavedUpload>
+    Ok(Json(saved))
+}
+```
+
+Les garde-fous sont appliqués (et vérifiés) : `allowed_extensions` est **insensible à la casse**
+(`"PNG"` et `"png"` sont identiques), et `max_bytes` interrompt le stream dès que la taille est
+dépassée. Les tests `uploads` intégrés pilotent de vrais corps multipart et affirment que les
+fichiers atterrissent dans le stockage, que les fichiers surdimensionnés sont rejetés, et que les
+extensions non autorisées sont refusées.
+
+```rust
+let cfg = UploadConfig::new("avatars/").allowed_extensions(&["PNG", "Jpg"]);
+assert!(cfg.allowed_extensions.contains("png"));   // normalized to lowercase
+assert!(cfg.allowed_extensions.contains("jpg"));
+```
+
+---
+
+## Noms de fichiers sûrs
+
+Ne faites jamais confiance à un nom de fichier fourni par le client. `sanitize_filename` le réduit
+à un basename sûr — en retirant les composantes de répertoire (traversée de chemin) et en
+remplaçant les caractères dangereux :
+
+```rust
+use rustango::uploads::sanitize_filename;
+
+sanitize_filename("../../etc/passwd");   // "passwd"   — no traversal
+sanitize_filename("my photo!.png");      // "my_photo_.png"
+sanitize_filename("");                    // "upload"   — never empty
+```
+
+`save_uploads` l'applique pour vous ; ne l'appelez directement que si vous construisez des clés à la
+main.
+
+---
+
+## Production : stockage compatible S3
+
+Pour les déploiements multi-serveurs, remplacez `LocalStorage` par `S3Storage` (derrière la
+fonctionnalité `storage-s3`). Il parle l'API S3 avec un signeur SigV4 fait maison, si bien qu'il
+fonctionne avec **AWS S3, Cloudflare R2, Backblaze B2 et MinIO**. Le trait est
+identique — seul le constructeur change :
+
+```rust
+use rustango::storage::s3::S3Storage;   // needs the `storage-s3` feature
+
+let storage: BoxedStorage = Arc::new(
+    S3Storage::new(/* bucket, region, endpoint, credentials */)
+);
+// save / load / delete / url — exactly the same calls as LocalStorage
+```
+
+Vos handlers et vos modèles ne changent pas ; seul le câblage au démarrage change.
+
+---
+
+## La médiathèque
+
+Lorsque les fichiers sont des enregistrements de première classe — suivis en base de données,
+parcourables dans l'admin, avec des miniatures et une livraison CDN/présignée — tournez-vous vers
+`rustango::media` plutôt que vers `Storage` brut. `MediaManager` persiste une ligne `Media` par
+fichier et prend en charge deux flux de téléversement :
+
+- **Côté serveur :** `manager.save_bytes(...)` stocke les octets et la ligne en un seul
+  appel.
+- **Direct vers le stockage :** `manager.begin_upload(...)` renvoie une URL de **PUT présigné**
+  vers laquelle le navigateur téléverse directement (votre serveur ne relaie jamais les octets),
+  puis vous confirmez la ligne.
+
+```rust
+use rustango::media::{Media, MediaManager};
+
+let manager = MediaManager::new_pool(pool.clone(), registry);
+// Hand the browser a short-lived download link:
+let url = manager.presigned_get(&media, Duration::from_secs(3600)).await?;
+```
+
+Il gère aussi la suppression douce et la purge des orphelins. Le flux complet est mis à l'épreuve
+dans `media_sqlite_live.rs` ; les méthodes présignées/de téléversement direct du manager sont
+orientées PostgreSQL.
+
+### Comment les tables de médias sont créées
+
+Les tables de médias (`rustango_media`, `rustango_media_collections`,
+`rustango_media_tags`, `rustango_media_tag_links`) sont des modèles gérés. Leur
+schéma est livré sous forme de **migration système** et est créé — par locataire, quand la
+fonctionnalité `media` est activée — de la même façon que le reste des propres tables du framework,
+chaque fois que vous exécutez `migrate` / provisionnez un locataire. Il n'y a pas d'étape paresseuse
+de « création à la première utilisation » ; si la fonctionnalité est désactivée, les tables ne sont
+jamais créées.
+
+> **Mise à niveau depuis une version antérieure à 0.51.** Les versions plus anciennes créaient les
+> tables de médias de façon paresseuse via un appel DDL `ensure_table` plutôt que via une migration.
+> Au premier `migrate` (ou provisionnement de locataire) après la mise à niveau, le framework
+> **réconcilie automatiquement** :
+> parce que les tables existent déjà, la migration de médias générée est enregistrée dans
+> le registre des migrations système *sans* réexécuter son `CREATE TABLE`, et vos
+> lignes existantes sont laissées intactes. **Aucune étape manuelle n'est requise** — la mise à
+> niveau qui échouerait autrement avec `relation already exists` / `table already exists`
+> fonctionne désormais tout simplement. (Introduit en 0.51.1 ; voir le CHANGELOG.)
+
+---
+
+## Référence
+
+**Trait `Storage` :** `save(key, &bytes)` · `load(key)` · `delete(key)` ·
+`exists(key)` · `url(key) -> Option<String>`.
+
+**`UploadConfig` :** `new(prefix)` · `.max_bytes(n)` · `.allowed_extensions(&[..])`
+(insensible à la casse) · `.randomize_filename(bool)`. Utilisé par
+`save_uploads(multipart, &cfg, &storage)`.
+
+**Backends :** `LocalStorage` (disque) · `S3Storage` (stockage objet, `storage-s3`)
+· `InMemoryStorage` (tests). Tous renvoient un `BoxedStorage`.
+
+---
+
+## Voir aussi
+
+- [L'admin](admin.md) — les médias et les widgets de FK font apparaître les fichiers téléversés dans l'UI.
+- [Tâches d'arrière-plan](jobs.md) — redimensionnez/transcodez un téléversement en dehors de la requête.
+- [Mise en cache](caching.md) — le même motif de trait « change-le-backend ».
+- [Guide de sécurité](security.md) — valider une entrée de téléversement non fiable.

--- a/docs/fr/glossary.md
+++ b/docs/fr/glossary.md
@@ -1,0 +1,206 @@
+# Glossaire
+
+Une référence en langage simple des mots utilisés dans cette documentation. Si un
+terme d'un guide vous est inconnu, cherchez-le ici d'abord. Les définitions sont
+volontairement informelles — les guides approfondis donnent les détails précis.
+
+Si vous n'avez jamais construit d'API web auparavant, lisez [Les bases des API web](#web-api-basics)
+de haut en bas ; c'est une introduction de cinq minutes. Tout le reste est fait pour
+être consulté au fur et à mesure.
+
+## Table des matières
+
+- [Les bases des API web](#web-api-basics) — ce qu'est une API, en termes de tous les jours
+- [Les briques de Rustango](#rustango-building-blocks) — les pièces que vous assemblez
+- [Les données et la base de données](#data-and-the-database)
+- [Quelques mots de Rust](#a-few-rust-words) — pour que les blocs de code ne fassent pas peur
+- [Frameworks auxquels nous comparons](#frameworks-we-compare-to)
+
+---
+
+## Les bases des API web
+
+**API** — *Application Programming Interface* (interface de programmation d'application). Un moyen pour un programme de parler à
+un autre. Une **API web** le fait par internet : votre application envoie un message, le
+serveur en renvoie un. Voyez-la comme un serveur au restaurant — vous commandez à partir d'un menu, la
+cuisine renvoie un plat.
+
+**API REST** — le style d'API web le plus courant. « REST » n'est qu'un ensemble de
+conventions : vous agissez sur des **ressources** (comme « posts » ou « users ») en utilisant des verbes
+web standard. Vous n'avez pas besoin de connaître la théorie — en pratique cela signifie *des
+URL prévisibles et une poignée de verbes*, décrits ci-après.
+
+**Endpoint (point de terminaison)** — une URL précise à laquelle votre API répond, comme `/api/posts` (tous les posts)
+ou `/api/posts/42` (le post d'id 42). Une API est un ensemble d'endpoints.
+
+**Verbe HTTP (ou méthode)** — *ce que* vous voulez faire à un endpoint. Il y en a cinq
+que vous verrez constamment :
+
+| Verbe | Signifie | Exemple |
+|---|---|---|
+| `GET` | lire / récupérer | « donne-moi tous les posts » |
+| `POST` | créer | « ajoute un nouveau post » |
+| `PUT` | remplacer | « écrase entièrement le post 42 » |
+| `PATCH` | mettre à jour partiellement | « change juste le titre du post 42 » |
+| `DELETE` | supprimer | « supprime le post 42 » |
+
+**Requête / Réponse** — une requête est le message que vous envoyez (un verbe + un endpoint
++ éventuellement un corps de données). La réponse est ce qui revient (un code de statut +
+généralement un corps de données).
+
+**JSON** — le format texte que les API utilisent pour transporter les données. Il ressemble à
+`{"title": "Hello", "published": true}` — des valeurs étiquetées, lisibles par un humain. Les
+requêtes comme les réponses sont généralement en JSON.
+
+**Code de statut** — un nombre à trois chiffres dans chaque réponse qui indique comment cela s'est passé :
+
+| Code | Signification |
+|---|---|
+| `200` | OK — voici vos données |
+| `201` | Created — votre nouvelle chose a été enregistrée |
+| `204` | Done — rien à renvoyer (p. ex. après une suppression) |
+| `400` | Bad request — vous avez envoyé quelque chose d'invalide (le corps dit quoi) |
+| `401` / `403` | Non connecté / non autorisé |
+| `404` | Not found (introuvable) |
+| `429` | Too many requests — ralentissez |
+| `500` | Le serveur a rencontré une erreur |
+
+**CRUD** — *Create, Read, Update, Delete* (créer, lire, mettre à jour, supprimer). Les quatre choses de base que vous faites aux données.
+Une « API CRUD » signifie simplement une API qui vous permet de faire les quatre. Voir
+[ViewSets](viewsets.md), qui construisent une API CRUD complète à partir d'une seule déclaration.
+
+**Chaîne de requête / paramètre de requête (query string / query parameter)** — la partie `?key=value` à la fin d'une URL,
+utilisée pour filtrer, rechercher, trier ou paginer les résultats — p. ex.
+`/api/posts?status=published&page=2`. Chaque `key=value` est un paramètre.
+
+**Pagination** — découper une longue liste de résultats en pages pour qu'une réponse ne soit pas
+énorme. L'**enveloppe** est l'emballage autour de la page qui vous indique aussi les
+totaux — p. ex. `{"count": 137, "page": 2, "results": [ … ]}`. Voir
+[Pagination](viewsets.md#pagination).
+
+**`curl`** — un outil en ligne de commande pour envoyer des requêtes d'API à la main. Les
+exemples `curl ...` dans cette documentation vous permettent d'essayer un endpoint depuis un terminal
+sans écrire de code.
+
+---
+
+## Les briques de Rustango
+
+Ce sont les pièces que vous assemblez pour construire une application. Chacune renvoie vers son guide complet.
+
+**Modèle (Model)** — une description d'un type de chose que votre application stocke, comme un `Post` ou
+un `User`. Vous l'écrivez comme un `struct` Rust ; Rustango le transforme en table de base de
+données. Voir le [guide de l'ORM](orm.md).
+
+**Migration** — un changement enregistré de la forme de votre base de données (ajouter une table,
+une colonne…). Vous en générez une avec `makemigrations` et l'appliquez avec `migrate`,
+pour que chaque environnement se retrouve avec la même structure de base de données.
+
+**Serializer (sérialiseur)** — le traducteur entre les lignes de votre base de données et le JSON que votre API
+envoie et reçoit. Il décide quels champs sont visibles, renomme ou calcule des
+champs pour la sortie, et valide les données entrantes. Il *met en forme* les données ; il ne les
+enregistre pas (c'est le modèle qui le fait). Voir le [guide des Serializers](serializers.md).
+
+**ViewSet** — prend un modèle et un serializer et produit une **API JSON** CRUD
+complète (les cinq verbes ci-dessus) automatiquement, pour que vous n'écriviez pas chaque
+endpoint à la main. La *vue API*. Voir le [guide des ViewSets](viewsets.md).
+
+**Vue HTML (template view, class-based view)** — la contrepartie rendue côté serveur
+d'un ViewSet : transforme un modèle en **pages** HTML — une page de liste, une
+page de détail, et des formulaires de création/édition/suppression — rendues via des templates Tera,
+au lieu de JSON. La *vue HTML*. Voir [Vues HTML](html-views.md).
+
+**Template (gabarit)** — un fichier avec des espaces réservés (Rustango utilise [Tera](https://keats.github.io/tera/),
+très semblable aux templates Django ou à Jinja) que le serveur remplit de données pour produire
+une page HTML. `{{ post.title }}` insère une valeur ; `{% for … %}` fait une boucle.
+
+**Router / montage (mount)** — le router associe les URL entrantes au code qui les
+traite. *Monter* un ViewSet signifie « attacher ses endpoints à votre application à un chemin
+donné », p. ex. monter l'API des posts sur `/api/posts`. Voir [URLs et routage](urls.md).
+
+**Middleware (une « couche » / layer)** — du code qui s'exécute *autour* de chaque requête — avant votre
+handler et après lui — pour des préoccupations transversales comme la journalisation, la limitation de débit, les
+en-têtes de sécurité ou le CSRF. « Layer » est le mot de Rustango pour une pièce de
+middleware. Voir le [guide du Middleware](middleware.md).
+
+**Pool (ou executor)** — la connexion à la base de données que votre code utilise pour lire et
+écrire. Rustango vous demande de passer le pool explicitement à chaque appel à la base de données
+(plutôt que de le cacher dans un global), pour qu'il soit toujours clair ce qui touche à la
+base de données. Vous verrez `&pool` comme dernier argument des appels de l'ORM.
+
+**QuerySet** — une requête de base de données que vous construisez étape par étape en Rust
+(`Post::objects().filter(...).order_by(...)`) avant de l'exécuter. Elle est paresseuse (lazy) :
+rien ne touche la base de données tant que vous ne la `fetch`ez pas.
+
+**Feature flag (drapeau de fonctionnalité)** — un interrupteur marche/arrêt, défini dans `Cargo.toml`, qui inclut ou
+exclut un morceau du framework à la compilation. Il vous permet de garder votre application petite
+en ne compilant que ce que vous utilisez. La plupart des fonctionnalités sont activées par défaut.
+
+**Scaffolding (génération de squelette)** — des commandes de génération (`startapp`, `make:serializer`,
+`make:viewset`…) qui écrivent des fichiers de départ pour vous, pour que vous ne partiez pas d'une
+page blanche. Voir [Scaffolding](scaffolding.md).
+
+---
+
+## Les données et la base de données
+
+**Champ / colonne (field / column)** — un morceau de données sur un modèle, comme le `title` ou le
+`published_at` d'un post. « Champ » est le côté Rust ; « colonne » est le côté base de données ; ils
+se correspondent un-à-un.
+
+**Clé primaire (primary key)** — l'id unique qui identifie une ligne, généralement un
+nombre auto-incrémenté appelé `id`.
+
+**Clé étrangère (foreign key, FK)** — un champ sur un modèle qui pointe vers la ligne d'un autre modèle,
+modélisant une relation — p. ex. un `Post` a une clé étrangère `author_id` pointant
+vers un `Author`. C'est ainsi que les lignes se référencent les unes les autres.
+
+**NULL / nullable** — `NULL` est le mot de la base de données pour « aucune valeur / vide ». Un
+champ **nullable** a le droit d'être vide ; un champ non-nullable est obligatoire.
+
+**Tri-dialecte (tri-dialect)** — « fonctionne de la même façon sur les trois bases de données prises en charge » —
+PostgreSQL, MySQL et SQLite. Quand une fonctionnalité est tri-dialecte, vous pouvez changer de
+base de données sans changer votre code.
+
+---
+
+## Quelques mots de Rust
+
+Vous n'avez pas besoin de connaître Rust pour *lire* la plupart des exemples, mais ces quatre mots
+apparaissent partout.
+
+**`struct`** — un ensemble nommé de champs, comme un enregistrement ou une classe qui n'a que
+des données. Les modèles et les serializers sont des structs.
+
+**Macro derive (`#[derive(Model)]`, `#[derive(Serializer)]`…)** — une annotation d'une
+ligne au-dessus d'un struct qui dit au compilateur d'auto-générer une pile de
+code pour vous (le mapping de la base de données, la conversion JSON, …). C'est la magie qui
+transforme un simple struct en modèle ou serializer fonctionnel.
+
+**`async` / `.await`** — la façon dont Rust gère le travail qui implique d'attendre (une
+requête de base de données, un appel réseau). Une fonction marquée `async` est « awaitable » ; le
+`.await` après un appel signifie « attends ici le résultat ». Tout ce qui touche à la
+base de données est `async`.
+
+**`Result` / `Option`** — comment Rust rapporte les résultats au lieu de lever des
+exceptions. Un `Result` est « un succès *ou* une erreur » ; une `Option` est « une valeur *ou*
+rien ». Le `?` que vous voyez après certains appels signifie « si cela a échoué, arrête-toi et
+renvoie l'erreur ».
+
+---
+
+## Frameworks auxquels nous comparons
+
+Cette documentation dit parfois « comme X » pour aider les lecteurs venant d'autres
+écosystèmes. Les comparaisons sont un bonus — vous n'en avez jamais besoin pour suivre un guide.
+
+**Django** — un framework web Python populaire. Rustango emprunte beaucoup de sa forme
+(modèles, migrations, une interface d'administration, les commandes `manage`).
+
+**DRF (Django REST Framework)** — l'extension de Django pour construire des API REST.
+Les serializers et ViewSets de Rustango en sont inspirés, donc « à la manière de DRF » signifie
+« disposé de la façon dont DRF le fait » — p. ex. des erreurs de validation renvoyées sous forme d'objet JSON
+indexé par nom de champ.
+
+**Laravel / Rails** — des frameworks web PHP et Ruby populaires, mentionnés pour la même
+raison « si vous avez utilisé ceci, cela vous semblera familier ».

--- a/docs/fr/html-views.md
+++ b/docs/fr/html-views.md
@@ -1,0 +1,334 @@
+# Vues HTML — pages rendues côté serveur
+
+Une vue HTML transforme un modèle en **pages web rendues côté serveur** — une
+page de liste, une page de détail, et des formulaires de création/édition/suppression — à partir
+d'une seule déclaration. C'est le **pendant des [ViewSets](viewsets.md)** : là où un ViewSet émet
+du JSON pour des clients d'API, une vue HTML émet une page rendue pour un navigateur. Les deux sont
+construits à partir du même `#[derive(Model)]`, et vous pouvez servir un modèle des *deux* façons à
+la fois.
+
+Ce sont l'équivalent dans **Rustango** des vues génériques basées sur les classes de Django
+(`ListView`, `DetailView`, `CreateView`, `UpdateView`, `DeleteView`) ou des contrôleurs de
+ressources de Laravel qui renvoient des vues Blade. Elles effectuent leur rendu via des templates
+[Tera](https://keats.github.io/tera/).
+
+[![Les vues HTML dans Rustango : un modèle alimente ListView, DetailView et CreateView/UpdateView/DeleteView, chacune effectuant le rendu d'un template Tera en une page rendue côté serveur](img/html-views.png)](img/html-views.png)
+
+> **Un terme vous est inconnu ?** Si *modèle*, *template*, *routeur* ou *rendu côté serveur* ne
+> vous sont pas familiers, le [glossaire](glossary.md) explique chacun d'eux en langage simple.
+
+> **Source :** `rustango::template_views` (`ListView`, `DetailView`, `CreateView`,
+> `UpdateView`, `DeleteView`, `TemplateView`, `RedirectView`) — derrière la
+> fonctionnalité `template_views` (activée par défaut).
+>
+> **Version exécutable :** l'exemple API-vs-HTML ci-dessous est fixé par le
+> test du framework
+> [`html_and_api_contrast_sqlite_live.rs`](../crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
+> (`cargo test -p rustango --features sqlite --test html_and_api_contrast_sqlite_live`).
+> Les vues individuelles sont couvertes par `template_view.rs` et
+> `template_views_context_object_name_sqlite_live.rs`.
+
+## Table des matières
+
+- [Vues API vs vues HTML — laquelle vous faut-il ?](#api-views-vs-html-views--which-do-you-want)
+- [Les cinq vues de modèle](#the-five-model-views)
+- [ListView](#listview) · [DetailView](#detailview)
+- [CreateView, UpdateView, DeleteView](#createview-updateview-deleteview)
+- [Le contexte Tera](#the-tera-context)
+- [TemplateView et RedirectView](#templateview-and-redirectview)
+- [Mono-locataire vs multi-locataire](#single-tenant-vs-multi-tenant)
+- [Servir un modèle des deux façons](#serving-one-model-both-ways)
+- [Voir aussi](#see-also)
+
+---
+
+## Vues API vs vues HTML — laquelle vous faut-il ?
+
+C'est la première décision. Les deux transforment un modèle en points d'accès ; elles diffèrent par
+*ce qui en ressort* et *qui appelle*.
+
+| | **Vue API** — [ViewSet](viewsets.md) | **Vue HTML** — ce guide |
+|---|---|---|
+| Module | `rustango::viewset` | `rustango::template_views` |
+| Renvoie | des **données JSON** | une **page HTML rendue côté serveur** |
+| Conçue pour | SPA, applications mobiles, autres services | navigateurs, sites rendus côté serveur, CRUD façon admin |
+| Une « création » | `POST` JSON → `201` + le nouvel objet | `POST` d'un formulaire → redirection `303` vers une page de succès |
+| En cas d'entrée invalide | `400` + une carte d'erreurs JSON indexée par champ | re-rend le formulaire avec les erreurs affichées |
+| Lit une liste comme | une enveloppe JSON paginée | un `<table>`/une boucle dans votre template |
+| Authentifiée en général par | jetons / JWT / clés d'API | cookies de session |
+| Équivalent Django | DRF `ModelViewSet` | vues génériques basées sur les classes |
+
+Vous n'avez pas à choisir globalement — choisissez par ressource, et vous pouvez monter **les deux
+sur le même modèle** (voir [ci-dessous](#serving-one-model-both-ways)). Règles empiriques :
+
+- Vous construisez un **backend JSON** pour un framework frontend ou une application mobile → ViewSet.
+- Vous construisez un **site rendu côté serveur** (le serveur renvoie des pages HTML) → vues
+  HTML.
+- Vous avez besoin des deux (une API publique *et* des pages CRUD internes) → montez les deux.
+
+> Vous cherchez le côté JSON ? Il a son propre approfondissement : [ViewSets — API REST
+> CRUD](viewsets.md).
+
+---
+
+## Les cinq vues de modèle
+
+Chaque vue est `for_model(SCHEMA)` plus un `.router(prefix, tera, pool)`. Les monter au même
+`prefix` (disons `/posts`) donne l'ensemble d'URL CRUD classique :
+
+| Vue | Rend | Routes montées | Template par défaut |
+|---|---|---|---|
+| [`ListView`](#listview) | une liste paginée | `GET <prefix>` | `<table>_list.html` |
+| [`DetailView`](#detailview) | une ligne | `GET <prefix>/{pk}` | `<table>_detail.html` |
+| [`CreateView`](#createview-updateview-deleteview) | un formulaire de nouvel enregistrement | `GET`/`POST <prefix>/new` | `<table>_form.html` |
+| [`UpdateView`](#createview-updateview-deleteview) | un formulaire d'édition prérempli | `GET`/`POST <prefix>/{pk}/edit` | `<table>_form.html` |
+| [`DeleteView`](#createview-updateview-deleteview) | une page de confirmation | `GET`/`POST <prefix>/{pk}/delete` | `<table>_confirm_delete.html` |
+
+`<table>` est le nom de la table du modèle, donc un `Post` (table `posts`) recherche
+`posts_list.html`, `posts_detail.html`, et ainsi de suite. Remplacez n'importe lequel d'entre eux
+avec `.template("my_name.html")`.
+
+---
+
+## ListView
+
+Une page de liste paginée. Vous fournissez un template qui boucle sur `object_list` ; la vue gère
+la pagination, le tri, le filtrage et la recherche à partir des paramètres de requête.
+
+```rust
+use rustango::template_views::ListView;
+use std::sync::Arc;
+use tera::Tera;
+
+let app = ListView::for_model(Post::SCHEMA)
+    .page_size(20)                       // rows per page (?page=N to navigate)
+    .order_by("published_at", true)      // default sort, true = DESC
+    .filter_fields(&["status", "author_id"])  // ?status=published
+    .search_fields(&["title", "body"])        // ?search=rust
+    .router("/posts", Arc::new(tera), pool);
+```
+
+Un `posts_list.html` correspondant — notez `object_list` et les variables de pagination que la vue
+estampille pour vous :
+
+```html
+<h1>Posts ({{ total }})</h1>
+{% for post in object_list %}
+  <article>
+    <h2><a href="/posts/{{ post.id }}">{{ post.title }}</a></h2>
+    <p>{{ post.body }}</p>
+  </article>
+{% endfor %}
+
+{% if has_prev %}<a href="?page={{ page - 1 }}">← prev</a>{% endif %}
+page {{ page }} / {{ total_pages }}
+{% if has_next %}<a href="?page={{ page + 1 }}">next →</a>{% endif %}
+```
+
+`?page=`, `?status=`, `?search=` et `?ordering=` fonctionnent de la même façon que sur une liste
+ViewSet — la différence tient uniquement au fait que le résultat est une page rendue plutôt qu'une
+enveloppe JSON. Utilisez `.context_object_name("posts")` si vous préférez boucler sur `posts`
+plutôt que sur `object_list` dans le template.
+
+---
+
+## DetailView
+
+Une ligne, recherchée à partir de l'URL. Par défaut elle correspond à la clé primaire
+(`/posts/42`) ; pointez-la vers une autre colonne avec `.lookup_field("slug")` pour des URL jolies
+(`/posts/my-first-post`). Une ligne manquante est un `404`.
+
+```rust
+use rustango::template_views::DetailView;
+
+let app = DetailView::for_model(Post::SCHEMA)
+    .lookup_field("slug")          // GET /posts/{slug} instead of /posts/{id}
+    .router("/posts", Arc::new(tera), pool);
+```
+
+Le template reçoit la ligne sous le nom `object` :
+
+```html
+<h1>{{ object.title }}</h1>
+<p>{{ object.body }}</p>
+<small>by author #{{ object.author_id }}</small>
+```
+
+---
+
+## CreateView, UpdateView, DeleteView
+
+Le côté écriture. Chacune gère un `GET` (rendre un formulaire / une page de confirmation) et un
+`POST` (faire le travail, puis **rediriger**). La redirection-après-POST est le motif standard
+**Post/Redirect/Get** — il empêche qu'un rafraîchissement du navigateur ne re-soumette.
+
+**CreateView** — `GET /posts/new` rend un formulaire vide ; `POST /posts/new`
+insère la ligne et fait un `303` vers `success_url` :
+
+```rust
+use rustango::template_views::CreateView;
+
+let app = CreateView::for_model(Post::SCHEMA)
+    .success_url("/posts")         // where to send the browser after a save
+    .router("/posts", Arc::new(tera), pool);
+```
+
+Le template de formulaire (`posts_form.html`) est partagé avec UpdateView. `is_update`
+distingue les deux, et `errors` ramène les éventuels messages de validation :
+
+```html
+<form method="post">
+  <input name="title" value="{{ object.title | default(value='') }}">
+  <textarea name="body">{{ object.body | default(value='') }}</textarea>
+  {% for field, msgs in errors %}
+    <p class="error">{{ field }}: {{ msgs | join(sep=', ') }}</p>
+  {% endfor %}
+  <button>{% if is_update %}Save{% else %}Create{% endif %}</button>
+</form>
+```
+
+**Validation.** Les règles de schéma (type, `max_length`, NOT NULL…) sont appliquées
+automatiquement. Ajoutez les vôtres avec un validateur en closure — en cas d'`Err`, le formulaire
+est re-rendu avec les messages et un statut `422` au lieu d'être enregistré :
+
+```rust
+use rustango::forms::FormErrors;
+
+CreateView::for_model(Post::SCHEMA)
+    .validator(|data| {
+        let mut errs = FormErrors::default();
+        if data.get("title").map_or(true, |t| t.len() < 5) {
+            errs.add("title", "must be at least 5 characters");
+        }
+        if errs.is_empty() { Ok(()) } else { Err(errs) }
+    })
+    .success_url("/posts")
+    .router("/posts", Arc::new(tera), pool);
+```
+
+Vous pouvez aussi réutiliser les validateurs d'une structure `#[derive(Form)]` avec `.form::<F>()`
+(validation seulement pour l'instant — voir la documentation de l'API).
+
+**UpdateView** — `GET /posts/{pk}/edit` rend le même formulaire prérempli à partir de la
+ligne (`object` est renseigné, `is_update` vaut `true`) ; `POST` met à jour et fait un `303`.
+
+```rust
+use rustango::template_views::UpdateView;
+
+UpdateView::for_model(Post::SCHEMA)
+    .success_url("/posts")
+    .router("/posts", Arc::new(tera), pool);
+```
+
+**DeleteView** — `GET /posts/{pk}/delete` rend une page de confirmation
+(`posts_confirm_delete.html`, avec `object`) ; `POST` supprime et fait un `303`.
+
+```rust
+use rustango::template_views::DeleteView;
+
+DeleteView::for_model(Post::SCHEMA)
+    .success_url("/posts")
+    .router("/posts", Arc::new(tera), pool);
+```
+
+Montez les cinq au même préfixe et vous avez un CRUD HTML complet :
+
+```rust
+let app = axum::Router::new()
+    .merge(ListView::for_model(Post::SCHEMA).router("/posts", tera.clone(), pool.clone()))
+    .merge(DetailView::for_model(Post::SCHEMA).router("/posts", tera.clone(), pool.clone()))
+    .merge(CreateView::for_model(Post::SCHEMA).success_url("/posts").router("/posts", tera.clone(), pool.clone()))
+    .merge(UpdateView::for_model(Post::SCHEMA).success_url("/posts").router("/posts", tera.clone(), pool.clone()))
+    .merge(DeleteView::for_model(Post::SCHEMA).success_url("/posts").router("/posts", tera, pool));
+```
+
+---
+
+## Le contexte Tera
+
+Chaque vue estampille un contexte cohérent afin que les templates se portent proprement de l'une à
+l'autre :
+
+| Vue | Variables disponibles dans le template |
+|---|---|
+| `ListView` | `object_list` (les lignes de la page), `page`, `page_size`, `total`, `total_pages`, `has_next`, `has_prev` |
+| `DetailView` | `object` (la ligne) |
+| `CreateView` / `UpdateView` | `object` (vide à la création, prérempli à la mise à jour), `is_update` (bool), `errors`, `values` |
+| `DeleteView` | `object` (la ligne à confirmer) |
+
+Les lignes sont exposées sous forme de simples maps indexées par nom de colonne (`{{ post.title }}`),
+avec le `NULL` SQL rendu en `null`. Utilisez `.context_object_name("posts" / "post")` pour
+ajouter un alias plus convivial à côté de `object_list` / `object`.
+
+---
+
+## TemplateView et RedirectView
+
+Deux helpers sans modèle pour les pages que tout site possède :
+
+**TemplateView** — rend un template statique avec un contexte fixe (une page « à propos », une page
+d'atterrissage). Pas de modèle, pas de base de données :
+
+```rust
+use rustango::template_views::TemplateView;
+
+let app = TemplateView::new("about.html")
+    .context_value("title", "About us")
+    .router("/about", Arc::new(tera));
+```
+
+**RedirectView** — une redirection permanente ou temporaire sur une URL (pour les pages déplacées) :
+
+```rust
+use rustango::template_views::RedirectView;
+
+let app = RedirectView::to("/posts").router("/old-posts");
+```
+
+---
+
+## Mono-locataire vs multi-locataire
+
+Chaque vue de modèle est livrée avec deux constructeurs de routeur — même builder, choisissez celui
+qui correspond à la façon dont votre application gère les connexions à la base de données :
+
+- **`.router(prefix, tera, pool)`** — mono-locataire ; capture un pool unique au moment du montage.
+  C'est ce qu'utilisent les exemples ci-dessus.
+- **`.tenant_router(prefix, tera)`** — multi-locataire ; résout une connexion par requête à partir
+  de l'extracteur [`Tenant`](https://docs.rs). Disponible avec les fonctionnalités
+  `template_views` + `tenancy`. Les templates se portent inchangés de l'une à l'autre.
+
+Cela reflète la séparation des ViewSets (`router` / `router_pool` vs `tenant_router`).
+
+---
+
+## Servir un modèle des deux façons
+
+Vous n'êtes pas limité à une seule porte d'entrée. Montez une API JSON *et* des pages HTML sur le
+même modèle et le même pool — une API publique pour les clients, des pages rendues côté serveur
+pour les personnes :
+
+```rust
+use rustango::viewset::ViewSet;
+use rustango::template_views::{ListView, DetailView};
+
+let app = axum::Router::new()
+    // JSON for API clients:
+    .merge(ViewSet::for_model(Post::SCHEMA).router_pool("/api/posts", pool.clone()))
+    // HTML pages for browsers:
+    .merge(ListView::for_model(Post::SCHEMA).router("/posts", tera.clone(), pool.clone()))
+    .merge(DetailView::for_model(Post::SCHEMA).router("/posts", tera, pool));
+```
+
+Maintenant `GET /api/posts` renvoie l'enveloppe JSON paginée et `GET /posts`
+renvoie une liste HTML rendue — mêmes lignes, même pool, deux formes. Cette configuration exacte est
+ce qu'affirme le [test de support](../crates/rustango/tests/html_and_api_contrast_sqlite_live.rs).
+
+---
+
+## Voir aussi
+
+- [ViewSets — API REST CRUD](viewsets.md) — le pendant JSON/API, en profondeur.
+- [Admin](admin.md) — l'admin auto-généré est construit sur ces mêmes vues.
+- [URL & routage](urls.md) — comment composer ces routeurs dans votre application.
+- [Sérialiseurs](serializers.md) — façonnez le JSON quand vous prenez la voie de l'API.

--- a/docs/fr/jobs.md
+++ b/docs/fr/jobs.md
@@ -1,0 +1,384 @@
+# Tâches d'arrière-plan
+
+Certains travaux ne devraient pas avoir lieu pendant une requête — envoyer un
+e-mail de bienvenue, redimensionner un fichier importé, synchroniser une API
+tierce. Le faire en ligne fait attendre l'utilisateur et couple la réponse à un
+appel externe instable. Une **tâche d'arrière-plan** déplace ce travail sur une
+file : le handler retourne immédiatement, et un pool de workers exécute la tâche
+quelques instants plus tard, avec des **nouvelles tentatives automatiques** et
+un chemin **dead-letter** pour les échecs. C'est Django-Q / Celery / les queues
+de Laravel, en Rust.
+
+[![Background jobs in Rustango: a handler dispatches a Job onto a queue, worker tasks run it, retryable failures back off and retry, fatal ones go to a dead-letter handler](img/jobs.png)](img/jobs.png)
+
+> **Un terme vous est inconnu ?** *file*, *worker*, *nouvelle tentative/backoff*,
+> *dead-letter* — voir le [glossaire](glossary.md).
+
+> **Source :** `rustango::jobs` (`Job`, `JobQueue`, `InMemoryJobQueue`,
+> `JobError`, `JobDeadLetter`) et `rustango::jobs::DatabaseJobQueue` (la file
+> adossée à une table, alias de `pg::PgJobQueue`) — derrière la feature `jobs`
+> (activée par défaut).
+>
+> **Version exécutable :** les extraits in-memory, nouvelle tentative et
+> dead-letter sont copiés depuis [`jobs_doc.rs`](../crates/rustango/tests/jobs_doc.rs)
+> (`cargo test -p rustango --test jobs_doc`) ; la file persistante est
+> éprouvée en dogfooding sur SQLite par
+> [`jobs_sqlite_live.rs`](../crates/rustango/tests/jobs_sqlite_live.rs)
+> (`cargo test -p rustango --features sqlite,jobs-postgres --test jobs_sqlite_live`).
+
+## Table des matières
+
+- [Étape 1 — Définir une tâche](#step-1--define-a-job)
+- [Étape 2 — Démarrer une file](#step-2--start-a-queue)
+- [Étape 3 — Dispatcher depuis un handler](#step-3--dispatch-from-a-handler)
+- [Étape 4 — Câbler dans votre application](#step-4--wire-it-into-your-app) — l'exemple complet
+- [Faire tourner les workers (CLI + production)](#running-the-workers-cli--production)
+- [Nouvelles tentatives et backoff](#retries-and-backoff)
+- [Le handler dead-letter](#the-dead-letter-handler)
+- [La file persistante (production)](#the-persistent-queue-production)
+- [Référence](#reference)
+- [Voir aussi](#see-also)
+
+---
+
+## Étape 1 — Définir une tâche
+
+Une tâche est une structure sérialisable qui implémente `Job`. La charge utile
+est ce qui est mis en file (sérialisé en JSON) ; `run()` est le travail. `NAME`
+route une charge utile mise en file vers son handler, il doit donc être unique.
+
+Générez un squelette avec la CLI — `cargo run -- make:job WelcomeEmail` — ou
+écrivez-le à la main :
+
+```rust
+use rustango::jobs::{Job, JobError};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct WelcomeEmail {
+    user_id: i64,
+}
+
+#[async_trait::async_trait]   // add `async-trait` to your Cargo.toml
+impl Job for WelcomeEmail {
+    const NAME: &'static str = "welcome_email";
+
+    async fn run(&self) -> Result<(), JobError> {
+        // ... look up the user and send the email
+        Ok(())
+    }
+}
+```
+
+`run()` retourne :
+
+- `Ok(())` — terminé.
+- `Err(JobError::Retryable(msg))` — transitoire ; le worker réessaie avec
+  backoff.
+- `Err(JobError::Fatal(msg))` — permanent ; passe les nouvelles tentatives,
+  dead-letter immédiatement.
+
+Surchargez `const MAX_ATTEMPTS: u32 = 3;` sur l'impl pour changer le plafond de
+nouvelles tentatives (5 par défaut).
+
+---
+
+## Étape 2 — Démarrer une file
+
+Pour un processus unique (et pour le dev et les tests), `InMemoryJobQueue`
+exécute les tâches sur des tâches worker tokio — sans base de données.
+**Enregistrez chaque type de tâche, puis `start()` les workers** (les tâches ne
+sont pas prises en charge tant que vous ne le faites pas) :
+
+```rust
+use rustango::jobs::{InMemoryJobQueue, JobQueue};
+use std::sync::Arc;
+
+let queue = Arc::new(InMemoryJobQueue::with_workers(4));   // 4 worker tasks
+queue.register::<WelcomeEmail>().await;                    // before start/dispatch
+queue.start().await;
+
+// ... app runs ...
+
+queue.shutdown().await;   // on shutdown: drain in-flight jobs, then stop
+```
+
+Conservez le `Arc<InMemoryJobQueue>` dans l'état de votre application pour que
+les handlers puissent l'atteindre.
+
+> **In-memory signifie in-memory.** Les tâches en file ou en cours sont
+> **perdues au redémarrage**. Pour tout ce que vous ne pouvez pas vous permettre
+> de perdre, utilisez la [file persistante](#the-persistent-queue-production).
+
+---
+
+## Étape 3 — Dispatcher depuis un handler
+
+Une fois la file en marche, le dispatch tient en un appel — il met en file et
+retourne immédiatement, de sorte que la requête n'attend pas le travail :
+
+```rust
+queue.dispatch(&WelcomeEmail { user_id: 42 }).await?;
+```
+
+Un worker la prend en charge et exécute `run()` quelques instants plus tard.
+Vérifié de bout en bout : les trois tâches dispatchées s'exécutent toutes sur
+les workers.
+
+```rust
+for user_id in 1..=3 {
+    queue.dispatch(&WelcomeEmail { user_id }).await.unwrap();
+}
+// → all three WelcomeEmail::run() calls execute on the worker pool
+```
+
+---
+
+## Étape 4 — Câbler dans votre application
+
+En assemblant les étapes 1 à 3 : construisez la file et enregistrez chaque tâche
+**une seule fois au démarrage**, lancez les workers, remettez la file à vos
+routes pour que les handlers puissent l'atteindre, puis drainez à l'arrêt. La
+file vit dans votre `main.rs` :
+
+```rust
+// src/main.rs
+use std::sync::Arc;
+use rustango::jobs::{InMemoryJobQueue, JobQueue};
+use rustango::manage::Cli;
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Build the queue + register every job type BEFORE starting workers.
+    let queue = Arc::new(InMemoryJobQueue::with_workers(4));
+    queue.register::<WelcomeEmail>().await;
+    queue
+        .on_dead_letter(|dl| async move {
+            tracing::error!(job = dl.name, attempts = dl.attempts, error = %dl.error,
+                            "job dead-lettered");
+        })
+        .await;
+
+    // 2. Start the workers — tokio tasks that run inside THIS process.
+    queue.start().await;
+
+    // 3. Share the queue with handlers (axum extension/state).
+    let app = urls::api().layer(axum::Extension(queue.clone()));
+
+    // 4. Boot the server. Cli::run() blocks until Ctrl-C / SIGTERM.
+    Cli::new().api(app).with_health().run().await?;
+
+    // 5. On shutdown: drain in-flight jobs, then stop.
+    queue.shutdown().await;
+    Ok(())
+}
+```
+
+Un handler dispatche en relisant la file depuis la requête :
+
+```rust
+use axum::Extension;
+use std::sync::Arc;
+use rustango::jobs::{InMemoryJobQueue, JobQueue};
+
+async fn signup(Extension(queue): Extension<Arc<InMemoryJobQueue>>) -> StatusCode {
+    // ... create the user ...
+    queue.dispatch(&WelcomeEmail { user_id: 42 }).await.ok();  // returns instantly
+    StatusCode::CREATED
+}
+```
+
+> **Stockez le type de file concret.** Le trait `JobQueue` n'est **pas
+> object-safe** (ses `register`/`dispatch` sont génériques), donc vous ne pouvez
+> pas conserver `Arc<dyn JobQueue>` dans l'état — gardez le
+> `Arc<InMemoryJobQueue>` concret (ou `Arc<DatabaseJobQueue>`).
+
+---
+
+## Faire tourner les workers (CLI + production)
+
+`start()` spawn les workers en tant que **tâches tokio à l'intérieur du
+processus courant**. Ainsi, quand vous lancez votre application avec la CLI —
+`cargo run` (qui exécute le serveur) — les workers tournent juste à côté de lui.
+Pour la plupart des applications, c'est tout ce dont vous avez besoin : **un seul
+processus sert les requêtes *et* draine la file** ; il n'y a pas de commande
+worker distincte.
+
+```bash
+cargo run                 # starts the server AND the in-process workers
+cargo run -- make:job WelcomeEmail   # scaffold a new job type
+```
+
+### Un processus worker dédié (production)
+
+À l'échelle, vous voulez souvent des workers **séparés** de la couche web — pour
+qu'un pic de trafic ne puisse pas affamer les tâches, et que vous mettiez à
+l'échelle chacun indépendamment. Avec la [file
+persistante](#the-persistent-queue-production), chaque processus tire de la même
+table `rustango_jobs`, donc lancez simplement un second binaire, sans serveur,
+qui construit la file, la démarre, et bloque jusqu'à un signal :
+
+```rust
+// src/bin/worker.rs — run with `cargo run --bin worker`
+use std::sync::Arc;
+use rustango::jobs::{DatabaseJobQueue, JobQueue};
+
+#[rustango::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pool = /* connect your tri-dialect Pool */;
+    DatabaseJobQueue::ensure_table_pool(&pool).await?;
+
+    let queue = Arc::new(DatabaseJobQueue::with_workers_pool(pool, 8));
+    queue.register::<WelcomeEmail>().await;   // register the SAME job types
+    queue.start().await;
+
+    tokio::signal::ctrl_c().await?;            // block until Ctrl-C / SIGTERM
+    queue.shutdown().await;                     // drain in-flight, then exit
+    Ok(())
+}
+```
+
+Déployez-le comme son propre conteneur/service et mettez-le à l'échelle sur **N
+réplicas** — ils tirent tous de la table partagée en toute sécurité. Le
+processus web n'a alors besoin que de `dispatch` (il n'a pas à `start()` de
+workers). Associez le worker à un balayage périodique
+[`reclaim_stuck_jobs_pool`](#the-persistent-queue-production) pour récupérer les
+tâches d'un worker crashé.
+
+---
+
+## Nouvelles tentatives et backoff
+
+Une tâche qui retourne `Retryable` est remise en file avec un **backoff
+exponentiel** (1s, 2s, 4s, 8s, …) jusqu'à `MAX_ATTEMPTS`. Utilisez-le pour les
+échecs transitoires — un timeout, une API rate-limitée, un deadlock :
+
+```rust
+#[async_trait::async_trait]
+impl Job for FlakyImport {
+    const NAME: &'static str = "flaky_import";
+    async fn run(&self) -> Result<(), JobError> {
+        match call_external_api().await {
+            Ok(_)  => Ok(()),
+            Err(e) => Err(JobError::Retryable(e.to_string())),   // try again later
+        }
+    }
+}
+```
+
+Le test sous-jacent dispatche une tâche qui échoue une fois puis réussit, et
+affirme qu'elle **s'est exécutée plus d'une fois et a fini par réussir** — la
+nouvelle tentative a bien lieu.
+
+---
+
+## Le handler dead-letter
+
+Quand une tâche épuise ses nouvelles tentatives — ou retourne `Fatal`
+immédiatement — elle est remise au callback **dead-letter** au lieu de
+disparaître. Enregistrez-en un (avant `start`) pour journaliser, alerter, ou
+persister l'échec :
+
+```rust
+queue
+    .on_dead_letter(|dl| async move {
+        // dl: JobDeadLetter { name, payload, attempts, error }
+        tracing::error!(job = dl.name, attempts = dl.attempts, error = %dl.error,
+                        "job dead-lettered");
+    })
+    .await;
+```
+
+Une erreur `Fatal` passe les nouvelles tentatives et atterrit ici dès la
+première tentative :
+
+```rust
+async fn run(&self) -> Result<(), JobError> {
+    Err(JobError::Fatal("unprocessable payload".into()))   // → dead-letter now
+}
+```
+
+Le test confirme que le callback se déclenche exactement une fois pour une tâche
+`Fatal`, avec le `name` et l'`error` de la tâche intacts.
+
+---
+
+## La file persistante (production)
+
+`InMemoryJobQueue` est mono-processus et oublie tout au redémarrage. Pour de
+vrais déploiements — plusieurs workers, plusieurs réplicas, des tâches qui
+doivent survivre à un crash — utilisez **`DatabaseJobQueue`** (le même type que
+`PgJobQueue`). Les tâches vivent dans une table `rustango_jobs` ; les workers
+les prennent en charge avec un `UPDATE … RETURNING` borné par une transaction,
+donc c'est sûr entre processus. Elle est **tri-dialecte** (PostgreSQL, MySQL,
+SQLite). Les définitions `Job` de l'étape 1 sont inchangées.
+
+```rust
+use rustango::jobs::DatabaseJobQueue;   // = rustango::jobs::pg::PgJobQueue
+use rustango::jobs::JobQueue;
+use std::sync::Arc;
+use std::time::Duration;
+
+// 1. Create the jobs table once at boot (idempotent, tri-dialect).
+DatabaseJobQueue::ensure_table_pool(&pool).await?;
+
+// 2. Build the queue over your pool + N workers, and start it.
+let queue = Arc::new(
+    DatabaseJobQueue::with_workers_pool(pool.clone(), 4)
+        .poll_interval(Duration::from_millis(50)),
+);
+queue.register::<WelcomeEmail>().await;
+queue.start().await;
+
+// 3. Dispatch exactly as before — now it's durable.
+queue.dispatch(&WelcomeEmail { user_id: 42 }).await?;
+```
+
+**Récupérer les workers crashés.** Si un worker meurt en cours de tâche, la
+ligne reste verrouillée. Lancez un balayage périodique pour relâcher les verrous
+plus anciens qu'un seuil afin qu'un autre worker reprenne la tâche :
+
+```rust
+// e.g. from a scheduled task every few minutes:
+let reclaimed = DatabaseJobQueue::reclaim_stuck_jobs_pool(&pool, Duration::from_secs(300)).await?;
+```
+
+Le flux dispatch-and-run et `reclaim_stuck_jobs_pool` sont tous deux éprouvés en
+dogfooding contre SQLite dans `jobs_sqlite_live.rs`.
+
+---
+
+## Référence
+
+**Backends**
+
+| Backend | À utiliser pour | Survit au redémarrage ? |
+|---|---|---|
+| `InMemoryJobQueue` | processus unique, dev, tests | non |
+| `DatabaseJobQueue` (`PgJobQueue`) | production ; multi-worker / multi-réplica | oui (table `rustango_jobs`) |
+
+**`JobError`**
+
+| Variante | Effet |
+|---|---|
+| `Retryable(String)` | remise en file avec backoff exponentiel, jusqu'à `MAX_ATTEMPTS` |
+| `Fatal(String)` | passe les nouvelles tentatives → dead-letter immédiatement |
+| `Queue(String)` | erreur de file interne (sérialisation/enregistrement) |
+
+**Méthodes de `JobQueue` :** `register::<T>()` · `dispatch(&payload)` · `start()` ·
+`shutdown()` · `pending_count()`. `DatabaseJobQueue` ajoute
+`ensure_table_pool`, `with_workers_pool`, `poll_interval`, et
+`reclaim_stuck_jobs_pool`.
+
+---
+
+## Voir aussi
+
+- [Planificateur](manage.md) — pour le travail récurrent *basé sur le temps*
+  (façon cron), par opposition aux tâches à la demande.
+- [E-mail](email.md) — la charge de travail canonique du « faites-le dans une
+  tâche ».
+- [Mise en cache](caching.md) — l'autre manière de garder les handlers de
+  requêtes rapides.
+- [Signals](orm.md) — des hooks fire-and-forget qui *dispatchent* souvent une
+  tâche.

--- a/docs/fr/mcp.md
+++ b/docs/fr/mcp.md
@@ -1,0 +1,479 @@
+# Serveur MCP
+
+Le **Model Context Protocol (MCP)** est le standard ouvert qui permet à un agent
+IA — Claude, un assistant d'IDE, votre propre application LLM — d'appeler en toute
+sécurité les **tools** de *votre* application, de lire ses **resources** et
+d'utiliser ses **prompts**. **Rustango** fournit un serveur MCP prêt pour la
+production : enregistrez un tool avec une seule macro, montez un routeur, et
+n'importe quel client MCP peut le découvrir et l'appeler via le transport
+JSON-RPC standard — avec une autorisation **fail-closed** par agent et OAuth 2.1
+intégrés.
+
+[![Serveur MCP dans Rustango : un agent LLM se connecte via JSON-RPC + SSE ; le serveur authentifie le JWT de l'agent, ne liste que les tools que ses skills accordés autorisent, et exécute le handler du tool contre le pool de votre application](img/mcp.png)](img/mcp.png)
+
+> **Nouveau ici ?** *MCP*, *JSON-RPC*, *tool/resource/prompt*, *agent*,
+> *JWT*, *OAuth* — voir le [glossaire](glossary.md).
+
+> **Source :** `rustango::mcp` (`router`, `tenant_router`, `secure_tenant_router`,
+> `secure_tenant_router_from_settings`, `register_mcp_tool!`,
+> `register_mcp_resource!`, `McpContext`, `issue_agent_token`) et les helpers
+> agent/skill de `rustango::tenancy` — derrière la **feature `mcp`** (désactivée
+> par défaut ; tire `tenancy, sse, serializer, openapi, jwt`).
+>
+> **Version exécutable :** chaque extrait est copié depuis
+> [`mcp_doc.rs`](../crates/rustango/tests/mcp_doc.rs)
+> (`cargo test -p rustango --features sqlite,mcp --test mcp_doc`) ; toute la
+> surface protocolaire est testée en conditions réelles par la suite
+> `crates/rustango/tests/mcp_*.rs`, et un serveur exécutable se trouve dans
+> [`examples/mcp_demo`](../crates/rustango/examples/mcp_demo).
+
+## Table des matières
+
+- [Ce que MCP vous apporte](#what-mcp-gives-you)
+- [Étape 1 — Activer la feature](#step-1--enable-the-feature)
+- [Étape 2 — Définir un tool](#step-2--define-a-tool)
+- [Étape 3 — Monter le serveur](#step-3--mount-the-server)
+- [Étape 4 — Autoriser les agents](#step-4--authorize-agents)
+- [Le protocole](#the-protocol)
+- [Réglages](#settings)
+- [Comment tester](#how-to-test) — [la suite](#a-the-test-suite) · [curl](#b-curl-the-json-rpc) · [le MCP Inspector visuel](#c-test-it-visually-with-the-mcp-inspector) · [un vrai client](#d-connect-a-real-mcp-client)
+- [Build optionnel vs. par défaut](#optional-vs-default-build)
+- [Voir aussi](#see-also)
+
+---
+
+## Ce que MCP vous apporte
+
+Un serveur MCP **Rustango** expose trois choses qu'un agent peut utiliser, toutes
+**enregistrées à la main pour un contrôle explicite** (rien n'est auto-exposé) :
+
+| Primitive | Ce que c'est | Comment c'est déclaré |
+|---|---|---|
+| **Tool** | une fonction que l'agent appelle (avec des arguments JSON typés) | `register_mcp_tool!` |
+| **Resource** | du contenu lisible que l'agent récupère par URI | `register_mcp_resource!` + attaché à un skill |
+| **Prompt** | un modèle d'instruction réutilisable | dérivé d'un **skill** accordé |
+
+Chaque appel est **autorisé par agent** : le JWT d'un agent porte les **skills**
+(et les tools qu'ils débloquent) qui lui ont été accordés, et `tools/list` /
+`tools/call` **échouent de manière fermée** — un agent ne voit jamais et
+n'exécute jamais un tool qui ne lui a pas été accordé.
+
+---
+
+## Étape 1 — Activer la feature
+
+MCP est la feature optionnelle `mcp` (désactivée par défaut). Activez-la :
+
+```toml
+# Cargo.toml
+rustango = { version = "0.44", features = ["mcp"] }
+```
+
+Elle tire `tenancy` (agents/skills), `sse` (le flux de notifications),
+`serializer` + `openapi` (les schémas d'entrée des tools) et `jwt` (les tokens
+d'agent). Un build **sans** la feature ne compile aucune partie du module MCP —
+voir [Build optionnel vs. par défaut](#optional-vs-default-build).
+
+---
+
+## Étape 2 — Définir un tool
+
+Un tool est une struct d'entrée typée + un handler async, enregistré à la
+compilation avec `register_mcp_tool!`. Le type d'entrée dérive
+`serde::Deserialize` et implémente `OpenApiSchema` (qui devient le JSON Schema
+publié du tool) :
+
+```rust
+use rustango::mcp::{McpContext, McpError};
+use serde_json::json;
+
+rustango::register_mcp_tool!(
+    "add",
+    "Add two integers",
+    AddInput,
+    |_ctx: McpContext, input: AddInput| async move {
+        Ok::<_, McpError>(json!({ "sum": input.a + input.b }))
+    },
+);
+
+#[derive(serde::Deserialize)]
+struct AddInput { a: i64, b: i64 }
+
+impl rustango::openapi::OpenApiSchema for AddInput {
+    fn openapi_schema() -> rustango::openapi::Schema {
+        rustango::openapi::Schema::object()
+            .property("a", rustango::openapi::Schema::integer())
+            .property("b", rustango::openapi::Schema::integer())
+            .required(["a", "b"])
+    }
+}
+```
+
+Le handler reçoit un `McpContext { pool, agent, progress, cancel }` — le pool DB
+du tenant, l'agent authentifié, un rapporteur de progression et un token
+d'annulation — de sorte qu'un tool peut interroger vos modèles, rapporter la
+progression d'un travail long et abandonner sur annulation. Retournez n'importe
+quel `serde_json::Value` (il est exposé comme le `structuredContent` du tool) ou
+un `McpError`.
+
+Les **resources** sont du contenu statique enregistré de la même façon :
+
+```rust
+rustango::register_mcp_resource!(
+    "rustango://about", "About", "text/plain",
+    || "This server exposes the demo tools.".to_string(),
+);
+```
+
+Les **prompts** proviennent des **skills** (étape suivante) — les instructions
+d'un skill deviennent un prompt que l'agent peut récupérer.
+
+---
+
+## Étape 3 — Monter le serveur
+
+Choisissez un montage adapté à votre déploiement ; tous retournent un
+`axum::Router` que vous imbriquez sous un préfixe (conventionnellement `/mcp`) :
+
+| Montage | Multi-tenancy | Auth | À utiliser pour |
+|---|---|---|---|
+| `mcp::router(pool)` | mono-tenant | aucune | transport seul (`initialize`/`ping`) |
+| `mcp::tenant_router()` | multi-tenant | aucune | transport seul (pool par requête) |
+| `mcp::secure_tenant_router()` | multi-tenant | **JWT d'agent** | la vraie affaire |
+| `mcp::secure_tenant_router_from_settings(&s)` | multi-tenant | JWT d'agent | production (CORS, rate-limit, SSE, plafond de corps depuis `[mcp]`) |
+
+Les tools requièrent le chemin **authentifié** (un contexte d'agent), donc les
+serveurs de production utilisent `secure_tenant_router*` :
+
+```rust
+use rustango::mcp;
+
+let api = axum::Router::new()
+    .nest("/mcp", mcp::secure_tenant_router_from_settings(&settings.mcp));
+// hand `api` to your tenancy Cli/Builder as usual
+```
+
+Le routeur authentifié monte : `POST {prefix}` (JSON-RPC), `GET {prefix}` (SSE
+notifications), `POST {prefix}/token` (credential → JWT), `POST {prefix}/oauth/token`
+(OAuth 2.1), et les deux documents de découverte `.well-known/*`. Il signe les
+tokens d'agent avec `RUSTANGO_SESSION_SECRET`.
+
+Le handshake `initialize` est un simple POST JSON-RPC et fonctionne sur
+n'importe quel montage :
+
+```json
+// → POST /mcp
+{ "jsonrpc": "2.0", "id": 1, "method": "initialize",
+  "params": { "protocolVersion": "2025-06-18", "capabilities": {},
+              "clientInfo": { "name": "my-client", "version": "0" } } }
+
+// ← 200
+{ "jsonrpc": "2.0", "id": 1, "result": {
+    "protocolVersion": "2025-06-18",
+    "serverInfo": { "name": "rustango", "version": "0.44.0" },
+    "capabilities": { "tools": { "listChanged": true }, "prompts": {}, "resources": {} } } }
+```
+
+---
+
+## Étape 4 — Autoriser les agents
+
+L'autorisation est **basée sur les skills et fail-closed**. Vous provisionnez un
+**agent** (qui reçoit un secret à usage unique), définissez un **skill** qui
+regroupe des tools (et des resources/un prompt), puis **accordez** le skill à
+l'agent dans un tenant :
+
+```rust
+use rustango::tenancy::{create_agent_pool, create_skill_pool, grant_skill_pool};
+
+// 1. Provision an agent — returns a one-time `name`.`secret` credential.
+let issued = create_agent_pool(&pool, "calc-bot").await?;
+
+// 2. A skill bundles tools (here, the `add` tool) + a prompt body.
+create_skill_pool(&pool, "calculator", "Calculator", "does arithmetic",
+                  "You are a precise calculator.", &["add".into()]).await?;
+
+// 3. Grant it to the agent in tenant "acme".
+grant_skill_pool(&pool, "acme", "calc-bot", "calculator").await?;
+```
+
+Le client échange son credential contre un **JWT épinglé au tenant et à portée
+limitée** à `POST /mcp/token` (ou via le flux OAuth `client_credentials` à
+`/mcp/oauth/token`). Le serveur résout le grant en claims `skills` + `tools` du
+token ; chaque requête le revérifie. L'effet, vérifié de bout en bout :
+
+```rust
+// tools/list returns ONLY the granted tool, with its JSON Schema:
+let listed = list_tools(&agent);                       // → { "tools": [ { "name": "add", … } ] }
+
+// tools/call runs the handler and returns a structured result:
+let out = call_tool(ctx, json!({ "name": "add", "arguments": { "a": 2, "b": 3 } })).await?;
+assert_eq!(out["structuredContent"]["sum"], 5);
+
+// An agent WITHOUT the grant sees an empty list and is refused:
+//   list_tools(&ungranted) → { "tools": [] }
+//   call_tool(ungranted, "add") → Err(code = TOOL_FORBIDDEN)
+```
+
+Les tokens sont épinglés au tenant : un token émis pour `acme` est rejeté contre
+tout autre tenant (replay cross-tenant → 401). Révoquez un agent et son JTI est
+mis sur liste noire.
+
+### Clés détenues par l'utilisateur (capacités pilotées par permissions)
+
+Les agents ci-dessus sont des identités machine autonomes. Un membre peut plutôt
+générer une **clé personnelle** — un agent détenu par l'utilisateur — pour qu'un
+LLM agisse *en son nom*, avec des capacités qui suivent le **RBAC** existant du
+tenant plutôt qu'une liste épinglée sur la clé.
+
+Deux pièces le câblent :
+
+```rust
+use rustango::tenancy::{create_user_key_pool, create_skill_pool, map_skill_to_permission_pool};
+
+// 1. Map a skill to a permission codename. Any user-owned key whose owner
+//    holds `mcp.coach` is then granted this skill's tools + prompt + resources.
+create_skill_pool(&pool, "coach", "Coach", "logs workouts",
+                  "You are the member's coach.", &["log_set".into()]).await?;
+map_skill_to_permission_pool(&pool, "coach", "mcp.coach").await?;
+
+// 2. The member generates a key — a one-time `name`.`secret`, shown once.
+//    `&[]` = a FULL key: everything the owner is entitled to. Pass skill
+//    codenames to SCOPE the key to a single skill or a skillset instead —
+//    always bounded by the owner's entitlement (you can't exceed your perms):
+let issued = create_user_key_pool(&pool, user_id, "Alice's phone", &[]).await?;
+// scoped: create_user_key_pool(&pool, user_id, "coach bot", &["coach".into()]).await?;
+println!("copy once: {}", issued.token);
+```
+
+À l'émission du token, le serveur appelle
+[`resolve_user_agent_grants_pool`](../crates/rustango/src/tenancy/agents.rs) —
+les permissions effectives du propriétaire (`user_permissions_pool`, c.-à-d.
+rôles + grants directs − refus) sélectionnent les skills mappés, dont les
+tools/prompts/resources sont aplatis dans les claims `skills`/`tools` du JWT.
+Ainsi `tools/list`, `tools/call`, `prompts/get` et `resources/read` sont **tous**
+gardés par le RBAC, sans aucun changement à ces handlers. L'utilisateur
+propriétaire voyage dans le claim `uid` du token ; un handler de tool le lit
+comme `ctx.agent.user_id` pour restreindre le travail à ce membre. Révoquez de
+nouvelles capacités en changeant les permissions de l'utilisateur (elles se
+re-résolvent au prochain token) ; révoquez la clé elle-même avec
+`revoke_user_key_pool(&pool, user_id, agent_id)`. Listez les clés d'un membre
+avec `list_user_keys_pool(&pool, user_id)`.
+
+**Portée par clé vs. droits par utilisateur.** Les skills atteignent une clé
+selon deux axes : les **droits** du propriétaire (superuser → tous les skills ;
+sinon les skills mappés à une permission qu'il détient) et la **portée** de la
+clé (les skills épinglés à la création). Une clé sans portée (`skills = &[]`)
+reçoit l'intégralité des droits du propriétaire ; une clé à portée limitée
+(`skills = &["coach", …]`) est restreinte à ceux-ci. La résolution re-intersecte
+toujours la portée avec les droits *courants* — de sorte qu'une clé ne peut
+jamais dépasser les permissions du propriétaire, et perdre une permission
+rétrécit chaque clé à la prochaine émission. Restreindre la portée à un skill
+auquel le propriétaire n'a pas droit est refusé à la création.
+
+Les agents autonomes ne sont pas affectés — un agent machine (`user_id = None`)
+n'utilise toujours que ses grants explicites `grant_skill_pool`.
+
+### Depuis la CLI (verbes `manage`)
+
+Tout ce qui précède est aussi disponible directement via le dispatcher `manage`
+conscient de la multi-tenancy (ces verbes se compilent avec la feature `mcp`).
+Chacun est à portée de tenant et prend un `<slug>` :
+
+| Verbe | Ce qu'il fait |
+|---|---|
+| `create-agent <slug> <name>` | Provisionne un agent machine ; imprime son `prefix.secret` **une seule fois**. |
+| `rotate-agent-secret <slug> <name>` | Émet un secret frais, invalidant l'ancien. |
+| `list-agents <slug>` | Liste les agents d'un tenant (id, name, status, prefix). |
+| `create-skill <slug> <codename> [--name ..] [--description ..] [--tools a,b] [--instructions ..]` | Définit un skill (un regroupement de tools + prompt). |
+| `grant-skill <slug> <agent> <skill>` | Accorde un skill à un agent. |
+| `revoke-skill <slug> <agent> <skill>` | Révoque un skill d'un agent. |
+| `list-skills <slug>` | Liste les skills d'un tenant. |
+| `create-user-key <slug> <username> [--label <l>] [--skill <codename>]…` | Émet une **clé détenue par l'utilisateur** ; imprime son token **une seule fois**. Répétez `--skill` pour restreindre la portée de la clé à un seul skill ou à un ensemble de skills ; omettez pour une clé complète (label par défaut = username). |
+| `list-user-keys <slug> <username>` | Liste les clés personnelles d'un utilisateur (id, label, created-at). |
+| `revoke-user-key <slug> <username> <key_id>` | Révoque l'une des clés personnelles d'un utilisateur par id (propriété vérifiée). |
+| `map-skill-permission <slug> <skill> <permission>` | Mappe un skill à un codename de permission. Idempotent — toute clé utilisateur dont le propriétaire détient `<permission>` gagne le skill. |
+| `unmap-skill-permission <slug> <skill> <permission>` | Supprime un mapping skill↔permission. |
+
+Le flux **permission → skill → tools** de bout en bout :
+
+```console
+# 1. Define the skill and map it to a permission codename.
+$ cargo run -- create-skill acme coach --tools log_set --instructions "You are the member's coach."
+$ cargo run -- map-skill-permission acme coach mcp.coach
+
+# 2. Grant the permission to the member (roles or direct — see grant-perm),
+#    then issue their personal key.
+$ cargo run -- grant-perm acme alice mcp.coach
+$ cargo run -- create-user-key acme alice --label "Alice's phone"
+created key #7 for user `alice` in tenant `acme` (label `Alice's phone`, scope full (owner's permissions))
+  token: 3f9c1a2b.7d…            # copy once — never shown again
+  store this safely — it won't be shown again
+
+# …or scope the key to a single skill / skillset (repeat --skill):
+$ cargo run -- create-user-key acme alice --label "coach bot" --skill coach
+```
+
+La clé d'Alice résout désormais les tools du skill `coach` à chaque émission de
+token parce qu'elle détient `mcp.coach`. Changez ses permissions et les
+capacités se re-résolvent à son prochain token ; révoquez la clé elle-même avec
+`revoke-user-key`. Le même id de clé se distingue des agents machine dans l'admin
+du tenant (la liste `Agent` affiche `user_id`).
+
+L'auto-admin les expose aussi : `Agent`, `AgentSkill`, `AgentSkillPermission`
+(et `AgentGrant`) rendent chacun une table auto-CRUD dans l'admin du tenant, de
+sorte que les mappings skill↔permission peuvent être revus et édités sans la CLI.
+
+---
+
+## Le protocole
+
+JSON-RPC 2.0 (version de protocole `2025-06-18`) sur HTTP POST, avec un flux SSE
+optionnel (`GET {prefix}`) pour les notifications serveur→client. Méthodes :
+
+| Méthode | Auth | But |
+|---|---|---|
+| `initialize` · `ping` | non | handshake + liveness |
+| `tools/list` · `tools/call` | oui | découvrir + invoquer les tools (accordés seulement) |
+| `prompts/list` · `prompts/get` | oui | prompts dérivés des skills |
+| `resources/list` · `resources/read` · `resources/templates/list` | oui | resources statiques + de skill |
+| `logging/setLevel` · `completion/complete` | oui | niveau de log + complétion de préfixe |
+| `notifications/progress` · `notifications/*/list_changed` | — | serveur→client via SSE |
+| `notifications/cancelled` | — | le client annule un appel en cours |
+
+Un *handler* de tool en échec retourne un résultat normal avec `isError: true`
+(l'agent peut réagir) ; les problèmes au niveau du protocole (tool
+inconnu/interdit, mauvais params) retournent une `error` JSON-RPC avec des codes
+comme `-32002` (`TOOL_NOT_FOUND`), `-32003` (`TOOL_FORBIDDEN`), `-32602`
+(`INVALID_PARAMS`). Les tools longs rapportent la progression et honorent
+l'annulation via le `McpContext`.
+
+---
+
+## Réglages
+
+La section `[mcp]` (lue par `secure_tenant_router_from_settings`) :
+
+```toml
+[mcp]
+prefix                = "/mcp"   # URL prefix the router mounts under
+token_ttl_secs        = 900      # agent access-token lifetime (15 min)
+enable_sse            = true     # serve the GET {prefix} SSE stream
+allowed_origins       = []       # CORS allow-list (empty = same-origin only)
+rate_limit_per_minute = 0        # per-IP cap (0/unset = unlimited)
+max_tools_listed      = 0        # tools/list page size (0/unset = unlimited)
+```
+
+---
+
+## Comment tester
+
+### (a) La suite de tests
+
+Tout le protocole est couvert par `crates/rustango/tests/mcp_*.rs` + le test qui
+adosse cette doc. Exécutez-les avec la feature activée :
+
+```bash
+# The doc's headline flow (register → initialize → grant → list → call → fail-closed):
+cargo test -p rustango --features sqlite,mcp --test mcp_doc
+
+# Slices + end-to-end + OAuth + settings:
+cargo test -p rustango --features sqlite,mcp,config --test 'mcp_*'
+```
+
+### (b) curl le JSON-RPC
+
+Démarrez la démo (section suivante) et parlez-lui directement. La démo garde
+**chaque** méthode derrière un token d'agent (un appel non authentifié retourne
+`401`), donc émettez-en un d'abord — la démo imprime le secret de l'agent au
+démarrage :
+
+```bash
+TOKEN=$(curl -sX POST http://localhost:8090/mcp/token \
+  -H 'content-type: application/json' -d '{"name":"demo-bot","secret":"<printed-secret>"}' \
+  | jq -r .access_token)
+
+# initialize:
+curl -sX POST http://localhost:8090/mcp -H "authorization: Bearer $TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
+
+# tools/call — only the granted `add` tool is callable:
+curl -sX POST http://localhost:8090/mcp -H "authorization: Bearer $TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"add","arguments":{"a":2,"b":3}}}'
+# → { ... "result": { "structuredContent": { "sum": 5 }, "isError": false } }
+```
+
+### (c) Testez-le visuellement avec le MCP Inspector
+
+Le [MCP Inspector](https://github.com/modelcontextprotocol/inspector) est le
+client visuel officiel — connectez-le à votre serveur et parcourez les tools,
+resources et prompts. Lancez la démo, puis l'Inspector :
+
+```bash
+# 1. Start the demo MCP server (seeds an `acme` tenant + `demo-bot` agent + the `add` tool):
+cd crates/rustango/examples/mcp_demo && cargo run   # serves on http://localhost:8090/mcp
+
+# 2. Launch the Inspector (opens a browser UI on http://localhost:6274):
+npx @modelcontextprotocol/inspector
+```
+
+Dans l'Inspector : réglez le transport sur **Streamable HTTP** et l'URL sur
+`http://localhost:8090/mcp`. Ouvrez **Authentication → Custom Headers**, ajoutez
+un header `Authorization` avec la valeur `Bearer <token>` (émettez le token avec
+l'appel `/mcp/token` ci-dessus), activez la ligne, puis **Connect**.
+
+Passez à l'onglet **Tools** et cliquez **List Tools** — vous verrez *seulement*
+le tool `add` que le skill de l'agent accorde, avec son JSON Schema.
+Sélectionnez-le, entrez `a = 2`, `b = 3`, et **Run Tool** :
+
+[![Le MCP Inspector connecté à la démo Rustango via Streamable HTTP, montrant le tool `add` accordé et son schéma d'entrée a/b](img/mcp-inspector-tools.png)](img/mcp-inspector-tools.png)
+
+L'appel retourne un résultat structuré — `{ "sum": 5 }` — et la requête apparaît
+dans le panneau History (`initialize` → `tools/list` → `tools/call`) :
+
+[![Le même Inspector après l'exécution du tool : Tool Result Success avec le contenu structuré { sum: 5 }, et l'historique des appels JSON-RPC](img/mcp-inspector-call.png)](img/mcp-inspector-call.png)
+
+### (d) Connectez un vrai client MCP
+
+Pointez Claude Code (ou n'importe quel client MCP) vers le serveur en cours
+d'exécution, en passant le token d'agent comme header (émettez-le avec l'appel
+`/mcp/token` ci-dessus) :
+
+```bash
+claude mcp add --transport http rustango-demo http://localhost:8090/mcp \
+  --header "Authorization: Bearer $TOKEN"
+```
+
+Puis demandez à l'agent d'additionner deux nombres — il découvre et appelle le
+tool `add` via le même protocole que celui utilisé par l'Inspector.
+
+---
+
+## Build optionnel vs. par défaut
+
+La feature est entièrement gardée — tout le module `rustango::mcp` est derrière
+`#[cfg(feature = "mcp")]`, de sorte qu'il n'affecte jamais les apps qui ne s'y
+inscrivent pas :
+
+```bash
+cargo build -p rustango                 # default — MCP module NOT compiled
+cargo build -p rustango --features mcp  # MCP server compiled + linked
+```
+
+Une app par défaut ne porte aucun code, dépendance ou route MCP ; activer la
+feature est la seule chose qui l'active.
+
+---
+
+## Voir aussi
+
+- [OpenAPI](openapi.md) — la machinerie JSON Schema que l'entrée d'un tool
+  réutilise.
+- [API d'auth JWT](auth-jwt-api.md) · [Backends d'auth](auth-backends.md) — le
+  cycle de vie des tokens sur lequel l'auth d'agent est construite.
+- [Guide de sécurité](security.md) — autorisation fail-closed, secrets, limites
+  de débit.
+- [Jobs en arrière-plan](jobs.md) — exécuter le travail d'un tool long hors de la
+  requête.

--- a/docs/fr/middleware.md
+++ b/docs/fr/middleware.md
@@ -1,0 +1,434 @@
+# Middleware
+
+Un middleware est du code qui s'exécute **autour** de chaque requête — avant que
+votre handler ne la voie et après qu'il a produit une réponse. C'est là que
+vivent les préoccupations transversales : journalisation, limitation de débit,
+en-têtes de sécurité, CSRF, résolution de la locale et du fuseau horaire.
+**Rustango** fournit un catalogue riche de middlewares prêts à l'emploi et rend
+l'écriture des vôtres possible en quelques lignes. Si vous venez de Django,
+c'est la liste `MIDDLEWARE` ; d'Express, c'est `app.use()` ; de Laravel, c'est
+le kernel HTTP — la même idée, rattachée à votre routeur.
+
+[![Middleware in Rustango: a request flows down through a stack of tower layers (request-id, locale, security headers, CSRF) into the handler and back up through the response side of each layer](img/middleware.png)](img/middleware.png)
+
+> **Source :** le middleware est bâti sur [`tower::Layer`](https://docs.rs/tower) +
+> `axum::middleware::from_fn`. Les composants intégrés se répartissent dans
+> `rustango::{access_log, rate_limit, cors, security_headers, request_id, …}`,
+> plus `rustango::forms::csrf` (la feature `csrf`) et `rustango::i18n`
+> (`middleware::LocaleMiddleware`, `timezone`). La plupart sont activés par
+> défaut.
+>
+> **Version exécutable :** chaque extrait ci-dessous est copié depuis l'exemple
+> testé situé dans
+> `crates/rustango/examples/getting_started_blog/tests/middleware.rs`
+> (locale, fuseau horaire, en-têtes de sécurité, CSRF — tous sans base de
+> données). Lancez-le avec
+> `cargo test -p getting_started_blog --test middleware`.
+
+> **Un terme vous est inconnu ?** *Middleware*, *layer*, *CSRF*, *locale* — le
+> [glossaire](glossary.md) les explique en langage clair.
+
+## Table des matières
+
+- [Comment fonctionne le middleware dans Rustango](#how-middleware-works-in-rustango)
+- [L'ordre compte](#ordering-matters)
+- [Le catalogue intégré](#the-built-in-catalog)
+- [Middleware sensible à la locale](#locale-aware-middleware)
+- [Middleware sensible au fuseau horaire](#timezone-aware-middleware)
+- [En-têtes de sécurité](#security-headers)
+- [Protection CSRF](#csrf-protection)
+- [Écrire votre propre middleware](#writing-your-own-middleware)
+- [Voir aussi](#see-also)
+
+---
+
+## Comment fonctionne le middleware dans Rustango
+
+Il existe deux formes, et vous utiliserez les deux :
+
+1. **Un `tower::Layer`** — une structure middleware réutilisable et
+   configurable. Chaque composant intégré en est un (`SecurityHeadersLayer`,
+   `RateLimitLayer`, …). Vous attachez un layer avec le `.layer(...)` d'axum,
+   ou — pour la plupart des composants intégrés — avec un **one-liner de trait
+   d'extension** qui se lit mieux :
+
+   ```rust
+   use rustango::security_headers::{SecurityHeadersLayer, SecurityHeadersRouterExt};
+
+   // These two are equivalent; the second is the ergonomic form.
+   let app = router.layer(SecurityHeadersLayer::strict());
+   let app = router.security_headers(SecurityHeadersLayer::strict());
+   ```
+
+   Chaque module intégré exporte un trait `…RouterExt` (`SecurityHeadersRouterExt`,
+   `RateLimitRouterExt`, …). Amenez-le dans la portée et vous obtenez une méthode
+   `.security_headers()` / `.rate_limit()` / `.cors()` directement sur `Router`.
+   C'est la manière idiomatique de câbler une pile :
+
+   ```rust
+   let app = router
+       .request_id(RequestIdLayer::default())
+       .access_log(AccessLogLayer::default())
+       .rate_limit(RateLimitLayer::per_ip(60, Duration::from_secs(60)))
+       .cors(CorsLayer::new().allow_origins(vec!["https://app.example.com"]))
+       .security_headers(SecurityHeadersLayer::strict());
+   ```
+
+2. **Une fonction via `axum::middleware::from_fn`** — le moyen le plus rapide
+   d'en écrire un ponctuel. Vous recevez la `Request` et un `Next` ; vous
+   appelez `next.run(req)` pour continuer, et vous pouvez faire du travail de
+   part et d'autre de cet appel. L'[exemple de fuseau
+   horaire](#timezone-aware-middleware) ci-dessous est exactement cela.
+
+Les deux se composent librement — un middleware `from_fn` *est* un layer, donc
+il s'empile avec les composants intégrés dans la même chaîne `.layer(...)`.
+
+---
+
+## L'ordre compte
+
+Un layer enveloppe tout ce qui a été ajouté **avant** lui, donc le **dernier**
+layer que vous attachez est le **plus externe** — il s'exécute en premier à
+l'aller et en dernier au retour. Imaginez la pile comme un oignon ; la requête
+descend jusqu'au handler et la réponse remonte :
+
+```text
+            ┌──────────────────────────────────────┐
+request  →  │ security_headers   (added last = top) │  → response
+            │   ┌────────────────────────────────┐  │
+            │   │ rate_limit                     │  │
+            │   │   ┌──────────────────────────┐ │  │
+            │   │   │ request_id (added first) │ │  │
+            │   │   │      → handler →         │ │  │
+            │   │   └──────────────────────────┘ │  │
+            │   └────────────────────────────────┘  │
+            └──────────────────────────────────────┘
+```
+
+Conséquences pratiques :
+
+- **Placez `request_id` / `access_log` près du bas** (ajoutés en premier) afin
+  que l'identifiant de corrélation et le span de journalisation couvrent tout
+  ce qui s'exécute après eux.
+- **Placez les gardes à rejet peu coûteux près du haut** (ajoutés en dernier) —
+  `allowed_hosts`, `rate_limit`, `body_limit` — afin qu'une requête bloquée
+  soit écartée avant d'atteindre les layers internes coûteux.
+- **`security_headers` le plus à l'extérieur** afin que les en-têtes soient
+  apposés sur *chaque* réponse, y compris celles court-circuitées par un layer
+  interne (un 429, un 403).
+
+---
+
+## Le catalogue intégré
+
+Chaque entrée est un `tower::Layer` avec un one-liner `…RouterExt` associé, sauf
+mention contraire. Amenez le trait `…RouterExt` du module dans la portée pour
+obtenir la méthode.
+
+| Préoccupation | Layer | Câblez-le avec |
+| --- | --- | --- |
+| **Sécurité & accès** | | |
+| En-têtes de sécurité (HSTS, XFO, CSP…) | `SecurityHeadersLayer` | `.security_headers(..)` |
+| CSRF (cookie double-submit) | `CsrfLayer` | `.layer(csrf::layer())` |
+| CORS | `CorsLayer` | `.cors(..)` |
+| Liste blanche d'hôtes | `AllowedHostsLayer` | `.allowed_hosts(..)` |
+| Autorisation/blocage d'IP | `IpFilterLayer` | `.ip_filter(..)` |
+| Forcer HTTPS | `SslRedirectLayer` | `.ssl_redirect(..)` |
+| Nonce CSP par requête | `CspNonceLayer` | `.csp_nonce(..)` |
+| Signature de requête HMAC | `HmacAuthLayer` | `.layer(..)` |
+| **Trafic & résilience** | | |
+| Limitation de débit (par IP/globale) | `RateLimitLayer` | `.rate_limit(..)` |
+| Limitation de débit distribuée (adossée au cache) | `CacheRateLimitLayer` | `.cache_rate_limit(..)` |
+| Timeout de requête | `RequestTimeoutLayer` | `.request_timeout(..)` |
+| Taille de corps maximale | `BodyLimitLayer` | `.body_limit(..)` |
+| Mode maintenance (503) | `MaintenanceLayer` | `.maintenance(..)` |
+| Clés d'idempotence | `IdempotencyLayer` | `.idempotency(..)` |
+| Restreindre les méthodes HTTP | `MethodRestrictLayer` | `.require_get()` / `.require_post()` / `.require_safe()` |
+| **Observabilité** | | |
+| Identifiant de requête (`X-Request-Id`) | `RequestIdLayer` | `.request_id(..)` |
+| Journal d'accès (PII expurgées) | `AccessLogLayer` | `.access_log(..)` |
+| Spans `tracing` | `TracingLayer` | `.layer(..)` |
+| En-tête `Server-Timing` | `ServerTimingLayer` | `.server_timing(..)` |
+| IP client réelle (derrière des proxys) | `RealIpLayer` | `.real_ip(..)` |
+| **Contenu & réponse** | | |
+| Compression gzip/br | `CompressionLayer` | `.compression(..)` |
+| ETag / GET conditionnel | `EtagLayer` | `.etag(..)` |
+| Redirection de slash final | `TrailingSlashLayer` | `.trailing_slash(..)` |
+| Mise en cache de page | `CachePageLayer` | `.layer(..)` |
+| **Localisation** | | |
+| Négociation de locale | `LocaleMiddleware` | `.layer(..)` (+ extracteur `ActiveLocale`) |
+| Fuseau horaire actif | *(à composer avec `from_fn`)* | voir [ci-dessous](#timezone-aware-middleware) |
+| **Développement** | | |
+| Rechargement à chaud | `LiveReloadLayer` | `.livereload(..)` |
+| Panneau de débogage | `DebugPanelLayer` | `.debug_panel(..)` |
+
+Les sections suivantes détaillent celles que la requête a demandées.
+
+---
+
+## Middleware sensible à la locale
+
+`LocaleMiddleware` résout une locale par requête et l'injecte dans la requête
+afin que n'importe quel handler puisse la lire. L'ordre de sélection est celui
+de Django : **cookie → `Accept-Language` → valeur par défaut**. La première
+locale que vous listez est la valeur par défaut, sauf si vous la surchargez.
+
+```rust
+use rustango::i18n::middleware::{ActiveLocale, LocaleMiddleware};
+
+// First entry is the default; `.default("en")` is explicit here. `ar`
+// (Arabic) is included so we can prove the RTL convenience too.
+let layer = LocaleMiddleware::new(&["en", "fr", "ar"]).default("en");
+
+let app = Router::new()
+    .route(
+        "/",
+        // The extractor pulls the locale the layer chose for THIS request.
+        get(|loc: ActiveLocale| async move { format!("{} {}", loc.0, loc.direction()) }),
+    )
+    .layer(layer);
+```
+
+Les handlers lisent le résultat avec l'extracteur `ActiveLocale`. Il est
+`Infallible` — si aucun middleware ne s'est exécuté, il retombe sur `"en"` — et
+il porte des helpers RTL afin que les templates puissent brancher selon la
+bidirectionnalité :
+
+```rust
+loc.0            // the picked locale, e.g. "fr"
+loc.direction()  // "ltr" / "rtl" — feed straight into <html dir="…">
+loc.is_rtl()     // true for ar, he, fa, …
+```
+
+Le nom du cookie est par défaut `django_language` (compatible Django) ;
+changez-le avec `.cookie_name("…")`, ou passez `None` pour désactiver
+entièrement la recherche par cookie. L'ordre de résolution, vérifié de bout en
+bout :
+
+```rust
+// Cookie says fr, Accept-Language says ar → the cookie wins.
+//   Cookie: django_language=fr ; Accept-Language: ar   → "fr ltr"
+//
+// No cookie → negotiate Accept-Language (ar is RTL).
+//   Accept-Language: ar,en;q=0.5                        → "ar rtl"
+//
+// Neither cookie nor a supported language → the default locale.
+//   (no headers)                                        → "en ltr"
+```
+
+Pour des locales en préfixe d'URL (`/en/about`, `/fr/about`) au lieu de la
+négociation par en-tête, montez un sous-routeur par locale avec
+`Router::nest("/fr", …)` et injectez-y la locale.
+
+---
+
+## Middleware sensible au fuseau horaire
+
+Il n'y a délibérément **aucun layer de fuseau horaire**. À la place, le
+framework vous donne un décalage actif task-local (`rustango::i18n::timezone`)
+et un décodeur d'en-tête/cookie, et vous composez un middleware d'une ligne qui
+l'active — l'exemple canonique du « écrivez le vôtre ». Cela reflète le
+`USE_TZ=True` de Django : stockez en UTC, affichez selon l'horloge locale de
+l'utilisateur.
+
+```rust
+use axum::middleware::{from_fn, Next};
+use rustango::i18n::timezone::{current_offset, from_request_headers, with_offset};
+
+/// Per-request middleware: decode the client's UTC offset from the
+/// `tz_offset` cookie (or a `Time-Zone:` header), then run the rest of the
+/// stack with that offset active so `current_offset()` / the `localtime`
+/// Tera filter see it. Falls back to UTC when nothing parseable is sent.
+async fn timezone_mw(req: Request<Body>, next: Next) -> Response {
+    match from_request_headers(req.headers(), "tz_offset") {
+        Some(offset) => with_offset(offset, next.run(req)).await,
+        None => next.run(req).await,
+    }
+}
+
+let app = Router::new()
+    .route(
+        "/now",
+        // The handler runs inside the activated scope, so the task-local
+        // offset is visible here (and inside any `.await` it makes).
+        get(|| async { current_offset().local_minus_utc().to_string() }),
+    )
+    .layer(from_fn(timezone_mw));
+```
+
+`with_offset` installe le décalage dans un **`tokio::task_local`**, de sorte
+qu'il survit aux points `.await` et aux sauts de thread au sein de la requête —
+contrairement à un thread-local, il ne disparaît pas quand tokio replanifie la
+tâche. À l'intérieur de la portée :
+
+- `current_offset()` retourne le `FixedOffset` actif (UTC en dehors de toute
+  portée),
+- `localtime(utc_dt)` convertit un `DateTime` UTC stocké vers celui-ci,
+- le filtre Tera `{{ ts | localtime }}` (enregistré avec
+  `timezone::register_filters`) l'affiche automatiquement.
+
+`from_request_headers` accepte d'abord le cookie `tz_offset`, puis un en-tête
+`Time-Zone:` (ou `X-Timezone:`). Les formats acceptés sont flexibles —
+`"+05:30"`, `"+0530"`, `"Z"`/`"UTC"`, ou des **minutes entières signées**
+(`"330"`, `"-300"`), la forme que produit `Date.getTimezoneOffset()` de JS. Le
+cookie est généralement posé par un minuscule extrait au chargement de la page :
+
+```html
+<script>
+  // getTimezoneOffset() is positive west-of-UTC, so flip the sign.
+  const minutes = -new Date().getTimezoneOffset();
+  document.cookie = `tz_offset=${minutes};path=/;max-age=31536000`;
+</script>
+```
+
+Comportement, vérifié :
+
+```rust
+// Cookie: tz_offset=330  (UTC+05:30)   → current_offset() = +19800s
+// Header: Time-Zone: -300 (UTC-05:00)  → current_offset() = -18000s
+// nothing sent                          → current_offset() = 0 (UTC)
+```
+
+> **Note — `FixedOffset`, pas IANA.** Cela modélise le fuseau horaire actif
+> comme un décalage fixe, ce qui est tout ce dont un *instant unique* a besoin
+> et évite la base `chrono-tz` d'environ 3 Mo. Cela ne gère **pas** les
+> transitions d'heure d'été. Pour un support IANA complet, parsez le `Tz` de
+> l'utilisateur avec `chrono-tz` au moment de la requête et passez
+> `tz.offset_from_utc_datetime(...)` à `with_offset` — la forme du middleware
+> ci-dessus est inchangée.
+
+---
+
+## En-têtes de sécurité
+
+`SecurityHeadersLayer` appose les en-têtes standard de durcissement du
+navigateur — HSTS, `X-Frame-Options`, `X-Content-Type-Options`,
+Referrer-Policy, et une Content-Security-Policy optionnelle — sur chaque
+réponse, en une ligne.
+
+```rust
+use rustango::security_headers::{CspBuilder, SecurityHeadersLayer, SecurityHeadersRouterExt};
+
+let app = Router::new()
+    .route("/", get(|| async { "ok" }))
+    .security_headers(SecurityHeadersLayer::strict().csp(CspBuilder::strict_starter().build()));
+```
+
+Cela durcit chaque réponse :
+
+```rust
+// strict-transport-security: max-age=31536000; includeSubDomains; preload
+// x-content-type-options:     nosniff
+// x-frame-options:            DENY
+// content-security-policy:    <built from CspBuilder::strict_starter()>
+```
+
+Trois presets couvrent les cas courants :
+
+| Preset | À utiliser pour | HSTS | `X-Frame-Options` |
+| --- | --- | --- | --- |
+| `strict()` | production | 1 an + preload | `DENY` |
+| `relaxed()` | pages intégrables | 1 an | `SAMEORIGIN` |
+| `dev()` | dev local | *(omis)* | — |
+
+Utilisez `dev()` en local — HSTS épinglerait autrement votre navigateur sur
+HTTPS pendant un an sur `localhost`. Construisez une CSP de manière fluide avec
+`CspBuilder` (`.default_src(..)`, `.script_src(..)`, …, `.build()`), et
+déployez-la en toute sécurité avec `.csp_report_only(true)` +
+`.csp_report_uri("/csp-report")` avant de l'appliquer.
+
+---
+
+## Protection CSRF
+
+Le CSRF (cross-site request forgery) survient quand un autre site trompe le
+navigateur d'un utilisateur connecté pour lui faire soumettre une requête à
+votre application. **Rustango** se défend avec le pattern **double-submit
+cookie**, dans `rustango::forms::csrf` (derrière la feature `csrf`, activée
+automatiquement par `admin`).
+
+```rust
+use rustango::forms::csrf;
+
+let app = Router::new()
+    .route("/form", get(|| async { "render form" }))
+    .route("/submit", post(|| async { "accepted" }))
+    .layer(csrf::layer());
+```
+
+Une méthode sûre (GET/HEAD/OPTIONS) émet un cookie `rustango_csrf`. Une méthode
+non sûre (POST/PUT/PATCH/DELETE) doit renvoyer la valeur de ce cookie, soit dans
+l'en-tête `X-CSRF-Token` soit dans le champ de formulaire `_csrf` ; une
+non-concordance donne un `403 Forbidden` :
+
+```rust
+// GET /form                            → 200 + Set-Cookie: rustango_csrf=…
+//
+// POST /submit  (no token)             → 403 Forbidden
+//
+// POST /submit  with both:
+//   Cookie:        rustango_csrf=<t>
+//   X-CSRF-Token:  <t>                 → 200 OK   (double-submit matches)
+```
+
+Dans les templates Tera, `{{ csrf_token }}` donne le jeton brut et
+`{{ csrf_input }}` un `<input name="_csrf">` caché prêt à l'emploi — déposez-en
+un dans chaque formulaire. Surchargez les noms de cookie/en-tête ou le flag
+`Secure` avec `csrf::with_config(CsrfConfig)` ; pour des configurations SPA,
+ajoutez `.with_trusted_origins([...])` pour activer la vérification de
+défense en profondeur de l'en-tête Origin en plus du jeton. Pour des endpoints
+collecteurs append-only atteints via `navigator.sendBeacon` (p. ex. analytics)
+qui ne peuvent pas envoyer d'en-tête de jeton, `CsrfConfig::exempt_prefix("/path")`
+saute l'application pour un préfixe de chemin étroit. L'auto-admin active le CSRF
+sur chaque mutation, sans possibilité d'opt-out.
+
+---
+
+## Écrire votre propre middleware
+
+Vous avez déjà vu la forme rapide — le [middleware de fuseau
+horaire](#timezone-aware-middleware) est un exemple `from_fn` complet. Utilisez
+`from_fn` chaque fois que la logique est spécifique à l'application et que vous
+n'avez pas besoin de la configurer :
+
+```rust
+use axum::middleware::{from_fn, Next};
+
+async fn add_app_version(req: Request<Body>, next: Next) -> Response {
+    let mut resp = next.run(req).await;          // run the rest of the stack
+    resp.headers_mut()
+        .insert("X-App-Version", HeaderValue::from_static(env!("CARGO_PKG_VERSION")));
+    resp                                          // …then touch the response
+}
+
+let app = router.layer(from_fn(add_app_version));
+```
+
+Optez pour un **`tower::Layer`** complet lorsque le middleware est réutilisable
+et configurable — quand vous le distribueriez comme partie d'une bibliothèque.
+Le pattern est une petite structure `Layer` qui construit un `Service`, plus
+(par convention) un trait d'extension `…RouterExt` pour le one-liner.
+`rustango::request_id` est la plus petite référence complète à copier :
+
+- `RequestIdLayer` — le layer configurable (`::default()`, `.always_generate()`),
+- `RequestIdService<S>` — enveloppe le service interne ; lit/pose l'en-tête
+  `X-Request-Id` à l'intérieur de `call`,
+- `RequestId` — un extracteur `FromRequestParts` pour que les handlers puissent
+  lire l'identifiant,
+- `RequestIdRouterExt` — fournit `Router::request_id(layer)`.
+
+`LocaleMiddleware` (à lire dans `crates/rustango/src/i18n/middleware.rs`) est un
+second exemple travaillé — les mêmes quatre pièces, plus une méthode pure
+`.pick(&req)` testable unitairement sans démarrer de serveur. Modélisez vos
+nouveaux layers sur l'un ou l'autre.
+
+---
+
+## Voir aussi
+
+- [Guide de sécurité](security.md) — la pile complète de défense en profondeur
+  et une checklist au moment du déploiement (`manage check --deploy`).
+- [Authentification](auth-sessions.md) — les backends d'auth et le middleware
+  `CurrentUser` s'appuient sur le même mécanisme de layer.
+- [URLs & routage](urls.md) — où les layers s'attachent aux routeurs et
+  sous-routeurs.

--- a/docs/fr/migrations.md
+++ b/docs/fr/migrations.md
@@ -1,0 +1,189 @@
+# Migrations et le moteur de migration
+
+**Rustango** livre un moteur de migration façon Django : vous éditez vos modèles,
+lancez `makemigrations` pour générer un fichier JSON versionné décrivant le
+changement de schéma, et `migrate` pour l'appliquer. Depuis la **0.48**, le framework
+migre même **ses propres** tables `rustango_*` via le même moteur —
+sans DDL de bootstrap livré à la main. Cette page explique les rouages qui
+rendent une mise à niveau sûre : les deux chaînes de migration, la réconciliation de squash,
+et le fake-initial gardé qui permet à une base de données préexistante d'adopter le
+moteur sans collisions.
+
+> **Nouveau aux migrations ?** Les verbes CLI du quotidien — `makemigrations`,
+> `migrate`, `migrate --squash`, `migrate --fake`, `downgrade`,
+> `showmigrations` — sont couverts commande par commande dans le
+> [guide manage](manage.md#migrations). Cette page est le modèle
+> conceptuel qui les sous-tend.
+
+> **Source :** `rustango::migrate` (`runner`, `make`, `file`, `manage`)
+> et `rustango::tenancy::migrate` — la réconciliation du runner vit dans
+> `migrate::runner::reconcile`.
+
+---
+
+## Deux chaînes de migration
+
+Une migration appartient à l'une de deux chaînes indépendantes, chacune avec sa propre
+table de registre (la ligne des noms appliqués que le runner consulte pour sauter du travail) :
+
+| Chaîne | Ce qu'elle gère | Table de registre |
+|---|---|---|
+| **Project** | vos tables `#[derive(Model)]`, dans `migrations/` | `__rustango_migrations__` |
+| **System** | les propres tables `rustango_*` du framework (`Org`, `User`, rôles/permissions, agents, media, …), dans `system/migrations/` | `__rustango_system_migrations__` |
+
+La **chaîne système** est ce qui rend le schéma du framework auto-descriptif.
+Ses fichiers sont générés depuis les modèles compilés du framework — et ils sont
+**conscients de `#[cfg(feature = …)]`** : une colonne ou une table protégée par feature est
+retirée par le compilateur lorsque la feature est désactivée, si bien qu'activer une feature fait
+émettre à `makemigrations` un `AddColumn` / `CreateTable` et la désactiver
+émet un `DropColumn` / `DropTable`. Les projets tenant échafaudés livrent un
+`system/migrations/` **vide** ; le premier `cargo run -- migrate`
+le génère et l'applique (voir [scaffolding](scaffolding.md)).
+
+`migrate` applique la chaîne système **avant** les migrations de votre projet.
+En mode tenancy, les deux périmètres se chevauchent délibérément sur les tables partagées
+du framework, si bien que c'est la chaîne à périmètre tenant qui s'exécute ; les
+tables du seul registre (`rustango_orgs`, `rustango_operators`) ne signifient rien
+sans tenancy. Les applications sans tenancy qui utilisent un sous-système du framework (par ex.
+`media`) reçoivent la chaîne système appliquée elles aussi.
+
+---
+
+## Réconciliation de squash — `Migration.replaces`
+
+Un **squash** effondre une série de migrations historiques en un seul fichier fraîchement
+généré qui recrée le même état final — pratique quand une pile de
+migrations à moitié terminées est plus facile à régénérer qu'à corriger. Le hic :
+les `CREATE TABLE` du fichier entreraient en collision sur toute base de données ayant déjà
+appliqué les migrations qu'il a effondrées (le checkout d'un collègue, la staging,
+la CI).
+
+`migrate --squash` résout cela en estampillant la liste **`replaces`** du nouveau fichier
+avec les noms qu'il a effondrés :
+
+```jsonc
+{
+  "name": "0007_squashed_0001_0006",
+  "replaces": ["0001_initial", "0002_add_status", "0003_add_slug", "…"],
+  "forward": [ /* recreates the end state */ ]
+}
+```
+
+Avec `replaces` défini, le runner **réconcilie** le squash face à l'état réel
+de la base de données au lieu de l'exécuter aveuglément. La décision est
+automatique et dépend entièrement de ce qui est déjà présent :
+
+| État de la base de données | Ce que fait le runner |
+|---|---|
+| vierge — pas d'historique, pas de tables | exécute le squash pour de vrai |
+| chaque migration remplacée est dans le registre | l'enregistre, met en tombstone les prédécesseurs, **pas de DDL** |
+| les tables existent mais le registre n'a pas d'historique | l'enregistre, **pas de DDL** (le `--fake-initial` inter-registres de Django) |
+| seulement *certaines* lignes / tables remplacées présentes | **refusé** — nomme ce qui manque, vous dit de résoudre à la main |
+
+Le cas **partiel** est une erreur bloquante à dessein : aucun choix automatique n'y est
+sûr, donc le runner s'arrête et rapporte ce qu'il a trouvé plutôt que de
+deviner. Résolvez-le avec `migrate --fake` (ci-dessous).
+
+Les migrations supplantées par un squash appliqué comptent comme appliquées, si bien que vous pouvez
+laisser les fichiers effondrés sur le disque pendant une release ou deux — les déploiements qui
+ne les ont jamais exécutés migrent quand même correctement vers l'avant. Les migrations ordinaires (hors squash)
+ne sont pas affectées : une migration simple dont la table existe déjà
+échoue quand même bruyamment, car c'est un vrai conflit, pas un
+historique connu-équivalent.
+
+---
+
+## La réconciliation fake-initial gardée
+
+C'est le mécanisme qui permet à une base de données **existante** d'adopter la chaîne
+système en toute transparence. Avant la 0.51, le framework construisait certaines de ses tables via
+un DDL brut paresseux `ensure_table` ; ces tables existent mais ne sont pas enregistrées dans
+le registre `__rustango_system_migrations__`, si bien qu'un nouveau `CREATE TABLE`
+issu de la nouvelle migration système entrerait en collision (`relation "rustango_media"
+already exists`, MySQL 1050, …).
+
+La chaîne système réconcilie cela elle-même. Une migration **système** en attente est
+inspectée : les opérations qui composent *la création de ses tables* —
+`CreateTable`, plus `CreateIndex` / `CreateM2MTable` ciblant une table que la
+même migration crée — constituent l'ensemble accepté. Si **toutes** les tables qu'elle
+crée existent déjà, la migration est **enregistrée dans le registre
+sans exécuter aucun DDL**, et les données existantes sont laissées intactes. Si seulement
+*certaines* de ses tables existent, la chaîne crée uniquement celles qui manquent
+(sémantique `CREATE TABLE IF NOT EXISTS`) et laisse le reste tranquille.
+
+Le garde est délibérément étroit :
+
+- **Restreint à la propre chaîne système du framework.** Les migrations utilisateur utilisent le
+  runner simple et ne font jamais d'auto-fake — le faking par existence de table est réservé,
+  par choix, au seul chemin système.
+- **Tout ce qui n'est pas de la création de table disqualifie le faking** — un index
+  sur une table préexistante, un alter / drop / opération de données / callback bascule
+  vers une exécution réelle, si bien que du vrai travail n'est jamais sauté.
+- **L'existence n'est interrogée que dans l'espace de noms courant** — Postgres
+  `current_schema()`, MySQL `DATABASE()`, SQLite `sqlite_master` — et non
+  via le `search_path`, si bien qu'en multi-tenancy en mode schéma, une table de même nom
+  dans `public` ne peut pas tromper un tenant en lui faisant sauter ses propres tables.
+
+L'état partiel d'un squash est toujours refusé (voir ci-dessus) ; seule la
+chaîne système du framework effectue la réparation « créer celles qui manquent » au coup par coup.
+
+---
+
+## Réparer un dérive à la main — `migrate --fake`
+
+Lorsque la base de données est déjà dans l'état cible mais que le registre ne le
+sait pas (une BDD montée hors-bande, un registre supprimé, une migration partiellement
+réussie, un squash partiel refusé), estampillez une migration comme appliquée
+**sans exécuter son SQL** :
+
+```bash
+cargo run -- migrate --fake 0004_add_indexes
+cargo run -- migrate --fake 0001_rustango_registry_initial --system       # framework's own chain
+cargo run -- migrate --fake 0001_rustango_registry_initial --all-tenants  # every active tenant
+```
+
+- `--system` estampille la chaîne système du framework
+  (`system/migrations/` → `__rustango_system_migrations__`) au lieu de
+  celle de votre projet.
+- `--all-tenants` diffuse l'estampille sur chaque tenant actif, rapportant
+  chacun et poursuivant au-delà des échecs — les tables du framework vivent par
+  tenant, donc les réparer est un travail par tenant. Combinez avec `--system`
+  pour les tables du framework sur tous les tenants.
+
+Le nom est validé contre le répertoire de migrations d'abord, si bien qu'une faute de frappe
+ne peut pas faire atterrir une ligne bidon ; l'estampillage est idempotent, et le flag peut être
+répété pour réparer une série de lignes en une seule commande.
+
+---
+
+## Mise à niveau vers 0.51.2
+
+> **Les 0.51.0 et 0.51.1 ont été retirées (yanked)** — la réconciliation qu'elles promettaient ne s'est jamais
+> réellement déclenchée face à de vraies bases de données 0.46–0.50 (la 0.51.0 a déplacé les tables
+> media sur les migrations système et est entrée en collision ; le garde de la 0.51.1 exigeait qu'une
+> migration soit *purement* `CreateTable`, ce qu'aucune migration générée n'est).
+> **Mettez à niveau directement vers la 0.51.2**, qui corrige les deux.
+
+Pour un déploiement existant, la mise à niveau est un simple déploiement — pas de
+reprovisionnement, pas de DDL manuel :
+
+```bash
+cargo run -- migrate
+```
+
+Le fake-initial gardé gère les tables du framework préexistantes : le
+premier `migrate` enregistre la migration système dont les tables existent déjà
+dans le registre sans y toucher, crée uniquement ce qui manque réellement,
+et laisse vos données tranquilles. Si une base de données est dans un état partiel véritablement
+incohérent, le runner s'arrête et vous dit ce qu'il a trouvé ;
+résolvez-le avec `migrate --fake` plutôt que de forcer.
+
+---
+
+## Voir aussi
+
+- [`manage` guide](manage.md#migrations) — chaque verbe CLI de migration, avec
+  des exemples.
+- [Scaffolding](scaffolding.md) — d'où viennent `migrations/` et
+  `system/migrations/`.
+- [Models](models.md) — le derive à partir duquel les migrations sont générées.

--- a/docs/fr/openapi.md
+++ b/docs/fr/openapi.md
@@ -1,0 +1,271 @@
+# OpenAPI
+
+**Rustango** génère une spécification **OpenAPI 3.1** pour votre API et la sert
+avec Swagger UI / Redoc — aucune annotation à maintenir à la main. Pointer le
+générateur vers les serializers et les ViewSets que vous avez déjà écrits : les
+schémas de champ proviennent de `#[derive(Serializer)]`, les chemins CRUD de votre
+ViewSet, et un routeur d'une ligne monte `/openapi.json` + une page de
+documentation interactive. Lorsqu'un contrôle total est nécessaire, ces mêmes
+types permettent de construire n'importe quelle spécification à la main.
+
+[![OpenAPI Rustango : les champs du serializer deviennent un schéma de composant, le ViewSet devient des chemins CRUD, et openapi_router sert /openapi.json + Swagger UI](img/openapi.png)](img/openapi.png)
+
+> **Source :** `rustango::openapi` (`OpenApiSpec`, `Schema`, `OpenApiSchema`,
+> `PathItem`, `Operation`, `SecurityScheme`, `router::openapi_router`) et
+> `ViewSet::openapi_paths` — derrière la feature `openapi` (activée par défaut ; le
+> routeur du visualiseur nécessite aussi `admin`).
+>
+> **Version exécutable :** chaque extrait ci-dessous est copié de l'exemple testé
+> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog/tests/openapi.rs)
+> — `cargo test -p getting_started_blog --test openapi`. Le builder, le schéma et
+> les types de routeur sont en outre couverts par les tests unitaires du framework
+> lui-même (`crates/rustango/src/openapi/`).
+
+> **Un terme nouveau ici ?** *OpenAPI*, *schema*, *serializer*, *ViewSet* — voir le
+> [glossaire](glossary.md).
+
+---
+
+## Table des matières
+- [Démarrage rapide](#quick-start) — générer + servir en un seul écran
+- [Schémas depuis les serializers](#schemas-from-serializers) · [Chemins depuis les ViewSets](#paths-from-viewsets)
+- [Le servir](#serving-the-spec-swagger-ui--redoc) · [Construire une spec à la main](#hand-building-a-spec)
+- [Schémas de sécurité](#security-schemes) · [Le builder `Schema`](#the-schema-builder)
+- [Notes et limites](#notes-and-limits)
+
+---
+
+## Démarrage rapide
+
+Générer un schéma de composant depuis un serializer, des chemins CRUD depuis un
+ViewSet, puis monter le visualiseur :
+
+```rust
+use rustango::core::Model;                  // brings `Post::SCHEMA` into scope
+use rustango::openapi::{OpenApiSpec, OpenApiSchema, SecurityScheme};
+use rustango::openapi::router::openapi_router;
+use rustango::viewset::ViewSet;
+
+let mut spec = OpenApiSpec::new("Blog API", "1.0.0")
+    .description("Demo of rustango's OpenAPI generation")
+    .server("https://api.example.com", "Production")
+    .add_security_scheme("bearerAuth", SecurityScheme::bearer("JWT"))
+    .require_security("bearerAuth", [])                  // global default
+    .add_schema("Post", PostSerializer::openapi_schema()); // from #[derive(Serializer)]
+
+// CRUD path items straight off the ViewSet:
+for (path, item) in ViewSet::for_model(Post::SCHEMA).openapi_paths("/api/posts", "Post") {
+    spec = spec.add_path(path, item);
+}
+
+// Mount /openapi.json + /docs (Swagger UI) + /redoc:
+let app = axum::Router::new().merge(openapi_router(spec));
+```
+
+Visiter `/docs` pour Swagger UI, `/redoc` pour Redoc, ou récupérer le
+`/openapi.json` brut pour la génération de code (`openapi-generator`,
+`oapi-codegen`, etc.).
+
+---
+
+## Schémas depuis les serializers
+
+Avec la feature `openapi` activée, `#[derive(Serializer)]` émet aussi une impl
+[`OpenApiSchema`], si bien que tout serializer devient un schéma de composant :
+
+```rust
+use rustango::openapi::OpenApiSchema;
+
+let schema = PostSerializer::openapi_schema();   // -> rustango::openapi::Schema
+spec = spec.add_schema("Post", schema);
+```
+
+Le schéma reflète la **forme de l'API**, non la table brute : les champs renommés
+(`#[serializer(source = "body")]` → `content`), la visibilité `read_only` /
+`write_only`, les champs méthode calculés et les serializers imbriqués sont tous
+répercutés. Les types de champ sont mis en correspondance automatiquement :
+
+| Champ Rust | OpenAPI |
+|---|---|
+| `i32` / `i64` | `integer` (`int32` / `int64`) |
+| `f32` / `f64` | `number` (`float` / `double`) |
+| `String`, `&str` | `string` |
+| `bool` | `boolean` |
+| `Vec<T>` / `[T; N]` | `array` de `T` |
+| `Option<T>` | `T`, marqué `nullable` |
+| `chrono::DateTime<Utc>` | `string` / `date-time` |
+| `chrono::NaiveDate` | `string` / `date` |
+| `uuid::Uuid` | `string` / `uuid` |
+| `Auto<T>` | identique à `T` (assigné par le serveur) |
+| `HashMap<String, V>` | `object` avec `additionalProperties` |
+| `serde_json::Value` | forme libre (any) |
+
+Pour un **type de champ personnalisé**, implémenter `OpenApiSchema` une fois et il
+fonctionne partout où ce type apparaît :
+
+```rust
+struct Money { cents: i64 }
+
+impl rustango::openapi::OpenApiSchema for Money {
+    fn openapi_schema() -> rustango::openapi::Schema {
+        rustango::openapi::Schema::integer().description("amount in cents")
+    }
+}
+```
+
+> Voir le [guide des Serializers](serializers.md#openapi-schemas) pour les
+> attributs de champ qui façonnent la sortie.
+
+---
+
+## Chemins depuis les ViewSets
+
+`ViewSet::openapi_paths(prefix, schema_ref)` retourne les paires
+`(path, PathItem)` pour les cinq routes CRUD standard — list, create, retrieve,
+update, partial update, delete — câblées pour référencer un schéma de composant
+enregistré :
+
+```rust
+for (path, item) in ViewSet::for_model(Post::SCHEMA)
+    .filter_fields(&["author_id", "status"])
+    .search_fields(&["title", "body"])
+    .openapi_paths("/api/posts", "Post")
+{
+    spec = spec.add_path(path, item);
+}
+```
+
+Il produit `/api/posts` (GET list, POST create) et `/api/posts/{pk}` (GET, PUT,
+PATCH, DELETE), et il reste synchronisé avec la configuration du ViewSet :
+
+- **Pagination** → les bons paramètres de requête + l'enveloppe de réponse de liste
+  pour le style configuré (`page`/`page_size`, `cursor`, ou `limit`/`offset`).
+- **Filtrage / recherche / tri** → un paramètre de requête `?field=` par
+  `filter_fields` (avec les lookups `__gt`/`__in`/… disponibles décrits), plus
+  `?search=` et `?ordering=` lorsqu'ils sont configurés.
+- **`read_only()`** → les opérations d'écriture (POST/PUT/PATCH/DELETE) sont
+  omises.
+- **Paramètre de chemin** → `{pk}` typé d'après la clé primaire du modèle.
+- **`operationId`** → `list_post`, `create_post`, … (en snake_case par action).
+
+> Le ViewSet lui-même est documenté dans le [guide des ViewSets](viewsets.md).
+
+---
+
+## Servir la spec (Swagger UI / Redoc)
+
+`openapi_router(spec)` monte trois routes :
+
+| Route | Sert |
+|---|---|
+| `GET /openapi.json` | la spec au format JSON (`application/json`) |
+| `GET /docs` | Swagger UI (essai interactif try-it-out) |
+| `GET /redoc` | Redoc (référence épurée à trois volets) |
+
+```rust
+let app = axum::Router::new()
+    .merge(PostViewSet::router("/api/posts", pool.clone()))
+    .merge(openapi_router(spec));        // adds /openapi.json, /docs, /redoc
+```
+
+Les pages du visualiseur sont de minuscules coquilles HTML qui chargent Swagger
+UI / Redoc depuis un CDN (`unpkg` / `jsdelivr`) — aucun JS n'est empaqueté dans
+**Rustango**. Pour un déploiement isolé du réseau, écrire `spec.to_json()` dans un
+fichier au démarrage et héberger soi-même les assets du visualiseur depuis votre
+propre répertoire statique.
+
+---
+
+## Construire une spec à la main
+
+Lorsque votre API n'a pas la forme d'un ViewSet, construire la spec directement —
+les mêmes types, la fidélité complète d'OpenAPI 3.1 :
+
+```rust
+use rustango::openapi::{OpenApiSpec, PathItem, Operation, Response, Parameter, Schema};
+
+let spec = OpenApiSpec::new("My API", "1.0.0")
+    .description("Customer-facing public API")
+    .add_schema("Post", Schema::object()
+        .property("id", Schema::integer())
+        .property("title", Schema::string())
+        .required(["id", "title"]))
+    .add_path("/posts/{id}", PathItem::new()
+        .parameter(Parameter::path("id", Schema::integer()))
+        .get(Operation::new()
+            .summary("Get a post")
+            .operation_id("get_post")
+            .tag("posts")
+            .response("200", Response::new("OK")
+                .json_content(Schema::ref_("Post")))
+            .response("404", Response::new("not found"))));
+
+let json = spec.to_json();   // pretty-printed OpenAPI 3.1
+```
+
+`OpenApiSpec` accepte aussi `.contact(...)`, `.license(...)`, `.add_tag(...)`, et
+plusieurs entrées `.server(...)`.
+
+---
+
+## Schémas de sécurité
+
+Déclarer comment l'API s'authentifie, puis exiger un schéma globalement (les
+surcharges par opération l'emportent) :
+
+```rust
+use rustango::openapi::SecurityScheme;
+
+let spec = OpenApiSpec::new("API", "1.0")
+    .add_security_scheme("bearerAuth", SecurityScheme::bearer("JWT"))
+    .add_security_scheme("apiKey", SecurityScheme::api_key_header("X-API-Key"))
+    .require_security("bearerAuth", []);     // default for every operation
+```
+
+Assistants : `SecurityScheme::bearer(fmt)`, `basic()`, `api_key_header(name)`,
+`api_key_query(name)`, `oauth2_authorization_code(auth_url, token_url, scopes)`.
+Sur une `Operation`, `.no_security()` marque un endpoint public et
+`.require_security(scheme, scopes)` surcharge la valeur globale par défaut. Ceux-ci
+s'alignent sur l'authentification propre de **Rustango** (voir le
+[guide de Sécurité](security.md#authenticating-users)) : JWT → `bearer`, clés
+d'API → `apiKey`, OAuth2 → `oauth2`.
+
+---
+
+## Le builder `Schema`
+
+`Schema` est un builder fluide de JSON-Schema (sous-ensemble d'OpenAPI 3.1) :
+
+```rust
+Schema::object()
+    .property("id", Schema::integer())                       // int64
+    .property("email", Schema::email())                      // string/email
+    .property("status", Schema::string().enum_(["draft", "published"]))
+    .property("tags", Schema::array_of(Schema::string()))
+    .property("created", Schema::datetime().nullable())
+    .required(["id", "email"]);
+```
+
+Constructeurs de type : `string` · `integer` / `int32` · `number` · `boolean` ·
+`object` · `array_of(..)` · `any_object` · `datetime` / `date` / `time` · `uuid`
+· `decimal` · `binary` · `email` · `uri` · `ref_("Name")`. Modificateurs :
+`.property`, `.required`, `.nullable`, `.enum_`, `.format`, `.description`,
+`.example`, `.default_value`, `.min_length` / `.max_length`, `.minimum` /
+`.maximum`.
+
+---
+
+## Notes et limites
+
+- **C'est de l'OpenAPI 3.1** (`"openapi": "3.1.0"`), qui s'aligne sur JSON Schema
+  2020-12 — la plupart des outils modernes le consomment directement.
+- **Le routeur du visualiseur nécessite la feature `admin`** (pour axum) ;
+  `openapi` seul suffit à *construire* et sérialiser une spec (`spec.to_json()`).
+- **Les visualiseurs chargent depuis un CDN** — convient pour la documentation
+  interne/dev ; héberger soi-même les assets pour les déploiements hors ligne ou
+  verrouillés par CSP.
+- **`openapi_paths` couvre la forme CRUD standard.** Les actions personnalisées, ou
+  les endpoints faits main, s'ajoutent avec `add_path` (section « construire à la
+  main » ci-dessus).
+- Régénérer les SDK clients depuis `/openapi.json` en CI afin qu'ils ne dérivent
+  jamais du serveur.

--- a/docs/fr/orm.md
+++ b/docs/fr/orm.md
@@ -1,63 +1,63 @@
-# Cookbook de l'ORM
+# Livre de recettes de l'ORM
 
-Des patterns pour l'ORM de **Rustango** au-delà des bases. Si vous venez de l'ORM de Django, d'Eloquent (Laravel) ou d'ActiveRecord (Rails), les formes présentées ici vous sembleront familières. La plupart des exemples supposent que vous disposez déjà d'un modèle `Post` issu de `Getting Started`.
+Modèles d'utilisation de l'ORM **Rustango** au-delà des bases. Si vous venez de l'ORM de Django, d'Eloquent (Laravel) ou d'ActiveRecord (Rails), les formes présentées ici vous sembleront familières. La plupart des exemples supposent que vous disposez déjà d'un modèle `Post` issu de `Getting Started`.
 
-[![Type-checked ORM queries: chained filters, ordering, limits, and aggregation — all without raw SQL](img/orm.png)](img/orm.png)
+[![Requêtes ORM vérifiées par le typage : filtres chaînés, tri, limites et agrégation — le tout sans SQL brut](img/orm.png)](img/orm.png)
 
-> **Source :** `rustango::sql` (`QuerySet`, la macro `Q!` / le builder `Qb`) et l'API de requête
-> `#[derive(Model)]` — toujours compilée ; choisissez une feature de backend
+> **Source :** `rustango::sql` (`QuerySet`, la macro `Q!` / le builder `Qb`) et
+> l'API de requêtes `#[derive(Model)]` — toujours compilée ; choisissez une fonctionnalité de backend
 > (`postgres` / `mysql` / `sqlite`).
 >
-> **Version exécutable :** les patterns présentés ici s'exécutent dans l'exemple testé
+> **Version exécutable :** les modèles présentés ici s'exécutent dans l'exemple testé
 > [`orm_cookbook`](../crates/rustango/examples/orm_cookbook).
 >
-> **Nouveau sur un terme ici ?** Le [glossaire](glossary.md) définit *modèle*, *queryset*,
+> **Un terme vous est inconnu ?** Le [glossaire](glossary.md) définit *model*, *queryset*,
 > *pool* et *migration* en langage simple.
 
-Quelques termes Rust reviennent tout au long du texte. `&pool` est une référence partagée vers le pool de connexions à la base de données ; vous la passez aux méthodes qui exécutent réellement du SQL. `.await` exécute un appel asynchrone et attend le résultat. `Option<T>` est une valeur qui peut être présente (`Some`) ou absente (`None`) — le null de Rust. `Result` représente succès-ou-erreur ; le `?` final sur un appel retourne immédiatement en cas d'erreur. `Auto<i64>` est une clé primaire auto-incrémentée qui est soit `Set` (chargée depuis la base) soit `Unset` (pas encore insérée).
+Quelques termes Rust reviennent tout au long du document. `&pool` est une référence partagée vers le pool de connexions à la base de données ; vous le passez aux méthodes qui exécutent réellement du SQL. `.await` lance un appel asynchrone et attend le résultat. `Option<T>` est une valeur qui peut être présente (`Some`) ou absente (`None`) — le null de Rust. `Result` représente un succès ou une erreur ; le `?` en fin d'appel provoque un retour anticipé en cas d'erreur. `Auto<i64>` est une clé primaire à incrémentation automatique qui est soit `Set` (chargée depuis la base) soit `Unset` (pas encore insérée).
 
 ## Nouveautés (v0.41 / v0.42)
 
-Les dernières versions ont ajouté un lot de fonctionnalités à parité avec Django qui ne sont pas encore intégrées dans chaque section ci-dessous. Repères rapides :
+Les versions récentes ont ajouté un lot de fonctionnalités de parité avec Django qui ne sont pas encore intégrées à toutes les sections ci-dessous. Repères rapides :
 
-- **Macro `Q!` + builder `Qb` au runtime** (#269, #263) — filtres de forme Django, sûrs à la compilation. `User::objects().where_(Q!(User.email__icontains = "alice"))` échoue à la compilation en cas de faute de frappe sur un nom de champ. Variante composable au runtime pour les puces de filtre de l'admin : `let q = Qb::eq("active", true) & Qb::gt("age", 18i64);`.
-- **`.distinct_on(&["author_id"])`** (#264) — natif PG ; repli portable par fonction fenêtrée sur MySQL / SQLite. Patterns « dernier par groupe ».
-- **`bulk_upsert_pool(rows, unique_fields, update_fields, &pool)`** (#267) — équivalent de `bulk_create(update_conflicts=True)` de Django. ON CONFLICT / ON DUPLICATE KEY UPDATE tri-dialecte.
+- **Macro `Q!` + builder d'exécution `Qb`** (#269, #263) — filtres de forme Django, sûrs à la compilation. `User::objects().where_(Q!(User.email__icontains = "alice"))` échoue à la compilation si un nom de champ comporte une faute de frappe. Variante composable à l'exécution pour les puces de filtre de l'admin : `let q = Qb::eq("active", true) & Qb::gt("age", 18i64);`.
+- **`.distinct_on(&["author_id"])`** (#264) — natif sur PG ; repli portable via fonction de fenêtrage sur MySQL / SQLite. Modèles « le plus récent par groupe ».
+- **`bulk_upsert_pool(rows, unique_fields, update_fields, &pool)`** (#267) — le `bulk_create(update_conflicts=True)` de Django. `ON CONFLICT` / `ON DUPLICATE KEY UPDATE` tri-dialecte.
 - **`explain_pool()`** (#272) — EXPLAIN tri-dialecte. PG `EXPLAIN (FORMAT JSON, ANALYZE, BUFFERS)` / MySQL `EXPLAIN ANALYZE` / SQLite `EXPLAIN QUERY PLAN`.
-- **Bibliothèque de fonctions DB** (#266) — `Cast`, `LPad`, `RPad`, `MD5`, `SHA1`, `SHA256`, `Position`, `Repeat`, `Reverse`, `Sign`, `Mod`, `Power`, `Sqrt`. Émission par dialecte avec des erreurs claires là où SQLite ne dispose pas de la fonction.
-- **Types de champs** — `rust_decimal::Decimal` (natif PG/MySQL, via un shim Decode sur SQLite), `chrono::NaiveTime`, `Vec<u8>` (`FieldType::Binary`) désormais acceptés par `#[derive(Model)]` (#524, v0.42).
-- **`ModelForm::prepare_save()` / `PreparedSave`** (#375, v0.42) — équivalent de `save(commit=False)` de Django. Validez maintenant, modifiez l'ensemble d'écriture préparé, validez (commit) quand vous êtes prêt.
-- **`#[rustango(unique_when(columns = "...", condition = "..."))]`** (#265) — contraintes d'unicité partielles. « Email unique par ligne non supprimée » / « Slug unique par tenant ».
-- **`#[rustango(manager(ext = "FooManagerExt"))]`** (#271) — trait d'extension de manager personnalisé de forme Django, émis à côté du modèle. (C'est aussi la forme Rust des modèles proxy de Django — même table physique, plusieurs « personnalités » via des méthodes par trait. Voir `inheritance.rs:98-127`.)
+- **Bibliothèque de fonctions SQL** (#266) — `Cast`, `LPad`, `RPad`, `MD5`, `SHA1`, `SHA256`, `Position`, `Repeat`, `Reverse`, `Sign`, `Mod`, `Power`, `Sqrt`. Émission par dialecte avec des erreurs claires là où SQLite ne dispose pas de la fonction.
+- **Types de champ** — `rust_decimal::Decimal` (natif sur PG/MySQL, via un shim Decode sur SQLite), `chrono::NaiveTime`, `Vec<u8>` (`FieldType::Binary`) sont désormais acceptés par `#[derive(Model)]` (#524, v0.42).
+- **`ModelForm::prepare_save()` / `PreparedSave`** (#375, v0.42) — le `save(commit=False)` de Django. Validez maintenant, modifiez l'ensemble d'écriture préparé, puis validez quand vous êtes prêt.
+- **`#[rustango(unique_when(columns = "...", condition = "..."))]`** (#265) — contraintes d'unicité partielles. « E-mail unique par ligne non supprimée » / « Slug unique par tenant ».
+- **`#[rustango(manager(ext = "FooManagerExt"))]`** (#271) — trait d'extension de gestionnaire personnalisé de forme Django, émis à côté du modèle. (C'est aussi la forme Rust des modèles proxy de Django — même table physique, plusieurs « personnalités » via des méthodes par trait. Voir `inheritance.rs:98-127`.)
 - **`manage makemigrations --merge`** (#346, v0.42) — nœud de fusion de forme Django pour les chaînes de branches divergentes. Voir [`docs/manage.md`](manage.md#makemigrations---merge).
 
 Le CHANGELOG contient l'index complet des tickets pour chaque version.
 
 ## Table des matières
 
-- [Requêtage](#querying)
-- [Valeurs calculées & fonctions de base de données](#computed-values--database-functions)
+- [Requêtes](#querying)
+- [Valeurs calculées et fonctions de base de données](#computed-values--database-functions)
 - [Agrégations](#aggregations)
-- [Jointures & préchargement des lignes liées](#joins--preloading-related-rows)
+- [Jointures et préchargement des lignes liées](#joins--preloading-related-rows)
 - [Opérations en masse](#bulk-operations)
 - [Insertion ou mise à jour (upsert)](#insert-or-update-upsert)
 - [Transactions](#transactions)
-- [Relations plusieurs-à-plusieurs](#many-to-many)
+- [Plusieurs-à-plusieurs](#many-to-many)
 - [JSON / JSONB](#json--jsonb)
 - [Suppression logique](#soft-delete)
-- [Piste d'audit](#audit-trail)
-- [Échappatoire SQL brut](#raw-sql-escape-hatch)
-- [Chargement paresseux des FK](#lazy-fk-loading)
+- [Journal d'audit](#audit-trail)
+- [Échappatoire vers le SQL brut](#raw-sql-escape-hatch)
+- [Chargement paresseux des clés étrangères](#lazy-fk-loading)
 - [Quatre façons de filtrer](#four-ways-to-filter)
-- [Requêtes cloisonnées par tenant](#tenant-scoped-queries)
+- [Requêtes limitées au tenant](#tenant-scoped-queries)
 - [Signaux](#signals)
 - [Conseils de performance](#performance-tips)
 
 ---
 
-## Requêtage
+## Requêtes
 
-Lire des lignes depuis la base de données. `Post::objects()` démarre une requête (comme `Post.objects` de Django) ; vous enchaînez des filtres et un tri, puis appelez `.fetch(&pool).await?` pour l'exécuter et récupérer un `Vec<Post>`. `.where_(...)` ajoute une condition jointe par un AND.
+Lit des lignes depuis la base de données. `Post::objects()` démarre une requête (comme `Post.objects` de Django) ; vous chaînez les filtres et le tri, puis appelez `.fetch(&pool).await?` pour l'exécuter et récupérer un `Vec<Post>`. `.where_(...)` ajoute une condition jointe par AND.
 
 ```rust
 use rustango::core::Column as _;
@@ -106,7 +106,7 @@ let either_but_not_both = Post::objects()
 
 ### Filtres de comparaison
 
-Les méthodes de filtre courantes, une par opérateur SQL. Ce sont les lookups de champs de Django (`__gt`, `__in`, `__icontains`, etc.) sous une forme typée.
+Les méthodes de filtrage du quotidien, une par opérateur SQL. Ce sont les lookups de champ de Django (`__gt`, `__in`, `__icontains`, etc.) sous forme typée.
 
 ```rust
 Post::objects().where_(Post::view_count.gt(100)).fetch(&pool).await?;
@@ -125,7 +125,7 @@ Post::objects().where_(Post::published_at.between(start, end)).fetch(&pool).awai
 
 ### Tri des résultats
 
-Triez les lignes par une ou plusieurs colonnes, par une expression, ou avec un contrôle explicite de l'emplacement des NULL. Au-delà du `.order_by(&[("col", desc)])` basique, vous disposez de trois dimensions supplémentaires :
+Trie les lignes selon une ou plusieurs colonnes, selon une expression, ou avec un contrôle explicite de l'emplacement des NULL. Au-delà du `.order_by(&[("col", desc)])` de base, vous disposez de trois dimensions supplémentaires :
 
 ```rust
 use rustango::core::funcs::lower;
@@ -154,21 +154,21 @@ Post::objects()
     .fetch(&pool).await?;
 ```
 
-**Gestion des NULL par dialecte (sans `NullsOrder` explicite) :**
+**Gestion des NULL par dialecte (aucun `NullsOrder` explicite défini) :**
 
 | Dialecte | Défaut ASC | Défaut DESC |
 |---|---|---|
 | PostgreSQL | NULLS LAST | NULLS FIRST |
 | SQLite | NULLS LAST | NULLS FIRST |
-| MySQL | NULL en premier (sémantique « plus petite valeur ») | NULL en dernier |
+| MySQL | NULL en premier (sémantique de plus petite valeur) | NULL en dernier |
 
-Utilisez `.order_by_with_nulls(...)` / `.order_by_expr_with_nulls(...)` pour fixer le placement ; sinon c'est le comportement natif par défaut de la base qui s'applique. Sur MySQL, le writer émet `<col> IS NULL <asc|desc>` avant le tri réel pour l'émuler ; le SQL émis comporte deux termes ORDER BY par colonne épinglée, mais la sémantique correspond à PG/SQLite.
+Utilisez `.order_by_with_nulls(...)` / `.order_by_expr_with_nulls(...)` pour fixer le placement ; sinon, le défaut natif de la base de données s'applique. Sur MySQL, le writer émet `<col> IS NULL <asc|desc>` avant le tri réel pour l'émuler ; le SQL émis comporte deux clauses ORDER BY par colonne fixée, mais la sémantique correspond à PG/SQLite.
 
-**Composition de la chaîne.** `.order_by(...)`, `.order_by_with_nulls(...)` et `.order_by_expr(...)` s'accumulent dans une liste unifiée, **dans l'ordre d'enregistrement**. `.replace_order_by(&[...])` efface tous les appels order-by précédents. `.flip_order_by()` inverse chaque direction ET échange `NullsOrder::First` ↔ `NullsOrder::Last` afin que la sémantique « les NULL restent du même côté » survive à une inversion (pour `First` / `Last` explicites ; le comportement par défaut du dialecte sous `Default` continue de suivre la direction).
+**Composition de la chaîne.** `.order_by(...)`, `.order_by_with_nulls(...)` et `.order_by_expr(...)` s'accumulent en une seule liste unifiée dans l'**ordre d'enregistrement**. `.replace_order_by(&[...])` efface tous les appels de tri précédents. `.flip_order_by()` inverse chaque direction ET échange `NullsOrder::First` ↔ `NullsOrder::Last` afin que la sémantique « NULL du même côté » survive à une inversion (pour les `First` / `Last` explicites ; le comportement par défaut du dialecte sous `Default` continue de suivre la direction).
 
 ### Tri aléatoire
 
-Retournez les lignes dans un ordre aléatoire — le `.order_by('?')` de Django. Utilisez `.order_random()`. Il émet `ORDER BY RANDOM()` sur PG et SQLite, `ORDER BY RAND()` sur MySQL. Pratique pour la rotation de bannières, l'échantillonnage, ou l'attribution de buckets de test A/B sans charger les lignes côté application pour les mélanger.
+Renvoie les lignes dans un ordre aléatoire — le `.order_by('?')` de Django. Utilisez `.order_random()`. Cela émet `ORDER BY RANDOM()` sur PG et SQLite, `ORDER BY RAND()` sur MySQL. Pratique pour la rotation de bannières, l'échantillonnage ou l'affectation à des groupes de test A/B sans charger les lignes dans l'application pour les mélanger.
 
 ```rust
 // Three random posts.
@@ -185,9 +185,9 @@ Post::objects()
     .fetch(&pool).await?;
 ```
 
-La variante IR ne porte aucune direction ni clause NULLS : un tri aléatoire est non ordonné par définition, et la clé aléatoire est calculée par ligne (non NULL).
+La variante IR ne porte aucune direction ni clause NULLS : le tri aléatoire est par définition non ordonné, et la clé aléatoire est calculée par ligne (non-NULL).
 
-**Avertissement de performance.** `ORDER BY RANDOM()` force un **balayage complet de la table + un tri en mémoire par une clé aléatoire par ligne**. Le planificateur de requêtes ne peut pas utiliser d'index. Pour des tables bien plus grandes que la mémoire, préférez le pattern compatible index :
+**Mise en garde de performance.** `ORDER BY RANDOM()` force un **balayage complet de la table + un tri en mémoire selon une clé aléatoire par ligne**. Le planificateur de requêtes ne peut pas utiliser d'index. Pour des tables bien plus grandes que la mémoire, préférez le modèle compatible avec les index :
 
 ```rust
 // Coin-flip offset; range-scans the PK index.
@@ -200,11 +200,11 @@ Post::objects()
     .fetch(&pool).await?;
 ```
 
-Le compromis : l'adjacence dans les lignes du résultat reflète l'adjacence des PK, ce n'est donc pas « uniformément aléatoire » au sens strict — mais c'est exempt du coût d'un balayage complet de table.
+Le compromis : l'adjacence dans les lignes du résultat reflète l'adjacence des clés primaires, ce n'est donc pas « uniformément aléatoire » au sens strict — mais c'est exempt du coût du balayage complet de la table.
 
 ### Pagination
 
-Récupérez une page de résultats à la fois. `.limit(size).offset(...)` est la forme simple par numéro de page ; la forme par curseur (« tout ce qui vient après le dernier id vu ») s'adapte mieux sur les grandes tables.
+Récupère une page de résultats à la fois. `.limit(size).offset(...)` est la forme simple par numéro de page ; la forme par curseur (« tout ce qui suit le dernier id que j'ai vu ») passe mieux à l'échelle sur les grandes tables.
 
 ```rust
 // Page-number — page 2 of 50-row pages = LIMIT 50 OFFSET 50.
@@ -220,9 +220,9 @@ let next = Post::objects()
 
 Pour la pagination par curseur côté HTTP, utilisez plutôt `ViewSet::cursor_pagination("id")`.
 
-### Récupérer des lignes dans une map
+### Récupération de lignes dans une map
 
-Recherchez plusieurs lignes à partir d'une liste de valeurs et récupérez-les sous forme de `HashMap` indexée par cette colonne. C'est le `in_bulk(ids, field_name=)` de Django. Utilisez `.in_bulk(...)` pour « récupérer ces N lignes en un aller-retour, indexées par id ». Un `HashMap<K, V>` est le dictionnaire / la table de hachage de Rust.
+Recherche de nombreuses lignes selon une liste de valeurs et les récupère sous forme de `HashMap` indexée par cette colonne. C'est le `in_bulk(ids, field_name=)` de Django. Utilisez `.in_bulk(...)` pour « récupérer ces N lignes en un seul aller-retour, indexées par id ». Un `HashMap<K, V>` est le dictionnaire / la table de hachage de Rust.
 
 ```rust
 use std::collections::HashMap;
@@ -243,13 +243,13 @@ let by_isbn: HashMap<String, Book> = Book::objects()
     .await?;
 ```
 
-Se compose avec les filtres `.where_()` précédents — la liste `IN` est jointe par un AND avec le WHERE existant. Un `ids` vide court-circuite avec une map vide (aucun SQL n'est émis). La closure gère explicitement le déballage `Auto<T>` / `ForeignKey<T, K>`, donnant à l'appelant le contrôle sur la façon dont la clé se matérialise.
+Se compose avec les filtres `.where_()` précédents — la liste `IN` se joint par AND au WHERE existant. Une liste `ids` vide court-circuite avec une map vide (aucun SQL n'est émis). La closure gère explicitement le déballage de `Auto<T>` / `ForeignKey<T, K>`, donnant aux appelants le contrôle sur la matérialisation de la clé.
 
-Pendant cloisonnée par tenant : `in_bulk_on(column, ids, extract, &executor)` prend n'importe quel executor sqlx — à combiner avec `tenant.conn()` pour les tenants en mode schéma.
+Variante limitée au tenant : `in_bulk_on(column, ids, extract, &executor)` prend n'importe quel exécuteur sqlx — à combiner avec `tenant.conn()` pour les tenants en mode schéma.
 
-### Verrouiller des lignes pour mise à jour
+### Verrouillage de lignes pour mise à jour
 
-Verrouillez les lignes sélectionnées afin qu'aucune autre transaction ne puisse les modifier avant votre commit — la manière standard de réserver du travail ou d'éviter les mises à jour perdues. C'est le `select_for_update(skip_locked=, nowait=, of=, no_key=)` de Django. Appelez `.select_for_update()` ; cela ajoute `SELECT … FOR UPDATE` (ou une variante) et le verrou dure pendant toute la transaction englobante.
+Verrouille les lignes que vous sélectionnez pour qu'aucune autre transaction ne puisse les modifier jusqu'à votre commit — la manière standard de réclamer du travail ou d'éviter les mises à jour perdues. C'est le `select_for_update(skip_locked=, nowait=, of=, no_key=)` de Django. Appelez `.select_for_update()` ; cela ajoute `SELECT … FOR UPDATE` (ou une variante) et le verrou dure pendant la transaction englobante.
 
 ```rust
 // Canonical "claim next available row" pattern. Worker A grabs the
@@ -269,27 +269,27 @@ tx.commit().await?;
 
 **Méthodes du builder** — à chaîner pour les activer :
 
-- `.select_for_update()` — simple `FOR UPDATE`.
-- `.skip_locked()` — ajoute `SKIP LOCKED` ; les lignes détenues par une autre transaction sont silencieusement écartées au lieu de bloquer.
-- `.nowait()` — ajoute `NOWAIT` ; remonte immédiatement une erreur du driver si une ligne correspondante est verrouillée. Mutuellement exclusif avec `skip_locked` (le writer choisit le plus permissif, `SKIP LOCKED`, si les deux sont définis).
-- `.no_key()` — émet `FOR NO KEY UPDATE` à la place (PG 9.3+). Verrou plus faible qui ne bloque pas les écrivains touchant uniquement des colonnes non-clé.
-- `.of(&["table_or_alias", …])` — restreint le verrou à des tables spécifiques quand la requête fait des JOIN.
+- `.select_for_update()` — un simple `FOR UPDATE`.
+- `.skip_locked()` — ajoute `SKIP LOCKED` ; les lignes détenues par une autre transaction sont silencieusement filtrées au lieu de bloquer.
+- `.nowait()` — ajoute `NOWAIT` ; fait remonter immédiatement une erreur du pilote si une ligne correspondante est verrouillée. Mutuellement exclusif avec `skip_locked` (le writer choisit le plus permissif `SKIP LOCKED` si les deux sont définis).
+- `.no_key()` — émet plutôt `FOR NO KEY UPDATE` (PG 9.3+). Verrou plus faible qui ne bloque pas les écrivains ne touchant que des colonnes non clés.
+- `.of(&["table_or_alias", …])` — restreint le verrou à des tables spécifiques lorsque la requête effectue des JOIN.
 
-Appeler `.skip_locked()` / `.nowait()` / `.no_key()` / `.of(…)` sans `.select_for_update()` préalable active implicitement le verrou, ce qui correspond à l'ergonomie de Django.
+Appeler `.skip_locked()` / `.nowait()` / `.no_key()` / `.of(…)` sans un `.select_for_update()` préalable active implicitement le verrou, à l'image de l'ergonomie de Django.
 
 **Comportement tri-dialecte :**
 
 | Dialecte | Comportement |
 |---|---|
-| PostgreSQL | Support complet — chaque flag émet sa syntaxe native. |
-| MySQL 8.0.1+ | Prend tout en charge sauf `NO KEY` — ce flag retombe sur le simple `FOR UPDATE` (le verrou le plus strict). |
-| SQLite | Aucune syntaxe de verrou au niveau ligne. Le writer n'émet aucune clause ; les transactions détiennent un verrou d'écriture implicite pour la base entière. Utilisez une autre stratégie pour SQLite (typiquement une boucle d'attente active sur la transaction elle-même). |
+| PostgreSQL | Prise en charge complète — chaque option émet sa syntaxe native. |
+| MySQL 8.0.1+ | Prend tout en charge sauf `NO KEY` — cette option retombe sur un simple `FOR UPDATE` (le verrou plus strict). |
+| SQLite | Aucune syntaxe de verrou au niveau ligne. Le writer n'émet aucune clause ; les transactions détiennent un verrou d'écriture implicite pour toute la base de données. Utilisez une autre stratégie pour SQLite (généralement une boucle d'attente active sur la transaction elle-même). |
 
-**Doit s'exécuter dans une transaction.** `FOR UPDATE` hors transaction est un no-op sur PostgreSQL (la transaction implicite à instruction unique libère le verrou immédiatement) et une erreur sur MySQL. À combiner avec `pool.begin()` (ou `rustango::sql::atomic`).
+**Doit s'exécuter à l'intérieur d'une transaction.** `FOR UPDATE` hors transaction est une opération sans effet sur PostgreSQL (la transaction implicite à instruction unique libère le verrou immédiatement) et une erreur sur MySQL. À combiner avec `pool.begin()` (ou `rustango::sql::atomic`).
 
-### Combiner des requêtes (union, intersection, différence)
+### Combinaison de requêtes (union, intersection, différence)
 
-Fusionnez deux requêtes ou plus sur le même modèle avec les opérateurs d'ensemble SQL. Ce sont les `.union()`, `.intersection()` et `.difference()` de Django.
+Fusionne deux requêtes ou plus portant sur le même modèle avec les opérateurs d'ensemble SQL. Ce sont les `.union()`, `.intersection()` et `.difference()` de Django.
 
 ```rust
 // Posts that are EITHER drafts OR currently in review.
@@ -307,10 +307,10 @@ let inbox: Vec<Post> = Post::objects()
 |---|---|---|
 | `.union(other)` | `UNION` | Combine + déduplique |
 | `.union_all(other)` | `UNION ALL` | Combine, conserve les doublons (moins coûteux, pas de passe DISTINCT) |
-| `.intersection(other)` | `INTERSECT` | Lignes présentes dans les DEUX querysets |
+| `.intersection(other)` | `INTERSECT` | Lignes présentes dans LES DEUX querysets |
 | `.difference(other)` | `EXCEPT` | Lignes du premier queryset mais PAS des autres |
 
-Chaque méthode prend un `QuerySet<T>` — les deux branches doivent cibler le même modèle `T`, de sorte que la forme des colonnes correspond par construction (vérifié à la compilation grâce aux génériques de Rust). Les appels s'accumulent ; mélanger des opérateurs dans une même chaîne est autorisé (`a.union(b).intersection(c)` s'évalue de gauche à droite conformément à la norme SQL).
+Chaque méthode prend un `QuerySet<T>` — les deux branches doivent cibler le même modèle `T`, de sorte que la forme des colonnes correspond par construction (vérifiée à la compilation par les génériques de Rust). Les appels s'accumulent ; mélanger les opérateurs dans une même chaîne est autorisé (`a.union(b).intersection(c)` s'évalue de gauche à droite selon le standard SQL).
 
 **Les modificateurs externes s'appliquent au résultat fusionné** :
 
@@ -331,13 +331,13 @@ let mixed = qs_a
     .fetch(&pool).await?;
 ```
 
-**Tri-dialecte** : PostgreSQL + SQLite prennent en charge les quatre opérateurs sur chaque version que **Rustango** supporte. MySQL 8.0+ prend en charge `UNION`/`UNION ALL` ; `INTERSECT`/`EXCEPT` sont arrivés dans MySQL 8.0.31. Les versions plus anciennes de MySQL font remonter l'erreur de syntaxe du driver au moment du fetch — il n'y a pas de garde côté client.
+**Tri-dialecte** : PostgreSQL + SQLite prennent en charge les quatre opérateurs sur toutes les versions que **Rustango** supporte. MySQL 8.0+ prend en charge `UNION`/`UNION ALL` ; `INTERSECT`/`EXCEPT` sont arrivés dans MySQL 8.0.31. Les versions plus anciennes de MySQL font remonter l'erreur de syntaxe du pilote au moment du fetch — il n'y a pas de garde côté client.
 
-**Chemin d'erreur sur le builder typé** : `.union(other_qs)` (ainsi que `.intersection()` / `.difference()`) compile la branche de manière eager et panique si la branche échoue à compiler (colonne mal orthographiée, etc.). Pour une composition faillible où l'appelant veut un `Result`, compilez d'abord la branche et passez-la via `.with_compound(SetOp::Union, branch)` — un point d'entrée générique unique couvre chaque opérateur. La forme de la panique correspond à celle de Django : une mauvaise branche est une erreur de programmation, pas une condition de données au runtime.
+**Chemin d'erreur sur le builder typé** : `.union(other_qs)` (ainsi que `.intersection()` / `.difference()`) compile la branche de manière anticipée et panique si la branche échoue à la compilation (colonne mal orthographiée, etc.). Pour une composition faillible où l'appelant veut un `Result`, compilez d'abord la branche et passez-la via `.with_compound(SetOp::Union, branch)` — un seul point d'entrée générique couvre tous les opérateurs. La forme de la panique correspond à celle de Django : une mauvaise branche est une erreur du programmeur, pas une condition de données à l'exécution.
 
-### Streamer de grands ensembles de résultats
+### Traitement en flux de grands ensembles de résultats
 
-Traitez une table volumineuse sans la charger entièrement en mémoire. C'est le `.iterator(chunk_size=2000)` de Django. Appelez `.iterator(chunk_size)` ; il récupère `chunk_size` lignes à la fois (via `LIMIT N OFFSET M`) et ne met jamais en tampon l'ensemble du résultat. À utiliser pour les exports de millions de lignes, les pipelines ETL, et les jobs batch.
+Traite une table volumineuse sans la charger entièrement en mémoire. C'est le `.iterator(chunk_size=2000)` de Django. Appelez `.iterator(chunk_size)` ; cela récupère `chunk_size` lignes à la fois (via `LIMIT N OFFSET M`) et ne met jamais en tampon l'ensemble complet des résultats. À utiliser pour les exports d'un million de lignes, les pipelines ETL et les traitements par lots.
 
 ```rust
 // 1. Whole-chunk loop — process N rows at a time.
@@ -356,15 +356,15 @@ while let Some(post) = iter.next_row(&pool).await? {
 }
 ```
 
-**Définissez un `order_by`.** `OFFSET` sur une requête sans tri stable retourne des lignes imprévisibles d'un chunk à l'autre — typiquement `.order_by(&[("pk", false)])` afin que chaque chunk reprenne proprement. La méthode n'impose pas de tri (certaines requêtes veulent légitimement aucun tri, par exemple une vidange en une seule fois), mais itérer sans tri est un piège classique.
+**Définissez un `order_by`.** Un `OFFSET` sur une requête sans tri stable renvoie des lignes imprévisibles d'un chunk à l'autre — typiquement `.order_by(&[("pk", false)])` afin que chaque chunk s'enchaîne proprement. La méthode n'impose pas de tri (certaines requêtes veulent légitimement ne pas trier, p. ex. une vidange en une seule passe), mais une itération non triée est un piège.
 
-**Compromis vs curseurs côté serveur.** C'est un simple découpeur par LIMIT/OFFSET. Sur une colonne de tri indexée par btree, PostgreSQL balaie les N premières lignes avant de retourner la (N+1)-ième — donc une pagination profonde coûte `O(n²)` au total. Pour une vidange de 10M de lignes, cela compte ; pour 100k lignes, généralement pas. Le découpeur l'emporte sur la portabilité (fonctionne sur tous les backends sans surcharge de transaction) et la simplicité (aucune gestion de cycle de vie de curseur). Pour une lecture réellement en streaming sur PG, passez par `pool.begin()` + l'API Stream `sqlx::query(...).fetch(&mut *tx)` en SQL brut directement — le protocole étendu streame depuis le serveur sans re-cherche par offset.
+**Compromis face aux curseurs côté serveur.** Il s'agit d'un simple découpage LIMIT/OFFSET. Sur une colonne de tri indexée par btree, PostgreSQL balaie les N premières lignes avant de renvoyer la (N+1)ᵉ — donc la pagination profonde représente un travail total en `O(n²)`. Pour une vidange de 10 M de lignes, cela compte ; pour 100 k lignes, généralement non. Le découpeur l'emporte sur la portabilité (fonctionne sur tous les backends sans surcoût de transaction) et la simplicité (aucune gestion du cycle de vie d'un curseur). Pour des lectures véritablement en flux sur PG, passez directement à l'API Stream `pool.begin()` + `sqlx::query(...).fetch(&mut *tx)` brut — le protocole étendu diffuse depuis le serveur sans re-recherche par offset.
 
-**Mélanger `next_chunk` et `next_row` sur le même itérateur est sûr.** Le tampon interne `VecDeque` se vide dans l'ordre des lignes avant tout nouveau fetch en base, donc `next_chunk` après un `next_row` partiel retourne d'abord les lignes déjà en tampon, puis continue avec des chunks frais.
+**Mélanger `next_chunk` et `next_row` sur le même itérateur est sûr.** Le tampon interne `VecDeque` se vide dans l'ordre des lignes avant toute nouvelle récupération en base, donc un `next_chunk` après une vidange partielle par `next_row` renvoie d'abord les lignes restantes en tampon, puis continue avec de nouveaux chunks.
 
-`.rows_seen()` (compteur cumulé) et `.is_exhausted()` (indicateur de fin de vidange) sont tous deux disponibles pour le suivi de progression et les vérifications de terminaison.
+`.rows_seen()` (compteur cumulé) et `.is_exhausted()` (indicateur post-vidange) sont tous deux disponibles pour le suivi de progression et les vérifications de terminaison.
 
-**Risque d'écriture concurrente.** Chaque chunk est une requête séparée, donc des lignes insérées/supprimées entre les chunks peuvent être ignorées ou dupliquées (le classique problème de « fenêtrage » de la pagination par OFFSET). Pour des tables en lecture seule / uniquement en ajout — le cas d'usage typique de l'export — ce n'est pas un problème. Pour des tables écrites de manière concurrente, il vous faut une transaction en isolation snapshot afin que chaque chunk voie la même vue. **`ChunkedIter` prend un `&Pool`, pas une `&mut Transaction`, donc l'API du découpeur ne peut pas être utilisée directement dans la transaction** — codez à la main le SELECT découpé contre la transaction :
+**Risque d'écriture concurrente.** Chaque chunk est une requête distincte, donc les lignes insérées/supprimées entre les chunks peuvent être omises ou dupliquées (le problème classique de « fenêtrage » de la pagination par OFFSET). Pour les tables en lecture seule / en ajout uniquement — le cas d'usage typique d'export — ce n'est pas un souci. Pour les tables écrites en concurrence, vous avez besoin d'une transaction en isolation par instantané afin que chaque chunk voie la même vue. **`ChunkedIter` prend un `&Pool`, pas un `&mut Transaction`, donc l'API du découpeur ne peut pas être utilisée directement à l'intérieur de la transaction** — écrivez plutôt le SELECT découpé à la main contre la transaction :
 
 ```rust
 let mut tx = pool.begin().await?;
@@ -390,18 +390,18 @@ loop {
 tx.commit().await?;
 ```
 
-**`select_for_update()` ne se propage pas d'un chunk à l'autre.** Les verrous de ligne détenus par `.select_for_update()` sont relâchés à la fin de la transaction implicite de chaque chunk. Il n'existe pas de correctif au niveau du découpeur : le builder `.iterator()` prend un `&Pool`, les variantes de verrouillage ont besoin d'une `&mut Transaction`, et les deux ne se combinent pas. Pour une vidange verrouillée, vous avez deux options, chacune avec un compromis :
+**`select_for_update()` ne se propage pas d'un chunk à l'autre.** Les verrous de ligne détenus par `.select_for_update()` sont libérés à la fin de la transaction implicite de chaque chunk. Il n'existe pas de correctif au niveau du découpeur : le builder `.iterator()` prend un `&Pool`, les variantes de verrouillage ont besoin d'un `&mut Transaction`, et les deux ne se composent pas. Pour une vidange verrouillée, vous avez deux chemins, chacun avec un compromis :
 
-- **`.fetch_on(&mut *tx)` sur tout le résultat** — un seul aller-retour, un `Vec<T>` complet en mémoire. Correct quand le résultat tient en mémoire.
-- **LIMIT/OFFSET codé à la main dans la transaction** — même forme que l'extrait en isolation snapshot ci-dessus ; les chunks restent streamés mais vous êtes hors de l'API `ChunkedIter`.
+- **`.fetch_on(&mut *tx)` sur tout le résultat** — un seul aller-retour, un `Vec<T>` complet en mémoire. Convient quand le résultat tient.
+- **LIMIT/OFFSET écrit à la main à l'intérieur de la transaction** — même forme que l'extrait d'isolation par instantané ci-dessus ; les chunks restent en flux mais vous sortez de l'API `ChunkedIter`.
 
-Un futur compagnon `iterator_on(&mut *tx, chunk_size)` (suivi d'issue) comblerait cet écart. Hors périmètre pour l'issue #23.
+Un futur compagnon `iterator_on(&mut *tx, chunk_size)` (suivi via un ticket) comblerait cet écart. Hors périmètre du ticket #23.
 
-**`chunk_size` doit être > 0.** Les valeurs nulles ou négatives paniquent. Choisissez une valeur adaptée à votre budget de taille de ligne (le défaut de Django est `2000` ; raisonnable pour des lignes étroites, plus bas pour de larges colonnes TEXT/JSONB).
+**`chunk_size` doit être > 0.** Les valeurs nulles ou négatives paniquent. Choisissez une valeur adaptée à votre budget de taille de ligne (le défaut de Django est `2000` ; raisonnable pour des lignes étroites, à baisser pour des colonnes TEXT/JSONB larges).
 
-### Sélectionner des colonnes spécifiques
+### Sélection de colonnes spécifiques
 
-Récupérez seulement quelques colonnes au lieu de structs `Post` entières — les `.values('col')` et `.values_list('col', flat=True)` de Django. Utilisez-les quand vous n'avez besoin que de quelques colonnes d'une table large, ou quand le résultat alimente du code dynamique (templates, export CSV, JSON). Vous récupérez des maps, des tuples, ou une liste typée plate au lieu d'instances de modèle.
+Récupère seulement quelques colonnes au lieu de structs `Post` complètes — les `.values('col')` et `.values_list('col', flat=True)` de Django. À utiliser lorsque vous n'avez besoin que de quelques colonnes d'une table large, ou lorsque le résultat alimente du code dynamique (templates, export CSV, JSON). Vous récupérez des maps, des tuples ou une liste plate typée au lieu d'instances de modèle.
 
 ```rust
 use rustango::core::SqlValue;
@@ -428,27 +428,27 @@ let ids: Vec<i64> = Post::objects()
     .fetch::<i64>(&pool).await?;
 ```
 
-**Trois builders, une seule IR.** Les trois définissent `SelectQuery::projection` sur la liste de colonnes validée — le SQL est identique dans les trois formes terminales ; seul le décodage des lignes diffère :
+**Trois builders, une seule IR.** Les trois définissent `SelectQuery::projection` sur la liste de colonnes validée — le SQL est identique pour les trois formes terminales ; seul le décodage des lignes diffère :
 
-| Builder | Forme SQL | Retourne |
+| Builder | Forme SQL | Renvoie |
 |---|---|---|
 | `.values_dict(&[cols])` | `SELECT col1, col2 FROM …` | `Vec<HashMap<String, SqlValue>>` |
-| `.values_list(&[cols])` | `SELECT col1, col2 FROM …` | `Vec<Vec<SqlValue>>` (ordonné selon `cols`) |
+| `.values_list(&[cols])` | `SELECT col1, col2 FROM …` | `Vec<Vec<SqlValue>>` (ordonné par `cols`) |
 | `.values_list_flat(col)` | `SELECT col FROM …` | `Vec<U>` (typé, via `fetch::<U>(...)`) |
 
-**Fonctionne avec le reste de la chaîne de requête.** `.where_()`, `.filter()`, `.order_by()`, `.limit()`, `.offset()`, et les opérateurs d'ensemble (`.union()` / `.intersection()` / `.difference()`) — toute méthode appelée AVANT `.values_*` est conservée. Les builders values sont terminaux (rien ne s'enchaîne après eux), donc définissez la forme de la requête d'abord, puis exécutez le fetch.
+**Fonctionne avec le reste de la chaîne de requête.** `.where_()`, `.filter()`, `.order_by()`, `.limit()`, `.offset()`, et les opérateurs d'ensemble (`.union()` / `.intersection()` / `.difference()`) — toute méthode appelée AVANT `.values_*` est propagée. Les builders de valeurs sont terminaux (rien ne se chaîne après eux), donc définissez d'abord la forme de la requête, puis fetchez.
 
 **Validation au moment de `.compile()` / `.fetch()` :**
 - Liste de colonnes vide (`.values_dict(&[])`) → [`QueryError::EmptyValuesProjection`].
 - Nom de colonne mal orthographié (`.values_dict(&["nope"])`) → [`QueryError::UnknownField`].
 
-**Tri-dialecte : émission de la projection identique sur PG / MySQL / SQLite** (seul le guillemetage des identifiants diffère). Pour `.values_list_flat::<U>(...)`, `U` doit implémenter `Decode + Type` de sqlx sur chaque backend ciblé par le binaire ; les choix courants (`i64`, `i32`, `String`, `bool`, `f64`) fonctionnent universellement.
+**Tri-dialecte : émission de projection identique sur PG / MySQL / SQLite** (seul le guillemetage des identifiants diffère). Pour `.values_list_flat::<U>(...)`, `U` doit implémenter `Decode + Type` de sqlx sur chaque backend ciblé par le binaire — les choix courants (`i64`, `i32`, `String`, `bool`, `f64`) fonctionnent universellement.
 
-**Pourquoi ne pas changer le `.values()` existant pour faire une projection pure ?** `QuerySet::values(cols)` est déjà promu vers [`AggregateBuilder`] pour le chemin d'auto-inférence de GROUP BY (issue #75). Le renommer casserait ~20 sites d'appel existants. La nouvelle chaîne de méthodes `.values_dict()` / `.values_list()` / `.values_list_flat()` se place à côté, en laissant le chemin d'agrégation intact. L'erreur préexistante `QueryError::ValuesRequiresAggregate` se déclenche toujours pour `.values(cols).compile()` sans `.annotate(...)` ultérieur — son message oriente désormais les appelants vers les nouvelles méthodes de projection pure.
+**Pourquoi ne pas modifier le `.values()` existant pour faire une projection pure ?** `QuerySet::values(cols)` promeut déjà vers [`AggregateBuilder`] pour le chemin d'inférence automatique du GROUP BY (ticket #75). Le renommer casserait environ 20 sites d'appel existants. Les nouvelles méthodes de chaîne `.values_dict()` / `.values_list()` / `.values_list_flat()` coexistent, laissant le chemin d'agrégation intact. L'erreur préexistante `QueryError::ValuesRequiresAggregate` se déclenche toujours pour `.values(cols).compile()` sans `.annotate(...)` ultérieur — son message oriente désormais les appelants vers les nouvelles méthodes de projection pure.
 
-### Inclure ou exclure des colonnes
+### Inclusion ou exclusion de colonnes
 
-Même idée que la section précédente, mais dans la forme include/exclude de Django : `.only('id', 'name')` ne conserve que les colonnes nommées, `.defer('big_field')` conserve tout sauf elles. Utilisez-les sur des tables larges où de grandes colonnes TEXT / BLOB / JSONB rendent les vues de liste coûteuses à lire :
+Même idée que la section précédente, mais dans la forme inclusion/exclusion de Django : `.only('id', 'name')` conserve uniquement les colonnes nommées, `.defer('big_field')` conserve tout sauf elles. À utiliser sur les tables larges où de grandes colonnes TEXT / BLOB / JSONB rendent les vues en liste coûteuses à lire :
 
 ```rust
 // .only(...) — fetch only the named columns.
@@ -464,15 +464,15 @@ let rows: Vec<HashMap<String, SqlValue>> = Post::objects()
     .fetch(&pool).await?;
 ```
 
-**Sémantique** : `.only(&[cols])` est un synonyme de `.values_dict(cols)` — même IR, même forme de retour, point d'entrée séparé pour une lisibilité de forme Django. `.defer(&[cols])` calcule le complément par rapport au schéma du modèle (chaque colonne scalaire du modèle SAUF celles listées) et route vers le même chemin.
+**Sémantique** : `.only(&[cols])` est un synonyme de `.values_dict(cols)` — même IR, même forme de retour, point d'entrée distinct pour une lisibilité de forme Django. `.defer(&[cols])` calcule le complément par rapport au schéma du modèle (toutes les colonnes scalaires du modèle SAUF celles listées) et emprunte le même chemin.
 
-**Avertissement — le type de retour diffère de Django.** Les `.only()` / `.defer()` de Django retournent des instances de `Model` partiellement hydratées où les champs différés se chargent paresseusement à l'accès à l'attribut. **Rustango** n'a pas d'équivalent à la magie des descripteurs de Python ; la forme de retour est `Vec<HashMap<String, SqlValue>>` (ou `Vec<Vec<SqlValue>>` si vous substituez `.values_list(...)` à la place). Le décodage de ligne partielle typé est prévu pour une future itération.
+**Mise en garde — le type de retour diffère de Django.** Les `.only()` / `.defer()` de Django renvoient des instances de `Model` partiellement hydratées où les champs différés se chargent paresseusement à l'accès à l'attribut. **Rustango** n'a pas d'équivalent de la magie des descripteurs de Python ; la forme de retour est `Vec<HashMap<String, SqlValue>>` (ou `Vec<Vec<SqlValue>>` si vous remplacez par `.values_list(...)`). Le décodage typé de ligne partielle est en file d'attente pour un futur incrément.
 
-**Sécurité vis-à-vis des fautes de frappe** : `.defer(&["nope_col"])` fait remonter `QueryError::UnknownField` au moment de `.compile()` — la faute de frappe ne se transforme pas silencieusement en « projeter toutes les colonnes ». `.only(&[])` fait remonter `QueryError::EmptyValuesProjection` ; `.defer(&[])` est un no-op sémantique (projette chaque colonne).
+**Sécurité face aux fautes de frappe** : `.defer(&["nope_col"])` fait remonter `QueryError::UnknownField` au moment de `.compile()` — la faute ne se transforme pas silencieusement en « projeter toutes les colonnes ». `.only(&[])` fait remonter `QueryError::EmptyValuesProjection` ; `.defer(&[])` est une opération sans effet sémantique (projette chaque colonne).
 
-### Filtrer avec des expressions régulières
+### Correspondance avec des expressions régulières
 
-Comparez une colonne à un motif regex — les `__regex` / `__iregex` de Django. `.regex()` est sensible à la casse, `.iregex()` insensible à la casse, et `.not_regex()` / `.not_iregex()` en sont les formes négées.
+Fait correspondre une colonne à un motif regex — les `__regex` / `__iregex` de Django. `.regex()` est sensible à la casse, `.iregex()` insensible à la casse, et `.not_regex()` / `.not_iregex()` sont les formes négatives.
 
 ```rust
 use rustango::core::Column as _;
@@ -503,35 +503,35 @@ User::objects()
 | Dialecte | Sensible à la casse | Insensible à la casse | Notes |
 |---|---|---|---|
 | PostgreSQL | `<col> ~ ?` / `<col> !~ ?` | `<col> ~* ?` / `<col> !~* ?` | Opérateurs POSIX natifs |
-| MySQL | `` `col` REGEXP ? `` / `` `col` NOT REGEXP ? `` | `LOWER(`col`) REGEXP LOWER(?)` (la forme négée enveloppe avec `NOT`) | Repli via LOWER() pour `i*` |
-| SQLite | `"col" REGEXP ?` / `"col" NOT REGEXP ?` | `LOWER("col") REGEXP LOWER(?)` (la forme négée enveloppe avec `NOT`) | Nécessite la fonction utilisateur `regexp` chargée sur la connexion |
+| MySQL | `` `col` REGEXP ? `` / `` `col` NOT REGEXP ? `` | `LOWER(`col`) REGEXP LOWER(?)` (la négation encapsule un `NOT`) | Repli via LOWER() pour `i*` |
+| SQLite | `"col" REGEXP ?` / `"col" NOT REGEXP ?` | `LOWER("col") REGEXP LOWER(?)` (la négation encapsule un `NOT`) | Nécessite le chargement de la fonction utilisateur `regexp` sur la connexion |
 
-**SQLite exige une fonction utilisateur `regexp` enregistrée** — elle n'est pas intégrée. sqlx-sqlite 0.8 n'en enregistre **pas** une par défaut. Deux façons de l'activer :
+**SQLite requiert une fonction utilisateur `regexp` enregistrée** — elle n'est pas intégrée. sqlx-sqlite 0.8 n'en enregistre **pas** par défaut. Deux façons de l'activer :
 
-1. **Simple** — activez la feature cargo `regexp` de sqlx-sqlite, puis activez-la sur la connexion :
+1. **Facile** — activez la fonctionnalité cargo `regexp` de sqlx-sqlite, puis activez-la sur la connexion :
    ```rust
    use sqlx::sqlite::SqliteConnectOptions;
    let opts = SqliteConnectOptions::new()
        .filename("app.db")
        .with_regexp();  // gated on sqlx-sqlite/regexp
    ```
-2. **Manuelle** — enregistrez une closure Rust via `SqliteConnection::lock_handle()` + FFI brut (`sqlite3_create_function_v2`).
+2. **Manuel** — enregistrez une closure Rust via `SqliteConnection::lock_handle()` + FFI brute (`sqlite3_create_function_v2`).
 
-Sans cela, la requête émet du SQL `REGEXP` valide que SQLite rejette à l'exécution avec `no such function: regexp` (propre à l'analyse syntaxique — `tests/regex_sqlite_live.rs` fixe ce comportement).
+Sans elle, la requête émet un SQL `REGEXP` valide que SQLite rejette à l'exécution avec `no such function: regexp` (l'analyse est propre — `tests/regex_sqlite_live.rs` verrouille ce comportement).
 
-**Le dialecte du motif diffère selon les backends.** PostgreSQL utilise les regex POSIX étendues ; MySQL utilise des regex basées sur ICU avec sa propre saveur ; SQLite délègue à ce que la fonction utilisateur implémente (typiquement la crate `regex` de Rust). Les motifs qui s'appuient sur une syntaxe spécifique à un dialecte (par exemple les frontières de mots `\m` / `\M` de PG) ne se transposent pas d'un dialecte à l'autre — restez sur le sous-ensemble portable (`^`, `$`, `.`, `*`, `+`, `?`, `[...]`, `()`, `|`) si le même modèle est interrogé depuis plusieurs backends.
+**Le dialecte des motifs diffère selon les backends.** PostgreSQL utilise la regex étendue POSIX ; MySQL utilise une regex basée sur ICU avec sa propre saveur ; SQLite délègue à ce que la fonction utilisateur implémente (généralement la crate `regex` de Rust). Les motifs qui s'appuient sur une syntaxe spécifique au dialecte (p. ex. les frontières de mot `\m` / `\M` de PG) ne sont pas portables — tenez-vous-en au sous-ensemble portable (`^`, `$`, `.`, `*`, `+`, `?`, `[...]`, `()`, `|`) si le même modèle est interrogé depuis plusieurs backends.
 
-**Les valeurs non-chaîne sont rejetées au moment de `.compile()`** — passer `SqlValue::I64(42)` à `__regex` fait remonter `QueryError::InvalidLookupValue { suffix: "regex", expected: "SqlValue::String(<regex pattern>)", … }` plutôt qu'une conversion silencieuse.
+**Les valeurs non-chaîne sont rejetées à `.compile()`** — passer `SqlValue::I64(42)` à `__regex` fait remonter `QueryError::InvalidLookupValue { suffix: "regex", expected: "SqlValue::String(<regex pattern>)", … }` plutôt qu'un cast silencieux.
 
 ---
 
-## Valeurs calculées & fonctions de base de données
+## Valeurs calculées et fonctions de base de données
 
-Laissez la base de données calculer les choses au lieu de charger des lignes dans l'application, les modifier, puis les réécrire. `F("col")` référence une colonne par son nom (l'objet `F()` de Django), et les builders `funcs::*` enveloppent des fonctions SQL scalaires comme `LOWER` ou `COALESCE`. Ensemble, ils débloquent trois patterns que le simple `.set()` / `.where_()` basé sur des valeurs ne peut pas exprimer :
+Laissez la base de données calculer des choses au lieu de charger les lignes dans l'application, les modifier, puis les réécrire. `F("col")` désigne une colonne par son nom (l'objet `F()` de Django), et les builders `funcs::*` encapsulent des fonctions SQL scalaires comme `LOWER` ou `COALESCE`. Ensemble, ils débloquent trois modèles que les `.set()` / `.where_()` basés sur des valeurs ne peuvent pas exprimer :
 
-### Incréments atomiques (pas de race lecture-modification-écriture)
+### Incréments atomiques (sans course lecture-modification-écriture)
 
-Le bug classique de compteur — récupérer une ligne, incrémenter un champ, sauvegarder — perd des mises à jour quand deux requêtes s'exécutent en même temps. `F("col") + 1` réduit l'aller-retour à un seul `UPDATE`, de sorte que la base détient le verrou de ligne pour vous :
+Le bug classique du compteur — récupérer une ligne, incrémenter un champ, sauvegarder — perd des mises à jour quand deux requêtes s'exécutent en même temps. `F("col") + 1` réduit l'aller-retour en un seul `UPDATE`, de sorte que la base de données tient le verrou de ligne pour vous :
 
 ```rust
 use rustango::core::F;
@@ -545,11 +545,11 @@ Post::objects()
 
 Tri-dialecte : émet `views = ("views" + $1)` sur PG, ``views = (`views` + ?)`` sur MySQL, identique sur SQLite. L'arithmétique est parenthésée afin que les opérations imbriquées restent non ambiguës : `F("a") + F("b") * 2`.
 
-Opérateurs pris en charge : `+ - * / %` plus `& | ^ << >>` (opérations sur bits ; le XOR sur SQLite émet une erreur claire `OpNotSupportedInDialect` puisque SQLite n'a pas de symbole XOR).
+Opérateurs pris en charge : `+ - * / %` plus `& | ^ << >>` (au niveau bit ; le XOR sur SQLite émet un `OpNotSupportedInDialect` clair puisque SQLite n'a pas de symbole XOR).
 
-### Comparer deux colonnes dans un filtre
+### Comparaison de deux colonnes dans un filtre
 
-Filtrez une colonne par rapport à une autre, pas par rapport à un littéral — par exemple `Reservation start_date < end_date` pour vérifier la cohérence d'une ligne, ou `Inventory available > reserved` pour trouver les lignes disposant de capacité :
+Filtre une colonne par rapport à une autre, et non par rapport à une valeur littérale — p. ex. `Reservation start_date < end_date` pour valider une ligne, ou `Inventory available > reserved` pour trouver les lignes ayant de la capacité :
 
 ```rust
 use rustango::core::Column as _;
@@ -566,16 +566,16 @@ let oversold = Inventory::objects()
     .fetch(&pool).await?;
 ```
 
-La famille `*_expr` — `eq_expr`, `ne_expr`, `lt_expr`, `lte_expr`, `gt_expr`, `gte_expr` — reflète les méthodes littérales `eq`, `ne`, … mais accepte n'importe quel `impl Into<Expr>` sur le côté droit : des références de colonne nues (`F("col")`), de l'arithmétique (`F("price") * 2`), ou des résultats de fonction (section suivante).
+La famille `*_expr` — `eq_expr`, `ne_expr`, `lt_expr`, `lte_expr`, `gt_expr`, `gte_expr` — reflète les méthodes littérales `eq`, `ne`, … mais accepte tout `impl Into<Expr>` du côté droit : références de colonne nues (`F("col")`), arithmétique (`F("price") * 2`) ou résultats de fonction (section suivante).
 
-### Fonctions scalaires — texte, mathématiques, gestion des NULL
+### Fonctions scalaires — texte, maths, gestion des NULL
 
 `rustango::core::funcs` fournit des builders pour les fonctions SQL les plus utilisées. Les 17 disponibles à ce jour :
 
 | Groupe | Builders |
 |---|---|
 | **Texte** | `lower`, `upper`, `length`, `trim`, `ltrim`, `rtrim`, `concat`, `substr`, `replace` |
-| **Mathématiques** | `abs`, `ceil`, `floor`, `round` (1 argument) / `round_to` (2 arguments, précision) |
+| **Maths** | `abs`, `ceil`, `floor`, `round` (1 arg) / `round_to` (précision à 2 args) |
 | **NULL** | `coalesce`, `greatest`, `least`, `nullif` |
 
 ```rust
@@ -621,7 +621,7 @@ Player::objects()
 
 ### Comportement tri-dialecte
 
-La plupart des fonctions émettent un SQL identique sur PG / MySQL / SQLite. Les formes divergentes sont gérées par dialecte, de manière transparente :
+La plupart des fonctions émettent un SQL identique sur PG / MySQL / SQLite. Les formes divergentes sont gérées par dialecte de manière transparente :
 
 | Builder | PG | MySQL | SQLite |
 |---|---|---|---|
@@ -630,9 +630,9 @@ La plupart des fonctions émettent un SQL identique sur PG / MySQL / SQLite. Les
 | `greatest([a, b])` | `GREATEST(a, b)` | `GREATEST(a, b)` | `MAX(a, b)` scalaire |
 | `least([a, b])` | `LEAST(a, b)` | `LEAST(a, b)` | `MIN(a, b)` scalaire |
 
-### Passer des arguments mixtes à une fonction
+### Passage d'arguments mixtes à une fonction
 
-Les fonctions qui prennent une liste d'arguments (comme `concat`) acceptent n'importe quel itérable d'`Expr`. Les tableaux Rust doivent contenir un seul type, donc un mélange de `F` (colonne) et `&str` (littéral) ne compile pas tel quel — appelez `.into()` une fois par élément pour élever chacun en `Expr` :
+Les fonctions qui prennent une liste d'arguments (comme `concat`) acceptent n'importe quel itérable d'`Expr`. Les tableaux Rust doivent contenir un seul type, donc un mélange de `F` (colonne) et de `&str` (littéral) ne passe pas la vérification de type tel quel — appelez `.into()` une fois par élément pour élever chacun en `Expr` :
 
 ```rust
 concat([F("first").into(), " ".into(), F("last").into()])
@@ -641,16 +641,16 @@ concat([F("first").into(), " ".into(), F("last").into()])
 
 Ou construisez un `Vec<Expr>` et passez-le directement — même forme, même résultat.
 
-### Avertissements
+### Mises en garde
 
-- **`length` octets-vs-caractères** : PG retourne des caractères sur `TEXT`/`VARCHAR`, MySQL retourne des **octets** (utilisez le futur builder `CharLength` du framework ou enveloppez manuellement dans `CHAR_LENGTH` si vous avez besoin de comptages de caractères multi-dialecte).
-- **`round(x, n)` sur PG** : la forme à 2 arguments de PG exige un `numeric`, pas un `double`. Passez soit une colonne entière, soit convertissez d'abord le float ; MySQL et SQLite acceptent les deux types.
-- **`greatest([single_arg])` / `least([single_arg])` sur SQLite** : non pris en charge — le `MAX(x)` à un seul argument de SQLite est la forme *agrégat*, pas la forme scalaire. Le writer retourne `OpNotSupportedInDialect`. PG et MySQL acceptent la forme à un seul argument comme un no-op retournant `x`. Enveloppez avec au moins un littéral pour rester portable.
-- **`substr` avec un début négatif** : PG traite un négatif comme « commencer à la position de caractère N » (avec un effet de clamp à 0) ; MySQL et SQLite traitent un négatif comme « compter depuis la fin ». Évitez les débuts négatifs dans du code portable.
+- **`length` octets contre caractères** : PG renvoie des caractères sur `TEXT`/`VARCHAR`, MySQL renvoie des **octets** (utilisez le futur builder `CharLength` du framework ou encapsulez manuellement dans `CHAR_LENGTH` si vous avez besoin d'un comptage de caractères multi-dialecte).
+- **`round(x, n)` sur PG** : la forme à 2 arguments de PG requiert un `numeric`, pas un `double`. Passez soit une colonne entière, soit castez d'abord le flottant ; MySQL et SQLite acceptent l'un ou l'autre type.
+- **`greatest([single_arg])` / `least([single_arg])` sur SQLite** : non pris en charge — le `MAX(x)` de SQLite avec un seul argument est la forme *agrégat*, pas la forme scalaire. Le writer renvoie `OpNotSupportedInDialect`. PG et MySQL acceptent la forme à argument unique comme une opération sans effet renvoyant `x`. Encapsulez avec au moins un littéral pour rester portable.
+- **`substr` avec un début négatif** : PG traite le négatif comme « commencer à la position N » (le ramène en pratique à 0) ; MySQL et SQLite traitent le négatif comme « compter depuis la fin ». Évitez les débuts négatifs dans du code portable.
 
-### Fonctions de date & heure
+### Fonctions de date et d'heure
 
-Les builders `now()`, `extract_*` et `trunc_*` fonctionnent sur les dates et timestamps. Utilisez-les pour les requêtes de cohortes, les agrégats par tranche temporelle, et l'estampillage de l'heure courante à l'écriture — tout cela dans la base de données, sans faire d'aller-retour de lignes vers l'application.
+Les builders `now()`, `extract_*` et `trunc_*` travaillent sur des dates et des horodatages. Utilisez-les pour les requêtes de cohorte, les agrégats par intervalle de temps et l'estampillage de l'heure courante à l'écriture — le tout dans la base de données, sans faire transiter les lignes par l'application.
 
 ```rust
 use rustango::core::funcs::{
@@ -722,19 +722,19 @@ Order::objects()
 | `trunc_date(x)` | `DATE(x)` | `DATE(x)` | `DATE(x)` |
 | `trunc_year(x)` | `DATE_TRUNC('year', x)` → timestamp | `DATE_FORMAT(x, '%Y-01-01')` → **chaîne** | `strftime('%Y-01-01', x)` → **chaîne** |
 | `trunc_month(x)` | `DATE_TRUNC('month', x)` → timestamp | `DATE_FORMAT(x, '%Y-%m-01')` → **chaîne** | `strftime('%Y-%m-01', x)` → **chaîne** |
-| `trunc_day(x)` | `DATE_TRUNC('day', x)` → timestamp | `DATE(x)` → date | `date(x)` → texte |
+| `trunc_day(x)` | `DATE_TRUNC('day', x)` → timestamp | `DATE(x)` → date | `date(x)` → text |
 
-**Avertissements spécifiques aux dates/heures :**
+**Mises en garde propres aux dates/heures :**
 
-- **Le type de retour de `trunc_year/month` diverge** : timestamp sur PG, texte sur MySQL/SQLite. Effectuez la conversion côté application à la lecture si vous avez besoin d'un `chrono::NaiveDate` typé — ou stockez le bucket comme un simple entier (`extract_year` + `extract_month`) et reconstruisez-le dans le code.
-- **`extract_weekday` est normalisé à 0 = dimanche** sur les trois dialectes. Le `DAYOFWEEK()` natif de MySQL retourne 1=dimanche, donc le writer soustrait 1.
-- **⚠ `extract_week` n'est PAS portable.** PG retourne des numéros de semaine ISO 8601 (début lundi, plage 1–53) ; le `WEEK(x)` par défaut de MySQL débute le dimanche avec une plage **0**–53 ; le `strftime('%W')` de SQLite débute le lundi avec une plage 00–53. Pour le 2024-01-01 (un lundi), les trois backends retournent respectivement `1`, `0` et `01`. Le code mono-backend peut l'utiliser librement ; le code multi-dialecte devrait calculer la limite de semaine comme un `chrono::DateTime` typé en Rust et filtrer sur la colonne timestamp à la place.
-- **`extract_quarter` génère une erreur sur SQLite** avec `OpNotSupportedInDialect` — SQLite n'a pas de jeton trimestre natif. Soit protégez la fonctionnalité derrière `cfg(not(sqlite))`, soit calculez via `((extract_month - 1) / 3) + 1` côté application.
-- **Gestion des fuseaux horaires** : `EXTRACT` de PG opère dans le fuseau horaire de la colonne ; `YEAR()` de MySQL opère dans le fuseau horaire de la session (`SET time_zone = ...`) ; SQLite n'a pas de vrai support de fuseau horaire — traitez tout comme UTC. Utilisez `TIMESTAMPTZ` sur PG, `DATETIME` sur MySQL avec le fuseau horaire de session défini, des chaînes ISO-8601 sur SQLite.
+- **Le type de retour de `trunc_year/month` diverge** : timestamp sur PG, texte sur MySQL/SQLite. Castez côté application à la lecture si vous avez besoin d'un `chrono::NaiveDate` typé — ou stockez l'intervalle sous forme d'entier simple (`extract_year` + `extract_month`) et reconstruisez-le dans le code.
+- **`extract_weekday` est normalisé à 0 = dimanche** sur les trois dialectes. Le `DAYOFWEEK()` natif de MySQL renvoie 1 = dimanche, donc le writer soustrait 1.
+- **⚠ `extract_week` n'est PAS portable.** PG renvoie les numéros de semaine ISO 8601 (début lundi, plage 1–53) ; le `WEEK(x)` par défaut de MySQL commence le dimanche avec une plage **0**–53 ; le `strftime('%W')` de SQLite commence le lundi avec une plage 00–53. Pour le 2024-01-01 (un lundi), les trois backends renvoient respectivement `1`, `0` et `01`. Le code mono-backend peut l'utiliser librement ; le code multi-dialecte devrait calculer la frontière de semaine sous forme de `chrono::DateTime` typé en Rust et filtrer sur la colonne d'horodatage.
+- **`extract_quarter` sur SQLite génère une erreur** avec `OpNotSupportedInDialect` — SQLite n'a pas de jeton de trimestre natif. Soit vous protégez la fonctionnalité derrière `cfg(not(sqlite))`, soit vous calculez via `((extract_month - 1) / 3) + 1` dans le code applicatif.
+- **Gestion des fuseaux horaires** : le `EXTRACT` de PG opère dans le fuseau horaire de la colonne ; le `YEAR()` de MySQL opère dans le fuseau horaire de la session (`SET time_zone = ...`) ; SQLite n'a pas de vraie prise en charge des fuseaux — traitez tout comme de l'UTC. Utilisez `TIMESTAMPTZ` sur PG, `DATETIME` sur MySQL avec le fuseau de session défini, des chaînes ISO-8601 sur SQLite.
 
 ### Expressions CASE WHEN
 
-Construisez un `CASE WHEN … THEN … ELSE … END` SQL avec les builders `case()` / `.when()` / `value()` — le `Case`/`When` de Django. Utilisez-le pour des tris personnalisés, des colonnes dérivées dans `annotate`, des valeurs par défaut calculées dans `update`, et (combiné avec `Sum`) des agrégats conditionnels.
+Construit un `CASE WHEN … THEN … ELSE … END` SQL avec les builders `case()` / `.when()` / `value()` — les `Case`/`When` de Django. À utiliser pour les tris personnalisés, les colonnes dérivées dans `annotate`, les valeurs par défaut calculées dans `update`, et (associé à `Sum`) les agrégats conditionnels.
 
 ```rust
 use rustango::core::case::{case, value};
@@ -787,33 +787,33 @@ Post::objects()
 **Forme du builder :**
 
 - `case()` — démarre un builder.
-- `.when(condition, then)` — ajoute une branche. `condition` est n'importe quoi implémentant `Into<WhereExpr>` (typiquement `Column::eq()`, `.and()`, `.or()`) ; `then` est n'importe quoi implémentant `Into<Expr>` (littéral, `F()`, appel de fonction, `case()` imbriqué).
-- `.default(expr)` — définit la branche `ELSE` optionnelle. L'omettre produit un `CASE` qui retourne `NULL` pour les lignes non appariées (norme SQL).
+- `.when(condition, then)` — ajoute une branche. `condition` est tout ce qui implémente `Into<WhereExpr>` (typiquement `Column::eq()`, `.and()`, `.or()`) ; `then` est tout ce qui implémente `Into<Expr>` (littéral, `F()`, appel de fonction, `case()` imbriqué).
+- `.default(expr)` — définit la branche `ELSE` optionnelle. L'omettre produit un `CASE` qui renvoie `NULL` pour les lignes non correspondantes (standard SQL).
 - `.build()` ou `.into()` — finalise en un `Expr` pour `set_expr` / `eq_expr` / `annotate`.
-- `value(literal)` — sucre syntaxique de style Django pour `Expr::Literal(...)`. Optionnel — les littéraux nus se convertissent via `Into<Expr>`, mais `value("…")` se lit explicitement comme « c'est un littéral chaîne, pas une référence de colonne ».
+- `value(literal)` — sucre syntaxique à la Django pour `Expr::Literal(...)`. Optionnel — les littéraux nus sont convertis via `Into<Expr>`, mais `value("…")` se lit explicitement comme « ceci est un littéral de chaîne, pas une référence de colonne ».
 
 **Émission tri-dialecte :**
 
-`CASE WHEN … THEN … [ELSE …] END` fait partie de la norme SQL-92 — émis de manière identique sur PG, MySQL et SQLite. Aucune répartition par dialecte dans le writer.
+`CASE WHEN … THEN … [ELSE …] END` est standard SQL-92 — émis à l'identique sur PG, MySQL et SQLite. Aucune répartition par dialecte dans le writer.
 
-**Avertissements :**
+**Mises en garde :**
 
-- **Branches vides** : `case().build()` sans appel `.when(...)` est rejeté à l'émission avec `SqlError::EmptyCaseBranches`. SQL exige au moins une clause `WHEN`. Une condition `WHEN` vide (par exemple `WhereExpr::And(vec![])`) est rejetée avec `SqlError::EmptyCaseWhenCondition` pour la même raison.
-- **Unification des types entre branches** : chaque dialecte choisit un type commun à partir des valeurs `THEN` et `ELSE`. Mélanger les types (`THEN 1_i64` + `ELSE "string"`) peut lever une erreur de conversion au runtime ou coercer de manière surprenante. Restez sur un seul type par `CASE`.
-- **Performance** : chaque ligne évalue les prédicats `WHEN` dans l'ordre jusqu'à ce qu'un corresponde (premier qui correspond gagne, par ligne). Le coût croît avec le nombre de branches et le coût des prédicats. Pour de nombreuses correspondances de chaînes fixes, une jointure avec une petite table de correspondance peut être moins coûteuse et plus lisible.
+- **Branches vides** : `case().build()` sans aucun appel `.when(...)` est rejeté au moment de l'émission avec `SqlError::EmptyCaseBranches`. SQL requiert au moins une clause `WHEN`. Une condition `WHEN` vide (p. ex. `WhereExpr::And(vec![])`) est rejetée avec `SqlError::EmptyCaseWhenCondition` pour la même raison.
+- **Unification de type entre les branches** : chaque dialecte choisit un type commun parmi les valeurs `THEN` et `ELSE`. Mélanger les types (`THEN 1_i64` + `ELSE "string"`) peut lever une erreur de cast à l'exécution ou convertir de manière surprenante. Tenez-vous-en à un seul type par `CASE`.
+- **Performance** : chaque ligne évalue les prédicats `WHEN` dans l'ordre jusqu'à ce qu'un corresponde (premier trouvé gagne, par ligne). Le coût croît avec le nombre de branches et le coût des prédicats. Pour de nombreux mappages chaîne-fixe, une jointure sur une petite table de correspondance peut être moins coûteuse et plus lisible.
 
 ### Sous-requêtes (EXISTS, IN, scalaire)
 
-Intégrez une requête dans une autre — les `Exists`, `Subquery` et `OuterRef` de Django. Ces builders couvrent la plupart des patterns « existe-t-il au moins une ligne liée ? » et « cette valeur est-elle dans cet ensemble ? » :
+Imbrique une requête dans une autre — les `Exists`, `Subquery` et `OuterRef` de Django. Ces builders couvrent la plupart des modèles « une ligne liée existe-t-elle ? » et « cette valeur est-elle dans cet ensemble ? » :
 
 | Builder | Forme | À utiliser pour |
 |---|---|---|
 | `exists(qs)` | `EXISTS (SELECT … FROM …)` | « Auteurs ayant au moins un livre » |
-| `not_exists(qs)` | `NOT EXISTS (SELECT …)` | « Auteurs sans aucun livre » (anti-jointure) |
+| `not_exists(qs)` | `NOT EXISTS (SELECT …)` | « Auteurs sans livre » (anti-jointure) |
 | `in_subquery(col, qs)` | `<col> IN (SELECT …)` | « Posts dans n'importe quelle catégorie publique » |
 | `not_in_subquery(col, qs)` | `<col> NOT IN (SELECT …)` | Inverse du précédent |
 | `subquery(qs)` | `(SELECT …)` en tant que scalaire | Valeur par défaut calculée dans `set_expr` |
-| `outer_ref(col)` | `"<outer_table>"."<col>"` | Référencer la ligne externe depuis l'intérieur de l'un des éléments ci-dessus |
+| `outer_ref(col)` | `"<outer_table>"."<col>"` | Référencer la ligne externe depuis l'intérieur de l'un des précédents |
 
 ```rust
 use rustango::core::subquery::{exists, not_exists, in_subquery, outer_ref};
@@ -852,27 +852,27 @@ let featured = Author::objects()
     .fetch(&pool).await?;
 ```
 
-**La corrélation imbriquée fonctionne.** Un OuterRef à l'intérieur d'une sous-requête doublement imbriquée se résout vers la portée englobante *immédiate* — le writer maintient une pile de portées au fur et à mesure qu'il descend, donc `EXISTS (Book WHERE id = outer.id AND EXISTS (Comment WHERE book_id = outer.id))` résout le `outer.id` interne vers `Book.id`, pas vers le `Author.id` le plus externe. Utilisez `outer_ref(...)` deux fois si vous avez réellement besoin d'atteindre deux portées plus haut.
+**La corrélation imbriquée fonctionne.** Un OuterRef à l'intérieur d'une sous-requête doublement imbriquée se résout vers la portée englobante *immédiate* — le writer maintient une pile de portées à mesure qu'il descend, de sorte que `EXISTS (Book WHERE id = outer.id AND EXISTS (Comment WHERE book_id = outer.id))` résout le `outer.id` interne vers `Book.id`, pas vers le `Author.id` le plus externe. Utilisez `outer_ref(...)` deux fois si vous avez réellement besoin d'atteindre deux portées plus haut.
 
 **Erreurs :**
 
-- **`OuterRefOutsideSubquery`** — émettre `outer_ref("col")` au niveau supérieur (pas à l'intérieur d'un wrapper de sous-requête) est une erreur de programmation. Le writer la signale bruyamment avec le nom de la colonne pour repérer facilement le site d'appel.
+- **`OuterRefOutsideSubquery`** — émettre `outer_ref("col")` au niveau supérieur (pas à l'intérieur d'une enveloppe de sous-requête) est une erreur de programmation. Le writer la lève bruyamment avec le nom de la colonne afin que le site d'appel soit facile à trouver.
 
-**Avertissements :**
+**Mises en garde :**
 
-- **Restriction de projection pour `IN (SELECT …)`** : PG exige strictement que le SELECT interne projette exactement une colonne pour la forme `<col> IN (…)`. **Rustango** ne fournit pas encore de restriction de projection de type `.values("col")` (issue #62), donc le queryset interne projette toujours chaque colonne du modèle — ce qui fait que `in_subquery` ne fonctionne aujourd'hui qu'avec des tables dont le modèle n'a qu'une seule colonne. Pour le cas multi-colonnes, utilisez plutôt `exists(inner.where_(<outer col>.eq_expr(outer_ref(...))))` — cela a la même sémantique et ne dépend pas de la forme de projection.
-- **Le `subquery(...)` scalaire exige un interne à une colonne-une ligne** : le SQL émis est `SET col = (SELECT …)` — si l'interne produit plus d'une ligne, la base lève une erreur au runtime. Contraignez via `.limit(1)` et soit restreignez la projection (une fois disponible), soit concevez l'interne autour d'un invariant d'unicité.
-- **La validation à la compilation des sous-requêtes vit sur le queryset interne** : les fautes de frappe sur les colonnes remontent à l'appel `queryset.compile()?` interne, pas à `compile()` de la requête externe. Construisez d'abord l'interne et propagez `?`.
+- **Rétrécissement de projection de `IN (SELECT …)`** : PG requiert strictement que le SELECT interne ne projette qu'une seule colonne pour la forme `<col> IN (…)`. **Rustango** ne livre pas encore le rétrécissement de projection de style `.values("col")` (ticket #62), donc le queryset interne projette toujours chaque colonne du modèle — ce qui fait que `in_subquery` ne fonctionne aujourd'hui que contre des tables dont le modèle a une seule colonne. Pour le cas multi-colonnes, utilisez `exists(inner.where_(<outer col>.eq_expr(outer_ref(...))))` — il a la même sémantique et ne dépend pas de la forme de la projection.
+- **Le `subquery(...)` scalaire requiert un interne une-colonne-une-ligne** : le SQL émis est `SET col = (SELECT …)` — si l'interne produit plus d'une ligne, la base de données génère une erreur à l'exécution. Contraignez via `.limit(1)` et soit rétrécissez la projection (une fois disponible), soit concevez l'interne autour d'un invariant d'unicité.
+- **La validation à la compilation des sous-requêtes réside sur le queryset interne** : les fautes de frappe de colonne remontent à l'appel `queryset.compile()?` interne, pas au `compile()` de la requête externe. Construisez l'interne en premier et propagez `?`.
 
-### Quand passer au SQL brut à la place
+### Quand passer plutôt au SQL brut
 
-Les builders ci-dessus couvrent les cas courants. Pour ce qu'ils n'expriment pas encore — `Cast`, la recherche plein texte, les opérateurs de chemin JSON, les fonctions de hachage, la trigonométrie, les fonctions fenêtrées — voir la section [Échappatoire SQL brut](#raw-sql-escape-hatch) ci-dessous, ou attendez les issues de suivi qui étendent le même arbre d'expressions.
+Les builders ci-dessus couvrent les cas courants. Pour ce qu'ils n'expriment pas encore — `Cast`, recherche plein texte, opérateurs de chemin JSON, fonctions de hachage, trigonométrie, fonctions de fenêtrage — voir la section [Échappatoire vers le SQL brut](#raw-sql-escape-hatch) ci-dessous, ou attendez les tickets de suivi qui étendent le même arbre d'expressions.
 
 ---
 
 ## Agrégations
 
-Comptez, sommez, moyennez, et groupez des lignes. `.count()`, `.sum()`, `.avg()`, `.min()` et `.max()` retournent un seul nombre ; `.annotate(...)` combiné avec `.values(...)` construit des requêtes GROUP BY (l'`aggregate` / `annotate` de Django). Les résultats d'agrégation reviennent sous forme de `Vec<HashMap<String, SqlValue>>` plutôt que de structs typées, car la forme est dynamique.
+Compte, somme, moyenne et regroupe des lignes. `.count()`, `.sum()`, `.avg()`, `.min()` et `.max()` renvoient un seul nombre ; `.annotate(...)` plus `.values(...)` construit des requêtes GROUP BY (les `aggregate` / `annotate` de Django). Les résultats d'agrégation reviennent sous forme de `Vec<HashMap<String, SqlValue>>` plutôt que de structs typées, car la forme est dynamique.
 
 ```rust
 use rustango::sql::CounterPool as _;
@@ -902,16 +902,16 @@ let rows = rustango::sql::fetch_aggregate_dict(&pool, &by_author).await?;
 
 ### Comment le GROUP BY est inféré
 
-Vous n'avez presque jamais besoin d'écrire vous-même `GROUP BY` — **Rustango** l'infère à partir de la forme de la requête, tout comme Django. Vous n'appelez `.group_by(...)` que pour surcharger cette inférence. Le tableau montre ce que chaque forme produit :
+Vous écrivez rarement `GROUP BY` vous-même — **Rustango** l'infère à partir de la forme de la requête, tout comme Django. Vous n'appelez `.group_by(...)` que pour surcharger cette inférence. Le tableau montre ce que produit chaque forme :
 
 | Forme | Builder | `GROUP BY` résultant |
 |---|---|---|
 | **2 — values + agrégat** | `.values(&["author_id"]).annotate("n", count_all().into())` | `GROUP BY "author_id"` |
-| **3 — agrégat nu** | `.annotate("n", count_all().into())` | `GROUP BY` chaque colonne scalaire non agrégée du modèle |
-| **Fenêtré uniquement** | `.aggregate().annotate("rn", row_number()…)` | (pas de `GROUP BY` — les fonctions fenêtrées sont par ligne) |
+| **3 — agrégat nu** | `.annotate("n", count_all().into())` | `GROUP BY` sur chaque colonne scalaire non agrégée du modèle |
+| **Fenêtrage seul** | `.aggregate().annotate("rn", row_number()…)` | (aucun `GROUP BY` — les fonctions de fenêtrage sont par ligne) |
 | **Surcharge explicite** | `.aggregate().group_by("month").annotate(...)` | `GROUP BY "month"` — l'explicite gagne |
 
-Le classificateur `AggregateExpr::is_aggregating()` distingue les variantes qui réduisent les lignes (`Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` / `StdDev*` / `Variance*` — plus les wrappers récursifs `Filtered` / `Coalesced`) de `Window`, qui est par ligne. Seules les variantes agrégeantes déclenchent l'inférence de la Forme 3.
+Le classificateur `AggregateExpr::is_aggregating()` distingue les variantes qui réduisent les lignes (`Count` / `Sum` / `Avg` / `Max` / `Min` / `CountDistinct` / `StdDev*` / `Variance*` — plus les enveloppes récursives `Filtered` / `Coalesced`) de `Window`, qui est par ligne. Seules les variantes agrégeantes déclenchent l'inférence de la Forme 3.
 
 ```rust
 use rustango::core::aggregates::{count_all, sum};
@@ -935,11 +935,11 @@ Post::objects()
 //   FROM "post" GROUP BY <every Post column>
 ```
 
-**Avertissement sur la projection pure.** `.values(cols)` *seul* (sans annotation d'agrégat) n'est **pas** pris en charge en v0.40 — `compile()` retourne `QueryError::ValuesRequiresAggregate`. La projection pure sous forme de dicts nécessite un chemin de writer séparé (c'est un SELECT sans GROUP BY, décodé en `Vec<HashMap>`) et est prévue pour un suivi. Pour l'instant, utilisez le `QuerySet::fetch(...)` typé pour lire des lignes entières.
+**Mise en garde sur la projection pure.** `.values(cols)` *seul* (sans annotation d'agrégat) n'est **pas** pris en charge en v0.40 — `compile()` renvoie `QueryError::ValuesRequiresAggregate`. La projection pure en dictionnaires nécessite un chemin d'écriture distinct (c'est un SELECT sans GROUP BY, décodé en `Vec<HashMap>`) et est en file d'attente pour un suivi. Pour l'instant, utilisez le `QuerySet::fetch(...)` typé pour lire des lignes entières.
 
-### Agrégats conditionnels & statistiques
+### Agrégats conditionnels et statistiques
 
-Comptez ou sommez seulement les lignes qui correspondent à une condition, fournissez une valeur de repli pour les résultats vides, et calculez l'écart-type / la variance. Ils reflètent le `Count('id', filter=...)`, le `Sum('price', default=0)` et le `StdDev` de Django. Enchaînez `.filter(...)` et `.default(...)` sur n'importe quel builder d'agrégat.
+Compte ou somme uniquement les lignes qui satisfont une condition, fournit une valeur de repli pour les résultats vides, et calcule l'écart-type / la variance. Cela reflète les `Count('id', filter=...)`, `Sum('price', default=0)` et `StdDev` de Django. Chaînez `.filter(...)` et `.default(...)` sur n'importe quel builder d'agrégat.
 
 ```rust
 use rustango::core::aggregates::{avg, count, count_all, stddev, sum};
@@ -980,12 +980,12 @@ let result = rustango::sql::fetch_aggregate_dict(&pool, &rows).await?;
 | `stddev(col)` / `stddev_pop(col)` | `STDDEV_SAMP` / `STDDEV_POP` |
 | `variance(col)` / `variance_pop(col)` | `VAR_SAMP` / `VAR_POP` |
 
-Chacun retourne un `AggregateBuilder` avec deux modificateurs chaînables :
+Chacun renvoie un `AggregateBuilder` avec deux modificateurs chaînables :
 
-- `.filter(predicate)` — enveloppe dans `FILTER (WHERE predicate)`. Le prédicat est n'importe quel `WhereExpr` (typé via `.eq()` / `.and()` / brut via `WhereExpr::Or(...)`), il se compose donc comme un WHERE normal.
-- `.default(value)` — enveloppe dans `COALESCE(..., value)` afin qu'un queryset vide retourne la valeur par défaut au lieu de `NULL`.
+- `.filter(predicate)` — encapsule dans `FILTER (WHERE predicate)`. Le prédicat est n'importe quel `WhereExpr` (`.eq()` / `.and()` typé / `WhereExpr::Or(...)` brut), il se compose donc de la même manière qu'un WHERE normal.
+- `.default(value)` — encapsule dans `COALESCE(..., value)` afin qu'un queryset vide renvoie la valeur par défaut au lieu de `NULL`.
 
-En chaînant les deux, `Coalesced` enveloppe `Filtered` : `COALESCE(SUM(col) FILTER (WHERE p), 0)`. L'ordre de chaînage n'a pas d'importance — `.filter(p).default(0)` et `.default(0).filter(p)` produisent la même IR.
+Appeler les deux chaînes comme `Coalesced` à l'extérieur de `Filtered` : `COALESCE(SUM(col) FILTER (WHERE p), 0)`. L'ordre de la chaîne n'a pas d'importance — `.filter(p).default(0)` et `.default(0).filter(p)` produisent la même IR.
 
 **Émission tri-dialecte :**
 
@@ -997,13 +997,13 @@ En chaînant les deux, `Coalesced` enveloppe `Filtered` : `COALESCE(SUM(col) FIL
 | `.filter(...)` — repli `CASE WHEN` | — | ✓ `<agg>(CASE WHEN … THEN <arg> END)` | — |
 | `.default(...)` — `COALESCE` | ✓ | ✓ | ✓ |
 
-Le writer applique la conversion int/float du dialecte (`::bigint`, `CAST(... AS SIGNED)`, etc.) autour de toute l'expression `FILTER` — `SUM(col)::bigint FILTER (...)` est une erreur d'analyse syntaxique sur PG, donc la forme émise est `(SUM(col) FILTER (...))::bigint`. Même forme pour `STDDEV_SAMP` / `VAR_SAMP` (ils retournent NUMERIC sur PG pour une entrée bigint).
+Le writer applique le cast entier/flottant du dialecte (`::bigint`, `CAST(... AS SIGNED)`, etc.) autour de toute l'expression `FILTER` — `SUM(col)::bigint FILTER (...)` est une erreur d'analyse sur PG, donc la forme émise est `(SUM(col) FILTER (...))::bigint`. Même forme pour `STDDEV_SAMP` / `VAR_SAMP` (ils renvoient un NUMERIC sur PG pour une entrée bigint).
 
-**SQLite + StdDev/Variance :** SQLite n'a pas d'agrégats statistiques intégrés, donc le writer rejette avec `SqlError::AggregateNotSupported { aggregate, dialect: "sqlite" }`. Calculez la formule de variance côté application si des statistiques portables sont nécessaires (même posture que Django).
+**SQLite + StdDev/Variance :** SQLite n'a pas d'agrégats statistiques intégrés, donc le writer rejette avec `SqlError::AggregateNotSupported { aggregate, dialect: "sqlite" }`. Calculez la formule de variance dans le code applicatif si vous avez besoin de statistiques portables (même posture que Django).
 
-### Fonctions fenêtrées
+### Fonctions de fenêtrage
 
-Calculez des totaux courants, des classements, et des deltas ligne-à-ligne sans réduire les lignes — le `Window(expression, partition_by=, order_by=, frame=)` de Django. Huit fonctions (`row_number`, `rank`, `dense_rank`, `lag`, `lead`, `first_value`, `last_value`, `ntile`) plus les frames ROWS/RANGE. Chaque backend supporté par **Rustango** (PG ≥ 9.0, MySQL ≥ 8.0, SQLite ≥ 3.25) fournit une syntaxe `OVER (…)` native, donc l'émission est uniforme.
+Calcule des totaux cumulés, des classements et des différences d'une ligne à l'autre sans réduire les lignes — le `Window(expression, partition_by=, order_by=, frame=)` de Django. Huit fonctions (`row_number`, `rank`, `dense_rank`, `lag`, `lead`, `first_value`, `last_value`, `ntile`) plus les frames ROWS/RANGE. Chaque backend que **Rustango** prend en charge (PG ≥ 9.0, MySQL ≥ 8.0, SQLite ≥ 3.25) livre la syntaxe native `OVER (…)`, donc l'émission est uniforme.
 
 ```rust
 use rustango::core::aggregates::max;
@@ -1061,28 +1061,28 @@ let q = Post::objects()
 
 **Builders** dans `rustango::core::window` :
 
-| Builder | SQL | Arguments |
+| Builder | SQL | Args |
 |---|---|---|
 | `row_number()` | `ROW_NUMBER()` | — |
 | `rank()` | `RANK()` | — |
 | `dense_rank()` | `DENSE_RANK()` | — |
-| `ntile(buckets)` | `NTILE(buckets)` | nombre de buckets |
-| `lag(col, offset, default)` | `LAG(col, offset, default?)` | colonne + offset + défaut optionnel |
-| `lead(col, offset, default)` | `LEAD(col, offset, default?)` | colonne + offset + défaut optionnel |
+| `ntile(buckets)` | `NTILE(buckets)` | nombre de compartiments |
+| `lag(col, offset, default)` | `LAG(col, offset, default?)` | colonne + décalage + défaut optionnel |
+| `lead(col, offset, default)` | `LEAD(col, offset, default?)` | colonne + décalage + défaut optionnel |
 | `first_value(col)` | `FIRST_VALUE(col)` | colonne |
 | `last_value(col)` | `LAST_VALUE(col)` | colonne |
 
-Chacun retourne un `WindowBuilder` avec trois modificateurs chaînables :
+Chacun renvoie un `WindowBuilder` avec trois modificateurs chaînables :
 
-- `.partition_by("col")` — ajoute une colonne `PARTITION BY`. Appelez-le plusieurs fois pour un partitionnement multi-colonnes.
+- `.partition_by("col")` — ajoute une colonne `PARTITION BY`. Appelez plusieurs fois pour un partitionnement multi-colonnes.
 - `.order_by(&[("col", desc)])` — ajoute des colonnes `ORDER BY` (`desc = true` → DESC).
 - `.frame(WindowFrame { kind, start, end })` — définit la clause de frame `ROWS`/`RANGE` optionnelle. `FrameBoundary::UnboundedPreceding` / `Preceding(n)` / `CurrentRow` / `Following(n)` / `UnboundedFollowing`.
 
-Le builder se convertit via `Into<AggregateExpr>` afin que les fonctions fenêtrées se composent avec `annotate()`. `Into<Expr>` est aussi implémenté (le slot au niveau IR pour les expressions fenêtrées), mais **chaque backend supporté par Rustango restreint les fonctions fenêtrées à la liste `SELECT` et à la clause `ORDER BY` d'une requête** — elles ne peuvent pas apparaître dans `WHERE` / `HAVING` / `GROUP BY` / `UPDATE SET` / `JOIN ON` / `RETURNING`. Le writer ne verrouille pas l'émission sur ce point, donc `set_expr("col", row_number())` compile en SQL que la base rejette à l'exécution. Construisez les expressions fenêtrées via `annotate()` ; passez par une sous-requête si vous devez alimenter un résultat de fonction fenêtrée dans un filtre WHERE ou un UPDATE.
+Le builder s'abaisse via `Into<AggregateExpr>` afin que les fonctions de fenêtrage se composent avec `annotate()`. `Into<Expr>` est également implémenté (l'emplacement au niveau IR pour les expressions de fenêtrage), mais **chaque backend que **Rustango** prend en charge restreint les fonctions de fenêtrage à la liste `SELECT` et à la clause `ORDER BY` d'une requête** — elles ne peuvent pas apparaître dans `WHERE` / `HAVING` / `GROUP BY` / `UPDATE SET` / `JOIN ON` / `RETURNING`. Le writer ne conditionne pas l'émission sur ce point, donc `set_expr("col", row_number())` se compile en un SQL que la base de données rejette à l'exécution. Construisez les expressions de fenêtrage via `annotate()` ; passez à une sous-requête si vous devez alimenter un résultat de fenêtrage dans un filtre WHERE ou un UPDATE.
 
 **Le piège de la frame par défaut de `LAST_VALUE` :**
 
-Un `last_value(col).order_by(&[("x", false)])` nu émet `LAST_VALUE("col") OVER (ORDER BY "x")` et semble devoir retourner le dernier `col` de la partition. Ce n'est pas le cas — la frame de fenêtre *par défaut* de SQL est `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`, donc `LAST_VALUE` retourne la valeur **de la ligne courante**, pas de la dernière ligne de la partition. Pour obtenir le comportement intuitif « dernière ligne de la partition », passez une frame illimitée explicite :
+Un simple `last_value(col).order_by(&[("x", false)])` émet `LAST_VALUE("col") OVER (ORDER BY "x")` et semble devoir renvoyer le dernier `col` de la partition. Ce n'est pas le cas — la frame de fenêtrage *par défaut* de SQL est `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`, donc `LAST_VALUE` renvoie la valeur de la **ligne courante**, pas de la dernière ligne de la partition. Pour obtenir le comportement intuitif « dernière ligne de la partition », passez une frame illimitée explicite :
 
 ```rust
 use rustango::core::{FrameBoundary, FrameKind, WindowFrame};
@@ -1097,11 +1097,11 @@ last_value("score")
     })
 ```
 
-`first_value` n'a pas ce piège — le début de la frame par défaut correspond au début de la partition, la réponse intuitive tombe donc naturellement.
+`first_value` n'a pas ce piège — le début de la frame par défaut coïncide avec le début de la partition, donc la réponse intuitive en découle.
 
-**Avertissement sur annotate (jusqu'à l'arrivée de l'issue #75) :**
+**Mise en garde sur annotate (jusqu'à la livraison du ticket #75) :**
 
-`annotate()` vit sur le builder d'agrégat qui exige `GROUP BY` pour projeter des colonnes scalaires par ligne à côté des agrégats. Pour projeter des résultats de fonction fenêtrée à côté de colonnes de ligne aujourd'hui, listez chaque colonne de ligne que vous voulez retourner dans des appels `.group_by(...)` et utilisez `annotate("_a", max("id").into())` comme espace réservé no-op pour garder l'identité de ligne stable. L'issue #75 (auto-inférence de GROUP BY) apportera une forme plus propre.
+`annotate()` réside sur le builder d'agrégat qui requiert un `GROUP BY` pour projeter des colonnes scalaires par ligne aux côtés des agrégats. Pour projeter aujourd'hui des résultats de fonction de fenêtrage à côté des colonnes de ligne, listez chaque colonne de ligne que vous voulez renvoyer dans des appels `.group_by(...)` et utilisez `annotate("_a", max("id").into())` comme placeholder sans effet pour maintenir stable l'identité de la ligne. Le ticket #75 (inférence automatique du GROUP BY) livre une forme plus propre.
 
 **Clauses de frame :**
 
@@ -1125,16 +1125,16 @@ let frame = WindowFrame {
 
 **Émission tri-dialecte :**
 
-`<fn>(args) OVER (PARTITION BY … ORDER BY … [frame])` fait partie de la norme SQL — identique sur PG, MySQL 8+ et SQLite 3.25+. La seule bizarrerie : `LAG` / `LEAD` / `NTILE` exigent des offsets/buckets entiers sur PG (les lier comme un paramètre bigint `$N` provoque `function lag(bigint, bigint, bigint) does not exist`). Le writer intègre directement des littéraux entiers dans le SQL pour ces emplacements ; les arguments de valeur par défaut se lient normalement.
+`<fn>(args) OVER (PARTITION BY … ORDER BY … [frame])` est standard SQL — identique sur PG, MySQL 8+ et SQLite 3.25+. La seule bizarrerie : `LAG` / `LEAD` / `NTILE` requièrent des décalages/compartiments entiers sur PG (les lier en tant que paramètre bigint `$N` provoque `function lag(bigint, bigint, bigint) does not exist`). Le writer intègre directement les littéraux entiers dans le SQL pour ces emplacements ; les arguments de valeur par défaut sont liés normalement.
 
-**Avertissements :**
+**Mises en garde :**
 
-- **`FILTER` + `Window` pas encore pris en charge** : combiner `.filter(...)` avec une fonction fenêtrée lève `SqlError::NestedAggregateWrapper { wrapper: "Filtered(Window)" }` — la syntaxe sous-jacente varie selon le type de fonction (PG autorise `agg_fn() FILTER (WHERE …) OVER (…)` pour les fonctions fenêtrées agrégeantes mais pas pour les fonctions de classement), et le writer n'a pas encore été enseigné cette répartition. Consigné pour un suivi si la demande se manifeste.
-- **`PercentRank` / `CumeDist` / `NthValue`** ne sont pas dans la v1 — l'ensemble complet de Django est plus large. La v1 fournit les 8 variantes les plus utilisées ; les trois manquantes peuvent être ajoutées progressivement avec la même forme de builder.
+- **`FILTER` + `Window` pas encore pris en charge** : combiner `.filter(...)` avec une fonction de fenêtrage lève `SqlError::NestedAggregateWrapper { wrapper: "Filtered(Window)" }` — la syntaxe sous-jacente varie selon le type de fonction (PG autorise `agg_fn() FILTER (WHERE …) OVER (…)` pour les fonctions agrégat-fenêtre mais pas pour les fonctions de classement), et le writer n'a pas encore appris la répartition. Reporté à un suivi si la demande émerge.
+- **`PercentRank` / `CumeDist` / `NthValue`** ne sont pas dans la v1 — l'ensemble complet de Django est plus vaste. La v1 livre les 8 variantes les plus utilisées ; les trois manquantes peuvent être ajoutées progressivement avec la même forme de builder.
 
-### Filtrer sur des agrégats (HAVING)
+### Filtrage sur les agrégats (HAVING)
 
-Un appel `.filter(...)` après `.annotate(...)` atterrit soit dans `WHERE` soit dans `HAVING`, selon que le nom correspond à un alias d'agrégat — exactement le comportement de Django. Ainsi, filtrer sur une vraie colonne ajoute un `WHERE`, tandis que filtrer sur une annotation comme `post_count` ajoute un `HAVING` :
+Un appel `.filter(...)` après `.annotate(...)` atterrit soit dans `WHERE`, soit dans `HAVING`, selon que le nom correspond ou non à un alias d'agrégat — exactement le comportement de Django. Ainsi, filtrer sur une vraie colonne ajoute un `WHERE`, tandis que filtrer sur une annotation comme `post_count` ajoute un `HAVING` :
 
 ```rust
 use rustango::core::aggregates::count_all;
@@ -1163,13 +1163,13 @@ GROUP BY "author_id"
 HAVING COUNT(*) > $2
 ```
 
-**L'expression d'agrégat est remontée dans HAVING, pas l'alias du SELECT.** PG interdit strictement les alias dans HAVING (seule l'expression se résout) ; MySQL + SQLite sont plus permissifs. Le writer émet la forme remontée de manière uniforme sur les trois afin que la même requête fonctionne partout.
+**L'expression d'agrégat est élevée dans le HAVING, pas dans l'alias du SELECT.** PG interdit strictement les alias dans le HAVING (seule l'expression se résout) ; MySQL + SQLite sont plus permissifs. Le writer émet la forme élevée uniformément sur les trois afin que la même requête fonctionne partout.
 
-**L'ordre de la chaîne compte en v1.** Appelez `.annotate(alias, ...)` AVANT le `.filter(alias, ...)` correspondant. Si l'ordre est inversé, `filter()` consulte un registre d'annotations vide et route vers `WHERE` — et le validateur `resolve_pending` fait remonter `UnknownField` à `compile()` parce que l'alias n'est pas une vraie colonne du modèle. Django diffère cette résolution au moment de la construction de la requête ; un suivi v0.50 pourrait adopter cette posture.
+**L'ordre de la chaîne compte en v1.** Appelez `.annotate(alias, ...)` AVANT le `.filter(alias, ...)` correspondant. Si l'ordre est inversé, `filter()` consulte un registre d'annotations vide et route vers `WHERE` — et le validateur `resolve_pending` fait remonter `UnknownField` à `compile()` car l'alias n'est pas une vraie colonne du modèle. Django diffère cette résolution au moment de la construction de la requête ; un suivi en v0.50 pourrait s'aligner sur cette posture.
 
-**Lacune du validateur (correspond à la posture existante des agrégats)** : les prédicats HAVING routés par alias ne parcourent pas le schéma du modèle. Les alias mal orthographiés remontent à la base de données, pas à `compile()`. Même lacune que `Sum("typo_col")` — préexistante et orthogonale.
+**Lacune du validateur (conforme à la posture existante des agrégats)** : les prédicats HAVING routés par alias sautent le parcours des colonnes du schéma du modèle. Les alias mal orthographiés remontent depuis la base de données, pas à `compile()`. Même lacune que `Sum("typo_col")` — préexistante et orthogonale.
 
-**Opérateurs pris en charge sur `.filter()` routé par alias** (issue #87) : l'ensemble des comparaisons binaires (`Op::Eq` / `Ne` / `Lt` / `Lte` / `Gt` / `Gte`) **plus** les prédicats standard SQL-92 qui se composent avec un LHS d'agrégat de manière uniforme sur chaque backend — `Op::In` / `NotIn`, `Between`, `IsNull`, `Like` / `NotLike`, `ILike` / `NotILike`. Chacun émet la forme prévisible :
+**Opérateurs pris en charge sur un `.filter()` routé par alias** (ticket #87) : l'ensemble des comparaisons binaires (`Op::Eq` / `Ne` / `Lt` / `Lte` / `Gt` / `Gte`) **plus** les prédicats standard SQL-92 qui se composent uniformément contre un membre gauche agrégé sur chaque backend — `Op::In` / `NotIn`, `Between`, `IsNull`, `Like` / `NotLike`, `ILike` / `NotILike`. Chacun émet la forme prévisible :
 
 ```rust
 use rustango::core::{Op, SqlValue};
@@ -1192,9 +1192,9 @@ Post::objects()
 .filter("max_name", Op::ILike, "SMITH%")
 ```
 
-Les opérateurs restants — la famille JSON (`JsonContains` / `JsonContainedBy` / `JsonHasKey` / `JsonHasAnyKey` / `JsonHasAllKeys`) et l'égalité null-safe (`IsDistinctFrom` / `IsNotDistinctFrom`) — nécessitent encore des writers spécifiques au dialecte prenant un `&str` pour le LHS, ils sont donc rejetés à `compile()` avec `QueryError::HavingOpNotSupported { alias, op }`. Pour ceux-là, passez par la forme typée `.having(<TypedExpr>)` avec un prédicat pré-construit.
+Les opérateurs restants — la famille des opérateurs JSON (`JsonContains` / `JsonContainedBy` / `JsonHasKey` / `JsonHasAnyKey` / `JsonHasAllKeys`) et l'égalité tolérante aux NULL (`IsDistinctFrom` / `IsNotDistinctFrom`) — nécessitent encore des writers spécifiques au dialecte qui prennent un `&str` pour le membre gauche, ils rejettent donc à `compile()` avec `QueryError::HavingOpNotSupported { alias, op }`. Pour ceux-là, passez à la forme typée `.having(<TypedExpr>)` avec un prédicat préconstruit.
 
-**Gonflement du vecteur de paramètres avec des agrégats non triviaux** : quand l'alias cible une annotation `Filtered { Count, filter: pred }` ou `Coalesced { Sum, default: 0 }`, le writer remonte l'**expression d'agrégat entière** dans HAVING — y compris ses prédicats internes et ses valeurs par défaut. Leurs littéraux liés obtiennent de nouveaux emplacements de paramètres dans HAVING, séparés de l'émission dans la liste SELECT. Concrètement :
+**Gonflement du vecteur de paramètres avec des agrégats non triviaux** : lorsque l'alias cible une annotation `Filtered { Count, filter: pred }` ou `Coalesced { Sum, default: 0 }`, le writer élève l'**expression d'agrégat entière** dans le HAVING — y compris ses prédicats internes et ses valeurs par défaut. Leurs littéraux liés obtiennent de nouveaux emplacements de paramètre dans le HAVING, distincts de l'émission de la liste SELECT. Concrètement :
 
 ```text
 SELECT … COUNT(*) FILTER (WHERE "status" = $1) AS "published_count" …
@@ -1202,13 +1202,13 @@ HAVING COUNT(*) FILTER (WHERE "status" = $2) > $3
               -- "published" bound twice (once at $1, once at $2)
 ```
 
-La sémantique SQL est inchangée (les mêmes nombres de lignes reviennent), mais `stmt.params.len()` croît à chaque appel `.filter()` ciblant un alias non trivial. Pour les alias `COUNT(*)` (aucun littéral interne), le gonflement est nul. À documenter si votre suite de tests fixe des comptes de paramètres.
+La sémantique SQL est inchangée (les mêmes comptages de lignes reviennent), mais `stmt.params.len()` croît à chaque appel `.filter()` qui cible un alias non trivial. Pour les alias `COUNT(*)` (sans littéraux internes), le gonflement est nul. Documentez-le si votre suite de tests verrouille le nombre de paramètres.
 
 ---
 
-## Jointures & préchargement des lignes liées
+## Jointures et préchargement des lignes liées
 
-Récupérez la cible d'une clé étrangère en même temps que la ligne principale, en une seule requête, afin de ne pas tirer une requête supplémentaire par ligne (le problème N+1). `.select_related("author")` est le `select_related` de Django / le chargement anticipé d'Eloquent. Un champ `ForeignKey<T>` arrive alors déjà rempli sans avoir besoin d'une recherche séparée.
+Récupère la cible d'une clé étrangère en même temps que la ligne principale en une seule requête, afin de ne pas déclencher une requête supplémentaire par ligne (le problème N+1). `.select_related("author")` est le `select_related` de Django / le chargement anticipé d'Eloquent. Un champ `ForeignKey<T>` arrive alors déjà rempli au lieu de nécessiter une recherche séparée.
 
 ```rust
 let posts = Post::objects()
@@ -1221,9 +1221,9 @@ for post in &posts {
 }
 ```
 
-`select_related` résout les champs FK au moment de la compilation du queryset. Le champ `ForeignKey<T>` sur le parent passe de `Unloaded(pk)` à `Loaded { pk, value }`.
+`select_related` résout les champs FK au moment de la compilation du queryset. Le champ `ForeignKey<T>` du parent passe de `Unloaded(pk)` à `Loaded { pk, value }`.
 
-Pour les FK inversées (parent.enfants), utilisez la méthode `_set` générée par la macro :
+Pour les FK inverses (parent.children), utilisez la méthode `_set` générée par la macro :
 
 ```rust
 let author_posts = author.post_set(&pool).await?;
@@ -1231,7 +1231,7 @@ let author_posts = author.post_set(&pool).await?;
 
 ### Jointures personnalisées
 
-Quand la jointure n'est pas pilotée par une clé étrangère — un prédicat personnalisé, une jointure non-équi, INNER au lieu de LEFT, une auto-jointure, ou une jointure sur une colonne non-PK — utilisez `.join(Join { … })`. Son champ `on` accepte n'importe quel `WhereExpr`, donc `and()` / `or()` / `Not` / appels de fonction / colonne-vs-colonne / filtres littéraux se composent tous librement.
+Lorsque la jointure n'est pas pilotée par une clé étrangère — un prédicat personnalisé, une non-équi-jointure, INNER au lieu de LEFT, une auto-jointure, ou une jointure sur une colonne non-PK — utilisez `.join(Join { … })`. Son champ `on` prend n'importe quel `WhereExpr`, donc `and()` / `or()` / `Not` / appels de fonction / colonne-contre-colonne / filtres littéraux se composent tous librement.
 
 ```rust
 use rustango::core::joins::aliased;
@@ -1264,12 +1264,12 @@ Post::objects()
 
 **Règles de qualification des colonnes à l'intérieur de `on` :**
 
-- **Les colonnes `Filter` / `ColumnFilter` nues + les références de colonne `F()`** se résolvent vers l'alias joint (`<alias>` que vous avez passé). C'est la lecture naturelle car la majeure partie d'un prédicat ON concerne la table jointe.
-- **`aliased(alias, col)`** émet explicitement `"<alias>"."<col>"` — utilisez-le pour des références croisées vers la table externe (`aliased("<outer_table>", "<col>")`) ou vers un alias précédemment joint.
-- **`WhereExpr::ExprCompare { lhs, op, rhs }`** est la forme adéquate pour des comparaisons colonne-vs-colonne entre tables, puisque les deux côtés acceptent n'importe quel `Expr`.
+- **Les colonnes `Filter` / `ColumnFilter` nues + les références de colonne `F()`** se résolvent vers l'alias joint (le `<alias>` que vous avez passé). C'est la lecture naturelle car l'essentiel d'un prédicat ON concerne la table jointe.
+- **`aliased(alias, col)`** émet explicitement `"<alias>"."<col>"` — à utiliser pour les références croisées vers la table externe (`aliased("<outer_table>", "<col>")`) ou vers un alias précédemment joint.
+- **`WhereExpr::ExprCompare { lhs, op, rhs }`** est la bonne forme pour les comparaisons colonne-contre-colonne entre tables, puisque les deux côtés prennent n'importe quel `Expr`.
 
-> ⚠️ **PATTERN DANGEREUX — filtres typés du modèle EXTERNE à l'intérieur de `on`.**
-> `Post::status.eq("draft").into()` produit un `WhereExpr::Predicate(Filter { column: "status", ... })` et **perd le tag du modèle `Post`** à la frontière `Into<WhereExpr>`. La règle d'auto-qualification ci-dessus route alors ce filtre par erreur vers l'**alias joint**, pas vers `Post`. Vous obtenez `"<joined_alias>"."status" = $N` — la mauvaise table — et le compilateur ne peut pas le détecter. **Utilisez [`joins::col_filter`] pour les prédicats portant sur une colonne dont la table n'est pas l'alias par défaut de la jointure :**
+> ⚠️ **MODÈLE DANGEREUX — filtres typés du modèle EXTERNE à l'intérieur de `on`.**
+> `Post::status.eq("draft").into()` produit un `WhereExpr::Predicate(Filter { column: "status", ... })` et **abandonne l'étiquette du modèle `Post`** à la frontière `Into<WhereExpr>`. La règle de qualification automatique ci-dessus route alors par erreur ce filtre vers l'**alias joint**, pas vers `Post`. Vous obtenez `"<joined_alias>"."status" = $N` — mauvaise table — et le compilateur ne peut pas le détecter. **Utilisez [`joins::col_filter`] pour les prédicats contre toute colonne dont la table n'est pas l'alias par défaut de la jointure :**
 >
 > ```rust
 > use rustango::core::joins::{aliased, col_filter};
@@ -1279,9 +1279,9 @@ Post::objects()
 > col_filter("post", "status", Op::Eq, "draft")
 > ```
 >
-> Réservez les filtres typés nus (`Comment::is_approved.eq(true).into()`) aux colonnes du modèle JOINT uniquement — jamais pour les colonnes du modèle externe.
+> Réservez les filtres typés nus (`Comment::is_approved.eq(true).into()`) uniquement aux colonnes du modèle JOINT — jamais pour les colonnes du modèle externe.
 
-**Support tri-dialecte de JoinKind :**
+**Prise en charge tri-dialecte de JoinKind :**
 
 | Type | PG | MySQL | SQLite |
 |---|---|---|---|
@@ -1290,27 +1290,27 @@ Post::objects()
 | `Right` | ✓ | ✓ | ✗ `SqlError::JoinKindNotSupported` |
 | `Full` | ✓ | ✗ | ✗ |
 
-`Right` est facile à contourner — échangez les opérandes et utilisez `Left`. `Full` sur MySQL est habituellement émulé avec `(LEFT JOIN) UNION (RIGHT JOIN)` si vous en avez vraiment besoin.
+`Right` est facile à contourner — échangez les opérandes et utilisez `Left`. `Full` sur MySQL est généralement émulé avec `(LEFT JOIN) UNION (RIGHT JOIN)` si vous en avez vraiment besoin.
 
-**Autres erreurs à l'émission :**
+**Autres erreurs au moment de l'émission :**
 
-- **Prédicat `on` vide** (`WhereExpr::And(vec![])` ou aucun `ExprCompare`) est rejeté avec `SqlError::EmptyJoinOnCondition`. SQL exige au moins un prédicat booléen à l'intérieur de `ON` ; le raccourci auto-`true` du WHERE de premier niveau ne s'applique pas ici.
+- **Prédicat `on` vide** (`WhereExpr::And(vec![])` ou aucun `ExprCompare`) est rejeté avec `SqlError::EmptyJoinOnCondition`. SQL requiert au moins un prédicat booléen à l'intérieur du `ON` ; le raccourci `true` automatique du WHERE de premier niveau ne s'applique pas ici.
 
 **`project` est actuellement une donnée morte sur les jointures ad hoc.**
 
-Le champ `Join.project` indique au writer d'émettre des colonnes `<alias>"."<col>" AS "<alias>__<col>"` dans la liste SELECT. Aujourd'hui, seul `select_related` décode réellement ces colonnes (via le décodeur de ligne complète de la cible FK). Les jointures ad hoc émettent les colonnes mais le décodeur `Vec<MainModel>` les ignore, donc renseigner `project` sur une jointure ad hoc ne fait qu'ajouter des octets sur le fil. Laissez-le à `vec![]` jusqu'à ce que la restriction de projection + le décodage de tuples arrivent.
+Le champ `Join.project` indique au writer d'émettre des colonnes `<alias>"."<col>" AS "<alias>__<col>"` dans la liste SELECT. Aujourd'hui, seul `select_related` décode réellement celles-ci (via le décodeur de ligne complète de la cible FK) ; les jointures ad hoc émettent les colonnes mais le décodeur `Vec<MainModel>` les ignore, donc remplir `project` sur une jointure ad hoc ne fait qu'ajouter des octets sur le réseau. Laissez-le à `vec![]` jusqu'à ce que le rétrécissement de projection + le décodage de tuples arrivent.
 
-**Quand utiliser des jointures ad hoc :**
+**Quand recourir aux jointures ad hoc :**
 
 | Besoin | Outil |
 |---|---|
 | Récupérer les lignes liées avec la ligne principale | `select_related` (forme Django) |
 | Filtrer les lignes principales par un prédicat de table liée | `exists(...)` / `not_exists(...)` |
 | Filtrer via INNER au lieu de LEFT, ou avec des prédicats ON supplémentaires | `.join(...)` |
-| Auto-jointure (par exemple `employee.manager_id = manager.id`) | `.join(...)` |
-| Anti-jointure (lignes de A sans AUCUNE correspondance dans B) | `not_exists(...)` |
+| Auto-jointure (p. ex. `employee.manager_id = manager.id`) | `.join(...)` |
+| Anti-jointure (lignes de A SANS correspondance dans B) | `not_exists(...)` |
 
-`select_related` reste l'outil approprié quand la jointure consiste à « suivre cette FK et projeter toutes ses colonnes ». Les jointures ad hoc sont l'échappatoire quand vous avez besoin : d'une clé de jointure non-FK, d'INNER au lieu de LEFT, d'un prédicat supplémentaire à l'intérieur du ON, ou d'une auto-jointure.
+`select_related` reste le bon outil quand la jointure consiste à « suivre cette FK et projeter toutes ses colonnes ». Les jointures ad hoc sont l'échappatoire lorsque vous avez besoin : d'une clé de jointure non-FK, d'INNER au lieu de LEFT, d'un prédicat supplémentaire à l'intérieur du ON, ou d'une auto-jointure.
 
 [`joins::col_filter`]: https://docs.rs/rustango/latest/rustango/core/joins/fn.col_filter.html
 
@@ -1318,9 +1318,9 @@ Le champ `Join.project` indique au writer d'émettre des colonnes `<alias>"."<co
 
 ---
 
-## Sauvegarder seulement certains champs
+## Sauvegarde de quelques champs seulement
 
-Écrivez uniquement les champs modifiés au lieu de toutes les colonnes — le `save(update_fields=[...])` de Django. Une sauvegarde normale réécrit toutes les colonnes non-PK ; `save_partial(&[...], &pool)` ne réécrit que celles que vous nommez.
+Écrit uniquement les champs que vous avez modifiés au lieu de chaque colonne — le `save(update_fields=[...])` de Django. Une sauvegarde normale réécrit chaque colonne non-PK ; `save_partial(&[...], &pool)` ne réécrit que celles que vous nommez.
 
 ```rust
 let mut post = Post::objects().fetch(&pool).await?.pop().unwrap();
@@ -1331,8 +1331,8 @@ post.save_partial(&["title"], &pool).await?;  // SET "title" = $1
 
 Deux motivations :
 
-* **Performance.** Les lignes larges avec des colonnes `TEXT` / `JSON` / `bytea` coûtent à re-lier et à réécrire à chaque `save()` même quand un seul champ a été modifié. `save_partial` limite la clause `SET` exactement à ce qui a changé.
-* **Sécurité de la concurrence.** Quand deux écrivains divergent après une lecture partagée, le perdant écrase silencieusement les modifications du gagnant sur les champs qu'il n'a pas touchés. Ne nommer que le champ réellement modifié préserve le travail de l'autre écrivain partout ailleurs.
+* **Performance.** Les lignes larges avec des colonnes `TEXT` / `JSON` / `bytea` paient pour re-lier et réécrire chaque champ à chaque `save()`, même quand un seul a été modifié. `save_partial` maintient la clause `SET` à exactement ce qui a changé.
+* **Sécurité en concurrence.** Quand deux écrivains divergent après une lecture partagée, le perdant écrase silencieusement les modifications du gagnant sur les champs qu'il n'a pas touchés. Ne nommer que le champ que vous avez réellement modifié préserve le travail de l'autre écrivain partout ailleurs.
 
 ```rust
 // Writer A — flips title.
@@ -1346,13 +1346,13 @@ b.status = "from-B".into();
 b.save_partial(&["status"], &pool).await?;
 ```
 
-**Les noms de champs sont des champs de struct côté Rust**, pas des colonnes SQL — `["author_id"]` (pas `["author"]` pour un champ typé FK). Les noms de champs inconnus retournent `ExecError::Query(QueryError::UnknownField)`. Une liste vide est un no-op (retourne `Ok(())` et journalise un `tracing::warn!`), ce qui correspond à la sémantique « rien à faire » de Django. Les modèles audités (`#[rustango(audit(...))]`) restreignent l'instantané du journal d'audit au même ensemble de colonnes — le journal reflète exactement ce qui a été écrit.
+**Les noms de champs sont les champs de struct côté Rust**, pas les colonnes SQL — `["author_id"]` (pas `["author"]` pour un champ de type FK). Les noms de champs inconnus renvoient `ExecError::Query(QueryError::UnknownField)`. Une liste vide est une opération sans effet (renvoie `Ok(())` et journalise un `tracing::warn!`), conforme à la sémantique « rien à faire » de Django. Les modèles audités (`#[rustango(audit(...))]`) restreignent l'instantané du journal d'audit au même ensemble de colonnes — le journal reflète exactement ce qui a été écrit.
 
-**Note sur les PK auto.** `save_partial` est UPDATE uniquement ; l'appeler sur une PK `Auto::Unset` est une erreur utilisateur (utilisez `insert_pool` / `save_pool` pour ce cas). Contrairement à `save_pool` qui dispatche automatiquement `Unset → insert_pool`, cette méthode suppose que vous avez déjà inséré la ligne.
+**Note sur l'auto-PK.** `save_partial` est réservé à l'UPDATE ; l'appeler sur une PK `Auto::Unset` est une erreur de l'utilisateur (utilisez `insert_pool` / `save_pool` pour ce cas). Contrairement à `save_pool` qui répartit automatiquement `Unset → insert_pool`, cette méthode suppose que vous avez déjà inséré.
 
 ### Liste de champs vérifiée à la compilation
 
-La forme à clés en chaînes ci-dessus convient aux listes de champs dynamiques (formulaires admin, payloads d'API). Quand la liste est fixe dans votre code, `save_partial_typed((Post::title, ...), &pool)` détecte les champs mal orthographiés ou renommés à la **compilation** plutôt qu'au runtime :
+La forme à clé de chaîne ci-dessus convient aux listes de champs dynamiques (formulaires d'admin, charges utiles d'API). Quand la liste est fixée dans votre code, `save_partial_typed((Post::title, ...), &pool)` détecte les champs mal orthographiés ou renommés **à la compilation** plutôt qu'à l'exécution :
 
 ```rust
 post.save_partial_typed((Post::title, Post::slug), &pool).await?;
@@ -1360,23 +1360,23 @@ post.save_partial_typed((Post::title, Post::slug), &pool).await?;
 //                       title_col   slug_col   ← distinct ZSTs
 ```
 
-Chaque `Post::<field>` est son propre type de taille zéro — une slice homogène (`&[Post::title, Post::slug]`) ne compile pas en Rust, donc l'API prend un **tuple** à la place. Les appels à un seul champ utilisent l'idiome de la virgule finale : `(Post::title,)`. Les tuples sont pris en charge de l'arité 1 jusqu'à 12 — au-delà, retombez sur `save_partial(&[&str], _)`.
+Chaque `Post::<field>` est son propre type de taille zéro — une slice homogène (`&[Post::title, Post::slug]`) ne passe pas la vérification de type en Rust, donc l'API prend un **tuple** à la place. Les appels à un seul champ utilisent l'idiome de la virgule finale : `(Post::title,)`. Les tuples sont pris en charge de l'arité 1 jusqu'à 12 — au-delà, passez à `save_partial(&[&str], _)`.
 
-Les tuples entre modèles différents sont une **erreur de compilation** — `(Post::title, Author::name)` échoue à la contrainte de trait `TypedFieldList<Post>` car `Author::name` a `Column::Model = Author`. C'est l'apport principal par rapport à la forme à clés en chaînes : les refactorisations de renommage sur un nom de colonne remontent au site d'appel typé, pas au runtime.
+Les tuples inter-modèles sont une **erreur de compilation** — `(Post::title, Author::name)` échoue au bound de trait `TypedFieldList<Post>` car le `Column::Model = Author` de `Author::name`. C'est la valeur phare par rapport à la forme à clé de chaîne : les refactorisations de renommage sur un nom de colonne remontent au site d'appel typé, pas à l'exécution.
 
-Se réduit en interne à `save_partial` — même restriction d'audit, même contrainte `Auto::Unset`, même sémantique de no-op sur liste vide.
+Se ramène en interne à `save_partial` — même restriction d'audit, même contrainte `Auto::Unset`, même sémantique d'opération sans effet pour liste vide.
 
 ---
 
 ## Opérations en masse
 
-> **Piège — les opérations en masse contournent les hooks par ligne.** `bulk_insert`, `.update().execute()` d'un queryset,
-> et `.delete()` s'exécutent comme du SQL orienté ensemble : ils ne déclenchent **pas**
-> les signaux, n'écrivent pas la piste d'audit, ne passent pas par la suppression logique, et n'exécutent pas
-> de validation par ligne. Utilisez-les pour la vitesse ; retombez sur le `save()` / `delete()` par ligne
+> **Piège — les opérations en masse sautent les hooks par ligne.** `bulk_insert`, le
+> `.update().execute()` sur un queryset et le `.delete()` s'exécutent comme du SQL basé sur des ensembles : ils ne
+> déclenchent **pas** de signaux, n'écrivent pas le journal d'audit, ne passent pas par la suppression logique, et n'exécutent pas
+> la validation par ligne. Utilisez-les pour la vitesse ; passez au `save()` / `delete()` par ligne
 > quand vous avez besoin de ces effets de bord.
 
-Insérez, mettez à jour, ou supprimez de nombreuses lignes en une seule instruction plutôt qu'une par ligne — le `bulk_create`, `QuerySet.update()` et `QuerySet.delete()` de Django. L'import `as _` place les méthodes d'un trait dans la portée sans nommer le trait directement.
+Insère, met à jour ou supprime de nombreuses lignes en une seule instruction au lieu d'une par ligne — les `bulk_create`, `QuerySet.update()` et `QuerySet.delete()` de Django. L'import `as _` amène les méthodes d'un trait dans la portée sans nommer directement le trait.
 
 ```rust
 // Bulk INSERT — rows FIRST (a `&mut [Self]`), executor/pool second.
@@ -1402,9 +1402,9 @@ Post::objects()
 
 ## Insertion ou mise à jour (upsert)
 
-Insérez une ligne, ou mettez-la à jour si une ligne avec la même clé existe déjà — le `update_or_create` de Django / l'`upsert` de Rails. Cela émet le `ON CONFLICT … DO UPDATE` natif de la base.
+Insère une ligne, ou la met à jour si une ligne avec la même clé existe déjà — les `update_or_create` de Django / `upsert` de Rails. Cela émet le `ON CONFLICT … DO UPDATE` natif de la base de données.
 
-Le `.upsert_on(executor)` sur une seule instance entre en conflit sur la **clé primaire** : avec une PK `Auto::Unset`, le serveur attribue une nouvelle clé (équivalent à `insert`) ; avec une PK `Auto::Set`, la ligne est insérée si absente ou toutes les colonnes non-PK sont écrasées si présente.
+Le `.upsert_on(executor)` d'instance unique entre en conflit sur la **clé primaire** : avec une PK `Auto::Unset`, le serveur assigne une nouvelle clé (équivalent à `insert`) ; avec une PK `Auto::Set`, la ligne est insérée si absente ou toutes les colonnes non-PK sont écrasées si présente.
 
 ```rust
 // Upsert on the PK — INSERT, or UPDATE every non-PK column if the
@@ -1412,7 +1412,7 @@ Le `.upsert_on(executor)` sur une seule instance entre en conflit sur la **clé 
 post.upsert_on(&pool).await?;
 ```
 
-Pour faire un upsert sur une clé unique arbitraire (le `bulk_create(update_conflicts=True, unique_fields=…, update_fields=…)` de Django), utilisez le helper en masse — il prend les lignes, les colonnes cibles du conflit, les colonnes à mettre à jour en cas de conflit, et le pool EN DERNIER :
+Pour faire un upsert sur une clé unique arbitraire (Django `bulk_create(update_conflicts=True, unique_fields=…, update_fields=…)`), utilisez l'assistant en masse — il prend les lignes, les colonnes cibles du conflit, les colonnes à mettre à jour en cas de conflit, et le pool en DERNIER :
 
 ```rust
 // ON CONFLICT (external_id) DO UPDATE SET title = EXCLUDED.title
@@ -1429,12 +1429,12 @@ Post::bulk_upsert_pool(
 ## Transactions
 
 > **Piège — ne mélangez pas les appels `&pool` à l'intérieur d'une transaction.** Chaque appel
-> entre `pool.begin()` et `commit` doit cibler le handle de transaction
-> (`&mut *tx`). Un `&pool` / `fetch()` / `save_on(&pool)` isolé récupère une
-> *deuxième* connexion et peut créer un deadlock du pool sous charge. Faites passer la `tx`
-> partout, ou utilisez `rustango::sql::atomic`.
+> entre `pool.begin()` et `commit` doit cibler le handle de la transaction
+> (`&mut *tx`). Un `&pool` / `fetch()` / `save_on(&pool)` égaré emprunte une
+> *seconde* connexion et peut provoquer un interblocage du pool sous charge. Faites passer le `tx`
+> à travers, ou utilisez `rustango::sql::atomic`.
 
-Exécutez plusieurs écritures comme une unité qui réussit entièrement ou est entièrement annulée — le `transaction.atomic()` de Django. Ouvrez-en une avec `pool.begin()` et exécutez chaque instruction sur la connexion de la transaction via les méthodes `_on` (`fetch_on`, `save_on`), afin que le travail atterrisse sur la transaction en cours plutôt que sur une connexion fraîchement tirée du pool.
+Exécute plusieurs écritures comme une unité qui réussit toute entière ou est entièrement annulée — le `transaction.atomic()` de Django. Ouvrez-en une avec `pool.begin()` et exécutez chaque instruction contre la connexion de la transaction via les méthodes `_on` (`fetch_on`, `save_on`), afin que le travail atterrisse sur la transaction en cours plutôt que sur une nouvelle connexion du pool.
 
 ```rust
 let mut tx = pool.begin().await?;
@@ -1456,13 +1456,13 @@ b.save_on(&mut *tx).await?;
 tx.commit().await?;
 ```
 
-Abandonnez la `tx` sans appeler `commit()` (par exemple lors d'un retour anticipé par `?`) et la transaction est annulée (rollback). Pour un hook après-commit (le `transaction.on_commit` de Django), utilisez le helper de style closure `rustango::sql::atomic(&pool, |tx| Box::pin(async move { … }))`, qui valide automatiquement (auto-commit) en cas de `Ok` et annule automatiquement en cas de `Err`.
+Abandonnez le `tx` sans appeler `commit()` (p. ex. sur un retour anticipé via `?`) et la transaction est annulée. Pour un hook après commit (le `transaction.on_commit` de Django), recourez à l'assistant de style closure `rustango::sql::atomic(&pool, |tx| Box::pin(async move { … }))`, qui valide automatiquement en cas de `Ok` et annule automatiquement en cas de `Err`.
 
 ---
 
-## Relations plusieurs-à-plusieurs
+## Plusieurs-à-plusieurs
 
-Reliez de nombreuses lignes à de nombreuses autres via une table de jonction — le `ManyToManyField` de Django. Déclarez la relation sur le modèle, puis utilisez l'accesseur généré pour ajouter, retirer, définir, ou lister les ids liés.
+Relie de nombreuses lignes à de nombreuses autres via une table de jonction — le `ManyToManyField` de Django. Déclarez la relation sur le modèle, puis utilisez l'accesseur généré pour ajouter, retirer, définir ou lister les ids liés.
 
 ```rust
 #[rustango(
@@ -1473,7 +1473,7 @@ Reliez de nombreuses lignes à de nombreuses autres via une table de jonction �
 pub struct Post { ... }
 ```
 
-Utilisez l'accesseur auto-généré :
+Utilisez l'accesseur généré automatiquement :
 
 ```rust
 let tag_ids: Vec<i64> = post.tags_m2m().all(&pool).await?;
@@ -1484,13 +1484,13 @@ post.tags_m2m().clear(&pool).await?;
 let has = post.tags_m2m().contains(42, &pool).await?;
 ```
 
-La table de jonction (`post_tags`) est auto-créée par `make_migrations` avec une PK composite + deux FK `ON DELETE CASCADE`. Actuellement, la jonction n'a que les deux colonnes FK — pour des colonnes supplémentaires (added_by, order, created_at), vous devrez définir un Model séparé et traverser manuellement jusqu'à ce que le « modèle through personnalisé » soit disponible.
+La table de jonction (`post_tags`) est créée automatiquement par `make_migrations` avec une PK composite + deux FK `ON DELETE CASCADE`. Actuellement, la jonction n'a que les deux colonnes FK — pour des colonnes supplémentaires (added_by, order, created_at), vous définirez un modèle séparé et le parcourrez manuellement jusqu'à ce que le « modèle through personnalisé » arrive.
 
 ---
 
 ## JSON / JSONB
 
-Stockez et interrogez un document JSON dans une colonne — le `JSONField` de Django. Déclarez le champ comme `serde_json::Value` (le type JSON générique), puis interrogez-le avec `json_contains` ou un filtre de chemin.
+Stocke et interroge un document JSON dans une colonne — le `JSONField` de Django. Déclarez le champ comme `serde_json::Value` (le type JSON générique), puis interrogez-le avec `json_contains` ou un filtre de chemin.
 
 ```rust
 #[derive(Model)]
@@ -1530,7 +1530,7 @@ Lisez/écrivez des types Rust via `serde_json::from_value` / `to_value`.
 
 ## Suppression logique
 
-Marquez une ligne comme supprimée en définissant un timestamp au lieu de la retirer — comme `django-safedelete` de Django ou `SoftDeletes` de Laravel. Marquez la colonne de timestamp avec l'attribut `#[rustango(soft_delete)]` (une annotation de derive qui indique à la macro comment traiter le champ) :
+Marque une ligne comme supprimée en définissant un horodatage au lieu de la retirer — comme `django-safedelete` de Django ou `SoftDeletes` de Laravel. Marquez la colonne d'horodatage avec l'attribut `#[rustango(soft_delete)]` (une annotation de derive qui indique à la macro comment traiter le champ) :
 
 ```rust
 #[derive(Model)]
@@ -1553,13 +1553,13 @@ post.restore_on(&pool).await?;          // sets deleted_at = NULL
 let live = Post::objects().where_(Post::deleted_at.is_null()).fetch(&pool).await?;
 ```
 
-Le bouton « Supprimer » de l'admin route automatiquement vers `soft_delete_on` pour tout modèle possédant la colonne. Le filtre automatique (exclusion par défaut) est sur la feuille de route de la v0.21.
+Le bouton « Delete » de l'admin route automatiquement vers `soft_delete_on` pour tout modèle qui possède la colonne. Le filtre automatique (exclusion par défaut) est sur la feuille de route v0.21.
 
 ---
 
-## Piste d'audit
+## Journal d'audit
 
-Enregistrez qui a modifié quels champs et quand, automatiquement à chaque sauvegarde et suppression — comme `django-simple-history` de Django ou les paquets d'audit de Laravel. Annotez le modèle avec les champs à suivre :
+Enregistre qui a modifié quels champs et quand, automatiquement à chaque sauvegarde et suppression — comme `django-simple-history` de Django ou les paquets d'audit de Laravel. Annotez le modèle avec les champs à suivre :
 
 ```rust
 #[derive(Model)]
@@ -1580,7 +1580,7 @@ with_source(
 ).await?;
 ```
 
-Le panneau d'historique par ligne de l'admin lit depuis cette table ; le flux inter-modèles se trouve sur `/__audit`.
+Le panneau d'historique par ligne de l'admin lit dans cette table ; le flux inter-modèles est à `/__audit`.
 
 Nettoyage :
 
@@ -1595,9 +1595,9 @@ manage audit-cleanup --keep-last 50 --tenant acme
 
 ---
 
-## Échappatoire SQL brut
+## Échappatoire vers le SQL brut
 
-Passez au SQL écrit à la main quand le query builder ne peut pas exprimer ce dont vous avez besoin — le `Model.objects.raw()` / `connection.cursor()` de Django. Les macros `sqlx` exécutent une requête et décodent le résultat en un tuple, un `Model` typé, ou rien :
+Passe au SQL écrit à la main quand le query builder ne peut pas exprimer ce dont vous avez besoin — les `Model.objects.raw()` / `connection.cursor()` de Django. Les macros `sqlx` exécutent une requête et décodent le résultat en un tuple, un `Model` typé, ou rien :
 
 ```rust
 use rustango::sql::sqlx;
@@ -1617,7 +1617,7 @@ let posts: Vec<Post> = sqlx::query_as::<_, Post>("SELECT * FROM posts WHERE comp
 sqlx::query("REINDEX TABLE posts").execute(&pool).await?;
 ```
 
-Pour du SQL brut programmatique au sein de la couche de requête **Rustango** (tri-dialecte ; prend le SQL, un `Vec<SqlValue>` de valeurs liées, puis le pool EN DERNIER, et retourne `Vec<T>`) :
+Pour du SQL brut programmatique au sein de la couche de requêtes **Rustango** (tri-dialecte ; prend le SQL, un `Vec<SqlValue>` de valeurs à lier, puis le pool en DERNIER, et renvoie `Vec<T>`) :
 
 ```rust
 use rustango::sql::raw_query_pool;
@@ -1632,9 +1632,9 @@ let count = rows.first().map(|r| r.0).unwrap_or(0);
 
 ---
 
-## Chargement paresseux des FK
+## Chargement paresseux des clés étrangères
 
-Une clé étrangère commence par ne détenir que l'id lié (`Unloaded`), et vous ne récupérez la ligne liée complète que lorsque vous la demandez — l'accès paresseux aux objets liés de Django. Faites un `match` sur la `ForeignKey` pour gérer les deux états, ou appelez `.get(&pool)` pour la charger à la demande. Pour un lot entier, utilisez `select_related` (ci-dessus) pour les précharger en une seule requête et éviter le fetch par ligne.
+Une clé étrangère commence par ne détenir que l'id lié (`Unloaded`), et vous ne récupérez la ligne liée complète que lorsque vous la demandez — l'accès paresseux aux objets liés de Django. Faites un `match` sur la `ForeignKey` pour gérer les deux états, ou appelez `.get(&pool)` pour la charger à la demande. Pour tout un lot, utilisez `select_related` (ci-dessus) afin de les précharger en une seule requête et de sauter la récupération par ligne.
 
 ```rust
 let mut post = Post::objects().find_or_fail(1, &pool).await?;
@@ -1656,7 +1656,7 @@ Utilisez `select_related("author")` sur le queryset pour précharger un lot.
 
 ## Quatre façons de filtrer
 
-Il existe quatre façons d'exprimer un filtre ; choisissez selon le contexte. Les colonnes typées sont vérifiées à la compilation et sont les mieux adaptées au code applicatif ; la forme en chaîne `field__lookup` est la syntaxe familière de Django pour l'admin et le CRUD générique ; `filter_op` sert lorsque vous détenez déjà un `Op` ; la chaîne de requête HTTP pilote l'API publique.
+Il y a quatre façons d'exprimer un filtre ; choisissez selon le contexte. Les colonnes typées sont vérifiées à la compilation et conviennent le mieux au code applicatif ; la forme chaîne `field__lookup` est la syntaxe familière de Django pour l'admin et le CRUD générique ; `filter_op` est pour quand vous détenez déjà un `Op` ; la chaîne de requête HTTP pilote l'API publique.
 
 ```rust
 // 1. HTTP query string (set via ViewSet filter_fields)
@@ -1679,36 +1679,36 @@ Post::objects().filter_op("author_id", Op::Eq, SqlValue::I64(42));
 Post::objects().where_(Post::author_id.eq(42));
 ```
 
-**Convention :** typé dans le code applicatif, forme Django dans l'admin / le CRUD générique, `filter_op` seulement quand vous avez déjà calculé un `Op` (par exemple depuis un parseur de requête), la chaîne de requête HTTP pour la surface d'API publique.
+**Convention :** typé dans le code applicatif, forme Django dans le code d'admin / CRUD générique, `filter_op` seulement lorsque vous avez déjà calculé un `Op` (p. ex. depuis un parseur de requête), requête HTTP pour la surface d'API publique.
 
 ### Suffixes de lookup pris en charge
 
-| Suffixe | Opérateur SQL | Forme de la valeur | Notes |
+| Suffixe | Opérateur SQL | Forme de valeur | Notes |
 |---|---|---|---|
-| *(aucun)* / `__exact` | `=` | scalaire | la clé nue est exact-eq |
+| *(aucun)* / `__exact` | `=` | scalaire | clé nue = égalité exacte |
 | `__ne` | `<>` | scalaire | |
 | `__gt` / `__gte` / `__lt` / `__lte` | `>` `>=` `<` `<=` | scalaire | |
-| `__contains` | `LIKE` | chaîne | enveloppe la valeur en `%v%` |
-| `__icontains` | `ILIKE` | chaîne | enveloppe la valeur en `%v%` ; émulé sur MySQL via `LOWER()` |
-| `__startswith` | `LIKE` | chaîne | enveloppe en `v%` |
-| `__istartswith` | `ILIKE` | chaîne | enveloppe en `v%` |
-| `__endswith` | `LIKE` | chaîne | enveloppe en `%v` |
-| `__iendswith` | `ILIKE` | chaîne | enveloppe en `%v` |
-| `__iexact` | `ILIKE` | chaîne | pas d'enveloppement par joker — correspondance exacte insensible à la casse |
+| `__contains` | `LIKE` | chaîne | encapsule la valeur en `%v%` |
+| `__icontains` | `ILIKE` | chaîne | encapsule la valeur en `%v%` ; émulé sur MySQL via `LOWER()` |
+| `__startswith` | `LIKE` | chaîne | encapsule en `v%` |
+| `__istartswith` | `ILIKE` | chaîne | encapsule en `v%` |
+| `__endswith` | `LIKE` | chaîne | encapsule en `%v` |
+| `__iendswith` | `ILIKE` | chaîne | encapsule en `%v` |
+| `__iexact` | `ILIKE` | chaîne | pas d'encapsulation par joker — correspondance exacte insensible à la casse |
 | `__in` | `IN (…)` | `SqlValue::List` | rejette les valeurs non-liste |
 | `__isnull` | `IS NULL` / `IS NOT NULL` | `bool` | `true` → IS NULL, `false` → IS NOT NULL |
 | `__between` / `__range` | `BETWEEN … AND …` | `SqlValue::List` à 2 éléments | inclusif aux deux bornes |
-| `__regex` / `__iregex` | PG `~` / `~*`, MySQL/SQLite `REGEXP` | chaîne | insensibilité à la casse émulée sur MySQL/SQLite via `LOWER()` ; SQLite nécessite une fonction utilisateur `regexp` |
+| `__regex` / `__iregex` | PG `~` / `~*`, MySQL/SQLite `REGEXP` | chaîne | insensible à la casse émulé sur MySQL/SQLite via encapsulation `LOWER()` ; SQLite nécessite une fonction utilisateur `regexp` |
 
-**Les erreurs remontent à `.compile()`, pas au moment de l'appel `.filter()`** — les incohérences de forme de valeur (par exemple `__in` avec un scalaire, `__isnull` avec un non-bool, `__between` avec une arité incorrecte) et les suffixes inconnus (`status__nope`) retournent `QueryError::UnknownLookup` / `QueryError::InvalidLookupValue` depuis `.compile()` afin que la chaîne fluide reste propre côté types. Les traversées chaînées (`author__name__icontains`) ne sont **pas** prises en charge en v0.39 — le découpeur prend le suffixe après le premier `__`, donc toute la queue `name__icontains` est traitée comme un suffixe inconnu.
+**Les erreurs remontent à `.compile()`, pas au moment de l'appel `.filter()`** — les incohérences de forme de valeur (p. ex. `__in` avec un scalaire, `__isnull` avec un non-bool, `__between` avec la mauvaise arité) et les suffixes inconnus (`status__nope`) renvoient `QueryError::UnknownLookup` / `QueryError::InvalidLookupValue` depuis `.compile()` afin que la chaîne fluide reste propre au niveau du typage. Les traversées chaînées (`author__name__icontains`) ne sont **pas** prises en charge en v0.39 — le séparateur prend le suffixe après le premier `__`, donc toute la queue `name__icontains` est traitée comme un suffixe inconnu.
 
-Chaque appel de filtre se joint par un AND à ceux qui précèdent ; mélangez librement la forme Django, `filter_op`, et `where_` sur le même queryset.
+Chaque appel de filtre se joint par AND à ceux qui le précèdent ; mélangez librement forme Django, `filter_op` et `where_` sur le même queryset.
 
 ---
 
-## Requêtes cloisonnées par tenant
+## Requêtes limitées au tenant
 
-Dans une application multi-tenant, exécutez chaque requête sur la connexion du tenant courant plutôt que sur le pool partagé. Récupérez une connexion par requête et passez-la à `fetch_on` (qui accepte n'importe quel executor de base de données) au lieu de `fetch` (qui utilise toujours `&pool`).
+Dans une application multi-tenant, exécute chaque requête contre la connexion du tenant courant plutôt que contre le pool partagé. Saisissez une connexion par requête et passez-la à `fetch_on` (qui accepte n'importe quel exécuteur de base de données) au lieu de `fetch` (qui utilise toujours `&pool`).
 
 ```rust
 use rustango::extractors::Tenant;
@@ -1720,17 +1720,17 @@ async fn handler(mut t: Tenant) -> Result<...> {
 }
 ```
 
-`fetch_on` fonctionne avec n'importe quel `sqlx::Executor` ; `fetch` est du sucre syntaxique pour `fetch_on(&pool)`.
+`fetch_on` fonctionne avec n'importe quel `sqlx::Executor` ; `fetch` est du sucre pour `fetch_on(&pool)`.
 
 ---
 
 ## Signaux
 
-Exécutez un callback quand quelque chose se produit — les signaux de Django. Il existe deux registres indépendants : un pour les écritures de modèles, un pour les requêtes HTTP.
+Exécute une fonction de rappel quand quelque chose se produit — les signaux de Django. Il y a deux registres indépendants : un pour les écritures de modèle, un pour les requêtes HTTP.
 
 ### Cycle de vie du modèle
 
-Déclenchez un hook avant ou après qu'un modèle soit sauvegardé ou supprimé : `pre_save`, `post_save`, `pre_delete`, `post_delete`. Enregistrez-en un avec `connect_post_save::<Post, _, _>(...)`.
+Déclenche un hook avant ou après qu'un modèle soit sauvegardé ou supprimé : `pre_save`, `post_save`, `pre_delete`, `post_delete`. Enregistrez-en un avec `connect_post_save::<Post, _, _>(...)`.
 
 ```rust
 use rustango::signals::{connect_post_save, PostSaveContext};
@@ -1742,11 +1742,11 @@ connect_post_save::<Post, _, _>(|post, ctx| async move {
 });
 ```
 
-`T: Clone + 'static` est requis (le dispatcher remet à chaque récepteur un clone `Arc<T>`). Les récepteurs s'exécutent séquentiellement dans l'ordre d'enregistrement. Déconnectez via le `ReceiverId` retourné par `connect_*`. Les quatre types de signaux + leurs formes de contexte sont documentés en ligne dans `rustango::signals`.
+`T: Clone + 'static` est requis (le distributeur remet à chaque récepteur un clone `Arc<T>`). Les récepteurs s'exécutent séquentiellement dans l'ordre d'enregistrement. Déconnectez via le `ReceiverId` renvoyé par `connect_*`. Les quatre types de signaux + leurs formes de contexte sont documentés en ligne dans `rustango::signals`.
 
 ### Cycle de vie de la requête
 
-Déclenchez un hook autour de chaque requête HTTP : `request_started`, `request_finished`, `got_request_exception`. Ajoutez le middleware `RequestSignalsLayer` à votre routeur, puis connectez des callbacks. Utile pour le traçage, l'audit, les métriques de temps de requête, et le reporting d'erreurs de style Django.
+Déclenche un hook autour de chaque requête HTTP : `request_started`, `request_finished`, `got_request_exception`. Ajoutez le middleware `RequestSignalsLayer` à votre routeur, puis connectez les fonctions de rappel. Utile pour le traçage, l'audit, les métriques au moment de la requête et le reporting d'erreurs de style Django.
 
 ```rust
 use axum::Router;
@@ -1772,29 +1772,29 @@ let app: Router = Router::new()
 | `request_finished` | `method`, `path`, `status`, `elapsed_ms` |
 | `got_request_exception` | `method`, `path`, `error` |
 
-Les récepteurs s'exécutent séquentiellement dans l'ordre d'enregistrement ; enveloppez un corps dans `tokio::spawn` pour un fan-out parallèle ou une isolation des panics. Les registres de requêtes et de modèles sont indépendants — connecter / déconnecter / vider l'un ne touche pas l'autre.
+Les récepteurs s'exécutent séquentiellement dans l'ordre d'enregistrement ; encapsulez un corps dans `tokio::spawn` pour un fanout parallèle ou l'isolation des paniques. Les registres de requête et de modèle sont indépendants — connecter / déconnecter / vider l'un ne touche pas l'autre.
 
 ---
 
 ## Conseils de performance
 
-Une checklist rapide pour garder les requêtes rapides à mesure que les données croissent :
+Une liste de contrôle rapide pour garder les requêtes rapides à mesure que les données grandissent :
 
-- **Utilisez toujours des index pour les colonnes `WHERE` et `ORDER BY`.** Déclarez-les via `#[rustango(index)]` afin qu'ils figurent dans les migrations.
-- **`select_related` pour l'affichage des FK dans les listes** — élimine le N+1 dans les vues de liste admin/publiques.
-- **`page` plutôt que `fetch().drain()`** — ne chargez jamais des tables entières.
-- **Pagination par curseur pour les tables volumineuses** — évite un `COUNT(*)` par page.
+- **Utilisez toujours des index pour les colonnes de `WHERE` et `ORDER BY`.** Déclarez-les via `#[rustango(index)]` afin qu'ils soient dans les migrations.
+- **`select_related` pour l'affichage des FK dans les listes** — élimine le N+1 dans les vues d'admin/liste.
+- **`page` au lieu de `fetch().drain()`** — ne chargez jamais des tables entières.
+- **Pagination par curseur pour les tables énormes** — évite le `COUNT(*)` par page.
 - **`bulk_insert_on` pour les lots** — un seul aller-retour au lieu de N.
-- **`upsert_on` pour les imports idempotents** — `ON CONFLICT` est plus rapide qu'un SELECT-puis-INSERT.
-- **`transaction` pour les écritures liées** — réduit la surcharge de commit et préserve la cohérence.
-- **Mettez en cache les lectures fréquentes** avec `cache::get_or_set` — invalidez sur un gestionnaire de signal `connect_post_save<T>(...)`.
+- **`upsert_on` pour les imports idempotents** — `ON CONFLICT` est plus rapide que SELECT-puis-INSERT.
+- **`transaction` pour les écritures liées** — réduit le surcoût de commit et maintient la cohérence.
+- **Mettez en cache les lectures chaudes** avec `cache::get_or_set` — invalidez sur le gestionnaire de signal `connect_post_save<T>(...)`.
 
 ---
 
 ## Voir aussi
 
-- [Models](models.md) — déclarer un modèle : types de champs, clés primaires, chaque attribut (le complément à ce guide de requêtage).
-- [Serializers](serializers.md) — mettre en forme les lignes de modèle en JSON.
-- [ViewSets](viewsets.md) — transformer un modèle en une API CRUD JSON.
-- [The admin](admin.md) — une interface utilisateur auto-générée sur les mêmes modèles.
-- [`manage` CLI](manage.md) — `makemigrations` / `migrate` pour les changements de schéma.
+- [Modèles](models.md) — déclarer un modèle : types de champs, clés primaires, chaque attribut (le compagnon de ce guide de requêtes).
+- [Sérialiseurs](serializers.md) — mettre en forme les lignes de modèle en JSON.
+- [ViewSets](viewsets.md) — transformer un modèle en API CRUD JSON.
+- [L'admin](admin.md) — une UI générée automatiquement au-dessus des mêmes modèles.
+- [CLI `manage`](manage.md) — `makemigrations` / `migrate` pour les changements de schéma.

--- a/docs/fr/query-method.md
+++ b/docs/fr/query-method.md
@@ -1,0 +1,182 @@
+# La méthode QUERY
+
+`QUERY` ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008), une norme proposée
+publiée en juin 2026) est le « GET sûr avec un corps ». Elle est **sûre** et
+**idempotente** comme `GET`, mais les critères de recherche voyagent dans le corps
+de la requête plutôt que dans l'URL — ainsi une recherche complexe n'a pas à être
+comprimée dans une chaîne de requête, et il n'y a pas de plafond de longueur d'URL.
+**Rustango** route `QUERY` aux côtés de `GET` dans tout le framework : le routage,
+un extracteur adaptatif à la méthode, la politique CSRF/CORS/retentative, la mise
+en cache par vue, les ViewSets, le client de test et OpenAPI.
+
+> **Source :** `rustango::http_query` (`query`, `QueryRouterExt`, `QUERY`) et
+> `rustango::params` (`Params`) — derrière la fonctionnalité `admin`. Surface
+> connexe : `viewset::ViewSet`, `cache_page::CachePageLayer::cache_query`,
+> `forms::csrf::CsrfConfig::require_csrf_on_query`, `cors::CorsLayer`,
+> `test_client` / `http_client`.
+
+## Quand y recourir
+
+Utilisez `QUERY` au lieu de `GET` lorsque les critères de recherche sont volumineux
+ou structurés :
+
+- Des ensembles de filtres qui dépasseraient une chaîne de requête (longues listes
+  `IN`, nombreuses facettes).
+- Des critères imbriqués / structurés qui ne se mappent pas proprement en paires
+  `?key=value` — envoyez-les sous forme de corps JSON.
+- Tout ce que vous seriez tenté de modéliser comme un `POST /search` alors même
+  qu'il ne lit aucun état et ne change rien — `QUERY` dit « ceci est une lecture
+  sûre et cacheable » dans la méthode elle-même.
+
+Utilisez un simple `GET` pour les requêtes simples, courtes et marque-pageables.
+`QUERY` est additif : le même handler peut servir les deux.
+
+## Routage
+
+axum 0.8 ne peut pas router `QUERY` nativement (son `MethodFilter` est un ensemble
+fermé — [tokio-rs/axum#3799](https://github.com/tokio-rs/axum/issues/3799)), donc
+rustango fournit `query()` et une chaîne `.query()` qui reflètent les propres
+`get()` / `post()` d'axum :
+
+```rust
+use rustango::http_query::{query, QueryRouterExt};
+use axum::routing::get;
+
+let app = axum::Router::new()
+    // QUERY-only route.
+    .route("/search", query(search))
+    // GET + QUERY on one path — chain `.query()` last.
+    .route("/products", get(list_products).query(search_products));
+```
+
+Un `405` sur une route mixte rapporte l'ensemble complet des méthodes, par ex.
+`Allow: GET,HEAD,QUERY`.
+
+## Un handler, deux transports
+
+`Params<T>` lit `T` depuis la chaîne de requête sur `GET`/`HEAD` et depuis le corps
+de la requête sur `QUERY`, de sorte qu'un seul handler sert les deux sans
+branchement :
+
+```rust
+use rustango::params::Params;
+use rustango::http_query::QueryRouterExt;
+use axum::routing::get;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Search { q: String, page: Option<u32> }
+
+async fn search(Params(s): Params<Search>) -> String {
+    format!("q={} page={:?}", s.q, s.page)
+}
+
+let app = axum::Router::new().route("/search", get(search).query(search));
+```
+
+`GET /search?q=hi` et `QUERY /search` avec le corps `q=hi` atteignent `search` et
+se désérialisent de manière identique. Sur `QUERY`, le corps est analysé selon le
+`Content-Type` :
+
+| `Content-Type` | Analysé comme | Notes |
+|---|---|---|
+| `application/x-www-form-urlencoded` (ou aucun) | `serde_urlencoded` | Même chemin de code que la chaîne de requête — plat, une seule valeur par clé. |
+| `application/json` (ou un suffixe `…+json`) | `serde_json` | À utiliser pour les tableaux / critères imbriqués. |
+| tout le reste | — | `415 Unsupported Media Type` |
+
+Les codes de statut correspondent aux conventions d'axum : une erreur d'analyse de
+la chaîne de requête est un `400`, une erreur d'analyse du corps est un `422`, et
+une méthode autre que GET/HEAD/QUERY est un `405`.
+
+```bash
+# urlencoded body
+curl -X QUERY http://localhost:8080/search \
+     -H 'Content-Type: application/x-www-form-urlencoded' \
+     --data 'q=hello&page=2'
+
+# JSON body (arrays / nesting)
+curl -X QUERY http://localhost:8080/search \
+     -H 'Content-Type: application/json' \
+     --data '{"q":"hello","tags":["rust","web"]}'
+```
+
+## ViewSets
+
+Un `ViewSet` obtient gratuitement une action de collection `QUERY` — `QUERY /things`
+renvoie la même liste filtrée / ordonnée / paginée que `GET /things?…`, mais avec
+les critères dans le corps :
+
+```bash
+# identical results:
+curl 'http://localhost:8080/posts?status=draft&ordering=-rating'
+curl -X QUERY http://localhost:8080/posts \
+     -H 'Content-Type: application/x-www-form-urlencoded' \
+     --data 'status=draft&ordering=-rating'
+
+# arrays via JSON (comma-joined internally for __in lookups):
+curl -X QUERY http://localhost:8080/posts \
+     -H 'Content-Type: application/json' \
+     --data '{"status__in":["draft","published"],"rating__gte":2}'
+```
+
+Les permissions et les throttles réutilisent celles de l'action `list`, et les vues
+d'administration personnalisées déclarées avec la méthode `QUERY` se routent
+correctement elles aussi.
+
+## Garanties du framework
+
+- **CSRF.** `QUERY` est exempté par défaut de l'application des jetons CSRF, aux
+  côtés de `GET`/`HEAD`/`OPTIONS`/`TRACE`. Les navigateurs ne peuvent pas soumettre
+  `QUERY` via un formulaire, et un `fetch` cross-origin avec la méthode `QUERY`
+  n'est jamais une « requête simple » figurant sur la liste blanche CORS — il
+  déclenche toujours un preflight — il n'y a donc pas de vecteur CSRF par
+  identifiants ambiants. Définissez `CsrfConfig::require_csrf_on_query = true` pour
+  une défense en profondeur pure. Gardez les handlers `QUERY` sans effet de bord,
+  et n'ajoutez jamais `QUERY` à la liste d'autorisation de la
+  [surcharge de méthode](middleware.md).
+- **CORS.** `QUERY` figure dans les listes de méthodes `permissive()` et dérivées
+  des paramètres. Parce que chaque `QUERY` cross-origin fait un preflight, elle doit
+  être annoncée dans `Access-Control-Allow-Methods` pour fonctionner en cross-origin.
+- **Retentatives.** Le client HTTP (`http_client`) traite `QUERY` comme idempotente,
+  elle est donc retentée en cas d'échecs transitoires comme `GET`.
+- **Idempotence.** `QUERY` n'a besoin d'aucun `Idempotency-Key` — la méthode est
+  idempotente par définition.
+- **Mise en cache.** `cache_page` peut mettre en cache les réponses `QUERY` lorsque
+  vous l'activez avec `CachePageLayer::cache_query(true)`. La clé de cache intègre un
+  condensé du corps de la requête, et la réponse est marquée `private` afin que les
+  caches partagés (qui ne peuvent pas se baser sur un corps) ne la servent jamais à
+  tort. Voir [Mise en cache](caching.md).
+
+## Tests
+
+`TestClient` et `RequestFactory` disposent de constructeurs `.query()`, et le
+`HttpClient` sortant peut envoyer `QUERY` :
+
+```rust
+let resp = client.query("/search").json(&criteria).send().await;
+```
+
+## OpenAPI
+
+OpenAPI 3.1 n'a pas d'opération `QUERY` ; [OpenAPI 3.2](https://www.openapis.org/blog/2025/09/23/announcing-openapi-v3-2)
+l'a ajoutée comme champ Path Item de première classe. Rustango émet une opération
+`query` lorsque vous en attachez une, et fait passer la spécification à
+`openapi: 3.2.0` uniquement pour les spécifications qui l'utilisent (les
+spécifications sans `QUERY` restent en `3.1.0` pour une compatibilité maximale avec
+l'outillage) :
+
+```rust
+use rustango::openapi::{OpenApiSpec, PathItem, Operation, RequestBody, Response, Schema};
+
+let spec = OpenApiSpec::new("API", "1.0").add_path(
+    "/posts",
+    PathItem::new()
+        .get(Operation::new().summary("List posts").response("200", Response::new("OK")))
+        .query(
+            Operation::new()
+                .summary("Search posts")
+                .request_body(RequestBody::json(Schema::ref_("SearchCriteria")))
+                .response("200", Response::new("OK")),
+        ),
+);
+```

--- a/docs/fr/security.md
+++ b/docs/fr/security.md
@@ -1,0 +1,671 @@
+# Guide de sécurité
+
+Ce guide couvre chaque fonctionnalité de sécurité fournie par **Rustango** et la manière de les combiner. Si vous venez de Django, Laravel ou Rails, la plupart vous sembleront familières — les noms diffèrent, mais les idées sont les mêmes. Chaque fonctionnalité ci-dessous se met généralement en place en une seule ligne. Quand vous êtes prêt à déployer, lancez `manage check --deploy` pour un audit automatisé.
+
+[![La pile de middleware renforcée câblée dans une seule chaîne : identifiants de requête, journalisation des accès, limitation de débit, CORS et en-têtes de sécurité](img/security.png)](img/security.png)
+
+## Table des matières
+
+- [La checklist de défense en profondeur](#the-defense-in-depth-checklist)
+- [Définir les en-têtes de sécurité](#setting-security-headers)
+- [Autoriser les requêtes cross-origin (CORS)](#allowing-cross-origin-requests-cors)
+- [Limiter le débit des requêtes](#rate-limiting-requests)
+- [Autoriser ou bloquer des IP](#allowing-or-blocking-ips)
+- [Se protéger contre le CSRF](#protecting-against-csrf)
+- [Prévenir le XSS](#preventing-xss)
+- [Prévenir l'injection SQL](#preventing-sql-injection)
+- [Authentifier les utilisateurs](#authenticating-users)
+- [Hacher et vérifier les mots de passe](#hashing-and-checking-passwords)
+- [Émettre et rafraîchir des JWT](#issuing-and-refreshing-jwts)
+- [S'authentifier avec des clés d'API](#authenticating-with-api-keys)
+- [Ajouter l'authentification à deux facteurs (TOTP)](#adding-two-factor-auth-totp)
+- [Envoyer des URL signées (liens magiques)](#sending-signed-urls-magic-links)
+- [Vérifier les webhooks entrants](#verifying-incoming-webhooks)
+- [Garder les secrets hors de vos journaux](#keeping-secrets-out-of-your-logs)
+- [Tracer les requêtes entre services](#tracing-requests-across-services)
+- [Gérer les secrets](#managing-secrets)
+- [Auditer avant de déployer](#auditing-before-you-deploy)
+
+---
+
+## La checklist de défense en profondeur
+
+Une bonne sécurité vient de nombreuses petites couches, pas d'un seul grand mur. Une application **Rustango** en production devrait empiler les couches ci-dessous — la plupart tiennent en une ligne chacune. Le reste de ce guide explique chacune d'elles.
+
+```rust
+let app = Router::new()
+    .route("/...", ...)
+    .merge(health::health_router(pool.clone()))         // /health, /ready
+    .request_id(RequestIdLayer::default())              // log correlation
+    .access_log(AccessLogLayer::default())              // PII-redacted by default
+    .rate_limit(RateLimitLayer::per_ip(60, ONE_MIN))    // 60 req/min/IP
+    .cors(CorsLayer::new().allow_origins(vec!["..."])) // explicit allowlist
+    .security_headers(                                   // HSTS + XFO + nosniff + Referrer + CSP
+        SecurityHeadersLayer::strict()
+            .csp(CspBuilder::strict_starter().build()),
+    );
+// Plus: TLS termination at reverse proxy.
+// Plus: argon2 for passwords, JWT lifecycle for tokens, TOTP for MFA.
+```
+
+---
+
+## Définir les en-têtes de sécurité
+
+Les en-têtes de sécurité indiquent au navigateur comment protéger vos utilisateurs (bloquer le clickjacking, forcer HTTPS, empêcher le sniffing de type de contenu). `SecurityHeadersLayer` définit l'ensemble standard en une ligne — les mêmes en-têtes que Django fournit par défaut. (Une « couche » est le terme de **Rustango** pour désigner un middleware ; vous l'attachez à votre routeur.)
+
+> À approfondir : [Middleware](middleware.md) couvre le fonctionnement des couches, leur ordre, le catalogue intégré complet et la rédaction de vos propres couches (sensibles à la locale, au fuseau horaire, en-têtes, CSRF).
+
+```rust
+use rustango::security_headers::{SecurityHeadersLayer, SecurityHeadersRouterExt, CspBuilder};
+
+let app = router.security_headers(SecurityHeadersLayer::strict());
+```
+
+### Presets
+
+| Preset | Quand l'utiliser |
+|---|---|
+| `strict()` | Production : HSTS preload + XFO=DENY + nosniff + Referrer-Policy=no-referrer + COOP=same-origin + Permissions-Policy verrouillée |
+| `relaxed()` | Intégrable dans des iframes : SAMEORIGIN + HSTS 1 an |
+| `dev()` | Local : nosniff uniquement (pas de HSTS pour éviter de verrouiller localhost en HTTPS pour toujours) |
+| `empty()` | Construire à partir de zéro |
+
+### CSP personnalisé
+
+```rust
+let csp = CspBuilder::new()
+    .default_src(&["'self'"])
+    .script_src(&["'self'", "https://cdn.example.com"])
+    .style_src(&["'self'", "'unsafe-inline'"])    // for inline <style>
+    .img_src(&["'self'", "data:", "https:"])
+    .font_src(&["'self'", "data:"])
+    .connect_src(&["'self'", "wss://realtime.example.com"])
+    .frame_ancestors(&["'none'"])                 // disallow embedding (clickjacking)
+    .object_src(&["'none'"])
+    .directive("base-uri", &["'self'"])
+    .build();
+
+let layer = SecurityHeadersLayer::strict().csp(csp);
+```
+
+### Déploiement progressif du CSP
+
+Utilisez `csp_report_only` pour surveiller sans casser la production :
+
+```rust
+let layer = SecurityHeadersLayer::strict()
+    .csp(CspBuilder::strict_starter().build())
+    .csp_report_only(true);                       // sends Content-Security-Policy-Report-Only
+```
+
+Après avoir vérifié l'absence d'erreurs dans la console → basculez `csp_report_only(false)` pour appliquer.
+
+---
+
+## Autoriser les requêtes cross-origin (CORS)
+
+Le CORS contrôle quels autres sites web sont autorisés à appeler votre API depuis un navigateur. Par défaut, les navigateurs bloquent ces appels ; vous réautorisez spécifiquement certaines origines. Listez vos vrais domaines front-end en production et ne l'ouvrez jamais à tout le monde.
+
+```rust
+use rustango::cors::{CorsLayer, CorsRouterExt};
+
+// Production
+let layer = CorsLayer::new()
+    .allow_origins(vec!["https://app.example.com", "https://admin.example.com"])
+    .allow_methods(vec!["GET", "POST", "PUT", "PATCH", "DELETE"])
+    .allow_headers(vec!["content-type", "authorization"])
+    .allow_credentials(true)
+    .max_age(Duration::from_secs(3600));
+
+// Dev only
+let layer = CorsLayer::permissive();              // any origin, common methods
+```
+
+**Note de sécurité :** ne combinez jamais `allow_credentials(true)` avec `allow_any_origin()` — le navigateur rejettera la réponse. Avec des identifiants, vous DEVEZ lister des origines explicites.
+
+---
+
+## Limiter le débit des requêtes
+
+La limitation de débit plafonne le nombre de requêtes qu'un client peut effectuer dans une fenêtre de temps. Utilisez-la pour ralentir les connexions par force brute, le scraping et les abus. Vous pouvez limiter par IP, par clé d'API ou globalement pour un endpoint coûteux.
+
+```rust
+use rustango::rate_limit::{RateLimitLayer, RateLimitRouterExt};
+
+// Per-IP
+router.rate_limit(RateLimitLayer::per_ip(60, Duration::from_secs(60)));
+
+// Per-API-key (header)
+router.rate_limit(RateLimitLayer::per_header("authorization", 1000, Duration::from_secs(3600)));
+
+// Global ceiling for an expensive endpoint
+router.rate_limit(RateLimitLayer::global(10, Duration::from_secs(1)));
+```
+
+En cas d'épuisement : `429 Too Many Requests` avec l'en-tête `Retry-After`. Chaque réponse réussie inclut `X-RateLimit-Limit` + `X-RateLimit-Remaining`.
+
+> **Derrière un reverse proxy, associez `per_ip` avec `real_ip`.** `RateLimitLayer::per_ip` s'indexe sur le socket de connexion (`ConnectInfo`), qui derrière un proxy est l'IP *du proxy* — donc tous les clients partagent un seul compartiment et la limite est inutile. Placez `real_ip::RealIpLayer` (qui lit `X-Forwarded-For` / `X-Real-IP`) avant lui pour que la vraie IP client soit utilisée.
+
+`RateLimitLayer` est **local au processus** — il compte les requêtes uniquement au sein d'une instance en cours d'exécution, ce qui convient si vous exécutez une seule instance. Si vous exécutez plusieurs instances (répliques) derrière un load balancer, chacune tiendrait son propre compte, et la limite réelle se multiplierait. Pour partager un seul compte entre toutes les répliques, utilisez `rate_limit_cache::CacheRateLimitLayer`, qui délègue à n'importe quelle implémentation de `cache::Cache` (à associer avec `cache::RedisCache` pour un compteur partagé incrémenté de façon atomique par le `INCRBY` de Redis) :
+
+```rust
+use rustango::cache::RedisCache;
+use rustango::rate_limit::KeyBy;
+use rustango::rate_limit_cache::{CacheRateLimitLayer, CacheRateLimitRouterExt};
+
+let cache: rustango::cache::BoxedCache =
+    std::sync::Arc::new(RedisCache::new("redis://localhost").await?);
+
+let app = axum::Router::new()
+    .route("/api/login", axum::routing::post(login))
+    .cache_rate_limit(
+        CacheRateLimitLayer::new(cache, 5, Duration::from_secs(60))
+            .key_by(KeyBy::Ip)
+            .key_prefix("login"),
+    );
+```
+
+---
+
+## Autoriser ou bloquer des IP
+
+Verrouillez les routes sensibles (comme votre admin) à un ensemble connu d'adresses IP, ou bloquez des abuseurs spécifiques. Une liste d'autorisation ne permet que les réseaux listés ; une liste de blocage refuse ceux qui sont listés.
+
+```rust
+use rustango::ip_filter::{IpFilterLayer, IpFilterRouterExt};
+
+// Internal admin only
+let admin_router = admin_router
+    .ip_filter(IpFilterLayer::allow_only(vec![
+        "10.0.0.0/8",
+        "192.168.0.0/16",
+        "203.0.113.0/24",
+    ])?);
+
+// Block known abusers
+let public_router = public_router
+    .ip_filter(IpFilterLayer::block(vec!["203.0.113.42"])?);
+```
+
+**IPv4 + IPv6 pris en charge.** Sûr entre familles (un CIDR IPv4 ne correspond pas aux adresses IPv6). Renvoie `403 Forbidden` en cas de rejet.
+
+**Important :** **Rustango** lit l'IP client depuis `ConnectInfo<SocketAddr>`. Montez avec :
+
+```rust
+axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await?;
+```
+
+Si votre reverse proxy transmet `X-Forwarded-For`, configurez-le pour définir `RemoteAddr` — `ip_filter` lit le pair de connexion, pas les en-têtes.
+
+---
+
+## Se protéger contre le CSRF
+
+> **CSRF et API à jeton.** Le CSRF protège les requêtes **authentifiées par cookie**. Une
+> API purement à jeton / Bearer / [JWT](auth-jwt.md) n'est pas une cible CSRF — n'appliquez pas
+> la couche CSRF sur celle-ci (sinon vous renverrez des 403 à des clients légitimes). Pour une SPA qui *utilise bien*
+> des cookies, lisez le cookie `rustango_csrf` et renvoyez-le dans l'en-tête
+> `X-CSRF-Token`.
+
+Le CSRF (cross-site request forgery) survient lorsqu'un autre site trompe le navigateur d'un utilisateur connecté pour lui faire soumettre une requête à votre application. La défense est un jeton secret sur chaque formulaire, tout comme le `{% csrf_token %}` de Django. Le middleware CSRF vit dans `rustango::forms::csrf` (derrière la feature `csrf`, activée automatiquement par la feature `admin`) :
+
+```rust
+use rustango::forms::csrf;
+
+let app = Router::new()
+    .route("/contact", get(form).post(submit))
+    .layer(csrf::layer());
+```
+
+`csrf::layer()` construit la couche avec des valeurs par défaut raisonnables ; `csrf::with_config(CsrfConfig)` vous permet de remplacer les noms de cookie/en-tête et le flag `Secure`. Dans les templates, `{{ csrf_token }}` vous donne le jeton brut et `{{ csrf_input }}` vous donne un `<input>` caché prêt à l'emploi — déposez-en un dans chaque formulaire. Il utilise le motif du cookie à double soumission : sur les méthodes non sûres (POST, PUT, PATCH, DELETE), la couche vérifie l'en-tête `X-CSRF-Token` (ou le champ de formulaire `_csrf`) par rapport au cookie `rustango_csrf` ; une discordance renvoie `403 Forbidden`.
+
+**Exempter les endpoints collecteurs.** `CsrfConfig::exempt_prefix("/path")` (répétable) ignore l'application du CSRF pour les méthodes non sûres sur les requêtes dont le chemin commence par le préfixe donné. Ceci concerne les endpoints append-only, sans état d'authentification, atteints via `navigator.sendBeacon` — par exemple un collecteur d'analytics — qui ne peuvent pas définir un en-tête `X-CSRF-Token` et, lorsque la page est servie depuis un cache CDN qui supprime `Set-Cookie`, peuvent ne porter aucun cookie CSRF du tout. Gardez les préfixes étroits et n'exemptez jamais quoi que ce soit qui lit ou écrit un état d'authentification.
+
+L'auto-admin active le CSRF sur chaque mutation par défaut, et il n'y a aucun moyen de s'y soustraire.
+
+---
+
+## Prévenir le XSS
+
+Le XSS (cross-site scripting) survient lorsqu'une entrée utilisateur est rendue en HTML et s'exécute comme du code dans le navigateur de quelqu'un d'autre. La solution est d'échapper toute entrée utilisateur avant qu'elle n'atteigne la page. **Rustango** gère cela de deux façons :
+
+**1. Auto-échappement des templates Tera** — Tera est le moteur de templates de **Rustango** (comme les templates Django ou Blade). Chaque `{{ var }}` est automatiquement échappé en HTML. Utilisez `{{ var | safe }}` pour vous en soustraire — rare, et dangereux, donc ne le faites que pour du HTML auquel vous faites entièrement confiance.
+
+**2. Fonction d'échappement manuelle** — pour quand vous construisez du HTML dans du code Rust au lieu d'un template :
+
+```rust
+use rustango::text::html_escape;
+
+let safe = html_escape(user_input);
+// "<script>" → "&lt;script&gt;"
+// "a & b" → "a &amp; b"
+```
+
+Remplace `&`, `<`, `>`, `"`, `'`. Convient pour le contenu d'éléments HTML + les attributs entre guillemets doubles.
+
+Pour une défense XSS basée sur le CSP, voir [Définir les en-têtes de sécurité](#setting-security-headers).
+
+---
+
+## Prévenir l'injection SQL
+
+L'injection SQL survient lorsqu'une entrée utilisateur est collée directement dans une chaîne SQL et modifie la requête. L'ORM de **Rustango** empêche cela par conception : il utilise partout le binding de paramètres de sqlx — chaque valeur est envoyée comme un placeholder `$1, $2, ...`, jamais collée dans le texte de la requête. (sqlx est la bibliothèque de base de données sous-jacente.) **Vous ne pouvez pas accidentellement concaténer une entrée utilisateur dans du SQL via l'API de l'ORM.**
+
+Il y a deux endroits où rester vigilant :
+
+**1. Les noms de table et de colonne dans `bulk_actions` :**
+
+Les placeholders protègent les valeurs, mais ils ne peuvent pas porter un identifiant (un nom de table ou de colonne), donc ceux-ci ont besoin de leur propre garde-fou. Le runner d'actions groupées ne colle jamais de noms de table/colonne bruts fournis par l'utilisateur dans du SQL. En interne, il valide chaque identifiant (une fonction privée au crate,
+`validate_ident`, qui rejette `"`, `` ` ``, `\0`, `\n`, `\r`, `\`, `;`,
+les espaces et les caractères de contrôle) puis le met entre guillemets via `dialect.quote_ident()`
+avant de construire l'instruction. Ce garde-fou s'exécute pour vous — vous ne l'appelez
+pas vous-même.
+
+**2. L'échappatoire du SQL brut :**
+
+Si vous descendez au niveau de `sqlx` brut, liez chaque *valeur* comme un paramètre et
+ne collez jamais un *identifiant* (nom de table ou de colonne) provenant d'une
+entrée utilisateur dans la chaîne de requête — les placeholders ne peuvent pas porter d'identifiants :
+
+```rust
+// ✅ values go through bound placeholders
+sqlx::query("SELECT * FROM posts WHERE id = $1")
+    .bind(1).fetch_all(&pool).await?;
+
+// ❌ NEVER interpolate a user-supplied identifier into the SQL string
+let sql = format!("SELECT * FROM \"{user_table}\" WHERE id = $1");
+sqlx::query(&sql).bind(1).fetch_all(&pool).await?;
+```
+
+---
+
+## Authentifier les utilisateurs
+
+L'authentification est la manière dont vous confirmez qui effectue une requête. **Rustango** fournit trois backends prêts à l'emploi (Basic auth, clés d'API et JWT) et vous laisse écrire les vôtres — un peu comme les backends d'authentification de Django. Vous les attachez aux routes, et les requêtes sans identifiant reconnu reçoivent un `401`.
+
+> **SSO admin.** Pour permettre aux opérateurs de se connecter à l'admin avec un IdP externe (Google, Microsoft/Azure AD, GitHub, ou tout fournisseur OpenID Connect) au lieu d'un mot de passe, activez la feature `admin-sso` — voir le [guide SSO](sso.md). Les fournisseurs sont **gérés depuis l'interface admin sous forme de lignes** (plusieurs par surface ; par tenant, ou un ensemble partagé entre tenants), avec le secret client **chiffré au repos**. C'est un rattachement à l'existant (l'email vérifié de l'IdP doit correspondre à un utilisateur admin ; pas d'auto-provisionnement) et cela réutilise la session existante.
+
+### Trois backends prêts à l'emploi
+
+```rust
+use rustango::tenancy::auth_backends::{ModelBackend, ApiKeyBackend, JwtBackend};
+use rustango::tenancy::middleware::{RouterAuthExt, CurrentUser};
+use std::sync::Arc;
+
+let backends = vec![
+    Arc::new(ModelBackend) as _,                   // Authorization: Basic <b64>
+    Arc::new(ApiKeyBackend) as _,                   // Authorization: Bearer <prefix>.<secret>
+    Arc::new(JwtBackend::new(secret)) as _,         // Authorization: Bearer <jwt>
+];
+
+let app = Router::new()
+    .route("/me", get(profile))
+    .require_auth(backends.clone(), pool.clone())   // 401 if no backend recognizes
+    .route("/posts/new", post(create_post))
+    .require_perm("post.add", pool.clone())         // gate by codename
+    .require_auth(backends, pool);
+```
+
+Le middleware essaie chaque backend dans l'ordre. Le premier qui réussit l'emporte ; le premier qui renvoie une erreur dure arrête la chaîne.
+
+### Écrire votre propre backend
+
+```rust
+use rustango::tenancy::auth_backends::{AuthBackend, AuthUser, AuthError};
+use async_trait::async_trait;
+
+pub struct OAuthBackend { /* ... */ }
+
+#[async_trait]
+impl AuthBackend for OAuthBackend {
+    async fn authenticate(&self, parts: &Parts, pool: &rustango::sql::Pool)
+        -> Result<Option<AuthUser>, AuthError>
+    {
+        // Read your custom header, validate, look up the user
+        Ok(None)  // means: not my request, try next backend
+    }
+}
+```
+
+---
+
+## Hacher et vérifier les mots de passe
+
+Ne stockez jamais les mots de passe en clair. Hachez-les à l'inscription avec `hash`, et à la connexion comparez la tentative avec `verify`. Utilisez `strength_score` pour rejeter les mots de passe faibles avant même de les hacher.
+
+```rust
+use rustango::passwords::{hash, verify, strength_score, StrengthIssue};
+
+// Signup
+let issues = strength_score(&new_password);
+if !issues.is_empty() {
+    return Err(format!("password too weak: {issues:?}"));
+}
+let hashed = hash(&new_password)?;
+
+// Login
+let ok = verify(&attempted, &user.password_hash)?;
+```
+
+Le hachage utilise **argon2id** (le défaut recommandé par l'OWASP depuis 2023 — il résiste mieux au cassage par GPU que bcrypt). Les hachages sont stockés au format PHC-string, de sorte que vous pouvez changer les paramètres plus tard sans casser les anciens hachages.
+
+La **vérification de robustesse** intégrée est intentionnellement minimale. Pour les déploiements sérieux, vérifiez aussi les mots de passe par rapport à l'API HIBP / pwned-passwords afin de rejeter ceux connus comme divulgués.
+
+> **À approfondir :** [Mots de passe](auth-passwords.md) — internals d'argon2id, salage automatique, connexions résistantes aux attaques temporelles (`verify_dummy`), et où vit le hachage. Une fois authentifié, passez la main à une [Session](auth-sessions.md) (navigateur) ou un [JWT](auth-jwt.md) (API).
+
+---
+
+## Émettre et rafraîchir des JWT
+
+Un JWT (JSON Web Token) est un jeton signé qu'un client envoie au lieu de se connecter à chaque fois. `JwtLifecycle` gère tout le flux : un jeton d'accès à courte durée de vie plus un jeton de rafraîchissement à durée de vie plus longue, avec vérification, rafraîchissement et révocation intégrés.
+
+```rust
+use rustango::tenancy::jwt_lifecycle::{JwtLifecycle, JwtTokenPair, JwtIssueError};
+use serde_json::json;
+
+let jwt = JwtLifecycle::new(secret)
+    .with_access_ttl(900)                         // 15 min
+    .with_refresh_ttl(7 * 86400);                 // 7 days
+```
+
+### Émettre un jeton avec des claims personnalisés (pas de lookup DB à la vérification)
+
+```rust
+let pair = jwt.issue_pair_with(user_id, json!({
+    "roles":  ["admin", "editor"],
+    "tenant": "acme",
+    "scope":  "read:posts write:posts",
+    "email":  "alice@example.com",
+}).as_object().unwrap().clone())?;
+```
+
+Les « claims » sont les faits clé/valeur que vous intégrez dans le jeton (rôles, tenant, etc.) ; le client les renvoie et vous les lisez sans toucher à la base de données. Les noms de claim réservés (`sub`, `exp`, `jti`, `typ`) sont utilisés par le framework et ne peuvent pas apparaître dans vos claims personnalisés — essayer renvoie `JwtIssueError::ReservedClaim`.
+
+### Vérifier un jeton
+
+```rust
+let claims = jwt.verify_access(&access_token)
+    .ok_or(StatusCode::UNAUTHORIZED)?;
+
+let roles: Vec<String> = claims.get_custom("roles").unwrap_or_default();
+let tenant: String = claims.get_custom("tenant").unwrap_or_default();
+```
+
+### Rafraîchir un jeton (conserve vos claims personnalisés)
+
+```rust
+let new_pair = jwt.refresh(&refresh_token)
+    .ok_or(StatusCode::UNAUTHORIZED)?;
+// new_pair has the same roles + scope + tenant
+```
+
+Le JTI de l'ancien jeton de rafraîchissement (son ID unique) est ajouté à une liste noire pour qu'il ne puisse pas être réutilisé — cela bloque les attaques par rejeu où un ancien jeton volé est renvoyé.
+
+### Rafraîchir avec re-vérification des permissions
+
+```rust
+// returns Result<Option<JwtTokenPair>, JwtIssueError>:
+// Err on a reserved-claim collision, Ok(None) on an invalid/expired refresh.
+let new_pair = jwt.refresh_with(&refresh_token, json!({
+    "roles": ["viewer"],     // role was demoted since login
+    "tenant": "acme",
+}).as_object().unwrap().clone())?
+    .ok_or(StatusCode::UNAUTHORIZED)?;
+```
+
+### Révoquer un jeton
+
+```rust
+jwt.revoke(&access_token);     // adds JTI to blacklist
+jwt.revoke(&refresh_token);
+```
+
+La liste noire en mémoire par défaut (`InMemoryJtiStore`) nettoie d'elle-même les entrées expirées, mais elle vit dans un seul processus et oublie chaque révocation au redémarrage. Pour les déploiements multi-processus, installez un store partagé et durable via `JwtLifecycle::new(secret).with_jti_store(store)` — `store` est n'importe quel `Arc<dyn JtiStore>` (par exemple un store adossé à Redis ou à une base de données). Sans store partagé, un jeton que vous révoquez sur une réplique peut encore être rejoué sur une autre jusqu'à son expiration.
+
+> **À approfondir :** [API d'authentification JWT](auth-jwt-api.md) — le routeur intégré `/api/auth/login|refresh|logout|me`, le rafraîchissement glissant, et le store de révocation JTI. Pour un seul jeton auto-géré, voir [JWT (autonome)](auth-jwt.md). Pour restreindre les routes navigateur/API selon la connexion, voir [décorateurs d'accès](auth-decorators.md).
+
+---
+
+## S'authentifier avec des clés d'API
+
+Les clés d'API permettent aux scripts et aux services de s'authentifier sans nom d'utilisateur, mot de passe ni session — pratique pour l'accès machine à machine. Vous générez une clé, la montrez à l'utilisateur une seule fois, et ne stockez que son préfixe et son hachage.
+
+```rust
+use rustango::api_keys::{generate_key, verify_key, split_token};
+
+// Issuance
+let (full_token, prefix, hash) = generate_key()?;
+// Format: {8-char hex prefix}.{32-char hex secret}
+// Show full_token to the user once. Store prefix + hash in your DB.
+
+// Verification on each request
+let (prefix, secret) = split_token(&inbound_header)
+    .ok_or(StatusCode::UNAUTHORIZED)?;
+let row = lookup_by_prefix(prefix).await?;
+if !verify_key(secret, &row.hash)? {
+    return Err(StatusCode::UNAUTHORIZED);
+}
+```
+
+Ces clés fonctionnent directement avec le `ApiKeyBackend` de la multi-tenancy — les deux utilisent le même format `{prefix}.{secret}` avec des secrets hachés en argon2id, de sorte qu'une clé émise ici s'authentifie là-bas sans travail supplémentaire.
+
+---
+
+## Ajouter l'authentification à deux facteurs (TOTP)
+
+Le TOTP est le code à 6 chiffres d'une application d'authentification — un second facteur en plus du mot de passe. Vous générez un secret par utilisateur, le montrez sous forme de QR code pour l'enrôlement, puis vérifiez le code qu'il saisit à chaque connexion. Il suit la norme RFC 6238.
+
+```rust
+use rustango::totp::{TotpSecret, otpauth_url, verify};
+
+// Enrollment
+let secret = TotpSecret::generate();                           // 20 random bytes
+user.totp_secret = secret.to_base32();                          // store in DB
+let qr_url = otpauth_url("MyApp", &user.email, &secret);        // encode as QR
+
+// Verification on login
+let secret = TotpSecret::from_base32(&user.totp_secret).unwrap();
+if !verify(&secret, &user_supplied_code, 30, 6, 1) {            // 6 digits, ±30s drift
+    return Err("bad TOTP code");
+}
+```
+
+Fonctionne avec Google Authenticator, Authy, 1Password, Bitwarden et d'autres applications d'authentification standard.
+
+**Codes de récupération** (codes de secours à usage unique pour quand un utilisateur perd son téléphone) pas encore fournis. Le motif courant est de stocker 8 à 10 codes hachés par utilisateur et d'en brûler un à chaque utilisation.
+
+---
+
+## Envoyer des URL signées (liens magiques)
+
+Une URL signée porte une signature infalsifiable, de sorte que vous pouvez lui faire confiance sans session — parfait pour les connexions par lien magique, les réinitialisations de mot de passe et les liens de téléchargement à durée limitée. Vous `sign` une URL (optionnellement avec une expiration) et la `verify` quand l'utilisateur clique. (Laravel les appelle des « signed routes ».)
+
+```rust
+use rustango::signed_url::{sign, verify, SignedUrlError};
+use std::time::Duration;
+
+// Issue a 1-hour magic-link login URL
+let url = sign(
+    "https://app.example.com/auth/login?email=alice@x.com",
+    secret,
+    Some(Duration::from_secs(3600)),
+);
+// Send via email...
+
+// On the callback handler
+match verify(&incoming_url, secret) {
+    Ok(()) => { /* identity confirmed */ }
+    Err(SignedUrlError::Expired) => { /* prompt to request a new link */ }
+    Err(SignedUrlError::InvalidSignature) => { /* tampered — log + 401 */ }
+    Err(_) => { /* malformed */ }
+}
+```
+
+Usages courants :
+- Connexion par lien magique (envoyer par email une URL à usage unique au lieu de demander un mot de passe)
+- Confirmation de réinitialisation de mot de passe
+- Téléchargements de fichiers à durée limitée
+- Liens « Cliquez ici pour vérifier votre email »
+- Liens de désinscription (aucune authentification nécessaire ; l'URL elle-même prouve l'intention)
+
+Avant la signature, les paramètres de requête sont triés dans un ordre fixe, de sorte qu'un attaquant ne peut pas les réordonner (par exemple déplacer `?expires=...`) pour changer ce que couvre la signature et forger un lien d'apparence valide.
+
+> À approfondir : [Flux de compte](auth-flows.md) construit la réinitialisation de mot de passe, la vérification d'email et la connexion par lien magique sur cette primitive d'URL signée.
+
+---
+
+## Vérifier les webhooks entrants
+
+Un webhook est un rappel HTTP qu'un autre service vous envoie (un paiement a réussi, un push a eu lieu). Vérifiez toujours sa signature pour savoir qu'il provient réellement de ce service et que le corps n'a pas été modifié. `verify_signature` gère les formats courants.
+
+```rust
+use rustango::webhook::{verify_signature, SignatureFormat};
+
+async fn handle_stripe_webhook(headers: HeaderMap, body: Bytes) -> impl IntoResponse {
+    let signature = headers.get("stripe-signature")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    if !verify_signature(SignatureFormat::HexSha256, secret, &body, signature) {
+        return StatusCode::UNAUTHORIZED;
+    }
+    // ... process the verified payload
+    StatusCode::OK
+}
+```
+
+| Format | Utilisé par |
+|---|---|
+| `HexSha256WithPrefix` | GitHub (`sha256=<hex>`) |
+| `HexSha256` | Slack, fournisseurs HMAC bruts |
+| `Base64Sha256` | Stripe, AWS SNS |
+
+La comparaison de signature est à temps constant, ce qui signifie qu'elle prend toujours le même temps que la supposition soit correcte ou fausse. Cela stoppe les attaques temporelles, où un attaquant mesure de minuscules différences de temps de réponse pour deviner le secret un caractère à la fois.
+
+---
+
+## Garder les secrets hors de vos journaux
+
+Les URL journalisées peuvent divulguer des mots de passe et des jetons qui apparaissent dans les query strings. `AccessLogLayer` masque automatiquement les paramètres d'identifiant connus avant d'écrire la ligne de journal (PII = informations personnellement identifiables).
+
+```rust
+let app = router.access_log(AccessLogLayer::default());
+```
+
+Par défaut, les valeurs de ces query params sont remplacées par `[redacted]` :
+`password`, `passwd`, `token`, `secret`, `api_key`, `apikey`, `access_token`, `refresh_token`, `signature`, `auth`.
+
+Ajouter à la liste :
+
+```rust
+let layer = AccessLogLayer::default()
+    .redact_additional("session_id")
+    .redact_additional("private_key");
+```
+
+Remplacer toute la liste :
+
+```rust
+let layer = AccessLogLayer::default()
+    .redact(vec!["only_this".into()]);
+```
+
+Note : ceci masque uniquement les **query strings**. Pour nettoyer les corps de requête ou les en-têtes, filtrez à la source avec `tracing::Subscriber`.
+
+---
+
+## Tracer les requêtes entre services
+
+Un identifiant de requête étiquette chaque ligne de journal d'une même requête avec le même ID, de sorte que vous pouvez suivre cette requête à travers les handlers — et à travers les services. `RequestIdLayer` en ajoute un à chaque requête.
+
+```rust
+let app = router.request_id(RequestIdLayer::default());
+```
+
+Il réutilise un `X-Request-Id` entrant (pour que les services chaînés partagent un seul ID) ou génère un nouvel ID base64 de 22 caractères. Les IDs entrants sont d'abord validés — tout ce qui contient des caractères de contrôle, des retours à la ligne, des octets nuls, ou dépasse 128 caractères est rejeté, ce qui bloque les attaques par injection d'en-tête.
+
+Dans les handlers :
+
+```rust
+async fn handler(id: rustango::request_id::RequestId) -> String {
+    tracing::info!(req_id = %id.0, "handling /me");
+    format!("req {}", id.0)
+}
+```
+
+Dans une configuration zero-trust, où vous ne faites pas confiance aux IDs envoyés par les services en amont, générez toujours le vôtre :
+
+```rust
+router.request_id(RequestIdLayer::always_generate());
+```
+
+---
+
+## Gérer les secrets
+
+Ne codez jamais en dur des secrets (mots de passe de base de données, clés d'API) dans votre source. Lisez-les à l'exécution via le trait `Secrets`, qui abstrait l'endroit où ils vivent réellement. (Un « trait » est la version Rust d'une interface.) Le `EnvSecrets` intégré lit depuis les variables d'environnement.
+
+```rust
+use rustango::secrets::{Secrets, EnvSecrets, BoxedSecrets};
+use std::sync::Arc;
+
+// Env vars (with optional prefix)
+let secrets: BoxedSecrets = Arc::new(EnvSecrets::with_prefix("MYAPP_"));
+
+let db_pwd = secrets.require("DB_PASSWORD").await?;       // reads MYAPP_DB_PASSWORD
+let redis_url = secrets.get("REDIS_URL").await?;          // None when unset
+```
+
+Pour extraire des secrets depuis Vault, AWS Secrets Manager ou GCP Secret Manager, implémentez le trait vous-même — ce n'est qu'une seule méthode async.
+
+---
+
+## Auditer avant de déployer
+
+Avant de passer en production, lancez l'audit intégré. Il attrape les mauvaises configurations courantes — comme un secret de signature manquant ou trop court — que vous ne voulez pas découvrir en production.
+
+```bash
+manage check --deploy
+```
+
+Vérifications toujours actives (exécutées avec ou sans `--deploy`) :
+- ✅ Modèles enregistrés dans l'inventaire
+- ✅ DB joignable (`SELECT 1`)
+- ✅ Migrations sur disque pour les modèles enregistrés
+
+Vérifications `--deploy` supplémentaires (durcissement pour la production) :
+- ✅ `RUSTANGO_ENV` est `prod` ou `production`
+- ✅ `RUSTANGO_SESSION_SECRET` défini et ≥ 32 octets (la clé HMAC pour la signature des cookies + JWT — `SECRET_KEY` n'est **pas** lu par le framework), sans placeholder du scaffolder laissé en place
+- ✅ `DATABASE_URL` défini (et avertit s'il pointe vers localhost)
+- ⚠️ Avertissements de cohérence `RUSTANGO_APEX_DOMAIN` / `RUSTANGO_BIND` pour la tenancy + le binding non-loopback
+
+Renvoie un code de sortie non nul en cas de constat de **niveau erreur** (idéal pour les gates de CI). Les avertissements ne déclenchent pas d'échec mais s'affichent dans la sortie.
+
+Pour des vérifications au-delà de ce qui est fourni, étendez avec du code personnalisé dans votre binaire `manage` avant de transmettre à `manage::run`.
+
+---
+
+## Ce qui n'est PAS encore fourni
+
+Quelques flux de bout en bout ont encore besoin d'être assemblés à partir des primitives ci-dessous :
+
+- **Réinitialisation de mot de passe + vérification d'email** — les helpers d'émission/vérification de jeton existent (`auth_flows::confirm_password_reset_pool`, plus les allers-retours de vérification d'email) et le pipeline d'email est fourni séparément, mais il n'y a pas de cycle unique préconstruit vue + email + validation câblé pour vous.
+- **Masquage PII du corps de requête / des en-têtes** dans `access_log` — le masquage de journal au niveau des champs existe (voir [Garder les secrets hors de vos journaux](#keeping-secrets-out-of-your-logs)), mais pas le nettoyage automatique du corps de requête ou des en-têtes.
+
+Déjà fournis (n'allez pas chercher un contournement) :
+
+- **Connexion sociale OAuth2 / OIDC** — `oauth2::providers` fournit les helpers Google, GitHub, Microsoft, GitLab et Discord (plus `OAuth2Provider::from_discovery` pour tout fournisseur OIDC), et `oauth2::router::oauth2_router` monte les routes de login + callback, crée l'enregistrement utilisateur et définit le cookie de session.
+- **Verrouillage par compte** — `rustango::account_lockout::Lockout` (adossé au cache ; `is_locked` / `record_failure` / `clear`, `max_attempts` + `lockout_duration` configurables).
+- **Endpoint de rapport CSP** — `security_headers::csp_report_router(path)` + `SecurityHeadersLayer::csp_report_uri(uri)`.
+- **Limitation de débit distribuée** — `rate_limit_cache::CacheRateLimitLayer` (voir [Limiter le débit des requêtes](#rate-limiting-requests)).
+
+Jusqu'à ce que les flux non fournis arrivent, assemblez-les à partir des primitives ci-dessus (`signed_url::sign` pour les jetons de réinitialisation de mot de passe, le pipeline d'email pour la livraison, etc.).
+
+---
+
+## Voir aussi
+
+- [Middleware](middleware.md) — comment les couches de sécurité s'attachent, leur ordre, et le catalogue complet.
+- [Authentification](auth-passwords.md) — mots de passe, sessions, JWT, clés d'API, HMAC, backends d'authentification et flux de compte, chacun en profondeur.
+- [Conventions d'API](api-conventions.md) — les règles de type d'erreur et de type de retour derrière ces API.

--- a/docs/fr/serializers.md
+++ b/docs/fr/serializers.md
@@ -1,0 +1,559 @@
+# Serializers
+
+Un serializer transforme une instance de modèle en une forme typée, prête pour le
+JSON — et inversement à l'entrée. C'est la réponse de **Rustango** à un
+`ModelSerializer` de Django REST Framework ou à une API Resource de Laravel :
+déclarer une structure, annoter ses champs, et l'on obtient une sortie contrôlée
+(renommage, masquage, calcul, imbrication), une validation au niveau du champ et
+de l'objet, ainsi qu'un point d'ancrage propre vers les ViewSets.
+
+Une chose à intégrer d'emblée, car elle diffère de DRF : un serializer Rustango
+**façonne les données, il ne les persiste pas**. Il n'existe pas de
+`serializer.save()` qui écrit dans la base de données — c'est l'ORM qui s'en
+charge. Le serializer met en correspondance un modèle avec du JSON (`from_model` →
+`to_value`), déclare quels champs sont accessibles en écriture, et valide. On le
+compose avec l'ORM et les ViewSets plutôt que d'acheminer les écritures *à
+travers* lui.
+
+> **Un terme nouveau ici ?** — *serializer*, *model*, *ORM*, *DRF* ? Le
+> [glossaire](glossary.md) définit chacun en langage clair.
+
+[![Un serializer Rustango : read_only, renommage via source, un champ méthode calculé, une FK imbriquée et un champ write_only — déclarés sur une seule structure](img/serializers.png)](img/serializers.png)
+
+> **Source :** `rustango::serializer` (`ModelSerializer`, `#[derive(Serializer)]`,
+> les attributs de champ `#[serializer(...)]`) — derrière la feature `serializer`
+> (activée par défaut).
+>
+> **Versions exécutables :** le serializer minimal est fourni dans l'exemple testé
+> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog/src/post_serializer.rs),
+> et le comportement complet du derive est couvert par les tests unitaires du
+> framework lui-même — `crates/rustango/tests/serializer_derive.rs` et
+> `serializer_cross_validate.rs`. Si un extrait semble incorrect, comparer avec
+> eux.
+
+---
+
+## Table des matières
+- [Démarrage rapide](#quick-start) · [Le trait `ModelSerializer`](#the-modelserializer-trait)
+- [Attributs de champ](#field-attributes) — la référence complète
+- [Champs calculés](#computed-fields) · [Serializers imbriqués](#nested-serializers) · [Collections](#collections-many) · [Champs slug](#slug-related-fields)
+- [Validation](#validation) · [Validation d'unicité combinée](#unique-together-validation)
+- [Sortie hyperliée](#hyperlinked-output) · [Sérialiser des listes](#serializing-lists)
+- [Utiliser un serializer avec un ViewSet](#using-a-serializer-with-a-viewset) · [Valider dans un handler personnalisé](#validating-in-a-custom-handler)
+- [OpenAPI](#openapi-schemas) · [Scaffolding](#scaffolding) · [Ajustements et limites](#tweaks-and-current-limits)
+
+---
+
+## Démarrage rapide
+
+Un serializer est une simple structure avec `#[derive(Serializer)]` et un
+`#[serializer(model = …)]` pointant vers le modèle qu'elle met en correspondance.
+Elle nécessite deux derives compagnons : `serde::Deserialize` (pour pouvoir aussi
+parser le JSON entrant) et `Default` (pour que les champs exclus/optionnels
+puissent être initialisés).
+
+```rust
+use rustango::Serializer;
+use rustango::serializer::ModelSerializer;
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: Auto<i64>,
+    pub title: String,
+
+    #[serializer(source = "body")]      // JSON key `content`, read from model.body
+    pub content: String,
+
+    #[serializer(read_only)]            // in output, never accepted on write
+    pub published_at: Auto<DateTime<Utc>>,
+}
+```
+
+Utilisation :
+
+```rust
+let post = Post::objects().find(42, &pool).await?.expect("post 42");
+
+let one  = PostSerializer::from_model(&post).to_value();   // a JSON object
+let many = PostSerializer::many_to_value(&posts);          // a JSON array
+```
+
+`from_model` clone les champs du modèle dans la structure (en respectant les
+attributs ci-dessous) ; `to_value` la sérialise (en ignorant les champs
+`write_only`). Voilà toute la boucle centrale.
+
+---
+
+## Le trait `ModelSerializer`
+
+`#[derive(Serializer)]` implémente `ModelSerializer` (plus un `serde::Serialize`
+qui respecte `write_only`, et une impl `OpenApiSchema` sous la feature `openapi`).
+La surface du trait :
+
+| Méthode | Signature | Notes |
+|---|---|---|
+| `from_model` | `fn(model: &Self::Model) -> Self` | Met en correspondance un modèle → serializer. Généré ; non redéfinissable. |
+| `to_value` | `fn(&self) -> serde_json::Value` | Sérialise en JSON (ignore `write_only`). Redéfinissable. |
+| `many` | `fn(&[Self::Model]) -> Vec<Self>` | `from_model` par lot. Redéfinissable. |
+| `many_to_value` | `fn(&[Self::Model]) -> serde_json::Value` | Lot → tableau JSON. Redéfinissable. |
+| `writable_fields` | `fn() -> &'static [&'static str]` | Noms des champs du serializer acceptés en écriture (exclut `read_only`, `skip`, `method`, `nested`, `many`, `slug`). |
+| `writable_source_fields` | `fn() -> &'static [&'static str]` | Les **colonnes du modèle** des champs accessibles en écriture (résolues via `source`). Le chemin d'écriture du ViewSet ne persiste que celles-ci. Généré. |
+| `from_writable_json` | `fn(&Value) -> Result<Self, FormErrors>` | Construit une instance à partir d'un corps de requête en n'utilisant que les champs accessibles en écriture (le reste prend sa valeur par défaut) ; les erreurs de parsing par champ → `FormErrors`. Généré. |
+| `validate` | `fn(&self) -> Result<(), FormErrors>` | Exécute les validateurs déclarés par champ + inter-champs. Sans effet quand aucun n'est déclaré ; redéfinissable. |
+
+Il n'y a délibérément **aucun** `create` / `update` / `save` sur le trait — les
+écritures passent par l'ORM (`model.save(&pool)`). Quand un serializer est câblé
+dans un [ViewSet](viewsets.md), le chemin create/update utilise
+`from_writable_json()` + `validate()` + `writable_source_fields()` pour valider et
+filtrer la requête avant l'enregistrement.
+
+---
+
+## Attributs de champ
+
+Tout est contrôlé par `#[serializer(...)]` sur chaque champ. L'ensemble complet :
+
+| Attribut | Ce que fait `from_model` | Dans la sortie JSON ? | Accessible en écriture ? |
+|---|---|---|---|
+| *(aucun)* | met en correspondance depuis le modèle | oui | oui |
+| `read_only` | met en correspondance depuis le modèle | oui | **non** |
+| `write_only` | `Default::default()` | **non** | oui |
+| `source = "x"` | met en correspondance depuis `model.x` (renomme) | oui | oui |
+| `skip` | `Default::default()` — à définir soi-même | oui | non |
+| `method = "fn"` | appelle `Self::fn(&model)` | oui | non |
+| `nested` | parcourt une FK → `Child::from_model(parent)` | oui | non |
+| `nested(strict)` | idem, mais panique si la FK n'a pas été chargée | oui | non |
+| `many = ChildSer` | initialise `Vec::new()` ; remplir via `set_<field>(&[Child])` | oui | non |
+| `slug = "name"` | clone `model.<source>.value()?.name` | oui | non |
+| `validate = "fn"` | validateur par champ exécuté par `validate(&self)` | s/o | s/o |
+
+**Mutuellement exclusifs** (erreurs de compilation si combinés) : `read_only` +
+`write_only` ; `method` + `source` ; `slug` + l'un de `method` / `nested` /
+`many`.
+
+**Validateurs déclaratifs.** `max_length = N`, `min_length = N`, `min = N` et
+`max = N` ajoutent une validation à l'écriture sur un champ sans changer la forme
+de sa sortie (et un champ dépourvu de ceux-ci hérite des bornes du modèle). Voir
+[Validation](#validation).
+
+`write_only` est destiné aux données entrantes uniquement (un mot de passe, un
+jeton à usage unique) : présent dans `writable_fields()`, absent de la sortie.
+`skip` est l'échappatoire inverse — le champ n'est pas lu depuis le modèle et
+n'est pas accessible en écriture, on le renseigne donc à la main après
+`from_model` (par exemple une liste d'ids de tags récupérée séparément).
+
+> **`write_only` ne transforme pas la valeur.** Un champ `write_only` est accepté
+> en écriture et persisté **tel quel** — le serializer ne le hache ni ne le
+> chiffre jamais. Pour un mot de passe, le hacher soi-même (voir
+> [Mots de passe](auth-passwords.md)) avant `save()` ; les champs `read_only`, à
+> l'inverse, sont silencieusement ignorés à l'écriture plutôt que rejetés.
+
+---
+
+## Champs calculés
+
+`method = "fn"` est l'équivalent du `SerializerMethodField` de DRF. Déclarer le
+champ, puis écrire une fonction associée `fn(&Model) -> FieldType` ; elle est
+appelée durant `from_model` :
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub title: String,
+    #[serializer(method = "excerpt")]
+    pub excerpt: String,
+}
+
+impl PostSerializer {
+    fn excerpt(model: &Post) -> String {
+        model.body.chars().take(80).collect::<String>() + "…"
+    }
+}
+```
+
+Les champs calculés sont en sortie seule (exclus de `writable_fields()`).
+
+---
+
+## Serializers imbriqués
+
+`nested` intègre un autre serializer en parcourant une clé étrangère chargée. Le
+type du champ est le serializer enfant :
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Comment)]
+pub struct CommentSerializer {
+    pub id: Auto<i64>,
+    pub body: String,
+    #[serializer(nested)]               // reads the loaded `author` FK
+    pub author: AuthorBrief,
+}
+```
+
+La FK doit déjà être chargée (via `select_related` / une récupération anticipée).
+Si elle **ne l'était pas**, le champ retombe sur `Default::default()` plutôt que
+de paniquer — la production se dégrade gracieusement en cas de prefetch manquant.
+Dans les tests, utiliser `#[serializer(nested(strict))]` pour transformer ce repli
+en panique afin qu'un prefetch oublié soit détecté. Pointer vers une FK au nom
+différent avec `source` :
+
+```rust
+#[serializer(nested, source = "owner")]
+pub author: AuthorBrief,
+```
+
+Les champs imbriqués sont en **lecture seule** dans la forme de sortie — les
+objets imbriqués accessibles en écriture ne sont pas encore pris en charge (voir
+[limites](#tweaks-and-current-limits)).
+
+---
+
+## Collections (`many`)
+
+Pour des enfants un-à-plusieurs ou M2M, `many = ChildSerializer` déclare un champ
+`Vec<…>`. Comme l'accesseur M2M/associé est asynchrone, la macro ne peut pas le
+charger automatiquement ; elle initialise le vec vide et émet un assistant
+`set_<field>(&[ChildModel])` à appeler après avoir récupéré les enfants :
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostWithTags {
+    pub id: Auto<i64>,
+    pub title: String,
+    #[serializer(many = TagBrief)]
+    pub tags: Vec<TagBrief>,
+}
+
+// usage
+let tags = post.tags_m2m().all(&pool).await?;
+let mut s = PostWithTags::from_model(&post);
+s.set_tags(&tags);                       // generated setter, named set_<field>
+let json = s.to_value();
+```
+
+---
+
+## Champs slug
+
+`slug = "name"` est l'équivalent du `SlugRelatedField` de DRF : au lieu d'un id de
+FK ou d'un objet imbriqué complet, émettre un unique champ nommé extrait du parent
+chargé.
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: Auto<i64>,
+    pub title: String,
+    #[serializer(slug = "name", source = "author")]   // author.name as a flat field
+    pub author_name: String,
+}
+```
+
+Comme nested, il lit depuis une FK chargée et retombe sur la valeur par défaut
+lorsqu'elle n'est pas chargée ; il est en affichage seul (non accessible en
+écriture).
+
+---
+
+## Validation
+
+Trois couches, toutes remontant sous forme de `rustango::forms::FormErrors` (et,
+lors d'une écriture via ViewSet, un `400` à la forme DRF). Elles s'exécutent dans
+cet ordre : contraintes déclaratives, puis validateurs par champ, puis le point
+d'ancrage inter-champs.
+
+**Contraintes déclaratives (les `validators` de DRF, hérités automatiquement).**
+`max_length`, `min_length`, `min` et `max` sont des attributs de champ — et
+lorsqu'on les omet, un champ **hérite des** `max_length` / `min` / `max` /
+`choices` du modèle. Ainsi, une colonne `#[rustango(max_length = 200)]` voit sa
+longueur vérifiée sans aucun attribut de serializer (comportement du
+`ModelSerializer` de DRF). Elles sont vérifiées sur chaque champ accessible en
+écriture, transformant des `500` de contrainte de base de données potentiels en
+aimables `400` :
+
+```rust
+#[serializer(model = Widget)]
+struct WidgetSerializer {
+    pub code: String,               // inherits the model's max_length
+    #[serializer(max_length = 4)]   // overrides the model's bound
+    pub note: String,
+    pub priority: i64,              // inherits the model's min / max
+    pub status: String,             // inherits the model's choices
+}
+```
+
+Les messages correspondent à ceux de Django/DRF :
+`"Ensure this value has at most N characters."`,
+`"Ensure this value has at least N characters."`, `"Ensure this value is ≥ N."` /
+`"≤ N"`, et `"Select a valid choice."`. (`min_length` est propre au serializer ;
+`choices` est hérité du modèle — il n'existe pas d'attribut `choices`.)
+
+**Par champ** (personnalisé) — déclarer `validate = "fn"` et écrire
+`fn(value: &FieldType) -> Result<(), String>` :
+
+```rust
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    #[serializer(validate = "title_min_3")]
+    pub title: String,
+    pub body: String,
+}
+
+impl PostSerializer {
+    fn title_min_3(t: &String) -> Result<(), String> {
+        if t.chars().count() < 3 { Err("title must be at least 3 chars".into()) } else { Ok(()) }
+    }
+}
+```
+
+Le derive génère un `validate(&self)` qui exécute chaque validateur par champ et
+collecte les échecs dans un `FormErrors` indexé par nom de champ.
+
+**Inter-champs** — déclarer un point d'ancrage au niveau de la structure et les
+validateurs fusionnent. Soit ajouter `#[serializer(validate = "cross_validate")]`
+sur la structure (retournant `Result<(), FormErrors>`), soit implémenter
+simplement `validate(&self)` soi-même lorsqu'il n'y a aucun validateur par champ
+pour le générer :
+
+```rust
+impl PostSerializer {
+    pub fn validate(&self) -> Result<(), rustango::forms::FormErrors> {
+        let mut errors = rustango::forms::FormErrors::default();
+        if self.title.is_empty() {
+            errors.add("title", "title cannot be empty");          // field error
+        }
+        if self.body.starts_with(&self.title) {
+            errors.add_non_field("body must not repeat the title"); // object-level error
+        }
+        if errors.is_empty() { Ok(()) } else { Err(errors) }
+    }
+}
+```
+
+`FormErrors` sépare les erreurs de **champ** (`add(field, msg)`, un
+`HashMap<String, Vec<String>>`) des erreurs **hors-champ**
+(`add_non_field(msg)`). L'inspecter avec `.fields()`, `.non_field()`,
+`.get(field)`, `.is_empty()`, et le combiner avec `.merge(other)`. Au-delà des
+contraintes déclaratives ci-dessus (`max_length` / `min_length` / `min` / `max` /
+`choices` hérités), les règles personnalisées sont de simples fonctions — il n'y a
+pas de magie `email`/regex, ce qui garde la validation personnalisée explicite et
+testable. Hors d'un ViewSet, le framework ne rend pas automatiquement les
+`FormErrors` dans un corps HTTP ; les mettre en correspondance avec votre réponse
+400 (la séparation champ/hors-champ s'aligne sur le JSON d'erreur de DRF).
+
+---
+
+## Validation d'unicité combinée
+
+Pour le `UniqueTogetherValidator` de Django — une vérification avant
+enregistrement qu'une ligne candidate n'entrera pas en collision sur un index
+d'unicité multi-colonnes — appeler `check_unique_together_pool` avant
+l'enregistrement :
+
+```rust
+use std::collections::HashMap;
+use rustango::core::SqlValue;
+use rustango::serializer::check_unique_together_pool;
+
+let mut values: HashMap<&'static str, SqlValue> = HashMap::new();
+values.insert("org_id",  SqlValue::I64(self.org_id));
+values.insert("user_id", SqlValue::I64(self.user_id));
+
+// None on insert; Some(&pk) on update so the row doesn't clash with itself.
+check_unique_together_pool(&pool, Membership::SCHEMA, &values, None).await?;
+```
+
+Il parcourt les index d'unicité multi-colonnes déclarés du modèle et retourne
+`Err(FormErrors)` avec une erreur hors-champ par collision
+(`"The fields a, b must be unique together."`). L'unicité mono-colonne `unique`
+est laissée à la gestion des conflits de l'insertion ; les index partiels
+(`unique_when`) sont ignorés.
+
+---
+
+## Sortie hyperliée
+
+Pour une forme de type `HyperlinkedModelSerializer` (URLs de ressource au lieu
+d'ids nus), deux assistants post-traitent le JSON :
+
+```rust
+use rustango::serializer::{hyperlink_url, hyperlinked_to_value};
+use std::collections::HashMap;
+
+let base = PostSerializer::from_model(&post).to_value();
+
+let mut fk_templates = HashMap::new();
+fk_templates.insert("author_id", "/api/users/{pk}");
+
+let out = hyperlinked_to_value(base, "/api/posts/{pk}", "id", &fk_templates);
+// → { "url": "/api/posts/42", "author_id_url": "/api/users/7", "id": 42, ... }
+```
+
+`hyperlink_url(template, &pk)` effectue une substitution ponctuelle de `{pk}` ;
+`hyperlinked_to_value` ajoute un `url` de premier niveau plus un `<fk>_url` par
+template (FK nulle → URL nulle). Les clés id/`<fk>_id` d'origine sont conservées
+(les supprimer ensuite si l'on veut s'en débarrasser).
+
+---
+
+## Sérialiser des listes
+
+`many_to_value(&models)` retourne un tableau JSON d'objets sérialisés. Les
+ViewSets enveloppent une page d'entre eux dans l'enveloppe standard :
+
+```json
+{ "count": 100, "page": 1, "page_size": 20, "last_page": 5, "results": [ { … }, { … } ] }
+```
+
+(C'est l'enveloppe par défaut à numéro de page ; voir
+[Pagination](viewsets.md#pagination) pour les formes cursor et limit/offset.)
+
+---
+
+## Utiliser un serializer avec un ViewSet
+
+Câbler un serializer dans un [ViewSet](viewsets.md) et il pilote toute la
+ressource REST — **sortie et entrée**, sur chaque backend (PostgreSQL, MySQL,
+SQLite) :
+
+```rust
+#[derive(ViewSet)]
+#[viewset(model = Post, serializer = crate::PostSerializer, ordering = "-published_at")]
+pub struct PostViewSet;
+// or, on the builder: ViewSet::for_model(Post::SCHEMA).serializer::<PostSerializer>()…
+```
+
+- **Sortie** — les réponses `list` / `retrieve` / `create` / `update` sont rendues
+  via `from_model`, si bien que `source` / `method` / `read_only` / `write_only`
+  façonnent le JSON.
+- **Entrée** — `create` / `update` exécutent le `validate()` du serializer (un
+  échec est un `400` à la forme DRF, `{field: [msgs]}`), et seuls les champs
+  accessibles en écriture sont écrits — les champs `read_only` / calculés qu'un
+  client poste sont ignorés, résolus via `source` vers la colonne du modèle.
+
+Le ViewSet pilote cela via trois méthodes `ModelSerializer` que le derive
+génère : `validate()`, `writable_source_fields()` et `from_writable_json()`. Voir
+le [guide des ViewSets](viewsets.md#the-serializer-marriage-input--output) pour le
+comportement complet et un exemple concret.
+
+On peut aussi utiliser un serializer **de façon autonome** — mettre une ligne en
+correspondance et émettre son JSON depuis n'importe quel handler :
+
+```rust
+let post = Post::objects().find(42, &pool).await?.expect("post 42");
+let body = PostSerializer::from_model(&post).to_value();   // shaped JSON
+```
+
+---
+
+## Valider dans un handler personnalisé
+
+Hors d'un ViewSet, le serializer dérive `serde::Deserialize`, on peut donc parser
+un corps de requête vers lui, exécuter `.validate()`, et — en cas de succès —
+mettre les données en correspondance avec un modèle et `save(&pool)`.
+`from_writable_json()` construit une instance à partir des seules clés accessibles
+en écriture (les champs read-only / calculés prennent leur valeur par défaut), et
+`writable_fields()` / `writable_source_fields()` indiquent quelles clés sont
+acceptées — la même mécanique que le ViewSet utilise en interne.
+
+---
+
+## Schémas OpenAPI
+
+Avec la feature `openapi` activée, le derive émet aussi une impl `OpenApiSchema` :
+les types de champ correspondent à des types JSON-schema, `Option<T>` devient
+nullable-et-non-requis, et les champs `write_only` sont exclus du schéma de
+réponse. C'est ce qui alimente la documentation d'API générée — aucun schéma
+distinct à maintenir.
+
+> **Approfondissement :** [OpenAPI](openapi.md) — transformer ce schéma (plus les
+> chemins CRUD de votre ViewSet) en une spécification OpenAPI 3.1 complète servie
+> avec Swagger UI / Redoc.
+
+---
+
+## Scaffolding
+
+Générer un squelette de serializer avec la CLI manage :
+
+```bash
+cargo run -- make:serializer PostSerializer --model Post
+```
+
+Elle écrit un module de départ à compléter :
+
+```rust
+//! Auto-scaffolded by `manage make:serializer PostSerializer`.
+
+use rustango::Serializer;
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: i64,
+    // pub title: String,
+    // #[serializer(read_only)]
+    // pub created_at: chrono::DateTime<chrono::Utc>,
+}
+```
+
+Enregistrer ensuite le module (`mod post_serializer;`) aux côtés des autres.
+
+---
+
+## Ajustements et limites actuelles
+
+Quelques angles saillants et échappatoires qu'il vaut la peine de connaître :
+
+- **Champs conditionnels.** Il n'y a pas de sélection de champ à l'exécution (les
+  champs sont fixés à la compilation). Pour « inclure uniquement lorsque
+  présent », utiliser `Option<T>` plus
+  `#[serde(skip_serializing_if = "Option::is_none")]` sur le champ — l'impl
+  `Serialize` personnalisée respecte les attributs serde.
+- **Forme de sortie personnalisée.** Redéfinir `to_value(&self)` sur votre
+  structure pour un objet JSON entièrement sur mesure lorsque les attributs ne
+  suffisent pas.
+- **Les objets imbriqués accessibles en écriture** ne sont pas pris en charge —
+  les champs `nested` / `many` / `slug` sont en sortie seule. Accepter les
+  écritures sous forme d'ids scalaires et les résoudre soi-même.
+- **Les validateurs intégrés se limitent à longueur/plage/choix** — `max_length` /
+  `min_length` / `min` / `max` (et les `choices` hérités) sont déclaratifs ; les
+  autres règles (`email`, regex, …) sont des fonctions que l'on écrit (voir
+  [Validation](#validation)).
+- **Un seul validateur par champ, par champ.** Pour plusieurs règles sur un champ,
+  les combiner dans la fonction de ce champ, ou ajouter un `validate(&self)`
+  inter-champs.
+- **Le serializer ne persiste pas.** Mettre en correspondance → valider → confier
+  les données à l'ORM ; il n'y a pas de `serializer.save()`.
+
+---
+
+## À essayer
+
+Le serializer minimal est fourni dans l'exemple
+[`getting_started_blog`](../crates/rustango/examples/getting_started_blog/src/post_serializer.rs)
+(étape 13 du guide de démarrage). Le comportement complet du derive — les
+attributs de champ, les champs computed/nested/many, et les deux couches de
+validation — est couvert par les tests unitaires du framework lui-même (aucune
+base de données requise) :
+
+```bash
+cd crates/rustango
+cargo test --test serializer_derive          # field attrs, method, nested, many, slug, OpenAPI
+cargo test --test serializer_cross_validate  # per-field + cross-field validation aggregation
+```
+
+---
+
+## Voir aussi
+
+- [ViewSets](viewsets.md) — câbler un serializer dans une API CRUD JSON.
+- [Vues HTML](html-views.md) — l'alternative rendue côté serveur à une API JSON.
+- [OpenAPI](openapi.md) — les champs d'un serializer deviennent un schéma de composant.
+- [Recueil de recettes ORM](orm.md) — les modèles depuis lesquels les serializers mettent en correspondance.

--- a/docs/fr/testing.md
+++ b/docs/fr/testing.md
@@ -1,0 +1,179 @@
+# Tests
+
+Des tests rapides et fiables doivent piloter votre application comme le ferait un client — sans
+démarrer de serveur ni toucher au réseau. Le `TestClient` de **Rustango** exécute votre
+routeur **in-process** : vous appelez `client.get("/path")`, il achemine la requête
+à travers la vraie pile (extractors, middleware, handlers) et vous renvoie la
+réponse sur laquelle faire des assertions. Ajoutez l'isolation par rollback de transaction pour les tests de base de données et
+un ensemble d'assertions de réponse, et vous obtenez le client de test de Django + `TestCase`, en
+Rust.
+
+[![Les tests dans Rustango : TestClient enveloppe votre Router et envoie des requêtes in-process à travers la vraie pile de handlers ; la TestResponse expose le statut, le texte et le JSON sur lesquels faire des assertions — pas de socket, pas de serveur](img/testing.png)](img/testing.png)
+
+> **Un terme nouveau ici ?** *router*, *handler*, *fixture*, *rollback* — voir le
+> [glossaire](glossary.md).
+
+> **Source :** `rustango::test_client` (`TestClient`, `TestResponse`),
+> `rustango::test_assertions` (`assert_status_2xx`, `assert_redirects`,
+> `assert_cookie_set`, …), et `rustango::test_db` (`with_rollback`) — toujours
+> compilés.
+>
+> **Version exécutable :** les snippets ci-dessous *sont* un test qui passe —
+> [`testing_doc.rs`](../crates/rustango/tests/testing_doc.rs)
+> (`cargo test -p rustango --test testing_doc`). Presque tous les autres `*_doc.rs`
+> de ce dépôt utilisent `TestClient` de la même manière.
+
+## Table des matières
+
+- [Étape 1 — Pilotez votre application avec TestClient](#step-1--drive-your-app-with-testclient)
+- [Étape 2 — Faites des assertions sur la réponse](#step-2--assert-on-the-response)
+- [Envoyer du JSON, des en-têtes et des corps](#sending-json-headers-and-bodies)
+- [Tester une vraie API](#testing-a-real-api)
+- [Tests de base de données avec rollback](#database-tests-with-rollback)
+- [Helpers d'assertion de réponse](#response-assertion-helpers)
+- [Voir aussi](#see-also)
+
+---
+
+## Étape 1 — Pilotez votre application avec TestClient
+
+Enveloppez n'importe quel `axum::Router` dans un `TestClient` et envoyez des requêtes — aucun socket n'est lié,
+aucune tâche serveur n'est lancée. La requête traverse votre vrai middleware et vos
+handlers :
+
+```rust
+use rustango::test_client::TestClient;
+
+let client = TestClient::new(app());          // app() returns your Router
+
+let res = client.get("/ping").send().await;   // routed in-process
+assert_eq!(res.status, 200);
+```
+
+`TestClient` a `get` / `post` / `put` / `patch` / `delete` / `head`, chacun
+renvoyant un builder que vous finissez avec `.send().await`.
+
+---
+
+## Étape 2 — Faites des assertions sur la réponse
+
+`TestResponse` expose le statut et le corps dans la forme dont vous avez besoin :
+
+```rust
+let res = client.get("/ping").send().await;
+
+res.status;                 // u16 — e.g. 200
+res.text();                 // body as a String
+res.header("content-type"); // Option<&str>
+```
+
+```rust
+// JSON, two ways:
+let res = client.post("/echo").json(&json!({ "name": "Ada" })).send().await;
+assert_eq!(res.json_value()["name"], "Ada");   // untyped
+
+#[derive(serde::Deserialize)]
+struct Out { name: String }
+let out: Out = res.json();                       // typed
+assert_eq!(out.name, "Ada");
+```
+
+---
+
+## Envoyer du JSON, des en-têtes et des corps
+
+Le builder de requête enchaîne tout avant `.send()` :
+
+```rust
+let res = client
+    .post("/api/posts")
+    .header("authorization", "Bearer <token>")   // auth, content negotiation, …
+    .json(&json!({ "title": "Hello", "body": "..." }))
+    .send()
+    .await;
+assert_eq!(res.status, 201);
+```
+
+Utilisez `.body(...)` pour les corps bruts (non-JSON), et une route manquante renvoie un vrai
+`404` — vérifié dans le test sous-jacent.
+
+---
+
+## Tester une vraie API
+
+`app()` dans vos tests n'est que votre routeur. Pour une API adossée à une DB, construisez-la exactement
+comme le fait `main.rs` mais avec un pool de test — le motif que la plupart des tests `*_doc.rs` utilisent :
+
+```rust
+async fn app() -> axum::Router {
+    let pool = test_pool().await;                 // a sqlite::memory: or test DB pool
+    PostViewSet::router("/api/posts", pool)
+}
+
+#[tokio::test]
+async fn create_then_list() {
+    let client = TestClient::new(app().await);
+    let created = client.post("/api/posts")
+        .json(&json!({ "title": "Hi", "body": "b" }))
+        .send().await;
+    assert_eq!(created.status, 201);
+
+    let list = client.get("/api/posts").send().await;
+    assert!(list.json_value()["results"].is_array());
+}
+```
+
+C'est le test [ViewSets](viewsets.md) de ce guide — le même `TestClient`.
+
+---
+
+## Tests de base de données avec rollback
+
+Les tests qui écrivent dans une base de données ne doivent pas laisser fuir leur état les uns dans les autres.
+`test_db::with_rollback` exécute votre test à l'intérieur d'une transaction et **la rollback**
+à la fin, de sorte que chaque test démarre depuis le même état propre et que rien ne persiste :
+
+```rust
+use rustango::test_db::with_rollback;
+
+#[tokio::test]
+async fn creating_a_post_persists_it() {
+    with_rollback(&pool, |tx| async move {
+        // ... insert + assert against `tx` ...
+        // everything here is rolled back when the closure returns
+    }).await;
+}
+```
+
+Pour SQLite, les tests `*_sqlite_live.rs` à travers ce dépôt utilisent à la place une base de données
+en mémoire par test — également entièrement isolée, avec zéro configuration externe.
+
+---
+
+## Helpers d'assertion de réponse
+
+Pour les valeurs `axum::Response` brutes (par exemple issues de `tower::oneshot`), `test_assertions`
+se lit comme les `assertContains` / `assertRedirects` de Django :
+
+```rust
+use rustango::test_assertions::{assert_status_2xx, assert_redirects, assert_cookie_set};
+
+assert_status_2xx(&res);
+assert_redirects(&res, "/login?next=/dashboard");
+assert_cookie_set(&res, "rustango_session", None);
+```
+
+Également disponibles : `assert_status` / `assert_status_in` / `assert_status_4xx` /
+`assert_status_5xx`, `assert_header`, `assert_content_type`,
+`assert_redirect_chain`, `assert_cookie_not_set`, et `assert_messages`.
+
+---
+
+## Voir aussi
+
+- [ViewSets](viewsets.md) · [Vues HTML](html-views.md) — ce sur quoi vous pointez le
+  `TestClient`.
+- [Middleware](middleware.md) — `TestClient` exerce aussi les couches (sans DB,
+  via `tower::oneshot` dans `middleware.rs`).
+- [Prise en main](getting-started.md) — l'étape 16 écrit le premier test.
+- [CLI `manage`](manage.md) — `make:test` génère un module de test.

--- a/docs/fr/urls.md
+++ b/docs/fr/urls.md
@@ -1,0 +1,298 @@
+# Noms d'URL & reverse
+
+Coder en dur des URL (`/posts/42`) partout dans les handlers et les templates est
+fragile — changez une route et chaque littéral casse silencieusement.
+**Rustango** vous donne la réponse de Django : **nommez un motif d'URL une fois,
+puis construisez l'URL par son nom partout** — en Rust avec `reverse(...)`, dans
+les templates avec `{{ url(...) }}`, et dans les redirections avec
+`redirect_to_view(...)`. La surface de l'API reflète les
+`reverse()` / `{% url %}` / `resolve_url()` / `redirect()` de Django.
+
+[![URL reverse à la Django : register_url! nomme un motif, reverse() construit l'URL en Rust, et {{ url(...) }} construit l'URL dans un template](img/urls.png)](img/urls.png)
+
+> **Source :** `rustango::urls` (`register_url!`, `reverse`, `reverse_owned`,
+> `all_routes`, `duplicates`, `register_url_tag`) et `rustango::shortcuts`
+> (`resolve_url`, `redirect_to_view`).
+
+> **Nouveau ici ?** *route*, *reverse*, *namespacing* — voir le
+> [glossaire](glossary.md).
+
+---
+
+## Table des matières
+- [Enregistrer une URL nommée](#register-a-named-url)
+- [Reverse en Rust](#reverse-in-rust) · [Reverse dans les templates](#reverse-in-templates)
+- [Rediriger par nom](#redirect-by-name) · [Namespacing](#namespacing)
+- [Inspecter la carte des URL](#inspect-the-url-map) · [Erreurs](#errors)
+- [Motifs regex & chemins typés](#regex--typed-path-patterns) · [Notes & limites](#notes-and-limits)
+
+---
+
+## Enregistrer une URL nommée
+
+`register_url!("name", "/pattern")` enregistre un mapping nom → motif. Il s'exécute
+au chargement du module (via `inventory`), donc la route atterrit dans un registre
+global dès que son module est lié — pas de `urls.py` central à éditer, et pas
+d'`include()` à câbler.
+
+```rust
+use rustango::register_url;
+
+register_url!("post-detail", "/posts/{id}");
+register_url!("user-posts",  "/users/{user_id}/posts/{post_id}");
+register_url!("home",        "/");
+```
+
+Les placeholders utilisent la syntaxe de chemin `{name}` d'axum. Le motif est la
+même chaîne à laquelle vous montez le handler — gardez-les synchronisés
+(enregistrez le nom là où vous construisez la route).
+
+---
+
+## Reverse en Rust
+
+`reverse(name, &params)` substitue les `{placeholders}` du motif par les valeurs
+données (en percent-encodant chacune) et retourne l'URL :
+
+```rust
+use std::collections::HashMap;
+use rustango::urls::reverse;
+
+let mut params = HashMap::new();
+params.insert("id", "42".to_string());
+
+let url = reverse("post-detail", &params)?;   // → "/posts/42"
+```
+
+Pour des clés dynamiques (p. ex. des valeurs assemblées à partir d'une requête),
+`reverse_owned` prend `HashMap<String, String>` au lieu de
+`HashMap<&str, String>` :
+
+```rust
+use rustango::urls::reverse_owned;
+let url = reverse_owned("post-detail", &owned_params)?;
+```
+
+`reverse` est **strict** : un placeholder manquant, ou une clé `params`
+supplémentaire que le motif n'a pas, est une erreur (pas un décalage silencieux) —
+voir [Erreurs](#errors).
+
+---
+
+## Reverse dans les templates
+
+Les templates reçoivent le `{% url %}` de Django comme fonction Tera.
+Enregistrez-la une fois sur votre instance `Tera` à l'initialisation (elle est
+derrière la feature `template_views`) :
+
+```rust
+rustango::urls::register_url_tag(&mut tera);
+```
+
+Puis appelez `url(name=..., <param>=...)` dans n'importe quel template — `name`
+est requis, et tout autre argument nommé est un paramètre de chemin (chaînes,
+nombres et booléens sont acceptés) :
+
+```jinja
+<a href="{{ url(name='post-detail', id=42) }}">View post</a>
+<a href="{{ url(name='user-posts', user_id=7, post_id=42) }}">…</a>
+```
+
+C'est l'équivalent du `{% url 'post-detail' id=42 %}` de Django. Pour le motif de
+capture `{% url 'x' as var %}`, utilisez le `{% set %}` de Tera :
+
+```jinja
+{% set post_url = url(name='post-detail', id=post.id) %}
+<a href="{{ post_url }}">{{ post.title }}</a>
+```
+
+Un argument `null` (généralement une variable de template non définie) échoue
+bruyamment plutôt que de produire silencieusement une URL cassée.
+
+---
+
+## Rediriger par nom
+
+`rustango::shortcuts` reflète les helpers de redirection par nom de vue de Django,
+de sorte que les handlers ne codent jamais en dur un `Location` :
+
+```rust
+use std::collections::HashMap;
+use rustango::shortcuts::{redirect_to_view, resolve_url};
+
+// redirect('post-detail', id=42) → 302 Location: /posts/42
+let mut params = HashMap::new();
+params.insert("id", "42".to_string());
+let response = redirect_to_view("post-detail", &params)?;
+```
+
+`resolve_url(spec, &params)` est le `resolve_url` de Django : si `spec` ressemble
+déjà à une URL (`/…`, `http://`, `https://`, `./`, `../`) elle est retournée
+telle quelle ; sinon elle est traitée comme un nom de route et résolue par
+reverse. Pratique pour un paramètre `?next=` ou un réglage pouvant contenir *soit*
+un chemin, *soit* un nom :
+
+```rust
+let url = resolve_url("post-detail", &params)?;  // name  → "/posts/42"
+let url = resolve_url("/dashboard", &params)?;   // path  → "/dashboard" (as-is)
+```
+
+(Pour les redirections brutes vers une URL connue, `rustango::shortcuts::redirect(url)`
+retourne un simple `302`.)
+
+---
+
+## Namespacing
+
+Il n'y a pas d'`include()` ni de namespace d'app auto-appliqué — chaque
+`register_url!` atterrit dans un unique registre global. Le namespacing est une
+**convention dans le nom lui-même** : préfixez avec `app:`, exactement comme vous
+appelleriez le `reverse("app:detail")` de Django.
+
+```rust
+register_url!("blog:post-detail", "/blog/posts/{id}");
+register_url!("shop:product",     "/shop/products/{slug}");
+```
+
+```rust
+reverse("blog:post-detail", &params)?;   // "/blog/posts/42"
+```
+
+Le deux-points fait simplement partie de la chaîne enregistrée — choisissez un
+préfixe cohérent par app pour éviter les collisions.
+
+---
+
+## Inspecter la carte des URL
+
+Listez toutes les routes enregistrées depuis la CLI — utile pour un audit rapide
+ou pour scripter :
+
+```bash
+cargo run -- showurls                  # plain table of name → pattern
+cargo run -- showurls --format json    # machine-readable
+```
+
+En code, `all_routes()` retourne tout le registre, et `duplicates()` retourne tout
+nom enregistré plus d'une fois (premier arrivé gagne sinon — à asserter au
+démarrage) :
+
+```rust
+use rustango::urls::{all_routes, duplicates};
+
+for route in all_routes() {
+    println!("{} → {}", route.name, route.pattern);
+}
+
+let dups = duplicates();
+assert!(dups.is_empty(), "duplicate URL names: {dups:?}");
+```
+
+---
+
+## Erreurs
+
+`reverse` / `reverse_owned` / `resolve_url` / `redirect_to_view` retournent
+`Result<_, rustango::urls::ReverseError>` :
+
+| Variante | Quand |
+|---|---|
+| `UnknownName(name)` | Aucun `register_url!` ne s'est exécuté pour ce nom (faute de frappe, ou son module n'était pas lié). |
+| `MissingParam { name, param }` | Le motif a `{param}` mais `params` ne l'a pas fourni. |
+| `UnexpectedParam { name, param }` | `params` portait une clé que le motif n'a pas (attrape les fautes de frappe). |
+| `MalformedPattern { name, detail }` | Le motif enregistré est malformé (p. ex. un `{` non fermé). |
+
+Dans les templates, elles remontent comme des erreurs de rendu Tera (un 500 via
+`shortcuts::render` / `template_views`), donc un mauvais `{{ url(...) }}` échoue
+visiblement plutôt que de rendre un lien cassé.
+
+---
+
+## Motifs regex & chemins typés
+
+**Rustango n'a pas de `re_path`, et aucun convertisseur de chemin n'est jamais
+appliqué.** Un segment de motif est soit un littéral (`/posts/new`) soit un
+placeholder `{name}` qui capture exactement un segment ; `{*name}` capture le
+reste du chemin. C'est tout le vocabulaire — il n'y a pas de
+`r'(?P<year>[0-9]{4})'`, et `{int:id}` ne contraint **pas** `id` à un entier.
+
+### Pourquoi — le matcher n'est pas un moteur de regex
+
+Le routage *est* [axum](https://docs.rs/axum) 0.8, et axum matche les chemins avec
+[`matchit`](https://docs.rs/matchit), un routeur à **arbre radix (radix-trie)**.
+Il parcourt l'URL un segment à la fois le long d'un arbre de préfixes, donc un
+match coûte O(longueur du chemin) et est indépendant du nombre de routes
+enregistrées. Un routeur regex fait l'inverse : Django évalue `urlpatterns` de
+haut en bas, exécutant la regex de chaque entrée contre le chemin jusqu'à ce
+qu'une corresponde. Le trie achète un matching en temps constant et une préséance
+non ambiguë « le littéral le plus spécifique gagne » — au prix de ne pas exprimer
+les contraintes de classe de caractères *dans le chemin lui-même*.
+
+Rustango hérite de ce matcher en bloc. Il n'y a **pas de second résolveur basé sur
+regex** superposé, et `register_url!` enregistre délibérément les *mêmes* chaînes
+`{name}` que le routeur comprend déjà — il ne compile jamais de regex. Donc les
+chemins regex ne sont pas « désactivés » ; la couche de routage n'a simplement
+jamais été un moteur de regex au départ.
+
+La forme `{int:id}` n'est acceptée que comme **facilité de portage** pour
+`reverse()` : le constructeur découpe le placeholder sur `:` et ne garde que le
+nom, jetant le préfixe de type ([`urls.rs`](../crates/rustango/src/urls.rs)). Cela
+permet à `reverse()` de fonctionner sur un motif copié verbatim d'un
+`path("<int:id>/", …)` de Django — mais rien ne valide que la valeur fournie est
+réellement un entier.
+
+### Comment exprimer une route contrainte
+
+Matchez le segment avec un simple `{placeholder}`, puis imposez sa forme là où la
+valeur est utilisée. Le `re_path(r'^articles/(?P<year>[0-9]{4})/$', …)` de Django
+devient :
+
+```rust
+register_url!("article-by-year", "/articles/{year}");
+// router:
+.route("/articles/{year}", get(article_by_year))
+
+async fn article_by_year(Path(year): Path<String>) -> impl IntoResponse {
+    // the router accepted any single segment; enforce [0-9]{4} here
+    match year.parse::<u16>() {
+        Ok(y) if (1000..=9999).contains(&y) => render_year(y).await,
+        _ => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+```
+
+Pour rejeter *avant* que le handler ne s'exécute (plus proche de la sémantique des
+convertisseurs de Django), placez le contrôle dans un extracteur axum personnalisé
+(`FromRequestParts`) et prenez ce type comme argument du handler au lieu de
+`Path<String>` — le framework n'en fournit pas, mais le trait d'extracteur d'axum
+est la couture prévue. Le crate `regex` est déjà une dépendance (l'ORM l'utilise
+pour les lookups `__regex`), donc un extracteur validant peut compiler une `Regex`
+une fois et la réutiliser à travers les requêtes.
+
+---
+
+## Notes et limites
+
+- **L'enregistrement se fait au moment du link.** Un `register_url!` ne prend effet
+  que si son module est compilé dans le binaire. Une erreur `UnknownName` signifie
+  généralement que le nom est une faute de frappe *ou* que son module n'est
+  référencé nulle part (donc le linker l'a écarté).
+- **Les motifs ne sont pas validés contre vos vraies routes.** `register_url!`
+  enregistre un mapping nom → chaîne ; il ne vérifie pas qu'un handler est
+  réellement monté à ce motif. Enregistrez le nom là où vous montez la route pour
+  qu'ils restent synchronisés.
+- **Les valeurs sont percent-encodées** par `reverse`, donc elles sont sûres à
+  déposer dans un header `Location` ou un `href`.
+- **Pas de convertisseurs regex/typés** dans les motifs (le `<int:pk>` de Django) ;
+  les placeholders sont de simples `{name}` et les valeurs sont substituées telles
+  quelles (après encodage). Voir [Motifs regex & chemins typés](#regex--typed-path-patterns)
+  pour le pourquoi, et comment contraindre une route à la place.
+
+
+---
+
+## Voir aussi
+
+- [Vues HTML](html-views.md)
+- [ViewSets](viewsets.md)
+- [Middleware](middleware.md)

--- a/docs/fr/viewsets.md
+++ b/docs/fr/viewsets.md
@@ -1,0 +1,884 @@
+# ViewSets — API REST CRUD
+
+Un ViewSet transforme un modèle en une ressource REST complète — des endpoints pour **lister,
+créer, lire, mettre à jour et supprimer** des enregistrements — à partir d'une seule déclaration. (C'est
+l'équivalent dans **Rustango** d'un `ModelViewSet` de Django REST Framework ou d'un
+contrôleur de ressource d'API Laravel, si vous en avez déjà utilisé.)
+
+> **Nouveau dans les API REST ?** Ce guide suppose que vous savez ce qu'est un *endpoint*, un *verbe
+> HTTP* (GET / POST / …) et une *requête et réponse JSON*. Si l'un de ces concepts
+> est flou, le [glossaire](glossary.md#web-api-basics) en fait un tour d'horizon de cinq minutes —
+> lisez-le d'abord, puis revenez ici.
+
+Associez un ViewSet à un [sérialiseur](serializers.md) — la pièce qui façonne votre
+JSON — et il protège **les deux directions** à la fois : le sérialiseur formate chaque
+**réponse** (renommer, masquer, calculer ou imbriquer des champs) *et* régit chaque
+**requête** (il valide les données entrantes et ignore silencieusement les champs qu'un client
+ne devrait pas être autorisé à définir). Les entrées rejetées reviennent dans la forme familière de DRF —
+un objet JSON indexé par nom de champ. Tout fonctionne de la même manière sur PostgreSQL,
+MySQL et SQLite.
+
+Ce guide est avant tout un tutoriel : nous **construisons une API REST de blog complète** de bout en bout —
+échafaudage, modèles, un sérialiseur, le ViewSet, les six endpoints CRUD, la validation
+des entrées, le filtrage/la recherche/la pagination, et les tests — puis le reste de la page
+est une référence pour chaque réglage.
+
+[![Un ViewSet Rustango branché sur un sérialiseur : un seul bloc #[viewset(serializer = …)] fournit une sortie JSON typée et une entrée validée sur les six routes CRUD](img/viewsets.png)](img/viewsets.png)
+
+> **Source :** `rustango::viewset` (`ViewSet`, `#[derive(ViewSet)]`, les
+> options `#[viewset(...)]` + le builder `for_model`) — toujours compilé.
+>
+> **Version exécutable :** le blog construit ici reflète l'exemple testé et compilable
+> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog)
+> (ses `Post` / `PostSerializer` / `PostViewSet`), et chaque comportement est
+> verrouillé par les propres tests live du framework — `crates/rustango/tests/viewset_*.rs`
+> (notamment `viewset_serializer_render_sqlite_live` et
+> `viewset_serializer_input_sqlite_live`).
+
+---
+
+## Table des matières
+- [Vues API vs vues HTML](#api-views-vs-html-views) — du JSON pour les clients, ou des pages HTML ?
+- [Construire une API REST de blog](#build-a-rest-blog-api) — la présentation complète
+- [Le mariage du sérialiseur : entrée + sortie](#the-serializer-marriage-input--output)
+- [Les deux façons de définir un ViewSet](#the-two-ways-to-define-a-viewset)
+- [Les endpoints CRUD](#the-crud-endpoints) · [Choisir lesquels exposer](#choosing-which-operations-to-expose)
+- [Référence `#[viewset(...)]`](#viewset-attribute-reference) · [Référence du builder](#builder-reference)
+- [Filtrage, recherche & tri](#filtering-search-and-ordering) · [Pagination](#pagination)
+- [Validation](#validation) · [Permissions & throttling](#permissions-and-throttling) · [Actions personnalisées](#custom-actions-beyond-crud)
+- [Montage](#mounting) · [Backends](#backend-support)
+
+---
+
+## Vues API vs vues HTML
+
+Avant le tutoriel, une bifurcation. **Rustango** a deux façons de transformer un
+modèle en endpoints, et un ViewSet est l'une d'elles :
+
+- Un **ViewSet** (ce guide) est une **vue API** — il parle **JSON**, pour les
+  frameworks frontend, les applications mobiles et les autres services.
+- Une **vue template** ([vues HTML](html-views.md)) est une **vue HTML** — elle
+  rend des **pages côté serveur** via Tera, pour les navigateurs et les sites
+  rendus côté serveur.
+
+Le même modèle en dessous ; ce qui diffère, c'est ce qui en ressort et qui appelle.
+
+| | **Vue API** — ViewSet (ici) | **Vue HTML** — [vues template](html-views.md) |
+|---|---|---|
+| Module | `rustango::viewset` | `rustango::template_views` |
+| Renvoie | **des données JSON** | une **page HTML rendue côté serveur** |
+| Conçue pour | les SPA, le mobile, les autres services | les navigateurs, les sites rendus côté serveur, le CRUD de type admin |
+| Un « create » | `POST` JSON → `201` + l'objet | `POST` d'un formulaire → redirection `303` (Post/Redirect/Get) |
+| Sur entrée invalide | `400` + une carte d'erreurs JSON indexée par champ | re-rendu du formulaire avec les erreurs affichées |
+| Un « list » est | une enveloppe JSON paginée | une boucle sur les lignes dans votre template |
+| Généralement authentifiée par | tokens / JWT / clés d'API | cookies de session |
+| Équivalent Django | `ModelViewSet` de DRF | vues génériques basées sur des classes |
+
+Choisissez par ressource — et vous pouvez monter **les deux sur le même modèle** (une API JSON
+publique *et* des pages CRUD internes). Le reste de ce guide concerne le côté JSON/API ; pour
+le côté HTML, voir [Vues HTML — pages rendues côté serveur](html-views.md).
+
+---
+
+## Construire une API REST de blog
+
+Nous allons construire un blog avec deux modèles — `Author` et `Post` — et exposer `Post` comme
+une ressource REST à `/api/posts` dont la forme JSON et la validation sont pilotées par un
+sérialiseur. À la fin, vous pourrez faire un `curl` sur chaque verbe CRUD et observer le sérialiseur
+façonner la sortie et rejeter les entrées invalides.
+
+Cette présentation suppose un projet créé avec `cargo rustango new myblog`
+(voir [Prise en main](getting-started.md) pour la configuration du projet et de la base de données).
+Chaque étape est une commande ou un fichier réel.
+
+### Étape 1 — Créer l'app blog
+
+Les apps sont des modules de fonctionnalités autonomes (le `startapp` de Django) :
+
+```bash
+cargo run -- startapp blog
+```
+
+Cela écrit `src/blog/{mod,models,views,urls,tests}.rs` et branche le module
+dans `main.rs` + l'agrégateur `urls::api()`.
+
+### Étape 2 — Définir les modèles
+
+`src/blog/models.rs` — un `Author` et un `Post` (une clé étrangère les relie) :
+
+```rust
+use rustango::{Auto, Model};
+use chrono::{DateTime, Utc};
+
+#[derive(Model, Clone, Debug)]
+#[rustango(table = "authors", display = "name")]
+pub struct Author {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 120)]
+    pub name: String,
+    #[rustango(max_length = 200)]
+    pub email: String,
+}
+
+#[derive(Model, Clone, Debug)]
+#[rustango(table = "posts", display = "title", index("status, published_at"))]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+
+    #[rustango(max_length = 200)]
+    pub title: String,
+
+    pub body: String,
+
+    #[rustango(max_length = 20, default = "'draft'")]
+    pub status: String,                       // draft | published | archived
+
+    #[rustango(fk = "authors", on = "id")]
+    pub author_id: i64,
+
+    #[rustango(auto_now_add)]
+    pub published_at: Auto<DateTime<Utc>>,
+}
+```
+
+### Étape 3 — Migrer
+
+Générez et appliquez la migration (comme `makemigrations` + `migrate`) :
+
+```bash
+cargo run -- makemigrations
+cargo run -- migrate
+```
+
+### Étape 4 — Échafauder le sérialiseur
+
+Le sérialiseur est ce qui fait de ceci une API *DRF* — il définit le
+contrat requête/réponse. Générez le squelette :
+
+```bash
+cargo run -- make:serializer PostSerializer --model Post
+```
+
+Puis complétez-le. Celui-ci exerce toute la surface entrée+sortie — un renommage,
+un champ calculé en lecture seule, un champ serveur en lecture seule, et un validateur de champ :
+
+```rust
+// src/blog/post_serializer.rs
+use rustango::{Auto, Serializer};
+use chrono::{DateTime, Utc};
+use crate::blog::models::Post;
+
+#[derive(Serializer, serde::Deserialize, Default)]
+#[serializer(model = Post)]
+pub struct PostSerializer {
+    pub id: Auto<i64>,
+
+    #[serializer(validate = "title_min_3")]   // input: reject titles < 3 chars
+    pub title: String,
+
+    #[serializer(source = "body")]            // JSON key `content`, column `body`
+    pub content: String,
+
+    pub status: String,
+    pub author_id: i64,
+
+    #[serializer(method = "summary")]         // output: computed, never written
+    pub summary: String,
+
+    #[serializer(read_only)]                  // output: shown, ignored on write
+    pub published_at: Auto<DateTime<Utc>>,
+}
+
+impl PostSerializer {
+    fn title_min_3(t: &String) -> Result<(), String> {
+        if t.chars().count() < 3 {
+            Err("title must be at least 3 characters".into())
+        } else {
+            Ok(())
+        }
+    }
+    fn summary(p: &Post) -> String {
+        p.body.chars().take(80).collect::<String>()
+    }
+}
+```
+
+Enregistrez le module — ajoutez `pub mod post_serializer;` à `src/blog/mod.rs`.
+
+Notez que nous n'avons écrit qu'un seul validateur (`title_min_3`) ; les champs **héritent aussi
+automatiquement des contraintes du modèle** — `title` voit sa longueur vérifiée contre le
+`max_length = 200` du modèle, et une colonne `choices`/`min`/`max` serait vérifiée
+également, renvoyant toutes des `400` conviviales à l'écriture. Ajoutez les attributs de sérialiseur `max_length` / `min_length` /
+`min` / `max` pour surcharger la borne d'un champ. (Voir le
+[guide des sérialiseurs](serializers.md#validation) pour l'histoire complète de la validation.)
+
+### Étape 5 — Échafauder le ViewSet et brancher le sérialiseur
+
+```bash
+cargo run -- make:viewset PostViewSet --model Post
+```
+
+Modifiez-le pour déclarer la ressource et **brancher le sérialiseur avec l'attribut
+`serializer`** — cette seule ligne active la sortie *et* l'entrée pilotées par le sérialiseur :
+
+```rust
+// src/blog/post_view_set.rs
+use rustango::ViewSet;
+
+#[derive(ViewSet)]
+#[viewset(
+    model         = Post,
+    serializer    = crate::blog::post_serializer::PostSerializer,
+    filter_fields = "author_id, status",
+    search_fields = "title, body",
+    ordering      = "-published_at",
+    page_size     = 20,
+)]
+pub struct PostViewSet;
+```
+
+Ajoutez `pub mod post_view_set;` à `src/blog/mod.rs`.
+
+> Avec un sérialiseur branché, vous n'avez pas besoin de `fields = "..."` — le sérialiseur est
+> la projection. N'utilisez `fields` que lorsque vous voulez la projection de champs par défaut
+> (non-sérialiseur) à la place.
+
+### Étape 6 — Monter les routes
+
+Dans un projet mono-locataire, imbriquez le routeur du ViewSet sous un chemin, en passant le
+pool :
+
+```rust
+// src/blog/urls.rs (or your urls::api aggregator)
+use axum::Router;
+use rustango::sql::sqlx::PgPool;
+use crate::blog::post_view_set::PostViewSet;
+
+pub fn api(pool: PgPool) -> Router {
+    Router::new()
+        .merge(PostViewSet::router("/api/posts", pool))
+}
+```
+
+`make:api_routes blog` échafaude exactement cet agrégateur si vous préférez le
+générer. Branchez `blog::urls::api(pool)` dans votre `urls.rs` de niveau supérieur.
+
+### Étape 7 — Le lancer et exercer chaque endpoint
+
+```bash
+cargo run            # listening on http://0.0.0.0:8080
+```
+
+**Créer** (`POST`). Le sérialiseur valide d'abord, puis n'écrit que les
+champs qu'il accepte :
+
+```bash
+# happy path — note `content` (the renamed `body`) on the way in
+curl -X POST localhost:8080/api/posts \
+  -H 'content-type: application/json' \
+  -d '{"title":"Hello Rustango","content":"First post body.","status":"published","author_id":1}'
+```
+```json
+{
+  "id": 1,
+  "title": "Hello Rustango",
+  "content": "First post body.",
+  "status": "published",
+  "author_id": 1,
+  "summary": "First post body.",
+  "published_at": "2026-01-02T12:00:00Z"
+}
+```
+La réponse est la forme du **sérialiseur** : `body` est revenu sous `content`, le
+`summary` calculé est apparu, et `published_at` (en lecture seule, défini par le serveur) est
+présent.
+
+**La validation rejette les entrées invalides** avec une `400` en forme DRF —
+des tableaux de messages indexés par champ :
+
+```bash
+curl -i -X POST localhost:8080/api/posts \
+  -H 'content-type: application/json' \
+  -d '{"title":"hi","content":"x","author_id":1}'
+# HTTP/1.1 400 Bad Request
+# {"title":["title must be at least 3 characters"]}
+```
+
+**Les champs en lecture seule / calculés qu'un client poste sont ignorés** — il ne peut pas injecter
+`published_at` ni `summary` :
+
+```bash
+curl -X POST localhost:8080/api/posts \
+  -H 'content-type: application/json' \
+  -d '{"title":"Sneaky","content":"x","author_id":1,"published_at":"1999-01-01T00:00:00Z","summary":"hax"}'
+# → published_at is the server value, not 1999; summary is recomputed from body.
+```
+
+**Lister** (`GET`) — paginé, chaque ligne dans la forme du sérialiseur :
+
+```bash
+curl localhost:8080/api/posts
+```
+```json
+{ "count": 1, "page": 1, "page_size": 20, "last_page": 1, "results": [ { "id": 1, "title": "Hello Rustango", … } ] }
+```
+
+**Récupérer / mettre à jour / mise à jour partielle / supprimer :**
+
+```bash
+curl localhost:8080/api/posts/1                       # retrieve  → 200
+curl -X PUT   localhost:8080/api/posts/1 -H 'content-type: application/json' \
+     -d '{"title":"Edited","content":"new body","status":"published","author_id":1}'   # full update → 200
+curl -X PATCH localhost:8080/api/posts/1 -H 'content-type: application/json' \
+     -d '{"title":"Just the title"}'                   # partial update → 200 (other fields untouched)
+curl -X DELETE localhost:8080/api/posts/1              # destroy → 204
+```
+
+La validation du `PATCH` s'exécute sur ce que vous envoyez ; les champs en lecture seule restent à leur valeur
+serveur même s'ils sont postés.
+
+### Étape 8 — Filtrer, rechercher, trier, paginer
+
+Tout sur l'endpoint de liste, sans code supplémentaire (vous avez déclaré les champs à l'Étape 5) :
+
+```bash
+curl 'localhost:8080/api/posts?status=published&author_id=1'      # filter
+curl 'localhost:8080/api/posts?status__in=published,archived'     # lookup
+curl 'localhost:8080/api/posts?search=rustango'                   # search title+body
+curl 'localhost:8080/api/posts?ordering=title'                    # sort (asc)
+curl 'localhost:8080/api/posts?page=2&page_size=10'               # paginate
+```
+
+### Étape 9 — Le tester
+
+Le framework fournit un client de test in-process — faites des assertions sur de vraies réponses HTTP
+sans démarrer de serveur :
+
+```rust
+// tests/post_api.rs
+use rustango::test_client::TestClient;
+use myblog::blog::post_view_set::PostViewSet;
+use rustango::sql::sqlx::PgPool;
+use serde_json::json;
+
+async fn app() -> axum::Router {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap()).await.unwrap();
+    PostViewSet::router("/api/posts", pool)
+}
+
+#[tokio::test]
+async fn rejects_short_title() {
+    let client = TestClient::new(app().await);
+    let res = client.post("/api/posts")
+        .json(&json!({"title":"hi","content":"x","author_id":1}))
+        .send().await;
+    assert_eq!(res.status, 400);
+    assert!(res.json_value()["title"].is_array());   // DRF field-error shape
+}
+
+#[tokio::test]
+async fn create_then_list() {
+    let client = TestClient::new(app().await);
+    let created = client.post("/api/posts")
+        .json(&json!({"title":"Hello","content":"b","status":"published","author_id":1}))
+        .send().await;
+    assert_eq!(created.status, 201);
+    let list = client.get("/api/posts").send().await;
+    assert!(list.json_value()["results"].is_array());
+}
+```
+
+```bash
+cargo test --test post_api
+```
+
+Voilà une ressource REST complète et validée. Le reste de cette page est la
+référence derrière chaque étape.
+
+---
+
+## Le mariage du sérialiseur : entrée + sortie
+
+Brancher un sérialiseur (via `serializer = …` sur le derive, ou `.serializer::<S>()`
+sur le builder) change **les deux** directions. Cela fonctionne sur PostgreSQL, MySQL et
+SQLite de la même manière.
+
+### Sortie — les réponses sont rendues à travers le sérialiseur
+
+Les réponses de `list`, `retrieve`, `create` et `update` sont produites par
+`S::from_model(&row)`, de sorte que les surcharges du sérialiseur façonnent le JSON :
+
+| Champ du sérialiseur | Effet sur la réponse |
+|---|---|
+| `#[serializer(source = "body")]` | la colonne `body` est émise sous le nom du champ (p. ex. `content`) |
+| `#[serializer(method = "fn")]` | un champ calculé apparaît (depuis `Self::fn(&model)`) |
+| `#[serializer(read_only)]` | inclus dans la sortie |
+| `#[serializer(write_only)]` | **omis** de la sortie |
+
+> **Mise en garde `nested` / `many`.** Les champs de sérialiseur imbriqués et de collection ne sont rendus
+> que lorsque les lignes liées ont été chargées (via `select_related` / une récupération
+> anticipée) ; sinon ils reviennent à leur valeur par défaut. La requête de liste automatique du ViewSet
+> charge la ligne de base — branchez les relations explicitement si un champ imbriqué doit
+> être renseigné.
+
+### Entrée — les requêtes sont validées et filtrées
+
+Sur `create` et `update`, lorsqu'un sérialiseur est enregistré :
+
+1. **La validation s'exécute.** Le `validate()` du sérialiseur — chaque
+   `#[serializer(validate = "fn")]` par champ plus le `validate` transversal au niveau
+   du conteneur — s'exécute contre le corps JSON. En cas d'échec, la requête est rejetée
+   `400 Bad Request` avec la forme d'erreur DRF : un objet JSON indexé par nom de champ
+   avec des tableaux de messages, p. ex. `{"title":["title must be at least 3 characters"]}`.
+2. **Filtrage des champs modifiables.** Seuls les champs modifiables du sérialiseur sont
+   persistés ; les champs `read_only` et `method`/calculés qu'un client poste sont
+   **ignorés** (non écrits), et les renommages `source` sont résolus vers la colonne du
+   modèle. Ainsi un client ne peut pas définir un champ contrôlé par le serveur en l'incluant dans
+   le corps.
+
+> **Les corps form-urlencoded** (par opposition à JSON) sautent `validate()` — il n'y a pas de valeur
+> typée à valider — mais bénéficient tout de même du filtrage des champs modifiables.
+
+Sous le capot, ce sont les méthodes `validate()`,
+`writable_source_fields()` et `from_writable_json()` du trait `ModelSerializer`, toutes générées par
+`#[derive(Serializer)]`. Voir le [guide des sérialiseurs](serializers.md) pour savoir comment
+écrire les validateurs.
+
+---
+
+## Les deux façons de définir un ViewSet
+
+Les deux produisent un `axum::Router` des mêmes routes CRUD.
+
+**1. La macro derive** — déclarative, mono-locataire ; branchez un sérialiseur avec
+`serializer = …` :
+
+```rust
+#[derive(ViewSet)]
+#[viewset(
+    model         = Post,
+    serializer    = crate::blog::post_serializer::PostSerializer,
+    filter_fields = "author_id, status",
+    search_fields = "title, body",
+    ordering      = "-published_at",
+    page_size     = 20,
+)]
+pub struct PostViewSet;
+
+let router = PostViewSet::router("/api/posts", pool);
+```
+
+**2. Le builder** — `ViewSet::for_model(...)`, programmatique, tri-dialecte
+(PostgreSQL / SQLite / MySQL) et conscient de la multi-location ; branchez un sérialiseur avec
+`.serializer::<S>()` :
+
+```rust
+use rustango::viewset::ViewSet;
+use rustango::core::Model as _;
+
+let router = ViewSet::for_model(Post::SCHEMA)
+    .serializer::<PostSerializer>()
+    .filter_fields(&["author_id", "status"])
+    .search_fields(&["title", "body"])
+    .ordering(&[("published_at", true)])    // true = DESC
+    .page_size(20)
+    .router_pool("/api/posts", pool);       // tri-dialect Pool
+```
+
+Optez pour le builder lorsque vous avez besoin de SQLite/MySQL, de la multi-location, d'une
+config construite au runtime, ou des extras (throttling, backends de filtre personnalisés, pagination par curseur).
+
+---
+
+## Les endpoints CRUD
+
+Le montage sur `/api/posts` branche les six opérations REST :
+
+| Verbe | Chemin | Action | Succès | Corps |
+|---|---|---|---|---|
+| `GET` | `/api/posts` | **list** | 200 | enveloppe paginée (voir [Pagination](#pagination)) |
+| `POST` | `/api/posts` | **create** | 201 | l'objet créé — *ou un tableau, pour la création en masse* |
+| `GET` | `/api/posts/{pk}` | **retrieve** | 200 | l'objet |
+| `PUT` | `/api/posts/{pk}` | **update** (complète) | 200 | l'objet mis à jour |
+| `PATCH` | `/api/posts/{pk}` | **partial update** | 200 | l'objet mis à jour (seuls les champs fournis changent) |
+| `DELETE` | `/api/posts/{pk}` | **destroy** | 204 | vide |
+
+Une barre oblique finale sur le préfixe de montage est optionnelle. Seuls ces six verbes sont
+branchés — pas de `HEAD`/`OPTIONS` automatique. La **création en masse** est gratuite : faites un `POST` d'un
+*tableau* JSON et chaque élément est inséré dans l'ordre, validé de manière atomique (un seul élément invalide
+rejette tout le lot).
+
+---
+
+## Choisir quelles opérations exposer
+
+Pour une ressource en **lecture seule** (list + retrieve uniquement), ajoutez `read_only` :
+
+```rust
+#[viewset(model = Post, read_only)]            // macro
+ViewSet::for_model(Post::SCHEMA).read_only()   // builder
+```
+
+Il n'y a pas de bascule par verbe au-delà de read_only. Pour « tout sauf delete »,
+montez le ViewSet et surchargez la route unique avec votre propre handler (voir
+[Actions personnalisées](#custom-actions-beyond-crud)).
+
+---
+
+## Référence de l'attribut `#[viewset(...)]`
+
+| Clé | Exemple | Défaut | Ce qu'elle fait |
+|---|---|---|---|
+| `model` | `model = Post` | **requis** | Le modèle sur lequel la ressource est construite. |
+| `serializer` | `serializer = path::To::S` | aucun | Brancher un sérialiseur pour une **sortie + entrée** typées (voir [ci-dessus](#the-serializer-marriage-input--output)). |
+| `fields` | `"id, title, body"` | tous les champs scalaires | Liste blanche pour la projection par défaut (non-sérialiseur) + les champs modifiables. |
+| `filter_fields` | `"author_id, status"` | aucun | Champs filtrables via `?field=value` (+ lookups). |
+| `search_fields` | `"title, body"` | aucun | Champs que la boîte `?search=` fait correspondre (OU insensible à la casse). |
+| `ordering` | `"-published_at, id"` | aucun | Tri par défaut (`-` = DESC). |
+| `page_size` | `20` | 20 | Lignes par page (le `?page_size=` du client est plafonné à 1000). |
+| `read_only` | *(drapeau)* | désactivé | N'exposer que GET (list + retrieve). |
+| `permissions(...)` | `permissions(create = "post.add")` | aucun | Codenames de permission par action. |
+
+---
+
+## Référence du builder
+
+Chaque méthode sur `ViewSet::for_model(SCHEMA)` (chacune renvoie `Self`) :
+
+| Méthode | But |
+|---|---|
+| `serializer::<S>()` | Brancher un sérialiseur pour une sortie + entrée typées (tri-dialecte). |
+| `fields(&["…"])` | Liste blanche de la projection par défaut + des champs modifiables (sans sérialiseur). |
+| `filter_fields(&["…"])` | Activer le filtrage `?field=value`. |
+| `search_fields(&["…"])` | Activer `?search=`. |
+| `ordering(&[("field", desc)])` | Ordre de tri par défaut. |
+| `ordering_fields(&["…"])` | Liste blanche des champs que `?ordering=` peut utiliser. |
+| `page_size(n)` | Taille de page par défaut (≤ 1000). |
+| `read_only()` | GET uniquement. |
+| `permissions(ViewSetPerms{…})` / `permissions_for_model::<T>()` | Barrières de codename par action (cette dernière sur la multi-location). |
+| `cursor_pagination("id")` / `cursor_pagination_desc("id")` | Pagination par keyset (saute `COUNT(*)`). |
+| `limit_offset_pagination()` | Fenêtrage `?limit=&offset=`. |
+| `pagination(PaginationStyle::…)` | Définir le style explicitement. |
+| `filter_backend(closure)` | Ajouter des prédicats `WHERE` personnalisés au-delà de `filter_fields`. |
+| `throttle(…)` / `throttle_all(max, secs)` | Limites de débit à fenêtre fixe par action. |
+| `router(prefix, pgpool)` | Monter (Postgres, pool statique). |
+| `router_pool(prefix, pool)` | Monter en tri-dialecte (PG / SQLite / MySQL). |
+| `tenant_router(prefix)` | *(multi-location)* monter avec résolution du locataire par requête. |
+
+---
+
+## Filtrage, recherche et tri
+
+Tout est piloté par les paramètres de requête sur l'endpoint de **liste**.
+
+**Filtrage** — chaque entrée de `filter_fields` accepte `?field=value` (exact) plus
+les lookups de style Django via un `__suffix` :
+
+```
+?status=published
+?author_id__in=1,2,3
+?published_at__gte=2026-01-01
+?title__icontains=rust
+?body__isnull=false
+```
+
+Lookups pris en charge : `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `not_in`, `contains`,
+`icontains`, `startswith`, `istartswith`, `endswith`, `iendswith`, `isnull`
+(pas de suffixe = exact). Les champs absents de `filter_fields` sont ignorés.
+
+**Recherche** — `?search=term` fait correspondre `search_fields` avec un OU insensible à la casse.
+
+**Tri** — `?ordering=field,-other` (`-` = DESC). N'importe quel champ est triable
+sauf si vous définissez `.ordering_fields([...])` pour le restreindre. Sans paramètre, le
+tri par défaut `ordering` s'applique. Ils se composent tous.
+
+---
+
+## Pagination
+
+> **Piège — paginez sur un ordre déterministe.** La pagination par numéro de page et par
+> limit/offset suppose un tri stable ; trier sur une colonne non unique
+> (ou aucune) laisse les lignes se décaler entre les pages — dupliquées ou sautées. Ajoutez toujours
+> un départageur unique, p. ex. `ordering = "-published_at, id"`. (Les deux exécutent aussi
+> un `COUNT(*)` par appel ; la pagination par curseur le saute pour les grandes tables.)
+
+Trois styles ; le numéro de page est le défaut. L'enveloppe de liste diffère selon le style :
+
+**Numéro de page** (défaut) — `?page=2&page_size=20` :
+
+```json
+{ "count": 137, "page": 2, "page_size": 20, "last_page": 7, "results": [ … ] }
+```
+
+**Curseur** — `.cursor_pagination("id")` (ou `_desc`) ; saute `COUNT(*)`, idéal
+pour les très grandes tables. `?cursor=<token>&page_size=20` :
+
+```json
+{ "page_size": 20, "next": "<opaque-cursor-or-null>", "results": [ … ] }
+```
+
+**Limit/offset** — `.limit_offset_pagination()`. `?limit=20&offset=40` :
+
+```json
+{ "count": 137, "limit": 20, "offset": 40, "results": [ … ] }
+```
+
+`page_size` / `limit` sont bornés à 1000.
+
+---
+
+## Validation
+
+Avec un **sérialiseur branché**, le chemin create/update exécute les
+validateurs du sérialiseur et renvoie des `400` en forme DRF — la manière recommandée de valider (voir
+[le mariage](#the-serializer-marriage-input--output) et le
+[guide des sérialiseurs](serializers.md#validation)). Trois couches s'exécutent :
+
+- **Contraintes déclaratives** — `max_length` / `min_length` / `min` / `max`, et
+  par défaut le champ **hérite des** `max_length` / `min` / `max` /
+  `choices` **du modèle**. Ainsi une colonne `#[rustango(max_length = 200)]` voit sa longueur vérifiée sur
+  l'API sans configuration supplémentaire (comportement du `ModelSerializer` de DRF), transformant des
+  `500` de contrainte-BDD potentielles en `400` conviviales comme
+  `{"title":["Ensure this value has at most 200 characters."]}`.
+- **Par champ** `validate = "fn"` et un hook `validate` **transversal** — vos
+  règles personnalisées (formats, inter-champs, logique métier).
+
+Indépendamment d'un sérialiseur, le chemin d'écriture applique toujours le **schéma** :
+
+- **Les types sont coercés et vérifiés** — une valeur `i64` / `DateTime` / `Uuid` / `bool`
+  invalide est une `400` nommant le champ.
+- **Requis / NOT NULL** — un champ non-nullable manquant (ou une chaîne vide pour une
+  `String` non-nullable) est une `400` ; les champs nullables acceptent le vide → `NULL`.
+- **Contraintes de base de données** — unique, clés étrangères et contraintes check apparaissent
+  comme une `400` sur INSERT/UPDATE.
+
+Ainsi, même sans sérialiseur, vous obtenez une validation de type + requis + contrainte-BDD ;
+branchez un sérialiseur pour obtenir les vérifications déclaratives de longueur/plage/choix (héritées automatiquement)
+plus vos propres règles par champ et inter-champs.
+
+---
+
+## Permissions et throttling
+
+> **Un ViewSet est public par défaut.** En monter un expose les six verbes CRUD
+> à n'importe qui — il n'y a pas d'authentification intégrée. Protégez-le avec `permissions(...)`
+> (ci-dessous), placez-le derrière le [middleware d'auth](auth-backends.md) (`require_auth`),
+> ou les deux, avant d'exposer les écritures.
+
+**Les permissions** protègent chaque action par des codenames (OU au sein d'une action) :
+
+```rust
+use rustango::viewset::{ViewSet, ViewSetPerms};
+
+ViewSet::for_model(Post::SCHEMA)
+    .permissions(ViewSetPerms {
+        list:     vec!["post.view".into()],
+        retrieve: vec!["post.view".into()],
+        create:   vec!["post.add".into()],
+        update:   vec!["post.change".into()],
+        destroy:  vec!["post.delete".into()],
+    })
+    .router_pool("/api/posts", pool);
+```
+
+Une liste d'action vide = pas de vérification. L'application lit un utilisateur authentifié depuis
+la requête (l'intégration d'auth `tenancy`) ; les superusers contournent, un utilisateur manquant
+est refusé. `.permissions_for_model::<Post>()` remplit automatiquement les codenames standard
+`post.view`/`add`/`change`/`delete`.
+
+**Le throttling** applique des limites à fenêtre fixe par client, par action :
+
+```rust
+ViewSet::for_model(Post::SCHEMA)
+    .throttle_all(60, 60)              // 60 requests / 60s per client, every action
+    .router_pool("/api/posts", pool);
+```
+
+Au-dessus de la limite → `429 Too Many Requests` + `Retry-After`. Les compteurs sont par processus ;
+la clé du client est l'IP de connexion (ou `X-Forwarded-For` / `X-Real-IP`).
+
+---
+
+## Actions personnalisées au-delà du CRUD
+
+Il n'y a pas de décorateur `@action` de DRF — le ViewSet est strictement les six routes
+CRUD. Pour des endpoints supplémentaires, montez vos propres handlers aux côtés du ViewSet :
+
+```rust
+use axum::{Router, routing::{get, post}};
+
+let api = Router::new()
+    .merge(ViewSet::for_model(Post::SCHEMA).router_pool("/api/posts", pool.clone()))
+    .route("/api/posts/stats", get(post_stats))
+    .route("/api/posts/bulk_archive", post(bulk_archive));
+```
+
+Pour une logique `WHERE` supplémentaire, `.filter_backend(…)` apporte des prédicats sans une
+route séparée.
+
+### Restreindre les lignes au principal authentifié
+
+Un backend s'exécute sur **chaque** action — `list`, `retrieve`, `update`, `destroy` —
+il se comporte donc comme le `get_queryset()` de DRF. Une ligne que le backend exclut est un
+**404** sur les routes d'item, pas un 403 : un 403 confirmerait que l'id existe.
+
+L'identité doit provenir de la credential, jamais de la chaîne de requête. Un
+filtre `?owner_id=` n'est pas une portée — c'est un paramètre que l'appelant choisit.
+
+#### `OwnedBy` — le backend fourni
+
+La plupart des ressources possédées ont besoin d'exactement une règle : *les lignes dont la colonne de propriété est
+l'appelant*. Nommez la colonne et montez-le.
+
+```rust
+use rustango::viewset::{OwnedBy, ViewSet};
+
+ViewSet::for_model(Note::SCHEMA)
+    .filter_backend(OwnedBy::column("member_id"))
+    .tenant_router("/api/notes")
+    .layer(axum::middleware::from_fn(
+        rustango::tenancy::auth_routes::require_bearer,
+    ))
+```
+
+N'importe quelle colonne fonctionne — `owner_id`, `member_id`, `author_id` — parce que le backend
+prend le nom plutôt que de supposer une convention. Il échoue de manière fermée sur les deux
+façons dont il peut être erroné : une requête non authentifiée et une colonne que le modèle ne
+possède pas correspondent toutes deux à **rien**, de sorte qu'une faute de frappe au moment du montage ne peut pas se transformer en
+« aucun prédicat, renvoyer la table ».
+
+Les superusers ne sont pas spéciaux par défaut ; `.superuser_sees_all()` active l'option, parce que
+« les admins voient tout » est une décision produit, pas une décision du framework.
+
+#### D'où vient l'identité
+
+[`Principal`] est le seul type d'identité, résolu depuis ce qui a vérifié la
+requête — un `Principal` explicite, un `AuthenticatedUser` laissé par une session ou
+un middleware Bearer, ou un token d'agent MCP (qui agit en tant que l'utilisateur qui l'a émis).
+Il n'authentifie rien lui-même ; il ne lit que ce qu'un middleware de vérification
+a déjà prouvé, de sorte que rien ne peut en insérer un sans vérifier d'abord une credential.
+
+`require_bearer` est ce middleware pour une API JSON : il vérifie le token d'accès
+contre le locataire résolu, relit la ligne utilisateur (un compte désactivé cesse
+de fonctionner à la prochaine requête, pas à l'expiration du token), et insère à la fois
+`AuthenticatedUser` et `Principal`. Utilisez-le comme extracteur n'importe où :
+
+```rust
+use rustango::tenancy::{OptionalPrincipal, Principal};
+
+async fn mine(principal: Principal) -> String {          // 401 when absent
+    format!("user {}", principal.user_id)
+}
+
+async fn home(OptionalPrincipal(who): OptionalPrincipal) -> String {
+    who.map_or("anonymous".into(), |p| format!("user {}", p.user_id))
+}
+```
+
+#### Écrire votre propre backend
+
+Quand la propriété n'est pas une colonne unique — une équipe partagée, une ligne en suppression douce, une
+fenêtre de dates — implémentez le trait et surchargez `filter_with`, qui reçoit
+les `Parts` de la requête :
+
+```rust
+use axum::http::request::Parts;
+use rustango::tenancy::Principal;
+use rustango::viewset::ViewSetFilter;
+
+struct OwnerFilter;
+
+impl ViewSetFilter for OwnerFilter {
+    // No principal in hand — fail closed. Returning no predicates here would
+    // widen the query to every row in the table.
+    fn filter(&self, _p: &HashMap<String, String>, schema: &'static ModelSchema) -> Vec<WhereExpr> {
+        deny_all(schema)
+    }
+
+    fn filter_with(
+        &self,
+        parts: &Parts,
+        _p: &HashMap<String, String>,
+        schema: &'static ModelSchema,
+    ) -> Vec<WhereExpr> {
+        let Some(principal) = Principal::from_parts(parts) else {
+            return deny_all(schema);
+        };
+        vec![WhereExpr::Predicate(Filter {
+            column: schema.field("owner_id").expect("owner_id").column,
+            op: Op::Eq,
+            value: SqlValue::from(principal.user_id),
+        })]
+    }
+}
+
+ViewSet::for_model(Note::SCHEMA)
+    .filter_backend(OwnerFilter)
+    .tenant_router("/api/notes")
+```
+
+`filter_with` a `filter` par défaut, de sorte qu'un backend qui n'a pas besoin de la requête
+— y compris la forme de closure simple — n'implémente que `filter` comme avant.
+
+---
+
+## Montage
+
+Composez le routeur du ViewSet dans votre app. Mono-locataire, pool statique :
+
+```rust
+let api = urls::api()
+    .merge(PostViewSet::router("/api/posts", pool.clone()))                          // macro
+    .merge(ViewSet::for_model(Author::SCHEMA).router_pool("/api/authors", pool.clone())); // builder
+```
+
+Multi-locataire (aucun pool capturé — chaque requête résout sa connexion de locataire) :
+
+```rust
+let api = urls::api()
+    .merge(ViewSet::for_model(Post::SCHEMA).tenant_router("/api/posts"));
+```
+
+`make:api_routes <app>` génère un `api()` par app qui rassemble ces
+lignes `.merge(...)` ; branchez-le dans votre `urls.rs` de niveau supérieur.
+
+---
+
+## Prise en charge des backends
+
+- **Le builder + `router_pool` / `tenant_router`** est **tri-dialecte** — PostgreSQL,
+  SQLite et MySQL — et c'est le chemin recommandé.
+- **Le `router(prefix, PgPool)` de la macro derive** capture un `PgPool` (PostgreSQL).
+- **L'entrée + sortie du sérialiseur** fonctionne désormais sur **les trois backends** (le
+  rendu par ligne est tri-dialecte ; l'ancienne barrière PG-uniquement a disparu).
+- Le filtrage, la recherche, le tri, les trois modes de pagination, les permissions,
+  le throttling et la création en masse fonctionnent tous à travers les backends pris en charge sur le
+  chemin builder.
+
+---
+
+## Essayez-le
+
+Le flux de bout en bout ci-dessus reflète l'exemple compilable `getting_started_blog`
+(Étapes 12–13 du [guide de prise en main](getting-started.md)). Les
+propres tests live du framework sous `crates/rustango/tests/viewset_*.rs` sont la
+référence exécutable la plus complète — y compris les tests d'entrée/sortie du sérialiseur.
+Ils s'exécutent sur SQLite en mémoire mais nécessitent les feature flags correspondants, p. ex. :
+
+```bash
+cd crates/rustango
+cargo test --features sqlite,tenancy --test viewset_serializer_render_sqlite_live
+cargo test --features sqlite,tenancy --test viewset_serializer_input_sqlite_live
+cargo test --features sqlite,tenancy --test viewset_sqlite_live
+```
+
+---
+
+## Voir aussi
+
+- [Sérialiseurs](serializers.md) — façonner le JSON qu'un ViewSet envoie et valide.
+- [Vues HTML](html-views.md) — la contrepartie rendue côté serveur de cette API JSON.
+- [OpenAPI](openapi.md) — générer une spec + Swagger UI depuis vos ViewSets.
+- [URLs & routage](urls.md) — composer les routeurs de ViewSet dans votre app.

--- a/docs/fr/websockets.md
+++ b/docs/fr/websockets.md
@@ -1,0 +1,218 @@
+# WebSockets & SSE
+
+La plupart des requêtes sont ponctuelles : on demande, on répond, terminé. Les fonctionnalités
+**temps réel** sont l'exception — une notification en direct, une barre de progression, un tableau
+de bord qui se met à jour tout seul, un chat. Le serveur doit *pousser* vers le navigateur sans
+qu'on le lui demande. **Rustango** vous offre les deux transports de push sur une seule fondation :
+
+- **SSE (Server-Sent Events)** — un flux unidirectionnel, serveur → navigateur, sur du HTTP simple.
+  L'`EventSource` intégré au navigateur se reconnecte automatiquement. La chose la plus simple qui
+  fonctionne ; utilisez-le pour les notifications, la progression, les compteurs en direct, les
+  flux.
+- **WebSockets** — un canal full-duplex, dans les deux sens. Utilisez-le quand le
+  client envoie aussi (chat, édition collaborative, présence).
+
+Les deux se diffusent à travers le même **bus de diffusion** en processus ([`EventBus`]), si bien
+que « envoyer ceci à chaque client connecté » est un seul appel quel que soit le transport. Si vous
+venez de Django, c'est Channels ; de Laravel, Echo/Reverb ; de Node,
+`ws` + `EventSource` — mêmes idées, un seul bus derrière elles.
+
+> **Source :** `rustango::sse` (`EventBus`) — derrière la fonctionnalité **`sse`** ; et
+> `rustango::ws` (`WsHub`, `WsConfig`, `ws_handler`) — derrière la
+> fonctionnalité **`websocket`** (implique `admin` + `sse` + `axum/ws`). Les deux sont dans
+> l'ensemble de fonctionnalités par défaut. Le canal serveur→client du serveur MCP
+> (`rustango::mcp::transport`) est un consommateur de production du côté SSE.
+>
+> **Référence exécutable :** les snippets faisant autorité et à jour sont les
+> guides de démarrage rapide des modules dans `src/sse.rs` et `src/ws.rs` ; la diffusion de
+> l'`EventBus` est couverte par les tests unitaires dans `src/sse.rs`.
+
+> **Un terme vous est inconnu ?** *SSE*, *WebSocket*, *broadcast*, *keep-alive/ping*,
+> *back-pressure* — voir le [glossaire](glossary.md).
+
+## Table des matières
+
+- [SSE ou WebSocket — lequel ?](#sse-or-websocket--which)
+- [Le bus de diffusion](#the-broadcast-bus)
+- [Server-Sent Events](#server-sent-events)
+- [WebSockets](#websockets)
+- [Envoyer depuis ailleurs](#sending-from-elsewhere)
+- [Auth & multi-locataire](#auth--tenancy)
+- [Notes de mise à l'échelle](#scaling-notes)
+- [Drapeaux de fonctionnalités](#feature-flags)
+
+---
+
+## SSE ou WebSocket — lequel ?
+
+| | **SSE** | **WebSocket** |
+|---|---|---|
+| Direction | serveur → client uniquement | bidirectionnel |
+| Transport | HTTP simple (`text/event-stream`) | mise à niveau `ws://` / `wss://` |
+| Reconnexion | automatique (intégrée à `EventSource`) | à votre charge (ou une bibliothèque cliente le fait) |
+| Proxys / infra | juste du HTTP — proxifié trivialement | nécessite des proxys conscients de la mise à niveau |
+| API cliente | `new EventSource(url)` | `new WebSocket(url)` |
+| À utiliser pour | notifications, progression, compteurs en direct, flux | chat, présence, édition collaborative, tout ce que le client *envoie* aussi |
+
+**Règle empirique :** si le client ne fait que *recevoir*, utilisez SSE — c'est moins de code, ça se reconnecte automatiquement, et ça roule sur du HTTP ordinaire. Tournez-vous vers un WebSocket seulement quand le client *envoie* aussi.
+
+## Le bus de diffusion
+
+Les deux transports reposent sur [`EventBus<T>`] — un canal de diffusion peu coûteux à cloner. Un
+seul `send` atteint chaque abonné ; les abonnés lents prennent du retard plutôt que de bloquer les
+autres. `T` est votre propre type de message `Clone`.
+
+```rust
+use rustango::sse::EventBus;
+use serde::{Serialize, Deserialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+struct Notification { kind: String, message: String }
+
+// capacity = per-subscriber buffer; older messages drop for a lagging client.
+let bus: EventBus<Notification> = EventBus::new(100);
+
+// share `bus` via router state (it's Clone). Then from anywhere:
+let delivered = bus.send(Notification { kind: "info".into(), message: "Saved".into() });
+//  `delivered` = how many connected clients received it (0 = no-op).
+```
+
+API d'`EventBus` : `new(capacity)`, `send(event) -> usize`, `subscribe() ->
+broadcast::Receiver<T>`, `receiver_count() -> usize`.
+
+## Server-Sent Events
+
+Câblez le bus à un point d'accès SSE avec la réponse `Sse` d'axum + un
+`async_stream::stream!` qui transmet chaque message de diffusion en tant qu'événement. Ajoutez
+`async-stream` et `futures` à votre `Cargo.toml`.
+
+```rust
+use std::convert::Infallible;
+use axum::{extract::State, response::sse::{Event, KeepAlive, Sse}, routing::get, Router};
+use futures::Stream;
+use rustango::sse::EventBus;
+
+async fn events(
+    State(bus): State<EventBus<Notification>>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let mut rx = bus.subscribe();
+    let stream = async_stream::stream! {
+        while let Ok(msg) = rx.recv().await {
+            let json = serde_json::to_string(&msg).unwrap_or_default();
+            yield Ok(Event::default().event("notification").data(json));
+        }
+    };
+    // keep-alive comments stop idle connections being reaped by proxies.
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+let app = Router::new()
+    .route("/events", get(events))
+    .with_state(bus.clone());
+```
+
+Navigateur — l'`EventSource` intégré se connecte et se reconnecte automatiquement :
+
+```js
+const es = new EventSource('/events');
+es.addEventListener('notification', (e) => {
+  const n = JSON.parse(e.data);
+  console.log(n.kind, n.message);
+});
+es.onerror = () => {/* EventSource retries automatically */};
+```
+
+## WebSockets
+
+Pour du trafic bidirectionnel, utilisez [`WsHub`] + [`ws_handler`]. Le hub enveloppe un
+`EventBus` et ajoute des pings keep-alive, la (dé)sérialisation JSON, et la gestion des
+consommateurs lents ; `ws_handler` fait tourner une connexion jusqu'à ce que le client se
+déconnecte.
+
+```rust
+use std::time::Duration;
+use axum::{extract::{State, WebSocketUpgrade}, response::Response, routing::get, Router};
+use rustango::{sse::EventBus, ws::{ws_handler, WsHub}};
+use serde::{Serialize, Deserialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+struct Tick { value: i64 }
+
+let bus: EventBus<Tick> = EventBus::new(100);
+let hub = WsHub::new(bus).keepalive(Duration::from_secs(20));
+
+async fn ws_route(ws: WebSocketUpgrade, State(hub): State<WsHub<Tick>>) -> Response {
+    ws.on_upgrade(move |socket| ws_handler(socket, hub.clone()))
+}
+
+let app = Router::new()
+    .route("/ws", get(ws_route))
+    .with_state(hub.clone());
+
+// From anywhere — one call fans out to every connected socket:
+hub.broadcast(Tick { value: 42 });
+```
+
+```js
+const ws = new WebSocket(`${location.origin.replace('http', 'ws')}/ws`);
+ws.onmessage = (e) => { const t = JSON.parse(e.data); console.log('tick', t.value); };
+```
+
+**Réglage** via [`WsConfig`] (méthodes de builder sur `WsHub`) :
+
+| Réglage | Défaut | Effet |
+|---|---|---|
+| `.keepalive(Duration)` | 30 s | intervalle de `Ping` en veille — plus bas détecte les connexions mortes plus tôt |
+| `.on_message(fn(&str) -> Option<String>)` | aucun | gère le texte client→serveur ; renvoyez `Some(reply)` pour renvoyer un écho **à ce client uniquement** (appelez `hub.broadcast(..)` pour la diffusion) |
+| `.max_message_bytes(n)` | 1 MiB | ferme la connexion si un message client dépasse cette limite |
+
+**Les consommateurs lents** ne sont pas abandonnés en silence : un client à la traîne se voit dire
+qu'il a manqué `n` messages (`Lagged(n)`) afin qu'il puisse se resynchroniser ou continuer.
+
+## Envoyer depuis ailleurs
+
+Le bus/hub est `Clone` et vit dans le state du routeur, si bien que n'importe quelle partie de votre
+application — un handler de requête, une [tâche d'arrière-plan](jobs.md), un récepteur de
+[signal](models.md) — peut pousser vers chaque client connecté en tenant un clone et en appelant
+`bus.send(..)` / `hub.broadcast(..)`. Un motif courant : une tâche se termine → elle diffuse une
+notification « terminé » → le flux SSE ouvert du navigateur met l'UI à jour.
+
+Un seul `EventBus` peut soutenir **à la fois** une route SSE et une route WebSocket en même temps —
+`WsHub::bus()` vous remet le bus sous-jacent à partager avec un handler SSE, si bien que les
+clients sur l'un ou l'autre transport voient le même flux.
+
+## Auth & multi-locataire
+
+Les routes SSE/WS sont des routes axum ordinaires — superposez-y votre auth habituelle
+(session, [JWT](auth-jwt-api.md), [clé d'API](auth-api-keys.md)) exactement comme vous le
+feriez pour n'importe quel handler ; ajoutez l'extracteur à la route et rejetez avant de
+s'abonner. Dans une application multi-locataire, résolvez le locataire sur la connexion et utilisez
+un **bus par locataire** (ou filtrez les messages par locataire) afin que les événements d'un
+locataire n'atteignent jamais les clients d'un autre. Le [serveur MCP](mcp.md) fait exactement
+cela — son canal SSE authentifié et par agent est construit sur cette même fondation `sse`.
+
+## Notes de mise à l'échelle
+
+`EventBus` est un `tokio::sync::broadcast` **en processus** — la diffusion est instantanée
+et légère en verrous, mais elle n'atteint que les clients connectés à *ce* processus. Vous exécutez
+plusieurs instances d'application derrière un équilibreur de charge ? Un client connecté au nœud A
+ne verra pas un événement envoyé sur le nœud B. Pour diffuser à travers les nœuds, faites le pont
+entre le bus et un pub/sub externe (par ex. Redis) — publiez-y les événements métier et faites en
+sorte que le souscripteur de chaque nœud les re-`send` vers son `EventBus` local. Le cas
+mono-nœud (le cas courant) n'a besoin de rien de tout cela.
+
+Dimensionnez aussi `EventBus::new(capacity)` pour votre débit en pointe : c'est le tampon par
+abonné, et un client qui prend plus de retard que `capacity` reçoit un
+signal `Lagged` plutôt qu'une croissance mémoire illimitée.
+
+## Drapeaux de fonctionnalités
+
+```toml
+# Cargo.toml — both are in Rustango's default set; list them if you slim features.
+rustango = { version = "*", features = ["sse", "websocket"] }
+```
+
+- **`sse`** — le bus de diffusion `EventBus` (tire `tokio`). Suffisant pour SSE, puisque
+  le format de fil SSE provient du `response::sse` propre à axum.
+- **`websocket`** — l'échafaudage `WsHub` / `ws_handler` ; implique `admin` (axum)
+  + `sse` + `axum/ws`.


### PR DESCRIPTION
Syncs the complete localized documentation into develop (already live on rustango.com via the docs deploy branch). 36 pages × French/German/Spanish (mirrored filenames + per-locale index.toml), plus README Docs links → rustango.com. Docs-only, no framework code.