### PR TITLE
fix: FileCache TTL precision, tracing target namespace, and two supply-chain gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,35 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
 
+  # The job above runs at the repo root, so it only ever sees the
+  # workspace lockfile — `examples/` sits outside `members = ["crates/*"]`
+  # and was invisible to it. That is how the quinn-proto advisory in #1236
+  # reached us via a Dependabot alert instead of a failing build (#1237).
+  #
+  # Advisories only, deliberately: the example crates are unpublished and
+  # carry no `license` field, so `check licenses` fails them as
+  # `unlicensed` for reasons that have nothing to do with security.
+  deny-examples:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        manifest:
+          - examples/showcase/Cargo.toml
+          - crates/rustango/examples/admin_demo/Cargo.toml
+          - crates/rustango/examples/auth_demo/Cargo.toml
+          - crates/rustango/examples/cookbook_blog/Cargo.toml
+          - crates/rustango/examples/getting_started_blog/Cargo.toml
+          - crates/rustango/examples/mcp_demo/Cargo.toml
+          - crates/rustango/examples/orm_cookbook/Cargo.toml
+          - crates/rustango/examples/tenant_user_extension/Cargo.toml
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          manifest-path: ${{ matrix.manifest }}
+          command: check advisories
+
   # Trivy security scan — the non-bypassable "detect vulnerabilities
   # before releases" gate. Complements `deny` (RustSec advisories) with
   # a broader vuln DB (GHSA), plus committed-secret and IaC/misconfig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,37 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
   the `JobContext` work in #1223.
 
 ### Fixed
+- **`FileCache` entries could expire the instant they were written** (#1233).
+  The on-disk header stamped `expires_at` in whole **seconds** and expired on
+  `now >= expires_at`, so a `set` landing at wall-clock `T.999` was already
+  expired by the read a millisecond later — a 1-second TTL that lived for one
+  millisecond. Sub-second TTLs were unrepresentable for the same reason:
+  `Duration::from_millis(500).as_secs()` is `0`, so the entry was born expired,
+  while `InMemoryCache` (which stores an `Instant`) handled the same API
+  correctly. The header is now epoch **milliseconds** and expiry is `>`, so an
+  entry lives for the full duration it was promised.
+
+  The header is the same 8 bytes, but its unit changed: entries written by an
+  older build decode as long-past and are dropped as expired, costing one cold
+  read per stale key on upgrade — the safe direction for a cache.
+
+- **48 `tracing` call sites were invisible to `RUST_LOG=rustango=…`** (#1234).
+  They passed `target: "crate::…"` — a literal string, not a path that expands —
+  so they sat in a namespace no realistic filter matches. Several were the only
+  diagnostic for a failure the framework deliberately swallows, including the
+  #1224 connection-reset path, the pre-warm cap warning, and `for_each_tenant`
+  skipping a tenant whose pool would not resolve. All six `tenancy/` files now
+  use `rustango::…`, matching the 60 sites that already did, and a test fails the
+  build if the literal form reappears.
+
+- **`quinn-proto` bumped to 0.11.15 in `examples/showcase/Cargo.lock`** (#1236),
+  closing the high-severity [GHSA-4w2j-m93h-cj5j](https://github.com/advisories/GHSA-4w2j-m93h-cj5j)
+  Dependabot alert (remote memory exhaustion via unbounded out-of-order stream
+  reassembly). Lockfile-only, and confined to the example — `examples/` is
+  outside the workspace, so nothing published to crates.io resolved through this
+  pin. The same refresh corrects a stale `rpassword 7.5.0` back to the `=7.3.1`
+  the workspace pins.
+
 - **Schema-mode tenancy leaked `search_path` between registry-pool borrowers**
   (#1224). `TenantPools::acquire` issues a session-level
   `SET search_path TO <schema>, public` on a connection borrowed from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,32 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
   pin. The same refresh corrects a stale `rpassword 7.5.0` back to the `=7.3.1`
   the workspace pins.
 
+- **`cargo deny` scanned neither optional features nor the one committed example
+  lockfile** (#1237).
+
+  `deny.toml` had `all-features = false`, so nothing behind an optional feature
+  was ever checked — the whole MySQL backend included — and an advisory in an
+  optional dependency would have gone unreported. It also left the
+  `RUSTSEC-2023-0071` ignore reporting as unmatched, since `rsa` only enters the
+  graph once `mysql` is on. Now `all-features = true`, verified clean across
+  advisories, bans, licenses and sources.
+
+  The CI `deny` job also ran only at the repo root. `examples/showcase` is
+  outside `members = ["crates/*"]` **and** is the only committed lockfile in the
+  repo, so it was both invisible to `deny` and the one place a stale pin can
+  actually persist — which is exactly how #1236 reached us as a Dependabot alert
+  rather than a failing build. A `deny-examples` matrix now gates it, along with
+  the other example manifests. Advisories-only: those crates are unpublished and
+  carry no `license` field, so `check licenses` fails them as `unlicensed` for
+  reasons unrelated to security.
+
+  `examples/showcase/Cargo.lock` also picks up `crossbeam-epoch` 0.9.20
+  (RUSTSEC-2026-0204 — invalid pointer dereference in the `fmt::Pointer` impl,
+  reached via `tera → globwalk → ignore`) and `spin` 0.9.9 (the previous 0.9.8
+  was yanked). The workspace `Cargo.lock` and the seven
+  `crates/rustango/examples/*/Cargo.lock` are gitignored, so they resolve fresh
+  on every build and needed no committed change.
+
 - **Schema-mode tenancy leaked `search_path` between registry-pool borrowers**
   (#1224). `TenantPools::acquire` issues a session-level
   `SET search_path TO <schema>, public` on a connection borrowed from the

--- a/crates/rustango/src/cache/mod.rs
+++ b/crates/rustango/src/cache/mod.rs
@@ -784,11 +784,17 @@ impl Cache for InMemoryCache {
 /// ## File format
 ///
 /// Each entry is a small binary blob:
-///   `[expires_at_unix_secs: i64 big-endian][value bytes]`
+///   `[expires_at_unix_millis: i64 big-endian][value bytes]`
 ///
-/// `expires_at_unix_secs` is `0` when the entry has no TTL. Expired
+/// `expires_at_unix_millis` is `0` when the entry has no TTL. Expired
 /// entries are pruned lazily on the next `get` / `exists` call —
 /// there is no background reaper.
+///
+/// The header held **seconds** before #1233, which made sub-second TTLs
+/// unrepresentable and let a 1-second entry expire immediately. Entries
+/// written by an older build decode as long-past and are treated as
+/// expired, so upgrading costs one cold read per stale key — the safe
+/// direction for a cache.
 ///
 /// ## Limitations vs Django
 ///
@@ -831,18 +837,30 @@ impl FileCache {
         self.dir.join(name)
     }
 
-    fn now_unix_secs() -> i64 {
+    /// Epoch **milliseconds**. Seconds were too coarse: an entry whose
+    /// TTL was stamped at second granularity could be born already
+    /// expired (#1233).
+    fn now_unix_millis() -> i64 {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
+            .ok()
+            .and_then(|d| i64::try_from(d.as_millis()).ok())
             .unwrap_or(0)
     }
 
-    /// Encode `[expires_at: i64 BE][value bytes]`. expires_at = 0
-    /// means no TTL.
+    /// Encode `[expires_at: i64 BE epoch-millis][value bytes]`.
+    /// `expires_at = 0` means no TTL.
+    ///
+    /// Milliseconds, not seconds. At second granularity a `set` landing
+    /// at wall-clock `T.999` stamped `expires_at = T + 1`, and the read
+    /// a millisecond later was already at `T+1` — so a 1-second TTL
+    /// could expire in one millisecond, and any sub-second TTL rounded
+    /// to `as_secs() == 0` and was born expired (#1233). The header is
+    /// the same 8 bytes; only its unit changed.
     fn encode(value: &str, ttl: Option<Duration>) -> Vec<u8> {
         let expires_at = ttl
-            .map(|d| Self::now_unix_secs().saturating_add(d.as_secs() as i64))
+            .and_then(|d| i64::try_from(d.as_millis()).ok())
+            .map(|ms| Self::now_unix_millis().saturating_add(ms))
             .unwrap_or(0);
         let mut out = Vec::with_capacity(8 + value.len());
         out.extend_from_slice(&expires_at.to_be_bytes());
@@ -853,6 +871,9 @@ impl FileCache {
     /// Decode the file body. Returns `Some(value)` if present + not
     /// expired, else `None`. Caller is responsible for deleting the
     /// file when this returns `None` due to expiry.
+    ///
+    /// Expiry is `>`, not `>=`: an entry is live for the full duration
+    /// it was promised, rather than dying on the boundary tick.
     fn decode(buf: &[u8]) -> Option<(String, bool /* expired */)> {
         if buf.len() < 8 {
             return None;
@@ -861,7 +882,7 @@ impl FileCache {
         ts.copy_from_slice(&buf[..8]);
         let expires_at = i64::from_be_bytes(ts);
         let value = std::str::from_utf8(&buf[8..]).ok()?.to_owned();
-        let expired = expires_at != 0 && Self::now_unix_secs() >= expires_at;
+        let expired = expires_at != 0 && Self::now_unix_millis() > expires_at;
         Some((value, expired))
     }
 }

--- a/crates/rustango/src/tenancy/admin.rs
+++ b/crates/rustango/src/tenancy/admin.rs
@@ -381,7 +381,7 @@ where
         Ok(Some(o)) => o,
         Ok(None) => return (StatusCode::NOT_FOUND, "tenant not found").into_response(),
         Err(e) => {
-            warn!(target: "crate::tenancy::admin", error = %e, "resolver error");
+            warn!(target: "rustango::tenancy::admin", error = %e, "resolver error");
             return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
         }
     };
@@ -397,7 +397,7 @@ where
         Ok(p) => p,
         Err(e) => {
             warn!(
-                target: "crate::tenancy::admin",
+                target: "rustango::tenancy::admin",
                 slug = %org.slug,
                 error = %e,
                 "tenant pool build failed",
@@ -566,7 +566,7 @@ where
                         }
                         Err(e) => {
                             warn!(
-                                target: "crate::tenancy::admin",
+                                target: "rustango::tenancy::admin",
                                 slug = %org.slug,
                                 user_id,
                                 error = %e,
@@ -779,7 +779,7 @@ async fn validate_session(
             Ok(v) => v,
             Err(e) => {
                 warn!(
-                    target: "crate::tenancy::admin",
+                    target: "rustango::tenancy::admin",
                     operator_id,
                     error = %e,
                     "operator re-check failed during impersonation session validation",
@@ -809,7 +809,7 @@ async fn validate_session(
         Ok(v) => v,
         Err(e) => {
             warn!(
-                target: "crate::tenancy::admin",
+                target: "rustango::tenancy::admin",
                 slug = %org.slug,
                 error = %e,
                 "tenant user lookup failed during session validation",
@@ -925,7 +925,7 @@ async fn login_form(
         Ok(html) => html,
         Err(e) => {
             tracing::error!(
-                target: "crate::tenancy::admin",
+                target: "rustango::tenancy::admin",
                 slug = %org.slug,
                 error = %e,
                 "tenant_login.html render failed",
@@ -984,7 +984,7 @@ async fn login_submit(
     {
         Ok(v) => v,
         Err(e) => {
-            warn!(target: "crate::tenancy::admin", error = %e, "login query");
+            warn!(target: "rustango::tenancy::admin", error = %e, "login query");
             return (StatusCode::INTERNAL_SERVER_ERROR, "login failed").into_response();
         }
     };
@@ -1130,7 +1130,7 @@ async fn redeem_impersonation_handoff(
         Ok(p) => p,
         Err(e) => {
             tracing::info!(
-                target: "crate::tenancy::admin",
+                target: "rustango::tenancy::admin",
                 slug = %org.slug,
                 error = %e,
                 "handoff token rejected",
@@ -1143,7 +1143,7 @@ async fn redeem_impersonation_handoff(
         .await
     {
         tracing::warn!(
-            target: "crate::tenancy::admin",
+            target: "rustango::tenancy::admin",
             slug = %org.slug,
             jti = %payload.jti,
             error = %e,
@@ -1186,7 +1186,7 @@ async fn redeem_impersonation_handoff(
         HeaderValue::from_static("no-referrer"),
     );
     tracing::info!(
-        target: "crate::tenancy::admin",
+        target: "rustango::tenancy::admin",
         slug = %org.slug,
         operator_id = payload.op,
         ttl_secs,
@@ -1309,7 +1309,7 @@ fn change_password_form(
         Ok(html) => html,
         Err(e) => {
             tracing::error!(
-                target: "crate::tenancy::admin",
+                target: "rustango::tenancy::admin",
                 slug = %org.slug,
                 error = %e,
                 "tenant_change_password.html render failed",
@@ -1373,7 +1373,7 @@ async fn change_password_submit(
     {
         Ok(v) => v,
         Err(e) => {
-            warn!(target: "crate::tenancy::admin", error = %e, "change-password lookup");
+            warn!(target: "rustango::tenancy::admin", error = %e, "change-password lookup");
             return (StatusCode::INTERNAL_SERVER_ERROR, "lookup failed").into_response();
         }
     };
@@ -1393,7 +1393,7 @@ async fn change_password_submit(
     user.password_hash = new_hash;
     user.password_changed_at = Some(chrono::Utc::now());
     if let Err(e) = user.save_pool(tenant_pool).await {
-        warn!(target: "crate::tenancy::admin", error = %e, "change-password update");
+        warn!(target: "rustango::tenancy::admin", error = %e, "change-password update");
         return (StatusCode::INTERNAL_SERVER_ERROR, "update failed").into_response();
     }
     Redirect::to(&format!(
@@ -1589,7 +1589,7 @@ async fn serve_brand_asset(slug: &str, filename: &str, brand_storage: &BoxedStor
             | branding::BrandError::InvalidFilename,
         ) => (StatusCode::NOT_FOUND, "not found").into_response(),
         Err(e) => {
-            warn!(target: "crate::tenancy::admin", error = %e, "brand asset");
+            warn!(target: "rustango::tenancy::admin", error = %e, "brand asset");
             (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
         }
     }

--- a/crates/rustango/src/tenancy/migrate.rs
+++ b/crates/rustango/src/tenancy/migrate.rs
@@ -201,7 +201,7 @@ pub async fn migrate_registry_pool(
     registry: &crate::sql::Pool,
     dir: &Path,
 ) -> Result<Vec<Migration>, TenancyError> {
-    info!(target: "crate::tenancy", "applying registry-scoped migrations");
+    info!(target: "rustango::tenancy", "applying registry-scoped migrations");
     let scoped_dir = scoped_subset(dir, MigrationScope::Registry).await?;
     let mut applied = match scoped_dir {
         ScopedDir::Owned(temp) => {
@@ -223,13 +223,13 @@ pub async fn migrate_registry_pool(
     // `contenttypes::ensure_seeded` (v0.34 slice 1).
     if let Err(e) = crate::contenttypes::ensure_seeded(registry).await {
         tracing::warn!(
-            target: "crate::tenancy",
+            target: "rustango::tenancy",
             error = %e,
             "contenttypes::ensure_seeded failed for registry pool",
         );
     }
     info!(
-        target: "crate::tenancy",
+        target: "rustango::tenancy",
         applied = applied.len(),
         "registry migrations done"
     );
@@ -274,7 +274,7 @@ pub async fn migrate_tenants(
         .await?;
 
     info!(
-        target: "crate::tenancy",
+        target: "rustango::tenancy",
         tenants = orgs.len(),
         migrations = migrations_in_scope,
         dir = %dir.display(),
@@ -287,7 +287,7 @@ pub async fn migrate_tenants(
         // was meant. The typed `tenancy::manage::api` auto-detects via
         // `resolve_migration_dirs`, but raw callers can still hit this.
         warn!(
-            target: "crate::tenancy",
+            target: "rustango::tenancy",
             dir = %dir.display(),
             "no tenant-scoped migrations found in dir; tenants will record applied=0 — \
              pass the flat migrations directory or a project root containing one"
@@ -299,13 +299,13 @@ pub async fn migrate_tenants(
         let outcome = run_for_one_tenant(pools, org, &scoped_path, registry_url).await;
         match &outcome {
             Ok(applied) => info!(
-                target: "crate::tenancy",
+                target: "rustango::tenancy",
                 slug = %org.slug,
                 applied = applied.len(),
                 "tenant migrations done"
             ),
             Err(e) => warn!(
-                target: "crate::tenancy",
+                target: "rustango::tenancy",
                 slug = %org.slug,
                 error = %e,
                 "tenant migration failed; continuing with remaining tenants"
@@ -363,7 +363,7 @@ where
         .await?;
 
     info!(
-        target: "crate::tenancy",
+        target: "rustango::tenancy",
         tenants = orgs.len(),
         dir = %dir.display(),
         "applying tenant-scoped migrations (db-mode only)"
@@ -374,13 +374,13 @@ where
         let outcome = run_for_one_tenant_db(pools, org, &scoped_path).await;
         match &outcome {
             Ok(applied) => info!(
-                target: "crate::tenancy",
+                target: "rustango::tenancy",
                 slug = %org.slug,
                 applied = applied.len(),
                 "tenant migrations done"
             ),
             Err(e) => warn!(
-                target: "crate::tenancy",
+                target: "rustango::tenancy",
                 slug = %org.slug,
                 error = %e,
                 "tenant migration failed; continuing with remaining tenants"
@@ -446,10 +446,10 @@ where
     // Data seeders (rows, not DDL — kept): the CRUD permission codenames
     // for every registered model (#61) + the content-type catalog (#89).
     if let Err(e) = super::permissions::auto_create_permissions_pool(&inner_pool).await {
-        tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "auto_create_permissions_pool failed for database-mode tenant");
+        tracing::warn!(target: "rustango::tenancy", slug = %org.slug, error = %e, "auto_create_permissions_pool failed for database-mode tenant");
     }
     if let Err(e) = crate::contenttypes::ensure_seeded(&inner_pool).await {
-        tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "contenttypes::ensure_seeded failed for database-mode tenant");
+        tracing::warn!(target: "rustango::tenancy", slug = %org.slug, error = %e, "contenttypes::ensure_seeded failed for database-mode tenant");
     }
     Ok(applied)
 }
@@ -510,10 +510,10 @@ async fn run_for_one_tenant(
             // codenames for every registered model (#61) + the
             // content-type catalog (#89). Idempotent.
             if let Err(e) = super::permissions::auto_create_permissions(&pool).await {
-                tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "auto_create_permissions failed for schema-mode tenant");
+                tracing::warn!(target: "rustango::tenancy", slug = %org.slug, error = %e, "auto_create_permissions failed for schema-mode tenant");
             }
             if let Err(e) = crate::contenttypes::ensure_seeded(&dbpool).await {
-                tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "contenttypes::ensure_seeded failed for schema-mode tenant");
+                tracing::warn!(target: "rustango::tenancy", slug = %org.slug, error = %e, "contenttypes::ensure_seeded failed for schema-mode tenant");
             }
             pool.close().await;
             Ok(applied)
@@ -527,10 +527,10 @@ async fn run_for_one_tenant(
             applied.extend(migrate::migrate(tenant_pool.pool(), dir).await?);
             // Data seeders (rows, not DDL — kept): #61 + #89.
             if let Err(e) = super::permissions::auto_create_permissions(tenant_pool.pool()).await {
-                tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "auto_create_permissions failed for database-mode tenant");
+                tracing::warn!(target: "rustango::tenancy", slug = %org.slug, error = %e, "auto_create_permissions failed for database-mode tenant");
             }
             if let Err(e) = crate::contenttypes::ensure_seeded(&dbpool).await {
-                tracing::warn!(target: "crate::tenancy", slug = %org.slug, error = %e, "contenttypes::ensure_seeded failed for database-mode tenant");
+                tracing::warn!(target: "rustango::tenancy", slug = %org.slug, error = %e, "contenttypes::ensure_seeded failed for database-mode tenant");
             }
             Ok(applied)
         }

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -536,7 +536,7 @@ async fn require_session(
             next.run(req).await
         }
         Err(e) => {
-            tracing::warn!(target: "crate::tenancy::operator_console", error = %e, "registry lookup");
+            tracing::warn!(target: "rustango::tenancy::operator_console", error = %e, "registry lookup");
             (StatusCode::INTERNAL_SERVER_ERROR, "registry lookup failed").into_response()
         }
     }
@@ -704,7 +704,7 @@ async fn login_submit(
                 .into_response();
             }
             Err(e) => {
-                tracing::warn!(target: "crate::tenancy::operator_console", error = %e);
+                tracing::warn!(target: "rustango::tenancy::operator_console", error = %e);
                 return (StatusCode::INTERNAL_SERVER_ERROR, "login failed").into_response();
             }
         };
@@ -812,7 +812,7 @@ async fn change_password_form(
             .tera
             .render("op_change_password.html", &ctx)
             .unwrap_or_else(|e| {
-                tracing::error!(target: "crate::tenancy::operator_console", error = %e, "op_change_password.html render");
+                tracing::error!(target: "rustango::tenancy::operator_console", error = %e, "op_change_password.html render");
                 "<!doctype html><h1>Change-password page unavailable</h1>".to_owned()
             }),
     )
@@ -880,7 +880,7 @@ async fn change_password_submit(
             }
         },
         Err(e) => {
-            tracing::warn!(target: "crate::tenancy::operator_console", error = %e, "change-password lookup");
+            tracing::warn!(target: "rustango::tenancy::operator_console", error = %e, "change-password lookup");
             return (StatusCode::INTERNAL_SERVER_ERROR, "lookup failed").into_response();
         }
     };
@@ -896,7 +896,7 @@ async fn change_password_submit(
     op_row.password_hash = new_hash;
     op_row.password_changed_at = Some(chrono::Utc::now());
     if let Err(e) = op_row.save_pool(&state.registry).await {
-        tracing::warn!(target: "crate::tenancy::operator_console", error = %e, "change-password update");
+        tracing::warn!(target: "rustango::tenancy::operator_console", error = %e, "change-password update");
         return (StatusCode::INTERNAL_SERVER_ERROR, "update failed").into_response();
     }
     redir("ok=Password+updated")
@@ -1441,7 +1441,7 @@ async fn emit_op_audit(
     };
     if let Err(e) = crate::audit::emit_one_pool(registry, &entry).await {
         tracing::warn!(
-            target: "crate::tenancy::operator_console",
+            target: "rustango::tenancy::operator_console",
             error = %e,
             slug = slug,
             operator_id,
@@ -1601,7 +1601,7 @@ async fn serve_brand_asset(
             | branding::BrandError::InvalidFilename,
         ) => (StatusCode::NOT_FOUND, "not found").into_response(),
         Err(e) => {
-            tracing::warn!(target: "crate::tenancy::operator_console", error = %e, "brand asset");
+            tracing::warn!(target: "rustango::tenancy::operator_console", error = %e, "brand asset");
             (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
         }
     }
@@ -1694,7 +1694,7 @@ async fn org_impersonate(
     {
         Ok(rows) => rows,
         Err(e) => {
-            tracing::warn!(target: "crate::tenancy::operator_console", error = %e, "org lookup failed");
+            tracing::warn!(target: "rustango::tenancy::operator_console", error = %e, "org lookup failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "registry lookup failed").into_response();
         }
     };
@@ -1778,7 +1778,7 @@ async fn org_impersonate(
         HeaderValue::from_static("no-referrer"),
     );
     tracing::info!(
-        target: "crate::tenancy::operator_console",
+        target: "rustango::tenancy::operator_console",
         slug = %slug,
         operator_id,
         ttl_secs = handoff::HANDOFF_TTL_SECS,

--- a/crates/rustango/src/tenancy/pools.rs
+++ b/crates/rustango/src/tenancy/pools.rs
@@ -509,7 +509,7 @@ impl<DB: Database> TenantPools<DB> {
         })?;
         let url = self.secrets.resolve(reference).await?;
         tracing::debug!(
-            target: "crate::tenancy::pools",
+            target: "rustango::tenancy::pools",
             slug = %org.slug,
             elapsed_ms = resolve_start.elapsed().as_millis() as u64,
             "secrets resolver resolved tenant URL",
@@ -517,7 +517,7 @@ impl<DB: Database> TenantPools<DB> {
         let connect_start = std::time::Instant::now();
         let pool = build_database_pool::<DB>(&url, &self.config).await?;
         tracing::info!(
-            target: "crate::tenancy::pools",
+            target: "rustango::tenancy::pools",
             slug = %org.slug,
             elapsed_ms = connect_start.elapsed().as_millis() as u64,
             min_conn = self.config.database_pool_min_connections,
@@ -636,7 +636,7 @@ where
         for org in orgs {
             if self.cache.read().await.len() >= self.config.max_cached_database_pools {
                 tracing::warn!(
-                    target: "crate::tenancy::pools",
+                    target: "rustango::tenancy::pools",
                     slug = %org.slug,
                     cap = self.config.max_cached_database_pools,
                     "skipping pre-warm: cache cap reached",
@@ -648,7 +648,7 @@ where
                 Ok(_) => report.warmed += 1,
                 Err(e) => {
                     tracing::warn!(
-                        target: "crate::tenancy::pools",
+                        target: "rustango::tenancy::pools",
                         slug = %org.slug,
                         error = %e,
                         "pre-warm failed for tenant",
@@ -658,7 +658,7 @@ where
             }
         }
         tracing::info!(
-            target: "crate::tenancy::pools",
+            target: "rustango::tenancy::pools",
             elapsed_ms = started.elapsed().as_millis() as u64,
             total = report.total_active,
             warmed = report.warmed,
@@ -967,7 +967,7 @@ fn reset_pg_search_path(
             Ok(_) => drop(conn),
             Err(error) => {
                 tracing::warn!(
-                    target: "crate::tenancy::pools",
+                    target: "rustango::tenancy::pools",
                     %error,
                     "could not reset search_path on release; closing the connection \
                      rather than returning it to the registry pool",

--- a/crates/rustango/src/tenancy/server.rs
+++ b/crates/rustango/src/tenancy/server.rs
@@ -203,7 +203,7 @@ where
 
 async fn shutdown_signal() {
     let _ = tokio::signal::ctrl_c().await;
-    tracing::info!(target: "crate::tenancy::server", "shutdown signal received");
+    tracing::info!(target: "rustango::tenancy::server", "shutdown signal received");
 }
 
 /// Print a loud warning if no operators exist — the operator UI

--- a/crates/rustango/src/tenancy/sweep.rs
+++ b/crates/rustango/src/tenancy/sweep.rs
@@ -189,7 +189,7 @@ where
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!(
-                    target: "crate::tenancy::sweep",
+                    target: "rustango::tenancy::sweep",
                     slug = %slug,
                     error = %e,
                     "skipping tenant: could not resolve its pool",
@@ -212,7 +212,7 @@ where
             // render the error from `TenantSweep::errors`.
             let _ = e;
             tracing::warn!(
-                target: "crate::tenancy::sweep",
+                target: "rustango::tenancy::sweep",
                 slug = %slug,
                 "tenant sweep returned an error; continuing with the remaining tenants",
             );

--- a/crates/rustango/tests/file_cache_backend.rs
+++ b/crates/rustango/tests/file_cache_backend.rs
@@ -126,3 +126,79 @@ async fn from_settings_file_backend_without_dir_falls_back_to_memory() {
     cache.set("k", "v", None).await.unwrap();
     assert_eq!(cache.get("k").await.unwrap().as_deref(), Some("v"));
 }
+
+/// #1233 — an entry must be readable for the *whole* TTL it was
+/// promised, including immediately after the write.
+///
+/// The old encoding stamped `expires_at` in whole seconds and expired on
+/// `now >= expires_at`, so a `set` landing at wall-clock `T.999` was
+/// already expired by the read a millisecond later. This deliberately
+/// starts each iteration just before a second boundary, which is the
+/// window that made the failure load-dependent rather than impossible.
+#[tokio::test]
+async fn entry_is_readable_immediately_even_across_a_second_boundary() {
+    let dir = unique_tmp_dir("boundary");
+    let cache = FileCache::new(&dir);
+
+    for i in 0..5 {
+        // Sleep to within ~5ms of the next whole second.
+        let sub_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| u64::from(d.subsec_millis()))
+            .unwrap_or(0);
+        tokio::time::sleep(Duration::from_millis(995u64.saturating_sub(sub_ms))).await;
+
+        let key = format!("boundary-{i}");
+        cache
+            .set(&key, "v", Some(Duration::from_secs(1)))
+            .await
+            .unwrap();
+        assert_eq!(
+            cache.get(&key).await.unwrap().as_deref(),
+            Some("v"),
+            "entry {i} expired immediately after being written",
+        );
+    }
+}
+
+/// #1233 — sub-second TTLs were unrepresentable: `as_secs()` truncated
+/// them to `0`, so `expires_at == now` and the entry was born expired.
+#[tokio::test]
+async fn sub_second_ttl_is_honored_not_truncated_to_zero() {
+    let dir = unique_tmp_dir("subsec");
+    let cache = FileCache::new(&dir);
+
+    cache
+        .set("k", "v", Some(Duration::from_millis(500)))
+        .await
+        .unwrap();
+    assert_eq!(
+        cache.get("k").await.unwrap().as_deref(),
+        Some("v"),
+        "a 500ms entry must exist immediately after the write",
+    );
+
+    tokio::time::sleep(Duration::from_millis(700)).await;
+    assert_eq!(
+        cache.get("k").await.unwrap(),
+        None,
+        "a 500ms entry must be gone after 700ms",
+    );
+}
+
+/// Parity guard: `InMemoryCache` already handled both cases (it stores an
+/// `Instant`). Pinning them side by side stops the two backends drifting
+/// apart on the same public API again.
+#[tokio::test]
+async fn memory_backend_agrees_on_sub_second_ttl() {
+    let cache = rustango::cache::InMemoryCache::new();
+
+    cache
+        .set("k", "v", Some(Duration::from_millis(500)))
+        .await
+        .unwrap();
+    assert_eq!(cache.get("k").await.unwrap().as_deref(), Some("v"));
+
+    tokio::time::sleep(Duration::from_millis(700)).await;
+    assert_eq!(cache.get("k").await.unwrap(), None);
+}

--- a/crates/rustango/tests/tracing_targets.rs
+++ b/crates/rustango/tests/tracing_targets.rs
@@ -1,0 +1,58 @@
+//! #1234 — every `tracing` event must live under the `rustango::` target
+//! root, so that the conventional `RUST_LOG=rustango=warn` actually
+//! reaches it.
+//!
+//! `target:` takes a **literal string**, not a path: `target: "crate::x"`
+//! compiles happily and then sits in a namespace no realistic filter
+//! matches. 48 call sites had drifted that way, several of them the only
+//! diagnostic for a deliberately-swallowed failure. The mistake is
+//! invisible in review — the string looks like a path — so it is worth a
+//! machine check rather than vigilance.
+
+use std::path::Path;
+
+fn rs_files(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rs_files(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn no_tracing_event_uses_a_literal_crate_target() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    rs_files(&src, &mut files);
+    assert!(
+        !files.is_empty(),
+        "found no sources under {}",
+        src.display()
+    );
+
+    let mut offenders = Vec::new();
+    for file in &files {
+        let Ok(text) = std::fs::read_to_string(file) else {
+            continue;
+        };
+        for (i, line) in text.lines().enumerate() {
+            if line.contains(r#"target: "crate::"#) {
+                offenders.push(format!("{}:{}", file.display(), i + 1));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "tracing targets must start with `rustango::`, not the literal \
+         `crate::` — `RUST_LOG=rustango=…` cannot match these {} site(s):\n  {}",
+        offenders.len(),
+        offenders.join("\n  "),
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,13 @@
 # cargo-deny configuration. Run `cargo deny check` in CI.
 
 [graph]
-all-features = false
+# Scan the FULL feature graph, not just default features (#1237).
+# With `all-features = false` nothing behind an optional feature was ever
+# checked — the whole mysql backend included — so an advisory in an
+# optional dep would go unreported. It also left the RUSTSEC-2023-0071
+# ignore below matching nothing, since `rsa` only enters the graph once
+# `mysql` is on, which cargo-deny reports as an unused-ignore warning.
+all-features = true
 no-default-features = false
 
 [advisories]

--- a/examples/showcase/Cargo.lock
+++ b/examples/showcase/Cargo.lock
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2142,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/examples/showcase/Cargo.lock
+++ b/examples/showcase/Cargo.lock
@@ -1511,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -1769,13 +1769,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.5.0"
+version = "7.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3bc4a3dd492cd6974dd3f32d6626ba9f36e5122e3df3b083474b104aebd139b"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.43.0"
+version = "0.52.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.43.0"
+version = "0.52.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",


### PR DESCRIPTION
Four fixes found while verifying #1225 and #1232, each filed first and closed here.

Closes #1233, closes #1234, closes #1236, closes #1237.

## #1233 — `FileCache` entries could expire the instant they were written

The on-disk header stamped `expires_at` in whole **seconds** and expired on `now >= expires_at`. A `set` landing at wall-clock `T.999` stamped `T+1`, and the read a millisecond later was already at `T+1` — so a 1-second TTL could live for one millisecond.

The same truncation made sub-second TTLs unrepresentable: `Duration::from_millis(500).as_secs()` is `0`, so the entry was born expired. `InMemoryCache` stores an `Instant` and handled that correctly, so the two backends disagreed about the same public API.

Header is now epoch **milliseconds** — same 8 bytes, different unit — and expiry is `>`. Entries from an older build decode as long-past and are dropped as expired: one cold read per stale key on upgrade, the safe direction for a cache.

This is the flake that surfaced during #1232's verification. It failed on its *first* assertion — the immediate read-back, before the deliberate sleep — and passed 3/3 in isolation, because the failure window is however much of the current second remains when `set` lands, which widens under load.

Two of the three new tests fail against the old code; the third is a parity guard that passes either way.

## #1234 — 48 tracing sites were invisible to `RUST_LOG=rustango=…`

`target:` takes a literal string, not a path that expands, so `target: "crate::tenancy"` compiled fine and landed where no realistic filter matches. Several were the only diagnostic for a failure the framework deliberately swallows — the #1224 connection-reset path, the pre-warm cap warning, and `for_each_tenant` skipping a tenant whose pool won't resolve, which is the silent under-coverage #1226 exists to prevent.

All 48 are in six `tenancy/` files; the other 60 sites already used `rustango::`. A new test walks `src/` and fails the build with file:line if the literal form returns — verified by reverting a target by hand. Every changed line in the diff is a `target:` line.

## #1236 — high-severity Dependabot alert

`quinn-proto` 0.11.14 → 0.11.15 in `examples/showcase/Cargo.lock`, closing GHSA-4w2j-m93h-cj5j. The refresh also moves `rpassword` 7.5.0 → 7.3.1, which reads as a downgrade but is a correction: the workspace pins `=7.3.1` exactly and the example lock had drifted while stale at rustango 0.43.

## #1237 — cargo-deny wasn't looking where it needed to

`deny.toml` had `all-features = false`, so nothing behind an optional feature was scanned — the entire MySQL backend included. That also explains the standing unused-ignore warning on `RUSTSEC-2023-0071`: the ignore isn't stale, `rsa` just needs `mysql` enabled to appear. Now `all-features = true`, clean across all four checks.

The CI `deny` job ran only at the repo root, and `examples/showcase` is both outside the workspace **and the only committed lockfile in the repo** — so it was invisible to `deny` and simultaneously the one place a stale pin can persist. That is exactly how #1236 arrived as a Dependabot alert instead of a red build. A `deny-examples` matrix now gates it, advisories-only (example crates are unpublished and carry no `license` field, so `check licenses` fails them as `unlicensed` for non-security reasons).

`crossbeam-epoch` 0.9.20 and `spin` 0.9.9 land in the showcase lock too.

**Correction recorded on the issue:** I first read those two as *workspace* lockfile failures. They weren't — only `examples/showcase/Cargo.lock` is committed; the workspace lock and the seven other example locks are gitignored and resolve fresh, so they'd already have picked the fixed versions. What I saw was my own stale local lock.

## Verification

`cargo test --workspace --all-features` against PostgreSQL 16: **510 binaries, 6780 tests, 0 failures**. `cargo fmt --check` clean; CI's exact clippy invocation unchanged from baseline; `cargo deny check` clean across advisories, bans, licenses and sources.

## Two things that need a human

- **GitHub Actions is disabled for this repository** (`actions/permissions` → `"enabled": false`). No workflow has run since 2026-08-18 — including on #1231, #1225 and #1232, which merged with no CI. The `deny-examples` job added here is therefore **unverified**.
- #1235 (schema-mode `Tenant` extraction builds an uncached `PgPool` per request) is filed but deliberately not addressed here — it is a design change needing its own PR.
