### PR TITLE
fix(cache_page): never cache Set-Cookie or per-user responses (session leak)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 ## [Unreleased]
 
 ### Fixed
+- **`cache_page` could serve one user's session cookie to another** (#1251).
+  The layer cached any 200 and replayed its stored headers verbatim on a HIT,
+  including `Set-Cookie` — so an authenticated response that minted
+  `Set-Cookie: session=<A>` was cached and handed to the next visitor, a session
+  hijack. It also shared personalized pages across users, since the cache key did
+  not consider `Authorization` / `Cookie` and the response `Vary` was not
+  consulted.
+
+  Now safe by default: a response carrying `Set-Cookie`, or marked
+  `Cache-Control: private` / `no-cache` / `no-store`, is never cached; and a
+  request carrying `Authorization` or `Cookie` is neither served from nor stored
+  in the shared cache. A route known to be public despite such a header can opt
+  back in with `CachePageLayer::cache_authenticated(true)`. The `Set-Cookie` and
+  `private` guards are unconditional and not configurable.
 - **ETag middleware ignored `If-None-Match` lists and `*`, and dropped required
   headers from the 304** (#1258). It compared the whole `If-None-Match` header
   against one etag, so a conditional request sending a list (`"a", "b"`) or the

--- a/crates/rustango/src/cache_page.rs
+++ b/crates/rustango/src/cache_page.rs
@@ -49,8 +49,15 @@
 //!   over the 1 MiB cacheable cap gets `413`.
 //! - **Status 200-only.** Errors / redirects / 304s aren't cached so
 //!   transient failures don't poison the cache.
-//! - **`Cache-Control: no-store`** on the response disables caching
-//!   for that response (matches RFC 9111 — caches must not store it).
+//! - **`Cache-Control: no-store` / `private` / `no-cache`** on the
+//!   response disables caching for it — `private` because this is a
+//!   shared cache (matches RFC 9111).
+//! - **Per-user responses are never shared (#1251).** A response
+//!   carrying `Set-Cookie` is never cached, and by default a request
+//!   carrying `Authorization` or `Cookie` is neither served from nor
+//!   stored in the cache — its response is assumed to depend on the
+//!   caller. Opt a known-public route back in with
+//!   [`CachePageLayer::cache_authenticated`].
 //! - **Body is buffered.** The layer materializes the full response
 //!   body so it can store it; streaming responses lose their streaming
 //!   property under the cache. Use `[never_cache]` headers on
@@ -99,6 +106,12 @@ pub struct CachePageLayer {
     key_prefix: String,
     vary_on: Vec<HeaderName>,
     cache_query: bool,
+    /// When `false` (default), a request carrying `Authorization` or
+    /// `Cookie` is neither served from nor stored in the shared cache —
+    /// its response is assumed per-user. Opt in only for a route you
+    /// know is genuinely public despite the header. See
+    /// [`Self::cache_authenticated`] (#1251).
+    cache_authenticated: bool,
 }
 
 impl CachePageLayer {
@@ -112,6 +125,7 @@ impl CachePageLayer {
             key_prefix: "rustango.cache_page".to_owned(),
             vary_on: Vec::new(),
             cache_query: false,
+            cache_authenticated: false,
         }
     }
 
@@ -154,6 +168,26 @@ impl CachePageLayer {
         self
     }
 
+    /// Allow caching responses to requests that carry `Authorization`
+    /// or `Cookie` (#1251).
+    ///
+    /// **Off by default, and leave it off unless you are certain.** The
+    /// safe default treats a request bearing either header as per-user:
+    /// it is neither served from nor stored in the shared cache, so one
+    /// user's page can't be handed to another. Enable this only for a
+    /// route whose response you know does not depend on the caller's
+    /// identity even though the header is present (e.g. a public page on
+    /// a site that sets an analytics cookie on everyone).
+    ///
+    /// A response that itself sends `Set-Cookie`, or marks itself
+    /// `Cache-Control: private` / `no-cache` / `no-store`, is **never**
+    /// cached regardless of this flag — that is not configurable.
+    #[must_use]
+    pub fn cache_authenticated(mut self, enabled: bool) -> Self {
+        self.cache_authenticated = enabled;
+        self
+    }
+
     /// Opt into caching RFC 10008 `QUERY` requests (default `false`).
     ///
     /// QUERY is safe + idempotent and its response is cacheable, keyed on
@@ -184,6 +218,7 @@ impl<S> tower::Layer<S> for CachePageLayer {
             key_prefix: Arc::new(self.key_prefix.clone()),
             vary_on: Arc::new(self.vary_on.clone()),
             cache_query: self.cache_query,
+            cache_authenticated: self.cache_authenticated,
         }
     }
 }
@@ -197,6 +232,7 @@ pub struct CachePageService<S> {
     key_prefix: Arc<String>,
     vary_on: Arc<Vec<HeaderName>>,
     cache_query: bool,
+    cache_authenticated: bool,
 }
 
 impl<S> Service<Request<Body>> for CachePageService<S>
@@ -222,6 +258,7 @@ where
         let prefix = self.key_prefix.clone();
         let vary = self.vary_on.clone();
         let cache_query = self.cache_query;
+        let cache_authenticated = self.cache_authenticated;
         let clone = self.inner.clone();
         let mut inner = std::mem::replace(&mut self.inner, clone);
 
@@ -264,6 +301,19 @@ where
                 (req, None)
             };
 
+            // A request bearing `Authorization` or `Cookie` is treated as
+            // per-user unless the route opted in: it is neither served
+            // from nor stored in the shared cache, so one user's response
+            // can't be handed to another (#1251).
+            let req_is_authed = !cache_authenticated
+                && (req
+                    .headers()
+                    .contains_key(axum::http::header::AUTHORIZATION)
+                    || req.headers().contains_key(axum::http::header::COOKIE));
+            if req_is_authed {
+                return inner.call(req).await;
+            }
+
             let key = compute_cache_key(&prefix, &req, &vary, body_digest.as_deref());
 
             // Cache hit?
@@ -281,20 +331,32 @@ where
 
             // Cache miss — run inner, then store the response.
             let resp = inner.call(req).await?;
-            // Only cache 200 OK responses. Don't cache responses
-            // that explicitly opt out via Cache-Control: no-store.
+            // Only cache 200 OK responses. Refuse to cache anything that
+            // is per-user or explicitly opted out:
+            //   - `Set-Cookie`: the response mints a cookie, so it is
+            //     definitionally per-user. Caching it would replay one
+            //     user's session cookie to the next (#1251).
+            //   - `Cache-Control: no-store | private | no-cache`: the
+            //     handler said don't (`private` = not for a shared cache,
+            //     which this is).
             let status = resp.status();
+            let sets_cookie = resp.headers().contains_key(axum::http::header::SET_COOKIE);
             let cache_control_opt_out = resp
                 .headers()
                 .get_all(axum::http::header::CACHE_CONTROL)
                 .iter()
                 .any(|v| {
                     v.to_str()
-                        .map(|s| s.to_ascii_lowercase().contains("no-store"))
+                        .map(|s| {
+                            let s = s.to_ascii_lowercase();
+                            s.contains("no-store")
+                                || s.contains("private")
+                                || s.contains("no-cache")
+                        })
                         .unwrap_or(false)
                 });
 
-            if status != StatusCode::OK || cache_control_opt_out {
+            if status != StatusCode::OK || sets_cookie || cache_control_opt_out {
                 return Ok(resp);
             }
 

--- a/crates/rustango/tests/cache_page.rs
+++ b/crates/rustango/tests/cache_page.rs
@@ -313,23 +313,31 @@ fn vary_on_emits_comma_separated_list() {
 /// Multi-value `Set-Cookie` headers survive the cache round-trip.
 /// Pre-fix: HashMap dedup truncated to one cookie.
 #[tokio::test]
-async fn multi_value_set_cookie_headers_survive_round_trip() {
-    use axum::http::{header::SET_COOKIE, HeaderName, HeaderValue};
+async fn multi_value_headers_survive_round_trip() {
+    // Regression for the JSON header round-trip: a response with two
+    // values of the same header must come back with both after a
+    // cache HIT. Uses `Link` — a legitimately multi-valued *and*
+    // cacheable header. (This test used to use `Set-Cookie`, which is
+    // now deliberately never cached — see
+    // `response_setting_a_cookie_is_never_cached` (#1251).)
+    use axum::http::{HeaderName, HeaderValue};
+    let link = HeaderName::from_static("link");
     let cache = Arc::new(InMemoryCache::new());
     let app: Router = Router::new()
         .route(
-            "/login",
-            get(|| async {
-                // Two distinct Set-Cookie headers — what a real
-                // login handler would emit.
-                let mut resp = axum::response::Response::new(Body::from("ok"));
-                resp.headers_mut().append(
-                    SET_COOKIE,
-                    HeaderValue::from_static("session=abc; HttpOnly"),
-                );
-                resp.headers_mut()
-                    .append(SET_COOKIE, HeaderValue::from_static("csrf=xyz; HttpOnly"));
-                resp
+            "/page",
+            get(move || {
+                let link = link.clone();
+                async move {
+                    let mut resp = axum::response::Response::new(Body::from("ok"));
+                    resp.headers_mut().append(
+                        link.clone(),
+                        HeaderValue::from_static("</a.css>; rel=preload"),
+                    );
+                    resp.headers_mut()
+                        .append(link, HeaderValue::from_static("</b.js>; rel=preload"));
+                    resp
+                }
             }),
         )
         .layer(CachePageLayer::new(cache));
@@ -337,23 +345,13 @@ async fn multi_value_set_cookie_headers_survive_round_trip() {
     // Warm the cache.
     let _ = app
         .clone()
-        .oneshot(
-            Request::builder()
-                .uri("/login")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(Request::builder().uri("/page").body(Body::empty()).unwrap())
         .await
         .unwrap();
     // Hit.
     let r2 = app
         .clone()
-        .oneshot(
-            Request::builder()
-                .uri("/login")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(Request::builder().uri("/page").body(Body::empty()).unwrap())
         .await
         .unwrap();
     assert_eq!(
@@ -362,19 +360,15 @@ async fn multi_value_set_cookie_headers_survive_round_trip() {
             .and_then(|h| h.to_str().ok()),
         Some("HIT")
     );
-    let cookies: Vec<String> = r2
+    let links: Vec<String> = r2
         .headers()
-        .get_all(HeaderName::from_static("set-cookie"))
+        .get_all(HeaderName::from_static("link"))
         .iter()
         .filter_map(|v| v.to_str().ok().map(str::to_owned))
         .collect();
-    assert_eq!(
-        cookies.len(),
-        2,
-        "both Set-Cookie headers must survive: {cookies:?}"
-    );
-    assert!(cookies.iter().any(|c| c.contains("session=abc")));
-    assert!(cookies.iter().any(|c| c.contains("csrf=xyz")));
+    assert_eq!(links.len(), 2, "both Link headers must survive: {links:?}");
+    assert!(links.iter().any(|c| c.contains("a.css")));
+    assert!(links.iter().any(|c| c.contains("b.js")));
 }
 
 /// Content-Type and other handler-set headers survive a HIT.
@@ -738,4 +732,169 @@ async fn get_and_query_do_not_collide() {
 
     let q = app.clone().oneshot(query_req("q=x")).await.unwrap();
     assert_eq!(body_to_string(q.into_body()).await, "q0:q=x");
+}
+
+// -------------------------------------------------------------- #1251
+// A cached page must never carry one user's identity to another.
+
+/// A 200 that mints a `Set-Cookie` is per-user and must not be cached:
+/// the second request runs the handler again (fresh cookie), rather than
+/// replaying the first user's cookie from cache.
+#[tokio::test]
+async fn response_setting_a_cookie_is_never_cached() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route(
+            "/me",
+            get(|| async {
+                let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+                axum::response::Response::builder()
+                    .status(StatusCode::OK)
+                    .header(header::SET_COOKIE, format!("session=user-{n}"))
+                    .body(Body::from(format!("hi user-{n}")))
+                    .unwrap()
+            }),
+        )
+        .layer(CachePageLayer::new(cache));
+
+    let r1 = app
+        .clone()
+        .oneshot(Request::builder().uri("/me").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(
+        r1.headers().get(header::SET_COOKIE).unwrap(),
+        "session=user-0"
+    );
+
+    // Second request: if the response had been cached, we'd replay
+    // `session=user-0`. It must not be — the handler runs again.
+    let r2 = app
+        .clone()
+        .oneshot(Request::builder().uri("/me").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(
+        r2.headers().get(header::SET_COOKIE).unwrap(),
+        "session=user-1",
+        "a Set-Cookie response was cached and replayed to the next request",
+    );
+    assert_eq!(body_to_string(r2.into_body()).await, "hi user-1");
+}
+
+/// `Cache-Control: private` opts a response out, like `no-store`.
+#[tokio::test]
+async fn private_response_is_not_cached() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route(
+            "/priv",
+            get(|| async {
+                let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+                axum::response::Response::builder()
+                    .status(StatusCode::OK)
+                    .header(header::CACHE_CONTROL, "private, max-age=60")
+                    .body(Body::from(format!("body-{n}")))
+                    .unwrap()
+            }),
+        )
+        .layer(CachePageLayer::new(cache));
+
+    for _ in 0..2 {
+        app.clone()
+            .oneshot(Request::builder().uri("/priv").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+    }
+    // Two distinct handler runs → not cached.
+    assert_eq!(COUNTER.load(Ordering::SeqCst), 2);
+}
+
+/// A request carrying `Cookie` is treated as per-user by default: it is
+/// not served a shared cached body, and its own response is not stored.
+#[tokio::test]
+async fn request_with_cookie_bypasses_shared_cache_by_default() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route(
+            "/p",
+            get(|| async {
+                let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+                format!("body-{n}")
+            }),
+        )
+        .layer(CachePageLayer::new(cache));
+
+    // Prime the cache with an anonymous request.
+    app.clone()
+        .oneshot(Request::builder().uri("/p").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    // A request with a Cookie must not be served the anonymous cached
+    // body — it bypasses to the handler.
+    let authed = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/p")
+                .header(header::COOKIE, "session=abc")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // Handler ran a second time for the cookie'd request.
+    assert_eq!(COUNTER.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        authed
+            .headers()
+            .get("x-cache-status")
+            .and_then(|h| h.to_str().ok()),
+        None,
+        "a cookie-bearing request should bypass, not report HIT",
+    );
+}
+
+/// Opt-in restores caching for cookie-bearing requests on a route the
+/// app has declared public.
+#[tokio::test]
+async fn cache_authenticated_opt_in_allows_cookie_requests() {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    COUNTER.store(0, Ordering::SeqCst);
+
+    let cache = Arc::new(InMemoryCache::new());
+    let app: Router = Router::new()
+        .route(
+            "/public",
+            get(|| async {
+                let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+                format!("body-{n}")
+            }),
+        )
+        .layer(CachePageLayer::new(cache).cache_authenticated(true));
+
+    for _ in 0..2 {
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/public")
+                    .header(header::COOKIE, "a=b")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+    // Second served from cache → handler ran once.
+    assert_eq!(COUNTER.load(Ordering::SeqCst), 1);
 }


### PR DESCRIPTION
Closes #1251. Highest-severity finding from the bug sweep.

## The bug

`CachePageLayer` cached any 200 and replayed its stored headers verbatim on a HIT — **including `Set-Cookie`**. An authenticated response minting `Set-Cookie: session=<A>` was cached and handed to the next visitor: **session hijack**. A pre-existing test even pinned it — `multi_value_set_cookie_headers_survive_round_trip` warmed a `/login` response and asserted both cookies replayed on the HIT — so the vulnerable behaviour was encoded as intended, not caught.

Separately, personalized pages were shared across users: the key was `(prefix, method, path, vary-on)`, ignoring `Authorization`/`Cookie`, and the response `Vary` was not consulted.

## The fix — safe by default

- A response with **`Set-Cookie`** is never cached (per-user by construction). Unconditional.
- **`Cache-Control: private` / `no-cache`** join `no-store` as opt-outs. Unconditional.
- A request bearing **`Authorization` or `Cookie`** is neither served from nor stored in the shared cache. Opt a known-public route back in with `CachePageLayer::cache_authenticated(true)`; the two response guards stay unconditional.

## Tests

Four new, **three fail against pre-fix code** (verified by reverting the guards):
- `response_setting_a_cookie_is_never_cached` — the session-hijack regression
- `private_response_is_not_cached`
- `request_with_cookie_bypasses_shared_cache_by_default`
- `cache_authenticated_opt_in_allows_cookie_requests` (opt-in still works)

The old Set-Cookie round-trip test was rewritten to use `Link` — it tested JSON header serialization, not cookie caching, and only happened to use the now-forbidden header. **25/25** pass.

## Not in scope

The other bug-sweep findings are filed as #1252–#1258 (rate limiter, account lockout, distributed lock, jobs, scheduler, LIKE escaping, ETag) and #1245 (DatabaseCache TTL). This PR is only the session-leak fix.