### PR TITLE
chore(release): 0.52.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+## [0.52.1] — 2026-08-15
+
+Patch. One fix, no breaking changes — `0.52.0` users can take it directly.
+
+### Fixed
+- **`#[rustango(soft_delete)]` did not compile on any build with `postgres`
+  off** (#1221). The derive emits `soft_delete_on` / `restore_on`, which take a
+  Postgres executor and reach `sql::__macro_internals` — a module that is itself
+  `#[cfg(feature = "postgres")]`. They were the only PG-executor methods in the
+  macro missing the matching gate, so a sqlite-only consumer got an expansion
+  referencing a module that had been configured out. The pool-based trio
+  (`soft_delete` / `restore` / `force_delete`, plus `active` / `only_trashed`)
+  already takes `&Pool` and was always backend-agnostic; only the two `_on`
+  methods needed the gate every other PG method in the file already carries.
+
+  Why the existing suites missed it: the three sqlite soft-delete tests are
+  `cfg(feature = "sqlite")`, and the crate's default features include
+  `postgres`, so each ran with the PG backend *also* compiled in — precisely the
+  condition that hid the fault. The regression test carries an inverted gate,
+  `not(feature = "postgres")`, so it exists only in the build the others cannot
+  see:
+
+  ```
+  cargo test -p rustango --no-default-features \
+    --features sqlite,testkit --test soft_delete_without_postgres
+  ```
+
+### Changed
+- **`find_or_provision_member` is now public.** The browser SSO flow is no
+  longer its only caller — a native mobile sign-in verifies an ID token itself
+  and then needs exactly this rule, and keeping it private forced a downstream
+  app to reimplement it. Two copies of "which existing member does this
+  verified email map to, and may it be provisioned" is the kind of duplication
+  that drifts into a security bug.
+
 ## [0.52.0] — 2026-08-13
 
 Headline: **a `ViewSet` can finally be scoped to the caller** (#1183) — the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.52.0"
+version = "0.52.1"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.52.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.52.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.52.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.52.1", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.52.1", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.52.1", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.52.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.52.1" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -480,7 +480,7 @@ runserver = ["_axum"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.52.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.52.1", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }


### PR DESCRIPTION
Patch release. One fix (#1221), no breaking changes — **0.52.0 users can take it directly.**

## The fix

`#[rustango(soft_delete)]` **did not compile on any build with `postgres` off.**

The derive emits `soft_delete_on` / `restore_on`, which take a Postgres executor
and reach `sql::__macro_internals` — a module that is itself
`#[cfg(feature = "postgres")]`. They were the only PG-executor methods in the
macro missing the matching gate, so the moment a consumer built sqlite-only the
derive expanded to a reference to a module that had been configured out.

Nothing needed writing. The pool-based trio (`soft_delete` / `restore` /
`force_delete`, plus `active` / `only_trashed`) already takes `&Pool` and has
always been backend-agnostic; only the two `_on` methods needed the gate every
other PG method in the file already carries.

**Why the existing suites missed it** — the interesting part. The three sqlite
soft-delete tests are `cfg(feature = "sqlite")`, and the crate's default
features include `postgres`, so every one of them ran with the PG backend *also*
compiled in — exactly the condition that hid the fault. Nothing in the repo
built sqlite-only. The regression test carries an inverted gate,
`not(feature = "postgres")`, so it exists only in the build the others cannot
see:

```
cargo test -p rustango --no-default-features \
  --features sqlite,testkit --test soft_delete_without_postgres
```

This is the same class of gap #1208 closed one release ago, in a corner that
sweep did not reach: a `cfg` that is correct for the module but absent from the
macro *expansion*, which no amount of building the framework itself can catch —
only building a consumer.

## Patch, not minor

#1221 also widens `find_or_provision_member` to `pub` (a native mobile sign-in
verifies an ID token itself and then needs exactly this rule; keeping it private
forced a downstream app to reimplement "which existing member does this verified
email map to, and may it be provisioned" — duplication that drifts into a
security bug).

Under strict SemVer a new public item argues for a minor. Taken as a patch here:
the crate is pre-1.0, where [the CHANGELOG already disclaims stability
guarantees](https://github.com/ujeenet/rustango/blob/main/CHANGELOG.md), and a
widened visibility breaks no existing caller.

## Scope

Workspace manifest, the three internal path deps, and `rustango-renamed-smoke`.

The `docs/sso.md` (en/de/es) pins read `version = "0.52"` — a range that already
admits 0.52.1, so they are left alone, unlike the 0.52.0 bump where the
major-minor pin had to move.

## Verification at the bumped version

- `cargo test --workspace --all-features --no-run` — finishes
- `cargo test -p rustango --all-features --lib` — 3586 passed
- #1221 regression test — passes in the inverted-gate build that hid the fault