### PR TITLE
fix(deps): unpin rpassword — =7.3.1 sits inside GHSA-2p6r-x3vv-xqm2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,20 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
   the `JobContext` work in #1223.
 
 ### Fixed
+- **`rpassword` unpinned from `=7.3.1` to `7.5`** (#1239). The exact pin dated
+  from rpassword 7.4 using `libc::__errno_location`, which is Linux-only and
+  broke macOS builds. Upstream made the errno call portable, but the pin
+  outlived its reason and had quietly become the problem: GHSA-2p6r-x3vv-xqm2
+  (partial password reveal when input is interrupted) covers `<= 7.4.0`, so
+  holding 7.3.1 held the interactive `manage create-admin` / tenancy CLI prompt
+  on the vulnerable side of it. Verified 7.5.4 builds clean on macOS aarch64 —
+  the platform the pin existed to protect — before lifting it.
+
+  Caught while refreshing the showcase lockfile for #1236, where `cargo update`
+  reported `Downgrading rpassword v7.5.0 -> v7.3.1` and it read as the example
+  being brought back in line with the workspace. It was the reverse: the example
+  had drifted onto the *patched* version, and honouring the pin moved it back.
+
 - **`FileCache` entries could expire the instant they were written** (#1233).
   The on-disk header stamped `expires_at` in whole **seconds** and expired on
   `now >= expires_at`, so a `set` landing at wall-clock `T.999` was already

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,9 +92,14 @@ chacha20poly1305 = "0.10"
 
 # Interactive manage CLI
 dotenvy   = "0.15"
-# 7.4+ uses `libc::__errno_location` which is Linux-only (breaks macOS
-# builds); pin to 7.3 until rpassword adopts a portable errno call.
-rpassword = "=7.3.1"
+# Was pinned `=7.3.1`: 7.4 used `libc::__errno_location`, which is
+# Linux-only and broke macOS builds. Upstream made the errno call
+# portable, and 7.5.4 compiles clean on macOS aarch64 — verified before
+# lifting the pin. The pin had become a liability: GHSA-2p6r-x3vv-xqm2
+# (partial password reveal when input is interrupted) covers `<= 7.4.0`,
+# so holding 7.3.1 held us on the vulnerable side of it. Keep this at
+# `>= 7.5`.
+rpassword = "7.5"
 
 # Admin (HTTP)
 axum = { version = "0.8", default-features = false, features = ["tokio", "http1", "json", "form", "query", "original-uri"] }

--- a/examples/showcase/Cargo.lock
+++ b/examples/showcase/Cargo.lock
@@ -1769,13 +1769,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.3.1"
+version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1239.

The workspace pinned `rpassword = "=7.3.1"` because 7.4 used `libc::__errno_location`, Linux-only, which broke macOS builds. Upstream made the errno call portable — but the pin outlived its reason and had become the problem:

- [GHSA-2p6r-x3vv-xqm2](https://github.com/advisories/GHSA-2p6r-x3vv-xqm2), partial password reveal when input is interrupted
- vulnerable: `<= 7.4.0` · patched: `7.5.0`

So the pin held the interactive `manage create-admin` and tenancy CLI prompt on the vulnerable side of an advisory. It is the last open Dependabot alert on the repo.

## Verified, not assumed

Built on the exact platform the pin protected — macOS aarch64:

```
$ cargo build -p rustango --features admin,tenancy
   Compiling rpassword v7.5.4
    Finished `dev` profile in 20.02s
```

The single call site is `rpassword::prompt_password` in `manage_interactive.rs`, unchanged between 7.3 and 7.5.

Now `rpassword = "7.5"`, with the comment rewritten to record why the old pin existed, that lifting it was verified, and that it must stay `>= 7.5`.

## How it surfaced — and a correction to #1238

While refreshing the showcase lockfile for #1236, `cargo update` reported:

```
Downgrading rpassword v7.5.0 -> v7.3.1 (available: v7.5.4)
```

I read that as a *correction*: the example lock was stale from when it tracked rustango 0.43, and 7.3.1 is what the workspace pin demands, so it looked like the example was being brought back in line. It was the reverse — the example had drifted onto the **patched** version, and honouring the pin moved it back onto the vulnerable one.

I described it as "a correction" in the #1236 commit message and the changelog. That was wrong on the security dimension, and this PR is the fix for it. A downgrade that restores consistency can still be a regression, and an `=` pin justified by "until upstream fixes X" is where that goes unnoticed — nothing re-checks the rationale. Left as a follow-up note on the issue.

## Verification

`cargo test --workspace --all-features` against PostgreSQL 16: **510 binaries, 6780 tests, 0 failures**. `cargo deny check advisories` clean. `cargo fmt --check` clean.

Note that CI still cannot verify this — GitHub Actions remains disabled for the repository.
