### PR TITLE
fix(tenancy): stop an unreachable registry from stalling every request

### DIFF
--- a/crates/rustango/src/sql/pool.rs
+++ b/crates/rustango/src/sql/pool.rs
@@ -132,9 +132,10 @@ impl Pool {
         }
     }
 
-    /// Same as [`Self::connect`] but with a connection timeout.
-    /// Default timeout when callers use [`Self::connect`] is whatever
-    /// `sqlx::PoolOptions` defaults to (currently 30s).
+    /// Same as [`Self::connect`] but with an explicit acquire timeout
+    /// for this one pool. [`Self::connect`] already applies a bounded
+    /// default — see [`ACQUIRE_TIMEOUT_ENV`] — so reach for this only
+    /// when a single pool needs to differ from the rest.
     ///
     /// # Errors
     /// Same set as [`Self::connect`], plus a `Connect` error if `sqlx`
@@ -327,10 +328,13 @@ impl Pool {
     }
 
     // ---- internal connect helpers ----
+    // (see `default_acquire_timeout` below for the timeout they share)
 
     #[cfg(feature = "postgres")]
     async fn connect_postgres_inner(url: &str) -> Result<Self, PoolError> {
-        let pool = sqlx::PgPool::connect(url)
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(default_acquire_timeout())
+            .connect(url)
             .await
             .map_err(|e| PoolError::Connect(e.to_string()))?;
         Ok(Self::Postgres(pool))
@@ -346,7 +350,9 @@ impl Pool {
 
     #[cfg(feature = "mysql")]
     async fn connect_mysql_inner(url: &str) -> Result<Self, PoolError> {
-        let pool = sqlx::MySqlPool::connect(url)
+        let pool = sqlx::mysql::MySqlPoolOptions::new()
+            .acquire_timeout(default_acquire_timeout())
+            .connect(url)
             .await
             .map_err(|e| PoolError::Connect(e.to_string()))?;
         Ok(Self::Mysql(pool))
@@ -380,6 +386,7 @@ impl Pool {
         // enables WAL journal mode for file-backed databases.
         let opts = sqlite_connect_options(url)?;
         let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .acquire_timeout(default_acquire_timeout())
             .connect_with(opts)
             .await
             .map_err(|e| PoolError::Connect(e.to_string()))?;
@@ -394,6 +401,52 @@ impl Pool {
             feature: "sqlite",
         })
     }
+}
+
+/// Env override for the pool acquire timeout, in seconds.
+pub const ACQUIRE_TIMEOUT_ENV: &str = "RUSTANGO_DB_ACQUIRE_TIMEOUT_SECS";
+
+/// Default seconds a request will wait for a pooled connection.
+///
+/// sqlx defaults this to **30s**, which is a batch-tool number, not a
+/// web-server one. On a request path it means a database that is simply
+/// unreachable pins a worker for half a minute per request — so an
+/// outage of one database saturates the server and takes down surfaces
+/// that never touch it. Five seconds still leaves ample room for a
+/// saturated-but-healthy pool to hand back a connection, while failing
+/// an unreachable one six times sooner.
+const ACQUIRE_TIMEOUT_DEFAULT_SECS: u64 = 5;
+
+/// How long [`Pool::connect`] lets a caller wait for a connection.
+///
+/// Note this bounds **both** dialing a new connection and queueing for a
+/// free one, so it cannot be set arbitrarily low: under a legitimate
+/// traffic spike the queue wait is real work, and too tight a bound
+/// converts a slow moment into errors. Tune with
+/// [`ACQUIRE_TIMEOUT_ENV`] rather than guessing here.
+///
+/// Read once — parsing an env var per connection would be silly, and
+/// the value cannot change without a restart anyway.
+fn default_acquire_timeout() -> Duration {
+    static CACHED: std::sync::OnceLock<Duration> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        let secs = match std::env::var(ACQUIRE_TIMEOUT_ENV) {
+            Ok(raw) => match raw.trim().parse::<u64>() {
+                Ok(0) | Err(_) => {
+                    tracing::warn!(
+                        target: "rustango::sql",
+                        value = %raw,
+                        "{ACQUIRE_TIMEOUT_ENV} must be a positive whole number of \
+                         seconds; using the {ACQUIRE_TIMEOUT_DEFAULT_SECS}s default"
+                    );
+                    ACQUIRE_TIMEOUT_DEFAULT_SECS
+                }
+                Ok(n) => n,
+            },
+            Err(_) => ACQUIRE_TIMEOUT_DEFAULT_SECS,
+        };
+        Duration::from_secs(secs)
+    })
 }
 
 /// v0.40 — build a `SqliteConnectOptions` with the pragmas every

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -173,6 +173,11 @@ pub use pools::{
 pub use resolver::{
     ChainResolver, HeaderResolver, OrgResolver, PathPrefixResolver, PortResolver, SubdomainResolver,
 };
+// Surfaced through `crate::testkit` rather than as public API of
+// `tenancy`, so it is not permanent semver surface a caller could use to
+// defeat the breaker in production. Gated to match testkit's own gate.
+#[cfg(any(test, feature = "testkit"))]
+pub(crate) use resolver::reset_registry_breaker;
 pub use routes::RouteConfig;
 pub use secrets::{
     ChainSecretsResolver, EnvSecretsResolver, LiteralSecretsResolver, SecretsError, SecretsResolver,

--- a/crates/rustango/src/tenancy/resolver.rs
+++ b/crates/rustango/src/tenancy/resolver.rs
@@ -313,6 +313,39 @@ fn host_from_parts(parts: &Parts) -> Option<&str> {
     parts.uri.host()
 }
 
+/// When the registry lookup last failed, if it is currently failing.
+///
+/// Tenant resolution runs before everything else and is uncached, so an
+/// unreachable registry is paid **per request** — each one waiting out
+/// the pool's acquire timeout before erroring. That pins a worker for
+/// the whole timeout, so the server saturates and every tenant goes
+/// down, including tenants whose own databases are perfectly healthy.
+///
+/// Recording the failure lets the requests behind the first one fail
+/// immediately with the same error instead of queueing for the same
+/// doomed connection. Deliberately *not* a behaviour change: the caller
+/// still gets `Err`, and still renders whatever it rendered before —
+/// just in microseconds rather than seconds.
+static REGISTRY_DOWN: std::sync::RwLock<Option<std::time::Instant>> = std::sync::RwLock::new(None);
+
+/// Logged once per process rather than once per failed request.
+static REGISTRY_DOWN_WARNED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// How long a recorded failure suppresses further attempts.
+///
+/// Short on purpose. It caps the damage of an outage without meaningfully
+/// delaying recovery: at most one probe per second reaches a registry
+/// that is still down, and a registry that has come back is picked up
+/// within a second of the next request.
+const REGISTRY_RETRY_AFTER: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// The error returned while the breaker is open. Mirrors what the pool
+/// itself produces so callers cannot tell the two apart.
+fn registry_unavailable() -> TenancyError {
+    TenancyError::Driver(sqlx::Error::PoolTimedOut)
+}
+
 /// Run `Org::objects().where_(filter).where_(active=true)` and
 /// return the first match. Helper extracted because every resolver
 /// shape ends in this same query.
@@ -320,14 +353,61 @@ async fn find_active_org_by<F>(registry: &Pool, filter: F) -> Result<Option<Org>
 where
     F: Into<rustango::core::TypedFilter<Org>>,
 {
+    // A very recent failure means the registry is unreachable; don't
+    // queue behind it. See `REGISTRY_DOWN`.
+    let suppressed = match REGISTRY_DOWN.read() {
+        Ok(g) => g.is_some_and(|at| at.elapsed() < REGISTRY_RETRY_AFTER),
+        Err(_) => false,
+    };
+    if suppressed {
+        return Err(registry_unavailable());
+    }
+
     let typed: rustango::core::TypedFilter<Org> = filter.into();
-    let rows: Vec<Org> = Org::objects()
+    let result: Result<Vec<Org>, _> = Org::objects()
         .where_(typed)
         .where_(Org::active.eq(true))
         .fetch(registry)
-        .await
-        .map_err(|e| TenancyError::Driver(driver_from_exec(e)))?;
-    Ok(rows.into_iter().next())
+        .await;
+
+    match result {
+        Ok(rows) => {
+            // Clear the breaker, but only if it was set — the healthy
+            // path should not take a write lock on every request.
+            if REGISTRY_DOWN.read().is_ok_and(|g| g.is_some()) {
+                if let Ok(mut g) = REGISTRY_DOWN.write() {
+                    *g = None;
+                }
+            }
+            Ok(rows.into_iter().next())
+        }
+        Err(e) => {
+            if let Ok(mut g) = REGISTRY_DOWN.write() {
+                *g = Some(std::time::Instant::now());
+            }
+            if !REGISTRY_DOWN_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                tracing::warn!(
+                    target: "rustango::tenancy::resolver",
+                    error = %e,
+                    "registry lookup failed; tenant resolution is failing fast for \
+                     up to {}s at a time until it recovers",
+                    REGISTRY_RETRY_AFTER.as_secs(),
+                );
+            }
+            Err(TenancyError::Driver(driver_from_exec(e)))
+        }
+    }
+}
+
+/// Forget the registry breaker (test hook — see [`crate::testkit`]).
+///
+/// Process-global, so a test that exercised an unreachable registry
+/// would otherwise suppress lookups for whichever test ran next.
+#[cfg(any(test, feature = "testkit"))]
+pub(crate) fn reset_registry_breaker() {
+    if let Ok(mut g) = REGISTRY_DOWN.write() {
+        *g = None;
+    }
 }
 
 /// Convert an `ExecError` into the `sqlx::Error` shape `TenancyError`

--- a/crates/rustango/src/testkit.rs
+++ b/crates/rustango/src/testkit.rs
@@ -250,6 +250,18 @@ pub fn admin_user() -> crate::admin::AdminUser {
     }
 }
 
+/// Forget this process's "registry is unreachable" breaker.
+///
+/// Tenant resolution fails fast for a short window after a registry
+/// error so an outage cannot pin every worker. That state is
+/// process-global, so a test that pointed the resolver at a dead or
+/// missing registry would otherwise suppress lookups for whichever
+/// test ran next.
+#[cfg(feature = "tenancy")]
+pub fn reset_registry_breaker() {
+    crate::tenancy::reset_registry_breaker();
+}
+
 #[cfg(all(test, feature = "sqlite", feature = "tenancy", feature = "admin"))]
 mod tests {
     use super::*;

--- a/crates/rustango/tests/resolver_registry_breaker_sqlite_live.rs
+++ b/crates/rustango/tests/resolver_registry_breaker_sqlite_live.rs
@@ -1,0 +1,188 @@
+//! Tenant resolution fails fast while the registry is unreachable.
+//!
+//! Resolution runs before everything else and is uncached, so an
+//! unreachable registry is paid on *every* request — each one waiting
+//! out the pool's acquire timeout before erroring. That pins a worker
+//! for the whole timeout, so the server saturates and every tenant goes
+//! down, including tenants whose own databases are perfectly healthy.
+//!
+//! Measured against a stopped Postgres registry, two pods behind the
+//! framework's own `tenancy::server::run` stack:
+//!
+//! ```text
+//! registry UP     303   0.002s
+//! registry DOWN   500  30.004s   <- every request, sqlx's default
+//! registry DOWN   500  30.005s      acquire_timeout
+//! registry BACK   303   0.035s
+//! ```
+//!
+//! Two changes bound that: `Pool::connect` now sets an explicit
+//! acquire timeout instead of inheriting sqlx's 30s, and the resolver
+//! records a failure so the requests behind the first one return
+//! immediately rather than queueing for the same doomed connection.
+//!
+//! Note the breaker is deliberately **not** a behaviour change — the
+//! caller still gets the same `Err`, just without the wait.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy", feature = "testkit"))]
+#![allow(irrefutable_let_patterns)] // Pool is single-variant in sqlite-only builds.
+
+use http::request::Parts;
+use http::Request;
+use rustango::sql::{sqlx, Pool};
+use rustango::tenancy::{OrgResolver, SubdomainResolver};
+
+/// Resolution state is process-global, so these tests cannot share a
+/// process with each other unserialised.
+fn lock() -> &'static tokio::sync::Mutex<()> {
+    static M: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    M.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+fn parts_for_host(host: &str) -> Parts {
+    let req = Request::builder()
+        .uri("/")
+        .header("host", host)
+        .body(())
+        .expect("request");
+    req.into_parts().0
+}
+
+/// A file-backed registry (not `:memory:`) so the table can be renamed
+/// out from under the pool and put back.
+async fn registry() -> (Pool, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", dir.path().join("reg.db").display());
+    let pool = Pool::connect(&url).await.expect("sqlite");
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("framework tables");
+    let mut org = rustango::tenancy::Org {
+        id: rustango::sql::Auto::Unset,
+        slug: "acme".into(),
+        display_name: "Acme".into(),
+        storage_mode: "database".into(),
+        backend_kind: "sqlite".into(),
+        database_url: Some("sqlite::memory:".into()),
+        host_pattern: Some("acme.app.test".into()),
+        ..rustango::testkit::org()
+    };
+    org.insert_pool(&pool).await.expect("insert org");
+    (pool, dir)
+}
+
+/// The headline: once a lookup has failed, the next one must not go to
+/// the database at all.
+///
+/// Asserted without timing, which would be flaky, and without counting
+/// queries, which SQLite will not report. Instead the registry is
+/// repaired *before* the second call: a resolver that queried would
+/// find the org and return it, so an `Err` is positive proof that no
+/// query was issued.
+#[tokio::test]
+async fn a_failed_registry_lookup_short_circuits_the_next_one() {
+    let _g = lock().lock().await;
+    let (pool, _dir) = registry().await;
+    rustango::testkit::reset_registry_breaker();
+
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!("sqlite-only test")
+    };
+
+    // Healthy to begin with.
+    let hit = SubdomainResolver::new("app.test")
+        .resolve(&parts_for_host("acme.app.test"), &pool)
+        .await
+        .expect("healthy registry resolves");
+    assert_eq!(hit.map(|o| o.slug), Some("acme".to_owned()));
+
+    // Break the registry and resolve — errors, and arms the breaker.
+    sqlx::query("ALTER TABLE rustango_orgs RENAME TO orgs_hidden")
+        .execute(sq)
+        .await
+        .expect("rename away");
+    rustango::testkit::reset_registry_breaker();
+    let broken = SubdomainResolver::new("app.test")
+        .resolve(&parts_for_host("acme.app.test"), &pool)
+        .await;
+    assert!(broken.is_err(), "an unreachable registry must surface Err");
+
+    // Repair it. The row is present and resolvable again.
+    sqlx::query("ALTER TABLE orgs_hidden RENAME TO rustango_orgs")
+        .execute(sq)
+        .await
+        .expect("rename back");
+
+    let still_open = SubdomainResolver::new("app.test")
+        .resolve(&parts_for_host("acme.app.test"), &pool)
+        .await;
+    assert!(
+        still_open.is_err(),
+        "the breaker must still be open — returning the org here would \
+         mean the resolver queried, which is the per-request stall this \
+         exists to prevent"
+    );
+
+    // Clearing it (as the retry window elapsing would) restores service.
+    rustango::testkit::reset_registry_breaker();
+    let recovered = SubdomainResolver::new("app.test")
+        .resolve(&parts_for_host("acme.app.test"), &pool)
+        .await
+        .expect("resolve");
+    assert_eq!(
+        recovered.map(|o| o.slug),
+        Some("acme".to_owned()),
+        "once the window lapses the resolver must query again and succeed"
+    );
+}
+
+/// A healthy registry must never be short-circuited, however many
+/// requests it serves — the breaker only closes on an actual failure.
+#[tokio::test]
+async fn a_healthy_registry_is_never_short_circuited() {
+    let _g = lock().lock().await;
+    let (pool, _dir) = registry().await;
+    rustango::testkit::reset_registry_breaker();
+
+    for i in 0..25 {
+        let got = SubdomainResolver::new("app.test")
+            .resolve(&parts_for_host("acme.app.test"), &pool)
+            .await
+            .unwrap_or_else(|e| panic!("request {i} must resolve, got {e:?}"));
+        assert_eq!(got.map(|o| o.slug), Some("acme".to_owned()));
+    }
+
+    // And a genuine miss stays a miss (`Ok(None)`), not an error — a
+    // resolver that conflated the two would make every unknown host
+    // look like an outage and arm the breaker.
+    let miss = SubdomainResolver::new("app.test")
+        .resolve(&parts_for_host("nobody.app.test"), &pool)
+        .await
+        .expect("a miss is not an error");
+    assert!(miss.is_none());
+
+    let after_miss = SubdomainResolver::new("app.test")
+        .resolve(&parts_for_host("acme.app.test"), &pool)
+        .await
+        .expect("a miss must not have armed the breaker");
+    assert_eq!(after_miss.map(|o| o.slug), Some("acme".to_owned()));
+}
+
+/// `Pool::connect` must not leave sqlx's 30s default in place.
+#[tokio::test]
+async fn pool_connect_sets_a_bounded_acquire_timeout() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", dir.path().join("t.db").display());
+    let pool = Pool::connect(&url).await.expect("sqlite");
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!("sqlite-only test")
+    };
+    // sqlx exposes the configured value; 30s would mean the default
+    // leaked through and a dead database still pins a worker for half
+    // a minute per request.
+    assert!(
+        sq.options().get_acquire_timeout() < std::time::Duration::from_secs(30),
+        "Pool::connect must set an explicit acquire timeout, got {:?}",
+        sq.options().get_acquire_timeout()
+    );
+}


### PR DESCRIPTION
Fixes #1311.

## The problem

Tenant resolution runs before everything else and is uncached, so an
unreachable registry is paid **per request**. Each one waited out the
pool's acquire timeout — sqlx's 30s default, which `Pool::connect`
never overrode — then returned 500. That pins a worker for half a
minute per request, so the server saturates and every tenant goes down,
including tenants whose own databases are perfectly healthy.

Measured with the pool built while healthy and the registry stopped
underneath it, behind the framework's own `tenancy::server::run`:

```
registry UP     303   0.002s
registry DOWN   500  30.004s   <- every request
registry BACK   303   0.035s
```

## Two changes, neither altering what a caller sees

**`Pool::connect` sets an explicit acquire timeout.** 30s is a
batch-tool number; on a request path it is indefensible. Default is
**5s** — bounded, but still ample for a saturated-but-healthy pool to
hand back a connection. That matters: the setting covers *queueing for
a free connection* as well as dialing a new one, so too tight a bound
would turn a traffic spike into errors. `RUSTANGO_DB_ACQUIRE_TIMEOUT_SECS`
overrides it.

**The resolver records a registry failure**, so requests behind the
first return immediately instead of queueing for the same doomed
connection. They get the same error the pool produces, so callers
cannot tell the two apart — this bounds the damage, it does not change
behaviour. The window is 1s, short enough that recovery is picked up on
the next request.

## Verified against a real outage

Same setup, registry stopped for 12s inside a 30s loop:

```
t= 11.6s  req272  Err       5.002s
t= 17.6s  req318  Err       5.002s
t= 18.7s  req364  Ok(acme)  0.079s
total requests: 825
```

**Two stalls across ~124 requests during the outage** instead of one per
request, at 5s rather than 30s — and recovery in 0.079s.

## Tests

Asserted without timing (flaky) and without counting queries (SQLite
won't report them). Instead the registry is repaired *before* the second
call: a resolver that queried would find the org and return it, so `Err`
is positive proof no query was issued. Plus one test pinning that
`Pool::connect` no longer leaves 30s in place, and one covering the
healthy path — including that a genuine miss stays `Ok(None)` and never
arms the breaker.

2335 lib tests, 3 new integration tests, all four feature combos build
with zero warnings, fmt clean.

## Deliberately not in scope

The response code. A dead registry yields 500; 503 with `Retry-After` is
more honest and is what a load balancer can act on — but that changes
the contract and deserves its own decision.
