### PR TITLE
release: 0.54.0 — version bump + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+## [0.54.0] — 2026-08-31
+
+Security and correctness batch — a bug-sweep of the cache / concurrency / HTTP
+middleware, plus the multi-tenancy isolation fixes and a documentation overhaul.
+No API removals; one behaviour change worth calling out.
+
+**Security-relevant:**
+
+- `cache_page` no longer caches a response carrying `Set-Cookie` or serves a
+  cached body to an `Authorization`/`Cookie`-bearing request — it previously
+  replayed one user's session cookie to the next (#1251).
+- The cache-backed rate limiter hashes secret header values instead of storing
+  them raw as cache keys, and warns instead of silently collapsing keyless
+  clients into one shared bucket (#1252).
+- The counter behind account lockout, and the `DistributedLock` acquire, are now
+  atomic (`InMemoryCache::incr` / new `Cache::add` = `SET NX`) — the lockout
+  threshold is no longer evadable by parallel attempts, and a lock can't be
+  double-held, wedged, or left permanently unacquirable (#1253, #1254).
+- Schema-mode tenancy resets `search_path` on connection release, so a shared
+  registry connection can't leak one tenant's schema to the next borrower
+  (#1224); scoped pools are cached per tenant (#1235); scheduled sweeps fan out
+  per tenant, and cache/locks scope per tenant (#1226–#1229).
+
+**Behaviour change:** `cache_page` refuses by default to cache responses that set
+a cookie or are marked `Cache-Control: private`, and bypasses the shared cache
+for authenticated requests. A route known to be public despite such a header
+opts back in with `CachePageLayer::cache_authenticated(true)`.
+
+**Also:** `FileCache`/`DatabaseCache` sub-second TTL correctness groundwork
+(#1233), scheduler zero-period + shutdown fixes (#1256), ETag RFC-7232
+conformance (#1258), 160 broken doc links fixed across all four locales with a
+guard test, and Docker demoted from a prerequisite in the getting-started guide
+(#1247, #1248). Supply-chain: `rpassword`, `quinn-proto`, `crossbeam-epoch`,
+`spin` advisories cleared, and `cargo deny` widened to optional features and
+example lockfiles.
+
+`Cache::add` (atomic set-if-absent) is new public API; `CachePageLayer` and
+`TenantPoolsConfig` gained methods/fields. All additive.
+
 ### Fixed
 - **`DistributedLock` acquire was non-atomic off Redis and could wedge or never
   re-grant** (#1254). Acquire used an `incr` counter plus a *separate* token
@@ -74,8 +113,6 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
   `INCRBY`); `DatabaseCache`'s default `incr` is still get-then-set, fine for a
   single process. A multi-threaded regression test drives 50–100 concurrent
   increments and asserts none are lost — it fails against the pre-fix code.
-
-### Fixed
 - **160 broken documentation references, across all four locales** (#1248).
   Reported as three 404s on the docs site; an audit found the whole class.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.53.0"
+version = "0.54.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.53.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.53.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.53.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.54.0", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.54.0", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.54.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.53.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.54.0" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -480,7 +480,7 @@ runserver = ["_axum"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.53.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.54.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }


### PR DESCRIPTION
Version bump + CHANGELOG for **0.54.0**. Step 1 of the release flow.

Rolls in the security/correctness bug-sweep and multi-tenancy isolation fixes that landed on develop past 0.53.0 (tagged but unpublished).

## Why minor

- New public API: `Cache::add` (atomic set-if-absent).
- Behaviour change: `cache_page` refuses by default to cache `Set-Cookie` / `private` responses and bypasses the shared cache for authenticated requests (opt back in with `cache_authenticated(true)`).
- Additive methods/fields on `CachePageLayer`, `TenantPoolsConfig`. No removals.

## Contents (8 fixes since 0.53.0)

Security: #1251 #1252 #1253 #1254 #1224 #1226-#1229 #1235. Plus #1256 #1258 #1233 #1247 #1248 and cleared `rpassword`/`quinn-proto`/`crossbeam-epoch`/`spin` advisories.

## Verification

`cargo metadata --no-deps` resolves all four publishable crates at 0.54.0. develop is CI-green (37/37, run 33354432975) on the exact content this bumps. `Cargo.lock` gitignored — nothing staged there.