### PR TITLE
release: 0.56.1 — promote develop → main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
 
 ## [Unreleased]
 
+## [0.56.1] — 2026-09-04
+
+Documentation fixes. No code changes — the crate is byte-for-byte 0.56.0
+plus corrected docs and scaffolder comments. Cut as a release because the
+docs site publishes from a release tag.
+
+### Fixed
+
+- **getting-started no longer claims the scaffolder generates
+  `admin_router`.** #1210/#1211 removed that helper from the fullstack
+  template (nothing generated called it, and it was the only generated
+  line naming `PgPool`, hard-wiring Postgres into a project whose manifest
+  offers sqlite and mysql), but the guide still told readers it was
+  already there. Step 11 now says to add it, and why the generator won't.
+  The removal note's claim that `Cli` mounts the auto-admin itself was
+  also wrong — there is no `Cli::admin_prefix` and no single-tenant
+  auto-mount (that exists only under `tenancy`), so a fullstack project
+  has no admin until the author writes the helper. Reported in #1179.
+- **Generated `src/main.rs` no longer points at the removed helper.**
+  Every freshly scaffolded project shipped a header comment referring to
+  `urls::admin_router(pool)`, which the scaffolder stopped emitting.
+- **getting-started Steps 14 and 15 now name their files.** The JWT and
+  security-middleware steps were bare snippets while every other step
+  says "Edit `src/…`". 14a/14b are fragments for a handler in
+  `src/views.rs` (or an extractor / layer); Step 15 lives in
+  `src/main.rs`, replacing the `let api = …` line. Reported in #1179.
+- Both fixes applied to the French translation as well.
+
+
 ## [0.56.0] — 2026-09-04
 
 A correctness and hardening release. Three of these were **silent** failures —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cargo-rustango"
-version = "0.56.0"
+version = "0.56.1"
 
 [[package]]
 name = "cc"
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-stream",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-orm-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "rustango",
  "rustango-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.56.0"
+version = "0.56.1"
 readme = "README.md"
 edition = "2021"
 rust-version = "1.88"
@@ -18,9 +18,9 @@ categories = ["web-programming::http-server", "database", "asynchronous"]
 # Internal — collapsed shape: one library facade `rustango` (with
 # feature flags for admin / tenancy) plus the proc-macro crate which
 # Rust requires to live separately.
-rustango-macros     = { version = "0.56.0", path = "crates/rustango-macros" }
-rustango-orm-macros = { version = "0.56.0", path = "crates/rustango-orm-macros" }
-rustango            = { version = "0.56.0", path = "crates/rustango" }
+rustango-macros     = { version = "0.56.1", path = "crates/rustango-macros" }
+rustango-orm-macros = { version = "0.56.1", path = "crates/rustango-orm-macros" }
+rustango            = { version = "0.56.1", path = "crates/rustango" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "signal", "net"] }

--- a/crates/cargo-rustango/src/templates.rs
+++ b/crates/cargo-rustango/src/templates.rs
@@ -316,9 +316,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 const MAIN_RS_FULLSTACK: &str = "//! Project entrypoint — `Cli::run()` is the unified dispatcher
 //! that handles `cargo run` (runserver) AND `cargo run -- migrate` /
 //! `makemigrations` / `startapp` / etc. from one binary. No
-//! `src/bin/manage.rs` needed. The auto-admin lives in
-//! `urls::admin_router(pool)`; nest it under `/admin` when you want
-//! it (see the getting-started guide).
+//! `src/bin/manage.rs` needed. The auto-admin is not wired up for
+//! you: add an `admin_router(pool)` helper to `src/urls.rs` and nest
+//! it under `/admin` (see the getting-started guide, Step 11).
 //!
 //! Logging is auto-configured by `#[rustango::main]` —
 //! `tracing_subscriber::fmt` with env-filter, default
@@ -464,12 +464,18 @@ pub fn api() -> Router<()> {
         }
         Template::Fullstack => {
             // #1210/#1211 — this used to also emit an `admin_router(pool)`
-            // helper. Nothing called it: `Cli` mounts the auto-admin itself,
-            // so calling the helper was never how you got an admin. It was
-            // therefore dead code (a warning in every fresh project) *and*
-            // misleading — and it was the only generated line naming `PgPool`,
-            // hard-wiring Postgres into a project whose manifest offers
-            // sqlite and mysql.
+            // helper. Nothing generated called it (the generated `main.rs`
+            // never nested it), so it was dead code — a warning in every
+            // fresh project — and it was the only generated line naming
+            // `PgPool`, hard-wiring Postgres into a project whose manifest
+            // offers sqlite and mysql.
+            //
+            // Removing it means a fullstack project has NO admin until the
+            // author adds one. There is no `Cli` auto-mount for the
+            // single-tenant admin (that exists only for `tenancy`), so
+            // getting-started Step 11 has to spell the helper out — see
+            // `examples/getting_started_blog/src/urls.rs`, which defines it
+            // by hand and is covered by `tests/admin_smoke.rs`.
             "//! Project URL routing (template: fullstack — ORM + auto-admin).
 //!
 //! `Router::new()` in `api()` is the auto-mount anchor —

--- a/crates/rustango-renamed-smoke/Cargo.toml
+++ b/crates/rustango-renamed-smoke/Cargo.toml
@@ -55,5 +55,5 @@ tenancy = ["orm/tenancy"]
 #   through orm — no direct dep needed.
 # - `uuid` — routed through `__uuid` — no direct dep needed.
 # - `rust_decimal` — 1 site; not yet routed (future follow-up).
-orm = { package = "rustango", path = "../rustango", version = "0.56.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.56.1" }
 chrono = { workspace = true }

--- a/crates/rustango/examples/admin_demo/Cargo.lock
+++ b/crates/rustango/examples/admin_demo/Cargo.lock
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/crates/rustango/examples/auth_demo/Cargo.lock
+++ b/crates/rustango/examples/auth_demo/Cargo.lock
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/crates/rustango/examples/cookbook_blog/Cargo.lock
+++ b/crates/rustango/examples/cookbook_blog/Cargo.lock
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/crates/rustango/examples/getting_started_blog/Cargo.lock
+++ b/crates/rustango/examples/getting_started_blog/Cargo.lock
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/crates/rustango/examples/mcp_demo/Cargo.lock
+++ b/crates/rustango/examples/mcp_demo/Cargo.lock
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-stream",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/crates/rustango/examples/orm_cookbook/Cargo.lock
+++ b/crates/rustango/examples/orm_cookbook/Cargo.lock
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/crates/rustango/examples/tenant_user_extension/Cargo.lock
+++ b/crates/rustango/examples/tenant_user_extension/Cargo.lock
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/docs/fr/getting-started.md
+++ b/docs/fr/getting-started.md
@@ -122,7 +122,7 @@ myblog/
     ├── main.rs                 # entry point: `Cli::new().api(urls::api()).run()`
     ├── models.rs               # every #[derive(Model)] lives here
     ├── views.rs                # axum request handlers
-    └── urls.rs                 # `pub fn api()` route aggregator + `admin_router(pool)`
+    └── urls.rs                 # agrégateur de routes `pub fn api()`
 ```
 
 Il n'y a qu'un seul binaire : `cargo run` démarre le serveur HTTP, et chaque verbe de style Django (`migrate`, `makemigrations`, `startapp`, `check`, …) passe par ce même binaire via `cargo run -- <verb>`. Il n'y a pas de binaire `manage` séparé.
@@ -415,9 +415,9 @@ Vous devriez voir l'identifiant de votre nouvel article ainsi que les lignes lue
 
 ## Étape 11 : activer l'administration automatique
 
-**Rustango** fournit une interface d'administration générée pour vos modèles, tout comme l'administration Django. Le générateur de squelette vous a déjà donné un utilitaire `admin_router(pool)` dans `src/urls.rs` qui construit l'administration automatique à partir d'un pool — vous n'avez qu'à l'imbriquer sous `/admin` et à l'injecter dans le `Cli`.
+**Rustango** fournit une interface d'administration générée pour vos modèles, tout comme l'administration Django. Sa mise en place tient en deux petites étapes : un utilitaire qui transforme un pool en routeur d'administration, et un seul appel `.nest(...)` pour le monter.
 
-Donnez d'abord un titre à l'administration dans `src/urls.rs`. Le `admin_prefix` doit correspondre au chemin sous lequel vous l'imbriquerez à l'étape suivante (`/admin`) afin que les propres liens et actions de formulaire de l'administration se résolvent correctement :
+Ajoutez vous-même cet utilitaire dans `src/urls.rs` — le générateur de squelette ne le crée pas (il n'émet volontairement aucun code typé `PgPool`, afin que le même modèle fonctionne sur SQLite et MySQL). Le `admin_prefix` doit correspondre au chemin sous lequel vous l'imbriquerez à l'étape suivante (`/admin`) afin que les propres liens et actions de formulaire de l'administration se résolvent correctement :
 
 ```rust
 pub fn admin_router(pool: PgPool) -> Router {
@@ -587,6 +587,8 @@ Les JWT sont des jetons signés que vous remettez à un client après la connexi
 
 ### 14a. Émettre un jeton à la connexion
 
+Il s'agit de fragments, et non de fichiers autonomes : celui-ci se place à l'intérieur de votre gestionnaire de connexion dans `src/views.rs`, aux côtés des gestionnaires de l'étape 6.
+
 Intégrez l'identifiant de l'utilisateur (le « sujet » du jeton) et toute revendication (claim) personnalisée, comme les rôles, dans un jeton signé, puis remettez-le au client :
 
 ```rust
@@ -604,6 +606,8 @@ let token = encode(&claims.ttl(Duration::from_secs(900)), &secret)?;
 ```
 
 ### 14b. Vérifier le jeton à chaque requête
+
+Ce code se place là où vous protégez une route — dans un gestionnaire protégé de `src/views.rs`, ou dans un extracteur axum / une couche `middleware::from_fn` si vous souhaitez l'appliquer à toute une sous-arborescence.
 
 Décodez le jeton — ceci vérifie la signature et l'expiration — puis relisez les revendications (claims). S'il est absent ou invalide, rejetez la requête comme non autorisée :
 
@@ -625,7 +629,7 @@ let roles: Vec<String> = claims.get("roles").unwrap_or_default();
 
 ## Étape 15 : ajouter le middleware de sécurité
 
-Le middleware englobe chaque requête pour y ajouter un comportement transversal. Ici, vous empilez les identifiants de requête, la journalisation des accès, la limitation de débit, le CORS et les en-têtes de sécurité en une seule chaîne. Chaque `.method(...)` ajoute une couche, de manière similaire au middleware Django ou à la pile de middleware de Laravel. Voir le [guide du middleware](middleware.md) pour le catalogue complet des couches et les règles d'ordonnancement.
+Le middleware englobe chaque requête pour y ajouter un comportement transversal. Ce code se place dans `src/main.rs` : il remplace la ligne `let api = ...` de l'étape 11, afin que le routeur soit entièrement assemblé avant d'atteindre le `Cli`. Ici, vous empilez les identifiants de requête, la journalisation des accès, la limitation de débit, le CORS et les en-têtes de sécurité en une seule chaîne. Chaque `.method(...)` ajoute une couche, de manière similaire au middleware Django ou à la pile de middleware de Laravel. Voir le [guide du middleware](middleware.md) pour le catalogue complet des couches et les règles d'ordonnancement.
 
 ```rust
 use rustango::security_headers::{SecurityHeadersLayer, SecurityHeadersRouterExt, CspBuilder};

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,7 +122,7 @@ myblog/
     ├── main.rs                 # entry point: `Cli::new().api(urls::api()).run()`
     ├── models.rs               # every #[derive(Model)] lives here
     ├── views.rs                # axum request handlers
-    └── urls.rs                 # `pub fn api()` route aggregator + `admin_router(pool)`
+    └── urls.rs                 # `pub fn api()` route aggregator
 ```
 
 There is a single binary: `cargo run` boots the HTTP server, and every Django-style verb (`migrate`, `makemigrations`, `startapp`, `check`, …) flows through the same binary via `cargo run -- <verb>`. There's no separate `manage` binary.
@@ -413,9 +413,9 @@ You should see your new post id and the rows read back. Restore `src/main.rs` to
 
 ## Step 11: Turn on the auto-admin
 
-**Rustango** ships a generated admin UI for your models, just like Django admin. The scaffolder already gave you an `admin_router(pool)` helper in `src/urls.rs` that builds the auto-admin from a pool — you just need to nest it under `/admin` and feed it into the `Cli`.
+**Rustango** ships a generated admin UI for your models, just like Django admin. Building it is two small steps: a helper that turns a pool into an admin router, and one `.nest(...)` call to mount it.
 
-First, give the admin a title in `src/urls.rs`. The `admin_prefix` must match the path you'll nest it under in the next step (`/admin`) so the admin's own links and form actions resolve:
+Add the helper to `src/urls.rs` yourself — the scaffolder does not generate it (it deliberately emits no `PgPool`-typed code, so the same template works on SQLite and MySQL). The `admin_prefix` must match the path you'll nest it under in the next step (`/admin`) so the admin's own links and form actions resolve:
 
 ```rust
 pub fn admin_router(pool: PgPool) -> Router {
@@ -585,6 +585,8 @@ JWTs are signed tokens you hand a client after login and check on each request, 
 
 ### 14a. Issue a token at login
 
+These are fragments, not standalone files: this one goes inside your login handler in `src/views.rs`, alongside the handlers from Step 6.
+
 Bake the user id (the token's "subject") and any custom claims, like roles, into a signed token, then hand it to the client:
 
 ```rust
@@ -602,6 +604,8 @@ let token = encode(&claims.ttl(Duration::from_secs(900)), &secret)?;
 ```
 
 ### 14b. Verify the token on each request
+
+This belongs wherever you guard a route — inside a protected handler in `src/views.rs`, or in an axum extractor / `middleware::from_fn` layer if you want it applied to a whole subtree.
 
 Decode the token — this checks the signature and expiry — then read the claims back. If it's missing or invalid, reject the request as unauthorized:
 
@@ -623,7 +627,7 @@ let roles: Vec<String> = claims.get("roles").unwrap_or_default();
 
 ## Step 15: Add security middleware
 
-Middleware wraps every request to add cross-cutting behavior. Here you stack request IDs, access logging, rate limiting, CORS, and security headers in one chain. Each `.method(...)` adds one layer, similar to Django middleware or Laravel's middleware stack. See the [Middleware guide](middleware.md) for the full layer catalog and ordering rules.
+Middleware wraps every request to add cross-cutting behavior. This one goes in `src/main.rs`: it replaces the `let api = ...` line from Step 11, so the router is fully assembled before it reaches the `Cli`. Here you stack request IDs, access logging, rate limiting, CORS, and security headers in one chain. Each `.method(...)` adds one layer, similar to Django middleware or Laravel's middleware stack. See the [Middleware guide](middleware.md) for the full layer catalog and ordering rules.
 
 ```rust
 use rustango::security_headers::{SecurityHeadersLayer, SecurityHeadersRouterExt, CspBuilder};

--- a/examples/showcase/Cargo.lock
+++ b/examples/showcase/Cargo.lock
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "rustango"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "rustango-macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",


### PR DESCRIPTION
Promotes develop → main for the **0.56.1** docs patch, mirroring how 0.56.0 was released (`b3224d96`, tagged on main).

Exactly two commits, nothing else:

- `fefd0c4c` — docs: stop claiming the scaffolder generates `admin_router`, and say where auth code goes (#1294)
- `45aec4d7` — release: 0.56.1 — version bump + CHANGELOG (#1295)

No code changes: the crate is byte-for-byte 0.56.0 plus corrected docs and scaffolder comments.

## After merging

1. Tag **`v0.56.1`** on main — no workflow triggers on tags, so this is CI-inert
2. Merge ujeenet/rustango-docs#99, which checks out that tag and deploys rustango.com

Until the tag exists, docs#99 cannot build. Publishing 0.56.1 to crates.io is optional — the change is documentation only, so `cargo install cargo-rustango` staying at 0.56.0 is harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
