### PR TITLE
fix(macros): let `soft_delete` compile without the postgres feature

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -6755,6 +6755,7 @@ fn inherent_impl_tokens(
                 ///
                 /// # Errors
                 /// As [`Self::delete`].
+                #[cfg(feature = "postgres")]
                 pub async fn soft_delete_on #executor_generics (
                     &self,
                     #executor_param,
@@ -6797,6 +6798,7 @@ fn inherent_impl_tokens(
                 ///
                 /// # Errors
                 /// As [`Self::delete`].
+                #[cfg(feature = "postgres")]
                 pub async fn restore_on #executor_generics (
                     &self,
                     #executor_param,

--- a/crates/rustango/src/tenancy/member_auth.rs
+++ b/crates/rustango/src/tenancy/member_auth.rs
@@ -590,7 +590,13 @@ async fn sso_callback(
 /// Match the IdP email to an existing member, else auto-provision one
 /// (when `auto_provision`). Returns `Ok(Some(id))` on match/create,
 /// `Ok(None)` when unknown and auto-provision is off (caller refuses).
-async fn find_or_provision_member(
+///
+/// Public because the browser SSO flow is not the only caller any more: a
+/// native mobile sign-in verifies an ID token itself and then needs exactly
+/// this rule. Keeping it private forced the one downstream app that does so to
+/// reimplement it, and two copies of "which existing member is this, and may
+/// we create one" drift apart silently — both keep working, differently.
+pub async fn find_or_provision_member(
     pool: &Pool,
     email: &str,
     profile: &NormalizedUser,

--- a/crates/rustango/tests/soft_delete_without_postgres.rs
+++ b/crates/rustango/tests/soft_delete_without_postgres.rs
@@ -1,0 +1,107 @@
+//! `#[rustango(soft_delete)]` has to compile when the `postgres` feature is
+//! **off**.
+//!
+//! This file is the regression guard for a bug that three existing sqlite
+//! soft-delete suites could not catch. They are `cfg(feature = "sqlite")`, and
+//! the crate's default features include `postgres` — so every one of them ran
+//! with the PG backend also compiled in, which is exactly the condition that
+//! hid the fault.
+//!
+//! The derive emits `soft_delete_on` / `restore_on`, which take a Postgres
+//! executor and reach `sql::__macro_internals`. That module is
+//! `#[cfg(feature = "postgres")]`. The two methods were the only PG-executor
+//! methods in the macro missing the same gate, so the moment a *consumer*
+//! built sqlite-only — as a dialect-native app does — the derive expanded to a
+//! reference to a module that was configured out, and the model would not
+//! compile at all.
+//!
+//! Hence the inverted gate below: this file exists only in the build the other
+//! suites cannot see. Run it with
+//! `cargo test -p rustango --no-default-features --features sqlite,testkit
+//! --test soft_delete_without_postgres`.
+
+#![cfg(all(feature = "sqlite", not(feature = "postgres")))]
+
+use rustango::sql::{Auto, FetcherPool as _, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "sdnp_note")]
+#[allow(dead_code)]
+pub struct Note {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 40)]
+    pub title: String,
+    #[rustango(soft_delete)]
+    pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+async fn pool() -> Pool {
+    let path = std::env::temp_dir().join("rustango_sd_no_pg.sqlite");
+    let _ = std::fs::remove_file(&path);
+    let pool = Pool::connect(&format!("sqlite://{}?mode=rwc", path.display()))
+        .await
+        .expect("connect");
+    rustango::testkit::create_tables_for::<Note>(&pool)
+        .await
+        .expect("schema");
+    pool
+}
+
+async fn a_note(pool: &Pool, title: &str) -> Note {
+    let mut n = Note {
+        id: Auto::Unset,
+        title: title.to_owned(),
+        deleted_at: None,
+    };
+    n.insert_pool(pool).await.expect("insert");
+    n
+}
+
+/// The compile is most of the test — if this file builds at all, the gate is
+/// right. The assertions confirm the pool-based trio is what remains, and that
+/// it actually works without a Postgres backend anywhere in the build.
+#[tokio::test]
+async fn the_pool_trio_works_with_no_postgres_backend() {
+    let pool = pool().await;
+    let keep = a_note(&pool, "keep").await;
+    let gone = a_note(&pool, "gone").await;
+
+    gone.soft_delete(&pool).await.expect("soft delete");
+
+    let live: Vec<Note> = Note::objects().active().fetch(&pool).await.expect("active");
+    assert_eq!(live.len(), 1);
+    assert_eq!(live[0].id.get().copied(), keep.id.get().copied());
+
+    let trashed: Vec<Note> = Note::objects()
+        .only_trashed()
+        .fetch(&pool)
+        .await
+        .expect("only_trashed");
+    assert_eq!(trashed.len(), 1, "the row is still there, marked");
+
+    gone.restore(&pool).await.expect("restore");
+    assert_eq!(
+        Note::objects()
+            .active()
+            .fetch(&pool)
+            .await
+            .expect("active")
+            .len(),
+        2,
+        "restore puts it back"
+    );
+
+    gone.force_delete(&pool).await.expect("force delete");
+    assert_eq!(
+        Note::objects()
+            .with_trashed()
+            .fetch(&pool)
+            .await
+            .expect("all")
+            .len(),
+        1,
+        "force_delete really removes the row"
+    );
+}


### PR DESCRIPTION
## The bug

`#[rustango(soft_delete)]` did not compile on any build that leaves `postgres` off.

The derive emits `soft_delete_on` / `restore_on`, which take a Postgres executor and reach `sql::__macro_internals` — a module that is itself `#[cfg(feature = "postgres")]`. They were the **only** PG-executor methods in the macro without the matching gate that `save` / `insert` / `delete` all carry. So the moment a consumer built sqlite-only, as a dialect-native app does, the derive expanded to a reference to a module that had been configured out and the model failed to build:

```
error[E0433]: failed to resolve: could not find `__macro_internals` in `sql`
note: found an item that was configured out
note: the item is gated behind the `postgres` feature
```

## The fix

Two `#[cfg(feature = "postgres")]` lines. Nothing needed writing: the pool-based trio (`soft_delete` / `restore` / `force_delete`, plus `active` / `only_trashed`) already takes `&Pool` and has always been backend-agnostic — only the two `_on` methods were missing the gate.

## Why the existing tests missed it

`model_soft_delete_scope_pool_sqlite_live`, `soft_delete_pool_instance_sqlite_live` and `soft_delete_queryset_sqlite_live` are all `cfg(feature = "sqlite")`, and the crate's default features include `postgres` — so every one of them ran with the PG backend *also* compiled in, which is exactly the condition that hid the fault. Nothing in the repo builds sqlite-only.

The new test carries an inverted gate, `not(feature = "postgres")`, so it exists only in the build the others cannot see:

```sh
cargo test -p rustango --no-default-features --features sqlite,testkit \
  --test soft_delete_without_postgres
```

Worth considering a CI job on that feature set — it is the shape every dialect-native downstream app builds, and nothing currently covers it.

## Also: `find_or_provision_member` is now public

The browser SSO flow is no longer its only caller. A native mobile sign-in verifies an ID token itself and then needs exactly this rule; keeping it private forced a downstream app to reimplement it. Two copies of "which existing member is this, and may we create one" drift apart silently, because both keep working — differently.

## Verification

- `cargo test -p rustango --lib` — 3235 passed
- the three existing soft-delete suites, with both backends on — 11 passed, so the PG path is intact
- the new sqlite-only test — passes, and fails to compile without the fix
- no version bump: left to the `chore(release)` process

🤖 Generated with [Claude Code](https://claude.com/claude-code)