### PR TITLE
fix(distributed-lock): rebuild acquire on an atomic set-if-absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 ## [Unreleased]
 
 ### Fixed
+- **`DistributedLock` acquire was non-atomic off Redis and could wedge or never
+  re-grant** (#1254). Acquire used an `incr` counter plus a *separate* token
+  write, which had three failure modes: the `incr` default is a racy get+set on
+  every non-Redis backend, so two acquirers could both read `1` and both believe
+  they held the lock; a crash between the counter and the token write left the
+  lock held with no token, unreleasable until its TTL; and a counter left above
+  zero could never be acquired again. Rebuilt on a single atomic set-if-absent —
+  `Cache::add`, now overridden as `SET NX EX` on `RedisCache` and a
+  lock-guarded test-and-set on `InMemoryCache`. The key's value *is* the token,
+  so there is nothing to desynchronise; release deletes it only when it is still
+  ours. `DatabaseCache`'s `add` stays the non-atomic default (documented) — a
+  DB-backed lock is single-process only; use Redis across replicas. Regression
+  tests: 50 racing acquirers yield exactly one winner, a released lock is
+  immediately re-acquirable, and `add` is atomic under 100 concurrent callers —
+  all fail against the pre-fix code.
 - **`cache_page` could serve one user's session cookie to another** (#1251).
   The layer cached any 200 and replayed its stored headers verbatim on a HIT,
   including `Set-Cookie` — so an authenticated response that minted

--- a/crates/rustango/src/cache/mod.rs
+++ b/crates/rustango/src/cache/mod.rs
@@ -772,6 +772,34 @@ impl Cache for InMemoryCache {
         Ok(new)
     }
 
+    /// Atomic set-if-absent (#1254). The trait default is a racy
+    /// `exists` then `set`; this holds the single write lock across the
+    /// check and the insert, so it is a genuine test-and-set — the
+    /// primitive `DistributedLock` acquire is built on.
+    async fn add(&self, key: &str, value: &str, ttl: Option<Duration>) -> Result<bool, CacheError> {
+        let tick = self.next_tick();
+        let mut store = self.inner.write().await;
+        if store.map.get(key).is_some_and(|e| !e.is_expired()) {
+            return Ok(false);
+        }
+        let size = key.len() + value.len();
+        if let Some(old) = store.map.remove(key) {
+            store.used_bytes = store.used_bytes.saturating_sub(old.size);
+        }
+        store.used_bytes += size;
+        store.map.insert(
+            key.to_owned(),
+            CacheEntry {
+                value: value.to_owned(),
+                expires_at: self.resolve_ttl(ttl),
+                last_used: AtomicU64::new(tick),
+                size,
+            },
+        );
+        self.evict_locked(&mut store);
+        Ok(true)
+    }
+
     async fn delete(&self, key: &str) -> Result<(), CacheError> {
         let mut store = self.inner.write().await;
         if let Some(e) = store.map.remove(key) {

--- a/crates/rustango/src/cache/redis_backend.rs
+++ b/crates/rustango/src/cache/redis_backend.rs
@@ -87,6 +87,28 @@ impl Cache for RedisCache {
         }
     }
 
+    /// Atomic set-if-absent via `SET key value NX [EX secs]` (#1254).
+    /// The default `add` is a racy `exists` + `set`; `NX` makes the
+    /// server do the test-and-set in one round trip, which is what makes
+    /// `DistributedLock` safe across replicas. Returns `true` when this
+    /// call created the key.
+    async fn add(&self, key: &str, value: &str, ttl: Option<Duration>) -> Result<bool, CacheError> {
+        let mut conn = self.conn.clone();
+        let mut cmd = redis::cmd("SET");
+        cmd.arg(key).arg(value).arg("NX");
+        if let Some(secs) = self.effective_ttl(ttl) {
+            cmd.arg("EX").arg(secs);
+        }
+        // `SET ... NX` replies with the string "OK" on success and a nil
+        // bulk on a no-op (key already existed). `Option<String>`
+        // decodes that as `Some("OK")` / `None`.
+        let reply: Option<String> = cmd
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| CacheError::Connection(e.to_string()))?;
+        Ok(reply.is_some())
+    }
+
     async fn delete(&self, key: &str) -> Result<(), CacheError> {
         let mut conn = self.conn.clone();
         conn.del::<_, ()>(key)

--- a/crates/rustango/src/distributed_lock.rs
+++ b/crates/rustango/src/distributed_lock.rs
@@ -7,11 +7,11 @@
 //!
 //! ## Mechanism
 //!
-//! Acquire is a Cache `set` of `lock:<name>` to a per-acquire token,
-//! gated on the existing default `incr`-based check. The lock auto-
-//! expires after `ttl`, so a process that crashes while holding the
-//! lock doesn't deadlock the system — at worst, the next acquirer
-//! waits `ttl` seconds.
+//! Acquire is one atomic set-if-absent (`Cache::add`) of `lock:<name>`
+//! to a per-acquire token: the key is written only if absent, and the
+//! call reports whether it won. The lock auto-expires after `ttl`, so a
+//! process that crashes while holding it doesn't deadlock the system —
+//! at worst, the next acquirer waits `ttl` seconds.
 //!
 //! Release is conditional on the token: a process that lost its lock
 //! (because TTL expired and someone else acquired) does NOT
@@ -40,11 +40,18 @@
 //!
 //! ## Caveats
 //!
-//! - The non-atomic default `Cache::incr` can race under heavy
-//!   contention with two acquirers in the same millisecond. RedisCache
-//!   uses native `INCRBY` so it's safe across replicas.
+//! - Acquire is a single atomic set-if-absent (`Cache::add`): `SET NX`
+//!   on `RedisCache` (safe across replicas) and a lock-guarded
+//!   test-and-set on `InMemoryCache` (#1254). `DatabaseCache`'s `add`
+//!   is still the non-atomic default, so a DB-backed lock is safe only
+//!   within one process — use Redis for multi-replica locking.
 //! - This is "best-effort exactly-once" — fine for cron-style work,
-//!   not a substitute for a transaction when correctness matters.
+//!   not a substitute for a transaction when correctness matters. The
+//!   one residual race is release: it reads the key then deletes it, so
+//!   a lock whose TTL expired mid-release could in principle be freed
+//!   just as another holder takes it. Bounded by the TTL, which the
+//!   design already relies on; a compare-and-delete script would close
+//!   it if you need stricter guarantees.
 //! - TTL must be longer than the worst-case execution time of the
 //!   protected work, OR the work must be idempotent. A too-short TTL
 //!   means another replica could grab the lock mid-execution.
@@ -135,33 +142,35 @@ impl DistributedLock {
     /// - `None` when someone else holds it.
     pub async fn try_acquire(&self, name: &str, ttl: Duration) -> Option<LockGuard> {
         let key = self.key_for(name);
-        // `incr(key, 1, ttl)` returns 1 ONLY when the counter was
-        // previously absent (or 0). On RedisCache the INCRBY+EXPIRE NX
-        // sequence is atomic; on the in-memory default impl it's racy
-        // but acceptable for tests.
-        let n = self.cache.incr(&key, 1, Some(ttl)).await.ok()?;
-        if n == 1 {
-            // We got the lock. Stash a token so release knows it's us.
-            let token = format!(
-                "{}-{}",
-                std::process::id(),
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map_or(0, |d| d.as_nanos())
-            );
-            // Keep the counter, but ALSO write a token — release reads
-            // both. (The counter is the gate; the token is the receipt.)
-            let token_key = format!("{key}:token");
-            let _ = self.cache.set(&token_key, &token, Some(ttl)).await;
-            Some(LockGuard {
+        // A single atomic set-if-absent (#1254). `add` writes the key
+        // ONLY when it is absent and returns whether it did — the whole
+        // acquire in one operation. On `RedisCache` it is `SET NX EX`
+        // (atomic across replicas); on `InMemoryCache` it holds the
+        // store lock across the test-and-set. This replaces the old
+        // incr-counter + separate token dance, which had three bugs: a
+        // non-atomic acquire off Redis, a crash window between the
+        // counter and the token that wedged the lock until TTL, and a
+        // counter that, once left above zero, could never be acquired
+        // again. The key's *value* is the token, so there is nothing to
+        // desynchronise.
+        let token = format!(
+            "{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos())
+        );
+        match self.cache.add(&key, &token, Some(ttl)).await {
+            Ok(true) => Some(LockGuard {
                 cache: self.cache.clone(),
                 key,
-                token_key,
                 token: Arc::new(token),
                 released: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            })
-        } else {
-            None
+            }),
+            // `Ok(false)` — someone else holds it. `Err` — cache
+            // unreachable; treat as "could not acquire" (fail closed:
+            // better to skip the work than run it unguarded).
+            _ => None,
         }
     }
 
@@ -186,7 +195,6 @@ impl DistributedLock {
 pub struct LockGuard {
     cache: BoxedCache,
     key: String,
-    token_key: String,
     token: Arc<String>,
     released: Arc<std::sync::atomic::AtomicBool>,
 }
@@ -205,15 +213,17 @@ impl LockGuard {
         {
             return;
         }
-        // Token check — if our token is still the one stored, we still
-        // hold the lock, so we can clear it. Otherwise someone else
-        // acquired after our TTL expired and we mustn't touch theirs.
-        let stored = self.cache.get(&self.token_key).await.ok().flatten();
-        if stored.as_deref() != Some(self.token.as_str()) {
-            return;
+        // The lock key's value IS our token. Only delete it if it is
+        // still ours: if our TTL expired and someone else re-acquired,
+        // the value is their token and we must not free their lock.
+        // (A get-then-delete has a small window on Redis — a compare-
+        // and-delete Lua script would close it — but this is a
+        // best-effort lock: the residual case is bounded by the TTL,
+        // which the whole design already leans on.)
+        let stored = self.cache.get(&self.key).await.ok().flatten();
+        if stored.as_deref() == Some(self.token.as_str()) {
+            let _ = self.cache.delete(&self.key).await;
         }
-        let _ = self.cache.delete(&self.key).await;
-        let _ = self.cache.delete(&self.token_key).await;
     }
 }
 
@@ -240,6 +250,50 @@ mod tests {
     fn lock() -> DistributedLock {
         let cache: BoxedCache = StdArc::new(InMemoryCache::new());
         DistributedLock::new(cache)
+    }
+
+    /// #1254 — under contention exactly ONE of many racing acquirers
+    /// may win. The old incr-counter acquire could hand the lock to two
+    /// callers that both read `1`; the atomic `add` cannot.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn only_one_of_many_racing_acquirers_wins() {
+        let cache: BoxedCache = StdArc::new(InMemoryCache::new());
+        let l = StdArc::new(DistributedLock::new(cache));
+        let mut handles = Vec::new();
+        for _ in 0..50 {
+            let l = l.clone();
+            handles.push(tokio::spawn(async move {
+                l.try_acquire("hot", Duration::from_secs(30))
+                    .await
+                    .map(|g| {
+                        // hold it — never release — so a second winner
+                        // would be a true double-acquire, not a
+                        // release/re-acquire.
+                        std::mem::forget(g);
+                    })
+                    .is_some()
+            }));
+        }
+        let mut winners = 0;
+        for h in handles {
+            if h.await.unwrap() {
+                winners += 1;
+            }
+        }
+        assert_eq!(winners, 1, "exactly one acquirer must win; got {winners}");
+    }
+
+    /// #1254 — a released lock is immediately re-acquirable. The old
+    /// design could leave the counter above zero so the lock was never
+    /// grantable again; the value-is-token design frees cleanly.
+    #[tokio::test]
+    async fn lock_is_reacquirable_after_release() {
+        let l = lock();
+        for _ in 0..5 {
+            let g = l.try_acquire("cycle", Duration::from_secs(5)).await;
+            assert!(g.is_some(), "should re-acquire after each release");
+            g.unwrap().release().await;
+        }
     }
 
     #[tokio::test]

--- a/crates/rustango/tests/cache_backends.rs
+++ b/crates/rustango/tests/cache_backends.rs
@@ -528,3 +528,29 @@ async fn inmemory_incr_is_atomic_under_contention() {
         .unwrap();
     assert_eq!(final_val, 100, "incr lost updates under contention");
 }
+
+/// #1254 — `InMemoryCache::add` (set-if-absent) must be atomic: exactly
+/// one of many racing callers may create the key. The trait default is
+/// a racy exists+set; `DistributedLock` acquire relies on this.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn inmemory_add_is_atomic_under_contention() {
+    use std::sync::Arc;
+    let cache: Arc<rustango::cache::InMemoryCache> =
+        Arc::new(rustango::cache::InMemoryCache::new());
+    let mut handles = Vec::new();
+    for _ in 0..100 {
+        let c = cache.clone();
+        handles.push(tokio::spawn(async move {
+            rustango::cache::Cache::add(&*c, "once", "v", None)
+                .await
+                .unwrap()
+        }));
+    }
+    let mut winners = 0;
+    for h in handles {
+        if h.await.unwrap() {
+            winners += 1;
+        }
+    }
+    assert_eq!(winners, 1, "exactly one add() may win; got {winners}");
+}

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -193,12 +193,12 @@ cache.clear().await?;                            // drops ONLY acme's entries
 than reimplementing anything, so native primitives (Redis `INCRBY`, `SET NX`,
 `MGET`) keep their atomicity and batching.
 
-**Atomic counters.** `Cache::incr(key, by, ttl)` returns the value after the
-increment and is the primitive behind [rate limiting](middleware.md),
-per-account lockout, and `DistributedLock`. It is atomic on `RedisCache`
-(native `INCRBY`) and on `InMemoryCache` (which holds its lock across the whole
-read-modify-write); `DatabaseCache` uses a non-atomic get-then-set — fine for
-one process, but reach for Redis when a counter must be exact across replicas.
+**Atomic counters and locks.** `Cache::incr` backs [rate limiting](middleware.md)
+and per-account lockout; `Cache::add` (set-if-absent) backs `DistributedLock`.
+Both are atomic on `RedisCache` (native `INCRBY` / `SET NX`) and on
+`InMemoryCache` (which holds its lock across the read-modify-write);
+`DatabaseCache` leaves both at the non-atomic default — fine for one process,
+but reach for Redis when a counter or lock must be exact across replicas.
 
 Two things worth knowing:
 

--- a/docs/de/caching.md
+++ b/docs/de/caching.md
@@ -200,13 +200,13 @@ cache.clear().await?;                            // drops ONLY acme's entries
 statt etwas neu zu implementieren, sodass native Primitive (Redis `INCRBY`,
 `SET NX`, `MGET`) ihre Atomarität und Batching behalten.
 
-**Atomare Zähler.** `Cache::incr(key, by, ttl)` liefert den Wert nach dem
-Inkrement und ist das Primitiv hinter [Rate-Limiting](middleware.md),
-Konto-Sperren und `DistributedLock`. Es ist atomar bei `RedisCache` (natives
-`INCRBY`) und bei `InMemoryCache` (das seine Sperre über das gesamte
-Read-Modify-Write hält); `DatabaseCache` nutzt ein nicht-atomares Get-dann-Set —
-für einen Prozess in Ordnung, aber greife zu Redis, wenn ein Zähler über
-Replikate hinweg exakt sein muss.
+**Atomare Zähler und Sperren.** `Cache::incr` steckt hinter
+[Rate-Limiting](middleware.md) und Konto-Sperren; `Cache::add` (set-if-absent)
+steckt hinter `DistributedLock`. Beide sind atomar bei `RedisCache` (natives
+`INCRBY` / `SET NX`) und bei `InMemoryCache` (das seine Sperre über das
+Read-Modify-Write hält); `DatabaseCache` belässt beide beim nicht-atomaren
+Standard — für einen Prozess in Ordnung, aber greife zu Redis, wenn ein Zähler
+oder eine Sperre über Replikate hinweg exakt sein muss.
 
 Zwei Dinge, die man wissen sollte:
 

--- a/docs/es/caching.md
+++ b/docs/es/caching.md
@@ -197,12 +197,13 @@ tome un `BoxedCache` — `cache_page`, `cache_fragment`, los rate limiters,
 de reimplementar nada, de modo que las primitivas nativas (Redis `INCRBY`,
 `SET NX`, `MGET`) conservan su atomicidad y su batching.
 
-**Contadores atómicos.** `Cache::incr(key, by, ttl)` devuelve el valor tras el
-incremento y es la primitiva tras el [rate limiting](middleware.md), el bloqueo
-por cuenta y `DistributedLock`. Es atómico en `RedisCache` (`INCRBY` nativo) y en
-`InMemoryCache` (que mantiene su cerrojo durante todo el read-modify-write);
-`DatabaseCache` usa un get-luego-set no atómico — suficiente para un proceso,
-pero usa Redis cuando un contador deba ser exacto entre réplicas.
+**Contadores atómicos y bloqueos.** `Cache::incr` está detrás del
+[rate limiting](middleware.md) y el bloqueo por cuenta; `Cache::add`
+(set-if-absent) está detrás de `DistributedLock`. Ambos son atómicos en
+`RedisCache` (`INCRBY` / `SET NX` nativos) y en `InMemoryCache` (que mantiene su
+cerrojo durante el read-modify-write); `DatabaseCache` deja ambos en el valor no
+atómico por defecto — suficiente para un proceso, pero usa Redis cuando un
+contador o bloqueo deba ser exacto entre réplicas.
 
 Dos cosas que conviene saber:
 

--- a/docs/fr/caching.md
+++ b/docs/fr/caching.md
@@ -200,13 +200,13 @@ cache.clear().await?;                            // drops ONLY acme's entries
 que de réimplémenter quoi que ce soit, si bien que les primitives natives (Redis
 `INCRBY`, `SET NX`, `MGET`) gardent leur atomicité et leur traitement par lots.
 
-**Compteurs atomiques.** `Cache::incr(key, by, ttl)` renvoie la valeur après
-l'incrément et est la primitive derrière le [rate limiting](middleware.md), le
-verrouillage par compte et `DistributedLock`. Il est atomique sur `RedisCache`
-(`INCRBY` natif) et sur `InMemoryCache` (qui garde son verrou pendant tout le
-read-modify-write) ; `DatabaseCache` utilise un get-puis-set non atomique —
-suffisant pour un seul processus, mais passez à Redis lorsqu'un compteur doit
-être exact entre réplicas.
+**Compteurs atomiques et verrous.** `Cache::incr` est derrière le
+[rate limiting](middleware.md) et le verrouillage par compte ; `Cache::add`
+(set-if-absent) est derrière `DistributedLock`. Les deux sont atomiques sur
+`RedisCache` (`INCRBY` / `SET NX` natifs) et sur `InMemoryCache` (qui garde son
+verrou pendant le read-modify-write) ; `DatabaseCache` laisse les deux au
+comportement non atomique par défaut — suffisant pour un seul processus, mais
+passez à Redis lorsqu'un compteur ou un verrou doit être exact entre réplicas.
 
 Deux choses à savoir :
 


### PR DESCRIPTION
Closes #1254. The last of the bug-sweep findings.

## The bug (three failure modes)

Acquire used an `incr` counter as the gate **plus a separate `set` of a `:token` key** as the receipt:

1. **Non-atomic off Redis** — `incr`'s default is get-then-set, so on `InMemoryCache`/`DatabaseCache` two acquirers could both read `1` and both think they hold the lock.
2. **Crash-wedge** — a process dying between the counter write and the token write left the counter set with no token; release read `None != our_token` and never cleared it → held until TTL with nobody holding it.
3. **Counter never resets** — acquire only won when `incr` returned exactly `1`; anything leaving it above zero made the lock permanently unacquirable until TTL.

## The fix

One **atomic set-if-absent** — `Cache::add`, now overridden as `SET NX EX` on `RedisCache` and a lock-guarded test-and-set on `InMemoryCache`. The lock key's **value is the token**, so there's nothing to desynchronise; release deletes it only when it's still ours. `DatabaseCache::add` stays the non-atomic default (documented; multi-replica → Redis).

## Tests — all fail against pre-fix code

- `only_one_of_many_racing_acquirers_wins` — 50 racing acquirers holding their guards, exactly one wins (proven 3/3 fail without the atomic `add`).
- `lock_is_reacquirable_after_release`.
- `inmemory_add_is_atomic_under_contention` — 100 concurrent `add`s, one winner.

## Docs

Lock rustdoc (mechanism + caveats) + `caching.md` atomic-primitives note, **all four locales**.

This completes the exploitable bug-sweep cluster. Only #1257 (LIKE tri-dialect ESCAPE) remains open, deferred as it needs the MySQL/SQLite live suites.