### PR TITLE
fix(migrate): drop FK constraints before tables so drop_all_pool works on MySQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test -p rustango --features mysql,jobs-postgres --test jobs_mysql_live
       - run: cargo test -p rustango --features mysql --test mysql_live
+      # Again under --all-features. #1277: MySQL enforces FKs and has no
+      # `DROP TABLE … CASCADE`, so `drop_all_pool` failed whenever it dropped
+      # a parent (`rustango_users`) before its child (`rustango_api_keys`).
+      # Which order that walk takes depends on how many models are registered,
+      # so only a full-feature build reliably provokes it — the bare
+      # `--features mysql` run above never did, which is why this went
+      # unnoticed. Keep both: the narrow run guards the common config, this
+      # one guards the FK-ordering regression.
+      - run: cargo test -p rustango --all-features --test mysql_live
       - run: cargo test -p rustango --features mysql --test explain_pool_mysql_live
       - run: cargo test -p rustango --features mysql --test bulk_upsert_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy --test tenancy_manage_mysql_live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,24 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 - **`[mcp] max_body_bytes` is now configurable** (default unchanged at 1 MiB,
   still tighter than axum's 2 MiB). Raise it for tools that accept inline
   payloads such as base64 media uploads; it was previously a hard-coded const.
+### Fixed
+- **`migrate::drop_all_pool` failed on MySQL whenever the schema had foreign
+  keys** (#1277). It dropped tables in model-registration order with `CASCADE`
+  emitted for Postgres only — fine on PG (cascades) and on SQLite (which leaves
+  `foreign_keys` off by default), but MySQL enforces FKs and rejects `CASCADE`
+  on `DROP TABLE`, so the call failed outright as soon as a parent was dropped
+  before its child (`rustango_users` before `rustango_api_keys`). Whether that
+  happened depended on how many models were registered, making it look
+  intermittent.
+
+  `drop_all_pool` is now two-phase — drop FK constraints, then drop tables —
+  mirroring `apply_all`'s two-phase create, so drop order is irrelevant on every
+  dialect. New emitter `migrate::ddl::drop_constraints_sql_with_dialect` (the
+  inverse of `create_constraints_sql_with_dialect`; empty for SQLite, which
+  inlines FKs and has no named constraint to drop). No session-level
+  `FOREIGN_KEY_CHECKS` toggling, which on a pooled connection would not reliably
+  reach the connection doing the drops — and would leak to the next borrower
+  (#1224).
 
 ## [0.55.0] — 2026-08-31
 

--- a/crates/rustango/src/migrate/ddl.rs
+++ b/crates/rustango/src/migrate/ddl.rs
@@ -174,6 +174,57 @@ pub fn drop_table_sql_with_dialect(
     s
 }
 
+/// The inverse of [`create_constraints_sql_with_dialect`]: one statement
+/// per FK / O2O field and per composite FK, dropping the constraint that
+/// the create emitter named `{table}_{column}_fkey`.
+///
+/// Needed because `DROP TABLE` is only FK-safe on two of the three
+/// dialects: Postgres has `CASCADE`, SQLite leaves `foreign_keys` off by
+/// default, but MySQL enforces FKs and rejects `CASCADE` — so dropping a
+/// parent before its child fails outright (#1277). Dropping constraints
+/// first makes table drop order irrelevant, mirroring the way
+/// [`create_constraints_sql_with_dialect`] makes create order irrelevant.
+///
+/// Returns empty for dialects that inline FKs in `CREATE TABLE` (SQLite):
+/// there is no named constraint to drop, and the table drop is unimpeded.
+///
+/// The statements are best-effort by nature — a constraint may already be
+/// gone, and only Postgres can say `IF EXISTS` here (MySQL's
+/// `DROP FOREIGN KEY` has no such form), so callers should ignore errors.
+#[must_use]
+pub fn drop_constraints_sql_with_dialect(
+    dialect: &dyn Dialect,
+    model: &ModelSchema,
+) -> Vec<String> {
+    if dialect.inline_fks_in_create_table() {
+        return Vec::new();
+    }
+    // MySQL spells it `DROP FOREIGN KEY`; Postgres `DROP CONSTRAINT`,
+    // which additionally accepts `IF EXISTS`.
+    let mysql = dialect.name() == "mysql";
+    let mut out = Vec::new();
+    let mut push = |name: String| {
+        let mut s = String::from("ALTER TABLE ");
+        s.push_str(&dialect.quote_ident(model.table));
+        if mysql {
+            s.push_str(" DROP FOREIGN KEY ");
+        } else {
+            s.push_str(" DROP CONSTRAINT IF EXISTS ");
+        }
+        s.push_str(&dialect.quote_ident(&name));
+        out.push(s);
+    };
+    for field in model.scalar_fields() {
+        if field.relation.is_some() {
+            push(format!("{}_{}_fkey", model.table, field.column));
+        }
+    }
+    for rel in model.composite_relations {
+        push(format!("{}_{}_fkey", model.table, rel.name));
+    }
+    out
+}
+
 /// One `ALTER TABLE … ADD CONSTRAINT … FOREIGN KEY` per FK / O2O field,
 /// plus one per composite FK declared via `#[rustango(fk_composite(...))]`
 /// (sub-slice F.2 of the v0.15.0 ContentType plan). MySQL accepts the

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -401,7 +401,19 @@ pub async fn drop_all_pool(pool: &crate::sql::Pool) -> Result<(), MigrateError> 
     let dialect = pool.dialect();
     // Cascade only emitted for PG — MySQL parses it as syntax error.
     let cascade = dialect.name() == "postgres";
-    for model in bootstrap_models() {
+    let models = bootstrap_models();
+    // Phase 1 — drop FK constraints, so table drop order can't matter.
+    // The mirror of `apply_all`'s two-phase create. Without it MySQL, which
+    // enforces FKs and has no `DROP TABLE … CASCADE`, fails as soon as a
+    // parent is dropped before its child (#1277). Best-effort: a constraint
+    // may already be absent, and only PG can say `IF EXISTS` here.
+    for model in &models {
+        for sql in ddl::drop_constraints_sql_with_dialect(dialect, model) {
+            let _ = crate::sql::raw_execute_pool(pool, &sql, ::std::vec::Vec::new()).await;
+        }
+    }
+    // Phase 2 — drop the tables themselves.
+    for model in &models {
         let sql =
             ddl::drop_table_sql_with_dialect(dialect, model, /* if_exists */ true, cascade);
         crate::sql::raw_execute_pool(pool, &sql, ::std::vec::Vec::new()).await?;


### PR DESCRIPTION
Closes #1277.

## The bug

`migrate::drop_all_pool` dropped tables in model-registration order, emitting
`CASCADE` for Postgres only. That is fine on two of the three dialects:

- **Postgres** — `CASCADE` takes care of dependent constraints.
- **SQLite** — `foreign_keys` is off by default, so nothing objects.
- **MySQL** — enforces FKs *and* rejects `CASCADE` on `DROP TABLE`. As soon as
  the walk reached a parent before its child, the whole call failed:

```
Cannot drop table 'rustango_users' referenced by a foreign key constraint
'rustango_api_keys_user_id_fkey' on table 'rustango_api_keys'.
```

Whether that ordering happened depended on how many models were registered,
which made it look intermittent — bare `--features mysql` never hit it, and
`--all-features` failed 6 of 7 tests in `mysql_live`.

## The fix

`drop_all_pool` is now two-phase — drop FK constraints, then drop tables —
the mirror of what `apply_all` already does on the create side ("two-phase so
create order doesn't matter"). Drop order stops mattering on every dialect.

New emitter `ddl::drop_constraints_sql_with_dialect`, the inverse of
`create_constraints_sql_with_dialect`: `DROP FOREIGN KEY` on MySQL,
`DROP CONSTRAINT IF EXISTS` on Postgres, and empty on SQLite (which inlines FKs
in `CREATE TABLE`, so there is no named constraint to drop). Constraint drops
are best-effort, since a constraint may already be gone and MySQL has no
`IF EXISTS` form here.

**Deliberately not** done with `SET FOREIGN_KEY_CHECKS = 0`: that is
session-scoped, so on a pooled connection it would not reliably reach the
connection running the drops — and it would leak to the next borrower, which is
exactly #1224.

## Verification

| | before | after |
|---|---|---|
| `--all-features --test mysql_live` | 1 passed / **6 failed** | **7 passed** |
| full `--all-features` suite vs live PG + MySQL + Redis | 503 ok / **1 failed** | **504 ok / 0 failed** |

CI now also runs `mysql_live` under `--all-features`. I first tried a narrower
guard (`mysql,tenancy,api_keys,testkit`) and verified it against the unpatched
code — it passed, so it would not have caught this. Only the full-feature build
provokes the registration order that triggers it, so that is what the new step
runs.
