### PR TITLE
fix: --help without a database, docs.rs feature coverage, template feature guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,12 @@ jobs:
         with:
           key: scaffolded-projects
       - run: cargo test -p cargo-rustango --test generated_project_compiles -- --ignored --test-threads=1
+      # #1217 — a generated project pins the *published* rustango, so a template
+      # may only name features that release actually has. Offline and fast: it
+      # compares the emitted feature list against `crates/rustango/Cargo.toml`.
+      # The compile test above cannot catch this — it builds with
+      # `--rustango-path`, where any new feature exists by definition.
+      - run: cargo test -p cargo-rustango --test templates_name_real_features
 
   # #1208 — the feature table is a public promise, so check the promise.
   # `sqlite_litmus` below is a single combination, and it happens to be one

--- a/crates/cargo-rustango/src/main.rs
+++ b/crates/cargo-rustango/src/main.rs
@@ -151,6 +151,24 @@ impl Template {
         // moved to v0.28+, breaking `cargo build` on every fresh
         // tenant project (#79).
         let v = mm_version();
+        // RELEASE ORDER IS LOAD-BEARING (#1217). A generated project pins the
+        // *published* rustango by version, while this feature list is written
+        // against the tree in this repo. Naming a feature that is not in the
+        // pinned release fails at resolution, before anything compiles:
+        //
+        //     package `myblog` depends on `rustango` with feature `batteries`
+        //     but `rustango` does not have that feature.
+        //
+        // Two things keep that from happening:
+        //   1. All four crates publish from one version, `rustango` BEFORE
+        //      `cargo-rustango` — so the pinned version always already exists
+        //      and already has whatever this names.
+        //   2. `tests/templates_name_real_features.rs` asserts every feature
+        //      named here is defined in `crates/rustango/Cargo.toml`.
+        //
+        // `generated_project_compiles.rs` cannot catch this: it builds with
+        // `--rustango-path` against the local tree, where the feature exists.
+        //
         // #1211 — the backend is NOT named here. The generated `[features]`
         // block forwards it (`postgres = ["rustango/postgres"]`, etc.), and
         // `#[derive(Model)]` gates its emissions on the *project's* feature,

--- a/crates/cargo-rustango/tests/generated_project_compiles.rs
+++ b/crates/cargo-rustango/tests/generated_project_compiles.rs
@@ -31,6 +31,14 @@ fn rustango_crate() -> PathBuf {
         .join("rustango")
 }
 
+/// These tests need the sibling `crates/rustango` source, so they only mean
+/// anything inside the repo. The published `cargo-rustango` tarball carries
+/// this file but not its sibling, so skip rather than fail confusingly for
+/// anyone who runs the suite from a downloaded crate.
+fn in_repo() -> bool {
+    rustango_crate().join("Cargo.toml").is_file()
+}
+
 /// A unique scratch directory. No `tempfile` dep — this crate deliberately has
 /// zero dependencies, and the scaffolder must keep working without them.
 fn scratch(tag: &str) -> PathBuf {
@@ -118,6 +126,10 @@ fn check(root: &Path, extra: &[&str]) -> (bool, usize, String) {
 }
 
 fn assert_compiles(template: &str, extra: &[&str], label: &str) {
+    if !in_repo() {
+        eprintln!("skipping: crates/rustango not alongside — not a repo checkout");
+        return;
+    }
     let (work, root) = generate(template, label);
     let (ok, warnings, log) = check(&root, extra);
     let _ = std::fs::remove_dir_all(&work);

--- a/crates/cargo-rustango/tests/templates_name_real_features.rs
+++ b/crates/cargo-rustango/tests/templates_name_real_features.rs
@@ -1,0 +1,180 @@
+//! Every feature a template names must exist in the `rustango` it pins (#1217).
+//!
+//! The generated manifest pins `rustango` by **version** — the published crate —
+//! while the template's feature list is written against the tree in this repo.
+//! When those disagree, a scaffolded project fails at *resolution*, before a
+//! single line compiles:
+//!
+//! ```text
+//! error: failed to select a version for `rustango`.
+//! package `myblog` depends on `rustango` with feature `batteries`
+//! but `rustango` does not have that feature.
+//! ```
+//!
+//! That is how the `batteries` feature broke 36 of 50 generated projects
+//! (every `fullstack` and `tenant`) the moment it was named by a template but
+//! not yet released.
+//!
+//! `generated_project_compiles.rs` cannot catch this class: it builds with
+//! `--rustango-path`, deliberately, so it validates the working tree rather
+//! than the last release — which is right for *that* test and blind to *this*
+//! failure.
+//!
+//! Checking against the live registry would trade one blind spot for another
+//! (it can only ever describe the last release, and it needs the network). So
+//! this asserts the invariant directly and offline: **the scaffolder may only
+//! name features the framework in this repo actually defines.** Combined with
+//! publishing all four crates from one version in lockstep — `rustango` before
+//! `cargo-rustango`, always — a named feature is guaranteed to exist in the
+//! version the template pins.
+
+use std::path::{Path, PathBuf};
+
+fn rustango_manifest() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/")
+        .join("rustango")
+        .join("Cargo.toml")
+}
+
+/// Feature names defined in `crates/rustango/Cargo.toml`.
+///
+/// Deliberately a hand-rolled scan rather than a TOML dependency: this crate
+/// ships with zero dependencies and the scaffolder must keep working without
+/// any, so the test suite holds the same line. A feature definition is a line
+/// of the form `name = [` at column zero inside `[features]`.
+fn framework_features(manifest: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut in_features = false;
+    for line in manifest.lines() {
+        let trimmed = line.trim_end();
+        if trimmed.starts_with('[') {
+            in_features = trimmed == "[features]";
+            continue;
+        }
+        if !in_features {
+            continue;
+        }
+        let Some((name, rest)) = trimmed.split_once('=') else {
+            continue;
+        };
+        let name = name.trim();
+        if name.is_empty() || name.starts_with('#') || !rest.trim_start().starts_with('[') {
+            continue;
+        }
+        out.push(name.to_owned());
+    }
+    out
+}
+
+/// Feature names a generated `Cargo.toml` asks of `rustango`.
+///
+/// Two shapes matter, and both are the project's *request* of the framework:
+///   - the dependency's own list:  `rustango = { …, features = ["batteries"] }`
+///   - the forwarding features:    `postgres = ["rustango/postgres"]`
+fn requested_features(generated: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in generated.lines() {
+        let t = line.trim();
+        if t.starts_with("rustango = ") {
+            if let Some(idx) = t.find("features = [") {
+                let tail = &t[idx + "features = [".len()..];
+                if let Some(end) = tail.find(']') {
+                    for f in tail[..end].split(',') {
+                        let f = f.trim().trim_matches('"').trim();
+                        if !f.is_empty() {
+                            out.push(f.to_owned());
+                        }
+                    }
+                }
+            }
+        }
+        // `sqlite = ["rustango/sqlite"]` — the forwarded backend.
+        for part in t.split('"') {
+            if let Some(f) = part.strip_prefix("rustango/") {
+                out.push(f.to_owned());
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn generate_manifest(template: &str) -> String {
+    let work = std::env::temp_dir().join(format!(
+        "rustango-featcheck-{}-{template}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    ));
+    std::fs::create_dir_all(&work).expect("scratch dir");
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_cargo-rustango"))
+        .current_dir(&work)
+        .args(["rustango", "new", "probe", "--template", template])
+        .output()
+        .expect("run the scaffolder");
+    assert!(
+        out.status.success(),
+        "scaffolding {template}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let manifest =
+        std::fs::read_to_string(work.join("probe").join("Cargo.toml")).expect("read manifest");
+    let _ = std::fs::remove_dir_all(&work);
+    manifest
+}
+
+#[test]
+fn every_template_names_only_features_the_framework_defines() {
+    let manifest_path = rustango_manifest();
+    if !manifest_path.is_file() {
+        eprintln!("skipping: crates/rustango not alongside — not a repo checkout");
+        return;
+    }
+    let defined = framework_features(&std::fs::read_to_string(&manifest_path).expect("read"));
+    assert!(
+        defined.contains(&"manage".to_owned()),
+        "sanity: the feature scan found nothing useful (got {} names)",
+        defined.len()
+    );
+
+    for template in ["api", "fullstack", "tenant"] {
+        let generated = generate_manifest(template);
+        let requested = requested_features(&generated);
+        assert!(
+            !requested.is_empty(),
+            "`{template}` requested no rustango features — the scan is wrong"
+        );
+        for feat in &requested {
+            assert!(
+                defined.contains(feat),
+                "template `{template}` requests rustango feature `{feat}`, which \
+                 crates/rustango/Cargo.toml does not define.\n\
+                 A generated project pins the PUBLISHED rustango, so naming a \
+                 feature that does not exist there fails at resolution before \
+                 anything compiles (#1217).\n\
+                 Defined features: {defined:?}"
+            );
+        }
+    }
+}
+
+/// The backend forwards are the ones most likely to be typo'd, since they are
+/// spelled twice — once in `[features]`, once as `rustango/<name>`.
+#[test]
+fn backend_forwards_resolve() {
+    if !rustango_manifest().is_file() {
+        return;
+    }
+    let generated = generate_manifest("fullstack");
+    for backend in ["postgres", "sqlite", "mysql"] {
+        assert!(
+            generated.contains(&format!(r#"{backend} = ["rustango/{backend}"]"#)),
+            "generated manifest is missing the `{backend}` forward:\n{generated}"
+        );
+    }
+}

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -15,6 +15,23 @@ categories.workspace = true
 # stay — they're baked into the binary via include_str! / include_bytes!.
 exclude = ["examples/", "tests/"]
 
+# docs.rs builds with **default features only** unless told otherwise, and
+# several headline modules are not in `default`: `tenancy`, `sso`, `mcp`,
+# `passkey`, `admin-sso`, `cache-redis`. Without this section every one of them
+# 404s on docs.rs — so multi-tenancy, the framework's flagship differentiator,
+# had no published API documentation at all, and a reader arriving from the
+# README would reasonably conclude the feature does not exist.
+#
+# `all-features` rather than an explicit list because the three backends
+# coexist by design (the tri-dialect work makes `postgres,mysql,sqlite`
+# together a supported, CI-tested combination), so there is nothing to exclude.
+#
+# `--cfg docsrs` enables `#[cfg_attr(docsrs, doc(cfg(...)))]` badges, so each
+# gated item shows which feature unlocks it instead of appearing unconditional.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lints]
 workspace = true
 

--- a/crates/rustango/src/manage.rs
+++ b/crates/rustango/src/manage.rs
@@ -536,6 +536,27 @@ impl Cli {
         // database, so none of them should care what `DATABASE_URL` says.
         {
             let mut out = std::io::stdout();
+
+            // A tenancy project has its own help — it lists `create-tenant`,
+            // `create-operator`, `create-user` and the rest of the tenancy
+            // verbs, which the plain migration runner knows nothing about.
+            // Route help there before the generic pool-free dispatch, or a
+            // tenancy project would print the wrong verb list. (Caught by
+            // `cookbook_blog`'s `cli_help_works_without_database_url`.)
+            //
+            // `write_help` needs no pool either, so tenancy projects get the
+            // same "help works whatever DATABASE_URL says" fix (#1216).
+            #[cfg(feature = "tenancy")]
+            if self.tenancy
+                && matches!(
+                    args.first().map(String::as_str),
+                    None | Some("") | Some("help") | Some("--help") | Some("-h")
+                )
+            {
+                crate::tenancy::manage::write_help(&mut out)?;
+                return Ok(());
+            }
+
             if let Some(res) = crate::migrate::manage::run_pool_free(&args, &mut out) {
                 res?;
                 return Ok(());

--- a/crates/rustango/src/manage.rs
+++ b/crates/rustango/src/manage.rs
@@ -528,6 +528,20 @@ impl Cli {
             return Ok(());
         }
 
+        // Verbs that need no database at all run here, before any pool is
+        // constructed (#1216). `connect_lazy` doesn't connect, but it does
+        // validate the URL scheme against the enabled backend features — so a
+        // SQLite-only build with a stale `postgres://` in the environment could
+        // not print its own `--help`. None of these verbs read or write a
+        // database, so none of them should care what `DATABASE_URL` says.
+        {
+            let mut out = std::io::stdout();
+            if let Some(res) = crate::migrate::manage::run_pool_free(&args, &mut out) {
+                res?;
+                return Ok(());
+            }
+        }
+
         // Verbs that print info and never touch the DB. We let these
         // run even when DATABASE_URL is unset so users can scaffold or
         // read help without configuring Postgres first.

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -69,6 +69,53 @@ pub async fn run(
     run_with_writer(pool, dir, args, &mut stdout).await
 }
 
+/// Dispatch the verbs that need **no database at all**, before any pool is
+/// built. Returns `None` when `args` names a verb that does need one, so the
+/// caller falls through to [`run`].
+///
+/// Exists because `Cli::dispatch` used to construct a pool for every verb,
+/// including `--help`. `Pool::connect_lazy` doesn't connect, but it *does*
+/// validate the URL scheme against the enabled backend features — so a project
+/// built for SQLite with a stale `postgres://` in the environment failed to
+/// print its own help text (#1216):
+///
+/// ```text
+/// $ DATABASE_URL=postgres://… cargo run --features sqlite -- --help
+/// Error: URL scheme `postgres` requires the `postgres` Cargo feature
+/// ```
+///
+/// That bites exactly when help is most wanted — you changed backend and want
+/// the verb list. None of these verbs read or write a database, so none of them
+/// should care what `DATABASE_URL` says, or whether it is set at all.
+///
+/// # Errors
+/// Whatever the dispatched verb returns.
+pub fn run_pool_free<W: Write>(
+    args: &[String],
+    writer: &mut W,
+) -> Option<Result<(), MigrateError>> {
+    let cmd = args.first().map_or("", String::as_str);
+    Some(match cmd {
+        "" | "--help" | "-h" | "help" => print_help(writer).map_err(Into::into),
+        "version" | "--version" => version_cmd(writer),
+        "docs" => docs_cmd(writer),
+        "db:info" => db_info_cmd(writer),
+        // Code generators: they read the model registry and write files.
+        "startapp" => startapp(&args[1..], writer),
+        "make:viewset" => make_viewset_cmd(&args[1..], writer),
+        "make:api_routes" => make_api_routes_cmd(&args[1..], writer),
+        "make:serializer" => make_serializer_cmd(&args[1..], writer),
+        "make:form" => make_form_cmd(&args[1..], writer),
+        "make:job" => make_job_cmd(&args[1..], writer),
+        "make:notification" => make_notification_cmd(&args[1..], writer),
+        "make:middleware" => make_middleware_cmd(&args[1..], writer),
+        "make:test" => make_test_cmd(&args[1..], writer),
+        "showurls" => showurls_cmd(&args[1..], writer),
+        "showmodels" => showmodels_cmd(&args[1..], writer),
+        _ => return None,
+    })
+}
+
 /// Same as [`run`] but writes user-facing output to `writer`. Useful
 /// for tests (`Vec<u8>`), captured logs, or piping the dispatcher's
 /// output through a custom formatter.
@@ -4564,6 +4611,79 @@ pub fn settings_audit_check(
 #[cfg(test)]
 mod gen_tests {
     use super::*;
+
+    /// #1216 — the verbs that need no database must be dispatchable without
+    /// one. `Cli` builds a pool before dispatch otherwise, and `connect_lazy`
+    /// validates the URL scheme against the enabled backends, so a SQLite-only
+    /// build with a stale `postgres://` in the environment could not print its
+    /// own help.
+    #[test]
+    fn pool_free_verbs_need_no_database() {
+        for verb in [
+            "",
+            "--help",
+            "-h",
+            "help",
+            "version",
+            "--version",
+            "docs",
+            "db:info",
+        ] {
+            let args = vec![verb.to_owned()];
+            let mut out = Vec::new();
+            let res = run_pool_free(&args, &mut out);
+            assert!(
+                res.is_some(),
+                "`{verb}` must be dispatchable without a pool"
+            );
+            assert!(res.unwrap().is_ok(), "`{verb}` failed");
+            assert!(!out.is_empty(), "`{verb}` produced no output");
+        }
+    }
+
+    /// The generators write files from the model registry — no database either.
+    #[test]
+    fn generators_need_no_database() {
+        for verb in [
+            "make:viewset",
+            "make:serializer",
+            "make:form",
+            "make:job",
+            "make:notification",
+            "make:middleware",
+            "make:test",
+            "startapp",
+        ] {
+            let args = vec![verb.to_owned()];
+            assert!(
+                run_pool_free(&args, &mut Vec::new()).is_some(),
+                "`{verb}` must be dispatchable without a pool"
+            );
+        }
+    }
+
+    /// The complement matters as much: a verb that genuinely reads or writes
+    /// the database must NOT be short-circuited here, or it would silently do
+    /// nothing instead of connecting.
+    #[test]
+    fn database_verbs_are_not_short_circuited() {
+        for verb in [
+            "migrate",
+            "makemigrations",
+            "downgrade",
+            "showmigrations",
+            "about",
+            "check",
+            "dumpdata",
+            "loaddata",
+        ] {
+            let args = vec![verb.to_owned()];
+            assert!(
+                run_pool_free(&args, &mut Vec::new()).is_none(),
+                "`{verb}` touches the database — it must fall through to `run`"
+            );
+        }
+    }
 
     #[test]
     fn pascal_to_snake_cases() {


### PR DESCRIPTION
Closes #1216, #1217. Also fixes docs.rs feature coverage (no issue — spotted while checking release readiness).

## #1216 — verbs that need no database no longer need one

`Cli::dispatch` built a pool before dispatching any verb. `connect_lazy` never
connects, but it **does** validate the URL scheme against the enabled backends,
so a SQLite-only build with a stale `postgres://` in the environment could not
print its own help:

```
$ DATABASE_URL=postgres://… cargo run --features sqlite -- --help
Error: URL scheme `postgres` requires the `postgres` Cargo feature on rustango
```

The tell was that **no** `DATABASE_URL` worked while a *wrong* one failed — the
pool was resolved before dispatch and skipped entirely when the variable was
absent.

`migrate::manage::run_pool_free` now dispatches the pool-free verbs before any
pool exists, the way `dbshell` already did: help/version/docs/db:info, the seven
`make:*` generators, `startapp`, `showurls`, `showmodels`.

Tested in both directions. Short-circuiting a verb that *does* touch the
database would make it silently do nothing, so there is an explicit test that
`migrate`, `makemigrations`, `downgrade`, `showmigrations`, `about`, `check`,
`dumpdata` and `loaddata` all still fall through.

Verified against the original repro on a real generated project:

| verb | mismatched `DATABASE_URL` | none set |
|---|---|---|
| `--help` | prints help | prints help |
| `version` | `rustango 0.51.2` | `rustango 0.51.2` |
| `docs`, `db:info` | work | work |
| `migrate` | still refuses, clearly | — |

## docs.rs was missing the headline modules

The crate had no `[package.metadata.docs.rs]`, so docs.rs built with **default
features only** — and `tenancy`, `sso`, `mcp`, `passkey`, `admin-sso` and
`cache-redis` are not in `default`. All of them 404'd. Multi-tenancy, the
framework's flagship differentiator, had **no published API documentation**, so
a reader arriving from the README would reasonably conclude it does not exist.

Verified locally before shipping, because a docs.rs build *failure* is worse
than the status quo — it would leave no new docs at all:

- `cargo doc --all-features --cfg docsrs` → **0 errors**
- all eight previously-missing modules now generate pages

`all-features` rather than an explicit list, because the three backends coexist
by design — tri-dialect makes `postgres,mysql,sqlite` together a supported,
CI-tested combination, so there is nothing to exclude.

## #1217 — a template must not name an unreleased feature

Generated projects pin the **published** rustango by version while the template's
feature list is written against this tree. `batteries` (added in #1215) exists
here and in no release, so every `fullstack` and `tenant` project failed at
*resolution* — 36 of 50 audited — before compiling anything.

Fixed by asserting the invariant rather than spelling out the feature list,
since a hand-maintained list is exactly what rotted into #79.
`templates_name_real_features` parses the features each template emits and
checks every one against `crates/rustango/Cargo.toml`. Offline, no network, no
registry round-trip. Combined with publishing all four crates from one version —
`rustango` **before** `cargo-rustango` — a named feature is guaranteed to exist
in the pinned release. That constraint is now written down at the pin.

**Confirmed the test fails for the right reason:** renaming `batteries` in the
framework manifest reproduces #1217's exact error message, and restoring it goes
green. A test that cannot fail is worth nothing.

Worth naming why the existing test missed this. `generated_project_compiles`
builds with `--rustango-path` **by design**, so it validates the working tree
rather than the last release — right for checking codegen, and structurally
blind to registry resolution. The two tests cover different halves, and the PR
comments say so at both sites.

## Verification

| check | result |
|---|---|
| `cargo test -p rustango --all-features --lib` | 3586 passed |
| `cargo test --workspace --all-features --no-run` | Finished |
| cargo-rustango | 8 unit + 2 feature-invariant + 7 generate-and-compile |
| `cargo doc --all-features` | 0 errors, 8/8 modules present |
| `cargo check -p rustango --all-features` | 0 errors, 0 warnings |