### PR TITLE
chore(release): 0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,35 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+## [0.52.0] — 2026-08-13
+
 Headline: **a `ViewSet` can finally be scoped to the caller** (#1183) — the
 authenticated identity is available to filter backends, backends apply to every
 action, and `OwnedBy` does the common case in one line.
+
+Runner-up, and the one to read if you build against the feature table: **most
+minimal feature sets did not compile**, and now do. `--no-default-features
+--features sqlite` — the bare ORM the manifest has always advertised — failed
+with 50 errors; `postgres,manage`, which `cargo rustango new --template api`
+generates verbatim, failed with 75. Effectively only combinations including
+`tenancy` built, because `tenancy` happened to pull in the four crates those
+modules used ungated. Ten combinations are now checked in CI, with warnings
+denied, and their unit tests run too.
+
+### Upgrading
+
+Three changes need action:
+
+1. **`JtiStore` is async.** Add `.await` at the call sites listed under
+   *Changed*. A synchronous implementation stays a one-line
+   `Box::pin(async move { … })` wrapper.
+2. **The ViewSet page ceiling defaults to 100**, down from a hard-coded 1000.
+   A client asking for `?page_size=500` now receives 100 rows **with no
+   error** — it reads the real size from the response's `page_size`. Restore
+   the old bound per ViewSet with `.max_page_size(1000)`.
+3. **`tokio` is no longer an optional dependency.** No action for almost
+   everyone: `sqlx` is a hard dependency built with `runtime-tokio`, so tokio
+   was already compiled into every build. Only the manifest changed.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.51.2"
+version = "0.52.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.51.2", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.51.2", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.51.2", path = "crates/rustango" }
+rustango-macros     = { version = "0.52.0", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.52.0", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.52.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.51.2" }
+orm = { package = "rustango", path = "../rustango", version = "0.52.0" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -480,7 +480,7 @@ runserver = ["_axum"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.51.2", path = "../rustango-macros" }
+rustango-macros = { version = "0.52.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }

--- a/docs/de/sso.md
+++ b/docs/de/sso.md
@@ -36,9 +36,9 @@ Auto-Admin, sodass eine Endbenutzer-Anmeldung (Member) gebaut werden kann, ohne
 ```toml
 [dependencies]
 # Admin login with SSO:
-rustango = { version = "0.51", features = ["admin-sso"] }
+rustango = { version = "0.52", features = ["admin-sso"] }
 # Member (end-user) SSO without the auto-admin:
-rustango = { version = "0.51", features = ["tenancy", "sso"] }
+rustango = { version = "0.52", features = ["tenancy", "sso"] }
 ```
 
 `admin::sso_provider` und die historischen `admin::sso::*`-Kernpfade sind

--- a/docs/es/sso.md
+++ b/docs/es/sso.md
@@ -35,9 +35,9 @@ compilarse sin arrastrar `crate::admin`:
 ```toml
 [dependencies]
 # Admin login with SSO:
-rustango = { version = "0.51", features = ["admin-sso"] }
+rustango = { version = "0.52", features = ["admin-sso"] }
 # Member (end-user) SSO without the auto-admin:
-rustango = { version = "0.51", features = ["tenancy", "sso"] }
+rustango = { version = "0.52", features = ["tenancy", "sso"] }
 ```
 
 `admin::sso_provider` y las rutas históricas del núcleo `admin::sso::*` son

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -35,9 +35,9 @@ auto-admin, so an end-user (member) login can build without pulling in
 ```toml
 [dependencies]
 # Admin login with SSO:
-rustango = { version = "0.51", features = ["admin-sso"] }
+rustango = { version = "0.52", features = ["admin-sso"] }
 # Member (end-user) SSO without the auto-admin:
-rustango = { version = "0.51", features = ["tenancy", "sso"] }
+rustango = { version = "0.52", features = ["tenancy", "sso"] }
 ```
 
 `admin::sso_provider` and the historical `admin::sso::*` core paths are


### PR DESCRIPTION
Version bump for **0.52.0**. Minor, not patch — three changes need action.

## Upgrading

1. **`JtiStore` is async** (#1191). Add `.await` at the call sites; a
   synchronous impl stays a one-line `Box::pin(async move { … })` wrapper.
2. **ViewSet page ceiling defaults to 100**, down from a hard-coded 1000
   (#1196). A client asking `?page_size=500` now gets 100 rows **with no
   error** — it reads the real size from the response. Restore per-ViewSet with
   `.max_page_size(1000)`.
3. **`tokio` is no longer optional** (#1208 follow-up). No practical effect:
   `sqlx` is a hard dependency built with `runtime-tokio`, so tokio was already
   in every build. Only the manifest changed.

## What's in the release

| | |
|---|---|
| #1183 | ViewSet scoped to the authenticated caller — `OwnedBy` in one line |
| #1191 | async `JtiStore` — a durable store is one conditional write, not an eventually-consistent cache |
| #1196 | page ceiling is the app's, not a hard-coded 1000 |
| #1208 | **most minimal feature sets did not compile** — now ten combinations in CI |
| #1207/#1209/#1210/#1211/#1214 | the scaffolder generated a project that could not compile; a third of templates were dead on arrival |
| #1216/#1217 | `--help` without a database; templates may only name released features |

The feature-gate work is the one to read if you build against the feature
table. `--no-default-features --features sqlite` — the bare ORM the manifest
has always advertised — failed with 50 errors. `postgres,manage`, which
`cargo rustango new --template api` generates verbatim, failed with 75. Only
combinations including `tenancy` built, because `tenancy` happened to pull in
the four crates those modules used ungated — and `sqlite,tenancy` was the one
combination CI checked.

docs.rs also gains `[package.metadata.docs.rs] all-features = true`: `tenancy`,
`sso`, `mcp`, `passkey`, `admin-sso` and `cache-redis` are not in `default`, so
every one of them 404'd. Multi-tenancy had no published API docs at all.

## Scope of the bump

Workspace manifest + three internal path deps + `rustango-renamed-smoke`, and
`docs/sso.md` (en/de/es), which pinned `version = "0.51"` in a copy-pasteable
snippet.

The scaffolder follows automatically — `mm_version()` derives from the crate
version, so a generated project now pins `rustango = "0.52"`, the first release
carrying the `batteries` feature its templates name.

## Publish order is load-bearing

`rustango-macros` → `rustango` → `rustango-orm-macros` → `cargo-rustango`.

Demonstrated rather than asserted: `cargo package` succeeds today for
`rustango-macros` and `cargo-rustango`, and **fails** for `rustango` and
`rustango-orm-macros` with

```
failed to select a version for `rustango-macros = "^0.52.0"`
candidate versions found: 0.51.2, 0.51.1, 0.51.0
```

which resolves the moment `rustango-macros 0.52.0` is live. #1217 is the same
constraint one layer up: `cargo-rustango` must not ship before the `rustango`
that has `batteries`.

## Verification at the bumped version

- `cargo test --workspace --all-features --no-run` — finishes
- `cargo test -p rustango --all-features --lib` — 3586 passed
- `cargo check -p rustango --all-features` — 0 errors, 0 warnings
- template feature-name guard (#1217) still green