### PR TITLE
fix(tenancy): reset search_path when a schema-mode TenantConn is released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+### Fixed
+- **Schema-mode tenancy leaked `search_path` between registry-pool borrowers**
+  (#1224). `TenantPools::acquire` issues a session-level
+  `SET search_path TO <schema>, public` on a connection borrowed from the
+  *shared* registry pool, and nothing undid it: `TenantConn` had no `Drop`, no
+  pool sets an `after_release` hook, and sqlx only pings on release — it never
+  issues `DISCARD ALL` / `RESET`. The connection returned to the pool still
+  pointing at that tenant's schema, so the next borrower silently inherited it,
+  and any registry-pool query against a table that also exists in tenant schemas
+  resolved against whichever tenant used that connection last.
+
+  Long-lived background work is the worst amplifier — a worker holding the
+  registry pool polls for the process lifetime, so it *will* draw dirtied
+  connections. It also hides in testing: when `public` lacks the table, the query
+  errors on a clean connection and succeeds against a random tenant on a dirty
+  one, so a single-tenant suite stays green.
+
+  `TenantConn` now resets `search_path` when released. `Drop` cannot be async, so
+  the reset runs in a spawned task — not racy, because the task owns the
+  `PoolConnection` and the pool cannot re-hand it out until the reset lands. A
+  failed reset closes the connection instead of returning it, and a drop with no
+  runtime available marks it `close_on_drop`, so both failure paths fail closed.
+  `after_release` would have been cheaper per request but is unreachable: apps
+  and `manage` hand `TenantPools::new` an already-built `PgPool`, and sqlx only
+  accepts that hook at `PoolOptions` construction.
+
+  Costs one extra round trip per release, with the connection still checked out
+  while it runs, so a registry pool sized near peak concurrency will feel it as
+  `acquire` latency.
+
+  Also corrects the `Tenant::pool()` docs, stale since v0.38: they claimed
+  schema-mode queries through it hit `public`. The PG extractor resolves that
+  pool via `scoped_pool_dyn`, which builds a *dedicated* pool with `search_path`
+  in its connect options — so `t.pool()` reads the tenant's schema and never
+  borrows from the shared registry pool.
+
 ## [0.52.1] — 2026-08-15
 
 Patch. One fix, no breaking changes — `0.52.0` users can take it directly.

--- a/crates/rustango/src/extractors/tenant.rs
+++ b/crates/rustango/src/extractors/tenant.rs
@@ -80,12 +80,13 @@ pub struct Tenant<DB: Database = DefaultTenantDb> {
     pub org: Org,
     conn: TenantConnCell<DB>,
     /// v0.38 — backend-erasing pool reference for the tenant's storage.
-    /// On PG schema-mode this wraps the registry pool (queries through
-    /// it would hit the `public` schema unless `SET search_path` is
-    /// applied — for that path prefer [`Tenant::conn`]). On non-PG
-    /// (and PG database-mode), this is the tenant's dedicated pool;
-    /// handlers can run `Model::objects().fetch(&t.pool)` for
-    /// tri-dialect ORM queries.
+    /// Always tenant-scoped, by whichever mechanism the storage mode
+    /// calls for: on PG schema-mode [`TenantPools::scoped_pool`] builds
+    /// a dedicated pool with `search_path` in its **connect options**
+    /// (so every checkout is scoped without a per-query `SET`); on
+    /// non-PG and PG database-mode it is the tenant's dedicated pool.
+    /// Handlers can run `Model::objects().fetch(&t.pool)` for
+    /// tri-dialect ORM queries in either mode.
     pool: crate::sql::Pool,
 }
 
@@ -145,17 +146,13 @@ impl<DB: Database> Tenant<DB> {
     /// `insert_pool` / `save_pool`) — every backend works through the
     /// same code path.
     ///
-    /// **PG schema-mode note**: the pool wraps the shared registry
-    /// pool; queries against it hit `public` instead of the tenant
-    /// schema. For schema-mode-on-PG paths use [`Tenant::conn`] (which
-    /// has `SET search_path` applied). Database-mode (any backend) is
-    /// unaffected.
-    ///
-    /// That `public` is a guarantee, not a coincidence:
-    /// `TenantConn` resets `search_path` when it is released, so this
-    /// pool never hands out a connection still scoped to whichever
-    /// tenant borrowed it last (#1224). Wrong-namespace queries here
-    /// fail loudly rather than reading another tenant's rows.
+    /// Tenant-scoped in **both** storage modes — schema-mode included.
+    /// [`TenantPools::scoped_pool`] bakes `search_path` into the
+    /// connect options of a dedicated pool rather than issuing a
+    /// per-checkout `SET`, so this pool never borrows from the shared
+    /// registry pool and cannot pick up another tenant's session state.
+    /// [`Tenant::conn`] is the shared-registry path; prefer it when you
+    /// want the request's single pinned connection rather than a pool.
     #[must_use]
     pub fn pool(&self) -> &crate::sql::Pool {
         &self.pool
@@ -263,9 +260,10 @@ where
             .map_err(|e| TenantRejection::Internal(e.to_string()))?;
         // v0.38 — also resolve the backend-erasing Pool enum so
         // `t.pool()` lets handlers use tri-dialect ORM helpers
-        // (fetch / save_pool / etc.). Schema-mode picks the
-        // shared registry pool (which requires SET search_path);
-        // database-mode resolves to the dedicated tenant pool.
+        // (fetch / save_pool / etc.). Schema-mode gets a dedicated
+        // pool with `search_path` in its connect options (NOT the
+        // shared registry pool); database-mode resolves to the
+        // tenant's own pool.
         let pool = ctx
             .pools
             .scoped_pool_dyn(&org)

--- a/crates/rustango/src/extractors/tenant.rs
+++ b/crates/rustango/src/extractors/tenant.rs
@@ -153,6 +153,12 @@ impl<DB: Database> Tenant<DB> {
     /// registry pool and cannot pick up another tenant's session state.
     /// [`Tenant::conn`] is the shared-registry path; prefer it when you
     /// want the request's single pinned connection rather than a pool.
+    ///
+    /// **Cost, schema-mode only:** that dedicated pool is built per
+    /// extraction and is not cached, and sqlx's `connect_with` opens a
+    /// connection eagerly — so a schema-mode request that touches this
+    /// pool pays a fresh PG connection. Database-mode reuses the
+    /// tenant's cached pool and pays nothing.
     #[must_use]
     pub fn pool(&self) -> &crate::sql::Pool {
         &self.pool

--- a/crates/rustango/src/extractors/tenant.rs
+++ b/crates/rustango/src/extractors/tenant.rs
@@ -146,10 +146,16 @@ impl<DB: Database> Tenant<DB> {
     /// same code path.
     ///
     /// **PG schema-mode note**: the pool wraps the shared registry
-    /// pool; queries against it would hit `public` instead of the
-    /// tenant schema. For schema-mode-on-PG paths use
-    /// [`Tenant::conn`] (which has `SET search_path` applied).
-    /// Database-mode (any backend) is unaffected.
+    /// pool; queries against it hit `public` instead of the tenant
+    /// schema. For schema-mode-on-PG paths use [`Tenant::conn`] (which
+    /// has `SET search_path` applied). Database-mode (any backend) is
+    /// unaffected.
+    ///
+    /// That `public` is a guarantee, not a coincidence:
+    /// `TenantConn` resets `search_path` when it is released, so this
+    /// pool never hands out a connection still scoped to whichever
+    /// tenant borrowed it last (#1224). Wrong-namespace queries here
+    /// fail loudly rather than reading another tenant's rows.
     #[must_use]
     pub fn pool(&self) -> &crate::sql::Pool {
         &self.pool

--- a/crates/rustango/src/tenancy/pools.rs
+++ b/crates/rustango/src/tenancy/pools.rs
@@ -6,7 +6,10 @@
 //!   lives in a Postgres schema inside the registry DB. The registry
 //!   pool is shared across all schema-mode tenants; per-checkout we
 //!   issue `SET search_path TO <schema>, public` so queries see the
-//!   tenant's schema. Cheap (one connection budget for all tenants).
+//!   tenant's schema, and on release [`TenantConn`] resets it so the
+//!   next borrower of that shared connection cannot inherit the
+//!   tenant's namespace (#1224). Cheap (one connection budget for all
+//!   tenants).
 //!
 //! * **Database mode** (`Org.storage_mode == "database"`). Tenant data
 //!   lives in a separate Postgres database. `Org.database_url` is a
@@ -403,8 +406,11 @@ impl<DB: Database> TenantPools<DB> {
         };
         let conn = pool.acquire().await?;
         Ok(TenantConn {
-            inner: conn,
+            inner: Some(conn),
             schema: None,
+            // Database-mode pools are per-tenant and carry no
+            // per-checkout session state, so there is nothing to undo.
+            reset: None,
         })
     }
 
@@ -719,15 +725,19 @@ impl TenantPools<sqlx::Postgres> {
                     .execute(&mut *conn)
                     .await?;
                 Ok(TenantConn {
-                    inner: conn,
+                    inner: Some(conn),
                     schema: Some(schema.clone()),
+                    // The `SET` above is session-level on a *shared*
+                    // pool — it must be undone on release (#1224).
+                    reset: Some(reset_pg_search_path),
                 })
             }
             TenantPool::Database { pool } => {
                 let conn = pool.acquire().await?;
                 Ok(TenantConn {
-                    inner: conn,
+                    inner: Some(conn),
                     schema: None,
+                    reset: None,
                 })
             }
         }
@@ -861,9 +871,23 @@ mod ensure_sqlite_creates_tests {
 /// Implements `Deref` to the inner [`sqlx::pool::PoolConnection`] for
 /// use as a sqlx executor.
 pub struct TenantConn<DB: Database = DefaultTenantDb> {
-    inner: sqlx::pool::PoolConnection<DB>,
+    /// `Option` only so [`Drop`] can move the connection into the
+    /// reset task. It is `Some` for the whole observable lifetime.
+    inner: Option<sqlx::pool::PoolConnection<DB>>,
     schema: Option<String>,
+    /// Session-state teardown, installed only by the schema-mode
+    /// branch of [`TenantPools::acquire`]. `None` means "this
+    /// connection carries no per-tenant session state" — the
+    /// database-mode and non-PG paths, which need no reset.
+    reset: Option<ResetFn<DB>>,
 }
+
+/// Undo whatever session state the acquire path installed, then let the
+/// connection fall back to its pool. Takes ownership so the pool cannot
+/// hand the connection to anyone else until the reset has landed.
+type ResetFn<DB> = fn(
+    sqlx::pool::PoolConnection<DB>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>;
 
 impl<DB: Database> TenantConn<DB> {
     /// `Some(schema)` for schema-mode connections, `None` for
@@ -877,14 +901,64 @@ impl<DB: Database> TenantConn<DB> {
 impl<DB: Database> std::ops::Deref for TenantConn<DB> {
     type Target = sqlx::pool::PoolConnection<DB>;
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        self.inner.as_ref().expect("connection taken only on drop")
     }
 }
 
 impl<DB: Database> std::ops::DerefMut for TenantConn<DB> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
+        self.inner.as_mut().expect("connection taken only on drop")
     }
+}
+
+/// Schema-mode `acquire` issues a **session-level** `SET search_path` on
+/// a connection borrowed from the *shared* registry pool. sqlx does not
+/// reset session state on release — it only pings — so without this the
+/// connection goes back to the pool still pointing at the tenant's
+/// schema, and the next borrower silently inherits it. That borrower is
+/// often a registry query, a `Tenant::pool()` handler, or a long-lived
+/// background worker, none of which issue a `SET` of their own (#1224).
+///
+/// The reset runs in a spawned task because `Drop` cannot be async, but
+/// it is not racy: the task owns the `PoolConnection`, so the pool
+/// cannot hand it out again until the reset has completed and the task
+/// drops it.
+impl<DB: Database> Drop for TenantConn<DB> {
+    fn drop(&mut self) {
+        let (Some(reset), Some(conn)) = (self.reset, self.inner.take()) else {
+            return;
+        };
+        // No runtime (a sync teardown, or the runtime is already gone)
+        // means nothing can run the reset. Dropping the connection here
+        // is what would have happened anyway.
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        handle.spawn(reset(conn));
+    }
+}
+
+/// The [`ResetFn`] for schema-mode Postgres connections. On failure the
+/// connection is closed rather than returned, so a dirty one can never
+/// be reused.
+#[cfg(feature = "postgres")]
+fn reset_pg_search_path(
+    mut conn: sqlx::pool::PoolConnection<sqlx::Postgres>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+    Box::pin(async move {
+        match sqlx::query("RESET search_path").execute(&mut *conn).await {
+            Ok(_) => drop(conn),
+            Err(error) => {
+                tracing::warn!(
+                    target: "crate::tenancy::pools",
+                    %error,
+                    "could not reset search_path on release; closing the connection \
+                     rather than returning it to the registry pool",
+                );
+                let _ = conn.close().await;
+            }
+        }
+    })
 }
 
 /// Quote a Postgres identifier — wrap in double-quotes, escape any

--- a/crates/rustango/src/tenancy/pools.rs
+++ b/crates/rustango/src/tenancy/pools.rs
@@ -932,15 +932,23 @@ impl<DB: Database> std::ops::DerefMut for TenantConn<DB> {
 /// it is not racy: the task owns the `PoolConnection`, so the pool
 /// cannot hand it out again until the reset has completed and the task
 /// drops it.
+///
+/// The one residual case is a reset task cancelled by a runtime that is
+/// shutting down. That is benign in practice — the pool is being torn
+/// down with the runtime, so there is no later borrower to leak to.
 impl<DB: Database> Drop for TenantConn<DB> {
     fn drop(&mut self) {
-        let (Some(reset), Some(conn)) = (self.reset, self.inner.take()) else {
+        let (Some(reset), Some(mut conn)) = (self.reset, self.inner.take()) else {
             return;
         };
         // No runtime (a sync teardown, or the runtime is already gone)
-        // means nothing can run the reset. Dropping the connection here
-        // is what would have happened anyway.
+        // means nothing can run the reset. Fail **closed**: mark the
+        // connection to be closed on drop rather than returned, so a
+        // still-tenant-scoped connection can never rejoin the shared
+        // registry pool. Losing one connection is cheap; handing the
+        // next borrower another tenant's `search_path` is #1224.
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            conn.close_on_drop();
             return;
         };
         handle.spawn(reset(conn));

--- a/crates/rustango/src/tenancy/pools.rs
+++ b/crates/rustango/src/tenancy/pools.rs
@@ -8,8 +8,11 @@
 //!   issue `SET search_path TO <schema>, public` so queries see the
 //!   tenant's schema, and on release [`TenantConn`] resets it so the
 //!   next borrower of that shared connection cannot inherit the
-//!   tenant's namespace (#1224). Cheap (one connection budget for all
-//!   tenants).
+//!   tenant's namespace (#1224). Cheap on connection budget (one for
+//!   all tenants); the reset costs one extra round trip per release,
+//!   with the connection still checked out while it runs, so a
+//!   registry pool sized near peak concurrency will feel it as
+//!   `acquire` latency.
 //!
 //! * **Database mode** (`Org.storage_mode == "database"`). Tenant data
 //!   lives in a separate Postgres database. `Org.database_url` is a
@@ -719,18 +722,24 @@ impl TenantPools<sqlx::Postgres> {
         let pool = self.pool_for_org(org).await?;
         match &pool {
             TenantPool::Schema { schema, registry } => {
-                let mut conn = registry.acquire().await?;
-                let stmt = format!("SET search_path TO {}, public", quote_ident(schema));
-                rustango::sql::sqlx::query(&stmt)
-                    .execute(&mut *conn)
-                    .await?;
-                Ok(TenantConn {
+                let conn = registry.acquire().await?;
+                // Install the reset *before* issuing the `SET`, not
+                // after. The statement is session-level on a **shared**
+                // pool, so it must be undone on release (#1224) — and
+                // if this future is cancelled (request timeout, client
+                // disconnect, `select!`) after PG has already applied
+                // the `SET`, only a live `TenantConn` can undo it.
+                // Constructing it afterwards leaves a window where the
+                // bare `PoolConnection` drops, sqlx's `ping()` recovers
+                // it, and it rejoins the shared pool tenant-scoped.
+                let mut tc = TenantConn {
                     inner: Some(conn),
                     schema: Some(schema.clone()),
-                    // The `SET` above is session-level on a *shared*
-                    // pool — it must be undone on release (#1224).
                     reset: Some(reset_pg_search_path),
-                })
+                };
+                let stmt = format!("SET search_path TO {}, public", quote_ident(schema));
+                rustango::sql::sqlx::query(&stmt).execute(&mut **tc).await?;
+                Ok(tc)
             }
             TenantPool::Database { pool } => {
                 let conn = pool.acquire().await?;

--- a/crates/rustango/tests/pools_live.rs
+++ b/crates/rustango/tests/pools_live.rs
@@ -174,6 +174,16 @@ async fn schema_mode_acquire_resets_search_path_on_release() {
     )
     .await;
 
+    // Baseline BEFORE any tenant touches the pool. Asserting against
+    // this rather than a hardcoded "public" keeps the test honest under
+    // a `DATABASE_URL` carrying `options=-csearch_path=…`, or a
+    // role-level default — `RESET search_path` restores the session's
+    // startup value, which is not always `public`.
+    let baseline = {
+        let mut conn = pool.acquire().await.unwrap();
+        current_schema(&mut conn).await
+    };
+
     let pools = TenantPools::new(pool.clone());
     {
         let mut conn = pools.acquire(&acme).await.unwrap();
@@ -184,10 +194,14 @@ async fn schema_mode_acquire_resets_search_path_on_release() {
     // `Tenant::pool()` query gets. It must NOT inherit the tenant's
     // search_path.
     let mut plain = pool.acquire().await.unwrap();
-    assert_eq!(
-        current_schema(&mut plain).await,
-        "public",
+    let after = current_schema(&mut plain).await;
+    assert_ne!(
+        after, "acme_tp_leak",
         "registry connection inherited the tenant's search_path after release"
+    );
+    assert_eq!(
+        after, baseline,
+        "release must restore the session's startup search_path, not just move off the tenant's"
     );
     drop(plain);
 

--- a/crates/rustango/tests/pools_live.rs
+++ b/crates/rustango/tests/pools_live.rs
@@ -138,6 +138,131 @@ async fn schema_mode_acquire_sets_search_path_to_tenant_schema() {
     migrate::drop_all(&pool).await.unwrap();
 }
 
+/// Schema-mode `acquire` issues a session-level `SET search_path` on a
+/// connection borrowed from the **shared registry pool**. Dropping the
+/// `TenantConn` must leave that connection scoped back at `public`,
+/// because the very next borrower may be a registry query, a
+/// `Tenant::pool()` handler, or a long-lived background worker — none of
+/// which issue a `SET` of their own. sqlx does not reset session state
+/// on release (it only pings), so the reset is the framework's job.
+///
+/// Pinned to `max_connections(1)` so the second checkout is guaranteed to
+/// be the same physical connection the tenant just used.
+#[tokio::test]
+async fn schema_mode_acquire_resets_search_path_on_release() {
+    let _g = live_lock().lock().await;
+    let Some(url) = std::env::var("DATABASE_URL").ok() else {
+        return;
+    };
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&url)
+        .await
+        .expect("connect to DATABASE_URL");
+
+    migrate::drop_all(&pool).await.unwrap();
+    migrate::apply_all(&pool).await.unwrap();
+    drop_schema(&pool, "acme_tp_leak").await;
+    create_schema(&pool, "acme_tp_leak").await;
+
+    let acme = seed_org(
+        &pool,
+        "acme_tp_leak",
+        StorageMode::Schema,
+        Some("acme_tp_leak"),
+        None,
+    )
+    .await;
+
+    let pools = TenantPools::new(pool.clone());
+    {
+        let mut conn = pools.acquire(&acme).await.unwrap();
+        assert_eq!(current_schema(&mut conn).await, "acme_tp_leak");
+    } // TenantConn dropped — connection goes back to the registry pool.
+
+    // A plain registry checkout — what a background worker or a
+    // `Tenant::pool()` query gets. It must NOT inherit the tenant's
+    // search_path.
+    let mut plain = pool.acquire().await.unwrap();
+    assert_eq!(
+        current_schema(&mut plain).await,
+        "public",
+        "registry connection inherited the tenant's search_path after release"
+    );
+    drop(plain);
+
+    drop_schema(&pool, "acme_tp_leak").await;
+    migrate::drop_all(&pool).await.unwrap();
+}
+
+/// The same leak stated as data rather than as a setting: a table name
+/// that exists in **both** the tenant schema and `public` must resolve to
+/// `public` for a plain registry checkout. This is the shape a background
+/// worker or a `Tenant::pool()` handler actually hits — it reads rows, not
+/// `current_schema()`.
+#[tokio::test]
+async fn released_registry_connection_does_not_read_tenant_rows() {
+    let _g = live_lock().lock().await;
+    let Some(url) = std::env::var("DATABASE_URL").ok() else {
+        return;
+    };
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&url)
+        .await
+        .expect("connect to DATABASE_URL");
+
+    migrate::drop_all(&pool).await.unwrap();
+    migrate::apply_all(&pool).await.unwrap();
+    drop_schema(&pool, "acme_tp_rows").await;
+    create_schema(&pool, "acme_tp_rows").await;
+
+    // Same table name in both namespaces: one tenant row, zero public rows.
+    for stmt in [
+        "DROP TABLE IF EXISTS public.leak_probe",
+        "CREATE TABLE public.leak_probe (id int)",
+        r#"CREATE TABLE "acme_tp_rows".leak_probe (id int)"#,
+        r#"INSERT INTO "acme_tp_rows".leak_probe (id) VALUES (1)"#,
+    ] {
+        sqlx::query(stmt).execute(&pool).await.unwrap();
+    }
+
+    let acme = seed_org(
+        &pool,
+        "acme_tp_rows",
+        StorageMode::Schema,
+        Some("acme_tp_rows"),
+        None,
+    )
+    .await;
+
+    let pools = TenantPools::new(pool.clone());
+    {
+        let mut conn = pools.acquire(&acme).await.unwrap();
+        let (n,): (i64,) = sqlx::query_as("SELECT count(*) FROM leak_probe")
+            .fetch_one(&mut **conn)
+            .await
+            .unwrap();
+        assert_eq!(n, 1, "the tenant's own connection should see its row");
+    }
+
+    let (n,): (i64,) = sqlx::query_as("SELECT count(*) FROM leak_probe")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        n, 0,
+        "a released registry connection read the tenant's rows — search_path leaked"
+    );
+
+    sqlx::query("DROP TABLE IF EXISTS public.leak_probe")
+        .execute(&pool)
+        .await
+        .unwrap();
+    drop_schema(&pool, "acme_tp_rows").await;
+    migrate::drop_all(&pool).await.unwrap();
+}
+
 #[tokio::test]
 async fn schema_mode_pool_uses_slug_when_schema_name_is_none() {
     // `schema_name = None` means "use the slug as the schema name".


### PR DESCRIPTION
Fixes #1224.

## The leak

Schema-mode `acquire` issues a **session-level** `SET search_path` on a
connection borrowed from the *shared* registry pool
([`pools.rs:717`](https://github.com/ujeenet/rustango/blob/develop/crates/rustango/src/tenancy/pools.rs#L717)),
and nothing ever undid it. `TenantConn` had no `Drop`, and no pool in the crate
installs an `after_release` hook — sqlx only `ping()`s on release
(`sqlx-core-0.8.6/src/pool/connection.rs:311`), never `DISCARD ALL` / `RESET`.
So the connection went back to the pool still pointing at that tenant's schema
and the next borrower silently inherited it.

Any registry-pool query against a table that also exists in tenant schemas
(`rustango_users`, `rustango_audit_log`, `rustango_media`, app models) therefore
resolved against **whichever tenant last used that connection**.

Reproduced against live PG before touching anything, `max_connections(1)`:

```
assertion `left == right` failed: registry connection inherited the tenant's search_path after release
  left: "acme_tp_leak"    right: "public"
```

And as data — same table name in `public` and in the tenant schema, one row in
the tenant's:

```
assertion `left == right` failed: a released registry connection read the tenant's rows — search_path leaked
  left: 1    right: 0
```

## The fix

`TenantConn` now owns teardown of the session state its acquire path installed:

- `inner` became `Option<PoolConnection<DB>>` so `Drop` can move the connection
  out, plus a `reset: Option<ResetFn<DB>>` fn-pointer set **only** by the
  schema-mode branch of `acquire`.
- `Drop` spawns the reset. It reads as racy but is not: the task **owns** the
  `PoolConnection`, so the pool cannot re-hand it out until the
  `RESET search_path` has landed and the task drops it. No tokio runtime
  available → skip, which is exactly what happened before.
- A failed reset **closes** the connection rather than returning it, so a dirty
  one can never be reused.
- Database-mode and non-PG carry `reset: None` — structurally zero cost, no
  extra round-trip on those paths.

### Why not `after_release`

Cheaper per request, but unreachable here: apps and `manage` hand
`TenantPools::new` an already-built `PgPool`, and sqlx only accepts the hook at
`PoolOptions` construction. Teardown has to live in the type that owns the
checkout.

`Drop` also cannot be async, which rules out doing the reset inline; and an
explicit `TenantConn::release().await` would need every call site to remember,
so it is no better than the status quo.

## Docs

`Tenant::pool()`'s note said queries through it "would hit `public`" — true only
by luck before this change. Reworded to state the guarantee and where it comes
from, since the difference is a wrong-namespace query failing loudly versus
reading another tenant's rows.

## Tests

Two PG live regressions in `pools_live.rs`, both pinned to `max_connections(1)`
so the second checkout is guaranteed to be the same physical connection:

- `schema_mode_acquire_resets_search_path_on_release` — `current_schema()` is
  `public` for a plain registry checkout after the `TenantConn` drops.
- `released_registry_connection_does_not_read_tenant_rows` — the same leak as
  data: a table name present in both namespaces reads 0 rows, not the tenant's 1.

Both were verified to fail with the source change stashed.

## Verification

- `pools_live` 8/8; tenancy PG live suites green: `org_live`, `tenant_auth_live`,
  `tenant_admin_live`, `tenant_migrate_live`, `viewset_tenant_router_live`,
  `branding_live`, `migrate_tenant_storage_live`, `operator_console_orgs_edit_live`.
- Database-mode path (`reset: None`) green on SQLite: `tenant_pools_sqlite_live`,
  `database_pools_sqlite_live`, `database_pools_sqlite_file_live`,
  `pure_sqlite_stack_live`.
- `cargo test --workspace --all-features --no-run` clean.
- `cargo build --no-default-features --features sqlite,tenancy` builds.
- `cargo clippy --features tenancy,postgres --all-targets` reports nothing on the
  new lines.

## Not in scope

#1223 covers the job layer's missing tenant context and worker fan-out — a
separate axis. This is only about the shared registry pool leaking session state
between unrelated borrowers.
