### PR TITLE
fix(sql): give sqlx a TLS backend so managed Postgres/MySQL work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1372,7 +1372,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "url",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2084,7 +2084,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2562,6 +2562,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2572,6 +2573,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3436,6 +3438,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -62,7 +62,13 @@ default = ["postgres", "batteries"]
 # `cargo rustango new` emits exactly that. Keeping the list here rather than in
 # the generated manifest means it can't rot out of sync with `default`.
 batteries = ["manage", "admin", "config", "forms", "serializer", "cache", "signals", "email", "storage", "scheduler", "secrets", "totp", "webhook", "webhook-delivery", "api_keys", "passwords", "signed_url", "notifications", "casts", "jobs", "jobs-postgres", "auth_flows", "sse", "websocket", "oauth2", "http-client", "compression", "openapi", "csp-nonce", "sessions", "hmac-auth", "jwt", "uploads", "storage-s3", "media", "runserver", "template_views"]
-postgres = ["sqlx/postgres"]
+# `tls-rustls` (→ rustls-ring + webpki roots, no openssl — matching the
+# reqwest / lettre stance) is folded in because a NETWORK database backend
+# is useless without it: every managed Postgres (Supabase, Neon, RDS,
+# Cloud SQL, …) mandates TLS, and sqlx built with no TLS backend cannot
+# honour `sslmode=require` — the handshake just fails. SQLite deliberately
+# stays TLS-free (local file, no socket).
+postgres = ["sqlx/postgres", "sqlx/tls-rustls"]
 
 # Unified `cargo run` / `cargo run -- <verb>` dispatcher. Pulls the
 # minimum axum + tokio surface so bare-API projects (without admin)
@@ -90,7 +96,7 @@ testkit = []
 # Serializer) works against MySQL through the same `&Pool` API as
 # Postgres. Schema-mode tenancy remains Postgres-only by language
 # semantics (`SET search_path` has no MySQL equivalent).
-mysql = ["sqlx/mysql"]
+mysql = ["sqlx/mysql", "sqlx/tls-rustls"]
 
 # SQLite 3.35+ backend. Fully tri-dialect since v0.38: every framework
 # surface works against a file-backed or in-memory SQLite DB through


### PR DESCRIPTION
## Problem

`sqlx` is declared with `default-features = false` and **no TLS feature**, so a rustango build cannot complete a TLS handshake against a networked database.

Every managed Postgres — Supabase, Neon, RDS, Cloud SQL — mandates TLS. `sslmode=require` therefore fails, and nothing in the error points at the real cause. `rustls` *is* in the dependency tree, but only via `reqwest`; it was never wired into `sqlx`:

```
$ cargo tree -i rustls            # before
rustls v0.23.40
├── hyper-rustls → reqwest → rustango     # HTTP client only
└── tokio-rustls → reqwest
$ cargo tree -p sqlx-postgres --depth 1   # no TLS dependency at all
```

## Fix

Fold `sqlx/tls-rustls` into the `postgres` and `mysql` features — rustls-ring + webpki roots, no openssl, matching the stance `reqwest` and `lettre` already take.

`sqlite` deliberately stays TLS-free: it's a local file with no socket, so sqlite-only builds shouldn't pay for rustls.

```toml
postgres = ["sqlx/postgres", "sqlx/tls-rustls"]
mysql    = ["sqlx/mysql",    "sqlx/tls-rustls"]
sqlite   = ["sqlx/sqlite"]                       # unchanged
```

## Verification

- **Gating holds** — on a sqlite-only build, `cargo tree -p rustango --no-default-features --features sqlite -i rustls` reports *no such package*, so sqlite builds are unchanged in weight.
- `postgres`, `mysql` and `sqlite` all compile.
- **End-to-end**: migrated a real rustango-cms app onto **Supabase** over the session pooler (`:5432`, `sslmode=require`) — `migrate-registry` + a schema-mode tenant with 7 migrations (68 tables) applied, and the app serves from it. This was simply impossible before: the connection could not be established.

`Cargo.lock` picks up `webpki-roots`.

## Risk

Low. Additive feature on the two network backends; no code changes, no API surface change. Postgres/MySQL builds gain rustls (already compiled in any build using the HTTP client); sqlite builds are untouched.
