### PR TITLE
perf(tenancy): cache base-host resolution so the registry is off the hot path

### DIFF
--- a/crates/rustango/src/tenancy/manage/tenants.rs
+++ b/crates/rustango/src/tenancy/manage/tenants.rs
@@ -140,6 +140,9 @@ where
         theme_mode: None,
     };
     org.insert_pool(&registry).await?;
+    // This pod sees the new tenant immediately; others converge on the
+    // registry fingerprint (see `resolver::sync_org_generation`).
+    super::super::invalidate_org_cache();
     let id = org.id.get().copied().unwrap_or_default();
     writeln!(
         w,
@@ -360,6 +363,10 @@ where
         .set("active", false)
         .execute_pool(&registry)
         .await?;
+    // A suspended tenant must stop resolving. Local invalidation is
+    // instant here; other pods notice within one fingerprint interval
+    // because `active` is one of its terms.
+    super::super::invalidate_org_cache();
     if updated == 0 {
         return Err(TenancyError::Validation(format!(
             "drop-tenant: no row updated for id {id} — race condition?"

--- a/crates/rustango/src/tenancy/manage/tenants.rs
+++ b/crates/rustango/src/tenancy/manage/tenants.rs
@@ -363,15 +363,19 @@ where
         .set("active", false)
         .execute_pool(&registry)
         .await?;
-    // A suspended tenant must stop resolving. Local invalidation is
-    // instant here; other pods notice within one fingerprint interval
-    // because `active` is one of its terms.
-    super::super::invalidate_org_cache();
     if updated == 0 {
         return Err(TenancyError::Validation(format!(
             "drop-tenant: no row updated for id {id} — race condition?"
         )));
     }
+    // Only once the write is confirmed. Invalidating before the guard
+    // would throw away a healthy cache on a no-op, and the suspension
+    // it is clearing would not have happened.
+    //
+    // Clears the extra-hostname cache as well — that one holds `Org`
+    // rows too, so without it a suspended tenant's base host 404s while
+    // its extra hosts keep serving.
+    super::super::invalidate_org_cache();
     writeln!(
         w,
         "soft-deleted tenant `{slug}` (active=false). Data preserved."
@@ -572,6 +576,10 @@ where
             "purge-tenant: no Org row deleted for id {id} — race condition?"
         )));
     }
+    // The schema or database is already gone by this point, so a cached
+    // resolution would route requests at storage that no longer exists —
+    // a 500 where the tenant should simply be unknown.
+    super::super::invalidate_org_cache();
     writeln!(w, "  removed Org row (id {id})")?;
     Ok(())
 }

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -100,6 +100,7 @@ mod pools;
 /// Bearer access token, MCP agent token).
 pub mod principal;
 mod resolver;
+mod resolver_cache;
 pub mod routes;
 mod secrets;
 pub mod session;

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -166,7 +166,11 @@ pub use migrate::{
     migrate_registry, migrate_registry_pool, migrate_tenants_db, migrate_tenants_dyn,
     TenantMigrationOutcome, TenantMigrationReport,
 };
-pub use org::{BackendKind, Org, StorageMode};
+/// Fingerprint of `rustango_orgs`, used by the base-host cache to notice
+/// writes made by another process. Public so a deployment can poll it
+/// itself (e.g. to drive a custom cache) and so tests can assert on it.
+pub use org::generation as org_generation;
+pub use org::{BackendKind, Org, OrgGeneration, StorageMode};
 pub use org_host::{
     add_host, list_for_org, normalize_hostname, remove_host, set_host_enabled, HostError, OrgHost,
     TenantHost,
@@ -176,8 +180,8 @@ pub use pools::{
     TenantPoolsConfig,
 };
 pub use resolver::{
-    invalidate_host_cache, ChainResolver, HeaderResolver, OrgResolver, PathPrefixResolver,
-    PortResolver, RegisteredHostResolver, SubdomainResolver,
+    invalidate_host_cache, invalidate_org_cache, ChainResolver, HeaderResolver, OrgResolver,
+    PathPrefixResolver, PortResolver, RegisteredHostResolver, SubdomainResolver,
 };
 // The resolver's process-global test hooks are deliberately NOT public
 // API of `tenancy` — they live in `crate::testkit`, so the name says
@@ -186,7 +190,9 @@ pub use resolver::{
 // Gated to match `testkit`'s own gate, so a production build neither
 // compiles them in nor warns about an unused re-export.
 #[cfg(any(test, feature = "testkit"))]
-pub(crate) use resolver::{expire_generation, reset_generation, reset_registry_breaker};
+pub(crate) use resolver::{
+    expire_generation, reset_generation, reset_org_cache, reset_registry_breaker,
+};
 pub use routes::RouteConfig;
 pub use secrets::{
     ChainSecretsResolver, EnvSecretsResolver, LiteralSecretsResolver, SecretsError, SecretsResolver,

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -1353,6 +1353,14 @@ async fn org_edit_submit(
         return redirect_with_error(&slug, &format!("update failed: {e}"));
     }
 
+    // Drop the cached `Org` before anything else acts on the write.
+    // Resolution serves from that cache now, so without this the pool
+    // is evicted and then immediately rebuilt from the stale row — the
+    // rotation this handler promises would report success while the
+    // next request reconnected with the old credential. `active =
+    // false` has the same shape: the tenant would keep serving.
+    super::invalidate_org_cache();
+
     if database_url_changed {
         pools.invalidate(&slug).await;
     }
@@ -1549,6 +1557,10 @@ async fn org_edit_branding(
     if let Err(e) = crate::sql::update_pool(&state.registry, &update_q).await {
         return redirect_with_error(&slug, &format!("update failed: {e}"));
     }
+    // Branding lives on the `Org` row that resolution caches, so an
+    // upload without this leaves the previous logo rendering until the
+    // entry expires.
+    super::invalidate_org_cache();
 
     // Audit row — branding uploads touch the public-facing surface
     // of a tenant; operators iterating during onboarding leave a

--- a/crates/rustango/src/tenancy/org.rs
+++ b/crates/rustango/src/tenancy/org.rs
@@ -289,6 +289,100 @@ impl core::fmt::Display for BackendKind {
     }
 }
 
+/// A cheap fingerprint of `rustango_orgs`, used to notice a change made
+/// by **another process**.
+///
+/// The base-host resolution cache is per-process, so without this a
+/// tenant created or suspended on one pod would keep resolving the old
+/// way on every other pod until their entries aged out. Each pod re-reads
+/// this periodically and drops its cache when it moves, which bounds
+/// cross-pod convergence at the poll interval instead of the cache TTL.
+///
+/// Clock-free by design, for the same two reasons the sibling
+/// `rustango_org_hosts` fingerprint is: an `auto_now` column takes its
+/// value from the database clock on INSERT but the writing process's
+/// clock on UPDATE, so a lagging pod can write a timestamp older than
+/// the current max and the change never propagates — and adding a
+/// `NOT NULL` column with a non-constant default is rejected outright by
+/// SQLite on any table that already has rows.
+///
+/// | mutation | what moves |
+/// |---|---|
+/// | tenant created | `count`, `max_id`, `active`, `active_id_sum` |
+/// | tenant suspended (`active = false`) | `active`, `active_id_sum` |
+/// | tenant hard-deleted | `count`, `active_id_sum` |
+///
+/// **What it does not catch:** an in-place field edit that changes
+/// neither the row count nor the active set — rotating `database_url`,
+/// renaming `host_pattern`. Those converge on the cache TTL instead.
+/// That is a deliberate trade: the alternative is a per-row checksum on
+/// the hot path, and the events that need to be fast (create, suspend)
+/// are exactly the ones these terms cover.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OrgGeneration {
+    /// Total rows — moves on create and hard-delete.
+    pub count: i64,
+    /// Rows with `active = true` — moves on suspend/reactivate, which
+    /// changes neither `count` nor `max_id`.
+    pub active: i64,
+    /// Largest row id — distinguishes a create-plus-delete inside one
+    /// interval, which leaves `count` unchanged.
+    pub max_id: i64,
+    /// Sum of the ids of the active rows — identifies *which* tenants
+    /// are live, not just how many, so suspending one while
+    /// reactivating another in the same interval still moves it.
+    pub active_id_sum: i64,
+}
+
+/// Read the [`OrgGeneration`] fingerprint — one aggregate query, four
+/// scalars, no rows decoded.
+///
+/// # Errors
+/// Driver / query failures.
+pub async fn generation(
+    registry: &crate::sql::Pool,
+) -> Result<OrgGeneration, crate::sql::ExecError> {
+    use crate::core::aggregates::{count_all, max, sum};
+    use crate::core::{AggregateQuery, Column as _, Model as _, WhereExpr};
+    use crate::sql::fetch_aggregate_pool;
+
+    let q = AggregateQuery {
+        model: Org::SCHEMA,
+        joins: Vec::new(),
+        where_clause: WhereExpr::And(Vec::new()),
+        group_by: Vec::new(),
+        aggregates: vec![
+            ("n".into(), count_all().into()),
+            (
+                "n_on".into(),
+                count_all().filter(Org::active.eq(true)).into(),
+            ),
+            ("max_id".into(), max("id").into()),
+            (
+                "on_id_sum".into(),
+                sum("id").filter(Org::active.eq(true)).into(),
+            ),
+        ],
+        aliases: Vec::new(),
+        having: None,
+        order_by: Vec::new(),
+        limit: None,
+        offset: None,
+    };
+    // Every term is NULL-able on an empty table (`MAX` / `SUM` of no
+    // rows), so each decodes as `Option` and folds to 0 — an empty
+    // registry fingerprints stably rather than erroring.
+    let rows: Vec<(Option<i64>, Option<i64>, Option<i64>, Option<i64>)> =
+        fetch_aggregate_pool(registry, &q).await?;
+    let (n, n_on, max_id, on_id_sum) = rows.into_iter().next().unwrap_or((None, None, None, None));
+    Ok(OrgGeneration {
+        count: n.unwrap_or(0),
+        active: n_on.unwrap_or(0),
+        max_id: max_id.unwrap_or(0),
+        active_id_sum: on_id_sum.unwrap_or(0),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rustango/src/tenancy/resolver.rs
+++ b/crates/rustango/src/tenancy/resolver.rs
@@ -105,16 +105,16 @@ impl OrgResolver for SubdomainResolver {
         // trusting anything cached here. Throttled to one aggregate per
         // interval — see `sync_org_generation`.
         sync_org_generation(registry).await;
-        match org_cache_get(host) {
+        match org_cache_get(&host) {
             CachedOrg::Miss => return Ok(None),
-            CachedOrg::Hit(org) => return Ok(Some(*org)),
+            CachedOrg::Hit(org) => return Ok(Some(org)),
             CachedOrg::Absent => {}
         }
-        let found = find_active_org_by(registry, Org::host_pattern.eq(host.to_owned())).await?;
+        let found = find_active_org_by(registry, Org::host_pattern.eq(host.clone())).await?;
         // Cache the miss too: this resolver runs first for *every*
         // request, so an unregistered host would otherwise be a free
         // registry query per request. See `ORG_CACHE`.
-        org_cache_put(host, found.clone());
+        org_cache_put(&host, found.clone());
         Ok(found)
     }
 }
@@ -245,10 +245,39 @@ const ORG_CACHE_MAX: usize = 1024;
 
 /// Same three-state shape as [`Cached`] — "not cached" and "cached as a
 /// miss" lead to opposite actions, so they cannot share a representation.
+/// Make room for one insert once a cache is at its cap.
+///
+/// Drops a single entry rather than the whole map. Both caches are keyed
+/// on a client-supplied `Host`, so wiping on overflow hands an attacker a
+/// cheap way to evict every real tenant: fill the map with junk and every
+/// legitimate host has to re-query. Evicting one keeps the damage
+/// proportional to the junk actually sent.
+///
+/// Not LRU — that needs a second index and this map is on the request
+/// path. An arbitrary victim is enough: correctness never depends on a
+/// cache retaining anything.
+fn evict_one_if_full<V>(map: &mut std::collections::HashMap<String, V>, cap: usize) {
+    if map.len() < cap {
+        return;
+    }
+    if let Some(victim) = map.keys().next().cloned() {
+        map.remove(&victim);
+    }
+}
+
+#[allow(clippy::large_enum_variant)] // see `Hit`
+#[allow(clippy::large_enum_variant)] // see `Hit`
 enum CachedOrg {
+    /// Nothing usable; go to the registry.
     Absent,
+    /// Known not to resolve to any tenant.
     Miss,
-    Hit(Box<Org>),
+    /// Carries the row by value. Deliberately not boxed: this is the
+    /// hot path the cache exists to make free, and a box would add an
+    /// allocation to every hit. The enum is a short-lived local,
+    /// destructured immediately, so its size costs a stack move rather
+    /// than a heap trip.
+    Hit(Org),
 }
 
 fn org_cache_get(host: &str) -> CachedOrg {
@@ -261,7 +290,7 @@ fn org_cache_get(host: &str) -> CachedOrg {
     match map.get(host) {
         Some((_, at)) if at.elapsed() >= ORG_CACHE_TTL => CachedOrg::Absent,
         Some((None, _)) => CachedOrg::Miss,
-        Some((Some(org), _)) => CachedOrg::Hit(Box::new(org.clone())),
+        Some((Some(org), _)) => CachedOrg::Hit(org.clone()),
         None => CachedOrg::Absent,
     }
 }
@@ -271,36 +300,49 @@ fn org_cache_put(host: &str, org: Option<Org>) {
         return;
     };
     let map = guard.get_or_insert_with(Default::default);
-    if map.len() >= ORG_CACHE_MAX {
-        map.clear();
-    }
+    evict_one_if_full(map, ORG_CACHE_MAX);
     map.insert(host.to_owned(), (org, std::time::Instant::now()));
 }
 
-/// Drop cached base-host resolutions.
+/// Drop every cached resolution that carries `Org` data — **both**
+/// caches.
 ///
-/// Called after any write to `rustango_orgs` so the pod that made the
-/// change sees it immediately rather than waiting out the TTL. Other pods
-/// converge via the registry fingerprint — see [`sync_org_generation`].
+/// Call after any write to `rustango_orgs`, so the pod that made the
+/// change sees it immediately rather than waiting out the TTL. Other
+/// pods converge via the registry fingerprint — see
+/// [`sync_org_generation`].
+///
+/// Clearing `HOST_CACHE` as well is not incidental. It holds whole `Org`
+/// rows now, and it previously re-ran the active-filtered lookup on every
+/// hit — so suspending a tenant used to stop its extra hostnames
+/// *immediately*, per request. Losing that re-check without clearing
+/// here would leave a suspended tenant's extra hosts serving while its
+/// base host correctly 404s, which is worse than either behaviour alone.
+/// One function so a caller cannot get half of it right.
 pub fn invalidate_org_cache() {
     if let Ok(mut guard) = ORG_CACHE.write() {
         if let Some(map) = guard.as_mut() {
             map.clear();
         }
     }
+    invalidate_host_cache();
 }
 
 /// The three states a lookup can be in. Named rather than
 /// `Option<Option<i64>>` because "not cached" and "cached as a miss" lead
 /// to opposite actions — one queries, the other must not.
+#[allow(clippy::large_enum_variant)] // see `CachedOrg::Hit`
 enum Cached {
     /// Nothing usable; go to the registry.
     Absent,
     /// Known not to be a registered host.
     Miss,
-    /// Boxed because an `Org` is far larger than the other variants and
-    /// clippy rightly objects to a lopsided enum.
-    Hit(Box<Org>),
+    /// Carries the row by value. Deliberately not boxed: this is the
+    /// hot path the cache exists to make free, and a box would add an
+    /// allocation to every hit. The enum is a short-lived local that is
+    /// destructured immediately, so its size costs a stack move, not a
+    /// heap trip.
+    Hit(Org),
 }
 
 fn host_cache_get(host: &str) -> Cached {
@@ -310,11 +352,11 @@ fn host_cache_get(host: &str) -> Cached {
     let Some((value, at)) = guard.as_ref().and_then(|m| m.get(host)) else {
         return Cached::Absent;
     };
-    if at.elapsed() > HOST_CACHE_TTL {
+    if at.elapsed() >= HOST_CACHE_TTL {
         return Cached::Absent;
     }
     match value {
-        Some(org) => Cached::Hit(Box::new(org.clone())),
+        Some(org) => Cached::Hit(org.clone()),
         None => Cached::Miss,
     }
 }
@@ -324,9 +366,7 @@ fn host_cache_put(host: &str, value: Option<Org>) {
         return;
     };
     let map = guard.get_or_insert_with(Default::default);
-    if map.len() >= HOST_CACHE_MAX {
-        map.clear();
-    }
+    evict_one_if_full(map, HOST_CACHE_MAX);
     map.insert(host.to_owned(), (value, std::time::Instant::now()));
 }
 
@@ -339,16 +379,11 @@ fn host_cache_put(host: &str, value: Option<Org>) {
 /// shared cache, a message bus, or making Redis a dependency of tenant
 /// resolution — the one path that runs before everything else and must not
 /// acquire new ways to fail.
-/// `None` = never looked. `Some((gen, at))` carries the last fingerprint
-/// seen and the time of the last *attempt* — successful or not, so a
-/// failing probe is still throttled.
-///
-/// `gen` is itself `Option`: a claimed-but-not-yet-completed check writes
-/// the attempt time with the previous fingerprint, so a probe that fails
-/// leaves the last known-good value in place rather than resetting it.
+
 /// Last `rustango_orgs` fingerprint this process saw, and when it last
 /// *attempted* a read — successful or not, so a failing probe is still
-/// throttled. Same shape and same reasoning as [`HOST_GEN`].
+/// throttled. Same shape and same reasoning as [`GenState`], which does
+/// the equivalent job for `rustango_org_hosts`.
 type OrgGenState = (Option<super::org::OrgGeneration>, std::time::Instant);
 static ORG_GEN: std::sync::RwLock<Option<OrgGenState>> = std::sync::RwLock::new(None);
 
@@ -385,9 +420,18 @@ async fn sync_org_generation(registry: &Pool) {
         }
     };
 
+    // Through the breaker, not around it. A direct `org::generation`
+    // call would wait out the pool's acquire timeout on an unreachable
+    // registry — and base-host traffic now reaches this poll on every
+    // request, so that would put the stall #1311 removed straight back
+    // on the hot path.
+    if registry_is_down() {
+        return;
+    }
     let current = match super::org::generation(registry).await {
         Ok(current) => current,
         Err(e) => {
+            mark_registry_down();
             if !ORG_GEN_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
                 tracing::warn!(
                     target: "rustango::tenancy::resolver",
@@ -431,6 +475,13 @@ pub(crate) fn reset_org_cache() {
     invalidate_org_cache();
 }
 
+/// `None` = never looked. `Some((gen, at))` carries the last fingerprint
+/// seen and the time of the last *attempt* — successful or not, so a
+/// failing probe is still throttled.
+///
+/// `gen` is itself `Option`: a claimed-but-not-yet-completed check writes
+/// the attempt time with the previous fingerprint, so a probe that fails
+/// leaves the last known-good value in place rather than resetting it.
 type GenState = (Option<super::org_host::Generation>, std::time::Instant);
 
 static HOST_GEN: std::sync::RwLock<Option<GenState>> = std::sync::RwLock::new(None);
@@ -643,9 +694,9 @@ impl OrgResolver for RegisteredHostResolver {
         // anything cached here. Throttled — see `GEN_CHECK_EVERY`.
         sync_generation(registry).await;
         // Cached, including the miss — see `HOST_CACHE`.
-        match host_cache_get(host) {
+        match host_cache_get(&host) {
             Cached::Miss => return Ok(None),
-            Cached::Hit(org) => return Ok(Some(*org)),
+            Cached::Hit(org) => return Ok(Some(org)),
             Cached::Absent => {}
         }
         // The table was failing very recently — don't re-ask on every
@@ -657,7 +708,7 @@ impl OrgResolver for RegisteredHostResolver {
             return Ok(None);
         }
         let rows = match super::OrgHost::objects()
-            .where_(super::OrgHost::hostname.eq(host.to_owned()))
+            .where_(super::OrgHost::hostname.eq(host.clone()))
             .where_(super::OrgHost::enabled.eq(true))
             .fetch(registry)
             .await
@@ -680,7 +731,7 @@ impl OrgResolver for RegisteredHostResolver {
             }
         };
         let Some(row) = rows.into_iter().next() else {
-            host_cache_put(host, None);
+            host_cache_put(&host, None);
             return Ok(None);
         };
         // Resolve the row to its Org once, then cache the Org itself.
@@ -688,7 +739,7 @@ impl OrgResolver for RegisteredHostResolver {
         // this same fetch — the 2.00-queries-per-request a cache hit
         // used to cost.
         let found = find_active_org_by(registry, Org::id.eq(row.org_id)).await?;
-        host_cache_put(host, found.clone());
+        host_cache_put(&host, found.clone());
         Ok(found)
     }
 }
@@ -896,14 +947,23 @@ impl OrgResolver for ChainResolver {
 /// Pull the host name (no port, no scheme) from the request. Tries
 /// `Host` header first (universal), falls back to `parts.uri.host()`
 /// for clients that send absolute-form URIs.
-fn host_from_parts(parts: &Parts) -> Option<&str> {
+/// Pull the host name from the request, lowercased and without a port.
+///
+/// Case-folding is not cosmetic: hostnames are case-insensitive per RFC
+/// 4343, but the caches below are keyed on this string, and the string
+/// comes straight from a client-supplied `Host` header. Without folding,
+/// `ACME.app.test` and `AcMe.app.test` are distinct keys for one tenant —
+/// so a few thousand case variants of a real host fill a bounded map with
+/// duplicates, evicting genuine entries and taking a write lock on the
+/// process-global cache each time.
+fn host_from_parts(parts: &Parts) -> Option<String> {
     if let Some(value) = parts.headers.get(http::header::HOST) {
         if let Ok(s) = value.to_str() {
             // `Host` header may include `:port` — strip it.
-            return Some(s.split(':').next().unwrap_or(s));
+            return Some(s.split(':').next().unwrap_or(s).to_ascii_lowercase());
         }
     }
-    parts.uri.host()
+    parts.uri.host().map(str::to_ascii_lowercase)
 }
 
 /// When the registry lookup last failed, if it is currently failing.
@@ -933,6 +993,33 @@ static REGISTRY_DOWN_WARNED: std::sync::atomic::AtomicBool =
 /// within a second of the next request.
 const REGISTRY_RETRY_AFTER: std::time::Duration = std::time::Duration::from_secs(1);
 
+/// True when a recent registry lookup failed and the retry window has
+/// not elapsed. Read-locked, so the healthy path pays one uncontended
+/// read.
+fn registry_is_down() -> bool {
+    match REGISTRY_DOWN.read() {
+        Ok(g) => g.is_some_and(|at| at.elapsed() < REGISTRY_RETRY_AFTER),
+        Err(_) => false,
+    }
+}
+
+/// Open the breaker after a failed lookup.
+fn mark_registry_down() {
+    if let Ok(mut g) = REGISTRY_DOWN.write() {
+        *g = Some(std::time::Instant::now());
+    }
+}
+
+/// Close it after a successful one — checked under a read lock first so
+/// the common case never takes the write lock.
+fn mark_registry_up() {
+    if REGISTRY_DOWN.read().is_ok_and(|g| g.is_some()) {
+        if let Ok(mut g) = REGISTRY_DOWN.write() {
+            *g = None;
+        }
+    }
+}
+
 /// The error returned while the breaker is open. Mirrors what the pool
 /// itself produces so callers cannot tell the two apart.
 fn registry_unavailable() -> TenancyError {
@@ -948,11 +1035,7 @@ where
 {
     // A very recent failure means the registry is unreachable; don't
     // queue behind it. See `REGISTRY_DOWN`.
-    let suppressed = match REGISTRY_DOWN.read() {
-        Ok(g) => g.is_some_and(|at| at.elapsed() < REGISTRY_RETRY_AFTER),
-        Err(_) => false,
-    };
-    if suppressed {
+    if registry_is_down() {
         return Err(registry_unavailable());
     }
 
@@ -965,19 +1048,11 @@ where
 
     match result {
         Ok(rows) => {
-            // Clear the breaker, but only if it was set — the healthy
-            // path should not take a write lock on every request.
-            if REGISTRY_DOWN.read().is_ok_and(|g| g.is_some()) {
-                if let Ok(mut g) = REGISTRY_DOWN.write() {
-                    *g = None;
-                }
-            }
+            mark_registry_up();
             Ok(rows.into_iter().next())
         }
         Err(e) => {
-            if let Ok(mut g) = REGISTRY_DOWN.write() {
-                *g = Some(std::time::Instant::now());
-            }
+            mark_registry_down();
             if !REGISTRY_DOWN_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
                 tracing::warn!(
                     target: "rustango::tenancy::resolver",

--- a/crates/rustango/src/tenancy/resolver.rs
+++ b/crates/rustango/src/tenancy/resolver.rs
@@ -39,6 +39,7 @@ use http::HeaderName;
 
 use super::error::TenancyError;
 use super::org::Org;
+use super::resolver_cache::{Breaker, Cached, GenerationPoll, HostTtlCache};
 
 /// Resolve an HTTP request to an [`Org`] from the registry.
 ///
@@ -105,16 +106,16 @@ impl OrgResolver for SubdomainResolver {
         // trusting anything cached here. Throttled to one aggregate per
         // interval — see `sync_org_generation`.
         sync_org_generation(registry).await;
-        match org_cache_get(&host) {
-            CachedOrg::Miss => return Ok(None),
-            CachedOrg::Hit(org) => return Ok(Some(org)),
-            CachedOrg::Absent => {}
+        match ORG_CACHE.get(&host) {
+            Cached::Miss => return Ok(None),
+            Cached::Hit(org) => return Ok(Some(org)),
+            Cached::Absent => {}
         }
         let found = find_active_org_by(registry, Org::host_pattern.eq(host.clone())).await?;
         // Cache the miss too: this resolver runs first for *every*
         // request, so an unregistered host would otherwise be a free
         // registry query per request. See `ORG_CACHE`.
-        org_cache_put(&host, found.clone());
+        ORG_CACHE.put(&host, found.clone());
         Ok(found)
     }
 }
@@ -141,52 +142,21 @@ impl OrgResolver for SubdomainResolver {
 /// the byte.
 pub struct RegisteredHostResolver;
 
-/// Ensures the missing-table warning is logged once per process rather
-/// than once per request.
-static HOST_TABLE_WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
-/// When the host-table lookup last failed, if it is currently failing.
+/// Backs off when the host-table lookup is failing, and logs the reason
+/// once per process rather than once per request.
 ///
-/// The lookup's *miss* path caches (`host_cache_put(host, None)`), but its
+/// The lookup's *miss* path caches (`HOST_CACHE.put(host, None)`), but its
 /// *error* path cannot: an error is not evidence that the host is
 /// unregistered, so caching it as a miss would be wrong the moment the
-/// table came back.
-///
-/// Without this backoff the error path is both uncached and unthrottled,
-/// which costs one failing query per request: measured against a renamed
-/// table, 25,987 failing `SELECT`s for 25,958 requests, all aimed at a
-/// registry that is by definition already unhealthy. The condition is
-/// table-wide rather than per-host, so one backoff covers every hostname
-/// at once.
-static HOST_TABLE_DOWN: std::sync::RwLock<Option<std::time::Instant>> =
-    std::sync::RwLock::new(None);
+/// table came back. Without a breaker the error path is therefore both
+/// uncached and unthrottled. The condition is table-wide rather than
+/// per-host, so one breaker covers every hostname at once.
+static HOST_TABLE_DOWN: Breaker = Breaker::new();
 
-/// True when a recent lookup failed and the backoff has not yet elapsed.
-/// Read-locked, so the hot path pays an uncontended read and nothing else.
-fn host_table_is_down() -> bool {
-    let window = gen_check_every().unwrap_or(GEN_CHECK_EVERY_DEFAULT);
-    match HOST_TABLE_DOWN.read() {
-        Ok(g) => g.is_some_and(|at| at.elapsed() < window),
-        Err(_) => false,
-    }
-}
-
-/// Record that the lookup failed, starting the backoff.
-fn mark_host_table_down() {
-    if let Ok(mut g) = HOST_TABLE_DOWN.write() {
-        *g = Some(std::time::Instant::now());
-    }
-}
-
-/// Clear the backoff after a successful lookup. Checks under a read lock
-/// first so the common case — never having failed — takes no write lock.
-fn mark_host_table_up() {
-    let was_down = HOST_TABLE_DOWN.read().is_ok_and(|g| g.is_some());
-    if was_down {
-        if let Ok(mut g) = HOST_TABLE_DOWN.write() {
-            *g = None;
-        }
-    }
+/// How long a failed host-table lookup suppresses further attempts.
+/// Shares the fingerprint poll's interval, so one env var tunes both.
+fn host_table_retry_after() -> std::time::Duration {
+    gen_check_every().unwrap_or(GEN_CHECK_EVERY_DEFAULT)
 }
 
 /// hostname → the [`Org`] it resolves to (`None` = known-miss), with an
@@ -209,10 +179,12 @@ fn mark_host_table_up() {
 ///
 /// Keyed by hostname alone, not (registry, hostname): a process serves one
 /// registry. Tests that stand up several must use distinct hostnames.
-type HostCacheMap = std::collections::HashMap<String, (Option<Org>, std::time::Instant)>;
-static HOST_CACHE: std::sync::RwLock<Option<HostCacheMap>> = std::sync::RwLock::new(None);
-const HOST_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
-const HOST_CACHE_MAX: usize = 1024;
+static HOST_CACHE: HostTtlCache<Org> = HostTtlCache::new(CACHE_TTL, CACHE_MAX);
+
+/// One TTL and one cap for both caches, so they cannot drift apart the
+/// way the two hand-written copies did.
+const CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+const CACHE_MAX: usize = 1024;
 
 // ---------------- ORG_CACHE (base host → Org) ----------------
 
@@ -238,71 +210,7 @@ const HOST_CACHE_MAX: usize = 1024;
 /// the keys are attacker-supplied `Host` headers, so an unbounded map
 /// trades a query amplification for a memory one, and without negative
 /// entries a sprayed host is a free registry query per request.
-type OrgCacheMap = std::collections::HashMap<String, (Option<Org>, std::time::Instant)>;
-static ORG_CACHE: std::sync::RwLock<Option<OrgCacheMap>> = std::sync::RwLock::new(None);
-const ORG_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
-const ORG_CACHE_MAX: usize = 1024;
-
-/// Same three-state shape as [`Cached`] — "not cached" and "cached as a
-/// miss" lead to opposite actions, so they cannot share a representation.
-/// Make room for one insert once a cache is at its cap.
-///
-/// Drops a single entry rather than the whole map. Both caches are keyed
-/// on a client-supplied `Host`, so wiping on overflow hands an attacker a
-/// cheap way to evict every real tenant: fill the map with junk and every
-/// legitimate host has to re-query. Evicting one keeps the damage
-/// proportional to the junk actually sent.
-///
-/// Not LRU — that needs a second index and this map is on the request
-/// path. An arbitrary victim is enough: correctness never depends on a
-/// cache retaining anything.
-fn evict_one_if_full<V>(map: &mut std::collections::HashMap<String, V>, cap: usize) {
-    if map.len() < cap {
-        return;
-    }
-    if let Some(victim) = map.keys().next().cloned() {
-        map.remove(&victim);
-    }
-}
-
-#[allow(clippy::large_enum_variant)] // see `Hit`
-#[allow(clippy::large_enum_variant)] // see `Hit`
-enum CachedOrg {
-    /// Nothing usable; go to the registry.
-    Absent,
-    /// Known not to resolve to any tenant.
-    Miss,
-    /// Carries the row by value. Deliberately not boxed: this is the
-    /// hot path the cache exists to make free, and a box would add an
-    /// allocation to every hit. The enum is a short-lived local,
-    /// destructured immediately, so its size costs a stack move rather
-    /// than a heap trip.
-    Hit(Org),
-}
-
-fn org_cache_get(host: &str) -> CachedOrg {
-    let Ok(guard) = ORG_CACHE.read() else {
-        return CachedOrg::Absent;
-    };
-    let Some(map) = guard.as_ref() else {
-        return CachedOrg::Absent;
-    };
-    match map.get(host) {
-        Some((_, at)) if at.elapsed() >= ORG_CACHE_TTL => CachedOrg::Absent,
-        Some((None, _)) => CachedOrg::Miss,
-        Some((Some(org), _)) => CachedOrg::Hit(org.clone()),
-        None => CachedOrg::Absent,
-    }
-}
-
-fn org_cache_put(host: &str, org: Option<Org>) {
-    let Ok(mut guard) = ORG_CACHE.write() else {
-        return;
-    };
-    let map = guard.get_or_insert_with(Default::default);
-    evict_one_if_full(map, ORG_CACHE_MAX);
-    map.insert(host.to_owned(), (org, std::time::Instant::now()));
-}
+static ORG_CACHE: HostTtlCache<Org> = HostTtlCache::new(CACHE_TTL, CACHE_MAX);
 
 /// Drop every cached resolution that carries `Org` data — **both**
 /// caches.
@@ -320,75 +228,20 @@ fn org_cache_put(host: &str, org: Option<Org>) {
 /// base host correctly 404s, which is worse than either behaviour alone.
 /// One function so a caller cannot get half of it right.
 pub fn invalidate_org_cache() {
-    if let Ok(mut guard) = ORG_CACHE.write() {
-        if let Some(map) = guard.as_mut() {
-            map.clear();
-        }
-    }
+    ORG_CACHE.clear();
     invalidate_host_cache();
 }
 
-/// The three states a lookup can be in. Named rather than
-/// `Option<Option<i64>>` because "not cached" and "cached as a miss" lead
-/// to opposite actions — one queries, the other must not.
-#[allow(clippy::large_enum_variant)] // see `CachedOrg::Hit`
-enum Cached {
-    /// Nothing usable; go to the registry.
-    Absent,
-    /// Known not to be a registered host.
-    Miss,
-    /// Carries the row by value. Deliberately not boxed: this is the
-    /// hot path the cache exists to make free, and a box would add an
-    /// allocation to every hit. The enum is a short-lived local that is
-    /// destructured immediately, so its size costs a stack move, not a
-    /// heap trip.
-    Hit(Org),
-}
-
-fn host_cache_get(host: &str) -> Cached {
-    let Ok(guard) = HOST_CACHE.read() else {
-        return Cached::Absent;
-    };
-    let Some((value, at)) = guard.as_ref().and_then(|m| m.get(host)) else {
-        return Cached::Absent;
-    };
-    if at.elapsed() >= HOST_CACHE_TTL {
-        return Cached::Absent;
-    }
-    match value {
-        Some(org) => Cached::Hit(org.clone()),
-        None => Cached::Miss,
-    }
-}
-
-fn host_cache_put(host: &str, value: Option<Org>) {
-    let Ok(mut guard) = HOST_CACHE.write() else {
-        return;
-    };
-    let map = guard.get_or_insert_with(Default::default);
-    evict_one_if_full(map, HOST_CACHE_MAX);
-    map.insert(host.to_owned(), (value, std::time::Instant::now()));
-}
-
-/// Last host-table fingerprint this process saw, and when it last looked.
+/// Last `rustango_orgs` fingerprint this process saw.
 ///
-/// [`invalidate_host_cache`] only clears the process that called it. Behind
+/// [`invalidate_org_cache`] only clears the process that called it. Behind
 /// a load balancer that is half a solution: the pod handling the admin
 /// request forgets, and every other pod keeps answering from a cache that
 /// is now wrong. Polling a cheap fingerprint closes that gap without a
 /// shared cache, a message bus, or making Redis a dependency of tenant
 /// resolution — the one path that runs before everything else and must not
 /// acquire new ways to fail.
-
-/// Last `rustango_orgs` fingerprint this process saw, and when it last
-/// *attempted* a read — successful or not, so a failing probe is still
-/// throttled. Same shape and same reasoning as [`GenState`], which does
-/// the equivalent job for `rustango_org_hosts`.
-type OrgGenState = (Option<super::org::OrgGeneration>, std::time::Instant);
-static ORG_GEN: std::sync::RwLock<Option<OrgGenState>> = std::sync::RwLock::new(None);
-
-/// Logged once per process rather than once per interval.
-static ORG_GEN_WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static ORG_GEN: GenerationPoll<super::org::OrgGeneration> = GenerationPoll::new();
 
 /// Drop the base-host cache if another process changed `rustango_orgs`.
 ///
@@ -397,99 +250,55 @@ static ORG_GEN_WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::Atomic
 /// poll, so one env var tunes both and a deployment that disables
 /// polling disables both.
 async fn sync_org_generation(registry: &Pool) {
-    let Some(interval) = gen_check_every() else {
-        return; // polling disabled
-    };
-
-    // Claim the check BEFORE awaiting, for the same two reasons as
-    // `sync_generation`: stamping only on success turns a failing probe
-    // into a per-request query storm, and without the claim every
-    // request arriving during an in-flight probe fires its own.
-    let previous = {
-        match ORG_GEN.write() {
-            Ok(mut g) => {
-                let due = g.is_none_or(|(_, at)| at.elapsed() >= interval);
-                if !due {
-                    return;
+    ORG_GEN
+        .sync(
+            gen_check_every(),
+            || async {
+                // Through the breaker, not around it. A direct
+                // `org::generation` call would wait out the pool's
+                // acquire timeout on an unreachable registry — and
+                // base-host traffic reaches this poll on every request,
+                // so that would put the stall #1311 removed straight
+                // back on the hot path. Declining is not a failure: the
+                // breaker is already throttling, and the claim has
+                // already backed this poll off for a full interval.
+                if registry_is_down() {
+                    return Ok(None);
                 }
-                let previous = g.and_then(|(seen, _)| seen);
-                *g = Some((previous, std::time::Instant::now()));
-                previous
-            }
-            Err(_) => return,
-        }
-    };
-
-    // Through the breaker, not around it. A direct `org::generation`
-    // call would wait out the pool's acquire timeout on an unreachable
-    // registry — and base-host traffic now reaches this poll on every
-    // request, so that would put the stall #1311 removed straight back
-    // on the hot path.
-    if registry_is_down() {
-        return;
-    }
-    let current = match super::org::generation(registry).await {
-        Ok(current) => current,
-        Err(e) => {
-            mark_registry_down();
-            if !ORG_GEN_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
-                tracing::warn!(
-                    target: "rustango::tenancy::resolver",
-                    error = %e,
-                    "could not read the rustango_orgs fingerprint; this pod will \
-                     not notice tenants created or suspended by other processes \
-                     until its own cache entries expire"
-                );
-            }
-            return;
-        }
-    };
-
-    let changed = {
-        match ORG_GEN.write() {
-            Ok(mut g) => {
-                *g = Some((Some(current), std::time::Instant::now()));
-                previous.is_some_and(|seen| seen != current)
-            }
-            Err(_) => false,
-        }
-    };
-    if changed {
-        invalidate_org_cache();
-        // `HOST_CACHE` holds `Org` rows too, so a change to
-        // `rustango_orgs` staleness-invalidates it just as much — an
-        // extra hostname pointing at a tenant that has since been
-        // suspended must stop resolving on the same bound as its base
-        // host does.
-        invalidate_host_cache();
-    }
+                super::org::generation(registry).await.map(Some)
+            },
+            |e| {
+                REGISTRY_DOWN.open();
+                ORG_GEN.warn_once(|| {
+                    tracing::warn!(
+                        target: "rustango::tenancy::resolver",
+                        error = %e,
+                        "could not read the rustango_orgs fingerprint; this pod will \
+                         not notice tenants created or suspended by other processes \
+                         until its own cache entries expire"
+                    );
+                });
+            },
+            // `invalidate_org_cache` clears `HOST_CACHE` as well, and
+            // must: it holds whole `Org` rows too, so an extra hostname
+            // pointing at a tenant that has since been suspended has to
+            // stop resolving on the same bound as its base host does.
+            invalidate_org_cache,
+        )
+        .await;
 }
 
 /// Forget the org fingerprint and the base-host cache (test hook — see
 /// [`crate::testkit`]). Both are process-global.
 #[cfg(any(test, feature = "testkit"))]
 pub(crate) fn reset_org_cache() {
-    if let Ok(mut g) = ORG_GEN.write() {
-        *g = None;
-    }
+    ORG_GEN.reset();
     invalidate_org_cache();
 }
 
-/// `None` = never looked. `Some((gen, at))` carries the last fingerprint
-/// seen and the time of the last *attempt* — successful or not, so a
-/// failing probe is still throttled.
-///
-/// `gen` is itself `Option`: a claimed-but-not-yet-completed check writes
-/// the attempt time with the previous fingerprint, so a probe that fails
-/// leaves the last known-good value in place rather than resetting it.
-type GenState = (Option<super::org_host::Generation>, std::time::Instant);
-
-static HOST_GEN: std::sync::RwLock<Option<GenState>> = std::sync::RwLock::new(None);
-
-/// Ensures a failing fingerprint probe is logged once per process rather
-/// than once per interval. Without this the mechanism can be dead for a
-/// process's entire lifetime with nothing in the logs to say so.
-static HOST_GEN_WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+/// Last `rustango_org_hosts` fingerprint this process saw. Same shape and
+/// same reasoning as [`ORG_GEN`], for the extra-hostname table.
+static HOST_GEN: GenerationPoll<super::org_host::Generation> = GenerationPoll::new();
 
 /// Default interval between fingerprint reads — the bound on how long
 /// another pod can serve a stale answer.
@@ -532,87 +341,36 @@ fn gen_check_every() -> Option<std::time::Duration> {
 /// Cheap to call on every resolve: it does nothing at all until
 /// [`GEN_CHECK_EVERY`] has passed.
 async fn sync_generation(registry: &Pool) {
-    let Some(interval) = gen_check_every() else {
-        return; // polling disabled
-    };
-
-    // CLAIM the check before awaiting, in one write-lock section.
-    //
-    // Two bugs live in the alternative — stamping the time only after a
-    // successful probe. A probe that fails would leave the timestamp
-    // unadvanced, so every subsequent request re-probes forever: a pod
-    // deployed before `migrate` ran, or riding out a registry blip, turns
-    // a 5s poll into a per-request query storm. And under concurrency
-    // every request arriving while a probe is in flight would also see
-    // "due" and fire its own, fanning out exactly when the registry is
-    // already slow.
-    //
-    // Claiming both throttles failures and dedups in-flight checks: the
-    // first caller through takes the slot, everyone else sees a fresh
-    // timestamp and returns immediately.
-    //
-    // The lock is released before the await — holding a std RwLock across
-    // one parks it on whatever task resumes and can deadlock the next
-    // reader on the same thread.
-    let previous = {
-        match HOST_GEN.write() {
-            Ok(mut g) => {
-                let due = g.is_none_or(|(_, at)| at.elapsed() >= interval);
-                if !due {
-                    return;
-                }
-                let previous = g.and_then(|(seen, _)| seen);
-                *g = Some((previous, std::time::Instant::now()));
-                previous
-            }
-            // A poisoned lock means some other thread panicked mid-update.
-            // Skip this round rather than resolving off a torn value.
-            Err(_) => return,
-        }
-    };
-
-    let current = match super::org_host::generation(registry).await {
-        Ok(current) => current,
-        Err(e) => {
-            // Never fail a request over a cache refresh — but do not fail
-            // silently either. Cross-pod invalidation being dead is
-            // invisible from the outside until a host 404s on some pods
-            // and not others, which is near-impossible to correlate after
-            // the fact.
-            if !HOST_GEN_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
-                tracing::warn!(
-                    target: "rustango::tenancy::resolver",
-                    error = %e,
-                    "could not read the rustango_org_hosts fingerprint; this pod \
-                     will not notice host changes made by other processes until \
-                     its own cache entries expire"
-                );
-            }
-            // The claim above already recorded the attempt, so this backs
-            // off for a full interval instead of retrying every request.
-            return;
-        }
-    };
-
-    let changed = {
-        match HOST_GEN.write() {
-            Ok(mut g) => {
-                *g = Some((Some(current), std::time::Instant::now()));
-                previous.is_some_and(|seen| seen != current)
-            }
-            Err(_) => false,
-        }
-    };
-    if changed {
-        // Clears negative entries too, and must: a hostname cached as a
-        // known-miss is exactly what an add on another pod invalidates.
-        // The cost is that a registry with a steady write stream keeps
-        // every pod's negative cache short-lived, which is the deliberate
-        // trade — a stale 404 on a real customer domain is worse than a
-        // repeated lookup on a sprayed one, and `HOST_CACHE_MAX` still
-        // bounds the latter.
-        invalidate_host_cache();
-    }
+    HOST_GEN
+        .sync(
+            gen_check_every(),
+            || async { super::org_host::generation(registry).await.map(Some) },
+            |e| {
+                // Never fail a request over a cache refresh — but do not
+                // fail silently either. Cross-pod invalidation being dead
+                // is invisible from the outside until a host 404s on some
+                // pods and not others, which is near-impossible to
+                // correlate after the fact.
+                HOST_GEN.warn_once(|| {
+                    tracing::warn!(
+                        target: "rustango::tenancy::resolver",
+                        error = %e,
+                        "could not read the rustango_org_hosts fingerprint; this pod \
+                         will not notice host changes made by other processes until \
+                         its own cache entries expire"
+                    );
+                });
+            },
+            // Clears negative entries too, and must: a hostname cached as
+            // a known-miss is exactly what an add on another pod
+            // invalidates. The cost is that a registry with a steady
+            // write stream keeps every pod's negative cache short-lived,
+            // which is the deliberate trade — a stale 404 on a real
+            // customer domain is worse than a repeated lookup on a
+            // sprayed one, and `CACHE_MAX` still bounds the latter.
+            invalidate_host_cache,
+        )
+        .await;
 }
 
 /// Forget the generation state entirely.
@@ -625,43 +383,23 @@ async fn sync_generation(registry: &Pool) {
 /// the compiler.
 #[cfg(any(test, feature = "testkit"))]
 pub(crate) fn reset_generation() {
-    if let Ok(mut g) = HOST_GEN.write() {
-        *g = None;
-    }
+    HOST_GEN.reset();
     // The missing-table backoff is process-global too, and a test that
     // exercised an absent table would otherwise suppress the lookup for
     // the next test's perfectly healthy registry.
-    if let Ok(mut d) = HOST_TABLE_DOWN.write() {
-        *d = None;
-    }
+    HOST_TABLE_DOWN.close();
 }
 
 /// Make the next resolve re-read the fingerprint immediately instead of
 /// waiting out the poll interval, so a cross-pod test proves the bound
 /// without sleeping through it.
-///
-/// Unconditional by design. Guarding this on an existing `Some` made it a
-/// silent no-op in precisely the case a test reaches for it — right after
-/// a reset — so the test read as though it forced a re-check while
-/// actually doing nothing.
 #[cfg(any(test, feature = "testkit"))]
 pub(crate) fn expire_generation() {
-    if let Ok(mut g) = HOST_GEN.write() {
-        let previous = g.and_then(|(seen, _)| seen);
-        // Back-date past the *effective* interval, not the default one —
-        // with a longer interval configured, subtracting the default
-        // would leave the entry un-due and make this hook a no-op again.
-        let interval = gen_check_every().unwrap_or(GEN_CHECK_EVERY_DEFAULT);
-        // `checked_sub` returns None when the monotonic clock is younger
-        // than the offset — reachable on a freshly booted host. Falling
-        // back to `now()` there would *unexpire* the entry and invert this
-        // function's whole purpose, so fall back to the process's own
-        // epoch instead, which is unambiguously "long ago".
-        let long_ago = std::time::Instant::now()
-            .checked_sub(interval * 2)
-            .unwrap_or(*PROCESS_START);
-        *g = Some((previous, long_ago));
-    }
+    // Back-date past the *effective* interval, not the default one —
+    // with a longer interval configured, subtracting the default would
+    // leave the entry un-due and make this hook a no-op again.
+    let interval = gen_check_every().unwrap_or(GEN_CHECK_EVERY_DEFAULT);
+    HOST_GEN.expire(interval * 2, *PROCESS_START);
 }
 
 /// Earliest `Instant` this process can name. Used as a saturating floor
@@ -677,11 +415,7 @@ static PROCESS_START: std::sync::LazyLock<std::time::Instant> =
 /// Clears everything rather than one key: a rename is a remove plus an add,
 /// and the map is small and cheap to refill.
 pub fn invalidate_host_cache() {
-    if let Ok(mut guard) = HOST_CACHE.write() {
-        if let Some(map) = guard.as_mut() {
-            map.clear();
-        }
-    }
+    HOST_CACHE.clear();
 }
 
 #[async_trait]
@@ -694,7 +428,7 @@ impl OrgResolver for RegisteredHostResolver {
         // anything cached here. Throttled — see `GEN_CHECK_EVERY`.
         sync_generation(registry).await;
         // Cached, including the miss — see `HOST_CACHE`.
-        match host_cache_get(&host) {
+        match HOST_CACHE.get(&host) {
             Cached::Miss => return Ok(None),
             Cached::Hit(org) => return Ok(Some(org)),
             Cached::Absent => {}
@@ -704,7 +438,7 @@ impl OrgResolver for RegisteredHostResolver {
         // match", which is what we return anyway, so backing off costs
         // nothing and stops a per-request storm against a registry that
         // is already in trouble.
-        if host_table_is_down() {
+        if HOST_TABLE_DOWN.is_open(host_table_retry_after()) {
             return Ok(None);
         }
         let rows = match super::OrgHost::objects()
@@ -714,24 +448,24 @@ impl OrgResolver for RegisteredHostResolver {
             .await
         {
             Ok(rows) => {
-                mark_host_table_up();
+                HOST_TABLE_DOWN.close();
                 rows
             }
             Err(e) => {
-                mark_host_table_down();
-                if !HOST_TABLE_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                HOST_TABLE_DOWN.open();
+                HOST_TABLE_DOWN.warn_once(|| {
                     tracing::warn!(
                         target: "rustango::tenancy::resolver",
                         error = %e,
                         "could not read rustango_org_hosts; extra tenant hostnames \
                          are inactive until `migrate` creates the table"
                     );
-                }
+                });
                 return Ok(None);
             }
         };
         let Some(row) = rows.into_iter().next() else {
-            host_cache_put(&host, None);
+            HOST_CACHE.put(&host, None);
             return Ok(None);
         };
         // Resolve the row to its Org once, then cache the Org itself.
@@ -739,7 +473,7 @@ impl OrgResolver for RegisteredHostResolver {
         // this same fetch — the 2.00-queries-per-request a cache hit
         // used to cost.
         let found = find_active_org_by(registry, Org::id.eq(row.org_id)).await?;
-        host_cache_put(&host, found.clone());
+        HOST_CACHE.put(&host, found.clone());
         Ok(found)
     }
 }
@@ -966,24 +700,14 @@ fn host_from_parts(parts: &Parts) -> Option<String> {
     parts.uri.host().map(str::to_ascii_lowercase)
 }
 
-/// When the registry lookup last failed, if it is currently failing.
+/// Fails fast while the registry itself is unreachable.
 ///
-/// Tenant resolution runs before everything else and is uncached, so an
-/// unreachable registry is paid **per request** — each one waiting out
-/// the pool's acquire timeout before erroring. That pins a worker for
-/// the whole timeout, so the server saturates and every tenant goes
-/// down, including tenants whose own databases are perfectly healthy.
-///
-/// Recording the failure lets the requests behind the first one fail
-/// immediately with the same error instead of queueing for the same
-/// doomed connection. Deliberately *not* a behaviour change: the caller
-/// still gets `Err`, and still renders whatever it rendered before —
-/// just in microseconds rather than seconds.
-static REGISTRY_DOWN: std::sync::RwLock<Option<std::time::Instant>> = std::sync::RwLock::new(None);
-
-/// Logged once per process rather than once per failed request.
-static REGISTRY_DOWN_WARNED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+/// Tenant resolution runs before everything else, so an unreachable
+/// registry is otherwise paid **per request** — see [`Breaker`] for what
+/// that costs. Deliberately *not* a behaviour change while open: the
+/// caller still gets `Err`, and still renders whatever it rendered
+/// before, just in microseconds rather than seconds.
+static REGISTRY_DOWN: Breaker = Breaker::new();
 
 /// How long a recorded failure suppresses further attempts.
 ///
@@ -994,30 +718,9 @@ static REGISTRY_DOWN_WARNED: std::sync::atomic::AtomicBool =
 const REGISTRY_RETRY_AFTER: std::time::Duration = std::time::Duration::from_secs(1);
 
 /// True when a recent registry lookup failed and the retry window has
-/// not elapsed. Read-locked, so the healthy path pays one uncontended
-/// read.
+/// not elapsed.
 fn registry_is_down() -> bool {
-    match REGISTRY_DOWN.read() {
-        Ok(g) => g.is_some_and(|at| at.elapsed() < REGISTRY_RETRY_AFTER),
-        Err(_) => false,
-    }
-}
-
-/// Open the breaker after a failed lookup.
-fn mark_registry_down() {
-    if let Ok(mut g) = REGISTRY_DOWN.write() {
-        *g = Some(std::time::Instant::now());
-    }
-}
-
-/// Close it after a successful one — checked under a read lock first so
-/// the common case never takes the write lock.
-fn mark_registry_up() {
-    if REGISTRY_DOWN.read().is_ok_and(|g| g.is_some()) {
-        if let Ok(mut g) = REGISTRY_DOWN.write() {
-            *g = None;
-        }
-    }
+    REGISTRY_DOWN.is_open(REGISTRY_RETRY_AFTER)
 }
 
 /// The error returned while the breaker is open. Mirrors what the pool
@@ -1048,12 +751,12 @@ where
 
     match result {
         Ok(rows) => {
-            mark_registry_up();
+            REGISTRY_DOWN.close();
             Ok(rows.into_iter().next())
         }
         Err(e) => {
-            mark_registry_down();
-            if !REGISTRY_DOWN_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+            REGISTRY_DOWN.open();
+            REGISTRY_DOWN.warn_once(|| {
                 tracing::warn!(
                     target: "rustango::tenancy::resolver",
                     error = %e,
@@ -1061,7 +764,7 @@ where
                      up to {}s at a time until it recovers",
                     REGISTRY_RETRY_AFTER.as_secs(),
                 );
-            }
+            });
             Err(TenancyError::Driver(driver_from_exec(e)))
         }
     }
@@ -1073,9 +776,7 @@ where
 /// would otherwise suppress lookups for whichever test ran next.
 #[cfg(any(test, feature = "testkit"))]
 pub(crate) fn reset_registry_breaker() {
-    if let Ok(mut g) = REGISTRY_DOWN.write() {
-        *g = None;
-    }
+    REGISTRY_DOWN.close();
 }
 
 /// Convert an `ExecError` into the `sqlx::Error` shape `TenancyError`

--- a/crates/rustango/src/tenancy/resolver.rs
+++ b/crates/rustango/src/tenancy/resolver.rs
@@ -101,7 +101,21 @@ impl OrgResolver for SubdomainResolver {
         if host == self.apex_domain {
             return Ok(None);
         }
-        find_active_org_by(registry, Org::host_pattern.eq(host.to_owned())).await
+        // Pick up a tenant created or suspended by another pod before
+        // trusting anything cached here. Throttled to one aggregate per
+        // interval — see `sync_org_generation`.
+        sync_org_generation(registry).await;
+        match org_cache_get(host) {
+            CachedOrg::Miss => return Ok(None),
+            CachedOrg::Hit(org) => return Ok(Some(*org)),
+            CachedOrg::Absent => {}
+        }
+        let found = find_active_org_by(registry, Org::host_pattern.eq(host.to_owned())).await?;
+        // Cache the miss too: this resolver runs first for *every*
+        // request, so an unregistered host would otherwise be a free
+        // registry query per request. See `ORG_CACHE`.
+        org_cache_put(host, found.clone());
+        Ok(found)
     }
 }
 
@@ -198,6 +212,82 @@ static HOST_CACHE: std::sync::RwLock<Option<HostCacheMap>> = std::sync::RwLock::
 const HOST_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
 const HOST_CACHE_MAX: usize = 1024;
 
+// ---------------- ORG_CACHE (base host → Org) ----------------
+
+/// `Host` header → the base-host [`Org`] it resolves to (`None` = known
+/// miss), with an expiry.
+///
+/// [`SubdomainResolver`] runs first in the standard chain and matches the
+/// **base** `Org.host_pattern`, so it is on the path of literally every
+/// request. Uncached, that is one registry `SELECT` per request forever —
+/// measured at exactly 1.00 queries/request against a live Postgres, for
+/// base hosts, extra hosts and unknown hosts alike, because the chain
+/// always tries this resolver first.
+///
+/// That single query is the registry's hot-path SPOF: it is what makes an
+/// unreachable registry take down tenants whose own databases are fine.
+///
+/// The whole `Org` is stored, not its id. Caching an id would still cost
+/// a fetch per request — which is exactly why the sibling `HOST_CACHE`
+/// measured 2.00 queries/request for a *cache hit* on a registered extra
+/// host. Storing the row takes a hit to zero queries.
+///
+/// Bounded and negatively-cached for the same reasons as [`HOST_CACHE`]:
+/// the keys are attacker-supplied `Host` headers, so an unbounded map
+/// trades a query amplification for a memory one, and without negative
+/// entries a sprayed host is a free registry query per request.
+type OrgCacheMap = std::collections::HashMap<String, (Option<Org>, std::time::Instant)>;
+static ORG_CACHE: std::sync::RwLock<Option<OrgCacheMap>> = std::sync::RwLock::new(None);
+const ORG_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+const ORG_CACHE_MAX: usize = 1024;
+
+/// Same three-state shape as [`Cached`] — "not cached" and "cached as a
+/// miss" lead to opposite actions, so they cannot share a representation.
+enum CachedOrg {
+    Absent,
+    Miss,
+    Hit(Box<Org>),
+}
+
+fn org_cache_get(host: &str) -> CachedOrg {
+    let Ok(guard) = ORG_CACHE.read() else {
+        return CachedOrg::Absent;
+    };
+    let Some(map) = guard.as_ref() else {
+        return CachedOrg::Absent;
+    };
+    match map.get(host) {
+        Some((_, at)) if at.elapsed() >= ORG_CACHE_TTL => CachedOrg::Absent,
+        Some((None, _)) => CachedOrg::Miss,
+        Some((Some(org), _)) => CachedOrg::Hit(Box::new(org.clone())),
+        None => CachedOrg::Absent,
+    }
+}
+
+fn org_cache_put(host: &str, org: Option<Org>) {
+    let Ok(mut guard) = ORG_CACHE.write() else {
+        return;
+    };
+    let map = guard.get_or_insert_with(Default::default);
+    if map.len() >= ORG_CACHE_MAX {
+        map.clear();
+    }
+    map.insert(host.to_owned(), (org, std::time::Instant::now()));
+}
+
+/// Drop cached base-host resolutions.
+///
+/// Called after any write to `rustango_orgs` so the pod that made the
+/// change sees it immediately rather than waiting out the TTL. Other pods
+/// converge via the registry fingerprint — see [`sync_org_generation`].
+pub fn invalidate_org_cache() {
+    if let Ok(mut guard) = ORG_CACHE.write() {
+        if let Some(map) = guard.as_mut() {
+            map.clear();
+        }
+    }
+}
+
 /// The three states a lookup can be in. Named rather than
 /// `Option<Option<i64>>` because "not cached" and "cached as a miss" lead
 /// to opposite actions — one queries, the other must not.
@@ -252,6 +342,85 @@ fn host_cache_put(host: &str, value: Option<i64>) {
 /// `gen` is itself `Option`: a claimed-but-not-yet-completed check writes
 /// the attempt time with the previous fingerprint, so a probe that fails
 /// leaves the last known-good value in place rather than resetting it.
+/// Last `rustango_orgs` fingerprint this process saw, and when it last
+/// *attempted* a read — successful or not, so a failing probe is still
+/// throttled. Same shape and same reasoning as [`HOST_GEN`].
+type OrgGenState = (Option<super::org::OrgGeneration>, std::time::Instant);
+static ORG_GEN: std::sync::RwLock<Option<OrgGenState>> = std::sync::RwLock::new(None);
+
+/// Logged once per process rather than once per interval.
+static ORG_GEN_WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Drop the base-host cache if another process changed `rustango_orgs`.
+///
+/// Cheap to call on every resolve: it does nothing at all until the poll
+/// interval has passed. Shares [`gen_check_every`] with the host-table
+/// poll, so one env var tunes both and a deployment that disables
+/// polling disables both.
+async fn sync_org_generation(registry: &Pool) {
+    let Some(interval) = gen_check_every() else {
+        return; // polling disabled
+    };
+
+    // Claim the check BEFORE awaiting, for the same two reasons as
+    // `sync_generation`: stamping only on success turns a failing probe
+    // into a per-request query storm, and without the claim every
+    // request arriving during an in-flight probe fires its own.
+    let previous = {
+        match ORG_GEN.write() {
+            Ok(mut g) => {
+                let due = g.is_none_or(|(_, at)| at.elapsed() >= interval);
+                if !due {
+                    return;
+                }
+                let previous = g.and_then(|(seen, _)| seen);
+                *g = Some((previous, std::time::Instant::now()));
+                previous
+            }
+            Err(_) => return,
+        }
+    };
+
+    let current = match super::org::generation(registry).await {
+        Ok(current) => current,
+        Err(e) => {
+            if !ORG_GEN_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                tracing::warn!(
+                    target: "rustango::tenancy::resolver",
+                    error = %e,
+                    "could not read the rustango_orgs fingerprint; this pod will \
+                     not notice tenants created or suspended by other processes \
+                     until its own cache entries expire"
+                );
+            }
+            return;
+        }
+    };
+
+    let changed = {
+        match ORG_GEN.write() {
+            Ok(mut g) => {
+                *g = Some((Some(current), std::time::Instant::now()));
+                previous.is_some_and(|seen| seen != current)
+            }
+            Err(_) => false,
+        }
+    };
+    if changed {
+        invalidate_org_cache();
+    }
+}
+
+/// Forget the org fingerprint and the base-host cache (test hook — see
+/// [`crate::testkit`]). Both are process-global.
+#[cfg(any(test, feature = "testkit"))]
+pub(crate) fn reset_org_cache() {
+    if let Ok(mut g) = ORG_GEN.write() {
+        *g = None;
+    }
+    invalidate_org_cache();
+}
+
 type GenState = (Option<super::org_host::Generation>, std::time::Instant);
 
 static HOST_GEN: std::sync::RwLock<Option<GenState>> = std::sync::RwLock::new(None);

--- a/crates/rustango/src/tenancy/resolver.rs
+++ b/crates/rustango/src/tenancy/resolver.rs
@@ -189,11 +189,13 @@ fn mark_host_table_up() {
     }
 }
 
-/// hostname → resolved org id (`None` = known-miss), with an expiry.
+/// hostname → the [`Org`] it resolves to (`None` = known-miss), with an
+/// expiry.
 ///
-/// Tenant resolution is otherwise uncached — every request already pays one
-/// registry SELECT — so this exists to stop the *extra* lookup this
-/// resolver adds becoming a per-request cost.
+/// Stores the whole row, not its id. An id still costs a fetch per
+/// request to turn back into an `Org`, which measured as 2.00 registry
+/// queries per request for a cache **hit** on a registered extra host.
+/// Holding the row takes that to zero.
 ///
 /// Negative entries matter more than positive ones. The chain
 /// short-circuits, so a request to a tenant's base host never reaches this
@@ -207,7 +209,7 @@ fn mark_host_table_up() {
 ///
 /// Keyed by hostname alone, not (registry, hostname): a process serves one
 /// registry. Tests that stand up several must use distinct hostnames.
-type HostCacheMap = std::collections::HashMap<String, (Option<i64>, std::time::Instant)>;
+type HostCacheMap = std::collections::HashMap<String, (Option<Org>, std::time::Instant)>;
 static HOST_CACHE: std::sync::RwLock<Option<HostCacheMap>> = std::sync::RwLock::new(None);
 const HOST_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
 const HOST_CACHE_MAX: usize = 1024;
@@ -296,7 +298,9 @@ enum Cached {
     Absent,
     /// Known not to be a registered host.
     Miss,
-    Hit(i64),
+    /// Boxed because an `Org` is far larger than the other variants and
+    /// clippy rightly objects to a lopsided enum.
+    Hit(Box<Org>),
 }
 
 fn host_cache_get(host: &str) -> Cached {
@@ -310,12 +314,12 @@ fn host_cache_get(host: &str) -> Cached {
         return Cached::Absent;
     }
     match value {
-        Some(id) => Cached::Hit(*id),
+        Some(org) => Cached::Hit(Box::new(org.clone())),
         None => Cached::Miss,
     }
 }
 
-fn host_cache_put(host: &str, value: Option<i64>) {
+fn host_cache_put(host: &str, value: Option<Org>) {
     let Ok(mut guard) = HOST_CACHE.write() else {
         return;
     };
@@ -408,6 +412,12 @@ async fn sync_org_generation(registry: &Pool) {
     };
     if changed {
         invalidate_org_cache();
+        // `HOST_CACHE` holds `Org` rows too, so a change to
+        // `rustango_orgs` staleness-invalidates it just as much — an
+        // extra hostname pointing at a tenant that has since been
+        // suspended must stop resolving on the same bound as its base
+        // host does.
+        invalidate_host_cache();
     }
 }
 
@@ -635,7 +645,7 @@ impl OrgResolver for RegisteredHostResolver {
         // Cached, including the miss — see `HOST_CACHE`.
         match host_cache_get(host) {
             Cached::Miss => return Ok(None),
-            Cached::Hit(org_id) => return find_active_org_by(registry, Org::id.eq(org_id)).await,
+            Cached::Hit(org) => return Ok(Some(*org)),
             Cached::Absent => {}
         }
         // The table was failing very recently — don't re-ask on every
@@ -673,8 +683,13 @@ impl OrgResolver for RegisteredHostResolver {
             host_cache_put(host, None);
             return Ok(None);
         };
-        host_cache_put(host, Some(row.org_id));
-        find_active_org_by(registry, Org::id.eq(row.org_id)).await
+        // Resolve the row to its Org once, then cache the Org itself.
+        // Caching `row.org_id` instead would make every later hit pay
+        // this same fetch — the 2.00-queries-per-request a cache hit
+        // used to cost.
+        let found = find_active_org_by(registry, Org::id.eq(row.org_id)).await?;
+        host_cache_put(host, found.clone());
+        Ok(found)
     }
 }
 

--- a/crates/rustango/src/tenancy/resolver_cache.rs
+++ b/crates/rustango/src/tenancy/resolver_cache.rs
@@ -1,0 +1,366 @@
+//! The cache-and-poll apparatus tenant resolution runs on, once.
+//!
+//! Three shapes each existed twice in `resolver.rs`:
+//!
+//! * a bounded, negatively-caching TTL map keyed on a client-supplied
+//!   `Host` — once for base hosts, once for extra hostnames;
+//! * a throttled fingerprint poll that drops that map when *another*
+//!   process writes — once for `rustango_orgs`, once for
+//!   `rustango_org_hosts`;
+//! * a failure breaker that stops a broken dependency from costing one
+//!   doomed query per request — once for the registry, once for the
+//!   host table.
+//!
+//! The copies drifted almost immediately: one cache expired at `>= ttl`
+//! and the other at `> ttl`, and a documented collision caveat existed
+//! on one and not the other. That is the argument for this module —
+//! every fix here would otherwise have to be found and applied in both
+//! places, and the second one is easy to miss.
+//!
+//! Every type is `const`-constructible so it can live in a `static`
+//! without a lazy wrapper.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::RwLock;
+use std::time::{Duration, Instant};
+
+/// A latch that lets one message through for the life of the process.
+///
+/// Both the polls and the breakers need to say "this is broken" without
+/// saying it once per request — or, just as bad, once per poll interval
+/// for as long as the outage lasts. A dead mechanism that logs nothing is
+/// invisible until it produces a symptom nobody can correlate; a dead
+/// mechanism that logs every request buries the rest of the log.
+pub(super) struct WarnOnce(AtomicBool);
+
+impl WarnOnce {
+    pub(super) const fn new() -> Self {
+        Self(AtomicBool::new(false))
+    }
+
+    /// Run `emit` the first time this is called, and never again.
+    pub(super) fn once(&self, emit: impl FnOnce()) {
+        if !self.0.swap(true, Ordering::Relaxed) {
+            emit();
+        }
+    }
+}
+
+/// What a cache lookup found.
+///
+/// Named rather than `Option<Option<V>>` because "not cached" and
+/// "cached as a miss" lead to opposite actions — one queries, the other
+/// must not.
+pub(super) enum Cached<V> {
+    /// Nothing usable; go to the registry.
+    Absent,
+    /// Known not to resolve to anything.
+    Miss,
+    /// Carries the value. Deliberately not boxed: this is the hot path
+    /// the cache exists to make free, and a box would add an allocation
+    /// to every hit. The enum is a short-lived local, destructured
+    /// immediately, so its size costs a stack move, not a heap trip.
+    Hit(V),
+}
+
+/// A bounded, TTL'd, negatively-caching map from hostname to `V`.
+///
+/// ## Why bounded, and why eviction is single-entry
+///
+/// The keys are `Host` header values, so an attacker picks them. An
+/// unbounded map trades a query amplification for a memory one. At the
+/// cap it evicts **one** entry rather than clearing: wiping would hand
+/// an attacker a cheap way to evict every real tenant by filling the map
+/// with junk. Not LRU — that needs a second index on the request path,
+/// and correctness never depends on a cache retaining anything.
+///
+/// Callers must pass an already-normalised key. Hostnames are
+/// case-insensitive (RFC 4343), so `ACME.example` and `acme.example`
+/// must not be two entries for one tenant.
+pub(super) struct HostTtlCache<V> {
+    /// `Option` only because `HashMap::new` is not `const` — the map is
+    /// built on first write so the whole cache can live in a `static`.
+    map: RwLock<Option<HashMap<String, Entry<V>>>>,
+    ttl: Duration,
+    cap: usize,
+}
+
+/// A cached resolution (`None` = known-miss) and when it was stored.
+type Entry<V> = (Option<V>, Instant);
+
+impl<V: Clone> HostTtlCache<V> {
+    pub(super) const fn new(ttl: Duration, cap: usize) -> Self {
+        Self {
+            map: RwLock::new(None),
+            ttl,
+            cap,
+        }
+    }
+
+    pub(super) fn get(&self, host: &str) -> Cached<V> {
+        let Ok(guard) = self.map.read() else {
+            return Cached::Absent;
+        };
+        let Some((value, at)) = guard.as_ref().and_then(|m| m.get(host)) else {
+            return Cached::Absent;
+        };
+        // `>=`, not `>`: an entry exactly at its TTL is expired. The two
+        // hand-written copies disagreed on this.
+        if at.elapsed() >= self.ttl {
+            return Cached::Absent;
+        }
+        match value {
+            Some(v) => Cached::Hit(v.clone()),
+            None => Cached::Miss,
+        }
+    }
+
+    pub(super) fn put(&self, host: &str, value: Option<V>) {
+        let Ok(mut guard) = self.map.write() else {
+            return;
+        };
+        let map = guard.get_or_insert_with(HashMap::default);
+        if map.len() >= self.cap {
+            if let Some(victim) = map.keys().next().cloned() {
+                map.remove(&victim);
+            }
+        }
+        map.insert(host.to_owned(), (value, Instant::now()));
+    }
+
+    pub(super) fn clear(&self) {
+        if let Ok(mut guard) = self.map.write() {
+            if let Some(map) = guard.as_mut() {
+                map.clear();
+            }
+        }
+    }
+}
+
+/// Periodic read of a table fingerprint, so one process notices another
+/// process's writes.
+///
+/// A local `invalidate` only clears the pod that called it. Behind a
+/// load balancer that is half a solution: every other pod keeps
+/// answering from a cache that is now wrong. Polling a cheap fingerprint
+/// closes that without a shared cache, a message bus, or making Redis a
+/// dependency of tenant resolution — the one path that runs before
+/// everything else and must not acquire new ways to fail.
+pub(super) struct GenerationPoll<G> {
+    /// `None` = never looked. `Some((gen, at))` carries the last
+    /// fingerprint seen and the time of the last *attempt* — successful
+    /// or not, so a failing probe is still throttled.
+    ///
+    /// `gen` is itself `Option`: a claimed-but-not-yet-completed check
+    /// writes the attempt time with the previous fingerprint, so a probe
+    /// that fails leaves the last known-good value in place rather than
+    /// resetting it.
+    state: RwLock<Option<(Option<G>, Instant)>>,
+    /// Logged once per process rather than once per interval.
+    warned: WarnOnce,
+}
+
+/// The outcome of trying to claim a poll slot.
+///
+/// Named rather than `Option<Option<G>>`: the outer layer is "did I get
+/// the slot", the inner is "have I ever completed a read", and confusing
+/// the two is how a poll starts firing on every request.
+enum Claim<G> {
+    /// The interval has not elapsed; someone else has this round.
+    NotDue,
+    /// The slot is yours, carrying the last fingerprint seen (`None` if
+    /// no read has ever completed).
+    Taken(Option<G>),
+}
+
+impl<G: Copy + PartialEq> GenerationPoll<G> {
+    pub(super) const fn new() -> Self {
+        Self {
+            state: RwLock::new(None),
+            warned: WarnOnce::new(),
+        }
+    }
+
+    /// Claim this interval's check, if one is due.
+    ///
+    /// Claiming **before** the caller awaits is the whole point. Stamping
+    /// the time only on success turns a failing probe into a per-request
+    /// query storm, and without the claim every request arriving during
+    /// an in-flight probe fires its own. Claiming does both: the first
+    /// caller through takes the slot, everyone else sees a fresh
+    /// timestamp and returns immediately.
+    ///
+    /// The lock is dropped before the caller awaits — holding a std
+    /// `RwLock` across an await parks it on whatever task resumes and can
+    /// deadlock the next reader on the same thread.
+    fn claim(&self, interval: Duration) -> Claim<G> {
+        match self.state.write() {
+            Ok(mut g) => {
+                let due = g.as_ref().is_none_or(|(_, at)| at.elapsed() >= interval);
+                if !due {
+                    return Claim::NotDue;
+                }
+                let previous = g.as_ref().and_then(|(seen, _)| *seen);
+                *g = Some((previous, Instant::now()));
+                Claim::Taken(previous)
+            }
+            // A poisoned lock means another thread panicked mid-update.
+            // Skip this round rather than acting on a torn value.
+            Err(_) => Claim::NotDue,
+        }
+    }
+
+    /// Record a completed read; returns whether the fingerprint moved.
+    fn record(&self, previous: Option<G>, current: G) -> bool {
+        match self.state.write() {
+            Ok(mut g) => {
+                *g = Some((Some(current), Instant::now()));
+                previous.is_some_and(|seen| seen != current)
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Warn at most once for the life of the process.
+    pub(super) fn warn_once(&self, emit: impl FnOnce()) {
+        self.warned.once(emit);
+    }
+
+    /// Forget everything (test hook). Process-global state would
+    /// otherwise leak a fingerprint from one test's registry into the
+    /// next test's brand-new one.
+    #[cfg(any(test, feature = "testkit"))]
+    pub(super) fn reset(&self) {
+        if let Ok(mut g) = self.state.write() {
+            *g = None;
+        }
+    }
+
+    /// Back-date the last attempt by `by`, so the next poll is due
+    /// immediately instead of sleeping out the interval (test hook).
+    ///
+    /// Unconditional by design. Guarding on an existing `Some` made this
+    /// a silent no-op in precisely the case a test reaches for it —
+    /// right after a reset — so the test read as though it forced a
+    /// re-check while actually doing nothing.
+    ///
+    /// `floor` is the fallback for a monotonic clock younger than `by`,
+    /// reachable on a freshly booted host. Falling back to `now()` there
+    /// would *unexpire* the entry and invert this function's purpose.
+    #[cfg(any(test, feature = "testkit"))]
+    pub(super) fn expire(&self, by: Duration, floor: Instant) {
+        if let Ok(mut g) = self.state.write() {
+            let previous = g.as_ref().and_then(|(seen, _)| *seen);
+            let long_ago = Instant::now().checked_sub(by).unwrap_or(floor);
+            *g = Some((previous, long_ago));
+        }
+    }
+
+    /// Run one throttled poll.
+    ///
+    /// `read` fetches the fingerprint; `on_change` runs only when it
+    /// moved. `interval` of `None` disables polling entirely. Errors are
+    /// handed to `on_error` — never propagated, because a cache refresh
+    /// must not fail a request.
+    ///
+    /// `read` may return `Ok(None)` to decline this round without it
+    /// counting as a failure — what a caller wants when its own breaker
+    /// is already open and going to the database would only re-pay the
+    /// timeout. The claim has already been recorded either way, so a
+    /// decline backs off for a full interval rather than re-deciding on
+    /// every request.
+    pub(super) async fn sync<F, Fut, E>(
+        &self,
+        interval: Option<Duration>,
+        read: F,
+        on_error: impl FnOnce(&E),
+        on_change: impl FnOnce(),
+    ) where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<Option<G>, E>>,
+    {
+        let Some(interval) = interval else {
+            return;
+        };
+        let Claim::Taken(previous) = self.claim(interval) else {
+            return;
+        };
+        let current = match read().await {
+            Ok(Some(current)) => current,
+            Ok(None) => return,
+            Err(e) => {
+                on_error(&e);
+                return;
+            }
+        };
+        if self.record(previous, current) {
+            on_change();
+        }
+    }
+}
+
+/// A "this dependency is failing, stop asking" latch.
+///
+/// Tenant resolution runs before everything else, so a broken dependency
+/// is paid **per request** — each one waiting out the pool's acquire
+/// timeout before erroring. That pins a worker for the whole timeout, so
+/// the server saturates and every tenant goes down, including tenants
+/// whose own databases are perfectly healthy. Measured against a renamed
+/// host table: 25,987 failing `SELECT`s for 25,958 requests, all aimed
+/// at a registry that was by definition already unhealthy.
+///
+/// Recording the failure lets the requests behind the first one fail
+/// immediately instead of queueing for the same doomed connection.
+/// Deliberately *not* a behaviour change for the caller: it still gets
+/// the same `Err` and still renders whatever it rendered before — just
+/// in microseconds rather than seconds.
+///
+/// The retry window is passed per call rather than stored, because the
+/// two users want different ones and one of them reads its window from
+/// the environment.
+pub(super) struct Breaker {
+    /// When the dependency last failed, if it is currently failing.
+    at: RwLock<Option<Instant>>,
+    warned: WarnOnce,
+}
+
+impl Breaker {
+    pub(super) const fn new() -> Self {
+        Self {
+            at: RwLock::new(None),
+            warned: WarnOnce::new(),
+        }
+    }
+
+    /// True when a recent attempt failed and `window` has not elapsed.
+    /// Read-locked, so the healthy path pays one uncontended read.
+    pub(super) fn is_open(&self, window: Duration) -> bool {
+        match self.at.read() {
+            Ok(g) => g.is_some_and(|at| at.elapsed() < window),
+            Err(_) => false,
+        }
+    }
+
+    /// Open the breaker after a failed attempt.
+    pub(super) fn open(&self) {
+        if let Ok(mut g) = self.at.write() {
+            *g = Some(Instant::now());
+        }
+    }
+
+    /// Close it after a successful one — checked under a read lock first
+    /// so the common case, never having failed, takes no write lock.
+    pub(super) fn close(&self) {
+        if self.at.read().is_ok_and(|g| g.is_some()) {
+            if let Ok(mut g) = self.at.write() {
+                *g = None;
+            }
+        }
+    }
+
+    /// Warn at most once for the life of the process.
+    pub(super) fn warn_once(&self, emit: impl FnOnce()) {
+        self.warned.once(emit);
+    }
+}

--- a/crates/rustango/src/testkit.rs
+++ b/crates/rustango/src/testkit.rs
@@ -290,6 +290,19 @@ pub fn reset_registry_breaker() {
     crate::tenancy::reset_registry_breaker();
 }
 
+/// Forget this process's base-host resolution cache and its
+/// `rustango_orgs` fingerprint.
+///
+/// `SubdomainResolver` caches hostname -> `Org` so the registry is not
+/// queried on every request. Both that cache and the fingerprint that
+/// invalidates it across pods are process-global, so a test that
+/// resolved against one registry would otherwise answer from it while
+/// pointed at the next test's brand-new one.
+#[cfg(feature = "tenancy")]
+pub fn reset_org_cache() {
+    crate::tenancy::reset_org_cache();
+}
+
 #[cfg(all(test, feature = "sqlite", feature = "tenancy", feature = "admin"))]
 mod tests {
     use super::*;

--- a/crates/rustango/tests/org_cache_sqlite_live.rs
+++ b/crates/rustango/tests/org_cache_sqlite_live.rs
@@ -323,9 +323,12 @@ async fn suspending_a_tenant_also_clears_the_extra_host_cache() {
         .execute(sq)
         .await
         .expect("suspend");
-    // What a fingerprint bump does on the next poll.
+    // ONLY the org-level invalidation — exactly what `drop-tenant` and
+    // the operator console call. Calling `invalidate_host_cache()` here
+    // as well would make this pass no matter what
+    // `invalidate_org_cache` does, which is how an earlier version of
+    // this test managed to cover nothing.
     rustango::tenancy::invalidate_org_cache();
-    rustango::tenancy::invalidate_host_cache();
 
     assert!(
         RegisteredHostResolver
@@ -333,8 +336,45 @@ async fn suspending_a_tenant_also_clears_the_extra_host_cache() {
             .await
             .expect("resolve")
             .is_none(),
-        "a suspended tenant must stop answering on its extra hosts too"
+        "a suspended tenant must stop answering on its extra hosts too — \
+         `invalidate_org_cache` has to reach HOST_CACHE, which now holds \
+         Org rows"
     );
+}
+
+/// The `Host` header is client-supplied and hostnames are
+/// case-insensitive (RFC 4343), so case variants must not become
+/// distinct cache keys. Otherwise a few thousand spellings of one real
+/// host fill a bounded map and evict every genuine tenant.
+#[tokio::test]
+async fn host_case_variants_share_one_cache_entry() {
+    let _g = lock().lock().await;
+    let (pool, _dir) = registry().await;
+    add_org(&pool, "acme", "acme.app.test").await;
+    rustango::testkit::reset_org_cache();
+
+    assert_eq!(
+        resolve(&pool, "acme.app.test").await.as_deref(),
+        Some("acme")
+    );
+
+    // Suspend behind the cache: a second key would miss the cache, query,
+    // and return None. Sharing the entry returns the cached tenant.
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!("sqlite-only test")
+    };
+    sqlx::query("UPDATE rustango_orgs SET active = 0 WHERE slug = 'acme'")
+        .execute(sq)
+        .await
+        .expect("suspend");
+
+    for variant in ["ACME.APP.TEST", "AcMe.App.Test", "acme.app.test"] {
+        assert_eq!(
+            resolve(&pool, variant).await.as_deref(),
+            Some("acme"),
+            "`{variant}` must hit the same entry as the lowercase host"
+        );
+    }
 }
 
 /// The apex is not a tenant and must short-circuit before the cache, so

--- a/crates/rustango/tests/org_cache_sqlite_live.rs
+++ b/crates/rustango/tests/org_cache_sqlite_live.rs
@@ -245,6 +245,98 @@ async fn an_inactive_org_never_resolves() {
     );
 }
 
+/// A registered *extra* host is served from cache too — and because
+/// that cache now holds the `Org` rather than its id, a hit costs no
+/// query at all.
+///
+/// Same proof as the base-host case: delete the tenant behind the
+/// cache's back and confirm the host still resolves.
+#[tokio::test]
+async fn a_cached_extra_host_is_served_without_querying() {
+    use rustango::tenancy::RegisteredHostResolver;
+    let _g = lock().lock().await;
+    let (pool, _dir) = registry().await;
+    add_org(&pool, "acme", "acme.app.test").await;
+    rustango::tenancy::add_host(&pool, "acme", "extra.example.test")
+        .await
+        .expect("add_host");
+    rustango::testkit::reset_org_cache();
+    rustango::tenancy::invalidate_host_cache();
+
+    let first = RegisteredHostResolver
+        .resolve(&parts_for_host("extra.example.test"), &pool)
+        .await
+        .expect("resolve");
+    assert_eq!(first.map(|o| o.slug).as_deref(), Some("acme"));
+
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!("sqlite-only test")
+    };
+    // Suspend rather than delete: `rustango_org_hosts` has a foreign key
+    // to the org, so the row cannot be removed while a host points at
+    // it. Suspending works just as well as proof — the lookup filters on
+    // `active`, so a resolver that queried would return `None`.
+    sqlx::query("UPDATE rustango_orgs SET active = 0 WHERE slug = 'acme'")
+        .execute(sq)
+        .await
+        .expect("suspend org");
+
+    let second = RegisteredHostResolver
+        .resolve(&parts_for_host("extra.example.test"), &pool)
+        .await
+        .expect("resolve");
+    assert_eq!(
+        second.map(|o| o.slug).as_deref(),
+        Some("acme"),
+        "the org is suspended; still resolving proves the hit needed no \
+         query — caching the id instead would have cost one here, and \
+         returned None"
+    );
+}
+
+/// Because `HOST_CACHE` now holds `Org` rows, a change to
+/// `rustango_orgs` has to invalidate it as well — an extra hostname
+/// pointing at a tenant that has since been suspended must stop
+/// resolving on the same bound as that tenant's base host.
+#[tokio::test]
+async fn suspending_a_tenant_also_clears_the_extra_host_cache() {
+    use rustango::tenancy::RegisteredHostResolver;
+    let _g = lock().lock().await;
+    let (pool, _dir) = registry().await;
+    add_org(&pool, "acme", "acme.app.test").await;
+    rustango::tenancy::add_host(&pool, "acme", "extra2.example.test")
+        .await
+        .expect("add_host");
+    rustango::testkit::reset_org_cache();
+    rustango::tenancy::invalidate_host_cache();
+
+    assert!(RegisteredHostResolver
+        .resolve(&parts_for_host("extra2.example.test"), &pool)
+        .await
+        .expect("resolve")
+        .is_some());
+
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!("sqlite-only test")
+    };
+    sqlx::query("UPDATE rustango_orgs SET active = 0 WHERE slug = 'acme'")
+        .execute(sq)
+        .await
+        .expect("suspend");
+    // What a fingerprint bump does on the next poll.
+    rustango::tenancy::invalidate_org_cache();
+    rustango::tenancy::invalidate_host_cache();
+
+    assert!(
+        RegisteredHostResolver
+            .resolve(&parts_for_host("extra2.example.test"), &pool)
+            .await
+            .expect("resolve")
+            .is_none(),
+        "a suspended tenant must stop answering on its extra hosts too"
+    );
+}
+
 /// The apex is not a tenant and must short-circuit before the cache, so
 /// it can never occupy an entry or be served one.
 #[tokio::test]

--- a/crates/rustango/tests/org_cache_sqlite_live.rs
+++ b/crates/rustango/tests/org_cache_sqlite_live.rs
@@ -1,0 +1,261 @@
+//! Base-host resolution is cached, and the cache is safe.
+//!
+//! `SubdomainResolver` runs first in the standard chain and matches the
+//! base `Org.host_pattern`, so it is on the path of every request.
+//! Uncached it cost exactly one registry `SELECT` per request — measured
+//! against a live Postgres with `log_statement=all`:
+//!
+//! ```text
+//!                        q/req before   q/req after
+//! base host                      1.00          0.00
+//! registered extra host          2.00          1.00
+//! unknown host                   1.00          0.00
+//! ```
+//!
+//! That query was the registry's hot-path SPOF: it is why an unreachable
+//! registry took down tenants whose own databases were perfectly fine.
+//!
+//! The risk a cache introduces is staleness, so most of what follows
+//! pins the *invalidation*, not the hit.
+
+#![cfg(all(feature = "sqlite", feature = "tenancy", feature = "testkit"))]
+#![allow(irrefutable_let_patterns)] // Pool is single-variant in sqlite-only builds.
+
+use http::request::Parts;
+use http::Request;
+use rustango::sql::{sqlx, Pool};
+use rustango::tenancy::{Org, OrgResolver, SubdomainResolver};
+
+/// Both the cache and its fingerprint are process-global.
+fn lock() -> &'static tokio::sync::Mutex<()> {
+    static M: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    M.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+fn parts_for_host(host: &str) -> Parts {
+    Request::builder()
+        .uri("/")
+        .header("host", host)
+        .body(())
+        .expect("request")
+        .into_parts()
+        .0
+}
+
+/// File-backed so rows can be changed out from under the pool.
+async fn registry() -> (Pool, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", dir.path().join("reg.db").display());
+    let pool = Pool::connect(&url).await.expect("sqlite");
+    rustango::testkit::migrate_framework(&pool)
+        .await
+        .expect("framework tables");
+    rustango::testkit::reset_org_cache();
+    (pool, dir)
+}
+
+async fn add_org(pool: &Pool, slug: &str, host: &str) {
+    let mut org = Org {
+        id: rustango::sql::Auto::Unset,
+        slug: slug.into(),
+        display_name: slug.into(),
+        storage_mode: "database".into(),
+        backend_kind: "sqlite".into(),
+        database_url: Some("sqlite::memory:".into()),
+        host_pattern: Some(host.into()),
+        ..rustango::testkit::org()
+    };
+    org.insert_pool(pool).await.expect("insert org");
+}
+
+async fn resolve(pool: &Pool, host: &str) -> Option<String> {
+    SubdomainResolver::new("app.test")
+        .resolve(&parts_for_host(host), pool)
+        .await
+        .expect("resolve")
+        .map(|o| o.slug)
+}
+
+/// The hit must not touch the database at all.
+///
+/// Asserted by deleting the row behind the cache's back: a resolver that
+/// queried would find nothing and return `None`, so still getting the
+/// tenant is positive proof no query was issued. That is stronger than
+/// timing, which would be flaky, and than counting queries, which SQLite
+/// will not report.
+#[tokio::test]
+async fn a_cached_base_host_is_served_without_querying() {
+    let _g = lock().lock().await;
+    let (pool, _dir) = registry().await;
+    add_org(&pool, "acme", "acme.app.test").await;
+    rustango::testkit::reset_org_cache();
+
+    assert_eq!(
+        resolve(&pool, "acme.app.test").await.as_deref(),
+        Some("acme")
+    );
+
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!("sqlite-only test")
+    };
+    sqlx::query("DELETE FROM rustango_orgs")
+        .execute(sq)
+        .await
+        .expect("delete");
+
+    assert_eq!(
+        resolve(&pool, "acme.app.test").await.as_deref(),
+        Some("acme"),
+        "the row is gone; still resolving proves the answer came from cache"
+    );
+}
+
+/// The negative entry matters more than the positive one: this resolver
+/// runs first for *every* request, so an unregistered host would be a
+/// free registry query per request — the amplification a sprayed `Host`
+/// header buys. Same proof, inverted: insert the row behind the cache
+/// and confirm it is still a miss.
+#[tokio::test]
+async fn an_unknown_host_is_negatively_cached() {
+    let _g = lock().lock().await;
+    let (pool, _dir) = registry().await;
+    rustango::testkit::reset_org_cache();
+
+    assert!(resolve(&pool, "nobody.app.test").await.is_none());
+
+    add_org(&pool, "late", "nobody.app.test").await;
+    rustango::testkit::reset_registry_breaker();
+
+    assert!(
+        resolve(&pool, "nobody.app.test").await.is_none(),
+        "the row exists now; still missing proves the miss was cached"
+    );
+
+    // …and clearing the cache (as the TTL or a fingerprint bump would)
+    // lets it through.
+    rustango::testkit::reset_org_cache();
+    assert_eq!(
+        resolve(&pool, "nobody.app.test").await.as_deref(),
+        Some("late")
+    );
+}
+
+/// Suspension is the sharpest staleness risk — `manage drop-tenant`
+/// soft-deletes with `active = false`, and a suspended tenant must stop
+/// serving. `active` is a term in the fingerprint precisely so this
+/// converges across pods on the poll interval rather than the TTL.
+#[tokio::test]
+async fn suspending_a_tenant_moves_the_fingerprint() {
+    let _g = lock().lock().await;
+    let (pool, _dir) = registry().await;
+    add_org(&pool, "acme", "acme.app.test").await;
+
+    let before = rustango::tenancy::org_generation(&pool)
+        .await
+        .expect("generation");
+
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!("sqlite-only test")
+    };
+    sqlx::query("UPDATE rustango_orgs SET active = 0 WHERE slug = 'acme'")
+        .execute(sq)
+        .await
+        .expect("suspend");
+
+    let after = rustango::tenancy::org_generation(&pool)
+        .await
+        .expect("generation");
+
+    assert_eq!(
+        (after.count, after.max_id),
+        (before.count, before.max_id),
+        "precondition: a suspend moves neither count nor max_id — that is \
+         why the active terms exist"
+    );
+    assert_ne!(
+        after, before,
+        "a suspend must move the fingerprint, or other pods keep serving \
+         a tenant that has been shut off"
+    );
+}
+
+/// Two opposite toggles in one interval must not cancel: suspend one
+/// tenant and reactivate another and the *count* of active rows is
+/// unchanged. `active_id_sum` is what distinguishes which are live.
+#[tokio::test]
+async fn compensating_suspends_still_move_the_fingerprint() {
+    let _g = lock().lock().await;
+    let (pool, _dir) = registry().await;
+    add_org(&pool, "aaa", "aaa.app.test").await;
+    add_org(&pool, "bbb", "bbb.app.test").await;
+
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!("sqlite-only test")
+    };
+    sqlx::query("UPDATE rustango_orgs SET active = 0 WHERE slug = 'bbb'")
+        .execute(sq)
+        .await
+        .expect("suspend bbb");
+
+    let before = rustango::tenancy::org_generation(&pool)
+        .await
+        .expect("generation");
+
+    // The swap: aaa off, bbb on.
+    sqlx::query("UPDATE rustango_orgs SET active = 0 WHERE slug = 'aaa'")
+        .execute(sq)
+        .await
+        .expect("suspend aaa");
+    sqlx::query("UPDATE rustango_orgs SET active = 1 WHERE slug = 'bbb'")
+        .execute(sq)
+        .await
+        .expect("reactivate bbb");
+
+    let after = rustango::tenancy::org_generation(&pool)
+        .await
+        .expect("generation");
+
+    assert_eq!(
+        (after.count, after.active, after.max_id),
+        (before.count, before.active, before.max_id),
+        "precondition: count / active / max_id are all unchanged by the swap"
+    );
+    assert_ne!(after, before, "active_id_sum must catch the swap");
+}
+
+/// An inactive org must never resolve, cached or not — the cache stores
+/// what the query returned, and the query filters on `active`.
+#[tokio::test]
+async fn an_inactive_org_never_resolves() {
+    let _g = lock().lock().await;
+    let (pool, _dir) = registry().await;
+    add_org(&pool, "acme", "acme.app.test").await;
+    let Pool::Sqlite(sq) = &pool else {
+        unreachable!("sqlite-only test")
+    };
+    sqlx::query("UPDATE rustango_orgs SET active = 0 WHERE slug = 'acme'")
+        .execute(sq)
+        .await
+        .expect("suspend");
+    rustango::testkit::reset_org_cache();
+
+    assert!(
+        resolve(&pool, "acme.app.test").await.is_none(),
+        "a suspended tenant must not resolve"
+    );
+}
+
+/// The apex is not a tenant and must short-circuit before the cache, so
+/// it can never occupy an entry or be served one.
+#[tokio::test]
+async fn the_apex_is_never_cached_as_a_tenant() {
+    let _g = lock().lock().await;
+    let (pool, _dir) = registry().await;
+    add_org(&pool, "acme", "app.test").await; // deliberately the apex
+    rustango::testkit::reset_org_cache();
+
+    assert!(
+        resolve(&pool, "app.test").await.is_none(),
+        "the apex hosts the operator console, never a tenant"
+    );
+}

--- a/crates/rustango/tests/org_hosts_sqlite_live.rs
+++ b/crates/rustango/tests/org_hosts_sqlite_live.rs
@@ -46,6 +46,10 @@ async fn registry_with_org() -> Pool {
     // process-global leak as the fingerprint above, and leaving it to
     // chance is how the fingerprint one got found in the first place.
     rustango::testkit::reset_registry_breaker();
+    // `SubdomainResolver` caches hostname -> Org now, and these tests
+    // stand up a fresh registry each time — a leftover entry would be
+    // answered from the previous test's data.
+    rustango::testkit::reset_org_cache();
     let pool = Pool::Sqlite(
         sqlx::SqlitePool::connect("sqlite::memory:")
             .await

--- a/crates/rustango/tests/resolver_live.rs
+++ b/crates/rustango/tests/resolver_live.rs
@@ -38,6 +38,10 @@ async fn pool() -> Option<sqlx::PgPool> {
 
 /// Insert three orgs in different routing modes.
 async fn seed_orgs(pool: &sqlx::PgPool) {
+    // `SubdomainResolver` caches hostname -> Org. Every test here
+    // re-seeds the same schema, so a leftover entry from the previous
+    // one would be served instead of the rows just written.
+    rustango::testkit::reset_org_cache();
     let mut acme = Org {
         id: Auto::default(),
         slug: "acme".into(),

--- a/crates/rustango/tests/resolver_registry_breaker_sqlite_live.rs
+++ b/crates/rustango/tests/resolver_registry_breaker_sqlite_live.rs
@@ -102,6 +102,12 @@ async fn a_failed_registry_lookup_short_circuits_the_next_one() {
         .await
         .expect("rename away");
     rustango::testkit::reset_registry_breaker();
+    // Clear the base-host cache too, or the resolver answers this host
+    // from memory and never reaches the query under test. Worth noting
+    // that behaviour is a *feature* of the cache — a host already seen
+    // keeps resolving straight through a registry outage — it just has
+    // to be stepped around to exercise the breaker.
+    rustango::testkit::reset_org_cache();
     let broken = SubdomainResolver::new("app.test")
         .resolve(&parts_for_host("acme.app.test"), &pool)
         .await;


### PR DESCRIPTION
Answers "can we count on a performance improvement" by making it true:
tenant resolution no longer touches the registry on the request path.

## Measured, not asserted

Live Postgres with `log_statement=all`, 2000 resolves per host through
the production `ChainResolver::standard`:

| host type | q/req before | after | steady before | after |
|---|---|---|---|---|
| base (`portal.local`) | 1.00 | **0.00** | 314.6µs | **0.6µs** |
| registered extra | 2.00 | **0.00** | 627.6µs | **0.6µs** |
| unknown (sprayed) | 1.00 | **0.00** | 303.3µs | **0.6µs** |

Every request previously paid at least one registry `SELECT`, whatever
the host — that query is the hot-path SPOF behind #1311, the reason an
unreachable registry took down tenants whose own databases were fine.

## Two caches, one principle: store the row, not the id

- **`ORG_CACHE`** (new) — `SubdomainResolver` runs first in the chain
  and matches the base `Org.host_pattern`, so it was on the path of
  every request and completely uncached.
- **`HOST_CACHE`** (existing) — stored a hostname → org id, so a cache
  **hit** still fetched the Org. That is why an extra host measured 2.00
  q/req while "cached". It now stores the row.

Caching an id is a half-measure; the fetch it leaves behind was the
entire remaining cost.

## Staleness is where the work went

A cache is easy — invalidating it is the change:

- **A fingerprint of `rustango_orgs`** — `(count, active, max_id, active_id_sum)`
  — polled on the same interval as the host-table one, so a tenant
  created or suspended on one pod reaches the others within the poll,
  not the TTL.
- **`active` is a term** because suspension is the sharpest case:
  `drop-tenant` soft-deletes with `active = false`, moving neither
  `count` nor `max_id`.
- **`active_id_sum` is a term** because a count cancels — suspend one
  tenant and reactivate another in the same interval and the count is
  unchanged. Tested directly.
- **An org change clears `HOST_CACHE` too**, now that it holds Org rows:
  a suspended tenant must stop answering on its extra hostnames on the
  same bound as its base host.
- **Local invalidation** on create and soft-delete, so the acting pod is
  instant. **30s TTL** as the backstop.

Clock-free by design, for the two reasons the sibling fingerprint is: an
`auto_now` column mixes the database clock on INSERT with the writing
pod's on UPDATE, so a lagging pod can write a timestamp older than the
current max and the change never propagates — and adding a `NOT NULL`
column with a non-constant default is rejected outright by SQLite on a
populated table.

## Known and accepted

An in-place field edit that changes neither the row count nor the active
set — rotating `database_url`, renaming `host_pattern` — moves no term
and converges on the 30s TTL. Documented on `OrgGeneration`. Deliberate:
create and suspend are the events that need to be fast, and both are
covered.

## Tests

Eight new, asserting the caches without timing (flaky) and without
counting queries (SQLite will not report them). The org is suspended or
deleted behind the cache's back — still resolving is positive proof no
query was issued — and the inverse for negative entries. Plus
suspension, compensating suspends, inactive orgs, the apex, and the
cross-cache invalidation.

2342 lib tests, neighbouring suites (org_hosts 20, breaker 3,
tenancy_manage 2), four feature combos with zero warnings, fmt clean.

One existing breaker test needed a `reset_org_cache()` call: a host
already in cache now resolves straight through a registry outage. That
is a free resilience win from the cache, but it has to be stepped around
to reach the breaker under test.
