### PR TITLE
fix(features): make the bare ORM build work (`--features sqlite` alone)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,9 @@ jobs:
       fail-fast: false
       matrix:
         features:
+          - sqlite                       # the bare ORM the manifest advertises
+          - postgres
+          - mysql
           - postgres,manage              # `cargo rustango new --template api`
           - sqlite,manage
           - sqlite,admin
@@ -206,6 +209,10 @@ jobs:
       - run: cargo check -p rustango --no-default-features --features ${{ matrix.features }}
         env:
           RUSTFLAGS: "-D warnings"
+      # Also run the unit tests: `cargo check` misses `#[cfg(test)]` code, and
+      # that is exactly where a gate mismatch hides — a test module can outlive
+      # the gated item it exercises without the library ever noticing.
+      - run: cargo test -p rustango --no-default-features --features ${{ matrix.features }} --lib
 
   sqlite_litmus:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,37 @@ action, and `OwnedBy` does the common case in one line.
   `admin`-gated health router unconditionally, and `migrate::runner` /
   `sql::m2m` emitted `signals` without the feature.
 
-  A `feature_combos` CI matrix now builds all seven combinations with
-  `-D warnings`, so a new gate gap fails the build instead of shipping.
+  A `feature_combos` CI matrix now builds every combination with `-D warnings`
+  **and runs its unit tests**, so a new gate gap fails the build instead of
+  shipping. (`cargo check` alone misses `#[cfg(test)]` code, which is exactly
+  where a gate mismatch hides.)
+
+- **The bare ORM build finally works** — `--no-default-features --features
+  sqlite` (or `postgres`, or `mysql`) failed with **50 errors**, despite the
+  manifest advertising exactly that: *"Drop `default-features` for the bare ORM
+  (core + query + sql + migrate)"*. Same root cause as above, two more
+  dependency families:
+
+  **tokio is no longer optional.** `sqlx` is a hard dependency built with
+  `runtime-tokio`, so tokio was already compiled into every build — `optional =
+  true` only controlled whether rustango was allowed to *name* the crate it was
+  already linking. Meanwhile the modules needing it are core, not opt-in: the
+  transaction on-commit registry (`sql::executor::atomic`), the audit-source
+  task-local and the event bus are all built on `tokio::task_local!` /
+  `tokio::sync`. Gating those would have silently removed transaction hooks
+  from a bare-ORM build; making the dependency honest costs no extra crate.
+
+  **axum gets an `_axum` capability.** `http_methods`, `auth_decorators`,
+  `redirects` and `flatpages` are axum middleware end to end and now gate as
+  such. Where a module is mostly dependency-free, only the axum-typed items
+  gate: `cookies::Cookie::header_value` (the builder and `build()` stay),
+  `i18n::timezone`'s two header readers (offset parsing and activation stay),
+  and the `axum::Response` assertions in `test_assertions` — that module stays
+  unconditional because its `query_counter` submodule is ORM instrumentation
+  the executor bumps on every query.
+
+  All ten checked combinations now build clean **and pass their unit tests**
+  (1443 on bare `sqlite`, 1417 on `postgres`, 1449 on `mysql`).
 
 - **ViewSet: 401 for anonymous, 403 for authenticated-but-unauthorised**
   (#1193) — the permission check collapsed both cases to 403. A token client

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -31,7 +31,7 @@ postgres = ["sqlx/postgres"]
 # can still use `rustango::manage::Cli::new().api(...).run().await`.
 # v0.16+. Default-on so `cargo rustango new` projects work with no
 # extra opt-ins.
-manage = ["dep:axum", "dep:tokio", "runtime"]
+manage = ["_axum", "runtime"]
 
 # Test-only constructors for downstream live tests. Currently
 # unlocks `Tenant::for_test(org, conn)` so tenancy-aware crates
@@ -82,6 +82,7 @@ sqlite = ["sqlx/sqlite"]
 _rand         = ["dep:rand"]
 _tera         = ["dep:tera"]
 _tower        = ["dep:tower"]
+_axum         = ["dep:axum"]
 _async_trait  = ["dep:async-trait"]
 _base64       = ["dep:base64"]
 # The three that always travel together for cookie/token signing.
@@ -107,7 +108,7 @@ serializer = ["forms"]
 # Caching layer (`rustango::cache`) — pluggable `Cache` trait with
 # `NullCache` (no-op) and `InMemoryCache` (tokio RwLock + TTL). Redis
 # backend is behind the separate `cache-redis` feature.
-cache = ["_async_trait", "dep:tokio", "dep:sha2"]
+cache = ["_async_trait", "dep:sha2"]
 
 # Per-view caching tower layer (`rustango::cache_page`) — Django's
 # @cache_page / @cache_control / @vary_on_headers analogs. Implies
@@ -118,7 +119,7 @@ cache-page = ["cache", "admin", "dep:base64"]
 # Signals layer (`rustango::signals`) — Django-shape pre_save / post_save
 # / pre_delete / post_delete async dispatch. Receivers register globally
 # per model type; senders fire signals after write paths.
-signals = ["dep:tokio"]
+signals = []
 
 # Email backends (`rustango::email`) — Mailer trait + ConsoleMailer +
 # InMemoryMailer + NullMailer. SMTP and external transports plug in via
@@ -129,7 +130,7 @@ email = ["_async_trait"]
 # Implies `email`. Pulls `lettre` with rustls TLS (no openssl).
 # Default builds don't include this — opt in when you ship to prod and
 # need a real relay (Postmark, SendGrid, AWS SES via SMTP, etc.).
-email-smtp = ["email", "dep:lettre", "dep:tokio"]
+email-smtp = ["email", "dep:lettre"]
 
 # Multi-channel notifications layer (`rustango::notifications`) — Laravel-shape
 # fan-out across mail / database / log / broadcast. Implies email + cache.
@@ -137,7 +138,7 @@ notifications = ["email", "cache"]
 
 # Background job queue (`rustango::jobs`) — Job trait, in-memory queue,
 # worker pool, retry with exponential backoff, dead-letter callback.
-jobs = ["_async_trait", "dep:tokio"]
+jobs = ["_async_trait"]
 
 # Database-backed job queue (`rustango::jobs::pg::PgJobQueue`).
 # v0.38 — tri-dialect: PostgreSQL + MySQL 8.0+ use `FOR UPDATE SKIP
@@ -155,7 +156,7 @@ auth_flows = ["signed_url"]
 
 # Broadcast event bus (`rustango::sse`) — fan-out for SSE / WebSocket /
 # signal-driven push. tokio::sync::broadcast under the hood.
-sse = ["dep:tokio"]
+sse = []
 
 # WebSocket handler scaffold (`rustango::ws`) — fan-out via the SSE
 # EventBus, axum upgrade handler with auto JSON encode/decode + ping/pong
@@ -170,19 +171,19 @@ websocket = ["admin", "sse", "axum/ws"]
 # notification bus; `serializer`/`openapi` the tool inputSchema; `jwt`
 # exposes `crate::signing` (agent-bound pagination cursors) and reflects that
 # MCP agent tokens are JWTs. Epic #1013.
-mcp = ["tenancy", "sse", "serializer", "openapi", "jwt", "dep:axum", "dep:tokio", "dep:async-stream"]
+mcp = ["tenancy", "sse", "serializer", "openapi", "jwt", "_axum", "dep:async-stream"]
 
 # OAuth2 / OIDC swiss-knife (`rustango::oauth2`) — works for pure OAuth2
 # providers (GitHub, Discord) AND OIDC providers (Google, Microsoft,
 # Apple, Keycloak) via the `/userinfo` endpoint as identity source.
 # Per-tenant via `OAuth2Registry`. Pulls reqwest (rustls — no openssl).
-oauth2 = ["_signing", "dep:reqwest", "dep:urlencoding", "dep:tokio", "_rand", "dep:subtle", "_async_trait"]
+oauth2 = ["_signing", "dep:reqwest", "dep:urlencoding", "_rand", "dep:subtle", "_async_trait"]
 
 # Opinionated HTTP client (`rustango::http_client`) — reqwest wrapper
 # with sane timeouts, exponential-backoff retry on idempotent verbs +
 # 5xx/timeout/connect failures, and a default User-Agent. Standalone
 # wrapper that any rustango app can use directly.
-http-client = ["dep:reqwest", "dep:tokio"]
+http-client = ["dep:reqwest"]
 
 # Response compression middleware (`rustango::compression`) — gzip +
 # deflate via flate2 (miniz_oxide by default, no C deps). Honors the
@@ -246,11 +247,11 @@ openapi = ["rustango-macros/openapi"]
 
 # File storage backends (`rustango::storage`) — Storage trait + LocalStorage
 # (filesystem) + InMemoryStorage (tests). S3/GCS/Azure plug in via the trait.
-storage = ["_async_trait", "dep:tokio"]
+storage = ["_async_trait"]
 
 # In-process scheduled task runner (`rustango::scheduler`) — fire async jobs
 # at fixed intervals with panic isolation per task.
-scheduler = ["dep:tokio"]
+scheduler = []
 
 # Secrets manager (`rustango::secrets`) — Secrets trait + EnvSecrets +
 # InMemorySecrets. Vault / AWS / GCP plug in via the trait.
@@ -299,13 +300,13 @@ cache-redis = ["cache", "dep:redis"]
 # axum middleware. Lives behind its own flag so `forms`-only users
 # (parsers without CSRF) don't pull cookie + rand + tower
 # transitively.
-csrf = ["forms", "dep:axum", "dep:base64", "dep:cookie", "_rand", "_tower"]
+csrf = ["forms", "_axum", "dep:base64", "dep:cookie", "_rand", "_tower"]
 
 # Generic class-based views for HTML templates (`rustango::template_views`)
 # — Django-shape `ListView` / `DetailView` / `CreateView` / `UpdateView` /
 # `DeleteView` over `#[derive(Model)]` types, rendered through Tera.
 # The JSON-API counterpart is `rustango::viewset` (always on).
-template_views = ["forms", "dep:axum", "_tera", "dep:tokio", "dep:serde_urlencoded"]
+template_views = ["forms", "_axum", "_tera", "dep:serde_urlencoded"]
 
 # Auto-admin HTTP layer (`rustango::admin`). Pulls in axum + Tera +
 # the supporting middleware deps. Implies `forms` + `csrf` so the
@@ -332,7 +333,7 @@ admin = [
     # Tokio was already in the admin closure; signals adds only the
     # in-process registry helpers.
     "signals",
-    "dep:axum",
+    "_axum",
     "_tera",
     "_signing",
     "dep:subtle",
@@ -343,7 +344,6 @@ admin = [
     "dep:http",
     "dep:http-body-util",
     "dep:serde_urlencoded",
-    "dep:tokio",
 ]
 
 # SSO for the admin login (`rustango::admin::sso`) — sign in with an
@@ -403,7 +403,6 @@ tenancy = [
     "dep:rpassword",
     "dep:serde_urlencoded",
     "dep:subtle",
-    "dep:tokio",
     "_tower",
 ]
 
@@ -417,13 +416,13 @@ tenancy = [
 # `#[::rustango::__private_runtime::tokio::main]` and user crates no
 # longer need to add tokio to their own Cargo.toml just to use the
 # rustango entrypoint shim.
-runtime = ["dep:tracing-subscriber", "dep:tracing-appender", "dep:tokio"]
+runtime = ["dep:tracing-subscriber", "dep:tracing-appender"]
 
 # Minimal axum runserver — `rustango::server::AppBuilder`. Bi-dialect
 # single-pool bootstrap (SQLite / Postgres / MySQL). Implies axum +
 # tokio. The full multi-tenant `Builder` lives behind `tenancy` and
 # pulls in much more.
-runserver = ["dep:axum", "dep:tokio"]
+runserver = ["_axum"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
@@ -470,7 +469,16 @@ serde_urlencoded = { workspace = true, optional = true }
 sha1             = { workspace = true, optional = true }
 sha2             = { workspace = true, optional = true }
 subtle           = { workspace = true, optional = true }
-tokio            = { workspace = true, optional = true }
+# Non-optional since #1208 follow-up. `sqlx` is a hard dependency built with
+# `runtime-tokio`, so tokio is already compiled into every build including
+# `--no-default-features --features sqlite` — `optional = true` only controlled
+# whether rustango was allowed to *name* the crate it was already linking.
+# Meanwhile the modules that need it are core, not opt-in: the transaction
+# on-commit registry (`sql::executor::atomic`), the audit source task-local,
+# and the event bus are all built on `tokio::task_local!` / `tokio::sync`.
+# Gating those would have silently removed transaction hooks from a bare-ORM
+# build; making the dependency honest costs no extra crate.
+tokio            = { workspace = true }
 tower            = { workspace = true, optional = true }
 redis            = { workspace = true, optional = true }
 

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -119,6 +119,10 @@ cache-page = ["cache", "admin", "dep:base64"]
 # Signals layer (`rustango::signals`) — Django-shape pre_save / post_save
 # / pre_delete / post_delete async dispatch. Receivers register globally
 # per model type; senders fire signals after write paths.
+#
+# Empty list, not dead config: the feature still gates `rustango::signals` and
+# the emission sites in `migrate::runner` / `sql::m2m`. It carried `dep:tokio`
+# until tokio became unconditional.
 signals = []
 
 # Email backends (`rustango::email`) — Mailer trait + ConsoleMailer +
@@ -156,6 +160,9 @@ auth_flows = ["signed_url"]
 
 # Broadcast event bus (`rustango::sse`) — fan-out for SSE / WebSocket /
 # signal-driven push. tokio::sync::broadcast under the hood.
+#
+# Empty list, not dead config — still gates `rustango::sse`. Carried
+# `dep:tokio` until tokio became unconditional.
 sse = []
 
 # WebSocket handler scaffold (`rustango::ws`) — fan-out via the SSE
@@ -251,6 +258,9 @@ storage = ["_async_trait"]
 
 # In-process scheduled task runner (`rustango::scheduler`) — fire async jobs
 # at fixed intervals with panic isolation per task.
+#
+# Empty list, not dead config — still gates `rustango::scheduler`. Carried
+# `dep:tokio` until tokio became unconditional.
 scheduler = []
 
 # Secrets manager (`rustango::secrets`) — Secrets trait + EnvSecrets +
@@ -417,15 +427,16 @@ tenancy = [
 # that don't want this dep can opt out by skipping the macro and
 # using `#[tokio::main]` directly.
 #
-# v0.31.1 (#4): `dep:tokio` so the macro can emit
-# `#[::rustango::__private_runtime::tokio::main]` and user crates no
-# longer need to add tokio to their own Cargo.toml just to use the
-# rustango entrypoint shim.
+# v0.31.1 (#4): the macro emits
+# `#[::rustango::__private_runtime::tokio::main]`, so user crates don't need
+# tokio in their own Cargo.toml just to use the rustango entrypoint shim.
+# That re-export no longer needs a feature to carry it — tokio is an
+# unconditional dependency (see the note on the `tokio` line below).
 runtime = ["dep:tracing-subscriber", "dep:tracing-appender"]
 
 # Minimal axum runserver — `rustango::server::AppBuilder`. Bi-dialect
-# single-pool bootstrap (SQLite / Postgres / MySQL). Implies axum +
-# tokio. The full multi-tenant `Builder` lives behind `tenancy` and
+# single-pool bootstrap (SQLite / Postgres / MySQL). Pulls axum; tokio is
+# unconditional. The full multi-tenant `Builder` lives behind `tenancy` and
 # pulls in much more.
 runserver = ["_axum"]
 

--- a/crates/rustango/src/cookies.rs
+++ b/crates/rustango/src/cookies.rs
@@ -241,6 +241,11 @@ impl Cookie {
     /// invalid (control characters, etc.) — should never happen
     /// with sane caller-supplied names/values, but exposed as
     /// `Option` to avoid panicking on attacker-controlled input.
+    ///
+    /// The one axum-typed method on an otherwise dependency-free builder, so
+    /// it gates alone rather than taking the module with it — `build()` still
+    /// returns the same cookie as a `String` in a bare-ORM build.
+    #[cfg(feature = "_axum")]
     #[must_use]
     pub fn header_value(&self) -> Option<axum::http::HeaderValue> {
         axum::http::HeaderValue::from_str(&self.build()).ok()
@@ -438,13 +443,18 @@ mod tests {
     }
 
     // -------- header_value --------
+    //
+    // Follow the `_axum` gate on the method they exercise; the rest of the
+    // cookie suite is dependency-free.
 
+    #[cfg(feature = "_axum")]
     #[test]
     fn header_value_returns_some_for_normal_cookie() {
         let v = Cookie::new("session", "abc").path("/").header_value();
         assert!(v.is_some());
     }
 
+    #[cfg(feature = "_axum")]
     #[test]
     fn header_value_returns_none_for_invalid_chars() {
         // A NUL byte in the value should make axum reject the

--- a/crates/rustango/src/i18n/timezone.rs
+++ b/crates/rustango/src/i18n/timezone.rs
@@ -173,6 +173,11 @@ pub fn parse_offset(s: &str) -> Option<FixedOffset> {
 /// Used by [`from_request_headers`] to feed the active timezone.
 /// Public so apps that wire their own middleware stack can reuse
 /// the decode step.
+///
+/// This and [`from_request_headers`] are the only axum-typed items here, so
+/// they gate on `_axum` rather than taking the module with them — offset
+/// parsing, activation and the task-local stay available everywhere.
+#[cfg(feature = "_axum")]
 pub fn from_cookie(headers: &axum::http::HeaderMap, cookie_name: &str) -> Option<FixedOffset> {
     let raw = headers
         .get(axum::http::header::COOKIE)
@@ -201,6 +206,7 @@ pub fn from_cookie(headers: &axum::http::HeaderMap, cookie_name: &str) -> Option
 ///   document.cookie = `tz_offset=${m};path=/;max-age=31536000`;
 /// </script>
 /// ```
+#[cfg(feature = "_axum")]
 pub fn from_request_headers(
     headers: &axum::http::HeaderMap,
     cookie_name: &str,
@@ -362,6 +368,9 @@ mod tests {
         assert_eq!(parse_offset("+05:99"), None); // minute out of range
     }
 
+    // The next four follow the `_axum` gate on the header-reading functions
+    // they exercise; the offset-parsing and activation tests stay ungated.
+    #[cfg(feature = "_axum")]
     #[test]
     fn from_cookie_finds_named_cookie() {
         let mut headers = axum::http::HeaderMap::new();
@@ -373,12 +382,14 @@ mod tests {
         assert_eq!(off.local_minus_utc(), 5 * 3600 + 30 * 60);
     }
 
+    #[cfg(feature = "_axum")]
     #[test]
     fn from_cookie_returns_none_when_absent() {
         let headers = axum::http::HeaderMap::new();
         assert!(from_cookie(&headers, "tz_offset").is_none());
     }
 
+    #[cfg(feature = "_axum")]
     #[test]
     fn from_request_headers_falls_back_to_time_zone_header() {
         let mut headers = axum::http::HeaderMap::new();
@@ -387,6 +398,7 @@ mod tests {
         assert_eq!(off.local_minus_utc(), 9 * 3600);
     }
 
+    #[cfg(feature = "_axum")]
     #[test]
     fn from_request_headers_prefers_cookie_over_header() {
         let mut headers = axum::http::HeaderMap::new();

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -1226,6 +1226,10 @@ pub mod cookies;
 /// middleware. Rejects unallowed methods with `405 Method Not
 /// Allowed` + RFC 7231-compliant `Allow:` header listing the
 /// accepted set.
+///
+/// Gated on `_axum` — it is tower middleware over `axum::extract::Request`,
+/// and `axum` is an optional dependency absent from a bare-ORM build.
+#[cfg(feature = "_axum")]
 pub mod http_methods;
 
 /// Django messages framework — `messages.success/info/warning/error/debug`
@@ -1238,6 +1242,9 @@ pub mod messages;
 
 /// Django-shape access decorators — `login_required` middleware +
 /// `?next=` round-trip helpers. Issue #11.
+///
+/// Gated on `_axum` — the module is axum middleware end to end.
+#[cfg(feature = "_axum")]
 pub mod auth_decorators;
 
 /// Pluggable `AUTHENTICATION_BACKENDS` chain — register an ordered
@@ -1309,6 +1316,11 @@ pub mod syndication;
 /// mount [`redirects::redirects_middleware`] on your axum router;
 /// matching requests short-circuit with a 301/302 response and the
 /// canonical URL in `Location`, query strings preserved. Issue #57.
+///
+/// The next three gate on `_axum` — each is axum middleware (or assertions
+/// over an `axum::Response`), and `axum` is optional. They were unconditional,
+/// which is most of why `--features sqlite` alone never built.
+#[cfg(feature = "_axum")]
 pub mod redirects;
 
 /// Static "flat pages" — `django.contrib.flatpages`. Build a
@@ -1316,11 +1328,17 @@ pub mod redirects;
 /// mount [`flatpages::flatpages_middleware`] on your axum router;
 /// matching requests serve the page body with `text/html` (or a
 /// custom content-type). Bring your own Tera wrapping. Issue #57.
+#[cfg(feature = "_axum")]
 pub mod flatpages;
 
 /// Django-shape test assertion helpers — `assert_contains` /
 /// `assert_redirects` / `assert_status` / `assert_messages` on axum
 /// Response objects. Issue #40.
+///
+/// Stays unconditional: its `query_counter` submodule is ORM instrumentation
+/// that `sql::executor` bumps on **every** query, so gating the module would
+/// break a bare-ORM build. The `axum::Response` assertions inside it carry
+/// their own `_axum` gate instead.
 pub mod test_assertions;
 
 /// Tag-based test filtering — Django's `@tag('slow')` +

--- a/crates/rustango/src/manage.rs
+++ b/crates/rustango/src/manage.rs
@@ -1541,6 +1541,9 @@ mod tests {
     /// router unchanged (no panic) when the user's api already
     /// routes `GET /`. Pre-fix this aborted the process at boot
     /// for any tenancy project with a per-tenant `/` handler.
+    // `try_mount_welcome` is `#[cfg(feature = "admin")]`, so these two follow
+    // it. Only visible once `postgres,manage` compiled at all (#1208).
+    #[cfg(feature = "admin")]
     #[test]
     fn try_mount_welcome_skips_on_root_collision_no_panic() {
         use axum::routing::get;
@@ -1555,6 +1558,7 @@ mod tests {
     /// `try_mount_welcome` mounts welcome cleanly when no
     /// conflict exists (the common case for fresh projects with
     /// no root handler).
+    #[cfg(feature = "admin")]
     #[test]
     fn try_mount_welcome_succeeds_on_empty_router() {
         let api = Router::new();

--- a/crates/rustango/src/test_assertions.rs
+++ b/crates/rustango/src/test_assertions.rs
@@ -73,8 +73,15 @@
 //! beyond `axum::Response` plus the existing test_client redirect
 //! follower.
 
+// Every assertion below is over an `axum::Response`, so the HTTP half of this
+// module gates on `_axum` (#1208 follow-up). `query_counter` does not: it is
+// ORM instrumentation that `sql::executor` bumps on every query, so it must
+// stay available in a bare-ORM build with no axum in the graph.
+#[cfg(feature = "_axum")]
 use axum::body::to_bytes;
+#[cfg(feature = "_axum")]
 use axum::http::header;
+#[cfg(feature = "_axum")]
 use axum::response::Response;
 
 pub mod query_counter;
@@ -83,6 +90,7 @@ pub use query_counter::{assert_num_queries, QueryCounter};
 /// Maximum bytes consumed from a response body for inspection.
 /// 1 MiB is far above any reasonable test payload; gives a clean
 /// error if a streamed body would otherwise hang the test.
+#[cfg(feature = "_axum")]
 const MAX_BODY_BYTES: usize = 1024 * 1024;
 
 /// Assert the response status equals `expected`. Panics on mismatch
@@ -92,6 +100,7 @@ const MAX_BODY_BYTES: usize = 1024 * 1024;
 /// assert_status(&res, 200);
 /// assert_status(&res, 404);
 /// ```
+#[cfg(feature = "_axum")]
 pub fn assert_status(res: &Response, expected: u16) {
     let actual = res.status().as_u16();
     assert_eq!(
@@ -109,6 +118,7 @@ pub fn assert_status(res: &Response, expected: u16) {
 /// assert_status_in(&res, &[200, 201]);
 /// assert_status_in(&res, &[301, 302, 307, 308]);
 /// ```
+#[cfg(feature = "_axum")]
 pub fn assert_status_in(res: &Response, allowed: &[u16]) {
     let actual = res.status().as_u16();
     assert!(
@@ -119,6 +129,7 @@ pub fn assert_status_in(res: &Response, allowed: &[u16]) {
 
 /// Assert the response status is in the 2xx range (success).
 /// Sugar for the very common "any success" check.
+#[cfg(feature = "_axum")]
 pub fn assert_status_2xx(res: &Response) {
     let actual = res.status().as_u16();
     assert!(
@@ -128,6 +139,7 @@ pub fn assert_status_2xx(res: &Response) {
 }
 
 /// Assert the response status is in the 4xx range (client error).
+#[cfg(feature = "_axum")]
 pub fn assert_status_4xx(res: &Response) {
     let actual = res.status().as_u16();
     assert!(
@@ -139,6 +151,7 @@ pub fn assert_status_4xx(res: &Response) {
 /// Assert the response status is in the 5xx range (server error).
 /// Useful for negative tests of error pages / handlers that must
 /// surface internal failures rather than degrade silently.
+#[cfg(feature = "_axum")]
 pub fn assert_status_5xx(res: &Response) {
     let actual = res.status().as_u16();
     assert!(
@@ -169,6 +182,7 @@ pub fn assert_status_5xx(res: &Response) {
 /// fragment isn't found. Snippet of the actual body (truncated +
 /// "more chars" indicator) is included in the panic message for fast
 /// debugging.
+#[cfg(feature = "_axum")]
 pub async fn assert_contains(res: Response, fragment: &str) {
     let body = to_bytes(res.into_body(), MAX_BODY_BYTES)
         .await
@@ -185,6 +199,7 @@ pub async fn assert_contains(res: Response, fragment: &str) {
 /// Inverse of [`assert_contains`] — panics when the fragment IS
 /// found. Useful for "the deleted post shouldn't appear in the list"
 /// style assertions.
+#[cfg(feature = "_axum")]
 pub async fn assert_not_contains(res: Response, fragment: &str) {
     let body = to_bytes(res.into_body(), MAX_BODY_BYTES)
         .await
@@ -208,6 +223,7 @@ pub async fn assert_not_contains(res: Response, fragment: &str) {
 ///
 /// Does NOT follow the redirect or check what the target serves —
 /// pair with [`assert_redirect_chain`] for that.
+#[cfg(feature = "_axum")]
 pub fn assert_redirects(res: &Response, target: &str) {
     let status = res.status();
     assert!(
@@ -242,7 +258,7 @@ pub fn assert_redirects(res: &Response, target: &str) {
 /// clear-cookie with `Max-Age=0`).
 // `_signing` as well as `template_views` (#1208): this reads the HMAC-signed
 // messages cookie, and `crate::messages` now gates on the signing capability.
-#[cfg(all(feature = "template_views", feature = "_signing"))]
+#[cfg(all(feature = "template_views", feature = "_signing", feature = "_axum"))]
 pub fn assert_messages(res: &Response, secret: &[u8], expected: &[(&str, &str)]) {
     use crate::messages::{Level, MESSAGES_COOKIE};
     use std::str::FromStr as _;
@@ -320,6 +336,7 @@ pub fn assert_messages(res: &Response, secret: &[u8], expected: &[(&str, &str)])
 /// Panics if the header is missing or carries a different value.
 /// Multiple headers with the same name match the FIRST occurrence
 /// (axum's default header API surfaces them in order).
+#[cfg(feature = "_axum")]
 pub fn assert_header(res: &Response, name: &str, value: &str) {
     let actual = res
         .headers()
@@ -339,6 +356,7 @@ pub fn assert_header(res: &Response, name: &str, value: &str) {
 /// assert_content_type(&res, "application/json");
 /// assert_content_type(&res, "text/html; charset=utf-8");
 /// ```
+#[cfg(feature = "_axum")]
 pub fn assert_content_type(res: &Response, expected: &str) {
     assert_header(res, "content-type", expected);
 }
@@ -355,6 +373,7 @@ pub fn assert_content_type(res: &Response, expected: &str) {
 /// Panics with both bodies in the message when:
 /// - the response body isn't valid JSON;
 /// - the parsed body doesn't structurally equal `expected`.
+#[cfg(feature = "_axum")]
 pub async fn assert_json_eq(res: Response, expected: &serde_json::Value) {
     let bytes = to_bytes(res.into_body(), MAX_BODY_BYTES)
         .await
@@ -385,6 +404,7 @@ pub async fn assert_json_eq(res: Response, expected: &serde_json::Value) {
 /// ```ignore
 /// assert_json_not_eq(res, &serde_json::json!({"password": "leaked"})).await;
 /// ```
+#[cfg(feature = "_axum")]
 pub async fn assert_json_not_eq(res: Response, unexpected: &serde_json::Value) {
     let bytes = to_bytes(res.into_body(), MAX_BODY_BYTES)
         .await
@@ -420,6 +440,7 @@ pub async fn assert_json_not_eq(res: Response, unexpected: &serde_json::Value) {
 /// Panics with the full chain in the message when the final hop's
 /// status or path doesn't match — so a misconfigured chain is easy
 /// to diagnose.
+#[cfg(feature = "_axum")]
 pub fn assert_redirect_chain(chain: &[(u16, String)], final_path: &str, final_status: u16) {
     let last = chain
         .last()
@@ -449,6 +470,7 @@ pub fn assert_redirect_chain(chain: &[(u16, String)], final_path: &str, final_st
 ///
 /// Panics with the actual count and a 500-char body snippet when
 /// the counts don't match.
+#[cfg(feature = "_axum")]
 pub async fn assert_contains_count(res: Response, fragment: &str, count: usize) {
     let bytes = to_bytes(res.into_body(), MAX_BODY_BYTES)
         .await
@@ -479,6 +501,7 @@ pub async fn assert_contains_count(res: Response, fragment: &str, count: usize) 
 ///
 /// Panics with the full Set-Cookie list when no header for that
 /// name is found, or when the value doesn't match.
+#[cfg(feature = "_axum")]
 pub fn assert_cookie_set(res: &Response, name: &str, expected_value: Option<&str>) {
     let mut matches: Vec<String> = Vec::new();
     for v in res.headers().get_all(axum::http::header::SET_COOKIE).iter() {
@@ -515,6 +538,7 @@ pub fn assert_cookie_set(res: &Response, name: &str, expected_value: Option<&str
 /// `name` IS present. Use to verify that a handler did NOT set a
 /// cookie under specific conditions (logged-out request shouldn't
 /// touch the session cookie, etc.).
+#[cfg(feature = "_axum")]
 pub fn assert_cookie_not_set(res: &Response, name: &str) {
     for v in res.headers().get_all(axum::http::header::SET_COOKIE).iter() {
         let Ok(s) = v.to_str() else { continue };
@@ -530,6 +554,9 @@ pub fn assert_cookie_not_set(res: &Response, name: &str) {
 /// Truncate a string at a UTF-8 char boundary at or before `max`,
 /// appending a `...(N more chars)` indicator so the panic message
 /// doesn't confuse a clipped 1000-char body for a 500-char one.
+///
+/// Only the body-inspecting assertions call it, so it follows their gate.
+#[cfg(feature = "_axum")]
 fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         return s.to_owned();
@@ -542,7 +569,9 @@ fn truncate(s: &str, max: usize) -> String {
     format!("{}...(+{remaining} more chars)", &s[..idx])
 }
 
-#[cfg(test)]
+// Every case here builds an `axum::Response`, so the suite follows the same
+// gate as the assertions it exercises. `query_counter` has its own tests.
+#[cfg(all(test, feature = "_axum"))]
 mod tests {
     use super::*;
     use axum::body::Body;
@@ -671,7 +700,9 @@ mod tests {
 
     // -------- assert_messages --------
 
-    #[cfg(feature = "template_views")]
+    // `_signing` as well: these exercise `assert_messages`, which reads the
+    // HMAC-signed messages cookie and now carries that gate too (#1208).
+    #[cfg(all(feature = "template_views", feature = "_signing"))]
     #[test]
     fn assert_messages_passes_on_staged_match() {
         use crate::messages;
@@ -688,14 +719,18 @@ mod tests {
         assert_messages(&res, SECRET, &[("success", "Item created.")]);
     }
 
-    #[cfg(feature = "template_views")]
+    // `_signing` as well: these exercise `assert_messages`, which reads the
+    // HMAC-signed messages cookie and now carries that gate too (#1208).
+    #[cfg(all(feature = "template_views", feature = "_signing"))]
     #[test]
     fn assert_messages_passes_on_empty_when_no_cookie_set() {
         let res = html_response(StatusCode::OK, "");
         assert_messages(&res, b"any-secret", &[]);
     }
 
-    #[cfg(feature = "template_views")]
+    // `_signing` as well: these exercise `assert_messages`, which reads the
+    // HMAC-signed messages cookie and now carries that gate too (#1208).
+    #[cfg(all(feature = "template_views", feature = "_signing"))]
     #[test]
     #[should_panic(expected = "messages don't match")]
     fn assert_messages_panics_on_mismatch() {

--- a/crates/rustango/src/url_codec.rs
+++ b/crates/rustango/src/url_codec.rs
@@ -611,7 +611,11 @@ mod tests {
     }
 
     // ---- urlsafe_base64 (Django parity) ----
+    //
+    // These follow the `_base64` gate on the functions they exercise; the
+    // rest of the suite is dependency-free and runs in every feature set.
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_encode_matches_django_examples() {
         assert_eq!(urlsafe_base64_encode(b"foo"), "Zm9v");
@@ -619,6 +623,7 @@ mod tests {
         assert_eq!(urlsafe_base64_encode(b""), "");
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_encode_drops_padding() {
         // 1 byte → standard b64 would emit `==` padding; urlsafe-no-pad
@@ -628,6 +633,7 @@ mod tests {
         assert!(!encoded.contains('='));
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_encode_uses_url_safe_alphabet() {
         // 0xfb 0xff in standard b64 is `+/8=`. URL-safe is `-_8`.
@@ -637,11 +643,13 @@ mod tests {
         assert!(!encoded.contains('/'));
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_decode_simple() {
         assert_eq!(urlsafe_base64_decode("Zm9v").as_deref(), Some(&b"foo"[..]));
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_decode_accepts_padding_for_django_compat() {
         // Django shape — `=` padding silently stripped so legacy senders
@@ -653,6 +661,7 @@ mod tests {
         assert_eq!(urlsafe_base64_decode("Zg==").as_deref(), Some(&b"f"[..]));
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_decode_rejects_standard_b64_chars() {
         // Standard b64 reserved chars `+` and `/` must be rejected when
@@ -660,12 +669,14 @@ mod tests {
         assert!(urlsafe_base64_decode("a+b/c").is_none());
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_decode_rejects_garbage() {
         assert!(urlsafe_base64_decode("!@#$%").is_none());
         assert!(urlsafe_base64_decode("hello\n").is_none()); // embedded LF
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_decode_empty_is_empty_vec() {
         assert_eq!(urlsafe_base64_decode("").as_deref(), Some(&[][..]));
@@ -768,6 +779,7 @@ mod tests {
         assert_eq!(escape_uri_path(""), "");
     }
 
+    #[cfg(feature = "_base64")]
     #[test]
     fn urlsafe_b64_round_trip_for_random_bytes() {
         // Every byte value through encode → decode lands back unchanged.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.88"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
Stacked on #1212 — review that first; this branch targets it, not `develop`.

## What was wrong

`--no-default-features --features sqlite` failed with **50 errors**, as did bare
`postgres` and `mysql`. The manifest advertises exactly that build:

> Drop `default-features` for the bare ORM (core + query + sql + migrate).

Same root cause as #1208, two more dependency families.

## tokio is no longer optional

`sqlx` is a **hard** dependency built with `runtime-tokio`, so tokio was already
compiled into every build — confirmed with `cargo tree -p rustango
--no-default-features --features sqlite`, which shows `tokio v1.52.1` present and
`axum` absent. `optional = true` only controlled whether rustango was allowed to
*name* the crate it was already linking.

And the modules that need it are core, not opt-in:

- `sql::executor::atomic` — the transaction on-commit registry is *entirely* a
  `tokio::task_local!`
- `audit` — the audit-source task-local
- `events` — the event bus, on `tokio::sync`

Gating those would have silently removed transaction hooks from a bare-ORM
build, which is a worse answer than depending on a crate that is already there.

## axum gets a capability

Unlike tokio, axum genuinely is absent from a bare build, so it gets `_axum`.
`http_methods`, `auth_decorators`, `redirects` and `flatpages` are axum
middleware end to end and gate as modules.

Where a module is mostly dependency-free, only the axum-typed **items** gate, so
the useful surface survives:

| module | gated | still available bare |
|---|---|---|
| `cookies` | `Cookie::header_value` | the whole builder + `build() -> String` |
| `i18n::timezone` | `from_cookie`, `from_request_headers` | offset parsing, activation, task-local |
| `test_assertions` | the `axum::Response` assertions | `query_counter` — the executor bumps it on **every** query, so the module stays unconditional |

## Test modules follow their items

`url_codec`'s base64 cases, `cookies`' `header_value` pair, `timezone`'s four
header tests. Two `manage` tests for the `admin`-gated `try_mount_welcome` were
never gated at all — invisible until `postgres,manage` compiled in the first
place.

The `feature_combos` matrix gains the three bare backends and now runs `--lib`
as well as `check`. That matters: `cargo check` never compiles `#[cfg(test)]`
code, and a test module outliving the gated item it exercises is precisely how
this class of bug hides.

## Verification

Every combination builds clean **and passes its unit tests**:

| features | tests |
|---|---|
| `sqlite` | 1443 |
| `postgres` | 1417 |
| `mysql` | 1449 |
| `postgres,manage` | 1533 |
| `sqlite,manage` | 1559 |
| `sqlite,admin` | 2069 |
| `sqlite,manage,admin` | 2088 |
| `postgres,manage,admin` | 2075 |
| `sqlite,template_views` | 2110 |
| `sqlite,tenancy` | 2313 |

No regressions: `--all-features` still 3578 passing, and `cargo test --workspace
--all-features --no-run` finishes. The 6 remaining warnings in bare-sqlite's
test build (`dateformat` snake-case names, two unused variables) are
pre-existing and appear identically under `--all-features`.