### PR TITLE
release: 0.56.1 — docs patch (merge after #1294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+## [0.56.1] — 2026-09-04
+
+Documentation fixes. No code changes — the crate is byte-for-byte 0.56.0
+plus corrected docs and scaffolder comments. Cut as a release because the
+docs site publishes from a release tag.
+
+### Fixed
+
+- **getting-started no longer claims the scaffolder generates
+  `admin_router`.** #1210/#1211 removed that helper from the fullstack
+  template (nothing generated called it, and it was the only generated
+  line naming `PgPool`, hard-wiring Postgres into a project whose manifest
+  offers sqlite and mysql), but the guide still told readers it was
+  already there. Step 11 now says to add it, and why the generator won't.
+  The removal note's claim that `Cli` mounts the auto-admin itself was
+  also wrong — there is no `Cli::admin_prefix` and no single-tenant
+  auto-mount (that exists only under `tenancy`), so a fullstack project
+  has no admin until the author writes the helper. Reported in #1179.
+- **Generated `src/main.rs` no longer points at the removed helper.**
+  Every freshly scaffolded project shipped a header comment referring to
+  `urls::admin_router(pool)`, which the scaffolder stopped emitting.
+- **getting-started Steps 14 and 15 now name their files.** The JWT and
+  security-middleware steps were bare snippets while every other step
+  says "Edit `src/…`". 14a/14b are fragments for a handler in
+  `src/views.rs` (or an extractor / layer); Step 15 lives in
+  `src/main.rs`, replacing the `let api = …` line. Reported in #1179.
+- Both fixes applied to the French translation as well.
+
+
 ## [0.56.0] — 2026-09-04
 
 A correctness and hardening release. Three of these were **silent** failures —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cargo-rustango"
-version = "0.56.0"
+version = "0.56.1"
 
 [[package]]
 name = "cc"
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-stream",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-orm-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "rustango",
  "rustango-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.56.0"
+version = "0.56.1"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.56.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.56.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.56.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.56.1", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.56.1", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.56.1", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.56.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.56.1" }
 chrono = { workspace = true }

--- a/crates/rustango/examples/admin_demo/Cargo.lock
+++ b/crates/rustango/examples/admin_demo/Cargo.lock
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/crates/rustango/examples/auth_demo/Cargo.lock
+++ b/crates/rustango/examples/auth_demo/Cargo.lock
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/crates/rustango/examples/cookbook_blog/Cargo.lock
+++ b/crates/rustango/examples/cookbook_blog/Cargo.lock
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/crates/rustango/examples/getting_started_blog/Cargo.lock
+++ b/crates/rustango/examples/getting_started_blog/Cargo.lock
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/crates/rustango/examples/mcp_demo/Cargo.lock
+++ b/crates/rustango/examples/mcp_demo/Cargo.lock
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-stream",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/crates/rustango/examples/orm_cookbook/Cargo.lock
+++ b/crates/rustango/examples/orm_cookbook/Cargo.lock
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/crates/rustango/examples/tenant_user_extension/Cargo.lock
+++ b/crates/rustango/examples/tenant_user_extension/Cargo.lock
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/examples/showcase/Cargo.lock
+++ b/examples/showcase/Cargo.lock
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",


### PR DESCRIPTION
Documentation-only patch release, cut so the fixes in #1294 can reach rustango.com — the docs site publishes its content from a release tag, so a doc correction cannot be published without one.

## ⚠️ Merge order

**Merge #1294 first.** This PR contains only the version bump and CHANGELOG; the actual doc fixes live in #1294. Tagging `v0.56.1` before that merges would ship a release that changes nothing.

1. Merge #1294 (doc fixes)
2. Merge this PR
3. Tag `v0.56.1` on develop
4. Point the docs site's content ref at the new tag (separate PR on rustango-docs)

## Contents

- Workspace version and internal path-dep versions `0.56.0` → `0.56.1`
- `crates/rustango-renamed-smoke` follows
- All nine lockfiles regenerated
- CHANGELOG `[0.56.1]` section

No code changes — the crate is byte-for-byte 0.56.0. The `rustango = "0.56"` examples in `lib.rs` are minor-level and deliberately unchanged.

`cargo check -p rustango --no-default-features --features sqlite` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
