### PR TITLE
docs: stop claiming the scaffolder generates admin_router; say where auth code goes

### DIFF
--- a/crates/cargo-rustango/src/templates.rs
+++ b/crates/cargo-rustango/src/templates.rs
@@ -316,9 +316,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 const MAIN_RS_FULLSTACK: &str = "//! Project entrypoint — `Cli::run()` is the unified dispatcher
 //! that handles `cargo run` (runserver) AND `cargo run -- migrate` /
 //! `makemigrations` / `startapp` / etc. from one binary. No
-//! `src/bin/manage.rs` needed. The auto-admin lives in
-//! `urls::admin_router(pool)`; nest it under `/admin` when you want
-//! it (see the getting-started guide).
+//! `src/bin/manage.rs` needed. The auto-admin is not wired up for
+//! you: add an `admin_router(pool)` helper to `src/urls.rs` and nest
+//! it under `/admin` (see the getting-started guide, Step 11).
 //!
 //! Logging is auto-configured by `#[rustango::main]` —
 //! `tracing_subscriber::fmt` with env-filter, default
@@ -464,12 +464,18 @@ pub fn api() -> Router<()> {
         }
         Template::Fullstack => {
             // #1210/#1211 — this used to also emit an `admin_router(pool)`
-            // helper. Nothing called it: `Cli` mounts the auto-admin itself,
-            // so calling the helper was never how you got an admin. It was
-            // therefore dead code (a warning in every fresh project) *and*
-            // misleading — and it was the only generated line naming `PgPool`,
-            // hard-wiring Postgres into a project whose manifest offers
-            // sqlite and mysql.
+            // helper. Nothing generated called it (the generated `main.rs`
+            // never nested it), so it was dead code — a warning in every
+            // fresh project — and it was the only generated line naming
+            // `PgPool`, hard-wiring Postgres into a project whose manifest
+            // offers sqlite and mysql.
+            //
+            // Removing it means a fullstack project has NO admin until the
+            // author adds one. There is no `Cli` auto-mount for the
+            // single-tenant admin (that exists only for `tenancy`), so
+            // getting-started Step 11 has to spell the helper out — see
+            // `examples/getting_started_blog/src/urls.rs`, which defines it
+            // by hand and is covered by `tests/admin_smoke.rs`.
             "//! Project URL routing (template: fullstack — ORM + auto-admin).
 //!
 //! `Router::new()` in `api()` is the auto-mount anchor —

--- a/docs/fr/getting-started.md
+++ b/docs/fr/getting-started.md
@@ -122,7 +122,7 @@ myblog/
     ├── main.rs                 # entry point: `Cli::new().api(urls::api()).run()`
     ├── models.rs               # every #[derive(Model)] lives here
     ├── views.rs                # axum request handlers
-    └── urls.rs                 # `pub fn api()` route aggregator + `admin_router(pool)`
+    └── urls.rs                 # agrégateur de routes `pub fn api()`
 ```
 
 Il n'y a qu'un seul binaire : `cargo run` démarre le serveur HTTP, et chaque verbe de style Django (`migrate`, `makemigrations`, `startapp`, `check`, …) passe par ce même binaire via `cargo run -- <verb>`. Il n'y a pas de binaire `manage` séparé.
@@ -415,9 +415,9 @@ Vous devriez voir l'identifiant de votre nouvel article ainsi que les lignes lue
 
 ## Étape 11 : activer l'administration automatique
 
-**Rustango** fournit une interface d'administration générée pour vos modèles, tout comme l'administration Django. Le générateur de squelette vous a déjà donné un utilitaire `admin_router(pool)` dans `src/urls.rs` qui construit l'administration automatique à partir d'un pool — vous n'avez qu'à l'imbriquer sous `/admin` et à l'injecter dans le `Cli`.
+**Rustango** fournit une interface d'administration générée pour vos modèles, tout comme l'administration Django. Sa mise en place tient en deux petites étapes : un utilitaire qui transforme un pool en routeur d'administration, et un seul appel `.nest(...)` pour le monter.
 
-Donnez d'abord un titre à l'administration dans `src/urls.rs`. Le `admin_prefix` doit correspondre au chemin sous lequel vous l'imbriquerez à l'étape suivante (`/admin`) afin que les propres liens et actions de formulaire de l'administration se résolvent correctement :
+Ajoutez vous-même cet utilitaire dans `src/urls.rs` — le générateur de squelette ne le crée pas (il n'émet volontairement aucun code typé `PgPool`, afin que le même modèle fonctionne sur SQLite et MySQL). Le `admin_prefix` doit correspondre au chemin sous lequel vous l'imbriquerez à l'étape suivante (`/admin`) afin que les propres liens et actions de formulaire de l'administration se résolvent correctement :
 
 ```rust
 pub fn admin_router(pool: PgPool) -> Router {
@@ -587,6 +587,8 @@ Les JWT sont des jetons signés que vous remettez à un client après la connexi
 
 ### 14a. Émettre un jeton à la connexion
 
+Il s'agit de fragments, et non de fichiers autonomes : celui-ci se place à l'intérieur de votre gestionnaire de connexion dans `src/views.rs`, aux côtés des gestionnaires de l'étape 6.
+
 Intégrez l'identifiant de l'utilisateur (le « sujet » du jeton) et toute revendication (claim) personnalisée, comme les rôles, dans un jeton signé, puis remettez-le au client :
 
 ```rust
@@ -604,6 +606,8 @@ let token = encode(&claims.ttl(Duration::from_secs(900)), &secret)?;
 ```
 
 ### 14b. Vérifier le jeton à chaque requête
+
+Ce code se place là où vous protégez une route — dans un gestionnaire protégé de `src/views.rs`, ou dans un extracteur axum / une couche `middleware::from_fn` si vous souhaitez l'appliquer à toute une sous-arborescence.
 
 Décodez le jeton — ceci vérifie la signature et l'expiration — puis relisez les revendications (claims). S'il est absent ou invalide, rejetez la requête comme non autorisée :
 
@@ -625,7 +629,7 @@ let roles: Vec<String> = claims.get("roles").unwrap_or_default();
 
 ## Étape 15 : ajouter le middleware de sécurité
 
-Le middleware englobe chaque requête pour y ajouter un comportement transversal. Ici, vous empilez les identifiants de requête, la journalisation des accès, la limitation de débit, le CORS et les en-têtes de sécurité en une seule chaîne. Chaque `.method(...)` ajoute une couche, de manière similaire au middleware Django ou à la pile de middleware de Laravel. Voir le [guide du middleware](middleware.md) pour le catalogue complet des couches et les règles d'ordonnancement.
+Le middleware englobe chaque requête pour y ajouter un comportement transversal. Ce code se place dans `src/main.rs` : il remplace la ligne `let api = ...` de l'étape 11, afin que le routeur soit entièrement assemblé avant d'atteindre le `Cli`. Ici, vous empilez les identifiants de requête, la journalisation des accès, la limitation de débit, le CORS et les en-têtes de sécurité en une seule chaîne. Chaque `.method(...)` ajoute une couche, de manière similaire au middleware Django ou à la pile de middleware de Laravel. Voir le [guide du middleware](middleware.md) pour le catalogue complet des couches et les règles d'ordonnancement.
 
 ```rust
 use rustango::security_headers::{SecurityHeadersLayer, SecurityHeadersRouterExt, CspBuilder};

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,7 +122,7 @@ myblog/
     ├── main.rs                 # entry point: `Cli::new().api(urls::api()).run()`
     ├── models.rs               # every #[derive(Model)] lives here
     ├── views.rs                # axum request handlers
-    └── urls.rs                 # `pub fn api()` route aggregator + `admin_router(pool)`
+    └── urls.rs                 # `pub fn api()` route aggregator
 ```
 
 There is a single binary: `cargo run` boots the HTTP server, and every Django-style verb (`migrate`, `makemigrations`, `startapp`, `check`, …) flows through the same binary via `cargo run -- <verb>`. There's no separate `manage` binary.
@@ -413,9 +413,9 @@ You should see your new post id and the rows read back. Restore `src/main.rs` to
 
 ## Step 11: Turn on the auto-admin
 
-**Rustango** ships a generated admin UI for your models, just like Django admin. The scaffolder already gave you an `admin_router(pool)` helper in `src/urls.rs` that builds the auto-admin from a pool — you just need to nest it under `/admin` and feed it into the `Cli`.
+**Rustango** ships a generated admin UI for your models, just like Django admin. Building it is two small steps: a helper that turns a pool into an admin router, and one `.nest(...)` call to mount it.
 
-First, give the admin a title in `src/urls.rs`. The `admin_prefix` must match the path you'll nest it under in the next step (`/admin`) so the admin's own links and form actions resolve:
+Add the helper to `src/urls.rs` yourself — the scaffolder does not generate it (it deliberately emits no `PgPool`-typed code, so the same template works on SQLite and MySQL). The `admin_prefix` must match the path you'll nest it under in the next step (`/admin`) so the admin's own links and form actions resolve:
 
 ```rust
 pub fn admin_router(pool: PgPool) -> Router {
@@ -585,6 +585,8 @@ JWTs are signed tokens you hand a client after login and check on each request, 
 
 ### 14a. Issue a token at login
 
+These are fragments, not standalone files: this one goes inside your login handler in `src/views.rs`, alongside the handlers from Step 6.
+
 Bake the user id (the token's "subject") and any custom claims, like roles, into a signed token, then hand it to the client:
 
 ```rust
@@ -602,6 +604,8 @@ let token = encode(&claims.ttl(Duration::from_secs(900)), &secret)?;
 ```
 
 ### 14b. Verify the token on each request
+
+This belongs wherever you guard a route — inside a protected handler in `src/views.rs`, or in an axum extractor / `middleware::from_fn` layer if you want it applied to a whole subtree.
 
 Decode the token — this checks the signature and expiry — then read the claims back. If it's missing or invalid, reject the request as unauthorized:
 
@@ -623,7 +627,7 @@ let roles: Vec<String> = claims.get("roles").unwrap_or_default();
 
 ## Step 15: Add security middleware
 
-Middleware wraps every request to add cross-cutting behavior. Here you stack request IDs, access logging, rate limiting, CORS, and security headers in one chain. Each `.method(...)` adds one layer, similar to Django middleware or Laravel's middleware stack. See the [Middleware guide](middleware.md) for the full layer catalog and ordering rules.
+Middleware wraps every request to add cross-cutting behavior. This one goes in `src/main.rs`: it replaces the `let api = ...` line from Step 11, so the router is fully assembled before it reaches the `Cli`. Here you stack request IDs, access logging, rate limiting, CORS, and security headers in one chain. Each `.method(...)` adds one layer, similar to Django middleware or Laravel's middleware stack. See the [Middleware guide](middleware.md) for the full layer catalog and ordering rules.
 
 ```rust
 use rustango::security_headers::{SecurityHeadersLayer, SecurityHeadersRouterExt, CspBuilder};


### PR DESCRIPTION
Fixes two documentation defects reported in discussion #1179 (comments 6 and 7), both live on rustango.com/0.56.

## 1. `admin_router` is documented as generated, but isn't

#1210/#1211 removed the `admin_router(pool)` helper from the fullstack template — nothing generated called it, and it was the only generated line naming `PgPool`, hard-wiring Postgres into a project whose manifest offers sqlite and mysql. Reasonable change; the docs just never followed.

`docs/getting-started.md` still said *"The scaffolder already gave you an `admin_router(pool)` helper in `src/urls.rs`"* (plus the project-tree listing and three code snippets). A reader following Step 11 goes looking for a function that does not exist. That is exactly the report.

**A wrong premise made it worse.** The removal comment said `Cli` mounts the auto-admin itself, so the helper "was never how you got an admin". That isn't true for this template — there is no `Cli::admin_prefix` and no single-tenant auto-mount; the only auto-mounted admin lives under `tenancy`. A fullstack project has **no admin at all** until the author writes the helper, which is precisely what `examples/getting_started_blog/src/urls.rs` does (covered by `tests/admin_smoke.rs`).

So Step 11 now tells you to add it, and says why the generator won't emit it. The rationale comment is corrected too, so this doesn't drift back.

The generated `src/main.rs` header had the same stale pointer — every freshly scaffolded project shipped a comment aimed at a removed helper. Also fixed.

## 2. Steps 14 and 15 never say which file

Every other step names its file ("Edit `src/post_view_set.rs`:"), but the JWT and security-middleware steps were bare snippets. Now:

- **14a** — a fragment for your login handler in `src/views.rs`
- **14b** — a protected handler, or an extractor / `middleware::from_fn` layer for a whole subtree
- **15** — lives in `src/main.rs`, replacing the `let api = ...` line from Step 11

## Notes

Applied to `docs/fr/getting-started.md` as well, which had both defects — that's the copy the reporter was actually reading.

Docs and comments only; no behaviour change. `cargo check -p cargo-rustango` clean.

Publishing these to rustango.com needs a follow-up, since the docs site pins its content ref to the `v0.56.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
