### PR TITLE
fix(manage): don't launch a browser from the docs verb during tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 - **`[mcp] max_body_bytes` is now configurable** (default unchanged at 1 MiB,
   still tighter than axum's 2 MiB). Raise it for tools that accept inline
   payloads such as base64 media uploads; it was previously a hard-coded const.
+
 ### Fixed
 - **`migrate::drop_all_pool` failed on MySQL whenever the schema had foreign
   keys** (#1277). It dropped tables in model-registration order with `CASCADE`
@@ -49,6 +50,13 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
   `FOREIGN_KEY_CHECKS` toggling, which on a pooled connection would not reliably
   reach the connection doing the drops — and would leak to the next borrower
   (#1224).
+- **`cargo test` opened a browser tab.** `manage docs` launches
+  `https://docs.rs/rustango` via the OS opener, and `docs` is one of the verbs
+  the `pool_free_verbs_need_no_database` unit test dispatches — so every
+  `cargo test --lib` run spawned a real tab on the developer's machine. The URL
+  is still printed, but the launch is now skipped under `cfg!(test)`, and also
+  when `RUSTANGO_NO_BROWSER` is set (for headless and CI shells, which have
+  nothing to open).
 
 ## [0.55.0] — 2026-08-31
 

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -408,7 +408,11 @@ fn print_help<W: Write>(w: &mut W) -> std::io::Result<()> {
         "      --model limits to a single model; pass multiple times for a set.\n"
     )?;
     writeln!(w, "  docs")?;
-    writeln!(w, "      Open docs.rs/rustango in the default browser.\n")?;
+    writeln!(
+        w,
+        "      Open docs.rs/rustango in the default browser. Set \
+         RUSTANGO_NO_BROWSER to just print the URL.\n"
+    )?;
     writeln!(w, "  version | --version")?;
     writeln!(w, "      Print the rustango framework version.\n")?;
     writeln!(
@@ -1812,9 +1816,19 @@ async fn check_cmd<W: Write>(
 }
 
 /// `manage docs` — try to open https://docs.rs/rustango in the user's browser.
+///
+/// The URL is always printed; the browser launch is skipped under `cfg!(test)`
+/// and when `RUSTANGO_NO_BROWSER` is set. Without the test guard this verb
+/// really did open a browser during `cargo test`: `docs` is in the pool-free
+/// verb list that `pool_free_verbs_need_no_database` dispatches, so every
+/// `cargo test --lib` spawned a tab. `RUSTANGO_NO_BROWSER` covers the same
+/// nuisance for headless and CI shells, which have nothing to open.
 fn docs_cmd<W: Write>(w: &mut W) -> Result<(), MigrateError> {
     let url = "https://docs.rs/rustango";
     writeln!(w, "{url}")?;
+    if cfg!(test) || std::env::var_os("RUSTANGO_NO_BROWSER").is_some() {
+        return Ok(());
+    }
     // Best-effort — don't fail if the OS has no `open` / `xdg-open` / `start`
     let opener = if cfg!(target_os = "macos") {
         Some(("open", url))


### PR DESCRIPTION
Running `cargo test` opened a real docs.rs tab in the developer's browser.

`manage docs` shells out to `open` / `xdg-open` / `start`, and `docs` is one of
the verbs `pool_free_verbs_need_no_database` dispatches (it is in the pool-free
verb list precisely because it needs no database). So **every `cargo test --lib`
run spawned a browser tab** — reported while running the suite twice in one
command and getting two tabs.

The URL is still printed. The launch is now skipped when:

- `cfg!(test)` — the crate's own unit tests, which is the reported case; and
- `RUSTANGO_NO_BROWSER` is set — headless boxes and CI shells, which have
  nothing to open.

The verb's `--help` line documents the variable.

## Verification

- `cargo test -p rustango --lib gen_tests::pool_free_verbs_need_no_database` —
  passes, no opener process spawned.
- `cargo test -p rustango --lib` — 3255 passed, 0 failed, and no browser tab
  (previously this run opened one every time).
