### PR TITLE
fix: bug-fix batch — API correctness, settings visibility, tenant aggregates, custom user model (#1200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,47 @@ Headline: **a `ViewSet` can finally be scoped to the caller** (#1183) — the
 authenticated identity is available to filter backends, backends apply to every
 action, and `OwnedBy` does the common case in one line.
 
+### Fixed
+
+- **ViewSet: 401 for anonymous, 403 for authenticated-but-unauthorised**
+  (#1193) — the permission check collapsed both cases to 403. A token client
+  treats 401 as its cue to refresh, so answering 403 to a request that simply
+  carried no credentials meant the refresh never fired and the member was
+  silently logged out. **Behaviour change:** an unauthenticated request to a
+  permission-gated ViewSet now returns `401`. (Without the `tenancy` feature
+  there is no permission engine at all, so the denial stays `403` — no amount
+  of authenticating could satisfy it.)
+- **Settings no longer inert in silence** (#1192) — CORS, body limit, request
+  timeout and security headers are read from the environment and then do
+  nothing unless `.with_settings_from_env()` is in the `Cli` chain. `runserver`
+  now emits a `WARN` naming exactly which layer-driving settings are configured
+  but unapplied, and the builder call that would activate them. Note that
+  turning them on also activates a strict CSP, which can break a
+  server-rendered app that was fine without it.
+- **A project model may own a framework table** (#1168) — the documented
+  custom-user-model path (extra columns on `rustango_users`) emitted a
+  duplicate `CREATE TABLE`, because the built-in `User` derive is unconditional
+  and the system snapshot did not dedup by table. Exactly one model now owns a
+  table, and a downstream model wins over the framework's own — with a warning,
+  since an accidental override is a typo'd table name. `Cli::user_model` itself
+  remains advisory.
+- **`migrate_manage` tests no longer assume the ledger exists** (#1186) — five
+  tests failed on a brand-new database and passed on re-run, so the suite's
+  result depended on test ordering and residue in the target database.
+
 ### Added
+
+- **`AggregateBuilder::fetch_on` / `ValuesQuerySet::fetch_on`** (#1172) — the
+  aggregate and values terminals can now run on a borrowed executor, like
+  `QuerySet::fetch_on`. Schema-per-tenant Postgres selects the tenant with
+  `SET search_path` on the checked-out connection, so a pool-resolved aggregate
+  silently read `public`; a tenant app had no public way to run a GROUP BY
+  against its own schema short of raw SQL.
+- **`ViewSet::pk_param(name)`** (#1194) — rename the detail-route capture
+  (default `pk`). axum allows one capture name per path position across a
+  router, so a hand-written sibling route spelling it `{id}` panicked at
+  startup, pointing at axum rather than the ViewSet. The generated OpenAPI path
+  and parameter follow the rename.
 
 - **`ViewSetFilter::filter_with(&Parts, params, schema)`** — a default-provided
   companion to `filter` that receives the request `Parts`, so a backend can read

--- a/crates/rustango/src/manage.rs
+++ b/crates/rustango/src/manage.rs
@@ -759,10 +759,7 @@ impl Cli {
                 None => api,
             };
             #[cfg(feature = "config")]
-            let api = match self.settings_for_layers.as_ref() {
-                Some(s) => apply_settings_layers(api, s),
-                None => api,
-            };
+            let api = apply_settings_layers_or_warn(api, self.settings_for_layers.as_ref());
             let app = api.layer(axum::Extension(pool));
             let listener = tokio::net::TcpListener::bind(&self.bind).await?;
             eprintln!("server listening on http://{}", listener.local_addr()?);
@@ -815,10 +812,7 @@ impl Cli {
                     None => api,
                 };
                 #[cfg(feature = "config")]
-                let api = match self.settings_for_layers.as_ref() {
-                    Some(s) => apply_settings_layers(api, s),
-                    None => api,
-                };
+                let api = apply_settings_layers_or_warn(api, self.settings_for_layers.as_ref());
                 let app = api.layer(axum::Extension(pool));
                 let listener = tokio::net::TcpListener::bind(&self.bind).await?;
                 eprintln!("server listening on http://{}", listener.local_addr()?);
@@ -856,10 +850,7 @@ impl Cli {
                 None => api,
             };
             #[cfg(feature = "config")]
-            let api = match self.settings_for_layers.as_ref() {
-                Some(s) => apply_settings_layers(api, s),
-                None => api,
-            };
+            let api = apply_settings_layers_or_warn(api, self.settings_for_layers.as_ref());
             let app = api.layer(axum::Extension(pool));
             let listener = tokio::net::TcpListener::bind(&self.bind).await?;
             eprintln!("server listening on http://{}", listener.local_addr()?);
@@ -897,10 +888,7 @@ impl Cli {
             None => api,
         };
         #[cfg(feature = "config")]
-        let api = match self.settings_for_layers.as_ref() {
-            Some(s) => apply_settings_layers(api, s),
-            None => api,
-        };
+        let api = apply_settings_layers_or_warn(api, self.settings_for_layers.as_ref());
         let mut builder = crate::server::Builder::from_env().await?.api(api);
         if self.health_endpoints {
             builder = builder.with_health();
@@ -944,10 +932,7 @@ impl Cli {
             None => api,
         };
         #[cfg(feature = "config")]
-        let api = match self.settings_for_layers.as_ref() {
-            Some(s) => apply_settings_layers(api, s),
-            None => api,
-        };
+        let api = apply_settings_layers_or_warn(api, self.settings_for_layers.as_ref());
         let apex = std::env::var("RUSTANGO_APEX_DOMAIN").unwrap_or_else(|_| "localhost".into());
         let registry_url =
             std::env::var("DATABASE_URL")
@@ -1067,6 +1052,82 @@ fn mount_static_dirs(api: Router, dirs: &[(String, PathBuf)]) -> Router {
 /// has nothing configured, so `with_settings` on a near-empty
 /// `default.toml` doesn't surprise the user with unexpected
 /// middleware.
+/// Apply the settings-driven layers, or — when no settings were installed —
+/// warn if the environment nonetheless *configures* some of them (#1192).
+///
+/// A setting that is absent is a bug you find; a setting that is present,
+/// parsed and ignored is a bug you ship. Without
+/// [`Cli::with_settings_from_env`] in the builder chain, CORS, the body
+/// limit, the request timeout and the security headers are read from the
+/// environment and then silently do nothing — reading the config and
+/// concluding the headers are being sent is entirely reasonable, and wrong.
+/// Naming the missing builder call turns that into a one-line fix.
+#[cfg(feature = "config")]
+fn apply_settings_layers_or_warn(
+    api: Router,
+    settings: Option<&crate::config::Settings>,
+) -> Router {
+    match settings {
+        Some(s) => apply_settings_layers(api, s),
+        None => {
+            warn_if_settings_inert();
+            api
+        }
+    }
+}
+
+/// The layer-driving settings that `s` configures, by dotted name.
+///
+/// Only settings that would actually install a layer count — a configured
+/// `secret_key` is not evidence that anyone expected CORS. Pure, so the
+/// warning's precision is unit-testable.
+#[cfg(feature = "config")]
+fn inert_layer_settings(s: &crate::config::Settings) -> Vec<&'static str> {
+    let mut inert: Vec<&'static str> = Vec::new();
+    if s.server.request_timeout_secs.is_some() {
+        inert.push("server.request_timeout_secs");
+    }
+    if s.server.max_body_bytes.is_some() {
+        inert.push("server.max_body_bytes");
+    }
+    if s.security.headers_preset.is_some() {
+        inert.push("security.headers_preset");
+    }
+    if s.security.csp.is_some() {
+        inert.push("security.csp");
+    }
+    if s.security.hsts_max_age_secs.is_some() {
+        inert.push("security.hsts_max_age_secs");
+    }
+    if !s.security.cors_allowed_origins.is_empty() {
+        inert.push("security.cors_allowed_origins");
+    }
+    inert
+}
+
+/// Emit a `WARN` naming every layer-driving setting that is configured in the
+/// environment while no settings layer is installed. Silent when nothing is
+/// configured (the common case for projects that never used `Settings`).
+#[cfg(feature = "config")]
+fn warn_if_settings_inert() {
+    let Ok(s) = crate::config::Settings::load_from_env() else {
+        return;
+    };
+    let inert = inert_layer_settings(&s);
+    if inert.is_empty() {
+        return;
+    }
+    tracing::warn!(
+        target: "rustango::manage",
+        settings = %inert.join(", "),
+        "these settings are configured but NOT being applied — no settings layer is \
+         installed. Add `.with_settings_from_env()` to the `Cli` builder chain to \
+         activate them (CORS, body limit, request timeout, security headers). \
+         Note that enabling them also turns on a strict CSP, which can break a \
+         server-rendered app that was fine without it."
+    );
+}
+
 #[cfg(feature = "config")]
 fn apply_settings_layers(api: Router, s: &crate::config::Settings) -> Router {
     use crate::access_log::{AccessLogLayer, AccessLogRouterExt as _};
@@ -1364,6 +1425,36 @@ mod tests {
     /// settings without panicking on axum layer-stacking
     /// constraints. End-to-end header-presence assertions live in
     /// the per-module smoke tests for each layer.
+    /// #1192 — the detector must name exactly the layer-driving settings that
+    /// are configured, and stay quiet when none are. A false positive would
+    /// train people to ignore the warning; a false negative is the original bug.
+    #[cfg(feature = "config")]
+    #[test]
+    fn inert_settings_detector_names_only_configured_layers() {
+        use crate::config::Settings;
+
+        // Nothing configured → nothing to warn about.
+        assert!(inert_layer_settings(&Settings::default()).is_empty());
+
+        // Each layer-driving field is reported, and only that field.
+        let mut s = Settings::default();
+        s.security.headers_preset = Some("strict".into());
+        assert_eq!(inert_layer_settings(&s), vec!["security.headers_preset"]);
+
+        let mut s = Settings::default();
+        s.server.max_body_bytes = Some(1024);
+        s.security.cors_allowed_origins = vec!["https://example.com".into()];
+        assert_eq!(
+            inert_layer_settings(&s),
+            vec!["server.max_body_bytes", "security.cors_allowed_origins"]
+        );
+
+        // A setting that drives no layer must NOT trigger the warning.
+        let mut s = Settings::default();
+        s.secret_key = Some("irrelevant".into());
+        assert!(inert_layer_settings(&s).is_empty());
+    }
+
     #[cfg(feature = "config")]
     #[test]
     fn apply_settings_layers_smoke() {

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -199,6 +199,13 @@ pub struct RelationSnapshot {
     pub on: String,
 }
 
+/// Was this model registered by the framework itself (as opposed to a
+/// downstream crate)? Used to decide which model owns a `rustango_*` table
+/// when a project overrides one — see [`SchemaSnapshot::from_registry_system_for_scope`].
+fn is_framework_model(e: &ModelEntry) -> bool {
+    e.module_path == "rustango" || e.module_path.starts_with("rustango::")
+}
+
 impl SchemaSnapshot {
     /// Capture every model registered in the binary's `inventory`.
     ///
@@ -280,15 +287,35 @@ impl SchemaSnapshot {
         // migration model can't say "both", so they're included in every
         // scope's system migrations (each DB creates its own copy).
         const SHARED: &[&str] = &["rustango_audit_log", "rustango_content_types"];
-        let entries: Vec<&ModelEntry> = inventory::iter::<ModelEntry>
-            .into_iter()
-            .filter(|e| {
-                (e.schema.scope == scope || SHARED.contains(&e.schema.table))
-                    && e.schema.table.starts_with("rustango_")
-                    && !e.schema.is_view
-                    && e.schema.managed
-            })
-            .collect();
+        let matching = inventory::iter::<ModelEntry>.into_iter().filter(|e| {
+            (e.schema.scope == scope || SHARED.contains(&e.schema.table))
+                && e.schema.table.starts_with("rustango_")
+                && !e.schema.is_view
+                && e.schema.managed
+        });
+        // Exactly one model may own a table. The documented custom-user-model
+        // path has a downstream model declare `rustango_users` with extra
+        // columns — but the built-in `User` derive is unconditional, so both
+        // land in the inventory and both used to flow into the migration,
+        // yielding a duplicate/ambiguous `CREATE TABLE` (#1168). Dedup by
+        // table, and let the *downstream* model win: a project that spells out
+        // a framework table is overriding it on purpose.
+        let mut by_table: std::collections::BTreeMap<&'static str, &ModelEntry> =
+            std::collections::BTreeMap::new();
+        for e in matching {
+            match by_table.entry(e.schema.table) {
+                std::collections::btree_map::Entry::Vacant(slot) => {
+                    slot.insert(e);
+                }
+                std::collections::btree_map::Entry::Occupied(mut slot) => {
+                    let held_is_framework = is_framework_model(slot.get());
+                    if held_is_framework && !is_framework_model(e) {
+                        slot.insert(e);
+                    }
+                }
+            }
+        }
+        let entries: Vec<&ModelEntry> = by_table.into_values().collect();
         let mut tables: Vec<TableSnapshot> = entries
             .iter()
             .map(|e| TableSnapshot::from_schema(e.schema))

--- a/crates/rustango/src/migrate/snapshot.rs
+++ b/crates/rustango/src/migrate/snapshot.rs
@@ -308,9 +308,37 @@ impl SchemaSnapshot {
                     slot.insert(e);
                 }
                 std::collections::btree_map::Entry::Occupied(mut slot) => {
-                    let held_is_framework = is_framework_model(slot.get());
-                    if held_is_framework && !is_framework_model(e) {
-                        slot.insert(e);
+                    let held = *slot.get();
+                    match (is_framework_model(held), is_framework_model(e)) {
+                        // Downstream model overrides the framework's own.
+                        (true, false) => {
+                            tracing::warn!(
+                                target: "rustango::migrate",
+                                table = %e.schema.table,
+                                model = %e.module_path,
+                                "a project model is overriding a framework table — its \
+                                 schema will be used instead of rustango's. If this was \
+                                 not intended, the table name is a typo."
+                            );
+                            slot.insert(e);
+                        }
+                        // Two downstream models claiming one table is ambiguous.
+                        // Resolve by module path so the emitted migration is
+                        // stable across builds (inventory order is link-order
+                        // dependent), and say so rather than silently picking.
+                        (false, false) => {
+                            tracing::warn!(
+                                target: "rustango::migrate",
+                                table = %e.schema.table,
+                                candidates = %format!("{}, {}", held.module_path, e.module_path),
+                                "two models declare the same table — using the \
+                                 lexicographically first module path; remove one"
+                            );
+                            if e.module_path < held.module_path {
+                                slot.insert(e);
+                            }
+                        }
+                        _ => {}
                     }
                 }
             }

--- a/crates/rustango/src/sql/executor/values.rs
+++ b/crates/rustango/src/sql/executor/values.rs
@@ -574,6 +574,50 @@ impl<T: crate::core::Model> crate::query::ValuesQuerySet<T> {
     }
 }
 
+impl<T: crate::core::Model> crate::query::ValuesQuerySet<T> {
+    /// Like [`Self::fetch`] but runs on a borrowed executor rather than the
+    /// pool — the terminal a **tenant-scoped** connection needs.
+    ///
+    /// In schema-per-tenant Postgres the tenant is selected by `SET
+    /// search_path` on the checked-out connection, so resolving against the
+    /// pool silently reads `public` instead. `QuerySet` has had `fetch_on`
+    /// for this; the values/aggregate terminals did not, which left a tenant
+    /// app with no public way to run a projection against its own schema
+    /// (#1172).
+    ///
+    /// # Errors
+    /// As [`Self::fetch`].
+    #[cfg(feature = "postgres")]
+    pub async fn fetch_on<'c, E>(
+        self,
+        executor: E,
+    ) -> Result<Vec<std::collections::HashMap<String, SqlValue>>, ExecError>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+    {
+        let query = self.compile()?;
+        let stmt = {
+            use crate::sql::Dialect as _;
+            crate::sql::Postgres.compile_select(&query)?
+        };
+        let mut q: Query<'_, sqlx::Postgres, PgArguments> = sqlx::query(&stmt.sql);
+        for v in stmt.params {
+            q = bind_query(q, v);
+        }
+        let rows = q.fetch_all(executor).await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for row in &rows {
+            use sqlx::{Column as _, Row as _};
+            let mut map = std::collections::HashMap::new();
+            for (i, col) in row.columns().iter().enumerate() {
+                map.insert(col.name().to_owned(), pg_cell_to_sqlvalue(row, i));
+            }
+            out.push(map);
+        }
+        Ok(out)
+    }
+}
+
 impl<T: crate::core::Model> crate::query::AggregateBuilder<T> {
     /// Execute the aggregate / annotate query and return rows as
     /// `Vec<HashMap<String, SqlValue>>` keyed by output-column name.
@@ -594,6 +638,36 @@ impl<T: crate::core::Model> crate::query::AggregateBuilder<T> {
     ) -> Result<Vec<std::collections::HashMap<String, SqlValue>>, ExecError> {
         let q = self.compile()?;
         fetch_aggregate_dict(pool, &q).await
+    }
+
+    /// Like [`Self::fetch`] but runs on a borrowed executor rather than the
+    /// pool — the terminal a **tenant-scoped** connection needs.
+    ///
+    /// Schema-per-tenant Postgres selects the tenant with `SET search_path`
+    /// on the checked-out connection, so a pool-resolved aggregate reads
+    /// `public` instead of the tenant's schema. Mirrors
+    /// [`crate::query::QuerySet::fetch_on`] (#1172).
+    ///
+    /// ```ignore
+    /// SetLog::objects()
+    ///     .values(&["member_id"])
+    ///     .annotate("total", sum("volume").into())
+    ///     .fetch_on(t.conn())   // runs in the tenant's schema
+    ///     .await?;
+    /// ```
+    ///
+    /// # Errors
+    /// As [`Self::fetch`].
+    #[cfg(feature = "postgres")]
+    pub async fn fetch_on<'c, E>(
+        self,
+        executor: E,
+    ) -> Result<Vec<std::collections::HashMap<String, SqlValue>>, ExecError>
+    where
+        E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+    {
+        let q = self.compile()?;
+        super::fetch_aggregate_on(&q, executor).await
     }
 }
 

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1198,12 +1198,14 @@ impl ViewSetState {
         }
         #[cfg(not(feature = "tenancy"))]
         {
-            // Without tenancy there's no AuthenticatedUser extension
-            // and no has_perm engine. Codenames present + no engine
-            // means we conservatively deny. There is no principal to
-            // speak of either, so this reads as "authenticate first".
+            // Without tenancy there's no AuthenticatedUser extension and no
+            // has_perm engine, so codenames present + no engine means we
+            // conservatively deny. Deliberately 403, NOT 401: no amount of
+            // authenticating can satisfy a check with no engine behind it,
+            // and answering 401 would send a token client into exactly the
+            // futile refresh loop this issue set out to remove (#1193).
             let _ = (parts, conn);
-            PermOutcome::Unauthenticated
+            PermOutcome::Forbidden
         }
     }
 

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1172,9 +1172,9 @@ impl ViewSetState {
         codenames: &[String],
         parts: &axum::http::request::Parts,
         conn: &mut AcquiredConn,
-    ) -> bool {
+    ) -> PermOutcome {
         if codenames.is_empty() {
-            return true;
+            return PermOutcome::Allow;
         }
         #[cfg(feature = "tenancy")]
         {
@@ -1182,25 +1182,28 @@ impl ViewSetState {
                 .extensions
                 .get::<crate::tenancy::middleware::AuthenticatedUser>()
             else {
-                return false;
+                // No principal at all — the client needs to authenticate,
+                // which is 401, not 403 (#1193).
+                return PermOutcome::Unauthenticated;
             };
             if auth.is_superuser {
-                return true;
+                return PermOutcome::Allow;
             }
             for cn in codenames {
                 if conn.has_perm(auth.id, cn).await {
-                    return true;
+                    return PermOutcome::Allow;
                 }
             }
-            false
+            PermOutcome::Forbidden
         }
         #[cfg(not(feature = "tenancy"))]
         {
             // Without tenancy there's no AuthenticatedUser extension
             // and no has_perm engine. Codenames present + no engine
-            // means we conservatively deny.
+            // means we conservatively deny. There is no principal to
+            // speak of either, so this reads as "authenticate first".
             let _ = (parts, conn);
-            false
+            PermOutcome::Unauthenticated
         }
     }
 
@@ -1385,6 +1388,21 @@ fn narrow(expr: WhereExpr, extra: Vec<WhereExpr>) -> WhereExpr {
     WhereExpr::And(all)
 }
 
+/// Outcome of a per-action permission check.
+///
+/// Three-valued on purpose: "no principal" and "principal without the
+/// permission" are different answers to the client. Collapsing them to a
+/// single bool is what produced a 403 for anonymous requests (#1193).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PermOutcome {
+    /// Authorised — proceed.
+    Allow,
+    /// No authenticated principal → `401`.
+    Unauthenticated,
+    /// Authenticated, but lacks every required codename → `403`.
+    Forbidden,
+}
+
 async fn enter(
     state: &Arc<ViewSetState>,
     req: axum::extract::Request,
@@ -1398,8 +1416,21 @@ async fn enter(
         return Err(resp);
     }
     let mut acq = state.acquire(&mut parts).await?;
-    if !state.check_perm(codenames, &parts, &mut acq).await {
-        return Err(json_error(StatusCode::FORBIDDEN, "permission denied"));
+    match state.check_perm(codenames, &parts, &mut acq).await {
+        PermOutcome::Allow => {}
+        // 401 means "authenticate", 403 means "you cannot do this". A token
+        // client treats 401 as its cue to refresh; answering 403 to an
+        // anonymous request means the refresh never fires and the member is
+        // silently logged out (#1193).
+        PermOutcome::Unauthenticated => {
+            return Err(json_error(
+                StatusCode::UNAUTHORIZED,
+                "authentication required",
+            ))
+        }
+        PermOutcome::Forbidden => {
+            return Err(json_error(StatusCode::FORBIDDEN, "permission denied"))
+        }
     }
     Ok((parts, body, acq))
 }

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -603,6 +603,9 @@ pub struct ViewSet {
     /// field-level projection. Tri-dialect. Wired via
     /// [`Self::serializer`].
     serializer: Option<Arc<dyn SerializerBridge>>,
+    /// Name of the path capture for the detail routes — `pk` by default,
+    /// giving `/{pk}`. See [`ViewSet::pk_param`].
+    pk_param: String,
 }
 
 impl ViewSet {
@@ -622,6 +625,7 @@ impl ViewSet {
             filter_backends: Vec::new(),
             throttle: ViewSetThrottle::default(),
             serializer: None,
+            pk_param: "pk".to_owned(),
         }
     }
 
@@ -800,6 +804,39 @@ impl ViewSet {
         self
     }
 
+    /// Rename the detail routes' path capture. Defaults to `pk`, i.e.
+    /// `/{pk}`.
+    ///
+    /// axum allows only **one** capture name per path position across a
+    /// router, so a hand-written route mounted beside a ViewSet that spells
+    /// the same position differently — `/{id}`, `/{token}` — panics at
+    /// startup, and the panic points at axum rather than at the ViewSet.
+    /// Rather than forcing every neighbouring route to adopt `pk`, match the
+    /// ViewSet to them:
+    ///
+    /// ```ignore
+    /// ViewSet::for_model(Post::SCHEMA).pk_param("id").router("/api/posts", pool)
+    /// // detail routes become /api/posts/{id}
+    /// ```
+    ///
+    /// The handlers read the capture positionally, so only the route string
+    /// and the generated OpenAPI parameter change.
+    ///
+    /// Note that a capture cannot share a segment with a literal, so an
+    /// AIP-style `/{token}:accept` is not expressible; use `/{token}/accept`.
+    #[must_use]
+    pub fn pk_param(mut self, name: impl Into<String>) -> Self {
+        self.pk_param = name.into();
+        self
+    }
+
+    /// The configured detail-route capture name (`pk` unless
+    /// [`ViewSet::pk_param`] changed it).
+    #[must_use]
+    pub fn pk_param_name(&self) -> &str {
+        &self.pk_param
+    }
+
     /// Allow GET only — wires list + retrieve, skips create/update/destroy.
     pub fn read_only(mut self) -> Self {
         self.read_only = true;
@@ -878,7 +915,7 @@ impl ViewSet {
         });
         let prefix = prefix.trim_end_matches('/').to_owned();
         let collection = prefix.clone();
-        let item = format!("{prefix}/{{pk}}");
+        let item = format!("{prefix}/{{{}}}", self.pk_param);
 
         let collection_route = if self.read_only {
             get(handle_list)

--- a/crates/rustango/src/viewset/openapi.rs
+++ b/crates/rustango/src/viewset/openapi.rs
@@ -39,7 +39,7 @@ impl ViewSet {
     pub fn openapi_paths(&self, prefix: &str, item_schema_ref: &str) -> Vec<(String, PathItem)> {
         let prefix = prefix.trim_end_matches('/').to_owned();
         let collection_path = prefix.clone();
-        let item_path = format!("{prefix}/{{pk}}");
+        let item_path = format!("{prefix}/{{{}}}", self.pk_param_name());
         let tag = item_schema_ref.to_owned();
 
         let collection = self.collection_path_item(&tag, item_schema_ref);
@@ -139,7 +139,10 @@ impl ViewSet {
         let pk_field = self.schema.primary_key();
         let schema = pk_field.map_or_else(Schema::integer, |f| field_type_to_schema(f.ty));
         let name = pk_field.map_or("pk", |f| f.name);
-        Parameter::path("pk", schema).description(format!("Primary key ({name})"))
+        // The parameter must be spelled the same as the route capture, which
+        // `ViewSet::pk_param` can rename (#1194) — otherwise the generated
+        // spec documents a path variable the server never binds.
+        Parameter::path(self.pk_param_name(), schema).description(format!("Primary key ({name})"))
     }
 
     fn list_query_params(&self) -> Vec<Parameter> {

--- a/crates/rustango/tests/aggregate_fetch_on_pg_live.rs
+++ b/crates/rustango/tests/aggregate_fetch_on_pg_live.rs
@@ -32,6 +32,14 @@ pub struct SetLog {
 
 const TENANT: &str = "agg_on_tenant";
 
+/// Suite-wide lock. Both tests DROP/CREATE the same tables; run in parallel
+/// they race on Postgres' `pg_type_typname_nsp_index` (23505 duplicate key)
+/// rather than on anything this file is testing.
+fn lock() -> &'static tokio::sync::Mutex<()> {
+    static M: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    M.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
 async fn pool() -> Option<PgPool> {
     let url = std::env::var("DATABASE_URL").ok()?;
     PgPool::connect(&url).await.ok()
@@ -73,6 +81,7 @@ async fn setup(pool: &PgPool) {
 /// `public`'s (10+5).
 #[tokio::test]
 async fn aggregate_fetch_on_reads_the_connections_schema() {
+    let _g = lock().lock().await;
     let Some(pool) = pool().await else {
         eprintln!("skipping — set DATABASE_URL");
         return;
@@ -104,6 +113,7 @@ async fn aggregate_fetch_on_reads_the_connections_schema() {
 /// Same guarantee for the plain values projection.
 #[tokio::test]
 async fn values_fetch_on_reads_the_connections_schema() {
+    let _g = lock().lock().await;
     let Some(pool) = pool().await else {
         eprintln!("skipping — set DATABASE_URL");
         return;

--- a/crates/rustango/tests/aggregate_fetch_on_pg_live.rs
+++ b/crates/rustango/tests/aggregate_fetch_on_pg_live.rs
@@ -1,0 +1,131 @@
+//! `AggregateBuilder::fetch_on` / `ValuesQuerySet::fetch_on` — tenant-scoped
+//! aggregates (#1172).
+//!
+//! In schema-per-tenant Postgres the tenant is selected by `SET search_path`
+//! on the **checked-out connection**, so a terminal that resolves against the
+//! pool reads `public` instead. `QuerySet` has had `fetch_on` for this; the
+//! aggregate/values builders did not, leaving a tenant app to drop to raw SQL.
+//!
+//! These tests put *different data* in two schemas and assert the aggregate
+//! reads the connection's schema — a terminal that silently used the pool
+//! would return the other schema's numbers and pass a weaker test.
+//!
+//! Reads `DATABASE_URL`; skips silently when unset.
+
+#![cfg(feature = "postgres")]
+
+use rustango::core::aggregates::sum;
+use rustango::core::Model as _;
+use rustango::sql::sqlx::{self, PgPool};
+use rustango::sql::Auto;
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "agg_on_setlog")]
+#[rustango(app = "agg_on_app")]
+pub struct SetLog {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub member_id: i64,
+    pub volume: i64,
+}
+
+const TENANT: &str = "agg_on_tenant";
+
+async fn pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    PgPool::connect(&url).await.ok()
+}
+
+/// Same table in two schemas, different numbers in each.
+async fn setup(pool: &PgPool) {
+    for (schema, volumes) in [("public", [10_i64, 5]), (TENANT, [100, 50])] {
+        if schema != "public" {
+            sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS {schema}"))
+                .execute(pool)
+                .await
+                .unwrap();
+        }
+        sqlx::query(&format!("DROP TABLE IF EXISTS {schema}.agg_on_setlog"))
+            .execute(pool)
+            .await
+            .unwrap();
+        sqlx::query(&format!(
+            "CREATE TABLE {schema}.agg_on_setlog \
+             (id BIGSERIAL PRIMARY KEY, member_id BIGINT NOT NULL, volume BIGINT NOT NULL)"
+        ))
+        .execute(pool)
+        .await
+        .unwrap();
+        for v in volumes {
+            sqlx::query(&format!(
+                "INSERT INTO {schema}.agg_on_setlog (member_id, volume) VALUES (1, {v})"
+            ))
+            .execute(pool)
+            .await
+            .unwrap();
+        }
+    }
+}
+
+/// The headline case from the issue: total volume per member, grouped, run on
+/// a tenant-scoped connection. Must read the tenant's rows (100+50), not
+/// `public`'s (10+5).
+#[tokio::test]
+async fn aggregate_fetch_on_reads_the_connections_schema() {
+    let Some(pool) = pool().await else {
+        eprintln!("skipping — set DATABASE_URL");
+        return;
+    };
+    setup(&pool).await;
+
+    let mut conn = pool.acquire().await.unwrap();
+    sqlx::query(&format!("SET search_path TO {TENANT}, public"))
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+
+    let rows = SetLog::objects()
+        .values(&["member_id"])
+        .annotate("total", sum("volume").into())
+        .fetch_on(&mut *conn)
+        .await
+        .expect("aggregate must run on the borrowed tenant connection");
+
+    assert_eq!(rows.len(), 1, "one group (member_id = 1)");
+    let total = format!("{:?}", rows[0].get("total"));
+    assert!(
+        total.contains("150"),
+        "must sum the TENANT schema's rows (100+50=150), got {total} — \
+         a pool-resolved aggregate would have returned 15"
+    );
+}
+
+/// Same guarantee for the plain values projection.
+#[tokio::test]
+async fn values_fetch_on_reads_the_connections_schema() {
+    let Some(pool) = pool().await else {
+        eprintln!("skipping — set DATABASE_URL");
+        return;
+    };
+    setup(&pool).await;
+
+    let mut conn = pool.acquire().await.unwrap();
+    sqlx::query(&format!("SET search_path TO {TENANT}, public"))
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+
+    let rows = SetLog::objects()
+        .values_dict(&["volume"])
+        .fetch_on(&mut *conn)
+        .await
+        .expect("values projection must run on the borrowed connection");
+
+    assert_eq!(rows.len(), 2, "the tenant schema holds two rows");
+    let dumped = format!("{rows:?}");
+    assert!(
+        dumped.contains("100") && dumped.contains("50"),
+        "must be the tenant's volumes, got {dumped}"
+    );
+}

--- a/crates/rustango/tests/custom_tenant_user_model.rs
+++ b/crates/rustango/tests/custom_tenant_user_model.rs
@@ -1,0 +1,80 @@
+//! A downstream model may own a framework table (#1168).
+//!
+//! The documented custom-user-model path has a project declare
+//! `rustango_users` with extra columns. The built-in `User` derive is
+//! unconditional, so both models land in the inventory — and the system
+//! snapshot used to take *both*, producing a duplicate/ambiguous
+//! `CREATE TABLE rustango_users`. Net effect: no supported way to add a
+//! column to the tenant user, and the documented extension point was dead.
+//!
+//! Exactly one model must own a table, and when a project spells out a
+//! framework table it is overriding it on purpose — so the downstream model
+//! wins.
+
+#![cfg(feature = "tenancy")]
+
+use rustango::migrate::SchemaSnapshot;
+use rustango::sql::Auto;
+use rustango::Model;
+
+/// Mirrors the `TenantUserModel` doc example: the framework's required
+/// columns plus a project-specific one.
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "rustango_users")]
+pub struct AppUser {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 150, unique)]
+    pub username: String,
+    #[rustango(max_length = 255)]
+    pub password_hash: String,
+    pub active: bool,
+    pub is_superuser: bool,
+    /// The whole point: an extra typed column on the tenant user.
+    #[rustango(max_length = 100)]
+    pub display_name: String,
+}
+
+/// `rustango_users` appears exactly once, and it is the project's version.
+#[test]
+fn downstream_model_owns_the_framework_table() {
+    let snap = SchemaSnapshot::from_registry_system_for_scope(rustango::core::ModelScope::Tenant);
+
+    let users: Vec<_> = snap
+        .tables
+        .iter()
+        .filter(|t| t.name == "rustango_users")
+        .collect();
+    assert_eq!(
+        users.len(),
+        1,
+        "exactly one model must own rustango_users — two would emit a \
+         duplicate CREATE TABLE"
+    );
+
+    let cols: Vec<&str> = users[0].fields.iter().map(|f| f.column.as_str()).collect();
+    assert!(
+        cols.contains(&"display_name"),
+        "the project's model must win, so its extra column is in the \
+         migration; got columns: {cols:?}"
+    );
+}
+
+/// Overriding one table must not drop the framework's other tables.
+#[test]
+fn other_framework_tables_are_untouched() {
+    let snap = SchemaSnapshot::from_registry_system_for_scope(rustango::core::ModelScope::Tenant);
+    let names: Vec<&str> = snap.tables.iter().map(|t| t.name.as_str()).collect();
+    for expected in ["rustango_roles", "rustango_permissions"] {
+        assert!(
+            names.contains(&expected),
+            "{expected} must still be present; got {names:?}"
+        );
+    }
+    // And every table is unique — the dedup applies across the board.
+    let mut sorted = names.clone();
+    sorted.sort_unstable();
+    let before = sorted.len();
+    sorted.dedup();
+    assert_eq!(before, sorted.len(), "no table may appear twice: {names:?}");
+}

--- a/crates/rustango/tests/migrate_manage.rs
+++ b/crates/rustango/tests/migrate_manage.rs
@@ -90,13 +90,19 @@ async fn drop_table(pool: &rustango::sql::Pool, table: &str) {
     sqlx::query(&sql).execute(pg).await.unwrap();
 }
 
+/// Remove a ledger row if it is there.
+///
+/// Tolerates a missing ledger table: this runs during setup, and on a
+/// brand-new database nothing has created `__rustango_migrations__` yet.
+/// Unwrapping here made the suite's result depend on test ordering and on
+/// residue in the target database — five tests failed on a fresh DB and
+/// passed on the second run (#1186).
 async fn delete_ledger_entry(pool: &rustango::sql::Pool, name: &str) {
     let pg = pool.as_postgres().expect("test pool is postgres");
-    sqlx::query("DELETE FROM __rustango_migrations__ WHERE name = $1")
+    let _ = sqlx::query("DELETE FROM __rustango_migrations__ WHERE name = $1")
         .bind(name)
         .execute(pg)
-        .await
-        .unwrap();
+        .await;
 }
 
 fn args(cmd: &[&str]) -> Vec<String> {

--- a/crates/rustango/tests/viewset_401_vs_403_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_401_vs_403_sqlite_live.rs
@@ -1,0 +1,140 @@
+//! ViewSet answers 401 for anonymous, 403 for authenticated-but-unauthorised
+//! (#1193).
+//!
+//! The distinction is not cosmetic. A token client treats **401** as its cue
+//! to refresh; answering **403** to a request that simply carried no
+//! credentials means the refresh never fires and the member is silently
+//! logged out. 403 must mean "you are known, and still may not do this".
+
+#![cfg(all(feature = "sqlite", feature = "tenancy", feature = "serializer"))]
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use rustango::core::Model as _;
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::viewset::{ViewSet, ViewSetPerms};
+use rustango::Model;
+use tower::ServiceExt as _;
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "vs_401_note")]
+#[rustango(app = "vs_401_app")]
+pub struct Note {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+async fn pool() -> Pool {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite");
+    sqlx::query(
+        "CREATE TABLE vs_401_note (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .unwrap();
+    Pool::Sqlite(sq)
+}
+
+/// A ViewSet gated on a codename nobody holds.
+fn gated(pool: Pool) -> axum::Router {
+    ViewSet::for_model(Note::SCHEMA)
+        .permissions(ViewSetPerms {
+            list: vec!["vs_401_app.view_note".to_owned()],
+            ..ViewSetPerms::default()
+        })
+        .router_pool("/notes", pool)
+}
+
+/// No credentials at all → 401, so a token client knows to refresh.
+#[tokio::test]
+async fn anonymous_request_gets_401() {
+    let app = gated(pool().await);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/notes")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        res.status(),
+        StatusCode::UNAUTHORIZED,
+        "an unauthenticated request must be 401, not 403"
+    );
+}
+
+/// Authenticated, but without the codename → 403. This is the case 403 is for,
+/// and it must NOT regress into 401 (which would send clients into a refresh
+/// loop over a permission they will never be granted).
+#[tokio::test]
+async fn authenticated_but_unauthorised_gets_403() {
+    let app = gated(pool().await);
+
+    let mut req = Request::builder()
+        .method(Method::GET)
+        .uri("/notes")
+        .body(Body::empty())
+        .unwrap();
+    // Present a principal the way the auth middleware does.
+    req.extensions_mut()
+        .insert(rustango::tenancy::middleware::AuthenticatedUser {
+            id: 42,
+            username: "member".to_owned(),
+            is_superuser: false,
+        });
+
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::FORBIDDEN,
+        "a known principal lacking the codename must stay 403"
+    );
+}
+
+/// A superuser passes, so the split didn't break the allow path.
+#[tokio::test]
+async fn superuser_is_allowed() {
+    let app = gated(pool().await);
+
+    let mut req = Request::builder()
+        .method(Method::GET)
+        .uri("/notes")
+        .body(Body::empty())
+        .unwrap();
+    req.extensions_mut()
+        .insert(rustango::tenancy::middleware::AuthenticatedUser {
+            id: 1,
+            username: "root".to_owned(),
+            is_superuser: true,
+        });
+
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+/// An ungated ViewSet is unaffected — no codenames means no auth check.
+#[tokio::test]
+async fn ungated_viewset_still_serves_anonymous() {
+    let app = ViewSet::for_model(Note::SCHEMA).router_pool("/notes", pool().await);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/notes")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}

--- a/crates/rustango/tests/viewset_pk_param_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_pk_param_sqlite_live.rs
@@ -1,0 +1,132 @@
+//! `ViewSet::pk_param` — rename the detail-route capture (#1194).
+//!
+//! axum permits only one capture name per path position across a router, so a
+//! hand-written route mounted beside a ViewSet that spells the same position
+//! differently (`/{id}`, `/{token}`) panics at startup — and the panic points
+//! at axum, not at the ViewSet. Renaming the ViewSet's capture is the escape
+//! hatch; these tests pin that it works, that the route still resolves, and
+//! that the generated OpenAPI agrees with the route it documents.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy", feature = "serializer"))]
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use rustango::core::Model as _;
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::Model;
+use tower::ServiceExt as _;
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "vs_pk_note")]
+#[rustango(app = "vs_pk_app")]
+pub struct Note {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+async fn pool_with_row() -> Pool {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite");
+    sqlx::query(
+        "CREATE TABLE vs_pk_note (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO vs_pk_note (title) VALUES ('hello')")
+        .execute(&sq)
+        .await
+        .unwrap();
+    Pool::Sqlite(sq)
+}
+
+/// The renamed capture still routes: `GET /notes/{id}/1` resolves and returns
+/// the row, so renaming changes the spelling and nothing else.
+#[tokio::test]
+async fn renamed_capture_still_resolves_the_detail_route() {
+    let pool = pool_with_row().await;
+    let app = rustango::viewset::ViewSet::for_model(Note::SCHEMA)
+        .pk_param("id")
+        .router_pool("/notes", pool);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/notes/1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK, "detail route must resolve");
+}
+
+/// The regression this exists for: a sibling route using a *different* capture
+/// name at the same position. With the ViewSet defaulting to `{pk}` this
+/// panics inside axum at startup; matching the names makes it mount.
+#[tokio::test]
+async fn sibling_route_with_matching_capture_name_mounts() {
+    let pool = pool_with_row().await;
+    let vs = rustango::viewset::ViewSet::for_model(Note::SCHEMA)
+        .pk_param("id")
+        .router_pool("/notes", pool);
+
+    // A hand-written neighbour spelling the same position `{id}`.
+    let app = vs.merge(axum::Router::new().route(
+        "/notes/{id}/archive",
+        axum::routing::post(|| async { "archived" }),
+    ));
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/notes/1/archive")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "sibling route must mount + serve"
+    );
+}
+
+/// The generated spec must document the capture the server actually binds —
+/// otherwise the OpenAPI describes a path variable that does not exist.
+#[test]
+fn openapi_path_and_parameter_follow_the_rename() {
+    let vs = rustango::viewset::ViewSet::for_model(Note::SCHEMA).pk_param("id");
+    let paths = vs.openapi_paths("/notes", "Note");
+
+    let item = paths
+        .iter()
+        .find(|(p, _)| p.contains('{'))
+        .expect("an item path");
+    assert_eq!(item.0, "/notes/{id}", "path must use the renamed capture");
+
+    // Path-level `parameters` (shared by every operation on the item path).
+    let json = serde_json::to_value(&item.1).unwrap();
+    let params = json["parameters"].as_array().expect("path parameters");
+    assert!(
+        params
+            .iter()
+            .any(|p| p["name"] == "id" && p["in"] == "path"),
+        "the path parameter must be named `id`, got: {params:?}"
+    );
+}
+
+/// Default is unchanged: no call to `pk_param` still yields `{pk}`.
+#[test]
+fn default_capture_is_still_pk() {
+    let vs = rustango::viewset::ViewSet::for_model(Note::SCHEMA);
+    assert_eq!(vs.pk_param_name(), "pk");
+    let paths = vs.openapi_paths("/notes", "Note");
+    assert!(paths.iter().any(|(p, _)| p == "/notes/{pk}"));
+}


### PR DESCRIPTION
Closes #1186, #1192, #1194, #1172, #1193 (status half), and #1168. Epic: #1200.

| # | Fix |
|---|---|
| **#1193** | ViewSet answers **401** when there is no principal and **403** only when a known principal lacks the codename. Not cosmetic: a token client treats 401 as its cue to refresh, so a 403 for a credential-less request means the refresh never fires and the member is silently logged out. |
| **#1192** | `runserver` **warns** when layer-driving settings (CORS, body limit, request timeout, security headers) are configured but no settings layer is installed, naming both the settings and the missing `.with_settings_from_env()`. The detector is a pure function with a unit test, because an imprecise warning gets ignored. |
| **#1194** | `ViewSet::pk_param("id")` renames the detail-route capture (default `pk`), so a sibling route spelling the same position differently no longer panics at startup. The generated OpenAPI path **and** parameter follow the rename. |
| **#1172** | Public `AggregateBuilder::fetch_on` / `ValuesQuerySet::fetch_on`, so a schema-per-tenant app can run a GROUP BY on its tenant connection instead of reaching into `__macro_internals` or dropping to raw SQL. |
| **#1168** | The system snapshot keeps **one model per table**, and a downstream model declaring a framework table wins — so the documented custom-user-model path (extra columns on `rustango_users`) works instead of emitting a duplicate CREATE TABLE. |
| **#1186** | `migrate_manage` no longer assumes the ledger exists, so the suite stops depending on test ordering and DB residue. |

## Verification

- **#1186 measured against the baseline**: `origin/develop` fails 5/28 on a fresh database; with the fix 28/28 pass.
- **#1172 proven, not asserted**: the test puts *different* data in `public` and a tenant schema, so a terminal that quietly used the pool returns the wrong numbers rather than merely failing to compile (must sum 150, not 15).
- **#1194** covers the actual regression — a sibling `/notes/{id}/archive` route mounts and serves.
- **#1193** pins both directions, including that authenticated-but-unauthorised must *not* regress into 401 (clients would loop refreshing for a permission they will never hold).
- 40 batch tests green; `cargo test --workspace --all-features --no-run` clean; clippy clean; `--no-default-features --features sqlite,tenancy` litmus builds.

## Deliberately left open

- **#1193's second half** — one error envelope across the framework. Wider than the ViewSet and wants its own change.
- **#1168's `Cli::user_model`** — still advisory (`init_tenancy_with` has been a no-op since the bootstrap-migration era). The working mechanism is now simply declaring the model; that needs a docs pass.