### PR TITLE
release: 0.55.0 — version bump + CHANGELOG + README refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+## [0.55.0] — 2026-08-31
+
+Follows 0.54.0 with the LIKE-escaping correctness fix and a README version
+refresh.
+
+**Behaviour change:** LIKE lookups now escape user-supplied wildcards — a `%`
+or `_` in a `__contains` / `__startswith` / `__endswith` / `__iexact` value (and
+the admin/viewset `?q=` search) matches literally instead of acting as a SQL
+wildcard, matching Django (#1257). Covers every producer: the `.filter()` lookup
+path, the `Q::contains` builder, the `Q!()` macro, and relation-spanning
+lookups. New public API: `core::escape_like`, `core::LIKE_ESCAPE_CHAR`,
+`core::LIKE_ESCAPE_CLAUSE`, `Op::LikeEscaped` / `Op::ILikeEscaped`, and
+`Column::contains` / `icontains` / `startswith` / `istartswith` / `endswith` /
+`iendswith` / `iexact`. Verified live on SQLite, Postgres and MySQL.
+
+Also: README install snippets bumped to the current version (docs.rs renders the
+README as the crate landing page).
+
 ### Fixed
 - **LIKE lookups did not escape user wildcards, on any dialect** (#1257).
   `__contains` / `__startswith` / `__endswith` (and the admin/viewset `?q=`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.54.0"
+version = "0.55.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.54.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.54.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.54.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.55.0", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.55.0", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.55.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ Rustango gives you the productivity of Django or Laravel with the speed and type
 ```toml
 [dependencies]
 # Postgres (default)
-rustango = "0.52"
+rustango = "0.55"
 
 # SQLite — file-backed or in-memory
-rustango = { version = "0.52", default-features = false, features = ["sqlite", "tenancy", "admin", "manage"] }
+rustango = { version = "0.55", default-features = false, features = ["sqlite", "tenancy", "admin", "manage"] }
 
 # MySQL 8+
-rustango = { version = "0.52", default-features = false, features = ["mysql", "tenancy", "admin", "manage"] }
+rustango = { version = "0.55", default-features = false, features = ["mysql", "tenancy", "admin", "manage"] }
 ```
 
-Every capability is a cargo feature you can turn off. Renaming the dep works too — `#[derive(Model)]` resolves the crate root via `proc-macro-crate`, so `orm = { package = "rustango", version = "0.52" }` needs no extra wiring.
+Every capability is a cargo feature you can turn off. Renaming the dep works too — `#[derive(Model)]` resolves the crate root via `proc-macro-crate`, so `orm = { package = "rustango", version = "0.55" }` needs no extra wiring.
 
 ## An app on SQLite in 30 lines
 

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.54.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.55.0" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -480,7 +480,7 @@ runserver = ["_axum"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.54.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.55.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }


### PR DESCRIPTION
Version bump for **0.55.0**. Ships the LIKE-escaping fix (#1257/#1268) and refreshes the README version (docs.rs renders it as the crate landing page, so the published README was showing a stale version).

Minor, not patch: #1268 adds public API (`core::escape_like`, escaped `Op` variants, `Column::contains`/`iexact`/…) and changes `__contains` behaviour (user `%`/`_` now literal). `cargo metadata` resolves all four crates at 0.55.0.