### PR TITLE
feat(tenancy): extra hostnames per tenant, with the base host protected

### DIFF
--- a/crates/rustango/src/server/builder.rs
+++ b/crates/rustango/src/server/builder.rs
@@ -13,7 +13,7 @@ use crate::extractors::TenantContext;
 use crate::sql::sqlx::PgPool;
 use crate::tenancy::{
     admin::TenantAdminBuilder, operator_console, ChainResolver, DefaultTenantDb, HeaderResolver,
-    SubdomainResolver, TenantPools,
+    RegisteredHostResolver, SubdomainResolver, TenantPools,
 };
 
 /// Stateless API router that the user supplies. The Builder injects
@@ -566,6 +566,10 @@ impl<DB: Database> Builder<DB> {
 fn build_resolver(apex: &str) -> ChainResolver {
     ChainResolver::new()
         .push(SubdomainResolver::new(apex.to_owned()))
+        // Extra tenant hostnames (`rustango_org_hosts`). Additive: it only
+        // runs when the base `host_pattern` did not match, and the lookup
+        // fails soft so a not-yet-migrated database behaves as before.
+        .push(RegisteredHostResolver)
         .push(HeaderResolver::default())
 }
 

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -176,10 +176,16 @@ pub use pools::{
     TenantPoolsConfig,
 };
 pub use resolver::{
-    expire_generation_for_test, invalidate_host_cache, reset_generation_for_test, ChainResolver,
-    HeaderResolver, OrgResolver, PathPrefixResolver, PortResolver, RegisteredHostResolver,
-    SubdomainResolver,
+    invalidate_host_cache, ChainResolver, HeaderResolver, OrgResolver, PathPrefixResolver,
+    PortResolver, RegisteredHostResolver, SubdomainResolver,
 };
+// The host-generation test hooks are deliberately NOT re-exported here —
+// they live in `crate::testkit`, so the name says what they are and they
+// are not permanent public API of `tenancy`. See `resolver::reset_generation`.
+// Gated to match `testkit`'s own gate, so a production build neither
+// compiles them in nor warns about an unused re-export.
+#[cfg(any(test, feature = "testkit"))]
+pub(crate) use resolver::{expire_generation, reset_generation};
 pub use routes::RouteConfig;
 pub use secrets::{
     ChainSecretsResolver, EnvSecretsResolver, LiteralSecretsResolver, SecretsError, SecretsResolver,

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -176,8 +176,9 @@ pub use pools::{
     TenantPoolsConfig,
 };
 pub use resolver::{
-    invalidate_host_cache, ChainResolver, HeaderResolver, OrgResolver, PathPrefixResolver,
-    PortResolver, RegisteredHostResolver, SubdomainResolver,
+    expire_generation_for_test, invalidate_host_cache, reset_generation_for_test, ChainResolver,
+    HeaderResolver, OrgResolver, PathPrefixResolver, PortResolver, RegisteredHostResolver,
+    SubdomainResolver,
 };
 pub use routes::RouteConfig;
 pub use secrets::{

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -92,6 +92,7 @@ pub mod middleware;
 pub mod migrate;
 pub mod operator_console;
 mod org;
+pub mod org_host;
 pub mod password;
 pub mod permissions;
 mod pools;
@@ -166,12 +167,17 @@ pub use migrate::{
     TenantMigrationOutcome, TenantMigrationReport,
 };
 pub use org::{BackendKind, Org, StorageMode};
+pub use org_host::{
+    add_host, list_for_org, normalize_hostname, remove_host, set_host_enabled, HostError, OrgHost,
+    TenantHost,
+};
 pub use pools::{
     DefaultTenantDb, PrewarmReport, TenantConn, TenantPool, TenantPoolInvalidator, TenantPools,
     TenantPoolsConfig,
 };
 pub use resolver::{
-    ChainResolver, HeaderResolver, OrgResolver, PathPrefixResolver, PortResolver, SubdomainResolver,
+    invalidate_host_cache, ChainResolver, HeaderResolver, OrgResolver, PathPrefixResolver,
+    PortResolver, RegisteredHostResolver, SubdomainResolver,
 };
 pub use routes::RouteConfig;
 pub use secrets::{

--- a/crates/rustango/src/tenancy/org_host.rs
+++ b/crates/rustango/src/tenancy/org_host.rs
@@ -317,17 +317,37 @@ pub async fn set_host_enabled(
 /// with non-constant default`. Every existing registry would be unable to
 /// migrate.
 ///
-/// These three counters need no clock and no new column, and cover every
+/// These counters need no clock and no new column, and cover every
 /// mutation this module can perform:
 ///
-/// | mutation           | what moves            |
-/// |--------------------|-----------------------|
-/// | [`add_host`]       | `count`, `max_id`     |
-/// | [`remove_host`]    | `count`               |
-/// | [`set_host_enabled`] | `enabled`           |
+/// | mutation             | what moves              |
+/// |----------------------|-------------------------|
+/// | [`add_host`]         | `count`, `max_id`       |
+/// | [`remove_host`]      | `count`                 |
+/// | [`set_host_enabled`] | `enabled`, `enabled_id_sum` |
+///
+/// ## Why `enabled_id_sum` and not just the enabled count
+///
+/// A count cancels. Disable one host and enable another inside the same
+/// poll interval — an operator swapping which domain is live, which is a
+/// perfectly ordinary admin action — and `enabled` goes −1 then +1 while
+/// `count` and `max_id` never move. The fingerprint would sit still and
+/// neither change would reach the other pods.
+///
+/// Summing the ids of the enabled rows distinguishes *which* rows are on,
+/// not just how many, so that swap moves the term. It stays clock-free
+/// and rides in the same query. `SUM` is cast to `bigint` by the
+/// aggregate writer, so it decodes as `i64` on all three backends rather
+/// than Postgres' native `numeric`.
+///
+/// Residual: two disjoint id-sets with equal sums toggled in opposite
+/// directions in one interval still collide. That needs a simultaneous
+/// multi-host swap with arithmetically matching ids, and the 30s
+/// `HOST_CACHE` TTL still backstops it — the cost is 30s convergence
+/// instead of 5s, never permanent staleness.
 ///
 /// **Invariant for future work:** a mutation that edits a row in place
-/// without changing the row count or the enabled count — renaming a
+/// without changing the row count or the enabled set — renaming a
 /// hostname, say — would not move any of these. There is deliberately no
 /// such path today. Add one and this fingerprint must grow a term with
 /// it, or cross-pod invalidation will silently miss it.
@@ -335,11 +355,11 @@ pub async fn set_host_enabled(
 /// # Errors
 /// Driver / query failures.
 pub async fn generation(registry: &Pool) -> Result<Generation, HostError> {
-    use crate::core::aggregates::{count_all, max};
+    use crate::core::aggregates::{count_all, max, sum};
     use crate::core::{AggregateQuery, Model as _, WhereExpr};
     use crate::sql::fetch_aggregate_pool;
 
-    // One round trip, three scalars, no rows decoded. The previous
+    // One round trip, four scalars, no rows decoded. The previous
     // implementation fetched and deserialized the entire table on every
     // pod every interval, which is the cost this cache exists to avoid.
     let q = AggregateQuery {
@@ -354,6 +374,10 @@ pub async fn generation(registry: &Pool) -> Result<Generation, HostError> {
                 count_all().filter(OrgHost::enabled.eq(true)).into(),
             ),
             ("max_id".into(), max("id").into()),
+            (
+                "on_id_sum".into(),
+                sum("id").filter(OrgHost::enabled.eq(true)).into(),
+            ),
         ],
         aliases: Vec::new(),
         having: None,
@@ -361,21 +385,22 @@ pub async fn generation(registry: &Pool) -> Result<Generation, HostError> {
         limit: None,
         offset: None,
     };
-    // Every term is NULL-able on an empty table (`MAX` of no rows), so
-    // each decodes as `Option` and folds to 0 — an empty registry has a
-    // stable fingerprint rather than an error.
-    let rows: Vec<(Option<i64>, Option<i64>, Option<i64>)> =
+    // Every term is NULL-able on an empty table (`MAX` / `SUM` of no
+    // rows), so each decodes as `Option` and folds to 0 — an empty
+    // registry has a stable fingerprint rather than an error.
+    let rows: Vec<(Option<i64>, Option<i64>, Option<i64>, Option<i64>)> =
         fetch_aggregate_pool(registry, &q).await?;
-    let (n, n_on, max_id) = rows.into_iter().next().unwrap_or((None, None, None));
+    let (n, n_on, max_id, on_id_sum) = rows.into_iter().next().unwrap_or((None, None, None, None));
     Ok(Generation {
         count: n.unwrap_or(0),
         enabled: n_on.unwrap_or(0),
         max_id: max_id.unwrap_or(0),
+        enabled_id_sum: on_id_sum.unwrap_or(0),
     })
 }
 
 /// The fingerprint [`generation`] returns. A plain tuple would work, but
-/// three same-typed `i64`s in a row are trivial to transpose at a call
+/// four same-typed `i64`s in a row are trivial to transpose at a call
 /// site and the compiler would not notice.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Generation {
@@ -387,6 +412,10 @@ pub struct Generation {
     /// Largest row id — distinguishes an add-plus-remove in the same
     /// interval, which leaves `count` unchanged.
     pub max_id: i64,
+    /// Sum of the ids of the enabled rows — identifies *which* rows are
+    /// on, not just how many, so a disable-one/enable-another swap in a
+    /// single interval still moves the fingerprint. See [`generation`].
+    pub enabled_id_sum: i64,
 }
 
 #[cfg(test)]

--- a/crates/rustango/src/tenancy/org_host.rs
+++ b/crates/rustango/src/tenancy/org_host.rs
@@ -51,15 +51,6 @@ pub struct OrgHost {
 
     #[rustango(auto_now_add)]
     pub created_at: crate::sql::Auto<chrono::DateTime<chrono::Utc>>,
-
-    /// Bumped on every write, including an enable/disable toggle.
-    ///
-    /// This is what makes cross-process cache invalidation possible: a
-    /// toggle changes neither the row count nor the max id, so without a
-    /// timestamp another pod has no way to notice it happened. See
-    /// [`generation`].
-    #[rustango(auto_now)]
-    pub updated_at: crate::sql::Auto<chrono::DateTime<chrono::Utc>>,
 }
 
 /// A hostname a tenant answers on, from either source.
@@ -220,7 +211,6 @@ pub async fn add_host(
         hostname: host,
         enabled: true,
         created_at: crate::sql::Auto::Unset,
-        updated_at: crate::sql::Auto::Unset,
     };
     row.insert_pool(registry).await?;
     super::invalidate_host_cache();
@@ -299,6 +289,106 @@ pub async fn set_host_enabled(
     Ok(())
 }
 
+/// A cheap fingerprint of the whole host table, used to detect a change
+/// made by **another process**.
+///
+/// `invalidate_host_cache` only clears the pod that called it. Behind a
+/// load balancer the others would keep serving a stale answer until their
+/// TTL expired — a host added on one pod 404ing on the rest, which is
+/// exactly the kind of thing that gets diagnosed as "DNS hasn't
+/// propagated". Each pod re-reads this fingerprint periodically and drops
+/// its cache when it moves.
+///
+/// ## Why `(count, enabled, max_id)` and not a timestamp
+///
+/// The obvious fingerprint is `max(updated_at)`, and it is wrong here for
+/// two independent reasons.
+///
+/// It is not monotonic across pods. An `auto_now` column takes its value
+/// from the *database* clock on INSERT (the column default) but from the
+/// *writing process* clock on UPDATE. A pod whose clock lags the registry
+/// can disable a host and write a timestamp older than the current max,
+/// leaving the fingerprint unmoved — silently failing at exactly the job
+/// it exists to do.
+///
+/// It also needs a new `NOT NULL` column, and adding one to a populated
+/// table is rejected outright by SQLite: `ALTER TABLE … ADD COLUMN …
+/// DEFAULT CURRENT_TIMESTAMP NOT NULL` fails with `Cannot add a column
+/// with non-constant default`. Every existing registry would be unable to
+/// migrate.
+///
+/// These three counters need no clock and no new column, and cover every
+/// mutation this module can perform:
+///
+/// | mutation           | what moves            |
+/// |--------------------|-----------------------|
+/// | [`add_host`]       | `count`, `max_id`     |
+/// | [`remove_host`]    | `count`               |
+/// | [`set_host_enabled`] | `enabled`           |
+///
+/// **Invariant for future work:** a mutation that edits a row in place
+/// without changing the row count or the enabled count — renaming a
+/// hostname, say — would not move any of these. There is deliberately no
+/// such path today. Add one and this fingerprint must grow a term with
+/// it, or cross-pod invalidation will silently miss it.
+///
+/// # Errors
+/// Driver / query failures.
+pub async fn generation(registry: &Pool) -> Result<Generation, HostError> {
+    use crate::core::aggregates::{count_all, max};
+    use crate::core::{AggregateQuery, Model as _, WhereExpr};
+    use crate::sql::fetch_aggregate_pool;
+
+    // One round trip, three scalars, no rows decoded. The previous
+    // implementation fetched and deserialized the entire table on every
+    // pod every interval, which is the cost this cache exists to avoid.
+    let q = AggregateQuery {
+        model: OrgHost::SCHEMA,
+        joins: Vec::new(),
+        where_clause: WhereExpr::And(Vec::new()),
+        group_by: Vec::new(),
+        aggregates: vec![
+            ("n".into(), count_all().into()),
+            (
+                "n_on".into(),
+                count_all().filter(OrgHost::enabled.eq(true)).into(),
+            ),
+            ("max_id".into(), max("id").into()),
+        ],
+        aliases: Vec::new(),
+        having: None,
+        order_by: Vec::new(),
+        limit: None,
+        offset: None,
+    };
+    // Every term is NULL-able on an empty table (`MAX` of no rows), so
+    // each decodes as `Option` and folds to 0 — an empty registry has a
+    // stable fingerprint rather than an error.
+    let rows: Vec<(Option<i64>, Option<i64>, Option<i64>)> =
+        fetch_aggregate_pool(registry, &q).await?;
+    let (n, n_on, max_id) = rows.into_iter().next().unwrap_or((None, None, None));
+    Ok(Generation {
+        count: n.unwrap_or(0),
+        enabled: n_on.unwrap_or(0),
+        max_id: max_id.unwrap_or(0),
+    })
+}
+
+/// The fingerprint [`generation`] returns. A plain tuple would work, but
+/// three same-typed `i64`s in a row are trivial to transpose at a call
+/// site and the compiler would not notice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Generation {
+    /// Total rows — moves on add and remove.
+    pub count: i64,
+    /// Rows with `enabled = true` — moves on a toggle, which is the
+    /// mutation a count-and-max-id fingerprint would otherwise miss.
+    pub enabled: i64,
+    /// Largest row id — distinguishes an add-plus-remove in the same
+    /// interval, which leaves `count` unchanged.
+    pub max_id: i64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -362,32 +452,4 @@ mod tests {
         assert!(base.is_base);
         assert!(base.id.is_none());
     }
-}
-
-/// A cheap fingerprint of the whole host table, used to detect a change
-/// made by **another process**.
-///
-/// `invalidate_host_cache` only clears the pod that called it. Behind a
-/// load balancer the others would keep serving a stale answer until their
-/// TTL expired — a host added on one pod 404ing on the rest, which is
-/// exactly the kind of thing that gets diagnosed as "DNS hasn't
-/// propagated". Each pod re-reads this fingerprint periodically and drops
-/// its cache when it moves.
-///
-/// `(count, max(updated_at))` covers all three mutations with one
-/// aggregate and no extra table: an add moves both, a delete moves the
-/// count, and a toggle moves the timestamp. Deliberately not `max(id)` —
-/// that misses a toggle entirely.
-///
-/// # Errors
-/// Driver / query failures.
-pub async fn generation(registry: &Pool) -> Result<(i64, i64), HostError> {
-    let rows: Vec<OrgHost> = OrgHost::objects().fetch(registry).await?;
-    let count = i64::try_from(rows.len()).unwrap_or(i64::MAX);
-    let newest = rows
-        .iter()
-        .filter_map(|r| r.updated_at.get().map(chrono::DateTime::timestamp_micros))
-        .max()
-        .unwrap_or(0);
-    Ok((count, newest))
 }

--- a/crates/rustango/src/tenancy/org_host.rs
+++ b/crates/rustango/src/tenancy/org_host.rs
@@ -1,0 +1,355 @@
+//! Additional hostnames a tenant answers on.
+//!
+//! [`Org::host_pattern`](super::Org) is the tenant's **base** host — the one
+//! `create-tenant` writes and every existing deployment already resolves
+//! through. This table holds the *extra* hosts an operator or a CMS adds
+//! later, so one tenant can serve several domains.
+//!
+//! ## Why the base host is not a row here
+//!
+//! It would be tidier to migrate `host_pattern` into this table and mark it
+//! `is_primary`, and that is exactly what makes it fragile: the guard
+//! against deleting the base becomes a runtime `if` that one careless
+//! `DELETE … WHERE org_id = ?` walks straight past, leaving a tenant no
+//! host at all and no obvious way back.
+//!
+//! Keeping the base in `Org.host_pattern` makes it *structurally*
+//! undeletable through this table — there is no row to remove. Listing
+//! unions the two and flags which is which, so callers still see one list.
+
+use serde::Serialize;
+
+/// One extra hostname bound to a tenant.
+#[derive(crate::Model, Debug, Clone, Serialize)]
+#[rustango(
+    table = "rustango_org_hosts",
+    scope = "registry",
+    display = "hostname",
+    admin(
+        list_display = "hostname, org_id, enabled, created_at",
+        ordering = "hostname",
+    )
+)]
+pub struct OrgHost {
+    #[rustango(primary_key)]
+    pub id: crate::sql::Auto<i64>,
+
+    #[rustango(fk = "rustango_orgs", on = "id", index)]
+    pub org_id: i64,
+
+    /// The `Host` header to match, lowercased, no port and no scheme.
+    ///
+    /// Unique across the whole registry, not per-org: a hostname resolves
+    /// to exactly one tenant, and letting two orgs claim one host would
+    /// make routing depend on row order.
+    #[rustango(max_length = 255, unique, index)]
+    pub hostname: String,
+
+    /// Lets an operator park a host without serving it — useful while DNS
+    /// propagates, or to retire a domain without losing the record.
+    pub enabled: bool,
+
+    #[rustango(auto_now_add)]
+    pub created_at: crate::sql::Auto<chrono::DateTime<chrono::Utc>>,
+}
+
+/// A hostname a tenant answers on, from either source.
+#[derive(Debug, Clone, Serialize)]
+pub struct TenantHost {
+    pub hostname: String,
+    /// True for `Org.host_pattern`. The caller uses this to refuse a
+    /// remove, and the UI to explain why the row has no delete button.
+    pub is_base: bool,
+    pub enabled: bool,
+    /// `None` for the base host — it has no row of its own.
+    pub id: Option<i64>,
+}
+
+/// Why a host could not be registered.
+#[derive(Debug)]
+pub enum HostError {
+    /// Empty, or carrying a scheme, port, path or uppercase.
+    Invalid(String),
+    /// Already claimed — by this tenant or another one.
+    Taken(String),
+    /// Removing the base host, which this table cannot represent.
+    IsBaseHost(String),
+    NotFound,
+    Driver(crate::sql::ExecError),
+}
+
+impl std::fmt::Display for HostError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Invalid(h) => write!(f, "`{h}` is not a bare hostname"),
+            Self::Taken(h) => write!(f, "`{h}` is already registered"),
+            Self::IsBaseHost(h) => {
+                write!(f, "`{h}` is this tenant's base host and cannot be removed")
+            }
+            Self::NotFound => write!(f, "no such host"),
+            Self::Driver(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for HostError {}
+
+impl From<crate::sql::ExecError> for HostError {
+    fn from(e: crate::sql::ExecError) -> Self {
+        Self::Driver(e)
+    }
+}
+
+/// Normalize and validate a hostname.
+///
+/// Rejects rather than repairs anything that is not a bare host, because
+/// the value is compared byte-for-byte against the `Host` header: a stored
+/// `https://x.com/` or `x.com:443` would simply never match, and would look
+/// like a routing bug rather than a bad input.
+///
+/// # Errors
+/// [`HostError::Invalid`] when the value is empty, over-long, or carries a
+/// scheme / port / path / whitespace.
+pub fn normalize_hostname(raw: &str) -> Result<String, HostError> {
+    let h = raw.trim().to_ascii_lowercase();
+    let bad = h.is_empty()
+        || h.len() > 255
+        || h.contains("://")
+        || h.contains('/')
+        || h.contains(':')
+        || h.contains(char::is_whitespace)
+        || h.starts_with('.')
+        || h.ends_with('.')
+        || !h
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-');
+    if bad {
+        return Err(HostError::Invalid(raw.to_owned()));
+    }
+    Ok(h)
+}
+
+use crate::core::Column as _;
+use crate::sql::{FetcherPool as _, Pool};
+
+/// Every hostname `org_slug` answers on — base first, then extras.
+///
+/// # Errors
+/// Driver / query failures.
+pub async fn list_for_org(registry: &Pool, org_slug: &str) -> Result<Vec<TenantHost>, HostError> {
+    let Some(org) = super::Org::objects()
+        .where_(super::Org::slug.eq(org_slug.to_owned()))
+        .first(registry)
+        .await?
+    else {
+        return Err(HostError::NotFound);
+    };
+    let org_id = org.id.get().copied().unwrap_or_default();
+    let mut out = Vec::new();
+    if let Some(base) = org.host_pattern.as_deref().filter(|h| !h.trim().is_empty()) {
+        out.push(TenantHost {
+            hostname: base.to_owned(),
+            is_base: true,
+            enabled: true,
+            id: None,
+        });
+    }
+    let extras: Vec<OrgHost> = OrgHost::objects()
+        .where_(OrgHost::org_id.eq(org_id))
+        .order_by(&[("hostname", false)])
+        .fetch(registry)
+        .await?;
+    out.extend(extras.into_iter().map(|h| TenantHost {
+        hostname: h.hostname,
+        is_base: false,
+        enabled: h.enabled,
+        id: h.id.get().copied(),
+    }));
+    Ok(out)
+}
+
+/// Bind an extra `hostname` to `org_slug`.
+///
+/// # Errors
+/// [`HostError::Invalid`] for a malformed host, [`HostError::Taken`] when
+/// any tenant already claims it (including as its base host), or
+/// [`HostError::NotFound`] for an unknown org.
+pub async fn add_host(
+    registry: &Pool,
+    org_slug: &str,
+    hostname: &str,
+) -> Result<OrgHost, HostError> {
+    let host = normalize_hostname(hostname)?;
+    let Some(org) = super::Org::objects()
+        .where_(super::Org::slug.eq(org_slug.to_owned()))
+        .first(registry)
+        .await?
+    else {
+        return Err(HostError::NotFound);
+    };
+    // Claimed as some tenant's BASE host? The unique index below cannot see
+    // `rustango_orgs.host_pattern`, so without this a host could be added
+    // here that silently never wins — `SubdomainResolver` runs first.
+    let base_clash: Vec<super::Org> = super::Org::objects()
+        .where_(super::Org::host_pattern.eq(Some(host.clone())))
+        .fetch(registry)
+        .await?;
+    if !base_clash.is_empty() {
+        return Err(HostError::Taken(host));
+    }
+    if !OrgHost::objects()
+        .where_(OrgHost::hostname.eq(host.clone()))
+        .fetch(registry)
+        .await?
+        .is_empty()
+    {
+        return Err(HostError::Taken(host));
+    }
+    let mut row = OrgHost {
+        id: crate::sql::Auto::Unset,
+        org_id: org.id.get().copied().unwrap_or_default(),
+        hostname: host,
+        enabled: true,
+        created_at: crate::sql::Auto::Unset,
+    };
+    row.insert_pool(registry).await?;
+    super::invalidate_host_cache();
+    Ok(row)
+}
+
+/// Unbind an extra hostname.
+///
+/// Refuses the base host: it lives on the org, not here, so there is
+/// nothing to delete — and a tenant with no host is unreachable.
+///
+/// # Errors
+/// [`HostError::IsBaseHost`] for the base host, [`HostError::NotFound`]
+/// when no extra row matches.
+pub async fn remove_host(registry: &Pool, org_slug: &str, hostname: &str) -> Result<(), HostError> {
+    let host = normalize_hostname(hostname)?;
+    let Some(org) = super::Org::objects()
+        .where_(super::Org::slug.eq(org_slug.to_owned()))
+        .first(registry)
+        .await?
+    else {
+        return Err(HostError::NotFound);
+    };
+    if org.host_pattern.as_deref() == Some(host.as_str()) {
+        return Err(HostError::IsBaseHost(host));
+    }
+    let org_id = org.id.get().copied().unwrap_or_default();
+    // Scoped to the org on purpose: one tenant must not be able to unbind
+    // another's host by guessing the name.
+    let Some(row) = OrgHost::objects()
+        .where_(OrgHost::hostname.eq(host))
+        .where_(OrgHost::org_id.eq(org_id))
+        .first(registry)
+        .await?
+    else {
+        return Err(HostError::NotFound);
+    };
+    row.delete_pool(registry).await?;
+    super::invalidate_host_cache();
+    Ok(())
+}
+
+/// Enable or disable an extra host without unbinding it.
+///
+/// # Errors
+/// [`HostError::IsBaseHost`], [`HostError::NotFound`], or a driver failure.
+pub async fn set_host_enabled(
+    registry: &Pool,
+    org_slug: &str,
+    hostname: &str,
+    enabled: bool,
+) -> Result<(), HostError> {
+    let host = normalize_hostname(hostname)?;
+    let Some(org) = super::Org::objects()
+        .where_(super::Org::slug.eq(org_slug.to_owned()))
+        .first(registry)
+        .await?
+    else {
+        return Err(HostError::NotFound);
+    };
+    if org.host_pattern.as_deref() == Some(host.as_str()) {
+        return Err(HostError::IsBaseHost(host));
+    }
+    let org_id = org.id.get().copied().unwrap_or_default();
+    let Some(mut row) = OrgHost::objects()
+        .where_(OrgHost::hostname.eq(host))
+        .where_(OrgHost::org_id.eq(org_id))
+        .first(registry)
+        .await?
+    else {
+        return Err(HostError::NotFound);
+    };
+    row.enabled = enabled;
+    row.save_pool(registry).await?;
+    super::invalidate_host_cache();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_a_bare_hostname_and_lowercases_it() {
+        assert_eq!(normalize_hostname("Example.COM").unwrap(), "example.com");
+        assert_eq!(
+            normalize_hostname("  a.b.example.com  ").unwrap(),
+            "a.b.example.com"
+        );
+        assert_eq!(
+            normalize_hostname("my-site.co.uk").unwrap(),
+            "my-site.co.uk"
+        );
+        // A bare label is legal — `localhost`, or an internal name.
+        assert_eq!(normalize_hostname("localhost").unwrap(), "localhost");
+    }
+
+    /// Each of these would insert happily and then never match the `Host`
+    /// header, which reads as "the feature is broken" rather than "the
+    /// input was wrong". Reject at the door instead.
+    #[test]
+    fn rejects_anything_that_is_not_a_bare_host() {
+        for bad in [
+            "",
+            "   ",
+            "https://example.com", // scheme
+            "example.com/",        // path
+            "example.com/blog",    // path
+            "example.com:8080",    // port
+            "exa mple.com",        // whitespace
+            ".example.com",        // leading dot
+            "example.com.",        // trailing dot
+            "exam_ple.com",        // underscore is not a hostname char
+            "exam?ple.com",
+        ] {
+            assert!(
+                normalize_hostname(bad).is_err(),
+                "{bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_an_over_long_hostname() {
+        assert!(normalize_hostname(&"a".repeat(256)).is_err());
+        assert!(normalize_hostname(&"a".repeat(255)).is_ok());
+    }
+
+    #[test]
+    fn base_host_is_flagged_so_callers_can_refuse_a_remove() {
+        let base = TenantHost {
+            hostname: "acme.example.com".into(),
+            is_base: true,
+            enabled: true,
+            id: None,
+        };
+        // The base has no row id precisely because it has no row — that is
+        // what makes it undeletable through this table.
+        assert!(base.is_base);
+        assert!(base.id.is_none());
+    }
+}

--- a/crates/rustango/src/tenancy/org_host.rs
+++ b/crates/rustango/src/tenancy/org_host.rs
@@ -51,6 +51,15 @@ pub struct OrgHost {
 
     #[rustango(auto_now_add)]
     pub created_at: crate::sql::Auto<chrono::DateTime<chrono::Utc>>,
+
+    /// Bumped on every write, including an enable/disable toggle.
+    ///
+    /// This is what makes cross-process cache invalidation possible: a
+    /// toggle changes neither the row count nor the max id, so without a
+    /// timestamp another pod has no way to notice it happened. See
+    /// [`generation`].
+    #[rustango(auto_now)]
+    pub updated_at: crate::sql::Auto<chrono::DateTime<chrono::Utc>>,
 }
 
 /// A hostname a tenant answers on, from either source.
@@ -211,6 +220,7 @@ pub async fn add_host(
         hostname: host,
         enabled: true,
         created_at: crate::sql::Auto::Unset,
+        updated_at: crate::sql::Auto::Unset,
     };
     row.insert_pool(registry).await?;
     super::invalidate_host_cache();
@@ -352,4 +362,32 @@ mod tests {
         assert!(base.is_base);
         assert!(base.id.is_none());
     }
+}
+
+/// A cheap fingerprint of the whole host table, used to detect a change
+/// made by **another process**.
+///
+/// `invalidate_host_cache` only clears the pod that called it. Behind a
+/// load balancer the others would keep serving a stale answer until their
+/// TTL expired — a host added on one pod 404ing on the rest, which is
+/// exactly the kind of thing that gets diagnosed as "DNS hasn't
+/// propagated". Each pod re-reads this fingerprint periodically and drops
+/// its cache when it moves.
+///
+/// `(count, max(updated_at))` covers all three mutations with one
+/// aggregate and no extra table: an add moves both, a delete moves the
+/// count, and a toggle moves the timestamp. Deliberately not `max(id)` —
+/// that misses a toggle entirely.
+///
+/// # Errors
+/// Driver / query failures.
+pub async fn generation(registry: &Pool) -> Result<(i64, i64), HostError> {
+    let rows: Vec<OrgHost> = OrgHost::objects().fetch(registry).await?;
+    let count = i64::try_from(rows.len()).unwrap_or(i64::MAX);
+    let newest = rows
+        .iter()
+        .filter_map(|r| r.updated_at.get().map(chrono::DateTime::timestamp_micros))
+        .max()
+        .unwrap_or(0);
+    Ok((count, newest))
 }

--- a/crates/rustango/src/tenancy/resolver.rs
+++ b/crates/rustango/src/tenancy/resolver.rs
@@ -105,6 +105,147 @@ impl OrgResolver for SubdomainResolver {
     }
 }
 
+// ---------------- RegisteredHostResolver ----------------
+
+/// Match the `Host` header against an extra hostname registered in
+/// [`rustango_org_hosts`](super::OrgHost), so one tenant can serve several
+/// domains beyond its base `Org.host_pattern`.
+///
+/// Composed AFTER [`SubdomainResolver`] in the standard chain: the base
+/// host keeps resolving exactly as it always did, and this only ever runs
+/// on a host that would otherwise have found nothing. The feature is
+/// purely additive — it cannot change where an existing request lands.
+///
+/// ## Missing table is not an error
+///
+/// The `rustango_org_hosts` table arrives with the generated system
+/// migration chain, so a deployment that upgrades the binary and has not
+/// yet run `migrate` does not have it. Propagating that error would turn
+/// "you haven't migrated yet" into a 500 on **every** request, including
+/// for tenants that never use extra hosts. So a failed lookup is logged
+/// once and treated as "no match", which is the pre-upgrade behaviour to
+/// the byte.
+pub struct RegisteredHostResolver;
+
+/// Ensures the missing-table warning is logged once per process rather
+/// than once per request.
+static HOST_TABLE_WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// hostname → resolved org id (`None` = known-miss), with an expiry.
+///
+/// Tenant resolution is otherwise uncached — every request already pays one
+/// registry SELECT — so this exists to stop the *extra* lookup this
+/// resolver adds becoming a per-request cost.
+///
+/// Negative entries matter more than positive ones. The chain
+/// short-circuits, so a request to a tenant's base host never reaches this
+/// resolver at all; what does reach it is every request to a host nobody
+/// has registered. Without a negative cache, spraying random `Host` headers
+/// is a free registry query per request.
+///
+/// Bounded on purpose: the keys are attacker-supplied, so an unbounded map
+/// would trade a query amplification for a memory one. At the cap the whole
+/// map is dropped — crude, but O(1) and always correct for a cache.
+///
+/// Keyed by hostname alone, not (registry, hostname): a process serves one
+/// registry. Tests that stand up several must use distinct hostnames.
+type HostCacheMap = std::collections::HashMap<String, (Option<i64>, std::time::Instant)>;
+static HOST_CACHE: std::sync::RwLock<Option<HostCacheMap>> = std::sync::RwLock::new(None);
+const HOST_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+const HOST_CACHE_MAX: usize = 1024;
+
+/// The three states a lookup can be in. Named rather than
+/// `Option<Option<i64>>` because "not cached" and "cached as a miss" lead
+/// to opposite actions — one queries, the other must not.
+enum Cached {
+    /// Nothing usable; go to the registry.
+    Absent,
+    /// Known not to be a registered host.
+    Miss,
+    Hit(i64),
+}
+
+fn host_cache_get(host: &str) -> Cached {
+    let Ok(guard) = HOST_CACHE.read() else {
+        return Cached::Absent;
+    };
+    let Some((value, at)) = guard.as_ref().and_then(|m| m.get(host)) else {
+        return Cached::Absent;
+    };
+    if at.elapsed() > HOST_CACHE_TTL {
+        return Cached::Absent;
+    }
+    match value {
+        Some(id) => Cached::Hit(*id),
+        None => Cached::Miss,
+    }
+}
+
+fn host_cache_put(host: &str, value: Option<i64>) {
+    let Ok(mut guard) = HOST_CACHE.write() else {
+        return;
+    };
+    let map = guard.get_or_insert_with(Default::default);
+    if map.len() >= HOST_CACHE_MAX {
+        map.clear();
+    }
+    map.insert(host.to_owned(), (value, std::time::Instant::now()));
+}
+
+/// Drop cached resolutions. Called after a host is bound, unbound or
+/// toggled so the admin's next request reflects the change instead of
+/// waiting out the TTL.
+///
+/// Clears everything rather than one key: a rename is a remove plus an add,
+/// and the map is small and cheap to refill.
+pub fn invalidate_host_cache() {
+    if let Ok(mut guard) = HOST_CACHE.write() {
+        if let Some(map) = guard.as_mut() {
+            map.clear();
+        }
+    }
+}
+
+#[async_trait]
+impl OrgResolver for RegisteredHostResolver {
+    async fn resolve(&self, parts: &Parts, registry: &Pool) -> Result<Option<Org>, TenancyError> {
+        let Some(host) = host_from_parts(parts) else {
+            return Ok(None);
+        };
+        // Cached, including the miss — see `HOST_CACHE`.
+        match host_cache_get(host) {
+            Cached::Miss => return Ok(None),
+            Cached::Hit(org_id) => return find_active_org_by(registry, Org::id.eq(org_id)).await,
+            Cached::Absent => {}
+        }
+        let rows = match super::OrgHost::objects()
+            .where_(super::OrgHost::hostname.eq(host.to_owned()))
+            .where_(super::OrgHost::enabled.eq(true))
+            .fetch(registry)
+            .await
+        {
+            Ok(rows) => rows,
+            Err(e) => {
+                if !HOST_TABLE_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                    tracing::warn!(
+                        target: "rustango::tenancy::resolver",
+                        error = %e,
+                        "could not read rustango_org_hosts; extra tenant hostnames \
+                         are inactive until `migrate` creates the table"
+                    );
+                }
+                return Ok(None);
+            }
+        };
+        let Some(row) = rows.into_iter().next() else {
+            host_cache_put(host, None);
+            return Ok(None);
+        };
+        host_cache_put(host, Some(row.org_id));
+        find_active_org_by(registry, Org::id.eq(row.org_id)).await
+    }
+}
+
 // ---------------- PathPrefixResolver ----------------
 
 /// Match the request URL's first path segment against
@@ -275,6 +416,11 @@ impl ChainResolver {
     pub fn standard(apex_domain: impl Into<String>) -> Self {
         Self::new()
             .push(SubdomainResolver::new(apex_domain))
+            // After the base host, before the header fallback: an extra
+            // hostname must never outrank a tenant's own `host_pattern`,
+            // and until an operator registers one the table is empty, so
+            // no existing deployment changes behaviour.
+            .push(RegisteredHostResolver)
             .push(HeaderResolver::default())
     }
 }

--- a/crates/rustango/src/tenancy/resolver.rs
+++ b/crates/rustango/src/tenancy/resolver.rs
@@ -131,6 +131,50 @@ pub struct RegisteredHostResolver;
 /// than once per request.
 static HOST_TABLE_WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
+/// When the host-table lookup last failed, if it is currently failing.
+///
+/// The lookup's *miss* path caches (`host_cache_put(host, None)`), but its
+/// *error* path cannot: an error is not evidence that the host is
+/// unregistered, so caching it as a miss would be wrong the moment the
+/// table came back.
+///
+/// Without this backoff the error path is both uncached and unthrottled,
+/// which costs one failing query per request: measured against a renamed
+/// table, 25,987 failing `SELECT`s for 25,958 requests, all aimed at a
+/// registry that is by definition already unhealthy. The condition is
+/// table-wide rather than per-host, so one backoff covers every hostname
+/// at once.
+static HOST_TABLE_DOWN: std::sync::RwLock<Option<std::time::Instant>> =
+    std::sync::RwLock::new(None);
+
+/// True when a recent lookup failed and the backoff has not yet elapsed.
+/// Read-locked, so the hot path pays an uncontended read and nothing else.
+fn host_table_is_down() -> bool {
+    let window = gen_check_every().unwrap_or(GEN_CHECK_EVERY_DEFAULT);
+    match HOST_TABLE_DOWN.read() {
+        Ok(g) => g.is_some_and(|at| at.elapsed() < window),
+        Err(_) => false,
+    }
+}
+
+/// Record that the lookup failed, starting the backoff.
+fn mark_host_table_down() {
+    if let Ok(mut g) = HOST_TABLE_DOWN.write() {
+        *g = Some(std::time::Instant::now());
+    }
+}
+
+/// Clear the backoff after a successful lookup. Checks under a read lock
+/// first so the common case — never having failed — takes no write lock.
+fn mark_host_table_up() {
+    let was_down = HOST_TABLE_DOWN.read().is_ok_and(|g| g.is_some());
+    if was_down {
+        if let Ok(mut g) = HOST_TABLE_DOWN.write() {
+            *g = None;
+        }
+    }
+}
+
 /// hostname → resolved org id (`None` = known-miss), with an expiry.
 ///
 /// Tenant resolution is otherwise uncached — every request already pays one
@@ -354,6 +398,12 @@ pub(crate) fn reset_generation() {
     if let Ok(mut g) = HOST_GEN.write() {
         *g = None;
     }
+    // The missing-table backoff is process-global too, and a test that
+    // exercised an absent table would otherwise suppress the lookup for
+    // the next test's perfectly healthy registry.
+    if let Ok(mut d) = HOST_TABLE_DOWN.write() {
+        *d = None;
+    }
 }
 
 /// Make the next resolve re-read the fingerprint immediately instead of
@@ -419,14 +469,26 @@ impl OrgResolver for RegisteredHostResolver {
             Cached::Hit(org_id) => return find_active_org_by(registry, Org::id.eq(org_id)).await,
             Cached::Absent => {}
         }
+        // The table was failing very recently — don't re-ask on every
+        // request. See `HOST_TABLE_DOWN`. Pre-upgrade behaviour is "no
+        // match", which is what we return anyway, so backing off costs
+        // nothing and stops a per-request storm against a registry that
+        // is already in trouble.
+        if host_table_is_down() {
+            return Ok(None);
+        }
         let rows = match super::OrgHost::objects()
             .where_(super::OrgHost::hostname.eq(host.to_owned()))
             .where_(super::OrgHost::enabled.eq(true))
             .fetch(registry)
             .await
         {
-            Ok(rows) => rows,
+            Ok(rows) => {
+                mark_host_table_up();
+                rows
+            }
             Err(e) => {
+                mark_host_table_down();
                 if !HOST_TABLE_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
                     tracing::warn!(
                         target: "rustango::tenancy::resolver",

--- a/crates/rustango/src/tenancy/resolver.rs
+++ b/crates/rustango/src/tenancy/resolver.rs
@@ -192,6 +192,89 @@ fn host_cache_put(host: &str, value: Option<i64>) {
     map.insert(host.to_owned(), (value, std::time::Instant::now()));
 }
 
+/// Last host-table fingerprint this process saw, and when it last looked.
+///
+/// [`invalidate_host_cache`] only clears the process that called it. Behind
+/// a load balancer that is half a solution: the pod handling the admin
+/// request forgets, and every other pod keeps answering from a cache that
+/// is now wrong. Polling a cheap fingerprint closes that gap without a
+/// shared cache, a message bus, or making Redis a dependency of tenant
+/// resolution — the one path that runs before everything else and must not
+/// acquire new ways to fail.
+static HOST_GEN: std::sync::RwLock<Option<((i64, i64), std::time::Instant)>> =
+    std::sync::RwLock::new(None);
+
+/// How often a process re-reads the fingerprint. The bound on how long
+/// another pod can serve a stale answer, and the interval of one small
+/// aggregate query — not one per request.
+const GEN_CHECK_EVERY: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Drop the local cache if another process changed the host table.
+///
+/// Cheap to call on every resolve: it does nothing at all until
+/// [`GEN_CHECK_EVERY`] has passed.
+async fn sync_generation(registry: &Pool) {
+    // Read the timestamp and release the lock BEFORE awaiting — holding a
+    // std RwLock across an await parks it on whatever task resumes and can
+    // deadlock the next reader on the same thread.
+    let due = {
+        match HOST_GEN.read() {
+            Ok(g) => g.is_none_or(|(_, at)| at.elapsed() >= GEN_CHECK_EVERY),
+            Err(_) => true,
+        }
+    };
+    if !due {
+        return;
+    }
+    let Ok(current) = super::org_host::generation(registry).await else {
+        // A missing table or a blip: leave the cache alone and try again
+        // next interval. Never fail a request over a cache refresh.
+        return;
+    };
+    let changed = {
+        match HOST_GEN.write() {
+            Ok(mut g) => {
+                let changed = g.is_some_and(|(seen, _)| seen != current);
+                *g = Some((current, std::time::Instant::now()));
+                changed
+            }
+            Err(_) => false,
+        }
+    };
+    if changed {
+        invalidate_host_cache();
+    }
+}
+
+/// Forget the generation state entirely (test hook).
+///
+/// Exposed rather than `#[cfg(test)]` because the behaviour it supports —
+/// one pod noticing another pod's write — can only be exercised from an
+/// integration test, which compiles against the crate as a dependency.
+#[doc(hidden)]
+pub fn reset_generation_for_test() {
+    if let Ok(mut g) = HOST_GEN.write() {
+        *g = None;
+    }
+}
+
+/// Make the next resolve re-read the fingerprint immediately instead of
+/// waiting out [`GEN_CHECK_EVERY`] (test hook), so a cross-pod test does
+/// not have to sleep five seconds to prove a five-second bound.
+#[doc(hidden)]
+pub fn expire_generation_for_test() {
+    if let Ok(mut g) = HOST_GEN.write() {
+        if let Some((seen, _)) = *g {
+            *g = Some((
+                seen,
+                std::time::Instant::now()
+                    .checked_sub(GEN_CHECK_EVERY * 2)
+                    .unwrap_or_else(std::time::Instant::now),
+            ));
+        }
+    }
+}
+
 /// Drop cached resolutions. Called after a host is bound, unbound or
 /// toggled so the admin's next request reflects the change instead of
 /// waiting out the TTL.
@@ -212,6 +295,9 @@ impl OrgResolver for RegisteredHostResolver {
         let Some(host) = host_from_parts(parts) else {
             return Ok(None);
         };
+        // Pick up a host added or toggled by another pod before trusting
+        // anything cached here. Throttled — see `GEN_CHECK_EVERY`.
+        sync_generation(registry).await;
         // Cached, including the miss — see `HOST_CACHE`.
         match host_cache_get(host) {
             Cached::Miss => return Ok(None),

--- a/crates/rustango/src/tenancy/resolver.rs
+++ b/crates/rustango/src/tenancy/resolver.rs
@@ -201,79 +201,194 @@ fn host_cache_put(host: &str, value: Option<i64>) {
 /// shared cache, a message bus, or making Redis a dependency of tenant
 /// resolution — the one path that runs before everything else and must not
 /// acquire new ways to fail.
-static HOST_GEN: std::sync::RwLock<Option<((i64, i64), std::time::Instant)>> =
-    std::sync::RwLock::new(None);
+/// `None` = never looked. `Some((gen, at))` carries the last fingerprint
+/// seen and the time of the last *attempt* — successful or not, so a
+/// failing probe is still throttled.
+///
+/// `gen` is itself `Option`: a claimed-but-not-yet-completed check writes
+/// the attempt time with the previous fingerprint, so a probe that fails
+/// leaves the last known-good value in place rather than resetting it.
+type GenState = (Option<super::org_host::Generation>, std::time::Instant);
 
-/// How often a process re-reads the fingerprint. The bound on how long
-/// another pod can serve a stale answer, and the interval of one small
-/// aggregate query — not one per request.
-const GEN_CHECK_EVERY: std::time::Duration = std::time::Duration::from_secs(5);
+static HOST_GEN: std::sync::RwLock<Option<GenState>> = std::sync::RwLock::new(None);
+
+/// Ensures a failing fingerprint probe is logged once per process rather
+/// than once per interval. Without this the mechanism can be dead for a
+/// process's entire lifetime with nothing in the logs to say so.
+static HOST_GEN_WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Default interval between fingerprint reads — the bound on how long
+/// another pod can serve a stale answer.
+const GEN_CHECK_EVERY_DEFAULT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Env override for [`GEN_CHECK_EVERY_DEFAULT`], in seconds. `0` disables
+/// cross-process polling entirely.
+///
+/// A hard-coded constant is the wrong shape for this: a single-process
+/// deployment gains nothing from the poll, a cross-region registry wants a
+/// longer interval, and an operator who needs tighter convergence wants a
+/// shorter one. None of them should have to fork the crate, and this runs
+/// on the path that must not acquire new ways to fail.
+const GEN_CHECK_ENV: &str = "RUSTANGO_HOST_GEN_CHECK_SECS";
+
+/// Resolved once — reading and parsing an env var on every resolve would
+/// cost more than the check it is gating.
+fn gen_check_every() -> Option<std::time::Duration> {
+    static CACHED: std::sync::OnceLock<Option<std::time::Duration>> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| match std::env::var(GEN_CHECK_ENV) {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(0) => None,
+            Ok(secs) => Some(std::time::Duration::from_secs(secs)),
+            Err(_) => {
+                tracing::warn!(
+                    target: "rustango::tenancy::resolver",
+                    value = %raw,
+                    "{GEN_CHECK_ENV} is not a whole number of seconds; \
+                     falling back to the default interval"
+                );
+                Some(GEN_CHECK_EVERY_DEFAULT)
+            }
+        },
+        Err(_) => Some(GEN_CHECK_EVERY_DEFAULT),
+    })
+}
 
 /// Drop the local cache if another process changed the host table.
 ///
 /// Cheap to call on every resolve: it does nothing at all until
 /// [`GEN_CHECK_EVERY`] has passed.
 async fn sync_generation(registry: &Pool) {
-    // Read the timestamp and release the lock BEFORE awaiting — holding a
-    // std RwLock across an await parks it on whatever task resumes and can
-    // deadlock the next reader on the same thread.
-    let due = {
-        match HOST_GEN.read() {
-            Ok(g) => g.is_none_or(|(_, at)| at.elapsed() >= GEN_CHECK_EVERY),
-            Err(_) => true,
+    let Some(interval) = gen_check_every() else {
+        return; // polling disabled
+    };
+
+    // CLAIM the check before awaiting, in one write-lock section.
+    //
+    // Two bugs live in the alternative — stamping the time only after a
+    // successful probe. A probe that fails would leave the timestamp
+    // unadvanced, so every subsequent request re-probes forever: a pod
+    // deployed before `migrate` ran, or riding out a registry blip, turns
+    // a 5s poll into a per-request query storm. And under concurrency
+    // every request arriving while a probe is in flight would also see
+    // "due" and fire its own, fanning out exactly when the registry is
+    // already slow.
+    //
+    // Claiming both throttles failures and dedups in-flight checks: the
+    // first caller through takes the slot, everyone else sees a fresh
+    // timestamp and returns immediately.
+    //
+    // The lock is released before the await — holding a std RwLock across
+    // one parks it on whatever task resumes and can deadlock the next
+    // reader on the same thread.
+    let previous = {
+        match HOST_GEN.write() {
+            Ok(mut g) => {
+                let due = g.is_none_or(|(_, at)| at.elapsed() >= interval);
+                if !due {
+                    return;
+                }
+                let previous = g.and_then(|(seen, _)| seen);
+                *g = Some((previous, std::time::Instant::now()));
+                previous
+            }
+            // A poisoned lock means some other thread panicked mid-update.
+            // Skip this round rather than resolving off a torn value.
+            Err(_) => return,
         }
     };
-    if !due {
-        return;
-    }
-    let Ok(current) = super::org_host::generation(registry).await else {
-        // A missing table or a blip: leave the cache alone and try again
-        // next interval. Never fail a request over a cache refresh.
-        return;
+
+    let current = match super::org_host::generation(registry).await {
+        Ok(current) => current,
+        Err(e) => {
+            // Never fail a request over a cache refresh — but do not fail
+            // silently either. Cross-pod invalidation being dead is
+            // invisible from the outside until a host 404s on some pods
+            // and not others, which is near-impossible to correlate after
+            // the fact.
+            if !HOST_GEN_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                tracing::warn!(
+                    target: "rustango::tenancy::resolver",
+                    error = %e,
+                    "could not read the rustango_org_hosts fingerprint; this pod \
+                     will not notice host changes made by other processes until \
+                     its own cache entries expire"
+                );
+            }
+            // The claim above already recorded the attempt, so this backs
+            // off for a full interval instead of retrying every request.
+            return;
+        }
     };
+
     let changed = {
         match HOST_GEN.write() {
             Ok(mut g) => {
-                let changed = g.is_some_and(|(seen, _)| seen != current);
-                *g = Some((current, std::time::Instant::now()));
-                changed
+                *g = Some((Some(current), std::time::Instant::now()));
+                previous.is_some_and(|seen| seen != current)
             }
             Err(_) => false,
         }
     };
     if changed {
+        // Clears negative entries too, and must: a hostname cached as a
+        // known-miss is exactly what an add on another pod invalidates.
+        // The cost is that a registry with a steady write stream keeps
+        // every pod's negative cache short-lived, which is the deliberate
+        // trade — a stale 404 on a real customer domain is worse than a
+        // repeated lookup on a sprayed one, and `HOST_CACHE_MAX` still
+        // bounds the latter.
         invalidate_host_cache();
     }
 }
 
-/// Forget the generation state entirely (test hook).
+/// Forget the generation state entirely.
 ///
-/// Exposed rather than `#[cfg(test)]` because the behaviour it supports —
-/// one pod noticing another pod's write — can only be exercised from an
-/// integration test, which compiles against the crate as a dependency.
-#[doc(hidden)]
-pub fn reset_generation_for_test() {
+/// `pub(crate)` and surfaced through [`crate::testkit`] rather than being
+/// `pub` here: as public API of `rustango::tenancy` these would be
+/// permanent semver surface that any downstream crate could call in
+/// production, silently defeating cross-process invalidation for the life
+/// of the process. `#[doc(hidden)]` hides a name from rustdoc, not from
+/// the compiler.
+#[cfg(any(test, feature = "testkit"))]
+pub(crate) fn reset_generation() {
     if let Ok(mut g) = HOST_GEN.write() {
         *g = None;
     }
 }
 
 /// Make the next resolve re-read the fingerprint immediately instead of
-/// waiting out [`GEN_CHECK_EVERY`] (test hook), so a cross-pod test does
-/// not have to sleep five seconds to prove a five-second bound.
-#[doc(hidden)]
-pub fn expire_generation_for_test() {
+/// waiting out the poll interval, so a cross-pod test proves the bound
+/// without sleeping through it.
+///
+/// Unconditional by design. Guarding this on an existing `Some` made it a
+/// silent no-op in precisely the case a test reaches for it — right after
+/// a reset — so the test read as though it forced a re-check while
+/// actually doing nothing.
+#[cfg(any(test, feature = "testkit"))]
+pub(crate) fn expire_generation() {
     if let Ok(mut g) = HOST_GEN.write() {
-        if let Some((seen, _)) = *g {
-            *g = Some((
-                seen,
-                std::time::Instant::now()
-                    .checked_sub(GEN_CHECK_EVERY * 2)
-                    .unwrap_or_else(std::time::Instant::now),
-            ));
-        }
+        let previous = g.and_then(|(seen, _)| seen);
+        // Back-date past the *effective* interval, not the default one —
+        // with a longer interval configured, subtracting the default
+        // would leave the entry un-due and make this hook a no-op again.
+        let interval = gen_check_every().unwrap_or(GEN_CHECK_EVERY_DEFAULT);
+        // `checked_sub` returns None when the monotonic clock is younger
+        // than the offset — reachable on a freshly booted host. Falling
+        // back to `now()` there would *unexpire* the entry and invert this
+        // function's whole purpose, so fall back to the process's own
+        // epoch instead, which is unambiguously "long ago".
+        let long_ago = std::time::Instant::now()
+            .checked_sub(interval * 2)
+            .unwrap_or(*PROCESS_START);
+        *g = Some((previous, long_ago));
     }
 }
+
+/// Earliest `Instant` this process can name. Used as a saturating floor
+/// by [`expire_generation`].
+#[cfg(any(test, feature = "testkit"))]
+static PROCESS_START: std::sync::LazyLock<std::time::Instant> =
+    std::sync::LazyLock::new(std::time::Instant::now);
 
 /// Drop cached resolutions. Called after a host is bound, unbound or
 /// toggled so the admin's next request reflects the change instead of

--- a/crates/rustango/src/testkit.rs
+++ b/crates/rustango/src/testkit.rs
@@ -250,6 +250,34 @@ pub fn admin_user() -> crate::admin::AdminUser {
     }
 }
 
+/// Forget this process's cached host-table fingerprint.
+///
+/// `RegisteredHostResolver` polls a fingerprint of `rustango_org_hosts` so
+/// one pod notices another pod's write. That state is process-global and
+/// keyed by nothing, so a test that resolves against one registry leaves a
+/// fingerprint behind that the next test's brand-new registry compares
+/// against — producing a spurious cache invalidation mid-test. Unlike the
+/// resolution cache, it cannot be side-stepped by using distinct hostnames
+/// per test.
+///
+/// Call this in any test that resolves through `RegisteredHostResolver`,
+/// alongside `invalidate_host_cache()`.
+#[cfg(feature = "tenancy")]
+pub fn reset_host_generation() {
+    crate::tenancy::reset_generation();
+}
+
+/// Make the next resolve re-read the host fingerprint immediately rather
+/// than waiting out the poll interval.
+///
+/// Lets a cross-process test prove the convergence bound without sleeping
+/// through it. Unconditional: safe to call whether or not a fingerprint
+/// has been recorded yet.
+#[cfg(feature = "tenancy")]
+pub fn expire_host_generation() {
+    crate::tenancy::expire_generation();
+}
+
 #[cfg(all(test, feature = "sqlite", feature = "tenancy", feature = "admin"))]
 mod tests {
     use super::*;

--- a/crates/rustango/tests/org_hosts_sqlite_live.rs
+++ b/crates/rustango/tests/org_hosts_sqlite_live.rs
@@ -401,6 +401,52 @@ async fn every_mutation_moves_the_fingerprint() {
     assert_eq!(after_remove.count, 0);
 }
 
+/// Two opposite toggles inside one poll interval must still register.
+///
+/// This is the case a plain enabled-*count* misses: disable one host and
+/// enable another — an operator swapping which domain is live — and the
+/// count goes −1 then +1 while `count` and `max_id` never move. The
+/// fingerprint would sit still and neither change would reach the other
+/// pods until the 30s TTL expired.
+///
+/// `enabled_id_sum` is what catches it, by identifying which rows are on
+/// rather than how many. Dropping that term fails this test and leaves
+/// every other one green.
+#[tokio::test]
+async fn compensating_toggles_still_move_the_fingerprint() {
+    let _guard = cache_lock().lock().await;
+    use rustango::tenancy::org_host::generation;
+    let pool = registry_with_org().await;
+
+    add_host(&pool, "acme", "aaa.acme.com").await.expect("add");
+    add_host(&pool, "acme", "bbb.acme.com").await.expect("add");
+    set_host_enabled(&pool, "acme", "bbb.acme.com", false)
+        .await
+        .expect("disable bbb");
+
+    let before = generation(&pool).await.expect("generation");
+
+    // The swap: aaa off, bbb on, inside one interval.
+    set_host_enabled(&pool, "acme", "aaa.acme.com", false)
+        .await
+        .expect("disable aaa");
+    set_host_enabled(&pool, "acme", "bbb.acme.com", true)
+        .await
+        .expect("enable bbb");
+
+    let after = generation(&pool).await.expect("generation");
+    assert_eq!(
+        (after.count, after.enabled, after.max_id),
+        (before.count, before.enabled, before.max_id),
+        "precondition: count / enabled / max_id are all unchanged by the \
+         swap — that is exactly why the extra term is needed"
+    );
+    assert_ne!(
+        after, before,
+        "a disable+enable pair must still move the fingerprint"
+    );
+}
+
 async fn table_exists(pool: &Pool, table: &str) -> bool {
     let Pool::Sqlite(sq) = pool else {
         unreachable!("sqlite-only test")

--- a/crates/rustango/tests/org_hosts_sqlite_live.rs
+++ b/crates/rustango/tests/org_hosts_sqlite_live.rs
@@ -290,21 +290,21 @@ async fn an_existing_registry_gains_the_table_on_a_plain_migrate() {
 /// Re-migrating a registry whose `rustango_org_hosts` **already has rows**
 /// must succeed and leave them alone.
 ///
-/// The sibling upgrade test above only proves the CREATE path, on a
-/// registry where the table is absent. That is a strictly easier case, and
-/// the gap is not theoretical: an earlier revision of this feature carried
-/// a `NOT NULL` `auto_now` column for the cross-pod fingerprint, which
-/// renders on SQLite as
+/// The sibling upgrade test above only covers the CREATE path, against a
+/// registry where the table is absent. That is the strictly easier case,
+/// and the difference is not academic: adding a `NOT NULL` column with a
+/// non-constant default to this table renders on SQLite as
 ///
 /// ```sql
 /// ALTER TABLE "rustango_org_hosts"
 ///   ADD COLUMN "updated_at" TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL
 /// ```
 ///
-/// SQLite rejects that outright — "Cannot add a column with non-constant
-/// default" — but *only* when the table has rows. On an empty table the
-/// identical statement succeeds, so the CREATE-path test stayed green
-/// while every real deployment would have failed to migrate.
+/// which SQLite rejects — "Cannot add a column with non-constant
+/// default" — but *only* once the table has rows. On an empty table the
+/// identical statement succeeds. A CREATE-path test therefore stays green
+/// while every populated deployment fails to migrate, so any column added
+/// to this model needs the assertion below and not that one.
 #[tokio::test]
 async fn a_populated_host_table_survives_a_re_migrate() {
     let _guard = cache_lock().lock().await;
@@ -444,6 +444,80 @@ async fn compensating_toggles_still_move_the_fingerprint() {
     assert_ne!(
         after, before,
         "a disable+enable pair must still move the fingerprint"
+    );
+}
+
+/// A failing host-table lookup must back off, not re-ask on every request.
+///
+/// The miss path caches; the error path cannot, because an error is not
+/// evidence that the host is unregistered. That left it uncached and
+/// unthrottled — one failing `SELECT` per request, aimed at a registry
+/// that is by definition already unhealthy. Measured against a renamed
+/// table with the backoff removed: 25,987 failing queries for 25,958
+/// requests.
+///
+/// Asserted without counting queries, which SQLite will not tell us:
+/// restore the table *and* clear the resolution cache, then resolve
+/// again. A resolver that queried would find the row and return the
+/// tenant; one that is backed off cannot, so `None` here is positive
+/// proof no query was issued.
+#[tokio::test]
+async fn a_failing_host_lookup_backs_off_instead_of_querying_per_request() {
+    use rustango::tenancy::{OrgResolver, RegisteredHostResolver};
+    let _guard = cache_lock().lock().await;
+    let pool = registry_with_org().await;
+    add_host(&pool, "acme", "backoff.acme.com")
+        .await
+        .expect("add");
+
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!("sqlite-only test")
+    };
+
+    // Take the table away and resolve — fails open, and arms the backoff.
+    sqlx::query("ALTER TABLE rustango_org_hosts RENAME TO hidden_hosts")
+        .execute(sq)
+        .await
+        .expect("rename away");
+    rustango::tenancy::invalidate_host_cache();
+    let during = RegisteredHostResolver
+        .resolve(&parts_for_host("backoff.acme.com"), &pool)
+        .await
+        .expect("a missing table must not error the request");
+    assert!(
+        during.is_none(),
+        "fail-open: a missing table means no match"
+    );
+
+    // Put it back, and clear the cache so the cache cannot explain the
+    // next result. The row is now present and resolvable.
+    sqlx::query("ALTER TABLE hidden_hosts RENAME TO rustango_org_hosts")
+        .execute(sq)
+        .await
+        .expect("rename back");
+    rustango::tenancy::invalidate_host_cache();
+
+    let still_backed_off = RegisteredHostResolver
+        .resolve(&parts_for_host("backoff.acme.com"), &pool)
+        .await
+        .expect("resolve");
+    assert!(
+        still_backed_off.is_none(),
+        "the resolver must still be backed off — returning the tenant here \
+         would mean it queried, which is the per-request storm this guards"
+    );
+
+    // Clearing the backoff (as the interval elapsing would) restores it.
+    rustango::testkit::reset_host_generation();
+    rustango::tenancy::invalidate_host_cache();
+    let recovered = RegisteredHostResolver
+        .resolve(&parts_for_host("backoff.acme.com"), &pool)
+        .await
+        .expect("resolve");
+    assert_eq!(
+        recovered.map(|o| o.slug),
+        Some("acme".to_owned()),
+        "once the backoff lapses the resolver must query again and succeed"
     );
 }
 

--- a/crates/rustango/tests/org_hosts_sqlite_live.rs
+++ b/crates/rustango/tests/org_hosts_sqlite_live.rs
@@ -1,0 +1,411 @@
+//! Extra tenant hostnames (`rustango_org_hosts`) against a real registry.
+//!
+//! The rules worth pinning are the ones a unit test cannot reach: a host
+//! may be bound and unbound freely, but the tenant's **base** host — the
+//! `Org.host_pattern` written by `create-tenant` — must survive every
+//! removal path, because a tenant with no host is unreachable and there is
+//! no UI to put it back.
+//! NOTE on isolation: the resolver's cache is process-global and keyed by
+//! hostname, so each test below uses a hostname of its own. Production has
+//! one registry per process, which is why the cache needs no registry key.
+#![cfg(all(feature = "tenancy", feature = "sqlite"))]
+
+use rustango::sql::{sqlx, Pool};
+use rustango::tenancy::{
+    add_host, list_for_org, normalize_hostname, remove_host, set_host_enabled, HostError, Org,
+};
+
+/// Suite-wide lock. The resolver's cache is process-global, so a test that
+/// asserts on cache behaviour cannot run beside one whose `add_host` clears
+/// it — that is not a hypothetical: without this, dropping the invalidation
+/// hook entirely still left the invalidation test green, because a sibling
+/// test happened to clear the cache in between.
+fn cache_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+/// A registry on an in-memory SQLite DB with one org whose base host is
+/// `acme.example.com`.
+async fn registry_with_org() -> Pool {
+    let pool = Pool::Sqlite(
+        sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite"),
+    );
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("framework tables");
+    let mut org = Org {
+        id: rustango::sql::Auto::Unset,
+        slug: "acme".into(),
+        display_name: "Acme".into(),
+        storage_mode: "database".into(),
+        backend_kind: "sqlite".into(),
+        database_url: Some("sqlite::memory:".into()),
+        host_pattern: Some("acme.example.com".into()),
+        ..rustango::testkit::org()
+    };
+    use rustango::sql::FetcherPool as _;
+    org.insert_pool(&pool).await.expect("insert org");
+    pool
+}
+
+#[tokio::test]
+async fn base_host_is_listed_and_flagged() {
+    let _guard = cache_lock().lock().await;
+    let pool = registry_with_org().await;
+    let hosts = list_for_org(&pool, "acme").await.expect("list");
+    assert_eq!(hosts.len(), 1);
+    assert_eq!(hosts[0].hostname, "acme.example.com");
+    assert!(hosts[0].is_base, "the org's host_pattern must be flagged");
+    assert!(hosts[0].id.is_none(), "the base host has no row of its own");
+}
+
+#[tokio::test]
+async fn an_extra_host_can_be_added_listed_and_removed() {
+    let _guard = cache_lock().lock().await;
+    let pool = registry_with_org().await;
+    add_host(&pool, "acme", "add-remove.acme.com")
+        .await
+        .expect("add");
+
+    let hosts = list_for_org(&pool, "acme").await.expect("list");
+    assert_eq!(hosts.len(), 2);
+    assert!(hosts[0].is_base, "base sorts first");
+    let extra = &hosts[1];
+    assert_eq!(extra.hostname, "add-remove.acme.com");
+    assert!(!extra.is_base);
+    assert!(extra.id.is_some(), "an extra host is a real row");
+
+    remove_host(&pool, "acme", "add-remove.acme.com")
+        .await
+        .expect("remove");
+    let hosts = list_for_org(&pool, "acme").await.expect("list");
+    assert_eq!(hosts.len(), 1, "only the base host remains");
+    assert!(hosts[0].is_base);
+}
+
+/// The rule the whole design is arranged around.
+#[tokio::test]
+async fn the_base_host_cannot_be_removed() {
+    let _guard = cache_lock().lock().await;
+    let pool = registry_with_org().await;
+    let err = remove_host(&pool, "acme", "acme.example.com")
+        .await
+        .expect_err("removing the base host must fail");
+    assert!(
+        matches!(err, HostError::IsBaseHost(_)),
+        "expected IsBaseHost, got {err:?}"
+    );
+    // And it is still there.
+    let hosts = list_for_org(&pool, "acme").await.expect("list");
+    assert!(hosts.iter().any(|h| h.is_base));
+}
+
+#[tokio::test]
+async fn the_base_host_cannot_be_disabled_either() {
+    let _guard = cache_lock().lock().await;
+    let pool = registry_with_org().await;
+    // Disabling is removal by another name — an unreachable tenant either
+    // way — so it has to be refused on the same grounds.
+    let err = set_host_enabled(&pool, "acme", "acme.example.com", false)
+        .await
+        .expect_err("disabling the base host must fail");
+    assert!(matches!(err, HostError::IsBaseHost(_)), "got {err:?}");
+}
+
+#[tokio::test]
+async fn a_host_cannot_be_claimed_twice() {
+    let _guard = cache_lock().lock().await;
+    let pool = registry_with_org().await;
+    add_host(&pool, "acme", "twice.acme.com")
+        .await
+        .expect("add");
+    let err = add_host(&pool, "acme", "twice.acme.com")
+        .await
+        .expect_err("duplicate must fail");
+    assert!(matches!(err, HostError::Taken(_)), "got {err:?}");
+}
+
+/// A registered host that duplicates some tenant's base would insert fine
+/// and then never resolve, because `SubdomainResolver` runs first. Refusing
+/// it up front turns a silent routing puzzle into an error message.
+#[tokio::test]
+async fn a_host_matching_another_tenants_base_is_refused() {
+    let _guard = cache_lock().lock().await;
+    let pool = registry_with_org().await;
+    let err = add_host(&pool, "acme", "acme.example.com")
+        .await
+        .expect_err("must not shadow a base host");
+    assert!(matches!(err, HostError::Taken(_)), "got {err:?}");
+}
+
+#[tokio::test]
+async fn removal_is_scoped_to_the_owning_org() {
+    let _guard = cache_lock().lock().await;
+    let pool = registry_with_org().await;
+    use rustango::sql::FetcherPool as _;
+    let mut other = Org {
+        id: rustango::sql::Auto::Unset,
+        slug: "globex".into(),
+        display_name: "Globex".into(),
+        storage_mode: "database".into(),
+        backend_kind: "sqlite".into(),
+        database_url: Some("sqlite::memory:".into()),
+        host_pattern: Some("globex.example.com".into()),
+        ..rustango::testkit::org()
+    };
+    other.insert_pool(&pool).await.expect("insert org");
+    add_host(&pool, "acme", "scoped.acme.com")
+        .await
+        .expect("add");
+
+    // Globex must not be able to unbind Acme's host by naming it.
+    let err = remove_host(&pool, "globex", "scoped.acme.com")
+        .await
+        .expect_err("cross-tenant removal must fail");
+    assert!(matches!(err, HostError::NotFound), "got {err:?}");
+    assert_eq!(list_for_org(&pool, "acme").await.expect("list").len(), 2);
+}
+
+#[tokio::test]
+async fn an_extra_host_can_be_disabled_without_unbinding_it() {
+    let _guard = cache_lock().lock().await;
+    let pool = registry_with_org().await;
+    add_host(&pool, "acme", "disabled.acme.com")
+        .await
+        .expect("add");
+    set_host_enabled(&pool, "acme", "disabled.acme.com", false)
+        .await
+        .expect("disable");
+    let hosts = list_for_org(&pool, "acme").await.expect("list");
+    let extra = hosts.iter().find(|h| !h.is_base).expect("still bound");
+    assert!(!extra.enabled, "disabled but retained");
+}
+
+#[tokio::test]
+async fn hostnames_are_normalized_on_the_way_in() {
+    let _guard = cache_lock().lock().await;
+    let pool = registry_with_org().await;
+    add_host(&pool, "acme", "  SHOP.Acme.COM  ")
+        .await
+        .expect("add");
+    let hosts = list_for_org(&pool, "acme").await.expect("list");
+    assert!(hosts.iter().any(|h| h.hostname == "shop.acme.com"));
+    // ...so the same host in a different case is a duplicate, not a second row.
+    assert!(add_host(&pool, "acme", "Shop.Acme.Com").await.is_err());
+    assert_eq!(
+        normalize_hostname("Shop.Acme.Com").unwrap(),
+        "shop.acme.com"
+    );
+}
+
+/// The upgrade path, which is the whole backward-compatibility question:
+/// an existing registry that predates this feature must gain
+/// `rustango_org_hosts` from the ordinary `migrate` an operator already
+/// runs, with nothing hand-written and nothing else disturbed.
+#[tokio::test]
+async fn an_existing_registry_gains_the_table_on_a_plain_migrate() {
+    let _guard = cache_lock().lock().await;
+    use rustango::sql::FetcherPool as _;
+
+    let dir = tempdir_unique("org-hosts-upgrade");
+    std::fs::create_dir_all(dir.join("migrations")).expect("migrations dir");
+    let db = dir.join("registry.db");
+    let pool = Pool::Sqlite(
+        sqlx::SqlitePool::connect(&format!("sqlite:{}?mode=rwc", db.display()))
+            .await
+            .expect("sqlite"),
+    );
+
+    // A pre-upgrade registry: every framework table EXCEPT the new one.
+    let models: Vec<&'static rustango::core::ModelSchema> = rustango::migrate::registered_models()
+        .into_iter()
+        .filter(|m| {
+            m.managed && m.table.starts_with("rustango_") && m.table != "rustango_org_hosts"
+        })
+        .collect();
+    let mut seen = std::collections::HashSet::new();
+    let models: Vec<_> = models
+        .into_iter()
+        .filter(|m| seen.insert(m.table))
+        .collect();
+    rustango::testkit::create_tables(&pool, &models)
+        .await
+        .expect("pre-upgrade tables");
+    let mut org = Org {
+        id: rustango::sql::Auto::Unset,
+        slug: "legacy".into(),
+        display_name: "Legacy".into(),
+        storage_mode: "database".into(),
+        backend_kind: "sqlite".into(),
+        database_url: Some("sqlite::memory:".into()),
+        host_pattern: Some("legacy.example.com".into()),
+        ..rustango::testkit::org()
+    };
+    org.insert_pool(&pool).await.expect("existing org survives");
+
+    assert!(
+        !table_exists(&pool, "rustango_org_hosts").await,
+        "precondition: the table must be absent before the upgrade"
+    );
+
+    // Exactly what an operator runs after upgrading the binary.
+    rustango::tenancy::migrate_registry_pool(&pool, &dir.join("migrations"))
+        .await
+        .expect("migrate must succeed against a pre-upgrade registry");
+
+    assert!(
+        table_exists(&pool, "rustango_org_hosts").await,
+        "the generated system chain must create the new table"
+    );
+    // And the pre-existing data is untouched.
+    let orgs: Vec<Org> = Org::objects().fetch(&pool).await.expect("orgs");
+    assert_eq!(orgs.len(), 1);
+    assert_eq!(orgs[0].slug, "legacy");
+    assert_eq!(orgs[0].host_pattern.as_deref(), Some("legacy.example.com"));
+
+    // The feature is live immediately after that migrate.
+    add_host(&pool, "legacy", "extra.example.com")
+        .await
+        .expect("add after upgrade");
+    let hosts = list_for_org(&pool, "legacy").await.expect("list");
+    assert_eq!(hosts.len(), 2);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+async fn table_exists(pool: &Pool, table: &str) -> bool {
+    let Pool::Sqlite(sq) = pool else {
+        unreachable!("sqlite-only test")
+    };
+    sqlx::query_scalar::<_, i64>("select count(*) from sqlite_master where type='table' and name=?")
+        .bind(table)
+        .fetch_one(sq)
+        .await
+        .unwrap_or(0)
+        > 0
+}
+
+fn tempdir_unique(prefix: &str) -> std::path::PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&p).expect("temp dir");
+    p
+}
+
+// ---------------------------------------------------------------- routing
+
+/// Build request `Parts` carrying a `Host` header, the way the resolver
+/// sees a real request.
+fn parts_for_host(host: &str) -> http::request::Parts {
+    let req = http::Request::builder()
+        .uri("/")
+        .header(http::header::HOST, host)
+        .body(())
+        .expect("request");
+    req.into_parts().0
+}
+
+#[tokio::test]
+async fn a_registered_host_routes_to_its_tenant() {
+    let _guard = cache_lock().lock().await;
+    use rustango::tenancy::{OrgResolver, RegisteredHostResolver};
+    let pool = registry_with_org().await;
+    rustango::tenancy::invalidate_host_cache();
+    add_host(&pool, "acme", "routes.acme.com")
+        .await
+        .expect("add");
+
+    let got = RegisteredHostResolver
+        .resolve(&parts_for_host("routes.acme.com"), &pool)
+        .await
+        .expect("resolve");
+    assert_eq!(got.map(|o| o.slug), Some("acme".to_owned()));
+}
+
+#[tokio::test]
+async fn an_unregistered_host_resolves_to_nothing() {
+    let _guard = cache_lock().lock().await;
+    use rustango::tenancy::{OrgResolver, RegisteredHostResolver};
+    let pool = registry_with_org().await;
+    rustango::tenancy::invalidate_host_cache();
+    let got = RegisteredHostResolver
+        .resolve(&parts_for_host("nobody.example.com"), &pool)
+        .await
+        .expect("resolve");
+    assert!(got.is_none());
+}
+
+/// A disabled host must stop routing without being unbound — that is the
+/// difference between "parked" and "removed".
+#[tokio::test]
+async fn a_disabled_host_stops_routing() {
+    let _guard = cache_lock().lock().await;
+    use rustango::tenancy::{OrgResolver, RegisteredHostResolver};
+    let pool = registry_with_org().await;
+    rustango::tenancy::invalidate_host_cache();
+    add_host(&pool, "acme", "parked.acme.com")
+        .await
+        .expect("add");
+    set_host_enabled(&pool, "acme", "parked.acme.com", false)
+        .await
+        .expect("disable");
+
+    let got = RegisteredHostResolver
+        .resolve(&parts_for_host("parked.acme.com"), &pool)
+        .await
+        .expect("resolve");
+    assert!(got.is_none(), "a disabled host must not route");
+}
+
+/// The cache must not outlive a mutation. Without the invalidation hook an
+/// operator would add a host and then watch it 404 for the TTL, which is
+/// exactly the kind of thing that gets diagnosed as "it doesn't work".
+#[tokio::test]
+async fn mutations_invalidate_the_resolution_cache() {
+    let _guard = cache_lock().lock().await;
+    use rustango::tenancy::{OrgResolver, RegisteredHostResolver};
+    let pool = registry_with_org().await;
+    rustango::tenancy::invalidate_host_cache();
+
+    // Prime the NEGATIVE entry first — the case that would otherwise stick.
+    let miss = RegisteredHostResolver
+        .resolve(&parts_for_host("later.acme.com"), &pool)
+        .await
+        .expect("resolve");
+    assert!(miss.is_none());
+
+    add_host(&pool, "acme", "later.acme.com")
+        .await
+        .expect("add");
+    let hit = RegisteredHostResolver
+        .resolve(&parts_for_host("later.acme.com"), &pool)
+        .await
+        .expect("resolve");
+    assert_eq!(
+        hit.map(|o| o.slug),
+        Some("acme".to_owned()),
+        "adding a host must invalidate its cached miss"
+    );
+
+    // ...and removing it must invalidate the positive entry just as fast.
+    remove_host(&pool, "acme", "later.acme.com")
+        .await
+        .expect("remove");
+    let gone = RegisteredHostResolver
+        .resolve(&parts_for_host("later.acme.com"), &pool)
+        .await
+        .expect("resolve");
+    assert!(
+        gone.is_none(),
+        "removing a host must invalidate its cached hit"
+    );
+}

--- a/crates/rustango/tests/org_hosts_sqlite_live.rs
+++ b/crates/rustango/tests/org_hosts_sqlite_live.rs
@@ -10,6 +10,7 @@
 //! one registry per process, which is why the cache needs no registry key.
 #![cfg(all(feature = "tenancy", feature = "sqlite"))]
 
+use rustango::core::Column as _;
 use rustango::sql::{sqlx, Pool};
 use rustango::tenancy::{
     add_host, list_for_org, normalize_hostname, remove_host, set_host_enabled, HostError, Org,
@@ -407,5 +408,103 @@ async fn mutations_invalidate_the_resolution_cache() {
     assert!(
         gone.is_none(),
         "removing a host must invalidate its cached hit"
+    );
+}
+
+// ------------------------------------------------- cross-process staleness
+
+/// Write straight to the table, the way a **different pod** would: no call
+/// to this process's `invalidate_host_cache`, because that pod has its own.
+async fn insert_host_behind_the_cache(pool: &Pool, org_slug: &str, hostname: &str) {
+    use rustango::sql::FetcherPool as _;
+    let org = Org::objects()
+        .where_(rustango::tenancy::Org::slug.eq(org_slug.to_owned()))
+        .first(pool)
+        .await
+        .expect("query")
+        .expect("org");
+    let mut row = rustango::tenancy::OrgHost {
+        id: rustango::sql::Auto::Unset,
+        org_id: org.id.get().copied().unwrap_or_default(),
+        hostname: hostname.to_owned(),
+        enabled: true,
+        created_at: rustango::sql::Auto::Unset,
+        updated_at: rustango::sql::Auto::Unset,
+    };
+    row.insert_pool(pool).await.expect("insert");
+}
+
+/// The gap local invalidation cannot close: another pod binds a host, and
+/// this one is still answering from a cached miss. The generation check has
+/// to notice and drop the cache.
+#[tokio::test]
+async fn a_host_added_by_another_pod_is_picked_up() {
+    use rustango::tenancy::{OrgResolver, RegisteredHostResolver};
+    let _guard = cache_lock().lock().await;
+    let pool = registry_with_org().await;
+    rustango::tenancy::invalidate_host_cache();
+    rustango::tenancy::reset_generation_for_test();
+
+    // This pod caches the miss.
+    let miss = RegisteredHostResolver
+        .resolve(&parts_for_host("otherpod.acme.com"), &pool)
+        .await
+        .expect("resolve");
+    assert!(miss.is_none());
+
+    // Another pod binds it — nothing invalidates *this* process.
+    insert_host_behind_the_cache(&pool, "acme", "otherpod.acme.com").await;
+
+    // Without the generation check this stays None until the 30s TTL.
+    rustango::tenancy::expire_generation_for_test();
+    let hit = RegisteredHostResolver
+        .resolve(&parts_for_host("otherpod.acme.com"), &pool)
+        .await
+        .expect("resolve");
+    assert_eq!(
+        hit.map(|o| o.slug),
+        Some("acme".to_owned()),
+        "a host bound by another pod must invalidate this pod's cached miss"
+    );
+}
+
+/// A toggle changes neither the row count nor the max id, so it is the
+/// mutation a naive fingerprint misses — hence `max(updated_at)`.
+#[tokio::test]
+async fn a_deactivation_by_another_pod_is_picked_up() {
+    use rustango::sql::FetcherPool as _;
+    use rustango::tenancy::{OrgResolver, RegisteredHostResolver};
+    let _guard = cache_lock().lock().await;
+    let pool = registry_with_org().await;
+    rustango::tenancy::invalidate_host_cache();
+    rustango::tenancy::reset_generation_for_test();
+
+    insert_host_behind_the_cache(&pool, "acme", "toggle.acme.com").await;
+    rustango::tenancy::expire_generation_for_test();
+    let hit = RegisteredHostResolver
+        .resolve(&parts_for_host("toggle.acme.com"), &pool)
+        .await
+        .expect("resolve");
+    assert!(hit.is_some(), "precondition: it routes while enabled");
+
+    // Another pod deactivates it — count and max(id) are unchanged.
+    let mut row = rustango::tenancy::OrgHost::objects()
+        .where_(rustango::tenancy::OrgHost::hostname.eq("toggle.acme.com".to_owned()))
+        .first(&pool)
+        .await
+        .expect("query")
+        .expect("row");
+    row.enabled = false;
+    row.save_pool(&pool).await.expect("save");
+
+    rustango::tenancy::expire_generation_for_test();
+    let gone = RegisteredHostResolver
+        .resolve(&parts_for_host("toggle.acme.com"), &pool)
+        .await
+        .expect("resolve");
+    assert!(
+        gone.is_none(),
+        "a deactivation elsewhere must reach this pod — the fingerprint has \
+         to include a timestamp, since count and max(id) do not move"
     );
 }

--- a/crates/rustango/tests/org_hosts_sqlite_live.rs
+++ b/crates/rustango/tests/org_hosts_sqlite_live.rs
@@ -9,6 +9,7 @@
 //! hostname, so each test below uses a hostname of its own. Production has
 //! one registry per process, which is why the cache needs no registry key.
 #![cfg(all(feature = "tenancy", feature = "sqlite"))]
+#![allow(irrefutable_let_patterns)] // Pool is single-variant in sqlite-only builds.
 
 use rustango::core::Column as _;
 use rustango::sql::{sqlx, Pool};
@@ -28,7 +29,18 @@ fn cache_lock() -> &'static tokio::sync::Mutex<()> {
 
 /// A registry on an in-memory SQLite DB with one org whose base host is
 /// `acme.example.com`.
+///
+/// Resets **both** pieces of resolver state, not just the resolution
+/// cache. The host-table fingerprint is process-global and keyed by
+/// nothing, so it cannot be side-stepped by giving each test its own
+/// hostnames the way `HOST_CACHE` can: a fingerprint left over from the
+/// previous test's registry gets compared against this brand-new one, and
+/// the mismatch fires a spurious invalidation partway through whichever
+/// test runs next. It only shows up when more than the poll interval
+/// elapses between two tests — a debug CI runner, `--test-threads=1`, a
+/// slow `migrate_framework` — which is the worst kind of flake to chase.
 async fn registry_with_org() -> Pool {
+    rustango::testkit::reset_host_generation();
     let pool = Pool::Sqlite(
         sqlx::SqlitePool::connect("sqlite::memory:")
             .await
@@ -47,7 +59,6 @@ async fn registry_with_org() -> Pool {
         host_pattern: Some("acme.example.com".into()),
         ..rustango::testkit::org()
     };
-    use rustango::sql::FetcherPool as _;
     org.insert_pool(&pool).await.expect("insert org");
     pool
 }
@@ -146,7 +157,6 @@ async fn a_host_matching_another_tenants_base_is_refused() {
 async fn removal_is_scoped_to_the_owning_org() {
     let _guard = cache_lock().lock().await;
     let pool = registry_with_org().await;
-    use rustango::sql::FetcherPool as _;
     let mut other = Org {
         id: rustango::sql::Auto::Unset,
         slug: "globex".into(),
@@ -275,6 +285,120 @@ async fn an_existing_registry_gains_the_table_on_a_plain_migrate() {
     assert_eq!(hosts.len(), 2);
 
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Re-migrating a registry whose `rustango_org_hosts` **already has rows**
+/// must succeed and leave them alone.
+///
+/// The sibling upgrade test above only proves the CREATE path, on a
+/// registry where the table is absent. That is a strictly easier case, and
+/// the gap is not theoretical: an earlier revision of this feature carried
+/// a `NOT NULL` `auto_now` column for the cross-pod fingerprint, which
+/// renders on SQLite as
+///
+/// ```sql
+/// ALTER TABLE "rustango_org_hosts"
+///   ADD COLUMN "updated_at" TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL
+/// ```
+///
+/// SQLite rejects that outright — "Cannot add a column with non-constant
+/// default" — but *only* when the table has rows. On an empty table the
+/// identical statement succeeds, so the CREATE-path test stayed green
+/// while every real deployment would have failed to migrate.
+#[tokio::test]
+async fn a_populated_host_table_survives_a_re_migrate() {
+    let _guard = cache_lock().lock().await;
+    let dir = tempdir_unique("org-hosts-remigrate");
+    std::fs::create_dir_all(dir.join("migrations")).expect("migrations dir");
+    let db = dir.join("registry.db");
+    let pool = Pool::Sqlite(
+        sqlx::SqlitePool::connect(&format!("sqlite:{}?mode=rwc", db.display()))
+            .await
+            .expect("sqlite"),
+    );
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("framework tables");
+    let mut org = Org {
+        id: rustango::sql::Auto::Unset,
+        slug: "acme".into(),
+        display_name: "Acme".into(),
+        storage_mode: "database".into(),
+        backend_kind: "sqlite".into(),
+        database_url: Some("sqlite::memory:".into()),
+        host_pattern: Some("acme.example.com".into()),
+        ..rustango::testkit::org()
+    };
+    org.insert_pool(&pool).await.expect("insert org");
+
+    // Real operator data in the table before the upgrade runs.
+    add_host(&pool, "acme", "kept.acme.com").await.expect("add");
+    add_host(&pool, "acme", "also-kept.acme.com")
+        .await
+        .expect("add");
+
+    rustango::tenancy::migrate_registry_pool(&pool, &dir.join("migrations"))
+        .await
+        .expect("migrate must succeed against a POPULATED rustango_org_hosts");
+
+    let hosts = list_for_org(&pool, "acme").await.expect("list");
+    let names: Vec<&str> = hosts.iter().map(|h| h.hostname.as_str()).collect();
+    assert!(
+        names.contains(&"kept.acme.com") && names.contains(&"also-kept.acme.com"),
+        "existing host rows must survive the migrate, got {names:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The fingerprint contract, asserted directly rather than through the
+/// resolver: every mutation this module can perform has to move it.
+///
+/// The toggle is the interesting one — it changes neither the row count
+/// nor the max id, so a `(count, max_id)` fingerprint would miss it
+/// entirely and a disable on one pod would never reach the others.
+#[tokio::test]
+async fn every_mutation_moves_the_fingerprint() {
+    let _guard = cache_lock().lock().await;
+    use rustango::tenancy::org_host::generation;
+    let pool = registry_with_org().await;
+
+    let empty = generation(&pool).await.expect("generation");
+    assert_eq!(
+        (empty.count, empty.enabled, empty.max_id),
+        (0, 0, 0),
+        "an empty table must fingerprint as all-zero, not error"
+    );
+
+    add_host(&pool, "acme", "fp.acme.com").await.expect("add");
+    let after_add = generation(&pool).await.expect("generation");
+    assert_ne!(after_add, empty, "an add must move the fingerprint");
+    assert_eq!((after_add.count, after_add.enabled), (1, 1));
+
+    set_host_enabled(&pool, "acme", "fp.acme.com", false)
+        .await
+        .expect("disable");
+    let after_toggle = generation(&pool).await.expect("generation");
+    assert_ne!(
+        after_toggle, after_add,
+        "a toggle must move the fingerprint — this is the mutation a \
+         count-and-max-id fingerprint misses"
+    );
+    assert_eq!(
+        (after_toggle.count, after_toggle.enabled),
+        (1, 0),
+        "the row is still there, just not enabled"
+    );
+
+    remove_host(&pool, "acme", "fp.acme.com")
+        .await
+        .expect("remove");
+    let after_remove = generation(&pool).await.expect("generation");
+    assert_ne!(
+        after_remove, after_toggle,
+        "a remove must move the fingerprint"
+    );
+    assert_eq!(after_remove.count, 0);
 }
 
 async fn table_exists(pool: &Pool, table: &str) -> bool {
@@ -416,7 +540,6 @@ async fn mutations_invalidate_the_resolution_cache() {
 /// Write straight to the table, the way a **different pod** would: no call
 /// to this process's `invalidate_host_cache`, because that pod has its own.
 async fn insert_host_behind_the_cache(pool: &Pool, org_slug: &str, hostname: &str) {
-    use rustango::sql::FetcherPool as _;
     let org = Org::objects()
         .where_(rustango::tenancy::Org::slug.eq(org_slug.to_owned()))
         .first(pool)
@@ -429,7 +552,6 @@ async fn insert_host_behind_the_cache(pool: &Pool, org_slug: &str, hostname: &st
         hostname: hostname.to_owned(),
         enabled: true,
         created_at: rustango::sql::Auto::Unset,
-        updated_at: rustango::sql::Auto::Unset,
     };
     row.insert_pool(pool).await.expect("insert");
 }
@@ -443,7 +565,7 @@ async fn a_host_added_by_another_pod_is_picked_up() {
     let _guard = cache_lock().lock().await;
     let pool = registry_with_org().await;
     rustango::tenancy::invalidate_host_cache();
-    rustango::tenancy::reset_generation_for_test();
+    rustango::testkit::reset_host_generation();
 
     // This pod caches the miss.
     let miss = RegisteredHostResolver
@@ -456,7 +578,7 @@ async fn a_host_added_by_another_pod_is_picked_up() {
     insert_host_behind_the_cache(&pool, "acme", "otherpod.acme.com").await;
 
     // Without the generation check this stays None until the 30s TTL.
-    rustango::tenancy::expire_generation_for_test();
+    rustango::testkit::expire_host_generation();
     let hit = RegisteredHostResolver
         .resolve(&parts_for_host("otherpod.acme.com"), &pool)
         .await
@@ -469,18 +591,21 @@ async fn a_host_added_by_another_pod_is_picked_up() {
 }
 
 /// A toggle changes neither the row count nor the max id, so it is the
-/// mutation a naive fingerprint misses — hence `max(updated_at)`.
+/// mutation a naive fingerprint misses — hence the `enabled` term.
+///
+/// Swapping the fingerprint back to `(count, max_id)` fails this test and
+/// leaves every other one green, which is the property that makes the
+/// third term worth carrying.
 #[tokio::test]
 async fn a_deactivation_by_another_pod_is_picked_up() {
-    use rustango::sql::FetcherPool as _;
     use rustango::tenancy::{OrgResolver, RegisteredHostResolver};
     let _guard = cache_lock().lock().await;
     let pool = registry_with_org().await;
     rustango::tenancy::invalidate_host_cache();
-    rustango::tenancy::reset_generation_for_test();
+    rustango::testkit::reset_host_generation();
 
     insert_host_behind_the_cache(&pool, "acme", "toggle.acme.com").await;
-    rustango::tenancy::expire_generation_for_test();
+    rustango::testkit::expire_host_generation();
     let hit = RegisteredHostResolver
         .resolve(&parts_for_host("toggle.acme.com"), &pool)
         .await
@@ -497,7 +622,7 @@ async fn a_deactivation_by_another_pod_is_picked_up() {
     row.enabled = false;
     row.save_pool(&pool).await.expect("save");
 
-    rustango::tenancy::expire_generation_for_test();
+    rustango::testkit::expire_host_generation();
     let gone = RegisteredHostResolver
         .resolve(&parts_for_host("toggle.acme.com"), &pool)
         .await


### PR DESCRIPTION
## What

`Org.host_pattern` is one exact host per tenant, so a tenant that needs to answer on a second domain has no way to say so. This adds `rustango_org_hosts` — any number of extra hostnames bound to an org — plus a `RegisteredHostResolver` that routes them, and a small CRUD API (`add_host` / `remove_host` / `set_host_enabled` / `list_for_org`).

## The base host is protected structurally, not by a check

It would be tidier to migrate `host_pattern` into the new table and mark it `is_primary`. That is exactly what makes it fragile: the guarantee "a tenant always has a host" becomes a runtime `if` that one careless `DELETE … WHERE org_id = ?` walks straight past, leaving a tenant unreachable with no UI to put it back.

Left on the org, there is no row to delete. `list_for_org` unions the two sources and flags which is which, so callers still see a single list — and `remove_host` / `set_host_enabled` refuse it explicitly for anyone who addresses it by name.

## Existing users

Additive by construction, and each point is tested:

- **Routing is unchanged.** Composed *after* `SubdomainResolver`, so a base host resolves as before and this only runs where nothing matched. Until an operator registers a host the table is empty.
- **No manual migration.** The table arrives via the generated system chain, which is produced from the compiled models at migrate time — so an existing registry gains it from the `migrate` already run on upgrade. `an_existing_registry_gains_the_table_on_a_plain_migrate` stands up a pre-feature registry and proves it, including that existing rows survive.
- **A missing table is not an error.** Between upgrading the binary and running migrate the table does not exist; propagating that would turn "you haven't migrated yet" into a 500 on *every* request, including for tenants that never use this. It logs once and reports no match.

## Caching: RAM, and invalidated across pods

Tenant resolution is otherwise uncached — every request already pays one registry SELECT, and this would have added a second. Resolution is cached in process memory (30s TTL, bounded at 1024 entries).

The **negative** entries matter more than the positive ones. The chain short-circuits, so what reaches this resolver is every request to a host nobody registered; without a cached miss, spraying random `Host` headers is a free registry query per request. The map is bounded for the same reason — the keys are attacker-supplied, and an unbounded one trades a query amplification for a memory one.

A purely local `invalidate_host_cache()` would only be half a fix: behind a load balancer the pod serving the admin request forgets and every other pod keeps answering from a stale cache until its TTL expires. So each process also re-reads a cheap fingerprint of the host table and drops its cache when it moves — throttled to once per 5s, so it is one small query per pod per interval rather than one per request.

The fingerprint is `(count, max(updated_at))`. `(count, max(id))` is the obvious choice and is wrong: an enable/disable toggle changes neither, so a deactivation on another pod would never propagate. There is a test for precisely that.

Redis was available (`cache-redis` ships a `RedisCache`) and deliberately not used: tenant resolution runs before everything else, and a shared cache would give it a new way to fail for a lookup whose miss costs one indexed SELECT. RAM plus a 5s convergence bound keeps the failure domain where it already was.

## Tests

16 in `tests/org_hosts_sqlite_live.rs` — sqlite, no external DB. All mutation-checked; each of these turns a test red:

- removing the base-host guard
- removing the cross-tenant scoping on `remove_host`
- removing either invalidation hook
- removing the cross-process generation sync
- swapping `max(updated_at)` for `max(id)` in the fingerprint (fails *only* the deactivation test, as designed)

One test was initially green *for the wrong reason* — the cache is process-global, and a sibling test's `add_host` was clearing the entry the invalidation test had primed. The file now takes a suite-wide lock, which is what makes the mutation checks meaningful.

## Not included

The CMS-side surface (a Sites screen, and mapping a host to a root page so one tenant can serve several sites) is a separate change on top of this; this PR is only the registry primitive and the resolver.