### PR TITLE
feat(jwt)!: make JtiStore async so a durable store can just write (#1191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ Headline: **a `ViewSet` can finally be scoped to the caller** (#1183) — the
 authenticated identity is available to filter backends, backends apply to every
 action, and `OwnedBy` does the common case in one line.
 
+### Changed
+
+- **`JtiStore` is async** (#1191) — `is_used` / `mark_used` / `approx_size` now
+  return `JtiFuture<'_, T>`, and everything that consults the store is `async`
+  with it: `JwtLifecycle::{verify_token, verify_access, verify_refresh, refresh,
+  refresh_with, revoke, blacklist_jti, is_blacklisted, blacklist_size}`,
+  `mcp::verify_agent_token`, `tenancy::auth_routes::verify_for_tenant`, and
+  `tenancy::admin::redeem_impersonation_handoff`. While the trait was
+  synchronous, a durable multi-instance store could not simply write — it had to
+  be a hot in-memory map with a background flusher, which is eventually
+  consistent, so a revoked `jti` stayed valid on other replicas for the length
+  of the convergence window. Revocation is exactly the operation that should be
+  immediate, and that constraint came from the signature rather than the
+  problem; a Redis- or Postgres-backed store is now one conditional write.
+
+  **Migration:** add `.await` at those call sites. A synchronous
+  implementation stays a one-line wrapper —
+  `fn is_used<'a>(&'a self, jti: &'a str) -> JtiFuture<'a, bool> { Box::pin(async move { … }) }`.
+  The trait returns boxed futures rather than using `async fn`, because every
+  consumer holds it as `Arc<dyn JtiStore>` and native `async fn` in traits is
+  not dyn-compatible. Token **expiry is now checked before** the store is
+  consulted, so an expired token costs no round trip. `InMemoryJtiStore`
+  behaves exactly as before.
+
 ### Fixed
 
 - **ViewSet: 401 for anonymous, 403 for authenticated-but-unauthorised**

--- a/crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs
+++ b/crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs
@@ -15,46 +15,46 @@ fn jwt() -> JwtLifecycle {
     JwtLifecycle::new(b"a-signing-secret-at-least-32-bytes-long!!".to_vec())
 }
 
-#[test]
-fn login_issues_a_pair_and_the_token_types_are_distinct() {
+#[tokio::test]
+async fn login_issues_a_pair_and_the_token_types_are_distinct() {
     let j = jwt();
     let pair = j.issue_pair(42); // what POST /api/auth/login returns
 
-    let claims = j.verify_access(&pair.access).expect("access verifies");
+    let claims = j.verify_access(&pair.access).await.expect("access verifies");
     assert_eq!(claims.sub, 42);
     assert_eq!(claims.typ, "access");
 
     // An access token is rejected where a refresh is required, and vice versa —
     // so a stolen short-lived access token can't be used to mint new ones.
-    assert!(j.verify_refresh(&pair.access).is_none());
-    assert!(j.verify_access(&pair.refresh).is_none());
+    assert!(j.verify_refresh(&pair.access).await.is_none());
+    assert!(j.verify_access(&pair.refresh).await.is_none());
 }
 
-#[test]
-fn refresh_rotates_and_blacklists_the_old_refresh_token() {
+#[tokio::test]
+async fn refresh_rotates_and_blacklists_the_old_refresh_token() {
     let j = jwt();
     let pair = j.issue_pair(7);
 
-    let rotated = j.refresh(&pair.refresh).expect("POST /api/auth/refresh");
+    let rotated = j.refresh(&pair.refresh).await.expect("POST /api/auth/refresh");
     assert_ne!(pair.access, rotated.access);
-    assert_eq!(j.verify_access(&rotated.access).unwrap().sub, 7);
+    assert_eq!(j.verify_access(&rotated.access).await.unwrap().sub, 7);
 
     // Sliding refresh: the old refresh token is single-use — replay is rejected.
-    assert!(j.refresh(&pair.refresh).is_none());
+    assert!(j.refresh(&pair.refresh).await.is_none());
 }
 
-#[test]
-fn logout_revokes_the_token() {
+#[tokio::test]
+async fn logout_revokes_the_token() {
     let j = jwt();
     let pair = j.issue_pair(1);
-    assert!(j.verify_access(&pair.access).is_some());
+    assert!(j.verify_access(&pair.access).await.is_some());
 
-    assert!(j.revoke(&pair.access)); // what POST /api/auth/logout does
-    assert!(j.verify_access(&pair.access).is_none());
+    assert!(j.revoke(&pair.access).await); // what POST /api/auth/logout does
+    assert!(j.verify_access(&pair.access).await.is_none());
 }
 
-#[test]
-fn custom_claims_ride_in_the_token_and_survive_refresh() {
+#[tokio::test]
+async fn custom_claims_ride_in_the_token_and_survive_refresh() {
     let j = jwt();
     let custom = serde_json::json!({ "roles": ["admin"], "tenant": "acme" })
         .as_object()
@@ -62,7 +62,7 @@ fn custom_claims_ride_in_the_token_and_survive_refresh() {
         .clone();
 
     let pair = j.issue_pair_with(99, custom).unwrap();
-    let claims = j.verify_access(&pair.access).unwrap();
+    let claims = j.verify_access(&pair.access).await.unwrap();
     assert_eq!(
         claims.get_custom::<Vec<String>>("roles").unwrap(),
         vec!["admin".to_string()]
@@ -70,13 +70,13 @@ fn custom_claims_ride_in_the_token_and_survive_refresh() {
 
     // refresh() carries the same custom payload onto the new pair (use
     // refresh_with() to re-evaluate permissions instead).
-    let rotated = j.refresh(&pair.refresh).unwrap();
-    let rc = j.verify_access(&rotated.access).unwrap();
+    let rotated = j.refresh(&pair.refresh).await.unwrap();
+    let rc = j.verify_access(&rotated.access).await.unwrap();
     assert_eq!(rc.get_custom::<String>("tenant").as_deref(), Some("acme"));
 }
 
-#[test]
-fn revocation_is_visible_across_handles_via_a_shared_store() {
+#[tokio::test]
+async fn revocation_is_visible_across_handles_via_a_shared_store() {
     // The default in-memory store is single-process. In production pass a
     // Redis/DB-backed `JtiStore` so a logout on one replica is seen by all —
     // here two handles share one in-memory store to prove the wiring.
@@ -86,10 +86,10 @@ fn revocation_is_visible_across_handles_via_a_shared_store() {
     let b = JwtLifecycle::new(secret).with_jti_store(Arc::clone(&shared));
 
     let pair = a.issue_pair(5);
-    assert!(b.verify_access(&pair.access).is_some());
-    a.revoke(&pair.access);
+    assert!(b.verify_access(&pair.access).await.is_some());
+    a.revoke(&pair.access).await;
     assert!(
-        b.verify_access(&pair.access).is_none(),
+        b.verify_access(&pair.access).await.is_none(),
         "instance B must see the revocation made on instance A"
     );
 }

--- a/crates/rustango/src/jti_store.rs
+++ b/crates/rustango/src/jti_store.rs
@@ -31,17 +31,65 @@
 //! rustango.
 
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Mutex;
+
+/// Future returned by the [`JtiStore`] methods.
+///
+/// Boxed rather than an `async fn` in the trait because every consumer
+/// holds the store as `Arc<dyn JtiStore>`, and native `async fn` in traits
+/// is not dyn-compatible. This is exactly what `#[async_trait]` expands to;
+/// it's written out by hand so `jti_store` — a core, ungated module — keeps
+/// building under every feature combination, including
+/// `--no-default-features --features sqlite,tenancy`, where the optional
+/// `async-trait` dependency isn't compiled in.
+pub type JtiFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Storage backend for "this JTI is no longer valid" lookups.
 ///
 /// Implementations MUST make `mark_used` atomic — concurrent callers
 /// for the same `jti` must observe exactly one success (the rest
 /// must observe `false`), or the single-use guarantee is broken.
+///
+/// # Async since v0.52 (#1191)
+///
+/// The methods return futures so a store can simply `await` a database
+/// write. While the trait was synchronous, a durable store had to be a hot
+/// `RwLock<HashMap>` with a background flusher — eventually consistent, with
+/// a convergence window during which a revoked `jti` was still accepted on
+/// another instance. Revoking a token is precisely the operation you want to
+/// be durable and immediate, and that constraint came from this signature
+/// rather than from the problem.
+///
+/// A synchronous implementation stays trivial — wrap the body:
+///
+/// ```ignore
+/// impl JtiStore for MyStore {
+///     fn is_used<'a>(&'a self, jti: &'a str) -> JtiFuture<'a, bool> {
+///         Box::pin(async move { self.map.lock().unwrap().contains_key(jti) })
+///     }
+///     fn mark_used<'a>(&'a self, jti: &'a str, exp_unix: i64) -> JtiFuture<'a, bool> {
+///         Box::pin(async move { /* … */ true })
+///     }
+/// }
+/// ```
+///
+/// …and a durable one is now just a query:
+///
+/// ```ignore
+/// fn mark_used<'a>(&'a self, jti: &'a str, exp_unix: i64) -> JtiFuture<'a, bool> {
+///     Box::pin(async move {
+///         // INSERT … ON CONFLICT DO NOTHING — one round trip, atomic,
+///         // and visible to every instance immediately.
+///         rows_affected == 1
+///     })
+/// }
+/// ```
 pub trait JtiStore: Send + Sync {
     /// Returns `true` if `jti` has previously been marked used /
     /// blacklisted. Read-only; never mutates the store.
-    fn is_used(&self, jti: &str) -> bool;
+    fn is_used<'a>(&'a self, jti: &'a str) -> JtiFuture<'a, bool>;
 
     /// Atomically check + record. Returns `true` when the JTI was
     /// newly recorded (i.e. the caller is the first to "use" it);
@@ -49,7 +97,12 @@ pub trait JtiStore: Send + Sync {
     ///
     /// `exp_unix` is the JWT's `exp` claim (unix seconds). Stores
     /// MAY use it to prune entries that are no longer relevant.
-    fn mark_used(&self, jti: &str, exp_unix: i64) -> bool;
+    ///
+    /// The atomicity requirement is unchanged by being async: a durable
+    /// store should express it as a single conditional write (e.g.
+    /// `INSERT … ON CONFLICT DO NOTHING`, or Redis `SET NX`), not as a
+    /// read followed by a write.
+    fn mark_used<'a>(&'a self, jti: &'a str, exp_unix: i64) -> JtiFuture<'a, bool>;
 
     /// Approximate count of currently-tracked JTIs. Used by admin
     /// dashboards and tests; not on the hot path.
@@ -59,8 +112,8 @@ pub trait JtiStore: Send + Sync {
     /// a status display would be silly). Default impl returns
     /// `None` so trait objects don't have to know how to count.
     /// v0.48.
-    fn approx_size(&self) -> Option<usize> {
-        None
+    fn approx_size(&self) -> JtiFuture<'_, Option<usize>> {
+        Box::pin(async { None })
     }
 }
 
@@ -93,26 +146,32 @@ impl Default for InMemoryJtiStore {
 }
 
 impl JtiStore for InMemoryJtiStore {
-    fn is_used(&self, jti: &str) -> bool {
-        let map = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        map.contains_key(jti)
+    // Bodies stay synchronous — nothing is awaited, so the `std::sync::Mutex`
+    // guard never crosses a suspend point.
+    fn is_used<'a>(&'a self, jti: &'a str) -> JtiFuture<'a, bool> {
+        Box::pin(async move {
+            let map = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            map.contains_key(jti)
+        })
     }
 
-    fn mark_used(&self, jti: &str, exp_unix: i64) -> bool {
-        let mut map = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        // Prune expired entries opportunistically so memory stays
-        // bounded without a background sweeper.
-        let now = chrono::Utc::now().timestamp();
-        map.retain(|_, &mut e| e > now);
-        if map.contains_key(jti) {
-            return false;
-        }
-        map.insert(jti.to_owned(), exp_unix);
-        true
+    fn mark_used<'a>(&'a self, jti: &'a str, exp_unix: i64) -> JtiFuture<'a, bool> {
+        Box::pin(async move {
+            let mut map = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            // Prune expired entries opportunistically so memory stays
+            // bounded without a background sweeper.
+            let now = chrono::Utc::now().timestamp();
+            map.retain(|_, &mut e| e > now);
+            if map.contains_key(jti) {
+                return false;
+            }
+            map.insert(jti.to_owned(), exp_unix);
+            true
+        })
     }
 
-    fn approx_size(&self) -> Option<usize> {
-        Some(self.inner.lock().unwrap_or_else(|e| e.into_inner()).len())
+    fn approx_size(&self) -> JtiFuture<'_, Option<usize>> {
+        Box::pin(async move { Some(self.inner.lock().unwrap_or_else(|e| e.into_inner()).len()) })
     }
 }
 
@@ -120,44 +179,44 @@ impl JtiStore for InMemoryJtiStore {
 mod tests {
     use super::*;
 
-    #[test]
-    fn fresh_jti_is_not_used() {
+    #[tokio::test]
+    async fn fresh_jti_is_not_used() {
         let store = InMemoryJtiStore::new();
-        assert!(!store.is_used("token-1"));
+        assert!(!store.is_used("token-1").await);
     }
 
-    #[test]
-    fn first_mark_used_returns_true() {
+    #[tokio::test]
+    async fn first_mark_used_returns_true() {
         let store = InMemoryJtiStore::new();
         let exp = chrono::Utc::now().timestamp() + 60;
-        assert!(store.mark_used("token-1", exp));
-        assert!(store.is_used("token-1"));
+        assert!(store.mark_used("token-1", exp).await);
+        assert!(store.is_used("token-1").await);
     }
 
-    #[test]
-    fn second_mark_used_returns_false_single_use_guarantee() {
+    #[tokio::test]
+    async fn second_mark_used_returns_false_single_use_guarantee() {
         let store = InMemoryJtiStore::new();
         let exp = chrono::Utc::now().timestamp() + 60;
-        assert!(store.mark_used("token-1", exp));
+        assert!(store.mark_used("token-1", exp).await);
         assert!(
-            !store.mark_used("token-1", exp),
+            !store.mark_used("token-1", exp).await,
             "second use must return false to preserve single-use guard"
         );
     }
 
-    #[test]
-    fn distinct_jtis_dont_collide() {
+    #[tokio::test]
+    async fn distinct_jtis_dont_collide() {
         let store = InMemoryJtiStore::new();
         let exp = chrono::Utc::now().timestamp() + 60;
-        assert!(store.mark_used("token-a", exp));
-        assert!(store.mark_used("token-b", exp));
-        assert!(store.is_used("token-a"));
-        assert!(store.is_used("token-b"));
-        assert!(!store.is_used("token-c"));
+        assert!(store.mark_used("token-a", exp).await);
+        assert!(store.mark_used("token-b", exp).await);
+        assert!(store.is_used("token-a").await);
+        assert!(store.is_used("token-b").await);
+        assert!(!store.is_used("token-c").await);
     }
 
-    #[test]
-    fn expired_entries_are_pruned_on_next_mark() {
+    #[tokio::test]
+    async fn expired_entries_are_pruned_on_next_mark() {
         let store = InMemoryJtiStore::new();
         let already_expired = chrono::Utc::now().timestamp() - 60;
         // Pre-poison the store with an expired entry — we can't go
@@ -170,21 +229,61 @@ mod tests {
             .insert("stale".to_owned(), already_expired);
         assert_eq!(store.len(), 1);
         let fresh_exp = chrono::Utc::now().timestamp() + 60;
-        assert!(store.mark_used("fresh", fresh_exp));
+        assert!(store.mark_used("fresh", fresh_exp).await);
         // Pruning ran during `mark_used("fresh", …)` and removed
         // the expired `stale` entry. Now the map holds only `fresh`.
         assert_eq!(store.len(), 1);
-        assert!(!store.is_used("stale"));
-        assert!(store.is_used("fresh"));
+        assert!(!store.is_used("stale").await);
+        assert!(store.is_used("fresh").await);
     }
 
-    #[test]
-    fn trait_object_is_usable() {
+    #[tokio::test]
+    async fn trait_object_is_usable() {
         // Lock in the dyn-compatible contract — `Arc<dyn JtiStore>`
-        // is the shape every consumer takes.
+        // is the shape every consumer takes, and the reason the trait
+        // returns boxed futures rather than using `async fn` (#1191).
         let store: std::sync::Arc<dyn JtiStore> = std::sync::Arc::new(InMemoryJtiStore::new());
         let exp = chrono::Utc::now().timestamp() + 60;
-        assert!(store.mark_used("via-dyn", exp));
-        assert!(store.is_used("via-dyn"));
+        assert!(store.mark_used("via-dyn", exp).await);
+        assert!(store.is_used("via-dyn").await);
+    }
+
+    /// A store that actually awaits between the check and the record — the
+    /// shape a database-backed store has. `mark_used` must still be
+    /// single-use under concurrency, which is why the contract demands one
+    /// conditional write rather than read-then-write (#1191).
+    #[tokio::test]
+    async fn awaiting_store_keeps_the_single_use_guarantee() {
+        struct AwaitingStore(Mutex<HashMap<String, i64>>);
+        impl JtiStore for AwaitingStore {
+            fn is_used<'a>(&'a self, jti: &'a str) -> JtiFuture<'a, bool> {
+                Box::pin(async move {
+                    tokio::task::yield_now().await;
+                    self.0.lock().unwrap().contains_key(jti)
+                })
+            }
+            fn mark_used<'a>(&'a self, jti: &'a str, exp_unix: i64) -> JtiFuture<'a, bool> {
+                Box::pin(async move {
+                    tokio::task::yield_now().await;
+                    // Single conditional write, holding the lock across the
+                    // check and the insert.
+                    let mut map = self.0.lock().unwrap();
+                    if map.contains_key(jti) {
+                        return false;
+                    }
+                    map.insert(jti.to_owned(), exp_unix);
+                    true
+                })
+            }
+        }
+
+        let store: std::sync::Arc<dyn JtiStore> =
+            std::sync::Arc::new(AwaitingStore(Mutex::new(HashMap::new())));
+        let exp = chrono::Utc::now().timestamp() + 60;
+
+        // Two concurrent claims on the same jti: exactly one must win.
+        let (a, b) = tokio::join!(store.mark_used("race", exp), store.mark_used("race", exp));
+        assert!(a ^ b, "exactly one concurrent mark_used must succeed");
+        assert!(store.is_used("race").await);
     }
 }

--- a/crates/rustango/src/mcp/auth.rs
+++ b/crates/rustango/src/mcp/auth.rs
@@ -91,13 +91,16 @@ pub fn issue_agent_token(
 /// Verify an agent access token and pin it to `expected_tenant`. Returns
 /// the resolved [`McpAgent`], or `None` for any failure — bad signature,
 /// expired, revoked JTI, not an agent token, or wrong tenant. Fail-closed.
+///
+/// Async since v0.52 — the revoked-JTI check may consult a durable
+/// [`crate::jti_store::JtiStore`] (#1191).
 #[must_use]
-pub fn verify_agent_token(
+pub async fn verify_agent_token(
     jwt: &JwtLifecycle,
     token: &str,
     expected_tenant: &str,
 ) -> Option<McpAgent> {
-    let claims = jwt.verify_access(token)?;
+    let claims = jwt.verify_access(token).await?;
     if claims.get_custom::<String>(CLAIM_KIND).as_deref() != Some(KIND_AGENT) {
         return None;
     }
@@ -233,7 +236,7 @@ pub(crate) async fn post_authed(
     let Some(token) = bearer(&headers) else {
         return unauthorized(&headers, &uri);
     };
-    let Some(agent) = verify_agent_token(jwt, token, &t.org.slug) else {
+    let Some(agent) = verify_agent_token(jwt, token, &t.org.slug).await else {
         return unauthorized(&headers, &uri);
     };
     // Revocation immediacy: the JWT is stateless, so re-check at request time
@@ -365,8 +368,8 @@ mod tests {
     use super::*;
     use axum::http::Uri;
 
-    #[test]
-    fn token_round_trips_the_owning_user_id() {
+    #[tokio::test]
+    async fn token_round_trips_the_owning_user_id() {
         use crate::tenancy::jwt_lifecycle::JwtLifecycle;
         let jwt = JwtLifecycle::new(b"unit-secret-at-least-32-bytes-long!!".to_vec());
 
@@ -380,7 +383,9 @@ mod tests {
             Some(99),
         )
         .expect("issue");
-        let agent = verify_agent_token(&jwt, &token, "acme").expect("verify");
+        let agent = verify_agent_token(&jwt, &token, "acme")
+            .await
+            .expect("verify");
         assert_eq!(agent.agent_id, 5);
         assert_eq!(agent.user_id, Some(99));
         assert_eq!(agent.tools, vec!["log"]);
@@ -389,6 +394,7 @@ mod tests {
         let token = issue_agent_token(&jwt, 5, "acme", &[], &[], None).expect("issue");
         assert_eq!(
             verify_agent_token(&jwt, &token, "acme")
+                .await
                 .expect("verify")
                 .user_id,
             None

--- a/crates/rustango/src/mcp/transport.rs
+++ b/crates/rustango/src/mcp/transport.rs
@@ -103,7 +103,7 @@ pub(crate) async fn sse_handler(
     let Some(token) = super::auth::bearer(&headers) else {
         return super::auth::unauthorized(&headers, &uri);
     };
-    let Some(agent) = super::auth::verify_agent_token(jwt, token, &t.org.slug) else {
+    let Some(agent) = super::auth::verify_agent_token(jwt, token, &t.org.slug).await else {
         return super::auth::unauthorized(&headers, &uri);
     };
     // Revocation immediacy: re-check the agent (and, for a user-owned key, its

--- a/crates/rustango/src/tenancy/admin.rs
+++ b/crates/rustango/src/tenancy/admin.rs
@@ -446,6 +446,7 @@ where
         // `JtiBlacklist` so a leaked URL can't be replayed.
         if path == routes.impersonation_handoff_url && method == axum::http::Method::GET {
             return redeem_impersonation_handoff(&org, cfg, routes, parts.uri.query())
+                .await
                 .into_response();
         }
         // SSO (admin-sso) — multi-provider OpenID Connect / social OAuth.
@@ -1111,7 +1112,9 @@ fn logout_response(routes: &super::routes::RouteConfig) -> Response {
 /// operator console emits descriptive logs on the mint side, and
 /// leaking detail here would help an attacker tune a brute-force
 /// against the token format.
-fn redeem_impersonation_handoff(
+/// Async since v0.52 — marking the handoff jti single-use goes through the
+/// [`crate::jti_store::JtiStore`], which may be durable (#1191).
+async fn redeem_impersonation_handoff(
     org: &super::Org,
     cfg: &TenantSessionConfig,
     routes: &super::routes::RouteConfig,
@@ -1135,7 +1138,10 @@ fn redeem_impersonation_handoff(
             return (StatusCode::UNAUTHORIZED, "invalid token").into_response();
         }
     };
-    if let Err(e) = JtiBlacklist::shared().mark_used(&payload.jti, payload.exp) {
+    if let Err(e) = JtiBlacklist::shared()
+        .mark_used(&payload.jti, payload.exp)
+        .await
+    {
         tracing::warn!(
             target: "crate::tenancy::admin",
             slug = %org.slug,

--- a/crates/rustango/src/tenancy/auth_routes.rs
+++ b/crates/rustango/src/tenancy/auth_routes.rs
@@ -344,9 +344,12 @@ async fn refresh(
     // /refresh (they share the session secret) and rotated — burning A's
     // refresh token (a cross-tenant DoS / rotation oracle). Verify the
     // token's `tenant` claim matches this subdomain BEFORE rotating.
-    let claims = jwt_handle().verify_refresh(&body.refresh).ok_or_else(|| {
-        (StatusCode::UNAUTHORIZED, "invalid or expired refresh token").into_response()
-    })?;
+    let claims = jwt_handle()
+        .verify_refresh(&body.refresh)
+        .await
+        .ok_or_else(|| {
+            (StatusCode::UNAUTHORIZED, "invalid or expired refresh token").into_response()
+        })?;
     let tenant_ok =
         claims.custom_value("tenant").and_then(|v| v.as_str()) == Some(t.org.slug.as_str());
     if !tenant_ok {
@@ -378,7 +381,7 @@ async fn refresh(
             );
         }
     }
-    let pair = jwt_handle().refresh(&body.refresh).ok_or_else(|| {
+    let pair = jwt_handle().refresh(&body.refresh).await.ok_or_else(|| {
         (StatusCode::UNAUTHORIZED, "invalid or expired refresh token").into_response()
     })?;
     Ok(Json(RefreshOutput {
@@ -400,7 +403,7 @@ async fn logout(
     // signal. We don't reject on verify-failure here — the revoke
     // call below still runs, and a stale/expired token logout is a
     // valid audit event in its own right.
-    let claims = jwt_handle().verify_access(&bearer.0);
+    let claims = jwt_handle().verify_access(&bearer.0).await;
     // Audit N3 — if the token IS valid but bound to a DIFFERENT tenant,
     // don't let this subdomain's endpoint revoke it. (An unverifiable /
     // expired token falls through to a best-effort revoke as before.)
@@ -416,7 +419,7 @@ async fn logout(
     let user_id = claims.map(|c| c.sub);
     let meta = meta_from_headers(&headers, Some("/auth/logout"));
 
-    jwt_handle().revoke(&bearer.0);
+    jwt_handle().revoke(&bearer.0).await;
 
     send_user_logged_out(UserLoggedOutContext {
         source: "jwt",
@@ -436,9 +439,13 @@ async fn logout(
 /// would validate). Tokens without a `tenant` claim are rejected
 /// with 401 — they must have been minted by an old or external
 /// issuer that doesn't honor this contract.
-pub fn verify_for_tenant(bearer: &str, expected_slug: &str) -> Result<i64, &'static str> {
+///
+/// Async since v0.52 — the revocation check may consult a durable
+/// [`crate::jti_store::JtiStore`] (#1191).
+pub async fn verify_for_tenant(bearer: &str, expected_slug: &str) -> Result<i64, &'static str> {
     let claims = jwt_handle()
         .verify_access(bearer)
+        .await
         .ok_or("invalid or expired token")?;
     let claim_tenant = claims
         .custom_value("tenant")
@@ -465,6 +472,7 @@ async fn me(t: Tenant, bearer: Bearer) -> Result<Json<UserBrief>, Response> {
     use crate::tenancy::auth::User;
 
     let user_id = verify_for_tenant(&bearer.0, &t.org.slug)
+        .await
         .map_err(|msg| (StatusCode::UNAUTHORIZED, msg).into_response())?;
 
     let users = User::objects()
@@ -539,7 +547,7 @@ pub async fn require_bearer(
         return unauthorized("missing Bearer token");
     };
 
-    let user_id = match verify_for_tenant(token, &t.org.slug) {
+    let user_id = match verify_for_tenant(token, &t.org.slug).await {
         Ok(id) => id,
         // The reason is deliberately not echoed: "expired" vs "wrong tenant"
         // vs "revoked" tells a prober which of those they achieved.
@@ -644,8 +652,8 @@ mod tests {
         let _ = cfg.build_jwt();
     }
 
-    #[test]
-    fn config_uses_explicit_secret_when_set() {
+    #[tokio::test]
+    async fn config_uses_explicit_secret_when_set() {
         let cfg = Config {
             session_secret: Some(b"super-secret-key-for-tests-32b!!".to_vec()),
             ..Default::default()
@@ -653,7 +661,10 @@ mod tests {
         assert!(cfg.session_secret.as_ref().unwrap().len() >= 32);
         let jwt = cfg.build_jwt();
         let token = jwt.issue_pair(42);
-        let claims = jwt.verify_access(&token.access).expect("access valid");
+        let claims = jwt
+            .verify_access(&token.access)
+            .await
+            .expect("access valid");
         assert_eq!(claims.sub, 42);
     }
 

--- a/crates/rustango/src/tenancy/impersonation_handoff.rs
+++ b/crates/rustango/src/tenancy/impersonation_handoff.rs
@@ -237,16 +237,21 @@ impl JtiBlacklist {
     }
 
     /// Returns `true` if the jti was previously marked used.
-    pub fn is_used(&self, jti: &str) -> bool {
-        self.store.is_used(jti)
+    ///
+    /// Async since v0.52 — the store may be durable (#1191).
+    pub async fn is_used(&self, jti: &str) -> bool {
+        self.store.is_used(jti).await
     }
 
     /// Atomically check + record. Returns `Err(AlreadyUsed)` if the
     /// jti is in the store; otherwise inserts `(jti, exp)` and
     /// returns `Ok(())`. Pruning of expired entries is the store's
     /// responsibility — the in-memory impl does it on every call.
-    pub fn mark_used(&self, jti: &str, exp: i64) -> Result<(), HandoffError> {
-        if self.store.mark_used(jti, exp) {
+    ///
+    /// Async since v0.52 — a single-use handoff redemption is exactly the
+    /// operation that wants a durable, immediately-visible write (#1191).
+    pub async fn mark_used(&self, jti: &str, exp: i64) -> Result<(), HandoffError> {
+        if self.store.mark_used(jti, exp).await {
             Ok(())
         } else {
             Err(HandoffError::AlreadyUsed)
@@ -353,21 +358,21 @@ mod tests {
         assert_ne!(p1.jti, p2.jti, "random jti collision is unacceptable");
     }
 
-    #[test]
-    fn jti_blacklist_first_use_succeeds_second_fails() {
+    #[tokio::test]
+    async fn jti_blacklist_first_use_succeeds_second_fails() {
         let bl = JtiBlacklist::new();
         let jti = "abc123";
         let exp = chrono::Utc::now().timestamp() + 60;
-        bl.mark_used(jti, exp).unwrap();
-        assert!(bl.is_used(jti));
+        bl.mark_used(jti, exp).await.unwrap();
+        assert!(bl.is_used(jti).await);
         assert_eq!(
-            bl.mark_used(jti, exp).unwrap_err(),
+            bl.mark_used(jti, exp).await.unwrap_err(),
             HandoffError::AlreadyUsed
         );
     }
 
-    #[test]
-    fn jti_blacklist_with_store_delegates_to_swapped_backend() {
+    #[tokio::test]
+    async fn jti_blacklist_with_store_delegates_to_swapped_backend() {
         // v0.47 — proves the multi-instance hook: an Arc<dyn JtiStore>
         // passed via `with_store` is the source of truth, not the
         // default in-memory map. Two JtiBlacklist handles built from
@@ -380,13 +385,13 @@ mod tests {
         let bl_b = JtiBlacklist::with_store(Arc::clone(&shared));
         let jti = "shared-token";
         let exp = chrono::Utc::now().timestamp() + 60;
-        bl_a.mark_used(jti, exp).unwrap();
+        bl_a.mark_used(jti, exp).await.unwrap();
         assert!(
-            bl_b.is_used(jti),
+            bl_b.is_used(jti).await,
             "second handle on the shared store must see the mark"
         );
         assert_eq!(
-            bl_b.mark_used(jti, exp).unwrap_err(),
+            bl_b.mark_used(jti, exp).await.unwrap_err(),
             HandoffError::AlreadyUsed,
             "single-use guard must hold across handles on the shared store"
         );

--- a/crates/rustango/src/tenancy/jwt_lifecycle.rs
+++ b/crates/rustango/src/tenancy/jwt_lifecycle.rs
@@ -218,9 +218,12 @@ impl JwtLifecycle {
 
     /// Verify an access token. Returns the claims on success, `None` if
     /// invalid, expired, blacklisted, or wrong type.
+    ///
+    /// Async since v0.52 — the revocation check consults the
+    /// [`crate::jti_store::JtiStore`], which may be a durable backend (#1191).
     #[must_use]
-    pub fn verify_access(&self, token: &str) -> Option<JwtClaims> {
-        let claims = self.verify_token(token)?;
+    pub async fn verify_access(&self, token: &str) -> Option<JwtClaims> {
+        let claims = self.verify_token(token).await?;
         if claims.typ != ACCESS_TYP {
             return None;
         }
@@ -229,9 +232,11 @@ impl JwtLifecycle {
 
     /// Verify a refresh token. Returns the claims on success, `None` if
     /// invalid, expired, blacklisted, or wrong type.
+    ///
+    /// Async since v0.52 — see [`Self::verify_access`].
     #[must_use]
-    pub fn verify_refresh(&self, token: &str) -> Option<JwtClaims> {
-        let claims = self.verify_token(token)?;
+    pub async fn verify_refresh(&self, token: &str) -> Option<JwtClaims> {
+        let claims = self.verify_token(token).await?;
         if claims.typ != REFRESH_TYP {
             return None;
         }
@@ -249,11 +254,11 @@ impl JwtLifecycle {
     ///
     /// Returns `None` if the refresh token is invalid, expired, or already
     /// blacklisted.
-    pub fn refresh(&self, refresh_token: &str) -> Option<JwtTokenPair> {
-        let claims = self.verify_refresh(refresh_token)?;
+    pub async fn refresh(&self, refresh_token: &str) -> Option<JwtTokenPair> {
+        let claims = self.verify_refresh(refresh_token).await?;
         // Rotate: blacklist the old refresh, issue a new pair carrying the
         // same custom payload (preserves `scope` / `roles` / `tenant`).
-        self.blacklist_jti(&claims.jti, claims.exp);
+        self.blacklist_jti(&claims.jti, claims.exp).await;
         // Safe to unwrap — the custom claims came from a token we ourselves
         // issued, so they can't contain reserved names (issue_pair_with
         // already rejected those at original issuance).
@@ -269,26 +274,26 @@ impl JwtLifecycle {
     /// # Errors
     /// [`JwtIssueError::ReservedClaim`] if `new_custom` overlaps reserved names.
     /// Returns `Ok(None)` if the refresh token is invalid / expired / blacklisted.
-    pub fn refresh_with(
+    pub async fn refresh_with(
         &self,
         refresh_token: &str,
         new_custom: serde_json::Map<String, serde_json::Value>,
     ) -> Result<Option<JwtTokenPair>, JwtIssueError> {
-        let Some(claims) = self.verify_refresh(refresh_token) else {
+        let Some(claims) = self.verify_refresh(refresh_token).await else {
             return Ok(None);
         };
-        self.blacklist_jti(&claims.jti, claims.exp);
+        self.blacklist_jti(&claims.jti, claims.exp).await;
         self.issue_pair_with(claims.sub, new_custom).map(Some)
     }
 
     /// Revoke a token by adding its JTI to the blacklist. Subsequent
     /// `verify_*` calls for this token will return `None` until the
     /// token's natural expiry passes.
-    pub fn revoke(&self, token: &str) -> bool {
+    pub async fn revoke(&self, token: &str) -> bool {
         let Some(claims) = self.decode_unchecked(token) else {
             return false;
         };
-        self.blacklist_jti(&claims.jti, claims.exp);
+        self.blacklist_jti(&claims.jti, claims.exp).await;
         true
     }
 
@@ -296,8 +301,8 @@ impl JwtLifecycle {
     /// / monitoring). Stores that don't cheaply expose a count
     /// (e.g. a Redis-backed [`JtiStore`]) return 0. v0.48.
     #[must_use]
-    pub fn blacklist_size(&self) -> usize {
-        self.jti_store.approx_size().unwrap_or(0)
+    pub async fn blacklist_size(&self) -> usize {
+        self.jti_store.approx_size().await.unwrap_or(0)
     }
 
     // ------------------------------------------------------------------ internals
@@ -331,14 +336,15 @@ impl JwtLifecycle {
         format!("{payload_b64}.{sig_b64}")
     }
 
-    fn verify_token(&self, token: &str) -> Option<JwtClaims> {
+    async fn verify_token(&self, token: &str) -> Option<JwtClaims> {
         let claims = self.decode_unchecked(token)?;
-        // Expiry
+        // Expiry — checked before the store, so an expired token never costs
+        // a round trip to a durable backend.
         if chrono::Utc::now().timestamp() >= claims.exp {
             return None;
         }
         // Blacklist
-        if self.is_blacklisted(&claims.jti) {
+        if self.is_blacklisted(&claims.jti).await {
             return None;
         }
         Some(claims)
@@ -389,24 +395,29 @@ impl JwtLifecycle {
         mac.finalize().into_bytes().to_vec()
     }
 
-    fn blacklist_jti(&self, jti: &str, expires_at: i64) {
+    async fn blacklist_jti(&self, jti: &str, expires_at: i64) {
         // v0.48 — delegate to the pluggable JtiStore. We ignore the
         // returned `bool` (newly-inserted vs already-present) because
         // re-revoking an already-revoked token is idempotent here:
         // either way the JTI is in the store on return. Pruning is
         // the store's responsibility (`InMemoryJtiStore` does it
         // opportunistically inside `mark_used`).
-        let _ = self.jti_store.mark_used(jti, expires_at);
+        //
+        // v0.52 (#1191) — awaited, so a durable store writes the revocation
+        // before we return. Previously the trait was sync, which forced
+        // durable stores into a write-behind cache with a window where a
+        // revoked token was still accepted on another instance.
+        let _ = self.jti_store.mark_used(jti, expires_at).await;
     }
 
-    fn is_blacklisted(&self, jti: &str) -> bool {
+    async fn is_blacklisted(&self, jti: &str) -> bool {
         // v0.48 — `JtiStore::is_used` doesn't filter by the entry's
         // expiry the way the pre-v0.48 in-line map did. That's a
         // tighter behaviour (a revoked-but-not-yet-pruned JTI stays
         // unusable for slightly longer), and harmless: the token
         // verify path rejects expired tokens before this check is
         // ever consulted.
-        self.jti_store.is_used(jti)
+        self.jti_store.is_used(jti).await
     }
 }
 
@@ -440,78 +451,84 @@ mod tests {
         JwtLifecycle::new(b"test-secret".to_vec())
     }
 
-    #[test]
-    fn issue_and_verify_access() {
+    #[tokio::test]
+    async fn issue_and_verify_access() {
         let j = jwt();
         let pair = j.issue_pair(42);
-        let claims = j.verify_access(&pair.access).expect("access verifies");
+        let claims = j
+            .verify_access(&pair.access)
+            .await
+            .expect("access verifies");
         assert_eq!(claims.sub, 42);
         assert_eq!(claims.typ, "access");
         assert!(!claims.jti.is_empty());
     }
 
-    #[test]
-    fn issue_and_verify_refresh() {
+    #[tokio::test]
+    async fn issue_and_verify_refresh() {
         let j = jwt();
         let pair = j.issue_pair(42);
-        let claims = j.verify_refresh(&pair.refresh).expect("refresh verifies");
+        let claims = j
+            .verify_refresh(&pair.refresh)
+            .await
+            .expect("refresh verifies");
         assert_eq!(claims.sub, 42);
         assert_eq!(claims.typ, "refresh");
     }
 
-    #[test]
-    fn access_token_rejected_as_refresh() {
+    #[tokio::test]
+    async fn access_token_rejected_as_refresh() {
         let j = jwt();
         let pair = j.issue_pair(1);
-        assert!(j.verify_refresh(&pair.access).is_none());
+        assert!(j.verify_refresh(&pair.access).await.is_none());
     }
 
-    #[test]
-    fn refresh_token_rejected_as_access() {
+    #[tokio::test]
+    async fn refresh_token_rejected_as_access() {
         let j = jwt();
         let pair = j.issue_pair(1);
-        assert!(j.verify_access(&pair.refresh).is_none());
+        assert!(j.verify_access(&pair.refresh).await.is_none());
     }
 
-    #[test]
-    fn refresh_returns_new_pair() {
+    #[tokio::test]
+    async fn refresh_returns_new_pair() {
         let j = jwt();
         let pair = j.issue_pair(7);
-        let new_pair = j.refresh(&pair.refresh).expect("refresh succeeds");
+        let new_pair = j.refresh(&pair.refresh).await.expect("refresh succeeds");
         assert_ne!(pair.access, new_pair.access);
         assert_ne!(pair.refresh, new_pair.refresh);
 
-        let claims = j.verify_access(&new_pair.access).unwrap();
+        let claims = j.verify_access(&new_pair.access).await.unwrap();
         assert_eq!(claims.sub, 7);
     }
 
-    #[test]
-    fn refresh_blacklists_old_refresh_token() {
+    #[tokio::test]
+    async fn refresh_blacklists_old_refresh_token() {
         let j = jwt();
         let pair = j.issue_pair(7);
-        let _new = j.refresh(&pair.refresh).unwrap();
+        let _new = j.refresh(&pair.refresh).await.unwrap();
         // The old refresh token can no longer be used.
-        assert!(j.refresh(&pair.refresh).is_none());
-        assert!(j.verify_refresh(&pair.refresh).is_none());
+        assert!(j.refresh(&pair.refresh).await.is_none());
+        assert!(j.verify_refresh(&pair.refresh).await.is_none());
     }
 
-    #[test]
-    fn revoke_invalidates_access_token() {
+    #[tokio::test]
+    async fn revoke_invalidates_access_token() {
         let j = jwt();
         let pair = j.issue_pair(1);
-        assert!(j.verify_access(&pair.access).is_some());
-        assert!(j.revoke(&pair.access));
-        assert!(j.verify_access(&pair.access).is_none());
+        assert!(j.verify_access(&pair.access).await.is_some());
+        assert!(j.revoke(&pair.access).await);
+        assert!(j.verify_access(&pair.access).await.is_none());
     }
 
-    #[test]
-    fn revoke_invalid_token_returns_false() {
+    #[tokio::test]
+    async fn revoke_invalid_token_returns_false() {
         let j = jwt();
-        assert!(!j.revoke("not-a-valid-token"));
+        assert!(!j.revoke("not-a-valid-token").await);
     }
 
-    #[test]
-    fn tampered_signature_fails_verification() {
+    #[tokio::test]
+    async fn tampered_signature_fails_verification() {
         let j = jwt();
         let pair = j.issue_pair(1);
         let mut bytes = pair.access.into_bytes();
@@ -519,24 +536,24 @@ mod tests {
         let last = bytes.len() - 1;
         bytes[last] ^= 0x01;
         let tampered = String::from_utf8(bytes).unwrap();
-        assert!(j.verify_access(&tampered).is_none());
+        assert!(j.verify_access(&tampered).await.is_none());
     }
 
-    #[test]
-    fn wrong_secret_fails_verification() {
+    #[tokio::test]
+    async fn wrong_secret_fails_verification() {
         let j1 = jwt();
         let j2 = JwtLifecycle::new(b"different-secret".to_vec());
         let pair = j1.issue_pair(5);
-        assert!(j2.verify_access(&pair.access).is_none());
+        assert!(j2.verify_access(&pair.access).await.is_none());
     }
 
-    #[test]
-    fn unique_jti_per_issuance() {
+    #[tokio::test]
+    async fn unique_jti_per_issuance() {
         let j = jwt();
         let pair1 = j.issue_pair(1);
         let pair2 = j.issue_pair(1);
-        let c1 = j.verify_access(&pair1.access).unwrap();
-        let c2 = j.verify_access(&pair2.access).unwrap();
+        let c1 = j.verify_access(&pair1.access).await.unwrap();
+        let c2 = j.verify_access(&pair2.access).await.unwrap();
         assert_ne!(c1.jti, c2.jti);
     }
 
@@ -555,8 +572,8 @@ mod tests {
         value.as_object().unwrap().clone()
     }
 
-    #[test]
-    fn issue_pair_with_embeds_custom_claims() {
+    #[tokio::test]
+    async fn issue_pair_with_embeds_custom_claims() {
         let j = jwt();
         let pair = j
             .issue_pair_with(
@@ -564,7 +581,7 @@ mod tests {
                 map(serde_json::json!({"roles": ["admin", "editor"], "tenant": "acme"})),
             )
             .unwrap();
-        let claims = j.verify_access(&pair.access).unwrap();
+        let claims = j.verify_access(&pair.access).await.unwrap();
         assert_eq!(claims.sub, 42);
         let roles: Vec<String> = claims.get_custom("roles").unwrap();
         assert_eq!(roles, vec!["admin", "editor"]);
@@ -572,11 +589,11 @@ mod tests {
         assert_eq!(tenant, "acme");
     }
 
-    #[test]
-    fn issue_pair_no_custom_returns_empty_custom_map() {
+    #[tokio::test]
+    async fn issue_pair_no_custom_returns_empty_custom_map() {
         let j = jwt();
         let pair = j.issue_pair(7);
-        let claims = j.verify_access(&pair.access).unwrap();
+        let claims = j.verify_access(&pair.access).await.unwrap();
         assert!(claims.custom.is_empty());
         let missing: Option<String> = claims.get_custom("anything");
         assert!(missing.is_none());
@@ -595,8 +612,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn refresh_preserves_custom_claims() {
+    #[tokio::test]
+    async fn refresh_preserves_custom_claims() {
         let j = jwt();
         let pair = j
             .issue_pair_with(
@@ -604,10 +621,10 @@ mod tests {
                 map(serde_json::json!({"scope": "read:posts write:posts"})),
             )
             .unwrap();
-        let new_pair = j.refresh(&pair.refresh).unwrap();
+        let new_pair = j.refresh(&pair.refresh).await.unwrap();
 
-        let new_access_claims = j.verify_access(&new_pair.access).unwrap();
-        let new_refresh_claims = j.verify_refresh(&new_pair.refresh).unwrap();
+        let new_access_claims = j.verify_access(&new_pair.access).await.unwrap();
+        let new_refresh_claims = j.verify_refresh(&new_pair.refresh).await.unwrap();
 
         assert_eq!(new_access_claims.sub, 7);
         let scope: String = new_access_claims.get_custom("scope").unwrap();
@@ -618,8 +635,8 @@ mod tests {
         assert_eq!(scope_r, "read:posts write:posts");
     }
 
-    #[test]
-    fn refresh_with_substitutes_new_custom_claims() {
+    #[tokio::test]
+    async fn refresh_with_substitutes_new_custom_claims() {
         let j = jwt();
         let pair = j
             .issue_pair_with(7, map(serde_json::json!({"roles": ["admin"]})))
@@ -627,64 +644,68 @@ mod tests {
         // Role got revoked since login — issue new pair with downgraded scope
         let new_pair = j
             .refresh_with(&pair.refresh, map(serde_json::json!({"roles": ["viewer"]})))
+            .await
             .unwrap()
             .unwrap();
 
-        let claims = j.verify_access(&new_pair.access).unwrap();
+        let claims = j.verify_access(&new_pair.access).await.unwrap();
         let roles: Vec<String> = claims.get_custom("roles").unwrap();
         assert_eq!(roles, vec!["viewer"]);
     }
 
-    #[test]
-    fn refresh_with_invalid_token_returns_ok_none() {
+    #[tokio::test]
+    async fn refresh_with_invalid_token_returns_ok_none() {
         let j = jwt();
         let r = j
             .refresh_with("not-a-token", map(serde_json::json!({})))
+            .await
             .unwrap();
         assert!(r.is_none());
     }
 
-    #[test]
-    fn refresh_with_rejects_reserved_claims() {
+    #[tokio::test]
+    async fn refresh_with_rejects_reserved_claims() {
         let j = jwt();
         let pair = j.issue_pair(1);
-        let r = j.refresh_with(&pair.refresh, map(serde_json::json!({"sub": 999})));
+        let r = j
+            .refresh_with(&pair.refresh, map(serde_json::json!({"sub": 999})))
+            .await;
         assert!(matches!(r, Err(JwtIssueError::ReservedClaim(_))));
     }
 
-    #[test]
-    fn issue_access_with_returns_single_token() {
+    #[tokio::test]
+    async fn issue_access_with_returns_single_token() {
         let j = jwt();
         let token = j
             .issue_access_with(42, map(serde_json::json!({"key_id": "abc"})))
             .unwrap();
-        let claims = j.verify_access(&token).unwrap();
+        let claims = j.verify_access(&token).await.unwrap();
         assert_eq!(claims.sub, 42);
         assert_eq!(claims.typ, "access");
         let key_id: String = claims.get_custom("key_id").unwrap();
         assert_eq!(key_id, "abc");
     }
 
-    #[test]
-    fn custom_value_returns_raw_json() {
+    #[tokio::test]
+    async fn custom_value_returns_raw_json() {
         let j = jwt();
         let token = j
             .issue_access_with(1, map(serde_json::json!({"nested": {"x": 1}})))
             .unwrap();
-        let claims = j.verify_access(&token).unwrap();
+        let claims = j.verify_access(&token).await.unwrap();
         let raw = claims.custom_value("nested").unwrap();
         assert_eq!(raw["x"], 1);
     }
 
-    #[test]
-    fn refresh_blacklists_old_refresh_even_with_custom_claims() {
+    #[tokio::test]
+    async fn refresh_blacklists_old_refresh_even_with_custom_claims() {
         let j = jwt();
         let pair = j
             .issue_pair_with(7, map(serde_json::json!({"role": "admin"})))
             .unwrap();
-        let _new = j.refresh(&pair.refresh).unwrap();
+        let _new = j.refresh(&pair.refresh).await.unwrap();
         // Original refresh token can no longer be used
-        assert!(j.refresh(&pair.refresh).is_none());
+        assert!(j.refresh(&pair.refresh).await.is_none());
     }
 
     // v0.48 — `with_jti_store` lets two JwtLifecycle handles share
@@ -696,8 +717,8 @@ mod tests {
     // wired. A Redis-backed JtiStore in production gives the same
     // semantics across actual replicas.
 
-    #[test]
-    fn shared_jti_store_makes_revoke_visible_across_handles() {
+    #[tokio::test]
+    async fn shared_jti_store_makes_revoke_visible_across_handles() {
         use crate::jti_store::{InMemoryJtiStore, JtiStore};
         let secret = b"shared-test-secret-32-bytes-long".to_vec();
         let shared: std::sync::Arc<dyn JtiStore> = std::sync::Arc::new(InMemoryJtiStore::new());
@@ -707,35 +728,35 @@ mod tests {
 
         let pair = j_a.issue_pair(7);
         // Both instances accept the token before revocation.
-        assert!(j_a.verify_access(&pair.access).is_some());
-        assert!(j_b.verify_access(&pair.access).is_some());
+        assert!(j_a.verify_access(&pair.access).await.is_some());
+        assert!(j_b.verify_access(&pair.access).await.is_some());
 
         // Revoke on A.
-        assert!(j_a.revoke(&pair.access));
+        assert!(j_a.revoke(&pair.access).await);
 
         // B must now reject the token even though revocation
         // happened on A. The shared store is the single source of
         // truth.
         assert!(
-            j_a.verify_access(&pair.access).is_none(),
+            j_a.verify_access(&pair.access).await.is_none(),
             "instance A must reject its own revoked token"
         );
         assert!(
-            j_b.verify_access(&pair.access).is_none(),
+            j_b.verify_access(&pair.access).await.is_none(),
             "instance B must see the revocation from A via the shared store"
         );
     }
 
-    #[test]
-    fn blacklist_size_uses_jti_store_approx_size() {
+    #[tokio::test]
+    async fn blacklist_size_uses_jti_store_approx_size() {
         // Confirms blacklist_size delegates to JtiStore::approx_size
         // rather than peeking at a private map.
         let j = jwt();
-        assert_eq!(j.blacklist_size(), 0);
+        assert_eq!(j.blacklist_size().await, 0);
         let pair = j.issue_pair(1);
-        j.revoke(&pair.access);
-        assert_eq!(j.blacklist_size(), 1);
-        j.revoke(&pair.refresh);
-        assert_eq!(j.blacklist_size(), 2);
+        j.revoke(&pair.access).await;
+        assert_eq!(j.blacklist_size().await, 1);
+        j.revoke(&pair.refresh).await;
+        assert_eq!(j.blacklist_size().await, 2);
     }
 }

--- a/crates/rustango/tests/mcp_doc.rs
+++ b/crates/rustango/tests/mcp_doc.rs
@@ -145,7 +145,9 @@ async fn agent_lists_and_calls_only_its_granted_tools() {
     let token = issue_agent_token(&jwt, agent_id, "acme", &skills, &tools, None).unwrap();
 
     // The guarded endpoint verifies the token on every request (tenant-pinned).
-    let agent = verify_agent_token(&jwt, &token, "acme").expect("valid agent token");
+    let agent = verify_agent_token(&jwt, &token, "acme")
+        .await
+        .expect("valid agent token");
 
     // tools/list shows ONLY the granted tool, with its JSON Schema.
     let listed = list_tools(&agent);

--- a/crates/rustango/tests/mcp_e2e_sqlite_live.rs
+++ b/crates/rustango/tests/mcp_e2e_sqlite_live.rs
@@ -127,7 +127,9 @@ async fn full_agent_loop() {
     let token = issue_agent_token(&jwt, agent_id, "acme", &skills, &tools, None).expect("issue");
 
     // 6. Verify the token (what the guarded endpoint does each request).
-    let agent = verify_agent_token(&jwt, &token, "acme").expect("verify");
+    let agent = verify_agent_token(&jwt, &token, "acme")
+        .await
+        .expect("verify");
     assert_eq!(agent.tools, vec!["echo"]);
 
     // 7. tools/list shows only the granted tool.

--- a/crates/rustango/tests/mcp_slice2.rs
+++ b/crates/rustango/tests/mcp_slice2.rs
@@ -119,7 +119,9 @@ fn jwt() -> Arc<JwtLifecycle> {
 async fn token_issue_and_verify_within_tenant() {
     let jwt = jwt();
     let token = rustango::mcp::issue_agent_token(&jwt, 42, "acme", &[], &[], None).expect("issue");
-    let agent = rustango::mcp::verify_agent_token(&jwt, &token, "acme").expect("verify");
+    let agent = rustango::mcp::verify_agent_token(&jwt, &token, "acme")
+        .await
+        .expect("verify");
     assert_eq!(agent.agent_id, 42);
     assert_eq!(agent.tenant, "acme");
     assert!(!agent.jti.is_empty());
@@ -130,16 +132,25 @@ async fn token_for_other_tenant_is_rejected() {
     let jwt = jwt();
     let token = rustango::mcp::issue_agent_token(&jwt, 42, "acme", &[], &[], None).expect("issue");
     // Same valid signature, wrong tenant → refused (cross-tenant replay).
-    assert!(rustango::mcp::verify_agent_token(&jwt, &token, "evilcorp").is_none());
+    assert!(rustango::mcp::verify_agent_token(&jwt, &token, "evilcorp")
+        .await
+        .is_none());
 }
 
 #[tokio::test]
 async fn revoked_token_is_refused() {
     let jwt = jwt();
     let token = rustango::mcp::issue_agent_token(&jwt, 7, "acme", &[], &[], None).expect("issue");
-    assert!(rustango::mcp::verify_agent_token(&jwt, &token, "acme").is_some());
-    assert!(jwt.revoke(&token), "revoke decodes + blacklists the jti");
-    assert!(rustango::mcp::verify_agent_token(&jwt, &token, "acme").is_none());
+    assert!(rustango::mcp::verify_agent_token(&jwt, &token, "acme")
+        .await
+        .is_some());
+    assert!(
+        jwt.revoke(&token).await,
+        "revoke decodes + blacklists the jti"
+    );
+    assert!(rustango::mcp::verify_agent_token(&jwt, &token, "acme")
+        .await
+        .is_none());
 }
 
 #[tokio::test]
@@ -149,5 +160,7 @@ async fn non_agent_token_is_refused() {
     let plain = jwt
         .issue_access_with(1, serde_json::Map::new())
         .expect("issue plain");
-    assert!(rustango::mcp::verify_agent_token(&jwt, &plain, "acme").is_none());
+    assert!(rustango::mcp::verify_agent_token(&jwt, &plain, "acme")
+        .await
+        .is_none());
 }

--- a/crates/rustango/tests/mcp_user_keys_sqlite_live.rs
+++ b/crates/rustango/tests/mcp_user_keys_sqlite_live.rs
@@ -179,7 +179,9 @@ async fn permission_grants_flow_into_a_user_key() {
     ));
     let token =
         issue_agent_token(&jwt, agent_id, "acme", &skills, &tools, Some(uid)).expect("issue");
-    let agent = verify_agent_token(&jwt, &token, "acme").expect("verify");
+    let agent = verify_agent_token(&jwt, &token, "acme")
+        .await
+        .expect("verify");
     assert_eq!(agent.user_id, Some(uid));
     assert_eq!(agent.tools, vec!["coach_log"]);
 

--- a/docs/api-conventions.md
+++ b/docs/api-conventions.md
@@ -79,7 +79,7 @@ A method's return type tells you how it can fail. Rust has no exceptions, so fai
 
 **`Option<T>`** — either a value (`Some`) or nothing (`None`), like a nullable field. Use it when "nothing found" is a normal outcome and you don't need an error message explaining why:
 - Lookups: `cache.get(k) -> Result<Option<String>, _>` (the `Result` covers I/O failure; the `Option` covers "key not present")
-- Verification: `JwtLifecycle::verify_access(token) -> Option<Claims>` ("expired or invalid" is an expected outcome, so `None` is enough)
+- Verification: `async JwtLifecycle::verify_access(token) -> Option<Claims>` ("expired or invalid" is an expected outcome, so `None` is enough)
 - Optional config reads: `env::optional("FOO") -> Result<Option<T>, _>`
 
 **`bool`** — a plain yes/no when no further detail is needed:

--- a/docs/auth-jwt-api.md
+++ b/docs/auth-jwt-api.md
@@ -98,7 +98,7 @@ let pair = jwt.issue_pair(user_id);
 // → pair.refresh (long TTL, store in an HttpOnly cookie / secure storage)
 
 // Authenticated request: verify the access token.
-match jwt.verify_access(&access) {
+match jwt.verify_access(&access).await {
     Some(claims) => { /* claims.sub is the user id */ }
     None => { /* 401: invalid, expired, revoked, or wrong type */ }
 }
@@ -110,8 +110,8 @@ used to mint new ones:
 
 ```rust
 let pair = jwt.issue_pair(42);
-assert!(jwt.verify_refresh(&pair.access).is_none());
-assert!(jwt.verify_access(&pair.refresh).is_none());
+assert!(jwt.verify_refresh(&pair.access).await.is_none());
+assert!(jwt.verify_access(&pair.refresh).await.is_none());
 ```
 
 ---
@@ -124,9 +124,9 @@ of the old one is rejected):
 
 ```rust
 let pair = jwt.issue_pair(7);
-let rotated = jwt.refresh(&pair.refresh).expect("refresh ok");
+let rotated = jwt.refresh(&pair.refresh).await.expect("refresh ok");
 assert_ne!(pair.access, rotated.access);
-assert!(jwt.refresh(&pair.refresh).is_none());   // old refresh is now dead
+assert!(jwt.refresh(&pair.refresh).await.is_none());   // old refresh is now dead
 ```
 
 By default `refresh` **preserves** the token's custom claims. If permissions may
@@ -143,8 +143,8 @@ Each token carries a unique `jti`. `revoke` adds it to a blacklist so subsequent
 
 ```rust
 let pair = jwt.issue_pair(1);
-assert!(jwt.revoke(&pair.access));
-assert!(jwt.verify_access(&pair.access).is_none());
+assert!(jwt.revoke(&pair.access).await);
+assert!(jwt.verify_access(&pair.access).await.is_none());
 ```
 
 The blacklist lives in a pluggable `JtiStore`. The default `InMemoryJtiStore` is
@@ -161,13 +161,49 @@ let a = JwtLifecycle::new(secret.clone()).with_jti_store(Arc::clone(&shared));
 let b = JwtLifecycle::new(secret).with_jti_store(Arc::clone(&shared));
 
 let pair = a.issue_pair(5);
-a.revoke(&pair.access);
-assert!(b.verify_access(&pair.access).is_none());   // B sees A's revocation
+a.revoke(&pair.access).await;
+assert!(b.verify_access(&pair.access).await.is_none());   // B sees A's revocation
 ```
 
 > Without a shared store, `/logout` is best-effort: a revoked token may still be
 > accepted on another replica until its natural expiry. This is the single most
 > important production setting for JWT auth.
+
+### Writing a durable store
+
+`JtiStore` is async (since v0.52, #1191), so a durable implementation is one
+query — no background flusher, no convergence window during which a revoked
+`jti` is still accepted elsewhere. Both methods return
+`JtiFuture<'_, T>` (a boxed future — the trait is used as `Arc<dyn JtiStore>`,
+and native `async fn` in traits is not dyn-compatible):
+
+```rust
+use rustango::jti_store::{JtiFuture, JtiStore};
+
+impl JtiStore for PgJtiStore {
+    fn is_used<'a>(&'a self, jti: &'a str) -> JtiFuture<'a, bool> {
+        Box::pin(async move { self.lookup(jti).await })
+    }
+
+    fn mark_used<'a>(&'a self, jti: &'a str, exp_unix: i64) -> JtiFuture<'a, bool> {
+        Box::pin(async move {
+            // One conditional write — atomic, and immediately visible to every
+            // replica. `INSERT … ON CONFLICT DO NOTHING` (or Redis `SET NX`);
+            // never a read followed by a write.
+            self.insert_if_absent(jti, exp_unix).await
+        })
+    }
+}
+```
+
+`mark_used` MUST be atomic: concurrent callers for the same `jti` must see
+exactly one `true`, or the single-use refresh guarantee is gone.
+
+Because verification consults the store, `verify_access`, `verify_refresh`,
+`refresh`, `revoke` and the MCP/tenant token helpers
+(`mcp::verify_agent_token`, `tenancy::auth_routes::verify_for_tenant`) are all
+`async`. Token **expiry is checked before** the store is consulted, so an
+expired token never costs a round trip.
 
 ---
 
@@ -181,7 +217,7 @@ let custom = serde_json::json!({ "roles": ["admin"], "tenant": "acme" })
     .as_object().unwrap().clone();
 let pair = jwt.issue_pair_with(99, custom)?;
 
-let claims = jwt.verify_access(&pair.access).unwrap();
+let claims = jwt.verify_access(&pair.access).await.unwrap();
 let roles: Vec<String> = claims.get_custom("roles").unwrap();   // ["admin"]
 ```
 

--- a/docs/de/api-conventions.md
+++ b/docs/de/api-conventions.md
@@ -79,7 +79,7 @@ Der Rückgabetyp einer Methode sagt Ihnen, wie sie fehlschlagen kann. Rust hat k
 
 **`Option<T>`** — entweder ein Wert (`Some`) oder nichts (`None`), wie ein nullbares Feld. Verwenden Sie es, wenn „nichts gefunden“ ein normales Ergebnis ist und Sie keine Fehlermeldung benötigen, die erklärt, warum:
 - Nachschlagen: `cache.get(k) -> Result<Option<String>, _>` (das `Result` deckt den I/O-Fehler ab; die `Option` deckt „Schlüssel nicht vorhanden“ ab)
-- Verifizierung: `JwtLifecycle::verify_access(token) -> Option<Claims>` („abgelaufen oder ungültig“ ist ein erwartetes Ergebnis, also genügt `None`)
+- Verifizierung: `async JwtLifecycle::verify_access(token) -> Option<Claims>` („abgelaufen oder ungültig“ ist ein erwartetes Ergebnis, also genügt `None`)
 - Optionale Config-Lesevorgänge: `env::optional("FOO") -> Result<Option<T>, _>`
 
 **`bool`** — ein schlichtes Ja/Nein, wenn kein weiteres Detail benötigt wird:

--- a/docs/de/auth-jwt-api.md
+++ b/docs/de/auth-jwt-api.md
@@ -101,7 +101,7 @@ let pair = jwt.issue_pair(user_id);
 // → pair.refresh (lange TTL, in einem HttpOnly-Cookie / sicheren Speicher ablegen)
 
 // Authentifizierte Anfrage: den Access-Token verifizieren.
-match jwt.verify_access(&access) {
+match jwt.verify_access(&access).await {
     Some(claims) => { /* claims.sub ist die Benutzer-ID */ }
     None => { /* 401: ungültig, abgelaufen, widerrufen oder falscher Typ */ }
 }
@@ -113,8 +113,8 @@ Access-Token nicht zum Erzeugen neuer Tokens verwendet werden kann:
 
 ```rust
 let pair = jwt.issue_pair(42);
-assert!(jwt.verify_refresh(&pair.access).is_none());
-assert!(jwt.verify_access(&pair.refresh).is_none());
+assert!(jwt.verify_refresh(&pair.access).await.is_none());
+assert!(jwt.verify_access(&pair.refresh).await.is_none());
 ```
 
 ---
@@ -128,9 +128,9 @@ abgelehnt):
 
 ```rust
 let pair = jwt.issue_pair(7);
-let rotated = jwt.refresh(&pair.refresh).expect("refresh ok");
+let rotated = jwt.refresh(&pair.refresh).await.expect("refresh ok");
 assert_ne!(pair.access, rotated.access);
-assert!(jwt.refresh(&pair.refresh).is_none());   // der alte Refresh ist jetzt tot
+assert!(jwt.refresh(&pair.refresh).await.is_none());   // der alte Refresh ist jetzt tot
 ```
 
 Standardmäßig **bewahrt** `refresh` die benutzerdefinierten Claims des Tokens.
@@ -149,8 +149,8 @@ abgelaufen wäre — genau das ruft `POST /api/auth/logout` auf:
 
 ```rust
 let pair = jwt.issue_pair(1);
-assert!(jwt.revoke(&pair.access));
-assert!(jwt.verify_access(&pair.access).is_none());
+assert!(jwt.revoke(&pair.access).await);
+assert!(jwt.verify_access(&pair.access).await.is_none());
 ```
 
 Die Sperrliste liegt in einem austauschbaren `JtiStore`. Der Standard
@@ -168,14 +168,48 @@ let a = JwtLifecycle::new(secret.clone()).with_jti_store(Arc::clone(&shared));
 let b = JwtLifecycle::new(secret).with_jti_store(Arc::clone(&shared));
 
 let pair = a.issue_pair(5);
-a.revoke(&pair.access);
-assert!(b.verify_access(&pair.access).is_none());   // B sieht As Widerruf
+a.revoke(&pair.access).await;
+assert!(b.verify_access(&pair.access).await.is_none());   // B sieht As Widerruf
 ```
 
 > Ohne gemeinsamen Speicher ist `/logout` bestenfalls „best-effort“: Ein
 > widerrufener Token kann auf einer anderen Replica bis zu seinem natürlichen
 > Ablauf noch akzeptiert werden. Dies ist die einzelne wichtigste
 > Produktionseinstellung für JWT-Auth.
+
+### Einen dauerhaften Speicher schreiben
+
+`JtiStore` ist asynchron (seit v0.52, #1191), eine dauerhafte Implementierung ist
+also eine einzige Abfrage — kein Hintergrund-Flusher, kein Konvergenzfenster, in
+dem ein widerrufener `jti` woanders noch akzeptiert wird. Beide Methoden geben
+`JtiFuture<'_, T>` zurück (ein geboxtes Future — der Trait wird als
+`Arc<dyn JtiStore>` verwendet, und natives `async fn` in Traits ist nicht
+dyn-kompatibel):
+
+```rust
+use rustango::jti_store::{JtiFuture, JtiStore};
+
+impl JtiStore for PgJtiStore {
+    fn is_used<'a>(&'a self, jti: &'a str) -> JtiFuture<'a, bool> {
+        Box::pin(async move { self.lookup(jti).await })
+    }
+
+    fn mark_used<'a>(&'a self, jti: &'a str, exp_unix: i64) -> JtiFuture<'a, bool> {
+        Box::pin(async move { self.insert_if_absent(jti, exp_unix).await })
+    }
+}
+```
+
+`mark_used` MUSS atomar sein: Bei gleichzeitigen Aufrufen für denselben `jti`
+darf genau einer `true` sehen — ein einziger bedingter Schreibvorgang
+(`INSERT … ON CONFLICT DO NOTHING`, Redis `SET NX`), niemals Lesen-dann-Schreiben.
+Sonst ist die Einmalverwendungs-Garantie für Refresh-Tokens verloren.
+
+Da die Verifizierung den Speicher konsultiert, sind `verify_access`,
+`verify_refresh`, `refresh`, `revoke` und die MCP-/Tenant-Token-Helfer
+(`mcp::verify_agent_token`, `tenancy::auth_routes::verify_for_tenant`) alle
+`async`. Der **Ablauf wird vor** dem Speicherzugriff geprüft, ein abgelaufener
+Token kostet also keinen Roundtrip.
 
 ---
 
@@ -190,7 +224,7 @@ let custom = serde_json::json!({ "roles": ["admin"], "tenant": "acme" })
     .as_object().unwrap().clone();
 let pair = jwt.issue_pair_with(99, custom)?;
 
-let claims = jwt.verify_access(&pair.access).unwrap();
+let claims = jwt.verify_access(&pair.access).await.unwrap();
 let roles: Vec<String> = claims.get_custom("roles").unwrap();   // ["admin"]
 ```
 

--- a/docs/de/security.md
+++ b/docs/de/security.md
@@ -385,7 +385,7 @@ let pair = jwt.issue_pair_with(user_id, json!({
 ### Ein Token verifizieren
 
 ```rust
-let claims = jwt.verify_access(&access_token)
+let claims = jwt.verify_access(&access_token).await
     .ok_or(StatusCode::UNAUTHORIZED)?;
 
 let roles: Vec<String> = claims.get_custom("roles").unwrap_or_default();
@@ -395,7 +395,7 @@ let tenant: String = claims.get_custom("tenant").unwrap_or_default();
 ### Ein Token erneuern (behält deine benutzerdefinierten Claims)
 
 ```rust
-let new_pair = jwt.refresh(&refresh_token)
+let new_pair = jwt.refresh(&refresh_token).await
     .ok_or(StatusCode::UNAUTHORIZED)?;
 // new_pair has the same roles + scope + tenant
 ```
@@ -410,18 +410,18 @@ Die JTI des alten Refresh-Tokens (seine eindeutige ID) wird zu einer Blacklist h
 let new_pair = jwt.refresh_with(&refresh_token, json!({
     "roles": ["viewer"],     // role was demoted since login
     "tenant": "acme",
-}).as_object().unwrap().clone())?
+}).as_object().unwrap().clone()).await?
     .ok_or(StatusCode::UNAUTHORIZED)?;
 ```
 
 ### Ein Token widerrufen
 
 ```rust
-jwt.revoke(&access_token);     // adds JTI to blacklist
-jwt.revoke(&refresh_token);
+jwt.revoke(&access_token).await;     // adds JTI to blacklist
+jwt.revoke(&refresh_token).await;
 ```
 
-Die standardmäßige In-Memory-Blacklist (`InMemoryJtiStore`) räumt abgelaufene Einträge von selbst aus, aber sie lebt in einem Prozess und vergisst bei jedem Neustart jeden Widerruf. Für Multi-Prozess-Deployments installiere einen gemeinsamen, dauerhaften Store über `JwtLifecycle::new(secret).with_jti_store(store)` — `store` ist ein beliebiger `Arc<dyn JtiStore>` (zum Beispiel ein Redis- oder DB-gestützter). Ohne einen gemeinsamen Store kann ein Token, das du auf einer Replica widerrufst, auf einer anderen weiterhin abgespielt werden, bis es abläuft.
+Die standardmäßige In-Memory-Blacklist (`InMemoryJtiStore`) räumt abgelaufene Einträge von selbst aus, aber sie lebt in einem Prozess und vergisst bei jedem Neustart jeden Widerruf. Für Multi-Prozess-Deployments installiere einen gemeinsamen, dauerhaften Store über `JwtLifecycle::new(secret).with_jti_store(store)` — `store` ist ein beliebiger `Arc<dyn JtiStore>` (zum Beispiel ein Redis- oder DB-gestützter). Ohne einen gemeinsamen Store kann ein Token, das du auf einer Replica widerrufst, auf einer anderen weiterhin abgespielt werden, bis es abläuft. Seit v0.52 (#1191) sind all diese Aufrufe `async` — `verify_*`, `refresh*` und `revoke` warten auf den Store, sodass ein dauerhafter Store ein einzelner bedingter Schreibvorgang sein kann statt eines letztlich konsistenten Caches mit Hintergrund-Flusher.
 
 > **Vertiefung:** [JWT-Auth-API](auth-jwt-api.md) — der eingebaute `/api/auth/login|refresh|logout|me`-Router, gleitendes Refresh und der JTI-Widerrufs-Store. Für ein einzelnes selbstverwaltetes Token siehe [JWT (standalone)](auth-jwt.md). Um Browser-/API-Routen per Login zu gaten, siehe [Access-Decorators](auth-decorators.md).
 

--- a/docs/es/api-conventions.md
+++ b/docs/es/api-conventions.md
@@ -79,7 +79,7 @@ El tipo de retorno de un método te dice cómo puede fallar. Rust no tiene excep
 
 **`Option<T>`** — o un valor (`Some`) o nada (`None`), como un campo anulable. Úsalo cuando «no se encontró nada» es un resultado normal y no necesitas un mensaje de error que explique por qué:
 - Búsquedas: `cache.get(k) -> Result<Option<String>, _>` (el `Result` cubre el fallo de E/S; el `Option` cubre «clave ausente»)
-- Verificación: `JwtLifecycle::verify_access(token) -> Option<Claims>` («expirado o inválido» es un resultado esperado, así que `None` basta)
+- Verificación: `async JwtLifecycle::verify_access(token) -> Option<Claims>` («expirado o inválido» es un resultado esperado, así que `None` basta)
 - Lecturas de configuración opcionales: `env::optional("FOO") -> Result<Option<T>, _>`
 
 **`bool`** — un simple sí/no cuando no se necesita más detalle:

--- a/docs/es/auth-jwt-api.md
+++ b/docs/es/auth-jwt-api.md
@@ -100,7 +100,7 @@ let pair = jwt.issue_pair(user_id);
 // → pair.refresh (TTL largo, almacenar en una cookie HttpOnly / almacenamiento seguro)
 
 // Petición autenticada: verificar el token de acceso.
-match jwt.verify_access(&access) {
+match jwt.verify_access(&access).await {
     Some(claims) => { /* claims.sub es el id de usuario */ }
     None => { /* 401: inválido, caducado, revocado, o tipo incorrecto */ }
 }
@@ -112,8 +112,8 @@ duración robado no puede usarse para acuñar nuevos:
 
 ```rust
 let pair = jwt.issue_pair(42);
-assert!(jwt.verify_refresh(&pair.access).is_none());
-assert!(jwt.verify_access(&pair.refresh).is_none());
+assert!(jwt.verify_refresh(&pair.access).await.is_none());
+assert!(jwt.verify_access(&pair.refresh).await.is_none());
 ```
 
 ---
@@ -126,9 +126,9 @@ tokens de refresco de un solo uso (la reproducción del antiguo se rechaza):
 
 ```rust
 let pair = jwt.issue_pair(7);
-let rotated = jwt.refresh(&pair.refresh).expect("refresh ok");
+let rotated = jwt.refresh(&pair.refresh).await.expect("refresh ok");
 assert_ne!(pair.access, rotated.access);
-assert!(jwt.refresh(&pair.refresh).is_none());   // el refresh antiguo ya está muerto
+assert!(jwt.refresh(&pair.refresh).await.is_none());   // el refresh antiguo ya está muerto
 ```
 
 Por defecto, `refresh` **preserva** los claims personalizados del token. Si los
@@ -146,8 +146,8 @@ todos modos — esto es lo que llama `POST /api/auth/logout`:
 
 ```rust
 let pair = jwt.issue_pair(1);
-assert!(jwt.revoke(&pair.access));
-assert!(jwt.verify_access(&pair.access).is_none());
+assert!(jwt.revoke(&pair.access).await);
+assert!(jwt.verify_access(&pair.access).await.is_none());
 ```
 
 La lista negra reside en un `JtiStore` intercambiable. El `InMemoryJtiStore` por
@@ -165,14 +165,49 @@ let a = JwtLifecycle::new(secret.clone()).with_jti_store(Arc::clone(&shared));
 let b = JwtLifecycle::new(secret).with_jti_store(Arc::clone(&shared));
 
 let pair = a.issue_pair(5);
-a.revoke(&pair.access);
-assert!(b.verify_access(&pair.access).is_none());   // B ve la revocación de A
+a.revoke(&pair.access).await;
+assert!(b.verify_access(&pair.access).await.is_none());   // B ve la revocación de A
 ```
 
 > Sin un almacén compartido, `/logout` es, en el mejor de los casos, «best-effort»:
 > un token revocado puede seguir siendo aceptado en otra réplica hasta su
 > expiración natural. Este es el ajuste de producción más importante para la
 > autenticación JWT.
+
+### Escribir un almacén duradero
+
+`JtiStore` es asíncrono (desde v0.52, #1191), así que una implementación duradera
+es una sola consulta — sin volcado en segundo plano ni ventana de convergencia
+durante la cual un `jti` revocado siga aceptándose en otra réplica. Ambos métodos
+devuelven `JtiFuture<'_, T>` (un future en caja — el trait se usa como
+`Arc<dyn JtiStore>`, y un `async fn` nativo en un trait no es compatible con
+objetos dyn):
+
+```rust
+use rustango::jti_store::{JtiFuture, JtiStore};
+
+impl JtiStore for PgJtiStore {
+    fn is_used<'a>(&'a self, jti: &'a str) -> JtiFuture<'a, bool> {
+        Box::pin(async move { self.lookup(jti).await })
+    }
+
+    fn mark_used<'a>(&'a self, jti: &'a str, exp_unix: i64) -> JtiFuture<'a, bool> {
+        Box::pin(async move { self.insert_if_absent(jti, exp_unix).await })
+    }
+}
+```
+
+`mark_used` DEBE ser atómico: entre llamadas concurrentes para el mismo `jti`,
+exactamente una debe obtener `true` — una única escritura condicional
+(`INSERT … ON CONFLICT DO NOTHING`, Redis `SET NX`), nunca una lectura seguida de
+una escritura. De lo contrario se pierde la garantía de un solo uso de los tokens
+de refresco.
+
+Como la verificación consulta el almacén, `verify_access`, `verify_refresh`,
+`refresh`, `revoke` y los helpers de token de MCP / tenant
+(`mcp::verify_agent_token`, `tenancy::auth_routes::verify_for_tenant`) son todos
+`async`. La **expiración se comprueba antes** de consultar el almacén, así que un
+token caducado no cuesta ningún viaje de ida y vuelta.
 
 ---
 
@@ -187,7 +222,7 @@ let custom = serde_json::json!({ "roles": ["admin"], "tenant": "acme" })
     .as_object().unwrap().clone();
 let pair = jwt.issue_pair_with(99, custom)?;
 
-let claims = jwt.verify_access(&pair.access).unwrap();
+let claims = jwt.verify_access(&pair.access).await.unwrap();
 let roles: Vec<String> = claims.get_custom("roles").unwrap();   // ["admin"]
 ```
 

--- a/docs/es/security.md
+++ b/docs/es/security.md
@@ -386,7 +386,7 @@ Los "claims" son los hechos clave/valor que incrustas en el token (roles, inquil
 ### Verificar un token
 
 ```rust
-let claims = jwt.verify_access(&access_token)
+let claims = jwt.verify_access(&access_token).await
     .ok_or(StatusCode::UNAUTHORIZED)?;
 
 let roles: Vec<String> = claims.get_custom("roles").unwrap_or_default();
@@ -396,7 +396,7 @@ let tenant: String = claims.get_custom("tenant").unwrap_or_default();
 ### Refrescar un token (mantiene tus claims personalizados)
 
 ```rust
-let new_pair = jwt.refresh(&refresh_token)
+let new_pair = jwt.refresh(&refresh_token).await
     .ok_or(StatusCode::UNAUTHORIZED)?;
 // new_pair has the same roles + scope + tenant
 ```
@@ -411,18 +411,18 @@ El JTI (su ID único) del antiguo token de refresco se añade a una lista negra 
 let new_pair = jwt.refresh_with(&refresh_token, json!({
     "roles": ["viewer"],     // role was demoted since login
     "tenant": "acme",
-}).as_object().unwrap().clone())?
+}).as_object().unwrap().clone()).await?
     .ok_or(StatusCode::UNAUTHORIZED)?;
 ```
 
 ### Revocar un token
 
 ```rust
-jwt.revoke(&access_token);     // adds JTI to blacklist
-jwt.revoke(&refresh_token);
+jwt.revoke(&access_token).await;     // adds JTI to blacklist
+jwt.revoke(&refresh_token).await;
 ```
 
-La lista negra en memoria por defecto (`InMemoryJtiStore`) limpia por sí sola las entradas caducadas, pero vive en un único proceso y olvida cada revocación al reiniciar. Para despliegues multiproceso, instala un almacén compartido y duradero vía `JwtLifecycle::new(secret).with_jti_store(store)` — `store` es cualquier `Arc<dyn JtiStore>` (por ejemplo uno respaldado por Redis o por BD). Sin un almacén compartido, un token que revocas en una réplica todavía puede repetirse en otra hasta que caduque.
+La lista negra en memoria por defecto (`InMemoryJtiStore`) limpia por sí sola las entradas caducadas, pero vive en un único proceso y olvida cada revocación al reiniciar. Para despliegues multiproceso, instala un almacén compartido y duradero vía `JwtLifecycle::new(secret).with_jti_store(store)` — `store` es cualquier `Arc<dyn JtiStore>` (por ejemplo uno respaldado por Redis o por BD). Sin un almacén compartido, un token que revocas en una réplica todavía puede repetirse en otra hasta que caduque. Desde v0.52 (#1191) todas estas llamadas son `async` — `verify_*`, `refresh*` y `revoke` esperan al almacén, de modo que un almacén duradero puede ser una única escritura condicional en lugar de una caché de consistencia eventual con volcado en segundo plano.
 
 > **Análisis en profundidad:** [API de auth JWT](auth-jwt-api.md) — el router incorporado `/api/auth/login|refresh|logout|me`, el refresco deslizante, y el almacén de revocación de JTI. Para un único token autogestionado, consulta [JWT (independiente)](auth-jwt.md). Para restringir rutas de navegador/API por inicio de sesión, consulta los [decoradores de acceso](auth-decorators.md).
 

--- a/docs/fr/api-conventions.md
+++ b/docs/fr/api-conventions.md
@@ -79,7 +79,7 @@ Le type de retour d'une méthode indique comment elle peut échouer. Rust n'a pa
 
 **`Option<T>`** — soit une valeur (`Some`), soit rien (`None`), comme un champ nullable. À utiliser quand « rien trouvé » est un résultat normal et que vous n'avez pas besoin d'un message d'erreur expliquant pourquoi :
 - Recherches : `cache.get(k) -> Result<Option<String>, _>` (le `Result` couvre l'échec d'E/S ; l'`Option` couvre « clé absente »)
-- Vérification : `JwtLifecycle::verify_access(token) -> Option<Claims>` (« expiré ou invalide » est un résultat attendu, donc `None` suffit)
+- Vérification : `async JwtLifecycle::verify_access(token) -> Option<Claims>` (« expiré ou invalide » est un résultat attendu, donc `None` suffit)
 - Lectures de config optionnelles : `env::optional("FOO") -> Result<Option<T>, _>`
 
 **`bool`** — un simple oui/non quand aucun détail supplémentaire n'est nécessaire :

--- a/docs/fr/auth-jwt-api.md
+++ b/docs/fr/auth-jwt-api.md
@@ -101,7 +101,7 @@ let pair = jwt.issue_pair(user_id);
 // → pair.refresh (TTL long, à stocker dans un cookie HttpOnly / stockage sécurisé)
 
 // Requête authentifiée : vérifier le token d'accès.
-match jwt.verify_access(&access) {
+match jwt.verify_access(&access).await {
     Some(claims) => { /* claims.sub est l'id utilisateur */ }
     None => { /* 401 : invalide, expiré, révoqué, ou mauvais type */ }
 }
@@ -114,8 +114,8 @@ nouveaux :
 
 ```rust
 let pair = jwt.issue_pair(42);
-assert!(jwt.verify_refresh(&pair.access).is_none());
-assert!(jwt.verify_access(&pair.refresh).is_none());
+assert!(jwt.verify_refresh(&pair.access).await.is_none());
+assert!(jwt.verify_access(&pair.refresh).await.is_none());
 ```
 
 ---
@@ -129,9 +129,9 @@ rejeu de l'ancien est refusé) :
 
 ```rust
 let pair = jwt.issue_pair(7);
-let rotated = jwt.refresh(&pair.refresh).expect("refresh ok");
+let rotated = jwt.refresh(&pair.refresh).await.expect("refresh ok");
 assert_ne!(pair.access, rotated.access);
-assert!(jwt.refresh(&pair.refresh).is_none());   // l'ancien refresh est maintenant mort
+assert!(jwt.refresh(&pair.refresh).await.is_none());   // l'ancien refresh est maintenant mort
 ```
 
 Par défaut, `refresh` **préserve** les claims personnalisés du token. Si les
@@ -149,8 +149,8 @@ façon expiré — c'est ce qu'appelle `POST /api/auth/logout` :
 
 ```rust
 let pair = jwt.issue_pair(1);
-assert!(jwt.revoke(&pair.access));
-assert!(jwt.verify_access(&pair.access).is_none());
+assert!(jwt.revoke(&pair.access).await);
+assert!(jwt.verify_access(&pair.access).await.is_none());
 ```
 
 La liste noire réside dans un `JtiStore` interchangeable. Le `InMemoryJtiStore`
@@ -168,14 +168,49 @@ let a = JwtLifecycle::new(secret.clone()).with_jti_store(Arc::clone(&shared));
 let b = JwtLifecycle::new(secret).with_jti_store(Arc::clone(&shared));
 
 let pair = a.issue_pair(5);
-a.revoke(&pair.access);
-assert!(b.verify_access(&pair.access).is_none());   // B voit la révocation de A
+a.revoke(&pair.access).await;
+assert!(b.verify_access(&pair.access).await.is_none());   // B voit la révocation de A
 ```
 
 > Sans magasin partagé, `/logout` est au mieux « best-effort » : un token révoqué
 > peut encore être accepté sur une autre réplica jusqu'à son expiration
 > naturelle. C'est le paramètre de production le plus important pour
 > l'authentification JWT.
+
+### Écrire un magasin durable
+
+`JtiStore` est asynchrone (depuis v0.52, #1191) : une implémentation durable
+tient donc en une requête — pas de vidage en arrière-plan, pas de fenêtre de
+convergence pendant laquelle un `jti` révoqué est encore accepté ailleurs. Les
+deux méthodes renvoient `JtiFuture<'_, T>` (un future boxé — le trait est utilisé
+comme `Arc<dyn JtiStore>`, et un `async fn` natif dans un trait n'est pas
+compatible avec les objets dyn) :
+
+```rust
+use rustango::jti_store::{JtiFuture, JtiStore};
+
+impl JtiStore for PgJtiStore {
+    fn is_used<'a>(&'a self, jti: &'a str) -> JtiFuture<'a, bool> {
+        Box::pin(async move { self.lookup(jti).await })
+    }
+
+    fn mark_used<'a>(&'a self, jti: &'a str, exp_unix: i64) -> JtiFuture<'a, bool> {
+        Box::pin(async move { self.insert_if_absent(jti, exp_unix).await })
+    }
+}
+```
+
+`mark_used` DOIT être atomique : parmi des appelants concurrents pour le même
+`jti`, exactement un doit obtenir `true` — une seule écriture conditionnelle
+(`INSERT … ON CONFLICT DO NOTHING`, Redis `SET NX`), jamais une lecture suivie
+d'une écriture. Sinon la garantie d'usage unique des tokens de rafraîchissement
+disparaît.
+
+Comme la vérification consulte le magasin, `verify_access`, `verify_refresh`,
+`refresh`, `revoke` et les helpers de token MCP / tenant
+(`mcp::verify_agent_token`, `tenancy::auth_routes::verify_for_tenant`) sont tous
+`async`. L'**expiration est vérifiée avant** le magasin : un token expiré ne
+coûte donc aucun aller-retour.
 
 ---
 
@@ -190,7 +225,7 @@ let custom = serde_json::json!({ "roles": ["admin"], "tenant": "acme" })
     .as_object().unwrap().clone();
 let pair = jwt.issue_pair_with(99, custom)?;
 
-let claims = jwt.verify_access(&pair.access).unwrap();
+let claims = jwt.verify_access(&pair.access).await.unwrap();
 let roles: Vec<String> = claims.get_custom("roles").unwrap();   // ["admin"]
 ```
 

--- a/docs/fr/security.md
+++ b/docs/fr/security.md
@@ -385,7 +385,7 @@ Les « claims » sont les faits clé/valeur que vous intégrez dans le jeton (r�
 ### Vérifier un jeton
 
 ```rust
-let claims = jwt.verify_access(&access_token)
+let claims = jwt.verify_access(&access_token).await
     .ok_or(StatusCode::UNAUTHORIZED)?;
 
 let roles: Vec<String> = claims.get_custom("roles").unwrap_or_default();
@@ -395,7 +395,7 @@ let tenant: String = claims.get_custom("tenant").unwrap_or_default();
 ### Rafraîchir un jeton (conserve vos claims personnalisés)
 
 ```rust
-let new_pair = jwt.refresh(&refresh_token)
+let new_pair = jwt.refresh(&refresh_token).await
     .ok_or(StatusCode::UNAUTHORIZED)?;
 // new_pair has the same roles + scope + tenant
 ```
@@ -410,18 +410,18 @@ Le JTI de l'ancien jeton de rafraîchissement (son ID unique) est ajouté à une
 let new_pair = jwt.refresh_with(&refresh_token, json!({
     "roles": ["viewer"],     // role was demoted since login
     "tenant": "acme",
-}).as_object().unwrap().clone())?
+}).as_object().unwrap().clone()).await?
     .ok_or(StatusCode::UNAUTHORIZED)?;
 ```
 
 ### Révoquer un jeton
 
 ```rust
-jwt.revoke(&access_token);     // adds JTI to blacklist
-jwt.revoke(&refresh_token);
+jwt.revoke(&access_token).await;     // adds JTI to blacklist
+jwt.revoke(&refresh_token).await;
 ```
 
-La liste noire en mémoire par défaut (`InMemoryJtiStore`) nettoie d'elle-même les entrées expirées, mais elle vit dans un seul processus et oublie chaque révocation au redémarrage. Pour les déploiements multi-processus, installez un store partagé et durable via `JwtLifecycle::new(secret).with_jti_store(store)` — `store` est n'importe quel `Arc<dyn JtiStore>` (par exemple un store adossé à Redis ou à une base de données). Sans store partagé, un jeton que vous révoquez sur une réplique peut encore être rejoué sur une autre jusqu'à son expiration.
+La liste noire en mémoire par défaut (`InMemoryJtiStore`) nettoie d'elle-même les entrées expirées, mais elle vit dans un seul processus et oublie chaque révocation au redémarrage. Pour les déploiements multi-processus, installez un store partagé et durable via `JwtLifecycle::new(secret).with_jti_store(store)` — `store` est n'importe quel `Arc<dyn JtiStore>` (par exemple un store adossé à Redis ou à une base de données). Sans store partagé, un jeton que vous révoquez sur une réplique peut encore être rejoué sur une autre jusqu'à son expiration. Depuis v0.52 (#1191), tous ces appels sont `async` — `verify_*`, `refresh*` et `revoke` attendent le store, de sorte qu'un store durable peut être une simple écriture conditionnelle au lieu d'un cache à cohérence à terme doté d'un vidage en arrière-plan.
 
 > **À approfondir :** [API d'authentification JWT](auth-jwt-api.md) — le routeur intégré `/api/auth/login|refresh|logout|me`, le rafraîchissement glissant, et le store de révocation JTI. Pour un seul jeton auto-géré, voir [JWT (autonome)](auth-jwt.md). Pour restreindre les routes navigateur/API selon la connexion, voir [décorateurs d'accès](auth-decorators.md).
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -385,7 +385,7 @@ let pair = jwt.issue_pair_with(user_id, json!({
 ### Verifying a token
 
 ```rust
-let claims = jwt.verify_access(&access_token)
+let claims = jwt.verify_access(&access_token).await
     .ok_or(StatusCode::UNAUTHORIZED)?;
 
 let roles: Vec<String> = claims.get_custom("roles").unwrap_or_default();
@@ -395,7 +395,7 @@ let tenant: String = claims.get_custom("tenant").unwrap_or_default();
 ### Refreshing a token (keeps your custom claims)
 
 ```rust
-let new_pair = jwt.refresh(&refresh_token)
+let new_pair = jwt.refresh(&refresh_token).await
     .ok_or(StatusCode::UNAUTHORIZED)?;
 // new_pair has the same roles + scope + tenant
 ```
@@ -410,18 +410,18 @@ The old refresh token's JTI (its unique ID) is added to a blacklist so it can't 
 let new_pair = jwt.refresh_with(&refresh_token, json!({
     "roles": ["viewer"],     // role was demoted since login
     "tenant": "acme",
-}).as_object().unwrap().clone())?
+}).as_object().unwrap().clone()).await?
     .ok_or(StatusCode::UNAUTHORIZED)?;
 ```
 
 ### Revoking a token
 
 ```rust
-jwt.revoke(&access_token);     // adds JTI to blacklist
-jwt.revoke(&refresh_token);
+jwt.revoke(&access_token).await;     // adds JTI to blacklist
+jwt.revoke(&refresh_token).await;
 ```
 
-The default in-memory blacklist (`InMemoryJtiStore`) cleans out expired entries on its own, but it lives in one process and forgets every revocation on restart. For multi-process deployments, install a shared, durable store via `JwtLifecycle::new(secret).with_jti_store(store)` — `store` is any `Arc<dyn JtiStore>` (for example a Redis- or DB-backed one). Without a shared store, a token you revoke on one replica can still be replayed on another until it expires.
+The default in-memory blacklist (`InMemoryJtiStore`) cleans out expired entries on its own, but it lives in one process and forgets every revocation on restart. For multi-process deployments, install a shared, durable store via `JwtLifecycle::new(secret).with_jti_store(store)` — `store` is any `Arc<dyn JtiStore>` (for example a Redis- or DB-backed one). Without a shared store, a token you revoke on one replica can still be replayed on another until it expires. All of these are `async` since v0.52 (#1191) — `verify_*`, `refresh*` and `revoke` await the store, so a durable store can be a single conditional write instead of an eventually-consistent cache with a background flusher.
 
 > **Deep dive:** [JWT auth API](auth-jwt-api.md) — the built-in `/api/auth/login|refresh|logout|me` router, sliding refresh, and the JTI revocation store. For a single self-managed token, see [JWT (standalone)](auth-jwt.md). To gate browser/API routes by login, see [access decorators](auth-decorators.md).
 


### PR DESCRIPTION
Closes #1191.

## The problem the signature created

`JtiStore` was synchronous. A store is consulted on the verify path, which is
async, so a shared multi-instance store could not simply `await` a write — the
only shape that fit a sync trait was a hot in-memory map plus a background
flusher. That is eventually consistent: after `/logout`, the revoked `jti`
stayed **valid on other replicas** for the length of the convergence window.
Revocation is precisely the operation that wants to be durable and immediate,
and the constraint came from the trait signature rather than from the problem.

## What changed

`is_used` / `mark_used` / `approx_size` return `JtiFuture<'_, T>`. Everything
that consults the store is async with them:

- `JwtLifecycle::{verify_token, verify_access, verify_refresh, refresh, refresh_with, revoke, blacklist_jti, is_blacklisted, blacklist_size}`
- `mcp::verify_agent_token`
- `tenancy::auth_routes::verify_for_tenant`
- `tenancy::admin::redeem_impersonation_handoff`

A durable store is now one query:

```rust
fn mark_used<'a>(&'a self, jti: &'a str, exp_unix: i64) -> JtiFuture<'a, bool> {
    Box::pin(async move {
        // INSERT … ON CONFLICT DO NOTHING — atomic, one round trip,
        // visible to every replica immediately.
        self.insert_if_absent(jti, exp_unix).await
    })
}
```

`mark_used` must still be **atomic** — concurrent callers for the same `jti`
must see exactly one `true`, expressed as a single conditional write
(`ON CONFLICT DO NOTHING`, Redis `SET NX`), never read-then-write. The doc
comment says so, and there is now a test that proves the contract holds for a
store that genuinely suspends between the check and the record.

## Why boxed futures and not `#[async_trait]`

Every consumer holds the store as `Arc<dyn JtiStore>`, and native `async fn` in
traits is not dyn-compatible, so the future has to be boxed either way. It is
written out by hand rather than via the macro because `jti_store` is a **core,
ungated** module while `async-trait` is an *optional* dependency, pulled in only
by `cache` / `storage` / `jobs` / `oauth2` / `email` / `secrets`. Using the
macro would break supported feature combinations — verified against the litmus
`--no-default-features --features sqlite,tenancy`, which builds clean.

## Behaviour

- `InMemoryJtiStore` is unchanged in behaviour. Its bodies stay synchronous, so
  the `std::sync::Mutex` guard never crosses a suspend point.
- Token **expiry is now checked before** the store is consulted — an expired
  token costs no round trip.
- Breaking for callers only in that `.await` is required; a synchronous custom
  store stays a one-line `Box::pin(async move { … })` wrapper.

## Verification

- `cargo test --workspace --all-features --no-run` — finished clean
- `cargo build --no-default-features --features sqlite,tenancy` — the combo that
  justified hand-rolling
- `jti_store::` 7 passed · `jwt_lifecycle::` 24 passed · `impersonation_handoff::`
  10 passed · `mcp::auth` 4 passed · `mcp_slice2` 8 passed
- doctests: 77 passed
- `auth_demo --test auth_jwt_api` (the CI-gated backing test for
  `docs/auth-jwt-api.md`): 5 passed
- clippy at CI's two invocations: clean

## Docs

All four locales (en / de / fr / es): `auth-jwt-api.md` gains a "writing a
durable store" section, `security.md` and `api-conventions.md` note the async
surface, and every snippet awaits.