### PR TITLE
feat(mcp): bring the raw prefix.secret bearer credential onto develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+### Added
+- **MCP: the raw `prefix.secret` credential is accepted as the Bearer token.**
+  A show-once agent key now works directly in any MCP client
+  (`Authorization: Bearer <prefix.secret>`) with no `POST /mcp/token` exchange
+  step. New `mcp::verify_raw_agent_credential` and
+  `tenancy::authenticate_agent_by_prefix_pool` (lookup by secret prefix rather
+  than agent name — a bearer client never knows the agent's name; fail-closed
+  and timing-neutral, burning a dummy argon2 verify on unknown prefixes per
+  #1099).
+
+  On this path liveness **and** grant resolution run on *every* request, so
+  capabilities always track the owner's live RBAC and revocation applies
+  immediately — strictly fresher than a minted JWT's claim snapshot. Only the
+  argon2 hash check is memoised, in a bounded process-local cache (256 entries,
+  60s TTL) keyed by `sha256(tenant \0 token)` so a credential verified for one
+  tenant can never authenticate against another. A malformed bearer is rejected
+  by a shape gate before any DB or argon2 work. The JWT path is tried first and
+  is unchanged.
+
+  **Deployment note:** because unknown prefixes deliberately burn a dummy argon2
+  verify to stay timing-neutral, set `[mcp] rate_limit_per_minute` in production
+  to bound the verification work an unauthenticated caller can induce.
+
+### Changed
+- **`[mcp] max_body_bytes` is now configurable** (default unchanged at 1 MiB,
+  still tighter than axum's 2 MiB). Raise it for tools that accept inline
+  payloads such as base64 media uploads; it was previously a hard-coded const.
+
 ## [0.55.0] — 2026-08-31
 
 Follows 0.54.0 with the LIKE-escaping correctness fix and a README version

--- a/crates/rustango/src/config/sections.rs
+++ b/crates/rustango/src/config/sections.rs
@@ -175,6 +175,9 @@ pub struct McpSettings {
     pub rate_limit_per_minute: Option<u32>,
     /// Max tools returned by `tools/list` (`None` = unlimited).
     pub max_tools_listed: Option<usize>,
+    /// Max JSON-RPC request body in bytes. Default 1 MiB — raise it when a
+    /// tool accepts inline payloads (e.g. base64 media uploads).
+    pub max_body_bytes: Option<usize>,
 }
 
 impl McpSettings {
@@ -192,6 +195,11 @@ impl McpSettings {
     #[must_use]
     pub fn sse_enabled(&self) -> bool {
         self.enable_sse.unwrap_or(true)
+    }
+    /// Request-body cap in bytes, defaulting to 1 MiB.
+    #[must_use]
+    pub fn max_body_bytes(&self) -> usize {
+        self.max_body_bytes.unwrap_or(1024 * 1024)
     }
 }
 

--- a/crates/rustango/src/mcp/auth.rs
+++ b/crates/rustango/src/mcp/auth.rs
@@ -236,23 +236,39 @@ pub(crate) async fn post_authed(
     let Some(token) = bearer(&headers) else {
         return unauthorized(&headers, &uri);
     };
-    let Some(agent) = verify_agent_token(jwt, token, &t.org.slug).await else {
-        return unauthorized(&headers, &uri);
-    };
-    // Revocation immediacy: the JWT is stateless, so re-check at request time
-    // that the agent (and, for a user-owned key, its owner) still exists and is
-    // active. A revoked / deactivated key is refused straight away rather than
-    // lingering until the token expires.
-    match crate::tenancy::agent_token_still_valid_pool(t.pool(), agent.agent_id, agent.user_id)
-        .await
-    {
-        Ok(true) => {}
-        Ok(false) => return unauthorized(&headers, &uri),
-        Err(e) => {
-            tracing::warn!(error = %e, "mcp agent liveness re-check failed");
-            return (StatusCode::INTERNAL_SERVER_ERROR, "auth check failed").into_response();
+    // Two accepted bearer shapes: a minted agent JWT, or the raw
+    // `name.secret` credential itself (#1272) — the copy-paste key a member
+    // generates in an app's UI works directly in any MCP client without a
+    // token-exchange step. The raw path verifies liveness and resolves grants
+    // per request inside [`verify_raw_agent_credential`], so RBAC changes and
+    // revocation apply immediately (no 15-minute JWT window).
+    let agent = match verify_agent_token(jwt, token, &t.org.slug).await {
+        Some(agent) => {
+            // Revocation immediacy: the JWT is stateless, so re-check at
+            // request time that the agent (and, for a user-owned key, its
+            // owner) still exists and is active. A revoked / deactivated key
+            // is refused straight away rather than lingering until expiry.
+            match crate::tenancy::agent_token_still_valid_pool(
+                t.pool(),
+                agent.agent_id,
+                agent.user_id,
+            )
+            .await
+            {
+                Ok(true) => agent,
+                Ok(false) => return unauthorized(&headers, &uri),
+                Err(e) => {
+                    tracing::warn!(error = %e, "mcp agent liveness re-check failed");
+                    return (StatusCode::INTERNAL_SERVER_ERROR, "auth check failed")
+                        .into_response();
+                }
+            }
         }
-    }
+        None => match verify_raw_agent_credential(t.pool(), &t.org.slug, token).await {
+            Some(agent) => agent,
+            None => return unauthorized(&headers, &uri),
+        },
+    };
     // Agent verified + tenant-pinned: hand the tools layer the resolved
     // tenant pool + principal so `tools/call` runs against the right tenant.
     let ctx = super::tools::McpContext {
@@ -263,6 +279,137 @@ pub(crate) async fn post_authed(
         cancel: super::progress::CancelToken::never(),
     };
     handle_message(&state, &body, Some(ctx)).await
+}
+
+/// Resolve a raw `name.secret` agent credential presented directly as the
+/// Bearer token (#1272). Returns the same [`McpAgent`] shape
+/// [`verify_agent_token`] yields, or `None` for any failure — fail-closed.
+///
+/// This is the copy-paste path: the show-once key a member generates works
+/// directly in any MCP client (`Authorization: Bearer <prefix.secret>`)
+/// without a token-exchange step. Liveness
+/// ([`crate::tenancy::agent_token_still_valid_pool`]) and grant resolution
+/// run on **every request**, so a user-owned key always reflects its owner's
+/// live RBAC and revocation is immediate — strictly fresher than a minted
+/// JWT's claim snapshot.
+///
+/// Cost control: the argon2 verification is the expensive step, so a
+/// successful verification is remembered for [`RAW_KEY_CACHE_TTL`] in a
+/// small bounded, process-local cache keyed by `(tenant, sha256(token))`.
+/// Only the *hash check* is skipped on a cache hit — liveness and grants are
+/// never cached. A garbage bearer never reaches argon2: the shape gate
+/// requires a `name.secret` split, and
+/// [`crate::tenancy::authenticate_agent_pool`] burns a dummy verification
+/// for unknown names to stay timing-neutral (#1099).
+pub async fn verify_raw_agent_credential(
+    pool: &crate::sql::Pool,
+    slug: &str,
+    token: &str,
+) -> Option<McpAgent> {
+    // Shape gate: credentials are `<8-hex prefix>.<hex secret>` (see
+    // `tenancy::agents::generate_credential`) — anything else (a JWT, a
+    // random string) is refused before any DB or argon2 work.
+    let (prefix, secret) = token.split_once('.')?;
+    let is_hex = |s: &str| !s.is_empty() && s.bytes().all(|b| b.is_ascii_hexdigit());
+    if prefix.len() != 8 || !is_hex(prefix) || !is_hex(secret) {
+        return None;
+    }
+
+    let cache_key = raw_key_cache_key(slug, token);
+    let (agent_id, user_id) = match raw_key_cache_get(&cache_key) {
+        Some(hit) => hit,
+        None => {
+            let agent =
+                match crate::tenancy::authenticate_agent_by_prefix_pool(pool, prefix, secret).await
+                {
+                    Ok(Some(a)) => a,
+                    Ok(None) => return None,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "mcp raw-key authentication failed");
+                        return None;
+                    }
+                };
+            let agent_id = agent.id.get().copied().unwrap_or_default();
+            raw_key_cache_put(cache_key, (agent_id, agent.user_id));
+            (agent_id, agent.user_id)
+        }
+    };
+
+    // Liveness on every request (covers the cache-hit path too): a revoked
+    // key or a deactivated owner is refused immediately.
+    match crate::tenancy::agent_token_still_valid_pool(pool, agent_id, user_id).await {
+        Ok(true) => {}
+        Ok(false) => return None,
+        Err(e) => {
+            tracing::warn!(error = %e, "mcp raw-key liveness check failed");
+            return None;
+        }
+    }
+
+    // Grants resolve fresh on every request — never cached.
+    let grants = match user_id {
+        Some(uid) => crate::tenancy::resolve_user_agent_grants_pool(pool, agent_id, uid).await,
+        None => crate::tenancy::resolve_agent_grants_pool(pool, agent_id).await,
+    };
+    let (skills, tools) = match grants {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::warn!(error = %e, "mcp raw-key grant resolution failed");
+            return None;
+        }
+    };
+    Some(McpAgent {
+        agent_id,
+        tenant: slug.to_owned(),
+        skills,
+        tools,
+        user_id,
+        jti: format!("raw:{agent_id}"),
+    })
+}
+
+/// TTL for a positive raw-key verification (argon2 skip window).
+const RAW_KEY_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+/// Bound on cached verifications; oldest entries are evicted past this.
+const RAW_KEY_CACHE_CAP: usize = 256;
+
+type RawKeyCache = std::collections::HashMap<[u8; 32], ((i64, Option<i64>), std::time::Instant)>;
+
+fn raw_key_cache() -> &'static std::sync::Mutex<RawKeyCache> {
+    static CACHE: std::sync::OnceLock<std::sync::Mutex<RawKeyCache>> = std::sync::OnceLock::new();
+    CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Cache key = SHA-256 over `tenant \0 token` — tenant-scoped so a credential
+/// verified against one tenant's pool can never authenticate on another.
+fn raw_key_cache_key(slug: &str, token: &str) -> [u8; 32] {
+    use sha2::Digest as _;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(slug.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(token.as_bytes());
+    hasher.finalize().into()
+}
+
+fn raw_key_cache_get(key: &[u8; 32]) -> Option<(i64, Option<i64>)> {
+    let cache = raw_key_cache().lock().ok()?;
+    let (identity, verified_at) = cache.get(key)?;
+    (verified_at.elapsed() < RAW_KEY_CACHE_TTL).then_some(*identity)
+}
+
+fn raw_key_cache_put(key: [u8; 32], identity: (i64, Option<i64>)) {
+    let Ok(mut cache) = raw_key_cache().lock() else {
+        return;
+    };
+    if cache.len() >= RAW_KEY_CACHE_CAP {
+        // Drop expired entries first; if still over cap, clear outright —
+        // the cache is a pure optimization and refilling costs one argon2.
+        cache.retain(|_, (_, at)| at.elapsed() < RAW_KEY_CACHE_TTL);
+        if cache.len() >= RAW_KEY_CACHE_CAP {
+            cache.clear();
+        }
+    }
+    cache.insert(key, (identity, std::time::Instant::now()));
 }
 
 pub(crate) fn bearer(headers: &HeaderMap) -> Option<&str> {

--- a/crates/rustango/src/mcp/auth.rs
+++ b/crates/rustango/src/mcp/auth.rs
@@ -237,7 +237,7 @@ pub(crate) async fn post_authed(
         return unauthorized(&headers, &uri);
     };
     // Two accepted bearer shapes: a minted agent JWT, or the raw
-    // `name.secret` credential itself (#1272) — the copy-paste key a member
+    // `prefix.secret` credential itself (epic #1013) — the copy-paste key a member
     // generates in an app's UI works directly in any MCP client without a
     // token-exchange step. The raw path verifies liveness and resolves grants
     // per request inside [`verify_raw_agent_credential`], so RBAC changes and
@@ -281,8 +281,8 @@ pub(crate) async fn post_authed(
     handle_message(&state, &body, Some(ctx)).await
 }
 
-/// Resolve a raw `name.secret` agent credential presented directly as the
-/// Bearer token (#1272). Returns the same [`McpAgent`] shape
+/// Resolve a raw `prefix.secret` agent credential presented directly as the
+/// Bearer token (epic #1013). Returns the same [`McpAgent`] shape
 /// [`verify_agent_token`] yields, or `None` for any failure — fail-closed.
 ///
 /// This is the copy-paste path: the show-once key a member generates works
@@ -298,9 +298,9 @@ pub(crate) async fn post_authed(
 /// small bounded, process-local cache keyed by `(tenant, sha256(token))`.
 /// Only the *hash check* is skipped on a cache hit — liveness and grants are
 /// never cached. A garbage bearer never reaches argon2: the shape gate
-/// requires a `name.secret` split, and
-/// [`crate::tenancy::authenticate_agent_pool`] burns a dummy verification
-/// for unknown names to stay timing-neutral (#1099).
+/// requires a `prefix.secret` split, and
+/// [`crate::tenancy::authenticate_agent_by_prefix_pool`] burns a dummy
+/// verification for unknown prefixes to stay timing-neutral (#1099).
 pub async fn verify_raw_agent_credential(
     pool: &crate::sql::Pool,
     slug: &str,

--- a/crates/rustango/src/mcp/mod.rs
+++ b/crates/rustango/src/mcp/mod.rs
@@ -36,7 +36,7 @@ mod transport;
 mod types;
 pub mod utilities;
 
-pub use auth::{issue_agent_token, verify_agent_token, McpAgent};
+pub use auth::{issue_agent_token, verify_agent_token, verify_raw_agent_credential, McpAgent};
 pub use notifications::{
     notify_prompts_list_changed, notify_resources_list_changed, notify_tools_list_changed,
 };

--- a/crates/rustango/src/mcp/router.rs
+++ b/crates/rustango/src/mcp/router.rs
@@ -77,10 +77,9 @@ pub fn secure_tenant_router() -> Router {
     tenant_router_authed(default_jwt())
 }
 
-/// Defensive cap on a JSON-RPC request body (tighter than axum's 2 MiB
-/// default). MCP messages are small; this bounds a hostile oversized payload.
-#[cfg(feature = "config")]
-const MCP_MAX_BODY_BYTES: usize = 1024 * 1024;
+// The JSON-RPC body cap defaults to 1 MiB (tighter than axum's 2 MiB) and
+// is configurable via `[mcp] max_body_bytes` for hosts whose tools accept
+// inline payloads (e.g. base64 media uploads).
 
 /// Agent-guarded tenant router configured from `[mcp]` settings. Applies the
 /// full knob set (#1098): `token_ttl_secs` → agent-token lifetime,
@@ -114,10 +113,10 @@ pub fn secure_tenant_router_from_settings(settings: &crate::config::McpSettings)
             std::time::Duration::from_secs(60),
         ));
     }
-    // Defensive body cap on every MCP route.
+    // Defensive body cap on every MCP route (`[mcp] max_body_bytes`).
     {
         use crate::body_limit::{BodyLimitLayer, BodyLimitRouterExt};
-        router = router.body_limit(BodyLimitLayer::new(MCP_MAX_BODY_BYTES));
+        router = router.body_limit(BodyLimitLayer::new(settings.max_body_bytes()));
     }
     router
 }

--- a/crates/rustango/src/tenancy/agents.rs
+++ b/crates/rustango/src/tenancy/agents.rs
@@ -232,6 +232,42 @@ pub async fn authenticate_agent_pool(
     }
 }
 
+/// Authenticate a full `prefix.secret` credential by its **secret prefix**
+/// (the lookup half) rather than the agent name — the shape a bearer token
+/// carries when the raw credential itself is presented (#1272), where the
+/// client never knows the agent's name. Same fail-closed + timing-neutral
+/// contract as [`authenticate_agent_pool`].
+///
+/// # Errors
+/// Propagates DB errors only; an unverifiable secret is `Ok(None)`.
+pub async fn authenticate_agent_by_prefix_pool(
+    pool: &Pool,
+    prefix: &str,
+    secret: &str,
+) -> Result<Option<Agent>, AgentError> {
+    use crate::core::Column as _;
+    use crate::sql::FetcherPool as _;
+
+    let Some(agent) = Agent::objects()
+        .where_(Agent::secret_prefix.eq(prefix))
+        .limit(1)
+        .fetch(pool)
+        .await?
+        .into_iter()
+        .next()
+        .filter(|a| a.active)
+    else {
+        // Timing-neutral for unknown prefixes (#1099).
+        super::password::verify_dummy(secret);
+        return Ok(None);
+    };
+
+    match super::password::verify(secret, &agent.secret_hash) {
+        Ok(true) => Ok(Some(agent)),
+        _ => Ok(None),
+    }
+}
+
 // ============================================================= skills (Slice 4)
 // Skills are the grant unit (epic #1013, Slice 4 / #1017): a skill bundles a
 // set of tools (+ a prompt + resources, Slice 5). Granting a skill to an agent

--- a/crates/rustango/src/tenancy/agents.rs
+++ b/crates/rustango/src/tenancy/agents.rs
@@ -234,7 +234,7 @@ pub async fn authenticate_agent_pool(
 
 /// Authenticate a full `prefix.secret` credential by its **secret prefix**
 /// (the lookup half) rather than the agent name — the shape a bearer token
-/// carries when the raw credential itself is presented (#1272), where the
+/// carries when the raw credential itself is presented (epic #1013), where the
 /// client never knows the agent's name. Same fail-closed + timing-neutral
 /// contract as [`authenticate_agent_pool`].
 ///

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -116,13 +116,14 @@ pub mod tenant_console;
 
 #[cfg(feature = "mcp")]
 pub use agents::{
-    add_skill_resource_pool, agent_token_still_valid_pool, authenticate_agent_pool,
-    create_agent_pool, create_skill_pool, create_user_key_pool, delete_user_keys_pool,
-    grant_skill_pool, list_agents_pool, list_skills_pool, list_user_keys_pool,
-    map_skill_to_permission_pool, resolve_agent_grants_pool, resolve_user_agent_grants_pool,
-    resources_for_skills_pool, revoke_skill_pool, revoke_user_key_pool, rotate_agent_secret_pool,
-    skills_by_codenames_pool, unmap_skill_from_permission_pool, Agent, AgentError, AgentGrant,
-    AgentSecret, AgentSkill, AgentSkillPermission, AgentSkillResource, AgentSkillTool,
+    add_skill_resource_pool, agent_token_still_valid_pool, authenticate_agent_by_prefix_pool,
+    authenticate_agent_pool, create_agent_pool, create_skill_pool, create_user_key_pool,
+    delete_user_keys_pool, grant_skill_pool, list_agents_pool, list_skills_pool,
+    list_user_keys_pool, map_skill_to_permission_pool, resolve_agent_grants_pool,
+    resolve_user_agent_grants_pool, resources_for_skills_pool, revoke_skill_pool,
+    revoke_user_key_pool, rotate_agent_secret_pool, skills_by_codenames_pool,
+    unmap_skill_from_permission_pool, Agent, AgentError, AgentGrant, AgentSecret, AgentSkill,
+    AgentSkillPermission, AgentSkillResource, AgentSkillTool,
 };
 #[cfg(feature = "postgres")]
 pub use auth::{authenticate_operator, authenticate_user};

--- a/crates/rustango/tests/mcp_raw_key.rs
+++ b/crates/rustango/tests/mcp_raw_key.rs
@@ -189,3 +189,64 @@ async fn garbage_and_wrong_secrets_are_refused() {
         .await
         .is_none());
 }
+
+/// A credential minted in one tenant must not authenticate against another —
+/// end to end, and specifically not via a cache warmed by the owning tenant.
+///
+/// The primary control is the pool boundary: the agent row exists only in its
+/// own tenant's database, so the prefix lookup finds nothing elsewhere. The
+/// per-request liveness re-check backstops it even on a cache hit, which is
+/// why this stays green regardless of whether the argon2-skip cache key
+/// carries the tenant (it does — `sha256(tenant \0 token)` — but that is
+/// defence in depth here, not the property under test).
+#[tokio::test]
+async fn credential_does_not_cross_tenants() {
+    let acme = world().await;
+    let globex = world().await;
+    skill_world(&acme).await;
+    skill_world(&globex).await;
+
+    let uid = make_user(&acme, "alice").await;
+    set_user_perm_pool(uid, "thing.edit", true, &acme)
+        .await
+        .expect("grant perm");
+    let issued = create_user_key_pool(&acme, uid, "alice's key", &[])
+        .await
+        .expect("key");
+
+    // Warm the cache on the owning tenant first.
+    assert!(
+        verify_raw_agent_credential(&acme, "acme", &issued.token)
+            .await
+            .is_some(),
+        "owning tenant must authenticate"
+    );
+
+    // Same token, other tenant's pool + slug: no such agent, and the warm
+    // cache entry must not be reused across the slug boundary.
+    assert!(
+        verify_raw_agent_credential(&globex, "globex", &issued.token)
+            .await
+            .is_none(),
+        "credential must not authenticate against another tenant"
+    );
+
+    // Cross-tenant is refused even when the foreign slug is presented
+    // against the owning pool's token first — i.e. the cache key, not just
+    // the pool, carries the tenant.
+    assert!(
+        verify_raw_agent_credential(&globex, "acme", &issued.token)
+            .await
+            .is_none(),
+        "foreign pool must refuse even with the owning slug"
+    );
+
+    // The owning tenant still works afterwards — isolation must not have
+    // poisoned the legitimate entry.
+    assert!(
+        verify_raw_agent_credential(&acme, "acme", &issued.token)
+            .await
+            .is_some(),
+        "owning tenant still authenticates after cross-tenant attempts"
+    );
+}

--- a/crates/rustango/tests/mcp_raw_key.rs
+++ b/crates/rustango/tests/mcp_raw_key.rs
@@ -1,4 +1,4 @@
-//! Raw-credential bearer (#1272) — the copy-paste key path.
+//! Raw-credential bearer (epic #1013) — the copy-paste key path.
 //!
 //! A user-owned key's show-once `prefix.secret` token works directly as the
 //! Bearer credential: [`rustango::mcp::verify_raw_agent_credential`] verifies

--- a/crates/rustango/tests/mcp_raw_key.rs
+++ b/crates/rustango/tests/mcp_raw_key.rs
@@ -1,0 +1,191 @@
+//! Raw-credential bearer (#1272) — the copy-paste key path.
+//!
+//! A user-owned key's show-once `prefix.secret` token works directly as the
+//! Bearer credential: [`rustango::mcp::verify_raw_agent_credential`] verifies
+//! the secret (argon2, cached), re-checks liveness, and resolves grants
+//! **per request** — so capabilities always track the owner's live RBAC and
+//! revocation is immediate. Exercised end-to-end on SQLite:
+//!
+//!   create user → grant permission → skill(+tool) → map skill↔perm
+//!     → create_user_key → verify raw credential → scope reflects RBAC
+//!     → permission change reflects immediately → revoke → refused
+//!
+//! Run: `cargo test -p rustango --no-default-features --features sqlite,mcp,testkit --test mcp_raw_key`.
+#![cfg(all(feature = "sqlite", feature = "mcp", feature = "testkit"))]
+#![allow(irrefutable_let_patterns)] // Pool is single-variant in sqlite-only builds
+
+use rustango::mcp::verify_raw_agent_credential;
+use rustango::sql::{sqlx, Pool};
+use rustango::tenancy::permissions::set_user_perm_pool;
+use rustango::tenancy::{
+    create_skill_pool, create_user_key_pool, map_skill_to_permission_pool, revoke_user_key_pool,
+};
+
+async fn world() -> Pool {
+    let pool = Pool::Sqlite(
+        sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite"),
+    );
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("migrate framework");
+    pool
+}
+
+async fn make_user(pool: &Pool, name: &str) -> i64 {
+    let Pool::Sqlite(sq) = pool else {
+        unreachable!()
+    };
+    sqlx::query(
+        "INSERT INTO rustango_users (username, password_hash, is_superuser, active, created_at) \
+         VALUES (?, '', 0, 1, datetime('now'))",
+    )
+    .bind(name)
+    .execute(sq)
+    .await
+    .expect("insert user");
+    let (id,): (i64,) = sqlx::query_as("SELECT id FROM rustango_users WHERE username = ?")
+        .bind(name)
+        .fetch_one(sq)
+        .await
+        .expect("fetch id");
+    id
+}
+
+async fn skill_world(pool: &Pool) {
+    create_skill_pool(
+        pool,
+        "editor",
+        "Editor",
+        "edits things",
+        "You edit.",
+        &["edit_thing".into()],
+    )
+    .await
+    .expect("skill");
+    map_skill_to_permission_pool(pool, "editor", "thing.edit")
+        .await
+        .expect("map");
+}
+
+#[tokio::test]
+async fn raw_credential_resolves_live_rbac_scope() {
+    let pool = world().await;
+    skill_world(&pool).await;
+    let uid = make_user(&pool, "alice").await;
+    set_user_perm_pool(uid, "thing.edit", true, &pool)
+        .await
+        .expect("grant perm");
+
+    let issued = create_user_key_pool(&pool, uid, "alice's key", &[])
+        .await
+        .expect("key");
+
+    // The raw show-once token authenticates directly.
+    let agent = verify_raw_agent_credential(&pool, "acme", &issued.token)
+        .await
+        .expect("raw credential verifies");
+    assert_eq!(agent.user_id, Some(uid));
+    assert_eq!(agent.tenant, "acme");
+    assert_eq!(agent.skills, vec!["editor"]);
+    assert_eq!(agent.tools, vec!["edit_thing"]);
+    assert!(agent.jti.starts_with("raw:"));
+
+    // RBAC change reflects on the very next request (grants are never
+    // cached), including through the argon2-skip cache-hit path.
+    set_user_perm_pool(uid, "thing.edit", false, &pool)
+        .await
+        .expect("deny perm");
+    let narrowed = verify_raw_agent_credential(&pool, "acme", &issued.token)
+        .await
+        .expect("still authenticates");
+    assert!(narrowed.skills.is_empty(), "denied perm drops the skill");
+    assert!(narrowed.tools.is_empty());
+}
+
+#[tokio::test]
+async fn revoked_key_is_refused_immediately() {
+    let pool = world().await;
+    skill_world(&pool).await;
+    let uid = make_user(&pool, "bob").await;
+    set_user_perm_pool(uid, "thing.edit", true, &pool)
+        .await
+        .expect("grant");
+    let issued = create_user_key_pool(&pool, uid, "bob's key", &[])
+        .await
+        .expect("key");
+    let agent_id = issued.agent.id.get().copied().unwrap();
+
+    // Warm the verification cache with a successful call…
+    assert!(verify_raw_agent_credential(&pool, "acme", &issued.token)
+        .await
+        .is_some());
+    // …then revoke: the liveness check runs per request, so even a cached
+    // verification is refused straight away.
+    revoke_user_key_pool(&pool, uid, agent_id)
+        .await
+        .expect("revoke");
+    assert!(
+        verify_raw_agent_credential(&pool, "acme", &issued.token)
+            .await
+            .is_none(),
+        "revoked key must be refused despite the warm cache"
+    );
+}
+
+#[tokio::test]
+async fn deactivated_owner_is_refused() {
+    let pool = world().await;
+    let uid = make_user(&pool, "carol").await;
+    let issued = create_user_key_pool(&pool, uid, "carol's key", &[])
+        .await
+        .expect("key");
+    assert!(verify_raw_agent_credential(&pool, "acme", &issued.token)
+        .await
+        .is_some());
+
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!()
+    };
+    sqlx::query("UPDATE rustango_users SET active = 0 WHERE id = ?")
+        .bind(uid)
+        .execute(sq)
+        .await
+        .expect("deactivate");
+    assert!(
+        verify_raw_agent_credential(&pool, "acme", &issued.token)
+            .await
+            .is_none(),
+        "a deactivated owner's keys must be refused"
+    );
+}
+
+#[tokio::test]
+async fn garbage_and_wrong_secrets_are_refused() {
+    let pool = world().await;
+    let uid = make_user(&pool, "dave").await;
+    let issued = create_user_key_pool(&pool, uid, "dave's key", &[])
+        .await
+        .expect("key");
+
+    // No dot → shape gate refuses without touching the DB.
+    assert!(verify_raw_agent_credential(&pool, "acme", "not-a-key")
+        .await
+        .is_none());
+    // Empty halves.
+    assert!(verify_raw_agent_credential(&pool, "acme", ".")
+        .await
+        .is_none());
+    // Right prefix, wrong secret.
+    let prefix = issued.token.split('.').next().unwrap();
+    let forged = format!("{prefix}.deadbeefdeadbeefdeadbeefdeadbeef");
+    assert!(verify_raw_agent_credential(&pool, "acme", &forged)
+        .await
+        .is_none());
+    // A JWT-shaped bearer (three dot-separated base64 parts) must not
+    // authenticate as a raw credential either.
+    assert!(verify_raw_agent_credential(&pool, "acme", "eyJx.eyJy.sig")
+        .await
+        .is_none());
+}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -193,7 +193,23 @@ grant_skill_pool(&pool, "acme", "calc-bot", "calculator").await?;
 The client exchanges its credential for a **tenant-pinned, scoped JWT** at
 `POST /mcp/token` (or the OAuth `client_credentials` flow at `/mcp/oauth/token`).
 The server resolves the grant into the token's `skills` + `tools` claims; every
-request re-verifies it. The effect, verified end to end:
+request re-verifies it.
+
+**Or skip the exchange entirely (#1272):** the raw `prefix.secret` credential
+itself is accepted as the Bearer token — paste the show-once key straight into
+any MCP client:
+
+```bash
+claude mcp add --transport http my-app https://acme.example/mcp \
+  --header "Authorization: Bearer 3f9c1a2b.7d…"
+```
+
+On the raw-key path the server verifies the secret (argon2, with a short
+process-local cache so the hash isn't recomputed per request), re-checks
+liveness, and resolves grants **on every request** — a user-owned key always
+reflects its owner's live RBAC, and revocation applies immediately instead of
+waiting out a JWT's TTL. Set `[mcp] rate_limit_per_minute` in production to
+bound verification work. The effect, verified end to end:
 
 ```rust
 // tools/list returns ONLY the granted tool, with its JSON Schema:
@@ -350,6 +366,8 @@ enable_sse            = true     # serve the GET {prefix} SSE stream
 allowed_origins       = []       # CORS allow-list (empty = same-origin only)
 rate_limit_per_minute = 0        # per-IP cap (0/unset = unlimited)
 max_tools_listed      = 0        # tools/list page size (0/unset = unlimited)
+max_body_bytes        = 1048576  # JSON-RPC body cap — raise for tools that
+                                 # accept inline payloads (base64 uploads)
 ```
 
 ---

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -195,7 +195,7 @@ The client exchanges its credential for a **tenant-pinned, scoped JWT** at
 The server resolves the grant into the token's `skills` + `tools` claims; every
 request re-verifies it.
 
-**Or skip the exchange entirely (#1272):** the raw `prefix.secret` credential
+**Or skip the exchange entirely:** the raw `prefix.secret` credential
 itself is accepted as the Bearer token — paste the show-once key straight into
 any MCP client:
 


### PR DESCRIPTION
Brings the MCP raw-credential bearer feature onto `develop`, where it should
have landed in the first place.

## Why

`b90d5ac2` was committed **directly to `main`** on Aug 31 at 12:23 — 48 minutes
*after* the 0.55.0 promote — so it never went through `develop`, never ran in
CI, and never shipped to crates.io. It was the only content `main` held that
`develop` lacked, which meant the next `develop → main` promote would have
silently deleted it (auth.rs −179, tenancy/agents.rs −36, mcp_raw_key.rs −191,
docs/mcp.md). This cherry-picks it forward so `develop` is canonical again.

## What the feature does

The show-once `prefix.secret` agent key now works directly as a Bearer token,
with no `POST /mcp/token` exchange:

```bash
claude mcp add --transport http my-app https://acme.example/mcp \
  --header "Authorization: Bearer 3f9c1a2b.7d…"
```

- `tenancy::authenticate_agent_by_prefix_pool` — looks the agent up by *secret
  prefix* (a bearer client never knows the agent name). Fail-closed and
  timing-neutral: burns a dummy argon2 verify on unknown prefixes (#1099).
- `mcp::verify_raw_agent_credential` — verifies the secret, re-checks liveness,
  and resolves grants on **every** request, so capabilities track the owner's
  live RBAC and revocation is immediate rather than waiting out a JWT TTL.
- Only the argon2 check is memoised: a bounded process-local cache (256 entries,
  60s TTL) keyed by `sha256(tenant \0 token)`. Liveness and grants are never
  cached. A malformed bearer is refused by a shape gate before any DB/argon2
  work. The JWT path is tried first and is unchanged.
- `[mcp] max_body_bytes` is now configurable (default unchanged at 1 MiB).

## What I changed on top of the cherry-pick

- **Fixed a misattributed issue reference.** The commit, three code comments and
  `docs/mcp.md` all cited `#1272` — but #1272 is *"probleme de scafolding"*, an
  unrelated report from an external contributor. Retargeted to epic #1013, which
  is how the rest of `src/mcp` cites itself.
- **Corrected two docs that contradicted the code**: the credential shape is
  `prefix.secret`, not `name.secret`; and the timing-neutral dummy verify is
  burned by `authenticate_agent_by_prefix_pool`, not the name-based
  `authenticate_agent_pool`.
- **Added `credential_does_not_cross_tenants`.** The docs asserted a credential
  cannot authenticate against another tenant and nothing tested it. The test is
  explicit that it exercises the pool boundary plus the per-request liveness
  re-check — the tenant-scoped cache key is defence in depth here, not the
  property under test.
- **Added the CHANGELOG entry** the feature never got, including the deployment
  note that `[mcp] rate_limit_per_minute` should be set in production (unknown
  prefixes deliberately burn argon2 to stay timing-neutral, so an
  unauthenticated caller can otherwise induce verification work).

## Testing

| Check | Result |
|---|---|
| `mcp_raw_key` (sqlite) | 5 passed — incl. the new cross-tenant test |
| Full `--all-features` suite vs live PG + MySQL + Redis | **503 suites, 6790 tests passed** |
| `--lib --all-features` unit tests | 3607 passed |
| `--workspace --all-features --no-run` | clean |
| Builds: sqlite-only / mysql-only / postgres — each with `mcp` | all clean |
| clippy, cargo doc | clean (no new broken intra-doc links) |

Existing coverage coming over with the cherry-pick: `raw_credential_resolves_live_rbac_scope`
(revokes a permission mid-flight and asserts the scope collapses),
`revoked_key_is_refused_immediately`, `deactivated_owner_is_refused`, and
`garbage_and_wrong_secrets_are_refused` (including a forged secret with a valid
prefix, and a JWT-shaped bearer).

## Pre-existing issue found, not fixed here

`tests/mysql_live.rs` fails under `--all-features` (6 of 7 tests): its cleanup
runs `SET FOREIGN_KEY_CHECKS = 0`, but that is **session-scoped** and
`drop_all_pool` then executes on a *different pooled connection*, so the drop
trips the `rustango_api_keys → rustango_users` FK. It only appears with
`api_keys` enabled, and CI runs this suite as `--features mysql`, so CI has
never seen it. Reproduced identically on clean `develop`, so it is unrelated to
this PR — filing separately rather than widening this one.
