### PR TITLE
fix(features): gate modules on the optional deps they use (#1208)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,9 @@ jobs:
       fail-fast: false
       matrix:
         features:
+          - sqlite                       # the bare ORM the manifest advertises
+          - postgres
+          - mysql
           - postgres,manage              # `cargo rustango new --template api`
           - sqlite,manage
           - sqlite,admin
@@ -206,6 +209,10 @@ jobs:
       - run: cargo check -p rustango --no-default-features --features ${{ matrix.features }}
         env:
           RUSTFLAGS: "-D warnings"
+      # Also run the unit tests: `cargo check` misses `#[cfg(test)]` code, and
+      # that is exactly where a gate mismatch hides — a test module can outlive
+      # the gated item it exercises without the library ever noticing.
+      - run: cargo test -p rustango --no-default-features --features ${{ matrix.features }} --lib
 
   sqlite_litmus:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,40 @@ jobs:
   # Runs `cargo check`, `cargo clippy`, and the SQLite pragma
   # regression test (foreign_keys ON, WAL on file-backed, busy_timeout
   # set, FK violation rejected — see tests/sqlite_pragmas_live.rs).
+  # #1208 — the feature table is a public promise, so check the promise.
+  # `sqlite_litmus` below is a single combination, and it happens to be one
+  # that *masks* gate gaps: `tenancy` pulls in rand / tower / hmac /
+  # async-trait, so modules that use those without gating on them still
+  # compiled. Meanwhile `postgres,manage` (what `cargo rustango new
+  # --template api` generates) failed with 75 errors, and `sqlite,admin`
+  # with 26 — undetected, because nothing built them.
+  #
+  # Warnings are errors here, unlike the rest of CI: these combinations are
+  # exactly where cfg'd-out code leaves unused imports and unconstructed
+  # variants behind, and a warning is the only signal that a gate is wrong.
+  feature_combos:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          - postgres,manage              # `cargo rustango new --template api`
+          - sqlite,manage
+          - sqlite,admin
+          - sqlite,manage,admin
+          - postgres,manage,admin
+          - sqlite,template_views
+          - sqlite,tenancy               # the pre-existing litmus
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.88
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: feature-combos
+      - run: cargo check -p rustango --no-default-features --features ${{ matrix.features }}
+        env:
+          RUSTFLAGS: "-D warnings"
+
   sqlite_litmus:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ action, and `OwnedBy` does the common case in one line.
 
 ### Fixed
 
+- **Most minimal feature sets did not build** (#1208) — nine modules were
+  declared `pub mod` with no `cfg` while their bodies used *optional*
+  dependencies (`tera`, `rand`, `tower`, `hmac`, `async-trait`), so they only
+  compiled when some unrelated feature happened to pull the crate in. Measured
+  before: `postgres,manage` **75 errors**, `sqlite,admin` 26, `sqlite,manage`,
+  `postgres,manage,admin`, `sqlite,template_views` all broken — effectively
+  only combinations including `tenancy` worked, because `tenancy` enables all
+  four crates and masked every gap. `--no-default-features --features
+  sqlite,tenancy`, the one combination CI checked, was one of the masking ones.
+
+  `cargo rustango new --template api` emits exactly `postgres,manage`, so a
+  third of the shipped project templates generated a project that could not
+  compile (#1209).
+
+  Fixed by giving each optional dependency an internal capability feature
+  (`_rand`, `_tera`, `_tower`, `_async_trait`, `_base64`, `_signing`) that
+  product features enable in place of the raw `dep:`, and gating each module on
+  the capability it actually needs. `url_codec` and `list_params` became
+  **unconditional** — both are pure `std`, were gated for no reason, and are
+  imported by unconditional modules. Also fixed: `manage` merged the
+  `admin`-gated health router unconditionally, and `migrate::runner` /
+  `sql::m2m` emitted `signals` without the feature.
+
+  A `feature_combos` CI matrix now builds all seven combinations with
+  `-D warnings`, so a new gate gap fails the build instead of shipping.
+
 - **ViewSet: 401 for anonymous, 403 for authenticated-but-unauthorised**
   (#1193) — the permission check collapsed both cases to 403. A token client
   treats 401 as its cue to refresh, so answering 403 to a request that simply

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,37 @@ action, and `OwnedBy` does the common case in one line.
   `admin`-gated health router unconditionally, and `migrate::runner` /
   `sql::m2m` emitted `signals` without the feature.
 
-  A `feature_combos` CI matrix now builds all seven combinations with
-  `-D warnings`, so a new gate gap fails the build instead of shipping.
+  A `feature_combos` CI matrix now builds every combination with `-D warnings`
+  **and runs its unit tests**, so a new gate gap fails the build instead of
+  shipping. (`cargo check` alone misses `#[cfg(test)]` code, which is exactly
+  where a gate mismatch hides.)
+
+- **The bare ORM build finally works** — `--no-default-features --features
+  sqlite` (or `postgres`, or `mysql`) failed with **50 errors**, despite the
+  manifest advertising exactly that: *"Drop `default-features` for the bare ORM
+  (core + query + sql + migrate)"*. Same root cause as above, two more
+  dependency families:
+
+  **tokio is no longer optional.** `sqlx` is a hard dependency built with
+  `runtime-tokio`, so tokio was already compiled into every build — `optional =
+  true` only controlled whether rustango was allowed to *name* the crate it was
+  already linking. Meanwhile the modules needing it are core, not opt-in: the
+  transaction on-commit registry (`sql::executor::atomic`), the audit-source
+  task-local and the event bus are all built on `tokio::task_local!` /
+  `tokio::sync`. Gating those would have silently removed transaction hooks
+  from a bare-ORM build; making the dependency honest costs no extra crate.
+
+  **axum gets an `_axum` capability.** `http_methods`, `auth_decorators`,
+  `redirects` and `flatpages` are axum middleware end to end and now gate as
+  such. Where a module is mostly dependency-free, only the axum-typed items
+  gate: `cookies::Cookie::header_value` (the builder and `build()` stay),
+  `i18n::timezone`'s two header readers (offset parsing and activation stay),
+  and the `axum::Response` assertions in `test_assertions` — that module stays
+  unconditional because its `query_counter` submodule is ORM instrumentation
+  the executor bumps on every query.
+
+  All ten checked combinations now build clean **and pass their unit tests**
+  (1443 on bare `sqlite`, 1417 on `postgres`, 1449 on `mysql`).
 
 - **ViewSet page ceiling is the app's, not a hard-coded 1000** (#1196) — a
   client could ask for `?page_size=1000` regardless of what the app configured,

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -397,7 +397,12 @@ tenancy = [
     "_async_trait",
     "dep:argon2",
     "dep:cookie",
-    "_signing",
+    # Deliberately the exact pair tenancy carried before #1208, not `_signing`
+    # — that capability also pulls `base64`, which tenancy never depended on.
+    # The capability features exist to stop the feature table lying about what
+    # it pulls in; widening one while introducing them would defeat that.
+    "dep:hmac",
+    "dep:sha2",
     "dep:password-hash",
     "_rand",
     "dep:rpassword",

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -31,7 +31,7 @@ postgres = ["sqlx/postgres"]
 # can still use `rustango::manage::Cli::new().api(...).run().await`.
 # v0.16+. Default-on so `cargo rustango new` projects work with no
 # extra opt-ins.
-manage = ["dep:axum", "dep:tokio", "runtime"]
+manage = ["_axum", "runtime"]
 
 # Test-only constructors for downstream live tests. Currently
 # unlocks `Tenant::for_test(org, conn)` so tenancy-aware crates
@@ -82,6 +82,7 @@ sqlite = ["sqlx/sqlite"]
 _rand         = ["dep:rand"]
 _tera         = ["dep:tera"]
 _tower        = ["dep:tower"]
+_axum         = ["dep:axum"]
 _async_trait  = ["dep:async-trait"]
 _base64       = ["dep:base64"]
 # The three that always travel together for cookie/token signing.
@@ -107,7 +108,7 @@ serializer = ["forms"]
 # Caching layer (`rustango::cache`) — pluggable `Cache` trait with
 # `NullCache` (no-op) and `InMemoryCache` (tokio RwLock + TTL). Redis
 # backend is behind the separate `cache-redis` feature.
-cache = ["_async_trait", "dep:tokio", "dep:sha2"]
+cache = ["_async_trait", "dep:sha2"]
 
 # Per-view caching tower layer (`rustango::cache_page`) — Django's
 # @cache_page / @cache_control / @vary_on_headers analogs. Implies
@@ -118,7 +119,11 @@ cache-page = ["cache", "admin", "dep:base64"]
 # Signals layer (`rustango::signals`) — Django-shape pre_save / post_save
 # / pre_delete / post_delete async dispatch. Receivers register globally
 # per model type; senders fire signals after write paths.
-signals = ["dep:tokio"]
+#
+# Empty list, not dead config: the feature still gates `rustango::signals` and
+# the emission sites in `migrate::runner` / `sql::m2m`. It carried `dep:tokio`
+# until tokio became unconditional.
+signals = []
 
 # Email backends (`rustango::email`) — Mailer trait + ConsoleMailer +
 # InMemoryMailer + NullMailer. SMTP and external transports plug in via
@@ -129,7 +134,7 @@ email = ["_async_trait"]
 # Implies `email`. Pulls `lettre` with rustls TLS (no openssl).
 # Default builds don't include this — opt in when you ship to prod and
 # need a real relay (Postmark, SendGrid, AWS SES via SMTP, etc.).
-email-smtp = ["email", "dep:lettre", "dep:tokio"]
+email-smtp = ["email", "dep:lettre"]
 
 # Multi-channel notifications layer (`rustango::notifications`) — Laravel-shape
 # fan-out across mail / database / log / broadcast. Implies email + cache.
@@ -137,7 +142,7 @@ notifications = ["email", "cache"]
 
 # Background job queue (`rustango::jobs`) — Job trait, in-memory queue,
 # worker pool, retry with exponential backoff, dead-letter callback.
-jobs = ["_async_trait", "dep:tokio"]
+jobs = ["_async_trait"]
 
 # Database-backed job queue (`rustango::jobs::pg::PgJobQueue`).
 # v0.38 — tri-dialect: PostgreSQL + MySQL 8.0+ use `FOR UPDATE SKIP
@@ -155,7 +160,10 @@ auth_flows = ["signed_url"]
 
 # Broadcast event bus (`rustango::sse`) — fan-out for SSE / WebSocket /
 # signal-driven push. tokio::sync::broadcast under the hood.
-sse = ["dep:tokio"]
+#
+# Empty list, not dead config — still gates `rustango::sse`. Carried
+# `dep:tokio` until tokio became unconditional.
+sse = []
 
 # WebSocket handler scaffold (`rustango::ws`) — fan-out via the SSE
 # EventBus, axum upgrade handler with auto JSON encode/decode + ping/pong
@@ -170,19 +178,19 @@ websocket = ["admin", "sse", "axum/ws"]
 # notification bus; `serializer`/`openapi` the tool inputSchema; `jwt`
 # exposes `crate::signing` (agent-bound pagination cursors) and reflects that
 # MCP agent tokens are JWTs. Epic #1013.
-mcp = ["tenancy", "sse", "serializer", "openapi", "jwt", "dep:axum", "dep:tokio", "dep:async-stream"]
+mcp = ["tenancy", "sse", "serializer", "openapi", "jwt", "_axum", "dep:async-stream"]
 
 # OAuth2 / OIDC swiss-knife (`rustango::oauth2`) — works for pure OAuth2
 # providers (GitHub, Discord) AND OIDC providers (Google, Microsoft,
 # Apple, Keycloak) via the `/userinfo` endpoint as identity source.
 # Per-tenant via `OAuth2Registry`. Pulls reqwest (rustls — no openssl).
-oauth2 = ["_signing", "dep:reqwest", "dep:urlencoding", "dep:tokio", "_rand", "dep:subtle", "_async_trait"]
+oauth2 = ["_signing", "dep:reqwest", "dep:urlencoding", "_rand", "dep:subtle", "_async_trait"]
 
 # Opinionated HTTP client (`rustango::http_client`) — reqwest wrapper
 # with sane timeouts, exponential-backoff retry on idempotent verbs +
 # 5xx/timeout/connect failures, and a default User-Agent. Standalone
 # wrapper that any rustango app can use directly.
-http-client = ["dep:reqwest", "dep:tokio"]
+http-client = ["dep:reqwest"]
 
 # Response compression middleware (`rustango::compression`) — gzip +
 # deflate via flate2 (miniz_oxide by default, no C deps). Honors the
@@ -246,11 +254,14 @@ openapi = ["rustango-macros/openapi"]
 
 # File storage backends (`rustango::storage`) — Storage trait + LocalStorage
 # (filesystem) + InMemoryStorage (tests). S3/GCS/Azure plug in via the trait.
-storage = ["_async_trait", "dep:tokio"]
+storage = ["_async_trait"]
 
 # In-process scheduled task runner (`rustango::scheduler`) — fire async jobs
 # at fixed intervals with panic isolation per task.
-scheduler = ["dep:tokio"]
+#
+# Empty list, not dead config — still gates `rustango::scheduler`. Carried
+# `dep:tokio` until tokio became unconditional.
+scheduler = []
 
 # Secrets manager (`rustango::secrets`) — Secrets trait + EnvSecrets +
 # InMemorySecrets. Vault / AWS / GCP plug in via the trait.
@@ -299,13 +310,13 @@ cache-redis = ["cache", "dep:redis"]
 # axum middleware. Lives behind its own flag so `forms`-only users
 # (parsers without CSRF) don't pull cookie + rand + tower
 # transitively.
-csrf = ["forms", "dep:axum", "dep:base64", "dep:cookie", "_rand", "_tower"]
+csrf = ["forms", "_axum", "dep:base64", "dep:cookie", "_rand", "_tower"]
 
 # Generic class-based views for HTML templates (`rustango::template_views`)
 # — Django-shape `ListView` / `DetailView` / `CreateView` / `UpdateView` /
 # `DeleteView` over `#[derive(Model)]` types, rendered through Tera.
 # The JSON-API counterpart is `rustango::viewset` (always on).
-template_views = ["forms", "dep:axum", "_tera", "dep:tokio", "dep:serde_urlencoded"]
+template_views = ["forms", "_axum", "_tera", "dep:serde_urlencoded"]
 
 # Auto-admin HTTP layer (`rustango::admin`). Pulls in axum + Tera +
 # the supporting middleware deps. Implies `forms` + `csrf` so the
@@ -332,7 +343,7 @@ admin = [
     # Tokio was already in the admin closure; signals adds only the
     # in-process registry helpers.
     "signals",
-    "dep:axum",
+    "_axum",
     "_tera",
     "_signing",
     "dep:subtle",
@@ -343,7 +354,6 @@ admin = [
     "dep:http",
     "dep:http-body-util",
     "dep:serde_urlencoded",
-    "dep:tokio",
 ]
 
 # SSO for the admin login (`rustango::admin::sso`) — sign in with an
@@ -408,7 +418,6 @@ tenancy = [
     "dep:rpassword",
     "dep:serde_urlencoded",
     "dep:subtle",
-    "dep:tokio",
     "_tower",
 ]
 
@@ -418,17 +427,18 @@ tenancy = [
 # that don't want this dep can opt out by skipping the macro and
 # using `#[tokio::main]` directly.
 #
-# v0.31.1 (#4): `dep:tokio` so the macro can emit
-# `#[::rustango::__private_runtime::tokio::main]` and user crates no
-# longer need to add tokio to their own Cargo.toml just to use the
-# rustango entrypoint shim.
-runtime = ["dep:tracing-subscriber", "dep:tracing-appender", "dep:tokio"]
+# v0.31.1 (#4): the macro emits
+# `#[::rustango::__private_runtime::tokio::main]`, so user crates don't need
+# tokio in their own Cargo.toml just to use the rustango entrypoint shim.
+# That re-export no longer needs a feature to carry it — tokio is an
+# unconditional dependency (see the note on the `tokio` line below).
+runtime = ["dep:tracing-subscriber", "dep:tracing-appender"]
 
 # Minimal axum runserver — `rustango::server::AppBuilder`. Bi-dialect
-# single-pool bootstrap (SQLite / Postgres / MySQL). Implies axum +
-# tokio. The full multi-tenant `Builder` lives behind `tenancy` and
+# single-pool bootstrap (SQLite / Postgres / MySQL). Pulls axum; tokio is
+# unconditional. The full multi-tenant `Builder` lives behind `tenancy` and
 # pulls in much more.
-runserver = ["dep:axum", "dep:tokio"]
+runserver = ["_axum"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
@@ -475,7 +485,16 @@ serde_urlencoded = { workspace = true, optional = true }
 sha1             = { workspace = true, optional = true }
 sha2             = { workspace = true, optional = true }
 subtle           = { workspace = true, optional = true }
-tokio            = { workspace = true, optional = true }
+# Non-optional since #1208 follow-up. `sqlx` is a hard dependency built with
+# `runtime-tokio`, so tokio is already compiled into every build including
+# `--no-default-features --features sqlite` — `optional = true` only controlled
+# whether rustango was allowed to *name* the crate it was already linking.
+# Meanwhile the modules that need it are core, not opt-in: the transaction
+# on-commit registry (`sql::executor::atomic`), the audit source task-local,
+# and the event bus are all built on `tokio::task_local!` / `tokio::sync`.
+# Gating those would have silently removed transaction hooks from a bare-ORM
+# build; making the dependency honest costs no extra crate.
+tokio            = { workspace = true }
 tower            = { workspace = true, optional = true }
 redis            = { workspace = true, optional = true }
 

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -62,6 +62,31 @@ mysql = ["sqlx/mysql"]
 # don't have to remember the SQLite-default-off FK pragma.
 sqlite = ["sqlx/sqlite"]
 
+# ---------------------------------------------------------------------
+# Internal capability features (#1208). Not for downstream use — enable a
+# product feature instead; these carry a leading underscore to say so.
+#
+# The problem they solve: several modules are declared `pub mod` with no
+# `cfg` at all, but their bodies use an *optional* dependency. That only
+# builds when some unrelated product feature happens to have pulled the
+# dep in, so `--no-default-features --features postgres,manage` (and most
+# other minimal sets) failed with dozens of "unlinked crate" errors deep
+# inside the framework. `cfg(feature = "...")` cannot ask "is dep:rand
+# enabled?", so each optional dep that a module needs gets a capability
+# feature, every product feature enables the capability rather than the
+# dep, and the module gates on the capability.
+#
+# Adding an optional dep to a module? Give it a capability here, route the
+# product features through it, and gate the module — do not leave the
+# module unconditional.
+_rand         = ["dep:rand"]
+_tera         = ["dep:tera"]
+_tower        = ["dep:tower"]
+_async_trait  = ["dep:async-trait"]
+_base64       = ["dep:base64"]
+# The three that always travel together for cookie/token signing.
+_signing      = ["_base64", "dep:hmac", "dep:sha2"]
+
 # Layered TOML config (`rustango::config`). Loads `config/default.toml`
 # → `config/{env}.toml` → env-var overrides. Slice 8.3.
 config = ["dep:toml"]
@@ -82,7 +107,7 @@ serializer = ["forms"]
 # Caching layer (`rustango::cache`) — pluggable `Cache` trait with
 # `NullCache` (no-op) and `InMemoryCache` (tokio RwLock + TTL). Redis
 # backend is behind the separate `cache-redis` feature.
-cache = ["dep:async-trait", "dep:tokio", "dep:sha2"]
+cache = ["_async_trait", "dep:tokio", "dep:sha2"]
 
 # Per-view caching tower layer (`rustango::cache_page`) — Django's
 # @cache_page / @cache_control / @vary_on_headers analogs. Implies
@@ -98,7 +123,7 @@ signals = ["dep:tokio"]
 # Email backends (`rustango::email`) — Mailer trait + ConsoleMailer +
 # InMemoryMailer + NullMailer. SMTP and external transports plug in via
 # the trait.
-email = ["dep:async-trait"]
+email = ["_async_trait"]
 
 # Production SMTP backend (`rustango::email::SmtpMailer`, issue #48).
 # Implies `email`. Pulls `lettre` with rustls TLS (no openssl).
@@ -112,7 +137,7 @@ notifications = ["email", "cache"]
 
 # Background job queue (`rustango::jobs`) — Job trait, in-memory queue,
 # worker pool, retry with exponential backoff, dead-letter callback.
-jobs = ["dep:async-trait", "dep:tokio"]
+jobs = ["_async_trait", "dep:tokio"]
 
 # Database-backed job queue (`rustango::jobs::pg::PgJobQueue`).
 # v0.38 — tri-dialect: PostgreSQL + MySQL 8.0+ use `FOR UPDATE SKIP
@@ -151,7 +176,7 @@ mcp = ["tenancy", "sse", "serializer", "openapi", "jwt", "dep:axum", "dep:tokio"
 # providers (GitHub, Discord) AND OIDC providers (Google, Microsoft,
 # Apple, Keycloak) via the `/userinfo` endpoint as identity source.
 # Per-tenant via `OAuth2Registry`. Pulls reqwest (rustls — no openssl).
-oauth2 = ["dep:reqwest", "dep:urlencoding", "dep:tokio", "dep:hmac", "dep:sha2", "dep:base64", "dep:rand", "dep:subtle", "dep:async-trait"]
+oauth2 = ["_signing", "dep:reqwest", "dep:urlencoding", "dep:tokio", "_rand", "dep:subtle", "_async_trait"]
 
 # Opinionated HTTP client (`rustango::http_client`) — reqwest wrapper
 # with sane timeouts, exponential-backoff retry on idempotent verbs +
@@ -170,18 +195,18 @@ compression = ["admin", "dep:flate2"]
 # for handlers to consume, and substitutes it into the
 # Content-Security-Policy header so inline `<script nonce="…">` blocks
 # pass strict CSP. Implies `admin` (axum-only) + rand for the nonce.
-csp-nonce = ["admin", "dep:rand"]
+csp-nonce = ["admin", "_rand"]
 
 # Server-side sessions (`rustango::sessions`) — opaque cookie ID
 # backed by any `Cache` implementation. Implies `cache` + rand for
 # the ID + base64 for encoding it.
-sessions = ["cache", "dep:rand", "dep:base64"]
+sessions = ["cache", "_rand", "dep:base64"]
 
 # HMAC-signed request authentication (`rustango::hmac_auth`) for
 # service-to-service traffic. AWS-style canonical request signed with
 # SHA-256, replay-bounded by an X-Date tolerance window. Implies
 # `admin` (axum) + the existing webhook crypto deps.
-hmac-auth = ["admin", "dep:hmac", "dep:sha2", "dep:subtle", "dep:base64"]
+hmac-auth = ["_signing", "admin", "dep:subtle"]
 
 # Standalone HS256 JWT (`rustango::jwt`) — sign / verify / decode for
 # magic links, microservice tokens, third-party SSO. Standalone
@@ -189,7 +214,7 @@ hmac-auth = ["admin", "dep:hmac", "dep:sha2", "dep:subtle", "dep:base64"]
 # blacklist + sliding rotation but is gated on tenancy; since v0.48
 # its blacklist is also pluggable via `Arc<dyn rustango::jti_store::JtiStore>`
 # for multi-instance deployments).
-jwt = ["dep:hmac", "dep:sha2", "dep:subtle", "dep:base64"]
+jwt = ["_signing", "dep:subtle"]
 
 # Multipart file upload helper (`rustango::uploads`) — wraps
 # axum's multipart extractor + the `storage::Storage` trait so file
@@ -221,7 +246,7 @@ openapi = ["rustango-macros/openapi"]
 
 # File storage backends (`rustango::storage`) — Storage trait + LocalStorage
 # (filesystem) + InMemoryStorage (tests). S3/GCS/Azure plug in via the trait.
-storage = ["dep:async-trait", "dep:tokio"]
+storage = ["_async_trait", "dep:tokio"]
 
 # In-process scheduled task runner (`rustango::scheduler`) — fire async jobs
 # at fixed intervals with panic isolation per task.
@@ -229,24 +254,24 @@ scheduler = ["dep:tokio"]
 
 # Secrets manager (`rustango::secrets`) — Secrets trait + EnvSecrets +
 # InMemorySecrets. Vault / AWS / GCP plug in via the trait.
-secrets = ["dep:async-trait"]
+secrets = ["_async_trait"]
 # Attribute casts (#819) — `Cast<C>` field wrapper + `CastValue` trait;
 # the `EncryptedString` built-in pulls XChaCha20-Poly1305 + base64 + a
 # SHA-256 key derivation (`rand` for the per-write nonce).
-casts = ["dep:chacha20poly1305", "dep:base64", "dep:rand", "dep:sha2"]
+casts = ["dep:chacha20poly1305", "dep:base64", "_rand", "dep:sha2"]
 
 # TOTP / 2FA (`rustango::totp`) — RFC 6238 time-based one-time passwords
 # for second-factor authentication. SHA-1 (Google Authenticator default).
-totp = ["dep:hmac", "dep:sha1", "dep:rand", "dep:subtle"]
+totp = ["dep:hmac", "dep:sha1", "_rand", "dep:subtle"]
 # Passkey / WebAuthn (#392). Foundation slice = credential storage only
 # (no extra deps). The ceremony layer adds pure-Rust CBOR (`ciborium`) +
 # ES256 (`p256`) when it lands — keeping the all-RustCrypto, no-C-dep
 # stack (vs `webauthn-rs` → openssl).
-passkey = ["dep:rand", "dep:base64", "dep:sha2", "dep:subtle", "dep:ciborium", "dep:p256"]
+passkey = ["_rand", "dep:base64", "dep:sha2", "dep:subtle", "dep:ciborium", "dep:p256"]
 
 # Webhook signature verification (`rustango::webhook`) — HMAC-SHA256
 # constant-time verification for inbound webhooks (Stripe, GitHub, etc.).
-webhook = ["dep:hmac", "dep:sha2", "dep:subtle", "dep:base64"]
+webhook = ["_signing", "dep:subtle"]
 
 # Outbound webhook delivery (`rustango::webhook_delivery`) — POSTs an
 # HMAC-signed JSON payload to a subscriber URL via the background job
@@ -256,7 +281,7 @@ webhook-delivery = ["webhook", "jobs", "dep:reqwest"]
 
 # API keys (`rustango::api_keys`) — standalone generate/hash/verify
 # helpers for `{prefix}.{secret}` keys with argon2id hashing.
-api_keys = ["dep:argon2", "dep:password-hash", "dep:rand"]
+api_keys = ["dep:argon2", "dep:password-hash", "_rand"]
 
 # Generic password helpers (`rustango::passwords`) — argon2id hash/verify
 # + minimal strength check. Standalone alternative to tenancy::password.
@@ -264,7 +289,7 @@ passwords = ["dep:argon2", "dep:password-hash"]
 
 # Signed URL helpers (`rustango::signed_url`) — HMAC-SHA256 signed URLs
 # with optional expiry. For magic-link login, password resets, etc.
-signed_url = ["dep:hmac", "dep:sha2", "dep:subtle", "dep:base64"]
+signed_url = ["_signing", "dep:subtle"]
 
 # Redis cache backend (`rustango::cache::RedisCache`). Adds the `redis`
 # async connection-manager client. Implies `cache`.
@@ -274,13 +299,13 @@ cache-redis = ["cache", "dep:redis"]
 # axum middleware. Lives behind its own flag so `forms`-only users
 # (parsers without CSRF) don't pull cookie + rand + tower
 # transitively.
-csrf = ["forms", "dep:axum", "dep:base64", "dep:cookie", "dep:rand", "dep:tower"]
+csrf = ["forms", "dep:axum", "dep:base64", "dep:cookie", "_rand", "_tower"]
 
 # Generic class-based views for HTML templates (`rustango::template_views`)
 # — Django-shape `ListView` / `DetailView` / `CreateView` / `UpdateView` /
 # `DeleteView` over `#[derive(Model)]` types, rendered through Tera.
 # The JSON-API counterpart is `rustango::viewset` (always on).
-template_views = ["forms", "dep:axum", "dep:tera", "dep:tokio"]
+template_views = ["forms", "dep:axum", "_tera", "dep:tokio", "dep:serde_urlencoded"]
 
 # Auto-admin HTTP layer (`rustango::admin`). Pulls in axum + Tera +
 # the supporting middleware deps. Implies `forms` + `csrf` so the
@@ -308,10 +333,8 @@ admin = [
     # in-process registry helpers.
     "signals",
     "dep:axum",
-    "dep:tera",
-    "dep:base64",
-    "dep:hmac",
-    "dep:sha2",
+    "_tera",
+    "_signing",
     "dep:subtle",
     # `manage create-admin` (slice B) prompts for a password
     # interactively when `--password` isn't supplied. `rpassword` was
@@ -371,18 +394,17 @@ tenancy = [
     "signals",
     "storage",
     "uploads",
-    "dep:async-trait",
+    "_async_trait",
     "dep:argon2",
     "dep:cookie",
-    "dep:hmac",
+    "_signing",
     "dep:password-hash",
-    "dep:rand",
+    "_rand",
     "dep:rpassword",
     "dep:serde_urlencoded",
-    "dep:sha2",
     "dep:subtle",
     "dep:tokio",
-    "dep:tower",
+    "_tower",
 ]
 
 # `#[rustango::main]` runserver shim (slice 9.0 / 0.8.2). Pulls in

--- a/crates/rustango/src/cookies.rs
+++ b/crates/rustango/src/cookies.rs
@@ -241,6 +241,11 @@ impl Cookie {
     /// invalid (control characters, etc.) — should never happen
     /// with sane caller-supplied names/values, but exposed as
     /// `Option` to avoid panicking on attacker-controlled input.
+    ///
+    /// The one axum-typed method on an otherwise dependency-free builder, so
+    /// it gates alone rather than taking the module with it — `build()` still
+    /// returns the same cookie as a `String` in a bare-ORM build.
+    #[cfg(feature = "_axum")]
     #[must_use]
     pub fn header_value(&self) -> Option<axum::http::HeaderValue> {
         axum::http::HeaderValue::from_str(&self.build()).ok()
@@ -438,13 +443,18 @@ mod tests {
     }
 
     // -------- header_value --------
+    //
+    // Follow the `_axum` gate on the method they exercise; the rest of the
+    // cookie suite is dependency-free.
 
+    #[cfg(feature = "_axum")]
     #[test]
     fn header_value_returns_some_for_normal_cookie() {
         let v = Cookie::new("session", "abc").path("/").header_value();
         assert!(v.is_some());
     }
 
+    #[cfg(feature = "_axum")]
     #[test]
     fn header_value_returns_none_for_invalid_chars() {
         // A NUL byte in the value should make axum reject the

--- a/crates/rustango/src/i18n/admin.rs
+++ b/crates/rustango/src/i18n/admin.rs
@@ -39,6 +39,9 @@
 
 #[cfg(feature = "admin")]
 use crate::i18n::db::{all_pool, delete_key_pool, upsert_pool, Translation};
+// Only the `admin`-gated functions below take a pool, so the import follows
+// the same gate — it was unconditional and warned in every admin-less build.
+#[cfg(feature = "admin")]
 use crate::sql::Pool;
 
 /// A single key's value across the active locales, for the pivoted grid.

--- a/crates/rustango/src/i18n/mod.rs
+++ b/crates/rustango/src/i18n/mod.rs
@@ -42,7 +42,13 @@ use std::sync::RwLock;
 
 pub mod admin;
 pub mod db;
+// Both gated since #1208: `middleware` is a tower `Service`/`Layer` impl and
+// `tera_tags` is a Tera integration, but `tower` and `tera` are optional
+// dependencies. Left unconditional, they broke every feature set that didn't
+// happen to pull those crates in.
+#[cfg(feature = "_tower")]
 pub mod middleware;
+#[cfg(feature = "_tera")]
 pub mod tera_tags;
 pub mod timezone;
 

--- a/crates/rustango/src/i18n/timezone.rs
+++ b/crates/rustango/src/i18n/timezone.rs
@@ -173,6 +173,11 @@ pub fn parse_offset(s: &str) -> Option<FixedOffset> {
 /// Used by [`from_request_headers`] to feed the active timezone.
 /// Public so apps that wire their own middleware stack can reuse
 /// the decode step.
+///
+/// This and [`from_request_headers`] are the only axum-typed items here, so
+/// they gate on `_axum` rather than taking the module with them — offset
+/// parsing, activation and the task-local stay available everywhere.
+#[cfg(feature = "_axum")]
 pub fn from_cookie(headers: &axum::http::HeaderMap, cookie_name: &str) -> Option<FixedOffset> {
     let raw = headers
         .get(axum::http::header::COOKIE)
@@ -201,6 +206,7 @@ pub fn from_cookie(headers: &axum::http::HeaderMap, cookie_name: &str) -> Option
 ///   document.cookie = `tz_offset=${m};path=/;max-age=31536000`;
 /// </script>
 /// ```
+#[cfg(feature = "_axum")]
 pub fn from_request_headers(
     headers: &axum::http::HeaderMap,
     cookie_name: &str,
@@ -362,6 +368,9 @@ mod tests {
         assert_eq!(parse_offset("+05:99"), None); // minute out of range
     }
 
+    // The next four follow the `_axum` gate on the header-reading functions
+    // they exercise; the offset-parsing and activation tests stay ungated.
+    #[cfg(feature = "_axum")]
     #[test]
     fn from_cookie_finds_named_cookie() {
         let mut headers = axum::http::HeaderMap::new();
@@ -373,12 +382,14 @@ mod tests {
         assert_eq!(off.local_minus_utc(), 5 * 3600 + 30 * 60);
     }
 
+    #[cfg(feature = "_axum")]
     #[test]
     fn from_cookie_returns_none_when_absent() {
         let headers = axum::http::HeaderMap::new();
         assert!(from_cookie(&headers, "tz_offset").is_none());
     }
 
+    #[cfg(feature = "_axum")]
     #[test]
     fn from_request_headers_falls_back_to_time_zone_header() {
         let mut headers = axum::http::HeaderMap::new();
@@ -387,6 +398,7 @@ mod tests {
         assert_eq!(off.local_minus_utc(), 9 * 3600);
     }
 
+    #[cfg(feature = "_axum")]
     #[test]
     fn from_request_headers_prefers_cookie_over_header() {
         let mut headers = axum::http::HeaderMap::new();

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -1226,6 +1226,10 @@ pub mod cookies;
 /// middleware. Rejects unallowed methods with `405 Method Not
 /// Allowed` + RFC 7231-compliant `Allow:` header listing the
 /// accepted set.
+///
+/// Gated on `_axum` — it is tower middleware over `axum::extract::Request`,
+/// and `axum` is an optional dependency absent from a bare-ORM build.
+#[cfg(feature = "_axum")]
 pub mod http_methods;
 
 /// Django messages framework — `messages.success/info/warning/error/debug`
@@ -1238,6 +1242,9 @@ pub mod messages;
 
 /// Django-shape access decorators — `login_required` middleware +
 /// `?next=` round-trip helpers. Issue #11.
+///
+/// Gated on `_axum` — the module is axum middleware end to end.
+#[cfg(feature = "_axum")]
 pub mod auth_decorators;
 
 /// Pluggable `AUTHENTICATION_BACKENDS` chain — register an ordered
@@ -1309,6 +1316,11 @@ pub mod syndication;
 /// mount [`redirects::redirects_middleware`] on your axum router;
 /// matching requests short-circuit with a 301/302 response and the
 /// canonical URL in `Location`, query strings preserved. Issue #57.
+///
+/// The next three gate on `_axum` — each is axum middleware (or assertions
+/// over an `axum::Response`), and `axum` is optional. They were unconditional,
+/// which is most of why `--features sqlite` alone never built.
+#[cfg(feature = "_axum")]
 pub mod redirects;
 
 /// Static "flat pages" — `django.contrib.flatpages`. Build a
@@ -1316,11 +1328,17 @@ pub mod redirects;
 /// mount [`flatpages::flatpages_middleware`] on your axum router;
 /// matching requests serve the page body with `text/html` (or a
 /// custom content-type). Bring your own Tera wrapping. Issue #57.
+#[cfg(feature = "_axum")]
 pub mod flatpages;
 
 /// Django-shape test assertion helpers — `assert_contains` /
 /// `assert_redirects` / `assert_status` / `assert_messages` on axum
 /// Response objects. Issue #40.
+///
+/// Stays unconditional: its `query_counter` submodule is ORM instrumentation
+/// that `sql::executor` bumps on **every** query, so gating the module would
+/// break a bare-ORM build. The `axum::Response` assertions inside it carry
+/// their own `_axum` gate instead.
 pub mod test_assertions;
 
 /// Tag-based test filtering — Django's `@tag('slow')` +

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -602,7 +602,11 @@ pub(crate) mod hex;
 /// directly (otherwise the `uri_to_iri` / `filepath_to_uri` /
 /// `escape_uri_path` / `is_uri_reserved` helpers shipped by the
 /// `django.utils` parity sweep would be unreachable).
-#[cfg(any(feature = "signed_url", feature = "auth_flows", feature = "tenancy",))]
+/// Unconditional since #1208. The module is pure `std` — it has no
+/// dependencies at all — yet it was gated on
+/// `any(signed_url, auth_flows, tenancy)` while unconditional modules
+/// ([`pagination`], [`urls`], [`crypto`], [`default_filters`]) import it.
+/// Any feature set without one of those three failed to build.
 pub mod url_codec;
 
 /// AWS-style canonical request signed with SHA-256, replay-bounded
@@ -1046,7 +1050,10 @@ pub mod viewset;
 /// `?page_size=` clamping. Used by both `viewset::handle_list` and
 /// the `template_views::ListView` CBV. Closes the drift hazard
 /// flagged in issue #809.
-#[cfg(any(feature = "tenancy", feature = "template_views"))]
+///
+/// Unconditional since #1208 — it depends on nothing but `std` and
+/// [`core`], and `viewset` (gated on `any(admin, tenancy)`) uses it, so
+/// the old `any(tenancy, template_views)` gate broke `admin` alone.
 pub mod list_params;
 
 /// Generic class-based views for HTML templates (Django-shape) —
@@ -1068,14 +1075,22 @@ pub mod template_views;
 
 /// Django-shape DEBUG template-error overlay — see [`template_debug`].
 /// Issue #386.
+///
+/// The next three modules are pure Tera integrations, so they gate on
+/// `_tera` (#1208). They were unconditional while `tera` is an optional
+/// dependency, which is why any feature set without `template_views` or
+/// `admin` failed to build.
+#[cfg(feature = "_tera")]
 pub mod template_debug;
 
 /// Django-shape template context processors — see
 /// [`template_context_processors`]. Issue #384.
+#[cfg(feature = "_tera")]
 pub mod template_context_processors;
 
 /// Django-shape custom template filters + functions — see
 /// [`template_extensions`]. Issue #383.
+#[cfg(feature = "_tera")]
 pub mod template_extensions;
 
 /// Django-shape view shortcuts — `get_object_or_404` / `get_list_or_404`
@@ -1137,6 +1152,10 @@ pub mod urls;
 /// Django-shape random-string helpers — `get_random_string`,
 /// `get_random_token_urlsafe`. CSPRNG-backed, suitable for
 /// session IDs, reset tokens, verification codes.
+///
+/// Gated on `_rand` since #1208 — the module *is* `rand`, and `rand` is
+/// an optional dependency.
+#[cfg(feature = "_rand")]
 pub mod random;
 
 /// Django-shape base36 integer encoding — used in password reset
@@ -1152,6 +1171,10 @@ pub mod base62;
 /// Django-shape lorem ipsum generators — placeholder text for
 /// demos, test fixtures, template scaffolds. `lorem::words(n)`,
 /// `lorem::paragraphs(n)`, `lorem::sentence()`.
+///
+/// Gated on `_rand` since #1208 — it shuffles with `rand`, an optional
+/// dependency.
+#[cfg(feature = "_rand")]
 pub mod lorem;
 
 /// Django-shape HTTP date parser + formatter — RFC 1123 / RFC 850 /
@@ -1207,6 +1230,10 @@ pub mod http_methods;
 
 /// Django messages framework — `messages.success/info/warning/error/debug`
 /// flash storage backed by a signed cookie. Issue #9.
+///
+/// Gated on `_signing` since #1208: the cookie is HMAC-signed, so the
+/// module needs `hmac` + `sha2` + `base64`, all optional dependencies.
+#[cfg(feature = "_signing")]
 pub mod messages;
 
 /// Django-shape access decorators — `login_required` middleware +
@@ -1217,6 +1244,10 @@ pub mod auth_decorators;
 /// list of [`auth_backends::AuthBackend`] impls; the chain returns
 /// the first non-`None` result. Ships `RemoteUserBackend` for SSO
 /// proxy deployments. Issue #54 (partial).
+///
+/// Gated on `_async_trait` since #1208 — `AuthBackend` is an async trait
+/// used as `dyn`, which needs `#[async_trait]`, an optional dependency.
+#[cfg(feature = "_async_trait")]
 pub mod auth_backends;
 
 /// Pluggable `AUTH_PASSWORD_VALIDATORS` chain — run an ordered list

--- a/crates/rustango/src/manage.rs
+++ b/crates/rustango/src/manage.rs
@@ -837,6 +837,10 @@ impl Cli {
             } else {
                 api
             };
+            // `crate::health` is `#[cfg(feature = "admin")]`, so the merge has
+            // to be too (#1208) — it was unconditional, which broke every
+            // admin-less build.
+            #[cfg(feature = "admin")]
             let api = if self.health_endpoints {
                 api.merge(crate::health::health_router(pool.clone()))
             } else {

--- a/crates/rustango/src/manage.rs
+++ b/crates/rustango/src/manage.rs
@@ -1541,6 +1541,9 @@ mod tests {
     /// router unchanged (no panic) when the user's api already
     /// routes `GET /`. Pre-fix this aborted the process at boot
     /// for any tenancy project with a per-tenant `/` handler.
+    // `try_mount_welcome` is `#[cfg(feature = "admin")]`, so these two follow
+    // it. Only visible once `postgres,manage` compiled at all (#1208).
+    #[cfg(feature = "admin")]
     #[test]
     fn try_mount_welcome_skips_on_root_collision_no_panic() {
         use axum::routing::get;
@@ -1555,6 +1558,7 @@ mod tests {
     /// `try_mount_welcome` mounts welcome cleanly when no
     /// conflict exists (the common case for fresh projects with
     /// no root handler).
+    #[cfg(feature = "admin")]
     #[test]
     fn try_mount_welcome_succeeds_on_empty_router() {
         let api = Router::new();

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -275,9 +275,13 @@ fn bootstrap_models() -> Vec<&'static ModelSchema> {
 /// constraint violation).
 #[cfg(feature = "postgres")]
 pub async fn apply_all(pool: &PgPool) -> Result<(), MigrateError> {
+    // `signals` is optional, so the pre/post_migrate emissions are gated
+    // (#1208) — they were unconditional while the module is not.
+    #[cfg(feature = "signals")]
     use crate::signals::migrate::{
         send_post_migrate, send_pre_migrate, PostMigrateContext, PreMigrateContext,
     };
+    #[cfg(feature = "signals")]
     send_pre_migrate(PreMigrateContext {
         source: "apply_all",
     })
@@ -295,6 +299,7 @@ pub async fn apply_all(pool: &PgPool) -> Result<(), MigrateError> {
     }
     // #411 — post_migrate fires once after the bootstrap walk
     // completes successfully.
+    #[cfg(feature = "signals")]
     send_post_migrate(PostMigrateContext {
         source: "apply_all",
         applied: Vec::new(),
@@ -333,9 +338,11 @@ pub async fn drop_all(pool: &PgPool) -> Result<(), MigrateError> {
 /// # Errors
 /// As [`apply_all`].
 pub async fn apply_all_pool(pool: &crate::sql::Pool) -> Result<(), MigrateError> {
+    #[cfg(feature = "signals")]
     use crate::signals::migrate::{
         send_post_migrate, send_pre_migrate, PostMigrateContext, PreMigrateContext,
     };
+    #[cfg(feature = "signals")]
     send_pre_migrate(PreMigrateContext {
         source: "apply_all_pool",
     })
@@ -370,6 +377,7 @@ pub async fn apply_all_pool(pool: &crate::sql::Pool) -> Result<(), MigrateError>
     // #411 — post_migrate fires once after the bootstrap walk
     // completes. `applied` is empty because apply_all_pool doesn't
     // carry per-migration names — it walks the model inventory.
+    #[cfg(feature = "signals")]
     send_post_migrate(PostMigrateContext {
         source: "apply_all_pool",
         applied: Vec::new(),
@@ -428,9 +436,11 @@ async fn migrate_with_ledger(
     dir: &Path,
     ledger: &str,
 ) -> Result<Vec<Migration>, MigrateError> {
+    #[cfg(feature = "signals")]
     use crate::signals::migrate::{
         send_post_migrate, send_pre_migrate, PostMigrateContext, PreMigrateContext,
     };
+    #[cfg(feature = "signals")]
     send_pre_migrate(PreMigrateContext { source: "migrate" }).await;
     ensure_ledger_for(pool, ledger).await?;
     let newly = with_migrate_lock(pool, async {
@@ -462,6 +472,7 @@ async fn migrate_with_ledger(
     // #411 — post_migrate fires once after the file-based migrate
     // session completes. `applied` lists newly-applied migration
     // names (empty when everything was already applied).
+    #[cfg(feature = "signals")]
     send_post_migrate(PostMigrateContext {
         source: "migrate",
         applied: newly.iter().map(|m| m.name.clone()).collect(),

--- a/crates/rustango/src/sql/m2m.rs
+++ b/crates/rustango/src/sql/m2m.rs
@@ -100,6 +100,9 @@ impl M2MManager {
         let binds = vec![SqlValue::I64(self.src_pk_i64()), SqlValue::I64(dst_id)];
         super::executor::raw_execute_pool(pool, &sql, binds).await?;
         // #410 — fire m2m_changed after successful junction-row write.
+        // `signals` is an optional feature, so every emission below is gated
+        // (#1208) — these statements were unconditional while the module is not.
+        #[cfg(feature = "signals")]
         crate::signals::m2m::send_m2m_changed(crate::signals::m2m::M2mChangedContext {
             action: crate::signals::m2m::M2mAction::Add,
             through: self.through,
@@ -130,6 +133,7 @@ impl M2MManager {
         let binds = vec![SqlValue::I64(self.src_pk_i64()), SqlValue::I64(dst_id)];
         super::executor::raw_execute_pool(pool, &sql, binds).await?;
         // #410 — fire m2m_changed after successful junction-row remove.
+        #[cfg(feature = "signals")]
         crate::signals::m2m::send_m2m_changed(crate::signals::m2m::M2mChangedContext {
             action: crate::signals::m2m::M2mAction::Remove,
             through: self.through,
@@ -197,6 +201,7 @@ impl M2MManager {
         // #410 — fire m2m_changed after the atomic DELETE+INSERT
         // commits. `dst_pks` is the new full set (may be empty when
         // `set([])` was called).
+        #[cfg(feature = "signals")]
         crate::signals::m2m::send_m2m_changed(crate::signals::m2m::M2mChangedContext {
             action: crate::signals::m2m::M2mAction::Set,
             through: self.through,
@@ -225,6 +230,7 @@ impl M2MManager {
         let binds = vec![SqlValue::I64(self.src_pk_i64())];
         super::executor::raw_execute_pool(pool, &sql, binds).await?;
         // #410 — fire m2m_changed after clear.
+        #[cfg(feature = "signals")]
         crate::signals::m2m::send_m2m_changed(crate::signals::m2m::M2mChangedContext {
             action: crate::signals::m2m::M2mAction::Clear,
             through: self.through,
@@ -319,6 +325,11 @@ impl GenericM2MManager {
 
     /// Fire `m2m_changed` for a junction mutation (reuses the monomorphic
     /// signal context; `src_col` reports the polymorphic `pk_col`).
+    ///
+    /// Gated with its call sites (#1208) — the parameter type comes from the
+    /// optional `signals` module, so the signature itself cannot exist without
+    /// the feature.
+    #[cfg(feature = "signals")]
     async fn signal(&self, action: crate::signals::m2m::M2mAction, dst_pks: Vec<i64>) {
         crate::signals::m2m::send_m2m_changed(crate::signals::m2m::M2mChangedContext {
             action,
@@ -378,6 +389,7 @@ impl GenericM2MManager {
             SqlValue::I64(dst_id),
         ];
         super::executor::raw_execute_pool(pool, &sql, binds).await?;
+        #[cfg(feature = "signals")]
         self.signal(crate::signals::m2m::M2mAction::Add, vec![dst_id])
             .await;
         Ok(())
@@ -406,6 +418,7 @@ impl GenericM2MManager {
             SqlValue::I64(dst_id),
         ];
         super::executor::raw_execute_pool(pool, &sql, binds).await?;
+        #[cfg(feature = "signals")]
         self.signal(crate::signals::m2m::M2mAction::Remove, vec![dst_id])
             .await;
         Ok(())
@@ -464,6 +477,7 @@ impl GenericM2MManager {
             crate::sql::raw_execute_tx(&mut tx, &ins_sql, binds).await?;
         }
         tx.commit().await.map_err(ExecError::Driver)?;
+        #[cfg(feature = "signals")]
         self.signal(crate::signals::m2m::M2mAction::Set, ids.to_vec())
             .await;
         Ok(())
@@ -486,6 +500,7 @@ impl GenericM2MManager {
         );
         let binds = vec![SqlValue::I64(self.src_pk_i64()), SqlValue::I64(ct)];
         super::executor::raw_execute_pool(pool, &sql, binds).await?;
+        #[cfg(feature = "signals")]
         self.signal(crate::signals::m2m::M2mAction::Clear, Vec::new())
             .await;
         Ok(())

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -97,7 +97,10 @@ pub use foreign_key::ForeignKey;
 pub use m2m::{GenericM2MManager, M2MManager};
 #[cfg(feature = "mysql")]
 pub use mysql::MySql;
-#[cfg(all(feature = "sqlite", feature = "manage"))]
+// Both call sites (`manage::dispatch`) sit inside `tenancy` gates, so the
+// re-export needs `tenancy` too (#1208) — without it, `sqlite,manage` warned
+// about an unused import.
+#[cfg(all(feature = "sqlite", feature = "manage", feature = "tenancy"))]
 pub(crate) use pool::sqlite_connect_options;
 pub use pool::{Pool, PoolError};
 pub use postgres::Postgres;

--- a/crates/rustango/src/test_assertions.rs
+++ b/crates/rustango/src/test_assertions.rs
@@ -73,8 +73,15 @@
 //! beyond `axum::Response` plus the existing test_client redirect
 //! follower.
 
+// Every assertion below is over an `axum::Response`, so the HTTP half of this
+// module gates on `_axum` (#1208 follow-up). `query_counter` does not: it is
+// ORM instrumentation that `sql::executor` bumps on every query, so it must
+// stay available in a bare-ORM build with no axum in the graph.
+#[cfg(feature = "_axum")]
 use axum::body::to_bytes;
+#[cfg(feature = "_axum")]
 use axum::http::header;
+#[cfg(feature = "_axum")]
 use axum::response::Response;
 
 pub mod query_counter;
@@ -83,6 +90,7 @@ pub use query_counter::{assert_num_queries, QueryCounter};
 /// Maximum bytes consumed from a response body for inspection.
 /// 1 MiB is far above any reasonable test payload; gives a clean
 /// error if a streamed body would otherwise hang the test.
+#[cfg(feature = "_axum")]
 const MAX_BODY_BYTES: usize = 1024 * 1024;
 
 /// Assert the response status equals `expected`. Panics on mismatch
@@ -92,6 +100,7 @@ const MAX_BODY_BYTES: usize = 1024 * 1024;
 /// assert_status(&res, 200);
 /// assert_status(&res, 404);
 /// ```
+#[cfg(feature = "_axum")]
 pub fn assert_status(res: &Response, expected: u16) {
     let actual = res.status().as_u16();
     assert_eq!(
@@ -109,6 +118,7 @@ pub fn assert_status(res: &Response, expected: u16) {
 /// assert_status_in(&res, &[200, 201]);
 /// assert_status_in(&res, &[301, 302, 307, 308]);
 /// ```
+#[cfg(feature = "_axum")]
 pub fn assert_status_in(res: &Response, allowed: &[u16]) {
     let actual = res.status().as_u16();
     assert!(
@@ -119,6 +129,7 @@ pub fn assert_status_in(res: &Response, allowed: &[u16]) {
 
 /// Assert the response status is in the 2xx range (success).
 /// Sugar for the very common "any success" check.
+#[cfg(feature = "_axum")]
 pub fn assert_status_2xx(res: &Response) {
     let actual = res.status().as_u16();
     assert!(
@@ -128,6 +139,7 @@ pub fn assert_status_2xx(res: &Response) {
 }
 
 /// Assert the response status is in the 4xx range (client error).
+#[cfg(feature = "_axum")]
 pub fn assert_status_4xx(res: &Response) {
     let actual = res.status().as_u16();
     assert!(
@@ -139,6 +151,7 @@ pub fn assert_status_4xx(res: &Response) {
 /// Assert the response status is in the 5xx range (server error).
 /// Useful for negative tests of error pages / handlers that must
 /// surface internal failures rather than degrade silently.
+#[cfg(feature = "_axum")]
 pub fn assert_status_5xx(res: &Response) {
     let actual = res.status().as_u16();
     assert!(
@@ -169,6 +182,7 @@ pub fn assert_status_5xx(res: &Response) {
 /// fragment isn't found. Snippet of the actual body (truncated +
 /// "more chars" indicator) is included in the panic message for fast
 /// debugging.
+#[cfg(feature = "_axum")]
 pub async fn assert_contains(res: Response, fragment: &str) {
     let body = to_bytes(res.into_body(), MAX_BODY_BYTES)
         .await
@@ -185,6 +199,7 @@ pub async fn assert_contains(res: Response, fragment: &str) {
 /// Inverse of [`assert_contains`] — panics when the fragment IS
 /// found. Useful for "the deleted post shouldn't appear in the list"
 /// style assertions.
+#[cfg(feature = "_axum")]
 pub async fn assert_not_contains(res: Response, fragment: &str) {
     let body = to_bytes(res.into_body(), MAX_BODY_BYTES)
         .await
@@ -208,6 +223,7 @@ pub async fn assert_not_contains(res: Response, fragment: &str) {
 ///
 /// Does NOT follow the redirect or check what the target serves —
 /// pair with [`assert_redirect_chain`] for that.
+#[cfg(feature = "_axum")]
 pub fn assert_redirects(res: &Response, target: &str) {
     let status = res.status();
     assert!(
@@ -242,7 +258,7 @@ pub fn assert_redirects(res: &Response, target: &str) {
 /// clear-cookie with `Max-Age=0`).
 // `_signing` as well as `template_views` (#1208): this reads the HMAC-signed
 // messages cookie, and `crate::messages` now gates on the signing capability.
-#[cfg(all(feature = "template_views", feature = "_signing"))]
+#[cfg(all(feature = "template_views", feature = "_signing", feature = "_axum"))]
 pub fn assert_messages(res: &Response, secret: &[u8], expected: &[(&str, &str)]) {
     use crate::messages::{Level, MESSAGES_COOKIE};
     use std::str::FromStr as _;
@@ -320,6 +336,7 @@ pub fn assert_messages(res: &Response, secret: &[u8], expected: &[(&str, &str)])
 /// Panics if the header is missing or carries a different value.
 /// Multiple headers with the same name match the FIRST occurrence
 /// (axum's default header API surfaces them in order).
+#[cfg(feature = "_axum")]
 pub fn assert_header(res: &Response, name: &str, value: &str) {
     let actual = res
         .headers()
@@ -339,6 +356,7 @@ pub fn assert_header(res: &Response, name: &str, value: &str) {
 /// assert_content_type(&res, "application/json");
 /// assert_content_type(&res, "text/html; charset=utf-8");
 /// ```
+#[cfg(feature = "_axum")]
 pub fn assert_content_type(res: &Response, expected: &str) {
     assert_header(res, "content-type", expected);
 }
@@ -355,6 +373,7 @@ pub fn assert_content_type(res: &Response, expected: &str) {
 /// Panics with both bodies in the message when:
 /// - the response body isn't valid JSON;
 /// - the parsed body doesn't structurally equal `expected`.
+#[cfg(feature = "_axum")]
 pub async fn assert_json_eq(res: Response, expected: &serde_json::Value) {
     let bytes = to_bytes(res.into_body(), MAX_BODY_BYTES)
         .await
@@ -385,6 +404,7 @@ pub async fn assert_json_eq(res: Response, expected: &serde_json::Value) {
 /// ```ignore
 /// assert_json_not_eq(res, &serde_json::json!({"password": "leaked"})).await;
 /// ```
+#[cfg(feature = "_axum")]
 pub async fn assert_json_not_eq(res: Response, unexpected: &serde_json::Value) {
     let bytes = to_bytes(res.into_body(), MAX_BODY_BYTES)
         .await
@@ -420,6 +440,7 @@ pub async fn assert_json_not_eq(res: Response, unexpected: &serde_json::Value) {
 /// Panics with the full chain in the message when the final hop's
 /// status or path doesn't match — so a misconfigured chain is easy
 /// to diagnose.
+#[cfg(feature = "_axum")]
 pub fn assert_redirect_chain(chain: &[(u16, String)], final_path: &str, final_status: u16) {
     let last = chain
         .last()
@@ -449,6 +470,7 @@ pub fn assert_redirect_chain(chain: &[(u16, String)], final_path: &str, final_st
 ///
 /// Panics with the actual count and a 500-char body snippet when
 /// the counts don't match.
+#[cfg(feature = "_axum")]
 pub async fn assert_contains_count(res: Response, fragment: &str, count: usize) {
     let bytes = to_bytes(res.into_body(), MAX_BODY_BYTES)
         .await
@@ -479,6 +501,7 @@ pub async fn assert_contains_count(res: Response, fragment: &str, count: usize) 
 ///
 /// Panics with the full Set-Cookie list when no header for that
 /// name is found, or when the value doesn't match.
+#[cfg(feature = "_axum")]
 pub fn assert_cookie_set(res: &Response, name: &str, expected_value: Option<&str>) {
     let mut matches: Vec<String> = Vec::new();
     for v in res.headers().get_all(axum::http::header::SET_COOKIE).iter() {
@@ -515,6 +538,7 @@ pub fn assert_cookie_set(res: &Response, name: &str, expected_value: Option<&str
 /// `name` IS present. Use to verify that a handler did NOT set a
 /// cookie under specific conditions (logged-out request shouldn't
 /// touch the session cookie, etc.).
+#[cfg(feature = "_axum")]
 pub fn assert_cookie_not_set(res: &Response, name: &str) {
     for v in res.headers().get_all(axum::http::header::SET_COOKIE).iter() {
         let Ok(s) = v.to_str() else { continue };
@@ -530,6 +554,9 @@ pub fn assert_cookie_not_set(res: &Response, name: &str) {
 /// Truncate a string at a UTF-8 char boundary at or before `max`,
 /// appending a `...(N more chars)` indicator so the panic message
 /// doesn't confuse a clipped 1000-char body for a 500-char one.
+///
+/// Only the body-inspecting assertions call it, so it follows their gate.
+#[cfg(feature = "_axum")]
 fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         return s.to_owned();
@@ -542,7 +569,9 @@ fn truncate(s: &str, max: usize) -> String {
     format!("{}...(+{remaining} more chars)", &s[..idx])
 }
 
-#[cfg(test)]
+// Every case here builds an `axum::Response`, so the suite follows the same
+// gate as the assertions it exercises. `query_counter` has its own tests.
+#[cfg(all(test, feature = "_axum"))]
 mod tests {
     use super::*;
     use axum::body::Body;
@@ -671,7 +700,9 @@ mod tests {
 
     // -------- assert_messages --------
 
-    #[cfg(feature = "template_views")]
+    // `_signing` as well: these exercise `assert_messages`, which reads the
+    // HMAC-signed messages cookie and now carries that gate too (#1208).
+    #[cfg(all(feature = "template_views", feature = "_signing"))]
     #[test]
     fn assert_messages_passes_on_staged_match() {
         use crate::messages;
@@ -688,14 +719,18 @@ mod tests {
         assert_messages(&res, SECRET, &[("success", "Item created.")]);
     }
 
-    #[cfg(feature = "template_views")]
+    // `_signing` as well: these exercise `assert_messages`, which reads the
+    // HMAC-signed messages cookie and now carries that gate too (#1208).
+    #[cfg(all(feature = "template_views", feature = "_signing"))]
     #[test]
     fn assert_messages_passes_on_empty_when_no_cookie_set() {
         let res = html_response(StatusCode::OK, "");
         assert_messages(&res, b"any-secret", &[]);
     }
 
-    #[cfg(feature = "template_views")]
+    // `_signing` as well: these exercise `assert_messages`, which reads the
+    // HMAC-signed messages cookie and now carries that gate too (#1208).
+    #[cfg(all(feature = "template_views", feature = "_signing"))]
     #[test]
     #[should_panic(expected = "messages don't match")]
     fn assert_messages_panics_on_mismatch() {

--- a/crates/rustango/src/test_assertions.rs
+++ b/crates/rustango/src/test_assertions.rs
@@ -240,7 +240,9 @@ pub fn assert_redirects(res: &Response, target: &str) {
 ///
 /// Empty `expected` asserts NO messages cookie was set (or it's a
 /// clear-cookie with `Max-Age=0`).
-#[cfg(feature = "template_views")]
+// `_signing` as well as `template_views` (#1208): this reads the HMAC-signed
+// messages cookie, and `crate::messages` now gates on the signing capability.
+#[cfg(all(feature = "template_views", feature = "_signing"))]
 pub fn assert_messages(res: &Response, secret: &[u8], expected: &[(&str, &str)]) {
     use crate::messages::{Level, MESSAGES_COOKIE};
     use std::str::FromStr as _;

--- a/crates/rustango/src/url_codec.rs
+++ b/crates/rustango/src/url_codec.rs
@@ -611,7 +611,11 @@ mod tests {
     }
 
     // ---- urlsafe_base64 (Django parity) ----
+    //
+    // These follow the `_base64` gate on the functions they exercise; the
+    // rest of the suite is dependency-free and runs in every feature set.
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_encode_matches_django_examples() {
         assert_eq!(urlsafe_base64_encode(b"foo"), "Zm9v");
@@ -619,6 +623,7 @@ mod tests {
         assert_eq!(urlsafe_base64_encode(b""), "");
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_encode_drops_padding() {
         // 1 byte → standard b64 would emit `==` padding; urlsafe-no-pad
@@ -628,6 +633,7 @@ mod tests {
         assert!(!encoded.contains('='));
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_encode_uses_url_safe_alphabet() {
         // 0xfb 0xff in standard b64 is `+/8=`. URL-safe is `-_8`.
@@ -637,11 +643,13 @@ mod tests {
         assert!(!encoded.contains('/'));
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_decode_simple() {
         assert_eq!(urlsafe_base64_decode("Zm9v").as_deref(), Some(&b"foo"[..]));
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_decode_accepts_padding_for_django_compat() {
         // Django shape — `=` padding silently stripped so legacy senders
@@ -653,6 +661,7 @@ mod tests {
         assert_eq!(urlsafe_base64_decode("Zg==").as_deref(), Some(&b"f"[..]));
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_decode_rejects_standard_b64_chars() {
         // Standard b64 reserved chars `+` and `/` must be rejected when
@@ -660,12 +669,14 @@ mod tests {
         assert!(urlsafe_base64_decode("a+b/c").is_none());
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_decode_rejects_garbage() {
         assert!(urlsafe_base64_decode("!@#$%").is_none());
         assert!(urlsafe_base64_decode("hello\n").is_none()); // embedded LF
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_decode_empty_is_empty_vec() {
         assert_eq!(urlsafe_base64_decode("").as_deref(), Some(&[][..]));
@@ -768,6 +779,7 @@ mod tests {
         assert_eq!(escape_uri_path(""), "");
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_round_trip_for_random_bytes() {
         // Every byte value through encode → decode lands back unchanged.

--- a/crates/rustango/src/url_codec.rs
+++ b/crates/rustango/src/url_codec.rs
@@ -414,6 +414,11 @@ pub fn filepath_to_uri(path: &str) -> String {
 /// // raw `+` → `-`, raw `/` → `_`.
 /// assert_eq!(urlsafe_base64_encode(&[0xfb, 0xff]), "-_8");
 /// ```
+///
+/// Gated on `_base64` (#1208): the module is otherwise pure `std`, so only
+/// the two base64 helpers depend on an optional crate — gating the pair keeps
+/// the rest of the URL/IRI surface available in every feature set.
+#[cfg(feature = "_base64")]
 #[must_use]
 pub fn urlsafe_base64_encode(bytes: &[u8]) -> String {
     use base64::Engine;
@@ -441,6 +446,7 @@ pub fn urlsafe_base64_encode(bytes: &[u8]) -> String {
 /// // Standard b64 reserved chars rejected.
 /// assert!(urlsafe_base64_decode("a+b/c").is_none());
 /// ```
+#[cfg(feature = "_base64")]
 #[must_use]
 pub fn urlsafe_base64_decode(s: &str) -> Option<Vec<u8>> {
     use base64::Engine;

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1126,6 +1126,10 @@ impl ViewSetState {
     /// pool. Errors return a fully-formed [`Response`] (with the
     /// appropriate status code) rather than a typed error so handlers
     /// can `?`-bubble straight to the client.
+    // Only the `PoolSource::Tenant` arm reads `parts` (it runs the tenant
+    // resolver chain), and that arm is `tenancy`-gated — so an admin-only
+    // build has an unused parameter it cannot rename (#1208).
+    #[cfg_attr(not(feature = "tenancy"), allow(unused_variables))]
     async fn acquire(
         &self,
         parts: &mut axum::http::request::Parts,
@@ -1400,6 +1404,11 @@ enum PermOutcome {
     /// Authorised — proceed.
     Allow,
     /// No authenticated principal → `401`.
+    ///
+    /// Only the permission engine constructs this, and that lives behind
+    /// `tenancy`; without it every denial is a `Forbidden` by design, so the
+    /// variant is legitimately unconstructed rather than dead (#1208).
+    #[cfg_attr(not(feature = "tenancy"), allow(dead_code))]
     Unauthenticated,
     /// Authenticated, but lacks every required codename → `403`.
     Forbidden,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.88"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
Closes #1208. Unblocks #1209 (the `api` template).

## What was wrong

Nine modules are declared `pub mod` with **no `cfg`**, but their bodies use
**optional** dependencies. They compiled only when some unrelated feature
happened to pull the crate in. Measured on develop:

| feature set | result |
|---|---|
| `postgres,manage` — what `cargo rustango new --template api` emits | **75 errors** |
| `sqlite,template_views` | 61 errors |
| `sqlite,admin` | 26 errors |
| `sqlite,manage,admin` | 26 errors |
| `sqlite,admin,signed_url` | 16 errors |
| `sqlite,manage` | broken |
| `postgres,manage,admin` | broken |
| `sqlite,tenancy` | OK |

Effectively **only combinations including `tenancy` built** — `tenancy` enables
`rand` + `tower` + `hmac` + `async-trait` and masked every gap. The one
combination CI checks, `--no-default-features --features sqlite,tenancy`, is one
of the masking ones. That is why this survived: the promise in the feature table
was never tested anywhere it could fail.

## The fix

`cfg(feature = "...")` cannot ask *"is `dep:rand` enabled?"*, so each optional
dependency a module needs gets an internal capability feature — `_rand`,
`_tera`, `_tower`, `_async_trait`, `_base64`, `_signing`. Product features
enable the capability instead of the raw `dep:`, and each module gates on the
capability it actually needs.

Two modules became **unconditional** instead: `url_codec` and `list_params` are
pure `std` with no dependencies at all, were gated anyway, and are imported by
unconditional modules (`pagination`, `urls`, `crypto`, `default_filters`,
`viewset`) — their gates could never have been satisfiable.

Three call-site bugs of the same family came out with it:

- `manage` merged the `admin`-gated health router unconditionally
- `migrate::runner` and `sql::m2m` emitted `signals` without the feature
- `sql::mod` re-exported `sqlite_connect_options` one gate short of its callers

`url_codec`'s two base64 helpers are gated rather than the whole module, so the
URL/IRI parity surface stays available in every feature set.

## Not fixed here

`--features sqlite` **alone** still fails (50 errors). It is the same class —
`cookies`, `http_methods`, `redirects`, `flatpages`, `auth_decorators`,
`i18n::timezone`, `audit` and `events` need `axum`/`tokio` — but it needs
`_axum`/`_tokio` capabilities across another eight modules and deserves its own
review. Worth noting the manifest advertises it ("Drop `default-features` for
the bare ORM"), so the promise is still outstanding; I'll file it as a follow-up
rather than widen this PR.

## Keeping it fixed

New `feature_combos` CI matrix builds all seven combinations with
`RUSTFLAGS: -D warnings`. Warnings are errors *there specifically* because
cfg'd-out code is exactly what leaves unused imports and unconstructed variants
behind, and that warning is usually the only signal a gate is wrong.

## Verification

| check | result |
|---|---|
| all seven combos | **build clean, zero warnings** |
| `cargo check -p rustango` (defaults) | 0 errors, 0 warnings |
| `cargo check -p rustango --all-features` | 0 errors, 0 warnings |
| `cargo test --workspace --all-features --no-run` | Finished |
| `cargo test -p rustango --all-features --lib` | 3578 passed |
| `cargo test -p rustango --no-default-features --features sqlite,tenancy,testkit --lib` | 2313 passed |
| regenerated `--template api`, built against this tree via `[patch.crates-io]` | **compiles** (was 75 errors) |