### PR TITLE
fix(viewset): page ceiling is the app's, not a hard-coded 1000 (#1196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ action, and `OwnedBy` does the common case in one line.
 
 ### Fixed
 
+- **ViewSet page ceiling is the app's, not a hard-coded 1000** (#1196) — a
+  client could ask for `?page_size=1000` regardless of what the app configured,
+  so an app sized around `page_size(20)` faced a 50× amplification of its
+  serializer, joins and response budget; where the serializer does per-row work
+  against the database, that turns an N+1 into a thousand queries in one
+  request. **Behaviour change:** the ceiling now defaults to **100** (matching
+  `template_views`, which the two pagination surfaces previously disagreed
+  about by a factor of ten), and is configurable per ViewSet with
+  `max_page_size(n)`. `?limit=` is bounded by the same value, so limit/offset
+  isn't a way around it, and a `page_size` larger than the ceiling can't
+  smuggle a bigger page through the default path either.
+
 - **ViewSet: 401 for anonymous, 403 for authenticated-but-unauthorised**
   (#1193) — the permission check collapsed both cases to 403. A token client
   treats 401 as its cue to refresh, so answering 403 to a request that simply

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -39,7 +39,7 @@
 //! | Parameter | Default | Description |
 //! |---|---|---|
 //! | `page` | 1 | 1-based page number |
-//! | `page_size` | configured default | Items per page (capped at 1000) |
+//! | `page_size` | configured default | Items per page (capped at `max_page_size`, default 100) |
 //! | `ordering` | configured default | Comma-separated field names, prefix `-` for DESC |
 //! | `search` | — | Full-text search across `search_fields` |
 //! | `{field}` | — | Exact filter for any `filter_fields` |
@@ -55,7 +55,7 @@
 //! | Parameter | Default | Description |
 //! |---|---|---|
 //! | `cursor` | — | Opaque token from a previous response's `next` field |
-//! | `page_size` | configured default | Items per page (capped at 1000) |
+//! | `page_size` | configured default | Items per page (capped at `max_page_size`, default 100) |
 //! | `{field}` | — | Exact filter for any `filter_fields` |
 //!
 //! Response: `{"page_size": S, "next": "<token>" \| null, "results": [...]}`
@@ -69,7 +69,7 @@
 //!
 //! | Parameter | Default | Description |
 //! |---|---|---|
-//! | `limit` | configured default | Items to return (capped at 1000) |
+//! | `limit` | configured default | Items to return (capped at `max_page_size`, default 100) |
 //! | `offset` | 0 | Rows to skip before the window |
 //! | `ordering` | configured default | Comma-separated field names, prefix `-` for DESC |
 //! | `search` | — | Full-text search across `search_fields` |
@@ -603,6 +603,9 @@ pub struct ViewSet {
     /// field-level projection. Tri-dialect. Wired via
     /// [`Self::serializer`].
     serializer: Option<Arc<dyn SerializerBridge>>,
+    /// Largest page a client may request via `?page_size=` / `?limit=`.
+    /// Defaults to 100. See [`ViewSet::max_page_size`].
+    max_page_size: usize,
     /// Name of the path capture for the detail routes — `pk` by default,
     /// giving `/{pk}`. See [`ViewSet::pk_param`].
     pk_param: String,
@@ -625,6 +628,7 @@ impl ViewSet {
             filter_backends: Vec::new(),
             throttle: ViewSetThrottle::default(),
             serializer: None,
+            max_page_size: 100,
             pk_param: "pk".to_owned(),
         }
     }
@@ -760,9 +764,37 @@ impl ViewSet {
         self
     }
 
-    /// Default page size for list responses (default: 20, max: 1000).
+    /// Default page size for list responses (default: 20).
+    ///
+    /// This is the size used when the client asks for none. What a client may
+    /// *request* is bounded separately by [`ViewSet::max_page_size`], and the
+    /// effective size is clamped to that bound at request time — so the order
+    /// of these two builder calls doesn't matter.
     pub fn page_size(mut self, n: usize) -> Self {
-        self.default_page_size = n.min(1000);
+        self.default_page_size = n.max(1);
+        self
+    }
+
+    /// Largest page a client may request via `?page_size=` / `?limit=`
+    /// (default: 100).
+    ///
+    /// The ceiling used to be a hard-coded 1000 with no way to lower it, so an
+    /// app that sized its serializer, joins and response budget around
+    /// `page_size(20)` could still be asked for 1000 rows by any client — a
+    /// 50× amplification. If the serializer does per-row work that touches the
+    /// database, that is an N+1 turning into a thousand queries in a single
+    /// request (#1196).
+    ///
+    /// The default matches `template_views`' ceiling, so the framework's two
+    /// pagination surfaces now agree. Raise it deliberately when a consumer
+    /// genuinely needs bigger pages:
+    ///
+    /// ```ignore
+    /// ViewSet::for_model(Post::SCHEMA).page_size(20).max_page_size(500)
+    /// ```
+    #[must_use]
+    pub fn max_page_size(mut self, n: usize) -> Self {
+        self.max_page_size = n.max(1);
         self
     }
 
@@ -1638,11 +1670,14 @@ async fn run_list(
     mut acq: AcquiredConn,
     parts: &axum::http::request::Parts,
 ) -> Response {
+    // Clamp to the ViewSet's own ceiling, not a hard-coded 1000 (#1196). The
+    // default page size is clamped too, so a `page_size` larger than
+    // `max_page_size` can't smuggle a bigger page through the default path.
     let page_size: i64 = params
         .get("page_size")
         .and_then(|p| p.parse().ok())
         .unwrap_or(state.vs.default_page_size as i64)
-        .min(1000)
+        .min(state.vs.max_page_size as i64)
         .max(1);
 
     // Build WHERE from filter_fields in query params.
@@ -1798,11 +1833,13 @@ async fn run_list(
         PaginationStyle::LimitOffset => {
             // `?limit=` overrides the default page size; `?offset=` skips
             // rows. Same `COUNT(*)` cost as page-number pagination.
+            // Same ceiling as `?page_size=` — otherwise limit/offset would be
+            // an unbounded way around it (#1196).
             let limit: i64 = params
                 .get("limit")
                 .and_then(|p| p.parse().ok())
                 .unwrap_or(page_size)
-                .min(1000)
+                .min(state.vs.max_page_size as i64)
                 .max(1);
             let offset: i64 = params
                 .get("offset")

--- a/crates/rustango/tests/viewset_limit_offset_pagination_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_limit_offset_pagination_sqlite_live.rs
@@ -141,7 +141,9 @@ async fn limit_offset_clamps_hostile_bounds() {
     let app = make_router_and_pool(10).await;
     seed(&app, 4).await;
 
-    // limit above the 1000 cap clamps to 1000; offset below 0 clamps to 0.
+    // A hostile `limit` clamps to the ViewSet's ceiling — `max_page_size`,
+    // which defaults to 100 (#1196). It used to be a hard-coded 1000 that no
+    // app could lower. `offset` below 0 clamps to 0.
     let body = body_json(
         app.clone()
             .oneshot(get("/posts?limit=999999&offset=-5"))
@@ -149,7 +151,7 @@ async fn limit_offset_clamps_hostile_bounds() {
             .unwrap(),
     )
     .await;
-    assert_eq!(body["limit"], 1000);
+    assert_eq!(body["limit"], 100);
     assert_eq!(body["offset"], 0);
     assert_eq!(ids(&body), vec![1, 2, 3, 4]);
 }

--- a/crates/rustango/tests/viewset_max_page_size_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_max_page_size_sqlite_live.rs
@@ -1,0 +1,134 @@
+//! `ViewSet::max_page_size` — the page ceiling is the app's, not a hard-coded
+//! 1000 (#1196).
+//!
+//! An app that sets `page_size(20)` has sized its serializer, joins and
+//! response budget around 20 rows. With the old fixed ceiling any client could
+//! ask for 1000 and get a 50× amplification of all of it — and if the
+//! serializer does per-row work that touches the database, that is an N+1
+//! becoming a thousand queries in one request. It was reachable by any
+//! authenticated caller, which made it the cheapest way to make a rustango app
+//! do expensive work.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy", feature = "serializer"))]
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use rustango::core::Model as _;
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::viewset::ViewSet;
+use rustango::Model;
+use serde_json::Value;
+use tower::ServiceExt as _;
+
+#[derive(Model, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[rustango(table = "vs_mps_note")]
+#[rustango(app = "vs_mps_app")]
+pub struct Note {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+/// 250 rows — more than the new default ceiling (100), so a clamp is visible.
+async fn pool_with_rows() -> Pool {
+    let sq = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite");
+    sqlx::query(
+        "CREATE TABLE vs_mps_note (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL)",
+    )
+    .execute(&sq)
+    .await
+    .unwrap();
+    for i in 0..250 {
+        sqlx::query("INSERT INTO vs_mps_note (title) VALUES (?)")
+            .bind(format!("n{i}"))
+            .execute(&sq)
+            .await
+            .unwrap();
+    }
+    Pool::Sqlite(sq)
+}
+
+async fn count_returned(app: axum::Router, uri: &str) -> usize {
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK, "{uri} should succeed");
+    let bytes = axum::body::to_bytes(res.into_body(), 4 * 1024 * 1024)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+    // Page-number pagination wraps rows in `results`.
+    json["results"]
+        .as_array()
+        .map(Vec::len)
+        .or_else(|| json.as_array().map(Vec::len))
+        .unwrap_or_else(|| panic!("no row array in response: {json}"))
+}
+
+/// The regression: a client asking for 1000 no longer gets 1000.
+#[tokio::test]
+async fn client_cannot_exceed_the_default_ceiling() {
+    let app = ViewSet::for_model(Note::SCHEMA)
+        .page_size(20)
+        .router_pool("/notes", pool_with_rows().await);
+    let n = count_returned(app, "/notes?page_size=1000").await;
+    assert_eq!(
+        n, 100,
+        "?page_size=1000 must clamp to the 100 default, not return 1000 rows"
+    );
+}
+
+/// The app can lower the ceiling below the default.
+#[tokio::test]
+async fn app_can_lower_the_ceiling() {
+    let app = ViewSet::for_model(Note::SCHEMA)
+        .page_size(20)
+        .max_page_size(25)
+        .router_pool("/notes", pool_with_rows().await);
+    let n = count_returned(app, "/notes?page_size=1000").await;
+    assert_eq!(n, 25, "the app's ceiling must win");
+}
+
+/// …and raise it deliberately when a consumer needs bigger pages.
+#[tokio::test]
+async fn app_can_raise_the_ceiling() {
+    let app = ViewSet::for_model(Note::SCHEMA)
+        .max_page_size(200)
+        .router_pool("/notes", pool_with_rows().await);
+    let n = count_returned(app, "/notes?page_size=200").await;
+    assert_eq!(n, 200, "a raised ceiling must be honoured");
+}
+
+/// `?limit=` must respect the same ceiling — otherwise limit/offset is an
+/// unbounded way around it.
+#[tokio::test]
+async fn limit_offset_respects_the_same_ceiling() {
+    let app = ViewSet::for_model(Note::SCHEMA)
+        .max_page_size(30)
+        .pagination(rustango::viewset::PaginationStyle::LimitOffset)
+        .router_pool("/notes", pool_with_rows().await);
+    let n = count_returned(app, "/notes?limit=1000").await;
+    assert_eq!(n, 30, "?limit= must clamp to max_page_size too");
+}
+
+/// A default larger than the ceiling can't smuggle a bigger page through the
+/// no-parameter path.
+#[tokio::test]
+async fn default_page_size_is_clamped_to_the_ceiling() {
+    let app = ViewSet::for_model(Note::SCHEMA)
+        .page_size(500)
+        .max_page_size(50)
+        .router_pool("/notes", pool_with_rows().await);
+    let n = count_returned(app, "/notes").await;
+    assert_eq!(n, 50, "the default must be clamped by the ceiling as well");
+}


### PR DESCRIPTION
Closes #1196.

`page_size(n)` set the *default*; the runtime clamp was `.min(1000)`, so any client could ask for 1000 rows regardless of what the app configured. An app sized around `page_size(20)` faced a **50× amplification** of its serializer, joins and response budget — and where the serializer does per-row work against the database, that is an N+1 becoming a thousand queries in a single request. Reachable by any authenticated caller.

### What changed

`max_page_size(n)` on the builder; the clamp uses it instead of 1000.

**Behaviour change:** the ceiling now defaults to **100**, matching `template_views`' existing `max_page_size`. The framework's two pagination surfaces previously disagreed by a factor of ten *and* differed in whether the ceiling was configurable at all — they now agree.

Two bypasses are closed as well:
- `?limit=` is bounded by the same value, so limit/offset isn't a way around it.
- a `page_size` larger than the ceiling is clamped, so it can't smuggle a bigger page through the no-parameter path.

### Tests

The amplification case (`?page_size=1000` → 100), lowering the ceiling, raising it deliberately, `?limit=` honouring it, and the oversized-default path. `limit_offset_clamps_hostile_bounds` encoded the old 1000 contract and was updated to the new one.

Gate: `cargo test --workspace --all-features --no-run` clean, clippy clean, pagination suites green.

### Upgrade note

An app that relied on clients requesting up to 1000 rows should add `.max_page_size(1000)` to restore the old bound.