### PR TITLE
release: 0.56.0 — version bump + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+## [0.56.0] — 2026-09-04
+
+A correctness and hardening release. Three of these were **silent** failures —
+a control that reported success while doing nothing — which is the property
+that makes a bug dangerous regardless of its severity.
+
+The headline items: rate limiting and account lockout did nothing at all on
+Redis 6.x; `DistributedLock` provided no mutual exclusion on `DatabaseCache`
+(measured: 13 of 16 concurrent acquirers won); and `drop_all_pool` failed on
+MySQL for any schema with foreign keys. CSV export gained formula-injection
+neutralisation, `bulk_insert` now batches against the backend's bind-parameter
+ceiling, and sqlx finally has a TLS backend so managed Postgres/MySQL
+(Supabase, Neon, RDS) work at all.
+
+Also: `Cargo.lock` is now committed. Ignoring it let two separate broken
+upstream releases (`time` 0.3.48, then `tinyvec` 1.13.0) turn every CI job red
+on unchanged code.
+
 ### Security
 - **Rate limiting and account lockout silently did nothing on Redis 6.x**
   (#1280). `RedisCache::incr` set its window TTL with `EXPIRE key secs NX`, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cargo-rustango"
-version = "0.55.0"
+version = "0.56.0"
 
 [[package]]
 name = "cc"
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-stream",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-orm-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "rustango",
  "rustango-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.55.0"
+version = "0.56.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.55.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.55.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.55.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.56.0", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.56.0", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.56.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ Rustango gives you the productivity of Django or Laravel with the speed and type
 ```toml
 [dependencies]
 # Postgres (default)
-rustango = "0.55"
+rustango = "0.56"
 
 # SQLite — file-backed or in-memory
-rustango = { version = "0.55", default-features = false, features = ["sqlite", "tenancy", "admin", "manage"] }
+rustango = { version = "0.56", default-features = false, features = ["sqlite", "tenancy", "admin", "manage"] }
 
 # MySQL 8+
-rustango = { version = "0.55", default-features = false, features = ["mysql", "tenancy", "admin", "manage"] }
+rustango = { version = "0.56", default-features = false, features = ["mysql", "tenancy", "admin", "manage"] }
 ```
 
-Every capability is a cargo feature you can turn off. Renaming the dep works too — `#[derive(Model)]` resolves the crate root via `proc-macro-crate`, so `orm = { package = "rustango", version = "0.55" }` needs no extra wiring.
+Every capability is a cargo feature you can turn off. Renaming the dep works too — `#[derive(Model)]` resolves the crate root via `proc-macro-crate`, so `orm = { package = "rustango", version = "0.56" }` needs no extra wiring.
 
 ## An app on SQLite in 30 lines
 

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.55.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.56.0" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -486,7 +486,7 @@ runserver = ["_axum"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.55.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.56.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }

--- a/crates/rustango/examples/admin_demo/Cargo.lock
+++ b/crates/rustango/examples/admin_demo/Cargo.lock
@@ -889,7 +889,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1753,7 +1753,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2170,6 +2170,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2180,6 +2181,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3017,6 +3019,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/auth_demo/Cargo.lock
+++ b/crates/rustango/examples/auth_demo/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1776,7 +1776,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2211,6 +2211,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2221,6 +2222,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3020,6 +3022,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/cookbook_blog/Cargo.lock
+++ b/crates/rustango/examples/cookbook_blog/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1772,7 +1772,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2188,6 +2188,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2198,6 +2199,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3025,6 +3027,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/getting_started_blog/Cargo.lock
+++ b/crates/rustango/examples/getting_started_blog/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1766,7 +1766,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2183,6 +2183,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2193,6 +2194,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3044,6 +3046,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/mcp_demo/Cargo.lock
+++ b/crates/rustango/examples/mcp_demo/Cargo.lock
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-stream",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/crates/rustango/examples/orm_cookbook/Cargo.lock
+++ b/crates/rustango/examples/orm_cookbook/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1752,7 +1752,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2169,6 +2169,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2179,6 +2180,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3016,6 +3018,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/tenant_user_extension/Cargo.lock
+++ b/crates/rustango/examples/tenant_user_extension/Cargo.lock
@@ -1445,6 +1445,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1541,13 +1555,47 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "serde_json",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1782,6 +1830,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -1792,6 +1841,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2360,6 +2410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2485,6 +2541,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,7 +2642,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2586,13 +2669,29 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2602,10 +2701,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2614,10 +2725,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2626,16 +2755,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -18,10 +18,10 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rustango = "0.55"                                        # Postgres (the default backend)
+//! rustango = "0.56"                                        # Postgres (the default backend)
 //! # or pick another backend — see "Choosing a backend" below:
-//! rustango = { version = "0.55", default-features = false, features = ["sqlite", "batteries"] }
-//! rustango = { version = "0.55", default-features = false, features = ["mysql",  "batteries"] }
+//! rustango = { version = "0.56", default-features = false, features = ["sqlite", "batteries"] }
+//! rustango = { version = "0.56", default-features = false, features = ["mysql",  "batteries"] }
 //! ```
 //!
 //! `default = ["postgres", "batteries"]`. The **`batteries`** feature is

--- a/examples/showcase/Cargo.lock
+++ b/examples/showcase/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1633,7 +1633,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2062,6 +2062,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2072,6 +2073,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2865,6 +2867,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]


### PR DESCRIPTION
Version bump + CHANGELOG for **0.56.0**. Cut fresh from current `develop` —
the old `release/v0.56.0` branch is stale at `bbebd24d` and predates six
merged PRs; it should be deleted rather than reused (it is also what led a
user in discussion #1179 to ask how to install a "0.56" that was never
published, since its README already advertised the version).

## What ships

A correctness and hardening release. Three of these were **silent** failures —
a control reporting success while doing nothing:

- **Rate limiting and account lockout did nothing on Redis 6.x** (#1280).
  `EXPIRE … NX` is 7.0+; both callers fail open.
- **`DistributedLock` had no mutual exclusion on `DatabaseCache`** (#1281).
  Measured: 16 concurrent acquirers → **13 winners**.
- **`drop_all_pool` failed on MySQL** for any schema with FKs (#1277).

Plus: CSV formula injection (#1283), `bulk_insert` bind-parameter batching
(#1284), the `?ordering=` allowlist (#1282), `derive(ViewSet)` taking
`Into<Pool>` (#1273), the MCP raw-credential bearer (#1276), sqlx TLS so
managed Postgres/MySQL work at all (#1288), and S3 endpoints carrying a path
prefix (#1289).

## Lockfiles move this cycle

New since #1287 made `Cargo.lock` tracked. The eight standalone example locks
pin `rustango` by path, so they recorded `0.55.0` and would have gone stale
against the bump — they are refreshed here alongside the workspace lock.

## Not included

**#1290** (zero rustc warnings + an example that never compiled) is still open.
It is not on `develop`, so it is not in this cut. If you want it in 0.56.0,
merge it first and I will rebase this branch — otherwise it lands in the next
release. Worth a moment's thought: it contains a real user-visible fix
(`#[derive(Model)]` emitted an unreachable-statement warning into every crate
with a PK-only model).

## After this merges

`develop` → `main` promote, tag `v0.56.0`, then publish four crates in
dependency order: `rustango-macros` → `rustango` → `rustango-orm-macros` →
`cargo-rustango`.
