### PR TITLE
fix(cache): make InMemoryCache::incr atomic; use it for account lockout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 ## [Unreleased]
 
 ### Fixed
+- **The failure counter behind account lockout, distributed locks, and rate
+  limiting was not atomic** (#1253). `AccountLockout::record_failure` did a
+  get-parse-set, which loses updates under concurrent failed logins: several
+  attempts read the same value and write back the same `+1`, so N parallel
+  guesses record far fewer than N and the lockout threshold can be out-run by
+  parallelising. Root cause was one level down — `InMemoryCache::incr` was the
+  racy trait default (a separate `get` then `set`), which every counter built on
+  the cache inherited.
+
+  `InMemoryCache::incr` now holds its write lock across the whole
+  read-modify-write, so an in-process increment is atomic, and `record_failure`
+  uses `incr` rather than get-parse-set. `RedisCache` was already atomic (native
+  `INCRBY`); `DatabaseCache`'s default `incr` is still get-then-set, fine for a
+  single process. A multi-threaded regression test drives 50–100 concurrent
+  increments and asserts none are lost — it fails against the pre-fix code.
+
+### Fixed
 - **160 broken documentation references, across all four locales** (#1248).
   Reported as three 404s on the docs site; an audit found the whole class.
 

--- a/crates/rustango/src/account_lockout.rs
+++ b/crates/rustango/src/account_lockout.rs
@@ -136,19 +136,24 @@ impl Lockout {
     ///   only fires for users who actually exist + are being attacked.
     pub async fn record_failure(&self, account: &str) -> u32 {
         let counter_key = self.counter_key(account);
-        let current: u32 = self
-            .cache
-            .get(&counter_key)
-            .await
-            .ok()
-            .flatten()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-        let next = current + 1;
-        let _ = self
-            .cache
-            .set(&counter_key, &next.to_string(), Some(self.counter_ttl))
-            .await;
+        // Atomic increment, not get-parse-set (#1253). Under concurrent
+        // failed logins a read-modify-write loses updates — several
+        // attempts read the same value and each write back the same
+        // `+1`, so N parallel guesses record far fewer than N and the
+        // threshold can be out-run by parallelising. `incr` is atomic on
+        // `RedisCache` (native `INCRBY`) and now on `InMemoryCache` (it
+        // holds its write lock across the read-modify-write). The one
+        // remaining racy backend is `DatabaseCache`, whose default
+        // `incr` is still get+set — acceptable for single-process use,
+        // and the multi-replica deploy that needs cross-process
+        // atomicity is on Redis anyway.
+        let next = u32::try_from(
+            self.cache
+                .incr(&counter_key, 1, Some(self.counter_ttl))
+                .await
+                .unwrap_or(0),
+        )
+        .unwrap_or(u32::MAX);
         if next >= self.max_attempts {
             // Set the lock flag with TTL = lockout_duration
             let _ = self
@@ -407,5 +412,33 @@ mod tests {
         // Smoke: the process-global default exists and answers. Unique
         // key so parallel tests can't perturb the assertion.
         assert!(!shared().is_locked("smoke:unique-unused-key").await);
+    }
+
+    /// #1253 — concurrent failed attempts must each count. The old
+    /// get-parse-set lost updates under contention, letting the
+    /// threshold be out-run by parallelising guesses. With an atomic
+    /// `incr` (now overridden on `InMemoryCache`) 50 racing failures
+    /// record exactly 50.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_failures_all_count() {
+        let cache: Arc<dyn Cache> = Arc::new(InMemoryCache::new());
+        let l = Arc::new(
+            Lockout::new(cache)
+                .max_attempts(1000) // don't lock; we're counting
+                .counter_ttl(Duration::from_secs(60)),
+        );
+        let mut handles = Vec::new();
+        for _ in 0..50 {
+            let l = l.clone();
+            handles.push(tokio::spawn(async move { l.record_failure("alice").await }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert_eq!(
+            l.attempt_count("alice").await,
+            50,
+            "lost-update race: concurrent failures did not all count",
+        );
     }
 }

--- a/crates/rustango/src/cache/mod.rs
+++ b/crates/rustango/src/cache/mod.rs
@@ -729,6 +729,49 @@ impl Cache for InMemoryCache {
         Ok(())
     }
 
+    /// Atomic increment (#1253). The trait default is get-parse-set,
+    /// which races two concurrent callers into a lost update — fatal
+    /// for the counters built on it (account lockout, distributed lock,
+    /// rate limiting). This holds the single write lock across the whole
+    /// read-modify-write, so an in-process increment is atomic. (Across
+    /// replicas you still need `RedisCache`, whose `INCRBY` is atomic on
+    /// the server; a per-process cache cannot help there.)
+    async fn incr(&self, key: &str, by: i64, ttl: Option<Duration>) -> Result<i64, CacheError> {
+        let tick = self.next_tick();
+        let mut store = self.inner.write().await;
+        let current = store
+            .map
+            .get(key)
+            .filter(|e| !e.is_expired())
+            .and_then(|e| e.value.parse::<i64>().ok())
+            .unwrap_or(0);
+        let new = current.saturating_add(by);
+        let value = new.to_string();
+        let size = key.len() + value.len();
+        // Preserve the existing expiry when the key is live and no new
+        // TTL is given, matching the fixed-window semantics counters
+        // rely on; a supplied TTL (or a fresh/expired key) resets it.
+        let expires_at = match store.map.get(key) {
+            Some(e) if !e.is_expired() && ttl.is_none() => e.expires_at,
+            _ => self.resolve_ttl(ttl),
+        };
+        if let Some(old) = store.map.remove(key) {
+            store.used_bytes = store.used_bytes.saturating_sub(old.size);
+        }
+        store.used_bytes += size;
+        store.map.insert(
+            key.to_owned(),
+            CacheEntry {
+                value,
+                expires_at,
+                last_used: AtomicU64::new(tick),
+                size,
+            },
+        );
+        self.evict_locked(&mut store);
+        Ok(new)
+    }
+
     async fn delete(&self, key: &str) -> Result<(), CacheError> {
         let mut store = self.inner.write().await;
         if let Some(e) = store.map.remove(key) {

--- a/crates/rustango/tests/cache_backends.rs
+++ b/crates/rustango/tests/cache_backends.rs
@@ -500,3 +500,31 @@ async fn get_or_does_not_write_default_back() {
     let _ = c.get_or("ghost", "would-not-be-stored").await.unwrap();
     assert!(!c.has_key("ghost").await.unwrap());
 }
+
+/// #1253 — `InMemoryCache::incr` must be atomic under concurrency.
+/// The trait default is get-parse-set, which loses updates; the counters
+/// built on it (lockout, distributed lock, rate limit) rely on this.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn inmemory_incr_is_atomic_under_contention() {
+    use std::sync::Arc;
+    let cache: Arc<rustango::cache::InMemoryCache> =
+        Arc::new(rustango::cache::InMemoryCache::new());
+    let mut handles = Vec::new();
+    for _ in 0..100 {
+        let c = cache.clone();
+        handles.push(tokio::spawn(async move {
+            rustango::cache::Cache::incr(&*c, "counter", 1, None)
+                .await
+                .unwrap()
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+    let final_val = rustango::cache::Cache::get(&*cache, "counter")
+        .await
+        .unwrap()
+        .and_then(|s| s.parse::<i64>().ok())
+        .unwrap();
+    assert_eq!(final_val, 100, "incr lost updates under contention");
+}

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -193,6 +193,13 @@ cache.clear().await?;                            // drops ONLY acme's entries
 than reimplementing anything, so native primitives (Redis `INCRBY`, `SET NX`,
 `MGET`) keep their atomicity and batching.
 
+**Atomic counters.** `Cache::incr(key, by, ttl)` returns the value after the
+increment and is the primitive behind [rate limiting](middleware.md),
+per-account lockout, and `DistributedLock`. It is atomic on `RedisCache`
+(native `INCRBY`) and on `InMemoryCache` (which holds its lock across the whole
+read-modify-write); `DatabaseCache` uses a non-atomic get-then-set — fine for
+one process, but reach for Redis when a counter must be exact across replicas.
+
 Two things worth knowing:
 
 | | |

--- a/docs/de/caching.md
+++ b/docs/de/caching.md
@@ -200,6 +200,14 @@ cache.clear().await?;                            // drops ONLY acme's entries
 statt etwas neu zu implementieren, sodass native Primitive (Redis `INCRBY`,
 `SET NX`, `MGET`) ihre Atomarität und Batching behalten.
 
+**Atomare Zähler.** `Cache::incr(key, by, ttl)` liefert den Wert nach dem
+Inkrement und ist das Primitiv hinter [Rate-Limiting](middleware.md),
+Konto-Sperren und `DistributedLock`. Es ist atomar bei `RedisCache` (natives
+`INCRBY`) und bei `InMemoryCache` (das seine Sperre über das gesamte
+Read-Modify-Write hält); `DatabaseCache` nutzt ein nicht-atomares Get-dann-Set —
+für einen Prozess in Ordnung, aber greife zu Redis, wenn ein Zähler über
+Replikate hinweg exakt sein muss.
+
 Zwei Dinge, die man wissen sollte:
 
 | | |

--- a/docs/es/caching.md
+++ b/docs/es/caching.md
@@ -197,6 +197,13 @@ tome un `BoxedCache` — `cache_page`, `cache_fragment`, los rate limiters,
 de reimplementar nada, de modo que las primitivas nativas (Redis `INCRBY`,
 `SET NX`, `MGET`) conservan su atomicidad y su batching.
 
+**Contadores atómicos.** `Cache::incr(key, by, ttl)` devuelve el valor tras el
+incremento y es la primitiva tras el [rate limiting](middleware.md), el bloqueo
+por cuenta y `DistributedLock`. Es atómico en `RedisCache` (`INCRBY` nativo) y en
+`InMemoryCache` (que mantiene su cerrojo durante todo el read-modify-write);
+`DatabaseCache` usa un get-luego-set no atómico — suficiente para un proceso,
+pero usa Redis cuando un contador deba ser exacto entre réplicas.
+
 Dos cosas que conviene saber:
 
 | | |

--- a/docs/fr/caching.md
+++ b/docs/fr/caching.md
@@ -200,6 +200,14 @@ cache.clear().await?;                            // drops ONLY acme's entries
 que de réimplémenter quoi que ce soit, si bien que les primitives natives (Redis
 `INCRBY`, `SET NX`, `MGET`) gardent leur atomicité et leur traitement par lots.
 
+**Compteurs atomiques.** `Cache::incr(key, by, ttl)` renvoie la valeur après
+l'incrément et est la primitive derrière le [rate limiting](middleware.md), le
+verrouillage par compte et `DistributedLock`. Il est atomique sur `RedisCache`
+(`INCRBY` natif) et sur `InMemoryCache` (qui garde son verrou pendant tout le
+read-modify-write) ; `DatabaseCache` utilise un get-puis-set non atomique —
+suffisant pour un seul processus, mais passez à Redis lorsqu'un compteur doit
+être exact entre réplicas.
+
 Deux choses à savoir :
 
 | | |


### PR DESCRIPTION
Closes #1253. Second bug-sweep fix.

## The bug

`AccountLockout::record_failure` counted failed logins with a get-parse-set — a lost-update race. Under concurrent attempts the reads interleave and each writes back the same `+1`, so **N parallel guesses record far fewer than N**, and the lockout threshold can be out-run by parallelising the attack it exists to stop.

Root cause was one level down: **`InMemoryCache::incr` was the racy trait default** (a `get` then a separate `set`), inherited by every counter on the cache — lockout, `DistributedLock`, and the cache-backed rate limiter all sit on `incr`. Fixing it once fixes all three for single-process deploys.

## The fix

- `InMemoryCache::incr` now holds its write lock across the whole read-modify-write (atomic in-process), preserving an existing entry's expiry when no new TTL is given so fixed-window counters keep working.
- `record_failure` uses `incr` instead of get-parse-set.
- `RedisCache` was already atomic (`INCRBY`); `DatabaseCache` stays get-then-set (documented, fine for one process — multi-replica is on Redis).

## Tests

Two, **both fail against pre-fix code** (verified):
- `inmemory_incr_is_atomic_under_contention` — 100 concurrent increments sum to 100.
- `concurrent_failures_all_count` — 50 concurrent failures all count.

Both use `#[tokio::test(flavor = "multi_thread")]` deliberately: the default single-threaded runtime never races, so the first draft passed against the bug. Worth flagging as a testing gotcha.

## Docs

`caching.md` gains an **atomic counters** note (what `incr` guarantees per backend) — all four locales.

## Related

Part of the bug sweep: #1252 (rate limiter), #1254 (distributed lock), #1256 (scheduler) still open; this fix's atomic `incr` is a prerequisite for the single-process correctness of #1252 and #1254.