### PR TITLE
fix(tenancy): cache schema-mode scoped pools instead of rebuilding per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,38 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
   the `JobContext` work in #1223.
 
 ### Fixed
+- **Schema-mode `Tenant` extraction built an uncached `PgPool` per request**
+  (#1235). `TenantPools::scoped_pool` rebuilt its `search_path`-baked pool on
+  every call, and the `Tenant` extractor calls it once per request — so a
+  schema-mode app paid a TCP connect, TLS handshake and auth round-trip per
+  request. `PgPoolOptions::connect_with` is eager, so even a handler that only
+  touched `Tenant::conn` paid it, and a burst of N concurrent requests opened up
+  to 2N short-lived connections against the very server schema mode exists to
+  protect. Database mode, by contrast, returned a cached clone for free.
+
+  Scoped pools are now cached per slug in their own map, bounded by the new
+  `TenantPoolsConfig::max_cached_scoped_pools` (default 64). The budget is
+  separate from `max_cached_database_pools` so schema-mode tenants can't
+  silently eat a mixed deployment's database-mode capacity. Past the cap,
+  `scoped_pool` falls back to the old per-call build and warns rather than
+  erroring — schema mode is sold for high tenant counts, so a hard failure there
+  would break exactly the deployments it targets.
+
+  `TenantPools::invalidate` now evicts the scoped pool too. Without that, a
+  tenant whose `schema_name` changed would keep being handed a pool with the old
+  schema baked into its connect options — a cross-tenant read of the kind #1224
+  was about.
+
+  **Behaviour change worth noting:** the per-tenant scoped pool is now *shared*
+  between request handlers and any long-lived worker built on `scoped_pool_dyn`
+  (the pattern in `docs/jobs.md`), where each previously got its own. The old
+  hardcoded `max_connections = 2` is unsafe under sharing — `Tenant::conn` pins a
+  connection for the handler's lifetime, a handler also using `t.pool()` needs a
+  second, and a job worker holds one more or less permanently. It is now
+  `TenantPoolsConfig::scoped_pool_max_connections`, defaulting to 8, with
+  `min_connections = 0` and the configured idle timeout so a quiet cached tenant
+  settles back to zero connections.
+
 - **`rpassword` unpinned from `=7.3.1` to `7.5`** (#1239). The exact pin dated
   from rpassword 7.4 using `libc::__errno_location`, which is Linux-only and
   broke macOS builds. Upstream made the errno call portable, but the pin

--- a/crates/rustango/src/tenancy/pools.rs
+++ b/crates/rustango/src/tenancy/pools.rs
@@ -28,8 +28,22 @@
 //! uncached org returns a [`TenancyError::Validation`] error. A real
 //! LRU evictor lands in a follow-up; the bounded-with-error semantics
 //! is the safest first version (silent eviction is its own footgun).
-//! Schema-mode tenants don't consume cache slots — they always reuse
-//! the registry pool.
+//!
+//! Schema-mode tenants don't consume *that* cache — acquiring a
+//! connection reuses the registry pool. They do have a second, separate
+//! cache: [`TenantPools::scoped_pool`] hands out a small pool with
+//! `search_path` baked into its connect options, and those are cached
+//! per slug under [`TenantPoolsConfig::max_cached_scoped_pools`]
+//! (#1235). Before that they were rebuilt on every call, which meant a
+//! full TCP + TLS + auth round-trip per request, since the `Tenant`
+//! extractor resolves one per request — the opposite of what schema
+//! mode is for. Past the cap they fall back to the old per-call build
+//! and warn, rather than erroring, because schema mode's whole premise
+//! is a high tenant count.
+//!
+//! The two budgets are deliberately separate: one shared cap would let
+//! schema-mode tenants silently eat a mixed deployment's database-mode
+//! capacity.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -104,6 +118,63 @@ pub struct TenantPoolsConfig {
     /// Schema-mode tenants are never pre-warmed (they share the
     /// registry pool which is already up). Default: `false`.
     pub prewarm_active_tenants: bool,
+
+    // v0.53 — schema-mode scoped-pool caching (#1235).
+    /// Maximum number of schema-mode *scoped* pools cached
+    /// simultaneously — the `search_path`-baked pools handed out by
+    /// [`TenantPools::scoped_pool`].
+    ///
+    /// Counted separately from `max_cached_database_pools` on
+    /// purpose: sharing one budget would silently halve a mixed
+    /// deployment's database-mode capacity the moment schema-mode
+    /// tenants started consuming slots.
+    ///
+    /// Past the cap, `scoped_pool` falls back to building a transient
+    /// pool per call — the pre-#1235 behavior — and warns, rather
+    /// than erroring. Schema mode exists for high tenant counts, so
+    /// turning "more tenants than the cap" into a hard failure would
+    /// break exactly the deployments the mode is for.
+    ///
+    /// Budget the worst case as `max_cached_scoped_pools *
+    /// scoped_pool_max_connections` concurrent connections against
+    /// the registry server, and keep that under its
+    /// `max_connections`. The default pair gives 64 × 8 = 512, far
+    /// above a stock Postgres' 100 — but that ceiling needs every
+    /// cached tenant saturated simultaneously, and these pools hold no
+    /// idle connections (`min_connections = 0` plus
+    /// `database_pool_idle_timeout`), so a quiet tenant costs nothing.
+    /// Lower this, or `scoped_pool_max_connections`, if your registry
+    /// server's limit is tight and your tenants are uniformly busy.
+    /// Default: 64.
+    pub max_cached_scoped_pools: usize,
+
+    /// Per-pool `max_connections` for schema-mode scoped pools.
+    ///
+    /// Was a hardcoded 2 while these pools were per-call throwaways.
+    /// Caching them (#1235) made every caller for a given tenant share
+    /// one pool, which makes 2 actively dangerous: the `Tenant`
+    /// extractor pins a connection for the handler's whole lifetime,
+    /// so a handler that also uses `t.pool()` needs a second slot, and
+    /// a long-lived per-tenant job worker built on `scoped_pool_dyn`
+    /// (see `docs/jobs.md`) holds one more or less permanently. At 2
+    /// those three uses deadlock each other. This is the same
+    /// reasoning that puts `database_pool_max_connections` at 16.
+    ///
+    /// Still smaller than the database-mode figure, because every
+    /// scoped pool points at the *same* registry server — this
+    /// multiplies across cached tenants instead of being spread over
+    /// separate databases. Budget the worst case as
+    /// `max_cached_scoped_pools * scoped_pool_max_connections` and
+    /// keep it under the server's `max_connections`; the defaults give
+    /// 64 × 8 = 512, which is only reachable with every cached tenant
+    /// saturated at once.
+    ///
+    /// These pools are built with `min_connections = 0` and inherit
+    /// `database_pool_idle_timeout`, so a cached-but-quiet tenant
+    /// settles back to zero connections. That is what makes caching
+    /// them affordable — the cache costs a `PgPool` struct, not a
+    /// held connection. Default: 8.
+    pub scoped_pool_max_connections: u32,
 }
 
 impl Default for TenantPoolsConfig {
@@ -119,6 +190,11 @@ impl Default for TenantPoolsConfig {
             database_pool_idle_timeout: Some(std::time::Duration::from_secs(10 * 60)),
             database_pool_max_lifetime: Some(std::time::Duration::from_secs(30 * 60)),
             prewarm_active_tenants: false,
+            max_cached_scoped_pools: 64,
+            // Raised from the pre-#1235 hardcoded 2: these pools are
+            // shared per tenant now, and 2 deadlocks the documented
+            // `Tenant::conn` + `t.pool()` + job-worker combination.
+            scoped_pool_max_connections: 8,
         }
     }
 }
@@ -272,6 +348,12 @@ pub struct TenantPools<DB: Database = DefaultTenantDb> {
     config: TenantPoolsConfig,
     secrets: Arc<dyn SecretsResolver>,
     cache: RwLock<HashMap<String, Arc<sqlx::Pool<DB>>>>,
+    /// Schema-mode scoped pools, keyed by `slug` (#1235). Separate
+    /// from `cache` so the two capacity budgets can't cannibalise
+    /// each other. Generic over `DB` rather than `PgPool`-typed so
+    /// this file still builds under `--no-default-features --features
+    /// sqlite,tenancy`; only the Postgres impl ever populates it.
+    scoped_cache: RwLock<HashMap<String, Arc<sqlx::Pool<DB>>>>,
 }
 
 impl<DB: Database> TenantPools<DB> {
@@ -295,6 +377,7 @@ impl<DB: Database> TenantPools<DB> {
             config: TenantPoolsConfig::default(),
             secrets: Arc::new(secrets),
             cache: RwLock::new(HashMap::new()),
+            scoped_cache: RwLock::new(HashMap::new()),
         }
     }
 
@@ -417,13 +500,18 @@ impl<DB: Database> TenantPools<DB> {
         })
     }
 
-    /// Drop a database-mode tenant's pool from the cache. Useful
-    /// when the operator updates `Org.database_url` (vault rotation,
-    /// migration to new server) and wants the next acquire to
-    /// rebuild from the new URL.
+    /// Drop a tenant's cached pools. Useful when the operator updates
+    /// `Org.database_url` (vault rotation, migration to new server)
+    /// and wants the next acquire to rebuild from the new URL.
+    ///
+    /// Evicts both the database-mode pool and the schema-mode scoped
+    /// pool (#1235). The scoped pool bakes `search_path` into its
+    /// connect options, so a tenant whose `schema_name` changed would
+    /// otherwise keep being served a pool pointing at the old schema —
+    /// a cross-tenant read, and the exact failure #1224 was about.
     pub async fn invalidate(&self, slug: &str) {
-        let mut cache = self.cache.write().await;
-        cache.remove(slug);
+        self.cache.write().await.remove(slug);
+        self.scoped_cache.write().await.remove(slug);
     }
 }
 
@@ -760,22 +848,94 @@ impl TenantPools<sqlx::Postgres> {
     /// every checkout is correctly scoped. Database mode just clones
     /// the cached pool.
     ///
+    /// Scoped pools are **cached per tenant** (#1235). They were built
+    /// fresh on every call before, and the `Tenant` extractor calls
+    /// this once per request — so a schema-mode app paid a TCP
+    /// connect, TLS handshake and auth round-trip per request, and
+    /// `PgPoolOptions::connect_with` is eager, so even a handler that
+    /// only ever touched `Tenant::conn` paid it. That inverted the
+    /// point of schema mode, which exists to *reduce* per-tenant
+    /// connection overhead relative to database mode.
+    ///
+    /// Past `max_cached_scoped_pools` this falls back to the old
+    /// per-call build and warns, rather than erroring — see that
+    /// field for why, and for the connection arithmetic.
+    ///
     /// # Errors
     /// As [`Self::pool_for_org`] plus [`TenancyError::Driver`] for
     /// the schema-mode dedicated pool build.
     pub async fn scoped_pool(&self, org: &Org) -> Result<PgPool, TenancyError> {
         match self.pool_for_org(org).await? {
             TenantPool::Schema { schema, registry } => {
-                let mut opts = (*registry.connect_options()).clone();
-                opts = opts.options([("search_path", &format!("{schema},public") as &str)]);
-                let scoped = PgPoolOptions::new()
-                    .max_connections(2)
-                    .connect_with(opts)
-                    .await?;
+                // Fast path: cache hit. Mirrors `pool_for_database_mode`.
+                {
+                    let cache = self.scoped_cache.read().await;
+                    if let Some(pool) = cache.get(&org.slug) {
+                        return Ok((**pool).clone());
+                    }
+                }
+
+                let span =
+                    tracing::info_span!("tenant_pool_init", slug = %org.slug, mode = "schema");
+                let _enter = span.enter();
+                let connect_start = std::time::Instant::now();
+                let scoped = self.build_scoped_pool(&schema, &registry).await?;
+                tracing::info!(
+                    target: "rustango::tenancy::pools",
+                    slug = %org.slug,
+                    schema = %schema,
+                    elapsed_ms = connect_start.elapsed().as_millis() as u64,
+                    max_conn = self.config.scoped_pool_max_connections,
+                    "tenant pool connected (schema mode)",
+                );
+
+                // Insert under write lock; check for race + capacity.
+                let mut cache = self.scoped_cache.write().await;
+                if let Some(existing) = cache.get(&org.slug) {
+                    return Ok((**existing).clone());
+                }
+                if cache.len() >= self.config.max_cached_scoped_pools {
+                    tracing::warn!(
+                        target: "rustango::tenancy::pools",
+                        slug = %org.slug,
+                        cap = self.config.max_cached_scoped_pools,
+                        "scoped-pool cache is full; this tenant rebuilds its pool on every \
+                         request. Raise `TenantPoolsConfig::max_cached_scoped_pools`.",
+                    );
+                    return Ok(scoped);
+                }
+                cache.insert(org.slug.clone(), Arc::new(scoped.clone()));
                 Ok(scoped)
             }
             TenantPool::Database { pool } => Ok((*pool).clone()),
         }
+    }
+
+    /// Build one `search_path`-scoped pool against the registry
+    /// server. Split out of [`Self::scoped_pool`] so the cache-miss
+    /// path stays readable.
+    async fn build_scoped_pool(
+        &self,
+        schema: &str,
+        registry: &PgPool,
+    ) -> Result<PgPool, TenancyError> {
+        let mut opts = (*registry.connect_options()).clone();
+        opts = opts.options([("search_path", &format!("{schema},public") as &str)]);
+        let mut builder = PgPoolOptions::new()
+            .max_connections(self.config.scoped_pool_max_connections)
+            // Explicitly 0: these are cached now, and every one of
+            // them points at the same registry server. Holding warm
+            // connections per tenant is what would make caching them
+            // expensive.
+            .min_connections(0)
+            .acquire_timeout(self.config.database_pool_acquire_timeout);
+        if let Some(idle) = self.config.database_pool_idle_timeout {
+            builder = builder.idle_timeout(idle);
+        }
+        if let Some(lifetime) = self.config.database_pool_max_lifetime {
+            builder = builder.max_lifetime(lifetime);
+        }
+        Ok(builder.connect_with(opts).await?)
     }
 }
 

--- a/crates/rustango/tests/pools_live.rs
+++ b/crates/rustango/tests/pools_live.rs
@@ -387,3 +387,217 @@ async fn database_mode_resolves_secret_reference_via_resolver() {
 
     migrate::drop_all(&pool).await.unwrap();
 }
+
+// ---------------------------------------------------------------- #1235
+// Schema-mode scoped pools are cached per tenant. They used to be
+// rebuilt on every call, and the `Tenant` extractor calls
+// `scoped_pool` once per request — so a schema-mode app paid a full
+// connection establishment per request, in the mode that exists to
+// reduce per-tenant connection overhead.
+//
+// These lean on `PgPool::size()` (connections the pool currently
+// owns) as the observable: a cached pool carries its predecessor's
+// connections, a freshly built one does not.
+
+#[tokio::test]
+async fn scoped_pool_is_cached_per_tenant() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    migrate::drop_all(&pool).await.unwrap();
+    migrate::apply_all(&pool).await.unwrap();
+    drop_schema(&pool, "acme_sp_cache").await;
+    create_schema(&pool, "acme_sp_cache").await;
+
+    let acme = seed_org(
+        &pool,
+        "acme_sp_cache",
+        StorageMode::Schema,
+        Some("acme_sp_cache"),
+        None,
+    )
+    .await;
+    let pools = TenantPools::new(pool.clone());
+
+    // Saturate the first pool: default `scoped_pool_max_connections`
+    // is 2, so holding two checkouts puts its size at 2.
+    let first = pools.scoped_pool(&acme).await.unwrap();
+    let _c1 = first.acquire().await.unwrap();
+    let _c2 = first.acquire().await.unwrap();
+    assert_eq!(first.size(), 2, "expected both connections established");
+
+    // A cached pool IS the first one, so it reports the same size.
+    // Pre-#1235 this was a brand-new pool and reported 1 — the single
+    // connection `connect_with` opens eagerly.
+    let second = pools.scoped_pool(&acme).await.unwrap();
+    assert_eq!(
+        second.size(),
+        2,
+        "second scoped_pool must reuse the cached pool, not build a new one",
+    );
+
+    drop(_c1);
+    drop(_c2);
+    drop_schema(&pool, "acme_sp_cache").await;
+    migrate::drop_all(&pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn scoped_pool_cache_is_keyed_per_tenant_and_stays_scoped() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    migrate::drop_all(&pool).await.unwrap();
+    migrate::apply_all(&pool).await.unwrap();
+    for s in ["acme_sp_key", "globex_sp_key"] {
+        drop_schema(&pool, s).await;
+        create_schema(&pool, s).await;
+    }
+
+    let acme = seed_org(
+        &pool,
+        "acme_sp_key",
+        StorageMode::Schema,
+        Some("acme_sp_key"),
+        None,
+    )
+    .await;
+    let globex = seed_org(
+        &pool,
+        "globex_sp_key",
+        StorageMode::Schema,
+        Some("globex_sp_key"),
+        None,
+    )
+    .await;
+    let pools = TenantPools::new(pool.clone());
+
+    // Caching must not collapse two tenants onto one pool — each keeps
+    // its own baked-in search_path. Interleaved on purpose, so a
+    // single shared entry would show up.
+    let a1 = pools.scoped_pool(&acme).await.unwrap();
+    let g1 = pools.scoped_pool(&globex).await.unwrap();
+    let a2 = pools.scoped_pool(&acme).await.unwrap();
+    let g2 = pools.scoped_pool(&globex).await.unwrap();
+
+    for (p, want) in [
+        (&a1, "acme_sp_key"),
+        (&a2, "acme_sp_key"),
+        (&g1, "globex_sp_key"),
+        (&g2, "globex_sp_key"),
+    ] {
+        let mut conn = p.acquire().await.unwrap();
+        assert_eq!(current_schema(&mut conn).await, want);
+    }
+
+    for s in ["acme_sp_key", "globex_sp_key"] {
+        drop_schema(&pool, s).await;
+    }
+    migrate::drop_all(&pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn invalidate_drops_the_scoped_pool_too() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    migrate::drop_all(&pool).await.unwrap();
+    migrate::apply_all(&pool).await.unwrap();
+    drop_schema(&pool, "acme_sp_inval").await;
+    create_schema(&pool, "acme_sp_inval").await;
+
+    let acme = seed_org(
+        &pool,
+        "acme_sp_inval",
+        StorageMode::Schema,
+        Some("acme_sp_inval"),
+        None,
+    )
+    .await;
+    let pools = TenantPools::new(pool.clone());
+
+    let first = pools.scoped_pool(&acme).await.unwrap();
+    let c1 = first.acquire().await.unwrap();
+    let c2 = first.acquire().await.unwrap();
+    assert_eq!(first.size(), 2);
+    drop(c1);
+    drop(c2);
+
+    // Without this eviction a tenant whose `schema_name` changed would
+    // keep being handed a pool with the OLD schema baked into its
+    // connect options — a cross-tenant read.
+    pools.invalidate(&acme.slug).await;
+
+    let rebuilt = pools.scoped_pool(&acme).await.unwrap();
+    assert!(
+        rebuilt.size() < 2,
+        "invalidate must drop the scoped pool; got a pool with {} connections \
+         (i.e. the cached one)",
+        rebuilt.size(),
+    );
+
+    drop_schema(&pool, "acme_sp_inval").await;
+    migrate::drop_all(&pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn scoped_pool_past_the_cap_falls_back_instead_of_failing() {
+    let _g = live_lock().lock().await;
+    let Some(pool) = pool().await else {
+        return;
+    };
+    migrate::drop_all(&pool).await.unwrap();
+    migrate::apply_all(&pool).await.unwrap();
+    for s in ["acme_sp_cap", "globex_sp_cap"] {
+        drop_schema(&pool, s).await;
+        create_schema(&pool, s).await;
+    }
+
+    let acme = seed_org(
+        &pool,
+        "acme_sp_cap",
+        StorageMode::Schema,
+        Some("acme_sp_cap"),
+        None,
+    )
+    .await;
+    let globex = seed_org(
+        &pool,
+        "globex_sp_cap",
+        StorageMode::Schema,
+        Some("globex_sp_cap"),
+        None,
+    )
+    .await;
+
+    // Cap of 1: the second tenant cannot be cached. Schema mode is
+    // sold for high tenant counts, so exceeding the cap must degrade
+    // to the old per-call build — never error.
+    let cfg = rustango::tenancy::TenantPoolsConfig {
+        max_cached_scoped_pools: 1,
+        ..Default::default()
+    };
+    let pools = TenantPools::new(pool.clone()).config(cfg);
+
+    let a = pools.scoped_pool(&acme).await.unwrap();
+    let g = pools.scoped_pool(&globex).await.unwrap();
+
+    // Both still work, and both are still correctly scoped — the
+    // uncached one is just rebuilt each time.
+    let mut ca = a.acquire().await.unwrap();
+    assert_eq!(current_schema(&mut ca).await, "acme_sp_cap");
+    let mut cg = g.acquire().await.unwrap();
+    assert_eq!(current_schema(&mut cg).await, "globex_sp_cap");
+
+    let g_again = pools.scoped_pool(&globex).await.unwrap();
+    let mut cg2 = g_again.acquire().await.unwrap();
+    assert_eq!(current_schema(&mut cg2).await, "globex_sp_cap");
+
+    for s in ["acme_sp_cap", "globex_sp_cap"] {
+        drop_schema(&pool, s).await;
+    }
+    migrate::drop_all(&pool).await.unwrap();
+}


### PR DESCRIPTION
Closes #1235.

`TenantPools::scoped_pool` rebuilt its `search_path`-baked pool on every call, and the `Tenant` extractor calls it **once per request**. So a schema-mode app paid a TCP connect, TLS handshake and auth round-trip per request — and `PgPoolOptions::connect_with` is eager, so even a handler that only touched `Tenant::conn` paid it without ever using the pool.

That inverts the point of the mode. Schema mode is documented as the high-tenant-count optimisation — one connection budget for all tenants — while database mode returns a cached clone for free. Schema mode was doing strictly *more* connection churn than the mode it's meant to be cheaper than, and N concurrent requests could open up to 2N short-lived connections against the very server it exists to protect.

## What changed

Scoped pools are cached per slug in their own map, bounded by a new `TenantPoolsConfig::max_cached_scoped_pools` (default 64).

- **Separate budget** from `max_cached_database_pools` — one shared cap would silently halve a mixed deployment's database-mode capacity the moment schema-mode tenants took slots.
- **Generic over `DB`** rather than `PgPool`-typed, so the file still builds under `--no-default-features --features sqlite,tenancy`. Only the Postgres impl populates it.
- **Past the cap it falls back** to the old per-call build and warns, rather than erroring. Schema mode's premise is a high tenant count, so a hard failure there would break exactly the deployments it targets — and the fallback is just today's behaviour.
- **`invalidate` now evicts the scoped pool too.** Without it, a tenant whose `schema_name` changed keeps being handed a pool with the old schema baked into its connect options — a cross-tenant read, same class as #1224.

## One behaviour change that needed its own fix

The scoped pool is now **shared** between request handlers and any long-lived worker built on `scoped_pool_dyn` (the per-tenant queue pattern in `docs/jobs.md`), where each previously got its own.

Under sharing the old hardcoded `max_connections(2)` deadlocks: `Tenant::conn` pins a connection for the handler's lifetime, a handler that also uses `t.pool()` needs a second, and a job worker holds one near-permanently. That is the same reasoning that already puts `database_pool_max_connections` at 16.

It is now `scoped_pool_max_connections`, default **8**, with `min_connections = 0` and the configured idle timeout — so a cached but quiet tenant settles back to zero connections, which is what makes caching them affordable. Worst case is `max_cached_scoped_pools × scoped_pool_max_connections` = 64 × 8, documented on both fields with the guidance to keep it under the server's `max_connections`.

## Tests

Four in `pools_live`, two of them true regressions — verified by reverting:

| Test | Fails pre-fix? |
|---|---|
| `scoped_pool_is_cached_per_tenant` — saturates the first pool's checkouts, asserts the second call sees the same `size()` | **yes** (new pool reports 1) |
| `invalidate_drops_the_scoped_pool_too` | **yes**, when the eviction is removed but the cache kept — checked by doing exactly that |
| `scoped_pool_cache_is_keyed_per_tenant_and_stays_scoped` — interleaves two tenants, checks `current_schema()` on each | no — guard against caching collapsing tenants |
| `scoped_pool_past_the_cap_falls_back_instead_of_failing` — cap of 1, two tenants | no — guards the new fallback path |

## Verification

`cargo test --workspace --all-features` against PostgreSQL 16: **510 binaries, 6784 tests, 0 failures**. `cargo fmt --check` clean. `cargo build --no-default-features --features sqlite,tenancy` clean (the multi-backend litmus).

CI still cannot verify this — GitHub Actions remains disabled for the repository.
