### PR TITLE
release: 0.55.0 — promote develop → main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+## [0.55.0] — 2026-08-31
+
+Follows 0.54.0 with the LIKE-escaping correctness fix and a README version
+refresh.
+
+**Behaviour change:** LIKE lookups now escape user-supplied wildcards — a `%`
+or `_` in a `__contains` / `__startswith` / `__endswith` / `__iexact` value (and
+the admin/viewset `?q=` search) matches literally instead of acting as a SQL
+wildcard, matching Django (#1257). Covers every producer: the `.filter()` lookup
+path, the `Q::contains` builder, the `Q!()` macro, and relation-spanning
+lookups. New public API: `core::escape_like`, `core::LIKE_ESCAPE_CHAR`,
+`core::LIKE_ESCAPE_CLAUSE`, `Op::LikeEscaped` / `Op::ILikeEscaped`, and
+`Column::contains` / `icontains` / `startswith` / `istartswith` / `endswith` /
+`iendswith` / `iexact`. Verified live on SQLite, Postgres and MySQL.
+
+Also: README install snippets bumped to the current version (docs.rs renders the
+README as the crate landing page).
+
 ### Fixed
 - **LIKE lookups did not escape user wildcards, on any dialect** (#1257).
   `__contains` / `__startswith` / `__endswith` (and the admin/viewset `?q=`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+### Fixed
+- **LIKE lookups did not escape user wildcards, on any dialect** (#1257).
+  `__contains` / `__startswith` / `__endswith` (and the admin/viewset `?q=`
+  search and `template_views` list search) built `%value%` from raw user input
+  with no escaping and no `ESCAPE` clause — so a `%` or `_` typed by a user acted
+  as a SQL wildcard (`50%` matched "50" then anything; a lone `%` matched every
+  row — a table-scan foot-gun), diverging from Django, which treats the value as
+  a literal substring. The one path that *did* escape (`template_views`, with
+  `\`) was itself wrong on SQLite, which has no default LIKE escape character.
+
+  Now escaped with a portable `!` escape char and emitted as `LIKE ? ESCAPE '!'`
+  via new `Op::LikeEscaped` / `Op::ILikeEscaped` (`\` is not portable — MySQL
+  eats it as a string-literal escape; `!` is why the cache layer chose it too).
+  Verified live on **all three backends** (SQLite/PG/MySQL) that `%`, `_` and `!`
+  now match literally. Raw `__like` / `__ilike` still bind the caller's pattern
+  verbatim (they own the wildcards).
+
+  Covered on **every** producer, not just `.filter()`: the ORM lookup path
+  (`wrap_like`), the `Q::contains`/`icontains`/… builder, the `Q!()` macro (now
+  via typed `Column::contains`/`icontains`/`iexact`/… methods), and the
+  admin/viewset `?q=` search. Relation-spanning lookups
+  (`author__name__icontains`, which route through `ExprCompare`) and `__iexact`
+  (case-insensitive equality — `email__iexact` with `%` had matched every row)
+  are included.
+
+  **Behaviour change:** `name__contains = "50%"` now matches a literal `50%`
+  instead of "50 then anything". New public API: `core::escape_like`,
+  `core::LIKE_ESCAPE_CHAR`, `core::LIKE_ESCAPE_CLAUSE`, `Op::LikeEscaped`,
+  `Op::ILikeEscaped`, and `Column::contains`/`icontains`/`startswith`/
+  `istartswith`/`endswith`/`iendswith`/`iexact`.
+
 ## [0.54.0] — 2026-08-31
 
 Security and correctness batch — a bug-sweep of the cache / concurrency / HTTP

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.54.0"
+version = "0.55.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.54.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.54.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.54.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.55.0", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.55.0", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.55.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ Rustango gives you the productivity of Django or Laravel with the speed and type
 ```toml
 [dependencies]
 # Postgres (default)
-rustango = "0.52"
+rustango = "0.55"
 
 # SQLite — file-backed or in-memory
-rustango = { version = "0.52", default-features = false, features = ["sqlite", "tenancy", "admin", "manage"] }
+rustango = { version = "0.55", default-features = false, features = ["sqlite", "tenancy", "admin", "manage"] }
 
 # MySQL 8+
-rustango = { version = "0.52", default-features = false, features = ["mysql", "tenancy", "admin", "manage"] }
+rustango = { version = "0.55", default-features = false, features = ["mysql", "tenancy", "admin", "manage"] }
 ```
 
-Every capability is a cargo feature you can turn off. Renaming the dep works too — `#[derive(Model)]` resolves the crate root via `proc-macro-crate`, so `orm = { package = "rustango", version = "0.52" }` needs no extra wiring.
+Every capability is a cargo feature you can turn off. Renaming the dep works too — `#[derive(Model)]` resolves the crate root via `proc-macro-crate`, so `orm = { package = "rustango", version = "0.55" }` needs no extra wiring.
 
 ## An app on SQLite in 30 lines
 

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -432,48 +432,30 @@ fn expand_q(input: TokenStream2) -> syn::Result<TokenStream2> {
         "lte" => quote! {
             #root::core::Column::lte(#path::#base_ident, #value)
         },
+        // The escaped-LIKE lookups delegate to the typed Column
+        // methods, which escape the value and pair it with the
+        // *Escaped ops so `%` / `_` match literally on every dialect
+        // (#1257) — the macro no longer owns any pattern wrapping.
         "iexact" => quote! {
-            // Django emulates `__iexact` as case-insensitive equality.
-            // The non-wildcard `ILIKE value` is semantically identical
-            // for plain strings; LIKE-metachars `%` `_` in the rhs would
-            // accidentally match more — document the caveat.
-            #root::core::Column::ilike(#path::#base_ident, ::std::string::ToString::to_string(&(#value)))
+            #root::core::Column::iexact(#path::#base_ident, ::std::string::ToString::to_string(&(#value)))
         },
         "contains" => quote! {
-            #root::core::Column::like(
-                #path::#base_ident,
-                ::std::format!("%{}%", #value),
-            )
+            #root::core::Column::contains(#path::#base_ident, ::std::string::ToString::to_string(&(#value)))
         },
         "icontains" => quote! {
-            #root::core::Column::ilike(
-                #path::#base_ident,
-                ::std::format!("%{}%", #value),
-            )
+            #root::core::Column::icontains(#path::#base_ident, ::std::string::ToString::to_string(&(#value)))
         },
         "startswith" => quote! {
-            #root::core::Column::like(
-                #path::#base_ident,
-                ::std::format!("{}%", #value),
-            )
+            #root::core::Column::startswith(#path::#base_ident, ::std::string::ToString::to_string(&(#value)))
         },
         "istartswith" => quote! {
-            #root::core::Column::ilike(
-                #path::#base_ident,
-                ::std::format!("{}%", #value),
-            )
+            #root::core::Column::istartswith(#path::#base_ident, ::std::string::ToString::to_string(&(#value)))
         },
         "endswith" => quote! {
-            #root::core::Column::like(
-                #path::#base_ident,
-                ::std::format!("%{}", #value),
-            )
+            #root::core::Column::endswith(#path::#base_ident, ::std::string::ToString::to_string(&(#value)))
         },
         "iendswith" => quote! {
-            #root::core::Column::ilike(
-                #path::#base_ident,
-                ::std::format!("%{}", #value),
-            )
+            #root::core::Column::iendswith(#path::#base_ident, ::std::string::ToString::to_string(&(#value)))
         },
         "in" => quote! {
             #root::core::Column::is_in(#path::#base_ident, #value)

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.54.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.55.0" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -480,7 +480,7 @@ runserver = ["_axum"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.54.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.55.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }

--- a/crates/rustango/src/cache/db_backend.rs
+++ b/crates/rustango/src/cache/db_backend.rs
@@ -289,16 +289,15 @@ impl Cache for DatabaseCache {
         let dialect = self.pool.dialect();
         let table = dialect.quote_ident(&self.table);
         let p = dialect.placeholder(1);
-        // Escape the escape character first, or `!` in a prefix would
-        // swallow the character after it.
-        let pattern = format!(
-            "{}%",
-            prefix
-                .replace('!', "!!")
-                .replace('%', "!%")
-                .replace('_', "!_")
+        // One escape algorithm for the whole crate (#1257 promoted this
+        // module's `!`-based escaping to `core::escape_like`); reusing
+        // it here means the escape character can never drift between
+        // the cache and the ORM's LIKE lookups.
+        let pattern = format!("{}%", crate::core::escape_like(prefix));
+        let sql = format!(
+            "DELETE FROM {table} WHERE cache_key LIKE {p}{}",
+            crate::core::LIKE_ESCAPE_CLAUSE
         );
-        let sql = format!("DELETE FROM {table} WHERE cache_key LIKE {p} ESCAPE '!'");
         raw_execute_pool(&self.pool, &sql, vec![SqlValue::String(pattern)])
             .await
             .map_err(|e| CacheError::Connection(format!("delete_prefix: {e}")))?;

--- a/crates/rustango/src/core/column.rs
+++ b/crates/rustango/src/core/column.rs
@@ -76,6 +76,75 @@ pub trait Column: Copy + 'static {
         TypedFilter::scalar(Self::COLUMN, Op::NotILike, value.into().into())
     }
 
+    /// Django `__contains` — the value is a **literal** substring: `%`
+    /// and `_` in it match themselves, escaped and emitted with
+    /// `ESCAPE '!'` on every dialect (#1257). Use [`Column::like`] for a
+    /// raw pattern you build yourself.
+    fn contains(self, value: impl AsRef<str>) -> TypedFilter<Self::Model> {
+        Self::escaped_like(self, "%", "%", value, false)
+    }
+
+    /// Django `__icontains` — case-insensitive literal substring match
+    /// (#1257).
+    fn icontains(self, value: impl AsRef<str>) -> TypedFilter<Self::Model> {
+        Self::escaped_like(self, "%", "%", value, true)
+    }
+
+    /// Django `__startswith` — literal prefix match (#1257).
+    fn startswith(self, value: impl AsRef<str>) -> TypedFilter<Self::Model> {
+        Self::escaped_like(self, "", "%", value, false)
+    }
+
+    /// Django `__istartswith` — case-insensitive literal prefix match
+    /// (#1257).
+    fn istartswith(self, value: impl AsRef<str>) -> TypedFilter<Self::Model> {
+        Self::escaped_like(self, "", "%", value, true)
+    }
+
+    /// Django `__endswith` — literal suffix match (#1257).
+    fn endswith(self, value: impl AsRef<str>) -> TypedFilter<Self::Model> {
+        Self::escaped_like(self, "%", "", value, false)
+    }
+
+    /// Django `__iendswith` — case-insensitive literal suffix match
+    /// (#1257).
+    fn iendswith(self, value: impl AsRef<str>) -> TypedFilter<Self::Model> {
+        Self::escaped_like(self, "%", "", value, true)
+    }
+
+    /// Django `__iexact` — case-insensitive **equality**. The value is a
+    /// literal, never a pattern: `%` / `_` in it match themselves
+    /// (#1257), unlike [`Column::ilike`], which binds the caller's
+    /// pattern verbatim.
+    fn iexact(self, value: impl AsRef<str>) -> TypedFilter<Self::Model> {
+        Self::escaped_like(self, "", "", value, true)
+    }
+
+    /// Shared builder for the escaped-LIKE lookups: escapes the user
+    /// value with [`crate::core::escape_like`] and pairs it with the
+    /// matching `*Escaped` op, so the escape⟷op invariant cannot be
+    /// broken at the call sites above (#1257).
+    #[doc(hidden)]
+    fn escaped_like(
+        self,
+        prefix: &str,
+        suffix: &str,
+        value: impl AsRef<str>,
+        case_insensitive: bool,
+    ) -> TypedFilter<Self::Model> {
+        let escaped = super::query::escape_like(value.as_ref());
+        let op = if case_insensitive {
+            Op::ILikeEscaped
+        } else {
+            Op::LikeEscaped
+        };
+        TypedFilter::scalar(
+            Self::COLUMN,
+            op,
+            SqlValue::String(format!("{prefix}{escaped}{suffix}")),
+        )
+    }
+
     /// `column REGEXP pattern` — POSIX regex match. Django `__regex`
     /// (issue #26). Pattern is bound as a `String` parameter. Emits
     /// PG `~`, MySQL `REGEXP`, SQLite `REGEXP`. SQLite's `REGEXP`

--- a/crates/rustango/src/core/mod.rs
+++ b/crates/rustango/src/core/mod.rs
@@ -25,11 +25,11 @@ pub use error::QueryError;
 pub use expr::{BinOp, CaseBranch, Expr, JsonPathStep, ScalarFn, VectorMetric, F};
 pub use field_type::{ArrayElem, FieldType, RangeElem};
 pub use query::{
-    AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery, ColumnFilter,
-    CompoundBranch, ConflictClause, CountQuery, CtFilter, DeleteQuery, DerivedSource, DistinctMode,
-    Filter, InsertQuery, Join, JoinKind, LockMode, NullsOrder, Op, OrderClause, OrderItem,
-    RelAggKind, RelCorrelation, SearchClause, SelectQuery, SetOp, SubqueryJoin, UpdateQuery,
-    WhereExpr,
+    escape_like, AggregateExpr, AggregateQuery, Assignment, BulkInsertQuery, BulkUpdateQuery,
+    ColumnFilter, CompoundBranch, ConflictClause, CountQuery, CtFilter, DeleteQuery, DerivedSource,
+    DistinctMode, Filter, InsertQuery, Join, JoinKind, LockMode, NullsOrder, Op, OrderClause,
+    OrderItem, RelAggKind, RelCorrelation, SearchClause, SelectQuery, SetOp, SubqueryJoin,
+    UpdateQuery, WhereExpr, LIKE_ESCAPE_CHAR, LIKE_ESCAPE_CLAUSE,
 };
 pub use schema::{
     infer_app_label_from_module_path, AdminConfig, CheckConstraint, CompositeFkRelation,

--- a/crates/rustango/src/core/query.rs
+++ b/crates/rustango/src/core/query.rs
@@ -30,6 +30,19 @@ pub enum Op {
     ILike,
     /// Case-insensitive `NOT ILIKE` (Postgres).
     NotILike,
+    /// Case-sensitive `LIKE` whose bound value was produced by
+    /// [`escape_like`] — emitted as `LIKE ? ESCAPE '!'` so the escaping
+    /// is honored on every dialect (#1257). SQLite has **no** default
+    /// LIKE escape character, so escaped values are meaningless there
+    /// without the explicit clause; `!` (rather than `\`) because MySQL
+    /// treats `\` as a string-literal escape, making `ESCAPE '\'`
+    /// non-portable. Used by the `contains` / `startswith` / `endswith`
+    /// lookups, which wrap **user input** in wildcards — a plain
+    /// [`Op::Like`] is for caller-owned patterns and is never escaped.
+    LikeEscaped,
+    /// Case-insensitive sibling of [`Op::LikeEscaped`] — the dialect's
+    /// ILIKE shape plus `ESCAPE '!'`.
+    ILikeEscaped,
     /// Range check. The bound value must be `SqlValue::List([lo, hi])`.
     /// Emits `col BETWEEN $lo AND $hi`.
     Between,
@@ -153,6 +166,40 @@ pub enum Op {
     /// abuts the value range (no overlap, no gap). **PG-only**.
     /// Issue #31.
     RangeAdjacent,
+}
+
+/// The LIKE escape character used by [`Op::LikeEscaped`] /
+/// [`Op::ILikeEscaped`] — `!`, because it is portable: `ESCAPE '\'`
+/// breaks on MySQL (backslash is its string-literal escape) and SQLite
+/// has no default escape at all (#1257).
+pub const LIKE_ESCAPE_CHAR: char = '!';
+
+/// The SQL suffix the escaped ops emit after their `LIKE` — pairs with
+/// [`LIKE_ESCAPE_CHAR`] (a unit test pins the two together, so neither
+/// can drift alone).
+pub const LIKE_ESCAPE_CLAUSE: &str = " ESCAPE '!'";
+
+/// Escape LIKE metacharacters in **user input** so `%` and `_` match
+/// literally (#1257, Django parity: `__contains` treats the value as a
+/// literal substring, not a pattern).
+///
+/// The output is only meaningful under [`LIKE_ESCAPE_CLAUSE`], i.e.
+/// bound to an [`Op::LikeEscaped`] / [`Op::ILikeEscaped`] predicate —
+/// pair them. Wildcards the *caller* adds around the escaped value (the
+/// `%…%` of a contains) stay unescaped and keep their meaning.
+#[must_use]
+pub fn escape_like(input: &str) -> String {
+    let e = LIKE_ESCAPE_CHAR;
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        // Escape the escape character itself, and the two LIKE
+        // metacharacters. Single pass, derived from the one const.
+        if ch == e || ch == '%' || ch == '_' {
+            out.push(e);
+        }
+        out.push(ch);
+    }
+    out
 }
 
 /// One predicate in a `WHERE` clause: `column <op> value`. Always

--- a/crates/rustango/src/query/mod.rs
+++ b/crates/rustango/src/query/mod.rs
@@ -2983,30 +2983,36 @@ fn parse_lookup(key: &str, value: SqlValue) -> Result<ParsedLookup, QueryError> 
         "gte" => Ok(pair(field, Op::Gte, value)),
         "lt" => Ok(pair(field, Op::Lt, value)),
         "lte" => Ok(pair(field, Op::Lte, value)),
-        "iexact" => Ok(pair(field, Op::ILike, value)),
+        "iexact" => {
+            // Case-insensitive EQUALITY, not a pattern: escape the
+            // value so `%` / `_` match themselves (#1257) — otherwise
+            // `email__iexact` with `%` matched every row.
+            let v = wrap_like(&value, "", "", &field, suffix)?;
+            Ok(pair(field, Op::ILikeEscaped, v))
+        }
         "contains" => {
             let v = wrap_like(&value, "%", "%", &field, suffix)?;
-            Ok(pair(field, Op::Like, v))
+            Ok(pair(field, Op::LikeEscaped, v))
         }
         "icontains" => {
             let v = wrap_like(&value, "%", "%", &field, suffix)?;
-            Ok(pair(field, Op::ILike, v))
+            Ok(pair(field, Op::ILikeEscaped, v))
         }
         "startswith" => {
             let v = wrap_like(&value, "", "%", &field, suffix)?;
-            Ok(pair(field, Op::Like, v))
+            Ok(pair(field, Op::LikeEscaped, v))
         }
         "istartswith" => {
             let v = wrap_like(&value, "", "%", &field, suffix)?;
-            Ok(pair(field, Op::ILike, v))
+            Ok(pair(field, Op::ILikeEscaped, v))
         }
         "endswith" => {
             let v = wrap_like(&value, "%", "", &field, suffix)?;
-            Ok(pair(field, Op::Like, v))
+            Ok(pair(field, Op::LikeEscaped, v))
         }
         "iendswith" => {
             let v = wrap_like(&value, "%", "", &field, suffix)?;
-            Ok(pair(field, Op::ILike, v))
+            Ok(pair(field, Op::ILikeEscaped, v))
         }
         // Raw LIKE / ILIKE / NOT LIKE / NOT ILIKE — Eloquent
         // `whereLike` / `whereNotLike` parity. Unlike `__contains` /
@@ -3236,7 +3242,13 @@ fn wrap_like(
             });
         }
     };
-    Ok(SqlValue::String(format!("{prefix}{s}{suffix_char}")))
+    // Escape LIKE metacharacters in the user value so `%` / `_` match
+    // literally (#1257) — the wrapping wildcards `prefix`/`suffix_char`
+    // are added AFTER escaping so they keep their pattern meaning. The
+    // resulting value is only correct under `ESCAPE '!'`, so every
+    // caller pairs it with `Op::LikeEscaped` / `Op::ILikeEscaped`.
+    let escaped = crate::core::escape_like(s);
+    Ok(SqlValue::String(format!("{prefix}{escaped}{suffix_char}")))
 }
 
 /// Human-readable shape name for an `SqlValue` — used in

--- a/crates/rustango/src/query/q.rs
+++ b/crates/rustango/src/query/q.rs
@@ -121,66 +121,72 @@ impl Q {
         Self::predicate(column, Op::ILike, value.into())
     }
 
-    /// Django `__contains` — `column LIKE '%value%'`. Wraps the
-    /// supplied string in `%` wildcards before binding.
+    /// Build one escaped-LIKE predicate: the user value is run through
+    /// [`crate::core::escape_like`] and paired with the matching
+    /// `*Escaped` op, so `%` / `_` in it match literally on every
+    /// dialect (#1257). The wrapping wildcards `prefix` / `suffix` are
+    /// added after escaping and keep their pattern meaning. Bundling the
+    /// escape with the op here is what makes the pairing invariant
+    /// unbreakable at the call sites below.
+    fn wrap_escaped(
+        column: &'static str,
+        prefix: &str,
+        suffix: &str,
+        value: impl AsRef<str>,
+        case_insensitive: bool,
+    ) -> Self {
+        let escaped = crate::core::escape_like(value.as_ref());
+        let op = if case_insensitive {
+            Op::ILikeEscaped
+        } else {
+            Op::LikeEscaped
+        };
+        Self::predicate(
+            column,
+            op,
+            SqlValue::String(format!("{prefix}{escaped}{suffix}")),
+        )
+    }
+
+    /// Django `__contains` — the value is a **literal** substring: `%`
+    /// and `_` in it match themselves (#1257). Use [`Q::like`] for a
+    /// raw pattern you build yourself.
     #[must_use]
     pub fn contains(column: &'static str, value: impl AsRef<str>) -> Self {
-        Self::predicate(
-            column,
-            Op::Like,
-            SqlValue::String(format!("%{}%", value.as_ref())),
-        )
+        Self::wrap_escaped(column, "%", "%", value, false)
     }
 
-    /// Django `__icontains` — `column ILIKE '%value%'`. Case-insensitive
-    /// substring match.
+    /// Django `__icontains` — case-insensitive literal substring match
+    /// (`%` / `_` in the value match themselves, #1257).
     #[must_use]
     pub fn icontains(column: &'static str, value: impl AsRef<str>) -> Self {
-        Self::predicate(
-            column,
-            Op::ILike,
-            SqlValue::String(format!("%{}%", value.as_ref())),
-        )
+        Self::wrap_escaped(column, "%", "%", value, true)
     }
 
-    /// Django `__startswith` — `column LIKE 'value%'`.
+    /// Django `__startswith` — literal prefix match (#1257).
     #[must_use]
     pub fn startswith(column: &'static str, value: impl AsRef<str>) -> Self {
-        Self::predicate(
-            column,
-            Op::Like,
-            SqlValue::String(format!("{}%", value.as_ref())),
-        )
+        Self::wrap_escaped(column, "", "%", value, false)
     }
 
-    /// Django `__istartswith` — `column ILIKE 'value%'`.
+    /// Django `__istartswith` — case-insensitive literal prefix match
+    /// (#1257).
     #[must_use]
     pub fn istartswith(column: &'static str, value: impl AsRef<str>) -> Self {
-        Self::predicate(
-            column,
-            Op::ILike,
-            SqlValue::String(format!("{}%", value.as_ref())),
-        )
+        Self::wrap_escaped(column, "", "%", value, true)
     }
 
-    /// Django `__endswith` — `column LIKE '%value'`.
+    /// Django `__endswith` — literal suffix match (#1257).
     #[must_use]
     pub fn endswith(column: &'static str, value: impl AsRef<str>) -> Self {
-        Self::predicate(
-            column,
-            Op::Like,
-            SqlValue::String(format!("%{}", value.as_ref())),
-        )
+        Self::wrap_escaped(column, "%", "", value, false)
     }
 
-    /// Django `__iendswith` — `column ILIKE '%value'`.
+    /// Django `__iendswith` — case-insensitive literal suffix match
+    /// (#1257).
     #[must_use]
     pub fn iendswith(column: &'static str, value: impl AsRef<str>) -> Self {
-        Self::predicate(
-            column,
-            Op::ILike,
-            SqlValue::String(format!("%{}", value.as_ref())),
-        )
+        Self::wrap_escaped(column, "%", "", value, true)
     }
 
     /// `column IN (v1, v2, …)`. Empty iterators are accepted at
@@ -394,7 +400,8 @@ mod tests {
         let WhereExpr::Predicate(f) = we else {
             panic!()
         };
-        assert_eq!(f.op, Op::Like);
+        // #1257 — contains escapes and pairs with the escaped op.
+        assert_eq!(f.op, Op::LikeEscaped);
         assert_eq!(f.value, SqlValue::String("%alice%".into()));
     }
 

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -17,7 +17,7 @@ use std::fmt::Write as _;
 use crate::core::{
     AggregateExpr, AggregateQuery, BulkInsertQuery, BulkUpdateQuery, CountQuery, DeleteQuery,
     Filter, InsertQuery, ModelSchema, Op, SearchClause, SelectQuery, SqlValue, UpdateQuery,
-    WhereExpr,
+    WhereExpr, LIKE_ESCAPE_CLAUSE,
 };
 
 use super::{CompiledStatement, Dialect, SqlError};
@@ -3534,12 +3534,18 @@ pub(super) fn write_where_with_search(
         // column got the bound value; subsequent ones bound to NULL
         // / empty / nothing depending on driver). Keeping per-column
         // binds also keeps the writer dialect-agnostic.
+        // Escape LIKE metacharacters in the user's `?q=` before
+        // wrapping in `%…%`, and append the ESCAPE clause per column —
+        // so a `%` or `_` typed into the admin search box matches
+        // literally instead of acting as a wildcard, on every dialect
+        // (#1257). Built once: the pattern is loop-invariant.
+        let pattern = format!("%{}%", crate::core::escape_like(&s.query));
         b.sql.push('(');
         for (i, col) in s.columns.iter().enumerate() {
             if i > 0 {
                 b.sql.push_str(" OR ");
             }
-            b.params.push(SqlValue::String(format!("%{}%", s.query)));
+            b.params.push(SqlValue::String(pattern.clone()));
             let placeholder = b.d.placeholder(b.params.len());
             // Build the qualified column identifier the same way the
             // rest of the writer does, then hand it to `write_ilike`.
@@ -3550,6 +3556,7 @@ pub(super) fn write_where_with_search(
             }
             qualified.push_str(&b.d.quote_ident(col));
             b.d.write_ilike(&mut b.sql, &qualified, &placeholder, false);
+            b.sql.push_str(LIKE_ESCAPE_CLAUSE);
         }
         b.sql.push(')');
     }
@@ -3749,6 +3756,18 @@ fn write_expr_compare(
         write_expr(b, rhs, None)?;
         return Ok(());
     }
+    // The escaped LIKE — same shape as Op::Like above plus the ESCAPE
+    // clause. Relation-spanning lookups (`author__name__contains`) land
+    // here: `resolve_span` re-parses the suffix through `parse_lookup`,
+    // which produces the escaped ops (#1257), and packs the comparison
+    // into an ExprCompare.
+    if matches!(op, Op::LikeEscaped) {
+        write_expr(b, lhs, None)?;
+        b.sql.push_str(" LIKE ");
+        write_expr(b, rhs, None)?;
+        b.sql.push_str(LIKE_ESCAPE_CLAUSE);
+        return Ok(());
+    }
 
     match op {
         Op::Search => {
@@ -3764,8 +3783,17 @@ fn write_expr_compare(
             write_expr(b, rhs, None)?;
             Ok(())
         }
-        Op::ILike | Op::NotILike => {
-            require_op(b.d, op)?;
+        Op::ILike | Op::NotILike | Op::ILikeEscaped => {
+            // ILikeEscaped shares the dialect gate + shape with ILike; it
+            // only appends the ESCAPE clause after the composed LIKE.
+            require_op(
+                b.d,
+                if matches!(op, Op::ILikeEscaped) {
+                    Op::ILike
+                } else {
+                    op
+                },
+            )?;
             // Render lhs first so its params land in the param vector
             // before the rhs literal — keeps `?`-positional dialects
             // (MySQL / SQLite) in textual order. Then carve the lhs
@@ -3784,6 +3812,9 @@ fn write_expr_compare(
             b.params.push(v.clone());
             let p = b.d.placeholder(b.params.len());
             b.d.write_ilike(&mut b.sql, &lhs_str, &p, matches!(op, Op::NotILike));
+            if matches!(op, Op::ILikeEscaped) {
+                b.sql.push_str(LIKE_ESCAPE_CLAUSE);
+            }
             Ok(())
         }
         Op::In | Op::NotIn => {
@@ -4017,8 +4048,29 @@ fn write_filter(
         Op::Gte => simple_op(b, &qualified_col, " >= ", filter.value.clone(), cast),
         Op::Like => simple_op(b, &qualified_col, " LIKE ", filter.value.clone(), cast),
         Op::NotLike => simple_op(b, &qualified_col, " NOT LIKE ", filter.value.clone(), cast),
-        Op::ILike | Op::NotILike => {
-            require_op(b.d, filter.op)?;
+        // The escaped variant carries a value produced by
+        // `core::escape_like` and MUST emit the ESCAPE clause (#1257):
+        // SQLite has no default LIKE escape character, so without it the
+        // escaping is not just ignored but wrong. `!` is the portable
+        // choice — `'\'` is not, MySQL eats it as a string-literal
+        // escape.
+        Op::LikeEscaped => {
+            simple_op(b, &qualified_col, " LIKE ", filter.value.clone(), cast);
+            b.sql.push_str(LIKE_ESCAPE_CLAUSE);
+        }
+        // ILikeEscaped shares the dialect gate + LOWER-fallback shape
+        // with ILike; it only appends the ESCAPE clause afterwards, so
+        // any future fix to the case-insensitive fallback applies to
+        // both automatically.
+        Op::ILike | Op::NotILike | Op::ILikeEscaped => {
+            require_op(
+                b.d,
+                if matches!(filter.op, Op::ILikeEscaped) {
+                    Op::ILike
+                } else {
+                    filter.op
+                },
+            )?;
             b.params.push(filter.value.clone());
             let p = b.d.placeholder(b.params.len());
             b.d.write_ilike(
@@ -4027,6 +4079,9 @@ fn write_filter(
                 &p,
                 matches!(filter.op, Op::NotILike),
             );
+            if matches!(filter.op, Op::ILikeEscaped) {
+                b.sql.push_str(LIKE_ESCAPE_CLAUSE);
+            }
         }
         Op::Regex | Op::NotRegex | Op::IRegex | Op::NotIRegex => {
             // Pattern shape is checked upstream — the typed builder
@@ -4314,6 +4369,8 @@ fn op_label(op: Op) -> &'static str {
         Op::NotLike => "NOT LIKE",
         Op::ILike => "ILIKE",
         Op::NotILike => "NOT ILIKE",
+        Op::LikeEscaped => "LIKE ... ESCAPE",
+        Op::ILikeEscaped => "ILIKE ... ESCAPE",
         Op::Between => "BETWEEN",
         Op::NotBetween => "NOT BETWEEN",
         Op::IsNull => "IS NULL",

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -2270,9 +2270,11 @@ fn resolve_active_order(
 /// subset, not the unsearched total.
 ///
 /// The `%` and `_` characters in the user's search input are
-/// escaped via the framework's `escape_like_pattern` so they
-/// match literally rather than acting as wildcards. This matches
-/// the viewset's behavior (defense against pattern injection).
+/// escaped via the framework's `core::escape_like` (paired with
+/// `Op::ILikeEscaped`, which emits `ESCAPE '!'`) so they match
+/// literally rather than acting as wildcards on any dialect (#1257).
+/// This matches the viewset's behavior (defense against pattern
+/// injection).
 fn build_list_where(
     schema: &'static ModelSchema,
     filter_fields: &[String],
@@ -2309,14 +2311,16 @@ fn build_list_where(
 
     // ILIKE search across `search_fields`, OR-combined.
     if let Some(q) = params.get("search").filter(|s| !s.is_empty()) {
-        let escaped = escape_like_pattern(q);
-        let pattern = format!("%{escaped}%");
+        // Escape LIKE metacharacters (`!`-based, portable) and pair
+        // with `Op::ILikeEscaped` so `ESCAPE '!'` is emitted — the only
+        // way the escaping is honored on SQLite (#1257).
+        let pattern = format!("%{}%", crate::core::escape_like(q));
         let mut or_branches: Vec<WhereExpr> = Vec::new();
         for name in search_fields {
             if let Some(field) = schema.field(name) {
                 or_branches.push(WhereExpr::Predicate(Filter {
                     column: field.column,
-                    op: Op::ILike,
+                    op: Op::ILikeEscaped,
                     value: SqlValue::String(pattern.clone()),
                 }));
             }
@@ -2337,28 +2341,6 @@ fn build_list_where(
     }
 }
 
-/// Escape `%` and `_` so the user's search input matches literally
-/// in `LIKE` / `ILIKE` rather than acting as wildcards. Mirrors
-/// what the viewset does with user input.
-fn escape_like_pattern(input: &str) -> String {
-    input
-        .replace('\\', r"\\")
-        .replace('%', r"\%")
-        .replace('_', r"\_")
-}
-
-/// Read or mint a CSRF token and stamp it into the Tera context as
-/// `csrf_token`. Returns the optional `Set-Cookie` header value the
-/// caller should attach to the response when the cookie was missing
-/// (so the first-ever GET to the form doesn't render an empty
-/// token, which would make the subsequent POST fail CSRF
-/// validation).
-///
-/// Without the `csrf` feature compiled in, this is a no-op:
-/// `csrf_token` is stamped as an empty string and `None` is
-/// returned. The `<input type="hidden" name="_csrf" value="">`
-/// in the rendered HTML is harmless — CSRF validation isn't
-/// enforced when the feature is off.
 fn stamp_csrf(_headers: &axum::http::HeaderMap, ctx: &mut Context) -> Option<String> {
     #[cfg(feature = "csrf")]
     {
@@ -4202,7 +4184,7 @@ mod tests {
         match where_clause {
             WhereExpr::Predicate(f) => {
                 assert_eq!(f.column, "title");
-                assert_eq!(f.op, Op::ILike);
+                assert_eq!(f.op, Op::ILikeEscaped);
                 if let SqlValue::String(p) = f.value {
                     assert!(p.contains("Hello"), "got: {p}");
                     assert!(p.starts_with('%') && p.ends_with('%'), "got: {p}");
@@ -4239,11 +4221,12 @@ mod tests {
     /// `%` and `_` in user input get escaped so they match
     /// literally rather than acting as `LIKE` wildcards.
     #[test]
-    fn escape_like_pattern_neutralizes_wildcards() {
-        assert_eq!(escape_like_pattern("100%"), r"100\%");
-        assert_eq!(escape_like_pattern("foo_bar"), r"foo\_bar");
-        assert_eq!(escape_like_pattern(r"a\b"), r"a\\b");
-        assert_eq!(escape_like_pattern("plain"), "plain");
+    fn escape_like_neutralizes_wildcards() {
+        use crate::core::escape_like;
+        assert_eq!(escape_like("100%"), "100!%");
+        assert_eq!(escape_like("foo_bar"), "foo!_bar");
+        assert_eq!(escape_like("a!b"), "a!!b");
+        assert_eq!(escape_like("plain"), "plain");
     }
 
     /// Empty `?search=` is treated as "no search" — different from

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1605,6 +1605,18 @@ fn build_lookup_filter(
     let column = field.column;
     let predicate =
         |op: Op, value: SqlValue| Some(WhereExpr::Predicate(Filter { column, op, value }));
+    // The escaped-LIKE builder: escapes the user value and pairs it with
+    // the matching `*Escaped` op in one place (#1257), so no arm can
+    // combine an escaped value with a plain `Op::Like` (or vice versa).
+    let escaped_like = |prefix: &str, suffix: &str, raw: &str, case_insensitive: bool| {
+        let escaped = crate::core::escape_like(raw);
+        let op = if case_insensitive {
+            Op::ILikeEscaped
+        } else {
+            Op::LikeEscaped
+        };
+        predicate(op, SqlValue::String(format!("{prefix}{escaped}{suffix}")))
+    };
     // #808 part 6 — six binary-comparison arms had byte-identical
     // bodies modulo the `Op` constant. Map the lookup token to its
     // `Op`, parse once, branch once.
@@ -1640,12 +1652,17 @@ fn build_lookup_filter(
             };
             predicate(op, SqlValue::List(parts))
         }
-        "contains" => predicate(Op::Like, SqlValue::String(format!("%{raw}%"))),
-        "icontains" => predicate(Op::ILike, SqlValue::String(format!("%{raw}%"))),
-        "startswith" => predicate(Op::Like, SqlValue::String(format!("{raw}%"))),
-        "istartswith" => predicate(Op::ILike, SqlValue::String(format!("{raw}%"))),
-        "endswith" => predicate(Op::Like, SqlValue::String(format!("%{raw}"))),
-        "iendswith" => predicate(Op::ILike, SqlValue::String(format!("%{raw}"))),
+        // Escape LIKE metacharacters in `raw` (URL-supplied) so `%`/`_`
+        // match literally, and pair with the *Escaped ops so the ESCAPE
+        // clause is emitted — required for correctness on SQLite
+        // (#1257). One helper owns the escape⟷op pairing so a future
+        // arm cannot mismatch them.
+        "contains" => escaped_like("%", "%", raw, false),
+        "icontains" => escaped_like("%", "%", raw, true),
+        "startswith" => escaped_like("", "%", raw, false),
+        "istartswith" => escaped_like("", "%", raw, true),
+        "endswith" => escaped_like("%", "", raw, false),
+        "iendswith" => escaped_like("%", "", raw, true),
         "isnull" => {
             let is_null = matches!(raw.to_ascii_lowercase().as_str(), "true" | "1" | "yes");
             predicate(Op::IsNull, SqlValue::Bool(is_null))
@@ -2824,14 +2841,14 @@ mod lookup_tests {
     fn contains_wraps_with_percents_and_uses_like() {
         let f =
             extract_pred(build_lookup_filter(string_field(), Some("contains"), "hello").unwrap());
-        assert_eq!(f.op, Op::Like);
+        assert_eq!(f.op, Op::LikeEscaped);
         assert!(matches!(f.value, SqlValue::String(ref s) if s == "%hello%"));
     }
 
     #[test]
     fn icontains_uses_ilike() {
         let f = extract_pred(build_lookup_filter(string_field(), Some("icontains"), "hi").unwrap());
-        assert_eq!(f.op, Op::ILike);
+        assert_eq!(f.op, Op::ILikeEscaped);
         assert!(matches!(f.value, SqlValue::String(ref s) if s == "%hi%"));
     }
 

--- a/crates/rustango/tests/filter_lookup.rs
+++ b/crates/rustango/tests/filter_lookup.rs
@@ -70,7 +70,11 @@ fn gt_gte_lt_lte_ne_map_directly() {
 fn contains_wraps_value_in_percent() {
     let qs = Post::objects().filter("title__contains", "rust");
     let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
-    assert!(stmt.sql.contains(r#""title" LIKE $1"#), "got: {}", stmt.sql);
+    assert!(
+        stmt.sql.contains(r#""title" LIKE $1 ESCAPE '!'"#),
+        "got: {}",
+        stmt.sql
+    );
     assert_eq!(stmt.params, vec![SqlValue::String("%rust%".into())]);
 }
 
@@ -79,7 +83,7 @@ fn icontains_uses_ilike_with_percent_wrap() {
     let qs = Post::objects().filter("title__icontains", "rust");
     let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
     assert!(
-        stmt.sql.contains(r#""title" ILIKE $1"#),
+        stmt.sql.contains(r#""title" ILIKE $1 ESCAPE '!'"#),
         "got: {}",
         stmt.sql
     );
@@ -90,7 +94,7 @@ fn icontains_uses_ilike_with_percent_wrap() {
 fn startswith_wraps_value_with_trailing_percent_only() {
     let qs = Post::objects().filter("title__startswith", "Hello");
     let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
-    assert!(stmt.sql.contains(r#""title" LIKE $1"#));
+    assert!(stmt.sql.contains(r#""title" LIKE $1 ESCAPE '!'"#));
     assert_eq!(stmt.params, vec![SqlValue::String("Hello%".into())]);
 }
 
@@ -98,8 +102,9 @@ fn startswith_wraps_value_with_trailing_percent_only() {
 fn endswith_wraps_value_with_leading_percent_only() {
     let qs = Post::objects().filter("title__endswith", "!");
     let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
-    assert!(stmt.sql.contains(r#""title" LIKE $1"#));
-    assert_eq!(stmt.params, vec![SqlValue::String("%!".into())]);
+    assert!(stmt.sql.contains(r#""title" LIKE $1 ESCAPE '!'"#));
+    // "!" is the escape char, so it is doubled: %!! matches a literal "!".
+    assert_eq!(stmt.params, vec![SqlValue::String("%!!".into())]);
 }
 
 #[test]
@@ -122,9 +127,126 @@ fn istartswith_iendswith_use_ilike() {
         stmt.params,
         vec![
             SqlValue::String("Hello%".into()),
-            SqlValue::String("%!".into()),
+            SqlValue::String("%!!".into()),
         ]
     );
+}
+
+// ---------- #1257: LIKE metacharacter escaping (tri-dialect) ----------
+
+#[test]
+fn escape_char_clause_and_helper_agree() {
+    // The escape char, the emitted ESCAPE clause, and the helper must
+    // never drift apart — each would silently corrupt the others.
+    use rustango::core::{escape_like, LIKE_ESCAPE_CHAR, LIKE_ESCAPE_CLAUSE};
+    assert_eq!(
+        LIKE_ESCAPE_CLAUSE,
+        format!(" ESCAPE '{LIKE_ESCAPE_CHAR}'"),
+        "clause must embed the escape char",
+    );
+    let e = LIKE_ESCAPE_CHAR;
+    assert_eq!(escape_like("%_"), format!("{e}%{e}_"));
+    assert_eq!(escape_like(&e.to_string()), format!("{e}{e}"));
+}
+
+#[test]
+fn contains_escapes_wildcards_in_user_value() {
+    // A `%` or `_` in the value must be neutralised so it matches
+    // literally — otherwise `50%` would match "50 then anything".
+    let qs = Post::objects().filter("title__contains", "50%_x");
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#""title" LIKE $1 ESCAPE '!'"#),
+        "{}",
+        stmt.sql
+    );
+    // 50 !% (escaped %) !_ (escaped _) x, wrapped in unescaped %…%.
+    assert_eq!(stmt.params, vec![SqlValue::String("%50!%!_x%".into())]);
+}
+
+#[test]
+fn escaped_like_emits_escape_clause_on_every_dialect() {
+    let qs = Post::objects().filter("title__contains", "a%b");
+    let pg = Postgres
+        .compile_select(&qs.clone().compile().unwrap())
+        .unwrap();
+    let my = MySql
+        .compile_select(&qs.clone().compile().unwrap())
+        .unwrap();
+    let sq = Sqlite.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(pg.sql.contains("LIKE $1 ESCAPE '!'"), "pg: {}", pg.sql);
+    assert!(my.sql.contains("LIKE ? ESCAPE '!'"), "mysql: {}", my.sql);
+    assert!(sq.sql.contains("LIKE ? ESCAPE '!'"), "sqlite: {}", sq.sql);
+    // All three escape the value identically.
+    for stmt in [&pg, &my, &sq] {
+        assert_eq!(stmt.params, vec![SqlValue::String("%a!%b%".into())]);
+    }
+}
+
+#[test]
+fn icontains_escape_clause_survives_the_ilike_fallback() {
+    // On MySQL/SQLite icontains lowers to LOWER(col) LIKE LOWER(?);
+    // the ESCAPE clause must still be appended after the fallback.
+    let qs = Post::objects().filter("title__icontains", "x_y");
+    let my = MySql
+        .compile_select(&qs.clone().compile().unwrap())
+        .unwrap();
+    let sq = Sqlite.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        my.sql.contains("LIKE LOWER(?) ESCAPE '!'"),
+        "mysql: {}",
+        my.sql
+    );
+    assert!(
+        sq.sql.contains("LIKE LOWER(?) ESCAPE '!'"),
+        "sqlite: {}",
+        sq.sql
+    );
+    for stmt in [&my, &sq] {
+        assert_eq!(stmt.params, vec![SqlValue::String("%x!_y%".into())]);
+    }
+}
+
+#[test]
+fn iexact_escapes_wildcards_as_literal_equality() {
+    // iexact is case-insensitive EQUALITY — a `%` in the value must not
+    // act as a wildcard (pre-#1257 fix, `email__iexact` with `%`
+    // matched every row).
+    let qs = Post::objects().filter("title__iexact", "50%");
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(
+        stmt.sql.contains(r#""title" ILIKE $1 ESCAPE '!'"#),
+        "{}",
+        stmt.sql
+    );
+    assert_eq!(stmt.params, vec![SqlValue::String("50!%".into())]);
+}
+
+#[test]
+fn q_builder_contains_escapes_wildcards() {
+    use rustango::query::{QuerySet, Q};
+    // The OR-composition API must escape exactly like .filter() does.
+    let qs: QuerySet<Post> =
+        QuerySet::default().where_(Q::icontains("title", "a%b") | Q::contains("status", "x_y"));
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(stmt.sql.contains("ESCAPE '!'"), "{}", stmt.sql);
+    assert!(stmt.params.contains(&SqlValue::String("%a!%b%".into())));
+    assert!(stmt.params.contains(&SqlValue::String("%x!_y%".into())));
+}
+
+#[test]
+fn raw_like_lookup_is_not_escaped() {
+    // The raw `__like` lookup binds the caller's pattern verbatim —
+    // no escaping, no ESCAPE clause (they own the wildcards).
+    let qs = Post::objects().filter("title__like", "%foo_bar%");
+    let stmt = Postgres.compile_select(&qs.compile().unwrap()).unwrap();
+    assert!(stmt.sql.contains(r#""title" LIKE $1"#), "{}", stmt.sql);
+    assert!(
+        !stmt.sql.contains("ESCAPE"),
+        "raw like must NOT add ESCAPE: {}",
+        stmt.sql
+    );
+    assert_eq!(stmt.params, vec![SqlValue::String("%foo_bar%".into())]);
 }
 
 // ---------- __in / __isnull / __between ----------

--- a/crates/rustango/tests/like_escape_live.rs
+++ b/crates/rustango/tests/like_escape_live.rs
@@ -1,0 +1,155 @@
+//! #1257 — LIKE metacharacter escaping must be honored by the database,
+//! on every dialect. Emission is pinned by `filter_lookup.rs`; this file
+//! proves the `ESCAPE '!'` clause actually makes `%` / `_` match
+//! literally against a real backend.
+//!
+//! SQLite (embedded) always runs — it was the previously-broken dialect
+//! (no default LIKE escape char). Postgres runs when `DATABASE_URL` is
+//! set, MySQL when `MYSQL_TEST_URL` is set; both skip silently otherwise.
+
+#![cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
+
+use rustango::query::QuerySet;
+use rustango::sql::{sqlx, Auto, FetcherPool, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "les_item")]
+#[allow(dead_code)]
+pub struct Item {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 80)]
+    pub name: String,
+}
+
+const ROWS: &[&str] = &["100%", "1000", "a_b", "axb", "50!off", "plain"];
+
+async fn seed(pool: &Pool) {
+    for name in ROWS {
+        let mut it = Item {
+            id: Auto::default(),
+            name: (*name).into(),
+        };
+        it.save_pool(pool).await.unwrap();
+    }
+}
+
+async fn names(pool: &Pool, lookup: &str, value: &str) -> Vec<String> {
+    let mut rows: Vec<String> = QuerySet::<Item>::default()
+        .filter(lookup, value)
+        .fetch(pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|i| i.name)
+        .collect();
+    rows.sort();
+    rows
+}
+
+/// The whole point (#1257): `%` and `_` in the search value match
+/// literally, not as wildcards — on every dialect the caller ran.
+async fn run_matrix(pool: Pool, dialect: &str) {
+    seed(&pool).await;
+
+    // `%` is literal: "100%" must match only itself, NOT "1000".
+    assert_eq!(
+        names(&pool, "name__contains", "100%").await,
+        vec!["100%".to_string()],
+        "[{dialect}] `%` leaked as a wildcard",
+    );
+
+    // `_` is literal: "a_b" must match only itself, NOT "axb".
+    assert_eq!(
+        names(&pool, "name__contains", "a_b").await,
+        vec!["a_b".to_string()],
+        "[{dialect}] `_` leaked as a wildcard",
+    );
+
+    // The escape char itself (`!`) is literal.
+    assert_eq!(
+        names(&pool, "name__contains", "50!off").await,
+        vec!["50!off".to_string()],
+        "[{dialect}] `!` (the escape char) was mishandled",
+    );
+
+    // iexact is case-insensitive EQUALITY: `%` must not wildcard.
+    assert_eq!(
+        names(&pool, "name__iexact", "100%").await,
+        vec!["100%".to_string()],
+        "[{dialect}] iexact let `%` act as a wildcard",
+    );
+    assert_eq!(
+        names(&pool, "name__iexact", "%").await,
+        Vec::<String>::new(),
+        "[{dialect}] iexact with a lone `%` matched rows",
+    );
+
+    // Case-insensitive path (ILIKE / LOWER-LIKE fallback) escapes too.
+    assert_eq!(
+        names(&pool, "name__icontains", "A_B").await,
+        vec!["a_b".to_string()],
+        "[{dialect}] icontains did not escape `_`",
+    );
+
+    // Sanity: a plain substring still matches as a substring.
+    assert_eq!(
+        names(&pool, "name__contains", "00").await,
+        vec!["100%".to_string(), "1000".to_string()],
+        "[{dialect}] literal substring match regressed",
+    );
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn sqlite_honors_like_escape() {
+    let p = sqlx::SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    sqlx::query("CREATE TABLE les_item (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)")
+        .execute(&p)
+        .await
+        .unwrap();
+    run_matrix(Pool::Sqlite(p), "sqlite").await;
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_honors_like_escape() {
+    let Ok(url) = std::env::var("DATABASE_URL") else {
+        return;
+    };
+    let p = sqlx::PgPool::connect(&url).await.expect("connect PG");
+    sqlx::query(r#"DROP TABLE IF EXISTS "les_item" CASCADE"#)
+        .execute(&p)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"CREATE TABLE "les_item" ("id" BIGSERIAL PRIMARY KEY, "name" VARCHAR(80) NOT NULL)"#,
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    run_matrix(Pool::Postgres(p), "postgres").await;
+}
+
+#[cfg(feature = "mysql")]
+#[tokio::test]
+async fn mysql_honors_like_escape() {
+    let Ok(url) = std::env::var("MYSQL_TEST_URL") else {
+        return;
+    };
+    let p = sqlx::MySqlPool::connect(&url).await.expect("connect MySQL");
+    sqlx::query("DROP TABLE IF EXISTS les_item")
+        .execute(&p)
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE TABLE les_item (id BIGINT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(80) NOT NULL)",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    run_matrix(Pool::Mysql(p), "mysql").await;
+}

--- a/crates/rustango/tests/q_macro.rs
+++ b/crates/rustango/tests/q_macro.rs
@@ -99,11 +99,12 @@ fn gt_gte_lt_lte_lower_to_comparison_methods() {
 
 #[test]
 fn icontains_wraps_with_percent_and_uses_ilike() {
+    // #1257 — the escaped typed method is the equivalence now.
     let qs_macro = base_qs().where_(Q!(User.email__icontains = "alice"));
-    let qs_typed = base_qs().where_(User::email.ilike("%alice%"));
+    let qs_typed = base_qs().where_(User::email.icontains("alice"));
     let sql_macro = compile_pg(qs_macro);
     let sql_typed = compile_pg(qs_typed);
-    assert_eq!(sql_macro, sql_typed, "Q!() must match hand-rolled ILIKE");
+    assert_eq!(sql_macro, sql_typed, "Q!() must match Column::icontains");
     assert!(
         sql_macro.contains("ILIKE"),
         "expected ILIKE in: {sql_macro}"
@@ -112,8 +113,10 @@ fn icontains_wraps_with_percent_and_uses_ilike() {
 
 #[test]
 fn contains_uses_like_with_percent_wrap() {
+    // #1257 — the macro delegates to the escaped typed method, so the
+    // hand-rolled equivalent is Column::contains, not raw like().
     let qs_macro = base_qs().where_(Q!(User.email__contains = "alice"));
-    let qs_typed = base_qs().where_(User::email.like("%alice%"));
+    let qs_typed = base_qs().where_(User::email.contains("alice"));
     assert_eq!(compile_pg(qs_macro), compile_pg(qs_typed));
 }
 
@@ -121,19 +124,19 @@ fn contains_uses_like_with_percent_wrap() {
 fn startswith_and_endswith_lower_correctly() {
     assert_eq!(
         compile_pg(base_qs().where_(Q!(User.email__startswith = "ali"))),
-        compile_pg(base_qs().where_(User::email.like("ali%"))),
+        compile_pg(base_qs().where_(User::email.startswith("ali"))),
     );
     assert_eq!(
         compile_pg(base_qs().where_(Q!(User.email__endswith = ".com"))),
-        compile_pg(base_qs().where_(User::email.like("%.com"))),
+        compile_pg(base_qs().where_(User::email.endswith(".com"))),
     );
     assert_eq!(
         compile_pg(base_qs().where_(Q!(User.email__istartswith = "ali"))),
-        compile_pg(base_qs().where_(User::email.ilike("ali%"))),
+        compile_pg(base_qs().where_(User::email.istartswith("ali"))),
     );
     assert_eq!(
         compile_pg(base_qs().where_(Q!(User.email__iendswith = ".COM"))),
-        compile_pg(base_qs().where_(User::email.ilike("%.COM"))),
+        compile_pg(base_qs().where_(User::email.iendswith(".COM"))),
     );
 }
 

--- a/crates/rustango/tests/sql.rs
+++ b/crates/rustango/tests/sql.rs
@@ -736,7 +736,7 @@ fn search_alone_emits_or_chain_with_one_param_per_column() {
     // a hair more explicit.
     assert_eq!(
         stmt.sql,
-        r#"SELECT "id", "name", "is_active" FROM "user" WHERE ("name" ILIKE $1 OR "is_active" ILIKE $2)"#,
+        r#"SELECT "id", "name", "is_active" FROM "user" WHERE ("name" ILIKE $1 ESCAPE '!' OR "is_active" ILIKE $2 ESCAPE '!')"#,
     );
     assert_eq!(
         stmt.params,
@@ -764,7 +764,7 @@ fn search_combined_with_filter_uses_and() {
     let stmt = pg().compile_select(&q).unwrap();
     assert_eq!(
         stmt.sql,
-        r#"SELECT "id", "name", "is_active" FROM "user" WHERE "is_active" = $1 AND ("name" ILIKE $2)"#,
+        r#"SELECT "id", "name", "is_active" FROM "user" WHERE "is_active" = $1 AND ("name" ILIKE $2 ESCAPE '!')"#,
     );
     assert_eq!(
         stmt.params,
@@ -813,7 +813,7 @@ fn search_with_limit_offset_orders_clauses_correctly() {
     let stmt = pg().compile_select(&q).unwrap();
     assert_eq!(
         stmt.sql,
-        r#"SELECT "id", "name", "is_active" FROM "user" WHERE ("name" ILIKE $1) LIMIT 10 OFFSET 20"#,
+        r#"SELECT "id", "name", "is_active" FROM "user" WHERE ("name" ILIKE $1 ESCAPE '!') LIMIT 10 OFFSET 20"#,
     );
 }
 
@@ -906,7 +906,8 @@ fn join_with_search_qualifies_search_columns() {
     };
     let stmt = pg().compile_select(&q).unwrap();
     assert!(
-        stmt.sql.contains(r#"WHERE ("post"."title" ILIKE $1)"#),
+        stmt.sql
+            .contains(r#"WHERE ("post"."title" ILIKE $1 ESCAPE '!')"#),
         "search column not qualified: {}",
         stmt.sql,
     );

--- a/docs/de/orm.md
+++ b/docs/de/orm.md
@@ -1700,6 +1700,8 @@ Post::objects().where_(Post::author_id.eq(42));
 | `__between` / `__range` | `BETWEEN … AND …` | 2-elementige `SqlValue::List` | an beiden Enden inklusiv |
 | `__regex` / `__iregex` | PG `~` / `~*`, MySQL/SQLite `REGEXP` | String | case-insensitiv emuliert auf MySQL/SQLite über `LOWER()`-Umschließung; SQLite braucht eine `regexp`-User-Funktion |
 
+> **LIKE-Metazeichen werden escaped.** `__contains` / `__startswith` / `__endswith` (und ihre `i`-Varianten) behandeln den Wert als **wörtlichen** Teilstring — ein `%` oder `_` darin passt auf sich selbst, nicht als Platzhalter, wie in Django. Das Framework escaped sie und gibt `ESCAPE '!'` aus, auf allen drei Dialekten wirksam (#1257). Für ein rohes Muster mit eigenen `%` / `_` nutze `__like` / `__ilike`, die den Wert wörtlich binden.
+
 **Fehler tauchen bei `.compile()` auf, nicht zur `.filter()`-Aufrufzeit** — Wertform-Diskrepanzen (z. B. `__in` mit einem Skalar, `__isnull` mit einem Nicht-Bool, `__between` mit falscher Stelligkeit) und unbekannte Suffixe (`status__nope`) geben `QueryError::UnknownLookup` / `QueryError::InvalidLookupValue` von `.compile()` zurück, sodass die fluente Kette typsauber bleibt. Verkettete Traversierungen (`author__name__icontains`) werden in v0.39 **nicht** unterstützt — der Splitter nimmt das Suffix nach dem ersten `__`, sodass der ganze Schwanz `name__icontains` als unbekanntes Suffix behandelt wird.
 
 Jeder Filteraufruf wird per AND mit allen vorhergehenden verknüpft; mische Django-Form, `filter_op` und `where_` frei auf demselben Queryset.

--- a/docs/es/orm.md
+++ b/docs/es/orm.md
@@ -1700,6 +1700,8 @@ Post::objects().where_(Post::author_id.eq(42));
 | `__between` / `__range` | `BETWEEN … AND …` | `SqlValue::List` de 2 elementos | inclusivo en ambos extremos |
 | `__regex` / `__iregex` | PG `~` / `~*`, MySQL/SQLite `REGEXP` | string | insensible a mayúsculas emulado en MySQL/SQLite vía envoltura `LOWER()`; SQLite necesita una función de usuario `regexp` |
 
+> **Los metacaracteres de LIKE se escapan.** `__contains` / `__startswith` / `__endswith` (y sus variantes `i`) tratan el valor como una subcadena **literal** — un `%` o `_` en él coincide consigo mismo, no como comodín, igual que en Django. El framework los escapa y emite `ESCAPE '!'`, respetado en los tres dialectos (#1257). Para un patrón crudo donde tú colocas tus `%` / `_`, usa `__like` / `__ilike`, que vinculan el valor literalmente.
+
 **Los errores se exponen en `.compile()`, no en el momento de la llamada a `.filter()`** — los desajustes de forma de valor (p. ej. `__in` con un escalar, `__isnull` con un no-bool, `__between` con la aridad equivocada) y los sufijos desconocidos (`status__nope`) devuelven `QueryError::UnknownLookup` / `QueryError::InvalidLookupValue` desde `.compile()` para que la cadena fluida se mantenga limpia de tipos. Los recorridos encadenados (`author__name__icontains`) **no** están soportados en v0.39 — el splitter toma el sufijo después del primer `__`, así que toda la cola `name__icontains` se trata como un sufijo desconocido.
 
 Cada llamada de filtro se une con AND a cualquier anterior; mezcla la forma de Django, `filter_op` y `where_` libremente en el mismo queryset.

--- a/docs/fr/orm.md
+++ b/docs/fr/orm.md
@@ -1700,6 +1700,8 @@ Post::objects().where_(Post::author_id.eq(42));
 | `__between` / `__range` | `BETWEEN … AND …` | `SqlValue::List` à 2 éléments | inclusif aux deux bornes |
 | `__regex` / `__iregex` | PG `~` / `~*`, MySQL/SQLite `REGEXP` | chaîne | insensible à la casse émulé sur MySQL/SQLite via encapsulation `LOWER()` ; SQLite nécessite une fonction utilisateur `regexp` |
 
+> **Les métacaractères de LIKE sont échappés.** `__contains` / `__startswith` / `__endswith` (et leurs variantes `i`) traitent la valeur comme une sous-chaîne **littérale** — un `%` ou `_` y correspond à lui-même, pas comme joker, comme dans Django. Le framework les échappe et émet `ESCAPE '!'`, respecté sur les trois dialectes (#1257). Pour un motif brut où vous placez vos propres `%` / `_`, utilisez `__like` / `__ilike`, qui lient la valeur telle quelle.
+
 **Les erreurs remontent à `.compile()`, pas au moment de l'appel `.filter()`** — les incohérences de forme de valeur (p. ex. `__in` avec un scalaire, `__isnull` avec un non-bool, `__between` avec la mauvaise arité) et les suffixes inconnus (`status__nope`) renvoient `QueryError::UnknownLookup` / `QueryError::InvalidLookupValue` depuis `.compile()` afin que la chaîne fluide reste propre au niveau du typage. Les traversées chaînées (`author__name__icontains`) ne sont **pas** prises en charge en v0.39 — le séparateur prend le suffixe après le premier `__`, donc toute la queue `name__icontains` est traitée comme un suffixe inconnu.
 
 Chaque appel de filtre se joint par AND à ceux qui le précèdent ; mélangez librement forme Django, `filter_op` et `where_` sur le même queryset.

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1700,6 +1700,8 @@ Post::objects().where_(Post::author_id.eq(42));
 | `__between` / `__range` | `BETWEEN … AND …` | 2-elt `SqlValue::List` | inclusive on both ends |
 | `__regex` / `__iregex` | PG `~` / `~*`, MySQL/SQLite `REGEXP` | string | case-insensitive emulated on MySQL/SQLite via `LOWER()` wrap; SQLite needs a `regexp` user-function |
 
+> **LIKE metacharacters are escaped.** `__contains` / `__startswith` / `__endswith` (and their `i` variants) treat the value as a **literal** substring — a `%` or `_` in it matches itself, not as a wildcard, matching Django. The framework escapes them and emits `ESCAPE '!'`, honored on all three dialects (#1257). For a raw pattern where you place your own `%` / `_`, use `__like` / `__ilike`, which bind the value verbatim.
+
 **Errors surface at `.compile()`, not at `.filter()` call time** — value-shape mismatches (e.g. `__in` with a scalar, `__isnull` with a non-bool, `__between` with the wrong arity) and unknown suffixes (`status__nope`) return `QueryError::UnknownLookup` / `QueryError::InvalidLookupValue` from `.compile()` so the fluent chain stays type-clean. Chained traversals (`author__name__icontains`) are **not** supported in v0.39 — the splitter takes the suffix after the first `__`, so the whole tail `name__icontains` is treated as an unknown suffix.
 
 Each filter call AND-joins to any preceding ones; mix Django-shape, `filter_op`, and `where_` freely on the same queryset.


### PR DESCRIPTION
Promote develop → main for 0.55.0 (bump in #1269). merge-tree verified: result tree == develop tree, no main-only content survives. Merge as a merge commit.