### PR TITLE
docs: fix 160 broken references across all locales, and stop requiring Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+### Fixed
+- **160 broken documentation references, across all four locales** (#1248).
+  Reported as three 404s on the docs site; an audit found the whole class.
+
+  `docs/index.toml` publishes only the files it lists, and the site has no
+  `crates/` tree — so every `../crates/…` pointer in a published page 404s
+  there. Those are mostly the "Runnable version:" links nearly every guide
+  carries, and they were **worse in the translations**: `../crates/…` from
+  `docs/fr/` resolves to `docs/crates/`, which has never existed, so the
+  translated pages were broken on GitHub too. All 160 now use absolute
+  `https://github.com/…` URLs (`/blob/` for files, `/tree/` for directories),
+  which resolve from any renderer.
+
+  Also fixed: `getting-started.md` linked `django-parity-audit-2026-05-21.md`,
+  which `index.toml` deliberately does not publish; **111 broken images** in
+  `de` / `es` / `fr`, which copied `img/foo.png` verbatim although images live
+  only in `docs/img/`; and one extensionless `](manage)` link against 246 that
+  use `.md`.
+
+  `tests/docs_links.rs` now walks every published page in every locale and fails
+  the build on a link that escapes the docs tree, does not resolve, or targets an
+  unpublished page — plus a second test pinning locale coverage to `index.toml`.
+
+### Changed
+- **Docker is no longer presented as a prerequisite** (#1247). The getting-started
+  guide listed it as required and had readers verify it with `docker --version`,
+  so a user on Windows — where the Hyper-V/WSL2 backend is a common source of
+  start-up failures — reasonably concluded rustango needed it. It never did:
+  generated projects already ship a `sqlite` feature (CI-gated via
+  `feature_combos`), and a natively-installed Postgres only needs the compose
+  hostname `postgres` swapped for `localhost`. Neither path was documented.
+
+  The prerequisites table now points at a "Choosing a database" section covering
+  all three options, SQLite is recommended for learning, and Step 4 tells the
+  non-Docker reader what to skip. Translated into all four locales.
+
+- `docs/index.toml` declares `version = "0.53"` (was `0.52`).
+
 ## [0.53.0] — 2026-08-28
 
 Minor, not a patch. Two reasons to take the version bump rather than call this

--- a/crates/rustango/tests/docs_links.rs
+++ b/crates/rustango/tests/docs_links.rs
@@ -1,0 +1,168 @@
+//! #1248 — every link and image in a published documentation page must
+//! resolve, in every locale.
+//!
+//! A reader found three 404s on the docs site; an audit turned up 160
+//! broken references across `en` / `de` / `es` / `fr`. Two failure modes,
+//! both invisible on GitHub-rendered English:
+//!
+//! * **`../`-relative links.** `docs/jobs.md` linking `../crates/…`
+//!   resolves on GitHub but not on the docs site, which publishes only
+//!   the files listed in `docs/index.toml` and has no `crates/` tree.
+//!   In a locale the same path is worse — from `docs/fr/` it points at
+//!   `docs/crates/`, which has never existed.
+//! * **Locale images.** Translations copied `img/foo.png` verbatim, but
+//!   images live only in `docs/img/`, so every hero image in `de` / `es`
+//!   / `fr` was broken.
+//!
+//! Repo links now use absolute `https://github.com/…` URLs, which work
+//! from any renderer. This test keeps it that way.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is crates/rustango.
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .expect("resolve repo root")
+}
+
+/// Pages the docs site actually publishes, per `docs/index.toml`.
+/// Anything absent is intentionally unpublished (internal audits), so a
+/// link to it 404s for readers.
+fn published_pages(root: &Path) -> HashSet<String> {
+    let toml = std::fs::read_to_string(root.join("docs/index.toml")).expect("read docs/index.toml");
+    let mut out = HashSet::new();
+    let mut rest = toml.as_str();
+    while let Some(i) = rest.find('"') {
+        rest = &rest[i + 1..];
+        let Some(j) = rest.find('"') else { break };
+        let val = &rest[..j];
+        rest = &rest[j + 1..];
+        if val.ends_with(".md") {
+            out.insert(val.to_owned());
+        }
+    }
+    assert!(!out.is_empty(), "parsed no pages out of docs/index.toml");
+    out
+}
+
+/// Markdown link/image targets: the `(...)` of `[..](..)` and `![..](..)`.
+fn link_targets(text: &str) -> Vec<String> {
+    let bytes: Vec<char> = text.chars().collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == ']' && i + 1 < bytes.len() && bytes[i + 1] == '(' {
+            let mut j = i + 2;
+            let mut buf = String::new();
+            while j < bytes.len() && bytes[j] != ')' && !bytes[j].is_whitespace() {
+                buf.push(bytes[j]);
+                j += 1;
+            }
+            if j < bytes.len() && bytes[j] == ')' && !buf.is_empty() {
+                out.push(buf);
+            }
+            i = j;
+        }
+        i += 1;
+    }
+    out
+}
+
+#[test]
+fn every_published_doc_link_resolves_in_every_locale() {
+    let root = repo_root();
+    let published = published_pages(&root);
+    let mut problems = Vec::new();
+    let mut checked = 0usize;
+
+    for locale_dir in ["docs", "docs/de", "docs/es", "docs/fr"] {
+        for page in &published {
+            let path = root.join(locale_dir).join(page);
+            if !path.exists() {
+                problems.push(format!(
+                    "{locale_dir}/{page}: published in index.toml but the file is missing"
+                ));
+                continue;
+            }
+            checked += 1;
+            let text = std::fs::read_to_string(&path).expect("read page");
+            for target in link_targets(&text) {
+                if target.starts_with("http")
+                    || target.starts_with('#')
+                    || target.starts_with("mailto")
+                {
+                    continue;
+                }
+                // A `../` escape leaves the published tree: it cannot
+                // resolve on the docs site, and in a locale it does not
+                // resolve on GitHub either. Link the repo absolutely.
+                if target.starts_with("../") && !target.starts_with("../img/") {
+                    problems.push(format!(
+                        "{locale_dir}/{page}: `{target}` escapes the docs tree — \
+                         use an absolute https://github.com/ujeenet/rustango/... URL"
+                    ));
+                    continue;
+                }
+                let base = target.split('#').next().unwrap_or(&target);
+                let resolved = path.parent().expect("page has a parent").join(base);
+                if !resolved.exists() {
+                    problems.push(format!("{locale_dir}/{page}: `{target}` does not resolve"));
+                    continue;
+                }
+                // A link to a markdown file that the site does not
+                // publish 404s for readers even though it exists here.
+                if base.ends_with(".md") && !published.contains(base.trim_start_matches("./")) {
+                    problems.push(format!(
+                        "{locale_dir}/{page}: `{target}` targets a page that index.toml \
+                         does not publish"
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(checked > 0, "checked no pages at all");
+    assert!(
+        problems.is_empty(),
+        "{} broken documentation reference(s) across {checked} pages:\n  {}",
+        problems.len(),
+        problems.join("\n  "),
+    );
+}
+
+/// Translations must cover exactly what the site publishes — a missing
+/// locale page is a 404 for that language, an extra one is unreachable.
+#[test]
+fn every_locale_has_every_published_page() {
+    let root = repo_root();
+    let published = published_pages(&root);
+    let mut problems = Vec::new();
+
+    for locale in ["de", "es", "fr"] {
+        let dir = root.join("docs").join(locale);
+        let have: HashSet<String> = std::fs::read_dir(&dir)
+            .expect("read locale dir")
+            .flatten()
+            .filter_map(|e| e.file_name().into_string().ok())
+            .filter(|n| n.ends_with(".md"))
+            .collect();
+        for missing in published.difference(&have) {
+            problems.push(format!("docs/{locale}/{missing} is missing"));
+        }
+        for extra in have.difference(&published) {
+            problems.push(format!(
+                "docs/{locale}/{extra} is not published by index.toml"
+            ));
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "locale coverage gaps:\n  {}",
+        problems.join("\n  "),
+    );
+}

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -17,7 +17,7 @@ and module-scope registration macros.
 >
 > **Runnable version:** every feature on this page is exercised in a tested,
 > compilable example at
-> [`crates/rustango/examples/admin_demo`](../crates/rustango/examples/admin_demo).
+> [`crates/rustango/examples/admin_demo`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/admin_demo).
 > The screenshots on this page are that example. If a snippet looks off, diff
 > against it.
 

--- a/docs/auth-api-keys.md
+++ b/docs/auth-api-keys.md
@@ -19,10 +19,10 @@ backend that stores keys and authenticates `Authorization: Bearer` requests.
 > `ensure_api_keys_table_pool`) — behind the `tenancy` feature.
 >
 > **Runnable version:** the helper snippets are copied from
-> [`auth_api_keys_doc.rs`](../crates/rustango/tests/auth_api_keys_doc.rs)
+> [`auth_api_keys_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_api_keys_doc.rs)
 > (`cargo test -p rustango --test auth_api_keys_doc`); the `ApiKeyBackend`
 > middleware flow from
-> [`auth_backends_doc.rs`](../crates/rustango/tests/auth_backends_doc.rs)
+> [`auth_backends_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_backends_doc.rs)
 > (`cargo test -p rustango --features sqlite,tenancy --test auth_backends_doc`).
 
 ## Table of contents

--- a/docs/auth-backends.md
+++ b/docs/auth-backends.md
@@ -19,7 +19,7 @@ the `CurrentUser` extractor to read the result.
 > `rustango::auth_backends` (always compiled).
 >
 > **Runnable version:** every snippet is copied from
-> [`auth_backends_doc.rs`](../crates/rustango/tests/auth_backends_doc.rs)
+> [`auth_backends_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_backends_doc.rs)
 > (`cargo test -p rustango --features sqlite,tenancy --test auth_backends_doc`).
 
 ## Table of contents

--- a/docs/auth-decorators.md
+++ b/docs/auth-decorators.md
@@ -13,7 +13,7 @@ or answered with 401/403 (API flow) — before they ever reach the handler.
 > behind the `tenancy` feature (the gates read the `SessionUser` extractor).
 >
 > **Runnable version:** the gating behavior is covered by the tested
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_decorators.rs) —
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_decorators.rs) —
 > `cargo test -p auth_demo --test auth_decorators`.
 
 > **New to a term here?** *middleware/layer*, *extractor*, *401/403* — see the

--- a/docs/auth-flows.md
+++ b/docs/auth-flows.md
@@ -17,7 +17,7 @@ trust its parameters without storing anything.
 > features (on by default; reset-confirm also needs `passwords` + a DB backend).
 >
 > **Runnable version:** every snippet is copied from
-> [`auth_flows_doc.rs`](../crates/rustango/tests/auth_flows_doc.rs)
+> [`auth_flows_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_flows_doc.rs)
 > (`cargo test -p rustango --features sqlite --test auth_flows_doc`).
 
 ## Table of contents

--- a/docs/auth-hmac.md
+++ b/docs/auth-hmac.md
@@ -18,7 +18,7 @@ tower layer.
 > protection additionally needs `cache`).
 >
 > **Runnable version:** every snippet is copied from
-> [`auth_hmac_doc.rs`](../crates/rustango/tests/auth_hmac_doc.rs)
+> [`auth_hmac_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_hmac_doc.rs)
 > (`cargo test -p rustango --test auth_hmac_doc`).
 
 ## Table of contents

--- a/docs/auth-jwt-api.md
+++ b/docs/auth-jwt-api.md
@@ -14,7 +14,7 @@ ships that as `JwtLifecycle` — and a batteries-included router that mounts
 > `tenancy`.
 >
 > **Runnable version:** the token engine is covered by the tested
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs) —
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs) —
 > `cargo test -p auth_demo --test auth_jwt_api`. The HTTP endpoints are
 > tenant-scoped and exercised end-to-end by the framework's own
 > `crates/rustango/tests/tenant_auth_live.rs`.

--- a/docs/auth-jwt.md
+++ b/docs/auth-jwt.md
@@ -14,7 +14,7 @@ them back, HS256 under the hood.
 > [JWT auth API](auth-jwt-api.md).
 >
 > **Runnable version:** snippets are copied from the tested
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt.rs) —
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_jwt.rs) —
 > `cargo test -p auth_demo --test auth_jwt`.
 
 > **New to a term here?** *JWT*, *claims*, *stateless*, *secret* — see the

--- a/docs/auth-passwords.md
+++ b/docs/auth-passwords.md
@@ -14,7 +14,7 @@ first choice. You never store, log, or compare the plaintext.
 > `rustango::tenancy::password`.
 >
 > **Runnable version:** every snippet below is copied from the tested
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_passwords.rs)
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_passwords.rs)
 > example — `cargo test -p auth_demo --test auth_passwords`.
 
 > **New to a term here?** *hash*, *salt*, *argon2id*, *PHC string* — see the
@@ -169,7 +169,7 @@ assert!(strength_score("short").contains(&StrengthIssue::TooShort));
 ## Where the hash lives
 
 The PHC string is just a `String` column on whatever account model you own. In
-the [`auth_demo`](../crates/rustango/examples/auth_demo/src/models.rs) example:
+the [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/src/models.rs) example:
 
 ```rust
 #[derive(Model, Clone, Debug)]

--- a/docs/auth-sessions.md
+++ b/docs/auth-sessions.md
@@ -15,7 +15,7 @@ request.
 > production, add the `cache-redis` feature (off by default) to get `RedisCache`.
 >
 > **Runnable version:** snippets below are copied from the tested
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_sessions.rs)
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_sessions.rs)
 > example — `cargo test -p auth_demo --test auth_sessions`.
 
 > **New to a term here?** *session*, *opaque id*, *cookie*, *cache* — see the

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -18,10 +18,10 @@ Django's cache framework or Laravel's `Cache` facade.
 > feature (off by default).
 >
 > **Runnable version:** every snippet is copied from
-> [`cache_doc.rs`](../crates/rustango/tests/cache_doc.rs)
+> [`cache_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/cache_doc.rs)
 > (`cargo test -p rustango --test cache_doc`); the database backend is dogfooded
 > on SQLite by
-> [`cache_db_backend_sqlite_live.rs`](../crates/rustango/tests/cache_db_backend_sqlite_live.rs).
+> [`cache_db_backend_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/cache_db_backend_sqlite_live.rs).
 
 ## Table of contents
 

--- a/docs/de/admin.md
+++ b/docs/de/admin.md
@@ -10,7 +10,7 @@ Live-Modellreferenz. Alles Folgende wird deklarativ in einem `admin(...)`-Block 
 Derive konfiguriert, oder mit einer Handvoll `Builder`-Methoden und Registrierungsmakros
 auf Modulebene.
 
-[![Das automatisch generierte Admin: eine Beitragsliste mit Filter-Facetten, Suche, Massenaktionen und Paginierung — alles aus einem einzigen `admin(...)`-Block](img/admin.png)](img/admin.png)
+[![Das automatisch generierte Admin: eine Beitragsliste mit Filter-Facetten, Suche, Massenaktionen und Paginierung — alles aus einem einzigen `admin(...)`-Block](../img/admin.png)](../img/admin.png)
 
 > **Quelle:** `rustango::admin` (die `admin(...)`-Derive-Optionen, die `Builder`-
 > API und die Registrierungsmakros) — hinter dem `admin`-Feature (standardmäßig
@@ -18,7 +18,7 @@ auf Modulebene.
 >
 > **Lauffähige Version:** jedes Feature auf dieser Seite wird in einem getesteten,
 > kompilierbaren Beispiel unter
-> [`crates/rustango/examples/admin_demo`](../crates/rustango/examples/admin_demo)
+> [`crates/rustango/examples/admin_demo`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/admin_demo)
 > ausgeführt. Die Screenshots auf dieser Seite stammen aus diesem Beispiel. Wenn ein
 > Snippet seltsam aussieht, vergleiche es damit.
 
@@ -84,7 +84,7 @@ Die Admin-Wurzel (`GET /<prefix>`) listet jedes registrierte Modell auf, gruppie
 App, mit Tabellennamen und Feldanzahl jedes Modells — plus einem **Recent actions**-
 Feed der neuesten geprüften Änderungen.
 
-[![Die Admin-Startseite: jedes registrierte Modell nach App gruppiert mit Tabellen- und Feldanzahl sowie ein Aktivitäts-Feed der letzten Aktionen](img/admin-home.png)](img/admin-home.png)
+[![Die Admin-Startseite: jedes registrierte Modell nach App gruppiert mit Tabellen- und Feldanzahl sowie ein Aktivitäts-Feed der letzten Aktionen](../img/admin-home.png)](../img/admin-home.png)
 
 ---
 
@@ -158,7 +158,7 @@ und Zeilenanzahl sowie Facetten-Anzahlen aktualisieren sich. Filter, Suche, Sort
 und die Datumshierarchie fügen sich alle in der Query-Zeichenkette zusammen und lassen
 sich kombinieren.
 
-[![Die nach status=published gefilterte Beitragsliste: ein aktiver Filter-Chip, die passende hervorgehobene Facette, das Suchfeld und der Massenaktionsauswähler](img/admin-list-filtered.png)](img/admin-list-filtered.png)
+[![Die nach status=published gefilterte Beitragsliste: ein aktiver Filter-Chip, die passende hervorgehobene Facette, das Suchfeld und der Massenaktionsauswähler](../img/admin-list-filtered.png)](../img/admin-list-filtered.png)
 
 **Sortieren.** Klicke auf einen Spaltenkopf zum Sortieren; erneut klicken, um die
 Richtung umzukehren (`?sort=col&order=asc|desc`). Der Standard kommt aus `ordering`.
@@ -185,7 +185,7 @@ Spalte hinzu, unter Verwendung der tri-dialektalen Datumsextraktion (PostgreSQL
 (bearbeiten) rendern das Formular. `fieldsets` gruppiert die Eingaben in benannte
 Abschnitte; ohne es erscheinen alle bearbeitbaren Felder in einem Block.
 
-[![Das Post-Änderungsformular gegliedert in die Feldgruppen Content und Publishing, jedes Feld mit dem passenden Eingabe-Widget für seinen Typ](img/admin-fieldsets.png)](img/admin-fieldsets.png)
+[![Das Post-Änderungsformular gegliedert in die Feldgruppen Content und Publishing, jedes Feld mit dem passenden Eingabe-Widget für seinen Typ](../img/admin-fieldsets.png)](../img/admin-fieldsets.png)
 
 Das Absenden eines Formulars validiert die Eingabe, schreibt die Zeile, erfasst einen
 Prüfpfad-Eintrag und leitet zur schreibgeschützten **Detail**-Ansicht
@@ -256,7 +256,7 @@ Tabellenzeile pro Kind, oder `Stacked` — eine Feldgruppe pro Kind), `label`, `
 (Standard: jedes Skalar außer dem FK), `extra` (leere Zeilen zum Hinzufügen angeboten),
 `max_num` und `readonly_fields`.
 
-[![Die Detailseite eines Beitrags: schreibgeschützte Felder, die Comments-Inline-Tabelle und die Prüfpfad-Karte, die den Erstellungs-Eintrag als JSON-Diff zeigt](img/admin-detail.png)](img/admin-detail.png)
+[![Die Detailseite eines Beitrags: schreibgeschützte Felder, die Comments-Inline-Tabelle und die Prüfpfad-Karte, die den Erstellungs-Eintrag als JSON-Diff zeigt](../img/admin-detail.png)](../img/admin-detail.png)
 
 Für Kindzeilen, die über einen generischen Fremdschlüssel (Paar aus Content-Type +
 Objekt-PK) statt über eine einzelne FK-Spalte angehängt sind, verwende
@@ -324,7 +324,7 @@ manipulationssicheren Fingerabdruck. Zwei Stellen zeigen es an:
   / Quelle und einem Aufräumformular, um Einträge älter als N Tage zu bereinigen (was
   selbst als Prüfpfad-Eintrag erfasst wird).
 
-[![Der Activity-Feed: jede geprüfte Änderung über Modelle hinweg mit JSON-Diffs, Facetten-Karten nach Tabelle/Operation/Quelle und einem Aufräumformular](img/admin-audit.png)](img/admin-audit.png)
+[![Der Activity-Feed: jede geprüfte Änderung über Modelle hinweg mit JSON-Diffs, Facetten-Karten nach Tabelle/Operation/Quelle und einem Aufräumformular](../img/admin-audit.png)](../img/admin-audit.png)
 
 ---
 
@@ -518,7 +518,7 @@ Jedes Admin liefert eine Live-Modellreferenz (Djangos admindocs) unter
 Feldern, Spalten, Typen, Flags (PK, unique, …) und Beziehungen. Nichts zu konfigurieren;
 es wird aus deinen Modellen generiert, also weicht es nie vom Schema ab.
 
-[![Die Modellreferenz: die Felder jedes Modells mit Spaltenname, Rust-Typ, Flags und Beziehungen — aus den Modellen generiert](img/admin-model-reference.png)](img/admin-model-reference.png)
+[![Die Modellreferenz: die Felder jedes Modells mit Spaltenname, Rust-Typ, Flags und Beziehungen — aus den Modellen generiert](../img/admin-model-reference.png)](../img/admin-model-reference.png)
 
 ---
 

--- a/docs/de/api-conventions.md
+++ b/docs/de/api-conventions.md
@@ -4,7 +4,7 @@
 
 Diese Seite erklärt die Muster, denen die API von **Rustango** folgt, damit Sie das Verhalten jeder Methode vorhersagen können, bevor Sie deren Dokumentation lesen. Wenn Sie zu einem Feature beitragen oder es auditieren, sind dies die Regeln.
 
-[![Namenskonvention von Rustango: das Methodensuffix sagt Ihnen, was sie entgegennimmt — `*_on` für einen typisierten Pool, blank für den Multi-Backend-Pool und pool-freie Signale](img/api-conventions.png)](img/api-conventions.png)
+[![Namenskonvention von Rustango: das Methodensuffix sagt Ihnen, was sie entgegennimmt — `*_on` für einen typisierten Pool, blank für den Multi-Backend-Pool und pool-freie Signale](../img/api-conventions.png)](../img/api-conventions.png)
 
 ## Inhaltsverzeichnis
 

--- a/docs/de/auth-api-keys.md
+++ b/docs/de/auth-api-keys.md
@@ -8,7 +8,7 @@ Ihnen zwei Ebenen: einen eigenständigen Erzeugungs-/Verifizierungshelfer, den
 Sie an Ihre eigene Tabelle anbinden können, und ein schlüsselfertiges Backend,
 das Schlüssel speichert und `Authorization: Bearer`-Anfragen authentifiziert.
 
-[![API-Schlüssel in Rustango: generate_key liefert einen Einmal-Token prefix.secret, Sie speichern das 8-stellige Präfix plus einen argon2id-Hash, und verify_key prüft ein eingehendes Secret](img/auth-api-keys.png)](img/auth-api-keys.png)
+[![API-Schlüssel in Rustango: generate_key liefert einen Einmal-Token prefix.secret, Sie speichern das 8-stellige Präfix plus einen argon2id-Hash, und verify_key prüft ein eingehendes Secret](../img/auth-api-keys.png)](../img/auth-api-keys.png)
 
 > **Ein Begriff hier neu für Sie?** *Token*, *Hash*, *Bearer*, *argon2id* — das
 > [Glossar](glossary.md) definiert die Bausteine.
@@ -20,10 +20,10 @@ das Schlüssel speichert und `Authorization: Bearer`-Anfragen authentifiziert.
 > `ensure_api_keys_table_pool`) — hinter dem Feature `tenancy`.
 >
 > **Lauffähige Version:** Die Helfer-Snippets sind aus
-> [`auth_api_keys_doc.rs`](../crates/rustango/tests/auth_api_keys_doc.rs) kopiert
+> [`auth_api_keys_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_api_keys_doc.rs) kopiert
 > (`cargo test -p rustango --test auth_api_keys_doc`); der Middleware-Ablauf des
 > `ApiKeyBackend` aus
-> [`auth_backends_doc.rs`](../crates/rustango/tests/auth_backends_doc.rs)
+> [`auth_backends_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_backends_doc.rs)
 > (`cargo test -p rustango --features sqlite,tenancy --test auth_backends_doc`).
 
 ## Inhaltsverzeichnis

--- a/docs/de/auth-backends.md
+++ b/docs/de/auth-backends.md
@@ -8,7 +8,7 @@ Routen akzeptieren kann. Das ist Djangos `AUTHENTICATION_BACKENDS`-Idee, an axum
 verdrahtet. Kombinieren Sie es mit `require_auth` / `require_perm`, um Routen
 abzusichern, und dem `CurrentUser`-Extraktor, um das Ergebnis zu lesen.
 
-[![Auth-Backends in Rustango: eine Anfrage durchläuft eine Kette von Backends (ModelBackend, ApiKeyBackend, JwtBackend); das erste, das den Anmeldenachweis erkennt, gewinnt und injiziert CurrentUser, dann prüft require_perm einen Codename](img/auth-backends.png)](img/auth-backends.png)
+[![Auth-Backends in Rustango: eine Anfrage durchläuft eine Kette von Backends (ModelBackend, ApiKeyBackend, JwtBackend); das erste, das den Anmeldenachweis erkennt, gewinnt und injiziert CurrentUser, dann prüft require_perm einen Codename](../img/auth-backends.png)](../img/auth-backends.png)
 
 > **Ein Begriff hier neu?** *Backend*, *Middleware*, *Extraktor*,
 > *Berechtigungs-Codename* — siehe das [Glossar](glossary.md).
@@ -20,7 +20,7 @@ abzusichern, und dem `CurrentUser`-Extraktor, um das Ergebnis zu lesen.
 > `rustango::auth_backends` (immer kompiliert).
 >
 > **Ausführbare Version:** jeder Ausschnitt ist aus
-> [`auth_backends_doc.rs`](../crates/rustango/tests/auth_backends_doc.rs)
+> [`auth_backends_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_backends_doc.rs)
 > kopiert (`cargo test -p rustango --features sqlite,tenancy --test auth_backends_doc`).
 
 ## Inhaltsverzeichnis

--- a/docs/de/auth-decorators.md
+++ b/docs/de/auth-decorators.md
@@ -6,7 +6,7 @@ hängen Sie einen an einen Router, und anonyme Anfragen werden abgewiesen — pe
 302 auf Ihre Anmeldeseite umgeleitet (Browser-Ablauf) oder mit 401/403
 beantwortet (API-Ablauf) —, bevor sie je den Handler erreichen.
 
-[![Zugriffs-Dekoratoren: login_required leitet anonyme Browser per 302 auf /login?next= um, die _or_403-Familie gibt 401/403 für APIs zurück, superuser_required sichert nach Rolle ab](img/auth-decorators.png)](img/auth-decorators.png)
+[![Zugriffs-Dekoratoren: login_required leitet anonyme Browser per 302 auf /login?next= um, die _or_403-Familie gibt 401/403 für APIs zurück, superuser_required sichert nach Rolle ab](../img/auth-decorators.png)](../img/auth-decorators.png)
 
 > **Quelle:** `rustango::auth_decorators` (`login_required`, `login_required_or_401`,
 > `user_passes_test`, `superuser_required`, `active_required`,
@@ -14,7 +14,7 @@ beantwortet (API-Ablauf) —, bevor sie je den Handler erreichen.
 > hinter dem Feature `tenancy` (die Gatter lesen den `SessionUser`-Extraktor).
 >
 > **Ausführbare Version:** das Absicherungsverhalten wird vom getesteten
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_decorators.rs)
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_decorators.rs)
 > abgedeckt — `cargo test -p auth_demo --test auth_decorators`.
 
 > **Ein Begriff hier neu?** *Middleware/Layer*, *Extraktor*, *401/403* — siehe das

--- a/docs/de/auth-flows.md
+++ b/docs/de/auth-flows.md
@@ -7,7 +7,7 @@ dann handeln, wenn er darauf klickt — und **Rustango** baut sie auf einem einz
 **signierten URLs**. Eine signierte URL ist eine normale URL mit angehängter HMAC-Signatur, sodass
 der Server ihren Parametern vertrauen kann, ohne irgendetwas zu speichern.
 
-[![Konto-Abläufe in Rustango: signed_url::sign hängt eine HMAC-Signatur + Ablauf an; die drei Abläufe (Passwort-Zurücksetzung, E-Mail-Verifizierung, Magic Link) stellen einen Link aus, versenden ihn per E-Mail und verifizieren ihn beim Klick](img/auth-flows.png)](img/auth-flows.png)
+[![Konto-Abläufe in Rustango: signed_url::sign hängt eine HMAC-Signatur + Ablauf an; die drei Abläufe (Passwort-Zurücksetzung, E-Mail-Verifizierung, Magic Link) stellen einen Link aus, versenden ihn per E-Mail und verifizieren ihn beim Klick](../img/auth-flows.png)](../img/auth-flows.png)
 
 > **Ein Begriff hier neu für Sie?** *HMAC*, *Token*, *Ablauf* — siehe das [Glossar](glossary.md).
 
@@ -17,7 +17,7 @@ der Server ihren Parametern vertrauen kann, ohne irgendetwas zu speichern.
 > (standardmäßig aktiv; die Reset-Bestätigung braucht zusätzlich `passwords` + ein DB-Backend).
 >
 > **Ausführbare Version:** jeder Ausschnitt ist aus
-> [`auth_flows_doc.rs`](../crates/rustango/tests/auth_flows_doc.rs) kopiert
+> [`auth_flows_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_flows_doc.rs) kopiert
 > (`cargo test -p rustango --features sqlite --test auth_flows_doc`).
 
 ## Inhaltsverzeichnis

--- a/docs/de/auth-hmac.md
+++ b/docs/de/auth-hmac.md
@@ -10,7 +10,7 @@ veraltete Anfrage abgelehnt wird. Es ist das Schema, das AWS SigV4 und
 Webhook-Signaturen verwenden, und **Rustango** liefert es als einen einzigen
 Tower-Layer.
 
-[![HMAC-Signierung in Rustango: der Client signiert Methode+Pfad+Query+Datum+Body-Hash mit einem gemeinsamen Secret; HmacAuthLayer berechnet neu und vergleicht in konstanter Zeit, manipulierte oder veraltete Anfragen werden abgelehnt](img/auth-hmac.png)](img/auth-hmac.png)
+[![HMAC-Signierung in Rustango: der Client signiert Methode+Pfad+Query+Datum+Body-Hash mit einem gemeinsamen Secret; HmacAuthLayer berechnet neu und vergleicht in konstanter Zeit, manipulierte oder veraltete Anfragen werden abgelehnt](../img/auth-hmac.png)](../img/auth-hmac.png)
 
 > **Ein Begriff hier neu für Sie?** *HMAC*, *gemeinsames Secret*, *Replay*, *Vergleich in konstanter Zeit* —
 > siehe das [Glossar](glossary.md).
@@ -20,7 +20,7 @@ Tower-Layer.
 > Replay-Schutz benötigt zusätzlich `cache`).
 >
 > **Lauffähige Version:** Jedes Snippet ist aus
-> [`auth_hmac_doc.rs`](../crates/rustango/tests/auth_hmac_doc.rs) kopiert
+> [`auth_hmac_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_hmac_doc.rs) kopiert
 > (`cargo test -p rustango --test auth_hmac_doc`).
 
 ## Inhaltsverzeichnis

--- a/docs/de/auth-jwt-api.md
+++ b/docs/de/auth-jwt-api.md
@@ -7,7 +7,7 @@ Refresh und **Widerruf** für das Abmelden. **Rustango** liefert das als
 `JwtLifecycle` — und einen schlüsselfertigen Router, der `POST /api/auth/login`,
 `/refresh`, `/logout` und `GET /me` für Sie einhängt.
 
-[![JWT-Auth-API: login stellt ein Access+Refresh-Paar aus, refresh rotiert und setzt den alten Token auf die Sperrliste, logout widerruft über einen JTI-Speicher](img/auth-jwt-api.png)](img/auth-jwt-api.png)
+[![JWT-Auth-API: login stellt ein Access+Refresh-Paar aus, refresh rotiert und setzt den alten Token auf die Sperrliste, logout widerruft über einen JTI-Speicher](../img/auth-jwt-api.png)](../img/auth-jwt-api.png)
 
 > **Quelle:** `rustango::tenancy::jwt_lifecycle` (`JwtLifecycle`, `JwtTokenPair`,
 > `JwtClaims`) und `rustango::tenancy::auth_routes` (`jwt_router`, `Config`) +
@@ -15,7 +15,7 @@ Refresh und **Widerruf** für das Abmelden. **Rustango** liefert das als
 > `tenancy`.
 >
 > **Lauffähige Version:** Die Token-Engine wird durch den getesteten
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs)
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs)
 > abgedeckt — `cargo test -p auth_demo --test auth_jwt_api`. Die HTTP-Endpunkte
 > sind tenant-bezogen und werden durchgängig durch das eigene
 > `crates/rustango/tests/tenant_auth_live.rs` des Frameworks geprüft.

--- a/docs/de/auth-jwt.md
+++ b/docs/de/auth-jwt.md
@@ -7,7 +7,7 @@ Cache-Abfrage pro Anfrage. Das Modul `rustango::jwt` von **Rustango** ist der
 minimale Baustein: `encode` zum Signieren von Claims, `decode` zum Verifizieren
 und Zurücklesen, HS256 unter der Haube.
 
-[![Eigenständiges JWT in Rustango: Claims tragen sub-/exp-/benutzerdefinierte Felder, encode() signiert mit einem gemeinsamen Secret, decode() verifiziert Signatur + Ablauf](img/auth-jwt.png)](img/auth-jwt.png)
+[![Eigenständiges JWT in Rustango: Claims tragen sub-/exp-/benutzerdefinierte Felder, encode() signiert mit einem gemeinsamen Secret, decode() verifiziert Signatur + Ablauf](../img/auth-jwt.png)](../img/auth-jwt.png)
 
 > **Quelle:** `rustango::jwt` (`Claims`, `encode`, `decode`, `decode_at`,
 > `decode_unverified`, `JwtError`) — hinter dem Feature `jwt` (standardmäßig
@@ -15,7 +15,7 @@ und Zurücklesen, HS256 unter der Haube.
 > [JWT-Auth-API](auth-jwt-api.md).
 >
 > **Lauffähige Version:** Die Snippets sind aus dem getesteten
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt.rs) kopiert —
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_jwt.rs) kopiert —
 > `cargo test -p auth_demo --test auth_jwt`.
 
 > **Ein Begriff hier neu für Sie?** *JWT*, *Claims*, *zustandslos*, *Secret* —

--- a/docs/de/auth-passwords.md
+++ b/docs/de/auth-passwords.md
@@ -7,7 +7,7 @@ gestützt auf **argon2id**, den *memory-hard* Gewinner der Password Hashing
 Competition und die aktuelle Erstwahl der OWASP. Sie speichern, protokollieren
 oder vergleichen den Klartext niemals.
 
-[![Passwörter in Rustango: hash() erzeugt eine gesalzene argon2id-PHC-Zeichenkette, verify() prüft einen Versuch dagegen, und verify_dummy() gleicht die Anmelde-Timing an](img/auth-passwords.png)](img/auth-passwords.png)
+[![Passwörter in Rustango: hash() erzeugt eine gesalzene argon2id-PHC-Zeichenkette, verify() prüft einen Versuch dagegen, und verify_dummy() gleicht die Anmelde-Timing an](../img/auth-passwords.png)](../img/auth-passwords.png)
 
 > **Quelle:** `rustango::passwords` (`hash`, `verify`, `verify_dummy`,
 > `strength_score`, `StrengthIssue`) — hinter dem Feature `passwords`
@@ -15,7 +15,7 @@ oder vergleichen den Klartext niemals.
 > Passwort-Hilfsfunktionen siehe `rustango::tenancy::password`.
 >
 > **Ausführbare Version:** jeder Ausschnitt unten ist aus dem getesteten Beispiel
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_passwords.rs)
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_passwords.rs)
 > kopiert — `cargo test -p auth_demo --test auth_passwords`.
 
 > **Ein Begriff hier neu?** *hash*, *salt*, *argon2id*, *PHC-Zeichenkette* — siehe
@@ -177,7 +177,7 @@ assert!(strength_score("short").contains(&StrengthIssue::TooShort));
 
 Die PHC-Zeichenkette ist lediglich eine `String`-Spalte auf dem beliebigen
 Kontomodell, das Ihnen gehört. Im Beispiel
-[`auth_demo`](../crates/rustango/examples/auth_demo/src/models.rs):
+[`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/src/models.rs):
 
 ```rust
 #[derive(Model, Clone, Debug)]

--- a/docs/de/auth-sessions.md
+++ b/docs/de/auth-sessions.md
@@ -7,7 +7,7 @@ behält. Der `SessionStore` von **Rustango** legt diesen Zustand in einen Cache
 trägt und eine Session **sofort widerrufen** werden kann — löschen Sie den
 Eintrag, und jede Replik sieht das Abmelden bei der nächsten Anfrage.
 
-[![Sessions in Rustango: das Cookie enthält nur eine opake ID, der SessionStore hält die Daten in Redis, und destroy() widerruft sie überall](img/auth-sessions.png)](img/auth-sessions.png)
+[![Sessions in Rustango: das Cookie enthält nur eine opake ID, der SessionStore hält die Daten in Redis, und destroy() widerruft sie überall](../img/auth-sessions.png)](../img/auth-sessions.png)
 
 > **Quelle:** `rustango::sessions` (`Session`, `SessionStore`) +
 > `rustango::cache` (`BoxedCache`, `InMemoryCache`) — hinter dem Feature
@@ -16,7 +16,7 @@ Eintrag, und jede Replik sieht das Abmelden bei der nächsten Anfrage.
 > hinzu (standardmäßig deaktiviert), um `RedisCache` zu erhalten.
 >
 > **Ausführbare Version:** die Ausschnitte unten sind aus dem getesteten Beispiel
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_sessions.rs)
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_sessions.rs)
 > kopiert — `cargo test -p auth_demo --test auth_sessions`.
 
 > **Ein Begriff hier neu?** *Session*, *opake ID*, *Cookie*, *Cache* — siehe das

--- a/docs/de/benchmarks.md
+++ b/docs/de/benchmarks.md
@@ -27,7 +27,7 @@ Ein-Kommando-Harness (siehe [Reproduce](#reproduce)). Nichts hier ist mit Handbe
 > liefert ein vollständiges, batteries-included Framework. Selbst das schnellste nicht kompilierte
 > Ergebnis, **Laravel auf Octane**, liegt um das 4- bis 7-Fache hinter beiden Binaries.
 
-[![Requests/Sek. auf dem nicht gecachten Blog-Index über alle sechs Laufzeiten — Go 6.651, Rustango 4.781, Laravel+Octane 1.238, Django+Hypercorn 910, Django+gunicorn 850, Laravel+php-fpm 408](img/benchmarks.png)](img/benchmarks.png)
+[![Requests/Sek. auf dem nicht gecachten Blog-Index über alle sechs Laufzeiten — Go 6.651, Rustango 4.781, Laravel+Octane 1.238, Django+Hypercorn 910, Django+gunicorn 850, Laravel+php-fpm 408](../img/benchmarks.png)](../img/benchmarks.png)
 
 ---
 

--- a/docs/de/caching.md
+++ b/docs/de/caching.md
@@ -8,7 +8,7 @@ Compute-on-Miss-Helfer (`get_or_set`) und typisierte JSON-Helfer. Tausche das
 Backend, ohne eine einzige Aufrufstelle anzufassen — wie Djangos Cache-Framework
 oder Laravels `Cache`-Fassade.
 
-[![Caching in Rustango: get_or_set checks the cache, runs the factory only on a miss, stores the result with a TTL, and serves hits instantly; the same Cache trait backs InMemory, Redis, and DB](img/caching.png)](img/caching.png)
+[![Caching in Rustango: get_or_set checks the cache, runs the factory only on a miss, stores the result with a TTL, and serves hits instantly; the same Cache trait backs InMemory, Redis, and DB](../img/caching.png)](../img/caching.png)
 
 > **Ein Begriff hier neu für dich?** *Cache*, *TTL*, *Key*, *Backend* — siehe
 > das [Glossar](glossary.md).
@@ -19,10 +19,10 @@ oder Laravels `Cache`-Fassade.
 > `cache-redis`-Feature (standardmäßig aus).
 >
 > **Ausführbare Version:** jeder Codeausschnitt ist aus
-> [`cache_doc.rs`](../crates/rustango/tests/cache_doc.rs) kopiert
+> [`cache_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/cache_doc.rs) kopiert
 > (`cargo test -p rustango --test cache_doc`); das Datenbank-Backend wird per
 > Dogfooding auf SQLite durch
-> [`cache_db_backend_sqlite_live.rs`](../crates/rustango/tests/cache_db_backend_sqlite_live.rs)
+> [`cache_db_backend_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/cache_db_backend_sqlite_live.rs)
 > erprobt.
 
 ## Inhaltsverzeichnis

--- a/docs/de/email.md
+++ b/docs/de/email.md
@@ -7,7 +7,7 @@ einen flüssigen `Email`-Builder mit Schutz vor Header-Injection und
 Template-Rendering. Schreibe `mailer.send(&email)` einmal; wechsle vom Drucken
 in dein Terminal zu echtem SMTP mit einer einzeiligen Änderung — wie Djangos E-Mail-Framework.
 
-[![E-Mail in Rustango: Ein Email-Builder (to/subject/body/html) wird gegen Header-Injection validiert und dann durch das Mailer-Trait versendet — ConsoleMailer in dev, SmtpMailer in prod, InMemoryMailer in Tests](img/email.png)](img/email.png)
+[![E-Mail in Rustango: Ein Email-Builder (to/subject/body/html) wird gegen Header-Injection validiert und dann durch das Mailer-Trait versendet — ConsoleMailer in dev, SmtpMailer in prod, InMemoryMailer in Tests](../img/email.png)](../img/email.png)
 
 > **Neu bei einem Begriff hier?** *transaktionale E-Mail*, *SMTP*, *Mailer-Backend* — siehe
 > das [Glossar](glossary.md).
@@ -18,7 +18,7 @@ in dein Terminal zu echtem SMTP mit einer einzeiligen Änderung — wie Djangos 
 > `email-smtp`-Feature.
 >
 > **Lauffähige Version:** Jedes Snippet ist kopiert aus
-> [`email_doc.rs`](../crates/rustango/tests/email_doc.rs)
+> [`email_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/email_doc.rs)
 > (`cargo test -p rustango --test email_doc`); die Send-Helfer und Anhänge
 > werden von `email_send_helpers.rs` und `email_attachments.rs` selbst erprobt.
 

--- a/docs/de/files.md
+++ b/docs/de/files.md
@@ -7,7 +7,7 @@ mit Größen-/Typ-Schutzvorkehrungen und — wenn du eine nachverfolgte Mediathe
 datenbankgestützten `MediaManager` mit vorsignierten URLs. Schreibe deinen Code
 einmal gegen das Trait; wechsle von lokaler Festplatte zu S3 mit einer einzeiligen Änderung.
 
-[![Dateien in Rustango: Ein Multipart-Upload wird größen- und erweiterungsgeprüft und dann durch das Storage-Trait geschrieben; dasselbe Trait unterlegt lokale Festplatte, S3 und In-Memory, und url() gibt eine öffentliche Adresse zurück](img/files.png)](img/files.png)
+[![Dateien in Rustango: Ein Multipart-Upload wird größen- und erweiterungsgeprüft und dann durch das Storage-Trait geschrieben; dasselbe Trait unterlegt lokale Festplatte, S3 und In-Memory, und url() gibt eine öffentliche Adresse zurück](../img/files.png)](../img/files.png)
 
 > **Neu bei einem Begriff hier?** *Storage-Backend*, *Multipart*, *Objektspeicher*,
 > *vorsignierte URL* — siehe das [Glossar](glossary.md).
@@ -19,11 +19,11 @@ einmal gegen das Trait; wechsle von lokaler Festplatte zu S3 mit einer einzeilig
 > `media` (alle standardmäßig aktiviert).
 >
 > **Lauffähige Version:** Die Storage- + Upload-Schutzvorkehrungs-Snippets sind kopiert aus
-> [`files_doc.rs`](../crates/rustango/tests/files_doc.rs)
+> [`files_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/files_doc.rs)
 > (`cargo test -p rustango --test files_doc`); der End-to-End-Multipart-`save_uploads`-Ablauf
 > wird von den In-File-Tests in
 > `crates/rustango/src/uploads.rs` selbst erprobt, und die Mediathek von
-> [`media_sqlite_live.rs`](../crates/rustango/tests/media_sqlite_live.rs).
+> [`media_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/media_sqlite_live.rs).
 
 ## Inhaltsverzeichnis
 

--- a/docs/de/getting-started.md
+++ b/docs/de/getting-started.md
@@ -4,9 +4,9 @@ Diese Anleitung führt dich von einem leeren Verzeichnis bis zu einem deployten 
 
 > **Dauer:** ~45 Minuten für die komplette Tour, ~10 Minuten, wenn du es nur laufen sehen willst.
 >
-> **Lauffähige Version:** Jeder Schritt unten ist in einem getesteten, kompilierbaren Beispiel unter [`crates/rustango/examples/getting_started_blog`](../crates/rustango/examples/getting_started_blog) nachgebildet. Falls ein Schritt jemals seltsam aussieht, vergleiche ihn damit.
+> **Lauffähige Version:** Jeder Schritt unten ist in einem getesteten, kompilierbaren Beispiel unter [`crates/rustango/examples/getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog) nachgebildet. Falls ein Schritt jemals seltsam aussieht, vergleiche ihn damit.
 
-[![Einen Blog mit Rustango bauen: die Migration generieren, sie anwenden, den Server starten und die JSON-API abfragen — alles aus einem einzigen Binary](img/getting-started.png)](img/getting-started.png)
+[![Einen Blog mit Rustango bauen: die Migration generieren, sie anwenden, den Server starten und die JSON-API abfragen — alles aus einem einzigen Binary](../img/getting-started.png)](../img/getting-started.png)
 
 ---
 
@@ -15,15 +15,69 @@ Diese Anleitung führt dich von einem leeren Verzeichnis bis zu einem deployten 
 | Werkzeug | Wofür | Installation |
 |---|---|---|
 | Rust 1.88+ | Compiler | <https://rustup.rs> |
-| Docker | Lokales Postgres | <https://docker.com> |
+| Eine Datenbank | Diese Anleitung nutzt Postgres | siehe [Datenbank wählen](#datenbank-wählen) unten |
 | `psql` (optional) | DB inspizieren | `brew install libpq` / `apt install postgresql-client` |
-
-Prüfe die installierten Versionen:
 
 ```bash
 rustc --version    # should print 1.88+
-docker --version   # any recent version
 ```
+
+### Datenbank wählen
+
+**Docker ist nicht erforderlich.** Diese Anleitung greift darauf zurück, weil ein
+einziger Befehl ein wegwerfbares Postgres liefert — aber nichts in rustango hängt
+davon ab. Wähle die Zeile, die zu deinem Rechner passt; alles Weitere ist identisch:
+
+| Du willst | Mach das | Hinweise |
+|---|---|---|
+| **Gar keinen Datenbankserver** | Mit SQLite laufen lassen (siehe unten) | Nichts zu installieren. Ideal zum Lernen. |
+| Postgres **ohne** Docker | Postgres nativ installieren, `DATABASE_URL` auf `localhost` zeigen lassen | Siehe [Natives Postgres](#natives-postgres-ohne-docker). |
+| Postgres **mit** Docker | `docker compose up -d` im generierten Projekt | Wovon der Rest dieser Anleitung ausgeht. |
+
+#### SQLite — ohne jede Einrichtung
+
+Generierte Projekte bringen ein `sqlite`-Feature mit, du kannst also loslegen,
+ohne irgendetwas zu installieren oder zu starten:
+
+```bash
+cargo run --no-default-features --features sqlite
+```
+
+mit einer dateibasierten URL in `.env` statt der Postgres-Variante:
+
+```bash
+DATABASE_URL=sqlite://myblog_dev.db?mode=rwc
+```
+
+`mode=rwc` weist SQLite an, die Datei anzulegen, falls sie fehlt. Alles in dieser
+Anleitung — Modelle, Migrationen, das Admin, das ORM — funktioniert unverändert;
+nur Postgres-spezifische Funktionen (`JSONB`-Operatoren, Schema-Mode-Mandanten)
+entfallen.
+
+#### Natives Postgres (ohne Docker)
+
+Installiere Postgres über deinen Paketmanager (`brew install postgresql@16`,
+`apt install postgresql` oder das Windows-Installationsprogramm unter
+<https://www.postgresql.org/download/windows/>) und lege dann Rolle und Datenbank
+an, die die generierte Konfiguration erwartet:
+
+```bash
+createuser -s rustango          # oder: CREATE ROLE rustango LOGIN SUPERUSER PASSWORD 'rustango';
+createdb myblog_dev -O rustango
+```
+
+Die generierte `.env.example` zeigt auf den Docker-Servicenamen. Ersetze den Host
+durch `localhost`:
+
+```bash
+# .env  —  `postgres` ist der docker-compose-Servicename; nativ ist es localhost
+DATABASE_URL=postgres://rustango:rustango@localhost:5432/myblog_dev
+```
+
+> **Unter Windows?** Das Hyper-V-/WSL2-Backend von Docker Desktop ist eine
+> häufige Ursache für Startprobleme. Wenn es sich querstellt, nimm den
+> SQLite-Weg oben, um das Framework zu lernen, und komm zu Docker zurück, wenn
+> es ans Deployment geht — dafür ist das Container-Setup eigentlich da.
 
 ---
 
@@ -123,7 +177,15 @@ openssl rand -base64 32     # paste output as RUSTANGO_SESSION_SECRET value
 
 ---
 
-## Schritt 4: Postgres starten
+## Schritt 4: Die Datenbank starten
+
+> **Du nutzt SQLite?** Überspring diesen Schritt — es gibt keinen Server zu
+> starten. Stell sicher, dass in `.env` `DATABASE_URL=sqlite://myblog_dev.db?mode=rwc`
+> steht, und häng an jedes `cargo run` unten `--no-default-features --features sqlite` an.
+>
+> **Du nutzt ein natives Postgres?** Es läuft bereits als Dienst; prüf nur, dass
+> `psql "$DATABASE_URL" -c "SELECT version();"` durchgeht, und spring weiter.
+
 
 Das Projekt bringt eine `docker-compose.yml` mit, die Postgres in einem Container ausführt, sodass du keine Datenbank von Hand installieren musst. Die App selbst führen wir mit `cargo` auf dem Host aus, also starte nur den `postgres`-Dienst im Hintergrund (die Compose-Datei definiert außerdem einen optionalen `rust`-Dev-Container, der andernfalls Port 8080 belegen würde):
 
@@ -713,15 +775,15 @@ Stelle sicher, dass dein Reverse-Proxy:
 
 | Thema | Doku |
 |---|---|
-| Lauffähige Version dieses Leitfadens | [`examples/getting_started_blog`](../crates/rustango/examples/getting_started_blog) |
+| Lauffähige Version dieses Leitfadens | [`examples/getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog) |
 | Jeder `manage`-Unterbefehl | [`docs/manage.md`](manage.md) |
 | ORM-Kochbuch (fortgeschrittene Filter, Aggregationen, M2M, Soft-Delete) | [`docs/orm.md`](orm.md) |
 | Middleware (der vollständige Schichtenkatalog + Reihenfolge) | [`docs/middleware.md`](middleware.md) |
 | Performance-Benchmarks (vs. Go) | [`docs/benchmarks.md`](benchmarks.md) |
 | API-Konventionen (Benennung, Builder-Muster, Feature-Gates) | [`docs/api-conventions.md`](api-conventions.md) |
 | Security-Features im Detail | [`docs/security.md`](security.md) |
-| Django-Parity-Audit | [`docs/django-parity-audit-2026-05-21.md`](django-parity-audit-2026-05-21.md) |
-| Multi-Tenancy | [README — Abschnitt Multi-tenancy](../README.md#multi-tenancy) |
+| Django-Parity-Audit | [`docs/django-parity-audit-2026-05-21.md`](https://github.com/ujeenet/rustango/blob/main/docs/django-parity-audit-2026-05-21.md) |
+| Multi-Tenancy | [README — Abschnitt Multi-tenancy](https://github.com/ujeenet/rustango/blob/main/README.md#multi-tenancy) |
 | API-Doku | <https://docs.rs/rustango> |
 
 Wenn du auf etwas stößt, das nicht funktioniert oder unklar ist, öffne ein Issue.

--- a/docs/de/html-views.md
+++ b/docs/de/html-views.md
@@ -11,7 +11,7 @@ Dies sind das Äquivalent von **Rustango** zu Djangos generischen klassenbasiert
 (`ListView`, `DetailView`, `CreateView`, `UpdateView`, `DeleteView`) oder Laravels
 Resource-Controllern, die Blade-Views zurückgeben. Sie rendern über [Tera](https://keats.github.io/tera/)-Templates.
 
-[![HTML-Views in Rustango: Ein Modell speist ListView, DetailView und CreateView/UpdateView/DeleteView, die jeweils ein Tera-Template zu einer serverseitig gerenderten Seite rendern](img/html-views.png)](img/html-views.png)
+[![HTML-Views in Rustango: Ein Modell speist ListView, DetailView und CreateView/UpdateView/DeleteView, die jeweils ein Tera-Template zu einer serverseitig gerenderten Seite rendern](../img/html-views.png)](../img/html-views.png)
 
 > **Neu bei einem Begriff hier?** Falls *Modell*, *Template*, *Router* oder *serverseitig gerendert*
 > unbekannt sind, erklärt das [Glossar](glossary.md) jeden in einfacher Sprache.
@@ -22,7 +22,7 @@ Resource-Controllern, die Blade-Views zurückgeben. Sie rendern über [Tera](htt
 >
 > **Lauffähige Version:** Das API-vs-HTML-Beispiel unten ist durch den
 > Framework-Test
-> [`html_and_api_contrast_sqlite_live.rs`](../crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
+> [`html_and_api_contrast_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
 > festgeschrieben (`cargo test -p rustango --features sqlite --test html_and_api_contrast_sqlite_live`).
 > Die einzelnen Views werden von `template_view.rs` und
 > `template_views_context_object_name_sqlite_live.rs` abgedeckt.
@@ -318,7 +318,7 @@ let app = axum::Router::new()
 
 Jetzt gibt `GET /api/posts` die paginierte JSON-Hülle zurück und `GET /posts`
 gibt eine gerenderte HTML-Liste zurück — dieselben Zeilen, derselbe Pool, zwei Formen. Genau dieses
-Setup ist es, was der [zugrunde liegende Test](../crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
+Setup ist es, was der [zugrunde liegende Test](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
 behauptet.
 
 ---

--- a/docs/de/i18n.md
+++ b/docs/de/i18n.md
@@ -8,7 +8,7 @@ worum es in diesem Leitfaden geht. Der `Translator` lädt Nachrichtenkataloge pr
 Locale, ersetzt `{placeholders}`, behandelt Pluralformen und fällt elegant zurück
 — Djangos `gettext` / `{% trans %}`, in Rust.
 
-[![i18n in Rustango: Ein Translator hält Kataloge pro Locale; gettext schlägt einen Schlüssel mit Fallback nach (Locale → Basissprache → Standard → der Schlüssel selbst), ersetzt {name}-Platzhalter, und ngettext wählt Singular vs. Plural](img/i18n.png)](img/i18n.png)
+[![i18n in Rustango: Ein Translator hält Kataloge pro Locale; gettext schlägt einen Schlüssel mit Fallback nach (Locale → Basissprache → Standard → der Schlüssel selbst), ersetzt {name}-Platzhalter, und ngettext wählt Singular vs. Plural](../img/i18n.png)](../img/i18n.png)
 
 > **Ein Begriff hier neu?** *Locale*, *Katalog*, *Accept-Language*,
 > *Pluralisierung*, *RTL* — siehe das [Glossar](glossary.md).
@@ -20,10 +20,10 @@ Locale, ersetzt `{placeholders}`, behandelt Pluralformen und fällt elegant zur�
 > (siehe [Middleware](middleware.md)).
 >
 > **Lauffähige Version:** Jeder Ausschnitt ist aus
-> [`i18n_doc.rs`](../crates/rustango/tests/i18n_doc.rs) kopiert
+> [`i18n_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/i18n_doc.rs) kopiert
 > (`cargo test -p rustango --test i18n_doc`); DB-gestützte Übersetzungs-Overrides
 > werden im Realbetrieb von
-> [`i18n_db_overrides_sqlite_live.rs`](../crates/rustango/tests/i18n_db_overrides_sqlite_live.rs)
+> [`i18n_db_overrides_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/i18n_db_overrides_sqlite_live.rs)
 > erprobt.
 
 ## Inhaltsverzeichnis

--- a/docs/de/jobs.md
+++ b/docs/de/jobs.md
@@ -9,7 +9,7 @@ Pool von Workern führt den Job Augenblicke später aus, mit **automatischen
 Retries** und einem **Dead-Letter**-Pfad für Fehlschläge. Das ist Django-Q /
 Celery / Laravel-Queues, in Rust.
 
-[![Background jobs in Rustango: a handler dispatches a Job onto a queue, worker tasks run it, retryable failures back off and retry, fatal ones go to a dead-letter handler](img/jobs.png)](img/jobs.png)
+[![Background jobs in Rustango: a handler dispatches a Job onto a queue, worker tasks run it, retryable failures back off and retry, fatal ones go to a dead-letter handler](../img/jobs.png)](../img/jobs.png)
 
 > **Ein Begriff hier neu für dich?** *Queue*, *Worker*, *Retry/Backoff*,
 > *Dead-Letter* — siehe das [Glossar](glossary.md).
@@ -20,10 +20,10 @@ Celery / Laravel-Queues, in Rust.
 > `jobs`-Feature (standardmäßig aktiv).
 >
 > **Ausführbare Version:** die In-Memory-, Retry- und Dead-Letter-Snippets sind
-> aus [`jobs_doc.rs`](../crates/rustango/tests/jobs_doc.rs) kopiert
+> aus [`jobs_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/jobs_doc.rs) kopiert
 > (`cargo test -p rustango --test jobs_doc`); die persistente Queue wird per
 > Dogfooding auf SQLite durch
-> [`jobs_sqlite_live.rs`](../crates/rustango/tests/jobs_sqlite_live.rs)
+> [`jobs_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/jobs_sqlite_live.rs)
 > erprobt (`cargo test -p rustango --features sqlite,jobs-postgres --test jobs_sqlite_live`).
 
 ## Inhaltsverzeichnis

--- a/docs/de/manage.md
+++ b/docs/de/manage.md
@@ -10,14 +10,14 @@ cargo run -- migrate               # any other verb
 cargo run -- --help                # full subcommand list
 ```
 
-[![One binary runs every manage verb — server, migrations, scaffolders, database utilities, and system commands — like Django's manage.py or Laravel's artisan](img/manage.png)](img/manage.png)
+[![One binary runs every manage verb — server, migrations, scaffolders, database utilities, and system commands — like Django's manage.py or Laravel's artisan](../img/manage.png)](../img/manage.png)
 
 > **Quelle:** `rustango::manage` (`Cli`, der Verb-Dispatcher) — hinter dem
 > `manage`-Feature (standardmäßig aktiviert).
 >
 > **Ausführbare Version:** jedes Verb hier läuft in einem generierten Projekt;
 > das Beispiel
-> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog)
+> [`getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog)
 > wird von `cargo run -- migrate` und Konsorten angetrieben.
 
 > **Neu bei einem Begriff hier?** *scaffold*, *migration*, *tenant* — siehe das
@@ -1152,7 +1152,7 @@ cargo run -- purge-tenant acme           # hard (drops schema/db)
 
 Tenants im database-Modus erhalten ihren eigenen Verbindungspool (einen
 `PgPool` — eine Menge wiederverwendeter Datenbankverbindungen), zwischengespeichert
-nach Slug in [`TenantPools`](../crates/rustango/src/tenancy/pools.rs).
+nach Slug in [`TenantPools`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/src/tenancy/pools.rs).
 Standardmäßig wird ein Pool **faul, beim ersten Request des Tenants** gebaut, es
 sei denn, Sie schalten das Pre-Warming ein. Die Einstellungen leben auf
 `TenantPoolsConfig`:

--- a/docs/de/mcp.md
+++ b/docs/de/mcp.md
@@ -9,7 +9,7 @@ Router, und jeder MCP-Client kann es über den standardmäßigen JSON-RPC-Transp
 entdecken und aufrufen — mit pro-Agent, **fail-closed** Autorisierung und
 eingebautem OAuth 2.1.
 
-[![MCP-Server in Rustango: Ein LLM-Agent verbindet sich über JSON-RPC + SSE; der Server authentifiziert das JWT des Agenten, listet nur die Tools auf, die seine gewährten Skills erlauben, und führt den Tool-Handler gegen den Pool Ihrer App aus](img/mcp.png)](img/mcp.png)
+[![MCP-Server in Rustango: Ein LLM-Agent verbindet sich über JSON-RPC + SSE; der Server authentifiziert das JWT des Agenten, listet nur die Tools auf, die seine gewährten Skills erlauben, und führt den Tool-Handler gegen den Pool Ihrer App aus](../img/mcp.png)](../img/mcp.png)
 
 > **Ein Begriff hier neu?** *MCP*, *JSON-RPC*, *Tool/Resource/Prompt*, *Agent*,
 > *JWT*, *OAuth* — siehe das [Glossar](glossary.md).
@@ -21,11 +21,11 @@ eingebautem OAuth 2.1.
 > (standardmäßig AUS; zieht `tenancy, sse, serializer, openapi, jwt` mit).
 >
 > **Lauffähige Version:** Jeder Ausschnitt ist aus
-> [`mcp_doc.rs`](../crates/rustango/tests/mcp_doc.rs) kopiert
+> [`mcp_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/mcp_doc.rs) kopiert
 > (`cargo test -p rustango --features sqlite,mcp --test mcp_doc`); die gesamte
 > Protokolloberfläche wird von der Suite `crates/rustango/tests/mcp_*.rs` im
 > Realbetrieb erprobt, und ein lauffähiger Server liegt in
-> [`examples/mcp_demo`](../crates/rustango/examples/mcp_demo).
+> [`examples/mcp_demo`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/mcp_demo).
 
 ## Inhaltsverzeichnis
 
@@ -249,7 +249,7 @@ println!("copy once: {}", issued.token);
 ```
 
 Bei der Token-Ausstellung ruft der Server
-[`resolve_user_agent_grants_pool`](../crates/rustango/src/tenancy/agents.rs) auf —
+[`resolve_user_agent_grants_pool`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/src/tenancy/agents.rs) auf —
 die effektiven Berechtigungen des Eigentümers (`user_permissions_pool`, d. h.
 Rollen + direkte Gewährungen − Verweigerungen) wählen die gemappten Skills, deren
 Tools/Prompts/Resources in die `skills`/`tools` Claims des JWT eingeebnet werden.
@@ -435,12 +435,12 @@ Wechseln Sie zum **Tools**-Tab und klicken Sie **List Tools** — Sie sehen *nur
 das `add`-Tool, das der Skill des Agenten gewährt, mit seinem JSON Schema. Wählen
 Sie es aus, geben Sie `a = 2`, `b = 3` ein und **Run Tool**:
 
-[![Der MCP Inspector über Streamable HTTP mit der Rustango-Demo verbunden, zeigt das gewährte `add`-Tool und sein a/b-Eingabeschema](img/mcp-inspector-tools.png)](img/mcp-inspector-tools.png)
+[![Der MCP Inspector über Streamable HTTP mit der Rustango-Demo verbunden, zeigt das gewährte `add`-Tool und sein a/b-Eingabeschema](../img/mcp-inspector-tools.png)](../img/mcp-inspector-tools.png)
 
 Der Aufruf gibt ein strukturiertes Ergebnis zurück — `{ "sum": 5 }` — und die
 Anfrage erscheint im History-Panel (`initialize` → `tools/list` → `tools/call`):
 
-[![Derselbe Inspector nach der Tool-Ausführung: Tool Result Success mit strukturiertem Inhalt { sum: 5 } und die JSON-RPC-Aufrufhistorie](img/mcp-inspector-call.png)](img/mcp-inspector-call.png)
+[![Derselbe Inspector nach der Tool-Ausführung: Tool Result Success mit strukturiertem Inhalt { sum: 5 } und die JSON-RPC-Aufrufhistorie](../img/mcp-inspector-call.png)](../img/mcp-inspector-call.png)
 
 ### (d) Einen echten MCP-Client verbinden
 

--- a/docs/de/middleware.md
+++ b/docs/de/middleware.md
@@ -9,7 +9,7 @@ weniger Zeilen. Wenn du von Django kommst, ist das die `MIDDLEWARE`-Liste; von
 Express `app.use()`; von Laravel der HTTP-Kernel — dieselbe Idee, an deinen
 Router angehängt.
 
-[![Middleware in Rustango: a request flows down through a stack of tower layers (request-id, locale, security headers, CSRF) into the handler and back up through the response side of each layer](img/middleware.png)](img/middleware.png)
+[![Middleware in Rustango: a request flows down through a stack of tower layers (request-id, locale, security headers, CSRF) into the handler and back up through the response side of each layer](../img/middleware.png)](../img/middleware.png)
 
 > **Quelle:** Middleware baut auf [`tower::Layer`](https://docs.rs/tower) +
 > `axum::middleware::from_fn` auf. Die eingebauten Bausteine verteilen sich über

--- a/docs/de/models.md
+++ b/docs/de/models.md
@@ -8,7 +8,7 @@ Modelle oder Laravels Eloquent, mit dem Compiler, der deine Spalten prüft. Dies
 `#[rustango(...)]`-Attribut. Für das *Abfragen* von Modellen, sobald sie deklariert sind,
 siehe das [ORM-Kochbuch](orm.md).
 
-[![Modelle in Rustango: ein #[derive(Model)]-Struct bildet Rust-Feldtypen auf dialektspezifische Spalten ab, der Primärschlüssel kann ein auto-inkrementierender Auto<i64> oder ein benutzerdefinierter, anwendungsseitig zugewiesener Schlüssel sein, und das Derive generiert SCHEMA + objects() + save/find](img/models.png)](img/models.png)
+[![Modelle in Rustango: ein #[derive(Model)]-Struct bildet Rust-Feldtypen auf dialektspezifische Spalten ab, der Primärschlüssel kann ein auto-inkrementierender Auto<i64> oder ein benutzerdefinierter, anwendungsseitig zugewiesener Schlüssel sein, und das Derive generiert SCHEMA + objects() + save/find](../img/models.png)](../img/models.png)
 
 > **Ein Begriff hier ist neu für dich?** *model*, *primary key*, *foreign key*,
 > *migration*, *nullable* — siehe das [Glossar](glossary.md).
@@ -20,7 +20,7 @@ siehe das [ORM-Kochbuch](orm.md).
 >
 > **Lauffähige Version:** die Feldtyp-Round-Trips, der benutzerdefinierte PK und die
 > SCHEMA-Snippets sind aus
-> [`models_doc.rs`](../crates/rustango/tests/models_doc.rs) kopiert
+> [`models_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/models_doc.rs) kopiert
 > (`cargo test -p rustango --features sqlite --test models_doc`).
 
 ## Inhaltsverzeichnis

--- a/docs/de/openapi.md
+++ b/docs/de/openapi.md
@@ -8,7 +8,7 @@ deinem ViewSet, und ein einzeiliger Router hängt `/openapi.json` + eine
 interaktive Docs-Seite ein. Wenn du volle Kontrolle brauchst, lassen dich
 dieselben Typen jede beliebige Spec von Hand bauen.
 
-[![Rustango OpenAPI: Serializer-Felder werden zu einem Component-Schema, das ViewSet wird zu CRUD-Pfaden, und openapi_router liefert /openapi.json + Swagger UI aus](img/openapi.png)](img/openapi.png)
+[![Rustango OpenAPI: Serializer-Felder werden zu einem Component-Schema, das ViewSet wird zu CRUD-Pfaden, und openapi_router liefert /openapi.json + Swagger UI aus](../img/openapi.png)](../img/openapi.png)
 
 > **Quelle:** `rustango::openapi` (`OpenApiSpec`, `Schema`, `OpenApiSchema`,
 > `PathItem`, `Operation`, `SecurityScheme`, `router::openapi_router`) und
@@ -16,7 +16,7 @@ dieselben Typen jede beliebige Spec von Hand bauen.
 > der Viewer-Router benötigt zusätzlich `admin`).
 >
 > **Lauffähige Version:** jedes Snippet unten ist aus dem getesteten
-> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog/tests/openapi.rs)-Beispiel
+> [`getting_started_blog`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/getting_started_blog/tests/openapi.rs)-Beispiel
 > kopiert — `cargo test -p getting_started_blog --test openapi`. Die Builder-,
 > Schema- und Router-Typen werden zusätzlich durch die eigenen Unit-Tests des
 > Frameworks abgedeckt (`crates/rustango/src/openapi/`).

--- a/docs/de/orm.md
+++ b/docs/de/orm.md
@@ -2,14 +2,14 @@
 
 Muster für das **Rustango**-ORM jenseits der Grundlagen. Wenn du von Djangos ORM, Laravel Eloquent oder Rails ActiveRecord kommst, werden dir die Formen hier vertraut vorkommen. Die meisten Beispiele setzen voraus, dass du bereits ein `Post`-Model aus `Getting Started` hast.
 
-[![Typgeprüfte ORM-Abfragen: verkettete Filter, Sortierung, Limits und Aggregation — alles ohne rohes SQL](img/orm.png)](img/orm.png)
+[![Typgeprüfte ORM-Abfragen: verkettete Filter, Sortierung, Limits und Aggregation — alles ohne rohes SQL](../img/orm.png)](../img/orm.png)
 
 > **Quelle:** `rustango::sql` (`QuerySet`, das `Q!`-Makro / der `Qb`-Builder) und die
 > `#[derive(Model)]`-Query-API — immer kompiliert; wähle ein Backend-Feature
 > (`postgres` / `mysql` / `sqlite`).
 >
 > **Lauffähige Version:** die Muster hier laufen im getesteten
-> [`orm_cookbook`](../crates/rustango/examples/orm_cookbook)-Beispiel.
+> [`orm_cookbook`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/orm_cookbook)-Beispiel.
 >
 > **Neu bei einem Begriff hier?** Das [Glossar](glossary.md) definiert *model*, *queryset*,
 > *pool* und *migration* in einfacher Sprache.

--- a/docs/de/scaffolding.md
+++ b/docs/de/scaffolding.md
@@ -5,7 +5,7 @@
 1. **Der Projektgenerator** — `cargo rustango new` erstellt ein komplett neues Projekt aus einer Vorlage.
 2. **Projektinterne Generatoren** — `manage startapp` und die `manage make:*`-Familie fügen Apps, Views, Serializer, Jobs und mehr in einem bestehenden Projekt hinzu.
 
-[![`cargo rustango new` scaffoldet ein komplettes, sofort lauffähiges Projekt — Cargo-Manifest, Config-Tiers, Docker, Migrationen und src — mit einem einzigen Befehl](img/scaffolding.png)](img/scaffolding.png)
+[![`cargo rustango new` scaffoldet ein komplettes, sofort lauffähiges Projekt — Cargo-Manifest, Config-Tiers, Docker, Migrationen und src — mit einem einzigen Befehl](../img/scaffolding.png)](../img/scaffolding.png)
 
 ## Inhaltsverzeichnis
 
@@ -149,7 +149,7 @@ Optionen:
 
 ## Einzelne Dateien generieren: die `make:*`-Befehle
 
-Innerhalb eines Projekts scaffolden die `make:*`-Verben jeweils eine Datei. Die vollständige Referenz pro Flag findest du in der [manage-CLI-Referenz](manage); die gängigen Formen sind:
+Innerhalb eines Projekts scaffolden die `make:*`-Verben jeweils eine Datei. Die vollständige Referenz pro Flag findest du in der [manage-CLI-Referenz](manage.md); die gängigen Formen sind:
 
 | Befehl | Generiert | Vergleichbar mit |
 |---|---|---|

--- a/docs/de/security.md
+++ b/docs/de/security.md
@@ -2,7 +2,7 @@
 
 Dieser Leitfaden behandelt jede Sicherheitsfunktion, die **Rustango** mitbringt, und wie man sie kombiniert. Wenn du von Django, Laravel oder Rails kommst, werden dir die meisten davon vertraut vorkommen — die Namen unterscheiden sich, aber die Ideen sind dieselben. Jede der folgenden Funktionen benötigt in der Regel eine Zeile Setup. Wenn du bereit bist, in Produktion zu gehen, führe `manage check --deploy` für ein automatisiertes Audit aus.
 
-[![Der gehärtete Middleware-Stack in einer Kette verdrahtet: Request-IDs, Zugriffsprotokollierung, Rate Limiting, CORS und Security-Header](img/security.png)](img/security.png)
+[![Der gehärtete Middleware-Stack in einer Kette verdrahtet: Request-IDs, Zugriffsprotokollierung, Rate Limiting, CORS und Security-Header](../img/security.png)](../img/security.png)
 
 ## Inhaltsverzeichnis
 

--- a/docs/de/serializers.md
+++ b/docs/de/serializers.md
@@ -18,14 +18,14 @@ zu leiten.
 > **Neu bei einem Begriff hier?** — *serializer*, *model*, *ORM*, *DRF*? Das
 > [Glossar](glossary.md) erklärt jeden Begriff in klarer Sprache.
 
-[![Ein Rustango-Serializer: read_only, source-Umbenennung, ein berechnetes Methodenfeld, ein verschachtelter FK und ein write_only-Feld — deklariert auf einem einzigen Struct](img/serializers.png)](img/serializers.png)
+[![Ein Rustango-Serializer: read_only, source-Umbenennung, ein berechnetes Methodenfeld, ein verschachtelter FK und ein write_only-Feld — deklariert auf einem einzigen Struct](../img/serializers.png)](../img/serializers.png)
 
 > **Quelle:** `rustango::serializer` (`ModelSerializer`, `#[derive(Serializer)]`,
 > die `#[serializer(...)]`-Feldattribute) — hinter dem `serializer`-Feature
 > (standardmäßig aktiv).
 >
 > **Lauffähige Versionen:** der minimale Serializer ist Teil des getesteten
-> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog/src/post_serializer.rs)-Beispiels,
+> [`getting_started_blog`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/getting_started_blog/src/post_serializer.rs)-Beispiels,
 > und das vollständige Verhalten des Derive wird durch die eigenen Unit-Tests des
 > Frameworks abgedeckt — `crates/rustango/tests/serializer_derive.rs` und
 > `serializer_cross_validate.rs`. Wenn ein Snippet seltsam aussieht, vergleiche
@@ -536,7 +536,7 @@ Ein paar scharfe Kanten und Schlupflöcher, die man kennen sollte:
 ## Probier es aus
 
 Der minimale Serializer ist Teil des
-[`getting_started_blog`](../crates/rustango/examples/getting_started_blog/src/post_serializer.rs)-Beispiels
+[`getting_started_blog`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/getting_started_blog/src/post_serializer.rs)-Beispiels
 (Schritt 13 des Getting-Started-Leitfadens). Das vollständige Verhalten des
 Derive — die Feldattribute, berechnete/verschachtelte/many-Felder und beide
 Validierungsschichten — wird durch die eigenen Unit-Tests des Frameworks

--- a/docs/de/testing.md
+++ b/docs/de/testing.md
@@ -8,7 +8,7 @@ Antwort zum Assertieren zurück. Füge Transaction-Rollback-Isolation für Daten
 ein Set von Response-Assertions hinzu, und du hast Djangos Test-Client + `TestCase`, in
 Rust.
 
-[![Testen in Rustango: TestClient umschließt deinen Router und sendet In-process-Anfragen durch den echten Handler-Stack; die TestResponse macht Status, Text und JSON zum Assertieren verfügbar — kein Socket, kein Server](img/testing.png)](img/testing.png)
+[![Testen in Rustango: TestClient umschließt deinen Router und sendet In-process-Anfragen durch den echten Handler-Stack; die TestResponse macht Status, Text und JSON zum Assertieren verfügbar — kein Socket, kein Server](../img/testing.png)](../img/testing.png)
 
 > **Neu bei einem Begriff hier?** *router*, *handler*, *fixture*, *rollback* — siehe das
 > [Glossar](glossary.md).
@@ -19,7 +19,7 @@ Rust.
 > kompiliert.
 >
 > **Lauffähige Version:** die untenstehenden Snippets *sind* ein bestehender Test —
-> [`testing_doc.rs`](../crates/rustango/tests/testing_doc.rs)
+> [`testing_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/testing_doc.rs)
 > (`cargo test -p rustango --test testing_doc`). Nahezu jede andere `*_doc.rs`
 > in diesem Repo verwendet `TestClient` auf dieselbe Weise.
 

--- a/docs/de/urls.md
+++ b/docs/de/urls.md
@@ -7,7 +7,7 @@ die URL überall über den Namen** — in Rust mit `reverse(...)`, in Templates 
 `{{ url(...) }}` und in Redirects mit `redirect_to_view(...)`. Die API-Oberfläche
 spiegelt Djangos `reverse()` / `{% url %}` / `resolve_url()` / `redirect()`.
 
-[![Reverse-URLs im Django-Stil: register_url! benennt ein Muster, reverse() baut die URL in Rust, und {{ url(...) }} baut die URL in einem Template](img/urls.png)](img/urls.png)
+[![Reverse-URLs im Django-Stil: register_url! benennt ein Muster, reverse() baut die URL in Rust, und {{ url(...) }} baut die URL in einem Template](../img/urls.png)](../img/urls.png)
 
 > **Quelle:** `rustango::urls` (`register_url!`, `reverse`, `reverse_owned`,
 > `all_routes`, `duplicates`, `register_url_tag`) und `rustango::shortcuts`
@@ -234,7 +234,7 @@ eine Regex-Engine.
 
 Die Form `{int:id}` wird nur als **Portierungshilfe** für `reverse()` akzeptiert:
 Der Builder teilt den Platzhalter an `:` und behält nur den Namen, verwirft das
-Typpräfix ([`urls.rs`](../crates/rustango/src/urls.rs)). Das lässt `reverse()` auf
+Typpräfix ([`urls.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/src/urls.rs)). Das lässt `reverse()` auf
 einem Muster laufen, das wortwörtlich aus einem Django-`path("<int:id>/", …)`
 kopiert wurde — aber nichts validiert, dass der gelieferte Wert tatsächlich eine
 Ganzzahl ist.

--- a/docs/de/viewsets.md
+++ b/docs/de/viewsets.md
@@ -23,13 +23,13 @@ Gerüst, Models, ein Serializer, das ViewSet, alle sechs CRUD-Endpunkte, Eingabe
 validierung, Filterung/Suche/Paginierung und Tests — und der Rest der Seite
 ist eine Referenz für jede Stellschraube.
 
-[![Ein Rustango-ViewSet, verdrahtet mit einem Serializer: Ein einziger #[viewset(serializer = …)]-Block liefert typisierte JSON-Ausgabe und validierte Eingabe über die sechs CRUD-Routen hinweg](img/viewsets.png)](img/viewsets.png)
+[![Ein Rustango-ViewSet, verdrahtet mit einem Serializer: Ein einziger #[viewset(serializer = …)]-Block liefert typisierte JSON-Ausgabe und validierte Eingabe über die sechs CRUD-Routen hinweg](../img/viewsets.png)](../img/viewsets.png)
 
 > **Quelle:** `rustango::viewset` (`ViewSet`, `#[derive(ViewSet)]`, die
 > `#[viewset(...)]`-Optionen + der `for_model`-Builder) — immer kompiliert.
 >
 > **Lauffähige Version:** Der hier gebaute Blog spiegelt das getestete, kompilierbare
-> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog)-
+> [`getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog)-
 > Beispiel (dessen `Post` / `PostSerializer` / `PostViewSet`), und jedes Verhalten ist
 > durch die eigenen Live-Tests des Frameworks abgesichert — `crates/rustango/tests/viewset_*.rs`
 > (insbesondere `viewset_serializer_render_sqlite_live` und

--- a/docs/email.md
+++ b/docs/email.md
@@ -18,7 +18,7 @@ terminal to real SMTP with a one-line change — like Django's email framework.
 > `email-smtp` feature.
 >
 > **Runnable version:** every snippet is copied from
-> [`email_doc.rs`](../crates/rustango/tests/email_doc.rs)
+> [`email_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/email_doc.rs)
 > (`cargo test -p rustango --test email_doc`); the send helpers and attachments
 > are dogfooded by `email_send_helpers.rs` and `email_attachments.rs`.
 

--- a/docs/es/admin.md
+++ b/docs/es/admin.md
@@ -10,7 +10,7 @@ de modelos en vivo. Todo lo que sigue se configura de forma declarativa en un bl
 `admin(...)` sobre el derive, o con un puñado de métodos del `Builder` y macros de
 registro a nivel de módulo.
 
-[![El admin autogenerado: una lista de entradas con facetas de filtro, búsqueda, acciones masivas y paginación — todo desde un solo bloque `admin(...)`](img/admin.png)](img/admin.png)
+[![El admin autogenerado: una lista de entradas con facetas de filtro, búsqueda, acciones masivas y paginación — todo desde un solo bloque `admin(...)`](../img/admin.png)](../img/admin.png)
 
 > **Fuente:** `rustango::admin` (las opciones del derive `admin(...)`, la API del
 > `Builder` y las macros de registro) — tras la característica `admin` (activada por
@@ -18,7 +18,7 @@ registro a nivel de módulo.
 >
 > **Versión ejecutable:** cada característica de esta página se ejercita en un ejemplo
 > probado y compilable en
-> [`crates/rustango/examples/admin_demo`](../crates/rustango/examples/admin_demo).
+> [`crates/rustango/examples/admin_demo`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/admin_demo).
 > Las capturas de esta página provienen de ese ejemplo. Si un fragmento parece extraño,
 > compáralo con él.
 
@@ -84,7 +84,7 @@ La raíz del admin (`GET /<prefix>`) lista cada modelo registrado, agrupado por 
 el nombre de tabla y el recuento de campos de cada modelo — más un feed de **Recent
 actions** con los cambios auditados más recientes.
 
-[![La página de inicio del admin: cada modelo registrado agrupado por app con recuentos de tabla y campos, y un feed de actividad de acciones recientes](img/admin-home.png)](img/admin-home.png)
+[![La página de inicio del admin: cada modelo registrado agrupado por app con recuentos de tabla y campos, y un feed de actividad de acciones recientes](../img/admin-home.png)](../img/admin-home.png)
 
 ---
 
@@ -158,7 +158,7 @@ recuento de filas y los recuentos de facetas se actualizan. Los filtros, la bús
 ordenación y la jerarquía de fechas se componen todos en la cadena de consulta y pueden
 combinarse.
 
-[![La lista de entradas filtrada por status=published: un chip de filtro activo, la faceta coincidente resaltada, el cuadro de búsqueda y el selector de acciones masivas](img/admin-list-filtered.png)](img/admin-list-filtered.png)
+[![La lista de entradas filtrada por status=published: un chip de filtro activo, la faceta coincidente resaltada, el cuadro de búsqueda y el selector de acciones masivas](../img/admin-list-filtered.png)](../img/admin-list-filtered.png)
 
 **Ordenación.** Haz clic en un encabezado de columna para ordenar; clic de nuevo para
 invertir la dirección (`?sort=col&order=asc|desc`). El valor por defecto proviene de
@@ -186,7 +186,7 @@ columna usando extracción de fechas tri-dialecto (PostgreSQL `EXTRACT`, MySQL, 
 renderizan el formulario. `fieldsets` agrupa las entradas en secciones con título; sin
 él, todos los campos editables aparecen en un solo bloque.
 
-[![El formulario de cambio de Post agrupado en los conjuntos de campos Content y Publishing, cada campo con el widget de entrada adecuado para su tipo](img/admin-fieldsets.png)](img/admin-fieldsets.png)
+[![El formulario de cambio de Post agrupado en los conjuntos de campos Content y Publishing, cada campo con el widget de entrada adecuado para su tipo](../img/admin-fieldsets.png)](../img/admin-fieldsets.png)
 
 Enviar un formulario valida la entrada, escribe la fila, registra una entrada de
 auditoría y redirige a la vista de **detalle** de solo lectura
@@ -257,7 +257,7 @@ por hijo, o `Stacked` — un conjunto de campos por hijo), `label`, `fields` (po
 cada escalar excepto el FK), `extra` (filas en blanco ofrecidas para añadir), `max_num`
 y `readonly_fields`.
 
-[![La página de detalle de una entrada: campos de solo lectura, la tabla inline de Comments y la tarjeta de registro de auditoría que muestra la entrada de creación como un diff JSON](img/admin-detail.png)](img/admin-detail.png)
+[![La página de detalle de una entrada: campos de solo lectura, la tabla inline de Comments y la tarjeta de registro de auditoría que muestra la entrada de creación como un diff JSON](../img/admin-detail.png)](../img/admin-detail.png)
 
 Para filas hijas adjuntadas mediante una clave foránea genérica (par content-type +
 object-pk) en lugar de una única columna FK, usa
@@ -324,7 +324,7 @@ resistente a manipulaciones. Dos lugares lo exponen:
   operación / fuente y un formulario de limpieza para purgar entradas de más de N días
   (lo cual se registra a su vez como una entrada de auditoría).
 
-[![El feed de Activity: cada cambio auditado a través de los modelos con diffs JSON, tarjetas de faceta por tabla/operación/fuente y un formulario de limpieza](img/admin-audit.png)](img/admin-audit.png)
+[![El feed de Activity: cada cambio auditado a través de los modelos con diffs JSON, tarjetas de faceta por tabla/operación/fuente y un formulario de limpieza](../img/admin-audit.png)](../img/admin-audit.png)
 
 ---
 
@@ -516,7 +516,7 @@ Cada admin incluye una referencia de modelos en vivo (los admindocs de Django) e
 columnas, tipos, flags (PK, unique, …) y relaciones. Nada que configurar; se genera a
 partir de tus modelos, así que nunca se desvía del esquema.
 
-[![La referencia de modelos: los campos de cada modelo con nombre de columna, tipo Rust, flags y relaciones — generados a partir de los modelos](img/admin-model-reference.png)](img/admin-model-reference.png)
+[![La referencia de modelos: los campos de cada modelo con nombre de columna, tipo Rust, flags y relaciones — generados a partir de los modelos](../img/admin-model-reference.png)](../img/admin-model-reference.png)
 
 ---
 

--- a/docs/es/api-conventions.md
+++ b/docs/es/api-conventions.md
@@ -4,7 +4,7 @@
 
 Esta página explica los patrones que sigue la API de **Rustango**, para que puedas predecir cómo se comporta cualquier método antes de leer su documentación. Si estás contribuyendo o auditando una funcionalidad, estas son las reglas.
 
-[![Convención de nombres de Rustango: el sufijo del método te dice qué recibe — `*_on` para un pool tipado, sin sufijo para el pool multi-backend, y señales sin pool](img/api-conventions.png)](img/api-conventions.png)
+[![Convención de nombres de Rustango: el sufijo del método te dice qué recibe — `*_on` para un pool tipado, sin sufijo para el pool multi-backend, y señales sin pool](../img/api-conventions.png)](../img/api-conventions.png)
 
 ## Tabla de contenidos
 

--- a/docs/es/auth-api-keys.md
+++ b/docs/es/auth-api-keys.md
@@ -8,7 +8,7 @@ la clave en cada petición; el servidor la busca e identifica al llamante.
 que puedes conectar a tu propia tabla, y un backend listo para usar que almacena
 las claves y autentica las peticiones `Authorization: Bearer`.
 
-[![Claves de API en Rustango: generate_key devuelve un token de un solo uso prefix.secret, almacenas el prefijo de 8 caracteres más un hash argon2id, y verify_key comprueba un secreto entrante](img/auth-api-keys.png)](img/auth-api-keys.png)
+[![Claves de API en Rustango: generate_key devuelve un token de un solo uso prefix.secret, almacenas el prefijo de 8 caracteres más un hash argon2id, y verify_key comprueba un secreto entrante](../img/auth-api-keys.png)](../img/auth-api-keys.png)
 
 > **¿Algún término te resulta nuevo?** *Token*, *hash*, *Bearer*, *argon2id* — el
 > [glosario](glossary.md) define los bloques de construcción.
@@ -20,10 +20,10 @@ las claves y autentica las peticiones `Authorization: Bearer`.
 > `ensure_api_keys_table_pool`) — tras la característica `tenancy`.
 >
 > **Versión ejecutable:** los fragmentos del ayudante están copiados de
-> [`auth_api_keys_doc.rs`](../crates/rustango/tests/auth_api_keys_doc.rs)
+> [`auth_api_keys_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_api_keys_doc.rs)
 > (`cargo test -p rustango --test auth_api_keys_doc`); el flujo del middleware
 > `ApiKeyBackend` de
-> [`auth_backends_doc.rs`](../crates/rustango/tests/auth_backends_doc.rs)
+> [`auth_backends_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_backends_doc.rs)
 > (`cargo test -p rustango --features sqlite,tenancy --test auth_backends_doc`).
 
 ## Tabla de contenidos

--- a/docs/es/auth-backends.md
+++ b/docs/es/auth-backends.md
@@ -8,7 +8,7 @@ máquinas en las mismas rutas. Es la idea de `AUTHENTICATION_BACKENDS` de Django
 cableada a axum. Combínalo con `require_auth` / `require_perm` para restringir
 rutas y el extractor `CurrentUser` para leer el resultado.
 
-[![Backends de autenticación en Rustango: una petición fluye por una cadena de backends (ModelBackend, ApiKeyBackend, JwtBackend); el primero que reconoce la credencial gana e inyecta CurrentUser, luego require_perm comprueba un codename](img/auth-backends.png)](img/auth-backends.png)
+[![Backends de autenticación en Rustango: una petición fluye por una cadena de backends (ModelBackend, ApiKeyBackend, JwtBackend); el primero que reconoce la credencial gana e inyecta CurrentUser, luego require_perm comprueba un codename](../img/auth-backends.png)](../img/auth-backends.png)
 
 > **¿Algún término aquí es nuevo para ti?** *Backend*, *middleware*, *extractor*,
 > *codename de permiso* — consulta el [glosario](glossary.md).
@@ -20,7 +20,7 @@ rutas y el extractor `CurrentUser` para leer el resultado.
 > vive en `rustango::auth_backends` (siempre compilado).
 >
 > **Versión ejecutable:** cada fragmento está copiado de
-> [`auth_backends_doc.rs`](../crates/rustango/tests/auth_backends_doc.rs)
+> [`auth_backends_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_backends_doc.rs)
 > (`cargo test -p rustango --features sqlite,tenancy --test auth_backends_doc`).
 
 ## Tabla de contenidos

--- a/docs/es/auth-decorators.md
+++ b/docs/es/auth-decorators.md
@@ -6,7 +6,7 @@ una a un router y las peticiones anónimas son rechazadas — redirigidas con 30
 tu página de inicio de sesión (flujo de navegador) o respondidas con 401/403
 (flujo de API) — antes de que lleguen siquiera al handler.
 
-[![Decoradores de acceso: login_required redirige con 302 a los navegadores anónimos a /login?next=, la familia _or_403 devuelve 401/403 para APIs, superuser_required restringe por rol](img/auth-decorators.png)](img/auth-decorators.png)
+[![Decoradores de acceso: login_required redirige con 302 a los navegadores anónimos a /login?next=, la familia _or_403 devuelve 401/403 para APIs, superuser_required restringe por rol](../img/auth-decorators.png)](../img/auth-decorators.png)
 
 > **Fuente:** `rustango::auth_decorators` (`login_required`, `login_required_or_401`,
 > `user_passes_test`, `superuser_required`, `active_required`,
@@ -15,7 +15,7 @@ tu página de inicio de sesión (flujo de navegador) o respondidas con 401/403
 > `SessionUser`).
 >
 > **Versión ejecutable:** el comportamiento de restricción está cubierto por el
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_decorators.rs)
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_decorators.rs)
 > probado — `cargo test -p auth_demo --test auth_decorators`.
 
 > **¿Algún término aquí es nuevo para ti?** *middleware/capa*, *extractor*,

--- a/docs/es/auth-flows.md
+++ b/docs/es/auth-flows.md
@@ -7,7 +7,7 @@ manipulaciones y con tiempo limitado, y luego actuar cuando hace clic en él —
 construye sobre un mismo sustrato: las **URL firmadas**. Una URL firmada es una URL normal con una
 firma HMAC añadida, de modo que el servidor puede confiar en sus parámetros sin almacenar nada.
 
-[![Flujos de cuenta en Rustango: signed_url::sign añade una firma HMAC + caducidad; los tres flujos (restablecimiento de contraseña, verificación de correo, enlace mágico) emiten un enlace, lo envían por correo y lo verifican al hacer clic](img/auth-flows.png)](img/auth-flows.png)
+[![Flujos de cuenta en Rustango: signed_url::sign añade una firma HMAC + caducidad; los tres flujos (restablecimiento de contraseña, verificación de correo, enlace mágico) emiten un enlace, lo envían por correo y lo verifican al hacer clic](../img/auth-flows.png)](../img/auth-flows.png)
 
 > **¿Algún término aquí es nuevo para ti?** *HMAC*, *token*, *caducidad* — consulta el [glosario](glossary.md).
 
@@ -17,7 +17,7 @@ firma HMAC añadida, de modo que el servidor puede confiar en sus parámetros si
 > (activadas por defecto; la confirmación de restablecimiento también necesita `passwords` + un backend de BD).
 >
 > **Versión ejecutable:** cada fragmento está copiado de
-> [`auth_flows_doc.rs`](../crates/rustango/tests/auth_flows_doc.rs)
+> [`auth_flows_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_flows_doc.rs)
 > (`cargo test -p rustango --features sqlite --test auth_flows_doc`).
 
 ## Tabla de contenidos

--- a/docs/es/auth-hmac.md
+++ b/docs/es/auth-hmac.md
@@ -9,7 +9,7 @@ y el cuerpo, de modo que una solicitud manipulada o caducada se rechaza. Es el
 esquema que usan AWS SigV4 y las firmas de webhooks, y **Rustango** lo incluye
 como una única capa tower.
 
-[![Firma HMAC en Rustango: el cliente firma method+path+query+date+body-hash con un secreto compartido; HmacAuthLayer recalcula y compara en tiempo constante, rechazando solicitudes manipuladas o caducadas](img/auth-hmac.png)](img/auth-hmac.png)
+[![Firma HMAC en Rustango: el cliente firma method+path+query+date+body-hash con un secreto compartido; HmacAuthLayer recalcula y compara en tiempo constante, rechazando solicitudes manipuladas o caducadas](../img/auth-hmac.png)](../img/auth-hmac.png)
 
 > **¿Nuevo en algún término de aquí?** *HMAC*, *secreto compartido*, *replay*,
 > *comparación en tiempo constante* — consulta el [glosario](glossary.md).
@@ -19,7 +19,7 @@ como una única capa tower.
 > protección contra replay además necesita `cache`).
 >
 > **Versión ejecutable:** cada fragmento está copiado de
-> [`auth_hmac_doc.rs`](../crates/rustango/tests/auth_hmac_doc.rs)
+> [`auth_hmac_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_hmac_doc.rs)
 > (`cargo test -p rustango --test auth_hmac_doc`).
 
 ## Tabla de contenidos

--- a/docs/es/auth-jwt-api.md
+++ b/docs/es/auth-jwt-api.md
@@ -7,7 +7,7 @@ duración, un token de *refresco* de larga duración, rotación en el refresco, 
 `JwtLifecycle` — y un router listo para usar que monta por ti
 `POST /api/auth/login`, `/refresh`, `/logout`, y `GET /me`.
 
-[![API de autenticación JWT: login emite un par access+refresh, refresh rota y pone en lista negra el token antiguo, logout revoca a través de un almacén de JTI](img/auth-jwt-api.png)](img/auth-jwt-api.png)
+[![API de autenticación JWT: login emite un par access+refresh, refresh rota y pone en lista negra el token antiguo, logout revoca a través de un almacén de JTI](../img/auth-jwt-api.png)](../img/auth-jwt-api.png)
 
 > **Fuente:** `rustango::tenancy::jwt_lifecycle` (`JwtLifecycle`, `JwtTokenPair`,
 > `JwtClaims`) y `rustango::tenancy::auth_routes` (`jwt_router`, `Config`) +
@@ -15,7 +15,7 @@ duración, un token de *refresco* de larga duración, rotación en el refresco, 
 > `tenancy`.
 >
 > **Versión ejecutable:** el motor de tokens está cubierto por el test
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs) —
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs) —
 > `cargo test -p auth_demo --test auth_jwt_api`. Los endpoints HTTP están
 > delimitados por tenant y se ejercitan de extremo a extremo por el propio
 > `crates/rustango/tests/tenant_auth_live.rs` del framework.

--- a/docs/es/auth-jwt.md
+++ b/docs/es/auth-jwt.md
@@ -6,7 +6,7 @@ un secreto — sin consultas a base de datos ni a caché por petición. El módu
 `rustango::jwt` de **Rustango** es el bloque mínimo: `encode` para firmar
 claims, `decode` para verificarlos y volver a leerlos, HS256 por debajo.
 
-[![JWT independiente en Rustango: los Claims llevan campos sub/exp/personalizados, encode() firma con un secreto compartido, decode() verifica la firma + la expiración](img/auth-jwt.png)](img/auth-jwt.png)
+[![JWT independiente en Rustango: los Claims llevan campos sub/exp/personalizados, encode() firma con un secreto compartido, decode() verifica la firma + la expiración](../img/auth-jwt.png)](../img/auth-jwt.png)
 
 > **Fuente:** `rustango::jwt` (`Claims`, `encode`, `decode`, `decode_at`,
 > `decode_unverified`, `JwtError`) — tras la característica `jwt` (activada por
@@ -14,7 +14,7 @@ claims, `decode` para verificarlos y volver a leerlos, HS256 por debajo.
 > [API de autenticación JWT](auth-jwt-api.md).
 >
 > **Versión ejecutable:** los fragmentos están copiados del test
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt.rs) —
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_jwt.rs) —
 > `cargo test -p auth_demo --test auth_jwt`.
 
 > **¿Algún término te resulta nuevo?** *JWT*, *claims*, *sin estado*, *secreto* — consulta el

--- a/docs/es/auth-passwords.md
+++ b/docs/es/auth-passwords.md
@@ -7,7 +7,7 @@ eso en dos llamadas — `hash` a la entrada, `verify` a la salida — respaldada
 primera opción actual de OWASP. Nunca almacenas, registras ni comparas el texto
 plano.
 
-[![Contraseñas en Rustango: hash() produce una cadena PHC argon2id con sal, verify() comprueba un intento contra ella, y verify_dummy() iguala los tiempos de inicio de sesión](img/auth-passwords.png)](img/auth-passwords.png)
+[![Contraseñas en Rustango: hash() produce una cadena PHC argon2id con sal, verify() comprueba un intento contra ella, y verify_dummy() iguala los tiempos de inicio de sesión](../img/auth-passwords.png)](../img/auth-passwords.png)
 
 > **Fuente:** `rustango::passwords` (`hash`, `verify`, `verify_dummy`,
 > `strength_score`, `StrengthIssue`) — detrás de la característica `passwords`
@@ -15,7 +15,7 @@ plano.
 > con la multitenencia, consulta `rustango::tenancy::password`.
 >
 > **Versión ejecutable:** cada fragmento a continuación está copiado del ejemplo
-> probado [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_passwords.rs)
+> probado [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_passwords.rs)
 > — `cargo test -p auth_demo --test auth_passwords`.
 
 > **¿Algún término aquí es nuevo para ti?** *hash*, *sal*, *argon2id*, *cadena
@@ -177,7 +177,7 @@ assert!(strength_score("short").contains(&StrengthIssue::TooShort));
 
 La cadena PHC no es más que una columna `String` en el modelo de cuenta que sea
 tuyo. En el ejemplo
-[`auth_demo`](../crates/rustango/examples/auth_demo/src/models.rs):
+[`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/src/models.rs):
 
 ```rust
 #[derive(Model, Clone, Debug)]

--- a/docs/es/auth-sessions.md
+++ b/docs/es/auth-sessions.md
@@ -8,7 +8,7 @@ cookie no lleva ningún secreto y una sesión puede **revocarse al instante** �
 elimina la entrada y cada réplica ve el cierre de sesión en la siguiente
 petición.
 
-[![Sesiones en Rustango: la cookie solo contiene un id opaco, el SessionStore guarda los datos en Redis, y destroy() la revoca en todas partes](img/auth-sessions.png)](img/auth-sessions.png)
+[![Sesiones en Rustango: la cookie solo contiene un id opaco, el SessionStore guarda los datos en Redis, y destroy() la revoca en todas partes](../img/auth-sessions.png)](../img/auth-sessions.png)
 
 > **Fuente:** `rustango::sessions` (`Session`, `SessionStore`) +
 > `rustango::cache` (`BoxedCache`, `InMemoryCache`) — detrás de la característica
@@ -18,7 +18,7 @@ petición.
 >
 > **Versión ejecutable:** los fragmentos a continuación están copiados del
 > ejemplo probado
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_sessions.rs) —
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_sessions.rs) —
 > `cargo test -p auth_demo --test auth_sessions`.
 
 > **¿Algún término aquí es nuevo para ti?** *sesión*, *id opaco*, *cookie*,

--- a/docs/es/benchmarks.md
+++ b/docs/es/benchmarks.md
@@ -31,7 +31,7 @@ palabrería.
 > completo con todo incluido. Incluso el resultado no compilado más rápido,
 > **Laravel sobre Octane**, va 4–7× por detrás de ambos binarios.
 
-[![Solicitudes/s en el índice del blog sin caché a través de los seis runtimes — Go 6.651, Rustango 4.781, Laravel+Octane 1.238, Django+Hypercorn 910, Django+gunicorn 850, Laravel+php-fpm 408](img/benchmarks.png)](img/benchmarks.png)
+[![Solicitudes/s en el índice del blog sin caché a través de los seis runtimes — Go 6.651, Rustango 4.781, Laravel+Octane 1.238, Django+Hypercorn 910, Django+gunicorn 850, Laravel+php-fpm 408](../img/benchmarks.png)](../img/benchmarks.png)
 
 ---
 

--- a/docs/es/caching.md
+++ b/docs/es/caching.md
@@ -8,7 +8,7 @@ datos), un helper de cálculo-al-fallar (`get_or_set`) y helpers JSON tipados.
 Cambia el backend sin tocar un solo sitio de llamada — como el framework de caché
 de Django o la fachada `Cache` de Laravel.
 
-[![Caching in Rustango: get_or_set checks the cache, runs the factory only on a miss, stores the result with a TTL, and serves hits instantly; the same Cache trait backs InMemory, Redis, and DB](img/caching.png)](img/caching.png)
+[![Caching in Rustango: get_or_set checks the cache, runs the factory only on a miss, stores the result with a TTL, and serves hits instantly; the same Cache trait backs InMemory, Redis, and DB](../img/caching.png)](../img/caching.png)
 
 > **¿Un término nuevo aquí?** *caché*, *TTL*, *clave*, *backend* — ver el
 > [glosario](glossary.md).
@@ -19,10 +19,10 @@ de Django o la fachada `Cache` de Laravel.
 > `cache-redis` (desactivada por defecto).
 >
 > **Versión ejecutable:** cada fragmento está copiado de
-> [`cache_doc.rs`](../crates/rustango/tests/cache_doc.rs)
+> [`cache_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/cache_doc.rs)
 > (`cargo test -p rustango --test cache_doc`); el backend de base de datos se
 > prueba con dogfooding sobre SQLite mediante
-> [`cache_db_backend_sqlite_live.rs`](../crates/rustango/tests/cache_db_backend_sqlite_live.rs).
+> [`cache_db_backend_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/cache_db_backend_sqlite_live.rs).
 
 ## Tabla de contenidos
 

--- a/docs/es/email.md
+++ b/docs/es/email.md
@@ -7,7 +7,7 @@ para pruebas), un builder `Email` fluido con protección contra inyección de ca
 renderizado de plantillas. Escribe `mailer.send(&email)` una vez; cambia de imprimir
 en tu terminal a SMTP real con un cambio de una línea — como el framework de correo de Django.
 
-[![Correo en Rustango: un builder Email (to/subject/body/html) se valida contra la inyección de cabeceras, luego se envía a través del trait Mailer — ConsoleMailer en dev, SmtpMailer en prod, InMemoryMailer en pruebas](img/email.png)](img/email.png)
+[![Correo en Rustango: un builder Email (to/subject/body/html) se valida contra la inyección de cabeceras, luego se envía a través del trait Mailer — ConsoleMailer en dev, SmtpMailer en prod, InMemoryMailer en pruebas](../img/email.png)](../img/email.png)
 
 > **¿Nuevo con algún término aquí?** *correo transaccional*, *SMTP*, *backend de correo* — ver
 > el [glosario](glossary.md).
@@ -18,7 +18,7 @@ en tu terminal a SMTP real con un cambio de una línea — como el framework de 
 > característica `email-smtp`.
 >
 > **Versión ejecutable:** cada snippet se copia de
-> [`email_doc.rs`](../crates/rustango/tests/email_doc.rs)
+> [`email_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/email_doc.rs)
 > (`cargo test -p rustango --test email_doc`); los ayudantes de envío y los adjuntos
 > se someten a prueba mediante `email_send_helpers.rs` y `email_attachments.rs`.
 

--- a/docs/es/files.md
+++ b/docs/es/files.md
@@ -8,7 +8,7 @@ biblioteca de medios rastreada — un `MediaManager` respaldado por base de dato
 prefirmadas. Escribe tu código una sola vez contra el trait; cambia de disco local a S3 con un
 cambio de una línea.
 
-[![Archivos en Rustango: una subida multipart se comprueba en tamaño y extensión y luego se escribe a través del trait Storage; el mismo trait respalda disco local, S3 y memoria, y url() devuelve una dirección pública](img/files.png)](img/files.png)
+[![Archivos en Rustango: una subida multipart se comprueba en tamaño y extensión y luego se escribe a través del trait Storage; el mismo trait respalda disco local, S3 y memoria, y url() devuelve una dirección pública](../img/files.png)](../img/files.png)
 
 > **¿Nuevo con algún término aquí?** *backend de almacenamiento*, *multipart*, *almacenamiento de
 > objetos*, *URL prefirmada* — ver el [glosario](glossary.md).
@@ -20,11 +20,11 @@ cambio de una línea.
 > `media` (todas activadas por defecto).
 >
 > **Versión ejecutable:** los snippets de Storage + guardas de subida se copian de
-> [`files_doc.rs`](../crates/rustango/tests/files_doc.rs)
+> [`files_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/files_doc.rs)
 > (`cargo test -p rustango --test files_doc`); el flujo multipart `save_uploads` de
 > extremo a extremo se somete a prueba mediante los tests internos en
 > `crates/rustango/src/uploads.rs`, y la biblioteca de medios mediante
-> [`media_sqlite_live.rs`](../crates/rustango/tests/media_sqlite_live.rs).
+> [`media_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/media_sqlite_live.rs).
 
 ## Tabla de contenidos
 

--- a/docs/es/getting-started.md
+++ b/docs/es/getting-started.md
@@ -4,9 +4,9 @@ Este recorrido te lleva desde un directorio vacío hasta un blog desplegado: pub
 
 > **Tiempo:** ~45 minutos para el recorrido completo, ~10 minutos si solo quieres verlo funcionar.
 >
-> **Versión ejecutable:** cada paso a continuación está replicado en un ejemplo probado y compilable en [`crates/rustango/examples/getting_started_blog`](../crates/rustango/examples/getting_started_blog). Si algún paso parece estar mal, compáralo con ese ejemplo.
+> **Versión ejecutable:** cada paso a continuación está replicado en un ejemplo probado y compilable en [`crates/rustango/examples/getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog). Si algún paso parece estar mal, compáralo con ese ejemplo.
 
-[![Construir un blog con Rustango: generar la migración, aplicarla, arrancar el servidor y consultar la API JSON — todo desde un único binario](img/getting-started.png)](img/getting-started.png)
+[![Construir un blog con Rustango: generar la migración, aplicarla, arrancar el servidor y consultar la API JSON — todo desde un único binario](../img/getting-started.png)](../img/getting-started.png)
 
 ---
 
@@ -15,15 +15,69 @@ Este recorrido te lleva desde un directorio vacío hasta un blog desplegado: pub
 | Herramienta | Para qué | Instalación |
 |---|---|---|
 | Rust 1.88+ | Compilador | <https://rustup.rs> |
-| Docker | Postgres local | <https://docker.com> |
+| Una base de datos | Esta guía usa Postgres | ver [Elegir base de datos](#elegir-base-de-datos) abajo |
 | `psql` (opcional) | Inspeccionar la BD | `brew install libpq` / `apt install postgresql-client` |
-
-Comprueba las versiones que tienes instaladas:
 
 ```bash
 rustc --version    # should print 1.88+
-docker --version   # any recent version
 ```
+
+### Elegir base de datos
+
+**Docker no es obligatorio.** Esta guía lo usa porque un solo comando te da un
+Postgres desechable, pero nada en rustango depende de él. Elige la fila que
+encaje con tu máquina; todo lo demás es idéntico:
+
+| Si quieres | Haz esto | Notas |
+|---|---|---|
+| **Ningún servidor de base de datos** | Ejecutar con SQLite (abajo) | Nada que instalar. Lo mejor para aprender. |
+| Postgres **sin** Docker | Instalar Postgres de forma nativa y apuntar `DATABASE_URL` a `localhost` | Ver [Postgres nativo](#postgres-nativo-sin-docker). |
+| Postgres **con** Docker | `docker compose up -d` en el proyecto generado | Lo que asume el resto de esta guía. |
+
+#### SQLite — sin configuración
+
+Los proyectos generados incluyen una feature `sqlite`, así que puedes ejecutar
+uno sin instalar ni arrancar nada:
+
+```bash
+cargo run --no-default-features --features sqlite
+```
+
+con una URL basada en fichero en `.env` en lugar de la de Postgres:
+
+```bash
+DATABASE_URL=sqlite://myblog_dev.db?mode=rwc
+```
+
+`mode=rwc` le dice a SQLite que cree el fichero si no existe. Todo lo de esta
+guía — modelos, migraciones, el admin, el ORM — funciona igual; solo quedan
+fuera las funciones específicas de Postgres (operadores `JSONB`, multi-tenancy
+en modo esquema).
+
+#### Postgres nativo (sin Docker)
+
+Instala Postgres con tu gestor de paquetes (`brew install postgresql@16`,
+`apt install postgresql`, o el instalador de Windows en
+<https://www.postgresql.org/download/windows/>) y crea el rol y la base de datos
+que espera la configuración generada:
+
+```bash
+createuser -s rustango          # o: CREATE ROLE rustango LOGIN SUPERUSER PASSWORD 'rustango';
+createdb myblog_dev -O rustango
+```
+
+El `.env.example` generado apunta al nombre del servicio de Docker. Cambia el
+host a `localhost`:
+
+```bash
+# .env  —  `postgres` es el nombre del servicio de docker-compose; en nativo, localhost
+DATABASE_URL=postgres://rustango:rustango@localhost:5432/myblog_dev
+```
+
+> **¿En Windows?** El backend Hyper-V / WSL2 de Docker Desktop es una causa
+> frecuente de fallos al arrancar. Si te da guerra, usa la vía SQLite de arriba
+> para aprender el framework y vuelve a Docker cuando prepares el despliegue —
+> para eso está realmente la configuración de contenedores.
 
 ---
 
@@ -123,7 +177,15 @@ openssl rand -base64 32     # paste output as RUSTANGO_SESSION_SECRET value
 
 ---
 
-## Paso 4: Arrancar Postgres
+## Paso 4: Arrancar la base de datos
+
+> **¿Usas SQLite?** Sáltate este paso — no hay servidor que arrancar. Asegúrate
+> de que `.env` tenga `DATABASE_URL=sqlite://myblog_dev.db?mode=rwc` y añade
+> `--no-default-features --features sqlite` a cada `cargo run` de abajo.
+>
+> **¿Usas un Postgres nativo?** Ya está corriendo como servicio; solo comprueba
+> que `psql "$DATABASE_URL" -c "SELECT version();"` funciona y sigue adelante.
+
 
 El proyecto incluye un `docker-compose.yml` que ejecuta Postgres en un contenedor, para que no instales una base de datos a mano. La app en sí la ejecutaremos con `cargo` en el host, así que arranca solo el servicio `postgres` en segundo plano (el archivo de compose también define un contenedor de desarrollo `rust` opcional que, de lo contrario, ocuparía el puerto 8080):
 
@@ -713,15 +775,15 @@ Asegúrate de que tu proxy inverso:
 
 | Tema | Doc |
 |---|---|
-| Versión ejecutable de esta guía | [`examples/getting_started_blog`](../crates/rustango/examples/getting_started_blog) |
+| Versión ejecutable de esta guía | [`examples/getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog) |
 | Cada subcomando de `manage` | [`docs/manage.md`](manage.md) |
 | Recetario del ORM (filtros avanzados, agregaciones, M2M, soft delete) | [`docs/orm.md`](orm.md) |
 | Middleware (el catálogo completo de capas + ordenamiento) | [`docs/middleware.md`](middleware.md) |
 | Benchmarks de rendimiento (vs. Go) | [`docs/benchmarks.md`](benchmarks.md) |
 | Convenciones de la API (nomenclatura, patrones builder, feature gates) | [`docs/api-conventions.md`](api-conventions.md) |
 | Funciones de seguridad en profundidad | [`docs/security.md`](security.md) |
-| Auditoría de paridad con Django | [`docs/django-parity-audit-2026-05-21.md`](django-parity-audit-2026-05-21.md) |
-| Multi-tenancy | [README — sección Multi-tenancy](../README.md#multi-tenancy) |
+| Auditoría de paridad con Django | [`docs/django-parity-audit-2026-05-21.md`](https://github.com/ujeenet/rustango/blob/main/docs/django-parity-audit-2026-05-21.md) |
+| Multi-tenancy | [README — sección Multi-tenancy](https://github.com/ujeenet/rustango/blob/main/README.md#multi-tenancy) |
 | Documentación de la API | <https://docs.rs/rustango> |
 
 Si te topas con algo que no funciona o no queda claro, abre un issue.

--- a/docs/es/html-views.md
+++ b/docs/es/html-views.md
@@ -12,7 +12,7 @@ Son el equivalente en **Rustango** de las vistas genéricas basadas en clases de
 recursos de Laravel que devuelven vistas Blade. Renderizan mediante plantillas
 [Tera](https://keats.github.io/tera/).
 
-[![Vistas HTML en Rustango: un modelo alimenta ListView, DetailView y CreateView/UpdateView/DeleteView, cada una renderizando una plantilla Tera en una página renderizada en el servidor](img/html-views.png)](img/html-views.png)
+[![Vistas HTML en Rustango: un modelo alimenta ListView, DetailView y CreateView/UpdateView/DeleteView, cada una renderizando una plantilla Tera en una página renderizada en el servidor](../img/html-views.png)](../img/html-views.png)
 
 > **¿Nuevo con algún término aquí?** Si *modelo*, *plantilla*, *router* o *renderizado en el
 > servidor* no te resultan familiares, el [glosario](glossary.md) explica cada uno en lenguaje
@@ -24,7 +24,7 @@ recursos de Laravel que devuelven vistas Blade. Renderizan mediante plantillas
 >
 > **Versión ejecutable:** el ejemplo API-vs-HTML de abajo está fijado por el
 > test del framework
-> [`html_and_api_contrast_sqlite_live.rs`](../crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
+> [`html_and_api_contrast_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
 > (`cargo test -p rustango --features sqlite --test html_and_api_contrast_sqlite_live`).
 > Las vistas individuales están cubiertas por `template_view.rs` y
 > `template_views_context_object_name_sqlite_live.rs`.
@@ -324,7 +324,7 @@ let app = axum::Router::new()
 
 Ahora `GET /api/posts` devuelve el sobre JSON paginado y `GET /posts`
 devuelve un listado HTML renderizado — las mismas filas, el mismo pool, dos formas. Esta
-configuración exacta es lo que afirma el [test de respaldo](../crates/rustango/tests/html_and_api_contrast_sqlite_live.rs).
+configuración exacta es lo que afirma el [test de respaldo](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/html_and_api_contrast_sqlite_live.rs).
 
 ---
 

--- a/docs/es/i18n.md
+++ b/docs/es/i18n.md
@@ -8,7 +8,7 @@ de esta guía. El `Translator` carga catálogos de mensajes por locale, sustituy
 `{placeholders}`, gestiona plurales y hace un fallback elegante — el `gettext` /
 `{% trans %}` de Django, en Rust.
 
-[![i18n en Rustango: un Translator mantiene catálogos por locale; gettext busca una clave con fallback (locale → idioma base → por defecto → la clave misma), sustituye placeholders {name}, y ngettext elige singular vs. plural](img/i18n.png)](img/i18n.png)
+[![i18n en Rustango: un Translator mantiene catálogos por locale; gettext busca una clave con fallback (locale → idioma base → por defecto → la clave misma), sustituye placeholders {name}, y ngettext elige singular vs. plural](../img/i18n.png)](../img/i18n.png)
 
 > **¿Nuevo con algún término aquí?** *locale*, *catálogo*, *Accept-Language*,
 > *pluralización*, *RTL* — consulta el [glosario](glossary.md).
@@ -20,10 +20,10 @@ de esta guía. El `Translator` carga catálogos de mensajes por locale, sustituy
 > [Middleware](middleware.md)).
 >
 > **Versión ejecutable:** cada fragmento está copiado de
-> [`i18n_doc.rs`](../crates/rustango/tests/i18n_doc.rs)
+> [`i18n_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/i18n_doc.rs)
 > (`cargo test -p rustango --test i18n_doc`); las sobrescrituras de traducción
 > respaldadas por base de datos se prueban en condiciones reales con
-> [`i18n_db_overrides_sqlite_live.rs`](../crates/rustango/tests/i18n_db_overrides_sqlite_live.rs).
+> [`i18n_db_overrides_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/i18n_db_overrides_sqlite_live.rs).
 
 ## Tabla de contenidos
 

--- a/docs/es/jobs.md
+++ b/docs/es/jobs.md
@@ -8,7 +8,7 @@ retorna de inmediato, y un pool de workers ejecuta el trabajo momentos después,
 con **reintentos automáticos** y una ruta **dead-letter** para los fallos. Esto
 es Django-Q / Celery / las colas de Laravel, en Rust.
 
-[![Background jobs in Rustango: a handler dispatches a Job onto a queue, worker tasks run it, retryable failures back off and retry, fatal ones go to a dead-letter handler](img/jobs.png)](img/jobs.png)
+[![Background jobs in Rustango: a handler dispatches a Job onto a queue, worker tasks run it, retryable failures back off and retry, fatal ones go to a dead-letter handler](../img/jobs.png)](../img/jobs.png)
 
 > **¿Un término nuevo aquí?** *cola*, *worker*, *reintento/backoff*,
 > *dead-letter* — ver el [glosario](glossary.md).
@@ -20,10 +20,10 @@ es Django-Q / Celery / las colas de Laravel, en Rust.
 >
 > **Versión ejecutable:** los fragmentos in-memory, de reintento y de
 > dead-letter están copiados de
-> [`jobs_doc.rs`](../crates/rustango/tests/jobs_doc.rs)
+> [`jobs_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/jobs_doc.rs)
 > (`cargo test -p rustango --test jobs_doc`); la cola persistente se prueba con
 > dogfooding sobre SQLite mediante
-> [`jobs_sqlite_live.rs`](../crates/rustango/tests/jobs_sqlite_live.rs)
+> [`jobs_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/jobs_sqlite_live.rs)
 > (`cargo test -p rustango --features sqlite,jobs-postgres --test jobs_sqlite_live`).
 
 ## Tabla de contenidos

--- a/docs/es/manage.md
+++ b/docs/es/manage.md
@@ -11,13 +11,13 @@ cargo run -- migrate               # any other verb
 cargo run -- --help                # full subcommand list
 ```
 
-[![One binary runs every manage verb — server, migrations, scaffolders, database utilities, and system commands — like Django's manage.py or Laravel's artisan](img/manage.png)](img/manage.png)
+[![One binary runs every manage verb — server, migrations, scaffolders, database utilities, and system commands — like Django's manage.py or Laravel's artisan](../img/manage.png)](../img/manage.png)
 
 > **Fuente:** `rustango::manage` (`Cli`, el despachador de verbos) — detrás de
 > la característica `manage` (activada por defecto).
 >
 > **Versión ejecutable:** cada verbo aquí se ejecuta en un proyecto generado; el
-> ejemplo [`getting_started_blog`](../crates/rustango/examples/getting_started_blog)
+> ejemplo [`getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog)
 > se maneja con `cargo run -- migrate` y compañía.
 
 > **¿Nuevo con algún término aquí?** *scaffold*, *migration*, *tenant* — consulta
@@ -1133,7 +1133,7 @@ cargo run -- purge-tenant acme           # hard (drops schema/db)
 
 Los tenants en modo database obtienen su propio pool de conexiones (un `PgPool`
 — un conjunto de conexiones de base de datos reutilizadas), cacheado por slug en
-[`TenantPools`](../crates/rustango/src/tenancy/pools.rs). Por defecto un pool se
+[`TenantPools`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/src/tenancy/pools.rs). Por defecto un pool se
 construye **de forma perezosa, en el primer request del tenant**, a menos que
 actives el pre-calentamiento. Los ajustes viven en `TenantPoolsConfig`:
 

--- a/docs/es/mcp.md
+++ b/docs/es/mcp.md
@@ -8,7 +8,7 @@ una sola macro, monta un router, y cualquier cliente MCP puede descubrirla y
 llamarla sobre el transporte JSON-RPC estándar — con autorización **fail-closed**
 por agente y OAuth 2.1 integrados.
 
-[![Servidor MCP en Rustango: un agente LLM se conecta sobre JSON-RPC + SSE; el servidor autentica el JWT del agente, lista solo las tools que sus skills concedidos permiten, y ejecuta el handler de la tool contra el pool de tu app](img/mcp.png)](img/mcp.png)
+[![Servidor MCP en Rustango: un agente LLM se conecta sobre JSON-RPC + SSE; el servidor autentica el JWT del agente, lista solo las tools que sus skills concedidos permiten, y ejecuta el handler de la tool contra el pool de tu app](../img/mcp.png)](../img/mcp.png)
 
 > **¿Nuevo con algún término aquí?** *MCP*, *JSON-RPC*, *tool/resource/prompt*,
 > *agente*, *JWT*, *OAuth* — consulta el [glosario](glossary.md).
@@ -20,11 +20,11 @@ por agente y OAuth 2.1 integrados.
 > por defecto; arrastra `tenancy, sse, serializer, openapi, jwt`).
 >
 > **Versión ejecutable:** cada fragmento está copiado de
-> [`mcp_doc.rs`](../crates/rustango/tests/mcp_doc.rs)
+> [`mcp_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/mcp_doc.rs)
 > (`cargo test -p rustango --features sqlite,mcp --test mcp_doc`); toda la
 > superficie del protocolo se prueba en condiciones reales con la suite
 > `crates/rustango/tests/mcp_*.rs`, y un servidor ejecutable vive en
-> [`examples/mcp_demo`](../crates/rustango/examples/mcp_demo).
+> [`examples/mcp_demo`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/mcp_demo).
 
 ## Tabla de contenidos
 
@@ -246,7 +246,7 @@ println!("copy once: {}", issued.token);
 ```
 
 En la emisión del token, el servidor llama a
-[`resolve_user_agent_grants_pool`](../crates/rustango/src/tenancy/agents.rs) —
+[`resolve_user_agent_grants_pool`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/src/tenancy/agents.rs) —
 los permisos efectivos del propietario (`user_permissions_pool`, es decir, roles +
 concesiones directas − denegaciones) seleccionan los skills mapeados, cuyos
 tools/prompts/resources se aplanan en los claims `skills`/`tools` del JWT. Así
@@ -428,12 +428,12 @@ Cambia a la pestaña **Tools** y haz clic en **List Tools** — verás *solo* la
 `add` que concede el skill del agente, con su JSON Schema. Selecciónala, introduce
 `a = 2`, `b = 3`, y **Run Tool**:
 
-[![El MCP Inspector conectado a la demo de Rustango sobre Streamable HTTP, mostrando la tool `add` concedida y su esquema de entrada a/b](img/mcp-inspector-tools.png)](img/mcp-inspector-tools.png)
+[![El MCP Inspector conectado a la demo de Rustango sobre Streamable HTTP, mostrando la tool `add` concedida y su esquema de entrada a/b](../img/mcp-inspector-tools.png)](../img/mcp-inspector-tools.png)
 
 La llamada devuelve un resultado estructurado — `{ "sum": 5 }` — y la petición
 aparece en el panel History (`initialize` → `tools/list` → `tools/call`):
 
-[![El mismo Inspector tras ejecutar la tool: Tool Result Success con contenido estructurado { sum: 5 }, y el historial de llamadas JSON-RPC](img/mcp-inspector-call.png)](img/mcp-inspector-call.png)
+[![El mismo Inspector tras ejecutar la tool: Tool Result Success con contenido estructurado { sum: 5 }, y el historial de llamadas JSON-RPC](../img/mcp-inspector-call.png)](../img/mcp-inspector-call.png)
 
 ### (d) Conecta un cliente MCP real
 

--- a/docs/es/middleware.md
+++ b/docs/es/middleware.md
@@ -9,7 +9,7 @@ sea cuestión de unas pocas líneas. Si vienes de Django, esto es la lista
 `MIDDLEWARE`; de Express, es `app.use()`; de Laravel, es el kernel HTTP — la
 misma idea, adjunta a tu router.
 
-[![Middleware in Rustango: a request flows down through a stack of tower layers (request-id, locale, security headers, CSRF) into the handler and back up through the response side of each layer](img/middleware.png)](img/middleware.png)
+[![Middleware in Rustango: a request flows down through a stack of tower layers (request-id, locale, security headers, CSRF) into the handler and back up through the response side of each layer](../img/middleware.png)](../img/middleware.png)
 
 > **Fuente:** el middleware está construido sobre
 > [`tower::Layer`](https://docs.rs/tower) + `axum::middleware::from_fn`. Los

--- a/docs/es/models.md
+++ b/docs/es/models.md
@@ -8,7 +8,7 @@ la referencia de **declaración**: cada tipo de campo, cada opción de clave pri
 cada atributo `#[rustango(...)]`. Para *consultar* los modelos una vez declarados,
 consulta el [recetario del ORM](orm.md).
 
-[![Modelos en Rustango: una struct #[derive(Model)] asigna tipos de campo Rust a columnas por dialecto, la clave primaria puede ser un Auto<i64> autoincremental o una clave personalizada asignada por la aplicación, y el derive genera SCHEMA + objects() + save/find](img/models.png)](img/models.png)
+[![Modelos en Rustango: una struct #[derive(Model)] asigna tipos de campo Rust a columnas por dialecto, la clave primaria puede ser un Auto<i64> autoincremental o una clave personalizada asignada por la aplicación, y el derive genera SCHEMA + objects() + save/find](../img/models.png)](../img/models.png)
 
 > **¿Un término aquí es nuevo para ti?** *model*, *primary key*, *foreign key*,
 > *migration*, *nullable* — consulta el [glosario](glossary.md).
@@ -21,7 +21,7 @@ consulta el [recetario del ORM](orm.md).
 >
 > **Versión ejecutable:** los round-trips de tipos de campo, la PK personalizada y los
 > fragmentos de SCHEMA están copiados de
-> [`models_doc.rs`](../crates/rustango/tests/models_doc.rs)
+> [`models_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/models_doc.rs)
 > (`cargo test -p rustango --features sqlite --test models_doc`).
 
 ## Tabla de contenidos

--- a/docs/es/openapi.md
+++ b/docs/es/openapi.md
@@ -7,7 +7,7 @@ serializadores y ViewSets que ya escribiste: los esquemas de campo vienen de
 monta `/openapi.json` + una página de documentación interactiva. Cuando necesitas
 control total, los mismos tipos te permiten construir a mano cualquier especificación.
 
-[![OpenAPI de Rustango: los campos del serializador se convierten en un esquema de componente, el ViewSet se convierte en rutas CRUD, y openapi_router sirve /openapi.json + Swagger UI](img/openapi.png)](img/openapi.png)
+[![OpenAPI de Rustango: los campos del serializador se convierten en un esquema de componente, el ViewSet se convierte en rutas CRUD, y openapi_router sirve /openapi.json + Swagger UI](../img/openapi.png)](../img/openapi.png)
 
 > **Fuente:** `rustango::openapi` (`OpenApiSpec`, `Schema`, `OpenApiSchema`,
 > `PathItem`, `Operation`, `SecurityScheme`, `router::openapi_router`) y
@@ -15,7 +15,7 @@ control total, los mismos tipos te permiten construir a mano cualquier especific
 > router del visor también necesita `admin`).
 >
 > **Versión ejecutable:** cada fragmento de abajo está copiado del ejemplo probado
-> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog/tests/openapi.rs)
+> [`getting_started_blog`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/getting_started_blog/tests/openapi.rs)
 > — `cargo test -p getting_started_blog --test openapi`. Los tipos del builder, del
 > esquema y del router están cubiertos además por las propias pruebas unitarias del
 > framework (`crates/rustango/src/openapi/`).

--- a/docs/es/orm.md
+++ b/docs/es/orm.md
@@ -2,14 +2,14 @@
 
 Patrones para el ORM de **Rustango** más allá de lo básico. Si vienes del ORM de Django, de Eloquent de Laravel o de ActiveRecord de Rails, las formas que verás aquí te resultarán familiares. La mayoría de los ejemplos asumen que ya tienes un modelo `Post` de `Getting Started`.
 
-[![Consultas del ORM verificadas por tipos: filtros encadenados, ordenamiento, límites y agregación — todo sin SQL crudo](img/orm.png)](img/orm.png)
+[![Consultas del ORM verificadas por tipos: filtros encadenados, ordenamiento, límites y agregación — todo sin SQL crudo](../img/orm.png)](../img/orm.png)
 
 > **Fuente:** `rustango::sql` (`QuerySet`, la macro `Q!` / el builder `Qb`) y la
 > API de consulta de `#[derive(Model)]` — siempre compilada; elige una característica de backend
 > (`postgres` / `mysql` / `sqlite`).
 >
 > **Versión ejecutable:** los patrones aquí se ejecutan en el ejemplo probado
-> [`orm_cookbook`](../crates/rustango/examples/orm_cookbook).
+> [`orm_cookbook`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/orm_cookbook).
 >
 > **¿Nuevo con algún término de aquí?** El [glosario](glossary.md) define *model*, *queryset*,
 > *pool* y *migración* en lenguaje sencillo.

--- a/docs/es/scaffolding.md
+++ b/docs/es/scaffolding.md
@@ -5,7 +5,7 @@
 1. **El generador de proyectos** — `cargo rustango new` crea un proyecto entero nuevo a partir de una plantilla.
 2. **Generadores dentro del proyecto** — `manage startapp` y la familia `manage make:*` añaden apps, vistas, serializers, jobs y más dentro de un proyecto existente.
 
-[![`cargo rustango new` genera un proyecto completo y listo para ejecutar — manifiesto de Cargo, niveles de configuración, Docker, migraciones y src — en un solo comando](img/scaffolding.png)](img/scaffolding.png)
+[![`cargo rustango new` genera un proyecto completo y listo para ejecutar — manifiesto de Cargo, niveles de configuración, Docker, migraciones y src — en un solo comando](../img/scaffolding.png)](../img/scaffolding.png)
 
 ## Tabla de contenidos
 
@@ -149,7 +149,7 @@ Opciones:
 
 ## Generar archivos sueltos: los comandos `make:*`
 
-Dentro de un proyecto, los verbos `make:*` generan el andamiaje de un archivo cada vez. La referencia completa por flag vive en la [referencia de la CLI de manage](manage); las formas comunes son:
+Dentro de un proyecto, los verbos `make:*` generan el andamiaje de un archivo cada vez. La referencia completa por flag vive en la [referencia de la CLI de manage](manage.md); las formas comunes son:
 
 | Comando | Genera | Comparable a |
 |---|---|---|

--- a/docs/es/security.md
+++ b/docs/es/security.md
@@ -2,7 +2,7 @@
 
 Esta guía cubre todas las funciones de seguridad que incluye **Rustango** y cómo combinarlas. Si vienes de Django, Laravel o Rails, la mayoría te resultarán familiares — los nombres difieren, pero las ideas son las mismas. Cada función de abajo suele ser una sola línea de configuración. Cuando estés listo para desplegar, ejecuta `manage check --deploy` para una auditoría automatizada.
 
-[![La pila de middleware endurecida conectada en una sola cadena: identificadores de petición, registro de accesos, limitación de tasa, CORS y cabeceras de seguridad](img/security.png)](img/security.png)
+[![La pila de middleware endurecida conectada en una sola cadena: identificadores de petición, registro de accesos, limitación de tasa, CORS y cabeceras de seguridad](../img/security.png)](../img/security.png)
 
 ## Tabla de contenidos
 

--- a/docs/es/serializers.md
+++ b/docs/es/serializers.md
@@ -17,14 +17,14 @@ escrituras *a través* de él.
 > **¿Algún término nuevo aquí?** — *serializer*, *model*, *ORM*, *DRF*? El
 > [glosario](glossary.md) define cada uno en lenguaje llano.
 
-[![Un serializador de Rustango: read_only, renombrado con source, un campo de método calculado, una FK anidada y un campo write_only — declarados en una sola struct](img/serializers.png)](img/serializers.png)
+[![Un serializador de Rustango: read_only, renombrado con source, un campo de método calculado, una FK anidada y un campo write_only — declarados en una sola struct](../img/serializers.png)](../img/serializers.png)
 
 > **Fuente:** `rustango::serializer` (`ModelSerializer`, `#[derive(Serializer)]`,
 > los atributos de campo `#[serializer(...)]`) — tras la característica `serializer`
 > (activada por defecto).
 >
 > **Versiones ejecutables:** el serializador mínimo se incluye en el ejemplo probado
-> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog/src/post_serializer.rs),
+> [`getting_started_blog`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/getting_started_blog/src/post_serializer.rs),
 > y el comportamiento completo del derive está cubierto por las propias pruebas
 > unitarias del framework — `crates/rustango/tests/serializer_derive.rs` y
 > `serializer_cross_validate.rs`. Si algún fragmento parece desalineado, compáralo
@@ -523,7 +523,7 @@ Unos cuantos filos afilados y escotillas de escape que conviene conocer:
 ## Pruébalo
 
 El serializador mínimo se incluye en el ejemplo
-[`getting_started_blog`](../crates/rustango/examples/getting_started_blog/src/post_serializer.rs)
+[`getting_started_blog`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/getting_started_blog/src/post_serializer.rs)
 (Paso 13 de la guía de primeros pasos). El comportamiento completo del derive — los
 atributos de campo, los campos calculados/anidados/many, y ambas capas de validación —
 está cubierto por las propias pruebas unitarias del framework (sin necesidad de base

--- a/docs/es/testing.md
+++ b/docs/es/testing.md
@@ -9,7 +9,7 @@ reversión de transacción para las pruebas de base de datos y un conjunto de
 aserciones de respuesta, y tienes el cliente de pruebas de Django + `TestCase`, en
 Rust.
 
-[![Pruebas en Rustango: TestClient envuelve tu Router y envía peticiones en proceso a través de la pila real de manejadores; el TestResponse expone el estado, el texto y el JSON para hacer aserciones — sin socket, sin servidor](img/testing.png)](img/testing.png)
+[![Pruebas en Rustango: TestClient envuelve tu Router y envía peticiones en proceso a través de la pila real de manejadores; el TestResponse expone el estado, el texto y el JSON para hacer aserciones — sin socket, sin servidor](../img/testing.png)](../img/testing.png)
 
 > **¿Hay algún término nuevo para ti aquí?** *router*, *handler*, *fixture*, *rollback* — consulta el
 > [glosario](glossary.md).
@@ -20,7 +20,7 @@ Rust.
 > compilados.
 >
 > **Versión ejecutable:** los fragmentos de abajo *son* una prueba que pasa —
-> [`testing_doc.rs`](../crates/rustango/tests/testing_doc.rs)
+> [`testing_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/testing_doc.rs)
 > (`cargo test -p rustango --test testing_doc`). Casi cualquier otro `*_doc.rs`
 > de este repositorio usa `TestClient` de la misma manera.
 

--- a/docs/es/urls.md
+++ b/docs/es/urls.md
@@ -8,7 +8,7 @@ su nombre en todas partes** — en Rust con `reverse(...)`, en templates con
 la API refleja los `reverse()` / `{% url %}` / `resolve_url()` / `redirect()` de
 Django.
 
-[![URLs reverse al estilo Django: register_url! nombra un patrón, reverse() construye la URL en Rust, y {{ url(...) }} construye la URL en un template](img/urls.png)](img/urls.png)
+[![URLs reverse al estilo Django: register_url! nombra un patrón, reverse() construye la URL en Rust, y {{ url(...) }} construye la URL en un template](../img/urls.png)](../img/urls.png)
 
 > **Fuente:** `rustango::urls` (`register_url!`, `reverse`, `reverse_owned`,
 > `all_routes`, `duplicates`, `register_url_tag`) y `rustango::shortcuts`
@@ -236,7 +236,7 @@ motor de regex de entrada.
 
 La forma `{int:id}` se acepta solo como **facilidad de portado** para `reverse()`:
 el constructor divide el placeholder por `:` y conserva solo el nombre, descartando
-el prefijo de tipo ([`urls.rs`](../crates/rustango/src/urls.rs)). Eso permite que
+el prefijo de tipo ([`urls.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/src/urls.rs)). Eso permite que
 `reverse()` funcione sobre un patrón copiado literalmente de un
 `path("<int:id>/", …)` de Django — pero nada valida que el valor suministrado sea
 realmente un entero.

--- a/docs/es/viewsets.md
+++ b/docs/es/viewsets.md
@@ -24,13 +24,13 @@ de principio a fin — scaffolding, modelos, un serializador, el ViewSet, los se
 endpoints CRUD, validación de entrada, filtrado/búsqueda/paginación y pruebas —
 y luego el resto de la página es una referencia de cada perilla.
 
-[![Un ViewSet de Rustango conectado a un serializador: un solo bloque #[viewset(serializer = …)] da salida JSON tipada y entrada validada en las seis rutas CRUD](img/viewsets.png)](img/viewsets.png)
+[![Un ViewSet de Rustango conectado a un serializador: un solo bloque #[viewset(serializer = …)] da salida JSON tipada y entrada validada en las seis rutas CRUD](../img/viewsets.png)](../img/viewsets.png)
 
 > **Fuente:** `rustango::viewset` (`ViewSet`, `#[derive(ViewSet)]`, las opciones
 > `#[viewset(...)]` + el builder `for_model`) — siempre compilado.
 >
 > **Versión ejecutable:** el blog construido aquí refleja el ejemplo probado y
-> compilable [`getting_started_blog`](../crates/rustango/examples/getting_started_blog)
+> compilable [`getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog)
 > (sus `Post` / `PostSerializer` / `PostViewSet`), y cada comportamiento está
 > fijado por las propias pruebas en vivo del framework — `crates/rustango/tests/viewset_*.rs`
 > (en particular `viewset_serializer_render_sqlite_live` y

--- a/docs/files.md
+++ b/docs/files.md
@@ -19,11 +19,11 @@ once against the trait; switch from local disk to S3 with a one-line change.
 > `media` features (all on by default).
 >
 > **Runnable version:** the Storage + upload-guard snippets are copied from
-> [`files_doc.rs`](../crates/rustango/tests/files_doc.rs)
+> [`files_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/files_doc.rs)
 > (`cargo test -p rustango --test files_doc`); the end-to-end multipart
 > `save_uploads` flow is dogfooded by the in-file tests in
 > `crates/rustango/src/uploads.rs`, and the media library by
-> [`media_sqlite_live.rs`](../crates/rustango/tests/media_sqlite_live.rs).
+> [`media_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/media_sqlite_live.rs).
 
 ## Table of contents
 

--- a/docs/fr/admin.md
+++ b/docs/fr/admin.md
@@ -11,7 +11,7 @@ Tout ce qui suit est configuré de manière déclarative dans un bloc
 `admin(...)` sur le derive, ou avec une poignée de méthodes `Builder` et de
 macros d'enregistrement au niveau du module.
 
-[![L'admin auto-généré : une liste de posts avec des facettes de filtre, la recherche, des actions groupées et la pagination — tout à partir d'un seul bloc `admin(...)`](img/admin.png)](img/admin.png)
+[![L'admin auto-généré : une liste de posts avec des facettes de filtre, la recherche, des actions groupées et la pagination — tout à partir d'un seul bloc `admin(...)`](../img/admin.png)](../img/admin.png)
 
 > **Source :** `rustango::admin` (les options du derive `admin(...)`, l'API
 > `Builder` et les macros d'enregistrement) — derrière la feature `admin`
@@ -19,7 +19,7 @@ macros d'enregistrement au niveau du module.
 >
 > **Version exécutable :** chaque fonctionnalité de cette page est illustrée
 > dans un exemple testé et compilable à
-> [`crates/rustango/examples/admin_demo`](../crates/rustango/examples/admin_demo).
+> [`crates/rustango/examples/admin_demo`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/admin_demo).
 > Les captures d'écran de cette page proviennent de cet exemple. Si un extrait
 > semble incorrect, comparez-le à celui-ci.
 
@@ -88,7 +88,7 @@ La racine de l'admin (`GET /<prefix>`) liste chaque modèle enregistré,
 regroupé par app, avec le nom de table et le nombre de champs de chaque
 modèle — plus un flux **Actions récentes** des derniers changements audités.
 
-[![La page d'accueil de l'admin : chaque modèle enregistré regroupé par app avec le nombre de tables et de champs, et un flux d'activité des actions récentes](img/admin-home.png)](img/admin-home.png)
+[![La page d'accueil de l'admin : chaque modèle enregistré regroupé par app avec le nombre de tables et de champs, et un flux d'activité des actions récentes](../img/admin-home.png)](../img/admin-home.png)
 
 ---
 
@@ -164,7 +164,7 @@ un lien **effacer**, et le nombre de lignes ainsi que les compteurs de
 facettes se mettent à jour. Les filtres, la recherche, le tri et la hiérarchie
 de dates se combinent tous dans la chaîne de requête et peuvent être associés.
 
-[![La liste des posts filtrée par status=published : une puce de filtre actif, la facette correspondante mise en évidence, la boîte de recherche et le sélecteur d'actions groupées](img/admin-list-filtered.png)](img/admin-list-filtered.png)
+[![La liste des posts filtrée par status=published : une puce de filtre actif, la facette correspondante mise en évidence, la boîte de recherche et le sélecteur d'actions groupées](../img/admin-list-filtered.png)](../img/admin-list-filtered.png)
 
 **Tri.** Cliquez sur l'en-tête d'une colonne pour trier ; cliquez à nouveau
 pour inverser le sens (`?sort=col&order=asc|desc`). La valeur par défaut vient
@@ -195,7 +195,7 @@ SQLite `strftime`).
 sections titrées ; sans lui, tous les champs modifiables apparaissent en un
 seul bloc.
 
-[![Le formulaire de modification de Post regroupé en fieldsets Content et Publishing, chaque champ avec le widget de saisie adapté à son type](img/admin-fieldsets.png)](img/admin-fieldsets.png)
+[![Le formulaire de modification de Post regroupé en fieldsets Content et Publishing, chaque champ avec le widget de saisie adapté à son type](../img/admin-fieldsets.png)](../img/admin-fieldsets.png)
 
 Soumettre un formulaire valide la saisie, écrit la ligne, enregistre une
 entrée d'audit, et redirige vers la vue **détail** en lecture seule
@@ -271,7 +271,7 @@ un fieldset par enfant), `label`, `fields` (par défaut : chaque scalaire sauf
 la FK), `extra` (lignes vierges proposées pour l'ajout), `max_num`, et
 `readonly_fields`.
 
-[![La page de détail d'un post : champs en lecture seule, le tableau inline Comments, et la carte de piste d'audit montrant l'entrée de création sous forme de diff JSON](img/admin-detail.png)](img/admin-detail.png)
+[![La page de détail d'un post : champs en lecture seule, le tableau inline Comments, et la carte de piste d'audit montrant l'entrée de création sous forme de diff JSON](../img/admin-detail.png)](../img/admin-detail.png)
 
 Pour les lignes enfants rattachées par une clé étrangère générique (paire
 type-de-contenu + pk-d'objet) plutôt que par une seule colonne FK, utilisez
@@ -343,7 +343,7 @@ empreinte inviolable. Deux endroits l'exposent :
   purger les entrées plus anciennes que N jours (lui-même enregistré comme
   une entrée d'audit).
 
-[![Le flux Activité : chaque changement audité à travers les modèles avec des diffs JSON, des cartes de facettes par table/opération/source, et un formulaire de nettoyage](img/admin-audit.png)](img/admin-audit.png)
+[![Le flux Activité : chaque changement audité à travers les modèles avec des diffs JSON, des cartes de facettes par table/opération/source, et un formulaire de nettoyage](../img/admin-audit.png)](../img/admin-audit.png)
 
 ---
 
@@ -526,7 +526,7 @@ enregistré avec ses champs, colonnes, types, drapeaux (PK, unique, …) et
 relations. Rien à configurer ; elle est générée à partir de vos modèles, donc
 elle ne dérive jamais du schéma.
 
-[![La référence de modèle : les champs de chaque modèle avec le nom de colonne, le type Rust, les drapeaux et les relations — générée à partir des modèles](img/admin-model-reference.png)](img/admin-model-reference.png)
+[![La référence de modèle : les champs de chaque modèle avec le nom de colonne, le type Rust, les drapeaux et les relations — générée à partir des modèles](../img/admin-model-reference.png)](../img/admin-model-reference.png)
 
 ---
 

--- a/docs/fr/admin.md
+++ b/docs/fr/admin.md
@@ -439,6 +439,24 @@ Verrouillez-le de l'une des deux façons suivantes :
   et placez une authentification HTTP Basic, OAuth2, ou un SSO d'entreprise
   devant le chemin de nesting avec votre propre middleware.
 
+Lorsque l'authentification par session est active, le pied de la barre latérale
+affiche une ligne **« Connecté en tant que _username_ »** et un bouton
+**Déconnexion** (un formulaire `POST`). Les admins autonomes postent vers
+`{admin_prefix}/logout` par défaut ; un admin de tenant se trouve derrière la
+route de déconnexion propre à la couche de multi-tenancy, alors pointez le
+bouton dessus avec `Builder::logout_url` :
+
+```rust
+let admin = admin::Builder::new(pool)
+    .with_session_auth(session_secret)
+    .logout_url("/staff-logout")       // POST target for the sidebar Logout button
+    .build();
+```
+
+Le builder d'admin de tenant câble cela automatiquement sur son
+`RouteConfig::logout_url`, de sorte que le bouton atteint toujours une route qui
+existe.
+
 ---
 
 ## Thème et image de marque

--- a/docs/fr/api-conventions.md
+++ b/docs/fr/api-conventions.md
@@ -4,7 +4,7 @@
 
 Cette page explique les patterns que suit l'API de **Rustango**, afin que vous puissiez prédire le comportement de n'importe quelle méthode avant même d'en lire la documentation. Si vous contribuez ou auditez une fonctionnalité, ce sont les règles à connaître.
 
-[![Convention de nommage de Rustango : le suffixe de la méthode indique ce qu'elle attend — `*_on` pour un pool typé, forme nue pour le pool multi-backend, et signaux sans pool](img/api-conventions.png)](img/api-conventions.png)
+[![Convention de nommage de Rustango : le suffixe de la méthode indique ce qu'elle attend — `*_on` pour un pool typé, forme nue pour le pool multi-backend, et signaux sans pool](../img/api-conventions.png)](../img/api-conventions.png)
 
 ## Table des matières
 

--- a/docs/fr/auth-api-keys.md
+++ b/docs/fr/auth-api-keys.md
@@ -9,7 +9,7 @@ génération/vérification que vous pouvez brancher sur votre propre table, et u
 backend clé en main qui stocke les clés et authentifie les requêtes
 `Authorization: Bearer`.
 
-[![Clés d'API dans Rustango : generate_key renvoie un token à usage unique prefix.secret, vous stockez le préfixe de 8 caractères plus un hash argon2id, et verify_key vérifie un secret entrant](img/auth-api-keys.png)](img/auth-api-keys.png)
+[![Clés d'API dans Rustango : generate_key renvoie un token à usage unique prefix.secret, vous stockez le préfixe de 8 caractères plus un hash argon2id, et verify_key vérifie un secret entrant](../img/auth-api-keys.png)](../img/auth-api-keys.png)
 
 > **Un terme vous est inconnu ?** *Token*, *hash*, *Bearer*, *argon2id* — le
 > [glossaire](glossary.md) définit les briques de base.
@@ -21,10 +21,10 @@ backend clé en main qui stocke les clés et authentifie les requêtes
 > `ensure_api_keys_table_pool`) — derrière la fonctionnalité `tenancy`.
 >
 > **Version exécutable :** les extraits de l'utilitaire sont copiés depuis
-> [`auth_api_keys_doc.rs`](../crates/rustango/tests/auth_api_keys_doc.rs)
+> [`auth_api_keys_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_api_keys_doc.rs)
 > (`cargo test -p rustango --test auth_api_keys_doc`) ; le flux du middleware
 > `ApiKeyBackend` depuis
-> [`auth_backends_doc.rs`](../crates/rustango/tests/auth_backends_doc.rs)
+> [`auth_backends_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_backends_doc.rs)
 > (`cargo test -p rustango --features sqlite,tenancy --test auth_backends_doc`).
 
 ## Table des matières

--- a/docs/fr/auth-backends.md
+++ b/docs/fr/auth-backends.md
@@ -9,7 +9,7 @@ accepter humains et machines sur les mêmes routes. C'est l'idée
 `require_auth` / `require_perm` pour verrouiller les routes et à l'extracteur
 `CurrentUser` pour lire le résultat.
 
-[![Les backends d'authentification dans Rustango : une requête traverse une chaîne de backends (ModelBackend, ApiKeyBackend, JwtBackend) ; le premier à reconnaître l'identifiant l'emporte et injecte CurrentUser, puis require_perm vérifie un codename](img/auth-backends.png)](img/auth-backends.png)
+[![Les backends d'authentification dans Rustango : une requête traverse une chaîne de backends (ModelBackend, ApiKeyBackend, JwtBackend) ; le premier à reconnaître l'identifiant l'emporte et injecte CurrentUser, puis require_perm vérifie un codename](../img/auth-backends.png)](../img/auth-backends.png)
 
 > **Un terme vous est inconnu ici ?** *Backend*, *middleware*, *extracteur*,
 > *codename de permission* — voir le [glossaire](glossary.md).
@@ -21,7 +21,7 @@ accepter humains et machines sur les mêmes routes. C'est l'idée
 > à `rustango::auth_backends` (toujours compilé).
 >
 > **Version exécutable :** chaque extrait est copié depuis
-> [`auth_backends_doc.rs`](../crates/rustango/tests/auth_backends_doc.rs)
+> [`auth_backends_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_backends_doc.rs)
 > (`cargo test -p rustango --features sqlite,tenancy --test auth_backends_doc`).
 
 ## Table des matières

--- a/docs/fr/auth-decorators.md
+++ b/docs/fr/auth-decorators.md
@@ -6,7 +6,7 @@ axum composables : attachez-en une à un routeur et les requêtes anonymes sont
 refoulées — redirigées par 302 vers votre page de connexion (flux navigateur) ou
 répondues par 401/403 (flux API) — avant même d'atteindre le handler.
 
-[![Décorateurs d'accès : login_required redirige par 302 les navigateurs anonymes vers /login?next=, la famille _or_403 renvoie 401/403 pour les API, superuser_required verrouille par rôle](img/auth-decorators.png)](img/auth-decorators.png)
+[![Décorateurs d'accès : login_required redirige par 302 les navigateurs anonymes vers /login?next=, la famille _or_403 renvoie 401/403 pour les API, superuser_required verrouille par rôle](../img/auth-decorators.png)](../img/auth-decorators.png)
 
 > **Source :** `rustango::auth_decorators` (`login_required`, `login_required_or_401`,
 > `user_passes_test`, `superuser_required`, `active_required`,
@@ -15,7 +15,7 @@ répondues par 401/403 (flux API) — avant même d'atteindre le handler.
 > `SessionUser`).
 >
 > **Version exécutable :** le comportement de verrouillage est couvert par le
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_decorators.rs)
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_decorators.rs)
 > testé — `cargo test -p auth_demo --test auth_decorators`.
 
 > **Un terme vous est inconnu ici ?** *middleware/couche*, *extracteur*,

--- a/docs/fr/auth-flows.md
+++ b/docs/fr/auth-flows.md
@@ -7,7 +7,7 @@ limitée, puis agir lorsqu'il clique dessus — et **Rustango** les construit su
 les **URL signées**. Une URL signée est une URL normale à laquelle est ajoutée une signature HMAC,
 de sorte que le serveur peut faire confiance à ses paramètres sans rien stocker.
 
-[![Flux de compte dans Rustango : signed_url::sign ajoute une signature HMAC + une expiration ; les trois flux (réinitialisation du mot de passe, vérification de l'e-mail, lien magique) émettent un lien, l'envoient par e-mail et le vérifient au clic](img/auth-flows.png)](img/auth-flows.png)
+[![Flux de compte dans Rustango : signed_url::sign ajoute une signature HMAC + une expiration ; les trois flux (réinitialisation du mot de passe, vérification de l'e-mail, lien magique) émettent un lien, l'envoient par e-mail et le vérifient au clic](../img/auth-flows.png)](../img/auth-flows.png)
 
 > **Un terme vous est inconnu ?** *HMAC*, *token*, *expiration* — voir le [glossaire](glossary.md).
 
@@ -17,7 +17,7 @@ de sorte que le serveur peut faire confiance à ses paramètres sans rien stocke
 > (activées par défaut ; la confirmation de réinitialisation nécessite en plus `passwords` + un backend BD).
 >
 > **Version exécutable :** chaque extrait est copié depuis
-> [`auth_flows_doc.rs`](../crates/rustango/tests/auth_flows_doc.rs)
+> [`auth_flows_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_flows_doc.rs)
 > (`cargo test -p rustango --features sqlite --test auth_flows_doc`).
 
 ## Table des matières

--- a/docs/fr/auth-hmac.md
+++ b/docs/fr/auth-hmac.md
@@ -9,7 +9,7 @@ corps, de sorte qu'une requête altérée ou périmée est rejetée. C'est le sc
 utilisé par AWS SigV4 et les signatures de webhooks, et **Rustango** le fournit
 sous la forme d'une seule couche tower.
 
-[![Signature HMAC dans Rustango : le client signe méthode+chemin+requête+date+hash-du-corps avec un secret partagé ; HmacAuthLayer recalcule et compare en temps constant, rejetant les requêtes altérées ou périmées](img/auth-hmac.png)](img/auth-hmac.png)
+[![Signature HMAC dans Rustango : le client signe méthode+chemin+requête+date+hash-du-corps avec un secret partagé ; HmacAuthLayer recalcule et compare en temps constant, rejetant les requêtes altérées ou périmées](../img/auth-hmac.png)](../img/auth-hmac.png)
 
 > **Un terme vous est inconnu ?** *HMAC*, *secret partagé*, *rejeu*, *comparaison en temps constant* —
 > voir le [glossaire](glossary.md).
@@ -19,7 +19,7 @@ sous la forme d'une seule couche tower.
 > la protection contre le rejeu nécessite en plus `cache`).
 >
 > **Version exécutable :** chaque extrait est copié depuis
-> [`auth_hmac_doc.rs`](../crates/rustango/tests/auth_hmac_doc.rs)
+> [`auth_hmac_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/auth_hmac_doc.rs)
 > (`cargo test -p rustango --test auth_hmac_doc`).
 
 ## Table des matières

--- a/docs/fr/auth-jwt-api.md
+++ b/docs/fr/auth-jwt-api.md
@@ -7,7 +7,7 @@ la **révocation** pour la déconnexion. **Rustango** fournit tout cela sous la
 forme de `JwtLifecycle` — et un routeur clé en main qui monte pour vous
 `POST /api/auth/login`, `/refresh`, `/logout`, et `GET /me`.
 
-[![API d'authentification JWT : login émet une paire access+refresh, refresh effectue une rotation et met en liste noire l'ancien token, logout révoque via un magasin de JTI](img/auth-jwt-api.png)](img/auth-jwt-api.png)
+[![API d'authentification JWT : login émet une paire access+refresh, refresh effectue une rotation et met en liste noire l'ancien token, logout révoque via un magasin de JTI](../img/auth-jwt-api.png)](../img/auth-jwt-api.png)
 
 > **Source :** `rustango::tenancy::jwt_lifecycle` (`JwtLifecycle`, `JwtTokenPair`,
 > `JwtClaims`) et `rustango::tenancy::auth_routes` (`jwt_router`, `Config`) +
@@ -15,7 +15,7 @@ forme de `JwtLifecycle` — et un routeur clé en main qui monte pour vous
 > `tenancy`.
 >
 > **Version exécutable :** le moteur de tokens est couvert par le test
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs) —
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_jwt_api.rs) —
 > `cargo test -p auth_demo --test auth_jwt_api`. Les endpoints HTTP sont
 > cloisonnés par tenant et éprouvés de bout en bout par le propre
 > `crates/rustango/tests/tenant_auth_live.rs` du framework.

--- a/docs/fr/auth-jwt.md
+++ b/docs/fr/auth-jwt.md
@@ -7,7 +7,7 @@ requête. Le module `rustango::jwt` de **Rustango** est la brique minimale :
 `encode` pour signer des claims, `decode` pour les vérifier et les relire,
 HS256 en interne.
 
-[![JWT autonome dans Rustango : les Claims portent des champs sub/exp/personnalisés, encode() signe avec un secret partagé, decode() vérifie la signature + l'expiration](img/auth-jwt.png)](img/auth-jwt.png)
+[![JWT autonome dans Rustango : les Claims portent des champs sub/exp/personnalisés, encode() signe avec un secret partagé, decode() vérifie la signature + l'expiration](../img/auth-jwt.png)](../img/auth-jwt.png)
 
 > **Source :** `rustango::jwt` (`Claims`, `encode`, `decode`, `decode_at`,
 > `decode_unverified`, `JwtError`) — derrière la fonctionnalité `jwt` (activée
@@ -15,7 +15,7 @@ HS256 en interne.
 > [API d'authentification JWT](auth-jwt-api.md).
 >
 > **Version exécutable :** les extraits sont copiés depuis le test
-> [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_jwt.rs) —
+> [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_jwt.rs) —
 > `cargo test -p auth_demo --test auth_jwt`.
 
 > **Un terme vous est inconnu ?** *JWT*, *claims*, *sans état*, *secret* — voir le

--- a/docs/fr/auth-passwords.md
+++ b/docs/fr/auth-passwords.md
@@ -7,7 +7,7 @@ cela en deux appels — `hash` à l'entrée, `verify` à la sortie — reposant 
 premier choix actuel de l'OWASP. Vous ne stockez, ne journalisez et ne comparez
 jamais le texte en clair.
 
-[![Les mots de passe dans Rustango : hash() produit une chaîne PHC argon2id salée, verify() vérifie une tentative par rapport à celle-ci, et verify_dummy() égalise le temps de connexion](img/auth-passwords.png)](img/auth-passwords.png)
+[![Les mots de passe dans Rustango : hash() produit une chaîne PHC argon2id salée, verify() vérifie une tentative par rapport à celle-ci, et verify_dummy() égalise le temps de connexion](../img/auth-passwords.png)](../img/auth-passwords.png)
 
 > **Source :** `rustango::passwords` (`hash`, `verify`, `verify_dummy`,
 > `strength_score`, `StrengthIssue`) — derrière la fonctionnalité `passwords`
@@ -15,7 +15,7 @@ jamais le texte en clair.
 > intégrés à la tenancy, voir `rustango::tenancy::password`.
 >
 > **Version exécutable :** chaque extrait ci-dessous est copié depuis l'exemple
-> testé [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_passwords.rs)
+> testé [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_passwords.rs)
 > — `cargo test -p auth_demo --test auth_passwords`.
 
 > **Un terme vous est inconnu ici ?** *hash*, *salt*, *argon2id*, *chaîne PHC* —
@@ -177,7 +177,7 @@ assert!(strength_score("short").contains(&StrengthIssue::TooShort));
 ## Où vit le hash
 
 La chaîne PHC n'est qu'une colonne `String` sur le modèle de compte que vous
-possédez. Dans l'exemple [`auth_demo`](../crates/rustango/examples/auth_demo/src/models.rs) :
+possédez. Dans l'exemple [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/src/models.rs) :
 
 ```rust
 #[derive(Model, Clone, Debug)]

--- a/docs/fr/auth-sessions.md
+++ b/docs/fr/auth-sessions.md
@@ -8,7 +8,7 @@ ne transporte aucun secret et qu'une session peut être **révoquée
 instantanément** — supprimez l'entrée et chaque réplique voit la déconnexion à la
 requête suivante.
 
-[![Les sessions dans Rustango : le cookie ne contient qu'un identifiant opaque, le SessionStore conserve les données dans Redis, et destroy() les révoque partout](img/auth-sessions.png)](img/auth-sessions.png)
+[![Les sessions dans Rustango : le cookie ne contient qu'un identifiant opaque, le SessionStore conserve les données dans Redis, et destroy() les révoque partout](../img/auth-sessions.png)](../img/auth-sessions.png)
 
 > **Source :** `rustango::sessions` (`Session`, `SessionStore`) +
 > `rustango::cache` (`BoxedCache`, `InMemoryCache`) — derrière la fonctionnalité
@@ -17,7 +17,7 @@ requête suivante.
 > pour obtenir `RedisCache`.
 >
 > **Version exécutable :** les extraits ci-dessous sont copiés depuis l'exemple
-> testé [`auth_demo`](../crates/rustango/examples/auth_demo/tests/auth_sessions.rs)
+> testé [`auth_demo`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/auth_demo/tests/auth_sessions.rs)
 > — `cargo test -p auth_demo --test auth_sessions`.
 
 > **Un terme vous est inconnu ici ?** *session*, *identifiant opaque*, *cookie*,

--- a/docs/fr/benchmarks.md
+++ b/docs/fr/benchmarks.md
@@ -27,7 +27,7 @@ harnais en une seule commande (voir [Reproduce](#reproduce)). Rien ici n'est esq
 > livre un framework complet et tout compris. Même le résultat non compilé le plus rapide,
 > **Laravel sur Octane**, reste 4 à 7× derrière les deux binaires.
 
-[![Requêtes/s sur l'index de blog non caché pour les six runtimes — Go 6 651, Rustango 4 781, Laravel+Octane 1 238, Django+Hypercorn 910, Django+gunicorn 850, Laravel+php-fpm 408](img/benchmarks.png)](img/benchmarks.png)
+[![Requêtes/s sur l'index de blog non caché pour les six runtimes — Go 6 651, Rustango 4 781, Laravel+Octane 1 238, Django+Hypercorn 910, Django+gunicorn 850, Laravel+php-fpm 408](../img/benchmarks.png)](../img/benchmarks.png)
 
 ---
 

--- a/docs/fr/caching.md
+++ b/docs/fr/caching.md
@@ -8,7 +8,7 @@ un helper de calcul-au-miss (`get_or_set`), et des helpers JSON typés. Changez 
 backend sans toucher à un seul site d'appel — comme le framework de cache de
 Django ou la façade `Cache` de Laravel.
 
-[![Caching in Rustango: get_or_set checks the cache, runs the factory only on a miss, stores the result with a TTL, and serves hits instantly; the same Cache trait backs InMemory, Redis, and DB](img/caching.png)](img/caching.png)
+[![Caching in Rustango: get_or_set checks the cache, runs the factory only on a miss, stores the result with a TTL, and serves hits instantly; the same Cache trait backs InMemory, Redis, and DB](../img/caching.png)](../img/caching.png)
 
 > **Un terme vous est inconnu ?** *cache*, *TTL*, *clé*, *backend* — voir le
 > [glossaire](glossary.md).
@@ -19,10 +19,10 @@ Django ou la façade `Cache` de Laravel.
 > `cache-redis` (désactivée par défaut).
 >
 > **Version exécutable :** chaque extrait est copié depuis
-> [`cache_doc.rs`](../crates/rustango/tests/cache_doc.rs)
+> [`cache_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/cache_doc.rs)
 > (`cargo test -p rustango --test cache_doc`) ; le backend base de données est
 > éprouvé en dogfooding sur SQLite par
-> [`cache_db_backend_sqlite_live.rs`](../crates/rustango/tests/cache_db_backend_sqlite_live.rs).
+> [`cache_db_backend_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/cache_db_backend_sqlite_live.rs).
 
 ## Table des matières
 

--- a/docs/fr/email.md
+++ b/docs/fr/email.md
@@ -8,7 +8,7 @@ l'injection d'en-têtes, et le rendu de templates. Écrivez `mailer.send(&email)
 passez de l'impression dans votre terminal à un vrai SMTP avec un changement d'une ligne — comme le
 framework d'e-mail de Django.
 
-[![L'e-mail dans Rustango : un builder Email (to/subject/body/html) est validé contre l'injection d'en-têtes, puis envoyé à travers le trait Mailer — ConsoleMailer en dev, SmtpMailer en prod, InMemoryMailer en test](img/email.png)](img/email.png)
+[![L'e-mail dans Rustango : un builder Email (to/subject/body/html) est validé contre l'injection d'en-têtes, puis envoyé à travers le trait Mailer — ConsoleMailer en dev, SmtpMailer en prod, InMemoryMailer en test](../img/email.png)](../img/email.png)
 
 > **Un terme vous est inconnu ?** *e-mail transactionnel*, *SMTP*, *backend de messagerie* — voir
 > le [glossaire](glossary.md).
@@ -19,7 +19,7 @@ framework d'e-mail de Django.
 > fonctionnalité `email-smtp`.
 >
 > **Version exécutable :** chaque snippet est copié depuis
-> [`email_doc.rs`](../crates/rustango/tests/email_doc.rs)
+> [`email_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/email_doc.rs)
 > (`cargo test -p rustango --test email_doc`) ; les helpers d'envoi et les pièces jointes
 > sont mis à l'épreuve par `email_send_helpers.rs` et `email_attachments.rs`.
 

--- a/docs/fr/files.md
+++ b/docs/fr/files.md
@@ -8,7 +8,7 @@ d'une médiathèque suivie — un `MediaManager` adossé à une base de données
 Écrivez votre code une seule fois contre le trait ; passez du disque local à S3 avec un changement
 d'une ligne.
 
-[![Les fichiers dans Rustango : un téléversement multipart est vérifié en taille et en extension puis écrit à travers le trait Storage ; le même trait alimente le disque local, S3 et en mémoire, et url() renvoie une adresse publique](img/files.png)](img/files.png)
+[![Les fichiers dans Rustango : un téléversement multipart est vérifié en taille et en extension puis écrit à travers le trait Storage ; le même trait alimente le disque local, S3 et en mémoire, et url() renvoie une adresse publique](../img/files.png)](../img/files.png)
 
 > **Un terme vous est inconnu ?** *backend de stockage*, *multipart*, *stockage objet*,
 > *URL présignée* — voir le [glossaire](glossary.md).
@@ -20,11 +20,11 @@ d'une ligne.
 > `media` (toutes activées par défaut).
 >
 > **Version exécutable :** les snippets Storage + garde-fous de téléversement sont copiés depuis
-> [`files_doc.rs`](../crates/rustango/tests/files_doc.rs)
+> [`files_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/files_doc.rs)
 > (`cargo test -p rustango --test files_doc`) ; le flux multipart `save_uploads` de bout
 > en bout est mis à l'épreuve par les tests intégrés dans
 > `crates/rustango/src/uploads.rs`, et la médiathèque par
-> [`media_sqlite_live.rs`](../crates/rustango/tests/media_sqlite_live.rs).
+> [`media_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/media_sqlite_live.rs).
 
 ## Table des matières
 

--- a/docs/fr/getting-started.md
+++ b/docs/fr/getting-started.md
@@ -4,9 +4,9 @@ Ce guide vous accompagne depuis un répertoire vide jusqu'à un blog déployé :
 
 > **Durée :** ~45 minutes pour la visite complète, ~10 minutes si vous voulez juste la voir fonctionner.
 >
-> **Version exécutable :** chaque étape ci-dessous est reproduite dans un exemple testé et compilable disponible dans [`crates/rustango/examples/getting_started_blog`](../crates/rustango/examples/getting_started_blog). Si une étape vous semble incorrecte, comparez-la à cet exemple.
+> **Version exécutable :** chaque étape ci-dessous est reproduite dans un exemple testé et compilable disponible dans [`crates/rustango/examples/getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog). Si une étape vous semble incorrecte, comparez-la à cet exemple.
 
-[![Construire un blog avec Rustango : générer la migration, l'appliquer, démarrer le serveur, et interroger l'API JSON — tout depuis un seul binaire](img/getting-started.png)](img/getting-started.png)
+[![Construire un blog avec Rustango : générer la migration, l'appliquer, démarrer le serveur, et interroger l'API JSON — tout depuis un seul binaire](../img/getting-started.png)](../img/getting-started.png)
 
 ---
 
@@ -15,15 +15,69 @@ Ce guide vous accompagne depuis un répertoire vide jusqu'à un blog déployé :
 | Outil | Pourquoi | Installation |
 |---|---|---|
 | Rust 1.88+ | Compilateur | <https://rustup.rs> |
-| Docker | Postgres local | <https://docker.com> |
+| Une base de données | Ce guide utilise Postgres | voir [Choisir une base de données](#choisir-une-base-de-données) ci-dessous |
 | `psql` (optionnel) | Inspecter la BDD | `brew install libpq` / `apt install postgresql-client` |
-
-Vérifiez les versions installées :
 
 ```bash
 rustc --version    # should print 1.88+
-docker --version   # any recent version
 ```
+
+### Choisir une base de données
+
+**Docker n'est pas obligatoire.** Ce guide y a recours parce qu'une seule
+commande fournit un Postgres jetable, mais rien dans rustango n'en dépend.
+Choisissez la ligne qui correspond à votre machine — tout le reste est identique :
+
+| Vous voulez | Faites ceci | Remarques |
+|---|---|---|
+| **Aucun serveur de base de données** | Lancer avec SQLite (ci-dessous) | Rien à installer. Idéal pour apprendre. |
+| Postgres **sans** Docker | Installer Postgres nativement et pointer `DATABASE_URL` sur `localhost` | Voir [Postgres natif](#postgres-natif-sans-docker). |
+| Postgres **avec** Docker | `docker compose up -d` dans le projet généré | Ce que suppose la suite de ce guide. |
+
+#### SQLite — zéro installation
+
+Les projets générés embarquent une fonctionnalité `sqlite` : vous pouvez donc en
+lancer un sans rien installer ni démarrer :
+
+```bash
+cargo run --no-default-features --features sqlite
+```
+
+avec une URL sur fichier dans `.env` à la place de celle de Postgres :
+
+```bash
+DATABASE_URL=sqlite://myblog_dev.db?mode=rwc
+```
+
+`mode=rwc` demande à SQLite de créer le fichier s'il n'existe pas. Tout ce que
+couvre ce guide — modèles, migrations, l'admin, l'ORM — fonctionne à l'identique ;
+seules les fonctionnalités propres à Postgres (opérateurs `JSONB`, multi-tenancy
+en mode schéma) ne s'appliquent pas.
+
+#### Postgres natif (sans Docker)
+
+Installez Postgres via votre gestionnaire de paquets (`brew install postgresql@16`,
+`apt install postgresql`, ou l'installateur Windows sur
+<https://www.postgresql.org/download/windows/>), puis créez le rôle et la base
+que la configuration générée attend :
+
+```bash
+createuser -s rustango          # ou : CREATE ROLE rustango LOGIN SUPERUSER PASSWORD 'rustango';
+createdb myblog_dev -O rustango
+```
+
+Le `.env.example` généré pointe sur le nom du service Docker. Remplacez l'hôte
+par `localhost` :
+
+```bash
+# .env  —  `postgres` est le nom du service docker-compose ; en natif, localhost
+DATABASE_URL=postgres://rustango:rustango@localhost:5432/myblog_dev
+```
+
+> **Sous Windows ?** Le backend Hyper-V / WSL2 de Docker Desktop est une cause
+> fréquente d'échecs au démarrage. S'il vous résiste, prenez la voie SQLite
+> ci-dessus pour apprendre le framework et revenez à Docker au moment du
+> déploiement — c'est à cela que sert vraiment la configuration conteneurisée.
 
 ---
 
@@ -123,7 +177,16 @@ openssl rand -base64 32     # paste output as RUSTANGO_SESSION_SECRET value
 
 ---
 
-## Étape 4 : démarrer Postgres
+## Étape 4 : démarrer la base de données
+
+> **Vous utilisez SQLite ?** Passez cette étape — il n'y a aucun serveur à
+> démarrer. Vérifiez que `.env` contient `DATABASE_URL=sqlite://myblog_dev.db?mode=rwc`
+> et ajoutez `--no-default-features --features sqlite` à chaque `cargo run` ci-dessous.
+>
+> **Vous utilisez un Postgres natif ?** Il tourne déjà comme service ; vérifiez
+> simplement que `psql "$DATABASE_URL" -c "SELECT version();"` aboutit, puis
+> passez à la suite.
+
 
 Le projet inclut un `docker-compose.yml` qui exécute Postgres dans un conteneur, afin que vous n'ayez pas à installer une base de données à la main. Nous allons exécuter l'application elle-même avec `cargo` sur l'hôte, donc démarrez uniquement le service `postgres` en arrière-plan (le fichier compose définit aussi un conteneur de développement `rust` optionnel qui occuperait sinon le port 8080) :
 
@@ -713,15 +776,15 @@ Assurez-vous que votre proxy inverse :
 
 | Sujet | Doc |
 |---|---|
-| Version exécutable de ce guide | [`examples/getting_started_blog`](../crates/rustango/examples/getting_started_blog) |
+| Version exécutable de ce guide | [`examples/getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog) |
 | Chaque sous-commande `manage` | [`docs/manage.md`](manage.md) |
 | Recueil de recettes ORM (filtres avancés, agrégations, M2M, suppression douce) | [`docs/orm.md`](orm.md) |
 | Middleware (le catalogue complet des couches + ordonnancement) | [`docs/middleware.md`](middleware.md) |
 | Benchmarks de performance (vs Go) | [`docs/benchmarks.md`](benchmarks.md) |
 | Conventions d'API (nommage, patrons de construction, feature gates) | [`docs/api-conventions.md`](api-conventions.md) |
 | Fonctionnalités de sécurité en détail | [`docs/security.md`](security.md) |
-| Audit de parité avec Django | [`docs/django-parity-audit-2026-05-21.md`](django-parity-audit-2026-05-21.md) |
-| Multi-tenancy | [README — section Multi-tenancy](../README.md#multi-tenancy) |
+| Audit de parité avec Django | [`docs/django-parity-audit-2026-05-21.md`](https://github.com/ujeenet/rustango/blob/main/docs/django-parity-audit-2026-05-21.md) |
+| Multi-tenancy | [README — section Multi-tenancy](https://github.com/ujeenet/rustango/blob/main/README.md#multi-tenancy) |
 | Documentation de l'API | <https://docs.rs/rustango> |
 
 Si vous rencontrez quelque chose qui ne fonctionne pas ou qui n'est pas clair, ouvrez un ticket.

--- a/docs/fr/html-views.md
+++ b/docs/fr/html-views.md
@@ -12,7 +12,7 @@ Ce sont l'équivalent dans **Rustango** des vues génériques basées sur les cl
 ressources de Laravel qui renvoient des vues Blade. Elles effectuent leur rendu via des templates
 [Tera](https://keats.github.io/tera/).
 
-[![Les vues HTML dans Rustango : un modèle alimente ListView, DetailView et CreateView/UpdateView/DeleteView, chacune effectuant le rendu d'un template Tera en une page rendue côté serveur](img/html-views.png)](img/html-views.png)
+[![Les vues HTML dans Rustango : un modèle alimente ListView, DetailView et CreateView/UpdateView/DeleteView, chacune effectuant le rendu d'un template Tera en une page rendue côté serveur](../img/html-views.png)](../img/html-views.png)
 
 > **Un terme vous est inconnu ?** Si *modèle*, *template*, *routeur* ou *rendu côté serveur* ne
 > vous sont pas familiers, le [glossaire](glossary.md) explique chacun d'eux en langage simple.
@@ -23,7 +23,7 @@ ressources de Laravel qui renvoient des vues Blade. Elles effectuent leur rendu 
 >
 > **Version exécutable :** l'exemple API-vs-HTML ci-dessous est fixé par le
 > test du framework
-> [`html_and_api_contrast_sqlite_live.rs`](../crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
+> [`html_and_api_contrast_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
 > (`cargo test -p rustango --features sqlite --test html_and_api_contrast_sqlite_live`).
 > Les vues individuelles sont couvertes par `template_view.rs` et
 > `template_views_context_object_name_sqlite_live.rs`.
@@ -322,7 +322,7 @@ let app = axum::Router::new()
 
 Maintenant `GET /api/posts` renvoie l'enveloppe JSON paginée et `GET /posts`
 renvoie une liste HTML rendue — mêmes lignes, même pool, deux formes. Cette configuration exacte est
-ce qu'affirme le [test de support](../crates/rustango/tests/html_and_api_contrast_sqlite_live.rs).
+ce qu'affirme le [test de support](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/html_and_api_contrast_sqlite_live.rs).
 
 ---
 

--- a/docs/fr/i18n.md
+++ b/docs/fr/i18n.md
@@ -9,7 +9,7 @@ charge des catalogues de messages par locale, substitue les `{placeholders}`,
 gère les pluriels, et se replie avec élégance en cas d'absence — le `gettext` / `{% trans %}`
 de Django, en Rust.
 
-[![i18n dans Rustango : un Translator détient des catalogues par locale ; gettext recherche une clé avec repli (locale → langue de base → défaut → la clé elle-même), substitue les placeholders {name}, et ngettext choisit entre singulier et pluriel](img/i18n.png)](img/i18n.png)
+[![i18n dans Rustango : un Translator détient des catalogues par locale ; gettext recherche une clé avec repli (locale → langue de base → défaut → la clé elle-même), substitue les placeholders {name}, et ngettext choisit entre singulier et pluriel](../img/i18n.png)](../img/i18n.png)
 
 > **Nouveau ici ?** *locale*, *catalogue*, *Accept-Language*, *pluralisation*,
 > *RTL* — voir le [glossaire](glossary.md).
@@ -21,10 +21,10 @@ de Django, en Rust.
 > `::timezone` (voir [Middleware](middleware.md)).
 >
 > **Version exécutable :** chaque extrait est copié depuis
-> [`i18n_doc.rs`](../crates/rustango/tests/i18n_doc.rs)
+> [`i18n_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/i18n_doc.rs)
 > (`cargo test -p rustango --test i18n_doc`) ; les surcharges de traduction
 > adossées à la base de données sont testées en conditions réelles par
-> [`i18n_db_overrides_sqlite_live.rs`](../crates/rustango/tests/i18n_db_overrides_sqlite_live.rs).
+> [`i18n_db_overrides_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/i18n_db_overrides_sqlite_live.rs).
 
 ## Table des matières
 

--- a/docs/fr/jobs.md
+++ b/docs/fr/jobs.md
@@ -9,7 +9,7 @@ quelques instants plus tard, avec des **nouvelles tentatives automatiques** et
 un chemin **dead-letter** pour les échecs. C'est Django-Q / Celery / les queues
 de Laravel, en Rust.
 
-[![Background jobs in Rustango: a handler dispatches a Job onto a queue, worker tasks run it, retryable failures back off and retry, fatal ones go to a dead-letter handler](img/jobs.png)](img/jobs.png)
+[![Background jobs in Rustango: a handler dispatches a Job onto a queue, worker tasks run it, retryable failures back off and retry, fatal ones go to a dead-letter handler](../img/jobs.png)](../img/jobs.png)
 
 > **Un terme vous est inconnu ?** *file*, *worker*, *nouvelle tentative/backoff*,
 > *dead-letter* — voir le [glossaire](glossary.md).
@@ -20,10 +20,10 @@ de Laravel, en Rust.
 > (activée par défaut).
 >
 > **Version exécutable :** les extraits in-memory, nouvelle tentative et
-> dead-letter sont copiés depuis [`jobs_doc.rs`](../crates/rustango/tests/jobs_doc.rs)
+> dead-letter sont copiés depuis [`jobs_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/jobs_doc.rs)
 > (`cargo test -p rustango --test jobs_doc`) ; la file persistante est
 > éprouvée en dogfooding sur SQLite par
-> [`jobs_sqlite_live.rs`](../crates/rustango/tests/jobs_sqlite_live.rs)
+> [`jobs_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/jobs_sqlite_live.rs)
 > (`cargo test -p rustango --features sqlite,jobs-postgres --test jobs_sqlite_live`).
 
 ## Table des matières

--- a/docs/fr/manage.md
+++ b/docs/fr/manage.md
@@ -11,14 +11,14 @@ cargo run -- migrate               # any other verb
 cargo run -- --help                # full subcommand list
 ```
 
-[![One binary runs every manage verb — server, migrations, scaffolders, database utilities, and system commands — like Django's manage.py or Laravel's artisan](img/manage.png)](img/manage.png)
+[![One binary runs every manage verb — server, migrations, scaffolders, database utilities, and system commands — like Django's manage.py or Laravel's artisan](../img/manage.png)](../img/manage.png)
 
 > **Source :** `rustango::manage` (`Cli`, le répartiteur de verbes) — derrière
 > la fonctionnalité `manage` (activée par défaut).
 >
 > **Version exécutable :** chaque verbe présenté ici s'exécute dans un projet
 > généré ; l'exemple
-> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog)
+> [`getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog)
 > est piloté par `cargo run -- migrate` et consorts.
 
 > **Nouveau terme rencontré ici ?** *scaffold* (générateur de squelette),
@@ -1182,7 +1182,7 @@ cargo run -- purge-tenant acme           # hard (drops schema/db)
 Les tenants en mode database obtiennent leur propre pool de connexions
 (un `PgPool` — un ensemble de connexions de base de données réutilisées),
 mis en cache par slug dans
-[`TenantPools`](../crates/rustango/src/tenancy/pools.rs). Par défaut, un
+[`TenantPools`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/src/tenancy/pools.rs). Par défaut, un
 pool est construit **de façon paresseuse, à la première requête du
 tenant**, sauf si vous activez le préchauffage. Les réglages se trouvent
 sur `TenantPoolsConfig` :

--- a/docs/fr/mcp.md
+++ b/docs/fr/mcp.md
@@ -9,7 +9,7 @@ n'importe quel client MCP peut le découvrir et l'appeler via le transport
 JSON-RPC standard — avec une autorisation **fail-closed** par agent et OAuth 2.1
 intégrés.
 
-[![Serveur MCP dans Rustango : un agent LLM se connecte via JSON-RPC + SSE ; le serveur authentifie le JWT de l'agent, ne liste que les tools que ses skills accordés autorisent, et exécute le handler du tool contre le pool de votre application](img/mcp.png)](img/mcp.png)
+[![Serveur MCP dans Rustango : un agent LLM se connecte via JSON-RPC + SSE ; le serveur authentifie le JWT de l'agent, ne liste que les tools que ses skills accordés autorisent, et exécute le handler du tool contre le pool de votre application](../img/mcp.png)](../img/mcp.png)
 
 > **Nouveau ici ?** *MCP*, *JSON-RPC*, *tool/resource/prompt*, *agent*,
 > *JWT*, *OAuth* — voir le [glossaire](glossary.md).
@@ -21,11 +21,11 @@ intégrés.
 > par défaut ; tire `tenancy, sse, serializer, openapi, jwt`).
 >
 > **Version exécutable :** chaque extrait est copié depuis
-> [`mcp_doc.rs`](../crates/rustango/tests/mcp_doc.rs)
+> [`mcp_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/mcp_doc.rs)
 > (`cargo test -p rustango --features sqlite,mcp --test mcp_doc`) ; toute la
 > surface protocolaire est testée en conditions réelles par la suite
 > `crates/rustango/tests/mcp_*.rs`, et un serveur exécutable se trouve dans
-> [`examples/mcp_demo`](../crates/rustango/examples/mcp_demo).
+> [`examples/mcp_demo`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/mcp_demo).
 
 ## Table des matières
 
@@ -247,7 +247,7 @@ println!("copy once: {}", issued.token);
 ```
 
 À l'émission du token, le serveur appelle
-[`resolve_user_agent_grants_pool`](../crates/rustango/src/tenancy/agents.rs) —
+[`resolve_user_agent_grants_pool`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/src/tenancy/agents.rs) —
 les permissions effectives du propriétaire (`user_permissions_pool`, c.-à-d.
 rôles + grants directs − refus) sélectionnent les skills mappés, dont les
 tools/prompts/resources sont aplatis dans les claims `skills`/`tools` du JWT.
@@ -428,12 +428,12 @@ Passez à l'onglet **Tools** et cliquez **List Tools** — vous verrez *seulemen
 le tool `add` que le skill de l'agent accorde, avec son JSON Schema.
 Sélectionnez-le, entrez `a = 2`, `b = 3`, et **Run Tool** :
 
-[![Le MCP Inspector connecté à la démo Rustango via Streamable HTTP, montrant le tool `add` accordé et son schéma d'entrée a/b](img/mcp-inspector-tools.png)](img/mcp-inspector-tools.png)
+[![Le MCP Inspector connecté à la démo Rustango via Streamable HTTP, montrant le tool `add` accordé et son schéma d'entrée a/b](../img/mcp-inspector-tools.png)](../img/mcp-inspector-tools.png)
 
 L'appel retourne un résultat structuré — `{ "sum": 5 }` — et la requête apparaît
 dans le panneau History (`initialize` → `tools/list` → `tools/call`) :
 
-[![Le même Inspector après l'exécution du tool : Tool Result Success avec le contenu structuré { sum: 5 }, et l'historique des appels JSON-RPC](img/mcp-inspector-call.png)](img/mcp-inspector-call.png)
+[![Le même Inspector après l'exécution du tool : Tool Result Success avec le contenu structuré { sum: 5 }, et l'historique des appels JSON-RPC](../img/mcp-inspector-call.png)](../img/mcp-inspector-call.png)
 
 ### (d) Connectez un vrai client MCP
 

--- a/docs/fr/middleware.md
+++ b/docs/fr/middleware.md
@@ -9,7 +9,7 @@ l'écriture des vôtres possible en quelques lignes. Si vous venez de Django,
 c'est la liste `MIDDLEWARE` ; d'Express, c'est `app.use()` ; de Laravel, c'est
 le kernel HTTP — la même idée, rattachée à votre routeur.
 
-[![Middleware in Rustango: a request flows down through a stack of tower layers (request-id, locale, security headers, CSRF) into the handler and back up through the response side of each layer](img/middleware.png)](img/middleware.png)
+[![Middleware in Rustango: a request flows down through a stack of tower layers (request-id, locale, security headers, CSRF) into the handler and back up through the response side of each layer](../img/middleware.png)](../img/middleware.png)
 
 > **Source :** le middleware est bâti sur [`tower::Layer`](https://docs.rs/tower) +
 > `axum::middleware::from_fn`. Les composants intégrés se répartissent dans

--- a/docs/fr/models.md
+++ b/docs/fr/models.md
@@ -8,7 +8,7 @@ chaque type de champ, chaque option de clé primaire, et chaque
 attribut `#[rustango(...)]`. Pour *interroger* les modèles une fois déclarés, voir
 le [cookbook ORM](orm.md).
 
-[![Models in Rustango: a #[derive(Model)] struct maps Rust field types to per-dialect columns, the primary key can be an auto-increment Auto<i64> or a custom application-assigned key, and the derive generates SCHEMA + objects() + save/find](img/models.png)](img/models.png)
+[![Models in Rustango: a #[derive(Model)] struct maps Rust field types to per-dialect columns, the primary key can be an auto-increment Auto<i64> or a custom application-assigned key, and the derive generates SCHEMA + objects() + save/find](../img/models.png)](../img/models.png)
 
 > **Nouveau sur un terme ici ?** *modèle*, *clé primaire*, *clé étrangère*, *migration*,
 > *nullable* — voir le [glossaire](glossary.md).
@@ -20,7 +20,7 @@ le [cookbook ORM](orm.md).
 >
 > **Version exécutable :** les allers-retours de types de champs, la PK personnalisée, et les
 > extraits SCHEMA sont copiés depuis
-> [`models_doc.rs`](../crates/rustango/tests/models_doc.rs)
+> [`models_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/models_doc.rs)
 > (`cargo test -p rustango --features sqlite --test models_doc`).
 
 ## Table des matières

--- a/docs/fr/openapi.md
+++ b/docs/fr/openapi.md
@@ -8,7 +8,7 @@ ViewSet, et un routeur d'une ligne monte `/openapi.json` + une page de
 documentation interactive. Lorsqu'un contrôle total est nécessaire, ces mêmes
 types permettent de construire n'importe quelle spécification à la main.
 
-[![OpenAPI Rustango : les champs du serializer deviennent un schéma de composant, le ViewSet devient des chemins CRUD, et openapi_router sert /openapi.json + Swagger UI](img/openapi.png)](img/openapi.png)
+[![OpenAPI Rustango : les champs du serializer deviennent un schéma de composant, le ViewSet devient des chemins CRUD, et openapi_router sert /openapi.json + Swagger UI](../img/openapi.png)](../img/openapi.png)
 
 > **Source :** `rustango::openapi` (`OpenApiSpec`, `Schema`, `OpenApiSchema`,
 > `PathItem`, `Operation`, `SecurityScheme`, `router::openapi_router`) et
@@ -16,7 +16,7 @@ types permettent de construire n'importe quelle spécification à la main.
 > routeur du visualiseur nécessite aussi `admin`).
 >
 > **Version exécutable :** chaque extrait ci-dessous est copié de l'exemple testé
-> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog/tests/openapi.rs)
+> [`getting_started_blog`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/getting_started_blog/tests/openapi.rs)
 > — `cargo test -p getting_started_blog --test openapi`. Le builder, le schéma et
 > les types de routeur sont en outre couverts par les tests unitaires du framework
 > lui-même (`crates/rustango/src/openapi/`).

--- a/docs/fr/orm.md
+++ b/docs/fr/orm.md
@@ -2,14 +2,14 @@
 
 Modèles d'utilisation de l'ORM **Rustango** au-delà des bases. Si vous venez de l'ORM de Django, d'Eloquent (Laravel) ou d'ActiveRecord (Rails), les formes présentées ici vous sembleront familières. La plupart des exemples supposent que vous disposez déjà d'un modèle `Post` issu de `Getting Started`.
 
-[![Requêtes ORM vérifiées par le typage : filtres chaînés, tri, limites et agrégation — le tout sans SQL brut](img/orm.png)](img/orm.png)
+[![Requêtes ORM vérifiées par le typage : filtres chaînés, tri, limites et agrégation — le tout sans SQL brut](../img/orm.png)](../img/orm.png)
 
 > **Source :** `rustango::sql` (`QuerySet`, la macro `Q!` / le builder `Qb`) et
 > l'API de requêtes `#[derive(Model)]` — toujours compilée ; choisissez une fonctionnalité de backend
 > (`postgres` / `mysql` / `sqlite`).
 >
 > **Version exécutable :** les modèles présentés ici s'exécutent dans l'exemple testé
-> [`orm_cookbook`](../crates/rustango/examples/orm_cookbook).
+> [`orm_cookbook`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/orm_cookbook).
 >
 > **Un terme vous est inconnu ?** Le [glossaire](glossary.md) définit *model*, *queryset*,
 > *pool* et *migration* en langage simple.

--- a/docs/fr/scaffolding.md
+++ b/docs/fr/scaffolding.md
@@ -5,7 +5,7 @@
 1. **Le générateur de projet** — `cargo rustango new` crée un tout nouveau projet à partir d'un template.
 2. **Les générateurs internes au projet** — `manage startapp` et la famille `manage make:*` ajoutent des apps, des vues, des sérialiseurs, des jobs, et bien plus au sein d'un projet existant.
 
-[![`cargo rustango new` scaffolds a complete, ready-to-run project — Cargo manifest, config tiers, Docker, migrations, and src — in one command](img/scaffolding.png)](img/scaffolding.png)
+[![`cargo rustango new` scaffolds a complete, ready-to-run project — Cargo manifest, config tiers, Docker, migrations, and src — in one command](../img/scaffolding.png)](../img/scaffolding.png)
 
 ## Table des matières
 
@@ -149,7 +149,7 @@ Options :
 
 ## Générer des fichiers individuels : les commandes `make:*`
 
-Au sein d'un projet, les verbes `make:*` échafaudent un fichier à la fois. La référence complète, drapeau par drapeau, se trouve dans la [référence CLI manage](manage) ; les formes les plus courantes sont :
+Au sein d'un projet, les verbes `make:*` échafaudent un fichier à la fois. La référence complète, drapeau par drapeau, se trouve dans la [référence CLI manage](manage.md) ; les formes les plus courantes sont :
 
 | Commande | Génère | Comparable à |
 |---|---|---|

--- a/docs/fr/security.md
+++ b/docs/fr/security.md
@@ -2,7 +2,7 @@
 
 Ce guide couvre chaque fonctionnalité de sécurité fournie par **Rustango** et la manière de les combiner. Si vous venez de Django, Laravel ou Rails, la plupart vous sembleront familières — les noms diffèrent, mais les idées sont les mêmes. Chaque fonctionnalité ci-dessous se met généralement en place en une seule ligne. Quand vous êtes prêt à déployer, lancez `manage check --deploy` pour un audit automatisé.
 
-[![La pile de middleware renforcée câblée dans une seule chaîne : identifiants de requête, journalisation des accès, limitation de débit, CORS et en-têtes de sécurité](img/security.png)](img/security.png)
+[![La pile de middleware renforcée câblée dans une seule chaîne : identifiants de requête, journalisation des accès, limitation de débit, CORS et en-têtes de sécurité](../img/security.png)](../img/security.png)
 
 ## Table des matières
 

--- a/docs/fr/serializers.md
+++ b/docs/fr/serializers.md
@@ -18,14 +18,14 @@ travers* lui.
 > **Un terme nouveau ici ?** — *serializer*, *model*, *ORM*, *DRF* ? Le
 > [glossaire](glossary.md) définit chacun en langage clair.
 
-[![Un serializer Rustango : read_only, renommage via source, un champ méthode calculé, une FK imbriquée et un champ write_only — déclarés sur une seule structure](img/serializers.png)](img/serializers.png)
+[![Un serializer Rustango : read_only, renommage via source, un champ méthode calculé, une FK imbriquée et un champ write_only — déclarés sur une seule structure](../img/serializers.png)](../img/serializers.png)
 
 > **Source :** `rustango::serializer` (`ModelSerializer`, `#[derive(Serializer)]`,
 > les attributs de champ `#[serializer(...)]`) — derrière la feature `serializer`
 > (activée par défaut).
 >
 > **Versions exécutables :** le serializer minimal est fourni dans l'exemple testé
-> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog/src/post_serializer.rs),
+> [`getting_started_blog`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/getting_started_blog/src/post_serializer.rs),
 > et le comportement complet du derive est couvert par les tests unitaires du
 > framework lui-même — `crates/rustango/tests/serializer_derive.rs` et
 > `serializer_cross_validate.rs`. Si un extrait semble incorrect, comparer avec
@@ -537,7 +537,7 @@ Quelques angles saillants et échappatoires qu'il vaut la peine de connaître :
 ## À essayer
 
 Le serializer minimal est fourni dans l'exemple
-[`getting_started_blog`](../crates/rustango/examples/getting_started_blog/src/post_serializer.rs)
+[`getting_started_blog`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/getting_started_blog/src/post_serializer.rs)
 (étape 13 du guide de démarrage). Le comportement complet du derive — les
 attributs de champ, les champs computed/nested/many, et les deux couches de
 validation — est couvert par les tests unitaires du framework lui-même (aucune

--- a/docs/fr/testing.md
+++ b/docs/fr/testing.md
@@ -8,7 +8,7 @@ réponse sur laquelle faire des assertions. Ajoutez l'isolation par rollback de 
 un ensemble d'assertions de réponse, et vous obtenez le client de test de Django + `TestCase`, en
 Rust.
 
-[![Les tests dans Rustango : TestClient enveloppe votre Router et envoie des requêtes in-process à travers la vraie pile de handlers ; la TestResponse expose le statut, le texte et le JSON sur lesquels faire des assertions — pas de socket, pas de serveur](img/testing.png)](img/testing.png)
+[![Les tests dans Rustango : TestClient enveloppe votre Router et envoie des requêtes in-process à travers la vraie pile de handlers ; la TestResponse expose le statut, le texte et le JSON sur lesquels faire des assertions — pas de socket, pas de serveur](../img/testing.png)](../img/testing.png)
 
 > **Un terme nouveau ici ?** *router*, *handler*, *fixture*, *rollback* — voir le
 > [glossaire](glossary.md).
@@ -19,7 +19,7 @@ Rust.
 > compilés.
 >
 > **Version exécutable :** les snippets ci-dessous *sont* un test qui passe —
-> [`testing_doc.rs`](../crates/rustango/tests/testing_doc.rs)
+> [`testing_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/testing_doc.rs)
 > (`cargo test -p rustango --test testing_doc`). Presque tous les autres `*_doc.rs`
 > de ce dépôt utilisent `TestClient` de la même manière.
 

--- a/docs/fr/urls.md
+++ b/docs/fr/urls.md
@@ -8,7 +8,7 @@ les templates avec `{{ url(...) }}`, et dans les redirections avec
 `redirect_to_view(...)`. La surface de l'API reflète les
 `reverse()` / `{% url %}` / `resolve_url()` / `redirect()` de Django.
 
-[![URL reverse à la Django : register_url! nomme un motif, reverse() construit l'URL en Rust, et {{ url(...) }} construit l'URL dans un template](img/urls.png)](img/urls.png)
+[![URL reverse à la Django : register_url! nomme un motif, reverse() construit l'URL en Rust, et {{ url(...) }} construit l'URL dans un template](../img/urls.png)](../img/urls.png)
 
 > **Source :** `rustango::urls` (`register_url!`, `reverse`, `reverse_owned`,
 > `all_routes`, `duplicates`, `register_url_tag`) et `rustango::shortcuts`
@@ -236,7 +236,7 @@ jamais été un moteur de regex au départ.
 
 La forme `{int:id}` n'est acceptée que comme **facilité de portage** pour
 `reverse()` : le constructeur découpe le placeholder sur `:` et ne garde que le
-nom, jetant le préfixe de type ([`urls.rs`](../crates/rustango/src/urls.rs)). Cela
+nom, jetant le préfixe de type ([`urls.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/src/urls.rs)). Cela
 permet à `reverse()` de fonctionner sur un motif copié verbatim d'un
 `path("<int:id>/", …)` de Django — mais rien ne valide que la valeur fournie est
 réellement un entier.

--- a/docs/fr/viewsets.md
+++ b/docs/fr/viewsets.md
@@ -23,13 +23,13 @@ Ce guide est avant tout un tutoriel : nous **construisons une API REST de blog c
 des entrées, le filtrage/la recherche/la pagination, et les tests — puis le reste de la page
 est une référence pour chaque réglage.
 
-[![Un ViewSet Rustango branché sur un sérialiseur : un seul bloc #[viewset(serializer = …)] fournit une sortie JSON typée et une entrée validée sur les six routes CRUD](img/viewsets.png)](img/viewsets.png)
+[![Un ViewSet Rustango branché sur un sérialiseur : un seul bloc #[viewset(serializer = …)] fournit une sortie JSON typée et une entrée validée sur les six routes CRUD](../img/viewsets.png)](../img/viewsets.png)
 
 > **Source :** `rustango::viewset` (`ViewSet`, `#[derive(ViewSet)]`, les
 > options `#[viewset(...)]` + le builder `for_model`) — toujours compilé.
 >
 > **Version exécutable :** le blog construit ici reflète l'exemple testé et compilable
-> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog)
+> [`getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog)
 > (ses `Post` / `PostSerializer` / `PostViewSet`), et chaque comportement est
 > verrouillé par les propres tests live du framework — `crates/rustango/tests/viewset_*.rs`
 > (notamment `viewset_serializer_render_sqlite_live` et

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This walkthrough takes you from an empty directory to a deployed blog: posts, an
 
 > **Time:** ~45 minutes for the full tour, ~10 minutes if you just want to see it running.
 >
-> **Runnable version:** every step below is mirrored in a tested, compilable example at [`crates/rustango/examples/getting_started_blog`](../crates/rustango/examples/getting_started_blog). If a step ever looks off, diff against it.
+> **Runnable version:** every step below is mirrored in a tested, compilable example at [`crates/rustango/examples/getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog). If a step ever looks off, diff against it.
 
 [![Build a blog with Rustango: generate the migration, apply it, boot the server, and hit the JSON API — all from one binary](img/getting-started.png)](img/getting-started.png)
 
@@ -15,15 +15,69 @@ This walkthrough takes you from an empty directory to a deployed blog: posts, an
 | Tool | Why | Install |
 |---|---|---|
 | Rust 1.88+ | Compiler | <https://rustup.rs> |
-| Docker | Local Postgres | <https://docker.com> |
+| A database | This guide uses Postgres | see [Choosing a database](#choosing-a-database) below |
 | `psql` (optional) | Inspect DB | `brew install libpq` / `apt install postgresql-client` |
-
-Check the versions you have installed:
 
 ```bash
 rustc --version    # should print 1.88+
-docker --version   # any recent version
 ```
+
+### Choosing a database
+
+**Docker is not required.** This guide reaches for it because one command gives
+you a throwaway Postgres, but nothing in rustango depends on it. Pick whichever
+row fits your machine — everything after this step is identical:
+
+| You want | Do this | Notes |
+|---|---|---|
+| **No database server at all** | Run with SQLite (below) | Nothing to install. Best for learning the framework. |
+| Postgres **without** Docker | Install Postgres natively, then point `DATABASE_URL` at `localhost` | See [Native Postgres](#native-postgres-no-docker). |
+| Postgres **with** Docker | `docker compose up -d` in the generated project | What the rest of this guide assumes. |
+
+#### SQLite — zero setup
+
+Generated projects ship a `sqlite` feature, so you can run one without
+installing or starting anything:
+
+```bash
+cargo run --no-default-features --features sqlite
+```
+
+with a file-backed URL in `.env` instead of the Postgres one:
+
+```bash
+DATABASE_URL=sqlite://myblog_dev.db?mode=rwc
+```
+
+`mode=rwc` tells SQLite to create the file if it does not exist. Everything in
+this guide — models, migrations, the admin, the ORM — works unchanged; only
+Postgres-specific features (`JSONB` operators, schema-mode multi-tenancy) do
+not apply.
+
+#### Native Postgres (no Docker)
+
+Install Postgres from your package manager (`brew install postgresql@16`,
+`apt install postgresql`, or the Windows installer at
+<https://www.postgresql.org/download/windows/>), then create the role and
+database the generated config expects:
+
+```bash
+createuser -s rustango          # or: CREATE ROLE rustango LOGIN SUPERUSER PASSWORD 'rustango';
+createdb myblog_dev -O rustango
+```
+
+The generated `.env.example` points at the Docker service hostname. Change the
+host to `localhost`:
+
+```bash
+# .env  —  `postgres` is the docker-compose service name; use localhost natively
+DATABASE_URL=postgres://rustango:rustango@localhost:5432/myblog_dev
+```
+
+> **On Windows?** Docker Desktop's Hyper-V / WSL2 backend is a common source of
+> start-up failures. If it is fighting you, use the SQLite path above to learn
+> the framework and come back to Docker when you are packaging for deployment —
+> that is what the container setup is really for.
 
 ---
 
@@ -123,7 +177,14 @@ openssl rand -base64 32     # paste output as RUSTANGO_SESSION_SECRET value
 
 ---
 
-## Step 4: Start Postgres
+## Step 4: Start the database
+
+> **Using SQLite?** Skip this step — there is no server to start. Make sure
+> `.env` has `DATABASE_URL=sqlite://myblog_dev.db?mode=rwc` and add
+> `--no-default-features --features sqlite` to every `cargo run` below.
+>
+> **Using a native Postgres?** It is already running as a service; just confirm
+> `psql "$DATABASE_URL" -c "SELECT version();"` succeeds, then skip ahead.
 
 The project ships with a `docker-compose.yml` that runs Postgres in a container, so you don't install a database by hand. We'll run the app itself with `cargo` on the host, so start just the `postgres` service in the background (the compose file also defines an optional `rust` dev-container that would otherwise bind port 8080):
 
@@ -713,15 +774,15 @@ Make sure your reverse proxy:
 
 | Topic | Doc |
 |---|---|
-| Runnable version of this guide | [`examples/getting_started_blog`](../crates/rustango/examples/getting_started_blog) |
+| Runnable version of this guide | [`examples/getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog) |
 | Every `manage` subcommand | [`docs/manage.md`](manage.md) |
 | ORM cookbook (advanced filters, aggregations, M2M, soft delete) | [`docs/orm.md`](orm.md) |
 | Middleware (the full layer catalog + ordering) | [`docs/middleware.md`](middleware.md) |
 | Performance benchmarks (vs Go) | [`docs/benchmarks.md`](benchmarks.md) |
 | API conventions (naming, builder patterns, feature gates) | [`docs/api-conventions.md`](api-conventions.md) |
 | Security features in depth | [`docs/security.md`](security.md) |
-| Django parity audit | [`docs/django-parity-audit-2026-05-21.md`](django-parity-audit-2026-05-21.md) |
-| Multi-tenancy | [README — Multi-tenancy section](../README.md#multi-tenancy) |
+| Django parity audit | [`docs/django-parity-audit-2026-05-21.md`](https://github.com/ujeenet/rustango/blob/main/docs/django-parity-audit-2026-05-21.md) |
+| Multi-tenancy | [README — Multi-tenancy section](https://github.com/ujeenet/rustango/blob/main/README.md#multi-tenancy) |
 | API docs | <https://docs.rs/rustango> |
 
 If you hit something that doesn't work or is unclear, open an issue.

--- a/docs/html-views.md
+++ b/docs/html-views.md
@@ -22,7 +22,7 @@ templates.
 >
 > **Runnable version:** the API-vs-HTML example below is pinned by the
 > framework test
-> [`html_and_api_contrast_sqlite_live.rs`](../crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
+> [`html_and_api_contrast_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
 > (`cargo test -p rustango --features sqlite --test html_and_api_contrast_sqlite_live`).
 > The individual views are covered by `template_view.rs` and
 > `template_views_context_object_name_sqlite_live.rs`.
@@ -321,7 +321,7 @@ let app = axum::Router::new()
 
 Now `GET /api/posts` returns the paginated JSON envelope and `GET /posts`
 returns a rendered HTML list — same rows, same pool, two shapes. This exact
-setup is what the [backing test](../crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
+setup is what the [backing test](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/html_and_api_contrast_sqlite_live.rs)
 asserts.
 
 ---

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -19,10 +19,10 @@ plurals, and falls back gracefully — Django's `gettext` / `{% trans %}`, in Ru
 > `::timezone` (see [Middleware](middleware.md)).
 >
 > **Runnable version:** every snippet is copied from
-> [`i18n_doc.rs`](../crates/rustango/tests/i18n_doc.rs)
+> [`i18n_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/i18n_doc.rs)
 > (`cargo test -p rustango --test i18n_doc`); DB-backed translation overrides are
 > dogfooded by
-> [`i18n_db_overrides_sqlite_live.rs`](../crates/rustango/tests/i18n_db_overrides_sqlite_live.rs).
+> [`i18n_db_overrides_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/i18n_db_overrides_sqlite_live.rs).
 
 ## Table of contents
 

--- a/docs/index.toml
+++ b/docs/index.toml
@@ -5,7 +5,7 @@
 # becomes one documentation page, rendered in the order listed here. Files
 # not listed below are not published (e.g. internal audits / inventories).
 
-version = "0.52"
+version = "0.53"
 
 [[section]]
 title = "Getting started"

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -18,10 +18,10 @@ failures. This is Django-Q / Celery / Laravel queues, in Rust.
 > by default).
 >
 > **Runnable version:** the in-memory, retry, and dead-letter snippets are
-> copied from [`jobs_doc.rs`](../crates/rustango/tests/jobs_doc.rs)
+> copied from [`jobs_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/jobs_doc.rs)
 > (`cargo test -p rustango --test jobs_doc`); the persistent queue is dogfooded
 > on SQLite by
-> [`jobs_sqlite_live.rs`](../crates/rustango/tests/jobs_sqlite_live.rs)
+> [`jobs_sqlite_live.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/jobs_sqlite_live.rs)
 > (`cargo test -p rustango --features sqlite,jobs-postgres --test jobs_sqlite_live`).
 
 ## Table of contents

--- a/docs/manage.md
+++ b/docs/manage.md
@@ -16,7 +16,7 @@ cargo run -- --help                # full subcommand list
 > `manage` feature (on by default).
 >
 > **Runnable version:** every verb here runs in a scaffolded project; the
-> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog)
+> [`getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog)
 > example is driven by `cargo run -- migrate` and friends.
 
 > **New to a term here?** *scaffold*, *migration*, *tenant* — see the
@@ -1132,7 +1132,7 @@ cargo run -- purge-tenant acme           # hard (drops schema/db)
 
 Database-mode tenants get their own connection pool (a `PgPool` — a set
 of reused database connections), cached by slug in
-[`TenantPools`](../crates/rustango/src/tenancy/pools.rs). By default a
+[`TenantPools`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/src/tenancy/pools.rs). By default a
 pool is built **lazily, on the tenant's first request**, unless you turn
 on pre-warming. The settings live on `TenantPoolsConfig`:
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -19,11 +19,11 @@ per-agent, **fail-closed** authorization and OAuth 2.1 built in.
 > default; pulls `tenancy, sse, serializer, openapi, jwt`).
 >
 > **Runnable version:** every snippet is copied from
-> [`mcp_doc.rs`](../crates/rustango/tests/mcp_doc.rs)
+> [`mcp_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/mcp_doc.rs)
 > (`cargo test -p rustango --features sqlite,mcp --test mcp_doc`); the full
 > protocol surface is dogfooded by the `crates/rustango/tests/mcp_*.rs` suite,
 > and a runnable server lives in
-> [`examples/mcp_demo`](../crates/rustango/examples/mcp_demo).
+> [`examples/mcp_demo`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/mcp_demo).
 
 ## Table of contents
 
@@ -239,7 +239,7 @@ println!("copy once: {}", issued.token);
 ```
 
 At token-issue the server calls
-[`resolve_user_agent_grants_pool`](../crates/rustango/src/tenancy/agents.rs) —
+[`resolve_user_agent_grants_pool`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/src/tenancy/agents.rs) —
 the owner's effective permissions (`user_permissions_pool`, i.e. roles + direct
 grants − denials) select the mapped skills, whose tools/prompts/resources are
 flattened into the JWT's `skills`/`tools` claims. So `tools/list`,

--- a/docs/models.md
+++ b/docs/models.md
@@ -20,7 +20,7 @@ the [ORM cookbook](orm.md).
 >
 > **Runnable version:** the field-type round-trips, custom-PK, and SCHEMA
 > snippets are copied from
-> [`models_doc.rs`](../crates/rustango/tests/models_doc.rs)
+> [`models_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/models_doc.rs)
 > (`cargo test -p rustango --features sqlite --test models_doc`).
 
 ## Table of contents

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -15,7 +15,7 @@ control, the same types let you hand-build any spec.
 > viewer router also needs `admin`).
 >
 > **Runnable version:** every snippet below is copied from the tested
-> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog/tests/openapi.rs)
+> [`getting_started_blog`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/getting_started_blog/tests/openapi.rs)
 > example — `cargo test -p getting_started_blog --test openapi`. The builder,
 > schema, and router types are additionally covered by the framework's own unit
 > tests (`crates/rustango/src/openapi/`).

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -9,7 +9,7 @@ Patterns for the **Rustango** ORM beyond the basics. If you come from Django's O
 > (`postgres` / `mysql` / `sqlite`).
 >
 > **Runnable version:** the patterns here run in the tested
-> [`orm_cookbook`](../crates/rustango/examples/orm_cookbook) example.
+> [`orm_cookbook`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/orm_cookbook) example.
 >
 > **New to a term here?** The [glossary](glossary.md) defines *model*, *queryset*,
 > *pool*, and *migration* in plain language.

--- a/docs/scaffolding.md
+++ b/docs/scaffolding.md
@@ -149,7 +149,7 @@ Options:
 
 ## Generate single files: the `make:*` commands
 
-Inside a project, the `make:*` verbs scaffold one file at a time. The full per-flag reference lives in the [manage CLI reference](manage); the common shapes are:
+Inside a project, the `make:*` verbs scaffold one file at a time. The full per-flag reference lives in the [manage CLI reference](manage.md); the common shapes are:
 
 | Command | Generates | Comparable to |
 |---|---|---|

--- a/docs/serializers.md
+++ b/docs/serializers.md
@@ -23,7 +23,7 @@ validates. You compose it with the ORM and ViewSets rather than routing writes
 > (on by default).
 >
 > **Runnable versions:** the minimal serializer ships in the tested
-> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog/src/post_serializer.rs)
+> [`getting_started_blog`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/getting_started_blog/src/post_serializer.rs)
 > example, and the derive's full behavior is covered by the framework's own
 > unit tests — `crates/rustango/tests/serializer_derive.rs` and
 > `serializer_cross_validate.rs`. If a snippet looks off, diff against them.
@@ -511,7 +511,7 @@ A few sharp edges and escape hatches worth knowing:
 ## Try it
 
 The minimal serializer ships in the
-[`getting_started_blog`](../crates/rustango/examples/getting_started_blog/src/post_serializer.rs)
+[`getting_started_blog`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/examples/getting_started_blog/src/post_serializer.rs)
 example (Step 13 of the getting-started guide). The derive's full behavior — the
 field attributes, computed/nested/many fields, and both validation layers — is
 covered by the framework's own unit tests (no database needed):

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,7 @@ Rust.
 > compiled.
 >
 > **Runnable version:** the snippets below *are* a passing test —
-> [`testing_doc.rs`](../crates/rustango/tests/testing_doc.rs)
+> [`testing_doc.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/tests/testing_doc.rs)
 > (`cargo test -p rustango --test testing_doc`). Nearly every other `*_doc.rs`
 > in this repo uses `TestClient` the same way.
 

--- a/docs/urls.md
+++ b/docs/urls.md
@@ -230,7 +230,7 @@ engine to begin with.
 
 The `{int:id}` form is accepted only as a **porting affordance** for `reverse()`:
 the builder splits the placeholder on `:` and keeps just the name, discarding the
-type prefix ([`urls.rs`](../crates/rustango/src/urls.rs)). That lets `reverse()`
+type prefix ([`urls.rs`](https://github.com/ujeenet/rustango/blob/main/crates/rustango/src/urls.rs)). That lets `reverse()`
 run on a pattern copied verbatim from a Django `path("<int:id>/", …)` — but
 nothing validates that the supplied value is actually an integer.
 

--- a/docs/viewsets.md
+++ b/docs/viewsets.md
@@ -29,7 +29,7 @@ is a reference for every knob.
 > `#[viewset(...)]` options + the `for_model` builder) — always compiled.
 >
 > **Runnable version:** the blog built here mirrors the tested, compilable
-> [`getting_started_blog`](../crates/rustango/examples/getting_started_blog)
+> [`getting_started_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/getting_started_blog)
 > example (its `Post` / `PostSerializer` / `PostViewSet`), and every behavior is
 > pinned by the framework's own live tests — `crates/rustango/tests/viewset_*.rs`
 > (notably `viewset_serializer_render_sqlite_live` and


### PR DESCRIPTION
Closes #1248, closes #1247. Both reported by @asaph1214-lang.

## #1248 — 160 broken references, not 3

The report was three 404s on the docs site. All three targets exist in the repo, so they work on GitHub and break once rendered: `docs/index.toml` publishes only the files it lists, and the site has no `crates/` tree. Auditing for that shape found the whole class.

| | before | after |
|---|---|---|
| `../`-escaping links | 156 (39 × 4 locales) | 0 |
| links to unpublished pages | 4 | 0 |
| broken images | 111 | 0 |
| extensionless links | 4 | 0 |

**The translations were worse than English.** `../crates/…` from `docs/fr/` resolves to `docs/crates/`, which has never existed — so the translated pages were broken on GitHub too, not only on the site. Same for images: `de`/`es`/`fr` copied `img/foo.png` verbatim, but images live only in `docs/img/`, so **every hero image in every translation was broken**.

All repo pointers are now absolute `https://github.com/…` URLs — `/blob/` for files, `/tree/` for directories — which resolve from any renderer. Every generated URL was validated against the working tree: 34 distinct targets, all present, all with the correct blob/tree kind.

## #1247 — Docker was never required

Same root cause in prose. The guide listed Docker as a prerequisite and had the reader verify it with `docker --version`, so a user on Windows — where the Hyper-V/WSL2 backend commonly fails to start — reasonably concluded the framework needed it.

It doesn't. Two Docker-free paths already worked and neither was documented:

- **SQLite** — generated projects already ship the feature, and CI gates `sqlite`, `sqlite,manage`, `sqlite,admin` precisely because that's what they use.
- **Native Postgres** — only needs the compose hostname `postgres` swapped for `localhost`, which the generated `.env.example` mentions in passing and no guide explains.

The prerequisites table now points at a **Choosing a database** section covering all three options, recommends SQLite for learning, documents the native-Postgres setup (`createuser` / `createdb` / the URL change), and says plainly that Docker is for deployment parity. Step 4 tells a non-Docker reader what to skip. Written in all four locales.

## Guard against regression

`tests/docs_links.rs` walks every published page in every locale and fails on a link that escapes the docs tree, doesn't resolve, or targets a page `index.toml` doesn't publish. A second test pins locale coverage to the manifest, so a missing or stray translation fails the build.

Verified it catches both modes — reintroducing one `../` link and deleting one locale page produces:

```
docs/fr/jobs.md: `../crates/rustango/tests/jobs_doc.rs` escapes the docs tree —
  use an absolute https://github.com/ujeenet/rustango/... URL
docs/de/glossary.md is missing
```

37 links rotted silently and a reader found them before we did; that's the kind of thing worth checking by machine.

## Verification

- `cargo test -p rustango --test docs_links` — 2 passed
- 144 pages (36 × 4 locales) audited: **0** broken local references
- anchors verified in all locales, including `#choisir-une-base-de-données` and `#datenbank-wählen`
- `cargo test --lib` — 3448 passed; `cargo fmt --check` clean

Also bumps `docs/index.toml` to `version = "0.53"` (was 0.52).

## Not in scope

**#1249** needs no code change — the published CLI still pinning generated projects to `channel = "1.88"` is already fixed on develop and ships when 0.53.0 reaches crates.io.
