### PR TITLE
fix(viewset): derive router() takes Into<Pool>, not PgPool (#1273)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,9 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_none
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_exclude_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test sqlmigrate
+      # #1273 — derive(ViewSet) must compile with no postgres feature.
+      - run: cargo test -p rustango --no-default-features --features sqlite,admin --test viewset_derive_pool_tridialect_compile --no-run
+      - run: cargo test -p rustango --no-default-features --features mysql,admin --test viewset_derive_pool_tridialect_compile --no-run
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_set_ops
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test set_algebra_emission
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test migrate_runpython_sqlite_live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Also: README install snippets bumped to the current version (docs.rs renders the
 README as the crate landing page).
 
 ### Fixed
+- **`#[derive(ViewSet)]` failed to compile without the `postgres` feature**
+  (#1273). The generated `router()` named `sqlx::PgPool`, so any sqlite/mysql-only
+  project got `cannot find type PgPool`. It now takes `impl Into<sql::Pool>` and
+  calls `router_pool`, accepting every backend's pool (PG callers unaffected). A
+  tri-dialect compile test — run under sqlite-only and mysql-only in CI — guards
+  it; the old derive test was `postgres`-gated, so nothing caught this.
 - **LIKE lookups did not escape user wildcards, on any dialect** (#1257).
   `__contains` / `__startswith` / `__endswith` (and the admin/viewset `?q=`
   search and `template_views` list search) built `%value%` from raw user input

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -12530,7 +12530,16 @@ fn expand_viewset(input: &DeriveInput) -> syn::Result<TokenStream2> {
         impl #struct_name {
             /// Build an `axum::Router` with the six standard REST endpoints
             /// for this ViewSet, mounted at `prefix`.
-            pub fn router(prefix: &str, pool: #root::sql::sqlx::PgPool) -> #root::__axum::Router {
+            ///
+            /// Accepts any backend's pool — a `sqlx::PgPool`,
+            /// `SqlitePool`, `MySqlPool`, or the [`rustango::sql::Pool`]
+            /// enum — because they all `Into<Pool>` (#1273). This is why
+            /// the derive no longer names `PgPool`, which would not
+            /// exist on a project built without the `postgres` feature.
+            pub fn router(
+                prefix: &str,
+                pool: impl ::core::convert::Into<#root::sql::Pool>,
+            ) -> #root::__axum::Router {
                 #root::viewset::ViewSet::for_model(
                     <#model_path as #root::core::Model>::SCHEMA
                 )
@@ -12542,7 +12551,7 @@ fn expand_viewset(input: &DeriveInput) -> syn::Result<TokenStream2> {
                     #perms_call
                     #read_only_call
                     #serializer_call
-                    .router(prefix, pool)
+                    .router_pool(prefix, pool.into())
             }
         }
     })

--- a/crates/rustango/tests/viewset_derive_pool_tridialect_compile.rs
+++ b/crates/rustango/tests/viewset_derive_pool_tridialect_compile.rs
@@ -1,0 +1,43 @@
+//! #1273 regression: `#[derive(ViewSet)]`'s `router()` must not name a
+//! backend-specific pool, so a derive compiles on ANY single backend.
+//! It previously named `sqlx::PgPool` and broke every sqlite/mysql-only
+//! project. One `router()` fn per dialect, each cfg'd to its feature so
+//! it is exercised in that backend's build (the sqlite/mysql arms are
+//! the ones that regress without postgres present).
+
+#![cfg(feature = "admin")]
+
+use rustango::sql::Auto;
+use rustango::{Model, ViewSet};
+
+#[derive(Model, Clone)]
+#[rustango(table = "vs_pool_post")]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+#[derive(ViewSet)]
+#[viewset(model = Post)]
+pub struct PostViewSet;
+
+// Compile-only: router() accepts each backend's pool via Into<Pool>.
+#[cfg(feature = "postgres")]
+#[allow(dead_code)]
+fn _pg(pool: rustango::sql::sqlx::PgPool) -> axum::Router {
+    PostViewSet::router("/api/posts", pool)
+}
+
+#[cfg(feature = "sqlite")]
+#[allow(dead_code)]
+fn _sqlite(pool: rustango::sql::sqlx::SqlitePool) -> axum::Router {
+    PostViewSet::router("/api/posts", pool)
+}
+
+#[cfg(feature = "mysql")]
+#[allow(dead_code)]
+fn _mysql(pool: rustango::sql::sqlx::MySqlPool) -> axum::Router {
+    PostViewSet::router("/api/posts", pool)
+}


### PR DESCRIPTION
Closes #1273. Reported by @asaph1214-lang on a SQLite-only 0.55.0 project.

`#[derive(ViewSet)]`'s generated `router()` named `sqlx::PgPool`, so any project without the `postgres` feature failed with `cannot find type PgPool`. Now takes `impl Into<sql::Pool>` → `router_pool`; every backend's pool works (PG callers unchanged, all `From<*Pool> for Pool` exist).

**Why tests missed it:** the only derive test was `#![cfg(feature = "postgres")]` and called `router(_, PgPool)` — gated to the config where the bug can't occur. The 17 `viewset_*_sqlite_live` tests build the ViewSet manually (0 use the derive), and `feature_combos` builds `--lib` only. So the generated `router()` was never compiled without postgres.

Adds a tri-dialect compile test run under **sqlite-only and mysql-only in CI** — verified it fails on the old code.