### PR TITLE
chore: zero rustc warnings across tests, examples and codegen (+ fix an example that never compiled)

### DIFF
--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -7599,6 +7599,15 @@ fn inherent_impl_tokens(
                                 );
                             }
                         };
+                        // A model whose only field is the primary key emits no
+                        // non-PK arms, so every arm above diverges and this push
+                        // is genuinely unreachable — correct, since such a model
+                        // has nothing to bulk-update. Scoped to the statement
+                        // rather than the fn so a real unreachability elsewhere
+                        // in this body still warns. Without it every PK-only
+                        // model warns in the *user's* crate, which they cannot
+                        // act on (#1290).
+                        #[allow(unreachable_code)]
                         _update_columns.push(_col);
                     }
                     let mut _rows: ::std::vec::Vec<

--- a/crates/rustango/examples/admin_demo/Cargo.lock
+++ b/crates/rustango/examples/admin_demo/Cargo.lock
@@ -889,7 +889,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1753,7 +1753,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2170,6 +2170,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2180,6 +2181,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3017,6 +3019,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/auth_demo/Cargo.lock
+++ b/crates/rustango/examples/auth_demo/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1776,7 +1776,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2211,6 +2211,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2221,6 +2222,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3020,6 +3022,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/cookbook_blog/Cargo.lock
+++ b/crates/rustango/examples/cookbook_blog/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1772,7 +1772,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2188,6 +2188,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2198,6 +2199,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3025,6 +3027,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/getting_started_blog/Cargo.lock
+++ b/crates/rustango/examples/getting_started_blog/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1766,7 +1766,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2183,6 +2183,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2193,6 +2194,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3044,6 +3046,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/getting_started_blog/src/blog/models.rs
+++ b/crates/rustango/examples/getting_started_blog/src/blog/models.rs
@@ -14,6 +14,11 @@ use chrono::{DateTime, Utc};
     audit(track = "title, body, status"),
     index("status, published_at"),
 )]
+// Schema columns exist for the table definition and the admin; this
+// tutorial's own code never reads them back, which is what `dead_code`
+// measures. Allowed rather than removed — dropping them would gut the
+// example the docs walk through.
+#[allow(dead_code)]
 pub struct Post {
     #[rustango(primary_key)]
     pub id: Auto<i64>,

--- a/crates/rustango/examples/getting_started_blog/src/blog/views.rs
+++ b/crates/rustango/examples/getting_started_blog/src/blog/views.rs
@@ -10,6 +10,10 @@ use axum::response::Html;
 
 /// `GET /<app-prefix>/hello` — placeholder. Wire the actual path
 /// in `urls.rs` once you decide on the app's URL prefix.
+///
+/// The matching `.route(...)` in `urls.rs` ships commented out on
+/// purpose, so nothing references this until you wire it.
+#[allow(dead_code)]
 pub async fn hello() -> Html<&'static str> {
     Html("<h1>hello from your new app</h1>")
 }

--- a/crates/rustango/examples/getting_started_blog/src/models.rs
+++ b/crates/rustango/examples/getting_started_blog/src/models.rs
@@ -9,6 +9,11 @@ use rustango::Model;
 
 #[derive(Model, Debug, Clone)]
 #[rustango(table = "item", display = "name")]
+// Schema columns exist for the table definition and the admin; this
+// tutorial's own code never reads them back, which is what `dead_code`
+// measures. Allowed rather than removed — dropping them would gut the
+// example the docs walk through.
+#[allow(dead_code)]
 pub struct Item {
     #[rustango(primary_key)]
     pub id: Auto<i64>,

--- a/crates/rustango/examples/orm_cookbook/Cargo.lock
+++ b/crates/rustango/examples/orm_cookbook/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1752,7 +1752,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2169,6 +2169,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2179,6 +2180,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3016,6 +3018,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/tenant_user_extension/Cargo.lock
+++ b/crates/rustango/examples/tenant_user_extension/Cargo.lock
@@ -992,6 +992,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1445,6 +1446,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,6 +1563,40 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1782,6 +1831,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -1792,6 +1842,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2360,6 +2411,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2485,6 +2542,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,7 +2643,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2586,13 +2670,29 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2602,10 +2702,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2614,10 +2726,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2626,16 +2756,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/crates/rustango/examples/tenant_user_extension/Cargo.toml
+++ b/crates/rustango/examples/tenant_user_extension/Cargo.toml
@@ -16,9 +16,23 @@ path = "src/lib.rs"
 name = "tenant_user_extension"
 path = "src/main.rs"
 
+# `#[derive(Model)]` cfg-gates its emissions on the features of the crate
+# it expands in — not on rustango's. Enabling `rustango/postgres` from the
+# dependency line alone therefore left this crate with no `postgres` feature
+# of its own, so the derive skipped every PG `FromRow` / `MaybePgFromRow`
+# impl and the example failed to compile with 57 errors (the #1211 shape).
+# It also produced an `unexpected cfg condition value: postgres` warning for
+# the same reason. Declaring the backend as a real feature here — the shape
+# every other standalone example already uses — fixes both.
+[features]
+default = ["postgres"]
+postgres = ["rustango/postgres"]
+sqlite = ["rustango/sqlite"]
+mysql = ["rustango/mysql"]
+
 [dependencies]
 rustango = { path = "../..", default-features = false, features = [
-    "postgres", "manage", "tenancy", "runtime", "serializer", "forms",
+    "manage", "tenancy", "runtime", "serializer", "forms",
 ] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 axum = { version = "0.8", default-features = false, features = ["tokio", "http1", "json"] }

--- a/crates/rustango/src/dateformat.rs
+++ b/crates/rustango/src/dateformat.rs
@@ -547,6 +547,11 @@ mod tests {
     }
 
     #[test]
+    // Named for the Django format code under test. Those codes are
+    // case-sensitive — `N` (AP-style month) is a different specifier
+    // from `n` (month number) — so lowercasing the suffix would make
+    // the pair indistinguishable.
+    #[allow(non_snake_case)]
     fn format_ap_month_abbr_N() {
         // Django format code `N` — AP-style month abbreviation: short
         // months get trailing period, long-form months (March, April,
@@ -560,6 +565,11 @@ mod tests {
     }
 
     #[test]
+    // Named for the Django format code under test. Those codes are
+    // case-sensitive — `N` (AP-style month) is a different specifier
+    // from `n` (month number) — so lowercasing the suffix would make
+    // the pair indistinguishable.
+    #[allow(non_snake_case)]
     fn format_unix_timestamp_U() {
         let t = dt(2026, 1, 1, 0, 0, 0);
         let expected = t.timestamp().to_string();
@@ -583,6 +593,11 @@ mod tests {
     }
 
     #[test]
+    // Named for the Django format code under test. Those codes are
+    // case-sensitive — `N` (AP-style month) is a different specifier
+    // from `n` (month number) — so lowercasing the suffix would make
+    // the pair indistinguishable.
+    #[allow(non_snake_case)]
     fn format_day_suffix_S() {
         // 1 → st, 2 → nd, 3 → rd, 4 → th, 11 → th, 21 → st.
         assert_eq!(format_datetime(&dt(2026, 1, 1, 0, 0, 0), "S"), "st");
@@ -594,6 +609,11 @@ mod tests {
     }
 
     #[test]
+    // Named for the Django format code under test. Those codes are
+    // case-sensitive — `N` (AP-style month) is a different specifier
+    // from `n` (month number) — so lowercasing the suffix would make
+    // the pair indistinguishable.
+    #[allow(non_snake_case)]
     fn format_leap_year_L() {
         assert_eq!(format_datetime(&dt(2024, 1, 1, 0, 0, 0), "L"), "1"); // leap
         assert_eq!(format_datetime(&dt(2026, 1, 1, 0, 0, 0), "L"), "0"); // not leap

--- a/crates/rustango/src/migrate/scaffold.rs
+++ b/crates/rustango/src/migrate/scaffold.rs
@@ -466,6 +466,12 @@ use axum::response::Html;
 
 /// `GET /<app-prefix>/hello` — placeholder. Wire the actual path
 /// in `urls.rs` once you decide on the app's URL prefix.
+///
+/// `dead_code` is allowed because the matching `.route(...)` line in
+/// `urls.rs` ships commented out on purpose — the stub is there to be
+/// wired up, so until you do, nothing references it. Without this a
+/// freshly generated app warns before you have written a line.
+#[allow(dead_code)]
 pub async fn hello() -> Html<&'static str> {
     Html(\"<h1>hello from your new app</h1>\")
 }

--- a/crates/rustango/src/test_db.rs
+++ b/crates/rustango/src/test_db.rs
@@ -286,7 +286,10 @@ mod tests {
         let _ = || async {
             // This closure never executes; the test exists to catch
             // macro hygiene regressions.
-            #[allow(unreachable_code, clippy::diverging_sub_expression)]
+            // `unused_variables` for the same reason as `unreachable_code`:
+            // the `unimplemented!()` initialiser diverges, so every use of
+            // `pool` below is unreachable and the binding reads as unused.
+            #[allow(unreachable_code, unused_variables, clippy::diverging_sub_expression)]
             {
                 let pool: &crate::sql::Pool = unimplemented!();
                 let _r: Result<i32, _> =

--- a/crates/rustango/src/testkit.rs
+++ b/crates/rustango/src/testkit.rs
@@ -253,7 +253,6 @@ pub fn admin_user() -> crate::admin::AdminUser {
 #[cfg(all(test, feature = "sqlite", feature = "tenancy", feature = "admin"))]
 mod tests {
     use super::*;
-    use crate::core::Model as _;
 
     #[tokio::test]
     async fn framework_tables_and_factories_roundtrip() {

--- a/crates/rustango/tests/admin_object_permissions_sqlite_live.rs
+++ b/crates/rustango/tests/admin_object_permissions_sqlite_live.rs
@@ -7,7 +7,6 @@
 
 use axum::body::Body;
 use axum::http::{header, Method, Request, StatusCode};
-use http_body_util::BodyExt;
 use rustango::sql::Pool;
 use rustango::Model;
 use serde_json::Value;
@@ -74,7 +73,7 @@ async fn fresh_pool() -> Pool {
 async fn status_of(method: Method, uri: &str, body: Body) -> StatusCode {
     let pool = fresh_pool().await;
     let app = build_app(pool);
-    let mut req = Request::builder().method(method).uri(uri);
+    let req = Request::builder().method(method).uri(uri);
     let req = req
         .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
         .body(body)

--- a/crates/rustango/tests/aggregate_alias.rs
+++ b/crates/rustango/tests/aggregate_alias.rs
@@ -15,7 +15,7 @@
 //!    SQLite — no hardcoded dialect.
 
 use rustango::core::aggregates::count_all;
-use rustango::core::{Model as _, Op};
+use rustango::core::Op;
 use rustango::query::QuerySet;
 use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
 use rustango::Model;

--- a/crates/rustango/tests/aggregate_fetch_on_pg_live.rs
+++ b/crates/rustango/tests/aggregate_fetch_on_pg_live.rs
@@ -15,7 +15,6 @@
 #![cfg(feature = "postgres")]
 
 use rustango::core::aggregates::sum;
-use rustango::core::Model as _;
 use rustango::sql::sqlx::{self, PgPool};
 use rustango::sql::Auto;
 use rustango::Model;

--- a/crates/rustango/tests/assert_num_queries_sqlite_live.rs
+++ b/crates/rustango/tests/assert_num_queries_sqlite_live.rs
@@ -9,7 +9,6 @@
 
 #![cfg(all(feature = "sqlite", feature = "tenancy"))]
 
-use rustango::core::{Column as _, Model as _};
 use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
 use rustango::test_assertions::{assert_num_queries, QueryCounter};
 use rustango::Model;

--- a/crates/rustango/tests/casts_encrypted_pg_live.rs
+++ b/crates/rustango/tests/casts_encrypted_pg_live.rs
@@ -9,7 +9,7 @@
 use std::sync::OnceLock;
 
 use rustango::casts::{Cast, EncryptedString};
-use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
+use rustango::sql::{sqlx, Auto, Pool};
 use rustango::Model;
 use tokio::sync::Mutex;
 

--- a/crates/rustango/tests/casts_encrypted_sqlite_live.rs
+++ b/crates/rustango/tests/casts_encrypted_sqlite_live.rs
@@ -4,7 +4,7 @@
 //! and decrypts on SELECT, while the raw column holds ciphertext.
 
 use rustango::casts::{Cast, EncryptedString};
-use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
+use rustango::sql::{sqlx, Auto, Pool};
 use rustango::Model;
 
 #[derive(Model, Debug, Clone)]

--- a/crates/rustango/tests/extra_permissions_live.rs
+++ b/crates/rustango/tests/extra_permissions_live.rs
@@ -7,7 +7,6 @@
 
 #![cfg(all(feature = "sqlite", feature = "tenancy"))]
 
-use rustango::core::Model as _;
 use rustango::sql::{sqlx, Pool};
 use rustango::tenancy::permissions::auto_create_permissions_pool;
 use rustango::Model;

--- a/crates/rustango/tests/get_latest_by_live.rs
+++ b/crates/rustango/tests/get_latest_by_live.rs
@@ -6,7 +6,6 @@
 
 #![cfg(feature = "sqlite")]
 
-use rustango::core::Model as _;
 use rustango::sql::{sqlx, Pool};
 use rustango::Model;
 

--- a/crates/rustango/tests/hstore_field_pg_live.rs
+++ b/crates/rustango/tests/hstore_field_pg_live.rs
@@ -10,7 +10,7 @@
 
 use std::sync::OnceLock;
 
-use rustango::sql::{sqlx, Auto, FetcherPool as _, HStore, Pool};
+use rustango::sql::{sqlx, Auto, HStore, Pool};
 use rustango::Model;
 use tokio::sync::Mutex;
 

--- a/crates/rustango/tests/i18n_admin_editor_sqlite_live.rs
+++ b/crates/rustango/tests/i18n_admin_editor_sqlite_live.rs
@@ -65,7 +65,7 @@ async fn editor_save_store_render_round_trip() {
     ];
     apply_edits(&p, &edits2, "bob").await.unwrap();
 
-    let (locales, rows) = pivot(&editor_rows(&p).await.unwrap());
+    let (_locales, rows) = pivot(&editor_rows(&p).await.unwrap());
     let greeting = rows.iter().find(|r| r.key == "greeting").unwrap();
     // en unchanged, fr updated — no duplicate rows.
     assert_eq!(

--- a/crates/rustango/tests/in_bulk_emission.rs
+++ b/crates/rustango/tests/in_bulk_emission.rs
@@ -4,7 +4,7 @@
 //! shape (a plain `WHERE <col> IN (...)`) across all three dialects
 //! without needing a database.
 
-use rustango::core::{Model as _, Op, SqlValue};
+use rustango::core::{Op, SqlValue};
 #[cfg(feature = "mysql")]
 use rustango::sql::MySql;
 #[cfg(feature = "sqlite")]

--- a/crates/rustango/tests/listview_tenant_action_pool.rs
+++ b/crates/rustango/tests/listview_tenant_action_pool.rs
@@ -13,7 +13,7 @@
 
 use std::sync::Arc;
 
-use rustango::core::{Model as _, SqlValue};
+use rustango::core::SqlValue;
 use rustango::sql::Pool;
 use rustango::template_views::{BulkActionFuture, ListView, TenantBulkActionPoolFn};
 use rustango::Model;

--- a/crates/rustango/tests/m2m_changed_signal_sqlite_live.rs
+++ b/crates/rustango/tests/m2m_changed_signal_sqlite_live.rs
@@ -62,7 +62,7 @@ async fn add_fires_with_add_action_and_single_dst_pk() {
     });
 
     let pool = pool_with_junction().await;
-    mgr(1).add_pool(7, &pool).await.unwrap();
+    mgr(1).add(7, &pool).await.unwrap();
 
     let got = captured.lock().await;
     assert_eq!(got.len(), 1, "exactly one fire, got: {got:?}");
@@ -90,10 +90,10 @@ async fn remove_fires_with_remove_action() {
 
     let pool = pool_with_junction().await;
     let m = mgr(1);
-    m.add_pool(7, &pool).await.unwrap();
+    m.add(7, &pool).await.unwrap();
     captured.lock().await.clear(); // ignore the Add for clarity
 
-    m.remove_pool(7, &pool).await.unwrap();
+    m.remove(7, &pool).await.unwrap();
 
     let got = captured.lock().await;
     assert_eq!(got.len(), 1);
@@ -116,7 +116,7 @@ async fn set_fires_with_set_action_and_full_new_set() {
     });
 
     let pool = pool_with_junction().await;
-    mgr(1).set_pool(&[7, 8, 9], &pool).await.unwrap();
+    mgr(1).set(&[7, 8, 9], &pool).await.unwrap();
 
     let got = captured.lock().await;
     assert_eq!(got.len(), 1, "set fires once, got: {got:?}");
@@ -139,10 +139,10 @@ async fn set_with_empty_slice_fires_set_with_empty_pks() {
     });
 
     let pool = pool_with_junction().await;
-    mgr(1).add_pool(7, &pool).await.unwrap();
+    mgr(1).add(7, &pool).await.unwrap();
     captured.lock().await.clear();
 
-    mgr(1).set_pool(&[], &pool).await.unwrap();
+    mgr(1).set(&[], &pool).await.unwrap();
 
     let got = captured.lock().await;
     assert_eq!(got.len(), 1);
@@ -166,11 +166,11 @@ async fn clear_fires_with_clear_action_and_empty_pks() {
 
     let pool = pool_with_junction().await;
     let m = mgr(1);
-    m.add_pool(7, &pool).await.unwrap();
-    m.add_pool(8, &pool).await.unwrap();
+    m.add(7, &pool).await.unwrap();
+    m.add(8, &pool).await.unwrap();
     captured.lock().await.clear();
 
-    m.clear_pool(&pool).await.unwrap();
+    m.clear(&pool).await.unwrap();
 
     let got = captured.lock().await;
     assert_eq!(got.len(), 1);
@@ -187,9 +187,9 @@ async fn no_receivers_does_not_break_m2m_ops() {
     let pool = pool_with_junction().await;
     let m = mgr(1);
     // All four mutating ops must succeed with no receivers connected.
-    m.add_pool(7, &pool).await.unwrap();
-    m.add_pool(8, &pool).await.unwrap();
-    m.remove_pool(7, &pool).await.unwrap();
-    m.set_pool(&[9, 10], &pool).await.unwrap();
-    m.clear_pool(&pool).await.unwrap();
+    m.add(7, &pool).await.unwrap();
+    m.add(8, &pool).await.unwrap();
+    m.remove(7, &pool).await.unwrap();
+    m.set(&[9, 10], &pool).await.unwrap();
+    m.clear(&pool).await.unwrap();
 }

--- a/crates/rustango/tests/m2m_sqlite_live.rs
+++ b/crates/rustango/tests/m2m_sqlite_live.rs
@@ -1,5 +1,5 @@
-//! Live regression for v0.35 slice 1 — `M2MManager::*_pool` methods
-//! against a SQLite junction table. Proves all six CRUD operations
+//! Live regression for v0.35 slice 1 — the `M2MManager` CRUD methods
+//! against a SQLite junction table. Proves all six operations
 //! (`all`, `add`, `remove`, `set`, `clear`, `contains`) work
 //! end-to-end on sqlite without any Postgres dependency.
 //!
@@ -49,54 +49,54 @@ async fn m2m_full_lifecycle_on_sqlite() {
     let m = mgr(1);
 
     // Empty to start.
-    let initial: Vec<i64> = m.all_pool(&pool).await.expect("all");
+    let initial: Vec<i64> = m.all(&pool).await.expect("all");
     assert!(initial.is_empty());
-    assert!(!m.contains_pool(42, &pool).await.expect("contains"));
+    assert!(!m.contains(42, &pool).await.expect("contains"));
 
     // Add three.
-    m.add_pool(10, &pool).await.expect("add 10");
-    m.add_pool(20, &pool).await.expect("add 20");
-    m.add_pool(30, &pool).await.expect("add 30");
+    m.add(10, &pool).await.expect("add 10");
+    m.add(20, &pool).await.expect("add 20");
+    m.add(30, &pool).await.expect("add 30");
 
     // add() is idempotent — duplicate is a no-op via
     // `INSERT … ON CONFLICT DO NOTHING` on sqlite.
-    m.add_pool(20, &pool).await.expect("add 20 again");
+    m.add(20, &pool).await.expect("add 20 again");
 
-    let mut got = m.all_pool(&pool).await.expect("all after add");
+    let mut got = m.all(&pool).await.expect("all after add");
     got.sort_unstable();
     assert_eq!(got, vec![10, 20, 30]);
 
-    assert!(m.contains_pool(10, &pool).await.expect("contains 10"));
-    assert!(m.contains_pool(20, &pool).await.expect("contains 20"));
-    assert!(!m.contains_pool(99, &pool).await.expect("contains 99"));
+    assert!(m.contains(10, &pool).await.expect("contains 10"));
+    assert!(m.contains(20, &pool).await.expect("contains 20"));
+    assert!(!m.contains(99, &pool).await.expect("contains 99"));
 
     // Remove one.
-    m.remove_pool(20, &pool).await.expect("remove 20");
-    let mut got = m.all_pool(&pool).await.expect("all after remove");
+    m.remove(20, &pool).await.expect("remove 20");
+    let mut got = m.all(&pool).await.expect("all after remove");
     got.sort_unstable();
     assert_eq!(got, vec![10, 30]);
     assert!(!m
-        .contains_pool(20, &pool)
+        .contains(20, &pool)
         .await
         .expect("contains 20 after remove"));
 
     // Replace via set — atomic DELETE + multi-row INSERT.
-    m.set_pool(&[100, 200, 300], &pool).await.expect("set");
-    let mut got = m.all_pool(&pool).await.expect("all after set");
+    m.set(&[100, 200, 300], &pool).await.expect("set");
+    let mut got = m.all(&pool).await.expect("all after set");
     got.sort_unstable();
     assert_eq!(got, vec![100, 200, 300]);
 
     // Empty set wipes.
-    m.set_pool(&[], &pool).await.expect("set empty");
-    let got = m.all_pool(&pool).await.expect("all after empty set");
+    m.set(&[], &pool).await.expect("set empty");
+    let got = m.all(&pool).await.expect("all after empty set");
     assert!(got.is_empty());
 
     // Clear is also a wipe (idempotent).
-    m.add_pool(7, &pool).await.expect("add 7");
-    m.clear_pool(&pool).await.expect("clear");
-    let got = m.all_pool(&pool).await.expect("all after clear");
+    m.add(7, &pool).await.expect("add 7");
+    m.clear(&pool).await.expect("clear");
+    let got = m.all(&pool).await.expect("all after clear");
     assert!(got.is_empty());
-    m.clear_pool(&pool).await.expect("clear idempotent");
+    m.clear(&pool).await.expect("clear idempotent");
 }
 
 #[tokio::test]
@@ -105,23 +105,19 @@ async fn m2m_isolates_by_source_pk_on_sqlite() {
     let m1 = mgr(1);
     let m2 = mgr(2);
 
-    m1.add_pool(10, &pool).await.expect("m1 add 10");
-    m1.add_pool(20, &pool).await.expect("m1 add 20");
-    m2.add_pool(99, &pool).await.expect("m2 add 99");
+    m1.add(10, &pool).await.expect("m1 add 10");
+    m1.add(20, &pool).await.expect("m1 add 20");
+    m2.add(99, &pool).await.expect("m2 add 99");
 
-    let mut got1 = m1.all_pool(&pool).await.expect("m1 all");
+    let mut got1 = m1.all(&pool).await.expect("m1 all");
     got1.sort_unstable();
     assert_eq!(got1, vec![10, 20]);
 
-    let got2 = m2.all_pool(&pool).await.expect("m2 all");
+    let got2 = m2.all(&pool).await.expect("m2 all");
     assert_eq!(got2, vec![99]);
 
     // Clearing m1 must not touch m2.
-    m1.clear_pool(&pool).await.expect("m1 clear");
-    assert!(m1
-        .all_pool(&pool)
-        .await
-        .expect("m1 all after clear")
-        .is_empty());
-    assert_eq!(m2.all_pool(&pool).await.expect("m2 all"), vec![99]);
+    m1.clear(&pool).await.expect("m1 clear");
+    assert!(m1.all(&pool).await.expect("m1 all after clear").is_empty());
+    assert_eq!(m2.all(&pool).await.expect("m2 all"), vec![99]);
 }

--- a/crates/rustango/tests/macro_db_table_comment.rs
+++ b/crates/rustango/tests/macro_db_table_comment.rs
@@ -4,7 +4,6 @@
 
 #![cfg(feature = "sqlite")]
 
-use rustango::core::Model as _;
 use rustango::migrate::ddl::{
     create_table_sql_with_dialect, table_comment_statements_with_dialect,
 };

--- a/crates/rustango/tests/offset_without_limit.rs
+++ b/crates/rustango/tests/offset_without_limit.rs
@@ -7,7 +7,6 @@
 //! placeholder) ahead of the OFFSET on MySQL. PG + SQLite accept
 //! the bare OFFSET and the writer leaves the LIMIT off.
 
-use rustango::core::Model as _;
 use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
 use rustango::Model;
 

--- a/crates/rustango/tests/order_random.rs
+++ b/crates/rustango/tests/order_random.rs
@@ -3,7 +3,6 @@
 //! direction / NULLS slot; the writer emits exactly
 //! `ORDER BY <fn>()` (no `DESC`, no `NULLS …`).
 
-use rustango::core::Model as _;
 use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
 use rustango::Model;
 

--- a/crates/rustango/tests/q_builder.rs
+++ b/crates/rustango/tests/q_builder.rs
@@ -7,7 +7,6 @@
 //!   3. The wrapped `Q` works in both `.where_raw(q.into())` (untyped)
 //!      and `.where_(q)` (typed via Into<TypedExpr<T>>).
 
-use rustango::core::Model as _;
 use rustango::query::{QuerySet, Q};
 use rustango::sql::{Dialect, MySql, Postgres, Sqlite};
 

--- a/crates/rustango/tests/queryset_exclude_sqlite_live.rs
+++ b/crates/rustango/tests/queryset_exclude_sqlite_live.rs
@@ -5,7 +5,6 @@
 
 #![cfg(all(feature = "sqlite", feature = "tenancy"))]
 
-use rustango::core::Model as _;
 use rustango::sql::{raw_execute_pool, sqlx, FetcherPool as _, Pool};
 use rustango::Model;
 

--- a/crates/rustango/tests/queryset_when_unless_tap.rs
+++ b/crates/rustango/tests/queryset_when_unless_tap.rs
@@ -4,7 +4,6 @@
 //! a real DB — the goal is to assert the closure ran or didn't
 //! based on the boolean flag.
 
-use rustango::core::Model as _;
 use rustango::sql::Auto;
 use rustango::Model;
 

--- a/crates/rustango/tests/sqlite_bulk_update_live.rs
+++ b/crates/rustango/tests/sqlite_bulk_update_live.rs
@@ -11,7 +11,7 @@
 
 #![cfg(feature = "sqlite")]
 
-use rustango::core::{BulkUpdateQuery, Model as _, SqlValue};
+use rustango::core::{BulkUpdateQuery, SqlValue};
 use rustango::sql::{bulk_update_pool, sqlx, Dialect as _, Pool, Sqlite};
 use rustango::Model;
 

--- a/crates/rustango/tests/subquery_join_lateral_pg_live.rs
+++ b/crates/rustango/tests/subquery_join_lateral_pg_live.rs
@@ -10,7 +10,7 @@
 use std::sync::OnceLock;
 
 use rustango::core::joins::aliased;
-use rustango::core::{Model as _, Op, WhereExpr};
+use rustango::core::{Op, WhereExpr};
 use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
 use rustango::Model;
 use tokio::sync::Mutex;

--- a/crates/rustango/tests/subquery_join_sqlite_live.rs
+++ b/crates/rustango/tests/subquery_join_sqlite_live.rs
@@ -6,7 +6,7 @@
 
 use rustango::core::joins::aliased;
 use rustango::core::window::row_number;
-use rustango::core::{Expr, Model as _, Op, SqlValue, WhereExpr};
+use rustango::core::{Expr, Op, SqlValue, WhereExpr};
 use rustango::sql::{sqlx, Auto, FetcherPool as _, ForeignKey, Pool};
 use rustango::Model;
 

--- a/crates/rustango/tests/tenant_auth_sqlite_live.rs
+++ b/crates/rustango/tests/tenant_auth_sqlite_live.rs
@@ -11,7 +11,6 @@
 
 #![cfg(all(feature = "sqlite", feature = "tenancy", feature = "passwords"))]
 
-use rustango::core::Model as _;
 use rustango::sql::{sqlx, Pool};
 
 async fn sqlite_pool() -> Pool {

--- a/examples/showcase/Cargo.lock
+++ b/examples/showcase/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1633,7 +1633,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2062,6 +2062,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2072,6 +2073,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2865,6 +2867,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]


### PR DESCRIPTION
Audited every build CI performs — the workspace, all 10 feature combos, and
all 8 standalone example crates — and took rustc warnings to zero.

**108 unique warnings → 0**, plus one example that did not compile at all.

| Lint | Was | Fix |
|---|---:|---|
| `unreachable_code` | 35 | one macro fix (below) |
| `deprecated` | 43 | `M2MManager::*_pool` → canonical bare names |
| `unused_imports` | 23 | `cargo fix`, plus 5 multi-item `use` by hand |
| `non_snake_case` | 4 | annotated, **not** renamed (below) |
| `unused_variables` / `unused_mut` | 3 | fixed |

Verified clean on `--workspace --all-features --all-targets`, each of the ten
`feature_combos` entries, and all eight example crates.

## Two of these were framework bugs, not test noise

**`#[derive(Model)]` emitted an unreachable statement into every user's crate.**
The generated `bulk_update` builds `let _col = match _f { … }`. For a model with
no updatable non-PK fields, the PK arm errors and the catch-all errors — every
arm diverges — so the following `_update_columns.push(_col)` is unreachable.
Any user with a **PK-only model** (join tables, marker tables) got a warning in
their own crate that they had no way to act on. One allow clears all 35; it is
scoped to the statement rather than the function so genuine unreachability
elsewhere in that body still warns.

**`manage startapp` generated an app that warns on sight.** The placeholder
`hello` view ships with its `.route(...)` line commented out on purpose — a
teaching device — so nothing references it and a freshly generated app warns
before the user has written a line. Fixed in the generator (`scaffold.rs`), not
only in the checked-in example.

## An example that never compiled, and CI could not have known

`tenant_user_extension` failed with **57 errors**. It is listed in
`deny-examples`, which runs advisories only, and is absent from the
`doc_examples` matrix — so nothing ever built it.

The cause is the #1211 shape: `#[derive(Model)]` gates its emissions on the
features of *the crate it expands in*, not on rustango's. This example enabled
`rustango/postgres` from the dependency line but declared no `postgres` feature
of its own, so the derive skipped every PG `FromRow` / `MaybePgFromRow` impl.
It also produced the `unexpected cfg condition value: postgres` warning, same
root cause. Added the `[features]` block every other standalone example already
carries.

Worth deciding separately: whether `tenant_user_extension` should join the
`doc_examples` matrix so it cannot rot again. I have not changed the matrix
here — that adds a CI job and is your call.

## Deliberately not silenced

- **The four `non_snake_case` names** in `dateformat.rs` are test functions
  named for Django format codes, which are **case-sensitive**: `N` (AP-style
  month) is a different specifier from `n` (month number). Lowercasing would
  make the pair indistinguishable, so they carry an annotation explaining why
  instead of a rename.
- **clippy::pedantic (~2689 warnings)** is untouched. That is a deliberate
  warn-level baseline the repo already documents, and a much larger, more
  opinionated question than rustc lints.

## Also in the diff

Example lockfiles pick up `rustls` / `ring` / `webpki-roots`: they were stale
relative to the `sqlx/tls-rustls` change from #1288 and re-resolved when these
crates were built.

## Scope

Compile-time warnings only. Test-*time* output (e.g. `tracing::warn!` during
runs) is not covered here and would be a separate pass.
