### PR TITLE
feat: tenant isolation for background/scheduled work (sweep fan-out, scoped cache, scoped locks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+### Added
+- **`tenancy::for_each_tenant`** (#1226) — the per-tenant fan-out that scheduled
+  sweeps were missing. `MediaManager::purge_orphans`,
+  `audit::cleanup_older_than_pool` and `prunable::prune_all` each take one pool,
+  and every table they touch is per-tenant, so a sweep wired to one pool cleaned
+  one tenant — on a registry pool in schema mode, only `public` — while every
+  other tenant's rows grew forever and the sweep still reported success.
+  `Scheduler::every` takes `Fn() -> Future` with no context, so there was nowhere
+  for a tenant to come from.
+
+  It resolves each active tenant's own pool via `scoped_pool_dyn`, never
+  short-circuits (a tenant whose pool won't resolve is recorded and the loop
+  continues, so one rotated credential can't starve the rest), and runs
+  sequentially — background sweeps compete with request traffic for the same
+  upstream. `active_tenants` is public for callers wanting their own
+  concurrency. Note the `TenantPools` cache cap (default 64, no eviction) is a
+  hard ceiling: with more active database-mode tenants than that, the tail fails
+  every run, so raise it before scheduling a sweep and treat a non-zero
+  `failed()` as alertable.
+
+  `MediaManager::purge_orphans_dry_run` runs the same query and deletes nothing —
+  that sweep is the only one that reaches outside the database.
+- **`cache::ScopedCache`** (#1227) — a `Cache` view that folds a namespace into
+  every key, so per-tenant caching can't be forgotten at the call site. It is
+  itself a `Cache`, so it drops into `cache_page`, the rate limiters and
+  `DistributedLock`, and forwards to the inner backend with mapped keys so native
+  primitives (Redis `INCRBY` / `SET NX` / `MGET`) keep their atomicity.
+- **`Cache::delete_prefix`** (#1227) — powers `ScopedCache::clear`, which must
+  drop one namespace without touching others (the flat `Cache::clear` is
+  process-global, so a per-tenant invalidation wiped everyone). `InMemoryCache`
+  filters its map, `DatabaseCache` issues a `LIKE`, `RedisCache` runs
+  `SCAN MATCH` + `DEL`. The default over-deletes — clears everything and warns —
+  because a backend that cannot enumerate keys has only two options and only one
+  is safe: under-deleting leaves a stale entry another namespace can read, which
+  is a correctness bug, while over-deleting costs a cache miss. `FileCache` is
+  that case; it hashes keys into paths.
+- **`DistributedLock::for_tenant` / `scoped`** (#1228) — lock names were global,
+  so looping tenants around one `with_lock("daily_report")` let the first tenant
+  win and skipped the rest for the whole TTL, silently (a refused acquire is the
+  expected outcome, so nothing is logged). Scoped, each tenant gets its own lock.
+  Additive — the unscoped form is still right for process-wide work.
+
+### Notes
+- Ambient `task_local!` scopes (audit source, timezone, admin session, signals)
+  do not cross a `tokio::spawn`, so jobs and scheduled tasks run with
+  `AuditSource::System` and the default timezone (#1229). Nothing crosses a
+  tenant boundary — task-locals fail closed — so this is documented on
+  `Job::run` and `Scheduler::every` rather than changed; propagation belongs with
+  the `JobContext` work in #1223.
+
 ### Fixed
 - **Schema-mode tenancy leaked `search_path` between registry-pool borrowers**
   (#1224). `TenantPools::acquire` issues a session-level

--- a/crates/rustango/src/audit.rs
+++ b/crates/rustango/src/audit.rs
@@ -990,6 +990,12 @@ pub async fn fetch_for_entity_pool(
 /// `cutoff_days = 0` clears the entire table (use with caution); a
 /// negative value is clamped to 0.
 ///
+/// **Under tenancy, pass a tenant-scoped pool.** `rustango_audit_log` is
+/// per-tenant, so this trims whichever tenant `pool` points at — on a
+/// registry pool in schema mode, only `public`, while every tenant's
+/// audit history grows unbounded and the sweep still reports success.
+/// Fan out with [`crate::tenancy::for_each_tenant`] (#1226).
+///
 /// # Errors
 /// Driver / SQL failures from the DELETE.
 pub async fn cleanup_older_than_pool(

--- a/crates/rustango/src/cache/db_backend.rs
+++ b/crates/rustango/src/cache/db_backend.rs
@@ -260,6 +260,43 @@ impl Cache for DatabaseCache {
             .map_err(|e| CacheError::Connection(format!("clear: {e}")))?;
         Ok(())
     }
+
+    /// Exact prefix delete via `LIKE 'prefix%'` — the keys are a real
+    /// column, so there is no need for the trait default's whole-table
+    /// clear (#1227).
+    ///
+    /// `%` and `_` are LIKE wildcards, so a prefix containing either
+    /// would match more rows than intended — an unescaped `_` matches
+    /// any single character, and one namespace's clear could sweep a
+    /// neighbour's rows.
+    ///
+    /// The escape character is **`!`, not `\`**. A backslash cannot be
+    /// written portably here: MySQL treats `\` as an escape *inside
+    /// string literals*, so `ESCAPE '\'` is a syntax error there, while
+    /// Postgres (with `standard_conforming_strings`) reads the same
+    /// literal as one backslash and accepts it. `!` needs no escaping in
+    /// any of the three dialects, so one statement works everywhere.
+    /// Covered on all three by `cache_db_backend_sqlite_live.rs` and
+    /// `cache_delete_prefix_live.rs`.
+    async fn delete_prefix(&self, prefix: &str) -> Result<(), CacheError> {
+        let dialect = self.pool.dialect();
+        let table = dialect.quote_ident(&self.table);
+        let p = dialect.placeholder(1);
+        // Escape the escape character first, or `!` in a prefix would
+        // swallow the character after it.
+        let pattern = format!(
+            "{}%",
+            prefix
+                .replace('!', "!!")
+                .replace('%', "!%")
+                .replace('_', "!_")
+        );
+        let sql = format!("DELETE FROM {table} WHERE cache_key LIKE {p} ESCAPE '!'");
+        raw_execute_pool(&self.pool, &sql, vec![SqlValue::String(pattern)])
+            .await
+            .map_err(|e| CacheError::Connection(format!("delete_prefix: {e}")))?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/rustango/src/cache/db_backend.rs
+++ b/crates/rustango/src/cache/db_backend.rs
@@ -278,6 +278,13 @@ impl Cache for DatabaseCache {
     /// any of the three dialects, so one statement works everywhere.
     /// Covered on all three by `cache_db_backend_sqlite_live.rs` and
     /// `cache_delete_prefix_live.rs`.
+    ///
+    /// One asymmetry to know about: `LIKE` uses the column's collation,
+    /// which folds ASCII case on SQLite and is case-insensitive by
+    /// default on MySQL, while `get` / `delete` compare with `=`. Two
+    /// namespaces differing only in case therefore collide on a prefix
+    /// delete but not on a read. Keep namespaces lower-case — tenant
+    /// slugs already are — and it does not arise.
     async fn delete_prefix(&self, prefix: &str) -> Result<(), CacheError> {
         let dialect = self.pool.dialect();
         let table = dialect.quote_ident(&self.table);

--- a/crates/rustango/src/cache/mod.rs
+++ b/crates/rustango/src/cache/mod.rs
@@ -57,6 +57,9 @@ pub mod redis_backend;
 #[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
 pub use db_backend::DatabaseCache;
 
+pub mod scoped;
+pub use scoped::{ScopedCache, TENANT_PREFIX};
+
 // ------------------------------------------------------------------ CacheError
 
 /// Errors returned by cache operations.
@@ -256,6 +259,35 @@ pub trait Cache: Send + Sync + 'static {
     /// on the hit path — the allocation only happens on miss.
     async fn get_or(&self, key: &str, default: &str) -> Result<String, CacheError> {
         Ok(self.get(key).await?.unwrap_or_else(|| default.to_owned()))
+    }
+
+    /// Delete every key starting with `prefix`. Powers
+    /// [`ScopedCache::clear`], which must drop one namespace's entries
+    /// without touching anyone else's (#1227).
+    ///
+    /// **The default over-deletes: it clears the whole cache** and logs
+    /// a warning. That is deliberate. A backend that cannot enumerate
+    /// its keys has two options, and only one of them is safe:
+    /// under-deleting leaves stale entries that a *different* namespace
+    /// can then read, which is a correctness bug; over-deleting costs
+    /// other namespaces a cache miss. [`FileCache`] is the concrete
+    /// case — it hashes keys into paths, so the prefix is not
+    /// recoverable from the filename.
+    ///
+    /// Backends that can enumerate override this:
+    /// [`InMemoryCache`] filters its map, [`DatabaseCache`] issues a
+    /// `DELETE … WHERE cache_key LIKE 'prefix%'`, and [`NullCache`]
+    /// has nothing to delete.
+    async fn delete_prefix(&self, prefix: &str) -> Result<(), CacheError> {
+        tracing::warn!(
+            target: "rustango::cache",
+            prefix = %prefix,
+            "this cache backend cannot enumerate keys, so a prefix delete clears \
+             the WHOLE cache — other namespaces will see a cold cache. Use a \
+             backend that overrides `delete_prefix` (memory / database) if that \
+             matters",
+        );
+        self.clear().await
     }
 }
 
@@ -477,6 +509,12 @@ impl Cache for NullCache {
     }
 
     async fn clear(&self) -> Result<(), CacheError> {
+        Ok(())
+    }
+
+    /// Nothing is stored, so nothing needs deleting — and in particular
+    /// this must not fall through to the warning on the trait default.
+    async fn delete_prefix(&self, _prefix: &str) -> Result<(), CacheError> {
         Ok(())
     }
 }
@@ -704,6 +742,25 @@ impl Cache for InMemoryCache {
         let mut store = self.inner.write().await;
         store.map.clear();
         store.used_bytes = 0;
+        Ok(())
+    }
+
+    /// Exact prefix delete — the map is right here, so there is no need
+    /// to fall back to the trait default's whole-cache clear (#1227).
+    /// `used_bytes` is decremented by what actually left, keeping the
+    /// LRU budget honest.
+    async fn delete_prefix(&self, prefix: &str) -> Result<(), CacheError> {
+        let mut store = self.inner.write().await;
+        let mut freed = 0usize;
+        store.map.retain(|k, e| {
+            if k.starts_with(prefix) {
+                freed += k.len() + e.value.len();
+                false
+            } else {
+                true
+            }
+        });
+        store.used_bytes = store.used_bytes.saturating_sub(freed);
         Ok(())
     }
 }

--- a/crates/rustango/src/cache/mod.rs
+++ b/crates/rustango/src/cache/mod.rs
@@ -274,10 +274,14 @@ pub trait Cache: Send + Sync + 'static {
     /// case — it hashes keys into paths, so the prefix is not
     /// recoverable from the filename.
     ///
-    /// Backends that can enumerate override this:
-    /// [`InMemoryCache`] filters its map, [`DatabaseCache`] issues a
-    /// `DELETE … WHERE cache_key LIKE 'prefix%'`, and [`NullCache`]
-    /// has nothing to delete.
+    /// **Every shipped backend that can enumerate overrides this**, and
+    /// a new backend that can MUST: [`InMemoryCache`] filters its map,
+    /// [`DatabaseCache`] issues a `DELETE … WHERE cache_key LIKE
+    /// 'prefix%'`, `RedisCache` runs `SCAN MATCH` + `DEL`, and
+    /// [`NullCache`] has nothing to delete. Redis is the cautionary
+    /// one: its `clear()` is `FLUSHDB`, so inheriting this default
+    /// would let one tenant's invalidation wipe every other tenant,
+    /// every rate-limit counter and every lock key.
     async fn delete_prefix(&self, prefix: &str) -> Result<(), CacheError> {
         tracing::warn!(
             target: "rustango::cache",

--- a/crates/rustango/src/cache/redis_backend.rs
+++ b/crates/rustango/src/cache/redis_backend.rs
@@ -109,6 +109,68 @@ impl Cache for RedisCache {
             .map_err(|e| CacheError::Connection(e.to_string()))
     }
 
+    /// `SCAN MATCH <prefix>*` + `DEL`, in cursor batches.
+    ///
+    /// **This override is load-bearing.** Without it the trait default
+    /// falls through to [`Self::clear`], which is `FLUSHDB` — so a
+    /// single tenant's [`ScopedCache::clear`](super::ScopedCache) would
+    /// wipe every other tenant's entries, every rate-limit counter, and
+    /// every `lock:*` key (letting two replicas both take a
+    /// "once per cluster" lock). Redis can enumerate, so the trait
+    /// default's "cannot enumerate, so over-delete" bargain does not
+    /// apply here (#1227).
+    ///
+    /// `SCAN` is non-blocking and cursor-based, unlike `KEYS`: it will
+    /// not stall the server on a large keyspace. The trade-off is that
+    /// it gives no snapshot guarantee — keys created *during* the sweep
+    /// may be missed. That is the right trade for cache invalidation
+    /// (a missed key is a stale entry that still expires on its TTL,
+    /// and the alternative blocks every other client).
+    ///
+    /// `MATCH` takes a glob, not a literal, so `*`, `?`, `[`, `]` and
+    /// `\` in the prefix are escaped — otherwise a prefix containing one
+    /// would match beyond its own namespace.
+    async fn delete_prefix(&self, prefix: &str) -> Result<(), CacheError> {
+        let mut conn = self.conn.clone();
+        let mut pattern = String::with_capacity(prefix.len() + 1);
+        for ch in prefix.chars() {
+            if matches!(ch, '*' | '?' | '[' | ']' | '\\') {
+                pattern.push('\\');
+            }
+            pattern.push(ch);
+        }
+        pattern.push('*');
+
+        let mut cursor: u64 = 0;
+        loop {
+            let (next, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(&pattern)
+                .arg("COUNT")
+                .arg(512)
+                .query_async(&mut conn)
+                .await
+                .map_err(|e| CacheError::Connection(format!("scan: {e}")))?;
+
+            if !keys.is_empty() {
+                redis::cmd("DEL")
+                    .arg(&keys)
+                    .query_async::<()>(&mut conn)
+                    .await
+                    .map_err(|e| CacheError::Connection(format!("del: {e}")))?;
+            }
+
+            // A zero cursor means the iteration completed. It is only
+            // valid to stop here — a non-empty batch does not imply
+            // more, and an empty one does not imply done.
+            if next == 0 {
+                return Ok(());
+            }
+            cursor = next;
+        }
+    }
+
     async fn incr(&self, key: &str, by: i64, ttl: Option<Duration>) -> Result<i64, CacheError> {
         let mut conn = self.conn.clone();
         let new: i64 = redis::cmd("INCRBY")

--- a/crates/rustango/src/cache/scoped.rs
+++ b/crates/rustango/src/cache/scoped.rs
@@ -1,0 +1,326 @@
+//! Key-namespaced cache view (#1227).
+//!
+//! [`Cache`](super::Cache) is a flat `&str`-keyed store. That is the
+//! right primitive, but under tenancy it is a footgun: the natural key
+//! is the leaky key. A handler (or worse, a background task with no
+//! ambient tenant) writes `"stats:monthly"` for one tenant and every
+//! other tenant reads it back.
+//!
+//! [`ScopedCache`] closes that by construction — it wraps any
+//! [`BoxedCache`](super::BoxedCache) and folds a namespace into every
+//! key on the way through, so the call site cannot forget:
+//!
+//! ```ignore
+//! use rustango::cache::ScopedCache;
+//!
+//! // In a handler, from the Org the resolver already produced:
+//! let cache = ScopedCache::for_tenant(shared_cache.clone(), &t.org.slug);
+//! cache.set("stats:monthly", &json, ttl).await?;   // stored as `tenant:acme:stats:monthly`
+//!
+//! // Invalidate just this tenant:
+//! cache.clear().await?;                            // other tenants keep their entries
+//! ```
+//!
+//! `ScopedCache` is itself a `Cache`, so it drops into anything that
+//! takes a `BoxedCache` — `cache_page`, `cache_fragment`, rate limiters,
+//! [`crate::distributed_lock::DistributedLock`].
+//!
+//! ## What it does not do
+//!
+//! It is a namespace, not a security boundary: everything still lives in
+//! one backend, and code holding the *unscoped* cache can read any key.
+//! The point is that the ergonomic path is the correct one.
+//!
+//! `clear()` routes through [`Cache::delete_prefix`], whose default
+//! over-deletes on backends that cannot enumerate keys (see that
+//! method's docs). Namespaced state stays correct either way; on those
+//! backends the other namespaces just pay a cache miss.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::{BoxedCache, Cache, CacheError};
+
+/// The prefix [`ScopedCache::for_tenant`] uses, matching the
+/// `tenant:{slug}:…` convention the tenancy layer already uses for
+/// lockout keys (`tenancy::auth_routes`).
+pub const TENANT_PREFIX: &str = "tenant";
+
+/// A [`Cache`] view that transparently namespaces every key.
+///
+/// Cheap to clone (the inner cache is an `Arc`).
+#[derive(Clone)]
+pub struct ScopedCache {
+    inner: BoxedCache,
+    /// Already includes the trailing separator, so key mapping is one
+    /// concat with no per-call formatting decisions.
+    prefix: String,
+}
+
+impl ScopedCache {
+    /// Namespace `inner` under an arbitrary `namespace`.
+    ///
+    /// An empty namespace is accepted and yields keys prefixed with just
+    /// `":"` — deliberately still distinct from the unscoped keyspace, so
+    /// an accidentally-empty slug cannot silently collide with unscoped
+    /// entries.
+    #[must_use]
+    pub fn new(inner: BoxedCache, namespace: impl AsRef<str>) -> Self {
+        Self {
+            prefix: format!("{}:", namespace.as_ref()),
+            inner,
+        }
+    }
+
+    /// Namespace `inner` for one tenant slug — `tenant:{slug}:…`.
+    #[must_use]
+    pub fn for_tenant(inner: BoxedCache, slug: impl AsRef<str>) -> Self {
+        Self::new(inner, format!("{TENANT_PREFIX}:{}", slug.as_ref()))
+    }
+
+    /// The prefix every key gets, including its trailing separator.
+    #[must_use]
+    pub fn prefix(&self) -> &str {
+        &self.prefix
+    }
+
+    /// Wrap in an `Arc` so it can be passed anywhere a
+    /// [`BoxedCache`] is expected.
+    #[must_use]
+    pub fn boxed(self) -> BoxedCache {
+        Arc::new(self)
+    }
+
+    fn k(&self, key: &str) -> String {
+        format!("{}{key}", self.prefix)
+    }
+}
+
+// Every method forwards to the inner cache with a mapped key rather than
+// relying on the trait defaults. The defaults would also be *correct*
+// (they route back through `self`), but they would flatten a backend's
+// native primitives — Redis `INCRBY` / `SET NX` / `MGET` — into
+// non-atomic, one-RTT-per-key loops. Forwarding keeps whatever the inner
+// backend actually implements.
+#[async_trait::async_trait]
+impl Cache for ScopedCache {
+    async fn get(&self, key: &str) -> Result<Option<String>, CacheError> {
+        self.inner.get(&self.k(key)).await
+    }
+
+    async fn set(&self, key: &str, value: &str, ttl: Option<Duration>) -> Result<(), CacheError> {
+        self.inner.set(&self.k(key), value, ttl).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), CacheError> {
+        self.inner.delete(&self.k(key)).await
+    }
+
+    async fn exists(&self, key: &str) -> Result<bool, CacheError> {
+        self.inner.exists(&self.k(key)).await
+    }
+
+    /// Clears **only this namespace** — the whole point of the type.
+    /// Delegates to [`Cache::delete_prefix`] on the inner cache.
+    async fn clear(&self) -> Result<(), CacheError> {
+        self.inner.delete_prefix(&self.prefix).await
+    }
+
+    async fn incr(&self, key: &str, by: i64, ttl: Option<Duration>) -> Result<i64, CacheError> {
+        self.inner.incr(&self.k(key), by, ttl).await
+    }
+
+    async fn add(&self, key: &str, value: &str, ttl: Option<Duration>) -> Result<bool, CacheError> {
+        self.inner.add(&self.k(key), value, ttl).await
+    }
+
+    async fn touch(&self, key: &str, ttl: Option<Duration>) -> Result<bool, CacheError> {
+        self.inner.touch(&self.k(key), ttl).await
+    }
+
+    /// The returned map is keyed by the caller's **unprefixed** keys —
+    /// the prefix is an implementation detail that must not leak back
+    /// out.
+    async fn get_many(
+        &self,
+        keys: &[&str],
+    ) -> Result<std::collections::HashMap<String, String>, CacheError> {
+        let scoped: Vec<String> = keys.iter().map(|k| self.k(k)).collect();
+        let refs: Vec<&str> = scoped.iter().map(String::as_str).collect();
+        let got = self.inner.get_many(&refs).await?;
+        // Map back by position: `scoped[i]` corresponds to `keys[i]`.
+        let mut out = std::collections::HashMap::with_capacity(got.len());
+        for (i, sk) in scoped.iter().enumerate() {
+            if let Some(v) = got.get(sk) {
+                out.insert(keys[i].to_owned(), v.clone());
+            }
+        }
+        Ok(out)
+    }
+
+    async fn set_many(
+        &self,
+        entries: &[(&str, &str)],
+        ttl: Option<Duration>,
+    ) -> Result<(), CacheError> {
+        let scoped: Vec<(String, &str)> = entries.iter().map(|(k, v)| (self.k(k), *v)).collect();
+        let refs: Vec<(&str, &str)> = scoped.iter().map(|(k, v)| (k.as_str(), *v)).collect();
+        self.inner.set_many(&refs, ttl).await
+    }
+
+    async fn delete_many(&self, keys: &[&str]) -> Result<(), CacheError> {
+        let scoped: Vec<String> = keys.iter().map(|k| self.k(k)).collect();
+        let refs: Vec<&str> = scoped.iter().map(String::as_str).collect();
+        self.inner.delete_many(&refs).await
+    }
+
+    /// Nested scoping composes: the outer prefix is applied on top of
+    /// this one, so `ScopedCache::new(scoped.boxed(), "x")` behaves as
+    /// `"<this>:x:"`.
+    async fn delete_prefix(&self, prefix: &str) -> Result<(), CacheError> {
+        self.inner.delete_prefix(&self.k(prefix)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::InMemoryCache;
+
+    fn mem() -> BoxedCache {
+        Arc::new(InMemoryCache::new())
+    }
+
+    /// The same logical key in two tenants is two entries.
+    #[tokio::test]
+    async fn tenants_do_not_see_each_others_keys() {
+        let shared = mem();
+        let acme = ScopedCache::for_tenant(shared.clone(), "acme");
+        let globex = ScopedCache::for_tenant(shared.clone(), "globex");
+
+        acme.set("stats", "acme-value", None).await.unwrap();
+
+        assert_eq!(
+            acme.get("stats").await.unwrap().as_deref(),
+            Some("acme-value")
+        );
+        assert_eq!(
+            globex.get("stats").await.unwrap(),
+            None,
+            "globex must not read acme's entry for the same logical key"
+        );
+        assert!(!globex.exists("stats").await.unwrap());
+    }
+
+    /// Scoped `clear` drops one tenant and leaves the others — the
+    /// behaviour the flat `Cache::clear` could not give.
+    #[tokio::test]
+    async fn scoped_clear_leaves_other_tenants_intact() {
+        let shared = mem();
+        let acme = ScopedCache::for_tenant(shared.clone(), "acme");
+        let globex = ScopedCache::for_tenant(shared.clone(), "globex");
+
+        acme.set("a", "1", None).await.unwrap();
+        acme.set("b", "2", None).await.unwrap();
+        globex.set("a", "9", None).await.unwrap();
+
+        acme.clear().await.unwrap();
+
+        assert_eq!(acme.get("a").await.unwrap(), None);
+        assert_eq!(acme.get("b").await.unwrap(), None);
+        assert_eq!(
+            globex.get("a").await.unwrap().as_deref(),
+            Some("9"),
+            "clearing acme must not touch globex"
+        );
+    }
+
+    /// A slug that is a prefix of another must not be caught by the
+    /// other's clear — `tenant:acme:` vs `tenant:acme-corp:`.
+    #[tokio::test]
+    async fn prefix_overlap_between_slugs_is_not_a_collision() {
+        let shared = mem();
+        let acme = ScopedCache::for_tenant(shared.clone(), "acme");
+        let acme_corp = ScopedCache::for_tenant(shared.clone(), "acme-corp");
+
+        acme.set("k", "short", None).await.unwrap();
+        acme_corp.set("k", "long", None).await.unwrap();
+
+        acme.clear().await.unwrap();
+
+        assert_eq!(acme.get("k").await.unwrap(), None);
+        assert_eq!(
+            acme_corp.get("k").await.unwrap().as_deref(),
+            Some("long"),
+            "the trailing separator must keep `acme` from matching `acme-corp`"
+        );
+    }
+
+    /// `get_many` maps results back to the caller's unprefixed keys.
+    #[tokio::test]
+    async fn get_many_returns_unprefixed_keys() {
+        let acme = ScopedCache::for_tenant(mem(), "acme");
+        acme.set_many(&[("x", "1"), ("y", "2")], None)
+            .await
+            .unwrap();
+
+        let got = acme.get_many(&["x", "y", "absent"]).await.unwrap();
+        assert_eq!(got.get("x").map(String::as_str), Some("1"));
+        assert_eq!(got.get("y").map(String::as_str), Some("2"));
+        assert!(!got.contains_key("absent"));
+        assert!(
+            got.keys().all(|k| !k.contains("tenant:")),
+            "the prefix must not leak back to the caller: {got:?}"
+        );
+    }
+
+    /// Counters are namespaced too — two tenants rate-limiting on the
+    /// same logical key must not share a budget.
+    #[tokio::test]
+    async fn counters_are_namespaced() {
+        let shared = mem();
+        let acme = ScopedCache::for_tenant(shared.clone(), "acme");
+        let globex = ScopedCache::for_tenant(shared.clone(), "globex");
+
+        assert_eq!(acme.incr("hits", 1, None).await.unwrap(), 1);
+        assert_eq!(acme.incr("hits", 1, None).await.unwrap(), 2);
+        assert_eq!(
+            globex.incr("hits", 1, None).await.unwrap(),
+            1,
+            "globex starts its own count"
+        );
+    }
+
+    /// `delete_many` and `delete` go through the prefix as well.
+    #[tokio::test]
+    async fn deletes_are_namespaced() {
+        let shared = mem();
+        let acme = ScopedCache::for_tenant(shared.clone(), "acme");
+        let globex = ScopedCache::for_tenant(shared.clone(), "globex");
+
+        acme.set_many(&[("p", "1"), ("q", "2")], None)
+            .await
+            .unwrap();
+        globex
+            .set_many(&[("p", "8"), ("q", "9")], None)
+            .await
+            .unwrap();
+
+        acme.delete_many(&["p", "q"]).await.unwrap();
+
+        assert_eq!(acme.get("p").await.unwrap(), None);
+        assert_eq!(globex.get("p").await.unwrap().as_deref(), Some("8"));
+        assert_eq!(globex.get("q").await.unwrap().as_deref(), Some("9"));
+    }
+
+    /// `NullCache` must not hit the trait default's whole-cache clear
+    /// path (it has nothing to enumerate, and the warning would be
+    /// noise on every invalidation).
+    #[tokio::test]
+    async fn null_cache_prefix_delete_is_a_noop() {
+        let null: BoxedCache = Arc::new(crate::cache::NullCache);
+        let scoped = ScopedCache::for_tenant(null, "acme");
+        scoped.clear().await.unwrap();
+        assert_eq!(scoped.get("anything").await.unwrap(), None);
+    }
+}

--- a/crates/rustango/src/distributed_lock.rs
+++ b/crates/rustango/src/distributed_lock.rs
@@ -48,6 +48,12 @@
 //! - TTL must be longer than the worst-case execution time of the
 //!   protected work, OR the work must be idempotent. A too-short TTL
 //!   means another replica could grab the lock mid-execution.
+//! - **Under tenancy, scope the lock.** Lock names are global by
+//!   default, so looping tenants around one `with_lock("daily_report")`
+//!   lets the first tenant win and skips the rest for the whole TTL —
+//!   silently, since a refused acquire is the expected outcome. Use
+//!   [`DistributedLock::for_tenant`] so each tenant gets its own lock
+//!   (#1228). Leave it unscoped only for genuinely process-wide work.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -60,12 +66,66 @@ const KEY_PREFIX: &str = "lock";
 #[derive(Clone)]
 pub struct DistributedLock {
     cache: BoxedCache,
+    /// Folded into every lock name. Empty for a process-wide lock;
+    /// `tenant:{slug}` after [`Self::for_tenant`] (#1228).
+    scope: Option<String>,
 }
 
 impl DistributedLock {
     #[must_use]
     pub fn new(cache: BoxedCache) -> Self {
-        Self { cache }
+        Self { cache, scope: None }
+    }
+
+    /// A lock factory whose names are scoped to one tenant, so the same
+    /// lock name in two tenants is two independent locks (#1228).
+    ///
+    /// Without this, the natural per-tenant cron —
+    ///
+    /// ```ignore
+    /// for org in active_orgs {
+    ///     lock.with_lock("daily_report", ttl, || async { report(&org).await }).await;
+    /// }
+    /// ```
+    ///
+    /// — has every tenant contend for one `lock:daily_report`. The first
+    /// tenant wins and the rest are skipped for the whole TTL, which
+    /// (with a TTL correctly sized to the work) means most tenants never
+    /// get their report. Nothing is logged, because a refused acquire is
+    /// the documented, expected outcome.
+    ///
+    /// Scoped, each tenant gets `lock:tenant:{slug}:daily_report` and
+    /// they no longer collide. Follows the `tenant:{slug}:…` convention
+    /// the tenancy layer already uses for lockout keys.
+    ///
+    /// ```ignore
+    /// let lock = DistributedLock::new(cache).for_tenant(&org.slug);
+    /// lock.with_lock("daily_report", ttl, || async { … }).await;
+    /// ```
+    ///
+    /// Keep using the unscoped form for genuinely process-wide work —
+    /// registry cleanup, a cross-tenant rollup — where "exactly one
+    /// replica, ever" is the point.
+    #[must_use]
+    pub fn for_tenant(mut self, slug: impl AsRef<str>) -> Self {
+        self.scope = Some(format!("tenant:{}", slug.as_ref()));
+        self
+    }
+
+    /// Scope lock names under an arbitrary namespace. [`Self::for_tenant`]
+    /// is this with the `tenant:` convention applied.
+    #[must_use]
+    pub fn scoped(mut self, namespace: impl AsRef<str>) -> Self {
+        self.scope = Some(namespace.as_ref().to_owned());
+        self
+    }
+
+    /// The cache key for `name`, including this factory's scope.
+    fn key_for(&self, name: &str) -> String {
+        match &self.scope {
+            Some(scope) => format!("{KEY_PREFIX}:{scope}:{name}"),
+            None => format!("{KEY_PREFIX}:{name}"),
+        }
     }
 
     /// Try to acquire `name` for `ttl`. Returns:
@@ -74,7 +134,7 @@ impl DistributedLock {
     ///   safe but slightly wasteful of contention slots).
     /// - `None` when someone else holds it.
     pub async fn try_acquire(&self, name: &str, ttl: Duration) -> Option<LockGuard> {
-        let key = format!("{KEY_PREFIX}:{name}");
+        let key = self.key_for(name);
         // `incr(key, 1, ttl)` returns 1 ONLY when the counter was
         // previously absent (or 0). On RedisCache the INCRBY+EXPIRE NX
         // sequence is atomic; on the in-memory default impl it's racy
@@ -294,5 +354,86 @@ mod tests {
         assert!(r.is_some());
         let g = l.try_acquire("job", Duration::from_secs(5)).await;
         assert!(g.is_some());
+    }
+
+    /// The bug from #1228: two tenants, one lock name, unscoped — the
+    /// second is refused. Pinned so the distinction between the scoped
+    /// and unscoped forms stays deliberate rather than accidental.
+    #[tokio::test]
+    async fn unscoped_lock_is_shared_across_tenants() {
+        let cache: BoxedCache = StdArc::new(InMemoryCache::new());
+        let lock = DistributedLock::new(cache);
+
+        let acme = lock
+            .try_acquire("daily_report", Duration::from_secs(30))
+            .await;
+        let globex = lock
+            .try_acquire("daily_report", Duration::from_secs(30))
+            .await;
+
+        assert!(acme.is_some(), "first caller takes the lock");
+        assert!(
+            globex.is_none(),
+            "unscoped, a second tenant contends for the same name — this is the \
+             starvation #1228 is about"
+        );
+    }
+
+    /// Scoped, the same lock name in two tenants is two locks, so a
+    /// per-tenant cron actually runs for every tenant.
+    #[tokio::test]
+    async fn scoped_locks_do_not_contend_across_tenants() {
+        let cache: BoxedCache = StdArc::new(InMemoryCache::new());
+        let acme_lock = DistributedLock::new(cache.clone()).for_tenant("acme");
+        let globex_lock = DistributedLock::new(cache).for_tenant("globex");
+
+        let acme = acme_lock
+            .try_acquire("daily_report", Duration::from_secs(30))
+            .await;
+        let globex = globex_lock
+            .try_acquire("daily_report", Duration::from_secs(30))
+            .await;
+
+        assert!(acme.is_some(), "acme gets its own lock");
+        assert!(globex.is_some(), "globex gets its own lock, not acme's");
+    }
+
+    /// Within one tenant the lock still excludes — scoping must not
+    /// weaken the guarantee it exists for.
+    #[tokio::test]
+    async fn scoped_lock_still_excludes_within_a_tenant() {
+        let cache: BoxedCache = StdArc::new(InMemoryCache::new());
+        let lock = DistributedLock::new(cache).for_tenant("acme");
+
+        let first = lock
+            .try_acquire("daily_report", Duration::from_secs(30))
+            .await;
+        let second = lock
+            .try_acquire("daily_report", Duration::from_secs(30))
+            .await;
+
+        assert!(first.is_some());
+        assert!(second.is_none(), "one holder at a time, per tenant");
+    }
+
+    /// A tenant scope must not let one slug's lock name collide with
+    /// another's by prefix (`acme` vs `acme-corp`).
+    #[tokio::test]
+    async fn tenant_scopes_are_separated_by_slug() {
+        let cache: BoxedCache = StdArc::new(InMemoryCache::new());
+        let acme = DistributedLock::new(cache.clone()).for_tenant("acme");
+        let acme_corp = DistributedLock::new(cache).for_tenant("acme-corp");
+
+        assert!(acme
+            .try_acquire("j", Duration::from_secs(30))
+            .await
+            .is_some());
+        assert!(
+            acme_corp
+                .try_acquire("j", Duration::from_secs(30))
+                .await
+                .is_some(),
+            "`acme-corp` must not be blocked by `acme`'s lock"
+        );
     }
 }

--- a/crates/rustango/src/jobs/mod.rs
+++ b/crates/rustango/src/jobs/mod.rs
@@ -101,6 +101,16 @@ pub trait Job: Send + Sync + Sized + Serialize + DeserializeOwned + 'static {
 
     /// Run the job. Return `Ok(())` on success, `Err(Retryable(_))` to
     /// retry with backoff, `Err(Fatal(_))` to dead-letter immediately.
+    ///
+    /// **No ambient context reaches here.** Workers are spawned with
+    /// [`tokio::spawn`], which does not inherit `tokio::task_local!`
+    /// state, so every scope the request path sets up is absent: the
+    /// audit source falls back to [`crate::audit::AuditSource::System`],
+    /// the active timezone falls back to the default, and there is no
+    /// admin session. Anything a job needs must travel in its payload
+    /// (#1229). For the audit case a job can re-enter the scope itself
+    /// with [`crate::audit::with_source`]. Tenant scoping is the same
+    /// story and is tracked separately in #1223.
     async fn run(&self) -> Result<(), JobError>;
 }
 

--- a/crates/rustango/src/media/mod.rs
+++ b/crates/rustango/src/media/mod.rs
@@ -578,7 +578,47 @@ impl MediaManager {
     ///
     /// Run from the [`crate::scheduler`] (e.g. nightly) to keep
     /// orphan storage objects from accumulating.
+    ///
+    /// **Under tenancy, pass a tenant-scoped pool.** `rustango_media` is
+    /// a per-tenant table, so this sweeps whichever tenant `self.pool`
+    /// points at — one pool means one tenant, and on a registry pool in
+    /// schema mode it means only `public`. This is the one sweep that
+    /// reaches outside the database (it deletes storage objects), so
+    /// fan it out with [`crate::tenancy::for_each_tenant`] and reach for
+    /// [`Self::purge_orphans_dry_run`] first when you are unsure what a
+    /// pool is pointing at (#1226).
     pub async fn purge_orphans(&self, older_than: Duration) -> Result<u64, MediaError> {
+        let rows = self.orphans_older_than(older_than).await?;
+        let mut purged = 0u64;
+        for m in rows {
+            self.purge(&m).await?;
+            purged += 1;
+        }
+        Ok(purged)
+    }
+
+    /// What [`Self::purge_orphans`] *would* delete, without deleting
+    /// anything. Same query, no `purge` call — so no rows are dropped
+    /// and no storage objects are removed.
+    ///
+    /// Worth a run before wiring the real sweep in a tenancy app: the
+    /// rows come back with their `disk` and `storage_key`, so a glance
+    /// tells you whether the pool is pointing where you think it is
+    /// (#1226).
+    ///
+    /// # Errors
+    /// Driver error reading `rustango_media`.
+    pub async fn purge_orphans_dry_run(
+        &self,
+        older_than: Duration,
+    ) -> Result<Vec<Media>, MediaError> {
+        self.orphans_older_than(older_than).await
+    }
+
+    /// The soft-deleted rows older than `older_than`. Shared by
+    /// [`Self::purge_orphans`] and [`Self::purge_orphans_dry_run`] so the
+    /// dry run can never drift from what the real sweep acts on.
+    async fn orphans_older_than(&self, older_than: Duration) -> Result<Vec<Media>, MediaError> {
         // v0.38 — cutoff pre-computed in Rust so the same SQL runs
         // on PG / MySQL / SQLite without per-dialect `NOW() - INTERVAL`.
         let cutoff = Utc::now()
@@ -591,19 +631,13 @@ impl MediaManager {
                FROM rustango_media \
               WHERE deleted_at IS NOT NULL AND deleted_at < {p}"
         );
-        let rows: Vec<Media> = crate::sql::raw_query_pool(
+        crate::sql::raw_query_pool(
             &sql,
             vec![crate::core::SqlValue::DateTime(cutoff)],
             &self.pool,
         )
         .await
-        .map_err(media_err_from_exec)?;
-        let mut purged = 0u64;
-        for m in rows {
-            self.purge(&m).await?;
-            purged += 1;
-        }
-        Ok(purged)
+        .map_err(media_err_from_exec)
     }
 
     /// Hard-delete every Media row stuck in `Pending` for longer

--- a/crates/rustango/src/prunable.rs
+++ b/crates/rustango/src/prunable.rs
@@ -200,6 +200,11 @@ pub struct PruneReport {
 ///
 /// Use [`prune_pretend`] for the dry-run variant.
 ///
+/// **Under tenancy, pass a tenant-scoped pool.** Prunable models are
+/// per-tenant, so this prunes whichever tenant `pool` points at — one
+/// pool means one tenant, and a registry pool in schema mode means only
+/// `public`. Fan out with [`crate::tenancy::for_each_tenant`] (#1226).
+///
 /// # Errors
 ///
 /// Each entry's prune is awaited sequentially. The FIRST error

--- a/crates/rustango/src/scheduler/mod.rs
+++ b/crates/rustango/src/scheduler/mod.rs
@@ -82,6 +82,16 @@ impl Scheduler {
     ///
     /// `name` appears in tracing logs and panic messages — keep it short
     /// and identifying.
+    ///
+    /// **The job runs with no ambient context.** Each tick is a
+    /// [`tokio::spawn`], which does not inherit `tokio::task_local!`
+    /// state — there is no request to inherit from anyway — so the audit
+    /// source is [`crate::audit::AuditSource::System`] and the timezone
+    /// is the default (#1229). Nor is there a tenant: a scheduled sweep
+    /// over per-tenant tables must fan out explicitly with
+    /// [`crate::tenancy::for_each_tenant`] (#1226), and a
+    /// once-per-cluster guard should be scoped per tenant with
+    /// [`crate::distributed_lock::DistributedLock::for_tenant`] (#1228).
     pub fn every<F, Fut>(&self, name: &str, period: Duration, job: F)
     where
         F: Fn() -> Fut + Send + Sync + 'static,

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -106,6 +106,7 @@ pub mod session;
 /// admin — the `admin-sso` feature. Reuses `crate::admin::sso`.
 #[cfg(feature = "admin-sso")]
 pub(crate) mod sso;
+pub mod sweep;
 // v0.38 slice 24 — `tenancy::server::run<DB>` is tri-dialect; the
 // operator console runs on whichever backend `TenantPools<DB>` was
 // built with, schema-mode dispatch only fires on PG (by language),
@@ -175,3 +176,4 @@ pub use routes::RouteConfig;
 pub use secrets::{
     ChainSecretsResolver, EnvSecretsResolver, LiteralSecretsResolver, SecretsError, SecretsResolver,
 };
+pub use sweep::{active_tenants, for_each_tenant, SweepError, TenantOutcome, TenantSweep};

--- a/crates/rustango/src/tenancy/sweep.rs
+++ b/crates/rustango/src/tenancy/sweep.rs
@@ -1,0 +1,233 @@
+//! Per-tenant fan-out for background sweeps (#1226).
+//!
+//! Every "run this from the [`scheduler`](crate::scheduler)" helper the
+//! framework ships — [`crate::media::MediaLibrary::purge_orphans`],
+//! [`crate::audit::cleanup_older_than_pool`],
+//! [`crate::prunable::prune_all`] — takes **one pool**. In a
+//! single-tenant app that is the whole story. Under tenancy each of
+//! those tables is per-tenant, so a sweep wired to one pool cleans one
+//! tenant (or, on the registry pool in schema mode, only `public`) and
+//! reports success while every other tenant's rows accumulate forever.
+//!
+//! The scheduler cannot help: [`crate::scheduler::Scheduler::every`]
+//! takes `Fn() -> Future` with no context, so there is nowhere for a
+//! tenant to come from. This module is the missing loop.
+//!
+//! ```ignore
+//! use rustango::tenancy::sweep::for_each_tenant;
+//!
+//! // Nightly, one prune per tenant:
+//! let sweep = for_each_tenant(&pools, |_org, pool| async move {
+//!     rustango::prunable::prune_all(&pool, &opts).await
+//! })
+//! .await?;
+//!
+//! tracing::info!(ok = sweep.succeeded(), failed = sweep.failed(), "prune sweep");
+//! ```
+//!
+//! ## Semantics
+//!
+//! - **Active tenants only.** Inactive orgs are skipped, matching
+//!   [`crate::tenancy::migrate`]'s fan-out.
+//! - **One tenant's failure does not stop the sweep.** A broken tenant
+//!   (unreachable database, rotated credential, unknown storage mode)
+//!   is recorded and the loop continues — the opposite of `?`, which
+//!   would let one bad tenant starve every tenant after it.
+//! - **Sequential.** Sweeps are background work competing with request
+//!   traffic for the same upstream; a fan-out that opened N tenant pools
+//!   at once is how you turn a nightly prune into an incident. Callers
+//!   who want concurrency can drive [`active_tenants`] themselves.
+//! - **Pools are resolved per tenant** through
+//!   [`TenantPools::scoped_pool_dyn`], so schema-mode tenants get a pool
+//!   with `search_path` in its connect options and database-mode tenants
+//!   get their own pool. The registry pool is never handed to the
+//!   closure.
+
+use crate::core::Column as _;
+use crate::sql::sqlx::Database;
+use crate::sql::FetcherPool as _;
+
+use super::error::TenancyError;
+use super::org::Org;
+use super::pools::TenantPools;
+
+/// What happened for one tenant.
+#[derive(Debug)]
+pub struct TenantOutcome<T, E> {
+    /// The tenant's slug.
+    pub slug: String,
+    /// `Ok` with the closure's value, `Err` if the closure failed or the
+    /// tenant's pool could not be resolved (the latter arrives as
+    /// [`SweepError::Pool`]).
+    pub result: Result<T, SweepError<E>>,
+}
+
+/// Why one tenant's sweep did not produce a value.
+#[derive(Debug, thiserror::Error)]
+pub enum SweepError<E> {
+    /// The tenant's pool could not be resolved — bad `storage_mode`,
+    /// unresolvable `database_url`, pool cache full, upstream down.
+    #[error("could not resolve pool: {0}")]
+    Pool(TenancyError),
+    /// The sweep closure itself returned an error for this tenant.
+    #[error("sweep failed: {0}")]
+    Sweep(E),
+}
+
+/// Per-tenant results of one sweep, in the order tenants were visited.
+#[derive(Debug)]
+pub struct TenantSweep<T, E> {
+    /// One entry per active tenant.
+    pub outcomes: Vec<TenantOutcome<T, E>>,
+}
+
+impl<T, E> TenantSweep<T, E> {
+    /// Number of tenants the sweep completed.
+    #[must_use]
+    pub fn succeeded(&self) -> usize {
+        self.outcomes.iter().filter(|o| o.result.is_ok()).count()
+    }
+
+    /// Number of tenants that failed. Non-zero is not fatal — inspect
+    /// [`Self::errors`] to decide whether to alert.
+    #[must_use]
+    pub fn failed(&self) -> usize {
+        self.outcomes.iter().filter(|o| o.result.is_err()).count()
+    }
+
+    /// `(slug, error)` for every tenant that failed.
+    pub fn errors(&self) -> impl Iterator<Item = (&str, &SweepError<E>)> {
+        self.outcomes.iter().filter_map(|o| match &o.result {
+            Err(e) => Some((o.slug.as_str(), e)),
+            Ok(_) => None,
+        })
+    }
+
+    /// `(slug, value)` for every tenant that succeeded.
+    pub fn values(&self) -> impl Iterator<Item = (&str, &T)> {
+        self.outcomes.iter().filter_map(|o| match &o.result {
+            Ok(v) => Some((o.slug.as_str(), v)),
+            Err(_) => None,
+        })
+    }
+}
+
+/// Every active tenant, read from the registry.
+///
+/// Exposed so callers who need something this module's loop does not do
+/// — concurrency, ordering, batching, a subset — can build it without
+/// re-deriving the query.
+///
+/// # Errors
+/// Driver error reading `rustango_orgs` from the registry pool.
+pub async fn active_tenants<DB>(pools: &TenantPools<DB>) -> Result<Vec<Org>, TenancyError>
+where
+    DB: Database,
+    crate::sql::Pool: From<crate::sql::sqlx::Pool<DB>>,
+{
+    let registry = pools.registry_pool();
+    Ok(Org::objects()
+        .where_(Org::active.eq(true))
+        .fetch(&registry)
+        .await?)
+}
+
+/// Run `f` once per active tenant, against that tenant's own pool.
+///
+/// Never short-circuits: a tenant whose pool cannot be resolved, or
+/// whose closure errors, is recorded in the returned
+/// [`TenantSweep`] and the loop moves on. The only `Err` this returns is
+/// a failure to read the tenant list itself, which means there is no
+/// sweep to run.
+///
+/// # Errors
+/// As [`active_tenants`].
+pub async fn for_each_tenant<DB, F, Fut, T, E>(
+    pools: &TenantPools<DB>,
+    f: F,
+) -> Result<TenantSweep<T, E>, TenancyError>
+where
+    DB: Database,
+    crate::sql::Pool: From<crate::sql::sqlx::Pool<DB>>,
+    F: Fn(Org, crate::sql::Pool) -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    let orgs = active_tenants(pools).await?;
+    let mut outcomes = Vec::with_capacity(orgs.len());
+
+    for org in orgs {
+        let slug = org.slug.clone();
+        let pool = match pools.scoped_pool_dyn(&org).await {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(
+                    target: "crate::tenancy::sweep",
+                    slug = %slug,
+                    error = %e,
+                    "skipping tenant: could not resolve its pool",
+                );
+                outcomes.push(TenantOutcome {
+                    slug,
+                    result: Err(SweepError::Pool(e)),
+                });
+                continue;
+            }
+        };
+
+        let result = match f(org, pool).await {
+            Ok(v) => Ok(v),
+            Err(e) => Err(SweepError::Sweep(e)),
+        };
+        if let Err(SweepError::Sweep(ref e)) = result {
+            // `E` is not `Display`-bound (sweep closures return whatever
+            // their helper returns), so log the slug and let the caller
+            // render the error from `TenantSweep::errors`.
+            let _ = e;
+            tracing::warn!(
+                target: "crate::tenancy::sweep",
+                slug = %slug,
+                "tenant sweep returned an error; continuing with the remaining tenants",
+            );
+        }
+        outcomes.push(TenantOutcome { slug, result });
+    }
+
+    Ok(TenantSweep { outcomes })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `succeeded` / `failed` / `errors` / `values` partition the same
+    /// set — the accounting a caller alerts on must not double-count.
+    #[test]
+    fn sweep_accounting_partitions_outcomes() {
+        let sweep: TenantSweep<u64, String> = TenantSweep {
+            outcomes: vec![
+                TenantOutcome {
+                    slug: "acme".into(),
+                    result: Ok(3),
+                },
+                TenantOutcome {
+                    slug: "globex".into(),
+                    result: Err(SweepError::Sweep("boom".to_owned())),
+                },
+                TenantOutcome {
+                    slug: "initech".into(),
+                    result: Ok(0),
+                },
+            ],
+        };
+
+        assert_eq!(sweep.succeeded(), 2);
+        assert_eq!(sweep.failed(), 1);
+        assert_eq!(sweep.succeeded() + sweep.failed(), sweep.outcomes.len());
+
+        let values: Vec<_> = sweep.values().map(|(s, v)| (s, *v)).collect();
+        assert_eq!(values, vec![("acme", 3), ("initech", 0)]);
+
+        let errors: Vec<_> = sweep.errors().map(|(s, _)| s).collect();
+        assert_eq!(errors, vec!["globex"]);
+    }
+}

--- a/crates/rustango/src/tenancy/sweep.rs
+++ b/crates/rustango/src/tenancy/sweep.rs
@@ -1,7 +1,7 @@
 //! Per-tenant fan-out for background sweeps (#1226).
 //!
 //! Every "run this from the [`scheduler`](crate::scheduler)" helper the
-//! framework ships — [`crate::media::MediaLibrary::purge_orphans`],
+//! framework ships — [`crate::media::MediaManager::purge_orphans`],
 //! [`crate::audit::cleanup_older_than_pool`],
 //! [`crate::prunable::prune_all`] — takes **one pool**. In a
 //! single-tenant app that is the whole story. Under tenancy each of
@@ -16,13 +16,22 @@
 //! ```ignore
 //! use rustango::tenancy::sweep::for_each_tenant;
 //!
-//! // Nightly, one prune per tenant:
-//! let sweep = for_each_tenant(&pools, |_org, pool| async move {
-//!     rustango::prunable::prune_all(&pool, &opts).await
+//! // Nightly, one prune per tenant. `opts` is borrowed, not moved:
+//! // the closure is `Fn` (it runs once per tenant), so an `async move`
+//! // body may only capture `Copy` values — and `&PruneOptions` is.
+//! let opts = &opts;
+//! let sweep = for_each_tenant(&pools, move |_org, pool| async move {
+//!     rustango::prunable::prune_all(&pool, opts).await
 //! })
 //! .await?;
 //!
+//! // `Ok` means the sweep RAN, not that every tenant succeeded —
+//! // always inspect the report, or a permanently-failing tenant is
+//! // exactly the silent under-coverage this exists to prevent.
 //! tracing::info!(ok = sweep.succeeded(), failed = sweep.failed(), "prune sweep");
+//! for (slug, err) in sweep.errors() {
+//!     tracing::warn!(%slug, %err, "tenant prune failed");
+//! }
 //! ```
 //!
 //! ## Semantics
@@ -42,6 +51,25 @@
 //!   with `search_path` in its connect options and database-mode tenants
 //!   get their own pool. The registry pool is never handed to the
 //!   closure.
+//!
+//! ## The pool-cache cap applies
+//!
+//! Database-mode pools come from `TenantPools`' cache, which is bounded
+//! by [`TenantPoolsConfig::max_cached_database_pools`] (default **64**)
+//! and does not evict — past the cap, `pool_for_org` errors rather than
+//! silently dropping someone's pool.
+//!
+//! For a sweep that means: with more active database-mode tenants than
+//! the cap, the tail of the list fails to resolve on **every run** and
+//! is recorded as [`SweepError::Pool`], while `for_each_tenant` still
+//! returns `Ok` — the unbounded-growth problem this module exists to
+//! solve, quietly reintroduced for those tenants.
+//!
+//! So: raise `max_cached_database_pools` to at least the number of
+//! active tenants before scheduling a sweep, and treat a non-zero
+//! [`TenantSweep::failed`] as alertable rather than informational.
+//! (A real LRU evictor is a `TenantPools` follow-up; until it lands the
+//! cap is a hard ceiling, not a soft one.)
 
 use crate::core::Column as _;
 use crate::sql::sqlx::Database;

--- a/crates/rustango/tests/cache_db_backend_sqlite_live.rs
+++ b/crates/rustango/tests/cache_db_backend_sqlite_live.rs
@@ -170,3 +170,93 @@ async fn purge_expired_is_no_op_when_table_has_only_live_rows() {
     assert_eq!(cache.get("k").await.unwrap().as_deref(), Some("v"));
     assert_eq!(cache.get("ttl").await.unwrap().as_deref(), Some("v"));
 }
+
+/// `delete_prefix` (#1227) drops exactly the matching keys. This is the
+/// path `ScopedCache::clear` uses, so getting it wrong means either a
+/// tenant's invalidation silently doing nothing or wiping a neighbour's
+/// entries.
+#[tokio::test]
+async fn delete_prefix_drops_only_the_matching_keys() {
+    let pool = fresh_pool().await;
+    let cache = DatabaseCache::new(pool, "rustango_cache_prefix");
+    cache.ensure_table().await.unwrap();
+
+    cache.set("tenant:acme:a", "1", None).await.unwrap();
+    cache.set("tenant:acme:b", "2", None).await.unwrap();
+    cache.set("tenant:globex:a", "9", None).await.unwrap();
+    cache.set("unrelated", "keep", None).await.unwrap();
+
+    cache
+        .delete_prefix("tenant:acme:")
+        .await
+        .expect("prefix delete");
+
+    assert_eq!(cache.get("tenant:acme:a").await.unwrap(), None);
+    assert_eq!(cache.get("tenant:acme:b").await.unwrap(), None);
+    assert_eq!(
+        cache.get("tenant:globex:a").await.unwrap().as_deref(),
+        Some("9"),
+        "another tenant's entry must survive"
+    );
+    assert_eq!(
+        cache.get("unrelated").await.unwrap().as_deref(),
+        Some("keep")
+    );
+}
+
+/// A slug that is a prefix of a longer one must not be swept by it —
+/// `tenant:acme:` vs `tenant:acme-corp:`.
+#[tokio::test]
+async fn delete_prefix_respects_the_separator() {
+    let pool = fresh_pool().await;
+    let cache = DatabaseCache::new(pool, "rustango_cache_prefix_sep");
+    cache.ensure_table().await.unwrap();
+
+    cache.set("tenant:acme:k", "short", None).await.unwrap();
+    cache.set("tenant:acme-corp:k", "long", None).await.unwrap();
+
+    cache.delete_prefix("tenant:acme:").await.unwrap();
+
+    assert_eq!(cache.get("tenant:acme:k").await.unwrap(), None);
+    assert_eq!(
+        cache.get("tenant:acme-corp:k").await.unwrap().as_deref(),
+        Some("long"),
+    );
+}
+
+/// `%` and `_` are LIKE wildcards. A prefix containing them must match
+/// literally, or one namespace's clear could sweep another's rows —
+/// `_` alone would match *any* single character.
+#[tokio::test]
+async fn delete_prefix_escapes_like_wildcards() {
+    let pool = fresh_pool().await;
+    let cache = DatabaseCache::new(pool, "rustango_cache_prefix_wild");
+    cache.ensure_table().await.unwrap();
+
+    cache.set("a_b:key", "underscore", None).await.unwrap();
+    cache
+        .set("axb:key", "wildcard-would-match", None)
+        .await
+        .unwrap();
+    cache.set("100%:key", "percent", None).await.unwrap();
+    cache
+        .set("100zz:key", "percent-would-match", None)
+        .await
+        .unwrap();
+
+    cache.delete_prefix("a_b:").await.unwrap();
+    assert_eq!(cache.get("a_b:key").await.unwrap(), None);
+    assert_eq!(
+        cache.get("axb:key").await.unwrap().as_deref(),
+        Some("wildcard-would-match"),
+        "`_` must be escaped, not treated as a single-character wildcard"
+    );
+
+    cache.delete_prefix("100%:").await.unwrap();
+    assert_eq!(cache.get("100%:key").await.unwrap(), None);
+    assert_eq!(
+        cache.get("100zz:key").await.unwrap().as_deref(),
+        Some("percent-would-match"),
+        "`%` must be escaped, not treated as a multi-character wildcard"
+    );
+}

--- a/crates/rustango/tests/cache_delete_prefix_live.rs
+++ b/crates/rustango/tests/cache_delete_prefix_live.rs
@@ -2,13 +2,17 @@
 //!
 //! The SQLite arm lives in `cache_db_backend_sqlite_live.rs`. This file
 //! covers Postgres and MySQL, because the statement is
-//! `DELETE … WHERE cache_key LIKE ? ESCAPE '\'` and `LIKE … ESCAPE` is
-//! exactly the kind of construct the three backends disagree about:
-//! MySQL treats `\` as an escape inside string literals (so the pattern
-//! needs the explicit `ESCAPE` clause to be unambiguous), while
-//! Postgres' `standard_conforming_strings` makes the same literal mean
-//! something slightly different. Emitting it once for all three is only
-//! safe if it is exercised on all three.
+//! `DELETE … WHERE cache_key LIKE ? ESCAPE '!'` and `LIKE … ESCAPE` is
+//! exactly the kind of construct the three backends disagree about.
+//!
+//! The escape character is `!` rather than the conventional `\` because
+//! the `\` form is *not* portable: MySQL treats a backslash as an escape
+//! inside string literals, so `ESCAPE '\'` is an unterminated literal
+//! and a 1064 syntax error there, while Postgres (with
+//! `standard_conforming_strings`) reads it as one backslash and accepts
+//! it happily. That divergence is the reason this file exists —
+//! emitting one statement for all three dialects is only safe if it is
+//! exercised on all three.
 //!
 //! Reads `DATABASE_URL` (Postgres) and `MYSQL_TEST_URL` (MySQL). Each
 //! test skips silently when its variable is unset, so the suite stays

--- a/crates/rustango/tests/cache_delete_prefix_live.rs
+++ b/crates/rustango/tests/cache_delete_prefix_live.rs
@@ -1,0 +1,124 @@
+//! Tri-dialect coverage for `DatabaseCache::delete_prefix` (#1227).
+//!
+//! The SQLite arm lives in `cache_db_backend_sqlite_live.rs`. This file
+//! covers Postgres and MySQL, because the statement is
+//! `DELETE … WHERE cache_key LIKE ? ESCAPE '\'` and `LIKE … ESCAPE` is
+//! exactly the kind of construct the three backends disagree about:
+//! MySQL treats `\` as an escape inside string literals (so the pattern
+//! needs the explicit `ESCAPE` clause to be unambiguous), while
+//! Postgres' `standard_conforming_strings` makes the same literal mean
+//! something slightly different. Emitting it once for all three is only
+//! safe if it is exercised on all three.
+//!
+//! Reads `DATABASE_URL` (Postgres) and `MYSQL_TEST_URL` (MySQL). Each
+//! test skips silently when its variable is unset, so the suite stays
+//! green offline.
+
+#![cfg(any(feature = "postgres", feature = "mysql"))]
+
+use rustango::cache::{Cache, DatabaseCache};
+use rustango::sql::Pool;
+
+/// Populate a fresh table, prefix-delete one namespace, and assert only
+/// that namespace went — including the wildcard-escaping cases, which
+/// are the ones that would silently over-delete.
+async fn assert_prefix_semantics(pool: Pool, table: &str) {
+    let cache = DatabaseCache::new(pool, table);
+    // Start from a known-empty table even if a previous run left rows.
+    cache.ensure_table().await.expect("ensure_table");
+    cache.clear().await.expect("clear");
+
+    cache.set("tenant:acme:a", "1", None).await.unwrap();
+    cache.set("tenant:acme:b", "2", None).await.unwrap();
+    cache.set("tenant:acme-corp:a", "long", None).await.unwrap();
+    cache.set("tenant:globex:a", "9", None).await.unwrap();
+    cache.set("unrelated", "keep", None).await.unwrap();
+    cache.set("a_b:key", "underscore", None).await.unwrap();
+    cache.set("axb:key", "would-match", None).await.unwrap();
+    cache.set("100%:key", "percent", None).await.unwrap();
+    cache.set("100zz:key", "would-match", None).await.unwrap();
+
+    cache
+        .delete_prefix("tenant:acme:")
+        .await
+        .expect("prefix delete");
+
+    assert_eq!(cache.get("tenant:acme:a").await.unwrap(), None);
+    assert_eq!(cache.get("tenant:acme:b").await.unwrap(), None);
+    assert_eq!(
+        cache.get("tenant:acme-corp:a").await.unwrap().as_deref(),
+        Some("long"),
+        "the trailing separator must stop `acme` matching `acme-corp`"
+    );
+    assert_eq!(
+        cache.get("tenant:globex:a").await.unwrap().as_deref(),
+        Some("9"),
+        "another tenant's entry must survive"
+    );
+    assert_eq!(
+        cache.get("unrelated").await.unwrap().as_deref(),
+        Some("keep")
+    );
+
+    // `_` is a single-character LIKE wildcard; unescaped, `a_b:` would
+    // also sweep `axb:key`.
+    cache.delete_prefix("a_b:").await.unwrap();
+    assert_eq!(cache.get("a_b:key").await.unwrap(), None);
+    assert_eq!(
+        cache.get("axb:key").await.unwrap().as_deref(),
+        Some("would-match"),
+        "`_` must be escaped rather than matching any character"
+    );
+
+    // `%` is a multi-character wildcard; unescaped, `100%:` would sweep
+    // everything starting with `100`.
+    cache.delete_prefix("100%:").await.unwrap();
+    assert_eq!(cache.get("100%:key").await.unwrap(), None);
+    assert_eq!(
+        cache.get("100zz:key").await.unwrap().as_deref(),
+        Some("would-match"),
+        "`%` must be escaped rather than matching any run of characters"
+    );
+
+    // `!` is the escape character itself, so a prefix containing one
+    // must have it doubled — otherwise `!%` inside a prefix would be
+    // read as an escaped wildcard and the delete would miss.
+    cache.set("wow!:key", "bang", None).await.unwrap();
+    cache.set("wow!x:key", "keep", None).await.unwrap();
+    cache.delete_prefix("wow!:").await.unwrap();
+    assert_eq!(
+        cache.get("wow!:key").await.unwrap(),
+        None,
+        "a literal `!` in the prefix must still match"
+    );
+    assert_eq!(
+        cache.get("wow!x:key").await.unwrap().as_deref(),
+        Some("keep")
+    );
+
+    cache.clear().await.unwrap();
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn delete_prefix_semantics_on_postgres() {
+    let Ok(url) = std::env::var("DATABASE_URL") else {
+        return;
+    };
+    let pg = rustango::sql::sqlx::PgPool::connect(&url)
+        .await
+        .expect("connect DATABASE_URL");
+    assert_prefix_semantics(Pool::Postgres(pg), "rustango_cache_prefix_pg").await;
+}
+
+#[cfg(feature = "mysql")]
+#[tokio::test]
+async fn delete_prefix_semantics_on_mysql() {
+    let Ok(url) = std::env::var("MYSQL_TEST_URL") else {
+        return;
+    };
+    let my = rustango::sql::sqlx::MySqlPool::connect(&url)
+        .await
+        .expect("connect MYSQL_TEST_URL");
+    assert_prefix_semantics(Pool::Mysql(my), "rustango_cache_prefix_my").await;
+}

--- a/crates/rustango/tests/cache_redis_prefix_live.rs
+++ b/crates/rustango/tests/cache_redis_prefix_live.rs
@@ -1,0 +1,182 @@
+//! `RedisCache::delete_prefix` against a live Redis (#1227).
+//!
+//! This file exists because of a bug that shipped in review: `Cache`
+//! grew a `delete_prefix` whose default clears the WHOLE cache (safe on
+//! a backend that cannot enumerate its keys — under-deleting would let
+//! another namespace read a stale entry). `RedisCache` did not override
+//! it, and `RedisCache::clear()` is **`FLUSHDB`** — so one tenant's
+//! `ScopedCache::clear()` would have wiped every other tenant's
+//! entries, every rate-limit counter, and every `lock:*` key, letting
+//! two replicas both take a "once per cluster" lock.
+//!
+//! Nothing caught it: the crate had no Redis tests and CI runs no Redis
+//! service, because `cache-redis` is off by default.
+//!
+//! Reads `REDIS_TEST_URL`; skips silently when unset:
+//!
+//! ```bash
+//! docker run -d -p 6399:6379 redis:7-alpine
+//! REDIS_TEST_URL=redis://127.0.0.1:6399/ \
+//!   cargo test -p rustango --features cache,cache-redis --test cache_redis_prefix_live
+//! ```
+
+#![cfg(feature = "cache-redis")]
+
+use std::sync::Arc;
+
+use rustango::cache::redis_backend::RedisCache;
+use rustango::cache::{BoxedCache, Cache, ScopedCache};
+use tokio::sync::Mutex;
+
+/// Suite-wide lock. Every test here starts from an empty keyspace, and
+/// the reset is `FLUSHDB` — which is global. Without serializing, one
+/// test's setup wipes another's data mid-run and they fail in exactly
+/// the way a real prefix-delete bug would, which is worse than useless.
+fn live_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn cache() -> Option<RedisCache> {
+    let url = std::env::var("REDIS_TEST_URL").ok()?;
+    Some(RedisCache::new(&url).await.expect("connect REDIS_TEST_URL"))
+}
+
+/// The regression: a scoped clear must delete only its own namespace.
+/// Before the `SCAN`-based override this flushed the entire database.
+#[tokio::test]
+async fn scoped_clear_does_not_flush_other_namespaces() {
+    let _g = live_lock().lock().await;
+    let Some(redis) = cache().await else {
+        return;
+    };
+    redis.clear().await.expect("start from an empty db");
+
+    let shared: BoxedCache = Arc::new(redis);
+    let acme = ScopedCache::for_tenant(shared.clone(), "acme");
+    let globex = ScopedCache::for_tenant(shared.clone(), "globex");
+
+    acme.set("stats", "acme-value", None).await.unwrap();
+    globex.set("stats", "globex-value", None).await.unwrap();
+    // Unscoped keys standing in for the collateral damage FLUSHDB did:
+    // a distributed lock and a rate-limit counter.
+    shared
+        .set("lock:nightly_prune", "held", None)
+        .await
+        .unwrap();
+    shared.set("ratelimit:1.2.3.4", "7", None).await.unwrap();
+
+    acme.clear().await.expect("scoped clear");
+
+    assert_eq!(
+        acme.get("stats").await.unwrap(),
+        None,
+        "acme's own key goes"
+    );
+    assert_eq!(
+        globex.get("stats").await.unwrap().as_deref(),
+        Some("globex-value"),
+        "another tenant's entry must survive — this is the FLUSHDB regression"
+    );
+    assert_eq!(
+        shared.get("lock:nightly_prune").await.unwrap().as_deref(),
+        Some("held"),
+        "a distributed lock must survive a tenant's cache invalidation"
+    );
+    assert_eq!(
+        shared.get("ratelimit:1.2.3.4").await.unwrap().as_deref(),
+        Some("7"),
+        "rate-limit counters must survive a tenant's cache invalidation"
+    );
+
+    shared.clear().await.ok();
+}
+
+/// The cursor loop must delete every match, not just the first `COUNT`
+/// batch — `SCAN` returns an arbitrary number of keys per call and a
+/// non-zero cursor means "keep going".
+#[tokio::test]
+async fn delete_prefix_sweeps_past_one_scan_batch() {
+    let _g = live_lock().lock().await;
+    let Some(redis) = cache().await else {
+        return;
+    };
+    redis.clear().await.expect("start from an empty db");
+
+    // Comfortably more than the COUNT hint (512) so the loop must
+    // iterate, plus a decoy namespace that must be untouched.
+    for i in 0..1500 {
+        redis
+            .set(&format!("tenant:bulk:{i}"), "x", None)
+            .await
+            .unwrap();
+    }
+    redis.set("tenant:keep:0", "y", None).await.unwrap();
+
+    redis.delete_prefix("tenant:bulk:").await.expect("sweep");
+
+    for i in [0, 500, 999, 1499] {
+        assert_eq!(
+            redis.get(&format!("tenant:bulk:{i}")).await.unwrap(),
+            None,
+            "key {i} survived the sweep — the cursor loop stopped early"
+        );
+    }
+    assert_eq!(
+        redis.get("tenant:keep:0").await.unwrap().as_deref(),
+        Some("y")
+    );
+
+    redis.clear().await.ok();
+}
+
+/// `MATCH` takes a glob. An unescaped `*` or `?` in the prefix would
+/// match beyond its own namespace.
+#[tokio::test]
+async fn delete_prefix_escapes_glob_metacharacters() {
+    let _g = live_lock().lock().await;
+    let Some(redis) = cache().await else {
+        return;
+    };
+    redis.clear().await.expect("start from an empty db");
+
+    redis.set("a*b:key", "literal-star", None).await.unwrap();
+    redis.set("axxb:key", "would-match", None).await.unwrap();
+    redis.set("q?:key", "literal-question", None).await.unwrap();
+    redis.set("qZ:key", "would-match", None).await.unwrap();
+
+    redis.delete_prefix("a*b:").await.unwrap();
+    assert_eq!(redis.get("a*b:key").await.unwrap(), None);
+    assert_eq!(
+        redis.get("axxb:key").await.unwrap().as_deref(),
+        Some("would-match"),
+        "`*` must be escaped, not treated as a glob wildcard"
+    );
+
+    redis.delete_prefix("q?:").await.unwrap();
+    assert_eq!(redis.get("q?:key").await.unwrap(), None);
+    assert_eq!(
+        redis.get("qZ:key").await.unwrap().as_deref(),
+        Some("would-match"),
+        "`?` must be escaped, not treated as a single-character wildcard"
+    );
+
+    redis.clear().await.ok();
+}
+
+/// An empty keyspace must not error, and must not fall back to a flush.
+#[tokio::test]
+async fn delete_prefix_on_no_matches_is_a_noop() {
+    let _g = live_lock().lock().await;
+    let Some(redis) = cache().await else {
+        return;
+    };
+    redis.clear().await.expect("start from an empty db");
+
+    redis.set("untouched", "v", None).await.unwrap();
+    redis.delete_prefix("nothing-here:").await.expect("noop");
+    assert_eq!(redis.get("untouched").await.unwrap().as_deref(), Some("v"));
+
+    redis.clear().await.ok();
+}

--- a/crates/rustango/tests/tenant_sweep_sqlite_live.rs
+++ b/crates/rustango/tests/tenant_sweep_sqlite_live.rs
@@ -1,0 +1,152 @@
+//! Live regressions for the per-tenant sweep fan-out (#1226).
+//!
+//! The framework's "run this from the scheduler" helpers all take one
+//! pool, which under tenancy means one tenant. `tenancy::for_each_tenant`
+//! is the loop that closes that gap; these tests pin the two properties
+//! that make it usable for a nightly sweep:
+//!
+//! - it visits **every active** tenant, each against its **own** pool
+//!   (so a sweep can't silently clean one tenant and report success), and
+//! - one broken tenant does **not** stop the others (so a rotated
+//!   credential doesn't starve every tenant later in the list).
+//!
+//! Database-mode SQLite throughout — each tenant is its own file, which
+//! is the cleanest way to prove per-tenant isolation without Postgres.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+
+use std::sync::{Arc, Mutex};
+
+use rustango::sql::{sqlx, Auto};
+use rustango::tenancy::{for_each_tenant, Org, SweepError, TenantPools};
+
+fn db_org(slug: &str, url: &str, active: bool) -> Org {
+    Org {
+        id: Auto::default(),
+        slug: slug.to_owned(),
+        display_name: slug.to_owned(),
+        storage_mode: "database".into(),
+        backend_kind: "sqlite".into(),
+        database_url: Some(url.to_owned()),
+        active,
+        ..rustango::testkit::org()
+    }
+}
+
+fn shared_mem(name: &str) -> String {
+    format!("sqlite:file:{name}?mode=memory&cache=shared")
+}
+
+/// Registry with `rustango_orgs` materialized and the given orgs seeded.
+async fn registry_with(orgs: &[Org]) -> sqlx::SqlitePool {
+    let pool: sqlx::SqlitePool = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("registry pool");
+    let erased = rustango::sql::Pool::Sqlite(pool.clone());
+    rustango::testkit::migrate_framework(&erased)
+        .await
+        .expect("framework tables");
+    for org in orgs {
+        let mut o = org.clone();
+        o.insert_pool(&erased).await.expect("seed org");
+    }
+    pool
+}
+
+#[tokio::test]
+async fn for_each_tenant_visits_every_active_tenant_with_its_own_pool() {
+    let acme = db_org("acme_sweep", &shared_mem("sweep_acme"), true);
+    let globex = db_org("globex_sweep", &shared_mem("sweep_globex"), true);
+    let dormant = db_org("dormant_sweep", &shared_mem("sweep_dormant"), false);
+    let registry = registry_with(&[acme, globex, dormant]).await;
+    let pools: TenantPools<sqlx::Sqlite> = TenantPools::new(registry);
+
+    // Each tenant writes its own slug into its own database, then reads
+    // back what that database holds. If the fan-out leaked one pool
+    // across tenants, a tenant would see more than its own row.
+    let sweep = for_each_tenant(&pools, |org, pool| async move {
+        rustango::sql::raw_execute_pool(
+            &pool,
+            "CREATE TABLE IF NOT EXISTS seen (slug TEXT)",
+            vec![],
+        )
+        .await?;
+        rustango::sql::raw_execute_pool(
+            &pool,
+            "INSERT INTO seen (slug) VALUES (?1)",
+            vec![rustango::core::SqlValue::String(org.slug.clone())],
+        )
+        .await?;
+        let rows: Vec<(String,)> =
+            rustango::sql::raw_query_pool("SELECT slug FROM seen", vec![], &pool).await?;
+        Ok::<_, rustango::sql::ExecError>(rows.into_iter().map(|(s,)| s).collect::<Vec<_>>())
+    })
+    .await
+    .expect("sweep runs");
+
+    assert_eq!(sweep.failed(), 0, "no tenant should fail");
+    assert_eq!(
+        sweep.succeeded(),
+        2,
+        "only the two active tenants are visited — the inactive one is skipped"
+    );
+
+    let mut visited: Vec<&str> = sweep.values().map(|(slug, _)| slug).collect();
+    visited.sort_unstable();
+    assert_eq!(visited, vec!["acme_sweep", "globex_sweep"]);
+
+    // Every tenant's database contains exactly its own slug.
+    for (slug, seen) in sweep.values() {
+        assert_eq!(
+            seen,
+            &vec![slug.to_owned()],
+            "tenant {slug} saw rows from another tenant's database"
+        );
+    }
+}
+
+#[tokio::test]
+async fn one_broken_tenant_does_not_stop_the_sweep() {
+    // `broken` names a directory that cannot be opened as a database, so
+    // resolving its pool fails while its neighbours are fine.
+    let good_a = db_org("good_a_sweep", &shared_mem("sweep_good_a"), true);
+    let broken = db_org("broken_sweep", "sqlite:/nonexistent-dir/nope.db", true);
+    let good_b = db_org("good_b_sweep", &shared_mem("sweep_good_b"), true);
+    let registry = registry_with(&[good_a, broken, good_b]).await;
+    let pools: TenantPools<sqlx::Sqlite> = TenantPools::new(registry);
+
+    let ran = Arc::new(Mutex::new(Vec::new()));
+    let ran_c = Arc::clone(&ran);
+    let sweep = for_each_tenant(&pools, move |org, pool| {
+        let ran = Arc::clone(&ran_c);
+        async move {
+            rustango::sql::raw_query_pool::<(i64,)>("SELECT 1", vec![], &pool).await?;
+            ran.lock().unwrap().push(org.slug.clone());
+            Ok::<_, rustango::sql::ExecError>(())
+        }
+    })
+    .await
+    .expect("sweep runs even though a tenant is broken");
+
+    assert_eq!(sweep.succeeded(), 2, "both healthy tenants ran");
+    assert_eq!(
+        sweep.failed(),
+        1,
+        "the broken tenant is recorded, not fatal"
+    );
+
+    let failed: Vec<&str> = sweep.errors().map(|(slug, _)| slug).collect();
+    assert_eq!(failed, vec!["broken_sweep"]);
+    assert!(
+        matches!(
+            sweep.errors().next().map(|(_, e)| e),
+            Some(SweepError::Pool(_))
+        ),
+        "an unopenable database should surface as a pool-resolution failure"
+    );
+
+    // Crucially, the tenant *after* the broken one still ran.
+    let mut ran = ran.lock().unwrap().clone();
+    ran.sort_unstable();
+    assert_eq!(ran, vec!["good_a_sweep", "good_b_sweep"]);
+}

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -31,6 +31,7 @@ Django's cache framework or Laravel's `Cache` facade.
 - [Typed JSON values](#typed-json-values)
 - [TTL and expiry](#ttl-and-expiry)
 - [Swapping backends](#swapping-backends)
+- [Caching under multi-tenancy](#caching-under-multi-tenancy)
 - [Reference](#reference)
 - [See also](#see-also)
 
@@ -162,6 +163,45 @@ let cache: BoxedCache = std::sync::Arc::new(RedisCache::new("redis://localhost")
 ```
 
 Same `get` / `set` / `get_or_set` calls — only the constructor changed.
+
+---
+
+## Caching under multi-tenancy
+
+`Cache` is a flat `&str`-keyed store, which under tenancy makes the natural
+key the leaky key: a handler — or worse a background task, which has no
+ambient tenant to borrow from — writes `"stats:monthly"` for one tenant and
+every other tenant reads it back.
+
+Wrap the shared cache in a **`ScopedCache`** so the namespace is applied for
+you and the call site cannot forget:
+
+```rust
+use rustango::cache::ScopedCache;
+
+// From the Org the resolver already produced:
+let cache = ScopedCache::for_tenant(shared.clone(), &t.org.slug);
+
+cache.set("stats:monthly", &json, ttl).await?;   // stored as tenant:acme:stats:monthly
+cache.get("stats:monthly").await?;               // reads only acme's entry
+cache.clear().await?;                            // drops ONLY acme's entries
+```
+
+`ScopedCache` is itself a `Cache`, so it drops into anything taking a
+`BoxedCache` — `cache_page`, `cache_fragment`, the rate limiters,
+`DistributedLock`. It forwards to the inner backend with mapped keys rather
+than reimplementing anything, so native primitives (Redis `INCRBY`, `SET NX`,
+`MGET`) keep their atomicity and batching.
+
+Two things worth knowing:
+
+| | |
+|---|---|
+| **It is a namespace, not a boundary** | Everything still lives in one backend, and code holding the *unscoped* cache can read any key. The point is that the ergonomic path is the correct one. |
+| **`clear()` needs key enumeration** | It routes through `Cache::delete_prefix`. `InMemoryCache` filters its map and `DatabaseCache` issues a `DELETE … LIKE 'prefix%'`. A backend that *cannot* enumerate — `FileCache` hashes keys into paths — falls back to clearing everything and logs a warning. That is deliberate: under-deleting would let another namespace read a stale entry, which is a correctness bug, while over-deleting only costs a cache miss. |
+
+The unscoped `Cache::clear()` is still process-global, so reach for the scoped
+view whenever a single tenant's change is what triggered the invalidation.
 
 ---
 

--- a/docs/de/caching.md
+++ b/docs/de/caching.md
@@ -33,6 +33,7 @@ oder Laravels `Cache`-Fassade.
 - [Typisierte JSON-Werte](#typed-json-values)
 - [TTL und Ablauf](#ttl-and-expiry)
 - [Backends tauschen](#swapping-backends)
+- [Caching unter Multi-Tenancy](#caching-under-multi-tenancy)
 - [Referenz](#reference)
 - [Siehe auch](#see-also)
 
@@ -169,6 +170,46 @@ let cache: BoxedCache = std::sync::Arc::new(RedisCache::new("redis://localhost")
 
 Dieselben `get` / `set` / `get_or_set`-Aufrufe — nur der Konstruktor hat sich
 geändert.
+
+---
+
+## Caching unter Multi-Tenancy
+
+`Cache` ist ein flacher, `&str`-indizierter Store — und das macht unter
+Multi-Tenancy den naheliegenden Key zum undichten Key: ein Handler (oder
+schlimmer ein Background-Task, der gar keinen ambienten Tenant hat) schreibt
+`"stats:monthly"` für einen Tenant, und jeder andere Tenant liest es zurück.
+
+Wickle den gemeinsamen Cache in einen **`ScopedCache`**, damit der Namespace
+für dich angewendet wird und die Aufrufstelle es nicht vergessen kann:
+
+```rust
+use rustango::cache::ScopedCache;
+
+// From the Org the resolver already produced:
+let cache = ScopedCache::for_tenant(shared.clone(), &t.org.slug);
+
+cache.set("stats:monthly", &json, ttl).await?;   // stored as tenant:acme:stats:monthly
+cache.get("stats:monthly").await?;               // reads only acme's entry
+cache.clear().await?;                            // drops ONLY acme's entries
+```
+
+`ScopedCache` ist selbst ein `Cache` und passt damit überall hinein, wo ein
+`BoxedCache` erwartet wird — `cache_page`, `cache_fragment`, die Rate-Limiter,
+`DistributedLock`. Er leitet mit gemappten Keys an das innere Backend weiter,
+statt etwas neu zu implementieren, sodass native Primitive (Redis `INCRBY`,
+`SET NX`, `MGET`) ihre Atomarität und Batching behalten.
+
+Zwei Dinge, die man wissen sollte:
+
+| | |
+|---|---|
+| **Ein Namespace, keine Sicherheitsgrenze** | Alles liegt weiter in einem Backend, und Code mit dem *ungescopeten* Cache kann jeden Key lesen. Der Punkt ist, dass der ergonomische Pfad der korrekte ist. |
+| **`clear()` braucht Key-Enumeration** | Es läuft über `Cache::delete_prefix`. `InMemoryCache` filtert seine Map, `DatabaseCache` schickt ein `DELETE … LIKE 'prefix%'`. Ein Backend, das *nicht* enumerieren kann — `FileCache` hasht Keys in Pfade — fällt darauf zurück, alles zu leeren, und loggt eine Warnung. Das ist Absicht: zu wenig zu löschen ließe einen anderen Namespace einen veralteten Eintrag lesen (ein Korrektheitsfehler), zu viel zu löschen kostet nur einen Cache-Miss. |
+
+Das ungescopete `Cache::clear()` ist weiterhin prozessweit — greife also zur
+gescopeten Sicht, wann immer die Änderung eines einzelnen Tenants die
+Invalidierung ausgelöst hat.
 
 ---
 

--- a/docs/de/jobs.md
+++ b/docs/de/jobs.md
@@ -37,6 +37,7 @@ Celery / Laravel-Queues, in Rust.
 - [Der Dead-Letter-Handler](#the-dead-letter-handler)
 - [Die persistente Queue (Produktion)](#the-persistent-queue-production)
 - [Jobs unter Multi-Tenancy](#jobs-under-multi-tenancy)
+- [Geplante Sweeps unter Multi-Tenancy](#scheduled-sweeps-under-multi-tenancy)
 - [Referenz](#reference)
 - [Siehe auch](#see-also)
 
@@ -418,6 +419,66 @@ angehängtem Tenant und keinen Tenant-bewussten `reclaim_stuck_jobs_pool`-Sweep
 provisioniert werden, bekommen bis zum Prozess-Neustart keine Worker.
 Verfolgt in
 [#1223](https://github.com/ujeenet/rustango/issues/1223).
+
+**Auch kein ambienter Kontext.** Worker werden per `tokio::spawn` gestartet,
+und Task-Locals überqueren keinen Spawn — ein Job läuft also mit der
+Audit-Quelle auf `AuditSource::System` und der Default-Zeitzone, egal was der
+dispatchende Request gesetzt hatte. Nimm mit, was du brauchst, im Payload, oder
+betritt den Scope in `run()` erneut mit `audit::with_source`. Verfolgt in
+[#1229](https://github.com/ujeenet/rustango/issues/1229).
+
+---
+
+## Geplante Sweeps unter Multi-Tenancy
+
+Dasselbe „ein Worker ist kein Request"-Problem trifft auch *zeitbasierte*
+Arbeit, und die Sweep-Helfer des Frameworks sind die Stelle, an der es beißt:
+`MediaLibrary::purge_orphans`, `audit::cleanup_older_than_pool` und
+`prunable::prune_all` nehmen jeweils **einen Pool**, und jede Tabelle, die sie
+anfassen, ist pro Tenant. Ein Pool heißt ein Tenant — und ein Registry-Pool im
+Schema-Modus heißt nur `public`, während die Zeilen jedes Tenants anwachsen und
+der Sweep trotzdem Erfolg meldet.
+
+Mach den Fan-out mit **`for_each_tenant`**: es löst für jeden aktiven Tenant
+dessen eigenen Pool auf und macht weiter, wenn ein Tenant scheitert:
+
+```rust
+use rustango::tenancy::for_each_tenant;
+
+let sweep = for_each_tenant(&pools, |_org, pool| async move {
+    rustango::prunable::prune_all(&pool, &opts).await
+})
+.await?;
+
+tracing::info!(ok = sweep.succeeded(), failed = sweep.failed(), "nightly prune");
+for (slug, err) in sweep.errors() {
+    tracing::warn!(%slug, %err, "tenant prune failed");
+}
+```
+
+Ein kaputter Tenant — rotiertes Credential, nicht erreichbare Datenbank —
+landet im Report, statt den Lauf abzubrechen, und kann so die Tenants danach
+nicht aushungern. Inaktive Orgs werden übersprungen. `purge_orphans` ist der
+eine Sweep, der über die Datenbank hinausgreift (er löscht Storage-Objekte),
+darum gibt es `purge_orphans_dry_run`: dieselbe Query, löscht nichts — ein Blick
+darauf lohnt sich, bevor du das echte Ding verdrahtest.
+
+Wenn du den Sweep so absicherst, dass nur eine Replica ihn ausführt, dann
+**scope das Lock pro Tenant**:
+
+```rust
+use rustango::distributed_lock::DistributedLock;
+
+let lock = DistributedLock::new(cache.clone()).for_tenant(&org.slug);
+lock.with_lock("nightly_prune", ttl, || async { /* … */ }).await;
+```
+
+Ungescoped konkurrieren alle Tenants um dasselbe `lock:nightly_prune`: der
+erste Tenant gewinnt, die übrigen werden für die gesamte TTL übersprungen — und
+zwar still, denn ein abgelehntes Acquire ist das erwartete Ergebnis, es wird
+nichts geloggt. Verfolgt in
+[#1226](https://github.com/ujeenet/rustango/issues/1226) und
+[#1228](https://github.com/ujeenet/rustango/issues/1228).
 
 ---
 

--- a/docs/de/jobs.md
+++ b/docs/de/jobs.md
@@ -433,7 +433,7 @@ betritt den Scope in `run()` erneut mit `audit::with_source`. Verfolgt in
 
 Dasselbe „ein Worker ist kein Request"-Problem trifft auch *zeitbasierte*
 Arbeit, und die Sweep-Helfer des Frameworks sind die Stelle, an der es beißt:
-`MediaLibrary::purge_orphans`, `audit::cleanup_older_than_pool` und
+`MediaManager::purge_orphans`, `audit::cleanup_older_than_pool` und
 `prunable::prune_all` nehmen jeweils **einen Pool**, und jede Tabelle, die sie
 anfassen, ist pro Tenant. Ein Pool heißt ein Tenant — und ein Registry-Pool im
 Schema-Modus heißt nur `public`, während die Zeilen jedes Tenants anwachsen und
@@ -445,8 +445,9 @@ dessen eigenen Pool auf und macht weiter, wenn ein Tenant scheitert:
 ```rust
 use rustango::tenancy::for_each_tenant;
 
-let sweep = for_each_tenant(&pools, |_org, pool| async move {
-    rustango::prunable::prune_all(&pool, &opts).await
+let opts = &opts;
+let sweep = for_each_tenant(&pools, move |_org, pool| async move {
+    rustango::prunable::prune_all(&pool, opts).await
 })
 .await?;
 

--- a/docs/de/jobs.md
+++ b/docs/de/jobs.md
@@ -36,6 +36,7 @@ Celery / Laravel-Queues, in Rust.
 - [Retries und Backoff](#retries-and-backoff)
 - [Der Dead-Letter-Handler](#the-dead-letter-handler)
 - [Die persistente Queue (Produktion)](#the-persistent-queue-production)
+- [Jobs unter Multi-Tenancy](#jobs-under-multi-tenancy)
 - [Referenz](#reference)
 - [Siehe auch](#see-also)
 
@@ -346,6 +347,80 @@ Dogfooding gegen SQLite in `jobs_sqlite_live.rs` erprobt.
 
 ---
 
+## Jobs unter Multi-Tenancy
+
+Ein Worker ist kein Request. Nichts hat für ihn einen Tenant aufgelöst — kein
+Host, kein Header, keine Middleware lief — also **trägt ein Job keinen
+Tenant-Kontext**: `run(&self)` erhält nur das deserialisierte Payload. Die
+Isolation kommt aus **dem Pool, auf dem die Queue gebaut wurde**, und daraus
+folgt die Regel:
+
+> Eine Queue pro Tenant-Pool. Eine Tenant-Id im Payload ist Routing, keine
+> Isolation.
+
+Diese eine Entscheidung ist es, die jeden Modus sicher macht:
+
+| Modus | Wo `rustango_jobs` liegt | Warum ein Worker gescoped bleibt |
+|---|---|---|
+| `database` | in der eigenen Datenbank / SQLite-Datei des Tenants | die Zeilen eines anderen Tenants stehen nicht in der Tabelle, die der Worker abfragt — Cross-Tenant-Lesezugriffe sind nicht ausdrückbar |
+| `schema` (PG) | im Schema des Tenants | `scoped_pool_dyn` liefert einen Pool, in dessen **Connect-Options** `search_path` eingebacken ist, statt eines `SET` pro Request — jeder Checkout ist also für die gesamte Lebensdauer des Pools gescoped, auch bei einem Worker, der tagelang läuft |
+
+Baue die Queues beim Boot, eine pro aktivem Tenant:
+
+```rust
+use rustango::core::Column as _;
+use rustango::jobs::{DatabaseJobQueue, JobQueue};
+use rustango::sql::FetcherPool as _;
+use rustango::tenancy::{Org, TenantPools};
+use std::sync::Arc;
+use std::time::Duration;
+
+let pools = Arc::new(TenantPools::new(registry));
+let registry_pool = pools.registry_pool();
+
+// The registry holds the tenant list; each `Org` names its own
+// database (or PG schema).
+let orgs: Vec<Org> = Org::objects()
+    .where_(Org::active.eq(true))
+    .fetch(&registry_pool)
+    .await?;
+
+let mut queues = Vec::new();
+for org in orgs {
+    let pool = pools.scoped_pool_dyn(&org).await?;   // scoped for its lifetime
+    DatabaseJobQueue::ensure_table_pool(&pool).await?;
+
+    let queue = Arc::new(
+        DatabaseJobQueue::with_workers_pool(pool, 2)
+            .poll_interval(Duration::from_secs(1)),
+    );
+    queue.register::<WelcomeEmail>().await;
+    queue.start().await;
+    queues.push((org.slug, queue));
+}
+```
+
+Der Dispatch geht dann an *die Queue dieses Tenants* — in einem
+Request-Handler an die, die unter dem `Org` liegt, das der Resolver schon
+erzeugt hat.
+
+**Was man nicht tun sollte.** Eine Queue auf dem Registry-Pool mit einem
+`org_id`-Feld im Payload legt die Jobs aller Tenants in eine gemeinsame
+Tabelle und überlässt es jedem `run()`, sich ans Re-Scoping zu erinnern. Ein
+einziges vergessenes Re-Scoping ist ein Cross-Tenant-Write. Wenn du aus
+betrieblichen Gründen eine gemeinsame Queue brauchst, löse den Tenant-Pool als
+*erstes* in `run()` auf und fasse den Registry-Pool danach nicht mehr an.
+
+**Bekannte Grenzen.** Das Framework übernimmt den Fan-out nicht für dich: es
+gibt keinen Worker-Supervisor pro Tenant, kein `Job::run(&ctx)` mit
+angehängtem Tenant und keinen Tenant-bewussten `reclaim_stuck_jobs_pool`-Sweep
+— du iterierst selbst über die Tenants, wie oben. Tenants, die nach dem Boot
+provisioniert werden, bekommen bis zum Prozess-Neustart keine Worker.
+Verfolgt in
+[#1223](https://github.com/ujeenet/rustango/issues/1223).
+
+---
+
 ## Referenz
 
 **Backends**
@@ -377,3 +452,5 @@ Dogfooding gegen SQLite in `jobs_sqlite_live.rs` erprobt.
 - [E-Mail](email.md) — die kanonische „mach es in einem Job"-Workload.
 - [Caching](caching.md) — der andere Weg, Request-Handler schnell zu halten.
 - [Signals](orm.md) — Fire-and-Forget-Hooks, die oft einen Job *dispatchen*.
+- [Tenancy-Befehle](manage.md#tenancy-commands) — das Provisionieren der
+  Tenants, über die eine Queue pro Tenant fan-out macht.

--- a/docs/es/caching.md
+++ b/docs/es/caching.md
@@ -32,6 +32,7 @@ de Django o la fachada `Cache` de Laravel.
 - [Valores JSON tipados](#typed-json-values)
 - [TTL y expiración](#ttl-and-expiry)
 - [Cambiar de backend](#swapping-backends)
+- [Caché con multi-tenancy](#caching-under-multi-tenancy)
 - [Referencia](#reference)
 - [Véase también](#see-also)
 
@@ -166,6 +167,46 @@ let cache: BoxedCache = std::sync::Arc::new(RedisCache::new("redis://localhost")
 ```
 
 Las mismas llamadas `get` / `set` / `get_or_set` — solo cambió el constructor.
+
+---
+
+## Caché con multi-tenancy
+
+`Cache` es un almacén plano indexado por `&str`, y con multi-tenancy eso
+convierte la clave natural en la clave que se filtra: un handler — o peor, una
+tarea de fondo, que no tiene ningún tenant ambiental del que tirar — escribe
+`"stats:monthly"` para un tenant y todos los demás lo leen.
+
+Envuelve la caché compartida en un **`ScopedCache`** para que el namespace se
+aplique por ti y el sitio de llamada no pueda olvidarlo:
+
+```rust
+use rustango::cache::ScopedCache;
+
+// From the Org the resolver already produced:
+let cache = ScopedCache::for_tenant(shared.clone(), &t.org.slug);
+
+cache.set("stats:monthly", &json, ttl).await?;   // stored as tenant:acme:stats:monthly
+cache.get("stats:monthly").await?;               // reads only acme's entry
+cache.clear().await?;                            // drops ONLY acme's entries
+```
+
+`ScopedCache` es en sí mismo un `Cache`, así que encaja en cualquier cosa que
+tome un `BoxedCache` — `cache_page`, `cache_fragment`, los rate limiters,
+`DistributedLock`. Reenvía al backend interno con las claves mapeadas en lugar
+de reimplementar nada, de modo que las primitivas nativas (Redis `INCRBY`,
+`SET NX`, `MGET`) conservan su atomicidad y su batching.
+
+Dos cosas que conviene saber:
+
+| | |
+|---|---|
+| **Es un namespace, no una frontera** | Todo sigue viviendo en un solo backend, y el código que tenga la caché *sin acotar* puede leer cualquier clave. La idea es que el camino ergonómico sea el correcto. |
+| **`clear()` necesita enumerar claves** | Va por `Cache::delete_prefix`. `InMemoryCache` filtra su mapa y `DatabaseCache` lanza un `DELETE … LIKE 'prefix%'`. Un backend que *no* puede enumerar — `FileCache` convierte las claves en rutas con hash — recurre a borrar todo y registra una advertencia. Es deliberado: borrar de menos dejaría que otro namespace leyera una entrada obsoleta, lo cual es un fallo de corrección; borrar de más solo cuesta un fallo de caché. |
+
+El `Cache::clear()` sin acotar sigue siendo global al proceso, así que usa la
+vista acotada siempre que el cambio de un solo tenant sea lo que disparó la
+invalidación.
 
 ---
 

--- a/docs/es/jobs.md
+++ b/docs/es/jobs.md
@@ -37,6 +37,7 @@ es Django-Q / Celery / las colas de Laravel, en Rust.
 - [El handler dead-letter](#the-dead-letter-handler)
 - [La cola persistente (producción)](#the-persistent-queue-production)
 - [Trabajos con multi-tenancy](#jobs-under-multi-tenancy)
+- [Barridos programados con multi-tenancy](#scheduled-sweeps-under-multi-tenancy)
 - [Referencia](#reference)
 - [Véase también](#see-also)
 
@@ -413,6 +414,66 @@ un barrido `reclaim_stuck_jobs_pool` consciente del tenant — iteras sobre los
 tenants tú mismo, como arriba. Los tenants provisionados después del arranque
 no obtienen workers hasta que el proceso se reinicia. Seguimiento en
 [#1223](https://github.com/ujeenet/rustango/issues/1223).
+
+**Tampoco hay contexto ambiental.** Los workers se lanzan con `tokio::spawn`, y
+los task-locals no cruzan un spawn — así que un trabajo corre con la fuente de
+auditoría en `AuditSource::System` y la zona horaria por defecto, sin importar
+lo que hubiera fijado el request que lo despachó. Lleva lo que necesites en el
+payload, o vuelve a entrar en el scope dentro de `run()` con
+`audit::with_source`. Seguimiento en
+[#1229](https://github.com/ujeenet/rustango/issues/1229).
+
+---
+
+## Barridos programados con multi-tenancy
+
+El mismo problema de «un worker no es un request» golpea al trabajo *basado en
+el tiempo*, y los propios helpers de barrido del framework son donde muerde:
+`MediaLibrary::purge_orphans`, `audit::cleanup_older_than_pool` y
+`prunable::prune_all` toman **un solo pool**, y cada tabla que tocan es por
+tenant. Un pool significa un tenant — y un pool del registry en modo esquema
+significa solo `public`, mientras las filas de cada tenant se acumulan y el
+barrido igual informa éxito.
+
+Haz el fan-out con **`for_each_tenant`**, que resuelve el pool propio de cada
+tenant activo y sigue adelante cuando uno falla:
+
+```rust
+use rustango::tenancy::for_each_tenant;
+
+let sweep = for_each_tenant(&pools, |_org, pool| async move {
+    rustango::prunable::prune_all(&pool, &opts).await
+})
+.await?;
+
+tracing::info!(ok = sweep.succeeded(), failed = sweep.failed(), "nightly prune");
+for (slug, err) in sweep.errors() {
+    tracing::warn!(%slug, %err, "tenant prune failed");
+}
+```
+
+Un tenant roto — credencial rotada, base de datos inalcanzable — queda
+registrado en el informe en lugar de abortar la ejecución, de modo que no puede
+dejar sin barrer a los tenants que van después. Las orgs inactivas se omiten.
+`purge_orphans` es el único barrido que sale de la base de datos (borra objetos
+de almacenamiento), así que tiene `purge_orphans_dry_run`: la misma consulta,
+sin borrar nada — vale la pena mirarlo antes de cablear el barrido real.
+
+Si proteges el barrido para que solo una réplica lo ejecute, **acota el lock por
+tenant**:
+
+```rust
+use rustango::distributed_lock::DistributedLock;
+
+let lock = DistributedLock::new(cache.clone()).for_tenant(&org.slug);
+lock.with_lock("nightly_prune", ttl, || async { /* … */ }).await;
+```
+
+Sin acotar, todos los tenants compiten por un único `lock:nightly_prune`: el
+primero gana y el resto se omite durante toda la TTL, en silencio — un acquire
+rechazado es el resultado esperado, así que no se registra nada. Seguimiento en
+[#1226](https://github.com/ujeenet/rustango/issues/1226) y
+[#1228](https://github.com/ujeenet/rustango/issues/1228).
 
 ---
 

--- a/docs/es/jobs.md
+++ b/docs/es/jobs.md
@@ -36,6 +36,7 @@ es Django-Q / Celery / las colas de Laravel, en Rust.
 - [Reintentos y backoff](#retries-and-backoff)
 - [El handler dead-letter](#the-dead-letter-handler)
 - [La cola persistente (producción)](#the-persistent-queue-production)
+- [Trabajos con multi-tenancy](#jobs-under-multi-tenancy)
 - [Referencia](#reference)
 - [Véase también](#see-also)
 
@@ -343,6 +344,78 @@ dogfooding contra SQLite en `jobs_sqlite_live.rs`.
 
 ---
 
+## Trabajos con multi-tenancy
+
+Un worker no es un request. Nada resolvió un tenant para él — ningún host,
+ninguna cabecera, ningún middleware se ejecutó — así que **un trabajo no lleva
+contexto de tenant**: `run(&self)` solo recibe el payload deserializado. El
+aislamiento viene **del pool sobre el que se construyó la cola**, y de ahí sale
+la regla:
+
+> Una cola por pool de tenant. Un id de tenant en el payload es enrutado, no
+> aislamiento.
+
+Esa única decisión es la que hace seguro cada modo:
+
+| Modo | Dónde vive `rustango_jobs` | Por qué un worker permanece acotado |
+|---|---|---|
+| `database` | dentro de la propia base de datos / archivo SQLite del tenant | las filas de otro tenant no están en la tabla que consulta el worker — las lecturas entre tenants no son expresables |
+| `schema` (PG) | en el esquema del tenant | `scoped_pool_dyn` devuelve un pool con `search_path` incorporado en sus **connect options**, no un `SET` por request — así cada checkout queda acotado durante toda la vida del pool, incluido un worker que viva días |
+
+Construye las colas en el arranque, una por tenant activo:
+
+```rust
+use rustango::core::Column as _;
+use rustango::jobs::{DatabaseJobQueue, JobQueue};
+use rustango::sql::FetcherPool as _;
+use rustango::tenancy::{Org, TenantPools};
+use std::sync::Arc;
+use std::time::Duration;
+
+let pools = Arc::new(TenantPools::new(registry));
+let registry_pool = pools.registry_pool();
+
+// The registry holds the tenant list; each `Org` names its own
+// database (or PG schema).
+let orgs: Vec<Org> = Org::objects()
+    .where_(Org::active.eq(true))
+    .fetch(&registry_pool)
+    .await?;
+
+let mut queues = Vec::new();
+for org in orgs {
+    let pool = pools.scoped_pool_dyn(&org).await?;   // scoped for its lifetime
+    DatabaseJobQueue::ensure_table_pool(&pool).await?;
+
+    let queue = Arc::new(
+        DatabaseJobQueue::with_workers_pool(pool, 2)
+            .poll_interval(Duration::from_secs(1)),
+    );
+    queue.register::<WelcomeEmail>().await;
+    queue.start().await;
+    queues.push((org.slug, queue));
+}
+```
+
+El despacho va entonces a la cola *de ese tenant* — en un handler de request, a
+la que está indexada por el `Org` que el resolver ya produjo.
+
+**Qué no hacer.** Una sola cola sobre el pool del registry con un campo
+`org_id` en el payload pone los trabajos de todos los tenants en una tabla
+compartida, y deja a cada `run()` la tarea de acordarse de reacotar. Un solo
+reacotado olvidado es una escritura entre tenants. Si necesitas una cola
+compartida por razones operativas, resuelve el pool del tenant como lo
+*primero* que hace `run()` y no vuelvas a tocar el pool del registry después.
+
+**Límites conocidos.** El framework no hace el fan-out por ti: no hay
+supervisor de workers por tenant, ni `Job::run(&ctx)` con el tenant adjunto, ni
+un barrido `reclaim_stuck_jobs_pool` consciente del tenant — iteras sobre los
+tenants tú mismo, como arriba. Los tenants provisionados después del arranque
+no obtienen workers hasta que el proceso se reinicia. Seguimiento en
+[#1223](https://github.com/ujeenet/rustango/issues/1223).
+
+---
+
 ## Referencia
 
 **Backends**
@@ -375,3 +448,5 @@ dogfooding contra SQLite en `jobs_sqlite_live.rs`.
 - [Caché](caching.md) — la otra manera de mantener rápidos los handlers de
   peticiones.
 - [Signals](orm.md) — hooks fire-and-forget que a menudo *despachan* un trabajo.
+- [Comandos de tenancy](manage.md#tenancy-commands) — el provisionamiento de los
+  tenants sobre los que una cola por tenant hace fan-out.

--- a/docs/es/jobs.md
+++ b/docs/es/jobs.md
@@ -429,7 +429,7 @@ payload, o vuelve a entrar en el scope dentro de `run()` con
 
 El mismo problema de «un worker no es un request» golpea al trabajo *basado en
 el tiempo*, y los propios helpers de barrido del framework son donde muerde:
-`MediaLibrary::purge_orphans`, `audit::cleanup_older_than_pool` y
+`MediaManager::purge_orphans`, `audit::cleanup_older_than_pool` y
 `prunable::prune_all` toman **un solo pool**, y cada tabla que tocan es por
 tenant. Un pool significa un tenant — y un pool del registry en modo esquema
 significa solo `public`, mientras las filas de cada tenant se acumulan y el
@@ -441,8 +441,9 @@ tenant activo y sigue adelante cuando uno falla:
 ```rust
 use rustango::tenancy::for_each_tenant;
 
-let sweep = for_each_tenant(&pools, |_org, pool| async move {
-    rustango::prunable::prune_all(&pool, &opts).await
+let opts = &opts;
+let sweep = for_each_tenant(&pools, move |_org, pool| async move {
+    rustango::prunable::prune_all(&pool, opts).await
 })
 .await?;
 

--- a/docs/fr/caching.md
+++ b/docs/fr/caching.md
@@ -32,6 +32,7 @@ Django ou la façade `Cache` de Laravel.
 - [Valeurs JSON typées](#typed-json-values)
 - [TTL et expiration](#ttl-and-expiry)
 - [Changer de backend](#swapping-backends)
+- [La mise en cache en multi-tenancy](#caching-under-multi-tenancy)
 - [Référence](#reference)
 - [Voir aussi](#see-also)
 
@@ -169,6 +170,45 @@ let cache: BoxedCache = std::sync::Arc::new(RedisCache::new("redis://localhost")
 ```
 
 Les mêmes appels `get` / `set` / `get_or_set` — seul le constructeur a changé.
+
+---
+
+## La mise en cache en multi-tenancy
+
+`Cache` est un magasin plat indexé par `&str`, ce qui en multi-tenancy fait de
+la clé naturelle la clé qui fuit : un handler — ou pire une tâche d'arrière-plan,
+qui n'a aucun tenant ambiant où puiser — écrit `"stats:monthly"` pour un tenant
+et tous les autres le relisent.
+
+Enveloppez le cache partagé dans un **`ScopedCache`** pour que l'espace de noms
+soit appliqué à votre place et que le site d'appel ne puisse pas l'oublier :
+
+```rust
+use rustango::cache::ScopedCache;
+
+// From the Org the resolver already produced:
+let cache = ScopedCache::for_tenant(shared.clone(), &t.org.slug);
+
+cache.set("stats:monthly", &json, ttl).await?;   // stored as tenant:acme:stats:monthly
+cache.get("stats:monthly").await?;               // reads only acme's entry
+cache.clear().await?;                            // drops ONLY acme's entries
+```
+
+`ScopedCache` est lui-même un `Cache`, il se glisse donc partout où un
+`BoxedCache` est attendu — `cache_page`, `cache_fragment`, les rate limiters,
+`DistributedLock`. Il transmet au backend interne avec les clés remappées plutôt
+que de réimplémenter quoi que ce soit, si bien que les primitives natives (Redis
+`INCRBY`, `SET NX`, `MGET`) gardent leur atomicité et leur traitement par lots.
+
+Deux choses à savoir :
+
+| | |
+|---|---|
+| **C'est un espace de noms, pas une frontière** | Tout vit encore dans un seul backend, et du code détenant le cache *non cadré* peut lire n'importe quelle clé. L'idée est que le chemin ergonomique soit le chemin correct. |
+| **`clear()` a besoin d'énumérer les clés** | Il passe par `Cache::delete_prefix`. `InMemoryCache` filtre sa map et `DatabaseCache` émet un `DELETE … LIKE 'prefix%'`. Un backend qui ne *peut pas* énumérer — `FileCache` hache les clés en chemins — se rabat sur un vidage complet et journalise un avertissement. C'est délibéré : trop peu supprimer laisserait un autre espace de noms lire une entrée périmée, ce qui est un bug de correction ; trop supprimer ne coûte qu'un défaut de cache. |
+
+Le `Cache::clear()` non cadré reste global au processus : utilisez la vue cadrée
+dès que c'est le changement d'un seul tenant qui a déclenché l'invalidation.
 
 ---
 

--- a/docs/fr/jobs.md
+++ b/docs/fr/jobs.md
@@ -436,7 +436,7 @@ qu'il vous faut dans le payload, ou ré-entrez le scope dans `run()` avec
 
 Le même problème — « un worker n'est pas une requête » — frappe le travail
 *basé sur le temps*, et les helpers de balayage du framework sont l'endroit où
-ça mord : `MediaLibrary::purge_orphans`, `audit::cleanup_older_than_pool` et
+ça mord : `MediaManager::purge_orphans`, `audit::cleanup_older_than_pool` et
 `prunable::prune_all` prennent chacun **un seul pool**, et chaque table qu'ils
 touchent est par tenant. Un pool veut dire un tenant — et un pool du registry en
 mode schéma veut dire seulement `public`, pendant que les lignes de chaque
@@ -448,8 +448,9 @@ chaque tenant actif et continue quand l'un échoue :
 ```rust
 use rustango::tenancy::for_each_tenant;
 
-let sweep = for_each_tenant(&pools, |_org, pool| async move {
-    rustango::prunable::prune_all(&pool, &opts).await
+let opts = &opts;
+let sweep = for_each_tenant(&pools, move |_org, pool| async move {
+    rustango::prunable::prune_all(&pool, opts).await
 })
 .await?;
 

--- a/docs/fr/jobs.md
+++ b/docs/fr/jobs.md
@@ -37,6 +37,7 @@ de Laravel, en Rust.
 - [Le handler dead-letter](#the-dead-letter-handler)
 - [La file persistante (production)](#the-persistent-queue-production)
 - [Les tâches en multi-tenancy](#jobs-under-multi-tenancy)
+- [Les balayages planifiés en multi-tenancy](#scheduled-sweeps-under-multi-tenancy)
 - [Référence](#reference)
 - [Voir aussi](#see-also)
 
@@ -420,6 +421,66 @@ vous itérez vous-même sur les tenants, comme ci-dessus. Les tenants
 provisionnés après le démarrage n'ont aucun worker jusqu'au redémarrage du
 processus. Suivi dans
 [#1223](https://github.com/ujeenet/rustango/issues/1223).
+
+**Pas de contexte ambiant non plus.** Les workers sont lancés par
+`tokio::spawn`, et les task-locals ne traversent pas un spawn — une tâche
+s'exécute donc avec la source d'audit à `AuditSource::System` et le fuseau
+horaire par défaut, quoi qu'ait posé la requête qui l'a dispatchée. Emportez ce
+qu'il vous faut dans le payload, ou ré-entrez le scope dans `run()` avec
+`audit::with_source`. Suivi dans
+[#1229](https://github.com/ujeenet/rustango/issues/1229).
+
+---
+
+## Les balayages planifiés en multi-tenancy
+
+Le même problème — « un worker n'est pas une requête » — frappe le travail
+*basé sur le temps*, et les helpers de balayage du framework sont l'endroit où
+ça mord : `MediaLibrary::purge_orphans`, `audit::cleanup_older_than_pool` et
+`prunable::prune_all` prennent chacun **un seul pool**, et chaque table qu'ils
+touchent est par tenant. Un pool veut dire un tenant — et un pool du registry en
+mode schéma veut dire seulement `public`, pendant que les lignes de chaque
+tenant s'accumulent et que le balayage annonce quand même une réussite.
+
+Faites le fan-out avec **`for_each_tenant`**, qui résout le pool propre à
+chaque tenant actif et continue quand l'un échoue :
+
+```rust
+use rustango::tenancy::for_each_tenant;
+
+let sweep = for_each_tenant(&pools, |_org, pool| async move {
+    rustango::prunable::prune_all(&pool, &opts).await
+})
+.await?;
+
+tracing::info!(ok = sweep.succeeded(), failed = sweep.failed(), "nightly prune");
+for (slug, err) in sweep.errors() {
+    tracing::warn!(%slug, %err, "tenant prune failed");
+}
+```
+
+Un tenant cassé — identifiant tourné, base injoignable — est consigné dans le
+rapport au lieu d'interrompre le run, et ne peut donc pas priver les tenants
+suivants. Les orgs inactives sont ignorées. `purge_orphans` est le seul
+balayage qui sort de la base (il supprime des objets de stockage), d'où
+`purge_orphans_dry_run` : la même requête, sans rien supprimer — à regarder
+avant de câbler le vrai balayage.
+
+Si vous protégez le balayage pour qu'une seule réplique l'exécute, **cadrez le
+verrou par tenant** :
+
+```rust
+use rustango::distributed_lock::DistributedLock;
+
+let lock = DistributedLock::new(cache.clone()).for_tenant(&org.slug);
+lock.with_lock("nightly_prune", ttl, || async { /* … */ }).await;
+```
+
+Non cadré, tous les tenants se disputent un unique `lock:nightly_prune` : le
+premier gagne et les autres sont ignorés pendant toute la TTL, en silence — un
+acquire refusé est le résultat attendu, donc rien n'est journalisé. Suivi dans
+[#1226](https://github.com/ujeenet/rustango/issues/1226) et
+[#1228](https://github.com/ujeenet/rustango/issues/1228).
 
 ---
 

--- a/docs/fr/jobs.md
+++ b/docs/fr/jobs.md
@@ -36,6 +36,7 @@ de Laravel, en Rust.
 - [Nouvelles tentatives et backoff](#retries-and-backoff)
 - [Le handler dead-letter](#the-dead-letter-handler)
 - [La file persistante (production)](#the-persistent-queue-production)
+- [Les tâches en multi-tenancy](#jobs-under-multi-tenancy)
 - [Référence](#reference)
 - [Voir aussi](#see-also)
 
@@ -348,6 +349,80 @@ dogfooding contre SQLite dans `jobs_sqlite_live.rs`.
 
 ---
 
+## Les tâches en multi-tenancy
+
+Un worker n'est pas une requête. Rien n'a résolu de tenant pour lui — aucun
+host, aucun en-tête, aucun middleware ne s'est exécuté — donc **une tâche ne
+porte aucun contexte de tenant** : `run(&self)` ne reçoit que le payload
+désérialisé. L'isolation vient **du pool sur lequel la file a été construite**,
+et la règle en découle :
+
+> Une file par pool de tenant. Un id de tenant dans le payload, c'est du
+> routage, pas de l'isolation.
+
+C'est cette seule décision qui rend chaque mode sûr :
+
+| Mode | Où vit `rustango_jobs` | Pourquoi un worker reste cadré |
+|---|---|---|
+| `database` | dans la base de données / le fichier SQLite propre au tenant | les lignes d'un autre tenant ne sont pas dans la table que le worker interroge — les lectures inter-tenants ne sont pas exprimables |
+| `schema` (PG) | dans le schéma du tenant | `scoped_pool_dyn` renvoie un pool dont les **connect options** embarquent `search_path`, et non un `SET` par requête — chaque checkout est donc cadré pour toute la durée de vie du pool, y compris pour un worker qui vit des jours |
+
+Construisez les files au démarrage, une par tenant actif :
+
+```rust
+use rustango::core::Column as _;
+use rustango::jobs::{DatabaseJobQueue, JobQueue};
+use rustango::sql::FetcherPool as _;
+use rustango::tenancy::{Org, TenantPools};
+use std::sync::Arc;
+use std::time::Duration;
+
+let pools = Arc::new(TenantPools::new(registry));
+let registry_pool = pools.registry_pool();
+
+// The registry holds the tenant list; each `Org` names its own
+// database (or PG schema).
+let orgs: Vec<Org> = Org::objects()
+    .where_(Org::active.eq(true))
+    .fetch(&registry_pool)
+    .await?;
+
+let mut queues = Vec::new();
+for org in orgs {
+    let pool = pools.scoped_pool_dyn(&org).await?;   // scoped for its lifetime
+    DatabaseJobQueue::ensure_table_pool(&pool).await?;
+
+    let queue = Arc::new(
+        DatabaseJobQueue::with_workers_pool(pool, 2)
+            .poll_interval(Duration::from_secs(1)),
+    );
+    queue.register::<WelcomeEmail>().await;
+    queue.start().await;
+    queues.push((org.slug, queue));
+}
+```
+
+Le dispatch part alors vers la file *de ce tenant* — dans un handler de
+requête, celle indexée par l'`Org` que le resolver a déjà produit.
+
+**Ce qu'il ne faut pas faire.** Une seule file sur le pool du registry avec un
+champ `org_id` dans le payload met les tâches de tous les tenants dans une
+table partagée, et laisse chaque `run()` se souvenir de re-cadrer. Un seul
+re-cadrage oublié est une écriture inter-tenants. S'il vous faut une file
+partagée pour des raisons opérationnelles, résolvez le pool du tenant comme
+*première* chose que fait `run()`, et ne touchez plus au pool du registry
+ensuite.
+
+**Limites connues.** Le framework ne fait pas le fan-out pour vous : pas de
+superviseur de workers par tenant, pas de `Job::run(&ctx)` avec le tenant
+attaché, et pas de balayage `reclaim_stuck_jobs_pool` conscient du tenant —
+vous itérez vous-même sur les tenants, comme ci-dessus. Les tenants
+provisionnés après le démarrage n'ont aucun worker jusqu'au redémarrage du
+processus. Suivi dans
+[#1223](https://github.com/ujeenet/rustango/issues/1223).
+
+---
+
 ## Référence
 
 **Backends**
@@ -382,3 +457,5 @@ dogfooding contre SQLite dans `jobs_sqlite_live.rs`.
   requêtes rapides.
 - [Signals](orm.md) — des hooks fire-and-forget qui *dispatchent* souvent une
   tâche.
+- [Commandes de tenancy](manage.md#tenancy-commands) — le provisionnement des
+  tenants sur lesquels une file par tenant fait son fan-out.

--- a/docs/fr/sso.md
+++ b/docs/fr/sso.md
@@ -1,9 +1,9 @@
-# SSO admin (OpenID Connect / connexion sociale)
+# SSO (OpenID Connect / connexion sociale)
 
-Connectez-vous à l'admin rustango avec un fournisseur d'identité externe —
-Google, Microsoft / Azure AD, GitHub, GitLab, Discord, ou **n'importe quel
+Connectez-vous avec un fournisseur d'identité externe — Google,
+Microsoft / Azure AD, GitHub, GitLab, Discord, ou **n'importe quel
 fournisseur OpenID Connect** (Okta, Auth0, Keycloak, …) — au lieu d'un
-mot de passe local. Activez-le avec la fonctionnalité cargo `admin-sso`.
+mot de passe local.
 
 Vous pouvez configurer **plusieurs providers**, chacun géré depuis
 l'interface d'admin comme une ligne (pas de fichier de configuration, pas
@@ -12,15 +12,53 @@ découverts automatiquement à partir de son URL d'émetteur (issuer) OIDC
 lors de la connexion ; les providers sociaux utilisent des préréglages
 intégrés.
 
-Le SSO fonctionne en **liaison à un compte existant** : l'email vérifié
-renvoyé par l'IdP doit correspondre à un utilisateur admin existant. Le
-SSO authentifie la personne ; il ne crée jamais de comptes et n'accorde
-jamais d'accès par lui-même. Un email inconnu ou non vérifié est refusé.
+Pour l'admin, le SSO fonctionne en **liaison à un compte existant** :
+l'email vérifié renvoyé par l'IdP doit correspondre à un utilisateur
+admin existant. Il authentifie la personne ; il ne crée jamais de comptes
+et n'accorde jamais d'accès par lui-même. Un email inconnu ou non vérifié
+est refusé. (Le flux membre, ci-dessous, peut opter pour le
+provisionnement automatique.)
+
+> **Source :** le cœur `rustango::sso`, indépendant de l'admin
+> (`SsoProvider`, `build_provider`, `verified_email`, `ResolvedSso`,
+> `SsoError`), le câblage bare-admin `rustango::admin::sso`, le SSO
+> par tenant / console `rustango::tenancy::sso`
+> (`SharedSsoProvider`), et le SSO membre
+> `rustango::tenancy::member_auth`.
+
+## Fonctionnalités et qui les utilise
+
+Depuis la **0.49**, le cœur SSO est sa propre fonctionnalité, indépendante
+de l'auto-admin, si bien qu'une connexion d'utilisateur final (membre)
+peut se compiler sans tirer `crate::admin` :
+
+| Fonctionnalité | Tire | Vous donne |
+|---|---|---|
+| `sso` | `oauth2`, `casts` | Le cœur indépendant de l'admin : `rustango::sso` — la poignée de main OIDC / OAuth social, le modèle `SsoProvider` adossé à la base (secret chiffré au repos via `casts`), et le flux membre (`tenancy::member_auth`, avec `tenancy`). |
+| `admin-sso` | `admin`, `sso` | Ce qui précède **plus** le câblage de connexion bare-admin (`rustango::admin::sso`) — les boutons SSO sur la page de connexion de l'admin, qui émettent la session admin. |
 
 ```toml
 [dependencies]
-rustango = { version = "0.48", features = ["admin-sso"] }
+# Connexion admin avec SSO :
+rustango = { version = "0.52", features = ["admin-sso"] }
+# SSO membre (utilisateur final) sans l'auto-admin :
+rustango = { version = "0.52", features = ["tenancy", "sso"] }
 ```
+
+`admin::sso_provider` et les anciens chemins du cœur `admin::sso::*` sont
+désormais des **shims de ré-export** au-dessus de `sso::provider` /
+`sso::*`, donc les imports existants
+`crate::admin::sso::{build_provider, ResolvedSso, …}` et
+`crate::admin::sso_provider::SsoProvider` continuent de résoudre
+inchangés (le nom de table `rustango_sso_providers` et tous ses champs
+sont intacts — les migrations ne sont pas affectées).
+
+L'email sur lequel un utilisateur est lié est la colonne `email`. Sur le
+modèle `User` du tenant, elle est conditionnée à la fonctionnalité
+**`sso`** (déplacée hors de `admin-sso` en 0.49, pour que les builds
+membre-SSO-seul obtiennent quand même la colonne) ; le `AdminUser.email`
+nu reste derrière `admin-sso`. Activer ou désactiver la fonctionnalité
+émet une migration `AddColumn` / `DropColumn` pour cette colonne.
 
 ## Comment ça fonctionne
 
@@ -93,6 +131,82 @@ L'URL de callback est dérivée par requête à partir de l'hôte + du slug
 faut enregistrer auprès de l'IdP. Liez un utilisateur en définissant la
 colonne `email` sur sa ligne `rustango_users` (tenant) /
 `rustango_admin_users` (nu) à l'adresse renvoyée par l'IdP.
+
+## SSO membre (utilisateur final)
+
+Les surfaces ci-dessus connectent des personnes à un **admin**.
+`tenancy::member_auth` en est l'équivalent côté membre : il connecte un
+utilisateur final au pool d'utilisateurs propre au tenant
+(`rustango_users`) et émet une **session membre**, pour qu'un adhérent de
+salle de sport / client SaaS puisse « Se connecter avec Google » sans
+toucher à l'admin. Il réutilise exactement le même cœur `rustango::sso`
+et les lignes `SsoProvider` du tenant — seule la session émise diffère,
+d'où le fait qu'il vive derrière la fonctionnalité `sso` (et non
+`admin-sso`) et n'ait besoin d'aucun auto-admin.
+
+Montez `member_sso_router` dans une pile `tenancy::server::Builder` (il
+lit l'`Arc<TenantContext>` résolu que le builder injecte) :
+
+```rust
+use rustango::tenancy::member_auth::{member_sso_router, MemberAuthConfig};
+
+let members = member_sso_router(MemberAuthConfig {
+    login_base:     "/auth".into(),   // buttons link to /auth/sso/<slug>
+    landing_url:    "/".into(),       // post-login destination (honors a same-origin ?next)
+    auto_provision: true,             // create a user from a verified email on first sign-in
+    session_ttl:    7 * 24 * 60 * 60, // 7 days
+    ..Default::default()
+});
+```
+
+Il monte deux routes par slug sous `login_base` :
+
+- `GET {login_base}/sso/{slug}` — démarrer la poignée de main, rediriger
+  vers l'IdP.
+- `GET {login_base}/sso/{slug}/callback` — la terminer, trouver ou
+  provisionner le membre, émettre le cookie de session.
+
+Différences avec le flux admin :
+
+- **Provisionnement automatique.** Avec `auto_provision = true` (le
+  défaut), un email IdP vérifié sans ligne `rustango_users`
+  correspondante en **crée** une — nom d'utilisateur issu de la partie
+  locale de l'email (dédupliqué en cas de collision), avec un hash de mot
+  de passe aléatoire réel mais inutilisable (les utilisateurs SSO ne
+  peuvent pas se connecter par mot de passe). Mettez-le à `false` pour
+  une liaison à un compte existant à la manière de l'admin (email inconnu
+  refusé).
+- **Son propre cookie de session.** Le cookie membre
+  (`rustango_member_session`) est **séparé par domaine** des cookies de
+  session tenant / admin : le message signé porte une étiquette
+  par domaine et une revendication d'audience, si bien qu'un cookie
+  membre ne peut jamais valider comme cookie tenant/admin (ni
+  l'inverse), même si les deux sont signés avec
+  `RUSTANGO_SESSION_SECRET`. Il est lié au slug (un cookie émis pour
+  `acme` n'authentifie jamais sur `globex`) et invalidé par une rotation
+  de mot de passe (parité avec la session admin).
+
+Lisez le membre courant dans un handler avec l'extracteur
+**`CurrentMember`** — l'équivalent membre de `SessionUser`. Il est
+infaillible (`None` pour les sessions anonymes / expirées / invalidées
+par rotation / inter-tenants), donc il se compose avec les routes
+publiques :
+
+```rust
+use rustango::tenancy::member_auth::CurrentMember;
+
+async fn dashboard(CurrentMember(member): CurrentMember) -> impl axum::response::IntoResponse {
+    match member {
+        Some(user) => format!("Hi, {}", user.username),
+        None => "Please sign in".to_owned(),
+    }
+}
+```
+
+> **Périmètre v1.** Le SSO membre résout les providers uniquement depuis
+> les lignes `SsoProvider` du tenant — la fusion avec le
+> `SharedSsoProvider` à l'échelle du registry et un hook `provision`
+> personnalisé sont des suites.
 
 ## Stockage des secrets
 

--- a/docs/index.toml
+++ b/docs/index.toml
@@ -5,7 +5,7 @@
 # becomes one documentation page, rendered in the order listed here. Files
 # not listed below are not published (e.g. internal audits / inventories).
 
-version = "0.51"
+version = "0.52"
 
 [[section]]
 title = "Getting started"

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -35,6 +35,7 @@ failures. This is Django-Q / Celery / Laravel queues, in Rust.
 - [The dead-letter handler](#the-dead-letter-handler)
 - [The persistent queue (production)](#the-persistent-queue-production)
 - [Jobs under multi-tenancy](#jobs-under-multi-tenancy)
+- [Scheduled sweeps under multi-tenancy](#scheduled-sweeps-under-multi-tenancy)
 - [Reference](#reference)
 - [See also](#see-also)
 
@@ -401,6 +402,64 @@ and no tenant-aware `reclaim_stuck_jobs_pool` sweep — you loop over tenants
 yourself, as above. New tenants provisioned after boot get no workers until
 the process restarts. Tracked in
 [#1223](https://github.com/ujeenet/rustango/issues/1223).
+
+**No ambient context, either.** Workers are `tokio::spawn`ed, and task-locals
+do not cross a spawn — so a job runs with the audit source at
+`AuditSource::System` and the default timezone, no matter what the dispatching
+request had set. Carry what you need in the payload, or re-enter the scope
+inside `run()` with `audit::with_source`. Tracked in
+[#1229](https://github.com/ujeenet/rustango/issues/1229).
+
+---
+
+## Scheduled sweeps under multi-tenancy
+
+The same "a worker is not a request" problem hits *time-based* work, and the
+framework's own sweep helpers are where it bites: `MediaLibrary::purge_orphans`,
+`audit::cleanup_older_than_pool` and `prunable::prune_all` each take **one
+pool**, and every table they touch is per-tenant. One pool means one tenant —
+and a registry pool in schema mode means only `public`, while every tenant's
+rows accumulate and the sweep still reports success.
+
+Fan out with **`for_each_tenant`**, which resolves each active tenant's own
+pool and keeps going when one tenant fails:
+
+```rust
+use rustango::tenancy::for_each_tenant;
+
+let sweep = for_each_tenant(&pools, |_org, pool| async move {
+    rustango::prunable::prune_all(&pool, &opts).await
+})
+.await?;
+
+tracing::info!(ok = sweep.succeeded(), failed = sweep.failed(), "nightly prune");
+for (slug, err) in sweep.errors() {
+    tracing::warn!(%slug, %err, "tenant prune failed");
+}
+```
+
+A broken tenant — rotated credential, unreachable database — is recorded in the
+report rather than aborting the run, so it cannot starve the tenants after it.
+Inactive orgs are skipped. `purge_orphans` is the one sweep that reaches outside
+the database (it deletes storage objects), so it has a
+`purge_orphans_dry_run` that runs the same query and deletes nothing — worth a
+look before you wire the real thing.
+
+If you guard the sweep so only one replica runs it, **scope the lock per
+tenant**:
+
+```rust
+use rustango::distributed_lock::DistributedLock;
+
+let lock = DistributedLock::new(cache.clone()).for_tenant(&org.slug);
+lock.with_lock("nightly_prune", ttl, || async { /* … */ }).await;
+```
+
+Unscoped, every tenant contends for one `lock:nightly_prune`: the first tenant
+wins and the rest are skipped for the whole TTL, silently — a refused acquire is
+the expected outcome, so nothing is logged. Tracked in
+[#1226](https://github.com/ujeenet/rustango/issues/1226) and
+[#1228](https://github.com/ujeenet/rustango/issues/1228).
 
 ---
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -415,7 +415,7 @@ inside `run()` with `audit::with_source`. Tracked in
 ## Scheduled sweeps under multi-tenancy
 
 The same "a worker is not a request" problem hits *time-based* work, and the
-framework's own sweep helpers are where it bites: `MediaLibrary::purge_orphans`,
+framework's own sweep helpers are where it bites: `MediaManager::purge_orphans`,
 `audit::cleanup_older_than_pool` and `prunable::prune_all` each take **one
 pool**, and every table they touch is per-tenant. One pool means one tenant —
 and a registry pool in schema mode means only `public`, while every tenant's
@@ -427,8 +427,9 @@ pool and keeps going when one tenant fails:
 ```rust
 use rustango::tenancy::for_each_tenant;
 
-let sweep = for_each_tenant(&pools, |_org, pool| async move {
-    rustango::prunable::prune_all(&pool, &opts).await
+let opts = &opts;
+let sweep = for_each_tenant(&pools, move |_org, pool| async move {
+    rustango::prunable::prune_all(&pool, opts).await
 })
 .await?;
 


### PR DESCRIPTION
Closes #1226, #1227, #1228. Refs #1229.

> **Base is `fix/scaffolder-toolchain-1230`, not `develop`.** The docs commit
> edits the "Jobs under multi-tenancy" section added by `dc4c30e4`, which lives
> on that branch. Retarget to `develop` once it lands (or merge it first).

The remaining findings from the multi-tenant background-work audit that produced
#1224 / #1225.

## #1226 — per-tenant sweep fan-out

Every "run this from the scheduler" helper takes **one pool**:
`MediaLibrary::purge_orphans`, `audit::cleanup_older_than_pool`,
`prunable::prune_all`. Under tenancy each of those tables is per-tenant, so a
sweep on one pool cleans one tenant — on a registry pool in schema mode, only
`public` — while every other tenant's rows accumulate forever and the sweep
still reports success. `Scheduler::every` takes `Fn() -> Future` with no
context, so there is nowhere for a tenant to come from.

`tenancy::for_each_tenant` is the missing loop. Two choices worth calling out:

- **It never short-circuits.** A tenant whose pool won't resolve, or whose
  closure errors, is recorded and the loop continues. `?` here would let one
  rotated credential starve every tenant after it in the list.
- **It is sequential.** Sweeps compete with request traffic for the same
  upstream; opening N tenant pools at once is how a nightly prune becomes an
  incident. `active_tenants` is public for callers who want their own
  concurrency.

`purge_orphans` is the only sweep that reaches outside the database, so it gains
`purge_orphans_dry_run`, sharing the query with the real path so the two can't
drift.

## #1227 — `ScopedCache` + `Cache::delete_prefix`

`Cache` is flat and `&str`-keyed, which under tenancy makes the natural key the
leaky key. `ScopedCache` folds a namespace into every key so the call site can't
forget, and is itself a `Cache` so it drops into `cache_page`, the rate
limiters, `DistributedLock`. It forwards to the inner backend with mapped keys
rather than using the trait defaults — the defaults would be correct (they route
through `self`) but would flatten Redis `INCRBY` / `SET NX` / `MGET` into
non-atomic per-key loops.

`clear()` was the other half: process-global, so a per-tenant invalidation wiped
everyone. It now routes through `Cache::delete_prefix`, whose default
deliberately **over-deletes** (clears everything, warns) — a backend that can't
enumerate keys has two options and only one is safe: under-deleting leaves a
stale entry another namespace can read, which is a correctness bug, while
over-deleting costs a cache miss. `FileCache` is the concrete case, since it
hashes keys into paths.

**The `LIKE` needed real cross-dialect work, and the first version was wrong.**
`%` and `_` in a prefix must be escaped or one namespace's clear sweeps a
neighbour's rows. I first used a backslash escape; it passed on SQLite and
Postgres and **failed on MySQL** with `1064 … syntax error near ''\\''`, because
MySQL treats `\` as an escape *inside string literals* so `ESCAPE '\'` is
unterminated. It now uses `ESCAPE '!'`, which needs no escaping in any of the
three, with `!` itself doubled in the pattern.

## #1228 — tenant-scoped lock keys

Keys were `lock:<name>` with no tenant, while the module docs recommend pairing
the lock with the scheduler. Follow that in a multi-tenant app and every tenant
contends for one `lock:daily_report`: the first wins, the rest are skipped for
the whole TTL, silently — a refused acquire is the documented expected outcome,
so nothing is logged. `for_tenant(slug)` folds the tenant in, matching the
`tenant:{slug}:…` convention `tenancy::auth_routes` already uses for lockout
keys. Additive; the unscoped form is still right for process-wide work.

## #1229 — documentation only

Ambient `task_local!` scopes (audit source, timezone, admin session, signals)
don't cross a `tokio::spawn`, so a job runs as `AuditSource::System` with the
default timezone. **Nothing crosses a tenant boundary** — task-locals fail
closed, a spawned task gets the default, never another request's value. So this
is a lost-attribution gap, not a leak, and the propagation half belongs with
#1223's `JobContext` where the envelope field and re-entry point already have to
exist. Documented on `Job::run` and `Scheduler::every`.

## Tests

- **SQLite live** (`tenant_sweep_sqlite_live.rs`): every active tenant visited
  against its own pool — each tenant's database ends up holding only its own row
  and the inactive org is skipped; and a tenant with an unopenable database is
  recorded as a pool failure while the tenants before **and after** it still run.
- **Tri-dialect** `delete_prefix`: SQLite in `cache_db_backend_sqlite_live.rs`,
  Postgres + MySQL in the new `cache_delete_prefix_live.rs` (skipping when
  `DATABASE_URL` / `MYSQL_TEST_URL` are unset). Both wildcards, the literal
  escape character, and slug-prefix overlap (`acme` must not sweep `acme-corp`).
- **Unit**: 7 `ScopedCache` tests (isolation, scoped clear, prefix overlap,
  unprefixed `get_many` keys, namespaced counters and deletes, `NullCache`
  no-op), 4 lock tests including one pinning the *unscoped* behaviour so the
  distinction stays deliberate.

Verification: 3448 lib tests pass; `cargo test --workspace --all-features
--no-run` clean; `--no-default-features --features sqlite,tenancy` litmus builds;
clippy reports nothing on the new files. MySQL was run locally on 3406 and
Postgres on 5432.

## Docs

English + de/es/fr in one commit so the locales can't drift again — the
`caching.md` and `jobs.md` sections, verified to match on h2 count, anchor list,
fence count and table shapes, with the repo-wide h2 sweep clean.

## Deliberately not done

The `manage check --deploy` lint for "a queue/sweep built on the registry pool
while tenancy is on" that #1223 and #1226 both sketch. It needs the `check`
surface and is better done once, with #1223.
