### PR TITLE
release: 0.53.0 — version bump + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+## [0.53.0] — 2026-08-28
+
+Minor, not a patch. Two reasons to take the version bump rather than call this
+`0.52.2`:
+
+- `TenantPoolsConfig` gained two `pub` fields and is not `#[non_exhaustive]`, so
+  any exhaustive struct literal against it stops compiling. Under Cargo's `0.x`
+  rules `0.52.2` would be a *compatible* update — every `rustango = "0.52"`
+  dependant would pick it up on a routine `cargo update` and break. `0.53.0`
+  does not match `^0.52`, so the upgrade is opt-in.
+- Schema-mode scoped pools are now shared per tenant rather than built per
+  request, and their `max_connections` default moves 2 → 8. Nothing breaks at
+  compile time, but connection behaviour against the registry server changes.
+
+Everything else is additive. `Cache::delete_prefix` ships with a default body,
+so existing `Cache` implementors are unaffected.
+
+**Upgrading:** add `..Default::default()` to any `TenantPoolsConfig` literal. If
+you run schema mode with many tenants, read the new
+`max_cached_scoped_pools` / `scoped_pool_max_connections` docs — the worst-case
+connection count against your registry server is their product (64 × 8 by
+default), though quiet tenants hold none.
+
+Security: closes GHSA-2p6r-x3vv-xqm2 (`rpassword`) and GHSA-4w2j-m93h-cj5j
+(`quinn-proto`), plus a Redis `FLUSHDB` bug that let one tenant's cache
+invalidation wipe every other tenant's entries.
+
 ### Added
 - **`tenancy::for_each_tenant`** (#1226) — the per-tenant fan-out that scheduled
   sweeps were missing. `MediaManager::purge_orphans`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.52.1"
+version = "0.53.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.52.1", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.52.1", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.52.1", path = "crates/rustango" }
+rustango-macros     = { version = "0.53.0", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.53.0", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.53.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.52.1" }
+orm = { package = "rustango", path = "../rustango", version = "0.53.0" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -480,7 +480,7 @@ runserver = ["_axum"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.52.1", path = "../rustango-macros" }
+rustango-macros = { version = "0.53.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }


### PR DESCRIPTION
Version bump + CHANGELOG for **0.53.0**. Step 1 of the release flow (bump → develop, then promote develop → main, tag, publish).

## Why minor, not `0.52.2`

Two reasons, either sufficient on its own:

1. **`TenantPoolsConfig` gained two `pub` fields** (#1235) and is not `#[non_exhaustive]`, so an exhaustive struct literal against it stops compiling. Under Cargo's `0.x` rules `0.52.2` is a *compatible* update — every `rustango = "0.52"` dependant picks it up on a routine `cargo update` and breaks. `0.53.0` does not match `^0.52`, so the upgrade is opt-in.
2. **Schema-mode scoped pools are now shared per tenant** rather than rebuilt per request, with `max_connections` defaulting 2 → 8. Compiles either way, but connection behaviour against the registry server changes.

Everything else is additive — `Cache::delete_prefix` ships with a default body, so existing `Cache` implementors are untouched.

## Contents

| Area | Issues |
|---|---|
| Tenant isolation for background/scheduled work | #1226 #1227 #1228 #1229 |
| Schema-mode `search_path` leak between registry-pool borrowers | #1224 |
| Redis `FLUSHDB` — one tenant's cache clear wiped every other tenant's entries, locks and rate-limit counters | in #1232 |
| `FileCache` TTL precision | #1233 |
| Tracing target namespace | #1234 |
| Scoped-pool caching | #1235 |
| Advisories: `rpassword`, `quinn-proto` | #1239 #1236 |
| cargo-deny coverage + CI triggers | #1237 #1242 |

## Verification

Bumps the single `[workspace.package] version` plus the five internal pins across three manifests; `cargo metadata --no-deps` resolves all four publishable crates at 0.53.0. `Cargo.lock` is gitignored, so nothing staged there.

The develop tree this is cut from is CI-green (37/37, run `33131919112`) and passed `cargo test --workspace --all-features` against PostgreSQL 16 locally — 510 binaries, 6784 tests.
