### PR TITLE
fix(rate-limit): hash secret header keys; warn on shared-bucket fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 ## [Unreleased]
 
 ### Fixed
+- **The cache-backed rate limiter leaked secrets and shared one bucket among
+  keyless clients** (#1252). Keyed by `Authorization` / `x-api-key`, it used the
+  raw header value as the cache key — so a shared Redis stored live credentials
+  where anyone able to enumerate keys (`SCAN`, an RDB dump) could harvest them.
+  The value is now hashed (a SHA-256 prefix) before use. And when the limiter
+  cannot derive a per-client key — `KeyBy::Ip` with no `ConnectInfo`, or a
+  missing header — every request fell into one shared bucket, so one client
+  throttled the whole site; it now logs a one-time warning so the
+  misconfiguration is visible. The in-process `RateLimitLayer` keeps raw keys
+  (they never leave the process) but gets the same warning.
 - **The failure counter behind account lockout, distributed locks, and rate
   limiting was not atomic** (#1253). `AccountLockout::record_failure` did a
   get-parse-set, which loses updates under concurrent failed logins: several

--- a/crates/rustango/src/rate_limit.rs
+++ b/crates/rustango/src/rate_limit.rs
@@ -33,15 +33,43 @@ use axum::http::{header, HeaderValue, Response, StatusCode};
 use axum::middleware::Next;
 use axum::Router;
 
+/// Warn (at most once per process) that the limiter could not derive a
+/// per-client key and is falling back to a shared bucket — a
+/// misconfiguration that turns the limiter into a site-wide throttle
+/// (#1252). Rate-limited to one line so a hot path can't flood logs.
+fn warn_missing_discriminator(what: &str) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if !WARNED.swap(true, Ordering::Relaxed) {
+        tracing::warn!(
+            target: "rustango::rate_limit",
+            discriminator = %what,
+            "rate limiter could not derive a per-client key; ALL such requests \
+             share ONE bucket, so one client throttles everyone. For IP keying, \
+             serve with `into_make_service_with_connect_info::<SocketAddr>()`; \
+             for header keying, ensure the header is present.",
+        );
+    }
+}
+
 /// Strategy for picking the bucket key per request.
 #[derive(Clone, Debug)]
 pub enum KeyBy {
     /// Use the connecting client's IP address (`ConnectInfo<SocketAddr>`).
-    /// Falls back to a constant key when `ConnectInfo` is missing — set up
-    /// `into_make_service_with_connect_info` so this works.
+    ///
+    /// Requires the server to be built with
+    /// `into_make_service_with_connect_info::<SocketAddr>()`. If it is
+    /// **not**, every request falls back to one shared bucket, so one
+    /// client throttles the whole site — a self-inflicted DoS. The
+    /// limiter logs a one-time warning when this happens (#1252); make
+    /// sure your bind wires up `ConnectInfo`.
     Ip,
     /// Use the value of a request header (e.g. `"x-api-key"` or `"authorization"`).
-    /// Requests missing the header get the constant fallback key.
+    ///
+    /// In the cache-backed limiter the value is **hashed** before use as
+    /// a key, so a shared cache never exposes a raw credential (#1252).
+    /// Requests missing the header fall back to one shared bucket and
+    /// log a one-time warning, as with `Ip`.
     Header(&'static str),
     /// Single global bucket — coarse but easy. Good for "max N requests/sec for the whole endpoint".
     Global,
@@ -139,13 +167,23 @@ impl RateLimitLayer {
                 .extensions()
                 .get::<ConnectInfo<SocketAddr>>()
                 .map(|ci| ci.ip().to_string())
-                .unwrap_or_else(|| "<no-ip>".to_owned()),
+                .unwrap_or_else(|| {
+                    warn_missing_discriminator("IP (ConnectInfo missing)");
+                    "<no-ip>".to_owned()
+                }),
+            // Unlike the cache-backed limiter, this store is a
+            // process-local `HashMap` that never leaves memory, so the
+            // header value is not persisted anywhere an attacker could
+            // read it — no hashing needed here (#1252).
             KeyBy::Header(name) => req
                 .headers()
                 .get(*name)
                 .and_then(|v| v.to_str().ok())
                 .map(str::to_owned)
-                .unwrap_or_else(|| "<no-header>".to_owned()),
+                .unwrap_or_else(|| {
+                    warn_missing_discriminator(name);
+                    "<no-header>".to_owned()
+                }),
             KeyBy::Global => "<global>".to_owned(),
         }
     }

--- a/crates/rustango/src/rate_limit_cache.rs
+++ b/crates/rustango/src/rate_limit_cache.rs
@@ -53,6 +53,43 @@ use axum::Router;
 use crate::cache::BoxedCache;
 use crate::rate_limit::KeyBy;
 
+/// One-way hash of a bucket discriminator (#1252). A `SHA-256` prefix —
+/// enough to distribute keys and to make the same client hash the same,
+/// while never exposing a secret header value (API key / bearer token)
+/// as a readable cache key.
+fn hash_discriminator(value: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(value.as_bytes());
+    // 16 hex chars (64 bits) — collision-negligible for a rate-limit
+    // keyspace, and short enough to keep cache keys compact.
+    digest[..8]
+        .iter()
+        .fold(String::with_capacity(16), |mut s, b| {
+            use std::fmt::Write as _;
+            let _ = write!(s, "{b:02x}");
+            s
+        })
+}
+
+/// Warn (at most once per process) that the limiter could not derive a
+/// per-client key and is falling back to a shared bucket — a
+/// misconfiguration that turns the limiter into a site-wide throttle
+/// (#1252). Rate-limited to one line so a hot path can't flood logs.
+fn warn_missing_discriminator(what: &str) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if !WARNED.swap(true, Ordering::Relaxed) {
+        tracing::warn!(
+            target: "rustango::rate_limit",
+            discriminator = %what,
+            "rate limiter could not derive a per-client key; ALL such requests \
+             share ONE bucket, so one client throttles everyone. For IP keying, \
+             serve with `into_make_service_with_connect_info::<SocketAddr>()`; \
+             for header keying, ensure the header is present.",
+        );
+    }
+}
+
 /// Fixed-window counter rate limiter backed by a [`Cache`](crate::cache::Cache).
 ///
 /// Cheap to clone (everything is `Arc`-wrapped or `Copy`).
@@ -98,13 +135,25 @@ impl CacheRateLimitLayer {
                 .extensions()
                 .get::<ConnectInfo<SocketAddr>>()
                 .map(|ci| ci.ip().to_string())
-                .unwrap_or_else(|| "<no-ip>".to_owned()),
+                .unwrap_or_else(|| {
+                    warn_missing_discriminator("IP (ConnectInfo missing)");
+                    "<no-ip>".to_owned()
+                }),
+            // Hash the header value, never store it raw (#1252). Keyed by
+            // `authorization` / `x-api-key`, the raw value is a live
+            // secret; this counter lives in a shared cache (Redis), so a
+            // raw key would leak credentials to anyone who can enumerate
+            // keys (`SCAN`, an RDB dump). A SHA-256 prefix distributes
+            // just as well and is one-way.
             KeyBy::Header(name) => req
                 .headers()
                 .get(*name)
                 .and_then(|v| v.to_str().ok())
-                .map(str::to_owned)
-                .unwrap_or_else(|| "<no-header>".to_owned()),
+                .map(hash_discriminator)
+                .unwrap_or_else(|| {
+                    warn_missing_discriminator(name);
+                    "<no-header>".to_owned()
+                }),
             KeyBy::Global => "<global>".to_owned(),
         }
     }
@@ -219,6 +268,25 @@ mod tests {
         let cache: BoxedCache = Arc::new(InMemoryCache::new());
         CacheRateLimitLayer::new(cache, capacity, Duration::from_secs(window_secs))
             .key_prefix("test")
+    }
+
+    #[test]
+    fn header_value_is_hashed_not_stored_raw() {
+        // #1252 — a secret header value (API key / bearer token) must
+        // never appear verbatim in a cache key.
+        let secret = "super-secret-api-key-abc123";
+        let h = hash_discriminator(secret);
+        assert_ne!(h, secret, "value must be transformed");
+        assert!(
+            !h.contains("secret"),
+            "raw secret must not leak into the key"
+        );
+        assert_eq!(h.len(), 16, "expected a 16-hex-char digest prefix");
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+        // Deterministic: the same client hashes to the same bucket.
+        assert_eq!(h, hash_discriminator(secret));
+        // Distinct values → distinct keys.
+        assert_ne!(h, hash_discriminator("a-different-key"));
     }
 
     #[tokio::test]

--- a/docs/de/security.md
+++ b/docs/de/security.md
@@ -166,6 +166,9 @@ let app = axum::Router::new()
     );
 ```
 
+> **Nach einem geheimen Header zu keyen ist teilbar-sicher.** Bei `key_by(KeyBy::Header("authorization"))` oder `"x-api-key"` **hasht** der cache-gestützte Limiter den Header-Wert, bevor er ihn als Schlüssel verwendet (#1252) — ein geteiltes Redis speichert also nie eine gültige Anmeldeinformation dort, wo jemand mit Schlüssel-Lesezugriff sie abgreifen könnte. `KeyBy::Ip` braucht `ConnectInfo` (oder ein vorgeschaltetes `RealIpLayer`); fehlt das, warnt der Limiter einmalig und fällt auf einen einzigen geteilten Bucket zurück.
+
+
 ---
 
 ## IPs erlauben oder blockieren

--- a/docs/es/security.md
+++ b/docs/es/security.md
@@ -166,6 +166,9 @@ let app = axum::Router::new()
     );
 ```
 
+> **Keyear por una cabecera secreta es seguro de compartir.** Con `key_by(KeyBy::Header("authorization"))` o `"x-api-key"`, el limitador respaldado por caché **hashea** el valor de la cabecera antes de usarlo como clave (#1252), de modo que un Redis compartido nunca almacena una credencial viva donde alguien con acceso de lectura a las claves pudiera cosecharla. `KeyBy::Ip` necesita `ConnectInfo` (o un `RealIpLayer` delante); sin ello, el limitador avisa una vez y recae en un único bucket compartido.
+
+
 ---
 
 ## Permitir o bloquear IPs

--- a/docs/fr/security.md
+++ b/docs/fr/security.md
@@ -166,6 +166,9 @@ let app = axum::Router::new()
     );
 ```
 
+> **Keyer sur un en-tête secret est sûr à partager.** Avec `key_by(KeyBy::Header("authorization"))` ou `"x-api-key"`, le limiteur adossé au cache **hache** la valeur de l'en-tête avant de l'utiliser comme clé (#1252) : un Redis partagé ne stocke donc jamais une crédential vivante là où quelqu'un lisant les clés pourrait la récolter. `KeyBy::Ip` nécessite `ConnectInfo` (ou un `RealIpLayer` en amont) ; sans cela, le limiteur avertit une fois et retombe sur un unique bucket partagé.
+
+
 ---
 
 ## Autoriser ou bloquer des IP

--- a/docs/security.md
+++ b/docs/security.md
@@ -166,6 +166,9 @@ let app = axum::Router::new()
     );
 ```
 
+> **Keying by a secret header is safe to share.** When you `key_by(KeyBy::Header("authorization"))` or `"x-api-key"`, the cache-backed limiter **hashes** the header value before using it as a key (#1252), so a shared Redis never stores a live credential where someone reading keys could harvest it. Keying by `KeyBy::Ip` needs `ConnectInfo` (or a `RealIpLayer` in front); without it the limiter warns once and falls back to a single shared bucket.
+
+
 ---
 
 ## Allowing or blocking IPs


### PR DESCRIPTION
Closes #1252. (Replaces #1261, which GitHub auto-closed when its stacked base branch #1260 was deleted on merge — same commit, now rebased onto develop.)

## Two defects in the cache-backed limiter

**Secrets as keys.** Keyed by `Authorization`/`x-api-key`, it used the **raw header value** as the cache key, exposing live credentials to anyone who could enumerate shared-Redis keys (`SCAN`, an RDB dump). Now hashed (SHA-256 prefix) before use.

**Shared bucket for keyless clients.** No `ConnectInfo` / missing header collapsed every request into one bucket → one client throttles the whole site. Now a one-time `tracing::warn`.

The in-process `RateLimitLayer` gets the warning but doesn't hash (its store never leaves memory).

Test: `header_value_is_hashed_not_stored_raw`. Docs: `security.md` note, all four locales. Demonstrated live — cache key came out `demo:914f0f73d88a6c5d:…`, secret nowhere in it.