### PR TITLE
fix(etag): honor If-None-Match lists and *, and keep caching headers on 304

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 ## [Unreleased]
 
 ### Fixed
+- **ETag middleware ignored `If-None-Match` lists and `*`, and dropped required
+  headers from the 304** (#1258). It compared the whole `If-None-Match` header
+  against one etag, so a conditional request sending a list (`"a", "b"`) or the
+  wildcard `*` — both valid per RFC 7232 — got a full `200` where a `304` was
+  due. And the `304` it did send carried only `ETag`, dropping `Cache-Control` /
+  `Vary` / `Expires` that RFC 7232 §4.1 requires, which could let a downstream
+  cache apply the wrong freshness. `If-None-Match` is now parsed as a list (and
+  `*`), and the 304 carries the caching-relevant headers.
 - **The scheduler panicked on a zero period and left in-flight jobs running
   after shutdown** (#1256). `every(_, Duration::ZERO, _)` panicked
   `tokio::time::interval` at spawn, silently killing that task's loop — now

--- a/crates/rustango/src/etag.rs
+++ b/crates/rustango/src/etag.rs
@@ -14,10 +14,12 @@
 //! ## How it works
 //!
 //! For every successful (2xx) response with a non-empty body:
-//! 1. Compute a SHA-256 hash of the body bytes
+//! 1. Compute a hash of the body bytes (64-bit FNV-1a + length)
 //! 2. Set `ETag: "<base64 hash>"` on the response
-//! 3. If the request had `If-None-Match: <same etag>`, replace the body with
-//!    empty + `304 Not Modified` to save bandwidth
+//! 3. If the request's `If-None-Match` matches — a comma-separated list
+//!    of etags, or the wildcard `*` — reply `304 Not Modified` with an
+//!    empty body, carrying the caching headers (`Cache-Control`, `Vary`,
+//!    `Expires`, …) a matching 200 would have sent (RFC 7232 §4.1).
 //!
 //! Non-2xx responses are passed through untouched.
 //!
@@ -115,15 +117,34 @@ async fn handle(cfg: Arc<EtagLayer>, req: Request<Body>, next: Next) -> Response
     }
 
     if let Some(client) = client_etag {
-        if normalize_etag(&client) == normalize_etag(&etag) {
-            // 304 Not Modified — drop body
+        // `If-None-Match` is a comma-separated list, or the wildcard `*`
+        // which matches any current representation (#1258). Weak
+        // comparison applies for a conditional GET (RFC 7232 §3.2).
+        let ours = normalize_etag(&etag);
+        let matched = client.trim() == "*"
+            || client
+                .split(',')
+                .any(|candidate| normalize_etag(candidate) == ours);
+        if matched {
+            // 304 Not Modified — drop the body, but carry the headers a
+            // matching 200 would have sent that govern caching (RFC 7232
+            // §4.1), not just the ETag. Dropping `Cache-Control` / `Vary`
+            // would let a downstream cache apply the wrong freshness or
+            // vary key.
             let mut not_modified = Response::builder()
                 .status(StatusCode::NOT_MODIFIED)
                 .body(Body::empty())
                 .unwrap();
-            // Preserve the ETag header on 304 (RFC 7232)
+            let carry = [
+                ETAG,
+                axum::http::header::CACHE_CONTROL,
+                axum::http::header::VARY,
+                axum::http::header::EXPIRES,
+                axum::http::header::CONTENT_LOCATION,
+                axum::http::header::DATE,
+            ];
             for (k, v) in response.headers() {
-                if k == ETAG {
+                if carry.contains(k) {
                     not_modified.headers_mut().insert(k.clone(), v.clone());
                 }
             }
@@ -176,6 +197,104 @@ fn normalize_etag(s: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use axum::http::header;
+    use axum::routing::get;
+    use tower::ServiceExt as _;
+
+    fn app() -> Router {
+        Router::new()
+            .route(
+                "/page",
+                get(|| async {
+                    axum::response::Response::builder()
+                        .status(StatusCode::OK)
+                        .header(header::CACHE_CONTROL, "max-age=60")
+                        .header(header::VARY, "Accept-Encoding")
+                        .body(Body::from("stable-body"))
+                        .unwrap()
+                }),
+            )
+            .etag(EtagLayer::new())
+    }
+
+    async fn etag_of(app: &Router) -> String {
+        let r = app
+            .clone()
+            .oneshot(Request::builder().uri("/page").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        r.headers().get(ETAG).unwrap().to_str().unwrap().to_owned()
+    }
+
+    /// #1258 — `If-None-Match: *` matches any representation → 304.
+    #[tokio::test]
+    async fn if_none_match_wildcard_returns_304() {
+        let app = app();
+        let r = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/page")
+                    .header(IF_NONE_MATCH, "*")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::NOT_MODIFIED);
+    }
+
+    /// #1258 — a comma-separated `If-None-Match` list containing our etag
+    /// must 304, not return a full 200.
+    #[tokio::test]
+    async fn if_none_match_list_matches_one_entry() {
+        let app = app();
+        let ours = etag_of(&app).await;
+        let list = format!("\"deadbeef\", {ours}");
+        let r = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/page")
+                    .header(IF_NONE_MATCH, list)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            r.status(),
+            StatusCode::NOT_MODIFIED,
+            "list match should 304"
+        );
+    }
+
+    /// #1258 — the 304 must carry the caching headers a 200 would
+    /// (RFC 7232 §4.1), not just the ETag.
+    #[tokio::test]
+    async fn not_modified_carries_caching_headers() {
+        let app = app();
+        let ours = etag_of(&app).await;
+        let r = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/page")
+                    .header(IF_NONE_MATCH, ours)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(
+            r.headers().get(header::CACHE_CONTROL).unwrap(),
+            "max-age=60"
+        );
+        assert_eq!(r.headers().get(header::VARY).unwrap(), "Accept-Encoding");
+        assert!(r.headers().get(ETAG).is_some());
+    }
 
     #[test]
     fn etag_is_deterministic_for_same_bytes() {


### PR DESCRIPTION
Closes #1258. **Stacked on #1262** (scheduler).

## Two RFC 7232 gaps

**`If-None-Match` matching was single-value.** It string-compared the whole header against one etag, so a request sending a comma-separated list (`"a", "b"`) or the wildcard `*` — both valid, and what real caches send — got a full 200 where a 304 was owed. Now split into candidates (and `*` handled), weak comparison.

**The 304 dropped required headers.** It copied only `ETag`; RFC 7232 §4.1 says a 304 carries the caching-governing headers a matching 200 would send. Dropping `Cache-Control` / `Vary` / `Expires` lets a downstream cache apply the wrong freshness. Now carries `ETag`, `Cache-Control`, `Vary`, `Expires`, `Content-Location`, `Date`.

## Tests

Three axum-oneshot integration tests, **all verified to fail against pre-fix code**: `*` → 304, list containing our etag → 304, and 304 carrying `Cache-Control`+`Vary`.

## Docs

Module rustdoc corrected (list/`*`, carried headers, and the actual FNV-1a hash — the doc claimed SHA-256). ETag's only localized-guide mention is a one-line middleware table entry with no claim to revise, so no per-locale change.

This is the last of the low-risk bug-sweep fixes. Remaining open: #1254 (distributed lock — needs a new `Cache` primitive), #1257 (LIKE escaping — tri-dialect ESCAPE, needs the MySQL/SQLite live suites); both deliberately deferred as too delicate for a quick fix.