### PR TITLE
ci: run on develop pushes, and allow manual dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,18 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    # `develop` is the default branch and where every PR lands, but it
+    # was absent here — so a merge into it ran nothing, and the branch
+    # everyone builds on had no post-merge gate. Only `main` (release)
+    # was covered. PRs were checked, which hides the gap right up until
+    # a squash-merge combination behaves differently from its PR.
+    branches: [main, develop]
   pull_request:
+  # Lets a run be triggered by hand against any branch, without
+  # inventing a no-op commit or opening a throwaway PR — useful for
+  # re-checking a branch after an advisory lands, since `deny` can go
+  # red with no code change at all.
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
`develop` is the default branch and the target of every PR, but the push trigger only listed `main` — so a merge into the branch everyone builds on ran nothing. Only release pushes to `main` and open PRs were gated.

PR coverage hides that gap rather than closing it: a squash-merge is a different commit from the PR head, and several PRs landing in sequence are never built in combination until someone cuts a release. Six merges went into develop before this with no post-merge run.

Also adds `workflow_dispatch`, so a branch can be re-checked by hand without a no-op commit or a throwaway PR. That matters for the `deny` jobs especially — advisories are published over time, so a green run can go red with no code change.

This PR doubles as the first real CI run since 2026-08-18, and the first ever for the `deny-examples` job added in #1238.